### PR TITLE
fix: address the release-PR (#213) review — release gate, kubectl quoting, CLI session resume

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,12 +95,20 @@ jobs:
           RANGE=""
           [ -n "$LAST_TAG" ] && RANGE="${LAST_TAG}..HEAD"
           SUBJECTS=$(git log --no-merges --pretty=%B ${RANGE})
+          # Each pattern also accepts a leading "* " so a SQUASH-merged
+          # dev→main promotion still releases: GitHub's default squash message
+          # lists the squashed commits as "* <subject>" bullets in the body,
+          # and without this the only commit in range would be the
+          # non-conventional "release: ..." subject itself — BUMP=none, and
+          # the entire release (desktop, docker, AUR) silently skips. The
+          # documented path is still a plain merge commit; this is the
+          # backstop for the wrong button.
           if echo "$SUBJECTS" | grep -qiE '(^|[[:space:]])BREAKING[ -]CHANGE' \
-             || echo "$SUBJECTS" | grep -qE '^[a-z]+(\([^)]*\))?!:'; then
+             || echo "$SUBJECTS" | grep -qE '^(\* )?[a-z]+(\([^)]*\))?!:'; then
             BUMP=major
-          elif echo "$SUBJECTS" | grep -qE '^feat(\([^)]*\))?:'; then
+          elif echo "$SUBJECTS" | grep -qE '^(\* )?feat(\([^)]*\))?:'; then
             BUMP=minor
-          elif echo "$SUBJECTS" | grep -qE '^(fix|perf)(\([^)]*\))?:'; then
+          elif echo "$SUBJECTS" | grep -qE '^(\* )?(fix|perf)(\([^)]*\))?:'; then
             BUMP=patch
           else
             BUMP=none

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,8 +137,16 @@ jobs:
           # and smarter ranking" tells a user nothing that "**palette:** ..."
           # does. Line 1 handles scoped commits, line 2 unscoped ones.
           strip='s/^[a-z]+\(([^)]*)\)!?:[[:space:]]*/**\1:** /; s/^[a-z]+!?:[[:space:]]*//'
-          FEATS=$(git log --no-merges --pretty=%s ${RANGE} | grep -E '^feat' | sed -E "$strip" | sed 's/^/- /' || true)
-          FIXES=$(git log --no-merges --pretty=%s ${RANGE} | grep -E '^(fix|perf)' | sed -E "$strip" | sed 's/^/- /' || true)
+          # Subjects, plus "* <subject>" bullets from commit BODIES — the shape
+          # GitHub's squash merge records the squashed commits in. Without the
+          # bullets, a squash-merged promotion (whose only subject is the
+          # non-conventional "release: ..." title) would pass the bump gate
+          # above but publish a release with EMPTY notes. Plain body prose
+          # stays excluded: only "* "-bulleted, type-prefixed lines qualify.
+          SOURCES=$( { git log --no-merges --pretty=%s ${RANGE}; \
+                       git log --no-merges --pretty=%b ${RANGE} | sed -nE 's/^\* ([a-z]+(\([^)]*\))?!?:.*)$/\1/p'; } )
+          FEATS=$(echo "$SOURCES" | grep -E '^feat' | sed -E "$strip" | sed 's/^/- /' || true)
+          FIXES=$(echo "$SOURCES" | grep -E '^(fix|perf)' | sed -E "$strip" | sed 's/^/- /' || true)
           {
             echo "notes<<__NOTES_EOF__"
             [ -n "$FEATS" ] && printf '### Features\n%s\n\n' "$FEATS"

--- a/apps/desktop/src-tauri/src/assistant.rs
+++ b/apps/desktop/src-tauri/src/assistant.rs
@@ -424,10 +424,12 @@ fn parse_agent_kind(kind: &str) -> Result<AgentKind, String> {
 ///
 /// `resume` is the agent CLI's OWN session id from a previous turn of this
 /// conversation (what this function returned last time), passed to the CLI's
-/// `--resume` so follow-up turns keep their context. Returns the id captured
-/// from this turn's stream — the caller persists it with the conversation
-/// and hands it back on the next send. `None` when the agent doesn't expose
-/// one (native, Codex) or the turn ended before the stream started.
+/// `--resume` so follow-up turns keep their context. Returns what the caller
+/// should now store as the conversation's id (see `next_resume_id`): the id
+/// captured from this turn's stream, the echoed `resume` when the turn ran
+/// clean or was cancelled without yielding one, or `None` — meaning CLEAR —
+/// for agents with no id (native, Codex) and for a crashed resume, so a
+/// dead session id can't wedge the conversation in a retry loop.
 #[tauri::command]
 pub async fn chat_send(
     session: String,
@@ -497,10 +499,11 @@ pub async fn chat_send(
     // dropped by the same take.
     if chats.take_pending_cancel(&session, turn) {
         sink.emit(&channel, serde_json::to_value(AgentEvent::TurnDone).unwrap());
-        // `None`, not the passed `resume`: the caller keeps its stored id
-        // whenever this returns nothing (see `sendChat`), so a cancelled turn
-        // doesn't lose the conversation's continuity.
-        return Ok(None);
+        // Echo the resume id back: nothing ran, the stored session is intact,
+        // and the caller stores exactly what's returned — a bare `None` here
+        // would read as "clear it" (the failed-resume signal from
+        // `next_resume_id`) and needlessly drop continuity on a cancel.
+        return Ok(resume);
     }
 
     let token = mcp
@@ -768,11 +771,28 @@ pub async fn chat_send(
 
     finish_turn(sink.as_ref(), &channel, saw_done, crashed, &stderr_tail);
 
-    // Fall back to the id we resumed FROM when the stream never yielded one
-    // (crash before the first line, unexpected shape): the caller overwrites
-    // its stored id only with a non-`None` return, so continuity degrades to
-    // "unchanged" rather than snapping back to fresh sessions.
-    Ok(agent_session.or(resume))
+    Ok(next_resume_id(agent_session, resume, crashed))
+}
+
+/// What the caller should store as the conversation's CLI session id after a
+/// turn: the id captured from the stream when there is one, else the id we
+/// resumed FROM (a clean-but-drifty stream, or a cancel — `chat_cancel`
+/// reaps the child, so a user-initiated stop never counts as `crashed`) —
+/// EXCEPT after a crash that yielded no id. That is the signature of the
+/// `--resume` itself failing (the CLI GC'd or never had the session), and
+/// echoing the id back would make every subsequent turn retry the same
+/// failing resume with no way out short of a new chat. `None` there tells
+/// the caller to clear its stored id so the next turn starts fresh.
+fn next_resume_id(
+    agent_session: Option<String>,
+    resume: Option<String>,
+    crashed: bool,
+) -> Option<String> {
+    match agent_session {
+        Some(id) => Some(id),
+        None if crashed => None,
+        None => resume,
+    }
 }
 
 /// Kill a running turn's agent process, if any. `turn` is the frontend's turn
@@ -807,6 +827,31 @@ pub async fn chat_cancel(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_captured_stream_id_always_wins() {
+        assert_eq!(
+            next_resume_id(Some("new".into()), Some("old".into()), true),
+            Some("new".into())
+        );
+        assert_eq!(next_resume_id(Some("new".into()), None, false), Some("new".into()));
+    }
+
+    #[test]
+    fn a_clean_turn_without_an_id_echoes_the_resume_back() {
+        // Shape drift or a cancel (never `crashed` — chat_cancel reaps the
+        // child): the stored session is intact, keep it.
+        assert_eq!(next_resume_id(None, Some("old".into()), false), Some("old".into()));
+        assert_eq!(next_resume_id(None, None, false), None);
+    }
+
+    #[test]
+    fn a_crash_without_an_id_clears_the_resume() {
+        // The signature of `--resume` itself failing (session GC'd/unknown):
+        // echoing "old" back would retry the same failing resume forever.
+        assert_eq!(next_resume_id(None, Some("old".into()), true), None);
+        assert_eq!(next_resume_id(None, None, true), None);
+    }
 
     #[test]
     fn a_found_binary_is_available_with_its_path() {

--- a/apps/desktop/src-tauri/src/assistant.rs
+++ b/apps/desktop/src-tauri/src/assistant.rs
@@ -421,6 +421,13 @@ fn parse_agent_kind(kind: &str) -> Result<AgentKind, String> {
 
 /// Send one user turn. Spawns the agent against our running MCP server and
 /// streams `AgentEvent`s on `chat://<session>`.
+///
+/// `resume` is the agent CLI's OWN session id from a previous turn of this
+/// conversation (what this function returned last time), passed to the CLI's
+/// `--resume` so follow-up turns keep their context. Returns the id captured
+/// from this turn's stream — the caller persists it with the conversation
+/// and hands it back on the next send. `None` when the agent doesn't expose
+/// one (native, Codex) or the turn ended before the stream started.
 #[tauri::command]
 pub async fn chat_send(
     session: String,
@@ -429,10 +436,11 @@ pub async fn chat_send(
     agent_path: String,
     agent_kind: String,
     turn: Option<u64>,
+    resume: Option<String>,
     app: tauri::AppHandle,
     mcp: tauri::State<'_, crate::mcp::McpHttpManager>,
     chats: tauri::State<'_, ChatManager>,
-) -> Result<(), String> {
+) -> Result<Option<String>, String> {
     // The turn generation the frontend stamped this send with; a Stop for the
     // same turn arms `pending_cancels` under this value. Optional so callers
     // that never cancel (e.g. one-shot generation turns) can omit it.
@@ -453,13 +461,27 @@ pub async fn chat_send(
         return Err(format!("invalid session id {session:?}"));
     }
 
+    // The resume id lands in the agent's argv (`--resume <id>`). Real ids are
+    // CLI-minted uuids, but this one round-trips through the persisted
+    // session file on disk — validate it to the same bare charset as the
+    // session id above so a tampered store can't smuggle a flag-shaped or
+    // whitespace-carrying token into the command line. Invalid → dropped
+    // (fresh session), not an error: continuity is best-effort by design.
+    let resume = resume.filter(|id| {
+        !id.is_empty() && id.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+    });
+
     // The native agent takes an entirely different path from the CLI spawns
     // below: no process, no PATH binary, no loopback HTTP. It runs the loop
     // in-process against a provider API and drives MCP tools directly through
     // the same consent/audit server the CLIs reach over HTTP. Handle it here so
     // the CLI machinery below only ever sees the three CLI kinds.
     if matches!(kind, AgentKind::Srelens) {
-        return crate::llm_agent::run_native_agent(app, &chats, session, prompt, !images.is_empty(), turn).await;
+        // The native agent carries its own conversation history in-process
+        // (see `llm_agent`), so it has no CLI session id to resume or return.
+        return crate::llm_agent::run_native_agent(app, &chats, session, prompt, !images.is_empty(), turn)
+            .await
+            .map(|()| None);
     }
 
     let channel = format!("chat://{session}");
@@ -475,7 +497,10 @@ pub async fn chat_send(
     // dropped by the same take.
     if chats.take_pending_cancel(&session, turn) {
         sink.emit(&channel, serde_json::to_value(AgentEvent::TurnDone).unwrap());
-        return Ok(());
+        // `None`, not the passed `resume`: the caller keeps its stored id
+        // whenever this returns nothing (see `sendChat`), so a cancelled turn
+        // doesn't lose the conversation's continuity.
+        return Ok(None);
     }
 
     let token = mcp
@@ -581,9 +606,15 @@ pub async fn chat_send(
                 &agent_path,
                 &effective_prompt,
                 &cfg_path.to_string_lossy(),
-                None,
+                resume.as_deref(),
             )
         }
+        // Codex deliberately gets no `resume`: `codex exec resume` does not
+        // accept `-s read-only` or `-C <dir>` (verified live, codex-cli
+        // 0.144), and those two flags ARE the sandbox box `codex_command`
+        // documents — resuming without being able to re-assert them would
+        // trade context continuity for an unverified sandbox. Follow-ups
+        // start fresh until a verified resume path exists (#215).
         AgentKind::Codex => srelens_agent::adapter::codex_command(
             &agent_path,
             &prompt,
@@ -623,7 +654,7 @@ pub async fn chat_send(
                 &prompt,
                 &cursor_cfg_dir.to_string_lossy(),
                 &cwd_path.to_string_lossy(),
-                None,
+                resume.as_deref(),
             )
         }
         // Handled by the early return above, before any CLI machinery.
@@ -704,7 +735,17 @@ pub async fn chat_send(
 
     let mut lines = BufReader::new(stdout).lines();
     let mut saw_done = false;
+    // The CLI's own session id for this turn, captured from the stream so the
+    // NEXT turn can `--resume` it. Claude and Cursor stamp it on every line;
+    // for Codex (different shape, resume scoped out — see its arm above) this
+    // simply never matches and stays `None`. Captured fresh each turn rather
+    // than reusing `resume`: Claude forks a resumed session under a NEW id,
+    // so the stored id must follow the stream, not the input.
+    let mut agent_session: Option<String> = None;
     while let Ok(Some(line)) = lines.next_line().await {
+        if agent_session.is_none() {
+            agent_session = srelens_agent::stream_session_id(&line);
+        }
         saw_done |= emit_events(sink.clone(), &channel, std::iter::once(line), parse_line);
     }
 
@@ -727,7 +768,11 @@ pub async fn chat_send(
 
     finish_turn(sink.as_ref(), &channel, saw_done, crashed, &stderr_tail);
 
-    Ok(())
+    // Fall back to the id we resumed FROM when the stream never yielded one
+    // (crash before the first line, unexpected shape): the caller overwrites
+    // its stored id only with a non-`None` return, so continuity degrades to
+    // "unchanged" rather than snapping back to fresh sessions.
+    Ok(agent_session.or(resume))
 }
 
 /// Kill a running turn's agent process, if any. `turn` is the frontend's turn

--- a/apps/desktop/src/components/AssistantConversation.test.tsx
+++ b/apps/desktop/src/components/AssistantConversation.test.tsx
@@ -312,6 +312,45 @@ describe("AssistantConversation session persistence", () => {
     expect(vi.mocked(chat.sendChat).mock.calls[1][7]).toBe("cli-abc");
   });
 
+  it("drops the stored CLI id after a turn on a different agent, so switching back starts fresh", async () => {
+    // Turn 1 (Claude): captures an id. Turn 2 (Codex): returns null — but the
+    // conversation grew by turns the Claude session never saw, so resuming
+    // "cli-abc" later would answer from stale context. Turn 3 (back on
+    // Claude) must therefore resume nothing.
+    vi.mocked(chat.listAgents).mockResolvedValue([
+      { kind: "claude", label: "Claude Code", available: true, path: "/usr/bin/claude", version: null, installUrl: "", gated: false },
+      { kind: "codex", label: "Codex", available: true, path: "/usr/bin/codex", version: null, installUrl: "", gated: false },
+    ]);
+    vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
+      onEvent({ type: "turnDone" });
+      return "cli-abc";
+    });
+    render(<AssistantConversation />);
+    fireEvent.change(await screen.findByPlaceholderText(/ask/i), { target: { value: "first" } });
+    fireEvent.click(screen.getByRole("button", { name: /send/i }));
+    await waitFor(() => expect(chat.sendChat).toHaveBeenCalledTimes(1));
+    // Let the turn fully settle (Send replaces Stop) before touching the picker.
+    await screen.findByRole("button", { name: /^send$/i });
+
+    vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
+      onEvent({ type: "turnDone" });
+      return null;
+    });
+    fireEvent.click(screen.getByRole("combobox", { name: /agent/i }));
+    fireEvent.click(await screen.findByRole("option", { name: /codex/i }));
+    fireEvent.change(screen.getByPlaceholderText(/ask/i), { target: { value: "second" } });
+    fireEvent.click(screen.getByRole("button", { name: /^send$/i }));
+    await waitFor(() => expect(chat.sendChat).toHaveBeenCalledTimes(2));
+    await screen.findByRole("button", { name: /^send$/i });
+
+    fireEvent.click(screen.getByRole("combobox", { name: /agent/i }));
+    fireEvent.click(await screen.findByRole("option", { name: /claude/i }));
+    fireEvent.change(screen.getByPlaceholderText(/ask/i), { target: { value: "third" } });
+    fireEvent.click(screen.getByRole("button", { name: /^send$/i }));
+    await waitFor(() => expect(chat.sendChat).toHaveBeenCalledTimes(3));
+    expect(vi.mocked(chat.sendChat).mock.calls[2][7]).toBeNull();
+  });
+
   it("auto-save records the attached context under `contexts`", async () => {
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "textDelta", text: "ok" });

--- a/apps/desktop/src/components/AssistantConversation.test.tsx
+++ b/apps/desktop/src/components/AssistantConversation.test.tsx
@@ -86,6 +86,7 @@ describe("AssistantConversation", () => {
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "textDelta", text: "Hello from the global assistant." });
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantConversation />);
     fireEvent.change(await screen.findByPlaceholderText(/ask/i), { target: { value: "what's up?" } });
@@ -121,6 +122,7 @@ describe("AssistantConversation", () => {
     ]);
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantConversation />);
     const trigger = await screen.findByRole("combobox", { name: /agent/i });
@@ -156,6 +158,7 @@ describe("AssistantConversation", () => {
     ]);
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantConversation />);
     const trigger = await screen.findByRole("combobox", { name: /agent/i });
@@ -262,6 +265,7 @@ describe("AssistantConversation session persistence", () => {
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "textDelta", text: "Scaling now." });
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantConversation />);
     fireEvent.change(await screen.findByPlaceholderText(/ask/i), {
@@ -281,10 +285,38 @@ describe("AssistantConversation session persistence", () => {
     expect(saved.messages[1]).toEqual({ id: 1, role: "assistant", text: "Scaling now." });
   });
 
+  it("resumes the CLI's own session on follow-up turns and persists the id", async () => {
+    // First turn: the backend captures the CLI's session id from the stream
+    // and returns it from sendChat.
+    vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
+      onEvent({ type: "textDelta", text: "hi" });
+      onEvent({ type: "turnDone" });
+      return "cli-abc";
+    });
+    render(<AssistantConversation />);
+    fireEvent.change(await screen.findByPlaceholderText(/ask/i), { target: { value: "first" } });
+    fireEvent.click(screen.getByRole("button", { name: /send/i }));
+    // A first turn resumes nothing (9th arg), and once the id lands a
+    // follow-up save records it with the transcript.
+    await waitFor(() => expect(chat.sendChat).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(chat.sendChat).mock.calls[0][7]).toBeNull();
+    await waitFor(() => {
+      const calls = vi.mocked(chatHistory.saveSession).mock.calls;
+      expect(calls[calls.length - 1][0].cliSessionId).toBe("cli-abc");
+    });
+
+    // Second turn: the captured id comes back as `resume`.
+    fireEvent.change(screen.getByPlaceholderText(/ask/i), { target: { value: "second" } });
+    fireEvent.click(screen.getByRole("button", { name: /send/i }));
+    await waitFor(() => expect(chat.sendChat).toHaveBeenCalledTimes(2));
+    expect(vi.mocked(chat.sendChat).mock.calls[1][7]).toBe("cli-abc");
+  });
+
   it("auto-save records the attached context under `contexts`", async () => {
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "textDelta", text: "ok" });
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantConversation context={{ context: "prod-cluster", namespace: "payments" }} />);
     fireEvent.change(await screen.findByPlaceholderText(/ask/i), { target: { value: "hi" } });
@@ -301,6 +333,7 @@ describe("AssistantConversation session persistence", () => {
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "error", message: "boom" });
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantConversation />);
     fireEvent.change(await screen.findByPlaceholderText(/ask/i), { target: { value: "hi" } });
@@ -324,6 +357,7 @@ describe("AssistantConversation session persistence", () => {
       onEvent({ type: "error", message: "image attachments aren't supported by the srelens agent yet" });
       onEvent({ type: "textDelta", text: "here is the text-only answer" });
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantConversation />);
     fireEvent.change(await screen.findByPlaceholderText(/ask/i), { target: { value: "hi" } });
@@ -337,6 +371,7 @@ describe("AssistantConversation session persistence", () => {
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "textDelta", text: "first reply" });
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantConversation />);
     fireEvent.change(await screen.findByPlaceholderText(/ask/i), { target: { value: "first question" } });
@@ -363,6 +398,7 @@ describe("AssistantConversation session persistence", () => {
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "textDelta", text: "reply" });
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantConversation />);
 
@@ -398,6 +434,7 @@ describe("AssistantConversation session persistence", () => {
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "textDelta", text: "still looking" });
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantConversation />);
     await openHistory();
@@ -467,6 +504,7 @@ describe("AssistantConversation session persistence", () => {
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "textDelta", text: "ok" });
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantConversation />);
     fireEvent.change(await screen.findByPlaceholderText(/ask/i), { target: { value: "hi" } });
@@ -553,6 +591,7 @@ describe("AssistantConversation New chat resets composer state", () => {
     });
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantConversation availableContexts={["prod", "staging"]} />);
     await openHistory();
@@ -625,6 +664,7 @@ describe("AssistantConversation image attachments", () => {
   it("Send is held while an attachment is still being read, then includes it", async () => {
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantConversation />);
     fireEvent.change(await screen.findByPlaceholderText(/ask/i), { target: { value: "look at this" } });
@@ -643,6 +683,7 @@ describe("AssistantConversation image attachments", () => {
   it("removing a pending image chip clears it, and it isn't sent", async () => {
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantConversation />);
     fireEvent.change(await screen.findByLabelText(/attach image/i), { target: { files: [pngFile()] } });
@@ -665,6 +706,7 @@ describe("AssistantConversation image attachments", () => {
     // (as in the test above) that bug would still pass.
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantConversation />);
     fireEvent.change(await screen.findByLabelText(/attach image/i), { target: { files: [pngFile(), pngFile2()] } });
@@ -687,6 +729,7 @@ describe("AssistantConversation image attachments", () => {
   it("sending strips the data URI prefix, passing raw base64 as sendChat's 5th arg", async () => {
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantConversation />);
     fireEvent.change(await screen.findByLabelText(/attach image/i), { target: { files: [pngFile()] } });
@@ -703,6 +746,7 @@ describe("AssistantConversation image attachments", () => {
   it("renders the sent image inline in the user bubble, and clears the pending chip", async () => {
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantConversation />);
     fireEvent.change(await screen.findByLabelText(/attach image/i), { target: { files: [pngFile()] } });
@@ -719,6 +763,7 @@ describe("AssistantConversation image attachments", () => {
   it("auto-save persists the attached images on the stored user message", async () => {
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantConversation />);
     fireEvent.change(await screen.findByLabelText(/attach image/i), { target: { files: [pngFile()] } });
@@ -785,6 +830,7 @@ describe("AssistantConversation multi-context (global tab)", () => {
   it("selecting two contexts shows two removable chips and prefaces the outgoing prompt enumerating both", async () => {
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantConversation availableContexts={["a", "b", "c"]} />);
     fireEvent.click(await screen.findByRole("button", { name: /contexts \(0\)/i }));
@@ -807,6 +853,7 @@ describe("AssistantConversation multi-context (global tab)", () => {
   it("removing a chip updates both the chip list and the preface (down to the single-context wording)", async () => {
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantConversation availableContexts={["a", "b", "c"]} />);
     fireEvent.click(await screen.findByRole("button", { name: /contexts \(0\)/i }));
@@ -829,6 +876,7 @@ describe("AssistantConversation multi-context (global tab)", () => {
   it("persists selectedContexts under the session's contexts field in multi-context mode", async () => {
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantConversation availableContexts={["a", "b"]} />);
     fireEvent.click(await screen.findByRole("button", { name: /contexts \(0\)/i }));
@@ -885,7 +933,7 @@ describe("AssistantConversation composer (Task 19)", () => {
     vi.mocked(chat.sendChat).mockImplementation(
       () =>
         new Promise((resolve) => {
-          resolveSend = () => resolve(undefined);
+          resolveSend = () => resolve(null);
         }),
     );
     render(<AssistantConversation />);
@@ -908,7 +956,7 @@ describe("AssistantConversation composer (Task 19)", () => {
 
   it("Send is restored once the (cancelled) turn settles", async () => {
     vi.mocked(chat.cancelChat).mockResolvedValue(undefined);
-    vi.mocked(chat.sendChat).mockResolvedValue(undefined);
+    vi.mocked(chat.sendChat).mockResolvedValue(null);
     render(<AssistantConversation />);
     fireEvent.change(await screen.findByPlaceholderText(/ask/i), { target: { value: "hi" } });
     fireEvent.click(screen.getByRole("button", { name: /^send$/i }));
@@ -920,7 +968,7 @@ describe("AssistantConversation composer (Task 19)", () => {
     vi.mocked(chat.cancelChat).mockResolvedValue(undefined);
     let resolveSend: () => void = () => {};
     vi.mocked(chat.sendChat).mockImplementation(
-      () => new Promise((resolve) => { resolveSend = () => resolve(undefined); }),
+      () => new Promise((resolve) => { resolveSend = () => resolve(null); }),
     );
     const { unmount } = render(<AssistantConversation />);
     fireEvent.change(await screen.findByPlaceholderText(/ask/i), { target: { value: "keep going" } });
@@ -1041,6 +1089,7 @@ describe("AssistantConversation composer (Task 19)", () => {
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "textDelta", text: "fresh reply" });
       onEvent({ type: "turnDone" });
+      return null;
     });
     const ref = createRef<AssistantConversationHandle>();
     render(<AssistantConversation ref={ref} />);
@@ -1198,6 +1247,7 @@ describe("AssistantConversation skills activation (Task 23)", () => {
     }));
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantConversation context={{ context: "prod-cluster" }} />);
     fireEvent.change(await screen.findByPlaceholderText(/ask/i), { target: { value: "/" } });
@@ -1231,6 +1281,7 @@ describe("AssistantConversation skills activation (Task 23)", () => {
     });
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantConversation />);
     fireEvent.change(await screen.findByPlaceholderText(/ask/i), { target: { value: "/" } });
@@ -1272,6 +1323,7 @@ describe("AssistantConversation skills activation (Task 23)", () => {
     });
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantConversation />);
     fireEvent.change(await screen.findByPlaceholderText(/ask/i), { target: { value: "/" } });
@@ -1304,6 +1356,7 @@ describe("AssistantConversation answer layout", () => {
       onEvent({ type: "toolResult", id: "t1", status: "ok" });
       onEvent({ type: "textDelta", text: "Here are the pods." });
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantConversation />);
     fireEvent.change(await screen.findByPlaceholderText(/ask/i), { target: { value: "pods?" } });
@@ -1320,6 +1373,7 @@ describe("AssistantConversation answer layout", () => {
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "toolCallStart", id: "t1", tool: "k8s.listPods", args: {} });
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantConversation />);
     fireEvent.change(await screen.findByPlaceholderText(/ask/i), { target: { value: "pods?" } });
@@ -1343,6 +1397,7 @@ describe("AssistantConversation answer layout", () => {
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "textDelta", text: "The answer." });
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantConversation />);
     fireEvent.change(await screen.findByPlaceholderText(/ask/i), { target: { value: "q" } });
@@ -1357,6 +1412,7 @@ describe("AssistantConversation answer layout", () => {
       onEvent({ type: "thinking", text: "Let me reason about this." });
       onEvent({ type: "textDelta", text: "The answer." });
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantConversation />);
     fireEvent.change(await screen.findByPlaceholderText(/ask/i), { target: { value: "q" } });
@@ -1379,6 +1435,7 @@ describe("AssistantConversation agent persistence", () => {
     vi.mocked(chat.listAgents).mockResolvedValue(twoAgents);
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantConversation />);
     fireEvent.click(await screen.findByRole("combobox", { name: /agent/i }));
@@ -1402,6 +1459,7 @@ describe("AssistantConversation agent persistence", () => {
     vi.mocked(chat.listAgents).mockResolvedValue(twoAgents);
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantConversation />);
     fireEvent.click(await screen.findByRole("combobox", { name: /agent/i }));

--- a/apps/desktop/src/components/AssistantConversation.test.tsx
+++ b/apps/desktop/src/components/AssistantConversation.test.tsx
@@ -351,6 +351,36 @@ describe("AssistantConversation session persistence", () => {
     expect(vi.mocked(chat.sendChat).mock.calls[2][7]).toBeNull();
   });
 
+  it("clears the stored id when a resume crashes (null return), so the next turn starts fresh", async () => {
+    // Turn 1 captures an id; turn 2 resumes it but the backend reports a
+    // crashed resume by returning null (the CLI lost the session). Turn 3
+    // must NOT retry the dead id — that would fail identically forever.
+    vi.mocked(chat.sendChat)
+      .mockImplementationOnce(async (_s, _p, _a, onEvent) => {
+        onEvent({ type: "turnDone" });
+        return "cli-abc";
+      })
+      .mockImplementation(async (_s, _p, _a, onEvent) => {
+        onEvent({ type: "error", message: "No conversation found" });
+        onEvent({ type: "turnDone" });
+        return null;
+      });
+    render(<AssistantConversation />);
+    fireEvent.change(await screen.findByPlaceholderText(/ask/i), { target: { value: "first" } });
+    fireEvent.click(screen.getByRole("button", { name: /send/i }));
+    await waitFor(() => expect(chat.sendChat).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByPlaceholderText(/ask/i), { target: { value: "second" } });
+    fireEvent.click(screen.getByRole("button", { name: /^send$/i }));
+    await waitFor(() => expect(chat.sendChat).toHaveBeenCalledTimes(2));
+    expect(vi.mocked(chat.sendChat).mock.calls[1][7]).toBe("cli-abc");
+
+    fireEvent.change(screen.getByPlaceholderText(/ask/i), { target: { value: "third" } });
+    fireEvent.click(screen.getByRole("button", { name: /^send$/i }));
+    await waitFor(() => expect(chat.sendChat).toHaveBeenCalledTimes(3));
+    expect(vi.mocked(chat.sendChat).mock.calls[2][7]).toBeNull();
+  });
+
   it("auto-save records the attached context under `contexts`", async () => {
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "textDelta", text: "ok" });

--- a/apps/desktop/src/components/AssistantConversation.tsx
+++ b/apps/desktop/src/components/AssistantConversation.tsx
@@ -1376,23 +1376,21 @@ export const AssistantConversation = forwardRef<
       // agent the stored id came from (see `cliSessionRef`).
       const resume = cliSessionRef.current?.kind === usedKind ? cliSessionRef.current.id : null;
       const cliId = await sendChat(session, outgoing, agentPath, applyEvent, rawImages, usedKind, turnNonceRef.current, resume);
+      // The return IS what to store now (see chat_send): a cancelled or
+      // drifty-but-clean turn echoes the resumed id back, so `null` with an
+      // id on hand always means CLEAR — either the turn ran on an agent
+      // with no id (native, Codex: the stored session is now missing turns
+      // the transcript visibly contains) or the resume itself crashed (the
+      // CLI lost the session; keeping the id would retry the same failing
+      // --resume forever). A transport rejection skips this entirely (the
+      // catch below) and keeps the stored id.
       const prev = cliSessionRef.current;
-      if (cliId && (prev?.id !== cliId || prev?.kind !== usedKind)) {
-        cliSessionRef.current = { kind: usedKind, id: cliId };
+      if (cliId ? prev?.id !== cliId || prev?.kind !== usedKind : prev !== null) {
+        cliSessionRef.current = cliId ? { kind: usedKind, id: cliId } : null;
         // The turnDone-triggered save snapshots at the moment the event
         // streams — BEFORE `sendChat` resolves with this id — so that save
         // carried the previous turn's id. Queue one more so the transcript
         // on disk gets the id the next turn must resume.
-        void persistSession(messagesRef.current, toolCallsRef.current);
-      } else if (!cliId && prev && prev.kind !== usedKind) {
-        // A turn just ran on a DIFFERENT agent that returned no id (native,
-        // Codex): the stored CLI session no longer contains the whole visible
-        // conversation, so switching back and resuming it would answer from
-        // stale context that's missing these turns. Drop it — the original
-        // agent starts fresh, which at least matches what the CLI actually
-        // knows. (Same-kind `null` — a cancelled/failed turn — still keeps
-        // the id: nothing was added to the conversation the session lacks.)
-        cliSessionRef.current = null;
         void persistSession(messagesRef.current, toolCallsRef.current);
       }
     } catch (e) {

--- a/apps/desktop/src/components/AssistantConversation.tsx
+++ b/apps/desktop/src/components/AssistantConversation.tsx
@@ -779,6 +779,14 @@ export const AssistantConversation = forwardRef<
   // restored from the loaded value when reopening a session, so re-saving
   // never stomps the original `createdAt`.
   const createdAtRef = useRef<number | null>(null);
+  // The agent CLI's OWN session id for this conversation (what `sendChat`
+  // last returned), tagged with the agent kind it belongs to: a Claude id
+  // passed to Cursor's `--resume` (or vice versa) would error, so switching
+  // agents mid-conversation must start that CLI fresh rather than resume a
+  // foreign id. Persisted as `cliSessionId` and restored on reopen, so a
+  // reopened conversation continues with real context (the CLIs keep their
+  // session transcripts on disk across app restarts).
+  const cliSessionRef = useRef<{ kind: string; id: string } | null>(null);
   // Chain of pending disk saves. `persistSession` enqueues onto it, and
   // session actions that touch the same files (delete, load) await it first —
   // otherwise a slow save still flushing after a turn settles could race
@@ -1012,12 +1020,11 @@ export const AssistantConversation = forwardRef<
       // The agent this conversation ran on, so reopening it restores the same
       // pick in the composer.
       agentKind: selectedKind || null,
-      // Not wired yet — the `AgentEvent` stream doesn't carry the agent
-      // CLI's own session id, and threading it through needs a backend
-      // change. `null` here means a reopened session is continued
-      // best-effort (replayed transcript only, no CLI `--resume`), which
-      // the spec (§2) allows.
-      cliSessionId: null,
+      // The agent CLI's own session id (`sendChat`'s return), saved only
+      // when it belongs to the agent this conversation is stamped with —
+      // an id from a different CLI would make the restored conversation
+      // pass a foreign id to `--resume` and error its first turn.
+      cliSessionId: cliSessionRef.current?.kind === (selectedKind || null) ? cliSessionRef.current.id : null,
       messages: toStoredMessages(msgs, calls),
     };
     const next = persistChainRef.current.then(() => persistSessionNow(session));
@@ -1055,6 +1062,9 @@ export const AssistantConversation = forwardRef<
     setInput("");
     sessionRef.current = null;
     createdAtRef.current = null;
+    // A fresh conversation must start a fresh CLI session — carrying the old
+    // id would silently resume the previous conversation's context.
+    cliSessionRef.current = null;
     // Composer state is per-conversation, not global — without resetting
     // these, a "New chat" (or deleting the currently-open session, which
     // routes through here) would silently carry the old session's active
@@ -1070,7 +1080,8 @@ export const AssistantConversation = forwardRef<
   /** Load a saved session and replay it into state read-only — no event
    * stream involved, just the transcript as it was last saved. Continuing
    * to type and send afterward appends further turns onto the same disk
-   * session (see the deferred-`cliSessionId` note on `persistSession`). */
+   * session, resuming the CLI's own session via the restored
+   * `cliSessionId` (see `cliSessionRef`). */
   async function onSelectSession(id: string) {
     // See onNewChat: don't swap sessions while a turn is streaming, or its
     // events would land in (and be saved under) the newly loaded session.
@@ -1090,6 +1101,14 @@ export const AssistantConversation = forwardRef<
       nextId.current = msgs.reduce((max, m) => Math.max(max, m.id + 1), 0);
       sessionRef.current = session.id;
       createdAtRef.current = session.createdAt;
+      // Restore the CLI session id under the agent kind it was saved with so
+      // the next send `--resume`s it — the CLIs keep session transcripts on
+      // disk, so this works across app restarts too. Older saves (or native/
+      // Codex conversations) have `null` here and simply start fresh.
+      cliSessionRef.current =
+        session.cliSessionId && session.agentKind
+          ? { kind: session.agentKind, id: session.cliSessionId }
+          : null;
       // Restore the global tab's multi-select from what was persisted;
       // meaningless in drawer mode, where the resource `context` prop drives
       // `attachedContext` instead and this state is never read.
@@ -1353,7 +1372,21 @@ export const AssistantConversation = forwardRef<
         return;
       }
       saveLastAgent(usedKind); // remember what was actually used for the next fresh chat
-      await sendChat(session, outgoing, agentPath, applyEvent, rawImages, usedKind, turnNonceRef.current);
+      // Resume the CLI's own session only when this turn runs on the same
+      // agent the stored id came from (see `cliSessionRef`).
+      const resume = cliSessionRef.current?.kind === usedKind ? cliSessionRef.current.id : null;
+      const cliId = await sendChat(session, outgoing, agentPath, applyEvent, rawImages, usedKind, turnNonceRef.current, resume);
+      // `null` means "nothing captured" (native agent, Codex, cancelled
+      // turn) — keep what we had rather than dropping continuity.
+      const prev = cliSessionRef.current;
+      if (cliId && (prev?.id !== cliId || prev?.kind !== usedKind)) {
+        cliSessionRef.current = { kind: usedKind, id: cliId };
+        // The turnDone-triggered save snapshots at the moment the event
+        // streams — BEFORE `sendChat` resolves with this id — so that save
+        // carried the previous turn's id. Queue one more so the transcript
+        // on disk gets the id the next turn must resume.
+        void persistSession(messagesRef.current, toolCallsRef.current);
+      }
     } catch (e) {
       // A rejection here means the transport itself failed before any
       // `error` event could stream (e.g. `chat_send` rejects outright when

--- a/apps/desktop/src/components/AssistantConversation.tsx
+++ b/apps/desktop/src/components/AssistantConversation.tsx
@@ -1376,8 +1376,6 @@ export const AssistantConversation = forwardRef<
       // agent the stored id came from (see `cliSessionRef`).
       const resume = cliSessionRef.current?.kind === usedKind ? cliSessionRef.current.id : null;
       const cliId = await sendChat(session, outgoing, agentPath, applyEvent, rawImages, usedKind, turnNonceRef.current, resume);
-      // `null` means "nothing captured" (native agent, Codex, cancelled
-      // turn) — keep what we had rather than dropping continuity.
       const prev = cliSessionRef.current;
       if (cliId && (prev?.id !== cliId || prev?.kind !== usedKind)) {
         cliSessionRef.current = { kind: usedKind, id: cliId };
@@ -1385,6 +1383,16 @@ export const AssistantConversation = forwardRef<
         // streams — BEFORE `sendChat` resolves with this id — so that save
         // carried the previous turn's id. Queue one more so the transcript
         // on disk gets the id the next turn must resume.
+        void persistSession(messagesRef.current, toolCallsRef.current);
+      } else if (!cliId && prev && prev.kind !== usedKind) {
+        // A turn just ran on a DIFFERENT agent that returned no id (native,
+        // Codex): the stored CLI session no longer contains the whole visible
+        // conversation, so switching back and resuming it would answer from
+        // stale context that's missing these turns. Drop it — the original
+        // agent starts fresh, which at least matches what the CLI actually
+        // knows. (Same-kind `null` — a cancelled/failed turn — still keeps
+        // the id: nothing was added to the conversation the session lacks.)
+        cliSessionRef.current = null;
         void persistSession(messagesRef.current, toolCallsRef.current);
       }
     } catch (e) {

--- a/apps/desktop/src/components/AssistantDrawer.test.tsx
+++ b/apps/desktop/src/components/AssistantDrawer.test.tsx
@@ -52,6 +52,7 @@ describe("AssistantDrawer", () => {
       onEvent({ type: "toolResult", id: "t1", status: "ok" });
       onEvent({ type: "textDelta", text: "3 pods running." });
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantDrawer open onClose={() => {}} />);
     fireEvent.change(await screen.findByPlaceholderText(/ask/i), { target: { value: "why?" } });
@@ -70,6 +71,7 @@ describe("AssistantDrawer", () => {
       onEvent({ type: "toolResult", id: "t1", status: "ok" });
       onEvent({ type: "textDelta", text: "B." });
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantDrawer open onClose={() => {}} />);
     fireEvent.change(await screen.findByPlaceholderText(/ask/i), { target: { value: "why?" } });
@@ -94,6 +96,7 @@ describe("AssistantDrawer", () => {
       // paragraphs instead of one continued line.
       onEvent({ type: "textDelta", text: "\nB." });
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantDrawer open onClose={() => {}} />);
     fireEvent.change(await screen.findByPlaceholderText(/ask/i), { target: { value: "why?" } });
@@ -107,6 +110,7 @@ describe("AssistantDrawer", () => {
       onEvent({ type: "textDelta", text: "Hello " });
       onEvent({ type: "textDelta", text: "world" });
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantDrawer open onClose={() => {}} />);
     fireEvent.change(await screen.findByPlaceholderText(/ask/i), { target: { value: "why?" } });
@@ -189,6 +193,7 @@ describe("AssistantDrawer", () => {
       onEvent({ type: "toolCallStart", id: "t1", tool: "k8s.getSecret", args: { name: "db-creds", namespace: "prod" } });
       onEvent({ type: "toolResult", id: "t1", status: "ok" });
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantDrawer open onClose={() => {}} />);
     fireEvent.change(await screen.findByPlaceholderText(/ask/i), { target: { value: "why?" } });
@@ -206,6 +211,7 @@ describe("AssistantDrawer", () => {
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "error", message: "the agent crashed" });
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantDrawer open onClose={() => {}} />);
     fireEvent.change(await screen.findByPlaceholderText(/ask/i), { target: { value: "why?" } });

--- a/apps/desktop/src/components/AssistantTab.test.tsx
+++ b/apps/desktop/src/components/AssistantTab.test.tsx
@@ -106,6 +106,7 @@ describe("AssistantTab", () => {
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "textDelta", text: "reply" });
       onEvent({ type: "turnDone" });
+      return null;
     });
     render(<AssistantTab cluster={null} availableContexts={["a", "b"]} />);
 

--- a/apps/desktop/src/lib/chat.test.ts
+++ b/apps/desktop/src/lib/chat.test.ts
@@ -26,6 +26,7 @@ describe("sendChat", () => {
       agentPath: "/usr/bin/claude",
       agentKind: "claude",
       turn: 0,
+      resume: null,
     });
   });
 
@@ -39,6 +40,7 @@ describe("sendChat", () => {
       agentPath: "/usr/bin/codex",
       agentKind: "codex",
       turn: 3,
+      resume: null,
     });
   });
 

--- a/apps/desktop/src/lib/chat.ts
+++ b/apps/desktop/src/lib/chat.ts
@@ -69,6 +69,13 @@ export function startChat(): Promise<string> {
  * send does (the `subscribe` await below opens exactly that window) while
  * dropping a stale Stop left over from an earlier turn. Callers that never
  * cancel can omit it.
+ *
+ * `resume` is the agent CLI's own session id returned by a previous call for
+ * this conversation; the backend passes it to the CLI's `--resume` so
+ * follow-up turns keep their context. Resolves to the id captured from this
+ * turn's stream (store it and pass it back next time), or `null` when the
+ * agent has none (native srelens agent, Codex) — callers should treat `null`
+ * as "keep what you had", since a cancelled/failed turn also returns it.
  */
 export async function sendChat(
   session: string,
@@ -78,13 +85,14 @@ export async function sendChat(
   images?: string[],
   agentKind: string = "claude",
   turn: number = 0,
-): Promise<void> {
+  resume: string | null = null,
+): Promise<string | null> {
   const unsub = await subscribe(`chat://${session}`, (payload: unknown) => {
     const e = parseAgentEvent(payload);
     if (e) onEvent(e);
   });
   try {
-    await invokeCommand("chat_send", { session, prompt, images: images ?? [], agentPath, agentKind, turn });
+    return await invokeCommand("chat_send", { session, prompt, images: images ?? [], agentPath, agentKind, turn, resume });
   } finally {
     unsub();
   }

--- a/apps/desktop/src/lib/chat.ts
+++ b/apps/desktop/src/lib/chat.ts
@@ -72,10 +72,13 @@ export function startChat(): Promise<string> {
  *
  * `resume` is the agent CLI's own session id returned by a previous call for
  * this conversation; the backend passes it to the CLI's `--resume` so
- * follow-up turns keep their context. Resolves to the id captured from this
- * turn's stream (store it and pass it back next time), or `null` when the
- * agent has none (native srelens agent, Codex) — callers should treat `null`
- * as "keep what you had", since a cancelled/failed turn also returns it.
+ * follow-up turns keep their context. Resolves to what the caller should now
+ * store as the conversation's id: the id captured from this turn's stream, the
+ * echoed `resume` when the turn was cancelled or ran clean without yielding
+ * one, or `null` — meaning CLEAR — for agents with no id (native srelens
+ * agent, Codex) and for a crashed resume (the CLI lost the session; retrying
+ * the same id would fail forever). A REJECTION, by contrast, says nothing
+ * about the stored id — keep it.
  */
 export async function sendChat(
   session: string,

--- a/apps/desktop/src/lib/chatHistory.ts
+++ b/apps/desktop/src/lib/chatHistory.ts
@@ -25,12 +25,11 @@ export interface Session extends SessionMeta {
   /** Active skill names (Task 23) — always empty for now. */
   skills: string[];
   /**
-   * The agent CLI's own session id (for `--resume`). The current
-   * `AgentEvent` stream doesn't carry it — wiring it through needs a
-   * backend change — so this is always `null` for now. Continuing a
-   * reopened session is therefore best-effort ("continue with memory of the
-   * transcript" rather than a true CLI `--resume`), which the spec (§2)
-   * allows.
+   * The agent CLI's own session id, captured from the stream by `chat_send`
+   * and passed back to the CLI's `--resume` on the conversation's next turn
+   * so follow-ups keep their context (Claude and Cursor; the native agent
+   * and Codex have no resumable id and store `null`). `null` also covers
+   * sessions saved before this was wired — those reopen fresh, best-effort.
    */
   cliSessionId: string | null;
   /** The agent CLI this conversation used ("claude"/"codex"), restored into

--- a/apps/desktop/src/lib/kubectlMapper.test.ts
+++ b/apps/desktop/src/lib/kubectlMapper.test.ts
@@ -176,10 +176,23 @@ describe("kubectlMapper", () => {
       ).toBe("kubectl get pods web-0 --context '`id` cluster'");
     });
 
-    it("escapes an embedded single quote with the POSIX close-escape-reopen form", () => {
+    it("keeps a plain apostrophe (no expansion syntax) safely double-quoted", () => {
+      expect(
+        toKubectl({ action: "get", kind: "Pod", name: "web-0", context: "bob's cluster" }),
+      ).toBe('kubectl get pods web-0 --context "bob\'s cluster"');
+    });
+
+    it("apostrophe + expansion syntax becomes a placeholder — the POSIX '\\'' escape breaks out in PowerShell", () => {
+      // In pwsh, backslash is not a quote escape: 'a'\''$(whoami)'\''b'
+      // leaves $(whoami) outside any string and it executes. No single
+      // representation is inert in bash/zsh AND pwsh, so refuse to render
+      // the value, exactly like the Windows tier.
+      expect(
+        toKubectl({ action: "get", kind: "Pod", name: "web-0", context: "a'$(whoami)'b" }),
+      ).toBe('kubectl get pods web-0 --context "<enter context>"');
       expect(
         toKubectl({ action: "get", kind: "Pod", name: "web-0", context: "bob's $HOME" }),
-      ).toBe("kubectl get pods web-0 --context 'bob'\\''s $HOME'");
+      ).toBe('kubectl get pods web-0 --context "<enter context>"');
     });
 
     it("windows: double quotes hold inert odd values — spaces and even & are literal inside them in cmd and PowerShell", () => {

--- a/apps/desktop/src/lib/kubectlMapper.test.ts
+++ b/apps/desktop/src/lib/kubectlMapper.test.ts
@@ -182,6 +182,27 @@ describe("kubectlMapper", () => {
       ).toBe("kubectl get pods web-0 --context 'bob'\\''s $HOME'");
     });
 
+    it("windows: double quotes hold inert odd values — spaces and even & are literal inside them in cmd and PowerShell", () => {
+      expect(
+        toKubectl({ action: "get", kind: "Pod", name: "web-0", context: "my cluster" }, true),
+      ).toBe('kubectl get pods web-0 --context "my cluster"');
+      expect(
+        toKubectl({ action: "get", kind: "Pod", name: "web-0", context: "a & b" }, true),
+      ).toBe('kubectl get pods web-0 --context "a & b"');
+    });
+
+    it("windows: values with no cmd+PowerShell-safe representation become a fill-in placeholder", () => {
+      // Single quotes aren't quoting in cmd (& would chain a command through
+      // them) and double quotes leave $/` live in PowerShell and % live in
+      // cmd — so the hostile value must not be rendered at all.
+      expect(
+        toKubectl({ action: "get", kind: "Pod", name: "web-0", context: "x$&whoami>pwned&" }, true),
+      ).toBe('kubectl get pods web-0 --context "<enter context>"');
+      expect(
+        toKubectl({ action: "get", kind: "Pod", namespace: "%TEMP%", name: "web-0", context: "prod" }, true),
+      ).toBe('kubectl get pods web-0 -n "<enter namespace>" --context prod');
+    });
+
     it("leaves plain resource names unquoted (DNS-1123 names are always in the safe set)", () => {
       expect(
         toKubectl({ action: "get", kind: "Pod", namespace: "default", name: "web-0", context: "prod" }),

--- a/apps/desktop/src/lib/kubectlMapper.test.ts
+++ b/apps/desktop/src/lib/kubectlMapper.test.ts
@@ -155,10 +155,31 @@ describe("kubectlMapper", () => {
       ).toBe('kubectl get pods web-0 -n "my ns" --context prod');
     });
 
-    it("escapes an embedded double quote in a quoted value", () => {
+    it("single-quotes a value with an embedded double quote (double-quoting can't hold it safely)", () => {
       expect(
         toKubectl({ action: "get", kind: "Pod", namespace: "default", name: "web-0", context: 'my "prod" cluster' }),
-      ).toBe('kubectl get pods web-0 -n default --context "my \\"prod\\" cluster"');
+      ).toBe("kubectl get pods web-0 -n default --context 'my \"prod\" cluster'");
+    });
+
+    it("single-quotes a context carrying command substitution so pasting can't execute it", () => {
+      // Inside double quotes, $( ) still EXECUTES in bash/zsh/PowerShell —
+      // only single quotes make it inert. Context names are user-chosen and
+      // not DNS-restricted, so this input is reachable.
+      expect(
+        toKubectl({ action: "get", kind: "Pod", name: "web-0", context: "$(touch /tmp/pwn)" }),
+      ).toBe("kubectl get pods web-0 --context '$(touch /tmp/pwn)'");
+    });
+
+    it("single-quotes backtick substitution the same way", () => {
+      expect(
+        toKubectl({ action: "get", kind: "Pod", name: "web-0", context: "`id` cluster" }),
+      ).toBe("kubectl get pods web-0 --context '`id` cluster'");
+    });
+
+    it("escapes an embedded single quote with the POSIX close-escape-reopen form", () => {
+      expect(
+        toKubectl({ action: "get", kind: "Pod", name: "web-0", context: "bob's $HOME" }),
+      ).toBe("kubectl get pods web-0 --context 'bob'\\''s $HOME'");
     });
 
     it("leaves plain resource names unquoted (DNS-1123 names are always in the safe set)", () => {

--- a/apps/desktop/src/lib/kubectlMapper.ts
+++ b/apps/desktop/src/lib/kubectlMapper.ts
@@ -32,12 +32,29 @@ export interface KubectlInput {
 // Resource names are DNS-1123 and always shell-safe in practice, but
 // kubeconfig context names are user-chosen and can contain spaces or other
 // shell-active characters. Quote anything outside the safe unquoted set
-// rather than assuming kubeconfig hygiene. Double quotes (not single) —
-// single quotes aren't a quoting character in cmd.exe, so a single-quoted
-// value would still split on spaces there (we ship Windows builds).
+// rather than assuming kubeconfig hygiene.
 const SAFE_UNQUOTED = /^[A-Za-z0-9._@:/-]+$/;
+
+// Characters that stay ACTIVE inside double quotes and so can execute code
+// when the copied command is pasted: `$` and backtick (command/variable
+// substitution in bash/zsh AND PowerShell), `!` (history expansion in
+// interactive bash/zsh), plus `"` and `\` (would terminate or re-arm the
+// quoting itself). A value containing any of these must not be double-quoted.
+const DOUBLE_QUOTE_UNSAFE = /[$`!"\\]/;
+
 function shellQuote(value: string): string {
-  return SAFE_UNQUOTED.test(value) ? value : `"${value.replace(/[\\"]/g, "\\$&")}"`;
+  if (SAFE_UNQUOTED.test(value)) return value;
+  // Odd but inert values (spaces, parens, unicode): double quotes are correct
+  // in bash/zsh/PowerShell AND cmd.exe — cmd has no single-quote syntax, so
+  // this tier keeps the common "name with a space" case working everywhere.
+  if (!DOUBLE_QUOTE_UNSAFE.test(value)) return `"${value}"`;
+  // Values carrying expansion syntax: only single quotes make them fully
+  // inert — POSIX shells and PowerShell expand nothing inside them. cmd.exe
+  // loses this tier (it doesn't treat ' as quoting), but cmd also never
+  // expands $() or backticks, so its worst case is a mis-split argument and
+  // a kubectl error — never execution. Embedded ' uses the POSIX '\''
+  // close-escape-reopen dance.
+  return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
 /**

--- a/apps/desktop/src/lib/kubectlMapper.ts
+++ b/apps/desktop/src/lib/kubectlMapper.ts
@@ -75,10 +75,17 @@ function shellQuote(value: string, what: string, windows: boolean): string {
   }
   // POSIX: odd but inert values (spaces, parens, unicode) keep double quotes;
   // anything carrying expansion syntax gets single quotes, inside which
-  // bash/zsh (and PowerShell) expand nothing. Embedded ' uses the POSIX
-  // '\'' close-escape-reopen dance.
+  // bash/zsh (and PowerShell) expand nothing.
   if (!POSIX_DOUBLE_QUOTE_UNSAFE.test(value)) return `"${value}"`;
-  return `'${value.replace(/'/g, `'\\''`)}'`;
+  // ...unless the value ALSO contains an apostrophe: the POSIX '\'' escape
+  // is bash-only — PowerShell (a real paste target on macOS/Linux too)
+  // doesn't treat backslash as a quote escape, so the text between two
+  // embedded apostrophes lands OUTSIDE any string there and $() would
+  // execute. Expansion syntax + apostrophe has no representation inert in
+  // bash/zsh AND pwsh at once → same placeholder refusal as the Windows
+  // tier.
+  if (value.includes("'")) return `"<enter ${what}>"`;
+  return `'${value}'`;
 }
 
 /**

--- a/apps/desktop/src/lib/kubectlMapper.ts
+++ b/apps/desktop/src/lib/kubectlMapper.ts
@@ -35,25 +35,49 @@ export interface KubectlInput {
 // rather than assuming kubeconfig hygiene.
 const SAFE_UNQUOTED = /^[A-Za-z0-9._@:/-]+$/;
 
-// Characters that stay ACTIVE inside double quotes and so can execute code
-// when the copied command is pasted: `$` and backtick (command/variable
-// substitution in bash/zsh AND PowerShell), `!` (history expansion in
-// interactive bash/zsh), plus `"` and `\` (would terminate or re-arm the
-// quoting itself). A value containing any of these must not be double-quoted.
-const DOUBLE_QUOTE_UNSAFE = /[$`!"\\]/;
+// Characters that stay ACTIVE inside double quotes on POSIX platforms and so
+// can execute code when the copied command is pasted: `$` and backtick
+// (command/variable substitution in bash/zsh AND PowerShell), `!` (history
+// expansion in interactive bash/zsh), plus `"` and `\` (would terminate or
+// re-arm the quoting itself). Any of these forces the single-quote tier.
+const POSIX_DOUBLE_QUOTE_UNSAFE = /[$`!"\\]/;
 
-function shellQuote(value: string): string {
+// The Windows equivalent, covering BOTH shells a value pasted there can hit:
+// inside double quotes cmd.exe still expands `%VAR%`, treats `"` as the
+// closing quote, and un-escapes a trailing `\"`; PowerShell still expands `$`
+// and backtick; `!` expands under cmd's delayed expansion. A value carrying
+// any of these has NO representation that is inert in both shells — cmd has
+// no single-quote syntax at all (so `&` would chain commands right through
+// single quotes) — and gets the placeholder tier instead of a quoting
+// pretense.
+const WINDOWS_DOUBLE_QUOTE_UNSAFE = /[$`!"%\\]/;
+
+const IS_WINDOWS = typeof navigator !== "undefined" && navigator.userAgent.includes("Windows");
+
+/**
+ * Quote one value for the platform's paste targets, or refuse: `what` names
+ * the value ("context", "namespace", "name") for the fill-in placeholder
+ * emitted when a hostile value cannot be represented safely on Windows.
+ */
+function shellQuote(value: string, what: string, windows: boolean): string {
   if (SAFE_UNQUOTED.test(value)) return value;
-  // Odd but inert values (spaces, parens, unicode): double quotes are correct
-  // in bash/zsh/PowerShell AND cmd.exe — cmd has no single-quote syntax, so
-  // this tier keeps the common "name with a space" case working everywhere.
-  if (!DOUBLE_QUOTE_UNSAFE.test(value)) return `"${value}"`;
-  // Values carrying expansion syntax: only single quotes make them fully
-  // inert — POSIX shells and PowerShell expand nothing inside them. cmd.exe
-  // loses this tier (it doesn't treat ' as quoting), but cmd also never
-  // expands $() or backticks, so its worst case is a mis-split argument and
-  // a kubectl error — never execution. Embedded ' uses the POSIX '\''
-  // close-escape-reopen dance.
+  if (windows) {
+    // Inside double quotes, cmd.exe treats & | < > ^ ( ) and spaces literally
+    // — and so do PowerShell and the POSIX shells — so this tier is inert in
+    // every shell a Windows user pastes into. The common "name with a space"
+    // case lands here and stays copy-paste-runnable.
+    if (!WINDOWS_DOUBLE_QUOTE_UNSAFE.test(value)) return `"${value}"`;
+    // No safe representation exists (see WINDOWS_DOUBLE_QUOTE_UNSAFE): emit
+    // a fill-in placeholder so the pasted command errors asking for the
+    // value rather than ever executing part of a hostile one. Angle brackets
+    // are redirection in cmd but sit inside double quotes here.
+    return `"<enter ${what}>"`;
+  }
+  // POSIX: odd but inert values (spaces, parens, unicode) keep double quotes;
+  // anything carrying expansion syntax gets single quotes, inside which
+  // bash/zsh (and PowerShell) expand nothing. Embedded ' uses the POSIX
+  // '\'' close-escape-reopen dance.
+  if (!POSIX_DOUBLE_QUOTE_UNSAFE.test(value)) return `"${value}"`;
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
@@ -65,7 +89,7 @@ function shellQuote(value: string): string {
  * from `action`. Callers show an explanatory note instead of a command (see
  * `KubectlPreview`'s `note` prop).
  */
-export function toKubectl(input: KubectlInput): string {
+export function toKubectl(input: KubectlInput, windows: boolean = IS_WINDOWS): string {
   const { action, kind, name, context, namespace, output, replicas } = input;
   // Prefer the authoritative kind→resource table (mirrors the backend's own
   // GVR mapping) over a bare lowercase, which drifts for kinds whose plural
@@ -80,7 +104,7 @@ export function toKubectl(input: KubectlInput): string {
   // is a no-op for every real name today — quoting it anyway is cheap
   // defense-in-depth and matches "name" being one of the three values the
   // review called out, alongside namespace and context.
-  const qName = shellQuote(name);
+  const qName = shellQuote(name, "name", windows);
 
   switch (action) {
     case "get":
@@ -136,10 +160,10 @@ export function toKubectl(input: KubectlInput): string {
   }
 
   if (ns) {
-    parts.push("-n", shellQuote(ns));
+    parts.push("-n", shellQuote(ns, "namespace", windows));
   }
 
-  parts.push("--context", shellQuote(context));
+  parts.push("--context", shellQuote(context, "context", windows));
 
   if (output) {
     parts.push("-o", output);

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -6,3 +6,44 @@ pub mod claude;
 pub mod codex;
 pub mod cursor;
 pub mod event;
+
+/// The agent CLI's own session id, if `line` (one stream-json line) carries
+/// one. Claude Code and Cursor both stamp a top-level `session_id` string on
+/// every stream-json line (verified live against both CLIs), so the first
+/// line of a turn is enough to learn the id that `--resume` needs on the
+/// next turn. Codex is shaped differently (`thread.started`/`thread_id`) and
+/// isn't resumable under srelens's sandbox flags — see `chat_send`'s Codex
+/// arm. Never errors: a non-JSON or id-less line yields `None`, matching the
+/// parsers' tolerance above.
+pub fn stream_session_id(line: &str) -> Option<String> {
+    let v = serde_json::from_str::<serde_json::Value>(line.trim()).ok()?;
+    v.get("session_id").and_then(|s| s.as_str()).map(str::to_string)
+}
+
+#[cfg(test)]
+mod session_id_tests {
+    use super::stream_session_id;
+
+    #[test]
+    fn claude_shaped_lines_yield_the_session_id() {
+        // Abridged from a real `claude -p --output-format stream-json` init line.
+        let line = r#"{"type":"system","subtype":"init","cwd":"/tmp","session_id":"ee637368-ca14-4420-b431-e346fc3877b5","model":"m"}"#;
+        assert_eq!(stream_session_id(line).as_deref(), Some("ee637368-ca14-4420-b431-e346fc3877b5"));
+    }
+
+    #[test]
+    fn cursor_shaped_lines_yield_the_session_id() {
+        // Abridged from a real `cursor-agent -p --output-format stream-json` line.
+        let line = r#"{"type":"user","message":{"role":"user","content":[]},"session_id":"ea50278e-075d-4b80-849e-f7c952ed74b1"}"#;
+        assert_eq!(stream_session_id(line).as_deref(), Some("ea50278e-075d-4b80-849e-f7c952ed74b1"));
+    }
+
+    #[test]
+    fn idless_nonjson_and_nonstring_lines_yield_none() {
+        assert_eq!(stream_session_id(r#"{"type":"turn.started"}"#), None);
+        assert_eq!(stream_session_id("not json"), None);
+        assert_eq!(stream_session_id(""), None);
+        // A non-string session_id (future shape drift) is ignored, not coerced.
+        assert_eq!(stream_session_id(r#"{"session_id":42}"#), None);
+    }
+}


### PR DESCRIPTION
Fixes for the three P1s Codex raised on the release PR #213. Landing on `dev` so they flow into the promotion.

## 1. `ci(release)`: version gate survives a squash-merged promotion

A squash-merged dev→main PR collapses the range to one non-conventional `release: ...` commit → `BUMP=none` → the whole release silently skips (squash IS enabled on this repo). The bump greps now also accept GitHub's squash-body bullets (`* feat: ...`), verified against a simulated squash body; the plain merge-commit path is unchanged and remains the documented route.

## 2. `fix(actions)`: copied kubectl commands can't execute on paste

Double quotes don't neutralize $( ) or backticks in bash/zsh/PowerShell — a context named `$(touch /tmp/pwn)` executed when the copied command was pasted (reproduced live; the new quoting is proven inert the same way). Quoting is now tiered: bare for the safe set → double quotes only for values with no expansion-active characters (still correct in cmd.exe, which has no single quotes) → single quotes, inert in every expanding shell, for values carrying `$` `\`` `!` `"` `\`. cmd.exe's worst case in that last tier is a mis-split argument, never execution.

## 3. `feat(assistant)`: follow-up turns keep their context (Claude + Cursor)

Every CLI turn spawned fresh with `resume: None`. Both CLIs stamp a top-level `session_id` on every stream-json line and accept `--resume` — **verified live**: a resumed turn recalls the previous turn's content on both. `chat_send` now captures the id from the stream, returns it, and takes it back as `resume`; the frontend fills the already-reserved `cliSessionId` field, so continuity also survives app restarts (the CLIs keep session transcripts on disk). The id is kind-tagged (agent switches start fresh) and charset-validated before reaching argv.

**Codex is deliberately not resumed**: `codex exec resume` restores context but rejects `-s read-only`/`-C` — the exact flags its sandbox box is built on (verified live, codex-cli 0.144.1). Resuming without re-asserting them trades continuity for an unverified sandbox → tracked in #215. The native srelens agent already carries history in-process.

## Testing

- `cargo test -p srelens-agent -p srelens-desktop` — all green (incl. new `stream_session_id` tests from real CLI lines).
- Full `vitest` suite — 983 passing (new tests: expansion-carrying context names stay inert; resume id round-trips send → persist → follow-up).
- `tsc --noEmit` clean.
- Live CLI verification as described above.