### PR TITLE
feat(bulk): multi-select tables + bulk delete/evict/rollout-restart (#18)

### DIFF
--- a/apps/desktop/src/components/BulkActionBar.test.tsx
+++ b/apps/desktop/src/components/BulkActionBar.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+
+const actions = vi.hoisted(() => ({ deleteResource: vi.fn(), rolloutRestart: vi.fn() }));
+const workloads = vi.hoisted(() => ({ deletePod: vi.fn(), evictPod: vi.fn() }));
+const notifyMock = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn(), info: vi.fn() }));
+vi.mock("../lib/actions", () => actions);
+vi.mock("../lib/workloads", () => workloads);
+vi.mock("../lib/notify", () => ({ notify: notifyMock }));
+
+import { BulkActionBar } from "./BulkActionBar";
+
+beforeEach(() => {
+  Object.values({ ...actions, ...workloads, ...notifyMock }).forEach((m) => m.mockReset());
+});
+
+describe("BulkActionBar", () => {
+  const podRows = [
+    { name: "web-1", namespace: "prod" },
+    { name: "web-2", namespace: "prod" },
+  ];
+
+  it("offers evict for pods and bulk-deletes with one confirm + a summary toast", async () => {
+    workloads.deletePod.mockResolvedValue({ deleted: true });
+    const onClear = vi.fn();
+    const onDone = vi.fn();
+    render(<BulkActionBar context="ctx" kind="Pod" rows={podRows} onClear={onClear} onDone={onDone} />);
+
+    expect(screen.getByText("2 selected")).toBeDefined();
+    expect(screen.getByRole("button", { name: /Evict/ })).toBeDefined();
+
+    fireEvent.click(screen.getByRole("button", { name: /Delete/ }));
+    const dialog = await screen.findByRole("dialog");
+    // Confirm lists exactly what's affected.
+    expect(within(dialog).getByText("prod/web-1")).toBeDefined();
+    expect(within(dialog).getByText("prod/web-2")).toBeDefined();
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Delete" }));
+    await waitFor(() => expect(workloads.deletePod).toHaveBeenCalledTimes(2));
+    expect(workloads.deletePod).toHaveBeenCalledWith("ctx", "prod", "web-1");
+    await waitFor(() => expect(notifyMock.success).toHaveBeenCalledWith("Deleted 2 Pods"));
+    expect(onClear).toHaveBeenCalled();
+    expect(onDone).toHaveBeenCalled();
+  });
+
+  it("reports partial failure without aborting the rest", async () => {
+    workloads.deletePod.mockImplementation(async (_c: string, _n: string, name: string) =>
+      name === "web-2" ? { error: "forbidden" } : { deleted: true },
+    );
+    render(<BulkActionBar context="ctx" kind="Pod" rows={podRows} onClear={vi.fn()} onDone={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: /Delete/ }));
+    fireEvent.click(within(await screen.findByRole("dialog")).getByRole("button", { name: "Delete" }));
+    await waitFor(() => expect(notifyMock.error).toHaveBeenCalled());
+    expect(notifyMock.error.mock.calls[0][0]).toMatch(/1 of 2 failed/);
+    expect(notifyMock.error.mock.calls[0][1]).toContain("web-2: forbidden");
+  });
+
+  it("offers rollout-restart for Deployments and delete via deleteResource", async () => {
+    actions.deleteResource.mockResolvedValue({ ok: true });
+    actions.rolloutRestart.mockResolvedValue({ ok: true });
+    const rows = [{ name: "api", namespace: "prod" }];
+    render(<BulkActionBar context="ctx" kind="Deployment" rows={rows} onClear={vi.fn()} onDone={vi.fn()} />);
+
+    expect(screen.queryByRole("button", { name: /Evict/ })).toBeNull(); // not a pod
+    fireEvent.click(screen.getByRole("button", { name: /Rollout restart/ }));
+    fireEvent.click(within(await screen.findByRole("dialog")).getByRole("button", { name: "Rollout-restart" }));
+    await waitFor(() => expect(actions.rolloutRestart).toHaveBeenCalledWith("ctx", "Deployment", "prod", "api"));
+  });
+});

--- a/apps/desktop/src/components/BulkActionBar.tsx
+++ b/apps/desktop/src/components/BulkActionBar.tsx
@@ -1,0 +1,126 @@
+import { useState } from "react";
+import { Trash2, RotateCw, LogOut } from "lucide-react";
+import { Button } from "../ui";
+import { ConfirmDialog } from "../ui/ConfirmDialog";
+import { deleteResource, rolloutRestart } from "../lib/actions";
+import { deletePod, evictPod } from "../lib/workloads";
+import { runBulk, summarize, type ActionOutcome } from "../lib/bulk";
+import { notify } from "../lib/notify";
+
+export interface BulkRow {
+  name: string;
+  namespace?: string;
+}
+
+type Action = "delete" | "evict" | "restart";
+
+const RESTARTABLE = new Set(["Deployment", "StatefulSet", "DaemonSet"]);
+
+const VERB: Record<Action, string> = { delete: "Delete", evict: "Evict", restart: "Rollout-restart" };
+
+const displayName = (r: BulkRow) => (r.namespace ? `${r.namespace}/${r.name}` : r.name);
+
+/**
+ * The bar shown above a resource table when rows are selected: offers the bulk
+ * actions valid for the kind, gathers one confirm listing exactly what's
+ * affected, then runs them with per-item results (partial failures reported,
+ * never aborting the rest).
+ */
+export function BulkActionBar({
+  context,
+  kind,
+  rows,
+  onClear,
+  onDone,
+}: {
+  context: string;
+  /** The K8s kind (e.g. "Pod", "Deployment"). */
+  kind: string;
+  rows: BulkRow[];
+  /** Clear the selection (also called after an action completes). */
+  onClear: () => void;
+  /** Refresh the list after a completed action. */
+  onDone: () => void;
+}) {
+  const [pending, setPending] = useState<Action | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const canEvict = kind === "Pod";
+  const canRestart = RESTARTABLE.has(kind);
+
+  const opFor = (action: Action) => (row: BulkRow): Promise<ActionOutcome> => {
+    const ns = row.namespace ?? "";
+    if (action === "evict") return evictPod(context, ns, row.name);
+    if (action === "restart") return rolloutRestart(context, kind, ns, row.name);
+    return kind === "Pod" ? deletePod(context, ns, row.name) : deleteResource(context, kind, ns || null, row.name);
+  };
+
+  const run = async () => {
+    if (!pending) return;
+    setBusy(true);
+    const outcomes = await runBulk(rows, opFor(pending));
+    const { ok, failed } = summarize(outcomes);
+    const verb = VERB[pending].toLowerCase();
+    if (failed === 0) {
+      notify.success(`${VERB[pending]}d ${ok} ${kind}${ok === 1 ? "" : "s"}`);
+    } else {
+      const detail = outcomes
+        .filter((o) => o.status === "error")
+        .map((o) => `${o.item.name}: ${o.error}`)
+        .join("\n");
+      notify.error(`${failed} of ${rows.length} failed to ${verb}`, detail);
+    }
+    setBusy(false);
+    setPending(null);
+    onClear();
+    onDone();
+  };
+
+  const preview = rows.slice(0, 10);
+
+  return (
+    <div className="fl-bulk-bar" role="region" aria-label="Bulk actions">
+      <span className="fl-bulk-bar__count">{rows.length} selected</span>
+      <Button variant="danger" onClick={() => setPending("delete")}>
+        <Trash2 data-icon="inline-start" /> Delete
+      </Button>
+      {canEvict && (
+        <Button variant="secondary" onClick={() => setPending("evict")}>
+          <LogOut data-icon="inline-start" /> Evict
+        </Button>
+      )}
+      {canRestart && (
+        <Button variant="secondary" onClick={() => setPending("restart")}>
+          <RotateCw data-icon="inline-start" /> Rollout restart
+        </Button>
+      )}
+      <Button variant="ghost" onClick={onClear}>
+        Clear
+      </Button>
+
+      {pending && (
+        <ConfirmDialog
+          title={`${VERB[pending]} ${rows.length} ${kind}${rows.length === 1 ? "" : "s"}?`}
+          danger={pending === "delete"}
+          busy={busy}
+          confirmLabel={VERB[pending]}
+          message={
+            <>
+              <p style={{ marginTop: 0 }}>This will {VERB[pending].toLowerCase()}:</p>
+              <ul className="fl-bulk-bar__list">
+                {preview.map((r) => (
+                  <li key={displayName(r)}>
+                    <code>{displayName(r)}</code>
+                  </li>
+                ))}
+              </ul>
+              {rows.length > preview.length && <p>…and {rows.length - preview.length} more.</p>}
+            </>
+          }
+          onConfirm={() => void run()}
+          onCancel={() => setPending(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/ResourceBrowser.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.tsx
@@ -55,6 +55,7 @@ import {
 } from "../lib/namespaces";
 import { NamespaceMultiSelect } from "../ui/NamespaceMultiSelect";
 import { PodActions, ResourceActions, ServiceForwardAction } from "./DetailActions";
+import { BulkActionBar } from "./BulkActionBar";
 import { NodeCordonAction } from "./NodeCordonAction";
 import { ResourceDetail } from "./ResourceDetail";
 import type { OpenResource } from "../lib/resourceNavigation";
@@ -603,6 +604,9 @@ export function ResourceBrowser({
   const [selectedPod, setSelectedPod] = useState<PodSummary | null>(null);
   const [otherDetail, setOtherDetail] = useState<OtherDetail | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
+  // Bulk-selection: keys are namespace-qualified so all-namespace views can't
+  // confuse two same-named resources.
+  const [bulkKeys, setBulkKeys] = useState<Set<string>>(new Set());
   // Bumped after a write action so the open detail overview re-fetches.
   const [detailReload, setDetailReload] = useState(0);
   const [filterColumn, setFilterColumn] = useState<string | null>(null);
@@ -809,7 +813,13 @@ export function ResourceBrowser({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [focus, res.rows]);
 
-  const selectedKey = kind === "pods" ? selectedPod?.name : otherDetail?.name;
+  const rowKeyOf = (r: { name: string; namespace?: string }) =>
+    r.namespace ? `${r.namespace}/${r.name}` : r.name;
+  const selectedKey =
+    kind === "pods"
+      ? selectedPod && rowKeyOf(selectedPod)
+      : otherDetail && rowKeyOf({ name: otherDetail.name, namespace: otherDetail.namespace ?? undefined });
+  const bulkEnabled = kind !== "events";
 
   // Merge live pod metrics into the pod rows, and restrict namespaced rows to
   // the selected namespaces (when watching all-namespaces for a multi-select).
@@ -831,6 +841,17 @@ export function ResourceBrowser({
     () => filterTableData(tableRows, visibleColumns, query, filterColumn),
     [visibleColumns, filterColumn, query, tableRows],
   );
+
+  // The selected rows that still exist (drop keys for rows that scrolled out of
+  // the current view / namespace / filter is fine — we act on what's known).
+  const bulkRows = useMemo(
+    () => tableRows.filter((r) => bulkKeys.has(rowKeyOf(r))),
+    // rowKeyOf is stable string work; deps intentionally on the inputs.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [tableRows, bulkKeys],
+  );
+  // Clear the selection whenever the underlying list changes shape.
+  useEffect(() => setBulkKeys(new Set()), [context, kind, watchNamespace, selectionKey]);
   const filterLabel = filterColumn
     ? visibleColumns.find((column) => column.key === filterColumn)?.header
     : null;
@@ -967,6 +988,16 @@ export function ResourceBrowser({
               )}
             </Toolbar>
 
+            {bulkEnabled && bulkRows.length > 0 && (
+              <BulkActionBar
+                context={context}
+                kind={K8S_KIND[kind]}
+                rows={bulkRows}
+                onClear={() => setBulkKeys(new Set())}
+                onDone={() => setReloadKey((k) => k + 1)}
+              />
+            )}
+
             <div className="min-h-0 flex-1 overflow-auto">
               {res.error && (
                 <ErrorState
@@ -982,8 +1013,9 @@ export function ResourceBrowser({
                 <Table
                   columns={visibleColumns}
                   data={filtered}
-                  getRowKey={(r) => r.name}
-                  selectedKey={selectedKey}
+                  getRowKey={rowKeyOf}
+                  selectedKey={selectedKey ?? undefined}
+                  selection={bulkEnabled ? { selected: bulkKeys, onChange: setBulkKeys } : undefined}
                   onRowClick={kind === "events" ? undefined : onRowClick}
                   activeFilterKey={filterColumn}
                   onActiveFilterKeyChange={setFilterColumn}

--- a/apps/desktop/src/lib/bulk.test.ts
+++ b/apps/desktop/src/lib/bulk.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from "vitest";
+import { runBulk, summarize } from "./bulk";
+
+describe("runBulk", () => {
+  it("returns a per-item outcome in original order", async () => {
+    const out = await runBulk([1, 2, 3], async (n) => (n === 2 ? { error: "boom" } : { ok: true }));
+    expect(out).toEqual([
+      { item: 1, status: "ok" },
+      { item: 2, status: "error", error: "boom" },
+      { item: 3, status: "ok" },
+    ]);
+  });
+
+  it("does not abort the rest when one item fails or throws", async () => {
+    const seen: number[] = [];
+    const out = await runBulk([1, 2, 3, 4], async (n) => {
+      seen.push(n);
+      if (n === 1) throw new Error("thrown");
+      if (n === 3) return { error: "returned" };
+      return { deleted: true };
+    });
+    expect(seen.sort()).toEqual([1, 2, 3, 4]); // every item attempted
+    expect(summarize(out)).toEqual({ ok: 2, failed: 2 });
+    expect(out[0]).toEqual({ item: 1, status: "error", error: "Error: thrown" });
+  });
+
+  it("bounds concurrency to at most `concurrency` in flight", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const op = vi.fn(async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight--;
+      return { ok: true };
+    });
+    await runBulk(Array.from({ length: 20 }, (_, i) => i), op, 4);
+    expect(op).toHaveBeenCalledTimes(20);
+    expect(peak).toBeLessThanOrEqual(4);
+  });
+
+  it("handles an empty list", async () => {
+    const op = vi.fn();
+    expect(await runBulk([], op)).toEqual([]);
+    expect(op).not.toHaveBeenCalled();
+  });
+
+  it("treats `{ deleted: true }` and `{ ok: true }` as success (no error only)", async () => {
+    const out = await runBulk(["a", "b"], async (s) => (s === "a" ? { deleted: true } : { ok: true }));
+    expect(summarize(out)).toEqual({ ok: 2, failed: 0 });
+  });
+});

--- a/apps/desktop/src/lib/bulk.ts
+++ b/apps/desktop/src/lib/bulk.ts
@@ -1,0 +1,57 @@
+/**
+ * Run one operation over many items, collecting a per-item outcome. A failing
+ * item never aborts the rest (partial failures are expected and reported), and
+ * concurrency is bounded so a 50-item bulk delete doesn't hammer the apiserver.
+ */
+
+/** The outcome of a bulk operation on a single item. */
+export interface BulkOutcome<T> {
+  item: T;
+  status: "ok" | "error";
+  error?: string;
+}
+
+/** A per-item result from any of the action wrappers (`{ ok }` / `{ deleted }`
+ *  / `{ error }`). Success is the absence of an `error`. */
+export type ActionOutcome = { ok?: boolean; deleted?: boolean; error?: string };
+
+/**
+ * Apply `op` to every item with at most `concurrency` in flight, returning an
+ * outcome per item in the original order. Never throws and never short-circuits:
+ * each item's failure is captured, the others continue.
+ */
+export async function runBulk<T>(
+  items: readonly T[],
+  op: (item: T) => Promise<ActionOutcome>,
+  concurrency = 8,
+): Promise<BulkOutcome<T>[]> {
+  const results: BulkOutcome<T>[] = new Array(items.length);
+  let next = 0;
+
+  const worker = async () => {
+    for (let i = next++; i < items.length; i = next++) {
+      const item = items[i];
+      try {
+        const r = await op(item);
+        results[i] = r.error ? { item, status: "error", error: r.error } : { item, status: "ok" };
+      } catch (e) {
+        results[i] = { item, status: "error", error: String(e) };
+      }
+    }
+  };
+
+  const workers = Math.max(1, Math.min(concurrency, items.length));
+  await Promise.all(Array.from({ length: workers }, worker));
+  return results;
+}
+
+/** Summary counts for a completed bulk run. */
+export function summarize<T>(outcomes: BulkOutcome<T>[]): { ok: number; failed: number } {
+  let ok = 0;
+  let failed = 0;
+  for (const o of outcomes) {
+    if (o.status === "ok") ok++;
+    else failed++;
+  }
+  return { ok, failed };
+}

--- a/apps/desktop/src/ui/Table.test.tsx
+++ b/apps/desktop/src/ui/Table.test.tsx
@@ -158,3 +158,49 @@ describe("Table", () => {
     expect(header?.closest("table")?.style.width).toBe("");
   });
 });
+
+describe("Table multi-selection", () => {
+  const cols: Column<{ name: string }>[] = [{ key: "name", header: "Name" }];
+  const rows = [{ name: "a" }, { name: "b" }, { name: "c" }, { name: "d" }];
+
+  function renderWithSelection(selected = new Set<string>()) {
+    const onChange = vi.fn();
+    const utils = render(
+      <Table
+        columns={cols}
+        data={rows}
+        getRowKey={(r) => r.name}
+        selection={{ selected, onChange }}
+      />,
+    );
+    return { onChange, ...utils };
+  }
+
+  it("toggles a single row", () => {
+    const { onChange } = renderWithSelection();
+    fireEvent.click(screen.getByLabelText("Select b"));
+    expect([...onChange.mock.calls[0][0]]).toEqual(["b"]);
+  });
+
+  it("select-all header selects every (filtered) row", () => {
+    const { onChange } = renderWithSelection();
+    fireEvent.click(screen.getByLabelText("Select all"));
+    expect([...onChange.mock.calls[0][0]].sort()).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("shift-click selects the range from the anchor", () => {
+    const { onChange, rerender } = renderWithSelection();
+    fireEvent.click(screen.getByLabelText("Select a")); // anchor = a
+    const selected = onChange.mock.calls[0][0] as Set<string>;
+    rerender(
+      <Table columns={cols} data={rows} getRowKey={(r) => r.name} selection={{ selected, onChange }} />,
+    );
+    fireEvent.click(screen.getByLabelText("Select c"), { shiftKey: true });
+    expect([...onChange.mock.calls[1][0]].sort()).toEqual(["a", "b", "c"]);
+  });
+
+  it("header checkbox is checked when all rows are selected", () => {
+    renderWithSelection(new Set(["a", "b", "c", "d"]));
+    expect((screen.getByLabelText("Select all") as HTMLInputElement).checked).toBe(true);
+  });
+});

--- a/apps/desktop/src/ui/Table.tsx
+++ b/apps/desktop/src/ui/Table.tsx
@@ -23,6 +23,14 @@ export interface Column<T> {
   minWidth?: number;
 }
 
+/** Opt-in multi-selection: the parent holds the set of selected row keys, the
+ *  Table owns the interaction (toggle, shift-click range over the sorted order,
+ *  select-all-of-filtered) and reports the new set. */
+export interface TableSelection {
+  selected: Set<string>;
+  onChange: (next: Set<string>) => void;
+}
+
 export interface TableProps<T> {
   columns: Column<T>[];
   data: T[];
@@ -30,6 +38,8 @@ export interface TableProps<T> {
   onRowClick?: (row: T) => void;
   /** Row key currently selected (highlighted). */
   selectedKey?: string;
+  /** When set, renders a leading checkbox column for bulk selection. */
+  selection?: TableSelection;
   /** Shown when `data` is empty. */
   emptyText?: React.ReactNode;
   /** Column currently used by the toolbar search; null searches every column. */
@@ -94,11 +104,14 @@ export function Table<T>({
   getRowKey,
   onRowClick,
   selectedKey,
+  selection,
   emptyText = "No items",
   activeFilterKey = null,
   onActiveFilterKeyChange,
 }: TableProps<T>) {
   const [sort, setSort] = useState<{ key: string; direction: "asc" | "desc" } | null>(null);
+  // Anchor for shift-click range selection (a key in sorted/visible order).
+  const selectionAnchor = useRef<string | null>(null);
   const [columnWidths, setColumnWidths] = useState<Record<string, number>>({});
   const columnSignature = columns.map((column) => column.key).join("|");
   const rootRef = useRef<HTMLDivElement>(null);
@@ -124,6 +137,38 @@ export function Table<T>({
       .map(({ row }) => row);
   }, [columns, data, sort]);
 
+  // Selection: keys in the order the user sees them (for shift-range + select-all).
+  const visibleKeys = useMemo(() => visibleData.map(getRowKey), [visibleData, getRowKey]);
+  const colCount = columns.length + (selection ? 1 : 0);
+  const allVisibleSelected =
+    !!selection && visibleKeys.length > 0 && visibleKeys.every((k) => selection.selected.has(k));
+
+  const toggleAllVisible = () => {
+    if (!selection) return;
+    const next = new Set(selection.selected);
+    if (allVisibleSelected) visibleKeys.forEach((k) => next.delete(k));
+    else visibleKeys.forEach((k) => next.add(k));
+    selection.onChange(next);
+  };
+
+  const toggleRow = (key: string, shift: boolean) => {
+    if (!selection) return;
+    const next = new Set(selection.selected);
+    const anchor = selectionAnchor.current;
+    const from = anchor ? visibleKeys.indexOf(anchor) : -1;
+    const to = visibleKeys.indexOf(key);
+    if (shift && from >= 0 && to >= 0) {
+      const [lo, hi] = from < to ? [from, to] : [to, from];
+      for (let i = lo; i <= hi; i++) next.add(visibleKeys[i]);
+    } else if (next.has(key)) {
+      next.delete(key);
+    } else {
+      next.add(key);
+    }
+    selectionAnchor.current = key;
+    selection.onChange(next);
+  };
+
   const cycleSort = (key: string) => {
     setSort((current) => {
       if (!current || current.key !== key) return { key, direction: "asc" };
@@ -137,10 +182,16 @@ export function Table<T>({
     event.stopPropagation();
     const table = event.currentTarget.closest("table");
     const headers = table?.querySelectorAll<HTMLTableCellElement>("thead tr:first-child th");
+    // The checkbox column (when present) is th[0], so data columns are offset.
+    const headOffset = selection ? 1 : 0;
     const measured = Object.fromEntries(
       columns.map((candidate, index) => [
         candidate.key,
-        Math.round(headers?.[index]?.getBoundingClientRect().width || columnWidths[candidate.key] || 120),
+        Math.round(
+          headers?.[index + headOffset]?.getBoundingClientRect().width ||
+            columnWidths[candidate.key] ||
+            120,
+        ),
       ]),
     );
     const startWidth = measured[column.key];
@@ -172,10 +223,16 @@ export function Table<T>({
     event.preventDefault();
     const table = event.currentTarget.closest("table");
     const headers = table?.querySelectorAll<HTMLTableCellElement>("thead tr:first-child th");
+    // The checkbox column (when present) is th[0], so data columns are offset.
+    const headOffset = selection ? 1 : 0;
     const measured = Object.fromEntries(
       columns.map((candidate, index) => [
         candidate.key,
-        Math.round(headers?.[index]?.getBoundingClientRect().width || columnWidths[candidate.key] || 120),
+        Math.round(
+          headers?.[index + headOffset]?.getBoundingClientRect().width ||
+            columnWidths[candidate.key] ||
+            120,
+        ),
       ]),
     );
     const delta = event.key === "ArrowRight" ? 16 : -16;
@@ -255,6 +312,7 @@ export function Table<T>({
       style={tableWidth ? { width: tableWidth, minWidth: "100%" } : undefined}
     >
       <colgroup>
+        {selection && <col style={{ width: 36 }} />}
         {columns.map((column) => (
           <col
             key={column.key}
@@ -264,6 +322,19 @@ export function Table<T>({
       </colgroup>
       <TableHeader className="sticky top-0 z-10">
         <TableRow className="hover:bg-transparent">
+          {selection && (
+            <TableHead className="fl-data-table__head fl-data-table__checkbox">
+              <input
+                type="checkbox"
+                aria-label="Select all"
+                checked={allVisibleSelected}
+                ref={(el) => {
+                  if (el) el.indeterminate = !allVisibleSelected && visibleKeys.some((k) => selection.selected.has(k));
+                }}
+                onChange={toggleAllVisible}
+              />
+            </TableHead>
+          )}
           {columns.map((c) => (
             <TableHead key={c.key} className="fl-data-table__head">
               <div className="fl-data-table__head-content">
@@ -314,20 +385,35 @@ export function Table<T>({
       <TableBody>
         {topPad > 0 && (
           <tr aria-hidden="true" className="fl-data-table__spacer">
-            <td colSpan={columns.length} style={{ height: topPad, padding: 0, border: 0 }} />
+            <td colSpan={colCount} style={{ height: topPad, padding: 0, border: 0 }} />
           </tr>
         )}
         {windowRows.map((row) => {
           const rowKey = getRowKey(row);
           const selected = selectedKey === rowKey;
+          const checked = selection?.selected.has(rowKey) ?? false;
           return (
             <TableRow
               key={rowKey}
               aria-selected={selected}
-              data-state={selected ? "selected" : undefined}
+              data-state={selected || checked ? "selected" : undefined}
               onClick={onRowClick ? () => onRowClick(row) : undefined}
               className={cn("fl-data-table__row", onRowClick && "cursor-pointer")}
             >
+              {selection && (
+                <TableCell
+                  className="fl-data-table__cell fl-data-table__checkbox"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <input
+                    type="checkbox"
+                    aria-label={`Select ${rowKey}`}
+                    checked={checked}
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => toggleRow(rowKey, (e.nativeEvent as MouseEvent).shiftKey)}
+                  />
+                </TableCell>
+              )}
               {columns.map((c) => (
                 <TableCell key={c.key} className="fl-data-table__cell">
                   {c.render ? c.render(row) : String((row as Record<string, unknown>)[c.key])}
@@ -338,12 +424,12 @@ export function Table<T>({
         })}
         {bottomPad > 0 && (
           <tr aria-hidden="true" className="fl-data-table__spacer">
-            <td colSpan={columns.length} style={{ height: bottomPad, padding: 0, border: 0 }} />
+            <td colSpan={colCount} style={{ height: bottomPad, padding: 0, border: 0 }} />
           </tr>
         )}
         {visibleData.length === 0 && (
           <TableRow>
-            <TableCell colSpan={columns.length} className="fl-data-table__no-results">
+            <TableCell colSpan={colCount} className="fl-data-table__no-results">
               No matching items
             </TableCell>
           </TableRow>

--- a/apps/desktop/src/ui/styles.css
+++ b/apps/desktop/src/ui/styles.css
@@ -3514,6 +3514,38 @@ body {
   opacity: 1;
 }
 
+/* Bulk action bar (shown above the table when rows are selected). */
+.fl-bulk-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--fl-color-surface);
+  border-bottom: 1px solid var(--fl-color-border-faint);
+}
+.fl-bulk-bar__count {
+  font-size: 13px;
+  font-weight: 500;
+  margin-right: 4px;
+}
+.fl-bulk-bar__list {
+  margin: 8px 0;
+  padding-left: 18px;
+  max-height: 220px;
+  overflow: auto;
+}
+/* Checkbox column in the data table. */
+.fl-data-table__checkbox {
+  width: 36px;
+  text-align: center;
+  padding-right: 0;
+}
+.fl-data-table__checkbox input {
+  cursor: pointer;
+  margin: 0;
+  vertical-align: middle;
+}
+
 .fl-resource-toolbar {
   min-height: 52px;
   gap: 8px;


### PR DESCRIPTION
Closes #18 — the bulk-operations item on v0.3.

Select many rows in any resource table and apply one action to all of them, with a single confirm listing exactly what's affected and per-item results (partial failures reported, never aborting the rest).

## What's here

- **`lib/bulk.ts`** — `runBulk` applies an op across N items with bounded concurrency (default 8), collecting an `ok`/`error` outcome per item in order; never throws or short-circuits.
- **`ui/Table.tsx`** — an opt-in `selection` prop adds a leading checkbox column: single toggle, **shift-click range** (over the sorted order the user sees), and **select-all-of-filtered**. Existing single-selection tables are untouched (the prop is optional).
- **`BulkActionBar`** — the bar shown when rows are selected. Offers the actions valid for the kind (Delete always; **Evict** for pods; **Rollout restart** for Deployment/StatefulSet/DaemonSet), gathers **one** `ConfirmDialog` listing the affected items, then runs them and shows a summary toast (or a per-failure detail toast).
- **`ResourceBrowser`** — rows keyed by `namespace/name` so an all-namespace view can't confuse two same-named resources; selection clears when the list changes shape (context / kind / namespace).

## Acceptance criterion

> Deleting 20 filtered pods is one flow with one confirm and a per-pod result list

✅ Select-all-of-filtered → Delete → one confirm listing them → `runBulk` deletes with bounded concurrency → summary toast (or per-failure detail).

## Testing

TDD across the stack: `runBulk` (order, partial-failure non-abort, bounded concurrency, empty), Table selection (toggle, shift-range, select-all, header checked state), `BulkActionBar` (pod bulk-delete + summary toast, partial-failure detail, deployment rollout-restart, evict offered only for pods). Full frontend suite **557 green**; `tsc` clean.