### PR TITLE
feat(editor): edit resources in a dedicated tab + fix tab-strip overflow scroll

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -69,10 +69,12 @@ vi.mock("./components/ResourceBrowser", () => ({
     context,
     kind,
     onOpenResource,
+    onOpenEdit,
   }: {
     context: string;
     kind: string;
     onOpenResource?: (target: { kind: string; namespace: string | null; name: string }) => void;
+    onOpenEdit?: (kind: string, namespace: string | null, name: string) => void;
   }) => (
     <div data-testid="browser">
       {context}:{kind}
@@ -81,11 +83,19 @@ vi.mock("./components/ResourceBrowser", () => ({
       >
         linked-pod
       </button>
+      <button onClick={() => onOpenEdit?.("Deployment", "default", "web")}>edit-web</button>
     </div>
   ),
 }));
 vi.mock("./components/SettingsView", () => ({
   SettingsView: () => <div data-testid="settings">workspace settings</div>,
+}));
+vi.mock("./components/EditResourceTab", () => ({
+  EditResourceTab: ({ kind, name }: { kind: string; name: string }) => (
+    <div data-testid="edit-tab">
+      {kind}/{name}
+    </div>
+  ),
 }));
 
 import { App } from "./App";
@@ -139,6 +149,20 @@ describe("App", () => {
     fireEvent.click(screen.getByText("nav-services"));
     fireEvent.click(screen.getByText("linked-pod"));
     expect(screen.getByTestId("browser").textContent).toContain("kind-dev:pods");
+  });
+
+  it("opens an edit tab from a resource and de-dupes re-edits", () => {
+    render(<App />);
+    fireEvent.click(screen.getByText("open-kind-dev"));
+    fireEvent.click(screen.getByText("nav-services"));
+    fireEvent.click(screen.getByText("edit-web"));
+    expect(screen.getByTestId("edit-tab").textContent).toBe("Deployment/web");
+    expect(screen.getByRole("tab", { name: /edit: Deployment\/web/ })).toBeDefined();
+
+    // Re-edit the same resource from the services tab → focuses, doesn't duplicate.
+    fireEvent.click(screen.getByRole("tab", { name: /Services/ }));
+    fireEvent.click(screen.getByText("edit-web"));
+    expect(screen.getAllByRole("tab", { name: /edit: Deployment\/web/ })).toHaveLength(1);
   });
 
   it("opens views across multiple clusters and closes tabs", () => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -15,6 +15,7 @@ import { ClusterOverview } from "./components/ClusterOverview";
 import { PortForwardsView } from "./components/PortForwardsView";
 import { HelmReleasesView } from "./components/HelmReleasesView";
 import { NewResourceEditor } from "./components/NewResourceEditor";
+import { EditResourceTab } from "./components/EditResourceTab";
 import { SettingsView } from "./components/SettingsView";
 import { CommandPalette } from "./components/CommandPalette";
 import { Toaster } from "./components/ui/sonner";
@@ -57,6 +58,8 @@ interface ViewTab {
   focus?: { name: string; namespace: string | null; nonce: number };
   /** For a "new resource" tab: the template kind to start from. */
   create?: { initialKind?: string };
+  /** For an "edit resource" tab: the resource to preload and apply back. */
+  edit?: { kind: string; namespace: string | null; name: string };
   /** Selected namespace filter (empty = all), preserved per tab. */
   namespace?: string;
 }
@@ -291,6 +294,26 @@ export function App() {
     setActiveTabId(id);
   }
 
+  /** Open (or focus) a full-tab editor preloaded with a resource's manifest. */
+  function openEditResource(kind: string, namespace: string | null, name: string) {
+    if (!activeCluster) return;
+    const existing = tabs.find(
+      (t) =>
+        t.kind === "editresource" &&
+        t.cluster === activeCluster &&
+        t.edit?.kind === kind &&
+        (t.edit?.namespace ?? null) === (namespace ?? null) &&
+        t.edit?.name === name,
+    );
+    if (existing) {
+      setActiveTabId(existing.id);
+      return;
+    }
+    const id = tabIdRef.current++;
+    setTabs((ts) => [...ts, { id, cluster: activeCluster, kind: "editresource", edit: { kind, namespace, name } }]);
+    setActiveTabId(id);
+  }
+
   /** Open (or focus) a custom-resource view for a cluster + CRD. */
   function openCrdView(cluster: string, crd: CrdRef) {
     const existing = tabs.find((t) => t.cluster === cluster && t.crd?.name === crd.name);
@@ -364,9 +387,11 @@ export function App() {
 
   const tabDescriptors: TabDescriptor[] = tabs.map((t) => ({
     id: t.id,
-    label: t.cluster
-      ? `${t.crd ? t.crd.kind : RESOURCE_LABELS[t.kind]} · ${contextDisplayName(t.cluster, contextProfiles[t.cluster])}`
-      : RESOURCE_LABELS[t.kind],
+    label: t.edit
+      ? `edit: ${t.edit.kind}/${t.edit.name}`
+      : t.cluster
+        ? `${t.crd ? t.crd.kind : RESOURCE_LABELS[t.kind]} · ${contextDisplayName(t.cluster, contextProfiles[t.cluster])}`
+        : RESOURCE_LABELS[t.kind],
   }));
 
   return (
@@ -461,6 +486,14 @@ export function App() {
                       context={activeCluster}
                       initialKind={activeTab.create?.initialKind}
                     />
+                  ) : activeCluster && activeKind === "editresource" && activeTab.edit ? (
+                    <EditResourceTab
+                      key={activeTab.id}
+                      context={activeCluster}
+                      kind={activeTab.edit.kind}
+                      namespace={activeTab.edit.namespace}
+                      name={activeTab.edit.name}
+                    />
                   ) : activeCluster ? (
                     <ResourceBrowser
                       key={activeTab.id}
@@ -470,6 +503,7 @@ export function App() {
                       onQueryChange={setQuery}
                       onOpenTerminal={(s) => openDock("terminal", s)}
                       onOpenLogs={(s) => openDock("logs", s)}
+                      onOpenEdit={openEditResource}
                       onOpenWorkloadLogs={(s) =>
                         openDock("logs", {
                           context: s.context,

--- a/apps/desktop/src/components/DetailActions.tsx
+++ b/apps/desktop/src/components/DetailActions.tsx
@@ -4,6 +4,7 @@ import {
   LogOut,
   Logs,
   Pause,
+  Pencil,
   Play,
   RotateCw,
   Scaling,
@@ -37,12 +38,14 @@ export function PodActions({
   onDeleted,
   onOpenTerminal,
   onOpenLogs,
+  onEdit,
 }: {
   context: string;
   pod: PodSummary;
   onDeleted?: () => void;
   onOpenTerminal?: Opener;
   onOpenLogs?: Opener;
+  onEdit?: () => void;
 }) {
   const [dialog, setDialog] = useState<"delete" | "evict" | "forward" | null>(null);
   const [busy, setBusy] = useState(false);
@@ -84,6 +87,7 @@ export function PodActions({
     <>
       <IconButton icon={Logs} label="Logs" onClick={() => onOpenLogs?.(target)} />
       <IconButton icon={SquareTerminal} label="Shell" onClick={() => onOpenTerminal?.(target)} />
+      {onEdit && <IconButton icon={Pencil} label="Edit" onClick={onEdit} />}
       <IconButton icon={ArrowLeftRight} label="Forward" onClick={() => setDialog("forward")} />
       <IconButton
         icon={LogOut}
@@ -190,6 +194,7 @@ export function ResourceActions({
   onDeleted,
   onChanged,
   onOpenLogs,
+  onEdit,
 }: {
   context: string;
   kind: string;
@@ -201,6 +206,7 @@ export function ResourceActions({
   /** Fired after a successful non-delete write action so the detail refreshes. */
   onChanged?: () => void;
   onOpenLogs?: (s: { context: string; namespace: string; kind: string; name: string }) => void;
+  onEdit?: () => void;
 }) {
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [scaling, setScaling] = useState(false);
@@ -297,6 +303,7 @@ export function ResourceActions({
           onClick={() => onOpenLogs({ context, namespace: namespace ?? "", kind, name })}
         />
       )}
+      {onEdit && <IconButton icon={Pencil} label="Edit" onClick={onEdit} />}
       {SCALABLE.includes(kind) && (
         <IconButton icon={Scaling} label="Scale" onClick={() => setScaling(true)} />
       )}

--- a/apps/desktop/src/components/EditResourceTab.test.tsx
+++ b/apps/desktop/src/components/EditResourceTab.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+
+const { loadEditableManifestMock } = vi.hoisted(() => ({ loadEditableManifestMock: vi.fn() }));
+vi.mock("../lib/manifestEdit", () => ({ loadEditableManifest: loadEditableManifestMock }));
+vi.mock("../lib/manifest", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/manifest")>()),
+  applyManifest: vi.fn(),
+  validateManifest: vi.fn().mockResolvedValue({ valid: true }),
+}));
+vi.mock("../lib/schema", () => ({ openApiSchema: vi.fn().mockResolvedValue({ error: "n/a" }) }));
+vi.mock("../ui/CodeEditor", () => ({
+  CodeEditor: ({ value, ariaLabel }: { value: string; ariaLabel?: string }) => (
+    <textarea aria-label={ariaLabel} value={value} readOnly />
+  ),
+}));
+
+import { EditResourceTab } from "./EditResourceTab";
+
+describe("EditResourceTab", () => {
+  it("preloads the resource's manifest into the editor with an Apply action", async () => {
+    loadEditableManifestMock.mockResolvedValue({ yaml: "kind: ConfigMap\nmetadata:\n  name: web\n" });
+    render(<EditResourceTab context="kind-dev" kind="ConfigMap" namespace="default" name="web" />);
+    await waitFor(() =>
+      expect(loadEditableManifestMock).toHaveBeenCalledWith("kind-dev", "ConfigMap", "default", "web"),
+    );
+    expect((await screen.findByLabelText("Edit resource YAML")) as HTMLTextAreaElement).toBeDefined();
+    expect((screen.getByLabelText("Edit resource YAML") as HTMLTextAreaElement).value).toContain("kind: ConfigMap");
+    expect(screen.getByText("Edit ConfigMap/web")).toBeDefined();
+    expect(screen.getByRole("button", { name: "Apply" })).toBeDefined();
+  });
+
+  it("shows an error when the manifest can't be loaded", async () => {
+    loadEditableManifestMock.mockResolvedValue({ error: "not found" });
+    render(<EditResourceTab context="kind-dev" kind="Pod" namespace="default" name="ghost" />);
+    expect(await screen.findByText(/not found/)).toBeDefined();
+  });
+});

--- a/apps/desktop/src/components/EditResourceTab.tsx
+++ b/apps/desktop/src/components/EditResourceTab.tsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from "react";
+import { Spinner } from "../ui";
+import { loadEditableManifest } from "../lib/manifestEdit";
+import { ManifestEditor } from "./ManifestEditor";
+
+/**
+ * A full-tab editor preloaded with a resource's current manifest (mirroring the
+ * New-resource tab). Loads via {@link loadEditableManifest} — which routes
+ * Secrets through the gated getSecret path — and applies via the shared
+ * {@link ManifestEditor} behind a confirm, toasting the result.
+ */
+export function EditResourceTab({
+  context,
+  kind,
+  namespace,
+  name,
+  onEdited,
+}: {
+  context: string;
+  kind: string;
+  namespace: string | null;
+  name: string;
+  /** Called after a successful apply (so the parent can refresh views). */
+  onEdited?: () => void;
+}) {
+  const [yaml, setYaml] = useState<string | null>(null);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let active = true;
+    setYaml(null);
+    setError("");
+    void loadEditableManifest(context, kind, namespace, name).then((out) => {
+      if (!active) return;
+      if (out.error) setError(out.error);
+      else setYaml(out.yaml ?? "");
+    });
+    return () => {
+      active = false;
+    };
+  }, [context, kind, namespace, name]);
+
+  if (error) return <p style={{ color: "var(--fl-color-danger)", padding: 12 }}>Error: {error}</p>;
+  if (yaml === null) return <Spinner label="Loading manifest" />;
+
+  return (
+    <ManifestEditor
+      context={context}
+      yaml={yaml}
+      onYamlChange={setYaml}
+      ariaLabel="Edit resource YAML"
+      fill
+      headerLabel={`Edit ${kind}/${name}`}
+      applyLabel="Apply"
+      applyingLabel="Applying…"
+      confirm={{ kind, name }}
+      onApplied={onEdited}
+    />
+  );
+}

--- a/apps/desktop/src/components/ManifestEditor.test.tsx
+++ b/apps/desktop/src/components/ManifestEditor.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React, { useState } from "react";
+
+const { applyManifestMock, notifyMock } = vi.hoisted(() => ({
+  applyManifestMock: vi.fn(),
+  notifyMock: { success: vi.fn(), error: vi.fn(), info: vi.fn(), updateAvailable: vi.fn() },
+}));
+vi.mock("../lib/manifest", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/manifest")>()),
+  applyManifest: applyManifestMock,
+  validateManifest: vi.fn().mockResolvedValue({ valid: true }),
+}));
+vi.mock("../lib/notify", () => ({ notify: notifyMock }));
+vi.mock("../lib/schema", () => ({ openApiSchema: vi.fn().mockResolvedValue({ error: "n/a" }) }));
+vi.mock("../ui/CodeEditor", () => ({
+  CodeEditor: ({ value, onChange, ariaLabel }: { value: string; onChange?: (v: string) => void; ariaLabel?: string }) => (
+    <textarea aria-label={ariaLabel} value={value} onChange={(e) => onChange?.(e.target.value)} />
+  ),
+}));
+
+import { ManifestEditor } from "./ManifestEditor";
+
+function Harness({ mode }: { mode: "create" | "edit" }) {
+  const [yaml, setYaml] = useState("kind: ConfigMap\nmetadata:\n  name: web\n");
+  return (
+    <ManifestEditor
+      context="kind-dev"
+      yaml={yaml}
+      onYamlChange={setYaml}
+      applyLabel={mode === "create" ? "Create" : "Apply"}
+      confirm={mode === "edit" ? { kind: "ConfigMap", name: "web" } : undefined}
+    />
+  );
+}
+
+beforeEach(() => {
+  applyManifestMock.mockReset();
+  notifyMock.success.mockReset();
+  notifyMock.error.mockReset();
+});
+
+describe("ManifestEditor", () => {
+  it("create mode applies immediately (no confirm) and toasts success", async () => {
+    applyManifestMock.mockResolvedValue({ kind: "ConfigMap", name: "web" });
+    render(<Harness mode="create" />);
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+    await waitFor(() => expect(applyManifestMock).toHaveBeenCalledWith("kind-dev", expect.stringContaining("ConfigMap")));
+    expect(notifyMock.success).toHaveBeenCalled();
+  });
+
+  it("edit mode confirms before applying", async () => {
+    applyManifestMock.mockResolvedValue({ kind: "ConfigMap", name: "web" });
+    render(<Harness mode="edit" />);
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    // Apply doesn't fire until the confirm dialog is accepted.
+    expect(applyManifestMock).not.toHaveBeenCalled();
+    await waitFor(() => expect(screen.getByText("Apply manifest?")).toBeDefined());
+    // Two "Apply" buttons now (header + dialog); the dialog's is last.
+    fireEvent.click(screen.getAllByRole("button", { name: "Apply" }).at(-1)!);
+    await waitFor(() => expect(applyManifestMock).toHaveBeenCalled());
+    expect(notifyMock.success).toHaveBeenCalled();
+  });
+
+  it("toasts an error when apply fails", async () => {
+    applyManifestMock.mockResolvedValue({ error: "conflict" });
+    render(<Harness mode="create" />);
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+    await waitFor(() => expect(notifyMock.error).toHaveBeenCalled());
+  });
+});

--- a/apps/desktop/src/components/ManifestEditor.tsx
+++ b/apps/desktop/src/components/ManifestEditor.tsx
@@ -1,0 +1,180 @@
+import React, { Suspense, lazy, useState } from "react";
+import { CircleCheck, Undo2, Upload } from "lucide-react";
+import { applyManifest, validateManifest } from "../lib/manifest";
+import { notify } from "../lib/notify";
+import { openApiSchema } from "../lib/schema";
+import { Spinner, Button, ConfirmDialog } from "../ui";
+
+// CodeMirror is heavy and only needed where a manifest is edited — load on demand.
+const CodeEditor = lazy(() => import("../ui/CodeEditor").then((m) => ({ default: m.CodeEditor })));
+
+/**
+ * The one YAML manifest editor shared by the New-resource tab, the Edit tab,
+ * and the drawer YAML view. Wraps CodeMirror (YAML highlighting + schema
+ * validation/completion for the context) with a server-side apply that
+ * optionally confirms first and always toasts the result.
+ *
+ * `yaml` is controlled by the parent so callers can swap templates (create) or
+ * load from the cluster (edit). `fill` pins the editor to fill a tab; otherwise
+ * it grows within a bounded height for the drawer.
+ */
+export function ManifestEditor({
+  context,
+  yaml,
+  onYamlChange,
+  ariaLabel = "Manifest YAML",
+  fill = false,
+  applyLabel = "Apply",
+  applyingLabel = "Applying…",
+  applyIcon,
+  confirm,
+  resetTo,
+  headerExtras,
+  headerLabel,
+  onApplied,
+}: {
+  context: string;
+  yaml: string;
+  onYamlChange: (yaml: string) => void;
+  ariaLabel?: string;
+  /** Fill the parent (tab); otherwise render at a bounded height (drawer). */
+  fill?: boolean;
+  applyLabel?: string;
+  applyingLabel?: string;
+  applyIcon?: React.ReactNode;
+  /** When set, Apply opens a confirm dialog naming this resource first. */
+  confirm?: { kind: string; name: string };
+  /** When set, show a Reset button that reverts the draft to this text. */
+  resetTo?: string;
+  /** Extra header content on the left (e.g. a create-template picker). */
+  headerExtras?: React.ReactNode;
+  /** Short header title (e.g. "New resource" / "Edit ConfigMap/web"). */
+  headerLabel?: string;
+  /** Called with the applied object on success. */
+  onApplied?: (result: { kind: string; name: string }) => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [confirming, setConfirming] = useState(false);
+  const [result, setResult] = useState<{ kind: string; name: string } | null>(null);
+
+  async function doApply() {
+    setBusy(true);
+    setError("");
+    const out = await applyManifest(context, yaml);
+    setBusy(false);
+    if (out.error) {
+      setError(out.error);
+      notify.error(`Failed to apply ${confirm?.name ?? "resource"}`, out.error);
+      return;
+    }
+    setConfirming(false);
+    const applied = { kind: out.kind ?? "", name: out.name ?? "" };
+    setResult(applied);
+    notify.success(`Applied ${applied.kind || "resource"} ${applied.name}`.trim());
+    onApplied?.(applied);
+  }
+
+  function onApplyClick() {
+    if (confirm) setConfirming(true);
+    else void doApply();
+  }
+
+  const editor = (
+    <Suspense fallback={<Spinner label="Loading editor" />}>
+      <CodeEditor
+        value={yaml}
+        onChange={onYamlChange}
+        language="yaml"
+        ariaLabel={ariaLabel}
+        fill={fill}
+        minHeight={fill ? undefined : 320}
+        maxHeight={fill ? undefined : 520}
+        schemaValidate={(y) =>
+          validateManifest(context, y).then((r) => (r.valid === false ? r.errors ?? [] : []))
+        }
+        schemaSource={(apiVersion, kind) =>
+          openApiSchema(context, apiVersion, kind).then((r) => ("error" in r ? null : r))
+        }
+      />
+    </Suspense>
+  );
+
+  const applyButton = (
+    <Button onClick={onApplyClick} disabled={busy || !yaml.trim() || (resetTo != null && yaml === resetTo)}>
+      {busy ? <Spinner label={applyingLabel} data-icon="inline-start" /> : applyIcon ?? <Upload data-icon="inline-start" />}
+      {busy ? applyingLabel : applyLabel}
+    </Button>
+  );
+
+  const confirmDialog = confirming ? (
+    <ConfirmDialog
+      title="Apply manifest?"
+      message={
+        <>
+          <p style={{ marginTop: 0 }}>
+            Server-side apply the edited <code>{confirm?.kind}</code> <code>{confirm?.name}</code> to the cluster?
+          </p>
+          {error && <p style={{ color: "var(--fl-color-danger)" }}>Error: {error}</p>}
+        </>
+      }
+      confirmLabel="Apply"
+      busy={busy}
+      onConfirm={() => void doApply()}
+      onCancel={() => setConfirming(false)}
+    />
+  ) : null;
+
+  if (fill) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col bg-background">
+        <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2 text-sm">
+          {headerLabel && <span className="font-medium">{headerLabel}</span>}
+          <span className="text-xs text-muted-foreground">on {context}</span>
+          {headerExtras}
+          <div className="ml-auto flex items-center gap-3">
+            {result && (
+              <span className="fl-apply-success">
+                <CircleCheck aria-hidden="true" />
+                Applied {result.kind} <code>{result.name}</code>
+              </span>
+            )}
+            {error && !confirming && (
+              <span className="max-w-md truncate text-destructive" title={error}>
+                Error: {error}
+              </span>
+            )}
+            {applyButton}
+          </div>
+        </div>
+        <div className="relative min-h-0 flex-1 overflow-hidden">
+          {/* Absolute-inset pins CodeMirror to a definite-height box so it fills the tab. */}
+          <div className="absolute inset-0">{editor}</div>
+        </div>
+        {confirmDialog}
+      </div>
+    );
+  }
+
+  const dirty = resetTo == null || yaml !== resetTo;
+  return (
+    <div>
+      {editor}
+      <div style={{ display: "flex", gap: 8, alignItems: "center", marginTop: 8 }}>
+        {applyButton}
+        {resetTo != null && (
+          <Button variant="ghost" onClick={() => onYamlChange(resetTo)} disabled={!dirty}>
+            <Undo2 data-icon="inline-start" />
+            Reset
+          </Button>
+        )}
+        {result && !dirty && (
+          <span className="fl-apply-success">
+            <CircleCheck aria-hidden="true" /> Applied
+          </span>
+        )}
+      </div>
+      {confirmDialog}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/NewResourceEditor.tsx
+++ b/apps/desktop/src/components/NewResourceEditor.tsx
@@ -1,10 +1,7 @@
-import React, { Suspense, lazy, useState } from "react";
-import { CircleCheck, FilePlus2 } from "lucide-react";
-import { Button, Combobox, Spinner } from "../ui";
-import { applyManifest, validateManifest } from "../lib/manifest";
-import { openApiSchema } from "../lib/schema";
-
-const CodeEditor = lazy(() => import("../ui/CodeEditor").then((m) => ({ default: m.CodeEditor })));
+import React, { useState } from "react";
+import { FilePlus2 } from "lucide-react";
+import { Combobox } from "../ui";
+import { ManifestEditor } from "./ManifestEditor";
 
 /** Starter manifests for common kinds, namespaced where relevant. */
 const TEMPLATES: Record<string, (ns: string) => string> = {
@@ -113,84 +110,37 @@ export function NewResourceEditor({
   const startTemplate = initialKind && TEMPLATES[initialKind] ? initialKind : "Deployment";
   const [template, setTemplate] = useState(startTemplate);
   const [yaml, setYaml] = useState(() => TEMPLATES[startTemplate](ns));
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState("");
-  const [result, setResult] = useState<{ kind: string; name: string } | null>(null);
 
   function pickTemplate(t: string) {
     setTemplate(t);
     setYaml(TEMPLATES[t](ns));
-    setResult(null);
-    setError("");
-  }
-
-  async function create() {
-    setBusy(true);
-    setError("");
-    setResult(null);
-    const out = await applyManifest(context, yaml);
-    setBusy(false);
-    if (out.error) {
-      setError(out.error);
-      return;
-    }
-    setResult({ kind: out.kind ?? "", name: out.name ?? "" });
-    onCreated?.();
   }
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col bg-background">
-      <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2 text-sm">
-        <span className="font-medium">New resource</span>
-        <span className="text-xs text-muted-foreground">on {context}</span>
-        <span className="mx-1 text-xs text-muted-foreground">Template</span>
-        <Combobox
-          value={template}
-          onValueChange={pickTemplate}
-          options={TEMPLATE_ORDER.map((t) => ({ value: t }))}
-          ariaLabel="Template"
-          searchPlaceholder="Search templates…"
-          className="min-w-40"
-        />
-        <div className="ml-auto flex items-center gap-3">
-          {result && (
-            <span className="fl-apply-success">
-              <CircleCheck aria-hidden="true" />
-              Applied {result.kind} <code>{result.name}</code>
-            </span>
-          )}
-          {error && <span className="max-w-md truncate text-destructive" title={error}>Error: {error}</span>}
-          <Button onClick={() => void create()} disabled={busy || !yaml.trim()}>
-            {busy ? (
-              <Spinner label="Creating resource" data-icon="inline-start" />
-            ) : (
-              <FilePlus2 data-icon="inline-start" />
-            )}
-            {busy ? "Creating…" : "Create"}
-          </Button>
-        </div>
-      </div>
-      <div className="relative min-h-0 flex-1 overflow-hidden">
-        <Suspense fallback={<Spinner label="Loading editor" />}>
-          {/* Absolute-inset pins CodeMirror to a definite-height box so it fills
-              the tab (its own height:100% then resolves) instead of collapsing. */}
-          <div className="absolute inset-0">
-            <CodeEditor
-              value={yaml}
-              onChange={setYaml}
-              language="yaml"
-              ariaLabel="New resource YAML"
-              fill
-              schemaValidate={(y) =>
-                validateManifest(context, y).then((r) => (r.valid === false ? r.errors ?? [] : []))
-              }
-              schemaSource={(apiVersion, kind) =>
-                openApiSchema(context, apiVersion, kind).then((r) => ("error" in r ? null : r))
-              }
-            />
-          </div>
-        </Suspense>
-      </div>
-    </div>
+    <ManifestEditor
+      context={context}
+      yaml={yaml}
+      onYamlChange={setYaml}
+      ariaLabel="New resource YAML"
+      fill
+      headerLabel="New resource"
+      applyLabel="Create"
+      applyingLabel="Creating…"
+      applyIcon={<FilePlus2 data-icon="inline-start" />}
+      onApplied={onCreated}
+      headerExtras={
+        <>
+          <span className="mx-1 text-xs text-muted-foreground">Template</span>
+          <Combobox
+            value={template}
+            onValueChange={pickTemplate}
+            options={TEMPLATE_ORDER.map((t) => ({ value: t }))}
+            ariaLabel="Template"
+            searchPlaceholder="Search templates…"
+            className="min-w-40"
+          />
+        </>
+      }
+    />
   );
 }

--- a/apps/desktop/src/components/ResourceBrowser.test.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.test.tsx
@@ -509,6 +509,18 @@ describe("ResourceBrowser", () => {
     );
   });
 
+  it("opens an edit tab from the detail Edit action", async () => {
+    listNamespacesMock.mockResolvedValue({ namespaces: ["default"] });
+    watchResourceMock.mockImplementation(
+      watchWith([{ name: "web", namespace: "default", ready: "1/1", upToDate: 1, available: 1 }]),
+    );
+    const onOpenEdit = vi.fn();
+    render(<ResourceBrowser context="kind-dev" kind="deployments" onOpenEdit={onOpenEdit} />);
+    fireEvent.click(await screen.findByText("web"));
+    fireEvent.click(await screen.findByRole("button", { name: "Edit" }));
+    expect(onOpenEdit).toHaveBeenCalledWith("Deployment", "default", "web");
+  });
+
   it("lists a generic kind (endpoints) via listResource", async () => {
     listNamespacesMock.mockResolvedValue({ namespaces: ["default"] });
     listResourceMock.mockResolvedValue({ items: [{ name: "ep-1", namespace: "default" }] });

--- a/apps/desktop/src/components/ResourceBrowser.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.tsx
@@ -113,7 +113,8 @@ export type ResourceKind =
   | "portforwards"
   | "helmreleases"
   | "settings"
-  | "newresource";
+  | "newresource"
+  | "editresource";
 
 export const RESOURCE_LABELS: Record<ResourceKind, string> = {
   overview: "Overview",
@@ -156,6 +157,7 @@ export const RESOURCE_LABELS: Record<ResourceKind, string> = {
   helmreleases: "Helm Releases",
   settings: "Settings",
   newresource: "New Resource",
+  editresource: "Edit Resource",
 };
 
 export const K8S_KIND: Record<ResourceKind, string> = {
@@ -199,6 +201,7 @@ export const K8S_KIND: Record<ResourceKind, string> = {
   helmreleases: "",
   settings: "",
   newresource: "",
+  editresource: "",
 };
 
 const CLUSTER_SCOPED: ResourceKind[] = [
@@ -536,6 +539,7 @@ export function ResourceBrowser({
   onOpenLogs,
   onOpenWorkloadLogs,
   onOpenNew,
+  onOpenEdit,
   onOpenResource,
   focus,
   initialNamespace = "",
@@ -551,6 +555,8 @@ export function ResourceBrowser({
   onOpenWorkloadLogs?: (s: { context: string; namespace: string; kind: string; name: string }) => void;
   /** Open a "new resource" editor tab, optionally seeded with this kind's template. */
   onOpenNew?: (initialKind?: string) => void;
+  /** Open a full-tab editor preloaded with a resource's manifest. */
+  onOpenEdit?: (kind: string, namespace: string | null, name: string) => void;
   onOpenResource?: OpenResource;
   /** Deep-link target (from global search): open this resource's detail once it loads. */
   focus?: { name: string; namespace: string | null; nonce: number };
@@ -827,6 +833,7 @@ export function ResourceBrowser({
       onDeleted={closeDetail}
       onOpenTerminal={onOpenTerminal}
       onOpenLogs={onOpenLogs}
+      onEdit={onOpenEdit ? () => onOpenEdit("Pod", selectedPod.namespace, selectedPod.name) : undefined}
     />
   ) : otherDetail ? (
     <>
@@ -853,6 +860,9 @@ export function ResourceBrowser({
         onDeleted={closeDetail}
         onChanged={() => setDetailReload((k) => k + 1)}
         onOpenLogs={onOpenWorkloadLogs}
+        onEdit={
+          onOpenEdit ? () => onOpenEdit(otherDetail.kind, otherDetail.namespace, otherDetail.name) : undefined
+        }
       />
     </>
   ) : null;

--- a/apps/desktop/src/components/ResourceTabs.test.tsx
+++ b/apps/desktop/src/components/ResourceTabs.test.tsx
@@ -1,7 +1,15 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import React from "react";
 import { ResourceTabs } from "./ResourceTabs";
+
+// jsdom stubs scrollIntoView on HTMLElement.prototype; replace it with a spy so
+// the active-tab effect is observable.
+const scrollIntoView = vi.fn();
+beforeEach(() => {
+  scrollIntoView.mockClear();
+  HTMLElement.prototype.scrollIntoView = scrollIntoView;
+});
 
 const tabs = [
   { id: 1, label: "Pods · dev" },
@@ -38,6 +46,11 @@ describe("ResourceTabs", () => {
 
     fireEvent.click(screen.getByText("Close to the Right"));
     expect(h.onCloseToRight).toHaveBeenCalledWith(2);
+  });
+
+  it("scrolls the active tab into view", () => {
+    setup(); // activeId=2
+    expect(scrollIntoView).toHaveBeenCalled();
   });
 
   it("disables Close to the Right on the last tab", async () => {

--- a/apps/desktop/src/components/ResourceTabs.tsx
+++ b/apps/desktop/src/components/ResourceTabs.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { X } from "lucide-react";
 import {
   ContextMenu,
@@ -36,10 +36,31 @@ export function ResourceTabs({
   onCloseToRight: (id: number) => void;
   onCloseAll: () => void;
 }) {
+  const stripRef = useRef<HTMLDivElement>(null);
+
+  // Keep the active tab visible — opening the 15th tab shouldn't leave it
+  // off-screen to the right. Query the strip (rather than hold a ref) since the
+  // tab is wrapped by Radix's asChild trigger, which owns the child ref.
+  useEffect(() => {
+    stripRef.current
+      ?.querySelector('[aria-selected="true"]')
+      ?.scrollIntoView({ inline: "nearest", block: "nearest" });
+  }, [activeId, tabs.length]);
+
+  // Translate vertical wheel gestures into horizontal scroll so a plain mouse
+  // (no shift, no trackpad) can reach overflowed tabs.
+  function onWheel(e: React.WheelEvent<HTMLDivElement>) {
+    const strip = stripRef.current;
+    if (!strip || e.deltaX !== 0 || e.deltaY === 0) return;
+    strip.scrollLeft += e.deltaY;
+  }
+
   return (
     <div
+      ref={stripRef}
       role="tablist"
       className="fl-ctabs"
+      onWheel={onWheel}
     >
       {tabs.map((t, i) => {
         const active = t.id === activeId;

--- a/apps/desktop/src/components/YamlView.tsx
+++ b/apps/desktop/src/components/YamlView.tsx
@@ -1,18 +1,12 @@
-import React, { Suspense, lazy, useEffect, useState } from "react";
-import { CircleCheck, Undo2, Upload } from "lucide-react";
-import { getManifest, applyManifest, validateManifest } from "../lib/manifest";
-import { notify } from "../lib/notify";
-import { openApiSchema } from "../lib/schema";
-import { Spinner, Button, ConfirmDialog } from "../ui";
-
-// CodeMirror is heavy and only needed on the YAML tab — load it on demand so it
-// stays out of the initial bundle.
-const CodeEditor = lazy(() => import("../ui/CodeEditor").then((m) => ({ default: m.CodeEditor })));
+import React, { useEffect, useState } from "react";
+import { getManifest } from "../lib/manifest";
+import { Spinner } from "../ui";
+import { ManifestEditor } from "./ManifestEditor";
 
 /**
- * Manifest view + editor for any resource. Loads YAML via `k8s.getManifest`,
- * edits it in a CodeMirror editor (YAML highlighting, line numbers, find), and
- * server-side applies via `k8s.applyManifest` (behind a confirm).
+ * Manifest view + editor for any resource in the detail drawer. Loads YAML via
+ * `k8s.getManifest`, then hands off to the shared {@link ManifestEditor} for
+ * editing and server-side apply (behind a confirm).
  */
 export function YamlView({
   context,
@@ -31,16 +25,11 @@ export function YamlView({
   const [original, setOriginal] = useState<string | null>(null);
   const [draft, setDraft] = useState("");
   const [error, setError] = useState("");
-  const [confirming, setConfirming] = useState(false);
-  const [applying, setApplying] = useState(false);
-  const [applyError, setApplyError] = useState("");
-  const [applied, setApplied] = useState(false);
 
   function load() {
     let active = true;
     setOriginal(null);
     setError("");
-    setApplied(false);
     void getManifest(context, kind, namespace, name, undefined, crd).then((out) => {
       if (!active) return;
       if (out.error) setError(out.error);
@@ -56,80 +45,17 @@ export function YamlView({
 
   useEffect(load, [context, kind, namespace, name, crd]);
 
-  async function apply() {
-    setApplying(true);
-    setApplyError("");
-    const out = await applyManifest(context, draft);
-    setApplying(false);
-    if (out.error) {
-      setApplyError(out.error);
-      notify.error(`Failed to apply ${name}`, out.error);
-      return;
-    }
-    setConfirming(false);
-    setApplied(true);
-    notify.success(`Applied ${name}`);
-    load();
-  }
-
   if (error) return <p style={{ color: "var(--fl-color-danger)" }}>Error: {error}</p>;
   if (original === null) return <Spinner label="Loading manifest" />;
 
-  const dirty = draft !== original;
-
   return (
-    <div>
-      <Suspense fallback={<Spinner label="Loading editor" />}>
-        <CodeEditor
-          value={draft}
-          onChange={setDraft}
-          language="yaml"
-          ariaLabel="Manifest YAML"
-          minHeight={320}
-          maxHeight={520}
-          schemaValidate={(y) =>
-            validateManifest(context, y).then((r) => (r.valid === false ? r.errors ?? [] : []))
-          }
-          schemaSource={(apiVersion, kind) =>
-            openApiSchema(context, apiVersion, kind).then((r) => ("error" in r ? null : r))
-          }
-        />
-      </Suspense>
-      <div style={{ display: "flex", gap: 8, alignItems: "center", marginTop: 8 }}>
-        <Button onClick={() => setConfirming(true)} disabled={!dirty}>
-          <Upload data-icon="inline-start" />
-          Apply
-        </Button>
-        <Button variant="ghost" onClick={() => setDraft(original)} disabled={!dirty}>
-          <Undo2 data-icon="inline-start" />
-          Reset
-        </Button>
-        {applied && !dirty && (
-          <span className="fl-apply-success">
-            <CircleCheck aria-hidden="true" /> Applied
-          </span>
-        )}
-      </div>
-
-      {confirming && (
-        <ConfirmDialog
-          title="Apply manifest?"
-          message={
-            <>
-              <p style={{ marginTop: 0 }}>
-                Server-side apply the edited <code>{kind}</code> <code>{name}</code> to the cluster?
-              </p>
-              {applyError && (
-                <p style={{ color: "var(--fl-color-danger)" }}>Error: {applyError}</p>
-              )}
-            </>
-          }
-          confirmLabel="Apply"
-          busy={applying}
-          onConfirm={() => void apply()}
-          onCancel={() => setConfirming(false)}
-        />
-      )}
-    </div>
+    <ManifestEditor
+      context={context}
+      yaml={draft}
+      onYamlChange={setDraft}
+      confirm={{ kind, name }}
+      resetTo={original}
+      onApplied={load}
+    />
   );
 }

--- a/apps/desktop/src/lib/manifestEdit.test.ts
+++ b/apps/desktop/src/lib/manifestEdit.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from "vitest";
+import { secretToStringData, loadEditableManifest } from "./manifestEdit";
+import { parse } from "yaml";
+
+describe("secretToStringData", () => {
+  it("replaces redacted base64 data with decoded stringData, keeping other fields", () => {
+    const manifest = `apiVersion: v1
+kind: Secret
+metadata:
+  name: web-tls
+  namespace: default
+  labels:
+    app: web
+type: Opaque
+data:
+  token: ""
+`;
+    // getSecret returns base64 values; "aGVsbG8=" decodes to "hello".
+    const out = secretToStringData(manifest, { token: "aGVsbG8=" });
+    const doc = parse(out);
+    expect(doc.data).toBeUndefined();
+    expect(doc.stringData).toEqual({ token: "hello" });
+    // Untouched fields survive.
+    expect(doc.metadata.labels).toEqual({ app: "web" });
+    expect(doc.type).toBe("Opaque");
+  });
+});
+
+describe("loadEditableManifest", () => {
+  it("returns the manifest verbatim for a non-secret kind", async () => {
+    const getManifest = vi.fn().mockResolvedValue({ yaml: "kind: ConfigMap\n" });
+    const getSecret = vi.fn();
+    const out = await loadEditableManifest("kind-dev", "ConfigMap", "default", "cm", { getManifest, getSecret });
+    expect(out.yaml).toBe("kind: ConfigMap\n");
+    expect(getSecret).not.toHaveBeenCalled();
+  });
+
+  it("fetches decoded values via getSecret and inlines them as stringData for a Secret", async () => {
+    const getManifest = vi.fn().mockResolvedValue({
+      yaml: "apiVersion: v1\nkind: Secret\nmetadata:\n  name: s\n  namespace: default\ndata:\n  token: \"\"\n",
+    });
+    const getSecret = vi.fn().mockResolvedValue({ data: { token: "aGVsbG8=" } });
+    const out = await loadEditableManifest("kind-dev", "Secret", "default", "s", { getManifest, getSecret });
+    expect(getSecret).toHaveBeenCalledWith("kind-dev", "default", "s");
+    expect(parse(out.yaml!).stringData).toEqual({ token: "hello" });
+  });
+
+  it("surfaces a getManifest error", async () => {
+    const getManifest = vi.fn().mockResolvedValue({ error: "boom" });
+    const out = await loadEditableManifest("x", "Pod", "default", "p", { getManifest, getSecret: vi.fn() });
+    expect(out.error).toBe("boom");
+  });
+});

--- a/apps/desktop/src/lib/manifestEdit.ts
+++ b/apps/desktop/src/lib/manifestEdit.ts
@@ -1,0 +1,64 @@
+import { parse, stringify } from "yaml";
+import { getManifest as defaultGetManifest, getSecret as defaultGetSecret } from "./manifest";
+
+/** Decode a base64 string to UTF-8 text (returns the input unchanged on failure). */
+function decodeBase64(value: string): string {
+  try {
+    const binary = atob(value);
+    const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+    return new TextDecoder().decode(bytes);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Rewrite a Secret manifest so its (redacted) base64 `data` becomes decoded,
+ * editable `stringData`. On apply, Kubernetes re-encodes `stringData`, so this
+ * keeps values round-trippable without exposing base64 in the editor.
+ */
+export function secretToStringData(manifestYaml: string, data: Record<string, string>): string {
+  const doc = (parse(manifestYaml) ?? {}) as Record<string, unknown>;
+  delete doc.data;
+  const stringData: Record<string, string> = {};
+  for (const [key, value] of Object.entries(data)) {
+    stringData[key] = decodeBase64(value);
+  }
+  doc.stringData = stringData;
+  return stringify(doc);
+}
+
+interface Deps {
+  getManifest?: typeof defaultGetManifest;
+  getSecret?: typeof defaultGetSecret;
+}
+
+/**
+ * Load a resource's manifest for the Edit tab. Most kinds come straight from
+ * `k8s.getManifest`. Secrets are special: `getManifest` redacts their values,
+ * so we fetch the real (base64) values through the gated `k8s.getSecret` and
+ * inline them as decoded `stringData` — keeping the sensitive path intact while
+ * making the Secret genuinely editable.
+ */
+export async function loadEditableManifest(
+  context: string,
+  kind: string,
+  namespace: string | null,
+  name: string,
+  deps: Deps = {},
+): Promise<{ yaml?: string; error?: string }> {
+  const getManifest = deps.getManifest ?? defaultGetManifest;
+  const getSecret = deps.getSecret ?? defaultGetSecret;
+
+  const out = await getManifest(context, kind, namespace, name);
+  if (out.error) return { error: out.error };
+  let manifestYaml = out.yaml ?? "";
+
+  if (kind === "Secret") {
+    const secret = await getSecret(context, namespace ?? "", name);
+    if (secret.error) return { error: secret.error };
+    manifestYaml = secretToStringData(manifestYaml, secret.data ?? {});
+  }
+
+  return { yaml: manifestYaml };
+}

--- a/apps/desktop/src/ui/styles.css
+++ b/apps/desktop/src/ui/styles.css
@@ -970,42 +970,8 @@ body {
 }
 
 /* Cluster tabs (multi-cluster) */
-.fl-ctabs {
-  display: flex;
-  background: var(--fl-color-hotbar);
-  border-bottom: 1px solid var(--fl-color-border);
-  min-height: 34px;
-  overflow-x: auto;
-}
-.fl-ctabs::-webkit-scrollbar { height: 0; }
-.fl-ctab {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 0 14px;
-  cursor: pointer;
-  color: var(--fl-color-text-muted);
-  border-right: 1px solid var(--fl-color-border);
-  font-size: 13px;
-  white-space: nowrap;
-}
-.fl-ctab--active {
-  background: var(--fl-color-bg);
-  color: var(--fl-color-text);
-}
-.fl-ctab__close {
-  background: transparent;
-  border: none;
-  color: inherit;
-  cursor: pointer;
-  opacity: 0.5;
-  font-size: 11px;
-}
-.fl-ctab__close:hover { opacity: 1; }
-.fl-ctab__close svg {
-  width: 12px;
-  height: 12px;
-}
+/* .fl-ctabs / .fl-ctab live in one consolidated block further down (search
+   ".fl-ctabs {"). The earlier duplicate was removed. */
 
 /* Top bar */
 .fl-topbar {
@@ -3181,12 +3147,22 @@ body {
   border-bottom-style: solid;
   border-bottom-width: 1px;
 }
+/* Thin, unobtrusive horizontal scrollbar so an overflowing strip stays usable. */
 .fl-ctabs::-webkit-scrollbar {
-  height: 0;
+  height: 6px;
+}
+.fl-ctabs::-webkit-scrollbar-thumb {
+  background: var(--fl-color-border);
+  border-radius: 3px;
+}
+.fl-ctabs::-webkit-scrollbar-track {
+  background: transparent;
 }
 .fl-ctab {
   display: inline-flex;
-  min-width: 0;
+  /* Keep each tab at its label width and let the strip overflow (scroll)
+     instead of squishing tabs below their text. */
+  flex: 0 0 auto;
   max-width: 360px;
   align-items: center;
   gap: 8px;
@@ -3231,6 +3207,10 @@ body {
 .fl-ctab__close:hover {
   background: var(--fl-color-surface-alt);
   opacity: 1;
+}
+.fl-ctab__close svg {
+  width: 14px;
+  height: 14px;
 }
 .fl-tabs {
   min-height: 42px;


### PR DESCRIPTION
Closes #67.

## 1. Edit in a dedicated tab

- **Shared `ManifestEditor`** — factored the CodeEditor + schema validate/complete + server-side apply + confirm + toast into one component (fill mode for tabs, bounded for the drawer). Refactored `NewResourceEditor` and the drawer `YamlView` onto it, removing the duplicated editor/apply logic the ticket called out.
- **Edit tab** — new `editresource` tab kind + `edit: { kind, namespace, name }` descriptor + `openEditResource(...)` in `App.tsx`, mirroring Create. Re-editing the same resource **focuses the existing tab**; label reads `edit: <kind>/<name>`.
- **Edit action** — a Pencil action on the resource detail (`DetailActions`, both Pod and non-pod) opens the preloaded editor tab.
- **Secrets** (per the design decision) — the edit tab preloads Secrets through the gated `k8s.getSecret` and inlines decoded values as **`stringData`** (`loadEditableManifest` / `secretToStringData`), so a Secret is genuinely editable without leaking base64/redacted data into a plain YAML tab.

## 2. Tab-strip overflow scrolling

- `.fl-ctab { flex: 0 0 auto }` so tabs keep their label width and the strip actually overflows (was: squishing).
- Thin styled scrollbar + **wheel → horizontal scroll**; the **active tab scrolls into view** on activate/open.
- De-duplicated the two `.fl-ctabs` / `.fl-ctab` blocks in `ui/styles.css` into one.

## Tests (TDD)

- `secretToStringData` / `loadEditableManifest` (incl. the Secret → stringData path).
- `ManifestEditor` create-vs-edit modes (direct apply vs confirm; error toast).
- `EditResourceTab` preload; `ResourceBrowser` Edit action → `onOpenEdit`; `App` open-edit + **de-dupe**; `ResourceTabs` **scroll-active-into-view**.

Full suite **388 passing**, coverage 83.63% (gate 80), `vite build` + `tsc --noEmit` clean. Frontend-only.