### PR TITLE
test(coverage): count the kind suites in the gate and ratchet 55 → 84

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,9 @@ jobs:
       - name: Tests with coverage — unit suites and kind-bound suites
         env:
           SRELENS_E2E_CONTEXT: kind-srelens-e2e
+          # Authenticates the toolbox suite's api.github.com lookups — the
+          # anonymous runner pool 403s intermittently (krew/helm "latest").
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cargo llvm-cov --no-report --workspace
           cargo llvm-cov --no-report -p srelens-desktop --test e2e -- --ignored --nocapture --test-threads=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,46 +68,6 @@ jobs:
           components: llvm-tools-preview
       - uses: taiki-e/install-action@cargo-llvm-cov
       - uses: Swatinem/rust-cache@v2
-      - name: Backend tests with coverage
-        # The Tauri runtime shell (commands, event streams, process entry) only
-        # executes inside a running app/cluster, so it is excluded from the
-        # measurement. The floor is a ratchet: currently 55%, raise it toward
-        # 85% as cluster-bound integration tests land — never lower it.
-        run: >-
-          cargo llvm-cov --workspace --summary-only --fail-under-lines 55
-          --ignore-filename-regex 'apps/desktop/src-tauri/src/(lib|main|bridge|exec|files|forward|logs|watch)\.rs'
-
-  integration:
-    name: integration (kind)
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      # Tauri v2 system libraries needed to compile the desktop crate.
-      - name: Install Linux dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            libjavascriptcoregtk-4.1-dev \
-            libappindicator3-dev \
-            librsvg2-dev \
-            patchelf \
-            libgtk-3-dev \
-            libssl-dev \
-            build-essential
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-      # tauri-build validates that frontendDist exists at compile time, so the
-      # frontend must be built before the Rust workspace compiles.
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm build
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
       - uses: azure/setup-helm@v4
         with:
           version: v3.16.3
@@ -115,20 +75,31 @@ jobs:
         uses: helm/kind-action@v1
         with:
           cluster_name: srelens-e2e
-      # These suites are #[ignore]d (they need a live cluster), so they must be
-      # run explicitly with --ignored. Without this job the e2e coverage
-      # assertion — "every registered capability is exercised end-to-end" —
-      # would never execute, and a new capability could land with no e2e case.
-      - name: Capability suite against the cluster
+      # ONE instrumented run covers everything (#28): the unit suites AND the
+      # #[ignore]d kind-bound suites, accumulated into one report. Running
+      # the integration suites under coverage is what took the honest number
+      # from ~80% to ~86% — the capability e2e executes exactly the closure
+      # bodies (actions, metrics, crds, helm, exec, manifest) that no mocked
+      # unit test reaches — and merging the old separate kind job in here
+      # buys that with one workspace build and one cluster instead of two.
+      # The e2e's own coverage assertion ("every registered capability is
+      # exercised") still runs, unchanged, as part of the suite itself.
+      - name: Tests with coverage — unit suites and kind-bound suites
         env:
           SRELENS_E2E_CONTEXT: kind-srelens-e2e
         run: |
-          cargo test -p srelens-desktop --test e2e -- --ignored --nocapture --test-threads=1
-      - name: Helm lifecycle against the cluster
-        env:
-          SRELENS_E2E_CONTEXT: kind-srelens-e2e
-        run: |
-          cargo test -p srelens-kube --test helm_lifecycle -- --ignored --nocapture --test-threads=1
+          cargo llvm-cov --no-report --workspace
+          cargo llvm-cov --no-report -p srelens-desktop --test e2e -- --ignored --nocapture --test-threads=1
+          cargo llvm-cov --no-report -p srelens-kube --test helm_lifecycle -- --ignored --nocapture --test-threads=1
+      - name: Enforce the coverage floor
+        # The Tauri runtime shell (bridge, event streams, process entry) only
+        # executes inside a running app, so it stays excluded. The floor is a
+        # ratchet — 55 at first green, 84 now that the kind suites count
+        # (measured 85.79) — never lower it; the final step to 85 lands with
+        # the seams for the remaining command files (#28).
+        run: >-
+          cargo llvm-cov report --summary-only --fail-under-lines 84
+          --ignore-filename-regex 'apps/desktop/src-tauri/src/(lib|main|bridge|exec|files|forward|logs|watch)\.rs'
 
   # The WebDriver smoke suite (issue #30): the REAL built app — WebView and
   # all — driven through tauri-driver against a kind cluster. This is the

--- a/apps/desktop/src-tauri/src/toolbox.rs
+++ b/apps/desktop/src-tauri/src/toolbox.rs
@@ -32,8 +32,20 @@ fn fetch_with_progress(url: &str, app: &AppHandle, tool: &str) -> Result<Vec<u8>
         .user_agent(concat!("srelens/", env!("CARGO_PKG_VERSION")))
         .build()
         .map_err(|e| InstallError::Download(e.to_string()))?;
-    let mut resp = client
-        .get(url)
+    let mut req = client.get(url);
+    // GitHub API lookups (helm/krew "latest release") from CI runners share
+    // the anonymous rate-limit pool and 403 intermittently; an ambient
+    // GITHUB_TOKEN — set by CI, absent on user machines — authenticates
+    // them. Restricted to api.github.com so the token can never leak to an
+    // arbitrary download host.
+    if github_api_wants_auth(url) {
+        if let Ok(token) = std::env::var("GITHUB_TOKEN") {
+            if !token.is_empty() {
+                req = req.bearer_auth(token);
+            }
+        }
+    }
+    let mut resp = req
         .send()
         .map_err(|e| InstallError::Download(e.to_string()))?;
     if !resp.status().is_success() {
@@ -80,4 +92,24 @@ pub async fn start_tool_install(app: AppHandle, tool: String) -> Result<InstallT
     })
     .await
     .map_err(|e| e.to_string())?
+}
+
+/// Whether `url` is a GitHub API endpoint an ambient `GITHUB_TOKEN` should
+/// authenticate. Exact-host match on purpose: a bearer token must never ride
+/// along to release-asset CDNs or arbitrary mirrors.
+fn github_api_wants_auth(url: &str) -> bool {
+    url.starts_with("https://api.github.com/")
+}
+
+#[cfg(test)]
+mod github_auth_tests {
+    use super::github_api_wants_auth;
+
+    #[test]
+    fn only_the_github_api_host_gets_the_token() {
+        assert!(github_api_wants_auth("https://api.github.com/repos/helm/helm/releases/latest"));
+        assert!(!github_api_wants_auth("https://github.com/srelens/srelens/releases"));
+        assert!(!github_api_wants_auth("https://get.helm.sh/helm-v3.tar.gz"));
+        assert!(!github_api_wants_auth("https://api.github.com.evil.example/x"));
+    }
 }

--- a/apps/desktop/src-tauri/src/toolbox.rs
+++ b/apps/desktop/src-tauri/src/toolbox.rs
@@ -38,11 +38,9 @@ fn fetch_with_progress(url: &str, app: &AppHandle, tool: &str) -> Result<Vec<u8>
     // GITHUB_TOKEN — set by CI, absent on user machines — authenticates
     // them. Restricted to api.github.com so the token can never leak to an
     // arbitrary download host.
-    if github_api_wants_auth(url) {
-        if let Ok(token) = std::env::var("GITHUB_TOKEN") {
-            if !token.is_empty() {
-                req = req.bearer_auth(token);
-            }
+    if srelens_kube::toolbox_install::github_api_wants_auth(url) {
+        if let Some(token) = srelens_kube::toolbox_install::ambient_github_token() {
+            req = req.bearer_auth(token);
         }
     }
     let mut resp = req
@@ -94,22 +92,3 @@ pub async fn start_tool_install(app: AppHandle, tool: String) -> Result<InstallT
     .map_err(|e| e.to_string())?
 }
 
-/// Whether `url` is a GitHub API endpoint an ambient `GITHUB_TOKEN` should
-/// authenticate. Exact-host match on purpose: a bearer token must never ride
-/// along to release-asset CDNs or arbitrary mirrors.
-fn github_api_wants_auth(url: &str) -> bool {
-    url.starts_with("https://api.github.com/")
-}
-
-#[cfg(test)]
-mod github_auth_tests {
-    use super::github_api_wants_auth;
-
-    #[test]
-    fn only_the_github_api_host_gets_the_token() {
-        assert!(github_api_wants_auth("https://api.github.com/repos/helm/helm/releases/latest"));
-        assert!(!github_api_wants_auth("https://github.com/srelens/srelens/releases"));
-        assert!(!github_api_wants_auth("https://get.helm.sh/helm-v3.tar.gz"));
-        assert!(!github_api_wants_auth("https://api.github.com.evil.example/x"));
-    }
-}

--- a/crates/kube/src/toolbox_install.rs
+++ b/crates/kube/src/toolbox_install.rs
@@ -162,9 +162,39 @@ pub struct ArchiveInstall {
     pub target: PathBuf,
 }
 
+/// Whether `url` is a GitHub API endpoint an ambient `GITHUB_TOKEN` should
+/// authenticate: unauthenticated calls from CI runners share a rate-limit
+/// pool and 403 intermittently. Exact-prefix on purpose — a bearer token
+/// must never ride along to release-asset CDNs or arbitrary mirrors. Both
+/// blocking fetch paths (the registry's plain `http_get` and the desktop's
+/// progress-emitting variant) consult this ONE predicate, so the two can't
+/// drift on which hosts get the token.
+pub fn github_api_wants_auth(url: &str) -> bool {
+    url.starts_with("https://api.github.com/")
+}
+
+/// The ambient GitHub token, if one is set and non-empty (CI sets it; user
+/// machines don't).
+pub fn ambient_github_token() -> Option<String> {
+    std::env::var("GITHUB_TOKEN").ok().filter(|t| !t.is_empty())
+}
+
 /// GitHub API endpoint for helm's latest release (helm has no `stable.txt`).
 pub const HELM_LATEST_RELEASE_URL: &str =
     "https://api.github.com/repos/helm/helm/releases/latest";
+
+#[cfg(test)]
+mod github_auth_tests {
+    use super::github_api_wants_auth;
+
+    #[test]
+    fn only_the_github_api_host_gets_the_token() {
+        assert!(github_api_wants_auth("https://api.github.com/repos/helm/helm/releases/latest"));
+        assert!(!github_api_wants_auth("https://github.com/srelens/srelens/releases"));
+        assert!(!github_api_wants_auth("https://get.helm.sh/helm-v3.tar.gz"));
+        assert!(!github_api_wants_auth("https://api.github.com.evil.example/x"));
+    }
+}
 
 /// Pull the `tag_name` (e.g. `v3.16.2`) out of a GitHub "latest release" JSON body.
 pub fn parse_github_latest_tag(body: &[u8]) -> Result<String, InstallError> {

--- a/crates/registry/src/lib.rs
+++ b/crates/registry/src/lib.rs
@@ -55,11 +55,23 @@ pub fn default_kubeconfig_path() -> PathBuf {
 /// `spawn_blocking` (the install capabilities), so blocking here is fine. A
 /// non-2xx or transport error maps to the retryable `Download` variant.
 fn http_get(url: &str) -> Result<Vec<u8>, srelens_kube::toolbox_install::InstallError> {
-    use srelens_kube::toolbox_install::InstallError;
-    let resp = reqwest::blocking::Client::builder()
+    use srelens_kube::toolbox_install::{ambient_github_token, github_api_wants_auth, InstallError};
+    let client = reqwest::blocking::Client::builder()
         .user_agent(concat!("srelens/", env!("CARGO_PKG_VERSION")))
         .build()
-        .and_then(|client| client.get(url).send())
+        .map_err(|e| InstallError::Download(e.to_string()))?;
+    let mut req = client.get(url);
+    // Same rule as the desktop's progress fetch, from the same predicate:
+    // api.github.com lookups authenticate with an ambient GITHUB_TOKEN so CI
+    // (whose anonymous pool 403s intermittently) stays reliable; the token
+    // never rides to other hosts.
+    if github_api_wants_auth(url) {
+        if let Some(token) = ambient_github_token() {
+            req = req.bearer_auth(token);
+        }
+    }
+    let resp = req
+        .send()
         .map_err(|e| InstallError::Download(e.to_string()))?;
     if !resp.status().is_success() {
         return Err(InstallError::Download(format!("{} for {url}", resp.status())));


### PR DESCRIPTION
First ratchet step for #28 (the issue stays open for the final 84 → 85 with command-file seams).

## What

- **The kind-bound suites now run UNDER coverage.** They always exercised exactly the closure bodies the gate scored worst — `actions` (39%), `metrics` (39%), `crds` (41%), `helm` (42%), `exec` (49%), `manifest` (73%) are capability handlers the e2e drives end-to-end — but they ran in a separate, uninstrumented job, so none of it counted. Measured effect: **80.52% → 85.79%** total lines.
- **The separate `integration (kind)` job is merged into `backend`**: one workspace build and one kind cluster instead of two of each, with the suites accumulated via `cargo llvm-cov --no-report` and the floor enforced in a final `report` step. The e2e's own "every capability is exercised" assertion runs unchanged inside the suite. (If branch protection lists `integration (kind)` as a required check, drop it — its suites now gate through `backend`.)
- **Floor: 55 → 84**, leaving honest headroom under the measured 85.79 so routine PRs don't trip on noise.

## What the remaining ~1.8 points need (follow-up, tracked on #28)

The residue is structural, not mechanical: `vault_password.rs`/`vault_biometric.rs`/`cluster_oidc_cmd.rs` at 0% and `mcp.rs` at 43% are Tauri command files needing thin seams (the logic extracted from `State`/`AppHandle` signatures), and `watch.rs` (30%) is live-watch machinery. Those come as their own PR and carry the floor to 85, per the issue's acceptance.

## Verification

Measured locally with the exact accumulation the job now runs (unit suites + capability e2e + helm lifecycle against kind): TOTAL 85.79% lines. The job's runtime grows by the cluster + e2e (~5 min) but retires the separate integration job's full build, so net CI time is roughly flat.