### PR TITLE
feat(workloads): CronJob/Job lifecycle actions + live detail refresh

### DIFF
--- a/apps/desktop/src-tauri/src/capabilities.rs
+++ b/apps/desktop/src-tauri/src/capabilities.rs
@@ -77,6 +77,12 @@ pub fn build_registry_with(cache: Arc<ClientCache>) -> Registry {
     reg.register(srelens_kube::cronjobs::list_cronjobs_capability(
         cache.clone(),
     ));
+    reg.register(srelens_kube::cronjobs::cronjob_set_suspend_capability(
+        cache.clone(),
+    ));
+    reg.register(srelens_kube::cronjobs::cronjob_trigger_now_capability(
+        cache.clone(),
+    ));
     reg.register(srelens_kube::services::list_services_capability(
         cache.clone(),
     ));

--- a/apps/desktop/src/components/DetailActions.test.tsx
+++ b/apps/desktop/src/components/DetailActions.test.tsx
@@ -2,14 +2,23 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import React from "react";
 
-const { deletePodMock, evictPodMock, deleteResourceMock, scaleResourceMock, rolloutRestartMock } =
-  vi.hoisted(() => ({
-    deletePodMock: vi.fn(),
-    evictPodMock: vi.fn(),
-    deleteResourceMock: vi.fn(),
-    scaleResourceMock: vi.fn(),
-    rolloutRestartMock: vi.fn(),
-  }));
+const {
+  deletePodMock,
+  evictPodMock,
+  deleteResourceMock,
+  scaleResourceMock,
+  rolloutRestartMock,
+  cronjobSetSuspendMock,
+  cronjobTriggerNowMock,
+} = vi.hoisted(() => ({
+  deletePodMock: vi.fn(),
+  evictPodMock: vi.fn(),
+  deleteResourceMock: vi.fn(),
+  scaleResourceMock: vi.fn(),
+  rolloutRestartMock: vi.fn(),
+  cronjobSetSuspendMock: vi.fn(),
+  cronjobTriggerNowMock: vi.fn(),
+}));
 vi.mock("../lib/workloads", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../lib/workloads")>();
   return { ...actual, deletePod: deletePodMock, evictPod: evictPodMock };
@@ -18,6 +27,8 @@ vi.mock("../lib/actions", () => ({
   deleteResource: deleteResourceMock,
   scaleResource: scaleResourceMock,
   rolloutRestart: rolloutRestartMock,
+  cronjobSetSuspend: cronjobSetSuspendMock,
+  cronjobTriggerNow: cronjobTriggerNowMock,
 }));
 
 import { PodActions, ResourceActions } from "./DetailActions";
@@ -38,6 +49,8 @@ beforeEach(() => {
   deleteResourceMock.mockReset();
   scaleResourceMock.mockReset();
   rolloutRestartMock.mockReset();
+  cronjobSetSuspendMock.mockReset();
+  cronjobTriggerNowMock.mockReset();
 });
 
 describe("PodActions", () => {
@@ -130,5 +143,60 @@ describe("ResourceActions", () => {
     expect(screen.queryByRole("button", { name: "Scale" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Restart" })).toBeNull();
     expect(screen.getByRole("button", { name: "Delete" })).toBeDefined();
+  });
+
+  it("triggers a CronJob run now with confirmation", async () => {
+    cronjobTriggerNowMock.mockResolvedValue({ jobName: "nightly-123" });
+    render(
+      <ResourceActions
+        context="kind-dev"
+        kind="CronJob"
+        namespace="ops"
+        name="nightly"
+        onDeleted={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Run now" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Run" }));
+    await waitFor(() =>
+      expect(cronjobTriggerNowMock).toHaveBeenCalledWith("kind-dev", "ops", "nightly"),
+    );
+  });
+
+  it("shows Resume for a suspended CronJob and calls setSuspend(false)", async () => {
+    cronjobSetSuspendMock.mockResolvedValue({ ok: true });
+    render(
+      <ResourceActions
+        context="kind-dev"
+        kind="CronJob"
+        namespace="ops"
+        name="nightly"
+        cronjobSuspended
+        onDeleted={() => {}}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: "Suspend" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Resume" }));
+    await waitFor(() =>
+      expect(cronjobSetSuspendMock).toHaveBeenCalledWith("kind-dev", "ops", "nightly", false),
+    );
+  });
+
+  it("shows Suspend for an active CronJob and calls setSuspend(true)", async () => {
+    cronjobSetSuspendMock.mockResolvedValue({ ok: true });
+    render(
+      <ResourceActions
+        context="kind-dev"
+        kind="CronJob"
+        namespace="ops"
+        name="nightly"
+        cronjobSuspended={false}
+        onDeleted={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Suspend" }));
+    await waitFor(() =>
+      expect(cronjobSetSuspendMock).toHaveBeenCalledWith("kind-dev", "ops", "nightly", true),
+    );
   });
 });

--- a/apps/desktop/src/components/DetailActions.tsx
+++ b/apps/desktop/src/components/DetailActions.tsx
@@ -3,13 +3,22 @@ import {
   ArrowLeftRight,
   LogOut,
   Logs,
+  Pause,
+  Play,
   RotateCw,
   Scaling,
   SquareTerminal,
   Trash2,
+  Zap,
 } from "lucide-react";
 import { deletePod, evictPod, type PodSummary } from "../lib/workloads";
-import { deleteResource, scaleResource, rolloutRestart } from "../lib/actions";
+import {
+  deleteResource,
+  scaleResource,
+  rolloutRestart,
+  cronjobSetSuspend,
+  cronjobTriggerNow,
+} from "../lib/actions";
 import { IconButton, ConfirmDialog, TextInput } from "../ui";
 import { ForwardDialog } from "./ForwardDialog";
 
@@ -172,21 +181,51 @@ export function ResourceActions({
   kind,
   namespace,
   name,
+  cronjobSuspended,
   onDeleted,
+  onChanged,
   onOpenLogs,
 }: {
   context: string;
   kind: string;
   namespace: string | null;
   name: string;
+  /** For CronJob details: current suspend state, to label Suspend/Resume. */
+  cronjobSuspended?: boolean;
   onDeleted: () => void;
+  /** Fired after a successful non-delete write action so the detail refreshes. */
+  onChanged?: () => void;
   onOpenLogs?: (s: { context: string; namespace: string; kind: string; name: string }) => void;
 }) {
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [scaling, setScaling] = useState(false);
   const [replicas, setReplicas] = useState("");
+  const [triggering, setTriggering] = useState(false);
   const [busy, setBusy] = useState("");
   const [err, setErr] = useState("");
+  const isCronJob = kind === "CronJob";
+
+  async function doSetSuspend() {
+    setBusy("suspend");
+    setErr("");
+    const r = await cronjobSetSuspend(context, namespace ?? "", name, !cronjobSuspended);
+    setBusy("");
+    if (r.error) setErr(r.error);
+    else onChanged?.();
+  }
+
+  async function doTrigger() {
+    setBusy("trigger");
+    setErr("");
+    const r = await cronjobTriggerNow(context, namespace ?? "", name);
+    setBusy("");
+    if (r.error) {
+      setErr(r.error);
+      return;
+    }
+    setTriggering(false);
+    onChanged?.();
+  }
 
   async function doDelete() {
     setBusy("delete");
@@ -216,13 +255,15 @@ export function ResourceActions({
       return;
     }
     setScaling(false);
+    onChanged?.();
   }
 
   async function doRestart() {
     setBusy("restart");
     setErr("");
-    await rolloutRestart(context, kind, namespace ?? "", name);
+    const r = await rolloutRestart(context, kind, namespace ?? "", name);
     setBusy("");
+    if (!r.error) onChanged?.();
   }
 
   return (
@@ -245,7 +286,36 @@ export function ResourceActions({
           onClick={() => void doRestart()}
         />
       )}
+      {isCronJob && (
+        <IconButton icon={Zap} label="Run now" onClick={() => setTriggering(true)} />
+      )}
+      {isCronJob && (
+        <IconButton
+          icon={cronjobSuspended ? Play : Pause}
+          label={cronjobSuspended ? "Resume" : "Suspend"}
+          disabled={busy === "suspend"}
+          onClick={() => void doSetSuspend()}
+        />
+      )}
       <IconButton icon={Trash2} label="Delete" danger onClick={() => setConfirmDelete(true)} />
+
+      {triggering && (
+        <ConfirmDialog
+          title="Run CronJob now"
+          message={
+            <>
+              <p style={{ marginTop: 0 }}>
+                Create a one-off Job from <code>{name}</code> and run it immediately.
+              </p>
+              {err && <p style={{ color: "var(--fl-color-danger)" }}>Error: {err}</p>}
+            </>
+          }
+          confirmLabel="Run"
+          busy={busy === "trigger"}
+          onConfirm={() => void doTrigger()}
+          onCancel={() => setTriggering(false)}
+        />
+      )}
 
       {scaling && (
         <ConfirmDialog

--- a/apps/desktop/src/components/ResourceBrowser.test.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.test.tsx
@@ -139,6 +139,27 @@ describe("ResourceBrowser", () => {
     expect(screen.getByText("backup")).toBeDefined();
   });
 
+  it("relabels the CronJob detail action when a watch update flips suspend", async () => {
+    listNamespacesMock.mockResolvedValue({ namespaces: ["ops"] });
+    let emit!: (rows: unknown) => void;
+    watchResourceMock.mockImplementation((_c: string, _n: string, _k: string, onRows: (r: unknown) => void) => {
+      emit = onRows;
+      onRows([{ name: "nightly", namespace: "ops", schedule: "0 2 * * *", suspended: false, active: 0, lastSchedule: "2h", age: "9d" }]);
+      return Promise.resolve({ stop: vi.fn() });
+    });
+
+    render(<ResourceBrowser context="kind-dev" kind="cronjobs" />);
+    fireEvent.click(await screen.findByText("nightly"));
+
+    // Active CronJob → the action reads "Suspend".
+    expect(await screen.findByRole("button", { name: "Suspend" })).toBeDefined();
+
+    // A live watch update marks it suspended; the still-open detail must follow.
+    emit([{ name: "nightly", namespace: "ops", schedule: "0 2 * * *", suspended: true, active: 0, lastSchedule: "2h", age: "9d" }]);
+    expect(await screen.findByRole("button", { name: "Resume" })).toBeDefined();
+    expect(screen.queryByRole("button", { name: "Suspend" })).toBeNull();
+  });
+
   it("streams cronjobs live and marks suspended ones", async () => {
     listNamespacesMock.mockResolvedValue({ namespaces: ["ops"] });
     watchResourceMock.mockImplementation(

--- a/apps/desktop/src/components/ResourceBrowser.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.tsx
@@ -391,6 +391,8 @@ export function ResourceBrowser({
   const [selectedPod, setSelectedPod] = useState<PodSummary | null>(null);
   const [otherDetail, setOtherDetail] = useState<OtherDetail | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
+  // Bumped after a write action so the open detail overview re-fetches.
+  const [detailReload, setDetailReload] = useState(0);
   const [filterColumn, setFilterColumn] = useState<string | null>(null);
   // Per-pod CPU/memory (millicores / MiB), merged into the pods table.
   const [podCpuMem, setPodCpuMem] = useState<Map<string, { cpu: number; mem: number }>>(new Map());
@@ -620,7 +622,13 @@ export function ResourceBrowser({
         kind={otherDetail.kind}
         namespace={otherDetail.namespace}
         name={otherDetail.name}
+        cronjobSuspended={
+          otherDetail.kind === "CronJob"
+            ? (res.rows as CronJobSummary[]).find((r) => r.name === otherDetail.name)?.suspended
+            : undefined
+        }
         onDeleted={closeDetail}
+        onChanged={() => setDetailReload((k) => k + 1)}
         onOpenLogs={onOpenWorkloadLogs}
       />
     </>
@@ -736,6 +744,7 @@ export function ResourceBrowser({
             kind={otherDetail.kind}
             namespace={otherDetail.namespace}
             name={otherDetail.name}
+            reloadKey={detailReload}
             onOpenResource={onOpenResource}
           />
         )}

--- a/apps/desktop/src/components/ResourceDetail.tsx
+++ b/apps/desktop/src/components/ResourceDetail.tsx
@@ -23,12 +23,15 @@ export function ResourceDetail({
   kind,
   namespace,
   name,
+  reloadKey = 0,
   onOpenResource,
 }: {
   context: string;
   kind: string;
   namespace: string | null;
   name: string;
+  /** Bumped by the parent after a write action to refresh the overview. */
+  reloadKey?: number;
   onOpenResource?: OpenResource;
 }) {
   const [tab, setTab] = useState<DetailTab>("overview");
@@ -43,6 +46,7 @@ export function ResourceDetail({
             kind={kind}
             namespace={namespace}
             name={name}
+            reloadKey={reloadKey}
             onOpenResource={onOpenResource}
           />
         )}

--- a/apps/desktop/src/components/ResourceOverview.test.tsx
+++ b/apps/desktop/src/components/ResourceOverview.test.tsx
@@ -460,4 +460,31 @@ describe("ResourceOverview", () => {
     );
     await waitFor(() => expect(screen.getByText(/not found/)).toBeDefined());
   });
+
+  it("re-fetches the object when reloadKey changes (after an action)", async () => {
+    const getObjectFn = vi.fn().mockResolvedValue({ object: podObject });
+    const { rerender } = render(
+      <ResourceOverview
+        context="kind-dev"
+        kind="Pod"
+        namespace="default"
+        name="web-1"
+        getObjectFn={getObjectFn}
+        reloadKey={0}
+      />,
+    );
+    await waitFor(() => expect(getObjectFn).toHaveBeenCalledTimes(1));
+
+    rerender(
+      <ResourceOverview
+        context="kind-dev"
+        kind="Pod"
+        namespace="default"
+        name="web-1"
+        getObjectFn={getObjectFn}
+        reloadKey={1}
+      />,
+    );
+    await waitFor(() => expect(getObjectFn).toHaveBeenCalledTimes(2));
+  });
 });

--- a/apps/desktop/src/components/ResourceOverview.tsx
+++ b/apps/desktop/src/components/ResourceOverview.tsx
@@ -2313,6 +2313,7 @@ export function ResourceOverview({
   namespace,
   name,
   getObjectFn = getObject,
+  reloadKey = 0,
   onOpenResource,
 }: {
   context: string;
@@ -2320,6 +2321,8 @@ export function ResourceOverview({
   namespace: string | null;
   name: string;
   getObjectFn?: typeof getObject;
+  /** Bumped by the parent after a write action to re-fetch the shown object. */
+  reloadKey?: number;
   onOpenResource?: OpenResource;
 }) {
   const [obj, setObj] = useState<K8sObject | null>(null);
@@ -2337,7 +2340,7 @@ export function ResourceOverview({
     return () => {
       active = false;
     };
-  }, [context, kind, namespace, name, getObjectFn]);
+  }, [context, kind, namespace, name, getObjectFn, reloadKey]);
 
   if (error) return <p style={{ color: "var(--fl-color-danger)" }}>Error: {error}</p>;
   if (obj === null) return <Spinner label="Loading details" />;

--- a/apps/desktop/src/lib/actions.test.ts
+++ b/apps/desktop/src/lib/actions.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
-import { deleteResource, scaleResource, rolloutRestart } from "./actions";
+import {
+  deleteResource,
+  scaleResource,
+  rolloutRestart,
+  cronjobSetSuspend,
+  cronjobTriggerNow,
+} from "./actions";
 
 describe("resource actions", () => {
   it("deleteResource passes kind/namespace/name", async () => {
@@ -42,5 +48,27 @@ describe("resource actions", () => {
       Promise.reject(new Error("forbidden")),
     );
     expect(out.error).toContain("forbidden");
+  });
+
+  it("cronjobSetSuspend passes the suspend flag", async () => {
+    const invoke = vi.fn().mockResolvedValue({ ok: true });
+    await cronjobSetSuspend("c", "ops", "nightly", true, invoke);
+    expect(invoke).toHaveBeenCalledWith("k8s.cronjobSetSuspend", {
+      context: "c",
+      namespace: "ops",
+      name: "nightly",
+      suspend: true,
+    });
+  });
+
+  it("cronjobTriggerNow sends a unique suffix and returns the job name", async () => {
+    const invoke = vi.fn().mockResolvedValue({ jobName: "nightly-123", ok: true });
+    const out = await cronjobTriggerNow("c", "ops", "nightly", invoke);
+    const call = invoke.mock.calls[0];
+    expect(call[0]).toBe("k8s.cronjobTriggerNow");
+    expect(call[1]).toMatchObject({ context: "c", namespace: "ops", name: "nightly" });
+    expect(typeof (call[1] as { suffix: string }).suffix).toBe("string");
+    expect((call[1] as { suffix: string }).suffix.length).toBeGreaterThan(0);
+    expect(out.jobName).toBe("nightly-123");
   });
 });

--- a/apps/desktop/src/lib/actions.ts
+++ b/apps/desktop/src/lib/actions.ts
@@ -62,6 +62,42 @@ export function cordonNode(
   return run("k8s.cordonNode", { context, name, unschedulable }, invoke);
 }
 
+/** Suspend or resume a CronJob via `k8s.cronjobSetSuspend`. */
+export function cronjobSetSuspend(
+  context: string,
+  namespace: string,
+  name: string,
+  suspend: boolean,
+  invoke: Invoker = invokeCapability,
+): Promise<ActionResult> {
+  return run("k8s.cronjobSetSuspend", { context, namespace, name, suspend }, invoke);
+}
+
+/**
+ * Run a CronJob immediately via `k8s.cronjobTriggerNow`. The unique Job-name
+ * suffix is generated here (a timestamp) so the backend handler stays
+ * deterministic. Returns the created Job's name.
+ */
+export async function cronjobTriggerNow(
+  context: string,
+  namespace: string,
+  name: string,
+  invoke: Invoker = invokeCapability,
+): Promise<{ jobName?: string; error?: string }> {
+  try {
+    const suffix = String(Date.now());
+    const out = await invoke<{ jobName: string }>("k8s.cronjobTriggerNow", {
+      context,
+      namespace,
+      name,
+      suffix,
+    });
+    return { jobName: out.jobName };
+  } catch (e) {
+    return { error: String(e) };
+  }
+}
+
 /** Cordon + evict a node's pods via `k8s.drainNode`. */
 export async function drainNode(
   context: string,

--- a/crates/kube/src/cronjobs.rs
+++ b/crates/kube/src/cronjobs.rs
@@ -3,14 +3,60 @@
 use std::sync::Arc;
 
 use srelens_capability::{Annotations, Capability, CapabilityError};
-use k8s_openapi::api::batch::v1::CronJob;
-use kube::api::ListParams;
+use k8s_openapi::api::batch::v1::{CronJob, Job};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference;
+use kube::api::{ListParams, Patch, PatchParams, PostParams};
 use kube::Api;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 
 use crate::client_cache::ClientCache;
 use crate::connect::request_timeout;
+
+/// Build a one-off Job from a CronJob's `jobTemplate` (the `kubectl create job
+/// --from=cronjob/x` mechanism). The Job is owned by the CronJob so it is
+/// garbage-collected with it and discoverable in the CronJob's relations, but
+/// `controller: false` leaves the CronJob controller's own scheduling alone.
+/// `suffix` (a timestamp) makes the name unique; the whole name is truncated to
+/// the 63-char Kubernetes limit.
+pub(crate) fn build_manual_job(cj: &CronJob, suffix: &str) -> Result<Job, String> {
+    let cj_name = cj.metadata.name.clone().ok_or("CronJob has no name")?;
+    let template = cj
+        .spec
+        .as_ref()
+        .map(|s| s.job_template.clone())
+        .ok_or("CronJob has no jobTemplate")?;
+
+    let mut name = format!("{cj_name}-{suffix}");
+    if name.len() > 63 {
+        name.truncate(63);
+        while name.ends_with('-') {
+            name.pop();
+        }
+    }
+
+    let owner = cj.metadata.uid.clone().map(|uid| OwnerReference {
+        api_version: "batch/v1".into(),
+        kind: "CronJob".into(),
+        name: cj_name,
+        uid,
+        controller: Some(false),
+        block_owner_deletion: Some(false),
+    });
+
+    Ok(Job {
+        metadata: kube::core::ObjectMeta {
+            name: Some(name),
+            namespace: cj.metadata.namespace.clone(),
+            labels: template.metadata.and_then(|m| m.labels),
+            owner_references: owner.map(|o| vec![o]),
+            ..Default::default()
+        },
+        spec: template.spec,
+        status: None,
+    })
+}
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ListCronJobsIn {
@@ -80,6 +126,103 @@ pub fn list_cronjobs_capability(cache: Arc<ClientCache>) -> Capability {
     )
 }
 
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct CronJobActionOut {
+    pub name: String,
+    pub ok: bool,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SetSuspendIn {
+    pub context: String,
+    pub namespace: String,
+    pub name: String,
+    /// true = suspend scheduling, false = resume.
+    pub suspend: bool,
+}
+
+/// `k8s.cronjobSetSuspend` — suspend or resume a CronJob (`spec.suspend`).
+/// Reversible, so it requires confirmation but is not flagged destructive.
+pub fn cronjob_set_suspend_capability(cache: Arc<ClientCache>) -> Capability {
+    Capability::typed::<SetSuspendIn, CronJobActionOut, _, _>(
+        "k8s.cronjobSetSuspend",
+        "suspend or resume a CronJob (set spec.suspend)",
+        Annotations {
+            read_only: false,
+            destructive: false,
+            requires_confirm: true,
+        },
+        move |input: SetSuspendIn| {
+            let cache = cache.clone();
+            async move {
+                let client = cache.get(&input.context).await.map_err(CapabilityError::Handler)?;
+                let api: Api<CronJob> = crate::scoped_api(client, &input.namespace);
+                let patch = json!({ "spec": { "suspend": input.suspend } });
+                tokio::time::timeout(
+                    request_timeout(),
+                    api.patch(&input.name, &PatchParams::default(), &Patch::Merge(&patch)),
+                )
+                .await
+                .map_err(|_| CapabilityError::Handler("set suspend timed out".into()))?
+                .map_err(|e| CapabilityError::Handler(e.to_string()))?;
+                Ok(CronJobActionOut { name: input.name, ok: true })
+            }
+        },
+    )
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct TriggerNowIn {
+    pub context: String,
+    pub namespace: String,
+    pub name: String,
+    /// A unique suffix for the created Job name (a timestamp from the caller,
+    /// so the handler stays deterministic and testable).
+    pub suffix: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct TriggerNowOut {
+    /// The name of the one-off Job that was created.
+    #[serde(rename = "jobName")]
+    pub job_name: String,
+    pub ok: bool,
+}
+
+/// `k8s.cronjobTriggerNow` — run a CronJob immediately by creating a one-off Job
+/// from its `jobTemplate` (like `kubectl create job --from`). Requires
+/// confirmation.
+pub fn cronjob_trigger_now_capability(cache: Arc<ClientCache>) -> Capability {
+    Capability::typed::<TriggerNowIn, TriggerNowOut, _, _>(
+        "k8s.cronjobTriggerNow",
+        "run a CronJob immediately by creating a Job from its jobTemplate",
+        Annotations {
+            read_only: false,
+            destructive: false,
+            requires_confirm: true,
+        },
+        move |input: TriggerNowIn| {
+            let cache = cache.clone();
+            async move {
+                let client = cache.get(&input.context).await.map_err(CapabilityError::Handler)?;
+                let api: Api<CronJob> = crate::scoped_api(client.clone(), &input.namespace);
+                let cj = tokio::time::timeout(request_timeout(), api.get(&input.name))
+                    .await
+                    .map_err(|_| CapabilityError::Handler("get cronjob timed out".into()))?
+                    .map_err(|e| CapabilityError::Handler(e.to_string()))?;
+                let job = build_manual_job(&cj, &input.suffix).map_err(CapabilityError::Handler)?;
+                let job_name = job.metadata.name.clone().unwrap_or_default();
+                let jobs: Api<Job> = crate::scoped_api(client, &input.namespace);
+                tokio::time::timeout(request_timeout(), jobs.create(&PostParams::default(), &job))
+                    .await
+                    .map_err(|_| CapabilityError::Handler("create job timed out".into()))?
+                    .map_err(|e| CapabilityError::Handler(e.to_string()))?;
+                Ok(TriggerNowOut { job_name, ok: true })
+            }
+        },
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -93,6 +236,22 @@ mod tests {
         let cap = list_cronjobs_capability(ClientCache::new(PathBuf::from("/x")));
         assert_eq!(cap.id, "k8s.listCronJobs");
         assert!(cap.annotations.read_only);
+    }
+
+    #[test]
+    fn suspend_and_trigger_capabilities_require_confirm() {
+        let cache = ClientCache::new(PathBuf::from("/x"));
+        let suspend = cronjob_set_suspend_capability(cache.clone());
+        assert_eq!(suspend.id, "k8s.cronjobSetSuspend");
+        assert!(suspend.annotations.requires_confirm);
+        assert!(!suspend.annotations.read_only);
+        // Suspend/resume is reversible, so not flagged destructive.
+        assert!(!suspend.annotations.destructive);
+
+        let trigger = cronjob_trigger_now_capability(cache);
+        assert_eq!(trigger.id, "k8s.cronjobTriggerNow");
+        assert!(trigger.annotations.requires_confirm);
+        assert!(!trigger.annotations.read_only);
     }
 
     #[test]
@@ -121,6 +280,60 @@ mod tests {
         assert!(s.suspended);
         assert_eq!(s.active, 2);
         assert_eq!(s.last_schedule, "0s");
+    }
+
+    fn cronjob_with_template(name: &str) -> CronJob {
+        use k8s_openapi::api::batch::v1::{JobSpec, JobTemplateSpec};
+        let mut labels = std::collections::BTreeMap::new();
+        labels.insert("app".to_string(), "backup".to_string());
+        CronJob {
+            metadata: kube::core::ObjectMeta {
+                name: Some(name.into()),
+                namespace: Some("ops".into()),
+                uid: Some("cj-uid-123".into()),
+                ..Default::default()
+            },
+            spec: Some(CronJobSpec {
+                schedule: "0 2 * * *".into(),
+                job_template: JobTemplateSpec {
+                    metadata: Some(kube::core::ObjectMeta {
+                        labels: Some(labels),
+                        ..Default::default()
+                    }),
+                    spec: Some(JobSpec {
+                        completions: Some(1),
+                        ..Default::default()
+                    }),
+                },
+                ..Default::default()
+            }),
+            status: None,
+        }
+    }
+
+    #[test]
+    fn builds_manual_job_with_owner_labels_and_spec() {
+        let cj = cronjob_with_template("backup");
+        let job = build_manual_job(&cj, "1700000000").unwrap();
+        assert_eq!(job.metadata.name.as_deref(), Some("backup-1700000000"));
+        assert_eq!(job.metadata.namespace.as_deref(), Some("ops"));
+        assert_eq!(job.metadata.labels.as_ref().unwrap().get("app").map(String::as_str), Some("backup"));
+        let owner = &job.metadata.owner_references.as_ref().unwrap()[0];
+        assert_eq!(owner.kind, "CronJob");
+        assert_eq!(owner.name, "backup");
+        assert_eq!(owner.uid, "cj-uid-123");
+        assert_eq!(owner.controller, Some(false));
+        assert_eq!(job.spec.as_ref().unwrap().completions, Some(1));
+    }
+
+    #[test]
+    fn truncates_manual_job_name_to_63_chars() {
+        let long = "a".repeat(60);
+        let cj = cronjob_with_template(&long);
+        let job = build_manual_job(&cj, "1700000000").unwrap();
+        let name = job.metadata.name.unwrap();
+        assert!(name.len() <= 63, "name was {} chars", name.len());
+        assert!(!name.ends_with('-'), "name should not end with a dash: {name}");
     }
 
     #[test]


### PR DESCRIPTION
Completes the actions and interactivity for #7 (second slice). Also fixes a reported bug: **the detail view didn't update after an action**.

## Lifecycle actions

**Backend (`crates/kube`, test-first):**
- `k8s.cronjobSetSuspend` — suspend/resume via `spec.suspend`. Reversible, so `requires_confirm` but **not** `destructive`.
- `k8s.cronjobTriggerNow` — run now by creating a Job from the CronJob's `jobTemplate` (like `kubectl create job --from`). The Job is owned by the CronJob (GC + discoverable in relations) with `controller: false` so the CronJob controller's own scheduling is untouched. The pure `build_manual_job` builder is unit-tested for owner ref, label copy, and **63-char name truncation**.
- Both registered → auto-exposed as MCP tools; completeness test green.

**Frontend (test-first):**
- `lib/actions`: `cronjobSetSuspend` + `cronjobTriggerNow` (unique Job-name suffix generated client-side so the handler stays deterministic/testable).
- `DetailActions`: **Run now** (confirm dialog) + **Suspend/Resume** buttons for CronJobs.

## Detail auto-refresh after actions (the reported bug)

Two independent staleness bugs, both fixed:
1. **Action button label** — the Suspend/Resume label was a frozen snapshot from row-click time. Now it derives from the **live watched row**, so it follows the change (self *or* external) the instant the watch re-emits.
2. **Overview panel** — `ResourceOverview` fetched the object once and never re-read it (screenshot: row + button said "Suspended"/"Resume" but the panel still read "Suspend: No"). Added a `reloadKey`; `ResourceActions` fires `onChanged` after a successful **scale / restart / suspend / trigger**, bumping it so the panel re-fetches. This fixes staleness for *all* mutating actions, not just CronJob.

## Relations
STS/DS → Pods and CronJob → active Jobs already work via the existing `ManagedPods`/`relatedPodSelector`/`CronJobBody` infrastructure — no new code needed.

## Verification
96 Rust + 281 frontend tests, coverage above both gates, production build clean.