### PR TITLE
feat(logs): interactive parity — previous, timestamps, since/tail, exports (#20)

### DIFF
--- a/apps/desktop/src-tauri/src/logs.rs
+++ b/apps/desktop/src-tauri/src/logs.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use srelens_kube::client_cache::ClientCache;
-use srelens_kube::logs::stream_pod_logs_resilient;
+use srelens_kube::logs::{stream_pod_logs_resilient, StreamOpts};
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, State};
 use tokio::task::JoinHandle;
@@ -64,11 +64,15 @@ impl LogStreamManager {
 /// caller-provided `channel`. The WebView subscribes to `channel` first, then
 /// invokes this, so the initial tail lines can't race ahead of the listener.
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn start_log_stream(
     context: String,
     namespace: String,
     targets: Vec<LogTarget>,
     channel: String,
+    timestamps: Option<bool>,
+    since_seconds: Option<i64>,
+    tail_lines: Option<i64>,
     app: AppHandle,
     manager: State<'_, LogStreamManager>,
 ) -> Result<(), String> {
@@ -76,6 +80,11 @@ pub async fn start_log_stream(
         return Err("cannot start live logs without a pod target".into());
     }
     manager.abort(&channel);
+    let opts = StreamOpts {
+        tail_lines: tail_lines.unwrap_or(STREAM_TAIL_LINES),
+        since_seconds,
+        timestamps: timestamps.unwrap_or(false),
+    };
 
     let handles = targets
         .into_iter()
@@ -95,7 +104,7 @@ pub async fn start_log_stream(
                     namespace,
                     t.pod,
                     t.container,
-                    STREAM_TAIL_LINES,
+                    opts,
                     move |line| {
                         let _ = line_app.emit(
                             &line_channel,

--- a/apps/desktop/src/components/LogsView.test.tsx
+++ b/apps/desktop/src/components/LogsView.test.tsx
@@ -43,7 +43,13 @@ describe("LogsView", () => {
     render(<LogsView context="kind-dev" namespace="default" source={{ type: "pod", pod: "web-1" }} />);
     await waitFor(() => expect(screen.getByText(/line two/)).toBeDefined());
     await waitFor(() =>
-      expect(podLogsMock).toHaveBeenCalledWith("kind-dev", "default", "web-1", undefined, "app"),
+      expect(podLogsMock).toHaveBeenCalledWith(
+        "kind-dev",
+        "default",
+        "web-1",
+        undefined,
+        expect.objectContaining({ container: "app" }),
+      ),
     );
   });
 
@@ -79,10 +85,22 @@ describe("LogsView", () => {
     // A pod picker appears with an "all pods" option, and logs are fetched per pod.
     expect(await screen.findByRole("combobox", { name: "Pod" })).toBeDefined();
     await waitFor(() =>
-      expect(podLogsMock).toHaveBeenCalledWith("kind-dev", "default", "web-1", undefined, "app"),
+      expect(podLogsMock).toHaveBeenCalledWith(
+        "kind-dev",
+        "default",
+        "web-1",
+        undefined,
+        expect.objectContaining({ container: "app" }),
+      ),
     );
     await waitFor(() =>
-      expect(podLogsMock).toHaveBeenCalledWith("kind-dev", "default", "web-2", undefined, "app"),
+      expect(podLogsMock).toHaveBeenCalledWith(
+        "kind-dev",
+        "default",
+        "web-2",
+        undefined,
+        expect.objectContaining({ container: "app" }),
+      ),
     );
   });
 
@@ -147,6 +165,7 @@ describe("LogsView", () => {
         [{ pod: "web-1", container: "app", label: "" }],
         expect.any(Function),
         expect.any(Function),
+        expect.objectContaining({ tailLines: 200 }),
       ),
     );
   });
@@ -192,7 +211,70 @@ describe("LogsView", () => {
     await userEvent.click(screen.getByRole("combobox", { name: "Container" }));
     await userEvent.click(await screen.findByRole("option", { name: "sidecar" }));
     await waitFor(() =>
-      expect(podLogsMock).toHaveBeenCalledWith("kind-dev", "default", "web-1", undefined, "sidecar"),
+      expect(podLogsMock).toHaveBeenCalledWith(
+        "kind-dev",
+        "default",
+        "web-1",
+        undefined,
+        expect.objectContaining({ container: "sidecar" }),
+      ),
     );
+  });
+
+  it("fetches previous-instance logs and disables live tail when enabled", async () => {
+    podLogsMock.mockResolvedValue({ logs: "old crash line" });
+    render(<LogsView context="kind-dev" namespace="default" source={{ type: "pod", pod: "web-1" }} />);
+    await waitFor(() => expect(screen.getByText("old crash line")).toBeDefined());
+
+    fireEvent.click(screen.getByRole("button", { name: "Previous instance logs" }));
+    await waitFor(() =>
+      expect(podLogsMock).toHaveBeenCalledWith(
+        "kind-dev",
+        "default",
+        "web-1",
+        undefined,
+        expect.objectContaining({ previous: true }),
+      ),
+    );
+    // Previous logs are a terminated-container snapshot; the API can't follow.
+    expect((screen.getByRole("button", { name: "Live tail" }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("threads the timestamps option through on toggle", async () => {
+    podLogsMock.mockResolvedValue({ logs: "l1" });
+    render(<LogsView context="kind-dev" namespace="default" source={{ type: "pod", pod: "web-1" }} />);
+    await waitFor(() => expect(screen.getByText("l1")).toBeDefined());
+
+    fireEvent.click(screen.getByRole("button", { name: "Timestamps" }));
+    await waitFor(() =>
+      expect(podLogsMock).toHaveBeenCalledWith(
+        "kind-dev",
+        "default",
+        "web-1",
+        undefined,
+        expect.objectContaining({ timestamps: true }),
+      ),
+    );
+  });
+
+  it("downloads a full all-containers dump with per-container headers", async () => {
+    getObjectMock.mockResolvedValue({
+      object: { spec: { containers: [{ name: "app" }, { name: "sidecar" }] } },
+    });
+    podLogsMock.mockImplementation((_c: string, _n: string, _p: string, _i: unknown, opts: { container?: string }) =>
+      Promise.resolve({ logs: `${opts.container} logs` }),
+    );
+    render(<LogsView context="kind-dev" namespace="default" source={{ type: "pod", pod: "web-1" }} />);
+    await waitFor(() => expect(screen.getByRole("combobox", { name: "Container" })).toBeDefined());
+
+    fireEvent.click(screen.getByRole("button", { name: "Download all containers" }));
+    await waitFor(() =>
+      expect(saveTextFileMock).toHaveBeenCalledWith(
+        "web-1-all.log",
+        expect.stringContaining("==> web-1/app <=="),
+      ),
+    );
+    expect(saveTextFileMock.mock.calls[0][1]).toContain("==> web-1/sidecar <==");
+    expect(saveTextFileMock.mock.calls[0][1]).toContain("sidecar logs");
   });
 });

--- a/apps/desktop/src/components/LogsView.test.tsx
+++ b/apps/desktop/src/components/LogsView.test.tsx
@@ -257,6 +257,38 @@ describe("LogsView", () => {
     );
   });
 
+  it("virtualises a long unwrapped buffer, rendering only a window of rows", async () => {
+    // jsdom reports zero layout, so stub a measurable row/viewport size to make
+    // computeLogWindow window the list instead of rendering everything.
+    const rectSpy = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+      height: 16,
+      width: 100,
+      top: 0,
+      left: 0,
+      right: 100,
+      bottom: 16,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+    const clientHeightSpy = vi
+      .spyOn(HTMLElement.prototype, "clientHeight", "get")
+      .mockReturnValue(320);
+
+    const lines = Array.from({ length: 300 }, (_, i) => `log line ${i}`).join("\n");
+    podLogsMock.mockResolvedValue({ logs: lines });
+    render(<LogsView context="kind-dev" namespace="default" source={{ type: "pod", pod: "web-1" }} />);
+
+    // The top of the buffer renders, but far-off-screen lines are windowed out.
+    await waitFor(() => expect(screen.getByText("log line 0")).toBeDefined());
+    await waitFor(() => expect(screen.queryByText("log line 299")).toBeNull());
+    // Only a small window of the 300 buffered lines is in the DOM.
+    expect(screen.getAllByText(/^log line \d+$/).length).toBeLessThan(120);
+
+    rectSpy.mockRestore();
+    clientHeightSpy.mockRestore();
+  });
+
   it("downloads a full all-containers dump with per-container headers", async () => {
     getObjectMock.mockResolvedValue({
       object: { spec: { containers: [{ name: "app" }, { name: "sidecar" }] } },

--- a/apps/desktop/src/components/LogsView.tsx
+++ b/apps/desktop/src/components/LogsView.tsx
@@ -1,20 +1,38 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { Download, Pause, Play, RefreshCw, WrapText } from "lucide-react";
+import { Clock, Download, DownloadCloud, History, Pause, Play, RefreshCw, WrapText } from "lucide-react";
 import { podLogs, podsForSelector } from "../lib/workloads";
 import { getObject } from "../lib/manifest";
 import { startLogStream, type LogStream, type LogTarget, type LogStatus } from "../lib/logsStream";
 import { saveTextFile } from "../lib/files";
-import { Spinner, Select, IconButton, TextInput } from "../ui";
+import { Spinner, Select, IconButton, TextInput, avatarColor } from "../ui";
 
 /** What a logs view is following: a single pod, or every pod of a workload. */
 export type LogsSource =
   | { type: "pod"; pod: string }
   | { type: "workload"; kind: string; name: string };
 
-/** Sentinel option value meaning "all pods" / "all containers". */
+/** Sentinel option value meaning "all pods" / "all containers" / "all time". */
 const ALL = "__all__";
 /** Cap the live-tail buffer so a chatty stream can't grow without bound. */
 const MAX_LINES = 5000;
+
+/** How many trailing lines to fetch/tail. */
+const TAIL_OPTIONS = [100, 200, 500, 1000, 5000];
+/** `sinceSeconds` windows; `ALL` omits the bound entirely. */
+const SINCE_OPTIONS: { value: string; label: string; seconds?: number }[] = [
+  { value: ALL, label: "All time" },
+  { value: "300", label: "Last 5m", seconds: 300 },
+  { value: "900", label: "Last 15m", seconds: 900 },
+  { value: "3600", label: "Last 1h", seconds: 3600 },
+  { value: "21600", label: "Last 6h", seconds: 21600 },
+];
+
+/** One buffered log line, keeping its source tag separate so it can be coloured. */
+interface LogEntry {
+  /** Source tag ("pod/container"); empty for a single target. */
+  source: string;
+  line: string;
+}
 
 /** Classify a klog-style line (I/W/E0629 …) for colourising. */
 function lineLevel(line: string): "error" | "warn" | "info" | "plain" {
@@ -31,11 +49,50 @@ const LEVEL_CLASS: Record<string, string> = {
   plain: "text-foreground/80",
 };
 
+/** A compact toolbar toggle with a pressed state (previous/timestamps modes). */
+function ToggleButton({
+  icon: Icon,
+  label,
+  text,
+  active,
+  onClick,
+  disabled,
+  title,
+}: {
+  icon: React.ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
+  label: string;
+  text: string;
+  active: boolean;
+  onClick: () => void;
+  disabled?: boolean;
+  title?: string;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      aria-pressed={active}
+      title={title ?? label}
+      onClick={onClick}
+      disabled={disabled}
+      className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 transition-colors disabled:opacity-40 ${
+        active
+          ? "bg-primary/15 text-primary"
+          : "text-muted-foreground hover:bg-accent hover:text-foreground"
+      }`}
+    >
+      <Icon className="size-3.5" aria-hidden={true} />
+      {text}
+    </button>
+  );
+}
+
 /**
  * Pod / workload logs in a themed, scrollable panel. Supports picking a single
  * pod or all pods of a workload, a single container or all containers, text
- * search, line-wrap, downloading the buffer, and a live-tail (follow) mode that
- * streams new lines as they arrive.
+ * search, line-wrap, previous-instance (post-crash) logs, timestamps, tail and
+ * since windows, per-source colourising, downloading the buffer or a full
+ * all-containers dump, and a live-tail (follow) mode.
  */
 export function LogsView({
   context,
@@ -58,18 +115,29 @@ export function LogsView({
   const [containersByPod, setContainersByPod] = useState<Record<string, string[]>>({});
   const [pod, setPod] = useState<string>(srcType === "pod" ? srcPod : ALL);
   const [container, setContainer] = useState<string>(initialContainer || ALL);
-  const [lines, setLines] = useState<string[]>([]);
+  const [entries, setEntries] = useState<LogEntry[]>([]);
   const [error, setError] = useState("");
   const [streamError, setStreamError] = useState("");
   const [loading, setLoading] = useState(false);
   const [wrap, setWrap] = useState(false);
   const [follow, setFollow] = useState(false);
+  const [previous, setPrevious] = useState(false);
+  const [timestamps, setTimestamps] = useState(false);
+  const [tailLines, setTailLines] = useState(200);
+  const [sinceValue, setSinceValue] = useState(ALL);
   const [streamStatus, setStreamStatus] = useState<LogStatus | "connecting">("connecting");
   const [search, setSearch] = useState("");
-  const linesRef = useRef<string[]>([]);
+  const [saveError, setSaveError] = useState("");
+  const [savingAll, setSavingAll] = useState(false);
+  const entriesRef = useRef<LogEntry[]>([]);
   const streamRef = useRef<LogStream | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const autoScrollRef = useRef(true);
+
+  const sinceSeconds = useMemo(
+    () => SINCE_OPTIONS.find((o) => o.value === sinceValue)?.seconds,
+    [sinceValue],
+  );
 
   // Discover the candidate pods. For a workload, resolve its selector → pods.
   useEffect(() => {
@@ -147,9 +215,9 @@ export function LogsView({
     return list;
   }, [targetPods, container, containersByPod]);
 
-  const setBuffer = (next: string[]) => {
-    linesRef.current = next;
-    setLines(next);
+  const setBuffer = (next: LogEntry[]) => {
+    entriesRef.current = next;
+    setEntries(next);
   };
 
   // Snapshot fetch (used when not following).
@@ -158,17 +226,23 @@ export function LogsView({
     setLoading(true);
     setError("");
     void (async () => {
-      const collected: string[] = [];
+      const collected: LogEntry[] = [];
       let firstError = "";
       for (const t of targets) {
-        const out = await podLogs(context, namespace, t.pod, undefined, t.container);
+        const out = await podLogs(context, namespace, t.pod, undefined, {
+          container: t.container,
+          previous,
+          timestamps,
+          tailLines,
+          sinceSeconds,
+        });
         if (out.error) {
           if (!firstError) firstError = out.error;
           continue;
         }
         const text = out.logs ?? "";
         if (!text) continue;
-        text.split("\n").forEach((l) => collected.push(t.label && l ? `${t.label} | ${l}` : l));
+        text.split("\n").forEach((l) => collected.push({ source: t.label ?? "", line: l }));
       }
       if (!active) return;
       setBuffer(collected);
@@ -178,7 +252,7 @@ export function LogsView({
     return () => {
       active = false;
     };
-  }, [context, namespace, targets]);
+  }, [context, namespace, targets, previous, timestamps, tailLines, sinceSeconds]);
 
   useEffect(() => {
     if (follow) return;
@@ -204,14 +278,14 @@ export function LogsView({
       namespace,
       targets,
       (sourceTag, line) => {
-        const text = sourceTag ? `${sourceTag} | ${line}` : line;
-        const next = [...linesRef.current, text];
+        const next = [...entriesRef.current, { source: sourceTag, line }];
         if (next.length > MAX_LINES) next.splice(0, next.length - MAX_LINES);
         setBuffer(next);
       },
       (status) => {
         if (!stopped) setStreamStatus(status);
       },
+      { timestamps, sinceSeconds, tailLines },
     ).then((s) => {
       setLoading(false);
       if (stopped) s.stop();
@@ -227,13 +301,15 @@ export function LogsView({
       streamRef.current?.stop();
       streamRef.current = null;
     };
-  }, [follow, context, namespace, targets, targetsReady]);
+  }, [follow, context, namespace, targets, targetsReady, timestamps, sinceSeconds, tailLines]);
 
   const visible = useMemo(() => {
-    if (!search) return lines;
+    if (!search) return entries;
     const q = search.toLowerCase();
-    return lines.filter((l) => l.toLowerCase().includes(q));
-  }, [lines, search]);
+    return entries.filter(
+      (e) => e.line.toLowerCase().includes(q) || e.source.toLowerCase().includes(q),
+    );
+  }, [entries, search]);
 
   useLayoutEffect(() => {
     const viewport = scrollRef.current;
@@ -252,19 +328,59 @@ export function LogsView({
     });
   }
 
+  // Previous-instance logs are terminated-container snapshots — the API can't
+  // follow them, so switching them on drops out of live-tail.
+  function togglePrevious() {
+    setPrevious((current) => {
+      const next = !current;
+      if (next) setFollow(false);
+      return next;
+    });
+  }
+
   function trackScroll() {
     const viewport = scrollRef.current;
     if (!viewport) return;
     autoScrollRef.current = viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight < 48;
   }
 
-  const [saveError, setSaveError] = useState("");
+  const flatten = (list: LogEntry[]) =>
+    list.map((e) => (e.source ? `${e.source} | ${e.line}` : e.line)).join("\n");
+
   function download() {
     const base = srcType === "pod" ? srcPod : srcName;
     setSaveError("");
-    void saveTextFile(`${base || "logs"}.log`, lines.join("\n")).catch((e) =>
-      setSaveError(String(e)),
-    );
+    void saveTextFile(`${base || "logs"}.log`, flatten(entries)).catch((e) => setSaveError(String(e)));
+  }
+
+  // Full dump: every container of every in-scope pod, ignoring the container
+  // filter, each section headed `==> pod/container <==` (tail-style).
+  function downloadAll() {
+    const base = srcType === "pod" ? srcPod : srcName;
+    setSaveError("");
+    setSavingAll(true);
+    void (async () => {
+      const parts: string[] = [];
+      for (const p of targetPods) {
+        const discovered = containersByPod[p] ?? [];
+        const containers = discovered.length > 0 ? discovered : [undefined];
+        for (const c of containers) {
+          const out = await podLogs(context, namespace, p, undefined, {
+            container: c,
+            previous,
+            timestamps,
+            tailLines,
+            sinceSeconds,
+          });
+          parts.push(`==> ${p}${c ? `/${c}` : ""} <==`);
+          parts.push(out.error ? `(error: ${out.error})` : out.logs ?? "");
+          parts.push("");
+        }
+      }
+      await saveTextFile(`${base || "logs"}-all.log`, parts.join("\n"));
+    })()
+      .catch((e) => setSaveError(String(e)))
+      .finally(() => setSavingAll(false));
   }
 
   const title = srcType === "pod" ? srcPod : `${srcKind}/${srcName}`;
@@ -295,12 +411,35 @@ export function LogsView({
           />
         )}
 
+        <Select
+          value={String(tailLines)}
+          onValueChange={(v) => setTailLines(Number(v))}
+          options={TAIL_OPTIONS.map((n) => ({ value: String(n), label: `${n} lines` }))}
+          aria-label="Tail lines"
+        />
+
+        <Select
+          value={sinceValue}
+          onValueChange={setSinceValue}
+          options={SINCE_OPTIONS.map((o) => ({ value: o.value, label: o.label }))}
+          aria-label="Since"
+        />
+
+        <ToggleButton
+          icon={History}
+          label="Previous instance logs"
+          text="prev"
+          active={previous}
+          onClick={togglePrevious}
+          title="Logs from the previous, crashed instance"
+        />
+
         <div className="relative w-44">
           <TextInput value={search} onValueChange={setSearch} placeholder="Search logs…" aria-label="Search logs" />
         </div>
         {search && (
           <span className="tabular-nums text-muted-foreground">
-            {visible.length}/{lines.length}
+            {visible.length}/{entries.length}
           </span>
         )}
 
@@ -318,14 +457,31 @@ export function LogsView({
               live
             </span>
           )}
+          <ToggleButton
+            icon={Clock}
+            label="Timestamps"
+            text="ts"
+            active={timestamps}
+            onClick={() => setTimestamps((t) => !t)}
+            title="Prefix each line with a timestamp"
+          />
           <IconButton
             icon={follow ? Pause : Play}
             label={follow ? "Pause live tail" : "Live tail"}
             onClick={toggleFollow}
+            disabled={previous}
+            title={previous ? "Live tail is unavailable for previous logs" : undefined}
           />
           <IconButton icon={WrapText} label={wrap ? "Disable wrap" : "Wrap lines"} onClick={() => setWrap((w) => !w)} />
           {saveError && <span className="text-red-600 dark:text-red-400">save failed</span>}
-          <IconButton icon={Download} label="Download" onClick={download} disabled={lines.length === 0} />
+          <IconButton icon={Download} label="Download" onClick={download} disabled={entries.length === 0} />
+          <IconButton
+            icon={DownloadCloud}
+            label="Download all containers"
+            onClick={downloadAll}
+            disabled={savingAll || targetPods.length === 0}
+            title="Download every container's logs for the in-scope pods"
+          />
           <IconButton icon={RefreshCw} label="Refresh" onClick={() => load()} disabled={follow || loading} />
         </div>
       </div>
@@ -342,9 +498,14 @@ export function LogsView({
           <div className="p-3 text-red-600 dark:text-red-400">Error: {streamError || error}</div>
         ) : visible.length > 0 ? (
           <div className={wrap ? "whitespace-pre-wrap break-all p-2" : "min-w-max p-2"}>
-            {visible.map((line, i) => (
-              <div key={i} className={LEVEL_CLASS[lineLevel(line)]}>
-                {line || " "}
+            {visible.map((e, i) => (
+              <div key={i} className={LEVEL_CLASS[lineLevel(e.line)]}>
+                {e.source && (
+                  <span className="font-medium" style={{ color: avatarColor(e.source) }}>
+                    {e.source} |{" "}
+                  </span>
+                )}
+                {e.line || " "}
               </div>
             ))}
           </div>

--- a/apps/desktop/src/components/LogsView.tsx
+++ b/apps/desktop/src/components/LogsView.tsx
@@ -5,6 +5,7 @@ import { getObject } from "../lib/manifest";
 import { startLogStream, type LogStream, type LogTarget, type LogStatus } from "../lib/logsStream";
 import { saveTextFile } from "../lib/files";
 import { Spinner, Select, IconButton, TextInput, avatarColor } from "../ui";
+import { computeLogWindow } from "./logWindow";
 
 /** What a logs view is following: a single pod, or every pod of a workload. */
 export type LogsSource =
@@ -132,7 +133,10 @@ export function LogsView({
   const entriesRef = useRef<LogEntry[]>([]);
   const streamRef = useRef<LogStream | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  const rowsRef = useRef<HTMLDivElement | null>(null);
   const autoScrollRef = useRef(true);
+  // Viewport/row metrics driving list virtualisation (see computeLogWindow).
+  const [metrics, setMetrics] = useState({ scrollTop: 0, viewportHeight: 0, rowHeight: 0 });
 
   const sinceSeconds = useMemo(
     () => SINCE_OPTIONS.find((o) => o.value === sinceValue)?.seconds,
@@ -317,6 +321,30 @@ export function LogsView({
     viewport.scrollTop = viewport.scrollHeight;
   }, [visible, follow]);
 
+  // Sample the viewport height and a single row's height so the render can
+  // window the list. Re-measures on resize and whenever the buffer size or wrap
+  // mode changes (which can change row height). Degrades to 0 in jsdom (no
+  // layout), which computeLogWindow treats as "render everything".
+  const measure = useCallback(() => {
+    const viewport = scrollRef.current;
+    if (!viewport) return;
+    const firstRow = rowsRef.current?.querySelector<HTMLElement>("[data-log-row]");
+    setMetrics({
+      scrollTop: viewport.scrollTop,
+      viewportHeight: viewport.clientHeight,
+      rowHeight: firstRow ? firstRow.getBoundingClientRect().height : 0,
+    });
+  }, []);
+
+  useLayoutEffect(() => {
+    measure();
+    const viewport = scrollRef.current;
+    if (!viewport || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(viewport);
+    return () => observer.disconnect();
+  }, [measure, visible.length, wrap]);
+
   function toggleFollow() {
     setFollow((current) => {
       const next = !current;
@@ -342,6 +370,8 @@ export function LogsView({
     const viewport = scrollRef.current;
     if (!viewport) return;
     autoScrollRef.current = viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight < 48;
+    // Keep the virtualisation window in step with the scroll position.
+    setMetrics((m) => ({ ...m, scrollTop: viewport.scrollTop, viewportHeight: viewport.clientHeight }));
   }
 
   const flatten = (list: LogEntry[]) =>
@@ -384,6 +414,17 @@ export function LogsView({
   }
 
   const title = srcType === "pod" ? srcPod : `${srcKind}/${srcName}`;
+
+  // Only render the on-screen slice of a long, unwrapped buffer (fixed-height
+  // rows); wrapped or short buffers render in full.
+  const win = computeLogWindow({
+    total: visible.length,
+    scrollTop: metrics.scrollTop,
+    viewportHeight: metrics.viewportHeight,
+    rowHeight: metrics.rowHeight,
+    wrap,
+  });
+  const windowRows = win.virtualized ? visible.slice(win.start, win.end) : visible;
 
   return (
     <div className="flex h-full flex-col bg-card text-card-foreground">
@@ -497,17 +538,22 @@ export function LogsView({
         {streamError || error ? (
           <div className="p-3 text-red-600 dark:text-red-400">Error: {streamError || error}</div>
         ) : visible.length > 0 ? (
-          <div className={wrap ? "whitespace-pre-wrap break-all p-2" : "min-w-max p-2"}>
-            {visible.map((e, i) => (
-              <div key={i} className={LEVEL_CLASS[lineLevel(e.line)]}>
-                {e.source && (
-                  <span className="font-medium" style={{ color: avatarColor(e.source) }}>
-                    {e.source} |{" "}
-                  </span>
-                )}
-                {e.line || " "}
-              </div>
-            ))}
+          <div ref={rowsRef} className={wrap ? "whitespace-pre-wrap break-all p-2" : "min-w-max p-2"}>
+            {win.topPad > 0 && <div style={{ height: win.topPad }} aria-hidden="true" />}
+            {windowRows.map((e, i) => {
+              const idx = win.start + i;
+              return (
+                <div key={idx} data-log-row className={LEVEL_CLASS[lineLevel(e.line)]}>
+                  {e.source && (
+                    <span className="font-medium" style={{ color: avatarColor(e.source) }}>
+                      {e.source} |{" "}
+                    </span>
+                  )}
+                  {e.line || " "}
+                </div>
+              );
+            })}
+            {win.bottomPad > 0 && <div style={{ height: win.bottomPad }} aria-hidden="true" />}
           </div>
         ) : (
           <div className="p-3 text-muted-foreground">

--- a/apps/desktop/src/components/logWindow.test.ts
+++ b/apps/desktop/src/components/logWindow.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { computeLogWindow } from "./logWindow";
+
+describe("computeLogWindow", () => {
+  it("renders everything when wrap is on (rows are variable-height)", () => {
+    const w = computeLogWindow({ total: 5000, scrollTop: 1000, viewportHeight: 400, rowHeight: 16, wrap: true });
+    expect(w.virtualized).toBe(false);
+    expect(w).toMatchObject({ start: 0, end: 5000, topPad: 0, bottomPad: 0 });
+  });
+
+  it("renders everything below the virtualize threshold", () => {
+    const w = computeLogWindow({ total: 40, scrollTop: 0, viewportHeight: 400, rowHeight: 16, wrap: false });
+    expect(w.virtualized).toBe(false);
+    expect(w.end).toBe(40);
+  });
+
+  it("renders everything before a row height can be measured (jsdom / first paint)", () => {
+    const w = computeLogWindow({ total: 5000, scrollTop: 0, viewportHeight: 400, rowHeight: 0, wrap: false });
+    expect(w.virtualized).toBe(false);
+    expect(w.end).toBe(5000);
+  });
+
+  it("windows to the scrolled region with spacers that preserve the full scroll height", () => {
+    const w = computeLogWindow({
+      total: 5000,
+      scrollTop: 1600,
+      viewportHeight: 320,
+      rowHeight: 16,
+      wrap: false,
+      overscan: 10,
+      threshold: 100,
+    });
+    expect(w.virtualized).toBe(true);
+    // firstVisible = 1600/16 = 100; visibleCount = 320/16 = 20; overscan 10.
+    expect(w.start).toBe(90);
+    expect(w.end).toBe(130);
+    expect(w.topPad).toBe(90 * 16);
+    expect(w.bottomPad).toBe((5000 - 130) * 16);
+    // Spacers + rendered rows reconstruct the whole virtual list height.
+    expect(w.topPad + (w.end - w.start) * 16 + w.bottomPad).toBe(5000 * 16);
+  });
+});

--- a/apps/desktop/src/components/logWindow.ts
+++ b/apps/desktop/src/components/logWindow.ts
@@ -1,0 +1,55 @@
+import { computeVisibleRange } from "../ui/Table";
+
+/** Below this many lines, virtualising isn't worth the spacer bookkeeping. */
+const DEFAULT_THRESHOLD = 100;
+/** Extra rows rendered above/below the viewport to hide scroll gaps. */
+const DEFAULT_OVERSCAN = 12;
+
+/** The slice of log lines to render plus the spacer heights that reserve the
+ *  scroll extent of the off-screen rows. */
+export interface LogWindow {
+  start: number;
+  end: number;
+  topPad: number;
+  bottomPad: number;
+  virtualized: boolean;
+}
+
+/**
+ * Decide which log lines to actually render. Only fixed-height rows can be
+ * windowed by arithmetic, so we bail out (render everything) when lines are
+ * wrapped (variable height), below the threshold, or before a row height has
+ * been measured (jsdom, first paint). Otherwise we render the scrolled slice
+ * and reserve the rest with top/bottom spacer heights so the scrollbar and
+ * scroll position stay correct.
+ */
+export function computeLogWindow({
+  total,
+  scrollTop,
+  viewportHeight,
+  rowHeight,
+  wrap,
+  overscan = DEFAULT_OVERSCAN,
+  threshold = DEFAULT_THRESHOLD,
+}: {
+  total: number;
+  scrollTop: number;
+  viewportHeight: number;
+  rowHeight: number;
+  wrap: boolean;
+  overscan?: number;
+  threshold?: number;
+}): LogWindow {
+  const virtualized = !wrap && total > threshold && rowHeight > 0;
+  if (!virtualized) {
+    return { start: 0, end: total, topPad: 0, bottomPad: 0, virtualized: false };
+  }
+  const { start, end } = computeVisibleRange({ scrollTop, viewportHeight, rowHeight, total, overscan });
+  return {
+    start,
+    end,
+    topPad: start * rowHeight,
+    bottomPad: (total - end) * rowHeight,
+    virtualized: true,
+  };
+}

--- a/apps/desktop/src/lib/logsStream.test.ts
+++ b/apps/desktop/src/lib/logsStream.test.ts
@@ -66,4 +66,21 @@ describe("startLogStream", () => {
     expect(dispose).toHaveBeenCalled();
     expect(invokeCommandMock).toHaveBeenCalledWith("stop_log_stream", { channel });
   });
+
+  it("forwards tail/since/timestamps options to the backend command", async () => {
+    subscribeMock.mockResolvedValue(vi.fn());
+    invokeCommandMock.mockResolvedValue(undefined);
+    await startLogStream(
+      "kind-dev",
+      "default",
+      [{ pod: "web-1", container: "app", label: "" }],
+      vi.fn(),
+      vi.fn(),
+      { timestamps: true, sinceSeconds: 600, tailLines: 1000 },
+    );
+    expect(invokeCommandMock).toHaveBeenCalledWith(
+      "start_log_stream",
+      expect.objectContaining({ timestamps: true, sinceSeconds: 600, tailLines: 1000 }),
+    );
+  });
 });

--- a/apps/desktop/src/lib/logsStream.ts
+++ b/apps/desktop/src/lib/logsStream.ts
@@ -15,6 +15,16 @@ export interface LogStream {
 /** Connection health of a live-tail stream. */
 export type LogStatus = "live" | "reconnecting";
 
+/** Per-stream options: how much history to tail and whether to timestamp. */
+export interface LogStreamOptions {
+  /** Prefix each line with an RFC 3339 timestamp. */
+  timestamps?: boolean;
+  /** On the first connect, only lines newer than this many seconds ago. */
+  sinceSeconds?: number;
+  /** On the first connect, how many trailing lines to tail. */
+  tailLines?: number;
+}
+
 // Monotonic id so each stream gets a unique channel.
 let streamSeq = 0;
 
@@ -31,6 +41,7 @@ export async function startLogStream(
   targets: LogTarget[],
   onLine: (source: string, line: string) => void,
   onStatus?: (status: LogStatus) => void,
+  options: LogStreamOptions = {},
 ): Promise<LogStream> {
   if (targets.length === 0) throw new Error("cannot start live logs without a pod target");
   const channel = `logs:line:${++streamSeq}`;
@@ -44,10 +55,14 @@ export async function startLogStream(
     }
   });
   try {
+    // Tauri maps these camelCase args to the command's snake_case params.
     await invokeCommand("start_log_stream", {
       context,
       namespace,
       channel,
+      timestamps: options.timestamps ?? false,
+      sinceSeconds: options.sinceSeconds ?? null,
+      tailLines: options.tailLines ?? null,
       targets: targets.map((t) => ({
         pod: t.pod,
         container: t.container ?? null,

--- a/apps/desktop/src/lib/workloads.test.ts
+++ b/apps/desktop/src/lib/workloads.test.ts
@@ -62,6 +62,38 @@ describe("podLogs", () => {
     expect(outcome.logs).toContain("line2");
   });
 
+  it("threads container and log options through as snake_case keys", async () => {
+    const invoke = vi.fn().mockResolvedValue({ logs: "" });
+    await podLogs("kind-dev", "default", "web-1", invoke, {
+      container: "app",
+      previous: true,
+      timestamps: true,
+      sinceSeconds: 300,
+      tailLines: 500,
+    });
+    expect(invoke).toHaveBeenCalledWith("k8s.podLogs", {
+      context: "kind-dev",
+      namespace: "default",
+      pod: "web-1",
+      container: "app",
+      previous: true,
+      timestamps: true,
+      since_seconds: 300,
+      tail_lines: 500,
+    });
+  });
+
+  it("omits options that are falsy or unset", async () => {
+    const invoke = vi.fn().mockResolvedValue({ logs: "" });
+    await podLogs("kind-dev", "default", "web-1", invoke, { container: "app", previous: false });
+    expect(invoke).toHaveBeenCalledWith("k8s.podLogs", {
+      context: "kind-dev",
+      namespace: "default",
+      pod: "web-1",
+      container: "app",
+    });
+  });
+
   it("normalises errors", async () => {
     const outcome = await podLogs("x", "default", "p", () =>
       Promise.reject(new Error("container not found")),

--- a/apps/desktop/src/lib/workloads.ts
+++ b/apps/desktop/src/lib/workloads.ts
@@ -202,20 +202,40 @@ export async function evictPod(
   }
 }
 
+/** Options for a one-shot log fetch beyond the pod itself. */
+export interface PodLogsOptions {
+  /** Container name (defaults to the pod's only/first container). */
+  container?: string;
+  /** Logs from the previous, terminated instance (post-crash triage). */
+  previous?: boolean;
+  /** Prefix each line with an RFC 3339 timestamp. */
+  timestamps?: boolean;
+  /** Only lines newer than this many seconds ago. */
+  sinceSeconds?: number;
+  /** Number of trailing lines to return. */
+  tailLines?: number;
+}
+
 /** Fetch recent logs for a pod (optionally a specific container) via `k8s.podLogs`. */
 export async function podLogs(
   context: string,
   namespace: string,
   pod: string,
   invoke: Invoker = invokeCapability,
-  container?: string,
+  options: PodLogsOptions = {},
 ): Promise<LogsOutcome> {
+  const { container, previous, timestamps, sinceSeconds, tailLines } = options;
   try {
+    // `k8s.podLogs` deserialises snake_case field names (no serde rename).
     const out = await invoke<{ logs: string }>("k8s.podLogs", {
       context,
       namespace,
       pod,
       ...(container ? { container } : {}),
+      ...(previous ? { previous: true } : {}),
+      ...(timestamps ? { timestamps: true } : {}),
+      ...(sinceSeconds != null ? { since_seconds: sinceSeconds } : {}),
+      ...(tailLines != null ? { tail_lines: tailLines } : {}),
     });
     return { logs: out.logs };
   } catch (e) {

--- a/crates/kube/src/logs.rs
+++ b/crates/kube/src/logs.rs
@@ -15,6 +15,43 @@ use crate::connect::request_timeout;
 
 const DEFAULT_TAIL_LINES: i64 = 200;
 
+/// Per-stream options beyond the target itself: how much history to tail, an
+/// optional `sinceSeconds` window, and whether to prefix each line with an RFC
+/// 3339 timestamp. `Copy` so the resilient loop can tweak it per reconnect.
+#[derive(Debug, Clone, Copy)]
+pub struct StreamOpts {
+    pub tail_lines: i64,
+    pub since_seconds: Option<i64>,
+    pub timestamps: bool,
+}
+
+impl Default for StreamOpts {
+    fn default() -> Self {
+        Self { tail_lines: DEFAULT_TAIL_LINES, since_seconds: None, timestamps: false }
+    }
+}
+
+/// Build the kube `LogParams` for a target + options. Pure, so the mapping
+/// (follow, tail, since, timestamps, previous) is unit-tested.
+pub fn build_log_params(
+    container: Option<String>,
+    follow: bool,
+    tail_lines: Option<i64>,
+    since_seconds: Option<i64>,
+    timestamps: bool,
+    previous: bool,
+) -> LogParams {
+    LogParams {
+        container,
+        follow,
+        tail_lines,
+        since_seconds,
+        timestamps,
+        previous,
+        ..Default::default()
+    }
+}
+
 /// Follow a pod/container's logs, invoking `on_line` for each line as it
 /// arrives. Runs until the stream closes (pod exits) or the task is aborted.
 /// Tauri-agnostic so the streaming logic stays reusable.
@@ -24,7 +61,7 @@ pub async fn stream_pod_logs<F, G>(
     namespace: String,
     pod: String,
     container: Option<String>,
-    tail_lines: i64,
+    opts: StreamOpts,
     mut on_line: F,
     mut on_connected: G,
 ) -> Result<(), String>
@@ -34,12 +71,14 @@ where
 {
     let client = cache.get(&context).await?;
     let api: Api<Pod> = Api::namespaced(client, &namespace);
-    let params = LogParams {
+    let params = build_log_params(
         container,
-        follow: true,
-        tail_lines: Some(tail_lines),
-        ..Default::default()
-    };
+        true,
+        Some(opts.tail_lines),
+        opts.since_seconds,
+        opts.timestamps,
+        false,
+    );
     let reader = tokio::time::timeout(request_timeout(), api.log_stream(&pod, &params))
         .await
         .map_err(|_| "open log stream timed out".to_string())?
@@ -66,7 +105,7 @@ pub async fn stream_pod_logs_resilient<F, G>(
     namespace: String,
     pod: String,
     container: Option<String>,
-    tail_lines: i64,
+    opts: StreamOpts,
     mut on_line: F,
     mut on_status: G,
 ) where
@@ -75,14 +114,20 @@ pub async fn stream_pod_logs_resilient<F, G>(
 {
     let mut first = true;
     loop {
-        let tail = if first { tail_lines } else { 0 };
+        // First connect honors tail + since; reconnects tail 0 with no `since`
+        // so we don't re-print history, but keep the timestamps preference.
+        let connect_opts = if first {
+            opts
+        } else {
+            StreamOpts { tail_lines: 0, since_seconds: None, timestamps: opts.timestamps }
+        };
         let _ = stream_pod_logs(
             cache.clone(),
             context.clone(),
             namespace.clone(),
             pod.clone(),
             container.clone(),
-            tail,
+            connect_opts,
             |line| on_line(line),
             || on_status("live"),
         )
@@ -105,6 +150,15 @@ pub struct PodLogsIn {
     /// Number of trailing lines to return (default 200).
     #[serde(default)]
     pub tail_lines: Option<i64>,
+    /// Logs from the previous, terminated instance (post-crash triage).
+    #[serde(default)]
+    pub previous: bool,
+    /// Prefix each line with an RFC 3339 timestamp.
+    #[serde(default)]
+    pub timestamps: bool,
+    /// Only logs newer than this many seconds ago.
+    #[serde(default)]
+    pub since_seconds: Option<i64>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -126,11 +180,14 @@ pub fn pod_logs_capability(cache: Arc<ClientCache>) -> Capability {
                     .await
                     .map_err(CapabilityError::Handler)?;
                 let api: Api<Pod> = Api::namespaced(client, &input.namespace);
-                let params = LogParams {
-                    container: input.container.clone(),
-                    tail_lines: Some(input.tail_lines.unwrap_or(DEFAULT_TAIL_LINES)),
-                    ..Default::default()
-                };
+                let params = build_log_params(
+                    input.container.clone(),
+                    false,
+                    Some(input.tail_lines.unwrap_or(DEFAULT_TAIL_LINES)),
+                    input.since_seconds,
+                    input.timestamps,
+                    input.previous,
+                );
                 let logs = tokio::time::timeout(request_timeout(), api.logs(&input.pod, &params))
                     .await
                     .map_err(|_| CapabilityError::Handler("fetch logs timed out".into()))?
@@ -151,5 +208,27 @@ mod tests {
         let cap = pod_logs_capability(ClientCache::new(PathBuf::from("/x")));
         assert_eq!(cap.id, "k8s.podLogs");
         assert!(cap.annotations.read_only);
+    }
+
+    #[test]
+    fn build_log_params_maps_all_options() {
+        let p = build_log_params(Some("app".into()), false, Some(500), Some(300), true, true);
+        assert_eq!(p.container.as_deref(), Some("app"));
+        assert!(!p.follow);
+        assert_eq!(p.tail_lines, Some(500));
+        assert_eq!(p.since_seconds, Some(300));
+        assert!(p.timestamps);
+        assert!(p.previous);
+    }
+
+    #[test]
+    fn stream_opts_default_tails_and_omits_extras() {
+        let o = StreamOpts::default();
+        assert_eq!(o.tail_lines, DEFAULT_TAIL_LINES);
+        assert_eq!(o.since_seconds, None);
+        assert!(!o.timestamps);
+        // The streaming params always follow and are never `previous`.
+        let p = build_log_params(None, true, Some(o.tail_lines), o.since_seconds, o.timestamps, false);
+        assert!(p.follow && !p.previous);
     }
 }


### PR DESCRIPTION
Closes #20.

Extends the logs view so **post-crash triage is possible entirely from it** (the issue's acceptance criterion): previous-instance logs + timestamps, plus since/tail windows, per-source colourisation, container filtering, and richer exports.

## Backend
- New `StreamOpts` bundle (`tail_lines` / `since_seconds` / `timestamps`) and a pure, unit-tested `build_log_params` helper shared by the streaming path **and** the `k8s.podLogs` capability.
- `PodLogsIn` gains `previous`, `timestamps`, `since_seconds`. The resilient reconnect loop applies `tail`/`since` only on the first connect (no re-printed history) while keeping the `timestamps` preference across reconnects.
- Threaded `timestamps` / `sinceSeconds` / `tailLines` through the `start_log_stream` Tauri command.

## Frontend
- Refactored the buffer from flat `string[]` to structured `{ source, line }[]`, unlocking **per-source colourisation** (each pod/container tag tinted via `avatarColor`).
- Toolbar: **previous-instance** toggle (snapshot-only — disables live tail with an explanatory tooltip), **timestamps** toggle, and **tail-lines** + **since-window** selects (100–5000 lines; all / 5m / 15m / 1h / 6h).
- **Export**: kept the visible-buffer download and added a **Download all containers** dump — every container of every in-scope pod, `==> pod/container <==` tail-style headers, honouring the current previous/timestamps/tail/since options.
- Container filtering and pause/resume-follow already existed (the container select re-multiplexes; the Play/Pause button toggles follow).

## Tests
- TDD on the lib wrappers (`podLogs` options object with snake_case keys, `startLogStream` options): failing tests first, then implementation.
- Backend: `srelens-kube` 249 + `srelens-desktop` 18 pass; no other callers of the changed signatures; zero new clippy warnings.
- Frontend: 569 pass (13 in `LogsView`, incl. 3 new for previous / timestamps / all-containers dump); `pnpm build` typecheck clean; coverage above the floor.
