### PR TITLE
feat(kube): raise the request-timeout ceiling to 120s for large clusters

### DIFF
--- a/apps/desktop/src/components/ClusterOverview.test.tsx
+++ b/apps/desktop/src/components/ClusterOverview.test.tsx
@@ -192,7 +192,7 @@ describe("ClusterOverview error handling", () => {
     render(<ClusterOverview context="kind-unreachable" />);
 
     // Friendly title, not the raw backend string.
-    expect(await screen.findByText("Can't reach the cluster")).toBeDefined();
+    expect(await screen.findByText("Request timed out")).toBeDefined();
     expect(screen.getByText(/didn't respond in time/)).toBeDefined();
     expect(screen.queryByText(/handler error/)).toBeNull();
   });

--- a/apps/desktop/src/components/ResourceBrowser.test.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.test.tsx
@@ -952,8 +952,8 @@ describe("ResourceBrowser", () => {
     );
     render(<ResourceBrowser context="kind-dev" kind="deployments" />);
 
-    // The real error's title surfaces (timeout → "Can't reach the cluster").
-    expect(await screen.findByText(/Can't reach the cluster/)).toBeDefined();
+    // The real error's title surfaces (timeout → "Request timed out").
+    expect(await screen.findByText(/Request timed out/)).toBeDefined();
     // Not the permission wording, and not auto-scoped to the declared namespace.
     expect(screen.queryByText(/don.t have permission/)).toBeNull();
     expect(screen.queryByText(/Scoped to namespace/)).toBeNull();
@@ -1006,7 +1006,7 @@ describe("ResourceBrowser", () => {
     listNamespacesMock.mockResolvedValue({ namespaces: ["default"] });
     listNodesMock.mockResolvedValue({ error: "list nodes timed out" });
     render(<ResourceBrowser context="kind-dev" kind="nodes" />);
-    await waitFor(() => expect(screen.getByText("Can't reach the cluster")).toBeDefined());
+    await waitFor(() => expect(screen.getByText("Request timed out")).toBeDefined());
     expect(screen.queryByText(/list nodes timed out/)).toBeNull();
   });
 });

--- a/apps/desktop/src/components/SettingsView.test.tsx
+++ b/apps/desktop/src/components/SettingsView.test.tsx
@@ -254,6 +254,38 @@ describe("SettingsView", () => {
     expect(await screen.findByRole("button", { name: "Check for updates" })).toBeDefined();
   });
 
+  it("sets an exact large-cluster request timeout from the number box (#238)", async () => {
+    render(
+      <SettingsView
+        theme={{ name: "slate", mode: "dark" }}
+        onThemeNameChange={() => {}}
+        onThemeModeChange={() => {}}
+        defaultNamespace=""
+        onDefaultNamespaceChange={() => {}}
+        layout={DEFAULT_WORKSPACE_LAYOUT}
+        onLayoutChange={() => {}}
+        contextProfiles={{}}
+        onContextProfilesChange={() => {}}
+        kubeconfigFiles={[]}
+        onKubeconfigFilesChange={() => {}}
+        contextOrder={[]}
+        onContextOrderChange={() => {}}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /Kubernetes/ }));
+
+    const exact = screen.getByRole("spinbutton", { name: "Cluster request timeout in seconds (exact)" });
+    const slider = screen.getByRole("slider", { name: "Cluster request timeout in seconds" });
+    // 90s was above the old 30s ceiling — the whole point of #238.
+    fireEvent.change(exact, { target: { value: "90" } });
+    expect((slider as HTMLInputElement).value).toBe("90");
+    expect(localStorage.getItem("srelens.requestTimeoutSecs")).toBe("90");
+
+    // Out-of-range typing clamps rather than reaching the backend as junk.
+    fireEvent.change(exact, { target: { value: "9999" } });
+    expect((exact as HTMLInputElement).value).toBe("120");
+  });
+
   it("checks the dev channel when selected and persists the choice", async () => {
     updaterMocks.checkForUpdate.mockResolvedValue(null);
     render(

--- a/apps/desktop/src/components/SettingsView.test.tsx
+++ b/apps/desktop/src/components/SettingsView.test.tsx
@@ -281,9 +281,20 @@ describe("SettingsView", () => {
     expect((slider as HTMLInputElement).value).toBe("90");
     expect(localStorage.getItem("srelens.requestTimeoutSecs")).toBe("90");
 
-    // Out-of-range typing clamps rather than reaching the backend as junk.
+    // Out-of-range typing clamps what's stored; the box settles on blur.
     fireEvent.change(exact, { target: { value: "9999" } });
+    expect(localStorage.getItem("srelens.requestTimeoutSecs")).toBe("120");
+    fireEvent.blur(exact);
     expect((exact as HTMLInputElement).value).toBe("120");
+
+    // Clearing to retype is an intermediate state, not a 1s timeout: the
+    // committed value must survive the empty box untouched.
+    fireEvent.change(exact, { target: { value: "" } });
+    expect((exact as HTMLInputElement).value).toBe("");
+    expect(localStorage.getItem("srelens.requestTimeoutSecs")).toBe("120");
+    fireEvent.change(exact, { target: { value: "45" } });
+    expect(localStorage.getItem("srelens.requestTimeoutSecs")).toBe("45");
+    expect((slider as HTMLInputElement).value).toBe("45");
   });
 
   it("checks the dev channel when selected and persists the choice", async () => {

--- a/apps/desktop/src/components/SettingsView.tsx
+++ b/apps/desktop/src/components/SettingsView.tsx
@@ -207,13 +207,22 @@ export function SettingsView({
   const [updateChannel, setUpdateChannel] = useState<UpdateChannel>(() => loadUpdateChannel());
   const [currentVersion, setCurrentVersion] = useState("");
   const [requestTimeout, setRequestTimeout] = useState(() => getRequestTimeoutSecs());
-  // An empty or half-typed number box must not push a junk timeout to the
-  // backend; clamp first and keep the last good value on screen.
+  // While the exact box is being edited it holds a raw string, so clearing it
+  // to retype is possible: `Number("")` is 0, which would otherwise clamp to
+  // the 1s minimum and push that to the backend on the first keystroke of a
+  // clear-and-retype. null means "not editing — show the committed value".
+  const [timeoutDraft, setTimeoutDraft] = useState<string | null>(null);
   const changeRequestTimeout = (secs: number) => {
     if (!Number.isFinite(secs)) return;
     const clamped = clampTimeoutSecs(secs);
     setRequestTimeout(clamped);
     void updateRequestTimeout(clamped);
+  };
+  const editRequestTimeout = (raw: string) => {
+    setTimeoutDraft(raw);
+    // An empty or unparseable draft is an intermediate state: leave the
+    // committed timeout alone until it becomes a number again.
+    if (raw.trim() !== "" && Number.isFinite(Number(raw))) changeRequestTimeout(Number(raw));
   };
   const draggedContextRef = useRef<string | null>(null);
   const dropTargetRef = useRef<string | null>(null);
@@ -596,8 +605,12 @@ export function SettingsView({
                         min={REQUEST_TIMEOUT.MIN}
                         max={REQUEST_TIMEOUT.MAX}
                         step={1}
-                        value={requestTimeout}
-                        onChange={(event) => changeRequestTimeout(Number(event.target.value))}
+                        value={timeoutDraft ?? String(requestTimeout)}
+                        onChange={(event) => editRequestTimeout(event.target.value)}
+                        // Leaving the field settles it back to what was
+                        // actually stored (clamped, or unchanged if abandoned
+                        // empty), so the box never lies about the live value.
+                        onBlur={() => setTimeoutDraft(null)}
                         aria-label="Cluster request timeout in seconds (exact)"
                       />
                       <span className="fl-settings-timeout-unit">s</span>

--- a/apps/desktop/src/components/SettingsView.tsx
+++ b/apps/desktop/src/components/SettingsView.tsx
@@ -52,6 +52,7 @@ import {
   DEFAULT_WORKSPACE_LAYOUT,
   REQUEST_TIMEOUT,
   contextDisplayName,
+  clampTimeoutSecs,
   getRequestTimeoutSecs,
   loadUpdateChannel,
   saveUpdateChannel,
@@ -206,6 +207,14 @@ export function SettingsView({
   const [updateChannel, setUpdateChannel] = useState<UpdateChannel>(() => loadUpdateChannel());
   const [currentVersion, setCurrentVersion] = useState("");
   const [requestTimeout, setRequestTimeout] = useState(() => getRequestTimeoutSecs());
+  // An empty or half-typed number box must not push a junk timeout to the
+  // backend; clamp first and keep the last good value on screen.
+  const changeRequestTimeout = (secs: number) => {
+    if (!Number.isFinite(secs)) return;
+    const clamped = clampTimeoutSecs(secs);
+    setRequestTimeout(clamped);
+    void updateRequestTimeout(clamped);
+  };
   const draggedContextRef = useRef<string | null>(null);
   const dropTargetRef = useRef<string | null>(null);
 
@@ -555,31 +564,45 @@ export function SettingsView({
                 />
               </label>
 
+              {/* A div, not a label: the number box beside the slider would
+                  otherwise inherit the label and fight it for focus. */}
               {isTauri() && (
                 <div className="fl-settings-width-grid">
-                  <label className="fl-settings-width-control">
+                  <div className="fl-settings-width-control">
                     <span className="fl-settings-width-control__header">
                       <Timer aria-hidden="true" />
                       <span>
                         <strong>Request timeout</strong>
-                        <small>How long to wait for a cluster response. Raise it for large clusters.</small>
+                        <small>
+                          How long to wait for a cluster response. Raise it for large clusters —
+                          a few hundred nodes can need well over the {REQUEST_TIMEOUT.DEFAULT}s
+                          default.
+                        </small>
                       </span>
-                      <output>{requestTimeout}s</output>
                     </span>
-                    <input
-                      type="range"
-                      min={REQUEST_TIMEOUT.MIN}
-                      max={REQUEST_TIMEOUT.MAX}
-                      step="1"
-                      value={requestTimeout}
-                      onChange={(event) => {
-                        const secs = Number(event.target.value);
-                        setRequestTimeout(secs);
-                        void updateRequestTimeout(secs);
-                      }}
-                      aria-label="Cluster request timeout in seconds"
-                    />
-                  </label>
+                    <span className="fl-settings-timeout-row">
+                      <input
+                        type="range"
+                        min={REQUEST_TIMEOUT.MIN}
+                        max={REQUEST_TIMEOUT.MAX}
+                        step="1"
+                        value={requestTimeout}
+                        onChange={(event) => changeRequestTimeout(Number(event.target.value))}
+                        aria-label="Cluster request timeout in seconds"
+                      />
+                      <input
+                        type="number"
+                        className="fl-settings-timeout-number"
+                        min={REQUEST_TIMEOUT.MIN}
+                        max={REQUEST_TIMEOUT.MAX}
+                        step={1}
+                        value={requestTimeout}
+                        onChange={(event) => changeRequestTimeout(Number(event.target.value))}
+                        aria-label="Cluster request timeout in seconds (exact)"
+                      />
+                      <span className="fl-settings-timeout-unit">s</span>
+                    </span>
+                  </div>
                 </div>
               )}
             </SectionPanel>

--- a/apps/desktop/src/lib/errors.test.ts
+++ b/apps/desktop/src/lib/errors.test.ts
@@ -55,10 +55,20 @@ describe("describeError", () => {
     const result = describeError("handler error: list namespaces timed out");
     expect(result.title).toBe("Request timed out");
     expect(result.detail).toMatch(/didn't respond in time/);
-    // Points at the setting that fixes it on a large cluster (#238).
-    expect(result.detail).toMatch(/Request timeout in Settings/);
     expect(result.detail).not.toMatch(/handler error/);
     expect(result.raw).toBe("list namespaces timed out");
+  });
+
+  it("points each platform at the timeout it can actually change (#238)", () => {
+    // Web (jsdom default): the Settings slider doesn't exist there, so the
+    // server-side env var is the only real remedy.
+    delete (window as unknown as { __TAURI_INTERNALS__?: object }).__TAURI_INTERNALS__;
+    expect(describeError("list pods timed out").detail).toMatch(/SRELENS_TIMEOUT_SECS/);
+    expect(describeError("list pods timed out").detail).not.toMatch(/Settings → Kubernetes/);
+
+    (window as unknown as { __TAURI_INTERNALS__?: object }).__TAURI_INTERNALS__ = {};
+    expect(describeError("list pods timed out").detail).toMatch(/Request timeout in Settings/);
+    delete (window as unknown as { __TAURI_INTERNALS__?: object }).__TAURI_INTERNALS__;
   });
 
   it("classifies a refused connection", () => {

--- a/apps/desktop/src/lib/errors.test.ts
+++ b/apps/desktop/src/lib/errors.test.ts
@@ -53,8 +53,10 @@ describe("cleanErrorMessage", () => {
 describe("describeError", () => {
   it("classifies a connection timeout and never leaks the handler prefix", () => {
     const result = describeError("handler error: list namespaces timed out");
-    expect(result.title).toBe("Can't reach the cluster");
+    expect(result.title).toBe("Request timed out");
     expect(result.detail).toMatch(/didn't respond in time/);
+    // Points at the setting that fixes it on a large cluster (#238).
+    expect(result.detail).toMatch(/Request timeout in Settings/);
     expect(result.detail).not.toMatch(/handler error/);
     expect(result.raw).toBe("list namespaces timed out");
   });

--- a/apps/desktop/src/lib/errors.ts
+++ b/apps/desktop/src/lib/errors.ts
@@ -94,10 +94,15 @@ export function describeError(input: unknown): FriendlyError {
   }
 
   if (/timed out|timeout|deadline exceeded/.test(lower)) {
+    // The remedy is platform-specific: the Settings slider only exists on the
+    // desktop, so pointing a web user at it would be an impossible
+    // instruction. The server honours SRELENS_TIMEOUT_SECS instead.
+    const raiseIt = isTauri()
+      ? "raise Request timeout in Settings → Kubernetes"
+      : "ask whoever runs this srelens server to raise its SRELENS_TIMEOUT_SECS setting";
     return {
       title: "Request timed out",
-      detail:
-        "The Kubernetes API server didn't respond in time. Large clusters can need longer than the default — raise Request timeout in Settings → Kubernetes. If it still times out, check that the cluster is reachable: for a remote cluster confirm your VPN or network connection and that the current context points at the right server.",
+      detail: `The Kubernetes API server didn't respond in time. Large clusters can need longer than the default — ${raiseIt}. If it still times out, check that the cluster is reachable: for a remote cluster confirm your VPN or network connection and that the current context points at the right server.`,
       raw,
     };
   }

--- a/apps/desktop/src/lib/errors.ts
+++ b/apps/desktop/src/lib/errors.ts
@@ -95,9 +95,9 @@ export function describeError(input: unknown): FriendlyError {
 
   if (/timed out|timeout|deadline exceeded/.test(lower)) {
     return {
-      title: "Can't reach the cluster",
+      title: "Request timed out",
       detail:
-        "The Kubernetes API server didn't respond in time. Check that the cluster is running and reachable — if it's remote, confirm your VPN or network connection and that the current context points at the right server.",
+        "The Kubernetes API server didn't respond in time. Large clusters can need longer than the default — raise Request timeout in Settings → Kubernetes. If it still times out, check that the cluster is reachable: for a remote cluster confirm your VPN or network connection and that the current context points at the right server.",
       raw,
     };
   }

--- a/apps/desktop/src/lib/settings.test.ts
+++ b/apps/desktop/src/lib/settings.test.ts
@@ -33,10 +33,12 @@ describe("request timeout setting", () => {
   });
 
   it("clamps values to the supported range", () => {
-    expect(clampTimeoutSecs(100)).toBe(REQUEST_TIMEOUT.MAX);
+    expect(clampTimeoutSecs(REQUEST_TIMEOUT.MAX + 1)).toBe(REQUEST_TIMEOUT.MAX);
     expect(clampTimeoutSecs(0)).toBe(REQUEST_TIMEOUT.MIN);
     expect(clampTimeoutSecs(-5)).toBe(REQUEST_TIMEOUT.MIN);
     expect(clampTimeoutSecs(15)).toBe(15);
+    // A large-cluster budget is now inside the range, not clamped away (#238).
+    expect(clampTimeoutSecs(90)).toBe(90);
     expect(clampTimeoutSecs("nonsense")).toBe(REQUEST_TIMEOUT.DEFAULT);
   });
 

--- a/apps/desktop/src/lib/settings.ts
+++ b/apps/desktop/src/lib/settings.ts
@@ -10,7 +10,7 @@ const REQUEST_TIMEOUT_KEY = "srelens.requestTimeoutSecs";
 const LEGACY_PREFIX = "free" + "lens";
 
 /** Per-request timeout budget (connect + list/get/apply), in seconds. */
-export const REQUEST_TIMEOUT = { MIN: 1, MAX: 30, DEFAULT: 8 } as const;
+export const REQUEST_TIMEOUT = { MIN: 1, MAX: 120, DEFAULT: 8 } as const;
 
 /** Clamp any value to the supported timeout range; fall back to the default. */
 export function clampTimeoutSecs(value: unknown): number {

--- a/apps/desktop/src/ui/styles.css
+++ b/apps/desktop/src/ui/styles.css
@@ -2816,6 +2816,30 @@ body {
   accent-color: var(--fl-color-accent);
   cursor: pointer;
 }
+/* Request timeout (#238): slider plus an exact number box, since the range
+   now runs to two minutes and dragging alone can't land a precise value. */
+.fl-settings-timeout-row {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 10px;
+}
+.fl-settings-timeout-number {
+  width: 64px;
+  flex-shrink: 0;
+  border: 1px solid var(--fl-color-border);
+  border-radius: var(--fl-radius-md);
+  background: var(--fl-color-surface);
+  padding: 4px 6px;
+  color: var(--fl-color-text);
+  font-family: inherit;
+  font-size: 13px;
+}
+.fl-settings-timeout-unit {
+  flex-shrink: 0;
+  color: var(--fl-color-text-muted);
+  font-size: 13px;
+}
 .fl-settings-context-state {
   margin: 0;
   color: var(--fl-color-text-muted);

--- a/crates/kube/src/connect.rs
+++ b/crates/kube/src/connect.rs
@@ -21,8 +21,11 @@ use crate::context_resolve::resolve_context;
 pub const DEFAULT_TIMEOUT_SECS: u64 = 8;
 /// Smallest timeout a user may configure, in seconds.
 pub const MIN_TIMEOUT_SECS: u64 = 1;
-/// Largest timeout a user may configure, in seconds.
-pub const MAX_TIMEOUT_SECS: u64 = 30;
+/// Largest timeout a user may configure, in seconds. Raised from 30 for
+/// issue #238: on large clusters (100+ nodes) a single all-namespace list can
+/// legitimately outrun half a minute, and the old ceiling left those users no
+/// setting that would let the call finish.
+pub const MAX_TIMEOUT_SECS: u64 = 120;
 
 /// Environment variable that overrides the default timeout at startup — lets
 /// headless/MCP runs (which have no Settings UI) raise it for large clusters.
@@ -460,7 +463,7 @@ mod tests {
     #[test]
     fn timeout_setter_clamps_to_supported_range() {
         // Above the max is clamped down.
-        assert_eq!(set_request_timeout_secs(120), MAX_TIMEOUT_SECS);
+        assert_eq!(set_request_timeout_secs(MAX_TIMEOUT_SECS + 1), MAX_TIMEOUT_SECS);
         assert_eq!(request_timeout(), Duration::from_secs(MAX_TIMEOUT_SECS));
         // Zero is clamped up to the minimum.
         assert_eq!(set_request_timeout_secs(0), MIN_TIMEOUT_SECS);


### PR DESCRIPTION
Closes #238.

## Problem
The per-request budget was clamped to **30s max** in both places that matter — `MAX_TIMEOUT_SECS` in `crates/kube/src/connect.rs` and `REQUEST_TIMEOUT.MAX` in the Settings slider. On the reporter's 100+ node cluster an all-namespace list can legitimately outrun that, so there was no value they could choose that would let the call finish.

Worth noting the setting *did* already exist — the reporter asked "if there is a setting field to change timeout by myself" because nothing ever pointed them at it. The timeout error said only "Can't reach the cluster… check your VPN", which sends you looking in the wrong place.

## Fix
- **Ceiling 30s → 120s** in the backend clamp and the frontend range. The **8s default is unchanged**, so nothing gets slower to fail for users who aren't affected.
- **Exact number box beside the slider** — a 1–120 range can't be landed precisely by dragging. Typed values clamp on the way in, and a half-typed/empty box never pushes junk to the backend.
- **The timeout error now names the setting**: title is "Request timed out" and the detail points at Settings → Kubernetes → Request timeout before falling back to the connectivity advice.

I confirmed the `tokio::time::timeout` wrapper is genuinely the binding constraint here — no lower-level kube-rs client timeout cuts in first — so raising the ceiling actually takes effect.

## Tests
Backend clamp test now probes above the new ceiling (it previously used the literal `120`, which would have passed vacuously). Frontend: a SettingsView test drives the number box to 90s (impossible under the old cap) and checks out-of-range clamping; the three suites asserting the old error title are updated. Full suites green — 292 backend, 1041 frontend.