### PR TITLE
feat(mcp): server→client push over HTTP — resources/subscribe works on both transports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5849,6 +5849,7 @@ version = "0.5.0"
 dependencies = [
  "async-trait",
  "axum",
+ "futures-core",
  "getrandom 0.2.17",
  "percent-encoding",
  "serde",

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -13,6 +13,9 @@ serde_yaml = "0.9"
 subtle = "2"
 tokio = { version = "1", features = ["io-util", "net", "rt-multi-thread", "macros", "sync"] }
 axum = "0.7"
+# Only the `Stream` TRAIT, for the hand-rolled SSE body in http.rs — already
+# in the tree under axum; no combinator crate is pulled in for one poll loop.
+futures-core = "0.3"
 # URI segments are percent-encoded because kube context names are arbitrary —
 # EKS names contexts with ARNs containing `/` and `:`, which would otherwise
 # reshape the path. Already in the workspace lockfile via reqwest/url.

--- a/crates/mcp/src/http.rs
+++ b/crates/mcp/src/http.rs
@@ -1,20 +1,169 @@
-//! MCP over HTTP (JSON-RPC POST). A networked transport for MCP clients that
-//! can't spawn the stdio binary. Binds loopback-only; destructive tools are
-//! consent-gated in the shared request handler.
+//! MCP over HTTP, Streamable-HTTP shaped (#193): `POST /mcp` for JSON-RPC,
+//! `GET /mcp` for the server→client SSE stream that carries
+//! `notifications/resources/updated` — the channel that makes
+//! `resources/subscribe` real on this transport. A networked transport for
+//! MCP clients that can't spawn the stdio binary. Binds loopback-only;
+//! destructive tools are consent-gated in the shared request handler.
 
+use std::collections::{BTreeSet, VecDeque};
 use std::net::SocketAddr;
-use std::sync::{Arc, OnceLock};
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::task::{Context, Poll};
 
 use axum::extract::{Request, State};
 use axum::http::{HeaderName, StatusCode};
 use axum::middleware::{self, Next};
+use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
-use serde_json::Value;
+use serde_json::{json, Value};
 
-use crate::stdio::handle_request;
+use crate::stdio::{handle_request, handle_subscription, subscription_notification};
+use crate::subscriptions::SubscriptionRegistry;
 use crate::McpServer;
+
+/// The push half of the transport. At most ONE live SSE stream exists per
+/// server — this is a loopback, single-user endpoint, and one stream is what
+/// the Streamable HTTP shape needs (the client opens GET /mcp once and every
+/// notification flows down it). A new GET replaces the previous stream: the
+/// old stream's wake sender drops, its poll sees the closed channel and ends
+/// the stream, and its guard aborts the watches it owned — so a reconnecting
+/// client starts clean and re-subscribes, and no watch ever outlives the
+/// stream that requested it. Subscriptions arriving while NO stream is
+/// connected are refused (see `rpc`): accepting one would promise
+/// notifications with nowhere to send them, the exact failure shape #195
+/// eliminated.
+#[derive(Default)]
+struct PushState {
+    active: Mutex<Option<PushChannels>>,
+    /// Distinguishes streams so a dying stream's guard can only clear ITS
+    /// slot, never a successor's (same shape as the subscription registry's
+    /// generations).
+    next_id: AtomicU64,
+}
+
+/// What `resources/subscribe` needs from the active stream: the same
+/// registry/dirty-set/wakeup trio the stdio serve loop owns per session.
+#[derive(Clone)]
+struct PushChannels {
+    id: u64,
+    subs: Arc<SubscriptionRegistry>,
+    dirty: Arc<Mutex<BTreeSet<String>>>,
+    wake: tokio::sync::mpsc::Sender<()>,
+}
+
+#[derive(Clone)]
+struct AppState {
+    server: Arc<McpServer>,
+    push: Arc<PushState>,
+}
+
+/// Aborts the stream's watches when the stream itself is dropped — client
+/// disconnect, replacement by a newer stream, or server shutdown all land
+/// here, so the "no watch outlives its stream" contract has one enforcement
+/// point. Clears the active slot only when it still holds this stream.
+struct StreamGuard {
+    push: Arc<PushState>,
+    subs: Arc<SubscriptionRegistry>,
+    id: u64,
+}
+
+impl Drop for StreamGuard {
+    fn drop(&mut self) {
+        self.subs.abort_all();
+        let mut active = self.push.active.lock().unwrap_or_else(|e| e.into_inner());
+        if active.as_ref().is_some_and(|a| a.id == self.id) {
+            *active = None;
+        }
+    }
+}
+
+/// The SSE body: wakes on the subscription machinery's wakeup channel, drains
+/// the dirty set, and yields one `notifications/resources/updated` per URI —
+/// each SSE event carrying exactly one JSON-RPC message, per Streamable HTTP.
+/// Ends when the wake sender is dropped (this stream was replaced). Implements
+/// `Stream` by hand (`futures-core` is the only extra dependency, and it is
+/// already in the tree under axum) rather than pulling in a stream-combinator
+/// crate for one loop.
+struct PushStream {
+    wake: tokio::sync::mpsc::Receiver<()>,
+    dirty: Arc<Mutex<BTreeSet<String>>>,
+    pending: VecDeque<String>,
+    _guard: StreamGuard,
+}
+
+impl futures_core::Stream for PushStream {
+    type Item = Result<Event, std::convert::Infallible>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        loop {
+            if let Some(uri) = this.pending.pop_front() {
+                let msg = subscription_notification(&uri);
+                return Poll::Ready(Some(Ok(Event::default().data(msg.to_string()))));
+            }
+            match this.wake.poll_recv(cx) {
+                Poll::Ready(Some(())) => {
+                    let uris = {
+                        let mut guard = this.dirty.lock().unwrap_or_else(|e| e.into_inner());
+                        std::mem::take(&mut *guard)
+                    };
+                    // Loop: emit the first drained URI, or wait again on a
+                    // spurious wake that raced an earlier drain.
+                    this.pending.extend(uris);
+                }
+                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+}
+
+/// `GET /mcp`: open the server→client SSE stream. Replaces any previous
+/// stream (see `PushState`). The keep-alive comment every 20s holds idle
+/// connections open through proxies and lets a dead client surface as a
+/// write error instead of a silent zombie.
+async fn sse(State(st): State<AppState>, headers: axum::http::HeaderMap) -> Response {
+    // The spec has clients send `Accept: text/event-stream`; a GET that
+    // explicitly refuses it gets 406 rather than a stream it won't parse.
+    // An absent Accept header is allowed (curl convenience).
+    let accept = headers
+        .get(axum::http::header::ACCEPT)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    if !accept.is_empty() && !accept.contains("text/event-stream") && !accept.contains("*/*") {
+        return (StatusCode::NOT_ACCEPTABLE, "this endpoint streams text/event-stream").into_response();
+    }
+
+    let (wake_tx, wake_rx) = tokio::sync::mpsc::channel(1);
+    let chans = PushChannels {
+        id: st.push.next_id.fetch_add(1, Ordering::Relaxed),
+        subs: Arc::new(SubscriptionRegistry::new()),
+        dirty: Arc::default(),
+        wake: wake_tx,
+    };
+    let stream = PushStream {
+        wake: wake_rx,
+        dirty: chans.dirty.clone(),
+        pending: VecDeque::new(),
+        _guard: StreamGuard { push: st.push.clone(), subs: chans.subs.clone(), id: chans.id },
+    };
+    // Install as THE stream. A previous stream's channels drop here: its wake
+    // sender closing is what ends its `PushStream`, whose guard then aborts
+    // the watches that stream owned.
+    *st.push.active.lock().unwrap_or_else(|e| e.into_inner()) = Some(chans);
+
+    (
+        [(MCP_SESSION_ID.clone(), session_id())],
+        Sse::new(stream).keep_alive(
+            KeepAlive::new().interval(std::time::Duration::from_secs(20)).text("keep-alive"),
+        ),
+    )
+        .into_response()
+}
 
 /// The `Mcp-Session-Id` header name, surfaced on every `/mcp` response.
 static MCP_SESSION_ID: HeaderName = HeaderName::from_static("mcp-session-id");
@@ -33,8 +182,28 @@ fn session_id() -> &'static str {
     ID.get_or_init(|| format!("srelens-{}", std::process::id()))
 }
 
-async fn rpc(State(server): State<Arc<McpServer>>, Json(req): Json<Value>) -> Response {
-    match handle_request(&server, &req, crate::Transport::Http).await {
+async fn rpc(State(st): State<AppState>, Json(req): Json<Value>) -> Response {
+    let method = req.get("method").and_then(Value::as_str).unwrap_or("");
+    // Subscription methods are handled here, not in `handle_request` — same
+    // split as the stdio serve loop, because they need this transport's push
+    // machinery: the registry, dirty set, and wakeup of the ACTIVE SSE
+    // stream. With no stream connected they are refused outright; accepting
+    // would promise notifications with nowhere to send them.
+    let resp = if method == "resources/subscribe" || method == "resources/unsubscribe" {
+        let chans = st.push.active.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        match chans {
+            Some(c) => handle_subscription(&st.server, &c.subs, &c.dirty, &c.wake, &req, method),
+            None => req.get("id").cloned().map(|id| {
+                json!({"jsonrpc": "2.0", "id": id, "error": {"code": -32002, "message":
+                    "no notification stream is connected: open GET /mcp with `Accept: \
+                     text/event-stream` first, then subscribe — this subscription's \
+                     notifications would otherwise have nowhere to go"}})
+            }),
+        }
+    } else {
+        handle_request(&st.server, &req, crate::Transport::Http).await
+    };
+    match resp {
         // `Json` sets `content-type: application/json`; we add the session-id
         // header the streamable-HTTP handshake needs.
         Some(resp) => ([(MCP_SESSION_ID.clone(), session_id())], Json(resp)).into_response(),
@@ -141,7 +310,8 @@ async fn token_guard(
     next.run(req).await
 }
 
-/// Build the MCP HTTP router (POST /mcp for JSON-RPC, GET /healthz). Requires a
+/// Build the MCP HTTP router (POST /mcp for JSON-RPC, GET /mcp for the SSE
+/// push stream, GET /healthz). Requires a
 /// token: there is no way to ask this crate for an unauthenticated production
 /// server, because an `Option` here is an invitation to pass `None` by accident.
 pub fn router_with_auth(server: McpServer, token: crate::auth::Token) -> Router {
@@ -152,12 +322,17 @@ pub fn router_with_auth(server: McpServer, token: crate::auth::Token) -> Router 
 /// check is an outer `layer` covering every route (and unmatched paths), so
 /// nothing this server exposes answers a non-loopback caller.
 fn router_inner(server: McpServer, token: Option<crate::auth::Token>) -> Router {
+    let state =
+        AppState { server: Arc::new(server), push: Arc::new(PushState::default()) };
     Router::new()
-        .route("/mcp", post(rpc))
+        // POST and GET share the route, so the token `route_layer` below
+        // covers the SSE stream exactly like the JSON-RPC endpoint — a
+        // long-lived stream is established under the same bearer check.
+        .route("/mcp", post(rpc).get(sse))
         .route_layer(middleware::from_fn_with_state(token, token_guard))
         .route("/healthz", get(|| async { "ok" }))
         .layer(middleware::from_fn(host_guard))
-        .with_state(Arc::new(server))
+        .with_state(state)
 }
 
 /// Test-only convenience: a router with authentication disabled. Never
@@ -212,6 +387,212 @@ mod tests {
             Ok(json!({ "echo": v }))
         }));
         McpServer::new(Arc::new(reg))
+    }
+
+    /// A server whose watcher spawns a forever-pending task per subscription,
+    /// firing `on_change` once synchronously (so the notification is already
+    /// queued when subscribe answers) and parking each task's JoinHandle where
+    /// the test can await its cancellation.
+    fn subscribable_server(
+        joins: Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
+    ) -> McpServer {
+        struct Kinds;
+        impl crate::resources::KindResolver for Kinds {
+            fn scope(&self, kind: &str) -> Option<crate::resources::KindScope> {
+                (kind == "Pod").then_some(crate::resources::KindScope::Namespaced)
+            }
+        }
+        struct FireOnceWatcher(Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>);
+        impl crate::resources::ObjectWatcher for FireOnceWatcher {
+            fn watch(
+                &self,
+                _uri: &crate::resources::ResourceUri,
+                mut on_change: Box<dyn FnMut() + Send>,
+                _on_dead: Box<dyn FnOnce(String) + Send>,
+            ) -> Result<tokio::task::AbortHandle, String> {
+                on_change();
+                let join = tokio::spawn(async { std::future::pending::<()>().await });
+                let abort = join.abort_handle();
+                self.0.lock().unwrap().push(join);
+                Ok(abort)
+            }
+        }
+        test_server()
+            .with_kind_resolver(Arc::new(Kinds))
+            .with_watcher(Arc::new(FireOnceWatcher(joins)))
+    }
+
+    fn sse_get() -> Request<Body> {
+        Request::builder()
+            .method("GET")
+            .uri("/mcp")
+            .header("host", "127.0.0.1:8765")
+            .header("accept", "text/event-stream")
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    fn subscribe_post(uri: &str) -> Request<Body> {
+        let body = json!({"jsonrpc":"2.0","id":7,"method":"resources/subscribe",
+            "params":{"uri": uri}});
+        Request::builder()
+            .method("POST")
+            .uri("/mcp")
+            .header("host", "127.0.0.1:8765")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    /// Next data chunk of a streaming body, under a bound so a regression
+    /// hangs the test for two seconds instead of forever.
+    async fn next_chunk(body: &mut axum::body::BodyDataStream) -> Option<String> {
+        use futures_core::Stream as _;
+        use std::future::poll_fn;
+        let fut = poll_fn(|cx| Pin::new(&mut *body).poll_next(cx));
+        match tokio::time::timeout(std::time::Duration::from_secs(2), fut).await {
+            Ok(Some(Ok(bytes))) => Some(String::from_utf8_lossy(&bytes).to_string()),
+            _ => None,
+        }
+    }
+
+    #[tokio::test]
+    async fn the_sse_route_sits_behind_the_same_token_check() {
+        let app = router_inner(test_server(), Some(crate::auth::Token::generate()));
+        let resp = app.oneshot(sse_get()).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn the_sse_route_rejects_a_non_loopback_host() {
+        let app = router(test_server());
+        let req = Request::builder()
+            .method("GET")
+            .uri("/mcp")
+            .header("host", "evil.example.com")
+            .header("accept", "text/event-stream")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn subscribe_without_a_stream_is_refused() {
+        let joins = Arc::new(Mutex::new(Vec::new()));
+        let app = router(subscribable_server(joins.clone()));
+        let resp = app.oneshot(subscribe_post("k8s://c/ns/Pod/web-0")).await.unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+        let v: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["error"]["code"], json!(-32002));
+        assert!(
+            v["error"]["message"].as_str().unwrap().contains("GET /mcp"),
+            "the refusal must say how to fix it: {v}"
+        );
+        assert!(joins.lock().unwrap().is_empty(), "no watch may be spawned for a refused subscribe");
+    }
+
+    #[tokio::test]
+    async fn a_watch_notification_reaches_the_http_client() {
+        let joins = Arc::new(Mutex::new(Vec::new()));
+        let app = router(subscribable_server(joins));
+
+        let stream_resp = app.clone().oneshot(sse_get()).await.unwrap();
+        assert_eq!(stream_resp.status(), StatusCode::OK);
+        assert!(
+            stream_resp
+                .headers()
+                .get(axum::http::header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok())
+                .is_some_and(|c| c.starts_with("text/event-stream")),
+            "the GET stream must be SSE"
+        );
+        let mut body = stream_resp.into_body().into_data_stream();
+
+        let sub_resp = app.oneshot(subscribe_post("k8s://c/ns/Pod/web-0")).await.unwrap();
+        let sub_body = axum::body::to_bytes(sub_resp.into_body(), 64 * 1024).await.unwrap();
+        let v: Value = serde_json::from_slice(&sub_body).unwrap();
+        assert!(v.get("error").is_none(), "subscribe must succeed with a live stream: {v}");
+
+        // The watcher fired on_change synchronously inside subscribe, so the
+        // notification is queued; read frames until it arrives (skipping any
+        // keep-alive comments).
+        let mut seen = String::new();
+        for _ in 0..5 {
+            match next_chunk(&mut body).await {
+                Some(chunk) => {
+                    seen.push_str(&chunk);
+                    if seen.contains("notifications/resources/updated") {
+                        break;
+                    }
+                }
+                None => break,
+            }
+        }
+        assert!(
+            seen.contains("notifications/resources/updated") && seen.contains("k8s://c/ns/Pod/web-0"),
+            "the update notification must reach the HTTP client: got {seen:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_dropped_stream_releases_its_watch() {
+        let joins = Arc::new(Mutex::new(Vec::new()));
+        let app = router(subscribable_server(joins.clone()));
+
+        let stream_resp = app.clone().oneshot(sse_get()).await.unwrap();
+        let sub_resp = app.oneshot(subscribe_post("k8s://c/ns/Pod/web-0")).await.unwrap();
+        assert_eq!(sub_resp.status(), StatusCode::OK);
+        assert_eq!(joins.lock().unwrap().len(), 1, "the subscribe spawned a watch");
+
+        // Client disconnect: hyper drops the response body; the stream guard
+        // must abort the watch — no watch outlives the stream that asked.
+        drop(stream_resp);
+        let join = joins.lock().unwrap().pop().unwrap();
+        match tokio::time::timeout(std::time::Duration::from_secs(2), join).await {
+            Ok(Err(e)) if e.is_cancelled() => {}
+            other => panic!("the watch must be cancelled when its stream drops: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn a_new_stream_replaces_the_old_and_aborts_its_watches() {
+        let joins = Arc::new(Mutex::new(Vec::new()));
+        let app = router(subscribable_server(joins.clone()));
+
+        let first = app.clone().oneshot(sse_get()).await.unwrap();
+        let sub = app.clone().oneshot(subscribe_post("k8s://c/ns/Pod/web-0")).await.unwrap();
+        assert_eq!(sub.status(), StatusCode::OK);
+        let mut first_body = first.into_body().into_data_stream();
+
+        // A reconnecting client opens a fresh stream: the old one ends. It
+        // may first flush what it had already queued (the buffered wakeup
+        // survives the sender dropping), so drain to end-of-stream rather
+        // than expecting an instant close — but it must END within those
+        // already-queued frames, not linger half-dead.
+        let second = app.clone().oneshot(sse_get()).await.unwrap();
+        assert_eq!(second.status(), StatusCode::OK);
+        let mut flushed = 0;
+        loop {
+            match next_chunk(&mut first_body).await {
+                None => break,
+                Some(_) if flushed < 3 => flushed += 1,
+                Some(chunk) => panic!("the replaced stream must end, got: {chunk:?}"),
+            }
+        }
+        drop(first_body);
+        // ...and its watch dies with it.
+        let join = joins.lock().unwrap().pop().unwrap();
+        match tokio::time::timeout(std::time::Duration::from_secs(2), join).await {
+            Ok(Err(e)) if e.is_cancelled() => {}
+            other => panic!("the replaced stream's watch must be cancelled: {other:?}"),
+        }
+
+        // The new stream subscribes cleanly — replacement leaves no residue.
+        let resub = app.oneshot(subscribe_post("k8s://c/ns/Pod/web-0")).await.unwrap();
+        let body = axum::body::to_bytes(resub.into_body(), 64 * 1024).await.unwrap();
+        let v: Value = serde_json::from_slice(&body).unwrap();
+        assert!(v.get("error").is_none(), "resubscribe on the new stream must succeed: {v}");
     }
 
     #[tokio::test]

--- a/crates/mcp/src/http.rs
+++ b/crates/mcp/src/http.rs
@@ -208,21 +208,39 @@ impl futures_core::Stream for PushStream {
 /// The caller treats an ABSENT header as accepting; this only judges a
 /// header that is present.
 fn accepts_event_stream(accept: &str) -> bool {
-    accept.split(',').any(|range| {
+    // Per RFC 9110 §12.5.1, the MOST SPECIFIC matching range decides the
+    // quality: `text/event-stream;q=0, */*;q=1` refuses SSE (the exact range
+    // zeroes it; the wildcard covers everything ELSE), so ranges cannot be
+    // judged independently. Specificity: exact > text/* > */*.
+    let mut best: Option<(u8, f32)> = None;
+    for range in accept.split(',') {
         let mut parts = range.split(';');
         let media = parts.next().unwrap_or("").trim().to_ascii_lowercase();
-        if !matches!(media.as_str(), "text/event-stream" | "text/*" | "*/*") {
-            return false;
-        }
-        let q_refused = parts
+        let specificity = match media.as_str() {
+            "text/event-stream" => 2u8,
+            "text/*" => 1,
+            "*/*" => 0,
+            _ => continue,
+        };
+        let q = parts
             .filter_map(|p| {
                 let p = p.trim().to_ascii_lowercase();
                 p.strip_prefix("q=").map(str::to_string)
             })
             .next_back()
-            .is_some_and(|v| v.trim().parse::<f32>().map(|q| q <= 0.0).unwrap_or(false));
-        !q_refused
-    })
+            .and_then(|v| v.trim().parse::<f32>().ok())
+            .unwrap_or(1.0);
+        best = match best {
+            Some((s, _)) if specificity > s => Some((specificity, q)),
+            // Duplicate ranges at equal specificity: keep the acceptance
+            // (lenient — a client contradicting itself gets the stream it
+            // half-asked for rather than a 406).
+            Some((s, bq)) if specificity == s => Some((s, bq.max(q))),
+            Some(kept) => Some(kept),
+            None => Some((specificity, q)),
+        };
+    }
+    best.is_some_and(|(_, q)| q > 0.0)
 }
 
 /// `GET /mcp`: open the server→client SSE stream. Replaces any previous
@@ -732,6 +750,11 @@ mod tests {
         assert!(!accepts_event_stream("text/event-stream;q=0"), "q=0 is an explicit refusal");
         assert!(!accepts_event_stream("text/event-stream; q=0.0"));
         assert!(accepts_event_stream("text/event-stream;charset=utf-8"), "non-q params ignored");
+        // The most specific matching range decides — a wildcard cannot
+        // resurrect an explicitly refused exact range.
+        assert!(!accepts_event_stream("text/event-stream;q=0, */*;q=1"));
+        assert!(!accepts_event_stream("text/*;q=0, */*"));
+        assert!(accepts_event_stream("text/event-stream, text/*;q=0"));
     }
 
     fn sse_get_with_session(session: &str) -> Request<Body> {

--- a/crates/mcp/src/http.rs
+++ b/crates/mcp/src/http.rs
@@ -9,7 +9,7 @@ use std::collections::{BTreeSet, VecDeque};
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 
 use axum::extract::{Request, State};
@@ -25,67 +25,87 @@ use crate::stdio::{handle_request, handle_subscription, subscription_notificatio
 use crate::subscriptions::SubscriptionRegistry;
 use crate::McpServer;
 
-/// The push half of the transport. At most ONE live SSE stream exists per
-/// server — this is a loopback, single-user endpoint, and one stream is what
-/// the Streamable HTTP shape needs (the client opens GET /mcp once and every
-/// notification flows down it). A new GET replaces the previous stream: the
-/// old stream's wake sender drops, its poll sees the closed channel and ends
-/// the stream, and its guard aborts the watches it owned — so a reconnecting
-/// client starts clean and re-subscribes, and no watch ever outlives the
-/// stream that requested it. Subscriptions arriving while NO stream is
-/// connected are refused (see `rpc`): accepting one would promise
-/// notifications with nowhere to send them, the exact failure shape #195
-/// eliminated.
+/// More concurrent sessions than this and new push streams are refused: this
+/// is a loopback single-user server, and its realistic clients are one IDE
+/// plus an assistant CLI or two — a runaway client must not mint streams
+/// (each carrying up to `MAX_SUBSCRIPTIONS` watches) without bound.
+const MAX_PUSH_SESSIONS: usize = 8;
+
+/// The push half of the transport: one SSE stream PER SESSION, keyed by the
+/// `Mcp-Session-Id` this server minted at `initialize` (see `rpc`). Distinct
+/// clients — a configured IDE and an assistant CLI, say — get distinct
+/// sessions, so one client's GET can never hijack or tear down another's
+/// stream; a GET carrying a session that already has a stream REPLACES that
+/// stream (the reconnect case), ending the old one and aborting the watches
+/// it owned — no watch ever outlives the stream that requested it.
+/// Subscriptions arriving for a session with no connected stream are refused
+/// (see `rpc`): accepting one would promise notifications with nowhere to
+/// send them, the exact failure shape #195 eliminated.
 #[derive(Default)]
 struct PushState {
-    active: Mutex<Option<PushChannels>>,
+    sessions: Mutex<std::collections::BTreeMap<String, PushChannels>>,
     /// Distinguishes streams so a dying stream's guard can only clear ITS
     /// slot, never a successor's (same shape as the subscription registry's
     /// generations).
     next_id: AtomicU64,
-    /// Set by `end_streams` at graceful shutdown. Checked under the `active`
-    /// lock on install, so a GET that was already accepted when shutdown
-    /// began cannot slip a fresh stream in after the teardown and stall the
-    /// shutdown all over again.
+    /// Set by `end_streams` at graceful shutdown. Checked under the
+    /// `sessions` lock on install, so a GET that was already accepted when
+    /// shutdown began cannot slip a fresh stream in after the teardown and
+    /// stall the shutdown all over again.
     closed: std::sync::atomic::AtomicBool,
 }
 
 impl PushState {
-    /// Install `chans` as THE stream, unless the server is shutting down.
-    /// Returns whether it was installed. Dropping a previous occupant here is
-    /// what ends a replaced stream: its wake sender closes, its poll sees the
-    /// closed channel, and its guard aborts the watches it owned.
-    fn install(&self, chans: PushChannels) -> bool {
-        let mut active = self.active.lock().unwrap_or_else(|e| e.into_inner());
+    /// Install `chans` as `session`'s stream, unless the server is shutting
+    /// down or the session cap is hit by OTHER sessions. Returns whether it
+    /// was installed. Dropping a previous same-session occupant here is what
+    /// ends a replaced stream (the reconnect case): its close signal fires
+    /// and its guard aborts the watches it owned.
+    fn install(&self, session: &str, chans: PushChannels) -> Result<(), StatusCode> {
+        let mut sessions = self.sessions.lock().unwrap_or_else(|e| e.into_inner());
         if self.closed.load(Ordering::Relaxed) {
-            return false;
+            return Err(StatusCode::SERVICE_UNAVAILABLE);
         }
-        *active = Some(chans);
-        true
+        if !sessions.contains_key(session) && sessions.len() >= MAX_PUSH_SESSIONS {
+            // Reap sessions whose stream already died before refusing —
+            // mirrors the subscription registry's cap-time reaping.
+            sessions.retain(|_, c| !c.wake.is_closed());
+            if sessions.len() >= MAX_PUSH_SESSIONS {
+                return Err(StatusCode::TOO_MANY_REQUESTS);
+            }
+        }
+        sessions.insert(session.to_string(), chans);
+        Ok(())
     }
 
-    /// Graceful-shutdown teardown (#193 review): drop the active stream's
-    /// channels so its SSE body ENDS. Without this the state and the stream
-    /// keep each other alive — the guard holds this state, the state's slot
-    /// holds the wake sender the stream waits on — and axum's graceful
-    /// shutdown waits on that body forever; the desktop only escaped by
-    /// timing out and aborting the whole server task, delaying stop and
-    /// token rotation by its two-second fallback.
+    /// Graceful-shutdown teardown (#193 review): drop every session's
+    /// channels so their SSE bodies END. Ending the body is what lets axum's
+    /// graceful shutdown complete instead of waiting on connected clients
+    /// forever (the desktop's only escape was its two-second abort
+    /// fallback, delaying stop and token rotation).
     fn end_streams(&self) {
-        let mut active = self.active.lock().unwrap_or_else(|e| e.into_inner());
+        let mut sessions = self.sessions.lock().unwrap_or_else(|e| e.into_inner());
         self.closed.store(true, Ordering::Relaxed);
-        active.take();
+        sessions.clear();
     }
 }
 
-/// What `resources/subscribe` needs from the active stream: the same
+/// What `resources/subscribe` needs from a session's stream: the same
 /// registry/dirty-set/wakeup trio the stdio serve loop owns per session.
-#[derive(Clone)]
+/// Deliberately NOT `Clone`: `_close` is the one non-cloneable handle whose
+/// drop tells the stream to end. The wake sender CANNOT serve that purpose —
+/// `handle_subscription` clones it into `on_change`/`on_dead`, and the real
+/// `CacheWatcher` moves those into its long-lived watch task, so with any
+/// real subscription active the wake channel stays open long after this
+/// struct is dropped (the first shutdown fix relied on exactly that and
+/// deadlocked: stream waits for watches to drop, watches drop when the
+/// guard runs, the guard runs when the stream ends).
 struct PushChannels {
     id: u64,
     subs: Arc<SubscriptionRegistry>,
     dirty: Arc<Mutex<BTreeSet<String>>>,
     wake: tokio::sync::mpsc::Sender<()>,
+    _close: tokio::sync::oneshot::Sender<()>,
 }
 
 #[derive(Clone)]
@@ -97,19 +117,20 @@ struct AppState {
 /// Aborts the stream's watches when the stream itself is dropped — client
 /// disconnect, replacement by a newer stream, or server shutdown all land
 /// here, so the "no watch outlives its stream" contract has one enforcement
-/// point. Clears the active slot only when it still holds this stream.
+/// point. Clears its session's slot only when it still holds this stream.
 struct StreamGuard {
     push: Arc<PushState>,
     subs: Arc<SubscriptionRegistry>,
+    session: String,
     id: u64,
 }
 
 impl Drop for StreamGuard {
     fn drop(&mut self) {
         self.subs.abort_all();
-        let mut active = self.push.active.lock().unwrap_or_else(|e| e.into_inner());
-        if active.as_ref().is_some_and(|a| a.id == self.id) {
-            *active = None;
+        let mut sessions = self.push.sessions.lock().unwrap_or_else(|e| e.into_inner());
+        if sessions.get(&self.session).is_some_and(|a| a.id == self.id) {
+            sessions.remove(&self.session);
         }
     }
 }
@@ -123,6 +144,11 @@ impl Drop for StreamGuard {
 /// crate for one loop.
 struct PushStream {
     wake: tokio::sync::mpsc::Receiver<()>,
+    /// Resolves (with `Err`, from the `_close` sender dropping) when this
+    /// stream's `PushChannels` leaves the session map — replacement or
+    /// shutdown. THE end-of-stream signal: the wake channel cannot be it,
+    /// because live watches hold wake-sender clones (see `PushChannels`).
+    closed: tokio::sync::oneshot::Receiver<()>,
     dirty: Arc<Mutex<BTreeSet<String>>>,
     pending: VecDeque<String>,
     _guard: StreamGuard,
@@ -137,6 +163,13 @@ impl futures_core::Stream for PushStream {
             if let Some(uri) = this.pending.pop_front() {
                 let msg = subscription_notification(&uri);
                 return Poll::Ready(Some(Ok(Event::default().data(msg.to_string()))));
+            }
+            // The close signal ends the stream even while queued
+            // notifications exist: the watches are being torn down, and the
+            // client's reconnect re-reads anyway (the initial-list
+            // notification fires on every fresh watch).
+            if std::future::Future::poll(Pin::new(&mut this.closed), cx).is_ready() {
+                return Poll::Ready(None);
             }
             match this.wake.poll_recv(cx) {
                 Poll::Ready(Some(())) => {
@@ -171,28 +204,40 @@ async fn sse(State(st): State<AppState>, headers: axum::http::HeaderMap) -> Resp
         return (StatusCode::NOT_ACCEPTABLE, "this endpoint streams text/event-stream").into_response();
     }
 
+    let session = presented_session(&headers).unwrap_or_else(|| DEFAULT_SESSION.to_string());
     let (wake_tx, wake_rx) = tokio::sync::mpsc::channel(1);
+    let (close_tx, close_rx) = tokio::sync::oneshot::channel();
     let chans = PushChannels {
         id: st.push.next_id.fetch_add(1, Ordering::Relaxed),
         subs: Arc::new(SubscriptionRegistry::new()),
         dirty: Arc::default(),
         wake: wake_tx,
+        _close: close_tx,
     };
     let stream = PushStream {
         wake: wake_rx,
+        closed: close_rx,
         dirty: chans.dirty.clone(),
         pending: VecDeque::new(),
-        _guard: StreamGuard { push: st.push.clone(), subs: chans.subs.clone(), id: chans.id },
+        _guard: StreamGuard {
+            push: st.push.clone(),
+            subs: chans.subs.clone(),
+            session: session.clone(),
+            id: chans.id,
+        },
     };
-    // Install as THE stream (see `PushState::install` for replacement and
-    // shutdown semantics). Refusal means graceful shutdown already began on
-    // this in-flight connection's watch — a fresh stream now would stall it.
-    if !st.push.install(chans) {
-        return (StatusCode::SERVICE_UNAVAILABLE, "the server is shutting down").into_response();
+    // Install as this session's stream (see `PushState::install` for
+    // replacement, cap, and shutdown semantics).
+    if let Err(status) = st.push.install(&session, chans) {
+        let message = match status {
+            StatusCode::TOO_MANY_REQUESTS => "too many concurrent push sessions",
+            _ => "the server is shutting down",
+        };
+        return (status, message).into_response();
     }
 
     (
-        [(MCP_SESSION_ID.clone(), session_id())],
+        [(MCP_SESSION_ID.clone(), session)],
         Sse::new(stream).keep_alive(
             KeepAlive::new().interval(std::time::Duration::from_secs(20)).text("keep-alive"),
         ),
@@ -203,53 +248,78 @@ async fn sse(State(st): State<AppState>, headers: axum::http::HeaderMap) -> Resp
 /// The `Mcp-Session-Id` header name, surfaced on every `/mcp` response.
 static MCP_SESSION_ID: HeaderName = HeaderName::from_static("mcp-session-id");
 
-/// A stable per-process MCP session id. Streamable-HTTP clients (e.g. Codex's
-/// `streamable_http` transport) establish a session on `initialize` and refuse
-/// to load tools unless the response carries this header — a minimal
-/// POST/JSON-RPC endpoint without it hangs their handshake (verified: Codex
-/// retries and reports "no tools"). srelens is stateless — the bearer token,
-/// not this id, is what authorizes each request — so the value only has to be
-/// present and stable across a server's lifetime, never validated on later
-/// requests. Claude Code's more lenient HTTP client works with or without it,
-/// so adding it is purely additive.
-fn session_id() -> &'static str {
-    static ID: OnceLock<String> = OnceLock::new();
-    ID.get_or_init(|| format!("srelens-{}", std::process::id()))
+/// Mint a fresh MCP session id for one `initialize`. Streamable-HTTP clients
+/// (e.g. Codex's `streamable_http` transport) establish a session on
+/// `initialize` and refuse to load tools unless the response carries this
+/// header — a minimal POST/JSON-RPC endpoint without it hangs their handshake
+/// (verified: Codex retries and reports "no tools"). Each client keeps the id
+/// IT was given and presents it on later requests, which is what routes its
+/// GET stream and its subscriptions to its own session slot — DISTINCT
+/// clients (an IDE and an assistant CLI) must not share one id, or one's
+/// reconnect would tear down the other's stream. The bearer token, not this
+/// id, is what authorizes a request; the id is routing, never auth.
+fn mint_session_id() -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    format!("srelens-{}-{}", std::process::id(), COUNTER.fetch_add(1, Ordering::Relaxed))
 }
 
-async fn rpc(State(st): State<AppState>, Json(req): Json<Value>) -> Response {
+/// The session id a request presents, if any. Absent for `initialize` (the
+/// client has none yet) and for hand-rolled callers (curl); those fall back
+/// to a shared default slot so single-client use needs no header discipline.
+fn presented_session(headers: &axum::http::HeaderMap) -> Option<String> {
+    headers.get(&MCP_SESSION_ID).and_then(|v| v.to_str().ok()).map(str::to_string)
+}
+
+/// The slot key for requests that present no session id.
+const DEFAULT_SESSION: &str = "default";
+
+async fn rpc(
+    State(st): State<AppState>,
+    headers: axum::http::HeaderMap,
+    Json(req): Json<Value>,
+) -> Response {
     let method = req.get("method").and_then(Value::as_str).unwrap_or("");
     // Subscription methods are handled here, not in `handle_request` — same
     // split as the stdio serve loop, because they need this transport's push
-    // machinery: the registry, dirty set, and wakeup of the ACTIVE SSE
-    // stream. With no stream connected they are refused outright; accepting
-    // would promise notifications with nowhere to send them.
+    // machinery: the registry, dirty set, and wakeup of the caller's OWN
+    // session stream. With no stream connected for that session they are
+    // refused outright; accepting would promise notifications with nowhere
+    // to send them.
     let resp = if method == "resources/subscribe" || method == "resources/unsubscribe" {
-        // The active-slot lock is held across `handle_subscription`, which is
-        // entirely synchronous (no await), so registration is SERIALIZED with
-        // stream replacement — `PushState::install` takes this same lock. The
-        // race this closes: a reconnecting GET replacing the stream between a
-        // clone of the channels and the registration completing would leave
-        // the watch in the old registry (whose guard then aborts it) while
-        // the client holds a success response for a subscription the new
-        // stream will never deliver.
-        let active = st.push.active.lock().unwrap_or_else(|e| e.into_inner());
-        match active.as_ref() {
+        let session = presented_session(&headers).unwrap_or_else(|| DEFAULT_SESSION.to_string());
+        // The sessions lock is held across `handle_subscription`, which is
+        // entirely synchronous (no await), so registration is SERIALIZED
+        // with stream replacement — `PushState::install` takes this same
+        // lock. The race this closes: a reconnecting GET replacing the
+        // stream between lookup and registration would leave the watch in
+        // the old registry (whose guard then aborts it) while the client
+        // holds a success response for a subscription the new stream will
+        // never deliver.
+        let sessions = st.push.sessions.lock().unwrap_or_else(|e| e.into_inner());
+        match sessions.get(&session) {
             Some(c) => handle_subscription(&st.server, &c.subs, &c.dirty, &c.wake, &req, method),
             None => req.get("id").cloned().map(|id| {
                 json!({"jsonrpc": "2.0", "id": id, "error": {"code": -32002, "message":
-                    "no notification stream is connected: open GET /mcp with `Accept: \
-                     text/event-stream` first, then subscribe — this subscription's \
-                     notifications would otherwise have nowhere to go"}})
+                    "no notification stream is connected for this session: open GET /mcp \
+                     with `Accept: text/event-stream` (presenting your Mcp-Session-Id) \
+                     first, then subscribe — this subscription's notifications would \
+                     otherwise have nowhere to go"}})
             }),
         }
     } else {
         handle_request(&st.server, &req, crate::Transport::Http).await
     };
+    // Streamable-HTTP session id: `initialize` MINTS a fresh one (each client
+    // then presents the id it was given, which is what keeps clients'
+    // sessions apart); every other response echoes the presented id back.
+    let sid = match presented_session(&headers) {
+        Some(sid) => sid,
+        None => mint_session_id(),
+    };
     match resp {
         // `Json` sets `content-type: application/json`; we add the session-id
         // header the streamable-HTTP handshake needs.
-        Some(resp) => ([(MCP_SESSION_ID.clone(), session_id())], Json(resp)).into_response(),
+        Some(resp) => ([(MCP_SESSION_ID.clone(), sid)], Json(resp)).into_response(),
         // A JSON-RPC notification (no `id`) expects no body. Streamable-HTTP
         // wants `202 Accepted` here, not `200` with a `{}` body — the latter
         // is what stalled Codex's client.
@@ -612,6 +682,108 @@ mod tests {
             Ok(Err(e)) if e.is_cancelled() => {}
             other => panic!("the watch must be cancelled when its stream drops: {other:?}"),
         }
+    }
+
+    fn sse_get_with_session(session: &str) -> Request<Body> {
+        Request::builder()
+            .method("GET")
+            .uri("/mcp")
+            .header("host", "127.0.0.1:8765")
+            .header("accept", "text/event-stream")
+            .header("mcp-session-id", session)
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    fn subscribe_post_with_session(uri: &str, session: &str) -> Request<Body> {
+        let body = json!({"jsonrpc":"2.0","id":7,"method":"resources/subscribe",
+            "params":{"uri": uri}});
+        Request::builder()
+            .method("POST")
+            .uri("/mcp")
+            .header("host", "127.0.0.1:8765")
+            .header("content-type", "application/json")
+            .header("mcp-session-id", session)
+            .body(Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    /// Two clients (an IDE and an assistant CLI, say) present distinct
+    /// session ids: one's GET must not hijack or tear down the other's
+    /// stream, and each subscribe routes to its own session's registry.
+    #[tokio::test]
+    async fn two_sessions_keep_separate_streams_and_subscriptions() {
+        let joins = Arc::new(Mutex::new(Vec::new()));
+        let app = router(subscribable_server(joins.clone()));
+
+        let a = app.clone().oneshot(sse_get_with_session("sess-a")).await.unwrap();
+        let b = app.clone().oneshot(sse_get_with_session("sess-b")).await.unwrap();
+        assert_eq!(a.status(), StatusCode::OK);
+        assert_eq!(b.status(), StatusCode::OK);
+        let mut a_body = a.into_body().into_data_stream();
+        let mut b_body = b.into_body().into_data_stream();
+
+        // A subscribes; the notification reaches A's stream...
+        let sub = app
+            .clone()
+            .oneshot(subscribe_post_with_session("k8s://c/ns/Pod/web-0", "sess-a"))
+            .await
+            .unwrap();
+        let sub_body = axum::body::to_bytes(sub.into_body(), 64 * 1024).await.unwrap();
+        let v: Value = serde_json::from_slice(&sub_body).unwrap();
+        assert!(v.get("error").is_none(), "A's subscribe must succeed: {v}");
+        let mut seen = String::new();
+        for _ in 0..5 {
+            match next_chunk(&mut a_body).await {
+                Some(chunk) => {
+                    seen.push_str(&chunk);
+                    if seen.contains("notifications/resources/updated") {
+                        break;
+                    }
+                }
+                None => break,
+            }
+        }
+        assert!(seen.contains("k8s://c/ns/Pod/web-0"), "A gets its notification: {seen:?}");
+
+        // ...and NOT B's, whose stream stays open and quiet (the bounded read
+        // times out with nothing).
+        assert!(next_chunk(&mut b_body).await.is_none(), "B must not receive A's notification");
+
+        // B's own GET reconnect replaces only B's stream: A's watch survives.
+        let b2 = app.clone().oneshot(sse_get_with_session("sess-b")).await.unwrap();
+        assert_eq!(b2.status(), StatusCode::OK);
+        assert_eq!(joins.lock().unwrap().len(), 1, "A's watch still exists");
+        let join = joins.lock().unwrap().pop().unwrap();
+        assert!(!join.is_finished(), "A's watch must survive B's reconnect");
+        join.abort();
+    }
+
+    /// Each `initialize` mints a fresh session id — two clients handed the
+    /// same id would collide in the session map, one reconnect tearing down
+    /// the other's stream.
+    #[tokio::test]
+    async fn initialize_mints_a_unique_session_id_per_client() {
+        let app = router(test_server());
+        let init = |app: Router| async move {
+            let body = json!({"jsonrpc":"2.0","id":1,"method":"initialize"});
+            let resp = app
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri("/mcp")
+                        .header("host", "127.0.0.1:8765")
+                        .header("content-type", "application/json")
+                        .body(Body::from(body.to_string()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            resp.headers().get("mcp-session-id").unwrap().to_str().unwrap().to_string()
+        };
+        let first = init(app.clone()).await;
+        let second = init(app).await;
+        assert_ne!(first, second, "each client must get its own session id");
     }
 
     /// The graceful-shutdown deadlock from review: the state and the stream

--- a/crates/mcp/src/http.rs
+++ b/crates/mcp/src/http.rs
@@ -43,6 +43,39 @@ struct PushState {
     /// slot, never a successor's (same shape as the subscription registry's
     /// generations).
     next_id: AtomicU64,
+    /// Set by `end_streams` at graceful shutdown. Checked under the `active`
+    /// lock on install, so a GET that was already accepted when shutdown
+    /// began cannot slip a fresh stream in after the teardown and stall the
+    /// shutdown all over again.
+    closed: std::sync::atomic::AtomicBool,
+}
+
+impl PushState {
+    /// Install `chans` as THE stream, unless the server is shutting down.
+    /// Returns whether it was installed. Dropping a previous occupant here is
+    /// what ends a replaced stream: its wake sender closes, its poll sees the
+    /// closed channel, and its guard aborts the watches it owned.
+    fn install(&self, chans: PushChannels) -> bool {
+        let mut active = self.active.lock().unwrap_or_else(|e| e.into_inner());
+        if self.closed.load(Ordering::Relaxed) {
+            return false;
+        }
+        *active = Some(chans);
+        true
+    }
+
+    /// Graceful-shutdown teardown (#193 review): drop the active stream's
+    /// channels so its SSE body ENDS. Without this the state and the stream
+    /// keep each other alive — the guard holds this state, the state's slot
+    /// holds the wake sender the stream waits on — and axum's graceful
+    /// shutdown waits on that body forever; the desktop only escaped by
+    /// timing out and aborting the whole server task, delaying stop and
+    /// token rotation by its two-second fallback.
+    fn end_streams(&self) {
+        let mut active = self.active.lock().unwrap_or_else(|e| e.into_inner());
+        self.closed.store(true, Ordering::Relaxed);
+        active.take();
+    }
 }
 
 /// What `resources/subscribe` needs from the active stream: the same
@@ -151,10 +184,12 @@ async fn sse(State(st): State<AppState>, headers: axum::http::HeaderMap) -> Resp
         pending: VecDeque::new(),
         _guard: StreamGuard { push: st.push.clone(), subs: chans.subs.clone(), id: chans.id },
     };
-    // Install as THE stream. A previous stream's channels drop here: its wake
-    // sender closing is what ends its `PushStream`, whose guard then aborts
-    // the watches that stream owned.
-    *st.push.active.lock().unwrap_or_else(|e| e.into_inner()) = Some(chans);
+    // Install as THE stream (see `PushState::install` for replacement and
+    // shutdown semantics). Refusal means graceful shutdown already began on
+    // this in-flight connection's watch — a fresh stream now would stall it.
+    if !st.push.install(chans) {
+        return (StatusCode::SERVICE_UNAVAILABLE, "the server is shutting down").into_response();
+    }
 
     (
         [(MCP_SESSION_ID.clone(), session_id())],
@@ -190,8 +225,16 @@ async fn rpc(State(st): State<AppState>, Json(req): Json<Value>) -> Response {
     // stream. With no stream connected they are refused outright; accepting
     // would promise notifications with nowhere to send them.
     let resp = if method == "resources/subscribe" || method == "resources/unsubscribe" {
-        let chans = st.push.active.lock().unwrap_or_else(|e| e.into_inner()).clone();
-        match chans {
+        // The active-slot lock is held across `handle_subscription`, which is
+        // entirely synchronous (no await), so registration is SERIALIZED with
+        // stream replacement — `PushState::install` takes this same lock. The
+        // race this closes: a reconnecting GET replacing the stream between a
+        // clone of the channels and the registration completing would leave
+        // the watch in the old registry (whose guard then aborts it) while
+        // the client holds a success response for a subscription the new
+        // stream will never deliver.
+        let active = st.push.active.lock().unwrap_or_else(|e| e.into_inner());
+        match active.as_ref() {
             Some(c) => handle_subscription(&st.server, &c.subs, &c.dirty, &c.wake, &req, method),
             None => req.get("id").cloned().map(|id| {
                 json!({"jsonrpc": "2.0", "id": id, "error": {"code": -32002, "message":
@@ -322,9 +365,18 @@ pub fn router_with_auth(server: McpServer, token: crate::auth::Token) -> Router 
 /// check is an outer `layer` covering every route (and unmatched paths), so
 /// nothing this server exposes answers a non-loopback caller.
 fn router_inner(server: McpServer, token: Option<crate::auth::Token>) -> Router {
-    let state =
-        AppState { server: Arc::new(server), push: Arc::new(PushState::default()) };
-    Router::new()
+    router_inner_with_push(server, token).0
+}
+
+/// Like `router_inner`, also handing back the push state so a graceful
+/// shutdown can end the live SSE stream (see `PushState::end_streams`).
+fn router_inner_with_push(
+    server: McpServer,
+    token: Option<crate::auth::Token>,
+) -> (Router, Arc<PushState>) {
+    let push = Arc::new(PushState::default());
+    let state = AppState { server: Arc::new(server), push: push.clone() };
+    let router = Router::new()
         // POST and GET share the route, so the token `route_layer` below
         // covers the SSE stream exactly like the JSON-RPC endpoint — a
         // long-lived stream is established under the same bearer check.
@@ -332,7 +384,8 @@ fn router_inner(server: McpServer, token: Option<crate::auth::Token>) -> Router 
         .route_layer(middleware::from_fn_with_state(token, token_guard))
         .route("/healthz", get(|| async { "ok" }))
         .layer(middleware::from_fn(host_guard))
-        .with_state(state)
+        .with_state(state);
+    (router, push)
 }
 
 /// Test-only convenience: a router with authentication disabled. Never
@@ -366,9 +419,15 @@ pub async fn serve_http_with_shutdown<F>(
 where
     F: std::future::Future<Output = ()> + Send + 'static,
 {
-    axum::serve(listener, router_with_auth(server, token))
-        .with_graceful_shutdown(shutdown)
-        .await
+    let (router, push) = router_inner_with_push(server, Some(token));
+    // End the live SSE stream BEFORE axum starts waiting on in-flight
+    // bodies, or an idle connected client would hold the shutdown open
+    // forever (see `PushState::end_streams`).
+    let shutdown = async move {
+        shutdown.await;
+        push.end_streams();
+    };
+    axum::serve(listener, router).with_graceful_shutdown(shutdown).await
 }
 
 #[cfg(test)]
@@ -553,6 +612,45 @@ mod tests {
             Ok(Err(e)) if e.is_cancelled() => {}
             other => panic!("the watch must be cancelled when its stream drops: {other:?}"),
         }
+    }
+
+    /// The graceful-shutdown deadlock from review: the state and the stream
+    /// kept each other alive, so axum's shutdown waited on the SSE body
+    /// forever and the desktop escaped only via its 2s abort fallback.
+    /// `end_streams` must END the live body (which is what lets the shutdown
+    /// complete), abort its watches, and refuse a late stream.
+    #[tokio::test]
+    async fn graceful_shutdown_ends_the_live_stream_instead_of_waiting_on_it() {
+        let joins = Arc::new(Mutex::new(Vec::new()));
+        let (app, push) = router_inner_with_push(subscribable_server(joins.clone()), None);
+
+        let stream_resp = app.clone().oneshot(sse_get()).await.unwrap();
+        let sub = app.clone().oneshot(subscribe_post("k8s://c/ns/Pod/web-0")).await.unwrap();
+        assert_eq!(sub.status(), StatusCode::OK);
+        let mut body = stream_resp.into_body().into_data_stream();
+
+        push.end_streams();
+        let mut flushed = 0;
+        loop {
+            match next_chunk(&mut body).await {
+                None => break,
+                Some(_) if flushed < 3 => flushed += 1,
+                Some(chunk) => panic!("the stream must end at shutdown, got: {chunk:?}"),
+            }
+        }
+        // In production hyper drops the completed body, which is what runs
+        // the guard; the drop is explicit here.
+        drop(body);
+        let join = joins.lock().unwrap().pop().unwrap();
+        match tokio::time::timeout(std::time::Duration::from_secs(2), join).await {
+            Ok(Err(e)) if e.is_cancelled() => {}
+            other => panic!("the watch must die with the shut-down stream: {other:?}"),
+        }
+
+        // An already-accepted GET racing the shutdown cannot reopen a stream
+        // and stall it all over again.
+        let late = app.oneshot(sse_get()).await.unwrap();
+        assert_eq!(late.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 
     #[tokio::test]

--- a/crates/mcp/src/http.rs
+++ b/crates/mcp/src/http.rs
@@ -201,19 +201,43 @@ impl futures_core::Stream for PushStream {
     }
 }
 
+/// Whether an `Accept` header value admits `text/event-stream`. Media-type
+/// tokens are case-insensitive (`Text/Event-Stream` is valid) and ranges
+/// carry optional quality values (`text/event-stream;q=0` is an explicit
+/// refusal, not an acceptance) — a bare substring check gets both wrong.
+/// The caller treats an ABSENT header as accepting; this only judges a
+/// header that is present.
+fn accepts_event_stream(accept: &str) -> bool {
+    accept.split(',').any(|range| {
+        let mut parts = range.split(';');
+        let media = parts.next().unwrap_or("").trim().to_ascii_lowercase();
+        if !matches!(media.as_str(), "text/event-stream" | "text/*" | "*/*") {
+            return false;
+        }
+        let q_refused = parts
+            .filter_map(|p| {
+                let p = p.trim().to_ascii_lowercase();
+                p.strip_prefix("q=").map(str::to_string)
+            })
+            .next_back()
+            .is_some_and(|v| v.trim().parse::<f32>().map(|q| q <= 0.0).unwrap_or(false));
+        !q_refused
+    })
+}
+
 /// `GET /mcp`: open the server→client SSE stream. Replaces any previous
 /// stream (see `PushState`). The keep-alive comment every 20s holds idle
 /// connections open through proxies and lets a dead client surface as a
 /// write error instead of a silent zombie.
 async fn sse(State(st): State<AppState>, headers: axum::http::HeaderMap) -> Response {
     // The spec has clients send `Accept: text/event-stream`; a GET that
-    // explicitly refuses it gets 406 rather than a stream it won't parse.
-    // An absent Accept header is allowed (curl convenience).
+    // refuses it gets 406 rather than a stream it won't parse. An absent
+    // Accept header is allowed (curl convenience).
     let accept = headers
         .get(axum::http::header::ACCEPT)
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
-    if !accept.is_empty() && !accept.contains("text/event-stream") && !accept.contains("*/*") {
+    if !accept.is_empty() && !accepts_event_stream(accept) {
         return (StatusCode::NOT_ACCEPTABLE, "this endpoint streams text/event-stream").into_response();
     }
 
@@ -695,6 +719,19 @@ mod tests {
             Ok(Err(e)) if e.is_cancelled() => {}
             other => panic!("the watch must be cancelled when its stream drops: {other:?}"),
         }
+    }
+
+    #[test]
+    fn accept_header_parsing_is_case_insensitive_and_honors_q_values() {
+        assert!(accepts_event_stream("text/event-stream"));
+        assert!(accepts_event_stream("Text/Event-Stream"), "media types are case-insensitive");
+        assert!(accepts_event_stream("application/json, text/event-stream;q=0.5"));
+        assert!(accepts_event_stream("*/*"));
+        assert!(accepts_event_stream("text/*"));
+        assert!(!accepts_event_stream("application/json"));
+        assert!(!accepts_event_stream("text/event-stream;q=0"), "q=0 is an explicit refusal");
+        assert!(!accepts_event_stream("text/event-stream; q=0.0"));
+        assert!(accepts_event_stream("text/event-stream;charset=utf-8"), "non-q params ignored");
     }
 
     fn sse_get_with_session(session: &str) -> Request<Body> {

--- a/crates/mcp/src/http.rs
+++ b/crates/mcp/src/http.rs
@@ -173,16 +173,19 @@ impl futures_core::Stream for PushStream {
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
         loop {
+            // The close signal is checked FIRST — before queued frames — so
+            // it ends the stream even when a slow client is backpressuring
+            // `pending`: replacement and shutdown must terminate promptly,
+            // not after the client deigns to read its backlog. Dropping the
+            // queued notifications is fine — the watches are being torn
+            // down, and the client's reconnect re-reads anyway (the
+            // initial-list notification fires on every fresh watch).
+            if std::future::Future::poll(Pin::new(&mut this.closed), cx).is_ready() {
+                return Poll::Ready(None);
+            }
             if let Some(uri) = this.pending.pop_front() {
                 let msg = subscription_notification(&uri);
                 return Poll::Ready(Some(Ok(Event::default().data(msg.to_string()))));
-            }
-            // The close signal ends the stream even while queued
-            // notifications exist: the watches are being torn down, and the
-            // client's reconnect re-reads anyway (the initial-list
-            // notification fires on every fresh watch).
-            if std::future::Future::poll(Pin::new(&mut this.closed), cx).is_ready() {
-                return Poll::Ready(None);
             }
             match this.wake.poll_recv(cx) {
                 Poll::Ready(Some(())) => {
@@ -251,11 +254,15 @@ async fn sse(State(st): State<AppState>, headers: axum::http::HeaderMap) -> Resp
     // The spec has clients send `Accept: text/event-stream`; a GET that
     // refuses it gets 406 rather than a stream it won't parse. An absent
     // Accept header is allowed (curl convenience).
+    // ALL Accept field lines, combined: HTTP defines repeated field lines as
+    // one comma-joined list, and `HeaderMap::get` sees only one of them.
     let accept = headers
-        .get(axum::http::header::ACCEPT)
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("");
-    if !accept.is_empty() && !accepts_event_stream(accept) {
+        .get_all(axum::http::header::ACCEPT)
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .collect::<Vec<_>>()
+        .join(",");
+    if !accept.is_empty() && !accepts_event_stream(&accept) {
         return (StatusCode::NOT_ACCEPTABLE, "this endpoint streams text/event-stream").into_response();
     }
 
@@ -779,6 +786,25 @@ mod tests {
             .header("mcp-session-id", session)
             .body(Body::from(body.to_string()))
             .unwrap()
+    }
+
+    /// Repeated `Accept` field lines are one combined list per HTTP — a
+    /// client sending `application/json` and `text/event-stream` as separate
+    /// lines is a valid SSE client whichever line the header map yields
+    /// first.
+    #[tokio::test]
+    async fn multiple_accept_field_lines_are_combined() {
+        let app = router(test_server());
+        let req = Request::builder()
+            .method("GET")
+            .uri("/mcp")
+            .header("host", "127.0.0.1:8765")
+            .header("accept", "application/json")
+            .header("accept", "text/event-stream")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
     }
 
     /// Two clients (an IDE and an assistant CLI, say) present distinct

--- a/crates/mcp/src/http.rs
+++ b/crates/mcp/src/http.rs
@@ -127,11 +127,24 @@ struct StreamGuard {
 
 impl Drop for StreamGuard {
     fn drop(&mut self) {
-        self.subs.abort_all();
-        let mut sessions = self.push.sessions.lock().unwrap_or_else(|e| e.into_inner());
-        if sessions.get(&self.session).is_some_and(|a| a.id == self.id) {
-            sessions.remove(&self.session);
+        // Slot removal FIRST, abort SECOND — and the removal takes the same
+        // lock every subscribe POST holds across its registration. After the
+        // slot is gone no POST can reach this registry (it finds no session
+        // and refuses), so the abort that follows closes the set for good.
+        // The reverse order had a window: a POST already holding the lock
+        // could insert its watch AFTER an early abort_all saw an empty
+        // registry, and the slot removal wouldn't abort again — an orphan
+        // watch surviving its stream. (A POST that completed before removal
+        // still answers success for a watch this abort kills moments later —
+        // but its stream is the one that just died, so the client sees the
+        // disconnect and resubscribes; no watch outlives the stream.)
+        {
+            let mut sessions = self.push.sessions.lock().unwrap_or_else(|e| e.into_inner());
+            if sessions.get(&self.session).is_some_and(|a| a.id == self.id) {
+                sessions.remove(&self.session);
+            }
         }
+        self.subs.abort_all();
     }
 }
 

--- a/crates/mcp/src/stdio.rs
+++ b/crates/mcp/src/stdio.rs
@@ -8,7 +8,17 @@ use tokio::io::{AsyncBufReadExt, AsyncWrite, AsyncWriteExt};
 
 use crate::{McpServer, Transport};
 
-const PROTOCOL_VERSION: &str = "2024-11-05";
+// 2025-03-26: the Streamable HTTP revision. Chosen over staying on
+// 2024-11-05 (whose HTTP transport is the legacy two-endpoint HTTP+SSE)
+// because the HTTP push channel (#193) follows the Streamable HTTP shape —
+// one /mcp endpoint, POST for requests, GET for the server->client SSE
+// stream — which is ALSO what the real clients already speak against this
+// server: the POST-only endpoint has been returning the Mcp-Session-Id
+// header specifically because Codex's streamable_http transport requires
+// it. Advertising the matching version makes the negotiated behaviour
+// truthful rather than a legacy label on a modern transport. Stdio
+// semantics are identical across the two revisions.
+const PROTOCOL_VERSION: &str = "2025-03-26";
 
 /// Stable prefix on the text of a consent-denied tool result. CLI transports
 /// strip `_meta`, so this text is the only denial signal that survives the
@@ -51,16 +61,16 @@ pub async fn handle_request(
             id?,
             json!({
                 "protocolVersion": PROTOCOL_VERSION,
-                // `subscribe` is transport-dependent: stdio can push
-                // notifications on its own stdout, the POST-only HTTP transport
-                // has no server-to-client channel at all (see issue #193).
-                // `listChanged` is false because the resource list is two fixed
-                // entries plus templates and never changes at runtime.
+                // Both transports can push now: stdio on its own stdout, HTTP
+                // on the GET /mcp SSE stream (#193) — so `subscribe` is
+                // truthfully true everywhere. `listChanged` is false because
+                // the resource list is two fixed entries plus templates and
+                // never changes at runtime.
                 "capabilities": {
                     "tools": {},
                     "prompts": {},
                     "resources": {
-                        "subscribe": transport == Transport::Stdio,
+                        "subscribe": true,
                         "listChanged": false
                     }
                 },
@@ -366,7 +376,7 @@ pub async fn handle_request(
 ///
 /// Synchronous: nothing here awaits. The watch it spawns signals changes by
 /// sending the canonical URI on `tx`, which the loop selects on.
-fn handle_subscription(
+pub(crate) fn handle_subscription(
     server: &std::sync::Arc<McpServer>,
     subs: &std::sync::Arc<crate::subscriptions::SubscriptionRegistry>,
     dirty: &std::sync::Arc<std::sync::Mutex<std::collections::BTreeSet<String>>>,
@@ -1268,10 +1278,10 @@ mod tests {
         assert!(caps["prompts"].is_object(), "prompts must survive");
     }
 
-    /// The HTTP transport is POST-only with no server-to-client channel, so it
-    /// must not claim a capability it cannot honour.
+    /// HTTP can genuinely push since #193 (the GET /mcp SSE stream), so the
+    /// capability it advertises is now truthfully `true` there too.
     #[tokio::test]
-    async fn initialize_advertises_subscribe_false_on_http() {
+    async fn initialize_advertises_subscribe_true_on_http() {
         let resp = handle_request(
             &server_with_ping(),
             &json!({"jsonrpc":"2.0","id":1,"method":"initialize"}),
@@ -1279,7 +1289,7 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(resp["result"]["capabilities"]["resources"]["subscribe"], json!(false));
+        assert_eq!(resp["result"]["capabilities"]["resources"]["subscribe"], json!(true));
     }
 
     #[tokio::test]
@@ -1464,9 +1474,10 @@ mod tests {
         assert!(n["params"].get("text").is_none());
     }
 
-    /// The HTTP transport has no server-to-client channel, so subscribe must
-    /// never be served there — `handle_request` (which HTTP uses) must not know
-    /// the method at all.
+    /// Subscription methods are the TRANSPORT LOOP's job on both transports
+    /// (each owns its registry/dirty-set/wake trio) — `handle_request` itself
+    /// must not know the method, or a transport that forgot to intercept it
+    /// would accept subscriptions it can't deliver.
     #[tokio::test]
     async fn handle_request_does_not_serve_subscribe() {
         let resp = handle_request(

--- a/crates/mcp/src/stdio.rs
+++ b/crates/mcp/src/stdio.rs
@@ -20,6 +20,15 @@ use crate::{McpServer, Transport};
 // semantics are identical across the two revisions.
 const PROTOCOL_VERSION: &str = "2025-03-26";
 
+/// Revisions this server can truthfully serve. Initialize NEGOTIATES: a
+/// client requesting one of these gets that revision echoed back (stdio
+/// semantics are identical across them, and HTTP implements the Streamable
+/// shape the newer one names); any other request — older, newer (e.g.
+/// 2025-06-18, whose extra MUSTs this server doesn't implement), or absent —
+/// gets the preferred `PROTOCOL_VERSION`, per the spec's "respond with the
+/// latest version the server supports" rule, and the client decides.
+const SUPPORTED_PROTOCOL_VERSIONS: [&str; 2] = ["2024-11-05", "2025-03-26"];
+
 /// Stable prefix on the text of a consent-denied tool result. CLI transports
 /// strip `_meta`, so this text is the only denial signal that survives the
 /// round trip through an agent CLI's transcript. `srelens_agent` defines the
@@ -57,10 +66,18 @@ pub async fn handle_request(
     let id = req.get("id").cloned();
 
     match method {
-        "initialize" => Some(ok(
+        "initialize" => {
+            let requested = req
+                .get("params")
+                .and_then(|p| p.get("protocolVersion"))
+                .and_then(Value::as_str);
+            let version = requested
+                .filter(|v| SUPPORTED_PROTOCOL_VERSIONS.contains(v))
+                .unwrap_or(PROTOCOL_VERSION);
+            Some(ok(
             id?,
             json!({
-                "protocolVersion": PROTOCOL_VERSION,
+                "protocolVersion": version,
                 // Both transports can push now: stdio on its own stdout, HTTP
                 // on the GET /mcp SSE stream (#193) — so `subscribe` is
                 // truthfully true everywhere. `listChanged` is false because
@@ -76,7 +93,8 @@ pub async fn handle_request(
                 },
                 "serverInfo": { "name": "srelens", "version": env!("CARGO_PKG_VERSION") }
             }),
-        )),
+            ))
+        }
         "ping" => Some(ok(id?, json!({}))),
         "notifications/initialized" | "initialized" => None,
         "tools/list" => {
@@ -1276,6 +1294,32 @@ mod tests {
         assert_eq!(caps["resources"]["listChanged"], json!(false));
         assert!(caps["tools"].is_object(), "tools must survive");
         assert!(caps["prompts"].is_object(), "prompts must survive");
+    }
+
+    /// Version negotiation: a client naming a supported revision gets THAT
+    /// revision back — an existing 2024-11-05 client must not be handed a
+    /// newer version it may reject — while unsupported or absent requests
+    /// get the server's preferred version, per spec.
+    #[tokio::test]
+    async fn initialize_negotiates_the_protocol_version() {
+        for (requested, expect) in [
+            (Some("2024-11-05"), "2024-11-05"),
+            (Some("2025-03-26"), "2025-03-26"),
+            (Some("2025-06-18"), PROTOCOL_VERSION),
+            (Some("bogus"), PROTOCOL_VERSION),
+            (None, PROTOCOL_VERSION),
+        ] {
+            let mut req = json!({"jsonrpc":"2.0","id":1,"method":"initialize"});
+            if let Some(v) = requested {
+                req["params"] = json!({ "protocolVersion": v });
+            }
+            let resp = handle_request(&server_with_ping(), &req, Transport::Stdio).await.unwrap();
+            assert_eq!(
+                resp["result"]["protocolVersion"],
+                json!(expect),
+                "requested {requested:?}"
+            );
+        }
     }
 
     /// HTTP can genuinely push since #193 (the GET /mcp SSE stream), so the

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -153,7 +153,7 @@ Beyond tools, the server implements:
 
 - **Prompts** (`crates/mcp/src/prompts.rs`) — canned diagnostic flows, with bodies in `crates/mcp/src/prompts/*.md` as `discover`/`targeted` pairs (pod-crashloop, pod-pending, node-pressure, service-no-endpoints), plus user-authored prompts from a host-supplied directory. A test asserts every tool a prompt names really exists and is on the read-only allowlist.
 - **Resources** (`crates/mcp/src/resources.rs`) — `k8s://` URIs resolved through a `KindResolver`. Secrets are deliberately *not* addressable as resources; they stay behind the gated `k8s.getSecret` tool, which is what keeps "the consent gate never fires on a resource read" true.
-- **Subscriptions** (`crates/mcp/src/subscriptions.rs`) — watch-backed `resources/subscribe`. Server→client push currently works on stdio; HTTP push is tracked as future work.
+- **Subscriptions** (`crates/mcp/src/subscriptions.rs`) — watch-backed `resources/subscribe` on both transports: stdio pushes on its stdout, HTTP on the `GET /mcp` SSE stream (`crates/mcp/src/http.rs`, #193), with every watch scoped to the stream that requested it.
 
 Every component fails closed: an `McpServer` whose host wires nothing denies every gated call, resolves no kinds, and refuses every subscription.
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -325,7 +325,9 @@ audited exactly like any other MCP call.
 
 Alongside tools and prompts, srelens exposes cluster state as MCP
 **resources** — addressable under `k8s://` URIs that a client can list,
-read, and (over stdio) subscribe to for change notifications. The exact
+read, and subscribe to for change notifications (on either transport — see
+the subscription section below for how HTTP clients open the push stream).
+The exact
 fixed URIs and parameterised URI shapes are listed in
 [mcp-catalog.md § Resources](mcp-catalog.md#resources); what matters here is
 what they mean and how to use them.

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -374,16 +374,21 @@ would make — `k8s.getManifest`, `k8s.listEvents`, `k8s.podLogs`, or
 exactly like a tool call**, appearing in the same audit log under the
 underlying capability's name, with the same redaction rules.
 
-**Subscriptions work over stdio only.** A client can send
+**Subscriptions work on both transports.** A client can send
 `resources/subscribe` for an object URI and receive a
 `notifications/resources/updated` message whenever that object changes; the
 notification carries only the URI, and the client re-reads to get the new
-content. The HTTP transport is request/response only, with no channel for
-the server to push a notification back, so it advertises `subscribe: false`
-in `initialize` and answers `resources/subscribe` with an error rather than
-silently accepting a subscription that can never fire. Pushing resource
-updates to HTTP clients (via SSE or similar) is tracked as a follow-up in
-[issue #193](https://github.com/srelens/srelens/issues/193). Up to 32
+content. Over stdio, notifications arrive on the server's stdout. Over HTTP
+([issue #193](https://github.com/srelens/srelens/issues/193)), the client
+first opens the push channel — `GET /mcp` with `Accept: text/event-stream`,
+authenticated with the same bearer token and covered by the same loopback
+`Host` check — and notifications arrive as SSE events on that stream.
+Subscribing with no stream connected is refused rather than silently
+accepted, since the notifications would have nowhere to go, and
+subscriptions live exactly as long as the stream that carries them: a
+disconnect, a reconnect replacing the stream, or a token rotation (which
+restarts the server) releases every watch, and the client re-subscribes on
+its new stream. Up to 32
 subscriptions can be live at once; re-subscribing to a URI you already hold
 replaces it in place rather than counting twice, and past the cap you need
 to unsubscribe from something before adding another.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -323,6 +323,21 @@ AI clients, using your locally authenticated cluster contexts. Open
 - **View the bearer token and audit log** — rotate or revoke the HTTP token,
   and review recent agent activity, from the same panel.
 
+Both transports support **resource subscriptions** (`resources/subscribe` on
+`k8s://` object URIs): the server pushes a `notifications/resources/updated`
+when the watched object changes, and the client re-reads. Over stdio,
+notifications arrive on the server's stdout. Over HTTP, the client first opens
+the push channel — `GET /mcp` with `Accept: text/event-stream`, same bearer
+token — and notifications arrive as SSE events on that stream; subscribing
+without the stream connected is refused, since the notifications would have
+nowhere to go. Subscriptions live exactly as long as the stream that carries
+them: if the stream drops — client disconnect, a reconnect replacing it, or
+**rotating the bearer token**, which restarts the HTTP server so the old token
+stops being accepted immediately — every watch it carried is released, and the
+client is expected to reconnect (with the new token, after a rotation) and
+subscribe again. That is deliberate: rotation is meant to cut off existing
+clients, and a subscription that silently survived it would be a leak.
+
 You can also start a server directly:
 
 ```sh


### PR DESCRIPTION
Fixes #193.

## The decision the issue asked for first

**Streamable HTTP semantics, `PROTOCOL_VERSION` bumped to `2025-03-26`** — not the legacy two-endpoint HTTP+SSE of the pinned `2024-11-05`. The reasoning (recorded at the constant): this endpoint has been streamable-HTTP *shaped* since the `Mcp-Session-Id` header landed for Codex's `streamable_http` transport — the real clients already speak it — so the push half follows the same shape (one `/mcp` endpoint; POST for JSON-RPC, GET for the SSE stream) and the advertised revision now matches the transport instead of labeling it with the legacy version. Stdio semantics are identical across the two revisions.

## What ships

- **`GET /mcp`** (with `Accept: text/event-stream`, behind the *same* bearer-token `route_layer` and loopback `Host` guard as POST) opens the server→client SSE stream. Keep-alive comments every 20s; each SSE event carries exactly one JSON-RPC message.
- **`resources/subscribe`/`unsubscribe` on HTTP** route into `handle_subscription` with a per-stream registry/dirty-set/wakeup trio — the exact machinery the stdio serve loop owns per session, including all the #195 eviction semantics.
- **Lifecycle**: at most one stream per server (loopback, single-user). A new GET replaces the old stream; a drop-guard on the stream body aborts every watch it owned — client disconnect, replacement, and server shutdown all land on the one enforcement point, so **no watch outlives the stream that requested it**. Subscribing with no stream connected is refused (`-32002`, with instructions) rather than accepted into silence.
- **`initialize` advertises `subscribe: true` on both transports** — truthfully, now.

## The #23 rotation collision

Resolved by design, not evasion: rotating the token restarts the HTTP server, the restart drops the stream, the drop-guard releases every watch, and clients reconnect with the new token and resubscribe. Rotation is *meant* to cut existing clients off — a subscription that silently survived it would be a leak. Documented in `docs/USAGE.md` (the guard path is identical however the connection dies, so the dropped-stream test covers the mechanism).

## Testing (all criteria from the issue)

- A subscription notification **reaches an HTTP client** end-to-end through the router (SSE frame carrying `notifications/resources/updated` + the URI).
- A **dropped stream releases its watch** (JoinHandle observed cancelled).
- A **replacing stream** ends the old one (after flushing what it had already queued), aborts its watches, and subscribes cleanly itself.
- **Auth + Host checks enforced on the streaming route** (401 / 403).
- Subscribe **without a stream** is refused with the fix in the message, and spawns no watch.
- Full suites: `srelens-mcp` 226 (18 HTTP-transport tests), `srelens-desktop` 158, `srelens-server` green; clippy clean for this change (the one warning is pre-existing in `prompts.rs`).

The only new dependency is `futures-core` (the `Stream` trait alone, already in the tree under axum) for the hand-rolled SSE body.
