### PR TITLE
feat(pods): container-scoped exec + icon actions on container cards

### DIFF
--- a/apps/desktop/src-tauri/src/exec.rs
+++ b/apps/desktop/src-tauri/src/exec.rs
@@ -40,6 +40,7 @@ pub async fn start_pod_exec(
     context: String,
     namespace: String,
     pod: String,
+    container: Option<String>,
     shell: Option<String>,
     app: AppHandle,
     manager: State<'_, ExecManager>,
@@ -57,6 +58,7 @@ pub async fn start_pod_exec(
             context,
             namespace,
             pod,
+            container,
             shell,
             move |chunk| {
                 let _ = app_out.emit(&out_channel, chunk);

--- a/apps/desktop/src/components/Dock.tsx
+++ b/apps/desktop/src/components/Dock.tsx
@@ -125,6 +125,7 @@ export function Dock({
               context={active.context}
               namespace={active.namespace}
               pod={active.pod}
+              container={active.container}
             />
           ) : (
             <LogsView

--- a/apps/desktop/src/components/PodTerminal.tsx
+++ b/apps/desktop/src/components/PodTerminal.tsx
@@ -10,10 +10,13 @@ export function PodTerminal({
   context,
   namespace,
   pod,
+  container,
 }: {
   context: string;
   namespace: string;
   pod: string;
+  /** Exec into this specific container (for multi-container pods). */
+  container?: string;
 }) {
   const ref = useRef<HTMLDivElement>(null);
 
@@ -47,6 +50,7 @@ export function PodTerminal({
         pod,
         (chunk) => term.write(chunk),
         (err) => term.write(`\r\n[session ended${err ? `: ${err}` : ""}]\r\n`),
+        container,
       ).then((s) => {
         if (disposed) {
           s.close();
@@ -66,7 +70,7 @@ export function PodTerminal({
       disposed = true;
       cleanup();
     };
-  }, [context, namespace, pod]);
+  }, [context, namespace, pod, container]);
 
   return <div ref={ref} style={{ height: "100%", width: "100%", background: "#000", padding: 6, boxSizing: "border-box" }} />;
 }

--- a/apps/desktop/src/components/ResourceBrowser.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.tsx
@@ -546,7 +546,7 @@ export function ResourceBrowser({
   kind: ResourceKind;
   query?: string;
   onQueryChange?: (q: string) => void;
-  onOpenTerminal?: (s: { context: string; namespace: string; pod: string }) => void;
+  onOpenTerminal?: (s: { context: string; namespace: string; pod: string; container?: string }) => void;
   onOpenLogs?: (s: { context: string; namespace: string; pod: string; container?: string }) => void;
   onOpenWorkloadLogs?: (s: { context: string; namespace: string; kind: string; name: string }) => void;
   /** Open a "new resource" editor tab, optionally seeded with this kind's template. */
@@ -968,6 +968,9 @@ export function ResourceBrowser({
             onOpenResource={onOpenResource}
             onOpenLogs={(container) =>
               onOpenLogs?.({ context, namespace: selectedPod.namespace, pod: selectedPod.name, container })
+            }
+            onOpenExec={(container) =>
+              onOpenTerminal?.({ context, namespace: selectedPod.namespace, pod: selectedPod.name, container })
             }
           />
         )}

--- a/apps/desktop/src/components/ResourceDetail.tsx
+++ b/apps/desktop/src/components/ResourceDetail.tsx
@@ -26,6 +26,7 @@ export function ResourceDetail({
   reloadKey = 0,
   onOpenResource,
   onOpenLogs,
+  onOpenExec,
 }: {
   context: string;
   kind: string;
@@ -36,6 +37,8 @@ export function ResourceDetail({
   onOpenResource?: OpenResource;
   /** Open logs scoped to a container (Pod detail only). */
   onOpenLogs?: (container: string) => void;
+  /** Open an exec session in a container (Pod detail only). */
+  onOpenExec?: (container: string) => void;
 }) {
   const [tab, setTab] = useState<DetailTab>("overview");
 
@@ -52,6 +55,7 @@ export function ResourceDetail({
             reloadKey={reloadKey}
             onOpenResource={onOpenResource}
             onOpenLogs={onOpenLogs}
+            onOpenExec={onOpenExec}
           />
         )}
         {tab === "yaml" && (

--- a/apps/desktop/src/components/ResourceOverview.test.tsx
+++ b/apps/desktop/src/components/ResourceOverview.test.tsx
@@ -333,6 +333,13 @@ describe("ObjectDetail (Pod parity: #13)", () => {
     fireEvent.click(screen.getByRole("button", { name: "Logs for nginx" }));
     expect(onOpenLogs).toHaveBeenCalledWith("nginx");
   });
+
+  it("offers per-container Exec that opens scoped to the container", () => {
+    const onOpenExec = vi.fn();
+    render(<ObjectDetail kind="Pod" obj={parityPod} now={NOW} context="kind-dev" onOpenExec={onOpenExec} />);
+    fireEvent.click(screen.getByRole("button", { name: "Exec into nginx" }));
+    expect(onOpenExec).toHaveBeenCalledWith("nginx");
+  });
 });
 
 describe("ObjectDetail (Deployment)", () => {

--- a/apps/desktop/src/components/ResourceOverview.tsx
+++ b/apps/desktop/src/components/ResourceOverview.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { ArrowLeftRight, ChevronDown, ChevronUp } from "lucide-react";
+import { ArrowLeftRight, ChevronDown, ChevronUp, ScrollText, SquareTerminal } from "lucide-react";
 import type { X509Certificate } from "@peculiar/x509";
 import { getObject, getSecret, type K8sObject } from "../lib/manifest";
 import { listEndpointSlices } from "../lib/network";
@@ -608,17 +608,9 @@ function ContainerCard({
         <span className={`fl-status__dot fl-status--${st?.kind ?? "neutral"}`} />
         {name}
         {(onLogs || onExec) && (
-          <span className="ml-auto flex gap-1">
-            {onLogs && (
-              <Button variant="ghost" size="sm" onClick={onLogs} aria-label={`Logs for ${name}`}>
-                Logs
-              </Button>
-            )}
-            {onExec && (
-              <Button variant="ghost" size="sm" onClick={onExec} aria-label={`Exec into ${name}`}>
-                Exec
-              </Button>
-            )}
+          <span className="ml-auto flex gap-0.5">
+            {onLogs && <IconButton icon={ScrollText} label={`Logs for ${name}`} onClick={onLogs} />}
+            {onExec && <IconButton icon={SquareTerminal} label={`Exec into ${name}`} onClick={onExec} />}
           </span>
         )}
       </div>
@@ -2912,6 +2904,7 @@ export function ObjectDetail({
   onEdited,
   onOpenResource,
   onOpenLogs,
+  onOpenExec,
 }: {
   kind: string;
   obj: K8sObject;
@@ -2921,6 +2914,8 @@ export function ObjectDetail({
   onOpenResource?: OpenResource;
   /** Open logs scoped to a container (Pod detail only). */
   onOpenLogs?: (container: string) => void;
+  /** Open an exec session in a container (Pod detail only). */
+  onOpenExec?: (container: string) => void;
 }) {
   const meta = asRecord(obj.metadata);
   // Metrics chart (Pod/Node) sits above the rest, matching Lens. Needs a
@@ -2945,6 +2940,7 @@ export function ObjectDetail({
           context={context}
           onOpenResource={onOpenResource}
           onOpenLogs={onOpenLogs}
+          onOpenExec={onOpenExec}
         />
       </>
     );
@@ -2991,6 +2987,7 @@ export function ResourceOverview({
   reloadKey = 0,
   onOpenResource,
   onOpenLogs,
+  onOpenExec,
 }: {
   context: string;
   kind: string;
@@ -3002,6 +2999,8 @@ export function ResourceOverview({
   onOpenResource?: OpenResource;
   /** Open logs scoped to a container (Pod detail only). */
   onOpenLogs?: (container: string) => void;
+  /** Open an exec session in a container (Pod detail only). */
+  onOpenExec?: (container: string) => void;
 }) {
   const [obj, setObj] = useState<K8sObject | null>(null);
   const [error, setError] = useState("");
@@ -3033,6 +3032,7 @@ export function ResourceOverview({
       onEdited={() => setEditReload((n) => n + 1)}
       onOpenResource={onOpenResource}
       onOpenLogs={onOpenLogs}
+      onOpenExec={onOpenExec}
     />
   );
 }

--- a/apps/desktop/src/lib/exec.test.ts
+++ b/apps/desktop/src/lib/exec.test.ts
@@ -33,6 +33,7 @@ describe("startPodExec", () => {
       context: "kind-dev",
       namespace: "default",
       pod: "web-1",
+      container: null,
       shell: null,
     });
     expect(onMock).toHaveBeenCalledWith("exec:out:7", expect.any(Function));
@@ -47,5 +48,18 @@ describe("startPodExec", () => {
     expect(invokeCommandMock).toHaveBeenCalledWith("exec_input", { session: 7, data: "ls\n" });
     session.close();
     expect(invokeCommandMock).toHaveBeenCalledWith("exec_close", { session: 7 });
+  });
+
+  it("forwards a container when execing into a specific one", async () => {
+    invokeCommandMock.mockResolvedValueOnce(9);
+    onMock.mockReturnValue(vi.fn());
+    await startPodExec("kind-dev", "default", "web-1", vi.fn(), vi.fn(), "sidecar");
+    expect(invokeCommandMock).toHaveBeenCalledWith("start_pod_exec", {
+      context: "kind-dev",
+      namespace: "default",
+      pod: "web-1",
+      container: "sidecar",
+      shell: null,
+    });
   });
 });

--- a/apps/desktop/src/lib/exec.ts
+++ b/apps/desktop/src/lib/exec.ts
@@ -18,11 +18,13 @@ export async function startPodExec(
   pod: string,
   onData: (chunk: string) => void,
   onExit: (error: string | null) => void,
+  container?: string,
 ): Promise<ExecSession> {
   const session = await invokeCommand<number>("start_pod_exec", {
     context,
     namespace,
     pod,
+    container: container ?? null,
     shell: null,
   });
   const disposeOut = on(`exec:out:${session}`, (p) => onData(p as string));

--- a/crates/kube/src/exec.rs
+++ b/crates/kube/src/exec.rs
@@ -23,11 +23,13 @@ pub fn shell_command(requested: Option<&str>) -> Vec<String> {
 /// Open an interactive exec session. `on_output` receives stdout chunks
 /// (lossy UTF-8); `input_rx` yields stdin keystrokes. Runs until either side
 /// closes or the task is aborted.
+#[allow(clippy::too_many_arguments)]
 pub async fn exec_shell<F>(
     cache: Arc<ClientCache>,
     context: String,
     namespace: String,
     pod: String,
+    container: Option<String>,
     shell: Option<String>,
     mut on_output: F,
     mut input_rx: Receiver<String>,
@@ -37,11 +39,16 @@ where
 {
     let client = cache.get(&context).await?;
     let api: Api<Pod> = Api::namespaced(client, &namespace);
-    let params = AttachParams::default()
+    let mut params = AttachParams::default()
         .stdin(true)
         .stdout(true)
         .stderr(false)
         .tty(true);
+    // Target a specific container when asked (multi-container / sidecar pods);
+    // otherwise the API defaults to the pod's first container.
+    if let Some(container) = container.filter(|c| !c.is_empty()) {
+        params = params.container(container);
+    }
 
     let command = shell_command(shell.as_deref());
     let mut attached = api


### PR DESCRIPTION
Closes #13 (the remaining item after #79).

## Changes

- **Container-scoped exec** — the Exec action on a container card now opens a terminal attached to that specific container (was: the pod's first container). Adds an optional `container` to the exec path:
  - `exec_shell` → `AttachParams::container(...)` (backend)
  - `start_pod_exec` (Tauri) → `startPodExec` (`lib/exec`) → `PodTerminal` → `Dock`
- **onOpenExec threading** — mirrors the logs wiring: `ResourceDetail → ResourceOverview → ObjectDetail → PodDetailView`, and `ResourceBrowser → App(openDock) → Dock → PodTerminal(container)`.
- **Icon actions** — the per-container **Logs** / **Exec** text buttons are now icon buttons (`ScrollText` / `SquareTerminal`) with the same accessible labels/tooltips, matching the compact card header.

## Tests

- `startPodExec` forwards a container when given one.
- Per-container **Exec** UI test (opens scoped to the container), alongside the existing Logs test.

Backend `cargo test --workspace` green; frontend **376 passing**, coverage 83.33% (gate 80), `vite build` + `tsc --noEmit` clean.