### PR TITLE
fix(debug): node shell exec 500 — wait for running + nsenter via exec

### DIFF
--- a/apps/desktop/src-tauri/src/exec.rs
+++ b/apps/desktop/src-tauri/src/exec.rs
@@ -36,12 +36,14 @@ impl ExecManager {
 /// on `exec:out:<id>` and an `exec:exit:<id>` event fires (with an optional
 /// error string) when the session ends.
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn start_pod_exec(
     context: String,
     namespace: String,
     pod: String,
     container: Option<String>,
     shell: Option<String>,
+    command: Option<Vec<String>>,
     app: AppHandle,
     manager: State<'_, ExecManager>,
 ) -> Result<u64, String> {
@@ -60,6 +62,7 @@ pub async fn start_pod_exec(
             pod,
             container,
             shell,
+            command,
             move |chunk| {
                 let _ = app_out.emit(&out_channel, chunk);
             },

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -472,6 +472,8 @@ export function App() {
       helm?: { args: string[]; title: string; values?: string; onComplete?: () => void };
       /** A pod to delete when this dock session closes (node debug shell). */
       deleteOnClose?: { context: string; namespace: string; pod: string };
+      /** Override the terminal's exec command (node shell `nsenter …`). */
+      execCommand?: string[];
     },
   ) {
     const id = dockIdRef.current++;

--- a/apps/desktop/src/components/Dock.tsx
+++ b/apps/desktop/src/components/Dock.tsx
@@ -16,6 +16,8 @@ export interface DockSession {
   pod?: string;
   /** Preselect this container in single-pod logs (from a per-container action). */
   container?: string;
+  /** Override the exec command for a terminal (e.g. node shell `nsenter …`). */
+  execCommand?: string[];
   /** Present for workload (e.g. Deployment) logs that span many pods. */
   workload?: { kind: string; name: string };
   /** Extra kubeconfig files, for a local `shell` terminal scoped to the context. */
@@ -165,6 +167,7 @@ export function Dock({
                 namespace={s.namespace}
                 pod={s.pod}
                 container={s.container}
+                command={s.execCommand}
               />
             ) : (
               <LogsView

--- a/apps/desktop/src/components/NodeCordonAction.test.tsx
+++ b/apps/desktop/src/components/NodeCordonAction.test.tsx
@@ -109,6 +109,7 @@ describe("NodeCordonAction RBAC gating", () => {
         namespace: "default",
         pod: "srelens-node-debug-x1",
         container: "debug",
+        execCommand: expect.arrayContaining(["nsenter", "/bin/sh"]),
         deleteOnClose: { context: "kind-dev", namespace: "default", pod: "srelens-node-debug-x1" },
       }),
     );

--- a/apps/desktop/src/components/NodeCordonAction.tsx
+++ b/apps/desktop/src/components/NodeCordonAction.tsx
@@ -6,6 +6,12 @@ import { notify } from "../lib/notify";
 import { useAccess, rbac, denyReason, reportActionError } from "../lib/access";
 import { IconButton, ConfirmDialog } from "../ui";
 
+/** Enter the host's namespaces from the privileged debug pod for a real node
+ *  shell — run via exec (the pod itself just stays alive). */
+const NODE_SHELL_COMMAND = [
+  "nsenter", "--target", "1", "--mount", "--uts", "--ipc", "--net", "--pid", "--", "/bin/sh",
+];
+
 /**
  * Header actions for a node: cordon/uncordon and drain. Reads the node's
  * current `spec.unschedulable` to label the cordon toggle. `getObjectFn`/
@@ -29,6 +35,7 @@ export function NodeCordonAction({
     pod: string;
     container?: string;
     deleteOnClose?: { context: string; namespace: string; pod: string };
+    execCommand?: string[];
   }) => void;
   getObjectFn?: typeof getObject;
   cordonFn?: typeof cordonNode;
@@ -57,6 +64,7 @@ export function NodeCordonAction({
       namespace: out.namespace,
       pod: out.pod,
       container: "debug",
+      execCommand: NODE_SHELL_COMMAND,
       deleteOnClose: { context, namespace: out.namespace, pod: out.pod },
     });
   }

--- a/apps/desktop/src/components/PodTerminal.tsx
+++ b/apps/desktop/src/components/PodTerminal.tsx
@@ -11,12 +11,15 @@ export function PodTerminal({
   namespace,
   pod,
   container,
+  command,
 }: {
   context: string;
   namespace: string;
   pod: string;
   /** Exec into this specific container (for multi-container pods). */
   container?: string;
+  /** Override the exec command (e.g. the node shell's `nsenter …`). */
+  command?: string[];
 }) {
   const ref = useRef<HTMLDivElement>(null);
 
@@ -51,6 +54,7 @@ export function PodTerminal({
         (chunk) => term.write(chunk),
         (err) => term.write(`\r\n[session ended${err ? `: ${err}` : ""}]\r\n`),
         container,
+        command,
       ).then((s) => {
         if (disposed) {
           s.close();
@@ -70,7 +74,9 @@ export function PodTerminal({
       disposed = true;
       cleanup();
     };
-  }, [context, namespace, pod, container]);
+    // command is a stable per-session array; joined into the deps key.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [context, namespace, pod, container, command?.join(" ")]);
 
   return <div ref={ref} style={{ height: "100%", width: "100%", background: "#000", padding: 6, boxSizing: "border-box" }} />;
 }

--- a/apps/desktop/src/components/ResourceBrowser.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.tsx
@@ -565,6 +565,7 @@ export function ResourceBrowser({
     pod: string;
     container?: string;
     deleteOnClose?: { context: string; namespace: string; pod: string };
+    execCommand?: string[];
   }) => void;
   onOpenLogs?: (s: { context: string; namespace: string; pod: string; container?: string }) => void;
   onOpenWorkloadLogs?: (s: { context: string; namespace: string; kind: string; name: string }) => void;

--- a/apps/desktop/src/lib/exec.test.ts
+++ b/apps/desktop/src/lib/exec.test.ts
@@ -35,6 +35,7 @@ describe("startPodExec", () => {
       pod: "web-1",
       container: null,
       shell: null,
+      command: null,
     });
     expect(onMock).toHaveBeenCalledWith("exec:out:7", expect.any(Function));
     expect(onMock).toHaveBeenCalledWith("exec:exit:7", expect.any(Function));
@@ -60,6 +61,7 @@ describe("startPodExec", () => {
       pod: "web-1",
       container: "sidecar",
       shell: null,
+      command: null,
     });
   });
 });

--- a/apps/desktop/src/lib/exec.ts
+++ b/apps/desktop/src/lib/exec.ts
@@ -19,6 +19,7 @@ export async function startPodExec(
   onData: (chunk: string) => void,
   onExit: (error: string | null) => void,
   container?: string,
+  command?: string[],
 ): Promise<ExecSession> {
   const session = await invokeCommand<number>("start_pod_exec", {
     context,
@@ -26,6 +27,7 @@ export async function startPodExec(
     pod,
     container: container ?? null,
     shell: null,
+    command: command ?? null,
   });
   const disposeOut = on(`exec:out:${session}`, (p) => onData(p as string));
   const disposeExit = on(`exec:exit:${session}`, (p) => onExit((p as string | null) ?? null));

--- a/crates/kube/src/debug.rs
+++ b/crates/kube/src/debug.rs
@@ -54,8 +54,11 @@ pub fn ephemeral_patch(name: &str, image: &str, target_container: Option<&str>) 
 }
 
 /// The privileged, host-namespaced debug pod spec pinned to `node`. It shares
-/// the host PID/network/IPC namespaces and `nsenter`s into PID 1's namespaces to
-/// give a real shell on the node. `restartPolicy: Never` + tolerations so it
+/// the host PID/network/IPC namespaces and just stays alive; the caller then
+/// `exec`s `nsenter --target 1 …` into it to enter PID 1's namespaces for a real
+/// host shell (a pod-that-nsenters-on-start would race the exec and 500). The
+/// keep-alive entrypoint has no dependencies beyond the image's shell, so the
+/// pod reaches Running reliably. `restartPolicy: Never` + tolerations so it
 /// schedules on any (even tainted) node and doesn't restart after exit.
 pub fn node_debug_pod_spec(node: &str, image: &str) -> Value {
     json!({
@@ -73,13 +76,7 @@ pub fn node_debug_pod_spec(node: &str, image: &str) -> Value {
                 "name": "debug",
                 "image": image,
                 "securityContext": { "privileged": true },
-                "stdin": true,
-                "tty": true,
-                "command": [
-                    "nsenter", "--target", "1",
-                    "--mount", "--uts", "--ipc", "--net", "--pid",
-                    "--", "/bin/sh",
-                ],
+                "command": ["sh", "-c", "while true; do sleep 3600; done"],
             }],
         }
     })
@@ -222,7 +219,8 @@ mod tests {
         assert_eq!(s.host_network, Some(true));
         let c = &s.containers[0];
         assert_eq!(c.security_context.as_ref().unwrap().privileged, Some(true));
-        assert!(c.command.as_ref().unwrap().iter().any(|a| a == "nsenter"));
+        // The pod just stays alive; nsenter is run via exec, not the entrypoint.
+        assert!(c.command.as_ref().unwrap().iter().any(|a| a.contains("sleep")));
     }
 
     #[test]

--- a/crates/kube/src/exec.rs
+++ b/crates/kube/src/exec.rs
@@ -3,6 +3,7 @@
 //! channel — Tauri-agnostic so the streaming logic stays reusable.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use k8s_openapi::api::core::v1::Pod;
 use kube::api::AttachParams;
@@ -20,6 +21,48 @@ pub fn shell_command(requested: Option<&str>) -> Vec<String> {
     }
 }
 
+/// Whether `container` (or any container, if `None`) is in the Running state —
+/// checks both regular and ephemeral container statuses. Exec into a container
+/// that isn't running yet fails the WebSocket upgrade with a 500, so we wait for
+/// this before attaching.
+pub fn container_running(pod: &Pod, container: Option<&str>) -> bool {
+    let Some(status) = pod.status.as_ref() else {
+        return false;
+    };
+    let running = |statuses: &[k8s_openapi::api::core::v1::ContainerStatus]| {
+        statuses.iter().any(|cs| {
+            (container.is_none() || container == Some(cs.name.as_str()))
+                && cs.state.as_ref().and_then(|s| s.running.as_ref()).is_some()
+        })
+    };
+    status.container_statuses.as_deref().is_some_and(running)
+        || status.ephemeral_container_statuses.as_deref().is_some_and(running)
+}
+
+/// Poll until `container` is running, or a deadline passes. Gives debug
+/// containers / node debug pods time to start before we exec into them.
+async fn wait_for_running(
+    api: &Api<Pod>,
+    pod: &str,
+    container: Option<&str>,
+    timeout: Duration,
+) -> Result<(), String> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let p = api.get(pod).await.map_err(|e| e.to_string())?;
+        if container_running(&p, container) {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(format!(
+                "container did not start within {}s",
+                timeout.as_secs()
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(700)).await;
+    }
+}
+
 /// Open an interactive exec session. `on_output` receives stdout chunks
 /// (lossy UTF-8); `input_rx` yields stdin keystrokes. Runs until either side
 /// closes or the task is aborted.
@@ -31,6 +74,7 @@ pub async fn exec_shell<F>(
     pod: String,
     container: Option<String>,
     shell: Option<String>,
+    command: Option<Vec<String>>,
     mut on_output: F,
     mut input_rx: Receiver<String>,
 ) -> Result<(), String>
@@ -39,6 +83,12 @@ where
 {
     let client = cache.get(&context).await?;
     let api: Api<Pod> = Api::namespaced(client, &namespace);
+    let target = container.filter(|c| !c.is_empty());
+
+    // Debug containers and node debug pods take a moment to start; exec before
+    // that 500s the WebSocket upgrade. Wait briefly for the target to run.
+    wait_for_running(&api, &pod, target.as_deref(), Duration::from_secs(30)).await?;
+
     let mut params = AttachParams::default()
         .stdin(true)
         .stdout(true)
@@ -46,11 +96,13 @@ where
         .tty(true);
     // Target a specific container when asked (multi-container / sidecar pods);
     // otherwise the API defaults to the pod's first container.
-    if let Some(container) = container.filter(|c| !c.is_empty()) {
+    if let Some(container) = target {
         params = params.container(container);
     }
 
-    let command = shell_command(shell.as_deref());
+    // An explicit `command` (e.g. the node shell's `nsenter …`) overrides the
+    // default login shell.
+    let command = command.filter(|c| !c.is_empty()).unwrap_or_else(|| shell_command(shell.as_deref()));
     let mut attached = api
         .exec(&pod, command, &params)
         .await
@@ -92,5 +144,31 @@ mod tests {
         assert_eq!(shell_command(None), vec!["/bin/sh".to_string()]);
         assert_eq!(shell_command(Some("")), vec!["/bin/sh".to_string()]);
         assert_eq!(shell_command(Some("/bin/bash")), vec!["/bin/bash".to_string()]);
+    }
+
+    fn pod_with(json: serde_json::Value) -> Pod {
+        serde_json::from_value(json).unwrap()
+    }
+
+    #[test]
+    fn container_running_checks_regular_and_ephemeral_statuses() {
+        let running = pod_with(serde_json::json!({
+            "status": { "containerStatuses": [{ "name": "app", "image": "x", "imageID": "", "ready": true, "restartCount": 0, "state": { "running": { "startedAt": "2020-01-01T00:00:00Z" } } }] }
+        }));
+        assert!(container_running(&running, Some("app")));
+        assert!(container_running(&running, None));
+        assert!(!container_running(&running, Some("other")));
+
+        let ephemeral = pod_with(serde_json::json!({
+            "status": { "ephemeralContainerStatuses": [{ "name": "debugger-1", "image": "x", "imageID": "", "ready": false, "restartCount": 0, "state": { "running": { "startedAt": "2020-01-01T00:00:00Z" } } }] }
+        }));
+        assert!(container_running(&ephemeral, Some("debugger-1")));
+
+        let waiting = pod_with(serde_json::json!({
+            "status": { "containerStatuses": [{ "name": "app", "image": "x", "imageID": "", "ready": false, "restartCount": 0, "state": { "waiting": { "reason": "ContainerCreating" } } }] }
+        }));
+        assert!(!container_running(&waiting, Some("app")));
+
+        assert!(!container_running(&pod_with(serde_json::json!({})), None));
     }
 }


### PR DESCRIPTION
Fixes the node debug shell reported failing with `failed to upgrade to a WebSocket connection: failed to switch protocol: 500 Internal Server Error`.

## Root cause (two compounding bugs in #17)

1. **No wait for the pod to run.** `createNodeDebugPod` returned the instant the pod was *created* (`Pending`), and the terminal exec'd immediately. Exec into a not-yet-running container 500s the WebSocket upgrade.
2. **Wrong exec design.** The pod's *entrypoint* was the `nsenter` host shell, but the terminal exec'd a *new* `/bin/sh` into it — which would land in the busybox container, not the host — and if that nsenter entrypoint couldn't start, the container never reached Running at all.

## Fix (the kubectl-node-shell pattern)

- The node debug pod now runs a trivial **keep-alive** entrypoint, so it reaches `Running` reliably (no nsenter dependency at startup).
- `exec_shell` gains an optional **command override**; the node shell exec's `nsenter --target 1 --mount --uts --ipc --net --pid -- /bin/sh` to enter the host namespaces. Threaded frontend → `start_pod_exec` → `exec_shell`.
- `exec_shell` now **waits (bounded, 30s) for the target container to be Running** before attaching — which also fixes the same startup race for **ephemeral debug containers** (pod Debug), so those are more reliable too.

## Testing

- New `container_running` unit tests (regular + ephemeral statuses, waiting, empty) and the updated node-pod-spec test.
- Frontend: the `command` param is threaded through `startPodExec` / `PodTerminal` / the dock; the node-shell opener test now asserts the `nsenter` exec command.
- kube **247 green**, frontend **563 green**, `tsc` + clippy clean.

The interactive exec paths (exec into a live container) can only be fully verified against a real cluster — worth a re-test of the node shell + a distroless-pod debug once this lands.