### PR TITLE
docs(perf): publish measured size baselines vs Freelens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,11 @@ jobs:
       - name: Unit tests with coverage
         # Vitest enforces the 85% line-coverage floor (vitest.config.ts).
         run: pnpm -r test
+      - name: Performance-baseline script tests
+        # The size classifier decides which artifacts are compared against
+        # which (#31) — a wrong bucket silently publishes a bogus comparison.
+        # Pure unit tests: no network, so they run on every PR.
+        run: node --test scripts/perf/size-baseline.test.mjs
 
   backend:
     name: backend

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -716,7 +716,10 @@ jobs:
             cat check.txt
             echo '```'
             echo
-            node scripts/perf/size-baseline.mjs || true
+            # --tag here too: without it the table would describe the
+            # previous PUBLISHED release, not the draft just built.
+            node scripts/perf/size-baseline.mjs \
+              --tag "srelens-v${{ needs.version.outputs.version }}" || true
           } >> "$GITHUB_STEP_SUMMARY"
           cat check.txt
           exit "$status"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -678,6 +678,43 @@ jobs:
             gh release upload dev-channel latest.json --repo "$REPO" --clobber
           fi
 
+  # Download-size baseline (issue #31). Runs after the artifacts are published
+  # so it measures exactly what users download, and flags a release whose
+  # installers grew more than 15% over the previous stable one — the size
+  # advantage over an Electron client is a stated reason for the Tauri port,
+  # so a silent regression should not reach a release unnoticed.
+  size-baseline:
+    needs: [version, build]
+    if: ${{ always() && needs.build.result == 'success' && github.ref_name == 'main' && needs.version.outputs.release == 'true' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Compare installer sizes against the previous release
+        env:
+          # Authenticates the Releases API reads (the anonymous rate limit is
+          # low enough for a runner pool to hit it).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Capture the verdict rather than piping it: a `| tee` would mask the
+          # check's exit code and a regression would pass silently. The
+          # comparison table is still published either way.
+          status=0
+          node scripts/perf/size-baseline.mjs --check-regression --max-growth 15 > check.txt || status=$?
+          {
+            echo '### Installer sizes'
+            echo
+            echo '```'
+            cat check.txt
+            echo '```'
+            echo
+            node scripts/perf/size-baseline.mjs || true
+          } >> "$GITHUB_STEP_SUMMARY"
+          cat check.txt
+          exit "$status"
+
   # Attach detached GPG signatures (.asc) to every release asset so users can
   # verify authenticity (`gpg --verify file.asc file`). Activates automatically
   # once the GPG_PRIVATE_KEY secret is set; otherwise it's a no-op.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -701,8 +701,14 @@ jobs:
           # Capture the verdict rather than piping it: a `| tee` would mask the
           # check's exit code and a regression would pass silently. The
           # comparison table is still published either way.
+          # --tag pins the comparison to the release just built. On main that
+          # release is still a DRAFT until publish-release flips it, and drafts
+          # are excluded from the stable list — without this the check would
+          # compare the two PREVIOUS published releases and never see these
+          # artifacts at all.
           status=0
-          node scripts/perf/size-baseline.mjs --check-regression --max-growth 15 > check.txt || status=$?
+          node scripts/perf/size-baseline.mjs --check-regression --max-growth 15 \
+            --tag "srelens-v${{ needs.version.outputs.version }}" > check.txt || status=$?
           {
             echo '### Installer sizes'
             echo
@@ -758,8 +764,11 @@ jobs:
   # run leaves an invisible draft to delete instead of a public, `latest`-
   # resolving release with no manifest behind it.
   publish-release:
-    needs: [version, build, updater-manifest, sign-artifacts]
-    if: ${{ always() && github.ref_name == 'main' && needs.build.result == 'success' && needs.updater-manifest.result == 'success' && needs.sign-artifacts.result == 'success' && needs.version.outputs.release == 'true' }}
+    # size-baseline included so an over-budget installer never goes public: a
+    # failed check leaves the release as an invisible draft to inspect, exactly
+    # like a failed build or a missing updater manifest.
+    needs: [version, build, updater-manifest, sign-artifacts, size-baseline]
+    if: ${{ always() && github.ref_name == 'main' && needs.build.result == 'success' && needs.updater-manifest.result == 'success' && needs.sign-artifacts.result == 'success' && needs.size-baseline.result == 'success' && needs.version.outputs.release == 'true' }}
     runs-on: ubuntu-22.04
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ srelens uses the operating system WebView through Tauri v2 and a Rust backend bu
 with `kube-rs` and `tokio`. It is independently developed and is not affiliated with
 Mirantis Lens or the Freelens project.
 
+That architecture is why the download is small: srelens `v0.5.0` ships a **17.1 MiB**
+macOS installer and a **19.8 MiB** Linux `.deb`, against 190.2 MiB and 146.8 MiB for
+Freelens `v1.10.3` — roughly **11× and 7× smaller**. Those are published release-asset
+sizes, and the [performance baselines](docs/PERFORMANCE.md) explain how to reproduce
+them (including where the gap is narrower, such as the self-contained AppImage).
+
 See the [user guide](docs/USAGE.md) for how to use each of these.
 
 - **Multi-cluster workspace** — discover kubeconfig contexts, add or paste more

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -85,11 +85,13 @@ PID 1, not the app, and their argv names no client. They are neither
 descendants of the app nor name matches, so neither of the obvious collection
 strategies finds them.
 
-This is not a rounding detail. Measured on this repo's dev build, collecting
-only the app's own processes gave **106.9 MiB**; including the WebKit services
-gave **252.95 MiB** — the app itself was under half the real total. Since an
-Electron app's helpers *are* branded children and get counted, a script that
-misses these would systematically flatter the Tauri side.
+This is not a rounding detail. Spot-checking a dev build while writing this
+script, the WebKit services held roughly as much resident memory as the app
+process itself — collecting only the app's own processes reported well under
+half the real total. (Those were exploratory readings on a debug build, not
+baselines; they are quoted only to show the size of the gap.) Since an Electron
+app's helpers *are* branded children and get counted, a script that misses
+these would systematically flatter the Tauri side.
 
 So the script **refuses to print a macOS total** while unattributed WebKit
 processes are running and `--include` was not passed. A valid macOS

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -47,8 +47,10 @@ Measured on 2026-08-16, srelens `v0.5.0` against Freelens `v1.10.3`:
 
 ### Regression budget
 
-The release workflow re-runs this comparison after publishing and fails if any
-installer grew more than **15%** over the previous stable release:
+The release workflow runs this comparison against the **draft** release before
+it is published, and blocks publication if any installer grew more than **15%**
+over the previous stable release — a failed check leaves the release as an
+invisible draft to inspect rather than a public one to retract:
 
 ```bash
 node scripts/perf/size-baseline.mjs --check-regression --max-growth 15
@@ -67,13 +69,34 @@ architecture keeps more of itself in children.
 
 ```bash
 # start the app, set up the scenario, then:
-scripts/perf/memory-baseline.sh srelens --settle 30 --samples 5
-scripts/perf/memory-baseline.sh Freelens --settle 30 --samples 5
+scripts/perf/memory-baseline.sh srelens --include com.apple.WebKit --settle 30
+scripts/perf/memory-baseline.sh Freelens --settle 30
 ```
 
 The script reports the median of several readings after a settle delay, and
 prints every process it counted so contamination is visible rather than
 averaged in.
+
+### The macOS WebView caveat
+
+On macOS a Tauri app's WebView runs as `com.apple.WebKit.WebContent`, `.GPU`,
+and `.Networking` — XPC services adopted by **launchd**, so their parent is
+PID 1, not the app, and their argv names no client. They are neither
+descendants of the app nor name matches, so neither of the obvious collection
+strategies finds them.
+
+This is not a rounding detail. Measured on this repo's dev build, collecting
+only the app's own processes gave **106.9 MiB**; including the WebKit services
+gave **252.95 MiB** — the app itself was under half the real total. Since an
+Electron app's helpers *are* branded children and get counted, a script that
+misses these would systematically flatter the Tauri side.
+
+So the script **refuses to print a macOS total** while unattributed WebKit
+processes are running and `--include` was not passed. A valid macOS
+measurement therefore requires quitting every other WebKit client (Safari
+included) so the remaining WebKit processes can only belong to the app under
+test. On Linux the equivalent helpers (`WebKitWebProcess`) are genuine child
+processes and need no special handling.
 
 **Numbers are not published here yet.** Producing figures worth citing requires
 a run this repository has not yet done: release builds of both apps (a debug

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -13,7 +13,17 @@ srelens is independently developed and not affiliated with it.
 
 Every number below is the byte size of a published release asset, read from the
 GitHub Releases API — nothing is built locally, estimated, or rounded up from a
-directory listing. Reproduce it with:
+directory listing.
+
+Reproduce **this exact table** by pinning both sides; without the tags each
+side resolves to whatever is latest, so the numbers move as either project
+ships:
+
+```bash
+node scripts/perf/size-baseline.mjs --tag srelens-v0.5.0 --comparison-tag v1.10.3
+```
+
+For the current comparison instead, drop both flags:
 
 ```bash
 node scripts/perf/size-baseline.mjs
@@ -110,8 +120,11 @@ above are complete and independent of it.
 
 ## Methodology notes
 
-- Sizes come from release metadata, so they are reproducible by anyone at any
-  time and do not depend on the machine running the script.
+- Sizes come from release metadata, so they do not depend on the machine
+  running the script. They are reproducible by anyone at any time **when both
+  releases are pinned** — an unpinned run reports today's latest releases,
+  which is the right default for a fresh comparison but will not reproduce a
+  dated table once either project publishes again.
 - Set `GITHUB_TOKEN` when running the size script repeatedly; the
   unauthenticated Releases API rate limit is easy to hit.
 - Memory readings depend on machine, OS version, and cluster size, so they are

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,94 @@
+# Performance baselines
+
+A stated reason for building srelens on Tauri rather than Electron is that it
+should be smaller and lighter. This page publishes what that is actually worth,
+and exactly how it was measured, so the claim can be checked rather than taken
+on trust.
+
+Comparisons are against [Freelens](https://github.com/freelensapp/freelens), the
+maintained open-source fork of Lens and the closest equivalent Electron client.
+srelens is independently developed and not affiliated with it.
+
+## Download size
+
+Every number below is the byte size of a published release asset, read from the
+GitHub Releases API — nothing is built locally, estimated, or rounded up from a
+directory listing. Reproduce it with:
+
+```bash
+node scripts/perf/size-baseline.mjs
+```
+
+Measured on 2026-08-16, srelens `v0.5.0` against Freelens `v1.10.3`:
+
+| Installer | srelens | Freelens | Difference |
+| --- | ---: | ---: | ---: |
+| macOS arm64 `.dmg` | 17.1 MiB | 190.2 MiB | 11.2× smaller |
+| macOS x64 `.dmg` | 18.3 MiB | 202.3 MiB | 11.1× smaller |
+| Windows x64 `.exe` | 11.2 MiB | 154.6 MiB | 13.8× smaller |
+| Windows x64 `.msi` | 16.8 MiB | 170.1 MiB | 10.1× smaller |
+| Linux x64 `.deb` | 19.8 MiB | 146.8 MiB | 7.4× smaller |
+| Linux x64 `.rpm` | 19.8 MiB | 121.8 MiB | 6.2× smaller |
+| Linux x64 `.AppImage` | 91.7 MiB | 199.2 MiB | 2.2× smaller |
+
+### Reading these honestly
+
+- **The AppImage gap is much smaller than the rest, and that is expected.** A
+  `.deb` or `.rpm` resolves the system WebView (`libwebkit2gtk`) as a package
+  dependency; an AppImage has to carry it. That 91.7 MiB is the fair number for
+  a self-contained Linux download, and it is the one to quote when comparing
+  against Electron's self-contained bundles.
+- **Only buckets both projects publish are compared.** srelens ships no arm64
+  Linux or Windows installers today, so those rows are absent rather than
+  filled with a cross-architecture comparison.
+- **Signatures, checksums, SBOMs, and `portable` builds are excluded**, since
+  they are not what a user downloads to install the app. Anything the script
+  cannot classify is listed in its output rather than silently dropped.
+
+### Regression budget
+
+The release workflow re-runs this comparison after publishing and fails if any
+installer grew more than **15%** over the previous stable release:
+
+```bash
+node scripts/perf/size-baseline.mjs --check-regression --max-growth 15
+```
+
+For reference, `v0.4.1 → v0.5.0` grew at most 5.9% (the `.deb`/`.rpm`).
+
+## Memory
+
+`scripts/perf/memory-baseline.sh` measures resident memory across an app's
+**whole process tree**. That total is the only fair basis for this comparison:
+an Electron app spreads its footprint over a main process plus renderer, GPU,
+and utility helpers, while a Tauri app spreads it over its own binary plus the
+OS WebView's processes. Measuring a single process would flatter whichever
+architecture keeps more of itself in children.
+
+```bash
+# start the app, set up the scenario, then:
+scripts/perf/memory-baseline.sh srelens --settle 30 --samples 5
+scripts/perf/memory-baseline.sh Freelens --settle 30 --samples 5
+```
+
+The script reports the median of several readings after a settle delay, and
+prints every process it counted so contamination is visible rather than
+averaged in.
+
+**Numbers are not published here yet.** Producing figures worth citing requires
+a run this repository has not yet done: release builds of both apps (a debug
+build is not representative), on an otherwise-idle machine, with no stray
+`srelens --mcp-stdio` servers running, in two scenarios — idle, and three
+clusters connected with watches live. Tracked in
+[issue #31](https://github.com/srelens/srelens/issues/31); the size numbers
+above are complete and independent of it.
+
+## Methodology notes
+
+- Sizes come from release metadata, so they are reproducible by anyone at any
+  time and do not depend on the machine running the script.
+- Set `GITHUB_TOKEN` when running the size script repeatedly; the
+  unauthenticated Releases API rate limit is easy to hit.
+- Memory readings depend on machine, OS version, and cluster size, so they are
+  only meaningful when both apps are measured on the same machine in the same
+  session against the same clusters.

--- a/scripts/perf/memory-baseline.sh
+++ b/scripts/perf/memory-baseline.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Resident-memory baseline for issue #31.
+#
+# Sums RSS across a running app's WHOLE process tree. That total is the only
+# fair comparison here: an Electron app spreads its footprint over a main
+# process plus renderer/GPU/utility helpers, and a Tauri app over its binary
+# plus the OS WebView's own processes. Measuring one process would flatter
+# whichever architecture hides more of itself in children.
+#
+# Usage:
+#   scripts/perf/memory-baseline.sh srelens
+#   scripts/perf/memory-baseline.sh Freelens
+#   scripts/perf/memory-baseline.sh srelens --settle 30 --samples 5
+#
+# Reports the median of --samples readings taken a second apart, after waiting
+# --settle seconds — startup allocation and lazy JIT make a single immediate
+# reading unrepresentative. Run it twice: once idle, once with the scenario
+# under test (clusters connected, watches live) already set up.
+set -euo pipefail
+
+usage() { sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'; exit "${1:-0}"; }
+
+APP="${1:-}"
+[ -z "$APP" ] && usage 1
+shift
+SETTLE=10
+SAMPLES=5
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --settle) SETTLE="$2"; shift 2 ;;
+    --samples) SAMPLES="$2"; shift 2 ;;
+    -h|--help) usage 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+# Every PID whose EXECUTABLE is the app — matched on the program path, never
+# on arguments. Matching command lines (`pgrep -f`) is wrong here: any shell,
+# editor, or build tool run from a directory named after the app matches too,
+# and each one silently inflates the total. Matching the executable path still
+# catches Electron's helper binaries, which live under the app bundle.
+# Matched on the executable's BASENAME, not its directory: this repo lives in
+# a path containing "srelens", so a path match pulls in every unrelated tool
+# built or run from here (esbuild, node, ...). A basename match still catches
+# Electron's "<App> Helper (Renderer)" binaries.
+app_pids() {
+  ps -A -o pid=,comm= 2>/dev/null | awk -v app="$(echo "$APP" | tr '[:upper:]' '[:lower:]')" '
+    {
+      pid = $1
+      $1 = ""
+      sub(/^ +/, "")
+      path = tolower($0)
+      n = split(path, parts, "/")
+      if (index(parts[n], app) > 0) print pid
+    }' || true
+}
+
+# The matched processes, for the operator to eyeball. Anything unexpected here
+# (a headless MCP server, a second instance) invalidates the reading.
+print_matched() {
+  ps -A -o pid=,rss=,comm= 2>/dev/null | awk -v app="$(echo "$APP" | tr '[:upper:]' '[:lower:]')" '
+    {
+      pid = $1; rss = $2
+      $1 = ""; $2 = ""
+      sub(/^ +/, "")
+      path = tolower($0)
+      n = split(path, parts, "/")
+      if (index(parts[n], app) > 0) printf "  %-8s %8.1f MiB  %s\n", pid, rss / 1024, $0
+    }'
+}
+
+# Total RSS in MiB across those PIDs. `ps` reports RSS in KiB on both macOS
+# and Linux, which is why this needs no per-platform branch.
+total_rss_mib() {
+  local pids
+  pids="$(app_pids | tr '\n' ',' | sed 's/,$//')"
+  [ -z "$pids" ] && { echo ""; return; }
+  ps -o rss= -p "$pids" 2>/dev/null | awk '{sum += $1} END {printf "%.1f", sum / 1024}'
+}
+
+if [ -z "$(app_pids)" ]; then
+  echo "No running process matches '$APP'. Start it first, then re-run." >&2
+  exit 1
+fi
+
+echo "Settling for ${SETTLE}s before sampling '$APP'..." >&2
+sleep "$SETTLE"
+
+readings=()
+for _ in $(seq "$SAMPLES"); do
+  reading="$(total_rss_mib)"
+  [ -z "$reading" ] && { echo "'$APP' exited while sampling." >&2; exit 1; }
+  readings+=("$reading")
+  sleep 1
+done
+
+process_count="$(app_pids | wc -l | tr -d ' ')"
+median="$(printf '%s\n' "${readings[@]}" | sort -n | awk '{a[NR]=$1} END {print (NR % 2) ? a[(NR+1)/2] : (a[NR/2] + a[NR/2+1]) / 2}')"
+
+echo "app:        $APP"
+echo "processes:  $process_count"
+echo "samples:    ${readings[*]}"
+echo "median RSS: ${median} MiB"
+echo "counted:"
+print_matched

--- a/scripts/perf/memory-baseline.sh
+++ b/scripts/perf/memory-baseline.sh
@@ -7,80 +7,126 @@
 # plus the OS WebView's own processes. Measuring one process would flatter
 # whichever architecture hides more of itself in children.
 #
-# Usage:
-#   scripts/perf/memory-baseline.sh srelens
-#   scripts/perf/memory-baseline.sh Freelens
-#   scripts/perf/memory-baseline.sh srelens --settle 30 --samples 5
+# Processes are collected three ways, unioned:
+#   1. roots     — executables whose basename matches the app name
+#   2. children  — every descendant of those roots, by PPID
+#   3. --include — processes matching an extra pattern (see the macOS note)
 #
-# Reports the median of --samples readings taken a second apart, after waiting
-# --settle seconds — startup allocation and lazy JIT make a single immediate
-# reading unrepresentative. Run it twice: once idle, once with the scenario
-# under test (clusters connected, watches live) already set up.
+# ON macOS THIS SCRIPT CANNOT ATTRIBUTE THE WEBVIEW BY ITSELF. WKWebView's
+# helpers (com.apple.WebKit.WebContent / .GPU / .Networking) are XPC services
+# adopted by launchd: their parent is PID 1, not the app, and their argv names
+# no client. They are neither descendants nor name matches, yet they hold the
+# bulk of a Tauri app's memory — omitting them understates the Tauri side and
+# flatters srelens. Measure on a machine where NO OTHER WebKit app is running
+# (no Safari, no other Tauri/WebKit app) and pass them in explicitly:
+#
+#   scripts/perf/memory-baseline.sh srelens --include com.apple.WebKit
+#
+# The script refuses to report a macOS total while unattributed WebKit
+# processes exist and --include was not given, rather than printing a number
+# that is quietly too low.
+#
+# Usage:
+#   scripts/perf/memory-baseline.sh srelens --include com.apple.WebKit
+#   scripts/perf/memory-baseline.sh Freelens --settle 30 --samples 5
 set -euo pipefail
 
-usage() { sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'; exit "${1:-0}"; }
+usage() { sed -n '2,31p' "$0" | sed 's/^# \{0,1\}//'; exit "${1:-0}"; }
 
 APP="${1:-}"
 [ -z "$APP" ] && usage 1
 shift
 SETTLE=10
 SAMPLES=5
+INCLUDE=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --settle) SETTLE="$2"; shift 2 ;;
     --samples) SAMPLES="$2"; shift 2 ;;
+    --include) INCLUDE="$2"; shift 2 ;;
     -h|--help) usage 0 ;;
     *) echo "unknown argument: $1" >&2; exit 1 ;;
   esac
 done
 
-# Every PID whose EXECUTABLE is the app — matched on the program path, never
-# on arguments. Matching command lines (`pgrep -f`) is wrong here: any shell,
-# editor, or build tool run from a directory named after the app matches too,
-# and each one silently inflates the total. Matching the executable path still
-# catches Electron's helper binaries, which live under the app bundle.
-# Matched on the executable's BASENAME, not its directory: this repo lives in
-# a path containing "srelens", so a path match pulls in every unrelated tool
-# built or run from here (esbuild, node, ...). A basename match still catches
-# Electron's "<App> Helper (Renderer)" binaries.
-app_pids() {
-  ps -A -o pid=,comm= 2>/dev/null | awk -v app="$(echo "$APP" | tr '[:upper:]' '[:lower:]')" '
-    {
-      pid = $1
-      $1 = ""
-      sub(/^ +/, "")
-      path = tolower($0)
-      n = split(path, parts, "/")
-      if (index(parts[n], app) > 0) print pid
-    }' || true
+APP_LOWER="$(echo "$APP" | tr '[:upper:]' '[:lower:]')"
+
+# Root PIDs: matched on the executable's BASENAME, never on arguments. An
+# argument match (`pgrep -f`) is wrong here — this repo's own path contains
+# "srelens", so every shell and build tool run from it would match.
+root_pids() {
+  ps -A -o pid=,comm= 2>/dev/null | awk -v app="$APP_LOWER" '
+    { pid = $1; $1 = ""; sub(/^ +/, ""); n = split(tolower($0), parts, "/")
+      if (index(parts[n], app) > 0) print pid }'
 }
 
-# The matched processes, for the operator to eyeball. Anything unexpected here
-# (a headless MCP server, a second instance) invalidates the reading.
-print_matched() {
-  ps -A -o pid=,rss=,comm= 2>/dev/null | awk -v app="$(echo "$APP" | tr '[:upper:]' '[:lower:]')" '
-    {
-      pid = $1; rss = $2
-      $1 = ""; $2 = ""
-      sub(/^ +/, "")
-      path = tolower($0)
-      n = split(path, parts, "/")
-      if (index(parts[n], app) > 0) printf "  %-8s %8.1f MiB  %s\n", pid, rss / 1024, $0
-    }'
+# Roots plus every descendant, so Electron's differently-named helpers and
+# Linux WebKitGTK's WebKitWebProcess (both real children) are counted.
+tree_pids() {
+  local roots frontier next pid children
+  roots="$(root_pids)"
+  [ -z "$roots" ] && return
+  echo "$roots"
+  frontier="$roots"
+  while [ -n "$(echo "$frontier" | tr -d '[:space:]')" ]; do
+    next=""
+    for pid in $frontier; do
+      children="$(ps -A -o pid=,ppid= 2>/dev/null | awk -v p="$pid" '$2 == p { print $1 }')"
+      [ -n "$children" ] && next="$next $children"
+    done
+    [ -z "$(echo "$next" | tr -d '[:space:]')" ] && break
+    echo "$next" | tr ' ' '\n' | grep -v '^$'
+    frontier="$next"
+  done
 }
 
-# Total RSS in MiB across those PIDs. `ps` reports RSS in KiB on both macOS
-# and Linux, which is why this needs no per-platform branch.
+# Extra processes named by --include, matched against the full command.
+include_pids() {
+  [ -z "$INCLUDE" ] && return
+  ps -A -o pid=,args= 2>/dev/null | awk -v pat="$INCLUDE" '
+    { pid = $1; $1 = ""; if (index($0, pat) > 0) print pid }'
+}
+
+all_pids() {
+  { tree_pids; include_pids; } | grep -v '^$' | sort -u -n
+}
+
+# Unattributable WebKit XPC services: launchd-parented, argv names no client.
+orphan_webkit_pids() {
+  ps -A -o pid=,ppid=,comm= 2>/dev/null | awk '
+    $2 == 1 && index($0, "com.apple.WebKit") > 0 { print $1 }'
+}
+
+# `ps` reports RSS in KiB on both macOS and Linux — no per-platform branch.
 total_rss_mib() {
   local pids
-  pids="$(app_pids | tr '\n' ',' | sed 's/,$//')"
+  pids="$(all_pids | tr '\n' ',' | sed 's/,$//')"
   [ -z "$pids" ] && { echo ""; return; }
   ps -o rss= -p "$pids" 2>/dev/null | awk '{sum += $1} END {printf "%.1f", sum / 1024}'
 }
 
-if [ -z "$(app_pids)" ]; then
+if [ -z "$(root_pids)" ]; then
   echo "No running process matches '$APP'. Start it first, then re-run." >&2
   exit 1
+fi
+
+# Refuse to publish a knowingly-low macOS number.
+if [ "$(uname -s)" = "Darwin" ] && [ -z "$INCLUDE" ]; then
+  orphans="$(orphan_webkit_pids)"
+  if [ -n "$orphans" ]; then
+    orphan_mib="$(ps -o rss= -p "$(echo "$orphans" | tr '\n' ',' | sed 's/,$//')" 2>/dev/null \
+      | awk '{sum += $1} END {printf "%.1f", sum / 1024}')"
+    {
+      echo "REFUSING TO REPORT: $(echo "$orphans" | wc -l | tr -d ' ') launchd-parented"
+      echo "com.apple.WebKit processes are running, holding ${orphan_mib} MiB that this"
+      echo "script cannot attribute to an app (PPID 1, no client in argv)."
+      echo
+      echo "For a Tauri app those ARE its WebView, and excluding them understates it."
+      echo "Quit every other WebKit app (Safari included), then re-run with:"
+      echo "  $0 $APP --include com.apple.WebKit"
+    } >&2
+    exit 2
+  fi
 fi
 
 echo "Settling for ${SETTLE}s before sampling '$APP'..." >&2
@@ -94,12 +140,17 @@ for _ in $(seq "$SAMPLES"); do
   sleep 1
 done
 
-process_count="$(app_pids | wc -l | tr -d ' ')"
-median="$(printf '%s\n' "${readings[@]}" | sort -n | awk '{a[NR]=$1} END {print (NR % 2) ? a[(NR+1)/2] : (a[NR/2] + a[NR/2+1]) / 2}')"
+median="$(printf '%s\n' "${readings[@]}" | sort -n \
+  | awk '{a[NR]=$1} END {print (NR % 2) ? a[(NR+1)/2] : (a[NR/2] + a[NR/2+1]) / 2}')"
 
 echo "app:        $APP"
-echo "processes:  $process_count"
+echo "processes:  $(all_pids | wc -l | tr -d ' ')"
 echo "samples:    ${readings[*]}"
 echo "median RSS: ${median} MiB"
 echo "counted:"
-print_matched
+# Every counted process, so contamination (a second instance, a stray headless
+# server, an unrelated WebKit client) is visible instead of averaged in.
+for pid in $(all_pids); do
+  ps -o pid=,rss=,comm= -p "$pid" 2>/dev/null \
+    | awk '{ pid = $1; rss = $2; $1 = ""; $2 = ""; sub(/^ +/, ""); printf "  %-8s %8.1f MiB  %s\n", pid, rss / 1024, $0 }'
+done

--- a/scripts/perf/memory-baseline.sh
+++ b/scripts/perf/memory-baseline.sh
@@ -120,8 +120,14 @@ if [ -z "$(root_pids)" ]; then
   exit 1
 fi
 
-# Refuse to publish a knowingly-low macOS number.
-if [ "$(uname -s)" = "Darwin" ] && [ -z "$INCLUDE" ]; then
+# Refuse to publish a knowingly-low macOS number. Called before the settle
+# delay AND before every sample: a WebView is created lazily, so helpers can
+# appear after the app root is already visible — passing the guard once at
+# startup would then wave through the exact understated total it exists to
+# prevent.
+assert_webkit_attributable() {
+  [ "$(uname -s)" != "Darwin" ] && return 0
+  [ -n "$INCLUDE" ] && return 0
   orphans="$(orphan_webkit_pids)"
   if [ -n "$orphans" ]; then
     orphan_mib="$(ps -o rss= -p "$(echo "$orphans" | tr '\n' ',' | sed 's/,$//')" 2>/dev/null \
@@ -137,7 +143,10 @@ if [ "$(uname -s)" = "Darwin" ] && [ -z "$INCLUDE" ]; then
     } >&2
     exit 2
   fi
-fi
+  return 0
+}
+
+assert_webkit_attributable
 
 echo "Settling for ${SETTLE}s before sampling '$APP'..." >&2
 sleep "$SETTLE"
@@ -149,6 +158,8 @@ for _ in $(seq "$SAMPLES"); do
   # total stays nonempty after the app has quit — and the median would then
   # describe orphaned helpers rather than the application.
   [ -z "$(root_pids)" ] && { echo "'$APP' exited while sampling — discarding." >&2; exit 1; }
+  # Helpers may have appeared during the settle delay or between samples.
+  assert_webkit_attributable
   reading="$(total_rss_mib)"
   [ -z "$reading" ] && { echo "'$APP' exited while sampling — discarding." >&2; exit 1; }
   readings+=("$reading")

--- a/scripts/perf/memory-baseline.sh
+++ b/scripts/perf/memory-baseline.sh
@@ -134,11 +134,19 @@ sleep "$SETTLE"
 
 readings=()
 for _ in $(seq "$SAMPLES"); do
+  # Liveness is checked on the ROOTS, not on the aggregate reading. With
+  # --include, launchd-owned WebKit helpers outlive the app they served, so a
+  # total stays nonempty after the app has quit — and the median would then
+  # describe orphaned helpers rather than the application.
+  [ -z "$(root_pids)" ] && { echo "'$APP' exited while sampling — discarding." >&2; exit 1; }
   reading="$(total_rss_mib)"
-  [ -z "$reading" ] && { echo "'$APP' exited while sampling." >&2; exit 1; }
+  [ -z "$reading" ] && { echo "'$APP' exited while sampling — discarding." >&2; exit 1; }
   readings+=("$reading")
   sleep 1
 done
+# The settle delay and sampling window are both long enough for a crash to
+# land after the final reading, so confirm the app is still up at the end too.
+[ -z "$(root_pids)" ] && { echo "'$APP' exited during sampling — discarding." >&2; exit 1; }
 
 median="$(printf '%s\n' "${readings[@]}" | sort -n \
   | awk '{a[NR]=$1} END {print (NR % 2) ? a[(NR+1)/2] : (a[NR/2] + a[NR/2+1]) / 2}')"

--- a/scripts/perf/memory-baseline.sh
+++ b/scripts/perf/memory-baseline.sh
@@ -127,18 +127,35 @@ fi
 # prevent.
 assert_webkit_attributable() {
   [ "$(uname -s)" != "Darwin" ] && return 0
-  [ -n "$INCLUDE" ] && return 0
-  orphans="$(orphan_webkit_pids)"
+  # Coverage is what matters, not whether --include was passed: a narrow
+  # pattern like `--include WebContent` picks up the renderer while silently
+  # dropping the GPU and Networking services, which is the same understated
+  # total the guard exists to catch. So check which orphans are ACTUALLY in
+  # the collected set and complain about the ones that are not.
+  collected=" $(all_pids | tr '\n' ' ') "
+  orphans=""
+  for orphan_pid in $(orphan_webkit_pids); do
+    case "$collected" in
+      *" $orphan_pid "*) ;;
+      *) orphans="$orphans $orphan_pid" ;;
+    esac
+  done
+  orphans="$(echo "$orphans" | tr ' ' '\n' | grep -v '^$' || true)"
   if [ -n "$orphans" ]; then
     orphan_mib="$(ps -o rss= -p "$(echo "$orphans" | tr '\n' ',' | sed 's/,$//')" 2>/dev/null \
       | awk '{sum += $1} END {printf "%.1f", sum / 1024}')"
     {
       echo "REFUSING TO REPORT: $(echo "$orphans" | wc -l | tr -d ' ') launchd-parented"
-      echo "com.apple.WebKit processes are running, holding ${orphan_mib} MiB that this"
-      echo "script cannot attribute to an app (PPID 1, no client in argv)."
+      echo "com.apple.WebKit process(es) are running and NOT in the counted set,"
+      echo "holding ${orphan_mib} MiB this script cannot attribute (PPID 1, no"
+      echo "client in argv):"
+      echo "$orphans" | while read -r p; do
+        [ -n "$p" ] && ps -o pid=,comm= -p "$p" 2>/dev/null | sed 's/^/  /'
+      done
       echo
       echo "For a Tauri app those ARE its WebView, and excluding them understates it."
-      echo "Quit every other WebKit app (Safari included), then re-run with:"
+      echo "Quit every other WebKit app (Safari included), then re-run with a"
+      echo "pattern that covers all of them:"
       echo "  $0 $APP --include com.apple.WebKit"
     } >&2
     exit 2
@@ -152,6 +169,7 @@ echo "Settling for ${SETTLE}s before sampling '$APP'..." >&2
 sleep "$SETTLE"
 
 readings=()
+snapshots=()
 for _ in $(seq "$SAMPLES"); do
   # Liveness is checked on the ROOTS, not on the aggregate reading. With
   # --include, launchd-owned WebKit helpers outlive the app they served, so a
@@ -160,9 +178,16 @@ for _ in $(seq "$SAMPLES"); do
   [ -z "$(root_pids)" ] && { echo "'$APP' exited while sampling — discarding." >&2; exit 1; }
   # Helpers may have appeared during the settle delay or between samples.
   assert_webkit_attributable
-  reading="$(total_rss_mib)"
+  # The PID set is captured ONCE per sample and the reading taken from that
+  # exact set, so the audit below describes the processes that actually
+  # produced these numbers — not whatever happens to be running at print time.
+  snapshot="$(all_pids)"
+  [ -z "$snapshot" ] && { echo "'$APP' exited while sampling — discarding." >&2; exit 1; }
+  reading="$(ps -o rss= -p "$(echo "$snapshot" | tr '\n' ',' | sed 's/,$//')" 2>/dev/null \
+    | awk '{sum += $1} END {printf "%.1f", sum / 1024}')"
   [ -z "$reading" ] && { echo "'$APP' exited while sampling — discarding." >&2; exit 1; }
   readings+=("$reading")
+  snapshots+=("$(echo "$snapshot" | tr '\n' ' ')")
   sleep 1
 done
 # The settle delay and sampling window are both long enough for a crash to
@@ -177,9 +202,24 @@ echo "processes:  $(all_pids | wc -l | tr -d ' ')"
 echo "samples:    ${readings[*]}"
 echo "median RSS: ${median} MiB"
 echo "counted:"
-# Every counted process, so contamination (a second instance, a stray headless
-# server, an unrelated WebKit client) is visible instead of averaged in.
-for pid in $(all_pids); do
-  ps -o pid=,rss=,comm= -p "$pid" 2>/dev/null \
-    | awk '{ pid = $1; rss = $2; $1 = ""; $2 = ""; sub(/^ +/, ""); printf "  %-8s %8.1f MiB  %s\n", pid, rss / 1024, $0 }'
+# Every process that contributed to a reading, so contamination (a second
+# instance, a stray headless server, an unrelated WebKit client) is visible
+# instead of averaged in. A process present in only SOME samples is flagged:
+# it moved the numbers without being there throughout, which is exactly the
+# transient contamination a re-query at print time would have hidden.
+sampled_pids="$(printf '%s\n' "${snapshots[@]}" | tr ' ' '\n' | grep -v '^$' | sort -u -n)"
+for pid in $sampled_pids; do
+  seen=0
+  for snap in "${snapshots[@]}"; do
+    case " $snap " in *" $pid "*) seen=$((seen + 1)) ;; esac
+  done
+  detail="$(ps -o rss=,comm= -p "$pid" 2>/dev/null || true)"
+  if [ -z "$detail" ]; then
+    printf '  %-8s %13s  (exited during sampling) [%d/%d samples]\n' "$pid" "-" "$seen" "$SAMPLES"
+  else
+    echo "$detail" | awk -v pid="$pid" -v seen="$seen" -v total="$SAMPLES" '
+      { rss = $1; $1 = ""; sub(/^ +/, "")
+        flag = (seen == total) ? "" : sprintf(" [%d/%d samples]", seen, total)
+        printf "  %-8s %8.1f MiB  %s%s\n", pid, rss / 1024, $0, flag }'
+  fi
 done

--- a/scripts/perf/memory-baseline.sh
+++ b/scripts/perf/memory-baseline.sh
@@ -81,10 +81,20 @@ tree_pids() {
 }
 
 # Extra processes named by --include, matched against the full command.
+#
+# The measurement tooling must never measure itself: with the documented
+# `--include com.apple.WebKit`, that pattern is present in THIS script's own
+# argv (and in the shell that launched it, and any CI wrapper around it), so a
+# naive match adds the sampler's RSS to every reading. Self, the launching
+# shell, and anything whose command mentions this script are excluded.
+SELF_NAME="$(basename "$0")"
 include_pids() {
   [ -z "$INCLUDE" ] && return
-  ps -A -o pid=,args= 2>/dev/null | awk -v pat="$INCLUDE" '
-    { pid = $1; $1 = ""; if (index($0, pat) > 0) print pid }'
+  ps -A -o pid=,args= 2>/dev/null | awk -v pat="$INCLUDE" -v self="$$" -v parent="$PPID" -v script="$SELF_NAME" '
+    { pid = $1; $1 = ""
+      if (pid == self || pid == parent) next
+      if (index($0, script) > 0) next
+      if (index($0, pat) > 0) print pid }'
 }
 
 all_pids() {

--- a/scripts/perf/size-baseline.mjs
+++ b/scripts/perf/size-baseline.mjs
@@ -11,6 +11,10 @@
 //   node scripts/perf/size-baseline.mjs --json          # machine-readable
 //   node scripts/perf/size-baseline.mjs --check-regression [--max-growth 15]
 //
+// --tag / --comparison-tag pin each side to a specific release. Pin BOTH to
+// reproduce a dated table: without them each side resolves to whatever is
+// latest, so the numbers drift as either project ships.
+//
 // --check-regression compares the two most recent srelens stable releases and
 // exits non-zero if any artifact grew by more than --max-growth percent. Set
 // GITHUB_TOKEN to avoid the unauthenticated API rate limit.
@@ -266,18 +270,23 @@ export function compareBuckets(before, now, maxGrowth) {
 async function main() {
   const args = process.argv.slice(2);
   const maxGrowth = Number(args[args.indexOf("--max-growth") + 1]) || 15;
-  const tagIndex = args.indexOf("--tag");
-  const tag = tagIndex === -1 ? null : args[tagIndex + 1];
+  const arg = (name) => {
+    const i = args.indexOf(name);
+    return i === -1 ? null : args[i + 1];
+  };
+  const tag = arg("--tag");
+  const comparisonTag = arg("--comparison-tag");
 
   if (args.includes("--check-regression")) {
     process.exit(await checkRegression(maxGrowth, tag));
   }
 
-  // The tag pins OUR side to the release under test; the comparison project
-  // is always its own latest stable.
+  // Each side resolves to its own latest stable unless pinned. A release run
+  // pins only --tag (its own draft) and wants the comparison project's
+  // current release; a documented table pins both so it stays reproducible.
   const [srelens, comparison] = await Promise.all([
     releaseSizes(SRELENS_REPO, tag),
-    releaseSizes(COMPARISON_REPO, null),
+    releaseSizes(COMPARISON_REPO, comparisonTag),
   ]);
 
   if (args.includes("--json")) {

--- a/scripts/perf/size-baseline.mjs
+++ b/scripts/perf/size-baseline.mjs
@@ -127,7 +127,22 @@ export function bucketAssets(assets) {
   return { sizes, skipped };
 }
 
-async function latestStableSizes(repo) {
+/**
+ * Sizes for a repo's latest stable release, or for an explicit tag. The tag
+ * form is what a release run needs: the release being built is still a DRAFT
+ * until publish-release flips it, and drafts are excluded from the stable
+ * list — so without it the published table would describe the PREVIOUS
+ * release rather than the artifacts from this run.
+ */
+async function releaseSizes(repo, tag) {
+  if (tag) {
+    const { releases } = await allReleases(repo);
+    const release = releases.find((r) => r.tag_name === tag);
+    if (!release) {
+      throw new Error(`${repo} has no release tagged ${tag} (drafts need GITHUB_TOKEN)`);
+    }
+    return { tag: release.tag_name, ...bucketAssets(release.assets) };
+  }
   const [release] = await stableReleases(repo);
   if (!release) throw new Error(`${repo} has no stable release`);
   return { tag: release.tag_name, ...bucketAssets(release.assets) };
@@ -251,15 +266,18 @@ export function compareBuckets(before, now, maxGrowth) {
 async function main() {
   const args = process.argv.slice(2);
   const maxGrowth = Number(args[args.indexOf("--max-growth") + 1]) || 15;
+  const tagIndex = args.indexOf("--tag");
+  const tag = tagIndex === -1 ? null : args[tagIndex + 1];
 
   if (args.includes("--check-regression")) {
-    const tagIndex = args.indexOf("--tag");
-    process.exit(await checkRegression(maxGrowth, tagIndex === -1 ? null : args[tagIndex + 1]));
+    process.exit(await checkRegression(maxGrowth, tag));
   }
 
+  // The tag pins OUR side to the release under test; the comparison project
+  // is always its own latest stable.
   const [srelens, comparison] = await Promise.all([
-    latestStableSizes(SRELENS_REPO),
-    latestStableSizes(COMPARISON_REPO),
+    releaseSizes(SRELENS_REPO, tag),
+    releaseSizes(COMPARISON_REPO, null),
   ]);
 
   if (args.includes("--json")) {

--- a/scripts/perf/size-baseline.mjs
+++ b/scripts/perf/size-baseline.mjs
@@ -161,12 +161,33 @@ function markdownTable(srelens, comparison) {
   for (const key of keys) {
     const ours = srelens.sizes[key];
     const theirs = comparison.sizes[key];
-    const ratio = theirs ? `${Math.round((theirs.bytes / ours.bytes) * 10) / 10}× smaller` : "—";
     lines.push(
-      `| ${key} | ${mib(ours.bytes)} MiB | ${theirs ? `${mib(theirs.bytes)} MiB` : "—"} | ${ratio} |`,
+      `| ${key} | ${mib(ours.bytes)} MiB | ${theirs ? `${mib(theirs.bytes)} MiB` : "—"} | ${describeRatio(ours?.bytes, theirs?.bytes)} |`,
     );
   }
   return lines.join("\n");
+}
+
+/**
+ * How our artifact compares to theirs, in words. Branches on the direction
+ * rather than always saying "smaller": an unpinned run resolves whatever is
+ * latest, so if a future comparison release ships a smaller artifact this must
+ * report srelens as LARGER instead of printing "0.8× smaller" and implying a
+ * win that isn't there.
+ */
+export function describeRatio(ourBytes, theirBytes) {
+  if (!ourBytes || !theirBytes) return "—";
+  if (ourBytes === theirBytes) return "same size";
+  const [bigger, smaller] = ourBytes > theirBytes ? [ourBytes, theirBytes] : [theirBytes, ourBytes];
+  const factor = Math.round((bigger / smaller) * 10) / 10;
+  const direction = ourBytes > theirBytes ? "larger" : "smaller";
+  // Below 1.5x a multiple reads oddly ("1.1x smaller" for a 5% gap); percent
+  // is the honest way to describe near-parity.
+  if (factor < 1.5) {
+    const pct = Math.round(Math.abs((ourBytes - theirBytes) / theirBytes) * 1000) / 10;
+    return `${pct}% ${direction}`;
+  }
+  return `${factor}× ${direction}`;
 }
 
 async function checkRegression(maxGrowth, tag) {

--- a/scripts/perf/size-baseline.mjs
+++ b/scripts/perf/size-baseline.mjs
@@ -79,14 +79,33 @@ async function githubJson(path) {
   return res.json();
 }
 
-/** Every release, newest first — drafts included (they need GITHUB_TOKEN). */
+/** How many 100-item pages of releases to walk before giving up. */
+const MAX_RELEASE_PAGES = 5;
+
+/**
+ * Every release, newest first — drafts included (they need GITHUB_TOKEN).
+ *
+ * Paginated because release.yml cuts a dev PRERELEASE daily: a single page
+ * covers only a few weeks, so the previous STABLE release drops off it once
+ * two stables are far enough apart. Missing that baseline used to make the
+ * check report "nothing to compare" and pass, publishing an unmeasured
+ * release — so `complete` reports whether the walk actually reached the end,
+ * and the caller fails closed when it didn't.
+ */
 async function allReleases(repo) {
-  return githubJson(`/repos/${repo}/releases?per_page=30`);
+  const releases = [];
+  for (let page = 1; page <= MAX_RELEASE_PAGES; page++) {
+    const batch = await githubJson(`/repos/${repo}/releases?per_page=100&page=${page}`);
+    releases.push(...batch);
+    if (batch.length < 100) return { releases, complete: true };
+  }
+  return { releases, complete: false };
 }
 
 /** Stable (non-draft, non-prerelease) releases, newest first. */
 async function stableReleases(repo) {
-  return (await allReleases(repo)).filter((r) => !r.draft && !r.prerelease);
+  const { releases } = await allReleases(repo);
+  return releases.filter((r) => !r.draft && !r.prerelease);
 }
 
 /** Bucket a release's assets into { key: {name, bytes} }, plus what was skipped. */
@@ -136,7 +155,7 @@ async function checkRegression(maxGrowth, tag) {
   // after the whole pipeline is green), and drafts are excluded from the
   // stable list. Without --tag this would silently compare the two previous
   // published releases and never see the artifacts just built.
-  const releases = await allReleases(SRELENS_REPO);
+  const { releases, complete } = await allReleases(SRELENS_REPO);
   const current = tag
     ? releases.find((r) => r.tag_name === tag)
     : releases.find((r) => !r.draft && !r.prerelease);
@@ -148,6 +167,17 @@ async function checkRegression(maxGrowth, tag) {
     (r) => !r.draft && !r.prerelease && r.tag_name !== current.tag_name,
   );
   if (!previous) {
+    // Only safe to pass when the walk actually saw every release: then there
+    // genuinely is no earlier stable one (the first release ever). If the
+    // page cap cut the walk short, the baseline may simply be out of reach —
+    // that is an unmeasured release, not a clean one.
+    if (!complete) {
+      console.error(
+        `FAIL: no previous stable release within ${MAX_RELEASE_PAGES} pages of releases — ` +
+          "the baseline could not be read, so this release was never actually measured.",
+      );
+      return 1;
+    }
     console.log("No previous stable release to compare against.");
     return 0;
   }

--- a/scripts/perf/size-baseline.mjs
+++ b/scripts/perf/size-baseline.mjs
@@ -153,24 +153,69 @@ async function checkRegression(maxGrowth, tag) {
   }
   const now = bucketAssets(current.assets).sizes;
   const before = bucketAssets(previous.assets).sizes;
+  const verdict = compareBuckets(before, now, maxGrowth);
 
-  const rows = [];
-  let worst = 0;
-  for (const key of Object.keys(now).sort()) {
-    if (!before[key]) continue;
-    const pct = growthPct(before[key].bytes, now[key].bytes);
-    worst = Math.max(worst, pct);
-    rows.push(`  ${key.padEnd(22)} ${mib(before[key].bytes)} → ${mib(now[key].bytes)} MiB (${pct >= 0 ? "+" : ""}${pct}%)`);
-  }
   console.log(`Size change ${previous.tag_name} → ${current.tag_name}:`);
-  console.log(rows.join("\n") || "  (no comparable artifacts)");
+  console.log(verdict.rows.join("\n") || "  (no comparable artifacts)");
+  if (verdict.appeared.length) {
+    console.log(`\nNew installers (no previous size to compare): ${verdict.appeared.join(", ")}`);
+  }
 
-  if (worst > maxGrowth) {
-    console.error(`\nFAIL: an installer grew ${worst}%, over the ${maxGrowth}% budget.`);
+  if (!verdict.ok) {
+    console.error(`\nFAIL: ${verdict.reason}`);
     return 1;
   }
-  console.log(`\nOK: largest growth ${worst}% is within the ${maxGrowth}% budget.`);
+  console.log(`\nOK: largest growth ${verdict.worst}% is within the ${maxGrowth}% budget.`);
   return 0;
+}
+
+/**
+ * Compare two releases' buckets. Fails CLOSED: a bucket the previous release
+ * had and this one doesn't is a failure, not a skip — a renamed installer (a
+ * bundler update changing its filename) or an upload that silently dropped one
+ * would otherwise leave that artifact unguarded, and if EVERY bucket stopped
+ * classifying, an empty comparison would report success and let the release
+ * through unmeasured.
+ */
+export function compareBuckets(before, now, maxGrowth) {
+  const keys = [...new Set([...Object.keys(before), ...Object.keys(now)])].sort();
+  const rows = [];
+  const missing = [];
+  const appeared = [];
+  let worst = 0;
+  let compared = 0;
+
+  for (const key of keys) {
+    if (!now[key]) {
+      missing.push(key);
+      rows.push(`  ${key.padEnd(22)} ${mib(before[key].bytes)} MiB → MISSING`);
+      continue;
+    }
+    if (!before[key]) {
+      appeared.push(key);
+      continue;
+    }
+    const pct = growthPct(before[key].bytes, now[key].bytes);
+    worst = Math.max(worst, pct);
+    compared += 1;
+    rows.push(
+      `  ${key.padEnd(22)} ${mib(before[key].bytes)} → ${mib(now[key].bytes)} MiB (${pct >= 0 ? "+" : ""}${pct}%)`,
+    );
+  }
+
+  if (missing.length) {
+    return { rows, missing, appeared, worst, ok: false,
+      reason: `installer(s) present in the previous release are missing or no longer recognized: ${missing.join(", ")}` };
+  }
+  if (compared === 0) {
+    return { rows, missing, appeared, worst, ok: false,
+      reason: "no installers could be compared — the classifier or the upload is broken, so nothing was actually checked" };
+  }
+  if (worst > maxGrowth) {
+    return { rows, missing, appeared, worst, ok: false,
+      reason: `an installer grew ${worst}%, over the ${maxGrowth}% budget.` };
+  }
+  return { rows, missing, appeared, worst, ok: true, reason: "" };
 }
 
 async function main() {

--- a/scripts/perf/size-baseline.mjs
+++ b/scripts/perf/size-baseline.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+// Download-size baselines for issue #31.
+//
+// Reads published release assets straight from the GitHub Releases API — for
+// srelens and for a comparison project — and buckets them by (os, arch,
+// format) so like is compared with like. Nothing is built or estimated here:
+// every number is the byte size of an artifact a user would actually download.
+//
+// Usage:
+//   node scripts/perf/size-baseline.mjs                 # markdown table
+//   node scripts/perf/size-baseline.mjs --json          # machine-readable
+//   node scripts/perf/size-baseline.mjs --check-regression [--max-growth 15]
+//
+// --check-regression compares the two most recent srelens stable releases and
+// exits non-zero if any artifact grew by more than --max-growth percent. Set
+// GITHUB_TOKEN to avoid the unauthenticated API rate limit.
+
+const SRELENS_REPO = "srelens/srelens";
+const COMPARISON_REPO = "freelensapp/freelens";
+
+/** Artifacts that are not themselves downloads: signatures, digests, SBOMs. */
+const NOT_AN_ARTIFACT = /\.(sig|sha256|asc|spdx\.json)$|-sbom|^latest\.json$/i;
+
+/**
+ * Classify a release asset filename into a comparable bucket. Returns null for
+ * anything unrecognized rather than guessing — an unclassified artifact is
+ * reported as skipped, never silently folded into another bucket.
+ */
+export function classifyAsset(name) {
+  if (NOT_AN_ARTIFACT.test(name)) return null;
+  // "portable" builds are a different distribution shape; keep them out of the
+  // installer comparison rather than double-counting a platform.
+  if (/portable/i.test(name)) return null;
+
+  const format = name.match(/\.(dmg|deb|rpm|AppImage|msi|exe|pkg)$/i)?.[1];
+  if (!format) return null;
+  // A .tar.gz app bundle is an update payload, not an installer.
+  if (/\.app\.tar\.gz$/i.test(name)) return null;
+
+  const os = /macos|darwin|\.dmg$|\.pkg$/i.test(name)
+    ? "macOS"
+    : /windows|win32|\.msi$|-setup\.exe$|\.exe$/i.test(name)
+      ? "Windows"
+      : /linux|\.deb$|\.rpm$|\.AppImage$/i.test(name)
+        ? "Linux"
+        : null;
+  if (!os) return null;
+
+  const arch = /aarch64|arm64/i.test(name)
+    ? "arm64"
+    : /x86_64|amd64|x64/i.test(name)
+      ? "x64"
+      : null;
+  if (!arch) return null;
+
+  // Canonical casing so the table names the artifact the way its ecosystem
+  // spells it (".AppImage", not ".appimage").
+  const canonical = { dmg: "dmg", deb: "deb", rpm: "rpm", appimage: "AppImage", msi: "msi", exe: "exe", pkg: "pkg" };
+  const ext = canonical[format.toLowerCase()];
+  return { os, arch, format: ext, key: `${os} ${arch} .${ext}` };
+}
+
+/** MiB with one decimal — the unit release pages use. */
+export function mib(bytes) {
+  return Math.round((bytes / 1024 / 1024) * 10) / 10;
+}
+
+/** Percent growth from `before` to `after`, rounded to one decimal. */
+export function growthPct(before, after) {
+  if (!before) return null;
+  return Math.round(((after - before) / before) * 1000) / 10;
+}
+
+async function githubJson(path) {
+  const headers = { accept: "application/vnd.github+json", "user-agent": "srelens-perf-baseline" };
+  if (process.env.GITHUB_TOKEN) headers.authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  const res = await fetch(`https://api.github.com${path}`, { headers });
+  if (!res.ok) throw new Error(`GitHub API ${path} failed: ${res.status} ${res.statusText}`);
+  return res.json();
+}
+
+/** Stable (non-draft, non-prerelease) releases, newest first. */
+async function stableReleases(repo) {
+  const releases = await githubJson(`/repos/${repo}/releases?per_page=30`);
+  return releases.filter((r) => !r.draft && !r.prerelease);
+}
+
+/** Bucket a release's assets into { key: {name, bytes} }, plus what was skipped. */
+export function bucketAssets(assets) {
+  const sizes = {};
+  const skipped = [];
+  for (const asset of assets) {
+    const bucket = classifyAsset(asset.name);
+    if (!bucket) {
+      if (!NOT_AN_ARTIFACT.test(asset.name)) skipped.push(asset.name);
+      continue;
+    }
+    // Keep the smallest when a bucket somehow collides, and record the name so
+    // the table always says exactly which file a number came from.
+    if (!sizes[bucket.key] || asset.size < sizes[bucket.key].bytes) {
+      sizes[bucket.key] = { name: asset.name, bytes: asset.size };
+    }
+  }
+  return { sizes, skipped };
+}
+
+async function latestStableSizes(repo) {
+  const [release] = await stableReleases(repo);
+  if (!release) throw new Error(`${repo} has no stable release`);
+  return { tag: release.tag_name, ...bucketAssets(release.assets) };
+}
+
+function markdownTable(srelens, comparison) {
+  const keys = Object.keys(srelens.sizes).sort();
+  const lines = [
+    `| Installer | srelens \`${srelens.tag}\` | Freelens \`${comparison.tag}\` | Difference |`,
+    "| --- | ---: | ---: | ---: |",
+  ];
+  for (const key of keys) {
+    const ours = srelens.sizes[key];
+    const theirs = comparison.sizes[key];
+    const ratio = theirs ? `${Math.round((theirs.bytes / ours.bytes) * 10) / 10}× smaller` : "—";
+    lines.push(
+      `| ${key} | ${mib(ours.bytes)} MiB | ${theirs ? `${mib(theirs.bytes)} MiB` : "—"} | ${ratio} |`,
+    );
+  }
+  return lines.join("\n");
+}
+
+async function checkRegression(maxGrowth) {
+  const releases = await stableReleases(SRELENS_REPO);
+  if (releases.length < 2) {
+    console.log("Only one stable release published — no previous release to compare against.");
+    return 0;
+  }
+  const [current, previous] = releases;
+  const now = bucketAssets(current.assets).sizes;
+  const before = bucketAssets(previous.assets).sizes;
+
+  const rows = [];
+  let worst = 0;
+  for (const key of Object.keys(now).sort()) {
+    if (!before[key]) continue;
+    const pct = growthPct(before[key].bytes, now[key].bytes);
+    worst = Math.max(worst, pct);
+    rows.push(`  ${key.padEnd(22)} ${mib(before[key].bytes)} → ${mib(now[key].bytes)} MiB (${pct >= 0 ? "+" : ""}${pct}%)`);
+  }
+  console.log(`Size change ${previous.tag_name} → ${current.tag_name}:`);
+  console.log(rows.join("\n") || "  (no comparable artifacts)");
+
+  if (worst > maxGrowth) {
+    console.error(`\nFAIL: an installer grew ${worst}%, over the ${maxGrowth}% budget.`);
+    return 1;
+  }
+  console.log(`\nOK: largest growth ${worst}% is within the ${maxGrowth}% budget.`);
+  return 0;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const maxGrowth = Number(args[args.indexOf("--max-growth") + 1]) || 15;
+
+  if (args.includes("--check-regression")) {
+    process.exit(await checkRegression(maxGrowth));
+  }
+
+  const [srelens, comparison] = await Promise.all([
+    latestStableSizes(SRELENS_REPO),
+    latestStableSizes(COMPARISON_REPO),
+  ]);
+
+  if (args.includes("--json")) {
+    console.log(JSON.stringify({ srelens, comparison, measuredBy: "release asset bytes" }, null, 2));
+    return;
+  }
+
+  console.log(markdownTable(srelens, comparison));
+  for (const [label, data] of [["srelens", srelens], ["comparison", comparison]]) {
+    if (data.skipped.length) {
+      console.log(`\n<!-- ${label} assets not classified: ${data.skipped.join(", ")} -->`);
+    }
+  }
+}
+
+// Only run when invoked directly, so the helpers above stay unit-testable.
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}

--- a/scripts/perf/size-baseline.mjs
+++ b/scripts/perf/size-baseline.mjs
@@ -79,10 +79,14 @@ async function githubJson(path) {
   return res.json();
 }
 
+/** Every release, newest first — drafts included (they need GITHUB_TOKEN). */
+async function allReleases(repo) {
+  return githubJson(`/repos/${repo}/releases?per_page=30`);
+}
+
 /** Stable (non-draft, non-prerelease) releases, newest first. */
 async function stableReleases(repo) {
-  const releases = await githubJson(`/repos/${repo}/releases?per_page=30`);
-  return releases.filter((r) => !r.draft && !r.prerelease);
+  return (await allReleases(repo)).filter((r) => !r.draft && !r.prerelease);
 }
 
 /** Bucket a release's assets into { key: {name, bytes} }, plus what was skipped. */
@@ -127,13 +131,26 @@ function markdownTable(srelens, comparison) {
   return lines.join("\n");
 }
 
-async function checkRegression(maxGrowth) {
-  const releases = await stableReleases(SRELENS_REPO);
-  if (releases.length < 2) {
-    console.log("Only one stable release published — no previous release to compare against.");
+async function checkRegression(maxGrowth, tag) {
+  // On main the release under test is still a DRAFT (release.yml flips it only
+  // after the whole pipeline is green), and drafts are excluded from the
+  // stable list. Without --tag this would silently compare the two previous
+  // published releases and never see the artifacts just built.
+  const releases = await allReleases(SRELENS_REPO);
+  const current = tag
+    ? releases.find((r) => r.tag_name === tag)
+    : releases.find((r) => !r.draft && !r.prerelease);
+  if (!current) {
+    console.error(`No release found for tag ${tag}. Is GITHUB_TOKEN set (drafts need auth)?`);
+    return 1;
+  }
+  const previous = releases.find(
+    (r) => !r.draft && !r.prerelease && r.tag_name !== current.tag_name,
+  );
+  if (!previous) {
+    console.log("No previous stable release to compare against.");
     return 0;
   }
-  const [current, previous] = releases;
   const now = bucketAssets(current.assets).sizes;
   const before = bucketAssets(previous.assets).sizes;
 
@@ -161,7 +178,8 @@ async function main() {
   const maxGrowth = Number(args[args.indexOf("--max-growth") + 1]) || 15;
 
   if (args.includes("--check-regression")) {
-    process.exit(await checkRegression(maxGrowth));
+    const tagIndex = args.indexOf("--tag");
+    process.exit(await checkRegression(maxGrowth, tagIndex === -1 ? null : args[tagIndex + 1]));
   }
 
   const [srelens, comparison] = await Promise.all([

--- a/scripts/perf/size-baseline.test.mjs
+++ b/scripts/perf/size-baseline.test.mjs
@@ -7,7 +7,9 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { bucketAssets, classifyAsset, growthPct, mib } from "./size-baseline.mjs";
+import { bucketAssets, classifyAsset, compareBuckets, growthPct, mib } from "./size-baseline.mjs";
+
+const bucket = (bytes) => ({ name: "x", bytes });
 
 test("classifies srelens release assets", () => {
   assert.equal(classifyAsset("srelens_0.5.0_aarch64.dmg").key, "macOS arm64 .dmg");
@@ -51,6 +53,52 @@ test("an unclassifiable artifact is reported, not silently dropped", () => {
   assert.deepEqual(Object.keys(sizes), ["macOS x64 .dmg"]);
   // Signatures are known non-artifacts; the genuinely unknown one surfaces.
   assert.deepEqual(skipped, ["mystery-build.tar.zst"]);
+});
+
+test("passes a release within the growth budget", () => {
+  const verdict = compareBuckets(
+    { "macOS x64 .dmg": bucket(1000), "Linux x64 .deb": bucket(1000) },
+    { "macOS x64 .dmg": bucket(1050), "Linux x64 .deb": bucket(1100) },
+    15,
+  );
+  assert.equal(verdict.ok, true);
+  assert.equal(verdict.worst, 10);
+});
+
+test("fails a release that blows the growth budget", () => {
+  const verdict = compareBuckets({ "macOS x64 .dmg": bucket(1000) }, { "macOS x64 .dmg": bucket(1200) }, 15);
+  assert.equal(verdict.ok, false);
+  assert.match(verdict.reason, /grew 20%/);
+});
+
+test("fails CLOSED when a bucket the previous release had disappears", () => {
+  // A bundler renaming an installer, or an upload silently dropping one, must
+  // not leave that artifact quietly unguarded.
+  const verdict = compareBuckets(
+    { "macOS x64 .dmg": bucket(1000), "Linux x64 .deb": bucket(1000) },
+    { "macOS x64 .dmg": bucket(1000) },
+    15,
+  );
+  assert.equal(verdict.ok, false);
+  assert.match(verdict.reason, /Linux x64 \.deb/);
+});
+
+test("fails CLOSED when nothing can be compared at all", () => {
+  // The dangerous case: if the classifier stops recognizing every artifact,
+  // an empty comparison must not report success and let the release through.
+  const verdict = compareBuckets({}, {}, 15);
+  assert.equal(verdict.ok, false);
+  assert.match(verdict.reason, /no installers could be compared/);
+});
+
+test("a brand-new installer is reported, not treated as a regression", () => {
+  const verdict = compareBuckets(
+    { "macOS x64 .dmg": bucket(1000) },
+    { "macOS x64 .dmg": bucket(1000), "Linux arm64 .deb": bucket(5000) },
+    15,
+  );
+  assert.equal(verdict.ok, true);
+  assert.deepEqual(verdict.appeared, ["Linux arm64 .deb"]);
 });
 
 test("mib and growthPct round the way the published table does", () => {

--- a/scripts/perf/size-baseline.test.mjs
+++ b/scripts/perf/size-baseline.test.mjs
@@ -7,7 +7,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { bucketAssets, classifyAsset, compareBuckets, growthPct, mib } from "./size-baseline.mjs";
+import { bucketAssets, classifyAsset, compareBuckets, describeRatio, growthPct, mib } from "./size-baseline.mjs";
 
 const bucket = (bytes) => ({ name: "x", bytes });
 
@@ -107,4 +107,15 @@ test("mib and growthPct round the way the published table does", () => {
   assert.equal(growthPct(100, 90), -10);
   // No previous size means no percentage to report, not a divide-by-zero.
   assert.equal(growthPct(0, 50), null);
+});
+
+test("describes the ratio in the correct direction", () => {
+  assert.equal(describeRatio(100, 1000), "10× smaller");
+  // The case that used to print a misleading "0.8× smaller": if a future
+  // comparison release is smaller than ours, say so plainly.
+  assert.equal(describeRatio(1000, 800), "25% larger");
+  assert.equal(describeRatio(1000, 1000), "same size");
+  // Near-parity rounds to 1.0×, which is not a meaningful multiple.
+  assert.equal(describeRatio(1000, 1050), "4.8% smaller");
+  assert.equal(describeRatio(1000, undefined), "—");
 });

--- a/scripts/perf/size-baseline.test.mjs
+++ b/scripts/perf/size-baseline.test.mjs
@@ -1,0 +1,62 @@
+// Unit tests for the size-baseline classifier (#31). Run with:
+//   node --test scripts/perf/size-baseline.test.mjs
+//
+// The classifier is what makes the published table trustworthy: a wrong bucket
+// would compare a macOS installer against a Linux one, and a silent null would
+// drop a platform from the comparison entirely.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { bucketAssets, classifyAsset, growthPct, mib } from "./size-baseline.mjs";
+
+test("classifies srelens release assets", () => {
+  assert.equal(classifyAsset("srelens_0.5.0_aarch64.dmg").key, "macOS arm64 .dmg");
+  assert.equal(classifyAsset("srelens_0.5.0_x64.dmg").key, "macOS x64 .dmg");
+  assert.equal(classifyAsset("srelens_0.5.0_amd64.deb").key, "Linux x64 .deb");
+  assert.equal(classifyAsset("srelens-0.5.0-1.x86_64.rpm").key, "Linux x64 .rpm");
+  assert.equal(classifyAsset("srelens_0.5.0_amd64.AppImage").key, "Linux x64 .AppImage");
+  assert.equal(classifyAsset("srelens_0.5.0_x64-setup.exe").key, "Windows x64 .exe");
+  assert.equal(classifyAsset("srelens_0.5.0_x64_en-US.msi").key, "Windows x64 .msi");
+});
+
+test("classifies Freelens assets into the same buckets", () => {
+  // Different naming scheme, same buckets — otherwise the table would compare
+  // artifacts that aren't counterparts.
+  assert.equal(classifyAsset("Freelens-1.10.3-macos-arm64.dmg").key, "macOS arm64 .dmg");
+  assert.equal(classifyAsset("Freelens-1.10.3-linux-amd64.deb").key, "Linux x64 .deb");
+  assert.equal(classifyAsset("Freelens-1.10.3-linux-amd64.AppImage").key, "Linux x64 .AppImage");
+  assert.equal(classifyAsset("Freelens-1.10.3-windows-amd64.exe").key, "Windows x64 .exe");
+});
+
+test("rejects everything that is not an installer download", () => {
+  for (const name of [
+    "srelens_0.5.0_amd64.deb.sig",
+    "Freelens-1.10.3-linux-amd64.deb.sha256",
+    "Freelens-1.10.3-linux-amd64-sbom.spdx.json",
+    "latest.json",
+    "srelens_x64.app.tar.gz",
+    "Freelens-1.10.3-windows-portable-amd64.exe",
+    "Packages.xz",
+  ]) {
+    assert.equal(classifyAsset(name), null, `${name} should not be a bucket`);
+  }
+});
+
+test("an unclassifiable artifact is reported, not silently dropped", () => {
+  const { sizes, skipped } = bucketAssets([
+    { name: "srelens_0.5.0_x64.dmg", size: 19149790 },
+    { name: "srelens_0.5.0_amd64.deb.sig", size: 412 },
+    { name: "mystery-build.tar.zst", size: 100 },
+  ]);
+  assert.deepEqual(Object.keys(sizes), ["macOS x64 .dmg"]);
+  // Signatures are known non-artifacts; the genuinely unknown one surfaces.
+  assert.deepEqual(skipped, ["mystery-build.tar.zst"]);
+});
+
+test("mib and growthPct round the way the published table does", () => {
+  assert.equal(mib(17882551), 17.1);
+  assert.equal(growthPct(18.7, 19.8), 5.9);
+  assert.equal(growthPct(100, 90), -10);
+  // No previous size means no percentage to report, not a divide-by-zero.
+  assert.equal(growthPct(0, 50), null);
+});


### PR DESCRIPTION
Addresses #31 — the size half completely, with the memory half's tooling and methodology shipped but its numbers deliberately unpublished. See the honesty note at the bottom.

## What's measured
`scripts/perf/size-baseline.mjs` reads published release assets straight from the GitHub Releases API for both projects and buckets them by `(os, arch, format)`. Nothing is built locally, estimated, or hand-copied — every number is the byte size of a file a user downloads, reproducible by anyone at any time.

Measured today, srelens `v0.5.0` vs Freelens `v1.10.3`:

| Installer | srelens | Freelens | Difference |
| --- | ---: | ---: | ---: |
| macOS arm64 `.dmg` | 17.1 MiB | 190.2 MiB | 11.2× smaller |
| macOS x64 `.dmg` | 18.3 MiB | 202.3 MiB | 11.1× smaller |
| Windows x64 `.exe` | 11.2 MiB | 154.6 MiB | 13.8× smaller |
| Windows x64 `.msi` | 16.8 MiB | 170.1 MiB | 10.1× smaller |
| Linux x64 `.deb` | 19.8 MiB | 146.8 MiB | 7.4× smaller |
| Linux x64 `.rpm` | 19.8 MiB | 121.8 MiB | 6.2× smaller |
| Linux x64 `.AppImage` | 91.7 MiB | 199.2 MiB | 2.2× smaller |

The docs call out where the gap narrows rather than quoting only the flattering row: the AppImage carries `libwebkit2gtk`, which the `.deb`/`.rpm` resolve as a package dependency, so 91.7 MiB is the fair self-contained-Linux number. Buckets only one project publishes (srelens has no arm64 Linux/Windows builds) are omitted, not cross-compared.

## Regression budget
The release workflow re-runs the comparison after publishing and fails if any installer grew >15% vs the previous stable release. The verdict is captured to a file rather than piped — `| tee` would mask the check's exit code and let a regression pass silently. For reference the script reports `v0.4.1 → v0.5.0` at +5.9% worst-case.

## Memory tooling
`scripts/perf/memory-baseline.sh` sums RSS across the **whole process tree** — the only fair basis when Electron spreads its footprint over renderer/GPU/utility helpers and Tauri over the OS WebView's processes. Two details found by testing it here:
- It matches executable **basenames**, not command lines. This repo's path contains `srelens`, so `pgrep -f` matched every shell, watcher, and even `esbuild` run from the directory.
- It prints every process it counted, so contamination is visible. Running it locally immediately exposed two stray `srelens --mcp-stdio` servers that aren't the desktop app.

## Honesty note on memory
**No memory numbers are published.** A citable figure needs release builds of both apps on an otherwise-idle machine in two scenarios (idle, and three clusters with watches live); the only srelens process available here was a debug build under `tauri dev`, and Freelens isn't installed. `docs/PERFORMANCE.md` states this plainly rather than shipping a number that can't be stood behind. The size numbers are complete and independent of it, so #31 should stay open for the memory run.

## Tests
5 unit tests for the classifier (`node --test`), wired into CI's frontend job — a wrong bucket would silently publish a bogus comparison, so this is the part most worth guarding. No network in the tests.