### PR TITLE
feat(assistant): surface Codex reasoning summaries as Thoughts

### DIFF
--- a/apps/desktop/src/components/AssistantConversation.test.tsx
+++ b/apps/desktop/src/components/AssistantConversation.test.tsx
@@ -8,6 +8,7 @@ import {
 } from "./AssistantConversation";
 import * as chat from "../lib/chat";
 import * as chatHistory from "../lib/chatHistory";
+import type { StoredMessage } from "../lib/chatHistory";
 import * as prompts from "../lib/prompts";
 import * as skills from "../lib/skills";
 
@@ -411,6 +412,45 @@ describe("AssistantConversation session persistence", () => {
     fireEvent.click(screen.getByRole("button", { name: /^send$/i }));
     await waitFor(() => expect(screen.getAllByText("Thoughts")).toHaveLength(2));
     expect(screen.getAllByText(/·\s*1s/)).toHaveLength(1);
+  });
+
+  it("thoughts round-trip through the saved session and reopen with their row intact", async () => {
+    vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
+      onEvent({ type: "thinking", text: "**Weighing options**\n" });
+      onEvent({ type: "textDelta", text: "answer" });
+      onEvent({ type: "turnDone" });
+      return null;
+    });
+    const ref = createRef<AssistantConversationHandle>();
+    render(<AssistantConversation ref={ref} />);
+    fireEvent.change(await screen.findByPlaceholderText(/ask/i), { target: { value: "think hard" } });
+    fireEvent.click(screen.getByRole("button", { name: /send/i }));
+
+    // The auto-save carries the reasoning, not just text and tool calls.
+    await waitFor(() => expect(chatHistory.saveSession).toHaveBeenCalled());
+    const calls = vi.mocked(chatHistory.saveSession).mock.calls;
+    const savedMsg = (calls[calls.length - 1][0].messages as StoredMessage[]).find((m) => m.role === "assistant")!;
+    expect(savedMsg.thoughts).toBe("**Weighing options**\n");
+    expect(savedMsg.thoughtSecs).toBe(1);
+
+    // Reopening a stored session restores the collapsible Thoughts row.
+    vi.mocked(chatHistory.loadSession).mockResolvedValue({
+      id: "old",
+      title: "old",
+      createdAt: 1,
+      updatedAt: 2,
+      contexts: [],
+      skills: [],
+      cliSessionId: null,
+      messages: [
+        { id: 0, role: "user", text: "earlier question" },
+        { id: 1, role: "assistant", text: "earlier answer", thoughts: "**Recalling context**\n", thoughtSecs: 4 },
+      ],
+    });
+    await act(async () => void ref.current!.selectSession("old"));
+    expect(await screen.findByText("earlier answer")).toBeTruthy();
+    expect(screen.getByText("Thoughts")).toBeTruthy();
+    expect(screen.getByText(/·\s*4s/)).toBeTruthy();
   });
 
   it("auto-save records the attached context under `contexts`", async () => {

--- a/apps/desktop/src/components/AssistantConversation.test.tsx
+++ b/apps/desktop/src/components/AssistantConversation.test.tsx
@@ -381,6 +381,38 @@ describe("AssistantConversation session persistence", () => {
     expect(vi.mocked(chat.sendChat).mock.calls[2][7]).toBeNull();
   });
 
+  it("codex thoughts render without a duration label; delta-streaming agents keep it", async () => {
+    // Codex reasoning arrives as an already-completed summary item, so
+    // wall-clock timing across its events would be fiction (a long burst
+    // would read "· 1s"). Agents that stream real deltas keep the label.
+    vi.mocked(chat.listAgents).mockResolvedValue([
+      { kind: "claude", label: "Claude Code", available: true, path: "/usr/bin/claude", version: null, installUrl: "", gated: false },
+      { kind: "codex", label: "Codex", available: true, path: "/usr/bin/codex", version: null, installUrl: "", gated: false },
+    ]);
+    vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
+      onEvent({ type: "thinking", text: "**Weighing options**\n" });
+      onEvent({ type: "textDelta", text: "answer" });
+      onEvent({ type: "turnDone" });
+      return null;
+    });
+    render(<AssistantConversation />);
+
+    // Claude-kind turn (default pick): the timer runs → "· 1s" appears.
+    fireEvent.change(await screen.findByPlaceholderText(/ask/i), { target: { value: "first" } });
+    fireEvent.click(screen.getByRole("button", { name: /send/i }));
+    await screen.findByText("Thoughts");
+    expect(screen.getByText(/·\s*1s/)).toBeTruthy();
+    await screen.findByRole("button", { name: /^send$/i });
+
+    // Codex turn: same events, no duration label on its Thoughts row.
+    fireEvent.click(screen.getByRole("combobox", { name: /agent/i }));
+    fireEvent.click(await screen.findByRole("option", { name: /codex/i }));
+    fireEvent.change(screen.getByPlaceholderText(/ask/i), { target: { value: "second" } });
+    fireEvent.click(screen.getByRole("button", { name: /^send$/i }));
+    await waitFor(() => expect(screen.getAllByText("Thoughts")).toHaveLength(2));
+    expect(screen.getAllByText(/·\s*1s/)).toHaveLength(1);
+  });
+
   it("auto-save records the attached context under `contexts`", async () => {
     vi.mocked(chat.sendChat).mockImplementation(async (_s, _p, _a, onEvent) => {
       onEvent({ type: "textDelta", text: "ok" });

--- a/apps/desktop/src/components/AssistantConversation.tsx
+++ b/apps/desktop/src/components/AssistantConversation.tsx
@@ -305,8 +305,11 @@ function CopyButton({ text }: { text: string }) {
 /**
  * The agent's reasoning for a turn, folded into a collapsible "Thoughts · Ns"
  * row above the tools and answer. Only rendered when the agent actually
- * streamed reasoning (Cursor does; Claude/Codex headless don't), collapsed by
- * default.
+ * streamed reasoning: the native agent and Cursor stream it, Codex reports
+ * reasoning summaries when the model reasons enough to produce them (the
+ * adapter requests them via `model_reasoning_summary`), and Claude headless
+ * redacts thinking content entirely (see `claude.rs`), so Claude turns have
+ * no Thoughts row. Collapsed by default.
  */
 function ThoughtsGroup({ text, secs }: { text: string; secs?: number }) {
   const [expanded, setExpanded] = useState(false);

--- a/apps/desktop/src/components/AssistantConversation.tsx
+++ b/apps/desktop/src/components/AssistantConversation.tsx
@@ -178,6 +178,8 @@ function toStoredMessages(msgs: ChatMessage[], calls: Record<string, ToolCallSta
     const stored: StoredMessage = { id: m.id, role: m.role, text: m.text };
     if (m.images && m.images.length > 0) stored.images = m.images;
     if (toolCalls.length > 0) stored.toolCalls = toolCalls;
+    if (m.thoughts) stored.thoughts = m.thoughts;
+    if (m.thoughtSecs) stored.thoughtSecs = m.thoughtSecs;
     return stored;
   });
 }
@@ -192,6 +194,8 @@ function fromStoredMessages(stored: StoredMessage[]): { msgs: ChatMessage[]; cal
     const msg: ChatMessage = { id: m.id, role: m.role, text: m.text };
     if (m.images && m.images.length > 0) msg.images = m.images;
     if (toolCallIds?.length) msg.toolCallIds = toolCallIds;
+    if (m.thoughts) msg.thoughts = m.thoughts;
+    if (m.thoughtSecs) msg.thoughtSecs = m.thoughtSecs;
     return msg;
   });
   return { msgs, calls };

--- a/apps/desktop/src/components/AssistantConversation.tsx
+++ b/apps/desktop/src/components/AssistantConversation.tsx
@@ -815,6 +815,13 @@ export const AssistantConversation = forwardRef<
   // When the current turn began streaming reasoning, so the Thoughts section
   // can show how long it thought once the thinking ends.
   const thinkingStartRef = useRef<number | null>(null);
+  // The agent kind the in-flight turn runs on. Codex delivers each reasoning
+  // burst as one COMPLETED summary item — it arrives after the thinking
+  // already happened, so wall-clock timing across its events would label a
+  // tens-of-seconds burst "Thoughts · 1s". For codex the timer never starts
+  // and the label shows no duration; agents that stream true deltas
+  // (native, Cursor) keep it.
+  const turnKindRef = useRef<string | null>(null);
 
   // This component only exists while its host (the drawer or the tab) is
   // showing it, so a subscription made on mount already covers "each time
@@ -1228,7 +1235,9 @@ export const AssistantConversation = forwardRef<
     }
     switch (e.type) {
       case "thinking":
-        if (thinkingStartRef.current === null) thinkingStartRef.current = Date.now();
+        // No timer for codex — see `turnKindRef`.
+        if (turnKindRef.current !== "codex" && thinkingStartRef.current === null)
+          thinkingStartRef.current = Date.now();
         setMessagesTracked((msgs) => {
           const last = msgs[msgs.length - 1];
           if (!last || last.role !== "assistant") return msgs;
@@ -1375,6 +1384,7 @@ export const AssistantConversation = forwardRef<
         return;
       }
       saveLastAgent(usedKind); // remember what was actually used for the next fresh chat
+      turnKindRef.current = usedKind; // drives the Thoughts timing decision — see the ref
       // Resume the CLI's own session only when this turn runs on the same
       // agent the stored id came from (see `cliSessionRef`).
       const resume = cliSessionRef.current?.kind === usedKind ? cliSessionRef.current.id : null;

--- a/apps/desktop/src/lib/chatHistory.ts
+++ b/apps/desktop/src/lib/chatHistory.ts
@@ -60,6 +60,12 @@ export interface StoredMessage {
   /** Data URIs (`data:image/...;base64,...`) attached to a user message
    * (Task 18) — only ever set for `role: "user"`. */
   images?: string[];
+  /** Reasoning streamed before the answer (the collapsible "Thoughts" row) —
+   * only for `role: "assistant"`, and only when the agent surfaced any. */
+  thoughts?: string;
+  /** Seconds spent thinking, when the agent streams reasoning live (absent
+   * for Codex, whose summaries arrive already completed and untimeable). */
+  thoughtSecs?: number;
 }
 
 /** Saved sessions, newest first. */

--- a/crates/agent/src/adapter.rs
+++ b/crates/agent/src/adapter.rs
@@ -225,6 +225,15 @@ pub fn codex_command(
         format!("mcp_servers.srelens.url=\"{}\"", escape_toml_string(mcp_url)),
         "-c".to_string(),
         format!("mcp_servers.srelens.bearer_token_env_var=\"{CODEX_TOKEN_ENV}\""),
+        // Surface the model's reasoning as `reasoning` items in the JSON
+        // stream (mapped to Thinking events by `codex::parse_line`) — with
+        // `--ignore-user-config` above, the user's own config.toml can't
+        // enable this, so srelens must. "detailed" only changes what the CLI
+        // REPORTS about reasoning the model already does; it does not raise
+        // the reasoning effort. Verified live: without it exec --json emits
+        // no reasoning items at all.
+        "-c".to_string(),
+        "model_reasoning_summary=\"detailed\"".to_string(),
     ];
     for path in image_paths {
         args.push("-i".to_string());

--- a/crates/agent/src/claude.rs
+++ b/crates/agent/src/claude.rs
@@ -58,6 +58,14 @@ fn block_to_event(block: &serde_json::Value) -> Option<AgentEvent> {
         // The `thinking` field is the documented key for this block, but we
         // fall back to `text` defensively in case a future CLI version
         // shapes it like a text block instead.
+        //
+        // KNOWN LIMITATION: in headless (`-p`) mode the CLI redacts the
+        // thinking CONTENT — blocks arrive with an empty `thinking` string
+        // and only the crypto `signature` (verified live on claude CLI
+        // 2.1.228, multiple models, with and without
+        // --include-partial-messages, whose thinking_deltas are empty too).
+        // So Claude turns currently produce no visible Thoughts; the mapping
+        // stays for the day the CLI starts sharing the text.
         Some("thinking") => Some(AgentEvent::Thinking {
             text: block
                 .get("thinking")

--- a/crates/agent/src/codex.rs
+++ b/crates/agent/src/codex.rs
@@ -51,6 +51,20 @@ fn item_completed(item: &serde_json::Value) -> Vec<AgentEvent> {
         Some("agent_message") => vec![AgentEvent::TextDelta {
             text: str_field(item, "text").to_string(),
         }],
+        // Reasoning summaries (markdown, one item per burst of thinking;
+        // emitted when the model actually reasons — `codex_command` requests
+        // them via `model_reasoning_summary`). The trailing newline separates
+        // consecutive items for the UI, which concatenates thinking deltas
+        // verbatim; Cursor-style true deltas must NOT get one, but each
+        // Codex item is a complete block.
+        Some("reasoning") => {
+            let text = str_field(item, "text");
+            if text.is_empty() {
+                Vec::new()
+            } else {
+                vec![AgentEvent::Thinking { text: format!("{text}\n") }]
+            }
+        }
         Some("mcp_tool_call") => {
             let has_error = item.get("error").map(|e| !e.is_null()).unwrap_or(false);
             let completed = item.get("status").and_then(|s| s.as_str()) == Some("completed");
@@ -97,11 +111,20 @@ mod tests {
     }
 
     #[test]
-    fn a_reasoning_item_is_ignored() {
+    fn a_reasoning_item_becomes_thinking_with_an_item_separator() {
+        // Shape verified live (codex-cli 0.144, model_reasoning_summary on):
+        // one complete markdown block per item, so the parser appends the
+        // newline that separates it from the next item's text in the UI.
         let out = parse_line(
-            r#"{"type":"item.completed","item":{"id":"item_9","type":"reasoning","text":"thinking about it"}}"#,
+            r#"{"type":"item.completed","item":{"id":"item_9","type":"reasoning","text":"**Mapping weigh outcomes**"}}"#,
         );
-        assert!(out.is_empty());
+        assert_eq!(out, vec![AgentEvent::Thinking { text: "**Mapping weigh outcomes**\n".into() }]);
+    }
+
+    #[test]
+    fn an_empty_reasoning_item_is_ignored() {
+        assert!(parse_line(r#"{"type":"item.completed","item":{"id":"item_9","type":"reasoning","text":""}}"#).is_empty());
+        assert!(parse_line(r#"{"type":"item.completed","item":{"id":"item_9","type":"reasoning"}}"#).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## What

Makes agent reasoning visible in the Thoughts row for Codex, and documents exactly why Claude's can't be.

- **Codex**: `exec --json` emits `reasoning` items **only** when `model_reasoning_summary` is configured — and srelens passes `--ignore-user-config`, so the user's own `config.toml` can never turn it on. `codex_command` now requests `"detailed"` summaries (reporting-only — it does not raise reasoning effort; verified live both ways on codex-cli 0.144.1: high-effort runs emit zero reasoning items without the flag, multiple with it). The parser maps each item to a `Thinking` event, newline-separated per item since each is a complete markdown block.
- **Claude**: headless `claude -p` **redacts thinking content** — blocks arrive with an empty `thinking` string and only the crypto signature. Verified live on claude CLI 2.1.228 across models, with and without `--include-partial-messages` (whose `thinking_delta`s are empty too). Nothing to render; the mapping stays for the day the CLI shares text, and the limitation is documented at the parser and the UI so nobody chases it again.
- **Cursor**: already streams real thinking deltas end-to-end (verified live) — untouched.

## Testing

- Parser: reasoning item → `Thinking` with separator; empty/absent text ignored — fixture shape captured from a live run.
- `cargo test -p srelens-agent -p srelens-desktop` green (88 + 145), `tsc` clean.
- Live CLI verification as described above.