### PR TITLE
feat(forward): resilient port-forwards + saved forwards

### DIFF
--- a/apps/desktop/src/components/ForwardDialog.test.tsx
+++ b/apps/desktop/src/components/ForwardDialog.test.tsx
@@ -2,12 +2,19 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import React from "react";
 
-const { startPortForwardMock } = vi.hoisted(() => ({ startPortForwardMock: vi.fn() }));
+const { startPortForwardMock, saveForwardMock } = vi.hoisted(() => ({
+  startPortForwardMock: vi.fn(),
+  saveForwardMock: vi.fn(),
+}));
 vi.mock("../lib/forward", () => ({ startPortForward: startPortForwardMock }));
+vi.mock("../lib/savedForwards", () => ({ saveForward: saveForwardMock }));
 
 import { ForwardDialog } from "./ForwardDialog";
 
-beforeEach(() => startPortForwardMock.mockReset());
+beforeEach(() => {
+  startPortForwardMock.mockReset();
+  saveForwardMock.mockReset();
+});
 
 const base = { context: "kind-dev", namespace: "default", kind: "Pod", name: "web-1" };
 
@@ -54,5 +61,57 @@ describe("ForwardDialog", () => {
 
     expect(screen.getByText(/between 1 and 65535/)).toBeDefined();
     expect(startPortForwardMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the backend's suggested port on a conflict and retries on it", async () => {
+    startPortForwardMock.mockRejectedValueOnce(
+      new Error("port 8080 is already in use; 54321 is free"),
+    );
+    startPortForwardMock.mockResolvedValueOnce({ id: 1, localPort: 54321 });
+    const onClose = vi.fn();
+    render(<ForwardDialog {...base} defaultRemotePort={80} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Forward" }));
+    await waitFor(() => expect(startPortForwardMock).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText(/54321 is free/)).toBeDefined();
+
+    fireEvent.click(screen.getByRole("button", { name: "Use port 54321" }));
+    await waitFor(() =>
+      expect(startPortForwardMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({ remotePort: 80, localPort: 54321 }),
+      ),
+    );
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it("does not show a suggestion for a non-conflict error", async () => {
+    startPortForwardMock.mockRejectedValueOnce(new Error("cluster unreachable"));
+    render(<ForwardDialog {...base} defaultRemotePort={80} onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Forward" }));
+    expect(await screen.findByText(/cluster unreachable/)).toBeDefined();
+    expect(screen.queryByRole("button", { name: /Use port/ })).toBeNull();
+  });
+
+  it("saves the current target as a shortcut without starting it", async () => {
+    saveForwardMock.mockResolvedValueOnce(undefined);
+    render(<ForwardDialog {...base} defaultRemotePort={80} onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Save this forward" }));
+
+    await waitFor(() =>
+      expect(saveForwardMock).toHaveBeenCalledWith(
+        "kind-dev",
+        expect.objectContaining({
+          namespace: "default",
+          kind: "Pod",
+          target: "web-1",
+          remotePort: 80,
+          localPort: undefined,
+        }),
+      ),
+    );
+    expect(startPortForwardMock).not.toHaveBeenCalled();
+    expect(await screen.findByRole("button", { name: "Saved" })).toBeDefined();
   });
 });

--- a/apps/desktop/src/components/ForwardDialog.tsx
+++ b/apps/desktop/src/components/ForwardDialog.tsx
@@ -1,10 +1,19 @@
 import React, { useState } from "react";
-import { ConfirmDialog, TextInput } from "../ui";
+import { ConfirmDialog, TextInput, Button } from "../ui";
 import { startPortForward } from "../lib/forward";
+import { saveForward } from "../lib/savedForwards";
 
 function validPort(v: string): number | null {
   const n = Number(v);
   return Number.isInteger(n) && n >= 1 && n <= 65535 ? n : null;
+}
+
+/** Extract the backend-suggested free port from a local-port conflict error,
+ *  e.g. "port 8080 is already in use; 54321 is free" (see `BindError::InUse`
+ *  in crates/kube/src/forward.rs). Returns null for any other error. */
+function suggestedPortFrom(message: string): number | null {
+  const match = /(\d+)\s+is free\b/.exec(message);
+  return match ? Number(match[1]) : null;
 }
 
 /**
@@ -30,8 +39,49 @@ export function ForwardDialog({
   const [local, setLocal] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
+  const [suggestedPort, setSuggestedPort] = useState<number | null>(null);
+  const [saveState, setSaveState] = useState<"idle" | "busy" | "saved">("idle");
 
-  async function submit() {
+  /** Start the forward. `overrideLocalPort` (used by "use it" on a conflict
+   *  suggestion) wins over whatever is in the local-port field. */
+  async function start(overrideLocalPort?: number) {
+    const remotePort = validPort(remote);
+    if (remotePort === null) {
+      setError("Enter a remote port between 1 and 65535");
+      return;
+    }
+    let localPort: number | undefined = overrideLocalPort;
+    if (localPort === undefined && local.trim()) {
+      const l = validPort(local);
+      if (l === null) {
+        setError("Local port must be between 1 and 65535");
+        return;
+      }
+      localPort = l;
+    }
+    setBusy(true);
+    setError("");
+    setSuggestedPort(null);
+    try {
+      await startPortForward({ context, namespace, kind, name, remotePort, localPort });
+      onClose();
+    } catch (e) {
+      const message = String(e);
+      setError(message);
+      setSuggestedPort(suggestedPortFrom(message));
+      setBusy(false);
+    }
+  }
+
+  /** Retry the forward on the backend's suggested free local port. */
+  async function useSuggestedPort() {
+    if (suggestedPort === null) return;
+    setLocal(String(suggestedPort));
+    await start(suggestedPort);
+  }
+
+  /** Persist the current target as a reusable shortcut (doesn't start it). */
+  async function handleSave() {
     const remotePort = validPort(remote);
     if (remotePort === null) {
       setError("Enter a remote port between 1 and 65535");
@@ -46,14 +96,21 @@ export function ForwardDialog({
       }
       localPort = l;
     }
-    setBusy(true);
-    setError("");
+    setSaveState("busy");
     try {
-      await startPortForward({ context, namespace, kind, name, remotePort, localPort });
-      onClose();
+      await saveForward(context, {
+        id: crypto.randomUUID(),
+        name,
+        namespace,
+        kind,
+        target: name,
+        remotePort,
+        localPort,
+      });
+      setSaveState("saved");
     } catch (e) {
       setError(String(e));
-      setBusy(false);
+      setSaveState("idle");
     }
   }
 
@@ -96,12 +153,30 @@ export function ForwardDialog({
               </div>
             </label>
           </div>
-          {error && <p className="m-0 text-sm text-destructive">Error: {error}</p>}
+          <div>
+            <Button
+              variant="secondary"
+              disabled={saveState !== "idle"}
+              onClick={() => void handleSave()}
+            >
+              {saveState === "saved" ? "Saved" : "Save this forward"}
+            </Button>
+          </div>
+          {error && (
+            <div className="flex flex-col items-start gap-2">
+              <p className="m-0 text-sm text-destructive">Error: {error}</p>
+              {suggestedPort !== null && (
+                <Button variant="secondary" disabled={busy} onClick={() => void useSuggestedPort()}>
+                  Use port {suggestedPort}
+                </Button>
+              )}
+            </div>
+          )}
         </div>
       }
       confirmLabel="Forward"
       busy={busy}
-      onConfirm={() => void submit()}
+      onConfirm={() => void start()}
       onCancel={onClose}
     />
   );

--- a/apps/desktop/src/components/ForwardsIndicator.test.tsx
+++ b/apps/desktop/src/components/ForwardsIndicator.test.tsx
@@ -5,12 +5,15 @@ import React from "react";
 
 const { invokeCommandMock, onMock } = vi.hoisted(() => ({
   invokeCommandMock: vi.fn(),
-  onMock: vi.fn(() => () => {}),
+  onMock: vi.fn((_channel: string, _handler: (payload?: unknown) => void) => () => {}),
 }));
 vi.mock("../transport/transport", () => ({ invokeCommand: invokeCommandMock, on: onMock }));
 
 import { ForwardsIndicator } from "./ForwardsIndicator";
 import { startPortForward, stopPortForward, getForwards } from "../lib/forward";
+
+// Capture `forward:status:<id>` handlers so tests can fire status events.
+const statusHandlers = new Map<string, (payload: unknown) => void>();
 
 beforeEach(async () => {
   // Reset the module-level store between tests.
@@ -20,6 +23,11 @@ beforeEach(async () => {
   }
   invokeCommandMock.mockReset();
   onMock.mockClear();
+  statusHandlers.clear();
+  onMock.mockImplementation((channel: string, handler: (payload?: unknown) => void) => {
+    if (channel.startsWith("forward:status:")) statusHandlers.set(channel, handler);
+    return () => statusHandlers.delete(channel);
+  });
 });
 
 describe("ForwardsIndicator", () => {
@@ -73,5 +81,32 @@ describe("ForwardsIndicator", () => {
     render(<ForwardsIndicator />);
     await userEvent.click(screen.getByRole("button", { name: /active port forwards/ }));
     expect(await screen.findByText(`${window.location.origin}/pf/2/ → 80`)).toBeDefined();
+  });
+
+  it("reflects a reconnecting/failed status instead of always showing active", async () => {
+    invokeCommandMock.mockResolvedValueOnce({ id: 3, localPort: 5002 });
+    await act(async () => {
+      await startPortForward({
+        context: "kind-dev",
+        namespace: "default",
+        kind: "Pod",
+        name: "web-1",
+        remotePort: 80,
+      });
+    });
+
+    render(<ForwardsIndicator />);
+    await userEvent.click(screen.getByRole("button", { name: /active port forwards/ }));
+    expect(await screen.findByText("Active")).toBeDefined();
+
+    act(() => {
+      statusHandlers.get("forward:status:3")?.({ state: "reconnecting" });
+    });
+    expect(await screen.findByText("Reconnecting")).toBeDefined();
+
+    act(() => {
+      statusHandlers.get("forward:status:3")?.({ state: "failed" });
+    });
+    expect(await screen.findByText("Failed")).toBeDefined();
   });
 });

--- a/apps/desktop/src/components/ForwardsIndicator.tsx
+++ b/apps/desktop/src/components/ForwardsIndicator.tsx
@@ -1,6 +1,7 @@
 import React, { useSyncExternalStore } from "react";
 import { ArrowLeftRight, CircleStop, Copy } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
+import { StatusPill, type StatusKind } from "../ui";
 import {
   getForwards,
   subscribeForwards,
@@ -12,6 +13,28 @@ import {
 /** Subscribe to the active port-forwards store. */
 export function useForwards(): ActiveForward[] {
   return useSyncExternalStore(subscribeForwards, getForwards, getForwards);
+}
+
+const STATUS_KIND: Record<ActiveForward["status"], StatusKind> = {
+  active: "success",
+  reconnecting: "warning",
+  failed: "danger",
+};
+
+const STATUS_LABEL: Record<ActiveForward["status"], string> = {
+  active: "Active",
+  reconnecting: "Reconnecting",
+  failed: "Failed",
+};
+
+/** Colour/label for a forward's live status — shared by every view that
+ *  lists forwards, so reconnecting/failed forwards never read as active. */
+export function forwardStatusKind(status: ActiveForward["status"]): StatusKind {
+  return STATUS_KIND[status];
+}
+
+export function forwardStatusLabel(status: ActiveForward["status"]): string {
+  return STATUS_LABEL[status];
 }
 
 /**
@@ -47,6 +70,7 @@ export function ForwardsIndicator() {
                 <div className="truncate font-mono text-muted-foreground">
                   {forwardAddress(f)} → {f.remotePort}
                 </div>
+                <StatusPill status={forwardStatusLabel(f.status)} kind={forwardStatusKind(f.status)} />
               </div>
               <button
                 type="button"

--- a/apps/desktop/src/components/PortForwardsView.test.tsx
+++ b/apps/desktop/src/components/PortForwardsView.test.tsx
@@ -4,12 +4,26 @@ import React from "react";
 
 const { invokeCommandMock, onMock } = vi.hoisted(() => ({
   invokeCommandMock: vi.fn(),
-  onMock: vi.fn(() => () => {}),
+  onMock: vi.fn((_channel: string, _handler: (payload?: unknown) => void) => () => {}),
 }));
 vi.mock("../transport/transport", () => ({ invokeCommand: invokeCommandMock, on: onMock }));
 
+const { listSavedForwardsMock, saveForwardMock, deleteSavedForwardMock } = vi.hoisted(() => ({
+  listSavedForwardsMock: vi.fn(),
+  saveForwardMock: vi.fn(),
+  deleteSavedForwardMock: vi.fn(),
+}));
+vi.mock("../lib/savedForwards", () => ({
+  listSavedForwards: listSavedForwardsMock,
+  saveForward: saveForwardMock,
+  deleteSavedForward: deleteSavedForwardMock,
+}));
+
 import { PortForwardsView } from "./PortForwardsView";
 import { startPortForward, stopPortForward, getForwards } from "../lib/forward";
+
+// Capture `forward:status:<id>` handlers so tests can fire status events.
+const statusHandlers = new Map<string, (payload: unknown) => void>();
 
 beforeEach(async () => {
   for (const f of [...getForwards()]) {
@@ -18,6 +32,14 @@ beforeEach(async () => {
   }
   invokeCommandMock.mockReset();
   onMock.mockClear();
+  statusHandlers.clear();
+  onMock.mockImplementation((channel: string, handler: (payload?: unknown) => void) => {
+    if (channel.startsWith("forward:status:")) statusHandlers.set(channel, handler);
+    return () => statusHandlers.delete(channel);
+  });
+  listSavedForwardsMock.mockReset().mockResolvedValue([]);
+  saveForwardMock.mockReset();
+  deleteSavedForwardMock.mockReset().mockResolvedValue(undefined);
 });
 
 describe("PortForwardsView", () => {
@@ -70,5 +92,81 @@ describe("PortForwardsView", () => {
 
     render(<PortForwardsView context="kind-dev" />);
     expect(screen.getByText(`${window.location.origin}/pf/2/`)).toBeDefined();
+  });
+
+  it("shows a reconnecting/failed active forward's status", async () => {
+    invokeCommandMock.mockResolvedValueOnce({ id: 7, localPort: 5010 });
+    await act(async () => {
+      await startPortForward({
+        context: "kind-dev",
+        namespace: "default",
+        kind: "Service",
+        name: "web",
+        remotePort: 80,
+      });
+    });
+
+    render(<PortForwardsView context="kind-dev" />);
+    expect(screen.getByText("Active")).toBeDefined();
+
+    act(() => {
+      statusHandlers.get("forward:status:7")?.({ state: "reconnecting" });
+    });
+    expect(await screen.findByText("Reconnecting")).toBeDefined();
+  });
+
+  describe("saved forwards", () => {
+    const sf = {
+      id: "sf-1",
+      name: "web console",
+      namespace: "default",
+      kind: "Service",
+      target: "web",
+      remotePort: 80,
+      localPort: 8080,
+    };
+
+    it("lists saved forwards for the context", async () => {
+      listSavedForwardsMock.mockResolvedValue([sf]);
+      render(<PortForwardsView context="kind-dev" />);
+
+      expect(await screen.findByText("web console")).toBeDefined();
+      expect(screen.getByText("web")).toBeDefined();
+      expect(listSavedForwardsMock).toHaveBeenCalledWith("kind-dev");
+    });
+
+    it("does not list saved forwards without a context", () => {
+      render(<PortForwardsView />);
+      expect(listSavedForwardsMock).not.toHaveBeenCalled();
+    });
+
+    it("Start on a saved row calls startPortForward with the saved target", async () => {
+      listSavedForwardsMock.mockResolvedValue([sf]);
+      invokeCommandMock.mockResolvedValueOnce({ id: 8, localPort: 8080 });
+      render(<PortForwardsView context="kind-dev" />);
+
+      fireEvent.click(await screen.findByRole("button", { name: "Start" }));
+
+      await waitFor(() =>
+        expect(invokeCommandMock).toHaveBeenCalledWith("start_port_forward", {
+          context: "kind-dev",
+          namespace: "default",
+          kind: "Service",
+          name: "web",
+          remotePort: 80,
+          localPort: 8080,
+        }),
+      );
+    });
+
+    it("Delete removes a saved row via deleteSavedForward", async () => {
+      listSavedForwardsMock.mockResolvedValueOnce([sf]).mockResolvedValueOnce([]);
+      render(<PortForwardsView context="kind-dev" />);
+
+      fireEvent.click(await screen.findByRole("button", { name: "Delete" }));
+
+      await waitFor(() => expect(deleteSavedForwardMock).toHaveBeenCalledWith("kind-dev", "sf-1"));
+      await waitFor(() => expect(screen.queryByText("web console")).toBeNull());
+    });
   });
 });

--- a/apps/desktop/src/components/PortForwardsView.test.tsx
+++ b/apps/desktop/src/components/PortForwardsView.test.tsx
@@ -159,6 +159,20 @@ describe("PortForwardsView", () => {
       );
     });
 
+    it("surfaces an error when starting a saved forward fails (not silent)", async () => {
+      listSavedForwardsMock.mockResolvedValue([sf]);
+      invokeCommandMock.mockRejectedValueOnce(
+        new Error("port 8080 is already in use; 8081 is free"),
+      );
+      render(<PortForwardsView context="kind-dev" />);
+
+      fireEvent.click(await screen.findByRole("button", { name: "Start" }));
+
+      const alert = await screen.findByRole("alert");
+      expect(alert.textContent).toContain("web console");
+      expect(alert.textContent).toContain("8080 is already in use");
+    });
+
     it("Delete removes a saved row via deleteSavedForward", async () => {
       listSavedForwardsMock.mockResolvedValueOnce([sf]).mockResolvedValueOnce([]);
       render(<PortForwardsView context="kind-dev" />);

--- a/apps/desktop/src/components/PortForwardsView.tsx
+++ b/apps/desktop/src/components/PortForwardsView.tsx
@@ -1,8 +1,15 @@
-import React from "react";
-import { CircleStop, Copy } from "lucide-react";
-import { Table, Badge, Button, ColumnPicker, useColumnVisibility, type Column } from "../ui";
-import { useForwards } from "./ForwardsIndicator";
-import { stopPortForward, forwardUrl, forwardAddress, type ActiveForward } from "../lib/forward";
+import React, { useCallback, useEffect, useState } from "react";
+import { CircleStop, Copy, Play, Trash2 } from "lucide-react";
+import { Table, Badge, Button, ColumnPicker, StatusPill, useColumnVisibility, type Column } from "../ui";
+import { useForwards, forwardStatusKind, forwardStatusLabel } from "./ForwardsIndicator";
+import {
+  startPortForward,
+  stopPortForward,
+  forwardUrl,
+  forwardAddress,
+  type ActiveForward,
+} from "../lib/forward";
+import { listSavedForwards, deleteSavedForward, type SavedForward } from "../lib/savedForwards";
 
 /**
  * Network overview of every active port-forward across all connected clusters.
@@ -46,6 +53,11 @@ export function PortForwardsView({ context }: { context?: string }) {
     },
     { key: "remote", header: "Remote", render: (f) => <span className="fl-mono">{f.remotePort}</span> },
     {
+      key: "status",
+      header: "Status",
+      render: (f) => <StatusPill status={forwardStatusLabel(f.status)} kind={forwardStatusKind(f.status)} />,
+    },
+    {
       key: "actions",
       header: "",
       render: (f) => (
@@ -71,6 +83,72 @@ export function PortForwardsView({ context }: { context?: string }) {
     columns,
   );
 
+  const [saved, setSaved] = useState<SavedForward[]>([]);
+  const [startingId, setStartingId] = useState<string | null>(null);
+
+  const refreshSaved = useCallback(() => {
+    if (!context) {
+      setSaved([]);
+      return;
+    }
+    void listSavedForwards(context).then(setSaved);
+  }, [context]);
+
+  useEffect(() => {
+    refreshSaved();
+  }, [refreshSaved]);
+
+  async function handleStartSaved(sf: SavedForward) {
+    if (!context) return;
+    setStartingId(sf.id);
+    try {
+      await startPortForward({
+        context,
+        namespace: sf.namespace,
+        kind: sf.kind,
+        name: sf.target,
+        remotePort: sf.remotePort,
+        localPort: sf.localPort,
+      });
+    } finally {
+      setStartingId(null);
+    }
+  }
+
+  async function handleDeleteSaved(sf: SavedForward) {
+    if (!context) return;
+    await deleteSavedForward(context, sf.id);
+    refreshSaved();
+  }
+
+  const savedColumns: Column<SavedForward>[] = [
+    { key: "name", header: "Name", render: (sf) => <span className="fl-mono">{sf.name}</span> },
+    { key: "kind", header: "Kind", render: (sf) => <Badge variant="info">{sf.kind}</Badge> },
+    { key: "namespace", header: "Namespace", render: (sf) => sf.namespace || "—" },
+    { key: "target", header: "Target", render: (sf) => <span className="fl-mono">{sf.target}</span> },
+    { key: "remote", header: "Remote", render: (sf) => <span className="fl-mono">{sf.remotePort}</span> },
+    {
+      key: "actions",
+      header: "",
+      render: (sf) => (
+        <div className="flex justify-end gap-2">
+          <Button
+            variant="ghost"
+            disabled={startingId === sf.id}
+            onClick={() => void handleStartSaved(sf)}
+          >
+            <Play data-icon="inline-start" />
+            Start
+          </Button>
+          <Button variant="danger" onClick={() => void handleDeleteSaved(sf)}>
+            <Trash2 data-icon="inline-start" />
+            Delete
+          </Button>
+        </div>
+      ),
+    },
+  ];
+
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="flex shrink-0 items-center gap-2 border-b border-border px-3 py-2 text-sm">
@@ -90,6 +168,23 @@ export function PortForwardsView({ context }: { context?: string }) {
           <Table columns={visibleColumns} data={forwards} getRowKey={(f) => String(f.id)} />
         )}
       </div>
+      {context && (
+        <div className="flex max-h-64 shrink-0 flex-col border-t border-border">
+          <div className="flex shrink-0 items-center gap-2 px-3 py-2 text-sm">
+            <span className="font-medium">Saved</span>
+            <Badge variant="neutral">{saved.length}</Badge>
+          </div>
+          <div className="min-h-0 flex-1 overflow-auto">
+            {saved.length === 0 ? (
+              <div className="p-4 text-center text-sm text-muted-foreground">
+                No saved forwards for this cluster. Save one from the Forward dialog to reuse it later.
+              </div>
+            ) : (
+              <Table columns={savedColumns} data={saved} getRowKey={(sf) => sf.id} />
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/components/PortForwardsView.tsx
+++ b/apps/desktop/src/components/PortForwardsView.tsx
@@ -85,6 +85,7 @@ export function PortForwardsView({ context }: { context?: string }) {
 
   const [saved, setSaved] = useState<SavedForward[]>([]);
   const [startingId, setStartingId] = useState<string | null>(null);
+  const [savedError, setSavedError] = useState("");
 
   const refreshSaved = useCallback(() => {
     if (!context) {
@@ -101,6 +102,7 @@ export function PortForwardsView({ context }: { context?: string }) {
   async function handleStartSaved(sf: SavedForward) {
     if (!context) return;
     setStartingId(sf.id);
+    setSavedError("");
     try {
       await startPortForward({
         context,
@@ -110,6 +112,10 @@ export function PortForwardsView({ context }: { context?: string }) {
         remotePort: sf.remotePort,
         localPort: sf.localPort,
       });
+    } catch (e) {
+      // Surface the failure (e.g. the pinned local port is now taken, or the
+      // target is unreachable) instead of failing silently.
+      setSavedError(`Couldn't start ${sf.name}: ${e instanceof Error ? e.message : String(e)}`);
     } finally {
       setStartingId(null);
     }
@@ -174,6 +180,11 @@ export function PortForwardsView({ context }: { context?: string }) {
             <span className="font-medium">Saved</span>
             <Badge variant="neutral">{saved.length}</Badge>
           </div>
+          {savedError && (
+            <div role="alert" className="shrink-0 px-3 pb-2 text-xs text-destructive">
+              {savedError}
+            </div>
+          )}
           <div className="min-h-0 flex-1 overflow-auto">
             {saved.length === 0 ? (
               <div className="p-4 text-center text-sm text-muted-foreground">

--- a/apps/desktop/src/lib/forward.test.ts
+++ b/apps/desktop/src/lib/forward.test.ts
@@ -19,14 +19,21 @@ import {
   type ActiveForward,
 } from "./forward";
 
-// Capture the `forward:closed:<id>` handlers so tests can fire the event.
+// Capture the `forward:closed:<id>` / `forward:status:<id>` handlers so tests
+// can fire the events.
 const closedHandlers = new Map<string, () => void>();
+const statusHandlers = new Map<string, (payload: unknown) => void>();
 
 beforeEach(async () => {
   invokeCommandMock.mockReset();
   onMock.mockReset();
   closedHandlers.clear();
-  onMock.mockImplementation((channel: string, handler: () => void) => {
+  statusHandlers.clear();
+  onMock.mockImplementation((channel: string, handler: (payload?: unknown) => void) => {
+    if (channel.startsWith("forward:status:")) {
+      statusHandlers.set(channel, handler);
+      return () => statusHandlers.delete(channel);
+    }
     closedHandlers.set(channel, handler);
     return () => closedHandlers.delete(channel);
   });
@@ -91,9 +98,29 @@ describe("forward store", () => {
     expect(getForwards()).toHaveLength(0);
   });
 
+  it("defaults a new forward's status to active", async () => {
+    invokeCommandMock.mockResolvedValueOnce({ id: 5, localPort: 5002 });
+    const fwd = await startPortForward(req);
+    expect(fwd.status).toBe("active");
+    expect(getForwards()[0].status).toBe("active");
+  });
+
+  it("flips status to reconnecting when the backend emits forward:status", async () => {
+    const notify = vi.fn();
+    invokeCommandMock.mockResolvedValueOnce({ id: 6, localPort: 5003 });
+    await startPortForward(req);
+    const unsub = subscribeForwards(notify);
+
+    statusHandlers.get("forward:status:6")?.({ state: "reconnecting", attempt: 1, error: null });
+
+    expect(getForwards()[0].status).toBe("reconnecting");
+    expect(notify).toHaveBeenCalled();
+    unsub();
+  });
+
   it("passes a preferred local port through", async () => {
     invokeCommandMock.mockResolvedValueOnce({ id: 4, localPort: 8080 });
-    const withLocal: ActiveForward = { ...req, id: 0, localPort: 0 };
+    const withLocal: ActiveForward = { ...req, id: 0, localPort: 0, status: "active" };
     await startPortForward({ ...withLocal, localPort: 8080 });
     expect(invokeCommandMock).toHaveBeenCalledWith(
       "start_port_forward",

--- a/apps/desktop/src/lib/forward.ts
+++ b/apps/desktop/src/lib/forward.ts
@@ -11,6 +11,8 @@ export interface ActiveForward {
   name: string;
   remotePort: number;
   localPort: number;
+  /** Live state, driven by `forward:status:<id>` events from the backend. */
+  status: "active" | "reconnecting" | "failed";
 }
 
 export interface ForwardRequest {
@@ -54,12 +56,19 @@ export async function startPortForward(req: ForwardRequest): Promise<ActiveForwa
     remotePort: req.remotePort,
     localPort: req.localPort ?? null,
   });
-  const fwd: ActiveForward = { ...req, id: info.id, localPort: info.localPort };
+  const fwd: ActiveForward = { ...req, id: info.id, localPort: info.localPort, status: "active" };
   forwards = [...forwards, fwd];
-  closers.set(
-    info.id,
-    on(`forward:closed:${info.id}`, () => removeForward(info.id)),
-  );
+  const unsubClosed = on(`forward:closed:${info.id}`, () => removeForward(info.id));
+  const unsubStatus = on(`forward:status:${info.id}`, (payload) => {
+    const state = (payload as { state?: unknown } | null)?.state;
+    if (state === "active" || state === "reconnecting" || state === "failed") {
+      setForwardStatus(info.id, state);
+    }
+  });
+  closers.set(info.id, () => {
+    unsubClosed();
+    unsubStatus();
+  });
   emit();
   return fwd;
 }
@@ -84,6 +93,14 @@ export function forwardAddress(info: { id: number; localPort: number }): string 
   return isTauri()
     ? `localhost:${info.localPort}`
     : `${window.location.origin}/pf/${info.id}/`;
+}
+
+function setForwardStatus(id: number, status: ActiveForward["status"]) {
+  const next = forwards.map((f) => (f.id === id && f.status !== status ? { ...f, status } : f));
+  if (next.some((f, i) => f !== forwards[i])) {
+    forwards = next;
+    emit();
+  }
 }
 
 function removeForward(id: number) {

--- a/apps/desktop/src/lib/savedForwards.test.ts
+++ b/apps/desktop/src/lib/savedForwards.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// isWeb is true under jsdom (no __TAURI_INTERNALS__) by default; these tests
+// exercise the desktop (localStorage) branch, so flip the Tauri marker before
+// importing (isWeb is a module-level const captured at import time).
+function setDesktop(on: boolean) {
+  if (on) {
+    (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {};
+  } else {
+    delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__;
+  }
+}
+
+describe("savedForwards on desktop (localStorage)", () => {
+  afterEach(() => {
+    setDesktop(false);
+    vi.resetModules();
+    localStorage.clear();
+  });
+
+  it("round-trips save -> list -> delete", async () => {
+    setDesktop(true);
+    vi.resetModules();
+    const { listSavedForwards, saveForward, deleteSavedForward } = await import("./savedForwards");
+
+    expect(await listSavedForwards("kind-dev")).toEqual([]);
+
+    const sf = {
+      id: "sf-1",
+      name: "web console",
+      namespace: "default",
+      kind: "Service",
+      target: "web",
+      remotePort: 80,
+      localPort: 8080,
+    };
+    await saveForward("kind-dev", sf);
+    expect(await listSavedForwards("kind-dev")).toEqual([sf]);
+
+    await deleteSavedForward("kind-dev", "sf-1");
+    expect(await listSavedForwards("kind-dev")).toEqual([]);
+  });
+
+  it("upserts by id instead of duplicating", async () => {
+    setDesktop(true);
+    vi.resetModules();
+    const { listSavedForwards, saveForward } = await import("./savedForwards");
+
+    const sf = { id: "sf-1", name: "a", namespace: "default", kind: "Pod", target: "web-1", remotePort: 80 };
+    await saveForward("kind-dev", sf);
+    await saveForward("kind-dev", { ...sf, name: "renamed" });
+
+    const rows = await listSavedForwards("kind-dev");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].name).toBe("renamed");
+  });
+
+  it("isolates saved forwards per context", async () => {
+    setDesktop(true);
+    vi.resetModules();
+    const { listSavedForwards, saveForward } = await import("./savedForwards");
+
+    const sf = { id: "sf-1", name: "a", namespace: "default", kind: "Pod", target: "web-1", remotePort: 80 };
+    await saveForward("kind-dev", sf);
+
+    expect(await listSavedForwards("kind-dev")).toEqual([sf]);
+    expect(await listSavedForwards("kind-prod")).toEqual([]);
+  });
+
+  it("persists under a single localStorage key holding a per-context map", async () => {
+    setDesktop(true);
+    vi.resetModules();
+    const { saveForward } = await import("./savedForwards");
+
+    const sf = { id: "sf-1", name: "a", namespace: "default", kind: "Pod", target: "web-1", remotePort: 80 };
+    await saveForward("kind-dev", sf);
+
+    const raw = localStorage.getItem("srelens.savedForwards");
+    expect(raw).toBeTruthy();
+    expect(JSON.parse(raw as string)).toEqual({ "kind-dev": [sf] });
+  });
+
+  it("tolerates corrupt storage", async () => {
+    setDesktop(true);
+    localStorage.setItem("srelens.savedForwards", "{not json");
+    vi.resetModules();
+    const { listSavedForwards } = await import("./savedForwards");
+    expect(await listSavedForwards("kind-dev")).toEqual([]);
+  });
+});
+
+describe("savedForwards on web (settings API)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("GETs /api/settings/savedForwards:<context> and returns the stored array", async () => {
+    // isWeb is already true by default under jsdom in this describe block.
+    const { listSavedForwards } = await import("./savedForwards");
+    const sf = { id: "sf-1", name: "a", namespace: "default", kind: "Pod", target: "web-1", remotePort: 80 };
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ value: [sf] }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(await listSavedForwards("kind-dev")).toEqual([sf]);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(`/api/settings/${encodeURIComponent("savedForwards:kind-dev")}`);
+    expect(init.credentials).toBe("include");
+    expect(init.headers["X-Srelens-Csrf"]).toBeTruthy();
+  });
+
+  it("treats a null stored value as an empty list", async () => {
+    const { listSavedForwards } = await import("./savedForwards");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ value: null }), { status: 200 })));
+    expect(await listSavedForwards("kind-dev")).toEqual([]);
+  });
+
+  it("saveForward reads the current list, appends, and PUTs the whole array", async () => {
+    const { saveForward } = await import("./savedForwards");
+    const existing = { id: "sf-1", name: "a", namespace: "default", kind: "Pod", target: "web-1", remotePort: 80 };
+    const added = { id: "sf-2", name: "b", namespace: "default", kind: "Pod", target: "web-2", remotePort: 81 };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ value: [existing] }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await saveForward("kind-dev", added);
+
+    const [putUrl, putInit] = fetchMock.mock.calls[1];
+    expect(putUrl).toBe(`/api/settings/${encodeURIComponent("savedForwards:kind-dev")}`);
+    expect(putInit.method).toBe("PUT");
+    expect(putInit.headers["Content-Type"]).toBe("application/json");
+    expect(JSON.parse(putInit.body)).toEqual([existing, added]);
+  });
+
+  it("deleteSavedForward PUTs the array filtered by id", async () => {
+    const { deleteSavedForward } = await import("./savedForwards");
+    const keep = { id: "sf-1", name: "a", namespace: "default", kind: "Pod", target: "web-1", remotePort: 80 };
+    const drop = { id: "sf-2", name: "b", namespace: "default", kind: "Pod", target: "web-2", remotePort: 81 };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ value: [keep, drop] }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await deleteSavedForward("kind-dev", "sf-2");
+
+    const [, putInit] = fetchMock.mock.calls[1];
+    expect(JSON.parse(putInit.body)).toEqual([keep]);
+  });
+});

--- a/apps/desktop/src/lib/savedForwards.ts
+++ b/apps/desktop/src/lib/savedForwards.ts
@@ -1,0 +1,101 @@
+// Saved port-forwards: user-defined shortcuts to re-establish a forward
+// later, without re-picking the namespace/kind/target/port each time.
+// Persisted per kube-context. Web mode stores rows server-side, one row per
+// context, via the per-user settings API (`GET`/`PUT /api/settings/:key`,
+// see crates/server/src/api_settings.rs); desktop persists the equivalent
+// state in localStorage, following loadClusterNamespaces/saveClusterNamespaces.
+import { isWeb } from "../transport/platform";
+import { csrfHeader } from "../transport/webTransport";
+
+export interface SavedForward {
+  id: string;
+  name: string;
+  namespace: string;
+  kind: string;
+  target: string;
+  remotePort: number;
+  localPort?: number;
+}
+
+const STORAGE_KEY = "srelens.savedForwards";
+
+function settingsKey(context: string): string {
+  return `savedForwards:${context}`;
+}
+
+async function parseError(res: Response): Promise<never> {
+  const data = await res.json().catch(() => ({}));
+  throw new Error((data as { error?: string }).error ?? `request failed: ${res.status}`);
+}
+
+async function webList(context: string): Promise<SavedForward[]> {
+  const res = await fetch(`/api/settings/${encodeURIComponent(settingsKey(context))}`, {
+    credentials: "include",
+    headers: { ...csrfHeader() },
+  });
+  if (!res.ok) await parseError(res);
+  const data = (await res.json()) as { value: SavedForward[] | null };
+  return Array.isArray(data.value) ? data.value : [];
+}
+
+async function webPutAll(context: string, list: SavedForward[]): Promise<void> {
+  const res = await fetch(`/api/settings/${encodeURIComponent(settingsKey(context))}`, {
+    method: "PUT",
+    credentials: "include",
+    headers: { "Content-Type": "application/json", ...csrfHeader() },
+    body: JSON.stringify(list),
+  });
+  if (!res.ok) await parseError(res);
+}
+
+function loadAll(): Record<string, SavedForward[]> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as Record<string, SavedForward[]>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function saveAll(map: Record<string, SavedForward[]>): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    // ignore unavailable/quota-exceeded storage
+  }
+}
+
+/** Saved port-forward shortcuts for a kube-context. */
+export async function listSavedForwards(context: string): Promise<SavedForward[]> {
+  if (isWeb) return webList(context);
+  return loadAll()[context] ?? [];
+}
+
+/** Upsert a saved forward (matched by id) for a kube-context. */
+export async function saveForward(context: string, sf: SavedForward): Promise<void> {
+  if (isWeb) {
+    const current = await webList(context);
+    await webPutAll(context, [...current.filter((f) => f.id !== sf.id), sf]);
+    return;
+  }
+  const all = loadAll();
+  const current = all[context] ?? [];
+  all[context] = [...current.filter((f) => f.id !== sf.id), sf];
+  saveAll(all);
+}
+
+/** Remove a saved forward by id for a kube-context. */
+export async function deleteSavedForward(context: string, id: string): Promise<void> {
+  if (isWeb) {
+    const current = await webList(context);
+    await webPutAll(
+      context,
+      current.filter((f) => f.id !== id),
+    );
+    return;
+  }
+  const all = loadAll();
+  const current = all[context] ?? [];
+  all[context] = current.filter((f) => f.id !== id);
+  saveAll(all);
+}

--- a/crates/kube/src/forward.rs
+++ b/crates/kube/src/forward.rs
@@ -61,20 +61,30 @@ pub async fn bind_local(port: u16) -> Result<TcpListener, BindError> {
     }
 }
 
+/// Build the port-forward API client for a context/namespace. Split out from
+/// `serve_pod_forward` so callers (the reconnect loop) can tell "the session
+/// established" (this succeeded) apart from "the accept loop ended" (below).
+pub async fn connect_pod_api(
+    cache: Arc<ClientCache>,
+    context: &str,
+    namespace: &str,
+) -> Result<Api<Pod>, String> {
+    let client = cache.get(context).await?;
+    Ok(Api::namespaced(client, namespace))
+}
+
 /// Accept loop for a bound listener: every inbound local connection opens its
 /// own port-forward stream to `pod:remote_port` and is piped bidirectionally.
-/// Runs until the listener errors or the spawning task is aborted.
+/// Runs until the listener errors or the spawning task is aborted. Takes the
+/// listener by reference so a reconnect loop can keep the same bound local
+/// port across attempts and re-accept on it (`TcpListener::accept` only needs
+/// `&self`, so no re-bind is required).
 pub async fn serve_pod_forward(
-    listener: TcpListener,
-    cache: Arc<ClientCache>,
-    context: String,
-    namespace: String,
+    listener: &TcpListener,
+    api: Api<Pod>,
     pod: String,
     remote_port: u16,
 ) -> Result<(), String> {
-    let client = cache.get(&context).await?;
-    let api: Api<Pod> = Api::namespaced(client, &namespace);
-
     loop {
         let (mut local, _peer) = listener.accept().await.map_err(|e| e.to_string())?;
         let api = api.clone();

--- a/crates/kube/src/forward.rs
+++ b/crates/kube/src/forward.rs
@@ -75,11 +75,33 @@ pub async fn connect_pod_api(
 
 /// Accept loop for a bound listener: every inbound local connection opens its
 /// own port-forward stream to `pod:remote_port` and is piped bidirectionally.
-/// Runs until the listener errors or the spawning task is aborted. Takes the
-/// listener by reference so a reconnect loop can keep the same bound local
-/// port across attempts and re-accept on it (`TcpListener::accept` only needs
-/// `&self`, so no re-bind is required).
+/// Runs until the listener errors, the target pod monitor detects the pod is
+/// gone (see below), or the spawning task is aborted. Takes the listener by
+/// reference so a reconnect loop can keep the same bound local port across
+/// attempts and re-accept on it (`TcpListener::accept` only needs `&self`, so
+/// no re-bind is required).
+///
+/// Per-connection port-forward failures (e.g. a single `portforward` call
+/// failing) are swallowed inside the detached per-connection task and do not
+/// end the session by themselves — only the accept loop erroring or the
+/// target-pod monitor detecting pod loss does. This matters for Service
+/// targets: without the monitor, a deleted target pod would leave the accept
+/// loop parked in `listener.accept()` forever, so the outer reconnect loop
+/// (which re-resolves a Service to its current backing pod on every attempt)
+/// would never get a chance to run again.
 pub async fn serve_pod_forward(
+    listener: &TcpListener,
+    api: Api<Pod>,
+    pod: String,
+    remote_port: u16,
+) -> Result<(), String> {
+    tokio::select! {
+        res = accept_loop(listener, api.clone(), pod.clone(), remote_port) => res,
+        res = monitor_target_pod(api, pod) => res,
+    }
+}
+
+async fn accept_loop(
     listener: &TcpListener,
     api: Api<Pod>,
     pod: String,
@@ -99,6 +121,46 @@ pub async fn serve_pod_forward(
             }
         });
     }
+}
+
+/// How often the target-pod monitor polls the cluster for the forwarded
+/// pod's liveness.
+const POD_MONITOR_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// Poll `pod` on a short interval and return an error once it's gone (deleted
+/// or no longer `Running`), ending the `serve_pod_forward` session so the
+/// outer reconnect loop gets a chance to re-resolve (a Service target picks
+/// up its replacement pod). A transient API error while polling (e.g. a
+/// momentary network blip) is not treated as "gone" — only an authoritative
+/// answer from the API (not found, or an object that fails `pod_is_gone`)
+/// ends the session, so we don't tear down a healthy forward on a hiccup.
+///
+/// The first check is skipped by `POD_MONITOR_INTERVAL` (rather than firing
+/// immediately) since a freshly resolved target may still be transitioning
+/// into `Running` right as this session starts.
+async fn monitor_target_pod(api: Api<Pod>, pod: String) -> Result<(), String> {
+    let mut interval = tokio::time::interval_at(
+        tokio::time::Instant::now() + POD_MONITOR_INTERVAL,
+        POD_MONITOR_INTERVAL,
+    );
+    loop {
+        interval.tick().await;
+        match api.get_opt(&pod).await {
+            Ok(Some(p)) if !pod_is_gone(&p) => continue,
+            Ok(_) => return Err(format!("target pod {pod} is no longer available")),
+            Err(_) => continue,
+        }
+    }
+}
+
+/// Whether `pod` should be treated as no longer usable as a forward target:
+/// it's mid-deletion (`deletionTimestamp` set) or its phase isn't `Running`
+/// (e.g. `Failed`, `Succeeded`, or missing status entirely).
+pub fn pod_is_gone(pod: &Pod) -> bool {
+    if pod.metadata.deletion_timestamp.is_some() {
+        return true;
+    }
+    pod.status.as_ref().and_then(|s| s.phase.as_deref()) != Some("Running")
 }
 
 /// Resolve a Service to a concrete `(pod, container_port)` to forward to: pick
@@ -303,5 +365,43 @@ mod tests {
             Some("pending")
         );
         assert!(pick_ready_pod(&[]).is_none());
+    }
+
+    fn pod_with(phase: Option<&str>, deleted: bool) -> Pod {
+        let deletion_timestamp = deleted.then(|| {
+            k8s_openapi::apimachinery::pkg::apis::meta::v1::Time(k8s_openapi::chrono::Utc::now())
+        });
+        Pod {
+            metadata: kube::core::ObjectMeta {
+                deletion_timestamp,
+                ..Default::default()
+            },
+            status: Some(PodStatus {
+                phase: phase.map(String::from),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn pod_is_gone_true_when_running_but_marked_for_deletion() {
+        // A pod mid-termination is still (briefly) `Running` in status, but
+        // the deletionTimestamp means it's on its way out — treat it as gone
+        // so the forward doesn't keep serving through a terminating pod.
+        assert!(pod_is_gone(&pod_with(Some("Running"), true)));
+    }
+
+    #[test]
+    fn pod_is_gone_true_when_phase_is_not_running() {
+        assert!(pod_is_gone(&pod_with(Some("Pending"), false)));
+        assert!(pod_is_gone(&pod_with(Some("Failed"), false)));
+        assert!(pod_is_gone(&pod_with(Some("Succeeded"), false)));
+        assert!(pod_is_gone(&pod_with(None, false)));
+    }
+
+    #[test]
+    fn pod_is_gone_false_when_running_and_not_deleted() {
+        assert!(!pod_is_gone(&pod_with(Some("Running"), false)));
     }
 }

--- a/crates/kube/src/forward.rs
+++ b/crates/kube/src/forward.rs
@@ -163,6 +163,16 @@ pub fn pod_is_gone(pod: &Pod) -> bool {
     pod.status.as_ref().and_then(|s| s.phase.as_deref()) != Some("Running")
 }
 
+/// One-shot readiness probe: true only when the target pod currently exists and
+/// is Running (not terminating). A missing pod or an API error reads as
+/// not-ready. Used to decide whether a reconnect attempt actually *established*
+/// — building an `Api<Pod>` handle does no I/O and always "succeeds", so without
+/// this probe a permanently-dead target would reconnect forever and never reach
+/// the give-up threshold. Mirrors the monitor's own liveness check.
+pub async fn pod_is_ready(api: &Api<Pod>, pod: &str) -> bool {
+    matches!(api.get_opt(pod).await, Ok(Some(p)) if !pod_is_gone(&p))
+}
+
 /// Resolve a Service to a concrete `(pod, container_port)` to forward to: pick
 /// the matching service port, then the first ready pod behind its selector, and
 /// map the service's target port onto that pod.

--- a/crates/kube/src/forward.rs
+++ b/crates/kube/src/forward.rs
@@ -2,6 +2,8 @@
 //! each inbound connection through its own port-forward stream to a pod —
 //! Tauri-agnostic so the listener/stream plumbing stays reusable and testable.
 
+use std::fmt;
+use std::io::ErrorKind;
 use std::sync::Arc;
 
 use k8s_openapi::api::core::v1::{Pod, Service, ServicePort};
@@ -13,12 +15,50 @@ use tokio::net::TcpListener;
 
 use crate::client_cache::ClientCache;
 
+/// Why `bind_local` failed. `InUse` carries a `suggested` free port (found by
+/// binding `:0` once) so callers can offer it to the user instead of just
+/// failing outright.
+#[derive(Debug)]
+pub enum BindError {
+    InUse { requested: u16, suggested: u16 },
+    Io(String),
+}
+
+impl fmt::Display for BindError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BindError::InUse { requested, suggested } => write!(
+                f,
+                "port {requested} is already in use; {suggested} is free"
+            ),
+            BindError::Io(msg) => write!(f, "{msg}"),
+        }
+    }
+}
+
+impl std::error::Error for BindError {}
+
 /// Bind a loopback TCP listener. A `port` of 0 lets the OS pick a free port;
-/// read `local_addr()` on the returned listener for the chosen port.
-pub async fn bind_local(port: u16) -> Result<TcpListener, String> {
-    TcpListener::bind(("127.0.0.1", port))
-        .await
-        .map_err(|e| e.to_string())
+/// read `local_addr()` on the returned listener for the chosen port. If
+/// `port` is already taken, binds `:0` to find a free port to suggest and
+/// returns `BindError::InUse` with that suggestion.
+pub async fn bind_local(port: u16) -> Result<TcpListener, BindError> {
+    match TcpListener::bind(("127.0.0.1", port)).await {
+        Ok(listener) => Ok(listener),
+        Err(e) if e.kind() == ErrorKind::AddrInUse => {
+            let suggested = TcpListener::bind(("127.0.0.1", 0))
+                .await
+                .map_err(|e| BindError::Io(e.to_string()))?
+                .local_addr()
+                .map_err(|e| BindError::Io(e.to_string()))?
+                .port();
+            Err(BindError::InUse {
+                requested: port,
+                suggested,
+            })
+        }
+        Err(e) => Err(BindError::Io(e.to_string())),
+    }
 }
 
 /// Accept loop for a bound listener: every inbound local connection opens its
@@ -157,6 +197,20 @@ mod tests {
         let addr = listener.local_addr().expect("addr");
         assert!(addr.ip().is_loopback());
         assert!(addr.port() > 0);
+    }
+
+    #[tokio::test]
+    async fn bind_local_reports_conflict_with_a_free_suggestion() {
+        let taken = bind_local(0).await.unwrap();
+        let p = taken.local_addr().unwrap().port();
+        match bind_local(p).await {
+            Err(BindError::InUse { requested, suggested }) => {
+                assert_eq!(requested, p);
+                assert!(suggested != 0 && suggested != p);
+                bind_local(suggested).await.expect("suggested port is free");
+            }
+            other => panic!("expected InUse, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/server/src/api_settings.rs
+++ b/crates/server/src/api_settings.rs
@@ -1,0 +1,301 @@
+//! Per-user settings API: `GET`/`PUT`/`DELETE /api/settings/:key`. Backs
+//! saved port-forwards (and future per-user preferences) on the web; the
+//! desktop app persists the equivalent state in `localStorage` instead.
+//!
+//! Values are opaque JSON, stored and returned verbatim in `value_json` —
+//! this route never inspects the shape, it just round-trips whatever the
+//! caller sent.
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::{Extension, Json};
+use serde_json::{json, Value};
+
+use crate::auth::session::UserCtx;
+use crate::AppState;
+
+fn error(status: StatusCode, message: &str) -> Response {
+    (status, Json(json!({ "error": message }))).into_response()
+}
+
+fn validate_key(key: &str) -> Result<(), &'static str> {
+    if key.trim().is_empty() {
+        return Err("key must not be empty");
+    }
+    Ok(())
+}
+
+/// GET /api/settings/:key → `{"value": <json | null>}`. The stored
+/// `value_json` is parsed and re-emitted as JSON (not a JSON-encoded string),
+/// so callers get back exactly the shape they PUT.
+pub async fn get(
+    State(state): State<AppState>,
+    Extension(user): Extension<UserCtx>,
+    Path(key): Path<String>,
+) -> Response {
+    if let Err(msg) = validate_key(&key) {
+        return error(StatusCode::BAD_REQUEST, msg);
+    }
+    match state.db.get_setting(user.user_id, &key).await {
+        Ok(Some(raw)) => match serde_json::from_str::<Value>(&raw) {
+            Ok(value) => Json(json!({ "value": value })).into_response(),
+            Err(e) => error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!("stored value is not valid JSON: {e}"),
+            ),
+        },
+        Ok(None) => Json(json!({ "value": null })).into_response(),
+        Err(e) => error(StatusCode::INTERNAL_SERVER_ERROR, &e),
+    }
+}
+
+/// PUT /api/settings/:key — stores the request body verbatim as the
+/// setting's `value_json`. Requires `Content-Type: application/json`, for the
+/// same CORS-preflight reason as `invoke_capability` (see `api.rs`): without
+/// it, a cross-origin `fetch` with a `text/plain` body is a CORS "simple
+/// request" the browser sends without preflight, which would let any website
+/// write this loopback server's per-user settings.
+pub async fn put(
+    State(state): State<AppState>,
+    Extension(user): Extension<UserCtx>,
+    Path(key): Path<String>,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> Response {
+    if let Err(msg) = validate_key(&key) {
+        return error(StatusCode::BAD_REQUEST, msg);
+    }
+
+    let is_json = headers
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(|v| {
+            v.trim()
+                .to_ascii_lowercase()
+                .starts_with("application/json")
+        })
+        .unwrap_or(false);
+    if !is_json {
+        return error(
+            StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            "content-type must be application/json",
+        );
+    }
+
+    let value: Value = match serde_json::from_slice(&body) {
+        Ok(v) => v,
+        Err(e) => {
+            return error(
+                StatusCode::BAD_REQUEST,
+                &format!("request body is not valid JSON: {e}"),
+            )
+        }
+    };
+    let value_json = value.to_string();
+
+    match state.db.set_setting(user.user_id, &key, &value_json).await {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(e) => error(StatusCode::INTERNAL_SERVER_ERROR, &e),
+    }
+}
+
+/// DELETE /api/settings/:key
+pub async fn delete(
+    State(state): State<AppState>,
+    Extension(user): Extension<UserCtx>,
+    Path(key): Path<String>,
+) -> Response {
+    if let Err(msg) = validate_key(&key) {
+        return error(StatusCode::BAD_REQUEST, msg);
+    }
+    match state.db.delete_setting(user.user_id, &key).await {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(e) => error(StatusCode::INTERNAL_SERVER_ERROR, &e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{router, AppState};
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use serde_json::{json, Value};
+    use srelens_capability::Registry;
+    use std::sync::Arc;
+    use tower::ServiceExt;
+
+    async fn state() -> AppState {
+        AppState::for_tests(Arc::new(Registry::new())).await
+    }
+
+    async fn send(
+        state: &AppState,
+        method: &str,
+        uri: &str,
+        cookie: Option<&str>,
+        body: Option<Value>,
+    ) -> (StatusCode, Value) {
+        let mut builder = Request::builder()
+            .method(method)
+            .uri(uri)
+            .header("x-srelens-csrf", "1");
+        if let Some(cookie) = cookie {
+            builder = builder.header("cookie", cookie);
+        }
+        let body = match body {
+            Some(v) => {
+                builder = builder.header("content-type", "application/json");
+                Body::from(v.to_string())
+            }
+            None => Body::empty(),
+        };
+        let resp = router(state.clone())
+            .oneshot(builder.body(body).unwrap())
+            .await
+            .unwrap();
+        let status = resp.status();
+        let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let v = if bytes.is_empty() {
+            Value::Null
+        } else {
+            serde_json::from_slice(&bytes).unwrap()
+        };
+        (status, v)
+    }
+
+    async fn login(state: &AppState) -> String {
+        let user = state.db.upsert_user("i", "s", "u@x", "U", 1).await.unwrap();
+        let token = state
+            .db
+            .create_session(user.id, crate::unix_now())
+            .await
+            .unwrap();
+        format!("srelens_session={token}")
+    }
+
+    #[tokio::test]
+    async fn settings_routes_require_auth() {
+        let state = state().await;
+        for (method, uri) in [
+            ("GET", "/api/settings/theme"),
+            ("PUT", "/api/settings/theme"),
+            ("DELETE", "/api/settings/theme"),
+        ] {
+            let (status, _) = send(&state, method, uri, None, None).await;
+            assert_eq!(status, StatusCode::UNAUTHORIZED, "{method} {uri}");
+        }
+    }
+
+    #[tokio::test]
+    async fn value_roundtrips_through_put_and_get() {
+        let state = state().await;
+        let cookie = login(&state).await;
+
+        // Absent key reads as null.
+        let (status, body) = send(&state, "GET", "/api/settings/theme", Some(&cookie), None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, json!({ "value": null }));
+
+        // PUT stores the body verbatim.
+        let (status, _) = send(
+            &state,
+            "PUT",
+            "/api/settings/theme",
+            Some(&cookie),
+            Some(json!({ "mode": "dark", "scale": 1.5 })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NO_CONTENT);
+
+        let (status, body) = send(&state, "GET", "/api/settings/theme", Some(&cookie), None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, json!({ "value": { "mode": "dark", "scale": 1.5 } }));
+
+        // DELETE clears it.
+        let (status, _) = send(&state, "DELETE", "/api/settings/theme", Some(&cookie), None).await;
+        assert_eq!(status, StatusCode::NO_CONTENT);
+        let (status, body) = send(&state, "GET", "/api/settings/theme", Some(&cookie), None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, json!({ "value": null }));
+    }
+
+    #[tokio::test]
+    async fn put_requires_json_content_type() {
+        let state = state().await;
+        let cookie = login(&state).await;
+        let resp = router(state.clone())
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/settings/theme")
+                    .header("cookie", &cookie)
+                    .header("x-srelens-csrf", "1")
+                    .header("content-type", "text/plain")
+                    .body(Body::from("\"dark\""))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    #[tokio::test]
+    async fn empty_key_is_rejected() {
+        let state = state().await;
+        let cookie = login(&state).await;
+        // The router only matches non-empty path segments, so an empty key
+        // segment can't reach the handler as `/api/settings/` — verify the
+        // validator directly rejects it via a whitespace-only key instead.
+        let (status, _) = send(
+            &state,
+            "PUT",
+            "/api/settings/%20",
+            Some(&cookie),
+            Some(json!("x")),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn settings_are_isolated_per_user() {
+        let state = state().await;
+        let alice_cookie = login(&state).await;
+
+        let bob = state
+            .db
+            .upsert_user("i", "bob", "b@x", "B", 1)
+            .await
+            .unwrap();
+        let bob_token = state
+            .db
+            .create_session(bob.id, crate::unix_now())
+            .await
+            .unwrap();
+        let bob_cookie = format!("srelens_session={bob_token}");
+
+        let (status, _) = send(
+            &state,
+            "PUT",
+            "/api/settings/theme",
+            Some(&alice_cookie),
+            Some(json!("dark")),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NO_CONTENT);
+
+        let (status, body) = send(
+            &state,
+            "GET",
+            "/api/settings/theme",
+            Some(&bob_cookie),
+            None,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, json!({ "value": null }));
+    }
+}

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -14,6 +14,7 @@ pub mod api;
 pub mod api_clusters;
 pub mod api_command;
 pub mod api_kubeconfigs;
+pub mod api_settings;
 pub mod assets;
 pub mod auth;
 pub mod cluster_auth_resolver;
@@ -128,6 +129,12 @@ pub fn router(state: AppState) -> Router {
         .route(
             "/api/command/:command",
             axum::routing::post(api_command::dispatch),
+        )
+        .route(
+            "/api/settings/:key",
+            get(api_settings::get)
+                .put(api_settings::put)
+                .delete(api_settings::delete),
         )
         .route_layer(axum::middleware::from_fn_with_state(
             state.clone(),

--- a/crates/server/src/stores.rs
+++ b/crates/server/src/stores.rs
@@ -270,6 +270,16 @@ impl Db {
                 .map_err(|e| e.to_string())?;
         Ok(row.map(|(v,)| v))
     }
+
+    pub async fn delete_setting(&self, user_id: i64, key: &str) -> Result<(), String> {
+        sqlx::query("DELETE FROM settings WHERE user_id = ? AND key = ?")
+            .bind(user_id)
+            .bind(key)
+            .execute(self.pool())
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -436,6 +446,47 @@ mod tests {
         db.set_setting(user.id, "theme", "\"light\"").await.unwrap();
         assert_eq!(
             db.get_setting(user.id, "theme").await.unwrap().unwrap(),
+            "\"light\""
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_setting_clears_the_value() {
+        let db = db().await;
+        let user = db.upsert_user("i", "s", "", "", 1).await.unwrap();
+        db.set_setting(user.id, "theme", "\"dark\"").await.unwrap();
+        db.delete_setting(user.id, "theme").await.unwrap();
+        assert!(db.get_setting(user.id, "theme").await.unwrap().is_none());
+
+        // Deleting an already-absent key is a no-op, not an error.
+        db.delete_setting(user.id, "theme").await.unwrap();
+        db.delete_setting(user.id, "never-set").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn settings_are_isolated_per_user() {
+        let db = db().await;
+        let alice = db.upsert_user("i", "alice", "", "", 1).await.unwrap();
+        let bob = db.upsert_user("i", "bob", "", "", 1).await.unwrap();
+
+        db.set_setting(alice.id, "theme", "\"dark\"").await.unwrap();
+        assert!(db.get_setting(bob.id, "theme").await.unwrap().is_none());
+
+        db.set_setting(bob.id, "theme", "\"light\"").await.unwrap();
+        assert_eq!(
+            db.get_setting(alice.id, "theme").await.unwrap().unwrap(),
+            "\"dark\""
+        );
+        assert_eq!(
+            db.get_setting(bob.id, "theme").await.unwrap().unwrap(),
+            "\"light\""
+        );
+
+        // Deleting one user's setting doesn't touch the other's.
+        db.delete_setting(alice.id, "theme").await.unwrap();
+        assert!(db.get_setting(alice.id, "theme").await.unwrap().is_none());
+        assert_eq!(
+            db.get_setting(bob.id, "theme").await.unwrap().unwrap(),
             "\"light\""
         );
     }

--- a/crates/streams/src/forward.rs
+++ b/crates/streams/src/forward.rs
@@ -17,6 +17,28 @@ struct Forward {
     local_port: u16,
 }
 
+/// Reconnect policy: a handful of attempts with a short capped exponential
+/// backoff, small enough that tests exercising the give-up path stay fast.
+const MAX_ATTEMPTS: u32 = 4;
+const BASE_BACKOFF_MS: u64 = 15;
+const MAX_BACKOFF_MS: u64 = 150;
+
+fn backoff_for(attempt: u32) -> std::time::Duration {
+    let multiplier = 1u64.checked_shl(attempt).unwrap_or(u64::MAX);
+    let ms = BASE_BACKOFF_MS
+        .saturating_mul(multiplier)
+        .min(MAX_BACKOFF_MS);
+    std::time::Duration::from_millis(ms)
+}
+
+fn status_payload(state: &str, attempt: u32, error: Option<&str>) -> serde_json::Value {
+    serde_json::json!({
+        "state": state,
+        "attempt": attempt,
+        "error": error,
+    })
+}
+
 /// Owns running port-forwards (keyed by numeric id).
 pub struct ForwardManager {
     cache: Arc<ClientCache>,
@@ -43,10 +65,15 @@ impl ForwardManager {
     }
 
     /// Start forwarding a local port to a Pod or Service. `kind` is "Pod" or
-    /// "Service"; a Service is resolved to a backing pod and target port
-    /// first. Returns the id + bound local port; a `forward:closed:<id>`
-    /// event fires (with an optional error string) if the forward loop ends
-    /// on its own.
+    /// "Service"; a Service is re-resolved to a backing pod and target port
+    /// on every (re)connect attempt, so a replaced pod is picked up. Returns
+    /// the id + bound local port (bound once, up front, and kept stable
+    /// across reconnects). The task then loops: serve until the connection
+    /// drops, emit `forward:status:<id>` (`active` on establish,
+    /// `reconnecting` with backoff between attempts, `failed` after
+    /// `MAX_ATTEMPTS`), and emit `forward:closed:<id>` when it gives up (a
+    /// user `stop(id)` aborts the task outright and never reaches that
+    /// point).
     pub async fn start(
         &self,
         sink: Arc<dyn EventSink>,
@@ -59,20 +86,6 @@ impl ForwardManager {
     ) -> Result<ForwardInfo, String> {
         let cache = self.cache.clone();
 
-        // Resolve a Service down to a concrete pod + container port.
-        let (pod, target_port) = if kind.eq_ignore_ascii_case("service") {
-            forward::resolve_service_target(
-                cache.clone(),
-                &context,
-                &namespace,
-                &name,
-                Some(i32::from(remote_port)),
-            )
-            .await?
-        } else {
-            (name, remote_port)
-        };
-
         let listener = forward::bind_local(local_port.unwrap_or(0))
             .await
             .map_err(|e| e.to_string())?;
@@ -80,13 +93,66 @@ impl ForwardManager {
 
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
         let closed_channel = format!("forward:closed:{id}");
+        let status_channel = format!("forward:status:{id}");
         let handle = tokio::spawn(async move {
-            let result =
-                forward::serve_pod_forward(listener, cache, context, namespace, pod, target_port)
-                    .await;
+            let mut attempt: u32 = 0;
+            let final_error = loop {
+                attempt += 1;
+
+                // Re-resolve Service targets every attempt so a replacement
+                // pod is picked up; a Pod target's name never changes.
+                let resolved = if kind.eq_ignore_ascii_case("service") {
+                    forward::resolve_service_target(
+                        cache.clone(),
+                        &context,
+                        &namespace,
+                        &name,
+                        Some(i32::from(remote_port)),
+                    )
+                    .await
+                } else {
+                    Ok((name.clone(), remote_port))
+                };
+
+                let attempt_result = match resolved {
+                    Ok((pod, target_port)) => {
+                        match forward::connect_pod_api(cache.clone(), &context, &namespace).await {
+                            Ok(api) => {
+                                sink.emit(&status_channel, status_payload("active", attempt, None));
+                                forward::serve_pod_forward(&listener, api, pod, target_port).await
+                            }
+                            Err(e) => Err(e),
+                        }
+                    }
+                    Err(e) => Err(e),
+                };
+
+                let err = match attempt_result {
+                    // The accept loop only returns on error; a clean Ok is
+                    // not expected in practice, but treat it as a terminal,
+                    // error-free close rather than looping forever.
+                    Ok(()) => break None,
+                    Err(e) => e,
+                };
+
+                if attempt >= MAX_ATTEMPTS {
+                    sink.emit(
+                        &status_channel,
+                        status_payload("failed", attempt, Some(&err)),
+                    );
+                    break Some(err);
+                }
+
+                sink.emit(
+                    &status_channel,
+                    status_payload("reconnecting", attempt, Some(&err)),
+                );
+                tokio::time::sleep(backoff_for(attempt)).await;
+            };
+
             sink.emit(
                 &closed_channel,
-                serde_json::to_value(result.err()).unwrap_or(serde_json::Value::Null),
+                serde_json::to_value(final_error).unwrap_or(serde_json::Value::Null),
             );
         });
 
@@ -146,6 +212,73 @@ impl ForwardManager {
 mod tests {
     use super::*;
     use crate::test_util::TestSink;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn forward_retries_then_marks_failed() {
+        // Empty cache: connecting the pod API client fails on every attempt
+        // (there's no context to resolve), so the reconnect loop should walk
+        // through `reconnecting` statuses and give up with `failed` after
+        // MAX_ATTEMPTS, without ever reporting `active`.
+        let manager = ForwardManager::new(ClientCache::new_many(vec![]));
+        let sink = Arc::new(TestSink::default());
+        let info = manager
+            .start(
+                sink.clone(),
+                "nope".into(),
+                "ns".into(),
+                "Pod".into(),
+                "pod-a".into(),
+                8080,
+                None,
+            )
+            .await
+            .expect("bind succeeds locally");
+
+        let status_channel = format!("forward:status:{}", info.id);
+        let mut failed_payload = None;
+        for _ in 0..200 {
+            if let Some(p) = sink
+                .payloads_for(&status_channel)
+                .into_iter()
+                .find(|p| p.get("state").and_then(|s| s.as_str()) == Some("failed"))
+            {
+                failed_payload = Some(p);
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        let failed_payload = failed_payload.expect("forward:status:<id> never reached 'failed'");
+        assert_eq!(failed_payload["attempt"], MAX_ATTEMPTS);
+        assert!(failed_payload["error"].is_string());
+
+        let statuses = sink.payloads_for(&status_channel);
+        assert!(
+            statuses
+                .iter()
+                .any(|p| p.get("state").and_then(|s| s.as_str()) == Some("reconnecting")),
+            "expected at least one 'reconnecting' status before giving up"
+        );
+        assert!(
+            !statuses
+                .iter()
+                .any(|p| p.get("state").and_then(|s| s.as_str()) == Some("active")),
+            "connect never succeeds against an empty cache, so 'active' should never fire"
+        );
+
+        let closed_channel = format!("forward:closed:{}", info.id);
+        for _ in 0..50 {
+            if !sink.payloads_for(&closed_channel).is_empty() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert!(
+            !sink.payloads_for(&closed_channel).is_empty(),
+            "forward:closed:<id> never fired after giving up"
+        );
+
+        manager.stop(info.id);
+    }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn pod_forward_binds_and_reports_close() {

--- a/crates/streams/src/forward.rs
+++ b/crates/streams/src/forward.rs
@@ -20,9 +20,11 @@ struct Forward {
 /// Reconnect policy: a handful of attempts with a short capped exponential
 /// backoff, small enough that tests exercising the give-up path stay fast.
 /// `MAX_ATTEMPTS` counts CONSECUTIVE failed attempts since the last
-/// successful establish — see `attempt_after_established` — so a forward
-/// that's been happily active for hours and then reconnects once doesn't
-/// inherit a stale attempt count from an earlier flaky period.
+/// successful establish — see `next_reconnect_state` — so a forward that's
+/// been happily active for hours and then reconnects once doesn't inherit a
+/// stale attempt count from an earlier flaky period: the first reconnect
+/// after ANY successful establish always reports `attempt:1`, never a
+/// continuation of whatever count came before that establish.
 ///
 /// 5 (not 4) so `MAX_BACKOFF_MS`'s cap is actually reachable: sleeps only
 /// happen for attempts before the last one (1..=MAX_ATTEMPTS-1), and
@@ -40,17 +42,42 @@ fn backoff_for(attempt: u32) -> std::time::Duration {
     std::time::Duration::from_millis(ms)
 }
 
-/// The attempt counter to carry into the next loop iteration once the
-/// current one has just reached "active" (a successful establish): reset to
-/// 0, so `attempt += 1` at the top of the next iteration starts a fresh
-/// consecutive-failure count instead of continuing to accumulate from
-/// before this success. When the session hasn't just established, the
-/// attempt count is left untouched.
-fn attempt_after_established(attempt: u32, just_established: bool) -> u32 {
-    if just_established {
-        0
+/// Outcome of one failed connect/serve attempt: whether the reconnect loop
+/// should give up, and the `attempt` number to report on the
+/// `forward:status:<id>` event for this failure (`reconnecting` when
+/// `give_up` is false, `failed` when it's true).
+struct ReconnectDecision {
+    give_up: bool,
+    attempt: u32,
+}
+
+/// Pure state transition for the reconnect loop's attempt bookkeeping.
+/// `attempt` always counts CONSECUTIVE failures since the last successful
+/// establish:
+///
+/// | `established_this_session` | `prev_consecutive_failures` | → `attempt` |
+/// |-----------------------------|-------------------------------|-------------|
+/// | `false` (never established this session) | `n`             | `n + 1`     |
+/// | `true` (established, then failed)         | any (ignored)   | `1`         |
+///
+/// A session that establishes and later fails ALWAYS restarts the
+/// consecutive-failure count at 1 — it never continues from whatever count
+/// preceded the successful establish, since that would double-count an
+/// earlier flaky period against a session that went on to work for a while.
+/// A session that never establishes just increments as usual. `give_up` is
+/// `attempt >= MAX_ATTEMPTS` either way.
+fn next_reconnect_state(
+    established_this_session: bool,
+    prev_consecutive_failures: u32,
+) -> ReconnectDecision {
+    let attempt = if established_this_session {
+        1
     } else {
-        attempt
+        prev_consecutive_failures + 1
+    };
+    ReconnectDecision {
+        give_up: attempt >= MAX_ATTEMPTS,
+        attempt,
     }
 }
 
@@ -118,9 +145,9 @@ impl ForwardManager {
         let closed_channel = format!("forward:closed:{id}");
         let status_channel = format!("forward:status:{id}");
         let handle = tokio::spawn(async move {
-            let mut attempt: u32 = 0;
+            let mut consecutive_failures: u32 = 0;
             let final_error = loop {
-                attempt += 1;
+                let mut established_this_session = false;
 
                 // Re-resolve Service targets every attempt so a replacement
                 // pod is picked up; a Pod target's name never changes.
@@ -141,12 +168,13 @@ impl ForwardManager {
                     Ok((pod, target_port)) => {
                         match forward::connect_pod_api(cache.clone(), &context, &namespace).await {
                             Ok(api) => {
-                                sink.emit(&status_channel, status_payload("active", attempt, None));
-                                // Reset now, not after `serve_pod_forward` returns: this
-                                // session has established, so the NEXT failure (whenever
-                                // it comes) starts a fresh consecutive-attempt count
-                                // rather than inheriting this attempt's number.
-                                attempt = attempt_after_established(attempt, true);
+                                established_this_session = true;
+                                // `active` always reports attempt:0 — reaching
+                                // "active" means there's no consecutive-failure
+                                // streak to report; see `next_reconnect_state`
+                                // for how a later failure of THIS session is
+                                // counted (always restarts at 1).
+                                sink.emit(&status_channel, status_payload("active", 0, None));
                                 forward::serve_pod_forward(&listener, api, pod, target_port).await
                             }
                             Err(e) => Err(e),
@@ -163,19 +191,22 @@ impl ForwardManager {
                     Err(e) => e,
                 };
 
-                if attempt >= MAX_ATTEMPTS {
+                let decision = next_reconnect_state(established_this_session, consecutive_failures);
+                consecutive_failures = decision.attempt;
+
+                if decision.give_up {
                     sink.emit(
                         &status_channel,
-                        status_payload("failed", attempt, Some(&err)),
+                        status_payload("failed", decision.attempt, Some(&err)),
                     );
                     break Some(err);
                 }
 
                 sink.emit(
                     &status_channel,
-                    status_payload("reconnecting", attempt, Some(&err)),
+                    status_payload("reconnecting", decision.attempt, Some(&err)),
                 );
-                tokio::time::sleep(backoff_for(attempt)).await;
+                tokio::time::sleep(backoff_for(decision.attempt)).await;
             };
 
             sink.emit(
@@ -242,29 +273,74 @@ mod tests {
     use crate::test_util::TestSink;
 
     #[test]
-    fn attempt_resets_to_zero_on_establish_else_unchanged() {
-        // A session that just reached "active" starts the next
-        // consecutive-failure count from scratch...
-        assert_eq!(attempt_after_established(3, true), 0);
-        assert_eq!(attempt_after_established(MAX_ATTEMPTS, true), 0);
-        // ...but an attempt count is left alone when nothing established
-        // (e.g. resolve/connect failed before a session could start).
-        assert_eq!(attempt_after_established(3, false), 3);
-        assert_eq!(attempt_after_established(0, false), 0);
+    fn next_reconnect_state_never_established_counts_up_then_gives_up() {
+        // A session that never reaches "active" just counts consecutive
+        // failures 1, 2, 3, ... and gives up exactly at MAX_ATTEMPTS.
+        let mut consecutive_failures = 0;
+        for expected in 1..MAX_ATTEMPTS {
+            let decision = next_reconnect_state(false, consecutive_failures);
+            assert_eq!(decision.attempt, expected);
+            assert!(
+                !decision.give_up,
+                "attempt {expected} should not give up yet"
+            );
+            consecutive_failures = decision.attempt;
+        }
+        let decision = next_reconnect_state(false, consecutive_failures);
+        assert_eq!(decision.attempt, MAX_ATTEMPTS);
+        assert!(
+            decision.give_up,
+            "the MAX_ATTEMPTS-th failure should give up"
+        );
     }
 
-    // NOTE on coverage: this proves the reset *decision* used by the loop
-    // (`attempt = attempt_after_established(attempt, true)` right after the
-    // "active" emit), but not the full end-to-end path — "forward is active
-    // against a real pod, that pod is deleted, the streams loop reconnects,
-    // emits active again on attempt N>1, resets, then fails MAX_ATTEMPTS
-    // times counting 1..MAX_ATTEMPTS instead of continuing from N". Driving
-    // that deterministically would need `connect_pod_api`/`serve_pod_forward`
-    // to succeed without a real cluster, which needs a fake kube apiserver
-    // (e.g. a mock HTTP service behind `kube::Client::new`) — no such test
-    // harness exists in this repo today and building one would pull in a new
-    // dev-dependency (tower/hyper test helpers), which is out of scope here.
-    // See the task report for this gap.
+    #[test]
+    fn next_reconnect_state_established_then_failed_resets_to_one() {
+        // No matter how many consecutive failures preceded a successful
+        // establish, the first failure AFTER that establish is attempt:1 —
+        // it never continues counting from whatever came before the success.
+        for prev in [0, 1, MAX_ATTEMPTS - 1, MAX_ATTEMPTS, 100] {
+            let decision = next_reconnect_state(true, prev);
+            assert_eq!(decision.attempt, 1, "prev_consecutive_failures={prev}");
+            assert!(!decision.give_up, "a single failure should never give up");
+        }
+    }
+
+    #[test]
+    fn next_reconnect_state_repeated_establish_fail_cycles_never_accumulate() {
+        // Simulate many establish -> fail cycles in a row (e.g. a pod that
+        // keeps getting recreated and immediately deleted again): the
+        // attempt count must reset to 1 every single time, never climbing
+        // toward MAX_ATTEMPTS just because it happened before.
+        let mut consecutive_failures = 0;
+        for _ in 0..(MAX_ATTEMPTS * 3) {
+            let decision = next_reconnect_state(true, consecutive_failures);
+            assert_eq!(decision.attempt, 1);
+            assert!(!decision.give_up);
+            consecutive_failures = decision.attempt;
+        }
+    }
+
+    #[test]
+    fn next_reconnect_state_give_up_threshold_is_exactly_max_attempts() {
+        assert!(!next_reconnect_state(false, MAX_ATTEMPTS - 2).give_up);
+        assert!(next_reconnect_state(false, MAX_ATTEMPTS - 1).give_up);
+    }
+
+    // NOTE on coverage: the tests above exhaustively prove the pure
+    // transition (`next_reconnect_state`) that the loop relies on, but not
+    // the full end-to-end path — "forward is active against a real pod,
+    // that pod is deleted, the streams loop reconnects, emits active again,
+    // then a later failure streak counts 1..MAX_ATTEMPTS instead of
+    // continuing from whatever count preceded the successful establish".
+    // Driving that deterministically would need `connect_pod_api` /
+    // `serve_pod_forward` to succeed without a real cluster, which needs a
+    // fake kube apiserver (e.g. a mock HTTP service behind
+    // `kube::Client::new`) — no such test harness exists in this repo today
+    // and building one would pull in a new dev-dependency (tower/hyper test
+    // helpers), which is out of scope here. A separate follow-up issue
+    // tracks building that cluster harness. See the task report for this
+    // gap.
 
     #[tokio::test(flavor = "multi_thread")]
     async fn forward_retries_then_marks_failed() {

--- a/crates/streams/src/forward.rs
+++ b/crates/streams/src/forward.rs
@@ -73,7 +73,9 @@ impl ForwardManager {
             (name, remote_port)
         };
 
-        let listener = forward::bind_local(local_port.unwrap_or(0)).await?;
+        let listener = forward::bind_local(local_port.unwrap_or(0))
+            .await
+            .map_err(|e| e.to_string())?;
         let bound = listener.local_addr().map_err(|e| e.to_string())?.port();
 
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);

--- a/crates/streams/src/forward.rs
+++ b/crates/streams/src/forward.rs
@@ -168,14 +168,24 @@ impl ForwardManager {
                     Ok((pod, target_port)) => {
                         match forward::connect_pod_api(cache.clone(), &context, &namespace).await {
                             Ok(api) => {
-                                established_this_session = true;
-                                // `active` always reports attempt:0 — reaching
-                                // "active" means there's no consecutive-failure
-                                // streak to report; see `next_reconnect_state`
-                                // for how a later failure of THIS session is
-                                // counted (always restarts at 1).
-                                sink.emit(&status_channel, status_payload("active", 0, None));
-                                forward::serve_pod_forward(&listener, api, pod, target_port).await
+                                // Building the Api handle does no I/O, so it isn't
+                                // evidence the target works. Probe readiness first:
+                                // only a pod that's actually present + Running counts
+                                // as "established". Otherwise a permanently-dead
+                                // target would reset the failure counter to 1 every
+                                // attempt and never reach the give-up threshold.
+                                if forward::pod_is_ready(&api, &pod).await {
+                                    established_this_session = true;
+                                    // `active` always reports attempt:0 — reaching
+                                    // "active" means there's no consecutive-failure
+                                    // streak to report; see `next_reconnect_state`
+                                    // for how a later failure of THIS session is
+                                    // counted (always restarts at 1).
+                                    sink.emit(&status_channel, status_payload("active", 0, None));
+                                    forward::serve_pod_forward(&listener, api, pod, target_port).await
+                                } else {
+                                    Err(format!("target pod {pod} is not ready"))
+                                }
                             }
                             Err(e) => Err(e),
                         }

--- a/crates/streams/src/forward.rs
+++ b/crates/streams/src/forward.rs
@@ -19,7 +19,16 @@ struct Forward {
 
 /// Reconnect policy: a handful of attempts with a short capped exponential
 /// backoff, small enough that tests exercising the give-up path stay fast.
-const MAX_ATTEMPTS: u32 = 4;
+/// `MAX_ATTEMPTS` counts CONSECUTIVE failed attempts since the last
+/// successful establish — see `attempt_after_established` — so a forward
+/// that's been happily active for hours and then reconnects once doesn't
+/// inherit a stale attempt count from an earlier flaky period.
+///
+/// 5 (not 4) so `MAX_BACKOFF_MS`'s cap is actually reachable: sleeps only
+/// happen for attempts before the last one (1..=MAX_ATTEMPTS-1), and
+/// `backoff_for(4)` is the first attempt whose uncapped value (240ms)
+/// exceeds the 150ms cap.
+const MAX_ATTEMPTS: u32 = 5;
 const BASE_BACKOFF_MS: u64 = 15;
 const MAX_BACKOFF_MS: u64 = 150;
 
@@ -29,6 +38,20 @@ fn backoff_for(attempt: u32) -> std::time::Duration {
         .saturating_mul(multiplier)
         .min(MAX_BACKOFF_MS);
     std::time::Duration::from_millis(ms)
+}
+
+/// The attempt counter to carry into the next loop iteration once the
+/// current one has just reached "active" (a successful establish): reset to
+/// 0, so `attempt += 1` at the top of the next iteration starts a fresh
+/// consecutive-failure count instead of continuing to accumulate from
+/// before this success. When the session hasn't just established, the
+/// attempt count is left untouched.
+fn attempt_after_established(attempt: u32, just_established: bool) -> u32 {
+    if just_established {
+        0
+    } else {
+        attempt
+    }
 }
 
 fn status_payload(state: &str, attempt: u32, error: Option<&str>) -> serde_json::Value {
@@ -119,6 +142,11 @@ impl ForwardManager {
                         match forward::connect_pod_api(cache.clone(), &context, &namespace).await {
                             Ok(api) => {
                                 sink.emit(&status_channel, status_payload("active", attempt, None));
+                                // Reset now, not after `serve_pod_forward` returns: this
+                                // session has established, so the NEXT failure (whenever
+                                // it comes) starts a fresh consecutive-attempt count
+                                // rather than inheriting this attempt's number.
+                                attempt = attempt_after_established(attempt, true);
                                 forward::serve_pod_forward(&listener, api, pod, target_port).await
                             }
                             Err(e) => Err(e),
@@ -212,6 +240,31 @@ impl ForwardManager {
 mod tests {
     use super::*;
     use crate::test_util::TestSink;
+
+    #[test]
+    fn attempt_resets_to_zero_on_establish_else_unchanged() {
+        // A session that just reached "active" starts the next
+        // consecutive-failure count from scratch...
+        assert_eq!(attempt_after_established(3, true), 0);
+        assert_eq!(attempt_after_established(MAX_ATTEMPTS, true), 0);
+        // ...but an attempt count is left alone when nothing established
+        // (e.g. resolve/connect failed before a session could start).
+        assert_eq!(attempt_after_established(3, false), 3);
+        assert_eq!(attempt_after_established(0, false), 0);
+    }
+
+    // NOTE on coverage: this proves the reset *decision* used by the loop
+    // (`attempt = attempt_after_established(attempt, true)` right after the
+    // "active" emit), but not the full end-to-end path — "forward is active
+    // against a real pod, that pod is deleted, the streams loop reconnects,
+    // emits active again on attempt N>1, resets, then fails MAX_ATTEMPTS
+    // times counting 1..MAX_ATTEMPTS instead of continuing from N". Driving
+    // that deterministically would need `connect_pod_api`/`serve_pod_forward`
+    // to succeed without a real cluster, which needs a fake kube apiserver
+    // (e.g. a mock HTTP service behind `kube::Client::new`) — no such test
+    // harness exists in this repo today and building one would pull in a new
+    // dev-dependency (tower/hyper test helpers), which is out of scope here.
+    // See the task report for this gap.
 
     #[tokio::test(flavor = "multi_thread")]
     async fn forward_retries_then_marks_failed() {


### PR DESCRIPTION
Closes #21.

Makes port-forwards survive pod restarts, detects local-port conflicts, and adds named saved-forwards per cluster with live status.

## What's in it
- **Auto-reconnect** (`crates/streams/forward.rs` + `crates/kube/forward.rs`) — when a forward drops, the backend retries with capped exponential backoff and, for service/workload forwards, **re-resolves to a fresh pod each attempt**, then gives up after N consecutive failures. A target-pod liveness monitor ends the serve session on pod deletion so recovery actually fires (the acceptance criterion). Consecutive-failure counting resets on each successful establish.
- **Status channel** — emits `forward:status:<id>` (`active`/`reconnecting`/`failed`), surfaced in `ForwardsIndicator` and `PortForwardsView`.
- **Local-port conflict detection** — `bind_local` returns a typed `BindError::InUse { requested, suggested }`; `ForwardDialog` offers a one-click retry on the suggested free port.
- **Saved forwards per cluster** — a `lib/savedForwards.ts` store: **web** persists to a new per-user `GET/PUT/DELETE /api/settings/:key` slice (previously-unused `settings` table); **desktop** uses `localStorage`. Managed from the Saved section of `PortForwardsView` (one-click Start / Delete), with errors surfaced (not silent).

## Tests
Backend: `bind_local` conflict, `pod_is_gone`, `next_reconnect_state` transition table, the retry→failed loop (streams 21, kube 282); per-user settings DB + route tests (server 130). Frontend: savedForwards store round-trips, status-event wiring, saved-forwards UI (Start/Delete/error), status rendering, suggested-port retry (**716/716**, tsc clean). No AI attribution across the 8 commits.

## Built via subagent-driven development
5 tasks, per-task reviews (spec + quality) with fix loops; a Critical (pod-deletion didn't trigger re-resolve) and several Important findings were caught and fixed in review.

## Known follow-ups (not blocking)
- **Live-cluster e2e** for the full pod-deletion → recovery path is tracked in #172 (unit-tested at the helper level + verified by review; a full test needs a kind/fake-apiserver harness).
- Minor: suggested-port parsing is coupled to the backend error wording (fail-safe); web saved-forwards write is read-modify-write (non-atomic across concurrent tabs); no separate friendly-name field on save.