### PR TITLE
feat(toolbox): krew plugin ops — search/install/upgrade/remove (slice 10)

### DIFF
--- a/apps/desktop/src-tauri/src/capabilities.rs
+++ b/apps/desktop/src-tauri/src/capabilities.rs
@@ -69,6 +69,24 @@ fn run_tool(
     }
 }
 
+/// Run `kubectl-krew` with args, returning stdout (or stderr as an error).
+/// Prefers the krew shim under `~/.krew/bin`, falling back to PATH. Called
+/// inside spawn_blocking by the plugin capabilities.
+fn run_krew(args: &[&str]) -> Result<String, srelens_kube::toolbox_install::InstallError> {
+    use srelens_kube::toolbox_install::InstallError;
+    let shim = srelens_kube::toolbox::krew_bin_dir().join("kubectl-krew");
+    let bin = if shim.is_file() { shim } else { std::path::PathBuf::from("kubectl-krew") };
+    let output = std::process::Command::new(bin)
+        .args(args)
+        .output()
+        .map_err(|e| InstallError::Download(e.to_string()))?;
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    } else {
+        Err(InstallError::Download(String::from_utf8_lossy(&output.stderr).into_owned()))
+    }
+}
+
 /// Probe a managed tool's version by running it and scanning for a semver.
 /// Each tool prints its version differently, so we pass tool-specific flags and
 /// let `first_semver` pull the `vX.Y.Z` out of whatever text comes back.
@@ -135,6 +153,10 @@ pub fn build_registry_with(cache: Arc<ClientCache>) -> Registry {
         |path| path.is_file(),
         tool_version,
     ));
+    reg.register(srelens_kube::toolbox::search_plugins_capability(run_krew));
+    reg.register(srelens_kube::toolbox::install_plugin_capability(run_krew));
+    reg.register(srelens_kube::toolbox::upgrade_plugin_capability(run_krew));
+    reg.register(srelens_kube::toolbox::remove_plugin_capability(run_krew));
 
     reg.register(srelens_kube::connect::cluster_info_capability(
         cache.clone(),

--- a/apps/desktop/src-tauri/tests/e2e.rs
+++ b/apps/desktop/src-tauri/tests/e2e.rs
@@ -165,6 +165,13 @@ const EXCLUDED: &[(&str, &str)] = &[
         "downloads krew from GitHub and runs its bootstrap subprocess to populate ~/.krew; \
          covered by unit tests with an injected fetch and command runner instead of the network in CI",
     ),
+    // The plugin ops shell out to kubectl-krew, which isn't installed in the kind
+    // CI image; unit-tested with an injected runner. Real krew + a small-plugin
+    // install is the integration test deferred to the kind-CI work in the spec.
+    ("toolbox.searchPlugins", "requires krew installed (not in the CI image); unit-tested with an injected runner"),
+    ("toolbox.installPlugin", "requires krew installed (not in the CI image); unit-tested with an injected runner"),
+    ("toolbox.upgradePlugin", "requires krew installed (not in the CI image); unit-tested with an injected runner"),
+    ("toolbox.removePlugin", "requires krew installed (not in the CI image); unit-tested with an injected runner"),
 ];
 
 fn deadline(secs: u64) -> Instant {

--- a/apps/desktop/src/lib/toolbox.test.ts
+++ b/apps/desktop/src/lib/toolbox.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  toolboxStatus,
+  diagnoseContext,
+  searchPlugins,
+  installKubectl,
+  installHelm,
+  installKrew,
+  installPlugin,
+  upgradePlugin,
+  removePlugin,
+} from "./toolbox";
+
+describe("toolbox lib wrappers", () => {
+  it("toolboxStatus unwraps the tools array", async () => {
+    const invoke = vi.fn().mockResolvedValue({ tools: [{ name: "kubectl", installed: true }] });
+    const r = await toolboxStatus(invoke);
+    expect(invoke).toHaveBeenCalledWith("toolbox.status", {});
+    expect(r.data).toEqual([{ name: "kubectl", installed: true }]);
+  });
+
+  it("diagnoseContext passes the context and returns the report", async () => {
+    const report = { context: "dev", items: [] };
+    const invoke = vi.fn().mockResolvedValue(report);
+    const r = await diagnoseContext("dev", invoke);
+    expect(invoke).toHaveBeenCalledWith("toolbox.diagnoseContext", { context: "dev" });
+    expect(r.data).toEqual(report);
+  });
+
+  it("searchPlugins passes the query and unwraps plugins", async () => {
+    const invoke = vi.fn().mockResolvedValue({ plugins: [{ name: "oidc-login", description: "", installed: false }] });
+    const r = await searchPlugins("oidc", invoke);
+    expect(invoke).toHaveBeenCalledWith("toolbox.searchPlugins", { query: "oidc" });
+    expect(r.data?.[0].name).toBe("oidc-login");
+  });
+
+  it.each([
+    ["installKubectl", installKubectl, "toolbox.installKubectl"],
+    ["installHelm", installHelm, "toolbox.installHelm"],
+    ["installKrew", installKrew, "toolbox.installKrew"],
+  ] as const)("%s invokes %s with no args", async (_name, fn, id) => {
+    const invoke = vi.fn().mockResolvedValue({ tool: "x", version: "v1", path: "/p" });
+    const r = await fn(invoke);
+    expect(invoke).toHaveBeenCalledWith(id, {});
+    expect(r.data?.version).toBe("v1");
+  });
+
+  it.each([
+    ["installPlugin", installPlugin, "toolbox.installPlugin"],
+    ["upgradePlugin", upgradePlugin, "toolbox.upgradePlugin"],
+    ["removePlugin", removePlugin, "toolbox.removePlugin"],
+  ] as const)("%s passes the plugin name to %s", async (_name, fn, id) => {
+    const invoke = vi.fn().mockResolvedValue({ plugin: "oidc-login", output: "ok" });
+    const r = await fn("oidc-login", invoke);
+    expect(invoke).toHaveBeenCalledWith(id, { plugin: "oidc-login" });
+    expect(r.data?.plugin).toBe("oidc-login");
+  });
+
+  it("maps a thrown error into the result", async () => {
+    const invoke = vi.fn().mockRejectedValue(new Error("krew not found"));
+    const r = await installKrew(invoke);
+    expect(r.error).toContain("krew not found");
+    expect(r.data).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/lib/toolbox.ts
+++ b/apps/desktop/src/lib/toolbox.ts
@@ -1,0 +1,113 @@
+import { invokeCapability, type Invoker } from "../transport/transport";
+
+// Types mirror the Rust DTOs in crates/kube/src/toolbox.rs.
+
+/** A managed CLI tool's inventory entry (Toolbox "Tools" section). */
+export interface ToolStatus {
+  name: string;
+  installed: boolean;
+  path?: string | null;
+  version?: string | null;
+  /** "managed" (srelens installed it) or "system". */
+  source?: string | null;
+}
+
+export type RequirementKind = "kubectl" | "krew-plugin" | "external";
+export type RequirementStatus = "found" | "not-on-app-path" | "missing";
+
+/** One exec-auth requirement of a context, resolved. */
+export interface RequirementResult {
+  binary: string;
+  kind: RequirementKind;
+  plugin?: string | null;
+  installable: boolean;
+  status: RequirementStatus;
+  path?: string | null;
+  version?: string | null;
+}
+
+export interface DiagnosisReport {
+  context: string;
+  items: RequirementResult[];
+}
+
+/** Result of a tool install. */
+export interface InstallResult {
+  tool: string;
+  version: string;
+  path: string;
+}
+
+/** A krew index entry. */
+export interface Plugin {
+  name: string;
+  description: string;
+  installed: boolean;
+}
+
+export interface PluginActionResult {
+  plugin: string;
+  output: string;
+}
+
+/** Result wrappers keep the try/catch out of components (mirrors lib/helm.ts). */
+type Result<T> = { data?: T; error?: string };
+
+async function call<T>(run: () => Promise<T>): Promise<Result<T>> {
+  try {
+    return { data: await run() };
+  } catch (e) {
+    return { error: String(e) };
+  }
+}
+
+/** Inventory the managed toolchain (kubectl, krew, helm). */
+export function toolboxStatus(invoke: Invoker = invokeCapability): Promise<Result<ToolStatus[]>> {
+  return call(async () => (await invoke<{ tools: ToolStatus[] }>("toolbox.status", {})).tools);
+}
+
+/** Diagnose a context's exec-auth tool requirements. */
+export function diagnoseContext(
+  context: string,
+  invoke: Invoker = invokeCapability,
+): Promise<Result<DiagnosisReport>> {
+  return call(() => invoke<DiagnosisReport>("toolbox.diagnoseContext", { context }));
+}
+
+/** Search the krew plugin index. */
+export function searchPlugins(
+  query: string,
+  invoke: Invoker = invokeCapability,
+): Promise<Result<Plugin[]>> {
+  return call(async () => (await invoke<{ plugins: Plugin[] }>("toolbox.searchPlugins", { query })).plugins);
+}
+
+const installTool = (id: string, invoke: Invoker) =>
+  call(() => invoke<InstallResult>(id, {}));
+
+/** Install the latest stable kubectl into ~/.srelens/bin. */
+export const installKubectl = (invoke: Invoker = invokeCapability) =>
+  installTool("toolbox.installKubectl", invoke);
+
+/** Install the latest helm into ~/.srelens/bin. */
+export const installHelm = (invoke: Invoker = invokeCapability) =>
+  installTool("toolbox.installHelm", invoke);
+
+/** Bootstrap krew into ~/.krew. */
+export const installKrew = (invoke: Invoker = invokeCapability) =>
+  installTool("toolbox.installKrew", invoke);
+
+const pluginAction = (id: string, plugin: string, invoke: Invoker) =>
+  call(() => invoke<PluginActionResult>(id, { plugin }));
+
+/** Install a krew plugin. */
+export const installPlugin = (plugin: string, invoke: Invoker = invokeCapability) =>
+  pluginAction("toolbox.installPlugin", plugin, invoke);
+
+/** Upgrade an installed krew plugin. */
+export const upgradePlugin = (plugin: string, invoke: Invoker = invokeCapability) =>
+  pluginAction("toolbox.upgradePlugin", plugin, invoke);
+
+/** Remove an installed krew plugin. */
+export const removePlugin = (plugin: string, invoke: Invoker = invokeCapability) =>
+  pluginAction("toolbox.removePlugin", plugin, invoke);

--- a/crates/kube/src/toolbox.rs
+++ b/crates/kube/src/toolbox.rs
@@ -649,6 +649,179 @@ where
     )
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SearchPluginsIn {
+    /// Substring to search the krew index for.
+    pub query: String,
+}
+
+/// One krew index entry.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct PluginDto {
+    pub name: String,
+    pub description: String,
+    pub installed: bool,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct SearchPluginsOut {
+    pub plugins: Vec<PluginDto>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct PluginIn {
+    /// The krew plugin name (e.g. `oidc-login`).
+    pub plugin: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct PluginActionOut {
+    pub plugin: String,
+    /// krew's own output from the operation.
+    pub output: String,
+}
+
+/// Parse `kubectl krew search` output — a padded `NAME  DESCRIPTION  INSTALLED`
+/// table — into plugin rows. Lines before the header are skipped.
+pub fn parse_krew_search(stdout: &str) -> Vec<PluginDto> {
+    stdout
+        .lines()
+        .skip_while(|line| !line.trim_start().starts_with("NAME"))
+        .skip(1)
+        .filter(|line| !line.trim().is_empty())
+        .filter_map(parse_search_row)
+        .collect()
+}
+
+fn parse_search_row(line: &str) -> Option<PluginDto> {
+    let name = line.split_whitespace().next()?.to_string();
+    let installed_token = line.split_whitespace().next_back()?;
+    let installed = installed_token.eq_ignore_ascii_case("yes");
+    // Description is what's between the name and the trailing INSTALLED column.
+    let mid = line.trim();
+    let mid = mid.strip_prefix(&name).unwrap_or(mid).trim_start();
+    let description = mid.strip_suffix(installed_token).unwrap_or(mid).trim().to_string();
+    Some(PluginDto { name, description, installed })
+}
+
+/// Read-only capability: search the krew plugin index. `run` executes
+/// `kubectl-krew <args>` and returns its stdout (injected for testing).
+pub fn search_plugins_capability<R>(run: R) -> Capability
+where
+    R: Fn(&[&str]) -> Result<String, InstallError> + Send + Sync + Clone + 'static,
+{
+    Capability::typed::<SearchPluginsIn, SearchPluginsOut, _, _>(
+        "toolbox.searchPlugins",
+        "search the krew index for kubectl plugins (name, description, installed)",
+        Annotations::READ_ONLY,
+        move |input: SearchPluginsIn| {
+            let run = run.clone();
+            async move {
+                tokio::task::spawn_blocking(move || {
+                    let out = run(&["search", input.query.as_str()]).map_err(to_handler)?;
+                    Ok(SearchPluginsOut { plugins: parse_krew_search(&out) })
+                })
+                .await
+                .map_err(|e| CapabilityError::Handler(e.to_string()))?
+            }
+        },
+    )
+}
+
+/// Shared builder for the confirm-gated plugin mutations (install / upgrade /
+/// uninstall), which differ only in the krew subcommand.
+fn plugin_action_capability<R>(
+    id: &'static str,
+    summary: &'static str,
+    verb: &'static str,
+    run: R,
+) -> Capability
+where
+    R: Fn(&[&str]) -> Result<String, InstallError> + Send + Sync + Clone + 'static,
+{
+    Capability::typed::<PluginIn, PluginActionOut, _, _>(
+        id,
+        summary,
+        Annotations::MUTATING,
+        move |input: PluginIn| {
+            let run = run.clone();
+            async move {
+                tokio::task::spawn_blocking(move || {
+                    let output = run(&[verb, input.plugin.as_str()]).map_err(to_handler)?;
+                    Ok(PluginActionOut { plugin: input.plugin, output })
+                })
+                .await
+                .map_err(|e| CapabilityError::Handler(e.to_string()))?
+            }
+        },
+    )
+}
+
+pub fn install_plugin_capability<R>(run: R) -> Capability
+where
+    R: Fn(&[&str]) -> Result<String, InstallError> + Send + Sync + Clone + 'static,
+{
+    plugin_action_capability(
+        "toolbox.installPlugin",
+        "install a kubectl plugin from the krew index",
+        "install",
+        run,
+    )
+}
+
+pub fn upgrade_plugin_capability<R>(run: R) -> Capability
+where
+    R: Fn(&[&str]) -> Result<String, InstallError> + Send + Sync + Clone + 'static,
+{
+    plugin_action_capability(
+        "toolbox.upgradePlugin",
+        "upgrade an installed krew plugin",
+        "upgrade",
+        run,
+    )
+}
+
+pub fn remove_plugin_capability<R>(run: R) -> Capability
+where
+    R: Fn(&[&str]) -> Result<String, InstallError> + Send + Sync + Clone + 'static,
+{
+    plugin_action_capability(
+        "toolbox.removePlugin",
+        "remove an installed krew plugin",
+        "uninstall",
+        run,
+    )
+}
+
+#[cfg(test)]
+mod plugin_tests {
+    use super::*;
+
+    const SAMPLE: &str = "\
+NAME            DESCRIPTION                              INSTALLED
+access-matrix   Show an RBAC access matrix               no
+oidc-login      Log in to the cluster via OIDC           yes
+";
+
+    #[test]
+    fn parse_krew_search_reads_name_description_and_installed() {
+        let plugins = parse_krew_search(SAMPLE);
+        assert_eq!(plugins.len(), 2);
+        assert_eq!(plugins[0].name, "access-matrix");
+        assert_eq!(plugins[0].description, "Show an RBAC access matrix");
+        assert!(!plugins[0].installed);
+        assert_eq!(plugins[1].name, "oidc-login");
+        assert_eq!(plugins[1].description, "Log in to the cluster via OIDC");
+        assert!(plugins[1].installed);
+    }
+
+    #[test]
+    fn parse_krew_search_is_empty_without_rows() {
+        assert!(parse_krew_search("").is_empty());
+        assert!(parse_krew_search("NAME  DESCRIPTION  INSTALLED\n").is_empty());
+    }
+}
+
 #[cfg(test)]
 mod capability_tests {
     use super::*;
@@ -856,6 +1029,58 @@ users:
             |_b: &Path, _a: &[&str]| Ok(()),
         );
         assert!(cap.annotations.requires_confirm);
+    }
+
+    #[tokio::test]
+    async fn search_plugins_runs_krew_search_and_parses_results() {
+        let run = |args: &[&str]| {
+            assert_eq!(args, ["search", "oidc"]);
+            Ok("NAME        DESCRIPTION       INSTALLED\noidc-login  OIDC login        yes\n".to_string())
+        };
+        let mut reg = Registry::new();
+        reg.register(search_plugins_capability(run));
+        let out = reg.invoke("toolbox.searchPlugins", json!({ "query": "oidc" })).await.unwrap();
+        let plugins = out["plugins"].as_array().unwrap();
+        assert_eq!(plugins.len(), 1);
+        assert_eq!(plugins[0]["name"], "oidc-login");
+        assert_eq!(plugins[0]["installed"], true);
+    }
+
+    #[tokio::test]
+    async fn install_plugin_runs_krew_install_and_is_confirm_gated() {
+        use std::sync::{Arc, Mutex};
+        let seen: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = seen.clone();
+        let run = move |args: &[&str]| {
+            sink.lock().unwrap().extend(args.iter().map(|s| s.to_string()));
+            Ok("Installed plugin: oidc-login".to_string())
+        };
+        let cap = install_plugin_capability(run);
+        assert!(cap.annotations.requires_confirm);
+
+        let mut reg = Registry::new();
+        reg.register(cap);
+        let out = reg
+            .invoke("toolbox.installPlugin", json!({ "plugin": "oidc-login" }))
+            .await
+            .unwrap();
+        assert_eq!(out["plugin"], "oidc-login");
+        assert_eq!(*seen.lock().unwrap(), vec!["install", "oidc-login"]);
+    }
+
+    #[tokio::test]
+    async fn remove_plugin_uses_the_uninstall_verb() {
+        use std::sync::{Arc, Mutex};
+        let seen: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = seen.clone();
+        let run = move |args: &[&str]| {
+            sink.lock().unwrap().extend(args.iter().map(|s| s.to_string()));
+            Ok(String::new())
+        };
+        let mut reg = Registry::new();
+        reg.register(remove_plugin_capability(run));
+        reg.invoke("toolbox.removePlugin", json!({ "plugin": "oidc-login" })).await.unwrap();
+        assert_eq!(*seen.lock().unwrap(), vec!["uninstall", "oidc-login"]);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Slice 10 of #55. **Stacked on #124** (base `feat/toolbox-install-krew`); retargets to `dev` once the chain lands.

Completes the plugin-management capabilities, all driving `kubectl-krew` through an injected runner:

- **`toolbox.searchPlugins`** (read-only) — searches the krew index. `parse_krew_search` turns krew's padded `NAME/DESCRIPTION/INSTALLED` table into rows.
- **`toolbox.installPlugin` / `upgradePlugin` / `removePlugin`** (confirm-gated) — one shared builder parameterised by the krew verb (`install` / `upgrade` / `uninstall`).

## Design

The runner (`Fn(&[&str]) -> Result<String>`) is injected, so the capabilities are unit-tested with a fake that asserts the exact krew args and returns canned output. Production runs the `~/.krew/bin/kubectl-krew` shim (falling back to PATH).

## Testing

- TDD: the padded-table parser (2 rows + negatives), `searchPlugins` (asserts `["search", query]` args + parsed result), `installPlugin` (asserts `["install", name]` + confirm-gated), `removePlugin` (asserts the `uninstall` verb).
- **All four excluded from the kind e2e suite** with a reason — krew isn't in the CI image. Real krew + small-plugin install is the integration test the spec defers to the kind-CI work.
- kube 242 green, app MCP completeness green, clippy clean.

## Next

The streaming `start_tool_install` Tauri command (download progress via `toolbox://progress`) and the frontend Toolbox page — the backend capability surface is now complete (diagnose, status, three tool installs, four plugin ops).