### PR TITLE
feat(perf): virtualize the resource table for large lists

### DIFF
--- a/apps/desktop/src/ui/Table.test.tsx
+++ b/apps/desktop/src/ui/Table.test.tsx
@@ -1,7 +1,71 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import React from "react";
-import { Table, filterTableData, type Column } from "./Table";
+import { Table, filterTableData, computeVisibleRange, type Column } from "./Table";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("Table virtualization", () => {
+  const bigColumns: Column<{ name: string; phase: string }>[] = [
+    { key: "name", header: "Name" },
+    { key: "phase", header: "Phase" },
+  ];
+  const bigData = Array.from({ length: 1000 }, (_, i) => ({ name: `row-${i}`, phase: "x" }));
+
+  it("renders every row when layout can't be measured (jsdom fallback)", () => {
+    const { container } = render(
+      <Table columns={bigColumns} data={bigData} getRowKey={(r) => r.name} />,
+    );
+    // No measurable row height → degrade to rendering all rows.
+    expect(container.querySelectorAll("tbody tr.fl-data-table__row").length).toBe(1000);
+  });
+
+  it("renders only a window of rows when the row height is measurable", () => {
+    // Simulate layout: each row 20px tall inside a 200px scroll viewport.
+    vi.spyOn(HTMLTableRowElement.prototype, "getBoundingClientRect").mockReturnValue({
+      height: 20,
+    } as DOMRect);
+    const { container } = render(
+      <div data-testid="scroll" style={{ overflowY: "auto" }}>
+        <Table columns={bigColumns} data={bigData} getRowKey={(r) => r.name} />
+      </div>,
+    );
+    const sp = screen.getByTestId("scroll");
+    Object.defineProperty(sp, "clientHeight", { value: 200, configurable: true });
+    Object.defineProperty(sp, "scrollTop", { value: 0, writable: true, configurable: true });
+    fireEvent.scroll(sp);
+
+    const rows = container.querySelectorAll("tbody tr.fl-data-table__row");
+    expect(rows.length).toBeLessThan(100); // a window, not all 1000
+    expect(rows.length).toBeGreaterThan(0);
+    expect(screen.getByText("row-0")).toBeDefined();
+    expect(screen.queryByText("row-900")).toBeNull(); // far off-screen, not rendered
+  });
+});
+
+describe("computeVisibleRange", () => {
+  it("returns the window of rows around the scroll position with overscan", () => {
+    // rowHeight 20, viewport 100 → 5 visible rows; scrolled to row 50; overscan 3.
+    const r = computeVisibleRange({ scrollTop: 1000, viewportHeight: 100, rowHeight: 20, total: 500, overscan: 3 });
+    expect(r.start).toBe(47); // 50 - 3
+    expect(r.end).toBe(58); // 50 + ceil(100/20)=5 + 3
+  });
+
+  it("clamps to the data bounds", () => {
+    expect(computeVisibleRange({ scrollTop: 0, viewportHeight: 100, rowHeight: 20, total: 500, overscan: 3 }).start).toBe(0);
+    const end = computeVisibleRange({ scrollTop: 999999, viewportHeight: 100, rowHeight: 20, total: 500, overscan: 3 });
+    expect(end.end).toBe(500);
+    expect(end.start).toBeLessThanOrEqual(500);
+  });
+
+  it("renders everything when the row height is unknown (0)", () => {
+    // jsdom / pre-measure: fall back to the full range rather than dividing by zero.
+    expect(computeVisibleRange({ scrollTop: 0, viewportHeight: 0, rowHeight: 0, total: 42, overscan: 3 })).toEqual({
+      start: 0,
+      end: 42,
+    });
+  });
+});
 
 interface Row {
   name: string;

--- a/apps/desktop/src/ui/Table.tsx
+++ b/apps/desktop/src/ui/Table.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { ArrowDown, ArrowUp, ArrowUpDown, Filter } from "lucide-react";
 import {
   Table as ShadTable,
@@ -41,6 +41,32 @@ function getColumnValue<T>(row: T, column: Column<T>): unknown {
   return column.getValue ? column.getValue(row) : (row as Record<string, unknown>)[column.key];
 }
 
+/**
+ * The slice of rows to render for a virtualized list. Returns the full range
+ * when `rowHeight` is unknown (0) — e.g. before measurement or in jsdom — so the
+ * table degrades to rendering everything rather than dividing by zero.
+ */
+export function computeVisibleRange({
+  scrollTop,
+  viewportHeight,
+  rowHeight,
+  total,
+  overscan,
+}: {
+  scrollTop: number;
+  viewportHeight: number;
+  rowHeight: number;
+  total: number;
+  overscan: number;
+}): { start: number; end: number } {
+  if (rowHeight <= 0) return { start: 0, end: total };
+  const firstVisible = Math.floor(scrollTop / rowHeight);
+  const visibleCount = Math.ceil(viewportHeight / rowHeight);
+  const end = Math.min(total, firstVisible + visibleCount + overscan);
+  const start = Math.min(Math.max(0, firstVisible - overscan), end);
+  return { start, end };
+}
+
 /** Apply the toolbar query to one selected column, or all searchable columns. */
 export function filterTableData<T>(
   data: T[],
@@ -75,6 +101,8 @@ export function Table<T>({
   const [sort, setSort] = useState<{ key: string; direction: "asc" | "desc" } | null>(null);
   const [columnWidths, setColumnWidths] = useState<Record<string, number>>({});
   const columnSignature = columns.map((column) => column.key).join("|");
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [metrics, setMetrics] = useState({ scrollTop: 0, viewportHeight: 0, rowHeight: 0 });
 
   useEffect(() => setColumnWidths({}), [columnSignature]);
 
@@ -164,10 +192,60 @@ export function Table<T>({
     ? Object.values(columnWidths).reduce((total, width) => total + width, 0)
     : undefined;
 
+  // Virtualize long lists: render only the rows near the viewport plus spacer
+  // rows that reserve the scroll height. Below the threshold — or before the row
+  // height can be measured (jsdom, first paint) — render everything.
+  const VIRTUALIZE_THRESHOLD = 60;
+  const OVERSCAN = 8;
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root || visibleData.length <= VIRTUALIZE_THRESHOLD) return;
+    let scrollParent: HTMLElement | null = root.parentElement;
+    while (scrollParent && scrollParent !== document.body) {
+      const overflowY = getComputedStyle(scrollParent).overflowY;
+      if (overflowY === "auto" || overflowY === "scroll") break;
+      scrollParent = scrollParent.parentElement;
+    }
+    if (!scrollParent) return;
+    const parent = scrollParent;
+    const measure = () => {
+      const firstRow = root.querySelector<HTMLElement>("tbody tr.fl-data-table__row");
+      setMetrics({
+        scrollTop: parent.scrollTop,
+        viewportHeight: parent.clientHeight,
+        rowHeight: firstRow ? firstRow.getBoundingClientRect().height : 0,
+      });
+    };
+    measure();
+    parent.addEventListener("scroll", measure, { passive: true });
+    const observer = typeof ResizeObserver !== "undefined" ? new ResizeObserver(measure) : null;
+    observer?.observe(parent);
+    return () => {
+      parent.removeEventListener("scroll", measure);
+      observer?.disconnect();
+    };
+  }, [visibleData.length]);
+
+  const virtualize = visibleData.length > VIRTUALIZE_THRESHOLD && metrics.rowHeight > 0;
+  const range = virtualize
+    ? computeVisibleRange({
+        scrollTop: metrics.scrollTop,
+        viewportHeight: metrics.viewportHeight,
+        rowHeight: metrics.rowHeight,
+        total: visibleData.length,
+        overscan: OVERSCAN,
+      })
+    : { start: 0, end: visibleData.length };
+  const windowRows = virtualize ? visibleData.slice(range.start, range.end) : visibleData;
+  const topPad = virtualize ? range.start * metrics.rowHeight : 0;
+  const bottomPad = virtualize ? (visibleData.length - range.end) * metrics.rowHeight : 0;
+
   if (data.length === 0) {
     return <EmptyState title={emptyText} />;
   }
   return (
+    <div ref={rootRef} style={{ display: "contents" }}>
     <ShadTable
       className={cn(
         "fl-data-table",
@@ -234,7 +312,12 @@ export function Table<T>({
         </TableRow>
       </TableHeader>
       <TableBody>
-        {visibleData.map((row) => {
+        {topPad > 0 && (
+          <tr aria-hidden="true" className="fl-data-table__spacer">
+            <td colSpan={columns.length} style={{ height: topPad, padding: 0, border: 0 }} />
+          </tr>
+        )}
+        {windowRows.map((row) => {
           const rowKey = getRowKey(row);
           const selected = selectedKey === rowKey;
           return (
@@ -253,6 +336,11 @@ export function Table<T>({
             </TableRow>
           );
         })}
+        {bottomPad > 0 && (
+          <tr aria-hidden="true" className="fl-data-table__spacer">
+            <td colSpan={columns.length} style={{ height: bottomPad, padding: 0, border: 0 }} />
+          </tr>
+        )}
         {visibleData.length === 0 && (
           <TableRow>
             <TableCell colSpan={columns.length} className="fl-data-table__no-results">
@@ -262,5 +350,6 @@ export function Table<T>({
         )}
       </TableBody>
     </ShadTable>
+    </div>
   );
 }


### PR DESCRIPTION
First half of #12. `Table.tsx` rendered **every row**, so pointing srelens at a real cluster (all namespaces, thousands of pods) janks. Now the table **windows** — renders only the rows near the viewport plus spacer rows that reserve the scroll height, so the DOM node count stays constant no matter how many rows there are. All test-first.

## How
- **`computeVisibleRange(scrollTop, viewportHeight, rowHeight, total, overscan)`** — the pure windowing math, unit-tested including bounds clamping and the unknown-height (`0`) fallback.
- The `Table` finds its scroll-parent, measures row height + viewport (via `scroll` + `ResizeObserver`), and renders `data.slice(start, end)` between two spacer `<tr>`s.
- **Degrades safely:** virtualizes only above 60 rows *and* once the row height is measurable. Small tables, first paint, and jsdom (no layout) render everything — so existing behaviour and tests are untouched. Sorting, filtering, column resize, and the sticky header all still work.

## Verification
304 frontend tests — including a 1000-row test asserting only a ~18-row window renders and far-off rows (`row-900`) stay out of the DOM. Coverage above gates, `tsc` clean, production build clean.

## Follow-up
Multi-select namespaces (persisted per cluster; watches across a namespace set) — the second half of #12 — is a separate PR.