### PR TITLE
feat(secrets): gated getSecret read, redact getObject, copy button + quota usage bars

### DIFF
--- a/apps/desktop/src-tauri/src/capabilities.rs
+++ b/apps/desktop/src-tauri/src/capabilities.rs
@@ -110,6 +110,7 @@ pub fn build_registry_with(cache: Arc<ClientCache>) -> Registry {
     reg.register(srelens_kube::nodes::list_nodes_capability(cache.clone()));
     reg.register(srelens_kube::manifest::get_manifest_capability(cache.clone()));
     reg.register(srelens_kube::manifest::get_object_capability(cache.clone()));
+    reg.register(srelens_kube::secrets::get_secret_capability(cache.clone()));
     reg.register(srelens_kube::manifest::apply_manifest_capability(cache.clone()));
     reg.register(srelens_kube::manifest::validate_manifest_capability(cache.clone()));
     reg.register(srelens_kube::schema::open_api_schema_capability(cache.clone()));

--- a/apps/desktop/src/components/ResourceOverview.test.tsx
+++ b/apps/desktop/src/components/ResourceOverview.test.tsx
@@ -11,12 +11,18 @@ vi.mock("./WorkloadRelations", () => ({
 vi.mock("./MetricsPanel", () => ({ MetricsPanel: () => <div data-testid="metrics" /> }));
 const { updateConfigDataMock } = vi.hoisted(() => ({ updateConfigDataMock: vi.fn() }));
 vi.mock("../lib/actions", () => ({ updateConfigData: updateConfigDataMock }));
+const { getSecretMock } = vi.hoisted(() => ({ getSecretMock: vi.fn() }));
+vi.mock("../lib/manifest", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/manifest")>()),
+  getSecret: getSecretMock,
+}));
 
 import {
   ResourceOverview,
   ObjectDetail,
   ageFromTimestamp,
   containerLastRestartTime,
+  parseQuantity,
 } from "./ResourceOverview";
 import type { K8sObject } from "../lib/manifest";
 
@@ -34,6 +40,19 @@ describe("ageFromTimestamp", () => {
   it("returns a dash for missing or invalid input", () => {
     expect(ageFromTimestamp(undefined, NOW)).toBe("—");
     expect(ageFromTimestamp("not-a-date", NOW)).toBe("—");
+  });
+});
+
+describe("parseQuantity", () => {
+  it("parses plain, milli, binary, and decimal suffixes", () => {
+    expect(parseQuantity("4")).toBe(4);
+    expect(parseQuantity("500m")).toBe(0.5);
+    expect(parseQuantity("2Gi")).toBe(2 * 2 ** 30);
+    expect(parseQuantity("1G")).toBe(1e9);
+  });
+  it("returns null for unparseable input", () => {
+    expect(parseQuantity("")).toBeNull();
+    expect(parseQuantity("abc")).toBeNull();
   });
 });
 
@@ -290,18 +309,23 @@ describe("ObjectDetail (ConfigMap / Secret)", () => {
     expect((screen.getByLabelText("Value for app.conf") as HTMLTextAreaElement).value).toBe("level=info");
   });
 
-  it("masks Secret values until revealed for editing (base64-decoded)", () => {
+  it("fetches Secret values via getSecret and masks them until revealed", async () => {
+    // getObject redacts Secret data (values blank); getSecret is the gated path.
+    getSecretMock.mockResolvedValue({ data: { token: "aGVsbG8=" } }); // "hello"
     const secret: K8sObject = {
       kind: "Secret",
       metadata: { name: "s", namespace: "default" },
-      data: { token: "aGVsbG8=" }, // "hello"
+      data: { token: "" }, // redacted by getObject — key present, no value
     };
-    render(<ObjectDetail kind="Secret" obj={secret} now={NOW} />);
-    // No editable field is exposed until the user reveals the key.
+    render(<ObjectDetail kind="Secret" obj={secret} now={NOW} context="kind-dev" />);
+    await waitFor(() => expect(getSecretMock).toHaveBeenCalledWith("kind-dev", "default", "s"));
+    // No editable field or plaintext is exposed until the user reveals the key.
     expect(screen.queryByLabelText("Value for token")).toBeNull();
     expect(screen.queryByDisplayValue("hello")).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: /Reveal/ }));
-    expect((screen.getByLabelText("Value for token") as HTMLTextAreaElement).value).toBe("hello");
+    await waitFor(() =>
+      expect((screen.getByLabelText("Value for token") as HTMLTextAreaElement).value).toBe("hello"),
+    );
   });
 
   it("saves an edited ConfigMap value via updateConfigData", async () => {
@@ -387,14 +411,19 @@ describe("ObjectDetail (more kinds)", () => {
     expect(screen.getByText("get, list")).toBeDefined();
   });
 
-  it("renders ResourceQuota used/hard", () => {
+  it("renders ResourceQuota used/hard with a usage bar", () => {
     const rq: K8sObject = {
       kind: "ResourceQuota",
       metadata: { name: "q", namespace: "default" },
-      status: { hard: { "limits.cpu": "4" }, used: { "limits.cpu": "1" } },
+      status: { hard: { "limits.cpu": "4", "requests.memory": "8Gi" }, used: { "limits.cpu": "1", "requests.memory": "2Gi" } },
     };
     render(<ObjectDetail kind="ResourceQuota" obj={rq} now={NOW} />);
     expect(screen.getByText("limits.cpu")).toBeDefined();
+    // 1/4 cpu and 2Gi/8Gi memory → both 25%.
+    const bars = screen.getAllByRole("progressbar");
+    expect(bars).toHaveLength(2);
+    expect(bars[0].getAttribute("aria-valuenow")).toBe("25");
+    expect(bars[1].getAttribute("aria-valuenow")).toBe("25");
   });
 
   it("offers an inline port-forward on Service ports when a context is given", () => {

--- a/apps/desktop/src/components/ResourceOverview.tsx
+++ b/apps/desktop/src/components/ResourceOverview.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { ArrowLeftRight, ChevronDown, ChevronUp } from "lucide-react";
 import type { X509Certificate } from "@peculiar/x509";
-import { getObject, type K8sObject } from "../lib/manifest";
+import { getObject, getSecret, type K8sObject } from "../lib/manifest";
 import { updateConfigData } from "../lib/actions";
 import {
   Spinner,
@@ -1389,8 +1389,7 @@ function privateKeyType(pem: string): string {
   return pem ? "Unrecognized format" : "Missing";
 }
 
-function TlsSecretBody({ obj }: { obj: K8sObject }) {
-  const data = asRecord(obj.data) as Record<string, string>;
+function TlsSecretBody({ data }: { data: Record<string, string> }) {
   const certificate = decodeBase64(str(data["tls.crt"]));
   const privateKey = decodeBase64(str(data["tls.key"]));
   const certificateCount = certificate.match(/-----BEGIN CERTIFICATE-----/g)?.length ?? 0;
@@ -1494,9 +1493,7 @@ function dockerRegistries(data: Record<string, string>, type: string): DockerReg
   }
 }
 
-function DockerSecretBody({ obj }: { obj: K8sObject }) {
-  const data = asRecord(obj.data) as Record<string, string>;
-  const type = str(obj.type);
+function DockerSecretBody({ data, type }: { data: Record<string, string>; type: string }) {
   const configKey = type === "kubernetes.io/dockercfg" ? ".dockercfg" : ".dockerconfigjson";
   const registries = dockerRegistries(data, type);
   const columns: Column<DockerRegistryRow>[] = [
@@ -1525,19 +1522,47 @@ function DockerSecretBody({ obj }: { obj: K8sObject }) {
   );
 }
 
+/**
+ * Fetch a Secret's real (base64) values via the gated `getSecret`. `getObject`
+ * redacts Secret data, so this is how the detail views get the actual values.
+ * Falls back to the redacted keys (blank values) while loading or when there's
+ * no context (a static preview). Values sit in memory but stay masked in the
+ * DOM until the user reveals a key.
+ */
+function useSecretData(
+  context: string,
+  namespace: string,
+  name: string,
+  redacted: Record<string, string>,
+): Record<string, string> {
+  const [data, setData] = useState<Record<string, string> | null>(null);
+  useEffect(() => {
+    setData(null);
+    if (!context) return;
+    let active = true;
+    void getSecret(context, namespace, name).then((r) => {
+      if (active && r.data) setData(r.data);
+    });
+    return () => {
+      active = false;
+    };
+  }, [context, namespace, name]);
+  return data ?? redacted;
+}
+
 function GeneralSecretBody({
   obj,
+  data,
   context = "",
   onEdited,
 }: {
   obj: K8sObject;
+  data: Record<string, string>;
   context?: string;
   onEdited?: () => void;
 }) {
   const meta = asRecord(obj.metadata);
-  const data = asRecord(obj.data) as Record<string, string>;
   const keys = Object.keys(data);
-  const totalBytes = Object.values(data).reduce((total, value) => total + decodedByteLength(str(value)), 0);
   const immutable = obj.immutable === true;
   return (
     <>
@@ -1546,7 +1571,6 @@ function GeneralSecretBody({
           pairs={[
             ["Type", str(obj.type) || "Opaque"],
             ["Keys", plural(keys.length, "key")],
-            ["Decoded size", formatBytes(totalBytes)],
             ["Immutable", immutable ? "Yes" : "No"],
           ]}
         />
@@ -1576,11 +1600,14 @@ function SecretBody({
   context?: string;
   onEdited?: () => void;
 }) {
+  const meta = asRecord(obj.metadata);
   const type = str(obj.type) || "Opaque";
-  if (type === "kubernetes.io/tls") return <TlsSecretBody obj={obj} />;
+  const redacted = asRecord(obj.data) as Record<string, string>;
+  const data = useSecretData(context, str(meta.namespace), str(meta.name), redacted);
+  if (type === "kubernetes.io/tls") return <TlsSecretBody data={data} />;
   if (type === "kubernetes.io/dockerconfigjson" || type === "kubernetes.io/dockercfg")
-    return <DockerSecretBody obj={obj} />;
-  return <GeneralSecretBody obj={obj} context={context} onEdited={onEdited} />;
+    return <DockerSecretBody data={data} type={type} />;
+  return <GeneralSecretBody obj={obj} data={data} context={context} onEdited={onEdited} />;
 }
 
 /**
@@ -1603,26 +1630,53 @@ export function ConfigDataEditor({
   kind: string;
   namespace: string;
   name: string;
+  /** Plaintext-or-base64 values by key. For Secrets these are the real values
+   * fetched via the gated `getSecret` (see SecretBody); base64 here. */
   data: Record<string, string>;
   secret: boolean;
   onSaved?: () => void;
 }) {
-  // Original plaintext per key (Secret values decoded once for editing).
-  const initial = useMemo(() => {
-    const out: Record<string, string> = {};
-    for (const [k, v] of Object.entries(data)) out[k] = secret ? decodeBase64(str(v)) : str(v);
-    return out;
-  }, [data, secret]);
-
+  // Baseline plaintext per key (Secret values decoded for editing).
+  const [baseline, setBaseline] = useState<Record<string, string>>({});
   const [edited, setEdited] = useState<Record<string, string>>({});
   const [revealed, setRevealed] = useState<Record<string, boolean>>({});
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState("");
+  const [copied, setCopied] = useState<string | null>(null);
 
-  const keys = Object.keys(initial);
-  const valueOf = (k: string) => edited[k] ?? initial[k];
-  const changedKeys = keys.filter((k) => edited[k] !== undefined && edited[k] !== initial[k]);
+  const keys = Object.keys(data);
+
+  // Baseline follows the data (Secret values arrive asynchronously via the
+  // gated fetch); updating it here must NOT clobber the user's reveal/edit
+  // state, so those reset only when the target object itself changes.
+  useEffect(() => {
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(data)) out[k] = secret ? decodeBase64(str(v)) : str(v);
+    setBaseline(out);
+  }, [data, secret]);
+
+  useEffect(() => {
+    setEdited({});
+    setRevealed({});
+  }, [context, kind, namespace, name]);
+
+  const valueOf = (k: string) => edited[k] ?? baseline[k] ?? "";
+  const changedKeys = keys.filter((k) => edited[k] !== undefined && edited[k] !== (baseline[k] ?? ""));
   const editable = context !== "";
+
+  function reveal(k: string) {
+    setRevealed((r) => ({ ...r, [k]: !r[k] }));
+  }
+
+  async function copy(k: string) {
+    try {
+      await navigator.clipboard?.writeText(valueOf(k));
+      setCopied(k);
+      setTimeout(() => setCopied((c) => (c === k ? null : c)), 1500);
+    } catch {
+      /* clipboard unavailable — ignore */
+    }
+  }
 
   async function save() {
     setBusy(true);
@@ -1648,15 +1702,27 @@ export function ConfigDataEditor({
           <div key={k} className="fl-secret-entry">
             <div className="fl-secret-entry__header">
               <span className="fl-mono">{k}</span>
-              {secret && (
-                <button
-                  type="button"
-                  className="fl-secret-entry__toggle"
-                  onClick={() => setRevealed((r) => ({ ...r, [k]: !r[k] }))}
-                >
-                  {revealed[k] ? "Hide" : "Reveal"}
-                </button>
-              )}
+              <span className="fl-config-editor__key-actions">
+                {shown && (
+                  <button
+                    type="button"
+                    className="fl-secret-entry__toggle"
+                    aria-label={`Copy value for ${k}`}
+                    onClick={() => void copy(k)}
+                  >
+                    {copied === k ? "Copied" : "Copy"}
+                  </button>
+                )}
+                {secret && (
+                  <button
+                    type="button"
+                    className="fl-secret-entry__toggle"
+                    onClick={() => void reveal(k)}
+                  >
+                    {revealed[k] ? "Hide" : "Reveal"}
+                  </button>
+                )}
+              </span>
             </div>
             {shown ? (
               <textarea
@@ -1926,6 +1992,29 @@ interface QuotaRow {
   hard: string;
 }
 
+/** Parse a Kubernetes quantity (e.g. "500m", "2Gi", "4") to a base-unit number. */
+export function parseQuantity(q: string): number | null {
+  const m = /^([0-9.]+)\s*([a-zA-Z]*)$/.exec((q ?? "").trim());
+  if (!m) return null;
+  const n = parseFloat(m[1]);
+  if (Number.isNaN(n)) return null;
+  const unit = m[2];
+  const binary: Record<string, number> = { Ki: 2 ** 10, Mi: 2 ** 20, Gi: 2 ** 30, Ti: 2 ** 40, Pi: 2 ** 50, Ei: 2 ** 60 };
+  const decimal: Record<string, number> = { k: 1e3, M: 1e6, G: 1e9, T: 1e12, P: 1e15, E: 1e18 };
+  if (unit === "") return n;
+  if (unit === "m") return n / 1000;
+  if (binary[unit]) return n * binary[unit];
+  if (decimal[unit]) return n * decimal[unit];
+  return n; // unknown unit — same on both sides, so the ratio still holds
+}
+
+function usagePercent(used: string, hard: string): number | null {
+  const u = parseQuantity(used);
+  const h = parseQuantity(hard);
+  if (u == null || h == null || h === 0) return null;
+  return Math.round((u / h) * 100);
+}
+
 function ResourceQuotaBody({ obj }: { obj: K8sObject }) {
   const status = asRecord(obj.status);
   const hard = asRecord(status.hard);
@@ -1940,6 +2029,28 @@ function ResourceQuotaBody({ obj }: { obj: K8sObject }) {
     { key: "resource", header: "Resource", render: (r) => <span className="fl-mono">{r.resource}</span> },
     { key: "used", header: "Used", render: (r) => r.used },
     { key: "hard", header: "Hard", render: (r) => r.hard },
+    {
+      key: "usage",
+      header: "Usage",
+      render: (r) => {
+        const pct = usagePercent(r.used, r.hard);
+        if (pct == null) return <span className="fl-detail-empty">—</span>;
+        const kind: StatusKind = pct >= 90 ? "danger" : pct >= 75 ? "warning" : "success";
+        return (
+          <div
+            className={`fl-usage-bar fl-usage-bar--${kind}`}
+            role="progressbar"
+            aria-label={`${r.resource} usage`}
+            aria-valuenow={pct}
+            aria-valuemin={0}
+            aria-valuemax={100}
+          >
+            <div className="fl-usage-bar__fill" style={{ width: `${Math.min(100, pct)}%` }} />
+            <span className="fl-usage-bar__label">{pct}%</span>
+          </div>
+        );
+      },
+    },
   ];
   return (
     <Section title="Quota">

--- a/apps/desktop/src/lib/manifest.ts
+++ b/apps/desktop/src/lib/manifest.ts
@@ -78,6 +78,30 @@ export async function getObject(
   }
 }
 
+/**
+ * Read a Secret's values via the dedicated, consent-gateable `k8s.getSecret`.
+ * `k8s.getObject` redacts Secret data, so this is the only structured path to
+ * the (base64-encoded) values — fetched lazily, only when the user reveals a
+ * key.
+ */
+export async function getSecret(
+  context: string,
+  namespace: string,
+  name: string,
+  invoke: Invoker = invokeCapability,
+): Promise<{ data?: Record<string, string>; error?: string }> {
+  try {
+    const out = await invoke<{ data: Record<string, string> }>("k8s.getSecret", {
+      context,
+      namespace,
+      name,
+    });
+    return { data: out.data };
+  } catch (e) {
+    return { error: String(e) };
+  }
+}
+
 /** Server-side apply a YAML manifest via `k8s.applyManifest`. */
 export async function applyManifest(
   context: string,

--- a/apps/desktop/src/ui/styles.css
+++ b/apps/desktop/src/ui/styles.css
@@ -1420,6 +1420,33 @@ body {
   display: flex;
   gap: 8px;
 }
+.fl-config-editor__key-actions {
+  display: inline-flex;
+  gap: 12px;
+}
+.fl-usage-bar {
+  position: relative;
+  min-width: 120px;
+  height: 18px;
+  border-radius: 4px;
+  overflow: hidden;
+  background: var(--fl-color-border-faint);
+}
+.fl-usage-bar__fill {
+  height: 100%;
+  background: var(--fl-color-accent);
+}
+.fl-usage-bar--warning .fl-usage-bar__fill { background: var(--fl-color-warning, #d9a441); }
+.fl-usage-bar--danger .fl-usage-bar__fill { background: var(--fl-color-danger, #e5484d); }
+.fl-usage-bar__label {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  color: var(--fl-color-text);
+}
 /* Monospace inline values (names, images, IPs). */
 .fl-mono {
   font-family: var(--fl-font-mono, ui-monospace, monospace);

--- a/crates/capability/src/annotations.rs
+++ b/crates/capability/src/annotations.rs
@@ -3,11 +3,17 @@ pub struct Annotations {
     pub read_only: bool,
     pub destructive: bool,
     pub requires_confirm: bool,
+    /// Reads or exposes sensitive material (e.g. Secret values). Lets an MCP
+    /// consent layer gate these separately from ordinary reads.
+    pub sensitive: bool,
 }
 
 impl Annotations {
     pub const READ_ONLY: Self =
-        Self { read_only: true, destructive: false, requires_confirm: false };
+        Self { read_only: true, destructive: false, requires_confirm: false, sensitive: false };
     pub const DESTRUCTIVE: Self =
-        Self { read_only: false, destructive: true, requires_confirm: true };
+        Self { read_only: false, destructive: true, requires_confirm: true, sensitive: false };
+    /// A read that returns sensitive material — gateable by consent policy.
+    pub const SENSITIVE_READ: Self =
+        Self { read_only: true, destructive: false, requires_confirm: false, sensitive: true };
 }

--- a/crates/kube/src/actions.rs
+++ b/crates/kube/src/actions.rs
@@ -155,6 +155,7 @@ pub fn update_config_data_capability(cache: Arc<ClientCache>) -> Capability {
             read_only: false,
             destructive: false,
             requires_confirm: true,
+            sensitive: false,
         },
         move |input: UpdateConfigDataIn| {
             let cache = cache.clone();
@@ -216,6 +217,7 @@ pub fn scale_capability(cache: Arc<ClientCache>) -> Capability {
             read_only: false,
             destructive: false,
             requires_confirm: true,
+            sensitive: false,
         },
         move |input: ScaleIn| {
             let cache = cache.clone();
@@ -255,6 +257,7 @@ pub fn rollout_restart_capability(cache: Arc<ClientCache>) -> Capability {
             read_only: false,
             destructive: false,
             requires_confirm: true,
+            sensitive: false,
         },
         move |input: RestartIn| {
             let cache = cache.clone();
@@ -298,6 +301,7 @@ pub fn cordon_node_capability(cache: Arc<ClientCache>) -> Capability {
             read_only: false,
             destructive: false,
             requires_confirm: true,
+            sensitive: false,
         },
         move |input: CordonIn| {
             let cache = cache.clone();

--- a/crates/kube/src/cronjobs.rs
+++ b/crates/kube/src/cronjobs.rs
@@ -151,6 +151,7 @@ pub fn cronjob_set_suspend_capability(cache: Arc<ClientCache>) -> Capability {
             read_only: false,
             destructive: false,
             requires_confirm: true,
+            sensitive: false,
         },
         move |input: SetSuspendIn| {
             let cache = cache.clone();
@@ -200,6 +201,7 @@ pub fn cronjob_trigger_now_capability(cache: Arc<ClientCache>) -> Capability {
             read_only: false,
             destructive: false,
             requires_confirm: true,
+            sensitive: false,
         },
         move |input: TriggerNowIn| {
             let cache = cache.clone();

--- a/crates/kube/src/manifest.rs
+++ b/crates/kube/src/manifest.rs
@@ -80,8 +80,13 @@ pub fn get_object_capability(cache: Arc<ClientCache>) -> Capability {
                     .map_err(|_| CapabilityError::Handler("get object timed out".into()))?
                     .map_err(|e| CapabilityError::Handler(e.to_string()))?;
                 obj.metadata.managed_fields = None;
-                let object = serde_json::to_value(obj)
+                let mut object = serde_json::to_value(obj)
                     .map_err(|e| CapabilityError::Handler(e.to_string()))?;
+                // Never return Secret values through the generic path; the UI
+                // reads them via the dedicated, consent-gateable `k8s.getSecret`.
+                if ar.kind == "Secret" && ar.group.is_empty() {
+                    crate::secrets::redact_secret_data(&mut object);
+                }
                 Ok(ObjectOut { object })
             }
         },
@@ -267,6 +272,7 @@ pub fn apply_manifest_capability(cache: Arc<ClientCache>) -> Capability {
             read_only: false,
             destructive: false,
             requires_confirm: true,
+            sensitive: false,
         },
         move |input: ApplyIn| {
             let cache = cache.clone();

--- a/crates/kube/src/secrets.rs
+++ b/crates/kube/src/secrets.rs
@@ -6,7 +6,10 @@
 
 use std::sync::Arc;
 
+use std::collections::BTreeMap;
+
 use srelens_capability::{Annotations, Capability, CapabilityError};
+use base64::Engine;
 use k8s_openapi::api::core::v1::Secret;
 use kube::api::ListParams;
 use kube::Api;
@@ -15,6 +18,18 @@ use serde::{Deserialize, Serialize};
 
 use crate::client_cache::ClientCache;
 use crate::connect::request_timeout;
+
+/// Blank the values of a serialized Secret's `data` map in place, keeping the
+/// keys. `get_object` runs this so the generic structured-detail path never
+/// carries Secret material — values are only read through the dedicated,
+/// consent-gateable `k8s.getSecret`.
+pub(crate) fn redact_secret_data(object: &mut serde_json::Value) {
+    if let Some(data) = object.get_mut("data").and_then(|d| d.as_object_mut()) {
+        for value in data.values_mut() {
+            *value = serde_json::Value::String(String::new());
+        }
+    }
+}
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ListSecretsIn {
@@ -77,10 +92,52 @@ pub fn list_secrets_capability(cache: Arc<ClientCache>) -> Capability {
     )
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct GetSecretIn {
+    pub context: String,
+    pub namespace: String,
+    pub name: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct GetSecretOut {
+    /// Base64-encoded values, keyed by name (as stored in `Secret.data`).
+    pub data: BTreeMap<String, String>,
+}
+
+/// `k8s.getSecret` — read a Secret's values. This is the **only** capability
+/// that returns Secret material through the structured API (the generic
+/// `k8s.getObject` redacts it), and it is annotated `sensitive` so a consent
+/// policy can gate it separately from ordinary reads.
+pub fn get_secret_capability(cache: Arc<ClientCache>) -> Capability {
+    Capability::typed::<GetSecretIn, GetSecretOut, _, _>(
+        "k8s.getSecret",
+        "read a Secret's values (sensitive; returns base64-encoded data)",
+        Annotations::SENSITIVE_READ,
+        move |input: GetSecretIn| {
+            let cache = cache.clone();
+            async move {
+                let client = cache.get(&input.context).await.map_err(CapabilityError::Handler)?;
+                let api: Api<Secret> = crate::scoped_api(client, &input.namespace);
+                let secret = tokio::time::timeout(request_timeout(), api.get(&input.name))
+                    .await
+                    .map_err(|_| CapabilityError::Handler("get secret timed out".into()))?
+                    .map_err(|e| CapabilityError::Handler(e.to_string()))?;
+                let data = secret
+                    .data
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|(k, v)| (k, base64::engine::general_purpose::STANDARD.encode(v.0)))
+                    .collect();
+                Ok(GetSecretOut { data })
+            }
+        },
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::BTreeMap;
     use std::path::PathBuf;
 
     #[test]
@@ -88,6 +145,32 @@ mod tests {
         let cap = list_secrets_capability(ClientCache::new(PathBuf::from("/x")));
         assert_eq!(cap.id, "k8s.listSecrets");
         assert!(cap.annotations.read_only);
+    }
+
+    #[test]
+    fn get_secret_is_sensitive() {
+        let cap = get_secret_capability(ClientCache::new(PathBuf::from("/x")));
+        assert_eq!(cap.id, "k8s.getSecret");
+        assert!(cap.annotations.read_only);
+        assert!(cap.annotations.sensitive, "getSecret must be annotated sensitive for consent gating");
+    }
+
+    #[test]
+    fn redaction_blanks_secret_values_but_keeps_keys() {
+        let mut object = serde_json::json!({
+            "kind": "Secret",
+            "metadata": { "name": "web-tls" },
+            "data": { "tls.crt": "U0VDUkVU", "tls.key": "TU9SRQ==" }
+        });
+        redact_secret_data(&mut object);
+        let data = object["data"].as_object().unwrap();
+        // Keys remain so the UI can list them...
+        assert!(data.contains_key("tls.crt"));
+        assert!(data.contains_key("tls.key"));
+        // ...but every value is blanked — no material survives the generic path.
+        assert_eq!(data["tls.crt"], serde_json::json!(""));
+        assert_eq!(data["tls.key"], serde_json::json!(""));
+        assert!(!object.to_string().contains("U0VDUkVU"));
     }
 
     #[test]


### PR DESCRIPTION
Closes the three items in #8 that were checked but not actually complete (per audit). test-first.

## Security: dedicated, policy-gateable Secret reads
Previously Secret **values** flowed through the generic `k8s.getObject` — an MCP client could read them with nothing to gate it. Now:
- New **`sensitive`** annotation flag (`Annotations::SENSITIVE_READ`) so a consent layer (#23) can gate secret-value reads separately from ordinary reads.
- **`k8s.getSecret`** capability (`sensitive`) — the only structured path to Secret values. Registered → MCP-exposed.
- **`k8s.getObject` now redacts Secret `data`** (keys kept, values blanked). The detail views fetch real values through `getSecret` (`SecretBody`'s `useSecretData`); values sit in memory but stay **masked in the DOM until the user reveals a key**. A backend unit test asserts redaction blanks values but keeps keys.

## UX
- **Copy button** per key on ConfigMap/Secret values (revealed values only).
- **ResourceQuota usage bars** — `parseQuantity` (handles `m` / `Ki…` / `k…` suffixes) drives a utilisation bar coloured green/amber/red, replacing the plain used/hard text.

## Verification
9 Rust + 299 frontend tests, coverage above gates, `tsc` clean, production build clean, MCP completeness green.

Note: rebased on dev after #62/#63/#64 merged; this branch predates the toasts PR #65 (independent).