### PR TITLE
docs: README Install + MCP sections, install guide MCP note

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 <p align="center">
   <a href="https://srelens.com">Website</a> ·
+  <a href="#install">Install</a> ·
   <a href="#quick-start">Quick start</a> ·
   <a href="#mcp-server">MCP server</a> ·
   <a href="docs/DEVELOPMENT.md">Developer guide</a> ·
@@ -62,6 +63,19 @@ surfaces never drift.
 - **Command palette** — `⌘K` keyboard-first navigation across contexts, resources, and actions.
 - **MCP-native** — every capability is also an MCP tool; enable the server and copy client config from **Settings → MCP** (see below).
 - **Local-first** — talks directly to your API servers with your kubeconfig credentials. No cloud service in between.
+
+## Install
+
+Download the latest build for your platform from the
+[**Releases**](https://github.com/srelens/srelens/releases/latest) page:
+
+- **macOS** — `.dmg` (Apple silicon & Intel)
+- **Linux** — `.AppImage`, `.deb`, or `.rpm`
+- **Windows** — `.msi` installer
+
+See the [installation guide](docs/INSTALL.md) for step-by-step instructions,
+first-launch security prompts, updating, and uninstalling. Prefer to build from
+source? See [Quick start](#quick-start).
 
 ## MCP server
 

--- a/README.md
+++ b/README.md
@@ -60,32 +60,37 @@ surfaces never drift.
 - **Helm** — browse installed releases and inspect release details.
 - **Metrics** — node and pod metrics (metrics-server) with usage overviews and sparklines.
 - **Command palette** — `⌘K` keyboard-first navigation across contexts, resources, and actions.
+- **MCP-native** — every capability is also an MCP tool; enable the server and copy client config from **Settings → MCP** (see below).
 - **Local-first** — talks directly to your API servers with your kubeconfig credentials. No cloud service in between.
 
 ## MCP server
 
-The same binary that runs the GUI can run as an MCP server, exposing the full capability registry:
+srelens is MCP-native — every capability it exposes to the UI is also an MCP tool, so
+agents and MCP-enabled editors can drive your clusters. Set it up in **Settings → MCP**:
+
+- **Run the MCP server (HTTP)** — toggle a loopback server (default `127.0.0.1:8765`) that
+  shares the app's authenticated clusters, so a client sees exactly what you do.
+- **Install the srelens CLI** — adds a `srelens` command to `~/.local/bin` so clients can
+  spawn `srelens --mcp-stdio` (make sure `~/.local/bin` is on your `PATH`).
+- **Client config** — copy ready-made config for Claude Code, Claude Desktop, Cursor,
+  Codex, Antigravity, and generic clients.
+
+Or run the server directly from a terminal:
 
 ```sh
-# stdio transport (for local agents / IDE clients)
-srelens-desktop --mcp-stdio
-
-# HTTP transport (loopback only, default 127.0.0.1:8765)
-srelens-desktop --mcp-http [addr]
+srelens --mcp-stdio                 # stdio (agents / IDE clients spawn this)
+srelens --mcp-http 127.0.0.1:8765   # loopback HTTP
 ```
 
-Destructive tools (delete, drain, apply, …) carry annotations and require an explicit
+Destructive tools (delete, drain, apply, …) are annotated and require an explicit
 `_confirm` argument — an agent can't delete or drain anything without approval.
 
-Example Claude Desktop / MCP client config:
+Example client config (stdio):
 
 ```json
 {
   "mcpServers": {
-    "srelens": {
-      "command": "/path/to/srelens-desktop",
-      "args": ["--mcp-stdio"]
-    }
+    "srelens": { "command": "srelens", "args": ["--mcp-stdio"] }
   }
 }
 ```

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -52,6 +52,19 @@ until then, verify by matching the file against the release.
 > "Windows protected your PC" prompt. Click **More info → Run anyway** to
 > proceed. Signed installers will remove this step in a future release.
 
+## Connect MCP clients
+
+srelens can act as an MCP server so agents and MCP-enabled editors drive your
+clusters. Open **Settings → MCP** to:
+
+- **Run the MCP server (HTTP)** on a loopback port — it shares your authenticated clusters.
+- **Install the `srelens` CLI** to `~/.local/bin` so clients can spawn `srelens --mcp-stdio`
+  (ensure `~/.local/bin` is on your `PATH`).
+- **Copy client config** for Claude Code, Claude Desktop, Cursor, Codex, Antigravity, and others.
+
+Destructive tools require an explicit `_confirm` — an agent can't delete or drain anything
+without approval.
+
 ## Updating
 
 srelens checks for updates from **Settings → Updates**:


### PR DESCRIPTION
Refreshes the docs for the MCP settings feature (#84).

- **README** — rewrote the *MCP server* section around the in-app **Settings → MCP** flow (loopback server toggle, `srelens` CLI install to `~/.local/bin`, per-tool client config), fixed the outdated `srelens-desktop` binary name, and added an **MCP-native** feature bullet.
- **INSTALL.md** — added a short *Connect MCP clients* section.

Docs-only.