### PR TITLE
fix(release): version every workspace crate with the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,8 +126,12 @@ jobs:
             const fs=require("fs");const v=process.argv[1];
             const sub=(p,re,to)=>{const s=fs.readFileSync(p,"utf8");const n=s.replace(re,to);if(n===s)throw new Error("no version match in "+p);fs.writeFileSync(p,n)};
             sub("apps/desktop/src-tauri/tauri.conf.json",/("version":\s*)"[^"]+"/,`$1"${v}"`);
-            sub("apps/desktop/src-tauri/Cargo.toml",/^version = "[^"]+"/m,`version = "${v}"`);
-            sub("Cargo.lock",/(name = "srelens-desktop"\r?\nversion = ")[^"]+(")/,`$1${v}$2`);
+            // Every crate inherits [workspace.package].version from the root
+            // Cargo.toml (src-tauri included), so ONE Cargo bump versions the
+            // whole workspace — the server binary, the MCP serverInfo, all of
+            // it — and the lock updates every srelens-* member to match.
+            sub("Cargo.toml",/^version = "[^"]+"/m,`version = "${v}"`);
+            sub("Cargo.lock",/(name = "srelens-[a-z-]+"\r?\nversion = ")[^"]+(")/g,`$1${v}$2`);
           ' "$NEW"
           # Grouped changelog for the release body. The Conventional Commit type
           # is dropped (the section heading already says Features / Fixes) but
@@ -195,6 +199,23 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+      # Stamp the release version into the workspace before the image builds:
+      # every crate inherits [workspace.package].version, and without this the
+      # server binary in the image reports the committed placeholder instead
+      # of the released version — on main this job checks out the pre-bump
+      # push sha (the version job's bump commit lands after), and on dev the
+      # pre-release version is never committed at all.
+      - name: Set build version
+        shell: bash
+        run: |
+          V="${{ needs.version.outputs.version }}"
+          node -e '
+            const fs=require("fs");const v=process.argv[1];
+            const sub=(p,re,to)=>{const s=fs.readFileSync(p,"utf8");if(!re.test(s))throw new Error("no version field in "+p);fs.writeFileSync(p,s.replace(re,to))};
+            sub("Cargo.toml",/^version = "[^"]+"/m,`version = "${v}"`);
+            sub("Cargo.lock",/(name = "srelens-[a-z-]+"\r?\nversion = ")[^"]+(")/g,`$1${v}$2`);
+          ' "$V"
+          echo "Docker build version: $V"
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
       - name: Log in to GHCR
@@ -407,8 +428,8 @@ jobs:
             const fs=require("fs");const v=process.argv[1];
             const sub=(p,re,to)=>{const s=fs.readFileSync(p,"utf8");if(!re.test(s))throw new Error("no version field in "+p);fs.writeFileSync(p,s.replace(re,to))};
             sub("apps/desktop/src-tauri/tauri.conf.json",/("version":\s*)"[^"]+"/,`$1"${v}"`);
-            sub("apps/desktop/src-tauri/Cargo.toml",/^version = "[^"]+"/m,`version = "${v}"`);
-            sub("Cargo.lock",/(name = "srelens-desktop"\r?\nversion = ")[^"]+(")/,`$1${v}$2`);
+            sub("Cargo.toml",/^version = "[^"]+"/m,`version = "${v}"`);
+            sub("Cargo.lock",/(name = "srelens-[a-z-]+"\r?\nversion = ")[^"]+(")/g,`$1${v}$2`);
           ' "$V"
           echo "Built version: $V"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5750,7 +5750,7 @@ dependencies = [
 
 [[package]]
 name = "srelens-agent"
-version = "0.0.0"
+version = "0.4.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -5758,7 +5758,7 @@ dependencies = [
 
 [[package]]
 name = "srelens-capability"
-version = "0.0.0"
+version = "0.4.1"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -5806,7 +5806,7 @@ dependencies = [
 
 [[package]]
 name = "srelens-kube"
-version = "0.0.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "srelens-llm"
-version = "0.0.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "futures",
@@ -5845,7 +5845,7 @@ dependencies = [
 
 [[package]]
 name = "srelens-mcp"
-version = "0.0.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "srelens-registry"
-version = "0.0.0"
+version = "0.4.1"
 dependencies = [
  "reqwest 0.13.4",
  "serde",
@@ -5876,7 +5876,7 @@ dependencies = [
 
 [[package]]
 name = "srelens-server"
-version = "0.0.0"
+version = "0.4.1"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -5908,7 +5908,7 @@ dependencies = [
 
 [[package]]
 name = "srelens-streams"
-version = "0.0.0"
+version = "0.4.1"
 dependencies = [
  "portable-pty",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,5 @@ members = ["crates/agent", "crates/capability", "crates/mcp", "crates/kube", "cr
 
 [workspace.package]
 edition = "2021"
-version = "0.0.0"
+version = "0.4.1"
 license = "MIT"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srelens-desktop"
-version = "0.4.1"
+version.workspace = true
 description = "srelens Kubernetes desktop workspace"
 edition = "2021"
 rust-version = "1.77.2"


### PR DESCRIPTION
## What

- All crates now inherit `[workspace.package].version` — including `src-tauri`, making the root `Cargo.toml` the single Cargo bump site (`tauri.conf.json` stays the app-version source Tauri reads).
- The version job and the desktop build's "Set build version" step bump the root `Cargo.toml` and **every** `srelens-*` entry in `Cargo.lock`, not just the desktop crate.
- The docker job gets the same stamp step — it previously built from a bare checkout, so images never saw any bump at all: on `main` it checks out the pre-bump push sha (the version job's bump commit lands after), and on `dev` the pre-release version is never committed.

## Why

Noticed while building: every crate except `src-tauri` sat at the never-bumped `0.0.0` workspace placeholder. User-visible consequences: the released `srelens-server` binary reports `0.0.0`, and the MCP `serverInfo` handshake (`crates/mcp/src/stdio.rs`, `env!("CARGO_PKG_VERSION")`) tells every MCP client it's talking to version `0.0.0`.

## Testing

- Stamp script exercised against real file copies with a pre-release version (`9.9.9-42`): root workspace version, all 9 `srelens-*` lock entries, and `tauri.conf.json` all stamped; pre-release identifiers are valid Cargo semver (dev builds already rely on this for src-tauri).
- `cargo check -p srelens-server -p srelens-desktop` clean with inherited versions; `Cargo.lock` refreshed (all 9 members at 0.4.1, none at 0.0.0).
- Internal crate deps are path-only (no version pins), so the workspace bump can't break resolution.