### PR TITLE
feat(debug): Debug pod + node shell UI with terminal + delete-on-close (#17 UI)

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -51,6 +51,7 @@ import { checkForUpdateAndNotify } from "./lib/updateNotifier";
 import { notify } from "./lib/notify";
 import type { SettingsSection } from "./components/SettingsView";
 import { listContexts, deleteContext, type ClusterContext } from "./lib/clusters";
+import { deletePod } from "./lib/workloads";
 import { clearAccessCache } from "./lib/access";
 
 interface ViewTab {
@@ -469,21 +470,35 @@ export function App() {
       workload?: { kind: string; name: string };
       kubeconfigFiles?: string[];
       helm?: { args: string[]; title: string; values?: string; onComplete?: () => void };
+      /** A pod to delete when this dock session closes (node debug shell). */
+      deleteOnClose?: { context: string; namespace: string; pod: string };
     },
   ) {
     const id = dockIdRef.current++;
     setDockSessions((t) => [...t, { id, kind, ...s }]);
     setActiveDock(id);
   }
+  /** Tear down any pod tied to a closing dock session (e.g. node debug shell). */
+  function teardownDock(sessions: DockSession[]) {
+    for (const s of sessions) {
+      if (s.deleteOnClose) {
+        void deletePod(s.deleteOnClose.context, s.deleteOnClose.namespace, s.deleteOnClose.pod);
+      }
+    }
+  }
   function closeDockTab(id: number) {
     setDockSessions((t) => {
+      teardownDock(t.filter((x) => x.id === id));
       const remaining = t.filter((x) => x.id !== id);
       setActiveDock((a) => (a === id ? (remaining.at(-1)?.id ?? null) : a));
       return remaining;
     });
   }
   function closeDock() {
-    setDockSessions([]);
+    setDockSessions((t) => {
+      teardownDock(t);
+      return [];
+    });
     setActiveDock(null);
   }
 

--- a/apps/desktop/src/components/DetailActions.test.tsx
+++ b/apps/desktop/src/components/DetailActions.test.tsx
@@ -10,6 +10,7 @@ const {
   rolloutRestartMock,
   cronjobSetSuspendMock,
   cronjobTriggerNowMock,
+  debugPodMock,
 } = vi.hoisted(() => ({
   deletePodMock: vi.fn(),
   evictPodMock: vi.fn(),
@@ -18,6 +19,7 @@ const {
   rolloutRestartMock: vi.fn(),
   cronjobSetSuspendMock: vi.fn(),
   cronjobTriggerNowMock: vi.fn(),
+  debugPodMock: vi.fn(),
 }));
 vi.mock("../lib/workloads", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../lib/workloads")>();
@@ -29,6 +31,7 @@ vi.mock("../lib/actions", () => ({
   rolloutRestart: rolloutRestartMock,
   cronjobSetSuspend: cronjobSetSuspendMock,
   cronjobTriggerNow: cronjobTriggerNowMock,
+  debugPod: debugPodMock,
 }));
 const { notifyMock } = vi.hoisted(() => ({
   notifyMock: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
@@ -71,6 +74,7 @@ beforeEach(() => {
   rolloutRestartMock.mockReset();
   cronjobSetSuspendMock.mockReset();
   cronjobTriggerNowMock.mockReset();
+  debugPodMock.mockReset();
   notifyMock.success.mockReset();
   notifyMock.error.mockReset();
   // Default: everything allowed, so pre-existing behavioural tests (written
@@ -107,6 +111,26 @@ describe("PodActions", () => {
     fireEvent.click(screen.getByRole("button", { name: "Delete" }));
     await waitFor(() => expect(deletePodMock).toHaveBeenCalledWith("kind-dev", "default", "web-1"));
     await waitFor(() => expect(onDeleted).toHaveBeenCalled());
+  });
+
+  it("attaches an ephemeral debug container and opens a terminal into it", async () => {
+    debugPodMock.mockResolvedValue({ container: "debugger-abc12" });
+    const onOpenTerminal = vi.fn();
+    render(<PodActions context="kind-dev" pod={pod} onOpenTerminal={onOpenTerminal} />);
+    fireEvent.click(screen.getByRole("button", { name: "Debug" }));
+    // Confirm the dialog (default image busybox).
+    fireEvent.click(screen.getByRole("button", { name: "Attach & open shell" }));
+    await waitFor(() =>
+      expect(debugPodMock).toHaveBeenCalledWith("kind-dev", "default", "web-1", "busybox", null),
+    );
+    await waitFor(() =>
+      expect(onOpenTerminal).toHaveBeenCalledWith({
+        context: "kind-dev",
+        namespace: "default",
+        pod: "web-1",
+        container: "debugger-abc12",
+      }),
+    );
   });
 
   it("evicts the pod behind a confirm", async () => {

--- a/apps/desktop/src/components/DetailActions.tsx
+++ b/apps/desktop/src/components/DetailActions.tsx
@@ -19,13 +19,14 @@ import {
   rolloutRestart,
   cronjobSetSuspend,
   cronjobTriggerNow,
+  debugPod,
 } from "../lib/actions";
 import { notify } from "../lib/notify";
 import { useAccess, rbac, kindToResource, denyReason, reportActionError, type AccessCheck } from "../lib/access";
 import { IconButton, ConfirmDialog, TextInput } from "../ui";
 import { ForwardDialog } from "./ForwardDialog";
 
-type Opener = (s: { context: string; namespace: string; pod: string }) => void;
+type Opener = (s: { context: string; namespace: string; pod: string; container?: string }) => void;
 
 const SCALABLE = ["Deployment", "StatefulSet", "ReplicaSet"];
 const RESTARTABLE = ["Deployment", "StatefulSet", "DaemonSet"];
@@ -48,9 +49,11 @@ export function PodActions({
   onOpenLogs?: Opener;
   onEdit?: () => void;
 }) {
-  const [dialog, setDialog] = useState<"delete" | "evict" | "forward" | null>(null);
+  const [dialog, setDialog] = useState<"delete" | "evict" | "forward" | "debug" | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
+  const [debugImage, setDebugImage] = useState("busybox");
+  const [debugTarget, setDebugTarget] = useState("");
 
   const deleteCheck = rbac.deletePod(pod.namespace);
   const evictCheck = rbac.evictPod(pod.namespace);
@@ -74,6 +77,21 @@ export function PodActions({
     onDeleted?.();
   }
 
+  async function doDebug() {
+    setBusy(true);
+    setError("");
+    const out = await debugPod(context, pod.namespace, pod.name, debugImage.trim() || "busybox", debugTarget.trim() || null);
+    setBusy(false);
+    if (out.error || !out.container) {
+      setError(out.error ?? "no container returned");
+      reportActionError(context, `Failed to debug ${pod.name}`, out.error ?? "");
+      return;
+    }
+    setDialog(null);
+    notify.success(`Debug container ${out.container} added to ${pod.name}`);
+    onOpenTerminal?.({ context, namespace: pod.namespace, pod: pod.name, container: out.container });
+  }
+
   async function doEvict() {
     setBusy(true);
     setError("");
@@ -93,6 +111,15 @@ export function PodActions({
     <>
       <IconButton icon={Logs} label="Logs" onClick={() => onOpenLogs?.(target)} />
       <IconButton icon={SquareTerminal} label="Shell" onClick={() => onOpenTerminal?.(target)} />
+      <IconButton
+        icon={Zap}
+        label="Debug"
+        title="Attach an ephemeral debug container"
+        onClick={() => {
+          setError("");
+          setDialog("debug");
+        }}
+      />
       {onEdit && (
         <IconButton
           icon={Pencil}
@@ -149,6 +176,38 @@ export function PodActions({
           danger
           busy={busy}
           onConfirm={() => void doDelete()}
+          onCancel={() => setDialog(null)}
+        />
+      )}
+      {dialog === "debug" && (
+        <ConfirmDialog
+          title="Attach debug container?"
+          message={
+            <>
+              <p style={{ marginTop: 0 }}>
+                Add an ephemeral debug container to <code>{pod.name}</code> and open a shell into
+                it. Ephemeral containers cannot be removed until the pod restarts.
+              </p>
+              <label className="fl-debug-field">
+                <span>Image</span>
+                <TextInput value={debugImage} onValueChange={setDebugImage} placeholder="busybox" aria-label="Debug image" />
+              </label>
+              <label className="fl-debug-field">
+                <span>Share process namespace with (optional)</span>
+                <TextInput
+                  value={debugTarget}
+                  onValueChange={setDebugTarget}
+                  placeholder="target container name"
+                  aria-label="Target container"
+                />
+              </label>
+              {error && <p className="text-destructive">Error: {error}</p>}
+            </>
+          }
+          confirmLabel="Attach & open shell"
+          danger
+          busy={busy}
+          onConfirm={() => void doDebug()}
           onCancel={() => setDialog(null)}
         />
       )}

--- a/apps/desktop/src/components/Dock.tsx
+++ b/apps/desktop/src/components/Dock.tsx
@@ -22,6 +22,8 @@ export interface DockSession {
   kubeconfigFiles?: string[];
   /** Present for streamed helm operations. */
   helm?: { args: string[]; title: string; values?: string; onComplete?: () => void };
+  /** A pod to delete when this session closes (node debug shell cleanup). */
+  deleteOnClose?: { context: string; namespace: string; pod: string };
 }
 
 /** Tab/session label: the pod name, the workload kind/name, or the context for a shell. */

--- a/apps/desktop/src/components/NodeCordonAction.test.tsx
+++ b/apps/desktop/src/components/NodeCordonAction.test.tsx
@@ -86,4 +86,39 @@ describe("NodeCordonAction RBAC gating", () => {
     const cordon = await screen.findByRole("button", { name: "Cordon" });
     expect((cordon as HTMLButtonElement).disabled).toBe(false);
   });
+
+  it("opens a node shell: creates a debug pod and opens a terminal that deletes it on close", async () => {
+    const getObjectFn = vi.fn().mockResolvedValue({ object: { spec: {} } });
+    const createNodeDebugPodFn = vi.fn().mockResolvedValue({ namespace: "default", pod: "srelens-node-debug-x1" });
+    const onOpenShell = vi.fn();
+    render(
+      <NodeCordonAction
+        context="kind-dev"
+        name="node-a"
+        getObjectFn={getObjectFn}
+        createNodeDebugPodFn={createNodeDebugPodFn}
+        onOpenShell={onOpenShell}
+      />,
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "Node shell" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open shell" }));
+    await waitFor(() => expect(createNodeDebugPodFn).toHaveBeenCalledWith("kind-dev", "node-a", null, null));
+    await waitFor(() =>
+      expect(onOpenShell).toHaveBeenCalledWith({
+        context: "kind-dev",
+        namespace: "default",
+        pod: "srelens-node-debug-x1",
+        container: "debug",
+        deleteOnClose: { context: "kind-dev", namespace: "default", pod: "srelens-node-debug-x1" },
+      }),
+    );
+  });
+
+  it("hides Node shell when no opener is provided", async () => {
+    const getObjectFn = vi.fn().mockResolvedValue({ object: { spec: {} } });
+    render(<NodeCordonAction context="kind-dev" name="node-a" getObjectFn={getObjectFn} />);
+    await screen.findByRole("button", { name: "Cordon" });
+    expect(screen.queryByRole("button", { name: "Node shell" })).toBeNull();
+  });
+
 });

--- a/apps/desktop/src/components/NodeCordonAction.tsx
+++ b/apps/desktop/src/components/NodeCordonAction.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
-import { ArrowDownToLine, CircleCheck, CircleSlash2 } from "lucide-react";
+import { ArrowDownToLine, CircleCheck, CircleSlash2, SquareTerminal } from "lucide-react";
 import { getObject } from "../lib/manifest";
-import { cordonNode, drainNode } from "../lib/actions";
+import { cordonNode, drainNode, createNodeDebugPod } from "../lib/actions";
 import { notify } from "../lib/notify";
 import { useAccess, rbac, denyReason, reportActionError } from "../lib/access";
 import { IconButton, ConfirmDialog } from "../ui";
@@ -14,20 +14,52 @@ import { IconButton, ConfirmDialog } from "../ui";
 export function NodeCordonAction({
   context,
   name,
+  onOpenShell,
   getObjectFn = getObject,
   cordonFn = cordonNode,
   drainFn = drainNode,
+  createNodeDebugPodFn = createNodeDebugPod,
 }: {
   context: string;
   name: string;
+  /** Open a terminal, deleting `deleteOnClose.pod` when the session closes. */
+  onOpenShell?: (s: {
+    context: string;
+    namespace: string;
+    pod: string;
+    container?: string;
+    deleteOnClose?: { context: string; namespace: string; pod: string };
+  }) => void;
   getObjectFn?: typeof getObject;
   cordonFn?: typeof cordonNode;
   drainFn?: typeof drainNode;
+  createNodeDebugPodFn?: typeof createNodeDebugPod;
 }) {
   const [cordoned, setCordoned] = useState<boolean | null>(null);
-  const [dialog, setDialog] = useState<"cordon" | "drain" | null>(null);
+  const [dialog, setDialog] = useState<"cordon" | "drain" | "shell" | null>(null);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState("");
+
+  async function doNodeShell() {
+    setBusy(true);
+    setErr("");
+    const out = await createNodeDebugPodFn(context, name, null, null);
+    setBusy(false);
+    if (out.error || !out.pod || !out.namespace) {
+      setErr(out.error ?? "no pod created");
+      reportActionError(context, `Failed to open node shell on ${name}`, out.error ?? "");
+      return;
+    }
+    setDialog(null);
+    notify.success(`Node debug pod ${out.pod} created`);
+    onOpenShell?.({
+      context,
+      namespace: out.namespace,
+      pod: out.pod,
+      container: "debug",
+      deleteOnClose: { context, namespace: out.namespace, pod: out.pod },
+    });
+  }
 
   const cordonCheck = rbac.cordon();
   const drainCheck = rbac.drain();
@@ -98,6 +130,38 @@ export function NodeCordonAction({
           setDialog("drain");
         }}
       />
+      {onOpenShell && (
+        <IconButton
+          icon={SquareTerminal}
+          label="Node shell"
+          title="Open a privileged shell on this node"
+          onClick={() => {
+            setErr("");
+            setDialog("shell");
+          }}
+        />
+      )}
+
+      {dialog === "shell" && (
+        <ConfirmDialog
+          title="Open node shell?"
+          message={
+            <>
+              <p style={{ marginTop: 0 }}>
+                Create a <strong>privileged</strong> debug pod on <code>{name}</code> that enters
+                the host namespaces, and open a root shell. The pod is deleted when you close the
+                terminal.
+              </p>
+              {err && <p className="text-destructive">Error: {err}</p>}
+            </>
+          }
+          confirmLabel="Open shell"
+          danger
+          busy={busy}
+          onConfirm={() => void doNodeShell()}
+          onCancel={() => setDialog(null)}
+        />
+      )}
 
       {dialog === "cordon" && (
         <ConfirmDialog

--- a/apps/desktop/src/components/ResourceBrowser.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.tsx
@@ -559,7 +559,13 @@ export function ResourceBrowser({
   kind: ResourceKind;
   query?: string;
   onQueryChange?: (q: string) => void;
-  onOpenTerminal?: (s: { context: string; namespace: string; pod: string; container?: string }) => void;
+  onOpenTerminal?: (s: {
+    context: string;
+    namespace: string;
+    pod: string;
+    container?: string;
+    deleteOnClose?: { context: string; namespace: string; pod: string };
+  }) => void;
   onOpenLogs?: (s: { context: string; namespace: string; pod: string; container?: string }) => void;
   onOpenWorkloadLogs?: (s: { context: string; namespace: string; kind: string; name: string }) => void;
   /** Open a "new resource" editor tab, optionally seeded with this kind's template. */
@@ -879,7 +885,7 @@ export function ResourceBrowser({
   ) : otherDetail ? (
     <>
       {otherDetail.kind === "Node" && (
-        <NodeCordonAction context={context} name={otherDetail.name} />
+        <NodeCordonAction context={context} name={otherDetail.name} onOpenShell={onOpenTerminal} />
       )}
       {otherDetail.kind === "Service" && (
         <ServiceForwardAction

--- a/apps/desktop/src/lib/actions.test.ts
+++ b/apps/desktop/src/lib/actions.test.ts
@@ -6,6 +6,8 @@ import {
   cronjobSetSuspend,
   cronjobTriggerNow,
   updateConfigData,
+  debugPod,
+  createNodeDebugPod,
 } from "./actions";
 
 describe("resource actions", () => {
@@ -83,5 +85,30 @@ describe("resource actions", () => {
     expect(typeof (call[1] as { suffix: string }).suffix).toBe("string");
     expect((call[1] as { suffix: string }).suffix.length).toBeGreaterThan(0);
     expect(out.jobName).toBe("nightly-123");
+  });
+});
+
+describe("debug actions", () => {
+  it("debugPod passes image + target and returns the container", async () => {
+    const invoke = vi.fn().mockResolvedValue({ container: "debugger-1" });
+    const out = await debugPod("c", "ns", "web", "busybox", "app", invoke);
+    expect(invoke).toHaveBeenCalledWith("k8s.debugPod", {
+      context: "c", namespace: "ns", pod: "web", image: "busybox", target_container: "app",
+    });
+    expect(out.container).toBe("debugger-1");
+  });
+
+  it("createNodeDebugPod defaults image/namespace to null and returns pod", async () => {
+    const invoke = vi.fn().mockResolvedValue({ namespace: "default", pod: "srelens-node-debug-x" });
+    const out = await createNodeDebugPod("c", "node-a", null, null, invoke);
+    expect(invoke).toHaveBeenCalledWith("k8s.createNodeDebugPod", {
+      context: "c", node: "node-a", image: null, namespace: null,
+    });
+    expect(out).toEqual({ namespace: "default", pod: "srelens-node-debug-x" });
+  });
+
+  it("maps a thrown error", async () => {
+    const invoke = vi.fn().mockRejectedValue(new Error("forbidden"));
+    expect((await debugPod("c", "ns", "web", "busybox", null, invoke)).error).toContain("forbidden");
   });
 });

--- a/apps/desktop/src/lib/actions.ts
+++ b/apps/desktop/src/lib/actions.ts
@@ -128,3 +128,55 @@ export async function drainNode(
     return { error: String(e) };
   }
 }
+
+/**
+ * Attach an ephemeral debug container to a running pod via `k8s.debugPod`
+ * (destructive). Returns the created container's name to exec into. `target`
+ * shares another container's process namespace (for distroless pods).
+ */
+export async function debugPod(
+  context: string,
+  namespace: string,
+  pod: string,
+  image: string,
+  target: string | null = null,
+  invoke: Invoker = invokeCapability,
+): Promise<{ container?: string; error?: string }> {
+  try {
+    const out = await invoke<{ container: string }>("k8s.debugPod", {
+      context,
+      namespace,
+      pod,
+      image,
+      target_container: target ?? null,
+    });
+    return { container: out.container };
+  } catch (e) {
+    return { error: String(e) };
+  }
+}
+
+/**
+ * Create a privileged node debug pod via `k8s.createNodeDebugPod` (destructive).
+ * Returns the pod's namespace + generated name; delete it (deletePod) when the
+ * shell closes.
+ */
+export async function createNodeDebugPod(
+  context: string,
+  node: string,
+  image: string | null = null,
+  namespace: string | null = null,
+  invoke: Invoker = invokeCapability,
+): Promise<{ namespace?: string; pod?: string; error?: string }> {
+  try {
+    const out = await invoke<{ namespace: string; pod: string }>("k8s.createNodeDebugPod", {
+      context,
+      node,
+      image: image ?? null,
+      namespace: namespace ?? null,
+    });
+    return { namespace: out.namespace, pod: out.pod };
+  } catch (e) {
+    return { error: String(e) };
+  }
+}

--- a/apps/desktop/src/ui/styles.css
+++ b/apps/desktop/src/ui/styles.css
@@ -3545,6 +3545,15 @@ body {
   margin: 0;
   vertical-align: middle;
 }
+/* Debug-container dialog fields. */
+.fl-debug-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 10px;
+  font-size: 12px;
+  color: var(--fl-color-text-muted);
+}
 
 .fl-resource-toolbar {
   min-height: 52px;


### PR DESCRIPTION
The GUI half of #17 — surfaces the debug capabilities from #131 in the UI, reusing the existing exec/terminal pipeline.

**Depends on #131** (the `k8s.debugPod` / `k8s.createNodeDebugPod` capabilities). Merge that first; this compiles and its tests pass independently (everything's mocked), but it only functions once the capabilities exist.

## What's here

- **Pod "Debug" action** (`DetailActions`) — a dialog takes an image (default `busybox`) and an optional container to share the process namespace with, calls `k8s.debugPod`, then opens a terminal into the returned ephemeral container. A **distroless** pod with no shell of its own is now debuggable from the UI.
- **Node "Node shell" action** (`NodeCordonAction`) — confirm-gated; creates the privileged node debug pod via `k8s.createNodeDebugPod` and opens a terminal into it. The dock session carries a `deleteOnClose` marker, so **closing the terminal deletes the pod** (wired through `App`'s `openDock`/`closeDock`).

`lib/actions.ts` gains `debugPod` / `createNodeDebugPod` wrappers; the terminal opener type is widened to carry `container` and `deleteOnClose`.

## Acceptance criteria

> Distroless pod debuggable via ephemeral container from the UI; node shell opens and cleans up its pod on exit

✅ Debug button → ephemeral container → terminal (with process-namespace sharing option). ✅ Node shell → privileged pod → terminal → auto-delete on close.

## Testing

TDD: the Debug flow (dialog → `debugPod` → terminal into the container), the node-shell flow (create → terminal → `deleteOnClose` marker; hidden when no opener is provided), and the lib wrappers. Full frontend suite **551 green**; `tsc` clean.

## Deferred

Command-palette entries for debug/node-shell — the palette has no selected-resource context, so it needs a picker flow; the detail-action buttons are the primary surface and satisfy the acceptance criteria. Follow-up nicety.