### PR TITLE
ci(aur): split the AUR publish out so it can be run by hand

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -1,0 +1,211 @@
+name: Publish AUR
+
+# Publishes the srelens-bin AUR package. Called by the release workflow after a
+# stable release goes public, and runnable BY HAND for any already-published
+# version — which is the point of splitting it out. Every stable release from
+# v0.2.0 to v0.4.1 failed this step silently, and with the publish welded to the
+# release pipeline the only way to retry was to cut another release.
+#
+# AUR carries exactly ONE version: `pkgver` is a scalar and users install
+# whatever it currently points at. There is no back-catalogue to fill in, so
+# republishing older tags in sequence would just land on the newest one — hence
+# a single `version` input rather than a list.
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version to publish, without a leading v (e.g. 0.4.1)'
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Published version to push to AUR, without a leading v. Defaults to the newest stable release.'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+# The package is a single git branch, so two runs would race on `git push`.
+concurrency:
+  group: aur-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: publish AUR (srelens-bin)
+    runs-on: ubuntu-22.04
+    # Do the AUR push ourselves rather than via a third-party action: an AUR
+    # PKGBUILD executes arbitrary code on a user's machine at build time, so
+    # push access to the package is a high-value target. Handing the AUR SSH key
+    # to an external action would put that entirely in someone else's supply
+    # chain for the sake of ~20 lines of shell.
+    container:
+      image: archlinux:base-devel
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Skip when the AUR key isn't configured
+        id: gate
+        shell: bash
+        env:
+          KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        run: |
+          if [ -z "${KEY:-}" ]; then
+            echo "AUR_SSH_PRIVATE_KEY not set — skipping AUR publish."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install toolchain
+        if: steps.gate.outputs.publish == 'true'
+        run: pacman -Syu --noconfirm --needed git openssh pacman-contrib namcap curl jq
+
+      # A manual run may omit the version, meaning "whatever the newest stable
+      # release is". Resolved here rather than defaulted in the input so the log
+      # records which version was chosen.
+      - name: Resolve version
+        id: resolve
+        if: steps.gate.outputs.publish == 'true'
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          VERSION="${INPUT_VERSION:-}"
+          if [ -z "$VERSION" ]; then
+            TAG=$(curl -fsSL "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest" | jq -r '.tag_name // empty')
+            VERSION="${TAG#srelens-v}"
+            echo "No version given — using the newest stable release: ${TAG:-<none>}"
+          fi
+          # Strip a leading v if someone types one; AUR pkgver must not carry it.
+          VERSION="${VERSION#v}"
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::'${VERSION}' is not a stable X.Y.Z version. Dev pre-releases cannot go to AUR: an Arch pkgver may not carry the -<run> suffix."
+            exit 1
+          fi
+          # The assets must actually exist — updpkgsums fetches them over plain
+          # HTTPS, and a missing/draft release would otherwise fail deep inside
+          # makepkg with a checksum error rather than here.
+          if ! curl -fsSL -o /dev/null "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/srelens-v${VERSION}"; then
+            echo "::error::no published release srelens-v${VERSION} — publish it before pushing to AUR"
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Publishing srelens-bin ${VERSION}"
+
+      - name: Build, lint and publish
+        if: steps.gate.outputs.publish == 'true'
+        shell: bash
+        env:
+          VERSION: ${{ steps.resolve.outputs.version }}
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          AUR_USERNAME: ${{ secrets.AUR_USERNAME }}
+          AUR_EMAIL: ${{ secrets.AUR_EMAIL }}
+        run: |
+          set -euo pipefail
+
+          # EVERY ssh path here is absolute, and known_hosts is passed to ssh
+          # explicitly. This is not style — it is the v0.4.1 bug.
+          #
+          # A container job runs with `-e HOME=/github/home`, but the container
+          # user is root, whose passwd entry says /root. The shell expands `~`
+          # via $HOME, while ssh resolves its DEFAULT UserKnownHostsFile against
+          # the password database. So `~/.ssh/known_hosts` written by this step
+          # landed in /github/home, and ssh looked in /root — which is how the
+          # job could print "host key verified" from a file it had just checked
+          # and then die with "Host key verification failed" one line later.
+          # (`-i ~/.ssh/aur` was unaffected: the shell expanded that one before
+          # ssh ever saw it, which is exactly what made the failure confusing.)
+          SSH_DIR=/tmp/aur-ssh
+          install -d -m 700 "$SSH_DIR"
+          printf '%s\n' "$AUR_SSH_PRIVATE_KEY" > "$SSH_DIR/id"
+          chmod 600 "$SSH_DIR/id"
+
+          # AUR's host key, fetched at runtime and PINNED BY FINGERPRINT.
+          #
+          # This deliberately does not come from a secret. Carrying the
+          # `known_hosts` lines in a secret makes the trust decision depend on a
+          # value nobody can inspect or lint. Fetching the key and checking its
+          # fingerprint against the value AUR publishes keeps the same security
+          # property — an unexpected key still aborts, this is not TOFU — while
+          # living in reviewable code. Rotate the constant if AUR rotates the
+          # key; the job then fails with both fingerprints in the log instead of
+          # an opaque ssh error. See packaging/aur/README.md.
+          AUR_ED25519_FP="SHA256:RFzBCUItH9LZS0cKB5UE6ceAYhBD5C8GeOBip8Z11+4"
+          if ! ssh-keyscan -t ed25519 aur.archlinux.org > "$SSH_DIR/known_hosts" 2> "$SSH_DIR/keyscan.err"; then
+            echo "::error::ssh-keyscan could not reach aur.archlinux.org"
+            cat "$SSH_DIR/keyscan.err" >&2
+            exit 1
+          fi
+          if [ ! -s "$SSH_DIR/known_hosts" ]; then
+            echo "::error::ssh-keyscan returned no host key for aur.archlinux.org"
+            cat "$SSH_DIR/keyscan.err" >&2
+            exit 1
+          fi
+          GOT_FP=$(ssh-keygen -lf "$SSH_DIR/known_hosts" | awk '{print $2}')
+          if [ "$GOT_FP" != "$AUR_ED25519_FP" ]; then
+            echo "::error::aur.archlinux.org host key fingerprint mismatch — refusing to push"
+            echo "  expected: $AUR_ED25519_FP" >&2
+            echo "  got:      $GOT_FP" >&2
+            exit 1
+          fi
+          echo "aur.archlinux.org host key verified: $GOT_FP"
+          chmod 600 "$SSH_DIR/known_hosts"
+          export GIT_SSH_COMMAND="ssh -i $SSH_DIR/id -o IdentitiesOnly=yes -o UserKnownHostsFile=$SSH_DIR/known_hosts -o StrictHostKeyChecking=yes"
+
+          # Preflight: prove the host key and the deploy key both work before
+          # touching the package. AUR answers `ssh -T` with an "Interactive
+          # shell is disabled" banner and a non-zero exit, so a failed status
+          # here is expected — what matters is telling a host-key failure apart
+          # from an auth failure, which the clone alone could not do.
+          ssh -o BatchMode=yes -T aur@aur.archlinux.org > "$SSH_DIR/preflight.log" 2>&1 || true
+          if grep -qi "host key verification failed" "$SSH_DIR/preflight.log"; then
+            echo "::error::ssh rejected AUR's host key even though the fingerprint matched — known_hosts is not being read from $SSH_DIR"
+            cat "$SSH_DIR/preflight.log" >&2
+            exit 1
+          fi
+          if grep -qi "permission denied" "$SSH_DIR/preflight.log"; then
+            echo "::error::AUR rejected the deploy key — check AUR_SSH_PRIVATE_KEY and that its public half is on the AUR account"
+            cat "$SSH_DIR/preflight.log" >&2
+            exit 1
+          fi
+          echo "AUR ssh preflight OK:"
+          cat "$SSH_DIR/preflight.log"
+
+          git config --global user.name "$AUR_USERNAME"
+          git config --global user.email "$AUR_EMAIL"
+          git config --global --add safe.directory '*'
+
+          git clone ssh://aur@aur.archlinux.org/srelens-bin.git aur
+          cp packaging/aur/PKGBUILD aur/PKGBUILD
+          cd aur
+          sed -i "s/^pkgver=.*/pkgver=${VERSION}/" PKGBUILD
+          sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
+
+          # makepkg refuses to run as root.
+          useradd -m builder
+          chown -R builder:builder .
+
+          # Pin real checksums from the published release assets, then regenerate
+          # .SRCINFO (the AUR reads metadata from it, not the PKGBUILD).
+          su builder -c 'updpkgsums'
+          su builder -c 'makepkg --printsrcinfo > .SRCINFO'
+
+          # Actually BUILD it before publishing. A PKGBUILD that does not build
+          # would otherwise reach users as a broken AUR package; --nodeps keeps
+          # this to a packaging check, not a full GUI dependency install.
+          su builder -c 'makepkg -f --nodeps --noconfirm'
+          su builder -c 'namcap PKGBUILD' || true
+          rm -f ./*.pkg.tar.*
+
+          if git diff --quiet PKGBUILD .SRCINFO; then
+            echo "AUR package already at ${VERSION} — nothing to push."
+            exit 0
+          fi
+          git add PKGBUILD .SRCINFO
+          git commit -m "srelens-bin ${VERSION}"
+          git push origin master
+          echo "Pushed srelens-bin ${VERSION} to the AUR."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -639,152 +639,16 @@ jobs:
   # build job now excludes those libs and asserts it, so the AppImage is no
   # longer affected either. See packaging/aur/README.md.
   #
-  # Requires (one-time, see packaging/aur/README.md): the srelens-bin name claimed
-  # on the AUR, plus AUR_USERNAME / AUR_EMAIL / AUR_SSH_PRIVATE_KEY secrets. The
-  # job no-ops when the key isn't configured, so it can land before that's done.
+  # The steps live in their own reusable workflow so the same publish can be run
+  # BY HAND for an already-released version. Welded to this pipeline, a failed
+  # AUR push could only be retried by cutting another release — which is how AUR
+  # sat at 0.2.0 while four stable releases came and went.
   aur:
-    name: publish AUR (srelens-bin)
     # Also needs publish-release: updpkgsums fetches the release assets over
     # plain HTTPS, which only works once the release is out of draft.
     needs: [version, build, publish-release]
     if: ${{ github.ref_name == 'main' && needs.publish-release.result == 'success' && needs.version.outputs.release == 'true' }}
-    runs-on: ubuntu-22.04
-    # Do the AUR push ourselves rather than via a third-party action: an AUR
-    # PKGBUILD executes arbitrary code on a user's machine at build time, so
-    # push access to the package is a high-value target. Handing the AUR SSH key
-    # to an external action would put that entirely in someone else's supply
-    # chain for the sake of ~20 lines of shell.
-    container:
-      image: archlinux:base-devel
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Skip when the AUR key isn't configured
-        id: gate
-        shell: bash
-        env:
-          KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
-        run: |
-          if [ -z "${KEY:-}" ]; then
-            echo "AUR_SSH_PRIVATE_KEY not set — skipping AUR publish."
-            echo "publish=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "publish=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Install toolchain
-        if: steps.gate.outputs.publish == 'true'
-        run: pacman -Syu --noconfirm --needed git openssh pacman-contrib namcap
-
-      - name: Build, lint and publish
-        if: steps.gate.outputs.publish == 'true'
-        shell: bash
-        env:
-          VERSION: ${{ needs.version.outputs.version }}
-          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
-          AUR_USERNAME: ${{ secrets.AUR_USERNAME }}
-          AUR_EMAIL: ${{ secrets.AUR_EMAIL }}
-        run: |
-          set -euo pipefail
-
-          # EVERY ssh path here is absolute, and known_hosts is passed to ssh
-          # explicitly. This is not style — it is the v0.4.1 bug.
-          #
-          # A container job runs with `-e HOME=/github/home`, but the container
-          # user is root, whose passwd entry says /root. The shell expands `~`
-          # via $HOME, while ssh resolves its DEFAULT UserKnownHostsFile against
-          # the password database. So `~/.ssh/known_hosts` written by this step
-          # landed in /github/home, and ssh looked in /root — which is how the
-          # job could print "host key verified" from a file it had just checked
-          # and then die with "Host key verification failed" one line later.
-          # (`-i ~/.ssh/aur` was unaffected: the shell expanded that one before
-          # ssh ever saw it, which is exactly what made the failure confusing.)
-          SSH_DIR=/tmp/aur-ssh
-          install -d -m 700 "$SSH_DIR"
-          printf '%s\n' "$AUR_SSH_PRIVATE_KEY" > "$SSH_DIR/id"
-          chmod 600 "$SSH_DIR/id"
-
-          # AUR's host key, fetched at runtime and PINNED BY FINGERPRINT.
-          #
-          # This deliberately does not come from a secret. Carrying the
-          # `known_hosts` lines in a secret makes the trust decision depend on a
-          # value nobody can inspect or lint. Fetching the key and checking its
-          # fingerprint against the value AUR publishes keeps the same security
-          # property — an unexpected key still aborts, this is not TOFU — while
-          # living in reviewable code. Rotate the constant if AUR rotates the
-          # key; the job then fails with both fingerprints in the log instead of
-          # an opaque ssh error. See packaging/aur/README.md.
-          AUR_ED25519_FP="SHA256:RFzBCUItH9LZS0cKB5UE6ceAYhBD5C8GeOBip8Z11+4"
-          if ! ssh-keyscan -t ed25519 aur.archlinux.org > "$SSH_DIR/known_hosts" 2> "$SSH_DIR/keyscan.err"; then
-            echo "::error::ssh-keyscan could not reach aur.archlinux.org"
-            cat "$SSH_DIR/keyscan.err" >&2
-            exit 1
-          fi
-          if [ ! -s "$SSH_DIR/known_hosts" ]; then
-            echo "::error::ssh-keyscan returned no host key for aur.archlinux.org"
-            cat "$SSH_DIR/keyscan.err" >&2
-            exit 1
-          fi
-          GOT_FP=$(ssh-keygen -lf "$SSH_DIR/known_hosts" | awk '{print $2}')
-          if [ "$GOT_FP" != "$AUR_ED25519_FP" ]; then
-            echo "::error::aur.archlinux.org host key fingerprint mismatch — refusing to push"
-            echo "  expected: $AUR_ED25519_FP" >&2
-            echo "  got:      $GOT_FP" >&2
-            exit 1
-          fi
-          echo "aur.archlinux.org host key verified: $GOT_FP"
-          chmod 600 "$SSH_DIR/known_hosts"
-          export GIT_SSH_COMMAND="ssh -i $SSH_DIR/id -o IdentitiesOnly=yes -o UserKnownHostsFile=$SSH_DIR/known_hosts -o StrictHostKeyChecking=yes"
-
-          # Preflight: prove the host key and the deploy key both work before
-          # touching the package. AUR answers `ssh -T` with an "Interactive
-          # shell is disabled" banner and exit 4, so a non-zero status here is
-          # expected — what matters is telling a host-key failure apart from an
-          # auth failure, which the clone alone could not do.
-          ssh -o BatchMode=yes -T aur@aur.archlinux.org > "$SSH_DIR/preflight.log" 2>&1 || true
-          if grep -qi "host key verification failed" "$SSH_DIR/preflight.log"; then
-            echo "::error::ssh rejected AUR's host key even though the fingerprint matched — known_hosts is not being read from $SSH_DIR"
-            cat "$SSH_DIR/preflight.log" >&2
-            exit 1
-          fi
-          if grep -qi "permission denied" "$SSH_DIR/preflight.log"; then
-            echo "::error::AUR rejected the deploy key — check AUR_SSH_PRIVATE_KEY and that its public half is on the AUR account"
-            cat "$SSH_DIR/preflight.log" >&2
-            exit 1
-          fi
-          echo "AUR ssh preflight OK:"
-          cat "$SSH_DIR/preflight.log"
-
-          git config --global user.name "$AUR_USERNAME"
-          git config --global user.email "$AUR_EMAIL"
-          git config --global --add safe.directory '*'
-
-          git clone ssh://aur@aur.archlinux.org/srelens-bin.git aur
-          cp packaging/aur/PKGBUILD aur/PKGBUILD
-          cd aur
-          sed -i "s/^pkgver=.*/pkgver=${VERSION}/" PKGBUILD
-          sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
-
-          # makepkg refuses to run as root.
-          useradd -m builder
-          chown -R builder:builder .
-
-          # Pin real checksums from the published release assets, then regenerate
-          # .SRCINFO (the AUR reads metadata from it, not the PKGBUILD).
-          su builder -c 'updpkgsums'
-          su builder -c 'makepkg --printsrcinfo > .SRCINFO'
-
-          # Actually BUILD it before publishing. A PKGBUILD that does not build
-          # would otherwise reach users as a broken AUR package; --nodeps keeps
-          # this to a packaging check, not a full GUI dependency install.
-          su builder -c 'makepkg -f --nodeps --noconfirm'
-          su builder -c 'namcap PKGBUILD' || true
-          rm -f ./*.pkg.tar.* 
-
-          if git diff --quiet PKGBUILD .SRCINFO; then
-            echo "AUR package already at ${VERSION} — nothing to push."
-            exit 0
-          fi
-          git add PKGBUILD .SRCINFO
-          git commit -m "srelens-bin ${VERSION}"
-          git push origin master
+    uses: ./.github/workflows/aur-publish.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+    secrets: inherit

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -73,6 +73,23 @@ Dev pre-releases (`srelens-v<version>-<run>`, cut from `dev`) are deliberately
 **not** published: AUR users expect stable versions, and an Arch `pkgver` cannot
 contain the `-<run>` suffix anyway.
 
+## Publishing by hand
+
+The steps live in their own reusable workflow (`.github/workflows/aur-publish.yml`),
+so the same publish can be run manually for any already-released version:
+
+**Actions → Publish AUR → Run workflow**, optionally with a version (omit it to
+use the newest stable release).
+
+This exists because AUR fell four releases behind: the publish was welded to the
+release pipeline, it failed silently on every stable release from v0.2.0 to
+v0.4.1, and the only way to retry was to cut another release.
+
+**AUR holds exactly one version.** `pkgver` is a scalar and users install
+whatever it currently points at, so there is no back-catalogue to backfill —
+publishing older tags in sequence would simply land on the newest. Only the
+latest version is ever worth pushing.
+
 ## One-time setup (needed before the first publish)
 
 The automation cannot run until a human claims the package name on the AUR:


### PR DESCRIPTION
AUR is at **`srelens-bin 0.2.0-1`** while four stable releases have shipped (0.2.0 → 0.4.1). The publish failed on every one of them, and because it was welded to the release pipeline, the only way to retry was to cut another release. That's how the package drifted four versions behind without anyone noticing.

## Change
Move the steps into a reusable workflow, `aur-publish.yml`, with two entry points:

- **`workflow_call`** — the release pipeline invokes it exactly as before; `release.yml`'s `aur` job becomes a `uses:` call with `secrets: inherit`. No behaviour change on a release.
- **`workflow_dispatch`** — *Actions → Publish AUR → Run workflow*, to republish an already-released version without cutting a release.

## On "release all the missing versions"
Not applicable, and worth recording why: **AUR carries exactly one version.** `pkgver` is a scalar (`PKGBUILD:18`) and users install whatever it currently points at. There is no back-catalogue — publishing 0.3.0, then 0.4.0, then 0.4.1 in sequence would simply land on 0.4.1, with the intermediate pushes invisible to everyone. So the manual input takes a single version, defaulting to the newest stable release.

(Re-running the old release pipelines wouldn't have worked either: a re-run replays the workflow file as it was at that commit, and all of those predate the AUR fixes — so they'd reproduce the same `Host key verification failed`, while also rebuilding and re-uploading assets onto already-published releases.)

## Guardrails in the resolve step
Both of these would otherwise fail deep inside `makepkg` with an error that doesn't point at the cause:
- **a dev pre-release version** — an Arch `pkgver` may not carry the `-<run>` suffix
- **a version with no published release** — `updpkgsums` fetches assets over plain HTTPS, so a missing or still-draft release shows up as a checksum failure

A leading `v` is tolerated.

## Verification
Resolve logic exercised against the live GitHub API:

| input | result |
|---|---|
| `0.4.1` | accepted |
| `v0.4.1` | accepted → `0.4.1` |
| `0.4.1-106` | rejected — not a stable X.Y.Z |
| `9.9.9` | rejected — no published release |
| *(empty)* | resolved to `srelens-v0.4.1` |

Both workflows parse, and the call job correctly carries no `runs-on`/`steps`/`container`.

**Still unproven:** the push itself, which needs the deploy key in CI. Once this merges, running *Publish AUR* for 0.4.1 is the real test — and the first time this code path has ever been retryable on demand.