### PR TITLE
feat(namespaces): hoist selected namespaces to top of selector

### DIFF
--- a/apps/desktop/src/ui/NamespaceMultiSelect.test.tsx
+++ b/apps/desktop/src/ui/NamespaceMultiSelect.test.tsx
@@ -45,4 +45,22 @@ describe("NamespaceMultiSelect", () => {
     fireEvent.click(await screen.findByText("All namespaces"));
     expect(onChange).toHaveBeenCalledWith([]);
   });
+
+  it("hoists selected namespaces to the top of the list, ahead of unselected ones", async () => {
+    render(
+      <NamespaceMultiSelect namespaces={namespaces} selection={["prod"]} onChange={() => {}} ariaLabel="Namespaces" />,
+    );
+    fireEvent.click(screen.getByRole("combobox", { name: "Namespaces" }));
+    await screen.findByText("kube-system");
+    const order = screen.getAllByRole("option").map((el) => el.textContent);
+    expect(order).toEqual(["All namespaces", "prod", "default", "kube-system"]);
+  });
+
+  it("keeps a stable order when nothing is selected", async () => {
+    render(<NamespaceMultiSelect namespaces={namespaces} selection={[]} onChange={() => {}} ariaLabel="Namespaces" />);
+    fireEvent.click(screen.getByRole("combobox", { name: "Namespaces" }));
+    await screen.findByText("default");
+    const order = screen.getAllByRole("option").map((el) => el.textContent);
+    expect(order).toEqual(["All namespaces", "default", "kube-system", "prod"]);
+  });
 });

--- a/apps/desktop/src/ui/NamespaceMultiSelect.tsx
+++ b/apps/desktop/src/ui/NamespaceMultiSelect.tsx
@@ -41,6 +41,13 @@ export function NamespaceMultiSelect({
     onChange([...next]);
   };
 
+  // Selected namespaces first (in their given order), then the rest — so a
+  // selection doesn't get lost among dozens of other namespaces.
+  const orderedNamespaces =
+    selected.size === 0
+      ? namespaces
+      : [...selection.filter((ns) => namespaces.includes(ns)), ...namespaces.filter((ns) => !selected.has(ns))];
+
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
@@ -68,7 +75,7 @@ export function NamespaceMultiSelect({
                 <Check className={cn("size-3.5 shrink-0", selection.length === 0 ? "opacity-100" : "opacity-0")} />
                 <span className="truncate">All namespaces</span>
               </CommandItem>
-              {namespaces.map((ns) => (
+              {orderedNamespaces.map((ns) => (
                 <CommandItem key={ns} value={ns} onSelect={() => toggle(ns)}>
                   <Check className={cn("size-3.5 shrink-0", selected.has(ns) ? "opacity-100" : "opacity-0")} />
                   <span className="truncate">{ns}</span>


### PR DESCRIPTION
Closes #147.

Selected namespaces stayed in their alphabetical position in `NamespaceMultiSelect`, so on a cluster with many namespaces they got lost among the rest instead of being easy to find/deselect.

## What's in it
- `NamespaceMultiSelect.tsx` — compute `orderedNamespaces` as `[...selected (in selection order), ...rest (unchanged order)]`; no-op when nothing is selected. "All namespaces" and search input behavior are untouched.

## Tests
Added two cases to `NamespaceMultiSelect.test.tsx`: selected namespaces render ahead of unselected ones (in selection order), and order is stable/unchanged with an empty selection. Written test-first — both fail against the pre-fix code. `pnpm test`: 105/105 files, 732/732 tests, 100% coverage on the changed file. `cargo test --workspace`: green (backend untouched).

Also visually verified by mounting the component in an isolated harness and driving it with Playwright — screenshot confirms selected namespaces render checked and hoisted to the top.

Not covered: integration in the real app screen (namespace filter toolbar) against a live cluster — verified via unit tests plus an isolated component harness, not the running app with real namespace data.