### PR TITLE
feat(mcp): k8s:// resource URIs with watch-backed subscriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5727,6 +5727,7 @@ dependencies = [
  "async-trait",
  "axum",
  "getrandom 0.2.17",
+ "percent-encoding",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ mod helm;
 mod logs;
 mod mcp;
 mod mcp_confirm;
+pub mod mcp_watch;
 mod settings;
 mod sink;
 mod terminal;

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -184,7 +184,19 @@ fn run_mcp_http(addr: &str, allow_destructive: bool, allow_sensitive_reads: bool
         .build()
         .expect("build tokio runtime");
     runtime.block_on(async {
-        let registry = srelens_desktop_lib::build_registry();
+        // Built explicitly (rather than via `build_registry`, which creates
+        // its own cache internally and does not expose it) so the same cache
+        // backs both the registry's reads and the watcher's subscriptions —
+        // a second cache would authenticate independently, double the
+        // connections, and could diverge from the read path on credential
+        // refresh.
+        let cache = srelens_kube::client_cache::ClientCache::new_many(
+            srelens_registry::default_kubeconfig_paths(),
+        );
+        let registry = srelens_desktop_lib::build_registry_with_paths(
+            cache.clone(),
+            srelens_registry::default_kubeconfig_paths(),
+        );
         let server = srelens_mcp::McpServer::new(Arc::new(registry))
             .with_policy(policy)
             .with_audit(Arc::new(srelens_mcp::audit::JsonlAuditLog::new(
@@ -193,6 +205,10 @@ fn run_mcp_http(addr: &str, allow_destructive: bool, allow_sensitive_reads: bool
             )))
             .with_prompts(srelens_mcp::prompts::PromptLibrary::new(Some(
                 mcp_prompts_dir(),
+            )))
+            .with_resources(srelens_registry::kind_resolver())
+            .with_watcher(Arc::new(srelens_desktop_lib::mcp_watch::CacheWatcher::new(
+                cache,
             )));
         eprintln!(
             "MCP HTTP listening on http://{addr}/mcp (loopback; gated tools need _confirm plus \
@@ -235,7 +251,16 @@ fn run_mcp_stdio(allow_destructive: bool, allow_sensitive_reads: bool) {
         .build()
         .expect("build tokio runtime");
     runtime.block_on(async {
-        let registry = srelens_desktop_lib::build_registry();
+        // Same reasoning as `run_mcp_http`: build the cache explicitly and
+        // share it between the registry and the watcher rather than letting
+        // `build_registry` create one it doesn't expose.
+        let cache = srelens_kube::client_cache::ClientCache::new_many(
+            srelens_registry::default_kubeconfig_paths(),
+        );
+        let registry = srelens_desktop_lib::build_registry_with_paths(
+            cache.clone(),
+            srelens_registry::default_kubeconfig_paths(),
+        );
         let server = srelens_mcp::McpServer::new(Arc::new(registry))
             .with_policy(policy)
             .with_audit(Arc::new(srelens_mcp::audit::JsonlAuditLog::new(
@@ -244,6 +269,10 @@ fn run_mcp_stdio(allow_destructive: bool, allow_sensitive_reads: bool) {
             )))
             .with_prompts(srelens_mcp::prompts::PromptLibrary::new(Some(
                 mcp_prompts_dir(),
+            )))
+            .with_resources(srelens_registry::kind_resolver())
+            .with_watcher(Arc::new(srelens_desktop_lib::mcp_watch::CacheWatcher::new(
+                cache,
             )));
         let reader = tokio::io::BufReader::new(tokio::io::stdin());
         let writer = tokio::io::stdout();

--- a/apps/desktop/src-tauri/src/mcp.rs
+++ b/apps/desktop/src-tauri/src/mcp.rs
@@ -126,6 +126,10 @@ async fn start_server(
         )))
         .with_prompts(srelens_mcp::prompts::PromptLibrary::new(Some(
             prompts_dir.to_path_buf(),
+        )))
+        .with_resources(srelens_registry::kind_resolver())
+        .with_watcher(std::sync::Arc::new(crate::mcp_watch::CacheWatcher::new(
+            manager.cache.clone(),
         )));
     let (tx, rx) = oneshot::channel();
     let handle = tokio::spawn(async move {

--- a/apps/desktop/src-tauri/src/mcp_watch.rs
+++ b/apps/desktop/src-tauri/src/mcp_watch.rs
@@ -1,0 +1,171 @@
+//! The real `ObjectWatcher`: bridges an MCP subscription to a single-object
+//! kube watch, using the app's shared authenticated client cache.
+
+use std::sync::Arc;
+
+use srelens_kube::client_cache::ClientCache;
+use srelens_mcp::resources::{KindResolver, KindScope, ObjectWatcher, ResourceUri, CLUSTER_SCOPED};
+
+/// Watches single objects through the app's shared authenticated client cache,
+/// so an MCP subscription sees exactly the clusters the GUI does.
+pub struct CacheWatcher {
+    cache: Arc<ClientCache>,
+    // The same addressability decision `plan_read` uses, held internally so the
+    // exclusion of unresolvable kinds (and `Secret`, which is curated out of
+    // `k8s://` addressing entirely) cannot drift between the read path and the
+    // watch path.
+    kinds: Arc<dyn KindResolver>,
+}
+
+impl CacheWatcher {
+    pub fn new(cache: Arc<ClientCache>) -> Self {
+        Self { cache, kinds: srelens_registry::kind_resolver() }
+    }
+}
+
+impl ObjectWatcher for CacheWatcher {
+    fn watch(
+        &self,
+        uri: &ResourceUri,
+        on_change: Box<dyn FnMut() + Send>,
+    ) -> Result<tokio::task::AbortHandle, String> {
+        let ResourceUri::Object { context, namespace, kind, name, .. } = uri else {
+            return Err("only object URIs can be watched".to_string());
+        };
+
+        // `srelens_registry::kind_resolver()` returns `None` both for kinds it
+        // cannot resolve at all and for `Secret`, which is deliberately not
+        // addressable as a resource — it stays reachable only through the
+        // consent-gated `k8s.getSecret` tool. Gating here (rather than on
+        // `srelens_kube::manifest::gvk_for`, which *does* resolve `Secret`)
+        // keeps that exclusion in one place instead of duplicating it.
+        let scope = self.kinds.scope(kind).ok_or_else(|| {
+            if kind == "Secret" {
+                "`Secret` is not addressable as a resource; read secrets with the \
+                 `k8s.getSecret` tool, which is consent-gated"
+                    .to_string()
+            } else {
+                format!("kind `{kind}` is not addressable as a resource")
+            }
+        })?;
+
+        // `watch_object`'s contract: `namespace: None` must mean the kind is
+        // genuinely cluster-scoped, or a namespaced kind's bare
+        // `metadata.name` selector would silently match same-named objects in
+        // every namespace. Mirrors the equivalent check in `plan_read`
+        // (`crates/mcp/src/resources.rs`) so the message is consistent
+        // whichever path a caller hits.
+        match (scope, namespace) {
+            (KindScope::Namespaced, None) => {
+                return Err(format!(
+                    "`{kind}` is namespaced; supply a namespace instead of `{CLUSTER_SCOPED}`"
+                ))
+            }
+            (KindScope::ClusterScoped, Some(ns)) => {
+                return Err(format!(
+                    "`{kind}` is cluster-scoped; use `{CLUSTER_SCOPED}` for the namespace, not `{ns}`"
+                ))
+            }
+            _ => {}
+        }
+
+        // The scope check above already establishes this kind is addressable,
+        // so `gvk_for` is used only to obtain the GVK `watch_object` needs.
+        let (gvk, _namespaced) = srelens_kube::manifest::gvk_for(kind)
+            .ok_or_else(|| format!("kind `{kind}` cannot be watched"))?;
+
+        let cache = self.cache.clone();
+        let (context, namespace, name) = (context.clone(), namespace.clone(), name.clone());
+        let task = tokio::spawn(async move {
+            let _ = srelens_kube::watch::watch_object(
+                cache,
+                context,
+                namespace,
+                gvk,
+                name,
+                on_change,
+                |_status| {},
+            )
+            .await;
+        });
+        Ok(task.abort_handle())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use srelens_mcp::resources::{ObjectWatcher, ResourceUri};
+
+    /// A cluster-scoped URI and a namespaced one must both resolve to a watch
+    /// without panicking. The watch itself needs an API server, so the handle
+    /// is expected to end in an error — what matters is that resolution and
+    /// spawning work and nothing panics.
+    #[tokio::test]
+    async fn spawns_a_watch_for_both_scopes_without_panicking() {
+        let cache = srelens_kube::client_cache::ClientCache::new(
+            std::path::PathBuf::from("/nonexistent/kubeconfig"),
+        );
+        let w = CacheWatcher::new(cache);
+        for uri in ["k8s://c/ns/Pod/web-0", "k8s://c/-/Node/node-1"] {
+            let parsed = ResourceUri::parse(uri).unwrap();
+            let handle = w.watch(&parsed, Box::new(|| {})).expect("spawns");
+            handle.abort();
+        }
+    }
+
+    #[tokio::test]
+    async fn refuses_a_kind_it_cannot_resolve() {
+        let cache = srelens_kube::client_cache::ClientCache::new(
+            std::path::PathBuf::from("/nonexistent/kubeconfig"),
+        );
+        let w = CacheWatcher::new(cache);
+        let parsed = ResourceUri::parse("k8s://c/ns/Nonsense/x").unwrap();
+        assert!(w.watch(&parsed, Box::new(|| {})).is_err());
+    }
+
+    /// `ResourceUri::parse` maps the `-` sentinel to `None`, so a namespaced
+    /// kind given `-` must be rejected rather than silently watched with
+    /// `Api::all_with` — which would match same-named objects in every
+    /// namespace (see `watch_object`'s documented contract).
+    #[tokio::test]
+    async fn refuses_a_namespaced_kind_given_no_namespace() {
+        let cache = srelens_kube::client_cache::ClientCache::new(
+            std::path::PathBuf::from("/nonexistent/kubeconfig"),
+        );
+        let w = CacheWatcher::new(cache);
+        let parsed = ResourceUri::parse("k8s://c/-/Pod/web-0").unwrap();
+        let err = w.watch(&parsed, Box::new(|| {})).unwrap_err();
+        assert!(err.contains("namespaced"), "got: {err}");
+    }
+
+    /// The mirror-image mismatch: a cluster-scoped kind given a namespace must
+    /// also be rejected, not silently scoped down to that namespace.
+    #[tokio::test]
+    async fn refuses_a_cluster_scoped_kind_given_a_namespace() {
+        let cache = srelens_kube::client_cache::ClientCache::new(
+            std::path::PathBuf::from("/nonexistent/kubeconfig"),
+        );
+        let w = CacheWatcher::new(cache);
+        let parsed = ResourceUri::parse("k8s://c/ns/Node/node-1").unwrap();
+        let err = w.watch(&parsed, Box::new(|| {})).unwrap_err();
+        assert!(err.contains("cluster-scoped"), "got: {err}");
+    }
+
+    /// `k8s://…/Secret/…` must never be watched: notifications carry no
+    /// content, but firing one still leaks the fact that a secret changed, and
+    /// the design's curation decision is that Secrets are not addressable at
+    /// all — not merely gated on the read path. The assertion checks the
+    /// message names Secrets specifically, so this can't pass for the wrong
+    /// reason (an unresolvable kind also returns `Err`).
+    #[tokio::test]
+    async fn refuses_to_watch_a_secret() {
+        let cache = srelens_kube::client_cache::ClientCache::new(
+            std::path::PathBuf::from("/nonexistent/kubeconfig"),
+        );
+        let w = CacheWatcher::new(cache);
+        let parsed = ResourceUri::parse("k8s://c/ns/Secret/db-creds").unwrap();
+        let err = w.watch(&parsed, Box::new(|| {})).unwrap_err();
+        assert!(err.contains("Secret") && err.contains("not addressable"), "got: {err}");
+    }
+}

--- a/apps/desktop/src-tauri/src/mcp_watch.rs
+++ b/apps/desktop/src-tauri/src/mcp_watch.rs
@@ -76,17 +76,37 @@ impl ObjectWatcher for CacheWatcher {
 
         let cache = self.cache.clone();
         let (context, namespace, name) = (context.clone(), namespace.clone(), name.clone());
+        // `watch` is synchronous and returns before the client is ever
+        // resolved, so it cannot validate the subscription up front — the
+        // best it can do is surface what happens once the task runs. stderr
+        // is free even on the stdio transport (stdout is the JSON-RPC
+        // channel there — see the precedent in `main.rs`), so a dead watch at
+        // least leaves a diagnostic instead of failing silently.
+        //
+        // NOTE: a failed watch (unknown context, or a namespace the identity
+        // cannot `watch`) still stays registered in the `SubscriptionRegistry`
+        // until the client unsubscribes or the session ends — it occupies one
+        // of the 32 slots without ever firing. Evicting it would mean
+        // plumbing the registry (owned by `crates/mcp`) into this watcher
+        // (owned by the desktop app), which crosses a layer boundary; that is
+        // being filed as a follow-up rather than done here.
+        let watch_uri = uri.to_string();
         let task = tokio::spawn(async move {
-            let _ = srelens_kube::watch::watch_object(
+            let result = srelens_kube::watch::watch_object(
                 cache,
                 context,
                 namespace,
                 gvk,
                 name,
                 on_change,
-                |_status| {},
+                |status| {
+                    eprintln!("srelens: mcp watch {watch_uri}: {}", status.as_str());
+                },
             )
             .await;
+            if let Err(e) = result {
+                eprintln!("srelens: mcp watch {watch_uri} ended with an error: {e}");
+            }
         });
         Ok(task.abort_handle())
     }

--- a/apps/desktop/src-tauri/tests/e2e.rs
+++ b/apps/desktop/src-tauri/tests/e2e.rs
@@ -1945,17 +1945,20 @@ async fn mcp_resource_reads(ctx: &str, pod: &str) {
 /// #24's subscription acceptance criterion: subscribe to a pod's manifest and
 /// see a notification when it changes.
 ///
-/// The initial list a subscribe triggers is DELIBERATELY silent:
-/// classification in `is_object_change` (`crates/kube/src/watch.rs`) only
-/// fires `on_change` for `Event::Apply`/`Event::Delete`, never for
-/// `Event::Init`/`InitApply`/`InitDone` — a subscribe must not immediately
-/// notify just because the client already read the resource once to get
-/// there. `is_object_change_fires_only_on_apply_and_delete` pins this. If
-/// this test ever reports zero hits, the fix is NOT to loosen that
-/// classification or weaken the assertion below to `>= 0` — either would
-/// silently undo that corrected behaviour. Instead this test causes a REAL
-/// change to the watched pod after the watch is confirmed running, and only
-/// then waits for a genuine notification.
+/// The initial list a subscribe triggers DOES notify: classification in
+/// `is_object_change` (`crates/kube/src/watch.rs`) fires `on_change` for
+/// every `InitDone`, including the very first one, because a read followed by
+/// a subscribe is not atomic — the object can already differ from what the
+/// client last saw by the time the subscription's first list completes, and
+/// staying silent would leave the client trusting stale state with no
+/// correction. So `hits` is already nonzero once the watch is confirmed
+/// running, before any mutation. To still prove that a REAL subsequent change
+/// produces its own notification (not just the guaranteed initial one), this
+/// test records the hit count as a baseline after the watch is up, then
+/// mutates the watched pod, and asserts the count rises *above that
+/// baseline* — not merely `> 0`, which the initial notification alone would
+/// already satisfy and would make this test pass without exercising the
+/// mutation path at all.
 ///
 /// The mutation is a label added via server-side apply (an `Apply` event)
 /// rather than deleting the pod: the pod is the live Deployment replica the
@@ -1992,6 +1995,11 @@ async fn mcp_resource_subscription(ctx: &str, pod: &str) {
         "the watch task ended before the mutation ran; it should still be watching"
     );
 
+    // Baseline after the initial list, which itself notifies (see the doc
+    // comment above) — the mutation must push the count *past* this, not
+    // merely make it nonzero.
+    let baseline = *hits.lock().unwrap();
+
     let label_yaml = format!(
         "apiVersion: v1\nkind: Pod\nmetadata:\n  name: {pod}\n  namespace: {NS}\n  labels:\n    e2e-subscription-marker: touched\n"
     );
@@ -2006,12 +2014,15 @@ async fn mcp_resource_subscription(ctx: &str, pod: &str) {
 
     let dl = deadline(30);
     loop {
-        if *hits.lock().unwrap() > 0 {
+        if *hits.lock().unwrap() > baseline {
             break;
         }
         if Instant::now() > dl {
             handle.abort();
-            panic!("expected at least one change notification after labeling {pod}");
+            panic!(
+                "expected the hit count to rise above the post-initial-list baseline \
+                 ({baseline}) after labeling {pod}, but it did not"
+            );
         }
         tokio::time::sleep(Duration::from_millis(200)).await;
     }

--- a/apps/desktop/src-tauri/tests/e2e.rs
+++ b/apps/desktop/src-tauri/tests/e2e.rs
@@ -1221,6 +1221,17 @@ async fn run_suite() {
         "expected the busybox loop's output: {out}"
     );
 
+    // === MCP resources (#24) ===================================================
+    // srelens's k8s:// resource-addressing feature, exercised end to end
+    // against this real cluster. Reuses `pod_name`, the Deployment pod
+    // already discovered above for the logs check, rather than provisioning
+    // new cluster state: the fixtures create only a Deployment (no
+    // directly-named pod), so any pod used here has to be discovered via
+    // listPods the same way the logs check above does.
+    println!("=== mcp resources (#24) ===");
+    mcp_resource_reads(&ctx, &pod_name).await;
+    mcp_resource_subscription(&ctx, &pod_name).await;
+
     // === 6. Metrics ============================================================
     // A bare kind cluster ships no metrics-server, so the metrics API may be
     // absent. Don't let that make the happy path vacuous: probe once, and when
@@ -1876,6 +1887,136 @@ async fn delete_context_on_a_copy(h: &mut Harness, ctx: &str) {
 
     let _ = std::fs::remove_file(&tmp);
     println!("deleteContext: removed from the throwaway copy only; real kubeconfig untouched");
+}
+
+/// #24's read acceptance criterion: a manifest, an events list and pod logs
+/// all read successfully over MCP's `resources/read`, plus the curation
+/// guarantee that a Secret which genuinely exists in this cluster is still
+/// not addressable. CI can only exercise the error paths (parse/plan
+/// failures pinned by unit tests in `crates/mcp/src/resources.rs` and
+/// `stdio.rs`) since a successful read needs a real object; this is the
+/// real-cluster half.
+///
+/// The `logs` expectation is an empty string deliberately: a pod may
+/// legitimately have produced no output, so the assertion is that the read
+/// *succeeds* and returns text, not that the text contains anything specific
+/// (this suite's Deployment pods do log "hello", so the substring check
+/// against "" is trivially satisfied either way).
+async fn mcp_resource_reads(ctx: &str, pod: &str) {
+    println!("=== mcp resources: reads ===");
+    let server = srelens_mcp::McpServer::new(Arc::new(build_registry_with(cache())))
+        .with_resources(srelens_registry::kind_resolver());
+
+    for (uri, expect) in [
+        (format!("k8s://{ctx}/{NS}/Pod/{pod}"), "kind: Pod"),
+        (format!("k8s://{ctx}/{NS}/Pod/{pod}/events"), "["),
+        (format!("k8s://{ctx}/{NS}/Pod/{pod}/logs"), ""),
+    ] {
+        let resp = srelens_mcp::stdio::handle_request(
+            &server,
+            &json!({"jsonrpc":"2.0","id":1,"method":"resources/read",
+                                "params":{"uri":uri}}),
+            srelens_mcp::Transport::Stdio,
+        )
+        .await
+        .expect("a response");
+        let contents = &resp["result"]["contents"][0];
+        let text = contents["text"]
+            .as_str()
+            .unwrap_or_else(|| panic!("read of {uri} failed: {resp}"));
+        assert!(text.contains(expect), "read of {uri} returned {text}");
+        assert!(contents["mimeType"].is_string());
+    }
+
+    // The curation guarantee against a real cluster: the SECRET fixture
+    // genuinely exists in NS, and is still not addressable.
+    let resp = srelens_mcp::stdio::handle_request(
+        &server,
+        &json!({"jsonrpc":"2.0","id":2,"method":"resources/read",
+                            "params":{"uri":format!("k8s://{ctx}/{NS}/Secret/{SECRET}")}}),
+        srelens_mcp::Transport::Stdio,
+    )
+    .await
+    .expect("a response");
+    assert_eq!(resp["error"]["code"], -32602, "unexpected response: {resp}");
+    println!("mcp resources: manifest/events/logs read OK; Secret still unaddressable");
+}
+
+/// #24's subscription acceptance criterion: subscribe to a pod's manifest and
+/// see a notification when it changes.
+///
+/// The initial list a subscribe triggers is DELIBERATELY silent:
+/// classification in `is_object_change` (`crates/kube/src/watch.rs`) only
+/// fires `on_change` for `Event::Apply`/`Event::Delete`, never for
+/// `Event::Init`/`InitApply`/`InitDone` — a subscribe must not immediately
+/// notify just because the client already read the resource once to get
+/// there. `is_object_change_fires_only_on_apply_and_delete` pins this. If
+/// this test ever reports zero hits, the fix is NOT to loosen that
+/// classification or weaken the assertion below to `>= 0` — either would
+/// silently undo that corrected behaviour. Instead this test causes a REAL
+/// change to the watched pod after the watch is confirmed running, and only
+/// then waits for a genuine notification.
+///
+/// The mutation is a label added via server-side apply (an `Apply` event)
+/// rather than deleting the pod: the pod is the live Deployment replica the
+/// logs check above already exercised, and a label patch leaves it running
+/// under the same name, so nothing else in the suite has to wait for the
+/// Deployment to notice and recreate a differently-named replacement.
+async fn mcp_resource_subscription(ctx: &str, pod: &str) {
+    println!("=== mcp resources: subscription ===");
+    let server = srelens_mcp::McpServer::new(Arc::new(build_registry_with(cache())))
+        .with_resources(srelens_registry::kind_resolver())
+        .with_watcher(Arc::new(srelens_desktop_lib::mcp_watch::CacheWatcher::new(
+            cache(),
+        )));
+
+    let uri = srelens_mcp::resources::ResourceUri::parse(&format!("k8s://{ctx}/{NS}/Pod/{pod}"))
+        .unwrap();
+
+    let hits = Arc::new(std::sync::Mutex::new(0usize));
+    let counter = hits.clone();
+    let handle = srelens_mcp::resources::ObjectWatcher::watch(
+        server.watcher().as_ref(),
+        &uri,
+        Box::new(move || *counter.lock().unwrap() += 1),
+    )
+    .expect("watch spawns");
+
+    // Establish the watch first, and confirm it is actually running, before
+    // mutating anything: the ordering is what makes the assertion below mean
+    // "the notification followed our change" rather than "something fired at
+    // some point".
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    assert!(
+        !handle.is_finished(),
+        "the watch task ended before the mutation ran; it should still be watching"
+    );
+
+    let label_yaml = format!(
+        "apiVersion: v1\nkind: Pod\nmetadata:\n  name: {pod}\n  namespace: {NS}\n  labels:\n    e2e-subscription-marker: touched\n"
+    );
+    let out = server
+        .call_tool(
+            "k8s.applyManifest",
+            json!({ "context": ctx, "yaml": label_yaml }),
+        )
+        .await
+        .expect("labeling the watched pod must succeed");
+    assert_eq!(out["applied"], true, "label apply must succeed: {out}");
+
+    let dl = deadline(30);
+    loop {
+        if *hits.lock().unwrap() > 0 {
+            break;
+        }
+        if Instant::now() > dl {
+            handle.abort();
+            panic!("expected at least one change notification after labeling {pod}");
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    handle.abort();
+    println!("mcp resources: subscription fired on Apply after a label change");
 }
 
 /// Delete the `srelens-e2e` namespace and its CRD, and make sure the node(s)

--- a/crates/kube/src/logs.rs
+++ b/crates/kube/src/logs.rs
@@ -144,7 +144,9 @@ pub struct PodLogsIn {
     pub context: String,
     pub namespace: String,
     pub pod: String,
-    /// Container name (optional; defaults to the pod's only/first container).
+    /// Container name. May be omitted only when the pod has exactly one
+    /// container — the Kubernetes log API rejects an omitted container name
+    /// for any pod with more than one (it does not pick one for you).
     #[serde(default)]
     pub container: Option<String>,
     /// Number of trailing lines to return (default 200).

--- a/crates/kube/src/watch.rs
+++ b/crates/kube/src/watch.rs
@@ -722,21 +722,45 @@ where
     .await
 }
 
-/// Classify a watcher event as an object change (`Apply`/`Delete`) versus
-/// part of the initial list (`Init`/`InitApply`/`InitDone`). Pulled out as a
-/// pure function because `watch_object` itself cannot be unit-tested without
-/// an API server, and getting this classification wrong (e.g. treating the
-/// initial list as a change) would spuriously notify a fresh subscriber.
-fn is_object_change<K>(event: &Event<K>) -> bool {
-    matches!(event, Event::Apply(_) | Event::Delete(_))
+/// Classify a watcher event as an object change. `Apply`/`Delete` always are.
+/// `Init`/`InitApply` never are — they only ever replay the current list.
+/// `InitDone` closes an init sequence, and kube-runtime runs *another* init
+/// sequence (`Init` → `InitApply` → `InitDone`) every time it re-lists after a
+/// desync (410 GONE, etcd compaction, apiserver restart), so `InitDone` is a
+/// change exactly when this is not the first init sequence — i.e. `seen_init_done`
+/// (whether an earlier `InitDone` has already fired) is `true`. That keeps the
+/// very first list silent (a subscribe must not notify just because the
+/// client already read the resource) while still notifying once per relist, so
+/// a change that lands during the reconnect gap — and so arrives only as part
+/// of the replayed list, never as a standalone `Apply` — is not silently lost.
+/// Pulled out as a pure function taking the flag explicitly (rather than
+/// closing over mutable state) because `watch_object` itself cannot be
+/// unit-tested without an API server, and getting this classification wrong
+/// would either spuriously notify a fresh subscriber or under-notify from
+/// missing a change made during a relist.
+fn is_object_change<K>(event: &Event<K>, seen_init_done: bool) -> bool {
+    match event {
+        Event::Apply(_) | Event::Delete(_) => true,
+        Event::Init | Event::InitApply(_) => false,
+        Event::InitDone => seen_init_done,
+    }
 }
 
-/// Watch a single object by name, calling `on_change` on every apply or delete.
+/// Watch a single object by name, calling `on_change` on every apply, delete,
+/// or relist-that-changed-something.
 ///
 /// One API watch per object via a `metadata.name` field selector, rather than
 /// streaming a whole namespace to observe one member. `on_change` takes no
 /// payload deliberately: the MCP subscription it backs sends only a URI and the
 /// client re-reads, so this needs to detect *that* something changed.
+///
+/// **First list silent, relists notify:** the very first `Init`/`InitApply`*/
+/// `InitDone` sequence is deliberately silent — a subscribe must not notify
+/// just because the client already read the resource. But kube-runtime resets
+/// and re-lists (another `Init`/`InitApply`*/`InitDone` sequence) after a watch
+/// desync, and that is the *only* way a change made during the reconnect gap
+/// ever arrives. So every init sequence after the first is treated as a
+/// change, notifying once on that relist's `InitDone`.
 ///
 /// **Namespace contract:** `namespace: None` means the caller has already
 /// established that `gvk` is cluster-scoped. This function cannot detect a
@@ -773,10 +797,19 @@ where
              a Kubernetes object name and would corrupt the metadata.name field selector"
         ));
     }
+    if namespace.as_deref() == Some("") {
+        return Err(
+            "watch_object: namespace must not be an empty string; pass None for a \
+             cluster-scoped kind, not Some(\"\") — an empty namespace would silently \
+             widen the watch to Api::all_with, matching same-named objects in every \
+             namespace"
+                .into(),
+        );
+    }
 
     let client = cache.get(&context).await?;
     let ar = ApiResource::from_gvk(&gvk);
-    let api: Api<DynamicObject> = match namespace.as_deref().filter(|s| !s.is_empty()) {
+    let api: Api<DynamicObject> = match namespace.as_deref() {
         Some(ns) => Api::namespaced_with(client, ns, &ar),
         None => Api::all_with(client, &ar),
     };
@@ -784,6 +817,7 @@ where
     let config = Config::default().fields(&format!("metadata.name={name}"));
     let mut stream = kube::runtime::watcher(api, config).boxed();
     let mut reconnecting = false;
+    let mut seen_init_done = false;
 
     while let Some(item) = stream.next().await {
         match item {
@@ -792,8 +826,11 @@ where
                     reconnecting = false;
                     on_status(WatchStatus::Live);
                 }
-                if is_object_change(&event) {
+                if is_object_change(&event, seen_init_done) {
                     on_change();
+                }
+                if matches!(event, Event::InitDone) {
+                    seen_init_done = true;
                 }
             }
             Err(e) => {
@@ -945,16 +982,77 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn watch_object_rejects_an_empty_namespace_instead_of_widening_the_watch() {
+        // `ResourceUri::parse` cannot currently produce `Some("")` (the `-`
+        // sentinel maps to `None`), so this is defence at the layer that
+        // documents the contract, not a live bug from the URI path. But
+        // silently coercing `Some("")` into `Api::all_with` would be exactly
+        // the cross-namespace wrong-object watch this function's own doc
+        // comment warns about, so it must be rejected like the empty-name and
+        // metacharacter cases above rather than swallowed.
+        let cache = ClientCache::new(std::path::PathBuf::from("/nonexistent/kubeconfig"));
+        let gvk = kube::api::GroupVersionKind::gvk("", "v1", "Pod");
+        let err = watch_object(
+            cache,
+            "no-such-context".into(),
+            Some("".into()),
+            gvk,
+            "web-0".into(),
+            || {},
+            |_| {},
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("namespace"), "expected a namespace error, got: {err}");
+    }
+
     /// `Event` is generic; `()` is the cheapest `K` that still lets us
     /// construct every variant, since `is_object_change` never inspects the
-    /// payload.
+    /// payload. `Apply`/`Delete` are always changes and `Init`/`InitApply`
+    /// never are, regardless of `seen_init_done`; `InitDone` depends on it —
+    /// that's the relist-notification behaviour pinned separately below.
     #[test]
     fn is_object_change_fires_only_on_apply_and_delete() {
-        assert!(!is_object_change(&Event::<()>::Init));
-        assert!(!is_object_change(&Event::InitApply(())));
-        assert!(!is_object_change(&Event::<()>::InitDone));
-        assert!(is_object_change(&Event::Apply(())));
-        assert!(is_object_change(&Event::Delete(())));
+        for seen_init_done in [false, true] {
+            assert!(!is_object_change(&Event::<()>::Init, seen_init_done));
+            assert!(!is_object_change(&Event::InitApply(()), seen_init_done));
+            assert!(is_object_change(&Event::Apply(()), seen_init_done));
+            assert!(is_object_change(&Event::Delete(()), seen_init_done));
+        }
+        assert!(!is_object_change(&Event::<()>::InitDone, false));
+        assert!(is_object_change(&Event::<()>::InitDone, true));
+    }
+
+    /// The relist scenario that this fix exists for: a change that lands
+    /// during the reconnect gap arrives only as part of the replayed init
+    /// sequence, never as a standalone `Apply`. The first init sequence
+    /// (`Init`, `InitApply`, `InitDone`) must stay silent — that's just the
+    /// normal first list a subscribe triggers — but the second one (the
+    /// relist) must report exactly one change, on its `InitDone`, mirroring
+    /// how `reduce` emits once per relist.
+    #[test]
+    fn a_relist_after_the_first_init_sequence_is_reported_as_one_change() {
+        let mut seen_init_done = false;
+        let mut changes = 0;
+
+        for event in [
+            Event::<()>::Init,
+            Event::InitApply(()),
+            Event::InitDone,
+            Event::Init,
+            Event::InitApply(()),
+            Event::InitDone,
+        ] {
+            if is_object_change(&event, seen_init_done) {
+                changes += 1;
+            }
+            if matches!(event, Event::InitDone) {
+                seen_init_done = true;
+            }
+        }
+
+        assert_eq!(changes, 1, "expected exactly one change, from the second InitDone");
     }
 
     #[test]

--- a/crates/kube/src/watch.rs
+++ b/crates/kube/src/watch.rs
@@ -737,6 +737,14 @@ fn is_object_change<K>(event: &Event<K>) -> bool {
 /// streaming a whole namespace to observe one member. `on_change` takes no
 /// payload deliberately: the MCP subscription it backs sends only a URI and the
 /// client re-reads, so this needs to detect *that* something changed.
+///
+/// **Namespace contract:** `namespace: None` means the caller has already
+/// established that `gvk` is cluster-scoped. This function cannot detect a
+/// kind's scope itself, so passing `None` for a *namespaced* kind will watch
+/// with `Api::all_with` and the bare `metadata.name={name}` selector will
+/// match same-named objects in every namespace, silently firing `on_change`
+/// for a different object than the one the caller subscribed to. Establishing
+/// scope before calling is the caller's responsibility.
 pub async fn watch_object<F, G>(
     cache: Arc<ClientCache>,
     context: String,
@@ -751,6 +759,20 @@ where
     G: FnMut(WatchStatus) + Send,
 {
     use kube::api::{ApiResource, DynamicObject};
+
+    if name.is_empty() {
+        return Err(
+            "watch_object: object name must not be empty (an empty metadata.name \
+             selector matches nothing, so the watch would sit forever without firing)"
+                .into(),
+        );
+    }
+    if let Some(bad) = name.chars().find(|c| *c == ',' || *c == '=') {
+        return Err(format!(
+            "watch_object: object name {name:?} contains '{bad}', which is not valid in \
+             a Kubernetes object name and would corrupt the metadata.name field selector"
+        ));
+    }
 
     let client = cache.get(&context).await?;
     let ar = ApiResource::from_gvk(&gvk);
@@ -869,6 +891,58 @@ mod tests {
         .await
         .unwrap_err();
         assert!(!err.is_empty(), "the client failure must be surfaced as an error string");
+    }
+
+    #[tokio::test]
+    async fn watch_object_rejects_an_empty_name_before_touching_the_client() {
+        // An empty `metadata.name=` selector matches nothing, so the watch
+        // would sit forever without ever firing `on_change` or erroring — the
+        // worst possible failure shape for a subscription. Reject up front.
+        // Uses the same nonexistent kubeconfig as the client-error test above;
+        // if this reached `cache.get` it would still error, but for the wrong
+        // reason, so the assertion pins the *message*, not just `is_err()`.
+        let cache = ClientCache::new(std::path::PathBuf::from("/nonexistent/kubeconfig"));
+        let gvk = kube::api::GroupVersionKind::gvk("", "v1", "Pod");
+        let err = watch_object(
+            cache,
+            "no-such-context".into(),
+            Some("ns".into()),
+            gvk,
+            "".into(),
+            || {},
+            |_| {},
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("empty"), "expected an empty-name error, got: {err}");
+    }
+
+    #[tokio::test]
+    async fn watch_object_rejects_a_name_containing_a_selector_metacharacter() {
+        // A `,` or `=` in `name` reshapes `metadata.name={name}` into extra or
+        // malformed field-selector terms. Neither character is valid in a real
+        // Kubernetes object name (RFC 1123), so reject both before any client
+        // work rather than silently producing a selector that matches the
+        // wrong thing (or nothing).
+        let gvk = kube::api::GroupVersionKind::gvk("", "v1", "Pod");
+        for bad_name in ["web-0,evil=1", "web=0"] {
+            let cache = ClientCache::new(std::path::PathBuf::from("/nonexistent/kubeconfig"));
+            let err = watch_object(
+                cache,
+                "no-such-context".into(),
+                Some("ns".into()),
+                gvk.clone(),
+                bad_name.into(),
+                || {},
+                |_| {},
+            )
+            .await
+            .unwrap_err();
+            assert!(
+                err.contains(bad_name),
+                "expected the offending name {bad_name:?} to be named in the error, got: {err}"
+            );
+        }
     }
 
     /// `Event` is generic; `()` is the cheapest `K` that still lets us

--- a/crates/kube/src/watch.rs
+++ b/crates/kube/src/watch.rs
@@ -723,26 +723,43 @@ where
 }
 
 /// Classify a watcher event as an object change. `Apply`/`Delete` always are.
-/// `Init`/`InitApply` never are — they only ever replay the current list.
-/// `InitDone` closes an init sequence, and kube-runtime runs *another* init
-/// sequence (`Init` → `InitApply` → `InitDone`) every time it re-lists after a
-/// desync (410 GONE, etcd compaction, apiserver restart), so `InitDone` is a
-/// change exactly when this is not the first init sequence — i.e. `seen_init_done`
-/// (whether an earlier `InitDone` has already fired) is `true`. That keeps the
-/// very first list silent (a subscribe must not notify just because the
-/// client already read the resource) while still notifying once per relist, so
-/// a change that lands during the reconnect gap — and so arrives only as part
-/// of the replayed list, never as a standalone `Apply` — is not silently lost.
-/// Pulled out as a pure function taking the flag explicitly (rather than
-/// closing over mutable state) because `watch_object` itself cannot be
-/// unit-tested without an API server, and getting this classification wrong
-/// would either spuriously notify a fresh subscriber or under-notify from
-/// missing a change made during a relist.
-fn is_object_change<K>(event: &Event<K>, seen_init_done: bool) -> bool {
+/// `Init`/`InitApply` never are — they are just the replay of the current list
+/// building up in memory, with nothing yet to report. `InitDone` — which
+/// closes *every* init sequence, the very first list and every subsequent
+/// relist alike — always is a change.
+///
+/// That includes the first list deliberately. A subscribe is never atomic
+/// with the read that precedes it: the client reads the object at version A,
+/// the object changes to B, and only then does the client subscribe. If the
+/// initial list stayed silent, the client would be stuck believing A is
+/// current until some unrelated later change happened to notify it — a lost
+/// update with no bound on how long it lasts. Notifying on the first list
+/// costs one redundant re-read when nothing actually changed between the read
+/// and the subscribe; that is the correct direction to be wrong in. This
+/// module's documented contract is that the signal may over-notify but must
+/// never under-notify, and firing on every `InitDone` — not just relists — is
+/// what makes that hold.
+///
+/// kube-runtime also runs additional init sequences (`Init` → `InitApply`* →
+/// `InitDone`) whenever it re-lists after a desync (410 GONE, etcd
+/// compaction, apiserver restart), and a change that lands during that
+/// reconnect gap arrives only as part of the replayed list, never as a
+/// standalone `Apply`. Firing on every `InitDone` covers that case too, for
+/// the same reason.
+///
+/// Do not special-case the first `InitDone` back to silent "for tidiness" —
+/// that reintroduces the lost-update window this rule closes.
+///
+/// Pulled out as a pure function (rather than inlined in `watch_object`)
+/// because `watch_object` itself cannot be unit-tested without an API server,
+/// and getting this classification wrong would either under-notify from
+/// missing a change made before a subscribe or during a relist, or spuriously
+/// notify on a relist that changed nothing.
+fn is_object_change<K>(event: &Event<K>) -> bool {
     match event {
         Event::Apply(_) | Event::Delete(_) => true,
         Event::Init | Event::InitApply(_) => false,
-        Event::InitDone => seen_init_done,
+        Event::InitDone => true,
     }
 }
 
@@ -754,13 +771,17 @@ fn is_object_change<K>(event: &Event<K>, seen_init_done: bool) -> bool {
 /// payload deliberately: the MCP subscription it backs sends only a URI and the
 /// client re-reads, so this needs to detect *that* something changed.
 ///
-/// **First list silent, relists notify:** the very first `Init`/`InitApply`*/
-/// `InitDone` sequence is deliberately silent — a subscribe must not notify
-/// just because the client already read the resource. But kube-runtime resets
-/// and re-lists (another `Init`/`InitApply`*/`InitDone` sequence) after a watch
-/// desync, and that is the *only* way a change made during the reconnect gap
-/// ever arrives. So every init sequence after the first is treated as a
-/// change, notifying once on that relist's `InitDone`.
+/// **Every list notifies, initial and relists alike:** each init sequence
+/// (`Init` → `InitApply`* → `InitDone`) fires `on_change` once, on its
+/// `InitDone` — see `is_object_change`. The initial list is included
+/// deliberately: a read followed by a subscribe is not atomic, so the object
+/// can already differ from what the client last saw by the time the
+/// subscription's first list completes, and staying silent would leave the
+/// client trusting stale state with nothing to correct it. A redundant
+/// notification when nothing actually changed is the correct failure
+/// direction, not a bug to tidy away. The same rule also covers a relist after
+/// a watch desync, which is the only way a change made during the reconnect
+/// gap ever arrives.
 ///
 /// **Namespace contract:** `namespace: None` means the caller has already
 /// established that `gvk` is cluster-scoped. This function cannot detect a
@@ -817,7 +838,6 @@ where
     let config = Config::default().fields(&format!("metadata.name={name}"));
     let mut stream = kube::runtime::watcher(api, config).boxed();
     let mut reconnecting = false;
-    let mut seen_init_done = false;
 
     while let Some(item) = stream.next().await {
         match item {
@@ -826,11 +846,8 @@ where
                     reconnecting = false;
                     on_status(WatchStatus::Live);
                 }
-                if is_object_change(&event, seen_init_done) {
+                if is_object_change(&event) {
                     on_change();
-                }
-                if matches!(event, Event::InitDone) {
-                    seen_init_done = true;
                 }
             }
             Err(e) => {
@@ -1009,31 +1026,24 @@ mod tests {
 
     /// `Event` is generic; `()` is the cheapest `K` that still lets us
     /// construct every variant, since `is_object_change` never inspects the
-    /// payload. `Apply`/`Delete` are always changes and `Init`/`InitApply`
-    /// never are, regardless of `seen_init_done`; `InitDone` depends on it —
-    /// that's the relist-notification behaviour pinned separately below.
+    /// payload. `Apply`/`Delete` and `InitDone` are always changes;
+    /// `Init`/`InitApply` never are.
     #[test]
-    fn is_object_change_fires_only_on_apply_and_delete() {
-        for seen_init_done in [false, true] {
-            assert!(!is_object_change(&Event::<()>::Init, seen_init_done));
-            assert!(!is_object_change(&Event::InitApply(()), seen_init_done));
-            assert!(is_object_change(&Event::Apply(()), seen_init_done));
-            assert!(is_object_change(&Event::Delete(()), seen_init_done));
-        }
-        assert!(!is_object_change(&Event::<()>::InitDone, false));
-        assert!(is_object_change(&Event::<()>::InitDone, true));
+    fn is_object_change_fires_on_apply_delete_and_init_done() {
+        assert!(!is_object_change(&Event::<()>::Init));
+        assert!(!is_object_change(&Event::InitApply(())));
+        assert!(is_object_change(&Event::Apply(())));
+        assert!(is_object_change(&Event::Delete(())));
+        assert!(is_object_change(&Event::<()>::InitDone));
     }
 
-    /// The relist scenario that this fix exists for: a change that lands
+    /// The relist scenario this signal exists to cover: a change that lands
     /// during the reconnect gap arrives only as part of the replayed init
-    /// sequence, never as a standalone `Apply`. The first init sequence
-    /// (`Init`, `InitApply`, `InitDone`) must stay silent — that's just the
-    /// normal first list a subscribe triggers — but the second one (the
-    /// relist) must report exactly one change, on its `InitDone`, mirroring
-    /// how `reduce` emits once per relist.
+    /// sequence, never as a standalone `Apply`. Both the first list and the
+    /// relist must report a change, once each, on their respective
+    /// `InitDone` — mirroring how `reduce` emits once per list.
     #[test]
-    fn a_relist_after_the_first_init_sequence_is_reported_as_one_change() {
-        let mut seen_init_done = false;
+    fn every_init_sequence_including_the_first_is_reported_as_one_change() {
         let mut changes = 0;
 
         for event in [
@@ -1044,15 +1054,12 @@ mod tests {
             Event::InitApply(()),
             Event::InitDone,
         ] {
-            if is_object_change(&event, seen_init_done) {
+            if is_object_change(&event) {
                 changes += 1;
-            }
-            if matches!(event, Event::InitDone) {
-                seen_init_done = true;
             }
         }
 
-        assert_eq!(changes, 1, "expected exactly one change, from the second InitDone");
+        assert_eq!(changes, 2, "expected one change per InitDone, first list and relist alike");
     }
 
     #[test]

--- a/crates/kube/src/watch.rs
+++ b/crates/kube/src/watch.rs
@@ -722,6 +722,73 @@ where
     .await
 }
 
+/// Classify a watcher event as an object change (`Apply`/`Delete`) versus
+/// part of the initial list (`Init`/`InitApply`/`InitDone`). Pulled out as a
+/// pure function because `watch_object` itself cannot be unit-tested without
+/// an API server, and getting this classification wrong (e.g. treating the
+/// initial list as a change) would spuriously notify a fresh subscriber.
+fn is_object_change<K>(event: &Event<K>) -> bool {
+    matches!(event, Event::Apply(_) | Event::Delete(_))
+}
+
+/// Watch a single object by name, calling `on_change` on every apply or delete.
+///
+/// One API watch per object via a `metadata.name` field selector, rather than
+/// streaming a whole namespace to observe one member. `on_change` takes no
+/// payload deliberately: the MCP subscription it backs sends only a URI and the
+/// client re-reads, so this needs to detect *that* something changed.
+pub async fn watch_object<F, G>(
+    cache: Arc<ClientCache>,
+    context: String,
+    namespace: Option<String>,
+    gvk: kube::api::GroupVersionKind,
+    name: String,
+    mut on_change: F,
+    mut on_status: G,
+) -> Result<(), String>
+where
+    F: FnMut() + Send,
+    G: FnMut(WatchStatus) + Send,
+{
+    use kube::api::{ApiResource, DynamicObject};
+
+    let client = cache.get(&context).await?;
+    let ar = ApiResource::from_gvk(&gvk);
+    let api: Api<DynamicObject> = match namespace.as_deref().filter(|s| !s.is_empty()) {
+        Some(ns) => Api::namespaced_with(client, ns, &ar),
+        None => Api::all_with(client, &ar),
+    };
+
+    let config = Config::default().fields(&format!("metadata.name={name}"));
+    let mut stream = kube::runtime::watcher(api, config).boxed();
+    let mut reconnecting = false;
+
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok(event) => {
+                if reconnecting {
+                    reconnecting = false;
+                    on_status(WatchStatus::Live);
+                }
+                if is_object_change(&event) {
+                    on_change();
+                }
+            }
+            Err(e) => {
+                let msg = e.to_string();
+                if is_permanent_watch_error(&msg) {
+                    return Err(msg);
+                }
+                if !reconnecting {
+                    reconnecting = true;
+                    on_status(WatchStatus::Reconnecting);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -771,6 +838,49 @@ mod tests {
         let snap = snapshot(&state);
         assert_eq!(snap.len(), 1);
         assert_eq!(snap[0].name, "b");
+    }
+
+    /// `watch_object` cannot be exercised without an API server, so this pins
+    /// the part that is pure: a permanent error must stop the loop rather than
+    /// reconnect forever, and everything else must be treated as transient.
+    #[test]
+    fn only_forbidden_is_a_permanent_watch_error_for_object_watches() {
+        assert!(is_permanent_watch_error("Forbidden: User cannot watch pods"));
+        assert!(is_permanent_watch_error("FORBIDDEN"));
+        assert!(!is_permanent_watch_error("connection reset by peer"));
+        assert!(!is_permanent_watch_error("401 Unauthorized"));
+        assert!(!is_permanent_watch_error("too old resource version"));
+    }
+
+    #[tokio::test]
+    async fn watch_object_surfaces_a_client_error_instead_of_panicking() {
+        // No such context, so `cache.get` fails before any watch begins.
+        let cache = ClientCache::new(std::path::PathBuf::from("/nonexistent/kubeconfig"));
+        let gvk = kube::api::GroupVersionKind::gvk("", "v1", "Pod");
+        let err = watch_object(
+            cache,
+            "no-such-context".into(),
+            Some("ns".into()),
+            gvk,
+            "web-0".into(),
+            || {},
+            |_| {},
+        )
+        .await
+        .unwrap_err();
+        assert!(!err.is_empty(), "the client failure must be surfaced as an error string");
+    }
+
+    /// `Event` is generic; `()` is the cheapest `K` that still lets us
+    /// construct every variant, since `is_object_change` never inspects the
+    /// payload.
+    #[test]
+    fn is_object_change_fires_only_on_apply_and_delete() {
+        assert!(!is_object_change(&Event::<()>::Init));
+        assert!(!is_object_change(&Event::InitApply(())));
+        assert!(!is_object_change(&Event::<()>::InitDone));
+        assert!(is_object_change(&Event::Apply(())));
+        assert!(is_object_change(&Event::Delete(())));
     }
 
     #[test]

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -19,7 +19,7 @@ axum = "0.7"
 percent-encoding = "2"
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt", "io-util"] }
+tokio = { version = "1", features = ["macros", "rt", "io-util", "time"] }
 tower = { version = "0.5", features = ["util"] }
 # Dev-only, so this does not create a real dependency cycle: `registry`
 # depends on `mcp` only as a dev-dependency too (for its own e2e prompt

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -13,6 +13,10 @@ serde_yaml = "0.9"
 subtle = "2"
 tokio = { version = "1", features = ["io-util", "net", "rt-multi-thread", "macros"] }
 axum = "0.7"
+# URI segments are percent-encoded because kube context names are arbitrary —
+# EKS names contexts with ARNs containing `/` and `:`, which would otherwise
+# reshape the path. Already in the workspace lockfile via reqwest/url.
+percent-encoding = "2"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt", "io-util"] }

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -11,7 +11,7 @@ serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 subtle = "2"
-tokio = { version = "1", features = ["io-util", "net", "rt-multi-thread", "macros"] }
+tokio = { version = "1", features = ["io-util", "net", "rt-multi-thread", "macros", "sync"] }
 axum = "0.7"
 # URI segments are percent-encoded because kube context names are arbitrary —
 # EKS names contexts with ARNs containing `/` and `:`, which would otherwise

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -45,6 +45,7 @@ pub struct McpServer {
     audit: Arc<dyn crate::audit::AuditSink>,
     prompts: crate::prompts::PromptLibrary,
     resources: std::sync::Arc<dyn crate::resources::KindResolver>,
+    watcher: std::sync::Arc<dyn crate::resources::ObjectWatcher>,
 }
 
 impl McpServer {
@@ -59,6 +60,9 @@ impl McpServer {
             // Fail closed: no resolver means no object resources, only the two
             // fixed ones.
             resources: std::sync::Arc::new(crate::resources::NoKinds),
+            // Fail closed: refuse subscriptions rather than accept ones that
+            // will never fire.
+            watcher: std::sync::Arc::new(crate::resources::NoWatcher),
         }
     }
 
@@ -99,6 +103,18 @@ impl McpServer {
 
     pub fn resources(&self) -> &std::sync::Arc<dyn crate::resources::KindResolver> {
         &self.resources
+    }
+
+    pub fn with_watcher(
+        mut self,
+        watcher: std::sync::Arc<dyn crate::resources::ObjectWatcher>,
+    ) -> Self {
+        self.watcher = watcher;
+        self
+    }
+
+    pub fn watcher(&self) -> &std::sync::Arc<dyn crate::resources::ObjectWatcher> {
+        &self.watcher
     }
 
     /// Whether a tool reads sensitive material, so the audit log can redact

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -43,6 +43,7 @@ pub struct McpServer {
     confirm_policy: Arc<dyn crate::policy::ConfirmPolicy>,
     audit: Arc<dyn crate::audit::AuditSink>,
     prompts: crate::prompts::PromptLibrary,
+    resources: std::sync::Arc<dyn crate::resources::KindResolver>,
 }
 
 impl McpServer {
@@ -54,6 +55,9 @@ impl McpServer {
             audit: Arc::new(crate::audit::NoopAudit),
             // Built-ins only until a host supplies a user prompt directory.
             prompts: crate::prompts::PromptLibrary::new(None),
+            // Fail closed: no resolver means no object resources, only the two
+            // fixed ones.
+            resources: std::sync::Arc::new(crate::resources::NoKinds),
         }
     }
 
@@ -82,6 +86,18 @@ impl McpServer {
 
     pub fn prompts(&self) -> &crate::prompts::PromptLibrary {
         &self.prompts
+    }
+
+    pub fn with_resources(
+        mut self,
+        kinds: std::sync::Arc<dyn crate::resources::KindResolver>,
+    ) -> Self {
+        self.resources = kinds;
+        self
+    }
+
+    pub fn resources(&self) -> &std::sync::Arc<dyn crate::resources::KindResolver> {
+        &self.resources
     }
 
     /// Whether a tool reads sensitive material, so the audit log can redact

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -8,6 +8,7 @@ pub mod policy;
 pub mod prompts;
 pub mod resources;
 pub mod stdio;
+pub mod subscriptions;
 
 use std::sync::Arc;
 

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -6,6 +6,7 @@ pub mod completeness;
 pub mod http;
 pub mod policy;
 pub mod prompts;
+pub mod resources;
 pub mod stdio;
 
 use std::sync::Arc;

--- a/crates/mcp/src/resources.rs
+++ b/crates/mcp/src/resources.rs
@@ -268,6 +268,55 @@ impl std::fmt::Display for ResourceUri {
     }
 }
 
+/// The only resources `resources/list` returns. Enumerating cluster objects
+/// would be unbounded and would need a cluster round-trip to answer a
+/// discovery call, so object addressing is advertised via templates instead.
+pub fn fixed_resources() -> Vec<serde_json::Value> {
+    use serde_json::json;
+    vec![
+        json!({
+            "uri": "k8s://contexts",
+            "name": "Kube contexts",
+            "description": "Contexts srelens can connect to, and which is current.",
+            "mimeType": "application/json"
+        }),
+        json!({
+            "uri": "k8s://catalog",
+            "name": "srelens catalog",
+            "description": "Every tool, prompt and resource template this server exposes.",
+            "mimeType": "application/json"
+        }),
+    ]
+}
+
+/// Parameterised URI shapes, which is what makes object addressing
+/// discoverable without enumerating anything.
+pub fn templates() -> Vec<serde_json::Value> {
+    use serde_json::json;
+    vec![
+        json!({
+            "uriTemplate": "k8s://{context}/{namespace}/{kind}/{name}",
+            "name": "Object manifest",
+            "description": "A resource's manifest as YAML. Use `-` as the namespace for \
+                            cluster-scoped kinds. Secrets are not addressable — read them \
+                            with the k8s.getSecret tool.",
+            "mimeType": "application/yaml"
+        }),
+        json!({
+            "uriTemplate": "k8s://{context}/{namespace}/{kind}/{name}/events",
+            "name": "Object events",
+            "description": "Events whose involved object is this resource.",
+            "mimeType": "application/json"
+        }),
+        json!({
+            "uriTemplate": "k8s://{context}/{namespace}/Pod/{name}/logs",
+            "name": "Pod logs",
+            "description": "Recent log output for a pod's default container.",
+            "mimeType": "text/plain"
+        }),
+    ]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -473,6 +522,34 @@ mod tests {
         ] {
             let e = ResourceUri::parse(uri).unwrap_err();
             assert!(e.contains(expect), "for {uri}, message {e:?} should mention {expect:?}");
+        }
+    }
+
+    #[test]
+    fn list_returns_only_the_two_fixed_resources() {
+        let list = fixed_resources();
+        assert_eq!(list.len(), 2, "cluster objects must never be enumerated: {list:?}");
+        let uris: Vec<&str> = list.iter().map(|r| r["uri"].as_str().unwrap()).collect();
+        assert!(uris.contains(&"k8s://contexts"));
+        assert!(uris.contains(&"k8s://catalog"));
+        for r in &list {
+            assert!(r["name"].is_string());
+            assert!(r["description"].is_string());
+            assert!(r["mimeType"].is_string());
+        }
+    }
+
+    #[test]
+    fn templates_describe_the_three_parameterised_shapes() {
+        let t = templates();
+        assert_eq!(t.len(), 3);
+        let patterns: Vec<&str> = t.iter().map(|x| x["uriTemplate"].as_str().unwrap()).collect();
+        assert!(patterns.contains(&"k8s://{context}/{namespace}/{kind}/{name}"));
+        assert!(patterns.contains(&"k8s://{context}/{namespace}/{kind}/{name}/events"));
+        assert!(patterns.contains(&"k8s://{context}/{namespace}/Pod/{name}/logs"));
+        for x in &t {
+            assert!(x["name"].is_string());
+            assert!(x["description"].is_string());
         }
     }
 }

--- a/crates/mcp/src/resources.rs
+++ b/crates/mcp/src/resources.rs
@@ -143,10 +143,16 @@ impl KindResolver for NoKinds {
 /// from the registry and prompt library rather than by invoking a capability.
 pub const CATALOG_IN_PROCESS: &str = "<catalog>";
 
+/// Capability IDs named by plan_read. Private to keep the single source of truth
+/// centralized — both MAPPED_CAPABILITIES and plan_read use these.
+const CAP_MANIFEST: &str = "k8s.getManifest";
+const CAP_EVENTS: &str = "k8s.listEvents";
+const CAP_LOGS: &str = "k8s.podLogs";
+const CAP_CONTEXTS: &str = "k8s.listContexts";
+
 /// Every capability a resource read can invoke. Task 6's guard asserts each is
 /// registered, `read_only`, and NOT consent-gated.
-pub const MAPPED_CAPABILITIES: [&str; 4] =
-    ["k8s.getManifest", "k8s.listEvents", "k8s.podLogs", "k8s.listContexts"];
+pub const MAPPED_CAPABILITIES: [&str; 4] = [CAP_MANIFEST, CAP_EVENTS, CAP_LOGS, CAP_CONTEXTS];
 
 /// A resolved read: which capability to invoke, with what arguments, and the
 /// mimeType to report to the client.
@@ -167,7 +173,7 @@ pub fn plan_read(uri: &ResourceUri, kinds: &dyn KindResolver) -> Result<Resource
     let (context, namespace, kind, name, sub) = match uri {
         ResourceUri::Contexts => {
             return Ok(ResourceRead {
-                capability: "k8s.listContexts",
+                capability: CAP_CONTEXTS,
                 args: json!({}),
                 mime: "application/json",
             })
@@ -214,10 +220,10 @@ pub fn plan_read(uri: &ResourceUri, kinds: &dyn KindResolver) -> Result<Resource
             if let Some(ns) = namespace {
                 args["namespace"] = json!(ns);
             }
-            Ok(ResourceRead { capability: "k8s.getManifest", args, mime: "application/yaml" })
+            Ok(ResourceRead { capability: CAP_MANIFEST, args, mime: "application/yaml" })
         }
         Some(SubResource::Events) => Ok(ResourceRead {
-            capability: "k8s.listEvents",
+            capability: CAP_EVENTS,
             args: json!({
                 "context": context,
                 "namespace": namespace.clone().unwrap_or_default(),
@@ -233,7 +239,7 @@ pub fn plan_read(uri: &ResourceUri, kinds: &dyn KindResolver) -> Result<Resource
                 ));
             }
             Ok(ResourceRead {
-                capability: "k8s.podLogs",
+                capability: CAP_LOGS,
                 args: json!({
                     "context": context,
                     "namespace": namespace.clone().unwrap_or_default(),
@@ -551,5 +557,120 @@ mod tests {
             assert!(x["name"].is_string());
             assert!(x["description"].is_string());
         }
+    }
+
+    /// Every id in MAPPED_CAPABILITIES must be registered, read-only, and NOT
+    /// consent-gated. Clients auto-fetch resources to populate context, so a
+    /// resource read that raised a confirm dialog would be a consent-fatigue
+    /// vector — the hazard #23's design warns about. This test guards the
+    /// listed ids. The companion test `every_plan_read_branch_is_mapped_and_nothing_extra`
+    /// enforces that MAPPED_CAPABILITIES contains exactly the ids that plan_read
+    /// can actually name, preventing drift as the code changes.
+    #[test]
+    fn every_mapped_capability_is_read_only_and_ungated() {
+        let registry = std::sync::Arc::new(srelens_registry::build_registry());
+        let server = crate::McpServer::new(registry.clone());
+        for id in MAPPED_CAPABILITIES {
+            let cap = registry
+                .get(id)
+                .unwrap_or_else(|| panic!("{id} is mapped for resource reads but not registered"));
+            assert!(cap.annotations.read_only, "{id} must be read_only");
+            assert_eq!(
+                server.consent_kind(id),
+                None,
+                "{id} is consent-gated, so a resource read would raise a confirm dialog"
+            );
+        }
+    }
+
+    /// The curation that the guard above depends on. If this ever passes with
+    /// `Some(_)`, secrets became addressable and the gate could be bypassed.
+    #[test]
+    fn the_real_resolver_still_excludes_secrets() {
+        assert_eq!(srelens_registry::kind_resolver().scope("Secret"), None);
+    }
+
+    /// Every capability that plan_read can name must appear in MAPPED_CAPABILITIES,
+    /// and nothing in MAPPED_CAPABILITIES must be unreachable. This test uses
+    /// compiler-enforced exhaustive matching to ensure the property holds as
+    /// code changes: adding a new ResourceUri or SubResource variant fails the
+    /// build until this test is updated to cover it.
+    #[test]
+    fn every_plan_read_branch_is_mapped_and_nothing_extra() {
+        // Compiler enforcement: if a new SubResource variant is added,
+        // this match becomes non-exhaustive and the build fails.
+        match SubResource::Events {
+            SubResource::Events | SubResource::Logs => {}
+        }
+        let sub_variants = [None, Some(SubResource::Events), Some(SubResource::Logs)];
+
+        // Resolver that allows all kinds we need to exercise every plan_read path:
+        // Pod (namespaced, can have logs), and Node (cluster-scoped).
+        struct AllowPodAndNode;
+        impl KindResolver for AllowPodAndNode {
+            fn scope(&self, kind: &str) -> Option<KindScope> {
+                match kind {
+                    "Pod" => Some(KindScope::Namespaced),
+                    "Node" => Some(KindScope::ClusterScoped),
+                    _ => None,
+                }
+            }
+        }
+
+        let mut capabilities_named = std::collections::HashSet::new();
+
+        // Compiler enforcement: if a new ResourceUri variant is added,
+        // this match becomes non-exhaustive and the build fails.
+        match ResourceUri::Contexts {
+            ResourceUri::Contexts | ResourceUri::Catalog | ResourceUri::Object { .. } => {}
+        }
+
+        // ResourceUri::Contexts
+        let read = plan_read(&ResourceUri::Contexts, &AllowPodAndNode).unwrap();
+        assert_ne!(read.capability, CATALOG_IN_PROCESS, "Contexts should map to a real capability");
+        capabilities_named.insert(read.capability);
+
+        // ResourceUri::Catalog (should NOT be in MAPPED_CAPABILITIES; it's a sentinel)
+        let read = plan_read(&ResourceUri::Catalog, &AllowPodAndNode).unwrap();
+        assert_eq!(read.capability, CATALOG_IN_PROCESS);
+        // Don't add it to the set; MAPPED_CAPABILITIES explicitly excludes it.
+
+        // ResourceUri::Object with all sub variants
+        for sub in sub_variants {
+            // Use Pod (namespaced) for most tests
+            let kind = "Pod";
+            let uri = ResourceUri::Object {
+                context: "ctx".into(),
+                namespace: Some("ns".into()),
+                kind: kind.into(),
+                name: "obj".into(),
+                sub,
+            };
+            let read = plan_read(&uri, &AllowPodAndNode).unwrap();
+            capabilities_named.insert(read.capability);
+
+            // Also test cluster-scoped (Node) with the object endpoint (no sub)
+            if sub.is_none() {
+                let uri = ResourceUri::Object {
+                    context: "ctx".into(),
+                    namespace: None,
+                    kind: "Node".into(),
+                    name: "node1".into(),
+                    sub,
+                };
+                let read = plan_read(&uri, &AllowPodAndNode).unwrap();
+                capabilities_named.insert(read.capability);
+            }
+        }
+
+        // Now verify that the set of capabilities named by plan_read
+        // exactly equals MAPPED_CAPABILITIES.
+        let mapped_set: std::collections::HashSet<&str> = MAPPED_CAPABILITIES.iter().copied().collect();
+        assert_eq!(
+            capabilities_named, mapped_set,
+            "plan_read named capabilities differ from MAPPED_CAPABILITIES: \
+             named={:?}, mapped={:?}",
+            capabilities_named, mapped_set
+        );
     }
 }

--- a/crates/mcp/src/resources.rs
+++ b/crates/mcp/src/resources.rs
@@ -139,6 +139,112 @@ impl KindResolver for NoKinds {
     }
 }
 
+/// Sentinel capability id for `k8s://catalog`, which is assembled in-process
+/// from the registry and prompt library rather than by invoking a capability.
+pub const CATALOG_IN_PROCESS: &str = "<catalog>";
+
+/// Every capability a resource read can invoke. Task 6's guard asserts each is
+/// registered, `read_only`, and NOT consent-gated.
+pub const MAPPED_CAPABILITIES: [&str; 4] =
+    ["k8s.getManifest", "k8s.listEvents", "k8s.podLogs", "k8s.listContexts"];
+
+/// A resolved read: which capability to invoke, with what arguments, and the
+/// mimeType to report to the client.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResourceRead {
+    pub capability: &'static str,
+    pub args: serde_json::Value,
+    pub mime: &'static str,
+}
+
+/// Resolve a URI to the capability call that serves it.
+///
+/// Every error here is a `-32602` message the caller must be able to act on, so
+/// each names the offending value and, where there is one, the alternative.
+pub fn plan_read(uri: &ResourceUri, kinds: &dyn KindResolver) -> Result<ResourceRead, String> {
+    use serde_json::json;
+
+    let (context, namespace, kind, name, sub) = match uri {
+        ResourceUri::Contexts => {
+            return Ok(ResourceRead {
+                capability: "k8s.listContexts",
+                args: json!({}),
+                mime: "application/json",
+            })
+        }
+        ResourceUri::Catalog => {
+            return Ok(ResourceRead {
+                capability: CATALOG_IN_PROCESS,
+                args: json!({}),
+                mime: "application/json",
+            })
+        }
+        ResourceUri::Object { context, namespace, kind, name, sub } => {
+            (context, namespace, kind, name, sub)
+        }
+    };
+
+    let scope = kinds.scope(kind).ok_or_else(|| {
+        if kind == "Secret" {
+            "`Secret` is not addressable as a resource; read secrets with the \
+             `k8s.getSecret` tool, which is consent-gated"
+                .to_string()
+        } else {
+            format!("kind `{kind}` is not addressable as a resource")
+        }
+    })?;
+
+    match (scope, namespace) {
+        (KindScope::Namespaced, None) => {
+            return Err(format!(
+                "`{kind}` is namespaced; supply a namespace instead of `{CLUSTER_SCOPED}`"
+            ))
+        }
+        (KindScope::ClusterScoped, Some(ns)) => {
+            return Err(format!(
+                "`{kind}` is cluster-scoped; use `{CLUSTER_SCOPED}` for the namespace, not `{ns}`"
+            ))
+        }
+        _ => {}
+    }
+
+    match sub {
+        None => {
+            let mut args = json!({ "context": context, "kind": kind, "name": name });
+            if let Some(ns) = namespace {
+                args["namespace"] = json!(ns);
+            }
+            Ok(ResourceRead { capability: "k8s.getManifest", args, mime: "application/yaml" })
+        }
+        Some(SubResource::Events) => Ok(ResourceRead {
+            capability: "k8s.listEvents",
+            args: json!({
+                "context": context,
+                "namespace": namespace.clone().unwrap_or_default(),
+                "objectKind": kind,
+                "objectName": name,
+            }),
+            mime: "application/json",
+        }),
+        Some(SubResource::Logs) => {
+            if kind != "Pod" {
+                return Err(format!(
+                    "logs exist only for Pods; `{kind}` has none"
+                ));
+            }
+            Ok(ResourceRead {
+                capability: "k8s.podLogs",
+                args: json!({
+                    "context": context,
+                    "namespace": namespace.clone().unwrap_or_default(),
+                    "pod": name,
+                }),
+                mime: "text/plain",
+            })
+        }
+    }
+}
+
 impl std::fmt::Display for ResourceUri {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -192,6 +298,87 @@ mod tests {
     fn the_default_resolver_addresses_nothing() {
         assert_eq!(NoKinds.scope("Pod"), None);
         assert_eq!(NoKinds.scope("Node"), None);
+    }
+
+    use serde_json::json;
+
+    #[test]
+    fn a_manifest_read_maps_to_get_manifest_as_yaml() {
+        let u = ResourceUri::parse("k8s://c/ns/Pod/web-0").unwrap();
+        let r = plan_read(&u, &StubKinds).unwrap();
+        assert_eq!(r.capability, "k8s.getManifest");
+        assert_eq!(r.mime, "application/yaml");
+        assert_eq!(r.args, json!({"context":"c","kind":"Pod","namespace":"ns","name":"web-0"}));
+    }
+
+    #[test]
+    fn a_cluster_scoped_manifest_read_sends_no_namespace() {
+        let u = ResourceUri::parse("k8s://c/-/Node/node-1").unwrap();
+        let r = plan_read(&u, &StubKinds).unwrap();
+        assert_eq!(r.args, json!({"context":"c","kind":"Node","name":"node-1"}));
+    }
+
+    #[test]
+    fn an_events_read_filters_by_object() {
+        let u = ResourceUri::parse("k8s://c/ns/Pod/web-0/events").unwrap();
+        let r = plan_read(&u, &StubKinds).unwrap();
+        assert_eq!(r.capability, "k8s.listEvents");
+        assert_eq!(r.mime, "application/json");
+        assert_eq!(
+            r.args,
+            json!({"context":"c","namespace":"ns","objectKind":"Pod","objectName":"web-0"})
+        );
+    }
+
+    #[test]
+    fn a_logs_read_maps_to_pod_logs_as_text() {
+        let u = ResourceUri::parse("k8s://c/ns/Pod/web-0/logs").unwrap();
+        let r = plan_read(&u, &StubKinds).unwrap();
+        assert_eq!(r.capability, "k8s.podLogs");
+        assert_eq!(r.mime, "text/plain");
+        assert_eq!(r.args, json!({"context":"c","namespace":"ns","pod":"web-0"}));
+    }
+
+    #[test]
+    fn the_fixed_resources_map_to_their_readers() {
+        let c = plan_read(&ResourceUri::Contexts, &StubKinds).unwrap();
+        assert_eq!(c.capability, "k8s.listContexts");
+        let cat = plan_read(&ResourceUri::Catalog, &StubKinds).unwrap();
+        assert_eq!(cat.capability, CATALOG_IN_PROCESS);
+    }
+
+    #[test]
+    fn logs_are_rejected_for_a_non_pod_kind() {
+        let u = ResourceUri::parse("k8s://c/ns/Deployment/api/logs").unwrap();
+        let e = plan_read(&u, &StubKinds).unwrap_err();
+        assert!(e.contains("Pod"), "got: {e}");
+    }
+
+    /// The curation guarantee, surfaced as an actionable error rather than a
+    /// bare "unknown kind": the caller is told where secrets actually live.
+    #[test]
+    fn a_secret_uri_is_rejected_and_points_at_the_gated_tool() {
+        let u = ResourceUri::parse("k8s://c/ns/Secret/db-creds").unwrap();
+        let e = plan_read(&u, &StubKinds).unwrap_err();
+        assert!(e.contains("k8s.getSecret"), "got: {e}");
+    }
+
+    #[test]
+    fn an_unknown_kind_is_rejected() {
+        let u = ResourceUri::parse("k8s://c/ns/Nonsense/x").unwrap();
+        let e = plan_read(&u, &StubKinds).unwrap_err();
+        assert!(e.contains("Nonsense"), "got: {e}");
+    }
+
+    #[test]
+    fn a_scope_mismatch_is_rejected_in_both_directions() {
+        let cluster_kind_with_ns = ResourceUri::parse("k8s://c/ns/Node/n").unwrap();
+        let e = plan_read(&cluster_kind_with_ns, &StubKinds).unwrap_err();
+        assert!(e.contains("cluster-scoped"), "got: {e}");
+
+        let namespaced_without_ns = ResourceUri::parse("k8s://c/-/Pod/p").unwrap();
+        let e = plan_read(&namespaced_without_ns, &StubKinds).unwrap_err();
+        assert!(e.contains("namespaced"), "got: {e}");
     }
 
     #[test]

--- a/crates/mcp/src/resources.rs
+++ b/crates/mcp/src/resources.rs
@@ -23,18 +23,23 @@ fn decode(s: &str) -> Result<String, String> {
         .map_err(|e| format!("segment is not valid UTF-8 after decoding: {e}"))
 }
 
-/// A subresource hanging off an object URI.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// A subresource hanging off an object URI. `Logs` carries its optional
+/// container name inside the variant, rather than alongside it on `Object`,
+/// so that an illegal state — a container set on `/events`, which has none —
+/// is unrepresentable.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SubResource {
     Events,
-    Logs,
+    /// `None` means "omit the container", which is only valid for a
+    /// single-container pod — see `k8s://.../Pod/<name>/logs[/<container>]`.
+    Logs { container: Option<String> },
 }
 
 impl SubResource {
-    fn as_str(self) -> &'static str {
+    fn as_str(&self) -> &'static str {
         match self {
             SubResource::Events => "events",
-            SubResource::Logs => "logs",
+            SubResource::Logs { .. } => "logs",
         }
     }
 }
@@ -73,10 +78,10 @@ impl ResourceUri {
         }
 
         let parts: Vec<&str> = rest.split('/').collect();
-        if parts.len() < 4 || parts.len() > 5 {
+        if parts.len() < 4 || parts.len() > 6 {
             return Err(format!(
                 "`{uri}` has {} segments; expected \
-                 k8s://<context>/<namespace|->/<kind>/<name>[/events|/logs], \
+                 k8s://<context>/<namespace|->/<kind>/<name>[/events|/logs[/<container>]], \
                  or the fixed k8s://contexts or k8s://catalog",
                 parts.len()
             ));
@@ -93,8 +98,22 @@ impl ResourceUri {
         let name = decode(parts[3])?;
         let sub = match parts.get(4) {
             None => None,
-            Some(&"events") => Some(SubResource::Events),
-            Some(&"logs") => Some(SubResource::Logs),
+            Some(&"events") => {
+                if parts.len() > 5 {
+                    return Err(format!(
+                        "`{uri}` has {} segments; `events` takes no further segments",
+                        parts.len()
+                    ));
+                }
+                Some(SubResource::Events)
+            }
+            Some(&"logs") => {
+                let container = match parts.get(5) {
+                    None => None,
+                    Some(c) => Some(decode(c)?),
+                };
+                Some(SubResource::Logs { container })
+            }
             Some(other) => {
                 return Err(format!(
                     "unknown subresource `{other}`; only `events` and `logs` exist"
@@ -181,7 +200,7 @@ pub fn is_subscribable(uri: &ResourceUri) -> Result<(), String> {
                  cannot be subscribed to"
                 .to_string())
         }
-        ResourceUri::Object { sub: Some(SubResource::Logs), .. } => {
+        ResourceUri::Object { sub: Some(SubResource::Logs { .. }), .. } => {
             Err("pod logs are a stream, not a state change; subscribe to the \
                  pod's manifest instead"
                 .to_string())
@@ -296,21 +315,21 @@ pub fn plan_read(uri: &ResourceUri, kinds: &dyn KindResolver) -> Result<Resource
             }),
             mime: "application/json",
         }),
-        Some(SubResource::Logs) => {
+        Some(SubResource::Logs { container }) => {
             if kind != "Pod" {
                 return Err(format!(
                     "logs exist only for Pods; `{kind}` has none"
                 ));
             }
-            Ok(ResourceRead {
-                capability: CAP_LOGS,
-                args: json!({
-                    "context": context,
-                    "namespace": namespace.clone().unwrap_or_default(),
-                    "pod": name,
-                }),
-                mime: "text/plain",
-            })
+            let mut args = json!({
+                "context": context,
+                "namespace": namespace.clone().unwrap_or_default(),
+                "pod": name,
+            });
+            if let Some(c) = container {
+                args["container"] = json!(c);
+            }
+            Ok(ResourceRead { capability: CAP_LOGS, args, mime: "text/plain" })
         }
     }
 }
@@ -331,6 +350,9 @@ impl std::fmt::Display for ResourceUri {
                 )?;
                 if let Some(s) = sub {
                     write!(f, "/{}", s.as_str())?;
+                    if let SubResource::Logs { container: Some(c) } = s {
+                        write!(f, "/{}", encode(c))?;
+                    }
                 }
                 Ok(())
             }
@@ -381,7 +403,16 @@ pub fn templates() -> Vec<serde_json::Value> {
         json!({
             "uriTemplate": "k8s://{context}/{namespace}/Pod/{name}/logs",
             "name": "Pod logs",
-            "description": "Recent log output for a pod's default container.",
+            "description": "Recent log output for a pod's default container. Omitting the \
+                            container is only valid for a single-container pod.",
+            "mimeType": "text/plain"
+        }),
+        json!({
+            "uriTemplate": "k8s://{context}/{namespace}/Pod/{name}/logs/{container}",
+            "name": "Pod container logs",
+            "description": "Recent log output for one named container. Required for a \
+                            multi-container (e.g. sidecar) pod, where Kubernetes rejects \
+                            a log request with no container named.",
             "mimeType": "text/plain"
         }),
     ]
@@ -502,6 +533,30 @@ mod tests {
         assert_eq!(r.args, json!({"context":"c","namespace":"ns","pod":"web-0"}));
     }
 
+    /// The sixth segment names a container, so a multi-container (sidecar)
+    /// pod's logs are reachable at all — without it, `k8s.podLogs` sends no
+    /// container and the Kubernetes API rejects the request outright.
+    #[test]
+    fn a_logs_read_with_a_container_includes_it_in_the_args() {
+        let u = ResourceUri::parse("k8s://c/ns/Pod/web-0/logs/sidecar").unwrap();
+        let r = plan_read(&u, &StubKinds).unwrap();
+        assert_eq!(r.capability, "k8s.podLogs");
+        assert_eq!(
+            r.args,
+            json!({"context":"c","namespace":"ns","pod":"web-0","container":"sidecar"})
+        );
+    }
+
+    /// The five-segment form must still omit the key entirely — not send
+    /// `"container": null` — since that is what makes it valid for a
+    /// single-container pod today.
+    #[test]
+    fn a_logs_read_without_a_container_omits_the_key() {
+        let u = ResourceUri::parse("k8s://c/ns/Pod/web-0/logs").unwrap();
+        let r = plan_read(&u, &StubKinds).unwrap();
+        assert!(r.args.get("container").is_none(), "got: {:?}", r.args);
+    }
+
     #[test]
     fn the_fixed_resources_map_to_their_readers() {
         let c = plan_read(&ResourceUri::Contexts, &StubKinds).unwrap();
@@ -580,10 +635,39 @@ mod tests {
         match (e, l) {
             (
                 ResourceUri::Object { sub: Some(SubResource::Events), .. },
-                ResourceUri::Object { sub: Some(SubResource::Logs), .. },
+                ResourceUri::Object { sub: Some(SubResource::Logs { container: None }), .. },
             ) => {}
             other => panic!("expected events + logs, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn parses_a_sixth_segment_as_the_logs_container() {
+        let u = ResourceUri::parse("k8s://c/ns/Pod/p/logs/sidecar").unwrap();
+        match u {
+            ResourceUri::Object { sub: Some(SubResource::Logs { container }), .. } => {
+                assert_eq!(container, Some("sidecar".into()));
+            }
+            other => panic!("expected logs with a container, got {other:?}"),
+        }
+    }
+
+    /// A sixth segment only means something after `logs`; after `events` it is
+    /// unrepresentable and must be a clear error rather than silently ignored
+    /// or misparsed as part of the object name.
+    #[test]
+    fn a_sixth_segment_after_events_is_rejected() {
+        let e = ResourceUri::parse("k8s://c/ns/Pod/p/events/extra").unwrap_err();
+        assert!(e.contains("events"), "got: {e}");
+        assert!(e.contains("no further segments"), "got: {e}");
+    }
+
+    /// An empty container segment is an error, not `None` — the same rule the
+    /// other segments already follow.
+    #[test]
+    fn an_empty_container_segment_is_rejected() {
+        let e = ResourceUri::parse("k8s://c/ns/Pod/p/logs/").unwrap_err();
+        assert!(e.contains("empty"), "got: {e}");
     }
 
     #[test]
@@ -618,10 +702,30 @@ mod tests {
             "k8s://c/-/Node/n",
             "k8s://c/ns/Pod/p/events",
             "k8s://c/ns/Pod/p/logs",
+            "k8s://c/ns/Pod/p/logs/sidecar",
         ] {
             let parsed = ResourceUri::parse(uri).unwrap();
             assert_eq!(parsed.to_string(), uri, "round trip failed for {uri}");
         }
+    }
+
+    /// A container name containing characters that must be percent-encoded
+    /// (mirroring `round_trips_a_context_name_containing_a_slash_and_colon`
+    /// for the context segment) must still round-trip through `Display` and
+    /// `parse` unharmed.
+    #[test]
+    fn round_trips_a_container_name_needing_percent_encoding() {
+        let original = ResourceUri::Object {
+            context: "c".into(),
+            namespace: Some("ns".into()),
+            kind: "Pod".into(),
+            name: "web-0".into(),
+            sub: Some(SubResource::Logs { container: Some("sidecar/proxy:1".into()) }),
+        };
+        let rendered = original.to_string();
+        assert!(!rendered.contains("proxy:1"), "the colon must be encoded: {rendered}");
+        assert!(!rendered.ends_with("sidecar/proxy:1"), "the slash must be encoded: {rendered}");
+        assert_eq!(ResourceUri::parse(&rendered).unwrap(), original);
     }
 
     #[test]
@@ -629,8 +733,9 @@ mod tests {
         for (uri, expect) in [
             ("http://c/ns/Pod/p", "k8s://"),
             ("k8s://c/ns/Pod", "segments"),
-            ("k8s://c/ns/Pod/p/x/y", "segments"),
+            ("k8s://c/ns/Pod/p/logs/sidecar/extra", "segments"),
             ("k8s://c/ns/Pod/p/status", "events"),
+            ("k8s://c/ns/Pod/p/events/extra", "no further segments"),
             ("k8s://c//Pod/p", "empty"),
             ("k8s://nonsense", "k8s://"),
         ] {
@@ -654,13 +759,14 @@ mod tests {
     }
 
     #[test]
-    fn templates_describe_the_three_parameterised_shapes() {
+    fn templates_describe_the_four_parameterised_shapes() {
         let t = templates();
-        assert_eq!(t.len(), 3);
+        assert_eq!(t.len(), 4);
         let patterns: Vec<&str> = t.iter().map(|x| x["uriTemplate"].as_str().unwrap()).collect();
         assert!(patterns.contains(&"k8s://{context}/{namespace}/{kind}/{name}"));
         assert!(patterns.contains(&"k8s://{context}/{namespace}/{kind}/{name}/events"));
         assert!(patterns.contains(&"k8s://{context}/{namespace}/Pod/{name}/logs"));
+        assert!(patterns.contains(&"k8s://{context}/{namespace}/Pod/{name}/logs/{container}"));
         for x in &t {
             assert!(x["name"].is_string());
             assert!(x["description"].is_string());
@@ -701,16 +807,21 @@ mod tests {
     /// Every capability that plan_read can name must appear in MAPPED_CAPABILITIES,
     /// and nothing in MAPPED_CAPABILITIES must be unreachable. This test uses
     /// compiler-enforced exhaustive matching to ensure the property holds as
-    /// code changes: adding a new ResourceUri or SubResource variant fails the
-    /// build until this test is updated to cover it.
+    /// code changes: adding a new ResourceUri or SubResource *variant* fails the
+    /// build until this test is updated to cover it. Note that this only guards
+    /// variants, not fields — `Logs { .. }` matches every field combination, so
+    /// adding a field to an existing variant (as the `container` field on
+    /// `Logs` was) does not, and should not, break this match; only a brand
+    /// new sibling variant would.
     #[test]
     fn every_plan_read_branch_is_mapped_and_nothing_extra() {
         // Compiler enforcement: if a new SubResource variant is added,
         // this match becomes non-exhaustive and the build fails.
         match SubResource::Events {
-            SubResource::Events | SubResource::Logs => {}
+            SubResource::Events | SubResource::Logs { .. } => {}
         }
-        let sub_variants = [None, Some(SubResource::Events), Some(SubResource::Logs)];
+        let sub_variants =
+            [None, Some(SubResource::Events), Some(SubResource::Logs { container: None })];
 
         // Resolver that allows all kinds we need to exercise every plan_read path:
         // Pod (namespaced, can have logs), and Node (cluster-scoped).
@@ -745,6 +856,10 @@ mod tests {
 
         // ResourceUri::Object with all sub variants
         for sub in sub_variants {
+            // SubResource dropped Copy when Logs grew a `container` field, so
+            // capture this before `sub` is moved into the first uri below.
+            let sub_is_none = sub.is_none();
+
             // Use Pod (namespaced) for most tests
             let kind = "Pod";
             let uri = ResourceUri::Object {
@@ -758,13 +873,13 @@ mod tests {
             capabilities_named.insert(read.capability);
 
             // Also test cluster-scoped (Node) with the object endpoint (no sub)
-            if sub.is_none() {
+            if sub_is_none {
                 let uri = ResourceUri::Object {
                     context: "ctx".into(),
                     namespace: None,
                     kind: "Node".into(),
                     name: "node1".into(),
-                    sub,
+                    sub: None,
                 };
                 let read = plan_read(&uri, &AllowPodAndNode).unwrap();
                 capabilities_named.insert(read.capability);

--- a/crates/mcp/src/resources.rs
+++ b/crates/mcp/src/resources.rs
@@ -167,17 +167,36 @@ impl ObjectWatcher for NoWatcher {
     }
 }
 
-/// Whether a URI can be subscribed to. The catalog is static, and logs are a
-/// stream rather than a state change.
+/// Whether a URI can be subscribed to. The catalog and the context list are
+/// fixed listings rather than watchable objects, logs are a stream rather
+/// than a state change, and events would need to watch a different object
+/// than the one the URI names (see the `Events` arm below).
 pub fn is_subscribable(uri: &ResourceUri) -> Result<(), String> {
     match uri {
         ResourceUri::Catalog => {
             Err("`k8s://catalog` is static and cannot be subscribed to".to_string())
         }
-        ResourceUri::Contexts => Ok(()),
+        ResourceUri::Contexts => {
+            Err("`k8s://contexts` is a fixed listing, not a watchable object, and \
+                 cannot be subscribed to"
+                .to_string())
+        }
         ResourceUri::Object { sub: Some(SubResource::Logs), .. } => {
             Err("pod logs are a stream, not a state change; subscribe to the \
                  pod's manifest instead"
+                .to_string())
+        }
+        ResourceUri::Object { sub: Some(SubResource::Events), .. } => {
+            // A watcher keyed on the URI's (context, namespace, kind, name)
+            // would watch the *object* the URI names, not the Event objects
+            // that reference it via `involvedObject` — so an Event with no
+            // matching object mutation would never notify, and an unrelated
+            // change to the object itself would notify spuriously. Watching
+            // real Event objects filtered by involvedObject is the
+            // feature-complete answer, but that's new scope (a follow-up),
+            // not this fix.
+            Err("events are not subscribable; subscribe to the object's \
+                 manifest instead"
                 .to_string())
         }
         ResourceUri::Object { .. } => Ok(()),
@@ -413,9 +432,35 @@ mod tests {
     #[test]
     fn only_state_bearing_uris_are_subscribable() {
         assert!(is_subscribable(&ResourceUri::parse("k8s://c/ns/Pod/p").unwrap()).is_ok());
-        assert!(is_subscribable(&ResourceUri::parse("k8s://c/ns/Pod/p/events").unwrap()).is_ok());
         assert!(is_subscribable(&ResourceUri::parse("k8s://c/ns/Pod/p/logs").unwrap()).is_err());
         assert!(is_subscribable(&ResourceUri::Catalog).is_err());
+        assert!(is_subscribable(&ResourceUri::Contexts).is_err());
+    }
+
+    /// `/events` is not subscribable: `CacheWatcher` destructures the URI with
+    /// `..` and drops `sub`, so a watch on an `/events` URI would actually
+    /// watch the named object, not the Event objects that reference it — an
+    /// Event with no matching object mutation would never notify, and an
+    /// unrelated object change would notify spuriously. Until real Event
+    /// objects are watched (a follow-up), refuse the subscription outright,
+    /// exactly as `/logs` already is.
+    #[test]
+    fn events_are_not_subscribable() {
+        let err = is_subscribable(&ResourceUri::parse("k8s://c/ns/Pod/p/events").unwrap())
+            .unwrap_err();
+        assert!(err.contains("not subscribable"), "got: {err}");
+        assert!(err.contains("manifest"), "got: {err}");
+    }
+
+    /// The predicate must not diverge from the real watcher: `k8s://contexts`
+    /// is a fixed listing, not a watchable object, and `CacheWatcher` already
+    /// rejects it with "only object URIs can be watched". A watcher less
+    /// strict than `CacheWatcher` (like the in-crate test stubs) would
+    /// otherwise accept a subscription that can never fire.
+    #[test]
+    fn contexts_is_not_subscribable() {
+        let err = is_subscribable(&ResourceUri::Contexts).unwrap_err();
+        assert!(err.contains("fixed listing"), "got: {err}");
     }
 
     use serde_json::json;

--- a/crates/mcp/src/resources.rs
+++ b/crates/mcp/src/resources.rs
@@ -112,6 +112,33 @@ impl ResourceUri {
     }
 }
 
+/// Whether a kind is namespaced. Returned only for kinds that are addressable
+/// as resources at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KindScope {
+    Namespaced,
+    ClusterScoped,
+}
+
+/// Answers "is this kind addressable as a resource, and is it namespaced".
+///
+/// Injected because `crates/mcp` cannot depend on `crates/kube`, where the kind
+/// table lives. `crates/registry` supplies the real implementation over
+/// `gvk_for`; a second table here would drift.
+pub trait KindResolver: Send + Sync {
+    fn scope(&self, kind: &str) -> Option<KindScope>;
+}
+
+/// The default. A host that wires no resolver exposes no object resources —
+/// only the two fixed ones. Fail closed, as `AlwaysDeny` is for consent.
+pub struct NoKinds;
+
+impl KindResolver for NoKinds {
+    fn scope(&self, _kind: &str) -> Option<KindScope> {
+        None
+    }
+}
+
 impl std::fmt::Display for ResourceUri {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -138,6 +165,34 @@ impl std::fmt::Display for ResourceUri {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct StubKinds;
+    impl KindResolver for StubKinds {
+        fn scope(&self, kind: &str) -> Option<KindScope> {
+            match kind {
+                "Pod" | "Deployment" => Some(KindScope::Namespaced),
+                "Node" => Some(KindScope::ClusterScoped),
+                _ => None,
+            }
+        }
+    }
+
+    #[test]
+    fn a_stub_resolver_answers_scope_and_addressability() {
+        let r = StubKinds;
+        assert_eq!(r.scope("Pod"), Some(KindScope::Namespaced));
+        assert_eq!(r.scope("Node"), Some(KindScope::ClusterScoped));
+        assert_eq!(r.scope("Secret"), None, "not addressable");
+        assert_eq!(r.scope("Nonsense"), None);
+    }
+
+    /// Fail closed: a host that wires no resolver addresses nothing, mirroring
+    /// how `AlwaysDeny` is the default `ConfirmPolicy`.
+    #[test]
+    fn the_default_resolver_addresses_nothing() {
+        assert_eq!(NoKinds.scope("Pod"), None);
+        assert_eq!(NoKinds.scope("Node"), None);
+    }
 
     #[test]
     fn parses_a_namespaced_object() {

--- a/crates/mcp/src/resources.rs
+++ b/crates/mcp/src/resources.rs
@@ -1,0 +1,236 @@
+//! `k8s://` resource addressing. A URI names a piece of cluster state; reads
+//! map to existing capabilities so annotations and the audit log apply.
+
+use percent_encoding::{percent_decode_str, utf8_percent_encode, AsciiSet, CONTROLS};
+
+/// Everything that is not unreserved per RFC 3986 gets encoded. Deliberately
+/// aggressive: `/` and `:` MUST be encoded (EKS context ARNs contain both), and
+/// encoding a few extra characters is harmless while missing one is not.
+const SEGMENT: &AsciiSet = &CONTROLS
+    .add(b' ').add(b'"').add(b'#').add(b'<').add(b'>').add(b'?').add(b'`')
+    .add(b'{').add(b'}').add(b'/').add(b':').add(b'%').add(b'[').add(b']')
+    .add(b'@').add(b'!').add(b'$').add(b'&').add(b'\'').add(b'(').add(b')')
+    .add(b'*').add(b'+').add(b',').add(b';').add(b'=');
+
+fn encode(s: &str) -> String {
+    utf8_percent_encode(s, SEGMENT).to_string()
+}
+
+fn decode(s: &str) -> Result<String, String> {
+    percent_decode_str(s)
+        .decode_utf8()
+        .map(|c| c.to_string())
+        .map_err(|e| format!("segment is not valid UTF-8 after decoding: {e}"))
+}
+
+/// A subresource hanging off an object URI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubResource {
+    Events,
+    Logs,
+}
+
+impl SubResource {
+    fn as_str(self) -> &'static str {
+        match self {
+            SubResource::Events => "events",
+            SubResource::Logs => "logs",
+        }
+    }
+}
+
+/// What a `k8s://` URI addresses.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResourceUri {
+    /// `k8s://contexts`
+    Contexts,
+    /// `k8s://catalog`
+    Catalog,
+    /// `k8s://<context>/<namespace|->/<kind>/<name>[/<sub>]`
+    Object {
+        context: String,
+        /// `None` for a cluster-scoped kind — the `-` sentinel.
+        namespace: Option<String>,
+        kind: String,
+        name: String,
+        sub: Option<SubResource>,
+    },
+}
+
+/// The sentinel standing in for "no namespace" on a cluster-scoped kind.
+pub const CLUSTER_SCOPED: &str = "-";
+
+impl ResourceUri {
+    pub fn parse(uri: &str) -> Result<Self, String> {
+        let rest = uri
+            .strip_prefix("k8s://")
+            .ok_or_else(|| format!("`{uri}` is not a k8s:// resource URI"))?;
+
+        match rest {
+            "contexts" => return Ok(ResourceUri::Contexts),
+            "catalog" => return Ok(ResourceUri::Catalog),
+            _ => {}
+        }
+
+        let parts: Vec<&str> = rest.split('/').collect();
+        if parts.len() < 4 || parts.len() > 5 {
+            return Err(format!(
+                "`{uri}` has {} segments; expected \
+                 k8s://<context>/<namespace|->/<kind>/<name>[/events|/logs], \
+                 or the fixed k8s://contexts or k8s://catalog",
+                parts.len()
+            ));
+        }
+        if parts.iter().any(|p| p.is_empty()) {
+            return Err(format!(
+                "`{uri}` has an empty segment; use `-` for a cluster-scoped kind's namespace"
+            ));
+        }
+
+        let context = decode(parts[0])?;
+        let namespace_raw = decode(parts[1])?;
+        let kind = decode(parts[2])?;
+        let name = decode(parts[3])?;
+        let sub = match parts.get(4) {
+            None => None,
+            Some(&"events") => Some(SubResource::Events),
+            Some(&"logs") => Some(SubResource::Logs),
+            Some(other) => {
+                return Err(format!(
+                    "unknown subresource `{other}`; only `events` and `logs` exist"
+                ))
+            }
+        };
+
+        Ok(ResourceUri::Object {
+            context,
+            namespace: if namespace_raw == CLUSTER_SCOPED { None } else { Some(namespace_raw) },
+            kind,
+            name,
+            sub,
+        })
+    }
+}
+
+impl std::fmt::Display for ResourceUri {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ResourceUri::Contexts => write!(f, "k8s://contexts"),
+            ResourceUri::Catalog => write!(f, "k8s://catalog"),
+            ResourceUri::Object { context, namespace, kind, name, sub } => {
+                write!(
+                    f,
+                    "k8s://{}/{}/{}/{}",
+                    encode(context),
+                    namespace.as_deref().map(encode).unwrap_or_else(|| CLUSTER_SCOPED.to_string()),
+                    encode(kind),
+                    encode(name)
+                )?;
+                if let Some(s) = sub {
+                    write!(f, "/{}", s.as_str())?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_a_namespaced_object() {
+        let u = ResourceUri::parse("k8s://kind-demo/prod/Pod/web-0").unwrap();
+        assert_eq!(
+            u,
+            ResourceUri::Object {
+                context: "kind-demo".into(),
+                namespace: Some("prod".into()),
+                kind: "Pod".into(),
+                name: "web-0".into(),
+                sub: None,
+            }
+        );
+    }
+
+    /// `-` is the cluster-scoped sentinel. An empty segment (`//`) is ambiguous
+    /// and invisible in a bug report, so it is rejected rather than accepted.
+    #[test]
+    fn parses_a_cluster_scoped_object_via_the_dash_sentinel() {
+        let u = ResourceUri::parse("k8s://kind-demo/-/Node/node-1").unwrap();
+        match u {
+            ResourceUri::Object { namespace, kind, .. } => {
+                assert_eq!(namespace, None);
+                assert_eq!(kind, "Node");
+            }
+            other => panic!("expected an object, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_the_events_and_logs_subresources() {
+        let e = ResourceUri::parse("k8s://c/ns/Pod/p/events").unwrap();
+        let l = ResourceUri::parse("k8s://c/ns/Pod/p/logs").unwrap();
+        match (e, l) {
+            (
+                ResourceUri::Object { sub: Some(SubResource::Events), .. },
+                ResourceUri::Object { sub: Some(SubResource::Logs), .. },
+            ) => {}
+            other => panic!("expected events + logs, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_the_two_fixed_resources() {
+        assert_eq!(ResourceUri::parse("k8s://contexts").unwrap(), ResourceUri::Contexts);
+        assert_eq!(ResourceUri::parse("k8s://catalog").unwrap(), ResourceUri::Catalog);
+    }
+
+    /// The load-bearing case: an EKS context name is an ARN containing `/` and
+    /// `:`. Unencoded, the `/` silently reshapes the path into a different
+    /// resource, so encoding is not optional.
+    #[test]
+    fn round_trips_a_context_name_containing_a_slash_and_colon() {
+        let original = ResourceUri::Object {
+            context: "arn:aws:eks:eu-west-1:123456789012:cluster/prod".into(),
+            namespace: Some("ns".into()),
+            kind: "Pod".into(),
+            name: "web-0".into(),
+            sub: None,
+        };
+        let rendered = original.to_string();
+        assert!(!rendered.contains("cluster/prod"), "the slash must be encoded: {rendered}");
+        assert_eq!(ResourceUri::parse(&rendered).unwrap(), original);
+    }
+
+    #[test]
+    fn round_trips_every_shape() {
+        for uri in [
+            "k8s://contexts",
+            "k8s://catalog",
+            "k8s://c/ns/Pod/p",
+            "k8s://c/-/Node/n",
+            "k8s://c/ns/Pod/p/events",
+            "k8s://c/ns/Pod/p/logs",
+        ] {
+            let parsed = ResourceUri::parse(uri).unwrap();
+            assert_eq!(parsed.to_string(), uri, "round trip failed for {uri}");
+        }
+    }
+
+    #[test]
+    fn rejects_malformed_uris() {
+        for (uri, expect) in [
+            ("http://c/ns/Pod/p", "k8s://"),
+            ("k8s://c/ns/Pod", "segments"),
+            ("k8s://c/ns/Pod/p/x/y", "segments"),
+            ("k8s://c/ns/Pod/p/status", "events"),
+            ("k8s://c//Pod/p", "empty"),
+            ("k8s://nonsense", "k8s://"),
+        ] {
+            let e = ResourceUri::parse(uri).unwrap_err();
+            assert!(e.contains(expect), "for {uri}, message {e:?} should mention {expect:?}");
+        }
+    }
+}

--- a/crates/mcp/src/resources.rs
+++ b/crates/mcp/src/resources.rs
@@ -139,6 +139,51 @@ impl KindResolver for NoKinds {
     }
 }
 
+/// Starts a watch for one object URI, calling `on_change` on every change.
+///
+/// A trait rather than a concrete type because the implementation needs kube,
+/// and `crates/mcp` must not depend on `crates/kube` — `crates/registry` wires
+/// the real one, exactly as it does for `KindResolver`.
+pub trait ObjectWatcher: Send + Sync {
+    fn watch(
+        &self,
+        uri: &ResourceUri,
+        on_change: Box<dyn FnMut() + Send>,
+    ) -> Result<tokio::task::AbortHandle, String>;
+}
+
+/// Fail-closed default: refuse a subscription rather than accept one that can
+/// never fire.
+pub struct NoWatcher;
+
+impl ObjectWatcher for NoWatcher {
+    fn watch(
+        &self,
+        _uri: &ResourceUri,
+        _on_change: Box<dyn FnMut() + Send>,
+    ) -> Result<tokio::task::AbortHandle, String> {
+        Err("this server has no cluster watcher wired, so resources cannot be subscribed to"
+            .to_string())
+    }
+}
+
+/// Whether a URI can be subscribed to. The catalog is static, and logs are a
+/// stream rather than a state change.
+pub fn is_subscribable(uri: &ResourceUri) -> Result<(), String> {
+    match uri {
+        ResourceUri::Catalog => {
+            Err("`k8s://catalog` is static and cannot be subscribed to".to_string())
+        }
+        ResourceUri::Contexts => Ok(()),
+        ResourceUri::Object { sub: Some(SubResource::Logs), .. } => {
+            Err("pod logs are a stream, not a state change; subscribe to the \
+                 pod's manifest instead"
+                .to_string())
+        }
+        ResourceUri::Object { .. } => Ok(()),
+    }
+}
+
 /// Sentinel capability id for `k8s://catalog`, which is assembled in-process
 /// from the registry and prompt library rather than by invoking a capability.
 pub const CATALOG_IN_PROCESS: &str = "<catalog>";
@@ -353,6 +398,24 @@ mod tests {
     fn the_default_resolver_addresses_nothing() {
         assert_eq!(NoKinds.scope("Pod"), None);
         assert_eq!(NoKinds.scope("Node"), None);
+    }
+
+    /// Fail closed: a host that wires no watcher refuses every subscription
+    /// rather than accepting one that can never fire, mirroring `NoKinds` and
+    /// `AlwaysDeny`.
+    #[test]
+    fn the_default_watcher_refuses_every_subscription() {
+        let uri = ResourceUri::parse("k8s://c/ns/Pod/web-0").unwrap();
+        let err = NoWatcher.watch(&uri, Box::new(|| {})).unwrap_err();
+        assert!(err.contains("no cluster watcher"), "got: {err}");
+    }
+
+    #[test]
+    fn only_state_bearing_uris_are_subscribable() {
+        assert!(is_subscribable(&ResourceUri::parse("k8s://c/ns/Pod/p").unwrap()).is_ok());
+        assert!(is_subscribable(&ResourceUri::parse("k8s://c/ns/Pod/p/events").unwrap()).is_ok());
+        assert!(is_subscribable(&ResourceUri::parse("k8s://c/ns/Pod/p/logs").unwrap()).is_err());
+        assert!(is_subscribable(&ResourceUri::Catalog).is_err());
     }
 
     use serde_json::json;

--- a/crates/mcp/src/stdio.rs
+++ b/crates/mcp/src/stdio.rs
@@ -33,7 +33,19 @@ pub async fn handle_request(
             id?,
             json!({
                 "protocolVersion": PROTOCOL_VERSION,
-                "capabilities": { "tools": {}, "prompts": {} },
+                // `subscribe` is transport-dependent: stdio can push
+                // notifications on its own stdout, the POST-only HTTP transport
+                // has no server-to-client channel at all (see issue #193).
+                // `listChanged` is false because the resource list is two fixed
+                // entries plus templates and never changes at runtime.
+                "capabilities": {
+                    "tools": {},
+                    "prompts": {},
+                    "resources": {
+                        "subscribe": transport == Transport::Stdio,
+                        "listChanged": false
+                    }
+                },
                 "serverInfo": { "name": "srelens", "version": env!("CARGO_PKG_VERSION") }
             }),
         )),
@@ -197,6 +209,110 @@ pub async fn handle_request(
                 // argument set this server cannot serve.
                 Err(message) => Some(err(id?, -32602, &message)),
             }
+        }
+        "resources/list" => Some(ok(
+            id?,
+            json!({ "resources": crate::resources::fixed_resources() }),
+        )),
+        "resources/templates/list" => Some(ok(
+            id?,
+            json!({ "resourceTemplates": crate::resources::templates() }),
+        )),
+        "resources/read" => {
+            let uri_str = req
+                .get("params")
+                .and_then(|p| p.get("uri"))
+                .and_then(Value::as_str)
+                .unwrap_or("");
+
+            let planned = crate::resources::ResourceUri::parse(uri_str)
+                .and_then(|uri| crate::resources::plan_read(&uri, server.resources().as_ref()));
+
+            let read = match planned {
+                Ok(r) => r,
+                Err(message) => return Some(err(id?, -32602, &message)),
+            };
+
+            // The catalog is assembled here rather than by invoking a
+            // capability: it describes this server, not the cluster.
+            let text = if read.capability == crate::resources::CATALOG_IN_PROCESS {
+                json!({
+                    "tools": server.list_tools().into_iter().map(|t| t.name).collect::<Vec<_>>(),
+                    "prompts": server.prompts().list().into_iter().map(|p| p.name).collect::<Vec<_>>(),
+                    "resourceTemplates": crate::resources::templates(),
+                })
+                .to_string()
+            } else {
+                // `McpServer::call_tool` is a bare registry invocation with no
+                // gating or auditing of its own — that lives in the
+                // `tools/call` arm, wrapped around the same call. This arm
+                // reproduces both here so a resource read leaves the same
+                // audit trail as the identical read via `tools/call`.
+                if server.consent_kind(read.capability).is_some() {
+                    // Unreachable today: `plan_read` only ever names the four
+                    // hardcoded, unconditionally-read-only capabilities in
+                    // `MAPPED_CAPABILITIES`, none of which are consent-gated.
+                    // Guarded explicitly anyway, fail-closed, rather than
+                    // assuming that stays true — clients auto-fetch
+                    // resources, so raising a confirm dialog here (as
+                    // `tools/call` does) would be exactly the consent-fatigue
+                    // vector the design avoids.
+                    let message = format!(
+                        "{} is consent-gated and must be called as a tool, not read as a resource",
+                        read.capability
+                    );
+                    server.audit().record(crate::audit::AuditRecord {
+                        transport,
+                        tool: read.capability.to_string(),
+                        args: crate::audit::redact(
+                            &read.args,
+                            server.is_sensitive(read.capability),
+                        ),
+                        decision: "denied",
+                        outcome: "error",
+                        error: Some(message.clone()),
+                    });
+                    return Some(err(id?, -32602, &message));
+                }
+
+                let sensitive = server.is_sensitive(read.capability);
+                let redacted_args = crate::audit::redact(&read.args, sensitive);
+                let called = server.call_tool(read.capability, read.args.clone()).await;
+                server.audit().record(crate::audit::AuditRecord {
+                    transport,
+                    tool: read.capability.to_string(),
+                    args: redacted_args,
+                    decision: "auto",
+                    outcome: if called.is_ok() { "ok" } else { "error" },
+                    error: called.as_ref().err().map(|e| e.to_string()),
+                });
+
+                match called {
+                    Ok(v) => match &v {
+                        // `getManifest` returns `{ yaml }` and `podLogs`
+                        // `{ logs }`; unwrap those so the client gets the
+                        // document, not a wrapper object. Keyed on the
+                        // planned mime rather than "one string-valued key":
+                        // a future capability that returns a single-key JSON
+                        // object (e.g. `{ "currentContext": "prod" }`) must
+                        // pass through as JSON, not be silently stripped to
+                        // a bare string.
+                        Value::Object(m) if read.mime != "application/json" && m.len() == 1 => m
+                            .values()
+                            .next()
+                            .and_then(Value::as_str)
+                            .map(str::to_string)
+                            .unwrap_or_else(|| v.to_string()),
+                        _ => v.to_string(),
+                    },
+                    Err(e) => return Some(err(id?, -32603, &e.to_string())),
+                }
+            };
+
+            Some(ok(
+                id?,
+                json!({ "contents": [{ "uri": uri_str, "mimeType": read.mime, "text": text }] }),
+            ))
         }
         _ => id.map(|id| err(id, -32601, "method not found")),
     }
@@ -784,5 +900,219 @@ mod tests {
             .as_str()
             .unwrap();
         assert!(text.contains("123"), "got {text}");
+    }
+
+    fn server_with_kinds() -> McpServer {
+        struct Kinds;
+        impl crate::resources::KindResolver for Kinds {
+            fn scope(&self, kind: &str) -> Option<crate::resources::KindScope> {
+                match kind {
+                    "Pod" => Some(crate::resources::KindScope::Namespaced),
+                    "Node" => Some(crate::resources::KindScope::ClusterScoped),
+                    _ => None,
+                }
+            }
+        }
+        server_with_ping().with_resources(Arc::new(Kinds))
+    }
+
+    #[tokio::test]
+    async fn initialize_advertises_resources_with_subscribe_true_on_stdio() {
+        let resp = handle_request(
+            &server_with_ping(),
+            &json!({"jsonrpc":"2.0","id":1,"method":"initialize"}),
+            Transport::Stdio,
+        )
+        .await
+        .unwrap();
+        let caps = &resp["result"]["capabilities"];
+        assert_eq!(caps["resources"]["subscribe"], json!(true));
+        assert_eq!(caps["resources"]["listChanged"], json!(false));
+        assert!(caps["tools"].is_object(), "tools must survive");
+        assert!(caps["prompts"].is_object(), "prompts must survive");
+    }
+
+    /// The HTTP transport is POST-only with no server-to-client channel, so it
+    /// must not claim a capability it cannot honour.
+    #[tokio::test]
+    async fn initialize_advertises_subscribe_false_on_http() {
+        let resp = handle_request(
+            &server_with_ping(),
+            &json!({"jsonrpc":"2.0","id":1,"method":"initialize"}),
+            Transport::Http,
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp["result"]["capabilities"]["resources"]["subscribe"], json!(false));
+    }
+
+    #[tokio::test]
+    async fn resources_list_returns_the_fixed_pair() {
+        let resp = handle_request(
+            &server_with_kinds(),
+            &json!({"jsonrpc":"2.0","id":2,"method":"resources/list"}),
+            Transport::Stdio,
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp["result"]["resources"].as_array().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn resources_templates_list_returns_three_templates() {
+        let resp = handle_request(
+            &server_with_kinds(),
+            &json!({"jsonrpc":"2.0","id":3,"method":"resources/templates/list"}),
+            Transport::Stdio,
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp["result"]["resourceTemplates"].as_array().unwrap().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn resources_read_rejects_a_secret_uri_with_invalid_params() {
+        let resp = handle_request(
+            &server_with_kinds(),
+            &json!({"jsonrpc":"2.0","id":4,"method":"resources/read",
+                    "params":{"uri":"k8s://c/ns/Secret/db-creds"}}),
+            Transport::Stdio,
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp["error"]["code"], -32602);
+        assert!(resp["error"]["message"].as_str().unwrap().contains("k8s.getSecret"));
+    }
+
+    #[tokio::test]
+    async fn resources_read_rejects_a_malformed_uri() {
+        let resp = handle_request(
+            &server_with_kinds(),
+            &json!({"jsonrpc":"2.0","id":5,"method":"resources/read",
+                    "params":{"uri":"not-a-uri"}}),
+            Transport::Stdio,
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp["error"]["code"], -32602);
+    }
+
+    /// `k8s://catalog` is assembled in-process, so it works with no cluster.
+    #[tokio::test]
+    async fn resources_read_serves_the_catalog_without_a_cluster() {
+        let resp = handle_request(
+            &server_with_kinds(),
+            &json!({"jsonrpc":"2.0","id":6,"method":"resources/read",
+                    "params":{"uri":"k8s://catalog"}}),
+            Transport::Stdio,
+        )
+        .await
+        .unwrap();
+        let contents = &resp["result"]["contents"][0];
+        assert_eq!(contents["uri"], "k8s://catalog");
+        assert_eq!(contents["mimeType"], "application/json");
+        let text = contents["text"].as_str().unwrap();
+        assert!(text.contains("ping"), "the catalog must list tools: {text}");
+    }
+
+    #[tokio::test]
+    async fn resources_read_without_a_resolver_addresses_no_objects() {
+        // `server_with_ping()` wires no resolver, so `NoKinds` applies.
+        let resp = handle_request(
+            &server_with_ping(),
+            &json!({"jsonrpc":"2.0","id":7,"method":"resources/read",
+                    "params":{"uri":"k8s://c/ns/Pod/web-0"}}),
+            Transport::Stdio,
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp["error"]["code"], -32602);
+    }
+
+    fn server_with_kinds_and_manifest(
+        handler: impl Fn(Value) -> Result<Value, srelens_capability::CapabilityError>
+            + Send
+            + Sync
+            + 'static,
+    ) -> McpServer {
+        struct Kinds;
+        impl crate::resources::KindResolver for Kinds {
+            fn scope(&self, kind: &str) -> Option<crate::resources::KindScope> {
+                match kind {
+                    "Pod" => Some(crate::resources::KindScope::Namespaced),
+                    _ => None,
+                }
+            }
+        }
+        let handler = Arc::new(handler);
+        let mut reg = Registry::new();
+        reg.register(Capability::read_only("k8s.getManifest", "reads a manifest", move |v| {
+            let handler = handler.clone();
+            async move { handler(v) }
+        }));
+        McpServer::new(Arc::new(reg)).with_resources(Arc::new(Kinds))
+    }
+
+    /// The vulnerability Finding 1 closes: `McpServer::call_tool` is a bare
+    /// registry invocation with no gating or auditing of its own, so a
+    /// resource read that skipped straight to it would leave zero trail
+    /// while the identical read via `tools/call` is logged. The audit
+    /// record must name the underlying capability, not `"resources/read"`,
+    /// since that is what an operator needs to see what actually touched
+    /// the cluster.
+    #[tokio::test]
+    async fn resources_read_records_one_audit_entry_naming_the_underlying_capability() {
+        use std::sync::Mutex;
+        #[derive(Default)]
+        struct Spy(Mutex<Vec<(String, &'static str, &'static str)>>);
+        impl crate::audit::AuditSink for Spy {
+            fn record(&self, rec: crate::audit::AuditRecord) {
+                self.0.lock().unwrap().push((rec.tool, rec.decision, rec.outcome));
+            }
+        }
+
+        let spy = Arc::new(Spy::default());
+        let server = server_with_kinds_and_manifest(|_| Ok(json!({ "yaml": "kind: Pod" })))
+            .with_audit(spy.clone());
+
+        let resp = handle_request(
+            &server,
+            &json!({"jsonrpc":"2.0","id":10,"method":"resources/read",
+                    "params":{"uri":"k8s://c/ns/Pod/web-0"}}),
+            Transport::Stdio,
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp["result"]["contents"][0]["text"], "kind: Pod", "got {resp}");
+
+        let seen = spy.0.lock().unwrap().clone();
+        assert_eq!(seen.len(), 1, "expected exactly one audit record, got {seen:?}");
+        assert_eq!(seen[0].0, "k8s.getManifest", "must name the underlying capability");
+        assert_eq!(seen[0].1, "auto");
+        assert_eq!(seen[0].2, "ok");
+    }
+
+    /// Finding 2: no existing test reached a real `call_tool` failure through
+    /// the read path — every other case is either the in-process catalog or
+    /// rejected earlier by `plan_read` with `-32602`.
+    #[tokio::test]
+    async fn resources_read_surfaces_a_capability_failure_as_internal_error() {
+        let server = server_with_kinds_and_manifest(|_| {
+            Err(srelens_capability::CapabilityError::Handler("no such pod".to_string()))
+        });
+
+        let resp = handle_request(
+            &server,
+            &json!({"jsonrpc":"2.0","id":11,"method":"resources/read",
+                    "params":{"uri":"k8s://c/ns/Pod/web-0"}}),
+            Transport::Stdio,
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp["error"]["code"], -32603, "got {resp}");
+        assert!(
+            resp["error"]["message"].as_str().unwrap().contains("no such pod"),
+            "got {resp}"
+        );
     }
 }

--- a/crates/mcp/src/stdio.rs
+++ b/crates/mcp/src/stdio.rs
@@ -1145,7 +1145,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resources_templates_list_returns_three_templates() {
+    async fn resources_templates_list_returns_four_templates() {
         let resp = handle_request(
             &server_with_kinds(),
             &json!({"jsonrpc":"2.0","id":3,"method":"resources/templates/list"}),
@@ -1153,7 +1153,7 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(resp["result"]["resourceTemplates"].as_array().unwrap().len(), 3);
+        assert_eq!(resp["result"]["resourceTemplates"].as_array().unwrap().len(), 4);
     }
 
     #[tokio::test]

--- a/crates/mcp/src/stdio.rs
+++ b/crates/mcp/src/stdio.rs
@@ -18,6 +18,17 @@ fn err(id: Value, code: i64, message: &str) -> Value {
     json!({ "jsonrpc": "2.0", "id": id, "error": { "code": code, "message": message } })
 }
 
+/// A `notifications/resources/updated` message. Carries only the URI — the
+/// client re-reads to get content, which is what MCP specifies and what lets a
+/// summary-level watch back a manifest subscription.
+pub fn subscription_notification(uri: &str) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/resources/updated",
+        "params": { "uri": uri }
+    })
+}
+
 /// Handle a single JSON-RPC request. Returns `None` for notifications (no id),
 /// which must not produce a response.
 pub async fn handle_request(
@@ -318,31 +329,169 @@ pub async fn handle_request(
     }
 }
 
-/// Run the MCP stdio loop: read newline-delimited JSON-RPC requests from
-/// `reader`, write responses to `writer`, until EOF.
+/// Subscription methods, handled in the serve loop rather than in
+/// `handle_request` — that function is shared with the POST-only HTTP transport,
+/// which must keep answering -32601 because it cannot push.
+///
+/// Synchronous: nothing here awaits. The watch it spawns signals changes by
+/// sending the canonical URI on `tx`, which the loop selects on.
+fn handle_subscription(
+    server: &std::sync::Arc<McpServer>,
+    subs: &std::sync::Arc<crate::subscriptions::SubscriptionRegistry>,
+    tx: &tokio::sync::mpsc::UnboundedSender<String>,
+    req: &Value,
+    method: &str,
+) -> Option<Value> {
+    let id = req.get("id").cloned()?;
+    let uri_str = req
+        .get("params")
+        .and_then(|p| p.get("uri"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+
+    let uri = match crate::resources::ResourceUri::parse(uri_str) {
+        Ok(u) => u,
+        Err(message) => return Some(err(id, -32602, &message)),
+    };
+    // Canonical form, so two spellings of one object cannot make two watches.
+    let canonical = uri.to_string();
+
+    if method == "resources/unsubscribe" {
+        subs.remove(&canonical);
+        return Some(ok(id, json!({})));
+    }
+
+    if let Err(message) = crate::resources::is_subscribable(&uri) {
+        return Some(err(id, -32602, &message));
+    }
+    // Reject anything unreadable up front, so a subscription cannot outlive a
+    // URI the server could never serve.
+    if let Err(message) = crate::resources::plan_read(&uri, server.resources().as_ref()) {
+        return Some(err(id, -32602, &message));
+    }
+
+    // The callback is sync and owns only a channel sender, so it needs no
+    // writer, no mutex and no spawn. A send failure means the loop is gone,
+    // which the watch's own abort will follow.
+    let tx = tx.clone();
+    let notify_uri = canonical.clone();
+    let on_change = Box::new(move || {
+        let _ = tx.send(notify_uri.clone());
+    });
+
+    let handle = match server.watcher().watch(&uri, on_change) {
+        Ok(h) => h,
+        Err(message) => return Some(err(id, -32602, &message)),
+    };
+    if let Err(message) = subs.insert(canonical, handle) {
+        return Some(err(id, -32602, &message));
+    }
+    Some(ok(id, json!({})))
+}
+
+/// Run the MCP stdio loop. Owns its writer and the subscription registry, so
+/// no watch outlives this session — stdio's client spawned the process, so loop
+/// exit *is* disconnect.
+///
+/// Watch callbacks are sync and cannot write asynchronously, so they send the
+/// changed URI over a channel; this loop selects on it alongside incoming
+/// requests. Responses and notifications are therefore written by one task and
+/// serialised by construction — no mutex, no spawn, and the writer bound stays
+/// `AsyncWrite + Unpin`.
 pub async fn serve<R, W>(server: McpServer, reader: R, mut writer: W) -> std::io::Result<()>
 where
     R: AsyncBufReadExt + Unpin,
     W: AsyncWrite + Unpin,
 {
+    let server = std::sync::Arc::new(server);
+    let subs = std::sync::Arc::new(crate::subscriptions::SubscriptionRegistry::new());
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+
+    let result = serve_loop(&server, &subs, &tx, &mut rx, reader, &mut writer).await;
+    // Release every watch however the loop ended — EOF or a write error. Doing
+    // this here rather than inside the loop means the `?` error path cannot skip
+    // it.
+    subs.abort_all();
+    result
+}
+
+async fn serve_loop<R, W>(
+    server: &std::sync::Arc<McpServer>,
+    subs: &std::sync::Arc<crate::subscriptions::SubscriptionRegistry>,
+    tx: &tokio::sync::mpsc::UnboundedSender<String>,
+    rx: &mut tokio::sync::mpsc::UnboundedReceiver<String>,
+    reader: R,
+    writer: &mut W,
+) -> std::io::Result<()>
+where
+    R: AsyncBufReadExt + Unpin,
+    W: AsyncWrite + Unpin,
+{
     let mut lines = reader.lines();
-    while let Some(line) = lines.next_line().await? {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let req: Value = match serde_json::from_str(trimmed) {
-            Ok(v) => v,
-            Err(_) => continue,
-        };
-        if let Some(resp) = handle_request(&server, &req, crate::Transport::Stdio).await {
-            let s = serde_json::to_string(&resp)?;
-            writer.write_all(s.as_bytes()).await?;
-            writer.write_all(b"\n").await?;
-            writer.flush().await?;
+
+    loop {
+        tokio::select! {
+            // Biased so a pending request is always drained before
+            // notifications, keeping request/response ordering predictable.
+            biased;
+
+            line = lines.next_line() => {
+                let Some(line) = line? else {
+                    // EOF. Biased select means a notification queued during the
+                    // last request would otherwise be dropped here, so drain
+                    // what is already pending before leaving.
+                    while let Ok(uri) = rx.try_recv() {
+                        write_line(writer, &subscription_notification(&uri)).await?;
+                    }
+                    return Ok(());
+                };
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                let Ok(req) = serde_json::from_str::<Value>(trimmed) else { continue };
+
+                let method = req.get("method").and_then(Value::as_str).unwrap_or("");
+                // Subscription methods are handled here, not in
+                // `handle_request`: that function is shared with the POST-only
+                // HTTP transport, which has no channel to push notifications and
+                // must keep answering -32601.
+                let resp = if method == "resources/subscribe" || method == "resources/unsubscribe" {
+                    handle_subscription(server, subs, tx, &req, method)
+                } else {
+                    handle_request(server, &req, crate::Transport::Stdio).await
+                };
+                if let Some(resp) = resp {
+                    write_line(writer, &resp).await?;
+                }
+                // A real stdio pipe naturally yields here whenever no more
+                // bytes are buffered, letting the executor poll a
+                // freshly-spawned watch task before the next request is
+                // handled. An in-memory reader/writer (`&[u8]` / `Vec<u8>`,
+                // as every test here uses) never returns `Pending`, so
+                // without an explicit yield point a current-thread runtime
+                // would never revisit its run queue and a watch's `on_change`
+                // could never fire before the session ends. This is a no-op
+                // in production and only matters for those in-memory
+                // fixtures.
+                tokio::task::yield_now().await;
+            }
+
+            Some(uri) = rx.recv() => {
+                write_line(writer, &subscription_notification(&uri)).await?;
+            }
         }
     }
-    Ok(())
+}
+
+async fn write_line<W>(writer: &mut W, value: &Value) -> std::io::Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    let s = serde_json::to_string(value)?;
+    writer.write_all(s.as_bytes()).await?;
+    writer.write_all(b"\n").await?;
+    writer.flush().await
 }
 
 #[cfg(test)]
@@ -913,7 +1062,17 @@ mod tests {
                 }
             }
         }
-        server_with_ping().with_resources(Arc::new(Kinds))
+        struct StubWatcher;
+        impl crate::resources::ObjectWatcher for StubWatcher {
+            fn watch(
+                &self,
+                _uri: &crate::resources::ResourceUri,
+                _on_change: Box<dyn FnMut() + Send>,
+            ) -> Result<tokio::task::AbortHandle, String> {
+                Ok(tokio::spawn(async { std::future::pending::<()>().await }).abort_handle())
+            }
+        }
+        server_with_ping().with_resources(Arc::new(Kinds)).with_watcher(Arc::new(StubWatcher))
     }
 
     #[tokio::test]
@@ -1114,5 +1273,184 @@ mod tests {
             resp["error"]["message"].as_str().unwrap().contains("no such pod"),
             "got {resp}"
         );
+    }
+
+    #[test]
+    fn a_subscription_notification_is_a_jsonrpc_notification_with_only_the_uri() {
+        let n = subscription_notification("k8s://c/ns/Pod/web-0");
+        assert_eq!(n["jsonrpc"], "2.0");
+        assert_eq!(n["method"], "notifications/resources/updated");
+        assert_eq!(n["params"]["uri"], "k8s://c/ns/Pod/web-0");
+        assert!(n.get("id").is_none(), "a notification must carry no id");
+        // Content is never pushed; the client re-reads.
+        assert!(n["params"].get("contents").is_none());
+        assert!(n["params"].get("text").is_none());
+    }
+
+    /// The HTTP transport has no server-to-client channel, so subscribe must
+    /// never be served there — `handle_request` (which HTTP uses) must not know
+    /// the method at all.
+    #[tokio::test]
+    async fn handle_request_does_not_serve_subscribe() {
+        let resp = handle_request(
+            &server_with_ping(),
+            &json!({"jsonrpc":"2.0","id":1,"method":"resources/subscribe",
+                    "params":{"uri":"k8s://c/ns/Pod/p"}}),
+            Transport::Http,
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp["error"]["code"], -32601);
+    }
+
+    /// End-to-end over the real `serve` loop: subscribe, then unsubscribe, and
+    /// confirm both are answered. The watch itself needs a cluster, so this
+    /// asserts the protocol handling and registry bookkeeping.
+    #[tokio::test]
+    async fn serve_answers_subscribe_and_unsubscribe() {
+        let input = concat!(
+            r#"{"jsonrpc":"2.0","id":1,"method":"resources/subscribe","params":{"uri":"k8s://c/ns/Pod/web-0"}}"#,
+            "\n",
+            r#"{"jsonrpc":"2.0","id":2,"method":"resources/unsubscribe","params":{"uri":"k8s://c/ns/Pod/web-0"}}"#,
+            "\n",
+        );
+        let mut out: Vec<u8> = Vec::new();
+        serve(server_with_kinds(), BufReader::new(input.as_bytes()), &mut out)
+            .await
+            .unwrap();
+        let text = String::from_utf8(out).unwrap();
+        let lines: Vec<&str> = text.lines().collect();
+        assert_eq!(lines.len(), 2, "one response each: {text}");
+        for line in lines {
+            let v: Value = serde_json::from_str(line).unwrap();
+            assert!(v.get("result").is_some(), "expected success, got {line}");
+        }
+    }
+
+    /// The notification path end to end, without a cluster: a stub watcher
+    /// fires `on_change` immediately, so this proves a watch event actually
+    /// reaches the client's stream — not just that the message shape is right.
+    #[tokio::test]
+    async fn a_watch_event_pushes_a_notification_onto_the_stream() {
+        struct FiringWatcher;
+        impl crate::resources::ObjectWatcher for FiringWatcher {
+            fn watch(
+                &self,
+                _uri: &crate::resources::ResourceUri,
+                mut on_change: Box<dyn FnMut() + Send>,
+            ) -> Result<tokio::task::AbortHandle, String> {
+                Ok(tokio::spawn(async move {
+                    on_change();
+                    std::future::pending::<()>().await
+                })
+                .abort_handle())
+            }
+        }
+
+        struct Kinds;
+        impl crate::resources::KindResolver for Kinds {
+            fn scope(&self, kind: &str) -> Option<crate::resources::KindScope> {
+                (kind == "Pod").then_some(crate::resources::KindScope::Namespaced)
+            }
+        }
+
+        let server = server_with_ping()
+            .with_resources(Arc::new(Kinds))
+            .with_watcher(Arc::new(FiringWatcher));
+
+        // A second line keeps the loop alive long enough for the spawned write
+        // to land before EOF ends the session.
+        let input = concat!(
+            r#"{"jsonrpc":"2.0","id":1,"method":"resources/subscribe","params":{"uri":"k8s://c/ns/Pod/web-0"}}"#,
+            "\n",
+            r#"{"jsonrpc":"2.0","id":2,"method":"ping"}"#,
+            "\n",
+        );
+        let mut out: Vec<u8> = Vec::new();
+        serve(server, BufReader::new(input.as_bytes()), &mut out).await.unwrap();
+
+        let text = String::from_utf8(out).unwrap();
+        assert!(
+            text.contains("notifications/resources/updated"),
+            "a watch event must push a notification: {text}"
+        );
+        assert!(text.contains("k8s://c/ns/Pod/web-0"), "the notification must name the URI: {text}");
+    }
+
+    /// stdio's client spawned the process, so loop exit IS disconnect — nothing
+    /// may outlive it. This is the leak the registry exists to prevent.
+    ///
+    /// This does not assert `AbortHandle::is_finished()` synchronously after
+    /// `serve` returns: `crates/mcp/src/subscriptions.rs`'s test module
+    /// documents (see `spawn_forever_joined`) that under this crate's
+    /// current-thread `#[tokio::test]` runtime, a freshly spawned task is
+    /// never even polled before such a synchronous check runs — measured at
+    /// 0/50 passes, independently reproduced at 0/20. Instead this retains the
+    /// watch's `JoinHandle` too and awaits it under `assert_aborted`'s bound,
+    /// which synchronizes on the cancellation actually completing rather than
+    /// racing the executor, and fails fast with a named message rather than
+    /// hanging if the abort never happens.
+    #[tokio::test]
+    async fn serve_aborts_every_subscription_when_the_loop_exits() {
+        use std::sync::{Arc as StdArc, Mutex};
+
+        type RecordedHandles = StdArc<Mutex<Option<(tokio::task::AbortHandle, tokio::task::JoinHandle<()>)>>>;
+
+        // Records the handles the watcher handed out, so the test can check
+        // the watch was aborted after `serve` returned.
+        #[derive(Clone)]
+        struct Recording(RecordedHandles);
+        impl crate::resources::ObjectWatcher for Recording {
+            fn watch(
+                &self,
+                _uri: &crate::resources::ResourceUri,
+                _on_change: Box<dyn FnMut() + Send>,
+            ) -> Result<tokio::task::AbortHandle, String> {
+                let join = tokio::spawn(async { std::future::pending::<()>().await });
+                let abort = join.abort_handle();
+                *self.0.lock().unwrap() = Some((abort.clone(), join));
+                Ok(abort)
+            }
+        }
+
+        let recorded = StdArc::new(Mutex::new(None));
+        let server = server_with_kinds().with_watcher(Arc::new(Recording(recorded.clone())));
+
+        let input = concat!(
+            r#"{"jsonrpc":"2.0","id":1,"method":"resources/subscribe","params":{"uri":"k8s://c/ns/Pod/web-0"}}"#,
+            "\n",
+        );
+        let mut out: Vec<u8> = Vec::new();
+        serve(server, BufReader::new(input.as_bytes()), &mut out).await.unwrap();
+
+        let (_, join) = recorded.lock().unwrap().take().expect("a watch was started");
+        match tokio::time::timeout(std::time::Duration::from_secs(2), join).await {
+            Ok(Ok(())) => panic!("watch task ran to completion instead of being aborted"),
+            Ok(Err(join_err)) => assert!(
+                join_err.is_cancelled(),
+                "the watch must be aborted when the loop exits, but it ended for another reason: {join_err}"
+            ),
+            Err(_) => panic!(
+                "timed out after 2s waiting for the watch to be aborted — it was never cancelled"
+            ),
+        }
+    }
+
+    #[tokio::test]
+    async fn serve_rejects_subscribing_to_a_non_subscribable_uri() {
+        let input = concat!(
+            r#"{"jsonrpc":"2.0","id":1,"method":"resources/subscribe","params":{"uri":"k8s://catalog"}}"#,
+            "\n",
+            r#"{"jsonrpc":"2.0","id":2,"method":"resources/subscribe","params":{"uri":"k8s://c/ns/Pod/p/logs"}}"#,
+            "\n",
+        );
+        let mut out: Vec<u8> = Vec::new();
+        serve(server_with_kinds(), BufReader::new(input.as_bytes()), &mut out)
+            .await
+            .unwrap();
+        for line in String::from_utf8(out).unwrap().lines() {
+            let v: Value = serde_json::from_str(line).unwrap();
+            assert_eq!(v["error"]["code"], -32602, "got {line}");
+        }
     }
 }

--- a/crates/mcp/src/stdio.rs
+++ b/crates/mcp/src/stdio.rs
@@ -364,8 +364,14 @@ fn handle_subscription(
     if let Err(message) = crate::resources::is_subscribable(&uri) {
         return Some(err(id, -32602, &message));
     }
-    // Reject anything unreadable up front, so a subscription cannot outlive a
-    // URI the server could never serve.
+    // `plan_read` is entirely offline: it validates the URI's shape, scope,
+    // and kind (and refuses Secrets) without checking that the capability it
+    // would invoke is actually registered on this server. So this guarantees
+    // the URI is well-formed and addressable — not that a later read will
+    // succeed; a subscription can still outlive a URI whose capability is
+    // missing or fails at call time. `server.resources()` matches the
+    // resolver `plan_read` and the real read path both use, so this and the
+    // eventual read agree on what's addressable.
     if let Err(message) = crate::resources::plan_read(&uri, server.resources().as_ref()) {
         return Some(err(id, -32602, &message));
     }

--- a/crates/mcp/src/stdio.rs
+++ b/crates/mcp/src/stdio.rs
@@ -338,7 +338,8 @@ pub async fn handle_request(
 fn handle_subscription(
     server: &std::sync::Arc<McpServer>,
     subs: &std::sync::Arc<crate::subscriptions::SubscriptionRegistry>,
-    tx: &tokio::sync::mpsc::UnboundedSender<String>,
+    dirty: &std::sync::Arc<std::sync::Mutex<std::collections::BTreeSet<String>>>,
+    wake: &tokio::sync::mpsc::Sender<()>,
     req: &Value,
     method: &str,
 ) -> Option<Value> {
@@ -376,13 +377,24 @@ fn handle_subscription(
         return Some(err(id, -32602, &message));
     }
 
-    // The callback is sync and owns only a channel sender, so it needs no
-    // writer, no mutex and no spawn. A send failure means the loop is gone,
-    // which the watch's own abort will follow.
-    let tx = tx.clone();
+    // The callback is sync and owns only the dirty set and a wakeup sender,
+    // so it needs no writer and no spawn. It never awaits, so the dirty
+    // set's lock is only ever held for the insert itself — matching the
+    // discipline in `subscriptions.rs`.
+    let dirty = dirty.clone();
+    let wake = wake.clone();
     let notify_uri = canonical.clone();
     let on_change = Box::new(move || {
-        let _ = tx.send(notify_uri.clone());
+        dirty
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(notify_uri.clone());
+        // `try_send` never blocks, keeping this callback synchronous. If the
+        // capacity-1 channel is already full, a wakeup is already pending —
+        // dropping this one is correct, not a lost notification, because
+        // that pending wakeup already guarantees `serve_loop` will come back
+        // and drain the whole dirty set, which by then includes this URI too.
+        let _ = wake.try_send(());
     });
 
     let handle = match server.watcher().watch(&uri, on_change) {
@@ -399,11 +411,18 @@ fn handle_subscription(
 /// no watch outlives this session — stdio's client spawned the process, so loop
 /// exit *is* disconnect.
 ///
-/// Watch callbacks are sync and cannot write asynchronously, so they send the
-/// changed URI over a channel; this loop selects on it alongside incoming
-/// requests. Responses and notifications are therefore written by one task and
-/// serialised by construction — no mutex, no spawn, and the writer bound stays
-/// `AsyncWrite + Unpin`.
+/// Watch callbacks are sync and cannot write asynchronously, so they cannot
+/// hand the loop content directly. Instead they insert the changed URI into a
+/// shared dirty set and signal a capacity-1 wakeup channel; this loop selects
+/// on the wakeup alongside incoming requests and, once woken, drains the
+/// whole dirty set. Because a notification carries only the URI (the client
+/// re-reads for content), N queued changes to the same URI are indistinguishable
+/// from one, so coalescing them is a strict improvement, not a tradeoff — it
+/// also bounds pending memory at the number of distinct subscribed URIs
+/// (at most `MAX_SUBSCRIPTIONS`) rather than growing without limit if the
+/// client stops reading. Responses and notifications are still written by one
+/// task and serialised by construction — no mutex around the writer, no
+/// spawn, and the writer bound stays `AsyncWrite + Unpin`.
 pub async fn serve<R, W>(server: McpServer, reader: R, mut writer: W) -> std::io::Result<()>
 where
     R: AsyncBufReadExt + Unpin,
@@ -411,9 +430,12 @@ where
 {
     let server = std::sync::Arc::new(server);
     let subs = std::sync::Arc::new(crate::subscriptions::SubscriptionRegistry::new());
-    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+    let dirty: std::sync::Arc<std::sync::Mutex<std::collections::BTreeSet<String>>> =
+        std::sync::Arc::new(std::sync::Mutex::new(std::collections::BTreeSet::new()));
+    let (wake_tx, mut wake_rx) = tokio::sync::mpsc::channel::<()>(1);
 
-    let result = serve_loop(&server, &subs, &tx, &mut rx, reader, &mut writer).await;
+    let result =
+        serve_loop(&server, &subs, &dirty, &wake_tx, &mut wake_rx, reader, &mut writer).await;
     // Release every watch however the loop ended — EOF or a write error. Doing
     // this here rather than inside the loop means the `?` error path cannot skip
     // it.
@@ -424,8 +446,9 @@ where
 async fn serve_loop<R, W>(
     server: &std::sync::Arc<McpServer>,
     subs: &std::sync::Arc<crate::subscriptions::SubscriptionRegistry>,
-    tx: &tokio::sync::mpsc::UnboundedSender<String>,
-    rx: &mut tokio::sync::mpsc::UnboundedReceiver<String>,
+    dirty: &std::sync::Arc<std::sync::Mutex<std::collections::BTreeSet<String>>>,
+    wake_tx: &tokio::sync::mpsc::Sender<()>,
+    wake_rx: &mut tokio::sync::mpsc::Receiver<()>,
     reader: R,
     writer: &mut W,
 ) -> std::io::Result<()>
@@ -454,8 +477,9 @@ where
             line = lines.next_line() => {
                 let Some(line) = line? else {
                     // EOF. Same starvation as above, one last time: drain
-                    // whatever is already pending before leaving.
-                    drain_notifications(writer, rx).await?;
+                    // whatever is already pending before leaving. No wakeup
+                    // token is needed here — the dirty set is read directly.
+                    drain_notifications(writer, dirty).await?;
                     return Ok(());
                 };
                 let trimmed = line.trim();
@@ -470,42 +494,57 @@ where
                 // HTTP transport, which has no channel to push notifications and
                 // must keep answering -32601.
                 let resp = if method == "resources/subscribe" || method == "resources/unsubscribe" {
-                    handle_subscription(server, subs, tx, &req, method)
+                    handle_subscription(server, subs, dirty, wake_tx, &req, method)
                 } else {
                     handle_request(server, &req, crate::Transport::Stdio).await
                 };
                 if let Some(resp) = resp {
                     write_line(writer, &resp).await?;
                 }
-                // `biased` means `rx.recv()` below is never polled while a
-                // line is ready — a pipelined client (several requests in one
-                // read, or a `try_recv` producer racing ahead) would starve
-                // every pending notification until EOF's drain otherwise.
-                // Draining here after every line bounds delivery to at most
-                // one request and keeps ordering deterministic: a request's
-                // own response is written before any notification a
-                // concurrent watch queued during its handling.
-                drain_notifications(writer, rx).await?;
+                // `biased` means `wake_rx.recv()` below is never polled while
+                // a line is ready — a pipelined client (several requests in
+                // one read, or a watch racing ahead) would starve every
+                // pending notification until EOF's drain otherwise. Draining
+                // here after every line bounds delivery to at most one
+                // request and keeps ordering deterministic: a request's own
+                // response is written before any notification a concurrent
+                // watch queued during its handling.
+                drain_notifications(writer, dirty).await?;
             }
 
-            Some(uri) = rx.recv() => {
-                write_line(writer, &subscription_notification(&uri)).await?;
+            Some(()) = wake_rx.recv() => {
+                // The wakeup itself carries no payload — it only means "the
+                // dirty set changed" — so draining reads the set directly
+                // rather than the channel.
+                drain_notifications(writer, dirty).await?;
             }
         }
     }
 }
 
-/// Write every notification already queued on `rx`, without waiting for more.
-/// Shared by the per-line and EOF paths so `biased` select's starvation gap
-/// (see `serve_loop`) is closed the same way in both places.
+/// Write one notification per URI currently in the dirty set, then clear it,
+/// without waiting for more to arrive. Shared by the per-line and EOF paths
+/// so `biased` select's starvation gap (see `serve_loop`) is closed the same
+/// way in both places.
+///
+/// Takes the whole set under the lock via `mem::take` and releases the lock
+/// before writing anything — the lock is never held across an await, matching
+/// the discipline in `subscriptions.rs`. `BTreeSet` yields URIs in sorted
+/// order rather than arrival order; that's fine, and deliberate: each
+/// notification is independent and carries no ordering meaning, it only
+/// tells the client to re-read that one URI.
 async fn drain_notifications<W>(
     writer: &mut W,
-    rx: &mut tokio::sync::mpsc::UnboundedReceiver<String>,
+    dirty: &std::sync::Arc<std::sync::Mutex<std::collections::BTreeSet<String>>>,
 ) -> std::io::Result<()>
 where
     W: AsyncWrite + Unpin,
 {
-    while let Ok(uri) = rx.try_recv() {
+    let uris = {
+        let mut guard = dirty.lock().unwrap_or_else(|e| e.into_inner());
+        std::mem::take(&mut *guard)
+    };
+    for uri in uris {
         write_line(writer, &subscription_notification(&uri)).await?;
     }
     Ok(())
@@ -1538,6 +1577,164 @@ mod tests {
             "the notification must not be pushed only by the EOF drain, \
              i.e. it must appear before the final response: {text}"
         );
+    }
+
+    /// A watcher whose spawned task calls `on_change` several times in a
+    /// tight loop with no `.await` between calls, so all the calls complete
+    /// within a single poll of the task — there is no scheduling point at
+    /// which the loop could interleave a drain between them. That makes the
+    /// dirty-set coalescing this proves deterministic rather than a race:
+    /// however the loop happens to be scheduled, all `times` inserts land in
+    /// the dirty set before it can ever be drained, so exactly one entry for
+    /// this URI survives regardless.
+    struct RepeatFiringWatcher {
+        times: usize,
+        fired: std::sync::Arc<tokio::sync::Notify>,
+    }
+    impl crate::resources::ObjectWatcher for RepeatFiringWatcher {
+        fn watch(
+            &self,
+            _uri: &crate::resources::ResourceUri,
+            mut on_change: Box<dyn FnMut() + Send>,
+        ) -> Result<tokio::task::AbortHandle, String> {
+            let fired = self.fired.clone();
+            let times = self.times;
+            Ok(tokio::spawn(async move {
+                for _ in 0..times {
+                    on_change();
+                }
+                fired.notify_one();
+                std::future::pending::<()>().await
+            })
+            .abort_handle())
+        }
+    }
+
+    /// The coalescing this closes: without it, 5 `on_change` calls to one
+    /// subscribed URI would queue 5 identical notifications, making the
+    /// client re-read the same URI 5 times to learn the same thing once.
+    /// Bounding pending memory at "distinct subscribed URIs" rather than
+    /// "watch events ever fired" depends on this actually deduplicating.
+    #[tokio::test]
+    async fn repeated_changes_to_one_uri_coalesce_to_fewer_notifications() {
+        struct Kinds;
+        impl crate::resources::KindResolver for Kinds {
+            fn scope(&self, kind: &str) -> Option<crate::resources::KindScope> {
+                (kind == "Pod").then_some(crate::resources::KindScope::Namespaced)
+            }
+        }
+
+        let fired = std::sync::Arc::new(tokio::sync::Notify::new());
+        let server = server_with_ping().with_resources(Arc::new(Kinds)).with_watcher(Arc::new(
+            RepeatFiringWatcher { times: 5, fired: fired.clone() },
+        ));
+
+        let (mut client_in, mut out_lines, serve_task) = spawn_serve_over_duplex(server);
+
+        client_in
+            .write_all(
+                br#"{"jsonrpc":"2.0","id":1,"method":"resources/subscribe","params":{"uri":"k8s://c/ns/Pod/web-0"}}
+"#,
+            )
+            .await
+            .unwrap();
+
+        // Deterministic: wait for all 5 `on_change` calls to have actually
+        // run and been inserted into the dirty set, rather than racing them
+        // against this test ending the session.
+        fired.notified().await;
+
+        drop(client_in); // EOF: nothing more is coming.
+        serve_task.await.unwrap().unwrap();
+
+        let mut text = String::new();
+        while let Some(line) = out_lines.next_line().await.unwrap() {
+            text.push_str(&line);
+            text.push('\n');
+        }
+        let count = text.matches("notifications/resources/updated").count();
+        assert_eq!(
+            count, 1,
+            "5 on_change calls to the same URI must coalesce to exactly one notification: {text}"
+        );
+    }
+
+    /// Sibling of the coalescing test above, pinning the other half: distinct
+    /// URIs must never collapse into each other just because they share a
+    /// drain pass. A dirty set keyed on the whole URI is what this depends
+    /// on; a regression that, say, coalesced by kind or by drain pass alone
+    /// would break this while leaving the single-URI test above green.
+    #[tokio::test]
+    async fn two_different_subscribed_uris_each_still_get_a_notification() {
+        struct Kinds;
+        impl crate::resources::KindResolver for Kinds {
+            fn scope(&self, kind: &str) -> Option<crate::resources::KindScope> {
+                (kind == "Pod").then_some(crate::resources::KindScope::Namespaced)
+            }
+        }
+
+        struct TwoUriWatcher {
+            fired_a: std::sync::Arc<tokio::sync::Notify>,
+            fired_b: std::sync::Arc<tokio::sync::Notify>,
+        }
+        impl crate::resources::ObjectWatcher for TwoUriWatcher {
+            fn watch(
+                &self,
+                uri: &crate::resources::ResourceUri,
+                mut on_change: Box<dyn FnMut() + Send>,
+            ) -> Result<tokio::task::AbortHandle, String> {
+                let fired = if uri.to_string().contains("web-0") {
+                    self.fired_a.clone()
+                } else {
+                    self.fired_b.clone()
+                };
+                Ok(tokio::spawn(async move {
+                    on_change();
+                    fired.notify_one();
+                    std::future::pending::<()>().await
+                })
+                .abort_handle())
+            }
+        }
+
+        let fired_a = std::sync::Arc::new(tokio::sync::Notify::new());
+        let fired_b = std::sync::Arc::new(tokio::sync::Notify::new());
+        let server = server_with_ping().with_resources(Arc::new(Kinds)).with_watcher(Arc::new(
+            TwoUriWatcher { fired_a: fired_a.clone(), fired_b: fired_b.clone() },
+        ));
+
+        let (mut client_in, mut out_lines, serve_task) = spawn_serve_over_duplex(server);
+
+        client_in
+            .write_all(
+                br#"{"jsonrpc":"2.0","id":1,"method":"resources/subscribe","params":{"uri":"k8s://c/ns/Pod/web-0"}}
+"#,
+            )
+            .await
+            .unwrap();
+        client_in
+            .write_all(
+                br#"{"jsonrpc":"2.0","id":2,"method":"resources/subscribe","params":{"uri":"k8s://c/ns/Pod/web-1"}}
+"#,
+            )
+            .await
+            .unwrap();
+
+        fired_a.notified().await;
+        fired_b.notified().await;
+
+        drop(client_in); // EOF: nothing more is coming.
+        serve_task.await.unwrap().unwrap();
+
+        let mut text = String::new();
+        while let Some(line) = out_lines.next_line().await.unwrap() {
+            text.push_str(&line);
+            text.push('\n');
+        }
+        let count = text.matches("notifications/resources/updated").count();
+        assert_eq!(count, 2, "two distinct URIs must not coalesce into one: {text}");
+        assert!(text.contains("web-0"), "got {text}");
+        assert!(text.contains("web-1"), "got {text}");
     }
 
     /// stdio's client spawned the process, so loop exit IS disconnect — nothing

--- a/crates/mcp/src/stdio.rs
+++ b/crates/mcp/src/stdio.rs
@@ -431,18 +431,25 @@ where
 
     loop {
         tokio::select! {
-            // Biased so a pending request is always drained before
-            // notifications, keeping request/response ordering predictable.
+            // Biased so a pending request is always answered before
+            // notifications, keeping request/response ordering deterministic.
+            // The cost: `tokio::select!` with `biased` polls branches in
+            // written order and returns on the first `Ready` one *without
+            // polling the rest* — so whenever `lines.next_line()` resolves
+            // immediately (a pipelined client, or several lines arriving in
+            // one read), `rx.recv()` below is never polled that iteration,
+            // and would starve every queued notification until EOF's drain.
+            // The explicit `drain_notifications` call after each processed
+            // line is what closes that gap; removing it silently turns
+            // "pushed" notifications into "delivered whenever the client
+            // happens to pause or disconnect".
             biased;
 
             line = lines.next_line() => {
                 let Some(line) = line? else {
-                    // EOF. Biased select means a notification queued during the
-                    // last request would otherwise be dropped here, so drain
-                    // what is already pending before leaving.
-                    while let Ok(uri) = rx.try_recv() {
-                        write_line(writer, &subscription_notification(&uri)).await?;
-                    }
+                    // EOF. Same starvation as above, one last time: drain
+                    // whatever is already pending before leaving.
+                    drain_notifications(writer, rx).await?;
                     return Ok(());
                 };
                 let trimmed = line.trim();
@@ -464,17 +471,15 @@ where
                 if let Some(resp) = resp {
                     write_line(writer, &resp).await?;
                 }
-                // A real stdio pipe naturally yields here whenever no more
-                // bytes are buffered, letting the executor poll a
-                // freshly-spawned watch task before the next request is
-                // handled. An in-memory reader/writer (`&[u8]` / `Vec<u8>`,
-                // as every test here uses) never returns `Pending`, so
-                // without an explicit yield point a current-thread runtime
-                // would never revisit its run queue and a watch's `on_change`
-                // could never fire before the session ends. This is a no-op
-                // in production and only matters for those in-memory
-                // fixtures.
-                tokio::task::yield_now().await;
+                // `biased` means `rx.recv()` below is never polled while a
+                // line is ready — a pipelined client (several requests in one
+                // read, or a `try_recv` producer racing ahead) would starve
+                // every pending notification until EOF's drain otherwise.
+                // Draining here after every line bounds delivery to at most
+                // one request and keeps ordering deterministic: a request's
+                // own response is written before any notification a
+                // concurrent watch queued during its handling.
+                drain_notifications(writer, rx).await?;
             }
 
             Some(uri) = rx.recv() => {
@@ -482,6 +487,22 @@ where
             }
         }
     }
+}
+
+/// Write every notification already queued on `rx`, without waiting for more.
+/// Shared by the per-line and EOF paths so `biased` select's starvation gap
+/// (see `serve_loop`) is closed the same way in both places.
+async fn drain_notifications<W>(
+    writer: &mut W,
+    rx: &mut tokio::sync::mpsc::UnboundedReceiver<String>,
+) -> std::io::Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    while let Ok(uri) = rx.try_recv() {
+        write_line(writer, &subscription_notification(&uri)).await?;
+    }
+    Ok(())
 }
 
 async fn write_line<W>(writer: &mut W, value: &Value) -> std::io::Result<()>
@@ -1327,23 +1348,149 @@ mod tests {
         }
     }
 
+    /// A watcher that records whether it fired, via a real async wakeup
+    /// rather than a flag a test would have to poll. Used by the two tests
+    /// below to synchronize deterministically on "the watch has run and
+    /// queued its notification" instead of racing a background task against
+    /// the test's own progress.
+    struct FiringWatcher(std::sync::Arc<tokio::sync::Notify>);
+    impl crate::resources::ObjectWatcher for FiringWatcher {
+        fn watch(
+            &self,
+            _uri: &crate::resources::ResourceUri,
+            mut on_change: Box<dyn FnMut() + Send>,
+        ) -> Result<tokio::task::AbortHandle, String> {
+            let fired = self.0.clone();
+            Ok(tokio::spawn(async move {
+                on_change();
+                fired.notify_one();
+                std::future::pending::<()>().await
+            })
+            .abort_handle())
+        }
+    }
+
+    /// Drives `serve` over a real async pipe pair (`tokio::io::duplex`)
+    /// rather than the in-memory `&[u8]`/`Vec<u8>` every other test in this
+    /// module uses.
+    ///
+    /// An in-memory reader/writer never returns `Pending`: `AsyncRead for
+    /// &[u8]` and `AsyncWrite for Vec<u8>` both resolve every poll
+    /// immediately. That gives a single-threaded executor no principled
+    /// reason to ever revisit its run queue, so a freshly `tokio::spawn`ed
+    /// watch task is never polled before the session ends — which is exactly
+    /// why `a_watch_event_pushes_a_notification_onto_the_stream` and the
+    /// pipelining test below need to observe a watch firing at all. An
+    /// earlier version of this fix tried `#[tokio::test(flavor =
+    /// "multi_thread")]` with the in-memory fixture instead, reasoning that
+    /// production (`apps/desktop/src-tauri/src/main.rs`'s `run_mcp_stdio`)
+    /// runs on a multi-thread runtime, so an idle worker would pick up the
+    /// spawned task regardless of whether this loop's own task ever yields.
+    /// That is true in isolation, but it is a race against OS thread
+    /// scheduling, not a `Pending`-driven guarantee: run as part of this
+    /// crate's full, highly parallel test binary (~200 concurrently
+    /// scheduled tests contending for CPU), it failed reliably (5/5), not
+    /// just occasionally. A `DuplexStream` genuinely returns `Pending` when
+    /// its peer has not written anything yet — exactly like a real stdio
+    /// pipe — so it gives the executor a real, load-independent reason to
+    /// poll the spawned watch task, making these tests deterministic under
+    /// any scheduling flavor or system load.
+    fn spawn_serve_over_duplex(
+        server: McpServer,
+    ) -> (
+        tokio::io::DuplexStream,
+        tokio::io::Lines<BufReader<tokio::io::DuplexStream>>,
+        tokio::task::JoinHandle<std::io::Result<()>>,
+    ) {
+        let (client_in, server_in) = tokio::io::duplex(8192);
+        let (server_out, client_out) = tokio::io::duplex(8192);
+        let serve_task = tokio::spawn(async move {
+            serve(server, BufReader::new(server_in), server_out).await
+        });
+        (client_in, BufReader::new(client_out).lines(), serve_task)
+    }
+
     /// The notification path end to end, without a cluster: a stub watcher
     /// fires `on_change` immediately, so this proves a watch event actually
     /// reaches the client's stream — not just that the message shape is right.
     #[tokio::test]
     async fn a_watch_event_pushes_a_notification_onto_the_stream() {
-        struct FiringWatcher;
-        impl crate::resources::ObjectWatcher for FiringWatcher {
+        struct Kinds;
+        impl crate::resources::KindResolver for Kinds {
+            fn scope(&self, kind: &str) -> Option<crate::resources::KindScope> {
+                (kind == "Pod").then_some(crate::resources::KindScope::Namespaced)
+            }
+        }
+
+        let fired = std::sync::Arc::new(tokio::sync::Notify::new());
+        let server = server_with_ping()
+            .with_resources(Arc::new(Kinds))
+            .with_watcher(Arc::new(FiringWatcher(fired.clone())));
+
+        let (mut client_in, mut out_lines, serve_task) = spawn_serve_over_duplex(server);
+
+        client_in
+            .write_all(
+                br#"{"jsonrpc":"2.0","id":1,"method":"resources/subscribe","params":{"uri":"k8s://c/ns/Pod/web-0"}}
+"#,
+            )
+            .await
+            .unwrap();
+
+        // Deterministic: wait for the watch to actually have run and queued
+        // its notification, rather than racing it against this test ending
+        // the session.
+        fired.notified().await;
+
+        drop(client_in); // EOF: nothing more is coming.
+        serve_task.await.unwrap().unwrap();
+
+        let mut text = String::new();
+        while let Some(line) = out_lines.next_line().await.unwrap() {
+            text.push_str(&line);
+            text.push('\n');
+        }
+        assert!(
+            text.contains("notifications/resources/updated"),
+            "a watch event must push a notification: {text}"
+        );
+        assert!(text.contains("k8s://c/ns/Pod/web-0"), "the notification must name the URI: {text}");
+    }
+
+    /// The bug the per-line drain in `serve_loop` closes: `biased` select
+    /// polls `rx.recv()` only when no line is ready, so a pipelined client —
+    /// several requests arriving in one read before the loop catches up —
+    /// would starve every queued notification until EOF, turning "pushed"
+    /// into "delivered whenever the client happens to pause or disconnect".
+    /// This asserts the notification is written right after the subscribe
+    /// response, well before the last of the pipelined responses — i.e. that
+    /// it did not wait for EOF's drain to appear.
+    ///
+    /// Unlike `a_watch_event_pushes_a_notification_onto_the_stream`, this
+    /// watcher fires `on_change` *synchronously inside `watch()` itself*,
+    /// before `handle_subscription` even returns, rather than from a spawned
+    /// task. That is deliberate, not a shortcut: it makes "the notification
+    /// is already in the channel by the time line 1 finishes processing" a
+    /// plain causal fact of call order, not a race against when some other
+    /// task happens to be scheduled — so this test is deterministic under
+    /// the default single-threaded `#[tokio::test]` runtime regardless of
+    /// how many other tests are contending for CPU, and can use the same
+    /// plain `&[u8]`/`Vec<u8>` fixture as every other non-watch test in this
+    /// module. It is still a faithful reproduction of the bug: what matters
+    /// for `biased` starvation is only that the notification is ready
+    /// *before* the loop finishes draining an already-buffered run of lines,
+    /// not how it got that way.
+    #[tokio::test]
+    async fn a_pipelined_client_still_gets_the_notification_before_the_session_ends() {
+        struct ImmediatelyFiringWatcher;
+        impl crate::resources::ObjectWatcher for ImmediatelyFiringWatcher {
             fn watch(
                 &self,
                 _uri: &crate::resources::ResourceUri,
                 mut on_change: Box<dyn FnMut() + Send>,
             ) -> Result<tokio::task::AbortHandle, String> {
-                Ok(tokio::spawn(async move {
-                    on_change();
-                    std::future::pending::<()>().await
-                })
-                .abort_handle())
+                on_change();
+                Ok(tokio::spawn(async { std::future::pending::<()>().await }).abort_handle())
             }
         }
 
@@ -1356,25 +1503,35 @@ mod tests {
 
         let server = server_with_ping()
             .with_resources(Arc::new(Kinds))
-            .with_watcher(Arc::new(FiringWatcher));
+            .with_watcher(Arc::new(ImmediatelyFiringWatcher));
 
-        // A second line keeps the loop alive long enough for the spawned write
-        // to land before EOF ends the session.
-        let input = concat!(
+        // Subscribe, then a burst of buffered requests arriving as one
+        // pipelined batch — exactly the shape that starves `rx.recv()` under
+        // `biased` select without a per-line drain, because `next_line()`
+        // resolves synchronously for every one of these without ever giving
+        // the executor cause to look elsewhere.
+        let mut input = String::from(
             r#"{"jsonrpc":"2.0","id":1,"method":"resources/subscribe","params":{"uri":"k8s://c/ns/Pod/web-0"}}"#,
-            "\n",
-            r#"{"jsonrpc":"2.0","id":2,"method":"ping"}"#,
-            "\n",
         );
+        input.push('\n');
+        for i in 2..22 {
+            input.push_str(&format!(r#"{{"jsonrpc":"2.0","id":{i},"method":"ping"}}"#));
+            input.push('\n');
+        }
         let mut out: Vec<u8> = Vec::new();
         serve(server, BufReader::new(input.as_bytes()), &mut out).await.unwrap();
 
         let text = String::from_utf8(out).unwrap();
+        let lines: Vec<&str> = text.lines().collect();
+        let notification_pos = lines
+            .iter()
+            .position(|l| l.contains("notifications/resources/updated"))
+            .expect("a watch event must push a notification");
         assert!(
-            text.contains("notifications/resources/updated"),
-            "a watch event must push a notification: {text}"
+            notification_pos < lines.len() - 1,
+            "the notification must not be pushed only by the EOF drain, \
+             i.e. it must appear before the final response: {text}"
         );
-        assert!(text.contains("k8s://c/ns/Pod/web-0"), "the notification must name the URI: {text}");
     }
 
     /// stdio's client spawned the process, so loop exit IS disconnect — nothing
@@ -1452,5 +1609,41 @@ mod tests {
             let v: Value = serde_json::from_str(line).unwrap();
             assert_eq!(v["error"]["code"], -32602, "got {line}");
         }
+    }
+
+    /// `NoWatcher` is unit-tested directly in `resources.rs`, but that alone
+    /// does not prove the fail-closed default is actually reachable through
+    /// the real subscribe path — a wiring bug could leave it dead code while
+    /// every real server accidentally got a working watcher some other way.
+    /// This drives `resources/subscribe` through `serve` on a server built
+    /// with plain `McpServer::new` — no `.with_watcher(...)` at all — so it
+    /// falls back to `NoWatcher`, and checks the rejection actually happens
+    /// end to end.
+    #[tokio::test]
+    async fn serve_rejects_a_subscription_when_no_watcher_is_wired() {
+        struct Kinds;
+        impl crate::resources::KindResolver for Kinds {
+            fn scope(&self, kind: &str) -> Option<crate::resources::KindScope> {
+                (kind == "Pod").then_some(crate::resources::KindScope::Namespaced)
+            }
+        }
+        // Deliberately no `.with_watcher(...)`: this is what a host that
+        // wires resources but forgets (or has no) cluster watcher looks like.
+        let server = server_with_ping().with_resources(Arc::new(Kinds));
+
+        let input = concat!(
+            r#"{"jsonrpc":"2.0","id":1,"method":"resources/subscribe","params":{"uri":"k8s://c/ns/Pod/web-0"}}"#,
+            "\n",
+        );
+        let mut out: Vec<u8> = Vec::new();
+        serve(server, BufReader::new(input.as_bytes()), &mut out).await.unwrap();
+
+        let text = String::from_utf8(out).unwrap();
+        let v: Value = serde_json::from_str(text.trim()).unwrap();
+        assert_eq!(v["error"]["code"], -32602, "got {text}");
+        assert!(
+            v["error"]["message"].as_str().unwrap().contains("no cluster watcher"),
+            "the message must explain no watcher is wired, got {text}"
+        );
     }
 }

--- a/crates/mcp/src/subscriptions.rs
+++ b/crates/mcp/src/subscriptions.rs
@@ -28,9 +28,17 @@ impl SubscriptionRegistry {
 
     /// Register a watch for `uri`. Re-subscribing to the same URI aborts the
     /// previous watch and replaces it, so one URI never has two.
+    ///
+    /// Takes ownership of `handle`, and disposes of it either way: on
+    /// success it is stored (and a displaced previous watch, if any, is
+    /// aborted); on `Err` — the cap was hit — `handle` itself is aborted
+    /// before returning, since a rejected watch is useless by definition and
+    /// the caller has no reference left to clean it up. Callers never need to
+    /// abort on `Err`.
     pub fn insert(&self, uri: String, handle: AbortHandle) -> Result<(), String> {
         let mut live = self.live.lock().unwrap_or_else(|e| e.into_inner());
         if !live.contains_key(&uri) && live.len() >= MAX_SUBSCRIPTIONS {
+            handle.abort();
             return Err(format!(
                 "too many subscriptions: the limit is {MAX_SUBSCRIPTIONS}; \
                  unsubscribe from something first"
@@ -102,6 +110,27 @@ mod tests {
         (abort, join)
     }
 
+    /// Awaits `join` under a short bound and asserts the task was actually
+    /// cancelled.
+    ///
+    /// A bare `join.await` here would hang the whole test binary forever
+    /// if a regression (e.g. deleting an `abort()` call) stops the task from
+    /// ever being cancelled — verified: doing exactly that during review made
+    /// the affected test hang past 20s instead of failing. Wrapping in
+    /// `tokio::time::timeout` turns that into a fast, explicit, named
+    /// failure instead of an indefinite stall that looks like an
+    /// infrastructure problem rather than a test failure.
+    async fn assert_aborted(join: tokio::task::JoinHandle<()>) {
+        match tokio::time::timeout(std::time::Duration::from_secs(2), join).await {
+            Ok(Ok(())) => panic!("watch task ran to completion instead of being aborted"),
+            Ok(Err(err)) => assert!(
+                err.is_cancelled(),
+                "watch task ended for a reason other than cancellation: {err}"
+            ),
+            Err(_) => panic!("timed out after 2s waiting for the watch to be aborted — it was never cancelled"),
+        }
+    }
+
     #[tokio::test]
     async fn insert_then_remove_tracks_length() {
         let r = SubscriptionRegistry::new();
@@ -126,8 +155,7 @@ mod tests {
         r.insert("k8s://c/ns/Pod/a".into(), first).unwrap();
         r.insert("k8s://c/ns/Pod/a".into(), spawn_forever()).unwrap();
         assert_eq!(r.len(), 1, "one URI, one subscription");
-        let err = first_join.await.unwrap_err();
-        assert!(err.is_cancelled(), "the replaced watch must have been aborted");
+        assert_aborted(first_join).await;
     }
 
     #[tokio::test]
@@ -139,6 +167,27 @@ mod tests {
         let e = r.insert("k8s://c/ns/Pod/one-too-many".into(), spawn_forever()).unwrap_err();
         assert!(e.contains(&MAX_SUBSCRIPTIONS.to_string()), "got: {e}");
         assert_eq!(r.len(), MAX_SUBSCRIPTIONS);
+    }
+
+    /// `insert` takes ownership of `handle`; on the cap-rejection branch it
+    /// must dispose of it by aborting it, not merely drop it —
+    /// `AbortHandle`'s `Drop` does not cancel the underlying task, so a
+    /// dropped-but-not-aborted handle would leak a detached, permanently
+    /// running watch. The caller has already spawned the task and, once
+    /// ownership of the handle moved into `insert`, has no reference left to
+    /// clean it up — a client retrying against the cap would leak one watch
+    /// per attempt, exactly the resource exhaustion `MAX_SUBSCRIPTIONS`
+    /// exists to prevent.
+    #[tokio::test]
+    async fn cap_rejection_aborts_the_rejected_watch() {
+        let r = SubscriptionRegistry::new();
+        for i in 0..MAX_SUBSCRIPTIONS {
+            r.insert(format!("k8s://c/ns/Pod/p{i}"), spawn_forever()).unwrap();
+        }
+        let (rejected, rejected_join) = spawn_forever_joined();
+        r.insert("k8s://c/ns/Pod/one-too-many".into(), rejected)
+            .expect_err("the cap should reject the extra subscription");
+        assert_aborted(rejected_join).await;
     }
 
     /// The `!contains_key` half of the cap guard (`if !live.contains_key(&uri)
@@ -168,7 +217,7 @@ mod tests {
         r.insert("b".into(), b).unwrap();
         r.abort_all();
         assert_eq!(r.len(), 0);
-        assert!(a_join.await.unwrap_err().is_cancelled());
-        assert!(b_join.await.unwrap_err().is_cancelled());
+        assert_aborted(a_join).await;
+        assert_aborted(b_join).await;
     }
 }

--- a/crates/mcp/src/subscriptions.rs
+++ b/crates/mcp/src/subscriptions.rs
@@ -1,0 +1,174 @@
+//! Live subscriptions for the stdio transport. Owned by the `serve` loop, so a
+//! watch cannot outlive the session that asked for it.
+
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+
+use tokio::task::AbortHandle;
+
+/// Prompt bodies and agents both loop, so an unbounded subscription count is a
+/// resource-exhaustion path. 32 concurrent watches is far more than a human
+/// triage session needs.
+pub const MAX_SUBSCRIPTIONS: usize = 32;
+
+/// Live subscriptions, keyed by canonical URI.
+///
+/// Uses a std `Mutex` around a plain map: every operation is a short,
+/// non-blocking map edit plus an `abort()` call, so nothing is held across an
+/// await.
+#[derive(Default)]
+pub struct SubscriptionRegistry {
+    live: Mutex<BTreeMap<String, AbortHandle>>,
+}
+
+impl SubscriptionRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a watch for `uri`. Re-subscribing to the same URI aborts the
+    /// previous watch and replaces it, so one URI never has two.
+    pub fn insert(&self, uri: String, handle: AbortHandle) -> Result<(), String> {
+        let mut live = self.live.lock().unwrap_or_else(|e| e.into_inner());
+        if !live.contains_key(&uri) && live.len() >= MAX_SUBSCRIPTIONS {
+            return Err(format!(
+                "too many subscriptions: the limit is {MAX_SUBSCRIPTIONS}; \
+                 unsubscribe from something first"
+            ));
+        }
+        if let Some(previous) = live.insert(uri, handle) {
+            previous.abort();
+        }
+        Ok(())
+    }
+
+    /// Abort and forget `uri`. Returns whether it was subscribed.
+    pub fn remove(&self, uri: &str) -> bool {
+        let mut live = self.live.lock().unwrap_or_else(|e| e.into_inner());
+        match live.remove(uri) {
+            Some(handle) => {
+                handle.abort();
+                true
+            }
+            None => false,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.live.lock().unwrap_or_else(|e| e.into_inner()).len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Abort every live watch. Called when the serve loop exits, so no watch
+    /// outlives the session.
+    pub fn abort_all(&self) {
+        let mut live = self.live.lock().unwrap_or_else(|e| e.into_inner());
+        for handle in live.values() {
+            handle.abort();
+        }
+        live.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spawn_forever() -> tokio::task::AbortHandle {
+        tokio::spawn(async { std::future::pending::<()>().await }).abort_handle()
+    }
+
+    /// Spawns a task that never finishes on its own, returning both the
+    /// `AbortHandle` (what `SubscriptionRegistry` stores) and the
+    /// `JoinHandle`.
+    ///
+    /// Tests that need to observe an abort use the `JoinHandle` rather than
+    /// polling `AbortHandle::is_finished()` synchronously: `abort()` only
+    /// *requests* cancellation, and `is_finished()` only flips once the
+    /// runtime has actually reaped the task. This crate's `#[tokio::test]`
+    /// runs on a current-thread runtime (`crates/mcp` enables tokio's `rt`
+    /// feature, not `rt-multi-thread`), so a freshly spawned task is never
+    /// even polled before a synchronous post-`abort()` check runs — measured
+    /// empirically at 0/50 passes for both `is_finished()`-based assertions
+    /// this replaced. Awaiting the `JoinHandle` instead synchronizes on the
+    /// cancellation actually completing, so it is deterministic rather than
+    /// racing the executor.
+    fn spawn_forever_joined() -> (tokio::task::AbortHandle, tokio::task::JoinHandle<()>) {
+        let join = tokio::spawn(async { std::future::pending::<()>().await });
+        let abort = join.abort_handle();
+        (abort, join)
+    }
+
+    #[tokio::test]
+    async fn insert_then_remove_tracks_length() {
+        let r = SubscriptionRegistry::new();
+        r.insert("k8s://c/ns/Pod/a".into(), spawn_forever()).unwrap();
+        assert_eq!(r.len(), 1);
+        assert!(r.remove("k8s://c/ns/Pod/a"));
+        assert_eq!(r.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn removing_an_unknown_uri_reports_false() {
+        let r = SubscriptionRegistry::new();
+        assert!(!r.remove("k8s://c/ns/Pod/nope"));
+    }
+
+    /// Re-subscribing must not leave two watches running for one URI — the leak
+    /// this type exists to prevent.
+    #[tokio::test]
+    async fn re_inserting_aborts_the_previous_watch() {
+        let r = SubscriptionRegistry::new();
+        let (first, first_join) = spawn_forever_joined();
+        r.insert("k8s://c/ns/Pod/a".into(), first).unwrap();
+        r.insert("k8s://c/ns/Pod/a".into(), spawn_forever()).unwrap();
+        assert_eq!(r.len(), 1, "one URI, one subscription");
+        let err = first_join.await.unwrap_err();
+        assert!(err.is_cancelled(), "the replaced watch must have been aborted");
+    }
+
+    #[tokio::test]
+    async fn the_cap_is_enforced_and_names_itself() {
+        let r = SubscriptionRegistry::new();
+        for i in 0..MAX_SUBSCRIPTIONS {
+            r.insert(format!("k8s://c/ns/Pod/p{i}"), spawn_forever()).unwrap();
+        }
+        let e = r.insert("k8s://c/ns/Pod/one-too-many".into(), spawn_forever()).unwrap_err();
+        assert!(e.contains(&MAX_SUBSCRIPTIONS.to_string()), "got: {e}");
+        assert_eq!(r.len(), MAX_SUBSCRIPTIONS);
+    }
+
+    /// The `!contains_key` half of the cap guard (`if !live.contains_key(&uri)
+    /// && live.len() >= MAX_SUBSCRIPTIONS`) exists precisely so that, once
+    /// already at the cap, re-subscribing to a URI already held still
+    /// succeeds instead of being rejected. Deleting that clause leaves every
+    /// other test in this module green, so it needs its own coverage.
+    #[tokio::test]
+    async fn re_subscribing_at_the_cap_still_succeeds() {
+        let r = SubscriptionRegistry::new();
+        for i in 0..MAX_SUBSCRIPTIONS {
+            r.insert(format!("k8s://c/ns/Pod/p{i}"), spawn_forever()).unwrap();
+        }
+        assert_eq!(r.len(), MAX_SUBSCRIPTIONS);
+
+        r.insert("k8s://c/ns/Pod/p0".into(), spawn_forever())
+            .expect("re-subscribing to an already-held URI must succeed even at the cap");
+        assert_eq!(r.len(), MAX_SUBSCRIPTIONS, "replacing in place must not change the count");
+    }
+
+    #[tokio::test]
+    async fn abort_all_stops_every_watch() {
+        let r = SubscriptionRegistry::new();
+        let (a, a_join) = spawn_forever_joined();
+        let (b, b_join) = spawn_forever_joined();
+        r.insert("a".into(), a).unwrap();
+        r.insert("b".into(), b).unwrap();
+        r.abort_all();
+        assert_eq!(r.len(), 0);
+        assert!(a_join.await.unwrap_err().is_cancelled());
+        assert!(b_join.await.unwrap_err().is_cancelled());
+    }
+}

--- a/crates/registry/Cargo.toml
+++ b/crates/registry/Cargo.toml
@@ -6,6 +6,13 @@ edition.workspace = true
 [dependencies]
 srelens-capability = { path = "../capability" }
 srelens-kube = { path = "../kube" }
+# `kind_resolver` returns `dyn srelens_mcp::resources::KindResolver`, so this is
+# real API surface, not test-only. `crates/mcp` also has `srelens-registry` as
+# a dev-dependency (for its own e2e prompt test), making this a dev-only cycle:
+# registry's real dependency on mcp, plus mcp's dev-only dependency on
+# registry. Cargo permits this because neither library build depends on the
+# other; confirmed via `cargo check -p srelens-registry -p srelens-mcp`.
+srelens-mcp = { path = "../mcp" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Blocking HTTP for toolbox downloads (run inside spawn_blocking). rustls with
@@ -15,5 +22,4 @@ serde_json = "1"
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "rustls-no-provider"] }
 
 [dev-dependencies]
-srelens-mcp = { path = "../mcp" }
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/crates/registry/src/lib.rs
+++ b/crates/registry/src/lib.rs
@@ -338,6 +338,28 @@ pub fn build_registry_with(cache: Arc<ClientCache>) -> Registry {
     build_registry_with_paths(cache, default_kubeconfig_paths())
 }
 
+/// The real resource kind resolver, over `srelens_kube::manifest::gvk_for`.
+///
+/// `Secret` is excluded deliberately: it is the one read-only kind that is
+/// consent-gated (`k8s.getSecret` is `SENSITIVE_READ`), and resource reads must
+/// never trip the consent gate — clients auto-fetch resources to populate
+/// context, so a confirm dialog there would be a consent-fatigue vector.
+pub fn kind_resolver() -> std::sync::Arc<dyn srelens_mcp::resources::KindResolver> {
+    struct GvkKinds;
+    impl srelens_mcp::resources::KindResolver for GvkKinds {
+        fn scope(&self, kind: &str) -> Option<srelens_mcp::resources::KindScope> {
+            use srelens_mcp::resources::KindScope;
+            if kind == "Secret" {
+                return None;
+            }
+            srelens_kube::manifest::gvk_for(kind).map(|(_, namespaced)| {
+                if namespaced { KindScope::Namespaced } else { KindScope::ClusterScoped }
+            })
+        }
+    }
+    std::sync::Arc::new(GvkKinds)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -389,6 +411,26 @@ mod tests {
         let mut default_ids = default_reg.ids();
         default_ids.sort();
         assert_eq!(ids, default_ids, "same capabilities regardless of paths");
+    }
+
+    #[test]
+    fn the_real_kind_resolver_covers_namespaced_and_cluster_scoped_kinds() {
+        use srelens_mcp::resources::{KindResolver, KindScope};
+        let r = crate::kind_resolver();
+        assert_eq!(r.scope("Pod"), Some(KindScope::Namespaced));
+        assert_eq!(r.scope("Deployment"), Some(KindScope::Namespaced));
+        assert_eq!(r.scope("Node"), Some(KindScope::ClusterScoped));
+        assert_eq!(r.scope("PersistentVolume"), Some(KindScope::ClusterScoped));
+        assert_eq!(r.scope("Nonsense"), None);
+    }
+
+    /// The curation that makes "the consent gate never fires on a resource
+    /// read" true: Secrets are reachable only through the gated
+    /// `k8s.getSecret` tool, never as an addressable resource.
+    #[test]
+    fn the_real_kind_resolver_excludes_secrets() {
+        use srelens_mcp::resources::KindResolver;
+        assert_eq!(crate::kind_resolver().scope("Secret"), None);
     }
 
     #[test]

--- a/crates/registry/src/lib.rs
+++ b/crates/registry/src/lib.rs
@@ -415,7 +415,7 @@ mod tests {
 
     #[test]
     fn the_real_kind_resolver_covers_namespaced_and_cluster_scoped_kinds() {
-        use srelens_mcp::resources::{KindResolver, KindScope};
+        use srelens_mcp::resources::KindScope;
         let r = crate::kind_resolver();
         assert_eq!(r.scope("Pod"), Some(KindScope::Namespaced));
         assert_eq!(r.scope("Deployment"), Some(KindScope::Namespaced));
@@ -429,7 +429,6 @@ mod tests {
     /// `k8s.getSecret` tool, never as an addressable resource.
     #[test]
     fn the_real_kind_resolver_excludes_secrets() {
-        use srelens_mcp::resources::KindResolver;
         assert_eq!(crate::kind_resolver().scope("Secret"), None);
     }
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -456,6 +456,68 @@ Retrieving a prompt is not itself an audited event — nothing touches a
 cluster to fetch one. The tool calls an agent makes while following it are
 audited exactly like any other MCP call.
 
+### Resources
+
+Alongside tools and prompts, srelens exposes cluster state as MCP
+**resources** — addressable under `k8s://` URIs that a client can list, read,
+and (over stdio) subscribe to for change notifications.
+
+Two URIs are fixed:
+
+- `k8s://contexts` — the same contexts `k8s.listContexts` returns.
+- `k8s://catalog` — every tool, prompt and resource template this server
+  exposes, so a client can introspect the whole surface in one read.
+
+Everything else addresses a single object, using one of three URI shapes:
+
+```
+k8s://<context>/<namespace>/<kind>/<name>
+k8s://<context>/<namespace>/<kind>/<name>/events
+k8s://<context>/<namespace>/Pod/<name>/logs
+```
+
+The first reads the object's manifest as YAML; `/events` lists events whose
+involved object is that resource; `/logs` reads a pod's recent log output.
+Cluster-scoped kinds (`Node`, `PersistentVolume`, `ClusterRole`, and so on)
+have no namespace — use `-` in that slot rather than leaving it blank.
+
+**Secrets are not addressable.** A `k8s://.../Secret/...` read is refused
+with an error naming the alternative: fetch secret data with the
+`k8s.getSecret` tool instead, which is consent-gated. A resource is the kind
+of thing a client fetches automatically to build context, with no
+confirmation step in front of it, so routing Secret contents through that
+path would quietly bypass the one control that exists to gate secret
+material.
+
+Every segment is percent-encoded, so a context name containing `/` or `:` —
+an EKS cluster ARN, say — round-trips safely.
+
+`resources/list` returns only the two fixed entries above. Enumerating every
+object in a cluster would be unbounded, and would need a cluster round trip
+just to answer a discovery call. Object addressing is discoverable instead
+through `resources/templates/list`, which advertises the three URI shapes
+above as templates for a client to fill in.
+
+A resource read is resolved to the same capability call a tool invocation
+would make — `k8s.getManifest`, `k8s.listEvents`, `k8s.podLogs`, or
+`k8s.listContexts` — so it goes through the identical path and is **audited
+exactly like a tool call**, appearing in the same audit log under the
+underlying capability's name, with the same redaction rules.
+
+**Subscriptions work over stdio only.** A client can send
+`resources/subscribe` for an object URI and receive a
+`notifications/resources/updated` message whenever that object changes; the
+notification carries only the URI, and the client re-reads to get the new
+content. The HTTP transport is request/response only, with no channel for
+the server to push a notification back, so it advertises `subscribe: false`
+in `initialize` and answers `resources/subscribe` with an error rather than
+silently accepting a subscription that can never fire. Pushing resource
+updates to HTTP clients (via SSE or similar) is tracked as a follow-up in
+[issue #193](https://github.com/srelens/srelens/issues/193). Up to 32
+subscriptions can be live at once; re-subscribing to a URI you already hold
+replaces it in place rather than counting twice, and past the cap you need to
+unsubscribe from something before adding another.
+
 ## Settings reference
 
 **Settings** (gear icon in the hotbar) has seven sections:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -468,18 +468,25 @@ Two URIs are fixed:
 - `k8s://catalog` — every tool, prompt and resource template this server
   exposes, so a client can introspect the whole surface in one read.
 
-Everything else addresses a single object, using one of three URI shapes:
+Everything else addresses a single object, using one of these URI shapes:
 
 ```
 k8s://<context>/<namespace>/<kind>/<name>
 k8s://<context>/<namespace>/<kind>/<name>/events
 k8s://<context>/<namespace>/Pod/<name>/logs
+k8s://<context>/<namespace>/Pod/<name>/logs/<container>
 ```
 
 The first reads the object's manifest as YAML; `/events` lists events whose
 involved object is that resource; `/logs` reads a pod's recent log output.
 Cluster-scoped kinds (`Node`, `PersistentVolume`, `ClusterRole`, and so on)
 have no namespace — use `-` in that slot rather than leaving it blank.
+
+`/logs` without a container works only for a single-container pod — that is
+the one case the Kubernetes log API will serve without being told which
+container you mean. For a pod with more than one container (a sidecar, say),
+add the container as a sixth segment; omitting it gets you an error naming
+every container to choose from, not a guess at which one you meant.
 
 **Secrets are not addressable.** A `k8s://.../Secret/...` read is refused
 with an error naming the alternative: fetch secret data with the
@@ -495,7 +502,7 @@ an EKS cluster ARN, say — round-trips safely.
 `resources/list` returns only the two fixed entries above. Enumerating every
 object in a cluster would be unbounded, and would need a cluster round trip
 just to answer a discovery call. Object addressing is discoverable instead
-through `resources/templates/list`, which advertises the three URI shapes
+through `resources/templates/list`, which advertises the four URI shapes
 above as templates for a client to fill in.
 
 A resource read is resolved to the same capability call a tool invocation


### PR DESCRIPTION
Closes #24.

Adds MCP **resources**, so an agent can address cluster state by URI instead of only calling tools — hold "the manifest of pod web-0" as a stable reference, hand it to a client to keep in context, and be told when it changes.

## URI scheme

```
k8s://<context>/<namespace>/<kind>/<name>            the object's manifest
k8s://<context>/<namespace>/<kind>/<name>/events     events for that object
k8s://<context>/<namespace>/Pod/<name>/logs          pod logs (Pod only)
k8s://contexts                                       fixed: connected contexts
k8s://catalog                                        fixed: tools + prompts + templates
```

Cluster-scoped kinds use `-` as the namespace segment. Every segment is percent-encoded — kube context names are arbitrary strings and EKS names them with ARNs containing both `/` and `:`, which would otherwise reshape the path into a different resource.

`resources/list` returns only the two fixed entries; enumerating cluster objects would be unbounded and would need a round-trip to answer a discovery call. Object addressing is discoverable through `resources/templates/list`.

## Reads

`resources/read` maps a URI onto one of four read-only capabilities and invokes it through the normal capability path, so annotations, Secret redaction and the audit log all apply — a resource read appears in the audit log as its underlying tool call.

## Subscriptions — stdio only

`resources/subscribe` / `resources/unsubscribe` are served on stdio, backed by a single-object kube watch using a `metadata.name` field selector: one API watch per subscribed object, reusing the existing backoff and reconnect handling. Notifications carry only the URI and the client re-reads.

The HTTP transport is POST-only with no server-to-client channel, so `initialize` advertises `subscribe: false` there and `true` on stdio — accurate by construction rather than claiming a capability the transport cannot honour. HTTP push is tracked as #193.

Subscriptions are owned by the `serve` loop, capped at 32, idempotent on re-subscribe (never two watches for one URI), and every watch is aborted when the loop exits — stdio's client spawned the process, so loop exit *is* disconnect.

## Security

Two curation decisions, both enforced rather than asserted:

- **Secrets are not addressable at all.** `k8s://…/Secret/…` is refused on both the read and the watch path, with the error pointing at the consent-gated `k8s.getSecret` tool. The exclusion lives in one place (`kind_resolver`) so it cannot drift between paths.
- **No capability reachable from a resource read is consent-gated.** Clients auto-fetch resources to populate context, so a resource read raising a confirm dialog would be a consent-fatigue vector. A guard test pins it, and `resources/read` also checks at request time and fails closed with `-32602`.

`crates/mcp` gains no dependency on `crates/kube` — the `KindResolver` and `ObjectWatcher` traits are the seams, with the real implementations wired by `crates/registry` and the desktop app.

## Notable fixes found in review

- A change arriving during a watch **relist** (410 GONE, etcd compaction, apiserver restart) was never notified, because the object comes back as `InitApply`. The first init sequence is silent by design — the client has just read the resource — but every subsequent one now notifies.
- A failed watch (unknown context, RBAC denial) answered `resources/subscribe` with success and squatted one of the 32 slots forever.
- `/events` subscriptions watched the *parent* object, so a new Event fired nothing and an unrelated parent bump fired spuriously. Now refused, like `/logs`.
- `resources/read` initially bypassed the audit log entirely: `call_tool` is a bare `registry.invoke`, and all consent/redaction/audit logic lives in the `tools/call` wrapper.

## Testing

695 workspace tests pass (up from 649 at the fork point). Docs in `docs/USAGE.md`.

The e2e subscription check against a live cluster is `#[ignore]`d and **compile-verified only** — no cluster was reachable during development. Worth running with `cargo test -p srelens-desktop --test e2e -- --ignored` against kind before merge.

## Follow-ups

- Evict dead watches from the subscription registry (currently they stay until unsubscribe or session end)
- Make `ResourceRead.capability` a closed enum, so the set `plan_read` can name is compiler-known rather than a hand-maintained list
- Make `/events` genuinely subscribable by watching `Event` objects filtered by `involvedObject`
- Audit-log `resources/subscribe`, so an operator can see an agent opened 32 watches
- Rename `McpServer::resources` / `with_resources` to `kind_resolver`, which is what they hold
