### PR TITLE
feat(overview): persist overview snapshots in the backend for instant cold starts

### DIFF
--- a/apps/desktop/src-tauri/src/assistant_history.rs
+++ b/apps/desktop/src-tauri/src/assistant_history.rs
@@ -124,8 +124,9 @@ fn upsert_index(dir: &Path, meta: &SessionMeta) -> Result<(), String> {
 /// A saved transcript can contain secrets returned by the consent-gated
 /// `k8s.getSecret` tool (plus logs/manifests), so on a shared Unix host it must
 /// not be left world-readable by the default `022`-umask `0644`. On non-Unix
-/// the default per-user permissions apply.
-fn write_private(path: &Path, contents: &str) -> std::io::Result<()> {
+/// the default per-user permissions apply. Shared with `overview_snapshot`,
+/// whose file names contexts and carries warning-event messages.
+pub(crate) fn write_private(path: &Path, contents: &str) -> std::io::Result<()> {
     #[cfg(unix)]
     {
         use std::io::Write;

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -18,6 +18,7 @@ mod logs;
 mod mcp;
 mod mcp_confirm;
 pub mod mcp_watch;
+mod overview_snapshot;
 mod settings;
 mod sink;
 mod terminal;
@@ -401,6 +402,9 @@ pub fn run() {
             assistant_history::chat_history_load,
             assistant_history::chat_history_save,
             assistant_history::chat_history_delete,
+            overview_snapshot::overview_snapshot_load,
+            overview_snapshot::overview_snapshot_save,
+            overview_snapshot::overview_snapshot_clear,
             assistant_prompts::assistant_prompts_list,
             assistant_prompts::assistant_prompt_get,
             assistant_skills::skills_list,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -378,6 +378,9 @@ pub fn run() {
             Ok(())
         })
         .manage(AppRegistry(registry))
+        // The cache itself, for commands that need the live kubeconfig paths
+        // (overview_snapshot resolves context → cluster identity from them).
+        .manage(cache.clone())
         .manage(WatchManager::new(cache.clone()))
         .manage(ExecManager::new(cache.clone()))
         .manage(ForwardManager::new(cache.clone()))

--- a/apps/desktop/src-tauri/src/overview_snapshot.rs
+++ b/apps/desktop/src-tauri/src/overview_snapshot.rs
@@ -45,11 +45,24 @@ fn read_all(path: &Path) -> BTreeMap<String, PersistedSnapshot> {
 /// mid-write never leaves a half-written file behind. Owner-only (`0600` on
 /// Unix; `rename` preserves the mode): the map names contexts and carries
 /// warning-event messages, which mustn't be world-readable on a shared host.
+///
+/// The tmp name is writer-unique (pid + counter) so overlapping writers — a
+/// second app instance, two commands in flight — can never truncate or rename
+/// away each other's in-progress file. The map update itself stays
+/// last-writer-wins: this is a self-healing cache (a lost entry is re-persisted
+/// by the next successful fetch), so an interprocess lock isn't warranted.
 fn write_all(path: &Path, all: &BTreeMap<String, PersistedSnapshot>) -> Result<(), String> {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static WRITE_SEQ: AtomicU64 = AtomicU64::new(0);
+
     if let Some(dir) = path.parent() {
         fs::create_dir_all(dir).map_err(|e| format!("could not create {}: {e}", dir.display()))?;
     }
-    let tmp = path.with_extension("json.tmp");
+    let tmp = path.with_extension(format!(
+        "json.{}-{}.tmp",
+        std::process::id(),
+        WRITE_SEQ.fetch_add(1, Ordering::Relaxed)
+    ));
     let raw = serde_json::to_string(all).map_err(|e| e.to_string())?;
     crate::assistant_history::write_private(&tmp, &raw)
         .map_err(|e| format!("could not write {}: {e}", tmp.display()))?;
@@ -253,6 +266,24 @@ mod tests {
 
         let mode = fs::metadata(tmp.file()).unwrap().permissions().mode();
         assert_eq!(mode & 0o777, 0o600, "overview.json must be 0600, got {mode:o}");
+    }
+
+    /// Concurrent writers (a second app instance, two commands in flight) must
+    /// not share a temp file: a save may never truncate or rename away another
+    /// writer's in-progress tmp.
+    #[test]
+    fn save_leaves_a_foreign_tmp_file_untouched() {
+        let tmp = TempDir::new("foreign-tmp");
+        let foreign = tmp.file().with_extension("json.tmp");
+        fs::write(&foreign, "other writer's half-finished payload").unwrap();
+
+        save(&tmp.file(), "kind-a", snapshot(1000, 3)).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(&foreign).unwrap(),
+            "other writer's half-finished payload"
+        );
+        assert_eq!(load(&tmp.file(), "kind-a"), Some(snapshot(1000, 3)));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/overview_snapshot.rs
+++ b/apps/desktop/src-tauri/src/overview_snapshot.rs
@@ -42,14 +42,17 @@ fn read_all(path: &Path) -> BTreeMap<String, PersistedSnapshot> {
 }
 
 /// Write the whole snapshot map atomically (`.tmp` + rename) so a crash
-/// mid-write never leaves a half-written file behind.
+/// mid-write never leaves a half-written file behind. Owner-only (`0600` on
+/// Unix; `rename` preserves the mode): the map names contexts and carries
+/// warning-event messages, which mustn't be world-readable on a shared host.
 fn write_all(path: &Path, all: &BTreeMap<String, PersistedSnapshot>) -> Result<(), String> {
     if let Some(dir) = path.parent() {
         fs::create_dir_all(dir).map_err(|e| format!("could not create {}: {e}", dir.display()))?;
     }
     let tmp = path.with_extension("json.tmp");
     let raw = serde_json::to_string(all).map_err(|e| e.to_string())?;
-    fs::write(&tmp, raw).map_err(|e| format!("could not write {}: {e}", tmp.display()))?;
+    crate::assistant_history::write_private(&tmp, &raw)
+        .map_err(|e| format!("could not write {}: {e}", tmp.display()))?;
     fs::rename(&tmp, path).map_err(|e| format!("could not finalize {}: {e}", path.display()))
 }
 
@@ -235,6 +238,21 @@ mod tests {
 
         assert_eq!(load(&tmp.file(), "kind-a"), None);
         assert!(!tmp.file().exists());
+    }
+
+    /// The snapshot names contexts and carries warning-event messages, so on a
+    /// shared Unix host the file must not be world-readable (same reasoning as
+    /// the assistant-history store).
+    #[cfg(unix)]
+    #[test]
+    fn snapshot_file_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = TempDir::new("perms");
+        save(&tmp.file(), "kind-a", snapshot(1000, 3)).unwrap();
+
+        let mode = fs::metadata(tmp.file()).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "overview.json must be 0600, got {mode:o}");
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/overview_snapshot.rs
+++ b/apps/desktop/src-tauri/src/overview_snapshot.rs
@@ -1,0 +1,246 @@
+//! Disk-backed cluster-overview snapshots, so a cold start can paint the
+//! overview instantly from the last run instead of an empty loading state
+//! (issue #148).
+//!
+//! Everything lives in one small `<config>/overview.json` file: a map of
+//! context name → last snapshot, capped to the most recently refreshed
+//! contexts. The `stats` payload is opaque JSON — the frontend owns its
+//! shape (same contract as assistant session `messages`).
+//!
+//! This is a cache, not user data: a corrupt or unreadable file is treated
+//! as empty rather than surfaced as an error, so a bad write can never
+//! wedge the overview.
+//!
+//! The `#[tauri::command]` wrappers at the bottom only resolve the app
+//! config dir and delegate; the pure `fn`s above them take a `path: &Path`
+//! so tests can drive them against a throwaway temp file.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager};
+
+/// One persisted overview: opaque frontend stats plus when they were fetched.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct PersistedSnapshot {
+    pub stats: serde_json::Value,
+    pub updated_at: i64,
+}
+
+/// Keep the file small: only the most recently refreshed contexts survive.
+const MAX_CONTEXTS: usize = 10;
+
+/// Read the whole snapshot map, treating a missing or corrupt file as empty.
+fn read_all(path: &Path) -> BTreeMap<String, PersistedSnapshot> {
+    let Ok(raw) = fs::read_to_string(path) else {
+        return BTreeMap::new();
+    };
+    serde_json::from_str(&raw).unwrap_or_default()
+}
+
+/// Write the whole snapshot map atomically (`.tmp` + rename) so a crash
+/// mid-write never leaves a half-written file behind.
+fn write_all(path: &Path, all: &BTreeMap<String, PersistedSnapshot>) -> Result<(), String> {
+    if let Some(dir) = path.parent() {
+        fs::create_dir_all(dir).map_err(|e| format!("could not create {}: {e}", dir.display()))?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    let raw = serde_json::to_string(all).map_err(|e| e.to_string())?;
+    fs::write(&tmp, raw).map_err(|e| format!("could not write {}: {e}", tmp.display()))?;
+    fs::rename(&tmp, path).map_err(|e| format!("could not finalize {}: {e}", path.display()))
+}
+
+/// Last persisted snapshot for `context`, if any.
+fn load(path: &Path, context: &str) -> Option<PersistedSnapshot> {
+    read_all(path).remove(context)
+}
+
+/// Persist a snapshot for `context`, evicting the least recently updated
+/// contexts beyond the cap.
+fn save(path: &Path, context: &str, snapshot: PersistedSnapshot) -> Result<(), String> {
+    let mut all = read_all(path);
+    all.insert(context.to_owned(), snapshot);
+    if all.len() > MAX_CONTEXTS {
+        let mut by_age: Vec<_> = all.iter().map(|(c, s)| (s.updated_at, c.clone())).collect();
+        by_age.sort();
+        for (_, context) in &by_age[..all.len() - MAX_CONTEXTS] {
+            all.remove(context);
+        }
+    }
+    write_all(path, &all)
+}
+
+/// Drop one context's snapshot, or every snapshot when `context` is `None`.
+/// Clearing what isn't there is not an error — clearing is idempotent.
+fn clear(path: &Path, context: Option<&str>) -> Result<(), String> {
+    match context {
+        Some(context) => {
+            let mut all = read_all(path);
+            if all.remove(context).is_some() {
+                write_all(path, &all)?;
+            }
+            Ok(())
+        }
+        None => match fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(format!("could not delete {}: {e}", path.display())),
+        },
+    }
+}
+
+/// Resolve `<app config dir>/overview.json` — the one bit of app-specific
+/// wiring the pure helpers above don't do.
+fn resolve_store_path(app: &AppHandle) -> Result<PathBuf, String> {
+    let base = app.path().app_config_dir().map_err(|e| e.to_string())?;
+    Ok(base.join("overview.json"))
+}
+
+/// Load the last persisted overview snapshot for a context, if any.
+#[tauri::command]
+pub fn overview_snapshot_load(
+    app: AppHandle,
+    context: String,
+) -> Result<Option<PersistedSnapshot>, String> {
+    Ok(load(&resolve_store_path(&app)?, &context))
+}
+
+/// Persist a context's overview snapshot for the next cold start.
+#[tauri::command]
+pub fn overview_snapshot_save(
+    app: AppHandle,
+    context: String,
+    snapshot: PersistedSnapshot,
+) -> Result<(), String> {
+    save(&resolve_store_path(&app)?, &context, snapshot)
+}
+
+/// Drop one context's persisted snapshot, or all of them.
+#[tauri::command]
+pub fn overview_snapshot_clear(app: AppHandle, context: Option<String>) -> Result<(), String> {
+    clear(&resolve_store_path(&app)?, context.as_deref())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// A fresh, empty directory under the OS temp dir, unique per test so
+    /// parallel test runs never collide. Removed on drop so a test's fixture
+    /// files don't linger.
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new(tag: &str) -> Self {
+            let dir = std::env::temp_dir().join(format!(
+                "srelens-overview-{tag}-{}-{:?}",
+                std::process::id(),
+                std::thread::current().id(),
+            ));
+            fs::create_dir_all(&dir).unwrap();
+            TempDir(dir)
+        }
+
+        fn file(&self) -> PathBuf {
+            self.0.join("overview.json")
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn snapshot(updated_at: i64, nodes: i64) -> PersistedSnapshot {
+        PersistedSnapshot {
+            stats: json!({ "nodes": { "total": nodes, "ready": nodes } }),
+            updated_at,
+        }
+    }
+
+    #[test]
+    fn round_trips_a_snapshot_per_context() {
+        let tmp = TempDir::new("roundtrip");
+        save(&tmp.file(), "kind-a", snapshot(1000, 3)).unwrap();
+        save(&tmp.file(), "kind-b", snapshot(2000, 5)).unwrap();
+
+        assert_eq!(load(&tmp.file(), "kind-a"), Some(snapshot(1000, 3)));
+        assert_eq!(load(&tmp.file(), "kind-b"), Some(snapshot(2000, 5)));
+    }
+
+    #[test]
+    fn missing_file_loads_nothing() {
+        let tmp = TempDir::new("missing");
+        assert_eq!(load(&tmp.file(), "kind-a"), None);
+    }
+
+    #[test]
+    fn corrupt_file_loads_nothing_and_saves_fresh() {
+        let tmp = TempDir::new("corrupt");
+        fs::write(tmp.file(), "{not json").unwrap();
+
+        assert_eq!(load(&tmp.file(), "kind-a"), None);
+
+        // A save starts the cache over rather than failing on the bad file.
+        save(&tmp.file(), "kind-a", snapshot(1000, 3)).unwrap();
+        assert_eq!(load(&tmp.file(), "kind-a"), Some(snapshot(1000, 3)));
+    }
+
+    #[test]
+    fn keeps_only_the_most_recently_updated_contexts() {
+        let tmp = TempDir::new("cap");
+        for i in 0..12 {
+            save(&tmp.file(), &format!("kind-{i}"), snapshot(i, 1)).unwrap();
+        }
+
+        // The two oldest fall off; the ten newest survive.
+        assert_eq!(load(&tmp.file(), "kind-0"), None);
+        assert_eq!(load(&tmp.file(), "kind-1"), None);
+        assert_eq!(load(&tmp.file(), "kind-2"), Some(snapshot(2, 1)));
+        assert_eq!(load(&tmp.file(), "kind-11"), Some(snapshot(11, 1)));
+    }
+
+    #[test]
+    fn resaving_a_context_replaces_its_snapshot() {
+        let tmp = TempDir::new("replace");
+        save(&tmp.file(), "kind-a", snapshot(1000, 3)).unwrap();
+        save(&tmp.file(), "kind-a", snapshot(2000, 4)).unwrap();
+
+        assert_eq!(load(&tmp.file(), "kind-a"), Some(snapshot(2000, 4)));
+    }
+
+    #[test]
+    fn clears_one_context_without_touching_the_others() {
+        let tmp = TempDir::new("clear-one");
+        save(&tmp.file(), "kind-a", snapshot(1000, 3)).unwrap();
+        save(&tmp.file(), "kind-b", snapshot(2000, 5)).unwrap();
+
+        clear(&tmp.file(), Some("kind-a")).unwrap();
+
+        assert_eq!(load(&tmp.file(), "kind-a"), None);
+        assert_eq!(load(&tmp.file(), "kind-b"), Some(snapshot(2000, 5)));
+    }
+
+    #[test]
+    fn clears_everything_when_no_context_is_given() {
+        let tmp = TempDir::new("clear-all");
+        save(&tmp.file(), "kind-a", snapshot(1000, 3)).unwrap();
+
+        clear(&tmp.file(), None).unwrap();
+
+        assert_eq!(load(&tmp.file(), "kind-a"), None);
+        assert!(!tmp.file().exists());
+    }
+
+    #[test]
+    fn clearing_is_idempotent() {
+        let tmp = TempDir::new("clear-idempotent");
+        clear(&tmp.file(), Some("kind-a")).unwrap();
+        clear(&tmp.file(), None).unwrap();
+    }
+}

--- a/apps/desktop/src-tauri/src/overview_snapshot.rs
+++ b/apps/desktop/src-tauri/src/overview_snapshot.rs
@@ -28,6 +28,14 @@ use tauri::{AppHandle, Manager};
 pub struct PersistedSnapshot {
     pub stats: serde_json::Value,
     pub updated_at: i64,
+    /// The cluster this snapshot came from (the context's server URL). A
+    /// context name can be deleted and reused for a different cluster; a
+    /// snapshot whose identity no longer matches must read as a cache miss,
+    /// not as the new cluster's data. Defaulted so pre-identity files parse —
+    /// and then mismatch, which retires them. Set by the save command, ignored
+    /// on the wire from the frontend.
+    #[serde(default)]
+    pub cluster: String,
 }
 
 /// Keep the file small: only the most recently refreshed contexts survive.
@@ -69,14 +77,21 @@ fn write_all(path: &Path, all: &BTreeMap<String, PersistedSnapshot>) -> Result<(
     fs::rename(&tmp, path).map_err(|e| format!("could not finalize {}: {e}", path.display()))
 }
 
-/// Last persisted snapshot for `context`, if any.
-fn load(path: &Path, context: &str) -> Option<PersistedSnapshot> {
-    read_all(path).remove(context)
+/// Last persisted snapshot for `context`, if it still belongs to `cluster` —
+/// an entry whose identity differs (or predates identities) is a miss.
+fn load(path: &Path, context: &str, cluster: &str) -> Option<PersistedSnapshot> {
+    read_all(path).remove(context).filter(|entry| entry.cluster == cluster)
 }
 
-/// Persist a snapshot for `context`, evicting the least recently updated
-/// contexts beyond the cap.
-fn save(path: &Path, context: &str, snapshot: PersistedSnapshot) -> Result<(), String> {
+/// Persist a snapshot for `context` under `cluster`'s identity, evicting the
+/// least recently updated contexts beyond the cap.
+fn save(
+    path: &Path,
+    context: &str,
+    cluster: &str,
+    mut snapshot: PersistedSnapshot,
+) -> Result<(), String> {
+    snapshot.cluster = cluster.to_owned();
     let mut all = read_all(path);
     all.insert(context.to_owned(), snapshot);
     if all.len() > MAX_CONTEXTS {
@@ -115,23 +130,42 @@ fn resolve_store_path(app: &AppHandle) -> Result<PathBuf, String> {
     Ok(base.join("overview.json"))
 }
 
-/// Load the last persisted overview snapshot for a context, if any.
-#[tauri::command]
-pub fn overview_snapshot_load(
-    app: AppHandle,
-    context: String,
-) -> Result<Option<PersistedSnapshot>, String> {
-    Ok(load(&resolve_store_path(&app)?, &context))
+/// A context's stable cluster identity — its server URL from the live
+/// kubeconfig set (no connection made). `None` when the context no longer
+/// exists there.
+async fn resolve_cluster(cache: &srelens_kube::client_cache::ClientCache, context: &str) -> Option<String> {
+    let paths = cache.paths().await;
+    srelens_kube::context_resolve::resolve_context(&paths, context).map(|c| c.server)
 }
 
-/// Persist a context's overview snapshot for the next cold start.
+/// Load the last persisted overview snapshot for a context, if it still
+/// belongs to the cluster that context currently points at.
 #[tauri::command]
-pub fn overview_snapshot_save(
+pub async fn overview_snapshot_load(
     app: AppHandle,
+    cache: tauri::State<'_, std::sync::Arc<srelens_kube::client_cache::ClientCache>>,
+    context: String,
+) -> Result<Option<PersistedSnapshot>, String> {
+    let Some(cluster) = resolve_cluster(&cache, &context).await else {
+        return Ok(None);
+    };
+    Ok(load(&resolve_store_path(&app)?, &context, &cluster))
+}
+
+/// Persist a context's overview snapshot for the next cold start. A context
+/// the kubeconfigs no longer know is not persisted — there is no identity to
+/// attribute the data to.
+#[tauri::command]
+pub async fn overview_snapshot_save(
+    app: AppHandle,
+    cache: tauri::State<'_, std::sync::Arc<srelens_kube::client_cache::ClientCache>>,
     context: String,
     snapshot: PersistedSnapshot,
 ) -> Result<(), String> {
-    save(&resolve_store_path(&app)?, &context, snapshot)
+    let Some(cluster) = resolve_cluster(&cache, &context).await else {
+        return Ok(());
+    };
+    save(&resolve_store_path(&app)?, &context, &cluster, snapshot)
 }
 
 /// Drop one context's persisted snapshot, or all of them.
@@ -172,27 +206,30 @@ mod tests {
         }
     }
 
+    const CLUSTER: &str = "https://prod:6443";
+
     fn snapshot(updated_at: i64, nodes: i64) -> PersistedSnapshot {
         PersistedSnapshot {
             stats: json!({ "nodes": { "total": nodes, "ready": nodes } }),
             updated_at,
+            cluster: CLUSTER.to_owned(),
         }
     }
 
     #[test]
     fn round_trips_a_snapshot_per_context() {
         let tmp = TempDir::new("roundtrip");
-        save(&tmp.file(), "kind-a", snapshot(1000, 3)).unwrap();
-        save(&tmp.file(), "kind-b", snapshot(2000, 5)).unwrap();
+        save(&tmp.file(), "kind-a", CLUSTER, snapshot(1000, 3)).unwrap();
+        save(&tmp.file(), "kind-b", CLUSTER, snapshot(2000, 5)).unwrap();
 
-        assert_eq!(load(&tmp.file(), "kind-a"), Some(snapshot(1000, 3)));
-        assert_eq!(load(&tmp.file(), "kind-b"), Some(snapshot(2000, 5)));
+        assert_eq!(load(&tmp.file(), "kind-a", CLUSTER), Some(snapshot(1000, 3)));
+        assert_eq!(load(&tmp.file(), "kind-b", CLUSTER), Some(snapshot(2000, 5)));
     }
 
     #[test]
     fn missing_file_loads_nothing() {
         let tmp = TempDir::new("missing");
-        assert_eq!(load(&tmp.file(), "kind-a"), None);
+        assert_eq!(load(&tmp.file(), "kind-a", CLUSTER), None);
     }
 
     #[test]
@@ -200,56 +237,77 @@ mod tests {
         let tmp = TempDir::new("corrupt");
         fs::write(tmp.file(), "{not json").unwrap();
 
-        assert_eq!(load(&tmp.file(), "kind-a"), None);
+        assert_eq!(load(&tmp.file(), "kind-a", CLUSTER), None);
 
         // A save starts the cache over rather than failing on the bad file.
-        save(&tmp.file(), "kind-a", snapshot(1000, 3)).unwrap();
-        assert_eq!(load(&tmp.file(), "kind-a"), Some(snapshot(1000, 3)));
+        save(&tmp.file(), "kind-a", CLUSTER, snapshot(1000, 3)).unwrap();
+        assert_eq!(load(&tmp.file(), "kind-a", CLUSTER), Some(snapshot(1000, 3)));
     }
 
     #[test]
     fn keeps_only_the_most_recently_updated_contexts() {
         let tmp = TempDir::new("cap");
         for i in 0..12 {
-            save(&tmp.file(), &format!("kind-{i}"), snapshot(i, 1)).unwrap();
+            save(&tmp.file(), &format!("kind-{i}"), CLUSTER, snapshot(i, 1)).unwrap();
         }
 
         // The two oldest fall off; the ten newest survive.
-        assert_eq!(load(&tmp.file(), "kind-0"), None);
-        assert_eq!(load(&tmp.file(), "kind-1"), None);
-        assert_eq!(load(&tmp.file(), "kind-2"), Some(snapshot(2, 1)));
-        assert_eq!(load(&tmp.file(), "kind-11"), Some(snapshot(11, 1)));
+        assert_eq!(load(&tmp.file(), "kind-0", CLUSTER), None);
+        assert_eq!(load(&tmp.file(), "kind-1", CLUSTER), None);
+        assert_eq!(load(&tmp.file(), "kind-2", CLUSTER), Some(snapshot(2, 1)));
+        assert_eq!(load(&tmp.file(), "kind-11", CLUSTER), Some(snapshot(11, 1)));
+    }
+
+    /// A context name deleted and reused for a different cluster must not
+    /// resolve the old cluster's snapshot: identity, not just name, gates a hit.
+    #[test]
+    fn context_reused_for_a_different_cluster_reads_as_a_miss() {
+        let tmp = TempDir::new("recycled");
+        save(&tmp.file(), "prod", CLUSTER, snapshot(1000, 3)).unwrap();
+
+        assert_eq!(load(&tmp.file(), "prod", "https://other:6443"), None);
+        assert_eq!(load(&tmp.file(), "prod", CLUSTER), Some(snapshot(1000, 3)));
+    }
+
+    /// Files written before the identity field existed parse (serde default)
+    /// but must retire as misses rather than pass for the current cluster.
+    #[test]
+    fn legacy_entries_without_a_cluster_identity_read_as_misses() {
+        let tmp = TempDir::new("legacy");
+        fs::write(tmp.file(), r#"{"prod":{"stats":{},"updatedAt":5}}"#).unwrap();
+
+        assert_eq!(load(&tmp.file(), "prod", CLUSTER), None);
     }
 
     #[test]
     fn resaving_a_context_replaces_its_snapshot() {
         let tmp = TempDir::new("replace");
-        save(&tmp.file(), "kind-a", snapshot(1000, 3)).unwrap();
-        save(&tmp.file(), "kind-a", snapshot(2000, 4)).unwrap();
+        save(&tmp.file(), "kind-a", CLUSTER, snapshot(1000, 3)).unwrap();
+        save(&tmp.file(), "kind-a", CLUSTER, snapshot(2000, 4)).unwrap();
 
-        assert_eq!(load(&tmp.file(), "kind-a"), Some(snapshot(2000, 4)));
+        assert_eq!(load(&tmp.file(), "kind-a", CLUSTER), Some(snapshot(2000, 4)));
     }
 
     #[test]
     fn clears_one_context_without_touching_the_others() {
         let tmp = TempDir::new("clear-one");
-        save(&tmp.file(), "kind-a", snapshot(1000, 3)).unwrap();
-        save(&tmp.file(), "kind-b", snapshot(2000, 5)).unwrap();
+        save(&tmp.file(), "kind-a", CLUSTER, snapshot(1000, 3)).unwrap();
+        save(&tmp.file(), "kind-b", CLUSTER, snapshot(2000, 5)).unwrap();
 
         clear(&tmp.file(), Some("kind-a")).unwrap();
 
-        assert_eq!(load(&tmp.file(), "kind-a"), None);
-        assert_eq!(load(&tmp.file(), "kind-b"), Some(snapshot(2000, 5)));
+        assert_eq!(load(&tmp.file(), "kind-a", CLUSTER), None);
+        assert_eq!(load(&tmp.file(), "kind-b", CLUSTER), Some(snapshot(2000, 5)));
     }
 
     #[test]
     fn clears_everything_when_no_context_is_given() {
         let tmp = TempDir::new("clear-all");
-        save(&tmp.file(), "kind-a", snapshot(1000, 3)).unwrap();
+        save(&tmp.file(), "kind-a", CLUSTER, snapshot(1000, 3)).unwrap();
 
         clear(&tmp.file(), None).unwrap();
 
-        assert_eq!(load(&tmp.file(), "kind-a"), None);
+        assert_eq!(load(&tmp.file(), "kind-a", CLUSTER), None);
         assert!(!tmp.file().exists());
     }
 
@@ -262,7 +320,7 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
 
         let tmp = TempDir::new("perms");
-        save(&tmp.file(), "kind-a", snapshot(1000, 3)).unwrap();
+        save(&tmp.file(), "kind-a", CLUSTER, snapshot(1000, 3)).unwrap();
 
         let mode = fs::metadata(tmp.file()).unwrap().permissions().mode();
         assert_eq!(mode & 0o777, 0o600, "overview.json must be 0600, got {mode:o}");
@@ -277,13 +335,13 @@ mod tests {
         let foreign = tmp.file().with_extension("json.tmp");
         fs::write(&foreign, "other writer's half-finished payload").unwrap();
 
-        save(&tmp.file(), "kind-a", snapshot(1000, 3)).unwrap();
+        save(&tmp.file(), "kind-a", CLUSTER, snapshot(1000, 3)).unwrap();
 
         assert_eq!(
             fs::read_to_string(&foreign).unwrap(),
             "other writer's half-finished payload"
         );
-        assert_eq!(load(&tmp.file(), "kind-a"), Some(snapshot(1000, 3)));
+        assert_eq!(load(&tmp.file(), "kind-a", CLUSTER), Some(snapshot(1000, 3)));
     }
 
     #[test]

--- a/apps/desktop/src/components/ClusterOverview.test.tsx
+++ b/apps/desktop/src/components/ClusterOverview.test.tsx
@@ -8,6 +8,9 @@ const mocks = vi.hoisted(() => ({
   listNodes: vi.fn(),
   listResource: vi.fn(),
   listEvents: vi.fn(),
+  loadPersistedOverview: vi.fn(),
+  persistOverview: vi.fn(),
+  clearPersistedOverview: vi.fn(),
 }));
 
 vi.mock("../lib/workloads", () => ({
@@ -21,7 +24,14 @@ vi.mock("../lib/manifest", () => ({
   listEvents: mocks.listEvents,
 }));
 
+vi.mock("../lib/overviewSnapshot", () => ({
+  loadPersistedOverview: mocks.loadPersistedOverview,
+  persistOverview: mocks.persistOverview,
+  clearPersistedOverview: mocks.clearPersistedOverview,
+}));
+
 import { ClusterOverview, clearClusterOverviewCache } from "./ClusterOverview";
+import type { OverviewSnapshot } from "../lib/overviewSnapshot";
 
 beforeEach(() => {
   clearClusterOverviewCache();
@@ -31,6 +41,9 @@ beforeEach(() => {
   mocks.listResource.mockResolvedValue({ items: [{ name: "one" }] });
   mocks.listNamespaces.mockResolvedValue({ namespaces: ["default"] });
   mocks.listEvents.mockResolvedValue({ events: [] });
+  mocks.loadPersistedOverview.mockResolvedValue(null);
+  mocks.persistOverview.mockResolvedValue(undefined);
+  mocks.clearPersistedOverview.mockResolvedValue(undefined);
 });
 
 describe("ClusterOverview cache", () => {
@@ -53,6 +66,90 @@ describe("ClusterOverview cache", () => {
     fireEvent.click(screen.getByRole("button", { name: "Refresh cluster overview" }));
     expect(screen.getAllByText("1 / 1")).toHaveLength(2);
     await waitFor(() => expect(mocks.listNodes).toHaveBeenCalledTimes(2));
+  });
+});
+
+function persistedSnapshot(updatedAt: number): OverviewSnapshot {
+  return {
+    stats: {
+      nodes: { total: 4, ready: 3 },
+      pods: { total: 6, running: 5, pending: 1, other: 0 },
+      deployments: 2,
+      services: 3,
+      namespaces: 4,
+      events: { total: 0, normal: 0, warnings: 0, recentWarnings: [] },
+    },
+    updatedAt,
+  };
+}
+
+/** A promise the test resolves by hand, to order fetch vs hydrate. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => (resolve = r));
+  return { promise, resolve };
+}
+
+describe("ClusterOverview persistence", () => {
+  it("hydrates the persisted snapshot while the first fetch is pending", async () => {
+    mocks.loadPersistedOverview.mockResolvedValue(persistedSnapshot(Date.now() - 3 * 86_400_000));
+    // Never-resolving fetches: only the persisted snapshot can paint the tiles.
+    mocks.listNodes.mockReturnValue(new Promise(() => {}));
+
+    render(<ClusterOverview context="kind-cold" />);
+
+    expect(await screen.findByText("3 / 4")).toBeDefined();
+    expect(screen.getByText("5 / 6")).toBeDefined();
+    expect(mocks.loadPersistedOverview).toHaveBeenCalledWith("kind-cold");
+  });
+
+  it("shows the snapshot's date while hydrated data is days old", async () => {
+    mocks.loadPersistedOverview.mockResolvedValue(persistedSnapshot(Date.now() - 3 * 86_400_000));
+    mocks.listNodes.mockReturnValue(new Promise(() => {}));
+
+    render(<ClusterOverview context="kind-cold" />);
+
+    // A days-old timestamp must not masquerade as today's: the header shows its date.
+    expect(await screen.findByText(/updated .*\b20\d\d\b/)).toBeDefined();
+  });
+
+  it("replaces the hydrated snapshot when fresh data arrives", async () => {
+    mocks.loadPersistedOverview.mockResolvedValue(persistedSnapshot(Date.now() - 3 * 86_400_000));
+
+    render(<ClusterOverview context="kind-cold" />);
+
+    expect(await screen.findAllByText("1 / 1")).toHaveLength(2);
+    expect(screen.queryByText("3 / 4")).toBeNull();
+  });
+
+  it("never lets a slow hydrate clobber already-fresh data", async () => {
+    const slowLoad = deferred<OverviewSnapshot>();
+    mocks.loadPersistedOverview.mockReturnValue(slowLoad.promise);
+
+    render(<ClusterOverview context="kind-race" />);
+    expect(await screen.findAllByText("1 / 1")).toHaveLength(2);
+
+    slowLoad.resolve(persistedSnapshot(Date.now() - 3 * 86_400_000));
+    await waitFor(() => expect(screen.queryByText("3 / 4")).toBeNull());
+    expect(screen.getAllByText("1 / 1")).toHaveLength(2);
+  });
+
+  it("persists a successful fetch for the next cold start", async () => {
+    render(<ClusterOverview context="kind-dev" />);
+    expect(await screen.findAllByText("1 / 1")).toHaveLength(2);
+
+    await waitFor(() => expect(mocks.persistOverview).toHaveBeenCalledTimes(1));
+    const [context, snapshot] = mocks.persistOverview.mock.calls[0];
+    expect(context).toBe("kind-dev");
+    expect(snapshot.stats.nodes).toEqual({ total: 1, ready: 1 });
+  });
+
+  it("clearClusterOverviewCache also clears the persisted copy", () => {
+    clearClusterOverviewCache("kind-a");
+    expect(mocks.clearPersistedOverview).toHaveBeenCalledWith("kind-a");
+
+    clearClusterOverviewCache();
+    expect(mocks.clearPersistedOverview).toHaveBeenCalledWith(undefined);
   });
 });
 

--- a/apps/desktop/src/components/ClusterOverview.test.tsx
+++ b/apps/desktop/src/components/ClusterOverview.test.tsx
@@ -134,6 +134,24 @@ describe("ClusterOverview persistence", () => {
     expect(screen.getAllByText("1 / 1")).toHaveLength(2);
   });
 
+  it("remounting during the first fetch still applies the fresh result", async () => {
+    // A recent (within-TTL) persisted snapshot must not let a remount skip
+    // joining the pending live request — the fresh data has to reach the
+    // screen, not just the module cache.
+    mocks.loadPersistedOverview.mockResolvedValue(persistedSnapshot(Date.now() - 1000));
+    const slowNodes = deferred<{ nodes: Array<{ status: string }> }>();
+    mocks.listNodes.mockReturnValue(slowNodes.promise);
+
+    const first = render(<ClusterOverview context="kind-remount" />);
+    expect(await screen.findByText("3 / 4")).toBeDefined();
+    first.unmount();
+
+    render(<ClusterOverview context="kind-remount" />);
+    slowNodes.resolve({ nodes: [{ status: "Ready" }] });
+
+    expect(await screen.findAllByText("1 / 1")).toHaveLength(2);
+  });
+
   it("persists a successful fetch for the next cold start", async () => {
     render(<ClusterOverview context="kind-dev" />);
     expect(await screen.findAllByText("1 / 1")).toHaveLength(2);

--- a/apps/desktop/src/components/ClusterOverview.test.tsx
+++ b/apps/desktop/src/components/ClusterOverview.test.tsx
@@ -162,6 +162,20 @@ describe("ClusterOverview persistence", () => {
     expect(snapshot.stats.nodes).toEqual({ total: 1, ready: 1 });
   });
 
+  it("a clear during an in-flight fetch stops it from repopulating the caches", async () => {
+    // The documented logout/reset flow: nothing fetched before the clear may
+    // survive it — the resolving request must not re-cache or re-persist.
+    const slowNodes = deferred<{ nodes: Array<{ status: string }> }>();
+    mocks.listNodes.mockReturnValue(slowNodes.promise);
+
+    render(<ClusterOverview context="kind-clear" />);
+    clearClusterOverviewCache();
+    slowNodes.resolve({ nodes: [{ status: "Ready" }] });
+
+    expect(await screen.findAllByText("1 / 1")).toHaveLength(2);
+    expect(mocks.persistOverview).not.toHaveBeenCalled();
+  });
+
   it("clearClusterOverviewCache also clears the persisted copy", () => {
     clearClusterOverviewCache("kind-a");
     expect(mocks.clearPersistedOverview).toHaveBeenCalledWith("kind-a");

--- a/apps/desktop/src/components/ClusterOverview.tsx
+++ b/apps/desktop/src/components/ClusterOverview.tsx
@@ -160,14 +160,17 @@ export function ClusterOverview({
     }
 
     // Cold start: while the fetch runs, restore the last persisted snapshot so
-    // the dashboard paints known values instead of a spinner (#148). The fetch
-    // populates `overviewCache` when it lands, so a snapshot that loses the
-    // race is discarded rather than clobbering fresher data — and after a
-    // failed fetch it still gives the error state stale-but-real numbers.
+    // the dashboard paints known values instead of a spinner (#148). The
+    // restored values go only into component state, never `overviewCache` —
+    // the cache means "live data from this run", and a persisted snapshot
+    // recent enough to pass the TTL check would otherwise let a remount skip
+    // joining the still-pending request and strand the screen on stale values.
+    // A snapshot that loses the race with the fetch (cache already populated)
+    // is discarded rather than clobbering fresher data — while after a failed
+    // fetch it still gives the error state stale-but-real numbers.
     if (!cached) {
       void loadPersistedOverview(context).then((persisted) => {
         if (!active || !persisted || overviewCache.has(context)) return;
-        overviewCache.set(context, persisted);
         setStats(persisted.stats);
         setLastUpdated(formatUpdatedAt(persisted.updatedAt));
       });

--- a/apps/desktop/src/components/ClusterOverview.tsx
+++ b/apps/desktop/src/components/ClusterOverview.tsx
@@ -15,29 +15,24 @@ import {
   StatusMeter,
 } from "../ui";
 import { describeError, isExecAuthError } from "../lib/errors";
+import {
+  clearPersistedOverview,
+  loadPersistedOverview,
+  persistOverview,
+  type OverviewSnapshot,
+  type OverviewStats as Stats,
+} from "../lib/overviewSnapshot";
 import { isTauri } from "../transport/platform";
 import type { ResourceKind } from "./ResourceBrowser";
-
-interface Stats {
-  nodes: { total: number; ready: number };
-  pods: { total: number; running: number; pending: number; other: number };
-  deployments: number;
-  services: number;
-  namespaces: number;
-  events: { total: number; normal: number; warnings: number; recentWarnings: string[] };
-}
-
-interface OverviewSnapshot {
-  stats: Stats;
-  updatedAt: number;
-}
 
 const CACHE_TTL_MS = 30_000;
 const overviewCache = new Map<string, OverviewSnapshot>();
 const overviewRequests = new Map<string, Promise<OverviewSnapshot>>();
 
-/** Clear cached overview snapshots. Exported for deterministic tests and future logout/reset flows. */
+/** Clear cached overview snapshots, including the backend's persisted copies.
+ * Exported for deterministic tests and future logout/reset flows. */
 export function clearClusterOverviewCache(context?: string) {
+  void clearPersistedOverview(context);
   if (context) {
     overviewCache.delete(context);
     overviewRequests.delete(context);
@@ -48,7 +43,14 @@ export function clearClusterOverviewCache(context?: string) {
 }
 
 function formatUpdatedAt(updatedAt: number) {
-  return new Intl.DateTimeFormat(undefined, { timeStyle: "medium" }).format(new Date(updatedAt));
+  const date = new Date(updatedAt);
+  // A restored snapshot can be days old — a bare time of day would masquerade
+  // as today's, so anything not from today carries its date.
+  const options: Intl.DateTimeFormatOptions =
+    date.toDateString() === new Date().toDateString()
+      ? { timeStyle: "medium" }
+      : { dateStyle: "medium", timeStyle: "short" };
+  return new Intl.DateTimeFormat(undefined, options).format(date);
 }
 
 async function fetchOverview(context: string): Promise<OverviewSnapshot> {
@@ -104,6 +106,7 @@ function requestOverview(context: string, force: boolean): Promise<OverviewSnaps
   const request = fetchOverview(context)
     .then((snapshot) => {
       overviewCache.set(context, snapshot);
+      void persistOverview(context, snapshot);
       return snapshot;
     })
     .finally(() => {
@@ -154,6 +157,20 @@ export function ClusterOverview({
       return () => {
         active = false;
       };
+    }
+
+    // Cold start: while the fetch runs, restore the last persisted snapshot so
+    // the dashboard paints known values instead of a spinner (#148). The fetch
+    // populates `overviewCache` when it lands, so a snapshot that loses the
+    // race is discarded rather than clobbering fresher data — and after a
+    // failed fetch it still gives the error state stale-but-real numbers.
+    if (!cached) {
+      void loadPersistedOverview(context).then((persisted) => {
+        if (!active || !persisted || overviewCache.has(context)) return;
+        overviewCache.set(context, persisted);
+        setStats(persisted.stats);
+        setLastUpdated(formatUpdatedAt(persisted.updatedAt));
+      });
     }
 
     setRefreshing(true);

--- a/apps/desktop/src/components/ClusterOverview.tsx
+++ b/apps/desktop/src/components/ClusterOverview.tsx
@@ -28,10 +28,15 @@ import type { ResourceKind } from "./ResourceBrowser";
 const CACHE_TTL_MS = 30_000;
 const overviewCache = new Map<string, OverviewSnapshot>();
 const overviewRequests = new Map<string, Promise<OverviewSnapshot>>();
+// Bumped by every clear. A fetch captures it at start and only writes the
+// caches if no clear happened in between — deleting the pending promise can't
+// cancel its .then, and a reset must not be undone by a late resolution.
+let clearGeneration = 0;
 
 /** Clear cached overview snapshots, including the backend's persisted copies.
  * Exported for deterministic tests and future logout/reset flows. */
 export function clearClusterOverviewCache(context?: string) {
+  clearGeneration++;
   void clearPersistedOverview(context);
   if (context) {
     overviewCache.delete(context);
@@ -103,10 +108,13 @@ function requestOverview(context: string, force: boolean): Promise<OverviewSnaps
   const pending = overviewRequests.get(context);
   if (pending) return pending;
 
+  const generation = clearGeneration;
   const request = fetchOverview(context)
     .then((snapshot) => {
-      overviewCache.set(context, snapshot);
-      void persistOverview(context, snapshot);
+      if (clearGeneration === generation) {
+        overviewCache.set(context, snapshot);
+        void persistOverview(context, snapshot);
+      }
       return snapshot;
     })
     .finally(() => {

--- a/apps/desktop/src/lib/overviewSnapshot.test.ts
+++ b/apps/desktop/src/lib/overviewSnapshot.test.ts
@@ -53,6 +53,15 @@ describe("loadPersistedOverview", () => {
     expect(await loadPersistedOverview("kind-dev", invoke)).toBeNull();
   });
 
+  it("returns null when the timestamp can't be represented as a Date", async () => {
+    // Rust's i64 round-trips values far past JS's ±8.64e15 Date range;
+    // formatUpdatedAt would throw a RangeError on them mid-hydration.
+    for (const updatedAt of [9_000_000_000_000_000, -9_000_000_000_000_000]) {
+      const invoke = vi.fn().mockResolvedValue({ ...snapshot(), updatedAt });
+      expect(await loadPersistedOverview("kind-dev", invoke)).toBeNull();
+    }
+  });
+
   it("returns null when stats is missing nested fields (older schema)", async () => {
     // Syntactically valid but incomplete payloads must read as cache misses:
     // the overview dereferences stats.nodes.ready etc. straight in render.

--- a/apps/desktop/src/lib/overviewSnapshot.test.ts
+++ b/apps/desktop/src/lib/overviewSnapshot.test.ts
@@ -44,6 +44,23 @@ describe("loadPersistedOverview", () => {
     const invoke = vi.fn().mockResolvedValue({ stats: null, updatedAt: "yesterday" });
     expect(await loadPersistedOverview("kind-dev", invoke)).toBeNull();
   });
+
+  it("returns null when stats is missing nested fields (older schema)", async () => {
+    // Syntactically valid but incomplete payloads must read as cache misses:
+    // the overview dereferences stats.nodes.ready etc. straight in render.
+    const incomplete = [
+      { stats: {}, updatedAt: 123 },
+      { stats: { nodes: { total: 1, ready: 1 } }, updatedAt: 123 },
+      { ...snapshot(), stats: { ...snapshot().stats, pods: { total: 6 } } },
+      { ...snapshot(), stats: { ...snapshot().stats, events: { total: 0 } } },
+      { ...snapshot(), stats: { ...snapshot().stats, deployments: "2" } },
+      { ...snapshot(), stats: { ...snapshot().stats, events: null } },
+    ];
+    for (const payload of incomplete) {
+      const invoke = vi.fn().mockResolvedValue(payload);
+      expect(await loadPersistedOverview("kind-dev", invoke)).toBeNull();
+    }
+  });
 });
 
 describe("persistOverview", () => {

--- a/apps/desktop/src/lib/overviewSnapshot.test.ts
+++ b/apps/desktop/src/lib/overviewSnapshot.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  clearPersistedOverview,
+  loadPersistedOverview,
+  persistOverview,
+  type OverviewSnapshot,
+} from "./overviewSnapshot";
+
+function snapshot(): OverviewSnapshot {
+  return {
+    stats: {
+      nodes: { total: 4, ready: 3 },
+      pods: { total: 6, running: 5, pending: 1, other: 0 },
+      deployments: 2,
+      services: 3,
+      namespaces: 4,
+      events: { total: 0, normal: 0, warnings: 0, recentWarnings: [] },
+    },
+    updatedAt: 1_755_000_000_000,
+  };
+}
+
+describe("loadPersistedOverview", () => {
+  it("loads the snapshot via overview_snapshot_load", async () => {
+    const invoke = vi.fn().mockResolvedValue(snapshot());
+
+    const loaded = await loadPersistedOverview("kind-dev", invoke);
+
+    expect(invoke).toHaveBeenCalledWith("overview_snapshot_load", { context: "kind-dev" });
+    expect(loaded).toEqual(snapshot());
+  });
+
+  it("returns null when nothing is persisted", async () => {
+    const invoke = vi.fn().mockResolvedValue(null);
+    expect(await loadPersistedOverview("kind-dev", invoke)).toBeNull();
+  });
+
+  it("returns null when the command is unavailable (web mode)", async () => {
+    const invoke = vi.fn().mockRejectedValue(new Error("unknown command: overview_snapshot_load"));
+    expect(await loadPersistedOverview("kind-dev", invoke)).toBeNull();
+  });
+
+  it("returns null when the payload has the wrong shape", async () => {
+    const invoke = vi.fn().mockResolvedValue({ stats: null, updatedAt: "yesterday" });
+    expect(await loadPersistedOverview("kind-dev", invoke)).toBeNull();
+  });
+});
+
+describe("persistOverview", () => {
+  it("saves the snapshot via overview_snapshot_save", async () => {
+    const invoke = vi.fn().mockResolvedValue(null);
+
+    await persistOverview("kind-dev", snapshot(), invoke);
+
+    expect(invoke).toHaveBeenCalledWith("overview_snapshot_save", {
+      context: "kind-dev",
+      snapshot: snapshot(),
+    });
+  });
+
+  it("swallows command failures", async () => {
+    const invoke = vi.fn().mockRejectedValue(new Error("unknown command"));
+    await expect(persistOverview("kind-dev", snapshot(), invoke)).resolves.toBeUndefined();
+  });
+});
+
+describe("clearPersistedOverview", () => {
+  it("clears one context via overview_snapshot_clear", async () => {
+    const invoke = vi.fn().mockResolvedValue(null);
+
+    await clearPersistedOverview("kind-dev", invoke);
+
+    expect(invoke).toHaveBeenCalledWith("overview_snapshot_clear", { context: "kind-dev" });
+  });
+
+  it("clears every context when called without one", async () => {
+    const invoke = vi.fn().mockResolvedValue(null);
+
+    await clearPersistedOverview(undefined, invoke);
+
+    expect(invoke).toHaveBeenCalledWith("overview_snapshot_clear", { context: null });
+  });
+
+  it("swallows command failures", async () => {
+    const invoke = vi.fn().mockRejectedValue(new Error("unknown command"));
+    await expect(clearPersistedOverview("kind-dev", invoke)).resolves.toBeUndefined();
+  });
+});

--- a/apps/desktop/src/lib/overviewSnapshot.test.ts
+++ b/apps/desktop/src/lib/overviewSnapshot.test.ts
@@ -1,10 +1,18 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const platform = vi.hoisted(() => ({ isTauri: vi.fn() }));
+vi.mock("../transport/platform", () => ({ isTauri: platform.isTauri }));
+
 import {
   clearPersistedOverview,
   loadPersistedOverview,
   persistOverview,
   type OverviewSnapshot,
 } from "./overviewSnapshot";
+
+beforeEach(() => {
+  platform.isTauri.mockReturnValue(true);
+});
 
 function snapshot(): OverviewSnapshot {
   return {
@@ -78,6 +86,21 @@ describe("persistOverview", () => {
   it("swallows command failures", async () => {
     const invoke = vi.fn().mockRejectedValue(new Error("unknown command"));
     await expect(persistOverview("kind-dev", snapshot(), invoke)).resolves.toBeUndefined();
+  });
+});
+
+describe("web mode", () => {
+  // The commands only exist on desktop; in web mode each call would be a real
+  // authenticated HTTP request the server 404s after resolving the user's env.
+  it("never sends the commands when not running under Tauri", async () => {
+    platform.isTauri.mockReturnValue(false);
+    const invoke = vi.fn();
+
+    expect(await loadPersistedOverview("kind-dev", invoke)).toBeNull();
+    await persistOverview("kind-dev", snapshot(), invoke);
+    await clearPersistedOverview("kind-dev", invoke);
+
+    expect(invoke).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/desktop/src/lib/overviewSnapshot.ts
+++ b/apps/desktop/src/lib/overviewSnapshot.ts
@@ -3,9 +3,11 @@
 // overview so a cold start paints the last known counts instantly.
 //
 // The backend treats `stats` as opaque JSON: this module owns the shape.
-// Every wrapper degrades to a no-op on failure — in web mode the commands
-// don't exist ("unknown command"), and a broken cache must never break the
-// overview itself.
+// Every wrapper degrades to a no-op on failure or off desktop — the commands
+// only exist under Tauri, so in web mode they short-circuit client-side
+// instead of sending authenticated HTTP requests the server would 404 — and
+// a broken cache must never break the overview itself.
+import { isTauri } from "../transport/platform";
 import { invokeCommand } from "../transport/transport";
 
 /** Cluster overview counts, as shown on the dashboard tiles. */
@@ -55,6 +57,7 @@ export async function loadPersistedOverview(
   context: string,
   invoke: Invoker = invokeCommand,
 ): Promise<OverviewSnapshot | null> {
+  if (!isTauri()) return null;
   try {
     const out = await invoke<OverviewSnapshot | null>("overview_snapshot_load", { context });
     if (!out || typeof out !== "object") return null;
@@ -72,10 +75,11 @@ export async function persistOverview(
   snapshot: OverviewSnapshot,
   invoke: Invoker = invokeCommand,
 ): Promise<void> {
+  if (!isTauri()) return;
   try {
     await invoke("overview_snapshot_save", { context, snapshot });
   } catch {
-    // web mode / storage failure — the overview works without the cache
+    // storage failure — the overview works without the cache
   }
 }
 
@@ -84,9 +88,10 @@ export async function clearPersistedOverview(
   context?: string,
   invoke: Invoker = invokeCommand,
 ): Promise<void> {
+  if (!isTauri()) return;
   try {
     await invoke("overview_snapshot_clear", { context: context ?? null });
   } catch {
-    // web mode / storage failure — nothing to clear
+    // storage failure — nothing to clear
   }
 }

--- a/apps/desktop/src/lib/overviewSnapshot.ts
+++ b/apps/desktop/src/lib/overviewSnapshot.ts
@@ -63,6 +63,9 @@ export async function loadPersistedOverview(
     if (!out || typeof out !== "object") return null;
     if (!isOverviewStats(out.stats)) return null;
     if (typeof out.updatedAt !== "number") return null;
+    // The backend's i64 outranges JS dates; formatUpdatedAt would throw on an
+    // unrepresentable timestamp, so it reads as a cache miss instead.
+    if (Number.isNaN(new Date(out.updatedAt).getTime())) return null;
     return out;
   } catch {
     return null;

--- a/apps/desktop/src/lib/overviewSnapshot.ts
+++ b/apps/desktop/src/lib/overviewSnapshot.ts
@@ -1,0 +1,69 @@
+// Typed wrappers for the overview-snapshot commands (backend:
+// `overview_snapshot.rs`, issue #148) — disk persistence for the cluster
+// overview so a cold start paints the last known counts instantly.
+//
+// The backend treats `stats` as opaque JSON: this module owns the shape.
+// Every wrapper degrades to a no-op on failure — in web mode the commands
+// don't exist ("unknown command"), and a broken cache must never break the
+// overview itself.
+import { invokeCommand } from "../transport/transport";
+
+/** Cluster overview counts, as shown on the dashboard tiles. */
+export interface OverviewStats {
+  nodes: { total: number; ready: number };
+  pods: { total: number; running: number; pending: number; other: number };
+  deployments: number;
+  services: number;
+  namespaces: number;
+  events: { total: number; normal: number; warnings: number; recentWarnings: string[] };
+}
+
+/** A point-in-time overview, persisted so a cold start can render instantly. */
+export interface OverviewSnapshot {
+  stats: OverviewStats;
+  updatedAt: number;
+}
+
+/** A command invoker — injectable for testing. */
+type Invoker = <T>(command: string, args?: Record<string, unknown>) => Promise<T>;
+
+/** Last persisted snapshot for a context, or null if absent or unavailable. */
+export async function loadPersistedOverview(
+  context: string,
+  invoke: Invoker = invokeCommand,
+): Promise<OverviewSnapshot | null> {
+  try {
+    const out = await invoke<OverviewSnapshot | null>("overview_snapshot_load", { context });
+    if (!out || typeof out !== "object") return null;
+    if (!out.stats || typeof out.stats !== "object") return null;
+    if (typeof out.updatedAt !== "number") return null;
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+/** Persist a context's snapshot for the next cold start (best-effort). */
+export async function persistOverview(
+  context: string,
+  snapshot: OverviewSnapshot,
+  invoke: Invoker = invokeCommand,
+): Promise<void> {
+  try {
+    await invoke("overview_snapshot_save", { context, snapshot });
+  } catch {
+    // web mode / storage failure — the overview works without the cache
+  }
+}
+
+/** Drop the persisted snapshot for one context, or all of them (best-effort). */
+export async function clearPersistedOverview(
+  context?: string,
+  invoke: Invoker = invokeCommand,
+): Promise<void> {
+  try {
+    await invoke("overview_snapshot_clear", { context: context ?? null });
+  } catch {
+    // web mode / storage failure — nothing to clear
+  }
+}

--- a/apps/desktop/src/lib/overviewSnapshot.ts
+++ b/apps/desktop/src/lib/overviewSnapshot.ts
@@ -27,6 +27,29 @@ export interface OverviewSnapshot {
 /** A command invoker — injectable for testing. */
 type Invoker = <T>(command: string, args?: Record<string, unknown>) => Promise<T>;
 
+function isNumbers(value: unknown, keys: string[]): boolean {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  return keys.every((key) => typeof record[key] === "number");
+}
+
+/** True only for a complete `OverviewStats` — the overview dereferences every
+ * nested field straight in render, so a snapshot from an older schema (or a
+ * half-corrupted file) must read as a cache miss, not crash the dashboard. */
+function isOverviewStats(value: unknown): value is OverviewStats {
+  if (!value || typeof value !== "object") return false;
+  const stats = value as Record<string, unknown>;
+  const events = stats.events as Record<string, unknown> | null | undefined;
+  return (
+    isNumbers(stats.nodes, ["total", "ready"]) &&
+    isNumbers(stats.pods, ["total", "running", "pending", "other"]) &&
+    isNumbers(stats, ["deployments", "services", "namespaces"]) &&
+    isNumbers(events, ["total", "normal", "warnings"]) &&
+    Array.isArray(events?.recentWarnings) &&
+    events.recentWarnings.every((warning) => typeof warning === "string")
+  );
+}
+
 /** Last persisted snapshot for a context, or null if absent or unavailable. */
 export async function loadPersistedOverview(
   context: string,
@@ -35,7 +58,7 @@ export async function loadPersistedOverview(
   try {
     const out = await invoke<OverviewSnapshot | null>("overview_snapshot_load", { context });
     if (!out || typeof out !== "object") return null;
-    if (!out.stats || typeof out.stats !== "object") return null;
+    if (!isOverviewStats(out.stats)) return null;
     if (typeof out.updatedAt !== "number") return null;
     return out;
   } catch {


### PR DESCRIPTION
Closes #148.

## Summary

- persist the last cluster-overview snapshot per context on the Rust side instead of only in the in-memory `Map`, so a cold start paints the previous counts instantly while the real fetch runs
- new `overview_snapshot.rs` (pattern: `assistant_history.rs`): pure functions over a path with thin `#[tauri::command]` wrappers `overview_snapshot_load/save/clear`
- store is one `<app config dir>/overview.json` — context → snapshot map, atomic tmp+rename writes, capped at the 10 most recently refreshed contexts, corrupt file treated as an empty cache (never an error)
- `stats` stays opaque JSON to the backend; the frontend owns the shape (same contract as assistant session `messages`)
- `ClusterOverview` hydrates the persisted snapshot on a cache miss while fetching; a hydrate that loses the race never clobbers fresher data, and a failed fetch still gets stale-but-real numbers instead of a bare error page
- days-old restored data shows its date in "updated …" instead of a misleading bare time of day
- `clearClusterOverviewCache` now clears the persisted copy too

## Web mode

The commands don't exist on the web command surface, so the typed wrappers degrade to a no-op there and web keeps today's behavior. Real web parity needs the store in a shared crate (or a per-user server DB table) — deferred, noted for a follow-up issue if wanted.

## Validation

- `cargo test -p srelens-desktop --lib` — 154 passed (8 new store tests)
- `pnpm test` — 128 files, 1007 tests passed; line coverage 83.87% → 84.94% (all new code covered; creeps toward #29's 85% goal)
- `cargo clippy -p srelens-desktop --lib` — no warnings in the new module
- all tests written first and watched fail (TDD)