### PR TITLE
fix(docker): keep the embedded MCP prompt markdown in the build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,6 @@ apps/desktop/src-tauri/target
 docs
 packaging
 **/*.md
+# The MCP diagnostic prompts are embedded into the binary via include_str! —
+# they must stay in the build context despite the markdown exclusion above.
+!crates/mcp/src/prompts/*.md


### PR DESCRIPTION
## What

Re-includes `crates/mcp/src/prompts/*.md` in the docker build context with a negation rule after the blanket `**/*.md` exclusion in `.dockerignore`.

## Why

The server image build has failed to compile since the MCP diagnostic prompts landed (#189): `prompts.rs` embeds the eight prompt files via `include_str!`, but `**/*.md` stripped them from the build context, so `COPY crates crates` delivered the crate without them:

```
error: couldn't read crates/mcp/src/prompts/pod-crashloop.targeted.md: No such file or directory
```

Seen in the [release run docker jobs](https://github.com/srelens/srelens/actions/runs/31643485602/job/94271562422). Local builds never caught it because the files exist on disk outside docker.

## Testing

- Simulated the dockerignore matching (last-match-wins + negation): the eight prompt files are back in the context; every other markdown (`README.md`, `docs/**`, crate READMEs) stays excluded.
- PR CI doesn't build the docker image — the end-to-end proof is the re-triggered release run's docker jobs after this merges to `dev`.