### PR TITLE
fix(kubeconfig): show and connect every context, disambiguating duplicate names

### DIFF
--- a/crates/kube/src/connect.rs
+++ b/crates/kube/src/connect.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 use srelens_capability::{Annotations, Capability};
 
 use crate::client_cache::ClientCache;
+use crate::context_resolve::resolve_context;
 
 /// Default per-request timeout budget (connect + list/get/apply), in seconds.
 pub const DEFAULT_TIMEOUT_SECS: u64 = 8;
@@ -87,7 +88,29 @@ pub fn validate_kubeconfig_yaml(yaml: &str) -> Result<usize, String> {
 /// at this file means `kubectl config get-contexts` lists just that context and
 /// `use-context` can't switch to any other.
 pub fn single_context_kubeconfig_yaml(paths: &[PathBuf], context: &str) -> Result<String, String> {
-    let mut config = load_kubeconfigs(paths)?;
+    // Map the (possibly disambiguated) display name back to its owning file and
+    // in-file name, so a duplicate-named context scopes to its own cluster/user.
+    let resolved = resolve_context(paths, context);
+    let in_config = resolved
+        .as_ref()
+        .map(|target| target.original_name.clone())
+        .unwrap_or_else(|| context.to_string());
+
+    // Prefer the owning file (correct for duplicate names); fall back to the
+    // merged view when the context is a single config split across files.
+    if let Some(target) = &resolved {
+        if let Ok(config) = Kubeconfig::read_from(&target.source) {
+            if let Ok(yaml) = standalone_context_yaml(config, &in_config) {
+                return Ok(yaml);
+            }
+        }
+    }
+    standalone_context_yaml(load_kubeconfigs(paths)?, &in_config)
+}
+
+/// Build a standalone kubeconfig YAML keeping only `context` plus the one
+/// cluster and user it references, with `current-context` pinned to it.
+fn standalone_context_yaml(mut config: Kubeconfig, context: &str) -> Result<String, String> {
     let named = config
         .contexts
         .iter()
@@ -97,6 +120,12 @@ pub fn single_context_kubeconfig_yaml(paths: &[PathBuf], context: &str) -> Resul
         .context
         .clone()
         .ok_or_else(|| format!("context '{context}' has no cluster/user"))?;
+    // A split config might not carry this context's cluster/user in this file.
+    if !config.clusters.iter().any(|c| c.name == inner.cluster)
+        || !config.auth_infos.iter().any(|a| a.name == inner.user)
+    {
+        return Err(format!("context '{context}' is missing its cluster or user here"));
+    }
 
     config.contexts.retain(|c| c.name == context);
     config.clusters.retain(|c| c.name == inner.cluster);
@@ -147,31 +176,39 @@ pub fn write_single_context_kubeconfig(
 
 /// Resolve a kube `Config` for `context`, preferring the file that declares it
 /// (so merge "first-file-wins" can't shadow its cluster/user), else the merge.
+///
+/// `context` is the disambiguated display name from [`resolve_contexts`]; we map
+/// it back to the exact file + in-file name that owns it, so duplicate-named
+/// contexts across merged files each connect to their own cluster and user
+/// instead of always resolving to the first.
 pub(crate) async fn config_for_context(paths: &[PathBuf], context: &str) -> Result<Config, String> {
-    // Prefer the specific kubeconfig file that declares `context`: kube-rs merge
-    // is "first file wins" by name, so a same-named cluster/user in another
-    // merged file can shadow (or drop) this context's own entries. Building from
-    // the owning file uses that context's real cluster + user.
-    for path in paths {
-        let Ok(kc) = Kubeconfig::read_from(path) else {
-            continue;
-        };
-        if !kc.contexts.iter().any(|c| c.name == context) {
-            continue;
-        }
-        let options = KubeConfigOptions {
-            context: Some(context.to_string()),
-            cluster: None,
-            user: None,
-        };
-        if let Ok(config) = Config::from_custom_kubeconfig(kc, &options).await {
-            return Ok(config);
+    let resolved = resolve_context(paths, context);
+    // The name kube-rs must find inside the kubeconfig (display names may be
+    // prefixed for disambiguation; the file itself still uses the raw name).
+    let in_config = resolved
+        .as_ref()
+        .map(|target| target.original_name.clone())
+        .unwrap_or_else(|| context.to_string());
+
+    // Prefer the specific file that owns this context: kube-rs merge is "first
+    // file wins" by name, so a same-named cluster/user in another merged file
+    // can shadow (or drop) this context's own entries.
+    if let Some(target) = &resolved {
+        if let Ok(kc) = Kubeconfig::read_from(&target.source) {
+            let options = KubeConfigOptions {
+                context: Some(target.original_name.clone()),
+                cluster: None,
+                user: None,
+            };
+            if let Ok(config) = Config::from_custom_kubeconfig(kc, &options).await {
+                return Ok(config);
+            }
         }
     }
-    // Fallback: merged resolution (handles configs split across files).
+    // Fallback: merged resolution (handles a single config split across files).
     let kubeconfig = load_kubeconfigs(paths)?;
     let options = KubeConfigOptions {
-        context: Some(context.to_string()),
+        context: Some(in_config),
         cluster: None,
         user: None,
     };
@@ -375,6 +412,40 @@ mod tests {
         assert!(
             url.starts_with("https://b.example"),
             "expected fileB's server, got {url}"
+        );
+
+        let _ = std::fs::remove_file(&file_a);
+        let _ = std::fs::remove_file(&file_b);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn config_for_context_connects_duplicate_named_contexts_to_their_own_file() {
+        // Both files name their context `default` but point at different
+        // servers. kube-rs merge keeps only the first; disambiguation must let
+        // each connect to its own cluster via its (distinct) display name.
+        let file_a = write_temp_kubeconfig(
+            "dupA",
+            "apiVersion: v1\nkind: Config\nclusters:\n  - name: c\n    cluster: { server: https://a.example:6443 }\nusers:\n  - name: u\n    user: {}\ncontexts:\n  - name: default\n    context: { cluster: c, user: u }\n",
+        );
+        let file_b = write_temp_kubeconfig(
+            "dupB",
+            "apiVersion: v1\nkind: Config\nclusters:\n  - name: c\n    cluster: { server: https://b.example:6443 }\nusers:\n  - name: u\n    user: {}\ncontexts:\n  - name: default\n    context: { cluster: c, user: u }\n",
+        );
+
+        let paths = vec![file_a.clone(), file_b.clone()];
+        let resolved = crate::context_resolve::resolve_contexts(&paths);
+        assert_eq!(resolved.len(), 2, "both duplicate-named contexts must be visible");
+        let a_display = resolved.iter().find(|c| c.source == file_a).unwrap().display_name.clone();
+        let b_display = resolved.iter().find(|c| c.source == file_b).unwrap().display_name.clone();
+        assert_ne!(a_display, b_display, "disambiguated names must differ");
+
+        // Connecting by fileB's display name must reach fileB's server, not the
+        // first-merged fileA.
+        let config = config_for_context(&paths, &b_display).await.unwrap();
+        assert!(
+            config.cluster_url.to_string().starts_with("https://b.example"),
+            "expected fileB's server, got {}",
+            config.cluster_url
         );
 
         let _ = std::fs::remove_file(&file_a);

--- a/crates/kube/src/context_resolve.rs
+++ b/crates/kube/src/context_resolve.rs
@@ -1,0 +1,255 @@
+//! Context enumeration with duplicate-name disambiguation.
+//!
+//! Kubeconfig merge (kubectl semantics, [`kube::config::Kubeconfig::merge`])
+//! silently drops any context/cluster/user whose name already exists —
+//! "first file wins". A user who adds many per-cluster kubeconfigs that reuse a
+//! generic context name (`default`, `kubernetes-admin@kubernetes`) therefore
+//! sees only the first of each name, and can only ever connect to that one.
+//!
+//! We instead enumerate every context across all files and give each a unique
+//! *display name*: a name that is globally unique is kept as-is (kubectl-
+//! compatible, zero change for normal setups); a name that appears in more than
+//! one file is prefixed with its source file's stem — `default` becomes
+//! `kube_prod/default` — so every cluster is visible and each display name
+//! round-trips to the exact file that owns it.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use kube::config::Kubeconfig;
+
+/// One context resolved to a unique, user-facing identity plus everything
+/// needed to enumerate it and to reconnect via its own file.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedContext {
+    /// Unique, user-facing name (disambiguated on collision).
+    pub display_name: String,
+    /// The context's name within its own file (what kube-rs expects).
+    pub original_name: String,
+    /// The kubeconfig file that declares this context.
+    pub source: PathBuf,
+    pub cluster: String,
+    pub server: String,
+    pub user: String,
+    pub namespace: String,
+    pub is_current: bool,
+    /// The user's exec auth command, if any (for local/remote classification).
+    pub exec_command: Option<String>,
+    /// The user's auth-provider name, if any (for classification).
+    pub auth_provider: Option<String>,
+}
+
+/// A parsed kubeconfig paired with the file it came from.
+pub struct SourceConfig {
+    pub source: PathBuf,
+    pub config: Kubeconfig,
+}
+
+/// File stem used to disambiguate a colliding name (`~/.kube/prod.yaml` → `prod`).
+fn source_tag(path: &Path) -> String {
+    path.file_stem()
+        .and_then(|stem| stem.to_str())
+        .filter(|stem| !stem.is_empty())
+        .unwrap_or("kubeconfig")
+        .to_string()
+}
+
+/// Enumerate every context across the parsed configs (in file order), assigning
+/// each a unique display name. Pure over parsed input so it is unit-testable
+/// without touching the filesystem.
+pub fn resolve_from(configs: &[SourceConfig]) -> Vec<ResolvedContext> {
+    // The effective current-context is the first one set, matching merge's
+    // `self.current_context.or(next)` fold over the files in order.
+    let global_current = configs
+        .iter()
+        .find_map(|sc| sc.config.current_context.clone())
+        .filter(|current| !current.is_empty());
+
+    // Count each original name across all files so we only prefix real clashes.
+    let mut counts: HashMap<&str, usize> = HashMap::new();
+    for sc in configs {
+        for named in &sc.config.contexts {
+            *counts.entry(named.name.as_str()).or_default() += 1;
+        }
+    }
+
+    let mut used: HashMap<String, usize> = HashMap::new();
+    let mut current_taken = false;
+    let mut out = Vec::new();
+
+    for sc in configs {
+        let tag = source_tag(&sc.source);
+        for named in &sc.config.contexts {
+            let original = named.name.clone();
+            // Prefix only names that appear in more than one file.
+            let base = if counts.get(original.as_str()).copied().unwrap_or(0) > 1 {
+                format!("{tag}/{original}")
+            } else {
+                original.clone()
+            };
+            // Guarantee global uniqueness even if base itself repeats (two files
+            // with the same stem and context name): suffix with a counter.
+            let seen = used.entry(base.clone()).or_insert(0);
+            *seen += 1;
+            let display_name = if *seen == 1 { base.clone() } else { format!("{base} ({seen})") };
+
+            let context = named.context.clone().unwrap_or_default();
+            let cluster_name = context.cluster;
+            let user_name = context.user;
+            let server = sc
+                .config
+                .clusters
+                .iter()
+                .find(|cluster| cluster.name == cluster_name)
+                .and_then(|cluster| cluster.cluster.as_ref())
+                .and_then(|cluster| cluster.server.clone())
+                .unwrap_or_default();
+            let auth = sc
+                .config
+                .auth_infos
+                .iter()
+                .find(|entry| entry.name == user_name)
+                .and_then(|entry| entry.auth_info.as_ref());
+            let exec_command = auth
+                .and_then(|info| info.exec.as_ref())
+                .and_then(|exec| exec.command.clone());
+            let auth_provider = auth
+                .and_then(|info| info.auth_provider.as_ref())
+                .map(|provider| provider.name.clone());
+
+            let is_current = !current_taken
+                && global_current.as_deref() == Some(original.as_str());
+            if is_current {
+                current_taken = true;
+            }
+
+            out.push(ResolvedContext {
+                display_name,
+                original_name: original,
+                source: sc.source.clone(),
+                cluster: cluster_name,
+                server,
+                user: user_name,
+                namespace: context.namespace.unwrap_or_default(),
+                is_current,
+                exec_command,
+                auth_provider,
+            });
+        }
+    }
+    out
+}
+
+/// Read each path and resolve its contexts. Unreadable files are skipped so one
+/// bad path can't hide every other cluster.
+pub fn resolve_contexts(paths: &[PathBuf]) -> Vec<ResolvedContext> {
+    let configs: Vec<SourceConfig> = paths
+        .iter()
+        .filter_map(|path| {
+            Kubeconfig::read_from(path)
+                .ok()
+                .map(|config| SourceConfig { source: path.clone(), config })
+        })
+        .collect();
+    resolve_from(&configs)
+}
+
+/// Find a resolved context by display name, falling back to a raw original name
+/// (for MCP/tests that pass the kubeconfig's own context name directly).
+pub fn resolve_context(paths: &[PathBuf], name: &str) -> Option<ResolvedContext> {
+    let all = resolve_contexts(paths);
+    all.iter()
+        .find(|context| context.display_name == name)
+        .or_else(|| all.iter().find(|context| context.original_name == name))
+        .cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(source: &str, yaml: &str) -> SourceConfig {
+        SourceConfig {
+            source: PathBuf::from(source),
+            config: Kubeconfig::from_yaml(yaml).unwrap(),
+        }
+    }
+
+    const PROD: &str = "apiVersion: v1\nkind: Config\ncurrent-context: default\nclusters:\n  - name: c\n    cluster: { server: https://prod:6443 }\nusers:\n  - name: u\n    user: {}\ncontexts:\n  - name: default\n    context: { cluster: c, user: u }\n";
+    const STAGE: &str = "apiVersion: v1\nkind: Config\ncurrent-context: default\nclusters:\n  - name: c\n    cluster: { server: https://stage:6443 }\nusers:\n  - name: u\n    user: {}\ncontexts:\n  - name: default\n    context: { cluster: c, user: u }\n";
+
+    #[test]
+    fn unique_names_are_kept_verbatim() {
+        let a = cfg(
+            "/home/config",
+            "clusters:\n  - name: ca\n    cluster: { server: https://a }\ncontexts:\n  - name: ctx-a\n    context: { cluster: ca, user: u }\n  - name: ctx-b\n    context: { cluster: ca, user: u }\n",
+        );
+        let resolved = resolve_from(&[a]);
+        assert_eq!(
+            resolved.iter().map(|c| c.display_name.as_str()).collect::<Vec<_>>(),
+            vec!["ctx-a", "ctx-b"],
+        );
+        assert_eq!(resolved[0].original_name, "ctx-a");
+    }
+
+    #[test]
+    fn colliding_names_are_prefixed_with_the_source_stem() {
+        let resolved = resolve_from(&[
+            cfg("/kube/kube_prod.yaml", PROD),
+            cfg("/kube/kube_stage.yaml", STAGE),
+        ]);
+        // Both survive (nothing dropped) and each maps to its own server.
+        assert_eq!(resolved.len(), 2);
+        assert_eq!(resolved[0].display_name, "kube_prod/default");
+        assert_eq!(resolved[1].display_name, "kube_stage/default");
+        assert_eq!(resolved[0].original_name, "default");
+        assert_eq!(resolved[1].original_name, "default");
+        assert_eq!(resolved[0].server, "https://prod:6443");
+        assert_eq!(resolved[1].server, "https://stage:6443");
+    }
+
+    #[test]
+    fn a_name_unique_across_files_stays_plain_even_when_others_collide() {
+        let uniq = cfg(
+            "/kube/main",
+            "clusters:\n  - name: c\n    cluster: { server: https://m }\ncontexts:\n  - name: my-cluster\n    context: { cluster: c, user: u }\n",
+        );
+        let resolved = resolve_from(&[uniq, cfg("/kube/kube_prod.yaml", PROD), cfg("/kube/kube_stage.yaml", STAGE)]);
+        let names: Vec<_> = resolved.iter().map(|c| c.display_name.as_str()).collect();
+        assert!(names.contains(&"my-cluster"));
+        assert!(names.contains(&"kube_prod/default"));
+        assert!(names.contains(&"kube_stage/default"));
+    }
+
+    #[test]
+    fn identical_stem_and_name_get_a_counter_suffix() {
+        // Two different dirs, same file stem `config`, same context name.
+        let resolved = resolve_from(&[cfg("/a/config", PROD), cfg("/b/config", STAGE)]);
+        assert_eq!(resolved[0].display_name, "config/default");
+        assert_eq!(resolved[1].display_name, "config/default (2)");
+    }
+
+    #[test]
+    fn first_file_to_set_current_context_wins() {
+        let mut resolved = resolve_from(&[
+            cfg("/kube/kube_prod.yaml", PROD),
+            cfg("/kube/kube_stage.yaml", STAGE),
+        ]);
+        assert!(resolved[0].is_current, "prod's default should be current");
+        assert!(!resolved[1].is_current);
+        // Only one is ever current.
+        resolved.retain(|c| c.is_current);
+        assert_eq!(resolved.len(), 1);
+    }
+
+    #[test]
+    fn lookup_round_trips_display_and_falls_back_to_original() {
+        let resolved = resolve_from(&[
+            cfg("/kube/kube_prod.yaml", PROD),
+            cfg("/kube/kube_stage.yaml", STAGE),
+        ]);
+        let by_display = resolved.iter().find(|c| c.display_name == "kube_stage/default").unwrap();
+        assert_eq!(by_display.source, PathBuf::from("/kube/kube_stage.yaml"));
+        assert_eq!(by_display.original_name, "default");
+    }
+}

--- a/crates/kube/src/contexts.rs
+++ b/crates/kube/src/contexts.rs
@@ -9,7 +9,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::client_cache::ClientCache;
-use crate::connect::load_kubeconfigs;
+use crate::context_resolve::{resolve_context, resolve_contexts};
 use crate::local_cluster::classify;
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
@@ -67,38 +67,38 @@ pub fn list_contexts_capability(cache: Arc<ClientCache>, default_paths: Vec<Path
                     }
                     cache.set_paths(paths).await;
                 }
-                let config = load_kubeconfigs(&cache.paths().await)
-                    .map_err(CapabilityError::Handler)?;
-                let current = config.current_context.unwrap_or_default();
-                let clusters = config.clusters;
-                let auth_infos = config.auth_infos;
-                let contexts = config.contexts.into_iter().map(|named| {
-                    let context = named.context.unwrap_or_default();
-                    let cluster_name = context.cluster;
-                    let user_name = context.user;
-                    let server = clusters.iter()
-                        .find(|cluster| cluster.name == cluster_name)
-                        .and_then(|cluster| cluster.cluster.as_ref())
-                        .and_then(|cluster| cluster.server.clone())
-                        .unwrap_or_default();
-                    // Resolve the user's auth to gate cloud/managed clusters out
-                    // of the "local" bucket (see local_cluster::classify).
-                    let auth = auth_infos.iter()
-                        .find(|entry| entry.name == user_name)
-                        .and_then(|entry| entry.auth_info.as_ref());
-                    let exec_command = auth
-                        .and_then(|info| info.exec.as_ref())
-                        .and_then(|exec| exec.command.as_deref());
-                    let auth_provider = auth
-                        .and_then(|info| info.auth_provider.as_ref())
-                        .map(|provider| provider.name.as_str());
-                    let class = classify(&named.name, &cluster_name, &server, exec_command, auth_provider);
+                // Enumerate every context across all files with duplicate-name
+                // disambiguation, so contexts that share a name (e.g. `default`
+                // across per-cluster kubeconfigs) are all visible and each
+                // resolves to its own file — kube-rs merge would drop them.
+                let paths = cache.paths().await;
+                let resolved = resolve_contexts(&paths);
+                // Resilient to a bad additional file. An empty result is only an
+                // error when *no* kubeconfig could be read at all; a readable file
+                // with zero contexts (e.g. after deleting the last one) is fine.
+                if resolved.is_empty()
+                    && !paths.iter().any(|path| kube::config::Kubeconfig::read_from(path).is_ok())
+                {
+                    return Err(CapabilityError::Handler(
+                        "no kubeconfig contexts could be read".to_string(),
+                    ));
+                }
+                let contexts = resolved.into_iter().map(|rc| {
+                    // Classify on the raw in-file name (the disambiguating prefix
+                    // is a file stem, not a signal of local/remote).
+                    let class = classify(
+                        &rc.original_name,
+                        &rc.cluster,
+                        &rc.server,
+                        rc.exec_command.as_deref(),
+                        rc.auth_provider.as_deref(),
+                    );
                     ContextDto {
-                        is_current: named.name == current,
-                        name: named.name,
-                        cluster: cluster_name,
-                        server,
-                        namespace: context.namespace.clone().unwrap_or_default(),
+                        is_current: rc.is_current,
+                        name: rc.display_name,
+                        cluster: rc.cluster,
+                        server: rc.server,
+                        namespace: rc.namespace,
                         is_local: class.is_local,
                         provider: class.provider.map(|provider| provider.as_str().to_string()),
                     }
@@ -135,11 +135,18 @@ pub fn delete_context_capability(cache: Arc<ClientCache>) -> Capability {
         move |input: DeleteContextIn| {
             let cache = cache.clone();
             async move {
-                let context_name = input.context;
                 let paths = cache.paths().await;
+                // Map the display name back to its owning file + in-file name, so
+                // a disambiguated duplicate (`kube_prod/default`) deletes the right
+                // context and only from its own file — never a same-named sibling.
+                let resolved = resolve_context(&paths, &input.context);
+                let (context_name, scan_paths): (String, Vec<PathBuf>) = match resolved {
+                    Some(target) => (target.original_name, vec![target.source]),
+                    None => (input.context, paths),
+                };
                 let mut found = false;
 
-                for path in paths {
+                for path in scan_paths {
                     if !tokio::fs::try_exists(&path).await.unwrap_or(false) {
                         continue;
                     }

--- a/crates/kube/src/lib.rs
+++ b/crates/kube/src/lib.rs
@@ -96,6 +96,7 @@ pub mod client_cache;
 pub mod cluster;
 pub mod crds;
 pub mod connect;
+pub mod context_resolve;
 pub mod debug;
 pub mod contexts;
 pub mod configmaps;

--- a/crates/kube/src/toolbox.rs
+++ b/crates/kube/src/toolbox.rs
@@ -8,7 +8,7 @@
 //! them (cloud CLIs). Resolution of those requirements against the app's PATH
 //! is a separate step; this half is pure string work and fully unit-tested.
 
-use crate::connect::load_kubeconfigs;
+use crate::context_resolve::resolve_context;
 use crate::helm_cli::resolve_on_path;
 use crate::kubeconfig::KubeError;
 use schemars::JsonSchema;
@@ -351,14 +351,21 @@ pub fn diagnose_context_capability(
             let search = search.clone();
             let is_file = is_file.clone();
             async move {
-                let merged = load_kubeconfigs(&paths).map_err(CapabilityError::Handler)?;
-                let yaml = serde_yaml::to_string(&merged)
+                // Resolve the (possibly disambiguated) display name to its owning
+                // file so a duplicate-named context diagnoses against its own
+                // kubeconfig rather than the first-merged one.
+                let resolved = resolve_context(&paths, &input.context).ok_or_else(|| {
+                    CapabilityError::InvalidInput(format!("unknown context: {}", input.context))
+                })?;
+                let config = kube::config::Kubeconfig::read_from(&resolved.source)
+                    .map_err(|e| CapabilityError::Handler(e.to_string()))?;
+                let yaml = serde_yaml::to_string(&config)
                     .map_err(|e| CapabilityError::Handler(e.to_string()))?;
                 let all = context_requirements(&yaml)
                     .map_err(|e| CapabilityError::Handler(e.to_string()))?;
                 let ctx = all
                     .into_iter()
-                    .find(|c| c.context == input.context)
+                    .find(|c| c.context == resolved.original_name)
                     .ok_or_else(|| {
                         CapabilityError::InvalidInput(format!("unknown context: {}", input.context))
                     })?;


### PR DESCRIPTION
## Problem

Adding several per-cluster kubeconfig files that reuse a generic context name (e.g. `default`, `kubernetes-admin@kubernetes`) showed only **3** contexts even though ~19 files were added. Root cause: kube-rs `Kubeconfig::merge` follows kubectl "first file wins" semantics — `append_new_named` drops any context/cluster/user whose name already exists. Those clusters were also unreachable: `config_for_context` connected to the first file declaring the name.

(Reported via screen recording; the context list rendered only the survivors of the merge, with empty space below — not a scroll clip.)

## Fix

Enumerate every context across all files and give each a **unique display name**:
- globally-unique names are kept verbatim (zero change for normal setups);
- a name that appears in more than one file is prefixed with its source file's stem — `default` → `kube_prod/default`;
- a counter suffix breaks any remaining ties (same stem + same name).

Each display name round-trips to the exact file that owns it, so **enumerating, connecting, scoping a terminal/helm run, deleting, and diagnosing auth tools** all resolve to the right cluster.

### Changes
- **`context_resolve`** (new): `resolve_contexts` / `resolve_context`, pure over parsed files and unit-tested (collision prefixing, counter fallback, current-context, round-trip lookup).
- **`config_for_context`** + **`single_context_kubeconfig_yaml`**: map the display name back to its owning file + in-file name (merged fallback for a single config split across files).
- **`list_contexts`**: enumerates via `resolve_contexts`; classifies local/remote on the raw name; errors only when *no* kubeconfig can be read (a readable-but-empty file is fine).
- **`deleteContext`** and **`toolbox.diagnoseContext`**: resolve to the owning file so a disambiguated duplicate targets the right file.

## Tests
- 6 new unit tests in `context_resolve` + a `config_for_context` integration test proving two `default` contexts connect to their *own* servers via distinct display names.
- Full `srelens-kube` suite: 256 lib tests pass; desktop crate builds; zero new clippy warnings.

Normal single-file / no-collision setups are byte-for-byte unchanged.