### PR TITLE
feat(nodes): show cordoned + tainted state in the Status column (#72)

### DIFF
--- a/apps/desktop/src/components/ResourceBrowser.test.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.test.tsx
@@ -364,13 +364,33 @@ describe("ResourceBrowser", () => {
   it("lists cluster-scoped nodes without a namespace selector", async () => {
     listNamespacesMock.mockResolvedValue({ namespaces: ["default"] });
     listNodesMock.mockResolvedValue({
-      nodes: [{ name: "cp-1", status: "Ready", version: "v1.35.0", roles: "control-plane" }],
+      nodes: [
+        { name: "cp-1", status: "Ready", unschedulable: false, taints: 0, version: "v1.35.0", roles: "control-plane" },
+      ],
     });
     render(<ResourceBrowser context="kind-dev" kind="nodes" />);
 
     await waitFor(() => expect(screen.getByText("cp-1")).toBeDefined());
     expect(listNodesMock).toHaveBeenCalledWith("kind-dev");
     expect(screen.queryByLabelText("Namespace")).toBeNull();
+    // A healthy, schedulable node shows no cordon/taint chips.
+    expect(screen.queryByText("SchedulingDisabled")).toBeNull();
+    expect(screen.queryByText(/Tainted/)).toBeNull();
+  });
+
+  it("flags cordoned and tainted nodes alongside readiness", async () => {
+    listNamespacesMock.mockResolvedValue({ namespaces: ["default"] });
+    listNodesMock.mockResolvedValue({
+      nodes: [
+        { name: "worker-1", status: "Ready", unschedulable: true, taints: 2, version: "v1.35.0", roles: "<none>" },
+      ],
+    });
+    render(<ResourceBrowser context="kind-dev" kind="nodes" />);
+
+    await waitFor(() => expect(screen.getByText("worker-1")).toBeDefined());
+    expect(screen.getByText("Ready")).toBeDefined();
+    expect(screen.getByText("SchedulingDisabled")).toBeDefined();
+    expect(screen.getByText("Tainted (2)")).toBeDefined();
   });
 
   it("shows a namespace load error and does not watch", async () => {

--- a/apps/desktop/src/components/ResourceBrowser.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.tsx
@@ -352,7 +352,19 @@ const serviceColumns: Column<ServiceSummary>[] = [
 
 const nodeColumns: Column<NodeRow>[] = [
   { key: "name", header: "Node", render: (n) => <strong>{n.name}</strong> },
-  { key: "status", header: "Status", render: (n) => <StatusPill status={n.status} kind={phaseKind(n.status)} /> },
+  {
+    key: "status",
+    header: "Status",
+    render: (n) => (
+      <span className="inline-flex items-center gap-1.5">
+        <StatusPill status={n.status} kind={phaseKind(n.status)} />
+        {n.unschedulable && <Badge variant="warning">SchedulingDisabled</Badge>}
+        {n.taints > 0 && (
+          <Badge variant="neutral">{n.taints > 1 ? `Tainted (${n.taints})` : "Tainted"}</Badge>
+        )}
+      </span>
+    ),
+  },
   { key: "roles", header: "Roles" },
   { key: "cpu", header: "CPU", render: (n) => <Muted>{n.cpu != null ? `${n.cpu}m` : "—"}</Muted> },
   { key: "memory", header: "Memory", render: (n) => <Muted>{n.memory != null ? `${n.memory}Mi` : "—"}</Muted> },

--- a/apps/desktop/src/lib/manifest.ts
+++ b/apps/desktop/src/lib/manifest.ts
@@ -2,7 +2,12 @@ import { invokeCapability, type Invoker } from "../transport/transport";
 
 export interface NodeSummary {
   name: string;
+  /** Readiness: "Ready", "NotReady", or "Unknown". */
   status: string;
+  /** Cordoned (`spec.unschedulable`) — surfaced as "SchedulingDisabled". */
+  unschedulable: boolean;
+  /** Number of taints, excluding the auto-added unschedulable taint. */
+  taints: number;
   version: string;
   roles: string;
   age: string;

--- a/crates/kube/src/nodes.rs
+++ b/crates/kube/src/nodes.rs
@@ -20,7 +20,12 @@ pub struct ListNodesIn {
 #[derive(Debug, Clone, PartialEq, Serialize, JsonSchema)]
 pub struct NodeSummary {
     pub name: String,
+    /// Readiness derived from the `Ready` condition: "Ready", "NotReady", or "Unknown".
     pub status: String,
+    /// Whether the node is cordoned (`spec.unschedulable`) — shown as "SchedulingDisabled".
+    pub unschedulable: bool,
+    /// Number of taints on the node, excluding the auto-added unschedulable taint.
+    pub taints: u32,
     pub version: String,
     pub roles: String,
     pub age: String,
@@ -65,9 +70,24 @@ fn summarise(node: Node) -> NodeSummary {
             }
         })
         .unwrap_or_else(|| "<none>".to_string());
+    let spec = node.spec.as_ref();
+    let unschedulable = spec.and_then(|s| s.unschedulable).unwrap_or(false);
+    // Count taints, ignoring the taint Kubernetes adds automatically when a node
+    // is cordoned — that state is already conveyed by `unschedulable`.
+    let taints = spec
+        .and_then(|s| s.taints.as_ref())
+        .map(|taints| {
+            taints
+                .iter()
+                .filter(|taint| taint.key != "node.kubernetes.io/unschedulable")
+                .count() as u32
+        })
+        .unwrap_or(0);
     NodeSummary {
         name,
         status,
+        unschedulable,
+        taints,
         version,
         roles,
         age: crate::humanize_age(node.metadata.creation_timestamp.as_ref()),
@@ -141,5 +161,48 @@ mod tests {
         assert_eq!(s.status, "Ready");
         assert_eq!(s.version, "v1.35.0");
         assert_eq!(s.roles, "control-plane");
+        assert!(!s.unschedulable);
+        assert_eq!(s.taints, 0);
+    }
+
+    #[test]
+    fn reports_cordoned_and_taints_excluding_the_unschedulable_taint() {
+        use k8s_openapi::api::core::v1::{NodeSpec, Taint};
+        let node = Node {
+            metadata: kube::core::ObjectMeta {
+                name: Some("worker-1".into()),
+                ..Default::default()
+            },
+            spec: Some(NodeSpec {
+                unschedulable: Some(true),
+                taints: Some(vec![
+                    Taint {
+                        key: "dedicated".into(),
+                        effect: "NoSchedule".into(),
+                        ..Default::default()
+                    },
+                    // Auto-added when cordoned — must not be counted as a taint.
+                    Taint {
+                        key: "node.kubernetes.io/unschedulable".into(),
+                        effect: "NoSchedule".into(),
+                        ..Default::default()
+                    },
+                ]),
+                ..Default::default()
+            }),
+            status: Some(NodeStatus {
+                conditions: Some(vec![NodeCondition {
+                    type_: "Ready".into(),
+                    status: "True".into(),
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let s = summarise(node);
+        assert_eq!(s.status, "Ready");
+        assert!(s.unschedulable);
+        assert_eq!(s.taints, 1);
     }
 }


### PR DESCRIPTION
Closes #72

## Problem

The Nodes tab **Status** column showed only readiness (`Ready` / `NotReady` / `Unknown`). A cordoned node looked identical to a healthy one, and taints weren't surfaced at all. These states can also co-occur.

## Change

Enrich `NodeSummary` (backend `crates/kube/src/nodes.rs`) with two structured fields and render them as chips beside readiness:

- **`unschedulable: bool`** — from `spec.unschedulable` (cordoned) → renders a **SchedulingDisabled** chip (warning).
- **`taints: u32`** — count of `spec.taints`, **excluding** the auto-added `node.kubernetes.io/unschedulable` taint (already conveyed by cordon) → renders a **Tainted** / **Tainted (N)** chip.

Readiness stays a single pill with unchanged colouring, so healthy nodes look exactly as before; the extra chips appear only when relevant. Combinations (e.g. `Ready` + SchedulingDisabled + Tainted) render together.

## Verification

- **Live cluster (113 nodes) via the MCP path**: new fields populate correctly — 6 control-plane nodes report `taints: 1`, 107 report `0`, none currently cordoned. `status` still reports readiness (so Cluster Overview's ready-count is unaffected).
- **Rust**: `summarise` tests cover the healthy case and a cordoned+tainted node (asserting the unschedulable taint is excluded from the count).
- **Frontend**: tests assert a healthy node shows no chips, and a cordoned+tainted node shows `Ready`, `SchedulingDisabled`, and `Tainted (2)`.
- Full suite green (323 frontend tests, `cargo test` green); `vite build` succeeds.

## Notes

- `taints` counts all remaining taints, including the standard control-plane `NoSchedule` taint — so control-plane nodes will read "Tainted". That's accurate and matches the request to surface taints; can be filtered further if you'd prefer to hide well-known taints.