### PR TITLE
feat(columns): show/hide columns on every resource table (#89)

### DIFF
--- a/apps/desktop/src/components/CustomResourceBrowser.tsx
+++ b/apps/desktop/src/components/CustomResourceBrowser.tsx
@@ -3,7 +3,7 @@ import { RefreshCw } from "lucide-react";
 import { listCustomResource, type CrdRef, type CustomRow } from "../lib/crds";
 import { listNamespaces } from "../lib/workloads";
 import { YamlView } from "./YamlView";
-import { Table, filterTableData, Select, Button, Spinner, Drawer, TextInput, type Column } from "../ui";
+import { Table, filterTableData, Select, Button, ColumnPicker, useColumnVisibility, Spinner, Drawer, TextInput, type Column } from "../ui";
 
 interface Selected {
   name: string;
@@ -70,12 +70,23 @@ export function CustomResourceBrowser({
     { key: "age", header: "Age", render: (r) => <span className="text-muted-foreground">{r.age}</span> },
   ];
 
+  // Show/hide columns, persisted per CRD.
+  const { visibleColumns, columnOptions, hidden, toggle, pinnedKey } = useColumnVisibility(
+    `crd:${crd.group}/${crd.kind}`,
+    columns,
+  );
+  useEffect(() => {
+    if (filterColumn && !visibleColumns.some((column) => column.key === filterColumn)) {
+      setFilterColumn(null);
+    }
+  }, [visibleColumns, filterColumn]);
+
   const filtered = useMemo(
-    () => filterTableData(rows ?? [], columns, query, filterColumn),
-    [columns, filterColumn, query, rows],
+    () => filterTableData(rows ?? [], visibleColumns, query, filterColumn),
+    [visibleColumns, filterColumn, query, rows],
   );
   const filterLabel = filterColumn
-    ? columns.find((column) => column.key === filterColumn)?.header
+    ? visibleColumns.find((column) => column.key === filterColumn)?.header
     : null;
 
   return (
@@ -99,7 +110,10 @@ export function CustomResourceBrowser({
             Refresh
           </Button>
           {rows === null && <Spinner label="Loading resources" />}
-          <div className="ml-auto w-56">
+          <div className="ml-auto">
+            <ColumnPicker columns={columnOptions} hidden={hidden} onToggle={toggle} pinnedKey={pinnedKey} />
+          </div>
+          <div className="w-56">
             <TextInput
               value={query}
               onValueChange={(q) => onQueryChange?.(q)}
@@ -119,7 +133,7 @@ export function CustomResourceBrowser({
           {error && <p className="px-3 py-2 text-sm text-destructive">Error: {error}</p>}
           {!error && (
             <Table
-              columns={columns}
+              columns={visibleColumns}
               data={filtered}
               getRowKey={(r) => r.name}
               selectedKey={selected?.name}

--- a/apps/desktop/src/components/HelmReleasesView.tsx
+++ b/apps/desktop/src/components/HelmReleasesView.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense, lazy, useEffect, useState } from "react";
 import { listHelmReleases, getHelmRelease, type HelmReleaseSummary, type HelmReleaseDetail } from "../lib/helm";
 import { ageFromTimestamp } from "./ResourceOverview";
-import { Table, Spinner, Badge, StatusPill, Drawer, Tabs, type Column, type StatusKind } from "../ui";
+import { Table, Spinner, Badge, ColumnPicker, useColumnVisibility, StatusPill, Drawer, Tabs, type Column, type StatusKind } from "../ui";
 
 const CodeEditor = lazy(() => import("../ui/CodeEditor").then((m) => ({ default: m.CodeEditor })));
 
@@ -51,6 +51,8 @@ export function HelmReleasesView({
     { key: "updated", header: "Updated", render: (r) => ageFromTimestamp(r.updated, now) },
   ];
 
+  const { visibleColumns, columnOptions, hidden, toggle, pinnedKey } = useColumnVisibility("helmreleases", columns);
+
   return (
     <div className="flex min-h-0 flex-1">
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
@@ -58,6 +60,9 @@ export function HelmReleasesView({
           <span className="font-medium">Helm Releases</span>
           <Badge variant="info">{releases.length}</Badge>
           {loading && <Spinner label="Loading releases" />}
+          <div className="ml-auto">
+            <ColumnPicker columns={columnOptions} hidden={hidden} onToggle={toggle} pinnedKey={pinnedKey} />
+          </div>
         </div>
         <div className="min-h-0 flex-1 overflow-auto">
           {error ? (
@@ -68,7 +73,7 @@ export function HelmReleasesView({
             </div>
           ) : (
             <Table
-              columns={columns}
+              columns={visibleColumns}
               data={releases}
               getRowKey={(r) => `${r.namespace}/${r.name}`}
               onRowClick={setSelected}

--- a/apps/desktop/src/components/PortForwardsView.tsx
+++ b/apps/desktop/src/components/PortForwardsView.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { CircleStop, Copy } from "lucide-react";
-import { Table, Badge, Button, type Column } from "../ui";
+import { Table, Badge, Button, ColumnPicker, useColumnVisibility, type Column } from "../ui";
 import { useForwards } from "./ForwardsIndicator";
 import { stopPortForward, type ActiveForward } from "../lib/forward";
 
@@ -66,11 +66,19 @@ export function PortForwardsView({ context }: { context?: string }) {
     },
   ];
 
+  const { visibleColumns, columnOptions, hidden, toggle, pinnedKey } = useColumnVisibility(
+    "portforwards",
+    columns,
+  );
+
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="flex shrink-0 items-center gap-2 border-b border-border px-3 py-2 text-sm">
         <span className="font-medium">Port Forwards</span>
         <Badge variant="info">{forwards.length}</Badge>
+        <div className="ml-auto">
+          <ColumnPicker columns={columnOptions} hidden={hidden} onToggle={toggle} pinnedKey={pinnedKey} />
+        </div>
       </div>
       <div className="min-h-0 flex-1 overflow-auto">
         {forwards.length === 0 ? (
@@ -79,7 +87,7 @@ export function PortForwardsView({ context }: { context?: string }) {
             to start one.
           </div>
         ) : (
-          <Table columns={columns} data={forwards} getRowKey={(f) => String(f.id)} />
+          <Table columns={visibleColumns} data={forwards} getRowKey={(f) => String(f.id)} />
         )}
       </div>
     </div>

--- a/apps/desktop/src/components/ResourceBrowser.test.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.test.tsx
@@ -122,6 +122,25 @@ describe("ResourceBrowser", () => {
     await waitFor(() => expect(screen.getByText("web-1")).toBeDefined());
     expect(watchResourceMock).toHaveBeenCalledWith("kind-dev", "", "pods", expect.any(Function), expect.any(Function));
     expect(screen.getByText("live")).toBeDefined();
+    // The column picker is now available on every resource table, not just Nodes.
+    expect(screen.getByRole("button", { name: "Choose columns" })).toBeDefined();
+  });
+
+  it("hides a column via the picker on a non-node view and remembers it", async () => {
+    localStorage.clear();
+    listNamespacesMock.mockResolvedValue({ namespaces: ["default"] });
+    watchResourceMock.mockImplementation(watchWith([pod]));
+    const user = userEvent.setup();
+
+    render(<ResourceBrowser context="kind-dev" kind="pods" />);
+    await waitFor(() => expect(screen.getByText("web-1")).toBeDefined());
+    expect(screen.getByRole("columnheader", { name: /Restarts/ })).toBeDefined();
+
+    await user.click(screen.getByRole("button", { name: "Choose columns" }));
+    await user.click(await screen.findByLabelText("Restarts"));
+
+    await waitFor(() => expect(screen.queryByRole("columnheader", { name: /Restarts/ })).toBeNull());
+    expect(JSON.parse(localStorage.getItem("srelens.hiddenColumns")!)).toEqual({ pods: ["restarts"] });
   });
 
   it("streams deployments live", async () => {

--- a/apps/desktop/src/components/ResourceBrowser.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.tsx
@@ -66,15 +66,14 @@ import {
   Badge,
   Button,
   ColumnPicker,
+  useColumnVisibility,
   Drawer,
   StatusPill,
   TextInput,
   Toolbar,
   type Column,
-  type ColumnOption,
   type StatusKind,
 } from "../ui";
-import { loadHiddenColumns, saveHiddenColumns } from "../lib/settings";
 
 export type ResourceKind =
   | "overview"
@@ -250,9 +249,6 @@ const TYPED_KINDS: ResourceKind[] = [
 const isGeneric = (kind: ResourceKind) => !TYPED_KINDS.includes(kind);
 const isNamespaced = (kind: ResourceKind) => !CLUSTER_SCOPED.includes(kind);
 const isWatchable = (kind: ResourceKind) => (WATCHABLE_KINDS as readonly string[]).includes(kind);
-// Views that let users show/hide columns (persisted per kind). Nodes to start.
-const COLUMN_PICKER_KINDS: ResourceKind[] = ["nodes"];
-const supportsColumnPicker = (kind: ResourceKind) => COLUMN_PICKER_KINDS.includes(kind);
 const POLL_MS = 5000;
 
 function phaseKind(phase: string): StatusKind {
@@ -592,10 +588,6 @@ export function ResourceBrowser({
   // Bumped after a write action so the open detail overview re-fetches.
   const [detailReload, setDetailReload] = useState(0);
   const [filterColumn, setFilterColumn] = useState<string | null>(null);
-  // Hidden table columns for views that support customization, loaded per kind.
-  const [hiddenColumns, setHiddenColumns] = useState<Set<string>>(() =>
-    supportsColumnPicker(kind) ? new Set(loadHiddenColumns(kind)) : new Set(),
-  );
   // Per-pod CPU/memory (millicores / MiB), merged into the pods table.
   const [podCpuMem, setPodCpuMem] = useState<Map<string, { cpu: number; mem: number }>>(new Map());
   const viewKeyRef = useRef("");
@@ -603,9 +595,6 @@ export function ResourceBrowser({
   const namespaced = isNamespaced(kind);
 
   useEffect(() => setFilterColumn(null), [kind]);
-  useEffect(() => {
-    setHiddenColumns(supportsColumnPicker(kind) ? new Set(loadHiddenColumns(kind)) : new Set());
-  }, [kind]);
 
   useEffect(() => {
     let active = true;
@@ -771,37 +760,16 @@ export function ResourceBrowser({
     }
   }, [kind]);
 
-  // Column visibility (supported views only). The first column is the row
-  // identifier and is always kept; everything else can be toggled off.
-  const pickerEnabled = supportsColumnPicker(kind);
-  const pinnedColumnKey = columns[0]?.key;
-  const visibleColumns = useMemo(
-    () =>
-      pickerEnabled
-        ? columns.filter((column) => column.key === pinnedColumnKey || !hiddenColumns.has(column.key))
-        : columns,
-    [columns, pickerEnabled, pinnedColumnKey, hiddenColumns],
-  );
-  const columnOptions: ColumnOption[] = useMemo(
-    () =>
-      columns.map((column) => ({
-        key: column.key,
-        label: typeof column.header === "string" ? column.header : column.key,
-      })),
-    [columns],
-  );
-  function toggleColumn(key: string) {
-    if (key === pinnedColumnKey) return;
-    setHiddenColumns((prev) => {
-      const next = new Set(prev);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
-      saveHiddenColumns(kind, [...next]);
-      return next;
-    });
-    // A hidden column can't stay the active search filter.
-    setFilterColumn((current) => (current === key ? null : current));
-  }
+  // Show/hide columns, persisted per resource kind. The first (identifier)
+  // column is always kept.
+  const { visibleColumns, columnOptions, hidden, toggle: toggleColumn, pinnedKey: pinnedColumnKey } =
+    useColumnVisibility(kind, columns);
+  // A hidden column can't remain the active search filter.
+  useEffect(() => {
+    if (filterColumn && !visibleColumns.some((column) => column.key === filterColumn)) {
+      setFilterColumn(null);
+    }
+  }, [visibleColumns, filterColumn]);
 
   function onRowClick(row: { name: string }) {
     if (kind === "events") return; // events have no manifest detail
@@ -959,17 +927,15 @@ export function ResourceBrowser({
                   <Badge variant="success">live</Badge>
                 ))}
               {res.loading && filtered.length > 0 && <Spinner label="Loading resources" />}
-              {pickerEnabled && (
-                <div className="ml-auto">
-                  <ColumnPicker
-                    columns={columnOptions}
-                    hidden={hiddenColumns}
-                    onToggle={toggleColumn}
-                    pinnedKey={pinnedColumnKey}
-                  />
-                </div>
-              )}
-              <div className={`fl-resource-toolbar__search w-56${pickerEnabled ? "" : " ml-auto"}`}>
+              <div className="ml-auto">
+                <ColumnPicker
+                  columns={columnOptions}
+                  hidden={hidden}
+                  onToggle={toggleColumn}
+                  pinnedKey={pinnedColumnKey}
+                />
+              </div>
+              <div className="fl-resource-toolbar__search w-56">
                 <TextInput
                   value={query}
                   onValueChange={(q) => onQueryChange?.(q)}

--- a/apps/desktop/src/ui/index.ts
+++ b/apps/desktop/src/ui/index.ts
@@ -16,6 +16,8 @@ export { Button } from "./Button";
 export type { ButtonProps, ButtonVariant } from "./Button";
 export { ColumnPicker } from "./ColumnPicker";
 export type { ColumnOption } from "./ColumnPicker";
+export { useColumnVisibility } from "./useColumnVisibility";
+export type { ColumnVisibility } from "./useColumnVisibility";
 export { TextInput } from "./TextInput";
 export type { TextInputProps } from "./TextInput";
 export { Panel } from "./Panel";

--- a/apps/desktop/src/ui/useColumnVisibility.test.ts
+++ b/apps/desktop/src/ui/useColumnVisibility.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useColumnVisibility } from "./useColumnVisibility";
+import type { Column } from "./Table";
+
+interface Row {
+  name: string;
+}
+
+const columns: Column<Row>[] = [
+  { key: "name", header: "Name" },
+  { key: "status", header: "Status" },
+  { key: "age", header: "Age" },
+  { key: "actions", header: "" }, // headerless — a row-actions cell
+];
+
+beforeEach(() => localStorage.clear());
+
+describe("useColumnVisibility", () => {
+  it("lists only labelled columns and pins the first", () => {
+    const { result } = renderHook(() => useColumnVisibility("nodes", columns));
+    expect(result.current.pinnedKey).toBe("name");
+    // The headerless "actions" column is not offered.
+    expect(result.current.columnOptions.map((c) => c.key)).toEqual(["name", "status", "age"]);
+    // All columns visible by default.
+    expect(result.current.visibleColumns.map((c) => c.key)).toEqual(["name", "status", "age", "actions"]);
+  });
+
+  it("hides a column, keeps identifier and headerless columns, and persists", () => {
+    const { result } = renderHook(() => useColumnVisibility("nodes", columns));
+    act(() => result.current.toggle("status"));
+    expect(result.current.visibleColumns.map((c) => c.key)).toEqual(["name", "age", "actions"]);
+    expect(JSON.parse(localStorage.getItem("srelens.hiddenColumns")!)).toEqual({ nodes: ["status"] });
+
+    // The pinned identifier and headerless columns can't be hidden.
+    act(() => result.current.toggle("name"));
+    act(() => result.current.toggle("actions"));
+    expect(result.current.visibleColumns.map((c) => c.key)).toEqual(["name", "age", "actions"]);
+  });
+
+  it("loads persisted hidden columns and isolates views by key", () => {
+    localStorage.setItem("srelens.hiddenColumns", JSON.stringify({ nodes: ["age"], pods: ["status"] }));
+    const nodes = renderHook(() => useColumnVisibility("nodes", columns));
+    expect(nodes.result.current.visibleColumns.map((c) => c.key)).toEqual(["name", "status", "actions"]);
+    const pods = renderHook(() => useColumnVisibility("pods", columns));
+    expect(pods.result.current.visibleColumns.map((c) => c.key)).toEqual(["name", "age", "actions"]);
+  });
+});

--- a/apps/desktop/src/ui/useColumnVisibility.ts
+++ b/apps/desktop/src/ui/useColumnVisibility.ts
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { loadHiddenColumns, saveHiddenColumns } from "@/lib/settings";
+import type { Column } from "./Table";
+import type { ColumnOption } from "./ColumnPicker";
+
+export interface ColumnVisibility<T> {
+  /** Columns to actually render (identifier column + non-hidden). */
+  visibleColumns: Column<T>[];
+  /** Options for the ColumnPicker (label falls back to key for non-string headers). */
+  columnOptions: ColumnOption[];
+  /** Currently hidden column keys. */
+  hidden: ReadonlySet<string>;
+  /** Toggle a column's visibility (no-op for the pinned identifier column). */
+  toggle: (key: string) => void;
+  /** The always-visible identifier column key (the first column). */
+  pinnedKey?: string;
+}
+
+/**
+ * Per-view show/hide column state, persisted in localStorage under `viewKey`.
+ * The first column is the row identifier and is always kept. Persistence is
+ * keyed only by the view, so a table's layout is shared across clusters.
+ */
+/** A column's label if it has a usable (non-empty string) header, else "". */
+function columnLabel<T>(column: Column<T>): string {
+  return typeof column.header === "string" ? column.header.trim() : "";
+}
+
+export function useColumnVisibility<T>(viewKey: string, columns: Column<T>[]): ColumnVisibility<T> {
+  const pinnedKey = columns[0]?.key;
+  const [hidden, setHidden] = useState<Set<string>>(() => new Set(loadHiddenColumns(viewKey)));
+
+  // Reload when the view changes (e.g. switching resource kind in one browser).
+  useEffect(() => {
+    setHidden(new Set(loadHiddenColumns(viewKey)));
+  }, [viewKey]);
+
+  // Only labelled, non-identifier columns can be hidden. The pinned first column
+  // and headerless columns (e.g. a row-actions cell) are always shown.
+  const isHideable = useCallback(
+    (column: Column<T>) => column.key !== pinnedKey && columnLabel(column) !== "",
+    [pinnedKey],
+  );
+
+  const visibleColumns = useMemo(
+    () => columns.filter((column) => !isHideable(column) || !hidden.has(column.key)),
+    [columns, hidden, isHideable],
+  );
+
+  const columnOptions: ColumnOption[] = useMemo(
+    () =>
+      columns
+        .filter((column) => column.key === pinnedKey || columnLabel(column) !== "")
+        .map((column) => ({ key: column.key, label: columnLabel(column) || column.key })),
+    [columns, pinnedKey],
+  );
+
+  const toggle = useCallback(
+    (key: string) => {
+      if (key === pinnedKey) return;
+      setHidden((prev) => {
+        const next = new Set(prev);
+        if (next.has(key)) next.delete(key);
+        else next.add(key);
+        saveHiddenColumns(viewKey, [...next]);
+        return next;
+      });
+    },
+    [viewKey, pinnedKey],
+  );
+
+  return { visibleColumns, columnOptions, hidden, toggle, pinnedKey };
+}


### PR DESCRIPTION
Closes #89 · follow-up to #80 / #82

## What

Rolls out the Nodes column show/hide picker to **every filterable resource table**.

- Extracts the visibility logic into a reusable **`useColumnVisibility(viewKey, columns)`** hook (`apps/desktop/src/ui/`), backed by the existing per-view `localStorage` persistence.
- Wires the hook + `<ColumnPicker>` into:
  - **ResourceBrowser** — all resource kinds (was Nodes-only)
  - **CustomResourceBrowser** — CRD instances (persisted per CRD)
  - **HelmReleasesView**
  - **PortForwardsView**

## Behaviour

- The first (identifier) column is **pinned** — always shown.
- Only columns with a real string header are offered; **headerless cells** (e.g. the Port-forwards row-actions with Copy/Stop) stay always-visible and aren't listed.
- Hidden columns are excluded from **render, sort, and search** (the active search filter resets if its column is hidden).
- Persistence is **per view** (resource kind / CRD identity / `helmreleases` / `portforwards`) and **shared across clusters**, consistent with #82.

Out of scope (noted in #89): detail-embedded sub-tables (ResourceEvents, WorkloadRelations, relation tables) — a picker there would be clutter.

## Testing

- New `useColumnVisibility` unit test: headerless-column rule, toggle + persistence, per-view isolation, pinned identifier.
- ResourceBrowser test: the picker is present on a non-Nodes view (pods) and hiding a column persists under the `pods` key.
- Existing Nodes/CRD/Helm/PortForwards tests still pass.
- Full suite green (**406 tests**); `vite build` succeeds.
- Verified locally across resource lists, CRDs, Helm, and Port-forwards.