### PR TITLE
docs: add install guide and code of conduct

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive, or
+harmful.
+
+Maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, issues, and other contributions that are not aligned to
+this Code of Conduct, and will communicate reasons for moderation decisions when
+appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainers responsible for enforcement by opening a
+[private report](https://github.com/srelens/srelens/security/advisories/new) or
+contacting a maintainer directly. All complaints will be reviewed and
+investigated promptly and fairly.
+
+All maintainers are obligated to respect the privacy and security of the reporter
+of any incident.
+
+## Enforcement Guidelines
+
+Maintainers will follow these Community Impact Guidelines in determining the
+consequences for any action they deem in violation of this Code of Conduct:
+
+1. **Correction** — A private, written warning for unprofessional or unwelcome
+   behavior, with clarity about the nature of the violation.
+2. **Warning** — A warning with consequences for continued behavior; no
+   interaction with the people involved for a specified period.
+3. **Temporary Ban** — A temporary ban from any sort of interaction or public
+   communication with the community for a specified period.
+4. **Permanent Ban** — A permanent ban from any sort of public interaction
+   within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1,
+available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thanks for your interest! srelens is in early, active development, so expect fast movement and breaking changes.
 
+By participating, you agree to abide by our [Code of Conduct](.github/CODE_OF_CONDUCT.md).
+
 ## Setup
 
 Follow the [developer guide](docs/DEVELOPMENT.md) — it covers prerequisites, running the app, architecture, and the capability-registry pattern that almost every change touches.

--- a/README.md
+++ b/README.md
@@ -134,11 +134,13 @@ packaging polish are on the roadmap. Expect breaking changes.
 
 Signed builds for macOS (Apple Silicon + Intel), Linux (AppImage/deb/rpm), and Windows
 are on the [latest release](https://github.com/srelens/srelens/releases/latest); the app
-updates itself from there. Prefer source? See the [quick start](#quick-start).
+updates itself from there. See the [install guide](docs/INSTALL.md) for per-platform steps,
+or the [quick start](#quick-start) to build from source.
 
 ## Contributing
 
 Issues and PRs are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) to get started.
+Please also review our [Code of Conduct](.github/CODE_OF_CONDUCT.md).
 
 ## License
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,73 @@
+# Installing srelens
+
+Signed builds are published on the
+[latest release](https://github.com/srelens/srelens/releases/latest) for macOS,
+Linux, and Windows. Once installed, srelens updates itself from **Settings →
+Updates** (Stable or Dev channel).
+
+Prefer to build from source? See the [developer guide](DEVELOPMENT.md).
+
+## macOS
+
+Builds are Developer-ID signed and notarized, so they open without warnings.
+
+1. Download the `.dmg` for your chip:
+   - Apple Silicon (M1/M2/M3/…): `srelens_<version>_aarch64.dmg`
+   - Intel: `srelens_<version>_x64.dmg`
+2. Open the `.dmg` and drag **srelens** into **Applications**.
+
+> **Kubeconfigs with exec auth (OIDC, cloud CLIs)?** srelens resolves your
+> login-shell `PATH` at startup, so tools like `kubectl` and its plugins are
+> found even when launched from the Dock. If a context still can't find its
+> credential plugin, make sure the tool is installed and on your shell `PATH`.
+
+## Linux
+
+Pick the package for your distribution:
+
+| Format | File | Install |
+| --- | --- | --- |
+| AppImage | `srelens_<version>_amd64.AppImage` | `chmod +x srelens_*.AppImage && ./srelens_*.AppImage` |
+| Debian/Ubuntu | `srelens_<version>_amd64.deb` | `sudo apt install ./srelens_*.deb` |
+| Fedora/RHEL | `srelens-<version>-1.x86_64.rpm` | `sudo dnf install ./srelens-*.rpm` |
+
+Requires a WebKitGTK runtime (`webkit2gtk-4.1`); the deb/rpm pull it in
+automatically. The in-app updater applies to the **AppImage** build; update
+deb/rpm installs by downloading the new package.
+
+### Verifying Linux downloads (optional)
+
+Each Linux asset ships a Tauri updater signature (`.sig`). GPG signatures for
+release assets are on the [roadmap](https://github.com/orgs/srelens/projects/1);
+until then, verify by matching the file against the release.
+
+## Windows
+
+1. Download and run one of:
+   - Installer: `srelens_<version>_x64-setup.exe` (recommended)
+   - MSI: `srelens_<version>_x64_en-US.msi`
+
+> **SmartScreen:** Windows code signing is on the
+> [roadmap](https://github.com/orgs/srelens/projects/1), so Windows may show a
+> "Windows protected your PC" prompt. Click **More info → Run anyway** to
+> proceed. Signed installers will remove this step in a future release.
+
+## Updating
+
+srelens checks for updates from **Settings → Updates**:
+
+- **Stable** — released versions (default).
+- **Dev** — rolling pre-releases for early access.
+
+Updates are cryptographically signed and verified before install. On Linux, the
+in-app updater applies to the AppImage build only.
+
+## Uninstalling
+
+- **macOS** — drag **srelens** from Applications to the Trash.
+- **Linux** — `sudo apt remove srelens` / `sudo dnf remove srelens`, or delete
+  the AppImage.
+- **Windows** — uninstall via **Settings → Apps**, or the MSI/installer entry.
+
+Application data lives in your OS config directory; remove it manually if you
+want a clean uninstall.


### PR DESCRIPTION
## Install guide (`docs/INSTALL.md`)
Per-platform install instructions with asset names matching the v0.1.1 release:
- **macOS** — signed/notarized `.dmg` by chip (aarch64 / x64), plus a note about exec-auth kubeconfigs and the login-shell PATH resolution
- **Linux** — AppImage / deb / rpm with install commands and the WebKitGTK runtime note; updater applies to AppImage
- **Windows** — exe / msi with the SmartScreen "Run anyway" note (Windows signing is roadmap #32)
- Updater channels (Stable/Dev) and uninstall steps

Linked from the README download section.

## Code of Conduct (`.github/CODE_OF_CONDUCT.md`)
Contributor Covenant 2.1 (GitHub renders it on the Community tab and links it in the contribution flow). Enforcement via GitHub private reporting. Linked from README and CONTRIBUTING.