### PR TITLE
fix(actions): confirm Rollout Restart and CronJob Suspend/Resume

### DIFF
--- a/apps/desktop/src/components/DetailActions.test.tsx
+++ b/apps/desktop/src/components/DetailActions.test.tsx
@@ -185,7 +185,7 @@ describe("ResourceActions", () => {
     expect(notifyMock.success).not.toHaveBeenCalled();
   });
 
-  it("triggers a rollout restart", async () => {
+  it("triggers a rollout restart only after confirmation", async () => {
     rolloutRestartMock.mockResolvedValue({ ok: true });
     render(
       <ResourceActions
@@ -196,7 +196,12 @@ describe("ResourceActions", () => {
         onDeleted={() => {}}
       />,
     );
+    // Clicking Restart opens a confirm dialog; it must NOT fire the mutation yet.
     fireEvent.click(screen.getByRole("button", { name: "Restart" }));
+    expect(rolloutRestartMock).not.toHaveBeenCalled();
+    // Confirm in the dialog (a second "Restart" button appears).
+    const buttons = await screen.findAllByRole("button", { name: "Restart" });
+    fireEvent.click(buttons[buttons.length - 1]);
     await waitFor(() =>
       expect(rolloutRestartMock).toHaveBeenCalledWith("kind-dev", "Deployment", "default", "web"),
     );
@@ -249,6 +254,9 @@ describe("ResourceActions", () => {
     );
     expect(screen.queryByRole("button", { name: "Suspend" })).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Resume" }));
+    // Confirm in the dialog (a second "Resume" button appears).
+    const buttons = await screen.findAllByRole("button", { name: "Resume" });
+    fireEvent.click(buttons[buttons.length - 1]);
     await waitFor(() =>
       expect(cronjobSetSuspendMock).toHaveBeenCalledWith("kind-dev", "ops", "nightly", false),
     );
@@ -266,7 +274,11 @@ describe("ResourceActions", () => {
         onDeleted={() => {}}
       />,
     );
+    // Clicking Suspend opens a confirm dialog; it must NOT fire the mutation yet.
     fireEvent.click(screen.getByRole("button", { name: "Suspend" }));
+    expect(cronjobSetSuspendMock).not.toHaveBeenCalled();
+    const buttons = await screen.findAllByRole("button", { name: "Suspend" });
+    fireEvent.click(buttons[buttons.length - 1]);
     await waitFor(() =>
       expect(cronjobSetSuspendMock).toHaveBeenCalledWith("kind-dev", "ops", "nightly", true),
     );

--- a/apps/desktop/src/components/DetailActions.tsx
+++ b/apps/desktop/src/components/DetailActions.tsx
@@ -286,6 +286,8 @@ export function ResourceActions({
   onEdit?: () => void;
 }) {
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [restarting, setRestarting] = useState(false);
+  const [confirmSuspend, setConfirmSuspend] = useState(false);
   const [scaling, setScaling] = useState(false);
   const [replicas, setReplicas] = useState("");
   const [triggering, setTriggering] = useState(false);
@@ -326,6 +328,7 @@ export function ResourceActions({
       reportActionError(context, `Failed to ${resume ? "resume" : "suspend"} ${name}`, r.error);
       return;
     }
+    setConfirmSuspend(false);
     notify.success(`${resume ? "Resumed" : "Suspended"} ${name}`);
     onChanged?.();
   }
@@ -386,9 +389,11 @@ export function ResourceActions({
     const r = await rolloutRestart(context, kind, namespace ?? "", name);
     setBusy("");
     if (r.error) {
+      setErr(r.error);
       reportActionError(context, `Failed to restart ${name}`, r.error);
       return;
     }
+    setRestarting(false);
     notify.success(`Rollout restart triggered for ${name}`);
     onChanged?.();
   }
@@ -426,7 +431,10 @@ export function ResourceActions({
           label="Restart"
           disabled={busy === "restart" || (restartCheck ? !access.allowed(restartCheck) : false)}
           title={restartCheck ? denyReason(access, restartCheck) : undefined}
-          onClick={() => void doRestart()}
+          onClick={() => {
+            setErr("");
+            setRestarting(true);
+          }}
         />
       )}
       {isCronJob && (
@@ -444,7 +452,10 @@ export function ResourceActions({
           label={cronjobSuspended ? "Resume" : "Suspend"}
           disabled={busy === "suspend" || (cronSuspendCheck ? !access.allowed(cronSuspendCheck) : false)}
           title={cronSuspendCheck ? denyReason(access, cronSuspendCheck) : undefined}
-          onClick={() => void doSetSuspend()}
+          onClick={() => {
+            setErr("");
+            setConfirmSuspend(true);
+          }}
         />
       )}
       <IconButton
@@ -455,6 +466,59 @@ export function ResourceActions({
         title={deleteCheck ? denyReason(access, deleteCheck) : undefined}
         onClick={() => setConfirmDelete(true)}
       />
+
+      {restarting && (
+        <ConfirmDialog
+          title={`Restart ${kind}`}
+          message={
+            <>
+              <p style={{ marginTop: 0 }}>
+                Trigger a rolling restart of <code>{name}</code>
+                {namespace ? (
+                  <>
+                    {" "}
+                    in <code>{namespace}</code>
+                  </>
+                ) : null}
+                ? This reschedules all of its pods.
+              </p>
+              {err && <p style={{ color: "var(--fl-color-danger)" }}>Error: {err}</p>}
+            </>
+          }
+          confirmLabel="Restart"
+          busy={busy === "restart"}
+          onConfirm={() => void doRestart()}
+          onCancel={() => setRestarting(false)}
+        />
+      )}
+
+      {confirmSuspend && (
+        <ConfirmDialog
+          title={cronjobSuspended ? "Resume CronJob" : "Suspend CronJob"}
+          message={
+            <>
+              <p style={{ marginTop: 0 }}>
+                {cronjobSuspended ? "Resume" : "Suspend"} <code>{name}</code>
+                {namespace ? (
+                  <>
+                    {" "}
+                    in <code>{namespace}</code>
+                  </>
+                ) : null}
+                ?{" "}
+                {cronjobSuspended
+                  ? "Scheduled runs will resume."
+                  : "Scheduled runs will be paused; already-running jobs are unaffected."}
+              </p>
+              {err && <p style={{ color: "var(--fl-color-danger)" }}>Error: {err}</p>}
+            </>
+          }
+          confirmLabel={cronjobSuspended ? "Resume" : "Suspend"}
+          busy={busy === "suspend"}
+          onConfirm={() => void doSetSuspend()}
+          onCancel={() => setConfirmSuspend(false)}
+        />
+      )}
 
       {triggering && (
         <ConfirmDialog


### PR DESCRIPTION
Closes #144.

Rollout Restart and CronJob Suspend/Resume executed immediately on click — unlike every other write action (delete, evict, run-now, scale), which prompt first. Both are disruptive (restart reschedules every pod; suspend pauses scheduled runs).

## Change
`DetailActions.tsx` (`ResourceActions`): both actions now open a `ConfirmDialog` stating the target name/namespace and effect before mutating, matching the existing confirmation pattern. The success handlers close their dialog; failures surface the error in the dialog.

## Tests
`DetailActions.test.tsx`: restart and suspend/resume now assert the mutation does **not** fire until the dialog is confirmed. 23/23 pass.

Confirmation audit from #144 (delete, evict, debug, run-now, scale, node actions already gated) is now complete.