### PR TITLE
feat(ui): interface scale setting with zoom shortcuts and steppers

### DIFF
--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
   ],
   "permissions": [
     "core:default",
+    "core:webview:allow-set-webview-zoom",
     "process:default"
   ]
 }

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -49,6 +49,7 @@ import {
   loadUpdateChannel,
   loadMcpSettings,
 } from "./lib/settings";
+import { applyUiScale, getUiScale, setUiScale, stepUiScale, uiScaleShortcut } from "./lib/uiScale";
 import { loadOpenTabs, saveOpenTabs, nextTabId } from "./lib/openTabs";
 import { startMcpHttp } from "./lib/mcp";
 import { checkForUpdateAndNotify } from "./lib/updateNotifier";
@@ -256,6 +257,24 @@ export function App() {
         e.preventDefault();
         setPaletteOpen((o) => !o);
       }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  // Interface scale (#237): restore the persisted zoom and serve the
+  // browser-zoom shortcuts (Cmd/Ctrl +, -, 0). Desktop only — a browser
+  // already zooms on these keys, and preventDefault here would suppress it.
+  useEffect(() => {
+    if (!isTauri()) return;
+    applyUiScale(getUiScale());
+    function onKey(e: KeyboardEvent) {
+      const action = uiScaleShortcut(e);
+      if (!action) return;
+      e.preventDefault();
+      applyUiScale(setUiScale(stepUiScale(getUiScale(), action)));
+      // Keep an open Settings slider in step with the shortcut.
+      window.dispatchEvent(new Event("srelens:uiscale"));
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);

--- a/apps/desktop/src/components/SettingsView.test.tsx
+++ b/apps/desktop/src/components/SettingsView.test.tsx
@@ -31,6 +31,7 @@ vi.mock("../lib/updater", () => updaterMocks);
 const transportMocks = vi.hoisted(() => ({
   appVersion: vi.fn(async () => "0.1.0"),
   relaunchApp: vi.fn(async () => {}),
+  setWebviewZoom: vi.fn(async () => {}),
 }));
 vi.mock("../transport/transport", () => transportMocks);
 
@@ -252,6 +253,48 @@ describe("SettingsView", () => {
     );
     // The Updates pane is shown without clicking the nav first.
     expect(await screen.findByRole("button", { name: "Check for updates" })).toBeDefined();
+  });
+
+  it("scales the interface from the Appearance slider and persists it (#237)", () => {
+    render(
+      <SettingsView
+        theme={{ name: "slate", mode: "dark" }}
+        onThemeNameChange={() => {}}
+        onThemeModeChange={() => {}}
+        defaultNamespace=""
+        onDefaultNamespaceChange={() => {}}
+        layout={DEFAULT_WORKSPACE_LAYOUT}
+        onLayoutChange={() => {}}
+        contextProfiles={{}}
+        onContextProfilesChange={() => {}}
+        kubeconfigFiles={[]}
+        onKubeconfigFilesChange={() => {}}
+        contextOrder={[]}
+        onContextOrderChange={() => {}}
+      />,
+    );
+
+    const slider = screen.getByRole("slider", { name: "Interface scale in percent" });
+    fireEvent.change(slider, { target: { value: "120" } });
+    // Native webview zoom, not a CSS knob — the stylesheet is px-based.
+    expect(transportMocks.setWebviewZoom).toHaveBeenCalledWith(1.2);
+    expect(localStorage.getItem("srelens.uiScale")).toBe("120");
+
+    // The steppers move one step and stay in sync with the slider.
+    fireEvent.click(screen.getByRole("button", { name: "Increase interface scale" }));
+    expect((slider as HTMLInputElement).value).toBe("130");
+    expect(transportMocks.setWebviewZoom).toHaveBeenLastCalledWith(1.3);
+    fireEvent.click(screen.getByRole("button", { name: "Decrease interface scale" }));
+    expect((slider as HTMLInputElement).value).toBe("120");
+
+    fireEvent.click(screen.getByRole("button", { name: "Reset" }));
+    expect((slider as HTMLInputElement).value).toBe("100");
+    expect(transportMocks.setWebviewZoom).toHaveBeenLastCalledWith(1);
+
+    // The zoom shortcuts announce their changes; the open slider follows.
+    localStorage.setItem("srelens.uiScale", "130");
+    fireEvent(window, new Event("srelens:uiscale"));
+    expect((slider as HTMLInputElement).value).toBe("130");
   });
 
   it("checks the dev channel when selected and persists the choice", async () => {

--- a/apps/desktop/src/components/SettingsView.tsx
+++ b/apps/desktop/src/components/SettingsView.tsx
@@ -12,8 +12,11 @@ import {
   PanelRight,
   RotateCcw,
   Sun,
+  Minus,
+  Plus,
   Timer,
   Upload,
+  ZoomIn,
   FilePlus2,
   X,
   ArrowDown,
@@ -61,6 +64,7 @@ import {
   type WorkspaceLayoutSettings,
   orderContexts,
 } from "../lib/settings";
+import { UI_SCALE, applyUiScale, getUiScale, setUiScale, stepUiScale } from "../lib/uiScale";
 import { updateRequestTimeout } from "../lib/requestTimeout";
 import { ContextAvatar, CONTEXT_LOGO_OPTIONS } from "./ContextAvatar";
 import { McpSettingsSection } from "./McpSettingsSection";
@@ -206,6 +210,18 @@ export function SettingsView({
   const [updateChannel, setUpdateChannel] = useState<UpdateChannel>(() => loadUpdateChannel());
   const [currentVersion, setCurrentVersion] = useState("");
   const [requestTimeout, setRequestTimeout] = useState(() => getRequestTimeoutSecs());
+  const [uiScale, setUiScaleState] = useState(() => getUiScale());
+  // The zoom shortcuts (App.tsx) announce changes so an open slider tracks them.
+  useEffect(() => {
+    const sync = () => setUiScaleState(getUiScale());
+    window.addEventListener("srelens:uiscale", sync);
+    return () => window.removeEventListener("srelens:uiscale", sync);
+  }, []);
+  const changeUiScale = (percent: number) => {
+    const stored = setUiScale(percent);
+    setUiScaleState(stored);
+    applyUiScale(stored);
+  };
   const draggedContextRef = useRef<string | null>(null);
   const dropTargetRef = useRef<string | null>(null);
 
@@ -473,6 +489,63 @@ export function SettingsView({
                   </button>
                 ))}
               </div>
+              {/* Desktop only: on the web the browser's own zoom owns this.
+                  A div, not a label: a label would forward the +/− button
+                  clicks to the slider it wraps. */}
+              {isTauri() && (
+                <div className="fl-settings-width-grid">
+                  <div className="fl-settings-width-control">
+                    <span className="fl-settings-width-control__header">
+                      <ZoomIn aria-hidden="true" />
+                      <span>
+                        <strong>Interface scale</strong>
+                        <small>
+                          Make everything larger or smaller. Also on ⌘/Ctrl with +, −, or 0
+                          anywhere in the app.
+                        </small>
+                      </span>
+                      <output>{uiScale}%</output>
+                    </span>
+                    <span className="fl-settings-zoom-row">
+                      <button
+                        type="button"
+                        className="fl-settings-zoom-step"
+                        onClick={() => changeUiScale(stepUiScale(uiScale, "out"))}
+                        disabled={uiScale <= UI_SCALE.MIN}
+                        aria-label="Decrease interface scale"
+                      >
+                        <Minus aria-hidden="true" />
+                      </button>
+                      <input
+                        type="range"
+                        min={UI_SCALE.MIN}
+                        max={UI_SCALE.MAX}
+                        step={UI_SCALE.STEP}
+                        value={uiScale}
+                        onChange={(event) => changeUiScale(Number(event.target.value))}
+                        aria-label="Interface scale in percent"
+                      />
+                      <button
+                        type="button"
+                        className="fl-settings-zoom-step"
+                        onClick={() => changeUiScale(stepUiScale(uiScale, "in"))}
+                        disabled={uiScale >= UI_SCALE.MAX}
+                        aria-label="Increase interface scale"
+                      >
+                        <Plus aria-hidden="true" />
+                      </button>
+                      <button
+                        type="button"
+                        className="fl-btn fl-btn--ghost fl-settings-zoom-reset"
+                        onClick={() => changeUiScale(UI_SCALE.DEFAULT)}
+                        disabled={uiScale === UI_SCALE.DEFAULT}
+                      >
+                        Reset
+                      </button>
+                    </span>
+                  </div>
+                </div>
+              )}
               <div className="fl-settings-theme-grid" aria-label="Theme palette">
                 {THEME_OPTIONS.map((option) => (
                   <button

--- a/apps/desktop/src/lib/uiScale.test.ts
+++ b/apps/desktop/src/lib/uiScale.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const transportMocks = vi.hoisted(() => ({ setWebviewZoom: vi.fn(async () => {}) }));
+vi.mock("../transport/transport", () => transportMocks);
+
+import {
+  UI_SCALE,
+  applyUiScale,
+  clampUiScale,
+  getUiScale,
+  setUiScale,
+  stepUiScale,
+  uiScaleShortcut,
+} from "./uiScale";
+
+beforeEach(() => transportMocks.setWebviewZoom.mockClear());
+afterEach(() => localStorage.clear());
+
+describe("clampUiScale", () => {
+  it("clamps to the supported range and rounds", () => {
+    expect(clampUiScale(79)).toBe(UI_SCALE.MIN);
+    expect(clampUiScale(151)).toBe(UI_SCALE.MAX);
+    expect(clampUiScale(112.4)).toBe(112);
+  });
+
+  it("falls back to the default for junk", () => {
+    expect(clampUiScale("huge")).toBe(UI_SCALE.DEFAULT);
+    expect(clampUiScale(NaN)).toBe(UI_SCALE.DEFAULT);
+    expect(clampUiScale(undefined)).toBe(UI_SCALE.DEFAULT);
+  });
+});
+
+describe("persistence", () => {
+  it("round-trips through localStorage, clamped", () => {
+    expect(setUiScale(120)).toBe(120);
+    expect(getUiScale()).toBe(120);
+    expect(setUiScale(9000)).toBe(UI_SCALE.MAX);
+    expect(getUiScale()).toBe(UI_SCALE.MAX);
+  });
+
+  it("defaults when unset or corrupted", () => {
+    expect(getUiScale()).toBe(UI_SCALE.DEFAULT);
+    localStorage.setItem("srelens.uiScale", "not json{");
+    expect(getUiScale()).toBe(UI_SCALE.DEFAULT);
+  });
+});
+
+describe("applyUiScale", () => {
+  it("zooms the webview by the clamped percentage as a factor", () => {
+    applyUiScale(120);
+    expect(transportMocks.setWebviewZoom).toHaveBeenCalledWith(1.2);
+    applyUiScale(100);
+    expect(transportMocks.setWebviewZoom).toHaveBeenLastCalledWith(1);
+    // Out-of-range input is clamped before it reaches the webview.
+    applyUiScale(400);
+    expect(transportMocks.setWebviewZoom).toHaveBeenLastCalledWith(UI_SCALE.MAX / 100);
+  });
+
+  it("swallows a zoom rejection so a keystroke never throws", () => {
+    transportMocks.setWebviewZoom.mockRejectedValueOnce(new Error("not permitted"));
+    expect(() => applyUiScale(110)).not.toThrow();
+  });
+});
+
+describe("uiScaleShortcut", () => {
+  const key = (key: string, mods: Partial<{ metaKey: boolean; ctrlKey: boolean; altKey: boolean }> = {}) => ({
+    key,
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    ...mods,
+  });
+
+  it("maps the browser-zoom vocabulary with either modifier", () => {
+    expect(uiScaleShortcut(key("+", { metaKey: true }))).toBe("in");
+    expect(uiScaleShortcut(key("=", { ctrlKey: true }))).toBe("in");
+    expect(uiScaleShortcut(key("-", { metaKey: true }))).toBe("out");
+    expect(uiScaleShortcut(key("_", { ctrlKey: true }))).toBe("out");
+    expect(uiScaleShortcut(key("0", { metaKey: true }))).toBe("reset");
+  });
+
+  it("ignores unmodified keys and Alt combos", () => {
+    expect(uiScaleShortcut(key("+"))).toBeNull();
+    expect(uiScaleShortcut(key("=", { metaKey: true, altKey: true }))).toBeNull();
+    expect(uiScaleShortcut(key("k", { metaKey: true }))).toBeNull();
+  });
+});
+
+describe("stepUiScale", () => {
+  it("steps by 10 within bounds and resets to 100", () => {
+    expect(stepUiScale(100, "in")).toBe(110);
+    expect(stepUiScale(UI_SCALE.MAX, "in")).toBe(UI_SCALE.MAX);
+    expect(stepUiScale(UI_SCALE.MIN, "out")).toBe(UI_SCALE.MIN);
+    expect(stepUiScale(130, "reset")).toBe(UI_SCALE.DEFAULT);
+  });
+});

--- a/apps/desktop/src/lib/uiScale.ts
+++ b/apps/desktop/src/lib/uiScale.ts
@@ -1,0 +1,81 @@
+// Interface scale (#237): one persisted percentage applied as the webview's
+// native zoom level.
+//
+// Why native zoom and not a CSS knob: the stylesheet is px-based (see
+// ui/styles.css), so scaling the root font-size moves almost nothing, and CSS
+// `zoom` on the root would multiply the app shell's `height: 100vh` and the
+// drawer's fixed positioning past the window edge. Native zoom shrinks the
+// layout viewport itself — exactly what a browser's Cmd/Ctrl +/- does — so px
+// sizes, viewport units, and fixed overlays all stay consistent.
+//
+// Desktop only: in web mode the browser's own zoom already does this, which is
+// why the shortcuts below must NOT be intercepted there (preventDefault would
+// suppress the native zoom the user already has).
+
+import { setWebviewZoom } from "../transport/transport";
+
+const UI_SCALE_KEY = "srelens.uiScale";
+
+/** Interface scale bounds, in percent of the default size. */
+export const UI_SCALE = { MIN: 80, MAX: 150, DEFAULT: 100, STEP: 10 } as const;
+
+/** Clamp any value to the supported scale range; fall back to the default. */
+export function clampUiScale(value: unknown): number {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n)) return UI_SCALE.DEFAULT;
+  return Math.round(Math.max(UI_SCALE.MIN, Math.min(UI_SCALE.MAX, n)));
+}
+
+/** The persisted interface scale in percent, or 100 when unset/invalid. */
+export function getUiScale(): number {
+  try {
+    const raw = localStorage.getItem(UI_SCALE_KEY);
+    return raw === null ? UI_SCALE.DEFAULT : clampUiScale(JSON.parse(raw));
+  } catch {
+    return UI_SCALE.DEFAULT;
+  }
+}
+
+/** Persist the interface scale (clamped). Returns the value stored. */
+export function setUiScale(percent: number): number {
+  const clamped = clampUiScale(percent);
+  try {
+    localStorage.setItem(UI_SCALE_KEY, JSON.stringify(clamped));
+  } catch {
+    // ignore unavailable/quota-exceeded storage
+  }
+  return clamped;
+}
+
+/**
+ * Apply a scale to the webview. Fire-and-forget: a zoom failure (missing
+ * permission, web mode) must never break the caller's render or keystroke.
+ */
+export function applyUiScale(percent: number): void {
+  void setWebviewZoom(clampUiScale(percent) / 100).catch(() => {});
+}
+
+/**
+ * Which scale action a keydown asks for, or null. Cmd/Ctrl with `+`/`=`
+ * zooms in, `-` zooms out, `0` resets — the browser-zoom vocabulary the
+ * reporter asked for. Alt/AltGr combos are left alone (they type characters
+ * on some layouts).
+ */
+export function uiScaleShortcut(e: {
+  key: string;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  altKey: boolean;
+}): "in" | "out" | "reset" | null {
+  if (!(e.metaKey || e.ctrlKey) || e.altKey) return null;
+  if (e.key === "+" || e.key === "=") return "in";
+  if (e.key === "-" || e.key === "_") return "out";
+  if (e.key === "0") return "reset";
+  return null;
+}
+
+/** The next scale after applying a shortcut action to `current`. */
+export function stepUiScale(current: number, action: "in" | "out" | "reset"): number {
+  if (action === "reset") return UI_SCALE.DEFAULT;
+  return clampUiScale(current + (action === "in" ? UI_SCALE.STEP : -UI_SCALE.STEP));
+}

--- a/apps/desktop/src/transport/tauriTransport.ts
+++ b/apps/desktop/src/transport/tauriTransport.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getVersion } from "@tauri-apps/api/app";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { parseClusterLoginRequired, requestClusterLogin } from "../lib/clusterLogin";
 
@@ -56,4 +57,9 @@ export async function relaunchApp(): Promise<void> {
 /** The running app's bundle version. */
 export async function appVersion(): Promise<string> {
   return getVersion();
+}
+
+/** Set the webview's native zoom level (1 = 100%) — the #237 interface scale. */
+export async function setWebviewZoom(factor: number): Promise<void> {
+  await getCurrentWebview().setZoom(factor);
 }

--- a/apps/desktop/src/transport/transport.ts
+++ b/apps/desktop/src/transport/transport.ts
@@ -13,3 +13,4 @@ export const on = impl.on;
 export const subscribe = impl.subscribe;
 export const relaunchApp = impl.relaunchApp;
 export const appVersion = impl.appVersion;
+export const setWebviewZoom = impl.setWebviewZoom;

--- a/apps/desktop/src/transport/webTransport.ts
+++ b/apps/desktop/src/transport/webTransport.ts
@@ -79,3 +79,10 @@ export async function subscribe(channel: string, handler: (payload: unknown) => 
   // the producer without losing the first frame (watch/logs/terminal/helm).
   return wsClient.subscribeChannel(channel, handler, { awaitAck: true });
 }
+
+/**
+ * No-op on the web: the browser's own Cmd/Ctrl +/- zoom already scales the
+ * page, and no API may set it programmatically. The settings control and the
+ * key handler are both gated to the desktop for this reason.
+ */
+export async function setWebviewZoom(_factor: number): Promise<void> {}

--- a/apps/desktop/src/ui/styles.css
+++ b/apps/desktop/src/ui/styles.css
@@ -2816,6 +2816,40 @@ body {
   accent-color: var(--fl-color-accent);
   cursor: pointer;
 }
+/* Interface scale (#237): −/+ steppers flanking the slider, then Reset. */
+.fl-settings-zoom-row {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 10px;
+}
+.fl-settings-zoom-step {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border: 1px solid var(--fl-color-border);
+  border-radius: var(--fl-radius-md);
+  background: var(--fl-color-surface);
+  color: var(--fl-color-text);
+  cursor: pointer;
+}
+.fl-settings-zoom-step:hover:not(:disabled) {
+  background: var(--fl-color-surface-alt);
+}
+.fl-settings-zoom-step:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+.fl-settings-zoom-step > svg {
+  width: 14px;
+  height: 14px;
+}
+.fl-settings-zoom-reset {
+  flex-shrink: 0;
+}
 .fl-settings-context-state {
   margin: 0;
   color: var(--fl-color-text-muted);


### PR DESCRIPTION
Closes #237.

## Problem
On high-DPI monitors the text is too small, and the app has no zoom of its own — the desktop WebView doesn't act on ⌘/Ctrl +/− the way a browser does.

## Approach: native webview zoom, not a CSS knob
The first cut scaled the root font-size. That barely moves anything here: `ui/styles.css` is px-based throughout. CSS `zoom` on the root is worse — it multiplies the app shell's `height: 100vh` and the drawer's `position: fixed` past the window edge.

Native zoom (`setZoom` → `setPageZoom` on macOS, equivalents on WebKitGTK/WebView2) shrinks the layout viewport itself, exactly like browser zoom, so px sizes, viewport units, and fixed overlays all stay consistent. It needs `core:webview:allow-set-webview-zoom`, added to the default capability.

## UI
- **Settings → Appearance → Interface scale**: slider (80–150%, 10% steps) flanked by −/+ steppers, with a Reset that's disabled at 100%. Steppers disable at the bounds.
- **⌘/Ctrl with `+`, `−`, `0`** anywhere in the app. Shortcut changes announce themselves so an open slider stays in sync.
- The choice persists across restarts.

Both are **desktop-only**: on the web the browser's own zoom already does this, and calling `preventDefault` on those keys there would suppress it. The slider is gated behind `isTauri()` like the request-timeout control.

## Tests
Unit tests for clamping, persistence, the shortcut vocabulary (including that Alt combos and unmodified keys are ignored), stepping at the bounds, and that a zoom rejection never throws out of a keystroke. A SettingsView test drives the slider, both steppers, Reset, and the shortcut-sync event. Full frontend suite: 1050 passing, coverage floor unchanged.