### PR TITLE
fix: resolve login-shell PATH so kubeconfig exec plugins work in GUI launches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,6 +1123,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fix-path-env"
+version = "0.0.0"
+source = "git+https://github.com/tauri-apps/fix-path-env-rs#c4c45d503ea115a839aae718d02f79e7c7f0f673"
+dependencies = [
+ "home",
+ "strip-ansi-escapes",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4030,6 +4040,7 @@ dependencies = [
 name = "srelens-desktop"
 version = "0.1.0"
 dependencies = [
+ "fix-path-env",
  "log",
  "serde",
  "serde_json",
@@ -4103,6 +4114,15 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
 ]
 
 [[package]]
@@ -5198,6 +5218,15 @@ checksum = "fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -34,6 +34,10 @@ tokio = { version = "1", features = ["rt-multi-thread", "io-std", "io-util", "ma
 [target."cfg(not(any(target_os = \"android\", target_os = \"ios\")))".dependencies]
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
+# GUI-launched apps on macOS/Linux get launchd's minimal PATH, so kubeconfig
+# exec plugins (kubectl, krew plugins, cloud CLIs) can't be found. This
+# resolves the user's login-shell PATH at startup. No-op on Windows.
+fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -4,6 +4,14 @@
 use std::sync::Arc;
 
 fn main() {
+    // GUI launches (Finder/Dock) inherit launchd's minimal PATH, not the
+    // user's shell PATH — kubeconfig exec plugins (kubectl, kubectl-oidc_login,
+    // cloud CLIs) then fail to spawn with "No such file or directory". Resolve
+    // the login-shell environment before anything creates a kube client.
+    if let Err(e) = fix_path_env::fix() {
+        eprintln!("warning: could not resolve login-shell PATH: {e}");
+    }
+
     // Apply the SRELENS_TIMEOUT_SECS override up front so every mode — GUI, MCP
     // stdio, and MCP HTTP — honors it (the GUI can adjust it further at runtime).
     srelens_kube::connect::init_timeout_from_env();


### PR DESCRIPTION
Fixes the v0.1.0 report: every exec-auth context fails with `auth error: unable to run auth exec: No such file or directory (os error 2)` when the app is launched from Finder/Dock.

## Root cause (verified)

macOS GUI launches inherit launchd's minimal `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin`) — `launchctl getenv PATH` is unset on this machine. kube-rs spawns the kubeconfig's exec credential plugin (`kubectl oidc-login get-token …`) by PATH lookup, and both `kubectl` (`/opt/homebrew/bin`) and its krew plugin `kubectl-oidc_login` are outside the launchd PATH → ENOENT. Dev builds never hit this because the terminal's full PATH leaks through.

Reproduced deterministically without the GUI by driving `k8s.clusterInfo` over MCP stdio:

| PATH | result |
|---|---|
| `/usr/bin:/bin:/usr/sbin:/sbin` (Finder-like) | `unable to run auth exec: No such file or directory` — the reported error |
| full shell PATH (terminal-like) | exec auth succeeds (`client error (Connect)` only because that cluster is VPN-bound) |

## Fix

`fix_path_env::fix()` (tauri-apps' crate, the standard for this — same idea as Lens's shell-env resolution) at the very top of `main()`, before any kube client exists. It resolves the user's login-shell environment; no-op on Windows; applies to GUI **and** MCP server modes.

## Verification

Re-ran the exact restricted-PATH reproduction against the fixed binary: exec auth now behaves identically to a terminal launch. Full test suite green.

Merging to dev then main will auto-release **v0.1.1** via the `fix:` commit.