### PR TITLE
fix(mcp): install srelens CLI to ~/.local/bin (no sudo)

### DIFF
--- a/apps/desktop/src-tauri/src/mcp.rs
+++ b/apps/desktop/src-tauri/src/mcp.rs
@@ -98,46 +98,73 @@ pub fn mcp_http_status(manager: State<'_, McpHttpManager>) -> Option<String> {
 #[derive(Debug, Serialize)]
 pub struct CliStatus {
     installed: bool,
-    /// The install path (`/usr/local/bin/srelens`).
+    /// The install path (`~/.local/bin/srelens`).
     path: String,
     /// What the symlink resolves to, if present.
     links_to: Option<String>,
+    /// Whether the install directory is on the current `$PATH`.
+    on_path: bool,
 }
 
-const CLI_PATH: &str = "/usr/local/bin/srelens";
+/// User-writable install dir — no elevation needed, unlike `/usr/local/bin`.
+fn cli_dir() -> Option<std::path::PathBuf> {
+    std::env::var_os("HOME").map(|home| std::path::PathBuf::from(home).join(".local").join("bin"))
+}
 
-/// Report whether the `srelens` CLI is installed on PATH and where it points.
+fn cli_path() -> Option<std::path::PathBuf> {
+    cli_dir().map(|dir| dir.join("srelens"))
+}
+
+/// Whether `dir` is one of the entries in `$PATH`.
+fn dir_on_path(dir: &std::path::Path) -> bool {
+    std::env::var_os("PATH")
+        .map(|path| std::env::split_paths(&path).any(|entry| entry == dir))
+        .unwrap_or(false)
+}
+
+/// Report whether the `srelens` CLI is installed and where it points.
 #[tauri::command]
 pub fn srelens_cli_status() -> CliStatus {
-    let path = std::path::Path::new(CLI_PATH);
+    let dir = cli_dir();
+    let path = cli_path();
     CliStatus {
-        installed: path.exists(),
-        path: CLI_PATH.to_string(),
-        links_to: std::fs::read_link(path)
-            .ok()
+        installed: path.as_ref().is_some_and(|p| p.exists()),
+        path: path
+            .as_ref()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_default(),
+        links_to: path
+            .as_ref()
+            .and_then(|p| std::fs::read_link(p).ok())
             .map(|p| p.to_string_lossy().to_string()),
+        on_path: dir.as_deref().is_some_and(dir_on_path),
     }
 }
 
-/// Symlink the running executable to `/usr/local/bin/srelens` so MCP clients can
-/// spawn `srelens --mcp-stdio`. Returns the install path on success; on a write
-/// failure returns a message with the manual command to run.
+/// Symlink the running executable to `~/.local/bin/srelens` so MCP clients can
+/// spawn `srelens --mcp-stdio`. Creates the directory if needed (no elevation);
+/// returns the install path on success, or the manual command on failure.
 #[tauri::command]
 pub fn install_srelens_cli() -> Result<String, String> {
     let exe = std::env::current_exe().map_err(|e| e.to_string())?;
 
     #[cfg(unix)]
     {
-        let target = std::path::Path::new(CLI_PATH);
+        let dir = cli_dir().ok_or("Could not resolve $HOME")?;
+        std::fs::create_dir_all(&dir)
+            .map_err(|e| format!("Could not create {} ({e})", dir.display()))?;
+        let target = dir.join("srelens");
         // Replace any existing symlink/file at the target.
-        if target.exists() || std::fs::symlink_metadata(target).is_ok() {
-            let _ = std::fs::remove_file(target);
+        if target.symlink_metadata().is_ok() {
+            let _ = std::fs::remove_file(&target);
         }
-        match std::os::unix::fs::symlink(&exe, target) {
-            Ok(()) => Ok(CLI_PATH.to_string()),
+        match std::os::unix::fs::symlink(&exe, &target) {
+            Ok(()) => Ok(target.to_string_lossy().to_string()),
             Err(e) => Err(format!(
-                "Could not write {CLI_PATH} ({e}). Run this in a terminal:\n  sudo ln -sf \"{}\" {CLI_PATH}",
-                exe.display()
+                "Could not write {} ({e}). Run this in a terminal:\n  ln -sf \"{}\" \"{}\"",
+                target.display(),
+                exe.display(),
+                target.display()
             )),
         }
     }

--- a/apps/desktop/src/components/McpSettingsSection.test.tsx
+++ b/apps/desktop/src/components/McpSettingsSection.test.tsx
@@ -20,7 +20,12 @@ beforeEach(() => {
   localStorage.clear();
   Object.values(mcp).forEach((m) => m.mockReset());
   mcp.mcpHttpStatus.mockResolvedValue(null);
-  mcp.srelensCliStatus.mockResolvedValue({ installed: false, path: "/usr/local/bin/srelens", links_to: null });
+  mcp.srelensCliStatus.mockResolvedValue({
+    installed: false,
+    path: "/home/u/.local/bin/srelens",
+    links_to: null,
+    on_path: true,
+  });
 });
 
 describe("McpSettingsSection", () => {
@@ -41,14 +46,30 @@ describe("McpSettingsSection", () => {
   });
 
   it("installs the srelens CLI", async () => {
-    mcp.installSrelensCli.mockResolvedValue("/usr/local/bin/srelens");
-    mcp.srelensCliStatus.mockResolvedValue({ installed: true, path: "/usr/local/bin/srelens", links_to: "/x" });
+    mcp.installSrelensCli.mockResolvedValue("/home/u/.local/bin/srelens");
+    mcp.srelensCliStatus.mockResolvedValue({
+      installed: true,
+      path: "/home/u/.local/bin/srelens",
+      links_to: "/x",
+      on_path: true,
+    });
     render(<McpSettingsSection />);
     fireEvent.click(screen.getByRole("button", { name: /Install srelens CLI/ }));
     await waitFor(() => expect(mcp.installSrelensCli).toHaveBeenCalled());
     // After install the button relabels to Reinstall and the path is shown.
     expect(await screen.findByRole("button", { name: /Reinstall srelens CLI/ })).toBeDefined();
     expect(screen.getAllByText(/Installed at/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("warns when the install directory is not on PATH", async () => {
+    mcp.srelensCliStatus.mockResolvedValue({
+      installed: true,
+      path: "/home/u/.local/bin/srelens",
+      links_to: "/x",
+      on_path: false,
+    });
+    render(<McpSettingsSection />);
+    expect(await screen.findByText(/isn't on your PATH/)).toBeDefined();
   });
 
   it("shows the client config for the selected tool and transport", async () => {

--- a/apps/desktop/src/components/McpSettingsSection.tsx
+++ b/apps/desktop/src/components/McpSettingsSection.tsx
@@ -158,6 +158,13 @@ export function McpSettingsSection() {
             </span>
           )}
         </div>
+        {cli?.installed && !cli.on_path && (
+          <p className="text-sm text-amber-600 dark:text-amber-500">
+            Its directory isn't on your PATH yet — add it (e.g.{" "}
+            <code className="fl-mono">export PATH="$HOME/.local/bin:$PATH"</code>) so clients can find{" "}
+            <code className="fl-mono">srelens</code>.
+          </p>
+        )}
         {cliMessage && <p className="whitespace-pre-wrap text-sm text-muted-foreground">{cliMessage}</p>}
       </section>
 

--- a/apps/desktop/src/lib/mcp.ts
+++ b/apps/desktop/src/lib/mcp.ts
@@ -19,6 +19,8 @@ export interface CliStatus {
   installed: boolean;
   path: string;
   links_to: string | null;
+  /** Whether the install directory is on the current $PATH. */
+  on_path: boolean;
 }
 
 /** Symlink the srelens binary onto PATH; returns the install path. */


### PR DESCRIPTION
Follow-up to #85. Installing the `srelens` CLI to `/usr/local/bin` required elevation and failed with `Permission denied (os error 13)` on most macs.

## Change
- Install to the user-writable **`~/.local/bin`** (created if missing) via symlink — no sudo. Falls back to a manual `ln -sf` command (now to the user dir) if the write still fails.
- `srelens_cli_status` now reports `on_path`; the Settings UI shows an amber hint to add `~/.local/bin` to `$PATH` when the install dir isn't on it.

## Tests
- Updated `McpSettingsSection` tests to the new status shape/path + a new test for the not-on-PATH warning.

Full suite 403 passing; backend builds; tsc + build clean.