### PR TITLE
feat(storage): typed live views for PVCs, PVs, StorageClasses

### DIFF
--- a/apps/desktop/src-tauri/src/capabilities.rs
+++ b/apps/desktop/src-tauri/src/capabilities.rs
@@ -105,6 +105,14 @@ pub fn build_registry_with(cache: Arc<ClientCache>) -> Registry {
     reg.register(srelens_kube::networkpolicies::list_networkpolicies_capability(
         cache.clone(),
     ));
+    reg.register(srelens_kube::pvcs::list_pvcs_capability(cache.clone()));
+    reg.register(srelens_kube::pvcs::pods_for_pvc_capability(cache.clone()));
+    reg.register(srelens_kube::persistentvolumes::list_pvs_capability(
+        cache.clone(),
+    ));
+    reg.register(srelens_kube::storageclasses::list_storageclasses_capability(
+        cache.clone(),
+    ));
     reg.register(srelens_kube::actions::delete_pod_capability(cache.clone()));
     reg.register(srelens_kube::actions::evict_pod_capability(cache.clone()));
     reg.register(srelens_kube::actions::delete_resource_capability(cache.clone()));

--- a/apps/desktop/src-tauri/src/watch.rs
+++ b/apps/desktop/src-tauri/src/watch.rs
@@ -244,6 +244,45 @@ pub async fn start_resource_watch(
                 )
                 .await
             }
+            "persistentvolumeclaims" => {
+                let (a, c) = (app_out.clone(), emit_channel.clone());
+                srelens_kube::watch::watch_pvcs(
+                    cache,
+                    context,
+                    namespace,
+                    move |rows| {
+                        let _ = a.emit(&c, rows);
+                    },
+                    status_of!(),
+                )
+                .await
+            }
+            "persistentvolumes" => {
+                let (a, c) = (app_out.clone(), emit_channel.clone());
+                srelens_kube::watch::watch_persistentvolumes(
+                    cache,
+                    context,
+                    namespace,
+                    move |rows| {
+                        let _ = a.emit(&c, rows);
+                    },
+                    status_of!(),
+                )
+                .await
+            }
+            "storageclasses" => {
+                let (a, c) = (app_out.clone(), emit_channel.clone());
+                srelens_kube::watch::watch_storageclasses(
+                    cache,
+                    context,
+                    namespace,
+                    move |rows| {
+                        let _ = a.emit(&c, rows);
+                    },
+                    status_of!(),
+                )
+                .await
+            }
             "events" => {
                 let (a, c) = (app_out.clone(), emit_channel.clone());
                 srelens_kube::watch::watch_events(

--- a/apps/desktop/src/components/ResourceBrowser.test.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.test.tsx
@@ -281,16 +281,18 @@ describe("ResourceBrowser", () => {
     expect(screen.getByText("Ingress, Egress")).toBeDefined();
   });
 
-  it("streams PVCs live with status, capacity and bound volume", async () => {
+  it("streams PVCs live and humanizes a raw-byte capacity", async () => {
     listNamespacesMock.mockResolvedValue({ namespaces: ["default"] });
     watchResourceMock.mockImplementation(
       watchWith([
-        { name: "data", namespace: "default", status: "Bound", capacity: "10Gi", accessModes: "RWO", storageClass: "standard", volume: "pv-123", age: "3d" },
+        // Raw bytes as MinIO/some provisioners report — must render as a size, not digits.
+        { name: "data", namespace: "default", status: "Bound", capacity: "7586630231655", accessModes: "RWO", storageClass: "standard", volume: "pv-123", age: "3d" },
       ]),
     );
     render(<ResourceBrowser context="kind-dev" kind="persistentvolumeclaims" />);
     await waitFor(() => expect(screen.getByText("data")).toBeDefined());
-    expect(screen.getByText("10Gi")).toBeDefined();
+    expect(screen.getByText("6.9Ti")).toBeDefined();
+    expect(screen.queryByText("7586630231655")).toBeNull();
     expect(screen.getByText("pv-123")).toBeDefined();
   });
 

--- a/apps/desktop/src/components/ResourceBrowser.test.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.test.tsx
@@ -56,6 +56,9 @@ vi.mock("../lib/watch", () => ({
     "ingresses",
     "endpointslices",
     "networkpolicies",
+    "persistentvolumeclaims",
+    "persistentvolumes",
+    "storageclasses",
   ],
 }));
 vi.mock("./PodTerminal", () => ({ PodTerminal: () => <div data-testid="pod-terminal" /> }));
@@ -276,6 +279,55 @@ describe("ResourceBrowser", () => {
     await waitFor(() => expect(screen.getByText("deny")).toBeDefined());
     expect(screen.getByText("app=web")).toBeDefined();
     expect(screen.getByText("Ingress, Egress")).toBeDefined();
+  });
+
+  it("streams PVCs live with status, capacity and bound volume", async () => {
+    listNamespacesMock.mockResolvedValue({ namespaces: ["default"] });
+    watchResourceMock.mockImplementation(
+      watchWith([
+        { name: "data", namespace: "default", status: "Bound", capacity: "10Gi", accessModes: "RWO", storageClass: "standard", volume: "pv-123", age: "3d" },
+      ]),
+    );
+    render(<ResourceBrowser context="kind-dev" kind="persistentvolumeclaims" />);
+    await waitFor(() => expect(screen.getByText("data")).toBeDefined());
+    expect(screen.getByText("10Gi")).toBeDefined();
+    expect(screen.getByText("pv-123")).toBeDefined();
+  });
+
+  it("streams cluster PersistentVolumes live (no namespace) with reclaim policy and claim", async () => {
+    listNamespacesMock.mockResolvedValue({ namespaces: [] });
+    watchResourceMock.mockImplementation(
+      watchWith([
+        { name: "pv-123", capacity: "20Gi", accessModes: "RWO", reclaimPolicy: "Retain", status: "Bound", claim: "default/data", storageClass: "standard", age: "5d" },
+      ]),
+    );
+    render(<ResourceBrowser context="kind-dev" kind="persistentvolumes" />);
+    await waitFor(() =>
+      expect(watchResourceMock).toHaveBeenCalledWith(
+        "kind-dev",
+        "",
+        "persistentvolumes",
+        expect.any(Function),
+        expect.any(Function),
+      ),
+    );
+    expect(await screen.findByText("pv-123")).toBeDefined();
+    expect(screen.getByText("Retain")).toBeDefined();
+    expect(screen.getByText("default/data")).toBeDefined();
+  });
+
+  it("streams StorageClasses live and marks the default", async () => {
+    listNamespacesMock.mockResolvedValue({ namespaces: [] });
+    watchResourceMock.mockImplementation(
+      watchWith([
+        { name: "standard", provisioner: "kubernetes.io/aws-ebs", reclaimPolicy: "Delete", volumeBindingMode: "WaitForFirstConsumer", default: true, age: "9d" },
+      ]),
+    );
+    render(<ResourceBrowser context="kind-dev" kind="storageclasses" />);
+    await waitFor(() => expect(screen.getByText("standard")).toBeDefined());
+    expect(screen.getByText("kubernetes.io/aws-ebs")).toBeDefined();
+    // "Default" appears as both the column header and the badge on the default class.
+    expect(screen.getAllByText("Default").length).toBeGreaterThanOrEqual(2);
   });
 
   it("starts on the provided namespace and reports filter changes", async () => {

--- a/apps/desktop/src/components/ResourceBrowser.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.tsx
@@ -30,6 +30,11 @@ import {
   type EndpointSliceSummary,
   type NetworkPolicySummary,
 } from "../lib/network";
+import {
+  type PvcSummary,
+  type PvSummary,
+  type StorageClassSummary,
+} from "../lib/storage";
 
 type NodeRow = NodeSummary & { cpu?: number; memory?: number };
 type PodRow = PodSummary & { cpu?: number; memory?: number };
@@ -217,6 +222,9 @@ const TYPED_KINDS: ResourceKind[] = [
   "ingresses",
   "endpointslices",
   "networkpolicies",
+  "persistentvolumeclaims",
+  "persistentvolumes",
+  "storageclasses",
   "nodes",
   "events",
 ];
@@ -386,6 +394,37 @@ const networkPolicyColumns: Column<NetworkPolicySummary>[] = [
   { key: "egress", header: "Egress" },
   { key: "policyTypes", header: "Policy Types", render: (n) => <Muted>{n.policyTypes || "—"}</Muted> },
   { key: "age", header: "Age", render: (n) => <Muted>{n.age}</Muted> },
+];
+
+const pvcColumns: Column<PvcSummary>[] = [
+  { key: "name", header: "Claim", render: (p) => <strong>{p.name}</strong> },
+  { key: "namespace", header: "Namespace", render: (p) => <span className="fl-link">{p.namespace}</span> },
+  { key: "status", header: "Status", render: (p) => <StatusPill status={p.status} kind={phaseKind(p.status === "Bound" ? "Ready" : p.status)} /> },
+  { key: "capacity", header: "Capacity", render: (p) => <Muted>{p.capacity || "—"}</Muted> },
+  { key: "accessModes", header: "Access Modes", render: (p) => <Muted>{p.accessModes || "—"}</Muted> },
+  { key: "storageClass", header: "Storage Class", render: (p) => <span className="fl-link">{p.storageClass || "—"}</span> },
+  { key: "volume", header: "Volume", render: (p) => <span className="fl-link">{p.volume || "—"}</span> },
+  { key: "age", header: "Age", render: (p) => <Muted>{p.age}</Muted> },
+];
+
+const pvColumns: Column<PvSummary>[] = [
+  { key: "name", header: "Volume", render: (p) => <strong>{p.name}</strong> },
+  { key: "capacity", header: "Capacity", render: (p) => <Muted>{p.capacity || "—"}</Muted> },
+  { key: "accessModes", header: "Access Modes", render: (p) => <Muted>{p.accessModes || "—"}</Muted> },
+  { key: "reclaimPolicy", header: "Reclaim", render: (p) => <Muted>{p.reclaimPolicy || "—"}</Muted> },
+  { key: "status", header: "Status", render: (p) => <StatusPill status={p.status} kind={phaseKind(p.status === "Bound" || p.status === "Available" ? "Ready" : p.status)} /> },
+  { key: "claim", header: "Claim", render: (p) => <span className="fl-link">{p.claim || "—"}</span> },
+  { key: "storageClass", header: "Storage Class", render: (p) => <span className="fl-link">{p.storageClass || "—"}</span> },
+  { key: "age", header: "Age", render: (p) => <Muted>{p.age}</Muted> },
+];
+
+const storageClassColumns: Column<StorageClassSummary>[] = [
+  { key: "name", header: "Storage Class", render: (s) => <strong>{s.name}</strong> },
+  { key: "provisioner", header: "Provisioner", render: (s) => <Muted>{s.provisioner}</Muted> },
+  { key: "reclaimPolicy", header: "Reclaim", render: (s) => <Muted>{s.reclaimPolicy || "—"}</Muted> },
+  { key: "volumeBindingMode", header: "Binding Mode", render: (s) => <Muted>{s.volumeBindingMode || "—"}</Muted> },
+  { key: "default", header: "Default", render: (s) => (s.default ? <StatusPill status="Default" kind="success" /> : <Muted>—</Muted>) },
+  { key: "age", header: "Age", render: (s) => <Muted>{s.age}</Muted> },
 ];
 
 const nodeColumns: Column<NodeRow>[] = [
@@ -644,6 +683,12 @@ export function ResourceBrowser({
         return endpointSliceColumns as Column<{ name: string }>[];
       case "networkpolicies":
         return networkPolicyColumns as Column<{ name: string }>[];
+      case "persistentvolumeclaims":
+        return pvcColumns as Column<{ name: string }>[];
+      case "persistentvolumes":
+        return pvColumns as Column<{ name: string }>[];
+      case "storageclasses":
+        return storageClassColumns as Column<{ name: string }>[];
       default:
         return nodeColumns as Column<{ name: string }>[];
     }

--- a/apps/desktop/src/components/ResourceBrowser.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.tsx
@@ -31,6 +31,7 @@ import {
   type NetworkPolicySummary,
 } from "../lib/network";
 import {
+  formatStorageSize,
   type PvcSummary,
   type PvSummary,
   type StorageClassSummary,
@@ -400,7 +401,7 @@ const pvcColumns: Column<PvcSummary>[] = [
   { key: "name", header: "Claim", render: (p) => <strong>{p.name}</strong> },
   { key: "namespace", header: "Namespace", render: (p) => <span className="fl-link">{p.namespace}</span> },
   { key: "status", header: "Status", render: (p) => <StatusPill status={p.status} kind={phaseKind(p.status === "Bound" ? "Ready" : p.status)} /> },
-  { key: "capacity", header: "Capacity", render: (p) => <Muted>{p.capacity || "—"}</Muted> },
+  { key: "capacity", header: "Capacity", render: (p) => <Muted>{formatStorageSize(p.capacity)}</Muted> },
   { key: "accessModes", header: "Access Modes", render: (p) => <Muted>{p.accessModes || "—"}</Muted> },
   { key: "storageClass", header: "Storage Class", render: (p) => <span className="fl-link">{p.storageClass || "—"}</span> },
   { key: "volume", header: "Volume", render: (p) => <span className="fl-link">{p.volume || "—"}</span> },
@@ -409,7 +410,7 @@ const pvcColumns: Column<PvcSummary>[] = [
 
 const pvColumns: Column<PvSummary>[] = [
   { key: "name", header: "Volume", render: (p) => <strong>{p.name}</strong> },
-  { key: "capacity", header: "Capacity", render: (p) => <Muted>{p.capacity || "—"}</Muted> },
+  { key: "capacity", header: "Capacity", render: (p) => <Muted>{formatStorageSize(p.capacity)}</Muted> },
   { key: "accessModes", header: "Access Modes", render: (p) => <Muted>{p.accessModes || "—"}</Muted> },
   { key: "reclaimPolicy", header: "Reclaim", render: (p) => <Muted>{p.reclaimPolicy || "—"}</Muted> },
   { key: "status", header: "Status", render: (p) => <StatusPill status={p.status} kind={phaseKind(p.status === "Bound" || p.status === "Available" ? "Ready" : p.status)} /> },

--- a/apps/desktop/src/components/ResourceOverview.test.tsx
+++ b/apps/desktop/src/components/ResourceOverview.test.tsx
@@ -18,6 +18,8 @@ vi.mock("../lib/manifest", async (importOriginal) => ({
 }));
 const { listEndpointSlicesMock } = vi.hoisted(() => ({ listEndpointSlicesMock: vi.fn() }));
 vi.mock("../lib/network", () => ({ listEndpointSlices: listEndpointSlicesMock }));
+const { podsForPvcMock } = vi.hoisted(() => ({ podsForPvcMock: vi.fn() }));
+vi.mock("../lib/storage", () => ({ podsForPvc: podsForPvcMock }));
 
 import {
   ResourceOverview,
@@ -30,10 +32,11 @@ import type { K8sObject } from "../lib/manifest";
 
 const NOW = Date.parse("2026-01-01T00:00:00Z");
 
-// Service detail lists its EndpointSlices; default to none so tests that render
-// a Service without exercising that link don't hit an unmocked call.
+// Service/PVC details fetch related resources; default to none so tests that
+// render them without exercising those links don't hit an unmocked call.
 beforeEach(() => {
   listEndpointSlicesMock.mockResolvedValue({ endpointslices: [] });
+  podsForPvcMock.mockResolvedValue({ pods: [] });
 });
 const TLS_CERTIFICATE = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURPakNDQWlLZ0F3SUJBZ0lVSjVQdnk1NXRIbUhESkd3elhNVld2YnV4ck5nd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0Z6RVZNQk1HQTFVRUF3d01aWGhoYlhCc1pTNTBaWE4wTUI0WERUSTJNRGN3TmpFeE1qazFOVm9YRFRNMgpNRGN3TXpFeE1qazFOVm93RnpFVk1CTUdBMVVFQXd3TVpYaGhiWEJzWlM1MFpYTjBNSUlCSWpBTkJna3Foa2lHCjl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUFzeFc2aHU0MVVwYittNXpHZm5aZ2tpT0xuaVhYTmhPYzhvTWgKaFZCcDVXL0Y5aXluelBGQjRGM0NOK2VlaEp1aVhYWHVFUWdQUVFqOVIrV3ErYlBUK1JPOHd6cEJqQ1BYaHo1TAp2Z0dzNDR1cXBQQ2JvUXVpV0RYcmZDWWtUT2xyd0tIZWJDcVRRM2FQUk1hUGk0YkhzRHdNdmlUcDRhMERGVTFWCkhGc2RXcHM0Uis3TG1MSXBhU3RUTTV1bU1qSC9FTzJGZ2psQmhYUUVGT1M0UnZ2WGpoV0E1ZGZiMEtwNUVSNFIKZjFGdktCRTNaTzVmbG5ldlFlTGdyMnZZT2Jhalg5OTQ1NVE0L1UwMTJJZG1ldWV4L2Q1ZU5VV0VNelprZzlrUQp1U00vMFpwbkhEVFU4UXZQTHh0Qy9jSlU1ekdKMzM0ZnppTGVmQUlpbDR2NFRvVzBQd0lEQVFBQm8zNHdmREFkCkJnTlZIUTRFRmdRVWxadEVndTl1L3ZTTVptSmNNa2RUcWhWVmJDSXdId1lEVlIwakJCZ3dGb0FVbFp0RWd1OXUKL3ZTTVptSmNNa2RUcWhWVmJDSXdEd1lEVlIwVEFRSC9CQVV3QXdFQi96QXBCZ05WSFJFRUlqQWdnZ3hsZUdGdApjR3hsTG5SbGMzU0NFSGQzZHk1bGVHRnRjR3hsTG5SbGMzUXdEUVlKS29aSWh2Y05BUUVMQlFBRGdnRUJBR2svCnp6cGhUNnRuNCtxUXg5Ly9meWNkSzFtNjg1eW1TRFZqT3ZXeWRQaWg4RzI4OUJkQ1BmYlc4ZVVrOXJqakJVZWcKR1k5OUJMcEhvcW9zZDNVWEhOUDJzWUdnZ0dZOG40QXdSbFFWZi9qajBPenVWUzZpS0FDM1ZXWFBtdGk5Q1JQZwpHVkdaR0VZMWI1SXYwVStaSzBjYlJ6c1NSN0FBN05VWGhTUUg0NjJDQlpJa1JSTXNFcVhSV2huUG5Kd3phLzJJCmJ1REdiTG1WMmhRUTdJeWJtb0FpL1FQVUM5WldrMExOV2pGYlpDa0kvem4wd2QxWVhham1iTHBSV0dsTjR1LzcKL2NDSER6NDNyWTZXeHJNRjVwYkJ5aWcvWk5obUVZK25rSFhwK2ZoRFdZOGV1QVVxT1p4bUQrNFIzL2lPQ2dhYgpsVWMzUnNCdmExVjNSbFB6K0pvPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==";
 
@@ -539,6 +542,21 @@ describe("ObjectDetail (storage links)", () => {
       namespace: "default",
       name: "data",
     });
+  });
+
+  it("lists the pods consuming a claim (PVC → consuming pods)", async () => {
+    podsForPvcMock.mockResolvedValue({ pods: [{ name: "web-1", namespace: "default" }] });
+    const pvc: K8sObject = {
+      kind: "PersistentVolumeClaim",
+      metadata: { name: "data", namespace: "default" },
+      spec: { volumeName: "pv-data", storageClassName: "fast", accessModes: ["ReadWriteOnce"] },
+      status: { phase: "Bound", capacity: { storage: "10Gi" } },
+    };
+    render(
+      <ObjectDetail kind="PersistentVolumeClaim" obj={pvc} now={NOW} context="kind-dev" onOpenResource={() => {}} />,
+    );
+    await waitFor(() => expect(podsForPvcMock).toHaveBeenCalledWith("kind-dev", "default", "data"));
+    expect(await screen.findByText("Pod/web-1")).toBeDefined();
   });
 });
 

--- a/apps/desktop/src/components/ResourceOverview.test.tsx
+++ b/apps/desktop/src/components/ResourceOverview.test.tsx
@@ -19,7 +19,10 @@ vi.mock("../lib/manifest", async (importOriginal) => ({
 const { listEndpointSlicesMock } = vi.hoisted(() => ({ listEndpointSlicesMock: vi.fn() }));
 vi.mock("../lib/network", () => ({ listEndpointSlices: listEndpointSlicesMock }));
 const { podsForPvcMock } = vi.hoisted(() => ({ podsForPvcMock: vi.fn() }));
-vi.mock("../lib/storage", () => ({ podsForPvc: podsForPvcMock }));
+vi.mock("../lib/storage", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/storage")>()),
+  podsForPvc: podsForPvcMock,
+}));
 
 import {
   ResourceOverview,

--- a/apps/desktop/src/components/ResourceOverview.tsx
+++ b/apps/desktop/src/components/ResourceOverview.tsx
@@ -3,6 +3,7 @@ import { ArrowLeftRight, ChevronDown, ChevronUp } from "lucide-react";
 import type { X509Certificate } from "@peculiar/x509";
 import { getObject, getSecret, type K8sObject } from "../lib/manifest";
 import { listEndpointSlices } from "../lib/network";
+import { podsForPvc } from "../lib/storage";
 import { updateConfigData } from "../lib/actions";
 import {
   Spinner,
@@ -1817,42 +1818,77 @@ function ConfigBody({
   );
 }
 
-function PvcBody({ obj, onOpenResource }: { obj: K8sObject; onOpenResource?: OpenResource }) {
+function PvcBody({
+  obj,
+  context = "",
+  onOpenResource,
+}: {
+  obj: K8sObject;
+  context?: string;
+  onOpenResource?: OpenResource;
+}) {
   const spec = asRecord(obj.spec);
   const status = asRecord(obj.status);
+  const meta = asRecord(obj.metadata);
+  const namespace = str(meta.namespace) || null;
+  const name = str(meta.name);
   const phase = str(status.phase);
+
+  // Pods that mount this claim — the backend scans pod volumes for the claim
+  // name; completes the PVC → consuming pods navigation.
+  const [podTargets, setPodTargets] = useState<ResourceTarget[]>([]);
+  useEffect(() => {
+    setPodTargets([]);
+    if (!context || !namespace || !name) return;
+    let active = true;
+    void podsForPvc(context, namespace, name).then((r) => {
+      if (!active) return;
+      setPodTargets((r.pods ?? []).map((p) => ({ kind: "Pod", namespace, name: p.name })));
+    });
+    return () => {
+      active = false;
+    };
+  }, [context, namespace, name]);
+
   return (
-    <Section title="Volume">
-      <KV
-        pairs={[
-          ["Status", <StatusPill key="s" status={phase || "—"} kind={phaseKind(phase)} />],
-          ["Capacity", str(asRecord(status.capacity).storage)],
-          ["Access modes", asArray(spec.accessModes).map(str).join(", ")],
-          [
-            "Storage class",
-            spec.storageClassName ? (
-              <ResourceLink
-                target={{ kind: "StorageClass", namespace: null, name: str(spec.storageClassName) }}
-                onOpenResource={onOpenResource}
-              />
-            ) : (
-              ""
-            ),
-          ],
-          [
-            "Volume",
-            spec.volumeName ? (
-              <ResourceLink
-                target={{ kind: "PersistentVolume", namespace: null, name: str(spec.volumeName) }}
-                onOpenResource={onOpenResource}
-              />
-            ) : (
-              ""
-            ),
-          ],
-        ]}
-      />
-    </Section>
+    <>
+      <Section title="Volume">
+        <KV
+          pairs={[
+            ["Status", <StatusPill key="s" status={phase || "—"} kind={phaseKind(phase)} />],
+            ["Capacity", str(asRecord(status.capacity).storage)],
+            ["Access modes", asArray(spec.accessModes).map(str).join(", ")],
+            [
+              "Storage class",
+              spec.storageClassName ? (
+                <ResourceLink
+                  target={{ kind: "StorageClass", namespace: null, name: str(spec.storageClassName) }}
+                  onOpenResource={onOpenResource}
+                />
+              ) : (
+                ""
+              ),
+            ],
+            [
+              "Volume",
+              spec.volumeName ? (
+                <ResourceLink
+                  target={{ kind: "PersistentVolume", namespace: null, name: str(spec.volumeName) }}
+                  onOpenResource={onOpenResource}
+                />
+              ) : (
+                ""
+              ),
+            ],
+          ]}
+        />
+      </Section>
+      {podTargets.length > 0 && (
+        <Section title="Consumed by">
+          <LinkedResources targets={podTargets} onOpenResource={onOpenResource} />
+        </Section>
+      )}
+    </>
   );
 }
 
@@ -2475,7 +2511,7 @@ function KindBody({
     case "Secret":
       return <SecretBody obj={obj} context={context} onEdited={onEdited} />;
     case "PersistentVolumeClaim":
-      return <PvcBody obj={obj} onOpenResource={onOpenResource} />;
+      return <PvcBody obj={obj} context={context} onOpenResource={onOpenResource} />;
     case "PersistentVolume":
       return <PersistentVolumeBody obj={obj} onOpenResource={onOpenResource} />;
     case "Ingress":

--- a/apps/desktop/src/components/ResourceOverview.tsx
+++ b/apps/desktop/src/components/ResourceOverview.tsx
@@ -3,7 +3,7 @@ import { ArrowLeftRight, ChevronDown, ChevronUp } from "lucide-react";
 import type { X509Certificate } from "@peculiar/x509";
 import { getObject, getSecret, type K8sObject } from "../lib/manifest";
 import { listEndpointSlices } from "../lib/network";
-import { podsForPvc } from "../lib/storage";
+import { podsForPvc, formatStorageSize } from "../lib/storage";
 import { updateConfigData } from "../lib/actions";
 import {
   Spinner,
@@ -1856,7 +1856,7 @@ function PvcBody({
         <KV
           pairs={[
             ["Status", <StatusPill key="s" status={phase || "—"} kind={phaseKind(phase)} />],
-            ["Capacity", str(asRecord(status.capacity).storage)],
+            ["Capacity", formatStorageSize(str(asRecord(status.capacity).storage))],
             ["Access modes", asArray(spec.accessModes).map(str).join(", ")],
             [
               "Storage class",
@@ -1909,7 +1909,7 @@ function PersistentVolumeBody({
       <KV
         pairs={[
           ["Status", <StatusPill key="s" status={phase || "—"} kind={phaseKind(phase)} />],
-          ["Capacity", str(asRecord(spec.capacity).storage)],
+          ["Capacity", formatStorageSize(str(asRecord(spec.capacity).storage))],
           ["Access modes", asArray(spec.accessModes).map(str).join(", ")],
           ["Reclaim policy", str(spec.persistentVolumeReclaimPolicy)],
           ["Volume mode", str(spec.volumeMode)],

--- a/apps/desktop/src/lib/storage.test.ts
+++ b/apps/desktop/src/lib/storage.test.ts
@@ -1,5 +1,31 @@
 import { describe, it, expect, vi } from "vitest";
-import { listPersistentVolumeClaims, listPersistentVolumes, listStorageClasses, podsForPvc } from "./storage";
+import {
+  listPersistentVolumeClaims,
+  listPersistentVolumes,
+  listStorageClasses,
+  podsForPvc,
+  formatStorageSize,
+} from "./storage";
+
+describe("formatStorageSize", () => {
+  it("humanizes a raw byte quantity to the nearest binary unit", () => {
+    expect(formatStorageSize("7586630231655")).toBe("6.9Ti");
+    expect(formatStorageSize("1073741824")).toBe("1Gi");
+    expect(formatStorageSize("536870912")).toBe("512Mi");
+  });
+
+  it("normalizes an already-suffixed quantity", () => {
+    expect(formatStorageSize("10Gi")).toBe("10Gi");
+    expect(formatStorageSize("500Mi")).toBe("500Mi");
+    expect(formatStorageSize("5G")).toBe("4.7Gi");
+  });
+
+  it("shows raw bytes below 1Ki and a dash for empty/invalid", () => {
+    expect(formatStorageSize("512")).toBe("512");
+    expect(formatStorageSize("")).toBe("—");
+    expect(formatStorageSize("nonsense")).toBe("nonsense");
+  });
+});
 
 describe("listPersistentVolumeClaims", () => {
   it("calls k8s.listPersistentVolumeClaims and returns typed rows", async () => {

--- a/apps/desktop/src/lib/storage.test.ts
+++ b/apps/desktop/src/lib/storage.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from "vitest";
+import { listPersistentVolumeClaims, listPersistentVolumes, listStorageClasses, podsForPvc } from "./storage";
+
+describe("listPersistentVolumeClaims", () => {
+  it("calls k8s.listPersistentVolumeClaims and returns typed rows", async () => {
+    const invoke = vi.fn().mockResolvedValue({
+      persistentvolumeclaims: [
+        { name: "data", namespace: "default", status: "Bound", capacity: "10Gi", accessModes: "RWO", storageClass: "standard", volume: "pv-123", age: "3d" },
+      ],
+    });
+    const out = await listPersistentVolumeClaims("kind-dev", "default", invoke);
+    expect(invoke).toHaveBeenCalledWith("k8s.listPersistentVolumeClaims", { context: "kind-dev", namespace: "default" });
+    expect(out.persistentvolumeclaims?.[0].volume).toBe("pv-123");
+  });
+
+  it("returns an error string when the call rejects", async () => {
+    const out = await listPersistentVolumeClaims("x", "default", () => Promise.reject(new Error("boom")));
+    expect(out.error).toContain("boom");
+  });
+});
+
+describe("listPersistentVolumes", () => {
+  it("calls k8s.listPersistentVolumes (cluster-scoped, no namespace)", async () => {
+    const invoke = vi.fn().mockResolvedValue({
+      persistentvolumes: [
+        { name: "pv-123", capacity: "20Gi", accessModes: "RWO", reclaimPolicy: "Retain", status: "Bound", claim: "default/data", storageClass: "standard", age: "5d" },
+      ],
+    });
+    const out = await listPersistentVolumes("kind-dev", invoke);
+    expect(invoke).toHaveBeenCalledWith("k8s.listPersistentVolumes", { context: "kind-dev" });
+    expect(out.persistentvolumes?.[0].claim).toBe("default/data");
+  });
+});
+
+describe("podsForPvc", () => {
+  it("calls k8s.podsForPvc with the claim name", async () => {
+    const invoke = vi.fn().mockResolvedValue({ pods: [{ name: "web-1", namespace: "default" }] });
+    const out = await podsForPvc("kind-dev", "default", "data", invoke);
+    expect(invoke).toHaveBeenCalledWith("k8s.podsForPvc", { context: "kind-dev", namespace: "default", pvc: "data" });
+    expect(out.pods?.[0].name).toBe("web-1");
+  });
+});
+
+describe("listStorageClasses", () => {
+  it("calls k8s.listStorageClasses and flags the default", async () => {
+    const invoke = vi.fn().mockResolvedValue({
+      storageclasses: [
+        { name: "standard", provisioner: "kubernetes.io/aws-ebs", reclaimPolicy: "Delete", volumeBindingMode: "WaitForFirstConsumer", default: true, age: "9d" },
+      ],
+    });
+    const out = await listStorageClasses("kind-dev", invoke);
+    expect(invoke).toHaveBeenCalledWith("k8s.listStorageClasses", { context: "kind-dev" });
+    expect(out.storageclasses?.[0].default).toBe(true);
+  });
+});

--- a/apps/desktop/src/lib/storage.ts
+++ b/apps/desktop/src/lib/storage.ts
@@ -1,6 +1,48 @@
 import { invokeCapability, type Invoker } from "../transport/transport";
 import type { PodSummary } from "./workloads";
 
+const BINARY_UNITS: Array<[string, number]> = [
+  ["Pi", 2 ** 50],
+  ["Ti", 2 ** 40],
+  ["Gi", 2 ** 30],
+  ["Mi", 2 ** 20],
+  ["Ki", 2 ** 10],
+];
+const UNIT_FACTORS: Record<string, number> = {
+  Ki: 2 ** 10, Mi: 2 ** 20, Gi: 2 ** 30, Ti: 2 ** 40, Pi: 2 ** 50, Ei: 2 ** 60,
+  k: 1e3, M: 1e6, G: 1e9, T: 1e12, P: 1e15, E: 1e18,
+};
+
+/** Parse a Kubernetes storage Quantity ("10Gi", "5G", "7586630231655") to bytes. */
+function quantityToBytes(quantity: string): number | null {
+  const m = /^([0-9.]+)\s*([a-zA-Z]*)$/.exec((quantity ?? "").trim());
+  if (!m) return null;
+  const n = parseFloat(m[1]);
+  if (Number.isNaN(n)) return null;
+  const unit = m[2];
+  if (unit === "") return n;
+  return UNIT_FACTORS[unit] ? n * UNIT_FACTORS[unit] : n;
+}
+
+/**
+ * Render a storage Quantity as a compact binary size ("6.9Ti", "10Gi"). Raw
+ * byte quantities (as MinIO and some provisioners report) become the nearest
+ * Ki/Mi/Gi/Ti/Pi; values below 1Ki stay as bytes, and an empty value shows "—".
+ */
+export function formatStorageSize(quantity: string): string {
+  if (!quantity) return "—";
+  const bytes = quantityToBytes(quantity);
+  if (bytes == null) return quantity;
+  if (bytes === 0) return "0";
+  for (const [suffix, factor] of BINARY_UNITS) {
+    if (bytes >= factor) {
+      const value = bytes / factor;
+      return `${value.toFixed(1).replace(/\.0$/, "")}${suffix}`;
+    }
+  }
+  return `${bytes}`;
+}
+
 /** PersistentVolumeClaim row — mirrors `crates/kube/src/pvcs.rs`. */
 export interface PvcSummary {
   name: string;

--- a/apps/desktop/src/lib/storage.ts
+++ b/apps/desktop/src/lib/storage.ts
@@ -1,0 +1,95 @@
+import { invokeCapability, type Invoker } from "../transport/transport";
+import type { PodSummary } from "./workloads";
+
+/** PersistentVolumeClaim row — mirrors `crates/kube/src/pvcs.rs`. */
+export interface PvcSummary {
+  name: string;
+  namespace: string;
+  status: string;
+  capacity: string;
+  accessModes: string;
+  storageClass: string;
+  volume: string;
+  age: string;
+}
+
+/** PersistentVolume row — mirrors `crates/kube/src/persistentvolumes.rs` (cluster-scoped). */
+export interface PvSummary {
+  name: string;
+  capacity: string;
+  accessModes: string;
+  reclaimPolicy: string;
+  status: string;
+  /** Bound claim as "namespace/name", empty when unbound. */
+  claim: string;
+  storageClass: string;
+  age: string;
+}
+
+/** StorageClass row — mirrors `crates/kube/src/storageclasses.rs` (cluster-scoped). */
+export interface StorageClassSummary {
+  name: string;
+  provisioner: string;
+  reclaimPolicy: string;
+  volumeBindingMode: string;
+  default: boolean;
+  age: string;
+}
+
+/** List PVCs in a namespace via `k8s.listPersistentVolumeClaims`. */
+export async function listPersistentVolumeClaims(
+  context: string,
+  namespace: string,
+  invoke: Invoker = invokeCapability,
+): Promise<{ persistentvolumeclaims?: PvcSummary[]; error?: string }> {
+  try {
+    const out = await invoke<{ persistentvolumeclaims: PvcSummary[] }>("k8s.listPersistentVolumeClaims", {
+      context,
+      namespace,
+    });
+    return { persistentvolumeclaims: out.persistentvolumeclaims };
+  } catch (e) {
+    return { error: String(e) };
+  }
+}
+
+/** List cluster PersistentVolumes via `k8s.listPersistentVolumes`. */
+export async function listPersistentVolumes(
+  context: string,
+  invoke: Invoker = invokeCapability,
+): Promise<{ persistentvolumes?: PvSummary[]; error?: string }> {
+  try {
+    const out = await invoke<{ persistentvolumes: PvSummary[] }>("k8s.listPersistentVolumes", { context });
+    return { persistentvolumes: out.persistentvolumes };
+  } catch (e) {
+    return { error: String(e) };
+  }
+}
+
+/** List pods that mount a PVC via `k8s.podsForPvc` (the claim's consumers). */
+export async function podsForPvc(
+  context: string,
+  namespace: string,
+  pvc: string,
+  invoke: Invoker = invokeCapability,
+): Promise<{ pods?: PodSummary[]; error?: string }> {
+  try {
+    const out = await invoke<{ pods: PodSummary[] }>("k8s.podsForPvc", { context, namespace, pvc });
+    return { pods: out.pods };
+  } catch (e) {
+    return { error: String(e) };
+  }
+}
+
+/** List cluster StorageClasses via `k8s.listStorageClasses`. */
+export async function listStorageClasses(
+  context: string,
+  invoke: Invoker = invokeCapability,
+): Promise<{ storageclasses?: StorageClassSummary[]; error?: string }> {
+  try {
+    const out = await invoke<{ storageclasses: StorageClassSummary[] }>("k8s.listStorageClasses", { context });
+    return { storageclasses: out.storageclasses };
+  } catch (e) {
+    return { error: String(e) };
+  }
+}

--- a/apps/desktop/src/lib/watch.ts
+++ b/apps/desktop/src/lib/watch.ts
@@ -23,6 +23,9 @@ export const WATCHABLE_KINDS = [
   "ingresses",
   "endpointslices",
   "networkpolicies",
+  "persistentvolumeclaims",
+  "persistentvolumes",
+  "storageclasses",
   "events",
 ] as const;
 

--- a/crates/kube/src/lib.rs
+++ b/crates/kube/src/lib.rs
@@ -31,6 +31,36 @@ pub(crate) fn humanize_age(creation: Option<&Time>) -> String {
     }
 }
 
+/// Abbreviate PV/PVC access modes ("ReadWriteOnce" → "RWO"), comma-joined.
+pub(crate) fn abbreviate_access_modes(modes: Option<&Vec<String>>) -> String {
+    modes
+        .map(|m| {
+            m.iter()
+                .map(|mode| match mode.as_str() {
+                    "ReadWriteOnce" => "RWO",
+                    "ReadOnlyMany" => "ROX",
+                    "ReadWriteMany" => "RWX",
+                    "ReadWriteOncePod" => "RWOP",
+                    other => other,
+                })
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod access_mode_tests {
+    use super::abbreviate_access_modes;
+
+    #[test]
+    fn abbreviates_known_modes() {
+        let modes = vec!["ReadWriteOnce".to_string(), "ReadOnlyMany".to_string()];
+        assert_eq!(abbreviate_access_modes(Some(&modes)), "RWO, ROX");
+        assert_eq!(abbreviate_access_modes(None), "");
+    }
+}
+
 /// Build a namespaced API, or an all-namespaces API when `namespace` is empty.
 /// An empty namespace is how the UI requests "All namespaces".
 pub(crate) fn scoped_api<K>(client: Client, namespace: &str) -> Api<K>
@@ -84,10 +114,13 @@ pub mod manifest;
 pub mod metrics;
 pub mod networkpolicies;
 pub mod nodes;
+pub mod persistentvolumes;
+pub mod pvcs;
 pub mod resourcequotas;
 pub mod schema;
 pub mod secrets;
 pub mod services;
 pub mod statefulsets;
+pub mod storageclasses;
 pub mod watch;
 pub mod workloads;

--- a/crates/kube/src/persistentvolumes.rs
+++ b/crates/kube/src/persistentvolumes.rs
@@ -1,0 +1,162 @@
+//! The `k8s.listPersistentVolumes` capability (cluster-scoped).
+
+use std::sync::Arc;
+
+use k8s_openapi::api::core::v1::PersistentVolume;
+use kube::api::ListParams;
+use kube::Api;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use srelens_capability::{Annotations, Capability, CapabilityError};
+
+use crate::client_cache::ClientCache;
+use crate::connect::request_timeout;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListPvsIn {
+    pub context: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, JsonSchema)]
+pub struct PvSummary {
+    pub name: String,
+    /// Declared capacity (e.g. "10Gi").
+    pub capacity: String,
+    #[serde(rename = "accessModes")]
+    pub access_modes: String,
+    #[serde(rename = "reclaimPolicy")]
+    pub reclaim_policy: String,
+    /// Bind phase: Available / Bound / Released / Failed.
+    pub status: String,
+    /// Bound claim as "namespace/name", empty when unbound.
+    pub claim: String,
+    #[serde(rename = "storageClass")]
+    pub storage_class: String,
+    pub age: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ListPvsOut {
+    pub persistentvolumes: Vec<PvSummary>,
+}
+
+pub(crate) fn summarise(pv: PersistentVolume) -> PvSummary {
+    let name = pv.metadata.name.clone().unwrap_or_default();
+    let spec = pv.spec.as_ref();
+    let capacity = spec
+        .and_then(|s| s.capacity.as_ref())
+        .and_then(|c| c.get("storage"))
+        .map(|q| q.0.clone())
+        .unwrap_or_default();
+    let access_modes = crate::abbreviate_access_modes(spec.and_then(|s| s.access_modes.as_ref()));
+    let reclaim_policy = spec
+        .and_then(|s| s.persistent_volume_reclaim_policy.clone())
+        .unwrap_or_default();
+    let status = pv
+        .status
+        .as_ref()
+        .and_then(|s| s.phase.clone())
+        .unwrap_or_default();
+    let claim = spec
+        .and_then(|s| s.claim_ref.as_ref())
+        .map(|r| {
+            let ns = r.namespace.clone().unwrap_or_default();
+            let n = r.name.clone().unwrap_or_default();
+            if ns.is_empty() {
+                n
+            } else {
+                format!("{ns}/{n}")
+            }
+        })
+        .unwrap_or_default();
+    let storage_class = spec
+        .and_then(|s| s.storage_class_name.clone())
+        .unwrap_or_default();
+    PvSummary {
+        name,
+        capacity,
+        access_modes,
+        reclaim_policy,
+        status,
+        claim,
+        storage_class,
+        age: crate::humanize_age(pv.metadata.creation_timestamp.as_ref()),
+    }
+}
+
+/// `k8s.listPersistentVolumes` — list cluster PersistentVolumes.
+pub fn list_pvs_capability(cache: Arc<ClientCache>) -> Capability {
+    Capability::typed::<ListPvsIn, ListPvsOut, _, _>(
+        "k8s.listPersistentVolumes",
+        "list PersistentVolumes of a connected kube context (cluster-scoped)",
+        Annotations::READ_ONLY,
+        move |input: ListPvsIn| {
+            let cache = cache.clone();
+            async move {
+                let client = cache
+                    .get(&input.context)
+                    .await
+                    .map_err(CapabilityError::Handler)?;
+                let api: Api<PersistentVolume> = Api::all(client);
+                let list = tokio::time::timeout(request_timeout(), api.list(&ListParams::default()))
+                    .await
+                    .map_err(|_| CapabilityError::Handler("list pvs timed out".into()))?
+                    .map_err(|e| CapabilityError::Handler(e.to_string()))?;
+                Ok(ListPvsOut {
+                    persistentvolumes: list.items.into_iter().map(summarise).collect(),
+                })
+            }
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::api::core::v1::{ObjectReference, PersistentVolumeSpec, PersistentVolumeStatus};
+    use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    #[test]
+    fn capability_has_expected_id() {
+        let cap = list_pvs_capability(ClientCache::new(PathBuf::from("/x")));
+        assert_eq!(cap.id, "k8s.listPersistentVolumes");
+        assert!(cap.annotations.read_only);
+    }
+
+    #[test]
+    fn summarises_bound_volume_with_claim() {
+        let mut capacity = BTreeMap::new();
+        capacity.insert("storage".to_string(), Quantity("20Gi".into()));
+        let pv = PersistentVolume {
+            metadata: kube::core::ObjectMeta {
+                name: Some("pv-123".into()),
+                ..Default::default()
+            },
+            spec: Some(PersistentVolumeSpec {
+                capacity: Some(capacity),
+                access_modes: Some(vec!["ReadWriteOnce".into()]),
+                persistent_volume_reclaim_policy: Some("Retain".into()),
+                storage_class_name: Some("standard".into()),
+                claim_ref: Some(ObjectReference {
+                    namespace: Some("default".into()),
+                    name: Some("data".into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            status: Some(PersistentVolumeStatus {
+                phase: Some("Bound".into()),
+                ..Default::default()
+            }),
+        };
+        let s = summarise(pv);
+        assert_eq!(s.capacity, "20Gi");
+        assert_eq!(s.access_modes, "RWO");
+        assert_eq!(s.reclaim_policy, "Retain");
+        assert_eq!(s.status, "Bound");
+        assert_eq!(s.claim, "default/data");
+        assert_eq!(s.storage_class, "standard");
+    }
+}

--- a/crates/kube/src/pvcs.rs
+++ b/crates/kube/src/pvcs.rs
@@ -1,0 +1,238 @@
+//! The `k8s.listPersistentVolumeClaims` capability.
+
+use std::sync::Arc;
+
+use k8s_openapi::api::core::v1::{PersistentVolumeClaim, Pod};
+use kube::api::ListParams;
+use kube::Api;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use srelens_capability::{Annotations, Capability, CapabilityError};
+
+use crate::client_cache::ClientCache;
+use crate::connect::request_timeout;
+use crate::workloads::{summarise_pod, ListPodsOut};
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListPvcsIn {
+    pub context: String,
+    pub namespace: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, JsonSchema)]
+pub struct PvcSummary {
+    pub name: String,
+    pub namespace: String,
+    /// Bind phase: Bound / Pending / Lost.
+    pub status: String,
+    /// Bound capacity (e.g. "10Gi"), empty until bound.
+    pub capacity: String,
+    #[serde(rename = "accessModes")]
+    pub access_modes: String,
+    #[serde(rename = "storageClass")]
+    pub storage_class: String,
+    /// Bound PersistentVolume name, empty until bound.
+    pub volume: String,
+    pub age: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ListPvcsOut {
+    pub persistentvolumeclaims: Vec<PvcSummary>,
+}
+
+pub(crate) fn summarise(pvc: PersistentVolumeClaim) -> PvcSummary {
+    let name = pvc.metadata.name.clone().unwrap_or_default();
+    let namespace = pvc.metadata.namespace.clone().unwrap_or_default();
+    let spec = pvc.spec.as_ref();
+    let status = pvc
+        .status
+        .as_ref()
+        .and_then(|s| s.phase.clone())
+        .unwrap_or_default();
+    let capacity = pvc
+        .status
+        .as_ref()
+        .and_then(|s| s.capacity.as_ref())
+        .and_then(|c| c.get("storage"))
+        .map(|q| q.0.clone())
+        .unwrap_or_default();
+    let access_modes = crate::abbreviate_access_modes(spec.and_then(|s| s.access_modes.as_ref()));
+    let storage_class = spec
+        .and_then(|s| s.storage_class_name.clone())
+        .unwrap_or_default();
+    let volume = spec.and_then(|s| s.volume_name.clone()).unwrap_or_default();
+    PvcSummary {
+        name,
+        namespace,
+        status,
+        capacity,
+        access_modes,
+        storage_class,
+        volume,
+        age: crate::humanize_age(pvc.metadata.creation_timestamp.as_ref()),
+    }
+}
+
+/// `k8s.listPersistentVolumeClaims` — list PVCs in a namespace.
+pub fn list_pvcs_capability(cache: Arc<ClientCache>) -> Capability {
+    Capability::typed::<ListPvcsIn, ListPvcsOut, _, _>(
+        "k8s.listPersistentVolumeClaims",
+        "list PersistentVolumeClaims in a namespace of a connected kube context",
+        Annotations::READ_ONLY,
+        move |input: ListPvcsIn| {
+            let cache = cache.clone();
+            async move {
+                let client = cache
+                    .get(&input.context)
+                    .await
+                    .map_err(CapabilityError::Handler)?;
+                let api: Api<PersistentVolumeClaim> = crate::scoped_api(client, &input.namespace);
+                let list = tokio::time::timeout(request_timeout(), api.list(&ListParams::default()))
+                    .await
+                    .map_err(|_| CapabilityError::Handler("list pvcs timed out".into()))?
+                    .map_err(|e| CapabilityError::Handler(e.to_string()))?;
+                Ok(ListPvcsOut {
+                    persistentvolumeclaims: list.items.into_iter().map(summarise).collect(),
+                })
+            }
+        },
+    )
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct PodsForPvcIn {
+    pub context: String,
+    pub namespace: String,
+    /// The PersistentVolumeClaim name whose consumers we want.
+    pub pvc: String,
+}
+
+/// Whether a pod mounts `pvc` via one of its `spec.volumes`.
+fn pod_uses_pvc(pod: &Pod, pvc: &str) -> bool {
+    pod.spec
+        .as_ref()
+        .and_then(|s| s.volumes.as_ref())
+        .is_some_and(|volumes| {
+            volumes.iter().any(|v| {
+                v.persistent_volume_claim
+                    .as_ref()
+                    .is_some_and(|c| c.claim_name == pvc)
+            })
+        })
+}
+
+/// `k8s.podsForPvc` — pods in a namespace that mount a given PVC, powering the
+/// "consumed by" link on a claim's detail view.
+pub fn pods_for_pvc_capability(cache: Arc<ClientCache>) -> Capability {
+    Capability::typed::<PodsForPvcIn, ListPodsOut, _, _>(
+        "k8s.podsForPvc",
+        "list pods in a namespace that mount a given PersistentVolumeClaim",
+        Annotations::READ_ONLY,
+        move |input: PodsForPvcIn| {
+            let cache = cache.clone();
+            async move {
+                if input.pvc.is_empty() {
+                    return Ok(ListPodsOut { pods: vec![] });
+                }
+                let client = cache
+                    .get(&input.context)
+                    .await
+                    .map_err(CapabilityError::Handler)?;
+                let api: Api<Pod> = crate::scoped_api(client, &input.namespace);
+                let list = tokio::time::timeout(request_timeout(), api.list(&ListParams::default()))
+                    .await
+                    .map_err(|_| CapabilityError::Handler("list pods timed out".into()))?
+                    .map_err(|e| CapabilityError::Handler(e.to_string()))?;
+                let pods = list
+                    .items
+                    .into_iter()
+                    .filter(|p| pod_uses_pvc(p, &input.pvc))
+                    .map(summarise_pod)
+                    .collect();
+                Ok(ListPodsOut { pods })
+            }
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::api::core::v1::{
+        PersistentVolumeClaimSpec, PersistentVolumeClaimStatus, PersistentVolumeClaimVolumeSource,
+        PodSpec, Volume,
+    };
+    use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    #[test]
+    fn capability_has_expected_id() {
+        let cap = list_pvcs_capability(ClientCache::new(PathBuf::from("/x")));
+        assert_eq!(cap.id, "k8s.listPersistentVolumeClaims");
+        assert!(cap.annotations.read_only);
+    }
+
+    #[test]
+    fn summarises_bound_claim() {
+        let mut capacity = BTreeMap::new();
+        capacity.insert("storage".to_string(), Quantity("10Gi".into()));
+        let pvc = PersistentVolumeClaim {
+            metadata: kube::core::ObjectMeta {
+                name: Some("data".into()),
+                namespace: Some("default".into()),
+                ..Default::default()
+            },
+            spec: Some(PersistentVolumeClaimSpec {
+                access_modes: Some(vec!["ReadWriteOnce".into()]),
+                storage_class_name: Some("standard".into()),
+                volume_name: Some("pv-123".into()),
+                ..Default::default()
+            }),
+            status: Some(PersistentVolumeClaimStatus {
+                phase: Some("Bound".into()),
+                capacity: Some(capacity),
+                ..Default::default()
+            }),
+        };
+        let s = summarise(pvc);
+        assert_eq!(s.status, "Bound");
+        assert_eq!(s.capacity, "10Gi");
+        assert_eq!(s.access_modes, "RWO");
+        assert_eq!(s.storage_class, "standard");
+        assert_eq!(s.volume, "pv-123");
+    }
+
+    #[test]
+    fn pods_for_pvc_capability_has_expected_id() {
+        let cap = pods_for_pvc_capability(ClientCache::new(PathBuf::from("/x")));
+        assert_eq!(cap.id, "k8s.podsForPvc");
+        assert!(cap.annotations.read_only);
+    }
+
+    fn pod_with_pvc(claim: Option<&str>) -> Pod {
+        Pod {
+            spec: Some(PodSpec {
+                volumes: claim.map(|c| {
+                    vec![Volume {
+                        persistent_volume_claim: Some(PersistentVolumeClaimVolumeSource {
+                            claim_name: c.into(),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    }]
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn detects_pods_mounting_the_claim() {
+        assert!(pod_uses_pvc(&pod_with_pvc(Some("data")), "data"));
+        assert!(!pod_uses_pvc(&pod_with_pvc(Some("other")), "data"));
+        assert!(!pod_uses_pvc(&pod_with_pvc(None), "data"));
+    }
+}

--- a/crates/kube/src/storageclasses.rs
+++ b/crates/kube/src/storageclasses.rs
@@ -1,0 +1,133 @@
+//! The `k8s.listStorageClasses` capability (cluster-scoped).
+
+use std::sync::Arc;
+
+use k8s_openapi::api::storage::v1::StorageClass;
+use kube::api::ListParams;
+use kube::Api;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use srelens_capability::{Annotations, Capability, CapabilityError};
+
+use crate::client_cache::ClientCache;
+use crate::connect::request_timeout;
+
+/// Annotation marking the cluster's default StorageClass.
+const DEFAULT_CLASS_ANNOTATION: &str = "storageclass.kubernetes.io/is-default-class";
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListStorageClassesIn {
+    pub context: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, JsonSchema)]
+pub struct StorageClassSummary {
+    pub name: String,
+    pub provisioner: String,
+    #[serde(rename = "reclaimPolicy")]
+    pub reclaim_policy: String,
+    #[serde(rename = "volumeBindingMode")]
+    pub volume_binding_mode: String,
+    /// Whether this is the cluster's default StorageClass.
+    pub default: bool,
+    pub age: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ListStorageClassesOut {
+    pub storageclasses: Vec<StorageClassSummary>,
+}
+
+pub(crate) fn summarise(sc: StorageClass) -> StorageClassSummary {
+    let name = sc.metadata.name.clone().unwrap_or_default();
+    let default = sc
+        .metadata
+        .annotations
+        .as_ref()
+        .and_then(|a| a.get(DEFAULT_CLASS_ANNOTATION))
+        .map(|v| v == "true")
+        .unwrap_or(false);
+    StorageClassSummary {
+        name,
+        provisioner: sc.provisioner,
+        reclaim_policy: sc.reclaim_policy.unwrap_or_default(),
+        volume_binding_mode: sc.volume_binding_mode.unwrap_or_default(),
+        default,
+        age: crate::humanize_age(sc.metadata.creation_timestamp.as_ref()),
+    }
+}
+
+/// `k8s.listStorageClasses` — list cluster StorageClasses.
+pub fn list_storageclasses_capability(cache: Arc<ClientCache>) -> Capability {
+    Capability::typed::<ListStorageClassesIn, ListStorageClassesOut, _, _>(
+        "k8s.listStorageClasses",
+        "list StorageClasses of a connected kube context (cluster-scoped)",
+        Annotations::READ_ONLY,
+        move |input: ListStorageClassesIn| {
+            let cache = cache.clone();
+            async move {
+                let client = cache
+                    .get(&input.context)
+                    .await
+                    .map_err(CapabilityError::Handler)?;
+                let api: Api<StorageClass> = Api::all(client);
+                let list = tokio::time::timeout(request_timeout(), api.list(&ListParams::default()))
+                    .await
+                    .map_err(|_| CapabilityError::Handler("list storageclasses timed out".into()))?
+                    .map_err(|e| CapabilityError::Handler(e.to_string()))?;
+                Ok(ListStorageClassesOut {
+                    storageclasses: list.items.into_iter().map(summarise).collect(),
+                })
+            }
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    #[test]
+    fn capability_has_expected_id() {
+        let cap = list_storageclasses_capability(ClientCache::new(PathBuf::from("/x")));
+        assert_eq!(cap.id, "k8s.listStorageClasses");
+        assert!(cap.annotations.read_only);
+    }
+
+    #[test]
+    fn summarises_default_class() {
+        let mut annotations = BTreeMap::new();
+        annotations.insert(DEFAULT_CLASS_ANNOTATION.to_string(), "true".to_string());
+        let sc = StorageClass {
+            metadata: kube::core::ObjectMeta {
+                name: Some("standard".into()),
+                annotations: Some(annotations),
+                ..Default::default()
+            },
+            provisioner: "kubernetes.io/aws-ebs".into(),
+            reclaim_policy: Some("Delete".into()),
+            volume_binding_mode: Some("WaitForFirstConsumer".into()),
+            ..Default::default()
+        };
+        let s = summarise(sc);
+        assert_eq!(s.provisioner, "kubernetes.io/aws-ebs");
+        assert_eq!(s.reclaim_policy, "Delete");
+        assert_eq!(s.volume_binding_mode, "WaitForFirstConsumer");
+        assert!(s.default);
+    }
+
+    #[test]
+    fn non_default_when_annotation_absent() {
+        let sc = StorageClass {
+            metadata: kube::core::ObjectMeta {
+                name: Some("slow".into()),
+                ..Default::default()
+            },
+            provisioner: "kubernetes.io/no-provisioner".into(),
+            ..Default::default()
+        };
+        assert!(!summarise(sc).default);
+    }
+}

--- a/crates/kube/src/watch.rs
+++ b/crates/kube/src/watch.rs
@@ -11,10 +11,12 @@ use futures::StreamExt;
 use k8s_openapi::api::apps::v1::{DaemonSet, Deployment, StatefulSet};
 use k8s_openapi::api::batch::v1::{CronJob, Job};
 use k8s_openapi::api::core::v1::{
-    ConfigMap, Event as CoreEvent, LimitRange, Pod, ResourceQuota, Secret, Service,
+    ConfigMap, Event as CoreEvent, LimitRange, PersistentVolume, PersistentVolumeClaim, Pod,
+    ResourceQuota, Secret, Service,
 };
 use k8s_openapi::api::discovery::v1::EndpointSlice;
 use k8s_openapi::api::networking::v1::{Ingress, NetworkPolicy};
+use k8s_openapi::api::storage::v1::StorageClass;
 use kube::runtime::watcher::{Config, Event};
 use kube::Api;
 use serde::de::DeserializeOwned;
@@ -27,6 +29,9 @@ use crate::endpointslices::{summarise as summarise_endpointslice, EndpointSliceS
 use crate::ingresses::{summarise as summarise_ingress, IngressSummary};
 use crate::limitranges::{summarise as summarise_limitrange, LimitRangeSummary};
 use crate::networkpolicies::{summarise as summarise_networkpolicy, NetworkPolicySummary};
+use crate::persistentvolumes::{summarise as summarise_pv, PvSummary};
+use crate::pvcs::{summarise as summarise_pvc, PvcSummary};
+use crate::storageclasses::{summarise as summarise_storageclass, StorageClassSummary};
 use crate::resourcequotas::{summarise as summarise_resourcequota, ResourceQuotaSummary};
 use crate::secrets::{summarise as summarise_secret, SecretSummary};
 use crate::deployments::{summarise as summarise_deployment, DeploymentSummary};
@@ -493,6 +498,78 @@ where
         api,
         summarise_networkpolicy,
         |n: &NetworkPolicySummary| n.name.clone(),
+        on_update,
+        on_status,
+    )
+    .await
+}
+
+/// Watch PersistentVolumeClaims in a namespace.
+pub async fn watch_pvcs<F, G>(
+    cache: Arc<ClientCache>,
+    context: String,
+    namespace: String,
+    on_update: F,
+    on_status: G,
+) -> Result<(), String>
+where
+    F: FnMut(Vec<PvcSummary>) + Send,
+    G: FnMut(WatchStatus) + Send,
+{
+    let client = cache.get(&context).await?;
+    let api: Api<PersistentVolumeClaim> = crate::scoped_api(client, &namespace);
+    watch_typed(
+        api,
+        summarise_pvc,
+        |p: &PvcSummary| p.name.clone(),
+        on_update,
+        on_status,
+    )
+    .await
+}
+
+/// Watch cluster PersistentVolumes (cluster-scoped; namespace ignored).
+pub async fn watch_persistentvolumes<F, G>(
+    cache: Arc<ClientCache>,
+    context: String,
+    _namespace: String,
+    on_update: F,
+    on_status: G,
+) -> Result<(), String>
+where
+    F: FnMut(Vec<PvSummary>) + Send,
+    G: FnMut(WatchStatus) + Send,
+{
+    let client = cache.get(&context).await?;
+    let api: Api<PersistentVolume> = Api::all(client);
+    watch_typed(
+        api,
+        summarise_pv,
+        |p: &PvSummary| p.name.clone(),
+        on_update,
+        on_status,
+    )
+    .await
+}
+
+/// Watch cluster StorageClasses (cluster-scoped; namespace ignored).
+pub async fn watch_storageclasses<F, G>(
+    cache: Arc<ClientCache>,
+    context: String,
+    _namespace: String,
+    on_update: F,
+    on_status: G,
+) -> Result<(), String>
+where
+    F: FnMut(Vec<StorageClassSummary>) + Send,
+    G: FnMut(WatchStatus) + Send,
+{
+    let client = cache.get(&context).await?;
+    let api: Api<StorageClass> = Api::all(client);
+    watch_typed(
+        api,
+        summarise_storageclass,
+        |s: &StorageClassSummary| s.name.clone(),
         on_update,
         on_status,
     )


### PR DESCRIPTION
Closes #10.

## What

The three storage kinds — PersistentVolumeClaim, PersistentVolume, StorageClass — previously used the generic table and polled. This gives each typed columns and a live watch stream, following the #7/#8/#9 pattern. PVs and StorageClasses are **cluster-scoped**, so they list/watch via `Api::all` and their columns omit the namespace.

## Backend (`crates/kube`, test-first)

- `k8s.listPersistentVolumeClaims` — status, capacity, access modes (RWO/ROX/RWX/RWOP), storage class, bound volume
- `k8s.listPersistentVolumes` — capacity, access modes, reclaim policy, status, bound claim (`ns/name`), storage class *(cluster-scoped)*
- `k8s.listStorageClasses` — provisioner, reclaim policy, volume binding mode, default marker *(cluster-scoped)*
- `k8s.podsForPvc` — pods in a namespace that mount a given PVC (scans pod volumes)
- A `watch_*` loop per list kind + Tauri dispatch arms; each capability registered once → exposed as both a Tauri command and an MCP tool (`every_capability_is_mcp_exposed` green).

## Frontend (test-first)

- `lib/storage.ts` — TS row types + `list*` / `podsForPvc` data-layer fns.
- ResourceBrowser columns for all three kinds; added to `TYPED_KINDS` + `WATCHABLE_KINDS` (PV/StorageClass stay in `CLUSTER_SCOPED`, no namespace column).
- **Binding navigation both directions**: PVC ⇄ PV and PVC → StorageClass were already linked in the detail bodies; this adds a **"Consumed by"** section on the claim detail listing its pods via `k8s.podsForPvc`.

## Tests

- Backend: new unit tests for each summary + the shared access-mode abbreviation + `pod_uses_pvc`; `cargo test --workspace` green.
- Frontend: `lib/storage` data-layer tests, 3 ResourceBrowser live-stream tests, and a PVC → consuming-pods detail test. Full suite **340 passing**, coverage 82.41% (gate 80), `vite build` + `tsc --noEmit` clean.