### PR TITLE
feat: apply flows — server-side apply, dry-run diff, conflict surfacing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3950,6 +3950,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4070,6 +4076,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "similar",
  "srelens-capability",
  "thiserror 1.0.69",
  "tokio",

--- a/apps/desktop/src-tauri/src/capabilities.rs
+++ b/apps/desktop/src-tauri/src/capabilities.rs
@@ -143,6 +143,7 @@ pub fn build_registry_with(cache: Arc<ClientCache>) -> Registry {
     reg.register(srelens_kube::secrets::get_secret_capability(cache.clone()));
     reg.register(srelens_kube::manifest::apply_manifest_capability(cache.clone()));
     reg.register(srelens_kube::manifest::validate_manifest_capability(cache.clone()));
+    reg.register(srelens_kube::manifest::diff_manifest_capability(cache.clone()));
     reg.register(srelens_kube::schema::open_api_schema_capability(cache.clone()));
     reg.register(srelens_kube::crds::list_crds_capability(cache.clone()));
     reg.register(srelens_kube::crds::list_custom_resource_capability(cache.clone()));

--- a/apps/desktop/src/components/DiffView.test.tsx
+++ b/apps/desktop/src/components/DiffView.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { DiffView } from "./DiffView";
+import type { DiffDoc } from "../lib/manifest";
+
+function doc(rows: DiffDoc["rows"], over: Partial<DiffDoc> = {}): DiffDoc {
+  return { kind: "ConfigMap", name: "a", namespace: "d", exists: true, changed: true, rows, currentResourceVersion: "1", ...over };
+}
+
+describe("DiffView", () => {
+  it("renders changed lines on both sides", () => {
+    render(
+      <DiffView doc={doc([
+        { tag: "same", left: "spec:", right: "spec:" },
+        { tag: "replace", left: "  replicas: 3", right: "  replicas: 5" },
+        { tag: "insert", left: null, right: "  paused: true" },
+        { tag: "delete", left: "  old: 1", right: null },
+      ])} />,
+    );
+    expect(screen.getByText("replicas: 3", { exact: false })).toBeDefined();
+    expect(screen.getByText("replicas: 5", { exact: false })).toBeDefined();
+    expect(screen.getByText("paused: true", { exact: false })).toBeDefined();
+    expect(screen.getByText("old: 1", { exact: false })).toBeDefined();
+  });
+
+  it("shows a no-changes state", () => {
+    render(<DiffView doc={doc([{ tag: "same", left: "a", right: "a" }], { changed: false })} />);
+    expect(screen.getByText(/no changes/i)).toBeDefined();
+  });
+
+  it("labels a create", () => {
+    render(<DiffView doc={doc([{ tag: "insert", left: null, right: "a" }], { exists: false })} />);
+    expect(screen.getByText(/new resource/i)).toBeDefined();
+  });
+});

--- a/apps/desktop/src/components/DiffView.tsx
+++ b/apps/desktop/src/components/DiffView.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import type { DiffDoc } from "../lib/manifest";
+
+/**
+ * Side-by-side render of one document's dry-run diff: current (live) lines on
+ * the left, proposed on the right, with insert/delete/replace rows highlighted
+ * and unchanged rows dimmed. Pure — driven entirely by `doc.rows`.
+ */
+export function DiffView({ doc }: { doc: DiffDoc }) {
+  const header = (
+    <div className="fl-diff__title">
+      <span className="font-medium">
+        {doc.kind}/{doc.name}
+      </span>
+      {doc.namespace && <span className="text-xs text-muted-foreground"> · {doc.namespace}</span>}
+      {!doc.exists && <span className="fl-diff__badge fl-diff__badge--new">New resource</span>}
+    </div>
+  );
+
+  if (doc.exists && !doc.changed) {
+    return (
+      <div className="fl-diff">
+        {header}
+        <p className="fl-diff__empty">No changes</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="fl-diff">
+      {header}
+      <table className="fl-diff__table">
+        <tbody>
+          {doc.rows.map((row, i) => (
+            <tr key={i} className={`fl-diff__row fl-diff__row--${row.tag}`}>
+              <td className="fl-diff__cell fl-diff__cell--left">{row.left ?? ""}</td>
+              <td className="fl-diff__cell fl-diff__cell--right">{row.right ?? ""}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/ManifestEditor.test.tsx
+++ b/apps/desktop/src/components/ManifestEditor.test.tsx
@@ -1,14 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import React, { useState } from "react";
 
-const { applyManifestMock, notifyMock } = vi.hoisted(() => ({
+const { applyManifestMock, diffManifestMock, notifyMock } = vi.hoisted(() => ({
   applyManifestMock: vi.fn(),
+  diffManifestMock: vi.fn(),
   notifyMock: { success: vi.fn(), error: vi.fn(), info: vi.fn(), updateAvailable: vi.fn() },
 }));
 vi.mock("../lib/manifest", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../lib/manifest")>()),
   applyManifest: applyManifestMock,
+  diffManifest: diffManifestMock,
   validateManifest: vi.fn().mockResolvedValue({ valid: true }),
 }));
 vi.mock("../lib/notify", () => ({ notify: notifyMock }));
@@ -36,21 +38,23 @@ function Harness({ mode }: { mode: "create" | "edit" }) {
 
 beforeEach(() => {
   applyManifestMock.mockReset();
+  diffManifestMock.mockReset();
+  diffManifestMock.mockResolvedValue({ documents: [] });
   notifyMock.success.mockReset();
   notifyMock.error.mockReset();
 });
 
 describe("ManifestEditor", () => {
   it("create mode applies immediately (no confirm) and toasts success", async () => {
-    applyManifestMock.mockResolvedValue({ kind: "ConfigMap", name: "web" });
+    applyManifestMock.mockResolvedValue({ applied: true, documents: [{ kind: "ConfigMap", name: "web", applied: true }] });
     render(<Harness mode="create" />);
     fireEvent.click(screen.getByRole("button", { name: "Create" }));
-    await waitFor(() => expect(applyManifestMock).toHaveBeenCalledWith("kind-dev", expect.stringContaining("ConfigMap")));
+    await waitFor(() => expect(applyManifestMock).toHaveBeenCalledWith("kind-dev", expect.stringContaining("ConfigMap"), false));
     expect(notifyMock.success).toHaveBeenCalled();
   });
 
   it("edit mode confirms before applying", async () => {
-    applyManifestMock.mockResolvedValue({ kind: "ConfigMap", name: "web" });
+    applyManifestMock.mockResolvedValue({ applied: true, documents: [{ kind: "ConfigMap", name: "web", applied: true }] });
     render(<Harness mode="edit" />);
     fireEvent.click(screen.getByRole("button", { name: "Apply" }));
     // Apply doesn't fire until the confirm dialog is accepted.
@@ -67,5 +71,117 @@ describe("ManifestEditor", () => {
     render(<Harness mode="create" />);
     fireEvent.click(screen.getByRole("button", { name: "Create" }));
     await waitFor(() => expect(notifyMock.error).toHaveBeenCalled());
+  });
+
+  it("offers Force apply on a conflict, then re-applies with force", async () => {
+    applyManifestMock
+      .mockResolvedValueOnce({
+        applied: false,
+        documents: [
+          {
+            kind: "Deployment",
+            name: "web",
+            applied: false,
+            conflict: { managers: ["kubectl"], fields: [".spec.replicas"], message: "conflict" },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ applied: true, documents: [{ kind: "Deployment", name: "web", applied: true }] });
+
+    render(
+      <ManifestEditor
+        context="ctx"
+        yaml={'apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: web\n  resourceVersion: "1"\n'}
+        onYamlChange={() => {}}
+        fill
+        confirm={{ kind: "Deployment", name: "web" }}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await waitFor(() => expect(screen.getByText("Apply manifest?")).toBeDefined());
+    fireEvent.click(screen.getByRole("button", { name: "Apply" })); // confirm dialog's — outside content is aria-hidden
+    const force = await screen.findByRole("button", { name: /force apply/i });
+    expect(screen.getByText(/kubectl/)).toBeDefined();
+    fireEvent.click(force);
+    await waitFor(() => expect(applyManifestMock).toHaveBeenLastCalledWith("ctx", expect.any(String), true));
+  });
+
+  it("drawer (non-fill) surfaces conflicts too: Force apply appears and re-applies with force", async () => {
+    applyManifestMock
+      .mockResolvedValueOnce({
+        applied: false,
+        documents: [
+          {
+            kind: "Deployment",
+            name: "web",
+            applied: false,
+            conflict: { managers: ["kubectl"], fields: [".spec.replicas"], message: "conflict" },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ applied: true, documents: [{ kind: "Deployment", name: "web", applied: true }] });
+
+    render(
+      <ManifestEditor
+        context="ctx"
+        yaml={'apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: web\n  resourceVersion: "1"\n'}
+        onYamlChange={() => {}}
+        confirm={{ kind: "Deployment", name: "web" }}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await waitFor(() => expect(screen.getByText("Apply manifest?")).toBeDefined());
+    fireEvent.click(screen.getByRole("button", { name: "Apply" })); // confirm dialog's — outside content is aria-hidden
+    const force = await screen.findByRole("button", { name: /force apply/i });
+    expect(screen.getByText(/kubectl/)).toBeDefined();
+    fireEvent.click(force);
+    await waitFor(() => expect(applyManifestMock).toHaveBeenLastCalledWith("ctx", expect.any(String), true));
+  });
+
+  it("multi-doc conflict banner names each conflicting document, not the applied one", async () => {
+    applyManifestMock.mockResolvedValue({
+      applied: false,
+      documents: [
+        { kind: "Deployment", name: "web", applied: true },
+        {
+          kind: "ConfigMap",
+          name: "cfg",
+          applied: false,
+          conflict: { managers: ["kubectl"], fields: [".data.x"], message: "conflict on cfg" },
+        },
+      ],
+    });
+    render(
+      <ManifestEditor
+        context="ctx"
+        yaml={"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cfg\n"}
+        onYamlChange={() => {}}
+        fill
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    const banner = await screen.findByRole("alert");
+    expect(within(banner).getByText(/ConfigMap\/cfg/)).toBeDefined();
+    expect(within(banner).queryByText(/Deployment\/web/)).toBeNull();
+    expect(within(banner).getByText(/kubectl/)).toBeDefined();
+    expect(within(banner).getByTitle(/conflict on cfg/)).toBeDefined();
+  });
+
+  it("shows a stale badge when the live resourceVersion differs", async () => {
+    diffManifestMock.mockResolvedValue({
+      documents: [
+        { kind: "Deployment", name: "web", namespace: null, exists: true, changed: true, rows: [], currentResourceVersion: "9" },
+      ],
+    });
+    render(
+      <ManifestEditor
+        context="ctx"
+        yaml={'apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: web\n  resourceVersion: "1"\n'}
+        onYamlChange={() => {}}
+        fill
+        confirm={{ kind: "Deployment", name: "web" }}
+      />,
+    );
+    expect(await screen.findByText(/changed elsewhere/i, {}, { timeout: 2000 })).toBeDefined();
   });
 });

--- a/apps/desktop/src/components/ManifestEditor.test.tsx
+++ b/apps/desktop/src/components/ManifestEditor.test.tsx
@@ -182,6 +182,35 @@ describe("ManifestEditor", () => {
         confirm={{ kind: "Deployment", name: "web" }}
       />,
     );
+    fireEvent.click(screen.getByRole("button", { name: "Changes" }));
     expect(await screen.findByText(/changed elsewhere/i, {}, { timeout: 2000 })).toBeDefined();
+  });
+
+  it("fill mode: diff pane is hidden by default; Changes reveals a resizable split, Hide changes collapses it", async () => {
+    const { container } = render(
+      <ManifestEditor
+        context="ctx"
+        yaml={"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cfg\n"}
+        onYamlChange={() => {}}
+        fill
+      />,
+    );
+    // Hidden by default: full-width editor, no diff content, no resize handle.
+    expect(screen.queryByText("No changes")).toBeNull();
+    expect(container.querySelector(".fl-changes-panel__resize")).toBeNull();
+    expect(container.querySelector(".fl-changes-panel")).toBeNull();
+    expect(screen.getByRole("button", { name: "Changes" })).toBeDefined();
+
+    fireEvent.click(screen.getByRole("button", { name: "Changes" }));
+    await waitFor(() => expect(diffManifestMock).toHaveBeenCalled());
+    expect(await screen.findByText("No changes")).toBeDefined();
+    expect(container.querySelector(".fl-changes-panel__resize")).not.toBeNull();
+    expect(container.querySelector(".fl-changes-panel")).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Hide changes" })).toBeDefined();
+
+    fireEvent.click(screen.getByRole("button", { name: "Hide changes" }));
+    expect(screen.queryByText("No changes")).toBeNull();
+    expect(container.querySelector(".fl-changes-panel__resize")).toBeNull();
+    expect(container.querySelector(".fl-changes-panel")).toBeNull();
   });
 });

--- a/apps/desktop/src/components/ManifestEditor.test.tsx
+++ b/apps/desktop/src/components/ManifestEditor.test.tsx
@@ -191,6 +191,90 @@ describe("ManifestEditor", () => {
     expect(screen.getByRole("button", { name: "Changes" })).toBeDefined();
   });
 
+  it("surfaces a hard error even when another document conflicts (first response)", async () => {
+    applyManifestMock.mockResolvedValue({
+      applied: false,
+      documents: [
+        {
+          kind: "ConfigMap",
+          name: "cfg",
+          applied: false,
+          conflict: { managers: ["kubectl"], fields: [".data.x"], message: "conflict on cfg" },
+        },
+        { kind: "Deployment", name: "web", applied: false, error: "deploy blew up" },
+      ],
+    });
+    render(
+      <ManifestEditor
+        context="ctx"
+        yaml={"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cfg\n"}
+        onYamlChange={() => {}}
+        fill
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    // The conflict banner appears for the conflicting document…
+    const banner = await screen.findByRole("alert");
+    expect(within(banner).getByText(/ConfigMap\/cfg/)).toBeDefined();
+    // …AND the OTHER document's hard error is surfaced on the same response,
+    // not swallowed until after the user clicks Force.
+    await waitFor(() => expect(notifyMock.error).toHaveBeenCalled());
+    expect(screen.getByText(/Failed to apply/)).toBeDefined();
+  });
+
+  it("does not flag the user's own apply as changed elsewhere (rebaselines rv after apply)", async () => {
+    let liveRv = "1";
+    let diffName = "web-before";
+    diffManifestMock.mockImplementation(async () => ({
+      documents: [
+        {
+          kind: "Deployment",
+          name: diffName,
+          namespace: null,
+          exists: true,
+          changed: true,
+          rows: [{ tag: "insert", left: null, right: "x" }],
+          currentResourceVersion: liveRv,
+        },
+      ],
+    }));
+    applyManifestMock.mockImplementation(async () => {
+      liveRv = "9"; // a successful apply bumps the live resourceVersion
+      return { applied: true, documents: [{ kind: "Deployment", name: "web", applied: true }] };
+    });
+
+    function Harness() {
+      const [yaml, setYaml] = useState(
+        'apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: web\n  resourceVersion: "1"\n',
+      );
+      return <ManifestEditor context="ctx" yaml={yaml} onYamlChange={setYaml} fill />;
+    }
+    render(<Harness />);
+
+    // Open the Changes panel so each diff resolution is observable via DiffView.
+    fireEvent.click(screen.getByRole("button", { name: "Changes" }));
+    // The first diff sees live rv "1" (matches the loaded manifest) → no badge.
+    expect(await screen.findByText("Deployment/web-before", {}, { timeout: 3000 })).toBeDefined();
+    expect(screen.queryByText(/changed elsewhere/i)).toBeNull();
+
+    // Apply — this bumps the live rv to "9" for the user's OWN change.
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await waitFor(() => expect(applyManifestMock).toHaveBeenCalled());
+
+    // A later edit triggers a fresh diff that now reports live rv "9".
+    diffName = "web-after";
+    fireEvent.change(screen.getByLabelText("Manifest YAML"), {
+      target: {
+        value: 'apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: web\n  resourceVersion: "1"\n  labels:\n    a: b\n',
+      },
+    });
+    expect(await screen.findByText("Deployment/web-after", {}, { timeout: 3000 })).toBeDefined();
+
+    // The stale badge must NOT appear: the rv bump was our own apply, so the
+    // baseline was rebased to "9" rather than flagged as an external change.
+    expect(screen.queryByText(/changed elsewhere/i)).toBeNull();
+  });
+
   it("fill mode: diff pane is hidden by default; Changes reveals a resizable split, Hide changes collapses it", async () => {
     const { container } = render(
       <ManifestEditor

--- a/apps/desktop/src/components/ManifestEditor.test.tsx
+++ b/apps/desktop/src/components/ManifestEditor.test.tsx
@@ -167,13 +167,13 @@ describe("ManifestEditor", () => {
     expect(within(banner).getByTitle(/conflict on cfg/)).toBeDefined();
   });
 
-  it("shows a stale badge when the live resourceVersion differs", async () => {
+  it("shows a stale badge when the live resourceVersion differs, without opening the Changes panel", async () => {
     diffManifestMock.mockResolvedValue({
       documents: [
         { kind: "Deployment", name: "web", namespace: null, exists: true, changed: true, rows: [], currentResourceVersion: "9" },
       ],
     });
-    render(
+    const { container } = render(
       <ManifestEditor
         context="ctx"
         yaml={'apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: web\n  resourceVersion: "1"\n'}
@@ -182,8 +182,13 @@ describe("ManifestEditor", () => {
         confirm={{ kind: "Deployment", name: "web" }}
       />,
     );
-    fireEvent.click(screen.getByRole("button", { name: "Changes" }));
+    // The badge must appear WITHOUT clicking "Changes" first — the diff runs
+    // in the background so a concurrently-modified resource is flagged even
+    // while the panel is collapsed.
     expect(await screen.findByText(/changed elsewhere/i, {}, { timeout: 2000 })).toBeDefined();
+    // The panel itself stays collapsed until the user opts in.
+    expect(container.querySelector(".fl-changes-panel")).toBeNull();
+    expect(screen.getByRole("button", { name: "Changes" })).toBeDefined();
   });
 
   it("fill mode: diff pane is hidden by default; Changes reveals a resizable split, Hide changes collapses it", async () => {

--- a/apps/desktop/src/components/ManifestEditor.tsx
+++ b/apps/desktop/src/components/ManifestEditor.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, lazy, useState } from "react";
+import React, { Suspense, lazy, useEffect, useRef, useState } from "react";
 import { CircleCheck, Undo2, Upload } from "lucide-react";
 import {
   applyManifest,
@@ -69,8 +69,44 @@ export function ManifestEditor({
   const [conflictDocs, setConflictDocs] = useState<ApplyDoc[] | null>(null);
   const [diffDocs, setDiffDocs] = useState<DiffDoc[] | null>(null);
   const [diffing, setDiffing] = useState(false);
-  const [showDiff, setShowDiff] = useState(fill);
+  const [showDiff, setShowDiff] = useState(false);
   const loadedRvRef = React.useRef<string | null>(null);
+  const diffHandleRef = useRef<HTMLDivElement>(null);
+  const [diffWidth, setDiffWidth] = useState(480);
+  const diffStartX = useRef(0);
+  const diffStartW = useRef(0);
+  const diffWidthRef = useRef(diffWidth);
+  diffWidthRef.current = diffWidth;
+
+  useEffect(() => {
+    if (!showDiff) return;
+    const handle = diffHandleRef.current;
+    if (!handle) return;
+    function move(e: MouseEvent) {
+      // Divider sits on the LEFT edge of the diff pane: dragging left grows it.
+      setDiffWidth(Math.max(300, Math.min(1100, diffStartW.current - (e.clientX - diffStartX.current))));
+    }
+    function up() {
+      window.removeEventListener("mousemove", move);
+      window.removeEventListener("mouseup", up);
+      document.body.style.userSelect = "";
+    }
+    function down(e: MouseEvent) {
+      e.preventDefault();
+      diffStartX.current = e.clientX;
+      diffStartW.current = diffWidthRef.current;
+      document.body.style.userSelect = "none";
+      window.addEventListener("mousemove", move);
+      window.addEventListener("mouseup", up);
+    }
+    handle.addEventListener("mousedown", down);
+    return () => {
+      handle.removeEventListener("mousedown", down);
+      window.removeEventListener("mousemove", move);
+      window.removeEventListener("mouseup", up);
+      document.body.style.userSelect = "";
+    };
+  }, [showDiff]);
 
   // Capture the resourceVersion of the first loaded manifest, for stale detection.
   React.useEffect(() => {
@@ -262,15 +298,21 @@ export function ManifestEditor({
             <div className="absolute inset-0">{editor}</div>
           </div>
           {showDiff && (
-            <div className="fl-changes-panel min-h-0 w-1/2 overflow-auto border-l border-border">
-              {diffing && !diffDocs ? (
-                <Spinner label="Computing diff" />
-              ) : diffDocs && diffDocs.length > 0 ? (
-                diffDocs.map((d, i) => <DiffView key={`${d.kind}/${d.name}/${i}`} doc={d} />)
-              ) : (
-                <p className="fl-diff__empty">No changes</p>
-              )}
-            </div>
+            <>
+              <div className="fl-changes-panel__resize" ref={diffHandleRef} aria-hidden="true" />
+              <div
+                className="fl-changes-panel min-h-0 shrink-0 overflow-auto border-l border-border"
+                style={{ width: diffWidth }}
+              >
+                {diffing && !diffDocs ? (
+                  <Spinner label="Computing diff" />
+                ) : diffDocs && diffDocs.length > 0 ? (
+                  diffDocs.map((d, i) => <DiffView key={`${d.kind}/${d.name}/${i}`} doc={d} />)
+                ) : (
+                  <p className="fl-diff__empty">No changes</p>
+                )}
+              </div>
+            </>
           )}
         </div>
         {confirmDialog}

--- a/apps/desktop/src/components/ManifestEditor.tsx
+++ b/apps/desktop/src/components/ManifestEditor.tsx
@@ -71,6 +71,10 @@ export function ManifestEditor({
   const [diffing, setDiffing] = useState(false);
   const [showDiff, setShowDiff] = useState(false);
   const loadedRvRef = React.useRef<string | null>(null);
+  // Set after a successful apply so the next background diff rebaselines
+  // `loadedRvRef` to the freshly-bumped resourceVersion — otherwise the user's
+  // OWN apply would be mistaken for an external change ("Changed elsewhere").
+  const rebaselineRef = React.useRef(false);
   const diffHandleRef = useRef<HTMLDivElement>(null);
   const [diffWidth, setDiffWidth] = useState(480);
   const diffStartX = useRef(0);
@@ -136,26 +140,37 @@ export function ManifestEditor({
     const docs = out.documents ?? [];
     const conflicted = docs.filter((d) => d.conflict);
     const failed = docs.filter((d) => d.error);
+    // Surface every document that failed outright (inline error + toast).
+    const surfaceFailed = (failedDocs: ApplyDoc[]) => {
+      const names = failedDocs.map((d) => `${d.kind}/${d.name}`).join(", ");
+      const label =
+        failedDocs.length > 1 ? `Failed to apply ${failedDocs.length} documents: ${names}` : `Failed to apply ${names}`;
+      const detail = failedDocs.map((d) => d.error).filter(Boolean).join("; ") || "apply failed";
+      setError(label);
+      notify.error(label, detail);
+    };
     // Close the confirm dialog for any resolved response (conflict, failure, or
     // success) — the conflict banner and error text render inline, outside the
     // (now-inert) dialog, so they'd otherwise never be reachable.
     setConfirming(false);
     if (conflicted.length > 0) {
       setConflictDocs(docs);
+      // A different document may have hard-failed alongside the conflict — show
+      // that error now too, rather than hiding it until the user clicks Force.
+      if (failed.length > 0) surfaceFailed(failed);
       return;
     }
     setConflictDocs(null);
     if (failed.length > 0) {
-      const names = failed.map((d) => `${d.kind}/${d.name}`).join(", ");
-      const label = failed.length > 1 ? `Failed to apply ${failed.length} documents: ${names}` : `Failed to apply ${names}`;
-      const detail = failed.map((d) => d.error).filter(Boolean).join("; ") || "apply failed";
-      setError(label);
-      notify.error(label, detail);
+      surfaceFailed(failed);
       return;
     }
     const first = docs[0];
     const applied = { kind: first?.kind ?? "", name: first?.name ?? "" };
     setResult(applied);
+    // The apply bumped the live resourceVersion; rebaseline off the next diff so
+    // this own change isn't later flagged as "Changed elsewhere".
+    rebaselineRef.current = true;
     const label = docs.length > 1 ? `Applied ${docs.length} resources` : `Applied ${applied.kind || "resource"} ${applied.name}`.trim();
     notify.success(label);
     onApplied?.(applied);
@@ -185,7 +200,17 @@ export function ManifestEditor({
     const t = setTimeout(() => {
       void diffManifest(context, yaml).then((out) => {
         if (!active) return;
-        setDiffDocs(out.error ? [] : out.documents ?? []);
+        const docs = out.error ? [] : out.documents ?? [];
+        // After a successful apply, adopt the freshly-bumped resourceVersion as
+        // the new baseline so the user's OWN change isn't flagged as external.
+        if (rebaselineRef.current) {
+          const rv = docs.find((d) => d.currentResourceVersion)?.currentResourceVersion;
+          if (rv) {
+            loadedRvRef.current = rv;
+            rebaselineRef.current = false;
+          }
+        }
+        setDiffDocs(docs);
         setDiffing(false);
       });
     }, 700);

--- a/apps/desktop/src/components/ManifestEditor.tsx
+++ b/apps/desktop/src/components/ManifestEditor.tsx
@@ -129,6 +129,7 @@ export function ManifestEditor({
     setBusy(false);
     if (out.error) {
       setError(out.error);
+      setConflictDocs(null);
       notify.error(`Failed to apply ${confirm?.name ?? "resource"}`, out.error);
       return;
     }
@@ -166,11 +167,16 @@ export function ManifestEditor({
     else void doApply(false);
   }
 
-  // Debounced dry-run diff against the cluster, whenever the Changes panel is
-  // open. Guarded by `active` so a stale response from a superseded edit can't
-  // clobber a newer one.
+  // Debounced dry-run diff against the cluster. Runs in the background in
+  // fill mode regardless of whether the Changes panel is open, so a
+  // concurrently-modified resource is flagged (via `staleRv`, derived from
+  // `diffDocs`) without the user having to open the panel first — the panel
+  // itself only renders when `showDiff` is true. (The drawer has no diff
+  // panel, so it's fine for non-fill callers to skip this.) Guarded by
+  // `active` so a stale response from a superseded edit can't clobber a
+  // newer one.
   React.useEffect(() => {
-    if (!showDiff || !yaml.trim()) {
+    if (!fill || !yaml.trim()) {
       setDiffDocs(null);
       return;
     }
@@ -187,7 +193,7 @@ export function ManifestEditor({
       active = false;
       clearTimeout(t);
     };
-  }, [context, yaml, showDiff]);
+  }, [context, yaml, fill]);
 
   const editor = (
     <Suspense fallback={<Spinner label="Loading editor" />}>

--- a/apps/desktop/src/components/ManifestEditor.tsx
+++ b/apps/desktop/src/components/ManifestEditor.tsx
@@ -1,9 +1,18 @@
 import React, { Suspense, lazy, useState } from "react";
 import { CircleCheck, Undo2, Upload } from "lucide-react";
-import { applyManifest, validateManifest } from "../lib/manifest";
+import {
+  applyManifest,
+  diffManifest,
+  parseResourceVersion,
+  validateManifest,
+  type ApplyDoc,
+  type Conflict,
+  type DiffDoc,
+} from "../lib/manifest";
 import { notify } from "../lib/notify";
 import { openApiSchema } from "../lib/schema";
 import { Spinner, Button, ConfirmDialog } from "../ui";
+import { DiffView } from "./DiffView";
 
 // CodeMirror is heavy and only needed where a manifest is edited — load on demand.
 const CodeEditor = lazy(() => import("../ui/CodeEditor").then((m) => ({ default: m.CodeEditor })));
@@ -57,28 +66,92 @@ export function ManifestEditor({
   const [error, setError] = useState("");
   const [confirming, setConfirming] = useState(false);
   const [result, setResult] = useState<{ kind: string; name: string } | null>(null);
+  const [conflictDocs, setConflictDocs] = useState<ApplyDoc[] | null>(null);
+  const [diffDocs, setDiffDocs] = useState<DiffDoc[] | null>(null);
+  const [diffing, setDiffing] = useState(false);
+  const [showDiff, setShowDiff] = useState(fill);
+  const loadedRvRef = React.useRef<string | null>(null);
 
-  async function doApply() {
+  // Capture the resourceVersion of the first loaded manifest, for stale detection.
+  React.useEffect(() => {
+    if (loadedRvRef.current == null && yaml.trim()) {
+      loadedRvRef.current = parseResourceVersion(yaml);
+    }
+  }, [yaml]);
+
+  const conflictEntries = (conflictDocs ?? []).filter(
+    (d): d is ApplyDoc & { conflict: Conflict } => d.conflict != null,
+  );
+  const staleRv =
+    diffDocs?.find((d) => d.currentResourceVersion && loadedRvRef.current && d.currentResourceVersion !== loadedRvRef.current)
+      ?.currentResourceVersion ?? null;
+
+  async function doApply(force: boolean) {
     setBusy(true);
     setError("");
-    const out = await applyManifest(context, yaml);
+    const out = await applyManifest(context, yaml, force);
     setBusy(false);
     if (out.error) {
       setError(out.error);
       notify.error(`Failed to apply ${confirm?.name ?? "resource"}`, out.error);
       return;
     }
+    const docs = out.documents ?? [];
+    const conflicted = docs.filter((d) => d.conflict);
+    const failed = docs.filter((d) => d.error);
+    // Close the confirm dialog for any resolved response (conflict, failure, or
+    // success) — the conflict banner and error text render inline, outside the
+    // (now-inert) dialog, so they'd otherwise never be reachable.
     setConfirming(false);
-    const applied = { kind: out.kind ?? "", name: out.name ?? "" };
+    if (conflicted.length > 0) {
+      setConflictDocs(docs);
+      return;
+    }
+    setConflictDocs(null);
+    if (failed.length > 0) {
+      const names = failed.map((d) => `${d.kind}/${d.name}`).join(", ");
+      const label = failed.length > 1 ? `Failed to apply ${failed.length} documents: ${names}` : `Failed to apply ${names}`;
+      const detail = failed.map((d) => d.error).filter(Boolean).join("; ") || "apply failed";
+      setError(label);
+      notify.error(label, detail);
+      return;
+    }
+    const first = docs[0];
+    const applied = { kind: first?.kind ?? "", name: first?.name ?? "" };
     setResult(applied);
-    notify.success(`Applied ${applied.kind || "resource"} ${applied.name}`.trim());
+    const label = docs.length > 1 ? `Applied ${docs.length} resources` : `Applied ${applied.kind || "resource"} ${applied.name}`.trim();
+    notify.success(label);
     onApplied?.(applied);
   }
 
   function onApplyClick() {
+    setConflictDocs(null);
     if (confirm) setConfirming(true);
-    else void doApply();
+    else void doApply(false);
   }
+
+  // Debounced dry-run diff against the cluster, whenever the Changes panel is
+  // open. Guarded by `active` so a stale response from a superseded edit can't
+  // clobber a newer one.
+  React.useEffect(() => {
+    if (!showDiff || !yaml.trim()) {
+      setDiffDocs(null);
+      return;
+    }
+    let active = true;
+    setDiffing(true);
+    const t = setTimeout(() => {
+      void diffManifest(context, yaml).then((out) => {
+        if (!active) return;
+        setDiffDocs(out.error ? [] : out.documents ?? []);
+        setDiffing(false);
+      });
+    }, 700);
+    return () => {
+      active = false;
+      clearTimeout(t);
+    };
+  }, [context, yaml, showDiff]);
 
   const editor = (
     <Suspense fallback={<Spinner label="Loading editor" />}>
@@ -120,10 +193,37 @@ export function ManifestEditor({
       }
       confirmLabel="Apply"
       busy={busy}
-      onConfirm={() => void doApply()}
+      onConfirm={() => void doApply(false)}
       onCancel={() => setConfirming(false)}
     />
   ) : null;
+
+  const conflictBanner = conflictEntries.length > 0 ? (
+    <div className="fl-apply-conflict" role="alert">
+      <div className="fl-apply-conflict__list">
+        {conflictEntries.map((d, i) => (
+          <p key={`${d.kind}/${d.name}/${i}`} className="fl-apply-conflict__item" title={d.conflict.message}>
+            <strong>
+              {d.kind}/{d.name}
+            </strong>{" "}
+            conflicts with <strong>{d.conflict.managers.join(", ") || "another manager"}</strong>
+            {d.conflict.fields.length > 0 && <> on {d.conflict.fields.join(", ")}</>}.
+          </p>
+        ))}
+      </div>
+      <Button variant="danger" onClick={() => void doApply(true)} disabled={busy}>
+        {busy ? <Spinner label="Forcing…" data-icon="inline-start" /> : <Upload data-icon="inline-start" />}
+        Force apply
+      </Button>
+    </div>
+  ) : null;
+
+  const inlineError =
+    error && !confirming ? (
+      <p className="fl-apply-inline-error" style={{ color: "var(--fl-color-danger)", margin: 0 }} title={error}>
+        Error: {error}
+      </p>
+    ) : null;
 
   if (fill) {
     return (
@@ -133,6 +233,14 @@ export function ManifestEditor({
           <span className="text-xs text-muted-foreground">on {context}</span>
           {headerExtras}
           <div className="ml-auto flex items-center gap-3">
+            {staleRv && (
+              <span className="fl-apply-stale" title="The live object changed since you opened it">
+                Changed elsewhere
+              </span>
+            )}
+            <Button variant="ghost" onClick={() => setShowDiff((v) => !v)}>
+              {showDiff ? "Hide changes" : "Changes"}
+            </Button>
             {result && (
               <span className="fl-apply-success">
                 <CircleCheck aria-hidden="true" />
@@ -147,9 +255,23 @@ export function ManifestEditor({
             {applyButton}
           </div>
         </div>
-        <div className="relative min-h-0 flex-1 overflow-hidden">
-          {/* Absolute-inset pins CodeMirror to a definite-height box so it fills the tab. */}
-          <div className="absolute inset-0">{editor}</div>
+        {conflictBanner}
+        <div className="flex min-h-0 flex-1 overflow-hidden">
+          <div className="relative min-h-0 flex-1 overflow-hidden">
+            {/* Absolute-inset pins CodeMirror to a definite-height box so it fills the tab. */}
+            <div className="absolute inset-0">{editor}</div>
+          </div>
+          {showDiff && (
+            <div className="fl-changes-panel min-h-0 w-1/2 overflow-auto border-l border-border">
+              {diffing && !diffDocs ? (
+                <Spinner label="Computing diff" />
+              ) : diffDocs && diffDocs.length > 0 ? (
+                diffDocs.map((d, i) => <DiffView key={`${d.kind}/${d.name}/${i}`} doc={d} />)
+              ) : (
+                <p className="fl-diff__empty">No changes</p>
+              )}
+            </div>
+          )}
         </div>
         {confirmDialog}
       </div>
@@ -160,6 +282,8 @@ export function ManifestEditor({
   return (
     <div>
       {editor}
+      {conflictBanner}
+      {inlineError}
       <div style={{ display: "flex", gap: 8, alignItems: "center", marginTop: 8 }}>
         {applyButton}
         {resetTo != null && (

--- a/apps/desktop/src/components/NewResourceEditor.test.tsx
+++ b/apps/desktop/src/components/NewResourceEditor.test.tsx
@@ -3,7 +3,10 @@ import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import React from "react";
 
 const { applyManifestMock } = vi.hoisted(() => ({ applyManifestMock: vi.fn() }));
-vi.mock("../lib/manifest", () => ({ applyManifest: applyManifestMock }));
+vi.mock("../lib/manifest", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/manifest")>()),
+  applyManifest: applyManifestMock,
+}));
 vi.mock("../ui/CodeEditor", () => ({
   CodeEditor: ({ value, onChange, ariaLabel }: { value: string; onChange?: (v: string) => void; ariaLabel?: string }) => (
     <textarea aria-label={ariaLabel} value={value} onChange={(e) => onChange?.(e.target.value)} />
@@ -16,7 +19,10 @@ beforeEach(() => applyManifestMock.mockReset());
 
 describe("NewResourceEditor", () => {
   it("prefills a template and applies it, staying open on success", async () => {
-    applyManifestMock.mockResolvedValue({ applied: true, kind: "Service", name: "my-app" });
+    applyManifestMock.mockResolvedValue({
+      applied: true,
+      documents: [{ kind: "Service", name: "my-app", applied: true }],
+    });
     const onCreated = vi.fn();
     render(<NewResourceEditor context="kind-dev" namespace="prod" initialKind="Service" onCreated={onCreated} />);
 
@@ -26,7 +32,7 @@ describe("NewResourceEditor", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Create" }));
 
-    await waitFor(() => expect(applyManifestMock).toHaveBeenCalledWith("kind-dev", editor.value));
+    await waitFor(() => expect(applyManifestMock).toHaveBeenCalledWith("kind-dev", editor.value, false));
     expect(await screen.findByText(/Applied Service/)).toBeDefined();
     expect(onCreated).toHaveBeenCalled();
     // Editor is still present (tab stays open to create more).

--- a/apps/desktop/src/components/YamlView.test.tsx
+++ b/apps/desktop/src/components/YamlView.test.tsx
@@ -53,7 +53,10 @@ describe("YamlView", () => {
 
   it("edits and applies the manifest behind a confirm", async () => {
     getManifestMock.mockResolvedValue({ yaml: "kind: ConfigMap\n" });
-    applyManifestMock.mockResolvedValue({ applied: true, kind: "ConfigMap", name: "cm" });
+    applyManifestMock.mockResolvedValue({
+      applied: true,
+      documents: [{ kind: "ConfigMap", name: "cm", applied: true }],
+    });
     render(<YamlView context="kind-dev" kind="ConfigMap" namespace="default" name="cm" />);
 
     const textarea = await screen.findByLabelText("Manifest YAML");
@@ -68,7 +71,7 @@ describe("YamlView", () => {
     fireEvent.click(screen.getByRole("button", { name: "Apply" }));
 
     await waitFor(() =>
-      expect(applyManifestMock).toHaveBeenCalledWith("kind-dev", "kind: ConfigMap\ndata:\n  k: v\n"),
+      expect(applyManifestMock).toHaveBeenCalledWith("kind-dev", "kind: ConfigMap\ndata:\n  k: v\n", false),
     );
   });
 });

--- a/apps/desktop/src/lib/manifest.test.ts
+++ b/apps/desktop/src/lib/manifest.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { getManifest, listNodes, applyManifest, listEvents, listResource } from "./manifest";
+import { getManifest, listNodes, applyManifest, diffManifest, parseResourceVersion, listEvents, listResource } from "./manifest";
 
 describe("getManifest", () => {
   it("passes kind/namespace/name and returns yaml", async () => {
@@ -53,18 +53,18 @@ describe("listEvents", () => {
 
 describe("applyManifest", () => {
   it("passes context+yaml and returns applied", async () => {
-    const invoke = vi.fn().mockResolvedValue({ applied: true, kind: "ConfigMap", name: "cm" });
-    const out = await applyManifest("kind-dev", "kind: ConfigMap\n", invoke);
+    const invoke = vi.fn().mockResolvedValue({ documents: [{ kind: "ConfigMap", name: "cm", applied: true, conflict: null, error: null }], applied: true });
+    const out = await applyManifest("kind-dev", "kind: ConfigMap\n", false, invoke);
     expect(invoke).toHaveBeenCalledWith("k8s.applyManifest", {
       context: "kind-dev",
       yaml: "kind: ConfigMap\n",
+      force: false,
     });
     expect(out.applied).toBe(true);
-    expect(out.kind).toBe("ConfigMap");
   });
 
   it("normalises errors", async () => {
-    const out = await applyManifest("c", "bad", () => Promise.reject(new Error("invalid")));
+    const out = await applyManifest("c", "bad", false, () => Promise.reject(new Error("invalid")));
     expect(out.error).toContain("invalid");
   });
 });
@@ -88,5 +88,50 @@ describe("listResource", () => {
       Promise.reject(new Error("forbidden")),
     );
     expect(out.error).toContain("forbidden");
+  });
+});
+
+describe("applyManifest force + multi-doc", () => {
+  it("passes force and returns per-document results", async () => {
+    const invoke = vi.fn().mockResolvedValue({
+      documents: [{ kind: "ConfigMap", name: "a", applied: true, conflict: null, error: null }],
+      applied: true,
+    });
+    const out = await applyManifest("ctx", "kind: ConfigMap", true, invoke);
+    expect(invoke).toHaveBeenCalledWith("k8s.applyManifest", { context: "ctx", yaml: "kind: ConfigMap", force: true });
+    expect(out.applied).toBe(true);
+    expect(out.documents?.[0].name).toBe("a");
+  });
+
+  it("defaults force to false", async () => {
+    const invoke = vi.fn().mockResolvedValue({ documents: [], applied: true });
+    await applyManifest("ctx", "kind: ConfigMap", undefined, invoke);
+    expect(invoke).toHaveBeenCalledWith("k8s.applyManifest", { context: "ctx", yaml: "kind: ConfigMap", force: false });
+  });
+
+  it("surfaces call errors", async () => {
+    const invoke = vi.fn().mockRejectedValue(new Error("boom"));
+    const out = await applyManifest("ctx", "x", false, invoke);
+    expect(out.error).toContain("boom");
+  });
+});
+
+describe("diffManifest", () => {
+  it("returns documents", async () => {
+    const invoke = vi.fn().mockResolvedValue({
+      documents: [{ kind: "ConfigMap", name: "a", namespace: "d", exists: true, changed: true, rows: [], currentResourceVersion: "9" }],
+    });
+    const out = await diffManifest("ctx", "kind: ConfigMap", invoke);
+    expect(invoke).toHaveBeenCalledWith("k8s.diffManifest", { context: "ctx", yaml: "kind: ConfigMap" });
+    expect(out.documents?.[0].currentResourceVersion).toBe("9");
+  });
+});
+
+describe("parseResourceVersion", () => {
+  it("reads metadata.resourceVersion", () => {
+    expect(parseResourceVersion("metadata:\n  resourceVersion: \"42\"\n")).toBe("42");
+  });
+  it("returns null when absent", () => {
+    expect(parseResourceVersion("metadata:\n  name: a\n")).toBeNull();
   });
 });

--- a/apps/desktop/src/lib/manifest.ts
+++ b/apps/desktop/src/lib/manifest.ts
@@ -182,6 +182,13 @@ export function parseResourceVersion(yaml: string): string | null {
   }
 }
 
+/** A single validation error, tagged with the (empty-doc-skipped) document it
+ *  came from so the editor can place it on the right `---`-separated document. */
+export interface ValidateError {
+  docIndex: number;
+  message: string;
+}
+
 /**
  * Validate a manifest against the API server (server-side dry-run, strict).
  * Returns the server's verdict + error messages. `error` is only set when the
@@ -191,9 +198,9 @@ export async function validateManifest(
   context: string,
   yaml: string,
   invoke: Invoker = invokeCapability,
-): Promise<{ valid?: boolean; errors?: string[]; error?: string }> {
+): Promise<{ valid?: boolean; errors?: ValidateError[]; error?: string }> {
   try {
-    const out = await invoke<{ valid: boolean; errors: string[] }>("k8s.validateManifest", {
+    const out = await invoke<{ valid: boolean; errors: ValidateError[] }>("k8s.validateManifest", {
       context,
       yaml,
     });

--- a/apps/desktop/src/lib/manifest.ts
+++ b/apps/desktop/src/lib/manifest.ts
@@ -1,3 +1,4 @@
+import { parse } from "yaml";
 import { invokeCapability, type Invoker } from "../transport/transport";
 
 export interface NodeSummary {
@@ -107,20 +108,77 @@ export async function getSecret(
   }
 }
 
-/** Server-side apply a YAML manifest via `k8s.applyManifest`. */
+export interface Conflict {
+  managers: string[];
+  fields: string[];
+  message: string;
+}
+
+export interface ApplyDoc {
+  kind: string;
+  name: string;
+  applied: boolean;
+  conflict?: Conflict | null;
+  error?: string | null;
+}
+
+export interface DiffRow {
+  tag: "same" | "insert" | "delete" | "replace";
+  left: string | null;
+  right: string | null;
+}
+
+export interface DiffDoc {
+  kind: string;
+  name: string;
+  namespace: string | null;
+  exists: boolean;
+  changed: boolean;
+  rows: DiffRow[];
+  currentResourceVersion: string | null;
+}
+
+/** Server-side apply one or more YAML documents via `k8s.applyManifest`. */
 export async function applyManifest(
   context: string,
   yaml: string,
+  force = false,
   invoke: Invoker = invokeCapability,
-): Promise<{ applied?: boolean; kind?: string; name?: string; error?: string }> {
+): Promise<{ documents?: ApplyDoc[]; applied?: boolean; error?: string }> {
   try {
-    const out = await invoke<{ applied: boolean; kind: string; name: string }>(
-      "k8s.applyManifest",
-      { context, yaml },
-    );
-    return { applied: out.applied, kind: out.kind, name: out.name };
+    const out = await invoke<{ documents: ApplyDoc[]; applied: boolean }>("k8s.applyManifest", {
+      context,
+      yaml,
+      force,
+    });
+    return { documents: out.documents, applied: out.applied };
   } catch (e) {
     return { error: String(e) };
+  }
+}
+
+/** Diff a manifest against the cluster (dry-run) via `k8s.diffManifest`. */
+export async function diffManifest(
+  context: string,
+  yaml: string,
+  invoke: Invoker = invokeCapability,
+): Promise<{ documents?: DiffDoc[]; error?: string }> {
+  try {
+    const out = await invoke<{ documents: DiffDoc[] }>("k8s.diffManifest", { context, yaml });
+    return { documents: out.documents };
+  } catch (e) {
+    return { error: String(e) };
+  }
+}
+
+/** Read `metadata.resourceVersion` from a manifest, for stale-edit detection. */
+export function parseResourceVersion(yaml: string): string | null {
+  try {
+    const doc = parse(yaml) as { metadata?: { resourceVersion?: unknown } } | null;
+    const rv = doc?.metadata?.resourceVersion;
+    return rv == null ? null : String(rv);
+  } catch {
+    return null;
   }
 }
 

--- a/apps/desktop/src/ui/CodeEditor.lint.test.ts
+++ b/apps/desktop/src/ui/CodeEditor.lint.test.ts
@@ -59,7 +59,7 @@ spec:
 
 describe("k8sDiagnostics (server validation → editor positions)", () => {
   it("positions an unknown-field error at that field in the YAML", () => {
-    const diags = k8sDiagnostics(manifest, ['strict decoding error: unknown field "spec.foo"']);
+    const diags = k8sDiagnostics(manifest, [{ docIndex: 0, message: 'strict decoding error: unknown field "spec.foo"' }]);
     expect(diags).toHaveLength(1);
     // The range should cover the `foo: bar` value, not the top of the doc.
     const at = manifest.indexOf("bar");
@@ -70,7 +70,7 @@ describe("k8sDiagnostics (server validation → editor positions)", () => {
 
   it("positions an invalid-value error at the offending field", () => {
     const diags = k8sDiagnostics(manifest, [
-      'Deployment.apps "my-app" is invalid: spec.replicas: Invalid value: -1: must be >= 0',
+      { docIndex: 0, message: 'Deployment.apps "my-app" is invalid: spec.replicas: Invalid value: -1: must be >= 0' },
     ]);
     expect(diags).toHaveLength(1);
     const at = manifest.indexOf("-1");
@@ -79,7 +79,7 @@ describe("k8sDiagnostics (server validation → editor positions)", () => {
   });
 
   it("falls back to the top of the document when no field can be located", () => {
-    const diags = k8sDiagnostics(manifest, ["admission webhook denied the request"]);
+    const diags = k8sDiagnostics(manifest, [{ docIndex: 0, message: "admission webhook denied the request" }]);
     expect(diags).toHaveLength(1);
     expect(diags[0].from).toBe(0);
     expect(diags[0].message).toContain("admission webhook");
@@ -87,7 +87,7 @@ describe("k8sDiagnostics (server validation → editor positions)", () => {
 
   it("returns nothing for no messages or empty text", () => {
     expect(k8sDiagnostics(manifest, [])).toHaveLength(0);
-    expect(k8sDiagnostics("", ["some error"])).toHaveLength(0);
+    expect(k8sDiagnostics("", [{ docIndex: 0, message: "some error" }])).toHaveLength(0);
   });
 
   it("maps a field that exists only in the SECOND document to a range inside it", () => {
@@ -96,11 +96,30 @@ describe("k8sDiagnostics (server validation → editor positions)", () => {
     const doc2 = "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: my-app-2\nspec:\n  replicas: 1\n  foo: bar\n";
     const twoDoc = `${doc1}${separator}${doc2}`;
     const separatorOffset = doc1.length;
-    const diags = k8sDiagnostics(twoDoc, ['strict decoding error: unknown field "spec.foo"']);
+    const diags = k8sDiagnostics(twoDoc, [{ docIndex: 1, message: 'strict decoding error: unknown field "spec.foo"' }]);
     expect(diags).toHaveLength(1);
     expect(diags[0].from).toBeGreaterThan(separatorOffset);
     const at = twoDoc.indexOf("bar");
     expect(diags[0].from).toBeLessThanOrEqual(at);
     expect(diags[0].to).toBeGreaterThanOrEqual(at);
+  });
+
+  it("uses docIndex to target the SECOND document when the field exists in BOTH", () => {
+    // `spec.replicas` is present in BOTH documents. An error tagged docIndex:1
+    // must land in the SECOND document, not the first — a first-match-wins
+    // implementation would wrongly point at doc 1's replicas.
+    const doc1 = "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: my-app\nspec:\n  replicas: 1\n";
+    const separator = "---\n";
+    const doc2 = "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: my-app-2\nspec:\n  replicas: 2\n";
+    const twoDoc = `${doc1}${separator}${doc2}`;
+    const separatorOffset = doc1.length;
+    const diags = k8sDiagnostics(twoDoc, [
+      { docIndex: 1, message: 'Deployment.apps "my-app-2" is invalid: spec.replicas: Invalid value: 2: bad' },
+    ]);
+    expect(diags).toHaveLength(1);
+    // Must point into the SECOND document (past the `---`), i.e. at doc2's replicas.
+    expect(diags[0].from).toBeGreaterThan(separatorOffset);
+    const secondReplicas = twoDoc.indexOf("replicas: 2");
+    expect(diags[0].from).toBeGreaterThanOrEqual(secondReplicas);
   });
 });

--- a/apps/desktop/src/ui/CodeEditor.lint.test.ts
+++ b/apps/desktop/src/ui/CodeEditor.lint.test.ts
@@ -26,6 +26,26 @@ describe("yamlDiagnostics", () => {
     const diags = yamlDiagnostics("ports: [80, 443\n");
     expect(diags.some((d) => d.severity === "error")).toBe(true);
   });
+
+  it("returns no diagnostics for a valid two-document manifest", () => {
+    const doc1 = "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: my-app\n";
+    const doc2 = "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: my-app-2\n";
+    const twoDoc = `${doc1}---\n${doc2}`;
+    expect(yamlDiagnostics(twoDoc)).toHaveLength(0);
+  });
+
+  it("locates a syntax error in the SECOND document of a multi-doc manifest", () => {
+    const doc1 = "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: my-app\n";
+    const separator = "---\n";
+    const badDoc2 = "spec:\n  foo: bar: baz\n";
+    const twoDoc = `${doc1}${separator}${badDoc2}`;
+    const secondDocOffset = doc1.length + separator.length;
+    const diags = yamlDiagnostics(twoDoc);
+    expect(diags.length).toBeGreaterThan(0);
+    expect(diags[0].severity).toBe("error");
+    // The offending line lives inside the second document, not at/before the `---`.
+    expect(diags[0].from).toBeGreaterThanOrEqual(secondDocOffset);
+  });
 });
 
 const manifest = `apiVersion: apps/v1
@@ -68,5 +88,19 @@ describe("k8sDiagnostics (server validation → editor positions)", () => {
   it("returns nothing for no messages or empty text", () => {
     expect(k8sDiagnostics(manifest, [])).toHaveLength(0);
     expect(k8sDiagnostics("", ["some error"])).toHaveLength(0);
+  });
+
+  it("maps a field that exists only in the SECOND document to a range inside it", () => {
+    const doc1 = "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: my-app\nspec:\n  replicas: 1\n";
+    const separator = "---\n";
+    const doc2 = "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: my-app-2\nspec:\n  replicas: 1\n  foo: bar\n";
+    const twoDoc = `${doc1}${separator}${doc2}`;
+    const separatorOffset = doc1.length;
+    const diags = k8sDiagnostics(twoDoc, ['strict decoding error: unknown field "spec.foo"']);
+    expect(diags).toHaveLength(1);
+    expect(diags[0].from).toBeGreaterThan(separatorOffset);
+    const at = twoDoc.indexOf("bar");
+    expect(diags[0].from).toBeLessThanOrEqual(at);
+    expect(diags[0].to).toBeGreaterThanOrEqual(at);
   });
 });

--- a/apps/desktop/src/ui/CodeEditor.tsx
+++ b/apps/desktop/src/ui/CodeEditor.tsx
@@ -22,26 +22,34 @@ import { highlightSelectionMatches, searchKeymap } from "@codemirror/search";
 import { yaml } from "@codemirror/lang-yaml";
 import { linter, lintGutter, type Diagnostic } from "@codemirror/lint";
 import { autocompletion, completionKeymap, type CompletionContext, type CompletionResult } from "@codemirror/autocomplete";
-import { parseDocument } from "yaml";
+import { parseAllDocuments } from "yaml";
 import { tags as t } from "@lezer/highlight";
 import type { SchemaBundle } from "../lib/schema";
 import { extractApiVersionKind, pathAtCursor, fieldCompletions, valueCompletions } from "../lib/schemaComplete";
 
-/** Parse YAML and return syntax errors/warnings as diagnostics. Pure + tested. */
+/**
+ * Parse YAML (one or more `---`-separated documents) and return syntax
+ * errors/warnings across ALL documents as diagnostics. The `yaml` package
+ * reports absolute offsets into the full source, so ranges from later
+ * documents still land correctly without any per-document adjustment.
+ * Pure + tested.
+ */
 export function yamlDiagnostics(text: string): Diagnostic[] {
   const len = text.length;
   if (!text.trim()) return [];
   const clamp = (n: number) => Math.max(0, Math.min(n, len));
   try {
-    const doc = parseDocument(text, { prettyErrors: false });
+    const docs = parseAllDocuments(text, { prettyErrors: false });
     const asDiag = (issue: { pos?: [number, number, number?]; message: string }, severity: "error" | "warning"): Diagnostic => {
       const [from, to] = issue.pos ?? [0, 1];
       return { from: clamp(from), to: Math.max(clamp(to), clamp(from) + 1), severity, message: issue.message };
     };
-    return [
-      ...doc.errors.map((e) => asDiag(e, "error")),
-      ...doc.warnings.map((w) => asDiag(w, "warning")),
-    ];
+    const diagnostics: Diagnostic[] = [];
+    for (const doc of docs) {
+      diagnostics.push(...doc.errors.map((e) => asDiag(e, "error")));
+      diagnostics.push(...doc.warnings.map((w) => asDiag(w, "warning")));
+    }
+    return diagnostics;
   } catch (e) {
     return [{ from: 0, to: len, severity: "error", message: String(e) }];
   }
@@ -80,23 +88,25 @@ function extractFieldPaths(message: string): string[] {
 export function k8sDiagnostics(text: string, messages: string[]): Diagnostic[] {
   if (!messages.length || !text.trim()) return [];
   const len = text.length;
-  let doc: ReturnType<typeof parseDocument> | null = null;
+  let docs: ReturnType<typeof parseAllDocuments> = [];
   try {
-    doc = parseDocument(text);
+    docs = parseAllDocuments(text);
   } catch {
-    doc = null;
+    docs = [];
   }
   const topTo = Math.max(1, text.indexOf("\n") === -1 ? len : text.indexOf("\n"));
   const diagnostics: Diagnostic[] = [];
   for (const message of messages) {
-    const ranges = doc
-      ? extractFieldPaths(message)
-          .map((p) => {
-            const node = doc!.getIn(fieldSegments(p), true) as { range?: [number, number] } | undefined;
-            return node?.range ? ([node.range[0], node.range[1]] as [number, number]) : null;
-          })
-          .filter((r): r is [number, number] => !!r)
-      : [];
+    const ranges = extractFieldPaths(message)
+      .map((p) => {
+        const segments = fieldSegments(p);
+        for (const doc of docs) {
+          const node = doc.getIn(segments, true) as { range?: [number, number] } | undefined;
+          if (node?.range) return [node.range[0], node.range[1]] as [number, number];
+        }
+        return null;
+      })
+      .filter((r): r is [number, number] => !!r);
     if (ranges.length) {
       for (const [from, to] of ranges) {
         diagnostics.push({ from, to: Math.max(to, from + 1), severity: "error", message });

--- a/apps/desktop/src/ui/CodeEditor.tsx
+++ b/apps/desktop/src/ui/CodeEditor.tsx
@@ -85,34 +85,38 @@ function extractFieldPaths(message: string): string[] {
  * in the YAML, else at the top of the document — so the error is always shown.
  * Pure + tested.
  */
-export function k8sDiagnostics(text: string, messages: string[]): Diagnostic[] {
-  if (!messages.length || !text.trim()) return [];
+export function k8sDiagnostics(text: string, errors: Array<{ docIndex: number; message: string }>): Diagnostic[] {
+  if (!errors.length || !text.trim()) return [];
   const len = text.length;
+  const clamp = (n: number) => Math.max(0, Math.min(n, len));
   let docs: ReturnType<typeof parseAllDocuments> = [];
   try {
-    docs = parseAllDocuments(text);
+    // Match the backend's split (which skips empty documents) so docIndex aligns.
+    docs = parseAllDocuments(text).filter((d) => d.contents != null);
   } catch {
     docs = [];
   }
-  const topTo = Math.max(1, text.indexOf("\n") === -1 ? len : text.indexOf("\n"));
   const diagnostics: Diagnostic[] = [];
-  for (const message of messages) {
-    const ranges = extractFieldPaths(message)
-      .map((p) => {
-        const segments = fieldSegments(p);
-        for (const doc of docs) {
-          const node = doc.getIn(segments, true) as { range?: [number, number] } | undefined;
-          if (node?.range) return [node.range[0], node.range[1]] as [number, number];
-        }
-        return null;
-      })
-      .filter((r): r is [number, number] => !!r);
+  for (const { docIndex, message } of errors) {
+    const doc = docs[docIndex];
+    const ranges = doc
+      ? extractFieldPaths(message)
+          .map((p) => {
+            const node = doc.getIn(fieldSegments(p), true) as { range?: [number, number] } | undefined;
+            return node?.range ? ([node.range[0], node.range[1]] as [number, number]) : null;
+          })
+          .filter((r): r is [number, number] => !!r)
+      : [];
     if (ranges.length) {
       for (const [from, to] of ranges) {
-        diagnostics.push({ from, to: Math.max(to, from + 1), severity: "error", message });
+        diagnostics.push({ from: clamp(from), to: Math.max(clamp(to), clamp(from) + 1), severity: "error", message });
       }
     } else {
-      diagnostics.push({ from: 0, to: topTo, severity: "error", message });
+      // Fall back to the START of the target document (not the whole-text top).
+      const docStart = (doc?.contents as { range?: [number, number] } | undefined)?.range?.[0] ?? 0;
+      const nl = text.indexOf("\n", docStart);
+      const to = nl === -1 ? len : nl;
+      diagnostics.push({ from: clamp(docStart), to: Math.max(clamp(to), clamp(docStart) + 1), severity: "error", message });
     }
   }
   return diagnostics;
@@ -227,7 +231,7 @@ export interface CodeEditorProps {
    * error messages (empty = valid). Wired to `k8s.validateManifest`. When set,
    * the editor lints against the API server in addition to YAML syntax.
    */
-  schemaValidate?: (yaml: string) => Promise<string[]>;
+  schemaValidate?: (yaml: string) => Promise<Array<{ docIndex: number; message: string }>>;
   /**
    * k8s field autocomplete: resolve the OpenAPI schema for a kind (wired to
    * `k8s.openApiSchema`). When set, the editor offers field-name and enum-value

--- a/apps/desktop/src/ui/CodeEditor.tsx
+++ b/apps/desktop/src/ui/CodeEditor.tsx
@@ -21,7 +21,7 @@ import {
 import { highlightSelectionMatches, searchKeymap } from "@codemirror/search";
 import { yaml } from "@codemirror/lang-yaml";
 import { linter, lintGutter, type Diagnostic } from "@codemirror/lint";
-import { autocompletion, type CompletionContext, type CompletionResult } from "@codemirror/autocomplete";
+import { autocompletion, completionKeymap, type CompletionContext, type CompletionResult } from "@codemirror/autocomplete";
 import { parseDocument } from "yaml";
 import { tags as t } from "@lezer/highlight";
 import type { SchemaBundle } from "../lib/schema";
@@ -162,13 +162,41 @@ function editorTheme(minHeight: number, maxHeight: number, fill: boolean) {
     },
     ".cm-panels": { backgroundColor: "var(--fl-color-surface)", color: "var(--fl-color-text)" },
     ".cm-searchMatch": { backgroundColor: "rgba(210, 153, 34, 0.3)" },
+    ".cm-tooltip": { maxWidth: "480px" },
     ".cm-tooltip.cm-tooltip-lint": {
       backgroundColor: "var(--fl-color-surface)",
       border: "1px solid var(--fl-color-border)",
       borderRadius: "var(--fl-radius-md)",
+      boxShadow: "0 4px 16px rgba(0, 0, 0, 0.18)",
+      color: "var(--fl-color-text)",
+      maxWidth: "480px",
+    },
+    ".cm-diagnostic": {
+      padding: "6px 10px",
+      whiteSpace: "normal",
+      maxHeight: "240px",
+      overflowY: "auto",
+      fontSize: "12px",
+      lineHeight: "1.45",
+    },
+    ".cm-diagnostic-error": { borderLeft: "3px solid var(--fl-color-danger)" },
+    ".cm-tooltip.cm-tooltip-autocomplete": {
+      backgroundColor: "var(--fl-color-surface)",
+      border: "1px solid var(--fl-color-border)",
+      borderRadius: "var(--fl-radius-md)",
+      boxShadow: "0 4px 16px rgba(0, 0, 0, 0.18)",
+    },
+    ".cm-tooltip-autocomplete > ul > li": {
+      padding: "2px 8px",
+      fontFamily: "var(--fl-font-mono)",
+      fontSize: "12px",
       color: "var(--fl-color-text)",
     },
-    ".cm-diagnostic": { padding: "3px 8px" },
+    ".cm-tooltip-autocomplete > ul > li[aria-selected]": {
+      backgroundColor: "var(--fl-color-accent)",
+      color: "#fff",
+    },
+    ".cm-completionDetail": { color: "var(--fl-color-text-muted)", fontStyle: "italic", marginLeft: "6px" },
     ".cm-lint-marker": { width: "0.9em", height: "0.9em" },
   });
 }
@@ -242,7 +270,7 @@ export function CodeEditor({
       indentOnInput(),
       bracketMatching(),
       highlightSelectionMatches(),
-      keymap.of([...defaultKeymap, ...historyKeymap, ...searchKeymap, ...foldKeymap, indentWithTab]),
+      keymap.of([...completionKeymap, ...defaultKeymap, ...historyKeymap, ...searchKeymap, ...foldKeymap, indentWithTab]),
       editorTheme(minHeight, maxHeight, fill),
       syntaxHighlighting(highlightStyle),
       EditorView.editable.of(!readOnly),

--- a/apps/desktop/src/ui/styles.css
+++ b/apps/desktop/src/ui/styles.css
@@ -3976,3 +3976,31 @@ body {
 .fl-apply-conflict__item { margin: 0; }
 .fl-apply-stale { font-size: 12px; padding: 1px 8px; border-radius: 999px; background: color-mix(in srgb, var(--fl-color-warning, #f59e0b) 20%, transparent); }
 .fl-changes-panel { padding: 4px 0; }
+.fl-changes-panel__resize {
+  position: relative;
+  flex: 0 0 8px;
+  width: 8px;
+  cursor: col-resize;
+  z-index: 5;
+  background: transparent;
+}
+.fl-changes-panel__resize:hover {
+  background: transparent;
+}
+.fl-changes-panel__resize::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 3px;
+  width: 2px;
+  height: 44px;
+  border-radius: 999px;
+  background: rgba(128, 128, 128, 0.45);
+  opacity: 0;
+  transform: translateY(-50%);
+  transition: opacity 0.12s ease, background 0.12s ease;
+}
+.fl-changes-panel__resize:hover::after {
+  background: rgba(128, 128, 128, 0.65);
+  opacity: 1;
+}

--- a/apps/desktop/src/ui/styles.css
+++ b/apps/desktop/src/ui/styles.css
@@ -3969,3 +3969,10 @@ body {
 .fl-diff__row--delete .fl-diff__cell--left { background: color-mix(in srgb, var(--fl-color-danger, #ef4444) 14%, transparent); }
 .fl-diff__row--replace .fl-diff__cell--right,
 .fl-diff__row--insert .fl-diff__cell--right { background: color-mix(in srgb, var(--fl-color-success, #22c55e) 16%, transparent); }
+
+.fl-apply-conflict { display: flex; align-items: center; gap: 12px; padding: 8px 12px; border-bottom: 1px solid var(--fl-color-border, #e5e7eb); background: color-mix(in srgb, var(--fl-color-danger, #ef4444) 10%, transparent); font-size: 13px; }
+.fl-apply-conflict > p { flex: 1 1 auto; }
+.fl-apply-conflict__list { flex: 1 1 auto; display: flex; flex-direction: column; gap: 4px; }
+.fl-apply-conflict__item { margin: 0; }
+.fl-apply-stale { font-size: 12px; padding: 1px 8px; border-radius: 999px; background: color-mix(in srgb, var(--fl-color-warning, #f59e0b) 20%, transparent); }
+.fl-changes-panel { padding: 4px 0; }

--- a/apps/desktop/src/ui/styles.css
+++ b/apps/desktop/src/ui/styles.css
@@ -3956,3 +3956,16 @@ body {
     width: 100%;
   }
 }
+
+.fl-diff { display: flex; flex-direction: column; gap: 6px; }
+.fl-diff__title { display: flex; align-items: center; gap: 6px; padding: 6px 8px; }
+.fl-diff__badge { font-size: 11px; padding: 1px 6px; border-radius: 999px; }
+.fl-diff__badge--new { background: color-mix(in srgb, var(--fl-color-success, #22c55e) 18%, transparent); }
+.fl-diff__empty { padding: 8px; color: var(--fl-color-muted-foreground, #888); font-size: 13px; }
+.fl-diff__table { width: 100%; border-collapse: collapse; table-layout: fixed; font-family: var(--fl-font-mono, ui-monospace, monospace); font-size: 12px; }
+.fl-diff__cell { width: 50%; white-space: pre-wrap; word-break: break-word; padding: 0 8px; vertical-align: top; border-left: 1px solid var(--fl-color-border, #e5e7eb); }
+.fl-diff__row--same { color: color-mix(in srgb, currentColor 55%, transparent); }
+.fl-diff__row--replace .fl-diff__cell--left,
+.fl-diff__row--delete .fl-diff__cell--left { background: color-mix(in srgb, var(--fl-color-danger, #ef4444) 14%, transparent); }
+.fl-diff__row--replace .fl-diff__cell--right,
+.fl-diff__row--insert .fl-diff__cell--right { background: color-mix(in srgb, var(--fl-color-success, #22c55e) 16%, transparent); }

--- a/crates/kube/Cargo.toml
+++ b/crates/kube/Cargo.toml
@@ -17,6 +17,7 @@ futures = "0.3"
 base64 = "0.22"
 flate2 = "1"
 http = "1"
+similar = "2"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/crates/kube/src/manifest.rs
+++ b/crates/kube/src/manifest.rs
@@ -1308,11 +1308,10 @@ metadata:
     // -- normalize_for_diff on stringData --------------------------------------
 
     #[test]
-    fn normalize_for_diff_does_not_touch_string_data_key_names() {
-        // redact_secret_data only blanks the `data` map; `stringData` (raw,
-        // un-encoded values) is a distinct field. Document current behavior:
-        // normalize_for_diff still strips noise/status around it, and leaves
-        // stringData values untouched (only `data` is redacted).
+    fn normalize_for_diff_redacts_string_data() {
+        // redact_secret_data blanks BOTH the `data` map and the `stringData`
+        // map so no Secret material leaks through the diff path — only the
+        // keys survive (so the UI can still show which fields changed).
         let mut v: serde_json::Value = serde_yaml::from_str(
             "apiVersion: v1\nkind: Secret\nmetadata:\n  name: s\n  uid: u\nstringData:\n  password: hunter2\ndata:\n  token: c2VjcmV0\nstatus:\n  phase: Active\n",
         )
@@ -1321,6 +1320,10 @@ metadata:
         assert!(v.get("status").is_none());
         assert!(v["metadata"].get("uid").is_none());
         assert_eq!(v["data"]["token"], "");
-        assert_eq!(v["stringData"]["password"], "hunter2");
+        assert!(v["stringData"]
+            .as_object()
+            .unwrap()
+            .contains_key("password"));
+        assert_eq!(v["stringData"]["password"], "");
     }
 }

--- a/crates/kube/src/manifest.rs
+++ b/crates/kube/src/manifest.rs
@@ -418,15 +418,27 @@ pub struct ApplyOut {
 /// Best-effort parse of an apiserver SSA conflict message into managers
 /// (quoted names) and field paths (leading-dot tokens).
 pub fn parse_conflict(message: &str) -> Conflict {
+    // Managers are the quoted names in the "conflict(s) with \"…\"" clause, up
+    // to the ':' that ends that clause (e.g. `conflicts with "kubectl" and
+    // "helm" using v1: .spec.replicas`). Scoping to this region avoids
+    // mislabeling a quoted resource name/value elsewhere in the message as a
+    // manager.
     let mut managers = Vec::new();
-    let mut i = 0;
-    while let Some(start) = message[i..].find('"') {
-        let abs = i + start + 1;
-        if let Some(end) = message[abs..].find('"') {
-            managers.push(message[abs..abs + end].to_string());
-            i = abs + end + 1;
-        } else {
-            break;
+    if let Some(w) = message.find("with \"") {
+        let region_end = message[w..]
+            .find(':')
+            .map(|i| w + i)
+            .unwrap_or(message.len());
+        let region = &message[w..region_end];
+        let mut i = 0;
+        while let Some(s) = region[i..].find('"') {
+            let abs = i + s + 1;
+            if let Some(e) = region[abs..].find('"') {
+                managers.push(region[abs..abs + e].to_string());
+                i = abs + e + 1;
+            } else {
+                break;
+            }
         }
     }
     let fields = message
@@ -543,8 +555,19 @@ pub struct ValidateIn {
 pub struct ValidateOut {
     /// True when the API server accepts the manifest (dry-run).
     pub valid: bool,
-    /// Validation error messages (empty when valid).
-    pub errors: Vec<String>,
+    /// Validation errors (empty when valid).
+    pub errors: Vec<ValidateError>,
+}
+
+/// A single validation error, tagged with the document it belongs to so the
+/// editor can surface it against the right document in a multi-doc manifest.
+#[derive(Debug, Clone, PartialEq, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ValidateError {
+    /// Index of the document (in split order, skipping empty docs) the error
+    /// belongs to. Serializes as `docIndex`.
+    pub doc_index: usize,
+    pub message: String,
 }
 
 /// Extract a clean, human message from a kube error — the API server's
@@ -591,6 +614,23 @@ async fn validate_document(
     Some(result.map(|_| ()).map_err(clean_kube_error))
 }
 
+/// Build the validation result from per-document outcomes. `None` = the
+/// document had no identity yet (skipped, not a failure); `Some(Ok(()))` =
+/// valid; a `Some(Err(message))` becomes a `ValidateError` tagged with its
+/// doc index. Pure, so it is unit-testable independent of the API server.
+fn aggregate_validation(results: Vec<(usize, Option<Result<(), String>>)>) -> ValidateOut {
+    let mut errors = Vec::new();
+    for (doc_index, r) in results {
+        if let Some(Err(message)) = r {
+            errors.push(ValidateError { doc_index, message });
+        }
+    }
+    ValidateOut {
+        valid: errors.is_empty(),
+        errors,
+    }
+}
+
 /// `k8s.validateManifest` — server-side dry-run apply with strict field
 /// validation, one or more `---`-separated documents. Returns the API
 /// server's real verdict (unknown fields, wrong types, invalid values,
@@ -612,15 +652,19 @@ pub fn validate_manifest_capability(cache: Arc<ClientCache>) -> Capability {
                     Err(e) => {
                         return Ok(ValidateOut {
                             valid: false,
-                            errors: vec![e.to_string()],
+                            errors: vec![ValidateError {
+                                doc_index: 0,
+                                message: e.to_string(),
+                            }],
                         })
                     }
                 };
-                let mut errors = Vec::new();
                 let mut client: Option<kube::Client> = None;
-                for value in &docs {
+                let mut results: Vec<(usize, Option<Result<(), String>>)> = Vec::new();
+                for (doc_index, value) in docs.iter().enumerate() {
                     if resource_ref(value).is_none() {
                         // Nothing to validate against the server yet; not an error.
+                        results.push((doc_index, None));
                         continue;
                     }
                     if client.is_none() {
@@ -631,14 +675,12 @@ pub fn validate_manifest_capability(cache: Arc<ClientCache>) -> Capability {
                                 .map_err(CapabilityError::Handler)?,
                         );
                     }
-                    if let Some(Err(message)) =
-                        validate_document(client.as_ref().unwrap(), value).await
-                    {
-                        errors.push(message);
-                    }
+                    results.push((
+                        doc_index,
+                        validate_document(client.as_ref().unwrap(), value).await,
+                    ));
                 }
-                let valid = errors.is_empty();
-                Ok(ValidateOut { valid, errors })
+                Ok(aggregate_validation(results))
             }
         },
     )
@@ -772,11 +814,12 @@ pub fn diff_manifest_capability(cache: Arc<ClientCache>) -> Capability {
                     .map_err(CapabilityError::Handler)?;
                 let mut documents = Vec::with_capacity(docs.len());
                 for value in docs {
-                    let r = resource_ref(&value).ok_or_else(|| {
-                        CapabilityError::Handler(
-                            "document missing apiVersion/kind/metadata.name".into(),
-                        )
-                    })?;
+                    let r = match resource_ref(&value) {
+                        Some(r) => r,
+                        // Incomplete document (e.g. still being typed) — skip
+                        // it rather than aborting the whole diff.
+                        None => continue,
+                    };
                     let (group, version) = parse_api_version(&r.api_version);
                     let gvk = GroupVersionKind::gvk(&group, &version, &r.kind);
                     let ar = ApiResource::from_gvk(&gvk);
@@ -1004,6 +1047,21 @@ metadata:
     }
 
     #[test]
+    fn parse_conflict_scopes_managers_to_the_with_clause() {
+        // Two managers in the "conflicts with ... and ..." clause, plus a
+        // quoted value AFTER the clause-ending ':' that must NOT be picked up
+        // as a manager.
+        let msg = "Apply failed with 2 conflicts: conflicts with \"kubectl\" and \"helm\" using apps/v1:\n- .spec.replicas\n- .metadata.labels.\"app\": \"web\"";
+        let c = parse_conflict(msg);
+        assert!(c.managers.contains(&"kubectl".to_string()));
+        assert!(c.managers.contains(&"helm".to_string()));
+        assert_eq!(c.managers.len(), 2);
+        assert!(!c.managers.contains(&"web".to_string()));
+        assert!(!c.managers.contains(&"app".to_string()));
+        assert_eq!(c.message, msg);
+    }
+
+    #[test]
     fn overall_applied_requires_nonempty_all_applied() {
         assert!(!overall_applied(&[]));
         let ok = ApplyDoc {
@@ -1031,6 +1089,31 @@ metadata:
         }))
         .unwrap();
         assert!(!input.force);
+    }
+
+    // -- aggregate_validation -----------------------------------------------
+
+    #[test]
+    fn aggregate_validation_empty_input_is_valid() {
+        let out = aggregate_validation(vec![]);
+        assert!(out.valid);
+        assert!(out.errors.is_empty());
+    }
+
+    #[test]
+    fn aggregate_validation_identityless_and_valid_docs_are_valid() {
+        let out = aggregate_validation(vec![(0, None), (1, Some(Ok(())))]);
+        assert!(out.valid);
+        assert!(out.errors.is_empty());
+    }
+
+    #[test]
+    fn aggregate_validation_tags_error_with_doc_index() {
+        let out = aggregate_validation(vec![(0, Some(Ok(()))), (2, Some(Err("boom".to_string())))]);
+        assert!(!out.valid);
+        assert_eq!(out.errors.len(), 1);
+        assert_eq!(out.errors[0].doc_index, 2);
+        assert_eq!(out.errors[0].message, "boom");
     }
 
     // -- diff_document -----------------------------------------------------

--- a/crates/kube/src/manifest.rs
+++ b/crates/kube/src/manifest.rs
@@ -356,15 +356,62 @@ pub fn list_resource_capability(cache: Arc<ClientCache>) -> Capability {
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ApplyIn {
     pub context: String,
-    /// The full resource manifest as YAML.
+    /// One or more resource manifests as YAML (documents separated by `---`).
     pub yaml: String,
+    /// Force apply, taking ownership of fields held by other managers.
+    #[serde(default)]
+    pub force: bool,
+}
+
+/// Fields owned by other managers that block a non-forced apply.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct Conflict {
+    pub managers: Vec<String>,
+    pub fields: Vec<String>,
+    pub message: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ApplyDoc {
+    pub kind: String,
+    pub name: String,
+    pub applied: bool,
+    pub conflict: Option<Conflict>,
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct ApplyOut {
-    pub kind: String,
-    pub name: String,
+    pub documents: Vec<ApplyDoc>,
+    /// True only when every document applied with no conflict or error.
     pub applied: bool,
+}
+
+/// Best-effort parse of an apiserver SSA conflict message into managers
+/// (quoted names) and field paths (leading-dot tokens).
+pub fn parse_conflict(message: &str) -> Conflict {
+    let mut managers = Vec::new();
+    let mut i = 0;
+    while let Some(start) = message[i..].find('"') {
+        let abs = i + start + 1;
+        if let Some(end) = message[abs..].find('"') {
+            managers.push(message[abs..abs + end].to_string());
+            i = abs + end + 1;
+        } else {
+            break;
+        }
+    }
+    let fields = message
+        .split_whitespace()
+        .map(|t| t.trim_start_matches('-').trim())
+        .filter(|t| t.starts_with('.') && t.len() > 1)
+        .map(String::from)
+        .collect();
+    Conflict {
+        managers,
+        fields,
+        message: message.to_string(),
+    }
 }
 
 /// Split an `apiVersion` into (group, version). Core resources ("v1") have an
@@ -376,11 +423,18 @@ pub fn parse_api_version(api_version: &str) -> (String, String) {
     }
 }
 
-/// `k8s.applyManifest` — server-side apply a YAML manifest (create or update).
+/// True only when there is at least one document and every one applied.
+fn overall_applied(docs: &[ApplyDoc]) -> bool {
+    !docs.is_empty() && docs.iter().all(|d| d.applied)
+}
+
+/// `k8s.applyManifest` — server-side apply one or more YAML documents with field
+/// manager `srelens`. Non-forcing by default: field conflicts come back as
+/// structured `Conflict` data (per document) rather than a raw 409.
 pub fn apply_manifest_capability(cache: Arc<ClientCache>) -> Capability {
     Capability::typed::<ApplyIn, ApplyOut, _, _>(
         "k8s.applyManifest",
-        "server-side apply a resource manifest (YAML); creates or updates",
+        "server-side apply resource manifests (YAML, multi-doc); creates or updates",
         Annotations {
             read_only: false,
             destructive: false,
@@ -390,44 +444,84 @@ pub fn apply_manifest_capability(cache: Arc<ClientCache>) -> Capability {
         move |input: ApplyIn| {
             let cache = cache.clone();
             async move {
-                let value: serde_json::Value = serde_yaml::from_str(&input.yaml)
-                    .map_err(|e| CapabilityError::Handler(format!("parse yaml: {e}")))?;
-                let get_str = |path: &[&str]| -> Option<String> {
-                    let mut cur = &value;
-                    for key in path {
-                        cur = cur.get(key)?;
-                    }
-                    cur.as_str().map(String::from)
-                };
-                let api_version = get_str(&["apiVersion"])
-                    .ok_or_else(|| CapabilityError::Handler("missing apiVersion".into()))?;
-                let kind = get_str(&["kind"])
-                    .ok_or_else(|| CapabilityError::Handler("missing kind".into()))?;
-                let name = get_str(&["metadata", "name"])
-                    .ok_or_else(|| CapabilityError::Handler("missing metadata.name".into()))?;
-                let namespace = get_str(&["metadata", "namespace"]);
-
-                let (group, version) = parse_api_version(&api_version);
-                let gvk = GroupVersionKind::gvk(&group, &version, &kind);
-                let ar = ApiResource::from_gvk(&gvk);
+                let docs = split_documents(&input.yaml)?;
                 let client = cache
                     .get(&input.context)
                     .await
                     .map_err(CapabilityError::Handler)?;
-                let api: Api<DynamicObject> = match &namespace {
-                    Some(ns) => Api::namespaced_with(client, ns, &ar),
-                    None => Api::all_with(client, &ar),
-                };
-                let params = PatchParams::apply("srelens").force();
-                tokio::time::timeout(request_timeout(), api.patch(&name, &params, &Patch::Apply(&value)))
+                let mut documents = Vec::with_capacity(docs.len());
+                for value in docs {
+                    let r = match resource_ref(&value) {
+                        Some(r) => r,
+                        None => {
+                            documents.push(ApplyDoc {
+                                kind: String::new(),
+                                name: String::new(),
+                                applied: false,
+                                conflict: None,
+                                error: Some(
+                                    "document missing apiVersion/kind/metadata.name".into(),
+                                ),
+                            });
+                            continue;
+                        }
+                    };
+                    let (group, version) = parse_api_version(&r.api_version);
+                    let ar =
+                        ApiResource::from_gvk(&GroupVersionKind::gvk(&group, &version, &r.kind));
+                    let api: Api<DynamicObject> = match &r.namespace {
+                        Some(ns) => Api::namespaced_with(client.clone(), ns, &ar),
+                        None => Api::all_with(client.clone(), &ar),
+                    };
+                    let mut params = PatchParams::apply("srelens");
+                    if input.force {
+                        params = params.force();
+                    }
+                    let result = match tokio::time::timeout(
+                        request_timeout(),
+                        api.patch(&r.name, &params, &Patch::Apply(&value)),
+                    )
                     .await
-                    .map_err(|_| CapabilityError::Handler("apply timed out".into()))?
-                    .map_err(|e| CapabilityError::Handler(e.to_string()))?;
-                Ok(ApplyOut {
-                    kind,
-                    name,
-                    applied: true,
-                })
+                    {
+                        Ok(result) => result,
+                        Err(_) => {
+                            documents.push(ApplyDoc {
+                                kind: r.kind,
+                                name: r.name,
+                                applied: false,
+                                conflict: None,
+                                error: Some("apply timed out".into()),
+                            });
+                            continue;
+                        }
+                    };
+                    let doc = match result {
+                        Ok(_) => ApplyDoc {
+                            kind: r.kind,
+                            name: r.name,
+                            applied: true,
+                            conflict: None,
+                            error: None,
+                        },
+                        Err(kube::Error::Api(resp)) if resp.code == 409 => ApplyDoc {
+                            kind: r.kind,
+                            name: r.name,
+                            applied: false,
+                            conflict: Some(parse_conflict(&resp.message)),
+                            error: None,
+                        },
+                        Err(e) => ApplyDoc {
+                            kind: r.kind,
+                            name: r.name,
+                            applied: false,
+                            conflict: None,
+                            error: Some(clean_kube_error(e)),
+                        },
+                    };
+                    documents.push(doc);
+                }
+                let applied = overall_applied(&documents);
+                Ok(ApplyOut { documents, applied })
             }
         },
     )
@@ -796,5 +890,48 @@ metadata:
         assert_eq!(cap.id, "k8s.diffManifest");
         assert!(cap.annotations.read_only);
         assert!(cap.annotations.sensitive);
+    }
+
+    #[test]
+    fn parse_conflict_extracts_managers_and_fields() {
+        let msg = "Apply failed with 2 conflicts: conflicts with \"kubectl\" using apps/v1:\n- .spec.replicas\n- .spec.template.spec.containers[0].image";
+        let c = parse_conflict(msg);
+        assert!(c.managers.contains(&"kubectl".to_string()));
+        assert!(c.fields.iter().any(|f| f == ".spec.replicas"));
+        assert!(c
+            .fields
+            .iter()
+            .any(|f| f == ".spec.template.spec.containers[0].image"));
+        assert_eq!(c.message, msg);
+    }
+
+    #[test]
+    fn overall_applied_requires_nonempty_all_applied() {
+        assert!(!overall_applied(&[]));
+        let ok = ApplyDoc {
+            kind: "Pod".into(),
+            name: "a".into(),
+            applied: true,
+            conflict: None,
+            error: None,
+        };
+        let bad = ApplyDoc {
+            kind: "Pod".into(),
+            name: "b".into(),
+            applied: false,
+            conflict: None,
+            error: Some("x".into()),
+        };
+        assert!(overall_applied(std::slice::from_ref(&ok)));
+        assert!(!overall_applied(&[ok, bad]));
+    }
+
+    #[test]
+    fn apply_in_defaults_force_false() {
+        let input: ApplyIn = serde_json::from_value(serde_json::json!({
+            "context": "c", "yaml": "kind: Pod"
+        }))
+        .unwrap();
+        assert!(!input.force);
     }
 }

--- a/crates/kube/src/manifest.rs
+++ b/crates/kube/src/manifest.rs
@@ -206,6 +206,34 @@ pub fn get_object_capability(cache: Arc<ClientCache>) -> Capability {
     )
 }
 
+/// Map a server-side-apply patch outcome to a per-document result: success,
+/// a structured 409 conflict, or a cleaned error. Pure, so it is unit-testable.
+fn apply_doc_from_result(kind: String, name: String, result: Result<(), kube::Error>) -> ApplyDoc {
+    match result {
+        Ok(()) => ApplyDoc {
+            kind,
+            name,
+            applied: true,
+            conflict: None,
+            error: None,
+        },
+        Err(kube::Error::Api(resp)) if resp.code == 409 => ApplyDoc {
+            kind,
+            name,
+            applied: false,
+            conflict: Some(parse_conflict(&resp.message)),
+            error: None,
+        },
+        Err(e) => ApplyDoc {
+            kind,
+            name,
+            applied: false,
+            conflict: None,
+            error: Some(clean_kube_error(e)),
+        },
+    }
+}
+
 /// Map a supported Kind to its GroupVersionKind and whether it is namespaced.
 pub fn gvk_for(kind: &str) -> Option<(GroupVersionKind, bool)> {
     let (group, version, k, namespaced) = match kind {
@@ -495,29 +523,7 @@ pub fn apply_manifest_capability(cache: Arc<ClientCache>) -> Capability {
                             continue;
                         }
                     };
-                    let doc = match result {
-                        Ok(_) => ApplyDoc {
-                            kind: r.kind,
-                            name: r.name,
-                            applied: true,
-                            conflict: None,
-                            error: None,
-                        },
-                        Err(kube::Error::Api(resp)) if resp.code == 409 => ApplyDoc {
-                            kind: r.kind,
-                            name: r.name,
-                            applied: false,
-                            conflict: Some(parse_conflict(&resp.message)),
-                            error: None,
-                        },
-                        Err(e) => ApplyDoc {
-                            kind: r.kind,
-                            name: r.name,
-                            applied: false,
-                            conflict: None,
-                            error: Some(clean_kube_error(e)),
-                        },
-                    };
+                    let doc = apply_doc_from_result(r.kind, r.name, result.map(|_| ()));
                     documents.push(doc);
                 }
                 let applied = overall_applied(&documents);
@@ -690,6 +696,41 @@ fn canonicalize_diff_strings(value: &mut serde_json::Value) {
     }
 }
 
+/// Build one document's diff from its already-fetched current + proposed JSON.
+/// Pure (no I/O) so it is unit-testable; the capability supplies the fetched
+/// values. `current_json` is `json!({})` when the resource does not exist.
+fn diff_document(
+    kind: String,
+    name: String,
+    namespace: Option<String>,
+    exists: bool,
+    current_resource_version: Option<String>,
+    mut current_json: serde_json::Value,
+    mut proposed_json: serde_json::Value,
+    is_secret: bool,
+) -> Result<DiffDoc, CapabilityError> {
+    normalize_for_diff(&mut current_json, is_secret);
+    normalize_for_diff(&mut proposed_json, is_secret);
+    let current_yaml = if exists {
+        serde_yaml::to_string(&current_json).map_err(|e| CapabilityError::Handler(e.to_string()))?
+    } else {
+        String::new()
+    };
+    let proposed_yaml = serde_yaml::to_string(&proposed_json)
+        .map_err(|e| CapabilityError::Handler(e.to_string()))?;
+    let rows = align_rows(&current_yaml, &proposed_yaml);
+    let changed = rows.iter().any(|row| row.tag != DiffTag::Same);
+    Ok(DiffDoc {
+        kind,
+        name,
+        namespace,
+        exists,
+        changed,
+        rows,
+        current_resource_version,
+    })
+}
+
 /// `k8s.diffManifest` — for each document, diff the live object against the
 /// server dry-run apply result (current | proposed) as aligned rows.
 pub fn diff_manifest_capability(cache: Arc<ClientCache>) -> Capability {
@@ -735,7 +776,7 @@ pub fn diff_manifest_capability(cache: Arc<ClientCache>) -> Capability {
                         .as_ref()
                         .and_then(|o| o.metadata.resource_version.clone());
                     let exists = current.is_some();
-                    let mut current_json = match current {
+                    let current_json = match current {
                         Some(o) => serde_json::to_value(o)
                             .map_err(|e| CapabilityError::Handler(e.to_string()))?,
                         None => serde_json::json!({}),
@@ -755,31 +796,19 @@ pub fn diff_manifest_capability(cache: Arc<ClientCache>) -> Capability {
                     .await
                     .map_err(|_| CapabilityError::Handler("diff dry-run timed out".into()))?
                     .map_err(|e| CapabilityError::Handler(clean_kube_error(e)))?;
-                    let mut proposed_json = serde_json::to_value(proposed)
+                    let proposed_json = serde_json::to_value(proposed)
                         .map_err(|e| CapabilityError::Handler(e.to_string()))?;
 
-                    normalize_for_diff(&mut current_json, is_secret);
-                    normalize_for_diff(&mut proposed_json, is_secret);
-                    let current_yaml = if exists {
-                        serde_yaml::to_string(&current_json)
-                            .map_err(|e| CapabilityError::Handler(e.to_string()))?
-                    } else {
-                        String::new()
-                    };
-                    let proposed_yaml = serde_yaml::to_string(&proposed_json)
-                        .map_err(|e| CapabilityError::Handler(e.to_string()))?;
-                    let rows = align_rows(&current_yaml, &proposed_yaml);
-                    let changed = rows.iter().any(|row| row.tag != DiffTag::Same);
-
-                    documents.push(DiffDoc {
-                        kind: r.kind,
-                        name: r.name,
-                        namespace: r.namespace,
+                    documents.push(diff_document(
+                        r.kind,
+                        r.name,
+                        r.namespace,
                         exists,
-                        changed,
-                        rows,
                         current_resource_version,
-                    });
+                        current_json,
+                        proposed_json,
+                        is_secret,
+                    )?);
                 }
                 Ok(DiffOut { documents })
             }
@@ -983,5 +1012,315 @@ metadata:
         }))
         .unwrap();
         assert!(!input.force);
+    }
+
+    // -- diff_document -----------------------------------------------------
+
+    #[test]
+    fn diff_document_marks_changed_replica_update() {
+        let current = serde_json::json!({
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": { "name": "web" },
+            "spec": { "replicas": 3 }
+        });
+        let proposed = serde_json::json!({
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": { "name": "web" },
+            "spec": { "replicas": 5 }
+        });
+        let doc = diff_document(
+            "Deployment".into(),
+            "web".into(),
+            None,
+            true,
+            Some("42".into()),
+            current,
+            proposed,
+            false,
+        )
+        .unwrap();
+        assert!(doc.exists);
+        assert!(doc.changed);
+        assert_eq!(doc.current_resource_version.as_deref(), Some("42"));
+        assert!(doc.rows.iter().any(|r| matches!(r.tag, DiffTag::Replace)));
+    }
+
+    #[test]
+    fn diff_document_handles_create_with_empty_current() {
+        let proposed = serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": { "name": "cfg" },
+            "data": { "k": "v" }
+        });
+        let doc = diff_document(
+            "ConfigMap".into(),
+            "cfg".into(),
+            None,
+            false,
+            None,
+            serde_json::json!({}),
+            proposed,
+            false,
+        )
+        .unwrap();
+        assert!(!doc.exists);
+        assert!(doc.changed);
+        assert!(doc.current_resource_version.is_none());
+        // The current side is empty, so every row is an insert (or the doc
+        // has no "same" rows at all since there's nothing to align against).
+        assert!(doc.rows.iter().all(|r| r.left.is_none()));
+    }
+
+    #[test]
+    fn diff_document_redacts_secret_values_on_both_sides() {
+        let current = serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "metadata": { "name": "s" },
+            "data": { "token": "c2VjcmV0" }
+        });
+        let proposed = serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "metadata": { "name": "s" },
+            "data": { "token": "bmV3c2VjcmV0" }
+        });
+        let doc = diff_document(
+            "Secret".into(),
+            "s".into(),
+            None,
+            true,
+            None,
+            current,
+            proposed,
+            true,
+        )
+        .unwrap();
+        for row in &doc.rows {
+            if let Some(left) = &row.left {
+                assert!(!left.contains("c2VjcmV0"));
+            }
+            if let Some(right) = &row.right {
+                assert!(!right.contains("bmV3c2VjcmV0"));
+            }
+        }
+    }
+
+    // -- apply_doc_from_result ----------------------------------------------
+
+    #[test]
+    fn apply_doc_from_result_ok_is_applied() {
+        let doc = apply_doc_from_result("Pod".into(), "web".into(), Ok(()));
+        assert!(doc.applied);
+        assert!(doc.conflict.is_none());
+        assert!(doc.error.is_none());
+    }
+
+    #[test]
+    fn apply_doc_from_result_409_becomes_conflict() {
+        let err = kube::Error::Api(kube::core::ErrorResponse {
+            status: "Failure".into(),
+            message: "conflict with \"kubectl\": .spec.replicas".into(),
+            reason: "Conflict".into(),
+            code: 409,
+        });
+        let doc = apply_doc_from_result("Deployment".into(), "web".into(), Err(err));
+        assert!(!doc.applied);
+        assert!(doc.error.is_none());
+        let conflict = doc.conflict.expect("expected a conflict");
+        assert!(conflict.managers.contains(&"kubectl".to_string()));
+    }
+
+    #[test]
+    fn apply_doc_from_result_other_error_is_cleaned() {
+        let err = kube::Error::Api(kube::core::ErrorResponse {
+            status: "Failure".into(),
+            message: "boom".into(),
+            reason: "InternalError".into(),
+            code: 500,
+        });
+        let doc = apply_doc_from_result("Deployment".into(), "web".into(), Err(err));
+        assert!(!doc.applied);
+        assert!(doc.conflict.is_none());
+        assert!(doc.error.as_deref().unwrap_or_default().contains("boom"));
+    }
+
+    // -- gvk_for extra arms ---------------------------------------------------
+
+    #[test]
+    fn gvk_for_covers_more_kinds() {
+        let (gvk, ns) = gvk_for("Service").unwrap();
+        assert_eq!(gvk.kind, "Service");
+        assert!(ns);
+        let (gvk, ns) = gvk_for("Ingress").unwrap();
+        assert_eq!(gvk.group, "networking.k8s.io");
+        assert!(ns);
+        let (gvk, ns) = gvk_for("ClusterRole").unwrap();
+        assert_eq!(gvk.group, "rbac.authorization.k8s.io");
+        assert!(!ns);
+        let (gvk, ns) = gvk_for("StorageClass").unwrap();
+        assert_eq!(gvk.group, "storage.k8s.io");
+        assert!(!ns);
+        let (gvk, ns) = gvk_for("HorizontalPodAutoscaler").unwrap();
+        assert_eq!(gvk.group, "autoscaling");
+        assert!(ns);
+        let (gvk, ns) = gvk_for("EndpointSlice").unwrap();
+        assert_eq!(gvk.group, "discovery.k8s.io");
+        assert!(ns);
+        let (gvk, ns) = gvk_for("MutatingWebhookConfiguration").unwrap();
+        assert_eq!(gvk.group, "admissionregistration.k8s.io");
+        assert!(!ns);
+    }
+
+    // -- resolve_api_resource --------------------------------------------------
+
+    #[test]
+    fn resolve_api_resource_uses_static_table_when_no_crd_fields() {
+        let input = ManifestIn {
+            context: "c".into(),
+            kind: "Deployment".into(),
+            namespace: Some("prod".into()),
+            name: "web".into(),
+            group: None,
+            version: None,
+            plural: None,
+        };
+        let (ar, namespaced) = resolve_api_resource(&input).unwrap();
+        assert_eq!(ar.group, "apps");
+        assert_eq!(ar.kind, "Deployment");
+        assert!(namespaced);
+    }
+
+    #[test]
+    fn resolve_api_resource_uses_dynamic_crd_fields_when_supplied() {
+        let input = ManifestIn {
+            context: "c".into(),
+            kind: "Widget".into(),
+            namespace: Some("prod".into()),
+            name: "w1".into(),
+            group: Some("example.com".into()),
+            version: Some("v1alpha1".into()),
+            plural: Some("widgets".into()),
+        };
+        let (ar, namespaced) = resolve_api_resource(&input).unwrap();
+        assert_eq!(ar.group, "example.com");
+        assert_eq!(ar.version, "v1alpha1");
+        assert_eq!(ar.kind, "Widget");
+        assert_eq!(ar.plural, "widgets");
+        assert!(namespaced);
+    }
+
+    #[test]
+    fn resolve_api_resource_cluster_scoped_when_namespace_empty_for_crd() {
+        let input = ManifestIn {
+            context: "c".into(),
+            kind: "Widget".into(),
+            namespace: None,
+            name: "w1".into(),
+            group: Some("example.com".into()),
+            version: Some("v1alpha1".into()),
+            plural: Some("widgets".into()),
+        };
+        let (_, namespaced) = resolve_api_resource(&input).unwrap();
+        assert!(!namespaced);
+    }
+
+    #[test]
+    fn resolve_api_resource_rejects_unsupported_kind() {
+        let input = ManifestIn {
+            context: "c".into(),
+            kind: "Bogus".into(),
+            namespace: None,
+            name: "x".into(),
+            group: None,
+            version: None,
+            plural: None,
+        };
+        assert!(resolve_api_resource(&input).is_err());
+    }
+
+    // -- parse_api_version edge cases ------------------------------------------
+
+    #[test]
+    fn parse_api_version_handles_multi_segment_group() {
+        // Only the first "/" is a separator; the rest of the string is the version.
+        let (group, version) = parse_api_version("networking.k8s.io/v1");
+        assert_eq!(group, "networking.k8s.io");
+        assert_eq!(version, "v1");
+    }
+
+    #[test]
+    fn parse_api_version_handles_empty_string() {
+        let (group, version) = parse_api_version("");
+        assert_eq!(group, "");
+        assert_eq!(version, "");
+    }
+
+    // -- align_rows additional cases --------------------------------------------
+
+    #[test]
+    fn align_rows_pairs_multi_line_replace_group() {
+        let current = "a\nb\nc\n";
+        let proposed = "a\nx\ny\nc\n";
+        let rows = align_rows(current, proposed);
+        // First and last rows are unchanged; the two middle lines pair up as
+        // Replace rows (delete "b"/insert "x" paired, "c" stays Same-ish since
+        // there's no leftover "y" to pair — it becomes a pure Insert).
+        assert!(matches!(rows[0].tag, DiffTag::Same));
+        assert!(rows
+            .iter()
+            .any(|r| matches!(r.tag, DiffTag::Replace) && r.left.as_deref() == Some("b")));
+        assert!(matches!(rows.last().unwrap().tag, DiffTag::Same));
+    }
+
+    #[test]
+    fn align_rows_handles_asymmetric_insert_delete_counts() {
+        // Two deletes, one insert: one Replace pair, one leftover Delete.
+        let rows = align_rows("a\nb\nc\n", "a\nz\n");
+        let replace_count = rows
+            .iter()
+            .filter(|r| matches!(r.tag, DiffTag::Replace))
+            .count();
+        let delete_count = rows
+            .iter()
+            .filter(|r| matches!(r.tag, DiffTag::Delete))
+            .count();
+        assert_eq!(replace_count, 1);
+        assert_eq!(delete_count, 1);
+
+        // One delete, two inserts: one Replace pair, one leftover Insert.
+        let rows = align_rows("a\nb\n", "a\ny\nz\n");
+        let replace_count = rows
+            .iter()
+            .filter(|r| matches!(r.tag, DiffTag::Replace))
+            .count();
+        let insert_count = rows
+            .iter()
+            .filter(|r| matches!(r.tag, DiffTag::Insert))
+            .count();
+        assert_eq!(replace_count, 1);
+        assert_eq!(insert_count, 1);
+    }
+
+    // -- normalize_for_diff on stringData --------------------------------------
+
+    #[test]
+    fn normalize_for_diff_does_not_touch_string_data_key_names() {
+        // redact_secret_data only blanks the `data` map; `stringData` (raw,
+        // un-encoded values) is a distinct field. Document current behavior:
+        // normalize_for_diff still strips noise/status around it, and leaves
+        // stringData values untouched (only `data` is redacted).
+        let mut v: serde_json::Value = serde_yaml::from_str(
+            "apiVersion: v1\nkind: Secret\nmetadata:\n  name: s\n  uid: u\nstringData:\n  password: hunter2\ndata:\n  token: c2VjcmV0\nstatus:\n  phase: Active\n",
+        )
+        .unwrap();
+        normalize_for_diff(&mut v, true);
+        assert!(v.get("status").is_none());
+        assert!(v["metadata"].get("uid").is_none());
+        assert_eq!(v["data"]["token"], "");
+        assert_eq!(v["stringData"]["password"], "hunter2");
     }
 }

--- a/crates/kube/src/manifest.rs
+++ b/crates/kube/src/manifest.rs
@@ -666,6 +666,28 @@ pub fn normalize_for_diff(value: &mut serde_json::Value, is_secret: bool) {
     if is_secret {
         crate::secrets::redact_secret_data(value);
     }
+    canonicalize_diff_strings(value);
+}
+
+/// For diff display only: strip trailing whitespace from each line of every
+/// multi-line string value, recursively. YAML block scalars (`|`) cannot carry
+/// trailing spaces, so serde_yaml falls back to an escaped single-line quoted
+/// string on whichever side has them — producing a spurious whole-block diff.
+/// Canonicalizing both sides keeps equal multi-line strings in readable block
+/// style and drops whitespace-only noise.
+fn canonicalize_diff_strings(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::String(s) if s.contains('\n') => {
+            *s = s
+                .split('\n')
+                .map(|line| line.trim_end())
+                .collect::<Vec<_>>()
+                .join("\n");
+        }
+        serde_json::Value::Array(a) => a.iter_mut().for_each(canonicalize_diff_strings),
+        serde_json::Value::Object(o) => o.values_mut().for_each(canonicalize_diff_strings),
+        _ => {}
+    }
 }
 
 /// `k8s.diffManifest` — for each document, diff the live object against the
@@ -882,6 +904,34 @@ metadata:
         .unwrap();
         normalize_for_diff(&mut v, true);
         assert_ne!(v["data"]["token"], "c2VjcmV0");
+    }
+
+    #[test]
+    fn canonicalize_strips_trailing_line_whitespace() {
+        let mut v = serde_json::json!({ "args": ["# c \nmkdir -p /app \nwhile true; do sleep 30; done;\n"] });
+        canonicalize_diff_strings(&mut v);
+        assert_eq!(
+            v["args"][0],
+            "# c\nmkdir -p /app\nwhile true; do sleep 30; done;\n"
+        );
+    }
+
+    #[test]
+    fn normalize_makes_multiline_serialize_as_block_not_quoted() {
+        // Same logical script; one side has trailing spaces (would force serde_yaml
+        // into escaped quoted style), the other is clean. After normalize_for_diff,
+        // both must serialize identically in readable block style — no spurious diff.
+        let mut clean = serde_json::json!({ "args": ["# c\nmkdir -p /app\ndone;\n"] });
+        let mut spaced = serde_json::json!({ "args": ["# c \nmkdir -p /app \ndone;\n"] });
+        normalize_for_diff(&mut clean, false);
+        normalize_for_diff(&mut spaced, false);
+        let cy = serde_yaml::to_string(&clean).unwrap();
+        let sy = serde_yaml::to_string(&spaced).unwrap();
+        assert_eq!(cy, sy);
+        assert!(cy.contains("- |"), "expected block scalar, got:\n{cy}");
+        // And align_rows over the two now shows no changes.
+        let rows = align_rows(&cy, &sy);
+        assert!(rows.iter().all(|r| matches!(r.tag, DiffTag::Same)));
     }
 
     #[test]

--- a/crates/kube/src/manifest.rs
+++ b/crates/kube/src/manifest.rs
@@ -557,10 +557,48 @@ fn clean_kube_error(e: kube::Error) -> String {
     }
 }
 
+/// Validate one already-parsed document against the API server (dry-run,
+/// strict field validation). `None` means the document has no
+/// apiVersion/kind/metadata.name yet — nothing to validate, not an error.
+/// `Some(Err(_))` carries the cleaned server error message.
+async fn validate_document(
+    client: &kube::Client,
+    value: &serde_json::Value,
+) -> Option<Result<(), String>> {
+    let r = resource_ref(value)?;
+    let (group, version) = parse_api_version(&r.api_version);
+    let gvk = GroupVersionKind::gvk(&group, &version, &r.kind);
+    let ar = ApiResource::from_gvk(&gvk);
+    let api: Api<DynamicObject> = match &r.namespace {
+        Some(ns) => Api::namespaced_with(client.clone(), ns, &ar),
+        None => Api::all_with(client.clone(), &ar),
+    };
+    let params = PatchParams {
+        field_manager: Some("srelens".into()),
+        dry_run: true,
+        force: true,
+        field_validation: Some(ValidationDirective::Strict),
+    };
+    let result = match tokio::time::timeout(
+        request_timeout(),
+        api.patch(&r.name, &params, &Patch::Apply(value)),
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => return Some(Err("validation timed out".into())),
+    };
+    Some(result.map(|_| ()).map_err(clean_kube_error))
+}
+
 /// `k8s.validateManifest` — server-side dry-run apply with strict field
-/// validation. Returns the API server's real verdict (unknown fields, wrong
-/// types, invalid values, admission errors) as data, so the editor can surface
-/// Kubernetes-aware diagnostics — CRDs included, no bundled schema needed.
+/// validation, one or more `---`-separated documents. Returns the API
+/// server's real verdict (unknown fields, wrong types, invalid values,
+/// admission errors) as data for every document, so the editor can surface
+/// Kubernetes-aware diagnostics anywhere in a multi-document manifest — CRDs
+/// included, no bundled schema needed. `valid` is true only when every
+/// document validates (documents without enough identity to validate yet are
+/// skipped, not treated as failures).
 pub fn validate_manifest_capability(cache: Arc<ClientCache>) -> Capability {
     Capability::typed::<ValidateIn, ValidateOut, _, _>(
         "k8s.validateManifest",
@@ -569,57 +607,38 @@ pub fn validate_manifest_capability(cache: Arc<ClientCache>) -> Capability {
         move |input: ValidateIn| {
             let cache = cache.clone();
             async move {
-                let value: serde_json::Value = match serde_yaml::from_str(&input.yaml) {
-                    Ok(v) => v,
+                let docs = match split_documents(&input.yaml) {
+                    Ok(docs) => docs,
                     Err(e) => {
                         return Ok(ValidateOut {
                             valid: false,
-                            errors: vec![format!("parse yaml: {e}")],
+                            errors: vec![e.to_string()],
                         })
                     }
                 };
-                let get_str = |path: &[&str]| -> Option<String> {
-                    let mut cur = &value;
-                    for key in path {
-                        cur = cur.get(key)?;
+                let mut errors = Vec::new();
+                let mut client: Option<kube::Client> = None;
+                for value in &docs {
+                    if resource_ref(value).is_none() {
+                        // Nothing to validate against the server yet; not an error.
+                        continue;
                     }
-                    cur.as_str().map(String::from)
-                };
-                let (Some(api_version), Some(kind), Some(name)) = (
-                    get_str(&["apiVersion"]),
-                    get_str(&["kind"]),
-                    get_str(&["metadata", "name"]),
-                ) else {
-                    // Nothing to validate against the server yet; not an error.
-                    return Ok(ValidateOut { valid: true, errors: vec![] });
-                };
-                let namespace = get_str(&["metadata", "namespace"]);
-
-                let (group, version) = parse_api_version(&api_version);
-                let gvk = GroupVersionKind::gvk(&group, &version, &kind);
-                let ar = ApiResource::from_gvk(&gvk);
-                let client = cache
-                    .get(&input.context)
-                    .await
-                    .map_err(CapabilityError::Handler)?;
-                let api: Api<DynamicObject> = match &namespace {
-                    Some(ns) => Api::namespaced_with(client, ns, &ar),
-                    None => Api::all_with(client, &ar),
-                };
-                let params = PatchParams {
-                    field_manager: Some("srelens".into()),
-                    dry_run: true,
-                    force: true,
-                    field_validation: Some(ValidationDirective::Strict),
-                };
-                let result =
-                    tokio::time::timeout(request_timeout(), api.patch(&name, &params, &Patch::Apply(&value)))
-                        .await
-                        .map_err(|_| CapabilityError::Handler("validation timed out".into()))?;
-                Ok(match result {
-                    Ok(_) => ValidateOut { valid: true, errors: vec![] },
-                    Err(e) => ValidateOut { valid: false, errors: vec![clean_kube_error(e)] },
-                })
+                    if client.is_none() {
+                        client = Some(
+                            cache
+                                .get(&input.context)
+                                .await
+                                .map_err(CapabilityError::Handler)?,
+                        );
+                    }
+                    if let Some(Err(message)) =
+                        validate_document(client.as_ref().unwrap(), value).await
+                    {
+                        errors.push(message);
+                    }
+                }
+                let valid = errors.is_empty();
+                Ok(ValidateOut { valid, errors })
             }
         },
     )

--- a/crates/kube/src/manifest.rs
+++ b/crates/kube/src/manifest.rs
@@ -525,6 +525,152 @@ pub fn validate_manifest_capability(cache: Arc<ClientCache>) -> Capability {
     )
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DiffIn {
+    pub context: String,
+    pub yaml: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DiffDoc {
+    pub kind: String,
+    pub name: String,
+    pub namespace: Option<String>,
+    /// False when the resource does not exist yet (a create).
+    pub exists: bool,
+    /// True when current and proposed differ.
+    pub changed: bool,
+    pub rows: Vec<DiffRow>,
+    /// Live resourceVersion, for stale-edit detection (None when creating).
+    /// Serializes as `currentResourceVersion` (camelCase) for the frontend.
+    pub current_resource_version: Option<String>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct DiffOut {
+    pub documents: Vec<DiffDoc>,
+}
+
+/// Drop server-managed noise and status so the diff shows only meaningful
+/// spec/metadata changes. Redacts Secret values when `is_secret`.
+pub fn normalize_for_diff(value: &mut serde_json::Value, is_secret: bool) {
+    if let Some(obj) = value.as_object_mut() {
+        obj.remove("status");
+        if let Some(meta) = obj.get_mut("metadata").and_then(|m| m.as_object_mut()) {
+            for k in [
+                "managedFields",
+                "resourceVersion",
+                "generation",
+                "uid",
+                "creationTimestamp",
+            ] {
+                meta.remove(k);
+            }
+        }
+    }
+    if is_secret {
+        crate::secrets::redact_secret_data(value);
+    }
+}
+
+/// `k8s.diffManifest` — for each document, diff the live object against the
+/// server dry-run apply result (current | proposed) as aligned rows.
+pub fn diff_manifest_capability(cache: Arc<ClientCache>) -> Capability {
+    Capability::typed::<DiffIn, DiffOut, _, _>(
+        "k8s.diffManifest",
+        "diff a manifest against the cluster via server dry-run apply (per document)",
+        Annotations {
+            read_only: true,
+            destructive: false,
+            requires_confirm: false,
+            sensitive: true,
+        },
+        move |input: DiffIn| {
+            let cache = cache.clone();
+            async move {
+                let docs = split_documents(&input.yaml)?;
+                let client = cache
+                    .get(&input.context)
+                    .await
+                    .map_err(CapabilityError::Handler)?;
+                let mut documents = Vec::with_capacity(docs.len());
+                for value in docs {
+                    let r = resource_ref(&value).ok_or_else(|| {
+                        CapabilityError::Handler(
+                            "document missing apiVersion/kind/metadata.name".into(),
+                        )
+                    })?;
+                    let (group, version) = parse_api_version(&r.api_version);
+                    let gvk = GroupVersionKind::gvk(&group, &version, &r.kind);
+                    let ar = ApiResource::from_gvk(&gvk);
+                    let api: Api<DynamicObject> = match &r.namespace {
+                        Some(ns) => Api::namespaced_with(client.clone(), ns, &ar),
+                        None => Api::all_with(client.clone(), &ar),
+                    };
+                    let is_secret = r.kind == "Secret" && group.is_empty();
+
+                    // Current live object (may not exist).
+                    let current = tokio::time::timeout(request_timeout(), api.get_opt(&r.name))
+                        .await
+                        .map_err(|_| CapabilityError::Handler("diff get timed out".into()))?
+                        .map_err(|e| CapabilityError::Handler(e.to_string()))?;
+                    let current_resource_version = current
+                        .as_ref()
+                        .and_then(|o| o.metadata.resource_version.clone());
+                    let exists = current.is_some();
+                    let mut current_json = match current {
+                        Some(o) => serde_json::to_value(o)
+                            .map_err(|e| CapabilityError::Handler(e.to_string()))?,
+                        None => serde_json::json!({}),
+                    };
+
+                    // Proposed = server dry-run apply (force to compute merged end-state).
+                    let params = PatchParams {
+                        field_manager: Some("srelens".into()),
+                        dry_run: true,
+                        force: true,
+                        field_validation: None,
+                    };
+                    let proposed = tokio::time::timeout(
+                        request_timeout(),
+                        api.patch(&r.name, &params, &Patch::Apply(&value)),
+                    )
+                    .await
+                    .map_err(|_| CapabilityError::Handler("diff dry-run timed out".into()))?
+                    .map_err(|e| CapabilityError::Handler(clean_kube_error(e)))?;
+                    let mut proposed_json = serde_json::to_value(proposed)
+                        .map_err(|e| CapabilityError::Handler(e.to_string()))?;
+
+                    normalize_for_diff(&mut current_json, is_secret);
+                    normalize_for_diff(&mut proposed_json, is_secret);
+                    let current_yaml = if exists {
+                        serde_yaml::to_string(&current_json)
+                            .map_err(|e| CapabilityError::Handler(e.to_string()))?
+                    } else {
+                        String::new()
+                    };
+                    let proposed_yaml = serde_yaml::to_string(&proposed_json)
+                        .map_err(|e| CapabilityError::Handler(e.to_string()))?;
+                    let rows = align_rows(&current_yaml, &proposed_yaml);
+                    let changed = rows.iter().any(|row| row.tag != DiffTag::Same);
+
+                    documents.push(DiffDoc {
+                        kind: r.kind,
+                        name: r.name,
+                        namespace: r.namespace,
+                        exists,
+                        changed,
+                        rows,
+                        current_resource_version,
+                    });
+                }
+                Ok(DiffOut { documents })
+            }
+        },
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -619,5 +765,36 @@ metadata:
         assert!(matches!(rows[1].tag, DiffTag::Delete));
         assert_eq!(rows[1].left.as_deref(), Some("b"));
         assert_eq!(rows[1].right, None);
+    }
+
+    #[test]
+    fn normalize_for_diff_strips_noise_and_status() {
+        let mut v: serde_json::Value = serde_yaml::from_str(
+            "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: a\n  resourceVersion: \"7\"\n  managedFields: [x]\n  uid: u\nstatus:\n  phase: Running\ndata:\n  k: v\n",
+        ).unwrap();
+        normalize_for_diff(&mut v, false);
+        assert!(v.get("status").is_none());
+        assert!(v["metadata"].get("resourceVersion").is_none());
+        assert!(v["metadata"].get("managedFields").is_none());
+        assert!(v["metadata"].get("uid").is_none());
+        assert_eq!(v["data"]["k"], "v");
+    }
+
+    #[test]
+    fn normalize_for_diff_redacts_secret_values() {
+        let mut v: serde_json::Value = serde_yaml::from_str(
+            "apiVersion: v1\nkind: Secret\nmetadata:\n  name: s\ndata:\n  token: c2VjcmV0\n",
+        )
+        .unwrap();
+        normalize_for_diff(&mut v, true);
+        assert_ne!(v["data"]["token"], "c2VjcmV0");
+    }
+
+    #[test]
+    fn diff_capability_is_read_only() {
+        let cap = diff_manifest_capability(ClientCache::new(PathBuf::from("/x")));
+        assert_eq!(cap.id, "k8s.diffManifest");
+        assert!(cap.annotations.read_only);
+        assert!(cap.annotations.sensitive);
     }
 }

--- a/crates/kube/src/manifest.rs
+++ b/crates/kube/src/manifest.rs
@@ -3,11 +3,12 @@
 
 use std::sync::Arc;
 
-use srelens_capability::{Annotations, Capability, CapabilityError};
 use kube::api::{Api, DynamicObject, ListParams, Patch, PatchParams, ValidationDirective};
 use kube::core::{ApiResource, GroupVersionKind};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use similar::{ChangeTag, TextDiff};
+use srelens_capability::{Annotations, Capability, CapabilityError};
 
 use crate::client_cache::ClientCache;
 use crate::connect::request_timeout;
@@ -36,6 +37,77 @@ pub fn resource_ref(value: &serde_json::Value) -> Option<ResourceRef> {
         name: s(&["metadata", "name"])?,
         namespace: s(&["metadata", "namespace"]),
     })
+}
+
+/// Side-by-side alignment tag for one diff row.
+#[derive(Debug, Clone, PartialEq, Serialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum DiffTag {
+    Same,
+    Insert,
+    Delete,
+    Replace,
+}
+
+/// One aligned row of a side-by-side diff. `left` is the current (live) line,
+/// `right` the proposed line; either is `None` for a pure insert/delete.
+#[derive(Debug, Clone, PartialEq, Serialize, JsonSchema)]
+pub struct DiffRow {
+    pub tag: DiffTag,
+    pub left: Option<String>,
+    pub right: Option<String>,
+}
+
+/// Compute line-aligned side-by-side rows. Consecutive deletes followed by
+/// inserts pair into `Replace` rows; leftovers become `Delete`/`Insert`.
+pub fn align_rows(current: &str, proposed: &str) -> Vec<DiffRow> {
+    let diff = TextDiff::from_lines(current, proposed);
+    let mut rows = Vec::new();
+    let mut pending: std::collections::VecDeque<String> = std::collections::VecDeque::new();
+    let flush = |rows: &mut Vec<DiffRow>, pending: &mut std::collections::VecDeque<String>| {
+        while let Some(left) = pending.pop_front() {
+            rows.push(DiffRow {
+                tag: DiffTag::Delete,
+                left: Some(left),
+                right: None,
+            });
+        }
+    };
+    for change in diff.iter_all_changes() {
+        let line = change
+            .value()
+            .strip_suffix('\n')
+            .unwrap_or(change.value())
+            .to_string();
+        match change.tag() {
+            ChangeTag::Equal => {
+                flush(&mut rows, &mut pending);
+                rows.push(DiffRow {
+                    tag: DiffTag::Same,
+                    left: Some(line.clone()),
+                    right: Some(line),
+                });
+            }
+            ChangeTag::Delete => pending.push_back(line),
+            ChangeTag::Insert => {
+                if let Some(left) = pending.pop_front() {
+                    rows.push(DiffRow {
+                        tag: DiffTag::Replace,
+                        left: Some(left),
+                        right: Some(line),
+                    });
+                } else {
+                    rows.push(DiffRow {
+                        tag: DiffTag::Insert,
+                        left: None,
+                        right: Some(line),
+                    });
+                }
+            }
+        }
+    }
+    flush(&mut rows, &mut pending);
+    rows
 }
 
 /// Split a multi-document YAML string into parsed JSON values, skipping empty
@@ -523,5 +595,29 @@ metadata:
         assert_eq!(r.kind, "Deployment");
         assert_eq!(r.name, "web");
         assert_eq!(r.namespace.as_deref(), Some("prod"));
+    }
+
+    #[test]
+    fn align_rows_pairs_a_changed_line() {
+        let rows = align_rows("spec:\n  replicas: 3\n", "spec:\n  replicas: 5\n");
+        assert_eq!(rows.len(), 2);
+        assert!(matches!(rows[0].tag, DiffTag::Same));
+        assert_eq!(rows[0].left.as_deref(), Some("spec:"));
+        assert!(matches!(rows[1].tag, DiffTag::Replace));
+        assert_eq!(rows[1].left.as_deref(), Some("  replicas: 3"));
+        assert_eq!(rows[1].right.as_deref(), Some("  replicas: 5"));
+    }
+
+    #[test]
+    fn align_rows_marks_pure_insert_and_delete() {
+        let rows = align_rows("a\n", "a\nb\n");
+        assert!(matches!(rows[1].tag, DiffTag::Insert));
+        assert_eq!(rows[1].left, None);
+        assert_eq!(rows[1].right.as_deref(), Some("b"));
+
+        let rows = align_rows("a\nb\n", "a\n");
+        assert!(matches!(rows[1].tag, DiffTag::Delete));
+        assert_eq!(rows[1].left.as_deref(), Some("b"));
+        assert_eq!(rows[1].right, None);
     }
 }

--- a/crates/kube/src/manifest.rs
+++ b/crates/kube/src/manifest.rs
@@ -12,6 +12,47 @@ use serde::{Deserialize, Serialize};
 use crate::client_cache::ClientCache;
 use crate::connect::request_timeout;
 
+/// Identifying fields of a manifest document.
+#[derive(Debug, Clone)]
+pub struct ResourceRef {
+    pub api_version: String,
+    pub kind: String,
+    pub name: String,
+    pub namespace: Option<String>,
+}
+
+/// Pull the identifying fields from a parsed manifest document.
+pub fn resource_ref(value: &serde_json::Value) -> Option<ResourceRef> {
+    let s = |path: &[&str]| -> Option<String> {
+        let mut cur = value;
+        for key in path {
+            cur = cur.get(key)?;
+        }
+        cur.as_str().map(String::from)
+    };
+    Some(ResourceRef {
+        api_version: s(&["apiVersion"])?,
+        kind: s(&["kind"])?,
+        name: s(&["metadata", "name"])?,
+        namespace: s(&["metadata", "namespace"]),
+    })
+}
+
+/// Split a multi-document YAML string into parsed JSON values, skipping empty
+/// or whitespace/comment-only documents. Single source of truth for apply-all.
+pub fn split_documents(yaml: &str) -> Result<Vec<serde_json::Value>, CapabilityError> {
+    let mut out = Vec::new();
+    for doc in serde_yaml::Deserializer::from_str(yaml) {
+        let value = serde_json::Value::deserialize(doc)
+            .map_err(|e| CapabilityError::Handler(format!("parse yaml: {e}")))?;
+        if value.is_null() {
+            continue;
+        }
+        out.push(value);
+    }
+    Ok(out)
+}
+
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ManifestIn {
     pub context: String,
@@ -448,5 +489,39 @@ mod tests {
         let cap = get_manifest_capability(ClientCache::new(PathBuf::from("/x")));
         assert_eq!(cap.id, "k8s.getManifest");
         assert!(cap.annotations.read_only);
+    }
+
+    #[test]
+    fn splits_multiple_documents_skipping_empty() {
+        let yaml = "\
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: a
+---
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: b
+";
+        let docs = split_documents(yaml).unwrap();
+        assert_eq!(docs.len(), 2);
+        assert_eq!(docs[0]["metadata"]["name"], "a");
+        assert_eq!(docs[1]["metadata"]["name"], "b");
+    }
+
+    #[test]
+    fn resource_ref_pulls_identity() {
+        let value: serde_json::Value = serde_yaml::from_str(
+            "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: web\n  namespace: prod\n",
+        )
+        .unwrap();
+        let r = resource_ref(&value).unwrap();
+        assert_eq!(r.api_version, "apps/v1");
+        assert_eq!(r.kind, "Deployment");
+        assert_eq!(r.name, "web");
+        assert_eq!(r.namespace.as_deref(), Some("prod"));
     }
 }

--- a/crates/kube/src/secrets.rs
+++ b/crates/kube/src/secrets.rs
@@ -19,14 +19,16 @@ use serde::{Deserialize, Serialize};
 use crate::client_cache::ClientCache;
 use crate::connect::request_timeout;
 
-/// Blank the values of a serialized Secret's `data` map in place, keeping the
-/// keys. `get_object` runs this so the generic structured-detail path never
-/// carries Secret material — values are only read through the dedicated,
-/// consent-gateable `k8s.getSecret`.
+/// Blank the values of a serialized Secret's `data` and `stringData` maps in
+/// place, keeping the keys. `get_object` runs this so the generic
+/// structured-detail path never carries Secret material — values are only
+/// read through the dedicated, consent-gateable `k8s.getSecret`.
 pub(crate) fn redact_secret_data(object: &mut serde_json::Value) {
-    if let Some(data) = object.get_mut("data").and_then(|d| d.as_object_mut()) {
-        for value in data.values_mut() {
-            *value = serde_json::Value::String(String::new());
+    for key in ["data", "stringData"] {
+        if let Some(map) = object.get_mut(key).and_then(|d| d.as_object_mut()) {
+            for value in map.values_mut() {
+                *value = serde_json::Value::String(String::new());
+            }
         }
     }
 }
@@ -171,6 +173,27 @@ mod tests {
         assert_eq!(data["tls.crt"], serde_json::json!(""));
         assert_eq!(data["tls.key"], serde_json::json!(""));
         assert!(!object.to_string().contains("U0VDUkVU"));
+    }
+
+    #[test]
+    fn redaction_blanks_string_data_values_but_keeps_keys() {
+        let mut object = serde_json::json!({
+            "kind": "Secret",
+            "metadata": { "name": "web-creds" },
+            "data": { "tls.crt": "U0VDUkVU" },
+            "stringData": { "password": "hunter2", "username": "admin" }
+        });
+        redact_secret_data(&mut object);
+        let data = object["data"].as_object().unwrap();
+        assert_eq!(data["tls.crt"], serde_json::json!(""));
+        let string_data = object["stringData"].as_object().unwrap();
+        // Keys remain so the UI can list them...
+        assert!(string_data.contains_key("password"));
+        assert!(string_data.contains_key("username"));
+        // ...but every value is blanked — no material survives the generic path.
+        assert_eq!(string_data["password"], serde_json::json!(""));
+        assert_eq!(string_data["username"], serde_json::json!(""));
+        assert!(!object.to_string().contains("hunter2"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #15

## What

Implements #15 (v0.3 "Operations hardening"): server-side apply with conflict surfacing, a pre-apply dry-run diff, multi-document apply-all, and stale-`resourceVersion` warnings — plus editor polish surfaced while testing the edit-in-tab flow.

## Backend (`crates/kube`)

- **`k8s.diffManifest`** — server dry-run diff (current vs proposed) as aligned side-by-side rows (via `similar`). Secret `data`/`stringData` redacted on **both** sides; multi-line strings canonicalized so serialization-style differences (block vs quoted) don't produce spurious whole-block diffs.
- **`k8s.applyManifest`** reworked — SSA with field manager `srelens`, **non-forcing by default**, per-document (multi-doc `---`) results, structured `409` conflict parsing (owning managers + fields), confirm-gated force. Malformed/timeout documents are reported per-document rather than aborting the batch.
- **`k8s.validateManifest`** — now validates **every** document in a multi-document manifest (was single-doc only).
- Testable helpers extracted (`diff_document`, `apply_doc_from_result`, `split_documents`, `align_rows`, `parse_conflict`).

## Frontend (`apps/desktop`)

- **`DiffView`** side-by-side renderer; **`ManifestEditor`** gains a **resizable** editor↔diff split (draggable divider), a **stale-`resourceVersion` badge** (computed in the background, no need to open the panel), and a **conflict → Force apply** flow with per-document results — working in both the Edit tab and the drawer.
- **Editor polish:** contained lint tooltip + wired completion keymap (schema autocomplete), and multi-document syntax + server diagnostics via `parseAllDocuments`.

## Tests

- **Backend:** document split, aligned diff rows, 409 conflict parsing, apply/diff helpers, Secret redaction (incl. `stringData`), multi-doc validation.
- **Frontend:** lib wrappers, `DiffView`, `ManifestEditor` (conflict/force/stale/per-doc), multi-document lint mapping.
- Gates green: backend `cargo llvm-cov` **56.39%** (≥55), frontend **426** tests / **83.8%** lines (≥80).
