### PR TITLE
feat(workloads): enrich StatefulSet/DaemonSet/Job/CronJob detail views

### DIFF
--- a/apps/desktop/src/components/CommandPalette.test.tsx
+++ b/apps/desktop/src/components/CommandPalette.test.tsx
@@ -65,6 +65,21 @@ describe("CommandPalette", () => {
     expect(await screen.findByText("Recent")).toBeDefined();
   });
 
+  it("can navigate to the workload controller views", async () => {
+    const { onOpenView } = setup();
+    const search = screen.getByPlaceholderText(/Search resources/);
+    for (const [label, kind] of [
+      ["StatefulSets", "statefulsets"],
+      ["DaemonSets", "daemonsets"],
+      ["CronJobs", "cronjobs"],
+    ] as const) {
+      await userEvent.clear(search);
+      await userEvent.type(search, label);
+      await userEvent.click(await screen.findByText(label));
+      expect(onOpenView).toHaveBeenCalledWith(kind);
+    }
+  });
+
   it("searches resources by name and deep-links to the selected one", async () => {
     const { onOpenResource } = setup();
     await waitFor(() => expect(listResourceMock).toHaveBeenCalled());

--- a/apps/desktop/src/components/ResourceOverview.test.tsx
+++ b/apps/desktop/src/components/ResourceOverview.test.tsx
@@ -6,6 +6,7 @@ import React from "react";
 vi.mock("./WorkloadRelations", () => ({
   DeployRevisions: () => <div data-testid="deploy-revisions" />,
   ManagedPods: () => <div data-testid="managed-pods" />,
+  CronJobJobs: () => <div data-testid="cronjob-jobs" />,
 }));
 vi.mock("./MetricsPanel", () => ({ MetricsPanel: () => <div data-testid="metrics" /> }));
 
@@ -200,6 +201,78 @@ describe("ObjectDetail (Deployment)", () => {
     expect(screen.getByText("Progressing")).toBeDefined();
     expect(screen.getByText("Available")).toBeDefined();
     expect(screen.getByText("Running")).toBeDefined();
+  });
+});
+
+describe("ObjectDetail (workload kinds)", () => {
+  it("shows Job timing (started, completed, duration)", () => {
+    const job: K8sObject = {
+      kind: "Job",
+      metadata: { name: "backup", namespace: "ops" },
+      spec: { completions: 1 },
+      status: {
+        succeeded: 1,
+        startTime: "2026-01-01T10:00:00Z",
+        completionTime: "2026-01-01T10:02:30Z",
+      },
+    };
+    render(<ObjectDetail kind="Job" obj={job} now={NOW} />);
+    expect(screen.getByText("Started")).toBeDefined();
+    expect(screen.getByText("Completed")).toBeDefined();
+    expect(screen.getByText("Duration")).toBeDefined();
+    // 150s → "2m 30s"
+    expect(screen.getByText("2m 30s")).toBeDefined();
+  });
+
+  it("shows a StatefulSet's service, update strategy, and partition", () => {
+    const sts: K8sObject = {
+      kind: "StatefulSet",
+      metadata: { name: "pg", namespace: "data" },
+      spec: {
+        replicas: 3,
+        serviceName: "pg-headless",
+        selector: { matchLabels: { app: "pg" } },
+        updateStrategy: { type: "RollingUpdate", rollingUpdate: { partition: 2 } },
+        volumeClaimTemplates: [{ metadata: { name: "data" } }, { metadata: { name: "wal" } }],
+      },
+      status: { replicas: 3, readyReplicas: 2, updatedReplicas: 3 },
+    };
+    render(<ObjectDetail kind="StatefulSet" obj={sts} now={NOW} />);
+    expect(screen.getByText("pg-headless")).toBeDefined();
+    expect(screen.getByText("RollingUpdate (partition 2)")).toBeDefined();
+    // volume claim template names
+    expect(screen.getByText("data, wal")).toBeDefined();
+  });
+
+  it("shows a CronJob's history limits and last schedule", () => {
+    const cj: K8sObject = {
+      kind: "CronJob",
+      metadata: { name: "nightly", namespace: "ops" },
+      spec: {
+        schedule: "0 2 * * *",
+        suspend: false,
+        concurrencyPolicy: "Forbid",
+        successfulJobsHistoryLimit: 3,
+        failedJobsHistoryLimit: 1,
+      },
+      status: { lastScheduleTime: "2026-01-01T02:00:00Z" },
+    };
+    render(<ObjectDetail kind="CronJob" obj={cj} now={NOW} />);
+    expect(screen.getByText("History (kept)")).toBeDefined();
+    expect(screen.getByText("3 succeeded, 1 failed")).toBeDefined();
+    expect(screen.getByText("Last schedule")).toBeDefined();
+  });
+
+  it("shows a DaemonSet's update strategy", () => {
+    const ds: K8sObject = {
+      kind: "DaemonSet",
+      metadata: { name: "fluentd", namespace: "logging" },
+      spec: { updateStrategy: { type: "RollingUpdate", rollingUpdate: { maxUnavailable: 1 } } },
+      status: { desiredNumberScheduled: 5, numberReady: 5 },
+    };
+    render(<ObjectDetail kind="DaemonSet" obj={ds} now={NOW} />);
+    expect(screen.getByText("Update strategy")).toBeDefined();
+    expect(screen.getByText("RollingUpdate (max unavailable 1)")).toBeDefined();
   });
 });
 

--- a/apps/desktop/src/components/ResourceOverview.tsx
+++ b/apps/desktop/src/components/ResourceOverview.tsx
@@ -12,7 +12,7 @@ import {
   type BadgeVariant,
   type Column,
 } from "../ui";
-import { DeployRevisions, ManagedPods } from "./WorkloadRelations";
+import { DeployRevisions, ManagedPods, CronJobJobs } from "./WorkloadRelations";
 import { MetricsPanel } from "./MetricsPanel";
 import { ForwardDialog } from "./ForwardDialog";
 import {
@@ -39,6 +39,20 @@ export function ageFromTimestamp(iso?: string, now: number = Date.now()): string
   if (hours < 24) return `${hours}h`;
   const days = Math.floor(hours / 24);
   return `${days}d`;
+}
+
+/** Human-readable duration between two ISO timestamps, e.g. "2m 30s". */
+export function durationBetween(startIso?: string, endIso?: string): string {
+  if (!startIso || !endIso) return "—";
+  const secs = Math.max(0, Math.floor((new Date(endIso).getTime() - new Date(startIso).getTime()) / 1000));
+  if (Number.isNaN(secs)) return "—";
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.floor(secs / 60);
+  const remSecs = secs % 60;
+  if (mins < 60) return remSecs ? `${mins}m ${remSecs}s` : `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  const remMins = mins % 60;
+  return remMins ? `${hours}h ${remMins}m` : `${hours}h`;
 }
 
 /** Absolute, human-readable timestamp, e.g. "Jun 10, 2026, 12:52:33 PM". */
@@ -956,7 +970,24 @@ function WorkloadDetailView({
                 ""
               ),
             ],
-            ["Strategy Type", str(asRecord(spec.strategy).type) || str(spec.updateStrategy && asRecord(spec.updateStrategy).type)],
+            [
+              "Strategy Type",
+              kind === "Deployment"
+                ? str(asRecord(spec.strategy).type)
+                : updateStrategyText(asRecord(spec.updateStrategy)),
+            ],
+            ...(kind === "StatefulSet"
+              ? ([
+                  ["Service", <span key="svc" className="fl-mono">{str(spec.serviceName)}</span>],
+                  [
+                    "Volume claim templates",
+                    asArray(spec.volumeClaimTemplates)
+                      .map((t) => str(asRecord(asRecord(t).metadata).name))
+                      .filter(Boolean)
+                      .join(", ") || "—",
+                  ],
+                ] as Pair[])
+              : []),
             ["Status", <StatusPill key="st" status={phase} kind={phaseKind(phase)} />],
             ["Conditions", <ConditionBadges key="c" conditions={conditions} />],
           ]}
@@ -983,9 +1014,21 @@ function WorkloadDetailView({
   );
 }
 
+/** "RollingUpdate (partition 2)" / "RollingUpdate (max unavailable 1)" / "OnDelete". */
+function updateStrategyText(strategy: Record<string, unknown>): string {
+  const type = str(strategy.type) || "RollingUpdate";
+  const ru = asRecord(strategy.rollingUpdate);
+  const parts: string[] = [];
+  if (ru.partition != null) parts.push(`partition ${str(ru.partition)}`);
+  if (ru.maxUnavailable != null) parts.push(`max unavailable ${str(ru.maxUnavailable)}`);
+  if (ru.maxSurge != null) parts.push(`max surge ${str(ru.maxSurge)}`);
+  return parts.length ? `${type} (${parts.join(", ")})` : type;
+}
+
 function DaemonSetBody({ obj }: { obj: K8sObject }) {
   const status = asRecord(obj.status);
-  const selector = asRecord(asRecord(asRecord(obj.spec).selector).matchLabels) as Record<string, string>;
+  const spec = asRecord(obj.spec);
+  const selector = asRecord(asRecord(spec.selector).matchLabels) as Record<string, string>;
   return (
     <Section title="Scheduling">
       <KV
@@ -995,6 +1038,7 @@ function DaemonSetBody({ obj }: { obj: K8sObject }) {
           ["Ready", str(status.numberReady)],
           ["Up-to-date", str(status.updatedNumberScheduled)],
           ["Available", str(status.numberAvailable)],
+          ["Update strategy", updateStrategyText(asRecord(spec.updateStrategy))],
           ["Selector", <Chips key="s" map={selector} />],
         ]}
       />
@@ -1110,9 +1154,16 @@ function NodeBody({ obj }: { obj: K8sObject }) {
   );
 }
 
-function JobBody({ obj }: { obj: K8sObject }) {
+function JobBody({ obj, now }: { obj: K8sObject; now: number }) {
   const spec = asRecord(obj.spec);
   const status = asRecord(obj.status);
+  const startTime = str(status.startTime);
+  const completionTime = str(status.completionTime);
+  const duration = completionTime
+    ? durationBetween(startTime, completionTime)
+    : startTime
+      ? `${ageFromTimestamp(startTime, now)} (running)`
+      : "—";
   return (
     <Section title="Job">
       <KV
@@ -1122,16 +1173,34 @@ function JobBody({ obj }: { obj: K8sObject }) {
           ["Succeeded", str(status.succeeded) || "0"],
           ["Failed", str(status.failed) || "0"],
           ["Active", str(status.active) || "0"],
+          ["Started", startTime ? timestampWithAge(startTime, now) : "—"],
+          ["Completed", completionTime ? timestampWithAge(completionTime, now) : "—"],
+          ["Duration", duration],
         ]}
       />
     </Section>
   );
 }
 
-function CronJobBody({ obj, onOpenResource }: { obj: K8sObject; onOpenResource?: OpenResource }) {
+function CronJobBody({
+  obj,
+  now,
+  context = "",
+  onOpenResource,
+}: {
+  obj: K8sObject;
+  now: number;
+  context?: string;
+  onOpenResource?: OpenResource;
+}) {
+  const meta = asRecord(obj.metadata);
   const spec = asRecord(obj.spec);
   const status = asRecord(obj.status);
-  const namespace = str(asRecord(obj.metadata).namespace) || null;
+  const namespace = str(meta.namespace) || null;
+  const name = str(meta.name);
+  const lastSchedule = str(status.lastScheduleTime);
+  const successKept = str(spec.successfulJobsHistoryLimit) || "3";
+  const failedKept = str(spec.failedJobsHistoryLimit) || "1";
   const activeJobs = asArray(status.active)
     .map(asRecord)
     .map((job) => ({
@@ -1141,23 +1210,35 @@ function CronJobBody({ obj, onOpenResource }: { obj: K8sObject; onOpenResource?:
     }))
     .filter((job) => job.name);
   return (
-    <Section title="Schedule">
-      <KV
-        pairs={[
-          ["Schedule", <span className="fl-mono">{str(spec.schedule)}</span>],
-          ["Suspend", spec.suspend === true ? "Yes" : "No"],
-          ["Concurrency policy", str(spec.concurrencyPolicy)],
-          [
-            "Active jobs",
-            activeJobs.length ? (
-              <LinkedResources targets={activeJobs} onOpenResource={onOpenResource} />
-            ) : (
-              "0"
-            ),
-          ],
-        ]}
-      />
-    </Section>
+    <>
+      <Section title="Schedule">
+        <KV
+          pairs={[
+            ["Schedule", <span className="fl-mono">{str(spec.schedule)}</span>],
+            ["Suspend", spec.suspend === true ? "Yes" : "No"],
+            ["Concurrency policy", str(spec.concurrencyPolicy)],
+            ["Last schedule", lastSchedule ? timestampWithAge(lastSchedule, now) : "—"],
+            ["History (kept)", `${successKept} succeeded, ${failedKept} failed`],
+            [
+              "Active jobs",
+              activeJobs.length ? (
+                <LinkedResources targets={activeJobs} onOpenResource={onOpenResource} />
+              ) : (
+                "0"
+              ),
+            ],
+          ]}
+        />
+      </Section>
+      {context && namespace && (
+        <CronJobJobs
+          context={context}
+          namespace={namespace}
+          ownerName={name}
+          onOpenResource={onOpenResource}
+        />
+      )}
+    </>
   );
 }
 
@@ -2075,11 +2156,13 @@ function KindBody({
   kind,
   obj,
   context = "",
+  now = Date.now(),
   onOpenResource,
 }: {
   kind: string;
   obj: K8sObject;
   context?: string;
+  now?: number;
   onOpenResource?: OpenResource;
 }) {
   switch (kind) {
@@ -2090,9 +2173,9 @@ function KindBody({
     case "Node":
       return <NodeBody obj={obj} />;
     case "Job":
-      return <JobBody obj={obj} />;
+      return <JobBody obj={obj} now={now} />;
     case "CronJob":
-      return <CronJobBody obj={obj} onOpenResource={onOpenResource} />;
+      return <CronJobBody obj={obj} now={now} context={context} onOpenResource={onOpenResource} />;
     case "ConfigMap":
       return <ConfigBody obj={obj} />;
     case "Secret":
@@ -2219,7 +2302,7 @@ function GenericDetail({
         <Chips map={meta.annotations as Record<string, string>} />
       </Section>
 
-      <KindBody kind={kind} obj={obj} context={context} onOpenResource={onOpenResource} />
+      <KindBody kind={kind} obj={obj} context={context} now={now} onOpenResource={onOpenResource} />
 
       {context && namespace && Object.keys(podSelector).length > 0 && (
         <ManagedPods

--- a/apps/desktop/src/components/WorkloadRelations.test.tsx
+++ b/apps/desktop/src/components/WorkloadRelations.test.tsx
@@ -1,7 +1,36 @@
 import { describe, it, expect, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
-import { DeployRevisions, ManagedPods } from "./WorkloadRelations";
+import { DeployRevisions, ManagedPods, CronJobJobs } from "./WorkloadRelations";
+
+describe("CronJobJobs", () => {
+  it("lists the CronJob's owned jobs newest-first and opens them", async () => {
+    const onOpenResource = vi.fn();
+    const listJobsFn = vi.fn().mockResolvedValue({
+      jobs: [
+        { name: "nightly-2", namespace: "ops", completions: "1/1", active: 0, failed: 0, duration: "2m", owner: "nightly", age: "1h" },
+        { name: "other", namespace: "ops", completions: "1/1", active: 0, failed: 0, duration: "1m", owner: "different", age: "2h" },
+        { name: "nightly-1", namespace: "ops", completions: "0/1", active: 0, failed: 1, duration: "30s", owner: "nightly", age: "1d" },
+      ],
+    });
+    render(
+      <CronJobJobs
+        context="kind-dev"
+        namespace="ops"
+        ownerName="nightly"
+        onOpenResource={onOpenResource}
+        listJobsFn={listJobsFn}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText("nightly-2")).toBeDefined());
+    expect(listJobsFn).toHaveBeenCalledWith("kind-dev", "ops");
+    // Only jobs owned by this CronJob; the unrelated "other" is filtered out.
+    expect(screen.queryByText("other")).toBeNull();
+    expect(screen.getByText("nightly-1")).toBeDefined();
+    fireEvent.click(screen.getByText("nightly-2"));
+    expect(onOpenResource).toHaveBeenCalledWith({ kind: "Job", namespace: "ops", name: "nightly-2" });
+  });
+});
 
 describe("DeployRevisions", () => {
   it("renders the deployment's revisions newest-first", async () => {

--- a/apps/desktop/src/components/WorkloadRelations.tsx
+++ b/apps/desktop/src/components/WorkloadRelations.tsx
@@ -6,6 +6,7 @@ import {
   type ReplicaSetSummary,
   type PodSummary,
 } from "../lib/workloads";
+import { listJobs, type JobSummary } from "../lib/controllers";
 import { Spinner, StatusPill, Table, type StatusKind, type Column } from "../ui";
 import type { OpenResource } from "../lib/resourceNavigation";
 
@@ -87,6 +88,76 @@ export function DeployRevisions({
             : undefined
         }
         emptyText="No revisions"
+      />
+    </Section>
+  );
+}
+
+/** "Recent Jobs": the Jobs a CronJob owns (its run history), newest-first. */
+export function CronJobJobs({
+  context,
+  namespace,
+  ownerName,
+  onOpenResource,
+  listJobsFn = listJobs,
+}: {
+  context: string;
+  namespace: string;
+  ownerName: string;
+  onOpenResource?: OpenResource;
+  listJobsFn?: typeof listJobs;
+}) {
+  const [rows, setRows] = useState<JobSummary[] | null>(null);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let active = true;
+    setRows(null);
+    setError("");
+    void listJobsFn(context, namespace).then((out) => {
+      if (!active) return;
+      if (out.error) setError(out.error);
+      else setRows((out.jobs ?? []).filter((j) => j.owner === ownerName));
+    });
+    return () => {
+      active = false;
+    };
+  }, [context, namespace, ownerName, listJobsFn]);
+
+  if (error) return null; // a missing jobs list shouldn't break the panel
+  if (rows === null)
+    return (
+      <Section title="Recent Jobs">
+        <Spinner label="Loading jobs" />
+      </Section>
+    );
+
+  const columns: Column<JobSummary>[] = [
+    { key: "name", header: "Name", render: (j) => <span className="fl-mono">{j.name}</span> },
+    { key: "completions", header: "Completions", render: (j) => j.completions },
+    {
+      key: "status",
+      header: "Status",
+      render: (j) => {
+        const [status, kind]: [string, StatusKind] =
+          j.failed > 0 ? ["Failed", "danger"] : j.active > 0 ? ["Active", "warning"] : ["Complete", "success"];
+        return <StatusPill status={status} kind={kind} />;
+      },
+    },
+    { key: "duration", header: "Duration", render: (j) => j.duration || "—" },
+    { key: "age", header: "Age", render: (j) => j.age },
+  ];
+
+  return (
+    <Section title="Recent Jobs">
+      <Table
+        columns={columns}
+        data={rows}
+        getRowKey={(j) => j.name}
+        onRowClick={
+          onOpenResource ? (row) => onOpenResource({ kind: "Job", namespace, name: row.name }) : undefined
+        }
+        emptyText="No jobs yet"
       />
     </Section>
   );


### PR DESCRIPTION
Closes #7 (final slice). The typed tables, actions, and auto-refresh already shipped (#59, #60); this fills in the thin per-kind Overview panels with the triage-relevant detail. All test-first.

## What's added

- **Job** — started / completed timestamps + **duration** (new `durationBetween` helper); a running job shows elapsed time. (Failure *reason* already surfaces via the generic conditions table, so no duplication.)
- **CronJob** — last-schedule time, **history limits** (kept success/failure), and a **Recent Jobs** table (`CronJobJobs`) listing the CronJob's *owned* Jobs — this closes the CronJob → Jobs relation properly (previously only *active* jobs were shown).
- **StatefulSet** — governing service, update strategy **with partition**, volume claim templates.
- **DaemonSet** — update strategy (`updateStrategyText` helper).
- **Palette** — the four kinds already navigate + search; added a test locking that in (§8).

## A caught bug worth calling out

`CronJobJobs` was referenced in `ResourceOverview` but its import was missing. It passed all tests because the `WorkloadRelations` test mock stubs `CronJobJobs`, and **CI runs no typecheck** — the frontend job runs `pnpm build` (esbuild transpiles without type-checking) and `pnpm test` (mocked), so nothing flags a missing import that's mocked. It only surfaced at runtime. Fixed here.

**Follow-up recommended:** add a `tsc --noEmit` gate to CI. It currently exits non-zero only on a pre-existing config nit (`@types/node` in the `types` list isn't installed under `apps/desktop`), so that's a small separate PR — but without it, this class of bug ships green.

## Verification
287 frontend tests + full Rust suite green, coverage above both gates, `tsc` clean on real code, production build clean.