### PR TITLE
feat(nodes): show/hide table columns (#80)

### DIFF
--- a/apps/desktop/src/components/ResourceBrowser.test.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.test.tsx
@@ -581,6 +581,30 @@ describe("ResourceBrowser", () => {
     expect(screen.queryByRole("columnheader", { name: /Version/ })).toBeNull();
   });
 
+  it("keeps hidden node columns after switching kubernetes context", async () => {
+    localStorage.clear();
+    listNamespacesMock.mockResolvedValue({ namespaces: ["default"] });
+    listNodesMock.mockResolvedValue({
+      nodes: [{ name: "cp-1", status: "Ready", unschedulable: false, taints: 0, version: "v1.35.0", roles: "control-plane" }],
+    });
+    const user = userEvent.setup();
+
+    const first = render(<ResourceBrowser context="cluster-a" kind="nodes" />);
+    await waitFor(() => expect(screen.getByText("cp-1")).toBeDefined());
+    await user.click(screen.getByRole("button", { name: "Choose columns" }));
+    await user.click(await screen.findByLabelText("Version"));
+    await waitFor(() => expect(screen.queryByRole("columnheader", { name: /Version/ })).toBeNull());
+
+    // Switching cluster mounts a fresh Nodes view for the new context; the
+    // choice is stored per-view (not per-context), so it must carry over.
+    first.unmount();
+    render(<ResourceBrowser context="cluster-b" kind="nodes" />);
+    await waitFor(() => expect(screen.getByText("cp-1")).toBeDefined());
+    expect(screen.queryByRole("columnheader", { name: /Version/ })).toBeNull();
+    // Other columns remain visible.
+    expect(screen.getByRole("columnheader", { name: /Roles/ })).toBeDefined();
+  });
+
   it("shows a namespace load error and does not watch", async () => {
     listNamespacesMock.mockResolvedValue({ error: "forbidden: namespaces" });
     render(<ResourceBrowser context="kind-dev" kind="pods" />);

--- a/apps/desktop/src/components/ResourceBrowser.test.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.test.tsx
@@ -551,6 +551,36 @@ describe("ResourceBrowser", () => {
     expect(screen.getByText("Tainted (2)")).toBeDefined();
   });
 
+  it("hides a node column via the column picker and remembers it", async () => {
+    localStorage.clear();
+    listNamespacesMock.mockResolvedValue({ namespaces: ["default"] });
+    listNodesMock.mockResolvedValue({
+      nodes: [{ name: "cp-1", status: "Ready", unschedulable: false, taints: 0, version: "v1.35.0", roles: "control-plane" }],
+    });
+    const user = userEvent.setup();
+    const view = render(<ResourceBrowser context="kind-dev" kind="nodes" />);
+
+    await waitFor(() => expect(screen.getByText("cp-1")).toBeDefined());
+    // Version column starts visible.
+    expect(screen.getByRole("columnheader", { name: /Version/ })).toBeDefined();
+
+    await user.click(screen.getByRole("button", { name: "Choose columns" }));
+    await user.click(await screen.findByLabelText("Version"));
+
+    // Header is gone…
+    await waitFor(() =>
+      expect(screen.queryByRole("columnheader", { name: /Version/ })).toBeNull(),
+    );
+    // …and the choice is persisted.
+    expect(JSON.parse(localStorage.getItem("srelens.hiddenColumns")!)).toEqual({ nodes: ["version"] });
+
+    // Remounting the nodes view keeps the column hidden.
+    view.unmount();
+    render(<ResourceBrowser context="kind-dev" kind="nodes" />);
+    await waitFor(() => expect(screen.getByText("cp-1")).toBeDefined());
+    expect(screen.queryByRole("columnheader", { name: /Version/ })).toBeNull();
+  });
+
   it("shows a namespace load error and does not watch", async () => {
     listNamespacesMock.mockResolvedValue({ error: "forbidden: namespaces" });
     render(<ResourceBrowser context="kind-dev" kind="pods" />);

--- a/apps/desktop/src/components/ResourceBrowser.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.tsx
@@ -65,13 +65,16 @@ import {
   LoadingState,
   Badge,
   Button,
+  ColumnPicker,
   Drawer,
   StatusPill,
   TextInput,
   Toolbar,
   type Column,
+  type ColumnOption,
   type StatusKind,
 } from "../ui";
+import { loadHiddenColumns, saveHiddenColumns } from "../lib/settings";
 
 export type ResourceKind =
   | "overview"
@@ -244,6 +247,9 @@ const TYPED_KINDS: ResourceKind[] = [
 const isGeneric = (kind: ResourceKind) => !TYPED_KINDS.includes(kind);
 const isNamespaced = (kind: ResourceKind) => !CLUSTER_SCOPED.includes(kind);
 const isWatchable = (kind: ResourceKind) => (WATCHABLE_KINDS as readonly string[]).includes(kind);
+// Views that let users show/hide columns (persisted per kind). Nodes to start.
+const COLUMN_PICKER_KINDS: ResourceKind[] = ["nodes"];
+const supportsColumnPicker = (kind: ResourceKind) => COLUMN_PICKER_KINDS.includes(kind);
 const POLL_MS = 5000;
 
 function phaseKind(phase: string): StatusKind {
@@ -580,6 +586,10 @@ export function ResourceBrowser({
   // Bumped after a write action so the open detail overview re-fetches.
   const [detailReload, setDetailReload] = useState(0);
   const [filterColumn, setFilterColumn] = useState<string | null>(null);
+  // Hidden table columns for views that support customization, loaded per kind.
+  const [hiddenColumns, setHiddenColumns] = useState<Set<string>>(() =>
+    supportsColumnPicker(kind) ? new Set(loadHiddenColumns(kind)) : new Set(),
+  );
   // Per-pod CPU/memory (millicores / MiB), merged into the pods table.
   const [podCpuMem, setPodCpuMem] = useState<Map<string, { cpu: number; mem: number }>>(new Map());
   const viewKeyRef = useRef("");
@@ -587,6 +597,9 @@ export function ResourceBrowser({
   const namespaced = isNamespaced(kind);
 
   useEffect(() => setFilterColumn(null), [kind]);
+  useEffect(() => {
+    setHiddenColumns(supportsColumnPicker(kind) ? new Set(loadHiddenColumns(kind)) : new Set());
+  }, [kind]);
 
   useEffect(() => {
     let active = true;
@@ -752,6 +765,38 @@ export function ResourceBrowser({
     }
   }, [kind]);
 
+  // Column visibility (supported views only). The first column is the row
+  // identifier and is always kept; everything else can be toggled off.
+  const pickerEnabled = supportsColumnPicker(kind);
+  const pinnedColumnKey = columns[0]?.key;
+  const visibleColumns = useMemo(
+    () =>
+      pickerEnabled
+        ? columns.filter((column) => column.key === pinnedColumnKey || !hiddenColumns.has(column.key))
+        : columns,
+    [columns, pickerEnabled, pinnedColumnKey, hiddenColumns],
+  );
+  const columnOptions: ColumnOption[] = useMemo(
+    () =>
+      columns.map((column) => ({
+        key: column.key,
+        label: typeof column.header === "string" ? column.header : column.key,
+      })),
+    [columns],
+  );
+  function toggleColumn(key: string) {
+    if (key === pinnedColumnKey) return;
+    setHiddenColumns((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      saveHiddenColumns(kind, [...next]);
+      return next;
+    });
+    // A hidden column can't stay the active search filter.
+    setFilterColumn((current) => (current === key ? null : current));
+  }
+
   function onRowClick(row: { name: string }) {
     if (kind === "events") return; // events have no manifest detail
     if (kind === "pods") {
@@ -802,11 +847,11 @@ export function ResourceBrowser({
   }, [res.rows, kind, podCpuMem, namespaced, selectionKey]);
 
   const filtered = useMemo(
-    () => filterTableData(tableRows, columns, query, filterColumn),
-    [columns, filterColumn, query, tableRows],
+    () => filterTableData(tableRows, visibleColumns, query, filterColumn),
+    [visibleColumns, filterColumn, query, tableRows],
   );
   const filterLabel = filterColumn
-    ? columns.find((column) => column.key === filterColumn)?.header
+    ? visibleColumns.find((column) => column.key === filterColumn)?.header
     : null;
 
   function closeDetail() {
@@ -904,7 +949,17 @@ export function ResourceBrowser({
                   <Badge variant="success">live</Badge>
                 ))}
               {res.loading && filtered.length > 0 && <Spinner label="Loading resources" />}
-              <div className="fl-resource-toolbar__search ml-auto w-56">
+              {pickerEnabled && (
+                <div className="ml-auto">
+                  <ColumnPicker
+                    columns={columnOptions}
+                    hidden={hiddenColumns}
+                    onToggle={toggleColumn}
+                    pinnedKey={pinnedColumnKey}
+                  />
+                </div>
+              )}
+              <div className={`fl-resource-toolbar__search w-56${pickerEnabled ? "" : " ml-auto"}`}>
                 <TextInput
                   value={query}
                   onValueChange={(q) => onQueryChange?.(q)}
@@ -927,7 +982,7 @@ export function ResourceBrowser({
               )}
               {!res.error && !(res.loading && filtered.length === 0) && (
                 <Table
-                  columns={columns}
+                  columns={visibleColumns}
                   data={filtered}
                   getRowKey={(r) => r.name}
                   selectedKey={selectedKey}

--- a/apps/desktop/src/lib/settings.test.ts
+++ b/apps/desktop/src/lib/settings.test.ts
@@ -21,6 +21,8 @@ import {
   clampTimeoutSecs,
   getRequestTimeoutSecs,
   setRequestTimeoutSecs,
+  loadHiddenColumns,
+  saveHiddenColumns,
 } from "./settings";
 
 beforeEach(() => localStorage.clear());
@@ -95,6 +97,22 @@ describe("settings persistence", () => {
   it("persists and deduplicates additional kubeconfig files", () => {
     saveKubeconfigFiles(["/tmp/a", "/tmp/b", "/tmp/a"]);
     expect(loadKubeconfigFiles()).toEqual(["/tmp/a", "/tmp/b"]);
+  });
+
+  it("persists hidden columns per view independently", () => {
+    expect(loadHiddenColumns("nodes")).toEqual([]);
+    saveHiddenColumns("nodes", ["cpu", "memory", "cpu"]);
+    expect(loadHiddenColumns("nodes")).toEqual(["cpu", "memory"]);
+    // A different view keeps its own set.
+    expect(loadHiddenColumns("pods")).toEqual([]);
+    saveHiddenColumns("pods", ["restarts"]);
+    expect(loadHiddenColumns("nodes")).toEqual(["cpu", "memory"]);
+    expect(loadHiddenColumns("pods")).toEqual(["restarts"]);
+  });
+
+  it("returns no hidden columns when storage is corrupt", () => {
+    localStorage.setItem("srelens.hiddenColumns", "{not json");
+    expect(loadHiddenColumns("nodes")).toEqual([]);
   });
 
   it("persists context order and appends unordered contexts", () => {

--- a/apps/desktop/src/lib/settings.ts
+++ b/apps/desktop/src/lib/settings.ts
@@ -171,6 +171,32 @@ export function saveKubeconfigFiles(paths: string[]): void {
   }
 }
 
+const HIDDEN_COLUMNS_KEY = "srelens.hiddenColumns";
+
+/** Column keys the user has hidden for a given table view (keyed by view id). */
+export function loadHiddenColumns(view: string): string[] {
+  try {
+    const parsed = JSON.parse(stored(HIDDEN_COLUMNS_KEY) ?? "{}") as unknown;
+    const map = parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
+    const keys = map[view];
+    return Array.isArray(keys) ? keys.filter((k): k is string => typeof k === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Persist the hidden column keys for a view, merging into the per-view map. */
+export function saveHiddenColumns(view: string, keys: string[]): void {
+  try {
+    const parsed = JSON.parse(stored(HIDDEN_COLUMNS_KEY) ?? "{}") as unknown;
+    const map = parsed && typeof parsed === "object" ? (parsed as Record<string, string[]>) : {};
+    map[view] = [...new Set(keys)];
+    localStorage.setItem(HIDDEN_COLUMNS_KEY, JSON.stringify(map));
+  } catch {
+    // ignore unavailable/quota-exceeded storage
+  }
+}
+
 export function loadContextOrder(): string[] {
   try {
     const parsed = JSON.parse(stored(CONTEXT_ORDER_KEY) ?? "[]") as unknown;

--- a/apps/desktop/src/ui/ColumnPicker.tsx
+++ b/apps/desktop/src/ui/ColumnPicker.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { Columns3 } from "lucide-react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Button } from "./Button";
+
+export interface ColumnOption {
+  key: string;
+  label: string;
+}
+
+/**
+ * Toolbar control for choosing which table columns are visible. Each column is a
+ * checkbox; the `pinnedKey` column (the row identifier) is always shown and
+ * can't be toggled off. Visibility state is owned by the caller so it can be
+ * persisted and applied to the table.
+ */
+export function ColumnPicker({
+  columns,
+  hidden,
+  onToggle,
+  pinnedKey,
+  label = "Columns",
+}: {
+  columns: ColumnOption[];
+  hidden: ReadonlySet<string>;
+  onToggle: (key: string) => void;
+  pinnedKey?: string;
+  label?: string;
+}) {
+  const hiddenCount = columns.filter((c) => c.key !== pinnedKey && hidden.has(c.key)).length;
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="ghost" size="sm" aria-label="Choose columns">
+          <Columns3 data-icon="inline-start" />
+          {label}
+          {hiddenCount > 0 && <span className="tabular-nums opacity-70">({columns.length - hiddenCount})</span>}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-52 p-1">
+        <div role="group" aria-label="Toggle columns" className="fl-column-picker">
+          {columns.map((column) => {
+            const pinned = column.key === pinnedKey;
+            const checked = pinned || !hidden.has(column.key);
+            return (
+              <label
+                key={column.key}
+                className="flex items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-accent aria-disabled:opacity-60"
+                aria-disabled={pinned}
+              >
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  disabled={pinned}
+                  onChange={() => onToggle(column.key)}
+                />
+                <span>{column.label}</span>
+              </label>
+            );
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/desktop/src/ui/index.ts
+++ b/apps/desktop/src/ui/index.ts
@@ -14,6 +14,8 @@ export { tokens } from "./tokens";
 export type { Tokens } from "./tokens";
 export { Button } from "./Button";
 export type { ButtonProps, ButtonVariant } from "./Button";
+export { ColumnPicker } from "./ColumnPicker";
+export type { ColumnOption } from "./ColumnPicker";
 export { TextInput } from "./TextInput";
 export type { TextInputProps } from "./TextInput";
 export { Panel } from "./Panel";


### PR DESCRIPTION
Closes #80

## Problem

The Nodes table showed a fixed set of columns (Node, Status, Roles, CPU, Memory, Version, Age) with no way to tailor it — everyone gets the same layout and can't hide the noise.

## Change

Add a **Columns** picker to the toolbar: a popover with a checkbox per column to toggle visibility.

- **`ColumnPicker`** — new reusable UI primitive (`apps/desktop/src/ui/ColumnPicker.tsx`) built on the existing popover. The row-identifier column (Node) is **pinned** — always shown, not toggleable.
- **Correctness** — hidden columns are filtered into `visibleColumns`, which feeds both the `Table` and the `filterTableData` search/sort path, so hidden columns are fully excluded (not just visually). If the active search-filter column is hidden, the filter resets.
- **Persistence** — the hidden set is stored in `localStorage`, keyed **per view** (`loadHiddenColumns` / `saveHiddenColumns`), so it survives restarts and each view keeps its own choices.
- **Scope** — wired for the **Nodes** view via a small allowlist (`COLUMN_PICKER_KINDS`); other views opt in by adding their kind. Default layout is unchanged when nothing is stored.

## Testing

- `settings` tests: per-view persistence isolation + corrupt-storage fallback.
- `ResourceBrowser` test: open the picker, hide the **Version** column, assert the header disappears, the choice persists to `localStorage`, and it stays hidden after remounting the view.
- Full suite green (377 tests); `vite build` succeeds.

## Notes

- Reusable by design — flipping on another view is a one-line allowlist change, but I kept this PR scoped to Nodes as requested.