### PR TITLE
feat: RBAC-aware UX — preflight access checks on actions

### DIFF
--- a/apps/desktop/src-tauri/src/capabilities.rs
+++ b/apps/desktop/src-tauri/src/capabilities.rs
@@ -145,6 +145,7 @@ pub fn build_registry_with(cache: Arc<ClientCache>) -> Registry {
     reg.register(srelens_kube::manifest::apply_manifest_capability(cache.clone()));
     reg.register(srelens_kube::manifest::validate_manifest_capability(cache.clone()));
     reg.register(srelens_kube::manifest::diff_manifest_capability(cache.clone()));
+    reg.register(srelens_kube::access::can_i_capability(cache.clone()));
     reg.register(srelens_kube::schema::open_api_schema_capability(cache.clone()));
     reg.register(srelens_kube::crds::list_crds_capability(cache.clone()));
     reg.register(srelens_kube::crds::list_custom_resource_capability(cache.clone()));

--- a/apps/desktop/src-tauri/src/watch.rs
+++ b/apps/desktop/src-tauri/src/watch.rs
@@ -39,10 +39,28 @@ pub async fn start_resource_watch(
     namespace: String,
     kind: String,
     channel: String,
+    kubeconfig_paths: Vec<String>,
     app: AppHandle,
     manager: State<'_, WatchManager>,
 ) -> Result<String, String> {
     manager.abort(&channel);
+
+    // The watched context may live in a pasted/added kubeconfig the cache
+    // hasn't been told about yet (its `set_paths` can race this call). Register
+    // those paths WITHOUT clearing cached clients so `build_client` below can
+    // resolve the context instead of failing with "failed to load current
+    // context".
+    if !kubeconfig_paths.is_empty() {
+        manager
+            .cache
+            .ensure_paths(
+                kubeconfig_paths
+                    .into_iter()
+                    .map(std::path::PathBuf::from)
+                    .collect(),
+            )
+            .await;
+    }
 
     let cache = manager.cache.clone();
     let emit_channel = channel.clone();
@@ -363,8 +381,11 @@ pub async fn start_resource_watch(
             }
             other => Err(format!("kind not watchable: {other}")),
         };
-        if let Err(e) = result {
-            eprintln!("resource watch error: {e}");
+        if let Err(msg) = result {
+            eprintln!("resource watch error: {msg}");
+            // Surface the failure to the WebView on the same channel so a
+            // permanent (403/401) error stops the perpetual "Loading" state.
+            let _ = app_out.emit(&emit_channel, serde_json::json!({ "error": msg }));
         }
     });
 

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -50,6 +50,7 @@ import { checkForUpdateAndNotify } from "./lib/updateNotifier";
 import { notify } from "./lib/notify";
 import type { SettingsSection } from "./components/SettingsView";
 import { listContexts, deleteContext, type ClusterContext } from "./lib/clusters";
+import { clearAccessCache } from "./lib/access";
 
 interface ViewTab {
   id: number;
@@ -260,6 +261,13 @@ export function App() {
     [...new Set(tabs.flatMap((t) => (t.cluster ? [t.cluster] : [])))].map((name) => ({ name })),
     contextOrder,
   ).map(({ name }) => name);
+
+  // RBAC preflight results are cached per (context, check) — clear them on
+  // context switch so a stale cache from a previous cluster (or an admin who
+  // just changed the user's bindings) can't leave controls mis-gated.
+  useEffect(() => {
+    clearAccessCache();
+  }, [activeCluster]);
 
   /** Open (or focus, if already open) a resource view for a cluster + kind. */
   function openView(cluster: string, kind: ResourceKind) {
@@ -591,6 +599,7 @@ export function App() {
                       initialNamespace={activeTab.namespace ?? ""}
                       onNamespaceChange={(ns) => setTabNamespace(activeTab.id, activeCluster, ns)}
                       detailDrawerWidth={layout.rightSidebarWidth}
+                      kubeconfigFiles={kubeconfigFiles}
                     />
                   ) : (
                     <LandingPage

--- a/apps/desktop/src/components/DetailActions.test.tsx
+++ b/apps/desktop/src/components/DetailActions.test.tsx
@@ -35,6 +35,13 @@ const { notifyMock } = vi.hoisted(() => ({
 }));
 vi.mock("../lib/notify", () => ({ notify: notifyMock }));
 
+vi.mock("../lib/access", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/access")>();
+  return { ...actual, useAccess: vi.fn() };
+});
+import { useAccess } from "../lib/access";
+import { describeError } from "../lib/errors";
+
 import { PodActions, ResourceActions } from "./DetailActions";
 
 const pod = {
@@ -47,6 +54,15 @@ const pod = {
   age: "2d",
 };
 
+// This repo doesn't pull in @testing-library/jest-dom, so assert directly on
+// DOM properties instead of `toBeDisabled`/`toHaveAttribute` sugar.
+function isDisabled(el: HTMLElement): boolean {
+  return (el as HTMLButtonElement).disabled;
+}
+function titleOf(el: HTMLElement): string | null {
+  return el.getAttribute("title");
+}
+
 beforeEach(() => {
   deletePodMock.mockReset();
   evictPodMock.mockReset();
@@ -57,6 +73,14 @@ beforeEach(() => {
   cronjobTriggerNowMock.mockReset();
   notifyMock.success.mockReset();
   notifyMock.error.mockReset();
+  // Default: everything allowed, so pre-existing behavioural tests (written
+  // before RBAC gating existed) keep exercising enabled controls.
+  vi.mocked(useAccess).mockReturnValue({
+    allowed: () => true,
+    reason: () => "",
+    known: () => true,
+    loading: false,
+  });
 });
 
 describe("PodActions", () => {
@@ -121,7 +145,7 @@ describe("ResourceActions", () => {
     await waitFor(() => expect(notifyMock.success).toHaveBeenCalledWith(expect.stringMatching(/Scaled web to 3/)));
   });
 
-  it("shows an error toast when an operation fails", async () => {
+  it("shows an actionable error toast (mapped, not raw) when an operation fails", async () => {
     scaleResourceMock.mockResolvedValue({ error: "forbidden" });
     render(
       <ResourceActions context="kind-dev" kind="Deployment" namespace="default" name="web" onDeleted={() => {}} />,
@@ -129,7 +153,11 @@ describe("ResourceActions", () => {
     fireEvent.click(screen.getByRole("button", { name: "Scale" }));
     fireEvent.change(screen.getByLabelText("Replicas"), { target: { value: "3" } });
     fireEvent.click(screen.getByRole("button", { name: "Scale" }));
-    await waitFor(() => expect(notifyMock.error).toHaveBeenCalledWith(expect.any(String), "forbidden"));
+    // The toast carries the friendly detail from describeError, not the raw "forbidden".
+    await waitFor(() =>
+      expect(notifyMock.error).toHaveBeenCalledWith("Failed to scale web", describeError("forbidden").detail),
+    );
+    expect(notifyMock.error).not.toHaveBeenCalledWith(expect.anything(), "forbidden");
     expect(notifyMock.success).not.toHaveBeenCalled();
   });
 
@@ -218,5 +246,211 @@ describe("ResourceActions", () => {
     await waitFor(() =>
       expect(cronjobSetSuspendMock).toHaveBeenCalledWith("kind-dev", "ops", "nightly", true),
     );
+  });
+});
+
+describe("PodActions RBAC gating", () => {
+  const prodPod = { ...pod, namespace: "prod" };
+
+  it("disables the Delete control and explains why when the user can't delete", () => {
+    vi.mocked(useAccess).mockReturnValue({
+      allowed: () => false,
+      reason: () => "RBAC: no rule",
+      known: () => true,
+      loading: false,
+    });
+    render(<PodActions context="kind-dev" pod={prodPod} onDeleted={() => {}} />);
+    const del = screen.getByRole("button", { name: "Delete" });
+    expect(isDisabled(del)).toBe(true);
+    expect(titleOf(del)).toEqual(expect.stringContaining("permission to delete pods in prod"));
+  });
+
+  it("enables Delete when allowed", () => {
+    vi.mocked(useAccess).mockReturnValue({
+      allowed: () => true,
+      reason: () => "",
+      known: () => true,
+      loading: false,
+    });
+    render(<PodActions context="kind-dev" pod={prodPod} onDeleted={() => {}} />);
+    expect(isDisabled(screen.getByRole("button", { name: "Delete" }))).toBe(false);
+  });
+
+  it("disables Evict and explains why when the user can't evict", () => {
+    vi.mocked(useAccess).mockReturnValue({
+      allowed: () => false,
+      reason: () => "RBAC: no rule",
+      known: () => true,
+      loading: false,
+    });
+    render(<PodActions context="kind-dev" pod={prodPod} onDeleted={() => {}} />);
+    const evict = screen.getByRole("button", { name: "Evict" });
+    expect(isDisabled(evict)).toBe(true);
+    expect(titleOf(evict)).toEqual(expect.stringContaining("permission to create pods in prod"));
+  });
+
+  it("disables the pod Edit control and explains why when the user can't patch pods", () => {
+    vi.mocked(useAccess).mockReturnValue({
+      allowed: () => false,
+      reason: () => "RBAC: no rule",
+      known: () => true,
+      loading: false,
+    });
+    render(<PodActions context="kind-dev" pod={prodPod} onDeleted={() => {}} onEdit={() => {}} />);
+    const edit = screen.getByRole("button", { name: "Edit" });
+    expect(isDisabled(edit)).toBe(true);
+    expect(titleOf(edit)).toEqual(expect.stringContaining("permission to patch pods in prod"));
+  });
+
+  it("enables the pod Edit control when allowed", () => {
+    vi.mocked(useAccess).mockReturnValue({
+      allowed: () => true,
+      reason: () => "",
+      known: () => true,
+      loading: false,
+    });
+    render(<PodActions context="kind-dev" pod={prodPod} onDeleted={() => {}} onEdit={() => {}} />);
+    expect(isDisabled(screen.getByRole("button", { name: "Edit" }))).toBe(false);
+  });
+});
+
+describe("ResourceActions RBAC gating", () => {
+  it("disables the Delete control and explains why when the user can't delete", () => {
+    vi.mocked(useAccess).mockReturnValue({
+      allowed: () => false,
+      reason: () => "RBAC: no rule",
+      known: () => true,
+      loading: false,
+    });
+    render(
+      <ResourceActions
+        context="kind-dev"
+        kind="Deployment"
+        namespace="prod"
+        name="web"
+        onDeleted={() => {}}
+      />,
+    );
+    const del = screen.getByRole("button", { name: "Delete" });
+    expect(isDisabled(del)).toBe(true);
+    expect(titleOf(del)).toEqual(expect.stringContaining("permission to delete deployments in prod"));
+  });
+
+  it("enables Delete when allowed", () => {
+    vi.mocked(useAccess).mockReturnValue({
+      allowed: () => true,
+      reason: () => "",
+      known: () => true,
+      loading: false,
+    });
+    render(
+      <ResourceActions
+        context="kind-dev"
+        kind="Deployment"
+        namespace="prod"
+        name="web"
+        onDeleted={() => {}}
+      />,
+    );
+    expect(isDisabled(screen.getByRole("button", { name: "Delete" }))).toBe(false);
+  });
+
+  it("disables Scale when the user can't patch the scale subresource", () => {
+    vi.mocked(useAccess).mockReturnValue({
+      allowed: () => false,
+      reason: () => "RBAC: no rule",
+      known: () => true,
+      loading: false,
+    });
+    render(
+      <ResourceActions
+        context="kind-dev"
+        kind="Deployment"
+        namespace="prod"
+        name="web"
+        onDeleted={() => {}}
+      />,
+    );
+    const scale = screen.getByRole("button", { name: "Scale" });
+    expect(isDisabled(scale)).toBe(true);
+    expect(titleOf(scale)).toEqual(expect.stringContaining("permission to patch deployments in prod"));
+  });
+
+  it("disables Restart when the user can't patch the workload", () => {
+    vi.mocked(useAccess).mockReturnValue({
+      allowed: () => false,
+      reason: () => "RBAC: no rule",
+      known: () => true,
+      loading: false,
+    });
+    render(
+      <ResourceActions
+        context="kind-dev"
+        kind="Deployment"
+        namespace="prod"
+        name="web"
+        onDeleted={() => {}}
+      />,
+    );
+    expect(isDisabled(screen.getByRole("button", { name: "Restart" }))).toBe(true);
+  });
+
+  it("disables Edit when the user can't patch the resource", () => {
+    vi.mocked(useAccess).mockReturnValue({
+      allowed: () => false,
+      reason: () => "RBAC: no rule",
+      known: () => true,
+      loading: false,
+    });
+    render(
+      <ResourceActions
+        context="kind-dev"
+        kind="Deployment"
+        namespace="prod"
+        name="web"
+        onDeleted={() => {}}
+        onEdit={() => {}}
+      />,
+    );
+    expect(isDisabled(screen.getByRole("button", { name: "Edit" }))).toBe(true);
+  });
+
+  it("disables cronjob Run now / Suspend when denied", () => {
+    vi.mocked(useAccess).mockReturnValue({
+      allowed: () => false,
+      reason: () => "RBAC: no rule",
+      known: () => true,
+      loading: false,
+    });
+    render(
+      <ResourceActions
+        context="kind-dev"
+        kind="CronJob"
+        namespace="ops"
+        name="nightly"
+        onDeleted={() => {}}
+      />,
+    );
+    expect(isDisabled(screen.getByRole("button", { name: "Run now" }))).toBe(true);
+    expect(isDisabled(screen.getByRole("button", { name: "Suspend" }))).toBe(true);
+  });
+
+  it("leaves controls enabled for an unknown/CRD kind, regardless of RBAC checks", () => {
+    vi.mocked(useAccess).mockReturnValue({
+      allowed: () => false,
+      reason: () => "RBAC: no rule",
+      known: () => true,
+      loading: false,
+    });
+    render(
+      <ResourceActions
+        context="kind-dev"
+        kind="Widget"
+        namespace="prod"
+        name="thing"
+        onDeleted={() => {}}
+      />,
+    );
+    expect(isDisabled(screen.getByRole("button", { name: "Delete" }))).toBe(false);
   });
 });

--- a/apps/desktop/src/components/DetailActions.tsx
+++ b/apps/desktop/src/components/DetailActions.tsx
@@ -21,6 +21,7 @@ import {
   cronjobTriggerNow,
 } from "../lib/actions";
 import { notify } from "../lib/notify";
+import { useAccess, rbac, kindToResource, denyReason, reportActionError, type AccessCheck } from "../lib/access";
 import { IconButton, ConfirmDialog, TextInput } from "../ui";
 import { ForwardDialog } from "./ForwardDialog";
 
@@ -51,6 +52,11 @@ export function PodActions({
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
 
+  const deleteCheck = rbac.deletePod(pod.namespace);
+  const evictCheck = rbac.evictPod(pod.namespace);
+  const editCheck = rbac.edit("", "pods", pod.namespace);
+  const access = useAccess(context, [deleteCheck, evictCheck, editCheck]);
+
   const target = { context, namespace: pod.namespace, pod: pod.name };
 
   async function doDelete() {
@@ -60,7 +66,7 @@ export function PodActions({
     setBusy(false);
     if (out.error) {
       setError(out.error);
-      notify.error(`Failed to delete ${pod.name}`, out.error);
+      reportActionError(context, `Failed to delete ${pod.name}`, out.error);
       return;
     }
     setDialog(null);
@@ -75,7 +81,7 @@ export function PodActions({
     setBusy(false);
     if (out.error) {
       setError(out.error);
-      notify.error(`Failed to evict ${pod.name}`, out.error);
+      reportActionError(context, `Failed to evict ${pod.name}`, out.error);
       return;
     }
     setDialog(null);
@@ -87,11 +93,21 @@ export function PodActions({
     <>
       <IconButton icon={Logs} label="Logs" onClick={() => onOpenLogs?.(target)} />
       <IconButton icon={SquareTerminal} label="Shell" onClick={() => onOpenTerminal?.(target)} />
-      {onEdit && <IconButton icon={Pencil} label="Edit" onClick={onEdit} />}
+      {onEdit && (
+        <IconButton
+          icon={Pencil}
+          label="Edit"
+          disabled={!access.allowed(editCheck)}
+          title={denyReason(access, editCheck)}
+          onClick={onEdit}
+        />
+      )}
       <IconButton icon={ArrowLeftRight} label="Forward" onClick={() => setDialog("forward")} />
       <IconButton
         icon={LogOut}
         label="Evict"
+        disabled={!access.allowed(evictCheck)}
+        title={denyReason(access, evictCheck)}
         onClick={() => {
           setError("");
           setDialog("evict");
@@ -101,6 +117,8 @@ export function PodActions({
         icon={Trash2}
         label="Delete"
         danger
+        disabled={!access.allowed(deleteCheck)}
+        title={denyReason(access, deleteCheck)}
         onClick={() => {
           setError("");
           setDialog("delete");
@@ -216,6 +234,28 @@ export function ResourceActions({
   const [err, setErr] = useState("");
   const isCronJob = kind === "CronJob";
 
+  // `res` is null for an unknown/CRD kind we don't have a GVR mapping for —
+  // in that case leave controls enabled and let the API server stay the
+  // source of truth, rather than guessing at RBAC.
+  const res = kindToResource(kind);
+  const ns = namespace ?? "";
+  const deleteCheck = res ? rbac.deleteResource(res.group, res.resource, ns) : null;
+  const scaleCheck = res && SCALABLE.includes(kind) ? rbac.scale(res.group, res.resource, ns) : null;
+  const restartCheck =
+    res && RESTARTABLE.includes(kind) ? rbac.rolloutRestart(res.group, res.resource, ns) : null;
+  const editCheck = res && onEdit ? rbac.edit(res.group, res.resource, ns) : null;
+  const cronSuspendCheck = res && isCronJob ? rbac.cronjobSuspend(ns) : null;
+  const cronTriggerCheck = res && isCronJob ? rbac.cronjobTrigger(ns) : null;
+  const checks: AccessCheck[] = [
+    deleteCheck,
+    scaleCheck,
+    restartCheck,
+    editCheck,
+    cronSuspendCheck,
+    cronTriggerCheck,
+  ].filter((c): c is AccessCheck => c !== null);
+  const access = useAccess(context, checks);
+
   async function doSetSuspend() {
     setBusy("suspend");
     setErr("");
@@ -224,7 +264,7 @@ export function ResourceActions({
     setBusy("");
     if (r.error) {
       setErr(r.error);
-      notify.error(`Failed to ${resume ? "resume" : "suspend"} ${name}`, r.error);
+      reportActionError(context, `Failed to ${resume ? "resume" : "suspend"} ${name}`, r.error);
       return;
     }
     notify.success(`${resume ? "Resumed" : "Suspended"} ${name}`);
@@ -238,7 +278,7 @@ export function ResourceActions({
     setBusy("");
     if (r.error) {
       setErr(r.error);
-      notify.error(`Failed to run ${name}`, r.error);
+      reportActionError(context, `Failed to run ${name}`, r.error);
       return;
     }
     setTriggering(false);
@@ -253,7 +293,7 @@ export function ResourceActions({
     setBusy("");
     if (r.error) {
       setErr(r.error);
-      notify.error(`Failed to delete ${name}`, r.error);
+      reportActionError(context, `Failed to delete ${name}`, r.error);
       return;
     }
     setConfirmDelete(false);
@@ -273,7 +313,7 @@ export function ResourceActions({
     setBusy("");
     if (r.error) {
       setErr(r.error);
-      notify.error(`Failed to scale ${name}`, r.error);
+      reportActionError(context, `Failed to scale ${name}`, r.error);
       return;
     }
     setScaling(false);
@@ -287,7 +327,7 @@ export function ResourceActions({
     const r = await rolloutRestart(context, kind, namespace ?? "", name);
     setBusy("");
     if (r.error) {
-      notify.error(`Failed to restart ${name}`, r.error);
+      reportActionError(context, `Failed to restart ${name}`, r.error);
       return;
     }
     notify.success(`Rollout restart triggered for ${name}`);
@@ -303,30 +343,59 @@ export function ResourceActions({
           onClick={() => onOpenLogs({ context, namespace: namespace ?? "", kind, name })}
         />
       )}
-      {onEdit && <IconButton icon={Pencil} label="Edit" onClick={onEdit} />}
+      {onEdit && (
+        <IconButton
+          icon={Pencil}
+          label="Edit"
+          disabled={editCheck ? !access.allowed(editCheck) : false}
+          title={editCheck ? denyReason(access, editCheck) : undefined}
+          onClick={onEdit}
+        />
+      )}
       {SCALABLE.includes(kind) && (
-        <IconButton icon={Scaling} label="Scale" onClick={() => setScaling(true)} />
+        <IconButton
+          icon={Scaling}
+          label="Scale"
+          disabled={scaleCheck ? !access.allowed(scaleCheck) : false}
+          title={scaleCheck ? denyReason(access, scaleCheck) : undefined}
+          onClick={() => setScaling(true)}
+        />
       )}
       {RESTARTABLE.includes(kind) && (
         <IconButton
           icon={RotateCw}
           label="Restart"
-          disabled={busy === "restart"}
+          disabled={busy === "restart" || (restartCheck ? !access.allowed(restartCheck) : false)}
+          title={restartCheck ? denyReason(access, restartCheck) : undefined}
           onClick={() => void doRestart()}
         />
       )}
       {isCronJob && (
-        <IconButton icon={Zap} label="Run now" onClick={() => setTriggering(true)} />
+        <IconButton
+          icon={Zap}
+          label="Run now"
+          disabled={cronTriggerCheck ? !access.allowed(cronTriggerCheck) : false}
+          title={cronTriggerCheck ? denyReason(access, cronTriggerCheck) : undefined}
+          onClick={() => setTriggering(true)}
+        />
       )}
       {isCronJob && (
         <IconButton
           icon={cronjobSuspended ? Play : Pause}
           label={cronjobSuspended ? "Resume" : "Suspend"}
-          disabled={busy === "suspend"}
+          disabled={busy === "suspend" || (cronSuspendCheck ? !access.allowed(cronSuspendCheck) : false)}
+          title={cronSuspendCheck ? denyReason(access, cronSuspendCheck) : undefined}
           onClick={() => void doSetSuspend()}
         />
       )}
-      <IconButton icon={Trash2} label="Delete" danger onClick={() => setConfirmDelete(true)} />
+      <IconButton
+        icon={Trash2}
+        label="Delete"
+        danger
+        disabled={deleteCheck ? !access.allowed(deleteCheck) : false}
+        title={deleteCheck ? denyReason(access, deleteCheck) : undefined}
+        onClick={() => setConfirmDelete(true)}
+      />
 
       {triggering && (
         <ConfirmDialog

--- a/apps/desktop/src/components/ManifestEditor.test.tsx
+++ b/apps/desktop/src/components/ManifestEditor.test.tsx
@@ -20,8 +20,19 @@ vi.mock("../ui/CodeEditor", () => ({
     <textarea aria-label={ariaLabel} value={value} onChange={(e) => onChange?.(e.target.value)} />
   ),
 }));
+vi.mock("../lib/access", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/access")>();
+  return { ...actual, useAccess: vi.fn() };
+});
+import { useAccess } from "../lib/access";
 
 import { ManifestEditor } from "./ManifestEditor";
+
+// This repo doesn't pull in @testing-library/jest-dom, so assert directly on
+// DOM properties instead of `toBeDisabled` sugar.
+function isDisabled(el: HTMLElement): boolean {
+  return (el as HTMLButtonElement).disabled;
+}
 
 function Harness({ mode }: { mode: "create" | "edit" }) {
   const [yaml, setYaml] = useState("kind: ConfigMap\nmetadata:\n  name: web\n");
@@ -42,6 +53,14 @@ beforeEach(() => {
   diffManifestMock.mockResolvedValue({ documents: [] });
   notifyMock.success.mockReset();
   notifyMock.error.mockReset();
+  // Default: allowed, so pre-existing behavioural tests (written before RBAC
+  // gating existed) keep exercising an enabled Apply button.
+  vi.mocked(useAccess).mockReturnValue({
+    allowed: () => true,
+    reason: () => "",
+    known: () => true,
+    loading: false,
+  });
 });
 
 describe("ManifestEditor", () => {
@@ -301,5 +320,100 @@ describe("ManifestEditor", () => {
     expect(screen.queryByText("No changes")).toBeNull();
     expect(container.querySelector(".fl-changes-panel__resize")).toBeNull();
     expect(container.querySelector(".fl-changes-panel")).toBeNull();
+  });
+
+  it("disables Apply when the user can't patch the edited resource", async () => {
+    vi.mocked(useAccess).mockReturnValue({ allowed: () => false, reason: () => "", known: () => true, loading: false });
+    render(
+      <ManifestEditor
+        context="ctx"
+        yaml={"apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: web\n  namespace: prod\n"}
+        onYamlChange={() => {}}
+        confirm={{ kind: "Deployment", name: "web" }}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: /apply/i });
+    expect(isDisabled(btn)).toBe(true);
+    expect(btn.getAttribute("title")).toBe("You don't have permission to patch deployments in prod");
+  });
+
+  it("edit mode: disables Apply while the access check is still loading (fail-closed, no title yet)", async () => {
+    // Check not yet resolved: known() false. Fail-closed ⇒ Apply is disabled,
+    // but the permission title isn't shown until the check resolves as denied.
+    vi.mocked(useAccess).mockReturnValue({ allowed: () => false, reason: () => "", known: () => false, loading: true });
+    render(
+      <ManifestEditor
+        context="ctx"
+        yaml={"apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: web\n  namespace: prod\n"}
+        onYamlChange={() => {}}
+        confirm={{ kind: "Deployment", name: "web" }}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: /apply/i });
+    expect(isDisabled(btn)).toBe(true);
+    expect(btn.getAttribute("title")).toBeNull();
+  });
+
+  it("new-resource mode (no confirm): does not access-gate Apply even when denied", async () => {
+    // The New-resource tab creates (verb `create`), not patches — so a user who
+    // can't patch must still be able to Apply. Only edit mode (confirm set) gates.
+    vi.mocked(useAccess).mockReturnValue({ allowed: () => false, reason: () => "", known: () => true, loading: false });
+    render(
+      <ManifestEditor
+        context="ctx"
+        yaml={"apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: web\n  namespace: prod\n"}
+        onYamlChange={() => {}}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: /apply/i });
+    expect(isDisabled(btn)).toBe(false);
+    expect(btn.getAttribute("title")).toBeNull();
+  });
+
+  it("keeps Apply enabled for an unknown/CRD kind", async () => {
+    vi.mocked(useAccess).mockReturnValue({ allowed: () => false, reason: () => "", known: () => true, loading: false });
+    render(
+      <ManifestEditor
+        context="ctx"
+        yaml={"apiVersion: example.com/v1\nkind: Widget\nmetadata:\n  name: w\n"}
+        onYamlChange={() => {}}
+      />,
+    );
+    expect(isDisabled(screen.getByRole("button", { name: /apply/i }))).toBe(false);
+  });
+
+  it("edit mode: disables Apply for a MULTI-document manifest whose first doc is a denied Deployment", async () => {
+    // `parse()` throws on multi-document YAML — the identity must instead be
+    // derived from the FIRST document via `parseAllDocuments`, or Apply is left
+    // ungated (fail-open). With useAccess denying the Deployment, Apply must be
+    // DISABLED with the permission title.
+    vi.mocked(useAccess).mockReturnValue({ allowed: () => false, reason: () => "", known: () => true, loading: false });
+    render(
+      <ManifestEditor
+        context="ctx"
+        yaml={
+          "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: web\n  namespace: prod\n---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cfg\n  namespace: prod\n"
+        }
+        onYamlChange={() => {}}
+        confirm={{ kind: "Deployment", name: "web" }}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: /apply/i });
+    expect(isDisabled(btn)).toBe(true);
+    expect(btn.getAttribute("title")).toBe("You don't have permission to patch deployments in prod");
+  });
+
+  it("names the authorized action in the edit-apply confirm dialog", async () => {
+    render(
+      <ManifestEditor
+        context="ctx"
+        yaml={"apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: web\n  namespace: prod\n"}
+        onYamlChange={() => {}}
+        confirm={{ kind: "Deployment", name: "web" }}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await waitFor(() => expect(screen.getByText("Apply manifest?")).toBeDefined());
+    expect(screen.getByText(/This authorizes patch on deployments in prod/)).toBeDefined();
   });
 });

--- a/apps/desktop/src/components/ManifestEditor.tsx
+++ b/apps/desktop/src/components/ManifestEditor.tsx
@@ -1,4 +1,5 @@
 import React, { Suspense, lazy, useEffect, useRef, useState } from "react";
+import { parseAllDocuments } from "yaml";
 import { CircleCheck, Undo2, Upload } from "lucide-react";
 import {
   applyManifest,
@@ -11,6 +12,8 @@ import {
 } from "../lib/manifest";
 import { notify } from "../lib/notify";
 import { openApiSchema } from "../lib/schema";
+import { useAccess, rbac, kindToResource, reportActionError, type AccessCheck } from "../lib/access";
+import { describeError } from "../lib/errors";
 import { Spinner, Button, ConfirmDialog } from "../ui";
 import { DiffView } from "./DiffView";
 
@@ -119,6 +122,37 @@ export function ManifestEditor({
     }
   }, [yaml]);
 
+  // Derive the edited resource's identity from the FIRST YAML document so Apply
+  // can be gated on whether the user is authorized to patch it. `parseAllDocuments`
+  // (not `parse`, which THROWS on multi-document input) handles multi-doc streams;
+  // we gate on the first document. Only EDIT mode (`confirm` set) is gated: the
+  // New-resource tab creates (verb `create`, not `patch`), so gating on `patch`
+  // there would wrongly disable Apply for a user who can create but not patch.
+  // Unknown/CRD kinds (kindToResource → null) resolve to `null` too — Apply stays
+  // enabled and the API server remains the source of truth for those.
+  const identity: AccessCheck | null = (() => {
+    if (!confirm) return null; // only gate edits; creates use a different verb (create)
+    try {
+      const docs = parseAllDocuments(yaml);
+      const first = docs[0]?.toJS() as { kind?: string; metadata?: { namespace?: string } } | null;
+      if (!first?.kind) return null;
+      const res = kindToResource(first.kind);
+      if (!res) return null;
+      return rbac.edit(res.group, res.resource, first.metadata?.namespace ?? "");
+    } catch {
+      return null;
+    }
+  })();
+  const access = useAccess(context, identity ? [identity] : []);
+  // Fail-CLOSED (matches DetailActions/NodeCordonAction and the spec): disabled
+  // while the check is still loading OR resolved as denied. The explanatory
+  // title only appears once the check has resolved as denied.
+  const applyDenied = identity ? !access.allowed(identity) : false;
+  const applyDeniedTitle =
+    identity && access.known(identity) && !access.allowed(identity)
+      ? `You don't have permission to patch ${identity.resource}${identity.namespace ? ` in ${identity.namespace}` : ""}`
+      : undefined;
+
   const conflictEntries = (conflictDocs ?? []).filter(
     (d): d is ApplyDoc & { conflict: Conflict } => d.conflict != null,
   );
@@ -132,9 +166,10 @@ export function ManifestEditor({
     const out = await applyManifest(context, yaml, force);
     setBusy(false);
     if (out.error) {
-      setError(out.error);
+      setError(describeError(out.error).detail);
       setConflictDocs(null);
-      notify.error(`Failed to apply ${confirm?.name ?? "resource"}`, out.error);
+      // Actionable toast; a 403 also invalidates this context's access cache.
+      reportActionError(context, `Failed to apply ${confirm?.name ?? "resource"}`, out.error);
       return;
     }
     const docs = out.documents ?? [];
@@ -147,7 +182,8 @@ export function ManifestEditor({
         failedDocs.length > 1 ? `Failed to apply ${failedDocs.length} documents: ${names}` : `Failed to apply ${names}`;
       const detail = failedDocs.map((d) => d.error).filter(Boolean).join("; ") || "apply failed";
       setError(label);
-      notify.error(label, detail);
+      // Actionable toast; a 403 also invalidates this context's access cache.
+      reportActionError(context, label, detail);
     };
     // Close the confirm dialog for any resolved response (conflict, failure, or
     // success) — the conflict banner and error text render inline, outside the
@@ -241,7 +277,11 @@ export function ManifestEditor({
   );
 
   const applyButton = (
-    <Button onClick={onApplyClick} disabled={busy || !yaml.trim() || (resetTo != null && yaml === resetTo)}>
+    <Button
+      onClick={onApplyClick}
+      disabled={busy || !yaml.trim() || (resetTo != null && yaml === resetTo) || applyDenied}
+      title={applyDeniedTitle}
+    >
       {busy ? <Spinner label={applyingLabel} data-icon="inline-start" /> : applyIcon ?? <Upload data-icon="inline-start" />}
       {busy ? applyingLabel : applyLabel}
     </Button>
@@ -255,6 +295,12 @@ export function ManifestEditor({
           <p style={{ marginTop: 0 }}>
             Server-side apply the edited <code>{confirm?.kind}</code> <code>{confirm?.name}</code> to the cluster?
           </p>
+          {identity && (
+            <p>
+              This authorizes patch on {identity.resource}
+              {identity.namespace ? ` in ${identity.namespace}` : ""}.
+            </p>
+          )}
           {error && <p style={{ color: "var(--fl-color-danger)" }}>Error: {error}</p>}
         </>
       }

--- a/apps/desktop/src/components/NodeCordonAction.test.tsx
+++ b/apps/desktop/src/components/NodeCordonAction.test.tsx
@@ -1,7 +1,25 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import React from "react";
+
+vi.mock("../lib/access", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/access")>();
+  return { ...actual, useAccess: vi.fn() };
+});
+import { useAccess } from "../lib/access";
+
 import { NodeCordonAction } from "./NodeCordonAction";
+
+beforeEach(() => {
+  // Default: everything allowed, so pre-existing behavioural tests (written
+  // before RBAC gating existed) keep exercising enabled controls.
+  vi.mocked(useAccess).mockReturnValue({
+    allowed: () => true,
+    reason: () => "",
+    known: () => true,
+    loading: false,
+  });
+});
 
 describe("NodeCordonAction", () => {
   it("offers Cordon for a schedulable node and applies it", async () => {
@@ -38,5 +56,34 @@ describe("NodeCordonAction", () => {
     // dialog open → the dialog's Drain button is the only reachable one
     fireEvent.click(screen.getByRole("button", { name: "Drain" }));
     await waitFor(() => expect(drainFn).toHaveBeenCalledWith("kind-dev", "node-a"));
+  });
+});
+
+describe("NodeCordonAction RBAC gating", () => {
+  it("disables Cordon and explains why when the user can't patch nodes", async () => {
+    vi.mocked(useAccess).mockReturnValue({
+      allowed: () => false,
+      reason: () => "RBAC: no rule",
+      known: () => true,
+      loading: false,
+    });
+    const getObjectFn = vi.fn().mockResolvedValue({ object: { spec: {} } });
+    render(<NodeCordonAction context="kind-dev" name="node-a" getObjectFn={getObjectFn} />);
+    const cordon = await screen.findByRole("button", { name: "Cordon" });
+    expect((cordon as HTMLButtonElement).disabled).toBe(true);
+    expect(cordon.getAttribute("title")).toEqual(expect.stringContaining("patch nodes"));
+  });
+
+  it("enables Cordon when allowed", async () => {
+    vi.mocked(useAccess).mockReturnValue({
+      allowed: () => true,
+      reason: () => "",
+      known: () => true,
+      loading: false,
+    });
+    const getObjectFn = vi.fn().mockResolvedValue({ object: { spec: {} } });
+    render(<NodeCordonAction context="kind-dev" name="node-a" getObjectFn={getObjectFn} />);
+    const cordon = await screen.findByRole("button", { name: "Cordon" });
+    expect((cordon as HTMLButtonElement).disabled).toBe(false);
   });
 });

--- a/apps/desktop/src/components/NodeCordonAction.tsx
+++ b/apps/desktop/src/components/NodeCordonAction.tsx
@@ -3,6 +3,7 @@ import { ArrowDownToLine, CircleCheck, CircleSlash2 } from "lucide-react";
 import { getObject } from "../lib/manifest";
 import { cordonNode, drainNode } from "../lib/actions";
 import { notify } from "../lib/notify";
+import { useAccess, rbac, denyReason, reportActionError } from "../lib/access";
 import { IconButton, ConfirmDialog } from "../ui";
 
 /**
@@ -28,6 +29,10 @@ export function NodeCordonAction({
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState("");
 
+  const cordonCheck = rbac.cordon();
+  const drainCheck = rbac.drain();
+  const access = useAccess(context, [cordonCheck, drainCheck]);
+
   useEffect(() => {
     let active = true;
     void getObjectFn(context, "Node", null, name).then((o) => {
@@ -48,7 +53,7 @@ export function NodeCordonAction({
     setBusy(false);
     if (r.error) {
       setErr(r.error);
-      notify.error(`Failed to ${cordoned ? "uncordon" : "cordon"} ${name}`, r.error);
+      reportActionError(context, `Failed to ${cordoned ? "uncordon" : "cordon"} ${name}`, r.error);
       return;
     }
     setDialog(null);
@@ -63,7 +68,7 @@ export function NodeCordonAction({
     setBusy(false);
     if (r.error) {
       setErr(r.error);
-      notify.error(`Failed to drain ${name}`, r.error);
+      reportActionError(context, `Failed to drain ${name}`, r.error);
       return;
     }
     setDialog(null);
@@ -76,6 +81,8 @@ export function NodeCordonAction({
       <IconButton
         icon={cordoned ? CircleCheck : CircleSlash2}
         label={cordoned ? "Uncordon" : "Cordon"}
+        disabled={!access.allowed(cordonCheck)}
+        title={denyReason(access, cordonCheck)}
         onClick={() => {
           setErr("");
           setDialog("cordon");
@@ -84,6 +91,8 @@ export function NodeCordonAction({
       <IconButton
         icon={ArrowDownToLine}
         label="Drain"
+        disabled={!access.allowed(drainCheck)}
+        title={denyReason(access, drainCheck)}
         onClick={() => {
           setErr("");
           setDialog("drain");

--- a/apps/desktop/src/components/ResourceBrowser.test.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.test.tsx
@@ -11,6 +11,7 @@ const {
   getManifestMock,
   getObjectMock,
   listResourceMock,
+  listContextsMock,
 } = vi.hoisted(() => ({
   listNamespacesMock: vi.fn(),
   podLogsMock: vi.fn(),
@@ -19,6 +20,7 @@ const {
   getManifestMock: vi.fn(),
   getObjectMock: vi.fn(),
   listResourceMock: vi.fn(),
+  listContextsMock: vi.fn(),
 }));
 vi.mock("../lib/workloads", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../lib/workloads")>();
@@ -37,6 +39,13 @@ vi.mock("../lib/manifest", async (importOriginal) => {
     getManifest: getManifestMock,
     getObject: getObjectMock,
     listResource: listResourceMock,
+  };
+});
+vi.mock("../lib/clusters", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/clusters")>();
+  return {
+    ...actual,
+    listContexts: listContextsMock,
   };
 });
 vi.mock("../lib/watch", () => ({
@@ -81,6 +90,22 @@ vi.mock("../ui/CodeEditor", () => ({
     <textarea aria-label={ariaLabel} value={value} onChange={(e) => onChange?.(e.target.value)} />
   ),
 }));
+// This suite doesn't exercise RBAC gating itself (see DetailActions.test.tsx
+// and NodeCordonAction.test.tsx for that); stub `useAccess` as always-allowed
+// so header actions stay enabled/clickable as they were before preflight
+// access checks existed.
+vi.mock("../lib/access", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/access")>();
+  return {
+    ...actual,
+    useAccess: () => ({
+      allowed: () => true,
+      reason: () => "",
+      known: () => true,
+      loading: false,
+    }),
+  };
+});
 
 import { ResourceBrowser } from "./ResourceBrowser";
 
@@ -110,6 +135,8 @@ beforeEach(() => {
   getObjectMock.mockReset();
   getObjectMock.mockResolvedValue({ object: { metadata: { name: "web" } } });
   listResourceMock.mockReset();
+  listContextsMock.mockReset();
+  listContextsMock.mockResolvedValue({ contexts: [] });
 });
 
 describe("ResourceBrowser", () => {
@@ -120,10 +147,61 @@ describe("ResourceBrowser", () => {
     render(<ResourceBrowser context="kind-dev" kind="pods" />);
 
     await waitFor(() => expect(screen.getByText("web-1")).toBeDefined());
-    expect(watchResourceMock).toHaveBeenCalledWith("kind-dev", "", "pods", expect.any(Function), expect.any(Function));
+    expect(watchResourceMock).toHaveBeenCalledWith("kind-dev", "", "pods", expect.any(Function), expect.any(Function), expect.any(Function), []);
     expect(screen.getByText("live")).toBeDefined();
     // The column picker is now available on every resource table, not just Nodes.
     expect(screen.getByRole("button", { name: "Choose columns" })).toBeDefined();
+  });
+
+  it("registers configured kubeconfig paths before building a client for the context", async () => {
+    // Regression: a restored tab for a context that lives in a PASTED/additional
+    // kubeconfig file must register that file's path (via listContexts) BEFORE it
+    // builds a client (listNamespaces / the watch). Otherwise build_client can't
+    // find the context and the first open fails with "failed to load current
+    // context" until a later call happens to set the paths.
+    const calls: string[] = [];
+    listContextsMock.mockImplementation(async (paths?: string[]) => {
+      calls.push(`listContexts:${JSON.stringify(paths)}`);
+      return { contexts: [] };
+    });
+    listNamespacesMock.mockImplementation(async () => {
+      calls.push("listNamespaces");
+      return { namespaces: ["default"] };
+    });
+    watchResourceMock.mockImplementation(
+      watchWith([{ name: "web", namespace: "default", ready: "1/1", upToDate: 1, available: 1 }]),
+    );
+
+    render(
+      <ResourceBrowser
+        context="kind-dev"
+        kind="deployments"
+        kubeconfigFiles={["/some/pasted.yaml"]}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("web")).toBeDefined());
+
+    // The path registration (listContexts with the configured files) must run
+    // FIRST, and before the namespace list / client build.
+    const registerCall = `listContexts:${JSON.stringify(["/some/pasted.yaml"])}`;
+    expect(listContextsMock).toHaveBeenCalledWith(["/some/pasted.yaml"]);
+    const registerIdx = calls.indexOf(registerCall);
+    const nsIdx = calls.indexOf("listNamespaces");
+    expect(registerIdx).toBeGreaterThanOrEqual(0);
+    expect(nsIdx).toBeGreaterThanOrEqual(0);
+    expect(registerIdx).toBeLessThan(nsIdx);
+  });
+
+  it("does not register paths (skips listContexts) when no kubeconfig files are configured", async () => {
+    listNamespacesMock.mockResolvedValue({ namespaces: ["default"] });
+    watchResourceMock.mockImplementation(watchWith([pod]));
+
+    render(<ResourceBrowser context="kind-dev" kind="pods" />);
+
+    await waitFor(() => expect(screen.getByText("web-1")).toBeDefined());
+    // With no additional files, the effect skips the path-registration pre-step.
+    expect(listContextsMock).not.toHaveBeenCalled();
   });
 
   it("hides a column via the picker on a non-node view and remembers it", async () => {
@@ -152,7 +230,7 @@ describe("ResourceBrowser", () => {
     render(<ResourceBrowser context="kind-dev" kind="deployments" />);
 
     await waitFor(() => expect(screen.getByText("web")).toBeDefined());
-    expect(watchResourceMock).toHaveBeenCalledWith("kind-dev", "", "deployments", expect.any(Function), expect.any(Function));
+    expect(watchResourceMock).toHaveBeenCalledWith("kind-dev", "", "deployments", expect.any(Function), expect.any(Function), expect.any(Function), []);
   });
 
   it("streams statefulsets live with the governing service column", async () => {
@@ -164,7 +242,7 @@ describe("ResourceBrowser", () => {
     render(<ResourceBrowser context="kind-dev" kind="statefulsets" />);
 
     await waitFor(() => expect(screen.getByText("pg")).toBeDefined());
-    expect(watchResourceMock).toHaveBeenCalledWith("kind-dev", "", "statefulsets", expect.any(Function), expect.any(Function));
+    expect(watchResourceMock).toHaveBeenCalledWith("kind-dev", "", "statefulsets", expect.any(Function), expect.any(Function), expect.any(Function), []);
     expect(screen.getByText("pg-headless")).toBeDefined();
   });
 
@@ -211,7 +289,7 @@ describe("ResourceBrowser", () => {
     render(<ResourceBrowser context="kind-dev" kind="cronjobs" />);
 
     await waitFor(() => expect(screen.getByText("nightly")).toBeDefined());
-    expect(watchResourceMock).toHaveBeenCalledWith("kind-dev", "", "cronjobs", expect.any(Function), expect.any(Function));
+    expect(watchResourceMock).toHaveBeenCalledWith("kind-dev", "", "cronjobs", expect.any(Function), expect.any(Function), expect.any(Function), []);
     expect(screen.getByText("0 2 * * *")).toBeDefined();
     expect(screen.getByText("Suspended")).toBeDefined();
   });
@@ -225,7 +303,7 @@ describe("ResourceBrowser", () => {
     render(<ResourceBrowser context="kind-dev" kind="configmaps" />);
 
     await waitFor(() => expect(screen.getByText("web-config")).toBeDefined());
-    expect(watchResourceMock).toHaveBeenCalledWith("kind-dev", "", "configmaps", expect.any(Function), expect.any(Function));
+    expect(watchResourceMock).toHaveBeenCalledWith("kind-dev", "", "configmaps", expect.any(Function), expect.any(Function), expect.any(Function), []);
     expect(screen.getByText("3")).toBeDefined();
   });
 
@@ -272,6 +350,8 @@ describe("ResourceBrowser", () => {
         "ingresses",
         expect.any(Function),
         expect.any(Function),
+        expect.any(Function),
+        [],
       ),
     );
     expect(await screen.findByText("web")).toBeDefined();
@@ -335,6 +415,8 @@ describe("ResourceBrowser", () => {
         "persistentvolumes",
         expect.any(Function),
         expect.any(Function),
+        expect.any(Function),
+        [],
       ),
     );
     expect(await screen.findByText("pv-123")).toBeDefined();
@@ -361,7 +443,7 @@ describe("ResourceBrowser", () => {
     watchResourceMock.mockImplementation(watchWith([{ name: "builder", namespace: "ci", secrets: 2, age: "3d" }]));
     render(<ResourceBrowser context="kind-dev" kind="serviceaccounts" />);
     await waitFor(() => expect(screen.getByText("builder")).toBeDefined());
-    expect(watchResourceMock).toHaveBeenCalledWith("kind-dev", "", "serviceaccounts", expect.any(Function), expect.any(Function));
+    expect(watchResourceMock).toHaveBeenCalledWith("kind-dev", "", "serviceaccounts", expect.any(Function), expect.any(Function), expect.any(Function), []);
     expect(screen.getByText("2")).toBeDefined();
   });
 
@@ -378,7 +460,7 @@ describe("ResourceBrowser", () => {
     watchResourceMock.mockImplementation(watchWith([{ name: "view", rules: 10, age: "9d" }]));
     render(<ResourceBrowser context="kind-dev" kind="clusterroles" />);
     await waitFor(() =>
-      expect(watchResourceMock).toHaveBeenCalledWith("kind-dev", "", "clusterroles", expect.any(Function), expect.any(Function)),
+      expect(watchResourceMock).toHaveBeenCalledWith("kind-dev", "", "clusterroles", expect.any(Function), expect.any(Function), expect.any(Function), []),
     );
     expect(await screen.findByText("view")).toBeDefined();
     expect(screen.getByText("10")).toBeDefined();
@@ -424,6 +506,8 @@ describe("ResourceBrowser", () => {
         "pods",
         expect.any(Function),
         expect.any(Function),
+        expect.any(Function),
+        [],
       ),
     );
 
@@ -440,6 +524,8 @@ describe("ResourceBrowser", () => {
         "pods",
         expect.any(Function),
         expect.any(Function),
+        expect.any(Function),
+        [],
       ),
     );
   });
@@ -636,17 +722,235 @@ describe("ResourceBrowser", () => {
     expect(screen.getByRole("columnheader", { name: /Roles/ })).toBeDefined();
   });
 
-  it("shows a namespace load error and does not watch", async () => {
-    listNamespacesMock.mockResolvedValue({ error: "forbidden: namespaces" });
-    render(<ResourceBrowser context="kind-dev" kind="pods" />);
-    await waitFor(() => expect(screen.getByText(/forbidden: namespaces/)).toBeDefined());
-    expect(watchResourceMock).not.toHaveBeenCalled();
+  it("keeps the workload view usable when the namespace list is forbidden (non-fatal)", async () => {
+    // A plain-user denial (not a ServiceAccount) with no declared namespace has
+    // nothing to scope to, so the generic non-fatal notice is what renders.
+    listNamespacesMock.mockResolvedValue({
+      error:
+        'handler error: ApiError: namespaces is forbidden: User "alice" cannot list resource "namespaces" in API group "" at the cluster scope: Forbidden (ErrorResponse { code: 403, reason: "Forbidden", message: "..." })',
+    });
+    watchResourceMock.mockImplementation(
+      watchWith([{ name: "web", namespace: "default", ready: "1/1", upToDate: 1, available: 1 }]),
+    );
+    render(<ResourceBrowser context="kind-dev" kind="deployments" />);
+
+    // The toolbar + resource list still render — this is a non-fatal notice,
+    // not a view-blocking error. The workload itself streams normally.
+    expect(await screen.findByRole("button", { name: "Refresh" })).toBeDefined();
+    expect(await screen.findByText("web")).toBeDefined();
+
+    // A small, friendly, non-blocking notice appears instead.
+    expect(screen.getByText(/Access denied/)).toBeDefined();
+    expect(screen.getByText(/can.t list namespaces/)).toBeDefined();
+
+    // The raw backend noise must not leak into the UI.
+    expect(screen.queryByText(/ErrorResponse \{/)).toBeNull();
+    expect(screen.queryByText(/handler error:/)).toBeNull();
+    expect(watchResourceMock).toHaveBeenCalledWith("kind-dev", "", "deployments", expect.any(Function), expect.any(Function), expect.any(Function), []);
   });
 
-  it("shows a resource load error for nodes", async () => {
+  it("scopes to the context's declared namespace when listing namespaces is forbidden", async () => {
+    listNamespacesMock.mockResolvedValue({
+      error:
+        'handler error: ApiError: namespaces is forbidden: User "system:serviceaccount:clavik-dev:viewer" cannot list resource "namespaces" in API group "" at the cluster scope: Forbidden (ErrorResponse { code: 403, reason: "Forbidden", message: "..." })',
+    });
+    listContextsMock.mockResolvedValue({
+      contexts: [
+        { name: "kind-dev", cluster: "kind-dev", server: "https://x", namespace: "clavik-dev" },
+        { name: "other-ctx", cluster: "other", server: "https://y", namespace: "team-b" },
+      ],
+    });
+    watchResourceMock.mockImplementation(
+      watchWith([{ name: "web", namespace: "clavik-dev", ready: "1/1", upToDate: 1, available: 1 }]),
+    );
+    render(<ResourceBrowser context="kind-dev" kind="deployments" />);
+
+    // Scoped straight to the credential's bound namespace, not "all".
+    expect(await screen.findByText(/Scoped to namespace clavik-dev/)).toBeDefined();
+    expect(await screen.findByText("web")).toBeDefined();
+    await waitFor(() =>
+      expect(watchResourceMock).toHaveBeenCalledWith(
+        "kind-dev",
+        "clavik-dev",
+        "deployments",
+        expect.any(Function),
+        expect.any(Function),
+        expect.any(Function),
+        [],
+      ),
+    );
+
+    // The namespace select reflects the scoped namespace.
+    expect(screen.getByRole("combobox", { name: "Namespace" }).textContent).toContain("clavik-dev");
+
+    // No raw backend noise leaks into the UI.
+    expect(screen.queryByText(/ErrorResponse \{/)).toBeNull();
+    expect(screen.queryByText(/handler error:/)).toBeNull();
+  });
+
+  it("scopes to the ServiceAccount namespace parsed from the error when the context declares none", async () => {
+    // Restricted kubeconfig that does NOT declare a namespace on the context —
+    // but the Forbidden message names the SA (system:serviceaccount:clavik-dev:…),
+    // whose namespace is the one the credential is bound to. Scope to it.
+    listNamespacesMock.mockResolvedValue({
+      error:
+        'handler error: ApiError: namespaces is forbidden: User "system:serviceaccount:clavik-dev:clavik-dev" cannot list resource "namespaces" in API group "" at the cluster scope: Forbidden (ErrorResponse { code: 403, reason: "Forbidden", message: "..." })',
+    });
+    listContextsMock.mockResolvedValue({
+      contexts: [{ name: "kind-dev", cluster: "kind-dev", server: "https://x", namespace: "" }],
+    });
+    watchResourceMock.mockImplementation(
+      watchWith([{ name: "web", namespace: "clavik-dev", ready: "1/1", upToDate: 1, available: 1 }]),
+    );
+    render(<ResourceBrowser context="kind-dev" kind="deployments" />);
+
+    // Scoped to the SA's namespace, not "all", and not the generic notice.
+    expect(await screen.findByText(/Scoped to namespace clavik-dev/)).toBeDefined();
+    expect(screen.queryByText(/can.t list namespaces; showing all/)).toBeNull();
+    expect(await screen.findByText("web")).toBeDefined();
+    await waitFor(() =>
+      expect(watchResourceMock).toHaveBeenCalledWith(
+        "kind-dev",
+        "clavik-dev",
+        "deployments",
+        expect.any(Function),
+        expect.any(Function),
+        expect.any(Function),
+        [],
+      ),
+    );
+    expect(screen.getByRole("combobox", { name: "Namespace" }).textContent).toContain("clavik-dev");
+  });
+
+  it("falls back to the generic non-fatal notice when the context has no declared namespace", async () => {
+    // A non-service-account denial (plain user) with no declared namespace has
+    // nothing to scope to — fall through to the generic "showing all" notice.
+    listNamespacesMock.mockResolvedValue({
+      error:
+        'handler error: ApiError: namespaces is forbidden: User "alice" cannot list resource "namespaces" in API group "" at the cluster scope: Forbidden (ErrorResponse { code: 403, reason: "Forbidden", message: "..." })',
+    });
+    listContextsMock.mockResolvedValue({
+      contexts: [{ name: "kind-dev", cluster: "kind-dev", server: "https://x", namespace: "" }],
+    });
+    watchResourceMock.mockImplementation(
+      watchWith([{ name: "web", namespace: "default", ready: "1/1", upToDate: 1, available: 1 }]),
+    );
+    render(<ResourceBrowser context="kind-dev" kind="deployments" />);
+
+    expect(await screen.findByText(/Access denied/)).toBeDefined();
+    expect(screen.getByText(/can.t list namespaces; showing all/)).toBeDefined();
+    expect(screen.queryByText(/Scoped to namespace/)).toBeNull();
+    await waitFor(() =>
+      expect(watchResourceMock).toHaveBeenCalledWith(
+        "kind-dev",
+        "",
+        "deployments",
+        expect.any(Function),
+        expect.any(Function),
+        expect.any(Function),
+        [],
+      ),
+    );
+  });
+
+  it("shows a friendly ErrorState (not raw text) when the resource list itself is forbidden", async () => {
+    listNamespacesMock.mockResolvedValue({ namespaces: ["prod"] });
+    listResourceMock.mockResolvedValue({
+      error:
+        'handler error: ApiError: endpoints is forbidden: User "system:serviceaccount:prod:viewer" cannot list resource "endpoints" in API group "" in the namespace "prod": Forbidden (ErrorResponse { code: 403, reason: "Forbidden", message: "..." })',
+    });
+    render(<ResourceBrowser context="kind-dev" kind="endpoints" />);
+
+    // Friendly, actionable title + detail via describeError/describeForbidden.
+    expect(await screen.findByText("Access denied")).toBeDefined();
+    expect(
+      screen.getByText("You don't have permission to list endpoints in prod."),
+    ).toBeDefined();
+
+    // No raw ApiError/ErrorResponse/handler-error noise anywhere in the DOM.
+    expect(screen.queryByText(/handler error:/)).toBeNull();
+    expect(screen.queryByText(/ErrorResponse \{/)).toBeNull();
+  });
+
+  it("shows a friendly namespace load error notice and still watches (non-fatal)", async () => {
+    listNamespacesMock.mockResolvedValue({ error: "forbidden: namespaces" });
+    watchResourceMock.mockImplementation(watchWith([pod]));
+    render(<ResourceBrowser context="kind-dev" kind="pods" />);
+    // The raw error string is no longer rendered verbatim; a friendly notice
+    // replaces it, and the resource view still renders/watches normally.
+    expect(await screen.findByText(/Access denied/)).toBeDefined();
+    expect(screen.queryByText(/^Error: forbidden: namespaces$/)).toBeNull();
+    await waitFor(() => expect(watchResourceMock).toHaveBeenCalled());
+  });
+
+  it("shows the REAL error (not a permission message) when listing namespaces fails for a non-403 reason", async () => {
+    // A genuine outage (timeout) must NOT be mischaracterized as an RBAC
+    // restriction: the notice reflects the real error, no "you don't have
+    // permission" wording, and it does NOT auto-scope to the context namespace.
+    listNamespacesMock.mockResolvedValue({ error: "list namespaces timed out" });
+    listContextsMock.mockResolvedValue({
+      contexts: [{ name: "kind-dev", cluster: "kind-dev", server: "https://x", namespace: "clavik-dev" }],
+    });
+    watchResourceMock.mockImplementation(
+      watchWith([{ name: "web", namespace: "default", ready: "1/1", upToDate: 1, available: 1 }]),
+    );
+    render(<ResourceBrowser context="kind-dev" kind="deployments" />);
+
+    // The real error's title surfaces (timeout → "Can't reach the cluster").
+    expect(await screen.findByText(/Can't reach the cluster/)).toBeDefined();
+    // Not the permission wording, and not auto-scoped to the declared namespace.
+    expect(screen.queryByText(/don.t have permission/)).toBeNull();
+    expect(screen.queryByText(/Scoped to namespace/)).toBeNull();
+    // Still non-fatal: the workload streams across all namespaces.
+    expect(await screen.findByText("web")).toBeDefined();
+    await waitFor(() =>
+      expect(watchResourceMock).toHaveBeenCalledWith(
+        "kind-dev",
+        "",
+        "deployments",
+        expect.any(Function),
+        expect.any(Function),
+        expect.any(Function),
+        [],
+      ),
+    );
+  });
+
+  it("surfaces a permanent watch error instead of hanging on Loading", async () => {
+    // A namespace-scoped credential doing an all-namespaces watch gets a 403
+    // that never self-heals. The watch emits it via onError; the view must stop
+    // loading and show the friendly access-denied message (not a perpetual spinner).
+    listNamespacesMock.mockResolvedValue({ namespaces: ["default"] });
+    watchResourceMock.mockImplementation(
+      (
+        _ctx: string,
+        _ns: string,
+        _kind: string,
+        _onRows: (r: unknown) => void,
+        _onStatus: (s: unknown) => void,
+        onError: (e: string) => void,
+      ) => {
+        onError(
+          'watch deployments is forbidden: User "system:serviceaccount:prod:viewer" cannot watch resource "deployments" in API group "apps" in the namespace "prod": Forbidden',
+        );
+        return Promise.resolve({ stop: vi.fn() });
+      },
+    );
+    render(<ResourceBrowser context="kind-dev" kind="deployments" />);
+
+    // Friendly, actionable access-denied error surfaces…
+    expect(await screen.findByText("Access denied")).toBeDefined();
+    // …and the perpetual loading spinner is gone.
+    expect(screen.queryByText("Loading deployments")).toBeNull();
+    // No raw backend noise leaks.
+    expect(screen.queryByText(/Forbidden$/)).toBeNull();
+  });
+
+  it("shows a friendly resource load error for nodes", async () => {
     listNamespacesMock.mockResolvedValue({ namespaces: ["default"] });
     listNodesMock.mockResolvedValue({ error: "list nodes timed out" });
     render(<ResourceBrowser context="kind-dev" kind="nodes" />);
-    await waitFor(() => expect(screen.getByText(/list nodes timed out/)).toBeDefined());
+    await waitFor(() => expect(screen.getByText("Can't reach the cluster")).toBeDefined());
+    expect(screen.queryByText(/list nodes timed out/)).toBeNull();
   });
 });

--- a/apps/desktop/src/components/ResourceBrowser.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.tsx
@@ -7,6 +7,7 @@ import {
   type DeploymentSummary,
   type ServiceSummary,
 } from "../lib/workloads";
+import { listContexts } from "../lib/clusters";
 import {
   listNodes,
   listResource,
@@ -58,6 +59,8 @@ import { PodActions, ResourceActions, ServiceForwardAction } from "./DetailActio
 import { NodeCordonAction } from "./NodeCordonAction";
 import { ResourceDetail } from "./ResourceDetail";
 import type { OpenResource } from "../lib/resourceNavigation";
+import { describeError, serviceAccountNamespace } from "../lib/errors";
+import { isForbidden } from "../lib/access";
 import {
   Table,
   filterTableData,
@@ -68,6 +71,7 @@ import {
   ColumnPicker,
   useColumnVisibility,
   Drawer,
+  ErrorState,
   StatusPill,
   TextInput,
   Toolbar,
@@ -547,6 +551,7 @@ export function ResourceBrowser({
   initialNamespace = "",
   onNamespaceChange,
   detailDrawerWidth = 480,
+  kubeconfigFiles = [],
 }: {
   context: string;
   kind: ResourceKind;
@@ -567,9 +572,20 @@ export function ResourceBrowser({
   /** Notified when the namespace filter changes, so the parent can preserve it. */
   onNamespaceChange?: (namespace: string) => void;
   detailDrawerWidth?: number;
+  /**
+   * All configured kubeconfig files (default path + pasted/additional). Used to
+   * register their paths in the backend client cache before we build a client
+   * for this context — otherwise a restored tab for a context from an additional
+   * file races the app's initial listContexts and fails with "failed to load
+   * current context".
+   */
+  kubeconfigFiles?: string[];
 }) {
   const [namespaces, setNamespaces] = useState<string[] | null>(null);
   const [nsError, setNsError] = useState("");
+  // Set when namespace listing was forbidden but the kubeconfig context
+  // declares a bound namespace — the view is scoped to it instead of "all".
+  const [nsScope, setNsScope] = useState("");
   // Namespace selection is a set (empty = all namespaces), serialized to/from
   // the persisted comma string. One selected namespace watches that namespace
   // directly; none or many watch all namespaces, filtered client-side.
@@ -593,6 +609,10 @@ export function ResourceBrowser({
   const viewKeyRef = useRef("");
 
   const namespaced = isNamespaced(kind);
+  // Stable dependency for the effect below: a fresh `kubeconfigFiles` array
+  // identity every render must not refire the effect (which would restart the
+  // watch); only a real change to the set of files should.
+  const kubeconfigFilesKey = kubeconfigFiles.join(" ");
 
   useEffect(() => setFilterColumn(null), [kind]);
 
@@ -600,16 +620,66 @@ export function ResourceBrowser({
     let active = true;
     setNamespaces(null);
     setNsError("");
-    void listNamespaces(context).then((outcome) => {
+    setNsScope("");
+    // Ensure the client cache knows about all configured kubeconfig files (incl.
+    // pasted/additional) before we build a client for this context. Otherwise a
+    // restored tab for a context from an additional file races the app's initial
+    // listContexts and fails with "failed to load current context". We only need
+    // the side effect (cache.set_paths); ignore the return, and if it errors
+    // still proceed to listNamespaces (which surfaces its own error).
+    const ready = kubeconfigFiles.length
+      ? listContexts(kubeconfigFiles).then(() => undefined)
+      : Promise.resolve(undefined);
+    void ready.then(() => {
       if (!active) return;
-      if (outcome.error) setNsError(outcome.error);
-      else setNamespaces(outcome.namespaces ?? []);
+      return listNamespaces(context).then((outcome) => {
+      if (!active) return;
+      if (outcome.error && isForbidden(outcome.error)) {
+        // Forbidden — a namespace-restricted credential. Scope the view to a
+        // single namespace instead of falling back to "all namespaces" (which
+        // would just 403 again). Prefer the namespace the context's kubeconfig
+        // entry declares; if it declares none, fall back to the ServiceAccount's
+        // namespace named in the Forbidden error itself.
+        void listContexts()
+          .then((ctxOutcome) => {
+            if (!active) return null;
+            return ctxOutcome.contexts?.find((c) => c.name === context)?.namespace?.trim();
+          })
+          .catch(() => undefined)
+          .then((declared) => {
+            if (!active) return;
+            const ns = declared || serviceAccountNamespace(outcome.error!);
+            if (ns) {
+              setNsError("");
+              setNsScope(ns);
+              setNamespaces([ns]);
+              setSelection([ns]);
+            } else {
+              setNsScope("");
+              setNsError(outcome.error!);
+              setNamespaces([]); // non-fatal: still render the toolbar + resource list
+            }
+          });
+      } else if (outcome.error) {
+        // A genuine failure (timeout, 5xx) — NOT a permission problem. Keep it
+        // non-fatal (render the view against all namespaces), but surface the
+        // REAL error rather than mischaracterizing it as an RBAC restriction,
+        // and do NOT auto-scope to the context's declared namespace.
+        setNsScope("");
+        setNsError(outcome.error);
+        setNamespaces([]);
+      } else {
+        setNsError("");
+        setNsScope("");
+        setNamespaces(outcome.namespaces ?? []);
+      }
       // namespace stays "" = All namespaces by default
+      });
     });
     return () => {
       active = false;
     };
-  }, [context]);
+  }, [context, kubeconfigFilesKey]);
 
   useEffect(() => {
     if (namespaced && namespaces === null) return; // wait for the namespace list
@@ -639,6 +709,10 @@ export function ResourceBrowser({
         (status) => {
           if (!cancelled) setWatchStatus(status);
         },
+        (err) => {
+          if (!cancelled) setRes({ rows: [], error: err, loading: false });
+        },
+        kubeconfigFiles,
       )
         .then((h) => (cancelled ? h.stop() : (handle = h)))
         .catch((e) => {
@@ -883,14 +957,23 @@ export function ResourceBrowser({
   return (
     <div className="flex min-h-0 flex-1">
       <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-        {nsError && <p className="px-3 py-2 text-sm text-destructive">Error: {nsError}</p>}
-        {!nsError && namespaces === null && (
+        {namespaces === null && (
           <div className="p-3">
             <Spinner label="Loading namespaces" />
           </div>
         )}
-        {!nsError && namespaces !== null && (
+        {namespaces !== null && (
           <>
+            {nsScope && (
+              <p className="px-3 py-1 text-xs text-muted-foreground" role="status">
+                Scoped to namespace {nsScope} — you don’t have permission to list all namespaces.
+              </p>
+            )}
+            {nsError && (
+              <p className="px-3 py-1 text-xs text-muted-foreground" role="status">
+                {describeError(nsError).title} — can’t list namespaces; showing all.
+              </p>
+            )}
             <Toolbar className="fl-resource-toolbar shrink-0 flex-wrap">
               {namespaced && (
                 <div className="fl-resource-toolbar__namespace flex items-center gap-2">
@@ -952,7 +1035,13 @@ export function ResourceBrowser({
             </Toolbar>
 
             <div className="min-h-0 flex-1 overflow-auto">
-              {res.error && <p className="px-3 py-2 text-sm text-destructive">Error: {res.error}</p>}
+              {res.error && (
+                <ErrorState
+                  title={describeError(res.error).title}
+                  detail={describeError(res.error).detail}
+                  onRetry={() => setReloadKey((k) => k + 1)}
+                />
+              )}
               {!res.error && res.loading && filtered.length === 0 && (
                 <LoadingState label={`Loading ${kind}`} />
               )}

--- a/apps/desktop/src/components/ResourceOverview.test.tsx
+++ b/apps/desktop/src/components/ResourceOverview.test.tsx
@@ -32,6 +32,15 @@ vi.mock("../lib/rbac", () => ({
   podsForServiceAccount: podsForServiceAccountMock,
 }));
 
+// Access gating is preflighted via useAccess; mock it so the ConfigMap/Secret
+// data editor tests control whether Save is permitted. Default: allowed, so the
+// existing behavioural tests keep exercising the enabled Save path.
+vi.mock("../lib/access", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/access")>();
+  return { ...actual, useAccess: vi.fn() };
+});
+import { useAccess } from "../lib/access";
+
 import {
   ResourceOverview,
   ObjectDetail,
@@ -52,6 +61,12 @@ beforeEach(() => {
   podsForPvcMock.mockResolvedValue({ pods: [] });
   bindingsForServiceAccountMock.mockResolvedValue({ bindings: [] });
   podsForServiceAccountMock.mockResolvedValue({ pods: [] });
+  vi.mocked(useAccess).mockReturnValue({
+    allowed: () => true,
+    reason: () => "",
+    known: () => true,
+    loading: false,
+  });
 });
 const TLS_CERTIFICATE = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURPakNDQWlLZ0F3SUJBZ0lVSjVQdnk1NXRIbUhESkd3elhNVld2YnV4ck5nd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0Z6RVZNQk1HQTFVRUF3d01aWGhoYlhCc1pTNTBaWE4wTUI0WERUSTJNRGN3TmpFeE1qazFOVm9YRFRNMgpNRGN3TXpFeE1qazFOVm93RnpFVk1CTUdBMVVFQXd3TVpYaGhiWEJzWlM1MFpYTjBNSUlCSWpBTkJna3Foa2lHCjl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUFzeFc2aHU0MVVwYittNXpHZm5aZ2tpT0xuaVhYTmhPYzhvTWgKaFZCcDVXL0Y5aXluelBGQjRGM0NOK2VlaEp1aVhYWHVFUWdQUVFqOVIrV3ErYlBUK1JPOHd6cEJqQ1BYaHo1TAp2Z0dzNDR1cXBQQ2JvUXVpV0RYcmZDWWtUT2xyd0tIZWJDcVRRM2FQUk1hUGk0YkhzRHdNdmlUcDRhMERGVTFWCkhGc2RXcHM0Uis3TG1MSXBhU3RUTTV1bU1qSC9FTzJGZ2psQmhYUUVGT1M0UnZ2WGpoV0E1ZGZiMEtwNUVSNFIKZjFGdktCRTNaTzVmbG5ldlFlTGdyMnZZT2Jhalg5OTQ1NVE0L1UwMTJJZG1ldWV4L2Q1ZU5VV0VNelprZzlrUQp1U00vMFpwbkhEVFU4UXZQTHh0Qy9jSlU1ekdKMzM0ZnppTGVmQUlpbDR2NFRvVzBQd0lEQVFBQm8zNHdmREFkCkJnTlZIUTRFRmdRVWxadEVndTl1L3ZTTVptSmNNa2RUcWhWVmJDSXdId1lEVlIwakJCZ3dGb0FVbFp0RWd1OXUKL3ZTTVptSmNNa2RUcWhWVmJDSXdEd1lEVlIwVEFRSC9CQVV3QXdFQi96QXBCZ05WSFJFRUlqQWdnZ3hsZUdGdApjR3hsTG5SbGMzU0NFSGQzZHk1bGVHRnRjR3hsTG5SbGMzUXdEUVlKS29aSWh2Y05BUUVMQlFBRGdnRUJBR2svCnp6cGhUNnRuNCtxUXg5Ly9meWNkSzFtNjg1eW1TRFZqT3ZXeWRQaWg4RzI4OUJkQ1BmYlc4ZVVrOXJqakJVZWcKR1k5OUJMcEhvcW9zZDNVWEhOUDJzWUdnZ0dZOG40QXdSbFFWZi9qajBPenVWUzZpS0FDM1ZXWFBtdGk5Q1JQZwpHVkdaR0VZMWI1SXYwVStaSzBjYlJ6c1NSN0FBN05VWGhTUUg0NjJDQlpJa1JSTXNFcVhSV2huUG5Kd3phLzJJCmJ1REdiTG1WMmhRUTdJeWJtb0FpL1FQVUM5WldrMExOV2pGYlpDa0kvem4wd2QxWVhham1iTHBSV0dsTjR1LzcKL2NDSER6NDNyWTZXeHJNRjVwYkJ5aWcvWk5obUVZK25rSFhwK2ZoRFdZOGV1QVVxT1p4bUQrNFIzL2lPQ2dhYgpsVWMzUnNCdmExVjNSbFB6K0pvPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==";
 
@@ -496,6 +511,59 @@ describe("ObjectDetail (ConfigMap / Secret)", () => {
         "app.conf": "level=debug",
       }),
     );
+  });
+
+  it("disables Save and explains why when the user can't update the ConfigMap", () => {
+    vi.mocked(useAccess).mockReturnValue({
+      allowed: () => false,
+      reason: () => "RBAC: no rule",
+      known: () => true,
+      loading: false,
+    });
+    const cm: K8sObject = {
+      kind: "ConfigMap",
+      metadata: { name: "web-config", namespace: "prod" },
+      data: { "app.conf": "level=info" },
+    };
+    render(<ObjectDetail kind="ConfigMap" obj={cm} now={NOW} context="kind-dev" />);
+    fireEvent.change(screen.getByLabelText("Value for app.conf"), { target: { value: "level=debug" } });
+    const save = screen.getByRole("button", { name: "Save" });
+    expect((save as HTMLButtonElement).disabled).toBe(true);
+    expect(save.getAttribute("title")).toEqual(expect.stringContaining("permission to update configmaps in prod"));
+  });
+
+  it("enables Save when the user can update the ConfigMap", () => {
+    vi.mocked(useAccess).mockReturnValue({
+      allowed: () => true,
+      reason: () => "",
+      known: () => true,
+      loading: false,
+    });
+    const cm: K8sObject = {
+      kind: "ConfigMap",
+      metadata: { name: "web-config", namespace: "prod" },
+      data: { "app.conf": "level=info" },
+    };
+    render(<ObjectDetail kind="ConfigMap" obj={cm} now={NOW} context="kind-dev" />);
+    fireEvent.change(screen.getByLabelText("Value for app.conf"), { target: { value: "level=debug" } });
+    expect((screen.getByRole("button", { name: "Save" }) as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("shows a friendly message (not the raw error) when a ConfigMap save fails", async () => {
+    updateConfigDataMock.mockResolvedValue({ error: "configmaps is forbidden: cannot update" });
+    const cm: K8sObject = {
+      kind: "ConfigMap",
+      metadata: { name: "web-config", namespace: "prod" },
+      data: { "app.conf": "level=info" },
+    };
+    render(<ObjectDetail kind="ConfigMap" obj={cm} now={NOW} context="kind-dev" />);
+    fireEvent.change(screen.getByLabelText("Value for app.conf"), { target: { value: "level=debug" } });
+    fireEvent.click(await screen.findByRole("button", { name: "Save" }));
+    await waitFor(() =>
+      expect(screen.getByText(/permission|RBAC roles/i)).toBeDefined(),
+    );
+    // The raw apiserver string is not shown verbatim.
+    expect(screen.queryByText(/is forbidden: cannot update/)).toBeNull();
   });
 
   it("shows parsed TLS certificate metadata without revealing material", async () => {

--- a/apps/desktop/src/components/ResourceOverview.tsx
+++ b/apps/desktop/src/components/ResourceOverview.tsx
@@ -6,6 +6,8 @@ import { listEndpointSlices } from "../lib/network";
 import { podsForPvc, formatStorageSize } from "../lib/storage";
 import { bindingsForServiceAccount, podsForServiceAccount, type SaBinding } from "../lib/rbac";
 import { updateConfigData } from "../lib/actions";
+import { useAccess, denyReason, reportActionError, type AccessCheck } from "../lib/access";
+import { describeError } from "../lib/errors";
 import {
   Spinner,
   StatusPill,
@@ -1859,6 +1861,15 @@ export function ConfigDataEditor({
 
   const keys = Object.keys(data);
 
+  // Preflight the mutating RBAC (verb `update` on configmaps/secrets in this
+  // namespace) so Save fails closed until the check resolves allowed.
+  const updateCheck: AccessCheck = {
+    verb: "update",
+    resource: kind === "Secret" ? "secrets" : "configmaps",
+    namespace,
+  };
+  const access = useAccess(context, [updateCheck]);
+
   // Baseline follows the data (Secret values arrive asynchronously via the
   // gated fetch); updating it here must NOT clobber the user's reveal/edit
   // state, so those reset only when the target object itself changes.
@@ -1898,7 +1909,8 @@ export function ConfigDataEditor({
     const r = await updateConfigData(context, kind, namespace, name, patch);
     setBusy(false);
     if (r.error) {
-      setErr(r.error);
+      setErr(describeError(r.error).detail);
+      reportActionError(context, `Failed to save ${name}`, r.error);
       return;
     }
     setEdited({});
@@ -1954,7 +1966,13 @@ export function ConfigDataEditor({
       })}
       {editable && changedKeys.length > 0 && (
         <div className="fl-config-editor__actions">
-          <Button size="sm" onClick={() => void save()} busy={busy}>
+          <Button
+            size="sm"
+            onClick={() => void save()}
+            busy={busy}
+            disabled={busy || !access.allowed(updateCheck)}
+            title={denyReason(access, updateCheck)}
+          >
             Save
           </Button>
           <Button size="sm" variant="ghost" onClick={() => setEdited({})} disabled={busy}>

--- a/apps/desktop/src/components/YamlView.test.tsx
+++ b/apps/desktop/src/components/YamlView.test.tsx
@@ -25,6 +25,16 @@ vi.mock("../ui/CodeEditor", () => ({
     <textarea aria-label={ariaLabel} value={value} onChange={(e) => onChange?.(e.target.value)} />
   ),
 }));
+// ManifestEditor gates Apply (fail-closed) on a preflight access check in edit
+// mode; stub the hook to "allowed" so these tests exercise the apply flow
+// rather than the RBAC gate (covered in ManifestEditor.test.tsx).
+vi.mock("../lib/access", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/access")>();
+  return {
+    ...actual,
+    useAccess: () => ({ allowed: () => true, reason: () => "", known: () => true, loading: false }),
+  };
+});
 
 import { YamlView } from "./YamlView";
 

--- a/apps/desktop/src/lib/access.test.ts
+++ b/apps/desktop/src/lib/access.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import {
+  canI,
+  clearAccessCache,
+  rbac,
+  kindToResource,
+  useAccess,
+  isForbidden,
+  reportActionError,
+  denyReason,
+  type AccessResult,
+  type AccessCheck,
+} from "./access";
+import { describeError } from "./errors";
+
+const { notifyMock } = vi.hoisted(() => ({
+  notifyMock: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+vi.mock("./notify", () => ({ notify: notifyMock }));
+
+describe("canI", () => {
+  it("posts checks and returns results", async () => {
+    const invoke = vi.fn().mockResolvedValue({ results: [{ allowed: true, denied: false, reason: "" }] });
+    const checks = [{ verb: "delete", resource: "pods", namespace: "prod" }];
+    const out = await canI("ctx", checks, invoke);
+    expect(invoke).toHaveBeenCalledWith("k8s.canI", { context: "ctx", checks });
+    expect(out.results?.[0].allowed).toBe(true);
+  });
+  it("returns error on failure", async () => {
+    const invoke = vi.fn().mockRejectedValue(new Error("boom"));
+    expect((await canI("ctx", [], invoke)).error).toContain("boom");
+  });
+});
+
+describe("rbac builders", () => {
+  it("maps actions to (verb, resource, subresource)", () => {
+    expect(rbac.deletePod("prod")).toEqual({ verb: "delete", resource: "pods", namespace: "prod" });
+    expect(rbac.evictPod("prod")).toEqual({ verb: "create", resource: "pods", subresource: "eviction", namespace: "prod" });
+    expect(rbac.scale("apps", "deployments", "prod")).toEqual({ verb: "patch", group: "apps", resource: "deployments", subresource: "scale", namespace: "prod" });
+    expect(rbac.cordon()).toEqual({ verb: "patch", resource: "nodes" });
+    expect(rbac.cronjobTrigger("prod")).toEqual({ verb: "create", group: "batch", resource: "jobs", namespace: "prod" });
+  });
+});
+
+describe("kindToResource", () => {
+  it("maps known kinds to {group, resource}, null otherwise", () => {
+    expect(kindToResource("Deployment")).toEqual({ group: "apps", resource: "deployments" });
+    expect(kindToResource("Pod")).toEqual({ group: "", resource: "pods" });
+    expect(kindToResource("CronJob")).toEqual({ group: "batch", resource: "cronjobs" });
+    expect(kindToResource("Wibble")).toBeNull();
+  });
+});
+
+describe("cache", () => {
+  it("clearAccessCache(context) does not throw", () => {
+    expect(() => clearAccessCache("ctx")).not.toThrow();
+    expect(() => clearAccessCache()).not.toThrow();
+  });
+});
+
+describe("isForbidden", () => {
+  it("is true for a 403 / Forbidden string, false otherwise", () => {
+    expect(isForbidden("pods is forbidden: User cannot delete")).toBe(true);
+    expect(isForbidden("the server responded with 403")).toBe(true);
+    expect(isForbidden("Forbidden")).toBe(true);
+    expect(isForbidden("connection refused")).toBe(false);
+    expect(isForbidden("4030 things happened")).toBe(false);
+    expect(isForbidden("")).toBe(false);
+  });
+});
+
+describe("reportActionError", () => {
+  beforeEach(() => {
+    clearAccessCache();
+    notifyMock.error.mockReset();
+  });
+
+  it("toasts the friendly detail (not the raw string)", () => {
+    const raw = "pods is forbidden: User cannot delete resource \"pods\" in the namespace \"prod\"";
+    reportActionError("ctx", "Failed to delete web-1", raw);
+    expect(notifyMock.error).toHaveBeenCalledWith("Failed to delete web-1", describeError(raw).detail);
+  });
+
+  it("clears the context's access cache on a 403 so the control re-gates", async () => {
+    const check: AccessCheck = { verb: "delete", resource: "pods", namespace: "prod" };
+    const invoke = vi.fn().mockResolvedValue({ results: [{ allowed: true, denied: false, reason: "" }] });
+    const { result } = renderHook(() => useAccess("ctx", [check], invoke));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.known(check)).toBe(true);
+
+    act(() => reportActionError("ctx", "Failed", "pods is forbidden: cannot delete"));
+
+    // Cache invalidated → the check is unknown again.
+    expect(result.current.known(check)).toBe(false);
+  });
+
+  it("keeps the cache when the error is not a 403", async () => {
+    const check: AccessCheck = { verb: "delete", resource: "pods", namespace: "prod" };
+    const invoke = vi.fn().mockResolvedValue({ results: [{ allowed: true, denied: false, reason: "" }] });
+    const { result } = renderHook(() => useAccess("ctx", [check], invoke));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => reportActionError("ctx", "Failed", "connection refused"));
+
+    expect(result.current.known(check)).toBe(true);
+  });
+});
+
+describe("denyReason", () => {
+  const access = (allowed: boolean, known: boolean) => ({
+    allowed: () => allowed,
+    known: () => known,
+  });
+
+  it("returns the sentence only when the check resolved denied", () => {
+    const check: AccessCheck = { verb: "delete", resource: "pods", namespace: "prod" };
+    expect(denyReason(access(false, true), check)).toBe(
+      "You don't have permission to delete pods in prod",
+    );
+  });
+
+  it("omits the namespace clause for a cluster-scoped check", () => {
+    const check: AccessCheck = { verb: "patch", resource: "nodes" };
+    expect(denyReason(access(false, true), check)).toBe("You don't have permission to patch nodes");
+  });
+
+  it("returns undefined when allowed or still unknown", () => {
+    const check: AccessCheck = { verb: "delete", resource: "pods", namespace: "prod" };
+    expect(denyReason(access(true, true), check)).toBeUndefined();
+    expect(denyReason(access(false, false), check)).toBeUndefined();
+  });
+});
+
+describe("useAccess", () => {
+  beforeEach(() => {
+    clearAccessCache();
+  });
+
+  it("batches only uncached checks into one canI call, and allowed() reflects the result once resolved", async () => {
+    const checkA: AccessCheck = { verb: "delete", resource: "pods", namespace: "prod" };
+    const checkB: AccessCheck = { verb: "get", resource: "pods", namespace: "prod" };
+    const resultA: AccessResult = { allowed: true, denied: false, reason: "" };
+    const resultB: AccessResult = { allowed: false, denied: true, reason: "forbidden" };
+
+    const invoke = vi
+      .fn()
+      .mockResolvedValueOnce({ results: [resultA] })
+      .mockResolvedValueOnce({ results: [resultB] });
+
+    const { result, rerender } = renderHook(({ checks }: { checks: AccessCheck[] }) => useAccess("ctx", checks, invoke), {
+      initialProps: { checks: [checkA] },
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(invoke).toHaveBeenNthCalledWith(1, "k8s.canI", { context: "ctx", checks: [checkA] });
+    expect(result.current.allowed(checkA)).toBe(true);
+
+    // Rerender with an additional, previously-uncached check. The already
+    // cached checkA must NOT be resent — only the new checkB is batched.
+    rerender({ checks: [checkA, checkB] });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(invoke).toHaveBeenNthCalledWith(2, "k8s.canI", { context: "ctx", checks: [checkB] });
+    expect(result.current.allowed(checkA)).toBe(true);
+    expect(result.current.allowed(checkB)).toBe(false);
+  });
+
+  it("treats unresolved checks as unknown/not-allowed while loading, then flips once resolved", async () => {
+    const check: AccessCheck = { verb: "delete", resource: "pods", namespace: "prod" };
+    let resolve!: (v: { results: AccessResult[] }) => void;
+    const pending = new Promise<{ results: AccessResult[] }>((r) => {
+      resolve = r;
+    });
+    const invoke = vi.fn().mockReturnValue(pending);
+
+    const { result } = renderHook(() => useAccess("ctx", [check], invoke));
+
+    // Before the promise resolves: unknown, not allowed, loading.
+    expect(result.current.loading).toBe(true);
+    expect(result.current.known(check)).toBe(false);
+    expect(result.current.allowed(check)).toBe(false);
+
+    resolve({ results: [{ allowed: true, denied: false, reason: "" }] });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.known(check)).toBe(true);
+    expect(result.current.allowed(check)).toBe(true);
+  });
+
+  it("does not collide checks that differ only by `name` (resourceNames-scoped RBAC)", async () => {
+    const checkPodA: AccessCheck = { verb: "get", resource: "pods", namespace: "ns", name: "pod-a" };
+    const checkPodB: AccessCheck = { verb: "get", resource: "pods", namespace: "ns", name: "pod-b" };
+    const invoke = vi.fn().mockResolvedValue({
+      results: [
+        { allowed: true, denied: false, reason: "" },
+        { allowed: false, denied: true, reason: "forbidden" },
+      ],
+    });
+
+    const { result } = renderHook(() => useAccess("ctx", [checkPodA, checkPodB], invoke));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.allowed(checkPodA)).toBe(true);
+    expect(result.current.allowed(checkPodB)).toBe(false);
+  });
+});

--- a/apps/desktop/src/lib/access.ts
+++ b/apps/desktop/src/lib/access.ts
@@ -1,0 +1,168 @@
+import { useEffect, useReducer } from "react";
+import { invokeCapability, type Invoker } from "../transport/transport";
+import { describeError } from "./errors";
+import { notify } from "./notify";
+
+export interface AccessCheck {
+  verb: string;
+  group?: string;
+  resource: string;
+  subresource?: string;
+  namespace?: string;
+  name?: string;
+}
+
+export interface AccessResult {
+  allowed: boolean;
+  denied: boolean;
+  reason: string;
+}
+
+/** Batched SelfSubjectAccessReview via `k8s.canI`. Results align 1:1 with `checks`. */
+export async function canI(
+  context: string,
+  checks: AccessCheck[],
+  invoke: Invoker = invokeCapability,
+): Promise<{ results?: AccessResult[]; error?: string }> {
+  try {
+    const out = await invoke<{ results: AccessResult[] }>("k8s.canI", { context, checks });
+    return { results: out.results };
+  } catch (e) {
+    return { error: String(e) };
+  }
+}
+
+/** Stable cache key for a check within a context. */
+function keyOf(context: string, c: AccessCheck): string {
+  return [context, c.namespace ?? "", c.verb, c.group ?? "", c.resource, c.subresource ?? "", c.name ?? ""].join("|");
+}
+
+const cache = new Map<string, AccessResult>();
+
+/** Clear cached results for a context (on switch) or everything. */
+export function clearAccessCache(context?: string): void {
+  if (!context) {
+    cache.clear();
+    return;
+  }
+  for (const k of [...cache.keys()]) {
+    if (k.startsWith(`${context}|`)) cache.delete(k);
+  }
+}
+
+/** Drop one cached check — call after a surprise 403 so the control re-gates. */
+export function invalidateAccess(context: string, c: AccessCheck): void {
+  cache.delete(keyOf(context, c));
+}
+
+/** True when a raw error string is a Kubernetes Forbidden/403. */
+export function isForbidden(error: string): boolean {
+  return /forbidden|\b403\b/i.test(error);
+}
+
+/**
+ * Report a failed mutating action: toast the actionable (describeError) message,
+ * and if it was a 403, clear this context's access cache so the control re-gates.
+ */
+export function reportActionError(context: string, title: string, error: string): void {
+  const friendly = describeError(error);
+  notify.error(title, friendly.detail);
+  if (isForbidden(error)) clearAccessCache(context);
+}
+
+/** Tooltip explaining a disabled control, only when the check RESOLVED denied. */
+export function denyReason(
+  access: { known: (c: AccessCheck) => boolean; allowed: (c: AccessCheck) => boolean },
+  c: AccessCheck,
+): string | undefined {
+  return access.known(c) && !access.allowed(c)
+    ? `You don't have permission to ${c.verb} ${c.resource}${c.namespace ? ` in ${c.namespace}` : ""}`
+    : undefined;
+}
+
+/**
+ * Preflight access for a set of checks. Batches the uncached ones into one
+ * `k8s.canI` call and caches results. Unknown/loading ⇒ NOT allowed, so callers
+ * keep controls disabled until the check resolves.
+ */
+export function useAccess(
+  context: string,
+  checks: AccessCheck[],
+  invoke: Invoker = invokeCapability,
+): {
+  allowed: (c: AccessCheck) => boolean;
+  reason: (c: AccessCheck) => string;
+  known: (c: AccessCheck) => boolean;
+  loading: boolean;
+} {
+  const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
+  const checksKey = checks.map((c) => keyOf(context, c)).join(";");
+
+  useEffect(() => {
+    const missing = checks.filter((c) => !cache.has(keyOf(context, c)));
+    if (missing.length === 0) return;
+    let active = true;
+    void canI(context, missing, invoke).then((out) => {
+      if (!active || !out.results) return;
+      missing.forEach((c, i) => cache.set(keyOf(context, c), out.results![i]));
+      forceUpdate();
+    });
+    return () => {
+      active = false;
+    };
+    // Deps are intentionally [context, checksKey], not [invoke, checks]: a
+    // fresh `invoke` function or `checks` array reference on every render
+    // would otherwise retrigger this effect and loop forever. `checksKey`
+    // already captures every semantic change to `checks` (including `name`),
+    // so it alone is sufficient to decide when to refetch.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [context, checksKey]);
+
+  return {
+    allowed: (c) => cache.get(keyOf(context, c))?.allowed ?? false,
+    reason: (c) => cache.get(keyOf(context, c))?.reason ?? "",
+    known: (c) => cache.has(keyOf(context, c)),
+    loading: checks.some((c) => !cache.has(keyOf(context, c))),
+  };
+}
+
+/** Action → RBAC (verb, group, resource, subresource) builders. */
+export const rbac = {
+  deletePod: (namespace: string): AccessCheck => ({ verb: "delete", resource: "pods", namespace }),
+  evictPod: (namespace: string): AccessCheck => ({ verb: "create", resource: "pods", subresource: "eviction", namespace }),
+  deleteResource: (group: string, resource: string, namespace?: string): AccessCheck => ({ verb: "delete", group, resource, namespace }),
+  scale: (group: string, resource: string, namespace: string): AccessCheck => ({ verb: "patch", group, resource, subresource: "scale", namespace }),
+  rolloutRestart: (group: string, resource: string, namespace: string): AccessCheck => ({ verb: "patch", group, resource, namespace }),
+  edit: (group: string, resource: string, namespace?: string): AccessCheck => ({ verb: "patch", group, resource, namespace }),
+  cordon: (): AccessCheck => ({ verb: "patch", resource: "nodes" }),
+  drain: (): AccessCheck => ({ verb: "create", resource: "pods", subresource: "eviction" }),
+  cronjobSuspend: (namespace: string): AccessCheck => ({ verb: "patch", group: "batch", resource: "cronjobs", namespace }),
+  cronjobTrigger: (namespace: string): AccessCheck => ({ verb: "create", group: "batch", resource: "jobs", namespace }),
+};
+
+/** Kind → {group, resource} for the mutating kinds (mirrors backend gvk_for). */
+export function kindToResource(kind: string): { group: string; resource: string } | null {
+  const m: Record<string, { group: string; resource: string }> = {
+    Pod: { group: "", resource: "pods" },
+    Service: { group: "", resource: "services" },
+    ConfigMap: { group: "", resource: "configmaps" },
+    Secret: { group: "", resource: "secrets" },
+    Namespace: { group: "", resource: "namespaces" },
+    Node: { group: "", resource: "nodes" },
+    PersistentVolumeClaim: { group: "", resource: "persistentvolumeclaims" },
+    ServiceAccount: { group: "", resource: "serviceaccounts" },
+    Deployment: { group: "apps", resource: "deployments" },
+    StatefulSet: { group: "apps", resource: "statefulsets" },
+    DaemonSet: { group: "apps", resource: "daemonsets" },
+    ReplicaSet: { group: "apps", resource: "replicasets" },
+    Job: { group: "batch", resource: "jobs" },
+    CronJob: { group: "batch", resource: "cronjobs" },
+    Ingress: { group: "networking.k8s.io", resource: "ingresses" },
+    NetworkPolicy: { group: "networking.k8s.io", resource: "networkpolicies" },
+    Role: { group: "rbac.authorization.k8s.io", resource: "roles" },
+    RoleBinding: { group: "rbac.authorization.k8s.io", resource: "rolebindings" },
+    ClusterRole: { group: "rbac.authorization.k8s.io", resource: "clusterroles" },
+    ClusterRoleBinding: { group: "rbac.authorization.k8s.io", resource: "clusterrolebindings" },
+  };
+  return m[kind] ?? null;
+}

--- a/apps/desktop/src/lib/clusters.test.ts
+++ b/apps/desktop/src/lib/clusters.test.ts
@@ -13,6 +13,14 @@ describe("listContexts", () => {
     expect(outcome.contexts?.[0].name).toBe("kind-dev");
   });
 
+  it("passes through the context's declared namespace", async () => {
+    const invoke = vi.fn().mockResolvedValue({
+      contexts: [{ name: "team-a-ctx", cluster: "c", server: "https://x", namespace: "team-a" }],
+    });
+    const outcome = await listContexts(["/tmp/extra"], invoke);
+    expect(outcome.contexts?.[0].namespace).toBe("team-a");
+  });
+
   it("returns a normalised error on failure", async () => {
     const outcome = await listContexts([], () =>
       Promise.reject(new Error("read kubeconfig: not found")),

--- a/apps/desktop/src/lib/clusters.ts
+++ b/apps/desktop/src/lib/clusters.ts
@@ -14,6 +14,8 @@ export interface ClusterContext {
   isLocal?: boolean;
   /** The detected local provider (e.g. "kind", "vind"), when `isLocal`. */
   provider?: string;
+  /** The context's default namespace from the kubeconfig; empty/absent when unset. */
+  namespace?: string;
 }
 
 export interface ContextsOutcome {

--- a/apps/desktop/src/lib/errors.test.ts
+++ b/apps/desktop/src/lib/errors.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { cleanErrorMessage, describeError } from "./errors";
+import {
+  cleanErrorMessage,
+  describeError,
+  describeForbidden,
+  serviceAccountNamespace,
+} from "./errors";
 
 describe("cleanErrorMessage", () => {
   it("strips the internal handler-error prefix", () => {
@@ -59,5 +64,38 @@ describe("describeError", () => {
 
   it("gives a stable message when there is nothing to show", () => {
     expect(describeError("").detail).toBe("An unexpected error occurred.");
+  });
+});
+
+describe("describeForbidden", () => {
+  it("extracts verb/resource/namespace from an apiserver 403", () => {
+    const raw = 'deployments.apps is forbidden: User "dev" cannot patch resource "deployments" in API group "apps" in the namespace "prod"';
+    expect(describeForbidden(raw)).toBe("You don't have permission to patch deployments in prod.");
+  });
+  it("handles cluster-scoped denials", () => {
+    const raw = 'nodes is forbidden: User "dev" cannot patch resource "nodes" in API group "" at the cluster scope';
+    expect(describeForbidden(raw)).toBe("You don't have permission to patch nodes at the cluster scope.");
+  });
+  it("returns null when it can't parse", () => {
+    expect(describeForbidden("some other error")).toBeNull();
+  });
+  it("describeError uses it for a forbidden error", () => {
+    const raw = 'pods is forbidden: User "dev" cannot delete resource "pods" in API group "" in the namespace "prod"';
+    expect(describeError(raw).detail).toContain("You don't have permission to delete pods in prod");
+  });
+});
+
+describe("serviceAccountNamespace", () => {
+  it("extracts the SA namespace from a forbidden error", () => {
+    const raw =
+      'namespaces is forbidden: User "system:serviceaccount:clavik-dev:clavik-dev" cannot list resource "namespaces" in API group "" at the cluster scope';
+    expect(serviceAccountNamespace(raw)).toBe("clavik-dev");
+  });
+  it("returns null for a non-service-account forbidden error", () => {
+    const raw = 'namespaces is forbidden: User "alice" cannot list resource "namespaces" in API group "" at the cluster scope';
+    expect(serviceAccountNamespace(raw)).toBeNull();
+  });
+  it("returns null for unrelated text", () => {
+    expect(serviceAccountNamespace("some other error")).toBeNull();
   });
 });

--- a/apps/desktop/src/lib/errors.ts
+++ b/apps/desktop/src/lib/errors.ts
@@ -30,6 +30,30 @@ export function cleanErrorMessage(input: unknown): string {
   return raw.replace(HANDLER_PREFIX, "").trim();
 }
 
+/**
+ * Parse an apiserver Forbidden message into an actionable sentence naming the
+ * verb, resource, and namespace (or cluster scope). Returns null when the text
+ * doesn't match the standard shape.
+ */
+export function describeForbidden(raw: string): string | null {
+  const m = raw.match(/cannot (\w+) resource "([^"]+)"(?:.*?in the namespace "([^"]+)"|.*?at the cluster scope)/s);
+  if (!m) return null;
+  const [, verb, resource, namespace] = m;
+  const where = namespace ? `in ${namespace}` : "at the cluster scope";
+  return `You don't have permission to ${verb} ${resource} ${where}.`;
+}
+
+/**
+ * The ServiceAccount's namespace named in a Forbidden error, if the denied user
+ * is a service account (`system:serviceaccount:<namespace>:<name>`). This is the
+ * namespace such a credential is typically scoped to — useful when the kubeconfig
+ * context doesn't declare a namespace.
+ */
+export function serviceAccountNamespace(error: string): string | null {
+  const m = error.match(/system:serviceaccount:([a-z0-9][a-z0-9-]*):/i);
+  return m ? m[1] : null;
+}
+
 /** Classify a raw error into a friendly, actionable message. */
 export function describeError(input: unknown): FriendlyError {
   const raw = cleanErrorMessage(input);
@@ -71,6 +95,7 @@ export function describeError(input: unknown): FriendlyError {
     return {
       title: "Access denied",
       detail:
+        describeForbidden(raw) ??
         "Your account doesn't have permission for this on the cluster. Check your RBAC roles, or switch to a context with the right access.",
       raw,
     };

--- a/apps/desktop/src/lib/watch.test.ts
+++ b/apps/desktop/src/lib/watch.test.ts
@@ -43,6 +43,7 @@ describe("watchResource", () => {
       namespace: "default",
       kind: "deployments",
       channel: subscribedChannel,
+      kubeconfigPaths: [],
     });
 
     // Array payloads are snapshots; `{status}` objects drive the status callback.
@@ -55,6 +56,47 @@ describe("watchResource", () => {
     handle.stop();
     expect(dispose).toHaveBeenCalled();
     expect(invokeCommandMock).toHaveBeenCalledWith("stop_watch", { channel: subscribedChannel });
+  });
+
+  it("passes the kubeconfig files to the backend as kubeconfigPaths", async () => {
+    let subscribedChannel = "";
+    subscribeMock.mockImplementation(async (ch: string) => {
+      subscribedChannel = ch;
+      return vi.fn();
+    });
+    invokeCommandMock.mockResolvedValue(undefined);
+
+    await watchResource("kind-dev", "default", "pods", vi.fn(), undefined, undefined, [
+      "/some/pasted.yaml",
+    ]);
+
+    expect(invokeCommandMock).toHaveBeenCalledWith("start_resource_watch", {
+      context: "kind-dev",
+      namespace: "default",
+      kind: "pods",
+      channel: subscribedChannel,
+      kubeconfigPaths: ["/some/pasted.yaml"],
+    });
+  });
+
+  it("routes an { error } payload to onError (permanent watch failure)", async () => {
+    let captured: ((payload: unknown) => void) | undefined;
+    subscribeMock.mockImplementation(async (_ch: string, handler: (p: unknown) => void) => {
+      captured = handler;
+      return vi.fn();
+    });
+    invokeCommandMock.mockResolvedValue(undefined);
+    const onRows = vi.fn();
+    const onStatus = vi.fn();
+    const onError = vi.fn();
+
+    await watchResource("kind-dev", "", "pods", onRows, onStatus, onError);
+
+    captured?.({ error: "watch pods is forbidden: User cannot watch" });
+    expect(onError).toHaveBeenCalledWith("watch pods is forbidden: User cannot watch");
+    // An error is neither a snapshot nor a status transition.
+    expect(onRows).not.toHaveBeenCalled();
+    expect(onStatus).not.toHaveBeenCalled();
   });
 
   it("sanitizes illegal characters in the channel name (Tauri event constraint)", async () => {
@@ -77,6 +119,7 @@ describe("watchResource", () => {
       namespace: "kube-system",
       kind: "pods",
       channel: subscribedChannel,
+      kubeconfigPaths: [],
     });
   });
 

--- a/apps/desktop/src/lib/watch.ts
+++ b/apps/desktop/src/lib/watch.ts
@@ -52,6 +52,8 @@ export async function watchResource(
   kind: string,
   onRows: (rows: Array<{ name: string }>) => void,
   onStatus?: (status: WatchStatus) => void,
+  onError?: (error: string) => void,
+  kubeconfigFiles: string[] = [],
 ): Promise<WatchHandle> {
   // Tauri event names allow only [alphanumeric, -, /, :, _], but a context name
   // can contain other characters (e.g. the "@" in "admin@cluster"), which makes
@@ -59,15 +61,24 @@ export async function watchResource(
   // every channel unique regardless of any collisions the replacement introduces.
   const channel = `watch:${kind}:${context}:${namespace}:${++watchSeq}`.replace(/[^a-zA-Z0-9/:_-]/g, "_");
   const dispose = await subscribe(channel, (payload) => {
-    // The backend emits either a snapshot (array) or a `{status}` object.
+    // The backend emits a snapshot (array), a `{status}` object, or, for a
+    // permanent (403/401) failure that won't self-heal, an `{error}` object.
     if (Array.isArray(payload)) {
       onRows(payload as Array<{ name: string }>);
     } else if (payload && typeof payload === "object" && "status" in payload) {
       onStatus?.((payload as { status: WatchStatus }).status);
+    } else if (payload && typeof payload === "object" && "error" in payload) {
+      onError?.(String((payload as { error: unknown }).error));
     }
   });
   try {
-    await invokeCommand("start_resource_watch", { context, namespace, kind, channel });
+    await invokeCommand("start_resource_watch", {
+      context,
+      namespace,
+      kind,
+      channel,
+      kubeconfigPaths: kubeconfigFiles,
+    });
   } catch (e) {
     dispose();
     throw e;

--- a/apps/desktop/src/ui/IconButton.tsx
+++ b/apps/desktop/src/ui/IconButton.tsx
@@ -4,19 +4,22 @@ import type { LucideIcon } from "lucide-react";
 
 export interface IconButtonProps {
   icon: LucideIcon;
-  /** Accessible name + tooltip (e.g. "Logs", "Delete"). */
+  /** Accessible name + default tooltip (e.g. "Logs", "Delete"). */
   label: string;
   onClick?: () => void;
   /** Tints the icon with the danger colour (e.g. Delete). */
   danger?: boolean;
   disabled?: boolean;
+  /** Tooltip override (defaults to `label`; used to explain a disabled reason). */
+  title?: string;
 }
 
 /**
  * A compact icon-only button (shadcn Button, ghost). The label is both the
- * accessible name and the hover tooltip, so the icon never stands alone.
+ * accessible name and the hover tooltip (unless `title` overrides it), so the
+ * icon never stands alone.
  */
-export function IconButton({ icon, label, onClick, danger, disabled }: IconButtonProps) {
+export function IconButton({ icon, label, onClick, danger, disabled, title }: IconButtonProps) {
   const Icon = icon;
   return (
     <Button
@@ -24,7 +27,7 @@ export function IconButton({ icon, label, onClick, danger, disabled }: IconButto
       variant="ghost"
       size="icon-sm"
       aria-label={label}
-      title={label}
+      title={title ?? label}
       onClick={onClick}
       disabled={disabled}
       className={danger ? "text-destructive hover:text-destructive" : undefined}

--- a/apps/desktop/src/ui/styles.css
+++ b/apps/desktop/src/ui/styles.css
@@ -3230,13 +3230,17 @@ body {
   border-bottom-style: solid;
   border-bottom-width: 1px;
 }
-/* Thin, unobtrusive horizontal scrollbar so an overflowing strip stays usable. */
+/* Ultra-thin horizontal scrollbar; the thumb only shows on hover so the strip
+   stays clean (wheel/trackpad scroll and auto-scroll-to-active still work). */
 .fl-ctabs::-webkit-scrollbar {
-  height: 6px;
+  height: 3px;
 }
 .fl-ctabs::-webkit-scrollbar-thumb {
-  background: var(--fl-color-border);
+  background: transparent;
   border-radius: 3px;
+}
+.fl-ctabs:hover::-webkit-scrollbar-thumb {
+  background: var(--fl-color-border);
 }
 .fl-ctabs::-webkit-scrollbar-track {
   background: transparent;

--- a/crates/kube/src/access.rs
+++ b/crates/kube/src/access.rs
@@ -1,0 +1,206 @@
+//! `k8s.canI` — batched preflight authorization checks via SelfSubjectAccessReview.
+//!
+//! Each check becomes one SSAR (`authorization.k8s.io/v1`) run concurrently. The
+//! result is a UI hint only: it can disable a control the user can't use, but the
+//! API server remains the source of truth (an unknown result never claims access).
+
+use std::sync::Arc;
+
+use futures::future::join_all;
+use k8s_openapi::api::authorization::v1::{
+    ResourceAttributes, SelfSubjectAccessReview, SelfSubjectAccessReviewSpec,
+    SubjectAccessReviewStatus,
+};
+use kube::api::{Api, PostParams};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use srelens_capability::{Annotations, Capability, CapabilityError};
+
+use crate::client_cache::ClientCache;
+use crate::connect::request_timeout;
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(default)]
+pub struct AccessCheck {
+    pub verb: String,
+    pub group: String,
+    pub resource: String,
+    pub subresource: String,
+    pub namespace: String,
+    pub name: String,
+}
+
+impl Default for AccessCheck {
+    fn default() -> Self {
+        Self {
+            verb: String::new(),
+            group: String::new(),
+            resource: String::new(),
+            subresource: String::new(),
+            namespace: String::new(),
+            name: String::new(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CanIIn {
+    pub context: String,
+    pub checks: Vec<AccessCheck>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, JsonSchema)]
+pub struct AccessResult {
+    pub allowed: bool,
+    pub denied: bool,
+    pub reason: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct CanIOut {
+    pub results: Vec<AccessResult>,
+}
+
+/// Build a SelfSubjectAccessReview for one check (pure — no I/O).
+fn build_review(check: &AccessCheck) -> SelfSubjectAccessReview {
+    let opt = |s: &str| {
+        if s.is_empty() {
+            None
+        } else {
+            Some(s.to_string())
+        }
+    };
+    SelfSubjectAccessReview {
+        spec: SelfSubjectAccessReviewSpec {
+            resource_attributes: Some(ResourceAttributes {
+                verb: opt(&check.verb),
+                group: opt(&check.group),
+                resource: opt(&check.resource),
+                subresource: opt(&check.subresource),
+                namespace: opt(&check.namespace),
+                name: opt(&check.name),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+/// Map an SSAR status into our result (pure). `None`/unknown never claims access.
+fn result_from_status(status: Option<&SubjectAccessReviewStatus>) -> AccessResult {
+    match status {
+        Some(s) => AccessResult {
+            allowed: s.allowed,
+            denied: s.denied.unwrap_or(false),
+            reason: s.reason.clone().unwrap_or_default(),
+        },
+        None => AccessResult {
+            allowed: false,
+            denied: false,
+            reason: String::new(),
+        },
+    }
+}
+
+/// `k8s.canI` — batched SelfSubjectAccessReview. Results align 1:1 with `checks`.
+pub fn can_i_capability(cache: Arc<ClientCache>) -> Capability {
+    Capability::typed::<CanIIn, CanIOut, _, _>(
+        "k8s.canI",
+        "check whether the current user can perform actions (SelfSubjectAccessReview, batched)",
+        Annotations::READ_ONLY,
+        move |input: CanIIn| {
+            let cache = cache.clone();
+            async move {
+                let client = cache
+                    .get(&input.context)
+                    .await
+                    .map_err(CapabilityError::Handler)?;
+                let api: Api<SelfSubjectAccessReview> = Api::all(client);
+                let futures = input.checks.iter().map(|check| {
+                    let api = api.clone();
+                    let review = build_review(check);
+                    async move {
+                        match tokio::time::timeout(
+                            request_timeout(),
+                            api.create(&PostParams::default(), &review),
+                        )
+                        .await
+                        {
+                            Ok(Ok(created)) => result_from_status(created.status.as_ref()),
+                            Ok(Err(e)) => AccessResult {
+                                allowed: false,
+                                denied: false,
+                                reason: e.to_string(),
+                            },
+                            Err(_) => AccessResult {
+                                allowed: false,
+                                denied: false,
+                                reason: "access check timed out".into(),
+                            },
+                        }
+                    }
+                });
+                let results = join_all(futures).await;
+                Ok(CanIOut { results })
+            }
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::api::authorization::v1::SubjectAccessReviewStatus;
+    use std::path::PathBuf;
+
+    #[test]
+    fn builds_resource_attributes_from_a_check() {
+        let check = AccessCheck {
+            verb: "patch".into(),
+            group: "apps".into(),
+            resource: "deployments".into(),
+            subresource: "scale".into(),
+            namespace: "prod".into(),
+            name: String::new(),
+        };
+        let review = build_review(&check);
+        let attrs = review.spec.resource_attributes.unwrap();
+        assert_eq!(attrs.verb.as_deref(), Some("patch"));
+        assert_eq!(attrs.group.as_deref(), Some("apps"));
+        assert_eq!(attrs.resource.as_deref(), Some("deployments"));
+        assert_eq!(attrs.subresource.as_deref(), Some("scale"));
+        assert_eq!(attrs.namespace.as_deref(), Some("prod"));
+        assert_eq!(attrs.name, None); // empty -> omitted
+    }
+
+    #[test]
+    fn maps_ssar_status_to_result() {
+        let allowed = result_from_status(Some(&SubjectAccessReviewStatus {
+            allowed: true,
+            denied: None,
+            reason: None,
+            evaluation_error: None,
+        }));
+        assert!(allowed.allowed && !allowed.denied);
+
+        let denied = result_from_status(Some(&SubjectAccessReviewStatus {
+            allowed: false,
+            denied: Some(true),
+            reason: Some("RBAC: no rule".into()),
+            evaluation_error: None,
+        }));
+        assert!(!denied.allowed && denied.denied);
+        assert_eq!(denied.reason, "RBAC: no rule");
+
+        let unknown = result_from_status(None);
+        assert!(!unknown.allowed && !unknown.denied);
+    }
+
+    #[test]
+    fn capability_is_read_only_with_expected_id() {
+        let cap = can_i_capability(ClientCache::new(PathBuf::from("/x")));
+        assert_eq!(cap.id, "k8s.canI");
+        assert!(cap.annotations.read_only);
+    }
+}

--- a/crates/kube/src/client_cache.rs
+++ b/crates/kube/src/client_cache.rs
@@ -37,6 +37,20 @@ impl ClientCache {
         self.clients.lock().await.clear();
     }
 
+    /// Add any kubeconfig paths not already present, WITHOUT clearing cached
+    /// clients (adding a path can't invalidate an existing client). Used by
+    /// operations that know about additional files (e.g. a resource watch for a
+    /// context that lives in a pasted/added kubeconfig) so they can't race the
+    /// app's initial `set_paths`.
+    pub async fn ensure_paths(&self, additional: Vec<PathBuf>) {
+        let mut current = self.paths.write().await;
+        for p in additional {
+            if !current.contains(&p) {
+                current.push(p);
+            }
+        }
+    }
+
     pub async fn paths(&self) -> Vec<PathBuf> {
         self.paths.read().await.clone()
     }
@@ -90,5 +104,20 @@ mod tests {
     async fn invalidate_is_safe_on_empty_cache() {
         let cache = ClientCache::new(PathBuf::from("/x"));
         cache.invalidate("nope").await; // must not panic
+    }
+
+    #[tokio::test]
+    async fn ensure_paths_adds_missing_without_duplicating_or_reordering() {
+        let a = PathBuf::from("/a");
+        let b = PathBuf::from("/b");
+        let cache = ClientCache::new(a.clone());
+        // `b` is new so it's appended; `a` already present so it's not
+        // duplicated and the existing order (a first) is preserved.
+        cache.ensure_paths(vec![b.clone(), a.clone()]).await;
+        assert_eq!(cache.paths().await, vec![a.clone(), b.clone()]);
+
+        // Ensuring an already-present set is a no-op on order/contents.
+        cache.ensure_paths(vec![a.clone(), b.clone()]).await;
+        assert_eq!(cache.paths().await, vec![a, b]);
     }
 }

--- a/crates/kube/src/connect.rs
+++ b/crates/kube/src/connect.rs
@@ -109,16 +109,43 @@ pub fn single_context_kubeconfig_yaml(paths: &[PathBuf], context: &str) -> Resul
     serde_yaml::to_string(&config).map_err(|e| e.to_string())
 }
 
-pub(crate) async fn build_client(paths: &[PathBuf], context: &str) -> Result<Client, String> {
+/// Resolve a kube `Config` for `context`, preferring the file that declares it
+/// (so merge "first-file-wins" can't shadow its cluster/user), else the merge.
+pub(crate) async fn config_for_context(paths: &[PathBuf], context: &str) -> Result<Config, String> {
+    // Prefer the specific kubeconfig file that declares `context`: kube-rs merge
+    // is "first file wins" by name, so a same-named cluster/user in another
+    // merged file can shadow (or drop) this context's own entries. Building from
+    // the owning file uses that context's real cluster + user.
+    for path in paths {
+        let Ok(kc) = Kubeconfig::read_from(path) else {
+            continue;
+        };
+        if !kc.contexts.iter().any(|c| c.name == context) {
+            continue;
+        }
+        let options = KubeConfigOptions {
+            context: Some(context.to_string()),
+            cluster: None,
+            user: None,
+        };
+        if let Ok(config) = Config::from_custom_kubeconfig(kc, &options).await {
+            return Ok(config);
+        }
+    }
+    // Fallback: merged resolution (handles configs split across files).
     let kubeconfig = load_kubeconfigs(paths)?;
     let options = KubeConfigOptions {
         context: Some(context.to_string()),
         cluster: None,
         user: None,
     };
-    let config = Config::from_custom_kubeconfig(kubeconfig, &options)
+    Config::from_custom_kubeconfig(kubeconfig, &options)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| e.to_string())
+}
+
+pub(crate) async fn build_client(paths: &[PathBuf], context: &str) -> Result<Client, String> {
+    let config = config_for_context(paths, context).await?;
     Client::try_from(config).map_err(|e| e.to_string())
 }
 
@@ -247,6 +274,49 @@ mod tests {
         let yaml = "apiVersion: v1\nkind: Config\nclusters:\n- name: a\n  cluster: { server: https://a }\ncontexts:\n- name: ctx-a\n  context: { cluster: a, user: user-a }\n";
         assert_eq!(validate_kubeconfig_yaml(yaml), Ok(1));
         assert!(validate_kubeconfig_yaml("apiVersion: v1\nkind: Config\ncontexts: []\n").is_err());
+    }
+
+    /// Write `contents` to a unique temp file (pid + nanos) and return its path.
+    fn write_temp_kubeconfig(tag: &str, contents: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "srelens-config-for-context-{tag}-{}-{}.yaml",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::write(&path, contents).unwrap();
+        path
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn config_for_context_prefers_the_owning_files_cluster() {
+        // fileA and fileB both declare a cluster named `shared`, but with
+        // different servers. kube-rs merge is "first file wins" by name, so a
+        // merge-only resolution of ctx-b would wrongly pick fileA's server.
+        let file_a = write_temp_kubeconfig(
+            "a",
+            "apiVersion: v1\nkind: Config\ncurrent-context: ctx-a\nclusters:\n  - name: shared\n    cluster: { server: https://a.example:6443 }\nusers:\n  - name: ua\n    user: {}\ncontexts:\n  - name: ctx-a\n    context: { cluster: shared, user: ua }\n",
+        );
+        let file_b = write_temp_kubeconfig(
+            "b",
+            "apiVersion: v1\nkind: Config\nclusters:\n  - name: shared\n    cluster: { server: https://b.example:6443 }\nusers:\n  - name: ub\n    user: {}\ncontexts:\n  - name: ctx-b\n    context: { cluster: shared, user: ub }\n",
+        );
+
+        let config = config_for_context(&[file_a.clone(), file_b.clone()], "ctx-b")
+            .await
+            .unwrap();
+
+        // ctx-b must resolve to fileB's own `shared` cluster, not fileA's.
+        let url = config.cluster_url.to_string();
+        assert!(
+            url.starts_with("https://b.example"),
+            "expected fileB's server, got {url}"
+        );
+
+        let _ = std::fs::remove_file(&file_a);
+        let _ = std::fs::remove_file(&file_b);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/kube/src/contexts.rs
+++ b/crates/kube/src/contexts.rs
@@ -24,6 +24,10 @@ pub struct ContextDto {
     pub name: String,
     pub cluster: String,
     pub server: String,
+    /// The context's default namespace from the kubeconfig
+    /// (`contexts[].context.namespace`); empty when unset — used to scope
+    /// views for namespace-restricted credentials that can't list namespaces.
+    pub namespace: String,
     #[serde(rename = "isCurrent")]
     pub is_current: bool,
     /// Whether this context points at a local development cluster (kind, k3d,
@@ -94,6 +98,7 @@ pub fn list_contexts_capability(cache: Arc<ClientCache>, default_paths: Vec<Path
                         name: named.name,
                         cluster: cluster_name,
                         server,
+                        namespace: context.namespace.clone().unwrap_or_default(),
                         is_local: class.is_local,
                         provider: class.provider.map(|provider| provider.as_str().to_string()),
                     }
@@ -312,6 +317,47 @@ mod tests {
         reg.register(list_contexts_capability(ClientCache::new(path.clone()), vec![path]));
         let err = reg.invoke("k8s.listContexts", json!({})).await.unwrap_err();
         assert!(matches!(err, CapabilityError::Handler(_)));
+    }
+
+    #[tokio::test]
+    async fn exposes_the_context_declared_namespace() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!(
+            "srelens-ctx-namespace-kubeconfig-{}.yaml",
+            std::process::id()
+        ));
+        tokio::fs::write(
+            &path,
+            r#"apiVersion: v1
+kind: Config
+clusters:
+- name: c
+  cluster: { server: "https://example.com" }
+contexts:
+- name: team-a-ctx
+  context: { cluster: c, user: u, namespace: team-a }
+- name: no-ns-ctx
+  context: { cluster: c, user: u }
+users:
+- name: u
+  user: {}
+"#,
+        )
+        .await
+        .unwrap();
+
+        let mut reg = Registry::new();
+        reg.register(list_contexts_capability(ClientCache::new(path.clone()), vec![path.clone()]));
+        let out = reg.invoke("k8s.listContexts", json!({})).await.unwrap();
+        let contexts = out["contexts"].as_array().unwrap();
+
+        let team_a = contexts.iter().find(|c| c["name"] == "team-a-ctx").unwrap();
+        assert_eq!(team_a["namespace"], "team-a");
+
+        let no_ns = contexts.iter().find(|c| c["name"] == "no-ns-ctx").unwrap();
+        assert_eq!(no_ns["namespace"], "");
+
+        let _ = tokio::fs::remove_file(&path).await;
     }
 
     #[tokio::test]

--- a/crates/kube/src/lib.rs
+++ b/crates/kube/src/lib.rs
@@ -90,6 +90,7 @@ mod age_tests {
     }
 }
 
+pub mod access;
 pub mod actions;
 pub mod client_cache;
 pub mod cluster;

--- a/crates/kube/src/watch.rs
+++ b/crates/kube/src/watch.rs
@@ -110,6 +110,13 @@ impl WatchStatus {
     }
 }
 
+/// A watcher error that will never self-heal (authentication/authorization) —
+/// surface it and stop, instead of reconnecting forever.
+fn is_permanent_watch_error(msg: &str) -> bool {
+    let m = msg.to_ascii_lowercase();
+    m.contains("forbidden") || m.contains("unauthorized") || m.contains("401") || m.contains("403")
+}
+
 /// Generic watch loop: stream `K`, summarise to `T`, key by `key_of`, call
 /// `on_update` with a full snapshot on every change, and `on_status` on
 /// connection transitions.
@@ -155,7 +162,13 @@ where
                     on_update(snapshot(&state));
                 }
             }
-            Err(_) => {
+            Err(e) => {
+                let msg = e.to_string();
+                if is_permanent_watch_error(&msg) {
+                    // Auth/authz failures never self-heal: stop and surface the
+                    // error so the caller can emit it to the UI.
+                    return Err(msg);
+                }
                 // Transient: the watcher backs off and re-lists internally. Flag
                 // the UI once per outage, then keep consuming.
                 if !reconnecting {
@@ -755,5 +768,23 @@ mod tests {
         let snap = snapshot(&state);
         assert_eq!(snap.len(), 1);
         assert_eq!(snap[0].name, "b");
+    }
+
+    #[test]
+    fn permanent_watch_errors_are_auth_failures() {
+        // Authentication/authorization failures never self-heal — surface them.
+        assert!(is_permanent_watch_error(
+            "watch deployments is forbidden: User cannot watch"
+        ));
+        assert!(is_permanent_watch_error("Forbidden (ErrorResponse { code: 403 })"));
+        assert!(is_permanent_watch_error("Unauthorized"));
+        assert!(is_permanent_watch_error("server responded with 401"));
+        assert!(is_permanent_watch_error("server responded with 403"));
+
+        // Transient failures must NOT be treated as permanent (they self-heal).
+        assert!(!is_permanent_watch_error("list deployments timed out"));
+        assert!(!is_permanent_watch_error(
+            "error trying to connect: connection refused"
+        ));
     }
 }


### PR DESCRIPTION
Closes #16

## What

Implements #16 (v0.3 "Operations hardening"): preflight `SelfSubjectAccessReview` checks so every mutating control is disabled (with a reason) when the user lacks permission, and Forbidden errors read as actionable messages. SSAR is a **UI hint only** — it can disable/hide, never permit; the API server stays the source of truth.

## Backend (`crates/kube`)

- **`k8s.canI`** — batched SelfSubjectAccessReview, one review per (verb, resource) check run concurrently; `READ_ONLY` (safe for MCP). Unknown/failed/timeout ⇒ `allowed:false` (fail-closed).

## Frontend (`apps/desktop`)

- **`lib/access.ts`** — `canI` wrapper, a per-cluster access cache (keyed incl. `name`), a `useAccess` hook (batches uncached checks, fail-closed), `rbac` action builders, `kindToResource`, and shared `reportActionError`/`denyReason`/`isForbidden` helpers.
- **Gated every mutating control** — pod delete/evict/edit, resource delete/scale/rollout/edit, cronjob suspend/trigger, node cordon/drain, ConfigMap/Secret Save, and Edit-mode manifest Apply — each disabled with a reason tooltip; unknown/CRD kinds stay enabled; consistently fail-closed. Destructive dialogs name the authorized verb/resource.
- **Forbidden → actionable messages** everywhere — list views (`ErrorState`), action toasts (`reportActionError`), and a 403 invalidates the access cache; cache also cleared on context switch.

## Namespace-scoped credentials (surfaced during testing)

A namespace-scoped ServiceAccount (pasted kubeconfig, can't list namespaces) exposed a chain of latent bugs, all fixed here:

- Forbidden namespace list is **non-fatal**; the view scopes to the context's declared namespace, or the **SA namespace parsed from the 403** when the context declares none.
- **Client build** now uses the context's **own** kubeconfig file (kube-rs merge is "first file wins", so a same-named cluster/user in another merged file could shadow it) and the **watch ensures its context's path** before building the client (fixes a first-open "failed to load current context" race).
- **Watch errors are surfaced** (a permanent 403/401 stops + shows an actionable error) instead of hanging on an infinite "Loading" spinner.

Plus minor UI polish (thinner, hover-reveal tab-strip scrollbar).

## Tests

TDD throughout (subagent-driven, per-task review + a whole-branch review): `k8s.canI` builders/mapping, `access.ts` cache + hook, `describeForbidden`, gating on every control, multi-doc apply gate, namespace scoping, per-file client build, watch error surfacing, `ensure_paths`.

Gates green: backend `cargo test` (166) + `llvm-cov` **56.7%** (≥55); frontend **492** tests / **83.4%** lines (≥80); tsc clean.
