### PR TITLE
feat(config): edit ConfigMap and Secret values in place from the overview

### DIFF
--- a/apps/desktop/src-tauri/src/capabilities.rs
+++ b/apps/desktop/src-tauri/src/capabilities.rs
@@ -91,6 +91,7 @@ pub fn build_registry_with(cache: Arc<ClientCache>) -> Registry {
     reg.register(srelens_kube::actions::delete_resource_capability(cache.clone()));
     reg.register(srelens_kube::actions::scale_capability(cache.clone()));
     reg.register(srelens_kube::actions::rollout_restart_capability(cache.clone()));
+    reg.register(srelens_kube::actions::update_config_data_capability(cache.clone()));
     reg.register(srelens_kube::actions::cordon_node_capability(cache.clone()));
     reg.register(srelens_kube::actions::drain_node_capability(cache.clone()));
     reg.register(srelens_kube::events::list_events_capability(cache.clone()));

--- a/apps/desktop/src/components/ResourceOverview.test.tsx
+++ b/apps/desktop/src/components/ResourceOverview.test.tsx
@@ -9,6 +9,8 @@ vi.mock("./WorkloadRelations", () => ({
   CronJobJobs: () => <div data-testid="cronjob-jobs" />,
 }));
 vi.mock("./MetricsPanel", () => ({ MetricsPanel: () => <div data-testid="metrics" /> }));
+const { updateConfigDataMock } = vi.hoisted(() => ({ updateConfigDataMock: vi.fn() }));
+vi.mock("../lib/actions", () => ({ updateConfigData: updateConfigDataMock }));
 
 import {
   ResourceOverview,
@@ -277,7 +279,7 @@ describe("ObjectDetail (workload kinds)", () => {
 });
 
 describe("ObjectDetail (ConfigMap / Secret)", () => {
-  it("shows ConfigMap values inline", () => {
+  it("shows ConfigMap values in editable fields", () => {
     const cm: K8sObject = {
       kind: "ConfigMap",
       metadata: { name: "cm", namespace: "default" },
@@ -285,20 +287,38 @@ describe("ObjectDetail (ConfigMap / Secret)", () => {
     };
     render(<ObjectDetail kind="ConfigMap" obj={cm} now={NOW} />);
     expect(screen.getByText("app.conf")).toBeDefined();
-    expect(screen.getByText("level=info")).toBeDefined();
+    expect((screen.getByLabelText("Value for app.conf") as HTMLTextAreaElement).value).toBe("level=info");
   });
 
-  it("masks Secret values until revealed (base64-decoded)", () => {
+  it("masks Secret values until revealed for editing (base64-decoded)", () => {
     const secret: K8sObject = {
       kind: "Secret",
       metadata: { name: "s", namespace: "default" },
       data: { token: "aGVsbG8=" }, // "hello"
     };
     render(<ObjectDetail kind="Secret" obj={secret} now={NOW} />);
-    expect(screen.getByText("••••••••")).toBeDefined();
-    expect(screen.queryByText("hello")).toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: "Reveal" }));
-    expect(screen.getByText("hello")).toBeDefined();
+    // No editable field is exposed until the user reveals the key.
+    expect(screen.queryByLabelText("Value for token")).toBeNull();
+    expect(screen.queryByDisplayValue("hello")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /Reveal/ }));
+    expect((screen.getByLabelText("Value for token") as HTMLTextAreaElement).value).toBe("hello");
+  });
+
+  it("saves an edited ConfigMap value via updateConfigData", async () => {
+    updateConfigDataMock.mockResolvedValue({ ok: true });
+    const cm: K8sObject = {
+      kind: "ConfigMap",
+      metadata: { name: "web-config", namespace: "default" },
+      data: { "app.conf": "level=info" },
+    };
+    render(<ObjectDetail kind="ConfigMap" obj={cm} now={NOW} context="kind-dev" />);
+    fireEvent.change(screen.getByLabelText("Value for app.conf"), { target: { value: "level=debug" } });
+    fireEvent.click(await screen.findByRole("button", { name: "Save" }));
+    await waitFor(() =>
+      expect(updateConfigDataMock).toHaveBeenCalledWith("kind-dev", "ConfigMap", "default", "web-config", {
+        "app.conf": "level=debug",
+      }),
+    );
   });
 
   it("shows parsed TLS certificate metadata without revealing material", async () => {

--- a/apps/desktop/src/components/ResourceOverview.tsx
+++ b/apps/desktop/src/components/ResourceOverview.tsx
@@ -1,11 +1,13 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { ArrowLeftRight, ChevronDown, ChevronUp } from "lucide-react";
 import type { X509Certificate } from "@peculiar/x509";
 import { getObject, type K8sObject } from "../lib/manifest";
+import { updateConfigData } from "../lib/actions";
 import {
   Spinner,
   StatusPill,
   Badge,
+  Button,
   Table,
   IconButton,
   type StatusKind,
@@ -1523,10 +1525,20 @@ function DockerSecretBody({ obj }: { obj: K8sObject }) {
   );
 }
 
-function GeneralSecretBody({ obj }: { obj: K8sObject }) {
+function GeneralSecretBody({
+  obj,
+  context = "",
+  onEdited,
+}: {
+  obj: K8sObject;
+  context?: string;
+  onEdited?: () => void;
+}) {
+  const meta = asRecord(obj.metadata);
   const data = asRecord(obj.data) as Record<string, string>;
   const keys = Object.keys(data);
   const totalBytes = Object.values(data).reduce((total, value) => total + decodedByteLength(str(value)), 0);
+  const immutable = obj.immutable === true;
   return (
     <>
       <Section title="Secret summary">
@@ -1535,37 +1547,170 @@ function GeneralSecretBody({ obj }: { obj: K8sObject }) {
             ["Type", str(obj.type) || "Opaque"],
             ["Keys", plural(keys.length, "key")],
             ["Decoded size", formatBytes(totalBytes)],
-            ["Immutable", obj.immutable === true ? "Yes" : "No"],
+            ["Immutable", immutable ? "Yes" : "No"],
           ]}
         />
       </Section>
-      <SecretData data={data} />
+      <Section title={`Data (${plural(keys.length, "key")})`}>
+        {/* Immutable Secrets can't be edited; render read-only by withholding context. */}
+        <ConfigDataEditor
+          context={immutable ? "" : context}
+          kind="Secret"
+          namespace={str(meta.namespace)}
+          name={str(meta.name)}
+          data={data}
+          secret
+          onSaved={onEdited}
+        />
+      </Section>
     </>
   );
 }
 
-function SecretBody({ obj }: { obj: K8sObject }) {
+function SecretBody({
+  obj,
+  context = "",
+  onEdited,
+}: {
+  obj: K8sObject;
+  context?: string;
+  onEdited?: () => void;
+}) {
   const type = str(obj.type) || "Opaque";
   if (type === "kubernetes.io/tls") return <TlsSecretBody obj={obj} />;
   if (type === "kubernetes.io/dockerconfigjson" || type === "kubernetes.io/dockercfg")
     return <DockerSecretBody obj={obj} />;
-  return <GeneralSecretBody obj={obj} />;
+  return <GeneralSecretBody obj={obj} context={context} onEdited={onEdited} />;
 }
 
-function ConfigBody({ obj }: { obj: K8sObject }) {
+/**
+ * Editable key/value data for ConfigMaps and Secrets. Secret values are masked
+ * until the user reveals a key (which decodes it for editing); Save only sends
+ * the keys that actually changed, as plaintext (the backend patches
+ * ConfigMap `data` / Secret `stringData`, so the apiserver handles encoding).
+ * Editing is only enabled when a `context` is available (i.e. the live detail).
+ */
+export function ConfigDataEditor({
+  context,
+  kind,
+  namespace,
+  name,
+  data,
+  secret,
+  onSaved,
+}: {
+  context: string;
+  kind: string;
+  namespace: string;
+  name: string;
+  data: Record<string, string>;
+  secret: boolean;
+  onSaved?: () => void;
+}) {
+  // Original plaintext per key (Secret values decoded once for editing).
+  const initial = useMemo(() => {
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(data)) out[k] = secret ? decodeBase64(str(v)) : str(v);
+    return out;
+  }, [data, secret]);
+
+  const [edited, setEdited] = useState<Record<string, string>>({});
+  const [revealed, setRevealed] = useState<Record<string, boolean>>({});
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState("");
+
+  const keys = Object.keys(initial);
+  const valueOf = (k: string) => edited[k] ?? initial[k];
+  const changedKeys = keys.filter((k) => edited[k] !== undefined && edited[k] !== initial[k]);
+  const editable = context !== "";
+
+  async function save() {
+    setBusy(true);
+    setErr("");
+    const patch = Object.fromEntries(changedKeys.map((k) => [k, edited[k]]));
+    const r = await updateConfigData(context, kind, namespace, name, patch);
+    setBusy(false);
+    if (r.error) {
+      setErr(r.error);
+      return;
+    }
+    setEdited({});
+    onSaved?.();
+  }
+
+  if (keys.length === 0) return <span className="fl-detail-empty">No data</span>;
+
+  return (
+    <div className="flex flex-col gap-3">
+      {keys.map((k) => {
+        const shown = !secret || revealed[k];
+        return (
+          <div key={k} className="fl-secret-entry">
+            <div className="fl-secret-entry__header">
+              <span className="fl-mono">{k}</span>
+              {secret && (
+                <button
+                  type="button"
+                  className="fl-secret-entry__toggle"
+                  onClick={() => setRevealed((r) => ({ ...r, [k]: !r[k] }))}
+                >
+                  {revealed[k] ? "Hide" : "Reveal"}
+                </button>
+              )}
+            </div>
+            {shown ? (
+              <textarea
+                className="fl-config-editor__value"
+                aria-label={`Value for ${k}`}
+                value={valueOf(k)}
+                readOnly={!editable}
+                onChange={(e) => setEdited((ed) => ({ ...ed, [k]: e.target.value }))}
+                rows={valueOf(k).split("\n").length > 1 ? 4 : 1}
+              />
+            ) : (
+              <pre className="fl-secret-entry__value">••••••••</pre>
+            )}
+          </div>
+        );
+      })}
+      {editable && changedKeys.length > 0 && (
+        <div className="fl-config-editor__actions">
+          <Button size="sm" onClick={() => void save()} busy={busy}>
+            Save
+          </Button>
+          <Button size="sm" variant="ghost" onClick={() => setEdited({})} disabled={busy}>
+            Reset
+          </Button>
+        </div>
+      )}
+      {err && <p style={{ color: "var(--fl-color-danger)" }}>Error: {err}</p>}
+    </div>
+  );
+}
+
+function ConfigBody({
+  obj,
+  context = "",
+  onEdited,
+}: {
+  obj: K8sObject;
+  context?: string;
+  onEdited?: () => void;
+}) {
+  const meta = asRecord(obj.metadata);
   const data = asRecord(obj.data) as Record<string, string>;
   const keys = Object.keys(data);
   return (
     <Section title={`Data (${plural(keys.length, "key")})`}>
-      {keys.length === 0 ? (
-        <span className="fl-detail-empty">No data</span>
-      ) : (
-        <div className="flex flex-col gap-3">
-          {keys.map((k) => (
-            <ConfigDataEntry key={k} name={k} value={str(data[k])} secret={false} />
-          ))}
-        </div>
-      )}
+      <ConfigDataEditor
+        context={context}
+        kind="ConfigMap"
+        namespace={str(meta.namespace)}
+        name={str(meta.name)}
+        data={data}
+        secret={false}
+        onSaved={onEdited}
+      />
     </Section>
   );
 }
@@ -2157,12 +2302,14 @@ function KindBody({
   obj,
   context = "",
   now = Date.now(),
+  onEdited,
   onOpenResource,
 }: {
   kind: string;
   obj: K8sObject;
   context?: string;
   now?: number;
+  onEdited?: () => void;
   onOpenResource?: OpenResource;
 }) {
   switch (kind) {
@@ -2177,9 +2324,9 @@ function KindBody({
     case "CronJob":
       return <CronJobBody obj={obj} now={now} context={context} onOpenResource={onOpenResource} />;
     case "ConfigMap":
-      return <ConfigBody obj={obj} />;
+      return <ConfigBody obj={obj} context={context} onEdited={onEdited} />;
     case "Secret":
-      return <SecretBody obj={obj} />;
+      return <SecretBody obj={obj} context={context} onEdited={onEdited} />;
     case "PersistentVolumeClaim":
       return <PvcBody obj={obj} onOpenResource={onOpenResource} />;
     case "PersistentVolume":
@@ -2249,12 +2396,14 @@ function GenericDetail({
   obj,
   now,
   context = "",
+  onEdited,
   onOpenResource,
 }: {
   kind: string;
   obj: K8sObject;
   now: number;
   context?: string;
+  onEdited?: () => void;
   onOpenResource?: OpenResource;
 }) {
   const meta = asRecord(obj.metadata);
@@ -2302,7 +2451,7 @@ function GenericDetail({
         <Chips map={meta.annotations as Record<string, string>} />
       </Section>
 
-      <KindBody kind={kind} obj={obj} context={context} now={now} onOpenResource={onOpenResource} />
+      <KindBody kind={kind} obj={obj} context={context} now={now} onEdited={onEdited} onOpenResource={onOpenResource} />
 
       {context && namespace && Object.keys(podSelector).length > 0 && (
         <ManagedPods
@@ -2324,12 +2473,14 @@ export function ObjectDetail({
   obj,
   now,
   context = "",
+  onEdited,
   onOpenResource,
 }: {
   kind: string;
   obj: K8sObject;
   now: number;
   context?: string;
+  onEdited?: () => void;
   onOpenResource?: OpenResource;
 }) {
   const meta = asRecord(obj.metadata);
@@ -2375,6 +2526,7 @@ export function ObjectDetail({
         obj={obj}
         now={now}
         context={context}
+        onEdited={onEdited}
         onOpenResource={onOpenResource}
       />
     </>
@@ -2410,6 +2562,8 @@ export function ResourceOverview({
 }) {
   const [obj, setObj] = useState<K8sObject | null>(null);
   const [error, setError] = useState("");
+  // Bumped locally after an in-place edit saves, to re-fetch the fresh object.
+  const [editReload, setEditReload] = useState(0);
 
   useEffect(() => {
     let active = true;
@@ -2423,7 +2577,7 @@ export function ResourceOverview({
     return () => {
       active = false;
     };
-  }, [context, kind, namespace, name, getObjectFn, reloadKey]);
+  }, [context, kind, namespace, name, getObjectFn, reloadKey, editReload]);
 
   if (error) return <p style={{ color: "var(--fl-color-danger)" }}>Error: {error}</p>;
   if (obj === null) return <Spinner label="Loading details" />;
@@ -2433,6 +2587,7 @@ export function ResourceOverview({
       obj={obj}
       now={Date.now()}
       context={context}
+      onEdited={() => setEditReload((n) => n + 1)}
       onOpenResource={onOpenResource}
     />
   );

--- a/apps/desktop/src/lib/actions.test.ts
+++ b/apps/desktop/src/lib/actions.test.ts
@@ -5,6 +5,7 @@ import {
   rolloutRestart,
   cronjobSetSuspend,
   cronjobTriggerNow,
+  updateConfigData,
 } from "./actions";
 
 describe("resource actions", () => {
@@ -58,6 +59,18 @@ describe("resource actions", () => {
       namespace: "ops",
       name: "nightly",
       suspend: true,
+    });
+  });
+
+  it("updateConfigData passes kind/namespace/name and the edited data map", async () => {
+    const invoke = vi.fn().mockResolvedValue({ ok: true });
+    await updateConfigData("c", "ConfigMap", "default", "web-config", { "app.conf": "level=debug" }, invoke);
+    expect(invoke).toHaveBeenCalledWith("k8s.updateConfigData", {
+      context: "c",
+      kind: "ConfigMap",
+      namespace: "default",
+      name: "web-config",
+      data: { "app.conf": "level=debug" },
     });
   });
 

--- a/apps/desktop/src/lib/actions.ts
+++ b/apps/desktop/src/lib/actions.ts
@@ -52,6 +52,23 @@ export function rolloutRestart(
   return run("k8s.rolloutRestart", { context, kind, namespace, name }, invoke);
 }
 
+/**
+ * Update ConfigMap/Secret values in place via `k8s.updateConfigData`. `data`
+ * holds plaintext values for the keys being changed; other keys are untouched.
+ * For Secrets the backend writes via `stringData`, so the caller passes
+ * plaintext and the apiserver base64-encodes it.
+ */
+export function updateConfigData(
+  context: string,
+  kind: string,
+  namespace: string,
+  name: string,
+  data: Record<string, string>,
+  invoke: Invoker = invokeCapability,
+): Promise<ActionResult> {
+  return run("k8s.updateConfigData", { context, kind, namespace, name, data }, invoke);
+}
+
 /** Cordon/uncordon a node via `k8s.cordonNode`. */
 export function cordonNode(
   context: string,

--- a/apps/desktop/src/ui/styles.css
+++ b/apps/desktop/src/ui/styles.css
@@ -1398,6 +1398,28 @@ body {
   word-break: break-all;
   white-space: pre-wrap;
 }
+.fl-config-editor__value {
+  width: 100%;
+  margin: 0;
+  padding: 8px 10px;
+  resize: vertical;
+  border: 1px solid var(--fl-color-border-faint);
+  border-radius: var(--fl-radius-md);
+  background: var(--fl-color-surface);
+  color: var(--fl-color-text);
+  font-family: var(--fl-font-mono, ui-monospace, monospace);
+  font-size: 12px;
+  line-height: 1.5;
+}
+.fl-config-editor__value:read-only {
+  border-color: transparent;
+  background: transparent;
+  color: var(--fl-color-text-muted);
+}
+.fl-config-editor__actions {
+  display: flex;
+  gap: 8px;
+}
 /* Monospace inline values (names, images, IPs). */
 .fl-mono {
   font-family: var(--fl-font-mono, ui-monospace, monospace);

--- a/crates/kube/src/actions.rs
+++ b/crates/kube/src/actions.rs
@@ -116,6 +116,66 @@ pub struct ActionOut {
     pub ok: bool,
 }
 
+/// Build the merge-patch body for an in-place ConfigMap/Secret data edit.
+///
+/// ConfigMap values are plain strings under `data`. Secret values go under
+/// `stringData` (write-only) so the apiserver base64-encodes them — the UI
+/// therefore never has to encode, and no existing values are touched beyond the
+/// keys provided (a merge patch only updates the given keys).
+pub(crate) fn build_config_patch(
+    kind: &str,
+    data: &std::collections::BTreeMap<String, String>,
+) -> Result<serde_json::Value, String> {
+    let field = match kind {
+        "ConfigMap" => "data",
+        "Secret" => "stringData",
+        other => return Err(format!("in-place data edit not supported for kind: {other}")),
+    };
+    Ok(json!({ field: data }))
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct UpdateConfigDataIn {
+    pub context: String,
+    /// "ConfigMap" or "Secret".
+    pub kind: String,
+    pub namespace: String,
+    pub name: String,
+    /// Keys to set to new (plaintext) values; other keys are left untouched.
+    pub data: std::collections::BTreeMap<String, String>,
+}
+
+/// `k8s.updateConfigData` — edit ConfigMap/Secret values in place via a merge
+/// patch. Requires confirmation.
+pub fn update_config_data_capability(cache: Arc<ClientCache>) -> Capability {
+    Capability::typed::<UpdateConfigDataIn, ActionOut, _, _>(
+        "k8s.updateConfigData",
+        "update ConfigMap or Secret values in place (merge patch)",
+        Annotations {
+            read_only: false,
+            destructive: false,
+            requires_confirm: true,
+        },
+        move |input: UpdateConfigDataIn| {
+            let cache = cache.clone();
+            async move {
+                let patch = build_config_patch(&input.kind, &input.data)
+                    .map_err(CapabilityError::Handler)?;
+                let client = cache.get(&input.context).await.map_err(CapabilityError::Handler)?;
+                let api = dynamic_api(client, &input.kind, &input.namespace)?;
+                tokio::time::timeout(
+                    request_timeout(),
+                    api.patch(&input.name, &PatchParams::default(), &Patch::Merge(&patch)),
+                )
+                .await
+                .map_err(|_| CapabilityError::Handler("update config data timed out".into()))?
+                .map_err(|e| CapabilityError::Handler(e.to_string()))?;
+                Ok(ActionOut { name: input.name, ok: true })
+            }
+        },
+    )
+}
+
 /// `k8s.deleteResource` — delete any supported resource. Destructive.
 pub fn delete_resource_capability(cache: Arc<ClientCache>) -> Capability {
     Capability::typed::<DeleteResourceIn, ActionOut, _, _>(
@@ -345,6 +405,31 @@ mod tests {
 
     fn cache() -> Arc<ClientCache> {
         ClientCache::new(PathBuf::from("/x"))
+    }
+
+    #[test]
+    fn config_patch_uses_data_for_configmap_and_stringdata_for_secret() {
+        let mut data = std::collections::BTreeMap::new();
+        data.insert("app.conf".to_string(), "level=debug".to_string());
+        let cm = build_config_patch("ConfigMap", &data).unwrap();
+        assert_eq!(cm, serde_json::json!({ "data": { "app.conf": "level=debug" } }));
+        // Secret uses stringData so the apiserver base64-encodes it; the UI sends plaintext.
+        let sec = build_config_patch("Secret", &data).unwrap();
+        assert_eq!(sec, serde_json::json!({ "stringData": { "app.conf": "level=debug" } }));
+    }
+
+    #[test]
+    fn config_patch_rejects_unsupported_kinds() {
+        let data = std::collections::BTreeMap::new();
+        assert!(build_config_patch("Pod", &data).is_err());
+    }
+
+    #[test]
+    fn update_config_data_requires_confirm() {
+        let cap = update_config_data_capability(cache());
+        assert_eq!(cap.id, "k8s.updateConfigData");
+        assert!(cap.annotations.requires_confirm);
+        assert!(!cap.annotations.read_only);
     }
 
     #[test]


### PR DESCRIPTION
Adds in-place editing of ConfigMap and Secret values directly from the detail Overview page (requested). All test-first.

## Backend (`crates/kube`)
- **`k8s.updateConfigData`** — merge-patches ConfigMap `data` / Secret `stringData`. Using `stringData` means the apiserver base64-encodes, so **the UI only ever handles plaintext** and only the *changed* keys are sent (a merge patch leaves the rest untouched). `requires_confirm`; registered → auto-exposed as an MCP tool (completeness green).
- Pure `build_config_patch` unit-tested: `data` for ConfigMap, `stringData` for Secret, error for unsupported kinds.

## Frontend
- `lib/actions.updateConfigData`.
- **`ConfigDataEditor`** used by `ConfigBody` + `GeneralSecretBody`:
  - ConfigMap values are editable textareas; a **Save** (and Reset) appears only when something changed.
  - **Secret values stay masked until "Reveal"** (which decodes for editing) — never shown otherwise; the security property from the read-only view is preserved.
  - **Immutable Secrets render read-only** (no context passed → no Save).
  - Editing is only enabled where a `context` exists (the live detail); pure `ObjectDetail` previews stay read-only.
- After a successful save the overview **re-fetches** the object (local reload) so the panel and its summary reflect the new values.

## Verification
9 Rust + 289 frontend tests, coverage above gates, `tsc` clean, production build clean, MCP completeness green.