### PR TITLE
release: promote dev to main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,6 +1123,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fix-path-env"
+version = "0.0.0"
+source = "git+https://github.com/tauri-apps/fix-path-env-rs#c4c45d503ea115a839aae718d02f79e7c7f0f673"
+dependencies = [
+ "home",
+ "strip-ansi-escapes",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4030,6 +4040,7 @@ dependencies = [
 name = "srelens-desktop"
 version = "0.1.0"
 dependencies = [
+ "fix-path-env",
  "log",
  "serde",
  "serde_json",
@@ -4103,6 +4114,15 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
 ]
 
 [[package]]
@@ -5198,6 +5218,15 @@ checksum = "fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ members = ["crates/capability", "crates/mcp", "crates/kube", "apps/desktop/src-t
 [workspace.package]
 edition = "2021"
 version = "0.0.0"
+license = "MIT"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 srelens contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ the repo to hear when signed builds land.
 
 Issues and PRs are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) to get started.
 
+## License
+
+srelens is open source under the [MIT License](LICENSE).
+
 ---
 
 <p align="center">

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -34,6 +34,10 @@ tokio = { version = "1", features = ["rt-multi-thread", "io-std", "io-util", "ma
 [target."cfg(not(any(target_os = \"android\", target_os = \"ios\")))".dependencies]
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
+# GUI-launched apps on macOS/Linux get launchd's minimal PATH, so kubeconfig
+# exec plugins (kubectl, krew plugins, cloud CLIs) can't be found. This
+# resolves the user's login-shell PATH at startup. No-op on Windows.
+fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod exec;
 mod files;
 mod forward;
 mod logs;
+mod settings;
 mod updater;
 mod watch;
 
@@ -13,6 +14,7 @@ use exec::{exec_close, exec_input, start_pod_exec, ExecManager};
 use forward::{start_port_forward, stop_port_forward, ForwardManager};
 use srelens_kube::client_cache::ClientCache;
 use logs::{start_log_stream, stop_log_stream, LogStreamManager};
+use settings::{get_request_timeout, set_request_timeout};
 use updater::{update_check, update_install};
 use watch::{start_resource_watch, stop_watch, WatchManager};
 
@@ -20,6 +22,9 @@ pub use capabilities::build_registry;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // The SRELENS_TIMEOUT_SECS override is applied in `main()` before dispatch,
+    // so it's live here; the Settings UI can adjust it further at runtime.
+
     // One shared client cache: request/response capabilities AND live watches
     // reuse the same authenticated kube-rs clients.
     let cache = ClientCache::new_many(capabilities::default_kubeconfig_paths());
@@ -62,7 +67,9 @@ pub fn run() {
             pick_kubeconfig_files,
             save_pasted_kubeconfig,
             update_check,
-            update_install
+            update_install,
+            set_request_timeout,
+            get_request_timeout
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -4,6 +4,10 @@
 use std::sync::Arc;
 
 fn main() {
+    // Apply the SRELENS_TIMEOUT_SECS override up front so every mode — GUI, MCP
+    // stdio, and MCP HTTP — honors it (the GUI can adjust it further at runtime).
+    srelens_kube::connect::init_timeout_from_env();
+
     let args: Vec<String> = std::env::args().collect();
     // `--mcp-stdio` / `--mcp-http [addr]` run the MCP server instead of the GUI,
     // so external MCP clients/agents can drive every capability.

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -4,6 +4,14 @@
 use std::sync::Arc;
 
 fn main() {
+    // GUI launches (Finder/Dock) inherit launchd's minimal PATH, not the
+    // user's shell PATH — kubeconfig exec plugins (kubectl, kubectl-oidc_login,
+    // cloud CLIs) then fail to spawn with "No such file or directory". Resolve
+    // the login-shell environment before anything creates a kube client.
+    if let Err(e) = fix_path_env::fix() {
+        eprintln!("warning: could not resolve login-shell PATH: {e}");
+    }
+
     // Apply the SRELENS_TIMEOUT_SECS override up front so every mode — GUI, MCP
     // stdio, and MCP HTTP — honors it (the GUI can adjust it further at runtime).
     srelens_kube::connect::init_timeout_from_env();

--- a/apps/desktop/src-tauri/src/settings.rs
+++ b/apps/desktop/src-tauri/src/settings.rs
@@ -1,0 +1,32 @@
+//! Runtime settings the WebView can adjust.
+//!
+//! Currently just the per-request timeout budget shared by every capability.
+//! The value lives in the kube crate (a process-wide atomic); the frontend
+//! persists it in localStorage and re-applies it here on each startup.
+
+use srelens_kube::connect::{request_timeout_secs, set_request_timeout_secs, MAX_TIMEOUT_SECS, MIN_TIMEOUT_SECS};
+
+/// The request-timeout bounds, so the UI can render/validate the same range.
+#[derive(serde::Serialize)]
+pub struct TimeoutBounds {
+    pub secs: u64,
+    pub min: u64,
+    pub max: u64,
+}
+
+/// Set the per-request timeout (seconds). The value is clamped to the supported
+/// range; the applied value is returned so the UI can reflect any clamping.
+#[tauri::command]
+pub fn set_request_timeout(secs: u64) -> u64 {
+    set_request_timeout_secs(secs)
+}
+
+/// Read the current per-request timeout and its supported bounds.
+#[tauri::command]
+pub fn get_request_timeout() -> TimeoutBounds {
+    TimeoutBounds {
+        secs: request_timeout_secs(),
+        min: MIN_TIMEOUT_SECS,
+        max: MAX_TIMEOUT_SECS,
+    }
+}

--- a/apps/desktop/src/components/SettingsView.tsx
+++ b/apps/desktop/src/components/SettingsView.tsx
@@ -12,6 +12,7 @@ import {
   PanelRight,
   RotateCcw,
   Sun,
+  Timer,
   Upload,
   FilePlus2,
   X,
@@ -34,7 +35,9 @@ import {
 import { listContexts, type ClusterContext } from "../lib/clusters";
 import {
   DEFAULT_WORKSPACE_LAYOUT,
+  REQUEST_TIMEOUT,
   contextDisplayName,
+  getRequestTimeoutSecs,
   loadUpdateChannel,
   saveUpdateChannel,
   type ContextLogo,
@@ -43,6 +46,7 @@ import {
   type WorkspaceLayoutSettings,
   orderContexts,
 } from "../lib/settings";
+import { updateRequestTimeout } from "../lib/requestTimeout";
 import { ContextAvatar, CONTEXT_LOGO_OPTIONS } from "./ContextAvatar";
 import { pickKubeconfigFiles, savePastedKubeconfig } from "../lib/files";
 import { checkForUpdate, installUpdate, type UpdateMeta } from "../lib/updater";
@@ -129,6 +133,7 @@ export function SettingsView({
   const [updateState, setUpdateState] = useState<UpdatePhase>({ phase: "idle" });
   const [updateChannel, setUpdateChannel] = useState<UpdateChannel>(() => loadUpdateChannel());
   const [currentVersion, setCurrentVersion] = useState("");
+  const [requestTimeout, setRequestTimeout] = useState(() => getRequestTimeoutSecs());
   const draggedContextRef = useRef<string | null>(null);
   const dropTargetRef = useRef<string | null>(null);
 
@@ -439,6 +444,32 @@ export function SettingsView({
                   aria-label="Default namespace"
                 />
               </label>
+
+              <div className="fl-settings-width-grid">
+                <label className="fl-settings-width-control">
+                  <span className="fl-settings-width-control__header">
+                    <Timer aria-hidden="true" />
+                    <span>
+                      <strong>Request timeout</strong>
+                      <small>How long to wait for a cluster response. Raise it for large clusters.</small>
+                    </span>
+                    <output>{requestTimeout}s</output>
+                  </span>
+                  <input
+                    type="range"
+                    min={REQUEST_TIMEOUT.MIN}
+                    max={REQUEST_TIMEOUT.MAX}
+                    step="1"
+                    value={requestTimeout}
+                    onChange={(event) => {
+                      const secs = Number(event.target.value);
+                      setRequestTimeout(secs);
+                      void updateRequestTimeout(secs);
+                    }}
+                    aria-label="Cluster request timeout in seconds"
+                  />
+                </label>
+              </div>
             </SectionPanel>
           )}
 

--- a/apps/desktop/src/lib/requestTimeout.ts
+++ b/apps/desktop/src/lib/requestTimeout.ts
@@ -1,0 +1,29 @@
+// Bridges the persisted request-timeout setting to the Rust backend.
+//
+// The backend keeps the timeout in a process-wide global that resets to its
+// default on every launch, so the persisted value must be re-applied at
+// startup and whenever the user changes it in Settings.
+
+import { invokeCommand } from "../transport/transport";
+import { getRequestTimeoutSecs, setRequestTimeoutSecs } from "./settings";
+
+/** Push the persisted timeout to the backend. Call once on startup. */
+export async function applyPersistedTimeout(): Promise<number> {
+  const secs = getRequestTimeoutSecs();
+  try {
+    return await invokeCommand<number>("set_request_timeout", { secs });
+  } catch {
+    // No backend (tests / web preview) — the persisted value still stands.
+    return secs;
+  }
+}
+
+/** Persist a new timeout and apply it to the backend; returns the clamped value. */
+export async function updateRequestTimeout(secs: number): Promise<number> {
+  const clamped = setRequestTimeoutSecs(secs);
+  try {
+    return await invokeCommand<number>("set_request_timeout", { secs: clamped });
+  } catch {
+    return clamped;
+  }
+}

--- a/apps/desktop/src/lib/settings.test.ts
+++ b/apps/desktop/src/lib/settings.test.ts
@@ -17,9 +17,40 @@ import {
   saveContextOrder,
   loadUpdateChannel,
   saveUpdateChannel,
+  REQUEST_TIMEOUT,
+  clampTimeoutSecs,
+  getRequestTimeoutSecs,
+  setRequestTimeoutSecs,
 } from "./settings";
 
 beforeEach(() => localStorage.clear());
+
+describe("request timeout setting", () => {
+  it("defaults to the documented default when unset", () => {
+    expect(getRequestTimeoutSecs()).toBe(REQUEST_TIMEOUT.DEFAULT);
+  });
+
+  it("clamps values to the supported range", () => {
+    expect(clampTimeoutSecs(100)).toBe(REQUEST_TIMEOUT.MAX);
+    expect(clampTimeoutSecs(0)).toBe(REQUEST_TIMEOUT.MIN);
+    expect(clampTimeoutSecs(-5)).toBe(REQUEST_TIMEOUT.MIN);
+    expect(clampTimeoutSecs(15)).toBe(15);
+    expect(clampTimeoutSecs("nonsense")).toBe(REQUEST_TIMEOUT.DEFAULT);
+  });
+
+  it("persists and reloads a clamped value", () => {
+    expect(setRequestTimeoutSecs(25)).toBe(25);
+    expect(getRequestTimeoutSecs()).toBe(25);
+    // Out-of-range writes are clamped on the way in.
+    expect(setRequestTimeoutSecs(999)).toBe(REQUEST_TIMEOUT.MAX);
+    expect(getRequestTimeoutSecs()).toBe(REQUEST_TIMEOUT.MAX);
+  });
+
+  it("falls back to the default when stored data is corrupt", () => {
+    localStorage.setItem("srelens.requestTimeoutSecs", "{not json");
+    expect(getRequestTimeoutSecs()).toBe(REQUEST_TIMEOUT.DEFAULT);
+  });
+});
 
 describe("settings persistence", () => {
   it("round-trips per-cluster namespaces", () => {

--- a/apps/desktop/src/lib/settings.ts
+++ b/apps/desktop/src/lib/settings.ts
@@ -6,7 +6,39 @@ const WORKSPACE_LAYOUT_KEY = "srelens.workspaceLayout";
 const CONTEXT_PROFILES_KEY = "srelens.contextProfiles";
 const KUBECONFIG_FILES_KEY = "srelens.kubeconfigFiles";
 const CONTEXT_ORDER_KEY = "srelens.contextOrder";
+const REQUEST_TIMEOUT_KEY = "srelens.requestTimeoutSecs";
 const LEGACY_PREFIX = "free" + "lens";
+
+/** Per-request timeout budget (connect + list/get/apply), in seconds. */
+export const REQUEST_TIMEOUT = { MIN: 1, MAX: 30, DEFAULT: 8 } as const;
+
+/** Clamp any value to the supported timeout range; fall back to the default. */
+export function clampTimeoutSecs(value: unknown): number {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n)) return REQUEST_TIMEOUT.DEFAULT;
+  return Math.round(Math.max(REQUEST_TIMEOUT.MIN, Math.min(REQUEST_TIMEOUT.MAX, n)));
+}
+
+/** The persisted request timeout in seconds, or the default when unset/invalid. */
+export function getRequestTimeoutSecs(): number {
+  try {
+    const raw = stored(REQUEST_TIMEOUT_KEY);
+    return raw === null ? REQUEST_TIMEOUT.DEFAULT : clampTimeoutSecs(JSON.parse(raw));
+  } catch {
+    return REQUEST_TIMEOUT.DEFAULT;
+  }
+}
+
+/** Persist the request timeout (clamped). Returns the clamped value stored. */
+export function setRequestTimeoutSecs(secs: number): number {
+  const clamped = clampTimeoutSecs(secs);
+  try {
+    localStorage.setItem(REQUEST_TIMEOUT_KEY, JSON.stringify(clamped));
+  } catch {
+    // ignore unavailable/quota-exceeded storage
+  }
+  return clamped;
+}
 
 function stored(key: string): string | null {
   return localStorage.getItem(key) ?? localStorage.getItem(key.replace("srelens", LEGACY_PREFIX));

--- a/apps/desktop/src/lib/watch.test.ts
+++ b/apps/desktop/src/lib/watch.test.ts
@@ -57,6 +57,29 @@ describe("watchResource", () => {
     expect(invokeCommandMock).toHaveBeenCalledWith("stop_watch", { channel: subscribedChannel });
   });
 
+  it("sanitizes illegal characters in the channel name (Tauri event constraint)", async () => {
+    let subscribedChannel = "";
+    subscribeMock.mockImplementation(async (ch: string) => {
+      subscribedChannel = ch;
+      return vi.fn();
+    });
+    invokeCommandMock.mockResolvedValue(undefined);
+
+    // Context names using the "<user>@<cluster>" convention contain "@", which
+    // Tauri rejects in event names.
+    await watchResource("admin@prod.example.com", "kube-system", "pods", vi.fn());
+
+    expect(subscribedChannel).not.toMatch(/[@.]/);
+    expect(subscribedChannel).toMatch(/^[a-zA-Z0-9/:_-]+$/);
+    // The backend watch is started on the exact sanitized channel we subscribed to.
+    expect(invokeCommandMock).toHaveBeenCalledWith("start_resource_watch", {
+      context: "admin@prod.example.com",
+      namespace: "kube-system",
+      kind: "pods",
+      channel: subscribedChannel,
+    });
+  });
+
   it("disposes the subscription if starting the watch fails", async () => {
     const dispose = vi.fn();
     subscribeMock.mockResolvedValue(dispose);

--- a/apps/desktop/src/lib/watch.ts
+++ b/apps/desktop/src/lib/watch.ts
@@ -29,7 +29,11 @@ export async function watchResource(
   onRows: (rows: Array<{ name: string }>) => void,
   onStatus?: (status: WatchStatus) => void,
 ): Promise<WatchHandle> {
-  const channel = `watch:${kind}:${context}:${namespace}:${++watchSeq}`;
+  // Tauri event names allow only [alphanumeric, -, /, :, _], but a context name
+  // can contain other characters (e.g. the "@" in "admin@cluster"), which makes
+  // `listen` throw. Sanitize to the allowed set; the `watchSeq` suffix keeps
+  // every channel unique regardless of any collisions the replacement introduces.
+  const channel = `watch:${kind}:${context}:${namespace}:${++watchSeq}`.replace(/[^a-zA-Z0-9/:_-]/g, "_");
   const dispose = await subscribe(channel, (payload) => {
     // The backend emits either a snapshot (array) or a `{status}` object.
     if (Array.isArray(payload)) {

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -2,6 +2,12 @@ import "./styles/globals.css"; // Tailwind + shadcn tokens — must load first.
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
+import { applyPersistedTimeout } from "./lib/requestTimeout";
+
+// Re-apply the persisted request timeout to the backend, which resets to its
+// default each launch. Fire-and-forget: it resolves well before the user picks
+// a context and triggers the first capability call.
+void applyPersistedTimeout();
 
 const container = document.getElementById("root");
 if (!container) throw new Error("Root element #root not found");

--- a/crates/kube/src/actions.rs
+++ b/crates/kube/src/actions.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::client_cache::ClientCache;
-use crate::connect::CONNECT_TIMEOUT;
+use crate::connect::request_timeout;
 use crate::manifest::gvk_for;
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -42,7 +42,7 @@ pub fn delete_pod_capability(cache: Arc<ClientCache>) -> Capability {
                     .await
                     .map_err(CapabilityError::Handler)?;
                 let api: Api<Pod> = Api::namespaced(client, &input.namespace);
-                tokio::time::timeout(CONNECT_TIMEOUT, api.delete(&input.pod, &DeleteParams::default()))
+                tokio::time::timeout(request_timeout(), api.delete(&input.pod, &DeleteParams::default()))
                     .await
                     .map_err(|_| CapabilityError::Handler("delete pod timed out".into()))?
                     .map_err(|e| CapabilityError::Handler(e.to_string()))?;
@@ -74,7 +74,7 @@ pub fn evict_pod_capability(cache: Arc<ClientCache>) -> Capability {
             async move {
                 let client = cache.get(&input.context).await.map_err(CapabilityError::Handler)?;
                 let api: Api<Pod> = Api::namespaced(client, &input.namespace);
-                tokio::time::timeout(CONNECT_TIMEOUT, api.evict(&input.pod, &EvictParams::default()))
+                tokio::time::timeout(request_timeout(), api.evict(&input.pod, &EvictParams::default()))
                     .await
                     .map_err(|_| CapabilityError::Handler("evict pod timed out".into()))?
                     .map_err(|e| CapabilityError::Handler(e.to_string()))?;
@@ -127,7 +127,7 @@ pub fn delete_resource_capability(cache: Arc<ClientCache>) -> Capability {
             async move {
                 let client = cache.get(&input.context).await.map_err(CapabilityError::Handler)?;
                 let api = dynamic_api(client, &input.kind, &input.namespace)?;
-                tokio::time::timeout(CONNECT_TIMEOUT, api.delete(&input.name, &DeleteParams::default()))
+                tokio::time::timeout(request_timeout(), api.delete(&input.name, &DeleteParams::default()))
                     .await
                     .map_err(|_| CapabilityError::Handler("delete timed out".into()))?
                     .map_err(|e| CapabilityError::Handler(e.to_string()))?;
@@ -164,7 +164,7 @@ pub fn scale_capability(cache: Arc<ClientCache>) -> Capability {
                 let api = dynamic_api(client, &input.kind, &input.namespace)?;
                 let patch = json!({ "spec": { "replicas": input.replicas } });
                 tokio::time::timeout(
-                    CONNECT_TIMEOUT,
+                    request_timeout(),
                     api.patch(&input.name, &PatchParams::default(), &Patch::Merge(&patch)),
                 )
                 .await
@@ -208,7 +208,7 @@ pub fn rollout_restart_capability(cache: Arc<ClientCache>) -> Capability {
                     }}}}
                 });
                 tokio::time::timeout(
-                    CONNECT_TIMEOUT,
+                    request_timeout(),
                     api.patch(&input.name, &PatchParams::default(), &Patch::Merge(&patch)),
                 )
                 .await
@@ -246,7 +246,7 @@ pub fn cordon_node_capability(cache: Arc<ClientCache>) -> Capability {
                 let api: Api<Node> = Api::all(client);
                 let patch = json!({ "spec": { "unschedulable": input.unschedulable } });
                 tokio::time::timeout(
-                    CONNECT_TIMEOUT,
+                    request_timeout(),
                     api.patch(&input.name, &PatchParams::default(), &Patch::Merge(&patch)),
                 )
                 .await
@@ -287,7 +287,7 @@ pub fn drain_node_capability(cache: Arc<ClientCache>) -> Capability {
                 let nodes: Api<Node> = Api::all(client.clone());
                 let patch = json!({ "spec": { "unschedulable": true } });
                 tokio::time::timeout(
-                    CONNECT_TIMEOUT,
+                    request_timeout(),
                     nodes.patch(&input.name, &PatchParams::default(), &Patch::Merge(&patch)),
                 )
                 .await
@@ -297,7 +297,7 @@ pub fn drain_node_capability(cache: Arc<ClientCache>) -> Capability {
                 // 2. Find the pods scheduled on this node.
                 let pods: Api<Pod> = Api::all(client.clone());
                 let lp = ListParams::default().fields(&format!("spec.nodeName={}", input.name));
-                let list = tokio::time::timeout(CONNECT_TIMEOUT, pods.list(&lp))
+                let list = tokio::time::timeout(request_timeout(), pods.list(&lp))
                     .await
                     .map_err(|_| CapabilityError::Handler("list pods timed out".into()))?
                     .map_err(|e| CapabilityError::Handler(e.to_string()))?;
@@ -325,7 +325,7 @@ pub fn drain_node_capability(cache: Arc<ClientCache>) -> Capability {
                         continue;
                     }
                     let api: Api<Pod> = Api::namespaced(client.clone(), &ns);
-                    match tokio::time::timeout(CONNECT_TIMEOUT, api.evict(&name, &EvictParams::default()))
+                    match tokio::time::timeout(request_timeout(), api.evict(&name, &EvictParams::default()))
                         .await
                     {
                         Ok(Ok(_)) => evicted += 1,

--- a/crates/kube/src/connect.rs
+++ b/crates/kube/src/connect.rs
@@ -4,6 +4,7 @@
 //! by kube-rs from the kubeconfig.
 
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -15,7 +16,50 @@ use serde::{Deserialize, Serialize};
 
 use crate::client_cache::ClientCache;
 
-pub(crate) const CONNECT_TIMEOUT: Duration = Duration::from_secs(8);
+/// Default per-request timeout budget (connect + list/get/apply), in seconds.
+pub const DEFAULT_TIMEOUT_SECS: u64 = 8;
+/// Smallest timeout a user may configure, in seconds.
+pub const MIN_TIMEOUT_SECS: u64 = 1;
+/// Largest timeout a user may configure, in seconds.
+pub const MAX_TIMEOUT_SECS: u64 = 30;
+
+/// Environment variable that overrides the default timeout at startup — lets
+/// headless/MCP runs (which have no Settings UI) raise it for large clusters.
+pub const TIMEOUT_ENV: &str = "SRELENS_TIMEOUT_SECS";
+
+/// Runtime-configurable per-request timeout, shared by every capability. Kept
+/// as a process-wide atomic so the Settings UI can adjust it live without
+/// threading a value through the whole capability registry.
+static TIMEOUT_SECS: AtomicU64 = AtomicU64::new(DEFAULT_TIMEOUT_SECS);
+
+/// The current per-request timeout budget.
+pub fn request_timeout() -> Duration {
+    Duration::from_secs(TIMEOUT_SECS.load(Ordering::Relaxed))
+}
+
+/// The current per-request timeout, in seconds.
+pub fn request_timeout_secs() -> u64 {
+    TIMEOUT_SECS.load(Ordering::Relaxed)
+}
+
+/// Set the per-request timeout, clamping to `[MIN_TIMEOUT_SECS, MAX_TIMEOUT_SECS]`.
+/// Returns the value actually applied so callers can reflect clamping back to the user.
+pub fn set_request_timeout_secs(secs: u64) -> u64 {
+    let clamped = secs.clamp(MIN_TIMEOUT_SECS, MAX_TIMEOUT_SECS);
+    TIMEOUT_SECS.store(clamped, Ordering::Relaxed);
+    clamped
+}
+
+/// Apply the `SRELENS_TIMEOUT_SECS` override if present and parseable. Invalid
+/// values are ignored, leaving the default in place. Returns the applied value.
+pub fn init_timeout_from_env() -> u64 {
+    if let Some(raw) = std::env::var_os(TIMEOUT_ENV) {
+        if let Some(secs) = raw.to_str().and_then(|s| s.trim().parse::<u64>().ok()) {
+            return set_request_timeout_secs(secs);
+        }
+    }
+    request_timeout_secs()
+}
 
 /// Build an authenticated kube-rs client for a named kubeconfig context.
 /// Authentication (certs, tokens, exec plugins) is resolved by kube-rs.
@@ -65,7 +109,7 @@ pub struct ClusterInfoOut {
 /// string if the connection/auth/handshake fails (or times out).
 async fn connect_and_version(cache: &ClientCache, context: &str) -> Result<String, String> {
     let client = cache.get(context).await?;
-    let info = tokio::time::timeout(CONNECT_TIMEOUT, client.apiserver_version())
+    let info = tokio::time::timeout(request_timeout(), client.apiserver_version())
         .await
         .map_err(|_| "connection timed out".to_string())?
         .map_err(|e| e.to_string())?;
@@ -110,6 +154,20 @@ mod tests {
     use srelens_capability::Registry;
     use serde_json::json;
     use std::path::PathBuf;
+
+    #[test]
+    fn timeout_setter_clamps_to_supported_range() {
+        // Above the max is clamped down.
+        assert_eq!(set_request_timeout_secs(120), MAX_TIMEOUT_SECS);
+        assert_eq!(request_timeout(), Duration::from_secs(MAX_TIMEOUT_SECS));
+        // Zero is clamped up to the minimum.
+        assert_eq!(set_request_timeout_secs(0), MIN_TIMEOUT_SECS);
+        // A value in range is applied verbatim.
+        assert_eq!(set_request_timeout_secs(20), 20);
+        assert_eq!(request_timeout_secs(), 20);
+        // Restore the default so other tests see a known value.
+        set_request_timeout_secs(DEFAULT_TIMEOUT_SECS);
+    }
 
     #[test]
     fn capability_has_expected_id_and_annotations() {

--- a/crates/kube/src/crds.rs
+++ b/crates/kube/src/crds.rs
@@ -10,7 +10,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::client_cache::ClientCache;
-use crate::connect::CONNECT_TIMEOUT;
+use crate::connect::request_timeout;
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ListCrdsIn {
@@ -68,7 +68,7 @@ pub fn list_crds_capability(cache: Arc<ClientCache>) -> Capability {
                     GroupVersionKind::gvk("apiextensions.k8s.io", "v1", "CustomResourceDefinition");
                 let ar = ApiResource::from_gvk(&gvk);
                 let api: Api<DynamicObject> = Api::all_with(client, &ar);
-                let list = tokio::time::timeout(CONNECT_TIMEOUT, api.list(&ListParams::default()))
+                let list = tokio::time::timeout(request_timeout(), api.list(&ListParams::default()))
                     .await
                     .map_err(|_| CapabilityError::Handler("list CRDs timed out".into()))?
                     .map_err(handler_err)?;
@@ -160,7 +160,7 @@ pub fn list_custom_resource_capability(cache: Arc<ClientCache>) -> Capability {
                 } else {
                     Api::all_with(client, &ar)
                 };
-                let list = tokio::time::timeout(CONNECT_TIMEOUT, api.list(&ListParams::default()))
+                let list = tokio::time::timeout(request_timeout(), api.list(&ListParams::default()))
                     .await
                     .map_err(|_| CapabilityError::Handler("list custom resource timed out".into()))?
                     .map_err(handler_err)?;

--- a/crates/kube/src/deployments.rs
+++ b/crates/kube/src/deployments.rs
@@ -10,7 +10,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::client_cache::ClientCache;
-use crate::connect::CONNECT_TIMEOUT;
+use crate::connect::request_timeout;
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ListDeploymentsIn {
@@ -66,7 +66,7 @@ pub fn list_deployments_capability(cache: Arc<ClientCache>) -> Capability {
                     .await
                     .map_err(CapabilityError::Handler)?;
                 let api: Api<Deployment> = crate::scoped_api(client, &input.namespace);
-                let list = tokio::time::timeout(CONNECT_TIMEOUT, api.list(&ListParams::default()))
+                let list = tokio::time::timeout(request_timeout(), api.list(&ListParams::default()))
                     .await
                     .map_err(|_| CapabilityError::Handler("list deployments timed out".into()))?
                     .map_err(|e| CapabilityError::Handler(e.to_string()))?;
@@ -147,7 +147,7 @@ pub fn list_replicasets_capability(cache: Arc<ClientCache>) -> Capability {
                     .await
                     .map_err(CapabilityError::Handler)?;
                 let api: Api<ReplicaSet> = crate::scoped_api(client, &input.namespace);
-                let list = tokio::time::timeout(CONNECT_TIMEOUT, api.list(&ListParams::default()))
+                let list = tokio::time::timeout(request_timeout(), api.list(&ListParams::default()))
                     .await
                     .map_err(|_| CapabilityError::Handler("list replicasets timed out".into()))?
                     .map_err(|e| CapabilityError::Handler(e.to_string()))?;

--- a/crates/kube/src/events.rs
+++ b/crates/kube/src/events.rs
@@ -9,7 +9,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::client_cache::ClientCache;
-use crate::connect::CONNECT_TIMEOUT;
+use crate::connect::request_timeout;
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ListEventsIn {
@@ -88,7 +88,7 @@ pub fn list_events_capability(cache: Arc<ClientCache>) -> Capability {
                     .map_err(CapabilityError::Handler)?;
                 let api: kube::Api<Event> = crate::scoped_api(client, &input.namespace);
                 let params = event_list_params(&input.object_kind, &input.object_name);
-                let list = tokio::time::timeout(CONNECT_TIMEOUT, api.list(&params))
+                let list = tokio::time::timeout(request_timeout(), api.list(&params))
                     .await
                     .map_err(|_| CapabilityError::Handler("list events timed out".into()))?
                     .map_err(|e| CapabilityError::Handler(e.to_string()))?;

--- a/crates/kube/src/logs.rs
+++ b/crates/kube/src/logs.rs
@@ -11,7 +11,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::client_cache::ClientCache;
-use crate::connect::CONNECT_TIMEOUT;
+use crate::connect::request_timeout;
 
 const DEFAULT_TAIL_LINES: i64 = 200;
 
@@ -40,7 +40,7 @@ where
         tail_lines: Some(tail_lines),
         ..Default::default()
     };
-    let reader = tokio::time::timeout(CONNECT_TIMEOUT, api.log_stream(&pod, &params))
+    let reader = tokio::time::timeout(request_timeout(), api.log_stream(&pod, &params))
         .await
         .map_err(|_| "open log stream timed out".to_string())?
         .map_err(|e| e.to_string())?;
@@ -131,7 +131,7 @@ pub fn pod_logs_capability(cache: Arc<ClientCache>) -> Capability {
                     tail_lines: Some(input.tail_lines.unwrap_or(DEFAULT_TAIL_LINES)),
                     ..Default::default()
                 };
-                let logs = tokio::time::timeout(CONNECT_TIMEOUT, api.logs(&input.pod, &params))
+                let logs = tokio::time::timeout(request_timeout(), api.logs(&input.pod, &params))
                     .await
                     .map_err(|_| CapabilityError::Handler("fetch logs timed out".into()))?
                     .map_err(|e| CapabilityError::Handler(e.to_string()))?;

--- a/crates/kube/src/manifest.rs
+++ b/crates/kube/src/manifest.rs
@@ -10,7 +10,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::client_cache::ClientCache;
-use crate::connect::CONNECT_TIMEOUT;
+use crate::connect::request_timeout;
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ManifestIn {
@@ -75,7 +75,7 @@ pub fn get_object_capability(cache: Arc<ClientCache>) -> Capability {
                 } else {
                     Api::all_with(client, &ar)
                 };
-                let mut obj = tokio::time::timeout(CONNECT_TIMEOUT, api.get(&input.name))
+                let mut obj = tokio::time::timeout(request_timeout(), api.get(&input.name))
                     .await
                     .map_err(|_| CapabilityError::Handler("get object timed out".into()))?
                     .map_err(|e| CapabilityError::Handler(e.to_string()))?;
@@ -158,7 +158,7 @@ pub fn get_manifest_capability(cache: Arc<ClientCache>) -> Capability {
                 } else {
                     Api::all_with(client, &ar)
                 };
-                let mut obj = tokio::time::timeout(CONNECT_TIMEOUT, api.get(&input.name))
+                let mut obj = tokio::time::timeout(request_timeout(), api.get(&input.name))
                     .await
                     .map_err(|_| CapabilityError::Handler("get manifest timed out".into()))?
                     .map_err(|e| CapabilityError::Handler(e.to_string()))?;
@@ -216,7 +216,7 @@ pub fn list_resource_capability(cache: Arc<ClientCache>) -> Capability {
                 } else {
                     Api::all_with(client, &ar)
                 };
-                let list = tokio::time::timeout(CONNECT_TIMEOUT, api.list(&ListParams::default()))
+                let list = tokio::time::timeout(request_timeout(), api.list(&ListParams::default()))
                     .await
                     .map_err(|_| CapabilityError::Handler("list resource timed out".into()))?
                     .map_err(|e| CapabilityError::Handler(e.to_string()))?;
@@ -300,7 +300,7 @@ pub fn apply_manifest_capability(cache: Arc<ClientCache>) -> Capability {
                     None => Api::all_with(client, &ar),
                 };
                 let params = PatchParams::apply("srelens").force();
-                tokio::time::timeout(CONNECT_TIMEOUT, api.patch(&name, &params, &Patch::Apply(&value)))
+                tokio::time::timeout(request_timeout(), api.patch(&name, &params, &Patch::Apply(&value)))
                     .await
                     .map_err(|_| CapabilityError::Handler("apply timed out".into()))?
                     .map_err(|e| CapabilityError::Handler(e.to_string()))?;
@@ -394,7 +394,7 @@ pub fn validate_manifest_capability(cache: Arc<ClientCache>) -> Capability {
                     field_validation: Some(ValidationDirective::Strict),
                 };
                 let result =
-                    tokio::time::timeout(CONNECT_TIMEOUT, api.patch(&name, &params, &Patch::Apply(&value)))
+                    tokio::time::timeout(request_timeout(), api.patch(&name, &params, &Patch::Apply(&value)))
                         .await
                         .map_err(|_| CapabilityError::Handler("validation timed out".into()))?;
                 Ok(match result {

--- a/crates/kube/src/metrics.rs
+++ b/crates/kube/src/metrics.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::client_cache::ClientCache;
-use crate::connect::CONNECT_TIMEOUT;
+use crate::connect::request_timeout;
 
 /// Parse a Kubernetes CPU quantity to integer millicores.
 pub fn cpu_millicores(s: &str) -> i64 {
@@ -85,7 +85,7 @@ pub fn node_metrics_capability(cache: Arc<ClientCache>) -> Capability {
             async move {
                 let client = cache.get(&input.context).await.map_err(CapabilityError::Handler)?;
                 let api = metrics_api(client, "NodeMetrics", false, "");
-                let list = tokio::time::timeout(CONNECT_TIMEOUT, api.list(&ListParams::default()))
+                let list = tokio::time::timeout(request_timeout(), api.list(&ListParams::default()))
                     .await
                     .map_err(|_| CapabilityError::Handler("node metrics timed out".into()))?
                     .map_err(|e| CapabilityError::Handler(e.to_string()))?;
@@ -153,7 +153,7 @@ pub fn pod_metrics_capability(cache: Arc<ClientCache>) -> Capability {
             async move {
                 let client = cache.get(&input.context).await.map_err(CapabilityError::Handler)?;
                 let api = metrics_api(client, "PodMetrics", true, &input.namespace);
-                let list = tokio::time::timeout(CONNECT_TIMEOUT, api.list(&ListParams::default()))
+                let list = tokio::time::timeout(request_timeout(), api.list(&ListParams::default()))
                     .await
                     .map_err(|_| CapabilityError::Handler("pod metrics timed out".into()))?
                     .map_err(|e| CapabilityError::Handler(e.to_string()))?;

--- a/crates/kube/src/nodes.rs
+++ b/crates/kube/src/nodes.rs
@@ -10,7 +10,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::client_cache::ClientCache;
-use crate::connect::CONNECT_TIMEOUT;
+use crate::connect::request_timeout;
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ListNodesIn {
@@ -88,7 +88,7 @@ pub fn list_nodes_capability(cache: Arc<ClientCache>) -> Capability {
                     .await
                     .map_err(CapabilityError::Handler)?;
                 let api: Api<Node> = Api::all(client);
-                let list = tokio::time::timeout(CONNECT_TIMEOUT, api.list(&ListParams::default()))
+                let list = tokio::time::timeout(request_timeout(), api.list(&ListParams::default()))
                     .await
                     .map_err(|_| CapabilityError::Handler("list nodes timed out".into()))?
                     .map_err(|e| CapabilityError::Handler(e.to_string()))?;

--- a/crates/kube/src/schema.rs
+++ b/crates/kube/src/schema.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
 use crate::client_cache::ClientCache;
-use crate::connect::CONNECT_TIMEOUT;
+use crate::connect::request_timeout;
 use crate::manifest::parse_api_version;
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -106,7 +106,7 @@ pub fn open_api_schema_capability(cache: Arc<ClientCache>) -> Capability {
                 let req = Request::get(&path)
                     .body(Vec::new())
                     .map_err(|e| CapabilityError::Handler(e.to_string()))?;
-                let doc: Value = tokio::time::timeout(CONNECT_TIMEOUT, client.request(req))
+                let doc: Value = tokio::time::timeout(request_timeout(), client.request(req))
                     .await
                     .map_err(|_| CapabilityError::Handler("openapi fetch timed out".into()))?
                     .map_err(|e| CapabilityError::Handler(e.to_string()))?;

--- a/crates/kube/src/services.rs
+++ b/crates/kube/src/services.rs
@@ -10,7 +10,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::client_cache::ClientCache;
-use crate::connect::CONNECT_TIMEOUT;
+use crate::connect::request_timeout;
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ListServicesIn {
@@ -82,7 +82,7 @@ pub fn list_services_capability(cache: Arc<ClientCache>) -> Capability {
                     .await
                     .map_err(CapabilityError::Handler)?;
                 let api: Api<Service> = crate::scoped_api(client, &input.namespace);
-                let list = tokio::time::timeout(CONNECT_TIMEOUT, api.list(&ListParams::default()))
+                let list = tokio::time::timeout(request_timeout(), api.list(&ListParams::default()))
                     .await
                     .map_err(|_| CapabilityError::Handler("list services timed out".into()))?
                     .map_err(|e| CapabilityError::Handler(e.to_string()))?;

--- a/crates/kube/src/workloads.rs
+++ b/crates/kube/src/workloads.rs
@@ -11,7 +11,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::client_cache::ClientCache;
-use crate::connect::CONNECT_TIMEOUT;
+use crate::connect::request_timeout;
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ListNamespacesIn {
@@ -63,7 +63,7 @@ pub fn list_namespaces_capability(cache: Arc<ClientCache>) -> Capability {
                     .await
                     .map_err(CapabilityError::Handler)?;
                 let api: Api<Namespace> = Api::all(client);
-                let list = tokio::time::timeout(CONNECT_TIMEOUT, api.list(&ListParams::default()))
+                let list = tokio::time::timeout(request_timeout(), api.list(&ListParams::default()))
                     .await
                     .map_err(|_| CapabilityError::Handler("list namespaces timed out".into()))?
                     .map_err(handler_err)?;
@@ -131,7 +131,7 @@ pub fn list_pods_capability(cache: Arc<ClientCache>) -> Capability {
                     .await
                     .map_err(CapabilityError::Handler)?;
                 let api: Api<Pod> = crate::scoped_api(client, &input.namespace);
-                let list = tokio::time::timeout(CONNECT_TIMEOUT, api.list(&ListParams::default()))
+                let list = tokio::time::timeout(request_timeout(), api.list(&ListParams::default()))
                     .await
                     .map_err(|_| CapabilityError::Handler("list pods timed out".into()))?
                     .map_err(handler_err)?;
@@ -179,7 +179,7 @@ pub fn pods_for_selector_capability(cache: Arc<ClientCache>) -> Capability {
                     .map_err(CapabilityError::Handler)?;
                 let api: Api<Pod> = crate::scoped_api(client, &input.namespace);
                 let params = ListParams::default().labels(&label_selector(&input.selector));
-                let list = tokio::time::timeout(CONNECT_TIMEOUT, api.list(&params))
+                let list = tokio::time::timeout(request_timeout(), api.list(&params))
                     .await
                     .map_err(|_| CapabilityError::Handler("list pods timed out".into()))?
                     .map_err(handler_err)?;


### PR DESCRIPTION
Promotes dev to main for the next stable release. Included since v0.1.0:

- **fix**: resolve login-shell PATH so kubeconfig exec plugins work in GUI launches (#48) — the v0.1.0 "unable to run auth exec" bug
- **fix**: sanitize watch channel names to valid Tauri event names (#47)
- **feat**: configurable cluster request timeout, up to 30s (#45)
- **chore**: MIT license (#49) — prerequisite for making the repo public

## Release mechanics

⚠️ **Merge with a merge commit — do not squash.** The release workflow derives the version from the individual Conventional Commits; squashing collapses them into one subject and breaks the bump detection.

Because #45 is a `feat`, the automated release will be **v0.2.0** (minor bump), not 0.1.1. After merging, the pipeline bumps versions, builds all four platforms, publishes the release with grouped notes, and refreshes the stable updater manifest.

Once released: flip the repo public, and installed 0.1.0 apps will see the update on the Stable channel.