### PR TITLE
fix(ui): context initials skip generated-id segments and use up to three letters

### DIFF
--- a/apps/desktop/src/ui/avatar.test.ts
+++ b/apps/desktop/src/ui/avatar.test.ts
@@ -38,8 +38,15 @@ describe("avatarInitials", () => {
     expect(avatarInitials("prod-babe42")).toBe("PB");
   });
 
+  it("keeps short numeric segments — often the only distinguisher", () => {
+    expect(avatarInitials("cluster-1")).toBe("C1");
+    expect(avatarInitials("cluster-2")).toBe("C2");
+    // Long digit runs are timestamps/serials, not names.
+    expect(avatarInitials("prod-eu-20260813")).toBe("PE");
+  });
+
   it("falls back to raw segments when everything looks generated", () => {
     expect(avatarInitials("7f3a9b21")).toBe("7F");
-    expect(avatarInitials("123-456789ab")).toBe("14");
+    expect(avatarInitials("123456-456789ab")).toBe("14");
   });
 });

--- a/apps/desktop/src/ui/avatar.test.ts
+++ b/apps/desktop/src/ui/avatar.test.ts
@@ -30,12 +30,16 @@ describe("avatarInitials", () => {
   it("keeps hex-alphabet words and digit-bearing short names as identity", () => {
     // Real words that happen to be hex letters are not ids...
     expect(avatarInitials("decade-cluster")).toBe("DC");
-    // ...and k3d/k8s-style segments have non-hex letters, so they count.
+    // ...k3d/k8s-style segments have non-hex letters, so they count...
     expect(avatarInitials("k3d-7f3a9b21")).toBe("K3");
+    // ...and hex-looking segments UNDER 8 chars are treated as chosen names,
+    // not ids (segments are user-defined — `c0ffee` is somebody's cluster).
+    expect(avatarInitials("prod-c0ffee")).toBe("PC");
+    expect(avatarInitials("prod-babe42")).toBe("PB");
   });
 
   it("falls back to raw segments when everything looks generated", () => {
     expect(avatarInitials("7f3a9b21")).toBe("7F");
-    expect(avatarInitials("123-456789a")).toBe("14");
+    expect(avatarInitials("123-456789ab")).toBe("14");
   });
 });

--- a/apps/desktop/src/ui/avatar.test.ts
+++ b/apps/desktop/src/ui/avatar.test.ts
@@ -9,10 +9,33 @@ describe("avatarColor", () => {
 });
 
 describe("avatarInitials", () => {
-  it("derives up to two initials, splitting on separators", () => {
+  it("derives up to three initials, splitting on separators", () => {
     expect(avatarInitials("prod")).toBe("PR");
     expect(avatarInitials("kind-dev")).toBe("KD");
-    expect(avatarInitials("my_staging_cluster")).toBe("MS");
+    expect(avatarInitials("my_staging_cluster")).toBe("MSC");
     expect(avatarInitials("")).toBe("?");
+  });
+
+  it("skips generated-id segments so similar contexts stay distinguishable (#209)", () => {
+    // The issue's real-world set: two initials collapsed all of these to
+    // DL/DL/DL/DL and ML/ML.
+    expect(avatarInitials("dev-lon-nrtc-6bcb8b63")).toBe("DLN");
+    expect(avatarInitials("dev-lon-nrtc-6bcb8b63-admin")).toBe("DLN");
+    expect(avatarInitials("dev-lon-workload-15d9c530")).toBe("DLW");
+    expect(avatarInitials("mbr-lon-nrtc-c678b415")).toBe("MLN");
+    expect(avatarInitials("k3d-dev-ai")).toBe("KDA");
+    expect(avatarInitials("k3d-nats")).toBe("KN");
+  });
+
+  it("keeps hex-alphabet words and digit-bearing short names as identity", () => {
+    // Real words that happen to be hex letters are not ids...
+    expect(avatarInitials("decade-cluster")).toBe("DC");
+    // ...and k3d/k8s-style segments have non-hex letters, so they count.
+    expect(avatarInitials("k3d-7f3a9b21")).toBe("K3");
+  });
+
+  it("falls back to raw segments when everything looks generated", () => {
+    expect(avatarInitials("7f3a9b21")).toBe("7F");
+    expect(avatarInitials("123-456789a")).toBe("14");
   });
 });

--- a/apps/desktop/src/ui/avatar.ts
+++ b/apps/desktop/src/ui/avatar.ts
@@ -35,9 +35,11 @@ export function avatarColor(name: string): string {
  * since segments are user-defined: the digit requirement keeps hex-alphabet
  * words (`decade`, `cafebabe`) as identity, and the 8-char floor keeps
  * short leetspeak-style names (`c0ffee`, `babe42`) as identity too — real
- * generated ids (k3d, EKS, the #209 set) are 8 hex chars or more. */
+ * generated ids (k3d, EKS, the #209 set) are 8 hex chars or more. Bare
+ * numbers are noise only from 6 digits up (timestamps, serials): a short
+ * number is usually the ONLY thing telling `cluster-1` from `cluster-2`. */
 function isNoiseSegment(segment: string): boolean {
-  return /^(?=.*\d)[0-9a-f]{8,}$/i.test(segment) || /^\d+$/.test(segment);
+  return /^(?=.*\d)[0-9a-f]{8,}$/i.test(segment) || /^\d{6,}$/.test(segment);
 }
 
 /** Up-to-3-char initials from a cluster name (splits on - _ space /),

--- a/apps/desktop/src/ui/avatar.ts
+++ b/apps/desktop/src/ui/avatar.ts
@@ -30,12 +30,14 @@ export function avatarColor(name: string): string {
 }
 
 /** A segment that carries no identity: a generated id (hex with at least one
- * digit, 6+ chars — `6bcb8b63`) or a bare number. Cluster names commonly end
- * in these, and their initial tells the user nothing. The digit requirement
- * keeps real words that happen to be hex-alphabet (`decade`, `facade`) out
- * of the noise class. */
+ * digit, 8+ chars — `6bcb8b63`) or a bare number. Cluster names commonly end
+ * in these, and their initial tells the user nothing. Deliberately narrow,
+ * since segments are user-defined: the digit requirement keeps hex-alphabet
+ * words (`decade`, `cafebabe`) as identity, and the 8-char floor keeps
+ * short leetspeak-style names (`c0ffee`, `babe42`) as identity too — real
+ * generated ids (k3d, EKS, the #209 set) are 8 hex chars or more. */
 function isNoiseSegment(segment: string): boolean {
-  return /^(?=.*\d)[0-9a-f]{6,}$/i.test(segment) || /^\d+$/.test(segment);
+  return /^(?=.*\d)[0-9a-f]{8,}$/i.test(segment) || /^\d+$/.test(segment);
 }
 
 /** Up-to-3-char initials from a cluster name (splits on - _ space /),

--- a/apps/desktop/src/ui/avatar.ts
+++ b/apps/desktop/src/ui/avatar.ts
@@ -29,10 +29,30 @@ export function avatarColor(name: string): string {
   return AVATAR_COLORS[hash(name) % AVATAR_COLORS.length];
 }
 
-/** Up-to-2-char initials from a cluster name (splits on - _ space /). */
+/** A segment that carries no identity: a generated id (hex with at least one
+ * digit, 6+ chars — `6bcb8b63`) or a bare number. Cluster names commonly end
+ * in these, and their initial tells the user nothing. The digit requirement
+ * keeps real words that happen to be hex-alphabet (`decade`, `facade`) out
+ * of the noise class. */
+function isNoiseSegment(segment: string): boolean {
+  return /^(?=.*\d)[0-9a-f]{6,}$/i.test(segment) || /^\d+$/.test(segment);
+}
+
+/** Up-to-3-char initials from a cluster name (splits on - _ space /),
+ * skipping generated-id segments so similarly named contexts stay
+ * distinguishable: `dev-lon-nrtc-6bcb8b63` → `DLN` and
+ * `dev-lon-workload-15d9c530` → `DLW`, where two initials gave `DL` for
+ * both (issue #209). Falls back to the raw segments when everything looks
+ * generated (`k3d-7f3a9b21` still gets a label). */
 export function avatarInitials(name: string): string {
   const parts = name.split(/[-_\s/]+/).filter(Boolean);
   if (parts.length === 0) return "?";
-  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
-  return (parts[0][0] + parts[1][0]).toUpperCase();
+  const meaningful = parts.filter((p) => !isNoiseSegment(p));
+  const chosen = meaningful.length > 0 ? meaningful : parts;
+  if (chosen.length === 1) return chosen[0].slice(0, 2).toUpperCase();
+  return chosen
+    .slice(0, 3)
+    .map((p) => p[0])
+    .join("")
+    .toUpperCase();
 }


### PR DESCRIPTION
Relates to #209 — the abbreviation-quality half (the hotbar overflow half landed in #211). Left to the issue reporter/maintainer to close after verifying against their real context set.

## What

`avatarInitials` took the first letter of the first two segments, which collapsed the issue's real-world contexts into identical labels:

| context | before | after |
|---|---|---|
| `dev-lon-nrtc-6bcb8b63` | DL | **DLN** |
| `dev-lon-nrtc-6bcb8b63-admin` | DL | **DLN** |
| `dev-lon-workload-15d9c530` | DL | **DLW** |
| `mbr-lon-nrtc-c678b415` | ML | **MLN** |
| `k3d-dev-ai` | KD | **KDA** |
| `k3d-nats` | KN | KN |

Initials now come from up to **three** segments, **skipping segments that carry no identity**: hex ids (6+ chars, required to contain a digit so real hex-alphabet words like `decade` still count) and bare numbers. A name that is entirely generated ids falls back to the raw segments so it always gets a label.

The `-admin` twins still share a label by construction — they differ only by their id — but they keep distinct avatar colours (hashed from the full name), the full name in the tooltip, and the per-context short-name override in Preferences remains the explicit escape hatch.

## Testing

Unit tests over the issue's real context set, the hex-word/mixed-segment edge cases, and the all-generated fallback. Full frontend suite green (991).