### PR TITLE
fix(toolbox): recover the Toolbox page + shell wiring lost in the stacked merge

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -17,6 +17,7 @@ import { HelmReleasesView } from "./components/HelmReleasesView";
 import { NewResourceEditor } from "./components/NewResourceEditor";
 import { EditResourceTab } from "./components/EditResourceTab";
 import { SettingsView } from "./components/SettingsView";
+import { ToolboxView } from "./components/ToolboxView";
 import { CommandPalette } from "./components/CommandPalette";
 import { Toaster } from "./components/ui/sonner";
 import { Dock, type DockSession, type DockKind } from "./components/Dock";
@@ -96,6 +97,8 @@ export function App() {
   // nonce bumps to remount SettingsView at the requested section when asked.
   const [settingsInitialSection, setSettingsInitialSection] = useState<SettingsSection>("appearance");
   const [settingsSectionNonce, setSettingsSectionNonce] = useState(0);
+  // The context to pre-diagnose when the Toolbox opens via a "Diagnose" deep-link.
+  const [toolboxContext, setToolboxContext] = useState<string | null>(null);
 
   const [contexts, setContexts] = useState<ClusterContext[] | null>(null);
   const [contextsError, setContextsError] = useState("");
@@ -275,6 +278,10 @@ export function App() {
       openSettings();
       return;
     }
+    if (kind === "toolbox") {
+      openToolbox();
+      return;
+    }
     const existing = tabs.find((t) => t.cluster === cluster && t.kind === kind && !t.crd);
     if (existing) {
       setActiveTabId(existing.id);
@@ -301,6 +308,22 @@ export function App() {
     }
     const id = tabIdRef.current++;
     setTabs((ts) => [...ts, { id, cluster: null, kind: "settings" }]);
+    setActiveTabId(id);
+    setQuery("");
+  }
+
+  /** Open (or focus) the single workspace-level Toolbox tab. When `context` is
+   *  given (from a "Diagnose in Toolbox" deep-link), that context is
+   *  pre-diagnosed in the health section. */
+  function openToolbox(context?: string) {
+    setToolboxContext(context ?? null);
+    const existing = tabs.find((t) => t.kind === "toolbox" && !t.cluster);
+    if (existing) {
+      setActiveTabId(existing.id);
+      return;
+    }
+    const id = tabIdRef.current++;
+    setTabs((ts) => [...ts, { id, cluster: null, kind: "toolbox" }]);
     setActiveTabId(id);
     setQuery("");
   }
@@ -484,6 +507,7 @@ export function App() {
         theme={theme}
         onToggleTheme={toggleThemeMode}
         onOpenSettings={openSettings}
+        onOpenToolbox={openToolbox}
         contextProfiles={contextProfiles}
         kubeconfigFiles={kubeconfigFiles}
         contextOrder={contextOrder}
@@ -538,6 +562,8 @@ export function App() {
                       contextsError={contextsError}
                       onDeleteContext={handleDeleteContext}
                     />
+                  ) : activeKind === "toolbox" ? (
+                    <ToolboxView key={activeTab.id} initialContext={toolboxContext} />
                   ) : activeTab.crd && activeCluster ? (
                     <CustomResourceBrowser
                       key={activeTab.id}
@@ -553,6 +579,7 @@ export function App() {
                         key={activeTab.id}
                         context={activeCluster}
                         onOpenView={(kind) => openView(activeCluster, kind)}
+                        onDiagnose={() => openToolbox(activeCluster)}
                       />
                     </div>
                   ) : activeCluster && activeKind === "portforwards" ? (
@@ -674,7 +701,13 @@ export function App() {
         open={paletteOpen}
         onOpenChange={setPaletteOpen}
         context={activeCluster}
-        onOpenView={(kind) => (kind === "settings" ? openSettings() : activeCluster && openView(activeCluster, kind))}
+        onOpenView={(kind) =>
+          kind === "settings"
+            ? openSettings()
+            : kind === "toolbox"
+              ? openToolbox()
+              : activeCluster && openView(activeCluster, kind)
+        }
         onOpenResource={openResource}
         onOpenCrd={(crd) => activeCluster && openCrdView(activeCluster, crd)}
       />

--- a/apps/desktop/src/components/ClusterHotbar.tsx
+++ b/apps/desktop/src/components/ClusterHotbar.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Moon, Settings, Sun } from "lucide-react";
+import { Moon, Settings, Sun, Wrench } from "lucide-react";
 import { listContexts, type ClusterContext } from "../lib/clusters";
 import {
   type Theme,
@@ -19,6 +19,7 @@ export function ClusterHotbar({
   theme,
   onToggleTheme,
   onOpenSettings,
+  onOpenToolbox,
   contextProfiles = {},
   kubeconfigFiles = EMPTY_LIST,
   contextOrder = EMPTY_LIST,
@@ -29,6 +30,7 @@ export function ClusterHotbar({
   theme: Theme;
   onToggleTheme: () => void;
   onOpenSettings: () => void;
+  onOpenToolbox?: () => void;
   contextProfiles?: ContextProfiles;
   kubeconfigFiles?: string[];
   contextOrder?: string[];
@@ -88,6 +90,16 @@ export function ClusterHotbar({
       >
         {theme.mode === "dark" ? <Sun aria-hidden="true" /> : <Moon aria-hidden="true" />}
       </button>
+      {onOpenToolbox && (
+        <button
+          className="fl-hotbar__theme"
+          aria-label="Open toolbox"
+          title="Open toolbox"
+          onClick={onOpenToolbox}
+        >
+          <Wrench aria-hidden="true" />
+        </button>
+      )}
       <button
         className="fl-hotbar__theme"
         aria-label="Open settings"

--- a/apps/desktop/src/components/ClusterOverview.tsx
+++ b/apps/desktop/src/components/ClusterOverview.tsx
@@ -14,7 +14,7 @@ import {
   Spinner,
   StatusMeter,
 } from "../ui";
-import { describeError } from "../lib/errors";
+import { describeError, isExecAuthError } from "../lib/errors";
 import type { ResourceKind } from "./ResourceBrowser";
 
 interface Stats {
@@ -121,9 +121,12 @@ function percent(part: number, total: number) {
 export function ClusterOverview({
   context,
   onOpenView,
+  onDiagnose,
 }: {
   context: string;
   onOpenView?: (kind: ResourceKind) => void;
+  /** Open the Toolbox to diagnose this context (shown on exec-auth errors). */
+  onDiagnose?: () => void;
 }) {
   const initialSnapshot = overviewCache.get(context);
   const [stats, setStats] = useState<Stats | null>(() => initialSnapshot?.stats ?? null);
@@ -177,7 +180,18 @@ export function ClusterOverview({
 
   if (error && !stats) {
     const friendly = describeError(error);
-    return <ErrorState title={friendly.title} detail={friendly.detail} onRetry={refresh} />;
+    return (
+      <ErrorState
+        title={friendly.title}
+        detail={friendly.detail}
+        onRetry={refresh}
+        action={
+          onDiagnose && isExecAuthError(error)
+            ? { label: "Diagnose in Toolbox", onClick: onDiagnose }
+            : undefined
+        }
+      />
+    );
   }
   if (!stats) return <Spinner label="Loading overview" />;
 

--- a/apps/desktop/src/components/ResourceBrowser.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.tsx
@@ -117,6 +117,7 @@ export type ResourceKind =
   | "portforwards"
   | "helmreleases"
   | "settings"
+  | "toolbox"
   | "newresource"
   | "editresource";
 
@@ -160,6 +161,7 @@ export const RESOURCE_LABELS: Record<ResourceKind, string> = {
   portforwards: "Port Forwards",
   helmreleases: "Helm Releases",
   settings: "Settings",
+  toolbox: "Toolbox",
   newresource: "New Resource",
   editresource: "Edit Resource",
 };
@@ -204,6 +206,7 @@ export const K8S_KIND: Record<ResourceKind, string> = {
   portforwards: "",
   helmreleases: "",
   settings: "",
+  toolbox: "",
   newresource: "",
   editresource: "",
 };

--- a/apps/desktop/src/components/ToolboxView.test.tsx
+++ b/apps/desktop/src/components/ToolboxView.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+
+const toolbox = vi.hoisted(() => ({
+  toolboxStatus: vi.fn(),
+  diagnoseContext: vi.fn(),
+  searchPlugins: vi.fn(),
+  installKubectl: vi.fn(),
+  installHelm: vi.fn(),
+  installKrew: vi.fn(),
+  installPlugin: vi.fn(),
+  removePlugin: vi.fn(),
+  upgradePlugin: vi.fn(),
+}));
+vi.mock("../lib/toolbox", () => toolbox);
+vi.mock("../lib/clusters", () => ({
+  listContexts: vi.fn().mockResolvedValue({ contexts: [{ name: "dev" }] }),
+}));
+
+import { ToolboxView } from "./ToolboxView";
+
+beforeEach(() => {
+  Object.values(toolbox).forEach((m) => m.mockReset());
+  toolbox.toolboxStatus.mockResolvedValue({
+    data: [
+      { name: "kubectl", installed: true, version: "v1.30.2", source: "system", path: "/usr/bin/kubectl" },
+      { name: "krew", installed: false },
+      { name: "helm", installed: true, version: "v3.16.2", source: "managed", path: "/h/helm" },
+    ],
+  });
+  toolbox.searchPlugins.mockResolvedValue({ data: [] });
+  toolbox.diagnoseContext.mockResolvedValue({ data: { context: "dev", items: [] } });
+});
+
+describe("ToolboxView", () => {
+  it("lists managed tools with version and source, and installs a missing one", async () => {
+    toolbox.installKrew.mockResolvedValue({ data: { tool: "krew", version: "v0.5.0", path: "/k" } });
+    render(<ToolboxView />);
+
+    expect(await screen.findByText("v1.30.2")).toBeDefined();
+    expect(screen.getByText("v3.16.2")).toBeDefined();
+    // krew is missing → its Install button
+    fireEvent.click(screen.getByRole("button", { name: "Install krew" }));
+    await waitFor(() => expect(toolbox.installKrew).toHaveBeenCalled());
+    // status is refreshed after install
+    await waitFor(() => expect(toolbox.toolboxStatus).toHaveBeenCalledTimes(2));
+  });
+
+  it("searches the krew index and installs a plugin after confirmation", async () => {
+    toolbox.searchPlugins.mockResolvedValue({
+      data: [{ name: "oidc-login", description: "OIDC login", installed: false }],
+    });
+    toolbox.installPlugin.mockResolvedValue({ data: { plugin: "oidc-login", output: "ok" } });
+    render(<ToolboxView />);
+    await screen.findByText("v1.30.2");
+
+    fireEvent.change(screen.getByLabelText("Search krew plugins"), { target: { value: "oidc" } });
+    fireEvent.click(screen.getByRole("button", { name: /Search/ }));
+    expect(await screen.findByText("oidc-login")).toBeDefined();
+    expect(toolbox.searchPlugins).toHaveBeenCalledWith("oidc");
+
+    // Install → confirm dialog (krew third-party caveat) → confirm
+    fireEvent.click(screen.getByRole("button", { name: "Install" }));
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText(/community-maintained/)).toBeDefined();
+    fireEvent.click(within(dialog).getByRole("button", { name: "Install" }));
+    await waitFor(() => expect(toolbox.installPlugin).toHaveBeenCalledWith("oidc-login"));
+  });
+
+  it("diagnoses a context and offers a one-click fix for a missing krew plugin", async () => {
+    toolbox.diagnoseContext.mockResolvedValue({
+      data: {
+        context: "dev",
+        items: [
+          { binary: "kubectl", kind: "kubectl", installable: true, status: "found", path: "/usr/bin/kubectl" },
+          { binary: "kubectl-oidc_login", kind: "krew-plugin", plugin: "oidc-login", installable: true, status: "missing" },
+        ],
+      },
+    });
+    toolbox.installPlugin.mockResolvedValue({ data: { plugin: "oidc-login", output: "ok" } });
+    render(<ToolboxView initialContext="dev" />);
+
+    // Auto-diagnosed via initialContext deep-link.
+    expect(await screen.findByText("kubectl-oidc_login")).toBeDefined();
+    expect(screen.getByText("Missing")).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: "Install" }));
+    await waitFor(() => expect(toolbox.installPlugin).toHaveBeenCalledWith("oidc-login"));
+  });
+});

--- a/apps/desktop/src/components/ToolboxView.tsx
+++ b/apps/desktop/src/components/ToolboxView.tsx
@@ -1,0 +1,308 @@
+import { useEffect, useState } from "react";
+import { Download, RefreshCw, Search, Trash2, Wrench } from "lucide-react";
+import { Badge, Button, PageHeader, SectionPanel, Spinner, StatusPill, TextInput } from "../ui";
+import { ConfirmDialog } from "../ui/ConfirmDialog";
+import { listContexts } from "../lib/clusters";
+import {
+  diagnoseContext,
+  installHelm,
+  installKrew,
+  installKubectl,
+  installPlugin,
+  removePlugin,
+  searchPlugins,
+  toolboxStatus,
+  type DiagnosisReport,
+  type InstallResult,
+  type Plugin,
+  type RequirementStatus,
+  type ToolStatus,
+} from "../lib/toolbox";
+
+const TOOL_INSTALLERS: Record<string, () => Promise<{ data?: InstallResult; error?: string }>> = {
+  kubectl: installKubectl,
+  helm: installHelm,
+  krew: installKrew,
+};
+
+const STATUS_KIND: Record<RequirementStatus, "success" | "warning" | "danger"> = {
+  found: "success",
+  "not-on-app-path": "warning",
+  missing: "danger",
+};
+
+const STATUS_LABEL: Record<RequirementStatus, string> = {
+  found: "Found",
+  "not-on-app-path": "Not on app PATH",
+  missing: "Missing",
+};
+
+/** The top-level Toolbox page: manage the CLI toolchain and diagnose contexts. */
+export function ToolboxView({ initialContext }: { initialContext?: string | null }) {
+  const [tools, setTools] = useState<ToolStatus[] | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState("");
+
+  const refreshStatus = async () => {
+    const r = await toolboxStatus();
+    setTools(r.data ?? []);
+    setError(r.error ?? "");
+  };
+  useEffect(() => {
+    void refreshStatus();
+  }, []);
+
+  const runInstall = async (label: string, fn: () => Promise<{ error?: string }>) => {
+    setBusy(label);
+    const r = await fn();
+    if (r.error) setError(r.error);
+    await refreshStatus();
+    setBusy(null);
+  };
+
+  return (
+    <div className="fl-toolbox">
+      <PageHeader
+        eyebrow="Toolbox"
+        title="CLI toolchain"
+        description="Install and manage the kubectl toolchain srelens drives, and diagnose what each context needs."
+        actions={
+          <Button variant="ghost" onClick={() => void refreshStatus()} aria-label="Refresh">
+            <RefreshCw data-icon="inline-start" /> Refresh
+          </Button>
+        }
+      />
+
+      {error && (
+        <p className="fl-toolbox-error" role="alert">
+          {error}
+        </p>
+      )}
+
+      <SectionPanel title="Tools" description="kubectl, krew and helm. srelens installs into ~/.srelens/bin and never touches system installs.">
+        {tools === null ? (
+          <Spinner />
+        ) : (
+          <div className="fl-toolbox-tools">
+            {tools.map((tool) => (
+              <ToolCard key={tool.name} tool={tool} busy={busy === tool.name} onInstall={() =>
+                runInstall(tool.name, TOOL_INSTALLERS[tool.name] ?? (async () => ({})))
+              } />
+            ))}
+          </div>
+        )}
+      </SectionPanel>
+
+      <PluginsSection />
+
+      <ContextHealthSection initialContext={initialContext ?? null} onInstall={runInstall} busy={busy} />
+    </div>
+  );
+}
+
+function ToolCard({ tool, busy, onInstall }: { tool: ToolStatus; busy: boolean; onInstall: () => void }) {
+  return (
+    <div className="fl-toolbox-card">
+      <div className="fl-toolbox-card__head">
+        <Wrench aria-hidden="true" />
+        <strong>{tool.name}</strong>
+        {tool.installed && tool.source && (
+          <Badge variant={tool.source === "managed" ? "info" : "neutral"}>{tool.source}</Badge>
+        )}
+      </div>
+      {tool.installed ? (
+        <>
+          <p className="fl-toolbox-card__meta">
+            <code>{tool.version ?? "installed"}</code>
+          </p>
+          <small className="fl-toolbox-card__path">{tool.path}</small>
+        </>
+      ) : (
+        <>
+          <p className="fl-toolbox-card__meta">Not installed</p>
+          <Button onClick={onInstall} disabled={busy} aria-label={`Install ${tool.name}`}>
+            {busy ? <Spinner /> : <Download data-icon="inline-start" />} Install
+          </Button>
+        </>
+      )}
+    </div>
+  );
+}
+
+function PluginsSection() {
+  const [query, setQuery] = useState("");
+  const [plugins, setPlugins] = useState<Plugin[] | null>(null);
+  const [searching, setSearching] = useState(false);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [confirm, setConfirm] = useState<string | null>(null);
+  const [error, setError] = useState("");
+
+  const runSearch = async () => {
+    if (!query.trim()) return;
+    setSearching(true);
+    const r = await searchPlugins(query.trim());
+    setPlugins(r.data ?? []);
+    setError(r.error ?? "");
+    setSearching(false);
+  };
+
+  const doInstall = async (name: string) => {
+    setConfirm(null);
+    setBusy(name);
+    const r = await installPlugin(name);
+    if (r.error) setError(r.error);
+    await runSearch();
+    setBusy(null);
+  };
+
+  const doRemove = async (name: string) => {
+    setBusy(name);
+    const r = await removePlugin(name);
+    if (r.error) setError(r.error);
+    await runSearch();
+    setBusy(null);
+  };
+
+  return (
+    <SectionPanel title="Plugins" description="Search the krew index and install kubectl plugins.">
+      <form
+        className="fl-toolbox-search"
+        onSubmit={(e) => {
+          e.preventDefault();
+          void runSearch();
+        }}
+      >
+        <TextInput value={query} onValueChange={setQuery} onEnter={() => void runSearch()} type="search" placeholder="Search krew plugins…" aria-label="Search krew plugins" />
+        <Button type="submit" variant="secondary" disabled={searching}>
+          {searching ? <Spinner /> : <Search data-icon="inline-start" />} Search
+        </Button>
+      </form>
+
+      {error && (
+        <p className="fl-toolbox-error" role="alert">
+          {error}
+        </p>
+      )}
+
+      {plugins?.length === 0 && <p className="fl-toolbox-empty">No plugins match “{query}”.</p>}
+
+      {plugins && plugins.length > 0 && (
+        <table className="fl-toolbox-plugins">
+          <tbody>
+            {plugins.map((p) => (
+              <tr key={p.name}>
+                <td>
+                  <strong>{p.name}</strong>
+                  <small>{p.description}</small>
+                </td>
+                <td className="fl-toolbox-plugins__action">
+                  {p.installed ? (
+                    <Button variant="ghost" onClick={() => void doRemove(p.name)} disabled={busy === p.name} aria-label={`Remove ${p.name}`}>
+                      {busy === p.name ? <Spinner /> : <Trash2 data-icon="inline-start" />} Remove
+                    </Button>
+                  ) : (
+                    <Button variant="secondary" onClick={() => setConfirm(p.name)} disabled={busy === p.name}>
+                      {busy === p.name ? <Spinner /> : <Download data-icon="inline-start" />} Install
+                    </Button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {confirm && (
+        <ConfirmDialog
+          title={`Install ${confirm}?`}
+          message="krew plugins are community-maintained and run with your kubectl. Only install plugins you trust."
+          confirmLabel="Install"
+          onConfirm={() => void doInstall(confirm)}
+          onCancel={() => setConfirm(null)}
+        />
+      )}
+    </SectionPanel>
+  );
+}
+
+function ContextHealthSection({
+  initialContext,
+  onInstall,
+  busy,
+}: {
+  initialContext: string | null;
+  onInstall: (label: string, fn: () => Promise<{ error?: string }>) => Promise<void>;
+  busy: string | null;
+}) {
+  const [contexts, setContexts] = useState<string[]>([]);
+  const [reports, setReports] = useState<Record<string, DiagnosisReport | "loading">>({});
+
+  useEffect(() => {
+    void listContexts().then((o) => setContexts((o.contexts ?? []).map((c) => c.name)));
+  }, []);
+
+  const diagnose = async (context: string) => {
+    setReports((r) => ({ ...r, [context]: "loading" }));
+    const out = await diagnoseContext(context);
+    if (out.data) setReports((r) => ({ ...r, [context]: out.data! }));
+  };
+
+  useEffect(() => {
+    if (initialContext) void diagnose(initialContext);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialContext]);
+
+  return (
+    <SectionPanel title="Context health" description="Diagnose the exec-auth tools each context needs.">
+      {contexts.length === 0 && <p className="fl-toolbox-empty">No contexts loaded.</p>}
+      <ul className="fl-toolbox-contexts">
+        {contexts.map((ctx) => {
+          const report = reports[ctx];
+          return (
+            <li key={ctx} className="fl-toolbox-context">
+              <div className="fl-toolbox-context__head">
+                <span>{ctx}</span>
+                <Button variant="ghost" onClick={() => void diagnose(ctx)} disabled={report === "loading"}>
+                  {report === "loading" ? <Spinner /> : "Check"}
+                </Button>
+              </div>
+              {report && report !== "loading" && (
+                report.items.length === 0 ? (
+                  <StatusPill status="No external tools needed" kind="success" />
+                ) : (
+                  <ul className="fl-toolbox-reqs">
+                    {report.items.map((item) => (
+                      <li key={item.binary} className="fl-toolbox-req">
+                        <code>{item.binary}</code>
+                        <StatusPill status={STATUS_LABEL[item.status]} kind={STATUS_KIND[item.status]} />
+                        {item.status === "missing" && item.installable && (
+                          <Button
+                            variant="secondary"
+                            disabled={busy !== null}
+                            onClick={() =>
+                              onInstall(
+                                item.binary,
+                                item.kind === "kubectl"
+                                  ? installKubectl
+                                  : () => installPlugin(item.plugin ?? item.binary),
+                              )
+                            }
+                          >
+                            {busy === item.binary ? <Spinner /> : "Install"}
+                          </Button>
+                        )}
+                        {item.status === "missing" && !item.installable && (
+                          <small className="fl-toolbox-req__hint">install {item.binary} yourself</small>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                )
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </SectionPanel>
+  );
+}

--- a/apps/desktop/src/lib/errors.test.ts
+++ b/apps/desktop/src/lib/errors.test.ts
@@ -3,8 +3,26 @@ import {
   cleanErrorMessage,
   describeError,
   describeForbidden,
+  isExecAuthError,
   serviceAccountNamespace,
 } from "./errors";
+
+describe("isExecAuthError", () => {
+  it("matches exec credential plugin failures", () => {
+    expect(isExecAuthError("unable to run auth exec: no such file or directory")).toBe(true);
+    expect(isExecAuthError('exec: "kubectl-oidc_login": executable file not found in $PATH')).toBe(true);
+    expect(isExecAuthError("getting credentials: exec plugin failed")).toBe(true);
+  });
+  it("does not match unrelated errors", () => {
+    expect(isExecAuthError("connection refused")).toBe(false);
+    expect(isExecAuthError("Unauthorized")).toBe(false);
+  });
+  it("describeError surfaces the auth-plugin message", () => {
+    expect(describeError("unable to run auth exec: executable not found").title).toBe(
+      "Auth plugin couldn't run",
+    );
+  });
+});
 
 describe("cleanErrorMessage", () => {
   it("strips the internal handler-error prefix", () => {

--- a/apps/desktop/src/lib/errors.ts
+++ b/apps/desktop/src/lib/errors.ts
@@ -54,10 +54,29 @@ export function serviceAccountNamespace(error: string): string | null {
   return m ? m[1] : null;
 }
 
+/** True when an error looks like an exec-auth credential plugin failing to run
+ *  (a missing kubectl-oidc_login / aws / gke-gcloud-auth-plugin, etc.) — the
+ *  case the Toolbox diagnoses and can often fix. */
+export function isExecAuthError(input: unknown): boolean {
+  const lower = cleanErrorMessage(input).toLowerCase();
+  return /auth exec|exec plugin|getting credentials|executable .* not found|exec: .*not found|no such file or directory/.test(
+    lower,
+  );
+}
+
 /** Classify a raw error into a friendly, actionable message. */
 export function describeError(input: unknown): FriendlyError {
   const raw = cleanErrorMessage(input);
   const lower = raw.toLowerCase();
+
+  if (isExecAuthError(raw)) {
+    return {
+      title: "Auth plugin couldn't run",
+      detail:
+        "This context authenticates through an exec credential plugin (e.g. kubectl-oidc_login, aws, or gke-gcloud-auth-plugin) that couldn't be found or run. Open the Toolbox to see exactly which tool is missing and install it.",
+      raw,
+    };
+  }
 
   if (/timed out|timeout|deadline exceeded/.test(lower)) {
     return {

--- a/apps/desktop/src/ui/Dashboard.tsx
+++ b/apps/desktop/src/ui/Dashboard.tsx
@@ -126,21 +126,33 @@ export function ErrorState({
   detail,
   onRetry,
   retryLabel = "Retry",
+  action,
 }: {
   title: React.ReactNode;
   detail?: React.ReactNode;
   onRetry?: () => void;
   retryLabel?: string;
+  /** An optional secondary action (e.g. "Diagnose in Toolbox"). */
+  action?: { label: string; onClick: () => void };
 }) {
   return (
     <div className="fl-error-state" role="alert">
       <AlertTriangle className="fl-error-state__icon" aria-hidden />
       <strong className="fl-error-state__title">{title}</strong>
       {detail && <p className="fl-error-state__detail">{detail}</p>}
-      {onRetry && (
-        <Button variant="secondary" size="sm" onClick={onRetry}>
-          {retryLabel}
-        </Button>
+      {(onRetry || action) && (
+        <div className="fl-error-state__actions">
+          {onRetry && (
+            <Button variant="secondary" size="sm" onClick={onRetry}>
+              {retryLabel}
+            </Button>
+          )}
+          {action && (
+            <Button variant="secondary" size="sm" onClick={action.onClick}>
+              {action.label}
+            </Button>
+          )}
+        </div>
       )}
     </div>
   );

--- a/apps/desktop/src/ui/NavIcon.tsx
+++ b/apps/desktop/src/ui/NavIcon.tsx
@@ -26,6 +26,7 @@ import {
   Server,
   ServerCog,
   Settings,
+  Wrench,
   Shield,
   ShieldCheck,
   ShipWheel,
@@ -78,6 +79,7 @@ const RESOURCE_ICONS: Record<string, LucideIcon> = {
   rolebindings: UserRoundCheck,
   helmreleases: ShipWheel,
   settings: Settings,
+  toolbox: Wrench,
   newresource: FilePlus2,
 };
 

--- a/apps/desktop/src/ui/styles.css
+++ b/apps/desktop/src/ui/styles.css
@@ -2314,6 +2314,131 @@ body {
   font-size: 13px;
   line-height: 1.5;
 }
+.fl-error-state__actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+/* --- Toolbox page --- */
+.fl-toolbox {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+  overflow: auto;
+  min-height: 0;
+}
+.fl-toolbox-error {
+  margin: 0;
+  color: var(--fl-color-danger, #dc2626);
+  font-size: 13px;
+}
+.fl-toolbox-empty {
+  margin: 0;
+  color: var(--fl-color-text-muted);
+  font-size: 13px;
+}
+.fl-toolbox-tools {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 12px;
+}
+.fl-toolbox-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 14px;
+  border: 1px solid var(--fl-color-border);
+  border-radius: 10px;
+  background: var(--fl-color-surface, transparent);
+}
+.fl-toolbox-card__head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.fl-toolbox-card__head strong {
+  font-size: 14px;
+  text-transform: capitalize;
+}
+.fl-toolbox-card__meta {
+  margin: 0;
+  font-size: 13px;
+  color: var(--fl-color-text-muted);
+}
+.fl-toolbox-card__path {
+  color: var(--fl-color-text-muted);
+  font-size: 11px;
+  word-break: break-all;
+}
+.fl-toolbox-search {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+.fl-toolbox-search > :first-child {
+  flex: 1;
+}
+.fl-toolbox-plugins {
+  width: 100%;
+  border-collapse: collapse;
+}
+.fl-toolbox-plugins td {
+  padding: 8px 0;
+  border-top: 1px solid var(--fl-color-border);
+  vertical-align: middle;
+}
+.fl-toolbox-plugins td strong {
+  display: block;
+  font-size: 13px;
+}
+.fl-toolbox-plugins td small {
+  color: var(--fl-color-text-muted);
+  font-size: 12px;
+}
+.fl-toolbox-plugins__action {
+  text-align: right;
+  white-space: nowrap;
+}
+.fl-toolbox-contexts {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.fl-toolbox-context {
+  border: 1px solid var(--fl-color-border);
+  border-radius: 8px;
+  padding: 10px 12px;
+}
+.fl-toolbox-context__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 13px;
+}
+.fl-toolbox-reqs {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.fl-toolbox-req {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 12px;
+}
+.fl-toolbox-req__hint {
+  color: var(--fl-color-text-muted);
+}
 
 .fl-settings-page {
   overflow: hidden;


### PR DESCRIPTION
## What happened

The Toolbox backend (slices 1–10) and the frontend **lib** (`lib/toolbox.ts`, slice 11) are on `dev`, but the **Toolbox page and all its shell wiring (slice 12)** never landed — even though PR #126 shows *merged*. In the stacked-PR cascade (#123→#124→#125→#126), only the first commit of #126 (the lib) propagated to `dev`; the second commit (`1a77d4c`, the page + integration) was dropped.

Net effect on `dev` today: the capabilities exist and are MCP-exposed, but there is **no ToolboxView, no way to open it, and no exec-auth deep-link** — the UI is unreachable.

## Fix

Cherry-pick of the lost commit `1a77d4c` onto `dev`. Applies cleanly (its only dependency, `lib/toolbox.ts`, is already on `dev`). Restores:

- `ToolboxView` — Tools / Plugins / Context-health sections.
- `toolbox` page-kind registration (ResourceKind + label + K8S_KIND + Wrench icon), the ClusterHotbar wrench button, `openToolbox()` in App, and the command-palette entry.
- The exec-auth deep-link: `isExecAuthError` classification + "Diagnose in Toolbox" on the cluster-overview error.

## Verification

Full frontend suite **544 green**, `tsc` clean (only the repo's pre-existing `@types/node` env warning). Same content that was reviewed in #126.