### PR TITLE
fix(updater): defer to the system package manager on installs it owns

### DIFF
--- a/.github/scripts/compose-latest.cjs
+++ b/.github/scripts/compose-latest.cjs
@@ -33,6 +33,11 @@ for (const f of sigFiles) {
   if (/aarch64\.app\.tar\.gz$/.test(artifact)) add('darwin-aarch64', artifact);
   else if (/(x64|x86_64)\.app\.tar\.gz$/.test(artifact)) add('darwin-x86_64', artifact);
   else if (/\.AppImage(\.tar\.gz)?$/.test(artifact)) add('linux-x86_64', artifact);
+  // The updater looks up "{os}-{arch}-{installer}" before "{os}-{arch}", and a
+  // .deb/.rpm install is stamped with its bundle type — without these keys it
+  // would download the AppImage and fail with InvalidUpdaterFormat.
+  else if (/\.deb$/.test(artifact)) add('linux-x86_64-deb', artifact);
+  else if (/\.rpm$/.test(artifact)) add('linux-x86_64-rpm', artifact);
   else if (/(-setup\.exe|\.nsis\.zip)$/.test(artifact)) add('windows-x86_64', artifact);
   else if (/\.msi(\.zip)?$/.test(artifact)) add('windows-x86_64', artifact); // MSI fallback
 }

--- a/apps/desktop/src-tauri/src/updater.rs
+++ b/apps/desktop/src-tauri/src/updater.rs
@@ -14,6 +14,7 @@
 //! builds; dev→stable does not auto-downgrade.
 
 use serde::Serialize;
+use tauri::utils::config::BundleType;
 use tauri::{AppHandle, Emitter};
 use tauri_plugin_updater::UpdaterExt;
 
@@ -30,11 +31,44 @@ fn endpoint_for(channel: &str) -> &'static str {
     }
 }
 
+/// Whether this install can update itself, or must defer to a system package
+/// manager. The bundler stamps the bundle type into the binary, so a pacman
+/// (AUR) repack of the .deb still reports `Deb` — the tell is that the tool
+/// the updater would run (`dpkg -i` / `rpm -U`) isn't there. In that case the
+/// install belongs to a package manager the updater knows nothing about, and
+/// self-updating would both fail and desync that manager's database.
+fn self_updatable(os: &str, bundle: Option<BundleType>, has_dpkg: bool, has_rpm: bool) -> bool {
+    if os != "linux" {
+        return true;
+    }
+    match bundle {
+        Some(BundleType::AppImage) => true,
+        Some(BundleType::Deb) => has_dpkg,
+        Some(BundleType::Rpm) => has_rpm,
+        _ => false,
+    }
+}
+
+fn externally_managed() -> bool {
+    let rpm_db = std::path::Path::new("/var/lib/rpm").exists()
+        || std::path::Path::new("/usr/lib/sysimage/rpm").exists();
+    !self_updatable(
+        std::env::consts::OS,
+        tauri::utils::platform::bundle_type(),
+        std::path::Path::new("/var/lib/dpkg").exists(),
+        rpm_db,
+    )
+}
+
 #[derive(Serialize, Clone)]
 pub struct UpdateMeta {
     pub version: String,
     pub current_version: String,
     pub notes: Option<String>,
+    /// True when the install is owned by a system package manager the updater
+    /// can't drive (e.g. pacman for the AUR package) — the UI should point at
+    /// that manager instead of offering an in-app install.
+    pub external: bool,
 }
 
 #[derive(Serialize, Clone)]
@@ -67,6 +101,7 @@ pub async fn update_check(app: AppHandle, channel: String) -> Result<Option<Upda
         version: u.version.clone(),
         current_version: u.current_version.clone(),
         notes: u.body.clone(),
+        external: externally_managed(),
     }))
 }
 
@@ -74,6 +109,13 @@ pub async fn update_check(app: AppHandle, channel: String) -> Result<Option<Upda
 /// `update://progress` events. The caller relaunches the app afterward.
 #[tauri::command]
 pub async fn update_install(app: AppHandle, channel: String) -> Result<(), String> {
+    if externally_managed() {
+        return Err(
+            "This install is managed by a system package manager; update it there instead \
+             (AUR package: pacman/paru)"
+                .to_string(),
+        );
+    }
     let update = fetch_update(&app, &channel)
         .await?
         .ok_or_else(|| "No update available".to_string())?;
@@ -106,5 +148,42 @@ mod tests {
         assert_eq!(endpoint_for("stable"), STABLE_ENDPOINT);
         assert_eq!(endpoint_for("nightly"), STABLE_ENDPOINT);
         assert_eq!(endpoint_for(""), STABLE_ENDPOINT);
+    }
+
+    // The Tauri bundler stamps the bundle type into the binary, so an AUR/
+    // pacman repack of the upstream .deb still reports BundleType::Deb. What
+    // separates it from a real Debian install is whether dpkg exists to run
+    // the update.
+
+    #[test]
+    fn aur_repack_of_the_deb_is_externally_managed() {
+        assert!(!self_updatable("linux", Some(BundleType::Deb), false, false));
+    }
+
+    #[test]
+    fn dpkg_managed_deb_install_self_updates() {
+        assert!(self_updatable("linux", Some(BundleType::Deb), true, false));
+    }
+
+    #[test]
+    fn rpm_install_self_updates_only_with_rpm_present() {
+        assert!(self_updatable("linux", Some(BundleType::Rpm), false, true));
+        assert!(!self_updatable("linux", Some(BundleType::Rpm), false, false));
+    }
+
+    #[test]
+    fn appimage_self_updates_without_any_package_tools() {
+        assert!(self_updatable("linux", Some(BundleType::AppImage), false, false));
+    }
+
+    #[test]
+    fn unknown_linux_packaging_is_externally_managed() {
+        assert!(!self_updatable("linux", None, true, true));
+    }
+
+    #[test]
+    fn non_linux_platforms_always_self_update() {
+        assert!(self_updatable("macos", Some(BundleType::App), false, false));
+        assert!(self_updatable("windows", None, false, false));
     }
 }

--- a/apps/desktop/src/components/SettingsView.test.tsx
+++ b/apps/desktop/src/components/SettingsView.test.tsx
@@ -303,6 +303,37 @@ describe("SettingsView", () => {
     await waitFor(() => expect(transportMocks.relaunchApp).toHaveBeenCalledTimes(1));
   });
 
+  it("offers package-manager guidance instead of install for external installs", async () => {
+    updaterMocks.checkForUpdate.mockResolvedValue({
+      version: "0.2.0",
+      currentVersion: "0.1.0",
+      notes: "New things",
+      external: true,
+    });
+    render(
+      <SettingsView
+        theme={{ name: "slate", mode: "dark" }}
+        onThemeNameChange={() => {}}
+        onThemeModeChange={() => {}}
+        defaultNamespace=""
+        onDefaultNamespaceChange={() => {}}
+        layout={DEFAULT_WORKSPACE_LAYOUT}
+        onLayoutChange={() => {}}
+        contextProfiles={{}}
+        onContextProfilesChange={() => {}}
+        kubeconfigFiles={[]}
+        onKubeconfigFilesChange={() => {}}
+        contextOrder={[]}
+        onContextOrderChange={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Updates/ }));
+    fireEvent.click(await screen.findByRole("button", { name: "Check for updates" }));
+    expect(await screen.findByText(/0\.2\.0/)).toBeDefined();
+    expect(screen.getByText(/system package manager/)).toBeDefined();
+    expect(screen.queryByRole("button", { name: /Download & install/ })).toBeNull();
+  });
+
   it("surfaces update check failures", async () => {
     updaterMocks.checkForUpdate.mockRejectedValue(new Error("endpoint unreachable"));
     render(

--- a/apps/desktop/src/components/SettingsView.tsx
+++ b/apps/desktop/src/components/SettingsView.tsx
@@ -898,9 +898,16 @@ export function SettingsView({
                     {updateState.update.notes && (
                       <pre className="fl-settings-update__notes">{updateState.update.notes}</pre>
                     )}
-                    <Button onClick={() => void startInstall()}>
-                      <Download data-icon="inline-start" /> Download &amp; install
-                    </Button>
+                    {updateState.update.external ? (
+                      <p className="fl-settings-update__status">
+                        This install is managed by your system package manager — update it there
+                        (AUR: <code>paru -Syu</code> or <code>yay -Syu</code>).
+                      </p>
+                    ) : (
+                      <Button onClick={() => void startInstall()}>
+                        <Download data-icon="inline-start" /> Download &amp; install
+                      </Button>
+                    )}
                   </div>
                 )}
 

--- a/apps/desktop/src/lib/updater.test.ts
+++ b/apps/desktop/src/lib/updater.test.ts
@@ -28,6 +28,7 @@ describe("checkForUpdate", () => {
       version: "0.2.0",
       current_version: "0.1.0",
       notes: "### Features\n- things",
+      external: false,
     });
     const meta = await checkForUpdate("dev");
     expect(invokeCommandMock).toHaveBeenCalledWith("update_check", { channel: "dev" });
@@ -35,12 +36,23 @@ describe("checkForUpdate", () => {
       version: "0.2.0",
       currentVersion: "0.1.0",
       notes: "### Features\n- things",
+      external: false,
     });
   });
 
   it("defaults notes to an empty string", async () => {
     invokeCommandMock.mockResolvedValue({ version: "0.2.0", current_version: "0.1.0", notes: null });
     expect((await checkForUpdate("stable"))?.notes).toBe("");
+  });
+
+  it("flags package-manager-owned installs as external", async () => {
+    invokeCommandMock.mockResolvedValue({
+      version: "0.2.0",
+      current_version: "0.1.0",
+      notes: null,
+      external: true,
+    });
+    expect((await checkForUpdate("stable"))?.external).toBe(true);
   });
 });
 

--- a/apps/desktop/src/lib/updater.ts
+++ b/apps/desktop/src/lib/updater.ts
@@ -6,12 +6,18 @@ export interface UpdateMeta {
   version: string;
   currentVersion: string;
   notes: string;
+  /**
+   * The install is owned by a system package manager the updater can't drive
+   * (e.g. pacman for the AUR package) — offer guidance, not an install button.
+   */
+  external: boolean;
 }
 
 interface RawUpdateMeta {
   version: string;
   current_version: string;
   notes: string | null;
+  external?: boolean;
 }
 
 interface RawProgress {
@@ -27,6 +33,7 @@ export async function checkForUpdate(channel: UpdateChannel): Promise<UpdateMeta
     version: meta.version,
     currentVersion: meta.current_version,
     notes: meta.notes ?? "",
+    external: meta.external ?? false,
   };
 }
 


### PR DESCRIPTION
Part of #35 (Linux update story).

## Problem

On an AUR install (`srelens-bin`, which repacks the upstream `.deb`), checking for updates offered the new version but **Download & install always failed with `InvalidUpdaterFormat`**.

Root cause (verified against `tauri-plugin-updater` 2.10.1 / `tauri-utils` 2.9.3 sources): the Tauri bundler stamps the bundle type into the binary at build time, so the repacked binary reports `BundleType::Deb` even on Arch. The updater then routes the downloaded artifact to `install_deb()`, which rejects it — `latest.json` only ever carried the AppImage under `linux-x86_64`. Genuine Debian/Fedora installs failed the same way. And even a "successful" self-update on Arch would be wrong: it would desync pacman's database.

## Fix

- **Backend** (`updater.rs`): `self_updatable()` — on Linux, self-update is allowed for AppImage always, `Deb` only if dpkg exists, `Rpm` only if an rpm database exists, unknown packaging never. `update_check` returns a new `external` flag and `update_install` refuses externally managed installs as defense in depth.
- **UI** (`SettingsView`): external installs see "update it via your system package manager (`paru -Syu` / `yay -Syu`)" instead of an install button that cannot work.
- **Release pipeline** (`compose-latest.cjs`): `latest.json` now also publishes `linux-x86_64-deb` and `linux-x86_64-rpm` keys (the updater's `{os}-{arch}-{installer}` lookup, tauri-apps/plugins-workspace#2277), so real dpkg/rpm installs self-update from the next release on. The `.deb.sig`/`.rpm.sig` assets are already uploaded by the build matrix — confirmed on the live v0.2.0 release.

## Testing

- TDD: Rust unit tests for the `self_updatable` matrix (AUR repack, Debian+dpkg, rpm±db, AppImage, unknown, non-Linux), vitest for the `external` mapping and the Settings UI branch — 13/13 Rust, 528/528 frontend.
- Manifest composer fixture-run against the real v0.2.0 asset names; keys and URLs verified.
- Not verifiable pre-release: the end-to-end dpkg/rpm self-update path needs the next tagged release to exercise.