### PR TITLE
fix(tabs): cache list rows so re-opened tabs show data instantly

### DIFF
--- a/apps/desktop/src/components/ResourceBrowser.test.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.test.tsx
@@ -107,7 +107,7 @@ vi.mock("../lib/access", async (importOriginal) => {
   };
 });
 
-import { ResourceBrowser } from "./ResourceBrowser";
+import { ResourceBrowser, __clearListRowCacheForTests } from "./ResourceBrowser";
 
 const pod = {
   name: "web-1",
@@ -132,6 +132,9 @@ function watchWith(rows: Array<{ name: string } & Record<string, unknown>>) {
 }
 
 beforeEach(() => {
+  // The row cache is module-level and persists across tests in this file;
+  // clear it so one test's loaded rows don't hydrate the next test's fresh mount.
+  __clearListRowCacheForTests();
   listNamespacesMock.mockReset();
   podLogsMock.mockReset();
   watchResourceMock.mockReset();
@@ -156,6 +159,23 @@ describe("ResourceBrowser", () => {
     expect(screen.getByText("live")).toBeDefined();
     // The column picker is now available on every resource table, not just Nodes.
     expect(screen.getByRole("button", { name: "Choose columns" })).toBeDefined();
+  });
+
+  it("re-opening a tab shows cached rows instantly instead of a full re-fetch", async () => {
+    listNamespacesMock.mockResolvedValue({ namespaces: ["default"] });
+    watchResourceMock.mockImplementation(watchWith([pod]));
+    const first = render(<ResourceBrowser context="kind-dev" kind="pods" />);
+    await waitFor(() => expect(screen.getByText("web-1")).toBeDefined());
+    first.unmount();
+
+    // Re-open the tab: the watch returns a handle but never pushes rows, so
+    // anything visible must have come from the cross-mount row cache.
+    watchResourceMock.mockImplementation(() => Promise.resolve({ stop: vi.fn() }));
+    render(<ResourceBrowser context="kind-dev" kind="pods" />);
+    await waitFor(() => expect(screen.getByText("web-1")).toBeDefined());
+    // Cached rows are present, so the full "Loading pods" state never shows
+    // (stale-while-revalidate: revalidation happens with rows already on screen).
+    expect(screen.queryByText("Loading pods")).toBeNull();
   });
 
   it("registers configured kubeconfig paths before building a client for the context", async () => {

--- a/apps/desktop/src/components/ResourceBrowser.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.tsx
@@ -532,6 +532,28 @@ interface ResourceState {
   loading: boolean;
 }
 
+// Last-seen rows per view (`context|namespace|kind`), kept module-level so
+// switching tabs — which unmounts the browser — and returning shows the data
+// instantly instead of an empty spinner + full re-fetch. Stale-while-revalidate:
+// the watch/list still runs on mount and overwrites both the view and this
+// cache, and the existing render shows a subtle inline spinner (not the full
+// LoadingState) while revalidating because rows are already present. Bounded via
+// a simple move-to-end LRU so it can't grow without limit.
+const LIST_CACHE_MAX = 40;
+const listRowCache = new Map<string, Array<{ name: string }>>();
+function cacheRows(key: string, rows: Array<{ name: string }>) {
+  listRowCache.delete(key); // re-insert at the end = most-recently-used
+  listRowCache.set(key, rows);
+  if (listRowCache.size > LIST_CACHE_MAX) {
+    const oldest = listRowCache.keys().next().value;
+    if (oldest !== undefined) listRowCache.delete(oldest);
+  }
+}
+/** Test-only: clear the cross-mount row cache between cases. */
+export function __clearListRowCacheForTests() {
+  listRowCache.clear();
+}
+
 interface OtherDetail {
   kind: string;
   namespace: string | null;
@@ -606,7 +628,12 @@ export function ResourceBrowser({
   }, [nsScope]);
   const watchNamespace = watchNamespaceForSelection(selection);
   const selectionKey = serializeNamespaceSelection(selection);
-  const [res, setRes] = useState<ResourceState>({ rows: [], error: "", loading: false });
+  const [res, setRes] = useState<ResourceState>(() => {
+    // Hydrate from the cross-mount cache on first render so a re-opened tab
+    // paints its previous rows immediately (no empty flash before the effect).
+    const cached = listRowCache.get(`${context}|${watchNamespace}|${kind}`);
+    return { rows: cached ?? [], error: "", loading: false };
+  });
   const [watchStatus, setWatchStatus] = useState<WatchStatus>("live");
   const [selectedPod, setSelectedPod] = useState<PodSummary | null>(null);
   const [otherDetail, setOtherDetail] = useState<OtherDetail | null>(null);
@@ -635,7 +662,10 @@ export function ResourceBrowser({
     if (fresh) {
       setSelectedPod(null);
       setOtherDetail(null);
-      setRes({ rows: [], error: "", loading: true });
+      // Show any cached rows for the new view immediately (revalidate below);
+      // only a view with no cache falls back to the full loading state.
+      const cached = listRowCache.get(viewKey);
+      setRes({ rows: cached ?? [], error: "", loading: true });
     } else {
       setRes((r) => ({ ...r, loading: true }));
     }
@@ -648,7 +678,10 @@ export function ResourceBrowser({
         watchNamespace,
         kind,
         (rows) => {
-          if (!cancelled) setRes({ rows, error: "", loading: false });
+          if (!cancelled) {
+            setRes({ rows, error: "", loading: false });
+            cacheRows(viewKey, rows);
+          }
         },
         (status) => {
           if (!cancelled) setWatchStatus(status);
@@ -686,7 +719,11 @@ export function ResourceBrowser({
             error: o.error,
           }));
     void loader.then(({ rows, error }) => {
-      if (!cancelled) setRes({ rows: rows ?? [], error: error ?? "", loading: false });
+      if (!cancelled) {
+        const loaded = rows ?? [];
+        setRes({ rows: loaded, error: error ?? "", loading: false });
+        if (!error) cacheRows(viewKey, loaded);
+      }
     });
     return () => {
       cancelled = true;


### PR DESCRIPTION
Closes #146.

Switching tabs unmounts the `ResourceBrowser` (App renders only the active tab), so returning re-fetched everything from scratch — an empty spinner flash on every switch.

## Change
Adds a bounded module-level row cache keyed by `context|namespace|kind` (`ResourceBrowser.tsx`):
- Hydrates `res` from the cache on mount (and when switching view within a mount), so a re-opened tab paints its previous rows immediately.
- Every successful watch/list update writes to the cache.
- Simple move-to-end LRU, capped at 40 views.

This is **stale-while-revalidate for free**: the existing render already shows a subtle inline spinner (not the full `LoadingState`) whenever rows are present, so cached rows appear instantly and the watch/list still revalidates once on mount. Inactive tabs remain unmounted, so hidden tabs do no background work (the issue's preferred option 2).

## Tests
- New: re-opening a tab shows cached rows with no full "Loading pods" state, even when the re-mounted watch never pushes.
- Cache cleared in `beforeEach` so module state doesn't leak across tests.
- Full frontend suite green (665).