### PR TITLE
feat(toolbox): toolbox.diagnoseContext capability (slice 5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3381,6 +3381,7 @@ checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",
@@ -4185,6 +4186,7 @@ dependencies = [
  "futures",
  "log",
  "portable-pty",
+ "reqwest",
  "serde",
  "serde_json",
  "srelens-capability",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -30,7 +30,12 @@ srelens-mcp = { path = "../../../crates/mcp" }
 srelens-kube = { path = "../../../crates/kube" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std", "io-util", "macros"] }
 # Blocking HTTP for Toolbox tool downloads (run inside spawn_blocking).
-reqwest = { version = "0.13", default-features = false, features = ["blocking", "default-tls"] }
+# rustls-no-provider matches tauri-plugin-updater's reqwest so no second TLS
+# crypto provider (aws-lc-rs) enters the tree — the workspace standardises on
+# ring via kube-client, and rustls only auto-selects it while it's the sole
+# provider. default-tls here pulls rustls-platform-verifier -> aws-lc-rs,
+# giving two providers and a runtime "could not determine CryptoProvider" panic.
+reqwest = { version = "0.13", default-features = false, features = ["blocking", "rustls-no-provider"] }
 # Local pseudo-terminal for the in-app kubectl shell (spawns the user's login shell).
 portable-pty = "0.8"
 

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -29,6 +29,8 @@ srelens-capability = { path = "../../../crates/capability" }
 srelens-mcp = { path = "../../../crates/mcp" }
 srelens-kube = { path = "../../../crates/kube" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std", "io-util", "macros"] }
+# Blocking HTTP for Toolbox tool downloads (run inside spawn_blocking).
+reqwest = { version = "0.13", default-features = false, features = ["blocking", "default-tls"] }
 # Local pseudo-terminal for the in-app kubectl shell (spawns the user's login shell).
 portable-pty = "0.8"
 

--- a/apps/desktop/src-tauri/src/capabilities.rs
+++ b/apps/desktop/src-tauri/src/capabilities.rs
@@ -33,6 +33,24 @@ pub fn default_kubeconfig_path() -> PathBuf {
         .unwrap_or_default()
 }
 
+/// Blocking HTTP GET for Toolbox tool downloads. Called only from inside
+/// `spawn_blocking` (the install capabilities), so blocking here is fine. A
+/// non-2xx or transport error maps to the retryable `Download` variant.
+fn http_get(url: &str) -> Result<Vec<u8>, srelens_kube::toolbox_install::InstallError> {
+    use srelens_kube::toolbox_install::InstallError;
+    let resp = reqwest::blocking::Client::builder()
+        .user_agent(concat!("srelens/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .and_then(|client| client.get(url).send())
+        .map_err(|e| InstallError::Download(e.to_string()))?;
+    if !resp.status().is_success() {
+        return Err(InstallError::Download(format!("{} for {url}", resp.status())));
+    }
+    resp.bytes()
+        .map(|b| b.to_vec())
+        .map_err(|e| InstallError::Download(e.to_string()))
+}
+
 /// Build the registry with a freshly-created client cache. Used by the MCP
 /// stdio binary, which doesn't need to share the cache with watch tasks.
 pub fn build_registry() -> Registry {
@@ -62,6 +80,10 @@ pub fn build_registry_with(cache: Arc<ClientCache>) -> Registry {
         default_kubeconfig_paths(),
         srelens_kube::toolbox::SearchPaths::from_env(),
         |path| path.is_file(),
+    ));
+    reg.register(srelens_kube::toolbox::install_kubectl_capability(
+        srelens_kube::toolbox::srelens_bin_dir(),
+        http_get,
     ));
 
     reg.register(srelens_kube::connect::cluster_info_capability(

--- a/apps/desktop/src-tauri/src/capabilities.rs
+++ b/apps/desktop/src-tauri/src/capabilities.rs
@@ -58,6 +58,12 @@ pub fn build_registry_with(cache: Arc<ClientCache>) -> Registry {
         cache.clone(),
     ));
 
+    reg.register(srelens_kube::toolbox::diagnose_context_capability(
+        default_kubeconfig_paths(),
+        srelens_kube::toolbox::SearchPaths::from_env(),
+        |path| path.is_file(),
+    ));
+
     reg.register(srelens_kube::connect::cluster_info_capability(
         cache.clone(),
     ));

--- a/apps/desktop/src-tauri/src/capabilities.rs
+++ b/apps/desktop/src-tauri/src/capabilities.rs
@@ -85,6 +85,10 @@ pub fn build_registry_with(cache: Arc<ClientCache>) -> Registry {
         srelens_kube::toolbox::srelens_bin_dir(),
         http_get,
     ));
+    reg.register(srelens_kube::toolbox::install_helm_capability(
+        srelens_kube::toolbox::srelens_bin_dir(),
+        http_get,
+    ));
 
     reg.register(srelens_kube::connect::cluster_info_capability(
         cache.clone(),

--- a/apps/desktop/src-tauri/tests/e2e.rs
+++ b/apps/desktop/src-tauri/tests/e2e.rs
@@ -632,6 +632,15 @@ async fn run_suite() {
         "listContexts must include {ctx}"
     );
 
+    // The kind context authenticates with a client cert (no exec-auth), so it
+    // has no external tool requirements — a healthy, empty diagnosis.
+    let out = h.ok("toolbox.diagnoseContext", json!({ "context": ctx })).await;
+    assert_eq!(out["context"], ctx);
+    assert!(
+        out["items"].as_array().unwrap().is_empty(),
+        "kind context should need no exec-auth tools: {out}"
+    );
+
     let out = h.ok("k8s.clusterInfo", json!({ "context": ctx })).await;
     assert_eq!(out["reachable"], true, "cluster must be reachable: {out}");
     assert!(out["version"].as_str().is_some());

--- a/apps/desktop/src-tauri/tests/e2e.rs
+++ b/apps/desktop/src-tauri/tests/e2e.rs
@@ -149,11 +149,18 @@ impl Harness {
 /// Capabilities genuinely excluded from this suite, with a written reason.
 /// A capability registered later with no case here fails the coverage
 /// assertion at the end of `full_capability_suite`.
-const EXCLUDED: &[(&str, &str)] = &[(
-    "toolbox.installKubectl",
-    "downloads a real ~50MB binary from dl.k8s.io and writes to ~/.srelens/bin; \
-     covered by unit tests with an injected fetch instead of hitting the network in CI",
-)];
+const EXCLUDED: &[(&str, &str)] = &[
+    (
+        "toolbox.installKubectl",
+        "downloads a real ~50MB binary from dl.k8s.io and writes to ~/.srelens/bin; \
+         covered by unit tests with an injected fetch instead of hitting the network in CI",
+    ),
+    (
+        "toolbox.installHelm",
+        "downloads a real release tarball from get.helm.sh and writes to ~/.srelens/bin; \
+         covered by unit tests with an injected fetch instead of hitting the network in CI",
+    ),
+];
 
 fn deadline(secs: u64) -> Instant {
     Instant::now() + Duration::from_secs(secs)

--- a/apps/desktop/src-tauri/tests/e2e.rs
+++ b/apps/desktop/src-tauri/tests/e2e.rs
@@ -147,10 +147,13 @@ impl Harness {
 }
 
 /// Capabilities genuinely excluded from this suite, with a written reason.
-/// Kept empty: every one of the 69 registered capabilities as of #27 is
-/// exercised below. A capability registered later with no case here fails
-/// the coverage assertion at the end of `full_capability_suite`.
-const EXCLUDED: &[(&str, &str)] = &[];
+/// A capability registered later with no case here fails the coverage
+/// assertion at the end of `full_capability_suite`.
+const EXCLUDED: &[(&str, &str)] = &[(
+    "toolbox.installKubectl",
+    "downloads a real ~50MB binary from dl.k8s.io and writes to ~/.srelens/bin; \
+     covered by unit tests with an injected fetch instead of hitting the network in CI",
+)];
 
 fn deadline(secs: u64) -> Instant {
     Instant::now() + Duration::from_secs(secs)

--- a/crates/capability/src/annotations.rs
+++ b/crates/capability/src/annotations.rs
@@ -13,6 +13,10 @@ impl Annotations {
         Self { read_only: true, destructive: false, requires_confirm: false, sensitive: false };
     pub const DESTRUCTIVE: Self =
         Self { read_only: false, destructive: true, requires_confirm: true, sensitive: false };
+    /// A change that isn't destructive but still needs user consent (e.g.
+    /// installing a tool): confirm-gated, not flagged destructive.
+    pub const MUTATING: Self =
+        Self { read_only: false, destructive: false, requires_confirm: true, sensitive: false };
     /// A read that returns sensitive material — gateable by consent policy.
     pub const SENSITIVE_READ: Self =
         Self { read_only: true, destructive: false, requires_confirm: false, sensitive: true };

--- a/crates/kube/src/toolbox.rs
+++ b/crates/kube/src/toolbox.rs
@@ -8,10 +8,14 @@
 //! them (cloud CLIs). Resolution of those requirements against the app's PATH
 //! is a separate step; this half is pure string work and fully unit-tested.
 
+use crate::connect::load_kubeconfigs;
 use crate::helm_cli::resolve_on_path;
 use crate::kubeconfig::KubeError;
-use serde::Deserialize;
-use std::path::Path;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use srelens_capability::{Annotations, Capability, CapabilityError};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 /// What kind of tool a requirement is — decides whether srelens can fix it.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -249,6 +253,222 @@ pub fn diagnose(
         })
         .collect();
     DiagnosisReport { context: ctx.context.clone(), items }
+}
+
+impl SearchPaths {
+    /// Build from the process environment: the app PATH (already resolved by
+    /// `fix-path-env` at startup) with the managed dirs `~/.srelens/bin` and
+    /// `~/.krew/bin` prepended, plus common system locations that back the
+    /// "present but not on the app PATH" check.
+    pub fn from_env() -> SearchPaths {
+        let home = std::env::var("HOME").unwrap_or_default();
+        let path = std::env::var_os("PATH").unwrap_or_default();
+        let managed = [
+            PathBuf::from(&home).join(".srelens/bin"),
+            PathBuf::from(&home).join(".krew/bin"),
+        ];
+        let app_dirs = managed.iter().cloned().chain(std::env::split_paths(&path));
+        let system_dirs = ["/usr/local/bin", "/opt/homebrew/bin", "/usr/bin", "/bin"]
+            .iter()
+            .map(PathBuf::from)
+            .chain(std::iter::once(PathBuf::from(&home).join(".local/bin")));
+        SearchPaths {
+            app_path: join_paths(app_dirs),
+            system_path: join_paths(system_dirs),
+        }
+    }
+}
+
+fn join_paths(dirs: impl IntoIterator<Item = PathBuf>) -> String {
+    std::env::join_paths(dirs)
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_default()
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DiagnoseContextIn {
+    /// The kube context to diagnose.
+    pub context: String,
+}
+
+/// One requirement's status, flattened for the UI and MCP.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct RequirementStatusDto {
+    pub binary: String,
+    /// `kubectl` | `krew-plugin` | `external`.
+    pub kind: String,
+    /// The krew plugin name when `kind == krew-plugin`.
+    pub plugin: Option<String>,
+    /// Whether srelens can install it (kubectl or a krew plugin).
+    pub installable: bool,
+    /// `found` | `not-on-app-path` | `missing`.
+    pub status: String,
+    pub path: Option<String>,
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct DiagnoseContextOut {
+    pub context: String,
+    /// Empty when the context needs no external tools (healthy).
+    pub items: Vec<RequirementStatusDto>,
+}
+
+fn kind_fields(kind: &RequirementKind) -> (&'static str, Option<String>, bool) {
+    match kind {
+        RequirementKind::Kubectl => ("kubectl", None, true),
+        RequirementKind::KrewPlugin { plugin } => ("krew-plugin", Some(plugin.clone()), true),
+        RequirementKind::External => ("external", None, false),
+    }
+}
+
+fn status_fields(res: Resolution) -> (&'static str, Option<String>, Option<String>) {
+    match res {
+        Resolution::Found { path, version } => ("found", Some(path), version),
+        Resolution::NotOnAppPath { path } => ("not-on-app-path", Some(path), None),
+        Resolution::Missing => ("missing", None, None),
+    }
+}
+
+/// Read-only capability: diagnose one context's exec-auth tool requirements.
+/// The resolution environment (`search`, `is_file`) is injected so it's
+/// deterministic under test; production supplies [`SearchPaths::from_env`] and a
+/// real filesystem check.
+pub fn diagnose_context_capability(
+    kubeconfig_paths: Vec<PathBuf>,
+    search: SearchPaths,
+    is_file: impl Fn(&Path) -> bool + Send + Sync + 'static,
+) -> Capability {
+    let search = Arc::new(search);
+    let is_file = Arc::new(is_file);
+    Capability::typed::<DiagnoseContextIn, DiagnoseContextOut, _, _>(
+        "toolbox.diagnoseContext",
+        "diagnose a kube context's exec-auth tool requirements: which external \
+         tools it needs and whether each is installed, off the app PATH, or missing",
+        Annotations::READ_ONLY,
+        move |input: DiagnoseContextIn| {
+            let paths = kubeconfig_paths.clone();
+            let search = search.clone();
+            let is_file = is_file.clone();
+            async move {
+                let merged = load_kubeconfigs(&paths).map_err(CapabilityError::Handler)?;
+                let yaml = serde_yaml::to_string(&merged)
+                    .map_err(|e| CapabilityError::Handler(e.to_string()))?;
+                let all = context_requirements(&yaml)
+                    .map_err(|e| CapabilityError::Handler(e.to_string()))?;
+                let ctx = all
+                    .into_iter()
+                    .find(|c| c.context == input.context)
+                    .ok_or_else(|| {
+                        CapabilityError::InvalidInput(format!("unknown context: {}", input.context))
+                    })?;
+                // Version probing (a subprocess) lands with the install
+                // capabilities; None for now keeps this read pure.
+                let report = diagnose(&ctx, &search, &|p| is_file(p), &|_p| None);
+                let items = report
+                    .items
+                    .into_iter()
+                    .map(|item| {
+                        let (kind, plugin, installable) = kind_fields(&item.requirement.kind);
+                        let (status, path, version) = status_fields(item.resolution);
+                        RequirementStatusDto {
+                            binary: item.requirement.binary,
+                            kind: kind.to_string(),
+                            plugin,
+                            installable,
+                            status: status.to_string(),
+                            path,
+                            version,
+                        }
+                    })
+                    .collect();
+                Ok(DiagnoseContextOut { context: report.context, items })
+            }
+        },
+    )
+}
+
+#[cfg(test)]
+mod capability_tests {
+    use super::*;
+    use serde_json::json;
+    use srelens_capability::Registry;
+
+    /// Write a kubeconfig with an oidc-login exec context to a temp file.
+    fn kubeconfig_with_oidc(dir: &Path) -> PathBuf {
+        let path = dir.join("config");
+        std::fs::write(
+            &path,
+            r#"
+apiVersion: v1
+kind: Config
+clusters:
+  - name: c
+    cluster: { server: https://x }
+contexts:
+  - name: dev
+    context: { cluster: c, user: oidc }
+users:
+  - name: oidc
+    user:
+      exec:
+        apiVersion: client.authentication.k8s.io/v1beta1
+        command: kubectl
+        args: ["oidc-login", "get-token"]
+"#,
+        )
+        .unwrap();
+        path
+    }
+
+    #[tokio::test]
+    async fn diagnoses_a_context_reporting_found_kubectl_and_missing_plugin() {
+        let dir = tempfile::tempdir().unwrap();
+        let kubeconfig = kubeconfig_with_oidc(dir.path());
+        // A bin dir holding kubectl but not the plugin.
+        let bin = dir.path().join("bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        std::fs::write(bin.join("kubectl"), b"#!/bin/sh\n").unwrap();
+        let search = SearchPaths {
+            app_path: bin.to_string_lossy().into_owned(),
+            system_path: String::new(),
+        };
+
+        let mut reg = Registry::new();
+        reg.register(diagnose_context_capability(vec![kubeconfig], search, |p| p.is_file()));
+        let out = reg
+            .invoke("toolbox.diagnoseContext", json!({ "context": "dev" }))
+            .await
+            .unwrap();
+
+        assert_eq!(out["context"], "dev");
+        let items = out["items"].as_array().unwrap();
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0]["kind"], "kubectl");
+        assert_eq!(items[0]["status"], "found");
+        assert!(items[0]["path"].as_str().unwrap().ends_with("/kubectl"));
+        assert_eq!(items[1]["kind"], "krew-plugin");
+        assert_eq!(items[1]["plugin"], "oidc-login");
+        assert_eq!(items[1]["status"], "missing");
+        assert_eq!(items[1]["installable"], true);
+    }
+
+    #[tokio::test]
+    async fn an_unknown_context_is_an_input_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let kubeconfig = kubeconfig_with_oidc(dir.path());
+        let mut reg = Registry::new();
+        reg.register(diagnose_context_capability(
+            vec![kubeconfig],
+            SearchPaths { app_path: String::new(), system_path: String::new() },
+            |p| p.is_file(),
+        ));
+        let err = reg
+            .invoke("toolbox.diagnoseContext", json!({ "context": "nope" }))
+            .await
+            .unwrap_err();
+        assert!(format!("{err:?}").contains("unknown context"));
+    }
 }
 
 #[cfg(test)]

--- a/crates/kube/src/toolbox.rs
+++ b/crates/kube/src/toolbox.rs
@@ -388,6 +388,71 @@ pub fn diagnose_context_capability(
     )
 }
 
+use crate::toolbox_install::{
+    install_binary, kubectl_install, InstallError, Platform, KUBECTL_STABLE_URL,
+};
+
+/// The directory srelens installs managed tools into: `~/.srelens/bin`.
+pub fn srelens_bin_dir() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_default();
+    PathBuf::from(home).join(".srelens").join("bin")
+}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+pub struct InstallKubectlIn {}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct InstallToolOut {
+    pub tool: String,
+    pub version: String,
+    pub path: String,
+}
+
+fn to_handler(e: InstallError) -> CapabilityError {
+    CapabilityError::Handler(e.to_string())
+}
+
+/// Confirm-gated capability: download the latest stable kubectl into
+/// `~/.srelens/bin`, verified against dl.k8s.io's published checksum. `fetch`
+/// (a blocking HTTP GET) is injected so the capability is testable without a
+/// real network; production supplies a reqwest-backed one at registration.
+pub fn install_kubectl_capability<F>(install_dir: PathBuf, fetch: F) -> Capability
+where
+    F: Fn(&str) -> Result<Vec<u8>, InstallError> + Send + Sync + Clone + 'static,
+{
+    Capability::typed::<InstallKubectlIn, InstallToolOut, _, _>(
+        "toolbox.installKubectl",
+        "download the latest stable kubectl into ~/.srelens/bin, verified against \
+         the dl.k8s.io checksum",
+        Annotations::MUTATING,
+        move |_input: InstallKubectlIn| {
+            let install_dir = install_dir.clone();
+            let fetch = fetch.clone();
+            async move {
+                // The install does blocking HTTP + filesystem work; keep it off
+                // the async runtime.
+                tokio::task::spawn_blocking(move || {
+                    let platform = Platform::current().map_err(to_handler)?;
+                    let raw = fetch(KUBECTL_STABLE_URL).map_err(to_handler)?;
+                    let version = std::str::from_utf8(&raw)
+                        .map_err(|e| CapabilityError::Handler(e.to_string()))?
+                        .trim()
+                        .to_string();
+                    let plan = kubectl_install(&version, &platform, &install_dir);
+                    let path = install_binary(&plan, &fetch).map_err(to_handler)?;
+                    Ok(InstallToolOut {
+                        tool: "kubectl".to_string(),
+                        version,
+                        path: path.to_string_lossy().into_owned(),
+                    })
+                })
+                .await
+                .map_err(|e| CapabilityError::Handler(e.to_string()))?
+            }
+        },
+    )
+}
+
 #[cfg(test)]
 mod capability_tests {
     use super::*;
@@ -468,6 +533,70 @@ users:
             .await
             .unwrap_err();
         assert!(format!("{err:?}").contains("unknown context"));
+    }
+
+    use std::collections::HashMap;
+
+    /// A fake blocking HTTP: URL -> bytes. Clone/Send/Sync so it satisfies the
+    /// capability's `fetch` bound.
+    fn net(entries: Vec<(String, Vec<u8>)>) -> impl Fn(&str) -> Result<Vec<u8>, InstallError> + Clone {
+        let map: HashMap<String, Vec<u8>> = entries.into_iter().collect();
+        move |url: &str| {
+            map.get(url).cloned().ok_or_else(|| InstallError::Download(format!("404 {url}")))
+        }
+    }
+
+    fn sha256_hex(bytes: &[u8]) -> String {
+        use sha2::{Digest, Sha256};
+        hex::encode(Sha256::digest(bytes))
+    }
+
+    #[tokio::test]
+    async fn install_kubectl_resolves_stable_downloads_and_verifies() {
+        let dir = tempfile::tempdir().unwrap();
+        let install_dir = dir.path().join("bin");
+        let platform = Platform::current().unwrap();
+        let plan = kubectl_install("v9.9.9", &platform, &install_dir);
+        let payload = b"#!/bin/sh\necho kubectl\n";
+        let fetch = net(vec![
+            (KUBECTL_STABLE_URL.to_string(), b"v9.9.9\n".to_vec()),
+            (plan.sha256_url.clone(), sha256_hex(payload).into_bytes()),
+            (plan.binary_url.clone(), payload.to_vec()),
+        ]);
+
+        let mut reg = Registry::new();
+        reg.register(install_kubectl_capability(install_dir, fetch));
+        let out = reg.invoke("toolbox.installKubectl", json!({})).await.unwrap();
+
+        assert_eq!(out["tool"], "kubectl");
+        assert_eq!(out["version"], "v9.9.9");
+        let installed = out["path"].as_str().unwrap();
+        assert_eq!(std::fs::read(installed).unwrap(), payload);
+    }
+
+    #[tokio::test]
+    async fn install_kubectl_is_confirm_gated() {
+        let cap = install_kubectl_capability(PathBuf::from("/tmp/x"), net(vec![]));
+        assert!(cap.annotations.requires_confirm, "installs must require consent");
+        assert!(!cap.annotations.read_only);
+    }
+
+    #[tokio::test]
+    async fn install_kubectl_surfaces_a_checksum_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let install_dir = dir.path().join("bin");
+        let platform = Platform::current().unwrap();
+        let plan = kubectl_install("v9.9.9", &platform, &install_dir);
+        let fetch = net(vec![
+            (KUBECTL_STABLE_URL.to_string(), b"v9.9.9".to_vec()),
+            (plan.sha256_url.clone(), sha256_hex(b"expected").into_bytes()),
+            (plan.binary_url.clone(), b"tampered".to_vec()),
+        ]);
+        let mut reg = Registry::new();
+        reg.register(install_kubectl_capability(install_dir.clone(), fetch));
+        let err = reg.invoke("toolbox.installKubectl", json!({})).await.unwrap_err();
+        assert!(format!("{err:?}").to_lowercase().contains("checksum"));
+        assert!(!plan.target.exists());
     }
 }
 

--- a/crates/kube/src/toolbox.rs
+++ b/crates/kube/src/toolbox.rs
@@ -389,7 +389,8 @@ pub fn diagnose_context_capability(
 }
 
 use crate::toolbox_install::{
-    install_binary, kubectl_install, InstallError, Platform, KUBECTL_STABLE_URL,
+    helm_install, install_binary, install_from_targz, kubectl_install, parse_github_latest_tag,
+    InstallError, Platform, HELM_LATEST_RELEASE_URL, KUBECTL_STABLE_URL,
 };
 
 /// The directory srelens installs managed tools into: `~/.srelens/bin`.
@@ -442,6 +443,44 @@ where
                     let path = install_binary(&plan, &fetch).map_err(to_handler)?;
                     Ok(InstallToolOut {
                         tool: "kubectl".to_string(),
+                        version,
+                        path: path.to_string_lossy().into_owned(),
+                    })
+                })
+                .await
+                .map_err(|e| CapabilityError::Handler(e.to_string()))?
+            }
+        },
+    )
+}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+pub struct InstallHelmIn {}
+
+/// Confirm-gated capability: download the latest helm release into
+/// `~/.srelens/bin`, verified against helm's published checksum. Version is
+/// resolved from GitHub's latest-release API (helm has no `stable.txt`).
+pub fn install_helm_capability<F>(install_dir: PathBuf, fetch: F) -> Capability
+where
+    F: Fn(&str) -> Result<Vec<u8>, InstallError> + Send + Sync + Clone + 'static,
+{
+    Capability::typed::<InstallHelmIn, InstallToolOut, _, _>(
+        "toolbox.installHelm",
+        "download the latest helm release into ~/.srelens/bin, verified against \
+         its published checksum",
+        Annotations::MUTATING,
+        move |_input: InstallHelmIn| {
+            let install_dir = install_dir.clone();
+            let fetch = fetch.clone();
+            async move {
+                tokio::task::spawn_blocking(move || {
+                    let platform = Platform::current().map_err(to_handler)?;
+                    let body = fetch(HELM_LATEST_RELEASE_URL).map_err(to_handler)?;
+                    let version = parse_github_latest_tag(&body).map_err(to_handler)?;
+                    let plan = helm_install(&version, &platform, &install_dir);
+                    let path = install_from_targz(&plan, &fetch).map_err(to_handler)?;
+                    Ok(InstallToolOut {
+                        tool: "helm".to_string(),
                         version,
                         path: path.to_string_lossy().into_owned(),
                     })
@@ -579,6 +618,48 @@ users:
         let cap = install_kubectl_capability(PathBuf::from("/tmp/x"), net(vec![]));
         assert!(cap.annotations.requires_confirm, "installs must require consent");
         assert!(!cap.annotations.read_only);
+    }
+
+    fn make_targz(members: &[(&str, &[u8])]) -> Vec<u8> {
+        use flate2::{write::GzEncoder, Compression};
+        let mut builder = tar::Builder::new(GzEncoder::new(Vec::new(), Compression::fast()));
+        for (name, bytes) in members {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(bytes.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder.append_data(&mut header, name, *bytes).unwrap();
+        }
+        builder.into_inner().unwrap().finish().unwrap()
+    }
+
+    #[tokio::test]
+    async fn install_helm_resolves_latest_downloads_and_extracts() {
+        let dir = tempfile::tempdir().unwrap();
+        let install_dir = dir.path().join("bin");
+        let platform = Platform::current().unwrap();
+        let plan = helm_install("v9.9.9", &platform, &install_dir);
+        let payload = b"#!/bin/sh\necho helm\n";
+        let archive = make_targz(&[(plan.member.as_str(), payload)]);
+        let fetch = net(vec![
+            (HELM_LATEST_RELEASE_URL.to_string(), br#"{"tag_name":"v9.9.9"}"#.to_vec()),
+            (plan.sha256_url.clone(), sha256_hex(&archive).into_bytes()),
+            (plan.archive_url.clone(), archive),
+        ]);
+
+        let mut reg = Registry::new();
+        reg.register(install_helm_capability(install_dir, fetch));
+        let out = reg.invoke("toolbox.installHelm", json!({})).await.unwrap();
+
+        assert_eq!(out["tool"], "helm");
+        assert_eq!(out["version"], "v9.9.9");
+        assert_eq!(std::fs::read(out["path"].as_str().unwrap()).unwrap(), payload);
+    }
+
+    #[tokio::test]
+    async fn install_helm_is_confirm_gated() {
+        let cap = install_helm_capability(PathBuf::from("/tmp/x"), net(vec![]));
+        assert!(cap.annotations.requires_confirm);
     }
 
     #[tokio::test]

--- a/crates/kube/src/toolbox_install.rs
+++ b/crates/kube/src/toolbox_install.rs
@@ -162,6 +162,22 @@ pub struct ArchiveInstall {
     pub target: PathBuf,
 }
 
+/// GitHub API endpoint for helm's latest release (helm has no `stable.txt`).
+pub const HELM_LATEST_RELEASE_URL: &str =
+    "https://api.github.com/repos/helm/helm/releases/latest";
+
+/// Pull the `tag_name` (e.g. `v3.16.2`) out of a GitHub "latest release" JSON body.
+pub fn parse_github_latest_tag(body: &[u8]) -> Result<String, InstallError> {
+    let value: serde_json::Value =
+        serde_json::from_slice(body).map_err(|e| InstallError::Download(e.to_string()))?;
+    value
+        .get("tag_name")
+        .and_then(serde_json::Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| InstallError::Download("no tag_name in GitHub release response".to_string()))
+}
+
 /// Plan a helm install for `version` (a `vX.Y.Z` tag) into `install_dir`.
 pub fn helm_install(version: &str, platform: &Platform, install_dir: &Path) -> ArchiveInstall {
     let ext = if platform.os == "windows" { ".exe" } else { "" };
@@ -369,6 +385,23 @@ mod tests {
         let plan = kubectl_install("v1.30.2", &Platform { os: "linux", arch: "amd64" }, dir.path());
         let fetch = net(&[]); // nothing resolves
         assert!(matches!(install_binary(&plan, &fetch), Err(InstallError::Download(_))));
+    }
+
+    #[test]
+    fn github_latest_tag_is_parsed_and_bad_bodies_rejected() {
+        assert_eq!(
+            parse_github_latest_tag(br#"{"tag_name":"v3.16.2","name":"Helm"}"#).unwrap(),
+            "v3.16.2"
+        );
+        assert!(matches!(
+            parse_github_latest_tag(br#"{"name":"no tag here"}"#),
+            Err(InstallError::Download(_))
+        ));
+        assert!(matches!(
+            parse_github_latest_tag(br#"{"tag_name":""}"#),
+            Err(InstallError::Download(_))
+        ));
+        assert!(matches!(parse_github_latest_tag(b"not json"), Err(InstallError::Download(_))));
     }
 
     #[test]


### PR DESCRIPTION
Slice 5 of #55, on `dev` (the install-core stack #118/#119 has merged). First capability of the Toolbox — it makes the now-complete pure diagnosis engine (#116 extraction + #117 resolution) usable end-to-end.

## What this does

`toolbox.diagnoseContext { context }` → a per-tool status report for that context's exec-auth requirements. The handler:

1. Merges the loaded kubeconfigs via the existing `load_kubeconfigs` (correct cross-file context↔user resolution), serializes back to YAML, and parses requirements.
2. Finds the named context (unknown → `InvalidInput`).
3. Resolves each requirement against the app PATH + managed dirs, returning a flattened DTO: `binary`, `kind` (kubectl / krew-plugin / external), `plugin`, `installable`, `status` (found / not-on-app-path / missing), `path`, `version`.

`SearchPaths::from_env` prepends `~/.srelens/bin` and `~/.krew/bin` to the app's PATH (already `fix-path-env`-resolved). This one `DiagnosisReport` is what spec §3 wires into the health UI, the error deep-link, and MCP ("why can't context X connect?").

## Design

- **Deterministic tests.** The resolution environment (search paths + filesystem check) is injected into the builder, so capability tests don't depend on what's installed on the test machine. Production supplies `from_env()` + a real `is_file`.
- **kubectl version deferred.** Probing it is a subprocess that belongs with the install capabilities; the DTO field exists but is `None` for now.
- **Auto-exposed over MCP** — `every_capability_is_mcp_exposed` passes with no extra wiring.

## Testing

TDD (verified the tests bite by breaking the status mapping → RED, then restored): 2 capability tests over a temp kubeconfig + injected search paths (found kubectl + missing plugin; unknown context → error). Full `srelens-kube` suite 221 green, app suite 18 green (incl. MCP completeness), clippy clean.

## Next

The install capabilities (`toolbox.installKubectl` / `installHelm`, `requires_confirm`) with the concrete HTTP client wiring `install_binary`/`install_from_targz`, then the streaming `start_tool_install` command, krew bootstrap, and the Toolbox page.