### PR TITLE
fix(mcp): evict dead watches from the subscription registry

### DIFF
--- a/apps/desktop/src-tauri/src/mcp_watch.rs
+++ b/apps/desktop/src-tauri/src/mcp_watch.rs
@@ -28,6 +28,7 @@ impl ObjectWatcher for CacheWatcher {
         &self,
         uri: &ResourceUri,
         on_change: Box<dyn FnMut() + Send>,
+        on_dead: Box<dyn FnOnce(String) + Send>,
     ) -> Result<tokio::task::AbortHandle, String> {
         let ResourceUri::Object { context, namespace, kind, name, .. } = uri else {
             return Err("only object URIs can be watched".to_string());
@@ -77,19 +78,16 @@ impl ObjectWatcher for CacheWatcher {
         let cache = self.cache.clone();
         let (context, namespace, name) = (context.clone(), namespace.clone(), name.clone());
         // `watch` is synchronous and returns before the client is ever
-        // resolved, so it cannot validate the subscription up front — the
-        // best it can do is surface what happens once the task runs. stderr
-        // is free even on the stdio transport (stdout is the JSON-RPC
-        // channel there — see the precedent in `main.rs`), so a dead watch at
-        // least leaves a diagnostic instead of failing silently.
-        //
-        // NOTE: a failed watch (unknown context, or a namespace the identity
-        // cannot `watch`) still stays registered in the `SubscriptionRegistry`
-        // until the client unsubscribes or the session ends — it occupies one
-        // of the 32 slots without ever firing. Evicting it would mean
-        // plumbing the registry (owned by `crates/mcp`) into this watcher
-        // (owned by the desktop app), which crosses a layer boundary; that is
-        // being filed as a follow-up rather than done here.
+        // resolved, so it cannot validate the subscription up front. What it
+        // CAN do is report the death once the task runs: `watch_object`
+        // returns only when the watch is genuinely over — client resolution
+        // failed (unknown context), a permanent watch error (RBAC
+        // `Forbidden`), or the stream ending; transient errors reconnect
+        // internally and never return. Any return therefore feeds `on_dead`,
+        // which the stdio loop uses to evict the registry entry (#195). An
+        // abort cancels the task at an await point, so `on_dead` never fires
+        // for a deliberate unsubscribe. Status transitions still go to
+        // stderr (stdout is the JSON-RPC channel on stdio — see `main.rs`).
         let watch_uri = uri.to_string();
         let task = tokio::spawn(async move {
             let result = srelens_kube::watch::watch_object(
@@ -104,9 +102,11 @@ impl ObjectWatcher for CacheWatcher {
                 },
             )
             .await;
-            if let Err(e) = result {
-                eprintln!("srelens: mcp watch {watch_uri} ended with an error: {e}");
-            }
+            let reason = match result {
+                Ok(()) => "the watch stream ended".to_string(),
+                Err(e) => e,
+            };
+            on_dead(reason);
         });
         Ok(task.abort_handle())
     }
@@ -129,9 +129,37 @@ mod tests {
         let w = CacheWatcher::new(cache);
         for uri in ["k8s://c/ns/Pod/web-0", "k8s://c/-/Node/node-1"] {
             let parsed = ResourceUri::parse(uri).unwrap();
-            let handle = w.watch(&parsed, Box::new(|| {})).expect("spawns");
+            let handle = w.watch(&parsed, Box::new(|| {}), Box::new(|_| {})).expect("spawns");
             handle.abort();
         }
+    }
+
+    /// The #195 contract: a watch that can never run (here: the kubeconfig
+    /// doesn't exist, so client resolution fails) must report through
+    /// `on_dead` with the underlying reason — that callback is how the stdio
+    /// loop evicts the registry entry.
+    #[tokio::test]
+    async fn reports_death_for_an_unresolvable_context() {
+        let cache = srelens_kube::client_cache::ClientCache::new(
+            std::path::PathBuf::from("/nonexistent/kubeconfig"),
+        );
+        let w = CacheWatcher::new(cache);
+        let parsed = ResourceUri::parse("k8s://c/ns/Pod/web-0").unwrap();
+        let (tx, rx) = tokio::sync::oneshot::channel::<String>();
+        let _handle = w
+            .watch(
+                &parsed,
+                Box::new(|| {}),
+                Box::new(move |reason| {
+                    let _ = tx.send(reason);
+                }),
+            )
+            .expect("spawns");
+        let reason = tokio::time::timeout(std::time::Duration::from_secs(10), rx)
+            .await
+            .expect("on_dead fires")
+            .expect("reason arrives");
+        assert!(!reason.is_empty(), "the death carries its reason");
     }
 
     #[tokio::test]
@@ -141,7 +169,7 @@ mod tests {
         );
         let w = CacheWatcher::new(cache);
         let parsed = ResourceUri::parse("k8s://c/ns/Nonsense/x").unwrap();
-        assert!(w.watch(&parsed, Box::new(|| {})).is_err());
+        assert!(w.watch(&parsed, Box::new(|| {}), Box::new(|_| {})).is_err());
     }
 
     /// `ResourceUri::parse` maps the `-` sentinel to `None`, so a namespaced
@@ -155,7 +183,7 @@ mod tests {
         );
         let w = CacheWatcher::new(cache);
         let parsed = ResourceUri::parse("k8s://c/-/Pod/web-0").unwrap();
-        let err = w.watch(&parsed, Box::new(|| {})).unwrap_err();
+        let err = w.watch(&parsed, Box::new(|| {}), Box::new(|_| {})).unwrap_err();
         assert!(err.contains("namespaced"), "got: {err}");
     }
 
@@ -168,7 +196,7 @@ mod tests {
         );
         let w = CacheWatcher::new(cache);
         let parsed = ResourceUri::parse("k8s://c/ns/Node/node-1").unwrap();
-        let err = w.watch(&parsed, Box::new(|| {})).unwrap_err();
+        let err = w.watch(&parsed, Box::new(|| {}), Box::new(|_| {})).unwrap_err();
         assert!(err.contains("cluster-scoped"), "got: {err}");
     }
 
@@ -185,7 +213,7 @@ mod tests {
         );
         let w = CacheWatcher::new(cache);
         let parsed = ResourceUri::parse("k8s://c/ns/Secret/db-creds").unwrap();
-        let err = w.watch(&parsed, Box::new(|| {})).unwrap_err();
+        let err = w.watch(&parsed, Box::new(|| {}), Box::new(|_| {})).unwrap_err();
         assert!(err.contains("Secret") && err.contains("not addressable"), "got: {err}");
     }
 }

--- a/apps/desktop/src-tauri/tests/e2e.rs
+++ b/apps/desktop/src-tauri/tests/e2e.rs
@@ -1982,6 +1982,7 @@ async fn mcp_resource_subscription(ctx: &str, pod: &str) {
         server.watcher().as_ref(),
         &uri,
         Box::new(move || *counter.lock().unwrap() += 1),
+        Box::new(|reason| eprintln!("e2e watch reported dead: {reason}")),
     )
     .expect("watch spawns");
 

--- a/crates/mcp/src/resources.rs
+++ b/crates/mcp/src/resources.rs
@@ -163,11 +163,22 @@ impl KindResolver for NoKinds {
 /// A trait rather than a concrete type because the implementation needs kube,
 /// and `crates/mcp` must not depend on `crates/kube` — `crates/registry` wires
 /// the real one, exactly as it does for `KindResolver`.
+///
+/// `on_dead` reports terminal failure: it is called AT MOST ONCE, with a
+/// human-readable reason, when the watch ends for any cause other than the
+/// returned handle being aborted — unknown context, RBAC `Forbidden`, the
+/// stream ending. `watch` itself is synchronous and returns before the
+/// cluster is ever contacted, so this callback is the only way the caller
+/// learns a subscription it already accepted will never fire; the stdio loop
+/// uses it to evict the registry entry (#195). `on_dead` may fire at any
+/// point — including synchronously inside `watch`, or concurrently with the
+/// caller still processing `watch`'s return.
 pub trait ObjectWatcher: Send + Sync {
     fn watch(
         &self,
         uri: &ResourceUri,
         on_change: Box<dyn FnMut() + Send>,
+        on_dead: Box<dyn FnOnce(String) + Send>,
     ) -> Result<tokio::task::AbortHandle, String>;
 }
 
@@ -180,6 +191,7 @@ impl ObjectWatcher for NoWatcher {
         &self,
         _uri: &ResourceUri,
         _on_change: Box<dyn FnMut() + Send>,
+        _on_dead: Box<dyn FnOnce(String) + Send>,
     ) -> Result<tokio::task::AbortHandle, String> {
         Err("this server has no cluster watcher wired, so resources cannot be subscribed to"
             .to_string())
@@ -456,7 +468,7 @@ mod tests {
     #[test]
     fn the_default_watcher_refuses_every_subscription() {
         let uri = ResourceUri::parse("k8s://c/ns/Pod/web-0").unwrap();
-        let err = NoWatcher.watch(&uri, Box::new(|| {})).unwrap_err();
+        let err = NoWatcher.watch(&uri, Box::new(|| {}), Box::new(|_| {})).unwrap_err();
         assert!(err.contains("no cluster watcher"), "got: {err}");
     }
 

--- a/crates/mcp/src/stdio.rs
+++ b/crates/mcp/src/stdio.rs
@@ -443,16 +443,27 @@ fn handle_subscription(
     // into an error — strictly better than accepting a subscription known to
     // be stillborn.
     let dead: std::sync::Arc<std::sync::Mutex<Option<String>>> = Default::default();
+    // This watch's registry generation, filled in right after `insert`. The
+    // callback evicts through `remove_if` with THIS token only — a client may
+    // re-subscribe the same URI while `on_dead` is in flight, and an
+    // unconditional remove would abort the replacement watch, leaving the
+    // client subscribed to nothing while believing otherwise. `None` means
+    // the death beat the insert; the post-insert check below owns that case.
+    let my_generation: std::sync::Arc<std::sync::Mutex<Option<u64>>> = Default::default();
     let on_dead = {
         let dead = dead.clone();
+        let my_generation = my_generation.clone();
         let subs = subs.clone();
         let dead_uri = canonical.clone();
         Box::new(move |reason: String| {
             eprintln!("srelens: mcp watch {dead_uri} evicted: {reason}");
             *dead.lock().unwrap_or_else(|e| e.into_inner()) = Some(reason);
-            if subs.remove(&dead_uri) {
-                dead_dirty.lock().unwrap_or_else(|e| e.into_inner()).insert(dead_uri.clone());
-                let _ = dead_wake.try_send(());
+            let generation = *my_generation.lock().unwrap_or_else(|e| e.into_inner());
+            if let Some(generation) = generation {
+                if subs.remove_if(&dead_uri, generation) {
+                    dead_dirty.lock().unwrap_or_else(|e| e.into_inner()).insert(dead_uri.clone());
+                    let _ = dead_wake.try_send(());
+                }
             }
         })
     };
@@ -461,11 +472,15 @@ fn handle_subscription(
         Ok(h) => h,
         Err(message) => return Some(err(id, -32602, &message)),
     };
-    if let Err(message) = subs.insert(canonical.clone(), handle) {
-        return Some(err(id, -32602, &message));
-    }
+    let generation = match subs.insert(canonical.clone(), handle) {
+        Ok(generation) => generation,
+        Err(message) => return Some(err(id, -32602, &message)),
+    };
+    *my_generation.lock().unwrap_or_else(|e| e.into_inner()) = Some(generation);
     if let Some(reason) = dead.lock().unwrap_or_else(|e| e.into_inner()).take() {
-        subs.remove(&canonical);
+        // Own generation only: a concurrent re-subscribe may already have
+        // replaced this entry, and that newer watch is not ours to evict.
+        subs.remove_if(&canonical, generation);
         return Some(err(id, -32603, &format!("the watch ended immediately: {reason}")));
     }
     Some(ok(id, json!({})))
@@ -1780,6 +1795,63 @@ mod tests {
             "the URI goes dirty so the client re-reads and discovers the death"
         );
         assert!(wake_rx.try_recv().is_ok(), "the serve loop must be woken to drain it");
+    }
+
+    /// The re-subscribe race on eviction: the first watch dies, and BEFORE
+    /// its `on_dead` runs, the client re-subscribes the same URI. The late
+    /// callback must not evict the replacement — the client would be
+    /// subscribed to nothing while holding a success response for it.
+    #[tokio::test]
+    async fn a_late_death_does_not_evict_the_watch_that_replaced_it() {
+        type OnDead = Box<dyn FnOnce(String) + Send>;
+        struct CollectingWatcher(std::sync::Mutex<Vec<OnDead>>);
+        impl crate::resources::ObjectWatcher for CollectingWatcher {
+            fn watch(
+                &self,
+                _uri: &crate::resources::ResourceUri,
+                _on_change: Box<dyn FnMut() + Send>,
+                on_dead: Box<dyn FnOnce(String) + Send>,
+            ) -> Result<tokio::task::AbortHandle, String> {
+                self.0.lock().unwrap().push(on_dead);
+                Ok(tokio::spawn(async { std::future::pending::<()>().await }).abort_handle())
+            }
+        }
+        struct Kinds;
+        impl crate::resources::KindResolver for Kinds {
+            fn scope(&self, kind: &str) -> Option<crate::resources::KindScope> {
+                (kind == "Pod").then_some(crate::resources::KindScope::Namespaced)
+            }
+        }
+        let watcher = Arc::new(CollectingWatcher(std::sync::Mutex::new(Vec::new())));
+        let server = Arc::new(
+            server_with_ping().with_resources(Arc::new(Kinds)).with_watcher(watcher.clone()),
+        );
+        let subs = Arc::new(crate::subscriptions::SubscriptionRegistry::new());
+        let dirty = Arc::new(std::sync::Mutex::new(std::collections::BTreeSet::new()));
+        let (wake_tx, _wake_rx) = tokio::sync::mpsc::channel(1);
+        let req = json!({"jsonrpc":"2.0","id":1,"method":"resources/subscribe",
+            "params":{"uri":"k8s://c/ns/Pod/web-0"}});
+
+        // Subscribe twice: the second replaces the first in the registry.
+        for _ in 0..2 {
+            let resp =
+                handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe")
+                    .unwrap();
+            assert!(resp.get("error").is_none(), "subscribe succeeds: {resp}");
+        }
+
+        // The FIRST watch's death arrives late.
+        let first_on_dead = watcher.0.lock().unwrap().remove(0);
+        first_on_dead("forbidden".to_string());
+
+        assert!(
+            !dirty.lock().unwrap().contains("k8s://c/ns/Pod/web-0"),
+            "no notification for an eviction that must not happen"
+        );
+        assert!(
+            subs.remove("k8s://c/ns/Pod/web-0"),
+            "the replacement watch must still be subscribed"
+        );
     }
 
     /// The coalescing this closes: without it, 5 `on_change` calls to one

--- a/crates/mcp/src/stdio.rs
+++ b/crates/mcp/src/stdio.rs
@@ -404,6 +404,10 @@ fn handle_subscription(
         return Some(err(id, -32602, &message));
     }
 
+    // Both callbacks below need the dirty set and wakeup sender; clone before
+    // the first closure takes ownership of its pair.
+    let (dead_dirty, dead_wake) = (dirty.clone(), wake.clone());
+
     // The callback is sync and owns only the dirty set and a wakeup sender,
     // so it needs no writer and no spawn. It never awaits, so the dirty
     // set's lock is only ever held for the insert itself — matching the
@@ -424,12 +428,45 @@ fn handle_subscription(
         let _ = wake.try_send(());
     });
 
-    let handle = match server.watcher().watch(&uri, on_change) {
+    // Terminal-failure path (#195): a watch that dies — unknown context,
+    // RBAC Forbidden, stream end — must not sit in the registry forever,
+    // holding a slot and letting the client mistake silence for "nothing
+    // changed". `on_dead` evicts the entry and, when one was actually
+    // registered, marks the URI dirty so the client's re-read discovers the
+    // terminal state through the existing notification channel.
+    //
+    // `on_dead` may fire at ANY point relative to this function — including
+    // before `subs.insert` below has run, in which case its `remove` finds
+    // nothing and the insert would park a dead handle. The shared `dead`
+    // slot closes that race: the post-insert check sees the reason whichever
+    // side wins, removes the entry, and turns the subscribe response itself
+    // into an error — strictly better than accepting a subscription known to
+    // be stillborn.
+    let dead: std::sync::Arc<std::sync::Mutex<Option<String>>> = Default::default();
+    let on_dead = {
+        let dead = dead.clone();
+        let subs = subs.clone();
+        let dead_uri = canonical.clone();
+        Box::new(move |reason: String| {
+            eprintln!("srelens: mcp watch {dead_uri} evicted: {reason}");
+            *dead.lock().unwrap_or_else(|e| e.into_inner()) = Some(reason);
+            if subs.remove(&dead_uri) {
+                dead_dirty.lock().unwrap_or_else(|e| e.into_inner()).insert(dead_uri.clone());
+                let _ = dead_wake.try_send(());
+            }
+        })
+    };
+
+    let handle = match server.watcher().watch(&uri, on_change, on_dead) {
         Ok(h) => h,
         Err(message) => return Some(err(id, -32602, &message)),
     };
-    if let Err(message) = subs.insert(canonical, handle) {
+    if let Err(message) = subs.insert(canonical.clone(), handle) {
         return Some(err(id, -32602, &message));
+    }
+    if let Some(reason) = dead.lock().unwrap_or_else(|e| e.into_inner()).take() {
+        subs.remove(&canonical);
+        return Some(err(id, -32603, &format!("the watch ended immediately: {reason}")));
     }
     Some(ok(id, json!({})))
 }
@@ -1171,6 +1208,7 @@ mod tests {
                 &self,
                 _uri: &crate::resources::ResourceUri,
                 _on_change: Box<dyn FnMut() + Send>,
+                _on_dead: Box<dyn FnOnce(String) + Send>,
             ) -> Result<tokio::task::AbortHandle, String> {
                 Ok(tokio::spawn(async { std::future::pending::<()>().await }).abort_handle())
             }
@@ -1441,6 +1479,7 @@ mod tests {
             &self,
             _uri: &crate::resources::ResourceUri,
             mut on_change: Box<dyn FnMut() + Send>,
+                _on_dead: Box<dyn FnOnce(String) + Send>,
         ) -> Result<tokio::task::AbortHandle, String> {
             let fired = self.0.clone();
             Ok(tokio::spawn(async move {
@@ -1570,6 +1609,7 @@ mod tests {
                 &self,
                 _uri: &crate::resources::ResourceUri,
                 mut on_change: Box<dyn FnMut() + Send>,
+                _on_dead: Box<dyn FnOnce(String) + Send>,
             ) -> Result<tokio::task::AbortHandle, String> {
                 on_change();
                 Ok(tokio::spawn(async { std::future::pending::<()>().await }).abort_handle())
@@ -1633,6 +1673,7 @@ mod tests {
             &self,
             _uri: &crate::resources::ResourceUri,
             mut on_change: Box<dyn FnMut() + Send>,
+                _on_dead: Box<dyn FnOnce(String) + Send>,
         ) -> Result<tokio::task::AbortHandle, String> {
             let fired = self.fired.clone();
             let times = self.times;
@@ -1645,6 +1686,100 @@ mod tests {
             })
             .abort_handle())
         }
+    }
+
+    /// The immediate-death half of eviction (#195): `on_dead` fires inside
+    /// `watch()` itself — before `handle_subscription` has inserted anything
+    /// — so the registry briefly parks a dead handle. The post-insert check
+    /// must catch it: the subscribe answers an ERROR (not a phantom `{}`)
+    /// and nothing stays registered.
+    #[tokio::test]
+    async fn a_watch_that_dies_immediately_errors_the_subscribe_and_leaves_no_entry() {
+        struct DeadOnArrival;
+        impl crate::resources::ObjectWatcher for DeadOnArrival {
+            fn watch(
+                &self,
+                _uri: &crate::resources::ResourceUri,
+                _on_change: Box<dyn FnMut() + Send>,
+                on_dead: Box<dyn FnOnce(String) + Send>,
+            ) -> Result<tokio::task::AbortHandle, String> {
+                on_dead("the cluster is unreachable".to_string());
+                Ok(tokio::spawn(async { std::future::pending::<()>().await }).abort_handle())
+            }
+        }
+        struct Kinds;
+        impl crate::resources::KindResolver for Kinds {
+            fn scope(&self, kind: &str) -> Option<crate::resources::KindScope> {
+                (kind == "Pod").then_some(crate::resources::KindScope::Namespaced)
+            }
+        }
+        let server = Arc::new(
+            server_with_ping().with_resources(Arc::new(Kinds)).with_watcher(Arc::new(DeadOnArrival)),
+        );
+        let subs = Arc::new(crate::subscriptions::SubscriptionRegistry::new());
+        let dirty = Arc::new(std::sync::Mutex::new(std::collections::BTreeSet::new()));
+        let (wake_tx, _wake_rx) = tokio::sync::mpsc::channel(1);
+        let req = json!({"jsonrpc":"2.0","id":1,"method":"resources/subscribe",
+            "params":{"uri":"k8s://c/ns/Pod/web-0"}});
+        let resp =
+            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe")
+                .unwrap();
+        let message = resp["error"]["message"].as_str().unwrap_or_default();
+        assert!(message.contains("ended immediately"), "got: {resp}");
+        assert!(message.contains("unreachable"), "the reason must survive: {resp}");
+        // Nothing left holding a slot: an unsubscribe finds no entry.
+        assert!(!subs.remove("k8s://c/ns/Pod/web-0"));
+    }
+
+    /// The late-death half of eviction (#195): the subscribe succeeded and
+    /// the watch dies LATER (RBAC revoked, apiserver gone for good). The
+    /// entry must leave the registry — silence must not impersonate "nothing
+    /// changed" while holding one of the 32 slots — and the URI goes dirty
+    /// so the client's re-read discovers the terminal state.
+    #[tokio::test]
+    async fn a_watch_death_after_subscribe_evicts_the_entry_and_queues_a_notification() {
+        type OnDead = Box<dyn FnOnce(String) + Send>;
+        struct LateDeath(std::sync::Mutex<Option<OnDead>>);
+        impl crate::resources::ObjectWatcher for LateDeath {
+            fn watch(
+                &self,
+                _uri: &crate::resources::ResourceUri,
+                _on_change: Box<dyn FnMut() + Send>,
+                on_dead: Box<dyn FnOnce(String) + Send>,
+            ) -> Result<tokio::task::AbortHandle, String> {
+                *self.0.lock().unwrap() = Some(on_dead);
+                Ok(tokio::spawn(async { std::future::pending::<()>().await }).abort_handle())
+            }
+        }
+        struct Kinds;
+        impl crate::resources::KindResolver for Kinds {
+            fn scope(&self, kind: &str) -> Option<crate::resources::KindScope> {
+                (kind == "Pod").then_some(crate::resources::KindScope::Namespaced)
+            }
+        }
+        let watcher = Arc::new(LateDeath(std::sync::Mutex::new(None)));
+        let server = Arc::new(
+            server_with_ping().with_resources(Arc::new(Kinds)).with_watcher(watcher.clone()),
+        );
+        let subs = Arc::new(crate::subscriptions::SubscriptionRegistry::new());
+        let dirty = Arc::new(std::sync::Mutex::new(std::collections::BTreeSet::new()));
+        let (wake_tx, mut wake_rx) = tokio::sync::mpsc::channel(1);
+        let req = json!({"jsonrpc":"2.0","id":1,"method":"resources/subscribe",
+            "params":{"uri":"k8s://c/ns/Pod/web-0"}});
+        let resp =
+            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe")
+                .unwrap();
+        assert!(resp.get("error").is_none(), "the live subscribe succeeds: {resp}");
+
+        // The watch dies later.
+        (watcher.0.lock().unwrap().take().unwrap())("forbidden: cannot watch pods".to_string());
+
+        assert!(!subs.remove("k8s://c/ns/Pod/web-0"), "the dead entry must be evicted");
+        assert!(
+            dirty.lock().unwrap().contains("k8s://c/ns/Pod/web-0"),
+            "the URI goes dirty so the client re-reads and discovers the death"
+        );
+        assert!(wake_rx.try_recv().is_ok(), "the serve loop must be woken to drain it");
     }
 
     /// The coalescing this closes: without it, 5 `on_change` calls to one
@@ -1719,6 +1854,7 @@ mod tests {
                 &self,
                 uri: &crate::resources::ResourceUri,
                 mut on_change: Box<dyn FnMut() + Send>,
+                _on_dead: Box<dyn FnOnce(String) + Send>,
             ) -> Result<tokio::task::AbortHandle, String> {
                 let fired = if uri.to_string().contains("web-0") {
                     self.fired_a.clone()
@@ -1802,6 +1938,7 @@ mod tests {
                 &self,
                 _uri: &crate::resources::ResourceUri,
                 _on_change: Box<dyn FnMut() + Send>,
+                _on_dead: Box<dyn FnOnce(String) + Send>,
             ) -> Result<tokio::task::AbortHandle, String> {
                 let join = tokio::spawn(async { std::future::pending::<()>().await });
                 let abort = join.abort_handle();

--- a/crates/mcp/src/stdio.rs
+++ b/crates/mcp/src/stdio.rs
@@ -472,14 +472,29 @@ fn handle_subscription(
         Ok(h) => h,
         Err(message) => return Some(err(id, -32602, &message)),
     };
+    // Death BEFORE commitment: check before `insert`, because on a
+    // re-subscribe `insert` replaces AND ABORTS the prior still-live watch —
+    // a replacement that was stillborn (the trait allows `on_dead` inside
+    // `watch()` itself) must cost the client an error response, not the
+    // working subscription they already had. The failed handle is aborted
+    // here since it never reaches the registry's ownership.
+    if let Some(reason) = dead.lock().unwrap_or_else(|e| e.into_inner()).take() {
+        handle.abort();
+        return Some(err(id, -32603, &format!("the watch ended immediately: {reason}")));
+    }
     let generation = match subs.insert(canonical.clone(), handle) {
         Ok(generation) => generation,
         Err(message) => return Some(err(id, -32602, &message)),
     };
     *my_generation.lock().unwrap_or_else(|e| e.into_inner()) = Some(generation);
     if let Some(reason) = dead.lock().unwrap_or_else(|e| e.into_inner()).take() {
-        // Own generation only: a concurrent re-subscribe may already have
-        // replaced this entry, and that newer watch is not ours to evict.
+        // A death that lost the race with the check above and landed after
+        // the commit. Own generation only: a concurrent re-subscribe may
+        // already have replaced this entry, and that newer watch is not ours
+        // to evict. On a re-subscribe the prior watch is gone by now
+        // (replaced at commit) — that residual few-instruction window is the
+        // cost of `watch` being synchronous; the client still learns the
+        // truth from the error response.
         subs.remove_if(&canonical, generation);
         return Some(err(id, -32603, &format!("the watch ended immediately: {reason}")));
     }
@@ -1795,6 +1810,61 @@ mod tests {
             "the URI goes dirty so the client re-reads and discovers the death"
         );
         assert!(wake_rx.try_recv().is_ok(), "the serve loop must be woken to drain it");
+    }
+
+    /// A stillborn REPLACEMENT must not cost the client the working watch it
+    /// already had: the death check runs before `insert`, which is what
+    /// replaces (and aborts) the prior entry on a re-subscribe. The failed
+    /// attempt answers an error; the original subscription stays live.
+    #[tokio::test]
+    async fn a_replacement_that_dies_immediately_leaves_the_prior_watch_subscribed() {
+        struct DiesOnSecondWatch(std::sync::atomic::AtomicUsize);
+        impl crate::resources::ObjectWatcher for DiesOnSecondWatch {
+            fn watch(
+                &self,
+                _uri: &crate::resources::ResourceUri,
+                _on_change: Box<dyn FnMut() + Send>,
+                on_dead: Box<dyn FnOnce(String) + Send>,
+            ) -> Result<tokio::task::AbortHandle, String> {
+                if self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst) > 0 {
+                    on_dead("the cluster went away".to_string());
+                }
+                Ok(tokio::spawn(async { std::future::pending::<()>().await }).abort_handle())
+            }
+        }
+        struct Kinds;
+        impl crate::resources::KindResolver for Kinds {
+            fn scope(&self, kind: &str) -> Option<crate::resources::KindScope> {
+                (kind == "Pod").then_some(crate::resources::KindScope::Namespaced)
+            }
+        }
+        let server = Arc::new(server_with_ping().with_resources(Arc::new(Kinds)).with_watcher(
+            Arc::new(DiesOnSecondWatch(std::sync::atomic::AtomicUsize::new(0))),
+        ));
+        let subs = Arc::new(crate::subscriptions::SubscriptionRegistry::new());
+        let dirty = Arc::new(std::sync::Mutex::new(std::collections::BTreeSet::new()));
+        let (wake_tx, _wake_rx) = tokio::sync::mpsc::channel(1);
+        let req = json!({"jsonrpc":"2.0","id":1,"method":"resources/subscribe",
+            "params":{"uri":"k8s://c/ns/Pod/web-0"}});
+
+        let first =
+            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe")
+                .unwrap();
+        assert!(first.get("error").is_none(), "the first subscribe succeeds: {first}");
+
+        // The re-subscribe's replacement watch is stillborn.
+        let second =
+            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe")
+                .unwrap();
+        assert!(
+            second["error"]["message"].as_str().unwrap_or_default().contains("ended immediately"),
+            "the failed re-subscribe answers an error: {second}"
+        );
+
+        assert!(
+            subs.remove("k8s://c/ns/Pod/web-0"),
+            "the ORIGINAL watch must still be subscribed — the failed replacement never touched it"
+        );
     }
 
     /// The re-subscribe race on eviction: the first watch dies, and BEFORE

--- a/crates/mcp/src/subscriptions.rs
+++ b/crates/mcp/src/subscriptions.rs
@@ -18,7 +18,18 @@ pub const MAX_SUBSCRIPTIONS: usize = 32;
 /// await.
 #[derive(Default)]
 pub struct SubscriptionRegistry {
-    live: Mutex<BTreeMap<String, AbortHandle>>,
+    live: Mutex<BTreeMap<String, Entry>>,
+    /// Monotonic id stamped onto each stored entry, so a watch's own
+    /// `on_dead` can prove the entry it is about to evict is still ITS watch
+    /// (see `remove_if`) — a re-subscribe may have replaced it in the
+    /// meantime, and evicting the replacement would silently unsubscribe a
+    /// live watch the client believes in.
+    next_generation: std::sync::atomic::AtomicU64,
+}
+
+struct Entry {
+    generation: u64,
+    handle: AbortHandle,
 }
 
 impl SubscriptionRegistry {
@@ -35,7 +46,9 @@ impl SubscriptionRegistry {
     /// before returning, since a rejected watch is useless by definition and
     /// the caller has no reference left to clean it up. Callers never need to
     /// abort on `Err`.
-    pub fn insert(&self, uri: String, handle: AbortHandle) -> Result<(), String> {
+    ///
+    /// Returns the stored entry's generation — the token `remove_if` needs.
+    pub fn insert(&self, uri: String, handle: AbortHandle) -> Result<u64, String> {
         let mut live = self.live.lock().unwrap_or_else(|e| e.into_inner());
         if !live.contains_key(&uri) && live.len() >= MAX_SUBSCRIPTIONS {
             // Before refusing, reap entries whose watch task already ended
@@ -43,7 +56,7 @@ impl SubscriptionRegistry {
             // callback, but a dead entry that slipped past it must not hold
             // a slot against a legitimate subscription. `is_finished` is
             // false for live watches, so this never evicts a working one.
-            live.retain(|_, h| !h.is_finished());
+            live.retain(|_, e| !e.handle.is_finished());
         }
         if !live.contains_key(&uri) && live.len() >= MAX_SUBSCRIPTIONS {
             handle.abort();
@@ -52,21 +65,43 @@ impl SubscriptionRegistry {
                  unsubscribe from something first"
             ));
         }
-        if let Some(previous) = live.insert(uri, handle) {
-            previous.abort();
+        let generation = self
+            .next_generation
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if let Some(previous) = live.insert(uri, Entry { generation, handle }) {
+            previous.handle.abort();
         }
-        Ok(())
+        Ok(generation)
     }
 
     /// Abort and forget `uri`. Returns whether it was subscribed.
     pub fn remove(&self, uri: &str) -> bool {
         let mut live = self.live.lock().unwrap_or_else(|e| e.into_inner());
         match live.remove(uri) {
-            Some(handle) => {
-                handle.abort();
+            Some(entry) => {
+                entry.handle.abort();
                 true
             }
             None => false,
+        }
+    }
+
+    /// Abort and forget `uri` ONLY if the stored entry still carries
+    /// `generation` — i.e. it is still the watch that obtained that token
+    /// from `insert`. The eviction path for a dead watch's `on_dead`
+    /// callback: a client may have re-subscribed the same URI while the
+    /// callback was in flight, and unconditional removal would abort the
+    /// replacement — leaving the client subscribed to nothing while
+    /// believing otherwise. Returns whether an entry was removed.
+    pub fn remove_if(&self, uri: &str, generation: u64) -> bool {
+        let mut live = self.live.lock().unwrap_or_else(|e| e.into_inner());
+        match live.get(uri) {
+            Some(entry) if entry.generation == generation => {
+                let entry = live.remove(uri).expect("checked present under the same lock");
+                entry.handle.abort();
+                true
+            }
+            _ => false,
         }
     }
 
@@ -82,8 +117,8 @@ impl SubscriptionRegistry {
     /// outlives the session.
     pub fn abort_all(&self) {
         let mut live = self.live.lock().unwrap_or_else(|e| e.into_inner());
-        for handle in live.values() {
-            handle.abort();
+        for entry in live.values() {
+            entry.handle.abort();
         }
         live.clear();
     }
@@ -175,6 +210,26 @@ mod tests {
         let e = r.insert("k8s://c/ns/Pod/one-too-many".into(), spawn_forever()).unwrap_err();
         assert!(e.contains(&MAX_SUBSCRIPTIONS.to_string()), "got: {e}");
         assert_eq!(r.len(), MAX_SUBSCRIPTIONS);
+    }
+
+    /// A dead watch's late `on_dead` must not evict the watch that REPLACED
+    /// it: `remove_if` only removes when the stored generation still matches
+    /// the caller's token.
+    #[tokio::test]
+    async fn remove_if_spares_a_replacement_watch() {
+        let r = SubscriptionRegistry::new();
+        let stale = r.insert("k8s://c/ns/Pod/a".into(), spawn_forever()).unwrap();
+        let (fresh_handle, fresh_join) = spawn_forever_joined();
+        let fresh = r.insert("k8s://c/ns/Pod/a".into(), fresh_handle).unwrap();
+
+        // The first watch died and its callback arrives late, carrying the
+        // stale token — the replacement must survive.
+        assert!(!r.remove_if("k8s://c/ns/Pod/a", stale));
+        assert_eq!(r.len(), 1, "the replacement watch stays subscribed");
+
+        // The replacement's own token still evicts it.
+        assert!(r.remove_if("k8s://c/ns/Pod/a", fresh));
+        assert_aborted(fresh_join).await;
     }
 
     /// The cheap half of #195: entries whose watch task already ended must

--- a/crates/mcp/src/subscriptions.rs
+++ b/crates/mcp/src/subscriptions.rs
@@ -38,6 +38,14 @@ impl SubscriptionRegistry {
     pub fn insert(&self, uri: String, handle: AbortHandle) -> Result<(), String> {
         let mut live = self.live.lock().unwrap_or_else(|e| e.into_inner());
         if !live.contains_key(&uri) && live.len() >= MAX_SUBSCRIPTIONS {
+            // Before refusing, reap entries whose watch task already ended
+            // (#195): the honest eviction path is the watcher's `on_dead`
+            // callback, but a dead entry that slipped past it must not hold
+            // a slot against a legitimate subscription. `is_finished` is
+            // false for live watches, so this never evicts a working one.
+            live.retain(|_, h| !h.is_finished());
+        }
+        if !live.contains_key(&uri) && live.len() >= MAX_SUBSCRIPTIONS {
             handle.abort();
             return Err(format!(
                 "too many subscriptions: the limit is {MAX_SUBSCRIPTIONS}; \
@@ -167,6 +175,30 @@ mod tests {
         let e = r.insert("k8s://c/ns/Pod/one-too-many".into(), spawn_forever()).unwrap_err();
         assert!(e.contains(&MAX_SUBSCRIPTIONS.to_string()), "got: {e}");
         assert_eq!(r.len(), MAX_SUBSCRIPTIONS);
+    }
+
+    /// The cheap half of #195: entries whose watch task already ended must
+    /// not hold slots against a legitimate subscription — the cap check
+    /// reaps them before refusing. (The honest path is the watcher's
+    /// `on_dead` eviction; this is the backstop for a watcher that never
+    /// reports.)
+    #[tokio::test]
+    async fn dead_entries_are_reaped_before_the_cap_refuses() {
+        let r = SubscriptionRegistry::new();
+        for i in 0..MAX_SUBSCRIPTIONS {
+            // A task that completes instantly, awaited to completion so
+            // `is_finished` is deterministically true by insert time.
+            let join = tokio::spawn(async {});
+            let handle = join.abort_handle();
+            join.await.unwrap();
+            r.insert(format!("k8s://c/ns/Pod/dead{i}"), handle).unwrap();
+        }
+        assert_eq!(r.len(), MAX_SUBSCRIPTIONS, "dead entries fill the registry");
+        // At the cap, but every occupant is dead — the new subscription must
+        // get a slot, not `too many subscriptions`.
+        r.insert("k8s://c/ns/Pod/alive".into(), spawn_forever())
+            .expect("reaping the dead entries makes room");
+        assert_eq!(r.len(), 1, "only the live subscription remains");
     }
 
     /// `insert` takes ownership of `handle`; on the cap-rejection branch it


### PR DESCRIPTION
Fixes #195.

## What

Implements the issue's preferred option — a completion callback — plus its cheap mitigation as a backstop:

- **`ObjectWatcher::watch` gains `on_dead: Box<dyn FnOnce(String) + Send>`**, called at most once with the reason when the watch ends for any cause other than an abort. The registry stays inside `crates/mcp`; no layer boundary is crossed.
- **`CacheWatcher` reports every death**: `watch_object` returns only when the watch is genuinely over (client resolution failure, permanent watch error; transients reconnect internally and never return), so any return feeds `on_dead`. An abort cancels the task at an await point, so a deliberate unsubscribe never fires it. The stale NOTE documenting this gap is gone.
- **`handle_subscription` evicts**: on death it removes the registry entry and marks the URI dirty (existing notification channel), so the client re-reads and discovers the terminal state instead of mistaking silence for "nothing changed".
- **The insert race is closed**: `on_dead` may fire before `subs.insert` has run (synchronously inside `watch`, even). A shared dead-slot makes the post-insert check catch either ordering — and an immediately-dead subscribe now answers an **error** (with the reason) instead of a phantom `{}`.
- **Cap-time reaping** (the issue's cheap mitigation): `SubscriptionRegistry::insert` reaps entries whose task already finished before refusing with `too many subscriptions`, as the backstop for any watcher that never reports. `is_finished` is false for live watches, so a working subscription is never evicted.

## Testing

- stdio: immediately-dead subscribe → error response carrying the reason, nothing registered; late death → entry evicted, URI dirty, serve loop woken.
- registry: 32 dead entries at the cap reap away and the live subscription gets its slot.
- `CacheWatcher`: unresolvable context → `on_dead` fires with a reason (real spawn, real failure).
- Full `srelens-mcp` (215) and `srelens-desktop` (146) suites green; e2e watch test updated for the new signature.