### PR TITLE
feat(metrics): CPU/memory timeline + time-range filter for nodes, pods & workloads (#86)

### DIFF
--- a/apps/desktop/src/components/MetricsPanel.test.tsx
+++ b/apps/desktop/src/components/MetricsPanel.test.tsx
@@ -56,4 +56,56 @@ describe("MetricsPanel", () => {
     );
     await waitFor(() => expect(screen.getByText(/No metrics available/)).toBeDefined());
   });
+
+  it("aggregates a workload's pods by summing their usage", async () => {
+    const podsForSelectorFn = vi.fn().mockResolvedValue({
+      pods: [{ name: "web-1" }, { name: "web-2" }],
+    });
+    const podMetricsFn = vi.fn().mockResolvedValue({
+      metrics: [
+        { name: "web-1", namespace: "default", cpuMillicores: 250, memoryMiB: 64 },
+        { name: "web-2", namespace: "default", cpuMillicores: 250, memoryMiB: 64 },
+        { name: "other-9", namespace: "default", cpuMillicores: 999, memoryMiB: 999 },
+      ],
+    });
+    render(
+      <MetricsPanel
+        kind="Deployment"
+        context="kind-dev"
+        namespace="default"
+        name="web"
+        selector={{ app: "web" }}
+        intervalMs={100000}
+        podMetricsFn={podMetricsFn}
+        podsForSelectorFn={podsForSelectorFn}
+      />,
+    );
+    // 250 + 250 millicores = 0.500 cores; 64 + 64 = 128 MiB. The unrelated pod is excluded.
+    await waitFor(() => expect(screen.getByText("0.500 cores")).toBeDefined());
+    expect(screen.getByText("128 MiB")).toBeDefined();
+    expect(podsForSelectorFn).toHaveBeenCalledWith("kind-dev", "default", { app: "web" });
+    expect(screen.getByText(/Aggregated across pods/)).toBeDefined();
+  });
+
+  it("offers a time-range filter", async () => {
+    const nodeMetricsFn = vi.fn().mockResolvedValue({
+      metrics: [{ name: "node-a", cpuMillicores: 1000, memoryMiB: 2048 }],
+    });
+    render(
+      <MetricsPanel
+        kind="Node"
+        context="kind-dev"
+        namespace={null}
+        name="node-a"
+        intervalMs={100000}
+        nodeMetricsFn={nodeMetricsFn}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText("1.000 cores")).toBeDefined());
+    // The four ranges are present; 5m is the default active one.
+    for (const label of ["5m", "10m", "30m", "1h"]) {
+      expect(screen.getByRole("button", { name: label })).toBeDefined();
+    }
+    expect(screen.getByRole("button", { name: "5m" }).getAttribute("aria-pressed")).toBe("true");
+  });
 });

--- a/apps/desktop/src/components/MetricsPanel.tsx
+++ b/apps/desktop/src/components/MetricsPanel.tsx
@@ -1,42 +1,78 @@
 import React, { useEffect, useRef, useState } from "react";
-import { podMetrics } from "../lib/workloads";
+import { podMetrics, podsForSelector } from "../lib/workloads";
 import { nodeMetrics } from "../lib/manifest";
 import { Sparkline } from "../ui";
 
 interface Sample {
+  t: number; // epoch ms
   cpu: number; // millicores
   mem: number; // MiB
 }
 
-const MAX_POINTS = 30;
+/** Kinds that can show a metrics timeline. Workload kinds are aggregated across their pods. */
+export type MetricsKind = "Pod" | "Node" | "Deployment" | "StatefulSet" | "DaemonSet" | "ReplicaSet" | "Job";
+
+const WORKLOAD_KINDS: MetricsKind[] = ["Deployment", "StatefulSet", "DaemonSet", "ReplicaSet", "Job"];
+const isWorkload = (kind: MetricsKind) => WORKLOAD_KINDS.includes(kind);
+
+export type MetricsRange = "5m" | "10m" | "30m" | "1h";
+
+// Each range picks a sampling cadence that keeps the series near ~30 points, so
+// longer windows don't accumulate unbounded samples. metrics-server only reports
+// the current value, so the window fills in over time rather than back-filling.
+const RANGES: { id: MetricsRange; label: string; windowMs: number; intervalMs: number }[] = [
+  { id: "5m", label: "5m", windowMs: 5 * 60_000, intervalMs: 10_000 },
+  { id: "10m", label: "10m", windowMs: 10 * 60_000, intervalMs: 20_000 },
+  { id: "30m", label: "30m", windowMs: 30 * 60_000, intervalMs: 60_000 },
+  { id: "1h", label: "1h", windowMs: 60 * 60_000, intervalMs: 120_000 },
+];
+
+function sumMetrics(rows: { cpuMillicores: number; memoryMiB: number }[]): { cpu: number; mem: number } {
+  return rows.reduce((acc, m) => ({ cpu: acc.cpu + m.cpuMillicores, mem: acc.mem + m.memoryMiB }), { cpu: 0, mem: 0 });
+}
 
 /**
- * A live metrics chart for a Pod or Node. The Metrics Server only reports the
- * current value, so — like Lens — we poll and build the series over time. CPU
- * and memory each get their own area chart; the latest value is labelled.
+ * A live CPU/memory timeline for a Pod, Node, or workload controller. The
+ * Metrics Server only reports the current value, so — like Lens — we poll and
+ * build the series over time. Workload kinds (Deployment/StatefulSet/…) sum the
+ * usage of their pods (matched by label selector). A time-range filter chooses
+ * the retention window and sampling cadence.
  *
- * `podMetricsFn`/`nodeMetricsFn` are injectable for testing.
+ * The *Fn props are injectable for testing.
  */
 export function MetricsPanel({
   kind,
   context,
   namespace,
   name,
-  intervalMs = 10000,
+  selector,
+  intervalMs,
+  range: initialRange = "5m",
   podMetricsFn = podMetrics,
   nodeMetricsFn = nodeMetrics,
+  podsForSelectorFn = podsForSelector,
 }: {
-  kind: "Pod" | "Node";
+  kind: MetricsKind;
   context: string;
   namespace: string | null;
   name: string;
+  /** Label selector for workload kinds — the pods whose usage is summed. */
+  selector?: Record<string, string>;
+  /** Override the range's sampling cadence (used by tests to pin ticks). */
   intervalMs?: number;
+  range?: MetricsRange;
   podMetricsFn?: typeof podMetrics;
   nodeMetricsFn?: typeof nodeMetrics;
+  podsForSelectorFn?: typeof podsForSelector;
 }) {
+  const [range, setRange] = useState<MetricsRange>(initialRange);
   const [series, setSeries] = useState<Sample[]>([]);
   const [status, setStatus] = useState<"loading" | "ok" | "unavailable">("loading");
   const gotData = useRef(false);
+
+  const cfg = RANGES.find((r) => r.id === range) ?? RANGES[0];
+  const effectiveInterval = intervalMs ?? cfg.intervalMs;
+  const selectorKey = JSON.stringify(selector ?? null);
 
   useEffect(() => {
     let active = true;
@@ -44,15 +80,28 @@ export function MetricsPanel({
     setSeries([]);
     setStatus("loading");
 
-    async function sample(): Promise<Sample | null> {
+    async function sample(): Promise<{ cpu: number; mem: number } | null> {
       if (kind === "Node") {
         const out = await nodeMetricsFn(context);
         const m = out.metrics?.find((x) => x.name === name);
         return m ? { cpu: m.cpuMillicores, mem: m.memoryMiB } : null;
       }
-      const out = await podMetricsFn(context, namespace ?? "");
-      const m = out.metrics?.find((x) => x.name === name);
-      return m ? { cpu: m.cpuMillicores, mem: m.memoryMiB } : null;
+      if (kind === "Pod") {
+        const out = await podMetricsFn(context, namespace ?? "");
+        const m = out.metrics?.find((x) => x.name === name);
+        return m ? { cpu: m.cpuMillicores, mem: m.memoryMiB } : null;
+      }
+      // Workload: sum the usage of the controller's pods (matched by selector).
+      if (!selector || Object.keys(selector).length === 0) return null;
+      const ns = namespace ?? "";
+      const [podsOut, metricsOut] = await Promise.all([
+        podsForSelectorFn(context, ns, selector),
+        podMetricsFn(context, ns),
+      ]);
+      const metrics = metricsOut.metrics ?? [];
+      if (metrics.length === 0) return null; // metrics-server unavailable / no data
+      const names = new Set((podsOut.pods ?? []).map((p) => p.name));
+      return sumMetrics(metrics.filter((m) => names.has(m.name)));
     }
 
     async function tick() {
@@ -66,21 +115,43 @@ export function MetricsPanel({
       }
       gotData.current = true;
       setStatus("ok");
-      setSeries((prev) => [...prev, s].slice(-MAX_POINTS));
+      const now = Date.now();
+      setSeries((prev) =>
+        [...prev, { t: now, cpu: s.cpu, mem: s.mem }].filter((x) => now - x.t <= cfg.windowMs),
+      );
     }
 
     void tick();
-    const timer = setInterval(() => void tick(), intervalMs);
+    const timer = setInterval(() => void tick(), effectiveInterval);
     return () => {
       active = false;
       clearInterval(timer);
     };
-  }, [kind, context, namespace, name, intervalMs, podMetricsFn, nodeMetricsFn]);
+  }, [kind, context, namespace, name, selectorKey, effectiveInterval, cfg.windowMs, podMetricsFn, nodeMetricsFn, podsForSelectorFn]);
+
+  const rangePicker = (
+    <div className="fl-metrics__range" role="group" aria-label="Metrics time range">
+      {RANGES.map((r) => (
+        <button
+          key={r.id}
+          type="button"
+          className={range === r.id ? "is-active" : undefined}
+          aria-pressed={range === r.id}
+          onClick={() => setRange(r.id)}
+        >
+          {r.label}
+        </button>
+      ))}
+    </div>
+  );
 
   if (status === "unavailable") {
     return (
       <section className="fl-metrics">
-        <h4 className="fl-detail-section__title">Metrics</h4>
+        <div className="fl-metrics__header">
+          <h4 className="fl-detail-section__title">Metrics</h4>
+          {rangePicker}
+        </div>
         <p className="fl-detail-empty" style={{ margin: 0 }}>
           No metrics available — the cluster needs the Kubernetes Metrics Server.
         </p>
@@ -93,8 +164,13 @@ export function MetricsPanel({
 
   return (
     <section className="fl-metrics">
-      <h4 className="fl-detail-section__title">Metrics</h4>
-      <p className="fl-metrics__source">Live from the Kubernetes Metrics Server</p>
+      <div className="fl-metrics__header">
+        <h4 className="fl-detail-section__title">Metrics</h4>
+        {rangePicker}
+      </div>
+      <p className="fl-metrics__source">
+        {isWorkload(kind) ? "Aggregated across pods · " : ""}Live from the Kubernetes Metrics Server
+      </p>
 
       <div className="fl-metric">
         <div className="fl-metric__head">

--- a/apps/desktop/src/components/ResourceOverview.tsx
+++ b/apps/desktop/src/components/ResourceOverview.tsx
@@ -2918,8 +2918,14 @@ export function ObjectDetail({
   onOpenExec?: (container: string) => void;
 }) {
   const meta = asRecord(obj.metadata);
-  // Metrics chart (Pod/Node) sits above the rest, matching Lens. Needs a
-  // context to poll; in tests without one it's simply omitted.
+  // Metrics chart sits above the rest, matching Lens. Pods and Nodes read their
+  // own usage; workload controllers aggregate the usage of their pods (matched
+  // by the controller's label selector). Needs a context to poll; in tests
+  // without one it's simply omitted.
+  const WORKLOAD_METRIC_KINDS = ["Deployment", "StatefulSet", "DaemonSet", "ReplicaSet", "Job"];
+  const workloadSelector = asRecord(asRecord(obj.spec).selector).matchLabels as
+    | Record<string, string>
+    | undefined;
   const metrics =
     context && (kind === "Pod" || kind === "Node") ? (
       <MetricsPanel
@@ -2927,6 +2933,14 @@ export function ObjectDetail({
         context={context}
         namespace={str(meta.namespace) || null}
         name={str(meta.name)}
+      />
+    ) : context && WORKLOAD_METRIC_KINDS.includes(kind) && workloadSelector ? (
+      <MetricsPanel
+        kind={kind as "Deployment" | "StatefulSet" | "DaemonSet" | "ReplicaSet" | "Job"}
+        context={context}
+        namespace={str(meta.namespace) || null}
+        name={str(meta.name)}
+        selector={workloadSelector}
       />
     ) : null;
 
@@ -2946,13 +2960,16 @@ export function ObjectDetail({
     );
   if (kind === "Deployment" || kind === "StatefulSet" || kind === "ReplicaSet")
     return (
-      <WorkloadDetailView
-        kind={kind}
-        obj={obj}
-        now={now}
-        context={context}
-        onOpenResource={onOpenResource}
-      />
+      <>
+        {metrics}
+        <WorkloadDetailView
+          kind={kind}
+          obj={obj}
+          now={now}
+          context={context}
+          onOpenResource={onOpenResource}
+        />
+      </>
     );
   return (
     <>

--- a/apps/desktop/src/ui/styles.css
+++ b/apps/desktop/src/ui/styles.css
@@ -1898,6 +1898,33 @@ body {
 
 /* Metrics panel (live CPU/memory charts). */
 .fl-metrics { margin-bottom: var(--fl-space-xl); }
+.fl-metrics__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--fl-space-md);
+}
+.fl-metrics__range {
+  display: inline-flex;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--fl-color-border);
+  border-radius: var(--fl-radius-md);
+}
+.fl-metrics__range button {
+  padding: 2px 8px;
+  border: 0;
+  border-radius: calc(var(--fl-radius-md) - 2px);
+  background: transparent;
+  color: var(--fl-color-text-muted);
+  font-size: 11px;
+  cursor: pointer;
+}
+.fl-metrics__range button:hover { color: var(--fl-color-text); }
+.fl-metrics__range button.is-active {
+  background: var(--fl-color-surface-alt);
+  color: var(--fl-color-text);
+}
 .fl-metrics__source {
   margin: -6px 0 var(--fl-space-md);
   font-size: 11px;


### PR DESCRIPTION
Closes #86

## Problem

The metrics chart (`MetricsPanel`) only covered **Pod** and **Node** detail views, with a fixed 30-point/10s window and **no time-range control**. Workload controllers had no metrics view at all.

## Change

- **Time-range filter** — a **5m / 10m / 30m / 1h** picker in the Metrics header. Each range sets its own retention window and sampling cadence (coarser for longer ranges) so the point count stays bounded. Switching range starts a clean series for the new window.
- **Workload aggregation** — **Deployment, StatefulSet, DaemonSet, ReplicaSet, Job** now show a CPU/Memory timeline that **sums the usage of their pods** (matched by the controller's `spec.selector.matchLabels`), labelled "Aggregated across pods".
- **`ResourceOverview`** surfaces the panel for those workload kinds in addition to Pod and Node.
- CPU and Memory only, as scoped.

## Constraint (by design)

metrics-server exposes only **instantaneous** usage — there's no historical store. So the timeline is a **rolling buffer built while the view is open**; selecting "1h" sets the window/cadence and the chart fills in over time rather than back-filling. This matches the panel's existing behaviour.

## Testing

- `MetricsPanel` tests: pod & node sampling, **workload aggregation** (unrelated pods excluded → 0.500 cores / 128 MiB from two 250m/64Mi pods), the 5m/10m/30m/1h filter (default 5m active), and the metrics-unavailable state.
- Full suite green (**394 tests**); `vite build` succeeds.
- Verified locally in the running app across Node/Pod/workload detail views.

## Notes

- Longer ranges only fill once the app has sampled that long (metrics-server limitation).
- The selected range is per-mount (not persisted). If you'd like it remembered like the Nodes column choices, easy follow-up.