### PR TITLE
feat(desktop): prominent loading indicator while fetching resources

### DIFF
--- a/apps/desktop/src/components/ResourceBrowser.test.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.test.tsx
@@ -267,6 +267,15 @@ describe("ResourceBrowser", () => {
     );
   });
 
+  it("shows a loading indicator while the first fetch is still in flight", async () => {
+    listNamespacesMock.mockResolvedValue({ namespaces: ["default"] });
+    // A watch that never delivers a snapshot keeps the browser in its loading
+    // state, so the content area should show the loading placeholder.
+    watchResourceMock.mockImplementation(() => new Promise(() => {}));
+    render(<ResourceBrowser context="kind-dev" kind="pods" />);
+    expect(await screen.findByText("Loading pods")).toBeDefined();
+  });
+
   it("filters rows client-side to the selected namespaces when several are chosen", async () => {
     listNamespacesMock.mockResolvedValue({ namespaces: ["default", "kube-system", "ops"] });
     // Two namespaces selected → watch runs across all namespaces and the rows

--- a/apps/desktop/src/components/ResourceBrowser.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.tsx
@@ -44,6 +44,7 @@ import {
   Table,
   filterTableData,
   Spinner,
+  LoadingState,
   Badge,
   Button,
   Drawer,
@@ -743,7 +744,7 @@ export function ResourceBrowser({
                 ) : (
                   <Badge variant="success">live</Badge>
                 ))}
-              {res.loading && <Spinner label="Loading resources" />}
+              {res.loading && filtered.length > 0 && <Spinner label="Loading resources" />}
               <div className="fl-resource-toolbar__search ml-auto w-56">
                 <TextInput
                   value={query}
@@ -762,7 +763,10 @@ export function ResourceBrowser({
 
             <div className="min-h-0 flex-1 overflow-auto">
               {res.error && <p className="px-3 py-2 text-sm text-destructive">Error: {res.error}</p>}
-              {!res.error && (
+              {!res.error && res.loading && filtered.length === 0 && (
+                <LoadingState label={`Loading ${kind}`} />
+              )}
+              {!res.error && !(res.loading && filtered.length === 0) && (
                 <Table
                   columns={columns}
                   data={filtered}

--- a/apps/desktop/src/ui/LoadingState.test.tsx
+++ b/apps/desktop/src/ui/LoadingState.test.tsx
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { LoadingState } from "./LoadingState";
+
+describe("LoadingState", () => {
+  it("shows the default caption and an accessible spinner", () => {
+    render(<LoadingState />);
+    expect(screen.getByText("Loading")).toBeDefined();
+    expect(screen.getByRole("status").getAttribute("aria-label")).toBe("Loading");
+  });
+
+  it("captions the load with a custom label", () => {
+    render(<LoadingState label="Loading pods" />);
+    expect(screen.getByText("Loading pods")).toBeDefined();
+    expect(screen.getByRole("status").getAttribute("aria-label")).toBe("Loading pods");
+  });
+});

--- a/apps/desktop/src/ui/LoadingState.tsx
+++ b/apps/desktop/src/ui/LoadingState.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { Spinner } from "./Spinner";
+import { cn } from "@/lib/utils";
+
+export interface LoadingStateProps {
+  /** Text shown beneath the spinner; also the spinner's accessible label. */
+  label?: string;
+  className?: string;
+}
+
+/**
+ * Prominent, centered loading placeholder for a content area whose data is
+ * still being fetched. Wraps {@link Spinner} with a caption so an in-flight
+ * load reads clearly instead of looking like an empty result.
+ */
+export function LoadingState({ label = "Loading", className }: LoadingStateProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center gap-3 py-16 text-muted-foreground",
+        className,
+      )}
+    >
+      <Spinner label={label} className="size-8 text-primary" />
+      <span className="text-sm">{label}</span>
+    </div>
+  );
+}

--- a/apps/desktop/src/ui/Spinner.test.tsx
+++ b/apps/desktop/src/ui/Spinner.test.tsx
@@ -13,4 +13,18 @@ describe("Spinner", () => {
     render(<Spinner label="Fetching pods" />);
     expect(screen.getByLabelText("Fetching pods")).toBeDefined();
   });
+
+  it("renders an animated svg ring with a muted track circle", () => {
+    const { container } = render(<Spinner />);
+    const svg = container.querySelector("svg");
+    expect(svg?.classList.contains("animate-spin")).toBe(true);
+    expect(container.querySelector("circle")).not.toBeNull();
+  });
+
+  it("forwards extra classes onto the svg", () => {
+    const { container } = render(<Spinner className="size-8 text-primary" />);
+    const svg = container.querySelector("svg");
+    expect(svg?.classList.contains("size-8")).toBe(true);
+    expect(svg?.classList.contains("text-primary")).toBe(true);
+  });
 });

--- a/apps/desktop/src/ui/Spinner.tsx
+++ b/apps/desktop/src/ui/Spinner.tsx
@@ -1,15 +1,28 @@
 import React from "react";
-import { Spinner as ShadSpinner } from "@/components/ui/spinner";
+import { cn } from "@/lib/utils";
 
-export interface SpinnerProps extends Omit<React.ComponentProps<typeof ShadSpinner>, "aria-label"> {
+export interface SpinnerProps extends Omit<React.ComponentProps<"svg">, "aria-label"> {
   /** Accessible label; defaults to "Loading". */
   label?: string;
 }
 
 /**
- * Indeterminate loading spinner. Local wrapper over shadcn's Spinner; inherits
- * the current text colour so it blends wherever it sits inline with a label.
+ * Indeterminate loading spinner: a muted track ring with a spinning accent arc.
+ * Inherits the current text colour so it blends wherever it sits inline with a
+ * label, and takes `className` (e.g. `size-8 text-primary`) to scale/recolour.
  */
-export function Spinner({ label = "Loading", ...props }: SpinnerProps) {
-  return <ShadSpinner aria-label={label} {...props} />;
+export function Spinner({ label = "Loading", className, ...props }: SpinnerProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      role="status"
+      aria-label={label}
+      className={cn("size-4 animate-spin", className)}
+      {...props}
+    >
+      <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="2.5" className="opacity-20" />
+      <path d="M21 12a9 9 0 0 0-9-9" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
+    </svg>
+  );
 }

--- a/apps/desktop/src/ui/index.ts
+++ b/apps/desktop/src/ui/index.ts
@@ -22,6 +22,8 @@ export { Badge } from "./Badge";
 export type { BadgeProps, BadgeVariant } from "./Badge";
 export { Spinner } from "./Spinner";
 export type { SpinnerProps } from "./Spinner";
+export { LoadingState } from "./LoadingState";
+export type { LoadingStateProps } from "./LoadingState";
 export { Table, filterTableData } from "./Table";
 export type { Column, TableProps } from "./Table";
 export { Select } from "./Select";


### PR DESCRIPTION
## Problem

While a resource list was being fetched, the only loading cue was a tiny `Loader2` spinner tucked inline in the toolbar. During an initial fetch the content area rendered the empty-state text ("No pods"), so it read as if nothing was loading.

## Changes

- **`ui/Spinner.tsx`** — replaced the generic lucide `Loader2` with a custom ring + spinning-arc SVG that inherits the current text colour and scales/recolours via `className`. Upgrades every spinner in the app consistently (namespace load, detail views, …).
- **`ui/LoadingState.tsx`** (new) — a prominent centered placeholder: the spinner at `size-8` in the primary colour with a caption beneath.
- **`components/ResourceBrowser.tsx`** — while the first fetch is in flight (loading and no rows yet), the content area shows `LoadingState` ("Loading pods") instead of the empty text. The small toolbar spinner is now reserved for refreshes that still have rows on screen.

## Tests (TDD, red → green)

- New `Spinner` assertions: animated svg with a track circle, class forwarding.
- New `LoadingState` tests: default + custom caption, accessible status role.
- New `ResourceBrowser` test: holds the watch pending and asserts the loading placeholder appears.

Full suite green (**322 passing**), `tsc` clean, `vite build` succeeds.

> Note: stacked on #69 (both touch the same resource-browser content region); merge #69 first for the cleanest diff.