### PR TITLE
ci(release): pin AUR host keys so the publish job can clone

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -529,7 +529,17 @@ jobs:
           install -d -m 700 ~/.ssh
           printf '%s\n' "$AUR_SSH_PRIVATE_KEY" > ~/.ssh/aur
           chmod 600 ~/.ssh/aur
-          ssh-keyscan -t ed25519,rsa aur.archlinux.org >> ~/.ssh/known_hosts 2>/dev/null
+          # Pin AUR's SSH host keys instead of an at-runtime ssh-keyscan. The
+          # scan hid its own errors (2>/dev/null), so a failed/empty scan left
+          # known_hosts empty and surfaced only as an opaque "Host key
+          # verification failed" at clone time. Verified fingerprints — ED25519
+          # SHA256:RFzBCUItH9LZS0cKB5UE6ceAYhBD5C8GeOBip8Z11+4, RSA
+          # SHA256:5s5cIyReIfNNVGRFdDbe3hdYiI5OelHGpw2rOUud3Q8.
+          {
+            echo 'aur.archlinux.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEuBKrPzbawxA/k2g6NcyV5jmqwJ2s+zpgZGZ7tpLIcN'
+            echo 'aur.archlinux.org ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDKF9vAFWdgm9Bi8uc+tYRBmXASBb5cB5iZsB7LOWWFeBrLp3r14w0/9S2vozjgqY5sJLDPONWoTTaVTbhe3vwO8CBKZTEt1AcWxuXNlRnk9FliR1/eNB9uz/7y1R0+c1Md+P98AJJSJWKN12nqIDIhjl2S1vOUvm7FNY43fU2knIhEbHybhwWeg+0wxpKwcAd/JeL5i92Uv03MYftOToUijd1pqyVFdJvQFhqD4v3M157jxS5FTOBrccAEjT+zYmFyD8WvKUa9vUclRddNllmBJdy4NyLB8SvVZULUPrP3QOlmzemeKracTlVOUG1wsDbxknF1BwSCU7CmU6UFP90kpWIyz66bP0bl67QAvlIc52Yix7pKJPbw85+zykvnfl2mdROsaT8p8R9nwCdFsBc9IiD0NhPEHcyHRwB8fokXTajk2QnGhL+zP5KnkmXnyQYOCUYo3EKMXIlVOVbPDgRYYT/XqvBuzq5S9rrU70KoI/S5lDnFfx/+lPLdtcnnEPk='
+          } > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
           export GIT_SSH_COMMAND="ssh -i ~/.ssh/aur -o IdentitiesOnly=yes"
 
           git config --global user.name "$AUR_USERNAME"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -523,22 +523,27 @@ jobs:
           AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
           AUR_USERNAME: ${{ secrets.AUR_USERNAME }}
           AUR_EMAIL: ${{ secrets.AUR_EMAIL }}
+          AUR_KNOWN_HOSTS: ${{ secrets.AUR_KNOWN_HOSTS }}
         run: |
           set -euo pipefail
 
           install -d -m 700 ~/.ssh
           printf '%s\n' "$AUR_SSH_PRIVATE_KEY" > ~/.ssh/aur
           chmod 600 ~/.ssh/aur
-          # Pin AUR's SSH host keys instead of an at-runtime ssh-keyscan. The
-          # scan hid its own errors (2>/dev/null), so a failed/empty scan left
-          # known_hosts empty and surfaced only as an opaque "Host key
-          # verification failed" at clone time. Verified fingerprints — ED25519
-          # SHA256:RFzBCUItH9LZS0cKB5UE6ceAYhBD5C8GeOBip8Z11+4, RSA
-          # SHA256:5s5cIyReIfNNVGRFdDbe3hdYiI5OelHGpw2rOUud3Q8.
-          {
-            echo 'aur.archlinux.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEuBKrPzbawxA/k2g6NcyV5jmqwJ2s+zpgZGZ7tpLIcN'
-            echo 'aur.archlinux.org ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDKF9vAFWdgm9Bi8uc+tYRBmXASBb5cB5iZsB7LOWWFeBrLp3r14w0/9S2vozjgqY5sJLDPONWoTTaVTbhe3vwO8CBKZTEt1AcWxuXNlRnk9FliR1/eNB9uz/7y1R0+c1Md+P98AJJSJWKN12nqIDIhjl2S1vOUvm7FNY43fU2knIhEbHybhwWeg+0wxpKwcAd/JeL5i92Uv03MYftOToUijd1pqyVFdJvQFhqD4v3M157jxS5FTOBrccAEjT+zYmFyD8WvKUa9vUclRddNllmBJdy4NyLB8SvVZULUPrP3QOlmzemeKracTlVOUG1wsDbxknF1BwSCU7CmU6UFP90kpWIyz66bP0bl67QAvlIc52Yix7pKJPbw85+zykvnfl2mdROsaT8p8R9nwCdFsBc9IiD0NhPEHcyHRwB8fokXTajk2QnGhL+zP5KnkmXnyQYOCUYo3EKMXIlVOVbPDgRYYT/XqvBuzq5S9rrU70KoI/S5lDnFfx/+lPLdtcnnEPk='
-          } > ~/.ssh/known_hosts
+          # AUR's SSH host keys come from the AUR_KNOWN_HOSTS secret (the two
+          # `known_hosts` lines) rather than a runtime ssh-keyscan, whose errors
+          # were swallowed (2>/dev/null) and surfaced only as an opaque "Host key
+          # verification failed" at clone time. These are the server's PUBLIC
+          # host keys; the secret just keeps them out of the workflow. Generate
+          # the value with `ssh-keyscan -t ed25519,rsa aur.archlinux.org` and
+          # verify against AUR's published fingerprints (ED25519
+          # SHA256:RFzBCUItH9LZS0cKB5UE6ceAYhBD5C8GeOBip8Z11+4). See
+          # packaging/aur/README.md.
+          if [ -z "${AUR_KNOWN_HOSTS:-}" ]; then
+            echo "AUR_KNOWN_HOSTS secret is not set — add it (see packaging/aur/README.md)." >&2
+            exit 1
+          fi
+          printf '%s\n' "$AUR_KNOWN_HOSTS" > ~/.ssh/known_hosts
           chmod 600 ~/.ssh/known_hosts
           export GIT_SSH_COMMAND="ssh -i ~/.ssh/aur -o IdentitiesOnly=yes"
 

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -93,6 +93,16 @@ The automation cannot run until a human claims the package name on the AUR:
    - `AUR_USERNAME` — your AUR account name
    - `AUR_EMAIL` — the email on that account
    - `AUR_SSH_PRIVATE_KEY` — the private half of the key from step 1
+   - `AUR_KNOWN_HOSTS` — AUR's SSH host keys, so the publish job can verify the
+     server before cloning. These are the server's *public* host keys (not a
+     secret in the cryptographic sense); the secret just keeps them out of the
+     workflow. Generate the value with:
+     ```
+     ssh-keyscan -t ed25519,rsa aur.archlinux.org
+     ```
+     and confirm the fingerprints match AUR's published ones (`ssh-keygen -lf`)
+     — currently ED25519 `SHA256:RFzBCUItH9LZS0cKB5UE6ceAYhBD5C8GeOBip8Z11+4`,
+     RSA `SHA256:5s5cIyReIfNNVGRFdDbe3hdYiI5OelHGpw2rOUud3Q8` — before pasting.
 
 The current stable release is **`srelens-v0.2.0`**, so the initial import can be
 done against it today (the PKGBUILD builds cleanly against its published `.deb`).


### PR DESCRIPTION
## Problem

The **publish AUR (srelens-bin)** job in the release pipeline failed at `git clone ssh://aur@aur.archlinux.org/srelens-bin.git` with:

```
Host key verification failed.
fatal: Could not read from remote repository.
##[error]Process completed with exit code 128.
```

([failed run](https://github.com/srelens/srelens/actions/runs/29833395153/job/88645420393))

The step fetched the host key with `ssh-keyscan -t ed25519,rsa aur.archlinux.org >> ~/.ssh/known_hosts 2>/dev/null`. The `2>/dev/null` swallowed the scan's errors, so a failed/empty scan left `known_hosts` empty and only surfaced later as the opaque clone failure. The clone itself *connected* (so the network is fine) — it just had no trusted host key. This was the first real run of the job now that the `AUR_*` secrets are configured.

## Fix

Pin AUR's `ed25519` and `rsa` host keys directly instead of scanning at runtime — deterministic, no network dependency for host verification, and stronger than trust-on-first-use for a supply-chain-sensitive push.

Fingerprints verified against AUR's published values:
- ED25519 `SHA256:RFzBCUItH9LZS0cKB5UE6ceAYhBD5C8GeOBip8Z11+4`
- RSA `SHA256:5s5cIyReIfNNVGRFdDbe3hdYiI5OelHGpw2rOUud3Q8`

Validated that the workflow YAML still parses and that the generated `known_hosts` lines reproduce those exact fingerprints.