### PR TITLE
fix(kube): treat an absent EndpointSlice conditions.ready as ready

### DIFF
--- a/crates/kube/src/endpointslices.rs
+++ b/crates/kube/src/endpointslices.rs
@@ -48,7 +48,12 @@ pub(crate) fn summarise(slice: EndpointSlice) -> EndpointSliceSummary {
     let ready = slice
         .endpoints
         .iter()
-        .filter(|e| e.conditions.as_ref().and_then(|c| c.ready).unwrap_or(false))
+        // The EndpointSlice API treats an ABSENT `conditions.ready` as ready
+        // ("consumers should interpret this unknown state as ready" — the
+        // field is only meaningful when explicitly set). Absent conditions
+        // mostly appear on manually managed slices (selector-less Services);
+        // kube-controller-manager always sets `ready` on slices it owns.
+        .filter(|e| e.conditions.as_ref().and_then(|c| c.ready).unwrap_or(true))
         .count();
     let ports = slice
         .ports
@@ -158,5 +163,34 @@ mod tests {
         assert_eq!(s.endpoints, "2/3");
         assert_eq!(s.ports, "8080");
         assert_eq!(s.service, "web");
+    }
+
+    #[test]
+    fn an_absent_ready_condition_counts_as_ready_but_an_explicit_false_does_not() {
+        // API convention (issue #191): `conditions.ready` is only meaningful
+        // when set — absent conditions, or conditions without `ready`, mean
+        // ready. Only an explicit `Some(false)` is not-ready. Manually
+        // managed slices (selector-less Services) commonly omit conditions
+        // entirely and used to show as 0/N.
+        let no_conditions = Endpoint::default();
+        let empty_conditions = Endpoint {
+            conditions: Some(EndpointConditions::default()),
+            ..Default::default()
+        };
+        let explicitly_not_ready = Endpoint {
+            conditions: Some(EndpointConditions { ready: Some(false), ..Default::default() }),
+            ..Default::default()
+        };
+        let slice = EndpointSlice {
+            metadata: kube::core::ObjectMeta {
+                name: Some("manual-abc".into()),
+                namespace: Some("default".into()),
+                ..Default::default()
+            },
+            address_type: "IPv4".into(),
+            endpoints: vec![no_conditions, empty_conditions, explicitly_not_ready],
+            ports: None,
+        };
+        assert_eq!(summarise(slice).endpoints, "2/3");
     }
 }

--- a/crates/mcp/src/prompts/service-no-endpoints.discover.md
+++ b/crates/mcp/src/prompts/service-no-endpoints.discover.md
@@ -20,15 +20,7 @@ endpoints, then explain why.
    managed slices. Exclude any service whose `type` (from step 1) is
    `ExternalName` from this candidate set entirely — it intentionally has no
    selector and no EndpointSlices, resolved instead via a DNS CNAME, so having
-   none is correct by design, not a fault this flow should surface. The
-   ready count itself can UNDER-report: it treats an endpoint whose
-   `conditions.ready` field is absent as not-ready, though Kubernetes
-   conventionally treats an absent `conditions.ready` as ready — a manually
-   managed EndpointSlice that omits the field can show `0/N` here while its
-   endpoints are actually fine. Before concluding a service in this candidate
-   set is genuinely broken, especially one fed by a manually managed slice,
-   confirm against the slice objects themselves (or the service's actual
-   reachability) rather than trusting the ready count alone.
+   none is correct by design, not a fault this flow should surface.
 3. Call `k8s.listIngresses` with `context: {{context}}`, `namespace: {{namespace}}`
    to enumerate Ingresses — but `IngressSummary` carries only name, namespace,
    class, hosts, address, ports and age, no backend service reference, so this

--- a/crates/mcp/src/prompts/service-no-endpoints.targeted.md
+++ b/crates/mcp/src/prompts/service-no-endpoints.targeted.md
@@ -27,14 +27,7 @@ endpoints, so nothing is receiving its traffic. Work out where the chain breaks.
 2. Call `k8s.listEndpointSlices` with `context: {{context}}`,
    `namespace: {{namespace}}`. Find the slices owned by `{{service}}`. Empty
    slices mean no pod matched or none is ready; slices with addresses marked
-   not-ready mean the pods exist but are failing readiness — BUT the
-   not-ready count can over-count: an endpoint whose `conditions.ready` field
-   is absent is reported here as not-ready, though Kubernetes conventionally
-   treats an absent `conditions.ready` as ready. This matters most for a
-   manually managed slice (no `spec.selector` on the Service, see step 1),
-   which is more likely to omit the field entirely. Before concluding the
-   pods are failing readiness on this evidence alone, confirm against the
-   slice objects themselves (or the service's actual reachability).
+   not-ready mean the pods exist but are failing readiness.
 3. If `spec.selector` from step 1 is non-empty, Call `k8s.podsForSelector` with
    `context: {{context}}`, `namespace: {{namespace}}`,
    `selector: <the Service's spec.selector map>`.


### PR DESCRIPTION
Fixes #191.

## What

`summarise` counted an endpoint as ready only when `conditions.ready` was explicitly `true` — but the EndpointSlice API defines the field as meaningful only when set: **absent means ready**. Manually managed slices (selector-less Services) commonly omit `conditions` entirely (kube-controller-manager always sets it on slices it owns, which is why this stayed hidden), so a healthy Service showed `0/N` in the endpoints view and looked broken to the `service-no-endpoints` prompt.

- Absent `conditions` or absent `ready` now count as ready; only an explicit `false` is not-ready.
- The `service-no-endpoints` prompts drop the over/under-count caveat prose that existed solely to work around this (the follow-up #191 called for).

## Audit

Per the issue's ask, checked every other optional-Kubernetes-boolean default in `crates/kube`: `suspend` (CronJobs), `unschedulable` (Nodes), the mirror-pod annotation, CRD `storage`/`served`, and access-review `denied` — for all of these, absent correctly means `false`. EndpointSlice readiness was the only inverted one.

## Testing

New unit test covering the three shapes: no `conditions` at all → ready, `conditions` without `ready` → ready, explicit `Some(false)` → not-ready (`2/3`). Full `srelens-kube` (291) and `srelens-mcp` (212) suites green.