### PR TITLE
feat(scale): slider with synced numeric input in the scale dialog

### DIFF
--- a/apps/desktop/src/components/DetailActions.test.tsx
+++ b/apps/desktop/src/components/DetailActions.test.tsx
@@ -281,9 +281,9 @@ describe("ResourceActions", () => {
     expect((screen.getByLabelText("Replicas") as HTMLInputElement).value).toBe("2");
     const slider = screen.getByRole("slider");
     expect(slider.getAttribute("aria-valuenow")).toBe("2");
-    // Range: 0 to max(currentReplicas * 2, 10).
+    // Range: 0 to max(currentReplicas * 2, 100).
     expect(slider.getAttribute("aria-valuemin")).toBe("0");
-    expect(slider.getAttribute("aria-valuemax")).toBe("10");
+    expect(slider.getAttribute("aria-valuemax")).toBe("100");
     // The row already knew the count — no object fetch needed.
     expect(getObjectMock).not.toHaveBeenCalled();
   });
@@ -353,19 +353,57 @@ describe("ResourceActions", () => {
     expect((screen.getByLabelText("Replicas") as HTMLInputElement).value).toBe("");
   });
 
-  it("widens the slider range for larger workloads", () => {
+  it("a pending fetch is invalidated by ANY later dialog open, not only fetching ones", async () => {
+    // The same component instance survives the detail switching resources.
+    // Open Scale on a ReplicaSet (fetch pending), switch to a Deployment
+    // whose row KNOWS its count (no fetch), open Scale again: the old fetch
+    // resolving now must not overwrite the Deployment's seeded count.
+    let resolveFetch!: (v: unknown) => void;
+    getObjectMock.mockReturnValue(new Promise((r) => (resolveFetch = r)));
+    const { rerender } = render(
+      <ResourceActions
+        context="kind-dev"
+        kind="ReplicaSet"
+        namespace="default"
+        name="web-abc123"
+        onDeleted={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Scale" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    rerender(
+      <ResourceActions
+        context="kind-dev"
+        kind="Deployment"
+        namespace="default"
+        name="api"
+        currentReplicas={3}
+        onDeleted={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Scale" }));
+    expect((screen.getByLabelText("Replicas") as HTMLInputElement).value).toBe("3");
+
+    resolveFetch({ object: { spec: { replicas: 9 } } });
+    await new Promise((r) => setTimeout(r, 0));
+    expect((screen.getByLabelText("Replicas") as HTMLInputElement).value).toBe("3");
+  });
+
+  it("widens the slider range past 100 for larger workloads", () => {
     render(
       <ResourceActions
         context="kind-dev"
         kind="Deployment"
         namespace="default"
         name="web"
-        currentReplicas={8}
+        currentReplicas={80}
         onDeleted={() => {}}
       />,
     );
     fireEvent.click(screen.getByRole("button", { name: "Scale" }));
-    expect(screen.getByRole("slider").getAttribute("aria-valuemax")).toBe("16");
+    // The slider must always be able to reach and double the current count.
+    expect(screen.getByRole("slider").getAttribute("aria-valuemax")).toBe("160");
   });
 
   it("keeps the numeric input and the slider in sync both ways", () => {

--- a/apps/desktop/src/components/DetailActions.test.tsx
+++ b/apps/desktop/src/components/DetailActions.test.tsx
@@ -329,6 +329,30 @@ describe("ResourceActions", () => {
     expect((screen.getByLabelText("Replicas") as HTMLInputElement).value).toBe("7");
   });
 
+  it("an intentionally CLEARED input also survives a late fetch", async () => {
+    // Clearing the field to type a fresh value is an edit: restoring the
+    // fetched count into the empty window would make the next digit append
+    // (clearing 4 to type 0 must not become 40).
+    let resolveFetch!: (v: unknown) => void;
+    getObjectMock.mockReturnValue(new Promise((r) => (resolveFetch = r)));
+    render(
+      <ResourceActions
+        context="kind-dev"
+        kind="ReplicaSet"
+        namespace="default"
+        name="web-abc123"
+        onDeleted={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Scale" }));
+    fireEvent.change(screen.getByLabelText("Replicas"), { target: { value: "7" } });
+    fireEvent.change(screen.getByLabelText("Replicas"), { target: { value: "" } });
+
+    resolveFetch({ object: { spec: { replicas: 4 } } });
+    await new Promise((r) => setTimeout(r, 0));
+    expect((screen.getByLabelText("Replicas") as HTMLInputElement).value).toBe("");
+  });
+
   it("widens the slider range for larger workloads", () => {
     render(
       <ResourceActions

--- a/apps/desktop/src/components/DetailActions.test.tsx
+++ b/apps/desktop/src/components/DetailActions.test.tsx
@@ -45,7 +45,7 @@ vi.mock("../lib/access", async (importOriginal) => {
 import { useAccess } from "../lib/access";
 import { describeError } from "../lib/errors";
 
-import { PodActions, ResourceActions } from "./DetailActions";
+import { PodActions, ResourceActions, desiredReplicasFrom } from "./DetailActions";
 
 const pod = {
   name: "web-1",
@@ -197,6 +197,23 @@ describe("PodActions", () => {
   });
 });
 
+describe("desiredReplicasFrom", () => {
+  it("derives the desired count from each scalable kind's row shape", () => {
+    // ReplicaSet rows carry `desired` directly.
+    expect(desiredReplicasFrom({ desired: 4, ready: 2 })).toBe(4);
+    // Deployment / StatefulSet rows encode it as "ready/total".
+    expect(desiredReplicasFrom({ ready: "1/3" })).toBe(3);
+    expect(desiredReplicasFrom({ ready: "0/0" })).toBe(0);
+  });
+
+  it("returns undefined when the row can't say", () => {
+    expect(desiredReplicasFrom(undefined)).toBeUndefined();
+    expect(desiredReplicasFrom({})).toBeUndefined();
+    expect(desiredReplicasFrom({ ready: "not-a-fraction" })).toBeUndefined();
+    expect(desiredReplicasFrom({ ready: 3 })).toBeUndefined();
+  });
+});
+
 describe("ResourceActions", () => {
   it("scales a deployment through the scale dialog", async () => {
     scaleResourceMock.mockResolvedValue({ ok: true });
@@ -219,6 +236,104 @@ describe("ResourceActions", () => {
     );
     // A success toast confirms the operation.
     await waitFor(() => expect(notifyMock.success).toHaveBeenCalledWith(expect.stringMatching(/Scaled web to 3/)));
+  });
+
+  it("defaults the scale dialog to the current replica count, on the slider too", () => {
+    render(
+      <ResourceActions
+        context="kind-dev"
+        kind="Deployment"
+        namespace="default"
+        name="web"
+        currentReplicas={2}
+        onDeleted={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Scale" }));
+
+    expect((screen.getByLabelText("Replicas") as HTMLInputElement).value).toBe("2");
+    const slider = screen.getByRole("slider");
+    expect(slider.getAttribute("aria-valuenow")).toBe("2");
+    // Range: 0 to max(currentReplicas * 2, 10).
+    expect(slider.getAttribute("aria-valuemin")).toBe("0");
+    expect(slider.getAttribute("aria-valuemax")).toBe("10");
+  });
+
+  it("widens the slider range for larger workloads", () => {
+    render(
+      <ResourceActions
+        context="kind-dev"
+        kind="Deployment"
+        namespace="default"
+        name="web"
+        currentReplicas={8}
+        onDeleted={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Scale" }));
+    expect(screen.getByRole("slider").getAttribute("aria-valuemax")).toBe("16");
+  });
+
+  it("keeps the numeric input and the slider in sync both ways", () => {
+    render(
+      <ResourceActions
+        context="kind-dev"
+        kind="Deployment"
+        namespace="default"
+        name="web"
+        currentReplicas={2}
+        onDeleted={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Scale" }));
+
+    // Typing updates the slider…
+    fireEvent.change(screen.getByLabelText("Replicas"), { target: { value: "5" } });
+    const slider = screen.getByRole("slider");
+    expect(slider.getAttribute("aria-valuenow")).toBe("5");
+
+    // …and moving the slider updates the input.
+    fireEvent.keyDown(slider, { key: "ArrowRight" });
+    expect((screen.getByLabelText("Replicas") as HTMLInputElement).value).toBe("6");
+  });
+
+  it("scales to the slider-chosen value on confirm", async () => {
+    scaleResourceMock.mockResolvedValue({ ok: true });
+    render(
+      <ResourceActions
+        context="kind-dev"
+        kind="Deployment"
+        namespace="default"
+        name="web"
+        currentReplicas={2}
+        onDeleted={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Scale" }));
+    fireEvent.keyDown(screen.getByRole("slider"), { key: "ArrowRight" });
+    fireEvent.click(screen.getByRole("button", { name: "Scale" }));
+    await waitFor(() =>
+      expect(scaleResourceMock).toHaveBeenCalledWith("kind-dev", "Deployment", "default", "web", 3),
+    );
+  });
+
+  it("still rejects a non-integer typed into the input", async () => {
+    scaleResourceMock.mockResolvedValue({ ok: true });
+    render(
+      <ResourceActions
+        context="kind-dev"
+        kind="Deployment"
+        namespace="default"
+        name="web"
+        currentReplicas={2}
+        onDeleted={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Scale" }));
+    fireEvent.change(screen.getByLabelText("Replicas"), { target: { value: "1.5" } });
+    fireEvent.click(screen.getByRole("button", { name: "Scale" }));
+    expect(await screen.findByText(/non-negative replica count/)).toBeDefined();
+    expect(scaleResourceMock).not.toHaveBeenCalled();
   });
 
   it("shows an actionable error toast (mapped, not raw) when an operation fails", async () => {

--- a/apps/desktop/src/components/DetailActions.test.tsx
+++ b/apps/desktop/src/components/DetailActions.test.tsx
@@ -33,6 +33,11 @@ vi.mock("../lib/actions", () => ({
   cronjobTriggerNow: cronjobTriggerNowMock,
   debugPod: debugPodMock,
 }));
+const { getObjectMock } = vi.hoisted(() => ({ getObjectMock: vi.fn() }));
+vi.mock("../lib/manifest", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/manifest")>();
+  return { ...actual, getObject: getObjectMock };
+});
 const { notifyMock } = vi.hoisted(() => ({
   notifyMock: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
 }));
@@ -45,7 +50,12 @@ vi.mock("../lib/access", async (importOriginal) => {
 import { useAccess } from "../lib/access";
 import { describeError } from "../lib/errors";
 
-import { PodActions, ResourceActions, desiredReplicasFrom } from "./DetailActions";
+import {
+  PodActions,
+  ResourceActions,
+  desiredReplicasFrom,
+  desiredReplicasForDetail,
+} from "./DetailActions";
 
 const pod = {
   name: "web-1",
@@ -75,6 +85,10 @@ beforeEach(() => {
   cronjobSetSuspendMock.mockReset();
   cronjobTriggerNowMock.mockReset();
   debugPodMock.mockReset();
+  getObjectMock.mockReset();
+  // Default: object fetches resolve to nothing useful — tests that care about
+  // the replica seed set their own return value.
+  getObjectMock.mockResolvedValue({});
   notifyMock.success.mockReset();
   notifyMock.error.mockReset();
   // Default: everything allowed, so pre-existing behavioural tests (written
@@ -212,6 +226,19 @@ describe("desiredReplicasFrom", () => {
     expect(desiredReplicasFrom({ ready: "not-a-fraction" })).toBeUndefined();
     expect(desiredReplicasFrom({ ready: 3 })).toBeUndefined();
   });
+
+  it("matches the detail's row by name AND namespace", () => {
+    // All-namespaces view: two workloads sharing a name must not seed
+    // each other's counts.
+    const rows = [
+      { name: "web", namespace: "team-a", ready: "1/3" },
+      { name: "web", namespace: "team-b", ready: "2/5" },
+    ];
+    expect(desiredReplicasForDetail(rows, "web", "team-b")).toBe(5);
+    expect(desiredReplicasForDetail(rows, "web", "team-a")).toBe(3);
+    expect(desiredReplicasForDetail(rows, "web", "team-c")).toBeUndefined();
+    expect(desiredReplicasForDetail(rows, "api", "team-a")).toBeUndefined();
+  });
 });
 
 describe("ResourceActions", () => {
@@ -257,6 +284,49 @@ describe("ResourceActions", () => {
     // Range: 0 to max(currentReplicas * 2, 10).
     expect(slider.getAttribute("aria-valuemin")).toBe("0");
     expect(slider.getAttribute("aria-valuemax")).toBe("10");
+    // The row already knew the count — no object fetch needed.
+    expect(getObjectMock).not.toHaveBeenCalled();
+  });
+
+  it("fetches the live count when the row can't provide one (ReplicaSets)", async () => {
+    getObjectMock.mockResolvedValue({ object: { spec: { replicas: 4 } } });
+    render(
+      <ResourceActions
+        context="kind-dev"
+        kind="ReplicaSet"
+        namespace="default"
+        name="web-abc123"
+        onDeleted={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Scale" }));
+
+    expect(getObjectMock).toHaveBeenCalledWith("kind-dev", "ReplicaSet", "default", "web-abc123");
+    await waitFor(() =>
+      expect((screen.getByLabelText("Replicas") as HTMLInputElement).value).toBe("4"),
+    );
+    expect(screen.getByRole("slider").getAttribute("aria-valuenow")).toBe("4");
+  });
+
+  it("never lets a late fetch overwrite what the user typed", async () => {
+    let resolveFetch!: (v: unknown) => void;
+    getObjectMock.mockReturnValue(new Promise((r) => (resolveFetch = r)));
+    render(
+      <ResourceActions
+        context="kind-dev"
+        kind="ReplicaSet"
+        namespace="default"
+        name="web-abc123"
+        onDeleted={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Scale" }));
+    fireEvent.change(screen.getByLabelText("Replicas"), { target: { value: "7" } });
+
+    resolveFetch({ object: { spec: { replicas: 4 } } });
+    // Give the resolved promise a tick to (wrongly) apply itself.
+    await new Promise((r) => setTimeout(r, 0));
+    expect((screen.getByLabelText("Replicas") as HTMLInputElement).value).toBe("7");
   });
 
   it("widens the slider range for larger workloads", () => {

--- a/apps/desktop/src/components/DetailActions.tsx
+++ b/apps/desktop/src/components/DetailActions.tsx
@@ -25,6 +25,7 @@ import {
 import { notify } from "../lib/notify";
 import { useAccess, rbac, kindToResource, denyReason, reportActionError, type AccessCheck } from "../lib/access";
 import { IconButton, ConfirmDialog, TextInput, KubectlPreview } from "../ui";
+import { Slider } from "@/components/ui/slider";
 import { ForwardDialog } from "./ForwardDialog";
 import { CopyAsKubectlButton } from "./CopyAsKubectlButton";
 import { toKubectl } from "../lib/kubectlMapper";
@@ -36,6 +37,18 @@ type Opener = (s: { context: string; namespace: string; pod: string; container?:
 export type AskAssistant = (s: AssistantContext) => void;
 
 const SCALABLE = ["Deployment", "StatefulSet", "ReplicaSet"];
+
+/** The desired replica count a list row implies, for seeding the scale
+ * dialog: ReplicaSet rows carry `desired`; Deployment/StatefulSet rows
+ * encode it as `ready: "ready/total"`. Undefined when the row can't say. */
+export function desiredReplicasFrom(row?: { desired?: unknown; ready?: unknown }): number | undefined {
+  if (typeof row?.desired === "number") return row.desired;
+  if (typeof row?.ready === "string") {
+    const total = /^\d+\/(\d+)$/.exec(row.ready)?.[1];
+    if (total !== undefined) return Number(total);
+  }
+  return undefined;
+}
 const RESTARTABLE = ["Deployment", "StatefulSet", "DaemonSet"];
 // Workloads whose pods are reachable via spec.selector.matchLabels.
 const LOGGABLE = ["Deployment", "StatefulSet", "DaemonSet", "ReplicaSet", "Job"];
@@ -290,6 +303,7 @@ export function ResourceActions({
   namespace,
   name,
   cronjobSuspended,
+  currentReplicas,
   onDeleted,
   onChanged,
   onOpenLogs,
@@ -302,6 +316,9 @@ export function ResourceActions({
   name: string;
   /** For CronJob details: current suspend state, to label Suspend/Resume. */
   cronjobSuspended?: boolean;
+  /** For scalable kinds: the current desired replica count, seeding the
+   * scale dialog's slider and input. Unknown → the dialog starts empty. */
+  currentReplicas?: number;
   onDeleted: () => void;
   /** Fired after a successful non-delete write action so the detail refreshes. */
   onChanged?: () => void;
@@ -427,6 +444,11 @@ export function ResourceActions({
   const replicasN = Number(replicas);
   const validReplicas = replicas.trim() !== "" && Number.isInteger(replicasN) && replicasN >= 0;
 
+  // Slider range: 0 to a sensible ceiling above today's count. The input
+  // stays free-form for values past the ceiling; the slider then just pins.
+  const sliderMax = Math.max((currentReplicas ?? 0) * 2, 10);
+  const sliderValue = validReplicas ? Math.min(replicasN, sliderMax) : 0;
+
   const restartCmd = toKubectl({ action: "rollout-restart", kind, namespace: namespace ?? "", name, context });
   const suspendCmd = toKubectl({
     action: cronjobSuspended ? "cronjob-resume" : "cronjob-suspend",
@@ -466,7 +488,12 @@ export function ResourceActions({
           label="Scale"
           disabled={scaleCheck ? !access.allowed(scaleCheck) : false}
           title={scaleCheck ? denyReason(access, scaleCheck) : undefined}
-          onClick={() => setScaling(true)}
+          onClick={() => {
+            // Start from the live count so the slider and input show where
+            // the workload is today, not whatever a previous dialog left.
+            setReplicas(currentReplicas !== undefined ? String(currentReplicas) : "");
+            setScaling(true);
+          }}
         />
       )}
       {RESTARTABLE.includes(kind) && (
@@ -601,14 +628,30 @@ export function ResourceActions({
               <p style={{ marginTop: 0 }}>
                 Set the replica count for <code>{name}</code>.
               </p>
-              <div style={{ width: 120 }}>
-                <TextInput
-                  value={replicas}
-                  onValueChange={setReplicas}
-                  placeholder="replicas"
-                  aria-label="Replicas"
+              <div className="flex items-center gap-3">
+                <Slider
+                  value={[sliderValue]}
+                  min={0}
+                  max={sliderMax}
+                  step={1}
+                  onValueChange={([v]) => setReplicas(String(v))}
+                  aria-label="Replica count slider"
+                  className="flex-1"
                 />
+                <div style={{ width: 80 }}>
+                  <TextInput
+                    value={replicas}
+                    onValueChange={setReplicas}
+                    placeholder="replicas"
+                    aria-label="Replicas"
+                  />
+                </div>
               </div>
+              {currentReplicas !== undefined && (
+                <p className="text-xs text-muted-foreground">
+                  current {currentReplicas} → target {validReplicas ? replicasN : "—"}
+                </p>
+              )}
               {scaleCmd && (
                 <KubectlPreview command={scaleCmd} onCopy={() => void copyKubectlCommand(scaleCmd)} />
               )}

--- a/apps/desktop/src/components/DetailActions.tsx
+++ b/apps/desktop/src/components/DetailActions.tsx
@@ -468,10 +468,13 @@ export function ResourceActions({
   const replicasN = Number(replicas);
   const validReplicas = replicas.trim() !== "" && Number.isInteger(replicasN) && replicasN >= 0;
 
-  // Slider range: 0 to a sensible ceiling above today's count. The input
-  // stays free-form for values past the ceiling; the slider then just pins.
+  // Slider range: 0 to 100 as the everyday ceiling (a tighter max(current*2)
+  // bound proved too limiting in practice), stretched further for workloads
+  // already above 50 replicas so the slider can always reach and double the
+  // current count. The input stays free-form past the ceiling; the slider
+  // then just pins.
   const knownReplicas = currentReplicas ?? fetchedReplicas;
-  const sliderMax = Math.max((knownReplicas ?? 0) * 2, 10);
+  const sliderMax = Math.max((knownReplicas ?? 0) * 2, 100);
   const sliderValue = validReplicas ? Math.min(replicasN, sliderMax) : 0;
 
   const restartCmd = toKubectl({ action: "rollout-restart", kind, namespace: namespace ?? "", name, context });
@@ -519,13 +522,18 @@ export function ResourceActions({
             setReplicas(currentReplicas !== undefined ? String(currentReplicas) : "");
             setFetchedReplicas(undefined);
             scaleEdited.current = false;
+            // Bump on EVERY open, not only when a fetch is needed: this same
+            // component instance survives the detail switching to a different
+            // resource, and a still-pending fetch from the previous resource
+            // must find its token stale even when THIS open needs no fetch —
+            // otherwise it would overwrite this resource's seeded count.
+            const seq = ++scaleOpenSeq.current;
             setScaling(true);
             if (currentReplicas === undefined) {
               // The list row couldn't say (generic rows carry no counts) —
               // read spec.replicas off the object. The sequence token drops
-              // a fetch that resolves after this dialog was reopened for a
-              // different resource, and typing always wins over the seed.
-              const seq = ++scaleOpenSeq.current;
+              // a fetch that resolves after any later dialog opening, and
+              // typing always wins over the seed.
               void getObject(context, kind, namespace, name).then((r) => {
                 const spec = (r.object as { spec?: { replicas?: unknown } } | undefined)?.spec;
                 if (seq !== scaleOpenSeq.current || typeof spec?.replicas !== "number") return;

--- a/apps/desktop/src/components/DetailActions.tsx
+++ b/apps/desktop/src/components/DetailActions.tsx
@@ -26,6 +26,7 @@ import { notify } from "../lib/notify";
 import { useAccess, rbac, kindToResource, denyReason, reportActionError, type AccessCheck } from "../lib/access";
 import { getObject } from "../lib/manifest";
 import { IconButton, ConfirmDialog, TextInput, KubectlPreview } from "../ui";
+import { Input } from "@/components/ui/input";
 import { Slider } from "@/components/ui/slider";
 import { ForwardDialog } from "./ForwardDialog";
 import { CopyAsKubectlButton } from "./CopyAsKubectlButton";
@@ -690,11 +691,17 @@ export function ResourceActions({
                   className="flex-1"
                 />
                 <div style={{ width: 80 }}>
-                  <TextInput
+                  {/* A number input, not TextInput: the native spinner and
+                      arrow-key stepping give single-replica increments
+                      without touching the slider. */}
+                  <Input
+                    type="number"
+                    min={0}
+                    step={1}
                     value={replicas}
-                    onValueChange={(v) => {
+                    onChange={(e) => {
                       scaleEdited.current = true;
-                      setReplicas(v);
+                      setReplicas(e.target.value);
                     }}
                     placeholder="replicas"
                     aria-label="Replicas"

--- a/apps/desktop/src/components/DetailActions.tsx
+++ b/apps/desktop/src/components/DetailActions.tsx
@@ -349,6 +349,12 @@ export function ResourceActions({
   // fetched from the object's spec.replicas when the scale dialog opens.
   const [fetchedReplicas, setFetchedReplicas] = useState<number | undefined>(undefined);
   const scaleOpenSeq = useRef(0);
+  // Whether the user has touched the replica control since the dialog opened.
+  // The late-fetch seed keys off THIS, not off the input being empty: a user
+  // who cleared the field to type a fresh value has edited it, and restoring
+  // the fetched count into that window would make their next digit append
+  // (clearing 4 to type 0 must not become 40).
+  const scaleEdited = useRef(false);
   const [triggering, setTriggering] = useState(false);
   const [busy, setBusy] = useState("");
   const [err, setErr] = useState("");
@@ -512,6 +518,7 @@ export function ResourceActions({
             // the workload is today, not whatever a previous dialog left.
             setReplicas(currentReplicas !== undefined ? String(currentReplicas) : "");
             setFetchedReplicas(undefined);
+            scaleEdited.current = false;
             setScaling(true);
             if (currentReplicas === undefined) {
               // The list row couldn't say (generic rows carry no counts) —
@@ -523,7 +530,7 @@ export function ResourceActions({
                 const spec = (r.object as { spec?: { replicas?: unknown } } | undefined)?.spec;
                 if (seq !== scaleOpenSeq.current || typeof spec?.replicas !== "number") return;
                 setFetchedReplicas(spec.replicas);
-                setReplicas((prev) => (prev === "" ? String(spec.replicas) : prev));
+                if (!scaleEdited.current) setReplicas(String(spec.replicas));
               });
             }
           }}
@@ -667,14 +674,20 @@ export function ResourceActions({
                   min={0}
                   max={sliderMax}
                   step={1}
-                  onValueChange={([v]) => setReplicas(String(v))}
+                  onValueChange={([v]) => {
+                    scaleEdited.current = true;
+                    setReplicas(String(v));
+                  }}
                   aria-label="Replica count slider"
                   className="flex-1"
                 />
                 <div style={{ width: 80 }}>
                   <TextInput
                     value={replicas}
-                    onValueChange={setReplicas}
+                    onValueChange={(v) => {
+                      scaleEdited.current = true;
+                      setReplicas(v);
+                    }}
                     placeholder="replicas"
                     aria-label="Replicas"
                   />

--- a/apps/desktop/src/components/DetailActions.tsx
+++ b/apps/desktop/src/components/DetailActions.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import {
   ArrowLeftRight,
   Bot,
@@ -24,6 +24,7 @@ import {
 } from "../lib/actions";
 import { notify } from "../lib/notify";
 import { useAccess, rbac, kindToResource, denyReason, reportActionError, type AccessCheck } from "../lib/access";
+import { getObject } from "../lib/manifest";
 import { IconButton, ConfirmDialog, TextInput, KubectlPreview } from "../ui";
 import { Slider } from "@/components/ui/slider";
 import { ForwardDialog } from "./ForwardDialog";
@@ -48,6 +49,19 @@ export function desiredReplicasFrom(row?: { desired?: unknown; ready?: unknown }
     if (total !== undefined) return Number(total);
   }
   return undefined;
+}
+
+/** Desired replicas for one specific detail: the row must match name AND
+ * namespace — in an all-namespaces view two workloads can share a name, and
+ * seeding one with the other's count would mis-scale on confirm. */
+export function desiredReplicasForDetail(
+  rows: Array<{ name: string; namespace?: string; desired?: unknown; ready?: unknown }>,
+  name: string,
+  namespace: string | null,
+): number | undefined {
+  return desiredReplicasFrom(
+    rows.find((r) => r.name === name && (namespace == null || r.namespace === namespace)),
+  );
 }
 const RESTARTABLE = ["Deployment", "StatefulSet", "DaemonSet"];
 // Workloads whose pods are reachable via spec.selector.matchLabels.
@@ -331,6 +345,10 @@ export function ResourceActions({
   const [confirmSuspend, setConfirmSuspend] = useState(false);
   const [scaling, setScaling] = useState(false);
   const [replicas, setReplicas] = useState("");
+  // Fallback seed for rows that can't say (e.g. generic ReplicaSet rows):
+  // fetched from the object's spec.replicas when the scale dialog opens.
+  const [fetchedReplicas, setFetchedReplicas] = useState<number | undefined>(undefined);
+  const scaleOpenSeq = useRef(0);
   const [triggering, setTriggering] = useState(false);
   const [busy, setBusy] = useState("");
   const [err, setErr] = useState("");
@@ -446,7 +464,8 @@ export function ResourceActions({
 
   // Slider range: 0 to a sensible ceiling above today's count. The input
   // stays free-form for values past the ceiling; the slider then just pins.
-  const sliderMax = Math.max((currentReplicas ?? 0) * 2, 10);
+  const knownReplicas = currentReplicas ?? fetchedReplicas;
+  const sliderMax = Math.max((knownReplicas ?? 0) * 2, 10);
   const sliderValue = validReplicas ? Math.min(replicasN, sliderMax) : 0;
 
   const restartCmd = toKubectl({ action: "rollout-restart", kind, namespace: namespace ?? "", name, context });
@@ -492,7 +511,21 @@ export function ResourceActions({
             // Start from the live count so the slider and input show where
             // the workload is today, not whatever a previous dialog left.
             setReplicas(currentReplicas !== undefined ? String(currentReplicas) : "");
+            setFetchedReplicas(undefined);
             setScaling(true);
+            if (currentReplicas === undefined) {
+              // The list row couldn't say (generic rows carry no counts) —
+              // read spec.replicas off the object. The sequence token drops
+              // a fetch that resolves after this dialog was reopened for a
+              // different resource, and typing always wins over the seed.
+              const seq = ++scaleOpenSeq.current;
+              void getObject(context, kind, namespace, name).then((r) => {
+                const spec = (r.object as { spec?: { replicas?: unknown } } | undefined)?.spec;
+                if (seq !== scaleOpenSeq.current || typeof spec?.replicas !== "number") return;
+                setFetchedReplicas(spec.replicas);
+                setReplicas((prev) => (prev === "" ? String(spec.replicas) : prev));
+              });
+            }
           }}
         />
       )}
@@ -647,9 +680,9 @@ export function ResourceActions({
                   />
                 </div>
               </div>
-              {currentReplicas !== undefined && (
+              {knownReplicas !== undefined && (
                 <p className="text-xs text-muted-foreground">
-                  current {currentReplicas} → target {validReplicas ? replicasN : "—"}
+                  current {knownReplicas} → target {validReplicas ? replicasN : "—"}
                 </p>
               )}
               {scaleCmd && (

--- a/apps/desktop/src/components/ResourceBrowser.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.tsx
@@ -54,7 +54,7 @@ import {
   rowInSelection,
 } from "../lib/namespaces";
 import { NamespaceMultiSelect } from "../ui/NamespaceMultiSelect";
-import { PodActions, ResourceActions, ServiceForwardAction, desiredReplicasFrom } from "./DetailActions";
+import { PodActions, ResourceActions, ServiceForwardAction, desiredReplicasForDetail } from "./DetailActions";
 import { BulkActionBar } from "./BulkActionBar";
 import { NodeCordonAction } from "./NodeCordonAction";
 import { ResourceDetail } from "./ResourceDetail";
@@ -953,13 +953,15 @@ export function ResourceBrowser({
         name={otherDetail.name}
         cronjobSuspended={
           otherDetail.kind === "CronJob"
-            ? (res.rows as CronJobSummary[]).find((r) => r.name === otherDetail.name)?.suspended
+            ? (res.rows as CronJobSummary[]).find(
+                (r) => r.name === otherDetail.name && r.namespace === otherDetail.namespace,
+              )?.suspended
             : undefined
         }
-        currentReplicas={desiredReplicasFrom(
-          (res.rows as Array<{ name: string; desired?: number; ready?: string | number }>).find(
-            (r) => r.name === otherDetail.name,
-          ),
+        currentReplicas={desiredReplicasForDetail(
+          res.rows as Array<{ name: string; namespace?: string; desired?: number; ready?: string | number }>,
+          otherDetail.name,
+          otherDetail.namespace,
         )}
         onDeleted={closeDetail}
         onChanged={() => setDetailReload((k) => k + 1)}

--- a/apps/desktop/src/components/ResourceBrowser.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.tsx
@@ -54,7 +54,7 @@ import {
   rowInSelection,
 } from "../lib/namespaces";
 import { NamespaceMultiSelect } from "../ui/NamespaceMultiSelect";
-import { PodActions, ResourceActions, ServiceForwardAction } from "./DetailActions";
+import { PodActions, ResourceActions, ServiceForwardAction, desiredReplicasFrom } from "./DetailActions";
 import { BulkActionBar } from "./BulkActionBar";
 import { NodeCordonAction } from "./NodeCordonAction";
 import { ResourceDetail } from "./ResourceDetail";
@@ -956,6 +956,11 @@ export function ResourceBrowser({
             ? (res.rows as CronJobSummary[]).find((r) => r.name === otherDetail.name)?.suspended
             : undefined
         }
+        currentReplicas={desiredReplicasFrom(
+          (res.rows as Array<{ name: string; desired?: number; ready?: string | number }>).find(
+            (r) => r.name === otherDetail.name,
+          ),
+        )}
         onDeleted={closeDetail}
         onChanged={() => setDetailReload((k) => k + 1)}
         onOpenLogs={onOpenWorkloadLogs}

--- a/apps/desktop/src/components/ui/slider.tsx
+++ b/apps/desktop/src/components/ui/slider.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import * as React from "react"
+import { Slider as SliderPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Slider({
+  className,
+  defaultValue,
+  value,
+  min = 0,
+  max = 100,
+  ...props
+}: React.ComponentProps<typeof SliderPrimitive.Root>) {
+  const _values = React.useMemo(
+    () =>
+      Array.isArray(value)
+        ? value
+        : Array.isArray(defaultValue)
+          ? defaultValue
+          : [min, max],
+    [value, defaultValue, min, max]
+  )
+
+  return (
+    <SliderPrimitive.Root
+      data-slot="slider"
+      defaultValue={defaultValue}
+      value={value}
+      min={min}
+      max={max}
+      className={cn(
+        "relative flex w-full touch-none items-center select-none data-[disabled]:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col",
+        className
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track
+        data-slot="slider-track"
+        className={cn(
+          "bg-muted relative grow overflow-hidden rounded-full data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5"
+        )}
+      >
+        <SliderPrimitive.Range
+          data-slot="slider-range"
+          className={cn(
+            "bg-primary absolute data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full"
+          )}
+        />
+      </SliderPrimitive.Track>
+      {Array.from({ length: _values.length }, (_, index) => (
+        <SliderPrimitive.Thumb
+          data-slot="slider-thumb"
+          key={index}
+          className="border-primary bg-background ring-ring/50 block size-4 shrink-0 rounded-full border shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+        />
+      ))}
+    </SliderPrimitive.Root>
+  )
+}
+
+export { Slider }

--- a/apps/desktop/src/components/ui/slider.tsx
+++ b/apps/desktop/src/components/ui/slider.tsx
@@ -11,6 +11,10 @@ function Slider({
   value,
   min = 0,
   max = 100,
+  // Pulled off the Root deliberately: the element carrying `role="slider"`
+  // is the generated Thumb below, so a label left only on the Root wrapper
+  // names nothing a screen reader announces. Forwarded to every thumb.
+  "aria-label": ariaLabel,
   ...props
 }: React.ComponentProps<typeof SliderPrimitive.Root>) {
   const _values = React.useMemo(
@@ -53,6 +57,7 @@ function Slider({
         <SliderPrimitive.Thumb
           data-slot="slider-thumb"
           key={index}
+          aria-label={ariaLabel}
           className="border-primary bg-background ring-ring/50 block size-4 shrink-0 rounded-full border shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
         />
       ))}


### PR DESCRIPTION
Closes #145.

## Summary

- the Scale dialog pairs a **slider** (range 0 to `max(currentReplicas*2, 10)`, integer steps) with the existing numeric input, both bound to the same state: typing moves the slider, arrow keys / dragging update the input, and a `current → target` line shows what the change means
- the dialog seeds from the workload's **live desired count**, threaded from the list row via the new `desiredReplicasFrom` helper (ReplicaSet rows carry `desired`; Deployment/StatefulSet rows encode it as `ready: "x/y"`); unknown rows leave the dialog empty as before
- the free-form input keeps the non-negative-integer guard and may exceed the slider ceiling (the slider pins there); the `scaleResource` call is unchanged
- new shadcn-style `Slider` primitive (`components/ui/slider.tsx`) wrapping radix-ui, matching the existing `components/ui` idiom

## Acceptance criteria

- [x] slider presented, defaulting to the current replicas
- [x] synced numeric input for exact entry
- [x] negative / non-integer unreachable via slider, rejected from the input path
- [x] confirm scales to the chosen value (existing `scaleResource` call unchanged)
- [x] tests cover slider ↔ input sync and the confirm value (7 new tests)

## Validation

- `pnpm test` — 129 files, 1030 tests passed; line coverage 85.31% (above the enforced 85% gate)
- `pnpm build` — passed