### PR TITLE
fix(deps): patch fast-uri, brace-expansion, @hono/node-server advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,5 +7,12 @@
     "build": "pnpm --filter @srelens/desktop build",
     "test": "pnpm -r test"
   },
-  "devDependencies": { "turbo": "^2.0.0" }
+  "devDependencies": { "turbo": "^2.0.0" },
+  "pnpm": {
+    "overrides": {
+      "fast-uri@>=3.0.0 <3.1.4": "^3.1.4",
+      "brace-expansion@>=2.0.0 <2.1.2": "^2.1.2",
+      "@hono/node-server@<2.0.5": "^2.0.5"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  fast-uri@>=3.0.0 <3.1.4: ^3.1.4
+  brace-expansion@>=2.0.0 <2.1.2: ^2.1.2
+  '@hono/node-server@<2.0.5': ^2.0.5
+
 importers:
 
   .:
@@ -539,9 +544,9 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
-    engines: {node: '>=18.14.1'}
+  '@hono/node-server@2.0.11':
+    resolution: {integrity: sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==}
+    engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
 
@@ -1886,8 +1891,8 @@ packages:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@2.1.1:
-    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
+  brace-expansion@2.1.2:
+    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
   brace-expansion@5.0.7:
     resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
@@ -2254,8 +2259,8 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -4019,7 +4024,7 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@hono/node-server@1.19.14(hono@4.12.27)':
+  '@hono/node-server@2.0.11(hono@4.12.27)':
     dependencies:
       hono: 4.12.27
 
@@ -4073,7 +4078,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.27)
+      '@hono/node-server': 2.0.11(hono@4.12.27)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -5337,7 +5342,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -5407,7 +5412,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@2.1.1:
+  brace-expansion@2.1.2:
     dependencies:
       balanced-match: 1.0.2
 
@@ -5788,7 +5793,7 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.4: {}
 
   fastq@1.20.1:
     dependencies:
@@ -6243,7 +6248,7 @@ snapshots:
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 2.1.2
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
Resolves all four open [Dependabot alerts](https://github.com/srelens/srelens/security/dependabot) by forcing patched versions of transitively-pulled packages via `pnpm.overrides`.

| Alert | Package | Was | Now | Severity |
|---|---|---|---|---|
| #14, #13 | `fast-uri` | 3.1.2 | 3.1.4 | high |
| #11 | `brace-expansion` (2.x line) | 2.1.1 | 2.1.2 | high |
| #12 | `@hono/node-server` | 1.19.14 | 2.0.11 | medium |

### Why overrides
All three are **transitive** — nothing in our declared `dependencies` needed changing:
- `fast-uri` & `@hono/node-server` are reached via the `shadcn` CLI (its bundled ajv / MCP SDK).
- `brace-expansion@2.1.1` is reached via `@vitest/coverage-v8 → test-exclude → glob → minimatch`.

### Notes
- The `brace-expansion` override is version-scoped (`>=2.0.0 <2.1.2`) so the unrelated `5.x` copy is left alone.
- `@hono/node-server` has **no 1.x patch** (first fix is 2.0.5), and `shadcn`'s MCP SDK declares `^1.19.9`. Forcing 2.x technically breaks that semver range, but `shadcn` is a build-time component-scaffolding CLI that is never in the app runtime, so this is safe. `shadcn --version` verified working.

### Verification
- `pnpm install` clean; lockfile updated to patched versions.
- Full test suite: **585 tests pass across 89 files**.
- Pre-existing `mobx-react` React-19 peer warning is unrelated and unchanged.