### PR TITLE
feat(toolbox): toolbox.installKubectl capability (slice 6)

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -29,6 +29,8 @@ srelens-capability = { path = "../../../crates/capability" }
 srelens-mcp = { path = "../../../crates/mcp" }
 srelens-kube = { path = "../../../crates/kube" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std", "io-util", "macros"] }
+# Blocking HTTP for Toolbox tool downloads (run inside spawn_blocking).
+reqwest = { version = "0.13", default-features = false, features = ["blocking", "default-tls"] }
 # Local pseudo-terminal for the in-app kubectl shell (spawns the user's login shell).
 portable-pty = "0.8"
 

--- a/apps/desktop/src-tauri/src/capabilities.rs
+++ b/apps/desktop/src-tauri/src/capabilities.rs
@@ -33,6 +33,24 @@ pub fn default_kubeconfig_path() -> PathBuf {
         .unwrap_or_default()
 }
 
+/// Blocking HTTP GET for Toolbox tool downloads. Called only from inside
+/// `spawn_blocking` (the install capabilities), so blocking here is fine. A
+/// non-2xx or transport error maps to the retryable `Download` variant.
+fn http_get(url: &str) -> Result<Vec<u8>, srelens_kube::toolbox_install::InstallError> {
+    use srelens_kube::toolbox_install::InstallError;
+    let resp = reqwest::blocking::Client::builder()
+        .user_agent(concat!("srelens/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .and_then(|client| client.get(url).send())
+        .map_err(|e| InstallError::Download(e.to_string()))?;
+    if !resp.status().is_success() {
+        return Err(InstallError::Download(format!("{} for {url}", resp.status())));
+    }
+    resp.bytes()
+        .map(|b| b.to_vec())
+        .map_err(|e| InstallError::Download(e.to_string()))
+}
+
 /// Build the registry with a freshly-created client cache. Used by the MCP
 /// stdio binary, which doesn't need to share the cache with watch tasks.
 pub fn build_registry() -> Registry {
@@ -62,6 +80,10 @@ pub fn build_registry_with(cache: Arc<ClientCache>) -> Registry {
         default_kubeconfig_paths(),
         srelens_kube::toolbox::SearchPaths::from_env(),
         |path| path.is_file(),
+    ));
+    reg.register(srelens_kube::toolbox::install_kubectl_capability(
+        srelens_kube::toolbox::srelens_bin_dir(),
+        http_get,
     ));
 
     reg.register(srelens_kube::connect::cluster_info_capability(

--- a/apps/desktop/src-tauri/tests/e2e.rs
+++ b/apps/desktop/src-tauri/tests/e2e.rs
@@ -147,10 +147,13 @@ impl Harness {
 }
 
 /// Capabilities genuinely excluded from this suite, with a written reason.
-/// Kept empty: every one of the 69 registered capabilities as of #27 is
-/// exercised below. A capability registered later with no case here fails
-/// the coverage assertion at the end of `full_capability_suite`.
-const EXCLUDED: &[(&str, &str)] = &[];
+/// A capability registered later with no case here fails the coverage
+/// assertion at the end of `full_capability_suite`.
+const EXCLUDED: &[(&str, &str)] = &[(
+    "toolbox.installKubectl",
+    "downloads a real ~50MB binary from dl.k8s.io and writes to ~/.srelens/bin; \
+     covered by unit tests with an injected fetch instead of hitting the network in CI",
+)];
 
 fn deadline(secs: u64) -> Instant {
     Instant::now() + Duration::from_secs(secs)

--- a/crates/capability/src/annotations.rs
+++ b/crates/capability/src/annotations.rs
@@ -13,6 +13,10 @@ impl Annotations {
         Self { read_only: true, destructive: false, requires_confirm: false, sensitive: false };
     pub const DESTRUCTIVE: Self =
         Self { read_only: false, destructive: true, requires_confirm: true, sensitive: false };
+    /// A change that isn't destructive but still needs user consent (e.g.
+    /// installing a tool): confirm-gated, not flagged destructive.
+    pub const MUTATING: Self =
+        Self { read_only: false, destructive: false, requires_confirm: true, sensitive: false };
     /// A read that returns sensitive material — gateable by consent policy.
     pub const SENSITIVE_READ: Self =
         Self { read_only: true, destructive: false, requires_confirm: false, sensitive: true };

--- a/crates/kube/src/toolbox.rs
+++ b/crates/kube/src/toolbox.rs
@@ -388,6 +388,71 @@ pub fn diagnose_context_capability(
     )
 }
 
+use crate::toolbox_install::{
+    install_binary, kubectl_install, InstallError, Platform, KUBECTL_STABLE_URL,
+};
+
+/// The directory srelens installs managed tools into: `~/.srelens/bin`.
+pub fn srelens_bin_dir() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_default();
+    PathBuf::from(home).join(".srelens").join("bin")
+}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+pub struct InstallKubectlIn {}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct InstallToolOut {
+    pub tool: String,
+    pub version: String,
+    pub path: String,
+}
+
+fn to_handler(e: InstallError) -> CapabilityError {
+    CapabilityError::Handler(e.to_string())
+}
+
+/// Confirm-gated capability: download the latest stable kubectl into
+/// `~/.srelens/bin`, verified against dl.k8s.io's published checksum. `fetch`
+/// (a blocking HTTP GET) is injected so the capability is testable without a
+/// real network; production supplies a reqwest-backed one at registration.
+pub fn install_kubectl_capability<F>(install_dir: PathBuf, fetch: F) -> Capability
+where
+    F: Fn(&str) -> Result<Vec<u8>, InstallError> + Send + Sync + Clone + 'static,
+{
+    Capability::typed::<InstallKubectlIn, InstallToolOut, _, _>(
+        "toolbox.installKubectl",
+        "download the latest stable kubectl into ~/.srelens/bin, verified against \
+         the dl.k8s.io checksum",
+        Annotations::MUTATING,
+        move |_input: InstallKubectlIn| {
+            let install_dir = install_dir.clone();
+            let fetch = fetch.clone();
+            async move {
+                // The install does blocking HTTP + filesystem work; keep it off
+                // the async runtime.
+                tokio::task::spawn_blocking(move || {
+                    let platform = Platform::current().map_err(to_handler)?;
+                    let raw = fetch(KUBECTL_STABLE_URL).map_err(to_handler)?;
+                    let version = std::str::from_utf8(&raw)
+                        .map_err(|e| CapabilityError::Handler(e.to_string()))?
+                        .trim()
+                        .to_string();
+                    let plan = kubectl_install(&version, &platform, &install_dir);
+                    let path = install_binary(&plan, &fetch).map_err(to_handler)?;
+                    Ok(InstallToolOut {
+                        tool: "kubectl".to_string(),
+                        version,
+                        path: path.to_string_lossy().into_owned(),
+                    })
+                })
+                .await
+                .map_err(|e| CapabilityError::Handler(e.to_string()))?
+            }
+        },
+    )
+}
+
 #[cfg(test)]
 mod capability_tests {
     use super::*;
@@ -468,6 +533,70 @@ users:
             .await
             .unwrap_err();
         assert!(format!("{err:?}").contains("unknown context"));
+    }
+
+    use std::collections::HashMap;
+
+    /// A fake blocking HTTP: URL -> bytes. Clone/Send/Sync so it satisfies the
+    /// capability's `fetch` bound.
+    fn net(entries: Vec<(String, Vec<u8>)>) -> impl Fn(&str) -> Result<Vec<u8>, InstallError> + Clone {
+        let map: HashMap<String, Vec<u8>> = entries.into_iter().collect();
+        move |url: &str| {
+            map.get(url).cloned().ok_or_else(|| InstallError::Download(format!("404 {url}")))
+        }
+    }
+
+    fn sha256_hex(bytes: &[u8]) -> String {
+        use sha2::{Digest, Sha256};
+        hex::encode(Sha256::digest(bytes))
+    }
+
+    #[tokio::test]
+    async fn install_kubectl_resolves_stable_downloads_and_verifies() {
+        let dir = tempfile::tempdir().unwrap();
+        let install_dir = dir.path().join("bin");
+        let platform = Platform::current().unwrap();
+        let plan = kubectl_install("v9.9.9", &platform, &install_dir);
+        let payload = b"#!/bin/sh\necho kubectl\n";
+        let fetch = net(vec![
+            (KUBECTL_STABLE_URL.to_string(), b"v9.9.9\n".to_vec()),
+            (plan.sha256_url.clone(), sha256_hex(payload).into_bytes()),
+            (plan.binary_url.clone(), payload.to_vec()),
+        ]);
+
+        let mut reg = Registry::new();
+        reg.register(install_kubectl_capability(install_dir, fetch));
+        let out = reg.invoke("toolbox.installKubectl", json!({})).await.unwrap();
+
+        assert_eq!(out["tool"], "kubectl");
+        assert_eq!(out["version"], "v9.9.9");
+        let installed = out["path"].as_str().unwrap();
+        assert_eq!(std::fs::read(installed).unwrap(), payload);
+    }
+
+    #[tokio::test]
+    async fn install_kubectl_is_confirm_gated() {
+        let cap = install_kubectl_capability(PathBuf::from("/tmp/x"), net(vec![]));
+        assert!(cap.annotations.requires_confirm, "installs must require consent");
+        assert!(!cap.annotations.read_only);
+    }
+
+    #[tokio::test]
+    async fn install_kubectl_surfaces_a_checksum_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let install_dir = dir.path().join("bin");
+        let platform = Platform::current().unwrap();
+        let plan = kubectl_install("v9.9.9", &platform, &install_dir);
+        let fetch = net(vec![
+            (KUBECTL_STABLE_URL.to_string(), b"v9.9.9".to_vec()),
+            (plan.sha256_url.clone(), sha256_hex(b"expected").into_bytes()),
+            (plan.binary_url.clone(), b"tampered".to_vec()),
+        ]);
+        let mut reg = Registry::new();
+        reg.register(install_kubectl_capability(install_dir.clone(), fetch));
+        let err = reg.invoke("toolbox.installKubectl", json!({})).await.unwrap_err();
+        assert!(format!("{err:?}").to_lowercase().contains("checksum"));
+        assert!(!plan.target.exists());
     }
 }
 


### PR DESCRIPTION
Slice 6 of #55. **Stacked on #120** (base `feat/toolbox-diagnose-capability`) — review/merge #120 first; GitHub retargets this to `dev` once #120 lands.

First install capability — wires the install core (#118) to a real download.

## What this does

`toolbox.installKubectl` resolves the latest stable version from dl.k8s.io's `stable.txt`, downloads kubectl into `~/.srelens/bin`, and verifies it against the published checksum before it lands (temp-then-rename from #118).

- **Confirm-gated:** new `Annotations::MUTATING` (`requires_confirm`, not `destructive`), so both the MCP `_confirm` gate and the UI confirm dialog apply. Installing is a change that needs consent but isn't destructive.
- **HTTP-free kube crate:** the blocking GET is an injected `fetch` closure; the app crate supplies a `reqwest::blocking`-backed one at registration. The download+verify runs inside `spawn_blocking` so it never blocks the async runtime.

## Testing

- TDD, unit-tested with a fake network: success (resolves stable → downloads → verifies → installs), checksum mismatch surfaces and installs nothing, and confirm-gating (RED-checked by flipping the annotation to READ_ONLY).
- **Excluded from the kind e2e suite** with a written reason: it downloads a real ~50MB binary and writes to disk, so it's covered by injected-fetch unit tests rather than run against the network in CI (real-install integration lands later with a small krew plugin per spec §7).
- kube 224 green, app 18 green (incl. MCP completeness), capability 7 green, clippy clean.

## Notes

- reqwest 0.13 renamed its TLS features; used `default-tls` (native-tls) since `libssl-dev` is already a declared Linux build dep, avoiding the rustls-no-provider crypto-provider dance.

## Next

`toolbox.installHelm` (needs GitHub-latest version resolution) + krew bootstrap, `toolbox.status` / `searchPlugins`, the streaming `start_tool_install` command, then the Toolbox page.