### PR TITLE
fix(aur): make the ssh preflight use the same options as git

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -154,14 +154,28 @@ jobs:
           fi
           echo "aur.archlinux.org host key verified: $GOT_FP"
           chmod 600 "$SSH_DIR/known_hosts"
-          export GIT_SSH_COMMAND="ssh -i $SSH_DIR/id -o IdentitiesOnly=yes -o UserKnownHostsFile=$SSH_DIR/known_hosts -o StrictHostKeyChecking=yes"
+
+          # ONE definition of the ssh options, used by both git and the direct
+          # preflight below. They were separate once: GIT_SSH_COMMAND carried
+          # the options while the preflight invoked a bare `ssh`, so the
+          # preflight read the default known_hosts (empty), failed, and aborted
+          # the job before the clone it was supposed to be de-risking ever ran.
+          # A check that doesn't test the real code path is worse than none.
+          # $SSH_DIR has no spaces, so [*] expands safely into the git command.
+          SSH_OPTS=(
+            -i "$SSH_DIR/id"
+            -o IdentitiesOnly=yes
+            -o UserKnownHostsFile="$SSH_DIR/known_hosts"
+            -o StrictHostKeyChecking=yes
+          )
+          export GIT_SSH_COMMAND="ssh ${SSH_OPTS[*]}"
 
           # Preflight: prove the host key and the deploy key both work before
           # touching the package. AUR answers `ssh -T` with an "Interactive
           # shell is disabled" banner and a non-zero exit, so a failed status
           # here is expected — what matters is telling a host-key failure apart
           # from an auth failure, which the clone alone could not do.
-          ssh -o BatchMode=yes -T aur@aur.archlinux.org > "$SSH_DIR/preflight.log" 2>&1 || true
+          ssh "${SSH_OPTS[@]}" -o BatchMode=yes -T aur@aur.archlinux.org > "$SSH_DIR/preflight.log" 2>&1 || true
           if grep -qi "host key verification failed" "$SSH_DIR/preflight.log"; then
             echo "::error::ssh rejected AUR's host key even though the fingerprint matched — known_hosts is not being read from $SSH_DIR"
             cat "$SSH_DIR/preflight.log" >&2


### PR DESCRIPTION
The first manual **Publish AUR** run failed — on the preflight I added in #182, not on the thing it was checking.

```
aur.archlinux.org host key verified: SHA256:RFzBCUItH9LZS0cK...
##[error]ssh rejected AUR's host key even though the fingerprint matched
Host key verification failed.
```

## What went wrong
The options lived only in `GIT_SSH_COMMAND`, but the preflight invoked a bare `ssh`:

```bash
export GIT_SSH_COMMAND="ssh -i $SSH_DIR/id -o UserKnownHostsFile=$SSH_DIR/known_hosts ..."
ssh -o BatchMode=yes -T aur@aur.archlinux.org        # ← none of the above
```

So it read the *default* `known_hosts` — empty — failed, and aborted the job before the clone ever ran. The failure it reported was its own, and told us nothing about the path git takes.

That's the second confident wrong answer in this thread, and the cause is the same both times: a check that doesn't exercise the real code path. My local verification of #182 passed `-o UserKnownHostsFile=` explicitly; the workflow's preflight didn't. The two diverged and I compared the wrong pair.

## Fix
Define the options once as `SSH_OPTS` and use them for both `GIT_SSH_COMMAND` and the preflight.

## Verification
The fixed invocation, run against the live server:
```
$ ssh -o UserKnownHostsFile=$D/known_hosts -o StrictHostKeyChecking=yes -o BatchMode=yes -T aur@aur.archlinux.org
Welcome to AUR, deveshk0! Interactive shell is disabled.
RESULT: host key OK
```
A bare `ssh`, as the old preflight ran it, fails host key verification — which is exactly what CI reported.

## Status of the underlying fix
The `known_hosts` path fix from #182 is still **untested in CI, not disproven** — nothing in that run reached the clone. Re-running *Publish AUR* after this merges is the next real test, and this time a failure will point at git's actual path.