### PR TITLE
fix: size the window to a comfortable default, clamped to the screen

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -20,6 +20,36 @@ use watch::{start_resource_watch, stop_watch, WatchManager};
 
 pub use capabilities::build_registry;
 
+/// Size the main window to a comfortable default, clamped to the screen it
+/// opens on: on a large display it stays at the preferred ~16" size (centered),
+/// on a smaller display it shrinks to fit the available work area. A margin
+/// keeps it clear of the menu bar / taskbar / dock.
+#[cfg(desktop)]
+fn size_main_window(app: &tauri::App) {
+    use tauri::{LogicalSize, Manager};
+
+    // Preferred size — the "16-inch" window shown on big screens.
+    const PREF_W: f64 = 1440.0;
+    const PREF_H: f64 = 900.0;
+    // Leave room for OS chrome so the window never sits edge-to-edge.
+    const MARGIN: f64 = 80.0;
+
+    let Some(window) = app.get_webview_window("main") else {
+        return;
+    };
+    let Ok(Some(monitor)) = window.current_monitor() else {
+        return;
+    };
+    let scale = monitor.scale_factor();
+    let avail_w = monitor.size().width as f64 / scale - MARGIN;
+    let avail_h = monitor.size().height as f64 / scale - MARGIN;
+
+    let width = PREF_W.min(avail_w).max(640.0);
+    let height = PREF_H.min(avail_h).max(480.0);
+    let _ = window.set_size(LogicalSize::new(width, height));
+    let _ = window.center();
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // The SRELENS_TIMEOUT_SECS override is applied in `main()` before dispatch,
@@ -45,6 +75,8 @@ pub fn run() {
                         .build(),
                 )?;
             }
+            #[cfg(desktop)]
+            size_main_window(app);
             Ok(())
         })
         .manage(AppRegistry(registry))

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -14,8 +14,11 @@
     "windows": [
       {
         "title": "srelens",
-        "width": 800,
-        "height": 600,
+        "width": 1440,
+        "height": 900,
+        "minWidth": 960,
+        "minHeight": 640,
+        "center": true,
         "resizable": true,
         "fullscreen": false
       }


### PR DESCRIPTION
The app launched at 800x600 — too cramped for the browser/detail split layout.

Now it opens at a preferred **~16-inch size (1440×900)** but **clamped to the display it lands on**:
- **Large monitor** (24"+): shows the centered 1440×900 window (not fullscreen).
- **Smaller laptop**: shrinks to fit the available work area (minus a margin for the menu bar / dock), never larger than the screen.

Implementation: static config seeds 1440×900 with a 960×640 minimum and centering; a setup-time pass in `lib.rs` queries the current monitor via `current_monitor()`, converts to logical size by scale factor, and clamps the preferred size to the available area. Window-state persistence is separate (roadmap #33), so this applies on each launch. Builds clean.