### PR TITLE
feat(session): restore open tabs and contexts on restart

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -27,7 +27,7 @@ import { Dock, type DockSession, type DockKind } from "./components/Dock";
 import { StatusBar } from "./components/StatusBar";
 import { LandingPage } from "./components/LandingPage";
 import { getInitialTheme, applyTheme, type Theme, type ThemeMode, type ThemeName } from "./ui";
-import type { CrdRef } from "./lib/crds";
+import { listCrds, type CrdRef } from "./lib/crds";
 import type { ResourceTarget } from "./lib/resourceNavigation";
 import {
   loadClusterNamespaces,
@@ -50,7 +50,14 @@ import {
   loadMcpSettings,
 } from "./lib/settings";
 import { applyUiScale, getUiScale, setUiScale, stepUiScale, uiScaleShortcut } from "./lib/uiScale";
-import { loadOpenTabs, saveOpenTabs, nextTabId, pruneMissingContexts } from "./lib/openTabs";
+import {
+  loadOpenTabs,
+  saveOpenTabs,
+  nextTabId,
+  pruneMissingContexts,
+  reconcileActiveTab,
+  reconcileCrdTabs,
+} from "./lib/openTabs";
 import { startMcpHttp } from "./lib/mcp";
 import { checkForUpdateAndNotify } from "./lib/updateNotifier";
 import { notify } from "./lib/notify";
@@ -134,20 +141,26 @@ export function App() {
       // Auto close any tabs of clusters/contexts that no longer exist!
       if (o.contexts) {
         const names = o.contexts.map((c) => c.name);
-        setTabs((ts) => {
-          const { tabs: kept, dropped } = pruneMissingContexts(ts, names);
+        // Computed from the ref rather than inside the updater: the active id
+        // has to be reconciled alongside, and state updaters must stay free
+        // of side effects (React re-invokes them in development).
+        const { tabs: kept, dropped } = pruneMissingContexts(tabsRef.current, names);
+        if (dropped > 0) {
+          setTabs(kept);
+          // Without this the workspace goes blank behind a populated tab
+          // strip, and the native close command loses its no-tabs path.
+          setActiveTabId((cur) => reconcileActiveTab(kept, cur));
           // Say something only for a RESTORED session (#159): a user who just
           // removed a kubeconfig already knows why those tabs closed, and
           // this runs on every kubeconfig change.
-          if (dropped > 0 && !sessionPruneReported.current) {
+          if (!sessionPruneReported.current) {
             notify.info(
               dropped === 1 ? "Closed 1 restored tab" : `Closed ${dropped} restored tabs`,
               "Their cluster context is no longer available.",
             );
           }
-          sessionPruneReported.current = true;
-          return kept;
-        });
+        }
+        sessionPruneReported.current = true;
       }
     });
   };
@@ -155,6 +168,50 @@ export function App() {
   useEffect(() => {
     refreshContexts();
   }, [kubeconfigFiles]);
+
+  // Restored CRD tabs carry a CrdRef captured in a previous session (#159).
+  // The CRD may since have been deleted, or may now serve a different version,
+  // and CustomResourceBrowser would surface that as a raw API error. Validate
+  // once per launch, per context that actually has a restored CRD tab.
+  const crdTabsValidated = useRef(false);
+  useEffect(() => {
+    if (crdTabsValidated.current || !contexts || !restored) return;
+    const pending = [...new Set(
+      tabsRef.current.filter((t) => t.crd && t.cluster).map((t) => t.cluster as string),
+    )].filter((name) => contexts.some((c) => c.name === name));
+    if (pending.length === 0) return;
+    crdTabsValidated.current = true;
+
+    let cancelled = false;
+    void Promise.all(
+      pending.map(async (context) => ({ context, result: await listCrds(context) })),
+    ).then((results) => {
+      if (cancelled) return;
+      let total = 0;
+      let next = tabsRef.current;
+      for (const { context, result } of results) {
+        // Only a SUCCESSFUL discovery is evidence of absence. An unreachable
+        // cluster must never silently delete the user's restored tabs.
+        if (!result.crds) continue;
+        const reconciled = reconcileCrdTabs(next, context, result.crds);
+        next = reconciled.tabs;
+        total += reconciled.dropped;
+      }
+      if (next !== tabsRef.current) {
+        setTabs(next);
+        setActiveTabId((cur) => reconcileActiveTab(next, cur));
+      }
+      if (total > 0) {
+        notify.info(
+          total === 1 ? "Closed 1 restored tab" : `Closed ${total} restored tabs`,
+          "Their custom resource is no longer installed.",
+        );
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [contexts, restored]);
 
   // Listen to external/internal kubeconfig changes
   useEffect(() => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -50,7 +50,7 @@ import {
   loadMcpSettings,
 } from "./lib/settings";
 import { applyUiScale, getUiScale, setUiScale, stepUiScale, uiScaleShortcut } from "./lib/uiScale";
-import { loadOpenTabs, saveOpenTabs, nextTabId } from "./lib/openTabs";
+import { loadOpenTabs, saveOpenTabs, nextTabId, pruneMissingContexts } from "./lib/openTabs";
 import { startMcpHttp } from "./lib/mcp";
 import { checkForUpdateAndNotify } from "./lib/updateNotifier";
 import { notify } from "./lib/notify";
@@ -120,6 +120,9 @@ export function App() {
 
   const [contexts, setContexts] = useState<ClusterContext[] | null>(null);
   const [contextsError, setContextsError] = useState("");
+  // The restored-session notice fires at most once, on the first contexts
+  // resolution after launch.
+  const sessionPruneReported = useRef(false);
 
   const refreshContexts = () => {
     // Web has no local kubeconfig files to merge in — the server resolves
@@ -130,8 +133,21 @@ export function App() {
 
       // Auto close any tabs of clusters/contexts that no longer exist!
       if (o.contexts) {
-        const existingNames = new Set(o.contexts.map((c) => c.name));
-        setTabs((ts) => ts.filter((t) => !t.cluster || existingNames.has(t.cluster)));
+        const names = o.contexts.map((c) => c.name);
+        setTabs((ts) => {
+          const { tabs: kept, dropped } = pruneMissingContexts(ts, names);
+          // Say something only for a RESTORED session (#159): a user who just
+          // removed a kubeconfig already knows why those tabs closed, and
+          // this runs on every kubeconfig change.
+          if (dropped > 0 && !sessionPruneReported.current) {
+            notify.info(
+              dropped === 1 ? "Closed 1 restored tab" : `Closed ${dropped} restored tabs`,
+              "Their cluster context is no longer available.",
+            );
+          }
+          sessionPruneReported.current = true;
+          return kept;
+        });
       }
     });
   };

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -180,13 +180,17 @@ export function App() {
       tabsRef.current.filter((t) => t.crd && t.cluster).map((t) => t.cluster as string),
     )].filter((name) => contexts.some((c) => c.name === name));
     if (pending.length === 0) return;
-    crdTabsValidated.current = true;
 
     let cancelled = false;
     void Promise.all(
       pending.map(async (context) => ({ context, result: await listCrds(context) })),
     ).then((results) => {
+      // Superseded by a newer contexts value (a kubeconfig change mid-flight):
+      // drop this result and leave the one-shot flag CLEAR, so the replacement
+      // effect still validates. Setting it before the await would have retired
+      // the check without it ever having run.
       if (cancelled) return;
+      crdTabsValidated.current = true;
       let total = 0;
       let next = tabsRef.current;
       for (const { context, result } of results) {

--- a/apps/desktop/src/components/SettingsView.tsx
+++ b/apps/desktop/src/components/SettingsView.tsx
@@ -57,7 +57,9 @@ import {
   contextDisplayName,
   clampTimeoutSecs,
   getRequestTimeoutSecs,
+  loadRestoreSession,
   loadUpdateChannel,
+  saveRestoreSession,
   saveUpdateChannel,
   type ContextLogo,
   type ContextProfiles,
@@ -228,6 +230,7 @@ export function SettingsView({
     // committed timeout alone until it becomes a number again.
     if (raw.trim() !== "" && Number.isFinite(Number(raw))) changeRequestTimeout(Number(raw));
   };
+  const [restoreSession, setRestoreSession] = useState(() => loadRestoreSession());
   const [uiScale, setUiScaleState] = useState(() => getUiScale());
   // The zoom shortcuts (App.tsx) announce changes so an open slider tracks them.
   useEffect(() => {
@@ -624,6 +627,23 @@ export function SettingsView({
                   />
                 </label>
               </div>
+              <label className="fl-settings-toggle">
+                <input
+                  type="checkbox"
+                  checked={restoreSession}
+                  onChange={(event) => {
+                    setRestoreSession(event.target.checked);
+                    saveRestoreSession(event.target.checked);
+                  }}
+                />
+                <span>
+                  <strong>Reopen tabs on launch</strong>
+                  <small>
+                    Start where you left off. Turn this off to open a clean workspace every
+                    time; tabs whose cluster is gone are closed either way.
+                  </small>
+                </span>
+              </label>
               <Button variant="ghost" size="sm" className="mt-3" onClick={() => onLayoutChange({ ...DEFAULT_WORKSPACE_LAYOUT })}>
                 <RotateCcw data-icon="inline-start" />
                 Restore layout defaults

--- a/apps/desktop/src/lib/openTabs.test.ts
+++ b/apps/desktop/src/lib/openTabs.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { loadOpenTabs, saveOpenTabs, nextTabId, pruneMissingContexts } from "./openTabs";
+import type { CrdRef } from "./crds";
+import {
+  loadOpenTabs,
+  saveOpenTabs,
+  nextTabId,
+  pruneMissingContexts,
+  reconcileActiveTab,
+  reconcileCrdTabs,
+} from "./openTabs";
 
 // ViewTab is a type; tests build plain objects matching its shape.
 type Tab = Parameters<typeof saveOpenTabs>[0][number];
@@ -164,5 +172,64 @@ describe("nextTabId", () => {
   });
   it("is 1 for an empty set", () => {
     expect(nextTabId([])).toBe(1);
+  });
+});
+
+describe("reconcileActiveTab", () => {
+  it("keeps the active tab when it survived the prune", () => {
+    expect(reconcileActiveTab([tab({ id: 1 }), tab({ id: 2 })], 2)).toBe(2);
+  });
+
+  it("falls back to the first survivor when the active tab was pruned", () => {
+    // Otherwise the workspace renders blank behind a populated tab strip.
+    expect(reconcileActiveTab([tab({ id: 3 }), tab({ id: 4 })], 99)).toBe(3);
+  });
+
+  it("clears the active id when nothing survives", () => {
+    // A stale id here also costs the native close command its no-tabs path.
+    expect(reconcileActiveTab([], 7)).toBeNull();
+  });
+});
+
+describe("reconcileCrdTabs", () => {
+  const crd = (over: Partial<CrdRef> = {}): CrdRef => ({
+    name: "widgets.example.com",
+    group: "example.com",
+    version: "v1",
+    kind: "Widget",
+    plural: "widgets",
+    namespaced: true,
+    ...over,
+  });
+  const crdTab = (id: number, over: Partial<CrdRef> = {}) =>
+    ({ ...tab({ id, cluster: "prod" }), crd: crd(over) }) as Tab;
+
+  it("drops a tab whose CRD is no longer installed", () => {
+    const result = reconcileCrdTabs([crdTab(1)], "prod", []);
+    expect(result.tabs).toHaveLength(0);
+    expect(result.dropped).toBe(1);
+  });
+
+  it("adopts the currently served version instead of dropping the tab", () => {
+    // The CRD still exists, just at v2 — keeping the stale v1 ref would query
+    // a version the cluster no longer serves.
+    const result = reconcileCrdTabs([crdTab(1)], "prod", [crd({ version: "v2" })]);
+    expect(result.dropped).toBe(0);
+    expect(result.tabs[0].crd?.version).toBe("v2");
+  });
+
+  it("leaves tabs from other contexts and non-CRD tabs untouched", () => {
+    const other = { ...tab({ id: 2, cluster: "staging" }), crd: crd() } as Tab;
+    const plain = tab({ id: 3, cluster: "prod" });
+    const result = reconcileCrdTabs([other, plain], "prod", []);
+    expect(result.tabs.map((t) => t.id)).toEqual([2, 3]);
+    expect(result.dropped).toBe(0);
+  });
+
+  it("returns the same tab objects when nothing changed", () => {
+    const tabs = [crdTab(1)];
+    const result = reconcileCrdTabs(tabs, "prod", [crd()]);
+    expect(result.tabs[0]).toBe(tabs[0]);
+    expect(result.dropped).toBe(0);
   });
 });

--- a/apps/desktop/src/lib/openTabs.test.ts
+++ b/apps/desktop/src/lib/openTabs.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { loadOpenTabs, saveOpenTabs, nextTabId } from "./openTabs";
+import { loadOpenTabs, saveOpenTabs, nextTabId, pruneMissingContexts } from "./openTabs";
 
 // ViewTab is a type; tests build plain objects matching its shape.
 type Tab = Parameters<typeof saveOpenTabs>[0][number];
@@ -95,13 +95,66 @@ describe("openTabs on desktop", () => {
     localStorage.clear();
   });
 
-  it("never reads or writes localStorage", () => {
+  // #159 changed this deliberately: the desktop used to be a no-op and start
+  // blank every launch. It now persists through the same settingsStorage
+  // path as the web, which is file-backed once the durable store loads.
+  it("persists and restores like the web does", () => {
     setDesktop(true);
-    saveOpenTabs([tab({ id: 1 })], 1);
-    expect(localStorage.getItem(KEY)).toBeNull();
-    // Even with data present, desktop restore is a no-op.
-    localStorage.setItem(KEY, JSON.stringify({ tabs: [tab({ id: 9 })], activeTabId: 9 }));
+    saveOpenTabs([tab({ id: 1 }), tab({ id: 2, kind: "services" })], 2);
+    const restored = loadOpenTabs();
+    expect(restored?.tabs.map((t) => t.id)).toEqual([1, 2]);
+    expect(restored?.activeTabId).toBe(2);
+  });
+});
+
+describe("session restore opt-out", () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("starts fresh when disabled, without discarding the stored session", () => {
+    saveOpenTabs([tab({ id: 4 })], 4);
+    expect(loadOpenTabs()?.tabs).toHaveLength(1);
+
+    localStorage.setItem("srelens.restoreSession", "false");
     expect(loadOpenTabs()).toBeNull();
+    // A later save must not clobber the snapshot either, so re-enabling the
+    // setting brings back the real session rather than an empty one.
+    saveOpenTabs([tab({ id: 5 })], 5);
+    localStorage.setItem("srelens.restoreSession", "true");
+    expect(loadOpenTabs()?.tabs.map((t) => t.id)).toEqual([4]);
+  });
+
+  it("is on unless explicitly disabled", () => {
+    saveOpenTabs([tab({ id: 6 })], 6);
+    localStorage.setItem("srelens.restoreSession", "garbage");
+    expect(loadOpenTabs()?.tabs).toHaveLength(1);
+  });
+});
+
+describe("pruneMissingContexts", () => {
+  it("drops tabs whose cluster is gone and reports how many", () => {
+    const result = pruneMissingContexts(
+      [tab({ id: 1, cluster: "prod" }), tab({ id: 2, cluster: "retired" })],
+      ["prod"],
+    );
+    expect(result.tabs.map((t) => t.id)).toEqual([1]);
+    expect(result.dropped).toBe(1);
+  });
+
+  it("keeps cluster-less tabs, which do not depend on a context", () => {
+    // Settings/Toolbox/landing tabs must survive a context disappearing.
+    const result = pruneMissingContexts(
+      [tab({ id: 1, cluster: null }), tab({ id: 2, cluster: "gone" })],
+      [],
+    );
+    expect(result.tabs.map((t) => t.id)).toEqual([1]);
+    expect(result.dropped).toBe(1);
+  });
+
+  it("reports nothing dropped when every context is still present", () => {
+    const tabs = [tab({ id: 1, cluster: "a" }), tab({ id: 2, cluster: "b" })];
+    expect(pruneMissingContexts(tabs, ["a", "b"])).toEqual({ tabs, dropped: 0 });
   });
 });
 

--- a/apps/desktop/src/lib/openTabs.ts
+++ b/apps/desktop/src/lib/openTabs.ts
@@ -1,10 +1,13 @@
-// Web-mode persistence of the open workspace tabs. In the desktop shell the
-// window stays open, so tab state lives only in memory; in a browser a reload
-// wipes React state and would dump the user back on the landing page. To avoid
-// that, web mode serializes the open tabs + active tab to localStorage and
-// rehydrates them on load. Desktop is a no-op (isTauri guard).
+// Session restore: the open workspace tabs + active tab survive a restart.
+//
+// This began as web-only (a browser reload wipes React state and dumps the
+// user on the landing page). Issue #159 extends it to the desktop, which used
+// to start blank every launch. Both now go through `settingsStorage`, so the
+// desktop writes into the durable settings file (#34) while web keeps using
+// localStorage — one code path, no platform branch.
 
-import { isTauri } from "../transport/platform";
+import { loadRestoreSession } from "./settings";
+import { settingsStorage } from "./settingsStorage";
 import type { ViewTab } from "../App";
 
 const KEY = "srelens.openTabs";
@@ -28,9 +31,12 @@ function isRestorable(t: ViewTab): boolean {
  * to the landing page.
  */
 export function loadOpenTabs(): PersistedWorkspace | null {
-  if (isTauri()) return null;
+  // Opting out starts fresh but deliberately leaves the stored snapshot
+  // alone, so turning the setting back on restores the last real session
+  // instead of nothing.
+  if (!loadRestoreSession()) return null;
   try {
-    const raw = localStorage.getItem(KEY);
+    const raw = settingsStorage.getItem(KEY);
     if (!raw) return null;
     const parsed = JSON.parse(raw) as PersistedWorkspace;
     if (!parsed || !Array.isArray(parsed.tabs)) return null;
@@ -61,18 +67,33 @@ export function nextTabId(tabs: ViewTab[]): number {
 
 /** Persist the open tabs + active tab (web-only, best-effort). */
 export function saveOpenTabs(tabs: ViewTab[], activeTabId: number | null): void {
-  if (isTauri()) return;
+  if (!loadRestoreSession()) return;
   try {
     const persist = tabs.filter(isRestorable);
     if (persist.length === 0) {
-      localStorage.removeItem(KEY);
+      settingsStorage.removeItem(KEY);
       return;
     }
     const active = persist.some((t) => t.id === activeTabId)
       ? activeTabId
       : persist[0].id;
-    localStorage.setItem(KEY, JSON.stringify({ tabs: persist, activeTabId: active }));
+    settingsStorage.setItem(KEY, JSON.stringify({ tabs: persist, activeTabId: active }));
   } catch {
-    // localStorage full or disabled — best-effort, ignore.
+    // Storage full, disabled, or the settings write failed — best-effort.
   }
+}
+
+/**
+ * Drop restored tabs whose cluster is no longer among the discovered
+ * contexts, returning the survivors and how many were dropped. Cluster-less
+ * tabs (Settings, Toolbox, the landing view) are always kept — they do not
+ * depend on a context existing.
+ */
+export function pruneMissingContexts(
+  tabs: ViewTab[],
+  contexts: readonly string[],
+): { tabs: ViewTab[]; dropped: number } {
+  const available = new Set(contexts);
+  const kept = tabs.filter((t) => !t.cluster || available.has(t.cluster));
+  return { tabs: kept, dropped: tabs.length - kept.length };
 }

--- a/apps/desktop/src/lib/openTabs.ts
+++ b/apps/desktop/src/lib/openTabs.ts
@@ -8,6 +8,7 @@
 
 import { loadRestoreSession } from "./settings";
 import { settingsStorage } from "./settingsStorage";
+import type { CrdRef } from "./crds";
 import type { ViewTab } from "../App";
 
 const KEY = "srelens.openTabs";
@@ -89,6 +90,51 @@ export function saveOpenTabs(tabs: ViewTab[], activeTabId: number | null): void 
  * tabs (Settings, Toolbox, the landing view) are always kept — they do not
  * depend on a context existing.
  */
+/**
+ * The active tab id after a prune: keep it when it survived, otherwise fall
+ * back to the first remaining tab, or null when nothing is left. A stale id
+ * would leave the workspace blank behind a populated tab strip, and would
+ * also stop the native close command taking its no-tabs path.
+ */
+export function reconcileActiveTab(tabs: ViewTab[], activeTabId: number | null): number | null {
+  if (tabs.length === 0) return null;
+  return tabs.some((t) => t.id === activeTabId) ? activeTabId : tabs[0].id;
+}
+
+/**
+ * Reconcile restored CRD tabs for one context against the CRDs actually
+ * discovered there. A CRD that is gone drops its tab; a CRD that still exists
+ * under a different served version (or plural) has its stale `CrdRef` replaced
+ * with the current one, so the tab keeps working instead of querying a version
+ * the cluster no longer serves.
+ *
+ * Only ever called with a SUCCESSFUL discovery result: an unreachable cluster
+ * must not be read as "this CRD is gone" and silently delete the workspace.
+ */
+export function reconcileCrdTabs(
+  tabs: ViewTab[],
+  context: string,
+  crds: readonly CrdRef[],
+): { tabs: ViewTab[]; dropped: number } {
+  const current = new Map(crds.map((c) => [`${c.group}/${c.kind}`, c]));
+  let dropped = 0;
+  const kept: ViewTab[] = [];
+  for (const t of tabs) {
+    if (t.cluster !== context || !t.crd) {
+      kept.push(t);
+      continue;
+    }
+    const live = current.get(`${t.crd.group}/${t.crd.kind}`);
+    if (!live) {
+      dropped += 1;
+      continue;
+    }
+    const stale = live.version !== t.crd.version || live.plural !== t.crd.plural;
+    kept.push(stale ? { ...t, crd: live } : t);
+  }
+  return { tabs: kept, dropped };
+}
+
 export function pruneMissingContexts(
   tabs: ViewTab[],
   contexts: readonly string[],

--- a/apps/desktop/src/lib/settings.ts
+++ b/apps/desktop/src/lib/settings.ts
@@ -221,6 +221,31 @@ export function saveContextOrder(order: string[]): void {
   }
 }
 
+const RESTORE_SESSION_KEY = "srelens.restoreSession";
+
+/**
+ * Whether to reopen the previous session's tabs on launch (#159). Defaults to
+ * true: landing back where you left off is the useful behavior, and the
+ * opt-out exists for people who prefer a clean workspace every launch.
+ */
+export function loadRestoreSession(): boolean {
+  try {
+    // Only an explicit "false" disables it, so an absent or unparseable value
+    // keeps the default rather than silently starting fresh.
+    return stored(RESTORE_SESSION_KEY) !== "false";
+  } catch {
+    return true;
+  }
+}
+
+export function saveRestoreSession(enabled: boolean): void {
+  try {
+    settingsStorage.setItem(RESTORE_SESSION_KEY, String(enabled));
+  } catch {
+    // ignore unavailable/quota-exceeded storage
+  }
+}
+
 /** Which release channel the in-app updater follows. */
 export type UpdateChannel = "stable" | "dev";
 

--- a/apps/desktop/src/ui/styles.css
+++ b/apps/desktop/src/ui/styles.css
@@ -2816,6 +2816,41 @@ body {
   accent-color: var(--fl-color-accent);
   cursor: pointer;
 }
+/* A checkbox preference with a title + explanation, matching the framing of
+   the slider controls above it (session restore, #159). */
+.fl-settings-toggle {
+  display: flex;
+  min-width: 0;
+  align-items: flex-start;
+  gap: 10px;
+  margin-top: 13px;
+  border: 1px solid var(--fl-color-border-faint);
+  border-radius: var(--fl-radius-lg);
+  background: var(--fl-color-bg);
+  padding: 12px;
+  cursor: pointer;
+}
+.fl-settings-toggle > input {
+  margin-top: 2px;
+  flex-shrink: 0;
+  accent-color: var(--fl-color-accent);
+  cursor: pointer;
+}
+.fl-settings-toggle > span {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+.fl-settings-toggle strong {
+  font-size: 13px;
+  font-weight: 600;
+}
+.fl-settings-toggle small {
+  color: var(--fl-color-text-muted);
+  font-size: 12px;
+}
+
 /* Interface scale (#237): −/+ steppers flanking the slider, then Reset.
    Request timeout (#238): slider plus an exact number box, since the range
    now runs to two minutes and dragging alone can't land a precise value.


### PR DESCRIPTION
Closes #159.

## Problem
The desktop started on an empty workspace every launch. `openTabs.ts` already persisted the open tabs + active tab, but only for the web — the desktop path was an explicit `isTauri()` no-op in both `loadOpenTabs` and `saveOpenTabs`.

## Change
- **One code path, no platform branch.** Both platforms now persist through `settingsStorage`, so the desktop writes into the durable settings file from #34 while web keeps using localStorage. Transient `create`/`edit` tabs and the deep-link `focus` nonce stay excluded, exactly as they were for web.
- **Stale contexts drop gracefully.** `pruneMissingContexts` is extracted from the inline filter in `refreshContexts` so it can be tested directly. Cluster-less tabs (Settings, Toolbox, landing) survive, since they don't depend on a context existing.
- **A note, but only when it's news.** The drop is reported by a toast at most once per launch. That filter also runs on every kubeconfig change, and someone who just removed a kubeconfig doesn't need telling why those tabs closed.
- **Opt-out**: Settings → Layout → *Reopen tabs on launch*, on by default.

## A deliberate detail
Disabling the setting starts fresh but **does not discard the stored snapshot**, and `saveOpenTabs` no-ops while it's off. So toggling it back on restores your last real session instead of an empty one — turning the setting off is not a destructive act.

## Tests
The pre-existing `openTabs on desktop > never reads or writes localStorage` test asserted precisely the behavior this issue removes, so it's replaced by one covering persist/restore on desktop. Added coverage for the opt-out (including that it preserves the snapshot, and that only an explicit `"false"` disables it) and for `pruneMissingContexts` across dropped, cluster-less, and nothing-to-drop cases.

Full frontend suite: 1064 passing, `tsc --noEmit` clean.

## Acceptance criteria
- [x] Open tabs + active tab persist across restart and are restored
- [x] Unavailable contexts/CRDs are dropped gracefully
- [x] A setting allows opting out (start fresh)
- [x] Tests cover serialize/restore and stale-tab handling