### PR TITLE
release: srelens v0.4.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -600,27 +600,48 @@ jobs:
           AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
           AUR_USERNAME: ${{ secrets.AUR_USERNAME }}
           AUR_EMAIL: ${{ secrets.AUR_EMAIL }}
-          AUR_KNOWN_HOSTS: ${{ secrets.AUR_KNOWN_HOSTS }}
         run: |
           set -euo pipefail
 
           install -d -m 700 ~/.ssh
           printf '%s\n' "$AUR_SSH_PRIVATE_KEY" > ~/.ssh/aur
           chmod 600 ~/.ssh/aur
-          # AUR's SSH host keys come from the AUR_KNOWN_HOSTS secret (the two
-          # `known_hosts` lines) rather than a runtime ssh-keyscan, whose errors
-          # were swallowed (2>/dev/null) and surfaced only as an opaque "Host key
-          # verification failed" at clone time. These are the server's PUBLIC
-          # host keys; the secret just keeps them out of the workflow. Generate
-          # the value with `ssh-keyscan -t ed25519,rsa aur.archlinux.org` and
-          # verify against AUR's published fingerprints (ED25519
-          # SHA256:RFzBCUItH9LZS0cKB5UE6ceAYhBD5C8GeOBip8Z11+4). See
-          # packaging/aur/README.md.
-          if [ -z "${AUR_KNOWN_HOSTS:-}" ]; then
-            echo "AUR_KNOWN_HOSTS secret is not set — add it (see packaging/aur/README.md)." >&2
+
+          # AUR's host key, fetched at runtime and PINNED BY FINGERPRINT.
+          #
+          # This deliberately does not come from a secret. Carrying the
+          # `known_hosts` lines in AUR_KNOWN_HOSTS made the trust decision
+          # depend on a value nobody can inspect or lint: a paste that loses
+          # the newlines (or the `aur.archlinux.org ` prefix) produces a file
+          # ssh silently ignores, and the only symptom is "Host key
+          # verification failed" at clone time — which is exactly how the
+          # v0.4.0 publish failed.
+          #
+          # Fetching and then checking the fingerprint against the value AUR
+          # publishes keeps the same security property (we still refuse an
+          # unexpected key — this is not TOFU) while making every failure mode
+          # self-describing. Rotate the constant if AUR ever rotates the key;
+          # the job then fails with both fingerprints in the log instead of an
+          # opaque ssh error. See packaging/aur/README.md.
+          AUR_ED25519_FP="SHA256:RFzBCUItH9LZS0cKB5UE6ceAYhBD5C8GeOBip8Z11+4"
+          if ! ssh-keyscan -t ed25519 aur.archlinux.org > ~/.ssh/known_hosts 2> keyscan.err; then
+            echo "::error::ssh-keyscan could not reach aur.archlinux.org"
+            cat keyscan.err >&2
             exit 1
           fi
-          printf '%s\n' "$AUR_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          if [ ! -s ~/.ssh/known_hosts ]; then
+            echo "::error::ssh-keyscan returned no host key for aur.archlinux.org"
+            cat keyscan.err >&2
+            exit 1
+          fi
+          GOT_FP=$(ssh-keygen -lf ~/.ssh/known_hosts | awk '{print $2}')
+          if [ "$GOT_FP" != "$AUR_ED25519_FP" ]; then
+            echo "::error::aur.archlinux.org host key fingerprint mismatch — refusing to push"
+            echo "  expected: $AUR_ED25519_FP" >&2
+            echo "  got:      $GOT_FP" >&2
+            exit 1
+          fi
+          echo "aur.archlinux.org host key verified: $GOT_FP"
           chmod 600 ~/.ssh/known_hosts
           export GIT_SSH_COMMAND="ssh -i ~/.ssh/aur -o IdentitiesOnly=yes"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,8 +121,14 @@ jobs:
             sub("apps/desktop/src-tauri/Cargo.toml",/^version = "[^"]+"/m,`version = "${v}"`);
             sub("Cargo.lock",/(name = "srelens-desktop"\r?\nversion = ")[^"]+(")/,`$1${v}$2`);
           ' "$NEW"
-          # Grouped changelog for the release body.
-          strip='s/^[a-z]+(\([^)]*\))?!?:[[:space:]]*//'
+          # Grouped changelog for the release body. The Conventional Commit type
+          # is dropped (the section heading already says Features / Fixes) but
+          # the SCOPE is kept as a bold lead-in: without it, subjects written to
+          # follow a scope read as context-free fragments in the release notes
+          # and the in-app updater — "full action coverage, capability audit,
+          # and smarter ranking" tells a user nothing that "**palette:** ..."
+          # does. Line 1 handles scoped commits, line 2 unscoped ones.
+          strip='s/^[a-z]+\(([^)]*)\)!?:[[:space:]]*/**\1:** /; s/^[a-z]+!?:[[:space:]]*//'
           FEATS=$(git log --no-merges --pretty=%s ${RANGE} | grep -E '^feat' | sed -E "$strip" | sed 's/^/- /' || true)
           FIXES=$(git log --no-merges --pretty=%s ${RANGE} | grep -E '^(fix|perf)' | sed -E "$strip" | sed 's/^/- /' || true)
           {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,10 +352,10 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-util",
- "http 1.4.2",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.10.1",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit",
@@ -369,7 +369,7 @@ dependencies = [
  "serde_path_to_error",
  "serde_urlencoded",
  "sha1",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
  "tower",
@@ -387,13 +387,13 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.4.2",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -407,7 +407,7 @@ checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
  "getrandom 0.2.17",
  "instant",
- "rand",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -415,12 +415,6 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -754,6 +748,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,16 +825,6 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -851,7 +846,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.13.0",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -864,7 +859,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.13.0",
- "core-foundation 0.10.1",
+ "core-foundation",
  "libc",
 ]
 
@@ -941,7 +936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -953,7 +948,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1386,7 +1381,7 @@ dependencies = [
  "hkdf",
  "pem-rfc7468",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -1411,15 +1406,6 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "endi"
@@ -1567,7 +1553,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1968,8 +1954,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2085,7 +2074,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2142,25 +2131,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.14.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2214,7 +2184,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "headers-core",
- "http 1.4.2",
+ "http",
  "httpdate",
  "mime",
  "sha1",
@@ -2226,7 +2196,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http 1.4.2",
+ "http",
 ]
 
 [[package]]
@@ -2292,17 +2262,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
@@ -2313,23 +2272,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.2",
+ "http",
 ]
 
 [[package]]
@@ -2340,8 +2288,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.2",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -2368,30 +2316,6 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
@@ -2400,8 +2324,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "http 1.4.2",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -2420,28 +2344,14 @@ dependencies = [
  "bytes",
  "futures-util",
  "headers",
- "http 1.4.2",
- "hyper 1.10.1",
- "hyper-rustls 0.27.9",
+ "http",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -2450,15 +2360,16 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.2",
- "hyper 1.10.1",
+ "http",
+ "hyper",
  "hyper-util",
  "log",
- "rustls 0.23.41",
+ "rustls",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2467,7 +2378,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.10.1",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2484,14 +2395,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.2",
- "http-body 1.0.1",
- "hyper 1.10.1",
+ "http",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2955,21 +2866,21 @@ dependencies = [
  "either",
  "futures",
  "home",
- "http 1.4.2",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.10.1",
+ "hyper",
  "hyper-http-proxy",
- "hyper-rustls 0.27.9",
+ "hyper-rustls",
  "hyper-timeout",
  "hyper-util",
  "jsonpath-rust",
  "k8s-openapi",
  "kube-core",
  "pem",
- "rand",
- "rustls 0.23.41",
- "rustls-pemfile 2.2.0",
+ "rand 0.8.6",
+ "rustls",
+ "rustls-pemfile",
  "secrecy",
  "serde",
  "serde_json",
@@ -2991,7 +2902,7 @@ checksum = "f42346d30bb34d1d7adc5c549b691bce7aa3a1e60254e68fab7e2d7b26fe3d77"
 dependencies = [
  "chrono",
  "form_urlencoded",
- "http 1.4.2",
+ "http",
  "json-patch 2.0.0",
  "k8s-openapi",
  "serde",
@@ -3144,6 +3055,12 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 dependencies = [
  "value-bag",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "markup5ever"
@@ -3315,7 +3232,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -3388,16 +3305,16 @@ dependencies = [
 
 [[package]]
 name = "oauth2"
-version = "4.4.2"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c38841cdd844847e3e7c8d29cef9dcfed8877f8f56f9071f77843ecf3baf937f"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
- "http 0.2.12",
- "rand",
- "reqwest 0.11.27",
+ "http",
+ "rand 0.8.6",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -3639,26 +3556,25 @@ dependencies = [
 
 [[package]]
 name = "openidconnect"
-version = "3.5.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47e80a9cfae4462dd29c41e987edd228971d6565553fbc14b8a11e666d91590"
+checksum = "0d8c6709ba2ea764bbed26bce1adf3c10517113ddea6f2d4196e4851757ef2b2"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.7",
  "chrono",
  "dyn-clone",
  "ed25519-dalek",
  "hmac",
- "http 0.2.12",
+ "http",
  "itertools",
  "log",
  "oauth2",
  "p256",
  "p384",
- "rand",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "serde-value",
- "serde_derive",
  "serde_json",
  "serde_path_to_error",
  "serde_plain",
@@ -4206,6 +4122,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4240,7 +4212,18 @@ checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4250,7 +4233,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4260,6 +4243,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4357,43 +4355,40 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-core",
- "futures-util",
- "h2",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
- "ipnet",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
  "js-sys",
  "log",
- "mime",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration",
+ "sync_wrapper",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
- "winreg 0.50.0",
 ]
 
 [[package]]
@@ -4407,24 +4402,24 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.2",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.10.1",
- "hyper-rustls 0.27.9",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.23.41",
+ "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -4526,7 +4521,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
@@ -4578,7 +4573,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",
@@ -4615,18 +4610,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
@@ -4635,7 +4618,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -4654,15 +4637,6 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
-]
-
-[[package]]
-name = "rustls-pemfile"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
@@ -4676,6 +4650,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -4685,15 +4660,15 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "jni 0.22.4",
  "log",
  "once_cell",
- "rustls 0.23.41",
+ "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -4705,16 +4680,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -4815,16 +4780,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4860,7 +4815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.13.0",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -5232,7 +5187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5282,16 +5237,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5483,7 +5428,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.6",
  "rsa",
  "sha1",
  "sha2 0.10.9",
@@ -5520,7 +5465,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -5603,7 +5548,7 @@ dependencies = [
  "flate2",
  "futures",
  "hex",
- "http 1.4.2",
+ "http",
  "k8s-openapi",
  "kube",
  "schemars 0.8.22",
@@ -5653,7 +5598,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.17",
  "hex",
- "hyper 1.10.1",
+ "hyper",
  "hyper-util",
  "kube",
  "mime_guess",
@@ -5784,12 +5729,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -5806,27 +5745,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -5850,7 +5768,7 @@ checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
  "bitflags 2.13.0",
  "block2",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-graphics",
  "crossbeam-channel",
  "dbus",
@@ -5932,7 +5850,7 @@ dependencies = [
  "glob",
  "gtk",
  "heck 0.5.0",
- "http 1.4.2",
+ "http",
  "jni 0.21.1",
  "libc",
  "log",
@@ -6151,14 +6069,14 @@ dependencies = [
  "dirs",
  "flate2",
  "futures-util",
- "http 1.4.2",
+ "http",
  "infer",
  "log",
  "minisign-verify",
  "osakit",
  "percent-encoding",
  "reqwest 0.13.4",
- "rustls 0.23.41",
+ "rustls",
  "semver",
  "serde",
  "serde_json",
@@ -6183,7 +6101,7 @@ dependencies = [
  "cookie",
  "dpi",
  "gtk",
- "http 1.4.2",
+ "http",
  "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
@@ -6206,7 +6124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe41e015bf8fc4d6477ff4926a0ef769dc64ff34c7b0038b6f7cacae892acb5c"
 dependencies = [
  "gtk",
- "http 1.4.2",
+ "http",
  "jni 0.21.1",
  "log",
  "objc2",
@@ -6238,7 +6156,7 @@ dependencies = [
  "dom_query",
  "dunce",
  "glob",
- "http 1.4.2",
+ "http",
  "infer",
  "json-patch 3.0.1",
  "log",
@@ -6434,7 +6352,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.4",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -6452,21 +6370,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.41",
+ "rustls",
  "tokio",
 ]
 
@@ -6636,7 +6544,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-util",
  "tower-layer",
@@ -6654,8 +6562,8 @@ dependencies = [
  "bitflags 2.13.0",
  "bytes",
  "futures-util",
- "http 1.4.2",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "mime",
  "pin-project-lite",
  "tower",
@@ -6746,10 +6654,10 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.4.2",
+ "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.6",
  "sha1",
  "thiserror 1.0.69",
  "utf-8",
@@ -7113,6 +7021,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7179,9 +7097,12 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "webview2-com"
@@ -7764,16 +7685,6 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -7810,7 +7721,7 @@ dependencies = [
  "dunce",
  "gdkx11",
  "gtk",
- "http 1.4.2",
+ "http",
  "javascriptcore-rs",
  "jni 0.21.1",
  "libc",

--- a/apps/desktop/src/components/ReleaseNotes.test.tsx
+++ b/apps/desktop/src/components/ReleaseNotes.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ReleaseNotes } from "./ReleaseNotes";
+
+describe("ReleaseNotes", () => {
+  it("renders headings and bullets as real elements, not raw markdown", () => {
+    const { container } = render(
+      <ReleaseNotes notes={"### Features\n- **forward:** saved forwards (#173)\n- web mode (#165)"} />,
+    );
+    expect(screen.getByRole("heading", { name: "Features" })).toBeTruthy();
+    expect(container.querySelectorAll("li")).toHaveLength(2);
+    expect(container.querySelector("strong")?.textContent).toBe("forward:");
+    // The regression this guards: markdown syntax leaking through as text.
+    expect(container.textContent).not.toContain("###");
+    expect(container.textContent).not.toContain("**");
+  });
+
+  it("renders inline code from dev-channel notes", () => {
+    const { container } = render(<ReleaseNotes notes={"**Commit:** `deadbeef`"} />);
+    expect(container.querySelector("code")?.textContent).toBe("deadbeef");
+  });
+
+  it("renders nothing when there are no notes", () => {
+    const { container } = render(<ReleaseNotes notes="   " />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("escapes markup in note text rather than injecting it", () => {
+    const { container } = render(<ReleaseNotes notes={"- <img src=x onerror=alert(1)>"} />);
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.textContent).toContain("<img src=x onerror=alert(1)>");
+  });
+});

--- a/apps/desktop/src/components/ReleaseNotes.tsx
+++ b/apps/desktop/src/components/ReleaseNotes.tsx
@@ -1,0 +1,51 @@
+import { parseReleaseNotes, type NoteSpan } from "../lib/releaseNotes";
+
+// Renders the update dialog's release notes as real headings and lists instead
+// of dumping the raw markdown into a <pre>. Everything goes through React
+// elements — no dangerouslySetInnerHTML — so note text can never inject markup.
+
+function Spans({ spans }: { spans: NoteSpan[] }) {
+  return (
+    <>
+      {spans.map((span, i) => {
+        if (span.kind === "code") return <code key={i}>{span.text}</code>;
+        if (span.kind === "strong") return <strong key={i}>{span.text}</strong>;
+        return <span key={i}>{span.text}</span>;
+      })}
+    </>
+  );
+}
+
+export function ReleaseNotes({ notes }: { notes: string }) {
+  const blocks = parseReleaseNotes(notes);
+  if (!blocks.length) return null;
+  return (
+    <div className="fl-settings-update__notes">
+      {blocks.map((block, i) => {
+        if (block.kind === "heading") {
+          return (
+            <h4 key={i} className="fl-release-notes__heading">
+              <Spans spans={block.spans} />
+            </h4>
+          );
+        }
+        if (block.kind === "list") {
+          return (
+            <ul key={i} className="fl-release-notes__list">
+              {block.items.map((item, j) => (
+                <li key={j}>
+                  <Spans spans={item} />
+                </li>
+              ))}
+            </ul>
+          );
+        }
+        return (
+          <p key={i} className="fl-release-notes__para">
+            <Spans spans={block.spans} />
+          </p>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/SettingsView.tsx
+++ b/apps/desktop/src/components/SettingsView.tsx
@@ -70,6 +70,7 @@ import { isTauri } from "../transport/platform";
 import { WebKubeconfigSection } from "./WebKubeconfigSection";
 import { WebAddClusterSection } from "./WebAddClusterSection";
 import { WebClusterSignInSection } from "./WebClusterSignInSection";
+import { ReleaseNotes } from "./ReleaseNotes";
 
 const MODE_OPTIONS: Array<{ mode: ThemeMode; label: string; description: string; icon: React.ElementType }> = [
   { mode: "dark", label: "Dark", description: "Low-light operational workspace", icon: Moon },
@@ -960,9 +961,7 @@ export function SettingsView({
                       Version <strong>{updateState.update.version}</strong> is available on the {updateChannel}{" "}
                       channel.
                     </p>
-                    {updateState.update.notes && (
-                      <pre className="fl-settings-update__notes">{updateState.update.notes}</pre>
-                    )}
+                    {updateState.update.notes && <ReleaseNotes notes={updateState.update.notes} />}
                     {updateState.update.external ? (
                       <p className="fl-settings-update__status">
                         This install is managed by your system package manager — update it there

--- a/apps/desktop/src/lib/releaseNotes.test.ts
+++ b/apps/desktop/src/lib/releaseNotes.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { parseReleaseNotes, parseSpans } from "./releaseNotes";
+
+describe("parseSpans", () => {
+  it("splits inline code and bold out of surrounding text", () => {
+    expect(parseSpans("**Commit:** `abc123` landed")).toEqual([
+      { kind: "strong", text: "Commit:" },
+      { kind: "text", text: " " },
+      { kind: "code", text: "abc123" },
+      { kind: "text", text: " landed" },
+    ]);
+  });
+
+  it("leaves unmatched markers as literal text", () => {
+    expect(parseSpans("2 ** 3 is not bold")).toEqual([{ kind: "text", text: "2 ** 3 is not bold" }]);
+    expect(parseSpans("a ` dangling tick")).toEqual([{ kind: "text", text: "a ` dangling tick" }]);
+  });
+
+  it("returns nothing for an empty line", () => {
+    expect(parseSpans("")).toEqual([]);
+  });
+});
+
+describe("parseReleaseNotes", () => {
+  // Exactly what the stable release workflow emits.
+  it("parses the generated stable-release shape", () => {
+    const blocks = parseReleaseNotes(
+      "### Features\n- **forward:** resilient port-forwards (#173)\n- web mode (#165)\n\n### Fixes\n- **tabs:** cache list rows\n",
+    );
+    expect(blocks).toEqual([
+      { kind: "heading", spans: [{ kind: "text", text: "Features" }] },
+      {
+        kind: "list",
+        items: [
+          [
+            { kind: "strong", text: "forward:" },
+            { kind: "text", text: " resilient port-forwards (#173)" },
+          ],
+          [{ kind: "text", text: "web mode (#165)" }],
+        ],
+      },
+      { kind: "heading", spans: [{ kind: "text", text: "Fixes" }] },
+      {
+        kind: "list",
+        items: [
+          [
+            { kind: "strong", text: "tabs:" },
+            { kind: "text", text: " cache list rows" },
+          ],
+        ],
+      },
+    ]);
+  });
+
+  // And what the dev-channel job emits — prose, bold labels, inline code.
+  it("parses the dev pre-release shape", () => {
+    const blocks = parseReleaseNotes(
+      "Development pre-release — unstable.\n\n**Commit:** `deadbeef`\n\n### Recent changes\n- fix: a thing (abc1234)\n",
+    );
+    expect(blocks.map((b) => b.kind)).toEqual(["paragraph", "paragraph", "heading", "list"]);
+  });
+
+  it("joins hard-wrapped prose into one paragraph but keeps bullets separate", () => {
+    const blocks = parseReleaseNotes("one line\nand its continuation\n- a bullet\n- another");
+    expect(blocks).toEqual([
+      { kind: "paragraph", spans: [{ kind: "text", text: "one line and its continuation" }] },
+      {
+        kind: "list",
+        items: [[{ kind: "text", text: "a bullet" }], [{ kind: "text", text: "another" }]],
+      },
+    ]);
+  });
+
+  it("treats a blank line as a block boundary between two lists", () => {
+    const blocks = parseReleaseNotes("- one\n\n- two");
+    expect(blocks).toEqual([
+      { kind: "list", items: [[{ kind: "text", text: "one" }]] },
+      { kind: "list", items: [[{ kind: "text", text: "two" }]] },
+    ]);
+  });
+
+  it("accepts * bullets and any heading depth", () => {
+    const blocks = parseReleaseNotes("# Title\n* starred");
+    expect(blocks).toEqual([
+      { kind: "heading", spans: [{ kind: "text", text: "Title" }] },
+      { kind: "list", items: [[{ kind: "text", text: "starred" }]] },
+    ]);
+  });
+
+  it("keeps unrecognised text rather than dropping it", () => {
+    expect(parseReleaseNotes("> a quote\n| a table |")).toEqual([
+      { kind: "paragraph", spans: [{ kind: "text", text: "> a quote | a table |" }] },
+    ]);
+  });
+
+  it("returns no blocks for empty or whitespace-only notes", () => {
+    expect(parseReleaseNotes("")).toEqual([]);
+    expect(parseReleaseNotes("\n  \n\n")).toEqual([]);
+  });
+});

--- a/apps/desktop/src/lib/releaseNotes.ts
+++ b/apps/desktop/src/lib/releaseNotes.ts
@@ -1,0 +1,92 @@
+// Parser for the release notes the updater shows. The notes come from our own
+// release workflow, so this handles that dialect rather than markdown at large:
+// `### Heading` sections, `-` bullets, plain paragraphs, and inline `**bold**`
+// and `code`. Anything it doesn't recognise falls through as a paragraph, so a
+// hand-edited GitHub release body still renders as readable text instead of
+// disappearing.
+//
+// Deliberately a hand-rolled subset, not a markdown dependency: the input is
+// ours, the surface is four constructs, and the output feeds React elements —
+// never `dangerouslySetInnerHTML` — so untrusted note text cannot inject markup.
+
+/** An inline run within a line: plain text, `code`, or **bold**. */
+export type NoteSpan =
+  | { kind: "text"; text: string }
+  | { kind: "code"; text: string }
+  | { kind: "strong"; text: string };
+
+export type NoteBlock =
+  | { kind: "heading"; spans: NoteSpan[] }
+  | { kind: "list"; items: NoteSpan[][] }
+  | { kind: "paragraph"; spans: NoteSpan[] };
+
+/** Split one line into inline spans. Unclosed markers stay literal text. */
+export function parseSpans(line: string): NoteSpan[] {
+  const spans: NoteSpan[] = [];
+  // Alternation order matters: `**` must be tried before a single `*` would be,
+  // and backticks bind tighter than emphasis in the notes we generate.
+  const pattern = /`([^`]+)`|\*\*([^*]+)\*\*/g;
+  let last = 0;
+  for (let m = pattern.exec(line); m; m = pattern.exec(line)) {
+    if (m.index > last) spans.push({ kind: "text", text: line.slice(last, m.index) });
+    if (m[1] !== undefined) spans.push({ kind: "code", text: m[1] });
+    else spans.push({ kind: "strong", text: m[2] });
+    last = m.index + m[0].length;
+  }
+  if (last < line.length) spans.push({ kind: "text", text: line.slice(last) });
+  return spans;
+}
+
+/**
+ * Parse release-note text into renderable blocks. Consecutive bullets collapse
+ * into one list; blank lines end the current block; consecutive plain lines join
+ * into a single paragraph so hard-wrapped prose doesn't render as fragments.
+ */
+export function parseReleaseNotes(notes: string): NoteBlock[] {
+  const blocks: NoteBlock[] = [];
+  let list: NoteSpan[][] | null = null;
+  let para: string[] = [];
+
+  const flushParagraph = () => {
+    if (para.length) {
+      blocks.push({ kind: "paragraph", spans: parseSpans(para.join(" ")) });
+      para = [];
+    }
+  };
+  const flushList = () => {
+    if (list) {
+      blocks.push({ kind: "list", items: list });
+      list = null;
+    }
+  };
+  const flushAll = () => {
+    flushParagraph();
+    flushList();
+  };
+
+  for (const raw of notes.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line) {
+      flushAll();
+      continue;
+    }
+    const heading = /^#{1,6}\s+(.*)$/.exec(line);
+    if (heading) {
+      flushAll();
+      blocks.push({ kind: "heading", spans: parseSpans(heading[1]) });
+      continue;
+    }
+    const bullet = /^[-*]\s+(.*)$/.exec(line);
+    if (bullet) {
+      // A bullet ends a paragraph but continues any run of bullets above it.
+      flushParagraph();
+      list ??= [];
+      list.push(parseSpans(bullet[1]));
+      continue;
+    }
+    flushList();
+    para.push(line);
+  }
+  flushAll();
+  return blocks;
+}

--- a/apps/desktop/src/ui/styles.css
+++ b/apps/desktop/src/ui/styles.css
@@ -2701,13 +2701,45 @@ body {
   margin: 0;
 }
 .fl-settings-update__notes {
-  max-height: 180px;
+  max-height: 220px;
   overflow: auto;
-  padding: 10px 12px;
+  padding: 12px 14px;
   border: 1px solid var(--fl-color-border-faint);
   border-radius: var(--fl-radius-md);
+  font-size: 13px;
+  line-height: 1.5;
+}
+/* First and last child margins would otherwise show as uneven inner padding. */
+.fl-settings-update__notes > :first-child {
+  margin-top: 0;
+}
+.fl-settings-update__notes > :last-child {
+  margin-bottom: 0;
+}
+.fl-release-notes__heading {
+  margin: 14px 0 6px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--fl-color-text-muted);
+}
+.fl-release-notes__list {
+  margin: 0;
+  padding-left: 18px;
+  list-style: disc;
+}
+.fl-release-notes__list li {
+  margin: 3px 0;
+}
+.fl-release-notes__para {
+  margin: 8px 0;
+}
+.fl-settings-update__notes code {
+  padding: 1px 4px;
+  border-radius: var(--fl-radius-sm);
+  background: var(--fl-color-surface-alt);
   font-size: 12px;
-  white-space: pre-wrap;
 }
 .fl-settings-width-grid {
   display: grid;

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -25,7 +25,7 @@ getrandom = "0.2"
 sha2 = "0.10"
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "sqlite", "migrate", "macros"] }
 async-trait = "0.1"
-openidconnect = { version = "3", default-features = false, features = ["reqwest", "rustls-tls"] }
+openidconnect = { version = "4", default-features = false, features = ["reqwest", "rustls-tls"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.6"

--- a/crates/server/src/auth/oidc.rs
+++ b/crates/server/src/auth/oidc.rs
@@ -3,17 +3,34 @@
 //! issuer discovery.
 
 use openidconnect::core::{CoreAuthenticationFlow, CoreClient, CoreProviderMetadata};
-use openidconnect::reqwest::async_http_client;
 use openidconnect::{
-    AuthorizationCode, ClientId, ClientSecret, CsrfToken, ErrorResponse, IssuerUrl, Nonce,
-    PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, RequestTokenError, Scope,
+    AuthorizationCode, ClientId, ClientSecret, CsrfToken, EndpointMaybeSet, EndpointNotSet,
+    EndpointSet, ErrorResponse, IssuerUrl, Nonce, PkceCodeChallenge, PkceCodeVerifier, RedirectUrl,
+    RequestTokenError, Scope,
 };
 
 use super::idp::{IdentityClaims, IdentityProvider, LoginBegin};
 use super::OidcSettings;
 
+/// The client typestate `from_provider_metadata(..).set_redirect_uri(..)`
+/// produces in openidconnect v4: authorization endpoint known, token and
+/// userinfo endpoints *maybe* set (discovery may omit them), the device-auth /
+/// introspection / revocation endpoints unset. Named once so the struct field
+/// and the constructor can't drift apart.
+type DiscoveredClient = CoreClient<
+    EndpointSet,
+    EndpointNotSet,
+    EndpointNotSet,
+    EndpointNotSet,
+    EndpointMaybeSet,
+    EndpointMaybeSet,
+>;
+
 pub struct OidcProvider {
-    client: CoreClient,
+    client: DiscoveredClient,
+    /// Reused across logins so the connection pool survives; see
+    /// [`crate::oidc_http_client`] for why it refuses redirects.
+    http: openidconnect::reqwest::Client,
 }
 
 impl OidcProvider {
@@ -22,7 +39,8 @@ impl OidcProvider {
     pub async fn discover(settings: &OidcSettings, public_url: &str) -> Result<Self, String> {
         let issuer = IssuerUrl::new(settings.issuer.clone())
             .map_err(|e| format!("invalid SRELENS_OIDC_ISSUER: {e}"))?;
-        let metadata = CoreProviderMetadata::discover_async(issuer, async_http_client)
+        let http = crate::oidc_http_client()?;
+        let metadata = CoreProviderMetadata::discover_async(issuer, &http)
             .await
             .map_err(|e| format!("OIDC discovery failed: {e}"))?;
         let redirect = RedirectUrl::new(format!("{public_url}/auth/callback"))
@@ -33,7 +51,7 @@ impl OidcProvider {
             Some(ClientSecret::new(settings.client_secret.clone())),
         )
         .set_redirect_uri(redirect);
-        Ok(Self { client })
+        Ok(Self { client, http })
     }
 }
 
@@ -96,8 +114,9 @@ impl IdentityProvider for OidcProvider {
         let tokens = self
             .client
             .exchange_code(AuthorizationCode::new(code.to_string()))
+            .map_err(|e| format!("IdP advertised no token endpoint: {e}"))?
             .set_pkce_verifier(PkceCodeVerifier::new(pkce_verifier.to_string()))
-            .request_async(async_http_client)
+            .request_async(&self.http)
             .await
             .map_err(|e| summarize_exchange_error(&e))?;
         let id_token = tokens

--- a/crates/server/src/cluster_oidc.rs
+++ b/crates/server/src/cluster_oidc.rs
@@ -6,10 +6,10 @@
 use std::sync::Arc;
 
 use openidconnect::core::{CoreAuthenticationFlow, CoreClient, CoreProviderMetadata};
-use openidconnect::reqwest::async_http_client;
 use openidconnect::{
-    AuthorizationCode, ClientId, ClientSecret, CsrfToken, IssuerUrl, Nonce, OAuth2TokenResponse,
-    PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, RefreshToken, Scope,
+    AuthorizationCode, ClientId, ClientSecret, CsrfToken, EndpointMaybeSet, EndpointNotSet,
+    EndpointSet, IssuerUrl, Nonce, OAuth2TokenResponse, PkceCodeChallenge, PkceCodeVerifier,
+    RedirectUrl, RefreshToken, Scope,
 };
 
 use srelens_kube::oidc_detect::OidcClusterConfig;
@@ -17,13 +17,29 @@ use srelens_kube::oidc_detect::OidcClusterConfig;
 use crate::cluster_registry::ClusterOidcRegistry;
 use crate::oidc_provider::{RefreshFn, RefreshedToken};
 
+/// The client typestate `from_provider_metadata(..).set_redirect_uri(..)`
+/// produces in openidconnect v4: authorization endpoint known, token and
+/// userinfo endpoints *maybe* set (discovery may omit them), the device-auth /
+/// introspection / revocation endpoints unset.
+type DiscoveredClient = CoreClient<
+    EndpointSet,
+    EndpointNotSet,
+    EndpointNotSet,
+    EndpointNotSet,
+    EndpointMaybeSet,
+    EndpointMaybeSet,
+>;
+
 /// Discover the cluster's IdP and build a client bound to srelens's callback.
+/// Returns the HTTP client alongside it: openidconnect v4 takes the transport
+/// per request, and every call in one flow must use the same one.
 pub async fn build_core_client(
     cfg: &OidcClusterConfig,
     redirect_uri: &str,
-) -> Result<CoreClient, String> {
+) -> Result<(DiscoveredClient, openidconnect::reqwest::Client), String> {
     let issuer = IssuerUrl::new(cfg.issuer.clone()).map_err(|e| format!("invalid issuer: {e}"))?;
-    let metadata = CoreProviderMetadata::discover_async(issuer, async_http_client)
+    let http = crate::oidc_http_client()?;
+    let metadata = CoreProviderMetadata::discover_async(issuer, &http)
         .await
         .map_err(|e| format!("cluster OIDC discovery failed: {e}"))?;
     let redirect = RedirectUrl::new(redirect_uri.to_string()).map_err(|e| e.to_string())?;
@@ -33,7 +49,7 @@ pub async fn build_core_client(
         cfg.client_secret.clone().map(ClientSecret::new),
     )
     .set_redirect_uri(redirect);
-    Ok(client)
+    Ok((client, http))
 }
 
 pub struct ClusterLoginBegin {
@@ -51,7 +67,7 @@ pub async fn begin_login(
     cfg: &OidcClusterConfig,
     redirect_uri: &str,
 ) -> Result<ClusterLoginBegin, String> {
-    let client = build_core_client(cfg, redirect_uri).await?;
+    let (client, _http) = build_core_client(cfg, redirect_uri).await?;
     let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
     let mut req = client
         .authorize_url(
@@ -86,11 +102,12 @@ pub async fn exchange_code(
     pkce_verifier: &str,
     now: i64,
 ) -> Result<RefreshedToken, String> {
-    let client = build_core_client(cfg, redirect_uri).await?;
+    let (client, http) = build_core_client(cfg, redirect_uri).await?;
     let tokens = client
         .exchange_code(AuthorizationCode::new(code.to_string()))
+        .map_err(|_| "cluster IdP advertised no token endpoint".to_string())?
         .set_pkce_verifier(PkceCodeVerifier::new(pkce_verifier.to_string()))
-        .request_async(async_http_client)
+        .request_async(&http)
         .await
         .map_err(|_| "cluster code exchange failed".to_string())?;
     into_refreshed(&tokens, now)
@@ -135,10 +152,11 @@ pub fn make_refresh_fn(
             let cfg = registry
                 .config_for_key(&oidc_key)
                 .ok_or_else(|| "unknown cluster oidc key".to_string())?;
-            let client = build_core_client(&cfg, &redirect_uri).await?;
+            let (client, http) = build_core_client(&cfg, &redirect_uri).await?;
             let tokens = client
                 .exchange_refresh_token(&RefreshToken::new(refresh_token))
-                .request_async(async_http_client)
+                .map_err(|_| "cluster IdP advertised no token endpoint".to_string())?
+                .request_async(&http)
                 .await
                 .map_err(|_| "cluster token refresh failed".to_string())?;
             into_refreshed(&tokens, now_fn())

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -37,6 +37,20 @@ pub mod ws;
 pub type RegistryFactory =
     Arc<dyn Fn(Arc<ClientCache>, Vec<std::path::PathBuf>) -> Registry + Send + Sync>;
 
+/// The HTTP client every OIDC flow (app login and per-cluster sign-in) uses.
+///
+/// Redirects are disabled deliberately: `openidconnect` v4 requires the caller
+/// to supply the client, and a redirect-following one turns discovery and the
+/// token exchange into an SSRF primitive — the IdP URL comes from config or, for
+/// cluster sign-in, from a user's kubeconfig. Redirects there are never
+/// legitimate, so refusing them is both safer and more honest than chasing them.
+pub fn oidc_http_client() -> Result<openidconnect::reqwest::Client, String> {
+    openidconnect::reqwest::ClientBuilder::new()
+        .redirect(openidconnect::reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|e| format!("failed to build OIDC http client: {e}"))
+}
+
 /// Current unix time in seconds — the single clock read for the HTTP edge.
 pub fn unix_now() -> i64 {
     std::time::SystemTime::now()

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "pnpm": {
     "overrides": {
       "fast-uri@>=3.0.0 <3.1.4": "^3.1.4",
-      "brace-expansion@>=2.0.0 <2.1.2": "^2.1.2",
+      "brace-expansion@>=2.0.0 <2.1.3": "^2.1.3",
+      "brace-expansion@>=4.0.0 <5.0.8": "^5.0.8",
+      "postcss@<8.5.18": "^8.5.18",
       "@hono/node-server@<2.0.5": "^2.0.5"
     }
   }

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -93,16 +93,21 @@ The automation cannot run until a human claims the package name on the AUR:
    - `AUR_USERNAME` — your AUR account name
    - `AUR_EMAIL` — the email on that account
    - `AUR_SSH_PRIVATE_KEY` — the private half of the key from step 1
-   - `AUR_KNOWN_HOSTS` — AUR's SSH host keys, so the publish job can verify the
-     server before cloning. These are the server's *public* host keys (not a
-     secret in the cryptographic sense); the secret just keeps them out of the
-     workflow. Generate the value with:
-     ```
-     ssh-keyscan -t ed25519,rsa aur.archlinux.org
-     ```
-     and confirm the fingerprints match AUR's published ones (`ssh-keygen -lf`)
-     — currently ED25519 `SHA256:RFzBCUItH9LZS0cKB5UE6ceAYhBD5C8GeOBip8Z11+4`,
-     RSA `SHA256:5s5cIyReIfNNVGRFdDbe3hdYiI5OelHGpw2rOUud3Q8` — before pasting.
+
+   There is deliberately **no** `AUR_KNOWN_HOSTS` secret. The publish job fetches
+   AUR's host key with `ssh-keyscan` and refuses to continue unless its
+   fingerprint matches a constant pinned in `.github/workflows/release.yml`
+   (currently ED25519 `SHA256:RFzBCUItH9LZS0cKB5UE6ceAYhBD5C8GeOBip8Z11+4`) — so
+   an unexpected key still stops the push, but the trust decision lives in
+   reviewable code rather than in an opaque secret whose formatting nobody can
+   check. A secret that lost its newlines on paste is what broke the v0.4.0
+   publish, with ssh reporting only "Host key verification failed".
+
+   If AUR rotates its host key, verify the new one against Arch's published
+   fingerprints and update the constant in the workflow:
+   ```
+   ssh-keyscan -t ed25519 aur.archlinux.org | ssh-keygen -lf -
+   ```
 
 The current stable release is **`srelens-v0.2.0`**, so the initial import can be
 done against it today (the PKGBUILD builds cleanly against its published `.deb`).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,9 @@ settings:
 
 overrides:
   fast-uri@>=3.0.0 <3.1.4: ^3.1.4
-  brace-expansion@>=2.0.0 <2.1.2: ^2.1.2
+  brace-expansion@>=2.0.0 <2.1.3: ^2.1.3
+  brace-expansion@>=4.0.0 <5.0.8: ^5.0.8
+  postcss@<8.5.18: ^8.5.18
   '@hono/node-server@<2.0.5': ^2.0.5
 
 importers:
@@ -1897,12 +1899,12 @@ packages:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2832,8 +2834,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2987,8 +2989,8 @@ packages:
     resolution: {integrity: sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==}
     engines: {node: '>=4'}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   powershell-utils@0.1.0:
@@ -5425,11 +5427,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6257,11 +6259,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 
@@ -6286,7 +6288,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.15: {}
+  nanoid@3.3.16: {}
 
   negotiator@1.0.0: {}
 
@@ -6424,9 +6426,9 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss@8.5.15:
+  postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -6718,7 +6720,7 @@ snapshots:
       kleur: 4.1.5
       open: 11.0.0
       ora: 8.2.0
-      postcss: 8.5.15
+      postcss: 8.5.25
       postcss-selector-parser: 7.1.4
       prompts: 2.4.2
       recast: 0.23.12
@@ -7001,7 +7003,7 @@ snapshots:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.25
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
Release merge for **srelens v0.4.1**.

3 `fix:` commits since `srelens-v0.4.0`, no `feat:` and no breaking markers → **patch bump, 0.4.0 → 0.4.1**.

### Fixes
- **updater:** render release notes as markup, and keep the commit scope (#179)
- **deps:** upgrade openidconnect 3 → 4 to drop vulnerable rustls-webpki (#177)
- **deps:** force patched brace-expansion and postcss via pnpm overrides (#177)

Also included (no release-note line of its own, `ci:` type):
- **AUR host-key fix** (#178) — the v0.4.0 `publish AUR` job died on `Host key verification failed`. This release is the first to run the fixed job, so it's the real end-to-end test of the AUR path.

### What to watch on this release
1. **AUR publish** — previously broken, now pinned by fingerprint rather than a secret. Whether the `srelens-bin` push actually lands is the open question.
2. **Release notes** — the body above is generated by the new scope-preserving `sed`, and the in-app updater now renders it as markup instead of raw `###`. Worth a screenshot of the update panel once published.
3. **OIDC** — 0.4.1 carries the openidconnect v4 rewrite. Unit tests pass but nothing here exercises a live IdP; app login and cluster sign-in deserve a manual check after release.

`AUR_KNOWN_HOSTS` can be deleted from repository secrets once this is out — the workflow no longer reads it.
