### PR TITLE
feat(toolbox): streaming install progress (start_tool_install)

### DIFF
--- a/apps/desktop/src-tauri/src/capabilities.rs
+++ b/apps/desktop/src-tauri/src/capabilities.rs
@@ -53,7 +53,7 @@ fn http_get(url: &str) -> Result<Vec<u8>, srelens_kube::toolbox_install::Install
 
 /// Run a managed tool with args, mapping a non-zero exit (with stderr) to a
 /// retryable error. Used for krew's self-bootstrap; called inside spawn_blocking.
-fn run_tool(
+pub(crate) fn run_tool(
     bin: &std::path::Path,
     args: &[&str],
 ) -> Result<(), srelens_kube::toolbox_install::InstallError> {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ mod logs;
 mod mcp;
 mod settings;
 mod terminal;
+mod toolbox;
 mod updater;
 mod watch;
 
@@ -25,6 +26,7 @@ use mcp::{
 use settings::{get_request_timeout, set_request_timeout};
 use srelens_kube::client_cache::ClientCache;
 use terminal::{start_terminal, terminal_close, terminal_input, terminal_resize, TerminalManager};
+use toolbox::start_tool_install;
 use updater::{update_check, update_install};
 use watch::{start_resource_watch, stop_watch, WatchManager};
 
@@ -266,6 +268,7 @@ pub fn run() {
             save_text_file,
             pick_kubeconfig_files,
             save_pasted_kubeconfig,
+            start_tool_install,
             update_check,
             update_install,
             set_request_timeout,

--- a/apps/desktop/src-tauri/src/toolbox.rs
+++ b/apps/desktop/src-tauri/src/toolbox.rs
@@ -1,0 +1,83 @@
+//! Streaming Toolbox installs.
+//!
+//! The `toolbox.install*` capabilities install synchronously (one await, for
+//! MCP). The GUI wants a progress bar, so `start_tool_install` runs the *same*
+//! install core (`srelens_kube::toolbox::run_*_install`) but with a fetch that
+//! streams the download and emits `toolbox://progress` as bytes arrive. One
+//! implementation, two surfaces (spec §4).
+
+use std::io::Read;
+
+use serde::Serialize;
+use srelens_kube::toolbox::{run_helm_install, run_krew_install, run_kubectl_install, srelens_bin_dir};
+use srelens_kube::toolbox::InstallToolOut;
+use srelens_kube::toolbox_install::InstallError;
+use tauri::{AppHandle, Emitter};
+
+/// Only report progress for real payload downloads, not the tiny checksum /
+/// version / GitHub-API requests that also flow through the same fetch.
+const PROGRESS_MIN_BYTES: u64 = 500_000;
+
+#[derive(Serialize, Clone)]
+struct ToolInstallProgress {
+    tool: String,
+    received: u64,
+    total: Option<u64>,
+}
+
+/// Blocking GET that streams the body, emitting `toolbox://progress` for large
+/// downloads. Returns the full bytes so the install core is unchanged.
+fn fetch_with_progress(url: &str, app: &AppHandle, tool: &str) -> Result<Vec<u8>, InstallError> {
+    let client = reqwest::blocking::Client::builder()
+        .user_agent(concat!("srelens/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(|e| InstallError::Download(e.to_string()))?;
+    let mut resp = client
+        .get(url)
+        .send()
+        .map_err(|e| InstallError::Download(e.to_string()))?;
+    if !resp.status().is_success() {
+        return Err(InstallError::Download(format!("{} for {url}", resp.status())));
+    }
+
+    let total = resp.content_length();
+    let report = total.is_some_and(|t| t >= PROGRESS_MIN_BYTES);
+    let mut buf = total.map_or_else(Vec::new, |t| Vec::with_capacity(t as usize));
+    let mut chunk = vec![0u8; 64 * 1024];
+    let mut received: u64 = 0;
+    loop {
+        let n = resp
+            .read(&mut chunk)
+            .map_err(|e| InstallError::Download(e.to_string()))?;
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        received += n as u64;
+        if report {
+            let _ = app.emit(
+                "toolbox://progress",
+                ToolInstallProgress { tool: tool.to_string(), received, total },
+            );
+        }
+    }
+    Ok(buf)
+}
+
+/// Install a managed tool (`kubectl` / `helm` / `krew`) with streaming download
+/// progress on `toolbox://progress`. Same verified install as the capability.
+#[tauri::command]
+pub async fn start_tool_install(app: AppHandle, tool: String) -> Result<InstallToolOut, String> {
+    tokio::task::spawn_blocking(move || {
+        let fetch = |url: &str| fetch_with_progress(url, &app, &tool);
+        let result = match tool.as_str() {
+            "kubectl" => run_kubectl_install(&srelens_bin_dir(), &fetch),
+            "helm" => run_helm_install(&srelens_bin_dir(), &fetch),
+            "krew" => run_krew_install(&std::env::temp_dir(), &fetch, &crate::capabilities::run_tool),
+            other => Err(InstallError::Download(format!("unknown tool: {other}"))),
+        };
+        result.map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}

--- a/apps/desktop/src/components/ToolboxView.test.tsx
+++ b/apps/desktop/src/components/ToolboxView.test.tsx
@@ -5,9 +5,8 @@ const toolbox = vi.hoisted(() => ({
   toolboxStatus: vi.fn(),
   diagnoseContext: vi.fn(),
   searchPlugins: vi.fn(),
+  startToolInstall: vi.fn(),
   installKubectl: vi.fn(),
-  installHelm: vi.fn(),
-  installKrew: vi.fn(),
   installPlugin: vi.fn(),
   removePlugin: vi.fn(),
   upgradePlugin: vi.fn(),
@@ -33,15 +32,18 @@ beforeEach(() => {
 });
 
 describe("ToolboxView", () => {
-  it("lists managed tools with version and source, and installs a missing one", async () => {
-    toolbox.installKrew.mockResolvedValue({ data: { tool: "krew", version: "v0.5.0", path: "/k" } });
+  it("lists managed tools with version and source, and installs a missing one with progress", async () => {
+    toolbox.startToolInstall.mockImplementation(async (_tool: string, onProgress?: (p: number | null) => void) => {
+      onProgress?.(42);
+      return { data: { tool: "krew", version: "v0.5.0", path: "/k" } };
+    });
     render(<ToolboxView />);
 
     expect(await screen.findByText("v1.30.2")).toBeDefined();
     expect(screen.getByText("v3.16.2")).toBeDefined();
-    // krew is missing → its Install button
+    // krew is missing → its Install button, which streams via start_tool_install
     fireEvent.click(screen.getByRole("button", { name: "Install krew" }));
-    await waitFor(() => expect(toolbox.installKrew).toHaveBeenCalled());
+    await waitFor(() => expect(toolbox.startToolInstall).toHaveBeenCalledWith("krew", expect.any(Function)));
     // status is refreshed after install
     await waitFor(() => expect(toolbox.toolboxStatus).toHaveBeenCalledTimes(2));
   });

--- a/apps/desktop/src/components/ToolboxView.tsx
+++ b/apps/desktop/src/components/ToolboxView.tsx
@@ -5,25 +5,17 @@ import { ConfirmDialog } from "../ui/ConfirmDialog";
 import { listContexts } from "../lib/clusters";
 import {
   diagnoseContext,
-  installHelm,
-  installKrew,
   installKubectl,
   installPlugin,
   removePlugin,
   searchPlugins,
+  startToolInstall,
   toolboxStatus,
   type DiagnosisReport,
-  type InstallResult,
   type Plugin,
   type RequirementStatus,
   type ToolStatus,
 } from "../lib/toolbox";
-
-const TOOL_INSTALLERS: Record<string, () => Promise<{ data?: InstallResult; error?: string }>> = {
-  kubectl: installKubectl,
-  helm: installHelm,
-  krew: installKrew,
-};
 
 const STATUS_KIND: Record<RequirementStatus, "success" | "warning" | "danger"> = {
   found: "success",
@@ -41,6 +33,7 @@ const STATUS_LABEL: Record<RequirementStatus, string> = {
 export function ToolboxView({ initialContext }: { initialContext?: string | null }) {
   const [tools, setTools] = useState<ToolStatus[] | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
+  const [progress, setProgress] = useState<number | null>(null);
   const [error, setError] = useState("");
 
   const refreshStatus = async () => {
@@ -58,6 +51,17 @@ export function ToolboxView({ initialContext }: { initialContext?: string | null
     if (r.error) setError(r.error);
     await refreshStatus();
     setBusy(null);
+  };
+
+  // Tools install with a streaming download progress bar.
+  const installTool = async (tool: "kubectl" | "helm" | "krew") => {
+    setBusy(tool);
+    setProgress(null);
+    const r = await startToolInstall(tool, setProgress);
+    if (r.error) setError(r.error);
+    await refreshStatus();
+    setBusy(null);
+    setProgress(null);
   };
 
   return (
@@ -85,9 +89,13 @@ export function ToolboxView({ initialContext }: { initialContext?: string | null
         ) : (
           <div className="fl-toolbox-tools">
             {tools.map((tool) => (
-              <ToolCard key={tool.name} tool={tool} busy={busy === tool.name} onInstall={() =>
-                runInstall(tool.name, TOOL_INSTALLERS[tool.name] ?? (async () => ({})))
-              } />
+              <ToolCard
+                key={tool.name}
+                tool={tool}
+                busy={busy === tool.name}
+                progress={busy === tool.name ? progress : undefined}
+                onInstall={() => installTool(tool.name as "kubectl" | "helm" | "krew")}
+              />
             ))}
           </div>
         )}
@@ -100,7 +108,18 @@ export function ToolboxView({ initialContext }: { initialContext?: string | null
   );
 }
 
-function ToolCard({ tool, busy, onInstall }: { tool: ToolStatus; busy: boolean; onInstall: () => void }) {
+function ToolCard({
+  tool,
+  busy,
+  progress,
+  onInstall,
+}: {
+  tool: ToolStatus;
+  busy: boolean;
+  /** Download percent while installing (null = unknown/finishing), undefined when idle. */
+  progress?: number | null;
+  onInstall: () => void;
+}) {
   return (
     <div className="fl-toolbox-card">
       <div className="fl-toolbox-card__head">
@@ -119,7 +138,9 @@ function ToolCard({ tool, busy, onInstall }: { tool: ToolStatus; busy: boolean; 
         </>
       ) : (
         <>
-          <p className="fl-toolbox-card__meta">Not installed</p>
+          <p className="fl-toolbox-card__meta">
+            {busy ? (progress != null ? `Downloading… ${progress}%` : "Installing…") : "Not installed"}
+          </p>
           <Button onClick={onInstall} disabled={busy} aria-label={`Install ${tool.name}`}>
             {busy ? <Spinner /> : <Download data-icon="inline-start" />} Install
           </Button>

--- a/apps/desktop/src/lib/toolbox.test.ts
+++ b/apps/desktop/src/lib/toolbox.test.ts
@@ -1,4 +1,14 @@
 import { describe, it, expect, vi } from "vitest";
+
+const { invokeCommandMock, subscribeMock } = vi.hoisted(() => ({
+  invokeCommandMock: vi.fn(),
+  subscribeMock: vi.fn(),
+}));
+vi.mock("../transport/transport", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../transport/transport")>();
+  return { ...actual, invokeCommand: invokeCommandMock, subscribe: subscribeMock };
+});
+
 import {
   toolboxStatus,
   diagnoseContext,
@@ -9,6 +19,7 @@ import {
   installPlugin,
   upgradePlugin,
   removePlugin,
+  startToolInstall,
 } from "./toolbox";
 
 describe("toolbox lib wrappers", () => {
@@ -61,5 +72,28 @@ describe("toolbox lib wrappers", () => {
     const r = await installKrew(invoke);
     expect(r.error).toContain("krew not found");
     expect(r.data).toBeUndefined();
+  });
+
+  it("startToolInstall reports progress as a percent and unsubscribes", async () => {
+    const dispose = vi.fn();
+    let emit: ((payload: unknown) => void) | undefined;
+    subscribeMock.mockImplementation(async (_ch: string, handler: (p: unknown) => void) => {
+      emit = handler;
+      return dispose;
+    });
+    invokeCommandMock.mockImplementation(async () => {
+      emit?.({ tool: "kubectl", received: 50, total: 200 }); // 25%
+      emit?.({ tool: "helm", received: 10, total: 20 }); // ignored — different tool
+      emit?.({ tool: "kubectl", received: 200, total: 200 }); // 100%
+      return { tool: "kubectl", version: "v1.30.2", path: "/p" };
+    });
+
+    const seen: Array<number | null> = [];
+    const r = await startToolInstall("kubectl", (p) => seen.push(p));
+
+    expect(invokeCommandMock).toHaveBeenCalledWith("start_tool_install", { tool: "kubectl" });
+    expect(seen).toEqual([25, 100]);
+    expect(r.data?.version).toBe("v1.30.2");
+    expect(dispose).toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/lib/toolbox.ts
+++ b/apps/desktop/src/lib/toolbox.ts
@@ -1,4 +1,4 @@
-import { invokeCapability, type Invoker } from "../transport/transport";
+import { invokeCapability, invokeCommand, subscribe, type Invoker } from "../transport/transport";
 
 // Types mirror the Rust DTOs in crates/kube/src/toolbox.rs.
 
@@ -96,6 +96,36 @@ export const installHelm = (invoke: Invoker = invokeCapability) =>
 /** Bootstrap krew into ~/.krew. */
 export const installKrew = (invoke: Invoker = invokeCapability) =>
   installTool("toolbox.installKrew", invoke);
+
+interface RawInstallProgress {
+  tool: string;
+  received: number;
+  total: number | null;
+}
+
+/**
+ * Install a managed tool (kubectl / helm / krew) via the streaming
+ * `start_tool_install` command, reporting download progress as a whole percent
+ * (or null while the total size is unknown / during the post-download install).
+ * The same verified install as the capability, with a progress bar.
+ */
+export async function startToolInstall(
+  tool: "kubectl" | "helm" | "krew",
+  onProgress?: (percent: number | null) => void,
+): Promise<Result<InstallResult>> {
+  const dispose = await subscribe("toolbox://progress", (payload) => {
+    const p = payload as RawInstallProgress;
+    if (p.tool !== tool) return;
+    onProgress?.(p.total ? Math.min(100, Math.round((p.received / p.total) * 100)) : null);
+  });
+  try {
+    return { data: await invokeCommand<InstallResult>("start_tool_install", { tool }) };
+  } catch (e) {
+    return { error: String(e) };
+  } finally {
+    dispose();
+  }
+}
 
 const pluginAction = (id: string, plugin: string, invoke: Invoker) =>
   call(() => invoke<PluginActionResult>(id, { plugin }));

--- a/crates/kube/src/toolbox.rs
+++ b/crates/kube/src/toolbox.rs
@@ -529,6 +529,61 @@ fn to_handler(e: InstallError) -> CapabilityError {
     CapabilityError::Handler(e.to_string())
 }
 
+/// Core kubectl install, shared by the `toolbox.installKubectl` capability and
+/// the streaming Tauri command: resolve the latest stable version, download and
+/// verify, install into `install_dir`. `fetch` is injected — a plain blocking
+/// GET for the capability, or a progress-emitting one for the streaming command.
+pub fn run_kubectl_install<F>(install_dir: &Path, fetch: &F) -> Result<InstallToolOut, InstallError>
+where
+    F: Fn(&str) -> Result<Vec<u8>, InstallError>,
+{
+    let platform = Platform::current()?;
+    let raw = fetch(KUBECTL_STABLE_URL)?;
+    let version = std::str::from_utf8(&raw)
+        .map_err(|_| InstallError::Download("kubectl version response was not UTF-8".to_string()))?
+        .trim()
+        .to_string();
+    let plan = kubectl_install(&version, &platform, install_dir);
+    let path = install_binary(&plan, fetch)?;
+    Ok(InstallToolOut { tool: "kubectl".to_string(), version, path: path.to_string_lossy().into_owned() })
+}
+
+/// Core helm install, shared by the capability and the streaming command.
+pub fn run_helm_install<F>(install_dir: &Path, fetch: &F) -> Result<InstallToolOut, InstallError>
+where
+    F: Fn(&str) -> Result<Vec<u8>, InstallError>,
+{
+    let platform = Platform::current()?;
+    let body = fetch(HELM_LATEST_RELEASE_URL)?;
+    let version = parse_github_latest_tag(&body)?;
+    let plan = helm_install(&version, &platform, install_dir);
+    let path = install_from_targz(&plan, fetch)?;
+    Ok(InstallToolOut { tool: "helm".to_string(), version, path: path.to_string_lossy().into_owned() })
+}
+
+/// Core krew install (download + verify + bootstrap), shared by the capability
+/// and the streaming command.
+pub fn run_krew_install<F, R>(
+    staging_dir: &Path,
+    fetch: &F,
+    run: &R,
+) -> Result<InstallToolOut, InstallError>
+where
+    F: Fn(&str) -> Result<Vec<u8>, InstallError>,
+    R: Fn(&Path, &[&str]) -> Result<(), InstallError>,
+{
+    let platform = Platform::current()?;
+    let body = fetch(KREW_LATEST_RELEASE_URL)?;
+    let version = parse_github_latest_tag(&body)?;
+    let plan = krew_archive(&version, &platform, staging_dir);
+    install_krew(&plan, fetch, run)?;
+    Ok(InstallToolOut {
+        tool: "krew".to_string(),
+        version,
+        path: krew_bin_dir().join("kubectl-krew").to_string_lossy().into_owned(),
+    })
+}
+
 /// Confirm-gated capability: download the latest stable kubectl into
 /// `~/.srelens/bin`, verified against dl.k8s.io's published checksum. `fetch`
 /// (a blocking HTTP GET) is injected so the capability is testable without a
@@ -549,19 +604,7 @@ where
                 // The install does blocking HTTP + filesystem work; keep it off
                 // the async runtime.
                 tokio::task::spawn_blocking(move || {
-                    let platform = Platform::current().map_err(to_handler)?;
-                    let raw = fetch(KUBECTL_STABLE_URL).map_err(to_handler)?;
-                    let version = std::str::from_utf8(&raw)
-                        .map_err(|e| CapabilityError::Handler(e.to_string()))?
-                        .trim()
-                        .to_string();
-                    let plan = kubectl_install(&version, &platform, &install_dir);
-                    let path = install_binary(&plan, &fetch).map_err(to_handler)?;
-                    Ok(InstallToolOut {
-                        tool: "kubectl".to_string(),
-                        version,
-                        path: path.to_string_lossy().into_owned(),
-                    })
+                    run_kubectl_install(&install_dir, &fetch).map_err(to_handler)
                 })
                 .await
                 .map_err(|e| CapabilityError::Handler(e.to_string()))?
@@ -590,16 +633,7 @@ where
             let fetch = fetch.clone();
             async move {
                 tokio::task::spawn_blocking(move || {
-                    let platform = Platform::current().map_err(to_handler)?;
-                    let body = fetch(HELM_LATEST_RELEASE_URL).map_err(to_handler)?;
-                    let version = parse_github_latest_tag(&body).map_err(to_handler)?;
-                    let plan = helm_install(&version, &platform, &install_dir);
-                    let path = install_from_targz(&plan, &fetch).map_err(to_handler)?;
-                    Ok(InstallToolOut {
-                        tool: "helm".to_string(),
-                        version,
-                        path: path.to_string_lossy().into_owned(),
-                    })
+                    run_helm_install(&install_dir, &fetch).map_err(to_handler)
                 })
                 .await
                 .map_err(|e| CapabilityError::Handler(e.to_string()))?
@@ -631,16 +665,7 @@ where
             let run = run.clone();
             async move {
                 tokio::task::spawn_blocking(move || {
-                    let platform = Platform::current().map_err(to_handler)?;
-                    let body = fetch(KREW_LATEST_RELEASE_URL).map_err(to_handler)?;
-                    let version = parse_github_latest_tag(&body).map_err(to_handler)?;
-                    let plan = krew_archive(&version, &platform, &staging_dir);
-                    install_krew(&plan, &fetch, &run).map_err(to_handler)?;
-                    Ok(InstallToolOut {
-                        tool: "krew".to_string(),
-                        version,
-                        path: krew_bin_dir().join("kubectl-krew").to_string_lossy().into_owned(),
-                    })
+                    run_krew_install(&staging_dir, &fetch, &run).map_err(to_handler)
                 })
                 .await
                 .map_err(|e| CapabilityError::Handler(e.to_string()))?


### PR DESCRIPTION
Item 1 of the Toolbox follow-ups — live download progress for tool installs (spec §4).

## What this does

The `toolbox.install*` capabilities install synchronously (one await, for MCP). The GUI wants a progress bar, so this adds `start_tool_install` — a Tauri command that runs the **same** install core but with a fetch that streams the download and emits `toolbox://progress { tool, received, total }` as bytes arrive.

## One implementation, two surfaces

The install orchestration is extracted into `run_kubectl_install` / `run_helm_install` / `run_krew_install` in the kube crate. The confirm-gated MCP capabilities and the streaming command both call these — the capability handlers are now thin wrappers, so there's no duplicated logic and the two surfaces can't drift.

Only real payload downloads (≥ 500 KB) report progress; the tiny checksum / version / GitHub-API requests that flow through the same fetch stay quiet, so the bar tracks the actual binary/tarball.

## Frontend

`startToolInstall(tool, onProgress)` subscribes to the event, reports a whole percent, and unsubscribes when done. The Tools cards show "Downloading… N%" then "Installing…". The MCP capabilities are unchanged (still synchronous).

## Testing

- The `run_*` refactor keeps all 49 kube toolbox tests green (capabilities still pass).
- `startToolInstall` percent-calc + dispose test (mocked transport); ToolboxView's tools-install test now asserts the streaming path with a progress callback.
- Full frontend **545**, kube **242**, app **18** green; `tsc` clean; clippy clean.

## Next

Item 2: the real-krew CI integration test (krew bootstrap + small-plugin install in the kind suite).