### PR TITLE
ci(frontend): typecheck with tsc, which nothing in CI did

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,12 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      # Nothing else in CI typechecks (#249): `vite build` strips types with
+      # esbuild and Vitest transpiles per file, so a real type error passed
+      # every check until it was caught by hand (PR #248, main.tsx). Runs
+      # before the build — it is the fastest step and the most likely to fail.
+      - name: Typecheck
+        run: pnpm typecheck
       - name: Build
         run: pnpm build
       - name: Unit tests with coverage

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "typecheck": "tsc --noEmit",
     "preview": "vite preview",
     "tauri": "tauri",
     "test": "vitest run --coverage",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,12 @@
     "dev": "pnpm --filter @srelens/desktop tauri dev",
     "tauri": "pnpm --filter @srelens/desktop tauri",
     "build": "pnpm --filter @srelens/desktop build",
+    "typecheck": "pnpm -r typecheck",
     "test": "pnpm -r test"
   },
-  "devDependencies": { "turbo": "^2.0.0" },
+  "devDependencies": {
+    "turbo": "^2.0.0"
+  },
   "pnpm": {
     "overrides": {
       "fast-uri@>=3.0.0 <3.1.4": "^3.1.4",


### PR DESCRIPTION
Closes #249.

## Problem
No CI job typechecked the frontend. `pnpm build` is Vite/esbuild, which strips types without checking them, and `pnpm -r test` is Vitest, which transpiles per file — so `tsc` never ran anywhere. A type error could land on `dev` with every check green, and one did: PR #248 passed all seven checks while `main.tsx` had

```
error TS2345: Argument of type 'HTMLElement | null' is not assignable to parameter of type 'Container'.
```

It was caught only by running `npx tsc --noEmit` by hand during review.

## Change
- `typecheck` script on `@srelens/desktop` (`tsc --noEmit`) and a root passthrough (`pnpm -r typecheck`), mirroring how `test` is already wired
- A **Typecheck** step in the `frontend` job, placed before the build: it is the cheapest step and the most likely to fail, so it should fail fast

## Verification
Rather than just asserting the gate works, I reintroduced the exact #248 error and ran all three gates against it:

| Gate | With the type error |
| --- | --- |
| `pnpm build` | exit **0** — passes |
| `vitest run` | exit **0** — passes |
| `pnpm typecheck` | exit **2** — **fails** |

That's the gap the issue describes, and the new step closes it. Current `dev` typechecks clean, so this goes green immediately.