### PR TITLE
feat(toolbox): the Toolbox frontend — lib, page, and shell integration

### DIFF
--- a/apps/desktop/src/lib/toolbox.test.ts
+++ b/apps/desktop/src/lib/toolbox.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  toolboxStatus,
+  diagnoseContext,
+  searchPlugins,
+  installKubectl,
+  installHelm,
+  installKrew,
+  installPlugin,
+  upgradePlugin,
+  removePlugin,
+} from "./toolbox";
+
+describe("toolbox lib wrappers", () => {
+  it("toolboxStatus unwraps the tools array", async () => {
+    const invoke = vi.fn().mockResolvedValue({ tools: [{ name: "kubectl", installed: true }] });
+    const r = await toolboxStatus(invoke);
+    expect(invoke).toHaveBeenCalledWith("toolbox.status", {});
+    expect(r.data).toEqual([{ name: "kubectl", installed: true }]);
+  });
+
+  it("diagnoseContext passes the context and returns the report", async () => {
+    const report = { context: "dev", items: [] };
+    const invoke = vi.fn().mockResolvedValue(report);
+    const r = await diagnoseContext("dev", invoke);
+    expect(invoke).toHaveBeenCalledWith("toolbox.diagnoseContext", { context: "dev" });
+    expect(r.data).toEqual(report);
+  });
+
+  it("searchPlugins passes the query and unwraps plugins", async () => {
+    const invoke = vi.fn().mockResolvedValue({ plugins: [{ name: "oidc-login", description: "", installed: false }] });
+    const r = await searchPlugins("oidc", invoke);
+    expect(invoke).toHaveBeenCalledWith("toolbox.searchPlugins", { query: "oidc" });
+    expect(r.data?.[0].name).toBe("oidc-login");
+  });
+
+  it.each([
+    ["installKubectl", installKubectl, "toolbox.installKubectl"],
+    ["installHelm", installHelm, "toolbox.installHelm"],
+    ["installKrew", installKrew, "toolbox.installKrew"],
+  ] as const)("%s invokes %s with no args", async (_name, fn, id) => {
+    const invoke = vi.fn().mockResolvedValue({ tool: "x", version: "v1", path: "/p" });
+    const r = await fn(invoke);
+    expect(invoke).toHaveBeenCalledWith(id, {});
+    expect(r.data?.version).toBe("v1");
+  });
+
+  it.each([
+    ["installPlugin", installPlugin, "toolbox.installPlugin"],
+    ["upgradePlugin", upgradePlugin, "toolbox.upgradePlugin"],
+    ["removePlugin", removePlugin, "toolbox.removePlugin"],
+  ] as const)("%s passes the plugin name to %s", async (_name, fn, id) => {
+    const invoke = vi.fn().mockResolvedValue({ plugin: "oidc-login", output: "ok" });
+    const r = await fn("oidc-login", invoke);
+    expect(invoke).toHaveBeenCalledWith(id, { plugin: "oidc-login" });
+    expect(r.data?.plugin).toBe("oidc-login");
+  });
+
+  it("maps a thrown error into the result", async () => {
+    const invoke = vi.fn().mockRejectedValue(new Error("krew not found"));
+    const r = await installKrew(invoke);
+    expect(r.error).toContain("krew not found");
+    expect(r.data).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/lib/toolbox.ts
+++ b/apps/desktop/src/lib/toolbox.ts
@@ -1,0 +1,113 @@
+import { invokeCapability, type Invoker } from "../transport/transport";
+
+// Types mirror the Rust DTOs in crates/kube/src/toolbox.rs.
+
+/** A managed CLI tool's inventory entry (Toolbox "Tools" section). */
+export interface ToolStatus {
+  name: string;
+  installed: boolean;
+  path?: string | null;
+  version?: string | null;
+  /** "managed" (srelens installed it) or "system". */
+  source?: string | null;
+}
+
+export type RequirementKind = "kubectl" | "krew-plugin" | "external";
+export type RequirementStatus = "found" | "not-on-app-path" | "missing";
+
+/** One exec-auth requirement of a context, resolved. */
+export interface RequirementResult {
+  binary: string;
+  kind: RequirementKind;
+  plugin?: string | null;
+  installable: boolean;
+  status: RequirementStatus;
+  path?: string | null;
+  version?: string | null;
+}
+
+export interface DiagnosisReport {
+  context: string;
+  items: RequirementResult[];
+}
+
+/** Result of a tool install. */
+export interface InstallResult {
+  tool: string;
+  version: string;
+  path: string;
+}
+
+/** A krew index entry. */
+export interface Plugin {
+  name: string;
+  description: string;
+  installed: boolean;
+}
+
+export interface PluginActionResult {
+  plugin: string;
+  output: string;
+}
+
+/** Result wrappers keep the try/catch out of components (mirrors lib/helm.ts). */
+type Result<T> = { data?: T; error?: string };
+
+async function call<T>(run: () => Promise<T>): Promise<Result<T>> {
+  try {
+    return { data: await run() };
+  } catch (e) {
+    return { error: String(e) };
+  }
+}
+
+/** Inventory the managed toolchain (kubectl, krew, helm). */
+export function toolboxStatus(invoke: Invoker = invokeCapability): Promise<Result<ToolStatus[]>> {
+  return call(async () => (await invoke<{ tools: ToolStatus[] }>("toolbox.status", {})).tools);
+}
+
+/** Diagnose a context's exec-auth tool requirements. */
+export function diagnoseContext(
+  context: string,
+  invoke: Invoker = invokeCapability,
+): Promise<Result<DiagnosisReport>> {
+  return call(() => invoke<DiagnosisReport>("toolbox.diagnoseContext", { context }));
+}
+
+/** Search the krew plugin index. */
+export function searchPlugins(
+  query: string,
+  invoke: Invoker = invokeCapability,
+): Promise<Result<Plugin[]>> {
+  return call(async () => (await invoke<{ plugins: Plugin[] }>("toolbox.searchPlugins", { query })).plugins);
+}
+
+const installTool = (id: string, invoke: Invoker) =>
+  call(() => invoke<InstallResult>(id, {}));
+
+/** Install the latest stable kubectl into ~/.srelens/bin. */
+export const installKubectl = (invoke: Invoker = invokeCapability) =>
+  installTool("toolbox.installKubectl", invoke);
+
+/** Install the latest helm into ~/.srelens/bin. */
+export const installHelm = (invoke: Invoker = invokeCapability) =>
+  installTool("toolbox.installHelm", invoke);
+
+/** Bootstrap krew into ~/.krew. */
+export const installKrew = (invoke: Invoker = invokeCapability) =>
+  installTool("toolbox.installKrew", invoke);
+
+const pluginAction = (id: string, plugin: string, invoke: Invoker) =>
+  call(() => invoke<PluginActionResult>(id, { plugin }));
+
+/** Install a krew plugin. */
+export const installPlugin = (plugin: string, invoke: Invoker = invokeCapability) =>
+  pluginAction("toolbox.installPlugin", plugin, invoke);
+
+/** Upgrade an installed krew plugin. */
+export const upgradePlugin = (plugin: string, invoke: Invoker = invokeCapability) =>
+  pluginAction("toolbox.upgradePlugin", plugin, invoke);
+
+/** Remove an installed krew plugin. */
+export const removePlugin = (plugin: string, invoke: Invoker = invokeCapability) =>
+  pluginAction("toolbox.removePlugin", plugin, invoke);


### PR DESCRIPTION
The complete Toolbox frontend for #55 — the remaining UI on top of the backend capability surface (#116–#125). **Stacked on #125** (base `feat/toolbox-plugin-ops`); retargets to `dev` as the backend chain lands.

## What's here

**`lib/toolbox.ts`** — typed wrappers over the whole capability surface (status, diagnose, search, three installs, three plugin ops), following the `lib/helm.ts` convention (injectable `Invoker`, `{ data?, error? }` results, types mirroring the Rust DTOs).

**`ToolboxView`** — the page, three sections:
- **Tools** — kubectl / krew / helm cards showing version, a managed/system source badge, and an install button for missing tools.
- **Plugins** — search the krew index; install (with a confirm dialog carrying krew's third-party-plugin caveat) / remove per row.
- **Context health** — per-context exec-auth diagnosis, with one-click fixes for a missing kubectl or krew plugin, and a "install X yourself" hint for cloud CLIs.

**Shell integration** — `toolbox` registered as a non-cluster page-kind (ResourceKind + label + K8S_KIND + `Wrench` nav icon), opened from a global wrench button in the ClusterHotbar (beside settings), the command palette ("Go to Toolbox"), and a new `openToolbox()` opener in `App`.

**Deep-link** — exec-auth connection failures now classify as "Auth plugin couldn't run" (`isExecAuthError`), and the cluster overview's error offers **"Diagnose in Toolbox"**, opening the page pre-diagnosed on that context (`ErrorState` gained an optional secondary action).

## Testing

TDD throughout: `lib/toolbox` wrappers (10), `ToolboxView` (tools install+refresh, plugin search+confirmed install, deep-linked diagnosis + one-click fix), and `isExecAuthError`/`describeError`. Found and fixed a real API mismatch along the way (`TextInput` takes `onValueChange`, not `onChange`). Full frontend suite **544 green**; `tsc` clean apart from the repo's pre-existing `@types/node` env warning.

## Deferred (one item)

Streaming install progress — the spec's `start_tool_install` Tauri command emitting `toolbox://progress`. Installs currently run as plain await-capabilities with a spinner, which is fully functional; live download progress is a polish follow-up and doesn't block the page.