### PR TITLE
fix: sanitize watch channel names to valid Tauri event names (#46)

### DIFF
--- a/apps/desktop/src/lib/watch.test.ts
+++ b/apps/desktop/src/lib/watch.test.ts
@@ -57,6 +57,29 @@ describe("watchResource", () => {
     expect(invokeCommandMock).toHaveBeenCalledWith("stop_watch", { channel: subscribedChannel });
   });
 
+  it("sanitizes illegal characters in the channel name (Tauri event constraint)", async () => {
+    let subscribedChannel = "";
+    subscribeMock.mockImplementation(async (ch: string) => {
+      subscribedChannel = ch;
+      return vi.fn();
+    });
+    invokeCommandMock.mockResolvedValue(undefined);
+
+    // Context names using the "<user>@<cluster>" convention contain "@", which
+    // Tauri rejects in event names.
+    await watchResource("admin@prod.example.com", "kube-system", "pods", vi.fn());
+
+    expect(subscribedChannel).not.toMatch(/[@.]/);
+    expect(subscribedChannel).toMatch(/^[a-zA-Z0-9/:_-]+$/);
+    // The backend watch is started on the exact sanitized channel we subscribed to.
+    expect(invokeCommandMock).toHaveBeenCalledWith("start_resource_watch", {
+      context: "admin@prod.example.com",
+      namespace: "kube-system",
+      kind: "pods",
+      channel: subscribedChannel,
+    });
+  });
+
   it("disposes the subscription if starting the watch fails", async () => {
     const dispose = vi.fn();
     subscribeMock.mockResolvedValue(dispose);

--- a/apps/desktop/src/lib/watch.ts
+++ b/apps/desktop/src/lib/watch.ts
@@ -29,7 +29,11 @@ export async function watchResource(
   onRows: (rows: Array<{ name: string }>) => void,
   onStatus?: (status: WatchStatus) => void,
 ): Promise<WatchHandle> {
-  const channel = `watch:${kind}:${context}:${namespace}:${++watchSeq}`;
+  // Tauri event names allow only [alphanumeric, -, /, :, _], but a context name
+  // can contain other characters (e.g. the "@" in "admin@cluster"), which makes
+  // `listen` throw. Sanitize to the allowed set; the `watchSeq` suffix keeps
+  // every channel unique regardless of any collisions the replacement introduces.
+  const channel = `watch:${kind}:${context}:${namespace}:${++watchSeq}`.replace(/[^a-zA-Z0-9/:_-]/g, "_");
   const dispose = await subscribe(channel, (payload) => {
     // The backend emits either a snapshot (array) or a `{status}` object.
     if (Array.isArray(payload)) {


### PR DESCRIPTION
Closes #46

## Problem

Opening a live-watch view (Pods, Deployments, Services, Events) failed for contexts whose name contains a character Tauri disallows in event names:

```
Error: invalid args `event` for command `listen`: Event name must include only
alphanumeric characters, `-`, `/`, `:` and `_`.
```

This hits the common `<user>@<cluster>` naming convention (the `@` is illegal).

## Root cause

The watch channel embedded the raw context name (`apps/desktop/src/lib/watch.ts`):

```js
const channel = `watch:${kind}:${context}:${namespace}:${++watchSeq}`;
```

That string is handed to Tauri's `listen`, which rejects names outside `[alphanumeric, -, /, :, _]`, so it throws before the watch starts.

- Only the **watch** channel embeds the context name — exec, logs, and port-forward key on numeric ids and are unaffected.
- The Cluster Overview doesn't use watches, so it loads while a Pods view fails on the same context.
- Pre-existing since the initial commit; latent until a context with an illegal character is watched.

## Fix

Sanitize the channel to the allowed charset before subscribing. The `watchSeq` suffix already guarantees per-watch uniqueness, and the backend only echoes the channel string back on `emit`, so no backend change is needed:

```js
const channel = `watch:${kind}:${context}:${namespace}:${++watchSeq}`
  .replace(/[^a-zA-Z0-9/:_-]/g, "_");
```

## Testing

- New regression test: a context named `admin@prod.example.com` yields a channel with no illegal characters (matches `^[a-zA-Z0-9/:_-]+$`), and the backend watch starts on that exact sanitized channel.
- Existing watch tests still pass (legal names are unchanged).
- Full Vitest suite (262 tests) green; `vite build` succeeds.