### PR TITLE
ci(release): build each docker arch on a native runner, join by manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,18 +147,38 @@ jobs:
   # Publish the srelens web image to GHCR (multi-arch) whenever the version
   # job determined there's something to release — mirrors the desktop build's
   # release gate, independent of the (long) desktop matrix below.
+  #
+  # ONE ARCHITECTURE PER NATIVE RUNNER, joined into a manifest by the job below.
+  # This used to be a single job building linux/amd64,linux/arm64 with QEMU, but
+  # the image compiles the server from source (see Dockerfile) and emulating a
+  # Rust release build is punishing: the last such run took 1h44m, against ~12
+  # minutes for all four desktop targets including Apple notarization. Worse, it
+  # serialized releases — `concurrency: release-<ref>` meant the next stable cut
+  # sat pending behind it. arm64 runners are free for public repos, so the arm
+  # leg now compiles natively instead of instruction-by-instruction.
+  #
+  # Each leg pushes by DIGEST only (no tag): two jobs pushing the same tag would
+  # race, with the loser's architecture silently dropped from the result.
   docker:
-    name: docker image
+    name: docker image (${{ matrix.arch }})
     needs: version
     if: needs.version.outputs.release == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-22.04
+            platform: linux/amd64
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            platform: linux/arm64
     permissions:
       contents: read
       packages: write
     steps:
       - uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
       - name: Log in to GHCR
@@ -167,25 +187,83 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Compute tags
-        id: tags
-        run: |
-          VERSION="${{ needs.version.outputs.version }}"
-          TAGS="ghcr.io/srelens/srelens:${VERSION}"
-          # `latest` only for stable releases on main.
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            TAGS="${TAGS},ghcr.io/srelens/srelens:latest"
-          fi
-          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
-      - name: Build and push
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.tags.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=ghcr.io/srelens/srelens,push-by-digest=true,name-canonical=true,push=true
+          # Per-arch cache scope: a shared scope would have the two legs
+          # overwrite each other's layers on every run, costing the cache hit
+          # this is meant to provide.
+          cache-from: type=gha,scope=docker-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=docker-${{ matrix.arch }}
+      - name: Export digest
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          if [ -z "$digest" ]; then
+            echo "::error::build produced no digest for ${{ matrix.arch }}"
+            exit 1
+          fi
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-digest-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Join the per-arch images into one multi-arch tag. Split from the build jobs
+  # so the tag appears only once BOTH architectures are published — a partial
+  # manifest would serve amd64 users an image while arm64 pulls 404.
+  docker-manifest:
+    name: docker manifest
+    needs: [version, docker]
+    if: needs.version.outputs.release == 'true'
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: docker-digest-*
+          merge-multiple: true
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and push manifest
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.version.outputs.version }}"
+          IMAGE=ghcr.io/srelens/srelens
+          TAGS=(-t "${IMAGE}:${VERSION}")
+          # `latest` only for stable releases on main.
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            TAGS+=(-t "${IMAGE}:latest")
+          fi
+          cd /tmp/digests
+          # Both legs must have landed; an empty or short list means a silent
+          # partial publish, which is exactly what this job exists to prevent.
+          count=$(ls -1 | wc -l)
+          if [ "$count" -ne 2 ]; then
+            echo "::error::expected 2 per-arch digests, found ${count}"
+            ls -la
+            exit 1
+          fi
+          docker buildx imagetools create "${TAGS[@]}" $(printf "${IMAGE}@sha256:%s " *)
+          docker buildx imagetools inspect "${IMAGE}:${VERSION}"
 
   build:
     needs: version


### PR DESCRIPTION
The `docker image` job built `linux/amd64,linux/arm64` in a single step under QEMU. Since the image compiles the server from source (`Dockerfile:24`), the arm64 leg emulated an entire Rust release build.

| Run | docker job |
|---|---|
| 0.3.1-101 (Jul 31) | **1h 44m** |
| 0.4.0 (today) | cancelled at 42m, still going |
| *all four desktop targets, incl. Apple notarization* | *~12 min* |

The cost wasn't only wall clock. `concurrency: release-${{ github.ref }}` with `cancel-in-progress: false` meant the **next stable release sat pending behind it** — cutting v0.4.1 required cancelling v0.4.0's still-running docker job first.

## Change
arm64 runners are free for public repos (this repo is public), so build each architecture natively instead of emulating one:

- `docker` becomes a 2-leg matrix — `ubuntu-22.04` / `ubuntu-24.04-arm` — each building only its own platform. The `Set up QEMU` step is gone entirely.
- Each leg pushes **by digest**, not by tag. Two jobs pushing the same tag would race, and the loser's architecture would be silently absent from the published image.
- New `docker-manifest` job joins the digests into the real tags once both legs are green. Splitting it out is the point: a partial publish must not serve amd64 users an image that 404s for arm64 pulls. It fails loudly if it doesn't find exactly two digests.
- Cache scope is per-arch (`docker-amd64` / `docker-arm64`); a shared scope had the two legs overwriting each other's layers every run.

Tag selection is unchanged: `:<version>` always, `:latest` only on `main`.

## Verification
YAML parses and the job graph resolves (`docker-manifest` needs `version` + `docker`; nothing else depended on `docker`, so no gating changed). The manifest command's argument construction was dry-run locally against two dummy digests.

**Not verified, and only a real release can:** that `ubuntu-24.04-arm` is enabled for this org, and the end-to-end digest → manifest join. If the label isn't available the leg fails fast with "no runner matching", and the fallback is a one-line revert to the QEMU platform list. Worth watching the first release that runs this.