### PR TITLE
fix(ui): sort Age columns by parsed duration, not the display string

### DIFF
--- a/apps/desktop/src/components/CustomResourceBrowser.tsx
+++ b/apps/desktop/src/components/CustomResourceBrowser.tsx
@@ -4,6 +4,7 @@ import { listCustomResource, type CrdRef, type CustomRow } from "../lib/crds";
 import { listNamespaces } from "../lib/workloads";
 import { YamlView } from "./YamlView";
 import { Table, filterTableData, Select, Button, ColumnPicker, useColumnVisibility, Spinner, Drawer, TextInput, type Column } from "../ui";
+import { ageSortValue } from "../lib/age";
 
 interface Selected {
   name: string;
@@ -67,7 +68,7 @@ export function CustomResourceBrowser({
           },
         ]
       : []),
-    { key: "age", header: "Age", render: (r) => <span className="text-muted-foreground">{r.age}</span> },
+    { key: "age", header: "Age", getSortValue: ageSortValue, render: (r) => <span className="text-muted-foreground">{r.age}</span> },
   ];
 
   // Show/hide columns, persisted per CRD.

--- a/apps/desktop/src/components/ResourceBrowser.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.tsx
@@ -62,6 +62,7 @@ import { AssistantDrawer, type AssistantContext } from "./AssistantDrawer";
 import { isTauri } from "../transport/platform";
 import type { OpenResource } from "../lib/resourceNavigation";
 import { describeError } from "../lib/errors";
+import { ageSortValue } from "../lib/age";
 import {
   Table,
   filterTableData,
@@ -292,7 +293,7 @@ const podColumns: Column<PodRow>[] = [
   { key: "phase", header: "Phase", render: (p) => <StatusPill status={p.phase} kind={phaseKind(p.phase)} /> },
   { key: "restarts", header: "Restarts" },
   { key: "node", header: "Node", render: (p) => <Muted>{p.node}</Muted> },
-  { key: "age", header: "Age", render: (p) => <Muted>{p.age}</Muted> },
+  { key: "age", header: "Age", getSortValue: ageSortValue, render: (p) => <Muted>{p.age}</Muted> },
 ];
 
 const deploymentColumns: Column<DeploymentSummary>[] = [
@@ -301,7 +302,7 @@ const deploymentColumns: Column<DeploymentSummary>[] = [
   { key: "ready", header: "Ready" },
   { key: "upToDate", header: "Up-to-date" },
   { key: "available", header: "Available" },
-  { key: "age", header: "Age", render: (d) => <Muted>{d.age}</Muted> },
+  { key: "age", header: "Age", getSortValue: ageSortValue, render: (d) => <Muted>{d.age}</Muted> },
 ];
 
 const statefulSetColumns: Column<StatefulSetSummary>[] = [
@@ -310,7 +311,7 @@ const statefulSetColumns: Column<StatefulSetSummary>[] = [
   { key: "ready", header: "Ready" },
   { key: "updated", header: "Updated" },
   { key: "service", header: "Service", render: (s) => <Muted>{s.service || "—"}</Muted> },
-  { key: "age", header: "Age", render: (s) => <Muted>{s.age}</Muted> },
+  { key: "age", header: "Age", getSortValue: ageSortValue, render: (s) => <Muted>{s.age}</Muted> },
 ];
 
 const daemonSetColumns: Column<DaemonSetSummary>[] = [
@@ -321,7 +322,7 @@ const daemonSetColumns: Column<DaemonSetSummary>[] = [
   { key: "ready", header: "Ready" },
   { key: "upToDate", header: "Up-to-date" },
   { key: "available", header: "Available" },
-  { key: "age", header: "Age", render: (d) => <Muted>{d.age}</Muted> },
+  { key: "age", header: "Age", getSortValue: ageSortValue, render: (d) => <Muted>{d.age}</Muted> },
 ];
 
 const jobColumns: Column<JobSummary>[] = [
@@ -339,7 +340,7 @@ const jobColumns: Column<JobSummary>[] = [
   },
   { key: "duration", header: "Duration", render: (j) => <Muted>{j.duration || "—"}</Muted> },
   { key: "owner", header: "Owner", render: (j) => <Muted>{j.owner || "—"}</Muted> },
-  { key: "age", header: "Age", render: (j) => <Muted>{j.age}</Muted> },
+  { key: "age", header: "Age", getSortValue: ageSortValue, render: (j) => <Muted>{j.age}</Muted> },
 ];
 
 const cronJobColumns: Column<CronJobSummary>[] = [
@@ -354,14 +355,14 @@ const cronJobColumns: Column<CronJobSummary>[] = [
   },
   { key: "active", header: "Active" },
   { key: "lastSchedule", header: "Last run", render: (c) => <Muted>{c.lastSchedule || "—"}</Muted> },
-  { key: "age", header: "Age", render: (c) => <Muted>{c.age}</Muted> },
+  { key: "age", header: "Age", getSortValue: ageSortValue, render: (c) => <Muted>{c.age}</Muted> },
 ];
 
 const configMapColumns: Column<ConfigMapSummary>[] = [
   { key: "name", header: "ConfigMap", render: (c) => <strong>{c.name}</strong> },
   { key: "namespace", header: "Namespace", render: (c) => <span className="fl-link">{c.namespace}</span> },
   { key: "keys", header: "Keys" },
-  { key: "age", header: "Age", render: (c) => <Muted>{c.age}</Muted> },
+  { key: "age", header: "Age", getSortValue: ageSortValue, render: (c) => <Muted>{c.age}</Muted> },
 ];
 
 const secretColumns: Column<SecretSummary>[] = [
@@ -369,21 +370,21 @@ const secretColumns: Column<SecretSummary>[] = [
   { key: "namespace", header: "Namespace", render: (s) => <span className="fl-link">{s.namespace}</span> },
   { key: "type", header: "Type", render: (s) => <Muted>{s.type}</Muted> },
   { key: "keys", header: "Keys" },
-  { key: "age", header: "Age", render: (s) => <Muted>{s.age}</Muted> },
+  { key: "age", header: "Age", getSortValue: ageSortValue, render: (s) => <Muted>{s.age}</Muted> },
 ];
 
 const resourceQuotaColumns: Column<ResourceQuotaSummary>[] = [
   { key: "name", header: "Resource Quota", render: (q) => <strong>{q.name}</strong> },
   { key: "namespace", header: "Namespace", render: (q) => <span className="fl-link">{q.namespace}</span> },
   { key: "resources", header: "Resources" },
-  { key: "age", header: "Age", render: (q) => <Muted>{q.age}</Muted> },
+  { key: "age", header: "Age", getSortValue: ageSortValue, render: (q) => <Muted>{q.age}</Muted> },
 ];
 
 const limitRangeColumns: Column<LimitRangeSummary>[] = [
   { key: "name", header: "Limit Range", render: (l) => <strong>{l.name}</strong> },
   { key: "namespace", header: "Namespace", render: (l) => <span className="fl-link">{l.namespace}</span> },
   { key: "limits", header: "Limits" },
-  { key: "age", header: "Age", render: (l) => <Muted>{l.age}</Muted> },
+  { key: "age", header: "Age", getSortValue: ageSortValue, render: (l) => <Muted>{l.age}</Muted> },
 ];
 
 const serviceColumns: Column<ServiceSummary>[] = [
@@ -392,7 +393,7 @@ const serviceColumns: Column<ServiceSummary>[] = [
   { key: "type", header: "Type" },
   { key: "clusterIP", header: "Cluster IP", render: (s) => <Muted>{s.clusterIP}</Muted> },
   { key: "ports", header: "Ports" },
-  { key: "age", header: "Age", render: (s) => <Muted>{s.age}</Muted> },
+  { key: "age", header: "Age", getSortValue: ageSortValue, render: (s) => <Muted>{s.age}</Muted> },
 ];
 
 const ingressColumns: Column<IngressSummary>[] = [
@@ -402,7 +403,7 @@ const ingressColumns: Column<IngressSummary>[] = [
   { key: "hosts", header: "Hosts", render: (i) => <Muted>{i.hosts || "*"}</Muted> },
   { key: "address", header: "Address", render: (i) => <Muted>{i.address || "—"}</Muted> },
   { key: "ports", header: "Ports", render: (i) => <Muted>{i.ports}</Muted> },
-  { key: "age", header: "Age", render: (i) => <Muted>{i.age}</Muted> },
+  { key: "age", header: "Age", getSortValue: ageSortValue, render: (i) => <Muted>{i.age}</Muted> },
 ];
 
 const endpointSliceColumns: Column<EndpointSliceSummary>[] = [
@@ -412,7 +413,7 @@ const endpointSliceColumns: Column<EndpointSliceSummary>[] = [
   { key: "endpoints", header: "Endpoints", render: (e) => <Muted>{e.endpoints}</Muted> },
   { key: "ports", header: "Ports", render: (e) => <Muted>{e.ports || "—"}</Muted> },
   { key: "service", header: "Service", render: (e) => <span className="fl-link">{e.service || "—"}</span> },
-  { key: "age", header: "Age", render: (e) => <Muted>{e.age}</Muted> },
+  { key: "age", header: "Age", getSortValue: ageSortValue, render: (e) => <Muted>{e.age}</Muted> },
 ];
 
 const networkPolicyColumns: Column<NetworkPolicySummary>[] = [
@@ -422,7 +423,7 @@ const networkPolicyColumns: Column<NetworkPolicySummary>[] = [
   { key: "ingress", header: "Ingress" },
   { key: "egress", header: "Egress" },
   { key: "policyTypes", header: "Policy Types", render: (n) => <Muted>{n.policyTypes || "—"}</Muted> },
-  { key: "age", header: "Age", render: (n) => <Muted>{n.age}</Muted> },
+  { key: "age", header: "Age", getSortValue: ageSortValue, render: (n) => <Muted>{n.age}</Muted> },
 ];
 
 const pvcColumns: Column<PvcSummary>[] = [
@@ -433,7 +434,7 @@ const pvcColumns: Column<PvcSummary>[] = [
   { key: "accessModes", header: "Access Modes", render: (p) => <Muted>{p.accessModes || "—"}</Muted> },
   { key: "storageClass", header: "Storage Class", render: (p) => <span className="fl-link">{p.storageClass || "—"}</span> },
   { key: "volume", header: "Volume", render: (p) => <span className="fl-link">{p.volume || "—"}</span> },
-  { key: "age", header: "Age", render: (p) => <Muted>{p.age}</Muted> },
+  { key: "age", header: "Age", getSortValue: ageSortValue, render: (p) => <Muted>{p.age}</Muted> },
 ];
 
 const pvColumns: Column<PvSummary>[] = [
@@ -444,7 +445,7 @@ const pvColumns: Column<PvSummary>[] = [
   { key: "status", header: "Status", render: (p) => <StatusPill status={p.status} kind={phaseKind(p.status === "Bound" || p.status === "Available" ? "Ready" : p.status)} /> },
   { key: "claim", header: "Claim", render: (p) => <span className="fl-link">{p.claim || "—"}</span> },
   { key: "storageClass", header: "Storage Class", render: (p) => <span className="fl-link">{p.storageClass || "—"}</span> },
-  { key: "age", header: "Age", render: (p) => <Muted>{p.age}</Muted> },
+  { key: "age", header: "Age", getSortValue: ageSortValue, render: (p) => <Muted>{p.age}</Muted> },
 ];
 
 const storageClassColumns: Column<StorageClassSummary>[] = [
@@ -453,27 +454,27 @@ const storageClassColumns: Column<StorageClassSummary>[] = [
   { key: "reclaimPolicy", header: "Reclaim", render: (s) => <Muted>{s.reclaimPolicy || "—"}</Muted> },
   { key: "volumeBindingMode", header: "Binding Mode", render: (s) => <Muted>{s.volumeBindingMode || "—"}</Muted> },
   { key: "default", header: "Default", render: (s) => (s.default ? <StatusPill status="Default" kind="success" /> : <Muted>—</Muted>) },
-  { key: "age", header: "Age", render: (s) => <Muted>{s.age}</Muted> },
+  { key: "age", header: "Age", getSortValue: ageSortValue, render: (s) => <Muted>{s.age}</Muted> },
 ];
 
 const serviceAccountColumns: Column<ServiceAccountSummary>[] = [
   { key: "name", header: "Service Account", render: (s) => <strong>{s.name}</strong> },
   { key: "namespace", header: "Namespace", render: (s) => <span className="fl-link">{s.namespace}</span> },
   { key: "secrets", header: "Secrets" },
-  { key: "age", header: "Age", render: (s) => <Muted>{s.age}</Muted> },
+  { key: "age", header: "Age", getSortValue: ageSortValue, render: (s) => <Muted>{s.age}</Muted> },
 ];
 
 const roleColumns: Column<RoleSummary>[] = [
   { key: "name", header: "Role", render: (r) => <strong>{r.name}</strong> },
   { key: "namespace", header: "Namespace", render: (r) => <span className="fl-link">{r.namespace}</span> },
   { key: "rules", header: "Rules" },
-  { key: "age", header: "Age", render: (r) => <Muted>{r.age}</Muted> },
+  { key: "age", header: "Age", getSortValue: ageSortValue, render: (r) => <Muted>{r.age}</Muted> },
 ];
 
 const clusterRoleColumns: Column<ClusterRoleSummary>[] = [
   { key: "name", header: "Cluster Role", render: (r) => <strong>{r.name}</strong> },
   { key: "rules", header: "Rules" },
-  { key: "age", header: "Age", render: (r) => <Muted>{r.age}</Muted> },
+  { key: "age", header: "Age", getSortValue: ageSortValue, render: (r) => <Muted>{r.age}</Muted> },
 ];
 
 const roleBindingColumns: Column<RoleBindingSummary>[] = [
@@ -481,14 +482,14 @@ const roleBindingColumns: Column<RoleBindingSummary>[] = [
   { key: "namespace", header: "Namespace", render: (b) => <span className="fl-link">{b.namespace}</span> },
   { key: "role", header: "Role", render: (b) => <span className="fl-link">{b.role}</span> },
   { key: "subjects", header: "Subjects" },
-  { key: "age", header: "Age", render: (b) => <Muted>{b.age}</Muted> },
+  { key: "age", header: "Age", getSortValue: ageSortValue, render: (b) => <Muted>{b.age}</Muted> },
 ];
 
 const clusterRoleBindingColumns: Column<ClusterRoleBindingSummary>[] = [
   { key: "name", header: "Cluster Role Binding", render: (b) => <strong>{b.name}</strong> },
   { key: "role", header: "Role", render: (b) => <span className="fl-link">{b.role}</span> },
   { key: "subjects", header: "Subjects" },
-  { key: "age", header: "Age", render: (b) => <Muted>{b.age}</Muted> },
+  { key: "age", header: "Age", getSortValue: ageSortValue, render: (b) => <Muted>{b.age}</Muted> },
 ];
 
 const nodeColumns: Column<NodeRow>[] = [
@@ -510,13 +511,13 @@ const nodeColumns: Column<NodeRow>[] = [
   { key: "cpu", header: "CPU", render: (n) => <Muted>{n.cpu != null ? `${n.cpu}m` : "—"}</Muted> },
   { key: "memory", header: "Memory", render: (n) => <Muted>{n.memory != null ? `${n.memory}Mi` : "—"}</Muted> },
   { key: "version", header: "Version", render: (n) => <Muted>{n.version}</Muted> },
-  { key: "age", header: "Age", render: (n) => <Muted>{n.age}</Muted> },
+  { key: "age", header: "Age", getSortValue: ageSortValue, render: (n) => <Muted>{n.age}</Muted> },
 ];
 
 const genericColumns: Column<ResourceRow>[] = [
   { key: "name", header: "Name", render: (r) => <strong>{r.name}</strong> },
   { key: "namespace", header: "Namespace", render: (r) => <span className="fl-link">{r.namespace}</span> },
-  { key: "age", header: "Age", render: (r) => <Muted>{r.age}</Muted> },
+  { key: "age", header: "Age", getSortValue: ageSortValue, render: (r) => <Muted>{r.age}</Muted> },
 ];
 
 const eventColumns: Column<EventSummary & { name: string }>[] = [
@@ -528,7 +529,7 @@ const eventColumns: Column<EventSummary & { name: string }>[] = [
   { key: "reason", header: "Reason", render: (e) => <strong>{e.reason}</strong> },
   { key: "object", header: "Object", render: (e) => <span className="fl-link">{e.object}</span> },
   { key: "message", header: "Message" },
-  { key: "age", header: "Age", render: (e) => <Muted>{e.age}</Muted> },
+  { key: "age", header: "Age", getSortValue: ageSortValue, render: (e) => <Muted>{e.age}</Muted> },
 ];
 
 interface ResourceState {

--- a/apps/desktop/src/components/ResourceEvents.tsx
+++ b/apps/desktop/src/components/ResourceEvents.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { listEvents, type EventSummary } from "../lib/manifest";
 import { Spinner, StatusPill, Table, type Column } from "../ui";
+import { ageSortValue } from "../lib/age";
 
 /**
  * Events involving a single object, shown in its detail drawer. Fetches the
@@ -60,7 +61,7 @@ export function ResourceEvents({
     },
     { key: "reason", header: "Reason", render: (e) => e.reason },
     { key: "message", header: "Message", render: (e) => e.message },
-    { key: "age", header: "Age", render: (e) => e.age },
+    { key: "age", header: "Age", getSortValue: ageSortValue, render: (e) => e.age },
   ];
 
   return (

--- a/apps/desktop/src/components/ResourceOverview.tsx
+++ b/apps/desktop/src/components/ResourceOverview.tsx
@@ -357,6 +357,9 @@ function ConditionsTable({ conditions, now }: { conditions: Condition[]; now: nu
     {
       key: "age",
       header: "Last transition",
+      // Negated timestamp so ascending = most recent first (smallest age),
+      // matching the age columns; unset timestamps (NaN → 0 here) group last.
+      getSortValue: (c) => -(Date.parse(c.lastTransitionTime ?? "") || 0),
       render: (c) => ageFromTimestamp(c.lastTransitionTime, now),
     },
   ];

--- a/apps/desktop/src/components/WorkloadRelations.tsx
+++ b/apps/desktop/src/components/WorkloadRelations.tsx
@@ -9,6 +9,7 @@ import {
 import { listJobs, type JobSummary } from "../lib/controllers";
 import { Spinner, StatusPill, Table, type StatusKind, type Column } from "../ui";
 import type { OpenResource } from "../lib/resourceNavigation";
+import { ageSortValue } from "../lib/age";
 
 function phaseKind(phase: string): StatusKind {
   if (phase === "Running" || phase === "Succeeded") return "success";
@@ -73,7 +74,7 @@ export function DeployRevisions({
     },
     { key: "name", header: "Name", render: (r) => <span className="fl-mono">{r.name}</span> },
     { key: "pods", header: "Pods", render: (r) => `${r.ready}/${r.desired}` },
-    { key: "age", header: "Age", render: (r) => r.age },
+    { key: "age", header: "Age", getSortValue: ageSortValue, render: (r) => r.age },
   ];
 
   return (
@@ -145,7 +146,7 @@ export function CronJobJobs({
       },
     },
     { key: "duration", header: "Duration", render: (j) => j.duration || "—" },
-    { key: "age", header: "Age", render: (j) => j.age },
+    { key: "age", header: "Age", getSortValue: ageSortValue, render: (j) => j.age },
   ];
 
   return (

--- a/apps/desktop/src/lib/age.test.ts
+++ b/apps/desktop/src/lib/age.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { ageSeconds, ageSortValue } from "./age";
+
+describe("ageSeconds", () => {
+  it("converts every backend unit to seconds", () => {
+    expect(ageSeconds("45s")).toBe(45);
+    expect(ageSeconds("3m")).toBe(180);
+    expect(ageSeconds("2h")).toBe(7_200);
+    expect(ageSeconds("300d")).toBe(300 * 86_400);
+    expect(ageSeconds("1y")).toBe(365 * 86_400);
+  });
+
+  it("orders across units — the #236 report: 1y must outrank 300d", () => {
+    expect(ageSeconds("1y")).toBeGreaterThan(ageSeconds("300d"));
+    expect(ageSeconds("2d")).toBeGreaterThan(ageSeconds("47h"));
+    expect(ageSeconds("10m")).toBeGreaterThan(ageSeconds("599s"));
+  });
+
+  it("reads a row's age through the shared column helper", () => {
+    expect(ageSortValue({ age: "1y" })).toBe(365 * 86_400);
+    expect(ageSortValue({})).toBe(-1);
+  });
+
+  it("groups unset and unrecognized ages below every real age", () => {
+    expect(ageSeconds("-")).toBe(-1);
+    expect(ageSeconds("")).toBe(-1);
+    expect(ageSeconds("5x")).toBe(-1);
+    expect(ageSeconds("y5")).toBe(-1);
+    expect(ageSeconds("-")).toBeLessThan(ageSeconds("0s"));
+  });
+});

--- a/apps/desktop/src/lib/age.ts
+++ b/apps/desktop/src/lib/age.ts
@@ -1,0 +1,32 @@
+// Sort keys for srelens compact age strings (#236). The backend renders ages
+// as a single value+unit pair ("45s", "3m", "2h", "300d", "1y" — see
+// `format_age` in crates/kube), which the table's numeric collation orders
+// wrong across units: "1y" sorted before "300d" because 1 < 300. Parsing the
+// string back to seconds gives the comparator a real duration.
+
+const UNIT_SECONDS: Record<string, number> = {
+  s: 1,
+  m: 60,
+  h: 3_600,
+  d: 86_400,
+  y: 86_400 * 365,
+};
+
+/**
+ * The duration (seconds) a compact age string denotes, for sorting. Unset
+ * ("-") or unrecognized ages return -1 so they group together below every
+ * real age instead of interleaving arbitrarily.
+ */
+export function ageSeconds(age: string): number {
+  const match = /^(\d+)([smhdy])$/.exec(age.trim());
+  if (!match) return -1;
+  return Number(match[1]) * UNIT_SECONDS[match[2]];
+}
+
+/**
+ * Drop-in `getSortValue` for any summary row carrying a compact `age` —
+ * one shared function rather than an arrow per column definition.
+ */
+export function ageSortValue(row: { age?: string }): number {
+  return ageSeconds(row.age ?? "");
+}

--- a/apps/desktop/src/ui/Table.test.tsx
+++ b/apps/desktop/src/ui/Table.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import React from "react";
 import { Table, filterTableData, computeVisibleRange, type Column } from "./Table";
+import { ageSeconds } from "../lib/age";
 
 afterEach(() => vi.restoreAllMocks());
 
@@ -125,6 +126,32 @@ describe("Table", () => {
     expect(screen.getAllByRole("row")[1].textContent).toContain("web-2");
     fireEvent.click(sort);
     expect(screen.getAllByRole("row")[1].textContent).toContain("web-2");
+  });
+
+  it("sorts by getSortValue while filtering stays on the visible text (#236)", () => {
+    const rows = [
+      { name: "old", age: "1y" },
+      { name: "older", age: "2y" },
+      { name: "recent", age: "300d" },
+    ];
+    const ageColumns = [
+      { key: "name", header: "Name" },
+      {
+        key: "age",
+        header: "Age",
+        getSortValue: (r: (typeof rows)[number]) => ageSeconds(r.age),
+      },
+    ];
+    render(<Table columns={ageColumns} data={rows} getRowKey={(r) => r.name} />);
+
+    // Ascending: 300d < 1y < 2y — numeric collation on the strings would
+    // have put both years first (1 < 2 < 300).
+    fireEvent.click(screen.getByRole("button", { name: "Sort by Age" }));
+    const names = screen.getAllByRole("row").slice(1).map((r) => r.textContent);
+    expect(names).toEqual(["recent300d", "old1y", "older2y"]);
+
+    // The filter still matches the display text, not the sort key.
+    expect(filterTableData(rows, ageColumns, "1y", null)).toEqual([{ name: "old", age: "1y" }]);
   });
 
   it("selects a column for the toolbar search", () => {

--- a/apps/desktop/src/ui/Table.tsx
+++ b/apps/desktop/src/ui/Table.tsx
@@ -18,6 +18,11 @@ export interface Column<T> {
   render?: (row: T) => React.ReactNode;
   /** Value used for sorting and filtering when it differs from `row[key]`. */
   getValue?: (row: T) => unknown;
+  /** Sort-only value, overriding `getValue`/`row[key]` for the comparator —
+   *  for columns whose display text doesn't order correctly (e.g. compact
+   *  ages, where "1y" must outrank "300d") while filtering stays on the
+   *  visible text. */
+  getSortValue?: (row: T) => unknown;
   sortable?: boolean;
   filterable?: boolean;
   minWidth?: number;
@@ -127,8 +132,8 @@ export function Table<T>({
     return data
       .map((row, index) => ({ row, index }))
       .sort((a, b) => {
-        const left = getColumnValue(a.row, column);
-        const right = getColumnValue(b.row, column);
+        const left = column.getSortValue ? column.getSortValue(a.row) : getColumnValue(a.row, column);
+        const right = column.getSortValue ? column.getSortValue(b.row) : getColumnValue(b.row, column);
         let result: number;
         if (typeof left === "number" && typeof right === "number") result = left - right;
         else result = collator.compare(String(left ?? ""), String(right ?? ""));


### PR DESCRIPTION
Closes #236.

## Problem
The Age cells render the backend's compact single-unit strings ("45s", "3m", "2h", "300d", "1y"), and the table sorted them with a numeric collator — which compares the leading numbers, so "1y" ordered before "300d" (1 < 300). The screenshot in #236 shows exactly the over-a-year pods landing in the wrong place.

## Fix
- `Column` gains an optional `getSortValue`, consulted only by the sort comparator — filtering still matches the visible text, so typing "3d" in the filter keeps working.
- New `lib/age.ts` parses a compact age back to seconds (`ageSeconds`), with `ageSortValue` as the drop-in column helper; unset/unrecognized ages ("-") group together below every real age.
- All 29 Age columns (ResourceBrowser, WorkloadRelations, ResourceEvents, CustomResourceBrowser) supply it. The ResourceOverview conditions "Last transition" column — whose sort key previously resolved to `undefined` — now sorts by its timestamp, most-recent first ascending, to match.

## Tests
Unit tests for the parser (cross-unit ordering, unset grouping) and a Table-level test proving the sort order fix plus the filter-stays-on-text guarantee. Full frontend suite: 1041 passing, coverage floor unchanged.