### PR TITLE
feat(toolbox): toolbox.installHelm capability (slice 7)

### DIFF
--- a/apps/desktop/src-tauri/src/capabilities.rs
+++ b/apps/desktop/src-tauri/src/capabilities.rs
@@ -85,6 +85,10 @@ pub fn build_registry_with(cache: Arc<ClientCache>) -> Registry {
         srelens_kube::toolbox::srelens_bin_dir(),
         http_get,
     ));
+    reg.register(srelens_kube::toolbox::install_helm_capability(
+        srelens_kube::toolbox::srelens_bin_dir(),
+        http_get,
+    ));
 
     reg.register(srelens_kube::connect::cluster_info_capability(
         cache.clone(),

--- a/apps/desktop/src-tauri/tests/e2e.rs
+++ b/apps/desktop/src-tauri/tests/e2e.rs
@@ -149,11 +149,18 @@ impl Harness {
 /// Capabilities genuinely excluded from this suite, with a written reason.
 /// A capability registered later with no case here fails the coverage
 /// assertion at the end of `full_capability_suite`.
-const EXCLUDED: &[(&str, &str)] = &[(
-    "toolbox.installKubectl",
-    "downloads a real ~50MB binary from dl.k8s.io and writes to ~/.srelens/bin; \
-     covered by unit tests with an injected fetch instead of hitting the network in CI",
-)];
+const EXCLUDED: &[(&str, &str)] = &[
+    (
+        "toolbox.installKubectl",
+        "downloads a real ~50MB binary from dl.k8s.io and writes to ~/.srelens/bin; \
+         covered by unit tests with an injected fetch instead of hitting the network in CI",
+    ),
+    (
+        "toolbox.installHelm",
+        "downloads a real release tarball from get.helm.sh and writes to ~/.srelens/bin; \
+         covered by unit tests with an injected fetch instead of hitting the network in CI",
+    ),
+];
 
 fn deadline(secs: u64) -> Instant {
     Instant::now() + Duration::from_secs(secs)

--- a/crates/kube/src/toolbox.rs
+++ b/crates/kube/src/toolbox.rs
@@ -389,7 +389,8 @@ pub fn diagnose_context_capability(
 }
 
 use crate::toolbox_install::{
-    install_binary, kubectl_install, InstallError, Platform, KUBECTL_STABLE_URL,
+    helm_install, install_binary, install_from_targz, kubectl_install, parse_github_latest_tag,
+    InstallError, Platform, HELM_LATEST_RELEASE_URL, KUBECTL_STABLE_URL,
 };
 
 /// The directory srelens installs managed tools into: `~/.srelens/bin`.
@@ -442,6 +443,44 @@ where
                     let path = install_binary(&plan, &fetch).map_err(to_handler)?;
                     Ok(InstallToolOut {
                         tool: "kubectl".to_string(),
+                        version,
+                        path: path.to_string_lossy().into_owned(),
+                    })
+                })
+                .await
+                .map_err(|e| CapabilityError::Handler(e.to_string()))?
+            }
+        },
+    )
+}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+pub struct InstallHelmIn {}
+
+/// Confirm-gated capability: download the latest helm release into
+/// `~/.srelens/bin`, verified against helm's published checksum. Version is
+/// resolved from GitHub's latest-release API (helm has no `stable.txt`).
+pub fn install_helm_capability<F>(install_dir: PathBuf, fetch: F) -> Capability
+where
+    F: Fn(&str) -> Result<Vec<u8>, InstallError> + Send + Sync + Clone + 'static,
+{
+    Capability::typed::<InstallHelmIn, InstallToolOut, _, _>(
+        "toolbox.installHelm",
+        "download the latest helm release into ~/.srelens/bin, verified against \
+         its published checksum",
+        Annotations::MUTATING,
+        move |_input: InstallHelmIn| {
+            let install_dir = install_dir.clone();
+            let fetch = fetch.clone();
+            async move {
+                tokio::task::spawn_blocking(move || {
+                    let platform = Platform::current().map_err(to_handler)?;
+                    let body = fetch(HELM_LATEST_RELEASE_URL).map_err(to_handler)?;
+                    let version = parse_github_latest_tag(&body).map_err(to_handler)?;
+                    let plan = helm_install(&version, &platform, &install_dir);
+                    let path = install_from_targz(&plan, &fetch).map_err(to_handler)?;
+                    Ok(InstallToolOut {
+                        tool: "helm".to_string(),
                         version,
                         path: path.to_string_lossy().into_owned(),
                     })
@@ -579,6 +618,48 @@ users:
         let cap = install_kubectl_capability(PathBuf::from("/tmp/x"), net(vec![]));
         assert!(cap.annotations.requires_confirm, "installs must require consent");
         assert!(!cap.annotations.read_only);
+    }
+
+    fn make_targz(members: &[(&str, &[u8])]) -> Vec<u8> {
+        use flate2::{write::GzEncoder, Compression};
+        let mut builder = tar::Builder::new(GzEncoder::new(Vec::new(), Compression::fast()));
+        for (name, bytes) in members {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(bytes.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder.append_data(&mut header, name, *bytes).unwrap();
+        }
+        builder.into_inner().unwrap().finish().unwrap()
+    }
+
+    #[tokio::test]
+    async fn install_helm_resolves_latest_downloads_and_extracts() {
+        let dir = tempfile::tempdir().unwrap();
+        let install_dir = dir.path().join("bin");
+        let platform = Platform::current().unwrap();
+        let plan = helm_install("v9.9.9", &platform, &install_dir);
+        let payload = b"#!/bin/sh\necho helm\n";
+        let archive = make_targz(&[(plan.member.as_str(), payload)]);
+        let fetch = net(vec![
+            (HELM_LATEST_RELEASE_URL.to_string(), br#"{"tag_name":"v9.9.9"}"#.to_vec()),
+            (plan.sha256_url.clone(), sha256_hex(&archive).into_bytes()),
+            (plan.archive_url.clone(), archive),
+        ]);
+
+        let mut reg = Registry::new();
+        reg.register(install_helm_capability(install_dir, fetch));
+        let out = reg.invoke("toolbox.installHelm", json!({})).await.unwrap();
+
+        assert_eq!(out["tool"], "helm");
+        assert_eq!(out["version"], "v9.9.9");
+        assert_eq!(std::fs::read(out["path"].as_str().unwrap()).unwrap(), payload);
+    }
+
+    #[tokio::test]
+    async fn install_helm_is_confirm_gated() {
+        let cap = install_helm_capability(PathBuf::from("/tmp/x"), net(vec![]));
+        assert!(cap.annotations.requires_confirm);
     }
 
     #[tokio::test]

--- a/crates/kube/src/toolbox_install.rs
+++ b/crates/kube/src/toolbox_install.rs
@@ -162,6 +162,22 @@ pub struct ArchiveInstall {
     pub target: PathBuf,
 }
 
+/// GitHub API endpoint for helm's latest release (helm has no `stable.txt`).
+pub const HELM_LATEST_RELEASE_URL: &str =
+    "https://api.github.com/repos/helm/helm/releases/latest";
+
+/// Pull the `tag_name` (e.g. `v3.16.2`) out of a GitHub "latest release" JSON body.
+pub fn parse_github_latest_tag(body: &[u8]) -> Result<String, InstallError> {
+    let value: serde_json::Value =
+        serde_json::from_slice(body).map_err(|e| InstallError::Download(e.to_string()))?;
+    value
+        .get("tag_name")
+        .and_then(serde_json::Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| InstallError::Download("no tag_name in GitHub release response".to_string()))
+}
+
 /// Plan a helm install for `version` (a `vX.Y.Z` tag) into `install_dir`.
 pub fn helm_install(version: &str, platform: &Platform, install_dir: &Path) -> ArchiveInstall {
     let ext = if platform.os == "windows" { ".exe" } else { "" };
@@ -369,6 +385,23 @@ mod tests {
         let plan = kubectl_install("v1.30.2", &Platform { os: "linux", arch: "amd64" }, dir.path());
         let fetch = net(&[]); // nothing resolves
         assert!(matches!(install_binary(&plan, &fetch), Err(InstallError::Download(_))));
+    }
+
+    #[test]
+    fn github_latest_tag_is_parsed_and_bad_bodies_rejected() {
+        assert_eq!(
+            parse_github_latest_tag(br#"{"tag_name":"v3.16.2","name":"Helm"}"#).unwrap(),
+            "v3.16.2"
+        );
+        assert!(matches!(
+            parse_github_latest_tag(br#"{"name":"no tag here"}"#),
+            Err(InstallError::Download(_))
+        ));
+        assert!(matches!(
+            parse_github_latest_tag(br#"{"tag_name":""}"#),
+            Err(InstallError::Download(_))
+        ));
+        assert!(matches!(parse_github_latest_tag(b"not json"), Err(InstallError::Download(_))));
     }
 
     #[test]


### PR DESCRIPTION
Slice 7 of #55. **Stacked on #120** (base `feat/toolbox-diagnose-capability`, which now also contains #121). Merges after that chain; GitHub retargets to `dev`.

Adds `toolbox.installHelm`, parallel to `toolbox.installKubectl` (#121), reusing the tarball install core (#119).

## What's new

The only genuinely new piece vs. installKubectl is **version resolution**: helm has no `stable.txt`, so `parse_github_latest_tag` pulls `tag_name` from GitHub's latest-release API. The handler then downloads the release tarball from get.helm.sh, verifies it against helm's published checksum, and extracts the `helm` binary into `~/.srelens/bin`. Confirm-gated (`Annotations::MUTATING`).

Everything else mirrors installKubectl: injected blocking `fetch` (kube crate stays HTTP-free), `reqwest` at the app layer, install runs in `spawn_blocking`.

## Testing

- TDD, unit-tested with a fake network: `parse_github_latest_tag` (valid / missing / empty / non-JSON), and the full capability (resolves latest → downloads → verifies → extracts, plus confirm-gating).
- Grounded against the live services: confirmed GitHub's `tag_name` field and the get.helm.sh tarball naming.
- **Excluded from the kind e2e suite** with a reason (real network download), same as installKubectl.
- 34 toolbox tests green, app MCP completeness green, clippy clean.

## Next

krew bootstrap (`installKrew` + `krew install krew` subprocess), the read-only `toolbox.status` / `searchPlugins`, the streaming `start_tool_install` command, then the Toolbox page.