### PR TITLE
ci(release): verify AUR's host key by fingerprint, not via a secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -600,27 +600,48 @@ jobs:
           AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
           AUR_USERNAME: ${{ secrets.AUR_USERNAME }}
           AUR_EMAIL: ${{ secrets.AUR_EMAIL }}
-          AUR_KNOWN_HOSTS: ${{ secrets.AUR_KNOWN_HOSTS }}
         run: |
           set -euo pipefail
 
           install -d -m 700 ~/.ssh
           printf '%s\n' "$AUR_SSH_PRIVATE_KEY" > ~/.ssh/aur
           chmod 600 ~/.ssh/aur
-          # AUR's SSH host keys come from the AUR_KNOWN_HOSTS secret (the two
-          # `known_hosts` lines) rather than a runtime ssh-keyscan, whose errors
-          # were swallowed (2>/dev/null) and surfaced only as an opaque "Host key
-          # verification failed" at clone time. These are the server's PUBLIC
-          # host keys; the secret just keeps them out of the workflow. Generate
-          # the value with `ssh-keyscan -t ed25519,rsa aur.archlinux.org` and
-          # verify against AUR's published fingerprints (ED25519
-          # SHA256:RFzBCUItH9LZS0cKB5UE6ceAYhBD5C8GeOBip8Z11+4). See
-          # packaging/aur/README.md.
-          if [ -z "${AUR_KNOWN_HOSTS:-}" ]; then
-            echo "AUR_KNOWN_HOSTS secret is not set — add it (see packaging/aur/README.md)." >&2
+
+          # AUR's host key, fetched at runtime and PINNED BY FINGERPRINT.
+          #
+          # This deliberately does not come from a secret. Carrying the
+          # `known_hosts` lines in AUR_KNOWN_HOSTS made the trust decision
+          # depend on a value nobody can inspect or lint: a paste that loses
+          # the newlines (or the `aur.archlinux.org ` prefix) produces a file
+          # ssh silently ignores, and the only symptom is "Host key
+          # verification failed" at clone time — which is exactly how the
+          # v0.4.0 publish failed.
+          #
+          # Fetching and then checking the fingerprint against the value AUR
+          # publishes keeps the same security property (we still refuse an
+          # unexpected key — this is not TOFU) while making every failure mode
+          # self-describing. Rotate the constant if AUR ever rotates the key;
+          # the job then fails with both fingerprints in the log instead of an
+          # opaque ssh error. See packaging/aur/README.md.
+          AUR_ED25519_FP="SHA256:RFzBCUItH9LZS0cKB5UE6ceAYhBD5C8GeOBip8Z11+4"
+          if ! ssh-keyscan -t ed25519 aur.archlinux.org > ~/.ssh/known_hosts 2> keyscan.err; then
+            echo "::error::ssh-keyscan could not reach aur.archlinux.org"
+            cat keyscan.err >&2
             exit 1
           fi
-          printf '%s\n' "$AUR_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          if [ ! -s ~/.ssh/known_hosts ]; then
+            echo "::error::ssh-keyscan returned no host key for aur.archlinux.org"
+            cat keyscan.err >&2
+            exit 1
+          fi
+          GOT_FP=$(ssh-keygen -lf ~/.ssh/known_hosts | awk '{print $2}')
+          if [ "$GOT_FP" != "$AUR_ED25519_FP" ]; then
+            echo "::error::aur.archlinux.org host key fingerprint mismatch — refusing to push"
+            echo "  expected: $AUR_ED25519_FP" >&2
+            echo "  got:      $GOT_FP" >&2
+            exit 1
+          fi
+          echo "aur.archlinux.org host key verified: $GOT_FP"
           chmod 600 ~/.ssh/known_hosts
           export GIT_SSH_COMMAND="ssh -i ~/.ssh/aur -o IdentitiesOnly=yes"
 

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -93,16 +93,21 @@ The automation cannot run until a human claims the package name on the AUR:
    - `AUR_USERNAME` — your AUR account name
    - `AUR_EMAIL` — the email on that account
    - `AUR_SSH_PRIVATE_KEY` — the private half of the key from step 1
-   - `AUR_KNOWN_HOSTS` — AUR's SSH host keys, so the publish job can verify the
-     server before cloning. These are the server's *public* host keys (not a
-     secret in the cryptographic sense); the secret just keeps them out of the
-     workflow. Generate the value with:
-     ```
-     ssh-keyscan -t ed25519,rsa aur.archlinux.org
-     ```
-     and confirm the fingerprints match AUR's published ones (`ssh-keygen -lf`)
-     — currently ED25519 `SHA256:RFzBCUItH9LZS0cKB5UE6ceAYhBD5C8GeOBip8Z11+4`,
-     RSA `SHA256:5s5cIyReIfNNVGRFdDbe3hdYiI5OelHGpw2rOUud3Q8` — before pasting.
+
+   There is deliberately **no** `AUR_KNOWN_HOSTS` secret. The publish job fetches
+   AUR's host key with `ssh-keyscan` and refuses to continue unless its
+   fingerprint matches a constant pinned in `.github/workflows/release.yml`
+   (currently ED25519 `SHA256:RFzBCUItH9LZS0cKB5UE6ceAYhBD5C8GeOBip8Z11+4`) — so
+   an unexpected key still stops the push, but the trust decision lives in
+   reviewable code rather than in an opaque secret whose formatting nobody can
+   check. A secret that lost its newlines on paste is what broke the v0.4.0
+   publish, with ssh reporting only "Host key verification failed".
+
+   If AUR rotates its host key, verify the new one against Arch's published
+   fingerprints and update the constant in the workflow:
+   ```
+   ssh-keyscan -t ed25519 aur.archlinux.org | ssh-keygen -lf -
+   ```
 
 The current stable release is **`srelens-v0.2.0`**, so the initial import can be
 done against it today (the PKGBUILD builds cleanly against its published `.deb`).


### PR DESCRIPTION
Fixes the failed AUR publish from the v0.4.0 release.

## What happened
`publish AUR (srelens-bin)` died at the clone:
```
Cloning into 'aur'...
Host key verification failed.
fatal: Could not read from remote repository.
```

## Diagnosis
AUR's host key has **not** rotated — a keyscan today returns the same ED25519 key whose fingerprint `8a3781c` already pinned in a comment:
```
$ ssh-keyscan -t ed25519 aur.archlinux.org | ssh-keygen -lf -
256 SHA256:RFzBCUItH9LZS0cKB5UE6ceAYhBD5C8GeOBip8Z11+4 aur.archlinux.org (ED25519)
```
The `AUR_KNOWN_HOSTS` secret was set and non-empty (the job's own guard passed), so the fault is its **content** — most likely newlines lost on paste, which produces a `known_hosts` ssh silently ignores.

## Fix
Drop the secret. Fetch the key with `ssh-keyscan` and refuse to continue unless the fingerprint matches a constant pinned in the workflow.

This keeps the security property — an unexpected key still aborts the push, so it is **not** TOFU — while moving the trust decision into reviewable code. And every failure now names itself instead of surfacing as one opaque ssh line: unreachable host, empty scan, or a mismatch printed with both the expected and received fingerprint.

## Verification
Ran the exact block against the live server: fingerprint matches and the job would proceed; substituting a bogus pin aborts as intended. YAML parses.

Note the job still no-ops unless `AUR_SSH_PRIVATE_KEY` is configured, and it only runs on stable releases — so the next stable cut is the real end-to-end test.

`AUR_KNOWN_HOSTS` can be deleted from repository secrets once this lands.