### PR TITLE
feat(debug): ephemeral debug containers + node debug shell capabilities (#17 backend)

### DIFF
--- a/apps/desktop/src-tauri/src/capabilities.rs
+++ b/apps/desktop/src-tauri/src/capabilities.rs
@@ -242,6 +242,8 @@ pub fn build_registry_with(cache: Arc<ClientCache>) -> Registry {
     ));
     reg.register(srelens_kube::actions::cordon_node_capability(cache.clone()));
     reg.register(srelens_kube::actions::drain_node_capability(cache.clone()));
+    reg.register(srelens_kube::debug::debug_pod_capability(cache.clone()));
+    reg.register(srelens_kube::debug::node_debug_pod_capability(cache.clone()));
     reg.register(srelens_kube::events::list_events_capability(cache.clone()));
     reg.register(srelens_kube::metrics::node_metrics_capability(
         cache.clone(),

--- a/apps/desktop/src-tauri/tests/e2e.rs
+++ b/apps/desktop/src-tauri/tests/e2e.rs
@@ -689,6 +689,20 @@ async fn run_suite() {
         "expected our fixture pods: {out}"
     );
 
+    // #17: attach an ephemeral debug container to a fixture pod. It can't be
+    // removed once added, but the whole namespace is torn down after the suite.
+    let debug_pod = out["pods"].as_array().unwrap()[0]["name"].as_str().unwrap().to_string();
+    let dbg = h
+        .ok(
+            "k8s.debugPod",
+            json!({ "context": ctx, "namespace": NS, "pod": debug_pod, "image": "busybox" }),
+        )
+        .await;
+    assert!(
+        dbg["container"].as_str().unwrap().starts_with("debugger-"),
+        "debug container name: {dbg}",
+    );
+
     let out = h
         .ok(
             "k8s.listDeployments",
@@ -892,6 +906,23 @@ async fn run_suite() {
 
     let out = h.ok("k8s.listNodes", json!({ "context": ctx })).await;
     assert!(!out["nodes"].as_array().unwrap().is_empty());
+
+    // #17: create a privileged node debug pod, then tear it down immediately.
+    let node_name = out["nodes"].as_array().unwrap()[0]["name"].as_str().unwrap().to_string();
+    let nd = h
+        .ok(
+            "k8s.createNodeDebugPod",
+            json!({ "context": ctx, "node": node_name, "namespace": NS, "image": "busybox" }),
+        )
+        .await;
+    assert_eq!(nd["namespace"], NS);
+    let node_debug_pod = nd["pod"].as_str().unwrap().to_string();
+    assert!(node_debug_pod.starts_with("srelens-node-debug-"), "generated name: {nd}");
+    h.ok(
+        "k8s.deletePod",
+        json!({ "context": ctx, "namespace": NS, "pod": node_debug_pod }),
+    )
+    .await;
 
     let out = h
         .ok("k8s.listEvents", json!({ "context": ctx, "namespace": NS }))

--- a/crates/kube/src/debug.rs
+++ b/crates/kube/src/debug.rs
@@ -1,0 +1,234 @@
+//! Ephemeral debug containers and node debug shells (#17).
+//!
+//! Two destructive, confirm-gated capabilities that create a target you can then
+//! open an interactive shell into (via the existing exec pipeline):
+//!
+//! - `k8s.debugPod` patches an ephemeral debug container onto a running pod
+//!   (optionally sharing another container's process namespace) and returns its
+//!   name — exec into that name for a debugger shell beside a distroless app.
+//! - `k8s.createNodeDebugPod` creates a privileged pod pinned to a node that
+//!   `nsenter`s into the host namespaces; the caller execs into it and deletes
+//!   it (via `k8s.deletePod`) when the shell closes.
+//!
+//! The JSON-building halves are pure and unit-tested; the API calls are covered
+//! by the kind integration suite.
+
+use std::sync::Arc;
+
+use k8s_openapi::api::core::v1::Pod;
+use kube::api::{Patch, PatchParams, PostParams};
+use kube::Api;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use srelens_capability::{Annotations, Capability, CapabilityError};
+
+use crate::client_cache::ClientCache;
+use crate::connect::request_timeout;
+
+/// A short, DNS-safe suffix so repeated debugs don't collide on the ephemeral
+/// container name (a name can't be reused once added to a pod).
+fn debug_container_name() -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(0);
+    format!("debugger-{:05x}", nanos & 0xf_ffff)
+}
+
+/// The strategic-merge patch that adds one ephemeral container to a pod. A
+/// strategic merge concatenates the `ephemeralContainers` list, so existing
+/// debuggers are preserved. `stdin`/`tty` are set so a shell can attach.
+pub fn ephemeral_patch(name: &str, image: &str, target_container: Option<&str>) -> Value {
+    let mut container = json!({
+        "name": name,
+        "image": image,
+        "stdin": true,
+        "tty": true,
+        "command": ["/bin/sh"],
+    });
+    if let Some(target) = target_container.filter(|t| !t.is_empty()) {
+        container["targetContainerName"] = json!(target);
+    }
+    json!({ "spec": { "ephemeralContainers": [container] } })
+}
+
+/// The privileged, host-namespaced debug pod spec pinned to `node`. It shares
+/// the host PID/network/IPC namespaces and `nsenter`s into PID 1's namespaces to
+/// give a real shell on the node. `restartPolicy: Never` + tolerations so it
+/// schedules on any (even tainted) node and doesn't restart after exit.
+pub fn node_debug_pod_spec(node: &str, image: &str) -> Value {
+    json!({
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": { "generateName": "srelens-node-debug-" },
+        "spec": {
+            "nodeName": node,
+            "hostPID": true,
+            "hostNetwork": true,
+            "hostIPC": true,
+            "restartPolicy": "Never",
+            "tolerations": [{ "operator": "Exists" }],
+            "containers": [{
+                "name": "debug",
+                "image": image,
+                "securityContext": { "privileged": true },
+                "stdin": true,
+                "tty": true,
+                "command": [
+                    "nsenter", "--target", "1",
+                    "--mount", "--uts", "--ipc", "--net", "--pid",
+                    "--", "/bin/sh",
+                ],
+            }],
+        }
+    })
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DebugPodIn {
+    pub context: String,
+    pub namespace: String,
+    pub pod: String,
+    /// The debugger image (e.g. `busybox`, `nicolaka/netshoot`).
+    pub image: String,
+    /// Optional container whose process namespace the debugger shares, so its
+    /// processes and filesystem (`/proc/1/root`) are visible.
+    #[serde(default)]
+    pub target_container: Option<String>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct DebugPodOut {
+    /// The ephemeral container that was added — exec into this for a shell.
+    pub container: String,
+}
+
+/// `k8s.debugPod` — attach an ephemeral debug container to a running pod.
+pub fn debug_pod_capability(cache: Arc<ClientCache>) -> Capability {
+    Capability::typed::<DebugPodIn, DebugPodOut, _, _>(
+        "k8s.debugPod",
+        "attach an ephemeral debug container to a running pod and return its \
+         name; exec into that container for a debugger shell (destructive)",
+        Annotations::DESTRUCTIVE,
+        move |input: DebugPodIn| {
+            let cache = cache.clone();
+            async move {
+                let client = cache.get(&input.context).await.map_err(CapabilityError::Handler)?;
+                let api: Api<Pod> = Api::namespaced(client, &input.namespace);
+                let name = debug_container_name();
+                let patch = ephemeral_patch(&name, &input.image, input.target_container.as_deref());
+                tokio::time::timeout(
+                    request_timeout(),
+                    api.patch_ephemeral_containers(&input.pod, &PatchParams::default(), &Patch::Strategic(patch)),
+                )
+                .await
+                .map_err(|_| CapabilityError::Handler("debug pod timed out".into()))?
+                .map_err(|e| CapabilityError::Handler(e.to_string()))?;
+                Ok(DebugPodOut { container: name })
+            }
+        },
+    )
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct NodeDebugIn {
+    pub context: String,
+    pub node: String,
+    /// Image for the debug pod (needs `nsenter`); defaults to `busybox`.
+    #[serde(default)]
+    pub image: Option<String>,
+    /// Namespace to create the debug pod in; defaults to `default`.
+    #[serde(default)]
+    pub namespace: Option<String>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct NodeDebugOut {
+    pub namespace: String,
+    pub pod: String,
+}
+
+/// `k8s.createNodeDebugPod` — create a privileged host-namespaced pod on a node.
+/// The caller execs into it and deletes it (via `k8s.deletePod`) when done.
+pub fn node_debug_pod_capability(cache: Arc<ClientCache>) -> Capability {
+    Capability::typed::<NodeDebugIn, NodeDebugOut, _, _>(
+        "k8s.createNodeDebugPod",
+        "create a privileged debug pod on a node that nsenters into the host \
+         namespaces; delete it when the shell closes (destructive)",
+        Annotations::DESTRUCTIVE,
+        move |input: NodeDebugIn| {
+            let cache = cache.clone();
+            async move {
+                let namespace = input.namespace.unwrap_or_else(|| "default".to_string());
+                let image = input.image.unwrap_or_else(|| "busybox".to_string());
+                let spec = node_debug_pod_spec(&input.node, &image);
+                let pod: Pod = serde_json::from_value(spec)
+                    .map_err(|e| CapabilityError::Handler(e.to_string()))?;
+                let client = cache.get(&input.context).await.map_err(CapabilityError::Handler)?;
+                let api: Api<Pod> = Api::namespaced(client, &namespace);
+                let created = tokio::time::timeout(
+                    request_timeout(),
+                    api.create(&PostParams::default(), &pod),
+                )
+                .await
+                .map_err(|_| CapabilityError::Handler("create node debug pod timed out".into()))?
+                .map_err(|e| CapabilityError::Handler(e.to_string()))?;
+                let pod = created
+                    .metadata
+                    .name
+                    .ok_or_else(|| CapabilityError::Handler("created pod has no name".into()))?;
+                Ok(NodeDebugOut { namespace, pod })
+            }
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ephemeral_patch_sets_stdin_tty_and_optional_target() {
+        let p = ephemeral_patch("debugger-1", "busybox", None);
+        let c = &p["spec"]["ephemeralContainers"][0];
+        assert_eq!(c["name"], "debugger-1");
+        assert_eq!(c["image"], "busybox");
+        assert_eq!(c["stdin"], true);
+        assert_eq!(c["tty"], true);
+        assert!(c.get("targetContainerName").is_none());
+
+        let p = ephemeral_patch("debugger-2", "netshoot", Some("app"));
+        assert_eq!(p["spec"]["ephemeralContainers"][0]["targetContainerName"], "app");
+    }
+
+    #[test]
+    fn ephemeral_patch_deserializes_into_a_pod() {
+        // The strategic patch body must be a valid partial Pod.
+        let p = ephemeral_patch("debugger-3", "busybox", Some("web"));
+        let pod: Pod = serde_json::from_value(p).expect("valid pod patch");
+        let ec = pod.spec.unwrap().ephemeral_containers.unwrap();
+        assert_eq!(ec[0].name, "debugger-3");
+        assert_eq!(ec[0].target_container_name.as_deref(), Some("web"));
+    }
+
+    #[test]
+    fn node_debug_pod_spec_is_privileged_host_namespaced_and_pinned() {
+        let spec = node_debug_pod_spec("node-1", "busybox");
+        let pod: Pod = serde_json::from_value(spec).expect("valid pod");
+        let s = pod.spec.unwrap();
+        assert_eq!(s.node_name.as_deref(), Some("node-1"));
+        assert_eq!(s.host_pid, Some(true));
+        assert_eq!(s.host_network, Some(true));
+        let c = &s.containers[0];
+        assert_eq!(c.security_context.as_ref().unwrap().privileged, Some(true));
+        assert!(c.command.as_ref().unwrap().iter().any(|a| a == "nsenter"));
+    }
+
+    #[test]
+    fn debug_container_name_is_dns_safe_and_prefixed() {
+        let n = debug_container_name();
+        assert!(n.starts_with("debugger-"));
+        assert!(n.bytes().all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-'));
+    }
+}

--- a/crates/kube/src/lib.rs
+++ b/crates/kube/src/lib.rs
@@ -96,6 +96,7 @@ pub mod client_cache;
 pub mod cluster;
 pub mod crds;
 pub mod connect;
+pub mod debug;
 pub mod contexts;
 pub mod configmaps;
 pub mod cronjobs;


### PR DESCRIPTION
Backend for #17 (v0.3 debug feature) — the two capabilities; the interactive terminal + UI follow in a second PR.

## Capabilities (both destructive, confirm-gated, MCP-exposed)

- **`k8s.debugPod`** — patches an ephemeral debug container onto a running pod (optional `targetContainer` for process-namespace sharing so you see the app's processes and `/proc/1/root`) via kube 0.96's native `patch_ephemeral_containers`, and returns the container name. Exec into that name to debug a **distroless** pod that has no shell of its own.
- **`k8s.createNodeDebugPod`** — creates a privileged, host-namespaced (`hostPID`/`hostNetwork`/`hostIPC`) pod pinned to a node that `nsenter`s into the host's namespaces. The caller execs in and deletes it (via the existing `k8s.deletePod`) when the shell closes.

## Design

The JSON-building halves — `ephemeral_patch` and `node_debug_pod_spec` — are pure and unit-tested, including round-tripping through the k8s-openapi `Pod` type so the patch/spec are provably valid. The API calls follow the same `Api<Pod>` + timeout pattern as the existing write capabilities. Registering them gets MCP + consent-gating for free (`Annotations::DESTRUCTIVE`).

## Testing

- 4 unit tests (patch shape + optional target, node spec is privileged/host-namespaced/pinned, name is DNS-safe).
- **Real integration in the kind e2e suite**: an ephemeral container is added to a fixture pod (asserts the returned `debugger-*` name), and a node debug pod is created and immediately torn down.
- kube suite **246 green**, app MCP completeness green, clippy clean.

## Next (PR 2)

The GUI: a "Debug" button on pods (image/target picker → ephemeral container → terminal into it) and a "Node shell" on nodes (create → terminal → delete on close), reusing the existing `ExecManager` / `exec_shell` pipeline, plus command-palette entries.