### PR TITLE
fix(appimage): stop bundled GLib from loading host GIO modules

### DIFF
--- a/apps/desktop/src-tauri/src/appimage.rs
+++ b/apps/desktop/src-tauri/src/appimage.rs
@@ -1,0 +1,85 @@
+//! AppImage runtime quirks.
+//!
+//! The AppImage bundles its own GLib (built on the release runner, currently
+//! 2.72). GLib's GIO scans a compiled-in module directory — the *host's*
+//! `/usr/lib/<arch>/gio/modules` — and the AppImage's GTK AppRun hook only
+//! *adds* the bundled dir via `GIO_EXTRA_MODULES` rather than replacing the
+//! search path. So on a host newer than the build runner, the bundled GLib
+//! tries to load the host's gvfs modules, which reference symbols it doesn't
+//! have (e.g. `g_task_set_static_name`, added in GLib 2.76), and startup prints
+//! `undefined symbol` / `Failed to load module` for every one.
+//!
+//! Pointing `GIO_MODULE_DIR` at the bundled dir makes the bundled GLib scan
+//! only its own compatible modules (the bundled TLS backend still loads, so
+//! HTTPS keeps working; host gvfs — already unusable here — is simply not
+//! scanned). The bundled dir is exactly what the GTK hook already exposes as
+//! `GIO_EXTRA_MODULES`, so we reuse it and stay arch-correct without hardcoding
+//! a multiarch tuple.
+
+/// Decide what `GIO_MODULE_DIR` should be set to, given the current
+/// `GIO_EXTRA_MODULES` and any existing `GIO_MODULE_DIR`. Returns `None` when
+/// nothing should change: outside an AppImage (`GIO_EXTRA_MODULES` unset/empty),
+/// or when the user already pinned `GIO_MODULE_DIR` themselves.
+pub fn gio_module_dir_for_appimage(
+    gio_extra_modules: Option<&str>,
+    existing_gio_module_dir: Option<&str>,
+) -> Option<String> {
+    // Respect an explicit override (including one deliberately set to empty).
+    if existing_gio_module_dir.is_some() {
+        return None;
+    }
+    // GIO_MODULE_DIR names a single directory; GIO_EXTRA_MODULES is a
+    // `:`-separated list. The GTK hook sets one entry — take the first.
+    let dir = gio_extra_modules?.split(':').next().unwrap_or("");
+    if dir.is_empty() {
+        return None;
+    }
+    Some(dir.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn outside_an_appimage_changes_nothing() {
+        assert_eq!(gio_module_dir_for_appimage(None, None), None);
+    }
+
+    #[test]
+    fn empty_extra_modules_changes_nothing() {
+        assert_eq!(gio_module_dir_for_appimage(Some(""), None), None);
+    }
+
+    #[test]
+    fn appimage_points_module_dir_at_the_bundled_dir() {
+        assert_eq!(
+            gio_module_dir_for_appimage(
+                Some("/tmp/.mount_x/usr/lib/x86_64-linux-gnu/gio/modules"),
+                None,
+            ),
+            Some("/tmp/.mount_x/usr/lib/x86_64-linux-gnu/gio/modules".to_string()),
+        );
+    }
+
+    #[test]
+    fn a_user_set_module_dir_is_left_alone() {
+        assert_eq!(
+            gio_module_dir_for_appimage(Some("/tmp/.mount_x/usr/lib/gio/modules"), Some("/opt/gio")),
+            None,
+        );
+        // Even an explicitly-empty override is respected, not clobbered.
+        assert_eq!(
+            gio_module_dir_for_appimage(Some("/tmp/.mount_x/usr/lib/gio/modules"), Some("")),
+            None,
+        );
+    }
+
+    #[test]
+    fn a_list_valued_extra_modules_yields_a_single_dir() {
+        assert_eq!(
+            gio_module_dir_for_appimage(Some("/appdir/gio/modules:/other/dir"), None),
+            Some("/appdir/gio/modules".to_string()),
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod appimage;
 mod bridge;
 pub mod capabilities;
 mod exec;
@@ -27,6 +28,7 @@ use terminal::{start_terminal, terminal_close, terminal_input, terminal_resize, 
 use updater::{update_check, update_install};
 use watch::{start_resource_watch, stop_watch, WatchManager};
 
+pub use appimage::gio_module_dir_for_appimage;
 pub use capabilities::build_registry;
 
 /// Size the main window to a comfortable default, clamped to the screen it

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -16,6 +16,22 @@ fn main() {
     // stdio, and MCP HTTP — honors it (the GUI can adjust it further at runtime).
     srelens_kube::connect::init_timeout_from_env();
 
+    // Running from a Linux AppImage, keep the bundled GLib from scanning the
+    // host's GIO modules (its gvfs modules use symbols the bundled GLib lacks,
+    // spamming "undefined symbol" on startup). Must happen before anything
+    // touches GLib/GTK; we're still single-threaded here. No-op off AppImage.
+    #[cfg(target_os = "linux")]
+    {
+        let extra = std::env::var("GIO_EXTRA_MODULES").ok();
+        let existing = std::env::var("GIO_MODULE_DIR").ok();
+        if let Some(dir) = srelens_desktop_lib::gio_module_dir_for_appimage(
+            extra.as_deref(),
+            existing.as_deref(),
+        ) {
+            std::env::set_var("GIO_MODULE_DIR", dir);
+        }
+    }
+
     let args: Vec<String> = std::env::args().collect();
     // `--mcp-stdio` / `--mcp-http [addr]` run the MCP server instead of the GUI,
     // so external MCP clients/agents can drive every capability.


### PR DESCRIPTION
## Problem

Launched from the AppImage on a current Linux desktop, srelens spams startup:

```
/usr/lib/x86_64-linux-gnu/gvfs/libgvfscommon.so: undefined symbol: g_task_set_static_name
Failed to load module: /usr/lib/x86_64-linux-gnu/gio/modules/libgvfsdbus.so
```

Non-fatal — the app runs — but noisy and confusing. Reported after testing the 0.2.1 AppImage (post-#111).

## Root cause

Confirmed against the shipped artifact and GLib source:

- The AppImage bundles **GLib 2.72** (the release runner's — `libgio-2.0.so.0.7200.4`; its `libgio` does not export `g_task_set_static_name`).
- GLib's GIO scans a compiled-in module directory — the **host's** `/usr/lib/<arch>/gio/modules`. The linuxdeploy GTK AppRun hook only *adds* the bundled dir via `GIO_EXTRA_MODULES`; it never replaces the host path.
- On a host newer than the build runner, the bundled GLib 2.72 tries to load the host's gvfs modules, which use `g_task_set_static_name` (added in **GLib 2.76**) → `undefined symbol`, load fails.

Same *family* as #111 (bundled platform lib older than host), far lower severity. Pre-dates #111 — the same GLib is bundled in 0.2.0.

## Fix

Set `GIO_MODULE_DIR` to the bundled module dir at the very top of `main()` (before any GLib/GTK init, still single-threaded), so the bundled GLib scans only its own compatible modules. The bundled TLS backend (`libgiognutls.so`) still loads, so HTTPS keeps working; host gvfs — already unusable here — is simply not scanned.

The value reused is exactly the dir the GTK hook already exposes as `GIO_EXTRA_MODULES`, so it stays arch-correct without hardcoding a multiarch tuple, and it's a no-op on deb/rpm/macOS/Windows (var unset) and when a user pins `GIO_MODULE_DIR` themselves.

## Testing

- TDD: pure decision function `gio_module_dir_for_appimage` unit-tested (no-op off AppImage, override respected incl. empty, list-valued `GIO_EXTRA_MODULES` → single dir) — watched RED, then GREEN, 18/18 crate tests pass.
- Mechanism verified against **GLib 2.72.4 source** (the bundled version): `get_gio_module_dir()` returns `$GIO_MODULE_DIR` in place of the compiled-in host default, and `_g_io_modules_ensure_loaded()` scans `GIO_EXTRA_MODULES` then that dir.
- End-to-end silence of the warnings can only be confirmed on a real Linux AppImage build (next dev pre-release).

## Not in scope

The `libEGL warning: DRI3 error` line in the same report is the reporter's VM lacking a GPU (software-rendering fallback), not a packaging issue.