### PR TITLE
feat(terminal): local kubectl terminal in the bottom dock (#96)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -906,6 +906,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,7 +991,7 @@ dependencies = [
  "rustc_version",
  "toml 1.1.2+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -1102,8 +1108,19 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
- "memoffset",
+ "memoffset 0.9.1",
  "rustc_version",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -1993,6 +2010,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ioctl-rs"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7970510895cee30b3e9128319f2cefd4bde883a39f38baa279567ba3a7eb97d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2412,6 +2438,15 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -2502,6 +2537,20 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.6.5",
+ "pin-utils",
+]
 
 [[package]]
 name = "num-conv"
@@ -2991,6 +3040,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3033,6 +3088,27 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "portable-pty"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806ee80c2a03dbe1a9fb9534f8d19e4c0546b790cde8fd1fea9d6390644cb0be"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "serial",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg 0.10.1",
 ]
 
 [[package]]
@@ -3859,6 +3935,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1237a96570fc377c13baa1b88c7589ab66edced652e43ffb17088f003db3e86"
+dependencies = [
+ "serial-core",
+ "serial-unix",
+ "serial-windows",
+]
+
+[[package]]
+name = "serial-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f46209b345401737ae2125fe5b19a77acce90cd53e1658cda928e4fe9a64581"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "serial-unix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03fbca4c9d866e24a459cbca71283f545a37f8e3e002ad8c70593871453cab7"
+dependencies = [
+ "ioctl-rs",
+ "libc",
+ "serial-core",
+ "termios",
+]
+
+[[package]]
+name = "serial-windows"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c6d3b776267a75d31bbdfd5d36c0ca051251caafc285827052bc53bcdc8162"
+dependencies = [
+ "libc",
+ "serial-core",
+]
+
+[[package]]
 name = "serialize-to-javascript"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3910,6 +4028,22 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -4042,6 +4176,7 @@ version = "0.2.0"
 dependencies = [
  "fix-path-env",
  "log",
+ "portable-pty",
  "serde",
  "serde_json",
  "srelens-capability",
@@ -4634,6 +4769,15 @@ checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
 dependencies = [
  "new_debug_unreachable",
  "utf-8",
+]
+
+[[package]]
+name = "termios"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -5898,6 +6042,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -29,6 +29,8 @@ srelens-capability = { path = "../../../crates/capability" }
 srelens-mcp = { path = "../../../crates/mcp" }
 srelens-kube = { path = "../../../crates/kube" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std", "io-util", "macros"] }
+# Local pseudo-terminal for the in-app kubectl shell (spawns the user's login shell).
+portable-pty = "0.8"
 
 # Auto-update is desktop-only (mobile stores handle their own updates).
 [target."cfg(not(any(target_os = \"android\", target_os = \"ios\")))".dependencies]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ mod forward;
 mod logs;
 mod mcp;
 mod settings;
+mod terminal;
 mod updater;
 mod watch;
 
@@ -20,6 +21,7 @@ use mcp::{
     McpHttpManager,
 };
 use settings::{get_request_timeout, set_request_timeout};
+use terminal::{start_terminal, terminal_close, terminal_input, terminal_resize, TerminalManager};
 use updater::{update_check, update_install};
 use watch::{start_resource_watch, stop_watch, WatchManager};
 
@@ -173,6 +175,7 @@ pub fn run() {
         .manage(ForwardManager::new(cache.clone()))
         .manage(McpHttpManager::new(cache.clone()))
         .manage(LogStreamManager::new(cache))
+        .manage(TerminalManager::new())
         .invoke_handler(tauri::generate_handler![
             invoke_capability,
             start_resource_watch,
@@ -195,7 +198,11 @@ pub fn run() {
             mcp_http_stop,
             mcp_http_status,
             install_srelens_cli,
-            srelens_cli_status
+            srelens_cli_status,
+            start_terminal,
+            terminal_input,
+            terminal_resize,
+            terminal_close
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/desktop/src-tauri/src/terminal.rs
+++ b/apps/desktop/src-tauri/src/terminal.rs
@@ -1,0 +1,178 @@
+//! Local pseudo-terminal bridge: spawns the user's login shell in a PTY,
+//! scoped to a kube context, and streams stdout to the WebView over Tauri
+//! events (stdin/resize come back the same way). This is the in-app `kubectl`
+//! terminal — a LOCAL process on the user's machine, distinct from the in-pod
+//! exec bridge. Desktop-only; never exposed through the MCP capability registry.
+
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
+use tauri::{AppHandle, Emitter, State};
+
+struct Session {
+    master: Mutex<Box<dyn MasterPty + Send>>,
+    writer: Mutex<Box<dyn Write + Send>>,
+    child: Mutex<Box<dyn Child + Send + Sync>>,
+    /// The temp overlay kubeconfig to clean up when the session closes.
+    overlay: PathBuf,
+}
+
+/// Tauri-managed state owning running local terminals (keyed by numeric id).
+pub struct TerminalManager {
+    next_id: AtomicU64,
+    sessions: Mutex<HashMap<u64, Arc<Session>>>,
+}
+
+impl TerminalManager {
+    pub fn new() -> Self {
+        Self {
+            next_id: AtomicU64::new(1),
+            sessions: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+/// Write a **standalone** kubeconfig that contains only `context` (and the one
+/// cluster/user it references) to a private temp file. Pointing `KUBECONFIG` at
+/// just this file locks the terminal to that cluster — no other contexts are
+/// listed or switchable. Returns the temp file path.
+fn write_locked_kubeconfig(id: u64, context: &str, extra: &[String]) -> Result<PathBuf, String> {
+    let mut paths: Vec<PathBuf> = crate::capabilities::default_kubeconfig_paths();
+    paths.extend(extra.iter().map(PathBuf::from));
+    let yaml = srelens_kube::connect::single_context_kubeconfig_yaml(&paths, context)?;
+
+    let path = std::env::temp_dir().join(format!("srelens-term-{id}.kubeconfig"));
+    std::fs::write(&path, yaml).map_err(|e| e.to_string())?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+    }
+    Ok(path)
+}
+
+/// Start a local shell scoped to `context`. Returns the session id; output
+/// streams on `term:out:<id>` and a `term:exit:<id>` event fires when it ends.
+#[tauri::command]
+pub async fn start_terminal(
+    context: String,
+    extra_kubeconfigs: Vec<String>,
+    cols: Option<u16>,
+    rows: Option<u16>,
+    app: AppHandle,
+    manager: State<'_, TerminalManager>,
+) -> Result<u64, String> {
+    let id = manager.next_id.fetch_add(1, Ordering::SeqCst);
+    let overlay = write_locked_kubeconfig(id, &context, &extra_kubeconfigs)?;
+    let kubeconfig = overlay.clone().into_os_string();
+
+    let pty = native_pty_system();
+    let pair = pty
+        .openpty(PtySize {
+            rows: rows.unwrap_or(24),
+            cols: cols.unwrap_or(80),
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .map_err(|e| e.to_string())?;
+
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".to_string());
+    let mut cmd = CommandBuilder::new(&shell);
+    // Propagate the parent environment (PATH is already resolved by fix-path-env
+    // at startup, so kubectl / helm / cloud CLIs are found), then scope kubectl.
+    for (key, value) in std::env::vars() {
+        cmd.env(key, value);
+    }
+    cmd.env("KUBECONFIG", &kubeconfig);
+    cmd.env("TERM", "xterm-256color");
+    cmd.env("SRELENS_CONTEXT", &context);
+    if let Ok(home) = std::env::var("HOME") {
+        cmd.cwd(home);
+    }
+
+    let child = pair.slave.spawn_command(cmd).map_err(|e| e.to_string())?;
+    // Drop the slave so the reader sees EOF once the child exits.
+    drop(pair.slave);
+
+    let mut reader = pair.master.try_clone_reader().map_err(|e| e.to_string())?;
+    let writer = pair.master.take_writer().map_err(|e| e.to_string())?;
+
+    let session = Arc::new(Session {
+        master: Mutex::new(pair.master),
+        writer: Mutex::new(writer),
+        child: Mutex::new(child),
+        overlay: overlay.clone(),
+    });
+    manager.sessions.lock().unwrap().insert(id, session);
+
+    // Blocking read loop on a dedicated thread (portable-pty readers are sync).
+    let out_channel = format!("term:out:{id}");
+    let exit_channel = format!("term:exit:{id}");
+    std::thread::spawn(move || {
+        let mut buf = [0u8; 8192];
+        loop {
+            match reader.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    let chunk = String::from_utf8_lossy(&buf[..n]).to_string();
+                    let _ = app.emit(&out_channel, chunk);
+                }
+                Err(_) => break,
+            }
+        }
+        let _ = app.emit(&exit_channel, Option::<String>::None);
+        let _ = std::fs::remove_file(&overlay);
+    });
+
+    Ok(id)
+}
+
+/// Forward keystrokes / pasted input to a terminal's stdin.
+#[tauri::command]
+pub async fn terminal_input(
+    session: u64,
+    data: String,
+    manager: State<'_, TerminalManager>,
+) -> Result<(), String> {
+    let s = manager.sessions.lock().unwrap().get(&session).cloned();
+    if let Some(s) = s {
+        let mut writer = s.writer.lock().unwrap();
+        let _ = writer.write_all(data.as_bytes());
+        let _ = writer.flush();
+    }
+    Ok(())
+}
+
+/// Resize a terminal's PTY (columns/rows) to match the xterm viewport.
+#[tauri::command]
+pub async fn terminal_resize(
+    session: u64,
+    cols: u16,
+    rows: u16,
+    manager: State<'_, TerminalManager>,
+) -> Result<(), String> {
+    let s = manager.sessions.lock().unwrap().get(&session).cloned();
+    if let Some(s) = s {
+        let _ = s.master.lock().unwrap().resize(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        });
+    }
+    Ok(())
+}
+
+/// Close a terminal: kill the shell and drop the session.
+#[tauri::command]
+pub async fn terminal_close(session: u64, manager: State<'_, TerminalManager>) -> Result<(), String> {
+    if let Some(s) = manager.sessions.lock().unwrap().remove(&session) {
+        let _ = s.child.lock().unwrap().kill();
+        let _ = std::fs::remove_file(&s.overlay);
+    }
+    Ok(())
+}

--- a/apps/desktop/src-tauri/src/terminal.rs
+++ b/apps/desktop/src-tauri/src/terminal.rs
@@ -24,14 +24,14 @@ struct Session {
 /// Tauri-managed state owning running local terminals (keyed by numeric id).
 pub struct TerminalManager {
     next_id: AtomicU64,
-    sessions: Mutex<HashMap<u64, Arc<Session>>>,
+    sessions: Arc<Mutex<HashMap<u64, Arc<Session>>>>,
 }
 
 impl TerminalManager {
     pub fn new() -> Self {
         Self {
             next_id: AtomicU64::new(1),
-            sessions: Mutex::new(HashMap::new()),
+            sessions: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 }
@@ -45,13 +45,23 @@ fn write_locked_kubeconfig(id: u64, context: &str, extra: &[String]) -> Result<P
     paths.extend(extra.iter().map(PathBuf::from));
     let yaml = srelens_kube::connect::single_context_kubeconfig_yaml(&paths, context)?;
 
-    let path = std::env::temp_dir().join(format!("srelens-term-{id}.kubeconfig"));
-    std::fs::write(&path, yaml).map_err(|e| e.to_string())?;
+    // Unique per-process + per-session name, created atomically with O_EXCL so a
+    // pre-existing path/symlink can't be followed or overwritten, and mode 0600 at
+    // creation so there's no world-readable window before perms are applied.
+    let path = std::env::temp_dir().join(format!(
+        "srelens-term-{}-{}.kubeconfig",
+        std::process::id(),
+        id
+    ));
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create_new(true);
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
     }
+    let mut file = opts.open(&path).map_err(|e| e.to_string())?;
+    file.write_all(yaml.as_bytes()).map_err(|e| e.to_string())?;
     Ok(path)
 }
 
@@ -112,6 +122,7 @@ pub async fn start_terminal(
     // Blocking read loop on a dedicated thread (portable-pty readers are sync).
     let out_channel = format!("term:out:{id}");
     let exit_channel = format!("term:exit:{id}");
+    let sessions = Arc::clone(&manager.sessions);
     std::thread::spawn(move || {
         let mut buf = [0u8; 8192];
         loop {
@@ -126,6 +137,7 @@ pub async fn start_terminal(
         }
         let _ = app.emit(&exit_channel, Option::<String>::None);
         let _ = std::fs::remove_file(&overlay);
+        sessions.lock().unwrap().remove(&id);
     });
 
     Ok(id)

--- a/apps/desktop/src-tauri/src/terminal.rs
+++ b/apps/desktop/src-tauri/src/terminal.rs
@@ -66,18 +66,24 @@ fn write_locked_kubeconfig(id: u64, context: &str, extra: &[String]) -> Result<P
 }
 
 /// Start a local shell scoped to `context`. Returns the session id; output
-/// streams on `term:out:<id>` and a `term:exit:<id>` event fires when it ends.
+/// streams on `term:out:<channel>` and a `term:exit:<channel>` event fires
+/// when it ends, where `channel` is the caller-supplied subscription token.
 #[tauri::command]
 pub async fn start_terminal(
     context: String,
     extra_kubeconfigs: Vec<String>,
+    channel: String,
     cols: Option<u16>,
     rows: Option<u16>,
     app: AppHandle,
     manager: State<'_, TerminalManager>,
 ) -> Result<u64, String> {
     let id = manager.next_id.fetch_add(1, Ordering::SeqCst);
-    let overlay = write_locked_kubeconfig(id, &context, &extra_kubeconfigs)?;
+    let ctx = context.clone();
+    let extra = extra_kubeconfigs.clone();
+    let overlay = tokio::task::spawn_blocking(move || write_locked_kubeconfig(id, &ctx, &extra))
+        .await
+        .map_err(|e| e.to_string())??;
     let kubeconfig = overlay.clone().into_os_string();
 
     let pty = native_pty_system();
@@ -120,20 +126,40 @@ pub async fn start_terminal(
     manager.sessions.lock().unwrap().insert(id, session);
 
     // Blocking read loop on a dedicated thread (portable-pty readers are sync).
-    let out_channel = format!("term:out:{id}");
-    let exit_channel = format!("term:exit:{id}");
+    let out_channel = format!("term:out:{channel}");
+    let exit_channel = format!("term:exit:{channel}");
     let sessions = Arc::clone(&manager.sessions);
     std::thread::spawn(move || {
         let mut buf = [0u8; 8192];
+        let mut carry: Vec<u8> = Vec::new();
         loop {
             match reader.read(&mut buf) {
                 Ok(0) => break,
                 Ok(n) => {
-                    let chunk = String::from_utf8_lossy(&buf[..n]).to_string();
-                    let _ = app.emit(&out_channel, chunk);
+                    carry.extend_from_slice(&buf[..n]);
+                    // Emit the valid UTF-8 prefix; keep an incomplete trailing
+                    // multibyte sequence (<=3 bytes) for the next read. If the
+                    // leftover exceeds 3 bytes it contains an actually-invalid byte,
+                    // so flush it lossily rather than stalling.
+                    let valid = std::str::from_utf8(&carry)
+                        .map(|s| s.len())
+                        .unwrap_or_else(|e| e.valid_up_to());
+                    let cut = if carry.len() - valid > 3 {
+                        carry.len()
+                    } else {
+                        valid
+                    };
+                    if cut > 0 {
+                        let text = String::from_utf8_lossy(&carry[..cut]).into_owned();
+                        let _ = app.emit(&out_channel, text);
+                        carry.drain(..cut);
+                    }
                 }
                 Err(_) => break,
             }
+        }
+        if !carry.is_empty() {
+            let _ = app.emit(&out_channel, String::from_utf8_lossy(&carry).into_owned());
         }
         let _ = app.emit(&exit_channel, Option::<String>::None);
         let _ = std::fs::remove_file(&overlay);

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -376,6 +376,7 @@ export function App() {
       pod?: string;
       container?: string;
       workload?: { kind: string; name: string };
+      kubeconfigFiles?: string[];
     },
   ) {
     const id = dockIdRef.current++;
@@ -546,6 +547,17 @@ export function App() {
                     onCloseTab={closeDockTab}
                     onClose={closeDock}
                     onResize={setDockHeight}
+                    onNewTerminal={(() => {
+                      // "+" opens another terminal for the active shell's context,
+                      // falling back to the connected cluster.
+                      const active = dockSessions.find((s) => s.id === activeDock);
+                      const ctx = active?.kind === "shell" ? active.context : activeCluster;
+                      const files =
+                        active?.kind === "shell" ? active.kubeconfigFiles ?? kubeconfigFiles : kubeconfigFiles;
+                      return ctx
+                        ? () => openDock("shell", { context: ctx, namespace: "", kubeconfigFiles: files })
+                        : undefined;
+                    })()}
                   />
                 )}
               </>
@@ -567,6 +579,12 @@ export function App() {
           activeTab ? (activeTab.crd ? activeTab.crd.kind : RESOURCE_LABELS[activeKind]) : undefined
         }
         tabCount={tabs.length}
+        onOpenTerminal={
+          activeCluster
+            ? () =>
+                openDock("shell", { context: activeCluster, namespace: "", kubeconfigFiles })
+            : undefined
+        }
       />
       <CommandPalette
         open={paletteOpen}

--- a/apps/desktop/src/components/Dock.test.tsx
+++ b/apps/desktop/src/components/Dock.test.tsx
@@ -44,10 +44,14 @@ describe("Dock", () => {
     expect(screen.getByTestId("terminal").textContent).toBe("web-1");
   });
 
-  it("renders the logs view when a logs tab is active", () => {
+  it("keeps every session mounted and shows only the active one", () => {
     renderDock({ activeId: 2 });
+    // Both panes are mounted (so terminals/streams survive tab switches)…
     expect(screen.getByTestId("logs").textContent).toBe("web-2");
-    expect(screen.queryByTestId("terminal")).toBeNull();
+    expect(screen.getByTestId("terminal").textContent).toBe("web-1");
+    // …but only the active session's pane is displayed.
+    expect((screen.getByTestId("logs").parentElement as HTMLElement).style.display).toBe("block");
+    expect((screen.getByTestId("terminal").parentElement as HTMLElement).style.display).toBe("none");
   });
 
   it("activates a tab on click", () => {
@@ -62,5 +66,36 @@ describe("Dock", () => {
     expect(props.onCloseTab).toHaveBeenCalledWith(1);
     fireEvent.click(screen.getByLabelText("Close dock"));
     expect(props.onClose).toHaveBeenCalled();
+  });
+
+  it("shows a New terminal button only when a handler is given", () => {
+    const { rerender } = render(
+      <Dock
+        sessions={sessions}
+        activeId={1}
+        height={300}
+        onActivate={vi.fn()}
+        onCloseTab={vi.fn()}
+        onClose={vi.fn()}
+        onResize={vi.fn()}
+      />,
+    );
+    expect(screen.queryByLabelText("New terminal")).toBeNull();
+
+    const onNewTerminal = vi.fn();
+    rerender(
+      <Dock
+        sessions={sessions}
+        activeId={1}
+        height={300}
+        onActivate={vi.fn()}
+        onCloseTab={vi.fn()}
+        onClose={vi.fn()}
+        onResize={vi.fn()}
+        onNewTerminal={onNewTerminal}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("New terminal"));
+    expect(onNewTerminal).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/components/Dock.tsx
+++ b/apps/desktop/src/components/Dock.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useRef } from "react";
-import { Logs, SquareTerminal, X } from "lucide-react";
+import { Logs, Plus, SquareTerminal, X } from "lucide-react";
 import { PodTerminal } from "./PodTerminal";
+import { LocalTerminal } from "./LocalTerminal";
 import { LogsView, type LogsSource } from "./LogsView";
 
-export type DockKind = "terminal" | "logs";
+export type DockKind = "terminal" | "logs" | "shell";
 
 export interface DockSession {
   id: number;
@@ -16,10 +17,13 @@ export interface DockSession {
   container?: string;
   /** Present for workload (e.g. Deployment) logs that span many pods. */
   workload?: { kind: string; name: string };
+  /** Extra kubeconfig files, for a local `shell` terminal scoped to the context. */
+  kubeconfigFiles?: string[];
 }
 
-/** Tab/session label: the pod name, or the workload kind/name. */
+/** Tab/session label: the pod name, the workload kind/name, or the context for a shell. */
 function sessionLabel(s: DockSession): string {
+  if (s.kind === "shell") return `kubectl · ${s.context}`;
   if (s.pod) return s.pod;
   if (s.workload) return `${s.workload.kind}/${s.workload.name}`;
   return "session";
@@ -37,6 +41,7 @@ export function Dock({
   onCloseTab,
   onClose,
   onResize,
+  onNewTerminal,
 }: {
   sessions: DockSession[];
   activeId: number | null;
@@ -45,8 +50,9 @@ export function Dock({
   onCloseTab: (id: number) => void;
   onClose: () => void;
   onResize: (height: number) => void;
+  /** Open another terminal for the active context (shown as a "+" in the tab bar). */
+  onNewTerminal?: () => void;
 }) {
-  const active = sessions.find((s) => s.id === activeId) ?? null;
   const startY = useRef(0);
   const startH = useRef(0);
   const heightRef = useRef(height);
@@ -88,58 +94,84 @@ export function Dock({
         <span className="fl-dock__grip" />
       </div>
       <div className="fl-dock__tabs">
-        {sessions.map((s) => (
-          <div
-            key={s.id}
-            role="tab"
-            aria-selected={s.id === activeId}
-            className={`fl-dock__tab${s.id === activeId ? " fl-dock__tab--active" : ""}`}
-            onClick={() => onActivate(s.id)}
-          >
-            <span>
-              {s.kind === "terminal" ? <SquareTerminal aria-hidden="true" /> : <Logs aria-hidden="true" />}
-              {sessionLabel(s)}
-            </span>
-            <button
-              className="fl-dock__tab-close"
-              aria-label={`Close ${sessionLabel(s)} ${s.kind}`}
-              onClick={(e) => {
-                e.stopPropagation();
-                onCloseTab(s.id);
-              }}
+        <div className="fl-dock__tablist" role="tablist">
+          {sessions.map((s) => (
+            <div
+              key={s.id}
+              role="tab"
+              aria-selected={s.id === activeId}
+              title={sessionLabel(s)}
+              className={`fl-dock__tab${s.id === activeId ? " fl-dock__tab--active" : ""}`}
+              onClick={() => onActivate(s.id)}
             >
-              <X aria-hidden="true" />
-            </button>
-          </div>
-        ))}
-        <div className="fl-dock__spacer" />
+              <span className="fl-dock__tab-main">
+                {s.kind === "terminal" || s.kind === "shell" ? (
+                  <SquareTerminal aria-hidden="true" />
+                ) : (
+                  <Logs aria-hidden="true" />
+                )}
+                <span className="fl-dock__tab-label">{sessionLabel(s)}</span>
+              </span>
+              <button
+                className="fl-dock__tab-close"
+                aria-label={`Close ${sessionLabel(s)} ${s.kind}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onCloseTab(s.id);
+                }}
+              >
+                <X aria-hidden="true" />
+              </button>
+            </div>
+          ))}
+        </div>
+        {onNewTerminal && (
+          <button
+            className="fl-dock__new"
+            aria-label="New terminal"
+            title="New terminal (same context)"
+            onClick={onNewTerminal}
+          >
+            <Plus aria-hidden="true" />
+          </button>
+        )}
         <button className="fl-dock__close" aria-label="Close dock" onClick={onClose}>
           <X aria-hidden="true" />
         </button>
       </div>
       <div className="fl-dock__body">
-        {active &&
-          (active.kind === "terminal" && active.pod ? (
-            <PodTerminal
-              key={active.id}
-              context={active.context}
-              namespace={active.namespace}
-              pod={active.pod}
-              container={active.container}
-            />
-          ) : (
-            <LogsView
-              key={active.id}
-              context={active.context}
-              namespace={active.namespace}
-              initialContainer={active.container}
-              source={
-                (active.pod
-                  ? { type: "pod", pod: active.pod }
-                  : { type: "workload", kind: active.workload!.kind, name: active.workload!.name }) as LogsSource
-              }
-            />
-          ))}
+        {/* Every session stays mounted; only the active one is shown. Unmounting
+            an inactive tab would tear down its shell/log stream and lose the
+            terminal scrollback, so we hide rather than remove. */}
+        {sessions.map((s) => (
+          <div
+            key={s.id}
+            className="fl-dock__pane"
+            style={{ display: s.id === activeId ? "block" : "none" }}
+          >
+            {s.kind === "shell" ? (
+              <LocalTerminal context={s.context} kubeconfigFiles={s.kubeconfigFiles ?? []} />
+            ) : s.kind === "terminal" && s.pod ? (
+              <PodTerminal
+                context={s.context}
+                namespace={s.namespace}
+                pod={s.pod}
+                container={s.container}
+              />
+            ) : (
+              <LogsView
+                context={s.context}
+                namespace={s.namespace}
+                initialContainer={s.container}
+                source={
+                  (s.pod
+                    ? { type: "pod", pod: s.pod }
+                    : { type: "workload", kind: s.workload!.kind, name: s.workload!.name }) as LogsSource
+                }
+              />
+            )}
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/apps/desktop/src/components/LocalTerminal.tsx
+++ b/apps/desktop/src/components/LocalTerminal.tsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useRef } from "react";
+import { startLocalTerminal, type TerminalSession } from "../lib/terminal";
+
+/**
+ * A local shell (the user's login shell) rendered with xterm, pre-scoped to a
+ * kube context so `kubectl` targets it by default. Runs on the user's machine —
+ * distinct from the in-pod exec terminal. xterm is loaded dynamically so it
+ * stays out of the jsdom test graph; verified live rather than in unit tests.
+ */
+export function LocalTerminal({
+  context,
+  kubeconfigFiles,
+}: {
+  context: string;
+  /** Extra kubeconfig files the app has been told about (merged for the shell). */
+  kubeconfigFiles: string[];
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let cleanup = () => {};
+    let disposed = false;
+
+    void (async () => {
+      const { Terminal } = await import("@xterm/xterm");
+      const { FitAddon } = await import("@xterm/addon-fit");
+      await import("@xterm/xterm/css/xterm.css");
+      if (disposed || !ref.current) return;
+
+      const term = new Terminal({
+        convertEol: false,
+        fontSize: 13,
+        fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+        theme: { background: "#1b1f23", foreground: "#e6e6e6" },
+      });
+      const fit = new FitAddon();
+      term.loadAddon(fit);
+      term.open(ref.current);
+      fit.fit();
+      term.focus();
+      term.write(`kubectl scoped to \x1b[1m${context}\x1b[0m — starting shell…\r\n`);
+
+      let session: TerminalSession | null = null;
+      void startLocalTerminal(
+        context,
+        kubeconfigFiles,
+        (chunk) => term.write(chunk),
+        () => term.write("\r\n[shell exited]\r\n"),
+        { cols: term.cols, rows: term.rows },
+      ).then((s) => {
+        if (disposed) {
+          s.close();
+          return;
+        }
+        session = s;
+        term.onData((d) => s.send(d));
+        term.onResize(({ cols, rows }) => s.resize(cols, rows));
+      });
+
+      // Keep the PTY sized to the panel as the dock is resized.
+      const onWindowResize = () => {
+        try {
+          fit.fit();
+        } catch {
+          /* fit can throw if the element is detached mid-teardown */
+        }
+      };
+      window.addEventListener("resize", onWindowResize);
+      const observer =
+        typeof ResizeObserver !== "undefined" ? new ResizeObserver(onWindowResize) : null;
+      if (observer && ref.current) observer.observe(ref.current);
+
+      cleanup = () => {
+        window.removeEventListener("resize", onWindowResize);
+        observer?.disconnect();
+        session?.close();
+        term.dispose();
+      };
+    })();
+
+    return () => {
+      disposed = true;
+      cleanup();
+    };
+  }, [context, kubeconfigFiles]);
+
+  return (
+    <div
+      ref={ref}
+      style={{ height: "100%", width: "100%", background: "#000", padding: 6, boxSizing: "border-box" }}
+    />
+  );
+}

--- a/apps/desktop/src/components/LocalTerminal.tsx
+++ b/apps/desktop/src/components/LocalTerminal.tsx
@@ -45,7 +45,10 @@ export function LocalTerminal({
         context,
         kubeconfigFiles,
         (chunk) => term.write(chunk),
-        () => term.write("\r\n[shell exited]\r\n"),
+        () => {
+          term.write("\r\n[shell exited]\r\n");
+          session?.close();
+        },
         { cols: term.cols, rows: term.rows },
       ).then((s) => {
         if (disposed) {

--- a/apps/desktop/src/components/StatusBar.test.tsx
+++ b/apps/desktop/src/components/StatusBar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 
 // Usage polls metrics; stub it so the status-bar tests stay focused.
@@ -24,5 +24,15 @@ describe("StatusBar", () => {
   it("uses the singular for a single tab", () => {
     render(<StatusBar activeCluster="dev" tabCount={1} />);
     expect(screen.getByText("1 tab")).toBeDefined();
+  });
+
+  it("offers a terminal launcher only when a handler is provided", () => {
+    const onOpenTerminal = vi.fn();
+    const { rerender } = render(<StatusBar activeCluster="dev" tabCount={1} />);
+    expect(screen.queryByRole("button", { name: "Open kubectl terminal" })).toBeNull();
+
+    rerender(<StatusBar activeCluster="dev" tabCount={1} onOpenTerminal={onOpenTerminal} />);
+    fireEvent.click(screen.getByRole("button", { name: "Open kubectl terminal" }));
+    expect(onOpenTerminal).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/components/StatusBar.tsx
+++ b/apps/desktop/src/components/StatusBar.tsx
@@ -1,20 +1,24 @@
 import React from "react";
+import { SquareTerminal } from "lucide-react";
 import { ClusterUsage } from "./ClusterUsage";
 import { ForwardsIndicator } from "./ForwardsIndicator";
 
 /**
  * Thin status bar across the bottom of the app: connection state + active
- * cluster on the left; live cluster CPU/memory, the current view, and the
- * open-tab count on the right.
+ * cluster on the left; a terminal launcher, live cluster CPU/memory, the
+ * current view, and the open-tab count on the right.
  */
 export function StatusBar({
   activeCluster,
   activeLabel,
   tabCount,
+  onOpenTerminal,
 }: {
   activeCluster: string | null;
   activeLabel?: string;
   tabCount: number;
+  /** Open a local kubectl terminal for the active cluster (omitted when disconnected). */
+  onOpenTerminal?: () => void;
 }) {
   return (
     <footer className="fl-statusbar col-[1/-1] flex h-6 items-center gap-3 border-t border-border bg-card px-3 text-xs text-muted-foreground">
@@ -32,6 +36,18 @@ export function StatusBar({
       {activeLabel && <span className="fl-statusbar__label truncate">{activeLabel}</span>}
 
       <span className="fl-statusbar__meta ml-auto flex items-center gap-3">
+        {onOpenTerminal && (
+          <button
+            type="button"
+            className="fl-statusbar__terminal flex items-center gap-1 hover:text-foreground"
+            onClick={onOpenTerminal}
+            title={`Open a kubectl terminal for ${activeCluster}`}
+            aria-label="Open kubectl terminal"
+          >
+            <SquareTerminal className="size-3.5" aria-hidden="true" />
+            Terminal
+          </button>
+        )}
         <ForwardsIndicator />
         {activeCluster && <ClusterUsage context={activeCluster} />}
         <span className="tabular-nums">

--- a/apps/desktop/src/lib/terminal.ts
+++ b/apps/desktop/src/lib/terminal.ts
@@ -1,4 +1,4 @@
-import { invokeCommand, on } from "../transport/transport";
+import { invokeCommand, subscribe } from "../transport/transport";
 
 export interface TerminalSession {
   /** Send keystrokes / pasted input to the shell's stdin. */
@@ -8,6 +8,9 @@ export interface TerminalSession {
   /** Close the session and unsubscribe. */
   close: () => void;
 }
+
+// Monotonic id so each terminal gets a unique channel.
+let terminalSeq = 0;
 
 /**
  * Open a local shell scoped to `context` (kubectl targets it by default).
@@ -21,14 +24,25 @@ export async function startLocalTerminal(
   onExit: () => void,
   size?: { cols: number; rows: number },
 ): Promise<TerminalSession> {
-  const session = await invokeCommand<number>("start_terminal", {
-    context,
-    extraKubeconfigs,
-    cols: size?.cols ?? null,
-    rows: size?.rows ?? null,
-  });
-  const disposeOut = on(`term:out:${session}`, (p) => onData(p as string));
-  const disposeExit = on(`term:exit:${session}`, () => onExit());
+  // Unique channel so we can subscribe BEFORE the backend spawns and emits —
+  // otherwise the first prompt can race ahead of the listener.
+  const channel = `term-${terminalSeq++}`;
+  const disposeOut = await subscribe(`term:out:${channel}`, (p) => onData(p as string));
+  const disposeExit = await subscribe(`term:exit:${channel}`, () => onExit());
+  let session: number;
+  try {
+    session = await invokeCommand<number>("start_terminal", {
+      context,
+      extraKubeconfigs,
+      channel,
+      cols: size?.cols ?? null,
+      rows: size?.rows ?? null,
+    });
+  } catch (e) {
+    disposeOut();
+    disposeExit();
+    throw e;
+  }
   return {
     send: (data) => void invokeCommand("terminal_input", { session, data }),
     resize: (cols, rows) => void invokeCommand("terminal_resize", { session, cols, rows }),

--- a/apps/desktop/src/lib/terminal.ts
+++ b/apps/desktop/src/lib/terminal.ts
@@ -1,0 +1,41 @@
+import { invokeCommand, on } from "../transport/transport";
+
+export interface TerminalSession {
+  /** Send keystrokes / pasted input to the shell's stdin. */
+  send: (data: string) => void;
+  /** Resize the PTY to match the xterm viewport. */
+  resize: (cols: number, rows: number) => void;
+  /** Close the session and unsubscribe. */
+  close: () => void;
+}
+
+/**
+ * Open a local shell scoped to `context` (kubectl targets it by default).
+ * Runs on the user's machine — distinct from in-pod exec. `onData` receives
+ * stdout chunks; `onExit` fires when the shell ends.
+ */
+export async function startLocalTerminal(
+  context: string,
+  extraKubeconfigs: string[],
+  onData: (chunk: string) => void,
+  onExit: () => void,
+  size?: { cols: number; rows: number },
+): Promise<TerminalSession> {
+  const session = await invokeCommand<number>("start_terminal", {
+    context,
+    extraKubeconfigs,
+    cols: size?.cols ?? null,
+    rows: size?.rows ?? null,
+  });
+  const disposeOut = on(`term:out:${session}`, (p) => onData(p as string));
+  const disposeExit = on(`term:exit:${session}`, () => onExit());
+  return {
+    send: (data) => void invokeCommand("terminal_input", { session, data }),
+    resize: (cols, rows) => void invokeCommand("terminal_resize", { session, cols, rows }),
+    close: () => {
+      disposeOut();
+      disposeExit();
+      void invokeCommand("terminal_close", { session });
+    },
+  };
+}

--- a/apps/desktop/src/ui/styles.css
+++ b/apps/desktop/src/ui/styles.css
@@ -860,6 +860,17 @@ body {
   height: 32px;
   border-bottom: 1px solid var(--fl-color-border);
 }
+/* Tabs scroll horizontally so many long-named terminals never break layout;
+   the +/close buttons stay pinned to the right of this scroll area. */
+.fl-dock__tablist {
+  display: flex;
+  align-items: stretch;
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+}
 .fl-dock__tab {
   display: inline-flex;
   align-items: center;
@@ -870,6 +881,23 @@ body {
   border-right: 1px solid var(--fl-color-border);
   font-size: 13px;
   background: transparent;
+  flex: 0 0 auto;
+  max-width: 240px;
+}
+.fl-dock__tab-main {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+.fl-dock__tab-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.fl-dock__new,
+.fl-dock__close {
+  flex: 0 0 auto;
 }
 .fl-dock__tab--active {
   background: var(--fl-dock-tab-active);
@@ -918,7 +946,23 @@ body {
   padding: 0 2px;
   box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.22);
 }
+.fl-dock__new {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  opacity: 0.6;
+  padding: 0 8px;
+}
+.fl-dock__new svg {
+  width: 15px;
+  height: 15px;
+}
 .fl-dock__tab-close:hover,
+.fl-dock__new:hover,
 .fl-dock__close:hover {
   opacity: 1;
 }
@@ -945,6 +989,11 @@ body {
   min-height: 0;
   background: var(--fl-color-bg);
   overflow: hidden;
+  position: relative;
+}
+.fl-dock__pane {
+  height: 100%;
+  width: 100%;
 }
 .fl-sidebar__cluster {
   display: flex;

--- a/crates/kube/src/connect.rs
+++ b/crates/kube/src/connect.rs
@@ -78,6 +78,37 @@ pub fn validate_kubeconfig_yaml(yaml: &str) -> Result<usize, String> {
     Ok(config.contexts.len())
 }
 
+/// Build a standalone kubeconfig (YAML) containing ONLY `context` plus the one
+/// cluster and user it references, with `current-context` pinned to it.
+///
+/// Used to lock the in-app terminal to a single cluster: pointing `KUBECONFIG`
+/// at this file means `kubectl config get-contexts` lists just that context and
+/// `use-context` can't switch to any other.
+pub fn single_context_kubeconfig_yaml(paths: &[PathBuf], context: &str) -> Result<String, String> {
+    let mut config = load_kubeconfigs(paths)?;
+    let named = config
+        .contexts
+        .iter()
+        .find(|c| c.name == context)
+        .ok_or_else(|| format!("context '{context}' not found in kubeconfig"))?;
+    let inner = named
+        .context
+        .clone()
+        .ok_or_else(|| format!("context '{context}' has no cluster/user"))?;
+
+    config.contexts.retain(|c| c.name == context);
+    config.clusters.retain(|c| c.name == inner.cluster);
+    config.auth_infos.retain(|a| a.name == inner.user);
+    config.current_context = Some(context.to_string());
+    if config.kind.is_none() {
+        config.kind = Some("Config".to_string());
+    }
+    if config.api_version.is_none() {
+        config.api_version = Some("v1".to_string());
+    }
+    serde_yaml::to_string(&config).map_err(|e| e.to_string())
+}
+
 pub(crate) async fn build_client(paths: &[PathBuf], context: &str) -> Result<Client, String> {
     let kubeconfig = load_kubeconfigs(paths)?;
     let options = KubeConfigOptions {
@@ -167,6 +198,33 @@ mod tests {
         assert_eq!(request_timeout_secs(), 20);
         // Restore the default so other tests see a known value.
         set_request_timeout_secs(DEFAULT_TIMEOUT_SECS);
+    }
+
+    #[test]
+    fn single_context_kubeconfig_keeps_only_the_named_context() {
+        let dir = std::env::temp_dir();
+        let path = dir.join("srelens-single-context-test.yaml");
+        std::fs::write(
+            &path,
+            "apiVersion: v1\nkind: Config\ncurrent-context: ctx-a\nclusters:\n  - name: cluster-a\n    cluster: { server: https://a:6443 }\n  - name: cluster-b\n    cluster: { server: https://b:6443 }\nusers:\n  - name: user-a\n    user: {}\n  - name: user-b\n    user: {}\ncontexts:\n  - name: ctx-a\n    context: { cluster: cluster-a, user: user-a }\n  - name: ctx-b\n    context: { cluster: cluster-b, user: user-b }\n",
+        )
+        .unwrap();
+
+        let yaml = single_context_kubeconfig_yaml(&[path.clone()], "ctx-b").unwrap();
+        let locked = Kubeconfig::from_yaml(&yaml).unwrap();
+
+        // Only ctx-b (and its cluster/user) survive, and it's the current context.
+        assert_eq!(locked.current_context.as_deref(), Some("ctx-b"));
+        assert_eq!(locked.contexts.len(), 1);
+        assert_eq!(locked.contexts[0].name, "ctx-b");
+        assert_eq!(locked.clusters.len(), 1);
+        assert_eq!(locked.clusters[0].name, "cluster-b");
+        assert_eq!(locked.auth_infos.len(), 1);
+        assert_eq!(locked.auth_infos[0].name, "user-b");
+
+        // A missing context is an error, not a full config.
+        assert!(single_context_kubeconfig_yaml(&[path.clone()], "nope").is_err());
+        let _ = std::fs::remove_file(&path);
     }
 
     #[test]

--- a/crates/kube/src/connect.rs
+++ b/crates/kube/src/connect.rs
@@ -203,7 +203,14 @@ mod tests {
     #[test]
     fn single_context_kubeconfig_keeps_only_the_named_context() {
         let dir = std::env::temp_dir();
-        let path = dir.join("srelens-single-context-test.yaml");
+        let path = dir.join(format!(
+            "srelens-single-context-{}-{}.yaml",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
         std::fs::write(
             &path,
             "apiVersion: v1\nkind: Config\ncurrent-context: ctx-a\nclusters:\n  - name: cluster-a\n    cluster: { server: https://a:6443 }\n  - name: cluster-b\n    cluster: { server: https://b:6443 }\nusers:\n  - name: user-a\n    user: {}\n  - name: user-b\n    user: {}\ncontexts:\n  - name: ctx-a\n    context: { cluster: cluster-a, user: user-a }\n  - name: ctx-b\n    context: { cluster: cluster-b, user: user-b }\n",


### PR DESCRIPTION
Closes #96

## What

An in-app **local terminal** — a real shell (your `$SHELL`) opened from the status bar and hosted in the bottom **dock** — so you can run `kubectl`/`helm` without leaving the app. Distinct from the in-pod exec terminal; **desktop-only, never exposed via MCP**.

## Backend

- **Local PTY bridge** (`portable-pty`) streaming stdout/stdin/resize over Tauri events: `start_terminal` / `terminal_input` / `terminal_resize` / `terminal_close`, keyed per session.
- **Locked to one context**: each terminal gets a standalone temp kubeconfig containing **only** the opened context (+ its cluster/user), written `0600`, set as `KUBECONFIG`. So `kubectl` targets it by default, `config get-contexts` lists just that one, and `use-context` can't switch away. (`srelens_kube::connect::single_context_kubeconfig_yaml`)
- Parent env (PATH resolved by `fix-path-env`) is propagated so `kubectl`/`helm` resolve.

## Frontend

- `LocalTerminal` (xterm) + `lib/terminal.ts` client.
- **Dock** gains a `shell` session kind, a **"+"** button to open another terminal for the same context, and now **keeps every session mounted** (hiding inactive panes) — switching tabs no longer tears down shells or loses scrollback.
- Tab bar **scrolls horizontally with truncated labels** (+ tooltip) so many long-named terminals don't break the layout.
- **StatusBar "Terminal"** launcher for the active cluster.

## Testing

- Rust: `single_context_kubeconfig_yaml` test (only the named context/cluster/user survive; missing context errors).
- Frontend: Dock tests (persistence/hide-not-unmount, "+" button) + StatusBar launcher test.
- Full suite green (**411**); `vite build` + `cargo check` clean.
- Verified live: locked context, multi-tab, tab persistence, layout.

## Notes / scope

- It's a **real shell on the user's machine** (their `$SHELL`/kubectl) — inherent that a determined user could `export KUBECONFIG=…` to escape the lock; the default/listed/switchable scope is the one cluster, which is the intent.
- UTF-8 output is forwarded lossily at chunk boundaries (fine for typical CLI output).
- Follow-up ideas: numbering same-context tabs to tell them apart; a command-palette entry.