### PR TITLE
test(desktop): cover the Tauri command shims, trim the coverage ignore-regex

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,15 +95,16 @@ jobs:
           cargo llvm-cov --no-report -p srelens-desktop --test e2e -- --ignored --nocapture --test-threads=1
           cargo llvm-cov --no-report -p srelens-kube --test helm_lifecycle -- --ignored --nocapture --test-threads=1
       - name: Enforce the coverage floor
-        # The Tauri runtime shell (bridge, event streams, process entry) and
-        # the server's process-entry binary only execute inside a running
-        # app/server, so they stay excluded. The floor is a ratchet — 55 at
-        # first green, 84 when the kind suites started counting, 85 with the
-        # vault-password seams (measured 86.16, issue #28's acceptance
-        # number) — never lower it.
+        # Only the process entries stay excluded (lib.rs/main.rs and the
+        # server's bin — they execute solely inside a running app/server).
+        # The command shims that used to sit here are unit-tested through
+        # tauri::test's MockRuntime and count like everything else. The floor
+        # is a ratchet — 55 at first green, 84 when the kind suites started
+        # counting, 85 with the vault-password seams (measured 86.16, issue
+        # #28's acceptance number) — never lower it.
         run: >-
           cargo llvm-cov report --summary-only --fail-under-lines 85
-          --ignore-filename-regex 'apps/desktop/src-tauri/src/(lib|main|bridge|exec|files|forward|logs|watch)\.rs|crates/server/src/bin/'
+          --ignore-filename-regex 'apps/desktop/src-tauri/src/(lib|main)\.rs|crates/server/src/bin/'
 
   # The WebDriver smoke suite (issue #30): the REAL built app — WebView and
   # all — driven through tauri-driver against a kind cluster. This is the

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -96,6 +96,10 @@ tauri-plugin-process = "2"
 fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs" }
 
 [dev-dependencies]
+# The "test" feature unlocks tauri::test::mock_app — the unit suites drive
+# the command shims (exec, forward, logs, watch, bridge, files) through a
+# MockRuntime app instead of leaving them excluded from coverage (#28).
+tauri = { version = "2.11.3", features = ["test"] }
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time", "process"] }
 futures = "0.3"
 # WebDriver client for the #[ignore]d smoke suite (tests/webdriver_smoke.rs,

--- a/apps/desktop/src-tauri/src/bridge.rs
+++ b/apps/desktop/src-tauri/src/bridge.rs
@@ -26,3 +26,34 @@ pub async fn invoke_capability(
         message
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use srelens_capability::Capability;
+    use tauri::Manager;
+
+    /// Both bridge paths through a MockRuntime app: a registered capability's
+    /// value passes through untouched, and a failure (unknown id here) comes
+    /// back as the flat string the WebView renders.
+    #[tokio::test]
+    async fn passes_values_through_and_flattens_errors() {
+        let mut registry = Registry::new();
+        registry.register(Capability::read_only("test.echo", "echo", |input| async move {
+            Ok(json!({ "echoed": input }))
+        }));
+        let app = tauri::test::mock_app();
+        app.manage(AppRegistry(registry));
+
+        let value = invoke_capability("test.echo".into(), json!({"k": 1}), app.state())
+            .await
+            .unwrap();
+        assert_eq!(value, json!({ "echoed": { "k": 1 } }));
+
+        let e = invoke_capability("test.missing".into(), json!({}), app.state())
+            .await
+            .unwrap_err();
+        assert!(e.contains("test.missing"), "unexpected error: {e}");
+    }
+}

--- a/apps/desktop/src-tauri/src/exec.rs
+++ b/apps/desktop/src-tauri/src/exec.rs
@@ -1,10 +1,14 @@
 //! Tauri adapter for in-pod exec: the streaming core lives in
 //! srelens_streams::exec; this module only maps the Tauri command surface.
+//!
+//! Commands are generic over the runtime (#28): the unit suite below drives
+//! them through `tauri::test::MockRuntime`, so this surface counts toward
+//! coverage instead of hiding behind the ignore-regex.
 
 use std::sync::Arc;
 
 use srelens_streams::exec::{ExecManager, ExecOpts};
-use tauri::{AppHandle, State};
+use tauri::{AppHandle, Runtime, State};
 
 use crate::sink::TauriSink;
 
@@ -13,7 +17,7 @@ use crate::sink::TauriSink;
 /// error string) when the session ends.
 #[tauri::command]
 #[allow(clippy::too_many_arguments)]
-pub async fn start_pod_exec(
+pub async fn start_pod_exec<R: Runtime>(
     context: String,
     namespace: String,
     pod: String,
@@ -22,7 +26,7 @@ pub async fn start_pod_exec(
     command: Option<Vec<String>>,
     cols: Option<u16>,
     rows: Option<u16>,
-    app: AppHandle,
+    app: AppHandle<R>,
     manager: State<'_, ExecManager>,
 ) -> Result<u64, String> {
     manager
@@ -70,4 +74,44 @@ pub async fn exec_resize(
 pub async fn exec_close(session: u64, manager: State<'_, ExecManager>) -> Result<(), String> {
     manager.close(session);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use srelens_kube::client_cache::ClientCache;
+    use tauri::Manager;
+
+    /// The full command surface against a MockRuntime app: start hands back a
+    /// session id immediately (connection failures surface later as an
+    /// `exec:exit` event), and input/resize/close are no-ops for a session
+    /// whose task already died — exactly the WebView's teardown race.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn commands_run_against_a_mock_runtime() {
+        let app = tauri::test::mock_app();
+        app.manage(ExecManager::new(ClientCache::new_many(vec![])));
+
+        let id = start_pod_exec(
+            "no-such-context".into(),
+            "ns".into(),
+            "pod".into(),
+            None,
+            None,
+            None,
+            Some(80),
+            Some(24),
+            app.handle().clone(),
+            app.state(),
+        )
+        .await
+        .unwrap();
+
+        exec_input(id, "ls\n".into(), app.state()).await.unwrap();
+        exec_resize(id, 120, 40, app.state()).await.unwrap();
+        exec_close(id, app.state()).await.unwrap();
+        // Unknown session: every command stays a quiet no-op.
+        exec_input(id + 1, "x".into(), app.state()).await.unwrap();
+        exec_resize(id + 1, 80, 24, app.state()).await.unwrap();
+        exec_close(id + 1, app.state()).await.unwrap();
+    }
 }

--- a/apps/desktop/src-tauri/src/files.rs
+++ b/apps/desktop/src-tauri/src/files.rs
@@ -3,16 +3,17 @@
 //! (and other text) downloads go through here.
 
 use std::fs;
+use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use tauri::{AppHandle, Manager};
+use tauri::{AppHandle, Manager, Runtime};
 use tauri_plugin_dialog::DialogExt;
 
 /// Prompt for a save location (pre-filled with `filename`) and write `content`
 /// there. Returns the chosen path, or `None` if the user cancelled.
 #[tauri::command]
-pub async fn save_text_file(
-    app: AppHandle,
+pub async fn save_text_file<R: Runtime>(
+    app: AppHandle<R>,
     filename: String,
     content: String,
 ) -> Result<Option<String>, String> {
@@ -27,7 +28,7 @@ pub async fn save_text_file(
 
 /// Select one or more existing kubeconfig files and return filesystem paths.
 #[tauri::command]
-pub async fn pick_kubeconfig_files(app: AppHandle) -> Result<Vec<String>, String> {
+pub async fn pick_kubeconfig_files<R: Runtime>(app: AppHandle<R>) -> Result<Vec<String>, String> {
     let picked = app.dialog().file().blocking_pick_files().unwrap_or_default();
     picked
         .into_iter()
@@ -41,22 +42,33 @@ pub async fn pick_kubeconfig_files(app: AppHandle) -> Result<Vec<String>, String
 
 /// Validate pasted kubeconfig YAML and persist it under the app config folder.
 #[tauri::command]
-pub async fn save_pasted_kubeconfig(
-    app: AppHandle,
+pub async fn save_pasted_kubeconfig<R: Runtime>(
+    app: AppHandle<R>,
     content: String,
     name: Option<String>,
 ) -> Result<String, String> {
-    if content.len() > 1024 * 1024 {
-        return Err("kubeconfig must be smaller than 1 MB".to_string());
-    }
-    srelens_kube::connect::validate_kubeconfig_yaml(&content)?;
-
     let directory = app
         .path()
         .app_config_dir()
         .map_err(|error| error.to_string())?
         .join("kubeconfigs");
-    fs::create_dir_all(&directory).map_err(|error| error.to_string())?;
+    save_pasted_kubeconfig_to(&directory, &content, name)
+}
+
+/// Everything but the config-dir lookup (#28 seam): size gate, YAML
+/// validation, name sanitizing, and the timestamped write — unit-tested
+/// against a temp directory.
+fn save_pasted_kubeconfig_to(
+    directory: &Path,
+    content: &str,
+    name: Option<String>,
+) -> Result<String, String> {
+    if content.len() > 1024 * 1024 {
+        return Err("kubeconfig must be smaller than 1 MB".to_string());
+    }
+    srelens_kube::connect::validate_kubeconfig_yaml(content)?;
+
+    fs::create_dir_all(directory).map_err(|error| error.to_string())?;
     let stem = name
         .unwrap_or_else(|| "pasted".to_string())
         .chars()
@@ -74,4 +86,76 @@ pub async fn save_pasted_kubeconfig(
     let path = directory.join(file_name);
     fs::write(&path, content).map_err(|error| error.to_string())?;
     Ok(path.to_string_lossy().into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_dir(label: &str) -> std::path::PathBuf {
+        static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        std::env::temp_dir().join(format!(
+            "srelens-files-{label}-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        ))
+    }
+
+    const VALID_KUBECONFIG: &str = "\
+apiVersion: v1
+kind: Config
+clusters:
+- name: c
+  cluster: { server: 'https://127.0.0.1:1' }
+contexts:
+- name: ctx
+  context: { cluster: c, user: u }
+users:
+- name: u
+  user: {}
+current-context: ctx
+";
+
+    #[test]
+    fn writes_a_sanitized_timestamped_yaml_and_creates_the_directory() {
+        let dir = temp_dir("save");
+        let path = save_pasted_kubeconfig_to(
+            &dir,
+            VALID_KUBECONFIG,
+            Some("My Cluster (prod)!".into()),
+        )
+        .unwrap();
+        let file = std::path::Path::new(&path).file_name().unwrap().to_string_lossy().into_owned();
+        // Every non [-a-zA-Z0-9] character became '-', edges trimmed.
+        assert!(file.starts_with("My-Cluster--prod"), "unexpected name: {file}");
+        assert!(file.ends_with(".yaml"), "unexpected name: {file}");
+        assert_eq!(fs::read_to_string(&path).unwrap(), VALID_KUBECONFIG);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_nameless_or_fully_scrubbed_name_falls_back_to_pasted() {
+        let dir = temp_dir("fallback");
+        let unnamed = save_pasted_kubeconfig_to(&dir, VALID_KUBECONFIG, None).unwrap();
+        let scrubbed =
+            save_pasted_kubeconfig_to(&dir, VALID_KUBECONFIG, Some("!!!".into())).unwrap();
+        for path in [unnamed, scrubbed] {
+            let file =
+                std::path::Path::new(&path).file_name().unwrap().to_string_lossy().into_owned();
+            assert!(file.starts_with("pasted-"), "unexpected name: {file}");
+        }
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn oversized_and_invalid_content_are_refused_without_writing() {
+        let dir = temp_dir("refused");
+        let big = "x".repeat(1024 * 1024 + 1);
+        let e = save_pasted_kubeconfig_to(&dir, &big, None).unwrap_err();
+        assert!(e.contains("smaller than 1 MB"), "unexpected error: {e}");
+        let e = save_pasted_kubeconfig_to(&dir, "not: [valid kubeconfig", None).unwrap_err();
+        assert!(!e.is_empty());
+        // Both refusals fired before the directory was ever created.
+        assert!(!dir.exists());
+    }
 }

--- a/apps/desktop/src-tauri/src/forward.rs
+++ b/apps/desktop/src-tauri/src/forward.rs
@@ -1,10 +1,14 @@
 //! Tauri adapter for port-forwards: the core lives in
 //! srelens_streams::forward; this module only maps the Tauri command surface.
+//!
+//! Commands are generic over the runtime (#28): the unit suite below drives
+//! them through `tauri::test::MockRuntime`, so this surface counts toward
+//! coverage instead of hiding behind the ignore-regex.
 
 use std::sync::Arc;
 
 use srelens_streams::forward::{ForwardInfo, ForwardManager};
-use tauri::{AppHandle, State};
+use tauri::{AppHandle, Runtime, State};
 
 use crate::sink::TauriSink;
 
@@ -13,14 +17,14 @@ use crate::sink::TauriSink;
 /// Returns the id + bound local port; a `forward:closed:<id>` event fires
 /// (with an optional error string) if the forward loop ends on its own.
 #[tauri::command]
-pub async fn start_port_forward(
+pub async fn start_port_forward<R: Runtime>(
     context: String,
     namespace: String,
     kind: String,
     name: String,
     remote_port: u16,
     local_port: Option<u16>,
-    app: AppHandle,
+    app: AppHandle<R>,
     manager: State<'_, ForwardManager>,
 ) -> Result<ForwardInfo, String> {
     manager
@@ -41,4 +45,37 @@ pub async fn start_port_forward(
 pub async fn stop_port_forward(id: u64, manager: State<'_, ForwardManager>) -> Result<(), String> {
     manager.stop(id);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use srelens_kube::client_cache::ClientCache;
+    use tauri::Manager;
+
+    /// start binds the local listener synchronously — an ephemeral port comes
+    /// back even though the forward loop itself will die on the unresolvable
+    /// context — and stop tears the forward down (twice: unknown id no-ops).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn commands_run_against_a_mock_runtime() {
+        let app = tauri::test::mock_app();
+        app.manage(ForwardManager::new(ClientCache::new_many(vec![])));
+
+        let info = start_port_forward(
+            "no-such-context".into(),
+            "ns".into(),
+            "Pod".into(),
+            "pod-0".into(),
+            8080,
+            None,
+            app.handle().clone(),
+            app.state(),
+        )
+        .await
+        .unwrap();
+        assert_ne!(info.local_port, 0, "an ephemeral port must have been bound");
+
+        stop_port_forward(info.id, app.state()).await.unwrap();
+        stop_port_forward(info.id + 1, app.state()).await.unwrap();
+    }
 }

--- a/apps/desktop/src-tauri/src/logs.rs
+++ b/apps/desktop/src-tauri/src/logs.rs
@@ -1,10 +1,14 @@
 //! Tauri adapter for live log tails: the streaming core lives in
 //! srelens_streams::logs; this module only maps the Tauri command surface.
+//!
+//! Commands are generic over the runtime (#28): the unit suite below drives
+//! them through `tauri::test::MockRuntime`, so this surface counts toward
+//! coverage instead of hiding behind the ignore-regex.
 
 use std::sync::Arc;
 
 use srelens_streams::logs::{LogStreamManager, LogTarget};
-use tauri::{AppHandle, State};
+use tauri::{AppHandle, Runtime, State};
 
 use crate::sink::TauriSink;
 
@@ -13,7 +17,7 @@ use crate::sink::TauriSink;
 /// invokes this, so the initial tail lines can't race ahead of the listener.
 #[tauri::command]
 #[allow(clippy::too_many_arguments)]
-pub async fn start_log_stream(
+pub async fn start_log_stream<R: Runtime>(
     context: String,
     namespace: String,
     targets: Vec<LogTarget>,
@@ -21,7 +25,7 @@ pub async fn start_log_stream(
     timestamps: Option<bool>,
     since_seconds: Option<i64>,
     tail_lines: Option<i64>,
-    app: AppHandle,
+    app: AppHandle<R>,
     manager: State<'_, LogStreamManager>,
 ) -> Result<(), String> {
     manager
@@ -46,4 +50,56 @@ pub async fn stop_log_stream(
 ) -> Result<(), String> {
     manager.stop(&channel);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use srelens_kube::client_cache::ClientCache;
+    use tauri::Manager;
+
+    /// The empty-target refusal comes back synchronously; a real target is
+    /// accepted (its follow task dies later on the unresolvable context) and
+    /// stop tears the stream down — plus the unknown-channel no-op.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn commands_run_against_a_mock_runtime() {
+        let app = tauri::test::mock_app();
+        app.manage(LogStreamManager::new(ClientCache::new_many(vec![])));
+
+        let e = start_log_stream(
+            "no-such-context".into(),
+            "ns".into(),
+            vec![],
+            "logs:test".into(),
+            None,
+            None,
+            None,
+            app.handle().clone(),
+            app.state(),
+        )
+        .await
+        .unwrap_err();
+        assert!(e.contains("without a pod target"), "unexpected error: {e}");
+
+        start_log_stream(
+            "no-such-context".into(),
+            "ns".into(),
+            vec![LogTarget {
+                pod: "pod-0".into(),
+                container: None,
+                label: String::new(),
+            }],
+            "logs:test".into(),
+            Some(true),
+            Some(60),
+            Some(100),
+            app.handle().clone(),
+            app.state(),
+        )
+        .await
+        .unwrap();
+
+        stop_log_stream("logs:test".into(), app.state()).await.unwrap();
+        stop_log_stream("logs:unknown".into(), app.state()).await.unwrap();
+    }
 }

--- a/apps/desktop/src-tauri/src/sink.rs
+++ b/apps/desktop/src-tauri/src/sink.rs
@@ -1,12 +1,16 @@
 //! Tauri implementation of the shared EventSink: events go to the WebView
 //! over the exact same channels the frontend already subscribes to.
+//!
+//! Generic over the runtime so the unit suites can construct it against
+//! `tauri::test::MockRuntime`; the app itself always instantiates it with
+//! the default (Wry) runtime.
 
 use srelens_streams::EventSink;
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Emitter, Runtime};
 
-pub struct TauriSink(pub AppHandle);
+pub struct TauriSink<R: Runtime>(pub AppHandle<R>);
 
-impl EventSink for TauriSink {
+impl<R: Runtime> EventSink for TauriSink<R> {
     fn emit(&self, channel: &str, payload: serde_json::Value) {
         let _ = self.0.emit(channel, payload);
     }

--- a/apps/desktop/src-tauri/src/watch.rs
+++ b/apps/desktop/src-tauri/src/watch.rs
@@ -1,10 +1,14 @@
 //! Tauri adapter for live watches: the streaming core lives in
 //! srelens_streams::watch; this module only maps the Tauri command surface.
+//!
+//! Commands are generic over the runtime (#28): the unit suite below drives
+//! them through `tauri::test::MockRuntime`, so this surface counts toward
+//! coverage instead of hiding behind the ignore-regex.
 
 use std::sync::Arc;
 
 use srelens_streams::watch::WatchManager;
-use tauri::{AppHandle, State};
+use tauri::{AppHandle, Runtime, State};
 
 use crate::sink::TauriSink;
 
@@ -13,13 +17,13 @@ use crate::sink::TauriSink;
 /// `channel` first, then invokes this, so the initial snapshot can't race
 /// ahead of the listener.
 #[tauri::command]
-pub async fn start_resource_watch(
+pub async fn start_resource_watch<R: Runtime>(
     context: String,
     namespace: String,
     kind: String,
     channel: String,
     kubeconfig_paths: Vec<String>,
-    app: AppHandle,
+    app: AppHandle<R>,
     manager: State<'_, WatchManager>,
 ) -> Result<String, String> {
     manager
@@ -42,4 +46,37 @@ pub async fn start_resource_watch(
 pub async fn stop_watch(channel: String, manager: State<'_, WatchManager>) -> Result<(), String> {
     manager.stop(&channel);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use srelens_kube::client_cache::ClientCache;
+    use tauri::Manager;
+
+    /// start registers the extra kubeconfig path, spawns the watch task, and
+    /// echoes the channel back (the unresolvable context fails INSIDE the
+    /// task, surfacing as an error payload on the channel — never here);
+    /// stop aborts it, and an unknown channel no-ops.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn commands_run_against_a_mock_runtime() {
+        let app = tauri::test::mock_app();
+        app.manage(WatchManager::new(ClientCache::new_many(vec![])));
+
+        let channel = start_resource_watch(
+            "no-such-context".into(),
+            "ns".into(),
+            "pods".into(),
+            "watch:test".into(),
+            vec!["/nonexistent/kubeconfig".into()],
+            app.handle().clone(),
+            app.state(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(channel, "watch:test");
+
+        stop_watch(channel, app.state()).await.unwrap();
+        stop_watch("watch:unknown".into(), app.state()).await.unwrap();
+    }
 }


### PR DESCRIPTION
Closes #28 — its last open clause: the stream-shim files are out of the coverage ignore-regex.

## What
- `bridge`, `exec`, `forward`, `logs`, `watch` commands are generic over `tauri::Runtime`, and new unit suites drive them through `tauri::test`'s `MockRuntime` app — the real command fns, managed-state lookup, `TauriSink`, and argument mapping all execute under coverage.
- `files.rs` gets the same seam treatment as vault_password: the pasted-kubeconfig transaction (size gate, YAML validation, name sanitizing, timestamped write) is extracted into `save_pasted_kubeconfig_to` and tested against a temp dir. The two native-dialog commands stay uncovered — they block on a real picker.
- The ignore-regex trims to `(lib|main)\.rs` + the server bin: only process entries that execute solely inside a running app/server remain excluded.

## Measurement (clean, with the kind suites)
- 86.24% lines under the trimmed regex; the 85 floor holds unchanged.
- Former shims now measure: bridge 97%, exec 95%, forward 96%, logs 97%, watch 96%, sink 100%; files 59% (dialog commands).