### PR TITLE
ci(release): attach GPG signatures to release assets

### DIFF
--- a/.github/scripts/compose-latest.cjs
+++ b/.github/scripts/compose-latest.cjs
@@ -1,0 +1,47 @@
+// Assemble a Tauri updater `latest.json` from the per-platform updater
+// signatures attached to a release. Run after all matrix builds have uploaded
+// their bundles + `.sig` files (the matrix uses includeUpdaterJson:false so it
+// never races on this single asset).
+//
+// Inputs (env): REPO (owner/name), REL_TAG (release the bundles live on),
+// VERSION, NOTES. Reads `*.sig` files from ./sigs (downloaded by the caller).
+// Writes ./latest.json.
+const fs = require('fs');
+const path = require('path');
+
+const REPO = process.env.REPO;
+const TAG = process.env.REL_TAG;
+const VERSION = process.env.VERSION;
+const NOTES = process.env.NOTES || '';
+const PUB_DATE = process.env.PUB_DATE || new Date().toISOString();
+const DIR = 'sigs';
+
+const urlFor = (artifact) =>
+  `https://github.com/${REPO}/releases/download/${TAG}/${encodeURIComponent(artifact)}`;
+
+const platforms = {};
+const add = (key, artifact) => {
+  if (platforms[key]) return; // first match wins
+  const sig = fs.readFileSync(path.join(DIR, `${artifact}.sig`), 'utf8').trim();
+  platforms[key] = { signature: sig, url: urlFor(artifact) };
+};
+
+const sigFiles = fs.existsSync(DIR) ? fs.readdirSync(DIR).filter((f) => f.endsWith('.sig')) : [];
+for (const f of sigFiles) {
+  const artifact = f.slice(0, -4); // strip ".sig"
+  if (!artifact.startsWith('srelens')) continue;
+  if (/aarch64\.app\.tar\.gz$/.test(artifact)) add('darwin-aarch64', artifact);
+  else if (/(x64|x86_64)\.app\.tar\.gz$/.test(artifact)) add('darwin-x86_64', artifact);
+  else if (/\.AppImage(\.tar\.gz)?$/.test(artifact)) add('linux-x86_64', artifact);
+  else if (/(-setup\.exe|\.nsis\.zip)$/.test(artifact)) add('windows-x86_64', artifact);
+  else if (/\.msi(\.zip)?$/.test(artifact)) add('windows-x86_64', artifact); // MSI fallback
+}
+
+if (Object.keys(platforms).length === 0) {
+  console.error('No updater signatures found in ./sigs — refusing to write an empty manifest.');
+  process.exit(1);
+}
+
+const manifest = { version: VERSION, notes: NOTES, pub_date: PUB_DATE, platforms };
+fs.writeFileSync('latest.json', JSON.stringify(manifest, null, 2));
+console.log('Composed latest.json for', VERSION, '— platforms:', Object.keys(platforms).join(', '));

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,3 +277,40 @@ jobs:
           | while read -r t; do
               [ -n "$t" ] && gh release delete "$t" --cleanup-tag --yes
             done
+
+  # Attach detached GPG signatures (.asc) to every release asset so users can
+  # verify authenticity (`gpg --verify file.asc file`). Activates automatically
+  # once the GPG_PRIVATE_KEY secret is set; otherwise it's a no-op.
+  sign-artifacts:
+    needs: [version, build]
+    if: ${{ always() && needs.build.result == 'success' && (github.ref_name != 'main' || needs.version.outputs.release == 'true') }}
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    env:
+      ENABLE_GPG: ${{ secrets.GPG_PRIVATE_KEY != '' }}
+    steps:
+      - name: Import GPG key
+        if: env.ENABLE_GPG == 'true'
+        run: echo "${{ secrets.GPG_PRIVATE_KEY }}" | base64 --decode | gpg --batch --import
+      - name: Sign release assets
+        if: env.ENABLE_GPG == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="srelens-v${{ needs.version.outputs.version }}"
+          KEYID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec/ {print $5; exit}')
+          mkdir -p _assets && cd _assets
+          gh release download "$TAG" --repo "${{ github.repository }}" --clobber
+          shopt -s nullglob
+          for f in *; do
+            case "$f" in *.asc) continue ;; esac
+            gpg --batch --yes --pinentry-mode loopback --passphrase "$GPG_PASSPHRASE" \
+                --local-user "$KEYID" --armor --detach-sign --output "$f.asc" "$f"
+          done
+          if ls *.asc >/dev/null 2>&1; then
+            gh release upload "$TAG" --repo "${{ github.repository }}" *.asc --clobber
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,6 +221,10 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Updater signing — produces the .sig files latest.json needs so the
+          # in-app updater can verify downloads.
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           # Apple signing env (APPLE_CERTIFICATE etc.) is exported to
           # GITHUB_ENV by the step above only when signing is enabled —
           # defining the variables empty here would trigger Tauri's signing
@@ -234,6 +238,10 @@ jobs:
           releaseBody: ${{ needs.version.outputs.notes || 'Generating release notes…' }}
           prerelease: ${{ github.ref_name != 'main' }}
           args: ${{ matrix.args }}
+          # Each matrix job uploads its own binaries + signatures, but NOT
+          # latest.json — parallel jobs would race on that single asset. The
+          # updater-manifest job assembles it once, after all builds.
+          includeUpdaterJson: false
 
   # Dev only: fill the pre-release body with a recent-commit list and keep the
   # Releases page tidy. Stable (main) notes come from the version job.
@@ -277,6 +285,49 @@ jobs:
           | while read -r t; do
               [ -n "$t" ] && gh release delete "$t" --cleanup-tag --yes
             done
+
+  # Assemble latest.json ONCE from the per-platform .sig files the matrix
+  # uploaded, then publish it per channel:
+  #   stable (main) -> the release itself, served at releases/latest/download/latest.json
+  #   dev           -> the permanent `dev-channel` pre-release, giving dev builds
+  #                    a stable manifest URL for this build's assets.
+  updater-manifest:
+    needs: [version, build]
+    if: ${{ always() && needs.build.result == 'success' && (github.ref_name != 'main' || needs.version.outputs.release == 'true') }}
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name == 'main' && 'main' || github.sha }}
+      - name: Compose and publish updater manifest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          VERSION: ${{ needs.version.outputs.version }}
+          NOTES: ${{ needs.version.outputs.notes }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          export REL_TAG="srelens-v${VERSION}"
+          mkdir -p sigs
+          gh release download "$REL_TAG" --repo "$REPO" --pattern '*.sig' --dir sigs --clobber || true
+          if ! ls sigs/*.sig >/dev/null 2>&1; then
+            echo "No .sig files on $REL_TAG — updater signing key not configured yet; skipping manifest."
+            exit 0
+          fi
+          node .github/scripts/compose-latest.cjs
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            gh release upload "$REL_TAG" latest.json --repo "$REPO" --clobber
+          else
+            gh release view dev-channel --repo "$REPO" >/dev/null 2>&1 || \
+              gh release create dev-channel --repo "$REPO" --prerelease \
+                --title "Dev channel" \
+                --notes "Rolling dev-channel updater manifest. Do not delete." \
+                --target "$GITHUB_SHA"
+            gh release upload dev-channel latest.json --repo "$REPO" --clobber
+          fi
 
   # Attach detached GPG signatures (.asc) to every release asset so users can
   # verify authenticity (`gpg --verify file.asc file`). Activates automatically

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,6 +782,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,6 +1104,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -2004,6 +2034,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2288,6 +2348,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2348,6 +2414,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2607,6 +2679,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2688,6 +2772,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3203,15 +3301,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3323,6 +3426,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3366,6 +3482,33 @@ checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3781,6 +3924,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3887,6 +4040,8 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-log",
+ "tauri-plugin-process",
+ "tauri-plugin-updater",
  "tokio",
 ]
 
@@ -4046,7 +4201,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -4086,6 +4241,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4108,7 +4274,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -4285,6 +4451,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4294,7 +4503,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -4317,7 +4526,7 @@ checksum = "fe41e015bf8fc4d6477ff4926a0ef769dc64ff34c7b0038b6f7cacae892acb5c"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -4382,6 +4591,19 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 1.1.2+spec-1.1.0",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5147,6 +5369,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5680,7 +5911,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",
@@ -5734,6 +5965,16 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]
@@ -5837,6 +6078,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -23,7 +23,6 @@
     "@peculiar/x509": "^2.0.0",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-process": "^2.3.1",
-    "@tauri-apps/plugin-updater": "^2.10.1",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",
     "class-variance-authority": "^0.7.1",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -22,6 +22,8 @@
     "@lezer/highlight": "^1.2.3",
     "@peculiar/x509": "^2.0.0",
     "@tauri-apps/api": "^2.0.0",
+    "@tauri-apps/plugin-process": "^2.3.1",
+    "@tauri-apps/plugin-updater": "^2.10.1",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",
     "class-variance-authority": "^0.7.1",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -30,5 +30,10 @@ srelens-mcp = { path = "../../../crates/mcp" }
 srelens-kube = { path = "../../../crates/kube" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std", "io-util", "macros"] }
 
+# Auto-update is desktop-only (mobile stores handle their own updates).
+[target."cfg(not(any(target_os = \"android\", target_os = \"ios\")))".dependencies]
+tauri-plugin-updater = "2"
+tauri-plugin-process = "2"
+
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -6,6 +6,8 @@
     "main"
   ],
   "permissions": [
-    "core:default"
+    "core:default",
+    "updater:default",
+    "process:default"
   ]
 }

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -7,7 +7,6 @@
   ],
   "permissions": [
     "core:default",
-    "updater:default",
     "process:default"
   ]
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -23,8 +23,13 @@ pub fn run() {
     let cache = ClientCache::new_many(capabilities::default_kubeconfig_paths());
     let registry = capabilities::build_registry_with(cache.clone());
 
-    tauri::Builder::default()
-        .plugin(tauri_plugin_dialog::init())
+    let builder = tauri::Builder::default().plugin(tauri_plugin_dialog::init());
+    #[cfg(desktop)]
+    let builder = builder
+        .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_process::init());
+
+    builder
         .setup(|app| {
             if cfg!(debug_assertions) {
                 app.handle().plugin(

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod exec;
 mod files;
 mod forward;
 mod logs;
+mod updater;
 mod watch;
 
 use bridge::{invoke_capability, AppRegistry};
@@ -12,6 +13,7 @@ use exec::{exec_close, exec_input, start_pod_exec, ExecManager};
 use forward::{start_port_forward, stop_port_forward, ForwardManager};
 use srelens_kube::client_cache::ClientCache;
 use logs::{start_log_stream, stop_log_stream, LogStreamManager};
+use updater::{update_check, update_install};
 use watch::{start_resource_watch, stop_watch, WatchManager};
 
 pub use capabilities::build_registry;
@@ -58,7 +60,9 @@ pub fn run() {
             stop_log_stream,
             save_text_file,
             pick_kubeconfig_files,
-            save_pasted_kubeconfig
+            save_pasted_kubeconfig,
+            update_check,
+            update_install
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/desktop/src-tauri/src/updater.rs
+++ b/apps/desktop/src-tauri/src/updater.rs
@@ -1,0 +1,110 @@
+//! Channel-aware auto-update.
+//!
+//! Tauri's updater endpoints are static config, so they can't be switched at
+//! runtime. To support a user-selectable channel ("stable" / "dev") we build
+//! the updater per check with the endpoint for the chosen channel via
+//! `app.updater_builder().endpoints(...)`.
+//!
+//! - stable → the latest non-prerelease `latest.json`
+//! - dev    → `latest.json` attached to the permanent `dev-channel` pre-release
+//!
+//! Both manifests are signed with the same updater key (configured in
+//! tauri.conf.json `plugins.updater.pubkey`), so switching channels is safe.
+//! Tauri only updates to a *higher* version, so stable→dev pulls newer dev
+//! builds; dev→stable does not auto-downgrade.
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter};
+use tauri_plugin_updater::UpdaterExt;
+
+const STABLE_ENDPOINT: &str =
+    "https://github.com/srelens/srelens/releases/latest/download/latest.json";
+const DEV_ENDPOINT: &str =
+    "https://github.com/srelens/srelens/releases/download/dev-channel/latest.json";
+
+fn endpoint_for(channel: &str) -> &'static str {
+    if channel == "dev" {
+        DEV_ENDPOINT
+    } else {
+        STABLE_ENDPOINT
+    }
+}
+
+#[derive(Serialize, Clone)]
+pub struct UpdateMeta {
+    pub version: String,
+    pub current_version: String,
+    pub notes: Option<String>,
+}
+
+#[derive(Serialize, Clone)]
+struct DownloadProgress {
+    downloaded: usize,
+    total: Option<u64>,
+}
+
+async fn fetch_update(
+    app: &AppHandle,
+    channel: &str,
+) -> Result<Option<tauri_plugin_updater::Update>, String> {
+    let url = endpoint_for(channel)
+        .parse()
+        .map_err(|e| format!("invalid update endpoint: {e}"))?;
+    let updater = app
+        .updater_builder()
+        .endpoints(vec![url])
+        .map_err(|e| e.to_string())?
+        .build()
+        .map_err(|e| e.to_string())?;
+    updater.check().await.map_err(|e| e.to_string())
+}
+
+/// Check the given channel's manifest for an available update.
+#[tauri::command]
+pub async fn update_check(app: AppHandle, channel: String) -> Result<Option<UpdateMeta>, String> {
+    let update = fetch_update(&app, &channel).await?;
+    Ok(update.map(|u| UpdateMeta {
+        version: u.version.clone(),
+        current_version: u.current_version.clone(),
+        notes: u.body.clone(),
+    }))
+}
+
+/// Download + install the available update on the given channel, emitting
+/// `update://progress` events. The caller relaunches the app afterward.
+#[tauri::command]
+pub async fn update_install(app: AppHandle, channel: String) -> Result<(), String> {
+    let update = fetch_update(&app, &channel)
+        .await?
+        .ok_or_else(|| "No update available".to_string())?;
+    let mut downloaded: usize = 0;
+    let app2 = app.clone();
+    update
+        .download_and_install(
+            move |chunk, total| {
+                downloaded += chunk;
+                let _ = app2.emit("update://progress", DownloadProgress { downloaded, total });
+            },
+            || {},
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dev_channel_uses_the_dev_manifest() {
+        assert_eq!(endpoint_for("dev"), DEV_ENDPOINT);
+    }
+
+    #[test]
+    fn everything_else_falls_back_to_stable() {
+        assert_eq!(endpoint_for("stable"), STABLE_ENDPOINT);
+        assert_eq!(endpoint_for("nightly"), STABLE_ENDPOINT);
+        assert_eq!(endpoint_for(""), STABLE_ENDPOINT);
+    }
+}

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -24,9 +24,18 @@
       "csp": null
     }
   },
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://github.com/srelens/srelens/releases/latest/download/latest.json"
+      ],
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDY0RkY3MDRGOTgzRjQwOQpSV1FKOUlQNUJQZFBCdk96SU9Oc0t1bGY5bXcyWCt2VGNab2xyaWgwMStKeHhnRjRWVk4wdlBvVwo="
+    }
+  },
   "bundle": {
     "active": true,
     "targets": "all",
+    "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/apps/desktop/src/components/SettingsView.test.tsx
+++ b/apps/desktop/src/components/SettingsView.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SettingsView } from "./SettingsView";
 import { DEFAULT_WORKSPACE_LAYOUT } from "../lib/settings";
 
@@ -12,6 +12,7 @@ vi.mock("../lib/files", () => fileMocks);
 
 const updaterMocks = vi.hoisted(() => ({
   checkForUpdate: vi.fn(),
+  installUpdate: vi.fn(),
 }));
 vi.mock("../lib/updater", () => updaterMocks);
 
@@ -32,6 +33,8 @@ vi.mock("../lib/clusters", () => ({
 }));
 
 describe("SettingsView", () => {
+  beforeEach(() => localStorage.clear());
+
   it("separates settings and edits context identity", async () => {
     const onContextProfilesChange = vi.fn();
     render(
@@ -208,18 +211,46 @@ describe("SettingsView", () => {
     expect(await screen.findByText("0.1.0")).toBeDefined();
     fireEvent.click(screen.getByRole("button", { name: "Check for updates" }));
     expect(await screen.findByText(/up to date/i)).toBeDefined();
-    expect(updaterMocks.checkForUpdate).toHaveBeenCalledTimes(1);
+    expect(updaterMocks.checkForUpdate).toHaveBeenCalledWith("stable");
+  });
+
+  it("checks the dev channel when selected and persists the choice", async () => {
+    updaterMocks.checkForUpdate.mockResolvedValue(null);
+    render(
+      <SettingsView
+        theme={{ name: "slate", mode: "dark" }}
+        onThemeNameChange={() => {}}
+        onThemeModeChange={() => {}}
+        defaultNamespace=""
+        onDefaultNamespaceChange={() => {}}
+        layout={DEFAULT_WORKSPACE_LAYOUT}
+        onLayoutChange={() => {}}
+        contextProfiles={{}}
+        onContextProfilesChange={() => {}}
+        kubeconfigFiles={[]}
+        onKubeconfigFilesChange={() => {}}
+        contextOrder={[]}
+        onContextOrderChange={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Updates/ }));
+    fireEvent.click(await screen.findByRole("button", { name: /^Dev\b/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Check for updates" }));
+    await waitFor(() => expect(updaterMocks.checkForUpdate).toHaveBeenCalledWith("dev"));
+    expect(localStorage.getItem("srelens.updateChannel")).toBe("dev");
   });
 
   it("downloads an available update and offers a restart", async () => {
-    const download = vi.fn(async (onProgress?: (pct: number | null) => void) => {
-      onProgress?.(100);
-    });
     updaterMocks.checkForUpdate.mockResolvedValue({
       version: "0.2.0",
+      currentVersion: "0.1.0",
       notes: "New things",
-      download,
     });
+    updaterMocks.installUpdate.mockImplementation(
+      async (_channel: string, onProgress?: (pct: number | null) => void) => {
+        onProgress?.(100);
+      },
+    );
     render(
       <SettingsView
         theme={{ name: "slate", mode: "dark" }}
@@ -241,7 +272,9 @@ describe("SettingsView", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Check for updates" }));
     expect(await screen.findByText(/0\.2\.0/)).toBeDefined();
     fireEvent.click(screen.getByRole("button", { name: /Download & install/ }));
-    await waitFor(() => expect(download).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(updaterMocks.installUpdate).toHaveBeenCalledWith("stable", expect.any(Function)),
+    );
     fireEvent.click(await screen.findByRole("button", { name: /Restart srelens/ }));
     await waitFor(() => expect(transportMocks.relaunchApp).toHaveBeenCalledTimes(1));
   });

--- a/apps/desktop/src/components/SettingsView.test.tsx
+++ b/apps/desktop/src/components/SettingsView.test.tsx
@@ -10,6 +10,17 @@ const fileMocks = vi.hoisted(() => ({
 
 vi.mock("../lib/files", () => fileMocks);
 
+const updaterMocks = vi.hoisted(() => ({
+  checkForUpdate: vi.fn(),
+}));
+vi.mock("../lib/updater", () => updaterMocks);
+
+const transportMocks = vi.hoisted(() => ({
+  appVersion: vi.fn(async () => "0.1.0"),
+  relaunchApp: vi.fn(async () => {}),
+}));
+vi.mock("../transport/transport", () => transportMocks);
+
 vi.mock("../lib/clusters", () => ({
   listContexts: () =>
     Promise.resolve({
@@ -172,5 +183,90 @@ describe("SettingsView", () => {
     await waitFor(() =>
       expect(onKubeconfigFilesChange).toHaveBeenCalledWith(["/app/kubeconfigs/team.yaml"]),
     );
+  });
+
+  it("checks for updates and reports up to date", async () => {
+    updaterMocks.checkForUpdate.mockResolvedValue(null);
+    render(
+      <SettingsView
+        theme={{ name: "slate", mode: "dark" }}
+        onThemeNameChange={() => {}}
+        onThemeModeChange={() => {}}
+        defaultNamespace=""
+        onDefaultNamespaceChange={() => {}}
+        layout={DEFAULT_WORKSPACE_LAYOUT}
+        onLayoutChange={() => {}}
+        contextProfiles={{}}
+        onContextProfilesChange={() => {}}
+        kubeconfigFiles={[]}
+        onKubeconfigFilesChange={() => {}}
+        contextOrder={[]}
+        onContextOrderChange={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Updates/ }));
+    expect(await screen.findByText("0.1.0")).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: "Check for updates" }));
+    expect(await screen.findByText(/up to date/i)).toBeDefined();
+    expect(updaterMocks.checkForUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("downloads an available update and offers a restart", async () => {
+    const download = vi.fn(async (onProgress?: (pct: number | null) => void) => {
+      onProgress?.(100);
+    });
+    updaterMocks.checkForUpdate.mockResolvedValue({
+      version: "0.2.0",
+      notes: "New things",
+      download,
+    });
+    render(
+      <SettingsView
+        theme={{ name: "slate", mode: "dark" }}
+        onThemeNameChange={() => {}}
+        onThemeModeChange={() => {}}
+        defaultNamespace=""
+        onDefaultNamespaceChange={() => {}}
+        layout={DEFAULT_WORKSPACE_LAYOUT}
+        onLayoutChange={() => {}}
+        contextProfiles={{}}
+        onContextProfilesChange={() => {}}
+        kubeconfigFiles={[]}
+        onKubeconfigFilesChange={() => {}}
+        contextOrder={[]}
+        onContextOrderChange={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Updates/ }));
+    fireEvent.click(await screen.findByRole("button", { name: "Check for updates" }));
+    expect(await screen.findByText(/0\.2\.0/)).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: /Download & install/ }));
+    await waitFor(() => expect(download).toHaveBeenCalledTimes(1));
+    fireEvent.click(await screen.findByRole("button", { name: /Restart srelens/ }));
+    await waitFor(() => expect(transportMocks.relaunchApp).toHaveBeenCalledTimes(1));
+  });
+
+  it("surfaces update check failures", async () => {
+    updaterMocks.checkForUpdate.mockRejectedValue(new Error("endpoint unreachable"));
+    render(
+      <SettingsView
+        theme={{ name: "slate", mode: "dark" }}
+        onThemeNameChange={() => {}}
+        onThemeModeChange={() => {}}
+        defaultNamespace=""
+        onDefaultNamespaceChange={() => {}}
+        layout={DEFAULT_WORKSPACE_LAYOUT}
+        onLayoutChange={() => {}}
+        contextProfiles={{}}
+        onContextProfilesChange={() => {}}
+        kubeconfigFiles={[]}
+        onKubeconfigFilesChange={() => {}}
+        contextOrder={[]}
+        onContextOrderChange={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Updates/ }));
+    fireEvent.click(await screen.findByRole("button", { name: "Check for updates" }));
+    expect(await screen.findByText(/endpoint unreachable/)).toBeDefined();
   });
 });

--- a/apps/desktop/src/components/SettingsView.tsx
+++ b/apps/desktop/src/components/SettingsView.tsx
@@ -35,14 +35,17 @@ import { listContexts, type ClusterContext } from "../lib/clusters";
 import {
   DEFAULT_WORKSPACE_LAYOUT,
   contextDisplayName,
+  loadUpdateChannel,
+  saveUpdateChannel,
   type ContextLogo,
   type ContextProfiles,
+  type UpdateChannel,
   type WorkspaceLayoutSettings,
   orderContexts,
 } from "../lib/settings";
 import { ContextAvatar, CONTEXT_LOGO_OPTIONS } from "./ContextAvatar";
 import { pickKubeconfigFiles, savePastedKubeconfig } from "../lib/files";
-import { checkForUpdate, type AvailableUpdate } from "../lib/updater";
+import { checkForUpdate, installUpdate, type UpdateMeta } from "../lib/updater";
 import { appVersion, relaunchApp } from "../transport/transport";
 
 const MODE_OPTIONS: Array<{ mode: ThemeMode; label: string; description: string; icon: React.ElementType }> = [
@@ -57,10 +60,15 @@ type UpdatePhase =
   | { phase: "idle" }
   | { phase: "checking" }
   | { phase: "uptodate" }
-  | { phase: "available"; update: AvailableUpdate }
-  | { phase: "downloading"; update: AvailableUpdate; percent: number | null }
+  | { phase: "available"; update: UpdateMeta }
+  | { phase: "downloading"; percent: number | null }
   | { phase: "ready" }
   | { phase: "error"; message: string };
+
+const UPDATE_CHANNELS: Array<{ id: UpdateChannel; label: string; description: string }> = [
+  { id: "stable", label: "Stable", description: "Released versions" },
+  { id: "dev", label: "Dev", description: "Rolling pre-releases" },
+];
 
 const SETTINGS_SECTIONS: Array<{
   id: SettingsSection;
@@ -119,6 +127,7 @@ export function SettingsView({
   const [pastedKubeconfig, setPastedKubeconfig] = useState("");
   const [pastedKubeconfigName, setPastedKubeconfigName] = useState("");
   const [updateState, setUpdateState] = useState<UpdatePhase>({ phase: "idle" });
+  const [updateChannel, setUpdateChannel] = useState<UpdateChannel>(() => loadUpdateChannel());
   const [currentVersion, setCurrentVersion] = useState("");
   const draggedContextRef = useRef<string | null>(null);
   const dropTargetRef = useRef<string | null>(null);
@@ -137,20 +146,26 @@ export function SettingsView({
     };
   }, []);
 
+  const switchUpdateChannel = (channel: UpdateChannel) => {
+    setUpdateChannel(channel);
+    saveUpdateChannel(channel);
+    setUpdateState({ phase: "idle" });
+  };
+
   const runUpdateCheck = async () => {
     setUpdateState({ phase: "checking" });
     try {
-      const update = await checkForUpdate();
+      const update = await checkForUpdate(updateChannel);
       setUpdateState(update ? { phase: "available", update } : { phase: "uptodate" });
     } catch (cause) {
       setUpdateState({ phase: "error", message: cause instanceof Error ? cause.message : String(cause) });
     }
   };
 
-  const installUpdate = async (update: AvailableUpdate) => {
-    setUpdateState({ phase: "downloading", update, percent: null });
+  const startInstall = async () => {
+    setUpdateState({ phase: "downloading", percent: null });
     try {
-      await update.download((percent) => setUpdateState({ phase: "downloading", update, percent }));
+      await installUpdate(updateChannel, (percent) => setUpdateState({ phase: "downloading", percent }));
       setUpdateState({ phase: "ready" });
     } catch (cause) {
       setUpdateState({ phase: "error", message: cause instanceof Error ? cause.message : String(cause) });
@@ -722,6 +737,24 @@ export function SettingsView({
                   <code>{currentVersion || "unknown"}</code>
                 </div>
 
+                <div className="fl-settings-update__channels" role="group" aria-label="Update channel">
+                  {UPDATE_CHANNELS.map(({ id, label, description }) => (
+                    <button
+                      key={id}
+                      type="button"
+                      className={`fl-settings-mode${updateChannel === id ? " fl-settings-mode--active" : ""}`}
+                      onClick={() => switchUpdateChannel(id)}
+                      aria-pressed={updateChannel === id}
+                    >
+                      <span>
+                        <strong>{label}</strong>
+                        <small>{description}</small>
+                      </span>
+                      {updateChannel === id && <Check aria-hidden="true" />}
+                    </button>
+                  ))}
+                </div>
+
                 {(updateState.phase === "idle" ||
                   updateState.phase === "checking" ||
                   updateState.phase === "uptodate" ||
@@ -739,12 +772,13 @@ export function SettingsView({
                 {updateState.phase === "available" && (
                   <div className="fl-settings-update__offer">
                     <p>
-                      Version <strong>{updateState.update.version}</strong> is available.
+                      Version <strong>{updateState.update.version}</strong> is available on the {updateChannel}{" "}
+                      channel.
                     </p>
                     {updateState.update.notes && (
                       <pre className="fl-settings-update__notes">{updateState.update.notes}</pre>
                     )}
-                    <Button onClick={() => void installUpdate(updateState.update)}>
+                    <Button onClick={() => void startInstall()}>
                       <Download data-icon="inline-start" /> Download &amp; install
                     </Button>
                   </div>

--- a/apps/desktop/src/components/SettingsView.tsx
+++ b/apps/desktop/src/components/SettingsView.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 import {
   Boxes,
   Check,
+  Download,
   LayoutPanelLeft,
   Monitor,
   Moon,
@@ -41,6 +42,8 @@ import {
 } from "../lib/settings";
 import { ContextAvatar, CONTEXT_LOGO_OPTIONS } from "./ContextAvatar";
 import { pickKubeconfigFiles, savePastedKubeconfig } from "../lib/files";
+import { checkForUpdate, type AvailableUpdate } from "../lib/updater";
+import { appVersion, relaunchApp } from "../transport/transport";
 
 const MODE_OPTIONS: Array<{ mode: ThemeMode; label: string; description: string; icon: React.ElementType }> = [
   { mode: "dark", label: "Dark", description: "Low-light operational workspace", icon: Moon },
@@ -48,7 +51,16 @@ const MODE_OPTIONS: Array<{ mode: ThemeMode; label: string; description: string;
   { mode: "system", label: "System", description: "Follow the OS appearance", icon: Monitor },
 ];
 
-type SettingsSection = "appearance" | "layout" | "kubernetes" | "contexts";
+type SettingsSection = "appearance" | "layout" | "kubernetes" | "contexts" | "updates";
+
+type UpdatePhase =
+  | { phase: "idle" }
+  | { phase: "checking" }
+  | { phase: "uptodate" }
+  | { phase: "available"; update: AvailableUpdate }
+  | { phase: "downloading"; update: AvailableUpdate; percent: number | null }
+  | { phase: "ready" }
+  | { phase: "error"; message: string };
 
 const SETTINGS_SECTIONS: Array<{
   id: SettingsSection;
@@ -60,6 +72,7 @@ const SETTINGS_SECTIONS: Array<{
   { id: "layout", label: "Layout", description: "Panel dimensions", icon: LayoutPanelLeft },
   { id: "kubernetes", label: "Kubernetes", description: "Workspace defaults", icon: Network },
   { id: "contexts", label: "Contexts", description: "Names, logos and colors", icon: Boxes },
+  { id: "updates", label: "Updates", description: "App version and updates", icon: Download },
 ];
 
 const CONTEXT_COLORS = ["#2563eb", "#7c3aed", "#db2777", "#dc2626", "#ea580c", "#16a34a", "#0891b2", "#475569"];
@@ -105,8 +118,44 @@ export function SettingsView({
   const [pasteKubeconfigOpen, setPasteKubeconfigOpen] = useState(false);
   const [pastedKubeconfig, setPastedKubeconfig] = useState("");
   const [pastedKubeconfigName, setPastedKubeconfigName] = useState("");
+  const [updateState, setUpdateState] = useState<UpdatePhase>({ phase: "idle" });
+  const [currentVersion, setCurrentVersion] = useState("");
   const draggedContextRef = useRef<string | null>(null);
   const dropTargetRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    appVersion()
+      .then((version) => {
+        if (active) setCurrentVersion(version);
+      })
+      .catch(() => {
+        /* version display is cosmetic — never block settings on it */
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const runUpdateCheck = async () => {
+    setUpdateState({ phase: "checking" });
+    try {
+      const update = await checkForUpdate();
+      setUpdateState(update ? { phase: "available", update } : { phase: "uptodate" });
+    } catch (cause) {
+      setUpdateState({ phase: "error", message: cause instanceof Error ? cause.message : String(cause) });
+    }
+  };
+
+  const installUpdate = async (update: AvailableUpdate) => {
+    setUpdateState({ phase: "downloading", update, percent: null });
+    try {
+      await update.download((percent) => setUpdateState({ phase: "downloading", update, percent }));
+      setUpdateState({ phase: "ready" });
+    } catch (cause) {
+      setUpdateState({ phase: "error", message: cause instanceof Error ? cause.message : String(cause) });
+    }
+  };
 
   useEffect(() => {
     let active = true;
@@ -662,6 +711,60 @@ export function SettingsView({
                   )}
                 </div>
               )}
+            </SectionPanel>
+          )}
+
+          {section === "updates" && (
+            <SectionPanel title="Updates" description="Check for and install new versions of srelens.">
+              <div className="fl-settings-update">
+                <div className="fl-settings-update__version">
+                  <small>Current version</small>
+                  <code>{currentVersion || "unknown"}</code>
+                </div>
+
+                {(updateState.phase === "idle" ||
+                  updateState.phase === "checking" ||
+                  updateState.phase === "uptodate" ||
+                  updateState.phase === "error") && (
+                  <Button onClick={() => void runUpdateCheck()} disabled={updateState.phase === "checking"}>
+                    {updateState.phase === "checking" ? "Checking…" : "Check for updates"}
+                  </Button>
+                )}
+
+                {updateState.phase === "uptodate" && <p className="fl-settings-update__status">srelens is up to date.</p>}
+                {updateState.phase === "error" && (
+                  <p className="fl-settings-update__status" role="alert">{updateState.message}</p>
+                )}
+
+                {updateState.phase === "available" && (
+                  <div className="fl-settings-update__offer">
+                    <p>
+                      Version <strong>{updateState.update.version}</strong> is available.
+                    </p>
+                    {updateState.update.notes && (
+                      <pre className="fl-settings-update__notes">{updateState.update.notes}</pre>
+                    )}
+                    <Button onClick={() => void installUpdate(updateState.update)}>
+                      <Download data-icon="inline-start" /> Download &amp; install
+                    </Button>
+                  </div>
+                )}
+
+                {updateState.phase === "downloading" && (
+                  <p className="fl-settings-update__status" role="status">
+                    Downloading{updateState.percent != null ? ` — ${updateState.percent}%` : "…"}
+                  </p>
+                )}
+
+                {updateState.phase === "ready" && (
+                  <div className="fl-settings-update__offer">
+                    <p>Update installed. Restart to finish.</p>
+                    <Button onClick={() => void relaunchApp()}>
+                      <RotateCcw data-icon="inline-start" /> Restart srelens
+                    </Button>
+                  </div>
+                )}
+              </div>
             </SectionPanel>
           )}
         </div>

--- a/apps/desktop/src/lib/settings.test.ts
+++ b/apps/desktop/src/lib/settings.test.ts
@@ -15,6 +15,8 @@ import {
   loadContextOrder,
   orderContexts,
   saveContextOrder,
+  loadUpdateChannel,
+  saveUpdateChannel,
 } from "./settings";
 
 beforeEach(() => localStorage.clear());
@@ -69,5 +71,16 @@ describe("settings persistence", () => {
     expect(loadContextOrder()).toEqual(["prod", "dev"]);
     expect(orderContexts([{ name: "dev" }, { name: "new" }, { name: "prod" }], loadContextOrder()))
       .toEqual([{ name: "prod" }, { name: "dev" }, { name: "new" }]);
+  });
+
+  it("persists the update channel and defaults to stable", () => {
+    expect(loadUpdateChannel()).toBe("stable");
+    saveUpdateChannel("dev");
+    expect(loadUpdateChannel()).toBe("dev");
+  });
+
+  it("falls back to stable for unknown stored channels", () => {
+    localStorage.setItem("srelens.updateChannel", "nightly");
+    expect(loadUpdateChannel()).toBe("stable");
   });
 });

--- a/apps/desktop/src/lib/settings.ts
+++ b/apps/desktop/src/lib/settings.ts
@@ -158,6 +158,28 @@ export function saveContextOrder(order: string[]): void {
   }
 }
 
+/** Which release channel the in-app updater follows. */
+export type UpdateChannel = "stable" | "dev";
+
+const UPDATE_CHANNEL_KEY = "srelens.updateChannel";
+
+export function loadUpdateChannel(): UpdateChannel {
+  try {
+    const value = stored(UPDATE_CHANNEL_KEY);
+    return value === "dev" ? "dev" : "stable";
+  } catch {
+    return "stable";
+  }
+}
+
+export function saveUpdateChannel(channel: UpdateChannel): void {
+  try {
+    localStorage.setItem(UPDATE_CHANNEL_KEY, channel);
+  } catch {
+    // ignore unavailable/quota-exceeded storage
+  }
+}
+
 export function orderContexts<T extends { name: string }>(contexts: T[], order: string[]): T[] {
   const rank = new Map(order.map((name, index) => [name, index]));
   return contexts

--- a/apps/desktop/src/lib/updater.test.ts
+++ b/apps/desktop/src/lib/updater.test.ts
@@ -1,68 +1,95 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { checkForAppUpdateMock } = vi.hoisted(() => ({
-  checkForAppUpdateMock: vi.fn(),
+const { invokeCommandMock, subscribeMock } = vi.hoisted(() => ({
+  invokeCommandMock: vi.fn(),
+  subscribeMock: vi.fn(),
 }));
 vi.mock("../transport/transport", () => ({
-  checkForAppUpdate: checkForAppUpdateMock,
+  invokeCommand: invokeCommandMock,
+  subscribe: subscribeMock,
 }));
 
-import { checkForUpdate } from "./updater";
+import { checkForUpdate, installUpdate } from "./updater";
 
 beforeEach(() => {
-  checkForAppUpdateMock.mockReset();
+  invokeCommandMock.mockReset();
+  subscribeMock.mockReset();
 });
 
 describe("checkForUpdate", () => {
-  it("returns null when the app is up to date", async () => {
-    checkForAppUpdateMock.mockResolvedValue(null);
-    expect(await checkForUpdate()).toBeNull();
+  it("returns null when the channel is up to date", async () => {
+    invokeCommandMock.mockResolvedValue(null);
+    expect(await checkForUpdate("stable")).toBeNull();
+    expect(invokeCommandMock).toHaveBeenCalledWith("update_check", { channel: "stable" });
   });
 
-  it("maps the update's version and notes", async () => {
-    checkForAppUpdateMock.mockResolvedValue({
+  it("checks the requested channel and maps the metadata", async () => {
+    invokeCommandMock.mockResolvedValue({
       version: "0.2.0",
-      body: "### Features\n- things",
-      downloadAndInstall: vi.fn(),
+      current_version: "0.1.0",
+      notes: "### Features\n- things",
     });
-    const update = await checkForUpdate();
-    expect(update?.version).toBe("0.2.0");
-    expect(update?.notes).toBe("### Features\n- things");
+    const meta = await checkForUpdate("dev");
+    expect(invokeCommandMock).toHaveBeenCalledWith("update_check", { channel: "dev" });
+    expect(meta).toEqual({
+      version: "0.2.0",
+      currentVersion: "0.1.0",
+      notes: "### Features\n- things",
+    });
   });
 
   it("defaults notes to an empty string", async () => {
-    checkForAppUpdateMock.mockResolvedValue({ version: "0.2.0", downloadAndInstall: vi.fn() });
-    expect((await checkForUpdate())?.notes).toBe("");
+    invokeCommandMock.mockResolvedValue({ version: "0.2.0", current_version: "0.1.0", notes: null });
+    expect((await checkForUpdate("stable"))?.notes).toBe("");
   });
+});
 
-  it("reports download percent from Started/Progress/Finished events", async () => {
-    const downloadAndInstall = vi.fn(async (onEvent: (e: unknown) => void) => {
-      onEvent({ event: "Started", data: { contentLength: 200 } });
-      onEvent({ event: "Progress", data: { chunkLength: 50 } });
-      onEvent({ event: "Progress", data: { chunkLength: 150 } });
-      onEvent({ event: "Finished" });
+describe("installUpdate", () => {
+  it("subscribes to progress before starting and reports whole percents", async () => {
+    let emit: ((payload: unknown) => void) | undefined;
+    const dispose = vi.fn();
+    subscribeMock.mockImplementation(async (_ch: string, handler: (p: unknown) => void) => {
+      emit = handler;
+      return dispose;
     });
-    checkForAppUpdateMock.mockResolvedValue({ version: "0.2.0", body: "", downloadAndInstall });
+    invokeCommandMock.mockImplementation(async () => {
+      emit?.({ downloaded: 50, total: 200 });
+      emit?.({ downloaded: 200, total: 200 });
+    });
 
-    const update = await checkForUpdate();
     const seen: Array<number | null> = [];
-    await update?.download((pct) => seen.push(pct));
+    await installUpdate("dev", (pct) => seen.push(pct));
 
-    expect(seen).toEqual([25, 100, 100]);
-    expect(downloadAndInstall).toHaveBeenCalledTimes(1);
+    expect(subscribeMock).toHaveBeenCalledWith("update://progress", expect.any(Function));
+    expect(subscribeMock.mock.invocationCallOrder[0]).toBeLessThan(
+      invokeCommandMock.mock.invocationCallOrder[0],
+    );
+    expect(invokeCommandMock).toHaveBeenCalledWith("update_install", { channel: "dev" });
+    expect(seen).toEqual([25, 100]);
+    expect(dispose).toHaveBeenCalled();
   });
 
   it("reports null percent when the total size is unknown", async () => {
-    const downloadAndInstall = vi.fn(async (onEvent: (e: unknown) => void) => {
-      onEvent({ event: "Started", data: {} });
-      onEvent({ event: "Progress", data: { chunkLength: 10 } });
+    let emit: ((payload: unknown) => void) | undefined;
+    subscribeMock.mockImplementation(async (_ch: string, handler: (p: unknown) => void) => {
+      emit = handler;
+      return vi.fn();
     });
-    checkForAppUpdateMock.mockResolvedValue({ version: "0.2.0", body: "", downloadAndInstall });
+    invokeCommandMock.mockImplementation(async () => {
+      emit?.({ downloaded: 10, total: null });
+    });
 
-    const update = await checkForUpdate();
     const seen: Array<number | null> = [];
-    await update?.download((pct) => seen.push(pct));
-
+    await installUpdate("stable", (pct) => seen.push(pct));
     expect(seen).toEqual([null]);
+  });
+
+  it("disposes the progress listener when the install fails", async () => {
+    const dispose = vi.fn();
+    subscribeMock.mockResolvedValue(dispose);
+    invokeCommandMock.mockRejectedValue(new Error("boom"));
+
+    await expect(installUpdate("stable")).rejects.toThrow("boom");
+    expect(dispose).toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/lib/updater.test.ts
+++ b/apps/desktop/src/lib/updater.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { checkForAppUpdateMock } = vi.hoisted(() => ({
+  checkForAppUpdateMock: vi.fn(),
+}));
+vi.mock("../transport/transport", () => ({
+  checkForAppUpdate: checkForAppUpdateMock,
+}));
+
+import { checkForUpdate } from "./updater";
+
+beforeEach(() => {
+  checkForAppUpdateMock.mockReset();
+});
+
+describe("checkForUpdate", () => {
+  it("returns null when the app is up to date", async () => {
+    checkForAppUpdateMock.mockResolvedValue(null);
+    expect(await checkForUpdate()).toBeNull();
+  });
+
+  it("maps the update's version and notes", async () => {
+    checkForAppUpdateMock.mockResolvedValue({
+      version: "0.2.0",
+      body: "### Features\n- things",
+      downloadAndInstall: vi.fn(),
+    });
+    const update = await checkForUpdate();
+    expect(update?.version).toBe("0.2.0");
+    expect(update?.notes).toBe("### Features\n- things");
+  });
+
+  it("defaults notes to an empty string", async () => {
+    checkForAppUpdateMock.mockResolvedValue({ version: "0.2.0", downloadAndInstall: vi.fn() });
+    expect((await checkForUpdate())?.notes).toBe("");
+  });
+
+  it("reports download percent from Started/Progress/Finished events", async () => {
+    const downloadAndInstall = vi.fn(async (onEvent: (e: unknown) => void) => {
+      onEvent({ event: "Started", data: { contentLength: 200 } });
+      onEvent({ event: "Progress", data: { chunkLength: 50 } });
+      onEvent({ event: "Progress", data: { chunkLength: 150 } });
+      onEvent({ event: "Finished" });
+    });
+    checkForAppUpdateMock.mockResolvedValue({ version: "0.2.0", body: "", downloadAndInstall });
+
+    const update = await checkForUpdate();
+    const seen: Array<number | null> = [];
+    await update?.download((pct) => seen.push(pct));
+
+    expect(seen).toEqual([25, 100, 100]);
+    expect(downloadAndInstall).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports null percent when the total size is unknown", async () => {
+    const downloadAndInstall = vi.fn(async (onEvent: (e: unknown) => void) => {
+      onEvent({ event: "Started", data: {} });
+      onEvent({ event: "Progress", data: { chunkLength: 10 } });
+    });
+    checkForAppUpdateMock.mockResolvedValue({ version: "0.2.0", body: "", downloadAndInstall });
+
+    const update = await checkForUpdate();
+    const seen: Array<number | null> = [];
+    await update?.download((pct) => seen.push(pct));
+
+    expect(seen).toEqual([null]);
+  });
+});

--- a/apps/desktop/src/lib/updater.ts
+++ b/apps/desktop/src/lib/updater.ts
@@ -1,37 +1,55 @@
-import { checkForAppUpdate } from "../transport/transport";
+import { invokeCommand, subscribe } from "../transport/transport";
+import type { UpdateChannel } from "./settings";
 
-/** An update ready to be downloaded and installed. */
-export interface AvailableUpdate {
+/** Metadata for an update available on a channel. */
+export interface UpdateMeta {
   version: string;
+  currentVersion: string;
   notes: string;
-  /**
-   * Download and install the update. Progress is reported as a whole percent,
-   * or null when the server didn't announce a total size. After this resolves
-   * the app must be relaunched for the new version to run.
-   */
-  download(onProgress?: (percent: number | null) => void): Promise<void>;
 }
 
-/** Ask the update endpoint whether a newer version exists (null = up to date). */
-export async function checkForUpdate(): Promise<AvailableUpdate | null> {
-  const update = await checkForAppUpdate();
-  if (!update) return null;
+interface RawUpdateMeta {
+  version: string;
+  current_version: string;
+  notes: string | null;
+}
+
+interface RawProgress {
+  downloaded: number;
+  total: number | null;
+}
+
+/** Ask the channel's manifest whether a newer version exists (null = up to date). */
+export async function checkForUpdate(channel: UpdateChannel): Promise<UpdateMeta | null> {
+  const meta = await invokeCommand<RawUpdateMeta | null>("update_check", { channel });
+  if (!meta) return null;
   return {
-    version: update.version,
-    notes: update.body ?? "",
-    download: async (onProgress) => {
-      let total: number | null = null;
-      let received = 0;
-      await update.downloadAndInstall((event) => {
-        if (event.event === "Started") {
-          total = event.data.contentLength ?? null;
-        } else if (event.event === "Progress") {
-          received += event.data.chunkLength;
-          onProgress?.(total ? Math.round((received / total) * 100) : null);
-        } else if (event.event === "Finished") {
-          onProgress?.(100);
-        }
-      });
-    },
+    version: meta.version,
+    currentVersion: meta.current_version,
+    notes: meta.notes ?? "",
   };
+}
+
+/**
+ * Download and install the channel's available update. Progress is reported as
+ * a whole percent, or null when the server didn't announce a total size. After
+ * this resolves the app must be relaunched for the new version to run.
+ */
+export async function installUpdate(
+  channel: UpdateChannel,
+  onProgress?: (percent: number | null) => void,
+): Promise<void> {
+  // Subscribe before starting the install so the first progress event can't
+  // race ahead of the listener.
+  const dispose = await subscribe("update://progress", (payload) => {
+    const progress = payload as RawProgress;
+    onProgress?.(
+      progress.total ? Math.min(100, Math.round((progress.downloaded / progress.total) * 100)) : null,
+    );
+  });
+  try {
+    await invokeCommand("update_install", { channel });
+  } finally {
+    dispose();
+  }
 }

--- a/apps/desktop/src/lib/updater.ts
+++ b/apps/desktop/src/lib/updater.ts
@@ -1,0 +1,37 @@
+import { checkForAppUpdate } from "../transport/transport";
+
+/** An update ready to be downloaded and installed. */
+export interface AvailableUpdate {
+  version: string;
+  notes: string;
+  /**
+   * Download and install the update. Progress is reported as a whole percent,
+   * or null when the server didn't announce a total size. After this resolves
+   * the app must be relaunched for the new version to run.
+   */
+  download(onProgress?: (percent: number | null) => void): Promise<void>;
+}
+
+/** Ask the update endpoint whether a newer version exists (null = up to date). */
+export async function checkForUpdate(): Promise<AvailableUpdate | null> {
+  const update = await checkForAppUpdate();
+  if (!update) return null;
+  return {
+    version: update.version,
+    notes: update.body ?? "",
+    download: async (onProgress) => {
+      let total: number | null = null;
+      let received = 0;
+      await update.downloadAndInstall((event) => {
+        if (event.event === "Started") {
+          total = event.data.contentLength ?? null;
+        } else if (event.event === "Progress") {
+          received += event.data.chunkLength;
+          onProgress?.(total ? Math.round((received / total) * 100) : null);
+        } else if (event.event === "Finished") {
+          onProgress?.(100);
+        }
+      });
+    },
+  };
+}

--- a/apps/desktop/src/transport/transport.test.ts
+++ b/apps/desktop/src/transport/transport.test.ts
@@ -1,17 +1,26 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { invokeMock, listenMock } = vi.hoisted(() => ({
+const { invokeMock, listenMock, checkMock, relaunchMock, getVersionMock } = vi.hoisted(() => ({
   invokeMock: vi.fn(),
   listenMock: vi.fn(),
+  checkMock: vi.fn(),
+  relaunchMock: vi.fn(),
+  getVersionMock: vi.fn(),
 }));
 vi.mock("@tauri-apps/api/core", () => ({ invoke: invokeMock }));
 vi.mock("@tauri-apps/api/event", () => ({ listen: listenMock }));
+vi.mock("@tauri-apps/api/app", () => ({ getVersion: getVersionMock }));
+vi.mock("@tauri-apps/plugin-updater", () => ({ check: checkMock }));
+vi.mock("@tauri-apps/plugin-process", () => ({ relaunch: relaunchMock }));
 
-import { invokeCapability, on } from "./transport";
+import { invokeCapability, invokeCommand, on, checkForAppUpdate, relaunchApp, appVersion } from "./transport";
 
 beforeEach(() => {
   invokeMock.mockReset();
   listenMock.mockReset();
+  checkMock.mockReset();
+  relaunchMock.mockReset();
+  getVersionMock.mockReset();
 });
 
 describe("transport", () => {
@@ -33,5 +42,29 @@ describe("transport", () => {
     dispose();
     await flush();
     expect(unlisten).toHaveBeenCalled();
+  });
+
+  it("invokeCommand forwards command name and args", async () => {
+    invokeMock.mockResolvedValue("ok");
+    const out = await invokeCommand<string>("save_text_file", { filename: "a.yaml" });
+    expect(invokeMock).toHaveBeenCalledWith("save_text_file", { filename: "a.yaml" });
+    expect(out).toBe("ok");
+  });
+
+  it("checkForAppUpdate delegates to the updater plugin", async () => {
+    checkMock.mockResolvedValue(null);
+    expect(await checkForAppUpdate()).toBeNull();
+    expect(checkMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("relaunchApp delegates to the process plugin", async () => {
+    relaunchMock.mockResolvedValue(undefined);
+    await relaunchApp();
+    expect(relaunchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("appVersion reads the bundle version", async () => {
+    getVersionMock.mockResolvedValue("1.2.3");
+    expect(await appVersion()).toBe("1.2.3");
   });
 });

--- a/apps/desktop/src/transport/transport.test.ts
+++ b/apps/desktop/src/transport/transport.test.ts
@@ -1,24 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { invokeMock, listenMock, checkMock, relaunchMock, getVersionMock } = vi.hoisted(() => ({
+const { invokeMock, listenMock, relaunchMock, getVersionMock } = vi.hoisted(() => ({
   invokeMock: vi.fn(),
   listenMock: vi.fn(),
-  checkMock: vi.fn(),
   relaunchMock: vi.fn(),
   getVersionMock: vi.fn(),
 }));
 vi.mock("@tauri-apps/api/core", () => ({ invoke: invokeMock }));
 vi.mock("@tauri-apps/api/event", () => ({ listen: listenMock }));
 vi.mock("@tauri-apps/api/app", () => ({ getVersion: getVersionMock }));
-vi.mock("@tauri-apps/plugin-updater", () => ({ check: checkMock }));
 vi.mock("@tauri-apps/plugin-process", () => ({ relaunch: relaunchMock }));
 
-import { invokeCapability, invokeCommand, on, checkForAppUpdate, relaunchApp, appVersion } from "./transport";
+import { invokeCapability, invokeCommand, on, relaunchApp, appVersion } from "./transport";
 
 beforeEach(() => {
   invokeMock.mockReset();
   listenMock.mockReset();
-  checkMock.mockReset();
   relaunchMock.mockReset();
   getVersionMock.mockReset();
 });
@@ -49,12 +46,6 @@ describe("transport", () => {
     const out = await invokeCommand<string>("save_text_file", { filename: "a.yaml" });
     expect(invokeMock).toHaveBeenCalledWith("save_text_file", { filename: "a.yaml" });
     expect(out).toBe("ok");
-  });
-
-  it("checkForAppUpdate delegates to the updater plugin", async () => {
-    checkMock.mockResolvedValue(null);
-    expect(await checkForAppUpdate()).toBeNull();
-    expect(checkMock).toHaveBeenCalledTimes(1);
   });
 
   it("relaunchApp delegates to the process plugin", async () => {

--- a/apps/desktop/src/transport/transport.ts
+++ b/apps/desktop/src/transport/transport.ts
@@ -1,7 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getVersion } from "@tauri-apps/api/app";
-import { check, type Update } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
 
 /** A function that invokes a backend capability — injectable for testing. */
@@ -40,11 +39,6 @@ export async function subscribe(
   handler: (payload: unknown) => void,
 ): Promise<() => void> {
   return listen(channel, (event) => handler(event.payload));
-}
-
-/** The updater plugin's check — talks Tauri IPC internally. */
-export async function checkForAppUpdate(): Promise<Update | null> {
-  return check();
 }
 
 /** Restart the app (used after an update is installed). */

--- a/apps/desktop/src/transport/transport.ts
+++ b/apps/desktop/src/transport/transport.ts
@@ -1,5 +1,8 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { getVersion } from "@tauri-apps/api/app";
+import { check, type Update } from "@tauri-apps/plugin-updater";
+import { relaunch } from "@tauri-apps/plugin-process";
 
 /** A function that invokes a backend capability — injectable for testing. */
 export type Invoker = <T>(id: string, input?: unknown) => Promise<T>;
@@ -37,4 +40,19 @@ export async function subscribe(
   handler: (payload: unknown) => void,
 ): Promise<() => void> {
   return listen(channel, (event) => handler(event.payload));
+}
+
+/** The updater plugin's check — talks Tauri IPC internally. */
+export async function checkForAppUpdate(): Promise<Update | null> {
+  return check();
+}
+
+/** Restart the app (used after an update is installed). */
+export async function relaunchApp(): Promise<void> {
+  return relaunch();
+}
+
+/** The running app's bundle version. */
+export async function appVersion(): Promise<string> {
+  return getVersion();
 }

--- a/apps/desktop/src/ui/styles.css
+++ b/apps/desktop/src/ui/styles.css
@@ -2394,6 +2394,12 @@ body {
 .fl-settings-update__version small {
   color: var(--fl-color-text-muted);
 }
+.fl-settings-update__channels {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  width: 100%;
+}
 .fl-settings-update__status {
   margin: 0;
   color: var(--fl-color-text-muted);

--- a/apps/desktop/src/ui/styles.css
+++ b/apps/desktop/src/ui/styles.css
@@ -2379,6 +2379,47 @@ body {
   font-size: 13px;
   font-weight: 600;
 }
+.fl-settings-update {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 14px;
+  max-width: 460px;
+}
+.fl-settings-update__version {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+.fl-settings-update__version small {
+  color: var(--fl-color-text-muted);
+}
+.fl-settings-update__status {
+  margin: 0;
+  color: var(--fl-color-text-muted);
+  font-size: 13px;
+}
+.fl-settings-update__status[role="alert"] {
+  color: var(--fl-color-danger, #e5484d);
+}
+.fl-settings-update__offer {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 10px;
+}
+.fl-settings-update__offer p {
+  margin: 0;
+}
+.fl-settings-update__notes {
+  max-height: 180px;
+  overflow: auto;
+  padding: 10px 12px;
+  border: 1px solid var(--fl-color-border-faint);
+  border-radius: var(--fl-radius-md);
+  font-size: 12px;
+  white-space: pre-wrap;
+}
 .fl-settings-width-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,12 @@ importers:
       '@tauri-apps/api':
         specifier: ^2.0.0
         version: 2.11.1
+      '@tauri-apps/plugin-process':
+        specifier: ^2.3.1
+        version: 2.3.1
+      '@tauri-apps/plugin-updater':
+        specifier: ^2.10.1
+        version: 2.10.1
       '@xterm/addon-fit':
         specifier: ^0.10.0
         version: 0.10.0(@xterm/xterm@5.5.0)
@@ -1609,6 +1615,12 @@ packages:
     resolution: {integrity: sha512-EElQe8z8uD7Pi5++tJ/UfEwWuK08rd3oCDYdeIbJAb6pZRrxlqmoF5gh5H5YvzmUPhS4IRCaLSsQhvWkrfK+GQ==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-process@2.3.1':
+    resolution: {integrity: sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==}
+
+  '@tauri-apps/plugin-updater@2.10.1':
+    resolution: {integrity: sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -5068,6 +5080,14 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.3
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.3
       '@tauri-apps/cli-win32-x64-msvc': 2.11.3
+
+  '@tauri-apps/plugin-process@2.3.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
+
+  '@tauri-apps/plugin-updater@2.10.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
 
   '@testing-library/dom@10.4.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,9 +50,6 @@ importers:
       '@tauri-apps/plugin-process':
         specifier: ^2.3.1
         version: 2.3.1
-      '@tauri-apps/plugin-updater':
-        specifier: ^2.10.1
-        version: 2.10.1
       '@xterm/addon-fit':
         specifier: ^0.10.0
         version: 0.10.0(@xterm/xterm@5.5.0)
@@ -1618,9 +1615,6 @@ packages:
 
   '@tauri-apps/plugin-process@2.3.1':
     resolution: {integrity: sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==}
-
-  '@tauri-apps/plugin-updater@2.10.1':
-    resolution: {integrity: sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -5082,10 +5076,6 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.11.3
 
   '@tauri-apps/plugin-process@2.3.1':
-    dependencies:
-      '@tauri-apps/api': 2.11.1
-
-  '@tauri-apps/plugin-updater@2.10.1':
     dependencies:
       '@tauri-apps/api': 2.11.1
 


### PR DESCRIPTION
Ports mqlens's \`sign-artifacts\` job: after a release's assets are uploaded, a follow-up job signs every asset with a detached armored GPG signature and attaches the \`.asc\` files, letting users verify authenticity with \`gpg --verify file.asc file\`.

- Gated on the \`GPG_PRIVATE_KEY\` secret — a complete no-op until it (and \`GPG_PASSPHRASE\`) are configured, so current releases are unaffected.
- Runs on both channels: dev pre-releases and stable releases (skipped when main has nothing to release).

To activate later:
1. \`gpg --export-secret-keys --armor KEYID | base64\` → \`GPG_PRIVATE_KEY\`
2. The key's passphrase → \`GPG_PASSPHRASE\`