### PR TITLE
feat(terminal): reconnect, PTY resize, scrollback search, session management (#19)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -24,6 +24,7 @@
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@xterm/addon-fit": "^0.10.0",
+    "@xterm/addon-search": "^0.16.0",
     "@xterm/xterm": "^5.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/desktop/src-tauri/src/exec.rs
+++ b/apps/desktop/src-tauri/src/exec.rs
@@ -13,6 +13,7 @@ use tokio::task::JoinHandle;
 struct Session {
     handle: JoinHandle<()>,
     input: mpsc::Sender<String>,
+    resize: mpsc::Sender<(u16, u16)>,
 }
 
 /// Tauri-managed state owning running exec sessions (keyed by numeric id).
@@ -44,11 +45,15 @@ pub async fn start_pod_exec(
     container: Option<String>,
     shell: Option<String>,
     command: Option<Vec<String>>,
+    cols: Option<u16>,
+    rows: Option<u16>,
     app: AppHandle,
     manager: State<'_, ExecManager>,
 ) -> Result<u64, String> {
     let id = manager.next_id.fetch_add(1, Ordering::SeqCst);
     let (tx, rx) = mpsc::channel::<String>(64);
+    let (resize_tx, resize_rx) = mpsc::channel::<(u16, u16)>(8);
+    let initial_size = cols.zip(rows);
     let cache = manager.cache.clone();
     let out_channel = format!("exec:out:{id}");
     let exit_channel = format!("exec:exit:{id}");
@@ -63,6 +68,8 @@ pub async fn start_pod_exec(
             container,
             shell,
             command,
+            initial_size,
+            resize_rx,
             move |chunk| {
                 let _ = app_out.emit(&out_channel, chunk);
             },
@@ -76,7 +83,7 @@ pub async fn start_pod_exec(
         .sessions
         .lock()
         .unwrap()
-        .insert(id, Session { handle, input: tx });
+        .insert(id, Session { handle, input: tx, resize: resize_tx });
     Ok(id)
 }
 
@@ -95,6 +102,26 @@ pub async fn exec_input(
         .map(|s| s.input.clone());
     if let Some(tx) = sender {
         let _ = tx.send(data).await;
+    }
+    Ok(())
+}
+
+/// Resize an exec session's remote PTY to `cols` x `rows`.
+#[tauri::command]
+pub async fn exec_resize(
+    session: u64,
+    cols: u16,
+    rows: u16,
+    manager: State<'_, ExecManager>,
+) -> Result<(), String> {
+    let sender = manager
+        .sessions
+        .lock()
+        .unwrap()
+        .get(&session)
+        .map(|s| s.resize.clone());
+    if let Some(tx) = sender {
+        let _ = tx.send((cols, rows)).await;
     }
     Ok(())
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -16,7 +16,7 @@ mod watch;
 
 use app_log::{app_log_path, read_app_log, reveal_app_log};
 use bridge::{invoke_capability, AppRegistry};
-use exec::{exec_close, exec_input, start_pod_exec, ExecManager};
+use exec::{exec_close, exec_input, exec_resize, start_pod_exec, ExecManager};
 use files::{pick_kubeconfig_files, save_pasted_kubeconfig, save_text_file};
 use forward::{start_port_forward, stop_port_forward, ForwardManager};
 use helm::{helm_op_close, start_helm_op, HelmManager};
@@ -280,6 +280,7 @@ pub fn run() {
             stop_watch,
             start_pod_exec,
             exec_input,
+            exec_resize,
             exec_close,
             start_port_forward,
             stop_port_forward,

--- a/apps/desktop/src/components/Dock.tsx
+++ b/apps/desktop/src/components/Dock.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Logs, Plus, SquareTerminal, X } from "lucide-react";
 import { PodTerminal } from "./PodTerminal";
 import { LocalTerminal } from "./LocalTerminal";
@@ -67,6 +67,26 @@ export function Dock({
   heightRef.current = height;
   const handleRef = useRef<HTMLDivElement>(null);
 
+  // In-memory tab renames (double-click a tab to rename; not persisted).
+  const [titles, setTitles] = useState<Record<number, string>>({});
+  const [renamingId, setRenamingId] = useState<number | null>(null);
+  const [draft, setDraft] = useState("");
+  const labelOf = (s: DockSession) => titles[s.id] ?? sessionLabel(s);
+  const startRename = (s: DockSession) => {
+    setDraft(labelOf(s));
+    setRenamingId(s.id);
+  };
+  const commitRename = (id: number) => {
+    const name = draft.trim();
+    setTitles((current) => {
+      const next = { ...current };
+      if (name) next[id] = name;
+      else delete next[id];
+      return next;
+    });
+    setRenamingId(null);
+  };
+
   useEffect(() => {
     const handle = handleRef.current;
     if (!handle) return;
@@ -108,7 +128,7 @@ export function Dock({
               key={s.id}
               role="tab"
               aria-selected={s.id === activeId}
-              title={sessionLabel(s)}
+              title={`${labelOf(s)} — double-click to rename`}
               className={`fl-dock__tab${s.id === activeId ? " fl-dock__tab--active" : ""}`}
               onClick={() => onActivate(s.id)}
             >
@@ -118,11 +138,35 @@ export function Dock({
                 ) : (
                   <Logs aria-hidden="true" />
                 )}
-                <span className="fl-dock__tab-label">{sessionLabel(s)}</span>
+                {renamingId === s.id ? (
+                  <input
+                    className="fl-dock__tab-rename"
+                    value={draft}
+                    autoFocus
+                    onChange={(e) => setDraft(e.target.value)}
+                    onClick={(e) => e.stopPropagation()}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") commitRename(s.id);
+                      else if (e.key === "Escape") setRenamingId(null);
+                    }}
+                    onBlur={() => commitRename(s.id)}
+                    aria-label={`Rename ${sessionLabel(s)}`}
+                  />
+                ) : (
+                  <span
+                    className="fl-dock__tab-label"
+                    onDoubleClick={(e) => {
+                      e.stopPropagation();
+                      startRename(s);
+                    }}
+                  >
+                    {labelOf(s)}
+                  </span>
+                )}
               </span>
               <button
                 className="fl-dock__tab-close"
-                aria-label={`Close ${sessionLabel(s)} ${s.kind}`}
+                aria-label={`Close ${labelOf(s)} ${s.kind}`}
                 onClick={(e) => {
                   e.stopPropagation();
                   onCloseTab(s.id);

--- a/apps/desktop/src/components/LocalTerminal.tsx
+++ b/apps/desktop/src/components/LocalTerminal.tsx
@@ -1,11 +1,12 @@
-import React, { useEffect, useRef } from "react";
-import { startLocalTerminal, type TerminalSession } from "../lib/terminal";
+import React, { useMemo } from "react";
+import { TerminalPane } from "./TerminalPane";
+import { localTerminalDriver } from "../lib/terminalDriver";
 
 /**
- * A local shell (the user's login shell) rendered with xterm, pre-scoped to a
- * kube context so `kubectl` targets it by default. Runs on the user's machine —
- * distinct from the in-pod exec terminal. xterm is loaded dynamically so it
- * stays out of the jsdom test graph; verified live rather than in unit tests.
+ * A local shell (the user's login shell) scoped to a kube context so `kubectl`
+ * targets it by default — distinct from the in-pod exec terminal. A thin
+ * adapter over the shared {@link TerminalPane}; a shell exit is intentional, so
+ * the pane offers a manual "Restart shell" rather than auto-reconnecting.
  */
 export function LocalTerminal({
   context,
@@ -15,82 +16,9 @@ export function LocalTerminal({
   /** Extra kubeconfig files the app has been told about (merged for the shell). */
   kubeconfigFiles: string[];
 }) {
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    let cleanup = () => {};
-    let disposed = false;
-
-    void (async () => {
-      const { Terminal } = await import("@xterm/xterm");
-      const { FitAddon } = await import("@xterm/addon-fit");
-      await import("@xterm/xterm/css/xterm.css");
-      if (disposed || !ref.current) return;
-
-      const term = new Terminal({
-        convertEol: false,
-        fontSize: 13,
-        fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
-        theme: { background: "#1b1f23", foreground: "#e6e6e6" },
-      });
-      const fit = new FitAddon();
-      term.loadAddon(fit);
-      term.open(ref.current);
-      fit.fit();
-      term.focus();
-      term.write(`kubectl scoped to \x1b[1m${context}\x1b[0m — starting shell…\r\n`);
-
-      let session: TerminalSession | null = null;
-      void startLocalTerminal(
-        context,
-        kubeconfigFiles,
-        (chunk) => term.write(chunk),
-        () => {
-          term.write("\r\n[shell exited]\r\n");
-          session?.close();
-        },
-        { cols: term.cols, rows: term.rows },
-      ).then((s) => {
-        if (disposed) {
-          s.close();
-          return;
-        }
-        session = s;
-        term.onData((d) => s.send(d));
-        term.onResize(({ cols, rows }) => s.resize(cols, rows));
-      });
-
-      // Keep the PTY sized to the panel as the dock is resized.
-      const onWindowResize = () => {
-        try {
-          fit.fit();
-        } catch {
-          /* fit can throw if the element is detached mid-teardown */
-        }
-      };
-      window.addEventListener("resize", onWindowResize);
-      const observer =
-        typeof ResizeObserver !== "undefined" ? new ResizeObserver(onWindowResize) : null;
-      if (observer && ref.current) observer.observe(ref.current);
-
-      cleanup = () => {
-        window.removeEventListener("resize", onWindowResize);
-        observer?.disconnect();
-        session?.close();
-        term.dispose();
-      };
-    })();
-
-    return () => {
-      disposed = true;
-      cleanup();
-    };
-  }, [context, kubeconfigFiles]);
-
-  return (
-    <div
-      ref={ref}
-      style={{ height: "100%", width: "100%", background: "#000", padding: 6, boxSizing: "border-box" }}
-    />
+  const driver = useMemo(
+    () => localTerminalDriver({ context, extraKubeconfigs: kubeconfigFiles }),
+    [context, kubeconfigFiles],
   );
+  return <TerminalPane driver={driver} banner={`kubectl scoped to \x1b[1m${context}\x1b[0m`} />;
 }

--- a/apps/desktop/src/components/PodTerminal.tsx
+++ b/apps/desktop/src/components/PodTerminal.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useRef } from "react";
-import { startPodExec, type ExecSession } from "../lib/exec";
+import React, { useMemo } from "react";
+import { TerminalPane } from "./TerminalPane";
+import { podExecDriver } from "../lib/terminalDriver";
 
 /**
- * Interactive in-pod shell rendered with xterm. xterm and its CSS are loaded
- * dynamically so they stay out of the jsdom test graph; this component is
- * verified live against a cluster rather than in unit tests.
+ * Interactive in-pod shell (and node shells, via a `command` override). A thin
+ * adapter over the shared {@link TerminalPane}, which owns the xterm instance,
+ * PTY resize, scrollback search, and reconnect.
  */
 export function PodTerminal({
   context,
@@ -21,62 +22,19 @@ export function PodTerminal({
   /** Override the exec command (e.g. the node shell's `nsenter …`). */
   command?: string[];
 }) {
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    let cleanup = () => {};
-    let disposed = false;
-
-    void (async () => {
-      const { Terminal } = await import("@xterm/xterm");
-      const { FitAddon } = await import("@xterm/addon-fit");
-      await import("@xterm/xterm/css/xterm.css");
-      if (disposed || !ref.current) return;
-
-      const term = new Terminal({
-        convertEol: true,
-        fontSize: 13,
-        fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
-        theme: { background: "#1b1f23", foreground: "#e6e6e6" },
-      });
-      const fit = new FitAddon();
-      term.loadAddon(fit);
-      term.open(ref.current);
-      fit.fit();
-      term.focus();
-      term.write("Connecting…\r\n");
-
-      let session: ExecSession | null = null;
-      void startPodExec(
+  const driver = useMemo(
+    () =>
+      podExecDriver({
         context,
         namespace,
         pod,
-        (chunk) => term.write(chunk),
-        (err) => term.write(`\r\n[session ended${err ? `: ${err}` : ""}]\r\n`),
         container,
         command,
-      ).then((s) => {
-        if (disposed) {
-          s.close();
-          return;
-        }
-        session = s;
-        term.onData((d) => s.send(d));
-      });
-
-      cleanup = () => {
-        session?.close();
-        term.dispose();
-      };
-    })();
-
-    return () => {
-      disposed = true;
-      cleanup();
-    };
+        kind: command ? "node" : "pod",
+      }),
     // command is a stable per-session array; joined into the deps key.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [context, namespace, pod, container, command?.join(" ")]);
-
-  return <div ref={ref} style={{ height: "100%", width: "100%", background: "#000", padding: 6, boxSizing: "border-box" }} />;
+    [context, namespace, pod, container, command?.join(" ")],
+  );
+  return <TerminalPane driver={driver} />;
 }

--- a/apps/desktop/src/components/TerminalPane.tsx
+++ b/apps/desktop/src/components/TerminalPane.tsx
@@ -1,0 +1,235 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Eraser, RotateCw, Search, X } from "lucide-react";
+import { IconButton } from "../ui";
+import type { TerminalConnection, TerminalDriver } from "../lib/terminalDriver";
+import {
+  type ExitReason,
+  type TermStatus,
+  nextStatusOnExit,
+  reconnectDelayMs,
+} from "../lib/terminalReconnect";
+
+/**
+ * Shared xterm terminal host for every terminal kind (in-pod exec, local PTY,
+ * node shell). Owns the xterm instance, PTY resize, scrollback search, and the
+ * reconnect state machine; the session itself comes from an injected driver.
+ *
+ * xterm and its CSS are dynamically imported so they stay out of the jsdom test
+ * graph — this component is verified live against a cluster. The reconnect
+ * *policy* it drives is pure and unit-tested in `lib/terminalReconnect`.
+ */
+export function TerminalPane({ driver, banner }: { driver: TerminalDriver; banner?: string }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [status, setStatus] = useState<TermStatus>({ kind: "connecting" });
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  // Manual controls, wired once xterm has loaded.
+  const controls = useRef({
+    reconnect() {},
+    clear() {},
+    focus() {},
+    searchNext(_q: string) {},
+    searchPrev(_q: string) {},
+  });
+
+  useEffect(() => {
+    let disposed = false;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let term: any = null;
+    let conn: TerminalConnection | null = null;
+    let attempt = 0;
+    let reconnectTimer: number | undefined;
+    let cleanupExtra: (() => void) | undefined;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let searchAddon: any = null;
+
+    const divider = (label: string) => `\r\n\x1b[2m── ${label} ──\x1b[0m\r\n`;
+
+    const handleExit = (reason: ExitReason) => {
+      if (disposed || !term) return;
+      conn = null;
+      const next = nextStatusOnExit(reason, driver.reconnectable, attempt);
+      setStatus(next);
+      if (next.kind === "reconnecting") {
+        attempt = next.attempt;
+        term.write(divider(`reconnecting… (attempt ${attempt})`));
+        reconnectTimer = window.setTimeout(() => void connect(true), reconnectDelayMs(attempt) ?? 0);
+      } else if (reason.kind === "error") {
+        term.write(`${divider("disconnected")}${reason.message}\r\n`);
+      } else {
+        term.write(divider("session ended"));
+      }
+    };
+
+    const connect = async (isReconnect: boolean) => {
+      if (disposed || !term) return;
+      setStatus(isReconnect ? { kind: "reconnecting", attempt: Math.max(attempt, 1) } : { kind: "connecting" });
+      let opened: TerminalConnection;
+      try {
+        opened = await driver.connect({
+          onData: (chunk) => term?.write(chunk),
+          onExit: handleExit,
+          initialSize: { cols: term.cols, rows: term.rows },
+        });
+      } catch (cause) {
+        handleExit({ kind: "error", message: cause instanceof Error ? cause.message : String(cause) });
+        return;
+      }
+      if (disposed) {
+        opened.close();
+        return;
+      }
+      conn = opened;
+      if (isReconnect) term.write(divider("reconnected (new shell)"));
+      attempt = 0;
+      setStatus({ kind: "live" });
+    };
+
+    controls.current = {
+      reconnect: () => {
+        if (reconnectTimer) clearTimeout(reconnectTimer);
+        attempt = 0;
+        void connect(true);
+      },
+      clear: () => term?.clear(),
+      focus: () => term?.focus(),
+      searchNext: (q: string) => searchAddon?.findNext(q),
+      searchPrev: (q: string) => searchAddon?.findPrevious(q),
+    };
+
+    void (async () => {
+      const { Terminal } = await import("@xterm/xterm");
+      const { FitAddon } = await import("@xterm/addon-fit");
+      const { SearchAddon } = await import("@xterm/addon-search");
+      await import("@xterm/xterm/css/xterm.css");
+      if (disposed || !ref.current) return;
+
+      term = new Terminal({
+        convertEol: true,
+        fontSize: 13,
+        fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+        scrollback: 10000,
+        theme: { background: "#1b1f23", foreground: "#e6e6e6" },
+      });
+      const fit = new FitAddon();
+      term.loadAddon(fit);
+      searchAddon = new SearchAddon();
+      term.loadAddon(searchAddon);
+      term.open(ref.current);
+      fit.fit();
+      term.focus();
+      if (banner) term.write(`${banner}\r\n`);
+
+      // Wire input/resize once; they read the CURRENT connection (which swaps on
+      // reconnect), so no handler churn.
+      term.onData((data: string) => conn?.send(data));
+      term.onResize(({ cols, rows }: { cols: number; rows: number }) => conn?.resize(cols, rows));
+
+      const onWindowResize = () => {
+        try {
+          fit.fit();
+        } catch {
+          /* fit can throw mid-teardown; ignore */
+        }
+      };
+      window.addEventListener("resize", onWindowResize);
+      const observer = typeof ResizeObserver !== "undefined" ? new ResizeObserver(onWindowResize) : null;
+      observer?.observe(ref.current);
+      cleanupExtra = () => {
+        window.removeEventListener("resize", onWindowResize);
+        observer?.disconnect();
+      };
+
+      void connect(false);
+    })();
+
+    return () => {
+      disposed = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      cleanupExtra?.();
+      conn?.close();
+      term?.dispose();
+    };
+  }, [driver, banner]);
+
+  const restartLabel = driver.kind === "local" ? "Restart shell" : "Reconnect";
+
+  function onPaneKeyDown(e: React.KeyboardEvent) {
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "f") {
+      e.preventDefault();
+      setSearchOpen(true);
+      requestAnimationFrame(() => searchInputRef.current?.focus());
+    }
+  }
+
+  function onSearchKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      if (e.shiftKey) controls.current.searchPrev(query);
+      else controls.current.searchNext(query);
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      setSearchOpen(false);
+      controls.current.focus();
+    }
+  }
+
+  return (
+    <div className="flex h-full flex-col bg-[#1b1f23]" onKeyDown={onPaneKeyDown}>
+      <div className="flex shrink-0 items-center gap-2 border-b border-white/10 px-2 py-1 text-xs text-white/70">
+        {status.kind === "connecting" && <span className="text-white/50">connecting…</span>}
+        {status.kind === "live" && (
+          <span className="flex items-center gap-1 text-emerald-400">
+            <span className="size-1.5 rounded-full bg-emerald-500" />
+            live
+          </span>
+        )}
+        {status.kind === "reconnecting" && (
+          <span className="text-amber-400">reconnecting… (attempt {status.attempt})</span>
+        )}
+        {status.kind === "disconnected" && (
+          <span className="flex items-center gap-2">
+            <span className="text-red-400">{status.reason ? `disconnected: ${status.reason}` : "disconnected"}</span>
+            <button
+              type="button"
+              onClick={() => controls.current.reconnect()}
+              className="inline-flex items-center gap-1 rounded bg-white/10 px-1.5 py-0.5 text-white/80 hover:bg-white/20"
+            >
+              <RotateCw aria-hidden="true" className="size-3" />
+              {restartLabel}
+            </button>
+          </span>
+        )}
+
+        <div className="ml-auto flex items-center gap-1">
+          <IconButton icon={Search} label="Search" onClick={() => setSearchOpen((o) => !o)} />
+          <IconButton icon={Eraser} label="Clear" onClick={() => controls.current.clear()} />
+          <IconButton
+            icon={RotateCw}
+            label={restartLabel}
+            onClick={() => controls.current.reconnect()}
+          />
+        </div>
+      </div>
+
+      {searchOpen && (
+        <div className="flex shrink-0 items-center gap-1 border-b border-white/10 bg-[#22262c] px-2 py-1">
+          <Search aria-hidden="true" className="size-3.5 text-white/40" />
+          <input
+            ref={searchInputRef}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={onSearchKeyDown}
+            placeholder="Find in terminal… (Enter / Shift+Enter)"
+            aria-label="Find in terminal"
+            className="min-w-0 flex-1 bg-transparent text-xs text-white/90 placeholder:text-white/30 focus:outline-none"
+          />
+          <IconButton icon={X} label="Close search" onClick={() => { setSearchOpen(false); controls.current.focus(); }} />
+        </div>
+      )}
+
+      <div ref={ref} className="min-h-0 flex-1" style={{ padding: 6, boxSizing: "border-box" }} />
+    </div>
+  );
+}

--- a/apps/desktop/src/lib/exec.test.ts
+++ b/apps/desktop/src/lib/exec.test.ts
@@ -36,6 +36,8 @@ describe("startPodExec", () => {
       container: null,
       shell: null,
       command: null,
+      cols: null,
+      rows: null,
     });
     expect(onMock).toHaveBeenCalledWith("exec:out:7", expect.any(Function));
     expect(onMock).toHaveBeenCalledWith("exec:exit:7", expect.any(Function));
@@ -47,6 +49,8 @@ describe("startPodExec", () => {
 
     session.send("ls\n");
     expect(invokeCommandMock).toHaveBeenCalledWith("exec_input", { session: 7, data: "ls\n" });
+    session.resize(120, 40);
+    expect(invokeCommandMock).toHaveBeenCalledWith("exec_resize", { session: 7, cols: 120, rows: 40 });
     session.close();
     expect(invokeCommandMock).toHaveBeenCalledWith("exec_close", { session: 7 });
   });
@@ -62,6 +66,8 @@ describe("startPodExec", () => {
       container: "sidecar",
       shell: null,
       command: null,
+      cols: null,
+      rows: null,
     });
   });
 });

--- a/apps/desktop/src/lib/exec.ts
+++ b/apps/desktop/src/lib/exec.ts
@@ -3,14 +3,17 @@ import { invokeCommand, on } from "../transport/transport";
 export interface ExecSession {
   /** Send a keystroke / input string to the pod's stdin. */
   send: (data: string) => void;
+  /** Resize the remote PTY to match the xterm viewport. */
+  resize: (cols: number, rows: number) => void;
   /** Close the session and unsubscribe. */
   close: () => void;
 }
 
 /**
  * Open an interactive shell into a pod. `onData` receives stdout chunks;
- * `onExit` fires when the session ends (with an optional error). Returns a
- * session handle for sending input and closing.
+ * `onExit` fires when the session ends (with an optional error). `size` sizes
+ * the remote PTY at attach so it matches the panel from the first prompt.
+ * Returns a session handle for sending input, resizing, and closing.
  */
 export async function startPodExec(
   context: string,
@@ -20,6 +23,7 @@ export async function startPodExec(
   onExit: (error: string | null) => void,
   container?: string,
   command?: string[],
+  size?: { cols: number; rows: number },
 ): Promise<ExecSession> {
   const session = await invokeCommand<number>("start_pod_exec", {
     context,
@@ -28,11 +32,14 @@ export async function startPodExec(
     container: container ?? null,
     shell: null,
     command: command ?? null,
+    cols: size?.cols ?? null,
+    rows: size?.rows ?? null,
   });
   const disposeOut = on(`exec:out:${session}`, (p) => onData(p as string));
   const disposeExit = on(`exec:exit:${session}`, (p) => onExit((p as string | null) ?? null));
   return {
     send: (data) => void invokeCommand("exec_input", { session, data }),
+    resize: (cols, rows) => void invokeCommand("exec_resize", { session, cols, rows }),
     close: () => {
       disposeOut();
       disposeExit();

--- a/apps/desktop/src/lib/terminalDriver.test.ts
+++ b/apps/desktop/src/lib/terminalDriver.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { startPodExecMock, startLocalTerminalMock } = vi.hoisted(() => ({
+  startPodExecMock: vi.fn(),
+  startLocalTerminalMock: vi.fn(),
+}));
+vi.mock("./exec", () => ({ startPodExec: startPodExecMock }));
+vi.mock("./terminal", () => ({ startLocalTerminal: startLocalTerminalMock }));
+
+import { podExecDriver, localTerminalDriver } from "./terminalDriver";
+
+const conn = () => ({ send: vi.fn(), resize: vi.fn(), close: vi.fn() });
+
+beforeEach(() => {
+  startPodExecMock.mockReset();
+  startLocalTerminalMock.mockReset();
+});
+
+describe("podExecDriver", () => {
+  it("maps a backend error to an unexpected drop and a clean end to closed", async () => {
+    let backendOnExit: ((err: string | null) => void) | undefined;
+    startPodExecMock.mockImplementation((_c, _n, _p, _onData, onExit) => {
+      backendOnExit = onExit;
+      return Promise.resolve(conn());
+    });
+    const driver = podExecDriver({ context: "c", namespace: "n", pod: "p" });
+    expect(driver.kind).toBe("pod");
+    expect(driver.reconnectable).toBe(true);
+
+    const onExit = vi.fn();
+    await driver.connect({ onData: vi.fn(), onExit });
+    backendOnExit?.("boom");
+    expect(onExit).toHaveBeenCalledWith({ kind: "error", message: "boom" });
+    backendOnExit?.(null);
+    expect(onExit).toHaveBeenCalledWith({ kind: "closed" });
+  });
+
+  it("threads command, container, and initial size through", async () => {
+    startPodExecMock.mockResolvedValue(conn());
+    const driver = podExecDriver({ context: "c", namespace: "n", pod: "p", command: ["nsenter"], kind: "node" });
+    expect(driver.kind).toBe("node");
+    await driver.connect({ onData: vi.fn(), onExit: vi.fn(), initialSize: { cols: 100, rows: 30 } });
+    expect(startPodExecMock).toHaveBeenCalledWith(
+      "c",
+      "n",
+      "p",
+      expect.any(Function),
+      expect.any(Function),
+      undefined,
+      ["nsenter"],
+      { cols: 100, rows: 30 },
+    );
+  });
+});
+
+describe("localTerminalDriver", () => {
+  it("treats a shell exit as an intentional clean close", async () => {
+    let backendOnExit: (() => void) | undefined;
+    startLocalTerminalMock.mockImplementation((_c, _k, _onData, onExit) => {
+      backendOnExit = onExit;
+      return Promise.resolve(conn());
+    });
+    const driver = localTerminalDriver({ context: "c", extraKubeconfigs: [] });
+    expect(driver.kind).toBe("local");
+
+    const onExit = vi.fn();
+    await driver.connect({ onData: vi.fn(), onExit });
+    backendOnExit?.();
+    expect(onExit).toHaveBeenCalledWith({ kind: "closed" });
+  });
+});

--- a/apps/desktop/src/lib/terminalDriver.ts
+++ b/apps/desktop/src/lib/terminalDriver.ts
@@ -1,0 +1,83 @@
+import { startPodExec } from "./exec";
+import { startLocalTerminal } from "./terminal";
+import type { ExitReason } from "./terminalReconnect";
+
+/** A live terminal session the pane drives. */
+export interface TerminalConnection {
+  send(data: string): void;
+  resize(cols: number, rows: number): void;
+  close(): void;
+}
+
+/**
+ * A pluggable session source for `TerminalPane`. Abstracts the three terminal
+ * kinds (in-pod exec, local PTY, node shell) behind one contract so the pane's
+ * xterm wiring, resize, search, and reconnect logic live in one place.
+ */
+export interface TerminalDriver {
+  kind: "pod" | "local" | "node";
+  /** Whether a fresh session can be opened (drives reconnect/restart). */
+  reconnectable: boolean;
+  connect(handlers: {
+    onData: (chunk: string) => void;
+    onExit: (reason: ExitReason) => void;
+    initialSize?: { cols: number; rows: number };
+  }): Promise<TerminalConnection>;
+}
+
+/**
+ * In-pod exec (or node shell, when `kind: "node"` with an `nsenter` command
+ * override). A backend error maps to an unexpected drop; a clean end is an
+ * intentional exit.
+ */
+export function podExecDriver(opts: {
+  context: string;
+  namespace: string;
+  pod: string;
+  container?: string;
+  command?: string[];
+  kind?: "pod" | "node";
+}): TerminalDriver {
+  return {
+    kind: opts.kind ?? "pod",
+    reconnectable: true,
+    async connect({ onData, onExit, initialSize }) {
+      const session = await startPodExec(
+        opts.context,
+        opts.namespace,
+        opts.pod,
+        onData,
+        (error) => onExit(error ? { kind: "error", message: error } : { kind: "closed" }),
+        opts.container,
+        opts.command,
+        initialSize,
+      );
+      return { send: session.send, resize: session.resize, close: session.close };
+    },
+  };
+}
+
+/**
+ * The user's local shell scoped to a context. A local PTY only ends when the
+ * shell exits, which is intentional — so its exit is always "closed" (the pane
+ * offers a manual Restart rather than auto-reconnecting).
+ */
+export function localTerminalDriver(opts: {
+  context: string;
+  extraKubeconfigs: string[];
+}): TerminalDriver {
+  return {
+    kind: "local",
+    reconnectable: true,
+    async connect({ onData, onExit, initialSize }) {
+      const session = await startLocalTerminal(
+        opts.context,
+        opts.extraKubeconfigs,
+        onData,
+        () => onExit({ kind: "closed" }),
+        initialSize,
+      );
+      return { send: session.send, resize: session.resize, close: session.close };
+    },
+  };
+}

--- a/apps/desktop/src/lib/terminalReconnect.test.ts
+++ b/apps/desktop/src/lib/terminalReconnect.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import {
+  reconnectDelayMs,
+  shouldAutoReconnect,
+  nextStatusOnExit,
+  RECONNECT_DELAYS_MS,
+} from "./terminalReconnect";
+
+describe("reconnectDelayMs", () => {
+  it("returns the backoff schedule, then null once exhausted", () => {
+    expect(reconnectDelayMs(1)).toBe(RECONNECT_DELAYS_MS[0]);
+    expect(reconnectDelayMs(RECONNECT_DELAYS_MS.length)).toBe(
+      RECONNECT_DELAYS_MS[RECONNECT_DELAYS_MS.length - 1],
+    );
+    expect(reconnectDelayMs(RECONNECT_DELAYS_MS.length + 1)).toBeNull();
+    expect(reconnectDelayMs(0)).toBeNull();
+  });
+});
+
+describe("shouldAutoReconnect", () => {
+  it("auto-reconnects only on an unexpected error, when reconnectable and not exhausted", () => {
+    expect(shouldAutoReconnect({ kind: "error", message: "drop" }, true, 0)).toBe(true);
+    // Exhausted the schedule → stop.
+    expect(shouldAutoReconnect({ kind: "error", message: "drop" }, true, RECONNECT_DELAYS_MS.length)).toBe(false);
+    // Clean exit (user typed exit) → never auto.
+    expect(shouldAutoReconnect({ kind: "closed" }, true, 0)).toBe(false);
+    // Driver can't reopen → never auto.
+    expect(shouldAutoReconnect({ kind: "error", message: "drop" }, false, 0)).toBe(false);
+  });
+});
+
+describe("nextStatusOnExit", () => {
+  it("schedules a reconnect on error, otherwise goes disconnected", () => {
+    expect(nextStatusOnExit({ kind: "error", message: "x" }, true, 0)).toEqual({
+      kind: "reconnecting",
+      attempt: 1,
+    });
+    expect(nextStatusOnExit({ kind: "closed" }, true, 0)).toEqual({ kind: "disconnected" });
+    // Exhausted error → disconnected, surfacing the last error message.
+    expect(nextStatusOnExit({ kind: "error", message: "boom" }, true, RECONNECT_DELAYS_MS.length)).toEqual({
+      kind: "disconnected",
+      reason: "boom",
+    });
+  });
+});

--- a/apps/desktop/src/lib/terminalReconnect.ts
+++ b/apps/desktop/src/lib/terminalReconnect.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure reconnect policy for terminals, split out from the xterm-wired pane so it
+ * can be unit-tested (the pane itself is verified live against a cluster).
+ *
+ * An exec session isn't resumable, so a reconnect is always a *fresh* session.
+ * Only an unexpected drop (a stream error) auto-reconnects; a clean exit — the
+ * user typed `exit`, or the process ended — is intentional and waits for a
+ * manual reconnect/restart.
+ */
+
+/** Why a terminal session ended. */
+export type ExitReason = { kind: "closed" } | { kind: "error"; message: string };
+
+/** Connection state of a terminal, driving its status pill and controls. */
+export type TermStatus =
+  | { kind: "connecting" }
+  | { kind: "live" }
+  | { kind: "reconnecting"; attempt: number }
+  | { kind: "disconnected"; reason?: string };
+
+/** Backoff before each successive reconnect attempt; length caps the retries. */
+export const RECONNECT_DELAYS_MS = [500, 1000, 2000, 4000, 8000];
+
+/** Delay before reconnect attempt `attempt` (1-based), or null when exhausted. */
+export function reconnectDelayMs(attempt: number): number | null {
+  if (attempt < 1 || attempt > RECONNECT_DELAYS_MS.length) return null;
+  return RECONNECT_DELAYS_MS[attempt - 1];
+}
+
+/**
+ * Whether to auto-reconnect after `reason`, given the driver can reopen a
+ * session and how many attempts have already been made. Only unexpected errors
+ * auto-reconnect, and only while the backoff schedule has retries left.
+ */
+export function shouldAutoReconnect(
+  reason: ExitReason,
+  reconnectable: boolean,
+  priorAttempts: number,
+): boolean {
+  if (!reconnectable) return false;
+  if (reason.kind !== "error") return false;
+  return priorAttempts < RECONNECT_DELAYS_MS.length;
+}
+
+/** The next status when a session exits: schedule a reconnect, or disconnect
+ *  (surfacing the last error message when there was one). */
+export function nextStatusOnExit(
+  reason: ExitReason,
+  reconnectable: boolean,
+  priorAttempts: number,
+): TermStatus {
+  if (shouldAutoReconnect(reason, reconnectable, priorAttempts)) {
+    return { kind: "reconnecting", attempt: priorAttempts + 1 };
+  }
+  return reason.kind === "error"
+    ? { kind: "disconnected", reason: reason.message }
+    : { kind: "disconnected" };
+}

--- a/apps/desktop/src/ui/styles.css
+++ b/apps/desktop/src/ui/styles.css
@@ -902,6 +902,16 @@ body {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.fl-dock__tab-rename {
+  min-width: 6ch;
+  max-width: 20ch;
+  border: 1px solid var(--fl-color-border);
+  border-radius: 4px;
+  background: var(--fl-color-bg);
+  color: inherit;
+  font: inherit;
+  padding: 0 4px;
+}
 .fl-dock__new,
 .fl-dock__close {
   flex: 0 0 auto;

--- a/crates/kube/src/exec.rs
+++ b/crates/kube/src/exec.rs
@@ -6,10 +6,17 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use k8s_openapi::api::core::v1::Pod;
-use kube::api::AttachParams;
+use kube::api::{AttachParams, TerminalSize};
 use kube::Api;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::mpsc::Receiver;
+
+/// Map an xterm `(cols, rows)` to a kube [`TerminalSize`]. Columns are the
+/// width and rows are the height — a pure helper so the mapping can't silently
+/// get swapped.
+pub fn terminal_size(cols: u16, rows: u16) -> TerminalSize {
+    TerminalSize { width: cols, height: rows }
+}
 
 use crate::client_cache::ClientCache;
 
@@ -75,6 +82,8 @@ pub async fn exec_shell<F>(
     container: Option<String>,
     shell: Option<String>,
     command: Option<Vec<String>>,
+    initial_size: Option<(u16, u16)>,
+    mut resize_rx: Receiver<(u16, u16)>,
     mut on_output: F,
     mut input_rx: Receiver<String>,
 ) -> Result<(), String>
@@ -108,9 +117,22 @@ where
         .await
         .map_err(|e| e.to_string())?;
 
+    // Resize channel (present because `tty(true)` above). Send the initial size
+    // so the remote PTY starts matching the panel, then forward later resizes.
+    // `terminal_size()` yields a futures `Sender`; `try_send` keeps resizes
+    // non-blocking and best-effort.
+    let mut size_tx = attached.terminal_size();
+    if let (Some(tx), Some((cols, rows))) = (size_tx.as_mut(), initial_size) {
+        let _ = tx.try_send(terminal_size(cols, rows));
+    }
+
     let mut stdout = attached.stdout().ok_or_else(|| "exec: no stdout".to_string())?;
     let mut stdin = attached.stdin().ok_or_else(|| "exec: no stdin".to_string())?;
     let mut buf = vec![0u8; 8192];
+    // Once the resize channel closes we stop polling it (a closed `recv()`
+    // returns immediately, which would otherwise spin the `select!`). A closed
+    // resize channel must NOT end the session, unlike stdin closing.
+    let mut resize_open = true;
 
     loop {
         tokio::select! {
@@ -128,6 +150,15 @@ where
                 }
                 None => break,
             },
+            size = resize_rx.recv(), if resize_open => match size {
+                // Resize the remote PTY; best-effort, never fatal.
+                Some((cols, rows)) => {
+                    if let Some(tx) = size_tx.as_mut() {
+                        let _ = tx.try_send(terminal_size(cols, rows));
+                    }
+                }
+                None => resize_open = false,
+            },
         }
     }
 
@@ -144,6 +175,15 @@ mod tests {
         assert_eq!(shell_command(None), vec!["/bin/sh".to_string()]);
         assert_eq!(shell_command(Some("")), vec!["/bin/sh".to_string()]);
         assert_eq!(shell_command(Some("/bin/bash")), vec!["/bin/bash".to_string()]);
+    }
+
+    #[test]
+    fn terminal_size_maps_cols_to_width_and_rows_to_height() {
+        // xterm reports (cols, rows); the k8s TerminalSize is (width, height).
+        // Columns are width and rows are height — guard against swapping them.
+        let size = terminal_size(120, 40);
+        assert_eq!(size.width, 120);
+        assert_eq!(size.height, 40);
     }
 
     fn pod_with(json: serde_json::Value) -> Pod {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@xterm/addon-fit':
         specifier: ^0.10.0
         version: 0.10.0(@xterm/xterm@5.5.0)
+      '@xterm/addon-search':
+        specifier: ^0.16.0
+        version: 0.16.0
       '@xterm/xterm':
         specifier: ^5.5.0
         version: 5.5.0
@@ -1777,6 +1780,9 @@ packages:
     resolution: {integrity: sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==}
     peerDependencies:
       '@xterm/xterm': ^5.0.0
+
+  '@xterm/addon-search@0.16.0':
+    resolution: {integrity: sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA==}
 
   '@xterm/xterm@5.5.0':
     resolution: {integrity: sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==}
@@ -5308,6 +5314,8 @@ snapshots:
   '@xterm/addon-fit@0.10.0(@xterm/xterm@5.5.0)':
     dependencies:
       '@xterm/xterm': 5.5.0
+
+  '@xterm/addon-search@0.16.0': {}
 
   '@xterm/xterm@5.5.0': {}
 


### PR DESCRIPTION
Closes #19. Part of **v0.4 — Interactive parity**: makes the in-pod exec terminal, the local kubectl terminal, and node shells feel production-grade.

## Architecture
Unifies the three near-duplicate xterm components onto a shared **`TerminalPane`** driven by a pluggable **session driver** (`pod` / `local` / `node`). Every feature is implemented once; `PodTerminal`/`LocalTerminal` are now thin adapters and node shells inherit reconnect for free.

## Reconnect (auto, with manual fallback)
An exec session isn't resumable, so a reconnect is always a **fresh shell** (scrollback kept; cwd/env lost).
- **Unexpected drop** (stream error) → auto-reconnect with backoff `[0.5,1,2,4,8]s`, then a manual **Reconnect** button.
- **Clean exit** (you typed `exit`) → manual **Reconnect** (pod) / **Restart shell** (local), no auto.
- Dividers (`── reconnecting… ──` / `── reconnected (new shell) ──`) mark attempts in preserved scrollback.
- The policy — backoff schedule, exit classification, status reducer — is **pure and unit-tested**; the xterm pane is verified live (repo norm).

## PTY resize (pod exec)
The local terminal already resized; pod exec didn't. Threads a resize channel through `exec_shell` → kube-rs `terminal_size()`, sizes the PTY at attach, and adds an `exec_resize` command. A pure `terminal_size(cols,rows)` helper locks cols→width / rows→height. The `select!` resize arm is guarded so a closed channel can't busy-loop or end the session.

## Scrollback search + session management
- **Search** (Cmd/Ctrl-F; Enter / Shift+Enter / Esc) via `@xterm/addon-search`.
- **Clear** the buffer; **rename** a dock tab (double-click, in-memory).

## Tests
- New pure units TDD'd: reconnect policy (3), driver exit-mapping (3), `exec_resize` payload, `terminal_size` (Rust).
- Frontend **585 pass** (coverage 83.1%); backend **257** kube + desktop tests; `pnpm build` typecheck clean; **zero new clippy warnings**.

## Out of scope (deliberate)
Persisted renames, a cross-session switcher, resumable/replayed shells, split panes.