### PR TITLE
ci(release): scheduled + on-demand dev pre-releases (not every push)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,31 @@
 name: Release
 
-# dev  branch -> rolling pre-release tagged `srelens-v<version>-<run>`
-# main branch -> the version is derived AUTOMATICALLY from Conventional Commits
-#                since the last stable tag (feat -> minor, fix/perf -> patch,
-#                BREAKING CHANGE or `!` -> major). The version files are bumped +
-#                committed back to main with [skip ci], then a stable
-#                `srelens-v<version>` release is built. No manual bump needed; if
-#                there are no releasable commits the release is skipped.
+# dev  branch  -> rolling pre-release tagged `srelens-v<version>-<run>`. NOT built
+#                 on every push: a dev release is cut once a day (see the cron
+#                 below) or on demand via "Run workflow". If nothing has landed
+#                 since the last dev pre-release the run skips the build, so we
+#                 don't burn an Apple notarization request on an identical
+#                 binary. A manual run can override that with `force`.
+# main branch  -> the version is derived AUTOMATICALLY from Conventional Commits
+#                 since the last stable tag (feat -> minor, fix/perf -> patch,
+#                 BREAKING CHANGE or `!` -> major). The version files are bumped +
+#                 committed back to main with [skip ci], then a stable
+#                 `srelens-v<version>` release is built. No manual bump needed; if
+#                 there are no releasable commits the release is skipped.
 on:
   push:
-    branches: [main, dev]
+    branches: [main]
+  # Once-a-day dev pre-release at 18:00 UTC. Scheduled runs always use the
+  # default branch (dev). Skipped automatically when nothing has landed since
+  # the last dev pre-release.
+  schedule:
+    - cron: '0 18 * * *'
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Release even if nothing changed since the last dev pre-release'
+        type: boolean
+        default: false
 
 # Don't cancel an in-flight release run (it could leave partial assets).
 concurrency:
@@ -48,6 +64,23 @@ jobs:
           # use the run number alone. Not committed; the build job writes it into
           # the version files locally before building.
           if [ "${{ github.ref_name }}" != "main" ]; then
+            # Nothing new since the last dev pre-release? Skip — rebuilding the
+            # same tree yields an identical app and costs an Apple notarization
+            # request, which is what we're economizing. `force` (manual runs
+            # only) overrides; inputs.force is empty on schedule/push events, so
+            # the check applies there.
+            LAST_DEV_TAG=$(git for-each-ref --sort=-creatordate --format='%(refname:short)' 'refs/tags/srelens-v*' \
+              | grep -vE '^srelens-v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
+            if [ "${{ inputs.force }}" != "true" ] && [ -n "$LAST_DEV_TAG" ]; then
+              LAST_SHA=$(git rev-list -n 1 "$LAST_DEV_TAG" 2>/dev/null || true)
+              if [ -n "$LAST_SHA" ] && [ "$LAST_SHA" = "$(git rev-parse HEAD)" ]; then
+                echo "release=false" >> "$GITHUB_OUTPUT"
+                echo "No new commits since ${LAST_DEV_TAG} — skipping dev release."
+                exit 0
+              fi
+              echo "Changes since ${LAST_DEV_TAG}:"
+              git log --oneline "${LAST_DEV_TAG}..HEAD" || true
+            fi
             CUR=$(node -p "require('./apps/desktop/src-tauri/tauri.conf.json').version")
             BASE=${CUR%%-*}
             NEXT=$(node -e 'const p=process.argv[1].split(".").map(Number);p[2]++;process.stdout.write(p.join("."))' "$BASE")
@@ -150,9 +183,10 @@ jobs:
 
   build:
     needs: version
-    # Always run on dev (prereleases); on main only when the version job
-    # determined there is something to release.
-    if: ${{ always() && needs.version.result == 'success' && (github.ref_name != 'main' || needs.version.outputs.release == 'true') }}
+    # Run only when the version job decided to release. On main that's when
+    # there are releasable commits; on dev that's a scheduled/manual run with
+    # new commits since the last dev pre-release (or a forced run).
+    if: ${{ always() && needs.version.result == 'success' && needs.version.outputs.release == 'true' }}
     permissions:
       contents: write
     env:


### PR DESCRIPTION
Closes #169.

Adopts the [mqlens-mongodb](https://github.com/mqlens/mqlens-mongodb) release cadence for dev pre-releases.

## Change (`.github/workflows/release.yml`)
- **Triggers**: `push` now only on `main`. Added `schedule` (cron `0 18 * * *` — one dev pre-release/day) and `workflow_dispatch` with a `force` boolean for on-demand runs. Scheduled/dispatch runs use the default branch (`dev`).
- **Skip-if-unchanged**: the version job compares `HEAD` to the commit of the last dev pre-release tag (`srelens-v*-<run>`); if identical it sets `release=false` and exits, so we don't rebuild + re-notarize an identical binary. `force=true` (manual only) overrides.
- **Gating**: the `build` job now runs only when `release == 'true'`, so a skipped dev run cascades cleanly (docker / release-notes / updater / gpg all skip via their existing `needs`).

Stable `main` releases (Conventional-Commits auto-versioning) are unchanged.

## Verification
- YAML parses; triggers are `push`/`schedule`/`workflow_dispatch`.
- Skip logic mirrors the reference: `inputs.force` is empty on schedule/push, so the unchanged-check applies there and only a manual `force` bypasses it.

Note: the daily schedule starts once this lands on the default branch (GitHub only runs `schedule` from the default branch's workflow file).