### PR TITLE
docs: add r/srelens community links

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
   <a href="https://github.com/srelens/srelens/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/srelens/srelens?display_name=release&label=release&color=22c55e"></a>
   <a href="https://github.com/srelens/srelens/releases"><img alt="Downloads" src="https://img.shields.io/github/downloads/srelens/srelens/total?label=downloads&color=3b82f6"></a>
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/github/license/srelens/srelens?color=675e80"></a>
+  <a href="https://www.reddit.com/r/srelens/"><img alt="Reddit: r/srelens" src="https://img.shields.io/badge/reddit-r%2Fsrelens-FF4500?logo=reddit&logoColor=white"></a>
 </p>
 
 <p align="center">
@@ -220,6 +221,13 @@ and reproducible troubleshooting details are welcome.
 - [Latest release](https://github.com/srelens/srelens/releases/latest)
 - [All releases](https://github.com/srelens/srelens/releases)
 - [Issues and roadmap](https://github.com/srelens/srelens/issues)
+
+## Community
+
+- [r/srelens on Reddit](https://www.reddit.com/r/srelens/) — announcements,
+  questions, and feedback
+- [Issues](https://github.com/srelens/srelens/issues) — bugs and feature requests
+- [Website](https://srelens.com)
 
 ## Contributing
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -358,3 +358,11 @@ restart in place.
 If srelens was installed through a system package manager (for example the Arch
 AUR package), the in-app updater steps aside and points you at your package
 manager instead. AppImage and Windows builds always self-update.
+
+## Questions and feedback
+
+Have a question, hit a rough edge, or want to suggest a feature?
+
+- Join the community on Reddit at [r/srelens](https://www.reddit.com/r/srelens/).
+- File bugs and feature requests on
+  [GitHub Issues](https://github.com/srelens/srelens/issues).


### PR DESCRIPTION
Adds the [r/srelens](https://www.reddit.com/r/srelens/) community to the docs:

- README: a Reddit badge in the header and a **Community** section (Reddit, Issues, Website).
- User guide: a **Questions and feedback** footer pointing to Reddit and GitHub Issues.

(These changes were accidentally pushed to the already-merged #140 branch; this PR brings them in properly.)