### PR TITLE
refactor(mcp): prompt bodies state the goal and the pitfalls, not a predicate

### DIFF
--- a/crates/mcp/src/prompts/node-pressure.discover.md
+++ b/crates/mcp/src/prompts/node-pressure.discover.md
@@ -9,45 +9,41 @@ arguments:
 No node was named, so find which nodes on context `{{context}}` are under pressure,
 then explain why.
 
-1. Call `k8s.listNodes` with `context: {{context}}`. It reports readiness and
-   schedulability, but not pressure conditions or capacity. Flag any node
-   that is not `Ready` or is unschedulable as an immediate candidate — but do
-   not stop there: a node under `MemoryPressure`, `DiskPressure` or
-   `PIDPressure` can still report `Ready` and schedulable, so this list alone
-   cannot rule a node out.
-2. Call `k8s.nodeMetrics` with `context: {{context}}` for raw cpu and memory
-   use per node. Raw usage cannot be used to shortlist which nodes to inspect
-   next: in a heterogeneous cluster a nearly-exhausted small node can report
-   lower raw usage than a large, healthy one, so ranking on the raw number
-   before reading capacity would let the actually-pressured node fall out of
-   consideration.
-3. Pressure conditions live only on the Node object itself, and step 1's
-   `Ready` status does not reveal them, so read every node's object BEFORE
-   shortlisting: for each node returned in step 1, Call `k8s.getObject` with
-   `context: {{context}}`, `kind: Node`, `name: <node>`. This is one call per
-   node — on a large cluster, say plainly how many nodes were sampled rather
-   than silently truncating the list. Read `status.conditions` for
-   `MemoryPressure`, `DiskPressure` and `PIDPressure`, and `status.capacity` /
-   `status.allocatable` to turn step 2's raw usage into a percentage of each
-   node's own capacity.
-4. Rank nodes by usage-as-a-fraction-of-capacity from step 3, not by step 2's
-   raw usage, and combine that ranking with any pressure condition or
-   not-Ready/unschedulable flag found in steps 1 and 3. Take the worst node.
-5. Call `k8s.listEvents` with `context: {{context}}`,
-   `objectKind: Node`, `objectName: <node>`. Look for eviction and
-   `SystemOOM` events.
-6. Call `k8s.listPods` with `context: {{context}}`, `namespace: ""` and keep
-   the pods scheduled on that node. `k8s.podMetrics` reports only
-   `cpuMillicores` and `memoryMiB`, so a ranking is only possible for
-   `MemoryPressure`. For `DiskPressure` or `PIDPressure`, no capability
-   reports per-pod disk or PID-count usage, so the responsible workload
-   cannot be determined this way — say that plainly instead of ranking by an
-   unrelated number. For `MemoryPressure`: Call `k8s.podMetrics` with
-   `context: {{context}}`. Rank those pods by memory use, then for the top
-   consumers, Call `k8s.getObject` with `context: {{context}}`, `kind: Pod`,
-   `namespace: <the pod's namespace>`, `name: <the pod>`. Compare usage
-   against `resources.requests` and `.limits`.
-7. If no node is under pressure, say so and report the closest one to its limit.
+The evidence:
+
+- Call `k8s.listNodes` with `context: {{context}}`. Not-`Ready` or
+  unschedulable nodes are immediate candidates — but this list cannot rule a
+  node OUT (first pitfall).
+- Call `k8s.nodeMetrics` with `context: {{context}}` for raw cpu and memory
+  use per node.
+- For each node, Call `k8s.getObject` with `context: {{context}}`,
+  `kind: Node`, `name: <node>`. Read `status.conditions` for the pressure
+  flags and `status.capacity` / `status.allocatable` to turn raw use into a
+  fraction of that node's own capacity. This is one call per node — on a
+  large cluster, say plainly how many nodes were sampled rather than
+  silently truncating.
+- For the worst node: Call `k8s.listEvents` with `context: {{context}}`,
+  `objectKind: Node`, `objectName: <node>`. Call `k8s.listPods` with
+  `context: {{context}}`, `namespace: ""` and keep its pods. Under
+  `MemoryPressure`, Call `k8s.podMetrics` with `context: {{context}}` and
+  rank by memory use. For the top consumers, Call `k8s.getObject` with
+  `context: {{context}}`, `kind: Pod`, `namespace: <the pod's namespace>`,
+  `name: <the pod>` and compare use against `resources.requests` and
+  `.limits`.
+
+Pitfalls — each of these has produced a wrong diagnosis before:
+
+- A node under `MemoryPressure`, `DiskPressure` or `PIDPressure` can still
+  report `Ready` and schedulable, and `listNodes` carries no pressure or
+  capacity detail — only the Node object does.
+- Rank by usage as a fraction of each node's OWN capacity, never by raw
+  usage: in a heterogeneous cluster a nearly-exhausted small node reports
+  lower raw numbers than a large healthy one.
+- `podMetrics` reports only `cpuMillicores` and `memoryMiB`, so the
+  responsible workload can be ranked for `MemoryPressure` only; for disk or
+  PID pressure, say plainly that no capability reports per-pod usage.
+- If no node is under pressure, say so and report the closest one to its
+  limit.
 
 Then report: which nodes are affected, which resource, the workloads responsible,
 and the minimal fix as a `kubectl` command the user can review.

--- a/crates/mcp/src/prompts/node-pressure.targeted.md
+++ b/crates/mcp/src/prompts/node-pressure.targeted.md
@@ -10,36 +10,38 @@ arguments:
 Node `{{node}}` on context `{{context}}` is reporting pressure. Work out what is
 consuming it and what is at risk.
 
-1. Call `k8s.getObject` with `context: {{context}}`, `kind: Node`,
-   `name: {{node}}`. Read `status.conditions` for `MemoryPressure`,
-   `DiskPressure` and `PIDPressure`, `status.capacity` and
-   `status.allocatable` for what the node has to work with, and
-   `spec.unschedulable` / `spec.taints` for whether it is schedulable.
-   `k8s.listNodes` does not return any of this — only a name, a
-   Ready/NotReady/Unknown status, and a taint COUNT. A node can be under
-   pressure and still `Ready`.
-2. Call `k8s.nodeMetrics` with `context: {{context}}`. Compare actual cpu and
-   memory use against the capacity read in step 1. Pressure with usage still
-   far below capacity points at the kubelet's eviction thresholds rather than
-   at a genuinely busy node.
-3. Call `k8s.listEvents` with `context: {{context}}`, `objectKind: Node`,
-   `objectName: {{node}}`. Eviction and `SystemOOM` events name what the kubelet
-   already acted on.
-4. Call `k8s.listPods` with `context: {{context}}`, `namespace: ""` and keep
-   the pods whose `node` is `{{node}}` — an empty namespace lists
-   cluster-wide. `k8s.podMetrics` reports only `cpuMillicores` and
-   `memoryMiB`, so a ranking is only possible for `MemoryPressure`. For
-   `DiskPressure` or `PIDPressure`, no capability reports per-pod disk or
-   PID-count usage, so which workload is responsible cannot be determined
-   this way — tell the user that plainly rather than ranking by an unrelated
-   number. For `MemoryPressure`: Call `k8s.podMetrics` with
-   `context: {{context}}` for their real usage and rank by memory
-   consumption.
-5. For the top consumers under `MemoryPressure`: Call `k8s.getObject` with
-   `context: {{context}}`, `kind: Pod`, `namespace: <the pod's namespace>`,
-   `name: <the pod>`. Compare usage against
-   `spec.containers[].resources.requests` and `.limits`. A pod using far more
-   than it requests is the one making the node's scheduling decisions wrong.
+The evidence:
+
+- Call `k8s.getObject` with `context: {{context}}`, `kind: Node`,
+  `name: {{node}}`. Read `status.conditions` for `MemoryPressure`,
+  `DiskPressure` and `PIDPressure`, `status.capacity` /
+  `status.allocatable` for what the node has to work with, and
+  `spec.unschedulable` / `spec.taints` for whether it is schedulable.
+- Call `k8s.nodeMetrics` with `context: {{context}}`. Compare actual use
+  against that capacity — pressure with usage still far below capacity
+  points at the kubelet's eviction thresholds, not a genuinely busy node.
+- Call `k8s.listEvents` with `context: {{context}}`, `objectKind: Node`,
+  `objectName: {{node}}`. Eviction and `SystemOOM` events name what the
+  kubelet already acted on.
+- Call `k8s.listPods` with `context: {{context}}`, `namespace: ""`. An empty
+  namespace lists cluster-wide; keep the pods whose `node` is `{{node}}`.
+  Under `MemoryPressure`, Call `k8s.podMetrics` with `context: {{context}}`
+  and rank those pods by memory use. For the top consumers, Call
+  `k8s.getObject` with `context: {{context}}`, `kind: Pod`,
+  `namespace: <the pod's namespace>`, `name: <the pod>` and compare use
+  against `spec.containers[].resources.requests` and `.limits` — a pod using
+  far more than it requests is what makes the node's scheduling decisions
+  wrong.
+
+Pitfalls — each of these has produced a wrong diagnosis before:
+
+- `listNodes` is a summary — a name, a Ready status, a taint COUNT. Pressure
+  conditions, capacity, and labels live only on the Node object, and a node
+  can be under pressure while still `Ready`.
+- `podMetrics` reports only `cpuMillicores` and `memoryMiB`, so a
+  responsible-workload ranking exists for `MemoryPressure` only. For
+  `DiskPressure` or `PIDPressure` no capability reports per-pod usage — say
+  that plainly instead of ranking by an unrelated number.
 
 Then tell the user: which resource is under pressure, the workloads responsible,
 which pods are at risk of eviction next, and the minimal fix as a `kubectl` command

--- a/crates/mcp/src/prompts/pod-crashloop.discover.md
+++ b/crates/mcp/src/prompts/pod-crashloop.discover.md
@@ -10,63 +10,37 @@ arguments:
 No pod was named, so find the restarting pods on context `{{context}}` first, then
 triage them. Use only srelens tools.
 
-1. Call `k8s.listPods` with `context: {{context}}`, `namespace: {{namespace}}`.
-   An empty namespace lists across all namespaces. Each entry carries
-   `restarts`, `phase`, `ready`, `name` and `namespace`.
-2. Use `restarts` only as a cheap PRE-FILTER to narrow the field — it sums
-   lifetime `status.containerStatuses[]` counts and does not say which pod is
-   failing right now. Shortlist every pod with `restarts > 0`, plus every pod
-   whose `ready` count is below its total but `restarts` is exactly zero:
-   `restarts` sums only `status.containerStatuses[]`, and Kubernetes records
-   an init container's crash loop under `status.initContainerStatuses[]`
-   instead, so a pod repeatedly failing an init container reports zero
-   restarts here even though it IS crash-looping. Do not assume such a pod is
-   only an image pull or a slow readiness probe — step 3 confirms which it
-   is. Do not rank or cap this shortlist yet: a handful of long-healthy pods
-   with large historical `restarts` sums would outrank a pod that is
-   currently crash-looping with a smaller lifetime sum, and a high lifetime
-   count on an otherwise-healthy pod is an old incident, not a finding — only
-   reading the Pod object in step 3 can tell current from historical.
-3. For each shortlisted candidate, using its `name` and `namespace` from step
-   1: Call `k8s.getObject` with `context: {{context}}`, `kind: Pod`,
-   `namespace: <the candidate's namespace>`, `name: <the candidate's name>`.
-   Read `status.initContainerStatuses[]` AND `status.containerStatuses[]`
-   independently — neither excludes the other. A classic init container that
-   already ran to completion keeps a positive lifetime `restartCount` from an
-   earlier failure forever, and a native restartable init sidecar
-   (`spec.initContainers[]` whose `restartPolicy` is `Always`) keeps running
-   alongside the app containers indefinitely — app containers do NOT
-   necessarily wait for every init container to finish in that case. `state`
-   is what is true right now; `lastState` is what happened before and is
-   RETAINED even after the container recovers to `state.running` — so
-   neither `lastState` nor lifetime `restartCount` may decide which pod or
-   container is currently failing. An entry in either array counts as a
-   CURRENT crash source only if its own `state` shows a `waiting.reason` of
-   `CrashLoopBackOff`, or a `state.terminated` with a non-zero `exitCode` and
-   a `reason` other than `Completed`. Discard any shortlisted candidate with
-   no such entry in either array — for a zero-restart candidate from step 2
-   this means it is genuinely out of scope here (an image pull or a
-   readiness stall, not a crash loop); for a `restarts > 0` candidate this
-   means its high lifetime count is an old incident, not a finding — mention
-   it to the user separately and move on without calling `podLogs` or
-   `listEvents` for it. Order the pods that remain worst first —
-   `CrashLoopBackOff` in `state.waiting` first, then the most recent
-   `state.terminated.finishedAt`, lifetime `restartCount` only as a final
-   tie-break — and take the top three. For each: pool every
-   current-crash-source entry across both arrays and pick the one to read by
-   that same order: `CrashLoopBackOff` first, otherwise the most recent
-   `state.terminated.finishedAt`. Read its crash detail — `state.terminated`
-   if that is its current state, otherwise `lastState.terminated` (since
-   `state.waiting` on `CrashLoopBackOff` carries no exit code of its own).
-   Call `k8s.podLogs` with `context: {{context}}`,
-   `namespace: <the candidate's namespace>`, `pod: <the candidate's name>`,
-   `container: <the crashing container>`, `previous: true`,
-   `tail_lines: 200`. Call `k8s.listEvents` with `context: {{context}}`,
-   `objectKind: Pod`, `objectName: <the candidate's name>`,
-   `namespace: <the candidate's namespace>`.
-4. If nothing shortlisted in step 2, or nothing in the shortlist shows a
-   current crash source in step 3, say so plainly rather than inventing a
-   problem.
+The evidence:
+
+- Call `k8s.listPods` with `context: {{context}}`, `namespace: {{namespace}}`.
+  An empty namespace lists across all namespaces.
+- For each candidate, Call `k8s.getObject` with `context: {{context}}`,
+  `kind: Pod`, `namespace: <the candidate's namespace>`,
+  `name: <the candidate's name>`. This confirms whether it is failing NOW and
+  which container is responsible.
+- For a confirmed offender, Call `k8s.podLogs` with `context: {{context}}`,
+  `namespace: <the candidate's namespace>`, `pod: <the candidate's name>`,
+  `container: <the crashing container>`, `previous: true`, `tail_lines: 200`.
+  Call `k8s.listEvents` with `context: {{context}}`, `objectKind: Pod`,
+  `objectName: <the candidate's name>`,
+  `namespace: <the candidate's namespace>`.
+
+Pitfalls — each of these has produced a wrong diagnosis before:
+
+- `listPods`' `restarts` is a lifetime sum over app containers only. Use it
+  as a cheap pre-filter, never as a ranking: a long-healthy pod keeps a large
+  historical sum forever, and only the Pod object tells current from
+  historical — via each container's `state`, not `lastState` or
+  `restartCount`, which are retained history.
+- A pod crash-looping in an INIT container reports ZERO restarts in
+  `listPods` (init statuses are a separate array), so also shortlist pods
+  whose `ready` count is below total with no restarts — that is where init
+  loops hide, and neither status array excludes the other.
+- Triage a handful of confirmed-current offenders rather than everything
+  with history. A candidate with no current failure is an old incident:
+  mention it and move on without reading its logs or events.
+- If nothing is currently failing, say so plainly rather than inventing a
+  problem.
 
 Then report per pod: the most likely cause, the evidence for it, and the minimal
 fix as a `kubectl` command the user can review. Finish with which pod to look at

--- a/crates/mcp/src/prompts/pod-crashloop.targeted.md
+++ b/crates/mcp/src/prompts/pod-crashloop.targeted.md
@@ -16,8 +16,10 @@ The evidence:
 - Call `k8s.getObject` with `context: {{context}}`, `kind: Pod`,
   `namespace: {{namespace}}`, `name: {{pod}}`. The container statuses say
   which container is failing right now, and its terminated detail (exit code,
-  reason, message) says how it died — exit 137/`OOMKilled` is a memory limit,
-  exit 1 or 2 usually means the process failed and the logs say why.
+  reason, message) says how it died — exit 137 WITH reason `OOMKilled` is a
+  memory-limit kill (137 alone is just SIGKILL, which an external eviction or
+  forced deletion also produces); exit 1 or 2 usually means the process
+  failed and the logs say why.
 - Call `k8s.podLogs` with `context: {{context}}`, `namespace: {{namespace}}`,
   `pod: {{pod}}`, `container: <the crashing container>`, `previous: true`,
   `tail_lines: 200`. The PREVIOUS instance's output is where the crash reason

--- a/crates/mcp/src/prompts/pod-crashloop.targeted.md
+++ b/crates/mcp/src/prompts/pod-crashloop.targeted.md
@@ -11,53 +11,37 @@ arguments:
 Pod `{{pod}}` in namespace `{{namespace}}` on context `{{context}}` is restarting
 repeatedly. Work out why, using only srelens tools.
 
-1. Call `k8s.getObject` with `context: {{context}}`, `kind: Pod`,
-   `namespace: {{namespace}}`, `name: {{pod}}`. Kubernetes records an init
-   container's crash loop separately from the app containers: read
-   `status.initContainerStatuses[]` AND `status.containerStatuses[]`
-   independently — neither excludes the other. A classic init container that
-   already ran to completion keeps a positive lifetime `restartCount` from an
-   earlier failure forever, and a native restartable init sidecar
-   (`spec.initContainers[]` whose `restartPolicy` is `Always`) keeps running
-   alongside the app containers indefinitely — app containers do NOT
-   necessarily wait for every init container to finish in that case. `state`
-   is what is true right now; `lastState` is what happened before and is
-   RETAINED even after the container recovers to `state.running` — so
-   neither `lastState` nor lifetime `restartCount` may decide which container
-   is currently failing. An entry in either array counts as a CURRENT crash
-   source only if its own `state` shows a `waiting.reason` of
-   `CrashLoopBackOff`, or a `state.terminated` with a non-zero `exitCode` and
-   a `reason` other than `Completed`. Pool every entry across both arrays
-   that meets this bar, then pick which one's logs to read: prefer whichever
-   has a `waiting.reason` of `CrashLoopBackOff`, otherwise the one with the
-   most recent `state.terminated.finishedAt` — a now-healthy container (init
-   or app) with many past restarts is not the one to read, and in a
-   multi-container pod the crashing one is not necessarily the first listed.
-   Note whether the chosen container came from `initContainerStatuses` or
-   `containerStatuses`; step 4 needs that to pick the matching resource spec.
-   Read its crash detail — `state.terminated` if that is its current state,
-   otherwise `lastState.terminated` (since `state.waiting` on
-   `CrashLoopBackOff` carries no exit code of its own): `exitCode`, `reason`,
-   `message`. Exit code 137 with reason `OOMKilled`
-   means the container hit its memory limit. Exit code 1 or 2 usually means
-   the process itself failed and the logs will say why. A `CrashLoopBackOff`
-   waiting reason only tells you Kubernetes is backing off; the terminated
-   block says what actually happened.
-2. Call `k8s.podLogs` with `context: {{context}}`, `namespace: {{namespace}}`,
-   `pod: {{pod}}`, `container: <the crashing container from step 1>`,
-   `previous: true`, `tail_lines: 200`. The **previous** instance's output is
-   where the crash reason is — the current instance may not have failed yet.
-   Naming `container` matters in a multi-container pod: without it, this
-   returns a healthy container's logs while the crashing one goes unread.
-3. Call `k8s.listEvents` with `context: {{context}}`, `objectKind: Pod`,
-   `objectName: {{pod}}`, `namespace: {{namespace}}`. Look for failing probes,
-   image pull failures, and repeated backoff events.
-4. If step 1 showed an OOM kill, compare it against the resource limits of the
-   SAME container that was chosen in step 1: read
-   `spec.initContainers[].resources.limits.memory` if the crashing entry came
-   from `initContainerStatuses`, otherwise
-   `spec.containers[].resources.limits.memory` — against what the logs
-   suggest the process needed.
+The evidence:
+
+- Call `k8s.getObject` with `context: {{context}}`, `kind: Pod`,
+  `namespace: {{namespace}}`, `name: {{pod}}`. The container statuses say
+  which container is failing right now, and its terminated detail (exit code,
+  reason, message) says how it died — exit 137/`OOMKilled` is a memory limit,
+  exit 1 or 2 usually means the process failed and the logs say why.
+- Call `k8s.podLogs` with `context: {{context}}`, `namespace: {{namespace}}`,
+  `pod: {{pod}}`, `container: <the crashing container>`, `previous: true`,
+  `tail_lines: 200`. The PREVIOUS instance's output is where the crash reason
+  lives — the current instance may not have failed yet.
+- Call `k8s.listEvents` with `context: {{context}}`, `objectKind: Pod`,
+  `objectName: {{pod}}`, `namespace: {{namespace}}`. Failing probes, image
+  pull failures, and backoff history show up here.
+
+Pitfalls — each of these has produced a wrong diagnosis before:
+
+- `state` is now; `lastState` and lifetime `restartCount` are history, and
+  history is RETAINED after a container recovers. Decide which container is
+  currently failing from `state` alone; read `lastState.terminated` only for
+  the crash detail of a container whose current `state` already shows it
+  failing (a `CrashLoopBackOff` wait carries no exit code of its own).
+- Init and app container statuses are separate arrays
+  (`status.initContainerStatuses[]` / `status.containerStatuses[]`) and
+  neither excludes the other — restartable init sidecars run alongside app
+  containers. Check both, and when comparing an OOM kill against limits, read
+  the matching spec array (`spec.initContainers[]` vs `spec.containers[]`)
+  for the SAME container that is crashing.
+- In a multi-container pod, always name the `container` when reading logs —
+  otherwise a healthy container's logs come back while the crashing one goes
+  unread.
 
 Then tell the user, in this order: the single most likely cause, the evidence for
 it, and the minimal fix stated as a `kubectl` command they can review.

--- a/crates/mcp/src/prompts/pod-pending.discover.md
+++ b/crates/mcp/src/prompts/pod-pending.discover.md
@@ -10,64 +10,45 @@ arguments:
 No pod was named, so find what is failing to schedule on context `{{context}}`,
 then explain why.
 
-1. Call `k8s.listPods` with `context: {{context}}`, `namespace: {{namespace}}`.
-   An empty namespace lists across all namespaces. Collect every pod whose
-   `phase` is `Pending`, then split them by `node`. A pod with an EMPTY `node`
-   is genuinely unscheduled — the scheduler has not placed it, and the
-   predicate-based triage in steps 2-4 applies. A pod with a NON-EMPTY `node`
-   already has one: `Pending` there is not a scheduling failure, it means
-   something else is blocking readiness on the node it was already assigned —
-   an image pull, an init container, a volume mount, or sandbox creation.
-   `Pending` is not a synonym for `FailedScheduling`, so do not run these
-   already-scheduled pods through the predicate steps below. Instead, for
-   each, Call `k8s.listEvents` with `context: {{context}}`,
-   `objectKind: Pod`, `objectName: <the pod>`,
-   `namespace: <the pod's namespace>`. Look for `Pulling`/`Failed`/`BackOff`
-   events (image pull), an `Init` container status, or a mount/volume error,
-   and report that instead of a scheduling predicate.
-2. Among the genuinely unscheduled pods, if several are Pending, group them:
-   pods blocked by the same cause usually share a namespace, a node selector,
-   or a PersistentVolumeClaim. Triage one per group rather than all of them.
-3. For each representative, Call `k8s.listEvents` with `context: {{context}}`,
-   `objectKind: Pod`, `objectName: <the pod>`,
-   `namespace: <the pod's namespace>`. `FailedScheduling` names the failed
-   predicate. Call `k8s.getObject` with `context: {{context}}`, `kind: Pod`,
-   `namespace: <the pod's namespace>`, `name: <the pod>`. Read its
-   `nodeSelector`, `affinity`, `tolerations` and `volumes`.
-4. For a capacity or a label/taint predicate, first Call `k8s.listNodes` with
-   `context: {{context}}` to enumerate candidate nodes — the per-node
-   `getObject` calls below need a real node name to read, and `listNodes` is
-   the only call that supplies one. Then, depending on the predicate:
-   - for capacity: the `FailedScheduling` event from step 3 is already the
-     scheduler's own authoritative statement of which resource is short and
-     on how many nodes; treat it as the source of truth rather than trying to
-     second-guess it by recomputing what the scheduler reserved. Kubernetes'
-     exact reservation math — a per-resource maximum across init containers,
-     restartable sidecar init containers accumulating with the app
-     containers, and pod overhead — is not reproduced here. Call
-     `k8s.getObject` with `context: {{context}}`, `kind: Node`,
-     `name: <candidate>`. Read `status.allocatable`, and Call
-     `k8s.nodeMetrics` with `context: {{context}}` to judge the SCALE of the
-     shortfall and whether it is cluster-wide or limited to a handful of
-     nodes;
-   - for labels or taints: Call `k8s.getObject` with `context: {{context}}`,
-     `kind: Node`, `name: <candidate>`. Read `metadata.labels` and
-     `spec.taints` — `k8s.listNodes` returns neither, only a taint COUNT and
-     no labels at all;
-   - for volume binding: Call `k8s.listPersistentVolumeClaims` with
-     `context: {{context}}`, `namespace: <the pod's namespace>`.
-     `{{namespace}}` is the optional SEARCH filter from step 1 and defaults
-     to `""`, which lists cluster-wide — use the pod's own namespace here
-     instead, or every claim in the cluster gets scanned for one pod's
-     problem. Call `k8s.listStorageClasses` with `context: {{context}}`;
-5. ResourceQuota and LimitRange are not scheduling predicates and cannot be
-   the cause here: both are enforced by an admission controller at CREATE
-   time, so a pod already existing in `Pending` state already passed them —
-   a violation would have been rejected before it was ever persisted, and
-   quota exhaustion surfaces instead as a controller event (for example on a
-   ReplicaSet) with no pod created, a different symptom from a Pending pod.
-   Do not check quota or limit ranges for this flow.
-6. If nothing is Pending, say so plainly.
+The evidence:
+
+- Call `k8s.listPods` with `context: {{context}}`, `namespace: {{namespace}}`.
+  An empty namespace lists across all namespaces. The candidates are the pods
+  whose `phase` is `Pending`; each one's `node` field splits the triage
+  (first pitfall).
+- Group the genuinely unscheduled pods by likely shared cause — same
+  namespace, node selector, or claim — and for one representative per group:
+  Call `k8s.listEvents` with `context: {{context}}`, `objectKind: Pod`,
+  `objectName: <the pod>`, `namespace: <the pod's namespace>`. Call
+  `k8s.getObject` with `context: {{context}}`, `kind: Pod`,
+  `namespace: <the pod's namespace>`, `name: <the pod>`.
+- For node-side facts, Call `k8s.listNodes` with `context: {{context}}` to
+  enumerate real node names. Then Call `k8s.getObject` with
+  `context: {{context}}`, `kind: Node`, `name: <candidate>` for
+  `status.allocatable`, `metadata.labels`, and `spec.taints`. Call
+  `k8s.nodeMetrics` with `context: {{context}}` to judge scale.
+- For volume binding, Call `k8s.listPersistentVolumeClaims` with
+  `context: {{context}}`, `namespace: <the pod's namespace>`. Use the pod's
+  OWN namespace here, not the search filter — the filter defaults to
+  cluster-wide, and every claim in the cluster should not be scanned for one
+  pod's problem. Call `k8s.listStorageClasses` with `context: {{context}}`.
+
+Pitfalls — each of these has produced a wrong diagnosis before:
+
+- `Pending` is not a synonym for `FailedScheduling`. A pod with a NON-EMPTY
+  `node` is already placed: something else is blocking readiness there — an
+  image pull, an init container, a volume mount, or sandbox creation. Read
+  its events and report that; the scheduling analysis applies only to pods
+  with an empty `node`.
+- The `FailedScheduling` event is the scheduler's own authoritative statement
+  of what failed. Do not recompute its reservation math (per-resource init
+  maxima, restartable sidecars, pod overhead); use capacity and metrics only
+  to judge the SCALE of what it names.
+- `listNodes` and `nodeMetrics` are summaries — no labels, no taint detail,
+  no capacity. Per-node facts come only from the Node object.
+- ResourceQuota and LimitRange are admission-time checks: a pod that EXISTS
+  in `Pending` already passed them, so do not check them here.
+- If nothing is Pending, say so plainly.
 
 Then report per group: the blocking reason, the evidence, and the minimal fix as a
 `kubectl` command the user can review.

--- a/crates/mcp/src/prompts/pod-pending.targeted.md
+++ b/crates/mcp/src/prompts/pod-pending.targeted.md
@@ -11,60 +11,46 @@ arguments:
 Pod `{{pod}}` in namespace `{{namespace}}` on context `{{context}}` is stuck in
 Pending. Work out what is blocking it.
 
-1. Call `k8s.getObject` with `context: {{context}}`, `kind: Pod`,
-   `namespace: {{namespace}}`, `name: {{pod}}`. Read `spec.nodeName` first.
-   - If `spec.nodeName` is NON-EMPTY, the scheduler has already placed this
-     pod: `Pending` here is not a scheduling failure, it means something else
-     is blocking readiness on the node it was already assigned — an image
-     pull, an init container, a volume mount, or sandbox creation. `Pending`
-     is not a synonym for `FailedScheduling`, so do not run this pod through
-     the predicate steps below. Instead, Call `k8s.listEvents` with
-     `context: {{context}}`, `objectKind: Pod`, `objectName: {{pod}}`,
-     `namespace: {{namespace}}`. Look for `Pulling`/`Failed`/`BackOff` events
-     (image pull), an `Init` container status, or a mount/volume error, and
-     report that instead of a scheduling predicate. Stop here.
-   - If `spec.nodeName` is EMPTY, the pod is genuinely unscheduled. Read
-     `spec.nodeSelector`, `spec.affinity`, `spec.tolerations` and
-     `spec.volumes`, then continue with the predicate-based triage below.
-2. Call `k8s.listEvents` with `context: {{context}}`, `objectKind: Pod`,
-   `objectName: {{pod}}`, `namespace: {{namespace}}`. The scheduler explains itself
-   here — `FailedScheduling` messages name the exact predicate that failed. Start
-   with this, not the manifest.
-3. Match the event against the cause. None of this is available from
-   `k8s.listNodes` or `k8s.nodeMetrics` alone — they report neither labels,
-   taint detail, nor capacity — so the pattern below is always: Call
-   `k8s.listNodes` with `context: {{context}}` to enumerate candidate nodes.
-   Then, Call `k8s.getObject` with `context: {{context}}`, `kind: Node`,
-   `name: <candidate>`. Read whichever field the cause below needs —
-   `status.allocatable`, `metadata.labels`, or `spec.taints`.
-   - insufficient cpu/memory → the `FailedScheduling` event from step 2 is
-     already the scheduler's own authoritative statement of which resource is
-     short and on how many nodes; treat it as the source of truth rather than
-     trying to second-guess it by recomputing what the scheduler reserved.
-     Kubernetes' exact reservation math — a per-resource maximum across init
-     containers, restartable sidecar init containers accumulating with the
-     app containers, and pod overhead — is not reproduced here. Read
-     `status.allocatable` from the `getObject` call above, and Call
-     `k8s.nodeMetrics` with `context: {{context}}` to judge the SCALE of the
-     shortfall and whether it is cluster-wide or limited to a handful of
-     nodes;
-   - node selector or affinity mismatch → read `metadata.labels` from the
-     `getObject` call above and compare against the pod's `spec.nodeSelector`
-     / `spec.affinity`;
-   - taint tolerations → read `spec.taints` (key, value, effect) from the same
-     `getObject` call above and compare against the pod's `spec.tolerations`;
-   - unbound PersistentVolumeClaim → Call `k8s.listPersistentVolumeClaims`
-     with `context: {{context}}`, `namespace: {{namespace}}`. Call
-     `k8s.listStorageClasses` with `context: {{context}}`. If the claim is
-     shared, Call `k8s.podsForPvc` with `context: {{context}}`,
-     `namespace: {{namespace}}`, `pvc: <the claim's name>`.
-4. ResourceQuota and LimitRange are not a scheduling blocker for a pod that
-   already exists in `Pending` state: both are enforced by an admission
-   controller at CREATE time, so a pod that violated either would have been
-   rejected and would never exist to triage here — a quota violation surfaces
-   instead as a controller event (for example on a ReplicaSet) with no pod
-   ever created, which is a different symptom from a Pending pod. Do not
-   check quota or limit ranges for this flow.
+The evidence:
+
+- Call `k8s.getObject` with `context: {{context}}`, `kind: Pod`,
+  `namespace: {{namespace}}`, `name: {{pod}}`. `spec.nodeName` decides the
+  shape of the whole triage (first pitfall); `spec.nodeSelector`,
+  `spec.affinity`, `spec.tolerations` and `spec.volumes` are the pod's side
+  of any scheduling comparison.
+- Call `k8s.listEvents` with `context: {{context}}`, `objectKind: Pod`,
+  `objectName: {{pod}}`, `namespace: {{namespace}}`. Start here — the
+  scheduler explains itself in `FailedScheduling` messages, and image pull,
+  init, and mount problems surface here too.
+- For node-side facts, Call `k8s.listNodes` with `context: {{context}}` to
+  enumerate real node names. Then Call `k8s.getObject` with
+  `context: {{context}}`, `kind: Node`, `name: <candidate>` and read
+  whichever the cause needs: `status.allocatable`, `metadata.labels`, or
+  `spec.taints`. Call `k8s.nodeMetrics` with `context: {{context}}` to judge
+  the scale of a capacity shortfall — cluster-wide or a handful of nodes.
+- For volume binding, Call `k8s.listPersistentVolumeClaims` with
+  `context: {{context}}`, `namespace: {{namespace}}`. Call
+  `k8s.listStorageClasses` with `context: {{context}}`. For a shared claim,
+  Call `k8s.podsForPvc` with `context: {{context}}`,
+  `namespace: {{namespace}}`, `pvc: <the claim's name>`.
+
+Pitfalls — each of these has produced a wrong diagnosis before:
+
+- `Pending` is not a synonym for `FailedScheduling`. A NON-EMPTY
+  `spec.nodeName` means the scheduler already placed this pod and something
+  else is blocking readiness — an image pull, an init container, a volume
+  mount, or sandbox creation. Read the events, report that, and stop;
+  scheduling analysis does not apply to a placed pod.
+- The `FailedScheduling` event is the scheduler's own authoritative statement
+  of what failed and on how many nodes. Do not recompute its reservation math
+  (per-resource init maxima, restartable sidecars, pod overhead — none of it
+  is reproduced here); use capacity and metrics only to judge the SCALE of
+  what the event already names.
+- `listNodes` and `nodeMetrics` are summaries: no labels, no taint detail,
+  no capacity. Per-node facts come only from the Node object.
+- ResourceQuota and LimitRange are admission-time checks: a pod that EXISTS
+  in `Pending` already passed them, so do not check them here — a quota
+  violation surfaces as a controller event with no pod created at all.
 
 Then tell the user the single blocking reason, the evidence for it, and the minimal
 fix as a `kubectl` command they can review.

--- a/crates/mcp/src/prompts/service-no-endpoints.discover.md
+++ b/crates/mcp/src/prompts/service-no-endpoints.discover.md
@@ -10,53 +10,50 @@ arguments:
 No service was named, so find which services on context `{{context}}` have no
 endpoints, then explain why.
 
-1. Call `k8s.listServices` with `context: {{context}}`,
-   `namespace: {{namespace}}`. An empty namespace lists across all namespaces.
-   Note each service's `type`.
-2. Call `k8s.listEndpointSlices` with `context: {{context}}`,
-   `namespace: {{namespace}}`. Match slices to services. Collect the services
-   with no slices, with empty slices, or whose addresses are all marked not-ready.
-   Ignore headless services with no selector unless they also have no manually
-   managed slices. Exclude any service whose `type` (from step 1) is
-   `ExternalName` from this candidate set entirely — it intentionally has no
-   selector and no EndpointSlices, resolved instead via a DNS CNAME, so having
-   none is correct by design, not a fault this flow should surface.
-3. Call `k8s.listIngresses` with `context: {{context}}`, `namespace: {{namespace}}`
-   to enumerate Ingresses — but `IngressSummary` carries only name, namespace,
-   class, hosts, address, ports and age, no backend service reference, so this
-   alone cannot say which Service an Ingress actually fronts. For each Ingress
-   returned, Call `k8s.getObject` with `context: {{context}}`, `kind: Ingress`,
-   `namespace: <the ingress's namespace>`, `name: <the ingress>`. Read
-   `spec.rules[].http.paths[].backend.service.name` and
-   `spec.defaultBackend.service.name` to build the routed-to set — but a
-   backend name is only ever resolved within its own Ingress's namespace, so
-   key each entry by the PAIR (the ingress's namespace, the backend service
-   name), never by name alone: in a cluster-wide search two different
-   namespaces can hold same-named Services, and keying on name only would
-   treat both as Ingress-backed.
-4. Take up to three of the broken services from step 2, worst first — a
-   service whose (namespace, name) pair is in step 3's routed-to set matters
-   more than one that is not.
-5. For each, Call `k8s.getObject` with `context: {{context}}`,
-   `kind: Service`, `namespace: <the service's namespace>`,
-   `name: <the service>`. Read `spec.selector` and `spec.ports`. If
-   `spec.selector` is empty or absent, this Service is fed by a manually
-   managed EndpointSlice, not a selector — stop here and diagnose it from
-   step 2's slice data rather than continuing on; do NOT call
-   `k8s.podsForSelector` with an empty selector, since it always returns zero
-   pods and that empty result would misread as a selector/label mismatch.
-   Otherwise, Call `k8s.podsForSelector` with `context: {{context}}`,
-   `namespace: <the service's namespace>`,
-   `selector: <the Service's spec.selector map>`. No match means a
-   selector/label mismatch: Call `k8s.listPods` with `context: {{context}}`,
-   `namespace: <the service's namespace>` and compare pod labels against the
-   selector. A match that is not ready means a failing readiness probe: for
-   one of the matched pods, Call `k8s.getObject` with `context: {{context}}`,
-   `kind: Pod`, `namespace: <the service's namespace>`, `name: <the pod>`.
-   Call `k8s.podLogs` with `context: {{context}}`,
-   `namespace: <the service's namespace>`, `pod: <the pod>`,
-   `tail_lines: 100`.
-6. If every service has healthy endpoints, say so plainly.
+The evidence:
+
+- Call `k8s.listServices` with `context: {{context}}`,
+  `namespace: {{namespace}}`. An empty namespace lists across all
+  namespaces; note each service's `type`.
+- Call `k8s.listEndpointSlices` with `context: {{context}}`,
+  `namespace: {{namespace}}`. The broken candidates are services with no
+  slices, empty slices, or all addresses not-ready.
+- To rank candidates by blast radius, Call `k8s.listIngresses` with
+  `context: {{context}}`, `namespace: {{namespace}}`. Then for each Ingress,
+  Call `k8s.getObject` with `context: {{context}}`, `kind: Ingress`,
+  `namespace: <the ingress's namespace>`, `name: <the ingress>` and read
+  `spec.rules[].http.paths[].backend.service.name` and
+  `spec.defaultBackend.service.name` — an Ingress-fronted broken service
+  matters more than one nothing routes to.
+- For a few of the worst candidates, diagnose exactly as the targeted flow
+  does. Call `k8s.getObject` with `context: {{context}}`, `kind: Service`,
+  `namespace: <the service's namespace>`, `name: <the service>`. With a
+  non-empty selector, Call `k8s.podsForSelector` with `context: {{context}}`,
+  `namespace: <the service's namespace>`,
+  `selector: <the Service's spec.selector map>`. To chase a label mismatch,
+  Call `k8s.listPods` with `context: {{context}}`,
+  `namespace: <the service's namespace>`. To chase failing readiness, Call
+  `k8s.getObject` with `context: {{context}}`, `kind: Pod`,
+  `namespace: <the service's namespace>`, `name: <the pod>`. Call
+  `k8s.podLogs` with `context: {{context}}`,
+  `namespace: <the service's namespace>`, `pod: <the pod>`,
+  `tail_lines: 100`.
+
+Pitfalls — each of these has produced a wrong diagnosis before:
+
+- `ExternalName` services have no selector and no EndpointSlices BY DESIGN
+  (DNS CNAME, no kube-proxy) — exclude them from the candidate set; they are
+  not broken.
+- Selector-less services are fed by manually managed EndpointSlices:
+  diagnose those from the slice data, and never call `podsForSelector` with
+  an empty selector — it always returns zero pods, which reads as a false
+  label mismatch.
+- `IngressSummary` carries no backend reference — only the Ingress object
+  does — and a backend name resolves within the Ingress's OWN namespace.
+  Key the routed-to set by the (namespace, name) PAIR: in a cluster-wide
+  search, same-named Services in different namespaces are different
+  services.
+- If every service has healthy endpoints, say so plainly.
 
 Then report per service: which link is broken — selector, readiness, or target port —
 the evidence, and the minimal fix as a `kubectl` command the user can review.

--- a/crates/mcp/src/prompts/service-no-endpoints.targeted.md
+++ b/crates/mcp/src/prompts/service-no-endpoints.targeted.md
@@ -9,41 +9,41 @@ arguments:
   - { name: service, target: true, description: the service with no endpoints }
 ---
 Service `{{service}}` in namespace `{{namespace}}` on context `{{context}}` has no
-endpoints, so nothing is receiving its traffic. Work out where the chain breaks.
+endpoints, so nothing is receiving its traffic. Work out where the chain breaks:
+type, then selector, then readiness, then port.
 
-1. Call `k8s.getObject` with `context: {{context}}`, `kind: Service`,
-   `namespace: {{namespace}}`, `name: {{service}}`. Read `spec.selector`,
-   `spec.ports` and `spec.type`.
-   - If `spec.type` is `ExternalName`, this Service intentionally has no
-     selector and no EndpointSlices at all — Kubernetes resolves it via a DNS
-     CNAME to `spec.externalName` instead of routing through kube-proxy.
-     Having no endpoints is correct by design here, not a fault. Say that and
-     stop; do not run steps 2-4.
-   - Otherwise, a Service with no selector is fed by a manually managed
-     EndpointSlice — if so, say that and check the slices directly in step 2,
-     and skip step 3 entirely: do NOT call `k8s.podsForSelector` with an empty
-     selector, since it always returns zero pods and that empty result would
-     misread as a selector/label mismatch rather than "manually managed."
-2. Call `k8s.listEndpointSlices` with `context: {{context}}`,
-   `namespace: {{namespace}}`. Find the slices owned by `{{service}}`. Empty
-   slices mean no pod matched or none is ready; slices with addresses marked
-   not-ready mean the pods exist but are failing readiness.
-3. If `spec.selector` from step 1 is non-empty, Call `k8s.podsForSelector` with
-   `context: {{context}}`, `namespace: {{namespace}}`,
-   `selector: <the Service's spec.selector map>`.
-   - No pods matched → the selector does not match any pod's labels. Call
-     `k8s.listPods` with `context: {{context}}`, `namespace: {{namespace}}`
-     and compare labels with the selector; a single mismatched key is the
-     usual cause.
-   - Pods matched but are not ready → their readiness probe is failing. For
-     one of them, Call `k8s.getObject` with `context: {{context}}`,
-     `kind: Pod`, `namespace: {{namespace}}`, `name: <the pod>`. Read
-     `status.conditions` and `spec.containers[].readinessProbe`. Call
-     `k8s.podLogs` with `context: {{context}}`, `namespace: {{namespace}}`,
-     `pod: <the pod>`, `tail_lines: 100`.
-4. Check that the Service's `spec.ports[].targetPort` matches a `containerPort` the
-   pods actually expose — a correct selector with the wrong target port still yields
-   no usable endpoint.
+The evidence:
+
+- Call `k8s.getObject` with `context: {{context}}`, `kind: Service`,
+  `namespace: {{namespace}}`, `name: {{service}}`. Read `spec.type`,
+  `spec.selector` and `spec.ports`.
+- Call `k8s.listEndpointSlices` with `context: {{context}}`,
+  `namespace: {{namespace}}`. Find the slices owned by `{{service}}`: empty
+  slices mean no pod matched or none is ready; addresses marked not-ready
+  mean the pods exist but are failing readiness.
+- With a non-empty selector, Call `k8s.podsForSelector` with
+  `context: {{context}}`, `namespace: {{namespace}}`,
+  `selector: <the Service's spec.selector map>`. To chase a label mismatch,
+  Call `k8s.listPods` with `context: {{context}}`, `namespace: {{namespace}}`
+  and compare pod labels against the selector — a single mismatched key is
+  the usual cause. To chase failing readiness, Call `k8s.getObject` with
+  `context: {{context}}`, `kind: Pod`, `namespace: {{namespace}}`,
+  `name: <the pod>` for its conditions and readiness probe. Call
+  `k8s.podLogs` with `context: {{context}}`, `namespace: {{namespace}}`,
+  `pod: <the pod>`, `tail_lines: 100`.
+
+Pitfalls — each of these has produced a wrong diagnosis before:
+
+- A `spec.type` of `ExternalName` has no selector and no EndpointSlices BY
+  DESIGN — it resolves via a DNS CNAME, never through kube-proxy. No
+  endpoints is correct there: say so and stop.
+- A Service with no selector is fed by manually managed EndpointSlices.
+  Never call `podsForSelector` with an empty selector — it always returns
+  zero pods, and that empty result reads as a false label mismatch. Diagnose
+  from the slice data instead.
+- A correct selector with a wrong port still yields nothing usable: check
+  that `spec.ports[].targetPort` matches a `containerPort` the pods actually
+  expose.
 
 Then tell the user which link in the chain is broken — selector, readiness, or port —
 the evidence for it, and the minimal fix as a `kubectl` command they can review.


### PR DESCRIPTION
Fixes #192.

## What

Rewrites all eight built-in prompt bodies from step-by-step decision procedures to **goal + canonical evidence calls + explicit pitfalls**, per the issue's proposal.

- The canonical ``Call `k8s.X` with `key: value``` lines keep their exact shape — the grammar guards (`call_sites`, `argument_key_tokens`, required-field enforcement, tool-name allowlist) depend on them, and they keep calls copyable. Each call now sits in its own sentence so the guards' sentence-boundary parsing stays precise.
- The hand-encoded predicates are gone: no more container-selection algorithms, shortlist-ordering procedures, or reservation math a revision can get subtly wrong — the class that caused #189's rounds 5–7.
- Every pitfall the issue lists survives as an explicit warning, each having cost a review round: `state` vs `lastState`/`restartCount` (history is retained), the separate init/app status arrays and restartable sidecars, `Pending` ≠ `FailedScheduling`, list summaries vs `getObject`, the `FailedScheduling` event as the scheduler's authoritative statement, `ExternalName` having no endpoints by design, and the empty-selector `podsForSelector` misread. Domain facts that aren't procedures (exit 137 = OOM, `previous: true` logs, per-pod disk/PID usage being unreportable) also stay.

## Success criterion from the issue

"removes more text than it adds": **506 → 426 lines (−80)**, with no body growing.

## Testing

All 81 prompt tests pass unchanged — including the four guard classes that catch mechanical drift (argument keys against real input schemas, required fields per call site, tool names against the registry, template-variable hygiene) — plus the full `srelens-mcp` (219) and `srelens-desktop` (146) suites.