### PR TITLE
feat(updater): proactive update check with a toast on startup

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
 import React from "react";
 
 // Capture the Tauri event handler App registers for the macOS Cmd+W menu item,
@@ -19,6 +19,18 @@ const tauri = vi.hoisted(() => {
 vi.mock("@tauri-apps/api/event", () => ({ listen: tauri.listen }));
 vi.mock("@tauri-apps/api/window", () => ({
   getCurrentWindow: () => ({ close: tauri.windowClose }),
+}));
+
+const { checkForUpdateMock, notifyUpdateAvailableMock } = vi.hoisted(() => ({
+  checkForUpdateMock: vi.fn(),
+  notifyUpdateAvailableMock: vi.fn(),
+}));
+vi.mock("./lib/updater", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./lib/updater")>()),
+  checkForUpdate: checkForUpdateMock,
+}));
+vi.mock("./lib/notify", () => ({
+  notify: { success: vi.fn(), error: vi.fn(), info: vi.fn(), updateAvailable: notifyUpdateAvailableMock },
 }));
 
 vi.mock("./components/ClusterHotbar", () => ({
@@ -78,7 +90,23 @@ vi.mock("./components/SettingsView", () => ({
 
 import { App } from "./App";
 
+beforeEach(() => {
+  checkForUpdateMock.mockReset();
+  checkForUpdateMock.mockResolvedValue(null); // up to date unless a test says otherwise
+  notifyUpdateAvailableMock.mockReset();
+});
+
 describe("App", () => {
+  it("checks for updates on startup and toasts, linking to the Updates section", async () => {
+    checkForUpdateMock.mockResolvedValue({ version: "0.3.0", currentVersion: "0.2.0", notes: "" });
+    render(<App />);
+    await waitFor(() => expect(notifyUpdateAvailableMock).toHaveBeenCalledWith("0.3.0", expect.any(Function)));
+    // The toast's action opens the Settings tab (deep-linked to Updates).
+    const onView = notifyUpdateAvailableMock.mock.calls[0][1] as () => void;
+    onView();
+    expect(await screen.findByTestId("settings")).toBeDefined();
+  });
+
   it("shows the welcome state until a cluster is opened", () => {
     render(<App />);
     expect(screen.getByText(/pure-Rust Kubernetes UI/)).toBeDefined();

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -41,7 +41,11 @@ import {
   loadContextOrder,
   saveContextOrder,
   orderContexts,
+  loadUpdateChannel,
 } from "./lib/settings";
+import { checkForUpdateAndNotify } from "./lib/updateNotifier";
+import { notify } from "./lib/notify";
+import type { SettingsSection } from "./components/SettingsView";
 
 interface ViewTab {
   id: number;
@@ -81,6 +85,10 @@ export function App() {
   activeTabIdRef.current = activeTabId;
   const tabsRef = useRef<ViewTab[]>([]);
   tabsRef.current = tabs;
+  // Deep-link the Settings tab to a section (e.g. from the update toast). The
+  // nonce bumps to remount SettingsView at the requested section when asked.
+  const [settingsInitialSection, setSettingsInitialSection] = useState<SettingsSection>("appearance");
+  const [settingsSectionNonce, setSettingsSectionNonce] = useState(0);
 
   // Persist per-cluster namespace whenever it changes.
   useEffect(() => saveClusterNamespaces(clusterNs), [clusterNs]);
@@ -205,8 +213,14 @@ export function App() {
     setQuery("");
   }
 
-  /** Open the single workspace-level Settings tab. */
-  function openSettings() {
+  /** Open the single workspace-level Settings tab, optionally at a section. */
+  function openSettings(section?: SettingsSection) {
+    if (section) {
+      setSettingsInitialSection(section);
+      // Remount SettingsView so it opens at the requested section even if the
+      // tab is already open on another section.
+      setSettingsSectionNonce((n) => n + 1);
+    }
     const existing = tabs.find((t) => t.kind === "settings" && !t.cluster);
     if (existing) {
       setActiveTabId(existing.id);
@@ -217,6 +231,31 @@ export function App() {
     setActiveTabId(id);
     setQuery("");
   }
+  // Keep a stable handle to openSettings so the update-check effect's toast
+  // action always uses the current tab state, not a stale closure.
+  const openSettingsRef = useRef(openSettings);
+  openSettingsRef.current = openSettings;
+
+  // Automatically check for updates on startup and periodically, surfacing a
+  // small toast (with a link to the Updates section) when one is available —
+  // rather than only when the user opens Settings and clicks "check".
+  const notifiedVersionRef = useRef<string | null>(null);
+  useEffect(() => {
+    const channel = loadUpdateChannel();
+    const run = () =>
+      void checkForUpdateAndNotify(
+        channel,
+        (update) => {
+          notifiedVersionRef.current = update.version;
+          notify.updateAvailable(update.version, () => openSettingsRef.current("updates"));
+        },
+        { alreadyNotified: (v) => notifiedVersionRef.current === v },
+      );
+    run();
+    const SIX_HOURS = 6 * 60 * 60 * 1000;
+    const timer = setInterval(run, SIX_HOURS);
+    return () => clearInterval(timer);
+  }, []);
 
   /** Open a resource's kind view and deep-link to its detail (from search). */
   function openResource(kind: ResourceKind, namespace: string | null, name: string) {
@@ -374,7 +413,8 @@ export function App() {
                 <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
                   {activeKind === "settings" ? (
                     <SettingsView
-                      key={activeTab.id}
+                      key={`${activeTab.id}:${settingsSectionNonce}`}
+                      initialSection={settingsInitialSection}
                       theme={theme}
                       onThemeNameChange={setThemeName}
                       onThemeModeChange={setThemeMode}

--- a/apps/desktop/src/components/SettingsView.test.tsx
+++ b/apps/desktop/src/components/SettingsView.test.tsx
@@ -214,6 +214,30 @@ describe("SettingsView", () => {
     expect(updaterMocks.checkForUpdate).toHaveBeenCalledWith("stable");
   });
 
+  it("opens directly on the section named by initialSection", async () => {
+    updaterMocks.checkForUpdate.mockResolvedValue(null);
+    render(
+      <SettingsView
+        theme={{ name: "slate", mode: "dark" }}
+        onThemeNameChange={() => {}}
+        onThemeModeChange={() => {}}
+        defaultNamespace=""
+        onDefaultNamespaceChange={() => {}}
+        layout={DEFAULT_WORKSPACE_LAYOUT}
+        onLayoutChange={() => {}}
+        contextProfiles={{}}
+        onContextProfilesChange={() => {}}
+        kubeconfigFiles={[]}
+        onKubeconfigFilesChange={() => {}}
+        contextOrder={[]}
+        onContextOrderChange={() => {}}
+        initialSection="updates"
+      />,
+    );
+    // The Updates pane is shown without clicking the nav first.
+    expect(await screen.findByRole("button", { name: "Check for updates" })).toBeDefined();
+  });
+
   it("checks the dev channel when selected and persists the choice", async () => {
     updaterMocks.checkForUpdate.mockResolvedValue(null);
     render(

--- a/apps/desktop/src/components/SettingsView.tsx
+++ b/apps/desktop/src/components/SettingsView.tsx
@@ -58,7 +58,7 @@ const MODE_OPTIONS: Array<{ mode: ThemeMode; label: string; description: string;
   { mode: "system", label: "System", description: "Follow the OS appearance", icon: Monitor },
 ];
 
-type SettingsSection = "appearance" | "layout" | "kubernetes" | "contexts" | "updates";
+export type SettingsSection = "appearance" | "layout" | "kubernetes" | "contexts" | "updates";
 
 type UpdatePhase =
   | { phase: "idle" }
@@ -103,6 +103,7 @@ export function SettingsView({
   onKubeconfigFilesChange,
   contextOrder,
   onContextOrderChange,
+  initialSection = "appearance",
 }: {
   theme: Theme;
   onThemeNameChange: (name: ThemeName) => void;
@@ -117,8 +118,10 @@ export function SettingsView({
   onKubeconfigFilesChange: (paths: string[]) => void;
   contextOrder: string[];
   onContextOrderChange: (order: string[]) => void;
+  /** Section to open on mount (e.g. deep-linked from the update toast). */
+  initialSection?: SettingsSection;
 }) {
-  const [section, setSection] = useState<SettingsSection>("appearance");
+  const [section, setSection] = useState<SettingsSection>(initialSection);
   const [contexts, setContexts] = useState<ClusterContext[] | null>(null);
   const [contextError, setContextError] = useState("");
   const [contextQuery, setContextQuery] = useState("");

--- a/apps/desktop/src/lib/notify.test.ts
+++ b/apps/desktop/src/lib/notify.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { toastMock } = vi.hoisted(() => {
+  const fn = vi.fn() as unknown as ReturnType<typeof vi.fn> & {
+    success: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+  };
+  fn.success = vi.fn();
+  fn.error = vi.fn();
+  return { toastMock: fn };
+});
+vi.mock("sonner", () => ({ toast: toastMock }));
+
+import { notify } from "./notify";
+
+beforeEach(() => {
+  toastMock.mockClear();
+  toastMock.success.mockClear();
+  toastMock.error.mockClear();
+});
+
+describe("notify.updateAvailable", () => {
+  it("shows a toast with a View-update action that runs the callback", () => {
+    const onView = vi.fn();
+    notify.updateAvailable("0.3.0", onView);
+    expect(toastMock).toHaveBeenCalledTimes(1);
+    const [message, opts] = toastMock.mock.calls[0];
+    expect(String(message)).toContain("Update available");
+    expect(opts.description).toContain("0.3.0");
+    expect(opts.action.label).toBe("View update");
+    opts.action.onClick();
+    expect(onView).toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/lib/notify.ts
+++ b/apps/desktop/src/lib/notify.ts
@@ -18,4 +18,15 @@ export const notify = {
   info(message: string, description?: string): void {
     toast(message, description ? { description } : undefined);
   },
+  /**
+   * A newer app version is available. Carries a "View update" action that takes
+   * the user to the Updates section; stays up for a while since it's passive.
+   */
+  updateAvailable(version: string, onView: () => void): void {
+    toast("Update available", {
+      description: `srelens ${version} is ready to install.`,
+      action: { label: "View update", onClick: () => onView() },
+      duration: 12000,
+    });
+  },
 };

--- a/apps/desktop/src/lib/updateNotifier.test.ts
+++ b/apps/desktop/src/lib/updateNotifier.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from "vitest";
+import { checkForUpdateAndNotify } from "./updateNotifier";
+import type { UpdateMeta } from "./updater";
+
+const update: UpdateMeta = { version: "0.3.0", currentVersion: "0.2.0", notes: "" };
+
+describe("checkForUpdateAndNotify", () => {
+  it("notifies when a newer version is available", async () => {
+    const onAvailable = vi.fn();
+    await checkForUpdateAndNotify("stable", onAvailable, { check: async () => update });
+    expect(onAvailable).toHaveBeenCalledWith(update);
+  });
+
+  it("does not notify when already up to date", async () => {
+    const onAvailable = vi.fn();
+    await checkForUpdateAndNotify("stable", onAvailable, { check: async () => null });
+    expect(onAvailable).not.toHaveBeenCalled();
+  });
+
+  it("stays silent when the check fails (an automatic check must not nag)", async () => {
+    const onAvailable = vi.fn();
+    await checkForUpdateAndNotify("stable", onAvailable, {
+      check: async () => {
+        throw new Error("offline");
+      },
+    });
+    expect(onAvailable).not.toHaveBeenCalled();
+  });
+
+  it("does not re-notify a version the user was already told about", async () => {
+    const onAvailable = vi.fn();
+    await checkForUpdateAndNotify("stable", onAvailable, {
+      check: async () => update,
+      alreadyNotified: (v) => v === "0.3.0",
+    });
+    expect(onAvailable).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/lib/updateNotifier.ts
+++ b/apps/desktop/src/lib/updateNotifier.ts
@@ -1,0 +1,32 @@
+import { checkForUpdate, type UpdateMeta } from "./updater";
+import type { UpdateChannel } from "./settings";
+
+interface Options {
+  /** Override the check (for tests); defaults to the real manifest check. */
+  check?: (channel: UpdateChannel) => Promise<UpdateMeta | null>;
+  /** Suppress the notification for a version already surfaced to the user. */
+  alreadyNotified?: (version: string) => boolean;
+}
+
+/**
+ * Run an automatic update check and call `onAvailable` when a newer version
+ * exists. Unlike the manual check in Settings, this is a background poll: it
+ * swallows errors (a failed check must not nag) and skips versions the user has
+ * already been told about, so it can run on startup and on a timer.
+ */
+export async function checkForUpdateAndNotify(
+  channel: UpdateChannel,
+  onAvailable: (update: UpdateMeta) => void,
+  options: Options = {},
+): Promise<void> {
+  const check = options.check ?? checkForUpdate;
+  let update: UpdateMeta | null;
+  try {
+    update = await check(channel);
+  } catch {
+    return;
+  }
+  if (update && !options.alreadyNotified?.(update.version)) {
+    onAvailable(update);
+  }
+}


### PR DESCRIPTION
Closes #77.

## Problem

The app only checked for updates when the user opened **Settings → Updates** and clicked *Check for updates*. There was no proactive signal, so new releases went unnoticed.

## Changes

- **`lib/updateNotifier.ts`** (new) — `checkForUpdateAndNotify(channel, onAvailable, opts)`: runs a background check, swallows errors (an automatic check must not nag), and skips versions the user was already told about.
- **`lib/notify.ts`** — `notify.updateAvailable(version, onView)`: a small toast with a **View update** action.
- **`App.tsx`** — checks on startup and every 6h; on an available update, toasts and (via a stable ref) deep-links to the Updates section. De-dupes by version so the same release isn't announced twice.
- **`SettingsView.tsx`** — new `initialSection` prop so the toast can open Settings directly on Updates; the tab remounts to the requested section.

## Tests (TDD)

- `updateNotifier`: notifies on a new version; silent when up-to-date, on failure, or already-notified.
- `notify.updateAvailable`: toast carries a working *View update* action.
- `SettingsView`: opens directly on the section named by `initialSection`.
- `App`: checks on startup and toasts, and the action opens the Settings tab.

Full suite **364 passing**, coverage 82.96% (gate 80), `vite build` + `tsc --noEmit` clean. Frontend-only.