### PR TITLE
feat(desktop): multi-select namespace filtering in resource browser

### DIFF
--- a/apps/desktop/src/components/ResourceBrowser.test.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.test.tsx
@@ -250,18 +250,38 @@ describe("ResourceBrowser", () => {
       ),
     );
 
+    // Selecting a second namespace is additive (multi-select): the serialized
+    // filter now holds both, and the watch widens to all namespaces (filtered
+    // client-side) since more than one is selected.
     await userEvent.click(screen.getByRole("combobox", { name: "Namespace" }));
     await userEvent.click(await screen.findByRole("option", { name: "default" }));
-    expect(onNamespaceChange).toHaveBeenCalledWith("default");
+    expect(onNamespaceChange).toHaveBeenCalledWith("kube-system,default");
     await waitFor(() =>
       expect(watchResourceMock).toHaveBeenCalledWith(
         "kind-dev",
-        "default",
+        "",
         "pods",
         expect.any(Function),
         expect.any(Function),
       ),
     );
+  });
+
+  it("filters rows client-side to the selected namespaces when several are chosen", async () => {
+    listNamespacesMock.mockResolvedValue({ namespaces: ["default", "kube-system", "ops"] });
+    // Two namespaces selected → watch runs across all namespaces and the rows
+    // are narrowed client-side to the selection.
+    watchResourceMock.mockImplementation(
+      watchWith([
+        { ...pod, name: "web-1", namespace: "default" },
+        { ...pod, name: "dns-1", namespace: "kube-system" },
+        { ...pod, name: "backup-1", namespace: "ops" },
+      ]),
+    );
+    render(<ResourceBrowser context="kind-dev" kind="pods" initialNamespace="default,kube-system" />);
+    await waitFor(() => expect(screen.getByText("web-1")).toBeDefined());
+    expect(screen.getByText("dns-1")).toBeDefined();
+    expect(screen.queryByText("backup-1")).toBeNull();
   });
 
   it("opens the pod detail drawer when a pod row is clicked", async () => {

--- a/apps/desktop/src/components/ResourceBrowser.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.tsx
@@ -29,6 +29,13 @@ import {
 type NodeRow = NodeSummary & { cpu?: number; memory?: number };
 type PodRow = PodSummary & { cpu?: number; memory?: number };
 import { watchResource, WATCHABLE_KINDS, type WatchHandle, type WatchStatus } from "../lib/watch";
+import {
+  parseNamespaceSelection,
+  serializeNamespaceSelection,
+  watchNamespaceForSelection,
+  rowInSelection,
+} from "../lib/namespaces";
+import { NamespaceMultiSelect } from "../ui/NamespaceMultiSelect";
 import { PodActions, ResourceActions, ServiceForwardAction } from "./DetailActions";
 import { NodeCordonAction } from "./NodeCordonAction";
 import { ResourceDetail } from "./ResourceDetail";
@@ -36,7 +43,6 @@ import type { OpenResource } from "../lib/resourceNavigation";
 import {
   Table,
   filterTableData,
-  Combobox,
   Spinner,
   Badge,
   Button,
@@ -418,11 +424,16 @@ export function ResourceBrowser({
 }) {
   const [namespaces, setNamespaces] = useState<string[] | null>(null);
   const [nsError, setNsError] = useState("");
-  const [namespace, setNamespace] = useState(initialNamespace);
-  const changeNamespace = (ns: string) => {
-    setNamespace(ns);
-    onNamespaceChange?.(ns);
+  // Namespace selection is a set (empty = all namespaces), serialized to/from
+  // the persisted comma string. One selected namespace watches that namespace
+  // directly; none or many watch all namespaces, filtered client-side.
+  const [selection, setSelection] = useState(() => parseNamespaceSelection(initialNamespace));
+  const changeNamespaces = (next: string[]) => {
+    setSelection(next);
+    onNamespaceChange?.(serializeNamespaceSelection(next));
   };
+  const watchNamespace = watchNamespaceForSelection(selection);
+  const selectionKey = serializeNamespaceSelection(selection);
   const [res, setRes] = useState<ResourceState>({ rows: [], error: "", loading: false });
   const [watchStatus, setWatchStatus] = useState<WatchStatus>("live");
   const [selectedPod, setSelectedPod] = useState<PodSummary | null>(null);
@@ -458,7 +469,7 @@ export function ResourceBrowser({
     if (namespaced && namespaces === null) return; // wait for the namespace list
     let cancelled = false;
     // Only reset the table for a genuinely new view; a poll keeps current rows.
-    const viewKey = `${context}|${namespace}|${kind}`;
+    const viewKey = `${context}|${watchNamespace}|${kind}`;
     const fresh = viewKeyRef.current !== viewKey;
     viewKeyRef.current = viewKey;
     if (fresh) {
@@ -474,7 +485,7 @@ export function ResourceBrowser({
       let handle: WatchHandle | null = null;
       void watchResource(
         context,
-        namespace,
+        watchNamespace,
         kind,
         (rows) => {
           if (!cancelled) setRes({ rows, error: "", loading: false });
@@ -506,7 +517,7 @@ export function ResourceBrowser({
             }));
             return { rows, error: n.error }; // metrics are best-effort
           })
-        : listResource(context, K8S_KIND[kind], namespace).then((o) => ({
+        : listResource(context, K8S_KIND[kind], watchNamespace).then((o) => ({
             rows: o.items,
             error: o.error,
           }));
@@ -516,7 +527,7 @@ export function ResourceBrowser({
     return () => {
       cancelled = true;
     };
-  }, [context, namespace, kind, namespaced, namespaces, reloadKey]);
+  }, [context, watchNamespace, kind, namespaced, namespaces, reloadKey]);
 
   // Poll non-watchable kinds for a live-updating feel (true watch streams
   // cover pods/deployments/services).
@@ -525,7 +536,7 @@ export function ResourceBrowser({
     if (namespaced && namespaces === null) return;
     const t = setInterval(() => setReloadKey((k) => k + 1), POLL_MS);
     return () => clearInterval(t);
-  }, [kind, namespace, namespaced, namespaces, context]);
+  }, [kind, watchNamespace, namespaced, namespaces, context]);
 
   // Pods stream over watch (no metrics) — poll pod CPU/memory separately and
   // merge by name. Best-effort: a missing metrics-server just leaves "—".
@@ -536,7 +547,7 @@ export function ResourceBrowser({
     }
     let active = true;
     const fetchMetrics = () =>
-      void podMetrics(context, namespace).then((o) => {
+      void podMetrics(context, watchNamespace).then((o) => {
         if (!active) return;
         setPodCpuMem(
           new Map((o.metrics ?? []).map((m) => [m.name, { cpu: m.cpuMillicores, mem: m.memoryMiB }])),
@@ -548,7 +559,7 @@ export function ResourceBrowser({
       active = false;
       clearInterval(t);
     };
-  }, [kind, context, namespace]);
+  }, [kind, context, watchNamespace]);
 
   const columns = useMemo(() => {
     if (kind === "events") return eventColumns as unknown as Column<{ name: string }>[];
@@ -589,7 +600,7 @@ export function ResourceBrowser({
       const rowNs = (row as { namespace?: string }).namespace;
       setOtherDetail({
         kind: K8S_KIND[kind],
-        namespace: namespaced ? rowNs || namespace || null : null,
+        namespace: namespaced ? rowNs || watchNamespace || null : null,
         name: row.name,
       });
     }
@@ -614,14 +625,21 @@ export function ResourceBrowser({
 
   const selectedKey = kind === "pods" ? selectedPod?.name : otherDetail?.name;
 
-  // Merge live pod metrics into the pod rows (other kinds pass through).
+  // Merge live pod metrics into the pod rows, and restrict namespaced rows to
+  // the selected namespaces (when watching all-namespaces for a multi-select).
   const tableRows = useMemo(() => {
-    if (kind !== "pods") return res.rows;
-    return (res.rows as PodSummary[]).map((p) => {
-      const m = podCpuMem.get(p.name);
-      return { ...p, cpu: m?.cpu, memory: m?.mem } as PodRow;
-    });
-  }, [res.rows, kind, podCpuMem]);
+    let rows: Array<{ name: string; namespace?: string }> =
+      kind === "pods"
+        ? (res.rows as PodSummary[]).map((p) => {
+            const m = podCpuMem.get(p.name);
+            return { ...p, cpu: m?.cpu, memory: m?.mem } as PodRow;
+          })
+        : (res.rows as Array<{ name: string; namespace?: string }>);
+    if (namespaced && selection.length > 0) {
+      rows = rows.filter((r) => rowInSelection(r.namespace ?? "", selection));
+    }
+    return rows;
+  }, [res.rows, kind, podCpuMem, namespaced, selectionKey]);
 
   const filtered = useMemo(
     () => filterTableData(tableRows, columns, query, filterColumn),
@@ -694,15 +712,11 @@ export function ResourceBrowser({
               {namespaced && (
                 <div className="fl-resource-toolbar__namespace flex items-center gap-2">
                   <span>Namespace</span>
-                  <Combobox
-                    value={namespace}
-                    onValueChange={changeNamespace}
-                    options={[
-                      { value: "", label: "All namespaces" },
-                      ...namespaces.map((n) => ({ value: n })),
-                    ]}
+                  <NamespaceMultiSelect
+                    namespaces={namespaces ?? []}
+                    selection={selection}
+                    onChange={changeNamespaces}
                     ariaLabel="Namespace"
-                    searchPlaceholder="Search namespaces…"
                     className="min-w-44"
                   />
                 </div>
@@ -758,7 +772,15 @@ export function ResourceBrowser({
                   activeFilterKey={filterColumn}
                   onActiveFilterKeyChange={setFilterColumn}
                   emptyText={
-                    query ? "No matches" : `No ${kind}${namespaced && namespace ? ` in ${namespace}` : ""}`
+                    query
+                      ? "No matches"
+                      : `No ${kind}${
+                          namespaced && selection.length === 1
+                            ? ` in ${selection[0]}`
+                            : namespaced && selection.length > 1
+                              ? ` in ${selection.length} namespaces`
+                              : ""
+                        }`
                   }
                 />
               )}

--- a/apps/desktop/src/lib/namespaces.test.ts
+++ b/apps/desktop/src/lib/namespaces.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { parseNamespaceSelection, serializeNamespaceSelection, watchNamespaceForSelection, rowInSelection } from "./namespaces";
+
+describe("parseNamespaceSelection", () => {
+  it("splits a comma string, trims, drops blanks, and dedupes", () => {
+    expect(parseNamespaceSelection("default,kube-system, default ,")).toEqual(["default", "kube-system"]);
+  });
+  it("treats empty / whitespace as 'all namespaces' (empty set)", () => {
+    expect(parseNamespaceSelection("")).toEqual([]);
+    expect(parseNamespaceSelection("  ")).toEqual([]);
+  });
+});
+
+describe("serializeNamespaceSelection", () => {
+  it("round-trips a set back to a comma string", () => {
+    expect(serializeNamespaceSelection(["default", "kube-system"])).toBe("default,kube-system");
+    expect(serializeNamespaceSelection([])).toBe("");
+  });
+});
+
+describe("watchNamespaceForSelection", () => {
+  it("watches the single namespace when exactly one is selected", () => {
+    expect(watchNamespaceForSelection(["prod"])).toBe("prod");
+  });
+  it("watches all namespaces for none or many (filtered client-side)", () => {
+    expect(watchNamespaceForSelection([])).toBe("");
+    expect(watchNamespaceForSelection(["a", "b"])).toBe("");
+  });
+});
+
+describe("rowInSelection", () => {
+  it("keeps every row when nothing is selected (all)", () => {
+    expect(rowInSelection("anything", [])).toBe(true);
+  });
+  it("keeps only rows whose namespace is in the set", () => {
+    expect(rowInSelection("a", ["a", "b"])).toBe(true);
+    expect(rowInSelection("c", ["a", "b"])).toBe(false);
+  });
+});

--- a/apps/desktop/src/lib/namespaces.ts
+++ b/apps/desktop/src/lib/namespaces.ts
@@ -1,0 +1,34 @@
+/**
+ * Namespace selection helpers. The selection is a set of namespace names; an
+ * empty set means "all namespaces". It's persisted/threaded as a comma-joined
+ * string so the tab/settings interface stays a plain string.
+ */
+
+/** Parse the persisted comma string into a deduped set (empty = all). */
+export function parseNamespaceSelection(value: string): string[] {
+  const seen = new Set<string>();
+  for (const part of value.split(",")) {
+    const ns = part.trim();
+    if (ns) seen.add(ns);
+  }
+  return [...seen];
+}
+
+/** Serialize a selection set back to the persisted comma string. */
+export function serializeNamespaceSelection(selection: string[]): string {
+  return selection.join(",");
+}
+
+/**
+ * The namespace to open a watch on for a selection. One selected namespace →
+ * that namespace (efficient); none or many → all namespaces (`""`), then
+ * filtered client-side by {@link rowInSelection}.
+ */
+export function watchNamespaceForSelection(selection: string[]): string {
+  return selection.length === 1 ? selection[0] : "";
+}
+
+/** Whether a row's namespace passes the selection (empty selection = all). */
+export function rowInSelection(rowNamespace: string, selection: string[]): boolean {
+  return selection.length === 0 || selection.includes(rowNamespace);
+}

--- a/apps/desktop/src/ui/NamespaceMultiSelect.test.tsx
+++ b/apps/desktop/src/ui/NamespaceMultiSelect.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+import { NamespaceMultiSelect } from "./NamespaceMultiSelect";
+
+const namespaces = ["default", "kube-system", "prod"];
+
+describe("NamespaceMultiSelect", () => {
+  it("summarizes an empty selection as 'All namespaces'", () => {
+    render(<NamespaceMultiSelect namespaces={namespaces} selection={[]} onChange={() => {}} ariaLabel="Namespaces" />);
+    expect(screen.getByRole("combobox", { name: "Namespaces" }).textContent).toContain("All namespaces");
+  });
+
+  it("summarizes a single selection by name and many by count", () => {
+    const { rerender } = render(
+      <NamespaceMultiSelect namespaces={namespaces} selection={["prod"]} onChange={() => {}} ariaLabel="Namespaces" />,
+    );
+    expect(screen.getByRole("combobox", { name: "Namespaces" }).textContent).toContain("prod");
+    rerender(
+      <NamespaceMultiSelect namespaces={namespaces} selection={["prod", "default"]} onChange={() => {}} ariaLabel="Namespaces" />,
+    );
+    expect(screen.getByRole("combobox", { name: "Namespaces" }).textContent).toContain("2 namespaces");
+  });
+
+  it("adds a namespace to the selection when toggled on", async () => {
+    const onChange = vi.fn();
+    render(<NamespaceMultiSelect namespaces={namespaces} selection={[]} onChange={onChange} ariaLabel="Namespaces" />);
+    fireEvent.click(screen.getByRole("combobox", { name: "Namespaces" }));
+    fireEvent.click(await screen.findByText("default"));
+    expect(onChange).toHaveBeenCalledWith(["default"]);
+  });
+
+  it("removes a namespace when toggled off", async () => {
+    const onChange = vi.fn();
+    render(<NamespaceMultiSelect namespaces={namespaces} selection={["default", "prod"]} onChange={onChange} ariaLabel="Namespaces" />);
+    fireEvent.click(screen.getByRole("combobox", { name: "Namespaces" }));
+    fireEvent.click(await screen.findByText("default"));
+    expect(onChange).toHaveBeenCalledWith(["prod"]);
+  });
+
+  it("clears to all namespaces via the 'All namespaces' option", async () => {
+    const onChange = vi.fn();
+    render(<NamespaceMultiSelect namespaces={namespaces} selection={["default"]} onChange={onChange} ariaLabel="Namespaces" />);
+    fireEvent.click(screen.getByRole("combobox", { name: "Namespaces" }));
+    fireEvent.click(await screen.findByText("All namespaces"));
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+});

--- a/apps/desktop/src/ui/NamespaceMultiSelect.tsx
+++ b/apps/desktop/src/ui/NamespaceMultiSelect.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from "react";
+import { Check, ChevronsUpDown } from "lucide-react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Command, CommandInput, CommandList, CommandEmpty, CommandGroup, CommandItem } from "@/components/ui/command";
+import { cn } from "@/lib/utils";
+
+export interface NamespaceMultiSelectProps {
+  namespaces: string[];
+  /** Selected namespaces; an empty array means "all namespaces". */
+  selection: string[];
+  onChange: (selection: string[]) => void;
+  ariaLabel?: string;
+  className?: string;
+}
+
+function summarize(selection: string[]): string {
+  if (selection.length === 0) return "All namespaces";
+  if (selection.length === 1) return selection[0];
+  return `${selection.length} namespaces`;
+}
+
+/**
+ * Multi-select namespace picker. An empty selection means all namespaces; the
+ * popover stays open while toggling so several can be picked at once. Serialized
+ * to/from a comma string by `lib/namespaces` for persistence.
+ */
+export function NamespaceMultiSelect({
+  namespaces,
+  selection,
+  onChange,
+  ariaLabel,
+  className,
+}: NamespaceMultiSelectProps) {
+  const [open, setOpen] = useState(false);
+  const selected = new Set(selection);
+
+  const toggle = (ns: string) => {
+    const next = new Set(selected);
+    if (next.has(ns)) next.delete(ns);
+    else next.add(ns);
+    onChange([...next]);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          role="combobox"
+          aria-expanded={open}
+          aria-label={ariaLabel}
+          className={cn(
+            "flex h-8 items-center justify-between gap-2 rounded-md border border-input bg-background px-3 text-sm shadow-xs outline-none hover:bg-accent/40 focus-visible:ring-2 focus-visible:ring-ring",
+            className,
+          )}
+        >
+          <span className="truncate">{summarize(selection)}</span>
+          <ChevronsUpDown className="size-3.5 shrink-0 opacity-50" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="w-64 p-0" align="start">
+        <Command>
+          <CommandInput placeholder="Search namespaces…" />
+          <CommandList>
+            <CommandEmpty>No results</CommandEmpty>
+            <CommandGroup>
+              <CommandItem value="All namespaces" onSelect={() => onChange([])}>
+                <Check className={cn("size-3.5 shrink-0", selection.length === 0 ? "opacity-100" : "opacity-0")} />
+                <span className="truncate">All namespaces</span>
+              </CommandItem>
+              {namespaces.map((ns) => (
+                <CommandItem key={ns} value={ns} onSelect={() => toggle(ns)}>
+                  <Check className={cn("size-3.5 shrink-0", selected.has(ns) ? "opacity-100" : "opacity-0")} />
+                  <span className="truncate">{ns}</span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}


### PR DESCRIPTION
Closes #12.

## What

Replaces the single-namespace picker in the resource browser with a multi-select popover, so several namespaces can be browsed at once (the last piece of the large-cluster performance work; the row virtualization half shipped in #68).

## How

- **`lib/namespaces.ts`** — pure selection helpers (100% covered): parse/serialize the persisted comma string ↔ a selection set, `watchNamespaceForSelection` (exactly one selected → watch that namespace efficiently; none or many → watch all and filter client-side), and `rowInSelection`.
- **`ui/NamespaceMultiSelect.tsx`** — multi-select popover that stays open while toggling; summarizes as *All namespaces* / the single name / *N namespaces*.
- **`components/ResourceBrowser.tsx`** — interprets the selection as a set, derives the watch namespace, and narrows rows client-side when several namespaces are selected. Empty-state text and the pod-metrics/poll effects follow the new model.

The persisted interface stays a plain comma string, so per-cluster namespace persistence in `App.tsx` is unchanged.

## Tests

- Full frontend suite green (**317 passing**), including a new integration test asserting rows from an unselected namespace are filtered out, and an updated filter-change test covering the additive multi-select semantics.
- Coverage 82.14% lines (gate 80). `vite build` succeeds.