### PR TITLE
feat(toolbox): toolbox.status tool inventory capability (slice 8)

### DIFF
--- a/apps/desktop/src-tauri/src/capabilities.rs
+++ b/apps/desktop/src-tauri/src/capabilities.rs
@@ -51,6 +51,42 @@ fn http_get(url: &str) -> Result<Vec<u8>, srelens_kube::toolbox_install::Install
         .map_err(|e| InstallError::Download(e.to_string()))
 }
 
+/// Run a managed tool with args, mapping a non-zero exit (with stderr) to a
+/// retryable error. Used for krew's self-bootstrap; called inside spawn_blocking.
+fn run_tool(
+    bin: &std::path::Path,
+    args: &[&str],
+) -> Result<(), srelens_kube::toolbox_install::InstallError> {
+    use srelens_kube::toolbox_install::InstallError;
+    let output = std::process::Command::new(bin)
+        .args(args)
+        .output()
+        .map_err(|e| InstallError::Download(e.to_string()))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(InstallError::Download(String::from_utf8_lossy(&output.stderr).into_owned()))
+    }
+}
+
+/// Run `kubectl-krew` with args, returning stdout (or stderr as an error).
+/// Prefers the krew shim under `~/.krew/bin`, falling back to PATH. Called
+/// inside spawn_blocking by the plugin capabilities.
+fn run_krew(args: &[&str]) -> Result<String, srelens_kube::toolbox_install::InstallError> {
+    use srelens_kube::toolbox_install::InstallError;
+    let shim = srelens_kube::toolbox::krew_bin_dir().join("kubectl-krew");
+    let bin = if shim.is_file() { shim } else { std::path::PathBuf::from("kubectl-krew") };
+    let output = std::process::Command::new(bin)
+        .args(args)
+        .output()
+        .map_err(|e| InstallError::Download(e.to_string()))?;
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    } else {
+        Err(InstallError::Download(String::from_utf8_lossy(&output.stderr).into_owned()))
+    }
+}
+
 /// Probe a managed tool's version by running it and scanning for a semver.
 /// Each tool prints its version differently, so we pass tool-specific flags and
 /// let `first_semver` pull the `vX.Y.Z` out of whatever text comes back.
@@ -103,6 +139,11 @@ pub fn build_registry_with(cache: Arc<ClientCache>) -> Registry {
         srelens_kube::toolbox::srelens_bin_dir(),
         http_get,
     ));
+    reg.register(srelens_kube::toolbox::install_krew_capability(
+        std::env::temp_dir(),
+        http_get,
+        run_tool,
+    ));
     reg.register(srelens_kube::toolbox::status_capability(
         srelens_kube::toolbox::SearchPaths::from_env(),
         vec![
@@ -112,6 +153,10 @@ pub fn build_registry_with(cache: Arc<ClientCache>) -> Registry {
         |path| path.is_file(),
         tool_version,
     ));
+    reg.register(srelens_kube::toolbox::search_plugins_capability(run_krew));
+    reg.register(srelens_kube::toolbox::install_plugin_capability(run_krew));
+    reg.register(srelens_kube::toolbox::upgrade_plugin_capability(run_krew));
+    reg.register(srelens_kube::toolbox::remove_plugin_capability(run_krew));
 
     reg.register(srelens_kube::connect::cluster_info_capability(
         cache.clone(),

--- a/apps/desktop/src-tauri/src/capabilities.rs
+++ b/apps/desktop/src-tauri/src/capabilities.rs
@@ -51,6 +51,20 @@ fn http_get(url: &str) -> Result<Vec<u8>, srelens_kube::toolbox_install::Install
         .map_err(|e| InstallError::Download(e.to_string()))
 }
 
+/// Probe a managed tool's version by running it and scanning for a semver.
+/// Each tool prints its version differently, so we pass tool-specific flags and
+/// let `first_semver` pull the `vX.Y.Z` out of whatever text comes back.
+fn tool_version(name: &str, path: &std::path::Path) -> Option<String> {
+    let args: &[&str] = match name {
+        "kubectl" => &["version", "--client", "-o", "json"],
+        "helm" => &["version", "--short"],
+        _ => &["version"], // krew and any future tool
+    };
+    let output = std::process::Command::new(path).args(args).output().ok()?;
+    let text = String::from_utf8_lossy(&output.stdout);
+    srelens_kube::toolbox::first_semver(&text)
+}
+
 /// Build the registry with a freshly-created client cache. Used by the MCP
 /// stdio binary, which doesn't need to share the cache with watch tasks.
 pub fn build_registry() -> Registry {
@@ -88,6 +102,15 @@ pub fn build_registry_with(cache: Arc<ClientCache>) -> Registry {
     reg.register(srelens_kube::toolbox::install_helm_capability(
         srelens_kube::toolbox::srelens_bin_dir(),
         http_get,
+    ));
+    reg.register(srelens_kube::toolbox::status_capability(
+        srelens_kube::toolbox::SearchPaths::from_env(),
+        vec![
+            srelens_kube::toolbox::srelens_bin_dir(),
+            srelens_kube::toolbox::krew_bin_dir(),
+        ],
+        |path| path.is_file(),
+        tool_version,
     ));
 
     reg.register(srelens_kube::connect::cluster_info_capability(

--- a/apps/desktop/src-tauri/tests/e2e.rs
+++ b/apps/desktop/src-tauri/tests/e2e.rs
@@ -160,6 +160,18 @@ const EXCLUDED: &[(&str, &str)] = &[
         "downloads a real release tarball from get.helm.sh and writes to ~/.srelens/bin; \
          covered by unit tests with an injected fetch instead of hitting the network in CI",
     ),
+    (
+        "toolbox.installKrew",
+        "downloads krew from GitHub and runs its bootstrap subprocess to populate ~/.krew; \
+         covered by unit tests with an injected fetch and command runner instead of the network in CI",
+    ),
+    // The plugin ops shell out to kubectl-krew, which isn't installed in the kind
+    // CI image; unit-tested with an injected runner. Real krew + a small-plugin
+    // install is the integration test deferred to the kind-CI work in the spec.
+    ("toolbox.searchPlugins", "requires krew installed (not in the CI image); unit-tested with an injected runner"),
+    ("toolbox.installPlugin", "requires krew installed (not in the CI image); unit-tested with an injected runner"),
+    ("toolbox.upgradePlugin", "requires krew installed (not in the CI image); unit-tested with an injected runner"),
+    ("toolbox.removePlugin", "requires krew installed (not in the CI image); unit-tested with an injected runner"),
 ];
 
 fn deadline(secs: u64) -> Instant {

--- a/apps/desktop/src-tauri/tests/e2e.rs
+++ b/apps/desktop/src-tauri/tests/e2e.rs
@@ -651,6 +651,15 @@ async fn run_suite() {
         "kind context should need no exec-auth tools: {out}"
     );
 
+    // Tool inventory: kubectl and helm are on PATH in this suite (per the
+    // module docstring), so status must find kubectl installed with a version.
+    let out = h.ok("toolbox.status", json!({})).await;
+    let tools = out["tools"].as_array().unwrap();
+    assert_eq!(tools.len(), 3, "kubectl/krew/helm: {out}");
+    let kubectl = tools.iter().find(|t| t["name"] == "kubectl").unwrap();
+    assert_eq!(kubectl["installed"], true, "kubectl must be on PATH here: {out}");
+    assert!(kubectl["version"].as_str().is_some(), "kubectl version should resolve: {out}");
+
     let out = h.ok("k8s.clusterInfo", json!({ "context": ctx })).await;
     assert_eq!(out["reachable"], true, "cluster must be reachable: {out}");
     assert!(out["version"].as_str().is_some());

--- a/apps/desktop/src/lib/toolbox.test.ts
+++ b/apps/desktop/src/lib/toolbox.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  toolboxStatus,
+  diagnoseContext,
+  searchPlugins,
+  installKubectl,
+  installHelm,
+  installKrew,
+  installPlugin,
+  upgradePlugin,
+  removePlugin,
+} from "./toolbox";
+
+describe("toolbox lib wrappers", () => {
+  it("toolboxStatus unwraps the tools array", async () => {
+    const invoke = vi.fn().mockResolvedValue({ tools: [{ name: "kubectl", installed: true }] });
+    const r = await toolboxStatus(invoke);
+    expect(invoke).toHaveBeenCalledWith("toolbox.status", {});
+    expect(r.data).toEqual([{ name: "kubectl", installed: true }]);
+  });
+
+  it("diagnoseContext passes the context and returns the report", async () => {
+    const report = { context: "dev", items: [] };
+    const invoke = vi.fn().mockResolvedValue(report);
+    const r = await diagnoseContext("dev", invoke);
+    expect(invoke).toHaveBeenCalledWith("toolbox.diagnoseContext", { context: "dev" });
+    expect(r.data).toEqual(report);
+  });
+
+  it("searchPlugins passes the query and unwraps plugins", async () => {
+    const invoke = vi.fn().mockResolvedValue({ plugins: [{ name: "oidc-login", description: "", installed: false }] });
+    const r = await searchPlugins("oidc", invoke);
+    expect(invoke).toHaveBeenCalledWith("toolbox.searchPlugins", { query: "oidc" });
+    expect(r.data?.[0].name).toBe("oidc-login");
+  });
+
+  it.each([
+    ["installKubectl", installKubectl, "toolbox.installKubectl"],
+    ["installHelm", installHelm, "toolbox.installHelm"],
+    ["installKrew", installKrew, "toolbox.installKrew"],
+  ] as const)("%s invokes %s with no args", async (_name, fn, id) => {
+    const invoke = vi.fn().mockResolvedValue({ tool: "x", version: "v1", path: "/p" });
+    const r = await fn(invoke);
+    expect(invoke).toHaveBeenCalledWith(id, {});
+    expect(r.data?.version).toBe("v1");
+  });
+
+  it.each([
+    ["installPlugin", installPlugin, "toolbox.installPlugin"],
+    ["upgradePlugin", upgradePlugin, "toolbox.upgradePlugin"],
+    ["removePlugin", removePlugin, "toolbox.removePlugin"],
+  ] as const)("%s passes the plugin name to %s", async (_name, fn, id) => {
+    const invoke = vi.fn().mockResolvedValue({ plugin: "oidc-login", output: "ok" });
+    const r = await fn("oidc-login", invoke);
+    expect(invoke).toHaveBeenCalledWith(id, { plugin: "oidc-login" });
+    expect(r.data?.plugin).toBe("oidc-login");
+  });
+
+  it("maps a thrown error into the result", async () => {
+    const invoke = vi.fn().mockRejectedValue(new Error("krew not found"));
+    const r = await installKrew(invoke);
+    expect(r.error).toContain("krew not found");
+    expect(r.data).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/lib/toolbox.ts
+++ b/apps/desktop/src/lib/toolbox.ts
@@ -1,0 +1,113 @@
+import { invokeCapability, type Invoker } from "../transport/transport";
+
+// Types mirror the Rust DTOs in crates/kube/src/toolbox.rs.
+
+/** A managed CLI tool's inventory entry (Toolbox "Tools" section). */
+export interface ToolStatus {
+  name: string;
+  installed: boolean;
+  path?: string | null;
+  version?: string | null;
+  /** "managed" (srelens installed it) or "system". */
+  source?: string | null;
+}
+
+export type RequirementKind = "kubectl" | "krew-plugin" | "external";
+export type RequirementStatus = "found" | "not-on-app-path" | "missing";
+
+/** One exec-auth requirement of a context, resolved. */
+export interface RequirementResult {
+  binary: string;
+  kind: RequirementKind;
+  plugin?: string | null;
+  installable: boolean;
+  status: RequirementStatus;
+  path?: string | null;
+  version?: string | null;
+}
+
+export interface DiagnosisReport {
+  context: string;
+  items: RequirementResult[];
+}
+
+/** Result of a tool install. */
+export interface InstallResult {
+  tool: string;
+  version: string;
+  path: string;
+}
+
+/** A krew index entry. */
+export interface Plugin {
+  name: string;
+  description: string;
+  installed: boolean;
+}
+
+export interface PluginActionResult {
+  plugin: string;
+  output: string;
+}
+
+/** Result wrappers keep the try/catch out of components (mirrors lib/helm.ts). */
+type Result<T> = { data?: T; error?: string };
+
+async function call<T>(run: () => Promise<T>): Promise<Result<T>> {
+  try {
+    return { data: await run() };
+  } catch (e) {
+    return { error: String(e) };
+  }
+}
+
+/** Inventory the managed toolchain (kubectl, krew, helm). */
+export function toolboxStatus(invoke: Invoker = invokeCapability): Promise<Result<ToolStatus[]>> {
+  return call(async () => (await invoke<{ tools: ToolStatus[] }>("toolbox.status", {})).tools);
+}
+
+/** Diagnose a context's exec-auth tool requirements. */
+export function diagnoseContext(
+  context: string,
+  invoke: Invoker = invokeCapability,
+): Promise<Result<DiagnosisReport>> {
+  return call(() => invoke<DiagnosisReport>("toolbox.diagnoseContext", { context }));
+}
+
+/** Search the krew plugin index. */
+export function searchPlugins(
+  query: string,
+  invoke: Invoker = invokeCapability,
+): Promise<Result<Plugin[]>> {
+  return call(async () => (await invoke<{ plugins: Plugin[] }>("toolbox.searchPlugins", { query })).plugins);
+}
+
+const installTool = (id: string, invoke: Invoker) =>
+  call(() => invoke<InstallResult>(id, {}));
+
+/** Install the latest stable kubectl into ~/.srelens/bin. */
+export const installKubectl = (invoke: Invoker = invokeCapability) =>
+  installTool("toolbox.installKubectl", invoke);
+
+/** Install the latest helm into ~/.srelens/bin. */
+export const installHelm = (invoke: Invoker = invokeCapability) =>
+  installTool("toolbox.installHelm", invoke);
+
+/** Bootstrap krew into ~/.krew. */
+export const installKrew = (invoke: Invoker = invokeCapability) =>
+  installTool("toolbox.installKrew", invoke);
+
+const pluginAction = (id: string, plugin: string, invoke: Invoker) =>
+  call(() => invoke<PluginActionResult>(id, { plugin }));
+
+/** Install a krew plugin. */
+export const installPlugin = (plugin: string, invoke: Invoker = invokeCapability) =>
+  pluginAction("toolbox.installPlugin", plugin, invoke);
+
+/** Upgrade an installed krew plugin. */
+export const upgradePlugin = (plugin: string, invoke: Invoker = invokeCapability) =>
+  pluginAction("toolbox.upgradePlugin", plugin, invoke);
+
+/** Remove an installed krew plugin. */
+export const removePlugin = (plugin: string, invoke: Invoker = invokeCapability) =>
+  pluginAction("toolbox.removePlugin", plugin, invoke);

--- a/crates/kube/src/toolbox.rs
+++ b/crates/kube/src/toolbox.rs
@@ -399,6 +399,121 @@ pub fn srelens_bin_dir() -> PathBuf {
     PathBuf::from(home).join(".srelens").join("bin")
 }
 
+/// Where krew installs its shim (`kubectl-krew`) and plugin binaries.
+pub fn krew_bin_dir() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_default();
+    PathBuf::from(home).join(".krew").join("bin")
+}
+
+/// The tools srelens can manage, in display order.
+const MANAGED_TOOLS: [&str; 3] = ["kubectl", "krew", "helm"];
+
+/// One managed tool's inventory entry for the Toolbox "Tools" section.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ToolStatusDto {
+    pub name: String,
+    pub installed: bool,
+    pub path: Option<String>,
+    pub version: Option<String>,
+    /// `managed` (srelens installed it under a managed dir) or `system`.
+    pub source: Option<String>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct StatusOut {
+    pub tools: Vec<ToolStatusDto>,
+}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+pub struct StatusIn {}
+
+/// Extract the first `vMAJOR.MINOR.PATCH` token from a tool's version output.
+/// kubectl/krew/helm each wrap the version in different surrounding text (plain
+/// "Client Version: v1.30.2", JSON `"gitVersion":"v1.30.2"`, or "v3.16.2+g…"),
+/// so we scan for the first well-formed semver rather than parse each format.
+pub fn first_semver(text: &str) -> Option<String> {
+    let bytes = text.as_bytes();
+    for i in 0..bytes.len() {
+        if bytes[i] != b'v' || i + 1 >= bytes.len() || !bytes[i + 1].is_ascii_digit() {
+            continue;
+        }
+        let start = i + 1;
+        let mut j = start;
+        while j < bytes.len() && (bytes[j].is_ascii_digit() || bytes[j] == b'.') {
+            j += 1;
+        }
+        let parts: Vec<&str> = text[start..j].split('.').collect();
+        if parts.len() >= 3 && parts[..3].iter().all(|p| !p.is_empty()) {
+            return Some(format!("v{}.{}.{}", parts[0], parts[1], parts[2]));
+        }
+    }
+    None
+}
+
+/// `managed` when the resolved binary lives under one of the srelens-managed
+/// dirs (`~/.srelens/bin`, `~/.krew/bin`), else `system`.
+fn tool_source(path: &Path, managed_dirs: &[PathBuf]) -> &'static str {
+    if managed_dirs.iter().any(|dir| path.starts_with(dir)) {
+        "managed"
+    } else {
+        "system"
+    }
+}
+
+/// Read-only capability: inventory the managed CLI toolchain (kubectl, krew,
+/// helm) — whether each is installed, where, its version, and whether srelens
+/// manages it. The resolution environment is injected so it's deterministic
+/// under test; production supplies [`SearchPaths::from_env`], a real filesystem
+/// check, and a per-tool version probe.
+pub fn status_capability(
+    search: SearchPaths,
+    managed_dirs: Vec<PathBuf>,
+    is_file: impl Fn(&Path) -> bool + Send + Sync + 'static,
+    version_of: impl Fn(&str, &Path) -> Option<String> + Send + Sync + 'static,
+) -> Capability {
+    let search = Arc::new(search);
+    let managed_dirs = Arc::new(managed_dirs);
+    let is_file = Arc::new(is_file);
+    let version_of = Arc::new(version_of);
+    Capability::typed::<StatusIn, StatusOut, _, _>(
+        "toolbox.status",
+        "inventory the managed CLI toolchain (kubectl, krew, helm): whether each \
+         is installed, its path and version, and whether srelens manages it",
+        Annotations::READ_ONLY,
+        move |_input: StatusIn| {
+            let search = search.clone();
+            let managed_dirs = managed_dirs.clone();
+            let is_file = is_file.clone();
+            let version_of = version_of.clone();
+            async move {
+                let tools = MANAGED_TOOLS
+                    .iter()
+                    .map(|&name| match locate(name, &search, &|p| is_file(p)) {
+                        Some(found) => {
+                            let path = Path::new(&found.path);
+                            ToolStatusDto {
+                                name: name.to_string(),
+                                installed: true,
+                                version: version_of(name, path),
+                                source: Some(tool_source(path, &managed_dirs).to_string()),
+                                path: Some(found.path),
+                            }
+                        }
+                        None => ToolStatusDto {
+                            name: name.to_string(),
+                            installed: false,
+                            path: None,
+                            version: None,
+                            source: None,
+                        },
+                    })
+                    .collect();
+                Ok(StatusOut { tools })
+            }
+        },
+    )
+}
+
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct InstallKubectlIn {}
 
@@ -663,6 +778,59 @@ users:
     }
 
     #[tokio::test]
+    async fn status_inventories_installed_and_missing_managed_tools() {
+        let dir = tempfile::tempdir().unwrap();
+        let managed = dir.path().join(".srelens/bin");
+        std::fs::create_dir_all(&managed).unwrap();
+        std::fs::write(managed.join("kubectl"), b"#!/bin/sh\n").unwrap();
+
+        let cap = status_capability(
+            SearchPaths { app_path: managed.to_string_lossy().into_owned(), system_path: String::new() },
+            vec![managed.clone()],
+            |p| p.is_file(),
+            |name, _p| (name == "kubectl").then(|| "v1.30.2".to_string()),
+        );
+        let mut reg = Registry::new();
+        reg.register(cap);
+        let out = reg.invoke("toolbox.status", json!({})).await.unwrap();
+
+        let tools = out["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 3);
+        let kubectl = &tools[0];
+        assert_eq!(kubectl["name"], "kubectl");
+        assert_eq!(kubectl["installed"], true);
+        assert_eq!(kubectl["source"], "managed");
+        assert_eq!(kubectl["version"], "v1.30.2");
+        assert!(kubectl["path"].as_str().unwrap().ends_with("/kubectl"));
+        // krew + helm absent.
+        assert_eq!(tools[1]["installed"], false);
+        assert_eq!(tools[1]["version"], serde_json::Value::Null);
+        assert_eq!(tools[2]["installed"], false);
+    }
+
+    #[tokio::test]
+    async fn status_classifies_a_tool_outside_managed_dirs_as_system() {
+        let dir = tempfile::tempdir().unwrap();
+        let sysbin = dir.path().join("usr/local/bin");
+        std::fs::create_dir_all(&sysbin).unwrap();
+        std::fs::write(sysbin.join("helm"), b"#!/bin/sh\n").unwrap();
+
+        let cap = status_capability(
+            SearchPaths { app_path: sysbin.to_string_lossy().into_owned(), system_path: String::new() },
+            vec![dir.path().join(".srelens/bin")], // managed dir, not where helm lives
+            |p| p.is_file(),
+            |_name, _p| None,
+        );
+        let mut reg = Registry::new();
+        reg.register(cap);
+        let out = reg.invoke("toolbox.status", json!({})).await.unwrap();
+        let helm = &out["tools"][2];
+        assert_eq!(helm["name"], "helm");
+        assert_eq!(helm["installed"], true);
+        assert_eq!(helm["source"], "system");
+    }
+
+    #[tokio::test]
     async fn install_kubectl_surfaces_a_checksum_mismatch() {
         let dir = tempfile::tempdir().unwrap();
         let install_dir = dir.path().join("bin");
@@ -678,6 +846,29 @@ users:
         let err = reg.invoke("toolbox.installKubectl", json!({})).await.unwrap_err();
         assert!(format!("{err:?}").to_lowercase().contains("checksum"));
         assert!(!plan.target.exists());
+    }
+}
+
+#[cfg(test)]
+mod version_tests {
+    use super::first_semver;
+
+    #[test]
+    fn extracts_the_first_semver_across_tool_output_shapes() {
+        assert_eq!(first_semver("Client Version: v1.30.2").as_deref(), Some("v1.30.2"));
+        assert_eq!(first_semver("v3.16.2+g4f50ac1").as_deref(), Some("v3.16.2"));
+        assert_eq!(
+            first_semver(r#"{"clientVersion":{"gitVersion":"v1.30.2","major":"1"}}"#).as_deref(),
+            Some("v1.30.2"),
+        );
+        assert_eq!(first_semver("GitTag           v0.4.4").as_deref(), Some("v0.4.4"));
+    }
+
+    #[test]
+    fn returns_none_without_a_semver() {
+        assert_eq!(first_semver("no version here"), None);
+        assert_eq!(first_semver("v1.2"), None); // needs three components
+        assert_eq!(first_semver(""), None);
     }
 }
 

--- a/crates/kube/src/toolbox.rs
+++ b/crates/kube/src/toolbox.rs
@@ -389,8 +389,9 @@ pub fn diagnose_context_capability(
 }
 
 use crate::toolbox_install::{
-    helm_install, install_binary, install_from_targz, kubectl_install, parse_github_latest_tag,
-    InstallError, Platform, HELM_LATEST_RELEASE_URL, KUBECTL_STABLE_URL,
+    helm_install, install_binary, install_from_targz, install_krew, krew_archive, kubectl_install,
+    parse_github_latest_tag, InstallError, Platform, HELM_LATEST_RELEASE_URL,
+    KREW_LATEST_RELEASE_URL, KUBECTL_STABLE_URL,
 };
 
 /// The directory srelens installs managed tools into: `~/.srelens/bin`.
@@ -607,6 +608,220 @@ where
     )
 }
 
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+pub struct InstallKrewIn {}
+
+/// Confirm-gated capability: download the latest krew, verify it, and run its
+/// self-bootstrap (`krew install krew`) to populate `~/.krew`. `fetch` (blocking
+/// HTTP) and `run` (executes the bootstrap command) are injected; production
+/// supplies a reqwest GET and a `std::process::Command` runner.
+pub fn install_krew_capability<F, R>(staging_dir: PathBuf, fetch: F, run: R) -> Capability
+where
+    F: Fn(&str) -> Result<Vec<u8>, InstallError> + Send + Sync + Clone + 'static,
+    R: Fn(&Path, &[&str]) -> Result<(), InstallError> + Send + Sync + Clone + 'static,
+{
+    Capability::typed::<InstallKrewIn, InstallToolOut, _, _>(
+        "toolbox.installKrew",
+        "download the latest krew, verify it, and bootstrap it into ~/.krew \
+         (the engine for kubectl plugin installs)",
+        Annotations::MUTATING,
+        move |_input: InstallKrewIn| {
+            let staging_dir = staging_dir.clone();
+            let fetch = fetch.clone();
+            let run = run.clone();
+            async move {
+                tokio::task::spawn_blocking(move || {
+                    let platform = Platform::current().map_err(to_handler)?;
+                    let body = fetch(KREW_LATEST_RELEASE_URL).map_err(to_handler)?;
+                    let version = parse_github_latest_tag(&body).map_err(to_handler)?;
+                    let plan = krew_archive(&version, &platform, &staging_dir);
+                    install_krew(&plan, &fetch, &run).map_err(to_handler)?;
+                    Ok(InstallToolOut {
+                        tool: "krew".to_string(),
+                        version,
+                        path: krew_bin_dir().join("kubectl-krew").to_string_lossy().into_owned(),
+                    })
+                })
+                .await
+                .map_err(|e| CapabilityError::Handler(e.to_string()))?
+            }
+        },
+    )
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SearchPluginsIn {
+    /// Substring to search the krew index for.
+    pub query: String,
+}
+
+/// One krew index entry.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct PluginDto {
+    pub name: String,
+    pub description: String,
+    pub installed: bool,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct SearchPluginsOut {
+    pub plugins: Vec<PluginDto>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct PluginIn {
+    /// The krew plugin name (e.g. `oidc-login`).
+    pub plugin: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct PluginActionOut {
+    pub plugin: String,
+    /// krew's own output from the operation.
+    pub output: String,
+}
+
+/// Parse `kubectl krew search` output — a padded `NAME  DESCRIPTION  INSTALLED`
+/// table — into plugin rows. Lines before the header are skipped.
+pub fn parse_krew_search(stdout: &str) -> Vec<PluginDto> {
+    stdout
+        .lines()
+        .skip_while(|line| !line.trim_start().starts_with("NAME"))
+        .skip(1)
+        .filter(|line| !line.trim().is_empty())
+        .filter_map(parse_search_row)
+        .collect()
+}
+
+fn parse_search_row(line: &str) -> Option<PluginDto> {
+    let name = line.split_whitespace().next()?.to_string();
+    let installed_token = line.split_whitespace().next_back()?;
+    let installed = installed_token.eq_ignore_ascii_case("yes");
+    // Description is what's between the name and the trailing INSTALLED column.
+    let mid = line.trim();
+    let mid = mid.strip_prefix(&name).unwrap_or(mid).trim_start();
+    let description = mid.strip_suffix(installed_token).unwrap_or(mid).trim().to_string();
+    Some(PluginDto { name, description, installed })
+}
+
+/// Read-only capability: search the krew plugin index. `run` executes
+/// `kubectl-krew <args>` and returns its stdout (injected for testing).
+pub fn search_plugins_capability<R>(run: R) -> Capability
+where
+    R: Fn(&[&str]) -> Result<String, InstallError> + Send + Sync + Clone + 'static,
+{
+    Capability::typed::<SearchPluginsIn, SearchPluginsOut, _, _>(
+        "toolbox.searchPlugins",
+        "search the krew index for kubectl plugins (name, description, installed)",
+        Annotations::READ_ONLY,
+        move |input: SearchPluginsIn| {
+            let run = run.clone();
+            async move {
+                tokio::task::spawn_blocking(move || {
+                    let out = run(&["search", input.query.as_str()]).map_err(to_handler)?;
+                    Ok(SearchPluginsOut { plugins: parse_krew_search(&out) })
+                })
+                .await
+                .map_err(|e| CapabilityError::Handler(e.to_string()))?
+            }
+        },
+    )
+}
+
+/// Shared builder for the confirm-gated plugin mutations (install / upgrade /
+/// uninstall), which differ only in the krew subcommand.
+fn plugin_action_capability<R>(
+    id: &'static str,
+    summary: &'static str,
+    verb: &'static str,
+    run: R,
+) -> Capability
+where
+    R: Fn(&[&str]) -> Result<String, InstallError> + Send + Sync + Clone + 'static,
+{
+    Capability::typed::<PluginIn, PluginActionOut, _, _>(
+        id,
+        summary,
+        Annotations::MUTATING,
+        move |input: PluginIn| {
+            let run = run.clone();
+            async move {
+                tokio::task::spawn_blocking(move || {
+                    let output = run(&[verb, input.plugin.as_str()]).map_err(to_handler)?;
+                    Ok(PluginActionOut { plugin: input.plugin, output })
+                })
+                .await
+                .map_err(|e| CapabilityError::Handler(e.to_string()))?
+            }
+        },
+    )
+}
+
+pub fn install_plugin_capability<R>(run: R) -> Capability
+where
+    R: Fn(&[&str]) -> Result<String, InstallError> + Send + Sync + Clone + 'static,
+{
+    plugin_action_capability(
+        "toolbox.installPlugin",
+        "install a kubectl plugin from the krew index",
+        "install",
+        run,
+    )
+}
+
+pub fn upgrade_plugin_capability<R>(run: R) -> Capability
+where
+    R: Fn(&[&str]) -> Result<String, InstallError> + Send + Sync + Clone + 'static,
+{
+    plugin_action_capability(
+        "toolbox.upgradePlugin",
+        "upgrade an installed krew plugin",
+        "upgrade",
+        run,
+    )
+}
+
+pub fn remove_plugin_capability<R>(run: R) -> Capability
+where
+    R: Fn(&[&str]) -> Result<String, InstallError> + Send + Sync + Clone + 'static,
+{
+    plugin_action_capability(
+        "toolbox.removePlugin",
+        "remove an installed krew plugin",
+        "uninstall",
+        run,
+    )
+}
+
+#[cfg(test)]
+mod plugin_tests {
+    use super::*;
+
+    const SAMPLE: &str = "\
+NAME            DESCRIPTION                              INSTALLED
+access-matrix   Show an RBAC access matrix               no
+oidc-login      Log in to the cluster via OIDC           yes
+";
+
+    #[test]
+    fn parse_krew_search_reads_name_description_and_installed() {
+        let plugins = parse_krew_search(SAMPLE);
+        assert_eq!(plugins.len(), 2);
+        assert_eq!(plugins[0].name, "access-matrix");
+        assert_eq!(plugins[0].description, "Show an RBAC access matrix");
+        assert!(!plugins[0].installed);
+        assert_eq!(plugins[1].name, "oidc-login");
+        assert_eq!(plugins[1].description, "Log in to the cluster via OIDC");
+        assert!(plugins[1].installed);
+    }
+
+    #[test]
+    fn parse_krew_search_is_empty_without_rows() {
+        assert!(parse_krew_search("").is_empty());
+        assert!(parse_krew_search("NAME  DESCRIPTION  INSTALLED\n").is_empty());
+    }
+}
+
 #[cfg(test)]
 mod capability_tests {
     use super::*;
@@ -775,6 +990,97 @@ users:
     async fn install_helm_is_confirm_gated() {
         let cap = install_helm_capability(PathBuf::from("/tmp/x"), net(vec![]));
         assert!(cap.annotations.requires_confirm);
+    }
+
+    #[tokio::test]
+    async fn install_krew_resolves_downloads_and_bootstraps() {
+        let dir = tempfile::tempdir().unwrap();
+        let platform = Platform::current().unwrap();
+        let plan = krew_archive("v9.9.9", &platform, dir.path());
+        let archive = make_targz(&[(format!("./{}", plan.member).as_str(), b"#!/bin/sh\n")]);
+        let fetch = net(vec![
+            (KREW_LATEST_RELEASE_URL.to_string(), br#"{"tag_name":"v9.9.9"}"#.to_vec()),
+            (plan.sha256_url.clone(), sha256_hex(&archive).into_bytes()),
+            (plan.archive_url.clone(), archive),
+        ]);
+        let bootstrapped = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let flag = bootstrapped.clone();
+        let run = move |_bin: &Path, args: &[&str]| {
+            assert_eq!(args, ["install", "krew"]);
+            flag.store(true, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        };
+
+        let mut reg = Registry::new();
+        reg.register(install_krew_capability(dir.path().to_path_buf(), fetch, run));
+        let out = reg.invoke("toolbox.installKrew", json!({})).await.unwrap();
+
+        assert_eq!(out["tool"], "krew");
+        assert_eq!(out["version"], "v9.9.9");
+        assert!(out["path"].as_str().unwrap().ends_with("kubectl-krew"));
+        assert!(bootstrapped.load(std::sync::atomic::Ordering::SeqCst), "krew bootstrap ran");
+    }
+
+    #[tokio::test]
+    async fn install_krew_is_confirm_gated() {
+        let cap = install_krew_capability(
+            PathBuf::from("/tmp/x"),
+            net(vec![]),
+            |_b: &Path, _a: &[&str]| Ok(()),
+        );
+        assert!(cap.annotations.requires_confirm);
+    }
+
+    #[tokio::test]
+    async fn search_plugins_runs_krew_search_and_parses_results() {
+        let run = |args: &[&str]| {
+            assert_eq!(args, ["search", "oidc"]);
+            Ok("NAME        DESCRIPTION       INSTALLED\noidc-login  OIDC login        yes\n".to_string())
+        };
+        let mut reg = Registry::new();
+        reg.register(search_plugins_capability(run));
+        let out = reg.invoke("toolbox.searchPlugins", json!({ "query": "oidc" })).await.unwrap();
+        let plugins = out["plugins"].as_array().unwrap();
+        assert_eq!(plugins.len(), 1);
+        assert_eq!(plugins[0]["name"], "oidc-login");
+        assert_eq!(plugins[0]["installed"], true);
+    }
+
+    #[tokio::test]
+    async fn install_plugin_runs_krew_install_and_is_confirm_gated() {
+        use std::sync::{Arc, Mutex};
+        let seen: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = seen.clone();
+        let run = move |args: &[&str]| {
+            sink.lock().unwrap().extend(args.iter().map(|s| s.to_string()));
+            Ok("Installed plugin: oidc-login".to_string())
+        };
+        let cap = install_plugin_capability(run);
+        assert!(cap.annotations.requires_confirm);
+
+        let mut reg = Registry::new();
+        reg.register(cap);
+        let out = reg
+            .invoke("toolbox.installPlugin", json!({ "plugin": "oidc-login" }))
+            .await
+            .unwrap();
+        assert_eq!(out["plugin"], "oidc-login");
+        assert_eq!(*seen.lock().unwrap(), vec!["install", "oidc-login"]);
+    }
+
+    #[tokio::test]
+    async fn remove_plugin_uses_the_uninstall_verb() {
+        use std::sync::{Arc, Mutex};
+        let seen: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = seen.clone();
+        let run = move |args: &[&str]| {
+            sink.lock().unwrap().extend(args.iter().map(|s| s.to_string()));
+            Ok(String::new())
+        };
+        let mut reg = Registry::new();
+        reg.register(remove_plugin_capability(run));
+        reg.invoke("toolbox.removePlugin", json!({ "plugin": "oidc-login" })).await.unwrap();
+        assert_eq!(*seen.lock().unwrap(), vec!["uninstall", "oidc-login"]);
     }
 
     #[tokio::test]

--- a/crates/kube/src/toolbox_install.rs
+++ b/crates/kube/src/toolbox_install.rs
@@ -210,6 +210,40 @@ pub fn install_from_targz(
     write_binary(&plan.target, &bytes)
 }
 
+/// GitHub API endpoint for krew's latest release.
+pub const KREW_LATEST_RELEASE_URL: &str =
+    "https://api.github.com/repos/kubernetes-sigs/krew/releases/latest";
+
+/// Plan a krew download for `version` into `staging_dir`. Unlike kubectl/helm,
+/// the extracted binary is transient: it's run once to bootstrap krew into
+/// `~/.krew`, not kept as the installed tool. The tar member is `krew-<os>_<arch>`.
+pub fn krew_archive(version: &str, platform: &Platform, staging_dir: &Path) -> ArchiveInstall {
+    let ext = if platform.os == "windows" { ".exe" } else { "" };
+    let member = format!("krew-{}_{}{ext}", platform.os, platform.arch);
+    let archive_url = format!(
+        "https://github.com/kubernetes-sigs/krew/releases/download/{version}/{member}.tar.gz"
+    );
+    ArchiveInstall {
+        sha256_url: format!("{archive_url}.sha256"),
+        target: staging_dir.join(&member),
+        member,
+        archive_url,
+    }
+}
+
+/// Install krew: download + verify + extract the transient binary (via
+/// [`install_from_targz`]), then run it as `<binary> install krew` to bootstrap
+/// krew into `~/.krew`. `run` executes that command (injected for testing);
+/// it must surface a non-zero exit as an error.
+pub fn install_krew<F, R>(plan: &ArchiveInstall, fetch: &F, run: &R) -> Result<(), InstallError>
+where
+    F: Fn(&str) -> Result<Vec<u8>, InstallError>,
+    R: Fn(&Path, &[&str]) -> Result<(), InstallError>,
+{
+    let binary = install_from_targz(plan, fetch)?;
+    run(&binary, &["install", "krew"])
+}
+
 /// Read one member's bytes out of a gzip-compressed tar.
 fn extract_member(targz: &[u8], member: &str) -> Result<Vec<u8>, InstallError> {
     use flate2::read::GzDecoder;
@@ -221,7 +255,9 @@ fn extract_member(targz: &[u8], member: &str) -> Result<Vec<u8>, InstallError> {
     for entry in entries {
         let mut entry = entry.map_err(|e| InstallError::BadArchive(e.to_string()))?;
         let path = entry.path().map_err(|e| InstallError::BadArchive(e.to_string()))?;
-        if path.to_string_lossy() == member {
+        // Tars vary on a leading `./` (helm omits it, krew includes it); compare
+        // on the normalized path so a plan's `member` needn't carry the prefix.
+        if path.to_string_lossy().trim_start_matches("./") == member {
             let mut buf = Vec::new();
             entry.read_to_end(&mut buf).map_err(|e| InstallError::BadArchive(e.to_string()))?;
             return Ok(buf);
@@ -471,6 +507,76 @@ mod tests {
             Err(InstallError::MemberNotFound { .. })
         ));
         assert!(!plan.target.exists());
+    }
+
+    #[test]
+    fn extract_member_ignores_a_leading_dot_slash() {
+        // krew's tar prefixes members with `./`.
+        let archive = make_targz(&[("./krew-linux_amd64", b"payload")]);
+        assert_eq!(extract_member(&archive, "krew-linux_amd64").unwrap(), b"payload");
+    }
+
+    #[test]
+    fn krew_plan_targets_the_github_release_and_transient_binary() {
+        let staging = std::path::Path::new("/tmp/stage");
+        let p = krew_archive("v0.5.0", &Platform { os: "linux", arch: "amd64" }, staging);
+        assert_eq!(
+            p.archive_url,
+            "https://github.com/kubernetes-sigs/krew/releases/download/v0.5.0/krew-linux_amd64.tar.gz"
+        );
+        assert_eq!(p.sha256_url, format!("{}.sha256", p.archive_url));
+        assert_eq!(p.member, "krew-linux_amd64");
+        assert_eq!(p.target, staging.join("krew-linux_amd64"));
+    }
+
+    #[test]
+    fn install_krew_extracts_then_bootstraps_with_install_krew() {
+        use std::cell::RefCell;
+        let dir = tempfile::tempdir().unwrap();
+        let plan = krew_archive("v0.5.0", &Platform { os: "linux", arch: "amd64" }, dir.path());
+        let payload = b"#!/bin/sh\n";
+        let archive = make_targz(&[(format!("./{}", plan.member).as_str(), payload)]);
+        let fetch = net(&[
+            (plan.sha256_url.as_str(), sha256_hex(&archive).as_bytes()),
+            (plan.archive_url.as_str(), &archive),
+        ]);
+
+        let calls: RefCell<Vec<(String, Vec<String>)>> = RefCell::new(Vec::new());
+        let run = |bin: &Path, args: &[&str]| {
+            calls
+                .borrow_mut()
+                .push((bin.to_string_lossy().into_owned(), args.iter().map(|s| s.to_string()).collect()));
+            Ok(())
+        };
+
+        install_krew(&plan, &fetch, &run).unwrap();
+
+        let calls = calls.into_inner();
+        assert_eq!(calls.len(), 1);
+        assert!(calls[0].0.ends_with("krew-linux_amd64"), "bootstrap ran the extracted binary");
+        assert_eq!(calls[0].1, vec!["install", "krew"]);
+    }
+
+    #[test]
+    fn install_krew_does_not_bootstrap_a_tampered_archive() {
+        use std::cell::Cell;
+        let dir = tempfile::tempdir().unwrap();
+        let plan = krew_archive("v0.5.0", &Platform { os: "linux", arch: "amd64" }, dir.path());
+        let archive = make_targz(&[(plan.member.as_str(), b"payload")]);
+        let fetch = net(&[
+            (plan.sha256_url.as_str(), sha256_hex(b"other").as_bytes()),
+            (plan.archive_url.as_str(), &archive),
+        ]);
+        let ran = Cell::new(false);
+        let run = |_bin: &Path, _args: &[&str]| {
+            ran.set(true);
+            Ok(())
+        };
+        assert!(matches!(
+            install_krew(&plan, &fetch, &run),
+            Err(InstallError::ChecksumMismatch { .. })
+        ));
+        assert!(!ran.get(), "must not bootstrap when the archive fails verification");
     }
 
     #[test]


### PR DESCRIPTION
Slice 8 of #55, on `dev` (the #120 stack has merged). Read-only capability backing the Toolbox "Tools" section.

## What this does

`toolbox.status` inventories the managed toolchain — for each of kubectl / krew / helm it reports:
- `installed` — resolved on the app PATH (reuses the diagnosis engine's `locate`)
- `path`, `version`
- `source` — `managed` (under `~/.srelens/bin` or `~/.krew/bin`) vs `system`

## Version extraction

`first_semver` is a pure, tested helper that scans a tool's version output for the first `vX.Y.Z`. kubectl prints JSON (`"gitVersion":"v1.25.2"`), helm `--short` prints `v3.11.3+g…`, krew prints `GitTag v0.4.4` — scanning for the first well-formed semver beats parsing three formats. The app supplies the thin command-runner adapter; the resolution env + version probe are injected into the capability so it's deterministic under test.

## Testing

- TDD: 2 capability tests (installed+managed with version / missing tools; system-vs-managed classification, RED-checked) + 2 `first_semver` tests (kubectl JSON, helm `+g`, krew GitTag, and negative cases).
- **Exercised in the kind e2e suite** (not excluded) — it's a read with no side effects, and kubectl/helm are on PATH there, so the case asserts kubectl resolves installed with a version.
- Grounded `first_semver` against real `kubectl version -o json` and `helm version --short` output. kube 231 green, app MCP completeness green, clippy clean.

## Next

Read-only `toolbox.searchPlugins` (krew index) and the krew capabilities (`installKrew` + plugin install/upgrade/remove), then the streaming `start_tool_install` command and the Toolbox page.