### PR TITLE
fix(detail): collapse labels & annotations for generic kinds (#105)

### DIFF
--- a/apps/desktop/src/components/ResourceOverview.test.tsx
+++ b/apps/desktop/src/components/ResourceOverview.test.tsx
@@ -210,6 +210,28 @@ describe("ObjectDetail (Pod)", () => {
     expect(screen.getByText("frontend")).toBeDefined();
   });
 
+  it("collapses labels and annotations for generic kinds (e.g. Node) too", () => {
+    const node: K8sObject = {
+      metadata: {
+        name: "worker-1",
+        creationTimestamp: "2026-01-01T00:00:00Z",
+        labels: { "beta.kubernetes.io/arch": "amd64", "kubernetes.io/os": "linux", role: "worker" },
+        annotations: { "node.alpha.kubernetes.io/ttl": "0" },
+      },
+      spec: {},
+      status: {},
+    };
+    render(<ObjectDetail kind="Node" obj={node} now={NOW} />);
+
+    // Collapsed by default — the count toggle shows, the chip values don't.
+    expect(screen.getByText("3 Labels")).toBeDefined();
+    expect(screen.getByText("1 Annotation")).toBeDefined();
+    expect(screen.queryByText("beta.kubernetes.io/arch")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /3 Labels/ }));
+    expect(screen.getByText("beta.kubernetes.io/arch")).toBeDefined();
+  });
+
   it("shows real volume sources and opens linked resources", () => {
     const onOpenResource = vi.fn();
     const pod: K8sObject = {

--- a/apps/desktop/src/components/ResourceOverview.tsx
+++ b/apps/desktop/src/components/ResourceOverview.tsx
@@ -180,6 +180,22 @@ function Chips({ map }: { map?: Record<string, string> }) {
 }
 
 /**
+ * A labels/annotations/selector map shown as a collapsed count summary
+ * ("42 Labels ⌄") that expands to the chips on click — so large maps (node
+ * feature labels, last-applied annotations) don't dominate the detail panel.
+ * The single source of truth for how these maps render across every detail view.
+ */
+function ChipMap({ map, singular }: { map?: Record<string, string>; singular: string }) {
+  const count = Object.keys(map ?? {}).length;
+  if (count === 0) return <span className="fl-detail-empty">None</span>;
+  return (
+    <Expandable summary={plural(count, singular)}>
+      <Chips map={map} />
+    </Expandable>
+  );
+}
+
+/**
  * A count summary that expands to its full content on click — the srelens
  * idiom for long label/annotation/toleration lists that would dominate the
  * panel ("6 Labels ⌄").
@@ -855,26 +871,8 @@ function PodDetailView({
                 ""
               ),
             ],
-            [
-              "Labels",
-              Object.keys(labels).length ? (
-                <Expandable summary={plural(Object.keys(labels).length, "Label")}>
-                  <Chips map={labels} />
-                </Expandable>
-              ) : (
-                ""
-              ),
-            ],
-            [
-              "Annotations",
-              Object.keys(annotations).length ? (
-                <Expandable summary={plural(Object.keys(annotations).length, "Annotation")}>
-                  <Chips map={annotations} />
-                </Expandable>
-              ) : (
-                ""
-              ),
-            ],
+            ["Labels", <ChipMap map={labels} singular="Label" />],
+            ["Annotations", <ChipMap map={annotations} singular="Annotation" />],
             [
               "Controlled By",
               ownerTargets.length ? (
@@ -1120,26 +1118,8 @@ function WorkloadDetailView({
                 ""
               ),
             ],
-            [
-              "Labels",
-              Object.keys(labels).length ? (
-                <Expandable summary={plural(Object.keys(labels).length, "Label")}>
-                  <Chips map={labels} />
-                </Expandable>
-              ) : (
-                ""
-              ),
-            ],
-            [
-              "Annotations",
-              Object.keys(annotations).length ? (
-                <Expandable summary={plural(Object.keys(annotations).length, "Annotation")}>
-                  <Chips map={annotations} />
-                </Expandable>
-              ) : (
-                ""
-              ),
-            ],
+            ["Labels", <ChipMap map={labels} singular="Label" />],
+            ["Annotations", <ChipMap map={annotations} singular="Annotation" />],
             ["Replicas", replicaText],
             ["Selector", <Chips key="s" map={selector} />],
             [
@@ -2874,9 +2854,9 @@ function GenericDetail({
           ]}
         />
         <div className="fl-detail-subhead">Labels</div>
-        <Chips map={meta.labels as Record<string, string>} />
+        <ChipMap map={meta.labels as Record<string, string>} singular="Label" />
         <div className="fl-detail-subhead">Annotations</div>
-        <Chips map={meta.annotations as Record<string, string>} />
+        <ChipMap map={meta.annotations as Record<string, string>} singular="Annotation" />
       </Section>
 
       <KindBody kind={kind} obj={obj} context={context} now={now} onEdited={onEdited} onOpenResource={onOpenResource} />


### PR DESCRIPTION
Closes #105

## Problem

On the Node detail (and other kinds), Labels rendered every entry as a chip with no collapse. Feature-discovery labels alone (`feature.node.kubernetes.io/*`, `directpv.min.io/*`, …) run to 50+, so the Labels block filled the panel and pushed **Annotations** far below the fold — a wall of chips instead of a scannable summary.

## Root cause

`PodDetailView` and `WorkloadDetailView` already wrapped labels/annotations in the collapsed `Expandable` idiom, but **`GenericDetail`** rendered raw `<Chips>`. Everything that isn't a Pod/Deployment/StatefulSet/ReplicaSet — **Nodes, Services, Jobs, CronJobs, ConfigMaps, Secrets, Namespaces, Ingresses, storage, RBAC, and CRD instances** — routes through `GenericDetail`, so they all showed the wall.

## Fix

- Extract a single **`ChipMap`** helper: collapsed `N Labels ⌄` count that expands to the chips on click, `None` when empty — the one source of truth for how these maps render.
- Point **all three** detail views at it. `GenericDetail` now collapses too, and the previously copy-pasted Expandable blocks in the Pod and Workload details are deduplicated so they can't drift apart again.
- Small selectors (node/pod selector, `matchLabels`) stay as inline chips — they're short and benefit from being visible.

## Result

- Node / Service / Job / CronJob / ConfigMap / Secret / Namespace / storage / RBAC / CRD details show Labels and Annotations **collapsed by default**; Annotations is reachable without scrolling.
- Pod / Deployment / StatefulSet / ReplicaSet keep their current behaviour, now via the shared helper.

## Testing

- New test: a **Node** (generic) detail collapses Labels and Annotations by default and expands on click.
- Existing Pod collapse tests still pass.
- Full suite green (**436**); `vite build` clean.
- Verified live against the reported Node detail and other kinds.

Frontend/presentation only — no capability or backend changes.