### PR TITLE
chore: add MIT license

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ members = ["crates/capability", "crates/mcp", "crates/kube", "apps/desktop/src-t
 [workspace.package]
 edition = "2021"
 version = "0.0.0"
+license = "MIT"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 srelens contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ the repo to hear when signed builds land.
 
 Issues and PRs are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) to get started.
 
+## License
+
+srelens is open source under the [MIT License](LICENSE).
+
 ---
 
 <p align="center">


### PR DESCRIPTION
Adds the MIT LICENSE file, `license = "MIT"` in the Cargo workspace metadata, and a README license section — prerequisite for making the repository public (the org already describes srelens as open source, and the private repo is what breaks the in-app updater's anonymous manifest fetch).