### PR TITLE
fix: RBAC-aware UX review follow-ups

### DIFF
--- a/apps/desktop/src/components/DetailActions.test.tsx
+++ b/apps/desktop/src/components/DetailActions.test.tsx
@@ -286,7 +286,7 @@ describe("PodActions RBAC gating", () => {
     render(<PodActions context="kind-dev" pod={prodPod} onDeleted={() => {}} />);
     const evict = screen.getByRole("button", { name: "Evict" });
     expect(isDisabled(evict)).toBe(true);
-    expect(titleOf(evict)).toEqual(expect.stringContaining("permission to create pods in prod"));
+    expect(titleOf(evict)).toEqual(expect.stringContaining("permission to create pods/eviction in prod"));
   });
 
   it("disables the pod Edit control and explains why when the user can't patch pods", () => {
@@ -373,7 +373,7 @@ describe("ResourceActions RBAC gating", () => {
     );
     const scale = screen.getByRole("button", { name: "Scale" });
     expect(isDisabled(scale)).toBe(true);
-    expect(titleOf(scale)).toEqual(expect.stringContaining("permission to patch deployments in prod"));
+    expect(titleOf(scale)).toEqual(expect.stringContaining("permission to patch deployments/scale in prod"));
   });
 
   it("disables Restart when the user can't patch the workload", () => {

--- a/apps/desktop/src/components/ManifestEditor.test.tsx
+++ b/apps/desktop/src/components/ManifestEditor.test.tsx
@@ -403,6 +403,26 @@ describe("ManifestEditor", () => {
     expect(btn.getAttribute("title")).toBe("You don't have permission to patch deployments in prod");
   });
 
+  it("edit mode: does NOT gate Apply when the manifest declares no namespace (avoids a wrong-scope false-disable)", async () => {
+    // A namespaced resource whose YAML omits metadata.namespace relies on the
+    // context's default namespace. Building the SSAR with an empty namespace
+    // makes it cluster-scoped and can FALSE-disable Apply. With no declared
+    // namespace we skip gating (server still enforces) — Apply stays ENABLED
+    // even though useAccess would deny.
+    vi.mocked(useAccess).mockReturnValue({ allowed: () => false, reason: () => "", known: () => true, loading: false });
+    render(
+      <ManifestEditor
+        context="ctx"
+        yaml={"apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: web\n"}
+        onYamlChange={() => {}}
+        confirm={{ kind: "Deployment", name: "web" }}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: /apply/i });
+    expect(isDisabled(btn)).toBe(false);
+    expect(btn.getAttribute("title")).toBeNull();
+  });
+
   it("names the authorized action in the edit-apply confirm dialog", async () => {
     render(
       <ManifestEditor

--- a/apps/desktop/src/components/ManifestEditor.tsx
+++ b/apps/desktop/src/components/ManifestEditor.tsx
@@ -138,7 +138,12 @@ export function ManifestEditor({
       if (!first?.kind) return null;
       const res = kindToResource(first.kind);
       if (!res) return null;
-      return rbac.edit(res.group, res.resource, first.metadata?.namespace ?? "");
+      const namespace = first.metadata?.namespace;
+      // No declared namespace: the resource relies on the context's default, so
+      // a preflight built with an empty namespace would be cluster-scoped and
+      // could FALSE-disable Apply. Skip gating — the API server still enforces.
+      if (!namespace) return null;
+      return rbac.edit(res.group, res.resource, namespace);
     } catch {
       return null;
     }

--- a/apps/desktop/src/components/ResourceBrowser.test.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.test.tsx
@@ -853,6 +853,37 @@ describe("ResourceBrowser", () => {
     );
   });
 
+  it("looks up the context's declared namespace using the CONFIGURED kubeconfig files when scoping a forbidden view", async () => {
+    // A restricted context that lives in a PASTED/additional kubeconfig file:
+    // its declared namespace is only discoverable when listContexts is passed
+    // the configured file paths. A bare listContexts() wouldn't find it, so the
+    // scoping lookup must forward `kubeconfigFiles`.
+    listNamespacesMock.mockResolvedValue({
+      error:
+        'handler error: ApiError: namespaces is forbidden: User "system:serviceaccount:clavik-dev:viewer" cannot list resource "namespaces" in API group "" at the cluster scope: Forbidden (ErrorResponse { code: 403, reason: "Forbidden", message: "..." })',
+    });
+    // The context's declared namespace (team-a) is ONLY returned when the paths
+    // are provided; a bare call yields nothing (and would fall back to the SA's
+    // namespace, clavik-dev, parsed from the error).
+    listContextsMock.mockImplementation(async (paths?: string[]) => {
+      if (paths && paths.length) {
+        return { contexts: [{ name: "kind-dev", cluster: "kind-dev", server: "https://x", namespace: "team-a" }] };
+      }
+      return { contexts: [] };
+    });
+    watchResourceMock.mockImplementation(
+      watchWith([{ name: "web", namespace: "team-a", ready: "1/1", upToDate: 1, available: 1 }]),
+    );
+    render(<ResourceBrowser context="kind-dev" kind="deployments" kubeconfigFiles={["/some/pasted.yaml"]} />);
+
+    // Scoped to the DECLARED namespace (found via the configured files), not the
+    // SA fallback — proving listContexts was called WITH the kubeconfig paths.
+    expect(await screen.findByText(/Scoped to namespace team-a/)).toBeDefined();
+    expect(screen.queryByText(/Scoped to namespace clavik-dev/)).toBeNull();
+    expect(listContextsMock).toHaveBeenCalledWith(["/some/pasted.yaml"]);
+    expect(listContextsMock).not.toHaveBeenCalledWith();
+  });
+
   it("shows a friendly ErrorState (not raw text) when the resource list itself is forbidden", async () => {
     listNamespacesMock.mockResolvedValue({ namespaces: ["prod"] });
     listResourceMock.mockResolvedValue({

--- a/apps/desktop/src/components/ResourceBrowser.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.tsx
@@ -640,7 +640,7 @@ export function ResourceBrowser({
         // would just 403 again). Prefer the namespace the context's kubeconfig
         // entry declares; if it declares none, fall back to the ServiceAccount's
         // namespace named in the Forbidden error itself.
-        void listContexts()
+        void listContexts(kubeconfigFiles)
           .then((ctxOutcome) => {
             if (!active) return null;
             return ctxOutcome.contexts?.find((c) => c.name === context)?.namespace?.trim();

--- a/apps/desktop/src/lib/access.test.ts
+++ b/apps/desktop/src/lib/access.test.ts
@@ -21,7 +21,7 @@ vi.mock("./notify", () => ({ notify: notifyMock }));
 
 describe("canI", () => {
   it("posts checks and returns results", async () => {
-    const invoke = vi.fn().mockResolvedValue({ results: [{ allowed: true, denied: false, reason: "" }] });
+    const invoke = vi.fn().mockResolvedValue({ results: [{ allowed: true, denied: false, reason: "", error: false }] });
     const checks = [{ verb: "delete", resource: "pods", namespace: "prod" }];
     const out = await canI("ctx", checks, invoke);
     expect(invoke).toHaveBeenCalledWith("k8s.canI", { context: "ctx", checks });
@@ -84,7 +84,7 @@ describe("reportActionError", () => {
 
   it("clears the context's access cache on a 403 so the control re-gates", async () => {
     const check: AccessCheck = { verb: "delete", resource: "pods", namespace: "prod" };
-    const invoke = vi.fn().mockResolvedValue({ results: [{ allowed: true, denied: false, reason: "" }] });
+    const invoke = vi.fn().mockResolvedValue({ results: [{ allowed: true, denied: false, reason: "", error: false }] });
     const { result } = renderHook(() => useAccess("ctx", [check], invoke));
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.known(check)).toBe(true);
@@ -97,7 +97,7 @@ describe("reportActionError", () => {
 
   it("keeps the cache when the error is not a 403", async () => {
     const check: AccessCheck = { verb: "delete", resource: "pods", namespace: "prod" };
-    const invoke = vi.fn().mockResolvedValue({ results: [{ allowed: true, denied: false, reason: "" }] });
+    const invoke = vi.fn().mockResolvedValue({ results: [{ allowed: true, denied: false, reason: "", error: false }] });
     const { result } = renderHook(() => useAccess("ctx", [check], invoke));
     await waitFor(() => expect(result.current.loading).toBe(false));
 
@@ -125,6 +125,17 @@ describe("denyReason", () => {
     expect(denyReason(access(false, true), check)).toBe("You don't have permission to patch nodes");
   });
 
+  it("includes the subresource so Evict/Scale name the real permission", () => {
+    const evict: AccessCheck = { verb: "create", resource: "pods", subresource: "eviction", namespace: "prod" };
+    expect(denyReason(access(false, true), evict)).toBe(
+      "You don't have permission to create pods/eviction in prod",
+    );
+    const scale: AccessCheck = { verb: "patch", group: "apps", resource: "deployments", subresource: "scale", namespace: "prod" };
+    expect(denyReason(access(false, true), scale)).toBe(
+      "You don't have permission to patch deployments/scale in prod",
+    );
+  });
+
   it("returns undefined when allowed or still unknown", () => {
     const check: AccessCheck = { verb: "delete", resource: "pods", namespace: "prod" };
     expect(denyReason(access(true, true), check)).toBeUndefined();
@@ -140,8 +151,8 @@ describe("useAccess", () => {
   it("batches only uncached checks into one canI call, and allowed() reflects the result once resolved", async () => {
     const checkA: AccessCheck = { verb: "delete", resource: "pods", namespace: "prod" };
     const checkB: AccessCheck = { verb: "get", resource: "pods", namespace: "prod" };
-    const resultA: AccessResult = { allowed: true, denied: false, reason: "" };
-    const resultB: AccessResult = { allowed: false, denied: true, reason: "forbidden" };
+    const resultA: AccessResult = { allowed: true, denied: false, reason: "", error: false };
+    const resultB: AccessResult = { allowed: false, denied: true, reason: "forbidden", error: false };
 
     const invoke = vi
       .fn()
@@ -183,11 +194,59 @@ describe("useAccess", () => {
     expect(result.current.known(check)).toBe(false);
     expect(result.current.allowed(check)).toBe(false);
 
-    resolve({ results: [{ allowed: true, denied: false, reason: "" }] });
+    resolve({ results: [{ allowed: true, denied: false, reason: "", error: false }] });
 
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.known(check)).toBe(true);
     expect(result.current.allowed(check)).toBe(true);
+  });
+
+  it("does NOT cache a failed check (error:true) and retries until it resolves", async () => {
+    vi.useFakeTimers();
+    try {
+      const check: AccessCheck = { verb: "delete", resource: "pods", namespace: "prod" };
+      const invoke = vi
+        .fn()
+        // First attempt FAILS (timeout/call error, not a real RBAC denial).
+        .mockResolvedValueOnce({ results: [{ allowed: false, denied: false, reason: "", error: true }] })
+        // Retry succeeds with a definitive answer.
+        .mockResolvedValue({ results: [{ allowed: true, denied: false, reason: "", error: false }] });
+
+      const { result } = renderHook(() => useAccess("ctx", [check], invoke));
+
+      // Flush the first (errored) response.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(invoke).toHaveBeenCalledTimes(1);
+      // A failed check is NOT cached: known() stays false so denyReason renders
+      // no false "no permission" tooltip and the control re-checks.
+      expect(result.current.known(check)).toBe(false);
+
+      // The bounded retry timer (1500ms * attempt) fires and re-checks.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1500);
+      });
+      expect(invoke).toHaveBeenCalledTimes(2);
+      expect(result.current.known(check)).toBe(true);
+      expect(result.current.allowed(check)).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("caches a definitive denial (error:false, allowed:false) as known — no retry", async () => {
+    const check: AccessCheck = { verb: "delete", resource: "pods", namespace: "prod" };
+    const invoke = vi
+      .fn()
+      .mockResolvedValue({ results: [{ allowed: false, denied: true, reason: "forbidden", error: false }] });
+
+    const { result } = renderHook(() => useAccess("ctx", [check], invoke));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.known(check)).toBe(true);
+    expect(result.current.allowed(check)).toBe(false);
+    expect(invoke).toHaveBeenCalledTimes(1);
   });
 
   it("does not collide checks that differ only by `name` (resourceNames-scoped RBAC)", async () => {
@@ -195,8 +254,8 @@ describe("useAccess", () => {
     const checkPodB: AccessCheck = { verb: "get", resource: "pods", namespace: "ns", name: "pod-b" };
     const invoke = vi.fn().mockResolvedValue({
       results: [
-        { allowed: true, denied: false, reason: "" },
-        { allowed: false, denied: true, reason: "forbidden" },
+        { allowed: true, denied: false, reason: "", error: false },
+        { allowed: false, denied: true, reason: "forbidden", error: false },
       ],
     });
 

--- a/apps/desktop/src/lib/access.ts
+++ b/apps/desktop/src/lib/access.ts
@@ -16,6 +16,10 @@ export interface AccessResult {
   allowed: boolean;
   denied: boolean;
   reason: string;
+  /** True when the check itself FAILED (timeout/call error) — NOT a real RBAC
+   * denial. Failed checks are left uncached so the control fail-closes but
+   * re-checks, and no false "no permission" tooltip is shown. */
+  error: boolean;
 }
 
 /** Batched SelfSubjectAccessReview via `k8s.canI`. Results align 1:1 with `checks`. */
@@ -76,7 +80,7 @@ export function denyReason(
   c: AccessCheck,
 ): string | undefined {
   return access.known(c) && !access.allowed(c)
-    ? `You don't have permission to ${c.verb} ${c.resource}${c.namespace ? ` in ${c.namespace}` : ""}`
+    ? `You don't have permission to ${c.verb} ${c.resource}${c.subresource ? `/${c.subresource}` : ""}${c.namespace ? ` in ${c.namespace}` : ""}`
     : undefined;
 }
 
@@ -99,16 +103,35 @@ export function useAccess(
   const checksKey = checks.map((c) => keyOf(context, c)).join(";");
 
   useEffect(() => {
-    const missing = checks.filter((c) => !cache.has(keyOf(context, c)));
-    if (missing.length === 0) return;
     let active = true;
-    void canI(context, missing, invoke).then((out) => {
-      if (!active || !out.results) return;
-      missing.forEach((c, i) => cache.set(keyOf(context, c), out.results![i]));
-      forceUpdate();
-    });
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let attempts = 0;
+    const run = () => {
+      const missing = checks.filter((c) => !cache.has(keyOf(context, c)));
+      if (missing.length === 0) return;
+      void canI(context, missing, invoke).then((out) => {
+        if (!active) return;
+        if (out.results) {
+          // Cache only DEFINITIVE results; a failed check (r.error) stays
+          // uncached so the control is fail-closed (disabled) but re-checks,
+          // and denyReason won't render a false "no permission".
+          missing.forEach((c, i) => {
+            const r = out.results![i];
+            if (r && !r.error) cache.set(keyOf(context, c), r);
+          });
+          forceUpdate();
+        }
+        const unresolved = checks.some((c) => !cache.has(keyOf(context, c)));
+        if (unresolved && attempts < 3) {
+          attempts += 1;
+          timer = setTimeout(run, 1500 * attempts);
+        }
+      });
+    };
+    run();
     return () => {
       active = false;
+      if (timer) clearTimeout(timer);
     };
     // Deps are intentionally [context, checksKey], not [invoke, checks]: a
     // fresh `invoke` function or `checks` array reference on every render

--- a/crates/kube/src/access.rs
+++ b/crates/kube/src/access.rs
@@ -54,6 +54,10 @@ pub struct AccessResult {
     pub allowed: bool,
     pub denied: bool,
     pub reason: String,
+    /// The check FAILED (network error / timeout) rather than completing. A
+    /// completed review with `allowed:false` is a real denial; `error:true`
+    /// means the frontend should retry, not cache a permanent "no permission".
+    pub error: bool,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -94,11 +98,13 @@ fn result_from_status(status: Option<&SubjectAccessReviewStatus>) -> AccessResul
             allowed: s.allowed,
             denied: s.denied.unwrap_or(false),
             reason: s.reason.clone().unwrap_or_default(),
+            error: false,
         },
         None => AccessResult {
             allowed: false,
             denied: false,
             reason: String::new(),
+            error: false,
         },
     }
 }
@@ -132,11 +138,13 @@ pub fn can_i_capability(cache: Arc<ClientCache>) -> Capability {
                                 allowed: false,
                                 denied: false,
                                 reason: e.to_string(),
+                                error: true,
                             },
                             Err(_) => AccessResult {
                                 allowed: false,
                                 denied: false,
                                 reason: "access check timed out".into(),
+                                error: true,
                             },
                         }
                     }
@@ -183,6 +191,8 @@ mod tests {
             evaluation_error: None,
         }));
         assert!(allowed.allowed && !allowed.denied);
+        // A completed review is authoritative — never an error, even when allowed.
+        assert!(!allowed.error);
 
         let denied = result_from_status(Some(&SubjectAccessReviewStatus {
             allowed: false,
@@ -192,9 +202,12 @@ mod tests {
         }));
         assert!(!denied.allowed && denied.denied);
         assert_eq!(denied.reason, "RBAC: no rule");
+        // A completed denial is authoritative, not a failed check.
+        assert!(!denied.error);
 
         let unknown = result_from_status(None);
         assert!(!unknown.allowed && !unknown.denied);
+        assert!(!unknown.error);
     }
 
     #[test]

--- a/crates/kube/src/watch.rs
+++ b/crates/kube/src/watch.rs
@@ -110,11 +110,14 @@ impl WatchStatus {
     }
 }
 
-/// A watcher error that will never self-heal (authentication/authorization) —
+/// A watcher error that will never self-heal (an RBAC Forbidden denial) —
 /// surface it and stop, instead of reconnecting forever.
 fn is_permanent_watch_error(msg: &str) -> bool {
-    let m = msg.to_ascii_lowercase();
-    m.contains("forbidden") || m.contains("unauthorized") || m.contains("401") || m.contains("403")
+    // Only a Forbidden (RBAC) denial is stable and won't self-heal. 401/token
+    // expiry IS recoverable (kube-rs refreshes creds and re-lists), so we keep
+    // reconnecting on it; and matching bare "401"/"403" substrings risks false
+    // positives (e.g. an id or byte count containing those digits).
+    msg.to_ascii_lowercase().contains("forbidden")
 }
 
 /// Generic watch loop: stream `K`, summarise to `T`, key by `key_of`, call
@@ -771,20 +774,29 @@ mod tests {
     }
 
     #[test]
-    fn permanent_watch_errors_are_auth_failures() {
-        // Authentication/authorization failures never self-heal — surface them.
+    fn only_forbidden_is_a_permanent_watch_error() {
+        // A genuine RBAC Forbidden denial is stable and won't self-heal — stop.
         assert!(is_permanent_watch_error(
             "watch deployments is forbidden: User cannot watch"
         ));
-        assert!(is_permanent_watch_error("Forbidden (ErrorResponse { code: 403 })"));
-        assert!(is_permanent_watch_error("Unauthorized"));
-        assert!(is_permanent_watch_error("server responded with 401"));
-        assert!(is_permanent_watch_error("server responded with 403"));
+        assert!(is_permanent_watch_error(
+            "deployments.apps is forbidden: ..."
+        ));
+        assert!(is_permanent_watch_error(
+            "Forbidden (ErrorResponse { code: 403 })"
+        ));
+
+        // 401 / token expiry IS recoverable: kube-rs refreshes creds and re-lists,
+        // so we keep reconnecting rather than permanently stopping the watch.
+        assert!(!is_permanent_watch_error("Unauthorized"));
+        assert!(!is_permanent_watch_error("server responded with 401"));
 
         // Transient failures must NOT be treated as permanent (they self-heal).
         assert!(!is_permanent_watch_error("list deployments timed out"));
         assert!(!is_permanent_watch_error(
             "error trying to connect: connection refused"
         ));
+        // A benign message with a "14030" substring must not false-positive.
+        assert!(!is_permanent_watch_error("read 14030 bytes"));
     }
 }


### PR DESCRIPTION
Follow-up to #16 (merged in #107). Addresses findings from an independent review that landed after #107 was merged.

## Fixes

- **Failed check ≠ denial.** `k8s.canI`'s `AccessResult` gains an `error` flag. A timeout / call failure was previously cached (and shown) as a permanent "you don't have permission." Now the UI caches only definitive results and **retries** failed ones (bounded backoff), so a one-off apiserver blip no longer disables Delete/Scale/Edit for the whole session with a false reason.
- **Watches stop only on Forbidden.** `is_permanent_watch_error` matched bare `401`/`403` substrings — false-positive on things like a byte count `14030`, and it permanently stopped **recoverable** 401/cloud-token-expiry watches (kube-rs self-heals). Now it stops only on a genuine `Forbidden`.
- **Tooltip precision.** `denyReason` includes the subresource — e.g. `create pods/eviction`, `patch deployments/scale`.
- **No false Apply-disable.** The manifest Apply gate is skipped when the edited YAML declares no namespace (an empty namespace built a cluster-scoped SSAR that could false-disable a namespaced edit relying on the context default; server still enforces).
- **Scoping with configured kubeconfigs.** The forbidden-namespace fallback registers `kubeconfigFiles`, so a restricted context in a pasted/added file finds its declared namespace.

## Tests

TDD for each (retry, subresource tooltip, no-namespace gate skip, scoping-with-files, watch-error matching). Gates green: backend `cargo test` (166) + `llvm-cov` **56.7%** (≥55); frontend **498** tests / **83.5%** lines (≥80); tsc clean.
