### PR TITLE
feat(pods): pod detail parity — conditions timeline, scheduling, ephemeral containers

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -342,6 +342,7 @@ export function App() {
       context: string;
       namespace: string;
       pod?: string;
+      container?: string;
       workload?: { kind: string; name: string };
     },
   ) {

--- a/apps/desktop/src/components/Dock.tsx
+++ b/apps/desktop/src/components/Dock.tsx
@@ -12,6 +12,8 @@ export interface DockSession {
   namespace: string;
   /** Present for terminals and single-pod logs. */
   pod?: string;
+  /** Preselect this container in single-pod logs (from a per-container action). */
+  container?: string;
   /** Present for workload (e.g. Deployment) logs that span many pods. */
   workload?: { kind: string; name: string };
 }
@@ -129,6 +131,7 @@ export function Dock({
               key={active.id}
               context={active.context}
               namespace={active.namespace}
+              initialContainer={active.container}
               source={
                 (active.pod
                   ? { type: "pod", pod: active.pod }

--- a/apps/desktop/src/components/LogsView.tsx
+++ b/apps/desktop/src/components/LogsView.tsx
@@ -41,10 +41,13 @@ export function LogsView({
   context,
   namespace,
   source,
+  initialContainer,
 }: {
   context: string;
   namespace: string;
   source: LogsSource;
+  /** Preselect this container instead of "all" (from a per-container action). */
+  initialContainer?: string;
 }) {
   const srcType = source.type;
   const srcPod = source.type === "pod" ? source.pod : "";
@@ -54,7 +57,7 @@ export function LogsView({
   const [pods, setPods] = useState<string[]>(srcType === "pod" ? [srcPod] : []);
   const [containersByPod, setContainersByPod] = useState<Record<string, string[]>>({});
   const [pod, setPod] = useState<string>(srcType === "pod" ? srcPod : ALL);
-  const [container, setContainer] = useState<string>(ALL);
+  const [container, setContainer] = useState<string>(initialContainer || ALL);
   const [lines, setLines] = useState<string[]>([]);
   const [error, setError] = useState("");
   const [streamError, setStreamError] = useState("");

--- a/apps/desktop/src/components/ResourceBrowser.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.tsx
@@ -547,7 +547,7 @@ export function ResourceBrowser({
   query?: string;
   onQueryChange?: (q: string) => void;
   onOpenTerminal?: (s: { context: string; namespace: string; pod: string }) => void;
-  onOpenLogs?: (s: { context: string; namespace: string; pod: string }) => void;
+  onOpenLogs?: (s: { context: string; namespace: string; pod: string; container?: string }) => void;
   onOpenWorkloadLogs?: (s: { context: string; namespace: string; kind: string; name: string }) => void;
   /** Open a "new resource" editor tab, optionally seeded with this kind's template. */
   onOpenNew?: (initialKind?: string) => void;
@@ -966,6 +966,9 @@ export function ResourceBrowser({
             namespace={selectedPod.namespace}
             name={selectedPod.name}
             onOpenResource={onOpenResource}
+            onOpenLogs={(container) =>
+              onOpenLogs?.({ context, namespace: selectedPod.namespace, pod: selectedPod.name, container })
+            }
           />
         )}
         {otherDetail && (

--- a/apps/desktop/src/components/ResourceDetail.tsx
+++ b/apps/desktop/src/components/ResourceDetail.tsx
@@ -25,6 +25,7 @@ export function ResourceDetail({
   name,
   reloadKey = 0,
   onOpenResource,
+  onOpenLogs,
 }: {
   context: string;
   kind: string;
@@ -33,6 +34,8 @@ export function ResourceDetail({
   /** Bumped by the parent after a write action to refresh the overview. */
   reloadKey?: number;
   onOpenResource?: OpenResource;
+  /** Open logs scoped to a container (Pod detail only). */
+  onOpenLogs?: (container: string) => void;
 }) {
   const [tab, setTab] = useState<DetailTab>("overview");
 
@@ -48,6 +51,7 @@ export function ResourceDetail({
             name={name}
             reloadKey={reloadKey}
             onOpenResource={onOpenResource}
+            onOpenLogs={onOpenLogs}
           />
         )}
         {tab === "yaml" && (

--- a/apps/desktop/src/components/ResourceOverview.test.tsx
+++ b/apps/desktop/src/components/ResourceOverview.test.tsx
@@ -38,6 +38,8 @@ import {
   ageFromTimestamp,
   containerLastRestartTime,
   parseQuantity,
+  orderPodConditions,
+  summarizeAffinity,
 } from "./ResourceOverview";
 import type { K8sObject } from "../lib/manifest";
 
@@ -77,6 +79,58 @@ describe("parseQuantity", () => {
   it("returns null for unparseable input", () => {
     expect(parseQuantity("")).toBeNull();
     expect(parseQuantity("abc")).toBeNull();
+  });
+});
+
+describe("orderPodConditions", () => {
+  it("orders lifecycle conditions PodScheduled → Initialized → ContainersReady → Ready", () => {
+    const shuffled = [
+      { type: "Ready", status: "True" },
+      { type: "PodScheduled", status: "True" },
+      { type: "ContainersReady", status: "False" },
+      { type: "Initialized", status: "True" },
+    ];
+    expect(orderPodConditions(shuffled).map((c) => c.type)).toEqual([
+      "PodScheduled",
+      "Initialized",
+      "ContainersReady",
+      "Ready",
+    ]);
+  });
+
+  it("appends unknown condition types after the known lifecycle ones", () => {
+    const conds = [
+      { type: "DisruptionTarget", status: "True" },
+      { type: "Ready", status: "True" },
+      { type: "PodScheduled", status: "True" },
+    ];
+    expect(orderPodConditions(conds).map((c) => c.type)).toEqual([
+      "PodScheduled",
+      "Ready",
+      "DisruptionTarget",
+    ]);
+  });
+});
+
+describe("summarizeAffinity", () => {
+  it("summarizes required and preferred rules per affinity type", () => {
+    const affinity = {
+      nodeAffinity: {
+        requiredDuringSchedulingIgnoredDuringExecution: { nodeSelectorTerms: [{}, {}] },
+        preferredDuringSchedulingIgnoredDuringExecution: [{}],
+      },
+      podAntiAffinity: {
+        requiredDuringSchedulingIgnoredDuringExecution: [{}],
+      },
+    };
+    expect(summarizeAffinity(affinity)).toEqual([
+      "Node affinity: 2 required, 1 preferred",
+      "Pod anti-affinity: 1 required",
+    ]);
+  });
+
+  it("returns an empty list when there is no affinity", () => {
+    expect(summarizeAffinity({})).toEqual([]);
   });
 });
 
@@ -210,6 +264,74 @@ describe("ObjectDetail (Pod)", () => {
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
     fireEvent.click(toggle);
     expect(screen.getByRole("button", { name: "Collapse command" }).getAttribute("aria-expanded")).toBe("true");
+  });
+});
+
+describe("ObjectDetail (Pod parity: #13)", () => {
+  const parityPod: K8sObject = {
+    kind: "Pod",
+    metadata: { name: "web-1", namespace: "default" },
+    spec: {
+      nodeName: "node-a",
+      nodeSelector: { "disktype": "ssd" },
+      affinity: {
+        podAntiAffinity: { requiredDuringSchedulingIgnoredDuringExecution: [{}] },
+      },
+      tolerations: [{ key: "dedicated", operator: "Equal", value: "gpu", effect: "NoSchedule" }],
+      containers: [
+        {
+          name: "nginx",
+          image: "nginx:1.27",
+          startupProbe: { httpGet: { path: "/healthz", port: 8080 } },
+        },
+      ],
+      ephemeralContainers: [{ name: "debugger", image: "busybox", targetContainerName: "nginx" }],
+    },
+    status: {
+      phase: "Running",
+      conditions: [
+        { type: "Ready", status: "True", lastTransitionTime: "2025-12-31T00:00:08Z" },
+        { type: "PodScheduled", status: "True", lastTransitionTime: "2025-12-31T00:00:00Z" },
+        { type: "Initialized", status: "True", lastTransitionTime: "2025-12-31T00:00:07Z" },
+        { type: "ContainersReady", status: "True", lastTransitionTime: "2025-12-31T00:00:08Z" },
+      ],
+      containerStatuses: [{ name: "nginx", ready: true, restartCount: 0, state: { running: {} } }],
+      ephemeralContainerStatuses: [{ name: "debugger", state: { running: {} } }],
+    },
+  };
+
+  it("renders the conditions in lifecycle order", () => {
+    render(<ObjectDetail kind="Pod" obj={parityPod} now={NOW} />);
+    const order = screen
+      .getAllByText(/PodScheduled|Initialized|ContainersReady|^Ready$/)
+      .map((el) => el.textContent);
+    expect(order).toEqual(["PodScheduled", "Initialized", "ContainersReady", "Ready"]);
+  });
+
+  it("shows a Scheduling section with node selector, affinity and tolerations", () => {
+    render(<ObjectDetail kind="Pod" obj={parityPod} now={NOW} />);
+    expect(screen.getByText("Scheduling")).toBeDefined();
+    expect(screen.getByText("disktype")).toBeDefined();
+    expect(screen.getByText("Pod anti-affinity: 1 required")).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: /1 toleration/ }));
+    expect(screen.getByText("dedicated=gpu → NoSchedule")).toBeDefined();
+  });
+
+  it("renders an ephemeral container with its debug target and a startup probe", () => {
+    render(<ObjectDetail kind="Pod" obj={parityPod} now={NOW} />);
+    expect(screen.getByText("Ephemeral Containers")).toBeDefined();
+    expect(screen.getByText("debugger")).toBeDefined();
+    // "Debugging" row surfaces which container it targets.
+    expect(screen.getByText("Debugging")).toBeDefined();
+    // Startup probe row exists on the main container.
+    expect(screen.getByText("Startup")).toBeDefined();
+  });
+
+  it("offers per-container Logs that open scoped to the container", () => {
+    const onOpenLogs = vi.fn();
+    render(<ObjectDetail kind="Pod" obj={parityPod} now={NOW} context="kind-dev" onOpenLogs={onOpenLogs} />);
+    fireEvent.click(screen.getByRole("button", { name: "Logs for nginx" }));
+    expect(onOpenLogs).toHaveBeenCalledWith("nginx");
   });
 });
 

--- a/apps/desktop/src/components/ResourceOverview.tsx
+++ b/apps/desktop/src/components/ResourceOverview.tsx
@@ -266,6 +266,49 @@ function conditionBadgeVariant(c: Condition): BadgeVariant {
   return negative ? "danger" : "success";
 }
 
+// The pod lifecycle, in the order kubelet reports it.
+const POD_CONDITION_ORDER = ["PodScheduled", "Initialized", "ContainersReady", "Ready"];
+
+/**
+ * Sort pod conditions into lifecycle order (PodScheduled → Initialized →
+ * ContainersReady → Ready); any other condition types keep their relative order
+ * after the known lifecycle ones.
+ */
+export function orderPodConditions(conditions: Condition[]): Condition[] {
+  const rank = (type: string) => {
+    const index = POD_CONDITION_ORDER.indexOf(type);
+    return index === -1 ? POD_CONDITION_ORDER.length : index;
+  };
+  return conditions
+    .map((condition, index) => ({ condition, index }))
+    .sort((a, b) => rank(a.condition.type) - rank(b.condition.type) || a.index - b.index)
+    .map(({ condition }) => condition);
+}
+
+/**
+ * One line per affinity type in use, e.g. "Node affinity: 2 required, 1
+ * preferred". `nodeAffinity` counts `nodeSelectorTerms`; pod (anti-)affinity
+ * count their rule arrays directly. Types with no rules are omitted.
+ */
+export function summarizeAffinity(affinity: Record<string, unknown>): string[] {
+  const lines: string[] = [];
+  const describe = (label: string, rule: Record<string, unknown>, requiredIsTerms: boolean) => {
+    const required = requiredIsTerms
+      ? asArray(asRecord(rule.requiredDuringSchedulingIgnoredDuringExecution).nodeSelectorTerms).length
+      : asArray(rule.requiredDuringSchedulingIgnoredDuringExecution).length;
+    const preferred = asArray(rule.preferredDuringSchedulingIgnoredDuringExecution).length;
+    if (required === 0 && preferred === 0) return;
+    const parts: string[] = [];
+    if (required) parts.push(`${required} required`);
+    if (preferred) parts.push(`${preferred} preferred`);
+    lines.push(`${label}: ${parts.join(", ")}`);
+  };
+  describe("Node affinity", asRecord(affinity.nodeAffinity), true);
+  describe("Pod affinity", asRecord(affinity.podAffinity), false);
+  describe("Pod anti-affinity", asRecord(affinity.podAntiAffinity), false);
+  return lines;
+}
+
 /** Conditions as a row of coloured badges (Pod/Deployment-style). */
 function ConditionBadges({ conditions }: { conditions: Condition[] }) {
   if (conditions.length === 0) return <span className="fl-detail-empty">None</span>;
@@ -447,6 +490,17 @@ function mountText(m: unknown): string {
   return `${str(r.mountPath)}${ro} ← ${str(r.name)}`;
 }
 
+/** A toleration as "key=value → effect" (or "key Exists → effect"). */
+function tolerationText(t: unknown): string {
+  const r = asRecord(t);
+  const key = str(r.key) || "(any taint)";
+  const operator = str(r.operator) || "Equal";
+  const effect = str(r.effect) || "all effects";
+  const secs = r.tolerationSeconds != null ? ` for ${str(r.tolerationSeconds)}s` : "";
+  const left = operator === "Exists" ? `${key} exists` : `${key}=${str(r.value)}`;
+  return `${left} → ${effect}${secs}`;
+}
+
 function PlainChips({ items }: { items: string[] }) {
   return (
     <div className="fl-chips">
@@ -520,11 +574,17 @@ function ContainerCard({
   status,
   forward,
   now,
+  onLogs,
+  onExec,
 }: {
   container: Record<string, unknown>;
   status?: Record<string, unknown>;
   forward?: ForwardTarget;
   now: number;
+  /** Open logs scoped to this container. */
+  onLogs?: () => void;
+  /** Open an exec session in this container. */
+  onExec?: () => void;
 }) {
   const name = str(container.name);
   const st = status ? containerStateText(status) : null;
@@ -536,6 +596,7 @@ function ContainerCard({
   const limits = asRecord(resources.limits);
   const liveness = asRecord(container.livenessProbe);
   const readiness = asRecord(container.readinessProbe);
+  const startup = asRecord(container.startupProbe);
   const command = [...asArray(container.command), ...asArray(container.args)].map(str).join(" ");
   const restartCount = status?.restartCount;
   const lastRestart = containerLastRestartTime(status);
@@ -546,10 +607,27 @@ function ContainerCard({
       <div className="fl-container-card__name">
         <span className={`fl-status__dot fl-status--${st?.kind ?? "neutral"}`} />
         {name}
+        {(onLogs || onExec) && (
+          <span className="ml-auto flex gap-1">
+            {onLogs && (
+              <Button variant="ghost" size="sm" onClick={onLogs} aria-label={`Logs for ${name}`}>
+                Logs
+              </Button>
+            )}
+            {onExec && (
+              <Button variant="ghost" size="sm" onClick={onExec} aria-label={`Exec into ${name}`}>
+                Exec
+              </Button>
+            )}
+          </span>
+        )}
       </div>
       <KV
         pairs={[
           ["Status", st ? <span className={`fl-status--${st.kind} fl-status-text`}>{st.text}</span> : ""],
+          container.targetContainerName
+            ? ["Debugging", <span className="fl-mono">{str(container.targetContainerName)}</span>]
+            : ["", ""],
           ["Restarts", restartCount != null ? str(restartCount) : ""],
           ["Last restart", timestampWithAge(lastRestart, now)],
           ["Running since", timestampWithAge(runningSince, now)],
@@ -588,6 +666,7 @@ function ContainerCard({
           ],
           ["Liveness", Object.keys(liveness).length ? <PlainChips items={probeChips(liveness)} /> : ""],
           ["Readiness", Object.keys(readiness).length ? <PlainChips items={probeChips(readiness)} /> : ""],
+          ["Startup", Object.keys(startup).length ? <PlainChips items={probeChips(startup)} /> : ""],
           ["Command", command ? <CollapsibleText text={command} label="command" muted /> : ""],
           ["Requests", Object.keys(requests).length ? resourceText(requests) : ""],
           ["Limits", Object.keys(limits).length ? resourceText(limits) : ""],
@@ -597,16 +676,54 @@ function ContainerCard({
   );
 }
 
+/**
+ * Pod lifecycle conditions as an ordered timeline. Three aligned columns —
+ * type (with reason), status pill, and the transition time (relative, with the
+ * absolute timestamp on hover) right-aligned so the progression scans top-down.
+ */
+function PodConditionsTimeline({ conditions, now }: { conditions: Condition[]; now: number }) {
+  if (conditions.length === 0) return null;
+  return (
+    <Section title="Conditions">
+      <ol className="grid grid-cols-[auto_auto_1fr] items-center gap-x-4 gap-y-2">
+        {orderPodConditions(conditions).map((condition) => (
+          <li key={condition.type} className="contents">
+            <span className="fl-mono text-sm">
+              {condition.type}
+              {condition.reason && condition.reason !== condition.type && (
+                <span className="text-muted-foreground"> · {condition.reason}</span>
+              )}
+            </span>
+            <StatusPill status={condition.status} kind={conditionKind(condition)} />
+            <span
+              className="text-right text-xs text-muted-foreground tabular-nums"
+              title={condition.lastTransitionTime ? absoluteTimestamp(condition.lastTransitionTime) : undefined}
+            >
+              {condition.lastTransitionTime ? `${ageFromTimestamp(condition.lastTransitionTime, now)} ago` : ""}
+            </span>
+          </li>
+        ))}
+      </ol>
+    </Section>
+  );
+}
+
 function PodDetailView({
   obj,
   now,
   context = "",
   onOpenResource,
+  onOpenLogs,
+  onOpenExec,
 }: {
   obj: K8sObject;
   now: number;
   context?: string;
   onOpenResource?: OpenResource;
+  /** Open logs for a specific container of this pod. */
+  onOpenLogs?: (container: string) => void;
+  /** Open an exec/terminal session in a specific container of this pod. */
+  onOpenExec?: (container: string) => void;
 }) {
   const meta = asRecord(obj.metadata);
   const spec = asRecord(obj.spec);
@@ -617,6 +734,13 @@ function PodDetailView({
   const conditions = asArray(status.conditions) as unknown as Condition[];
   const podIPs = asArray(status.podIPs).map((p) => str(asRecord(p).ip)).filter(Boolean);
   const tolerations = asArray(spec.tolerations);
+  const nodeSelector = (spec.nodeSelector ?? {}) as Record<string, string>;
+  const affinityLines = summarizeAffinity(asRecord(spec.affinity));
+  const hasScheduling =
+    !!spec.nodeName ||
+    Object.keys(nodeSelector).length > 0 ||
+    affinityLines.length > 0 ||
+    tolerations.length > 0;
   const created = str(meta.creationTimestamp);
   const namespace = str(meta.namespace) || null;
   const forward: ForwardTarget | undefined = context
@@ -641,6 +765,10 @@ function PodDetailView({
   const initStatuses = new Map(
     asArray(status.initContainerStatuses).map((s) => [str(asRecord(s).name), asRecord(s)]),
   );
+  const ephemeralStatuses = new Map(
+    asArray(status.ephemeralContainerStatuses).map((s) => [str(asRecord(s).name), asRecord(s)]),
+  );
+  const ephemeralContainers = asArray(spec.ephemeralContainers).map(asRecord);
   const allContainerStatuses = [
     ...asArray(status.initContainerStatuses),
     ...asArray(status.containerStatuses),
@@ -824,11 +952,46 @@ function PodDetailView({
               ),
             ],
             ["QoS Class", str(status.qosClass)],
-            ["Conditions", <ConditionBadges key="c" conditions={conditions} />],
-            ["Tolerations", tolerations.length ? plural(tolerations.length, "toleration") : ""],
           ]}
         />
       </Section>
+
+      <PodConditionsTimeline conditions={conditions} now={now} />
+
+      {hasScheduling && (
+        <Section title="Scheduling">
+          <KV
+            pairs={[
+              [
+                "Node",
+                spec.nodeName ? (
+                  <ResourceLink
+                    target={{ kind: "Node", namespace: null, name: str(spec.nodeName) }}
+                    onOpenResource={onOpenResource}
+                  />
+                ) : (
+                  "Not scheduled"
+                ),
+              ],
+              [
+                "Node selector",
+                Object.keys(nodeSelector).length ? <Chips map={nodeSelector} /> : "",
+              ],
+              ["Affinity", affinityLines.length ? <PlainChips items={affinityLines} /> : ""],
+              [
+                "Tolerations",
+                tolerations.length ? (
+                  <Expandable summary={plural(tolerations.length, "toleration")}>
+                    <PlainChips items={tolerations.map(tolerationText)} />
+                  </Expandable>
+                ) : (
+                  ""
+                ),
+              ],
+            ]}
+          />
+        </Section>
+      )}
 
       {podVolumes.length > 0 && (
         <Section title="Pod Volumes">
@@ -862,18 +1025,38 @@ function PodDetailView({
         ) : (
           asArray(spec.containers).map((c) => {
             const cr = asRecord(c);
+            const cn = str(cr.name);
             return (
               <ContainerCard
-                key={str(cr.name)}
+                key={cn}
                 container={cr}
-                status={containerStatuses.get(str(cr.name))}
+                status={containerStatuses.get(cn)}
                 forward={forward}
                 now={now}
+                onLogs={onOpenLogs ? () => onOpenLogs(cn) : undefined}
+                onExec={onOpenExec ? () => onOpenExec(cn) : undefined}
               />
             );
           })
         )}
       </Section>
+
+      {ephemeralContainers.length > 0 && (
+        <Section title="Ephemeral Containers">
+          {ephemeralContainers.map((cr) => {
+            const cn = str(cr.name);
+            return (
+              <ContainerCard
+                key={cn}
+                container={cr}
+                status={ephemeralStatuses.get(cn)}
+                now={now}
+                onLogs={onOpenLogs ? () => onOpenLogs(cn) : undefined}
+              />
+            );
+          })}
+        </Section>
+      )}
     </div>
   );
 }
@@ -2728,6 +2911,7 @@ export function ObjectDetail({
   context = "",
   onEdited,
   onOpenResource,
+  onOpenLogs,
 }: {
   kind: string;
   obj: K8sObject;
@@ -2735,6 +2919,8 @@ export function ObjectDetail({
   context?: string;
   onEdited?: () => void;
   onOpenResource?: OpenResource;
+  /** Open logs scoped to a container (Pod detail only). */
+  onOpenLogs?: (container: string) => void;
 }) {
   const meta = asRecord(obj.metadata);
   // Metrics chart (Pod/Node) sits above the rest, matching Lens. Needs a
@@ -2758,6 +2944,7 @@ export function ObjectDetail({
           now={now}
           context={context}
           onOpenResource={onOpenResource}
+          onOpenLogs={onOpenLogs}
         />
       </>
     );
@@ -2803,6 +2990,7 @@ export function ResourceOverview({
   getObjectFn = getObject,
   reloadKey = 0,
   onOpenResource,
+  onOpenLogs,
 }: {
   context: string;
   kind: string;
@@ -2812,6 +3000,8 @@ export function ResourceOverview({
   /** Bumped by the parent after a write action to re-fetch the shown object. */
   reloadKey?: number;
   onOpenResource?: OpenResource;
+  /** Open logs scoped to a container (Pod detail only). */
+  onOpenLogs?: (container: string) => void;
 }) {
   const [obj, setObj] = useState<K8sObject | null>(null);
   const [error, setError] = useState("");
@@ -2842,6 +3032,7 @@ export function ResourceOverview({
       context={context}
       onEdited={() => setEditReload((n) => n + 1)}
       onOpenResource={onOpenResource}
+      onOpenLogs={onOpenLogs}
     />
   );
 }


### PR DESCRIPTION
Part of #13 (closes all but container-scoped exec — see below).

`PodDetailView` was already rich (container table, init containers, volumes, tolerations). This closes the remaining parity gaps.

## Changes

- **Conditions timeline** — conditions now render as an ordered lifecycle timeline (PodScheduled → Initialized → ContainersReady → Ready) in three aligned columns (type · reason | status | right-aligned transition time, absolute on hover), replacing the unordered badge row in Properties. Pure `orderPodConditions` helper, tested.
- **Scheduling section** — node, `nodeSelector`, an affinity / anti-affinity summary (`summarizeAffinity`, tested), and detailed tolerations (expandable).
- **Ephemeral containers** — rendered as container cards showing their debug **target** container.
- **Startup probe** — added to the container card (alongside liveness/readiness).
- **Per-container Logs** — a **Logs** button on each container card opens the logs dock preselected to that container, threaded `ResourceDetail → ResourceOverview → ObjectDetail → PodDetailView`, and `ResourceBrowser → App(openDock) → Dock → LogsView(initialContainer)`.

## Deferred

Container-scoped **exec** — the card's plumbing is in place (`onExec`), but wiring it end-to-end needs a container param on the backend exec (`AttachParams::container`). Filed as a small follow-up so #13 stays honest.

## Tests (TDD)

- `orderPodConditions` (lifecycle order + unknown-type handling) and `summarizeAffinity`.
- New Pod-parity UI tests: ordered conditions, scheduling (nodeSelector/affinity/tolerations), ephemeral container + startup probe, and the per-container Logs action opening scoped to the container.

Full suite **374 passing**, coverage 83.31% (gate 80), `vite build` + `tsc --noEmit` clean. Frontend-only.