### PR TITLE
feat(toolbox): toolbox.installKrew capability (slice 9)

### DIFF
--- a/apps/desktop/src-tauri/src/capabilities.rs
+++ b/apps/desktop/src-tauri/src/capabilities.rs
@@ -51,6 +51,24 @@ fn http_get(url: &str) -> Result<Vec<u8>, srelens_kube::toolbox_install::Install
         .map_err(|e| InstallError::Download(e.to_string()))
 }
 
+/// Run a managed tool with args, mapping a non-zero exit (with stderr) to a
+/// retryable error. Used for krew's self-bootstrap; called inside spawn_blocking.
+fn run_tool(
+    bin: &std::path::Path,
+    args: &[&str],
+) -> Result<(), srelens_kube::toolbox_install::InstallError> {
+    use srelens_kube::toolbox_install::InstallError;
+    let output = std::process::Command::new(bin)
+        .args(args)
+        .output()
+        .map_err(|e| InstallError::Download(e.to_string()))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(InstallError::Download(String::from_utf8_lossy(&output.stderr).into_owned()))
+    }
+}
+
 /// Probe a managed tool's version by running it and scanning for a semver.
 /// Each tool prints its version differently, so we pass tool-specific flags and
 /// let `first_semver` pull the `vX.Y.Z` out of whatever text comes back.
@@ -102,6 +120,11 @@ pub fn build_registry_with(cache: Arc<ClientCache>) -> Registry {
     reg.register(srelens_kube::toolbox::install_helm_capability(
         srelens_kube::toolbox::srelens_bin_dir(),
         http_get,
+    ));
+    reg.register(srelens_kube::toolbox::install_krew_capability(
+        std::env::temp_dir(),
+        http_get,
+        run_tool,
     ));
     reg.register(srelens_kube::toolbox::status_capability(
         srelens_kube::toolbox::SearchPaths::from_env(),

--- a/apps/desktop/src-tauri/src/capabilities.rs
+++ b/apps/desktop/src-tauri/src/capabilities.rs
@@ -69,6 +69,24 @@ fn run_tool(
     }
 }
 
+/// Run `kubectl-krew` with args, returning stdout (or stderr as an error).
+/// Prefers the krew shim under `~/.krew/bin`, falling back to PATH. Called
+/// inside spawn_blocking by the plugin capabilities.
+fn run_krew(args: &[&str]) -> Result<String, srelens_kube::toolbox_install::InstallError> {
+    use srelens_kube::toolbox_install::InstallError;
+    let shim = srelens_kube::toolbox::krew_bin_dir().join("kubectl-krew");
+    let bin = if shim.is_file() { shim } else { std::path::PathBuf::from("kubectl-krew") };
+    let output = std::process::Command::new(bin)
+        .args(args)
+        .output()
+        .map_err(|e| InstallError::Download(e.to_string()))?;
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    } else {
+        Err(InstallError::Download(String::from_utf8_lossy(&output.stderr).into_owned()))
+    }
+}
+
 /// Probe a managed tool's version by running it and scanning for a semver.
 /// Each tool prints its version differently, so we pass tool-specific flags and
 /// let `first_semver` pull the `vX.Y.Z` out of whatever text comes back.
@@ -135,6 +153,10 @@ pub fn build_registry_with(cache: Arc<ClientCache>) -> Registry {
         |path| path.is_file(),
         tool_version,
     ));
+    reg.register(srelens_kube::toolbox::search_plugins_capability(run_krew));
+    reg.register(srelens_kube::toolbox::install_plugin_capability(run_krew));
+    reg.register(srelens_kube::toolbox::upgrade_plugin_capability(run_krew));
+    reg.register(srelens_kube::toolbox::remove_plugin_capability(run_krew));
 
     reg.register(srelens_kube::connect::cluster_info_capability(
         cache.clone(),

--- a/apps/desktop/src-tauri/tests/e2e.rs
+++ b/apps/desktop/src-tauri/tests/e2e.rs
@@ -160,6 +160,11 @@ const EXCLUDED: &[(&str, &str)] = &[
         "downloads a real release tarball from get.helm.sh and writes to ~/.srelens/bin; \
          covered by unit tests with an injected fetch instead of hitting the network in CI",
     ),
+    (
+        "toolbox.installKrew",
+        "downloads krew from GitHub and runs its bootstrap subprocess to populate ~/.krew; \
+         covered by unit tests with an injected fetch and command runner instead of the network in CI",
+    ),
 ];
 
 fn deadline(secs: u64) -> Instant {

--- a/apps/desktop/src-tauri/tests/e2e.rs
+++ b/apps/desktop/src-tauri/tests/e2e.rs
@@ -165,6 +165,13 @@ const EXCLUDED: &[(&str, &str)] = &[
         "downloads krew from GitHub and runs its bootstrap subprocess to populate ~/.krew; \
          covered by unit tests with an injected fetch and command runner instead of the network in CI",
     ),
+    // The plugin ops shell out to kubectl-krew, which isn't installed in the kind
+    // CI image; unit-tested with an injected runner. Real krew + a small-plugin
+    // install is the integration test deferred to the kind-CI work in the spec.
+    ("toolbox.searchPlugins", "requires krew installed (not in the CI image); unit-tested with an injected runner"),
+    ("toolbox.installPlugin", "requires krew installed (not in the CI image); unit-tested with an injected runner"),
+    ("toolbox.upgradePlugin", "requires krew installed (not in the CI image); unit-tested with an injected runner"),
+    ("toolbox.removePlugin", "requires krew installed (not in the CI image); unit-tested with an injected runner"),
 ];
 
 fn deadline(secs: u64) -> Instant {

--- a/apps/desktop/src/lib/toolbox.test.ts
+++ b/apps/desktop/src/lib/toolbox.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  toolboxStatus,
+  diagnoseContext,
+  searchPlugins,
+  installKubectl,
+  installHelm,
+  installKrew,
+  installPlugin,
+  upgradePlugin,
+  removePlugin,
+} from "./toolbox";
+
+describe("toolbox lib wrappers", () => {
+  it("toolboxStatus unwraps the tools array", async () => {
+    const invoke = vi.fn().mockResolvedValue({ tools: [{ name: "kubectl", installed: true }] });
+    const r = await toolboxStatus(invoke);
+    expect(invoke).toHaveBeenCalledWith("toolbox.status", {});
+    expect(r.data).toEqual([{ name: "kubectl", installed: true }]);
+  });
+
+  it("diagnoseContext passes the context and returns the report", async () => {
+    const report = { context: "dev", items: [] };
+    const invoke = vi.fn().mockResolvedValue(report);
+    const r = await diagnoseContext("dev", invoke);
+    expect(invoke).toHaveBeenCalledWith("toolbox.diagnoseContext", { context: "dev" });
+    expect(r.data).toEqual(report);
+  });
+
+  it("searchPlugins passes the query and unwraps plugins", async () => {
+    const invoke = vi.fn().mockResolvedValue({ plugins: [{ name: "oidc-login", description: "", installed: false }] });
+    const r = await searchPlugins("oidc", invoke);
+    expect(invoke).toHaveBeenCalledWith("toolbox.searchPlugins", { query: "oidc" });
+    expect(r.data?.[0].name).toBe("oidc-login");
+  });
+
+  it.each([
+    ["installKubectl", installKubectl, "toolbox.installKubectl"],
+    ["installHelm", installHelm, "toolbox.installHelm"],
+    ["installKrew", installKrew, "toolbox.installKrew"],
+  ] as const)("%s invokes %s with no args", async (_name, fn, id) => {
+    const invoke = vi.fn().mockResolvedValue({ tool: "x", version: "v1", path: "/p" });
+    const r = await fn(invoke);
+    expect(invoke).toHaveBeenCalledWith(id, {});
+    expect(r.data?.version).toBe("v1");
+  });
+
+  it.each([
+    ["installPlugin", installPlugin, "toolbox.installPlugin"],
+    ["upgradePlugin", upgradePlugin, "toolbox.upgradePlugin"],
+    ["removePlugin", removePlugin, "toolbox.removePlugin"],
+  ] as const)("%s passes the plugin name to %s", async (_name, fn, id) => {
+    const invoke = vi.fn().mockResolvedValue({ plugin: "oidc-login", output: "ok" });
+    const r = await fn("oidc-login", invoke);
+    expect(invoke).toHaveBeenCalledWith(id, { plugin: "oidc-login" });
+    expect(r.data?.plugin).toBe("oidc-login");
+  });
+
+  it("maps a thrown error into the result", async () => {
+    const invoke = vi.fn().mockRejectedValue(new Error("krew not found"));
+    const r = await installKrew(invoke);
+    expect(r.error).toContain("krew not found");
+    expect(r.data).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/lib/toolbox.ts
+++ b/apps/desktop/src/lib/toolbox.ts
@@ -1,0 +1,113 @@
+import { invokeCapability, type Invoker } from "../transport/transport";
+
+// Types mirror the Rust DTOs in crates/kube/src/toolbox.rs.
+
+/** A managed CLI tool's inventory entry (Toolbox "Tools" section). */
+export interface ToolStatus {
+  name: string;
+  installed: boolean;
+  path?: string | null;
+  version?: string | null;
+  /** "managed" (srelens installed it) or "system". */
+  source?: string | null;
+}
+
+export type RequirementKind = "kubectl" | "krew-plugin" | "external";
+export type RequirementStatus = "found" | "not-on-app-path" | "missing";
+
+/** One exec-auth requirement of a context, resolved. */
+export interface RequirementResult {
+  binary: string;
+  kind: RequirementKind;
+  plugin?: string | null;
+  installable: boolean;
+  status: RequirementStatus;
+  path?: string | null;
+  version?: string | null;
+}
+
+export interface DiagnosisReport {
+  context: string;
+  items: RequirementResult[];
+}
+
+/** Result of a tool install. */
+export interface InstallResult {
+  tool: string;
+  version: string;
+  path: string;
+}
+
+/** A krew index entry. */
+export interface Plugin {
+  name: string;
+  description: string;
+  installed: boolean;
+}
+
+export interface PluginActionResult {
+  plugin: string;
+  output: string;
+}
+
+/** Result wrappers keep the try/catch out of components (mirrors lib/helm.ts). */
+type Result<T> = { data?: T; error?: string };
+
+async function call<T>(run: () => Promise<T>): Promise<Result<T>> {
+  try {
+    return { data: await run() };
+  } catch (e) {
+    return { error: String(e) };
+  }
+}
+
+/** Inventory the managed toolchain (kubectl, krew, helm). */
+export function toolboxStatus(invoke: Invoker = invokeCapability): Promise<Result<ToolStatus[]>> {
+  return call(async () => (await invoke<{ tools: ToolStatus[] }>("toolbox.status", {})).tools);
+}
+
+/** Diagnose a context's exec-auth tool requirements. */
+export function diagnoseContext(
+  context: string,
+  invoke: Invoker = invokeCapability,
+): Promise<Result<DiagnosisReport>> {
+  return call(() => invoke<DiagnosisReport>("toolbox.diagnoseContext", { context }));
+}
+
+/** Search the krew plugin index. */
+export function searchPlugins(
+  query: string,
+  invoke: Invoker = invokeCapability,
+): Promise<Result<Plugin[]>> {
+  return call(async () => (await invoke<{ plugins: Plugin[] }>("toolbox.searchPlugins", { query })).plugins);
+}
+
+const installTool = (id: string, invoke: Invoker) =>
+  call(() => invoke<InstallResult>(id, {}));
+
+/** Install the latest stable kubectl into ~/.srelens/bin. */
+export const installKubectl = (invoke: Invoker = invokeCapability) =>
+  installTool("toolbox.installKubectl", invoke);
+
+/** Install the latest helm into ~/.srelens/bin. */
+export const installHelm = (invoke: Invoker = invokeCapability) =>
+  installTool("toolbox.installHelm", invoke);
+
+/** Bootstrap krew into ~/.krew. */
+export const installKrew = (invoke: Invoker = invokeCapability) =>
+  installTool("toolbox.installKrew", invoke);
+
+const pluginAction = (id: string, plugin: string, invoke: Invoker) =>
+  call(() => invoke<PluginActionResult>(id, { plugin }));
+
+/** Install a krew plugin. */
+export const installPlugin = (plugin: string, invoke: Invoker = invokeCapability) =>
+  pluginAction("toolbox.installPlugin", plugin, invoke);
+
+/** Upgrade an installed krew plugin. */
+export const upgradePlugin = (plugin: string, invoke: Invoker = invokeCapability) =>
+  pluginAction("toolbox.upgradePlugin", plugin, invoke);
+
+/** Remove an installed krew plugin. */
+export const removePlugin = (plugin: string, invoke: Invoker = invokeCapability) =>
+  pluginAction("toolbox.removePlugin", plugin, invoke);

--- a/crates/kube/src/toolbox.rs
+++ b/crates/kube/src/toolbox.rs
@@ -649,6 +649,179 @@ where
     )
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SearchPluginsIn {
+    /// Substring to search the krew index for.
+    pub query: String,
+}
+
+/// One krew index entry.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct PluginDto {
+    pub name: String,
+    pub description: String,
+    pub installed: bool,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct SearchPluginsOut {
+    pub plugins: Vec<PluginDto>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct PluginIn {
+    /// The krew plugin name (e.g. `oidc-login`).
+    pub plugin: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct PluginActionOut {
+    pub plugin: String,
+    /// krew's own output from the operation.
+    pub output: String,
+}
+
+/// Parse `kubectl krew search` output — a padded `NAME  DESCRIPTION  INSTALLED`
+/// table — into plugin rows. Lines before the header are skipped.
+pub fn parse_krew_search(stdout: &str) -> Vec<PluginDto> {
+    stdout
+        .lines()
+        .skip_while(|line| !line.trim_start().starts_with("NAME"))
+        .skip(1)
+        .filter(|line| !line.trim().is_empty())
+        .filter_map(parse_search_row)
+        .collect()
+}
+
+fn parse_search_row(line: &str) -> Option<PluginDto> {
+    let name = line.split_whitespace().next()?.to_string();
+    let installed_token = line.split_whitespace().next_back()?;
+    let installed = installed_token.eq_ignore_ascii_case("yes");
+    // Description is what's between the name and the trailing INSTALLED column.
+    let mid = line.trim();
+    let mid = mid.strip_prefix(&name).unwrap_or(mid).trim_start();
+    let description = mid.strip_suffix(installed_token).unwrap_or(mid).trim().to_string();
+    Some(PluginDto { name, description, installed })
+}
+
+/// Read-only capability: search the krew plugin index. `run` executes
+/// `kubectl-krew <args>` and returns its stdout (injected for testing).
+pub fn search_plugins_capability<R>(run: R) -> Capability
+where
+    R: Fn(&[&str]) -> Result<String, InstallError> + Send + Sync + Clone + 'static,
+{
+    Capability::typed::<SearchPluginsIn, SearchPluginsOut, _, _>(
+        "toolbox.searchPlugins",
+        "search the krew index for kubectl plugins (name, description, installed)",
+        Annotations::READ_ONLY,
+        move |input: SearchPluginsIn| {
+            let run = run.clone();
+            async move {
+                tokio::task::spawn_blocking(move || {
+                    let out = run(&["search", input.query.as_str()]).map_err(to_handler)?;
+                    Ok(SearchPluginsOut { plugins: parse_krew_search(&out) })
+                })
+                .await
+                .map_err(|e| CapabilityError::Handler(e.to_string()))?
+            }
+        },
+    )
+}
+
+/// Shared builder for the confirm-gated plugin mutations (install / upgrade /
+/// uninstall), which differ only in the krew subcommand.
+fn plugin_action_capability<R>(
+    id: &'static str,
+    summary: &'static str,
+    verb: &'static str,
+    run: R,
+) -> Capability
+where
+    R: Fn(&[&str]) -> Result<String, InstallError> + Send + Sync + Clone + 'static,
+{
+    Capability::typed::<PluginIn, PluginActionOut, _, _>(
+        id,
+        summary,
+        Annotations::MUTATING,
+        move |input: PluginIn| {
+            let run = run.clone();
+            async move {
+                tokio::task::spawn_blocking(move || {
+                    let output = run(&[verb, input.plugin.as_str()]).map_err(to_handler)?;
+                    Ok(PluginActionOut { plugin: input.plugin, output })
+                })
+                .await
+                .map_err(|e| CapabilityError::Handler(e.to_string()))?
+            }
+        },
+    )
+}
+
+pub fn install_plugin_capability<R>(run: R) -> Capability
+where
+    R: Fn(&[&str]) -> Result<String, InstallError> + Send + Sync + Clone + 'static,
+{
+    plugin_action_capability(
+        "toolbox.installPlugin",
+        "install a kubectl plugin from the krew index",
+        "install",
+        run,
+    )
+}
+
+pub fn upgrade_plugin_capability<R>(run: R) -> Capability
+where
+    R: Fn(&[&str]) -> Result<String, InstallError> + Send + Sync + Clone + 'static,
+{
+    plugin_action_capability(
+        "toolbox.upgradePlugin",
+        "upgrade an installed krew plugin",
+        "upgrade",
+        run,
+    )
+}
+
+pub fn remove_plugin_capability<R>(run: R) -> Capability
+where
+    R: Fn(&[&str]) -> Result<String, InstallError> + Send + Sync + Clone + 'static,
+{
+    plugin_action_capability(
+        "toolbox.removePlugin",
+        "remove an installed krew plugin",
+        "uninstall",
+        run,
+    )
+}
+
+#[cfg(test)]
+mod plugin_tests {
+    use super::*;
+
+    const SAMPLE: &str = "\
+NAME            DESCRIPTION                              INSTALLED
+access-matrix   Show an RBAC access matrix               no
+oidc-login      Log in to the cluster via OIDC           yes
+";
+
+    #[test]
+    fn parse_krew_search_reads_name_description_and_installed() {
+        let plugins = parse_krew_search(SAMPLE);
+        assert_eq!(plugins.len(), 2);
+        assert_eq!(plugins[0].name, "access-matrix");
+        assert_eq!(plugins[0].description, "Show an RBAC access matrix");
+        assert!(!plugins[0].installed);
+        assert_eq!(plugins[1].name, "oidc-login");
+        assert_eq!(plugins[1].description, "Log in to the cluster via OIDC");
+        assert!(plugins[1].installed);
+    }
+
+    #[test]
+    fn parse_krew_search_is_empty_without_rows() {
+        assert!(parse_krew_search("").is_empty());
+        assert!(parse_krew_search("NAME  DESCRIPTION  INSTALLED\n").is_empty());
+    }
+}
+
 #[cfg(test)]
 mod capability_tests {
     use super::*;
@@ -856,6 +1029,58 @@ users:
             |_b: &Path, _a: &[&str]| Ok(()),
         );
         assert!(cap.annotations.requires_confirm);
+    }
+
+    #[tokio::test]
+    async fn search_plugins_runs_krew_search_and_parses_results() {
+        let run = |args: &[&str]| {
+            assert_eq!(args, ["search", "oidc"]);
+            Ok("NAME        DESCRIPTION       INSTALLED\noidc-login  OIDC login        yes\n".to_string())
+        };
+        let mut reg = Registry::new();
+        reg.register(search_plugins_capability(run));
+        let out = reg.invoke("toolbox.searchPlugins", json!({ "query": "oidc" })).await.unwrap();
+        let plugins = out["plugins"].as_array().unwrap();
+        assert_eq!(plugins.len(), 1);
+        assert_eq!(plugins[0]["name"], "oidc-login");
+        assert_eq!(plugins[0]["installed"], true);
+    }
+
+    #[tokio::test]
+    async fn install_plugin_runs_krew_install_and_is_confirm_gated() {
+        use std::sync::{Arc, Mutex};
+        let seen: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = seen.clone();
+        let run = move |args: &[&str]| {
+            sink.lock().unwrap().extend(args.iter().map(|s| s.to_string()));
+            Ok("Installed plugin: oidc-login".to_string())
+        };
+        let cap = install_plugin_capability(run);
+        assert!(cap.annotations.requires_confirm);
+
+        let mut reg = Registry::new();
+        reg.register(cap);
+        let out = reg
+            .invoke("toolbox.installPlugin", json!({ "plugin": "oidc-login" }))
+            .await
+            .unwrap();
+        assert_eq!(out["plugin"], "oidc-login");
+        assert_eq!(*seen.lock().unwrap(), vec!["install", "oidc-login"]);
+    }
+
+    #[tokio::test]
+    async fn remove_plugin_uses_the_uninstall_verb() {
+        use std::sync::{Arc, Mutex};
+        let seen: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = seen.clone();
+        let run = move |args: &[&str]| {
+            sink.lock().unwrap().extend(args.iter().map(|s| s.to_string()));
+            Ok(String::new())
+        };
+        let mut reg = Registry::new();
+        reg.register(remove_plugin_capability(run));
+        reg.invoke("toolbox.removePlugin", json!({ "plugin": "oidc-login" })).await.unwrap();
+        assert_eq!(*seen.lock().unwrap(), vec!["uninstall", "oidc-login"]);
     }
 
     #[tokio::test]

--- a/crates/kube/src/toolbox.rs
+++ b/crates/kube/src/toolbox.rs
@@ -389,8 +389,9 @@ pub fn diagnose_context_capability(
 }
 
 use crate::toolbox_install::{
-    helm_install, install_binary, install_from_targz, kubectl_install, parse_github_latest_tag,
-    InstallError, Platform, HELM_LATEST_RELEASE_URL, KUBECTL_STABLE_URL,
+    helm_install, install_binary, install_from_targz, install_krew, krew_archive, kubectl_install,
+    parse_github_latest_tag, InstallError, Platform, HELM_LATEST_RELEASE_URL,
+    KREW_LATEST_RELEASE_URL, KUBECTL_STABLE_URL,
 };
 
 /// The directory srelens installs managed tools into: `~/.srelens/bin`.
@@ -607,6 +608,47 @@ where
     )
 }
 
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+pub struct InstallKrewIn {}
+
+/// Confirm-gated capability: download the latest krew, verify it, and run its
+/// self-bootstrap (`krew install krew`) to populate `~/.krew`. `fetch` (blocking
+/// HTTP) and `run` (executes the bootstrap command) are injected; production
+/// supplies a reqwest GET and a `std::process::Command` runner.
+pub fn install_krew_capability<F, R>(staging_dir: PathBuf, fetch: F, run: R) -> Capability
+where
+    F: Fn(&str) -> Result<Vec<u8>, InstallError> + Send + Sync + Clone + 'static,
+    R: Fn(&Path, &[&str]) -> Result<(), InstallError> + Send + Sync + Clone + 'static,
+{
+    Capability::typed::<InstallKrewIn, InstallToolOut, _, _>(
+        "toolbox.installKrew",
+        "download the latest krew, verify it, and bootstrap it into ~/.krew \
+         (the engine for kubectl plugin installs)",
+        Annotations::MUTATING,
+        move |_input: InstallKrewIn| {
+            let staging_dir = staging_dir.clone();
+            let fetch = fetch.clone();
+            let run = run.clone();
+            async move {
+                tokio::task::spawn_blocking(move || {
+                    let platform = Platform::current().map_err(to_handler)?;
+                    let body = fetch(KREW_LATEST_RELEASE_URL).map_err(to_handler)?;
+                    let version = parse_github_latest_tag(&body).map_err(to_handler)?;
+                    let plan = krew_archive(&version, &platform, &staging_dir);
+                    install_krew(&plan, &fetch, &run).map_err(to_handler)?;
+                    Ok(InstallToolOut {
+                        tool: "krew".to_string(),
+                        version,
+                        path: krew_bin_dir().join("kubectl-krew").to_string_lossy().into_owned(),
+                    })
+                })
+                .await
+                .map_err(|e| CapabilityError::Handler(e.to_string()))?
+            }
+        },
+    )
+}
+
 #[cfg(test)]
 mod capability_tests {
     use super::*;
@@ -774,6 +816,45 @@ users:
     #[tokio::test]
     async fn install_helm_is_confirm_gated() {
         let cap = install_helm_capability(PathBuf::from("/tmp/x"), net(vec![]));
+        assert!(cap.annotations.requires_confirm);
+    }
+
+    #[tokio::test]
+    async fn install_krew_resolves_downloads_and_bootstraps() {
+        let dir = tempfile::tempdir().unwrap();
+        let platform = Platform::current().unwrap();
+        let plan = krew_archive("v9.9.9", &platform, dir.path());
+        let archive = make_targz(&[(format!("./{}", plan.member).as_str(), b"#!/bin/sh\n")]);
+        let fetch = net(vec![
+            (KREW_LATEST_RELEASE_URL.to_string(), br#"{"tag_name":"v9.9.9"}"#.to_vec()),
+            (plan.sha256_url.clone(), sha256_hex(&archive).into_bytes()),
+            (plan.archive_url.clone(), archive),
+        ]);
+        let bootstrapped = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let flag = bootstrapped.clone();
+        let run = move |_bin: &Path, args: &[&str]| {
+            assert_eq!(args, ["install", "krew"]);
+            flag.store(true, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        };
+
+        let mut reg = Registry::new();
+        reg.register(install_krew_capability(dir.path().to_path_buf(), fetch, run));
+        let out = reg.invoke("toolbox.installKrew", json!({})).await.unwrap();
+
+        assert_eq!(out["tool"], "krew");
+        assert_eq!(out["version"], "v9.9.9");
+        assert!(out["path"].as_str().unwrap().ends_with("kubectl-krew"));
+        assert!(bootstrapped.load(std::sync::atomic::Ordering::SeqCst), "krew bootstrap ran");
+    }
+
+    #[tokio::test]
+    async fn install_krew_is_confirm_gated() {
+        let cap = install_krew_capability(
+            PathBuf::from("/tmp/x"),
+            net(vec![]),
+            |_b: &Path, _a: &[&str]| Ok(()),
+        );
         assert!(cap.annotations.requires_confirm);
     }
 

--- a/crates/kube/src/toolbox_install.rs
+++ b/crates/kube/src/toolbox_install.rs
@@ -210,6 +210,40 @@ pub fn install_from_targz(
     write_binary(&plan.target, &bytes)
 }
 
+/// GitHub API endpoint for krew's latest release.
+pub const KREW_LATEST_RELEASE_URL: &str =
+    "https://api.github.com/repos/kubernetes-sigs/krew/releases/latest";
+
+/// Plan a krew download for `version` into `staging_dir`. Unlike kubectl/helm,
+/// the extracted binary is transient: it's run once to bootstrap krew into
+/// `~/.krew`, not kept as the installed tool. The tar member is `krew-<os>_<arch>`.
+pub fn krew_archive(version: &str, platform: &Platform, staging_dir: &Path) -> ArchiveInstall {
+    let ext = if platform.os == "windows" { ".exe" } else { "" };
+    let member = format!("krew-{}_{}{ext}", platform.os, platform.arch);
+    let archive_url = format!(
+        "https://github.com/kubernetes-sigs/krew/releases/download/{version}/{member}.tar.gz"
+    );
+    ArchiveInstall {
+        sha256_url: format!("{archive_url}.sha256"),
+        target: staging_dir.join(&member),
+        member,
+        archive_url,
+    }
+}
+
+/// Install krew: download + verify + extract the transient binary (via
+/// [`install_from_targz`]), then run it as `<binary> install krew` to bootstrap
+/// krew into `~/.krew`. `run` executes that command (injected for testing);
+/// it must surface a non-zero exit as an error.
+pub fn install_krew<F, R>(plan: &ArchiveInstall, fetch: &F, run: &R) -> Result<(), InstallError>
+where
+    F: Fn(&str) -> Result<Vec<u8>, InstallError>,
+    R: Fn(&Path, &[&str]) -> Result<(), InstallError>,
+{
+    let binary = install_from_targz(plan, fetch)?;
+    run(&binary, &["install", "krew"])
+}
+
 /// Read one member's bytes out of a gzip-compressed tar.
 fn extract_member(targz: &[u8], member: &str) -> Result<Vec<u8>, InstallError> {
     use flate2::read::GzDecoder;
@@ -221,7 +255,9 @@ fn extract_member(targz: &[u8], member: &str) -> Result<Vec<u8>, InstallError> {
     for entry in entries {
         let mut entry = entry.map_err(|e| InstallError::BadArchive(e.to_string()))?;
         let path = entry.path().map_err(|e| InstallError::BadArchive(e.to_string()))?;
-        if path.to_string_lossy() == member {
+        // Tars vary on a leading `./` (helm omits it, krew includes it); compare
+        // on the normalized path so a plan's `member` needn't carry the prefix.
+        if path.to_string_lossy().trim_start_matches("./") == member {
             let mut buf = Vec::new();
             entry.read_to_end(&mut buf).map_err(|e| InstallError::BadArchive(e.to_string()))?;
             return Ok(buf);
@@ -471,6 +507,76 @@ mod tests {
             Err(InstallError::MemberNotFound { .. })
         ));
         assert!(!plan.target.exists());
+    }
+
+    #[test]
+    fn extract_member_ignores_a_leading_dot_slash() {
+        // krew's tar prefixes members with `./`.
+        let archive = make_targz(&[("./krew-linux_amd64", b"payload")]);
+        assert_eq!(extract_member(&archive, "krew-linux_amd64").unwrap(), b"payload");
+    }
+
+    #[test]
+    fn krew_plan_targets_the_github_release_and_transient_binary() {
+        let staging = std::path::Path::new("/tmp/stage");
+        let p = krew_archive("v0.5.0", &Platform { os: "linux", arch: "amd64" }, staging);
+        assert_eq!(
+            p.archive_url,
+            "https://github.com/kubernetes-sigs/krew/releases/download/v0.5.0/krew-linux_amd64.tar.gz"
+        );
+        assert_eq!(p.sha256_url, format!("{}.sha256", p.archive_url));
+        assert_eq!(p.member, "krew-linux_amd64");
+        assert_eq!(p.target, staging.join("krew-linux_amd64"));
+    }
+
+    #[test]
+    fn install_krew_extracts_then_bootstraps_with_install_krew() {
+        use std::cell::RefCell;
+        let dir = tempfile::tempdir().unwrap();
+        let plan = krew_archive("v0.5.0", &Platform { os: "linux", arch: "amd64" }, dir.path());
+        let payload = b"#!/bin/sh\n";
+        let archive = make_targz(&[(format!("./{}", plan.member).as_str(), payload)]);
+        let fetch = net(&[
+            (plan.sha256_url.as_str(), sha256_hex(&archive).as_bytes()),
+            (plan.archive_url.as_str(), &archive),
+        ]);
+
+        let calls: RefCell<Vec<(String, Vec<String>)>> = RefCell::new(Vec::new());
+        let run = |bin: &Path, args: &[&str]| {
+            calls
+                .borrow_mut()
+                .push((bin.to_string_lossy().into_owned(), args.iter().map(|s| s.to_string()).collect()));
+            Ok(())
+        };
+
+        install_krew(&plan, &fetch, &run).unwrap();
+
+        let calls = calls.into_inner();
+        assert_eq!(calls.len(), 1);
+        assert!(calls[0].0.ends_with("krew-linux_amd64"), "bootstrap ran the extracted binary");
+        assert_eq!(calls[0].1, vec!["install", "krew"]);
+    }
+
+    #[test]
+    fn install_krew_does_not_bootstrap_a_tampered_archive() {
+        use std::cell::Cell;
+        let dir = tempfile::tempdir().unwrap();
+        let plan = krew_archive("v0.5.0", &Platform { os: "linux", arch: "amd64" }, dir.path());
+        let archive = make_targz(&[(plan.member.as_str(), b"payload")]);
+        let fetch = net(&[
+            (plan.sha256_url.as_str(), sha256_hex(b"other").as_bytes()),
+            (plan.archive_url.as_str(), &archive),
+        ]);
+        let ran = Cell::new(false);
+        let run = |_bin: &Path, _args: &[&str]| {
+            ran.set(true);
+            Ok(())
+        };
+        assert!(matches!(
+            install_krew(&plan, &fetch, &run),
+            Err(InstallError::ChecksumMismatch { .. })
+        ));
+        assert!(!ran.get(), "must not bootstrap when the archive fails verification");
     }
 
     #[test]


### PR DESCRIPTION
Slice 9 of #55. **Stacked on #123** (base `feat/toolbox-status-capability`); GitHub retargets to `dev` once #123 lands.

Completes the managed-tool install trio (kubectl, helm, krew).

## What's different about krew

Unlike kubectl/helm, the extracted krew binary is **transient**: after download + verify + extract it's run once as `krew install krew` to bootstrap krew into `~/.krew`, rather than kept in `~/.srelens/bin`. So `install_krew` reuses `install_from_targz` for the download/verify/extract and then runs the bootstrap via an **injected command runner** — the same pattern the upcoming plugin ops (install/upgrade/remove) will reuse. Confirm-gated (`Annotations::MUTATING`).

Also made `extract_member` tolerant of a leading `./` on tar entries (krew's tar prefixes members with `./`, helm's doesn't).

## Testing

- TDD: `install_krew` (extract-then-bootstrap with a recording runner; a tampered archive is **never** bootstrapped — checksum fails first), the krew plan, `./`-prefix extraction, and the capability (resolves latest → downloads → verifies → bootstraps; confirm-gating). Both `fetch` and `run` injected, so it's deterministic.
- **Excluded from the kind e2e suite** (real GitHub download + bootstrap subprocess), like the other installs.
- Grounded against the live release: `./krew-<os>_<arch>` tar layout, bare-hex `.sha256`, GitHub latest tag. kube 237 green, app MCP completeness green, clippy clean.

## Next

`toolbox.searchPlugins` (krew index) + the plugin ops (`installPlugin` / `upgradePlugin` / `removePlugin`, reusing the injected runner), then the streaming `start_tool_install` command and the Toolbox page.