### PR TITLE
fix(hotbar): scroll only the cluster list so fixed controls stay visible

### DIFF
--- a/apps/desktop/src/components/ClusterHotbar.tsx
+++ b/apps/desktop/src/components/ClusterHotbar.tsx
@@ -78,12 +78,16 @@ export function ClusterHotbar({
 
   return (
     <div className="fl-hotbar">
-      {remoteContexts.map(renderItem)}
-      {remoteContexts.length > 0 && localContexts.length > 0 && (
-        <div className="fl-hotbar__divider" role="separator" aria-label="Local clusters" />
-      )}
-      {localContexts.map(renderItem)}
-      <div className="fl-hotbar__spacer" aria-hidden="true" />
+      {/* Only the cluster list scrolls — with many contexts it must never
+          push the fixed controls below (toolbox, assistant, settings) out
+          of the window. */}
+      <div className="fl-hotbar__clusters">
+        {remoteContexts.map(renderItem)}
+        {remoteContexts.length > 0 && localContexts.length > 0 && (
+          <div className="fl-hotbar__divider" role="separator" aria-label="Local clusters" />
+        )}
+        {localContexts.map(renderItem)}
+      </div>
       <button
         className="fl-hotbar__theme"
         aria-label={theme.mode === "dark" ? "Switch to light mode" : "Switch to dark mode"}

--- a/apps/desktop/src/ui/styles.css
+++ b/apps/desktop/src/ui/styles.css
@@ -610,9 +610,29 @@ body {
   align-items: center;
   gap: var(--fl-space-sm);
   padding: var(--fl-space-md) 0;
-  overflow-y: auto;
+  /* The rail itself never scrolls — the fixed controls at the bottom
+     (toolbox, assistant, settings) must always stay visible. Only the
+     cluster list inside scrolls. */
+  overflow: hidden;
 }
-.fl-hotbar::-webkit-scrollbar { width: 0; }
+.fl-hotbar__clusters {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--fl-space-sm);
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  /* Keep the rail visually clean; the list still scrolls by wheel/trackpad. */
+  scrollbar-width: none;
+  width: 100%;
+}
+.fl-hotbar__clusters::-webkit-scrollbar { width: 0; }
+/* Flex children in a constrained column SHRINK before the container scrolls
+   — avatars would squish instead of scrolling without this. */
+.fl-hotbar__clusters > * {
+  flex-shrink: 0;
+}
 .fl-hotbar__theme {
   margin-top: auto;
   width: 36px;
@@ -3556,9 +3576,6 @@ body {
 }
 
 /* Enterprise navigation/list polish. */
-.fl-hotbar__spacer {
-  flex: 1 1 auto;
-}
 .fl-hotbar__theme {
   margin-top: 0;
 }


### PR DESCRIPTION
Relates to #209 (does not close it — the abbreviation quality itself is a separate fix).

## What

With many kube contexts, the cluster hotbar grew past the window and pushed the fixed controls — theme, toolbox, assistant, Settings — out of view. The whole rail was the scroll container with a hidden scrollbar, so they scrolled away invisibly with no way to reach them.

## How

- The cluster avatars move into their own `.fl-hotbar__clusters` container: `flex: 1 1 auto; min-height: 0; overflow-y: auto`, scrollbar hidden, children `flex-shrink: 0` so avatars scroll instead of squishing.
- The rail itself is `overflow: hidden` — the bottom controls stay pinned regardless of cluster count.
- The old `fl-hotbar__spacer` div (previously pushing the controls down) is obsolete and removed.

## Testing

- `tsc --noEmit` clean; all 977 frontend tests pass (4 hotbar tests among them).
- Visual: with a tall cluster list, the strip scrolls under the wheel while Settings and friends stay visible.
