### PR TITLE
feat(toolbox): resolve requirements into a DiagnosisReport (slice 2)

### DIFF
--- a/crates/kube/src/helm_cli.rs
+++ b/crates/kube/src/helm_cli.rs
@@ -12,7 +12,7 @@ use srelens_capability::{Annotations, Capability, CapabilityError};
 
 /// Find `program` on the `PATH`-style `path_var`; first existing candidate wins.
 /// `is_file` is injected so this is unit-testable without touching the disk.
-fn resolve_on_path(
+pub(crate) fn resolve_on_path(
     program: &str,
     path_var: &str,
     is_file: impl Fn(&Path) -> bool,

--- a/crates/kube/src/toolbox.rs
+++ b/crates/kube/src/toolbox.rs
@@ -8,8 +8,10 @@
 //! them (cloud CLIs). Resolution of those requirements against the app's PATH
 //! is a separate step; this half is pure string work and fully unit-tested.
 
+use crate::helm_cli::resolve_on_path;
 use crate::kubeconfig::KubeError;
 use serde::Deserialize;
+use std::path::Path;
 
 /// What kind of tool a requirement is — decides whether srelens can fix it.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -148,6 +150,232 @@ struct RawExec {
     command: String,
     #[serde(default)]
     args: Vec<String>,
+}
+
+/// The directories the resolver searches, as PATH-style strings (matching the
+/// rest of the crate). A hit in `app_path` is usable now; a hit only in
+/// `system_path` is present-but-not-visible-to-the-app.
+pub struct SearchPaths {
+    /// The app's effective PATH (post `fix-path-env`) plus `~/.srelens/bin` and
+    /// `~/.krew/bin`.
+    pub app_path: String,
+    /// Broader locations a tool might live in that the app doesn't search.
+    pub system_path: String,
+}
+
+/// Whether a requirement is satisfied, and if so from where.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Resolution {
+    /// On the app's effective PATH (or an absolute exec path that exists) —
+    /// usable now. `version` is populated for kubectl.
+    Found { path: String, version: Option<String> },
+    /// Present on the system but off the app's PATH — needs a PATH fix, not an
+    /// install.
+    NotOnAppPath { path: String },
+    /// Not found anywhere searched.
+    Missing,
+}
+
+/// A requirement paired with where (if anywhere) it resolved.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedRequirement {
+    pub requirement: Requirement,
+    pub resolution: Resolution,
+}
+
+/// A context's exec-auth requirements, each resolved against the search paths —
+/// the single type that drives the health UI, the error deep-link, and the
+/// `toolbox.diagnoseContext` capability.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiagnosisReport {
+    pub context: String,
+    pub items: Vec<ResolvedRequirement>,
+}
+
+/// Locate `binary` against the search paths. A bare name is searched in the app
+/// path first (usable), then the system path (present-but-hidden). A command
+/// written as a path is exec'd directly by client-go, so PATH is irrelevant: it
+/// resolves iff the file exists where written.
+pub fn locate(
+    binary: &str,
+    paths: &SearchPaths,
+    is_file: &impl Fn(&Path) -> bool,
+) -> Option<Located> {
+    // A command written as a path is exec'd directly by client-go; PATH is
+    // irrelevant, so it's usable iff the file exists exactly where written.
+    if binary.contains('/') {
+        return is_file(Path::new(binary))
+            .then(|| Located { path: binary.to_string(), on_app_path: true });
+    }
+    if let Some(p) = resolve_on_path(binary, &paths.app_path, is_file) {
+        return Some(Located { path: p.to_string_lossy().into_owned(), on_app_path: true });
+    }
+    resolve_on_path(binary, &paths.system_path, is_file)
+        .map(|p| Located { path: p.to_string_lossy().into_owned(), on_app_path: false })
+}
+
+/// Where a requirement was found and whether the app can use it as-is.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Located {
+    pub path: String,
+    pub on_app_path: bool,
+}
+
+/// Resolve every requirement of a context into a [`DiagnosisReport`].
+/// `kubectl_version` is injected (it runs a subprocess in production) and is
+/// consulted only for a found kubectl binary.
+pub fn diagnose(
+    ctx: &ContextRequirements,
+    paths: &SearchPaths,
+    is_file: &impl Fn(&Path) -> bool,
+    kubectl_version: &impl Fn(&Path) -> Option<String>,
+) -> DiagnosisReport {
+    let items = ctx
+        .requirements
+        .iter()
+        .map(|req| {
+            let resolution = match locate(&req.binary, paths, is_file) {
+                None => Resolution::Missing,
+                Some(l) if !l.on_app_path => Resolution::NotOnAppPath { path: l.path },
+                Some(l) => {
+                    // Only kubectl reports a client version.
+                    let version = matches!(req.kind, RequirementKind::Kubectl)
+                        .then(|| kubectl_version(Path::new(&l.path)))
+                        .flatten();
+                    Resolution::Found { path: l.path, version }
+                }
+            };
+            ResolvedRequirement { requirement: req.clone(), resolution }
+        })
+        .collect();
+    DiagnosisReport { context: ctx.context.clone(), items }
+}
+
+#[cfg(test)]
+mod resolution_tests {
+    use super::*;
+
+    /// A fake filesystem: the given paths exist and are executable.
+    fn fs(existing: &[&str]) -> impl Fn(&Path) -> bool {
+        let owned: Vec<std::path::PathBuf> = existing.iter().map(std::path::PathBuf::from).collect();
+        move |p: &Path| owned.iter().any(|e| e == p)
+    }
+
+    fn paths() -> SearchPaths {
+        SearchPaths { app_path: "/app/bin".into(), system_path: "/usr/bin".into() }
+    }
+
+    fn kubectl_req() -> Requirement {
+        Requirement { binary: "kubectl".into(), kind: RequirementKind::Kubectl }
+    }
+
+    #[test]
+    fn a_binary_on_the_app_path_is_found() {
+        assert_eq!(
+            locate("kubectl", &paths(), &fs(&["/app/bin/kubectl"])),
+            Some(Located { path: "/app/bin/kubectl".into(), on_app_path: true }),
+        );
+    }
+
+    #[test]
+    fn a_binary_only_on_the_system_path_is_not_on_app_path() {
+        assert_eq!(
+            locate("kubectl", &paths(), &fs(&["/usr/bin/kubectl"])),
+            Some(Located { path: "/usr/bin/kubectl".into(), on_app_path: false }),
+        );
+    }
+
+    #[test]
+    fn a_binary_found_nowhere_is_none() {
+        assert_eq!(locate("kubectl", &paths(), &fs(&[])), None);
+    }
+
+    #[test]
+    fn an_absolute_command_resolves_at_its_written_path_and_is_usable() {
+        let p = "/opt/sdk/gke-gcloud-auth-plugin";
+        assert_eq!(
+            locate(p, &paths(), &fs(&[p])),
+            Some(Located { path: p.into(), on_app_path: true }),
+        );
+        assert_eq!(locate(p, &paths(), &fs(&[])), None);
+    }
+
+    #[test]
+    fn diagnose_reports_found_kubectl_with_version_and_missing_plugin_in_order() {
+        let ctx = ContextRequirements {
+            context: "dev".into(),
+            requirements: vec![
+                kubectl_req(),
+                Requirement {
+                    binary: "kubectl-oidc_login".into(),
+                    kind: RequirementKind::KrewPlugin { plugin: "oidc-login".into() },
+                },
+            ],
+        };
+        let report = diagnose(
+            &ctx,
+            &paths(),
+            &fs(&["/app/bin/kubectl"]),
+            &|_p| Some("v1.30.2".into()),
+        );
+        assert_eq!(
+            report,
+            DiagnosisReport {
+                context: "dev".into(),
+                items: vec![
+                    ResolvedRequirement {
+                        requirement: kubectl_req(),
+                        resolution: Resolution::Found {
+                            path: "/app/bin/kubectl".into(),
+                            version: Some("v1.30.2".into()),
+                        },
+                    },
+                    ResolvedRequirement {
+                        requirement: Requirement {
+                            binary: "kubectl-oidc_login".into(),
+                            kind: RequirementKind::KrewPlugin { plugin: "oidc-login".into() },
+                        },
+                        resolution: Resolution::Missing,
+                    },
+                ],
+            },
+        );
+    }
+
+    #[test]
+    fn version_is_only_probed_for_kubectl_not_other_found_tools() {
+        let ctx = ContextRequirements {
+            context: "eks".into(),
+            requirements: vec![Requirement {
+                binary: "aws".into(),
+                kind: RequirementKind::External,
+            }],
+        };
+        // The version probe would panic if called for a non-kubectl tool.
+        let report = diagnose(&ctx, &paths(), &fs(&["/app/bin/aws"]), &|_p| {
+            panic!("kubectl_version must not be called for external tools")
+        });
+        assert_eq!(
+            report.items[0].resolution,
+            Resolution::Found { path: "/app/bin/aws".into(), version: None },
+        );
+    }
+
+    #[test]
+    fn a_tool_off_the_app_path_reports_not_on_app_path() {
+        let ctx = ContextRequirements {
+            context: "eks".into(),
+            requirements: vec![Requirement {
+                binary: "aws".into(),
+                kind: RequirementKind::External,
+            }],
+        };
+        let report = diagnose(&ctx, &paths(), &fs(&["/usr/bin/aws"]), &|_p| None);
+        assert_eq!(
+            report.items[0].resolution,
+            Resolution::NotOnAppPath { path: "/usr/bin/aws".into() },
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Second slice of #55 (Toolbox), building on #116. Completes the diagnosis engine from the [design spec](../blob/dev/docs/superpowers/specs/2026-07-07-toolbox-kubectl-plugin-manager-design.md) §3: resolve each extracted requirement against the app's PATH.

## What this does

`diagnose(ctx, paths, is_file, kubectl_version) -> DiagnosisReport` resolves each requirement into:

- `Found { path, version }` — on the app's effective PATH, or an absolute exec path that exists (client-go execs those directly, so PATH is irrelevant). Usable now. `version` is populated for kubectl only.
- `NotOnAppPath { path }` — present on the system but off the app's PATH: a PATH fix, not an install (the spec's ⚠ state).
- `Missing` — not found anywhere searched.

`SearchPaths` splits the app's effective PATH (post `fix-path-env`, incl. `~/.srelens/bin` + `~/.krew/bin`) from broader system dirs, so a hit's location decides Found vs NotOnAppPath. `DiagnosisReport` is the single type spec §3 wires into the health UI, the error deep-link, and the future `toolbox.diagnoseContext` capability.

## Design

- **Pure and testable.** The filesystem predicate and the kubectl version probe (a subprocess in production) are injected closures — no disk or process access in the crate. A test asserts the version probe is consulted *only* for a found kubectl, never for other tools.
- **Reuse over duplication.** The PATH search reuses the existing, tested `helm_cli::resolve_on_path` (promoted to `pub(crate)`) instead of re-implementing `split_paths`.

## Scope / next

Diagnosis is now complete (extraction + resolution). Next slices: the install core (kubectl/krew/helm download + sha256 verify into `~/.srelens/bin`), then the capabilities, then the Toolbox page. The real FS/subprocess-backed `SearchPaths`/version wiring lands with the capability slice that runs them.

## Testing

TDD (RED → GREEN): 7 new unit tests (app-path hit, system-path-only, missing, absolute-path present/absent, full report ordering + kubectl version, version-not-probed-for-others). Full `srelens-kube` suite 207 green; clippy clean on the new code.