### PR TITLE
fix(updater): render release notes as markup, and keep the commit scope

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,8 +121,14 @@ jobs:
             sub("apps/desktop/src-tauri/Cargo.toml",/^version = "[^"]+"/m,`version = "${v}"`);
             sub("Cargo.lock",/(name = "srelens-desktop"\r?\nversion = ")[^"]+(")/,`$1${v}$2`);
           ' "$NEW"
-          # Grouped changelog for the release body.
-          strip='s/^[a-z]+(\([^)]*\))?!?:[[:space:]]*//'
+          # Grouped changelog for the release body. The Conventional Commit type
+          # is dropped (the section heading already says Features / Fixes) but
+          # the SCOPE is kept as a bold lead-in: without it, subjects written to
+          # follow a scope read as context-free fragments in the release notes
+          # and the in-app updater — "full action coverage, capability audit,
+          # and smarter ranking" tells a user nothing that "**palette:** ..."
+          # does. Line 1 handles scoped commits, line 2 unscoped ones.
+          strip='s/^[a-z]+\(([^)]*)\)!?:[[:space:]]*/**\1:** /; s/^[a-z]+!?:[[:space:]]*//'
           FEATS=$(git log --no-merges --pretty=%s ${RANGE} | grep -E '^feat' | sed -E "$strip" | sed 's/^/- /' || true)
           FIXES=$(git log --no-merges --pretty=%s ${RANGE} | grep -E '^(fix|perf)' | sed -E "$strip" | sed 's/^/- /' || true)
           {

--- a/apps/desktop/src/components/ReleaseNotes.test.tsx
+++ b/apps/desktop/src/components/ReleaseNotes.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ReleaseNotes } from "./ReleaseNotes";
+
+describe("ReleaseNotes", () => {
+  it("renders headings and bullets as real elements, not raw markdown", () => {
+    const { container } = render(
+      <ReleaseNotes notes={"### Features\n- **forward:** saved forwards (#173)\n- web mode (#165)"} />,
+    );
+    expect(screen.getByRole("heading", { name: "Features" })).toBeTruthy();
+    expect(container.querySelectorAll("li")).toHaveLength(2);
+    expect(container.querySelector("strong")?.textContent).toBe("forward:");
+    // The regression this guards: markdown syntax leaking through as text.
+    expect(container.textContent).not.toContain("###");
+    expect(container.textContent).not.toContain("**");
+  });
+
+  it("renders inline code from dev-channel notes", () => {
+    const { container } = render(<ReleaseNotes notes={"**Commit:** `deadbeef`"} />);
+    expect(container.querySelector("code")?.textContent).toBe("deadbeef");
+  });
+
+  it("renders nothing when there are no notes", () => {
+    const { container } = render(<ReleaseNotes notes="   " />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("escapes markup in note text rather than injecting it", () => {
+    const { container } = render(<ReleaseNotes notes={"- <img src=x onerror=alert(1)>"} />);
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.textContent).toContain("<img src=x onerror=alert(1)>");
+  });
+});

--- a/apps/desktop/src/components/ReleaseNotes.tsx
+++ b/apps/desktop/src/components/ReleaseNotes.tsx
@@ -1,0 +1,51 @@
+import { parseReleaseNotes, type NoteSpan } from "../lib/releaseNotes";
+
+// Renders the update dialog's release notes as real headings and lists instead
+// of dumping the raw markdown into a <pre>. Everything goes through React
+// elements — no dangerouslySetInnerHTML — so note text can never inject markup.
+
+function Spans({ spans }: { spans: NoteSpan[] }) {
+  return (
+    <>
+      {spans.map((span, i) => {
+        if (span.kind === "code") return <code key={i}>{span.text}</code>;
+        if (span.kind === "strong") return <strong key={i}>{span.text}</strong>;
+        return <span key={i}>{span.text}</span>;
+      })}
+    </>
+  );
+}
+
+export function ReleaseNotes({ notes }: { notes: string }) {
+  const blocks = parseReleaseNotes(notes);
+  if (!blocks.length) return null;
+  return (
+    <div className="fl-settings-update__notes">
+      {blocks.map((block, i) => {
+        if (block.kind === "heading") {
+          return (
+            <h4 key={i} className="fl-release-notes__heading">
+              <Spans spans={block.spans} />
+            </h4>
+          );
+        }
+        if (block.kind === "list") {
+          return (
+            <ul key={i} className="fl-release-notes__list">
+              {block.items.map((item, j) => (
+                <li key={j}>
+                  <Spans spans={item} />
+                </li>
+              ))}
+            </ul>
+          );
+        }
+        return (
+          <p key={i} className="fl-release-notes__para">
+            <Spans spans={block.spans} />
+          </p>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/SettingsView.tsx
+++ b/apps/desktop/src/components/SettingsView.tsx
@@ -70,6 +70,7 @@ import { isTauri } from "../transport/platform";
 import { WebKubeconfigSection } from "./WebKubeconfigSection";
 import { WebAddClusterSection } from "./WebAddClusterSection";
 import { WebClusterSignInSection } from "./WebClusterSignInSection";
+import { ReleaseNotes } from "./ReleaseNotes";
 
 const MODE_OPTIONS: Array<{ mode: ThemeMode; label: string; description: string; icon: React.ElementType }> = [
   { mode: "dark", label: "Dark", description: "Low-light operational workspace", icon: Moon },
@@ -960,9 +961,7 @@ export function SettingsView({
                       Version <strong>{updateState.update.version}</strong> is available on the {updateChannel}{" "}
                       channel.
                     </p>
-                    {updateState.update.notes && (
-                      <pre className="fl-settings-update__notes">{updateState.update.notes}</pre>
-                    )}
+                    {updateState.update.notes && <ReleaseNotes notes={updateState.update.notes} />}
                     {updateState.update.external ? (
                       <p className="fl-settings-update__status">
                         This install is managed by your system package manager — update it there

--- a/apps/desktop/src/lib/releaseNotes.test.ts
+++ b/apps/desktop/src/lib/releaseNotes.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { parseReleaseNotes, parseSpans } from "./releaseNotes";
+
+describe("parseSpans", () => {
+  it("splits inline code and bold out of surrounding text", () => {
+    expect(parseSpans("**Commit:** `abc123` landed")).toEqual([
+      { kind: "strong", text: "Commit:" },
+      { kind: "text", text: " " },
+      { kind: "code", text: "abc123" },
+      { kind: "text", text: " landed" },
+    ]);
+  });
+
+  it("leaves unmatched markers as literal text", () => {
+    expect(parseSpans("2 ** 3 is not bold")).toEqual([{ kind: "text", text: "2 ** 3 is not bold" }]);
+    expect(parseSpans("a ` dangling tick")).toEqual([{ kind: "text", text: "a ` dangling tick" }]);
+  });
+
+  it("returns nothing for an empty line", () => {
+    expect(parseSpans("")).toEqual([]);
+  });
+});
+
+describe("parseReleaseNotes", () => {
+  // Exactly what the stable release workflow emits.
+  it("parses the generated stable-release shape", () => {
+    const blocks = parseReleaseNotes(
+      "### Features\n- **forward:** resilient port-forwards (#173)\n- web mode (#165)\n\n### Fixes\n- **tabs:** cache list rows\n",
+    );
+    expect(blocks).toEqual([
+      { kind: "heading", spans: [{ kind: "text", text: "Features" }] },
+      {
+        kind: "list",
+        items: [
+          [
+            { kind: "strong", text: "forward:" },
+            { kind: "text", text: " resilient port-forwards (#173)" },
+          ],
+          [{ kind: "text", text: "web mode (#165)" }],
+        ],
+      },
+      { kind: "heading", spans: [{ kind: "text", text: "Fixes" }] },
+      {
+        kind: "list",
+        items: [
+          [
+            { kind: "strong", text: "tabs:" },
+            { kind: "text", text: " cache list rows" },
+          ],
+        ],
+      },
+    ]);
+  });
+
+  // And what the dev-channel job emits — prose, bold labels, inline code.
+  it("parses the dev pre-release shape", () => {
+    const blocks = parseReleaseNotes(
+      "Development pre-release — unstable.\n\n**Commit:** `deadbeef`\n\n### Recent changes\n- fix: a thing (abc1234)\n",
+    );
+    expect(blocks.map((b) => b.kind)).toEqual(["paragraph", "paragraph", "heading", "list"]);
+  });
+
+  it("joins hard-wrapped prose into one paragraph but keeps bullets separate", () => {
+    const blocks = parseReleaseNotes("one line\nand its continuation\n- a bullet\n- another");
+    expect(blocks).toEqual([
+      { kind: "paragraph", spans: [{ kind: "text", text: "one line and its continuation" }] },
+      {
+        kind: "list",
+        items: [[{ kind: "text", text: "a bullet" }], [{ kind: "text", text: "another" }]],
+      },
+    ]);
+  });
+
+  it("treats a blank line as a block boundary between two lists", () => {
+    const blocks = parseReleaseNotes("- one\n\n- two");
+    expect(blocks).toEqual([
+      { kind: "list", items: [[{ kind: "text", text: "one" }]] },
+      { kind: "list", items: [[{ kind: "text", text: "two" }]] },
+    ]);
+  });
+
+  it("accepts * bullets and any heading depth", () => {
+    const blocks = parseReleaseNotes("# Title\n* starred");
+    expect(blocks).toEqual([
+      { kind: "heading", spans: [{ kind: "text", text: "Title" }] },
+      { kind: "list", items: [[{ kind: "text", text: "starred" }]] },
+    ]);
+  });
+
+  it("keeps unrecognised text rather than dropping it", () => {
+    expect(parseReleaseNotes("> a quote\n| a table |")).toEqual([
+      { kind: "paragraph", spans: [{ kind: "text", text: "> a quote | a table |" }] },
+    ]);
+  });
+
+  it("returns no blocks for empty or whitespace-only notes", () => {
+    expect(parseReleaseNotes("")).toEqual([]);
+    expect(parseReleaseNotes("\n  \n\n")).toEqual([]);
+  });
+});

--- a/apps/desktop/src/lib/releaseNotes.ts
+++ b/apps/desktop/src/lib/releaseNotes.ts
@@ -1,0 +1,92 @@
+// Parser for the release notes the updater shows. The notes come from our own
+// release workflow, so this handles that dialect rather than markdown at large:
+// `### Heading` sections, `-` bullets, plain paragraphs, and inline `**bold**`
+// and `code`. Anything it doesn't recognise falls through as a paragraph, so a
+// hand-edited GitHub release body still renders as readable text instead of
+// disappearing.
+//
+// Deliberately a hand-rolled subset, not a markdown dependency: the input is
+// ours, the surface is four constructs, and the output feeds React elements —
+// never `dangerouslySetInnerHTML` — so untrusted note text cannot inject markup.
+
+/** An inline run within a line: plain text, `code`, or **bold**. */
+export type NoteSpan =
+  | { kind: "text"; text: string }
+  | { kind: "code"; text: string }
+  | { kind: "strong"; text: string };
+
+export type NoteBlock =
+  | { kind: "heading"; spans: NoteSpan[] }
+  | { kind: "list"; items: NoteSpan[][] }
+  | { kind: "paragraph"; spans: NoteSpan[] };
+
+/** Split one line into inline spans. Unclosed markers stay literal text. */
+export function parseSpans(line: string): NoteSpan[] {
+  const spans: NoteSpan[] = [];
+  // Alternation order matters: `**` must be tried before a single `*` would be,
+  // and backticks bind tighter than emphasis in the notes we generate.
+  const pattern = /`([^`]+)`|\*\*([^*]+)\*\*/g;
+  let last = 0;
+  for (let m = pattern.exec(line); m; m = pattern.exec(line)) {
+    if (m.index > last) spans.push({ kind: "text", text: line.slice(last, m.index) });
+    if (m[1] !== undefined) spans.push({ kind: "code", text: m[1] });
+    else spans.push({ kind: "strong", text: m[2] });
+    last = m.index + m[0].length;
+  }
+  if (last < line.length) spans.push({ kind: "text", text: line.slice(last) });
+  return spans;
+}
+
+/**
+ * Parse release-note text into renderable blocks. Consecutive bullets collapse
+ * into one list; blank lines end the current block; consecutive plain lines join
+ * into a single paragraph so hard-wrapped prose doesn't render as fragments.
+ */
+export function parseReleaseNotes(notes: string): NoteBlock[] {
+  const blocks: NoteBlock[] = [];
+  let list: NoteSpan[][] | null = null;
+  let para: string[] = [];
+
+  const flushParagraph = () => {
+    if (para.length) {
+      blocks.push({ kind: "paragraph", spans: parseSpans(para.join(" ")) });
+      para = [];
+    }
+  };
+  const flushList = () => {
+    if (list) {
+      blocks.push({ kind: "list", items: list });
+      list = null;
+    }
+  };
+  const flushAll = () => {
+    flushParagraph();
+    flushList();
+  };
+
+  for (const raw of notes.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line) {
+      flushAll();
+      continue;
+    }
+    const heading = /^#{1,6}\s+(.*)$/.exec(line);
+    if (heading) {
+      flushAll();
+      blocks.push({ kind: "heading", spans: parseSpans(heading[1]) });
+      continue;
+    }
+    const bullet = /^[-*]\s+(.*)$/.exec(line);
+    if (bullet) {
+      // A bullet ends a paragraph but continues any run of bullets above it.
+      flushParagraph();
+      list ??= [];
+      list.push(parseSpans(bullet[1]));
+      continue;
+    }
+    flushList();
+    para.push(line);
+  }
+  flushAll();
+  return blocks;
+}

--- a/apps/desktop/src/ui/styles.css
+++ b/apps/desktop/src/ui/styles.css
@@ -2701,13 +2701,45 @@ body {
   margin: 0;
 }
 .fl-settings-update__notes {
-  max-height: 180px;
+  max-height: 220px;
   overflow: auto;
-  padding: 10px 12px;
+  padding: 12px 14px;
   border: 1px solid var(--fl-color-border-faint);
   border-radius: var(--fl-radius-md);
+  font-size: 13px;
+  line-height: 1.5;
+}
+/* First and last child margins would otherwise show as uneven inner padding. */
+.fl-settings-update__notes > :first-child {
+  margin-top: 0;
+}
+.fl-settings-update__notes > :last-child {
+  margin-bottom: 0;
+}
+.fl-release-notes__heading {
+  margin: 14px 0 6px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--fl-color-text-muted);
+}
+.fl-release-notes__list {
+  margin: 0;
+  padding-left: 18px;
+  list-style: disc;
+}
+.fl-release-notes__list li {
+  margin: 3px 0;
+}
+.fl-release-notes__para {
+  margin: 8px 0;
+}
+.fl-settings-update__notes code {
+  padding: 1px 4px;
+  border-radius: var(--fl-radius-sm);
+  background: var(--fl-color-surface-alt);
   font-size: 12px;
-  white-space: pre-wrap;
 }
 .fl-settings-width-grid {
   display: grid;


### PR DESCRIPTION
Two separate defects behind the same bad screenshot.

## 1. The app printed raw markdown
`SettingsView` dumped the release body into a `<pre>`, so the update panel showed literal `### Features` and `- ...` in a monospace block.

**Fix:** parse the small dialect our release workflow emits — `###` headings, `-` bullets, paragraphs, inline `` `code` `` and `**bold**` — and render real `<h4>`/`<ul>`/`<p>`.

Hand-rolled rather than pulling in a markdown renderer: the input is ours, the surface is four constructs, and everything goes through React elements — never `dangerouslySetInnerHTML` — so note text cannot inject markup. Unrecognised lines fall through as paragraphs, so a hand-edited GitHub release body still renders as readable text instead of vanishing.

## 2. The notes were context-free fragments
The workflow stripped the whole Conventional Commit prefix, scope included. That turned real subjects into bullets that explain nothing:

| Before | After |
|---|---|
| `full action coverage, capability audit, and smarter ranking (#171)` | `**palette:** full action coverage, capability audit, and smarter ranking (#171)` |
| `cache list rows across mounts...` | `**tabs:** cache list rows across mounts...` |
| `only manage clusters added via the srelens form (#175)` | `**cluster-oidc:** only manage clusters added via the srelens form (#175)` |

The type is still dropped — the `Features` / `Fixes` heading already says it — but the scope is kept as a bold lead-in.

## Also
The new CSS uses `--fl-color-surface-alt`. While writing it I reached for `--fl-color-surface-sunken`, which turns out to be defined in **none** of the 15 themes (0 definitions, and the only reference in the file was the line I'd just added) — it would have silently resolved to nothing.

## Verification
- 14 new tests: parser shapes for both the stable and dev-channel note formats, unclosed-marker handling, empty input, plus component tests asserting no `###`/`**` leaks through as text and that markup in note text is escaped rather than injected.
- Full suite green: 105 files, 730 tests, coverage floor held. `pnpm build` clean. Workflow YAML parses, and I rendered the 0.4.0 notes through the new `sed` to confirm the output.

Not verified: the panel in a running app against a live update — the parser and component tests stand in for it, but a screenshot on the next release is the real check.