### PR TITLE
fix(cluster-oidc): only manage clusters added via the srelens form

### DIFF
--- a/apps/desktop/src-tauri/src/cluster_oidc.rs
+++ b/apps/desktop/src-tauri/src/cluster_oidc.rs
@@ -1,8 +1,11 @@
 //! Desktop-side managed cluster OIDC. Reuses the server's OIDC machinery (token
 //! provider, registry, resolver, flow) but with a LOCAL sqlite token store
 //! under the app config dir and a loopback browser-login flow (see
-//! commands in `cluster_oidc_cmd.rs` / lib.rs). Managed sign-in is the desktop
-//! default for detected OIDC contexts; non-OIDC exec plugins still run natively.
+//! commands in `cluster_oidc_cmd.rs` / lib.rs). Managed sign-in applies only to
+//! clusters added through the srelens Add-cluster form (their synthesized
+//! kubeconfig carries srelens's managed-OIDC marker); every pre-existing
+//! kubeconfig context — including one with its own kubelogin/aws/gke exec
+//! plugin — keeps running that plugin natively.
 
 use std::path::Path;
 use std::sync::Arc;

--- a/crates/kube/src/cluster_synth.rs
+++ b/crates/kube/src/cluster_synth.rs
@@ -63,6 +63,17 @@ pub fn synthesize_kubeconfig(form: &ClusterForm) -> Result<String, String> {
         exec.insert("command".into(), "kubelogin".into());
         exec.insert("args".into(), serde_yaml::Value::Sequence(args));
         exec.insert("interactiveMode".into(), "IfAvailable".into());
+        // Stamp srelens's managed-OIDC marker so this context (and only clusters
+        // added through the srelens OIDC form) is routed to the managed browser
+        // sign-in; native kubeconfig+plugin contexts carry no marker and are
+        // left to run their own exec plugin. `kubelogin` ignores unknown env.
+        let mut env_entry = serde_yaml::Mapping::new();
+        env_entry.insert("name".into(), crate::oidc_detect::SRELENS_MANAGED_OIDC_ENV.into());
+        env_entry.insert("value".into(), "1".into());
+        exec.insert(
+            "env".into(),
+            serde_yaml::Value::Sequence(vec![serde_yaml::Value::Mapping(env_entry)]),
+        );
         user.insert("exec".into(), serde_yaml::Value::Mapping(exec));
     }
 
@@ -158,7 +169,7 @@ pub fn synthesize_cluster_capability() -> Capability {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::oidc_detect::{detect_oidc_user, OidcClusterConfig};
+    use crate::oidc_detect::{detect_oidc_user, is_srelens_managed_oidc, OidcClusterConfig};
     use kube::config::Kubeconfig;
 
     #[test]
@@ -182,8 +193,13 @@ mod tests {
         assert!(yaml.contains("command: kubelogin"));
         let kc = Kubeconfig::from_yaml(&yaml).expect("kube parses it");
         assert_eq!(kc.contexts[0].name, "prod");
-        // The detector recovers the OIDC config from the exec block.
+        // The synthesized cluster carries srelens's managed-OIDC marker, so it
+        // (and only form-added clusters) is routed to the managed sign-in.
         let auth = kc.auth_infos[0].auth_info.clone().unwrap();
+        assert!(
+            is_srelens_managed_oidc(&auth),
+            "synthesized OIDC clusters must carry the srelens managed marker"
+        );
         let got = detect_oidc_user(&auth).unwrap();
         assert_eq!(got.issuer, "https://dex");
         assert_eq!(got.client_id, "k8s");

--- a/crates/kube/src/cluster_synth.rs
+++ b/crates/kube/src/cluster_synth.rs
@@ -41,9 +41,11 @@ pub fn synthesize_kubeconfig(form: &ClusterForm) -> Result<String, String> {
     let mut user = serde_yaml::Mapping::new();
     if let Some(oidc) = &form.oidc {
         // Emit the `exec` kubelogin form (not the legacy `auth-provider: oidc`
-        // block). Desktop runs kubelogin natively to authenticate; web detects
-        // this same form, strips the exec block, and injects a srelens-managed
-        // token — so one synthesized kubeconfig works on both surfaces.
+        // block), stamped with srelens's managed-OIDC marker below. Both desktop
+        // and web recognise the marker and authenticate the context with a
+        // srelens-managed token instead of running the plugin — so one
+        // synthesized kubeconfig works on both surfaces. The exec block is still
+        // emitted so the file stays a valid, portable kubeconfig for `kubectl`.
         let mut args: Vec<serde_yaml::Value> = vec![
             "get-token".into(),
             format!("--oidc-issuer-url={}", oidc.issuer).into(),

--- a/crates/kube/src/oidc_detect.rs
+++ b/crates/kube/src/oidc_detect.rs
@@ -71,6 +71,29 @@ fn exec_flag(args: &[String], flag: &str) -> Option<String> {
     None
 }
 
+/// Env-var marker srelens stamps into the `exec` block of kubeconfigs it
+/// synthesizes from the "Add cluster" OIDC form. It lets srelens tell apart a
+/// cluster the user added *through srelens* (which should use the managed
+/// browser sign-in) from a pre-existing kubeconfig context that uses its own
+/// `kubectl` exec plugin (kubelogin/aws/gke — which must be left to run
+/// natively). `kubelogin` ignores unknown env vars, so the marker is inert to
+/// the plugin.
+pub const SRELENS_MANAGED_OIDC_ENV: &str = "SRELENS_MANAGED_OIDC";
+
+/// True when a kubeconfig user's `exec` block carries srelens's managed-OIDC
+/// marker (see [`SRELENS_MANAGED_OIDC_ENV`]) — i.e. srelens synthesized it from
+/// the Add-cluster form. Only such contexts should be routed to the managed
+/// cluster sign-in; everything else keeps its native auth.
+pub fn is_srelens_managed_oidc(auth: &kube::config::AuthInfo) -> bool {
+    let Some(exec) = &auth.exec else {
+        return false;
+    };
+    exec.env.as_ref().is_some_and(|env| {
+        env.iter()
+            .any(|e| e.get("name").map(String::as_str) == Some(SRELENS_MANAGED_OIDC_ENV))
+    })
+}
+
 /// Detect OIDC settings from a kubeconfig user, or None if it isn't OIDC.
 pub fn detect_oidc_user(auth: &kube::config::AuthInfo) -> Option<OidcClusterConfig> {
     // 1) Legacy auth-provider: oidc
@@ -299,5 +322,38 @@ users:
     token: static-bearer
 "#;
         assert!(detect_oidc_user(&auth_of(yaml)).is_none());
+    }
+
+    #[test]
+    fn is_srelens_managed_oidc_requires_the_marker() {
+        // srelens-form-added: exec with the SRELENS_MANAGED_OIDC env marker.
+        let marked = r#"apiVersion: v1
+kind: Config
+users:
+- name: u
+  user:
+    exec:
+      command: kubelogin
+      args: [get-token, --oidc-issuer-url=https://idp, --oidc-client-id=k8s]
+      env:
+      - {name: SRELENS_MANAGED_OIDC, value: "1"}
+"#;
+        assert!(is_srelens_managed_oidc(&auth_of(marked)));
+
+        // A user's own kubelogin cluster: same exec shape, no marker → native.
+        let plain = r#"apiVersion: v1
+kind: Config
+users:
+- name: u
+  user:
+    exec:
+      command: kubelogin
+      args: [get-token, --oidc-issuer-url=https://idp, --oidc-client-id=k8s]
+"#;
+        assert!(!is_srelens_managed_oidc(&auth_of(plain)));
+
+        // No exec at all → native.
+        let token = "apiVersion: v1\nkind: Config\nusers:\n- name: u\n  user: {token: static}\n";
+        assert!(!is_srelens_managed_oidc(&auth_of(token)));
     }
 }

--- a/crates/kube/src/oidc_detect.rs
+++ b/crates/kube/src/oidc_detect.rs
@@ -78,6 +78,11 @@ fn exec_flag(args: &[String], flag: &str) -> Option<String> {
 /// `kubectl` exec plugin (kubelogin/aws/gke — which must be left to run
 /// natively). `kubelogin` ignores unknown env vars, so the marker is inert to
 /// the plugin.
+///
+/// The marker is **advisory, not a trust boundary**: it travels in-band in a
+/// file the user controls, so an uploaded kubeconfig can set it and opt itself
+/// into the managed flow. That is no worse than the user editing any other
+/// kubeconfig field, but never use it to make an authorization decision.
 pub const SRELENS_MANAGED_OIDC_ENV: &str = "SRELENS_MANAGED_OIDC";
 
 /// True when a kubeconfig user's `exec` block carries srelens's managed-OIDC
@@ -95,6 +100,13 @@ pub fn is_srelens_managed_oidc(auth: &kube::config::AuthInfo) -> bool {
 }
 
 /// Detect OIDC settings from a kubeconfig user, or None if it isn't OIDC.
+///
+/// This answers "what OIDC config does this user describe?", NOT "should srelens
+/// manage it" — callers gate on [`is_srelens_managed_oidc`] first. Since the
+/// marker lives in an `exec` block and srelens only ever synthesizes the `exec`
+/// form, the legacy `auth-provider: oidc` branch below is currently reachable
+/// only from tests; it is kept so the detector stays complete for kubeconfigs
+/// srelens didn't write (diagnostics, and any future opt-in path).
 pub fn detect_oidc_user(auth: &kube::config::AuthInfo) -> Option<OidcClusterConfig> {
     // 1) Legacy auth-provider: oidc
     if let Some(ap) = &auth.auth_provider {

--- a/crates/server/src/cluster_registry.rs
+++ b/crates/server/src/cluster_registry.rs
@@ -4,7 +4,7 @@
 
 use std::collections::HashMap;
 
-use srelens_kube::oidc_detect::{detect_oidc_user, OidcClusterConfig};
+use srelens_kube::oidc_detect::{detect_oidc_user, is_srelens_managed_oidc, OidcClusterConfig};
 
 #[derive(Default)]
 pub struct ClusterOidcRegistry {
@@ -23,11 +23,18 @@ impl ClusterOidcRegistry {
                 continue;
             };
             // Map user-name -> detected OIDC config.
+            // Only clusters ADDED THROUGH the srelens OIDC form are managed:
+            // their synthesized `exec` carries srelens's marker. A pre-existing
+            // kubeconfig context that uses its own kubelogin/aws/gke exec plugin
+            // has no marker and is left untouched to run natively — even though
+            // `detect_oidc_user` would recognize its shape.
             let mut oidc_users: HashMap<String, OidcClusterConfig> = HashMap::new();
             for named in &kc.auth_infos {
                 if let Some(auth) = &named.auth_info {
-                    if let Some(cfg) = detect_oidc_user(auth) {
-                        oidc_users.insert(named.name.clone(), cfg);
+                    if is_srelens_managed_oidc(auth) {
+                        if let Some(cfg) = detect_oidc_user(auth) {
+                            oidc_users.insert(named.name.clone(), cfg);
+                        }
                     }
                 }
             }
@@ -82,16 +89,37 @@ impl ClusterOidcRegistry {
 mod tests {
     use super::*;
 
-    fn oidc_kc(ctx: &str, issuer: &str, client: &str) -> String {
+    // A kubeconfig the srelens Add-cluster form would synthesize: the exec
+    // kubelogin form WITH srelens's managed-OIDC env marker, so it's routed to
+    // the managed sign-in.
+    fn managed_oidc_kc(ctx: &str, issuer: &str, client: &str) -> String {
         format!(
-            "apiVersion: v1\nkind: Config\nclusters:\n- name: c\n  cluster: {{server: https://x}}\nusers:\n- name: u\n  user:\n    auth-provider:\n      name: oidc\n      config:\n        idp-issuer-url: {issuer}\n        client-id: {client}\ncontexts:\n- name: {ctx}\n  context: {{cluster: c, user: u}}\n"
+            "apiVersion: v1\nkind: Config\nclusters:\n- name: c\n  cluster: {{server: https://x}}\nusers:\n- name: u\n  user:\n    exec:\n      apiVersion: client.authentication.k8s.io/v1beta1\n      command: kubelogin\n      args: [\"get-token\", \"--oidc-issuer-url={issuer}\", \"--oidc-client-id={client}\"]\n      env:\n      - {{name: SRELENS_MANAGED_OIDC, value: \"1\"}}\ncontexts:\n- name: {ctx}\n  context: {{cluster: c, user: u}}\n"
+        )
+    }
+
+    // A user's OWN kubelogin cluster: same exec shape, but NO srelens marker —
+    // it must run its native plugin, not be hijacked into managed sign-in.
+    fn unmarked_kubelogin_kc(ctx: &str) -> String {
+        format!(
+            "apiVersion: v1\nkind: Config\nclusters:\n- name: c\n  cluster: {{server: https://x}}\nusers:\n- name: u\n  user:\n    exec:\n      apiVersion: client.authentication.k8s.io/v1beta1\n      command: kubelogin\n      args: [\"get-token\", \"--oidc-issuer-url=https://idp\", \"--oidc-client-id=k8s\"]\ncontexts:\n- name: {ctx}\n  context: {{cluster: c, user: u}}\n"
         )
     }
 
     #[test]
+    fn unmarked_exec_plugin_context_is_native_not_managed() {
+        // The bug this guards: a pre-existing kubelogin kubeconfig must NOT be
+        // pulled into managed sign-in — only srelens-form-added (marked)
+        // clusters are managed.
+        let reg = ClusterOidcRegistry::from_kubeconfig_yamls(&[unmarked_kubelogin_kc("mine")]);
+        assert!(reg.key_for_context("mine").is_none());
+        assert!(reg.all_keys().is_empty());
+    }
+
+    #[test]
     fn indexes_oidc_contexts_and_dedups_by_key() {
-        let a = oidc_kc("ctx-a", "https://idp", "k8s");
-        let b = oidc_kc("ctx-b", "https://idp", "k8s"); // same issuer+client → same key
+        let a = managed_oidc_kc("ctx-a", "https://idp", "k8s");
+        let b = managed_oidc_kc("ctx-b", "https://idp", "k8s"); // same issuer+client → same key
         let reg = ClusterOidcRegistry::from_kubeconfig_yamls(&[a, b]);
         let ka = reg.key_for_context("ctx-a").unwrap();
         let kb = reg.key_for_context("ctx-b").unwrap();
@@ -104,8 +132,8 @@ mod tests {
 
     #[test]
     fn oidc_clusters_dedups_by_key_and_lists_all_contexts() {
-        let a = oidc_kc("ctx-a", "https://idp", "k8s");
-        let b = oidc_kc("ctx-b", "https://idp", "k8s"); // same issuer+client → same key
+        let a = managed_oidc_kc("ctx-a", "https://idp", "k8s");
+        let b = managed_oidc_kc("ctx-b", "https://idp", "k8s"); // same issuer+client → same key
         let reg = ClusterOidcRegistry::from_kubeconfig_yamls(&[a, b]);
         let entries = reg.oidc_clusters();
         assert_eq!(entries.len(), 1);

--- a/crates/server/src/cluster_registry.rs
+++ b/crates/server/src/cluster_registry.rs
@@ -13,9 +13,12 @@ pub struct ClusterOidcRegistry {
 }
 
 impl ClusterOidcRegistry {
-    /// Build from a user's kubeconfig YAML documents. Contexts whose user is
-    /// OIDC are indexed; non-OIDC contexts are ignored. Malformed YAML
-    /// documents are skipped rather than aborting the whole build.
+    /// Build from a user's kubeconfig YAML documents. A context is indexed only
+    /// when its user carries srelens's managed-OIDC marker (i.e. srelens
+    /// synthesized it from the Add-cluster form); every other context — including
+    /// one whose user *looks* like OIDC to `detect_oidc_user` — is ignored and
+    /// keeps its native auth. Malformed YAML documents are skipped rather than
+    /// aborting the whole build.
     pub fn from_kubeconfig_yamls(yamls: &[String]) -> Self {
         let mut reg = ClusterOidcRegistry::default();
         for yaml in yamls {

--- a/docs/WEB.md
+++ b/docs/WEB.md
@@ -141,17 +141,18 @@ for API calls — the same approach Headlamp takes — so no exec plugin is need
 authenticate you *to srelens*; cluster OIDC authenticates you *to a Kubernetes
 API server*. They can use entirely different identity providers.
 
-You define an OIDC cluster two ways:
+You opt a cluster into managed sign-in through **Settings → Contexts → Add
+cluster**: fill in the API server URL, a CA certificate (or check *skip TLS
+verify*), and the OIDC issuer + client id (+ optional client secret and extra
+scopes). srelens synthesizes and stores the kubeconfig, stamping it with an
+internal marker so *only* these clusters use the managed browser flow.
 
-- **Upload a kubeconfig** whose user is an OIDC user — either a legacy
-  `auth-provider: oidc` block (`idp-issuer-url`, `client-id`, optional
-  `client-secret`/`extra-scopes`) or an `exec` `kubelogin`/`oidc-login` plugin
-  (srelens reads the issuer/client from its flags). srelens detects it
-  automatically.
-- **Settings → Contexts → Add cluster**: fill in the API server URL, a CA
-  certificate (or check *skip TLS verify*), and the OIDC issuer + client id
-  (+ optional client secret and extra scopes). srelens synthesizes and stores
-  the kubeconfig for you.
+**Clusters from an existing kubeconfig are left alone.** A context that already
+authenticates with its own `kubectl` exec plugin — `kubelogin`/`oidc-login`,
+`aws eks get-token`, `gke-gcloud-auth-plugin`, etc. — keeps using that plugin
+natively; srelens does **not** take it over, so on desktop your working setup is
+untouched. (On the web container exec plugins can't run at all — so to use such
+a cluster in web mode, re-add it via **Add cluster** to get the managed flow.)
 
 **When you use an OIDC cluster that has no valid token, srelens prompts
 "Sign in to `<cluster>`"** (from any view or stream). Clicking it runs the


### PR DESCRIPTION
Closes #174.

## Bug
Managed browser sign-in was applied to **every** kubeconfig context whose user is an OIDC exec plugin (`kubelogin`/`oidc-login`). On desktop this overrode working native auth: a cluster from your `~/.kube/config` that authenticates via its own `kubectl` exec plugin (kubelogin/aws/gke) got hijacked into the srelens "Sign in" prompt instead of running its plugin.

## Fix
srelens now marks the kubeconfigs it synthesizes from **Settings → Contexts → Add cluster** with a `SRELENS_MANAGED_OIDC` env sentinel in the exec block (kubelogin ignores unknown env), and `ClusterOidcRegistry::from_kubeconfig_yamls` treats a context as managed **only if it carries that marker** — on both desktop and web.

- Pre-existing kubeconfig contexts with their own exec plugin → **no marker → left to run natively** (fixes the hijack on desktop).
- Clusters added via the srelens OIDC form → marked → managed browser sign-in.
- On web, exec plugins can't run in the container, so an unmarked kubelogin kubeconfig now falls back to the existing "add it via Add cluster" guidance rather than an auto-managed prompt (per the chosen "form-added only, everywhere" scope).

## Tests
- `oidc_detect`: `is_srelens_managed_oidc` true only with the marker.
- `cluster_synth`: synthesized config carries the marker.
- `cluster_registry`: a marked context is indexed; **an unmarked kubelogin context is excluded** (the regression guard).
- Full backend green: kube 283, server 131; desktop unit tests pass.

Docs (`WEB.md`) updated to describe the form-added-only scope.
