### PR TITLE
feat(settings): add durable file-backed store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5874,12 +5874,15 @@ dependencies = [
 name = "srelens-registry"
 version = "0.5.0"
 dependencies = [
+ "dirs",
  "reqwest 0.13.4",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "srelens-capability",
  "srelens-kube",
  "srelens-mcp",
+ "tempfile",
  "tokio",
 ]
 

--- a/apps/desktop/src-tauri/src/capabilities.rs
+++ b/apps/desktop/src-tauri/src/capabilities.rs
@@ -7,6 +7,7 @@
 //! `install_krew` capability.
 
 pub use srelens_registry::{
-    build_registry, build_registry_with, build_registry_with_paths, default_kubeconfig_paths,
+    build_registry, build_registry_with, build_registry_with_paths,
+    build_registry_with_paths_and_settings, default_kubeconfig_paths, default_settings_path,
     run_tool,
 };

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -56,7 +56,10 @@ use updater::{update_check, update_install};
 use watch::{start_resource_watch, stop_watch};
 
 pub use appimage::gio_module_dir_for_appimage;
-pub use capabilities::{build_registry, build_registry_with_paths};
+pub use capabilities::{
+    build_registry, build_registry_with_paths, build_registry_with_paths_and_settings,
+    default_settings_path,
+};
 
 /// Size the main window to a comfortable default, clamped to the screen it
 /// opens on: on a large display it stays at the preferred ~16" size (centered),

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -227,9 +227,10 @@ fn run_mcp_http(
         let cache = srelens_kube::client_cache::ClientCache::new_many(
             srelens_registry::default_kubeconfig_paths(),
         );
-        let registry = srelens_desktop_lib::build_registry_with_paths(
+        let registry = srelens_desktop_lib::build_registry_with_paths_and_settings(
             cache.clone(),
             srelens_registry::default_kubeconfig_paths(),
+            Some(srelens_desktop_lib::default_settings_path()),
         );
         let server = srelens_mcp::McpServer::new(Arc::new(registry))
             .with_policy(policy)
@@ -291,9 +292,10 @@ fn run_mcp_stdio(allow_destructive: bool, allow_sensitive_reads: bool) {
         let cache = srelens_kube::client_cache::ClientCache::new_many(
             srelens_registry::default_kubeconfig_paths(),
         );
-        let registry = srelens_desktop_lib::build_registry_with_paths(
+        let registry = srelens_desktop_lib::build_registry_with_paths_and_settings(
             cache.clone(),
             srelens_registry::default_kubeconfig_paths(),
+            Some(srelens_desktop_lib::default_settings_path()),
         );
         let server = srelens_mcp::McpServer::new(Arc::new(registry))
             .with_policy(policy)

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -230,7 +230,7 @@ fn run_mcp_http(
         let registry = srelens_desktop_lib::build_registry_with_paths_and_settings(
             cache.clone(),
             srelens_registry::default_kubeconfig_paths(),
-            Some(srelens_desktop_lib::default_settings_path()),
+            srelens_desktop_lib::default_settings_path(),
         );
         let server = srelens_mcp::McpServer::new(Arc::new(registry))
             .with_policy(policy)
@@ -295,7 +295,7 @@ fn run_mcp_stdio(allow_destructive: bool, allow_sensitive_reads: bool) {
         let registry = srelens_desktop_lib::build_registry_with_paths_and_settings(
             cache.clone(),
             srelens_registry::default_kubeconfig_paths(),
-            Some(srelens_desktop_lib::default_settings_path()),
+            srelens_desktop_lib::default_settings_path(),
         );
         let server = srelens_mcp::McpServer::new(Arc::new(registry))
             .with_policy(policy)

--- a/apps/desktop/src-tauri/tests/e2e.rs
+++ b/apps/desktop/src-tauri/tests/e2e.rs
@@ -3,7 +3,7 @@
 //! Drives the app's REAL capability registry — the exact same
 //! `(cap.handler)(json_value).await` path the Tauri bridge and the MCP server
 //! use — against a live kind cluster, and ENFORCES COVERAGE: every capability
-//! registered in `srelens_desktop_lib::capabilities::build_registry_with` must
+//! registered in the desktop capability registry must
 //! be exercised by this suite, or explicitly listed in `EXCLUDED` with a
 //! written reason. A capability added later with no e2e case fails this test.
 //! Mirrors the philosophy of `every_capability_is_mcp_exposed` in
@@ -35,7 +35,9 @@ use base64::Engine;
 use futures::FutureExt;
 use serde_json::{json, Value};
 use srelens_capability::Registry;
-use srelens_desktop_lib::capabilities::build_registry_with;
+use srelens_desktop_lib::capabilities::{
+    build_registry_with, build_registry_with_paths_and_settings,
+};
 use srelens_kube::client_cache::ClientCache;
 
 const NS: &str = "srelens-e2e";
@@ -80,6 +82,25 @@ fn kubeconfig_paths() -> Vec<PathBuf> {
 
 fn cache() -> Arc<ClientCache> {
     ClientCache::new_many(kubeconfig_paths())
+}
+
+/// Keeps the settings capability e2e isolated from a developer's real app
+/// preferences, including when the suite unwinds after a failed assertion.
+struct TempSettings(PathBuf);
+
+impl TempSettings {
+    fn new() -> Self {
+        Self(std::env::temp_dir().join(format!(
+            "srelens-e2e-settings-{}.json",
+            uuid::Uuid::new_v4()
+        )))
+    }
+}
+
+impl Drop for TempSettings {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
 }
 
 /// Drives the real capability registry and tracks which capability ids have
@@ -513,8 +534,39 @@ async fn full_capability_suite() {
 
 async fn run_suite() {
     let ctx = context();
-    let reg = build_registry_with(cache());
+    let settings = TempSettings::new();
+    let reg = build_registry_with_paths_and_settings(
+        cache(),
+        kubeconfig_paths(),
+        Some(settings.0.clone()),
+    );
     let mut h = Harness::new(reg);
+
+    // === Durable settings: real file round-trip, isolated from app data ===
+    println!("=== settings ===");
+    let saved = h
+        .ok(
+            "settings.set",
+            json!({
+                "values": { "e2e.roundTrip": { "theme": "dark", "scale": 120 } },
+                "localStorageMigrated": true
+            }),
+        )
+        .await;
+    assert_eq!(saved["saved"], true);
+    let loaded = h
+        .ok("settings.get", json!({ "key": "e2e.roundTrip" }))
+        .await;
+    assert_eq!(
+        loaded["values"]["e2e.roundTrip"],
+        json!({ "theme": "dark", "scale": 120 })
+    );
+    assert_eq!(loaded["localStorageMigrated"], true);
+    h.ok(
+        "settings.set",
+        json!({ "remove": ["e2e.roundTrip"] }),
+    )
+    .await;
 
     // === Fixtures: dogfood k8s.applyManifest to seed the namespace =========
     println!("=== fixtures ===");

--- a/apps/desktop/src/components/AssistantConversation.tsx
+++ b/apps/desktop/src/components/AssistantConversation.tsx
@@ -18,6 +18,7 @@ import {
   type StoredToolCall,
 } from "../lib/chatHistory";
 import { relativeTime } from "../lib/relativeTime";
+import { settingsStorage } from "../lib/settingsStorage";
 import { AssistantMarkdown } from "./AssistantMarkdown";
 
 export type AssistantContext = { context: string; namespace?: string; kind?: string; name?: string };
@@ -104,19 +105,19 @@ export function stripDataUri(uri: string): string {
 /** Persist the agent the user last actually used so a fresh chat defaults back
  * to it instead of always falling to the first-available (Claude). Stored
  * globally (not per-session — that's `Session.agentKind`); guarded so a missing
- * `localStorage` (or a private-mode throw) degrades to the first-available
+ * persistent storage (or a private-mode throw) degrades to the first-available
  * default rather than erroring. */
 const LAST_AGENT_KEY = "srelens.assistant.lastAgent";
 function loadLastAgent(): string | null {
   try {
-    return localStorage.getItem(LAST_AGENT_KEY);
+    return settingsStorage.getItem(LAST_AGENT_KEY);
   } catch {
     return null;
   }
 }
 function saveLastAgent(kind: string) {
   try {
-    if (kind) localStorage.setItem(LAST_AGENT_KEY, kind);
+    if (kind) settingsStorage.setItem(LAST_AGENT_KEY, kind);
   } catch {
     /* ignore — persistence is a convenience, not required */
   }

--- a/apps/desktop/src/lib/capability-catalog.json
+++ b/apps/desktop/src/lib/capability-catalog.json
@@ -365,6 +365,16 @@
     "destructive": false
   },
   {
+    "id": "settings.get",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
+    "id": "settings.set",
+    "readOnly": false,
+    "destructive": false
+  },
+  {
     "id": "toolbox.diagnoseContext",
     "readOnly": true,
     "destructive": false

--- a/apps/desktop/src/lib/paletteActions.audit.test.ts
+++ b/apps/desktop/src/lib/paletteActions.audit.test.ts
@@ -21,6 +21,7 @@ const EXCLUDED: Record<string, string> = {
   "toolbox.installPlugin": "toolbox installs live in the Toolbox view",
   "toolbox.upgradePlugin": "toolbox installs live in the Toolbox view",
   "toolbox.removePlugin": "toolbox installs live in the Toolbox view",
+  "settings.set": "settings writes are performed by controls in Settings and other stateful views",
 };
 
 describe("command palette action coverage", () => {

--- a/apps/desktop/src/lib/recents.ts
+++ b/apps/desktop/src/lib/recents.ts
@@ -1,4 +1,5 @@
 import type { CrdRef } from "./crds";
+import { settingsStorage } from "./settingsStorage";
 
 /** A recently-opened palette target, persisted across sessions. */
 export type RecentItem =
@@ -19,7 +20,7 @@ export function recentId(r: RecentItem): string {
 
 export function getRecents(): RecentItem[] {
   try {
-    const raw = localStorage.getItem(KEY) ?? localStorage.getItem(LEGACY_KEY);
+    const raw = settingsStorage.getItem(KEY) ?? settingsStorage.getItem(LEGACY_KEY);
     return raw ? (JSON.parse(raw) as RecentItem[]) : [];
   } catch {
     return [];
@@ -31,7 +32,7 @@ export function pushRecent(item: RecentItem): void {
   const id = recentId(item);
   const next = [item, ...getRecents().filter((r) => recentId(r) !== id)].slice(0, MAX);
   try {
-    localStorage.setItem(KEY, JSON.stringify(next));
+    settingsStorage.setItem(KEY, JSON.stringify(next));
   } catch {
     // ignore quota / unavailable storage
   }

--- a/apps/desktop/src/lib/savedForwards.ts
+++ b/apps/desktop/src/lib/savedForwards.ts
@@ -3,9 +3,10 @@
 // Persisted per kube-context. Web mode stores rows server-side, one row per
 // context, via the per-user settings API (`GET`/`PUT /api/settings/:key`,
 // see crates/server/src/api_settings.rs); desktop persists the equivalent
-// state in localStorage, following loadClusterNamespaces/saveClusterNamespaces.
+// state through the durable settings mirror.
 import { isWeb } from "../transport/platform";
 import { csrfHeader } from "../transport/webTransport";
+import { settingsStorage } from "./settingsStorage";
 
 export interface SavedForward {
   id: string;
@@ -50,7 +51,7 @@ async function webPutAll(context: string, list: SavedForward[]): Promise<void> {
 
 function loadAll(): Record<string, SavedForward[]> {
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
+    const raw = settingsStorage.getItem(STORAGE_KEY);
     return raw ? (JSON.parse(raw) as Record<string, SavedForward[]>) : {};
   } catch {
     return {};
@@ -59,7 +60,7 @@ function loadAll(): Record<string, SavedForward[]> {
 
 function saveAll(map: Record<string, SavedForward[]>): void {
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+    settingsStorage.setItem(STORAGE_KEY, JSON.stringify(map));
   } catch {
     // ignore unavailable/quota-exceeded storage
   }

--- a/apps/desktop/src/lib/settings.ts
+++ b/apps/desktop/src/lib/settings.ts
@@ -1,4 +1,7 @@
-// Small persisted-settings helpers (localStorage). Survives app restarts.
+// Small synchronous persisted-settings helpers. Desktop reads from an
+// in-memory mirror of settings.json; web mode falls back to localStorage.
+
+import { settingsStorage } from "./settingsStorage";
 
 const CLUSTER_NS_KEY = "srelens.clusterNamespaces";
 const DEFAULT_NS_KEY = "srelens.defaultNamespace";
@@ -33,7 +36,7 @@ export function getRequestTimeoutSecs(): number {
 export function setRequestTimeoutSecs(secs: number): number {
   const clamped = clampTimeoutSecs(secs);
   try {
-    localStorage.setItem(REQUEST_TIMEOUT_KEY, JSON.stringify(clamped));
+    settingsStorage.setItem(REQUEST_TIMEOUT_KEY, JSON.stringify(clamped));
   } catch {
     // ignore unavailable/quota-exceeded storage
   }
@@ -41,7 +44,9 @@ export function setRequestTimeoutSecs(secs: number): number {
 }
 
 function stored(key: string): string | null {
-  return localStorage.getItem(key) ?? localStorage.getItem(key.replace("srelens", LEGACY_PREFIX));
+  return (
+    settingsStorage.getItem(key) ?? settingsStorage.getItem(key.replace("srelens", LEGACY_PREFIX))
+  );
 }
 
 export type ContextLogo = "initials" | "cluster" | "cloud" | "shield" | "database" | "globe" | "custom";
@@ -84,7 +89,7 @@ export function loadClusterNamespaces(): Record<string, string> {
 
 export function saveClusterNamespaces(map: Record<string, string>): void {
   try {
-    localStorage.setItem(CLUSTER_NS_KEY, JSON.stringify(map));
+    settingsStorage.setItem(CLUSTER_NS_KEY, JSON.stringify(map));
   } catch {
     // ignore unavailable/quota-exceeded storage
   }
@@ -101,7 +106,7 @@ export function getDefaultNamespace(): string {
 
 export function setDefaultNamespace(ns: string): void {
   try {
-    localStorage.setItem(DEFAULT_NS_KEY, ns);
+    settingsStorage.setItem(DEFAULT_NS_KEY, ns);
   } catch {
     // ignore
   }
@@ -123,7 +128,7 @@ export function loadWorkspaceLayout(): WorkspaceLayoutSettings {
 
 export function saveWorkspaceLayout(layout: WorkspaceLayoutSettings): void {
   try {
-    localStorage.setItem(WORKSPACE_LAYOUT_KEY, JSON.stringify(layout));
+    settingsStorage.setItem(WORKSPACE_LAYOUT_KEY, JSON.stringify(layout));
   } catch {
     // ignore unavailable/quota-exceeded storage
   }
@@ -142,7 +147,7 @@ export function loadContextProfiles(): ContextProfiles {
 
 export function saveContextProfiles(profiles: ContextProfiles): void {
   try {
-    localStorage.setItem(CONTEXT_PROFILES_KEY, JSON.stringify(profiles));
+    settingsStorage.setItem(CONTEXT_PROFILES_KEY, JSON.stringify(profiles));
   } catch {
     // ignore unavailable/quota-exceeded storage
   }
@@ -165,7 +170,7 @@ export function loadKubeconfigFiles(): string[] {
 
 export function saveKubeconfigFiles(paths: string[]): void {
   try {
-    localStorage.setItem(KUBECONFIG_FILES_KEY, JSON.stringify([...new Set(paths)]));
+    settingsStorage.setItem(KUBECONFIG_FILES_KEY, JSON.stringify([...new Set(paths)]));
   } catch {
     // ignore unavailable/quota-exceeded storage
   }
@@ -191,7 +196,7 @@ export function saveHiddenColumns(view: string, keys: string[]): void {
     const parsed = JSON.parse(stored(HIDDEN_COLUMNS_KEY) ?? "{}") as unknown;
     const map = parsed && typeof parsed === "object" ? (parsed as Record<string, string[]>) : {};
     map[view] = [...new Set(keys)];
-    localStorage.setItem(HIDDEN_COLUMNS_KEY, JSON.stringify(map));
+    settingsStorage.setItem(HIDDEN_COLUMNS_KEY, JSON.stringify(map));
   } catch {
     // ignore unavailable/quota-exceeded storage
   }
@@ -210,7 +215,7 @@ export function loadContextOrder(): string[] {
 
 export function saveContextOrder(order: string[]): void {
   try {
-    localStorage.setItem(CONTEXT_ORDER_KEY, JSON.stringify([...new Set(order)]));
+    settingsStorage.setItem(CONTEXT_ORDER_KEY, JSON.stringify([...new Set(order)]));
   } catch {
     // ignore unavailable/quota-exceeded storage
   }
@@ -232,7 +237,7 @@ export function loadUpdateChannel(): UpdateChannel {
 
 export function saveUpdateChannel(channel: UpdateChannel): void {
   try {
-    localStorage.setItem(UPDATE_CHANNEL_KEY, channel);
+    settingsStorage.setItem(UPDATE_CHANNEL_KEY, channel);
   } catch {
     // ignore unavailable/quota-exceeded storage
   }
@@ -282,7 +287,7 @@ export function loadMcpSettings(): McpSettings {
 
 export function saveMcpSettings(settings: McpSettings): void {
   try {
-    localStorage.setItem(MCP_SETTINGS_KEY, JSON.stringify(settings));
+    settingsStorage.setItem(MCP_SETTINGS_KEY, JSON.stringify(settings));
   } catch {
     // ignore unavailable/quota-exceeded storage
   }

--- a/apps/desktop/src/lib/settingsStorage.test.ts
+++ b/apps/desktop/src/lib/settingsStorage.test.ts
@@ -116,6 +116,40 @@ describe("desktop settings storage", () => {
     error.mockRestore();
   });
 
+  it("keeps the file backend when localStorage itself is unavailable", async () => {
+    // A WebView with localStorage disabled throws from getItem. That must not
+    // discard the file document we just loaded — falling back to the very
+    // storage that is unavailable would leave nothing able to persist.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const getItem = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("localStorage is disabled");
+    });
+    invokeCapability
+      .mockResolvedValueOnce({
+        schemaVersion: 1,
+        localStorageMigrated: false,
+        values: { "srelens.uiScale": 130 },
+      })
+      .mockResolvedValue(undefined);
+
+    const { initializeSettingsStorage, settingsStorage, flushSettingsWrites } = await import(
+      "./settingsStorage"
+    );
+    await initializeSettingsStorage();
+
+    // Served from the file mirror, not from the throwing localStorage.
+    expect(settingsStorage.getItem("srelens.uiScale")).toBe("130");
+    // And writes still reach the file store.
+    settingsStorage.setItem("srelens.defaultNamespace", '"kube-system"');
+    await flushSettingsWrites();
+    expect(invokeCapability).toHaveBeenCalledWith("settings.set", {
+      values: { "srelens.defaultNamespace": "kube-system" },
+    });
+
+    getItem.mockRestore();
+    warn.mockRestore();
+  });
+
   it("keeps the storage-shaped localStorage fallback in web mode", async () => {
     Reflect.deleteProperty(window, "__TAURI_INTERNALS__");
     vi.resetModules();

--- a/apps/desktop/src/lib/settingsStorage.test.ts
+++ b/apps/desktop/src/lib/settingsStorage.test.ts
@@ -139,6 +139,15 @@ describe("desktop settings storage", () => {
 
     // Served from the file mirror, not from the throwing localStorage.
     expect(settingsStorage.getItem("srelens.uiScale")).toBe("130");
+
+    // Crucially, migration must NOT be marked done: the scan never ran, so
+    // committing the flag would retire the one-time import and strand the
+    // legacy preferences forever once storage came back.
+    expect(invokeCapability).not.toHaveBeenCalledWith(
+      "settings.set",
+      expect.objectContaining({ localStorageMigrated: true }),
+    );
+
     // And writes still reach the file store.
     settingsStorage.setItem("srelens.defaultNamespace", '"kube-system"');
     await flushSettingsWrites();
@@ -147,6 +156,41 @@ describe("desktop settings storage", () => {
     });
 
     getItem.mockRestore();
+    warn.mockRestore();
+  });
+
+  it("retries migration on a later launch after a transient storage failure", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const getItem = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("storage temporarily disabled");
+    });
+    invokeCapability.mockResolvedValueOnce({
+      schemaVersion: 1,
+      localStorageMigrated: false,
+      values: {},
+    });
+
+    const first = await import("./settingsStorage");
+    await first.initializeSettingsStorage();
+    getItem.mockRestore();
+
+    // Second launch: storage is back and the flag was never set, so the real
+    // values are imported instead of being lost.
+    vi.resetModules();
+    invokeCapability.mockReset();
+    localStorage.setItem("srelens.uiScale", "140");
+    invokeCapability
+      .mockResolvedValueOnce({ schemaVersion: 1, localStorageMigrated: false, values: {} })
+      .mockResolvedValue(undefined);
+
+    const second = await import("./settingsStorage");
+    await second.initializeSettingsStorage();
+
+    expect(invokeCapability).toHaveBeenCalledWith("settings.set", {
+      values: { "srelens.uiScale": 140 },
+      localStorageMigrated: true,
+    });
+    expect(second.settingsStorage.getItem("srelens.uiScale")).toBe("140");
     warn.mockRestore();
   });
 

--- a/apps/desktop/src/lib/settingsStorage.test.ts
+++ b/apps/desktop/src/lib/settingsStorage.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const invokeCapability = vi.hoisted(() => vi.fn());
+
+vi.mock("../transport/transport", () => ({ invokeCapability }));
+
+function tauriWindow(): void {
+  Object.defineProperty(window, "__TAURI_INTERNALS__", {
+    configurable: true,
+    value: {},
+  });
+}
+
+describe("desktop settings storage", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    invokeCapability.mockReset();
+    localStorage.clear();
+    tauriWindow();
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(window, "__TAURI_INTERNALS__");
+  });
+
+  it("imports known localStorage values once and clears them after the file write", async () => {
+    localStorage.setItem("srelens.uiScale", "120");
+    localStorage.setItem("freelens.contextOrder", JSON.stringify(["prod", "dev"]));
+    localStorage.setItem("fl-theme", "light");
+    localStorage.setItem("unrelated", "keep me");
+    invokeCapability
+      .mockResolvedValueOnce({
+        schemaVersion: 1,
+        localStorageMigrated: false,
+        values: {},
+      })
+      .mockResolvedValueOnce({ saved: true });
+
+    const { initializeSettingsStorage, settingsStorage } = await import("./settingsStorage");
+    await initializeSettingsStorage();
+
+    expect(invokeCapability).toHaveBeenNthCalledWith(1, "settings.get", {});
+    expect(invokeCapability).toHaveBeenNthCalledWith(2, "settings.set", {
+      values: {
+        "srelens.uiScale": 120,
+        "srelens.contextOrder": ["prod", "dev"],
+        "fl-theme-v2": { name: "slate", mode: "light" },
+      },
+      localStorageMigrated: true,
+    });
+    expect(settingsStorage.getItem("srelens.uiScale")).toBe("120");
+    expect(settingsStorage.getItem("srelens.contextOrder")).toBe('["prod","dev"]');
+    expect(localStorage.getItem("srelens.uiScale")).toBeNull();
+    expect(localStorage.getItem("freelens.contextOrder")).toBeNull();
+    expect(localStorage.getItem("fl-theme")).toBeNull();
+    expect(localStorage.getItem("unrelated")).toBe("keep me");
+  });
+
+  it("uses the file as source of truth after migration", async () => {
+    localStorage.setItem("srelens.uiScale", "90");
+    invokeCapability.mockResolvedValueOnce({
+      schemaVersion: 1,
+      localStorageMigrated: true,
+      values: { "srelens.uiScale": 130 },
+    });
+
+    const { initializeSettingsStorage, settingsStorage } = await import("./settingsStorage");
+    await initializeSettingsStorage();
+
+    expect(settingsStorage.getItem("srelens.uiScale")).toBe("130");
+    expect(invokeCapability).toHaveBeenCalledTimes(1);
+  });
+
+  it("updates the synchronous mirror immediately and writes through in order", async () => {
+    invokeCapability.mockResolvedValue({
+      schemaVersion: 1,
+      localStorageMigrated: true,
+      values: {},
+    });
+    const { initializeSettingsStorage, settingsStorage, flushSettingsWrites } = await import(
+      "./settingsStorage"
+    );
+    await initializeSettingsStorage();
+
+    settingsStorage.setItem("srelens.uiScale", "140");
+    expect(settingsStorage.getItem("srelens.uiScale")).toBe("140");
+    settingsStorage.removeItem("srelens.uiScale");
+    expect(settingsStorage.getItem("srelens.uiScale")).toBeNull();
+    await flushSettingsWrites();
+
+    expect(invokeCapability).toHaveBeenNthCalledWith(2, "settings.set", {
+      values: { "srelens.uiScale": 140 },
+    });
+    expect(invokeCapability).toHaveBeenNthCalledWith(3, "settings.set", {
+      remove: ["srelens.uiScale"],
+    });
+  });
+
+  it("retains localStorage when migration cannot be committed", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    localStorage.setItem("srelens.uiScale", "125");
+    invokeCapability
+      .mockResolvedValueOnce({
+        schemaVersion: 1,
+        localStorageMigrated: false,
+        values: {},
+      })
+      .mockRejectedValueOnce(new Error("disk full"));
+
+    const { initializeSettingsStorage, settingsStorage } = await import("./settingsStorage");
+    await initializeSettingsStorage();
+
+    expect(localStorage.getItem("srelens.uiScale")).toBe("125");
+    expect(settingsStorage.getItem("srelens.uiScale")).toBe("125");
+    expect(error).toHaveBeenCalled();
+    error.mockRestore();
+  });
+
+  it("keeps the storage-shaped localStorage fallback in web mode", async () => {
+    Reflect.deleteProperty(window, "__TAURI_INTERNALS__");
+    vi.resetModules();
+    const { initializeSettingsStorage, settingsStorage } = await import("./settingsStorage");
+
+    await initializeSettingsStorage();
+    settingsStorage.setItem("theme", "dark");
+    expect(settingsStorage.getItem("theme")).toBe("dark");
+    settingsStorage.removeItem("theme");
+    expect(settingsStorage.getItem("theme")).toBeNull();
+    expect(invokeCapability).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/lib/settingsStorage.ts
+++ b/apps/desktop/src/lib/settingsStorage.ts
@@ -1,0 +1,156 @@
+import { invokeCapability } from "../transport/transport";
+import { isTauri } from "../transport/platform";
+
+interface SettingsGetOutput {
+  schemaVersion: number;
+  localStorageMigrated: boolean;
+  values: Record<string, unknown>;
+}
+
+interface SettingsSetInput {
+  values?: Record<string, unknown>;
+  remove?: string[];
+  localStorageMigrated?: boolean;
+}
+
+// Every desktop preference that existed before the file store. Keeping this
+// list explicit prevents a broad localStorage sweep from importing unrelated
+// WebView/application data.
+const MIGRATION_KEYS = [
+  "srelens.requestTimeoutSecs",
+  "srelens.clusterNamespaces",
+  "srelens.defaultNamespace",
+  "srelens.workspaceLayout",
+  "srelens.contextProfiles",
+  "srelens.kubeconfigFiles",
+  "srelens.hiddenColumns",
+  "srelens.contextOrder",
+  "srelens.updateChannel",
+  "srelens.mcp",
+  "srelens.recents",
+  "srelens.uiScale",
+  "srelens.savedForwards",
+  "srelens.assistant.lastAgent",
+  "fl-theme-v2",
+] as const;
+
+const LEGACY_ALIASES: Record<string, string[]> = {
+  "fl-theme-v2": ["fl-theme"],
+};
+
+const values = new Map<string, unknown>();
+let fileBacked = false;
+let writes: Promise<void> = Promise.resolve();
+
+function decode(raw: string): unknown {
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return raw;
+  }
+}
+
+function encode(value: unknown): string {
+  return typeof value === "string" ? value : (JSON.stringify(value) ?? "null");
+}
+
+function aliasesFor(key: string): string[] {
+  const aliases = [...(LEGACY_ALIASES[key] ?? [])];
+  if (key.startsWith("srelens.")) aliases.push(key.replace("srelens.", "freelens."));
+  return aliases;
+}
+
+function enqueue(input: SettingsSetInput): void {
+  writes = writes
+    .then(async () => {
+      await invokeCapability("settings.set", input);
+    })
+    .catch((error) => {
+      // Persistence remains best-effort at synchronous call sites, as it was
+      // with localStorage, but failures are no longer silent.
+      console.error("could not persist settings", error);
+    });
+}
+
+/**
+ * Load the desktop file before React initializes synchronous settings state.
+ * On the first successful load, import known localStorage keys in one atomic
+ * write and only then remove the old copies.
+ */
+export async function initializeSettingsStorage(): Promise<void> {
+  if (!isTauri()) return;
+  try {
+    const loaded = await invokeCapability<SettingsGetOutput>("settings.get", {});
+    values.clear();
+    Object.entries(loaded.values).forEach(([key, value]) => values.set(key, value));
+
+    if (!loaded.localStorageMigrated) {
+      const migrated: Record<string, unknown> = {};
+      for (const key of MIGRATION_KEYS) {
+        if (values.has(key)) continue;
+        for (const candidate of [key, ...aliasesFor(key)]) {
+          const raw = localStorage.getItem(candidate);
+          if (raw === null) continue;
+          migrated[key] =
+            key === "fl-theme-v2" && candidate === "fl-theme" && (raw === "light" || raw === "dark")
+              ? { name: "slate", mode: raw }
+              : decode(raw);
+          break;
+        }
+      }
+      await invokeCapability("settings.set", {
+        values: migrated,
+        localStorageMigrated: true,
+      } satisfies SettingsSetInput);
+      Object.entries(migrated).forEach(([key, value]) => values.set(key, value));
+
+      // A failed migration never reaches this point, so its localStorage data
+      // remains available for a retry on the next launch.
+      try {
+        for (const key of MIGRATION_KEYS) {
+          localStorage.removeItem(key);
+          for (const alias of aliasesFor(key)) localStorage.removeItem(alias);
+        }
+      } catch (error) {
+        console.warn("durable settings migrated but old localStorage could not be cleared", error);
+      }
+    }
+    fileBacked = true;
+  } catch (error) {
+    // A corrupt/unwritable file must not prevent the app from opening.
+    fileBacked = false;
+    console.error("could not initialize durable settings; using localStorage", error);
+  }
+}
+
+/** Storage-shaped synchronous facade used by the existing settings helpers. */
+export const settingsStorage = {
+  getItem(key: string): string | null {
+    if (!fileBacked) return localStorage.getItem(key);
+    return values.has(key) ? encode(values.get(key)) : null;
+  },
+
+  setItem(key: string, raw: string): void {
+    if (!fileBacked) {
+      localStorage.setItem(key, raw);
+      return;
+    }
+    const value = decode(raw);
+    values.set(key, value);
+    enqueue({ values: { [key]: value } });
+  },
+
+  removeItem(key: string): void {
+    if (!fileBacked) {
+      localStorage.removeItem(key);
+      return;
+    }
+    values.delete(key);
+    enqueue({ remove: [key] });
+  },
+};
+
+/** Test seam for callers that need to observe queued write completion. */
+export async function flushSettingsWrites(): Promise<void> {
+  await writes;
+}

--- a/apps/desktop/src/lib/settingsStorage.ts
+++ b/apps/desktop/src/lib/settingsStorage.ts
@@ -86,17 +86,28 @@ export async function initializeSettingsStorage(): Promise<void> {
 
     if (!loaded.localStorageMigrated) {
       const migrated: Record<string, unknown> = {};
-      for (const key of MIGRATION_KEYS) {
-        if (values.has(key)) continue;
-        for (const candidate of [key, ...aliasesFor(key)]) {
-          const raw = localStorage.getItem(candidate);
-          if (raw === null) continue;
-          migrated[key] =
-            key === "fl-theme-v2" && candidate === "fl-theme" && (raw === "light" || raw === "dark")
-              ? { name: "slate", mode: raw }
-              : decode(raw);
-          break;
+      // Reading the OLD store is optional work: a WebView with localStorage
+      // disabled throws from getItem, and letting that escape would abandon
+      // the file backend we just loaded successfully — falling back to the
+      // very storage that is unavailable, so nothing could persist at all.
+      // There is simply nothing to import in that case.
+      try {
+        for (const key of MIGRATION_KEYS) {
+          if (values.has(key)) continue;
+          for (const candidate of [key, ...aliasesFor(key)]) {
+            const raw = localStorage.getItem(candidate);
+            if (raw === null) continue;
+            migrated[key] =
+              key === "fl-theme-v2" &&
+              candidate === "fl-theme" &&
+              (raw === "light" || raw === "dark")
+                ? { name: "slate", mode: raw }
+                : decode(raw);
+            break;
+          }
         }
+      } catch (error) {
+        console.warn("localStorage unavailable; nothing to migrate", error);
       }
       await invokeCapability("settings.set", {
         values: migrated,

--- a/apps/desktop/src/lib/settingsStorage.ts
+++ b/apps/desktop/src/lib/settingsStorage.ts
@@ -90,7 +90,7 @@ export async function initializeSettingsStorage(): Promise<void> {
       // disabled throws from getItem, and letting that escape would abandon
       // the file backend we just loaded successfully — falling back to the
       // very storage that is unavailable, so nothing could persist at all.
-      // There is simply nothing to import in that case.
+      let scanned = true;
       try {
         for (const key of MIGRATION_KEYS) {
           if (values.has(key)) continue;
@@ -107,23 +107,34 @@ export async function initializeSettingsStorage(): Promise<void> {
           }
         }
       } catch (error) {
-        console.warn("localStorage unavailable; nothing to migrate", error);
+        // The scan is all-or-nothing on purpose. Committing the migrated flag
+        // after a partial read would retire the one-time import for good, so a
+        // transient storage failure would strand the legacy preferences
+        // permanently. Leave the flag unset and retry on the next launch.
+        scanned = false;
+        console.warn("localStorage unreadable; deferring migration to a later launch", error);
       }
-      await invokeCapability("settings.set", {
-        values: migrated,
-        localStorageMigrated: true,
-      } satisfies SettingsSetInput);
-      Object.entries(migrated).forEach(([key, value]) => values.set(key, value));
 
-      // A failed migration never reaches this point, so its localStorage data
-      // remains available for a retry on the next launch.
-      try {
-        for (const key of MIGRATION_KEYS) {
-          localStorage.removeItem(key);
-          for (const alias of aliasesFor(key)) localStorage.removeItem(alias);
+      if (scanned) {
+        await invokeCapability("settings.set", {
+          values: migrated,
+          localStorageMigrated: true,
+        } satisfies SettingsSetInput);
+        Object.entries(migrated).forEach(([key, value]) => values.set(key, value));
+
+        // Only reached once the import is committed, so a failed or deferred
+        // migration always leaves its localStorage data intact for the retry.
+        try {
+          for (const key of MIGRATION_KEYS) {
+            localStorage.removeItem(key);
+            for (const alias of aliasesFor(key)) localStorage.removeItem(alias);
+          }
+        } catch (error) {
+          console.warn(
+            "durable settings migrated but old localStorage could not be cleared",
+            error,
+          );
         }
-      } catch (error) {
-        console.warn("durable settings migrated but old localStorage could not be cleared", error);
       }
     }
     fileBacked = true;

--- a/apps/desktop/src/lib/uiScale.ts
+++ b/apps/desktop/src/lib/uiScale.ts
@@ -13,6 +13,7 @@
 // suppress the native zoom the user already has).
 
 import { setWebviewZoom } from "../transport/transport";
+import { settingsStorage } from "./settingsStorage";
 
 const UI_SCALE_KEY = "srelens.uiScale";
 
@@ -29,7 +30,7 @@ export function clampUiScale(value: unknown): number {
 /** The persisted interface scale in percent, or 100 when unset/invalid. */
 export function getUiScale(): number {
   try {
-    const raw = localStorage.getItem(UI_SCALE_KEY);
+    const raw = settingsStorage.getItem(UI_SCALE_KEY);
     return raw === null ? UI_SCALE.DEFAULT : clampUiScale(JSON.parse(raw));
   } catch {
     return UI_SCALE.DEFAULT;
@@ -40,7 +41,7 @@ export function getUiScale(): number {
 export function setUiScale(percent: number): number {
   const clamped = clampUiScale(percent);
   try {
-    localStorage.setItem(UI_SCALE_KEY, JSON.stringify(clamped));
+    settingsStorage.setItem(UI_SCALE_KEY, JSON.stringify(clamped));
   } catch {
     // ignore unavailable/quota-exceeded storage
   }

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -4,13 +4,19 @@ import { createRoot } from "react-dom/client";
 import AppGate from "./AppGate";
 import { applyPersistedTimeout } from "./lib/requestTimeout";
 import { isTauri } from "./transport/platform";
+import { initializeSettingsStorage } from "./lib/settingsStorage";
 
 // Re-apply the persisted request timeout to the backend, which resets to its
 // default each launch. Fire-and-forget: it resolves well before the user picks
 // a context and triggers the first capability call. Tauri-only: on web this
 // would race an unauthenticated 401 before the login gate resolves.
-if (isTauri()) void applyPersistedTimeout();
-
 const container = document.getElementById("root");
 if (!container) throw new Error("Root element #root not found");
-createRoot(container).render(<AppGate />);
+
+async function bootstrap(): Promise<void> {
+  await initializeSettingsStorage();
+  if (isTauri()) void applyPersistedTimeout();
+  createRoot(container).render(<AppGate />);
+}
+
+void bootstrap();

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -13,10 +13,13 @@ import { initializeSettingsStorage } from "./lib/settingsStorage";
 const container = document.getElementById("root");
 if (!container) throw new Error("Root element #root not found");
 
-async function bootstrap(): Promise<void> {
+// The container is passed in rather than captured: `bootstrap` is a hoisted
+// function declaration, so TypeScript cannot rely on the null check above
+// having run before a call and keeps the type as HTMLElement | null inside.
+async function bootstrap(root: HTMLElement): Promise<void> {
   await initializeSettingsStorage();
   if (isTauri()) void applyPersistedTimeout();
-  createRoot(container).render(<AppGate />);
+  createRoot(root).render(<AppGate />);
 }
 
-void bootstrap();
+void bootstrap(container);

--- a/apps/desktop/src/ui/theme.ts
+++ b/apps/desktop/src/ui/theme.ts
@@ -1,3 +1,5 @@
+import { settingsStorage } from "../lib/settingsStorage";
+
 export type ThemeMode = "dark" | "light" | "system";
 export type ThemeName = "slate" | "srelens" | "graphite";
 
@@ -61,7 +63,7 @@ export function resolvedThemeMode(mode: ThemeMode): "dark" | "light" {
 /** Read the persisted theme (defaults to dark). */
 export function getInitialTheme(): Theme {
   try {
-    const stored = localStorage.getItem(KEY);
+    const stored = settingsStorage.getItem(KEY);
     if (stored) {
       const parsed = JSON.parse(stored) as Partial<Theme>;
       return {
@@ -70,7 +72,7 @@ export function getInitialTheme(): Theme {
       };
     }
 
-    const legacy = localStorage.getItem(LEGACY_KEY);
+    const legacy = settingsStorage.getItem(LEGACY_KEY);
     if (legacy === "light" || legacy === "dark") {
       return { ...DEFAULT_THEME, mode: legacy };
     }
@@ -94,7 +96,7 @@ export function applyTheme(theme: Theme): void {
   root.classList.toggle("dark", mode === "dark");
   root.style.colorScheme = mode;
   try {
-    localStorage.setItem(KEY, JSON.stringify(theme));
+    settingsStorage.setItem(KEY, JSON.stringify(theme));
   } catch {
     /* storage unavailable, theme still applied for this session */
   }

--- a/crates/registry/Cargo.toml
+++ b/crates/registry/Cargo.toml
@@ -15,6 +15,8 @@ srelens-kube = { path = "../kube" }
 srelens-mcp = { path = "../mcp" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+schemars = "0.8"
+dirs = "6"
 # Blocking HTTP for toolbox downloads (run inside spawn_blocking). rustls with
 # NO auto crypto-provider: the workspace standardises on ring via kube-client;
 # a second provider (aws-lc-rs) causes a runtime "could not determine
@@ -23,3 +25,4 @@ reqwest = { version = "0.13", default-features = false, features = ["blocking", 
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
+tempfile = "3"

--- a/crates/registry/src/lib.rs
+++ b/crates/registry/src/lib.rs
@@ -375,7 +375,7 @@ pub fn build_registry_with(cache: Arc<ClientCache>) -> Registry {
     build_registry_with_paths_and_settings(
         cache,
         default_kubeconfig_paths(),
-        Some(default_settings_path()),
+        default_settings_path(),
     )
 }
 
@@ -448,7 +448,7 @@ mod tests {
         let reg = build_registry_with_paths_and_settings(
             cache,
             vec![std::path::PathBuf::from("/nonexistent")],
-            Some(default_settings_path()),
+            default_settings_path(),
         );
         let mut ids = reg.ids();
         ids.sort();

--- a/crates/registry/src/lib.rs
+++ b/crates/registry/src/lib.rs
@@ -13,6 +13,8 @@ use srelens_kube::client_cache::ClientCache;
 
 mod catalog;
 pub use catalog::{catalog_of, CatalogEntry};
+mod settings;
+pub use settings::default_settings_path;
 
 // Test-only: every consumer of this module — `render_catalog` (regenerated via
 // `UPDATE_CATALOG=1 cargo test`), the doc-scan tests below, and mcp_docs.rs's
@@ -147,6 +149,17 @@ pub fn build_registry() -> Registry {
 pub fn build_registry_with_paths(
     cache: Arc<ClientCache>,
     kubeconfig_paths: Vec<PathBuf>,
+) -> Registry {
+    build_registry_with_paths_and_settings(cache, kubeconfig_paths, None)
+}
+
+/// Build a registry and optionally add the durable desktop settings surface.
+/// Web-server registries omit it because web settings are per-user SQLite
+/// rows; desktop GUI and MCP callers pass the stable desktop settings path.
+pub fn build_registry_with_paths_and_settings(
+    cache: Arc<ClientCache>,
+    kubeconfig_paths: Vec<PathBuf>,
+    settings_path: Option<PathBuf>,
 ) -> Registry {
     let mut reg = Registry::new();
 
@@ -349,13 +362,21 @@ pub fn build_registry_with_paths(
     ));
     reg.register(srelens_kube::manifest::list_resource_capability(cache));
 
+    if let Some(path) = settings_path {
+        settings::register(&mut reg, path);
+    }
+
     reg
 }
 
 /// Build the registry using a caller-provided client cache with the host's
 /// default kubeconfig discovery (desktop + MCP behavior, unchanged).
 pub fn build_registry_with(cache: Arc<ClientCache>) -> Registry {
-    build_registry_with_paths(cache, default_kubeconfig_paths())
+    build_registry_with_paths_and_settings(
+        cache,
+        default_kubeconfig_paths(),
+        Some(default_settings_path()),
+    )
 }
 
 /// The real resource kind resolver, over `srelens_kube::manifest::gvk_for`.
@@ -422,15 +443,27 @@ mod tests {
     }
 
     #[test]
-    fn with_paths_builds_same_capability_set() {
+    fn with_paths_and_settings_builds_same_capability_set() {
         let cache = ClientCache::new_many(vec![]);
-        let reg = build_registry_with_paths(cache, vec![std::path::PathBuf::from("/nonexistent")]);
+        let reg = build_registry_with_paths_and_settings(
+            cache,
+            vec![std::path::PathBuf::from("/nonexistent")],
+            Some(default_settings_path()),
+        );
         let mut ids = reg.ids();
         ids.sort();
         let default_reg = build_registry();
         let mut default_ids = default_reg.ids();
         default_ids.sort();
         assert_eq!(ids, default_ids, "same capabilities regardless of paths");
+    }
+
+    #[test]
+    fn web_registry_omits_host_desktop_settings() {
+        let cache = ClientCache::new_many(vec![]);
+        let reg = build_registry_with_paths(cache, vec![]);
+        assert!(!reg.ids().contains(&"settings.get"));
+        assert!(!reg.ids().contains(&"settings.set"));
     }
 
     #[test]

--- a/crates/registry/src/settings.rs
+++ b/crates/registry/src/settings.rs
@@ -1,0 +1,399 @@
+//! Durable desktop settings, exposed through the same capability registry as
+//! the rest of the application.
+//!
+//! The frontend keeps a synchronous in-memory mirror, but this file is the
+//! source of truth. Each mutation writes a complete, schema-versioned document
+//! to a sibling temporary file and renames it into place.
+
+use std::collections::BTreeMap;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock, Weak};
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use srelens_capability::{Annotations, Capability, CapabilityError};
+
+const SCHEMA_VERSION: u32 = 1;
+const MAX_DOCUMENT_BYTES: usize = 1024 * 1024;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(default, deny_unknown_fields)]
+struct SettingsDocument {
+    schema_version: u32,
+    local_storage_migrated: bool,
+    values: BTreeMap<String, Value>,
+}
+
+impl Default for SettingsDocument {
+    fn default() -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION,
+            local_storage_migrated: false,
+            values: BTreeMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(default, deny_unknown_fields, rename_all = "camelCase")]
+struct GetSettingsInput {
+    /// Return only this key. Omit it to return the complete settings map.
+    key: Option<String>,
+}
+
+impl Default for GetSettingsInput {
+    fn default() -> Self {
+        Self { key: None }
+    }
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+struct GetSettingsOutput {
+    schema_version: u32,
+    local_storage_migrated: bool,
+    values: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(default, deny_unknown_fields, rename_all = "camelCase")]
+struct SetSettingsInput {
+    /// Keys to insert or replace in one atomic write.
+    values: BTreeMap<String, Value>,
+    /// Keys to remove in the same atomic write.
+    remove: Vec<String>,
+    /// Set by the desktop after its one-time localStorage import succeeds.
+    local_storage_migrated: Option<bool>,
+}
+
+impl Default for SetSettingsInput {
+    fn default() -> Self {
+        Self {
+            values: BTreeMap::new(),
+            remove: Vec::new(),
+            local_storage_migrated: None,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+struct SetSettingsOutput {
+    saved: bool,
+}
+
+struct FileSettingsStore {
+    path: PathBuf,
+}
+
+impl FileSettingsStore {
+    fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    fn document(&self) -> Result<SettingsDocument, String> {
+        // Re-read for every capability call. GUI and headless MCP processes
+        // can coexist; keeping a process-local document cached would let a
+        // later write overwrite settings changed by the other process.
+        read_document(&self.path)
+    }
+
+    fn update(&self, input: SetSettingsInput) -> Result<(), String> {
+        validate_keys(input.values.keys().map(String::as_str))?;
+        validate_keys(input.remove.iter().map(String::as_str))?;
+
+        let mut next = self.document()?;
+        for (key, value) in input.values {
+            next.values.insert(key, value);
+        }
+        for key in input.remove {
+            next.values.remove(&key);
+        }
+        if let Some(migrated) = input.local_storage_migrated {
+            next.local_storage_migrated = migrated;
+        }
+        write_document(&self.path, &next)?;
+        Ok(())
+    }
+}
+
+fn validate_keys<'a>(keys: impl Iterator<Item = &'a str>) -> Result<(), String> {
+    for key in keys {
+        if key.trim().is_empty() {
+            return Err("setting key must not be empty".into());
+        }
+        if key.len() > 256 {
+            return Err("setting key must be at most 256 bytes".into());
+        }
+        if key.chars().any(char::is_control) {
+            return Err("setting key must not contain control characters".into());
+        }
+    }
+    Ok(())
+}
+
+fn read_document(path: &Path) -> Result<SettingsDocument, String> {
+    let raw = match fs::read(path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(SettingsDocument::default())
+        }
+        Err(error) => return Err(format!("read {}: {error}", path.display())),
+    };
+    if raw.len() > MAX_DOCUMENT_BYTES {
+        return Err(format!("{} exceeds the 1 MB settings limit", path.display()));
+    }
+    let document: SettingsDocument = serde_json::from_slice(&raw)
+        .map_err(|error| format!("parse {}: {error}", path.display()))?;
+    if document.schema_version != SCHEMA_VERSION {
+        return Err(format!(
+            "unsupported settings schema {} in {} (expected {})",
+            document.schema_version,
+            path.display(),
+            SCHEMA_VERSION
+        ));
+    }
+    Ok(document)
+}
+
+fn write_document(path: &Path, document: &SettingsDocument) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("{} has no parent directory", path.display()))?;
+    fs::create_dir_all(parent).map_err(|error| format!("create {}: {error}", parent.display()))?;
+
+    let file_name = path.file_name().and_then(|name| name.to_str()).unwrap_or("settings.json");
+    let temp = parent.join(format!(".{file_name}.tmp-{}", std::process::id()));
+    let raw = serde_json::to_vec_pretty(document).map_err(|error| error.to_string())?;
+    if raw.len() > MAX_DOCUMENT_BYTES {
+        return Err("settings document exceeds the 1 MB limit".into());
+    }
+
+    let mut options = OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(&temp)
+        .map_err(|error| format!("create {}: {error}", temp.display()))?;
+    if let Err(error) = file
+        .write_all(&raw)
+        .and_then(|_| file.write_all(b"\n"))
+        .and_then(|_| file.sync_all())
+    {
+        let _ = fs::remove_file(&temp);
+        return Err(format!("write {}: {error}", temp.display()));
+    }
+    drop(file);
+    if let Err(error) = fs::rename(&temp, path) {
+        let _ = fs::remove_file(&temp);
+        return Err(format!("replace {}: {error}", path.display()));
+    }
+    Ok(())
+}
+
+/// The stable settings path shared by GUI and headless MCP launches. It is
+/// derived from the Tauri bundle identifier, so binary renames do not move it.
+pub fn default_settings_path() -> PathBuf {
+    dirs::config_dir()
+        .expect("could not resolve the platform config directory")
+        .join("app.srelens.desktop")
+        .join("settings.json")
+}
+
+/// Register `settings.get` and `settings.set` backed by `path`.
+pub fn register(registry: &mut srelens_capability::Registry, path: PathBuf) {
+    // The GUI bridge and its in-process MCP server build separate registries.
+    // Reuse one store per path so their read/modify/write cycles cannot race
+    // and overwrite each other inside the same process.
+    static STORES: OnceLock<Mutex<BTreeMap<PathBuf, Weak<Mutex<FileSettingsStore>>>>> =
+        OnceLock::new();
+    let stores = STORES.get_or_init(|| Mutex::new(BTreeMap::new()));
+    let mut stores = stores.lock().expect("settings store map lock poisoned");
+    let store = stores
+        .get(&path)
+        .and_then(Weak::upgrade)
+        .unwrap_or_else(|| {
+            let store = Arc::new(Mutex::new(FileSettingsStore::new(path.clone())));
+            stores.insert(path, Arc::downgrade(&store));
+            store
+        });
+    drop(stores);
+
+    let get_store = store.clone();
+    registry.register(Capability::typed::<GetSettingsInput, GetSettingsOutput, _, _>(
+        "settings.get",
+        "read durable desktop settings; omit key to return the complete map",
+        Annotations::READ_ONLY,
+        move |input| {
+            let store = get_store.clone();
+            async move {
+                let guard = store
+                    .lock()
+                    .map_err(|_| CapabilityError::Handler("settings lock poisoned".into()))?;
+                let document = guard.document().map_err(CapabilityError::Handler)?;
+                let values = match input.key {
+                    Some(key) => {
+                        validate_keys(std::iter::once(key.as_str()))
+                            .map_err(CapabilityError::InvalidInput)?;
+                        document
+                            .values
+                            .get(&key)
+                            .cloned()
+                            .map(|value| BTreeMap::from([(key, value)]))
+                            .unwrap_or_default()
+                    }
+                    None => document.values.clone(),
+                };
+                Ok(GetSettingsOutput {
+                    schema_version: document.schema_version,
+                    local_storage_migrated: document.local_storage_migrated,
+                    values,
+                })
+            }
+        },
+    ));
+
+    registry.register(Capability::typed::<SetSettingsInput, SetSettingsOutput, _, _>(
+        "settings.set",
+        "atomically write or remove durable desktop settings",
+        Annotations::MUTATING,
+        move |input| {
+            let store = store.clone();
+            async move {
+                let guard = store
+                    .lock()
+                    .map_err(|_| CapabilityError::Handler("settings lock poisoned".into()))?;
+                guard.update(input).map_err(CapabilityError::Handler)?;
+                Ok(SetSettingsOutput { saved: true })
+            }
+        },
+    ));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn document_roundtrips_and_reopens() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        let store = FileSettingsStore::new(path.clone());
+        store
+            .update(SetSettingsInput {
+                values: BTreeMap::from([
+                    ("theme".into(), json!({"mode": "dark"})),
+                    ("scale".into(), json!(120)),
+                ]),
+                remove: vec![],
+                local_storage_migrated: Some(true),
+            })
+            .unwrap();
+
+        let reopened = read_document(&path).unwrap();
+        assert_eq!(reopened.schema_version, SCHEMA_VERSION);
+        assert!(reopened.local_storage_migrated);
+        assert_eq!(reopened.values["scale"], json!(120));
+        assert_eq!(reopened.values["theme"], json!({"mode": "dark"}));
+        assert!(!dir.path().join(format!(".settings.json.tmp-{}", std::process::id())).exists());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(fs::metadata(&path).unwrap().permissions().mode() & 0o777, 0o600);
+        }
+    }
+
+    #[test]
+    fn failed_update_does_not_change_the_loaded_document() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        let store = FileSettingsStore::new(path);
+        store
+            .update(SetSettingsInput {
+                values: BTreeMap::from([("ok".into(), json!(1))]),
+                ..Default::default()
+            })
+            .unwrap();
+        let error = store
+            .update(SetSettingsInput {
+                values: BTreeMap::from([("\n".into(), json!(2))]),
+                ..Default::default()
+            })
+            .unwrap_err();
+        assert!(error.contains("control"));
+        assert_eq!(
+            store.document().unwrap().values,
+            BTreeMap::from([("ok".into(), json!(1))])
+        );
+    }
+
+    #[tokio::test]
+    async fn capabilities_read_write_filter_and_remove() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut registry = srelens_capability::Registry::new();
+        register(&mut registry, dir.path().join("settings.json"));
+
+        registry
+            .invoke(
+                "settings.set",
+                json!({"values": {"a": 1, "b": {"nested": true}}, "localStorageMigrated": true}),
+            )
+            .await
+            .unwrap();
+        let one = registry.invoke("settings.get", json!({"key": "b"})).await.unwrap();
+        assert_eq!(one["values"], json!({"b": {"nested": true}}));
+        assert_eq!(one["localStorageMigrated"], json!(true));
+
+        registry
+            .invoke("settings.set", json!({"remove": ["a"]}))
+            .await
+            .unwrap();
+        let all = registry.invoke("settings.get", json!({})).await.unwrap();
+        assert_eq!(all["values"], json!({"b": {"nested": true}}));
+
+        assert_eq!(registry.get("settings.get").unwrap().annotations, Annotations::READ_ONLY);
+        assert_eq!(registry.get("settings.set").unwrap().annotations, Annotations::MUTATING);
+    }
+
+    #[test]
+    fn corrupt_or_future_documents_are_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        fs::write(&path, b"{not json").unwrap();
+        assert!(read_document(&path).unwrap_err().contains("parse"));
+        fs::write(
+            &path,
+            br#"{"schema_version":99,"local_storage_migrated":false,"values":{}}"#,
+        )
+        .unwrap();
+        assert!(read_document(&path).unwrap_err().contains("unsupported settings schema"));
+    }
+
+    #[test]
+    fn oversized_documents_are_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        fs::write(&path, vec![b' '; MAX_DOCUMENT_BYTES + 1]).unwrap();
+        assert!(read_document(&path).unwrap_err().contains("1 MB"));
+
+        let document = SettingsDocument {
+            values: BTreeMap::from([("large".into(), json!("x".repeat(MAX_DOCUMENT_BYTES)))]),
+            ..Default::default()
+        };
+        assert!(write_document(&path, &document).unwrap_err().contains("1 MB"));
+    }
+
+    #[test]
+    fn default_path_is_bound_to_the_application_identifier() {
+        let path = default_settings_path();
+        assert!(path.ends_with(Path::new("app.srelens.desktop").join("settings.json")));
+    }
+}

--- a/crates/registry/src/settings.rs
+++ b/crates/registry/src/settings.rs
@@ -122,14 +122,14 @@ impl FileSettingsStore {
 
 fn validate_keys<'a>(keys: impl Iterator<Item = &'a str>) -> Result<(), String> {
     for key in keys {
+        if key.chars().any(char::is_control) {
+            return Err("setting key must not contain control characters".into());
+        }
         if key.trim().is_empty() {
             return Err("setting key must not be empty".into());
         }
         if key.len() > 256 {
             return Err("setting key must be at most 256 bytes".into());
-        }
-        if key.chars().any(char::is_control) {
-            return Err("setting key must not contain control characters".into());
         }
     }
     Ok(())

--- a/crates/registry/src/settings.rs
+++ b/crates/registry/src/settings.rs
@@ -18,6 +18,8 @@ use srelens_capability::{Annotations, Capability, CapabilityError};
 
 const SCHEMA_VERSION: u32 = 1;
 const MAX_DOCUMENT_BYTES: usize = 1024 * 1024;
+/// The trailing newline `write_document` appends, counted against the limit.
+const NEWLINE_BYTES: usize = 1;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
@@ -105,6 +107,12 @@ impl FileSettingsStore {
         validate_keys(input.values.keys().map(String::as_str))?;
         validate_keys(input.remove.iter().map(String::as_str))?;
 
+        // Held across the WHOLE read-modify-rename. The process-local mutex
+        // only serializes registries inside one process; the GUI and a
+        // separately launched `--mcp-stdio` / `--mcp-http` process each have
+        // their own, so without this both could read the same document and
+        // the later rename would silently drop the other's unrelated keys.
+        let _guard = write_lock(&self.path)?;
         let mut next = self.document()?;
         for (key, value) in input.values {
             next.values.insert(key, value);
@@ -118,6 +126,24 @@ impl FileSettingsStore {
         write_document(&self.path, &next)?;
         Ok(())
     }
+}
+
+/// An exclusive advisory lock on a sibling `.lock` file, serializing the
+/// read-modify-write across processes. Mirrors `vault::transition_lock`. The
+/// lock lives beside the document rather than on it, so the atomic rename
+/// never swaps the file the lock is held on.
+fn write_lock(path: &Path) -> Result<fs::File, String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("{} has no parent directory", path.display()))?;
+    fs::create_dir_all(parent).map_err(|error| format!("create {}: {error}", parent.display()))?;
+    let file_name = path.file_name().and_then(|name| name.to_str()).unwrap_or("settings.json");
+    let lock_path = parent.join(format!("{file_name}.lock"));
+    let lock = fs::File::create(&lock_path)
+        .map_err(|error| format!("create {}: {error}", lock_path.display()))?;
+    lock.lock()
+        .map_err(|error| format!("lock {}: {error}", lock_path.display()))?;
+    Ok(lock)
 }
 
 fn validate_keys<'a>(keys: impl Iterator<Item = &'a str>) -> Result<(), String> {
@@ -168,7 +194,12 @@ fn write_document(path: &Path, document: &SettingsDocument) -> Result<(), String
     let file_name = path.file_name().and_then(|name| name.to_str()).unwrap_or("settings.json");
     let temp = parent.join(format!(".{file_name}.tmp-{}", std::process::id()));
     let raw = serde_json::to_vec_pretty(document).map_err(|error| error.to_string())?;
-    if raw.len() > MAX_DOCUMENT_BYTES {
+    // The write below appends a trailing newline, so the on-disk file is one
+    // byte longer than `raw`. Checking `raw` alone would accept a document of
+    // exactly the limit, write limit+1 bytes, and leave a file that
+    // `read_document` then rejects forever — settings unreachable until
+    // someone deletes the file by hand.
+    if raw.len() + NEWLINE_BYTES > MAX_DOCUMENT_BYTES {
         return Err("settings document exceeds the 1 MB limit".into());
     }
 
@@ -200,11 +231,19 @@ fn write_document(path: &Path, document: &SettingsDocument) -> Result<(), String
 
 /// The stable settings path shared by GUI and headless MCP launches. It is
 /// derived from the Tauri bundle identifier, so binary renames do not move it.
-pub fn default_settings_path() -> PathBuf {
-    dirs::config_dir()
-        .expect("could not resolve the platform config directory")
-        .join("app.srelens.desktop")
-        .join("settings.json")
+///
+/// `None` when the platform config directory cannot be resolved (on Linux,
+/// both `XDG_CONFIG_HOME` and `HOME` unset). This is deliberately not a panic:
+/// the GUI builds its registry BEFORE Tauri starts, so panicking here stopped
+/// the application from opening at all instead of reaching the frontend's
+/// localStorage fallback. `None` simply leaves the settings capabilities
+/// unregistered, which is the case that fallback already handles.
+pub fn default_settings_path() -> Option<PathBuf> {
+    Some(
+        dirs::config_dir()?
+            .join("app.srelens.desktop")
+            .join("settings.json"),
+    )
 }
 
 /// Register `settings.get` and `settings.set` backed by `path`.
@@ -393,7 +432,71 @@ mod tests {
 
     #[test]
     fn default_path_is_bound_to_the_application_identifier() {
-        let path = default_settings_path();
+        // Some() on any machine with a resolvable config dir; the None arm is
+        // the unresolvable-config-dir case, which must not panic the GUI.
+        let path = default_settings_path().expect("config dir resolvable in the test environment");
         assert!(path.ends_with(Path::new("app.srelens.desktop").join("settings.json")));
+    }
+
+    #[test]
+    fn a_document_at_the_limit_is_refused_rather_than_written_unreadable() {
+        // The trailing newline is what makes this subtle: a payload that
+        // serializes to exactly the limit used to pass the pre-write check,
+        // land as limit+1 bytes, and then be rejected by every later read —
+        // settings permanently unreachable. Refusing up front is the fix, so
+        // whatever IS accepted must still be readable afterwards.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+
+        let mut filler = MAX_DOCUMENT_BYTES;
+        let document = loop {
+            let candidate = SettingsDocument {
+                values: BTreeMap::from([("k".into(), json!("x".repeat(filler)))]),
+                ..Default::default()
+            };
+            let len = serde_json::to_vec_pretty(&candidate).unwrap().len();
+            if len + NEWLINE_BYTES <= MAX_DOCUMENT_BYTES {
+                break candidate;
+            }
+            // Step down until the serialized form plus its newline just fits.
+            filler -= (len + NEWLINE_BYTES - MAX_DOCUMENT_BYTES).max(1);
+        };
+
+        write_document(&path, &document).expect("a document that fits must be written");
+        let on_disk = fs::metadata(&path).unwrap().len() as usize;
+        assert!(on_disk <= MAX_DOCUMENT_BYTES, "wrote {on_disk} bytes, over the limit");
+        read_document(&path).expect("anything written must be readable back");
+    }
+
+    #[test]
+    fn the_write_lock_excludes_other_processes() {
+        // The process-local mutex cannot serialize a separately launched
+        // --mcp-stdio process, so the read-modify-rename takes a file lock.
+        // Proven by mutual exclusion rather than by racing threads, which
+        // could pass by luck.
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        let held = write_lock(&path).unwrap();
+
+        let (tx, rx) = mpsc::channel();
+        let other = path.clone();
+        let handle = std::thread::spawn(move || {
+            let _guard = write_lock(&other).unwrap();
+            tx.send(()).unwrap();
+        });
+
+        assert!(
+            rx.recv_timeout(Duration::from_millis(300)).is_err(),
+            "a second holder acquired the lock while it was held"
+        );
+        drop(held);
+        assert!(
+            rx.recv_timeout(Duration::from_secs(10)).is_ok(),
+            "the lock was never released to the waiter"
+        );
+        handle.join().unwrap();
     }
 }

--- a/crates/server/src/api_settings.rs
+++ b/crates/server/src/api_settings.rs
@@ -1,6 +1,9 @@
 //! Per-user settings API: `GET`/`PUT`/`DELETE /api/settings/:key`. Backs
 //! saved port-forwards (and future per-user preferences) on the web; the
-//! desktop app persists the equivalent state in `localStorage` instead.
+//! desktop app persists the equivalent state in its durable settings file
+//! (`crates/registry/src/settings.rs`) instead. Web preferences OTHER than
+//! these rows stay in the browser's `localStorage`, so they are scoped to a
+//! browser profile rather than to an account.
 //!
 //! Values are opaque JSON, stored and returned verbatim in `value_json` —
 //! this route never inspects the shape, it just round-trips whatever the

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -400,8 +400,14 @@ Desktop preferences are stored in a schema-versioned `settings.json` under the
 OS application-config directory (`app.srelens.desktop`). That location is tied
 to the application identifier rather than the executable name, so preferences
 survive dev/installed builds and binary renames. The first launch after an
-upgrade imports the previous WebView `localStorage` values automatically. Web
-mode continues to keep each user's settings in the server database.
+upgrade imports the previous WebView `localStorage` values automatically.
+
+Web mode is different. Most preferences — theme, layout, namespace selections,
+request timeout, interface scale — stay in the browser's own `localStorage`, so
+they belong to that **browser profile rather than to your account**: they do not
+follow you to another browser or machine, and anyone sharing the profile shares
+them. Saved port-forwards are the exception, stored per user in the server
+database through the settings API.
 
 ## Updating
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -396,6 +396,13 @@ bearer token good for this loopback MCP server and nothing else.
 7. **Updates** — version, release channel, and the in-app updater
    ([below](#updating)).
 
+Desktop preferences are stored in a schema-versioned `settings.json` under the
+OS application-config directory (`app.srelens.desktop`). That location is tied
+to the application identifier rather than the executable name, so preferences
+survive dev/installed builds and binary renames. The first launch after an
+upgrade imports the previous WebView `localStorage` values automatically. Web
+mode continues to keep each user's settings in the server database.
+
 ## Updating
 
 Open **Settings → Updates** to check for and install new versions. Choose the

--- a/docs/mcp-catalog.md
+++ b/docs/mcp-catalog.md
@@ -5,7 +5,7 @@
 
 Everything this server exposes over MCP, generated from the live registry so it cannot drift. Written for someone wiring an agent to srelens; the narrative reference is [MCP.md](MCP.md).
 
-## Tools (82)
+## Tools (84)
 
 Argument schemas are not reproduced here — call `tools/list` for those, which cannot go stale.
 
@@ -135,11 +135,18 @@ Argument schemas are not reproduced here — call `tools/list` for those, which 
 | `toolbox.removePlugin` | remove an installed krew plugin |
 | `toolbox.upgradePlugin` | upgrade an installed krew plugin |
 
-### Server — read-only (1)
+### Server — read-only (2)
 
 | Tool | Summary |
 | --- | --- |
 | `ping` | health check; echoes the input back as { pong: <input> } |
+| `settings.get` | read durable desktop settings; omit key to return the complete map |
+
+### Server — needs confirmation (1)
+
+| Tool | Summary |
+| --- | --- |
+| `settings.set` | atomically write or remove durable desktop settings |
 
 ## Prompts (4)
 


### PR DESCRIPTION
## Summary

- add schema-versioned, atomic file-backed desktop settings capabilities
- boot-load settings into a synchronous frontend mirror and write changes through
- migrate known WebView localStorage preferences once, including legacy keys
- expose settings.get and confirmation-gated settings.set through desktop MCP
- keep web settings isolated in the existing per-user database store

## Validation

- `git diff --check`
- capability catalog JSON parsed, sorted, and verified at 84 entries
- Cargo manifests parsed successfully
- added Rust persistence/capability tests and frontend migration/write-through tests

## Not run locally

- Rust tests and formatting (Rust toolchain unavailable in the workspace)
- Vitest/build (frontend dependencies unavailable in the workspace)

Closes #34