### PR TITLE
feat(settings): application logs — file logging + in-app viewer

### DIFF
--- a/apps/desktop/src-tauri/src/app_log.rs
+++ b/apps/desktop/src-tauri/src/app_log.rs
@@ -1,0 +1,100 @@
+//! Application-log file access for the Settings "Application logs" view.
+//!
+//! The `tauri-plugin-log` `LogDir` target (configured in `lib.rs`) writes a
+//! rotating `srelens.log` in the OS log directory. These commands expose it to
+//! the WebView: read a bounded tail, get the path (to copy), and reveal it in
+//! the file manager.
+
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+
+use tauri::{AppHandle, Manager};
+
+/// Default amount of the log tail to return (bytes) — enough for triage without
+/// loading an arbitrarily large file into the WebView.
+const DEFAULT_TAIL_BYTES: u64 = 1_000_000;
+
+/// The current log file: `<app log dir>/srelens.log` (matches the plugin's
+/// `LogDir { file_name: Some("srelens") }` target).
+fn log_file(app: &AppHandle) -> Result<PathBuf, String> {
+    let dir = app.path().app_log_dir().map_err(|e| e.to_string())?;
+    Ok(dir.join("srelens.log"))
+}
+
+/// The absolute path of the application log file (for copy / display).
+#[tauri::command]
+pub async fn app_log_path(app: AppHandle) -> Result<String, String> {
+    Ok(log_file(&app)?.to_string_lossy().into_owned())
+}
+
+/// Return the tail of the log file (last `max_bytes`, default 1 MB), dropping a
+/// partial first line. An absent file (nothing logged yet) reads as empty.
+#[tauri::command]
+pub async fn read_app_log(app: AppHandle, max_bytes: Option<u64>) -> Result<String, String> {
+    let path = log_file(&app)?;
+    let cap = max_bytes.unwrap_or(DEFAULT_TAIL_BYTES);
+    let mut file = match std::fs::File::open(&path) {
+        Ok(file) => file,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(String::new()),
+        Err(e) => return Err(e.to_string()),
+    };
+    let len = file.metadata().map_err(|e| e.to_string())?.len();
+    let start = len.saturating_sub(cap);
+    file.seek(SeekFrom::Start(start)).map_err(|e| e.to_string())?;
+    // Read as bytes: a byte-offset seek can split a UTF-8 char, so decode lossy
+    // rather than risk a hard error on a valid log.
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes).map_err(|e| e.to_string())?;
+    let mut text = String::from_utf8_lossy(&bytes).into_owned();
+    // Started mid-file — drop the partial first line.
+    if start > 0 {
+        if let Some(newline) = text.find('\n') {
+            text.drain(..=newline);
+        }
+    }
+    Ok(text)
+}
+
+/// Reveal the log file in the OS file manager (or its directory when the file
+/// doesn't exist yet, or on Linux where selecting a file isn't portable).
+#[tauri::command]
+pub async fn reveal_app_log(app: AppHandle) -> Result<(), String> {
+    reveal_in_file_manager(&log_file(&app)?)
+}
+
+fn reveal_in_file_manager(path: &Path) -> Result<(), String> {
+    let dir = path.parent().unwrap_or(path);
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    let exists = path.exists();
+
+    #[cfg(target_os = "macos")]
+    let mut command = {
+        let mut command = std::process::Command::new("open");
+        if exists {
+            command.arg("-R").arg(path);
+        } else {
+            command.arg(dir);
+        }
+        command
+    };
+    #[cfg(target_os = "windows")]
+    let mut command = {
+        let mut command = std::process::Command::new("explorer");
+        if exists {
+            command.arg(format!("/select,{}", path.display()));
+        } else {
+            command.arg(dir);
+        }
+        command
+    };
+    // No portable "select a file" on Linux — open the containing directory.
+    #[cfg(all(unix, not(target_os = "macos")))]
+    let mut command = {
+        let mut command = std::process::Command::new("xdg-open");
+        command.arg(dir);
+        command
+    };
+
+    command.spawn().map_err(|e| e.to_string())?;
+    Ok(())
+}

--- a/apps/desktop/src-tauri/src/bridge.rs
+++ b/apps/desktop/src-tauri/src/bridge.rs
@@ -18,5 +18,11 @@ pub async fn invoke_capability(
     input: Value,
     registry: State<'_, AppRegistry>,
 ) -> Result<Value, String> {
-    registry.0.invoke(&id, input).await.map_err(|e| e.to_string())
+    registry.0.invoke(&id, input).await.map_err(|e| {
+        // Surface capability failures (connection timeouts, denied RBAC, bad
+        // input) to the application log for post-hoc diagnosis.
+        let message = e.to_string();
+        log::warn!("capability '{id}' failed: {message}");
+        message
+    })
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod app_log;
 mod appimage;
 mod bridge;
 pub mod capabilities;
@@ -13,6 +14,7 @@ mod toolbox;
 mod updater;
 mod watch;
 
+use app_log::{app_log_path, read_app_log, reveal_app_log};
 use bridge::{invoke_capability, AppRegistry};
 use exec::{exec_close, exec_input, start_pod_exec, ExecManager};
 use files::{pick_kubeconfig_files, save_pasted_kubeconfig, save_text_file};
@@ -220,13 +222,31 @@ pub fn run() {
     let watcher_cache = cache.clone();
     builder
         .setup(move |app| {
+            // Application logging: always write a rotating file to the OS log
+            // directory so the Settings "Application logs" view (and post-hoc
+            // debugging of a shipped build) has something to read; mirror to
+            // stdout in dev for convenience.
+            let mut log_targets = vec![tauri_plugin_log::Target::new(
+                tauri_plugin_log::TargetKind::LogDir { file_name: Some("srelens".into()) },
+            )];
             if cfg!(debug_assertions) {
-                app.handle().plugin(
-                    tauri_plugin_log::Builder::default()
-                        .level(log::LevelFilter::Info)
-                        .build(),
-                )?;
+                log_targets.push(tauri_plugin_log::Target::new(
+                    tauri_plugin_log::TargetKind::Stdout,
+                ));
             }
+            app.handle().plugin(
+                tauri_plugin_log::Builder::default()
+                    .level(log::LevelFilter::Info)
+                    // Keep noisy transport crates out of the file so it stays
+                    // readable for triage.
+                    .level_for("hyper", log::LevelFilter::Warn)
+                    .level_for("rustls", log::LevelFilter::Warn)
+                    .max_file_size(5_000_000)
+                    .rotation_strategy(tauri_plugin_log::RotationStrategy::KeepOne)
+                    .targets(log_targets)
+                    .build(),
+            )?;
+            log::info!("srelens {} starting", env!("CARGO_PKG_VERSION"));
             #[cfg(desktop)]
             size_main_window(app);
             #[cfg(target_os = "macos")]
@@ -283,7 +303,10 @@ pub fn run() {
             terminal_resize,
             terminal_close,
             start_helm_op,
-            helm_op_close
+            helm_op_close,
+            read_app_log,
+            app_log_path,
+            reveal_app_log
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/desktop/src/components/AppLogView.test.tsx
+++ b/apps/desktop/src/components/AppLogView.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+const { readAppLogMock, appLogPathMock, revealAppLogMock } = vi.hoisted(() => ({
+  readAppLogMock: vi.fn(),
+  appLogPathMock: vi.fn(),
+  revealAppLogMock: vi.fn(),
+}));
+vi.mock("../lib/appLog", () => ({
+  readAppLog: readAppLogMock,
+  appLogPath: appLogPathMock,
+  revealAppLog: revealAppLogMock,
+}));
+
+import { AppLogView, logLineLevel } from "./AppLogView";
+
+const SAMPLE = [
+  "[2026-07-21][12:00:00][srelens][INFO] srelens 0.3.0 starting",
+  "[2026-07-21][12:00:01][srelens][WARN] capability 'k8s.listPods' failed: timeout",
+  "[2026-07-21][12:00:02][srelens][ERROR] connect kube_prod/default: unreachable",
+].join("\n");
+
+beforeEach(() => {
+  readAppLogMock.mockReset();
+  appLogPathMock.mockReset();
+  revealAppLogMock.mockReset();
+  readAppLogMock.mockResolvedValue(SAMPLE);
+  appLogPathMock.mockResolvedValue("/Users/x/Library/Logs/srelens/srelens.log");
+  revealAppLogMock.mockResolvedValue(undefined);
+});
+
+describe("logLineLevel", () => {
+  it("extracts the level from a plugin-formatted line, defaulting to INFO", () => {
+    expect(logLineLevel("[d][t][srelens][ERROR] boom")).toBe("ERROR");
+    expect(logLineLevel("[d][t][srelens][WARN] hmm")).toBe("WARN");
+    expect(logLineLevel("a line with no level")).toBe("INFO");
+  });
+});
+
+describe("AppLogView", () => {
+  it("loads the log and shows its path", async () => {
+    render(<AppLogView />);
+    await waitFor(() => expect(screen.getByText(/srelens 0.3.0 starting/)).toBeDefined());
+    expect(screen.getByText("/Users/x/Library/Logs/srelens/srelens.log")).toBeDefined();
+  });
+
+  it("filters by level", async () => {
+    render(<AppLogView />);
+    await waitFor(() => expect(screen.getByText(/starting/)).toBeDefined());
+
+    await userEvent.click(screen.getByRole("combobox", { name: "Log level" }));
+    await userEvent.click(await screen.findByRole("option", { name: "ERROR" }));
+
+    expect(screen.getByText(/unreachable/)).toBeDefined();
+    expect(screen.queryByText(/starting/)).toBeNull();
+  });
+
+  it("filters by search text", async () => {
+    render(<AppLogView />);
+    await waitFor(() => expect(screen.getByText(/starting/)).toBeDefined());
+
+    fireEvent.change(screen.getByLabelText("Search log"), { target: { value: "timeout" } });
+    expect(screen.getByText(/k8s.listPods/)).toBeDefined();
+    expect(screen.queryByText(/starting/)).toBeNull();
+  });
+
+  it("reveals the log file in the file manager", async () => {
+    render(<AppLogView />);
+    await waitFor(() => expect(screen.getByText(/starting/)).toBeDefined());
+    fireEvent.click(screen.getByRole("button", { name: "Reveal" }));
+    await waitFor(() => expect(revealAppLogMock).toHaveBeenCalled());
+  });
+});

--- a/apps/desktop/src/components/AppLogView.tsx
+++ b/apps/desktop/src/components/AppLogView.tsx
@@ -1,0 +1,138 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Check, Copy, FolderOpen, RefreshCw } from "lucide-react";
+import { appLogPath, readAppLog, revealAppLog } from "../lib/appLog";
+import { Button, IconButton, Select, Spinner, TextInput } from "../ui";
+
+/** Log levels emitted by tauri-plugin-log, most→least severe. */
+const LEVELS = ["ERROR", "WARN", "INFO", "DEBUG", "TRACE"] as const;
+type Level = (typeof LEVELS)[number];
+
+const LEVEL_CLASS: Record<Level, string> = {
+  ERROR: "text-red-600 dark:text-red-400",
+  WARN: "text-amber-600 dark:text-amber-400",
+  INFO: "text-foreground/80",
+  DEBUG: "text-foreground/60",
+  TRACE: "text-foreground/50",
+};
+
+/** Cap rendered lines so a large log can't balloon the DOM. */
+const MAX_RENDERED = 5000;
+
+/** The level of a `[date][time][target][LEVEL] message` line (INFO if absent). */
+export function logLineLevel(line: string): Level {
+  const match = line.match(/\]\[(TRACE|DEBUG|INFO|WARN|ERROR)\]/);
+  return (match?.[1] as Level) ?? "INFO";
+}
+
+/**
+ * View srelens's own application log: read the tail of the rotating log file,
+ * filter by level and text, refresh, copy its path, or reveal it in the file
+ * manager. For diagnosing issues (connection failures, RBAC denials, …) after
+ * they happen.
+ */
+export function AppLogView() {
+  const [raw, setRaw] = useState("");
+  const [path, setPath] = useState("");
+  const [level, setLevel] = useState<string>("all");
+  const [search, setSearch] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [copied, setCopied] = useState(false);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    setError("");
+    Promise.all([readAppLog(), appLogPath()])
+      .then(([text, logPath]) => {
+        setRaw(text);
+        setPath(logPath);
+      })
+      .catch((cause: unknown) => setError(cause instanceof Error ? cause.message : String(cause)))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => load(), [load]);
+
+  const lines = useMemo(() => (raw ? raw.split("\n").filter(Boolean) : []), [raw]);
+  const filtered = useMemo(() => {
+    const query = search.toLowerCase();
+    const matches = lines.filter((line) => {
+      if (level !== "all" && logLineLevel(line) !== level) return false;
+      if (query && !line.toLowerCase().includes(query)) return false;
+      return true;
+    });
+    // Keep the most recent when a large log exceeds the render cap.
+    return matches.length > MAX_RENDERED ? matches.slice(matches.length - MAX_RENDERED) : matches;
+  }, [lines, level, search]);
+
+  async function copyPath() {
+    try {
+      await navigator.clipboard.writeText(path);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard may be unavailable; the path is shown for manual copy.
+    }
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <Select
+          value={level}
+          onValueChange={setLevel}
+          options={[{ value: "all", label: "All levels" }, ...LEVELS.map((l) => ({ value: l, label: l }))]}
+          aria-label="Log level"
+        />
+        <div className="relative w-48">
+          <TextInput value={search} onValueChange={setSearch} placeholder="Search log…" aria-label="Search log" />
+        </div>
+        {(search || level !== "all") && (
+          <span className="tabular-nums text-xs text-muted-foreground">
+            {filtered.length}/{lines.length}
+          </span>
+        )}
+        <div className="ml-auto flex items-center gap-1">
+          {loading && <Spinner label="Loading log" />}
+          <IconButton icon={RefreshCw} label="Refresh" onClick={load} disabled={loading} />
+          <Button variant="outline" size="sm" onClick={() => void revealAppLog()}>
+            <FolderOpen aria-hidden="true" className="size-3.5" />
+            Reveal
+          </Button>
+        </div>
+      </div>
+
+      {path && (
+        <button
+          type="button"
+          onClick={() => void copyPath()}
+          title="Copy log file path"
+          className="flex items-center gap-1.5 self-start rounded font-mono text-[11px] text-muted-foreground hover:text-foreground"
+        >
+          {copied ? <Check aria-hidden="true" className="size-3 text-emerald-600 dark:text-emerald-400" /> : <Copy aria-hidden="true" className="size-3" />}
+          <span className="max-w-[52ch] truncate">{path}</span>
+        </button>
+      )}
+
+      <div
+        role="log"
+        aria-label="Application log"
+        className="min-h-[16rem] flex-1 overflow-auto rounded border border-border bg-card p-2 font-mono text-xs leading-relaxed"
+      >
+        {error ? (
+          <div className="p-2 text-red-600 dark:text-red-400">Error: {error}</div>
+        ) : filtered.length > 0 ? (
+          filtered.map((line, i) => (
+            <div key={i} className={LEVEL_CLASS[logLineLevel(line)]}>
+              {line}
+            </div>
+          ))
+        ) : (
+          <div className="p-2 text-muted-foreground">
+            {loading ? "Loading…" : lines.length > 0 ? "No matching lines" : "No log entries yet."}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/SettingsView.tsx
+++ b/apps/desktop/src/components/SettingsView.tsx
@@ -21,6 +21,7 @@ import {
   GripVertical,
   ClipboardPaste,
   Plug,
+  ScrollText,
   Trash2,
 } from "lucide-react";
 import {
@@ -60,6 +61,7 @@ import {
 import { updateRequestTimeout } from "../lib/requestTimeout";
 import { ContextAvatar, CONTEXT_LOGO_OPTIONS } from "./ContextAvatar";
 import { McpSettingsSection } from "./McpSettingsSection";
+import { AppLogView } from "./AppLogView";
 import { pickKubeconfigFiles, savePastedKubeconfig } from "../lib/files";
 import { checkForUpdate, installUpdate, type UpdateMeta } from "../lib/updater";
 import { appVersion, relaunchApp } from "../transport/transport";
@@ -70,7 +72,7 @@ const MODE_OPTIONS: Array<{ mode: ThemeMode; label: string; description: string;
   { mode: "system", label: "System", description: "Follow the OS appearance", icon: Monitor },
 ];
 
-export type SettingsSection = "appearance" | "layout" | "kubernetes" | "contexts" | "mcp" | "updates";
+export type SettingsSection = "appearance" | "layout" | "kubernetes" | "contexts" | "mcp" | "logs" | "updates";
 
 type UpdatePhase =
   | { phase: "idle" }
@@ -97,6 +99,7 @@ const SETTINGS_SECTIONS: Array<{
   { id: "kubernetes", label: "Kubernetes", description: "Workspace defaults", icon: Network },
   { id: "contexts", label: "Contexts", description: "Names, logos and colors", icon: Boxes },
   { id: "mcp", label: "MCP", description: "Agent access and client config", icon: Plug },
+  { id: "logs", label: "Application logs", description: "Diagnostics and log file", icon: ScrollText },
   { id: "updates", label: "Updates", description: "App version and updates", icon: Download },
 ];
 
@@ -846,6 +849,15 @@ export function SettingsView({
               description="Expose srelens to agents and MCP clients, and get ready-to-paste client config."
             >
               <McpSettingsSection />
+            </SectionPanel>
+          )}
+
+          {section === "logs" && (
+            <SectionPanel
+              title="Application logs"
+              description="srelens's own log file — for diagnosing connection failures, permission errors, and other issues after they happen."
+            >
+              <AppLogView />
             </SectionPanel>
           )}
 

--- a/apps/desktop/src/lib/appLog.ts
+++ b/apps/desktop/src/lib/appLog.ts
@@ -1,0 +1,16 @@
+import { invokeCommand } from "../transport/transport";
+
+/** Read the tail of srelens's own application log file. */
+export async function readAppLog(maxBytes?: number): Promise<string> {
+  return (await invokeCommand<string>("read_app_log", { maxBytes: maxBytes ?? null })) ?? "";
+}
+
+/** The absolute path of the application log file (for display / copy). */
+export async function appLogPath(): Promise<string> {
+  return (await invokeCommand<string>("app_log_path")) ?? "";
+}
+
+/** Reveal the log file in the OS file manager. */
+export async function revealAppLog(): Promise<void> {
+  await invokeCommand("reveal_app_log");
+}


### PR DESCRIPTION
Adds a **Settings ▸ Application logs** view so srelens's own logs are inspectable after something goes wrong (e.g. the kubeconfig/context issue). Requested feature — srelens had no log file at all before this.

## Backend
- `tauri-plugin-log` now runs **always** (it was debug-only, stdout) with a rotating **file** target: `srelens.log` in the OS log dir (5 MB, `KeepOne`), plus stdout in dev.
- Log app start, and route **every capability failure** through `log::warn!` in the bridge — so connection timeouts, RBAC denials, and bad input show up in the file. (Noisy transport crates pinned to `warn`.)
- New commands: `read_app_log` (bounded ~1 MB tail, UTF-8-lossy, drops the partial first line), `app_log_path`, and `reveal_app_log` (cross-platform reveal-in-file-manager).

## Frontend
- `AppLogView`: level filter (all/ERROR/WARN/INFO/DEBUG/TRACE), text search, refresh, copy-path, reveal button, per-level colouring, render cap (last 5000 lines) so a big log can't balloon the DOM.
- Wired into `SettingsView` as a new nav section.

## Tests
- `logLineLevel` parsing + 4 `AppLogView` integration tests (load/path, level filter, search, reveal).
- Full frontend suite 579 pass; `pnpm build` typecheck clean; desktop crate builds; no new clippy warnings.

Screenshot-of-behaviour: an ERROR/WARN/INFO stream with a copyable path and a Reveal button, matching the mock in the request.