### PR TITLE
feat(mcp): consent-gated MCP with token auth and an audit log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5516,6 +5516,7 @@ dependencies = [
 name = "srelens-desktop"
 version = "0.4.0"
 dependencies = [
+ "async-trait",
  "base64 0.22.1",
  "fix-path-env",
  "futures",
@@ -5537,6 +5538,7 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-updater",
  "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,6 +495,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -699,6 +708,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,6 +843,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -846,7 +874,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.13.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -859,7 +887,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.13.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -1085,6 +1113,24 @@ dependencies = [
  "libc",
  "libdbus-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
+ "dbus",
+ "fastrand",
+ "hkdf",
+ "num",
+ "once_cell",
+ "sha2 0.10.9",
+ "zeroize",
 ]
 
 [[package]]
@@ -2589,6 +2635,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
 
@@ -2840,6 +2887,22 @@ dependencies = [
  "bitflags 2.13.0",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "log",
+ "secret-service",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
 ]
 
 [[package]]
@@ -3222,6 +3285,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset 0.9.1",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3235,6 +3335,15 @@ dependencies = [
  "rand 0.8.6",
  "smallvec",
  "zeroize",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -3258,6 +3367,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -3983,7 +4103,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "nix",
+ "nix 0.25.1",
  "serial",
  "shared_library",
  "shell-words",
@@ -4632,7 +4752,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -4660,7 +4780,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni 0.22.4",
  "log",
@@ -4669,7 +4789,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -4809,13 +4929,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "secret-service"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+ "sha2 0.10.9",
+ "zbus 4.4.0",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.13.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -5521,6 +5673,7 @@ dependencies = [
  "dirs",
  "fix-path-env",
  "futures",
+ "keyring",
  "log",
  "reqwest 0.13.4",
  "serde",
@@ -5643,6 +5796,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
@@ -5774,7 +5933,7 @@ checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
  "bitflags 2.13.0",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dbus",
@@ -6052,7 +6211,7 @@ dependencies = [
  "thiserror 2.0.18",
  "url",
  "windows",
- "zbus",
+ "zbus 5.18.0",
 ]
 
 [[package]]
@@ -7796,6 +7955,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7816,6 +7985,38 @@ dependencies = [
  "quote",
  "syn 2.0.118",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-process",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix 0.29.0",
+ "ordered-stream",
+ "rand 0.8.6",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros 4.4.0",
+ "zbus_names 3.0.0",
+ "zvariant 4.2.0",
 ]
 
 [[package]]
@@ -7848,9 +8049,22 @@ dependencies = [
  "uuid",
  "windows-sys 0.61.2",
  "winnow 1.0.3",
- "zbus_macros",
- "zbus_names",
- "zvariant",
+ "zbus_macros 5.18.0",
+ "zbus_names 4.3.4",
+ "zvariant 5.13.1",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -7863,9 +8077,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
- "zbus_names",
- "zvariant",
- "zvariant_utils",
+ "zbus_names 4.3.4",
+ "zvariant 5.13.1",
+ "zvariant_utils 3.5.0",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant 4.2.0",
 ]
 
 [[package]]
@@ -7876,7 +8101,7 @@ checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
 dependencies = [
  "serde",
  "winnow 1.0.3",
- "zvariant",
+ "zvariant 5.13.1",
 ]
 
 [[package]]
@@ -7925,6 +8150,20 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "zerotrie"
@@ -7979,6 +8218,19 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive 4.2.0",
+]
+
+[[package]]
+name = "zvariant"
 version = "5.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bee2a0bcd2a907786a456fff45aaaaf54c9ba5f50b71ae9ec1a4edd200c94911"
@@ -7987,8 +8239,21 @@ dependencies = [
  "enumflags2",
  "serde",
  "winnow 1.0.3",
- "zvariant_derive",
- "zvariant_utils",
+ "zvariant_derive 5.13.1",
+ "zvariant_utils 3.5.0",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -8001,7 +8266,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
- "zvariant_utils",
+ "zvariant_utils 3.5.0",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5570,8 +5570,10 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "axum",
+ "getrandom 0.2.17",
  "serde_json",
  "srelens-capability",
+ "subtle",
  "tokio",
  "tower",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5568,6 +5568,7 @@ dependencies = [
 name = "srelens-mcp"
 version = "0.0.0"
 dependencies = [
+ "async-trait",
  "axum",
  "serde_json",
  "srelens-capability",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5518,6 +5518,7 @@ version = "0.4.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
+ "dirs",
  "fix-path-env",
  "futures",
  "log",

--- a/README.md
+++ b/README.md
@@ -129,8 +129,9 @@ MCP-capable clients without creating a separate cluster integration layer.
 Open **Settings → MCP** to:
 
 - run the MCP server over loopback HTTP, protected by a bearer token you can
-  reveal, rotate, or revoke (rotating invalidates configs that used the old
-  value; revoking also stops the server);
+  reveal, rotate, or revoke — rotating restarts the running server so the new
+  token takes effect at once (dropping any in-flight request and invalidating
+  configs that used the old value); revoking also stops the server;
 - install the `srelens` CLI for stdio connections, which need no token — the
   client already holds your privileges by spawning the process;
 - copy client configuration for supported MCP clients.

--- a/README.md
+++ b/README.md
@@ -128,8 +128,11 @@ MCP-capable clients without creating a separate cluster integration layer.
 
 Open **Settings → MCP** to:
 
-- run the MCP server over loopback HTTP;
-- install the `srelens` CLI for stdio connections;
+- run the MCP server over loopback HTTP, protected by a bearer token you can
+  reveal, rotate, or revoke (rotating invalidates configs that used the old
+  value; revoking also stops the server);
+- install the `srelens` CLI for stdio connections, which need no token — the
+  client already holds your privileges by spawning the process;
 - copy client configuration for supported MCP clients.
 
 You can also start the server directly:
@@ -139,7 +142,12 @@ srelens --mcp-stdio
 srelens --mcp-http 127.0.0.1:8765
 ```
 
-Mutating tools require an explicit `_confirm: true` argument before they run.
+Destructive tools prompt for confirmation in the app. Headless runs have no
+dialog to show, so they need both `--mcp-allow-destructive` on the process
+*and* `"_confirm": true` on the call — neither alone authorizes anything, and
+there's no GUI toggle for stdio. See the
+[user guide](docs/USAGE.md#mcp-server-for-ai-agents) for the full security
+model, including the Host-header check, audit log, and token storage.
 
 Example stdio configuration:
 

--- a/README.md
+++ b/README.md
@@ -144,11 +144,13 @@ srelens --mcp-http 127.0.0.1:8765
 ```
 
 Destructive tools prompt for confirmation in the app. Headless runs have no
-dialog to show, so they need both `--mcp-allow-destructive` on the process
-*and* `"_confirm": true` on the call — neither alone authorizes anything, and
-there's no GUI toggle for stdio. See the
-[user guide](docs/USAGE.md#mcp-server-for-ai-agents) for the full security
-model, including the Host-header check, audit log, and token storage.
+dialog to show, so they need `"_confirm": true` on the call *and* a
+process-level opt-in — `--mcp-allow-destructive` to change anything, or
+`--mcp-allow-sensitive-reads` to read Secrets. The two are independent, so
+reading a Secret never implies permission to drain a node, and neither flag
+alone authorizes anything without `_confirm`. There's no GUI toggle for stdio.
+See the [user guide](docs/USAGE.md#mcp-server-for-ai-agents) for the full
+security model, including the Host-header check, audit log, and token storage.
 
 Example stdio configuration:
 

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -33,6 +33,8 @@ srelens-streams = { path = "../../../crates/streams" }
 srelens-server = { path = "../../../crates/server" }
 srelens-registry = { path = "../../../crates/registry" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std", "io-util", "macros"] }
+uuid = { version = "1", features = ["v4"] }
+async-trait = "0.1"
 # Blocking HTTP for Toolbox tool downloads (run inside spawn_blocking).
 # rustls-no-provider matches tauri-plugin-updater's reqwest so no second TLS
 # crypto provider (aws-lc-rs) enters the tree — the workspace standardises on

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -37,6 +37,19 @@ srelens-kube = { path = "../../../crates/kube" }
 srelens-streams = { path = "../../../crates/streams" }
 srelens-server = { path = "../../../crates/server" }
 srelens-registry = { path = "../../../crates/registry" }
+# MCP bearer token storage: prefer the OS keychain, falling back to the 0600
+# file (`FileTokenStore`) where none exists. Feature selection:
+#   - apple-native: macOS/iOS Keychain via `security-framework`.
+#   - windows-native: Windows Credential Manager via `windows-sys`.
+#   - sync-secret-service: Linux/BSD D-Bus Secret Service via `dbus-secret-service`,
+#     synchronous — matches `TokenStore`'s sync API without pulling in an async
+#     D-Bus runtime (the `async-secret-service` alternative needs zbus/tokio).
+#   - crypto-rust: the Secret Service session is encrypted; this backs that
+#     with a pure-Rust implementation instead of `crypto-openssl`, so we don't
+#     need a system OpenSSL dev package at build time.
+# Each backend's transitive deps are already gated to their own target by the
+# keyring crate itself, so enabling all four is safe cross-platform.
+keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service", "crypto-rust"] }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std", "io-util", "macros"] }
 uuid = { version = "1", features = ["v4"] }
 async-trait = "0.1"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -22,6 +22,11 @@ tauri-build = { version = "2.6.3", features = [] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
+# Headless MCP (`--mcp-http`/`--mcp-stdio`) never boots a Tauri `App`, so
+# `app.path().app_config_dir()` isn't callable there. `dirs` reproduces that
+# resolver's formula directly (see `mcp_token_path` in main.rs) so the CLI and
+# the GUI resolve to the same config dir and share one token file.
+dirs = "6"
 tauri = { version = "2.11.3", features = [] }
 tauri-plugin-log = "2"
 tauri-plugin-dialog = "2"

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -330,17 +330,22 @@ pub fn run() {
             // that dir resolution succeeds, rather than aborting startup.
             //
             // The token store itself prefers the OS keychain, falling back to
-            // a 0600 file (same path `main.rs`'s headless CLI resolves) where
-            // no keychain is available — see `token_store::keychain_or_file`.
+            // a 0600 file (same path `main.rs`'s headless CLI resolves) the
+            // first time a keychain operation genuinely fails — see
+            // `token_store::keychain_or_file`. Managed both as the concrete
+            // `Arc<ResilientTokenStore>` (so `mcp_token_storage` can read the
+            // live backend flag) and, via unsized coercion, as the
+            // `Arc<dyn TokenStore>` the other MCP commands take.
             match app.path().app_config_dir().map(|d| d.join("mcp")) {
                 Ok(dir) => {
                     if let Err(e) = std::fs::create_dir_all(&dir) {
                         log::warn!("could not create MCP config dir {}: {e}", dir.display());
                     }
-                    let (token_store, file_fallback) =
-                        token_store::keychain_or_file(dir.join("token"));
+                    let resilient_store = token_store::keychain_or_file(dir.join("token"));
+                    let token_store: std::sync::Arc<dyn srelens_mcp::auth::TokenStore> =
+                        resilient_store.clone();
                     app.manage(token_store);
-                    app.manage(token_store::TokenStorage::for_fallback(file_fallback));
+                    app.manage(resilient_store);
                     app.manage(McpAuditPath(dir.join("audit.jsonl")));
                 }
                 Err(e) => log::warn!("MCP config dir unavailable: {e}"),

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ mod mcp_confirm;
 mod settings;
 mod sink;
 mod terminal;
+pub mod token_store;
 mod toolbox;
 mod updater;
 mod watch;
@@ -27,8 +28,8 @@ use helm::{helm_op_close, start_helm_op};
 use logs::{start_log_stream, stop_log_stream};
 use mcp::{
     install_srelens_cli, mcp_audit_tail, mcp_confirm_respond, mcp_http_start, mcp_http_status,
-    mcp_http_stop, mcp_token_get, mcp_token_revoke, mcp_token_rotate, srelens_cli_status,
-    McpAuditPath, McpHttpManager,
+    mcp_http_stop, mcp_token_get, mcp_token_revoke, mcp_token_rotate, mcp_token_storage,
+    srelens_cli_status, McpAuditPath, McpHttpManager,
 };
 use settings::{get_request_timeout, set_request_timeout};
 use srelens_kube::client_cache::ClientCache;
@@ -327,16 +328,19 @@ pub fn run() {
             // resolvable config dir is logged and skipped — the MCP token/
             // audit commands simply error until the app is restarted somewhere
             // that dir resolution succeeds, rather than aborting startup.
+            //
+            // The token store itself prefers the OS keychain, falling back to
+            // a 0600 file (same path `main.rs`'s headless CLI resolves) where
+            // no keychain is available — see `token_store::keychain_or_file`.
             match app.path().app_config_dir().map(|d| d.join("mcp")) {
                 Ok(dir) => {
                     if let Err(e) = std::fs::create_dir_all(&dir) {
                         log::warn!("could not create MCP config dir {}: {e}", dir.display());
                     }
-                    let token_store: std::sync::Arc<dyn srelens_mcp::auth::TokenStore> =
-                        std::sync::Arc::new(srelens_mcp::auth::FileTokenStore::new(
-                            dir.join("token"),
-                        ));
+                    let (token_store, file_fallback) =
+                        token_store::keychain_or_file(dir.join("token"));
                     app.manage(token_store);
+                    app.manage(token_store::TokenStorage::for_fallback(file_fallback));
                     app.manage(McpAuditPath(dir.join("audit.jsonl")));
                 }
                 Err(e) => log::warn!("MCP config dir unavailable: {e}"),
@@ -380,6 +384,7 @@ pub fn run() {
             mcp_token_get,
             mcp_token_rotate,
             mcp_token_revoke,
+            mcp_token_storage,
             mcp_audit_tail,
             install_srelens_cli,
             srelens_cli_status,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ mod forward;
 mod helm;
 mod logs;
 mod mcp;
+mod mcp_confirm;
 mod settings;
 mod sink;
 mod terminal;
@@ -25,8 +26,9 @@ use forward::{start_port_forward, stop_port_forward};
 use helm::{helm_op_close, start_helm_op};
 use logs::{start_log_stream, stop_log_stream};
 use mcp::{
-    install_srelens_cli, mcp_http_start, mcp_http_status, mcp_http_stop, srelens_cli_status,
-    McpHttpManager,
+    install_srelens_cli, mcp_audit_tail, mcp_confirm_respond, mcp_http_start, mcp_http_status,
+    mcp_http_stop, mcp_token_get, mcp_token_revoke, mcp_token_rotate, srelens_cli_status,
+    McpAuditPath, McpHttpManager,
 };
 use settings::{get_request_timeout, set_request_timeout};
 use srelens_kube::client_cache::ClientCache;
@@ -320,6 +322,27 @@ pub fn run() {
                 Err(e) => log::warn!("cluster OIDC unavailable: {e}"),
             }
 
+            // MCP: the token store and audit log live under the app config
+            // dir, same convention as cluster OIDC above. Absence of a
+            // resolvable config dir is logged and skipped — the MCP token/
+            // audit commands simply error until the app is restarted somewhere
+            // that dir resolution succeeds, rather than aborting startup.
+            match app.path().app_config_dir().map(|d| d.join("mcp")) {
+                Ok(dir) => {
+                    if let Err(e) = std::fs::create_dir_all(&dir) {
+                        log::warn!("could not create MCP config dir {}: {e}", dir.display());
+                    }
+                    let token_store: std::sync::Arc<dyn srelens_mcp::auth::TokenStore> =
+                        std::sync::Arc::new(srelens_mcp::auth::FileTokenStore::new(
+                            dir.join("token"),
+                        ));
+                    app.manage(token_store);
+                    app.manage(McpAuditPath(dir.join("audit.jsonl")));
+                }
+                Err(e) => log::warn!("MCP config dir unavailable: {e}"),
+            }
+            app.manage(std::sync::Arc::new(mcp_confirm::Pending::default()));
+
             Ok(())
         })
         .manage(AppRegistry(registry))
@@ -353,6 +376,11 @@ pub fn run() {
             mcp_http_start,
             mcp_http_stop,
             mcp_http_status,
+            mcp_confirm_respond,
+            mcp_token_get,
+            mcp_token_rotate,
+            mcp_token_revoke,
+            mcp_audit_tail,
             install_srelens_cli,
             srelens_cli_status,
             start_terminal,

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -60,40 +60,39 @@ fn main() {
     }
     // `--mcp-stdio` / `--mcp-http [addr]` run the MCP server instead of the GUI,
     // so external MCP clients/agents can drive every capability. Headless runs
-    // get no GUI to prompt for consent, so destructive tools are gated behind
-    // an explicit process-level opt-in (`--mcp-allow-destructive`) rather than
-    // the GUI's per-call dialog.
+    // get no GUI to prompt for consent, so gated tools need an explicit
+    // process-level opt-in rather than the GUI's per-call dialog.
+    //
+    // Two independent flags, because they are two different risks: mutating the
+    // cluster and reading out its secrets. Granting one must not grant the
+    // other, so an agent allowed to read a Secret still cannot drain a node.
     let allow_destructive = args.iter().any(|a| a == "--mcp-allow-destructive");
+    let allow_sensitive_reads = args.iter().any(|a| a == "--mcp-allow-sensitive-reads");
     if args.iter().any(|a| a == "--mcp-stdio") {
-        run_mcp_stdio(allow_destructive);
+        run_mcp_stdio(allow_destructive, allow_sensitive_reads);
         return;
     }
     if let Some(i) = args.iter().position(|a| a == "--mcp-http") {
         // The next arg is the address unless it's itself a flag (e.g.
-        // `--mcp-http --mcp-token ...` with no address given).
+        // `--mcp-http --mcp-allow-destructive` with no address given).
         let addr = args
             .get(i + 1)
             .filter(|a| !a.starts_with("--"))
             .cloned()
             .unwrap_or_else(|| "127.0.0.1:8765".into());
-        let cli_token = flag_value(&args, "--mcp-token");
-        run_mcp_http(&addr, allow_destructive, cli_token);
+        run_mcp_http(&addr, allow_destructive, allow_sensitive_reads);
         return;
     }
     srelens_desktop_lib::run();
 }
 
-/// The value following `flag` in `args`, e.g. `flag_value(&args, "--mcp-token")`
-/// for `--mcp-token abc123`. Exits loudly if the flag is present but bare —
-/// matches the `--data` handling in the `serve` branch above.
-fn flag_value(args: &[String], flag: &str) -> Option<String> {
-    args.iter().position(|a| a == flag).map(|i| {
-        args.get(i + 1).cloned().unwrap_or_else(|| {
-            eprintln!("{flag} requires a value");
-            std::process::exit(2);
-        })
-    })
-}
+/// Environment variable carrying a caller-supplied MCP bearer token.
+///
+/// Deliberately NOT a `--mcp-token` flag: argv is world-readable through `ps`
+/// on both Linux and macOS, so a flag would hand the token to every other
+/// account on the machine — the exact local-process threat the token exists to
+/// stop. A process's environment is readable only by its own user.
+const TOKEN_ENV: &str = "SRELENS_MCP_TOKEN";
 
 /// Where the desktop app keeps its MCP bearer token's file fallback, under
 /// the app config dir. Headless mode never boots a Tauri `App`, so
@@ -127,22 +126,29 @@ fn mcp_audit_path() -> std::path::PathBuf {
 /// identically.
 const MCP_AUDIT_CAP_BYTES: u64 = 5 * 1024 * 1024;
 
-fn run_mcp_http(addr: &str, allow_destructive: bool, cli_token: Option<String>) {
+fn run_mcp_http(addr: &str, allow_destructive: bool, allow_sensitive_reads: bool) {
     let addr: std::net::SocketAddr = addr.parse().expect("invalid --mcp-http address");
-    let policy = Arc::new(srelens_mcp::policy::FlagGated::new(allow_destructive));
+    let policy = Arc::new(srelens_mcp::policy::FlagGated::new(
+        allow_destructive,
+        allow_sensitive_reads,
+    ));
 
     // The HTTP transport must never serve unauthenticated: resolve a token
-    // from the flag, then the store, then generate and persist one. Uses the
-    // same keychain-or-file resolution as the GUI (`token_store.rs`) so a
+    // from the environment, then the store, then generate and persist one. Uses
+    // the same keychain-or-file resolution as the GUI (`token_store.rs`) so a
     // token provisioned in one is usable from the other. The store itself
     // absorbs a genuinely failed keychain call and falls back to the file
     // rather than erroring — it only ever returns `Err` from `save` for a
     // real file-write failure, so `.expect` below can't panic just because
     // there's no D-Bus session on this host.
     let store = srelens_desktop_lib::token_store::keychain_or_file(mcp_token_path());
-    let token = match cli_token {
-        Some(hex) => srelens_mcp::auth::Token::from_hex(&hex)
-            .expect("--mcp-token must be 64 hex characters"),
+    let token = match std::env::var(TOKEN_ENV).ok().filter(|v| !v.trim().is_empty()) {
+        Some(hex) => srelens_mcp::auth::Token::from_hex(&hex).unwrap_or_else(|| {
+            // The value itself is never echoed — that's the whole point of
+            // keeping it out of argv.
+            eprintln!("{TOKEN_ENV} must be 64 hex characters");
+            std::process::exit(2);
+        }),
         None => match store.load() {
             Some(t) => t,
             None => {
@@ -176,10 +182,10 @@ fn run_mcp_http(addr: &str, allow_destructive: bool, cli_token: Option<String>) 
                 MCP_AUDIT_CAP_BYTES,
             )));
         eprintln!(
-            "MCP HTTP listening on http://{addr}/mcp (loopback; destructive tools need \
-             --mcp-allow-destructive and _confirm)"
+            "MCP HTTP listening on http://{addr}/mcp (loopback; gated tools need _confirm plus \
+             --mcp-allow-destructive to mutate or --mcp-allow-sensitive-reads to read secrets)"
         );
-        if let Err(e) = srelens_mcp::http::serve_http(server, addr, Some(token)).await {
+        if let Err(e) = srelens_mcp::http::serve_http(server, addr, token).await {
             eprintln!("mcp http server error: {e}");
         }
     });
@@ -206,8 +212,11 @@ fn run_serve(addr: &str, data_flag: Option<&str>) {
     });
 }
 
-fn run_mcp_stdio(allow_destructive: bool) {
-    let policy = Arc::new(srelens_mcp::policy::FlagGated::new(allow_destructive));
+fn run_mcp_stdio(allow_destructive: bool, allow_sensitive_reads: bool) {
+    let policy = Arc::new(srelens_mcp::policy::FlagGated::new(
+        allow_destructive,
+        allow_sensitive_reads,
+    ));
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -80,7 +80,7 @@ fn run_mcp_http(addr: &str) {
         let registry = srelens_desktop_lib::build_registry();
         let server = srelens_mcp::McpServer::new(Arc::new(registry));
         eprintln!("MCP HTTP listening on http://{addr}/mcp (loopback; destructive tools need _confirm)");
-        if let Err(e) = srelens_mcp::http::serve_http(server, addr).await {
+        if let Err(e) = srelens_mcp::http::serve_http(server, addr, None).await {
             eprintln!("mcp http server error: {e}");
         }
     });

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -3,8 +3,6 @@
 
 use std::sync::Arc;
 
-use srelens_mcp::auth::TokenStore as _;
-
 fn main() {
     // GUI launches (Finder/Dock) inherit launchd's minimal PATH, not the
     // user's shell PATH — kubeconfig exec plugins (kubectl, kubectl-oidc_login,
@@ -95,12 +93,14 @@ fn flag_value(args: &[String], flag: &str) -> Option<String> {
     })
 }
 
-/// Where the desktop app keeps its MCP bearer token (Task 8's
-/// `FileTokenStore`, under the app config dir). Headless mode never boots a
-/// Tauri `App`, so `app.path().app_config_dir()` (used in `lib.rs`'s setup)
-/// isn't callable here. This reproduces that resolver's formula —
-/// `dirs::config_dir()/<bundle identifier>` — directly, so the CLI and the
-/// GUI share one token file instead of each minting their own.
+/// Where the desktop app keeps its MCP bearer token's file fallback, under
+/// the app config dir. Headless mode never boots a Tauri `App`, so
+/// `app.path().app_config_dir()` (used in `lib.rs`'s setup) isn't callable
+/// here. This reproduces that resolver's formula — `dirs::config_dir()/<bundle
+/// identifier>` — directly, so the CLI and the GUI resolve to the same
+/// fallback file when the OS keychain isn't available, and to the same
+/// keychain entry (same service/account, see `token_store.rs`) when it is —
+/// either way, a token provisioned in one is usable from the other.
 fn mcp_token_path() -> std::path::PathBuf {
     dirs::config_dir()
         .expect("could not resolve the platform config directory")
@@ -114,8 +114,15 @@ fn run_mcp_http(addr: &str, allow_destructive: bool, cli_token: Option<String>) 
     let policy = Arc::new(srelens_mcp::policy::FlagGated::new(allow_destructive));
 
     // The HTTP transport must never serve unauthenticated: resolve a token
-    // from the flag, then the store, then generate and persist one.
-    let store = srelens_mcp::auth::FileTokenStore::new(mcp_token_path());
+    // from the flag, then the store, then generate and persist one. Uses the
+    // same keychain-or-file resolution as the GUI (`token_store.rs`) so a
+    // token provisioned in one is usable from the other; only the fallback
+    // path (never the token itself) is logged.
+    let (store, file_fallback) =
+        srelens_desktop_lib::token_store::keychain_or_file(mcp_token_path());
+    if file_fallback {
+        eprintln!("srelens: no OS keychain available, storing the MCP token in a 0600 file");
+    }
     let token = match cli_token {
         Some(hex) => srelens_mcp::auth::Token::from_hex(&hex)
             .expect("--mcp-token must be 64 hex characters"),

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -3,6 +3,8 @@
 
 use std::sync::Arc;
 
+use srelens_mcp::auth::TokenStore as _;
+
 fn main() {
     // GUI launches (Finder/Dock) inherit launchd's minimal PATH, not the
     // user's shell PATH — kubeconfig exec plugins (kubectl, kubectl-oidc_login,
@@ -57,30 +59,92 @@ fn main() {
         return;
     }
     // `--mcp-stdio` / `--mcp-http [addr]` run the MCP server instead of the GUI,
-    // so external MCP clients/agents can drive every capability.
+    // so external MCP clients/agents can drive every capability. Headless runs
+    // get no GUI to prompt for consent, so destructive tools are gated behind
+    // an explicit process-level opt-in (`--mcp-allow-destructive`) rather than
+    // the GUI's per-call dialog.
+    let allow_destructive = args.iter().any(|a| a == "--mcp-allow-destructive");
     if args.iter().any(|a| a == "--mcp-stdio") {
-        run_mcp_stdio();
+        run_mcp_stdio(allow_destructive);
         return;
     }
     if let Some(i) = args.iter().position(|a| a == "--mcp-http") {
-        let addr = args.get(i + 1).cloned().unwrap_or_else(|| "127.0.0.1:8765".into());
-        run_mcp_http(&addr);
+        // The next arg is the address unless it's itself a flag (e.g.
+        // `--mcp-http --mcp-token ...` with no address given).
+        let addr = args
+            .get(i + 1)
+            .filter(|a| !a.starts_with("--"))
+            .cloned()
+            .unwrap_or_else(|| "127.0.0.1:8765".into());
+        let cli_token = flag_value(&args, "--mcp-token");
+        run_mcp_http(&addr, allow_destructive, cli_token);
         return;
     }
     srelens_desktop_lib::run();
 }
 
-fn run_mcp_http(addr: &str) {
+/// The value following `flag` in `args`, e.g. `flag_value(&args, "--mcp-token")`
+/// for `--mcp-token abc123`. Exits loudly if the flag is present but bare —
+/// matches the `--data` handling in the `serve` branch above.
+fn flag_value(args: &[String], flag: &str) -> Option<String> {
+    args.iter().position(|a| a == flag).map(|i| {
+        args.get(i + 1).cloned().unwrap_or_else(|| {
+            eprintln!("{flag} requires a value");
+            std::process::exit(2);
+        })
+    })
+}
+
+/// Where the desktop app keeps its MCP bearer token (Task 8's
+/// `FileTokenStore`, under the app config dir). Headless mode never boots a
+/// Tauri `App`, so `app.path().app_config_dir()` (used in `lib.rs`'s setup)
+/// isn't callable here. This reproduces that resolver's formula —
+/// `dirs::config_dir()/<bundle identifier>` — directly, so the CLI and the
+/// GUI share one token file instead of each minting their own.
+fn mcp_token_path() -> std::path::PathBuf {
+    dirs::config_dir()
+        .expect("could not resolve the platform config directory")
+        .join("app.srelens.desktop") // tauri.conf.json "identifier"
+        .join("mcp")
+        .join("token")
+}
+
+fn run_mcp_http(addr: &str, allow_destructive: bool, cli_token: Option<String>) {
     let addr: std::net::SocketAddr = addr.parse().expect("invalid --mcp-http address");
+    let policy = Arc::new(srelens_mcp::policy::FlagGated::new(allow_destructive));
+
+    // The HTTP transport must never serve unauthenticated: resolve a token
+    // from the flag, then the store, then generate and persist one.
+    let store = srelens_mcp::auth::FileTokenStore::new(mcp_token_path());
+    let token = match cli_token {
+        Some(hex) => srelens_mcp::auth::Token::from_hex(&hex)
+            .expect("--mcp-token must be 64 hex characters"),
+        None => match store.load() {
+            Some(t) => t,
+            None => {
+                let t = srelens_mcp::auth::Token::generate();
+                store.save(&t).expect("could not persist the MCP token");
+                // stderr, not stdout: stdout is the JSON-RPC channel on the
+                // stdio transport and must stay parseable. HTTP has no such
+                // constraint but stays consistent with stdio here.
+                eprintln!("srelens: generated MCP token: {}", t.as_str());
+                t
+            }
+        },
+    };
+
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .expect("build tokio runtime");
     runtime.block_on(async {
         let registry = srelens_desktop_lib::build_registry();
-        let server = srelens_mcp::McpServer::new(Arc::new(registry));
-        eprintln!("MCP HTTP listening on http://{addr}/mcp (loopback; destructive tools need _confirm)");
-        if let Err(e) = srelens_mcp::http::serve_http(server, addr, None).await {
+        let server = srelens_mcp::McpServer::new(Arc::new(registry)).with_policy(policy);
+        eprintln!(
+            "MCP HTTP listening on http://{addr}/mcp (loopback; destructive tools need \
+             --mcp-allow-destructive and _confirm)"
+        );
+        if let Err(e) = srelens_mcp::http::serve_http(server, addr, Some(token)).await {
             eprintln!("mcp http server error: {e}");
         }
     });
@@ -107,14 +171,15 @@ fn run_serve(addr: &str, data_flag: Option<&str>) {
     });
 }
 
-fn run_mcp_stdio() {
+fn run_mcp_stdio(allow_destructive: bool) {
+    let policy = Arc::new(srelens_mcp::policy::FlagGated::new(allow_destructive));
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .expect("build tokio runtime");
     runtime.block_on(async {
         let registry = srelens_desktop_lib::build_registry();
-        let server = srelens_mcp::McpServer::new(Arc::new(registry));
+        let server = srelens_mcp::McpServer::new(Arc::new(registry)).with_policy(policy);
         let reader = tokio::io::BufReader::new(tokio::io::stdin());
         let writer = tokio::io::stdout();
         if let Err(e) = srelens_mcp::stdio::serve(server, reader, writer).await {

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -3,6 +3,8 @@
 
 use std::sync::Arc;
 
+use srelens_mcp::auth::TokenStore as _;
+
 fn main() {
     // GUI launches (Finder/Dock) inherit launchd's minimal PATH, not the
     // user's shell PATH — kubeconfig exec plugins (kubectl, kubectl-oidc_login,
@@ -116,13 +118,12 @@ fn run_mcp_http(addr: &str, allow_destructive: bool, cli_token: Option<String>) 
     // The HTTP transport must never serve unauthenticated: resolve a token
     // from the flag, then the store, then generate and persist one. Uses the
     // same keychain-or-file resolution as the GUI (`token_store.rs`) so a
-    // token provisioned in one is usable from the other; only the fallback
-    // path (never the token itself) is logged.
-    let (store, file_fallback) =
-        srelens_desktop_lib::token_store::keychain_or_file(mcp_token_path());
-    if file_fallback {
-        eprintln!("srelens: no OS keychain available, storing the MCP token in a 0600 file");
-    }
+    // token provisioned in one is usable from the other. The store itself
+    // absorbs a genuinely failed keychain call and falls back to the file
+    // rather than erroring — it only ever returns `Err` from `save` for a
+    // real file-write failure, so `.expect` below can't panic just because
+    // there's no D-Bus session on this host.
+    let store = srelens_desktop_lib::token_store::keychain_or_file(mcp_token_path());
     let token = match cli_token {
         Some(hex) => srelens_mcp::auth::Token::from_hex(&hex)
             .expect("--mcp-token must be 64 hex characters"),
@@ -139,6 +140,12 @@ fn run_mcp_http(addr: &str, allow_destructive: bool, cli_token: Option<String>) 
             }
         },
     };
+    // Checked after the load/save attempt above (not before): only then do
+    // we know whether the keychain actually served this call, rather than
+    // guessing from whether it merely looked reachable.
+    if store.current_backend() == "file" {
+        eprintln!("srelens: no OS keychain available, storing the MCP token in a 0600 file");
+    }
 
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -111,6 +111,22 @@ fn mcp_token_path() -> std::path::PathBuf {
         .join("token")
 }
 
+/// Where a headless run (`--mcp-stdio` / `--mcp-http`) writes its audit log —
+/// `audit.jsonl` next to the token file, in the same `mcp/` directory
+/// `mcp_token_path()` resolves. Derived from that path (not recomputed from
+/// the formula it documents) so the two can never drift apart.
+fn mcp_audit_path() -> std::path::PathBuf {
+    mcp_token_path()
+        .parent()
+        .expect("mcp_token_path() always has a parent directory")
+        .join("audit.jsonl")
+}
+
+/// Same rotation cap the desktop app's in-process MCP server uses (see
+/// `McpAuditPath` wiring in `mcp.rs`), so a headless run and the GUI behave
+/// identically.
+const MCP_AUDIT_CAP_BYTES: u64 = 5 * 1024 * 1024;
+
 fn run_mcp_http(addr: &str, allow_destructive: bool, cli_token: Option<String>) {
     let addr: std::net::SocketAddr = addr.parse().expect("invalid --mcp-http address");
     let policy = Arc::new(srelens_mcp::policy::FlagGated::new(allow_destructive));
@@ -153,7 +169,12 @@ fn run_mcp_http(addr: &str, allow_destructive: bool, cli_token: Option<String>) 
         .expect("build tokio runtime");
     runtime.block_on(async {
         let registry = srelens_desktop_lib::build_registry();
-        let server = srelens_mcp::McpServer::new(Arc::new(registry)).with_policy(policy);
+        let server = srelens_mcp::McpServer::new(Arc::new(registry))
+            .with_policy(policy)
+            .with_audit(Arc::new(srelens_mcp::audit::JsonlAuditLog::new(
+                mcp_audit_path(),
+                MCP_AUDIT_CAP_BYTES,
+            )));
         eprintln!(
             "MCP HTTP listening on http://{addr}/mcp (loopback; destructive tools need \
              --mcp-allow-destructive and _confirm)"
@@ -193,7 +214,12 @@ fn run_mcp_stdio(allow_destructive: bool) {
         .expect("build tokio runtime");
     runtime.block_on(async {
         let registry = srelens_desktop_lib::build_registry();
-        let server = srelens_mcp::McpServer::new(Arc::new(registry)).with_policy(policy);
+        let server = srelens_mcp::McpServer::new(Arc::new(registry))
+            .with_policy(policy)
+            .with_audit(Arc::new(srelens_mcp::audit::JsonlAuditLog::new(
+                mcp_audit_path(),
+                MCP_AUDIT_CAP_BYTES,
+            )));
         let reader = tokio::io::BufReader::new(tokio::io::stdin());
         let writer = tokio::io::stdout();
         if let Err(e) = srelens_mcp::stdio::serve(server, reader, writer).await {

--- a/apps/desktop/src-tauri/src/mcp.rs
+++ b/apps/desktop/src-tauri/src/mcp.rs
@@ -62,9 +62,14 @@ pub async fn mcp_http_start(port: u16, manager: State<'_, McpHttpManager>) -> Re
     let server = srelens_mcp::McpServer::new(Arc::new(registry));
     let (tx, rx) = oneshot::channel();
     let handle = tokio::spawn(async move {
-        let _ = srelens_mcp::http::serve_http_with_shutdown(server, listener, async {
-            let _ = rx.await;
-        })
+        let _ = srelens_mcp::http::serve_http_with_shutdown(
+            server,
+            listener,
+            async {
+                let _ = rx.await;
+            },
+            None,
+        )
         .await;
     });
 

--- a/apps/desktop/src-tauri/src/mcp.rs
+++ b/apps/desktop/src-tauri/src/mcp.rs
@@ -34,16 +34,31 @@ impl McpHttpManager {
     }
 }
 
-fn stop_running(manager: &McpHttpManager, pending: &crate::mcp_confirm::Pending) {
+/// Stop whatever server is currently registered, if any, and wait for its
+/// task to actually finish before returning. Signals graceful shutdown first
+/// (axum's graceful shutdown waits on in-flight keep-alive connections, which
+/// an idle MCP client may be holding open) and only falls back to `abort()`
+/// if that doesn't finish promptly — aborting alone does not synchronously
+/// drop the task's future, so the old listener fd can still be open when the
+/// caller immediately tries to rebind the same port.
+async fn stop_running(manager: &McpHttpManager, pending: &crate::mcp_confirm::Pending) {
     // Release every in-flight confirm as denied first, so a call blocked on a
     // dialog fails fast instead of hanging until its timeout once the
     // transport it belongs to is gone.
     pending.deny_all();
-    if let Some(mut running) = manager.running.lock().unwrap().take() {
+    let running = manager.running.lock().unwrap().take();
+    if let Some(mut running) = running {
         if let Some(tx) = running.shutdown.take() {
             let _ = tx.send(());
         }
-        running.handle.abort();
+        let mut handle = running.handle;
+        if tokio::time::timeout(std::time::Duration::from_secs(2), &mut handle)
+            .await
+            .is_err()
+        {
+            handle.abort();
+            let _ = handle.await;
+        }
     }
 }
 
@@ -65,7 +80,7 @@ async fn start_server(
     token: srelens_mcp::auth::Token,
     audit_path: &std::path::Path,
 ) -> Result<String, String> {
-    stop_running(manager, pending);
+    stop_running(manager, pending).await;
 
     let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
     let listener = tokio::net::TcpListener::bind(addr)
@@ -130,11 +145,11 @@ pub async fn mcp_http_start(
 
 /// Stop the MCP HTTP server if running.
 #[tauri::command]
-pub fn mcp_http_stop(
+pub async fn mcp_http_stop(
     manager: State<'_, McpHttpManager>,
     pending: State<'_, Arc<crate::mcp_confirm::Pending>>,
 ) -> Result<(), String> {
-    stop_running(&manager, &pending);
+    stop_running(&manager, &pending).await;
     Ok(())
 }
 
@@ -213,13 +228,13 @@ pub fn mcp_token_storage(
 /// Revoke the MCP bearer token and stop the HTTP transport — it must never
 /// serve unauthenticated.
 #[tauri::command]
-pub fn mcp_token_revoke(
+pub async fn mcp_token_revoke(
     store: State<'_, Arc<dyn srelens_mcp::auth::TokenStore>>,
     manager: State<'_, McpHttpManager>,
     pending: State<'_, Arc<crate::mcp_confirm::Pending>>,
 ) -> Result<(), String> {
     store.clear().map_err(|e| e.to_string())?;
-    stop_running(&manager, &pending);
+    stop_running(&manager, &pending).await;
     Ok(())
 }
 
@@ -318,5 +333,50 @@ pub fn install_srelens_cli() -> Result<String, String> {
     {
         let _ = exe;
         Err("Installing the srelens CLI is only supported on macOS/Linux.".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The bug this closes: `stop_running` used to send the shutdown signal
+    /// and `abort()` the task without waiting for either to actually finish,
+    /// so `start_server`'s immediate rebind on the same port raced the old
+    /// listener's fd closing — the reviewer reproduced 38/50 failures. This
+    /// drives the exact shape of that race (bind, register as `Running`,
+    /// `stop_running`, rebind the identical port) 50 times in a row; with the
+    /// fix (`await` the handle, with a bounded `abort()` fallback) every
+    /// rebind must succeed.
+    #[tokio::test]
+    async fn stop_running_releases_the_port_before_returning() {
+        let cache = ClientCache::new(std::path::PathBuf::from("/dev/null"));
+        let manager = McpHttpManager::new(cache);
+        let pending = crate::mcp_confirm::Pending::default();
+
+        for i in 0..50 {
+            let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 0)); // OS-assigned port
+            let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+            let bound_addr = listener.local_addr().unwrap();
+            let (tx, rx) = oneshot::channel::<()>();
+            // Mirrors `serve_http_with_shutdown`: the task owns the listener
+            // and only lets go of it once told to shut down, just like axum
+            // holding the socket open for an idle keep-alive connection.
+            let handle = tokio::spawn(async move {
+                let _ = rx.await;
+                drop(listener);
+            });
+            *manager.running.lock().unwrap() = Some(Running {
+                addr: bound_addr,
+                shutdown: Some(tx),
+                handle,
+            });
+
+            stop_running(&manager, &pending).await;
+
+            tokio::net::TcpListener::bind(bound_addr).await.unwrap_or_else(|e| {
+                panic!("rebind attempt {i} on {bound_addr} failed: {e}")
+            });
+        }
     }
 }

--- a/apps/desktop/src-tauri/src/mcp.rs
+++ b/apps/desktop/src-tauri/src/mcp.rs
@@ -165,12 +165,16 @@ pub fn mcp_token_rotate(
 }
 
 /// Where the MCP bearer token is actually stored right now: `"keychain"` when
-/// the OS keychain is available, `"file"` when it fell back to the 0600 file.
-/// Settings surfaces this so a file-backed token isn't mistaken for one
-/// protected by the OS.
+/// the OS keychain is serving, `"file"` once it has fallen back to the 0600
+/// file. Reads the live flag off the store (flipped the first time a keychain
+/// operation genuinely failed) rather than a value guessed at startup, so
+/// Settings reports observed reality even if the keychain looked available
+/// when the app launched but failed on first use.
 #[tauri::command]
-pub fn mcp_token_storage(storage: State<'_, crate::token_store::TokenStorage>) -> &'static str {
-    storage.0
+pub fn mcp_token_storage(
+    store: State<'_, Arc<crate::token_store::ResilientTokenStore>>,
+) -> &'static str {
+    store.current_backend()
 }
 
 /// Revoke the MCP bearer token and stop the HTTP transport — it must never

--- a/apps/desktop/src-tauri/src/mcp.rs
+++ b/apps/desktop/src-tauri/src/mcp.rs
@@ -51,44 +51,36 @@ fn url_for(addr: SocketAddr) -> String {
     format!("http://{addr}/mcp")
 }
 
-/// Start (or restart) the loopback MCP HTTP server on `port`. Returns its URL.
-#[tauri::command]
-pub async fn mcp_http_start(
+/// Bind `port` and serve the MCP HTTP transport on it, replacing whatever was
+/// previously running. Shared by `mcp_http_start` (a fresh start/restart from
+/// the toggle) and `mcp_token_rotate` (a same-port restart so a freshly
+/// rotated token takes effect at once instead of leaving the old token
+/// accepted by an already-running listener). Bind happens before anything
+/// else so a port conflict is reported to the caller immediately.
+async fn start_server(
     port: u16,
-    app: tauri::AppHandle,
-    manager: State<'_, McpHttpManager>,
-    pending: State<'_, Arc<crate::mcp_confirm::Pending>>,
-    token_store: State<'_, Arc<dyn srelens_mcp::auth::TokenStore>>,
-    audit_path: State<'_, McpAuditPath>,
+    app: &tauri::AppHandle,
+    manager: &McpHttpManager,
+    pending: &Arc<crate::mcp_confirm::Pending>,
+    token: srelens_mcp::auth::Token,
+    audit_path: &std::path::Path,
 ) -> Result<String, String> {
-    stop_running(&manager, &pending);
+    stop_running(manager, pending);
 
     let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
-    // Bind up front so a port conflict is reported to the UI immediately.
     let listener = tokio::net::TcpListener::bind(addr)
         .await
         .map_err(|e| format!("Could not bind {addr}: {e}"))?;
-
-    // The HTTP transport must never serve unauthenticated: mint a token on
-    // first use if one hasn't been generated yet.
-    let token = match token_store.load() {
-        Some(t) => t,
-        None => {
-            let t = srelens_mcp::auth::Token::generate();
-            token_store.save(&t).map_err(|e| e.to_string())?;
-            t
-        }
-    };
 
     let registry = build_registry_with(manager.cache.clone());
     let server = srelens_mcp::McpServer::new(Arc::new(registry))
         .with_policy(Arc::new(crate::mcp_confirm::PromptUser::new(
             app.clone(),
-            pending.inner().clone(),
+            pending.clone(),
             std::time::Duration::from_secs(60),
         )))
         .with_audit(Arc::new(srelens_mcp::audit::JsonlAuditLog::new(
-            audit_path.0.clone(),
+            audit_path.to_path_buf(),
             5 * 1024 * 1024,
         )));
     let (tx, rx) = oneshot::channel();
@@ -110,6 +102,30 @@ pub async fn mcp_http_start(
         handle,
     });
     Ok(url_for(addr))
+}
+
+/// Start (or restart) the loopback MCP HTTP server on `port`. Returns its URL.
+#[tauri::command]
+pub async fn mcp_http_start(
+    port: u16,
+    app: tauri::AppHandle,
+    manager: State<'_, McpHttpManager>,
+    pending: State<'_, Arc<crate::mcp_confirm::Pending>>,
+    token_store: State<'_, Arc<dyn srelens_mcp::auth::TokenStore>>,
+    audit_path: State<'_, McpAuditPath>,
+) -> Result<String, String> {
+    // The HTTP transport must never serve unauthenticated: mint a token on
+    // first use if one hasn't been generated yet.
+    let token = match token_store.load() {
+        Some(t) => t,
+        None => {
+            let t = srelens_mcp::auth::Token::generate();
+            token_store.save(&t).map_err(|e| e.to_string())?;
+            t
+        }
+    };
+
+    start_server(port, &app, &manager, pending.inner(), token, &audit_path.0).await
 }
 
 /// Stop the MCP HTTP server if running.
@@ -155,12 +171,29 @@ pub fn mcp_token_get(store: State<'_, Arc<dyn srelens_mcp::auth::TokenStore>>) -
 }
 
 /// Generate and persist a fresh MCP bearer token, replacing any existing one.
+/// If the HTTP server is currently running, restarts it on the same port so
+/// the new token takes effect immediately — the previously running listener
+/// had the old token baked into its middleware state and would otherwise
+/// keep accepting it until the app restarted. If the server is not running,
+/// it is left stopped: rotating a token must never switch the server on.
 #[tauri::command]
-pub fn mcp_token_rotate(
+pub async fn mcp_token_rotate(
+    app: tauri::AppHandle,
     store: State<'_, Arc<dyn srelens_mcp::auth::TokenStore>>,
+    manager: State<'_, McpHttpManager>,
+    pending: State<'_, Arc<crate::mcp_confirm::Pending>>,
+    audit_path: State<'_, McpAuditPath>,
 ) -> Result<String, String> {
     let t = srelens_mcp::auth::Token::generate();
     store.save(&t).map_err(|e| e.to_string())?;
+
+    // Read the running port (if any) and drop the lock before restarting —
+    // `start_server` takes it again via `stop_running`.
+    let running_port = manager.running.lock().unwrap().as_ref().map(|r| r.addr.port());
+    if let Some(port) = running_port {
+        start_server(port, &app, &manager, pending.inner(), t.clone(), &audit_path.0).await?;
+    }
+
     Ok(t.as_str().to_string())
 }
 

--- a/apps/desktop/src-tauri/src/mcp.rs
+++ b/apps/desktop/src-tauri/src/mcp.rs
@@ -23,6 +23,14 @@ struct Running {
 pub struct McpHttpManager {
     cache: Arc<ClientCache>,
     running: Mutex<Option<Running>>,
+    /// Serializes whole lifecycle transitions. `running` is a std mutex that
+    /// cannot be held across an await, so on its own it only makes each
+    /// individual read/write atomic — not the stop-then-rebind sequence around
+    /// them. Two overlapping transitions (the Settings toggle and a token
+    /// rotate are separate controls) could therefore both pass teardown and
+    /// then both bind the same port, or the later one could overwrite a live
+    /// `Running` and orphan a task still holding the listener.
+    lifecycle: tokio::sync::Mutex<()>,
 }
 
 impl McpHttpManager {
@@ -30,9 +38,21 @@ impl McpHttpManager {
         Self {
             cache,
             running: Mutex::new(None),
+            lifecycle: tokio::sync::Mutex::new(()),
         }
     }
+
+    /// Take the lifecycle lock for the duration of a start/stop/rotate. The
+    /// resulting guard is threaded into [`stop_running`] and [`start_server`]
+    /// as a witness, so neither can be called without it being held.
+    async fn lifecycle(&self) -> tokio::sync::MutexGuard<'_, ()> {
+        self.lifecycle.lock().await
+    }
 }
+
+/// Proof that the caller holds `McpHttpManager::lifecycle`. Only exists to make
+/// "you must hold the lock" a compile-time requirement rather than a comment.
+type Lifecycle<'a> = tokio::sync::MutexGuard<'a, ()>;
 
 /// Stop whatever server is currently registered, if any, and wait for its
 /// task to actually finish before returning. Signals graceful shutdown first
@@ -41,7 +61,11 @@ impl McpHttpManager {
 /// if that doesn't finish promptly — aborting alone does not synchronously
 /// drop the task's future, so the old listener fd can still be open when the
 /// caller immediately tries to rebind the same port.
-async fn stop_running(manager: &McpHttpManager, pending: &crate::mcp_confirm::Pending) {
+async fn stop_running(
+    manager: &McpHttpManager,
+    pending: &crate::mcp_confirm::Pending,
+    _lifecycle: &Lifecycle<'_>,
+) {
     // Release every in-flight confirm as denied first, so a call blocked on a
     // dialog fails fast instead of hanging until its timeout once the
     // transport it belongs to is gone.
@@ -79,8 +103,9 @@ async fn start_server(
     pending: &Arc<crate::mcp_confirm::Pending>,
     token: srelens_mcp::auth::Token,
     audit_path: &std::path::Path,
+    lifecycle: &Lifecycle<'_>,
 ) -> Result<String, String> {
-    stop_running(manager, pending).await;
+    stop_running(manager, pending, lifecycle).await;
 
     let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
     let listener = tokio::net::TcpListener::bind(addr)
@@ -106,7 +131,7 @@ async fn start_server(
             async {
                 let _ = rx.await;
             },
-            Some(token),
+            token,
         )
         .await;
     });
@@ -140,7 +165,17 @@ pub async fn mcp_http_start(
         }
     };
 
-    start_server(port, &app, &manager, pending.inner(), token, &audit_path.0).await
+    let lifecycle = manager.lifecycle().await;
+    start_server(
+        port,
+        &app,
+        &manager,
+        pending.inner(),
+        token,
+        &audit_path.0,
+        &lifecycle,
+    )
+    .await
 }
 
 /// Stop the MCP HTTP server if running.
@@ -149,7 +184,8 @@ pub async fn mcp_http_stop(
     manager: State<'_, McpHttpManager>,
     pending: State<'_, Arc<crate::mcp_confirm::Pending>>,
 ) -> Result<(), String> {
-    stop_running(&manager, &pending).await;
+    let lifecycle = manager.lifecycle().await;
+    stop_running(&manager, &pending, &lifecycle).await;
     Ok(())
 }
 
@@ -202,11 +238,22 @@ pub async fn mcp_token_rotate(
     let t = srelens_mcp::auth::Token::generate();
     store.save(&t).map_err(|e| e.to_string())?;
 
-    // Read the running port (if any) and drop the lock before restarting —
-    // `start_server` takes it again via `stop_running`.
+    // Held across the read-port-then-restart sequence, so a concurrent toggle
+    // can't stop the server between the two and leave us restarting one the
+    // user just switched off.
+    let lifecycle = manager.lifecycle().await;
     let running_port = manager.running.lock().unwrap().as_ref().map(|r| r.addr.port());
     if let Some(port) = running_port {
-        start_server(port, &app, &manager, pending.inner(), t.clone(), &audit_path.0).await?;
+        start_server(
+            port,
+            &app,
+            &manager,
+            pending.inner(),
+            t.clone(),
+            &audit_path.0,
+            &lifecycle,
+        )
+        .await?;
     }
 
     Ok(t.as_str().to_string())
@@ -234,21 +281,17 @@ pub async fn mcp_token_revoke(
     pending: State<'_, Arc<crate::mcp_confirm::Pending>>,
 ) -> Result<(), String> {
     store.clear().map_err(|e| e.to_string())?;
-    stop_running(&manager, &pending).await;
+    let lifecycle = manager.lifecycle().await;
+    stop_running(&manager, &pending, &lifecycle).await;
     Ok(())
 }
 
-/// The most recent `limit` MCP audit records, newest first.
+/// The most recent `limit` MCP audit records, newest first. Reading is owned by
+/// `srelens_mcp::audit`, which also writes the format and so knows how to tail
+/// it without parsing the whole 5 MB file.
 #[tauri::command]
 pub fn mcp_audit_tail(limit: usize, path: State<'_, McpAuditPath>) -> Vec<serde_json::Value> {
-    let body = std::fs::read_to_string(&path.0).unwrap_or_default();
-    let mut lines: Vec<serde_json::Value> = body
-        .lines()
-        .filter_map(|l| serde_json::from_str(l).ok())
-        .collect();
-    lines.reverse(); // newest first
-    lines.truncate(limit);
-    lines
+    srelens_mcp::audit::tail(&path.0, limit)
 }
 
 /// Path to the audit log, managed so the command can read it without
@@ -348,6 +391,86 @@ mod tests {
     /// `stop_running`, rebind the identical port) 50 times in a row; with the
     /// fix (`await` the handle, with a bounded `abort()` fallback) every
     /// rebind must succeed.
+    /// Mirrors `start_server`'s lifecycle shape (take the lock, tear the old
+    /// server down, rebind, register) without the Tauri bits `start_server`
+    /// needs — an `AppHandle` can't be built in a unit test. The listener-owning
+    /// task stands in for axum holding the socket.
+    async fn restart_on(
+        manager: &McpHttpManager,
+        pending: &crate::mcp_confirm::Pending,
+        addr: SocketAddr,
+    ) -> std::io::Result<()> {
+        let guard = manager.lifecycle().await;
+        stop_running(manager, pending, &guard).await;
+        let listener = tokio::net::TcpListener::bind(addr).await?;
+        let (tx, rx) = oneshot::channel::<()>();
+        let handle = tokio::spawn(async move {
+            let _ = rx.await;
+            drop(listener);
+        });
+        *manager.running.lock().unwrap() = Some(Running {
+            addr,
+            shutdown: Some(tx),
+            handle,
+        });
+        Ok(())
+    }
+
+    /// Rotating a token restarts the server, and the Settings toggle starts and
+    /// stops it — two separate controls that can overlap. Without a lock around
+    /// the whole transition, both can complete teardown (each seeing no running
+    /// server) and then race to bind the same port, so one loses with
+    /// `Address already in use` and the user sees a spurious failure.
+    #[tokio::test]
+    async fn concurrent_lifecycle_transitions_do_not_race_the_bind() {
+        let manager = Arc::new(McpHttpManager::new(ClientCache::new(
+            std::path::PathBuf::from("/dev/null"),
+        )));
+        let pending = Arc::new(crate::mcp_confirm::Pending::default());
+
+        // Start with a server ALREADY running on the port. This is what opens
+        // the window: the first transition's teardown awaits the old task's
+        // JoinHandle, and that await is where the second transition gets in —
+        // finding `running` already taken, so it sails past teardown and binds
+        // the port the first one is about to rebind. With no server running
+        // there is no await in teardown, the two never interleave, and the test
+        // would pass against the racy code.
+        let addr = {
+            let listener = tokio::net::TcpListener::bind(SocketAddr::from((
+                Ipv4Addr::LOCALHOST,
+                0,
+            )))
+            .await
+            .unwrap();
+            let addr = listener.local_addr().unwrap();
+            let (tx, rx) = oneshot::channel::<()>();
+            let handle = tokio::spawn(async move {
+                let _ = rx.await;
+                // Mirror axum's unhurried release of the socket.
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+                drop(listener);
+            });
+            *manager.running.lock().unwrap() = Some(Running {
+                addr,
+                shutdown: Some(tx),
+                handle,
+            });
+            addr
+        };
+
+        let a = tokio::spawn({
+            let (m, p) = (manager.clone(), pending.clone());
+            async move { restart_on(&m, &p, addr).await }
+        });
+        let b = tokio::spawn({
+            let (m, p) = (manager.clone(), pending.clone());
+            async move { restart_on(&m, &p, addr).await }
+        });
+
+        a.await.unwrap().expect("first transition must bind");
+        b.await.unwrap().expect("second transition must bind after the first tore down");
+    }
+
     #[tokio::test]
     async fn stop_running_releases_the_port_before_returning() {
         let cache = ClientCache::new(std::path::PathBuf::from("/dev/null"));
@@ -372,7 +495,10 @@ mod tests {
                 handle,
             });
 
-            stop_running(&manager, &pending).await;
+            {
+                let guard = manager.lifecycle().await;
+                stop_running(&manager, &pending, &guard).await;
+            }
 
             tokio::net::TcpListener::bind(bound_addr).await.unwrap_or_else(|e| {
                 panic!("rebind attempt {i} on {bound_addr} failed: {e}")

--- a/apps/desktop/src-tauri/src/mcp.rs
+++ b/apps/desktop/src-tauri/src/mcp.rs
@@ -34,7 +34,11 @@ impl McpHttpManager {
     }
 }
 
-fn stop_running(manager: &McpHttpManager) {
+fn stop_running(manager: &McpHttpManager, pending: &crate::mcp_confirm::Pending) {
+    // Release every in-flight confirm as denied first, so a call blocked on a
+    // dialog fails fast instead of hanging until its timeout once the
+    // transport it belongs to is gone.
+    pending.deny_all();
     if let Some(mut running) = manager.running.lock().unwrap().take() {
         if let Some(tx) = running.shutdown.take() {
             let _ = tx.send(());
@@ -49,8 +53,15 @@ fn url_for(addr: SocketAddr) -> String {
 
 /// Start (or restart) the loopback MCP HTTP server on `port`. Returns its URL.
 #[tauri::command]
-pub async fn mcp_http_start(port: u16, manager: State<'_, McpHttpManager>) -> Result<String, String> {
-    stop_running(&manager);
+pub async fn mcp_http_start(
+    port: u16,
+    app: tauri::AppHandle,
+    manager: State<'_, McpHttpManager>,
+    pending: State<'_, Arc<crate::mcp_confirm::Pending>>,
+    token_store: State<'_, Arc<dyn srelens_mcp::auth::TokenStore>>,
+    audit_path: State<'_, McpAuditPath>,
+) -> Result<String, String> {
+    stop_running(&manager, &pending);
 
     let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
     // Bind up front so a port conflict is reported to the UI immediately.
@@ -58,8 +69,28 @@ pub async fn mcp_http_start(port: u16, manager: State<'_, McpHttpManager>) -> Re
         .await
         .map_err(|e| format!("Could not bind {addr}: {e}"))?;
 
+    // The HTTP transport must never serve unauthenticated: mint a token on
+    // first use if one hasn't been generated yet.
+    let token = match token_store.load() {
+        Some(t) => t,
+        None => {
+            let t = srelens_mcp::auth::Token::generate();
+            token_store.save(&t).map_err(|e| e.to_string())?;
+            t
+        }
+    };
+
     let registry = build_registry_with(manager.cache.clone());
-    let server = srelens_mcp::McpServer::new(Arc::new(registry));
+    let server = srelens_mcp::McpServer::new(Arc::new(registry))
+        .with_policy(Arc::new(crate::mcp_confirm::PromptUser::new(
+            app.clone(),
+            pending.inner().clone(),
+            std::time::Duration::from_secs(60),
+        )))
+        .with_audit(Arc::new(srelens_mcp::audit::JsonlAuditLog::new(
+            audit_path.0.clone(),
+            5 * 1024 * 1024,
+        )));
     let (tx, rx) = oneshot::channel();
     let handle = tokio::spawn(async move {
         let _ = srelens_mcp::http::serve_http_with_shutdown(
@@ -68,7 +99,7 @@ pub async fn mcp_http_start(port: u16, manager: State<'_, McpHttpManager>) -> Re
             async {
                 let _ = rx.await;
             },
-            None,
+            Some(token),
         )
         .await;
     });
@@ -83,8 +114,11 @@ pub async fn mcp_http_start(port: u16, manager: State<'_, McpHttpManager>) -> Re
 
 /// Stop the MCP HTTP server if running.
 #[tauri::command]
-pub fn mcp_http_stop(manager: State<'_, McpHttpManager>) -> Result<(), String> {
-    stop_running(&manager);
+pub fn mcp_http_stop(
+    manager: State<'_, McpHttpManager>,
+    pending: State<'_, Arc<crate::mcp_confirm::Pending>>,
+) -> Result<(), String> {
+    stop_running(&manager, &pending);
     Ok(())
 }
 
@@ -98,6 +132,67 @@ pub fn mcp_http_status(manager: State<'_, McpHttpManager>) -> Option<String> {
         .as_ref()
         .map(|running| url_for(running.addr))
 }
+
+/// Resolve a pending MCP confirm dialog. `approved` decides whether the
+/// blocked tool call proceeds or is refused.
+#[tauri::command]
+pub fn mcp_confirm_respond(
+    id: String,
+    approved: bool,
+    pending: State<'_, Arc<crate::mcp_confirm::Pending>>,
+) -> Result<(), String> {
+    if pending.resolve(&id, approved) {
+        Ok(())
+    } else {
+        Err("that confirmation is no longer waiting (it timed out or was already answered)".into())
+    }
+}
+
+/// The current MCP bearer token, if one has been generated.
+#[tauri::command]
+pub fn mcp_token_get(store: State<'_, Arc<dyn srelens_mcp::auth::TokenStore>>) -> Option<String> {
+    store.load().map(|t| t.as_str().to_string())
+}
+
+/// Generate and persist a fresh MCP bearer token, replacing any existing one.
+#[tauri::command]
+pub fn mcp_token_rotate(
+    store: State<'_, Arc<dyn srelens_mcp::auth::TokenStore>>,
+) -> Result<String, String> {
+    let t = srelens_mcp::auth::Token::generate();
+    store.save(&t).map_err(|e| e.to_string())?;
+    Ok(t.as_str().to_string())
+}
+
+/// Revoke the MCP bearer token and stop the HTTP transport — it must never
+/// serve unauthenticated.
+#[tauri::command]
+pub fn mcp_token_revoke(
+    store: State<'_, Arc<dyn srelens_mcp::auth::TokenStore>>,
+    manager: State<'_, McpHttpManager>,
+    pending: State<'_, Arc<crate::mcp_confirm::Pending>>,
+) -> Result<(), String> {
+    store.clear().map_err(|e| e.to_string())?;
+    stop_running(&manager, &pending);
+    Ok(())
+}
+
+/// The most recent `limit` MCP audit records, newest first.
+#[tauri::command]
+pub fn mcp_audit_tail(limit: usize, path: State<'_, McpAuditPath>) -> Vec<serde_json::Value> {
+    let body = std::fs::read_to_string(&path.0).unwrap_or_default();
+    let mut lines: Vec<serde_json::Value> = body
+        .lines()
+        .filter_map(|l| serde_json::from_str(l).ok())
+        .collect();
+    lines.reverse(); // newest first
+    lines.truncate(limit);
+    lines
+}
+
+/// Path to the audit log, managed so the command can read it without
+/// reconstructing the app config dir.
+pub struct McpAuditPath(pub std::path::PathBuf);
 
 /// Where the `srelens` CLI symlink is installed, and whether it points at us.
 #[derive(Debug, Serialize)]

--- a/apps/desktop/src-tauri/src/mcp.rs
+++ b/apps/desktop/src-tauri/src/mcp.rs
@@ -164,6 +164,15 @@ pub fn mcp_token_rotate(
     Ok(t.as_str().to_string())
 }
 
+/// Where the MCP bearer token is actually stored right now: `"keychain"` when
+/// the OS keychain is available, `"file"` when it fell back to the 0600 file.
+/// Settings surfaces this so a file-backed token isn't mistaken for one
+/// protected by the OS.
+#[tauri::command]
+pub fn mcp_token_storage(storage: State<'_, crate::token_store::TokenStorage>) -> &'static str {
+    storage.0
+}
+
 /// Revoke the MCP bearer token and stop the HTTP transport — it must never
 /// serve unauthenticated.
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/mcp.rs
+++ b/apps/desktop/src-tauri/src/mcp.rs
@@ -154,6 +154,13 @@ pub async fn mcp_http_start(
     token_store: State<'_, Arc<dyn srelens_mcp::auth::TokenStore>>,
     audit_path: State<'_, McpAuditPath>,
 ) -> Result<String, String> {
+    // Taken BEFORE the token is read, not just around the restart: a rotate
+    // that lands in between would persist a new token and restart the server
+    // with it, and then this start would rebind with the token it had already
+    // loaded — leaving the transport serving a value the store no longer holds,
+    // so every client configured from Settings gets a 401.
+    let lifecycle = manager.lifecycle().await;
+
     // The HTTP transport must never serve unauthenticated: mint a token on
     // first use if one hasn't been generated yet.
     let token = match token_store.load() {
@@ -165,7 +172,6 @@ pub async fn mcp_http_start(
         }
     };
 
-    let lifecycle = manager.lifecycle().await;
     start_server(
         port,
         &app,
@@ -235,13 +241,15 @@ pub async fn mcp_token_rotate(
     pending: State<'_, Arc<crate::mcp_confirm::Pending>>,
     audit_path: State<'_, McpAuditPath>,
 ) -> Result<String, String> {
+    // Held across persist-then-restart, not just the restart: a revoke landing
+    // between the two would clear the store and stop the server, and this
+    // rotate would then leave a freshly persisted token behind it — Settings
+    // showing a live token for a server that was deliberately switched off.
+    let lifecycle = manager.lifecycle().await;
+
     let t = srelens_mcp::auth::Token::generate();
     store.save(&t).map_err(|e| e.to_string())?;
 
-    // Held across the read-port-then-restart sequence, so a concurrent toggle
-    // can't stop the server between the two and leave us restarting one the
-    // user just switched off.
-    let lifecycle = manager.lifecycle().await;
     let running_port = manager.running.lock().unwrap().as_ref().map(|r| r.addr.port());
     if let Some(port) = running_port {
         start_server(
@@ -280,8 +288,11 @@ pub async fn mcp_token_revoke(
     manager: State<'_, McpHttpManager>,
     pending: State<'_, Arc<crate::mcp_confirm::Pending>>,
 ) -> Result<(), String> {
-    store.clear().map_err(|e| e.to_string())?;
+    // Same ordering rule as rotate: clear and stop are one transition, so a
+    // concurrent start can't load the token between them and bring the server
+    // back up on a value that has just been revoked.
     let lifecycle = manager.lifecycle().await;
+    store.clear().map_err(|e| e.to_string())?;
     stop_running(&manager, &pending, &lifecycle).await;
     Ok(())
 }

--- a/apps/desktop/src-tauri/src/mcp_confirm.rs
+++ b/apps/desktop/src-tauri/src/mcp_confirm.rs
@@ -1,0 +1,137 @@
+//! Human-in-the-loop consent for MCP tool calls. The MCP request blocks on a
+//! oneshot while the UI shows a dialog; approve resumes it, deny (or silence)
+//! refuses. Timing out DENIES: never auto-approve because nobody could be asked.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use serde_json::Value;
+use srelens_mcp::policy::{ConfirmPolicy, Decision};
+use tokio::sync::oneshot;
+
+#[derive(Default)]
+pub struct Pending(Mutex<HashMap<String, oneshot::Sender<bool>>>);
+
+impl Pending {
+    pub fn register(&self, id: String, tx: oneshot::Sender<bool>) {
+        self.0.lock().unwrap().insert(id, tx);
+    }
+
+    /// Returns false when the id is unknown (already answered or timed out).
+    pub fn resolve(&self, id: &str, approved: bool) -> bool {
+        match self.0.lock().unwrap().remove(id) {
+            Some(tx) => tx.send(approved).is_ok(),
+            None => false,
+        }
+    }
+
+    pub fn forget(&self, id: &str) {
+        self.0.lock().unwrap().remove(id);
+    }
+
+    /// Deny everything still waiting — used when the server is toggled off so
+    /// in-flight calls fail fast instead of hanging until timeout.
+    pub fn deny_all(&self) {
+        for (_, tx) in self.0.lock().unwrap().drain() {
+            let _ = tx.send(false);
+        }
+    }
+}
+
+pub struct PromptUser {
+    app: tauri::AppHandle,
+    pending: Arc<Pending>,
+    timeout: Duration,
+}
+
+impl PromptUser {
+    pub fn new(app: tauri::AppHandle, pending: Arc<Pending>, timeout: Duration) -> Self {
+        Self { app, pending, timeout }
+    }
+}
+
+#[async_trait::async_trait]
+impl ConfirmPolicy for PromptUser {
+    async fn confirm(&self, tool: &str, args: &Value) -> Decision {
+        use tauri::{Emitter, Manager};
+
+        let id = uuid::Uuid::new_v4().to_string();
+        let (tx, rx) = oneshot::channel();
+        self.pending.register(id.clone(), tx);
+
+        // A dialog behind another window is indistinguishable from a hang.
+        let Some(win) = self.app.get_webview_window("main") else {
+            self.pending.forget(&id);
+            return Decision::Denied(format!(
+                "no window available to confirm `{tool}`"
+            ));
+        };
+        let _ = win.show();
+        let _ = win.unminimize();
+        let _ = win.set_focus();
+
+        if self
+            .app
+            .emit(
+                "mcp://confirm-request",
+                serde_json::json!({ "id": id, "tool": tool, "args": args }),
+            )
+            .is_err()
+        {
+            self.pending.forget(&id);
+            return Decision::Denied("srelens could not show a confirmation dialog".into());
+        }
+
+        match tokio::time::timeout(self.timeout, rx).await {
+            Ok(Ok(true)) => Decision::Approved,
+            Ok(Ok(false)) => Decision::Denied(format!("user declined `{tool}`")),
+            Ok(Err(_)) => Decision::Denied("confirmation channel closed".into()),
+            Err(_) => {
+                self.pending.forget(&id);
+                Decision::Denied(format!("no response to the confirmation for `{tool}`"))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn resolve_delivers_the_answer() {
+        let p = Pending::default();
+        let (tx, rx) = oneshot::channel();
+        p.register("abc".into(), tx);
+        assert!(p.resolve("abc", true));
+        assert_eq!(rx.await.unwrap(), true);
+    }
+
+    #[tokio::test]
+    async fn resolving_an_unknown_id_is_reported() {
+        let p = Pending::default();
+        assert!(!p.resolve("nope", true));
+    }
+
+    #[tokio::test]
+    async fn deny_all_releases_every_waiter() {
+        let p = Pending::default();
+        let (tx1, rx1) = oneshot::channel();
+        let (tx2, rx2) = oneshot::channel();
+        p.register("a".into(), tx1);
+        p.register("b".into(), tx2);
+        p.deny_all();
+        assert_eq!(rx1.await.unwrap(), false);
+        assert_eq!(rx2.await.unwrap(), false);
+    }
+
+    #[tokio::test]
+    async fn an_id_can_only_be_answered_once() {
+        let p = Pending::default();
+        let (tx, _rx) = oneshot::channel();
+        p.register("a".into(), tx);
+        assert!(p.resolve("a", true));
+        assert!(!p.resolve("a", false), "second answer must not be accepted");
+    }
+}

--- a/apps/desktop/src-tauri/src/mcp_confirm.rs
+++ b/apps/desktop/src-tauri/src/mcp_confirm.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use serde_json::Value;
-use srelens_mcp::policy::{ConfirmPolicy, Decision};
+use srelens_mcp::policy::{ConfirmPolicy, ConsentKind, Decision};
 use tokio::sync::oneshot;
 
 #[derive(Default)]
@@ -53,7 +53,11 @@ impl PromptUser {
 
 #[async_trait::async_trait]
 impl ConfirmPolicy for PromptUser {
-    async fn confirm(&self, tool: &str, args: &Value) -> Decision {
+    /// `kind` is deliberately unused: a human being shown the tool name and its
+    /// arguments is the consent mechanism either way, so the GUI prompts for a
+    /// sensitive read exactly as it does for a mutation. The distinction exists
+    /// for headless policies, which have no human to look at the call.
+    async fn confirm(&self, tool: &str, args: &Value, _kind: ConsentKind) -> Decision {
         use tauri::{Emitter, Manager};
 
         let id = uuid::Uuid::new_v4().to_string();

--- a/apps/desktop/src-tauri/src/token_store.rs
+++ b/apps/desktop/src-tauri/src/token_store.rs
@@ -115,6 +115,12 @@ impl TokenStore for ResilientTokenStore {
             // D-Bus session into a process-killing panic in the caller.
             Err(_) => {
                 self.file_fallback.store(true, Ordering::Relaxed);
+                // Best-effort: drop whatever entry the keychain still holds.
+                // `load()` prefers the keychain, so leaving a stale entry
+                // behind would let a later process (with a working keychain)
+                // read the OLD token in preference to the file written just
+                // below — silently reinstating a token this save replaced.
+                let _ = self.keychain.delete_credential();
                 self.file.save(t)
             }
         }
@@ -200,6 +206,49 @@ mod tests {
             *self.stored.lock().unwrap() = None;
             Ok(())
         }
+    }
+
+    /// A keychain that is readable-but-empty and fails every write, recording
+    /// whether it was asked to delete its entry.
+    struct FailingWrites(Arc<Mutex<bool>>);
+
+    impl KeychainBackend for FailingWrites {
+        fn get_password(&self) -> Result<String, keyring::Error> {
+            Err(keyring::Error::NoEntry)
+        }
+        fn set_password(&self, _value: &str) -> Result<(), keyring::Error> {
+            Err(keyring::Error::NoStorageAccess(Box::new(std::io::Error::other(
+                "stub: keychain write failed",
+            ))))
+        }
+        fn delete_credential(&self) -> Result<(), keyring::Error> {
+            *self.0.lock().unwrap() = true;
+            Ok(())
+        }
+    }
+
+    /// The stale-token hazard: a keychain that fails *this* save (a transient
+    /// D-Bus hiccup, a locked login keychain) sends the token to the file, but
+    /// any entry already in the keychain survives. The next process starts
+    /// with a healthy keychain, `load()` prefers it, and the OLD token comes
+    /// back — so a rotate looks undone and a token the user believed replaced
+    /// still authenticates. `clear()` already clears both backends; `save()`
+    /// has to as well.
+    #[test]
+    fn falling_back_on_save_clears_the_stale_keychain_entry() {
+        let deleted = Arc::new(Mutex::new(false));
+        let store = ResilientTokenStore::with_backend(
+            Box::new(FailingWrites(deleted.clone())),
+            temp_dir("stale").join("token"),
+        );
+
+        store.save(&Token::generate()).expect("save falls back to the file");
+
+        assert_eq!(store.current_backend(), "file");
+        assert!(
+            *deleted.lock().unwrap(),
+            "a save that fell back to the file must clear the keychain entry it could not update"
+        );
     }
 
     fn temp_dir(label: &str) -> PathBuf {

--- a/apps/desktop/src-tauri/src/token_store.rs
+++ b/apps/desktop/src-tauri/src/token_store.rs
@@ -2,8 +2,20 @@
 //! Linux without a Secret Service (headless boxes, minimal WMs) has no
 //! keychain at all; refusing to run there would strand those users, so we fall
 //! back and tell them plainly in Settings.
+//!
+//! The store does **not** decide once at startup by probing whether a
+//! keychain "looks" available. On the sync-secret-service backend,
+//! `keyring::Entry::new` only builds an in-memory attribute map — it never
+//! dials D-Bus, so on a headless host it happily returns `Ok`, and the first
+//! real failure only surfaces later, inside `get_password`/`set_password`.
+//! Deciding at construction time would report "keychain" right up until an
+//! operation panics. Instead, [`ResilientTokenStore`] attempts the keychain
+//! on every call and falls back to the file the moment an operation genuinely
+//! fails, remembering that for the rest of the process so Settings reports
+//! what's actually serving rather than a one-time guess.
 
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use srelens_mcp::auth::{FileTokenStore, Token, TokenStore};
@@ -11,62 +23,257 @@ use srelens_mcp::auth::{FileTokenStore, Token, TokenStore};
 const SERVICE: &str = "srelens";
 const ACCOUNT: &str = "mcp-http-token";
 
-pub struct KeychainTokenStore;
+/// The raw keychain operations, factored out so tests can inject a stub that
+/// deterministically fails — the only way to exercise the fallback branch
+/// without a real (or deliberately broken) OS keychain.
+trait KeychainBackend: Send + Sync {
+    fn get_password(&self) -> Result<String, keyring::Error>;
+    fn set_password(&self, value: &str) -> Result<(), keyring::Error>;
+    fn delete_credential(&self) -> Result<(), keyring::Error>;
+}
 
-impl TokenStore for KeychainTokenStore {
-    fn load(&self) -> Option<Token> {
-        keyring::Entry::new(SERVICE, ACCOUNT)
-            .ok()?
-            .get_password()
-            .ok()
-            .and_then(|s| Token::from_hex(&s))
+/// The real backend: a fresh `keyring::Entry` per call (entries are cheap,
+/// stateless handles — the actual connection happens inside each operation).
+struct RealKeychain;
+
+impl KeychainBackend for RealKeychain {
+    fn get_password(&self) -> Result<String, keyring::Error> {
+        keyring::Entry::new(SERVICE, ACCOUNT)?.get_password()
     }
 
-    fn save(&self, t: &Token) -> std::io::Result<()> {
-        keyring::Entry::new(SERVICE, ACCOUNT)
-            .and_then(|e| e.set_password(t.as_str()))
-            .map_err(|e| std::io::Error::other(e.to_string()))
+    fn set_password(&self, value: &str) -> Result<(), keyring::Error> {
+        keyring::Entry::new(SERVICE, ACCOUNT)?.set_password(value)
     }
 
-    fn clear(&self) -> std::io::Result<()> {
-        match keyring::Entry::new(SERVICE, ACCOUNT).and_then(|e| e.delete_credential()) {
-            Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
-            Err(e) => Err(std::io::Error::other(e.to_string())),
+    fn delete_credential(&self) -> Result<(), keyring::Error> {
+        keyring::Entry::new(SERVICE, ACCOUNT)?.delete_credential()
+    }
+}
+
+/// Prefers the OS keychain; falls back to a 0600 file the first time a
+/// keychain operation genuinely fails, and stays on the file for the rest of
+/// this process's lifetime (retrying per-call would re-pay a slow/failing
+/// D-Bus dial on every load/save, and would let a load silently miss a
+/// file-stored token by checking an empty keychain instead).
+pub struct ResilientTokenStore {
+    keychain: Box<dyn KeychainBackend>,
+    file: FileTokenStore,
+    file_fallback: AtomicBool,
+}
+
+impl ResilientTokenStore {
+    fn new(fallback: PathBuf) -> Self {
+        Self::with_backend(Box::new(RealKeychain), fallback)
+    }
+
+    fn with_backend(keychain: Box<dyn KeychainBackend>, fallback: PathBuf) -> Self {
+        Self {
+            keychain,
+            file: FileTokenStore::new(fallback),
+            file_fallback: AtomicBool::new(false),
+        }
+    }
+
+    /// The backend actually serving right now: `"keychain"` or `"file"`.
+    /// Reflects observed reality (flips permanently to `"file"` the first
+    /// time a keychain operation fails), not a value guessed at construction.
+    pub fn current_backend(&self) -> &'static str {
+        if self.file_fallback.load(Ordering::Relaxed) {
+            "file"
+        } else {
+            "keychain"
         }
     }
 }
 
-/// Tauri-managed marker recording which backend is actually in use, so
-/// Settings can tell the user plainly when the token sits on disk unencrypted
-/// rather than implying it's always keychain-protected.
-pub struct TokenStorage(pub &'static str);
+impl TokenStore for ResilientTokenStore {
+    fn load(&self) -> Option<Token> {
+        if self.file_fallback.load(Ordering::Relaxed) {
+            return self.file.load();
+        }
+        match self.keychain.get_password() {
+            Ok(s) => Token::from_hex(&s),
+            // The keychain works; there's just nothing stored yet. Must NOT
+            // fall back here — that would silently prefer a stale file token
+            // over a genuinely empty keychain.
+            Err(keyring::Error::NoEntry) => None,
+            Err(_) => {
+                self.file_fallback.store(true, Ordering::Relaxed);
+                self.file.load()
+            }
+        }
+    }
 
-impl TokenStorage {
-    pub fn for_fallback(file_fallback: bool) -> Self {
-        Self(if file_fallback { "file" } else { "keychain" })
+    fn save(&self, t: &Token) -> std::io::Result<()> {
+        if self.file_fallback.load(Ordering::Relaxed) {
+            return self.file.save(t);
+        }
+        match self.keychain.set_password(t.as_str()) {
+            Ok(()) => Ok(()),
+            // Never propagate the keychain error up as a hard failure when
+            // the file write succeeds — that's what turned an unavailable
+            // D-Bus session into a process-killing panic in the caller.
+            Err(_) => {
+                self.file_fallback.store(true, Ordering::Relaxed);
+                self.file.save(t)
+            }
+        }
+    }
+
+    fn clear(&self) -> std::io::Result<()> {
+        // Clear both backends: a revoke must not leave a stale token behind
+        // in whichever one wasn't the active one this run (e.g. an earlier
+        // process saved to the keychain; this one has been in file fallback
+        // since startup, or vice versa). The keychain half is best-effort —
+        // an entry that's already absent, or a keychain that's unreachable,
+        // isn't a reason to fail the revoke when the file half succeeds.
+        let _ = self.keychain.delete_credential();
+        self.file.clear()
     }
 }
 
-/// Returns the store and whether the on-disk fallback is in use.
-pub fn keychain_or_file(fallback: PathBuf) -> (Arc<dyn TokenStore>, bool) {
-    let probe = keyring::Entry::new(SERVICE, ACCOUNT);
-    match probe {
-        Ok(_) => (Arc::new(KeychainTokenStore), false),
-        Err(_) => (Arc::new(FileTokenStore::new(fallback)), true),
-    }
+/// Returns a store that prefers the OS keychain, falling back to `fallback`
+/// (a 0600 file) the first time a keychain operation genuinely fails. Always
+/// usable — construction itself cannot fail.
+pub fn keychain_or_file(fallback: PathBuf) -> Arc<ResilientTokenStore> {
+    Arc::new(ResilientTokenStore::new(fallback))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    /// Always fails with a non-`NoEntry` error, so tests can exercise the
+    /// fallback path deterministically without a broken real keychain.
+    struct AlwaysFails;
+
+    impl KeychainBackend for AlwaysFails {
+        fn get_password(&self) -> Result<String, keyring::Error> {
+            Err(keyring::Error::NoStorageAccess(Box::new(std::io::Error::other(
+                "stub: no keychain in this test",
+            ))))
+        }
+        fn set_password(&self, _value: &str) -> Result<(), keyring::Error> {
+            Err(keyring::Error::NoStorageAccess(Box::new(std::io::Error::other(
+                "stub: no keychain in this test",
+            ))))
+        }
+        fn delete_credential(&self) -> Result<(), keyring::Error> {
+            Err(keyring::Error::NoStorageAccess(Box::new(std::io::Error::other(
+                "stub: no keychain in this test",
+            ))))
+        }
+    }
+
+    /// Always reports "nothing stored", the way a *working* keychain does
+    /// before any token has been saved.
+    struct EmptyButWorking;
+
+    impl KeychainBackend for EmptyButWorking {
+        fn get_password(&self) -> Result<String, keyring::Error> {
+            Err(keyring::Error::NoEntry)
+        }
+        fn set_password(&self, _value: &str) -> Result<(), keyring::Error> {
+            Ok(())
+        }
+        fn delete_credential(&self) -> Result<(), keyring::Error> {
+            Err(keyring::Error::NoEntry)
+        }
+    }
+
+    /// Records whether it was ever asked to store/load a token, so tests can
+    /// exercise a genuinely working (in-memory) keychain path.
+    struct RecordingWorking {
+        stored: Mutex<Option<String>>,
+    }
+
+    impl KeychainBackend for RecordingWorking {
+        fn get_password(&self) -> Result<String, keyring::Error> {
+            self.stored.lock().unwrap().clone().ok_or(keyring::Error::NoEntry)
+        }
+        fn set_password(&self, value: &str) -> Result<(), keyring::Error> {
+            *self.stored.lock().unwrap() = Some(value.to_string());
+            Ok(())
+        }
+        fn delete_credential(&self) -> Result<(), keyring::Error> {
+            *self.stored.lock().unwrap() = None;
+            Ok(())
+        }
+    }
+
+    fn temp_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("srelens-ks-{label}-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn a_working_keychain_is_used_and_reported_as_such() {
+        let store = ResilientTokenStore::with_backend(
+            Box::new(RecordingWorking { stored: Mutex::new(None) }),
+            temp_dir("working").join("token"),
+        );
+        assert_eq!(store.current_backend(), "keychain");
+        let t = Token::generate();
+        store.save(&t).unwrap();
+        assert_eq!(store.load().unwrap().as_str(), t.as_str());
+        assert_eq!(store.current_backend(), "keychain");
+        store.clear().unwrap();
+        assert!(store.load().is_none());
+    }
+
+    #[test]
+    fn a_keychain_that_genuinely_fails_falls_back_to_the_file_without_panicking() {
+        let store = ResilientTokenStore::with_backend(
+            Box::new(AlwaysFails),
+            temp_dir("broken").join("token"),
+        );
+        let t = Token::generate();
+        // This is the exact call that used to panic when the "probe once"
+        // design reported `Ok` up front and the real dial failed here.
+        store.save(&t).expect("a usable store must always be returned");
+        assert_eq!(store.load().unwrap().as_str(), t.as_str());
+        assert_eq!(store.current_backend(), "file");
+        store.clear().unwrap();
+        assert!(store.load().is_none());
+    }
+
+    #[test]
+    fn no_entry_from_a_working_keychain_does_not_trigger_fallback() {
+        let store = ResilientTokenStore::with_backend(
+            Box::new(EmptyButWorking),
+            temp_dir("empty").join("token"),
+        );
+        // Nothing saved yet: a working-but-empty keychain must read as "no
+        // token", not silently fall through to whatever (stale) file might
+        // be sitting at `fallback`.
+        assert!(store.load().is_none());
+        assert_eq!(store.current_backend(), "keychain");
+    }
+
+    #[test]
+    fn once_fallen_back_a_store_stays_on_the_file_for_subsequent_calls() {
+        let store = ResilientTokenStore::with_backend(
+            Box::new(AlwaysFails),
+            temp_dir("sticky").join("token"),
+        );
+        let a = Token::generate();
+        store.save(&a).unwrap();
+        assert_eq!(store.current_backend(), "file");
+        // A later load must find the file-stored token via the same path,
+        // not re-probe the (still-broken) keychain and come back empty.
+        assert_eq!(store.load().unwrap().as_str(), a.as_str());
+    }
 
     #[test]
     fn falls_back_to_a_file_when_no_keychain_is_available() {
-        // On CI Linux there is usually no Secret Service; either branch is
-        // valid, but the store must always be usable.
-        let dir = std::env::temp_dir().join(format!("srelens-ks-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let (store, _fallback) = keychain_or_file(dir.join("token"));
+        // The real backend, exercised end-to-end. On this developer's
+        // machine (macOS) this goes through the actual Keychain; on a
+        // headless Linux CI runner without a D-Bus session it goes through
+        // the file fallback. Either way the store must always be usable —
+        // that's what's asserted, not which branch was taken.
+        let store = keychain_or_file(temp_dir("real").join("token"));
         let t = Token::generate();
         store.save(&t).expect("a usable store must always be returned");
         assert_eq!(store.load().unwrap().as_str(), t.as_str());

--- a/apps/desktop/src-tauri/src/token_store.rs
+++ b/apps/desktop/src-tauri/src/token_store.rs
@@ -1,0 +1,75 @@
+//! Token storage preferring the OS keychain, falling back to a 0600 file.
+//! Linux without a Secret Service (headless boxes, minimal WMs) has no
+//! keychain at all; refusing to run there would strand those users, so we fall
+//! back and tell them plainly in Settings.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use srelens_mcp::auth::{FileTokenStore, Token, TokenStore};
+
+const SERVICE: &str = "srelens";
+const ACCOUNT: &str = "mcp-http-token";
+
+pub struct KeychainTokenStore;
+
+impl TokenStore for KeychainTokenStore {
+    fn load(&self) -> Option<Token> {
+        keyring::Entry::new(SERVICE, ACCOUNT)
+            .ok()?
+            .get_password()
+            .ok()
+            .and_then(|s| Token::from_hex(&s))
+    }
+
+    fn save(&self, t: &Token) -> std::io::Result<()> {
+        keyring::Entry::new(SERVICE, ACCOUNT)
+            .and_then(|e| e.set_password(t.as_str()))
+            .map_err(|e| std::io::Error::other(e.to_string()))
+    }
+
+    fn clear(&self) -> std::io::Result<()> {
+        match keyring::Entry::new(SERVICE, ACCOUNT).and_then(|e| e.delete_credential()) {
+            Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+            Err(e) => Err(std::io::Error::other(e.to_string())),
+        }
+    }
+}
+
+/// Tauri-managed marker recording which backend is actually in use, so
+/// Settings can tell the user plainly when the token sits on disk unencrypted
+/// rather than implying it's always keychain-protected.
+pub struct TokenStorage(pub &'static str);
+
+impl TokenStorage {
+    pub fn for_fallback(file_fallback: bool) -> Self {
+        Self(if file_fallback { "file" } else { "keychain" })
+    }
+}
+
+/// Returns the store and whether the on-disk fallback is in use.
+pub fn keychain_or_file(fallback: PathBuf) -> (Arc<dyn TokenStore>, bool) {
+    let probe = keyring::Entry::new(SERVICE, ACCOUNT);
+    match probe {
+        Ok(_) => (Arc::new(KeychainTokenStore), false),
+        Err(_) => (Arc::new(FileTokenStore::new(fallback)), true),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn falls_back_to_a_file_when_no_keychain_is_available() {
+        // On CI Linux there is usually no Secret Service; either branch is
+        // valid, but the store must always be usable.
+        let dir = std::env::temp_dir().join(format!("srelens-ks-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let (store, _fallback) = keychain_or_file(dir.join("token"));
+        let t = Token::generate();
+        store.save(&t).expect("a usable store must always be returned");
+        assert_eq!(store.load().unwrap().as_str(), t.as_str());
+        store.clear().unwrap();
+    }
+}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -19,6 +19,7 @@ import { EditResourceTab } from "./components/EditResourceTab";
 import { SettingsView } from "./components/SettingsView";
 import { ToolboxView } from "./components/ToolboxView";
 import { CommandPalette } from "./components/CommandPalette";
+import { McpConfirmDialog } from "./components/McpConfirmDialog";
 import { Toaster } from "./components/ui/sonner";
 import { Dock, type DockSession, type DockKind } from "./components/Dock";
 import { StatusBar } from "./components/StatusBar";
@@ -756,6 +757,7 @@ export function App() {
         onAfterAction={() => setViewReloadNonce((n) => n + 1)}
       />
       <Toaster position="top-right" richColors closeButton />
+      <McpConfirmDialog />
     </div>
   );
 }

--- a/apps/desktop/src/components/McpAuditList.test.tsx
+++ b/apps/desktop/src/components/McpAuditList.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const auditTail = vi.fn();
+vi.mock("../lib/mcpSecurity", () => ({ auditTail: (...a: unknown[]) => auditTail(...a) }));
+
+import { McpAuditList } from "./McpAuditList";
+
+describe("McpAuditList", () => {
+  it("renders entries newest-first with their decision", async () => {
+    auditTail.mockResolvedValue([
+      { ts: 1780000000, transport: "http", tool: "k8s_deletePod", args: { name: "web" }, decision: "approved", outcome: "ok" },
+      { ts: 1779999999, transport: "stdio", tool: "k8s_listPods", args: {}, decision: "auto", outcome: "ok" },
+    ]);
+    render(<McpAuditList />);
+    expect(await screen.findByText(/k8s_deletePod/)).toBeTruthy();
+    expect(screen.getByText(/approved/i)).toBeTruthy();
+  });
+
+  it("shows an empty state rather than a blank panel", async () => {
+    auditTail.mockResolvedValue([]);
+    render(<McpAuditList />);
+    expect(await screen.findByText(/no agent activity/i)).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/components/McpAuditList.test.tsx
+++ b/apps/desktop/src/components/McpAuditList.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const auditTail = vi.fn();
 vi.mock("../lib/mcpSecurity", () => ({ auditTail: (...a: unknown[]) => auditTail(...a) }));
@@ -7,6 +7,12 @@ vi.mock("../lib/mcpSecurity", () => ({ auditTail: (...a: unknown[]) => auditTail
 import { McpAuditList } from "./McpAuditList";
 
 describe("McpAuditList", () => {
+  // Without this the spy accumulates across cases, so any test asserting a
+  // call count measures the whole file rather than its own component.
+  beforeEach(() => {
+    auditTail.mockReset();
+  });
+
   it("renders entries newest-first with their decision", async () => {
     auditTail.mockResolvedValue([
       { ts: 1780000000, transport: "http", tool: "k8s_deletePod", args: { name: "web" }, decision: "approved", outcome: "ok" },
@@ -21,5 +27,31 @@ describe("McpAuditList", () => {
     auditTail.mockResolvedValue([]);
     render(<McpAuditList />);
     expect(await screen.findByText(/no agent activity/i)).toBeTruthy();
+  });
+
+  /// Settings stays open while agents keep calling, so a list fetched once on
+  /// mount silently goes stale — an operator watching for an agent's action
+  /// sees nothing and concludes it never happened.
+  it("re-reads the log when refreshed", async () => {
+    auditTail.mockResolvedValue([]);
+    render(<McpAuditList />);
+    expect(await screen.findByText(/no agent activity/i)).toBeTruthy();
+    expect(auditTail).toHaveBeenCalledTimes(1);
+
+    auditTail.mockResolvedValue([
+      {
+        ts: 1780000001,
+        transport: "http",
+        tool: "k8s_drainNode",
+        args: { name: "node-1" },
+        decision: "denied",
+        outcome: "error",
+        err: "user declined",
+      },
+    ]);
+    fireEvent.click(screen.getByLabelText(/refresh agent activity/i));
+
+    expect(await screen.findByText(/k8s_drainNode/)).toBeTruthy();
+    expect(auditTail).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/desktop/src/components/McpAuditList.tsx
+++ b/apps/desktop/src/components/McpAuditList.tsx
@@ -1,0 +1,62 @@
+import { auditTail, type AuditEntry } from "../lib/mcpSecurity";
+import { Badge, Spinner, Table, type BadgeVariant, type Column } from "../ui";
+import { useEffect, useState } from "react";
+
+const DECISION_VARIANT: Record<AuditEntry["decision"], BadgeVariant> = {
+  approved: "success",
+  denied: "danger",
+  auto: "neutral",
+};
+
+const OUTCOME_VARIANT: Record<AuditEntry["outcome"], BadgeVariant> = {
+  ok: "success",
+  error: "danger",
+};
+
+// Table rows need a stable key that survives sorting; the fetch-order index
+// works since the underlying entries never reorder themselves.
+type Row = AuditEntry & { id: number };
+
+const columns: Column<Row>[] = [
+  { key: "ts", header: "Time", render: (e) => new Date(e.ts * 1000).toLocaleString() },
+  { key: "tool", header: "Tool", render: (e) => <code>{e.tool}</code> },
+  { key: "transport", header: "Transport" },
+  {
+    key: "decision",
+    header: "Decision",
+    render: (e) => <Badge variant={DECISION_VARIANT[e.decision]}>{e.decision}</Badge>,
+  },
+  {
+    key: "outcome",
+    header: "Outcome",
+    render: (e) => <Badge variant={OUTCOME_VARIANT[e.outcome]}>{e.outcome}</Badge>,
+  },
+];
+
+/** Recent MCP tool calls — what an agent actually did, and whether it was allowed. */
+export function McpAuditList() {
+  const [entries, setEntries] = useState<AuditEntry[] | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    void auditTail(50).then((out) => {
+      if (active) setEntries(out);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  if (entries === null) return <Spinner label="Loading agent activity" />;
+
+  const rows: Row[] = entries.map((entry, id) => ({ ...entry, id }));
+
+  return (
+    <Table
+      columns={columns}
+      data={rows}
+      getRowKey={(row) => String(row.id)}
+      emptyText="No agent activity yet."
+    />
+  );
+}

--- a/apps/desktop/src/components/McpAuditList.tsx
+++ b/apps/desktop/src/components/McpAuditList.tsx
@@ -1,6 +1,7 @@
 import { auditTail, type AuditEntry } from "../lib/mcpSecurity";
-import { Badge, Spinner, Table, type BadgeVariant, type Column } from "../ui";
-import { useEffect, useState } from "react";
+import { Badge, Button, Spinner, Table, type BadgeVariant, type Column } from "../ui";
+import { RefreshCw } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
 
 const DECISION_VARIANT: Record<AuditEntry["decision"], BadgeVariant> = {
   approved: "success",
@@ -36,6 +37,10 @@ const columns: Column<Row>[] = [
 /** Recent MCP tool calls — what an agent actually did, and whether it was allowed. */
 export function McpAuditList() {
   const [entries, setEntries] = useState<AuditEntry[] | null>(null);
+  // Bumped to re-run the fetch. Settings can sit open for a long while as
+  // agents keep calling, and a list read once on mount quietly goes stale —
+  // an operator looking for an agent's action would conclude it never happened.
+  const [nonce, setNonce] = useState(0);
 
   useEffect(() => {
     let active = true;
@@ -45,18 +50,34 @@ export function McpAuditList() {
     return () => {
       active = false;
     };
-  }, []);
+  }, [nonce]);
 
-  if (entries === null) return <Spinner label="Loading agent activity" />;
-
-  const rows: Row[] = entries.map((entry, id) => ({ ...entry, id }));
+  const refresh = useCallback(() => setNonce((n) => n + 1), []);
 
   return (
-    <Table
-      columns={columns}
-      data={rows}
-      getRowKey={(row) => String(row.id)}
-      emptyText="No agent activity yet."
-    />
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="ml-auto"
+          onClick={refresh}
+          aria-label="Refresh agent activity"
+        >
+          <RefreshCw data-icon="inline-start" />
+          Refresh
+        </Button>
+      </div>
+      {entries === null ? (
+        <Spinner label="Loading agent activity" />
+      ) : (
+        <Table
+          columns={columns}
+          data={entries.map((entry, id) => ({ ...entry, id }))}
+          getRowKey={(row) => String(row.id)}
+          emptyText="No agent activity yet."
+        />
+      )}
+    </div>
   );
 }

--- a/apps/desktop/src/components/McpConfirmDialog.test.tsx
+++ b/apps/desktop/src/components/McpConfirmDialog.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const respondToConfirm = vi.fn();
+let emit: (payload: unknown) => void = () => {};
+
+vi.mock("../lib/mcpSecurity", () => ({
+  respondToConfirm: (...a: unknown[]) => respondToConfirm(...a),
+}));
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: (_name: string, cb: (e: { payload: unknown }) => void) => {
+    emit = (payload) => cb({ payload });
+    return Promise.resolve(() => {});
+  },
+}));
+
+import { McpConfirmDialog } from "./McpConfirmDialog";
+
+describe("McpConfirmDialog", () => {
+  beforeEach(() => respondToConfirm.mockReset());
+
+  it("renders nothing until a request arrives", () => {
+    const { container } = render(<McpConfirmDialog />);
+    expect(container.textContent).toBe("");
+  });
+
+  it("shows the tool and arguments, and approves", async () => {
+    render(<McpConfirmDialog />);
+    emit({ id: "r1", tool: "k8s_deletePod", args: { name: "web-1", namespace: "prod" } });
+    await screen.findByText(/k8s_deletePod/);
+    expect(screen.getByText(/web-1/)).toBeTruthy();
+    await userEvent.click(screen.getByRole("button", { name: /approve/i }));
+    await waitFor(() => expect(respondToConfirm).toHaveBeenCalledWith("r1", true));
+  });
+
+  it("denies on the deny button", async () => {
+    render(<McpConfirmDialog />);
+    emit({ id: "r2", tool: "k8s_scale", args: {} });
+    await screen.findByText(/k8s_scale/);
+    await userEvent.click(screen.getByRole("button", { name: /deny/i }));
+    await waitFor(() => expect(respondToConfirm).toHaveBeenCalledWith("r2", false));
+  });
+
+  it("queues a second request rather than dropping it", async () => {
+    render(<McpConfirmDialog />);
+    emit({ id: "a", tool: "toolA", args: {} });
+    emit({ id: "b", tool: "toolB", args: {} });
+    await screen.findByText(/toolA/);
+    await userEvent.click(screen.getByRole("button", { name: /deny/i }));
+    await screen.findByText(/toolB/);
+  });
+});

--- a/apps/desktop/src/components/McpConfirmDialog.test.tsx
+++ b/apps/desktop/src/components/McpConfirmDialog.test.tsx
@@ -14,11 +14,20 @@ vi.mock("@tauri-apps/api/event", () => ({
     return Promise.resolve(() => {});
   },
 }));
+const { notify } = vi.hoisted(() => ({
+  notify: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+vi.mock("../lib/notify", () => ({ notify }));
 
 import { McpConfirmDialog } from "./McpConfirmDialog";
 
 describe("McpConfirmDialog", () => {
-  beforeEach(() => respondToConfirm.mockReset());
+  beforeEach(() => {
+    respondToConfirm.mockReset();
+    notify.success.mockReset();
+    notify.error.mockReset();
+    notify.info.mockReset();
+  });
 
   it("renders nothing until a request arrives", () => {
     const { container } = render(<McpConfirmDialog />);
@@ -49,5 +58,18 @@ describe("McpConfirmDialog", () => {
     await screen.findByText(/toolA/);
     await userEvent.click(screen.getByRole("button", { name: /deny/i }));
     await screen.findByText(/toolB/);
+  });
+
+  it("surfaces an error instead of silently swallowing a failed response", async () => {
+    respondToConfirm.mockRejectedValue(new Error("already timed out"));
+    render(<McpConfirmDialog />);
+    emit({ id: "r3", tool: "k8s_deletePod", args: {} });
+    await screen.findByText(/k8s_deletePod/);
+    await userEvent.click(screen.getByRole("button", { name: /approve/i }));
+    await waitFor(() => expect(notify.error).toHaveBeenCalled());
+    // The user must not be left believing the call was actioned: the
+    // request is still dropped from the queue (nothing left to retry), but
+    // the failure is surfaced rather than silent.
+    expect(screen.queryByText(/k8s_deletePod/)).toBeNull();
   });
 });

--- a/apps/desktop/src/components/McpConfirmDialog.tsx
+++ b/apps/desktop/src/components/McpConfirmDialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { respondToConfirm, type ConfirmRequest } from "../lib/mcpSecurity";
+import { notify } from "../lib/notify";
 import { ConfirmDialog } from "../ui";
 
 /**
@@ -30,9 +31,14 @@ export function McpConfirmDialog() {
     setBusy(true);
     try {
       await respondToConfirm(current.id, approved);
-    } catch {
-      // The request already timed out or was answered elsewhere — there's
-      // nothing left to respond to, so just drop it and move to the next.
+    } catch (e) {
+      // The request already timed out or was answered elsewhere (e.g. it
+      // timed out server-side while queued behind another dialog) — the
+      // user's click didn't actually take effect, and silently swallowing
+      // this would let them believe they approved (or denied) a call that
+      // was in fact already resolved without them. Surface it, then drop the
+      // request and move to the next: there's nothing left here to retry.
+      notify.error("Could not respond to that confirmation", String(e));
     } finally {
       setBusy(false);
       setQueue((q) => q.slice(1));

--- a/apps/desktop/src/components/McpConfirmDialog.tsx
+++ b/apps/desktop/src/components/McpConfirmDialog.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { respondToConfirm, type ConfirmRequest } from "../lib/mcpSecurity";
+import { ConfirmDialog } from "../ui";
+
+/**
+ * Consent prompt for MCP tool calls. The Rust side blocks a destructive tool
+ * call and emits `mcp://confirm-request`, raising/focusing the window first —
+ * this listens app-wide (mounted once in App.tsx) since a request can arrive
+ * from any view. Requests queue rather than replace one another: two agents
+ * can call concurrently, and dropping one would hang that call until its
+ * own timeout denies it.
+ */
+export function McpConfirmDialog() {
+  const [queue, setQueue] = useState<ConfirmRequest[]>([]);
+  const [busy, setBusy] = useState(false);
+  const current = queue[0];
+
+  useEffect(() => {
+    const unlisten = listen<ConfirmRequest>("mcp://confirm-request", (event) => {
+      setQueue((q) => [...q, event.payload]);
+    });
+    return () => {
+      void unlisten.then((f) => f());
+    };
+  }, []);
+
+  async function answer(approved: boolean) {
+    if (!current) return;
+    setBusy(true);
+    try {
+      await respondToConfirm(current.id, approved);
+    } catch {
+      // The request already timed out or was answered elsewhere — there's
+      // nothing left to respond to, so just drop it and move to the next.
+    } finally {
+      setBusy(false);
+      setQueue((q) => q.slice(1));
+    }
+  }
+
+  if (!current) return null;
+
+  return (
+    <ConfirmDialog
+      title="An agent wants to run a cluster action"
+      message={
+        <div className="flex flex-col gap-2">
+          <p className="m-0">
+            Tool: <code>{current.tool}</code>
+          </p>
+          <pre className="max-h-64 overflow-auto rounded-md border border-border bg-muted/40 p-3 text-xs">
+            <code>{JSON.stringify(current.args, null, 2)}</code>
+          </pre>
+          {queue.length > 1 && (
+            <p className="m-0 text-xs text-muted-foreground">
+              {queue.length - 1} more request{queue.length - 1 === 1 ? "" : "s"} waiting
+            </p>
+          )}
+        </div>
+      }
+      confirmLabel="Approve"
+      cancelLabel="Deny"
+      danger
+      busy={busy}
+      onConfirm={() => void answer(true)}
+      onCancel={() => void answer(false)}
+    />
+  );
+}

--- a/apps/desktop/src/components/McpSettingsSection.test.tsx
+++ b/apps/desktop/src/components/McpSettingsSection.test.tsx
@@ -14,6 +14,16 @@ const { mcp } = vi.hoisted(() => ({
 vi.mock("../lib/mcp", () => mcp);
 vi.mock("../lib/notify", () => ({ notify: { success: vi.fn(), error: vi.fn(), info: vi.fn() } }));
 
+const { mcpSecurity } = vi.hoisted(() => ({
+  mcpSecurity: {
+    getMcpToken: vi.fn(),
+    rotateMcpToken: vi.fn(),
+    revokeMcpToken: vi.fn(),
+    auditTail: vi.fn(),
+  },
+}));
+vi.mock("../lib/mcpSecurity", () => mcpSecurity);
+
 import { McpSettingsSection } from "./McpSettingsSection";
 
 beforeEach(() => {
@@ -26,6 +36,9 @@ beforeEach(() => {
     links_to: null,
     on_path: true,
   });
+  Object.values(mcpSecurity).forEach((m) => m.mockReset());
+  mcpSecurity.getMcpToken.mockResolvedValue(null);
+  mcpSecurity.auditTail.mockResolvedValue([]);
 });
 
 describe("McpSettingsSection", () => {
@@ -79,5 +92,29 @@ describe("McpSettingsSection", () => {
     // Switch to Codex → TOML block.
     fireEvent.click(screen.getByRole("button", { name: "Codex" }));
     expect(screen.getByText(/\[mcp_servers\.srelens\]/)).toBeDefined();
+  });
+
+  it("masks the token until revealed and rotates on request", async () => {
+    const token = `${"a".repeat(60)}wxyz`;
+    mcpSecurity.getMcpToken.mockResolvedValue(token);
+    mcpSecurity.rotateMcpToken.mockResolvedValue(`${"b".repeat(60)}1234`);
+    render(<McpSettingsSection />);
+
+    // The masked form (last 4 chars only) is visible once the token loads,
+    // but the raw 64-char value must not be anywhere in the DOM yet.
+    await screen.findByText(/wxyz/);
+    expect(screen.queryByText(token)).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Reveal token" }));
+    expect(await screen.findByText(token)).toBeDefined();
+
+    // Rotating warns inline before it commits, then calls rotateMcpToken on confirm.
+    fireEvent.click(screen.getByRole("button", { name: "Rotate token" }));
+    expect(screen.getByText(/need the new value/i)).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: "Rotate" }));
+    await waitFor(() => expect(mcpSecurity.rotateMcpToken).toHaveBeenCalled());
+
+    // The freshly rotated token is masked again until explicitly revealed.
+    expect(screen.queryByText(token)).toBeNull();
   });
 });

--- a/apps/desktop/src/components/McpSettingsSection.test.tsx
+++ b/apps/desktop/src/components/McpSettingsSection.test.tsx
@@ -17,6 +17,7 @@ vi.mock("../lib/notify", () => ({ notify: { success: vi.fn(), error: vi.fn(), in
 const { mcpSecurity } = vi.hoisted(() => ({
   mcpSecurity: {
     getMcpToken: vi.fn(),
+    getMcpTokenStorage: vi.fn(),
     rotateMcpToken: vi.fn(),
     revokeMcpToken: vi.fn(),
     auditTail: vi.fn(),
@@ -38,6 +39,7 @@ beforeEach(() => {
   });
   Object.values(mcpSecurity).forEach((m) => m.mockReset());
   mcpSecurity.getMcpToken.mockResolvedValue(null);
+  mcpSecurity.getMcpTokenStorage.mockResolvedValue("keychain");
   mcpSecurity.auditTail.mockResolvedValue([]);
 });
 
@@ -116,5 +118,18 @@ describe("McpSettingsSection", () => {
 
     // The freshly rotated token is masked again until explicitly revealed.
     expect(screen.queryByText(token)).toBeNull();
+  });
+
+  it("warns when the token fell back to the plain file, and stays quiet for the keychain", async () => {
+    mcpSecurity.getMcpTokenStorage.mockResolvedValue("file");
+    render(<McpSettingsSection />);
+    expect(await screen.findByText(/stored in a plain file on disk/)).toBeDefined();
+  });
+
+  it("shows no fallback warning when the token is in the OS keychain", async () => {
+    mcpSecurity.getMcpTokenStorage.mockResolvedValue("keychain");
+    render(<McpSettingsSection />);
+    await waitFor(() => expect(mcpSecurity.getMcpTokenStorage).toHaveBeenCalled());
+    expect(screen.queryByText(/stored in a plain file on disk/)).toBeNull();
   });
 });

--- a/apps/desktop/src/components/McpSettingsSection.tsx
+++ b/apps/desktop/src/components/McpSettingsSection.tsx
@@ -46,17 +46,34 @@ export function McpSettingsSection() {
   const [cliMessage, setCliMessage] = useState("");
   const [tool, setTool] = useState<McpTool>("claude-code");
   const [transport, setTransport] = useState<McpTransport>("stdio");
+  // `token` is `null` both while it's still loading and once we know for
+  // certain there isn't one yet (e.g. the server has never been enabled, so
+  // `mcp_http_start` — the only place that mints one — hasn't run). `tokenLoading`
+  // tells those two apart so the row can show "Loading…" only for the former
+  // and a real "generate one" action for the latter, instead of getting stuck
+  // on "Loading…" forever.
   const [token, setToken] = useState<string | null>(null);
+  const [tokenLoading, setTokenLoading] = useState(true);
   const [tokenRevealed, setTokenRevealed] = useState(false);
   const [tokenBusy, setTokenBusy] = useState(false);
   const [tokenError, setTokenError] = useState("");
   const [tokenConfirm, setTokenConfirm] = useState<"rotate" | "revoke" | null>(null);
   const [tokenStorage, setTokenStorage] = useState<"keychain" | "file" | null>(null);
 
+  async function refreshToken() {
+    try {
+      setToken(await getMcpToken());
+    } catch {
+      setToken(null);
+    } finally {
+      setTokenLoading(false);
+    }
+  }
+
   useEffect(() => {
     void mcpHttpStatus().then(setRunningUrl).catch(() => {});
     void srelensCliStatus().then(setCli).catch(() => {});
-    void getMcpToken().then(setToken).catch(() => {});
+    void refreshToken();
     void getMcpTokenStorage().then(setTokenStorage).catch(() => {});
   }, []);
 
@@ -69,8 +86,13 @@ export function McpSettingsSection() {
     setServerError("");
     persist({ ...settings, enabled });
     try {
-      if (enabled) setRunningUrl(await startMcpHttp(settings.port));
-      else {
+      if (enabled) {
+        setRunningUrl(await startMcpHttp(settings.port));
+        // Starting the server for the first time is also the first place a
+        // token can get minted (`mcp_http_start` mints one on first use), so
+        // the previously-fetched `null` may now be stale.
+        void refreshToken();
+      } else {
         await stopMcpHttp();
         setRunningUrl(null);
       }
@@ -128,7 +150,7 @@ export function McpSettingsSection() {
     setTokenError("");
     try {
       await revokeMcpToken();
-      setToken(null);
+      await refreshToken();
       setTokenRevealed(false);
       notify.success("Token revoked. The MCP HTTP server has stopped.");
       // The server stops as a side effect of revocation; reflect that instead
@@ -145,7 +167,7 @@ export function McpSettingsSection() {
   }
 
   const url = runningUrl ?? `http://127.0.0.1:${settings.port}/mcp`;
-  const config = mcpClientConfig(tool, transport, { url });
+  const config = mcpClientConfig(tool, transport, { url, token });
 
   return (
     <div className="flex flex-col gap-6">
@@ -230,7 +252,7 @@ export function McpSettingsSection() {
         </p>
         <div className="flex flex-wrap items-center gap-2">
           <code className="fl-mono rounded-md border border-border bg-muted/40 px-2 py-1 text-sm">
-            {token ? (tokenRevealed ? token : maskToken(token)) : "Loading…"}
+            {tokenLoading ? "Loading…" : token ? (tokenRevealed ? token : maskToken(token)) : "No token yet"}
           </code>
           <Button
             variant="ghost"
@@ -255,11 +277,15 @@ export function McpSettingsSection() {
           <Button
             variant="secondary"
             size="sm"
-            onClick={() => setTokenConfirm("rotate")}
-            disabled={!token || tokenBusy}
+            // Rotating an existing token restarts a running server and drops
+            // in-flight requests, so that path still confirms first. Minting
+            // the very first token has nothing to warn about — there's no
+            // previous value to invalidate — so it just runs.
+            onClick={() => (token ? setTokenConfirm("rotate") : void confirmRotate())}
+            disabled={tokenLoading || tokenBusy}
           >
             <RefreshCw data-icon="inline-start" />
-            Rotate token
+            {token ? "Rotate token" : "Generate token"}
           </Button>
           <Button
             variant="danger"
@@ -271,6 +297,12 @@ export function McpSettingsSection() {
             Revoke token
           </Button>
         </div>
+        {!tokenLoading && !token && (
+          <p className="text-sm text-muted-foreground">
+            No token has been generated yet. Generate one to connect over HTTP — stdio connections
+            don't need it.
+          </p>
+        )}
         {tokenStorage === "file" && (
           <p className="text-sm text-amber-600 dark:text-amber-500">
             No OS keychain is available here, so this token is stored in a plain file on disk

--- a/apps/desktop/src/components/McpSettingsSection.tsx
+++ b/apps/desktop/src/components/McpSettingsSection.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
-import { Copy, Download, Radio } from "lucide-react";
-import { Button, TextInput } from "../ui";
+import { Copy, Download, Eye, EyeOff, Radio, RefreshCw, Trash2 } from "lucide-react";
+import { Button, ConfirmDialog, TextInput } from "../ui";
 import { notify } from "../lib/notify";
 import {
   loadMcpSettings,
@@ -15,7 +15,14 @@ import {
   srelensCliStatus,
   type CliStatus,
 } from "../lib/mcp";
+import { getMcpToken, revokeMcpToken, rotateMcpToken } from "../lib/mcpSecurity";
 import { mcpClientConfig, MCP_TOOLS, type McpTool, type McpTransport } from "../lib/mcpClients";
+import { McpAuditList } from "./McpAuditList";
+
+/** Masked by default: only the last 4 characters are shown until revealed. */
+function maskToken(token: string): string {
+  return `••••${token.slice(-4)}`;
+}
 
 async function copy(text: string) {
   try {
@@ -39,10 +46,16 @@ export function McpSettingsSection() {
   const [cliMessage, setCliMessage] = useState("");
   const [tool, setTool] = useState<McpTool>("claude-code");
   const [transport, setTransport] = useState<McpTransport>("stdio");
+  const [token, setToken] = useState<string | null>(null);
+  const [tokenRevealed, setTokenRevealed] = useState(false);
+  const [tokenBusy, setTokenBusy] = useState(false);
+  const [tokenError, setTokenError] = useState("");
+  const [tokenConfirm, setTokenConfirm] = useState<"rotate" | "revoke" | null>(null);
 
   useEffect(() => {
     void mcpHttpStatus().then(setRunningUrl).catch(() => {});
     void srelensCliStatus().then(setCli).catch(() => {});
+    void getMcpToken().then(setToken).catch(() => {});
   }, []);
 
   function persist(next: McpSettings) {
@@ -89,6 +102,43 @@ export function McpSettingsSection() {
       notify.success("srelens CLI installed");
     } catch (e) {
       setCliMessage(String(e));
+    }
+  }
+
+  async function confirmRotate() {
+    setTokenBusy(true);
+    setTokenError("");
+    try {
+      const next = await rotateMcpToken();
+      setToken(next);
+      setTokenRevealed(false);
+      notify.success("Token rotated — connected clients need the new value.");
+      setTokenConfirm(null);
+    } catch (e) {
+      setTokenError(String(e));
+    } finally {
+      setTokenBusy(false);
+    }
+  }
+
+  async function confirmRevoke() {
+    setTokenBusy(true);
+    setTokenError("");
+    try {
+      await revokeMcpToken();
+      setToken(null);
+      setTokenRevealed(false);
+      notify.success("Token revoked. The MCP HTTP server has stopped.");
+      // The server stops as a side effect of revocation; reflect that instead
+      // of leaving the toggle showing a server that's no longer listening.
+      const status = await mcpHttpStatus().catch(() => null);
+      setRunningUrl(status);
+      if (!status) persist({ ...settings, enabled: false });
+      setTokenConfirm(null);
+    } catch (e) {
+      setTokenError(String(e));
+    } finally {
+      setTokenBusy(false);
     }
   }
 
@@ -166,6 +216,84 @@ export function McpSettingsSection() {
           </p>
         )}
         {cliMessage && <p className="whitespace-pre-wrap text-sm text-muted-foreground">{cliMessage}</p>}
+      </section>
+
+      {/* Access token */}
+      <section className="flex flex-col gap-2">
+        <h4 className="text-sm font-medium">Access token</h4>
+        <p className="text-sm text-muted-foreground">
+          The HTTP transport requires this token — clients must send it as{" "}
+          <code className="fl-mono">Authorization: Bearer &lt;token&gt;</code>. Stdio connections (spawned
+          via the CLI) don't need it.
+        </p>
+        <div className="flex flex-wrap items-center gap-2">
+          <code className="fl-mono rounded-md border border-border bg-muted/40 px-2 py-1 text-sm">
+            {token ? (tokenRevealed ? token : maskToken(token)) : "Loading…"}
+          </code>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setTokenRevealed((r) => !r)}
+            disabled={!token}
+            aria-label={tokenRevealed ? "Hide token" : "Reveal token"}
+          >
+            {tokenRevealed ? <EyeOff data-icon="inline-start" /> : <Eye data-icon="inline-start" />}
+            {tokenRevealed ? "Hide" : "Reveal"}
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => token && void copy(token)}
+            disabled={!token}
+            aria-label="Copy token"
+          >
+            <Copy data-icon="inline-start" />
+            Copy
+          </Button>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => setTokenConfirm("rotate")}
+            disabled={!token || tokenBusy}
+          >
+            <RefreshCw data-icon="inline-start" />
+            Rotate token
+          </Button>
+          <Button
+            variant="danger"
+            size="sm"
+            onClick={() => setTokenConfirm("revoke")}
+            disabled={!token || tokenBusy}
+          >
+            <Trash2 data-icon="inline-start" />
+            Revoke token
+          </Button>
+        </div>
+        {tokenError && <p className="text-sm text-destructive">Error: {tokenError}</p>}
+      </section>
+
+      {tokenConfirm && (
+        <ConfirmDialog
+          title={tokenConfirm === "rotate" ? "Rotate access token?" : "Revoke access token?"}
+          message={
+            tokenConfirm === "rotate" ? (
+              "Connected clients are using the current token — once you rotate it, they'll need the new value or they'll stop working."
+            ) : (
+              "Revoking also stops the MCP HTTP server: it never serves without a valid token. Any clients connected over HTTP will disconnect."
+            )
+          }
+          confirmLabel={tokenConfirm === "rotate" ? "Rotate" : "Revoke"}
+          danger={tokenConfirm === "revoke"}
+          busy={tokenBusy}
+          onConfirm={() => void (tokenConfirm === "rotate" ? confirmRotate() : confirmRevoke())}
+          onCancel={() => setTokenConfirm(null)}
+        />
+      )}
+
+      {/* Recent agent activity */}
+      <section className="flex flex-col gap-2">
+        <h4 className="text-sm font-medium">Recent agent activity</h4>
+        <McpAuditList />
       </section>
 
       {/* Per-tool config */}

--- a/apps/desktop/src/components/McpSettingsSection.tsx
+++ b/apps/desktop/src/components/McpSettingsSection.tsx
@@ -15,7 +15,7 @@ import {
   srelensCliStatus,
   type CliStatus,
 } from "../lib/mcp";
-import { getMcpToken, revokeMcpToken, rotateMcpToken } from "../lib/mcpSecurity";
+import { getMcpToken, getMcpTokenStorage, revokeMcpToken, rotateMcpToken } from "../lib/mcpSecurity";
 import { mcpClientConfig, MCP_TOOLS, type McpTool, type McpTransport } from "../lib/mcpClients";
 import { McpAuditList } from "./McpAuditList";
 
@@ -51,11 +51,13 @@ export function McpSettingsSection() {
   const [tokenBusy, setTokenBusy] = useState(false);
   const [tokenError, setTokenError] = useState("");
   const [tokenConfirm, setTokenConfirm] = useState<"rotate" | "revoke" | null>(null);
+  const [tokenStorage, setTokenStorage] = useState<"keychain" | "file" | null>(null);
 
   useEffect(() => {
     void mcpHttpStatus().then(setRunningUrl).catch(() => {});
     void srelensCliStatus().then(setCli).catch(() => {});
     void getMcpToken().then(setToken).catch(() => {});
+    void getMcpTokenStorage().then(setTokenStorage).catch(() => {});
   }, []);
 
   function persist(next: McpSettings) {
@@ -269,6 +271,12 @@ export function McpSettingsSection() {
             Revoke token
           </Button>
         </div>
+        {tokenStorage === "file" && (
+          <p className="text-sm text-amber-600 dark:text-amber-500">
+            No OS keychain is available here, so this token is stored in a plain file on disk
+            (readable only by your user account) rather than the OS keychain.
+          </p>
+        )}
         {tokenError && <p className="text-sm text-destructive">Error: {tokenError}</p>}
       </section>
 

--- a/apps/desktop/src/components/McpSettingsSection.tsx
+++ b/apps/desktop/src/components/McpSettingsSection.tsx
@@ -114,7 +114,7 @@ export function McpSettingsSection() {
       const next = await rotateMcpToken();
       setToken(next);
       setTokenRevealed(false);
-      notify.success("Token rotated — connected clients need the new value.");
+      notify.success("Token rotated — the server restarted and connected clients need the new value.");
       setTokenConfirm(null);
     } catch (e) {
       setTokenError(String(e));
@@ -285,7 +285,7 @@ export function McpSettingsSection() {
           title={tokenConfirm === "rotate" ? "Rotate access token?" : "Revoke access token?"}
           message={
             tokenConfirm === "rotate" ? (
-              "Connected clients are using the current token — once you rotate it, they'll need the new value or they'll stop working."
+              "If the MCP HTTP server is running, rotating restarts it immediately so the new token takes effect — any in-flight agent request is dropped. Connected clients need the new value or they'll stop working."
             ) : (
               "Revoking also stops the MCP HTTP server: it never serves without a valid token. Any clients connected over HTTP will disconnect."
             )

--- a/apps/desktop/src/lib/mcpClients.test.ts
+++ b/apps/desktop/src/lib/mcpClients.test.ts
@@ -8,10 +8,25 @@ describe("mcpClientConfig", () => {
     expect(c.snippet).toBe("claude mcp add srelens -- srelens --mcp-stdio");
   });
 
-  it("emits an http `claude mcp add` command with the url", () => {
-    const c = mcpClientConfig("claude-code", "http", { url: "http://127.0.0.1:8765/mcp" });
+  it("emits an http `claude mcp add` command with the url and bearer token", () => {
+    const c = mcpClientConfig("claude-code", "http", {
+      url: "http://127.0.0.1:8765/mcp",
+      token: "a".repeat(64),
+    });
     expect(c.snippet).toContain("--transport http");
     expect(c.snippet).toContain("http://127.0.0.1:8765/mcp");
+    expect(c.snippet).toContain(`--header "Authorization: Bearer ${"a".repeat(64)}"`);
+  });
+
+  it("emits an obvious placeholder instead of the token when none exists yet", () => {
+    const c = mcpClientConfig("claude-code", "http", { url: "http://127.0.0.1:8765/mcp", token: null });
+    expect(c.snippet).not.toContain("Bearer");
+    expect(c.snippet).toContain("<enable the MCP server to generate a token>");
+  });
+
+  it("omits any token concern for stdio, even if one is passed", () => {
+    const c = mcpClientConfig("claude-code", "stdio", { token: "a".repeat(64) });
+    expect(c.snippet).toBe("claude mcp add srelens -- srelens --mcp-stdio");
   });
 
   it("emits an mcpServers JSON block for Claude Desktop / Cursor / Antigravity (stdio)", () => {
@@ -23,9 +38,23 @@ describe("mcpClientConfig", () => {
     }
   });
 
-  it("emits a url entry for JSON tools over http", () => {
-    const c = mcpClientConfig("cursor", "http", { url: "http://127.0.0.1:9000/mcp" });
-    expect(JSON.parse(c.snippet).mcpServers.srelens).toEqual({ url: "http://127.0.0.1:9000/mcp" });
+  it("emits a url entry with a bearer header for JSON tools over http", () => {
+    const c = mcpClientConfig("cursor", "http", {
+      url: "http://127.0.0.1:9000/mcp",
+      token: "b".repeat(64),
+    });
+    expect(JSON.parse(c.snippet).mcpServers.srelens).toEqual({
+      url: "http://127.0.0.1:9000/mcp",
+      headers: { Authorization: `Bearer ${"b".repeat(64)}` },
+    });
+  });
+
+  it("emits a placeholder header for JSON tools over http with no token yet", () => {
+    const c = mcpClientConfig("cursor", "http", { url: "http://127.0.0.1:9000/mcp", token: null });
+    expect(JSON.parse(c.snippet).mcpServers.srelens).toEqual({
+      url: "http://127.0.0.1:9000/mcp",
+      headers: { Authorization: "<enable the MCP server to generate a token>" },
+    });
   });
 
   it("emits TOML for Codex", () => {
@@ -34,6 +63,17 @@ describe("mcpClientConfig", () => {
     expect(c.snippet).toContain("[mcp_servers.srelens]");
     expect(c.snippet).toContain('command = "srelens"');
     expect(c.snippet).toContain('args = ["--mcp-stdio"]');
+  });
+
+  it("emits TOML for Codex over http with a headers table carrying the bearer token", () => {
+    const c = mcpClientConfig("codex", "http", {
+      url: "http://127.0.0.1:8765/mcp",
+      token: "c".repeat(64),
+    });
+    expect(c.format).toBe("toml");
+    expect(c.snippet).toContain('url = "http://127.0.0.1:8765/mcp"');
+    expect(c.snippet).toContain("[mcp_servers.srelens.headers]");
+    expect(c.snippet).toContain(`Authorization = "Bearer ${"c".repeat(64)}"`);
   });
 
   it("carries a hint about where the config goes for each tool", () => {

--- a/apps/desktop/src/lib/mcpClients.ts
+++ b/apps/desktop/src/lib/mcpClients.ts
@@ -36,25 +36,37 @@ export interface McpClientConfig {
 
 const DEFAULT_URL = "http://127.0.0.1:8765/mcp";
 
+/** Emitted instead of a real bearer value when http config is generated
+ * before a token exists. Deliberately not a plausible-looking token: a
+ * config that quietly 401s because it copied an empty/undefined value would
+ * be worse than one that's obviously incomplete. */
+const NO_TOKEN_PLACEHOLDER = "<enable the MCP server to generate a token>";
+
 /** Pretty mcpServers JSON block for a stdio or http entry. */
 function mcpServersJson(entry: Record<string, unknown>): string {
   return JSON.stringify({ mcpServers: { srelens: entry } }, null, 2);
 }
 
-/** Config for connecting `tool` to srelens over `transport`. */
+/**
+ * Config for connecting `tool` to srelens over `transport`. `opts.token` is
+ * the current MCP bearer token (or `null`/absent if none has been generated
+ * yet) — the HTTP transport requires it on every request, so an http config
+ * without it would 401. Ignored for stdio, which needs no token at all.
+ */
 export function mcpClientConfig(
   tool: McpTool,
   transport: McpTransport,
-  opts: { url?: string },
+  opts: { url?: string; token?: string | null },
 ): McpClientConfig {
   const url = opts.url || DEFAULT_URL;
+  const authValue = transport === "http" ? (opts.token ? `Bearer ${opts.token}` : NO_TOKEN_PLACEHOLDER) : "";
   const hint = MCP_TOOLS.find((t) => t.id === tool)?.hint ?? "";
 
   if (tool === "claude-code") {
     const snippet =
       transport === "stdio"
         ? "claude mcp add srelens -- srelens --mcp-stdio"
-        : `claude mcp add --transport http srelens ${url}`;
+        : `claude mcp add --transport http srelens ${url} --header "Authorization: ${authValue}"`;
     return { format: "shell", snippet, hint };
   }
 
@@ -62,11 +74,14 @@ export function mcpClientConfig(
     const snippet =
       transport === "stdio"
         ? `[mcp_servers.srelens]\ncommand = "srelens"\nargs = ["--mcp-stdio"]`
-        : `[mcp_servers.srelens]\nurl = "${url}"`;
+        : `[mcp_servers.srelens]\nurl = "${url}"\n\n[mcp_servers.srelens.headers]\nAuthorization = "${authValue}"`;
     return { format: "toml", snippet, hint };
   }
 
   // JSON mcpServers tools: Claude Desktop, Cursor, Antigravity, generic.
-  const entry = transport === "stdio" ? { command: "srelens", args: ["--mcp-stdio"] } : { url };
+  const entry =
+    transport === "stdio"
+      ? { command: "srelens", args: ["--mcp-stdio"] }
+      : { url, headers: { Authorization: authValue } };
   return { format: "json", snippet: mcpServersJson(entry), hint };
 }

--- a/apps/desktop/src/lib/mcpSecurity.test.ts
+++ b/apps/desktop/src/lib/mcpSecurity.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 const invoke = vi.fn();
 vi.mock("@tauri-apps/api/core", () => ({ invoke: (...a: unknown[]) => invoke(...a) }));
 
-import { auditTail, respondToConfirm, rotateMcpToken } from "./mcpSecurity";
+import { auditTail, getMcpTokenStorage, respondToConfirm, rotateMcpToken } from "./mcpSecurity";
 
 describe("mcpSecurity", () => {
   beforeEach(() => invoke.mockReset());
@@ -22,5 +22,11 @@ describe("mcpSecurity", () => {
   it("returns an empty list when the audit log is unreadable", async () => {
     invoke.mockRejectedValueOnce(new Error("nope"));
     await expect(auditTail(10)).resolves.toEqual([]);
+  });
+
+  it("reports which backend holds the token", async () => {
+    invoke.mockResolvedValue("file");
+    await expect(getMcpTokenStorage()).resolves.toBe("file");
+    expect(invoke).toHaveBeenCalledWith("mcp_token_storage");
   });
 });

--- a/apps/desktop/src/lib/mcpSecurity.test.ts
+++ b/apps/desktop/src/lib/mcpSecurity.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const invoke = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({ invoke: (...a: unknown[]) => invoke(...a) }));
+
+import { auditTail, respondToConfirm, rotateMcpToken } from "./mcpSecurity";
+
+describe("mcpSecurity", () => {
+  beforeEach(() => invoke.mockReset());
+
+  it("passes the confirm decision through to the command", async () => {
+    invoke.mockResolvedValue(undefined);
+    await respondToConfirm("abc", true);
+    expect(invoke).toHaveBeenCalledWith("mcp_confirm_respond", { id: "abc", approved: true });
+  });
+
+  it("returns the rotated token", async () => {
+    invoke.mockResolvedValue("f".repeat(64));
+    await expect(rotateMcpToken()).resolves.toHaveLength(64);
+  });
+
+  it("returns an empty list when the audit log is unreadable", async () => {
+    invoke.mockRejectedValueOnce(new Error("nope"));
+    await expect(auditTail(10)).resolves.toEqual([]);
+  });
+});

--- a/apps/desktop/src/lib/mcpSecurity.ts
+++ b/apps/desktop/src/lib/mcpSecurity.ts
@@ -14,7 +14,7 @@ export interface AuditEntry {
   args: Record<string, unknown>;
   decision: "approved" | "denied" | "auto";
   outcome: "ok" | "error";
-  err?: string | null;
+  err: string | null;
 }
 
 export async function respondToConfirm(id: string, approved: boolean): Promise<void> {

--- a/apps/desktop/src/lib/mcpSecurity.ts
+++ b/apps/desktop/src/lib/mcpSecurity.ts
@@ -33,6 +33,13 @@ export async function revokeMcpToken(): Promise<void> {
   await invoke("mcp_token_revoke");
 }
 
+/** Where the token actually lives right now: the OS keychain, or (when none
+ * is available) the 0600 fallback file — so Settings can say plainly when
+ * it's on disk unencrypted rather than implying it's always protected. */
+export async function getMcpTokenStorage(): Promise<"keychain" | "file"> {
+  return await invoke<"keychain" | "file">("mcp_token_storage");
+}
+
 /** Newest first. Returns [] rather than throwing: a missing log is not an error. */
 export async function auditTail(limit: number): Promise<AuditEntry[]> {
   try {

--- a/apps/desktop/src/lib/mcpSecurity.ts
+++ b/apps/desktop/src/lib/mcpSecurity.ts
@@ -1,0 +1,43 @@
+// Typed wrappers for the MCP consent/token/audit commands.
+import { invoke } from "@tauri-apps/api/core";
+
+export interface ConfirmRequest {
+  id: string;
+  tool: string;
+  args: Record<string, unknown>;
+}
+
+export interface AuditEntry {
+  ts: number;
+  transport: "stdio" | "http";
+  tool: string;
+  args: Record<string, unknown>;
+  decision: "approved" | "denied" | "auto";
+  outcome: "ok" | "error";
+  err?: string | null;
+}
+
+export async function respondToConfirm(id: string, approved: boolean): Promise<void> {
+  await invoke("mcp_confirm_respond", { id, approved });
+}
+
+export async function getMcpToken(): Promise<string | null> {
+  return (await invoke<string | null>("mcp_token_get")) ?? null;
+}
+
+export async function rotateMcpToken(): Promise<string> {
+  return await invoke<string>("mcp_token_rotate");
+}
+
+export async function revokeMcpToken(): Promise<void> {
+  await invoke("mcp_token_revoke");
+}
+
+/** Newest first. Returns [] rather than throwing: a missing log is not an error. */
+export async function auditTail(limit: number): Promise<AuditEntry[]> {
+  try {
+    return await invoke<AuditEntry[]>("mcp_audit_tail", { limit });
+  } catch {
+    return [];
+  }
+}

--- a/crates/capability/src/annotations.rs
+++ b/crates/capability/src/annotations.rs
@@ -17,7 +17,9 @@ impl Annotations {
     /// installing a tool): confirm-gated, not flagged destructive.
     pub const MUTATING: Self =
         Self { read_only: false, destructive: false, requires_confirm: true, sensitive: false };
-    /// A read that returns sensitive material — gateable by consent policy.
+    /// A read that returns sensitive material (e.g. Secret values): confirm-gated
+    /// even though it's read-only and non-destructive, so an MCP consent layer
+    /// doesn't hand raw secrets to a client without a human seeing it first.
     pub const SENSITIVE_READ: Self =
-        Self { read_only: true, destructive: false, requires_confirm: false, sensitive: true };
+        Self { read_only: true, destructive: false, requires_confirm: true, sensitive: true };
 }

--- a/crates/kube/src/helm_cli.rs
+++ b/crates/kube/src/helm_cli.rs
@@ -608,7 +608,7 @@ pub fn helm_repo_update_capability(_cache: Arc<ClientCache>) -> Capability {
     Capability::typed::<HelmRepoUpdateIn, HelmOpOut, _, _>(
         "k8s.helmRepoUpdate",
         "refresh the local cache of chart repositories",
-        Annotations::default(),
+        Annotations::MUTATING,
         move |_input: HelmRepoUpdateIn| async move {
             let out = run_helm_local(&repo_update_args())
                 .await

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -5,8 +5,10 @@ edition.workspace = true
 
 [dependencies]
 async-trait = "0.1"
+getrandom = "0.2"
 srelens-capability = { path = "../capability" }
 serde_json = "1"
+subtle = "2"
 tokio = { version = "1", features = ["io-util", "net", "rt-multi-thread", "macros"] }
 axum = "0.7"
 

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+async-trait = "0.1"
 srelens-capability = { path = "../capability" }
 serde_json = "1"
 tokio = { version = "1", features = ["io-util", "net", "rt-multi-thread", "macros"] }

--- a/crates/mcp/src/audit.rs
+++ b/crates/mcp/src/audit.rs
@@ -33,17 +33,33 @@ impl AuditSink for NoopAudit {
 
 /// Redact argument VALUES while keeping keys, so an operator can see the shape
 /// of a call without its secrets. Sensitive-annotated tools redact everything;
-/// otherwise only keys that name a credential. Recursively walks nested objects
-/// and arrays to find and redact credentials at any depth.
+/// otherwise a value goes only if its key names a credential or holds a
+/// caller-supplied payload. Recursively walks nested objects and arrays to find
+/// and redact credentials at any depth.
 pub fn redact(args: &Value, sensitive: bool) -> Value {
+    /// Substring-matched: a key admitting it holds a credential, at any depth
+    /// and in any casing (`apiToken`, `tls.key`, `rootPassword`).
     const NEEDLES: [&str; 4] = ["token", "secret", "password", "key"];
+    /// Whole fields whose value is a caller-supplied payload that can carry
+    /// secret material with no credential-shaped key inside it to catch:
+    /// `data`/`stringData` on a Secret write (`k8s.updateConfigData` — a
+    /// Secret's own keys are things like `username` and `ca.crt`), `yaml` on
+    /// `k8s.applyManifest` (one opaque string holding a whole manifest), and
+    /// `values` on the helm install/upgrade/template capabilities (user YAML
+    /// that routinely holds registry credentials and database passwords).
+    ///
+    /// Matched EXACTLY, not as substrings, so `metadata` stays readable — the
+    /// point is to keep the shape of a call auditable while dropping the part
+    /// that carries secrets.
+    const PAYLOAD_FIELDS: [&str; 4] = ["data", "stringdata", "yaml", "values"];
 
     match args {
         Value::Object(map) => {
             let mut out = serde_json::Map::new();
             for (k, v) in map {
                 let lower = k.to_ascii_lowercase();
-                let is_credential_key = NEEDLES.iter().any(|n| lower.contains(n));
+                let is_credential_key = NEEDLES.iter().any(|n| lower.contains(n))
+                    || PAYLOAD_FIELDS.contains(&lower.as_str());
 
                 if sensitive || is_credential_key {
                     // Redact this value entirely
@@ -62,6 +78,51 @@ pub fn redact(args: &Value, sensitive: bool) -> Value {
         // Scalars stay as-is (no redaction needed)
         other => other.clone(),
     }
+}
+
+/// The most recent `limit` entries, newest first.
+///
+/// Reads at most a bounded window from the END of the log rather than the whole
+/// file: the log is capped at 5 MB and a caller only ever wants the last
+/// handful, so parsing every line to discard nearly all of them is wasted work
+/// on every Settings open. Unparseable lines are skipped — a torn final write,
+/// or the fragment of a line the window's start lands inside, is not an error.
+///
+/// Only the live log is read; entries rotated into `.jsonl.1` are not included.
+pub fn tail(path: &std::path::Path, limit: usize) -> Vec<Value> {
+    /// Generous next to a realistic `limit` (tens of entries at a few hundred
+    /// bytes each) while staying a small fraction of the 5 MB cap.
+    const WINDOW: u64 = 512 * 1024;
+
+    use std::io::{Read, Seek, SeekFrom};
+
+    let Ok(mut f) = std::fs::File::open(path) else {
+        return Vec::new();
+    };
+    let len = f.metadata().map(|m| m.len()).unwrap_or(0);
+    let start = len.saturating_sub(WINDOW);
+    if start > 0 && f.seek(SeekFrom::Start(start)).is_err() {
+        return Vec::new();
+    }
+    let mut buf = Vec::new();
+    if f.read_to_end(&mut buf).is_err() {
+        return Vec::new();
+    }
+    // Lossy: a window start can land inside a multi-byte character, and a
+    // mangled leading fragment is discarded below regardless.
+    let text = String::from_utf8_lossy(&buf);
+    let mut lines: Vec<&str> = text.lines().collect();
+    if start > 0 && !lines.is_empty() {
+        // Seeking mid-file almost certainly lands inside a line; that fragment
+        // is not a record.
+        lines.remove(0);
+    }
+    lines
+        .iter()
+        .rev()
+        .filter_map(|l| serde_json::from_str(l).ok())
+        .take(limit)
+        .collect()
 }
 
 pub struct JsonlAuditLog {
@@ -102,12 +163,26 @@ impl AuditSink for JsonlAuditLog {
             "outcome": rec.outcome,
             "err": rec.error,
         });
-        let opened = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&self.path);
+        // 0600: the log holds every tool call's arguments, so it is at least
+        // as sensitive as the token file beside it. `mode` applies only when
+        // the file is created, so an existing log is tightened after the write
+        // — a log an older build left 0644 must not stay readable forever.
+        let mut opts = std::fs::OpenOptions::new();
+        opts.create(true).append(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            opts.mode(0o600);
+        }
+        let opened = opts.open(&self.path);
         if let Ok(mut f) = opened {
             let _ = writeln!(f, "{line}");
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ =
+                    std::fs::set_permissions(&self.path, std::fs::Permissions::from_mode(0o600));
+            }
         } else {
             eprintln!("srelens: could not write MCP audit log at {}", self.path.display());
         }
@@ -160,6 +235,135 @@ mod tests {
         assert!(parsed["ts"].as_u64().unwrap() > 0);
     }
 
+    fn write_entries(path: &std::path::Path, count: usize, pad: usize) {
+        let log = JsonlAuditLog::new(path.to_path_buf(), u64::MAX); // never rotate
+        for i in 0..count {
+            log.record(AuditRecord {
+                transport: Transport::Stdio,
+                tool: format!("tool{i}"),
+                args: json!({ "pad": "x".repeat(pad) }),
+                decision: "auto",
+                outcome: "ok",
+                error: None,
+            });
+        }
+    }
+
+    #[test]
+    fn tail_returns_the_newest_entries_first() {
+        let dir = std::env::temp_dir().join(format!("srelens-tail-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("t.jsonl");
+        let _ = std::fs::remove_file(&path);
+        write_entries(&path, 10, 0);
+
+        let out = tail(&path, 3);
+
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0]["tool"], json!("tool9"), "newest first");
+        assert_eq!(out[1]["tool"], json!("tool8"));
+        assert_eq!(out[2]["tool"], json!("tool7"));
+    }
+
+    #[test]
+    fn tail_of_a_missing_log_is_empty() {
+        let out = tail(std::path::Path::new("/nonexistent/srelens/audit.jsonl"), 50);
+        assert!(out.is_empty(), "a log that was never written is not an error");
+    }
+
+    /// The log is capped at 5 MB, so reading and parsing all of it to show 50
+    /// rows is wasted work on every Settings open. Reading a bounded window from
+    /// the end means the oldest entries are never touched — which is what this
+    /// asserts, by demanding an entry from the far past be absent even when the
+    /// caller asks for far more rows than exist.
+    #[test]
+    fn tail_reads_only_a_bounded_window_from_the_end() {
+        let dir = std::env::temp_dir().join(format!("srelens-tailwin-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("big.jsonl");
+        let _ = std::fs::remove_file(&path);
+        // ~1 KB per entry x 2000 = ~2 MB, comfortably past any sane window.
+        write_entries(&path, 2000, 1000);
+        assert!(std::fs::metadata(&path).unwrap().len() > 1024 * 1024);
+
+        let out = tail(&path, 100_000);
+
+        assert!(!out.is_empty());
+        assert_eq!(out[0]["tool"], json!("tool1999"), "newest entry must be present");
+        assert!(
+            out.iter().all(|e| e["tool"] != json!("tool0")),
+            "the oldest entry must not be read at all"
+        );
+    }
+
+    /// Seeking to a byte offset lands mid-line. That fragment is not valid JSON
+    /// and must be dropped rather than surfacing as a missing row or an error.
+    #[test]
+    fn tail_discards_the_partial_line_at_the_window_boundary() {
+        let dir = std::env::temp_dir().join(format!("srelens-tailfrag-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("frag.jsonl");
+        let _ = std::fs::remove_file(&path);
+        write_entries(&path, 3000, 1000);
+
+        let out = tail(&path, 100_000);
+
+        assert!(
+            out.iter().all(|e| e.get("tool").is_some()),
+            "every returned row must be a fully parsed entry, not a fragment"
+        );
+    }
+
+    fn a_record() -> AuditRecord {
+        AuditRecord {
+            transport: Transport::Http,
+            tool: "k8s.updateConfigData".into(),
+            args: json!({ "name": "db-creds" }),
+            decision: "approved",
+            outcome: "ok",
+            error: None,
+        }
+    }
+
+    /// The log records every tool call's arguments, so it is at least as
+    /// sensitive as the token file sitting beside it — which is explicitly
+    /// 0600 (see `auth::FileTokenStore::save`). `create(true).append(true)`
+    /// with no mode yields 0644 under a standard umask, i.e. readable by
+    /// every other account on the machine.
+    #[cfg(unix)]
+    #[test]
+    fn audit_log_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir().join(format!("srelens-audit-perm-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("perm.jsonl");
+        let _ = std::fs::remove_file(&path);
+
+        JsonlAuditLog::new(path.clone(), 1024 * 1024).record(a_record());
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "the audit log must not be group/world readable");
+    }
+
+    /// An upgrade case: a log already on disk from a build that created it
+    /// 0644 must be tightened, not left permanently readable because the file
+    /// happened to exist before.
+    #[cfg(unix)]
+    #[test]
+    fn audit_log_tightens_loose_permissions_on_an_existing_file() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir().join(format!("srelens-audit-perm2-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("loose.jsonl");
+        std::fs::write(&path, "{}\n").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        JsonlAuditLog::new(path.clone(), 1024 * 1024).record(a_record());
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "an existing loose log must be tightened");
+    }
+
     #[test]
     fn rotates_once_past_the_cap() {
         let dir = std::env::temp_dir().join(format!("srelens-rot-{}", std::process::id()));
@@ -183,21 +387,72 @@ mod tests {
         assert!(live <= 200 * 2, "live file should stay near the cap, was {live}");
     }
 
+    /// `k8s.updateConfigData` takes `kind: "Secret"` and a `data` map of
+    /// *plaintext* values. None of a Secret's own key names need look like a
+    /// credential (`username`, `host`, `ca.crt`), so key-name matching alone
+    /// writes them verbatim. The field that holds a payload is the thing to
+    /// redact, not just the keys that admit to being secrets.
+    #[test]
+    fn redacts_the_data_payload_of_a_secret_write() {
+        let args = json!({
+            "kind": "Secret",
+            "namespace": "prod",
+            "name": "db-creds",
+            "data": { "username": "admin" }
+        });
+        let out = redact(&args, false);
+        // The shape an operator needs to audit the call must survive.
+        assert_eq!(out["kind"], json!("Secret"));
+        assert_eq!(out["namespace"], json!("prod"));
+        assert_eq!(out["name"], json!("db-creds"));
+        // The payload must not.
+        assert_eq!(out["data"], json!("<redacted>"));
+    }
+
+    /// `k8s.applyManifest`'s `yaml` is the entire manifest, so applying a
+    /// Secret puts its whole body in the log. `yaml` is one opaque string —
+    /// there are no nested keys for the needle list to catch.
+    #[test]
+    fn redacts_the_yaml_payload_of_an_apply() {
+        let args = json!({
+            "context": "prod",
+            "yaml": "apiVersion: v1\nkind: Secret\nstringData:\n  password: hunter2\n"
+        });
+        let out = redact(&args, false);
+        assert_eq!(out["context"], json!("prod"), "which cluster must stay visible");
+        assert_eq!(out["yaml"], json!("<redacted>"));
+    }
+
+    /// Helm values are user-supplied YAML and routinely carry registry
+    /// credentials and database passwords.
+    #[test]
+    fn redacts_helm_values() {
+        let args = json!({ "release": "web", "chart": "bitnami/nginx", "values": "auth:\n  rootPassword: hunter2\n" });
+        let out = redact(&args, false);
+        assert_eq!(out["release"], json!("web"));
+        assert_eq!(out["chart"], json!("bitnami/nginx"));
+        assert_eq!(out["values"], json!("<redacted>"));
+    }
+
+    /// Deliberately nests under `spec`/`template` rather than `data`: those are
+    /// ordinary structural keys, so this keeps testing what it's named for —
+    /// that a credential key is found at *depth* — instead of being short-
+    /// circuited by `PAYLOAD_FIELDS` redacting the wrapper wholesale.
     #[test]
     fn redaction_recurses_into_nested_objects() {
         let args = json!({
-            "manifest": {
-                "data": {
+            "spec": {
+                "template": {
                     "password": "hunter2"
                 }
             }
         });
         let out = redact(&args, false);
         // Keys must survive at all levels
-        assert!(out["manifest"].is_object());
-        assert!(out["manifest"]["data"].is_object());
+        assert!(out["spec"].is_object());
+        assert!(out["spec"]["template"].is_object());
         // But the credential value must be redacted
-        assert_eq!(out["manifest"]["data"]["password"], json!("<redacted>"));
+        assert_eq!(out["spec"]["template"]["password"], json!("<redacted>"));
     }
 
     #[test]

--- a/crates/mcp/src/audit.rs
+++ b/crates/mcp/src/audit.rs
@@ -33,22 +33,33 @@ impl AuditSink for NoopAudit {
 
 /// Redact argument VALUES while keeping keys, so an operator can see the shape
 /// of a call without its secrets. Sensitive-annotated tools redact everything;
-/// otherwise only keys that name a credential.
+/// otherwise only keys that name a credential. Recursively walks nested objects
+/// and arrays to find and redact credentials at any depth.
 pub fn redact(args: &Value, sensitive: bool) -> Value {
     const NEEDLES: [&str; 4] = ["token", "secret", "password", "key"];
+
     match args {
         Value::Object(map) => {
             let mut out = serde_json::Map::new();
             for (k, v) in map {
                 let lower = k.to_ascii_lowercase();
-                let hit = sensitive || NEEDLES.iter().any(|n| lower.contains(n));
-                out.insert(
-                    k.clone(),
-                    if hit { json!("<redacted>") } else { v.clone() },
-                );
+                let is_credential_key = NEEDLES.iter().any(|n| lower.contains(n));
+
+                if sensitive || is_credential_key {
+                    // Redact this value entirely
+                    out.insert(k.clone(), json!("<redacted>"));
+                } else {
+                    // Recurse into the value to find nested credentials
+                    out.insert(k.clone(), redact(v, false));
+                }
             }
             Value::Object(out)
         }
+        Value::Array(arr) => {
+            // Recurse into array elements with the same sensitivity
+            Value::Array(arr.iter().map(|v| redact(v, sensitive)).collect())
+        }
+        // Scalars stay as-is (no redaction needed)
         other => other.clone(),
     }
 }
@@ -170,5 +181,53 @@ mod tests {
         assert!(dir.join("b.jsonl.1").exists(), "expected a rotated file");
         let live = std::fs::metadata(&path).unwrap().len();
         assert!(live <= 200 * 2, "live file should stay near the cap, was {live}");
+    }
+
+    #[test]
+    fn redaction_recurses_into_nested_objects() {
+        let args = json!({
+            "manifest": {
+                "data": {
+                    "password": "hunter2"
+                }
+            }
+        });
+        let out = redact(&args, false);
+        // Keys must survive at all levels
+        assert!(out["manifest"].is_object());
+        assert!(out["manifest"]["data"].is_object());
+        // But the credential value must be redacted
+        assert_eq!(out["manifest"]["data"]["password"], json!("<redacted>"));
+    }
+
+    #[test]
+    fn redaction_recurses_into_array_elements() {
+        let args = json!({
+            "items": [
+                { "apiKey": "secret123" },
+                { "name": "safe" }
+            ]
+        });
+        let out = redact(&args, false);
+        // Array structure is preserved
+        assert!(out["items"].is_array());
+        // Credential in first element is redacted
+        assert_eq!(out["items"][0]["apiKey"], json!("<redacted>"));
+        // Non-credential in second element is preserved
+        assert_eq!(out["items"][1]["name"], json!("safe"));
+    }
+
+    #[test]
+    fn redaction_preserves_deep_non_credential_values() {
+        let args = json!({
+            "spec": {
+                "replicas": 3,
+                "image": "nginx:1.14"
+            }
+        });
+        let out = redact(&args, false);
+        // Non-credential scalar values must survive redaction
+        assert_eq!(out["spec"]["replicas"], json!(3));
+        assert_eq!(out["spec"]["image"], json!("nginx:1.14"));
     }
 }

--- a/crates/mcp/src/audit.rs
+++ b/crates/mcp/src/audit.rs
@@ -1,0 +1,174 @@
+//! Append-only record of what agents did. Values from sensitive capabilities
+//! are never written: names and shapes only.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use serde_json::{json, Value};
+
+use crate::Transport;
+
+#[derive(Debug, Clone)]
+pub struct AuditRecord {
+    pub transport: Transport,
+    pub tool: String,
+    pub args: Value,
+    /// "approved" | "denied" | "auto" (no consent needed) — never free text.
+    pub decision: &'static str,
+    pub outcome: &'static str,
+    pub error: Option<String>,
+}
+
+pub trait AuditSink: Send + Sync {
+    fn record(&self, rec: AuditRecord);
+}
+
+/// Default sink: records nothing. Used by tests and by hosts that opt out.
+pub struct NoopAudit;
+
+impl AuditSink for NoopAudit {
+    fn record(&self, _rec: AuditRecord) {}
+}
+
+/// Redact argument VALUES while keeping keys, so an operator can see the shape
+/// of a call without its secrets. Sensitive-annotated tools redact everything;
+/// otherwise only keys that name a credential.
+pub fn redact(args: &Value, sensitive: bool) -> Value {
+    const NEEDLES: [&str; 4] = ["token", "secret", "password", "key"];
+    match args {
+        Value::Object(map) => {
+            let mut out = serde_json::Map::new();
+            for (k, v) in map {
+                let lower = k.to_ascii_lowercase();
+                let hit = sensitive || NEEDLES.iter().any(|n| lower.contains(n));
+                out.insert(
+                    k.clone(),
+                    if hit { json!("<redacted>") } else { v.clone() },
+                );
+            }
+            Value::Object(out)
+        }
+        other => other.clone(),
+    }
+}
+
+pub struct JsonlAuditLog {
+    path: PathBuf,
+    cap_bytes: u64,
+    lock: Mutex<()>,
+}
+
+impl JsonlAuditLog {
+    pub fn new(path: PathBuf, cap_bytes: u64) -> Self {
+        Self { path, cap_bytes, lock: Mutex::new(()) }
+    }
+}
+
+fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+impl AuditSink for JsonlAuditLog {
+    fn record(&self, rec: AuditRecord) {
+        // Bookkeeping fails open: a lost log line must never break a working
+        // cluster operation, so every error here is swallowed after logging.
+        let _guard = self.lock.lock().unwrap_or_else(|e| e.into_inner());
+        if let Ok(meta) = std::fs::metadata(&self.path) {
+            if meta.len() >= self.cap_bytes {
+                let _ = std::fs::rename(&self.path, self.path.with_extension("jsonl.1"));
+            }
+        }
+        let line = json!({
+            "ts": unix_now(),
+            "transport": rec.transport.as_str(),
+            "tool": rec.tool,
+            "args": rec.args,
+            "decision": rec.decision,
+            "outcome": rec.outcome,
+            "err": rec.error,
+        });
+        let opened = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path);
+        if let Ok(mut f) = opened {
+            let _ = writeln!(f, "{line}");
+        } else {
+            eprintln!("srelens: could not write MCP audit log at {}", self.path.display());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacts_only_credential_keys_by_default() {
+        let args = json!({ "namespace": "prod", "apiToken": "abc", "name": "web" });
+        let out = redact(&args, false);
+        assert_eq!(out["namespace"], json!("prod"));
+        assert_eq!(out["name"], json!("web"));
+        assert_eq!(out["apiToken"], json!("<redacted>"));
+    }
+
+    #[test]
+    fn sensitive_capability_redacts_every_value_but_keeps_keys() {
+        let args = json!({ "namespace": "prod", "name": "db-creds" });
+        let out = redact(&args, true);
+        assert_eq!(out["namespace"], json!("<redacted>"));
+        assert_eq!(out["name"], json!("<redacted>"));
+        assert!(out.get("namespace").is_some(), "keys must survive redaction");
+    }
+
+    #[test]
+    fn writes_one_json_line_per_record() {
+        let dir = std::env::temp_dir().join(format!("srelens-audit-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("a.jsonl");
+        let _ = std::fs::remove_file(&path);
+        let log = JsonlAuditLog::new(path.clone(), 1024 * 1024);
+        log.record(AuditRecord {
+            transport: Transport::Http,
+            tool: "k8s_deletePod".into(),
+            args: json!({ "name": "web" }),
+            decision: "approved",
+            outcome: "ok",
+            error: None,
+        });
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(body.lines().count(), 1);
+        let parsed: Value = serde_json::from_str(body.lines().next().unwrap()).unwrap();
+        assert_eq!(parsed["tool"], json!("k8s_deletePod"));
+        assert_eq!(parsed["transport"], json!("http"));
+        assert_eq!(parsed["decision"], json!("approved"));
+        assert!(parsed["ts"].as_u64().unwrap() > 0);
+    }
+
+    #[test]
+    fn rotates_once_past_the_cap() {
+        let dir = std::env::temp_dir().join(format!("srelens-rot-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("b.jsonl");
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(dir.join("b.jsonl.1"));
+        let log = JsonlAuditLog::new(path.clone(), 200); // tiny cap
+        for i in 0..40 {
+            log.record(AuditRecord {
+                transport: Transport::Stdio,
+                tool: format!("tool{i}"),
+                args: json!({}),
+                decision: "auto",
+                outcome: "ok",
+                error: None,
+            });
+        }
+        assert!(dir.join("b.jsonl.1").exists(), "expected a rotated file");
+        let live = std::fs::metadata(&path).unwrap().len();
+        assert!(live <= 200 * 2, "live file should stay near the cap, was {live}");
+    }
+}

--- a/crates/mcp/src/auth.rs
+++ b/crates/mcp/src/auth.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 
 use subtle::ConstantTimeEq;
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone)]
 pub struct Token(String);
 
 impl Token {
@@ -74,11 +74,24 @@ impl TokenStore for FileTokenStore {
         if let Some(parent) = self.path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        std::fs::write(&self.path, t.as_str())?;
         #[cfg(unix)]
         {
+            use std::io::Write;
+            use std::os::unix::fs::OpenOptionsExt;
+            let mut f = std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .mode(0o600)
+                .open(&self.path)?;
+            f.write_all(t.as_str().as_bytes())?;
+            // Belt-and-braces: enforce 0600 even for overwrites of existing files
             use std::os::unix::fs::PermissionsExt;
             std::fs::set_permissions(&self.path, std::fs::Permissions::from_mode(0o600))?;
+        }
+        #[cfg(not(unix))]
+        {
+            std::fs::write(&self.path, t.as_str())?;
         }
         Ok(())
     }
@@ -152,5 +165,22 @@ mod tests {
         store.save(&Token::generate()).unwrap();
         let mode = std::fs::metadata(&path).unwrap().permissions().mode();
         assert_eq!(mode & 0o777, 0o600, "token file must not be group/world readable");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn file_store_tightens_loose_permissions_on_overwrite() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir().join(format!("srelens-perm2-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("token");
+        // Pre-create with loose permissions (0644)
+        std::fs::write(&path, "dummy").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        // Now save should tighten to 0600
+        let store = FileTokenStore::new(path.clone());
+        store.save(&Token::generate()).unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "save must tighten loose permissions to 0600");
     }
 }

--- a/crates/mcp/src/auth.rs
+++ b/crates/mcp/src/auth.rs
@@ -1,0 +1,156 @@
+//! Bearer-token auth for the HTTP transport. stdio needs none: the client
+//! spawned the process and already holds the user's privileges.
+
+use std::path::PathBuf;
+
+use subtle::ConstantTimeEq;
+
+#[derive(Clone, PartialEq)]
+pub struct Token(String);
+
+impl Token {
+    pub fn generate() -> Self {
+        let mut bytes = [0u8; 32];
+        getrandom::getrandom(&mut bytes).expect("system randomness");
+        Token(bytes.iter().map(|b| format!("{b:02x}")).collect())
+    }
+
+    pub fn from_hex(s: &str) -> Option<Self> {
+        let s = s.trim();
+        if s.len() == 64 && s.bytes().all(|b| b.is_ascii_hexdigit()) {
+            Some(Token(s.to_ascii_lowercase()))
+        } else {
+            None
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Constant-time comparison: a byte-by-byte `==` leaks the shared prefix
+    /// length through timing, which is enough to recover a token.
+    pub fn matches(&self, presented: &str) -> bool {
+        let a = self.0.as_bytes();
+        let b = presented.as_bytes();
+        if a.len() != b.len() {
+            return false;
+        }
+        a.ct_eq(b).into()
+    }
+}
+
+/// Deliberately opaque: a token must never reach a log line by accident.
+impl std::fmt::Debug for Token {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Token(<redacted>)")
+    }
+}
+
+pub trait TokenStore: Send + Sync {
+    fn load(&self) -> Option<Token>;
+    fn save(&self, t: &Token) -> std::io::Result<()>;
+    fn clear(&self) -> std::io::Result<()>;
+}
+
+/// Fallback store: a 0600 file. Used where no OS keychain is available
+/// (headless Linux, minimal window managers).
+pub struct FileTokenStore {
+    path: PathBuf,
+}
+
+impl FileTokenStore {
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+impl TokenStore for FileTokenStore {
+    fn load(&self) -> Option<Token> {
+        std::fs::read_to_string(&self.path).ok().and_then(|s| Token::from_hex(&s))
+    }
+
+    fn save(&self, t: &Token) -> std::io::Result<()> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&self.path, t.as_str())?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&self.path, std::fs::Permissions::from_mode(0o600))?;
+        }
+        Ok(())
+    }
+
+    fn clear(&self) -> std::io::Result<()> {
+        match std::fs::remove_file(&self.path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_tokens_are_64_hex_chars_and_unique() {
+        let a = Token::generate();
+        let b = Token::generate();
+        assert_eq!(a.as_str().len(), 64);
+        assert!(a.as_str().bytes().all(|c| c.is_ascii_hexdigit()));
+        assert_ne!(a.as_str(), b.as_str());
+    }
+
+    #[test]
+    fn matches_accepts_itself_and_rejects_others() {
+        let t = Token::generate();
+        assert!(t.matches(t.as_str()));
+        assert!(!t.matches(""));
+        assert!(!t.matches("short"));
+        assert!(!t.matches(&format!("{}0", t.as_str())));
+    }
+
+    #[test]
+    fn debug_never_prints_the_token() {
+        let t = Token::generate();
+        let shown = format!("{t:?}");
+        assert!(!shown.contains(t.as_str()), "token leaked into Debug output");
+    }
+
+    #[test]
+    fn from_hex_rejects_malformed_values() {
+        assert!(Token::from_hex("nope").is_none());
+        assert!(Token::from_hex(&"z".repeat(64)).is_none());
+        assert!(Token::from_hex(&"a".repeat(64)).is_some());
+    }
+
+    #[test]
+    fn file_store_round_trips_and_clears() {
+        let dir = std::env::temp_dir().join(format!("srelens-tok-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let store = FileTokenStore::new(dir.join("token"));
+        assert!(store.load().is_none());
+        let t = Token::generate();
+        store.save(&t).unwrap();
+        assert_eq!(store.load().unwrap().as_str(), t.as_str());
+        store.clear().unwrap();
+        assert!(store.load().is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn file_store_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir().join(format!("srelens-perm-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("token");
+        let store = FileTokenStore::new(path.clone());
+        store.save(&Token::generate()).unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "token file must not be group/world readable");
+    }
+}

--- a/crates/mcp/src/completeness.rs
+++ b/crates/mcp/src/completeness.rs
@@ -21,6 +21,62 @@ pub fn assert_every_capability_has_a_tool(
     if missing.is_empty() { Ok(()) } else { Err(missing) }
 }
 
+/// A destructive capability that is not confirm-gated would be executable by
+/// any client with no consent step. Registering one must fail the build, not
+/// wait for a review to catch it.
+pub fn assert_destructive_capabilities_are_gated(reg: &srelens_capability::Registry) {
+    let ungated: Vec<String> = reg
+        .ids()
+        .into_iter()
+        .filter_map(|id| reg.get(id))
+        .filter(|c| c.annotations.destructive && !c.annotations.requires_confirm)
+        .map(|c| c.id.clone())
+        .collect();
+    assert!(
+        ungated.is_empty(),
+        "destructive capabilities are not confirm-gated: {ungated:?}"
+    );
+}
+
+#[cfg(test)]
+mod gate_tests {
+    use super::*;
+    use serde_json::json;
+    use srelens_capability::{Annotations, Capability, Registry};
+
+    #[test]
+    fn flags_a_destructive_capability_that_is_not_gated() {
+        let mut reg = Registry::new();
+        let mut cap = Capability::read_only("oops", "destroys without asking", |_| async {
+            Ok(json!({}))
+        });
+        cap.annotations = Annotations {
+            read_only: false,
+            destructive: true,
+            requires_confirm: false,
+            sensitive: false,
+        };
+        reg.register(cap);
+        let reg = std::panic::AssertUnwindSafe(reg);
+        let caught = std::panic::catch_unwind(|| assert_destructive_capabilities_are_gated(&reg));
+        assert!(
+            caught.is_err(),
+            "an ungated destructive capability must fail the assertion"
+        );
+    }
+
+    #[test]
+    fn passes_when_destructive_capability_requires_confirm() {
+        let mut reg = Registry::new();
+        let mut cap = Capability::read_only("safe-destroy", "destroys, but asks first", |_| {
+            async { Ok(json!({})) }
+        });
+        cap.annotations = Annotations::DESTRUCTIVE;
+        reg.register(cap);
+        assert_destructive_capabilities_are_gated(&reg);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/mcp/src/completeness.rs
+++ b/crates/mcp/src/completeness.rs
@@ -21,20 +21,29 @@ pub fn assert_every_capability_has_a_tool(
     if missing.is_empty() { Ok(()) } else { Err(missing) }
 }
 
-/// A destructive capability that is not confirm-gated would be executable by
-/// any client with no consent step. Registering one must fail the build, not
-/// wait for a review to catch it.
-pub fn assert_destructive_capabilities_are_gated(reg: &srelens_capability::Registry) {
+/// A capability that mutates something (i.e. is not `read_only`) but is not
+/// confirm-gated would be executable by any client with no consent step —
+/// whether or not it also happens to be flagged `destructive`. A capability
+/// can be non-destructive and still need consent (e.g. refreshing local
+/// cache state, installing a tool); the only annotation that actually gates
+/// execution is `requires_confirm` (see `McpServer::requires_confirm`), so
+/// that is what this checks. Registering an ungated mutating capability must
+/// fail the build, not wait for a review to catch it.
+///
+/// This subsumes the narrower "destructive but not confirm-gated" check:
+/// every destructive capability is also non-read-only, so any capability the
+/// old, narrower predicate would have flagged is still flagged here.
+pub fn assert_mutating_capabilities_are_gated(reg: &srelens_capability::Registry) {
     let ungated: Vec<String> = reg
         .ids()
         .into_iter()
         .filter_map(|id| reg.get(id))
-        .filter(|c| c.annotations.destructive && !c.annotations.requires_confirm)
+        .filter(|c| !c.annotations.read_only && !c.annotations.requires_confirm)
         .map(|c| c.id.clone())
         .collect();
     assert!(
         ungated.is_empty(),
-        "destructive capabilities are not confirm-gated: {ungated:?}"
+        "mutating capabilities are not confirm-gated: {ungated:?}"
     );
 }
 
@@ -45,10 +54,47 @@ mod gate_tests {
     use srelens_capability::{Annotations, Capability, Registry};
 
     #[test]
-    fn flags_a_destructive_capability_that_is_not_gated() {
+    fn flags_a_mutating_capability_that_is_not_gated() {
         let mut reg = Registry::new();
-        let mut cap = Capability::read_only("oops", "destroys without asking", |_| async {
+        let mut cap = Capability::read_only("oops", "mutates without asking", |_| async {
             Ok(json!({}))
+        });
+        cap.annotations = Annotations::default(); // read_only: false, requires_confirm: false
+        reg.register(cap);
+        let reg = std::panic::AssertUnwindSafe(reg);
+        let caught = std::panic::catch_unwind(|| assert_mutating_capabilities_are_gated(&reg));
+        assert!(
+            caught.is_err(),
+            "an ungated mutating capability must fail the assertion"
+        );
+    }
+
+    #[test]
+    fn does_not_flag_a_read_only_capability() {
+        let mut reg = Registry::new();
+        let cap = Capability::read_only("readit", "reads only", |_| async { Ok(json!({})) });
+        reg.register(cap);
+        assert_mutating_capabilities_are_gated(&reg);
+    }
+
+    #[test]
+    fn does_not_flag_a_confirm_gated_mutating_capability() {
+        let mut reg = Registry::new();
+        let mut cap = Capability::read_only("safe-mutate", "mutates, but asks first", |_| {
+            async { Ok(json!({})) }
+        });
+        cap.annotations = Annotations::MUTATING;
+        reg.register(cap);
+        assert_mutating_capabilities_are_gated(&reg);
+    }
+
+    #[test]
+    fn still_flags_a_destructive_capability_that_is_not_gated() {
+        // The narrower "destructive but ungated" case must still be caught
+        // by the widened predicate.
+        let mut reg = Registry::new();
+        let mut cap = Capability::read_only("oops-destroy", "destroys without asking", |_| {
+            async { Ok(json!({})) }
         });
         cap.annotations = Annotations {
             read_only: false,
@@ -58,22 +104,11 @@ mod gate_tests {
         };
         reg.register(cap);
         let reg = std::panic::AssertUnwindSafe(reg);
-        let caught = std::panic::catch_unwind(|| assert_destructive_capabilities_are_gated(&reg));
+        let caught = std::panic::catch_unwind(|| assert_mutating_capabilities_are_gated(&reg));
         assert!(
             caught.is_err(),
-            "an ungated destructive capability must fail the assertion"
+            "an ungated destructive capability must still fail the assertion"
         );
-    }
-
-    #[test]
-    fn passes_when_destructive_capability_requires_confirm() {
-        let mut reg = Registry::new();
-        let mut cap = Capability::read_only("safe-destroy", "destroys, but asks first", |_| {
-            async { Ok(json!({})) }
-        });
-        cap.annotations = Annotations::DESTRUCTIVE;
-        reg.register(cap);
-        assert_destructive_capabilities_are_gated(&reg);
     }
 }
 

--- a/crates/mcp/src/http.rs
+++ b/crates/mcp/src/http.rs
@@ -32,8 +32,24 @@ async fn rpc(State(server): State<Arc<McpServer>>, Json(req): Json<Value>) -> Js
 fn host_is_loopback(host: &str) -> bool {
     let h: &str = if let Some(rest) = host.strip_prefix('[') {
         // Bracketed IPv6, with or without a trailing `:port`. Split on `]`,
-        // never on `:`, so the address's own colons are never touched.
-        rest.split(']').next().unwrap_or("")
+        // never on `:`, so the address's own colons are never touched. The
+        // bracket must actually close, and whatever follows the `]` must be
+        // either nothing or a numeric `:port` — anything else (a bare
+        // trailing hostname, a stray `.evil.com`, a non-numeric "port") is
+        // not a valid authority and must reject, not fall through as if the
+        // bracketed address were the whole story.
+        let Some((inside, tail)) = rest.split_once(']') else {
+            return false;
+        };
+        let tail_ok = tail.is_empty()
+            || tail
+                .strip_prefix(':')
+                .map(|port| !port.is_empty() && port.bytes().all(|b| b.is_ascii_digit()))
+                .unwrap_or(false);
+        if !tail_ok {
+            return false;
+        }
+        inside
     } else if host.matches(':').count() > 1 {
         // Unbracketed IPv6 (e.g. bare "::1"): more than one colon means
         // there's no unambiguous port suffix, so treat it all as the host.
@@ -282,7 +298,21 @@ mod tests {
 
     #[test]
     fn host_is_loopback_rejects_non_loopback_forms() {
-        for host in ["evil.com", "evil.com:80", "127.0.0.1.evil.com"] {
+        for host in [
+            "evil.com",
+            "evil.com:80",
+            "127.0.0.1.evil.com",
+            "localhost.evil.com",
+            "",
+            // A closed bracket doesn't end the authority: anything after
+            // it other than a numeric `:port` must still reject, or a
+            // spoofed Host slips through as if `[::1]` were the whole
+            // story.
+            "[::1]evil.com",
+            "[::1].evil.com",
+            "[::1]:notaport",
+            "[::1]:",
+        ] {
             assert!(!host_is_loopback(host), "expected {host:?} to be rejected");
         }
     }

--- a/crates/mcp/src/http.rs
+++ b/crates/mcp/src/http.rs
@@ -23,11 +23,29 @@ async fn rpc(State(server): State<Arc<McpServer>>, Json(req): Json<Value>) -> Js
     }
 }
 
-/// True for `127.0.0.1[:port]`, `[::1]:port` and `localhost[:port]`.
+/// True for `127.0.0.1[:port]`, `[::1]`, `[::1]:port`, bare `::1`, and
+/// `localhost[:port]` (case-insensitively). Host header hostnames are
+/// case-insensitive per HTTP semantics, and IPv6 needs care: a bracketed
+/// address may carry a `:port` suffix outside the brackets, but the colons
+/// *inside* the brackets are part of the address, not port separators, and
+/// an unbracketed literal like `::1` has no unambiguous port syntax at all.
 fn host_is_loopback(host: &str) -> bool {
-    let h = host.rsplit_once(':').map(|(h, _)| h).unwrap_or(host);
-    let h = h.trim_start_matches('[').trim_end_matches(']');
-    h == "127.0.0.1" || h == "::1" || h == "localhost"
+    let h: &str = if let Some(rest) = host.strip_prefix('[') {
+        // Bracketed IPv6, with or without a trailing `:port`. Split on `]`,
+        // never on `:`, so the address's own colons are never touched.
+        rest.split(']').next().unwrap_or("")
+    } else if host.matches(':').count() > 1 {
+        // Unbracketed IPv6 (e.g. bare "::1"): more than one colon means
+        // there's no unambiguous port suffix, so treat it all as the host.
+        host
+    } else {
+        // "host:port" or a bare host — strip a numeric trailing port only.
+        match host.rsplit_once(':') {
+            Some((h, port)) if !port.is_empty() && port.bytes().all(|b| b.is_ascii_digit()) => h,
+            _ => host,
+        }
+    };
+    h.eq_ignore_ascii_case("127.0.0.1") || h == "::1" || h.eq_ignore_ascii_case("localhost")
 }
 
 async fn guard(
@@ -118,6 +136,8 @@ where
 mod tests {
     use super::*;
     use crate::McpServer;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
     use srelens_capability::{Capability, Registry};
     use tower::ServiceExt; // oneshot
 
@@ -131,9 +151,6 @@ mod tests {
 
     #[tokio::test]
     async fn http_handles_tools_call() {
-        use axum::body::Body;
-        use axum::http::{Request, StatusCode};
-
         let app = router(test_server());
         let body = json!({"jsonrpc":"2.0","id":1,"method":"tools/call",
             "params":{"name":"ping","arguments":"hi"}});
@@ -155,9 +172,6 @@ mod tests {
         assert_eq!(v["result"]["isError"], false);
         assert!(v["result"]["content"][0]["text"].as_str().unwrap().contains("echo"));
     }
-
-    use axum::body::Body;
-    use axum::http::{Request, StatusCode};
 
     fn call_body() -> Body {
         Body::from(
@@ -249,5 +263,44 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[test]
+    fn host_is_loopback_accepts_loopback_forms() {
+        for host in [
+            "[::1]",
+            "[::1]:8765",
+            "LOCALHOST",
+            "LocalHost:8765",
+            "127.0.0.1",
+            "127.0.0.1:8765",
+            "::1",
+        ] {
+            assert!(host_is_loopback(host), "expected {host:?} to be accepted");
+        }
+    }
+
+    #[test]
+    fn host_is_loopback_rejects_non_loopback_forms() {
+        for host in ["evil.com", "evil.com:80", "127.0.0.1.evil.com"] {
+            assert!(!host_is_loopback(host), "expected {host:?} to be rejected");
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_a_missing_host_header() {
+        let token = crate::auth::Token::generate();
+        let app = router_with_auth(test_server(), Some(token.clone()));
+        let resp = app
+            .oneshot(
+                Request::post("/mcp")
+                    .header("authorization", format!("Bearer {}", token.as_str()))
+                    .header("content-type", "application/json")
+                    .body(call_body())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     }
 }

--- a/crates/mcp/src/http.rs
+++ b/crates/mcp/src/http.rs
@@ -75,13 +75,11 @@ fn strip_bearer_prefix(header: &str) -> Option<&str> {
     scheme.eq_ignore_ascii_case("Bearer").then_some(rest)
 }
 
-async fn guard(
-    State(token): State<Option<crate::auth::Token>>,
-    req: Request,
-    next: Next,
-) -> Response {
-    // DNS rebinding: a page on evil.com can resolve to 127.0.0.1 and post
-    // here. Binding loopback does not stop it; checking Host does.
+/// Applied to EVERY route, including `/healthz`. DNS rebinding: a page on
+/// evil.com can resolve to 127.0.0.1 and reach this port. Binding loopback does
+/// not stop it; checking Host does. An unauthenticated route is still a signal
+/// — "something is listening here" — so the Host check has to cover it too.
+async fn host_guard(req: Request, next: Next) -> Response {
     let host_ok = req
         .headers()
         .get(axum::http::header::HOST)
@@ -91,7 +89,16 @@ async fn guard(
     if !host_ok {
         return (StatusCode::FORBIDDEN, "non-loopback Host rejected").into_response();
     }
+    next.run(req).await
+}
 
+/// Applied to `/mcp` only: `/healthz` is deliberately reachable without a
+/// token so a client can probe liveness before it has been configured.
+async fn token_guard(
+    State(token): State<Option<crate::auth::Token>>,
+    req: Request,
+    next: Next,
+) -> Response {
     if let Some(expected) = token {
         let presented = req
             .headers()
@@ -112,14 +119,22 @@ async fn guard(
     next.run(req).await
 }
 
-/// Build the MCP HTTP router (POST /mcp for JSON-RPC, GET /healthz). `token`
-/// of `None` disables auth and is for tests only — production hosts always
-/// pass a token.
-pub fn router_with_auth(server: McpServer, token: Option<crate::auth::Token>) -> Router {
+/// Build the MCP HTTP router (POST /mcp for JSON-RPC, GET /healthz). Requires a
+/// token: there is no way to ask this crate for an unauthenticated production
+/// server, because an `Option` here is an invitation to pass `None` by accident.
+pub fn router_with_auth(server: McpServer, token: crate::auth::Token) -> Router {
+    router_inner(server, Some(token))
+}
+
+/// Layering: the token check is a `route_layer` on `/mcp` alone, while the Host
+/// check is an outer `layer` covering every route (and unmatched paths), so
+/// nothing this server exposes answers a non-loopback caller.
+fn router_inner(server: McpServer, token: Option<crate::auth::Token>) -> Router {
     Router::new()
         .route("/mcp", post(rpc))
-        .route_layer(middleware::from_fn_with_state(token, guard))
+        .route_layer(middleware::from_fn_with_state(token, token_guard))
         .route("/healthz", get(|| async { "ok" }))
+        .layer(middleware::from_fn(host_guard))
         .with_state(Arc::new(server))
 }
 
@@ -128,14 +143,14 @@ pub fn router_with_auth(server: McpServer, token: Option<crate::auth::Token>) ->
 /// the kind of thing that gets called by accident later.
 #[cfg(test)]
 pub(crate) fn router(server: McpServer) -> Router {
-    router_with_auth(server, None)
+    router_inner(server, None)
 }
 
 /// Serve the MCP HTTP transport on `addr` (use a loopback address).
 pub async fn serve_http(
     server: McpServer,
     addr: SocketAddr,
-    token: Option<crate::auth::Token>,
+    token: crate::auth::Token,
 ) -> std::io::Result<()> {
     let listener = tokio::net::TcpListener::bind(addr).await?;
     axum::serve(listener, router_with_auth(server, token)).await
@@ -149,7 +164,7 @@ pub async fn serve_http_with_shutdown<F>(
     server: McpServer,
     listener: tokio::net::TcpListener,
     shutdown: F,
-    token: Option<crate::auth::Token>,
+    token: crate::auth::Token,
 ) -> std::io::Result<()>
 where
     F: std::future::Future<Output = ()> + Send + 'static,
@@ -212,7 +227,7 @@ mod tests {
     #[tokio::test]
     async fn rejects_a_request_with_no_token() {
         let token = crate::auth::Token::generate();
-        let app = router_with_auth(test_server(), Some(token));
+        let app = router_with_auth(test_server(), token);
         let resp = app
             .oneshot(
                 Request::post("/mcp")
@@ -229,7 +244,7 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_a_wrong_token() {
-        let app = router_with_auth(test_server(), Some(crate::auth::Token::generate()));
+        let app = router_with_auth(test_server(), crate::auth::Token::generate());
         let resp = app
             .oneshot(
                 Request::post("/mcp")
@@ -250,7 +265,7 @@ mod tests {
     #[tokio::test]
     async fn accepts_a_lowercase_bearer_scheme() {
         let token = crate::auth::Token::generate();
-        let app = router_with_auth(test_server(), Some(token.clone()));
+        let app = router_with_auth(test_server(), token.clone());
         let resp = app
             .oneshot(
                 Request::post("/mcp")
@@ -268,7 +283,7 @@ mod tests {
     #[tokio::test]
     async fn accepts_the_right_token() {
         let token = crate::auth::Token::generate();
-        let app = router_with_auth(test_server(), Some(token.clone()));
+        let app = router_with_auth(test_server(), token.clone());
         let resp = app
             .oneshot(
                 Request::post("/mcp")
@@ -288,7 +303,7 @@ mod tests {
     #[tokio::test]
     async fn rejects_a_non_loopback_host_header() {
         let token = crate::auth::Token::generate();
-        let app = router_with_auth(test_server(), Some(token.clone()));
+        let app = router_with_auth(test_server(), token.clone());
         let resp = app
             .oneshot(
                 Request::post("/mcp")
@@ -305,12 +320,37 @@ mod tests {
 
     #[tokio::test]
     async fn healthz_needs_no_token() {
-        let app = router_with_auth(test_server(), Some(crate::auth::Token::generate()));
+        let app = router_with_auth(test_server(), crate::auth::Token::generate());
         let resp = app
-            .oneshot(Request::get("/healthz").body(Body::empty()).unwrap())
+            .oneshot(
+                Request::get("/healthz")
+                    .header("host", "127.0.0.1:8765")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    /// `/healthz` deliberately needs no token, but that must not make it a
+    /// free "is srelens listening on this port?" oracle for any process or web
+    /// page sweeping loopback ports. The Host check is what makes the answer
+    /// unavailable to a caller that isn't genuinely local, so it has to cover
+    /// every route, not just `/mcp`.
+    #[tokio::test]
+    async fn healthz_rejects_a_non_loopback_host() {
+        let app = router_with_auth(test_server(), crate::auth::Token::generate());
+        let resp = app
+            .oneshot(
+                Request::get("/healthz")
+                    .header("host", "evil.com")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     }
 
     #[test]
@@ -352,7 +392,7 @@ mod tests {
     #[tokio::test]
     async fn rejects_a_missing_host_header() {
         let token = crate::auth::Token::generate();
-        let app = router_with_auth(test_server(), Some(token.clone()));
+        let app = router_with_auth(test_server(), token.clone());
         let resp = app
             .oneshot(
                 Request::post("/mcp")

--- a/crates/mcp/src/http.rs
+++ b/crates/mcp/src/http.rs
@@ -5,7 +5,10 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use axum::extract::State;
+use axum::extract::{Request, State};
+use axum::http::StatusCode;
+use axum::middleware::{self, Next};
+use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde_json::{json, Value};
@@ -20,18 +23,77 @@ async fn rpc(State(server): State<Arc<McpServer>>, Json(req): Json<Value>) -> Js
     }
 }
 
-/// Build the MCP HTTP router (POST /mcp for JSON-RPC, GET /healthz).
-pub fn router(server: McpServer) -> Router {
+/// True for `127.0.0.1[:port]`, `[::1]:port` and `localhost[:port]`.
+fn host_is_loopback(host: &str) -> bool {
+    let h = host.rsplit_once(':').map(|(h, _)| h).unwrap_or(host);
+    let h = h.trim_start_matches('[').trim_end_matches(']');
+    h == "127.0.0.1" || h == "::1" || h == "localhost"
+}
+
+async fn guard(
+    State(token): State<Option<crate::auth::Token>>,
+    req: Request,
+    next: Next,
+) -> Response {
+    // DNS rebinding: a page on evil.com can resolve to 127.0.0.1 and post
+    // here. Binding loopback does not stop it; checking Host does.
+    let host_ok = req
+        .headers()
+        .get(axum::http::header::HOST)
+        .and_then(|v| v.to_str().ok())
+        .map(host_is_loopback)
+        .unwrap_or(false);
+    if !host_ok {
+        return (StatusCode::FORBIDDEN, "non-loopback Host rejected").into_response();
+    }
+
+    if let Some(expected) = token {
+        let presented = req
+            .headers()
+            .get(axum::http::header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.strip_prefix("Bearer "))
+            .unwrap_or("");
+        if !expected.matches(presented) {
+            // No detail in the body: do not reveal whether a token is set.
+            return (
+                StatusCode::UNAUTHORIZED,
+                [(axum::http::header::WWW_AUTHENTICATE, "Bearer")],
+                "unauthorized",
+            )
+                .into_response();
+        }
+    }
+    next.run(req).await
+}
+
+/// Build the MCP HTTP router (POST /mcp for JSON-RPC, GET /healthz). `token`
+/// of `None` disables auth and is for tests only — production hosts always
+/// pass a token.
+pub fn router_with_auth(server: McpServer, token: Option<crate::auth::Token>) -> Router {
     Router::new()
         .route("/mcp", post(rpc))
+        .route_layer(middleware::from_fn_with_state(token, guard))
         .route("/healthz", get(|| async { "ok" }))
         .with_state(Arc::new(server))
 }
 
+/// Test-only convenience: a router with authentication disabled. Never
+/// available to production code — a public no-auth constructor is exactly
+/// the kind of thing that gets called by accident later.
+#[cfg(test)]
+pub(crate) fn router(server: McpServer) -> Router {
+    router_with_auth(server, None)
+}
+
 /// Serve the MCP HTTP transport on `addr` (use a loopback address).
-pub async fn serve_http(server: McpServer, addr: SocketAddr) -> std::io::Result<()> {
+pub async fn serve_http(
+    server: McpServer,
+    addr: SocketAddr,
+    token: Option<crate::auth::Token>,
+) -> std::io::Result<()> {
     let listener = tokio::net::TcpListener::bind(addr).await?;
-    axum::serve(listener, router(server)).await
+    axum::serve(listener, router_with_auth(server, token)).await
 }
 
 /// Serve on an already-bound `listener` until `shutdown` resolves. Lets a host
@@ -42,11 +104,12 @@ pub async fn serve_http_with_shutdown<F>(
     server: McpServer,
     listener: tokio::net::TcpListener,
     shutdown: F,
+    token: Option<crate::auth::Token>,
 ) -> std::io::Result<()>
 where
     F: std::future::Future<Output = ()> + Send + 'static,
 {
-    axum::serve(listener, router(server))
+    axum::serve(listener, router_with_auth(server, token))
         .with_graceful_shutdown(shutdown)
         .await
 }
@@ -58,7 +121,7 @@ mod tests {
     use srelens_capability::{Capability, Registry};
     use tower::ServiceExt; // oneshot
 
-    fn server() -> McpServer {
+    fn test_server() -> McpServer {
         let mut reg = Registry::new();
         reg.register(Capability::read_only("ping", "health", |v| async move {
             Ok(json!({ "echo": v }))
@@ -71,7 +134,7 @@ mod tests {
         use axum::body::Body;
         use axum::http::{Request, StatusCode};
 
-        let app = router(server());
+        let app = router(test_server());
         let body = json!({"jsonrpc":"2.0","id":1,"method":"tools/call",
             "params":{"name":"ping","arguments":"hi"}});
         let resp = app
@@ -79,6 +142,7 @@ mod tests {
                 Request::builder()
                     .method("POST")
                     .uri("/mcp")
+                    .header("host", "127.0.0.1:8765")
                     .header("content-type", "application/json")
                     .body(Body::from(body.to_string()))
                     .unwrap(),
@@ -90,5 +154,100 @@ mod tests {
         let v: Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(v["result"]["isError"], false);
         assert!(v["result"]["content"][0]["text"].as_str().unwrap().contains("echo"));
+    }
+
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+
+    fn call_body() -> Body {
+        Body::from(
+            serde_json::to_vec(&json!({
+                "jsonrpc": "2.0", "id": 1, "method": "tools/list"
+            }))
+            .unwrap(),
+        )
+    }
+
+    #[tokio::test]
+    async fn rejects_a_request_with_no_token() {
+        let token = crate::auth::Token::generate();
+        let app = router_with_auth(test_server(), Some(token));
+        let resp = app
+            .oneshot(
+                Request::post("/mcp")
+                    .header("host", "127.0.0.1:8765")
+                    .header("content-type", "application/json")
+                    .body(call_body())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        assert!(resp.headers().get("www-authenticate").is_some());
+    }
+
+    #[tokio::test]
+    async fn rejects_a_wrong_token() {
+        let app = router_with_auth(test_server(), Some(crate::auth::Token::generate()));
+        let resp = app
+            .oneshot(
+                Request::post("/mcp")
+                    .header("host", "127.0.0.1:8765")
+                    .header("authorization", format!("Bearer {}", "a".repeat(64)))
+                    .header("content-type", "application/json")
+                    .body(call_body())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn accepts_the_right_token() {
+        let token = crate::auth::Token::generate();
+        let app = router_with_auth(test_server(), Some(token.clone()));
+        let resp = app
+            .oneshot(
+                Request::post("/mcp")
+                    .header("host", "127.0.0.1:8765")
+                    .header("authorization", format!("Bearer {}", token.as_str()))
+                    .header("content-type", "application/json")
+                    .body(call_body())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    /// Loopback binding does NOT stop a page on evil.com that resolves to
+    /// 127.0.0.1 from posting here. A Host check does.
+    #[tokio::test]
+    async fn rejects_a_non_loopback_host_header() {
+        let token = crate::auth::Token::generate();
+        let app = router_with_auth(test_server(), Some(token.clone()));
+        let resp = app
+            .oneshot(
+                Request::post("/mcp")
+                    .header("host", "evil.com")
+                    .header("authorization", format!("Bearer {}", token.as_str()))
+                    .header("content-type", "application/json")
+                    .body(call_body())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn healthz_needs_no_token() {
+        let app = router_with_auth(test_server(), Some(crate::auth::Token::generate()));
+        let resp = app
+            .oneshot(Request::get("/healthz").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
     }
 }

--- a/crates/mcp/src/http.rs
+++ b/crates/mcp/src/http.rs
@@ -64,6 +64,17 @@ fn host_is_loopback(host: &str) -> bool {
     h.eq_ignore_ascii_case("127.0.0.1") || h == "::1" || h.eq_ignore_ascii_case("localhost")
 }
 
+/// Strip a leading `Bearer ` auth scheme from an `Authorization` header value.
+/// RFC 7235 §2.1 makes the scheme name case-insensitive ("bearer", "BEARER",
+/// "Bearer" all name the same scheme) — only the scheme, not the credentials
+/// that follow, so this does a case-insensitive match on `"Bearer"` alone and
+/// leaves the token half untouched for `Token::matches`'s constant-time
+/// comparison.
+fn strip_bearer_prefix(header: &str) -> Option<&str> {
+    let (scheme, rest) = header.split_once(' ')?;
+    scheme.eq_ignore_ascii_case("Bearer").then_some(rest)
+}
+
 async fn guard(
     State(token): State<Option<crate::auth::Token>>,
     req: Request,
@@ -86,7 +97,7 @@ async fn guard(
             .headers()
             .get(axum::http::header::AUTHORIZATION)
             .and_then(|v| v.to_str().ok())
-            .and_then(|v| v.strip_prefix("Bearer "))
+            .and_then(strip_bearer_prefix)
             .unwrap_or("");
         if !expected.matches(presented) {
             // No detail in the body: do not reveal whether a token is set.
@@ -231,6 +242,27 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    /// RFC 7235 §2.1: the auth scheme name is case-insensitive, so a client
+    /// sending `bearer <token>` (lowercase) must still authenticate — not get
+    /// a 401 that reads as a wrong token.
+    #[tokio::test]
+    async fn accepts_a_lowercase_bearer_scheme() {
+        let token = crate::auth::Token::generate();
+        let app = router_with_auth(test_server(), Some(token.clone()));
+        let resp = app
+            .oneshot(
+                Request::post("/mcp")
+                    .header("host", "127.0.0.1:8765")
+                    .header("authorization", format!("bearer {}", token.as_str()))
+                    .header("content-type", "application/json")
+                    .body(call_body())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
     }
 
     #[tokio::test]

--- a/crates/mcp/src/http.rs
+++ b/crates/mcp/src/http.rs
@@ -14,7 +14,7 @@ use crate::stdio::handle_request;
 use crate::McpServer;
 
 async fn rpc(State(server): State<Arc<McpServer>>, Json(req): Json<Value>) -> Json<Value> {
-    match handle_request(&server, &req).await {
+    match handle_request(&server, &req, crate::Transport::Http).await {
         Some(resp) => Json(resp),
         None => Json(json!({})), // notification — no response body
     }

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -1,6 +1,7 @@
 //! Bridges the capability registry to the Model Context Protocol.
 
 pub mod audit;
+pub mod auth;
 pub mod completeness;
 pub mod http;
 pub mod policy;

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -38,6 +38,7 @@ impl Transport {
 pub struct McpServer {
     registry: Arc<Registry>,
     confirm_policy: Arc<dyn crate::policy::ConfirmPolicy>,
+    audit: Arc<dyn crate::audit::AuditSink>,
 }
 
 impl McpServer {
@@ -46,6 +47,7 @@ impl McpServer {
             registry,
             // Fail closed: a host that wires nothing permits nothing.
             confirm_policy: Arc::new(crate::policy::AlwaysDeny),
+            audit: Arc::new(crate::audit::NoopAudit),
         }
     }
 
@@ -56,6 +58,24 @@ impl McpServer {
 
     pub fn confirm_policy(&self) -> &Arc<dyn crate::policy::ConfirmPolicy> {
         &self.confirm_policy
+    }
+
+    pub fn with_audit(mut self, audit: Arc<dyn crate::audit::AuditSink>) -> Self {
+        self.audit = audit;
+        self
+    }
+
+    pub fn audit(&self) -> &Arc<dyn crate::audit::AuditSink> {
+        &self.audit
+    }
+
+    /// Whether a tool reads sensitive material, so the audit log can redact
+    /// its arguments wholesale.
+    pub fn is_sensitive(&self, name: &str) -> bool {
+        self.registry
+            .get(name)
+            .map(|c| c.annotations.sensitive)
+            .unwrap_or(false)
     }
 
     pub fn list_tools(&self) -> Vec<ToolDescriptor> {

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -101,10 +101,28 @@ impl McpServer {
     /// confirmation (e.g. `k8s.getSecret`, which is a `SENSITIVE_READ` and so
     /// sets `requires_confirm` itself even though it's read-only).
     pub fn requires_confirm(&self, name: &str) -> bool {
-        self.registry
-            .get(name)
-            .map(|c| c.annotations.requires_confirm || c.annotations.destructive)
-            .unwrap_or(false)
+        self.consent_kind(name).is_some()
+    }
+
+    /// *Why* a tool needs consent, or `None` if it doesn't — the single source
+    /// of truth for the gate in `handle_request`.
+    ///
+    /// The split reads off `read_only`, not `sensitive`: a gated capability
+    /// that changes nothing is gated because of what it *returns*
+    /// (`SENSITIVE_READ`), while anything else gated mutates something. Using
+    /// `sensitive` here would misfile `k8s.diffManifest`, which is `sensitive`
+    /// (its output can echo Secret data, so the audit log redacts it) but
+    /// isn't gated at all.
+    pub fn consent_kind(&self, name: &str) -> Option<crate::policy::ConsentKind> {
+        let cap = self.registry.get(name)?;
+        if !(cap.annotations.requires_confirm || cap.annotations.destructive) {
+            return None;
+        }
+        Some(if cap.annotations.read_only {
+            crate::policy::ConsentKind::SensitiveRead
+        } else {
+            crate::policy::ConsentKind::Destructive
+        })
     }
 }
 
@@ -156,6 +174,90 @@ mod tests {
             server.requires_confirm("k8s.getSecret"),
             "a sensitive-read capability must be consent-gated"
         );
+    }
+
+    /// A gated capability that changes nothing is gated for what it RETURNS,
+    /// so it must classify as a sensitive read — otherwise headless operators
+    /// are back to needing `--mcp-allow-destructive` to read a Secret.
+    #[tokio::test]
+    async fn a_gated_read_only_capability_is_a_sensitive_read() {
+        let mut reg = Registry::new();
+        let mut cap = Capability::read_only("k8s.getSecret", "reads a secret", |_| async {
+            Ok(json!({}))
+        });
+        cap.annotations = srelens_capability::Annotations::SENSITIVE_READ;
+        reg.register(cap);
+        let server = McpServer::new(Arc::new(reg));
+
+        assert_eq!(
+            server.consent_kind("k8s.getSecret"),
+            Some(crate::policy::ConsentKind::SensitiveRead)
+        );
+    }
+
+    /// A gated capability that mutates classifies as destructive, whether or
+    /// not it is flagged `destructive` — `MUTATING` (e.g. `k8s.applyManifest`,
+    /// `k8s.helmRepoUpdate`) changes state and belongs behind the write flag.
+    #[tokio::test]
+    async fn a_gated_mutating_capability_is_destructive() {
+        let mut reg = Registry::new();
+        let mut destructive = Capability::read_only("k8s.deletePod", "deletes", |_| async {
+            Ok(json!({}))
+        });
+        destructive.annotations = srelens_capability::Annotations::DESTRUCTIVE;
+        reg.register(destructive);
+        let mut mutating = Capability::read_only("k8s.applyManifest", "applies", |_| async {
+            Ok(json!({}))
+        });
+        mutating.annotations = srelens_capability::Annotations::MUTATING;
+        reg.register(mutating);
+        let server = McpServer::new(Arc::new(reg));
+
+        assert_eq!(
+            server.consent_kind("k8s.deletePod"),
+            Some(crate::policy::ConsentKind::Destructive)
+        );
+        assert_eq!(
+            server.consent_kind("k8s.applyManifest"),
+            Some(crate::policy::ConsentKind::Destructive),
+            "a non-destructive mutation still belongs behind the write flag"
+        );
+    }
+
+    /// The case that pins WHICH annotation drives the split. `SENSITIVE_READ`
+    /// happens to set both `read_only` and `sensitive`, so the two readings
+    /// agree there and neither of the tests above can tell them apart. They
+    /// diverge on a capability that mutates AND handles sensitive material —
+    /// a Secret write, say. Classifying that as a sensitive read would mean
+    /// `--mcp-allow-sensitive-reads` alone authorizes *modifying* Secrets:
+    /// read permission escalating to write. It mutates, so it is destructive.
+    #[tokio::test]
+    async fn a_gated_capability_that_mutates_sensitive_data_is_destructive() {
+        let mut reg = Registry::new();
+        let mut cap = Capability::read_only("k8s.updateConfigData", "writes a Secret", |_| async {
+            Ok(json!({}))
+        });
+        cap.annotations = srelens_capability::Annotations {
+            read_only: false,
+            destructive: false,
+            requires_confirm: true,
+            sensitive: true,
+        };
+        reg.register(cap);
+        let server = McpServer::new(Arc::new(reg));
+
+        assert_eq!(
+            server.consent_kind("k8s.updateConfigData"),
+            Some(crate::policy::ConsentKind::Destructive),
+            "a sensitive WRITE must not be unlocked by the sensitive-read flag"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_ungated_capability_has_no_consent_kind() {
+        let server = McpServer::new(registry_with_ping());
+        assert_eq!(server.consent_kind("ping"), None);
+        assert_eq!(server.consent_kind("no-such-tool"), None);
     }
 
     #[tokio::test]

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -17,13 +17,44 @@ pub struct ToolDescriptor {
     pub input_schema: Value,
 }
 
+/// Which transport a request arrived on. Recorded in the audit log and used to
+/// tell an operator how an agent reached them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Transport {
+    Stdio,
+    Http,
+}
+
+impl Transport {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Transport::Stdio => "stdio",
+            Transport::Http => "http",
+        }
+    }
+}
+
 pub struct McpServer {
     registry: Arc<Registry>,
+    confirm_policy: Arc<dyn crate::policy::ConfirmPolicy>,
 }
 
 impl McpServer {
     pub fn new(registry: Arc<Registry>) -> Self {
-        Self { registry }
+        Self {
+            registry,
+            // Fail closed: a host that wires nothing permits nothing.
+            confirm_policy: Arc::new(crate::policy::AlwaysDeny),
+        }
+    }
+
+    pub fn with_policy(mut self, policy: Arc<dyn crate::policy::ConfirmPolicy>) -> Self {
+        self.confirm_policy = policy;
+        self
+    }
+
+    pub fn confirm_policy(&self) -> &Arc<dyn crate::policy::ConfirmPolicy> {
+        &self.confirm_policy
     }
 
     pub fn list_tools(&self) -> Vec<ToolDescriptor> {

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod completeness;
 pub mod http;
+pub mod policy;
 pub mod stdio;
 
 use std::sync::Arc;

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -97,15 +97,13 @@ impl McpServer {
     }
 
     /// Whether a tool should be consent-gated over remote transports: it
-    /// mutates the cluster (destructive or confirmation-requiring), or it
-    /// reads sensitive material (e.g. `k8s.getSecret`) — a read causes no
-    /// cluster damage, but handing raw Secret material to whichever client
-    /// happens to be connected is exactly the kind of call a human should see
-    /// first.
+    /// mutates the cluster (destructive), or otherwise requires explicit
+    /// confirmation (e.g. `k8s.getSecret`, which is a `SENSITIVE_READ` and so
+    /// sets `requires_confirm` itself even though it's read-only).
     pub fn requires_confirm(&self, name: &str) -> bool {
         self.registry
             .get(name)
-            .map(|c| c.annotations.requires_confirm || c.annotations.destructive || c.annotations.sensitive)
+            .map(|c| c.annotations.requires_confirm || c.annotations.destructive)
             .unwrap_or(false)
     }
 }
@@ -141,8 +139,9 @@ mod tests {
     }
 
     /// The vulnerability this closes: a `SENSITIVE_READ` capability like
-    /// `k8s.getSecret` mutates nothing, so `destructive`/`requires_confirm`
-    /// alone let it run with no prompt at all. `sensitive` must gate it too.
+    /// `k8s.getSecret` mutates nothing, so plain `destructive` gating alone
+    /// would let it run with no prompt at all. `SENSITIVE_READ` sets
+    /// `requires_confirm: true` itself to close that gap.
     #[tokio::test]
     async fn sensitive_read_capability_requires_confirm() {
         let mut reg = Registry::new();
@@ -163,5 +162,33 @@ mod tests {
     async fn plain_read_only_capability_does_not_require_confirm() {
         let server = McpServer::new(registry_with_ping());
         assert!(!server.requires_confirm("ping"));
+    }
+
+    /// Regression test for the collateral gating this branch fixes:
+    /// `k8s.diffManifest` is read-only and sets `sensitive: true` (its diff
+    /// output can echo Secret data, so it's redacted in the audit log) but is
+    /// NOT `requires_confirm` and NOT `destructive` — it makes no cluster
+    /// change (a server dry-run apply). `sensitive` alone must not gate it,
+    /// or a purely read-only tool gets denied over headless MCP with a
+    /// mutation warning it doesn't deserve.
+    #[tokio::test]
+    async fn sensitive_but_not_confirm_gated_capability_is_not_gated() {
+        let mut reg = Registry::new();
+        let mut cap = Capability::read_only("k8s.diffManifest", "diff a manifest", |_| async {
+            Ok(json!({}))
+        });
+        cap.annotations = srelens_capability::Annotations {
+            read_only: true,
+            destructive: false,
+            requires_confirm: false,
+            sensitive: true,
+        };
+        reg.register(cap);
+        let server = McpServer::new(Arc::new(reg));
+
+        assert!(
+            !server.requires_confirm("k8s.diffManifest"),
+            "a read-only, non-confirm-requiring capability must not be gated just because it is sensitive"
+        );
     }
 }

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -1,5 +1,6 @@
 //! Bridges the capability registry to the Model Context Protocol.
 
+pub mod audit;
 pub mod completeness;
 pub mod http;
 pub mod policy;

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -96,12 +96,16 @@ impl McpServer {
         self.registry.invoke(name, args).await
     }
 
-    /// Whether a tool mutates the cluster and should be consent-gated over
-    /// remote transports (destructive or confirmation-requiring capabilities).
+    /// Whether a tool should be consent-gated over remote transports: it
+    /// mutates the cluster (destructive or confirmation-requiring), or it
+    /// reads sensitive material (e.g. `k8s.getSecret`) — a read causes no
+    /// cluster damage, but handing raw Secret material to whichever client
+    /// happens to be connected is exactly the kind of call a human should see
+    /// first.
     pub fn requires_confirm(&self, name: &str) -> bool {
         self.registry
             .get(name)
-            .map(|c| c.annotations.requires_confirm || c.annotations.destructive)
+            .map(|c| c.annotations.requires_confirm || c.annotations.destructive || c.annotations.sensitive)
             .unwrap_or(false)
     }
 }
@@ -134,5 +138,30 @@ mod tests {
         let server = McpServer::new(registry_with_ping());
         let out = server.call_tool("ping", json!("hi")).await.unwrap();
         assert_eq!(out, json!({ "echo": "hi" }));
+    }
+
+    /// The vulnerability this closes: a `SENSITIVE_READ` capability like
+    /// `k8s.getSecret` mutates nothing, so `destructive`/`requires_confirm`
+    /// alone let it run with no prompt at all. `sensitive` must gate it too.
+    #[tokio::test]
+    async fn sensitive_read_capability_requires_confirm() {
+        let mut reg = Registry::new();
+        let mut cap = Capability::read_only("k8s.getSecret", "reads a secret", |_| async {
+            Ok(json!({}))
+        });
+        cap.annotations = srelens_capability::Annotations::SENSITIVE_READ;
+        reg.register(cap);
+        let server = McpServer::new(Arc::new(reg));
+
+        assert!(
+            server.requires_confirm("k8s.getSecret"),
+            "a sensitive-read capability must be consent-gated"
+        );
+    }
+
+    #[tokio::test]
+    async fn plain_read_only_capability_does_not_require_confirm() {
+        let server = McpServer::new(registry_with_ping());
+        assert!(!server.requires_confirm("ping"));
     }
 }

--- a/crates/mcp/src/policy.rs
+++ b/crates/mcp/src/policy.rs
@@ -11,48 +11,90 @@ pub enum Decision {
     Denied(String),
 }
 
-#[async_trait::async_trait]
-pub trait ConfirmPolicy: Send + Sync {
-    async fn confirm(&self, tool: &str, args: &Value) -> Decision;
+/// Why a tool needs consent. These are different risks with different blast
+/// radii, so a headless operator can grant one without the other: letting an
+/// agent read a Secret should not also let it drain a node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConsentKind {
+    /// Changes cluster state (or local host state, e.g. installing a tool).
+    Destructive,
+    /// Changes nothing, but returns sensitive material — `k8s.getSecret` and
+    /// anything else annotated `SENSITIVE_READ`.
+    SensitiveRead,
 }
 
-/// The default. A host that wires no policy must not permit destructive tools.
+impl ConsentKind {
+    /// The CLI flag that opts a headless process in to this kind of call.
+    pub fn flag(self) -> &'static str {
+        match self {
+            ConsentKind::Destructive => "--mcp-allow-destructive",
+            ConsentKind::SensitiveRead => "--mcp-allow-sensitive-reads",
+        }
+    }
+
+    /// What the tool does, for a denial an agent has to act on.
+    fn effect(self) -> &'static str {
+        match self {
+            ConsentKind::Destructive => "mutates the cluster",
+            ConsentKind::SensitiveRead => "returns sensitive material",
+        }
+    }
+}
+
+#[async_trait::async_trait]
+pub trait ConfirmPolicy: Send + Sync {
+    async fn confirm(&self, tool: &str, args: &Value, kind: ConsentKind) -> Decision;
+}
+
+/// The default. A host that wires no policy must not permit gated tools.
 pub struct AlwaysDeny;
 
-/// Headless policy: the operator opts the process in with
-/// `--mcp-allow-destructive` AND the caller states intent with `_confirm: true`.
-/// Neither alone is sufficient.
+/// Headless policy: the operator opts the process in with the flag matching the
+/// call's [`ConsentKind`] AND the caller states intent with `_confirm: true`.
+/// Neither alone is sufficient, and neither flag implies the other.
 pub struct FlagGated {
     allow_destructive: bool,
+    allow_sensitive_reads: bool,
 }
 
 impl FlagGated {
-    pub fn new(allow_destructive: bool) -> Self {
-        Self { allow_destructive }
+    pub fn new(allow_destructive: bool, allow_sensitive_reads: bool) -> Self {
+        Self { allow_destructive, allow_sensitive_reads }
+    }
+
+    fn allows(&self, kind: ConsentKind) -> bool {
+        match kind {
+            ConsentKind::Destructive => self.allow_destructive,
+            ConsentKind::SensitiveRead => self.allow_sensitive_reads,
+        }
     }
 }
 
 #[async_trait::async_trait]
 impl ConfirmPolicy for AlwaysDeny {
-    async fn confirm(&self, tool: &str, _args: &Value) -> Decision {
+    async fn confirm(&self, tool: &str, _args: &Value, kind: ConsentKind) -> Decision {
         Decision::Denied(format!(
-            "`{tool}` mutates the cluster and no consent mechanism is configured for this srelens process"
+            "`{tool}` {} and no consent mechanism is configured for this srelens process",
+            kind.effect()
         ))
     }
 }
 
 #[async_trait::async_trait]
 impl ConfirmPolicy for FlagGated {
-    async fn confirm(&self, tool: &str, args: &Value) -> Decision {
-        if !self.allow_destructive {
+    async fn confirm(&self, tool: &str, args: &Value, kind: ConsentKind) -> Decision {
+        if !self.allows(kind) {
             return Decision::Denied(format!(
-                "`{tool}` mutates the cluster; this srelens process was not started with --mcp-allow-destructive"
+                "`{tool}` {}; this srelens process was not started with {}",
+                kind.effect(),
+                kind.flag()
             ));
         }
         let confirmed = args.get("_confirm").and_then(Value::as_bool).unwrap_or(false);
         if !confirmed {
             return Decision::Denied(format!(
-                "`{tool}` mutates the cluster. Re-send with \"_confirm\": true to state intent."
+                "`{tool}` {}. Re-send with \"_confirm\": true to state intent.",
+                kind.effect()
             ));
         }
         Decision::Approved
@@ -64,32 +106,100 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    /// Both flags on — the baseline for tests about `_confirm` rather than
+    /// about which flag gates which kind.
+    fn permissive() -> FlagGated {
+        FlagGated::new(true, true)
+    }
+
     #[tokio::test]
     async fn always_deny_refuses_everything() {
-        let d = AlwaysDeny.confirm("k8s_deletePod", &json!({})).await;
+        let d = AlwaysDeny
+            .confirm("k8s_deletePod", &json!({}), ConsentKind::Destructive)
+            .await;
+        assert!(matches!(d, Decision::Denied(_)));
+    }
+
+    #[tokio::test]
+    async fn always_deny_refuses_a_sensitive_read_too() {
+        let d = AlwaysDeny
+            .confirm("k8s.getSecret", &json!({}), ConsentKind::SensitiveRead)
+            .await;
         assert!(matches!(d, Decision::Denied(_)));
     }
 
     #[tokio::test]
     async fn flag_gated_requires_both_flag_and_confirm() {
-        let with_flag = FlagGated::new(true);
-        let without_flag = FlagGated::new(false);
+        let with_flag = permissive();
+        let without_flag = FlagGated::new(false, false);
         let confirmed = json!({ "_confirm": true });
         let bare = json!({});
+        let k = ConsentKind::Destructive;
 
         // The full 2x2. Only flag AND _confirm approves.
-        assert_eq!(with_flag.confirm("t", &confirmed).await, Decision::Approved);
-        assert!(matches!(with_flag.confirm("t", &bare).await, Decision::Denied(_)));
-        assert!(matches!(without_flag.confirm("t", &confirmed).await, Decision::Denied(_)));
-        assert!(matches!(without_flag.confirm("t", &bare).await, Decision::Denied(_)));
+        assert_eq!(with_flag.confirm("t", &confirmed, k).await, Decision::Approved);
+        assert!(matches!(with_flag.confirm("t", &bare, k).await, Decision::Denied(_)));
+        assert!(matches!(without_flag.confirm("t", &confirmed, k).await, Decision::Denied(_)));
+        assert!(matches!(without_flag.confirm("t", &bare, k).await, Decision::Denied(_)));
     }
 
     #[tokio::test]
     async fn flag_gated_denial_explains_which_half_is_missing() {
-        let d = FlagGated::new(false).confirm("t", &json!({ "_confirm": true })).await;
+        let d = FlagGated::new(false, false)
+            .confirm("t", &json!({ "_confirm": true }), ConsentKind::Destructive)
+            .await;
         match d {
             Decision::Denied(r) => assert!(r.contains("--mcp-allow-destructive"), "got: {r}"),
             other => panic!("expected denial, got {other:?}"),
         }
+    }
+
+    /// The point of the split: authorizing an agent to READ a Secret must not
+    /// also authorize it to delete or drain anything. Granting only
+    /// `--mcp-allow-sensitive-reads` lets `k8s.getSecret` through...
+    #[tokio::test]
+    async fn allowing_sensitive_reads_authorizes_a_sensitive_read() {
+        let d = FlagGated::new(false, true)
+            .confirm("k8s.getSecret", &json!({ "_confirm": true }), ConsentKind::SensitiveRead)
+            .await;
+        assert_eq!(d, Decision::Approved);
+    }
+
+    /// ...and must NOT let a mutating tool through.
+    #[tokio::test]
+    async fn allowing_sensitive_reads_does_not_authorize_a_destructive_tool() {
+        let d = FlagGated::new(false, true)
+            .confirm("k8s.deletePod", &json!({ "_confirm": true }), ConsentKind::Destructive)
+            .await;
+        match d {
+            Decision::Denied(r) => assert!(r.contains("--mcp-allow-destructive"), "got: {r}"),
+            other => panic!("expected denial, got {other:?}"),
+        }
+    }
+
+    /// The converse, which is the actual bug being fixed: before the split,
+    /// `--mcp-allow-destructive` was the only way to read a Secret headless.
+    /// Now the destructive flag alone must not unlock sensitive reads.
+    #[tokio::test]
+    async fn allowing_destructive_does_not_authorize_a_sensitive_read() {
+        let d = FlagGated::new(true, false)
+            .confirm("k8s.getSecret", &json!({ "_confirm": true }), ConsentKind::SensitiveRead)
+            .await;
+        match d {
+            Decision::Denied(r) => {
+                assert!(r.contains("--mcp-allow-sensitive-reads"), "got: {r}")
+            }
+            other => panic!("expected denial, got {other:?}"),
+        }
+    }
+
+    /// A sensitive read still needs stated intent, exactly like a mutation:
+    /// the flag opts the process in, `_confirm` opts the individual call in.
+    #[tokio::test]
+    async fn a_sensitive_read_still_needs_confirm() {
+        let d = FlagGated::new(true, true)
+            .confirm("k8s.getSecret", &json!({}), ConsentKind::SensitiveRead)
+            .await;
+        assert!(matches!(d, Decision::Denied(_)));
     }
 }

--- a/crates/mcp/src/policy.rs
+++ b/crates/mcp/src/policy.rs
@@ -1,0 +1,95 @@
+//! Who decides whether a mutating tool may run. The decision is injected so
+//! the same gate serves a GUI (prompt a human), a headless CLI (explicit
+//! flags), and tests (a stub) without branching inside the request handler.
+
+use serde_json::Value;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Decision {
+    Approved,
+    /// Reason is surfaced to the agent so it can adapt rather than retry blindly.
+    Denied(String),
+}
+
+#[async_trait::async_trait]
+pub trait ConfirmPolicy: Send + Sync {
+    async fn confirm(&self, tool: &str, args: &Value) -> Decision;
+}
+
+/// The default. A host that wires no policy must not permit destructive tools.
+pub struct AlwaysDeny;
+
+/// Headless policy: the operator opts the process in with
+/// `--mcp-allow-destructive` AND the caller states intent with `_confirm: true`.
+/// Neither alone is sufficient.
+pub struct FlagGated {
+    allow_destructive: bool,
+}
+
+impl FlagGated {
+    pub fn new(allow_destructive: bool) -> Self {
+        Self { allow_destructive }
+    }
+}
+
+#[async_trait::async_trait]
+impl ConfirmPolicy for AlwaysDeny {
+    async fn confirm(&self, tool: &str, _args: &Value) -> Decision {
+        Decision::Denied(format!(
+            "`{tool}` mutates the cluster and no consent mechanism is configured for this srelens process"
+        ))
+    }
+}
+
+#[async_trait::async_trait]
+impl ConfirmPolicy for FlagGated {
+    async fn confirm(&self, tool: &str, args: &Value) -> Decision {
+        if !self.allow_destructive {
+            return Decision::Denied(format!(
+                "`{tool}` mutates the cluster; this srelens process was not started with --mcp-allow-destructive"
+            ));
+        }
+        let confirmed = args.get("_confirm").and_then(Value::as_bool).unwrap_or(false);
+        if !confirmed {
+            return Decision::Denied(format!(
+                "`{tool}` mutates the cluster. Re-send with \"_confirm\": true to state intent."
+            ));
+        }
+        Decision::Approved
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn always_deny_refuses_everything() {
+        let d = AlwaysDeny.confirm("k8s_deletePod", &json!({})).await;
+        assert!(matches!(d, Decision::Denied(_)));
+    }
+
+    #[tokio::test]
+    async fn flag_gated_requires_both_flag_and_confirm() {
+        let with_flag = FlagGated::new(true);
+        let without_flag = FlagGated::new(false);
+        let confirmed = json!({ "_confirm": true });
+        let bare = json!({});
+
+        // The full 2x2. Only flag AND _confirm approves.
+        assert_eq!(with_flag.confirm("t", &confirmed).await, Decision::Approved);
+        assert!(matches!(with_flag.confirm("t", &bare).await, Decision::Denied(_)));
+        assert!(matches!(without_flag.confirm("t", &confirmed).await, Decision::Denied(_)));
+        assert!(matches!(without_flag.confirm("t", &bare).await, Decision::Denied(_)));
+    }
+
+    #[tokio::test]
+    async fn flag_gated_denial_explains_which_half_is_missing() {
+        let d = FlagGated::new(false).confirm("t", &json!({ "_confirm": true })).await;
+        match d {
+            Decision::Denied(r) => assert!(r.contains("--mcp-allow-destructive"), "got: {r}"),
+            other => panic!("expected denial, got {other:?}"),
+        }
+    }
+}

--- a/crates/mcp/src/stdio.rs
+++ b/crates/mcp/src/stdio.rs
@@ -6,7 +6,7 @@
 use serde_json::{json, Value};
 use tokio::io::{AsyncBufReadExt, AsyncWrite, AsyncWriteExt};
 
-use crate::McpServer;
+use crate::{McpServer, Transport};
 
 const PROTOCOL_VERSION: &str = "2024-11-05";
 
@@ -20,7 +20,11 @@ fn err(id: Value, code: i64, message: &str) -> Value {
 
 /// Handle a single JSON-RPC request. Returns `None` for notifications (no id),
 /// which must not produce a response.
-pub async fn handle_request(server: &McpServer, req: &Value) -> Option<Value> {
+pub async fn handle_request(
+    server: &McpServer,
+    req: &Value,
+    transport: Transport,
+) -> Option<Value> {
     let method = req.get("method").and_then(Value::as_str).unwrap_or("");
     let id = req.get("id").cloned();
 
@@ -61,26 +65,35 @@ pub async fn handle_request(server: &McpServer, req: &Value) -> Option<Value> {
                 .cloned()
                 .unwrap_or_else(|| json!({}));
 
-            // Consent gate: a mutating tool must carry `"_confirm": true`.
-            let confirmed = args.get("_confirm").and_then(Value::as_bool).unwrap_or(false);
+            // `_confirm` is a caller-supplied hint, never authorization: strip it
+            // before the tool sees it, and let the injected policy decide.
             if let Some(obj) = args.as_object_mut() {
                 obj.remove("_confirm");
             }
-            if server.requires_confirm(name) && !confirmed {
-                return Some(ok(
-                    id?,
-                    json!({
-                        "content": [{
-                            "type": "text",
-                            "text": format!(
-                                "Tool `{name}` mutates the cluster and requires confirmation. \
-                                 Re-send the call with \"_confirm\": true in arguments."
-                            )
-                        }],
-                        "isError": true
-                    }),
-                ));
+            // Deliberately re-read from `params` rather than reusing `args`: the
+            // policy (e.g. `FlagGated`) needs to see `_confirm` to make its
+            // decision, but the tool must never receive it. Two views of the
+            // same call, scoped to who is allowed to see what.
+            let raw_args = params
+                .and_then(|p| p.get("arguments"))
+                .cloned()
+                .unwrap_or_else(|| json!({}));
+
+            if server.requires_confirm(name) {
+                if let crate::policy::Decision::Denied(reason) =
+                    server.confirm_policy().confirm(name, &raw_args).await
+                {
+                    // A result, not a transport error, so the agent can adapt.
+                    return Some(ok(
+                        id?,
+                        json!({
+                            "content": [{ "type": "text", "text": reason }],
+                            "isError": true
+                        }),
+                    ));
+                }
             }
+            let _ = transport; // consumed by the audit task
 
             let result = match server.call_tool(name, args).await {
                 Ok(v) => json!({
@@ -115,7 +128,7 @@ where
             Ok(v) => v,
             Err(_) => continue,
         };
-        if let Some(resp) = handle_request(&server, &req).await {
+        if let Some(resp) = handle_request(&server, &req, crate::Transport::Stdio).await {
             let s = serde_json::to_string(&resp)?;
             writer.write_all(s.as_bytes()).await?;
             writer.write_all(b"\n").await?;
@@ -142,18 +155,26 @@ mod tests {
 
     #[tokio::test]
     async fn initialize_returns_protocol_and_server_info() {
-        let resp = handle_request(&server_with_ping(), &json!({"jsonrpc":"2.0","id":1,"method":"initialize"}))
-            .await
-            .unwrap();
+        let resp = handle_request(
+            &server_with_ping(),
+            &json!({"jsonrpc":"2.0","id":1,"method":"initialize"}),
+            Transport::Stdio,
+        )
+        .await
+        .unwrap();
         assert_eq!(resp["result"]["protocolVersion"], PROTOCOL_VERSION);
         assert_eq!(resp["result"]["serverInfo"]["name"], "srelens");
     }
 
     #[tokio::test]
     async fn tools_list_includes_registry_capabilities() {
-        let resp = handle_request(&server_with_ping(), &json!({"jsonrpc":"2.0","id":2,"method":"tools/list"}))
-            .await
-            .unwrap();
+        let resp = handle_request(
+            &server_with_ping(),
+            &json!({"jsonrpc":"2.0","id":2,"method":"tools/list"}),
+            Transport::Stdio,
+        )
+        .await
+        .unwrap();
         let tools = resp["result"]["tools"].as_array().unwrap();
         assert_eq!(tools.len(), 1);
         assert_eq!(tools[0]["name"], "ping");
@@ -165,6 +186,7 @@ mod tests {
         let resp = handle_request(
             &server_with_ping(),
             &json!({"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"ping","arguments":"hi"}}),
+            Transport::Stdio,
         )
         .await
         .unwrap();
@@ -184,32 +206,106 @@ mod tests {
         McpServer::new(Arc::new(reg))
     }
 
+    // `Capability`'s field set in this codebase includes `output_schema`,
+    // which the brief's literal omits — so this mirrors `server_with_destructive`
+    // (build via `Capability::read_only`, then override only what differs)
+    // rather than constructing the struct literal directly.
+    fn server_with_readonly() -> McpServer {
+        use srelens_capability::{Annotations, Capability};
+        let mut reg = Registry::new();
+        let mut cap = Capability::read_only("readit", "reads", |_| async {
+            Ok(json!({ "ok": true }))
+        });
+        cap.annotations = Annotations::READ_ONLY;
+        reg.register(cap);
+        McpServer::new(Arc::new(reg))
+    }
+
     #[tokio::test]
     async fn destructive_tool_is_gated_without_confirm() {
         let server = server_with_destructive();
         let resp = handle_request(
             &server,
             &json!({"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"danger","arguments":{}}}),
+            Transport::Http,
         )
         .await
         .unwrap();
         assert_eq!(resp["result"]["isError"], true);
-        assert!(resp["result"]["content"][0]["text"]
-            .as_str()
-            .unwrap()
-            .contains("_confirm"));
     }
 
+    /// The bug this closes: the gate used to read `_confirm` from the caller's
+    /// own arguments, so any client could authorize itself.
     #[tokio::test]
-    async fn destructive_tool_runs_with_confirm() {
+    async fn caller_supplied_confirm_does_not_authorize() {
         let server = server_with_destructive();
         let resp = handle_request(
             &server,
-            &json!({"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"danger","arguments":{"_confirm":true}}}),
+            &json!({
+                "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                "params": { "name": "danger", "arguments": { "_confirm": true } }
+            }),
+            Transport::Http,
         )
         .await
-        .unwrap();
-        assert_eq!(resp["result"]["isError"], false);
+        .expect("response");
+        assert_eq!(resp["result"]["isError"], json!(true), "expected denial, got {resp}");
+    }
+
+    #[tokio::test]
+    async fn destructive_denied_when_no_policy_wired() {
+        let server = server_with_destructive(); // default policy = AlwaysDeny
+        let resp = handle_request(
+            &server,
+            &json!({
+                "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                "params": { "name": "danger", "arguments": {} }
+            }),
+            Transport::Http,
+        )
+        .await
+        .expect("response");
+        assert_eq!(resp["result"]["isError"], json!(true));
+    }
+
+    #[tokio::test]
+    async fn approving_policy_lets_the_tool_run_and_strips_confirm() {
+        struct Yes;
+        #[async_trait::async_trait]
+        impl crate::policy::ConfirmPolicy for Yes {
+            async fn confirm(&self, _t: &str, _a: &serde_json::Value) -> crate::policy::Decision {
+                crate::policy::Decision::Approved
+            }
+        }
+        let server = server_with_destructive().with_policy(std::sync::Arc::new(Yes));
+        let resp = handle_request(
+            &server,
+            &json!({
+                "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                "params": { "name": "danger", "arguments": { "_confirm": true } }
+            }),
+            Transport::Http,
+        )
+        .await
+        .expect("response");
+        assert_eq!(resp["result"]["isError"], json!(false), "got {resp}");
+    }
+
+    #[tokio::test]
+    async fn read_only_tool_never_consults_the_policy() {
+        // AlwaysDeny is the default; a read-only tool must still work.
+        let server = server_with_readonly();
+        let resp = handle_request(
+            &server,
+            &json!({
+                "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                "params": { "name": "readit", "arguments": {} }
+            }),
+            Transport::Stdio,
+        )
+        .await
+        .expect("response");
+        assert_eq!(resp["result"]["isError"], json!(false), "got {resp}");
     }
 
     #[tokio::test]
@@ -217,6 +313,7 @@ mod tests {
         let resp = handle_request(
             &server_with_ping(),
             &json!({"jsonrpc":"2.0","method":"notifications/initialized"}),
+            Transport::Stdio,
         )
         .await;
         assert!(resp.is_none());

--- a/crates/mcp/src/stdio.rs
+++ b/crates/mcp/src/stdio.rs
@@ -82,9 +82,9 @@ pub async fn handle_request(
             let sensitive = server.is_sensitive(name);
             let mut decision = "auto";
 
-            if server.requires_confirm(name) {
+            if let Some(kind) = server.consent_kind(name) {
                 if let crate::policy::Decision::Denied(reason) =
-                    server.confirm_policy().confirm(name, &raw_args).await
+                    server.confirm_policy().confirm(name, &raw_args, kind).await
                 {
                     server.audit().record(crate::audit::AuditRecord {
                         transport,
@@ -307,7 +307,12 @@ mod tests {
         struct Yes(Arc<Mutex<Option<Value>>>);
         #[async_trait::async_trait]
         impl crate::policy::ConfirmPolicy for Yes {
-            async fn confirm(&self, _t: &str, a: &serde_json::Value) -> crate::policy::Decision {
+            async fn confirm(
+                &self,
+                _t: &str,
+                a: &serde_json::Value,
+                _kind: crate::policy::ConsentKind,
+            ) -> crate::policy::Decision {
                 *self.0.lock().unwrap() = Some(a.clone());
                 crate::policy::Decision::Approved
             }
@@ -429,7 +434,12 @@ mod tests {
         struct AlwaysApprove;
         #[async_trait::async_trait]
         impl crate::policy::ConfirmPolicy for AlwaysApprove {
-            async fn confirm(&self, _tool: &str, _args: &Value) -> crate::policy::Decision {
+            async fn confirm(
+                &self,
+                _tool: &str,
+                _args: &Value,
+                _kind: crate::policy::ConsentKind,
+            ) -> crate::policy::Decision {
                 crate::policy::Decision::Approved
             }
         }

--- a/crates/mcp/src/stdio.rs
+++ b/crates/mcp/src/stdio.rs
@@ -412,6 +412,81 @@ mod tests {
         assert_eq!(seen[0].1, "denied");
     }
 
+    /// Sibling of `every_tool_call_is_audited_with_its_decision`, pinning the
+    /// `"approved"` value: without this, `"approved"` and `"auto"` could be
+    /// swapped in the implementation and no test would notice — `decision` is
+    /// the whole point of the audit log.
+    #[tokio::test]
+    async fn a_destructive_call_approved_by_policy_is_audited_as_approved() {
+        use std::sync::Mutex;
+        #[derive(Default)]
+        struct Spy(Mutex<Vec<(String, &'static str, &'static str)>>);
+        impl crate::audit::AuditSink for Spy {
+            fn record(&self, rec: crate::audit::AuditRecord) {
+                self.0.lock().unwrap().push((rec.tool, rec.decision, rec.outcome));
+            }
+        }
+        struct AlwaysApprove;
+        #[async_trait::async_trait]
+        impl crate::policy::ConfirmPolicy for AlwaysApprove {
+            async fn confirm(&self, _tool: &str, _args: &Value) -> crate::policy::Decision {
+                crate::policy::Decision::Approved
+            }
+        }
+
+        let spy = Arc::new(Spy::default());
+        let server = server_with_destructive()
+            .with_policy(Arc::new(AlwaysApprove))
+            .with_audit(spy.clone());
+
+        let _ = handle_request(
+            &server,
+            &json!({
+                "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                "params": { "name": "danger", "arguments": {} }
+            }),
+            Transport::Http,
+        )
+        .await;
+
+        let seen = spy.0.lock().unwrap().clone();
+        assert_eq!(seen.len(), 1, "expected one audit record, got {seen:?}");
+        assert_eq!(seen[0].0, "danger");
+        assert_eq!(seen[0].1, "approved");
+    }
+
+    /// Sibling pinning the `"auto"` value: a read-only tool never consults
+    /// the policy, so it must be recorded as `"auto"`, not `"approved"`.
+    #[tokio::test]
+    async fn a_read_only_call_is_audited_as_auto() {
+        use std::sync::Mutex;
+        #[derive(Default)]
+        struct Spy(Mutex<Vec<(String, &'static str, &'static str)>>);
+        impl crate::audit::AuditSink for Spy {
+            fn record(&self, rec: crate::audit::AuditRecord) {
+                self.0.lock().unwrap().push((rec.tool, rec.decision, rec.outcome));
+            }
+        }
+
+        let spy = Arc::new(Spy::default());
+        let server = server_with_readonly().with_audit(spy.clone());
+
+        let _ = handle_request(
+            &server,
+            &json!({
+                "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                "params": { "name": "readit", "arguments": {} }
+            }),
+            Transport::Stdio,
+        )
+        .await;
+
+        let seen = spy.0.lock().unwrap().clone();
+        assert_eq!(seen.len(), 1, "expected one audit record, got {seen:?}");
+        assert_eq!(seen[0].0, "readit");
+        assert_eq!(seen[0].1, "auto");
+    }
+
     #[tokio::test]
     async fn serve_processes_a_session_over_the_stream() {
         let input = concat!(

--- a/crates/mcp/src/stdio.rs
+++ b/crates/mcp/src/stdio.rs
@@ -268,16 +268,47 @@ mod tests {
         assert_eq!(resp["result"]["isError"], json!(true));
     }
 
+    /// The pair of assertions here is the point: the tool must never see
+    /// `_confirm`, while the policy must. A regression that reordered the
+    /// strip, or that started passing the stripped `args` to the policy
+    /// instead of `raw_args`, would silently break `FlagGated` in production
+    /// with nothing else in this suite catching it.
     #[tokio::test]
     async fn approving_policy_lets_the_tool_run_and_strips_confirm() {
-        struct Yes;
+        use srelens_capability::Annotations;
+        use std::sync::Mutex;
+
+        // Captures what each side actually received, rather than trusting
+        // that "the tool ran" and "the policy approved" implies either saw
+        // the right shape of arguments.
+        let policy_saw: Arc<Mutex<Option<Value>>> = Arc::new(Mutex::new(None));
+        let tool_saw: Arc<Mutex<Option<Value>>> = Arc::new(Mutex::new(None));
+
+        struct Yes(Arc<Mutex<Option<Value>>>);
         #[async_trait::async_trait]
         impl crate::policy::ConfirmPolicy for Yes {
-            async fn confirm(&self, _t: &str, _a: &serde_json::Value) -> crate::policy::Decision {
+            async fn confirm(&self, _t: &str, a: &serde_json::Value) -> crate::policy::Decision {
+                *self.0.lock().unwrap() = Some(a.clone());
                 crate::policy::Decision::Approved
             }
         }
-        let server = server_with_destructive().with_policy(std::sync::Arc::new(Yes));
+
+        let mut reg = Registry::new();
+        let mut cap = {
+            let tool_saw = tool_saw.clone();
+            Capability::read_only("danger", "destructive", move |args| {
+                let tool_saw = tool_saw.clone();
+                async move {
+                    *tool_saw.lock().unwrap() = Some(args.clone());
+                    Ok(json!({ "done": true }))
+                }
+            })
+        };
+        cap.annotations = Annotations::DESTRUCTIVE;
+        reg.register(cap);
+        let server =
+            McpServer::new(Arc::new(reg)).with_policy(Arc::new(Yes(policy_saw.clone())));
+
         let resp = handle_request(
             &server,
             &json!({
@@ -289,6 +320,19 @@ mod tests {
         .await
         .expect("response");
         assert_eq!(resp["result"]["isError"], json!(false), "got {resp}");
+
+        let seen_by_tool = tool_saw.lock().unwrap().clone().expect("tool ran");
+        assert!(
+            seen_by_tool.get("_confirm").is_none(),
+            "tool must not see _confirm, got {seen_by_tool}"
+        );
+
+        let seen_by_policy = policy_saw.lock().unwrap().clone().expect("policy consulted");
+        assert_eq!(
+            seen_by_policy.get("_confirm"),
+            Some(&json!(true)),
+            "policy must see _confirm, got {seen_by_policy}"
+        );
     }
 
     #[tokio::test]

--- a/crates/mcp/src/stdio.rs
+++ b/crates/mcp/src/stdio.rs
@@ -79,10 +79,21 @@ pub async fn handle_request(
                 .cloned()
                 .unwrap_or_else(|| json!({}));
 
+            let sensitive = server.is_sensitive(name);
+            let mut decision = "auto";
+
             if server.requires_confirm(name) {
                 if let crate::policy::Decision::Denied(reason) =
                     server.confirm_policy().confirm(name, &raw_args).await
                 {
+                    server.audit().record(crate::audit::AuditRecord {
+                        transport,
+                        tool: name.to_string(),
+                        args: crate::audit::redact(&args, sensitive),
+                        decision: "denied",
+                        outcome: "error",
+                        error: Some(reason.clone()),
+                    });
                     // A result, not a transport error, so the agent can adapt.
                     return Some(ok(
                         id?,
@@ -92,10 +103,19 @@ pub async fn handle_request(
                         }),
                     ));
                 }
+                decision = "approved";
             }
-            let _ = transport; // consumed by the audit task
 
-            let result = match server.call_tool(name, args).await {
+            let called = server.call_tool(name, args.clone()).await;
+            server.audit().record(crate::audit::AuditRecord {
+                transport,
+                tool: name.to_string(),
+                args: crate::audit::redact(&args, sensitive),
+                decision,
+                outcome: if called.is_ok() { "ok" } else { "error" },
+                error: called.as_ref().err().map(|e| e.to_string()),
+            });
+            let result = match called {
                 Ok(v) => json!({
                     "content": [{ "type": "text", "text": v.to_string() }],
                     "isError": false
@@ -361,6 +381,35 @@ mod tests {
         )
         .await;
         assert!(resp.is_none());
+    }
+
+    #[tokio::test]
+    async fn every_tool_call_is_audited_with_its_decision() {
+        use std::sync::Mutex;
+        #[derive(Default)]
+        struct Spy(Mutex<Vec<(String, &'static str, &'static str)>>);
+        impl crate::audit::AuditSink for Spy {
+            fn record(&self, rec: crate::audit::AuditRecord) {
+                self.0.lock().unwrap().push((rec.tool, rec.decision, rec.outcome));
+            }
+        }
+        let spy = Arc::new(Spy::default());
+        let server = server_with_destructive().with_audit(spy.clone());
+
+        let _ = handle_request(
+            &server,
+            &json!({
+                "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                "params": { "name": "danger", "arguments": {} }
+            }),
+            Transport::Http,
+        )
+        .await;
+
+        let seen = spy.0.lock().unwrap().clone();
+        assert_eq!(seen.len(), 1, "expected one audit record, got {seen:?}");
+        assert_eq!(seen[0].0, "danger");
+        assert_eq!(seen[0].1, "denied");
     }
 
     #[tokio::test]

--- a/crates/registry/src/lib.rs
+++ b/crates/registry/src/lib.rs
@@ -350,7 +350,7 @@ mod tests {
         let reg = build_registry();
         let server = McpServer::new(Arc::new(reg.clone()));
         assert_eq!(assert_every_capability_has_a_tool(&reg, &server), Ok(()));
-        srelens_mcp::completeness::assert_destructive_capabilities_are_gated(&reg);
+        srelens_mcp::completeness::assert_mutating_capabilities_are_gated(&reg);
     }
 
     #[test]

--- a/crates/registry/src/lib.rs
+++ b/crates/registry/src/lib.rs
@@ -350,6 +350,7 @@ mod tests {
         let reg = build_registry();
         let server = McpServer::new(Arc::new(reg.clone()));
         assert_eq!(assert_every_capability_has_a_tool(&reg, &server), Ok(()));
+        srelens_mcp::completeness::assert_destructive_capabilities_are_gated(&reg);
     }
 
     #[test]

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -88,7 +88,7 @@ cargo run -p srelens-desktop --no-default-features -- --mcp-stdio
 cargo run -p srelens-desktop --no-default-features -- --mcp-http 127.0.0.1:8765
 ```
 
-The HTTP transport binds to loopback, requires a bearer token (`crates/mcp/src/auth.rs`), and checks the `Host` header to block DNS rebinding. Tools annotated `destructive` are gated by an injected `ConfirmPolicy` (`crates/mcp/src/policy.rs`): the desktop app prompts in-app, and headless runs need `--mcp-allow-destructive` **and** `"_confirm": true` on the call — `_confirm` alone never authorizes anything. See the [user guide](USAGE.md#mcp-server-for-ai-agents) for the full security model.
+The HTTP transport binds to loopback, requires a bearer token (`crates/mcp/src/auth.rs`, supplied via `SRELENS_MCP_TOKEN` — never a flag, since argv is readable via `ps`), and checks the `Host` header on every route to block DNS rebinding. Gated tools go through an injected `ConfirmPolicy` (`crates/mcp/src/policy.rs`), which receives a `ConsentKind` derived from the capability's annotations: a gated capability that is `read_only` is a `SensitiveRead`, anything else gated is `Destructive`. The desktop app prompts in-app for both; headless runs need `"_confirm": true` on the call plus the matching flag (`--mcp-allow-destructive` or `--mcp-allow-sensitive-reads`) — `_confirm` alone never authorizes anything, and neither flag implies the other. See the [user guide](USAGE.md#mcp-server-for-ai-agents) for the full security model.
 
 ## Testing standards
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -88,7 +88,7 @@ cargo run -p srelens-desktop --no-default-features -- --mcp-stdio
 cargo run -p srelens-desktop --no-default-features -- --mcp-http 127.0.0.1:8765
 ```
 
-The HTTP transport binds to loopback and serves MCP at `/mcp`. Tools annotated `destructive` reject calls without an explicit `_confirm` argument.
+The HTTP transport binds to loopback, requires a bearer token (`crates/mcp/src/auth.rs`), and checks the `Host` header to block DNS rebinding. Tools annotated `destructive` are gated by an injected `ConfirmPolicy` (`crates/mcp/src/policy.rs`): the desktop app prompts in-app, and headless runs need `--mcp-allow-destructive` **and** `"_confirm": true` on the call — `_confirm` alone never authorizes anything. See the [user guide](USAGE.md#mcp-server-for-ai-agents) for the full security model.
 
 ## Testing standards
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -73,9 +73,10 @@ clusters. Open **Settings → MCP** to:
 The HTTP server requires a bearer token, shown (and rotatable) from that same
 Settings page. Destructive tools prompt for confirmation in the app — an agent
 can't delete or drain anything without your approval. Headless CLI use needs
-both `--mcp-allow-destructive` on the process and `"_confirm": true` on the
-call; see the [user guide](USAGE.md#mcp-server-for-ai-agents) for the full
-security model.
+`"_confirm": true` on the call plus a process-level opt-in:
+`--mcp-allow-destructive` to change anything, or `--mcp-allow-sensitive-reads`
+to read Secrets. See the [user guide](USAGE.md#mcp-server-for-ai-agents) for the
+full security model.
 
 ## Updating
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -70,8 +70,12 @@ clusters. Open **Settings → MCP** to:
   (ensure `~/.local/bin` is on your `PATH`).
 - **Copy client config** for Claude Code, Claude Desktop, Cursor, Codex, Antigravity, and others.
 
-Destructive tools require an explicit `_confirm` — an agent can't delete or drain anything
-without approval.
+The HTTP server requires a bearer token, shown (and rotatable) from that same
+Settings page. Destructive tools prompt for confirmation in the app — an agent
+can't delete or drain anything without your approval. Headless CLI use needs
+both `--mcp-allow-destructive` on the process and `"_confirm": true` on the
+call; see the [user guide](USAGE.md#mcp-server-for-ai-agents) for the full
+security model.
 
 ## Updating
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -331,10 +331,12 @@ srelens --mcp-http 127.0.0.1:8765
 
 - **HTTP requires a bearer token.** The transport never serves unauthenticated.
   Settings → MCP shows the current token (masked, with reveal/copy) plus
-  **Rotate** and **Revoke** buttons. Rotating replaces the token immediately, so
-  any client already configured with the old value stops working until it gets
-  the new one. Revoking also stops the server — it must never run without a
-  valid token.
+  **Rotate** and **Revoke** buttons. If the server is running, rotating
+  restarts it immediately so the new token takes effect — any in-flight agent
+  request is dropped, and every client still configured with the old value
+  needs the new one before it works again. (Rotating while the server is
+  stopped just replaces the stored token; it does not start the server.)
+  Revoking also stops the server — it must never run without a valid token.
 - A **Host header check** rejects requests whose `Host` isn't a loopback value
   (`127.0.0.1`, `::1`, or `localhost`). Binding loopback alone doesn't stop a
   page on another domain from resolving to 127.0.0.1 and posting to the port;
@@ -349,8 +351,10 @@ srelens --mcp-http 127.0.0.1:8765
   needs an explicit opt-in instead: `--mcp-allow-destructive` on the process
   *and* `"_confirm": true` on the individual tool call. Neither alone is
   enough — `_confirm` states intent, it does not authorize anything by itself.
-  Pass `--mcp-token <hex>` to supply your own token; otherwise srelens reads
-  one from the store, or generates one and prints it to stderr.
+  This applies to both transports; `--mcp-token <hex>`, however, is
+  `--mcp-http`-only (stdio takes no token at all) and supplies your own token —
+  otherwise srelens reads one from the store, or generates one and prints it
+  to stderr.
 - **There is no GUI toggle for stdio.** A GUI can't govern a process a client
   spawned directly, so those two CLI flags are the entire stdio control
   surface.
@@ -362,8 +366,10 @@ srelens --mcp-http 127.0.0.1:8765
   nesting depth.
 - The bearer token lives in your **OS keychain** where one is available,
   falling back to a `0600` file otherwise (headless Linux, minimal window
-  managers). Settings → MCP shows which is in use — when it says file, the
-  token sits on disk unencrypted.
+  managers). Settings → MCP only speaks up about this when it has fallen back:
+  a warning appears saying the token is stored in a plain file on disk
+  (readable only by your user account) instead of the keychain. No warning
+  means the keychain is serving.
 
 Review tool calls and use appropriate Kubernetes RBAC, especially with
 critical clusters.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -340,30 +340,50 @@ srelens --mcp-http 127.0.0.1:8765
 - A **Host header check** rejects requests whose `Host` isn't a loopback value
   (`127.0.0.1`, `::1`, or `localhost`). Binding loopback alone doesn't stop a
   page on another domain from resolving to 127.0.0.1 and posting to the port;
-  the Host check does.
+  the Host check does. It applies to every route, including the unauthenticated
+  `/healthz`, so nothing here answers a caller that isn't genuinely local.
 - **stdio needs no token** — the client spawned the `srelens --mcp-stdio`
   process itself and already holds your privileges.
+- **To supply your own token**, set `SRELENS_MCP_TOKEN` to 64 hex characters.
+  There is deliberately **no `--mcp-token` flag**: command-line arguments are
+  visible to every account on the machine via `ps`, which would hand the token
+  to exactly the local processes it exists to keep out. Without the variable,
+  srelens reads a token from the store, or generates one and prints it to
+  stderr. HTTP only — stdio takes no token at all.
 - **Destructive tools prompt in the app.** The MCP call blocks until you approve
   or deny the dialog that pops up. Letting it time out, dismissing it, or
   having no srelens window open at all count as **deny**. Confirmation
   requests from concurrent calls queue rather than colliding.
 - **Headless use** (`--mcp-stdio` / `--mcp-http` with no GUI to show a dialog)
-  needs an explicit opt-in instead: `--mcp-allow-destructive` on the process
-  *and* `"_confirm": true` on the individual tool call. Neither alone is
-  enough — `_confirm` states intent, it does not authorize anything by itself.
-  This applies to both transports; `--mcp-token <hex>`, however, is
-  `--mcp-http`-only (stdio takes no token at all) and supplies your own token —
-  otherwise srelens reads one from the store, or generates one and prints it
-  to stderr.
+  needs an explicit opt-in instead: a process-level flag *and* `"_confirm":
+  true` on the individual tool call. Neither alone is enough — `_confirm` states
+  intent, it does not authorize anything by itself. There are two flags, because
+  they are two different risks and granting one must not grant the other:
+
+  | Flag | Authorizes |
+  | --- | --- |
+  | `--mcp-allow-destructive` | anything that changes state — delete, drain, scale, apply, helm install, installing local tooling |
+  | `--mcp-allow-sensitive-reads` | reads that return secret material, i.e. `k8s.getSecret` |
+
+  So an agent allowed to read a Secret still cannot drain a node, and an agent
+  allowed to drain nodes cannot read your Secrets. Both flags apply to both
+  transports.
 - **There is no GUI toggle for stdio.** A GUI can't govern a process a client
-  spawned directly, so those two CLI flags are the entire stdio control
-  surface.
+  spawned directly, so those CLI flags are the entire stdio control surface.
 - Every call is recorded to an **audit log** at `<app config dir>/mcp/audit.jsonl`
-  (rotated once to `.1` past 5 MB), viewable in Settings → MCP under recent
-  agent activity. Argument values are redacted before they're written:
-  sensitive capabilities redact every value, and keys that look like
-  credentials (`token`, `secret`, `password`, `key`) are redacted at any
-  nesting depth.
+  (mode `0600`, rotated once to `.1` past 5 MB), viewable in Settings → MCP
+  under recent agent activity. Argument values are redacted before they're
+  written, so the log records the shape of a call without its contents:
+  - sensitive capabilities redact every value;
+  - keys that look like credentials (`token`, `secret`, `password`, `key`) are
+    redacted at any nesting depth;
+  - whole payload fields are redacted — `data`/`stringData` on a Secret write,
+    `yaml` on `k8s.applyManifest`, and `values` on the helm capabilities. These
+    carry secret material under key names that look perfectly ordinary
+    (`username`, `ca.crt`), so matching key names alone would miss them.
+
+  Identifying fields like `context`, `namespace`, `name` and `kind` survive, so
+  you can still see which cluster and object an agent touched.
 - The bearer token lives in your **OS keychain** where one is available,
   falling back to a `0600` file otherwise (headless Linux, minimal window
   managers). Settings → MCP only speaks up about this when it has fallen back:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -327,9 +327,46 @@ srelens --mcp-stdio
 srelens --mcp-http 127.0.0.1:8765
 ```
 
-Mutating and destructive tools require an explicit `"_confirm": true` argument
-before they run. Review tool calls and use appropriate Kubernetes RBAC,
-especially with critical clusters.
+### Security model
+
+- **HTTP requires a bearer token.** The transport never serves unauthenticated.
+  Settings → MCP shows the current token (masked, with reveal/copy) plus
+  **Rotate** and **Revoke** buttons. Rotating replaces the token immediately, so
+  any client already configured with the old value stops working until it gets
+  the new one. Revoking also stops the server — it must never run without a
+  valid token.
+- A **Host header check** rejects requests whose `Host` isn't a loopback value
+  (`127.0.0.1`, `::1`, or `localhost`). Binding loopback alone doesn't stop a
+  page on another domain from resolving to 127.0.0.1 and posting to the port;
+  the Host check does.
+- **stdio needs no token** — the client spawned the `srelens --mcp-stdio`
+  process itself and already holds your privileges.
+- **Destructive tools prompt in the app.** The MCP call blocks until you approve
+  or deny the dialog that pops up. Letting it time out, dismissing it, or
+  having no srelens window open at all count as **deny**. Confirmation
+  requests from concurrent calls queue rather than colliding.
+- **Headless use** (`--mcp-stdio` / `--mcp-http` with no GUI to show a dialog)
+  needs an explicit opt-in instead: `--mcp-allow-destructive` on the process
+  *and* `"_confirm": true` on the individual tool call. Neither alone is
+  enough — `_confirm` states intent, it does not authorize anything by itself.
+  Pass `--mcp-token <hex>` to supply your own token; otherwise srelens reads
+  one from the store, or generates one and prints it to stderr.
+- **There is no GUI toggle for stdio.** A GUI can't govern a process a client
+  spawned directly, so those two CLI flags are the entire stdio control
+  surface.
+- Every call is recorded to an **audit log** at `<app config dir>/mcp/audit.jsonl`
+  (rotated once to `.1` past 5 MB), viewable in Settings → MCP under recent
+  agent activity. Argument values are redacted before they're written:
+  sensitive capabilities redact every value, and keys that look like
+  credentials (`token`, `secret`, `password`, `key`) are redacted at any
+  nesting depth.
+- The bearer token lives in your **OS keychain** where one is available,
+  falling back to a `0600` file otherwise (headless Linux, minimal window
+  managers). Settings → MCP shows which is in use — when it says file, the
+  token sits on disk unencrypted.
+
+Review tool calls and use appropriate Kubernetes RBAC, especially with
+critical clusters.
 
 ## Settings reference
 


### PR DESCRIPTION
Closes #23.

## The problem

Two real holes, not missing features:

1. **The MCP HTTP transport had no authentication at all.** `POST /mcp` accepted any JSON-RPC request — no token, no origin check. Loopback binding was the only control, so any local process could drive your clusters while the server was on.
2. **The consent gate was decorative.** It read `_confirm` from the *caller's own arguments*:
   ```rust
   let confirmed = args.get("_confirm").and_then(Value::as_bool).unwrap_or(false);
   if server.requires_confirm(name) && !confirmed { /* refuse */ }
   ```
   A hostile or careless client set `_confirm: true` and deleted whatever it liked.

There was also no record of what an agent did.

## What changed

**Consent.** A `ConfirmPolicy` trait injected into `McpServer`, defaulting to `AlwaysDeny` so a host that wires nothing permits nothing. The gate lives in `handle_request` — the one point both transports converge — so stdio can't drift ungated. `_confirm` is stripped before the tool sees it; the policy still sees it, because the headless policy needs it.

- **Desktop:** the MCP call blocks, srelens raises its window and prompts. Timeout, dismissal, and no-window all **deny**. Concurrent requests queue.
- **Headless:** needs **both** `--mcp-allow-destructive` on the process **and** `"_confirm": true` on the call. Neither alone suffices.

**Auth.** Bearer token on the HTTP router only (stdio's client spawned the process and already holds your privileges). Constant-time comparison, opaque `Debug`. Plus a `Host` header check — loopback binding does *not* stop a page on `evil.com` resolving to `127.0.0.1`; rejecting a non-loopback `Host` does.

**Storage.** OS keychain, with a resilient fallback: the store attempts the keychain per call and falls back to a `0600` file on genuine failure — never on `NoEntry`, which would silently prefer a stale file token. Settings reports which backend actually served.

**Audit.** Every call recorded to `<config>/mcp/audit.jsonl` (5 MB, one rotation) with the consent decision. Arguments are redacted recursively: sensitive capabilities wholesale, credential-shaped keys at any depth.

## Things the reviews caught that weren't in the plan

- **`k8s.helmRepoUpdate` was live and ungated** — `Annotations::default()`, so neither read-only nor confirm-gated. Now `MUTATING`, and the completeness guard was widened to fail the build on *any* capability that is neither read-only nor confirm-gated.
- **Rotate didn't rotate.** The token was baked into the middleware at router-build time and `mcp_token_rotate` never restarted anything — a leaked token kept working until the app restarted. Now the transport restarts (and a stopped server stays stopped).
- **That restart hit a bind race**, measured at 38/50 `Address already in use`: `abort()` doesn't synchronously drop the listener fd. Fixed by awaiting the `JoinHandle` with a bounded fallback.
- **Client configs would have 401'd on day one** — the generator was never updated for the new token requirement.
- **`k8s.getSecret` wasn't consent-gated.** Now is, via `SENSITIVE_READ`.

## Deviation from the issue

#23 asks for independent stdio/HTTP toggles in Settings. **stdio has no GUI toggle**, because a GUI cannot govern a process an MCP client spawned. The CLI flags are stdio's control surface; this is documented rather than silently dropped.

## Verification

`cargo test --workspace` — 525 passed, 0 failed. `vitest` — 108 files, 748 tests. Regression guards specifically pin the two original holes: `_confirm` alone no longer authorizes, and a destructive tool is denied when no policy is wired. Both fail against the old code.

Not covered: Linux Secret Service and Windows Credential Manager backends (untestable here — the fallback *logic* is tested via an injected failing backend, so what's unverified is only which error variant each OS returns), and the desktop server lifecycle has no tests.

## Follow-ups (not blocking)

- Headless audit needs a `create_dir_all` — on a machine where the GUI never ran, the log directory doesn't exist yet
- The token renders unmasked in the HTTP config snippet while the token row above it stays masked
- `docs/USAGE.md` doesn't yet mention that sensitive reads prompt too
- `refreshToken` conflates a fetch error with "no token yet"
- Audit/auth/token tests leave temp dirs under `/tmp`
