### PR TITLE
feat(mcp): MCP settings — in-app server toggle, CLI install, per-tool client config

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod exec;
 mod files;
 mod forward;
 mod logs;
+mod mcp;
 mod settings;
 mod updater;
 mod watch;
@@ -14,6 +15,10 @@ use exec::{exec_close, exec_input, start_pod_exec, ExecManager};
 use forward::{start_port_forward, stop_port_forward, ForwardManager};
 use srelens_kube::client_cache::ClientCache;
 use logs::{start_log_stream, stop_log_stream, LogStreamManager};
+use mcp::{
+    install_srelens_cli, mcp_http_start, mcp_http_status, mcp_http_stop, srelens_cli_status,
+    McpHttpManager,
+};
 use settings::{get_request_timeout, set_request_timeout};
 use updater::{update_check, update_install};
 use watch::{start_resource_watch, stop_watch, WatchManager};
@@ -166,6 +171,7 @@ pub fn run() {
         .manage(WatchManager::new(cache.clone()))
         .manage(ExecManager::new(cache.clone()))
         .manage(ForwardManager::new(cache.clone()))
+        .manage(McpHttpManager::new(cache.clone()))
         .manage(LogStreamManager::new(cache))
         .invoke_handler(tauri::generate_handler![
             invoke_capability,
@@ -184,7 +190,12 @@ pub fn run() {
             update_check,
             update_install,
             set_request_timeout,
-            get_request_timeout
+            get_request_timeout,
+            mcp_http_start,
+            mcp_http_stop,
+            mcp_http_status,
+            install_srelens_cli,
+            srelens_cli_status
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/desktop/src-tauri/src/mcp.rs
+++ b/apps/desktop/src-tauri/src/mcp.rs
@@ -1,0 +1,149 @@
+//! In-app MCP HTTP server lifecycle and `srelens` CLI install, driven from the
+//! Settings → MCP section. The HTTP server shares the app's authenticated
+//! client cache, so an MCP client can drive the same clusters the GUI sees.
+
+use std::net::{Ipv4Addr, SocketAddr};
+use std::sync::{Arc, Mutex};
+
+use serde::Serialize;
+use srelens_kube::client_cache::ClientCache;
+use tauri::State;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
+use crate::capabilities::build_registry_with;
+
+struct Running {
+    addr: SocketAddr,
+    shutdown: Option<oneshot::Sender<()>>,
+    handle: JoinHandle<()>,
+}
+
+/// Tauri-managed state owning the running MCP HTTP server (if any).
+pub struct McpHttpManager {
+    cache: Arc<ClientCache>,
+    running: Mutex<Option<Running>>,
+}
+
+impl McpHttpManager {
+    pub fn new(cache: Arc<ClientCache>) -> Self {
+        Self {
+            cache,
+            running: Mutex::new(None),
+        }
+    }
+}
+
+fn stop_running(manager: &McpHttpManager) {
+    if let Some(mut running) = manager.running.lock().unwrap().take() {
+        if let Some(tx) = running.shutdown.take() {
+            let _ = tx.send(());
+        }
+        running.handle.abort();
+    }
+}
+
+fn url_for(addr: SocketAddr) -> String {
+    format!("http://{addr}/mcp")
+}
+
+/// Start (or restart) the loopback MCP HTTP server on `port`. Returns its URL.
+#[tauri::command]
+pub async fn mcp_http_start(port: u16, manager: State<'_, McpHttpManager>) -> Result<String, String> {
+    stop_running(&manager);
+
+    let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
+    // Bind up front so a port conflict is reported to the UI immediately.
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .map_err(|e| format!("Could not bind {addr}: {e}"))?;
+
+    let registry = build_registry_with(manager.cache.clone());
+    let server = srelens_mcp::McpServer::new(Arc::new(registry));
+    let (tx, rx) = oneshot::channel();
+    let handle = tokio::spawn(async move {
+        let _ = srelens_mcp::http::serve_http_with_shutdown(server, listener, async {
+            let _ = rx.await;
+        })
+        .await;
+    });
+
+    *manager.running.lock().unwrap() = Some(Running {
+        addr,
+        shutdown: Some(tx),
+        handle,
+    });
+    Ok(url_for(addr))
+}
+
+/// Stop the MCP HTTP server if running.
+#[tauri::command]
+pub fn mcp_http_stop(manager: State<'_, McpHttpManager>) -> Result<(), String> {
+    stop_running(&manager);
+    Ok(())
+}
+
+/// The MCP HTTP server's URL if it's currently running.
+#[tauri::command]
+pub fn mcp_http_status(manager: State<'_, McpHttpManager>) -> Option<String> {
+    manager
+        .running
+        .lock()
+        .unwrap()
+        .as_ref()
+        .map(|running| url_for(running.addr))
+}
+
+/// Where the `srelens` CLI symlink is installed, and whether it points at us.
+#[derive(Debug, Serialize)]
+pub struct CliStatus {
+    installed: bool,
+    /// The install path (`/usr/local/bin/srelens`).
+    path: String,
+    /// What the symlink resolves to, if present.
+    links_to: Option<String>,
+}
+
+const CLI_PATH: &str = "/usr/local/bin/srelens";
+
+/// Report whether the `srelens` CLI is installed on PATH and where it points.
+#[tauri::command]
+pub fn srelens_cli_status() -> CliStatus {
+    let path = std::path::Path::new(CLI_PATH);
+    CliStatus {
+        installed: path.exists(),
+        path: CLI_PATH.to_string(),
+        links_to: std::fs::read_link(path)
+            .ok()
+            .map(|p| p.to_string_lossy().to_string()),
+    }
+}
+
+/// Symlink the running executable to `/usr/local/bin/srelens` so MCP clients can
+/// spawn `srelens --mcp-stdio`. Returns the install path on success; on a write
+/// failure returns a message with the manual command to run.
+#[tauri::command]
+pub fn install_srelens_cli() -> Result<String, String> {
+    let exe = std::env::current_exe().map_err(|e| e.to_string())?;
+
+    #[cfg(unix)]
+    {
+        let target = std::path::Path::new(CLI_PATH);
+        // Replace any existing symlink/file at the target.
+        if target.exists() || std::fs::symlink_metadata(target).is_ok() {
+            let _ = std::fs::remove_file(target);
+        }
+        match std::os::unix::fs::symlink(&exe, target) {
+            Ok(()) => Ok(CLI_PATH.to_string()),
+            Err(e) => Err(format!(
+                "Could not write {CLI_PATH} ({e}). Run this in a terminal:\n  sudo ln -sf \"{}\" {CLI_PATH}",
+                exe.display()
+            )),
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = exe;
+        Err("Installing the srelens CLI is only supported on macOS/Linux.".to_string())
+    }
+}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -43,7 +43,9 @@ import {
   saveContextOrder,
   orderContexts,
   loadUpdateChannel,
+  loadMcpSettings,
 } from "./lib/settings";
+import { startMcpHttp } from "./lib/mcp";
 import { checkForUpdateAndNotify } from "./lib/updateNotifier";
 import { notify } from "./lib/notify";
 import type { SettingsSection } from "./components/SettingsView";
@@ -258,6 +260,13 @@ export function App() {
     const SIX_HOURS = 6 * 60 * 60 * 1000;
     const timer = setInterval(run, SIX_HOURS);
     return () => clearInterval(timer);
+  }, []);
+
+  // Start the in-app MCP HTTP server on launch if the user left it enabled, so
+  // agents can connect without opening Settings first.
+  useEffect(() => {
+    const mcp = loadMcpSettings();
+    if (mcp.enabled) void startMcpHttp(mcp.port).catch(() => {});
   }, []);
 
   /** Open a resource's kind view and deep-link to its detail (from search). */

--- a/apps/desktop/src/components/McpSettingsSection.test.tsx
+++ b/apps/desktop/src/components/McpSettingsSection.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+
+const { mcp } = vi.hoisted(() => ({
+  mcp: {
+    startMcpHttp: vi.fn(),
+    stopMcpHttp: vi.fn(),
+    mcpHttpStatus: vi.fn(),
+    installSrelensCli: vi.fn(),
+    srelensCliStatus: vi.fn(),
+  },
+}));
+vi.mock("../lib/mcp", () => mcp);
+vi.mock("../lib/notify", () => ({ notify: { success: vi.fn(), error: vi.fn(), info: vi.fn() } }));
+
+import { McpSettingsSection } from "./McpSettingsSection";
+
+beforeEach(() => {
+  localStorage.clear();
+  Object.values(mcp).forEach((m) => m.mockReset());
+  mcp.mcpHttpStatus.mockResolvedValue(null);
+  mcp.srelensCliStatus.mockResolvedValue({ installed: false, path: "/usr/local/bin/srelens", links_to: null });
+});
+
+describe("McpSettingsSection", () => {
+  it("starts the MCP HTTP server when toggled on and shows the URL", async () => {
+    mcp.startMcpHttp.mockResolvedValue("http://127.0.0.1:8765/mcp");
+    render(<McpSettingsSection />);
+    fireEvent.click(screen.getByLabelText("Run MCP HTTP server"));
+    await waitFor(() => expect(mcp.startMcpHttp).toHaveBeenCalledWith(8765));
+    expect(await screen.findByText("http://127.0.0.1:8765/mcp")).toBeDefined();
+  });
+
+  it("surfaces a bind error and leaves the toggle off", async () => {
+    mcp.startMcpHttp.mockRejectedValue("Could not bind 127.0.0.1:8765: address in use");
+    render(<McpSettingsSection />);
+    fireEvent.click(screen.getByLabelText("Run MCP HTTP server"));
+    expect(await screen.findByText(/address in use/)).toBeDefined();
+    expect((screen.getByLabelText("Run MCP HTTP server") as HTMLInputElement).checked).toBe(false);
+  });
+
+  it("installs the srelens CLI", async () => {
+    mcp.installSrelensCli.mockResolvedValue("/usr/local/bin/srelens");
+    mcp.srelensCliStatus.mockResolvedValue({ installed: true, path: "/usr/local/bin/srelens", links_to: "/x" });
+    render(<McpSettingsSection />);
+    fireEvent.click(screen.getByRole("button", { name: /Install srelens CLI/ }));
+    await waitFor(() => expect(mcp.installSrelensCli).toHaveBeenCalled());
+    // After install the button relabels to Reinstall and the path is shown.
+    expect(await screen.findByRole("button", { name: /Reinstall srelens CLI/ })).toBeDefined();
+    expect(screen.getAllByText(/Installed at/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows the client config for the selected tool and transport", async () => {
+    render(<McpSettingsSection />);
+    // Default tool is Claude Code (stdio) → a `claude mcp add` command.
+    expect(screen.getByText("claude mcp add srelens -- srelens --mcp-stdio")).toBeDefined();
+    // Switch to Codex → TOML block.
+    fireEvent.click(screen.getByRole("button", { name: "Codex" }));
+    expect(screen.getByText(/\[mcp_servers\.srelens\]/)).toBeDefined();
+  });
+});

--- a/apps/desktop/src/components/McpSettingsSection.tsx
+++ b/apps/desktop/src/components/McpSettingsSection.tsx
@@ -1,0 +1,212 @@
+import React, { useEffect, useState } from "react";
+import { Copy, Download, Radio } from "lucide-react";
+import { Button, TextInput } from "../ui";
+import { notify } from "../lib/notify";
+import {
+  loadMcpSettings,
+  saveMcpSettings,
+  type McpSettings,
+} from "../lib/settings";
+import {
+  startMcpHttp,
+  stopMcpHttp,
+  mcpHttpStatus,
+  installSrelensCli,
+  srelensCliStatus,
+  type CliStatus,
+} from "../lib/mcp";
+import { mcpClientConfig, MCP_TOOLS, type McpTool, type McpTransport } from "../lib/mcpClients";
+
+async function copy(text: string) {
+  try {
+    await navigator.clipboard?.writeText(text);
+    notify.success("Copied to clipboard");
+  } catch {
+    notify.error("Could not copy");
+  }
+}
+
+/**
+ * Settings → MCP. Toggles the in-app loopback MCP HTTP server, installs the
+ * `srelens` CLI onto PATH (so clients can spawn `srelens --mcp-stdio`), and
+ * shows ready-to-paste config for each MCP client.
+ */
+export function McpSettingsSection() {
+  const [settings, setSettings] = useState<McpSettings>(loadMcpSettings);
+  const [runningUrl, setRunningUrl] = useState<string | null>(null);
+  const [serverError, setServerError] = useState("");
+  const [cli, setCli] = useState<CliStatus | null>(null);
+  const [cliMessage, setCliMessage] = useState("");
+  const [tool, setTool] = useState<McpTool>("claude-code");
+  const [transport, setTransport] = useState<McpTransport>("stdio");
+
+  useEffect(() => {
+    void mcpHttpStatus().then(setRunningUrl).catch(() => {});
+    void srelensCliStatus().then(setCli).catch(() => {});
+  }, []);
+
+  function persist(next: McpSettings) {
+    setSettings(next);
+    saveMcpSettings(next);
+  }
+
+  async function toggleServer(enabled: boolean) {
+    setServerError("");
+    persist({ ...settings, enabled });
+    try {
+      if (enabled) setRunningUrl(await startMcpHttp(settings.port));
+      else {
+        await stopMcpHttp();
+        setRunningUrl(null);
+      }
+    } catch (e) {
+      setServerError(String(e));
+      persist({ ...settings, enabled: false });
+      setRunningUrl(null);
+    }
+  }
+
+  async function changePort(value: string) {
+    const port = Number(value);
+    if (!Number.isInteger(port) || port <= 0 || port >= 65536) return;
+    persist({ ...settings, port });
+    if (settings.enabled) {
+      setServerError("");
+      try {
+        setRunningUrl(await startMcpHttp(port));
+      } catch (e) {
+        setServerError(String(e));
+      }
+    }
+  }
+
+  async function installCli() {
+    setCliMessage("");
+    try {
+      const path = await installSrelensCli();
+      setCliMessage(`Installed at ${path}`);
+      setCli(await srelensCliStatus());
+      notify.success("srelens CLI installed");
+    } catch (e) {
+      setCliMessage(String(e));
+    }
+  }
+
+  const url = runningUrl ?? `http://127.0.0.1:${settings.port}/mcp`;
+  const config = mcpClientConfig(tool, transport, { url });
+
+  return (
+    <div className="flex flex-col gap-6">
+      <p className="text-sm text-muted-foreground">
+        srelens is MCP-native: every action it can take is exposed as an MCP tool, so agents and other
+        MCP clients can drive your clusters. Connect over stdio (spawning the srelens CLI) or the
+        loopback HTTP server below.
+      </p>
+
+      {/* Server toggle */}
+      <section className="flex flex-col gap-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <label className="flex items-center gap-2 text-sm font-medium">
+            <input
+              type="checkbox"
+              checked={settings.enabled}
+              onChange={(e) => void toggleServer(e.target.checked)}
+              aria-label="Run MCP HTTP server"
+            />
+            Run MCP server (HTTP) while srelens is open
+          </label>
+          <label className="ml-auto flex items-center gap-2 text-sm text-muted-foreground">
+            Port
+            <TextInput
+              type="number"
+              value={String(settings.port)}
+              onValueChange={changePort}
+              aria-label="MCP server port"
+              className="w-24"
+            />
+          </label>
+        </div>
+        {settings.enabled && runningUrl && (
+          <div className="flex items-center gap-2 text-sm">
+            <Radio className="size-4 text-green-600 dark:text-green-500" aria-hidden />
+            <span>Listening at</span>
+            <code className="fl-mono">{runningUrl}</code>
+            <Button variant="ghost" size="sm" onClick={() => void copy(runningUrl)} aria-label="Copy MCP URL">
+              <Copy data-icon="inline-start" />
+              Copy
+            </Button>
+          </div>
+        )}
+        {serverError && <p className="text-sm text-destructive">Error: {serverError}</p>}
+      </section>
+
+      {/* CLI install */}
+      <section className="flex flex-col gap-2">
+        <h4 className="text-sm font-medium">srelens CLI</h4>
+        <p className="text-sm text-muted-foreground">
+          Installs a <code className="fl-mono">srelens</code> command on your PATH so MCP clients can
+          spawn <code className="fl-mono">srelens --mcp-stdio</code>.
+        </p>
+        <div className="flex flex-wrap items-center gap-3">
+          <Button onClick={() => void installCli()}>
+            <Download data-icon="inline-start" />
+            {cli?.installed ? "Reinstall srelens CLI" : "Install srelens CLI"}
+          </Button>
+          {cli?.installed && (
+            <span className="text-sm text-muted-foreground">
+              Installed at <code className="fl-mono">{cli.path}</code>
+            </span>
+          )}
+        </div>
+        {cliMessage && <p className="whitespace-pre-wrap text-sm text-muted-foreground">{cliMessage}</p>}
+      </section>
+
+      {/* Per-tool config */}
+      <section className="flex flex-col gap-3">
+        <h4 className="text-sm font-medium">Connect a client</h4>
+        <div className="flex flex-wrap gap-1" role="group" aria-label="MCP client">
+          {MCP_TOOLS.map((t) => (
+            <Button
+              key={t.id}
+              variant={tool === t.id ? "default" : "ghost"}
+              size="sm"
+              aria-pressed={tool === t.id}
+              onClick={() => setTool(t.id)}
+            >
+              {t.label}
+            </Button>
+          ))}
+        </div>
+        <div className="flex gap-1" role="group" aria-label="Transport">
+          {(["stdio", "http"] as McpTransport[]).map((tr) => (
+            <Button
+              key={tr}
+              variant={transport === tr ? "default" : "ghost"}
+              size="sm"
+              aria-pressed={transport === tr}
+              onClick={() => setTransport(tr)}
+            >
+              {tr}
+            </Button>
+          ))}
+        </div>
+        <p className="text-xs text-muted-foreground">{config.hint}</p>
+        <div className="relative">
+          <pre className="max-h-64 overflow-auto rounded-md border border-border bg-muted/40 p-3 text-xs">
+            <code>{config.snippet}</code>
+          </pre>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="absolute right-2 top-2"
+            onClick={() => void copy(config.snippet)}
+            aria-label="Copy config"
+          >
+            <Copy data-icon="inline-start" />
+            Copy
+          </Button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/SettingsView.tsx
+++ b/apps/desktop/src/components/SettingsView.tsx
@@ -20,6 +20,7 @@ import {
   ArrowUp,
   GripVertical,
   ClipboardPaste,
+  Plug,
 } from "lucide-react";
 import {
   PageHeader,
@@ -48,6 +49,7 @@ import {
 } from "../lib/settings";
 import { updateRequestTimeout } from "../lib/requestTimeout";
 import { ContextAvatar, CONTEXT_LOGO_OPTIONS } from "./ContextAvatar";
+import { McpSettingsSection } from "./McpSettingsSection";
 import { pickKubeconfigFiles, savePastedKubeconfig } from "../lib/files";
 import { checkForUpdate, installUpdate, type UpdateMeta } from "../lib/updater";
 import { appVersion, relaunchApp } from "../transport/transport";
@@ -58,7 +60,7 @@ const MODE_OPTIONS: Array<{ mode: ThemeMode; label: string; description: string;
   { mode: "system", label: "System", description: "Follow the OS appearance", icon: Monitor },
 ];
 
-export type SettingsSection = "appearance" | "layout" | "kubernetes" | "contexts" | "updates";
+export type SettingsSection = "appearance" | "layout" | "kubernetes" | "contexts" | "mcp" | "updates";
 
 type UpdatePhase =
   | { phase: "idle" }
@@ -84,6 +86,7 @@ const SETTINGS_SECTIONS: Array<{
   { id: "layout", label: "Layout", description: "Panel dimensions", icon: LayoutPanelLeft },
   { id: "kubernetes", label: "Kubernetes", description: "Workspace defaults", icon: Network },
   { id: "contexts", label: "Contexts", description: "Names, logos and colors", icon: Boxes },
+  { id: "mcp", label: "MCP", description: "Agent access and client config", icon: Plug },
   { id: "updates", label: "Updates", description: "App version and updates", icon: Download },
 ];
 
@@ -760,6 +763,15 @@ export function SettingsView({
                   )}
                 </div>
               )}
+            </SectionPanel>
+          )}
+
+          {section === "mcp" && (
+            <SectionPanel
+              title="MCP"
+              description="Expose srelens to agents and MCP clients, and get ready-to-paste client config."
+            >
+              <McpSettingsSection />
             </SectionPanel>
           )}
 

--- a/apps/desktop/src/lib/mcp.ts
+++ b/apps/desktop/src/lib/mcp.ts
@@ -1,0 +1,32 @@
+import { invokeCommand } from "../transport/transport";
+
+/** Start (or restart) the in-app MCP HTTP server on `port`; returns its URL. */
+export async function startMcpHttp(port: number): Promise<string> {
+  return invokeCommand<string>("mcp_http_start", { port });
+}
+
+/** Stop the in-app MCP HTTP server. */
+export async function stopMcpHttp(): Promise<void> {
+  await invokeCommand("mcp_http_stop");
+}
+
+/** The MCP HTTP server's URL if it's running, else null. */
+export async function mcpHttpStatus(): Promise<string | null> {
+  return invokeCommand<string | null>("mcp_http_status");
+}
+
+export interface CliStatus {
+  installed: boolean;
+  path: string;
+  links_to: string | null;
+}
+
+/** Symlink the srelens binary onto PATH; returns the install path. */
+export async function installSrelensCli(): Promise<string> {
+  return invokeCommand<string>("install_srelens_cli");
+}
+
+/** Whether the `srelens` CLI is installed on PATH and where it points. */
+export async function srelensCliStatus(): Promise<CliStatus> {
+  return invokeCommand<CliStatus>("srelens_cli_status");
+}

--- a/apps/desktop/src/lib/mcpClients.test.ts
+++ b/apps/desktop/src/lib/mcpClients.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { mcpClientConfig, MCP_TOOLS } from "./mcpClients";
+
+describe("mcpClientConfig", () => {
+  it("emits a `claude mcp add` command for Claude Code (stdio)", () => {
+    const c = mcpClientConfig("claude-code", "stdio", {});
+    expect(c.format).toBe("shell");
+    expect(c.snippet).toBe("claude mcp add srelens -- srelens --mcp-stdio");
+  });
+
+  it("emits an http `claude mcp add` command with the url", () => {
+    const c = mcpClientConfig("claude-code", "http", { url: "http://127.0.0.1:8765/mcp" });
+    expect(c.snippet).toContain("--transport http");
+    expect(c.snippet).toContain("http://127.0.0.1:8765/mcp");
+  });
+
+  it("emits an mcpServers JSON block for Claude Desktop / Cursor / Antigravity (stdio)", () => {
+    for (const tool of ["claude-desktop", "cursor", "antigravity", "generic"] as const) {
+      const c = mcpClientConfig(tool, "stdio", {});
+      expect(c.format).toBe("json");
+      const parsed = JSON.parse(c.snippet);
+      expect(parsed.mcpServers.srelens).toEqual({ command: "srelens", args: ["--mcp-stdio"] });
+    }
+  });
+
+  it("emits a url entry for JSON tools over http", () => {
+    const c = mcpClientConfig("cursor", "http", { url: "http://127.0.0.1:9000/mcp" });
+    expect(JSON.parse(c.snippet).mcpServers.srelens).toEqual({ url: "http://127.0.0.1:9000/mcp" });
+  });
+
+  it("emits TOML for Codex", () => {
+    const c = mcpClientConfig("codex", "stdio", {});
+    expect(c.format).toBe("toml");
+    expect(c.snippet).toContain("[mcp_servers.srelens]");
+    expect(c.snippet).toContain('command = "srelens"');
+    expect(c.snippet).toContain('args = ["--mcp-stdio"]');
+  });
+
+  it("carries a hint about where the config goes for each tool", () => {
+    for (const tool of MCP_TOOLS) {
+      expect(mcpClientConfig(tool.id, "stdio", {}).hint).toBeTruthy();
+    }
+  });
+});

--- a/apps/desktop/src/lib/mcpClients.ts
+++ b/apps/desktop/src/lib/mcpClients.ts
@@ -1,0 +1,72 @@
+/**
+ * Ready-to-paste MCP client configuration for the tools people connect to
+ * srelens. srelens runs as an MCP server via its own binary — `srelens
+ * --mcp-stdio` for clients that spawn a subprocess, or the loopback HTTP
+ * endpoint for clients that connect to a URL.
+ */
+
+export type McpTool = "claude-code" | "claude-desktop" | "cursor" | "codex" | "antigravity" | "generic";
+export type McpTransport = "stdio" | "http";
+
+export interface McpToolInfo {
+  id: McpTool;
+  label: string;
+  /** Where the config lives / how to apply it. */
+  hint: string;
+}
+
+export const MCP_TOOLS: McpToolInfo[] = [
+  { id: "claude-code", label: "Claude Code", hint: "Run the command in your terminal." },
+  {
+    id: "claude-desktop",
+    label: "Claude Desktop",
+    hint: "Add to claude_desktop_config.json (Settings → Developer → Edit Config).",
+  },
+  { id: "cursor", label: "Cursor", hint: "Add to ~/.cursor/mcp.json (or a project .cursor/mcp.json)." },
+  { id: "codex", label: "Codex", hint: "Add to ~/.codex/config.toml." },
+  { id: "antigravity", label: "Antigravity", hint: "Add to the IDE's MCP config (mcpServers)." },
+  { id: "generic", label: "Other (mcpServers JSON)", hint: "Most MCP clients accept this mcpServers block." },
+];
+
+export interface McpClientConfig {
+  format: "shell" | "json" | "toml";
+  snippet: string;
+  hint: string;
+}
+
+const DEFAULT_URL = "http://127.0.0.1:8765/mcp";
+
+/** Pretty mcpServers JSON block for a stdio or http entry. */
+function mcpServersJson(entry: Record<string, unknown>): string {
+  return JSON.stringify({ mcpServers: { srelens: entry } }, null, 2);
+}
+
+/** Config for connecting `tool` to srelens over `transport`. */
+export function mcpClientConfig(
+  tool: McpTool,
+  transport: McpTransport,
+  opts: { url?: string },
+): McpClientConfig {
+  const url = opts.url || DEFAULT_URL;
+  const hint = MCP_TOOLS.find((t) => t.id === tool)?.hint ?? "";
+
+  if (tool === "claude-code") {
+    const snippet =
+      transport === "stdio"
+        ? "claude mcp add srelens -- srelens --mcp-stdio"
+        : `claude mcp add --transport http srelens ${url}`;
+    return { format: "shell", snippet, hint };
+  }
+
+  if (tool === "codex") {
+    const snippet =
+      transport === "stdio"
+        ? `[mcp_servers.srelens]\ncommand = "srelens"\nargs = ["--mcp-stdio"]`
+        : `[mcp_servers.srelens]\nurl = "${url}"`;
+    return { format: "toml", snippet, hint };
+  }
+
+  // JSON mcpServers tools: Claude Desktop, Cursor, Antigravity, generic.
+  const entry = transport === "stdio" ? { command: "srelens", args: ["--mcp-stdio"] } : { url };
+  return { format: "json", snippet: mcpServersJson(entry), hint };
+}

--- a/apps/desktop/src/lib/settings.ts
+++ b/apps/desktop/src/lib/settings.ts
@@ -252,3 +252,38 @@ export function orderContexts<T extends { name: string }>(contexts: T[], order: 
     })
     .map(({ context }) => context);
 }
+
+const MCP_SETTINGS_KEY = "srelens.mcp";
+
+/** In-app MCP HTTP server preferences. */
+export interface McpSettings {
+  /** Run the loopback MCP HTTP server while the app is open. */
+  enabled: boolean;
+  /** Port for the loopback server. */
+  port: number;
+}
+
+export const DEFAULT_MCP_SETTINGS: McpSettings = { enabled: false, port: 8765 };
+
+export function loadMcpSettings(): McpSettings {
+  try {
+    const raw = stored(MCP_SETTINGS_KEY);
+    if (!raw) return { ...DEFAULT_MCP_SETTINGS };
+    const parsed = JSON.parse(raw) as Partial<McpSettings>;
+    const port = Number(parsed.port);
+    return {
+      enabled: parsed.enabled === true,
+      port: Number.isInteger(port) && port > 0 && port < 65536 ? port : DEFAULT_MCP_SETTINGS.port,
+    };
+  } catch {
+    return { ...DEFAULT_MCP_SETTINGS };
+  }
+}
+
+export function saveMcpSettings(settings: McpSettings): void {
+  try {
+    localStorage.setItem(MCP_SETTINGS_KEY, JSON.stringify(settings));
+  } catch {
+    // ignore unavailable/quota-exceeded storage
+  }
+}

--- a/crates/mcp/src/http.rs
+++ b/crates/mcp/src/http.rs
@@ -34,6 +34,23 @@ pub async fn serve_http(server: McpServer, addr: SocketAddr) -> std::io::Result<
     axum::serve(listener, router(server)).await
 }
 
+/// Serve on an already-bound `listener` until `shutdown` resolves. Lets a host
+/// (e.g. the desktop app) bind the port up front — surfacing bind errors
+/// synchronously — then run the server with graceful shutdown so it can be
+/// toggled off from Settings and the port released cleanly.
+pub async fn serve_http_with_shutdown<F>(
+    server: McpServer,
+    listener: tokio::net::TcpListener,
+    shutdown: F,
+) -> std::io::Result<()>
+where
+    F: std::future::Future<Output = ()> + Send + 'static,
+{
+    axum::serve(listener, router(server))
+        .with_graceful_shutdown(shutdown)
+        .await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Closes #84.

A new **Settings → MCP** section so agents/MCP clients can connect to srelens.

## In-app MCP HTTP server (toggle)
- Switch to run the loopback MCP HTTP server inside the app on a configurable port. It shares the app's authenticated `ClientCache`, so a client drives the **same clusters the GUI sees**.
- Auto-starts on launch when enabled; shows the listening URL (copyable); bind errors surface and leave the toggle off.
- Backend: `mcp_http_start` / `mcp_http_stop` / `mcp_http_status` + a new `serve_http_with_shutdown` in the mcp crate (bind up front → report conflicts synchronously → graceful shutdown so it toggles cleanly).

## Install srelens CLI
- `install_srelens_cli` symlinks the running binary to `/usr/local/bin/srelens` so clients can spawn `srelens --mcp-stdio`. On a permission failure it returns the exact manual `ln -sf` command. `srelens_cli_status` reports install state.

## Per-tool client config
- `lib/mcpClients.ts` generates ready-to-paste config for **Claude Code, Claude Desktop, Cursor, Codex, Antigravity, and generic** clients — `claude mcp add …` (shell), `mcpServers` (JSON), or `[mcp_servers.srelens]` (TOML) — over **stdio or http**, each with a where-to-put-it hint and a copy button.

## Tests
- `mcpClientConfig` per tool/transport (shell/json/toml + url entry).
- `McpSettingsSection`: toggle starts the server + shows URL; bind error keeps it off; CLI install; per-tool snippet switches (Claude Code → Codex).

Full suite **402 passing**, coverage 83.68% (gate 80); backend `cargo test --workspace` green; `vite build` + `tsc --noEmit` clean.