### PR TITLE
feat: detect local clusters and keep them separate from remote/prod

### DIFF
--- a/apps/desktop/src/components/ClusterHotbar.test.tsx
+++ b/apps/desktop/src/components/ClusterHotbar.test.tsx
@@ -40,6 +40,29 @@ describe("ClusterHotbar", () => {
     expect(onOpenContext).toHaveBeenCalledWith("prod");
   });
 
+  it("separates local clusters from remote ones with a divider", async () => {
+    listContextsMock.mockResolvedValue({
+      contexts: [
+        { name: "prod", cluster: "p", server: "s", isCurrent: false },
+        { name: "kind-dev", cluster: "k", server: "s", isCurrent: true, isLocal: true, provider: "kind" },
+      ],
+    });
+    render(
+      <ClusterHotbar
+        openContext="kind-dev"
+        onOpenContext={() => {}}
+        theme={theme}
+        onToggleTheme={() => {}}
+        onOpenSettings={() => {}}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByLabelText("kind-dev (local)")).toBeDefined());
+    expect(screen.getByRole("separator", { name: "Local clusters" })).toBeDefined();
+    // Remote clusters keep their plain label.
+    expect(screen.getByLabelText("prod")).toBeDefined();
+  });
+
   it("toggles the theme", async () => {
     listContextsMock.mockResolvedValue({ contexts: [] });
     const onToggleTheme = vi.fn();

--- a/apps/desktop/src/components/ClusterHotbar.tsx
+++ b/apps/desktop/src/components/ClusterHotbar.tsx
@@ -44,25 +44,34 @@ export function ClusterHotbar({
     };
   }, [contextOrder, kubeconfigFiles]);
 
+  const renderItem = (c: ClusterContext) => {
+    const profile = contextProfiles[c.name];
+    const displayName = contextDisplayName(c.name, profile);
+    return (
+      <button
+        key={c.name}
+        className={`fl-hotbar__item${openContext === c.name ? " fl-hotbar__item--active" : ""}`}
+        title={c.isLocal ? `${displayName} (local)` : displayName}
+        aria-label={c.isLocal ? `${displayName} (local)` : displayName}
+        onClick={() => onOpenContext(c.name)}
+      >
+        <ContextAvatar context={c.name} profile={profile} />
+      </button>
+    );
+  };
+
+  // Keep local dev clusters visually separated from the rest so they don't get
+  // mixed up with remote/production contexts.
+  const remoteContexts = contexts.filter((c) => !c.isLocal);
+  const localContexts = contexts.filter((c) => c.isLocal);
+
   return (
     <div className="fl-hotbar">
-      {contexts.map((c) => (
-        (() => {
-          const profile = contextProfiles[c.name];
-          const displayName = contextDisplayName(c.name, profile);
-          return (
-        <button
-          key={c.name}
-          className={`fl-hotbar__item${openContext === c.name ? " fl-hotbar__item--active" : ""}`}
-          title={displayName}
-          aria-label={displayName}
-          onClick={() => onOpenContext(c.name)}
-        >
-          <ContextAvatar context={c.name} profile={profile} />
-        </button>
-          );
-        })()
-      ))}
+      {remoteContexts.map(renderItem)}
+      {remoteContexts.length > 0 && localContexts.length > 0 && (
+        <div className="fl-hotbar__divider" role="separator" aria-label="Local clusters" />
+      )}
+      {localContexts.map(renderItem)}
       <div className="fl-hotbar__spacer" aria-hidden="true" />
       <button
         className="fl-hotbar__theme"

--- a/apps/desktop/src/components/LandingPage.test.tsx
+++ b/apps/desktop/src/components/LandingPage.test.tsx
@@ -41,6 +41,35 @@ describe("LandingPage", () => {
     expect(onOpenContext).toHaveBeenCalledWith("production-eu");
   });
 
+  it("splits local and remote contexts into groups with a provider badge", async () => {
+    listContexts.mockResolvedValue({
+      contexts: [
+        {
+          name: "kind-dev",
+          cluster: "kind-dev",
+          server: "https://127.0.0.1:6443",
+          isCurrent: false,
+          isLocal: true,
+          provider: "kind",
+        },
+        {
+          name: "production-eu",
+          cluster: "prod-eu",
+          server: "https://prod.example.com",
+          isCurrent: true,
+        },
+      ],
+    });
+
+    render(<LandingPage onOpenContext={vi.fn()} onOpenSettings={vi.fn()} />);
+    await screen.findByRole("button", { name: "Open context kind-dev" });
+
+    // Both groups are labelled, and the local row carries its provider badge.
+    expect(screen.getByText("Local")).toBeDefined();
+    expect(screen.getByText("Remote")).toBeDefined();
+    expect(screen.getByText("kind")).toBeDefined();
+  });
+
   it("opens workspace preferences from the masthead", async () => {
     listContexts.mockResolvedValue({ contexts: [] });
     const onOpenSettings = vi.fn();

--- a/apps/desktop/src/components/LandingPage.tsx
+++ b/apps/desktop/src/components/LandingPage.tsx
@@ -78,6 +78,53 @@ export function LandingPage({
 
   const contextCount = contexts?.length ?? 0;
 
+  const localContexts = filteredContexts.filter((context) => context.isLocal);
+  const remoteContexts = filteredContexts.filter((context) => !context.isLocal);
+  // Only split into labelled sections when both kinds are present; a single
+  // group renders as a plain list, exactly as before.
+  const grouped = localContexts.length > 0 && remoteContexts.length > 0;
+
+  const renderRow = (context: ClusterContext) => (
+    <button
+      key={context.name}
+      type="button"
+      className="fl-landing__context-row"
+      onClick={() => onOpenContext(context.name)}
+      aria-label={`Open context ${context.name}`}
+    >
+      <span className="fl-landing__context-main">
+        <ContextAvatar
+          context={context.name}
+          profile={contextProfiles[context.name]}
+          className="fl-landing__context-list-avatar"
+        />
+        <span>
+          <strong>{contextDisplayName(context.name, contextProfiles[context.name])}</strong>
+          <small>{context.cluster}</small>
+        </span>
+      </span>
+      <span className="fl-landing__context-action" aria-hidden="true">
+        {context.isLocal && (
+          <Badge variant="outline" className="fl-landing__context-badge">
+            {context.provider ?? "local"}
+          </Badge>
+        )}
+        {context.isCurrent && <small>Current</small>}
+        <ArrowRight />
+      </span>
+    </button>
+  );
+
+  const renderGroup = (label: string, items: ClusterContext[]) => (
+    <div className="fl-landing__context-group" key={label}>
+      <p className="fl-landing__context-group-label">
+        <span>{label}</span>
+        <span className="fl-landing__context-group-count">{items.length}</span>
+      </p>
+      {items.map(renderRow)}
+    </div>
+  );
+
   return (
     <div className="fl-landing">
       <div className="fl-landing__frame">
@@ -117,7 +164,12 @@ export function LandingPage({
                 <CardDescription>Continue from your active kubeconfig context.</CardDescription>
                 {currentContext && (
                   <CardAction>
-                    <Badge variant="secondary">Current</Badge>
+                    <span className="fl-landing__current-badges">
+                      {currentContext.isLocal && (
+                        <Badge variant="outline">{currentContext.provider ?? "local"}</Badge>
+                      )}
+                      <Badge variant="secondary">Current</Badge>
+                    </span>
                   </CardAction>
                 )}
               </CardHeader>
@@ -180,34 +232,15 @@ export function LandingPage({
                   <p className="fl-landing__empty">Reading kubeconfig…</p>
                 ) : error ? (
                   <p className="fl-landing__empty">Unable to load kube contexts.</p>
-                ) : filteredContexts.length > 0 ? (
-                  filteredContexts.map((context) => (
-                    <button
-                      key={context.name}
-                      type="button"
-                      className="fl-landing__context-row"
-                      onClick={() => onOpenContext(context.name)}
-                      aria-label={`Open context ${context.name}`}
-                    >
-                      <span className="fl-landing__context-main">
-                        <ContextAvatar
-                          context={context.name}
-                          profile={contextProfiles[context.name]}
-                          className="fl-landing__context-list-avatar"
-                        />
-                        <span>
-                          <strong>{contextDisplayName(context.name, contextProfiles[context.name])}</strong>
-                          <small>{context.cluster}</small>
-                        </span>
-                      </span>
-                      <span className="fl-landing__context-action" aria-hidden="true">
-                        {context.isCurrent && <small>Current</small>}
-                        <ArrowRight />
-                      </span>
-                    </button>
-                  ))
-                ) : (
+                ) : filteredContexts.length === 0 ? (
                   <p className="fl-landing__empty">No contexts match this filter.</p>
+                ) : grouped ? (
+                  <>
+                    {renderGroup("Local", localContexts)}
+                    {renderGroup("Remote", remoteContexts)}
+                  </>
+                ) : (
+                  filteredContexts.map(renderRow)
                 )}
               </div>
             </CardContent>

--- a/apps/desktop/src/lib/clusters.ts
+++ b/apps/desktop/src/lib/clusters.ts
@@ -5,6 +5,15 @@ export interface ClusterContext {
   cluster: string;
   server: string;
   isCurrent: boolean;
+  /**
+   * Whether this context points at a local development cluster (kind, k3d,
+   * minikube, docker-desktop, kiac, vind, …). Classified precision-first in the
+   * Rust core: only a tool-generated name earns it and cloud auth always wins
+   * as remote, so a production cluster is never marked local.
+   */
+  isLocal?: boolean;
+  /** The detected local provider (e.g. "kind", "vind"), when `isLocal`. */
+  provider?: string;
 }
 
 export interface ContextsOutcome {

--- a/apps/desktop/src/ui/styles.css
+++ b/apps/desktop/src/ui/styles.css
@@ -643,6 +643,13 @@ body {
   position: relative;
   border-radius: var(--fl-radius-md);
 }
+.fl-hotbar__divider {
+  width: 24px;
+  height: 1px;
+  margin: 4px auto;
+  flex: 0 0 auto;
+  background: var(--fl-color-border-faint);
+}
 .fl-hotbar__item--active::before {
   content: "";
   position: absolute;
@@ -3853,6 +3860,47 @@ body {
   justify-content: space-between;
   color: var(--fl-color-text-muted);
   font-size: 11px;
+}
+.fl-landing__context-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.fl-landing__context-group + .fl-landing__context-group {
+  margin-top: 14px;
+}
+.fl-landing__context-group-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 2px 2px 2px;
+  color: var(--fl-color-text-muted);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.fl-landing__context-group-count {
+  display: inline-flex;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 6px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: var(--fl-color-surface-alt);
+  color: var(--fl-color-text-muted);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0;
+}
+.fl-landing__context-badge {
+  text-transform: lowercase;
+}
+.fl-landing__current-badges {
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 .fl-landing__capabilities {
   display: grid;

--- a/crates/kube/src/contexts.rs
+++ b/crates/kube/src/contexts.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::client_cache::ClientCache;
 use crate::connect::load_kubeconfigs;
+use crate::local_cluster::classify;
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 #[serde(default)]
@@ -25,6 +26,16 @@ pub struct ContextDto {
     pub server: String,
     #[serde(rename = "isCurrent")]
     pub is_current: bool,
+    /// Whether this context points at a local development cluster (kind, k3d,
+    /// minikube, docker-desktop, kiac, vind, …). Classified precision-first:
+    /// only a tool-generated name earns this, and cloud auth always wins as
+    /// remote, so a production cluster is never marked local. See
+    /// [`crate::local_cluster`].
+    #[serde(rename = "isLocal")]
+    pub is_local: bool,
+    /// The detected local provider (e.g. `"kind"`, `"vind"`), when `isLocal`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -56,19 +67,35 @@ pub fn list_contexts_capability(cache: Arc<ClientCache>, default_paths: Vec<Path
                     .map_err(CapabilityError::Handler)?;
                 let current = config.current_context.unwrap_or_default();
                 let clusters = config.clusters;
+                let auth_infos = config.auth_infos;
                 let contexts = config.contexts.into_iter().map(|named| {
                     let context = named.context.unwrap_or_default();
                     let cluster_name = context.cluster;
+                    let user_name = context.user;
                     let server = clusters.iter()
                         .find(|cluster| cluster.name == cluster_name)
                         .and_then(|cluster| cluster.cluster.as_ref())
                         .and_then(|cluster| cluster.server.clone())
                         .unwrap_or_default();
+                    // Resolve the user's auth to gate cloud/managed clusters out
+                    // of the "local" bucket (see local_cluster::classify).
+                    let auth = auth_infos.iter()
+                        .find(|entry| entry.name == user_name)
+                        .and_then(|entry| entry.auth_info.as_ref());
+                    let exec_command = auth
+                        .and_then(|info| info.exec.as_ref())
+                        .and_then(|exec| exec.command.as_deref());
+                    let auth_provider = auth
+                        .and_then(|info| info.auth_provider.as_ref())
+                        .map(|provider| provider.name.as_str());
+                    let class = classify(&named.name, &cluster_name, &server, exec_command, auth_provider);
                     ContextDto {
                         is_current: named.name == current,
                         name: named.name,
                         cluster: cluster_name,
                         server,
+                        is_local: class.is_local,
+                        provider: class.provider.map(|provider| provider.as_str().to_string()),
                     }
                 }).collect();
                 Ok(ListContextsOut { contexts })
@@ -118,6 +145,57 @@ mod tests {
         reg.register(list_contexts_capability(ClientCache::new(path.clone()), vec![path]));
         let err = reg.invoke("k8s.listContexts", json!({})).await.unwrap_err();
         assert!(matches!(err, CapabilityError::Handler(_)));
+    }
+
+    #[tokio::test]
+    async fn classifies_local_and_remote_contexts() {
+        let dir = std::env::temp_dir();
+        let path = dir.join("srelens-classify-kubeconfig.yaml");
+        // A local kind cluster (client-cert auth) and a managed EKS cluster
+        // (aws exec plugin) side by side.
+        tokio::fs::write(
+            &path,
+            r#"apiVersion: v1
+kind: Config
+clusters:
+- name: kind-dev
+  cluster: { server: "https://127.0.0.1:6443" }
+- name: eks-prod
+  cluster: { server: "https://abc123.gr7.us-east-1.eks.amazonaws.com" }
+contexts:
+- name: kind-dev
+  context: { cluster: kind-dev, user: kind-dev }
+- name: eks-prod
+  context: { cluster: eks-prod, user: eks-prod }
+users:
+- name: kind-dev
+  user: { client-certificate-data: abc }
+- name: eks-prod
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      command: aws
+      args: ["eks", "get-token"]
+"#,
+        )
+        .await
+        .unwrap();
+
+        let mut reg = Registry::new();
+        reg.register(list_contexts_capability(ClientCache::new(path.clone()), vec![path.clone()]));
+        let out = reg.invoke("k8s.listContexts", json!({})).await.unwrap();
+        let contexts = out["contexts"].as_array().unwrap();
+
+        let kind = contexts.iter().find(|c| c["name"] == "kind-dev").unwrap();
+        assert_eq!(kind["isLocal"], true);
+        assert_eq!(kind["provider"], "kind");
+
+        // Managed EKS: remote despite reachability, and `provider` is omitted.
+        let eks = contexts.iter().find(|c| c["name"] == "eks-prod").unwrap();
+        assert_eq!(eks["isLocal"], false);
+        assert!(eks["provider"].is_null());
+
+        let _ = tokio::fs::remove_file(&path).await;
     }
 
     #[tokio::test]

--- a/crates/kube/src/contexts.rs
+++ b/crates/kube/src/contexts.rs
@@ -150,7 +150,8 @@ mod tests {
     #[tokio::test]
     async fn classifies_local_and_remote_contexts() {
         let dir = std::env::temp_dir();
-        let path = dir.join("srelens-classify-kubeconfig.yaml");
+        // Unique per process so concurrent test runs don't collide on the path.
+        let path = dir.join(format!("srelens-classify-kubeconfig-{}.yaml", std::process::id()));
         // A local kind cluster (client-cert auth) and a managed EKS cluster
         // (aws exec plugin) side by side.
         tokio::fs::write(

--- a/crates/kube/src/lib.rs
+++ b/crates/kube/src/lib.rs
@@ -109,6 +109,7 @@ pub mod ingresses;
 pub mod jobs;
 pub mod kubeconfig;
 pub mod limitranges;
+pub mod local_cluster;
 pub mod logs;
 pub mod manifest;
 pub mod metrics;

--- a/crates/kube/src/local_cluster.rs
+++ b/crates/kube/src/local_cluster.rs
@@ -135,14 +135,17 @@ const CLOUD_AUTH_PROVIDERS: &[&str] = &["gcp", "azure", "oidc"];
 /// vind) all use embedded client certs or tokens, never these.
 fn is_cloud_auth(exec_command: Option<&str>, auth_provider: Option<&str>) -> bool {
     if let Some(cmd) = exec_command {
-        // The command may be an absolute path; compare on its basename.
-        let base = cmd.rsplit(['/', '\\']).next().unwrap_or(cmd).trim();
+        // The command may be an absolute path and, on Windows, carry a `.exe`
+        // suffix or mixed case; compare on its lowercased basename.
+        let base = cmd.rsplit(['/', '\\']).next().unwrap_or(cmd).trim().to_ascii_lowercase();
+        let base = base.strip_suffix(".exe").unwrap_or(&base);
         if CLOUD_EXEC_COMMANDS.contains(&base) {
             return true;
         }
     }
     if let Some(provider) = auth_provider {
-        if CLOUD_AUTH_PROVIDERS.contains(&provider.trim()) {
+        let provider = provider.trim().to_ascii_lowercase();
+        if CLOUD_AUTH_PROVIDERS.contains(&provider.as_str()) {
             return true;
         }
     }
@@ -183,10 +186,6 @@ fn host_is_public(server: &str) -> bool {
     {
         return false;
     }
-    // IPv6 loopback.
-    if host == "::1" {
-        return false;
-    }
     // IPv4 ranges.
     if let Some(v4) = parse_ipv4(&host) {
         let [a, b, ..] = v4;
@@ -198,8 +197,21 @@ fn host_is_public(server: &str) -> bool {
             || v4 == [0, 0, 0, 0]; // 0.0.0.0
         return !is_private;
     }
-    // A non-IPv4, non-local hostname (e.g. *.eks.amazonaws.com) is public.
-    // IPv6 non-loopback is also treated as public.
+    // IPv6 ranges, mirroring the IPv4 private handling: loopback (::1),
+    // unspecified (::), unique-local (fc00::/7), and link-local unicast
+    // (fe80::/10) are non-public. (std's is_unique_local/is_unicast_link_local
+    // are still unstable, so match the prefixes on the leading segment.)
+    if let Ok(v6) = host.parse::<std::net::Ipv6Addr>() {
+        if v6.is_loopback() || v6.is_unspecified() {
+            return false;
+        }
+        let first = v6.segments()[0];
+        let is_unique_local = (first & 0xfe00) == 0xfc00; // fc00::/7
+        let is_link_local = (first & 0xffc0) == 0xfe80; // fe80::/10
+        return !(is_unique_local || is_link_local);
+    }
+    // A non-IPv4, non-IPv6, non-local hostname (e.g. *.eks.amazonaws.com) is
+    // public.
     true
 }
 
@@ -364,6 +376,13 @@ mod tests {
             Some("gcp"),
         );
         assert_eq!(got, Classification::remote());
+        // Windows kubeconfigs: `.exe` suffix and mixed case still gate.
+        for cmd in ["aws.exe", "AWS", "C:\\bin\\Az.EXE", "gke-gcloud-auth-plugin.exe"] {
+            let got = classify("kind-win", "kind-win", "https://127.0.0.1:6443", Some(cmd), None);
+            assert_eq!(got, Classification::remote(), "exec {cmd} should gate to remote");
+        }
+        let got = classify("kind-x", "kind-x", "https://localhost:6443", None, Some("GCP"));
+        assert_eq!(got, Classification::remote());
     }
 
     #[test]
@@ -398,6 +417,19 @@ mod tests {
         assert!(local("kind-v6", "https://[::1]:6443").is_local);
         assert_eq!(
             local("kind-v6", "https://[2001:db8::1]:6443"),
+            Classification::remote()
+        );
+    }
+
+    #[test]
+    fn ipv6_private_ranges_are_not_public() {
+        // Unique-local (fc00::/7) and link-local (fe80::/10) mirror the IPv4
+        // private ranges: a local-looking name over them stays local.
+        assert!(local("kind-ula", "https://[fd12:3456::1]:6443").is_local);
+        assert!(local("kind-ll", "https://[fe80::1]:6443").is_local);
+        // A global-unicast v6 address still demotes a local-looking name.
+        assert_eq!(
+            local("kind-gua", "https://[2606:4700::1111]:6443"),
             Classification::remote()
         );
     }

--- a/crates/kube/src/local_cluster.rs
+++ b/crates/kube/src/local_cluster.rs
@@ -1,0 +1,415 @@
+//! Precision-first classification of kube contexts into local vs remote.
+//!
+//! The guiding rule: **never tag a production cluster as local.** Detection is
+//! therefore biased toward precision, not recall:
+//!
+//! 1. A cluster earns `is_local` **only** from a tool-generated context/cluster
+//!    name signature. Its network address alone never promotes it.
+//! 2. Cloud authentication (an `aws`/`gcloud`/`az`/`kubelogin` exec plugin, or a
+//!    `gcp`/`azure`/`oidc` auth provider) is a hard gate: it forces `remote`
+//!    even when the server is a loopback address (e.g. a port-forwarded EKS).
+//! 3. The server address is only allowed to *demote*: a public host cancels a
+//!    local-looking name. A private/loopback host never promotes on its own.
+//!
+//! Anything we are unsure about stays remote. The heuristic is always
+//! overridable by the user in the UI.
+
+use serde::Serialize;
+
+/// A recognised local-cluster provider. Serialised as its wire string (see
+/// [`LocalProvider::as_str`]) for the `provider` field of a context.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(into = "String")]
+pub enum LocalProvider {
+    Kind,
+    K3d,
+    Minikube,
+    Microk8s,
+    DockerDesktop,
+    RancherDesktop,
+    Colima,
+    Orbstack,
+    /// Kubernetes in Apple Containers (github.com/saiyam1814/kiac).
+    Kiac,
+    /// vCluster in Docker — `vcluster create <name> --driver docker` (vind).
+    Vind,
+}
+
+impl LocalProvider {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            LocalProvider::Kind => "kind",
+            LocalProvider::K3d => "k3d",
+            LocalProvider::Minikube => "minikube",
+            LocalProvider::Microk8s => "microk8s",
+            LocalProvider::DockerDesktop => "docker-desktop",
+            LocalProvider::RancherDesktop => "rancher-desktop",
+            LocalProvider::Colima => "colima",
+            LocalProvider::Orbstack => "orbstack",
+            LocalProvider::Kiac => "kiac",
+            LocalProvider::Vind => "vind",
+        }
+    }
+}
+
+impl From<LocalProvider> for String {
+    fn from(value: LocalProvider) -> Self {
+        value.as_str().to_string()
+    }
+}
+
+/// The outcome of classifying a single context.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Classification {
+    pub is_local: bool,
+    /// The detected local provider, present only when `is_local` is true.
+    pub provider: Option<LocalProvider>,
+}
+
+impl Classification {
+    fn remote() -> Self {
+        Classification {
+            is_local: false,
+            provider: None,
+        }
+    }
+}
+
+/// Match a single name against the known tool-generated signatures.
+///
+/// Both the context name and the cluster name are checked by the caller, since
+/// tools such as kind, kiac and vind name every entry identically.
+fn provider_from_name(name: &str) -> Option<LocalProvider> {
+    let n = name.trim();
+    // Prefixed, per-cluster names.
+    if n.starts_with("kind-") {
+        return Some(LocalProvider::Kind);
+    }
+    if n.starts_with("k3d-") {
+        return Some(LocalProvider::K3d);
+    }
+    if n.starts_with("kiac-") {
+        return Some(LocalProvider::Kiac);
+    }
+    // vind: `vcluster create <name> --driver docker` writes `vcluster-docker_<name>`.
+    // NB: the helm/platform drivers write `vcluster_<name>_<ns>_<host-context>`,
+    // which is deliberately NOT matched — that tenant cluster may live in a
+    // production host cluster and must stay remote.
+    if n.starts_with("vcluster-docker_") {
+        return Some(LocalProvider::Vind);
+    }
+    if n == "colima" || n.starts_with("colima-") {
+        return Some(LocalProvider::Colima);
+    }
+    // Fixed, single-cluster names.
+    match n {
+        "minikube" => Some(LocalProvider::Minikube),
+        "microk8s" => Some(LocalProvider::Microk8s),
+        "docker-desktop" | "docker-for-desktop" => Some(LocalProvider::DockerDesktop),
+        "rancher-desktop" => Some(LocalProvider::RancherDesktop),
+        "orbstack" => Some(LocalProvider::Orbstack),
+        _ => None,
+    }
+}
+
+/// Exec-plugin command basenames that indicate a managed/cloud cluster.
+const CLOUD_EXEC_COMMANDS: &[&str] = &[
+    "aws",
+    "aws-iam-authenticator",
+    "gcloud",
+    "gke-gcloud-auth-plugin",
+    "az",
+    "kubelogin",
+    "kubectl-oidc_login",
+    "oidc-login",
+    "doctl",
+    "linode-cli",
+    "tsh",
+];
+
+/// Auth-provider names (the legacy `auth-provider` field) that indicate cloud.
+const CLOUD_AUTH_PROVIDERS: &[&str] = &["gcp", "azure", "oidc"];
+
+/// Whether the context's user authenticates via a cloud/managed mechanism.
+/// Local tools (kind, k3d, minikube, docker-desktop, rancher-desktop, kiac,
+/// vind) all use embedded client certs or tokens, never these.
+fn is_cloud_auth(exec_command: Option<&str>, auth_provider: Option<&str>) -> bool {
+    if let Some(cmd) = exec_command {
+        // The command may be an absolute path; compare on its basename.
+        let base = cmd.rsplit(['/', '\\']).next().unwrap_or(cmd).trim();
+        if CLOUD_EXEC_COMMANDS.contains(&base) {
+            return true;
+        }
+    }
+    if let Some(provider) = auth_provider {
+        if CLOUD_AUTH_PROVIDERS.contains(&provider.trim()) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Extract the host portion of a `scheme://host:port/...` server URL.
+fn host_of(server: &str) -> &str {
+    let after_scheme = match server.find("://") {
+        Some(i) => &server[i + 3..],
+        None => server,
+    };
+    // Strip path/query, then the port. IPv6 hosts are bracketed: [::1]:6443.
+    let authority = after_scheme
+        .split(['/', '?'])
+        .next()
+        .unwrap_or(after_scheme);
+    if let Some(rest) = authority.strip_prefix('[') {
+        // [ipv6]:port -> ipv6
+        return rest.split(']').next().unwrap_or(rest);
+    }
+    authority.split(':').next().unwrap_or(authority)
+}
+
+/// Whether the server host is a routable public address. Empty/unparseable
+/// hosts return false (we do not demote on missing information). Loopback,
+/// RFC1918 private ranges, link-local, and `*.internal`/`*.local` names are
+/// treated as non-public (consistent with a local cluster).
+fn host_is_public(server: &str) -> bool {
+    let host = host_of(server).trim().to_ascii_lowercase();
+    if host.is_empty() {
+        return false;
+    }
+    if host == "localhost"
+        || host.ends_with(".localhost")
+        || host.ends_with(".internal")
+        || host.ends_with(".local")
+    {
+        return false;
+    }
+    // IPv6 loopback.
+    if host == "::1" {
+        return false;
+    }
+    // IPv4 ranges.
+    if let Some(v4) = parse_ipv4(&host) {
+        let [a, b, ..] = v4;
+        let is_private = a == 127 // loopback 127.0.0.0/8
+            || a == 10 // 10.0.0.0/8
+            || (a == 192 && b == 168) // 192.168.0.0/16
+            || (a == 172 && (16..=31).contains(&b)) // 172.16.0.0/12
+            || (a == 169 && b == 254) // 169.254.0.0/16 link-local
+            || v4 == [0, 0, 0, 0]; // 0.0.0.0
+        return !is_private;
+    }
+    // A non-IPv4, non-local hostname (e.g. *.eks.amazonaws.com) is public.
+    // IPv6 non-loopback is also treated as public.
+    true
+}
+
+/// Parse a dotted IPv4 string into four octets, or `None` if it is not one.
+fn parse_ipv4(host: &str) -> Option<[u8; 4]> {
+    let mut octets = [0u8; 4];
+    let mut count = 0;
+    for part in host.split('.') {
+        if count == 4 {
+            return None;
+        }
+        octets[count] = part.parse::<u8>().ok()?;
+        count += 1;
+    }
+    if count == 4 {
+        Some(octets)
+    } else {
+        None
+    }
+}
+
+/// Classify a context. Pure and dependency-free so it can be exhaustively
+/// unit-tested; the capability layer supplies the strings from the kubeconfig.
+///
+/// - `context_name` / `cluster_name`: the two names to match signatures against.
+/// - `server`: the cluster's API server URL (used only to demote).
+/// - `exec_command`: the user's `exec` auth plugin command, if any.
+/// - `auth_provider`: the user's legacy `auth-provider` name, if any.
+pub fn classify(
+    context_name: &str,
+    cluster_name: &str,
+    server: &str,
+    exec_command: Option<&str>,
+    auth_provider: Option<&str>,
+) -> Classification {
+    let provider = provider_from_name(context_name).or_else(|| provider_from_name(cluster_name));
+    let Some(provider) = provider else {
+        // No local signature -> remote. We never promote from address alone.
+        return Classification::remote();
+    };
+    // Hard gate: cloud auth wins over any name.
+    if is_cloud_auth(exec_command, auth_provider) {
+        return Classification::remote();
+    }
+    // The address may only demote: a public host cancels the local guess.
+    if host_is_public(server) {
+        return Classification::remote();
+    }
+    Classification {
+        is_local: true,
+        provider: Some(provider),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn local(name: &str, server: &str) -> Classification {
+        classify(name, name, server, None, None)
+    }
+
+    #[test]
+    fn recognises_each_local_provider_by_name() {
+        let cases: &[(&str, &str, LocalProvider)] = &[
+            ("kind-dev", "https://127.0.0.1:6443", LocalProvider::Kind),
+            ("k3d-demo", "https://0.0.0.0:52000", LocalProvider::K3d),
+            (
+                "minikube",
+                "https://192.168.49.2:8443",
+                LocalProvider::Minikube,
+            ),
+            (
+                "microk8s",
+                "https://127.0.0.1:16443",
+                LocalProvider::Microk8s,
+            ),
+            (
+                "docker-desktop",
+                "https://kubernetes.docker.internal:6443",
+                LocalProvider::DockerDesktop,
+            ),
+            (
+                "docker-for-desktop",
+                "https://localhost:6443",
+                LocalProvider::DockerDesktop,
+            ),
+            (
+                "rancher-desktop",
+                "https://127.0.0.1:6443",
+                LocalProvider::RancherDesktop,
+            ),
+            ("colima", "https://127.0.0.1:6443", LocalProvider::Colima),
+            (
+                "colima-work",
+                "https://127.0.0.1:6443",
+                LocalProvider::Colima,
+            ),
+            (
+                "orbstack",
+                "https://127.0.0.1:26443",
+                LocalProvider::Orbstack,
+            ),
+            (
+                "kiac-demo",
+                "https://192.168.64.5:6443",
+                LocalProvider::Kiac,
+            ),
+            (
+                "vcluster-docker_demo",
+                "https://localhost:13755",
+                LocalProvider::Vind,
+            ),
+        ];
+        for (name, server, want) in cases {
+            let got = local(name, server);
+            assert!(got.is_local, "{name} should be local");
+            assert_eq!(got.provider, Some(*want), "{name} provider");
+        }
+    }
+
+    #[test]
+    fn unknown_names_default_to_remote() {
+        // On-prem prod on a private IP, but no local signature -> remote.
+        assert_eq!(
+            local("production", "https://10.0.0.5:6443"),
+            Classification::remote()
+        );
+        assert_eq!(
+            local("prod-eu", "https://127.0.0.1:6443"),
+            Classification::remote()
+        );
+        assert_eq!(local("", ""), Classification::remote());
+    }
+
+    #[test]
+    fn cloud_auth_forces_remote_even_with_local_name() {
+        // A port-forwarded EKS reachable on localhost, but auth is `aws`.
+        let got = classify(
+            "kind-tunnel",
+            "kind-tunnel",
+            "https://127.0.0.1:6443",
+            Some("aws"),
+            None,
+        );
+        assert_eq!(got, Classification::remote());
+        // Absolute exec path is compared on its basename.
+        let got = classify(
+            "kind-tunnel",
+            "kind-tunnel",
+            "https://127.0.0.1:6443",
+            Some("/opt/homebrew/bin/gke-gcloud-auth-plugin"),
+            None,
+        );
+        assert_eq!(got, Classification::remote());
+        // Legacy auth-provider (gcp/oidc) also gates.
+        let got = classify(
+            "kind-x",
+            "kind-x",
+            "https://localhost:6443",
+            None,
+            Some("gcp"),
+        );
+        assert_eq!(got, Classification::remote());
+    }
+
+    #[test]
+    fn public_host_demotes_a_local_looking_name() {
+        // A local-looking name pointed at a public address is cancelled.
+        let got = local("kind-weird", "https://34.120.1.2:443");
+        assert_eq!(got, Classification::remote());
+        let got = local("kind-weird", "https://my-cluster.eks.amazonaws.com");
+        assert_eq!(got, Classification::remote());
+    }
+
+    #[test]
+    fn helm_or_platform_vcluster_stays_remote() {
+        // Only the docker driver (`vcluster-docker_`) is local. A tenant cluster
+        // in a host cluster is `vcluster_<name>_<ns>_<host-context>`.
+        assert_eq!(
+            local("vcluster_demo_default_prod-eks", "https://localhost:8443"),
+            Classification::remote()
+        );
+    }
+
+    #[test]
+    fn matches_on_cluster_name_when_context_is_renamed() {
+        // Context renamed, but the cluster still carries the signature.
+        let got = classify("my-alias", "kind-dev", "https://127.0.0.1:6443", None, None);
+        assert!(got.is_local);
+        assert_eq!(got.provider, Some(LocalProvider::Kind));
+    }
+
+    #[test]
+    fn ipv6_loopback_is_local_public_ipv6_is_not() {
+        assert!(local("kind-v6", "https://[::1]:6443").is_local);
+        assert_eq!(
+            local("kind-v6", "https://[2001:db8::1]:6443"),
+            Classification::remote()
+        );
+    }
+
+    #[test]
+    fn host_parsing_handles_ports_paths_and_schemes() {
+        assert_eq!(host_of("https://127.0.0.1:6443"), "127.0.0.1");
+        assert_eq!(
+            host_of("https://kubernetes.docker.internal:6443/foo"),
+            "kubernetes.docker.internal"
+        );
+        assert_eq!(host_of("[::1]:6443"), "::1");
+        assert_eq!(host_of("localhost"), "localhost");
+    }
+}


### PR DESCRIPTION
## What

Detects **local development clusters** and keeps them from mixing with remote/production contexts — end to end, from the Rust core through the UI. Classification lives on `ContextDto` in the `k8s.listContexts` capability, so both the desktop app and MCP agents see it.

## Detection rule (bias: never tag a production cluster as local)

1. **A tool-generated name is the only promoter.** A context is local only when its context/cluster name matches a known signature:

   | Provider | Signature |
   |---|---|
   | kind | `kind-*` |
   | k3d | `k3d-*` |
   | minikube | `minikube` |
   | microk8s | `microk8s` |
   | docker desktop | `docker-desktop` / `docker-for-desktop` |
   | rancher desktop | `rancher-desktop` |
   | colima / orbstack | `colima*` / `orbstack` |
   | kiac (Kubernetes in Apple Containers) | `kiac-*` |
   | vind (vCluster in Docker) | `vcluster-docker_*` |

2. **Cloud auth forces remote.** An `aws` / `gcloud` / `gke-gcloud-auth-plugin` / `az` / `kubelogin` exec plugin, or a `gcp` / `azure` / `oidc` auth-provider, marks the context remote even when the server is on `localhost` (e.g. a port-forwarded EKS).
3. **A public server address only demotes.** A public host cancels a local-looking name; a private/loopback host never promotes on its own.
4. **Unsure ⇒ remote.** On-prem prod on `10.x` stays remote (no local name). Helm/platform vCluster tenant contexts (`vcluster_<name>_<ns>_<host>`) are deliberately **not** matched — only the docker driver (`vcluster-docker_`) is local — so a tenant cluster in a production host cluster is never mistaken for local.

Signatures for **kiac** and **vind** were confirmed from source (`kiac` kubeconfig writer; `loft-sh/vcluster` `pkg/cli/connect_docker.go`).

## Changes

**Core (`crates/kube`)**
- New `local_cluster.rs`: pure `classify(context, cluster, server, exec_command, auth_provider)`.
- `ContextDto` gains `isLocal` + `provider`, wired into `k8s.listContexts` (now reads `auth_infos` for the cloud-auth gate).

**Desktop UI (`apps/desktop`)**
- `ClusterContext` mirrors `isLocal`/`provider`.
- **Landing page**: when both kinds are present, the context list splits into labelled **Local** and **Remote** sections with counts; each local row (and the current-context card) shows the detected provider as a badge. A single-kind list is unchanged.
- **Cluster hotbar**: remote avatars, a divider, then local avatars; local titles are suffixed `(local)`.

## Tests
- `local_cluster.rs`: table-driven unit tests per provider, the cloud-auth gate, public-host demotion, helm/platform vCluster staying remote, IPv6 loopback, URL host parsing.
- `contexts.rs`: end-to-end capability test (local kind + managed EKS) asserting `isLocal`/`provider` on the emitted JSON.
- `LandingPage.test.tsx` / `ClusterHotbar.test.tsx`: assert the group labels, provider badge, and hotbar separator render.

Verified locally: `cargo test -p srelens-kube` (123 pass), `pnpm build`, `pnpm -r test` (411 pass) — all green.

## Not included (deliberately deferred)
Manual per-context override (force local/remote) and dev/test/stage/prod tiers — those build on the same field and can follow if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
