### PR TITLE
feat(palette): full action coverage, capability audit, and smarter ranking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5635,6 +5635,7 @@ name = "srelens-registry"
 version = "0.0.0"
 dependencies = [
  "reqwest 0.13.4",
+ "serde",
  "serde_json",
  "srelens-capability",
  "srelens-kube",

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -90,6 +90,10 @@ export function App() {
   const [contextOrder, setContextOrder] = useState(loadContextOrder);
   const [theme, setTheme] = useState<Theme>(getInitialTheme);
   const [paletteOpen, setPaletteOpen] = useState(false);
+  // Bumped after a palette action mutates a resource, so the active
+  // ResourceBrowser remounts and re-fetches (mirrors the settingsSectionNonce
+  // remount-via-key pattern below).
+  const [viewReloadNonce, setViewReloadNonce] = useState(0);
   // Last-used namespace per cluster (persisted across restarts).
   const [clusterNs, setClusterNs] = useState<Record<string, string>>(loadClusterNamespaces);
   // Global fallback namespace for clusters with no remembered selection.
@@ -645,7 +649,7 @@ export function App() {
                     />
                   ) : activeCluster ? (
                     <ResourceBrowser
-                      key={activeTab.id}
+                      key={`${activeTab.id}:${viewReloadNonce}`}
                       context={activeCluster}
                       kind={activeKind}
                       query={query}
@@ -748,6 +752,8 @@ export function App() {
         }
         onOpenResource={openResource}
         onOpenCrd={(crd) => activeCluster && openCrdView(activeCluster, crd)}
+        currentViewKind={activeTab?.kind}
+        onAfterAction={() => setViewReloadNonce((n) => n + 1)}
       />
       <Toaster position="top-right" richColors closeButton />
     </div>

--- a/apps/desktop/src/components/CommandPalette.test.tsx
+++ b/apps/desktop/src/components/CommandPalette.test.tsx
@@ -220,4 +220,27 @@ describe("CommandPalette", () => {
     setup({ currentViewKind: "pods" });
     expect(await screen.findByText("Quick: Pods")).toBeDefined();
   });
+
+  it("narrows to the given kind when the query starts with a known kind token", async () => {
+    listResourceMock.mockImplementation((_c: string, kind: string) =>
+      Promise.resolve({
+        items:
+          kind === "Pod"
+            ? [{ name: "nginx", namespace: "default", age: "1m" }]
+            : kind === "Service"
+              ? [{ name: "nginx", namespace: "default", age: "1m" }]
+              : [],
+      }),
+    );
+    setup();
+    await waitFor(() => expect(listResourceMock).toHaveBeenCalled());
+
+    await userEvent.type(screen.getByPlaceholderText(/Search resources/), "pod ng");
+
+    // Both a pod and a service named "nginx" are indexed, but "pod ng" must
+    // only surface the pod.
+    expect(await screen.findByText("nginx")).toBeDefined();
+    expect(screen.getByText("Pod")).toBeDefined();
+    expect(screen.queryByText("Service")).toBeNull();
+  });
 });

--- a/apps/desktop/src/components/CommandPalette.test.tsx
+++ b/apps/desktop/src/components/CommandPalette.test.tsx
@@ -13,6 +13,20 @@ vi.mock("../lib/manifest", async (importOriginal) => {
 });
 vi.mock("../lib/crds", () => ({ listCrds: listCrdsMock }));
 
+const { deleteResourceMock, rolloutRestartMock } = vi.hoisted(() => ({
+  deleteResourceMock: vi.fn(),
+  rolloutRestartMock: vi.fn(),
+}));
+vi.mock("../lib/actions", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/actions")>();
+  return { ...actual, deleteResource: deleteResourceMock, rolloutRestart: rolloutRestartMock };
+});
+
+const { notifyMock } = vi.hoisted(() => ({
+  notifyMock: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+vi.mock("../lib/notify", () => ({ notify: notifyMock }));
+
 import { CommandPalette } from "./CommandPalette";
 
 const widgetCrd = {
@@ -28,18 +42,28 @@ beforeEach(() => {
   localStorage.clear();
   listResourceMock.mockReset();
   listCrdsMock.mockReset();
+  deleteResourceMock.mockReset();
+  rolloutRestartMock.mockReset();
+  notifyMock.success.mockReset();
+  notifyMock.error.mockReset();
   listResourceMock.mockImplementation((_c: string, kind: string) =>
     Promise.resolve({
-      items: kind === "Pod" ? [{ name: "web-1", namespace: "default", age: "1m" }] : [],
+      items:
+        kind === "Pod"
+          ? [{ name: "web-1", namespace: "default", age: "1m" }]
+          : kind === "Deployment"
+            ? [{ name: "web-deploy", namespace: "default", age: "1m" }]
+            : [],
     }),
   );
   listCrdsMock.mockResolvedValue({ crds: [widgetCrd] });
 });
 
-function setup() {
+function setup(extra?: Partial<React.ComponentProps<typeof CommandPalette>>) {
   const onOpenView = vi.fn();
   const onOpenResource = vi.fn();
   const onOpenCrd = vi.fn();
+  const onAfterAction = vi.fn();
   const r = render(
     <CommandPalette
       open
@@ -48,9 +72,11 @@ function setup() {
       onOpenView={onOpenView}
       onOpenResource={onOpenResource}
       onOpenCrd={onOpenCrd}
+      onAfterAction={onAfterAction}
+      {...extra}
     />,
   );
-  return { ...r, onOpenView, onOpenResource, onOpenCrd };
+  return { ...r, onOpenView, onOpenResource, onOpenCrd, onAfterAction };
 }
 
 describe("CommandPalette", () => {
@@ -80,18 +106,118 @@ describe("CommandPalette", () => {
     }
   });
 
-  it("searches resources by name and deep-links to the selected one", async () => {
-    const { onOpenResource } = setup();
-    await waitFor(() => expect(listResourceMock).toHaveBeenCalled());
-    await userEvent.type(screen.getByPlaceholderText(/Search resources/), "web");
-    await userEvent.click(await screen.findByText("web-1"));
-    expect(onOpenResource).toHaveBeenCalledWith("pods", "default", "web-1");
-  });
-
   it("surfaces CRDs in Go to and opens them", async () => {
     const { onOpenCrd } = setup();
     await userEvent.type(screen.getByPlaceholderText(/Search resources/), "widget");
     await userEvent.click(await screen.findByText("Widget (CRD)"));
     expect(onOpenCrd).toHaveBeenCalledWith(widgetCrd);
+  });
+
+  it("drills into a pod's actions instead of opening it directly, then opens details on demand", async () => {
+    const { onOpenResource } = setup();
+    await waitFor(() => expect(listResourceMock).toHaveBeenCalled());
+    await userEvent.type(screen.getByPlaceholderText(/Search resources/), "web-1");
+    await userEvent.click(await screen.findByText("web-1"));
+
+    // Selecting the pod drills into action mode instead of opening it.
+    expect(onOpenResource).not.toHaveBeenCalled();
+    expect(await screen.findByText("Actions for web-1")).toBeDefined();
+    expect(screen.getByText("Delete")).toBeDefined();
+    expect(screen.getByText("Evict pod")).toBeDefined();
+
+    await userEvent.click(screen.getByText("Open details"));
+    expect(onOpenResource).toHaveBeenCalledWith("pods", "default", "web-1");
+  });
+
+  it("drills into a resource's actions and runs a non-destructive one directly", async () => {
+    rolloutRestartMock.mockResolvedValue({ ok: true });
+    const { onAfterAction } = setup();
+    await waitFor(() => expect(listResourceMock).toHaveBeenCalled());
+    await userEvent.type(screen.getByPlaceholderText(/Search resources/), "web-deploy");
+    await userEvent.click(await screen.findByText("web-deploy"));
+    expect(await screen.findByText("Actions for web-deploy")).toBeDefined();
+
+    await userEvent.click(screen.getByText("Rollout restart"));
+
+    await waitFor(() =>
+      expect(rolloutRestartMock).toHaveBeenCalledWith("kind-dev", "Deployment", "default", "web-deploy"),
+    );
+    await waitFor(() => expect(onAfterAction).toHaveBeenCalled());
+  });
+
+  it("calls onOpenResource for opensDialog actions (scale), never invoking a run handler", async () => {
+    const { onOpenResource } = setup();
+    await waitFor(() => expect(listResourceMock).toHaveBeenCalled());
+    await userEvent.type(screen.getByPlaceholderText(/Search resources/), "web-deploy");
+    await userEvent.click(await screen.findByText("web-deploy"));
+    expect(await screen.findByText("Actions for web-deploy")).toBeDefined();
+
+    await userEvent.click(screen.getByText("Scale…"));
+
+    expect(onOpenResource).toHaveBeenCalledWith("deployments", "default", "web-deploy");
+  });
+
+  it("requires confirmation before running a destructive action, then dispatches it", async () => {
+    deleteResourceMock.mockResolvedValue({ ok: true });
+    const { onAfterAction } = setup();
+    await waitFor(() => expect(listResourceMock).toHaveBeenCalled());
+    await userEvent.type(screen.getByPlaceholderText(/Search resources/), "web-deploy");
+    await userEvent.click(await screen.findByText("web-deploy"));
+    expect(await screen.findByText("Actions for web-deploy")).toBeDefined();
+
+    await userEvent.click(screen.getByText("Delete"));
+
+    // The mutation must not fire before the confirm dialog is accepted.
+    expect(deleteResourceMock).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog")).toBeDefined();
+
+    // The dialog hides the outside content, so its own "Delete" button is the
+    // only one reachable now.
+    await userEvent.click(await screen.findByRole("button", { name: "Delete" }));
+
+    await waitFor(() =>
+      expect(deleteResourceMock).toHaveBeenCalledWith("kind-dev", "Deployment", "default", "web-deploy"),
+    );
+    await waitFor(() => expect(onAfterAction).toHaveBeenCalled());
+  });
+
+  it("surfaces a failed action's error via notify", async () => {
+    deleteResourceMock.mockResolvedValue({ error: "forbidden" });
+    setup();
+    await waitFor(() => expect(listResourceMock).toHaveBeenCalled());
+    await userEvent.type(screen.getByPlaceholderText(/Search resources/), "web-deploy");
+    await userEvent.click(await screen.findByText("web-deploy"));
+    await userEvent.click(await screen.findByText("Delete"));
+    await userEvent.click(await screen.findByRole("button", { name: "Delete" }));
+
+    await waitFor(() => expect(notifyMock.error).toHaveBeenCalledWith("Failed: Delete", "forbidden"));
+  });
+
+  it("goes back to browsing via the Back item without dispatching anything", async () => {
+    const { onOpenResource } = setup();
+    await waitFor(() => expect(listResourceMock).toHaveBeenCalled());
+    await userEvent.type(screen.getByPlaceholderText(/Search resources/), "web-deploy");
+    await userEvent.click(await screen.findByText("web-deploy"));
+    expect(await screen.findByText("Actions for web-deploy")).toBeDefined();
+
+    await userEvent.click(screen.getByText("← Back"));
+
+    expect(screen.queryByText("Actions for web-deploy")).toBeNull();
+    expect(onOpenResource).not.toHaveBeenCalled();
+    expect(deleteResourceMock).not.toHaveBeenCalled();
+  });
+
+  it("ranks recents for the current view kind under a Quick group before Recent and Go to", async () => {
+    // Seed a recent pod so it shows up once the palette is reopened.
+    const { unmount, onOpenResource } = setup({ currentViewKind: "pods" });
+    await waitFor(() => expect(listResourceMock).toHaveBeenCalled());
+    await userEvent.type(screen.getByPlaceholderText(/Search resources/), "web-1");
+    await userEvent.click(await screen.findByText("web-1"));
+    await userEvent.click(await screen.findByText("Open details"));
+    expect(onOpenResource).toHaveBeenCalledWith("pods", "default", "web-1");
+    unmount();
+
+    setup({ currentViewKind: "pods" });
+    expect(await screen.findByText("Quick: Pods")).toBeDefined();
   });
 });

--- a/apps/desktop/src/components/CommandPalette.tsx
+++ b/apps/desktop/src/components/CommandPalette.tsx
@@ -39,6 +39,38 @@ const SEARCH_KINDS: ResourceKind[] = [
 // Views you can jump to. "portforwards" is a virtual view, still navigable.
 const NAV_KINDS = (Object.keys(RESOURCE_LABELS) as ResourceKind[]).filter((k) => k !== "overview");
 
+/**
+ * Maps a leading query token to a kind, so "pod nginx" or "svc web" narrows
+ * the resource search to that kind before name-filtering. Keys include each
+ * searchable ResourceKind itself, its singular K8S_KIND label, and common
+ * kubectl-style short aliases.
+ */
+const KIND_TOKENS: Partial<Record<string, ResourceKind>> = (() => {
+  const map: Partial<Record<string, ResourceKind>> = {};
+  for (const k of SEARCH_KINDS) {
+    map[k] = k;
+    const label = K8S_KIND[k];
+    if (label) map[label.toLowerCase()] = k;
+  }
+  const aliases: Record<string, ResourceKind> = {
+    po: "pods",
+    deploy: "deployments",
+    deploys: "deployments",
+    sts: "statefulsets",
+    ds: "daemonsets",
+    rs: "replicasets",
+    cj: "cronjobs",
+    svc: "services",
+    ing: "ingresses",
+    cm: "configmaps",
+    pvc: "persistentvolumeclaims",
+    sa: "serviceaccounts",
+    no: "nodes",
+  };
+  Object.assign(map, aliases);
+  return map;
+})();
+
 interface ResItem {
   kind: ResourceKind;
   namespace: string;
@@ -228,9 +260,15 @@ export function CommandPalette({
 
   const resMatches = useMemo(() => {
     if (!q) return [];
-    return items
-      .filter((r) => r.name.toLowerCase().includes(q))
-      .sort(rankBy(q, (r) => r.name))
+    // A leading kind token ("pod nginx", "svc web") narrows the search to
+    // that kind before filtering by the rest of the query as the name.
+    const [first, ...rest] = q.split(/\s+/);
+    const kind = KIND_TOKENS[first];
+    const nameQuery = kind ? rest.join(" ") : q;
+    const scoped = kind ? items.filter((r) => r.kind === kind) : items;
+    return scoped
+      .filter((r) => r.name.toLowerCase().includes(nameQuery))
+      .sort(rankBy(nameQuery, (r) => r.name))
       .slice(0, 50);
   }, [items, q]);
 

--- a/apps/desktop/src/components/CommandPalette.tsx
+++ b/apps/desktop/src/components/CommandPalette.tsx
@@ -12,8 +12,11 @@ import {
 import { RESOURCE_LABELS, K8S_KIND, type ResourceKind } from "./ResourceBrowser";
 import { listResource } from "../lib/manifest";
 import { listCrds, type CrdRef } from "../lib/crds";
-import { getRecents, pushRecent, type RecentItem } from "../lib/recents";
+import { getRecents, pushRecent, recentId, type RecentItem } from "../lib/recents";
 import { iconForResourceKind } from "../ui/NavIcon";
+import { actionsForKind, type PaletteAction, type PaletteActionCtx } from "../lib/paletteActions";
+import { ConfirmDialog } from "../ui";
+import { notify } from "../lib/notify";
 
 /** Kinds indexed for name search when the palette opens. */
 const SEARCH_KINDS: ResourceKind[] = [
@@ -39,6 +42,13 @@ const NAV_KINDS = (Object.keys(RESOURCE_LABELS) as ResourceKind[]).filter((k) =>
 interface ResItem {
   kind: ResourceKind;
   namespace: string;
+  name: string;
+}
+
+/** The resource the palette has drilled into — showing its available actions. */
+interface ActionTarget {
+  kind: ResourceKind;
+  namespace: string | null;
   name: string;
 }
 
@@ -73,6 +83,8 @@ export function CommandPalette({
   onOpenView,
   onOpenResource,
   onOpenCrd,
+  currentViewKind,
+  onAfterAction,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -80,12 +92,22 @@ export function CommandPalette({
   onOpenView: (kind: ResourceKind) => void;
   onOpenResource: (kind: ResourceKind, namespace: string | null, name: string) => void;
   onOpenCrd: (crd: CrdRef) => void;
+  /** The resource kind of the view the user currently has open, for ranking. */
+  currentViewKind?: ResourceKind;
+  /** Fired after a dispatched action completes, so the caller can refresh. */
+  onAfterAction?: () => void;
 }) {
   const [query, setQuery] = useState("");
   const [items, setItems] = useState<ResItem[]>([]);
   const [crds, setCrds] = useState<CrdRef[]>([]);
   const [recents, setRecents] = useState<RecentItem[]>([]);
   const [loading, setLoading] = useState(false);
+  // Set once the user picks a resource that has applicable actions — the
+  // palette then shows "action mode" for it instead of opening its detail.
+  const [target, setTarget] = useState<ActionTarget | null>(null);
+  // A destructive action awaiting confirmation.
+  const [pendingAction, setPendingAction] = useState<PaletteAction | null>(null);
+  const [busy, setBusy] = useState(false);
 
   // Index resources + CRDs, and read recents, each time the palette opens.
   useEffect(() => {
@@ -111,7 +133,11 @@ export function CommandPalette({
   }, [open, context]);
 
   useEffect(() => {
-    if (open) setQuery("");
+    if (open) {
+      setQuery("");
+      setTarget(null);
+      setPendingAction(null);
+    }
   }, [open]);
 
   const q = query.trim().toLowerCase();
@@ -136,13 +162,68 @@ export function CommandPalette({
       .slice(0, 8);
   }, [q, crds]);
 
-  // Dispatch a chosen item, record it in recents, and close the palette.
+  // Dispatch a chosen item. A resource with applicable actions drills into
+  // "action mode" instead of opening its detail directly; everything else
+  // (views, CRDs, action-less resources) records it in recents and closes.
   function pick(item: RecentItem) {
+    if (item.type === "resource") {
+      const kind = item.kind as ResourceKind;
+      if (actionsForKind(kind).length > 0) {
+        pushRecent(item);
+        setTarget({ kind, namespace: item.namespace, name: item.name });
+        setQuery("");
+        return;
+      }
+    }
     pushRecent(item);
     if (item.type === "view") onOpenView(item.kind as ResourceKind);
     else if (item.type === "resource") onOpenResource(item.kind as ResourceKind, item.namespace, item.name);
     else onOpenCrd(item.crd);
     onOpenChange(false);
+  }
+
+  /** Back out of action mode to normal browsing. */
+  function goBack() {
+    setTarget(null);
+    setQuery("");
+  }
+
+  function openTargetDetails() {
+    if (!target) return;
+    onOpenResource(target.kind, target.namespace, target.name);
+    onOpenChange(false);
+  }
+
+  // Dispatch a chosen action for the current target.
+  function selectAction(action: PaletteAction) {
+    if (!target) return;
+    if (action.opensDialog) {
+      // Input-needing actions (scale/debug) are a one-hop to the resource's
+      // detail drawer, where their dialogs already live — the palette never
+      // renders them itself.
+      onOpenResource(target.kind, target.namespace, target.name);
+      onOpenChange(false);
+      return;
+    }
+    if (action.destructive) {
+      setPendingAction(action);
+      return;
+    }
+    void runAction(action);
+  }
+
+  async function runAction(action: PaletteAction) {
+    if (!target || !context) return;
+    setBusy(true);
+    const ctx: PaletteActionCtx = { context, kind: target.kind, namespace: target.namespace, name: target.name };
+    const result = await action.run?.(ctx);
+    setBusy(false);
+    setPendingAction(null);
+    if (result && "error" in result && result.error) {
+      notify.error(`Failed: ${action.label}`, result.error);
+    }
+    onOpenChange(false);
+    onAfterAction?.();
   }
 
   const resMatches = useMemo(() => {
@@ -153,62 +234,151 @@ export function CommandPalette({
       .slice(0, 50);
   }, [items, q]);
 
+  // Actions available for the drilled-into resource, optionally text-filtered.
+  const actionMatches = useMemo(() => {
+    if (!target) return [];
+    const acts = actionsForKind(target.kind);
+    if (!q) return acts;
+    return acts.filter((a) => a.label.toLowerCase().includes(q));
+  }, [target, q]);
+
+  // Context-aware ranking: when browsing with no query, surface recents for
+  // the resource kind currently in view ahead of the rest of Recent.
+  const quickRecents = useMemo(() => {
+    if (q || !currentViewKind) return [];
+    return recents.filter((r) => r.type === "resource" && r.kind === currentViewKind);
+  }, [q, currentViewKind, recents]);
+
+  const otherRecents = useMemo(() => {
+    if (!quickRecents.length) return recents;
+    const quickIds = new Set(quickRecents.map(recentId));
+    return recents.filter((r) => !quickIds.has(recentId(r)));
+  }, [recents, quickRecents]);
+
   return (
     <CommandDialog open={open} onOpenChange={onOpenChange} title="Search" description="Jump to a view or resource">
       <Command shouldFilter={false}>
-        <CommandInput value={query} onValueChange={setQuery} placeholder="Search resources and views…" />
+        <CommandInput
+          value={query}
+          onValueChange={setQuery}
+          placeholder={target ? `Actions for ${target.name}…` : "Search resources and views…"}
+          onKeyDown={(e) => {
+            if (e.key === "Backspace" && query === "" && target) {
+              e.preventDefault();
+              goBack();
+            }
+          }}
+        />
         <CommandList>
           <CommandEmpty>{loading ? "Indexing…" : "No results"}</CommandEmpty>
 
-          {!q && recents.length > 0 && (
-            <CommandGroup heading="Recent">
-              {recents.map((r) => (
-                <CommandItem key={`recent:${r.type}:${r.label}`} value={`recent:${r.label}`} onSelect={() => pick(r)}>
-                  <PaletteIcon icon={iconForRecent(r)} />
-                  <span className="truncate">{r.label}</span>
-                  <span className="ml-2 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
-                    {r.type === "resource" ? K8S_KIND[r.kind as ResourceKind] : r.type === "crd" ? "CRD" : "view"}
-                  </span>
+          {target ? (
+            <CommandGroup heading={`Actions for ${target.name}`}>
+              {actionMatches.map((a) => (
+                <CommandItem key={a.capabilityId + a.label} value={`action:${a.label}`} onSelect={() => selectAction(a)}>
+                  {a.label}
                 </CommandItem>
               ))}
+              <CommandItem value="palette:open-details" onSelect={openTargetDetails}>
+                Open details
+              </CommandItem>
+              <CommandItem value="palette:back" onSelect={goBack}>
+                ← Back
+              </CommandItem>
             </CommandGroup>
-          )}
+          ) : (
+            <>
+              {!q && quickRecents.length > 0 && currentViewKind && (
+                <CommandGroup heading={`Quick: ${RESOURCE_LABELS[currentViewKind]}`}>
+                  {quickRecents.map((r) => (
+                    <CommandItem key={`quick:${r.type}:${r.label}`} value={`quick:${r.label}`} onSelect={() => pick(r)}>
+                      <PaletteIcon icon={iconForRecent(r)} />
+                      <span className="truncate">{r.label}</span>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              )}
 
-          {navMatches.length > 0 && (
-            <CommandGroup heading="Go to">
-              {navMatches.map((n) => (
-                <CommandItem key={n.id} value={`nav:${n.id}`} onSelect={() => pick(n.recent)}>
-                  <PaletteIcon icon={iconForRecent(n.recent)} />
-                  {n.label}
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          )}
+              {!q && otherRecents.length > 0 && (
+                <CommandGroup heading="Recent">
+                  {otherRecents.map((r) => (
+                    <CommandItem key={`recent:${r.type}:${r.label}`} value={`recent:${r.label}`} onSelect={() => pick(r)}>
+                      <PaletteIcon icon={iconForRecent(r)} />
+                      <span className="truncate">{r.label}</span>
+                      <span className="ml-2 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                        {r.type === "resource" ? K8S_KIND[r.kind as ResourceKind] : r.type === "crd" ? "CRD" : "view"}
+                      </span>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              )}
 
-          {resMatches.length > 0 && (
-            <CommandGroup heading={loading ? "Resources (indexing…)" : "Resources"}>
-              {resMatches.map((r, i) => (
-                <CommandItem
-                  key={`${r.kind}/${r.namespace}/${r.name}/${i}`}
-                  value={`res:${i}`}
-                  onSelect={() =>
-                    pick({ type: "resource", kind: r.kind, namespace: r.namespace || null, name: r.name, label: r.name })
-                  }
-                >
-                  <PaletteIcon icon={iconForResourceKind(r.kind)} />
-                  <span className="truncate">{r.name}</span>
-                  <span className="ml-2 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
-                    {K8S_KIND[r.kind]}
-                  </span>
-                  {r.namespace && (
-                    <span className="ml-auto truncate pl-2 text-xs text-muted-foreground">{r.namespace}</span>
-                  )}
-                </CommandItem>
-              ))}
-            </CommandGroup>
+              {navMatches.length > 0 && (
+                <CommandGroup heading="Go to">
+                  {navMatches.map((n) => (
+                    <CommandItem key={n.id} value={`nav:${n.id}`} onSelect={() => pick(n.recent)}>
+                      <PaletteIcon icon={iconForRecent(n.recent)} />
+                      {n.label}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              )}
+
+              {resMatches.length > 0 && (
+                <CommandGroup heading={loading ? "Resources (indexing…)" : "Resources"}>
+                  {resMatches.map((r, i) => (
+                    <CommandItem
+                      key={`${r.kind}/${r.namespace}/${r.name}/${i}`}
+                      value={`res:${i}`}
+                      onSelect={() =>
+                        pick({
+                          type: "resource",
+                          kind: r.kind,
+                          namespace: r.namespace || null,
+                          name: r.name,
+                          label: r.name,
+                        })
+                      }
+                    >
+                      <PaletteIcon icon={iconForResourceKind(r.kind)} />
+                      <span className="truncate">{r.name}</span>
+                      <span className="ml-2 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                        {K8S_KIND[r.kind]}
+                      </span>
+                      {r.namespace && (
+                        <span className="ml-auto truncate pl-2 text-xs text-muted-foreground">{r.namespace}</span>
+                      )}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              )}
+            </>
           )}
         </CommandList>
       </Command>
+
+      {pendingAction && target && (
+        <ConfirmDialog
+          title={`${pendingAction.label}?`}
+          message={
+            <p style={{ marginTop: 0 }}>
+              {pendingAction.label} <code>{target.name}</code>
+              {target.namespace ? (
+                <>
+                  {" "}
+                  in <code>{target.namespace}</code>
+                </>
+              ) : null}
+              ? This cannot be undone.
+            </p>
+          }
+          confirmLabel={pendingAction.label}
+          danger
+          busy={busy}
+          onConfirm={() => void runAction(pendingAction)}
+          onCancel={() => setPendingAction(null)}
+        />
+      )}
     </CommandDialog>
   );
 }

--- a/apps/desktop/src/lib/capability-catalog.json
+++ b/apps/desktop/src/lib/capability-catalog.json
@@ -1,0 +1,412 @@
+[
+  {
+    "id": "k8s.applyManifest",
+    "readOnly": false,
+    "destructive": false
+  },
+  {
+    "id": "k8s.bindingsForServiceAccount",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.canI",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.clusterInfo",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.cordonNode",
+    "readOnly": false,
+    "destructive": false
+  },
+  {
+    "id": "k8s.createNodeDebugPod",
+    "readOnly": false,
+    "destructive": true
+  },
+  {
+    "id": "k8s.cronjobSetSuspend",
+    "readOnly": false,
+    "destructive": false
+  },
+  {
+    "id": "k8s.cronjobTriggerNow",
+    "readOnly": false,
+    "destructive": false
+  },
+  {
+    "id": "k8s.debugPod",
+    "readOnly": false,
+    "destructive": true
+  },
+  {
+    "id": "k8s.deleteContext",
+    "readOnly": false,
+    "destructive": true
+  },
+  {
+    "id": "k8s.deletePod",
+    "readOnly": false,
+    "destructive": true
+  },
+  {
+    "id": "k8s.deleteResource",
+    "readOnly": false,
+    "destructive": true
+  },
+  {
+    "id": "k8s.diffManifest",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.drainNode",
+    "readOnly": false,
+    "destructive": true
+  },
+  {
+    "id": "k8s.evictPod",
+    "readOnly": false,
+    "destructive": true
+  },
+  {
+    "id": "k8s.getHelmRelease",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.getManifest",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.getObject",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.getSecret",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.helmInstall",
+    "readOnly": false,
+    "destructive": false
+  },
+  {
+    "id": "k8s.helmRepoAdd",
+    "readOnly": false,
+    "destructive": false
+  },
+  {
+    "id": "k8s.helmRepoUpdate",
+    "readOnly": false,
+    "destructive": false
+  },
+  {
+    "id": "k8s.helmRollback",
+    "readOnly": false,
+    "destructive": false
+  },
+  {
+    "id": "k8s.helmSearchRepo",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.helmTemplate",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.helmUninstall",
+    "readOnly": false,
+    "destructive": true
+  },
+  {
+    "id": "k8s.helmUpgrade",
+    "readOnly": false,
+    "destructive": false
+  },
+  {
+    "id": "k8s.helmVersion",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.listCRDs",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.listClusterRoleBindings",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.listClusterRoles",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.listConfigMaps",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.listContexts",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.listCronJobs",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.listCustomResource",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.listDaemonSets",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.listDeployments",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.listEndpointSlices",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.listEvents",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.listHelmReleases",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.listIngresses",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.listJobs",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.listLimitRanges",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.listNamespaces",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.listNetworkPolicies",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.listNodes",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.listPersistentVolumeClaims",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.listPersistentVolumes",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.listPods",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.listReplicaSets",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.listResource",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.listResourceQuotas",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.listRoleBindings",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.listRoles",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.listSecrets",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.listServiceAccounts",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.listServices",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.listStatefulSets",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.listStorageClasses",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.nodeMetrics",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.openApiSchema",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.podLogs",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.podMetrics",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.podsForPvc",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.podsForSelector",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.podsForServiceAccount",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.rolloutRestart",
+    "readOnly": false,
+    "destructive": false
+  },
+  {
+    "id": "k8s.scale",
+    "readOnly": false,
+    "destructive": false
+  },
+  {
+    "id": "k8s.synthesizeClusterKubeconfig",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.testClusterConnection",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "k8s.updateConfigData",
+    "readOnly": false,
+    "destructive": false
+  },
+  {
+    "id": "k8s.validateManifest",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "ping",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "toolbox.diagnoseContext",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "toolbox.installHelm",
+    "readOnly": false,
+    "destructive": false
+  },
+  {
+    "id": "toolbox.installKrew",
+    "readOnly": false,
+    "destructive": false
+  },
+  {
+    "id": "toolbox.installKubectl",
+    "readOnly": false,
+    "destructive": false
+  },
+  {
+    "id": "toolbox.installPlugin",
+    "readOnly": false,
+    "destructive": false
+  },
+  {
+    "id": "toolbox.removePlugin",
+    "readOnly": false,
+    "destructive": false
+  },
+  {
+    "id": "toolbox.searchPlugins",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "toolbox.status",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "toolbox.upgradePlugin",
+    "readOnly": false,
+    "destructive": false
+  }
+]

--- a/apps/desktop/src/lib/paletteActions.audit.test.ts
+++ b/apps/desktop/src/lib/paletteActions.audit.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import catalog from "./capability-catalog.json";
+import { paletteActionCapabilityIds } from "./paletteActions";
+
+// Capabilities intentionally NOT palette actions, each with a reason. Keep this
+// list small and justified — the whole point is that new mutating capabilities
+// fail CI until they are either palette-registered or excluded here.
+const EXCLUDED: Record<string, string> = {
+  "k8s.applyManifest": "reached via the manifest editor, not a one-click palette action",
+  "k8s.updateConfigData": "ConfigMap/Secret data edits happen in the ResourceOverview drawer, which needs a key/value patch beyond a bare resource ref",
+  "k8s.deleteContext": "kubeconfig management lives in Settings",
+  "k8s.helmInstall": "surfaced via HelmOpDialog from HelmReleasesView, not a resource-targeted palette action",
+  "k8s.helmUpgrade": "surfaced via HelmOpDialog from HelmReleasesView, not a resource-targeted palette action",
+  "k8s.helmRollback": "surfaced via HelmOpDialog from HelmReleasesView, not a resource-targeted palette action",
+  "k8s.helmUninstall": "surfaced via HelmOpDialog from HelmReleasesView, not a resource-targeted palette action",
+  "k8s.helmRepoAdd": "surfaced via the repo form in HelmReleasesView, not a resource-targeted palette action",
+  "k8s.helmRepoUpdate": "surfaced via the repo form in HelmReleasesView, not a resource-targeted palette action",
+  "toolbox.installKubectl": "toolbox installs live in the Toolbox view",
+  "toolbox.installHelm": "toolbox installs live in the Toolbox view",
+  "toolbox.installKrew": "toolbox installs live in the Toolbox view",
+  "toolbox.installPlugin": "toolbox installs live in the Toolbox view",
+  "toolbox.upgradePlugin": "toolbox installs live in the Toolbox view",
+  "toolbox.removePlugin": "toolbox installs live in the Toolbox view",
+};
+
+describe("command palette action coverage", () => {
+  it("registers every non-read-only capability (or explicitly excludes it)", () => {
+    const registered = paletteActionCapabilityIds();
+    const missing = (catalog as Array<{ id: string; readOnly: boolean }>)
+      .filter((c) => !c.readOnly)
+      .map((c) => c.id)
+      .filter((id) => !registered.has(id) && !(id in EXCLUDED));
+    expect(missing).toEqual([]);
+  });
+  it("has no stale EXCLUDED entries", () => {
+    const ids = new Set((catalog as Array<{ id: string }>).map((c) => c.id));
+    expect(Object.keys(EXCLUDED).filter((id) => !ids.has(id))).toEqual([]);
+  });
+});

--- a/apps/desktop/src/lib/paletteActions.test.ts
+++ b/apps/desktop/src/lib/paletteActions.test.ts
@@ -1,5 +1,70 @@
-import { describe, it, expect } from "vitest";
-import { PALETTE_ACTIONS, actionsForKind, paletteActionCapabilityIds } from "./paletteActions";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  deleteResourceMock,
+  rolloutRestartMock,
+  cordonNodeMock,
+  drainNodeMock,
+  cronjobSetSuspendMock,
+  cronjobTriggerNowMock,
+  createNodeDebugPodMock,
+} = vi.hoisted(() => ({
+  deleteResourceMock: vi.fn(),
+  rolloutRestartMock: vi.fn(),
+  cordonNodeMock: vi.fn(),
+  drainNodeMock: vi.fn(),
+  cronjobSetSuspendMock: vi.fn(),
+  cronjobTriggerNowMock: vi.fn(),
+  createNodeDebugPodMock: vi.fn(),
+}));
+vi.mock("../lib/actions", () => ({
+  deleteResource: deleteResourceMock,
+  rolloutRestart: rolloutRestartMock,
+  cordonNode: cordonNodeMock,
+  drainNode: drainNodeMock,
+  cronjobSetSuspend: cronjobSetSuspendMock,
+  cronjobTriggerNow: cronjobTriggerNowMock,
+  createNodeDebugPod: createNodeDebugPodMock,
+}));
+
+const { deletePodMock, evictPodMock } = vi.hoisted(() => ({
+  deletePodMock: vi.fn(),
+  evictPodMock: vi.fn(),
+}));
+vi.mock("../lib/workloads", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/workloads")>();
+  return { ...actual, deletePod: deletePodMock, evictPod: evictPodMock };
+});
+
+import { PALETTE_ACTIONS, actionsForKind, paletteActionCapabilityIds, type PaletteActionCtx } from "./paletteActions";
+
+function ctx(overrides: Partial<PaletteActionCtx> = {}): PaletteActionCtx {
+  return {
+    context: "kind-dev",
+    kind: "deployments",
+    namespace: "default",
+    name: "web",
+    ...overrides,
+  };
+}
+
+function actionByCapability(capabilityId: string, label?: string) {
+  const action = PALETTE_ACTIONS.find((a) => a.capabilityId === capabilityId && (label === undefined || a.label === label));
+  if (!action) throw new Error(`no action found for ${capabilityId}${label ? ` (${label})` : ""}`);
+  return action;
+}
+
+beforeEach(() => {
+  deleteResourceMock.mockReset();
+  rolloutRestartMock.mockReset();
+  cordonNodeMock.mockReset();
+  drainNodeMock.mockReset();
+  cronjobSetSuspendMock.mockReset();
+  cronjobTriggerNowMock.mockReset();
+  createNodeDebugPodMock.mockReset();
+  deletePodMock.mockReset();
+  evictPodMock.mockReset();
+});
 
 describe("paletteActions", () => {
   it("exposes actions with non-empty capability ids and labels", () => {
@@ -9,6 +74,7 @@ describe("paletteActions", () => {
       expect(a.label.length).toBeGreaterThan(0);
     }
   });
+
   it("filters actions applicable to a kind", () => {
     const forDeploy = actionsForKind("deployments").map((a) => a.capabilityId);
     expect(forDeploy).toContain("k8s.scale");
@@ -16,7 +82,104 @@ describe("paletteActions", () => {
     const forCm = actionsForKind("configmaps").map((a) => a.capabilityId);
     expect(forCm).not.toContain("k8s.scale");
   });
+
+  it("returns no actions for UI-only pseudo-kinds", () => {
+    expect(actionsForKind("settings")).toEqual([]);
+  });
+
   it("reports its covered capability ids", () => {
-    expect(paletteActionCapabilityIds().has("k8s.deleteResource")).toBe(true);
+    const ids = paletteActionCapabilityIds();
+    expect(ids.has("k8s.deleteResource")).toBe(true);
+    expect(ids.has("k8s.scale")).toBe(true);
+    expect(ids.has("k8s.debugPod")).toBe(true);
+  });
+
+  it("marks scale as dialog-based with no run", () => {
+    const scale = actionByCapability("k8s.scale");
+    expect(scale.opensDialog).toBe("scale");
+    expect(scale.run).toBeUndefined();
+  });
+
+  it("marks debug pod as dialog-based with no run", () => {
+    const debug = actionByCapability("k8s.debugPod");
+    expect(debug.opensDialog).toBe("debug");
+    expect(debug.run).toBeUndefined();
+  });
+
+  it("deletes a resource, converting kind via K8S_KIND and passing namespace through as-is", async () => {
+    deleteResourceMock.mockResolvedValue({ ok: true });
+    const del = actionByCapability("k8s.deleteResource");
+    await del.run!(ctx({ kind: "deployments", namespace: null, name: "web" }));
+    expect(deleteResourceMock).toHaveBeenCalledWith("kind-dev", "Deployment", null, "web");
+  });
+
+  it("triggers a rollout restart with the converted kind and namespace", async () => {
+    rolloutRestartMock.mockResolvedValue({ ok: true });
+    const restart = actionByCapability("k8s.rolloutRestart");
+    await restart.run!(ctx({ kind: "statefulsets", namespace: "prod", name: "web" }));
+    expect(rolloutRestartMock).toHaveBeenCalledWith("kind-dev", "StatefulSet", "prod", "web");
+  });
+
+  it("cordons a node", async () => {
+    cordonNodeMock.mockResolvedValue({ ok: true });
+    const cordon = actionByCapability("k8s.cordonNode", "Cordon node");
+    await cordon.run!(ctx({ kind: "nodes", namespace: null, name: "node-a" }));
+    expect(cordonNodeMock).toHaveBeenCalledWith("kind-dev", "node-a", true);
+  });
+
+  it("uncordons a node", async () => {
+    cordonNodeMock.mockResolvedValue({ ok: true });
+    const uncordon = actionByCapability("k8s.cordonNode", "Uncordon node");
+    await uncordon.run!(ctx({ kind: "nodes", namespace: null, name: "node-a" }));
+    expect(cordonNodeMock).toHaveBeenCalledWith("kind-dev", "node-a", false);
+  });
+
+  it("suspends a cronjob", async () => {
+    cronjobSetSuspendMock.mockResolvedValue({ ok: true });
+    const suspend = actionByCapability("k8s.cronjobSetSuspend", "Suspend CronJob");
+    await suspend.run!(ctx({ kind: "cronjobs", namespace: "ops", name: "nightly" }));
+    expect(cronjobSetSuspendMock).toHaveBeenCalledWith("kind-dev", "ops", "nightly", true);
+  });
+
+  it("resumes a cronjob", async () => {
+    cronjobSetSuspendMock.mockResolvedValue({ ok: true });
+    const resume = actionByCapability("k8s.cronjobSetSuspend", "Resume CronJob");
+    await resume.run!(ctx({ kind: "cronjobs", namespace: "ops", name: "nightly" }));
+    expect(cronjobSetSuspendMock).toHaveBeenCalledWith("kind-dev", "ops", "nightly", false);
+  });
+
+  it("triggers a cronjob run now", async () => {
+    cronjobTriggerNowMock.mockResolvedValue({ jobName: "nightly-123" });
+    const runNow = actionByCapability("k8s.cronjobTriggerNow");
+    await runNow.run!(ctx({ kind: "cronjobs", namespace: "ops", name: "nightly" }));
+    expect(cronjobTriggerNowMock).toHaveBeenCalledWith("kind-dev", "ops", "nightly");
+  });
+
+  it("evicts a pod", async () => {
+    evictPodMock.mockResolvedValue({ ok: true });
+    const evict = actionByCapability("k8s.evictPod");
+    await evict.run!(ctx({ kind: "pods", namespace: "default", name: "web-1" }));
+    expect(evictPodMock).toHaveBeenCalledWith("kind-dev", "default", "web-1");
+  });
+
+  it("force deletes a pod", async () => {
+    deletePodMock.mockResolvedValue({ deleted: true });
+    const del = actionByCapability("k8s.deletePod");
+    await del.run!(ctx({ kind: "pods", namespace: "default", name: "web-1" }));
+    expect(deletePodMock).toHaveBeenCalledWith("kind-dev", "default", "web-1");
+  });
+
+  it("drains a node", async () => {
+    drainNodeMock.mockResolvedValue({ evicted: 3, skipped: 0 });
+    const drain = actionByCapability("k8s.drainNode");
+    await drain.run!(ctx({ kind: "nodes", namespace: null, name: "node-a" }));
+    expect(drainNodeMock).toHaveBeenCalledWith("kind-dev", "node-a");
+  });
+
+  it("creates a node debug pod", async () => {
+    createNodeDebugPodMock.mockResolvedValue({ namespace: "kube-system", pod: "node-debugger-abc" });
+    const debugNode = actionByCapability("k8s.createNodeDebugPod");
+    await debugNode.run!(ctx({ kind: "nodes", namespace: null, name: "node-a" }));
+    expect(createNodeDebugPodMock).toHaveBeenCalledWith("kind-dev", "node-a");
   });
 });

--- a/apps/desktop/src/lib/paletteActions.test.ts
+++ b/apps/desktop/src/lib/paletteActions.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { PALETTE_ACTIONS, actionsForKind, paletteActionCapabilityIds } from "./paletteActions";
+
+describe("paletteActions", () => {
+  it("exposes actions with non-empty capability ids and labels", () => {
+    expect(PALETTE_ACTIONS.length).toBeGreaterThan(0);
+    for (const a of PALETTE_ACTIONS) {
+      expect(a.capabilityId).toMatch(/^[a-z0-9]+\./);
+      expect(a.label.length).toBeGreaterThan(0);
+    }
+  });
+  it("filters actions applicable to a kind", () => {
+    const forDeploy = actionsForKind("deployments").map((a) => a.capabilityId);
+    expect(forDeploy).toContain("k8s.scale");
+    expect(forDeploy).toContain("k8s.rolloutRestart");
+    const forCm = actionsForKind("configmaps").map((a) => a.capabilityId);
+    expect(forCm).not.toContain("k8s.scale");
+  });
+  it("reports its covered capability ids", () => {
+    expect(paletteActionCapabilityIds().has("k8s.deleteResource")).toBe(true);
+  });
+});

--- a/apps/desktop/src/lib/paletteActions.ts
+++ b/apps/desktop/src/lib/paletteActions.ts
@@ -1,0 +1,167 @@
+import { K8S_KIND, type ResourceKind } from "../components/ResourceBrowser";
+import {
+  deleteResource,
+  scaleResource,
+  rolloutRestart,
+  cordonNode,
+  drainNode,
+  cronjobSetSuspend,
+  cronjobTriggerNow,
+  debugPod,
+  createNodeDebugPod,
+} from "./actions";
+import { deletePod, evictPod } from "./workloads";
+
+/** Target resource a palette action runs against. */
+export interface PaletteActionCtx {
+  context: string;
+  kind: ResourceKind;
+  namespace: string | null;
+  name: string;
+}
+
+/** One entry in the palette's action registry. */
+export interface PaletteAction {
+  /** Backend capability id this action invokes (see capability-catalog.json). */
+  capabilityId: string;
+  label: string;
+  /** Resource kinds this action applies to, or "*" for every kind. */
+  kinds: ResourceKind[] | "*";
+  destructive?: boolean;
+  run: (c: PaletteActionCtx) => Promise<{ error?: string }> | { error?: string } | void;
+}
+
+/** Convert a palette `ResourceKind` to the API kind string `lib/actions.ts` expects. */
+function kindToK8s(kind: ResourceKind): string {
+  return K8S_KIND[kind];
+}
+
+// Same grouping as SCALABLE/RESTARTABLE in DetailActions.tsx, expressed as
+// ResourceKind rather than API-kind strings so they can key the registry.
+const SCALABLE_KINDS: ResourceKind[] = ["deployments", "statefulsets", "replicasets"];
+const RESTARTABLE_KINDS: ResourceKind[] = ["deployments", "statefulsets", "daemonsets"];
+
+/**
+ * Registry of resource-targeted mutating actions, one entry per
+ * (capability, verb) pair. Covers every non-read-only, single-resource
+ * capability in the catalog except: manifest editing (`k8s.applyManifest`),
+ * ConfigMap/Secret data edits (`k8s.updateConfigData`, drawer-only — needs a
+ * key/value patch beyond a bare resource ref), context management
+ * (`k8s.deleteContext`), and Helm/toolbox operations (their own release- or
+ * plugin-scoped flows, not a single ResourceKind target). Task 3's audit
+ * tracks those exclusions explicitly.
+ */
+export const PALETTE_ACTIONS: PaletteAction[] = [
+  {
+    capabilityId: "k8s.scale",
+    label: "Scale…",
+    kinds: SCALABLE_KINDS,
+    run: (c) => {
+      const input = typeof window !== "undefined" ? window.prompt(`Scale ${c.name} to how many replicas?`) : null;
+      if (input === null) return;
+      const replicas = Number(input);
+      if (!Number.isInteger(replicas) || replicas < 0) return { error: "Enter a non-negative replica count" };
+      return scaleResource(c.context, kindToK8s(c.kind), c.namespace ?? "", c.name, replicas);
+    },
+  },
+  {
+    capabilityId: "k8s.rolloutRestart",
+    label: "Rollout restart",
+    kinds: RESTARTABLE_KINDS,
+    run: (c) => rolloutRestart(c.context, kindToK8s(c.kind), c.namespace ?? "", c.name),
+  },
+  {
+    capabilityId: "k8s.deleteResource",
+    label: "Delete",
+    kinds: "*",
+    destructive: true,
+    run: (c) => deleteResource(c.context, kindToK8s(c.kind), c.namespace, c.name),
+  },
+  {
+    capabilityId: "k8s.deletePod",
+    label: "Force delete pod",
+    kinds: ["pods"],
+    destructive: true,
+    run: (c) => deletePod(c.context, c.namespace ?? "", c.name),
+  },
+  {
+    capabilityId: "k8s.evictPod",
+    label: "Evict pod",
+    kinds: ["pods"],
+    destructive: true,
+    run: (c) => evictPod(c.context, c.namespace ?? "", c.name),
+  },
+  {
+    capabilityId: "k8s.debugPod",
+    label: "Debug (ephemeral container)",
+    kinds: ["pods"],
+    destructive: true,
+    run: async (c) => {
+      const out = await debugPod(c.context, c.namespace ?? "", c.name, "busybox");
+      return out.error ? { error: out.error } : {};
+    },
+  },
+  {
+    capabilityId: "k8s.cordonNode",
+    label: "Cordon node",
+    kinds: ["nodes"],
+    run: (c) => cordonNode(c.context, c.name, true),
+  },
+  {
+    capabilityId: "k8s.cordonNode",
+    label: "Uncordon node",
+    kinds: ["nodes"],
+    run: (c) => cordonNode(c.context, c.name, false),
+  },
+  {
+    capabilityId: "k8s.drainNode",
+    label: "Drain node",
+    kinds: ["nodes"],
+    destructive: true,
+    run: async (c) => {
+      const out = await drainNode(c.context, c.name);
+      return out.error ? { error: out.error } : {};
+    },
+  },
+  {
+    capabilityId: "k8s.createNodeDebugPod",
+    label: "Debug node",
+    kinds: ["nodes"],
+    destructive: true,
+    run: async (c) => {
+      const out = await createNodeDebugPod(c.context, c.name);
+      return out.error ? { error: out.error } : {};
+    },
+  },
+  {
+    capabilityId: "k8s.cronjobSetSuspend",
+    label: "Suspend CronJob",
+    kinds: ["cronjobs"],
+    run: (c) => cronjobSetSuspend(c.context, c.namespace ?? "", c.name, true),
+  },
+  {
+    capabilityId: "k8s.cronjobSetSuspend",
+    label: "Resume CronJob",
+    kinds: ["cronjobs"],
+    run: (c) => cronjobSetSuspend(c.context, c.namespace ?? "", c.name, false),
+  },
+  {
+    capabilityId: "k8s.cronjobTriggerNow",
+    label: "Run now",
+    kinds: ["cronjobs"],
+    run: async (c) => {
+      const out = await cronjobTriggerNow(c.context, c.namespace ?? "", c.name);
+      return out.error ? { error: out.error } : {};
+    },
+  },
+];
+
+/** Actions applicable to a given resource kind, in registry order. */
+export function actionsForKind(kind: ResourceKind): PaletteAction[] {
+  return PALETTE_ACTIONS.filter((a) => a.kinds === "*" || a.kinds.includes(kind));
+}
+
+/** Distinct backend capability ids this registry covers. */
+export function paletteActionCapabilityIds(): Set<string> {
+  return new Set(PALETTE_ACTIONS.map((a) => a.capabilityId));
+}

--- a/apps/desktop/src/lib/paletteActions.ts
+++ b/apps/desktop/src/lib/paletteActions.ts
@@ -1,13 +1,11 @@
 import { K8S_KIND, type ResourceKind } from "../components/ResourceBrowser";
 import {
   deleteResource,
-  scaleResource,
   rolloutRestart,
   cordonNode,
   drainNode,
   cronjobSetSuspend,
   cronjobTriggerNow,
-  debugPod,
   createNodeDebugPod,
 } from "./actions";
 import { deletePod, evictPod } from "./workloads";
@@ -28,7 +26,16 @@ export interface PaletteAction {
   /** Resource kinds this action applies to, or "*" for every kind. */
   kinds: ResourceKind[] | "*";
   destructive?: boolean;
-  run: (c: PaletteActionCtx) => Promise<{ error?: string }> | { error?: string } | void;
+  /**
+   * Marks this action as needing extra input the palette can't collect
+   * inline (a replica count, a debug image). Rather than prompting via
+   * `window.prompt` or a hardcoded value, the palette (wired up in Task 4)
+   * opens the matching existing dialog — the scale dialog for "scale", the
+   * debug-container dialog for "debug" — and lets that dialog's own submit
+   * flow invoke the backend. Actions marked this way have no `run`.
+   */
+  opensDialog?: "scale" | "debug";
+  run?: (c: PaletteActionCtx) => Promise<{ error?: string }> | { error?: string } | void;
 }
 
 /** Convert a palette `ResourceKind` to the API kind string `lib/actions.ts` expects. */
@@ -56,13 +63,7 @@ export const PALETTE_ACTIONS: PaletteAction[] = [
     capabilityId: "k8s.scale",
     label: "Scale…",
     kinds: SCALABLE_KINDS,
-    run: (c) => {
-      const input = typeof window !== "undefined" ? window.prompt(`Scale ${c.name} to how many replicas?`) : null;
-      if (input === null) return;
-      const replicas = Number(input);
-      if (!Number.isInteger(replicas) || replicas < 0) return { error: "Enter a non-negative replica count" };
-      return scaleResource(c.context, kindToK8s(c.kind), c.namespace ?? "", c.name, replicas);
-    },
+    opensDialog: "scale",
   },
   {
     capabilityId: "k8s.rolloutRestart",
@@ -93,13 +94,10 @@ export const PALETTE_ACTIONS: PaletteAction[] = [
   },
   {
     capabilityId: "k8s.debugPod",
-    label: "Debug (ephemeral container)",
+    label: "Debug (ephemeral container)…",
     kinds: ["pods"],
     destructive: true,
-    run: async (c) => {
-      const out = await debugPod(c.context, c.namespace ?? "", c.name, "busybox");
-      return out.error ? { error: out.error } : {};
-    },
+    opensDialog: "debug",
   },
   {
     capabilityId: "k8s.cordonNode",
@@ -158,6 +156,9 @@ export const PALETTE_ACTIONS: PaletteAction[] = [
 
 /** Actions applicable to a given resource kind, in registry order. */
 export function actionsForKind(kind: ResourceKind): PaletteAction[] {
+  // UI-only pseudo-kinds (settings, toolbox, overview, …) have no API kind
+  // string and aren't a real resource a "*" action could target.
+  if (kindToK8s(kind) === "") return [];
   return PALETTE_ACTIONS.filter((a) => a.kinds === "*" || a.kinds.includes(kind));
 }
 

--- a/crates/capability/src/lib.rs
+++ b/crates/capability/src/lib.rs
@@ -96,6 +96,10 @@ impl Registry {
         self.caps.keys().map(String::as_str).collect()
     }
 
+    pub fn entries(&self) -> impl Iterator<Item = &Capability> {
+        self.caps.values()
+    }
+
     pub fn get(&self, id: &str) -> Option<&Capability> {
         self.caps.get(id)
     }

--- a/crates/registry/Cargo.toml
+++ b/crates/registry/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 [dependencies]
 srelens-capability = { path = "../capability" }
 srelens-kube = { path = "../kube" }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Blocking HTTP for toolbox downloads (run inside spawn_blocking). rustls with
 # NO auto crypto-provider: the workspace standardises on ring via kube-client;

--- a/crates/registry/src/catalog.rs
+++ b/crates/registry/src/catalog.rs
@@ -1,0 +1,28 @@
+//! The capability catalog: a stable, serializable projection of the registry
+//! (id + the annotation flags the frontend palette audit needs). Emitted to a
+//! committed JSON so a Vitest test can cross-check the palette without linking
+//! Rust. Kept in sync by a test in `lib.rs`.
+use serde::Serialize;
+use srelens_capability::Registry;
+
+#[derive(Serialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "camelCase")]
+pub struct CatalogEntry {
+    pub id: String,
+    pub read_only: bool,
+    pub destructive: bool,
+}
+
+/// Project a registry into a sorted catalog for the frontend bridge.
+pub fn catalog_of(reg: &Registry) -> Vec<CatalogEntry> {
+    let mut out: Vec<CatalogEntry> = reg
+        .entries()
+        .map(|c| CatalogEntry {
+            id: c.id.clone(),
+            read_only: c.annotations.read_only,
+            destructive: c.annotations.destructive,
+        })
+        .collect();
+    out.sort();
+    out
+}

--- a/crates/registry/src/lib.rs
+++ b/crates/registry/src/lib.rs
@@ -11,6 +11,16 @@ use serde_json::json;
 use srelens_capability::{Capability, Registry};
 use srelens_kube::client_cache::ClientCache;
 
+mod catalog;
+pub use catalog::{catalog_of, CatalogEntry};
+
+/// Sorted id + annotation-flag projection of the live registry, emitted to a
+/// committed JSON so the frontend palette audit can cross-check it without
+/// linking Rust. See `capability_catalog_json_is_in_sync`.
+pub fn capability_catalog() -> Vec<CatalogEntry> {
+    catalog_of(&build_registry())
+}
+
 /// Resolve kubeconfig paths: every `$KUBECONFIG` entry, else `$HOME/.kube/config`.
 pub fn default_kubeconfig_paths() -> Vec<PathBuf> {
     if let Some(value) = std::env::var_os("KUBECONFIG") {
@@ -378,5 +388,19 @@ mod tests {
         let mut default_ids = default_reg.ids();
         default_ids.sort();
         assert_eq!(ids, default_ids, "same capabilities regardless of paths");
+    }
+
+    #[test]
+    fn capability_catalog_json_is_in_sync() {
+        // The committed JSON is the bridge to the frontend palette audit. It MUST
+        // equal the live registry; regenerate with `UPDATE_CATALOG=1 cargo test`.
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../apps/desktop/src/lib/capability-catalog.json");
+        let want = serde_json::to_string_pretty(&capability_catalog()).unwrap() + "\n";
+        if std::env::var("UPDATE_CATALOG").is_ok() {
+            std::fs::write(path, &want).unwrap();
+            return;
+        }
+        let got = std::fs::read_to_string(path).unwrap_or_default();
+        assert_eq!(got, want, "capability-catalog.json is stale — run UPDATE_CATALOG=1 cargo test -p srelens-registry");
     }
 }


### PR DESCRIPTION
Closes #22.

Turns the Cmd/Ctrl-K palette into a two-step action surface (find a resource → drill in → act), backed by a CI audit that fails when a new mutating capability isn't reachable.

## What's in it
- **Capability catalog bridge** — `crates/registry` emits + verifies (via a `cargo test`) `apps/desktop/src/lib/capability-catalog.json` (id + `readOnly`/`destructive` per capability). The single Rust→TS source of truth for the audit.
- **Action registry** (`lib/paletteActions.ts`) — typed map from each resource-targeted action to its capability id, applicable kinds, and a handler reusing `lib/actions.ts`. Input-needing actions (scale/debug) declare `opensDialog` and hand off to the resource's detail drawer instead of faking input.
- **Coverage audit** (`paletteActions.audit.test.ts`) — every non-read-only capability must be palette-registered or in a justified `EXCLUDED` list; **fails CI on a gap** (and on a stale exclusion). Both the Rust sync test and the Vitest audit run in CI.
- **Two-step palette UX** — select a resource → "Actions for `<name>`" (+ Open details + Back); destructive actions confirm via the shared `ConfirmDialog`; errors surface via `notify`; a post-action hook refreshes the current view.
- **Ranking + jump** — a "Quick: `<kind>`" group hoists the current view's recents; kind-aware jump (`pod ng`, `svc web`, kubectl-style aliases) narrows before name-filtering.

## Tests
Rust catalog sync gate; `paletteActions` registry + audit; `CommandPalette` interaction tests (drill-in, dispatch, opensDialog handoff, destructive-confirm, error surfacing, ranking, kind-jump). Full frontend suite **695/695**, `tsc` clean.

## Built via subagent-driven development
5 tasks, each with an independent per-task review (spec + quality), plus a clean whole-branch final review. No AI attribution in any commit.

## Known follow-up (not blocking)
Kind-aware jump currently indexes **all namespaces**, not "selected namespaces" (#22's ideal) — the palette has no clean selected-namespaces input today. Tracked as follow-up. Minor UX polish also noted (bare alias token lists a whole kind; action list stays mounted under the confirm dialog).