### PR TITLE
feat(packaging): AUR package (srelens-bin) for Arch/CachyOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -365,3 +365,98 @@ jobs:
           if ls *.asc >/dev/null 2>&1; then
             gh release upload "$TAG" --repo "${{ github.repository }}" *.asc --clobber
           fi
+
+  # Arch / CachyOS / Manjaro install path. Deliberately STABLE-ONLY: AUR users
+  # expect released versions, and an Arch `pkgver` cannot carry the `-<run>`
+  # suffix that dev pre-release tags use.
+  #
+  # This also sidesteps a real bug class: the AppImage vendors libwayland-*, which
+  # the host's newer Mesa then resolves against, breaking EGL and yielding a blank
+  # window. A -bin package linking the SYSTEM webkit2gtk/gtk3/wayland/mesa cannot
+  # hit that. See packaging/aur/README.md.
+  #
+  # Requires (one-time, see packaging/aur/README.md): the srelens-bin name claimed
+  # on the AUR, plus AUR_USERNAME / AUR_EMAIL / AUR_SSH_PRIVATE_KEY secrets. The
+  # job no-ops when the key isn't configured, so it can land before that's done.
+  aur:
+    name: publish AUR (srelens-bin)
+    needs: [version, build]
+    if: ${{ github.ref_name == 'main' && needs.build.result == 'success' && needs.version.outputs.release == 'true' }}
+    runs-on: ubuntu-22.04
+    # Do the AUR push ourselves rather than via a third-party action: an AUR
+    # PKGBUILD executes arbitrary code on a user's machine at build time, so
+    # push access to the package is a high-value target. Handing the AUR SSH key
+    # to an external action would put that entirely in someone else's supply
+    # chain for the sake of ~20 lines of shell.
+    container:
+      image: archlinux:base-devel
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Skip when the AUR key isn't configured
+        id: gate
+        shell: bash
+        env:
+          KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        run: |
+          if [ -z "${KEY:-}" ]; then
+            echo "AUR_SSH_PRIVATE_KEY not set — skipping AUR publish."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install toolchain
+        if: steps.gate.outputs.publish == 'true'
+        run: pacman -Syu --noconfirm --needed git openssh pacman-contrib namcap
+
+      - name: Build, lint and publish
+        if: steps.gate.outputs.publish == 'true'
+        shell: bash
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          AUR_USERNAME: ${{ secrets.AUR_USERNAME }}
+          AUR_EMAIL: ${{ secrets.AUR_EMAIL }}
+        run: |
+          set -euo pipefail
+
+          install -d -m 700 ~/.ssh
+          printf '%s\n' "$AUR_SSH_PRIVATE_KEY" > ~/.ssh/aur
+          chmod 600 ~/.ssh/aur
+          ssh-keyscan -t ed25519,rsa aur.archlinux.org >> ~/.ssh/known_hosts 2>/dev/null
+          export GIT_SSH_COMMAND="ssh -i ~/.ssh/aur -o IdentitiesOnly=yes"
+
+          git config --global user.name "$AUR_USERNAME"
+          git config --global user.email "$AUR_EMAIL"
+          git config --global --add safe.directory '*'
+
+          git clone ssh://aur@aur.archlinux.org/srelens-bin.git aur
+          cp packaging/aur/PKGBUILD aur/PKGBUILD
+          cd aur
+          sed -i "s/^pkgver=.*/pkgver=${VERSION}/" PKGBUILD
+          sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
+
+          # makepkg refuses to run as root.
+          useradd -m builder
+          chown -R builder:builder .
+
+          # Pin real checksums from the published release assets, then regenerate
+          # .SRCINFO (the AUR reads metadata from it, not the PKGBUILD).
+          su builder -c 'updpkgsums'
+          su builder -c 'makepkg --printsrcinfo > .SRCINFO'
+
+          # Actually BUILD it before publishing. A PKGBUILD that does not build
+          # would otherwise reach users as a broken AUR package; --nodeps keeps
+          # this to a packaging check, not a full GUI dependency install.
+          su builder -c 'makepkg -f --nodeps --noconfirm'
+          su builder -c 'namcap PKGBUILD' || true
+          rm -f ./*.pkg.tar.* 
+
+          if git diff --quiet PKGBUILD .SRCINFO; then
+            echo "AUR package already at ${VERSION} — nothing to push."
+            exit 0
+          fi
+          git add PKGBUILD .SRCINFO
+          git commit -m "srelens-bin ${VERSION}"
+          git push origin master

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,0 +1,63 @@
+# Maintainer: Devesh Kumar <vrshu112@gmail.com>
+#
+# srelens-bin — repackages the upstream .deb for Arch.
+#
+# Why a -bin package rather than an AppImage: an AppImage vendors its own copies
+# of platform libraries (GTK, and — via linuxdeploy — libwayland-*), which then
+# get loaded ahead of the system's. On a rolling distro with a much newer Mesa,
+# the host's EGL resolves against those stale bundled Wayland libs, eglGetDisplay()
+# fails, and the app opens a blank window with no error. Linking against the
+# system's own webkit2gtk/gtk3/wayland/mesa makes that whole class of failure
+# impossible, which is exactly what this package does.
+#
+# CI renders pkgver and the checksums on each stable release; see packaging/aur/README.md.
+
+pkgname=srelens-bin
+_pkgname=srelens
+pkgver=0.0.0
+pkgrel=1
+pkgdesc="Kubernetes IDE — an MCP-native desktop workspace for operating clusters"
+arch=('x86_64')
+url="https://github.com/srelens/srelens"
+license=('MIT')
+
+# Verified against the shipped binary's DT_NEEDED, not guessed:
+#   libwebkit2gtk-4.1.so.0, libjavascriptcoregtk-4.1.so.0, libsoup-3.0.so.0  -> webkit2gtk-4.1
+#   libgtk-3.so.0 (+ cairo, gdk-pixbuf, glib, gobject, gio, dbus)            -> gtk3
+# Note the binary does NOT link libwayland directly — it comes in transitively
+# via GTK/Mesa, which is precisely why bundling it (as the AppImage does) is both
+# unnecessary and harmful.
+depends=('webkit2gtk-4.1' 'gtk3' 'hicolor-icon-theme')
+
+# srelens deliberately does not bundle a toolchain — it drives the kubectl/helm
+# already installed on your machine (including kubeconfig exec-auth plugins), so
+# these are genuinely optional rather than hard requirements.
+optdepends=(
+  'kubectl: cluster access and kubeconfig exec-auth plugins (e.g. kubectl-oidc_login)'
+  'helm: Helm release management (install/upgrade/rollback/uninstall)'
+)
+
+provides=("$_pkgname")
+conflicts=("$_pkgname")
+
+# The upstream binary is already built for release; don't let makepkg re-process it.
+options=('!strip' '!debug' '!lto')
+
+source=(
+  "$_pkgname-$pkgver.deb::$url/releases/download/$_pkgname-v$pkgver/${_pkgname}_${pkgver}_amd64.deb"
+  "LICENSE-$pkgver::https://raw.githubusercontent.com/srelens/srelens/$_pkgname-v$pkgver/LICENSE"
+)
+# Replaced with real hashes by `updpkgsums` in CI on every release.
+sha256sums=('SKIP' 'SKIP')
+
+package() {
+  # The .deb payload is exactly usr/bin/srelens + a .desktop entry + hicolor icons.
+  bsdtar -O -xf "$_pkgname-$pkgver.deb" data.tar.gz | bsdtar -xf - -C "$pkgdir"
+
+  # Upstream's generated .desktop ships an empty `Categories=`, which can hide the
+  # app from desktop menus. Give it one until that's fixed upstream.
+  sed -i 's/^Categories=$/Categories=Development;/' \
+    "$pkgdir/usr/share/applications/$_pkgname.desktop"
+
+  install -Dm644 "LICENSE-$pkgver" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -80,10 +80,10 @@ The automation cannot run until a human claims the package name on the AUR:
    - `AUR_EMAIL` — the email on that account
    - `AUR_SSH_PRIVATE_KEY` — the private half of the key from step 1
 
-**Blocked on a stable release.** Every release so far is a rolling `dev`
-pre-release (`srelens-v0.2.1-68`); an Arch `pkgver` cannot carry the `-<run>`
-suffix. The first publish has to wait for a stable `srelens-v<version>` tag cut
-from `main`.
+The current stable release is **`srelens-v0.2.0`**, so the initial import can be
+done against it today (the PKGBUILD builds cleanly against its published `.deb`).
+Rolling `dev` pre-releases (`srelens-v<version>-<run>`) are never published: AUR
+expects released versions, and an Arch `pkgver` cannot carry the `-<run>` suffix.
 
 ## Verifying a change locally (on Arch)
 

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -1,0 +1,95 @@
+# AUR package (`srelens-bin`)
+
+Arch / CachyOS / Manjaro / EndeavourOS:
+
+```sh
+paru -S srelens-bin     # or: yay -S srelens-bin
+```
+
+## Why this channel exists
+
+The AppImage vendors its own copies of platform libraries — including
+`libwayland-{client,cursor,egl,server}` — and loads them ahead of the system's.
+On a rolling distro with a much newer Mesa, the host's EGL then resolves against
+those stale bundled Wayland libs, `eglGetDisplay()` fails with `EGL_BAD_PARAMETER`,
+and srelens opens a **blank window with no error** (#111, first reported on
+CachyOS + GNOME).
+
+This package links the system's own `webkit2gtk-4.1` / `gtk3` / wayland / Mesa,
+so that entire class of failure is *structurally impossible* rather than patched
+around.
+
+## Design notes
+
+- **`-bin`, not a source build.** AUR policy requires the `-bin` suffix for a
+  package that ships a prebuilt binary. It repackages the upstream `.deb`, whose
+  payload is exactly `usr/bin` + a `.desktop` entry + hicolor icons.
+- **Dependencies come from the binary's real `DT_NEEDED`,** not guesswork:
+  `webkit2gtk-4.1` (which supplies javascriptcore + libsoup3) and `gtk3` (which
+  pulls cairo/gdk-pixbuf/glib/dbus). Note the binary never links `libwayland`
+  directly — it arrives transitively via GTK/Mesa, which is exactly why the
+  AppImage bundling it was both unnecessary and harmful.
+- **`kubectl` and `helm` are `optdepends`, not `depends`.** srelens deliberately
+  drives whatever toolchain is already on your machine rather than bundling one;
+  hard-requiring them would contradict that design.
+- The `.desktop` entry upstream ships an empty `Categories=`, which can hide the
+  app from desktop menus; the package fills it in until that's fixed upstream.
+
+## How it's published
+
+`PKGBUILD` here is the source of truth. On every **stable** release (cut from
+`main`), the `aur` job in `.github/workflows/release.yml` runs in an
+`archlinux:base-devel` container and:
+
+1. clones `ssh://aur@aur.archlinux.org/srelens-bin.git`,
+2. rewrites `pkgver` to the released version,
+3. runs `updpkgsums` to pin real `sha256sums` from the published release assets,
+4. regenerates `.SRCINFO` (the AUR reads its metadata from that file, not the PKGBUILD),
+5. **actually builds the package** and lints it with `namcap` — a PKGBUILD that
+   doesn't build must never reach users,
+6. pushes, and no-ops if nothing changed.
+
+The push uses plain `git`/`ssh` rather than a third-party action **on purpose**:
+an AUR PKGBUILD executes arbitrary code on a user's machine at build time, so
+push access to this package is a high-value target. Handing the AUR SSH key to an
+external action would put that in someone else's supply chain to save ~20 lines
+of shell.
+
+Dev pre-releases (`srelens-v<version>-<run>`, cut from `dev`) are deliberately
+**not** published: AUR users expect stable versions, and an Arch `pkgver` cannot
+contain the `-<run>` suffix anyway.
+
+## One-time setup (needed before the first publish)
+
+The automation cannot run until a human claims the package name on the AUR:
+
+1. Create an account at <https://aur.archlinux.org> and add an SSH public key to it.
+2. Claim the name with a first manual push:
+   ```sh
+   git clone ssh://aur@aur.archlinux.org/srelens-bin.git
+   cd srelens-bin
+   cp /path/to/srelens/packaging/aur/PKGBUILD .
+   # set pkgver to the released version, then:
+   updpkgsums
+   makepkg --printsrcinfo > .SRCINFO
+   makepkg -si            # verify it builds AND runs locally
+   git add PKGBUILD .SRCINFO && git commit -m "Initial import" && git push
+   ```
+3. Add these repository secrets:
+   - `AUR_USERNAME` — your AUR account name
+   - `AUR_EMAIL` — the email on that account
+   - `AUR_SSH_PRIVATE_KEY` — the private half of the key from step 1
+
+**Blocked on a stable release.** Every release so far is a rolling `dev`
+pre-release (`srelens-v0.2.1-68`); an Arch `pkgver` cannot carry the `-<run>`
+suffix. The first publish has to wait for a stable `srelens-v<version>` tag cut
+from `main`.
+
+## Verifying a change locally (on Arch)
+
+```sh
+cd packaging/aur
+updpkgsums && makepkg --printsrcinfo > .SRCINFO
+namcap PKGBUILD
+makepkg -si
+```

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -35,6 +35,18 @@ around.
 - The `.desktop` entry upstream ships an empty `Categories=`, which can hide the
   app from desktop menus; the package fills it in until that's fixed upstream.
 
+## In-app updates
+
+srelens's built-in updater cannot drive this install — the binary is repacked
+from the `.deb`, so it self-identifies as a dpkg bundle on a system with no
+dpkg, and self-replacing `/usr/bin/srelens` would desync pacman's database
+anyway. The app detects this and, when a new version is out, points at the
+package manager (`paru -Syu` / `yay -Syu`) instead of offering an in-app
+install; the update itself arrives through the `aur` job below, which bumps the
+AUR package on every stable release. (Builds up to 0.2.0 predate that detection
+and show a "Download & install" button that fails with `InvalidUpdaterFormat` —
+harmless, but update via the package manager.)
+
 ## How it's published
 
 `PKGBUILD` here is the source of truth. On every **stable** release (cut from


### PR DESCRIPTION
Adds an AUR package (`srelens-bin`) so Arch / CachyOS / Manjaro / EndeavourOS users can `paru -S srelens-bin`.

## Why

The AppImage vendors `libwayland-{client,cursor,egl,server}` and loads them ahead of the system's. On a rolling distro with a much newer Mesa, the host's EGL resolves against those stale bundled libs, `eglGetDisplay()` fails with `EGL_BAD_PARAMETER`, and srelens opens a **blank window with no error** (#111 — first reported on CachyOS + GNOME).

I confirmed this by extracting our actually-shipped AppImage: those four libs **are** bundled, while `libEGL`/`libGL` are **not** — a **half-vendored graphics stack**. That's the bug.

A `-bin` package links the system's own `webkit2gtk-4.1` / `gtk3` / wayland / Mesa, so that entire class of failure is *structurally impossible* rather than patched around.

## The package

- **Dependencies derived from the binary's real `DT_NEEDED`**, not guessed: `webkit2gtk-4.1` (supplies javascriptcore + libsoup3) and `gtk3`. Note the binary **never links `libwayland` directly** — it arrives transitively via GTK/Mesa, which is precisely why the AppImage bundling it was gratuitous.
- **`kubectl` / `helm` are `optdepends`, not `depends`** — the honest encoding of srelens's design: it drives whatever toolchain is already on your machine rather than bundling one.
- Ships the MIT `LICENSE` (Arch requires it) and fills in the **empty `Categories=`** our generated `.desktop` currently has, which can hide the app from desktop menus. Worth fixing upstream in `tauri.conf.json` too.

## Publishing

Runs in an `archlinux:base-devel` container on **stable releases only** (AUR expects released versions, and an Arch `pkgver` cannot carry the `-<run>` suffix our dev pre-release tags use). It no-ops until the AUR secrets exist, so it can land today.

Two deliberate choices:

- **No third-party action.** An AUR PKGBUILD **executes arbitrary code on a user's machine at build time**, so push access to this package is a high-value target. Handing the AUR SSH key to an external action would put that in someone else's supply chain to save ~20 lines of shell. We push with plain `git`/`ssh`.
- **It builds and `namcap`-lints the package before pushing** — a PKGBUILD that doesn't build must never reach users.

## Verification

Ran the exact CI sequence in a real Arch container: `updpkgsums` → `.SRCINFO` → `makepkg` → `srelens-bin-0.2.1-1-x86_64.pkg.tar.zst` produced, with the packaged `.desktop` carrying `Categories=Development;`.

## Before it can actually publish (needs a human)

1. **A stable release.** Every release so far is a rolling `dev` pre-release; an Arch `pkgver` can't carry `-<run>`. Needs a stable `srelens-v<version>` from `main`.
2. **Claim `srelens-bin` on the AUR** (the name is free) with one manual push, then add `AUR_USERNAME` / `AUR_EMAIL` / `AUR_SSH_PRIVATE_KEY`. Steps in `packaging/aur/README.md`.

Related to #111 — this gives Arch users a working channel, but does **not** by itself fix the AppImage for everyone else.
