### PR TITLE
fix(detail): close the resource detail drawer on Escape

### DIFF
--- a/apps/desktop/src/ui/Drawer.test.tsx
+++ b/apps/desktop/src/ui/Drawer.test.tsx
@@ -26,4 +26,59 @@ describe("Drawer", () => {
     fireEvent.click(screen.getByRole("button", { name: "Close" }));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  it("closes on Escape when open", () => {
+    const onClose = vi.fn();
+    render(
+      <Drawer open onClose={onClose}>
+        body
+      </Drawer>,
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not close on Escape when closed", () => {
+    const onClose = vi.fn();
+    render(
+      <Drawer open={false} onClose={onClose}>
+        body
+      </Drawer>,
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("lets a layered modal dialog consume Escape first (does not close the drawer)", () => {
+    const onClose = vi.fn();
+    render(
+      <Drawer open onClose={onClose}>
+        body
+      </Drawer>,
+    );
+    // Simulate an open radix dialog layered over the drawer.
+    const dialog = document.createElement("div");
+    dialog.setAttribute("role", "dialog");
+    dialog.setAttribute("data-state", "open");
+    document.body.appendChild(dialog);
+    try {
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(onClose).not.toHaveBeenCalled();
+    } finally {
+      dialog.remove();
+    }
+  });
+
+  it("does not hijack Escape while focus is in an editable field", () => {
+    const onClose = vi.fn();
+    render(
+      <Drawer open onClose={onClose}>
+        <input aria-label="search" />
+      </Drawer>,
+    );
+    const input = screen.getByLabelText("search");
+    input.focus();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
 });

--- a/apps/desktop/src/ui/Drawer.tsx
+++ b/apps/desktop/src/ui/Drawer.tsx
@@ -56,6 +56,25 @@ export function Drawer({ open, title, headerActions, onClose, children, defaultW
     };
   }, [open]);
 
+  // Close on Escape while open. Bail when a modal dialog is layered on top — it
+  // owns Esc, so the first Esc closes the dialog and a second closes the drawer —
+  // and when focus is in an editable field / the manifest editor, where Esc has
+  // its own meaning.
+  useEffect(() => {
+    if (!open) return;
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key !== "Escape" || e.defaultPrevented) return;
+      if (document.querySelector('[role="dialog"][data-state="open"]')) return;
+      const el = document.activeElement as HTMLElement | null;
+      if (el && (el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.isContentEditable)) {
+        return;
+      }
+      onClose();
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [open, onClose]);
+
   if (!open) return null;
   return (
     <aside


### PR DESCRIPTION
Closes #149.

The shared `Drawer` (`apps/desktop/src/ui/Drawer.tsx`) registered no keydown listener, so the detail slide-over could only be dismissed with the ✕ button.

## Change
Adds an Escape handler active only while the drawer is open, calling `onClose`. Guards:
- **Layered modals win Esc first** — bails if a radix `[role="dialog"][data-state="open"]` is present, so the first Esc closes a confirm dialog and a second closes the drawer.
- **Editable focus not hijacked** — skips when `activeElement` is an `input`/`textarea`/`contenteditable` (the CodeMirror manifest editor or a search box).

## Tests
`Drawer.test.tsx` (6/6): Esc closes when open, no-op when closed, layered dialog consumes Esc first, and Esc is not hijacked while an input is focused.

Acceptance criteria in #149 all covered.