### PR TITLE
feat(desktop): srelens:// deep links, single instance, window state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,6 +878,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,6 +1022,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -1319,6 +1345,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -3800,6 +3835,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4782,6 +4827,16 @@ checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
 dependencies = [
  "sha2 0.11.0",
  "walkdir",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -5802,11 +5857,14 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-biometry",
+ "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
  "tauri-plugin-log",
  "tauri-plugin-opener",
  "tauri-plugin-process",
+ "tauri-plugin-single-instance",
  "tauri-plugin-updater",
+ "tauri-plugin-window-state",
  "thirtyfour",
  "tokio",
  "uuid",
@@ -6321,6 +6379,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-deep-link"
+version = "2.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ee75bc5627f77bfdf40c913255ebc258117b10ebe2b2239a1a1cf40b0b58aa"
+dependencies = [
+ "dunce",
+ "plist",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "windows-registry",
+ "windows-result 0.3.4",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6417,6 +6496,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin-deep-link",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus 5.18.0",
+]
+
+[[package]]
 name = "tauri-plugin-updater"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6447,6 +6543,21 @@ dependencies = [
  "url",
  "windows-sys 0.60.2",
  "zip",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.13.0",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6708,6 +6819,15 @@ checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -7691,6 +7811,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -90,6 +90,14 @@ base64 = "0.22"
 [target."cfg(not(any(target_os = \"android\", target_os = \"ios\")))".dependencies]
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
+# Issue #36. single-instance must be registered FIRST so a second launch hands
+# its argv to the running app instead of opening a rival window; its
+# `deep-link` feature is what forwards an `srelens://` URL on Windows/Linux,
+# where the OS starts a new process per link rather than signalling the
+# running one (macOS delivers the event to the existing app itself).
+tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
+tauri-plugin-deep-link = "2"
+tauri-plugin-window-state = "2"
 # GUI-launched apps on macOS/Linux get launchd's minimal PATH, so kubeconfig
 # exec plugins (kubectl, krew plugins, cloud CLIs) can't be found. This
 # resolves the user's login-shell PATH at startup. No-op on Windows.

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -8,6 +8,8 @@
   "permissions": [
     "core:default",
     "core:webview:allow-set-webview-zoom",
-    "process:default"
+    "process:default",
+    "deep-link:default",
+    "window-state:default"
   ]
 }

--- a/apps/desktop/src-tauri/src/deep_link.rs
+++ b/apps/desktop/src-tauri/src/deep_link.rs
@@ -1,0 +1,79 @@
+//! Deep links (`srelens://`), single-instance focus, and window-state glue
+//! for issue #36.
+
+/// A deep link that arrived before the frontend was listening.
+///
+/// A cold start via `srelens://…` delivers the URL while the WebView is still
+/// booting, so an event alone would be emitted into the void. Every link is
+/// stashed here and the frontend DRAINS it (see `take_pending_deep_link`),
+/// with the event acting only as a nudge — so a link is handled exactly once
+/// whether the app was already running or started by the link itself.
+#[derive(Default)]
+pub struct PendingDeepLink(std::sync::Mutex<Option<String>>);
+
+/// Take the pending deep link, if any. Draining is what makes delivery
+/// exactly-once: the nudge event and the cold-start path both call this.
+#[tauri::command]
+pub fn take_pending_deep_link(pending: tauri::State<'_, PendingDeepLink>) -> Option<String> {
+    pending.0.lock().ok().and_then(|mut slot| slot.take())
+}
+
+/// Bring the main window to the user. A second launch, or a link click while
+/// the app sits minimized behind other windows, should surface it.
+pub fn focus_main_window<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
+    use tauri::Manager;
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.unminimize();
+        let _ = window.show();
+        let _ = window.set_focus();
+    }
+}
+
+/// Whether the window-state plugin has a saved geometry to restore.
+pub fn has_saved_window_state(app: &tauri::App) -> bool {
+    use tauri::Manager;
+    app.path()
+        .app_config_dir()
+        .map(|dir| dir.join(tauri_plugin_window_state::DEFAULT_FILENAME).exists())
+        .unwrap_or(false)
+}
+
+/// Route `srelens://` links to the frontend.
+pub fn register_deep_links(app: &tauri::App) {
+    use tauri::{Emitter, Manager};
+    use tauri_plugin_deep_link::DeepLinkExt;
+
+    // A dev build is never "installed", so no OS registration exists for the
+    // scheme. Registering at runtime makes deep links testable with
+    // `tauri dev`; packaged builds get theirs from the bundle configuration.
+    #[cfg(debug_assertions)]
+    let _ = app.deep_link().register_all();
+
+    let handle = app.handle().clone();
+    app.deep_link().on_open_url(move |event| {
+        let Some(url) = event.urls().into_iter().next() else {
+            return;
+        };
+        if let Some(pending) = handle.try_state::<PendingDeepLink>() {
+            if let Ok(mut slot) = pending.0.lock() {
+                *slot = Some(url.to_string());
+            }
+        }
+        focus_main_window(&handle);
+        // Only a nudge — the frontend drains the slot above, so a link that
+        // lands before it is listening is not lost.
+        let _ = handle.emit("deep-link-pending", ());
+    });
+
+    // A cold start THROUGH a link: the URL is already waiting here, well
+    // before the frontend can subscribe to anything.
+    if let Ok(Some(urls)) = app.deep_link().get_current() {
+        if let Some(url) = urls.into_iter().next() {
+            if let Some(slot) = app.try_state::<PendingDeepLink>() {
+                if let Ok(mut slot) = slot.0.lock() {
+                    *slot = Some(url.to_string());
+                }
+            }
+        }
+    }
+}

--- a/apps/desktop/src-tauri/src/deep_link.rs
+++ b/apps/desktop/src-tauri/src/deep_link.rs
@@ -1,21 +1,48 @@
 //! Deep links (`srelens://`), single-instance focus, and window-state glue
 //! for issue #36.
 
-/// A deep link that arrived before the frontend was listening.
+/// Deep links that arrived before the frontend consumed them.
 ///
 /// A cold start via `srelens://…` delivers the URL while the WebView is still
 /// booting, so an event alone would be emitted into the void. Every link is
-/// stashed here and the frontend DRAINS it (see `take_pending_deep_link`),
-/// with the event acting only as a nudge — so a link is handled exactly once
-/// whether the app was already running or started by the link itself.
+/// queued here and the frontend DRAINS the queue (see
+/// `take_pending_deep_links`), with the event acting only as a nudge — so a
+/// link is handled exactly once whether the app was already running or was
+/// started by the link itself.
+///
+/// A queue rather than a single slot: several links can land back-to-back
+/// (a user clicking twice, or one `OpenUrlEvent` carrying several URLs), and
+/// overwriting would silently drop all but the last.
 #[derive(Default)]
-pub struct PendingDeepLink(std::sync::Mutex<Option<String>>);
+pub struct PendingDeepLink(std::sync::Mutex<Vec<String>>);
 
-/// Take the pending deep link, if any. Draining is what makes delivery
-/// exactly-once: the nudge event and the cold-start path both call this.
+/// Ignore links past this depth. Unbounded growth would otherwise be possible
+/// if the frontend never drains — a WebView that failed to boot, say — and a
+/// backlog that deep is a malfunction, not a user intent worth honouring.
+const MAX_PENDING_LINKS: usize = 32;
+
+impl PendingDeepLink {
+    fn push<I: IntoIterator<Item = String>>(&self, urls: I) {
+        let Ok(mut queue) = self.0.lock() else { return };
+        for url in urls {
+            if queue.len() >= MAX_PENDING_LINKS {
+                log::warn!("dropping deep link, {MAX_PENDING_LINKS} already pending: {url}");
+                break;
+            }
+            queue.push(url);
+        }
+    }
+}
+
+/// Take every pending deep link, oldest first. Draining is what makes delivery
+/// exactly-once: the nudge event and the startup path both call this.
 #[tauri::command]
-pub fn take_pending_deep_link(pending: tauri::State<'_, PendingDeepLink>) -> Option<String> {
-    pending.0.lock().ok().and_then(|mut slot| slot.take())
+pub fn take_pending_deep_links(pending: tauri::State<'_, PendingDeepLink>) -> Vec<String> {
+    pending
+        .0
+        .lock()
+        .map(|mut queue| std::mem::take(&mut *queue))
+        .unwrap_or_default()
 }
 
 /// Bring the main window to the user. A second launch, or a link click while
@@ -51,16 +78,17 @@ pub fn register_deep_links(app: &tauri::App) {
 
     let handle = app.handle().clone();
     app.deep_link().on_open_url(move |event| {
-        let Some(url) = event.urls().into_iter().next() else {
+        // Every URL in the event, not just the first: one activation can carry
+        // several, and dropping the rest loses navigations silently.
+        let urls: Vec<String> = event.urls().iter().map(ToString::to_string).collect();
+        if urls.is_empty() {
             return;
-        };
+        }
         if let Some(pending) = handle.try_state::<PendingDeepLink>() {
-            if let Ok(mut slot) = pending.0.lock() {
-                *slot = Some(url.to_string());
-            }
+            pending.push(urls);
         }
         focus_main_window(&handle);
-        // Only a nudge — the frontend drains the slot above, so a link that
+        // Only a nudge — the frontend drains the queue above, so a link that
         // lands before it is listening is not lost.
         let _ = handle.emit("deep-link-pending", ());
     });
@@ -68,12 +96,8 @@ pub fn register_deep_links(app: &tauri::App) {
     // A cold start THROUGH a link: the URL is already waiting here, well
     // before the frontend can subscribe to anything.
     if let Ok(Some(urls)) = app.deep_link().get_current() {
-        if let Some(url) = urls.into_iter().next() {
-            if let Some(slot) = app.try_state::<PendingDeepLink>() {
-                if let Ok(mut slot) = slot.0.lock() {
-                    *slot = Some(url.to_string());
-                }
-            }
+        if let Some(pending) = app.try_state::<PendingDeepLink>() {
+            pending.push(urls.iter().map(ToString::to_string));
         }
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -420,7 +420,7 @@ pub fn run() {
         .manage(TerminalManager::new())
         .manage(HelmManager::new())
         .invoke_handler(tauri::generate_handler![
-            deep_link::take_pending_deep_link,
+            deep_link::take_pending_deep_links,
             assistant::agent_list,
             assistant::chat_start,
             assistant::chat_send,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod app_log;
+mod deep_link;
 mod appimage;
 mod assistant;
 mod assistant_history;
@@ -248,14 +249,32 @@ pub fn run() {
     let cache = ClientCache::new_many(capabilities::default_kubeconfig_paths());
     let registry = capabilities::build_registry_with(cache.clone());
 
-    let builder = tauri::Builder::default()
+    // single-instance is registered BEFORE every other plugin, as the plugin
+    // requires: it has to claim the lock and hand a second launch's argv over
+    // before anything else initializes. Its `deep-link` feature forwards those
+    // arguments to the deep-link plugin first, so an `srelens://` link on
+    // Windows/Linux reaches the running app rather than starting a rival one.
+    #[cfg(desktop)]
+    let builder = tauri::Builder::default().plugin(tauri_plugin_single_instance::init(
+        |app, _argv, _cwd| {
+            deep_link::focus_main_window(app);
+        },
+    ));
+    #[cfg(not(desktop))]
+    let builder = tauri::Builder::default();
+
+    let builder = builder
+        .manage(deep_link::PendingDeepLink::default())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_biometry::init())
         .plugin(tauri_plugin_opener::init());
     #[cfg(desktop)]
     let builder = builder
         .plugin(tauri_plugin_updater::Builder::new().build())
-        .plugin(tauri_plugin_process::init());
+        .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_deep_link::init())
+        // Size, position and maximized state, restored at window creation.
+        .plugin(tauri_plugin_window_state::Builder::default().build());
 
     let watcher_cache = cache.clone();
     let oidc_cache = cache.clone();
@@ -288,8 +307,15 @@ pub fn run() {
                     .build(),
             )?;
             log::info!("srelens {} starting", env!("CARGO_PKG_VERSION"));
+            // Only impose the default geometry on a first launch: after that
+            // the window-state plugin has already restored the user's own
+            // size and position, and re-centering would undo it every time.
             #[cfg(desktop)]
-            size_main_window(app);
+            if !deep_link::has_saved_window_state(app) {
+                size_main_window(app);
+            }
+            #[cfg(desktop)]
+            deep_link::register_deep_links(app);
             #[cfg(target_os = "macos")]
             install_macos_menu(app)?;
 
@@ -394,6 +420,7 @@ pub fn run() {
         .manage(TerminalManager::new())
         .manage(HelmManager::new())
         .invoke_handler(tauri::generate_handler![
+            deep_link::take_pending_deep_link,
             assistant::agent_list,
             assistant::chat_start,
             assistant::chat_send,

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -33,6 +33,13 @@
         "https://github.com/srelens/srelens/releases/latest/download/latest.json"
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDY0RkY3MDRGOTgzRjQwOQpSV1FKOUlQNUJQZFBCdk96SU9Oc0t1bGY5bXcyWCt2VGNab2xyaWgwMStKeHhnRjRWVk4wdlBvVwo="
+    },
+    "deep-link": {
+      "desktop": {
+        "schemes": [
+          "srelens"
+        ]
+      }
     }
   },
   "bundle": {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -28,7 +28,7 @@ import { StatusBar } from "./components/StatusBar";
 import { LandingPage } from "./components/LandingPage";
 import { getInitialTheme, applyTheme, type Theme, type ThemeMode, type ThemeName } from "./ui";
 import { listCrds, type CrdRef } from "./lib/crds";
-import type { ResourceTarget } from "./lib/resourceNavigation";
+import { targetNamespace, type ResourceTarget } from "./lib/resourceNavigation";
 import {
   loadClusterNamespaces,
   saveClusterNamespaces,
@@ -50,6 +50,8 @@ import {
   loadMcpSettings,
 } from "./lib/settings";
 import { applyUiScale, getUiScale, setUiScale, stepUiScale, uiScaleShortcut } from "./lib/uiScale";
+import { parseDeepLink } from "./lib/deepLink";
+import { invokeCommand } from "./transport/transport";
 import {
   loadOpenTabs,
   saveOpenTabs,
@@ -168,6 +170,58 @@ export function App() {
   useEffect(() => {
     refreshContexts();
   }, [kubeconfigFiles]);
+
+  // Deep links (#36). The backend stashes the URL and only nudges us, so a
+  // link that launched the app cold is not lost while the WebView boots; both
+  // paths DRAIN the same slot, so a link is acted on exactly once.
+  const [pendingLink, setPendingLink] = useState<string | null>(null);
+  useEffect(() => {
+    if (!isTauri()) return;
+    const drain = () => {
+      void invokeCommand<string | null>("take_pending_deep_link")
+        .then((url) => {
+          if (url) setPendingLink(url);
+        })
+        .catch(() => {});
+    };
+    drain();
+    const unlistenPromise = listen("deep-link-pending", drain).catch(() => () => {});
+    return () => {
+      void unlistenPromise.then((unlisten) => unlisten());
+    };
+  }, []);
+
+  // Routed only once the contexts are known: a link that arrives during a cold
+  // start would otherwise be judged against an empty context list and
+  // rejected as pointing at a cluster that "doesn't exist".
+  useEffect(() => {
+    if (!pendingLink || !contexts) return;
+    setPendingLink(null);
+    const target = parseDeepLink(pendingLink);
+    if (!target) {
+      notify.error("Couldn't open that link", "It isn't a link srelens understands.");
+      return;
+    }
+    if (!contexts.some((c) => c.name === target.context)) {
+      notify.error("Couldn't open that link", `No kube context named "${target.context}".`);
+      return;
+    }
+    if (target.route === "cluster") {
+      openView(target.context, "overview");
+      return;
+    }
+    const entry = Object.entries(K8S_KIND).find(([, k8sKind]) => k8sKind === target.kind);
+    if (!entry) {
+      notify.error("Couldn't open that link", `srelens has no view for "${target.kind}".`);
+      return;
+    }
+    openResourceIn(
+      target.context,
+      entry[0] as ResourceKind,
+      targetNamespace(target.kind, target.namespace),
+      target.name,
+    );
+  }, [pendingLink, contexts]);
 
   // Restored CRD tabs carry a CrdRef captured in a previous session (#159).
   // The CRD may since have been deleted, or may now serve a different version,
@@ -515,23 +569,35 @@ export function App() {
     if (mcp.enabled) void startMcpHttp(mcp.port).catch(() => {});
   }, [vaultReady]);
 
-  /** Open a resource's kind view and deep-link to its detail (from search). */
-  function openResource(kind: ResourceKind, namespace: string | null, name: string) {
-    if (!activeCluster) return;
+  /** Open a resource's kind view in a NAMED cluster and focus its detail.
+   *  Takes the cluster explicitly because a deep link can target a context
+   *  other than the one currently in front (#36). */
+  function openResourceIn(
+    cluster: string,
+    kind: ResourceKind,
+    namespace: string | null,
+    name: string,
+  ) {
     const focus = { name, namespace, nonce: ++focusNonce.current };
     // Filter the list to the resource's namespace so its row is present to focus.
     const ns = namespace ?? "";
-    const existing = tabs.find((t) => t.cluster === activeCluster && t.kind === kind && !t.crd);
+    const existing = tabs.find((t) => t.cluster === cluster && t.kind === kind && !t.crd);
     if (existing) {
       setTabs((ts) => ts.map((t) => (t.id === existing.id ? { ...t, focus, namespace: ns } : t)));
       setActiveTabId(existing.id);
     } else {
       const id = tabIdRef.current++;
-      setTabs((ts) => [...ts, { id, cluster: activeCluster, kind, focus, namespace: ns }]);
+      setTabs((ts) => [...ts, { id, cluster, kind, focus, namespace: ns }]);
       setActiveTabId(id);
     }
-    setClusterNs((m) => ({ ...m, [activeCluster]: ns }));
+    setClusterNs((m) => ({ ...m, [cluster]: ns }));
     setQuery("");
+  }
+
+  /** Open a resource's kind view and deep-link to its detail (from search). */
+  function openResource(kind: ResourceKind, namespace: string | null, name: string) {
+    if (!activeCluster) return;
+    openResourceIn(activeCluster, kind, namespace, name);
   }
 
   /** Resolve a canonical Kubernetes kind from a detail link to its product view. */

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -174,20 +174,35 @@ export function App() {
   // Deep links (#36). The backend stashes the URL and only nudges us, so a
   // link that launched the app cold is not lost while the WebView boots; both
   // paths DRAIN the same slot, so a link is acted on exactly once.
-  const [pendingLink, setPendingLink] = useState<string | null>(null);
+  const [pendingLinks, setPendingLinks] = useState<string[]>([]);
   useEffect(() => {
     if (!isTauri()) return;
     const drain = () => {
-      void invokeCommand<string | null>("take_pending_deep_link")
-        .then((url) => {
-          if (url) setPendingLink(url);
+      void invokeCommand<string[]>("take_pending_deep_links")
+        .then((urls) => {
+          if (urls.length > 0) setPendingLinks((queued) => [...queued, ...urls]);
         })
         .catch(() => {});
     };
-    drain();
-    const unlistenPromise = listen("deep-link-pending", drain).catch(() => () => {});
+    let unlisten: (() => void) | undefined;
+    let disposed = false;
+    // Subscribe BEFORE the first drain. Draining first leaves a window
+    // between taking the queue and the listener being attached, and a link
+    // landing in it would be stored, nudged into the void, and never drained
+    // again until some later link happened to fire another event.
+    void listen("deep-link-pending", drain)
+      .then((fn) => {
+        if (disposed) {
+          fn();
+          return;
+        }
+        unlisten = fn;
+        drain();
+      })
+      .catch(() => {});
     return () => {
-      void unlistenPromise.then((unlisten) => unlisten());
+      disposed = true;
+      unlisten?.();
     };
   }, []);
 
@@ -195,33 +210,39 @@ export function App() {
   // start would otherwise be judged against an empty context list and
   // rejected as pointing at a cluster that "doesn't exist".
   useEffect(() => {
-    if (!pendingLink || !contexts) return;
-    setPendingLink(null);
-    const target = parseDeepLink(pendingLink);
-    if (!target) {
-      notify.error("Couldn't open that link", "It isn't a link srelens understands.");
-      return;
+    if (pendingLinks.length === 0 || !contexts) return;
+    // Drain the whole queue: several links can arrive while the contexts are
+    // still loading, and routing only the newest would silently swallow the
+    // rest. They open in order, so the last one ends up in front.
+    const queued = pendingLinks;
+    setPendingLinks([]);
+    for (const url of queued) {
+      const target = parseDeepLink(url);
+      if (!target) {
+        notify.error("Couldn't open that link", "It isn't a link srelens understands.");
+        continue;
+      }
+      if (!contexts.some((c) => c.name === target.context)) {
+        notify.error("Couldn't open that link", `No kube context named "${target.context}".`);
+        continue;
+      }
+      if (target.route === "cluster") {
+        openView(target.context, "overview");
+        continue;
+      }
+      const entry = Object.entries(K8S_KIND).find(([, k8sKind]) => k8sKind === target.kind);
+      if (!entry) {
+        notify.error("Couldn't open that link", `srelens has no view for "${target.kind}".`);
+        continue;
+      }
+      openResourceIn(
+        target.context,
+        entry[0] as ResourceKind,
+        targetNamespace(target.kind, target.namespace),
+        target.name,
+      );
     }
-    if (!contexts.some((c) => c.name === target.context)) {
-      notify.error("Couldn't open that link", `No kube context named "${target.context}".`);
-      return;
-    }
-    if (target.route === "cluster") {
-      openView(target.context, "overview");
-      return;
-    }
-    const entry = Object.entries(K8S_KIND).find(([, k8sKind]) => k8sKind === target.kind);
-    if (!entry) {
-      notify.error("Couldn't open that link", `srelens has no view for "${target.kind}".`);
-      return;
-    }
-    openResourceIn(
-      target.context,
-      entry[0] as ResourceKind,
-      targetNamespace(target.kind, target.namespace),
-      target.name,
-    );
-  }, [pendingLink, contexts]);
+  }, [pendingLinks, contexts]);
 
   // Restored CRD tabs carry a CrdRef captured in a previous session (#159).
   // The CRD may since have been deleted, or may now serve a different version,

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -28,7 +28,12 @@ import { StatusBar } from "./components/StatusBar";
 import { LandingPage } from "./components/LandingPage";
 import { getInitialTheme, applyTheme, type Theme, type ThemeMode, type ThemeName } from "./ui";
 import { listCrds, type CrdRef } from "./lib/crds";
-import { targetNamespace, type ResourceTarget } from "./lib/resourceNavigation";
+import {
+  isClusterScopedKind,
+  isNavigableResourceKind,
+  targetNamespace,
+  type ResourceTarget,
+} from "./lib/resourceNavigation";
 import {
   loadClusterNamespaces,
   saveClusterNamespaces,
@@ -50,7 +55,7 @@ import {
   loadMcpSettings,
 } from "./lib/settings";
 import { applyUiScale, getUiScale, setUiScale, stepUiScale, uiScaleShortcut } from "./lib/uiScale";
-import { parseDeepLink } from "./lib/deepLink";
+import { dedupeDeepLinkTargets, parseDeepLink, type DeepLinkTarget } from "./lib/deepLink";
 import { invokeCommand } from "./transport/transport";
 import {
   loadOpenTabs,
@@ -216,6 +221,11 @@ export function App() {
     // rest. They open in order, so the last one ends up in front.
     const queued = pendingLinks;
     setPendingLinks([]);
+
+    // Validate first, then route: a batch is applied against ONE render's
+    // `tabs`, so links sharing a view have to be collapsed before any of them
+    // appends a tab (see dedupeDeepLinkTargets).
+    const valid: DeepLinkTarget[] = [];
     for (const url of queued) {
       const target = parseDeepLink(url);
       if (!target) {
@@ -226,15 +236,35 @@ export function App() {
         notify.error("Couldn't open that link", `No kube context named "${target.context}".`);
         continue;
       }
+      if (target.route === "resource") {
+        // K8S_KIND alone is too permissive: Events have a list view but no
+        // detail, so such a link would quietly land on the list instead of
+        // the object it named.
+        if (!isNavigableResourceKind(target.kind)) {
+          notify.error("Couldn't open that link", `srelens can't open a ${target.kind} directly.`);
+          continue;
+        }
+        // "-" means cluster-scoped. Allowing it for a namespaced kind would
+        // search every namespace and focus whichever matching name came back
+        // first — a link that silently opens the wrong object.
+        if (!isClusterScopedKind(target.kind) && target.namespace === null) {
+          notify.error(
+            "Couldn't open that link",
+            `${target.kind} is namespaced, so the link needs a namespace.`,
+          );
+          continue;
+        }
+      }
+      valid.push(target);
+    }
+
+    for (const target of dedupeDeepLinkTargets(valid)) {
       if (target.route === "cluster") {
         openView(target.context, "overview");
         continue;
       }
       const entry = Object.entries(K8S_KIND).find(([, k8sKind]) => k8sKind === target.kind);
-      if (!entry) {
-        notify.error("Couldn't open that link", `srelens has no view for "${target.kind}".`);
-        continue;
-      }
+      if (!entry) continue;
       openResourceIn(
         target.context,
         entry[0] as ResourceKind,

--- a/apps/desktop/src/lib/deepLink.test.ts
+++ b/apps/desktop/src/lib/deepLink.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { parseDeepLink } from "./deepLink";
+
+describe("parseDeepLink", () => {
+  it("parses a cluster link", () => {
+    expect(parseDeepLink("srelens://cluster/kind-dev")).toEqual({
+      route: "cluster",
+      context: "kind-dev",
+    });
+  });
+
+  it("parses a namespaced resource link", () => {
+    expect(parseDeepLink("srelens://resource/prod/kube-system/Pod/coredns-abc")).toEqual({
+      route: "resource",
+      context: "prod",
+      namespace: "kube-system",
+      kind: "Pod",
+      name: "coredns-abc",
+    });
+  });
+
+  it("treats '-' as no namespace, for cluster-scoped kinds", () => {
+    // An empty segment would collapse when the path is split, so the
+    // placeholder has to be a real character.
+    expect(parseDeepLink("srelens://resource/prod/-/Node/worker-1")).toMatchObject({
+      namespace: null,
+      kind: "Node",
+      name: "worker-1",
+    });
+  });
+
+  it("accepts the extra slashes different platforms produce", () => {
+    // A link with no authority component is normalized differently by each OS
+    // handler; both spellings must land in the same place.
+    const expected = { route: "cluster", context: "prod" };
+    expect(parseDeepLink("srelens://cluster/prod")).toEqual(expected);
+    expect(parseDeepLink("srelens:///cluster/prod")).toEqual(expected);
+    expect(parseDeepLink("SRELENS://cluster/prod")).toEqual(expected);
+    expect(parseDeepLink("  srelens://cluster/prod/  ")).toEqual(expected);
+  });
+
+  it("keeps an encoded slash inside a context instead of splitting the route", () => {
+    // OpenShift contexts genuinely look like this; splitting here would turn
+    // one context into three path segments and break the link.
+    expect(parseDeepLink("srelens://cluster/default%2Fapi-example-com%3A6443%2Fdev")).toEqual({
+      route: "cluster",
+      context: "default/api-example-com:6443/dev",
+    });
+  });
+
+  it("ignores a query string or fragment", () => {
+    expect(parseDeepLink("srelens://cluster/prod?utm=x")).toEqual({
+      route: "cluster",
+      context: "prod",
+    });
+    expect(parseDeepLink("srelens://cluster/prod#frag")).toEqual({
+      route: "cluster",
+      context: "prod",
+    });
+  });
+
+  it("refuses anything that is not an srelens link", () => {
+    for (const url of ["", "https://example.com/cluster/prod", "srelen://cluster/prod", "cluster/prod"]) {
+      expect(parseDeepLink(url)).toBeNull();
+    }
+  });
+
+  it("refuses unknown routes and wrong segment counts", () => {
+    // A malformed link must be inert, never partially honoured.
+    for (const url of [
+      "srelens://",
+      "srelens://cluster",
+      "srelens://cluster/a/b",
+      "srelens://resource/prod/ns/Pod",
+      "srelens://resource/prod/ns/Pod/name/extra",
+      "srelens://evil/prod",
+    ]) {
+      expect(parseDeepLink(url)).toBeNull();
+    }
+  });
+
+  it("refuses control characters and malformed encoding", () => {
+    expect(parseDeepLink("srelens://cluster/pro%00d")).toBeNull();
+    expect(parseDeepLink("srelens://cluster/bad%ZZ")).toBeNull();
+  });
+});

--- a/apps/desktop/src/lib/deepLink.test.ts
+++ b/apps/desktop/src/lib/deepLink.test.ts
@@ -123,13 +123,17 @@ describe("dedupeDeepLinkTargets", () => {
     expect(result).toEqual([{ route: "cluster", context: "prod" }]);
   });
 
-  it("preserves order of first appearance", () => {
+  it("orders by LAST occurrence, so the final link is routed last", () => {
+    // Routing order decides which tab ends up active. A replaced entry must
+    // move to the end, or an earlier link would be applied after a later one
+    // and steal focus from the link the user actually clicked most recently.
     const result = dedupeDeepLinkTargets([
       resource("prod", "Pod", "a"),
       { route: "cluster", context: "prod" },
       resource("prod", "Pod", "b"),
     ]);
-    expect(result[0]).toMatchObject({ route: "resource", name: "b" });
-    expect(result[1]).toMatchObject({ route: "cluster" });
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ route: "cluster" });
+    expect(result[1]).toMatchObject({ route: "resource", name: "b" });
   });
 });

--- a/apps/desktop/src/lib/deepLink.test.ts
+++ b/apps/desktop/src/lib/deepLink.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseDeepLink } from "./deepLink";
+import { dedupeDeepLinkTargets, parseDeepLink, type DeepLinkTarget } from "./deepLink";
 
 describe("parseDeepLink", () => {
   it("parses a cluster link", () => {
@@ -82,5 +82,54 @@ describe("parseDeepLink", () => {
   it("refuses control characters and malformed encoding", () => {
     expect(parseDeepLink("srelens://cluster/pro%00d")).toBeNull();
     expect(parseDeepLink("srelens://cluster/bad%ZZ")).toBeNull();
+  });
+});
+
+describe("dedupeDeepLinkTargets", () => {
+  const resource = (context: string, kind: string, name: string): DeepLinkTarget => ({
+    route: "resource",
+    context,
+    namespace: "default",
+    kind,
+    name,
+  });
+
+  it("collapses links that open the same view, keeping the last", () => {
+    // A double-click would otherwise append two Pods tabs against the same
+    // render's state, duplicating the tab and its resource watch.
+    const result = dedupeDeepLinkTargets([
+      resource("prod", "Pod", "first"),
+      resource("prod", "Pod", "second"),
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ name: "second" });
+  });
+
+  it("keeps distinct views separate", () => {
+    const result = dedupeDeepLinkTargets([
+      resource("prod", "Pod", "a"),
+      resource("prod", "Service", "b"),
+      resource("staging", "Pod", "c"),
+      { route: "cluster", context: "prod" },
+    ]);
+    expect(result).toHaveLength(4);
+  });
+
+  it("collapses repeated cluster links", () => {
+    const result = dedupeDeepLinkTargets([
+      { route: "cluster", context: "prod" },
+      { route: "cluster", context: "prod" },
+    ]);
+    expect(result).toEqual([{ route: "cluster", context: "prod" }]);
+  });
+
+  it("preserves order of first appearance", () => {
+    const result = dedupeDeepLinkTargets([
+      resource("prod", "Pod", "a"),
+      { route: "cluster", context: "prod" },
+      resource("prod", "Pod", "b"),
+    ]);
+    expect(result[0]).toMatchObject({ route: "resource", name: "b" });
+    expect(result[1]).toMatchObject({ route: "cluster" });
   });
 });

--- a/apps/desktop/src/lib/deepLink.ts
+++ b/apps/desktop/src/lib/deepLink.ts
@@ -86,3 +86,25 @@ export function parseDeepLink(url: string): DeepLinkTarget | null {
 
   return null;
 }
+
+/**
+ * Collapse links that would open the SAME view, keeping the last of each.
+ *
+ * A batch is routed against one render's `tabs`, so two links to the same
+ * cluster+kind would each find no existing tab and append their own —
+ * duplicate tabs and duplicate resource watches from one double-click. The
+ * last link wins because it is the one whose focus should end up in front.
+ */
+export function dedupeDeepLinkTargets(targets: DeepLinkTarget[]): DeepLinkTarget[] {
+  const byView = new Map<string, DeepLinkTarget>();
+  for (const target of targets) {
+    const key =
+      target.route === "cluster"
+        ? `cluster:${target.context}`
+        : // Keyed by the VIEW, not the resource: two pods in one cluster share
+          // a single Pods tab.
+          `resource:${target.context}:${target.kind}`;
+    byView.set(key, target);
+  }
+  return [...byView.values()];
+}

--- a/apps/desktop/src/lib/deepLink.ts
+++ b/apps/desktop/src/lib/deepLink.ts
@@ -104,6 +104,11 @@ export function dedupeDeepLinkTargets(targets: DeepLinkTarget[]): DeepLinkTarget
         : // Keyed by the VIEW, not the resource: two pods in one cluster share
           // a single Pods tab.
           `resource:${target.context}:${target.kind}`;
+    // Delete before re-inserting: Map.set keeps a replaced key at its ORIGINAL
+    // position, which would emit an earlier link after a later one. Routing
+    // order is what decides which tab ends up active, so the batch has to come
+    // out in last-occurrence order for "the last link wins" to hold.
+    byView.delete(key);
     byView.set(key, target);
   }
   return [...byView.values()];

--- a/apps/desktop/src/lib/deepLink.ts
+++ b/apps/desktop/src/lib/deepLink.ts
@@ -1,0 +1,88 @@
+// `srelens://` deep-link parsing (#36).
+//
+// Two routes, both taking a kube context as their first segment:
+//   srelens://cluster/<context>
+//   srelens://resource/<context>/<namespace>/<kind>/<name>
+//
+// Parsing is kept pure and separate from navigation so the URL grammar can be
+// tested exhaustively — a deep link is attacker-reachable in the sense that
+// any web page can ask the OS to open one, so it is validated rather than
+// trusted.
+
+/** A parsed, validated deep-link destination. */
+export type DeepLinkTarget =
+  | { route: "cluster"; context: string }
+  | {
+      route: "resource";
+      context: string;
+      /** Null for cluster-scoped kinds, or when the link omits a namespace. */
+      namespace: string | null;
+      /** Canonical Kubernetes kind, e.g. "Pod" — resolved by the caller. */
+      kind: string;
+      name: string;
+    };
+
+/** A single path segment is rejected outright if it carries control
+ *  characters; they cannot appear in a legitimate Kubernetes name or context
+ *  and would otherwise reach logs and the UI verbatim. */
+function isCleanSegment(value: string): boolean {
+  return value.length > 0 && ![...value].some((c) => c.codePointAt(0)! < 0x20 || c.codePointAt(0)! === 0x7f);
+}
+
+/**
+ * Split an `srelens://` URL into decoded path segments, or null when it is not
+ * an srelens link at all.
+ *
+ * Tolerates the extra slashes different platforms produce (`srelens://x` and
+ * `srelens:///x` both occur, since a link with no authority component is
+ * normalized differently by each OS handler). Each segment is
+ * percent-decoded AFTER splitting, so an encoded `/` inside a context name —
+ * OpenShift contexts look like `default/api-example-com:6443/user` — stays a
+ * single segment instead of splitting the route apart.
+ */
+function segmentsOf(url: string): string[] | null {
+  const match = /^srelens:\/*(.*)$/i.exec(url.trim());
+  if (!match) return null;
+  const [path] = match[1].split(/[?#]/, 1);
+  const raw = path.split("/").filter((segment) => segment.length > 0);
+  try {
+    return raw.map(decodeURIComponent);
+  } catch {
+    // Malformed percent-encoding — refuse rather than guess.
+    return null;
+  }
+}
+
+/**
+ * Parse a deep link, or return null when it is not a link we serve. Unknown
+ * routes and wrong segment counts are refused rather than partially honoured,
+ * so a malformed link is inert instead of navigating somewhere unintended.
+ */
+export function parseDeepLink(url: string): DeepLinkTarget | null {
+  const segments = segmentsOf(url);
+  if (!segments || segments.length === 0) return null;
+  if (!segments.every(isCleanSegment)) return null;
+
+  const [route, ...rest] = segments;
+
+  if (route === "cluster") {
+    if (rest.length !== 1) return null;
+    return { route: "cluster", context: rest[0] };
+  }
+
+  if (route === "resource") {
+    if (rest.length !== 4) return null;
+    const [context, namespace, kind, name] = rest;
+    return {
+      route: "resource",
+      context,
+      // "-" is the conventional placeholder for a cluster-scoped resource,
+      // since an empty path segment would collapse when the URL is split.
+      namespace: namespace === "-" ? null : namespace,
+      kind,
+      name,
+    };
+  }
+
+  return null;
+}

--- a/apps/desktop/src/lib/resourceNavigation.ts
+++ b/apps/desktop/src/lib/resourceNavigation.ts
@@ -61,6 +61,11 @@ const CLUSTER_SCOPED_KINDS = new Set([
   "ValidatingWebhookConfiguration",
 ]);
 
+/** True for kinds that exist outside any namespace (Node, ClusterRole, …). */
+export function isClusterScopedKind(kind: string): boolean {
+  return CLUSTER_SCOPED_KINDS.has(kind);
+}
+
 export function targetNamespace(kind: string, namespace: string | null): string | null {
   return CLUSTER_SCOPED_KINDS.has(kind) ? null : namespace;
 }

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -293,6 +293,42 @@ Press **Cmd/Ctrl-K** to open the command palette. It offers your **recent** pick
 (pods, deployments, services, config, and more, indexed when you open the
 palette). Selecting a view opens its tab; selecting a resource opens its detail.
 
+## Deep links
+
+srelens registers the `srelens://` URL scheme, so a link in a browser, chat
+message, runbook, or alert can open the exact thing it refers to. Clicking one
+reuses the running app — a second copy is never started — and brings its window
+to the front.
+
+| Link | Opens |
+| --- | --- |
+| `srelens://cluster/<context>` | That context's cluster overview |
+| `srelens://resource/<context>/<namespace>/<kind>/<name>` | That resource's detail view |
+
+`<kind>` is the Kubernetes kind (`Pod`, `Deployment`, `Service`, …). For a
+cluster-scoped resource such as a Node, use `-` in place of the namespace:
+
+```
+srelens://resource/prod-eu/kube-system/Pod/coredns-7db6d8ff4d-abcde
+srelens://resource/prod-eu/-/Node/worker-1
+```
+
+Percent-encode any segment containing a `/` or `:` — OpenShift context names
+usually need this:
+
+```
+srelens://cluster/default%2Fapi-example-com%3A6443%2Fdev
+```
+
+A link naming a context you don't have, or a kind srelens has no view for, is
+reported and otherwise ignored.
+
+## Window and session state
+
+The window's size, position, and maximized state are remembered across
+restarts, as are your open tabs and the active one — see
+[Reopen tabs on launch](#settings-reference) to turn the tab part off.
+
 ## Application logs
 
 srelens keeps its own rotating log file so you can diagnose problems after they

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -305,8 +305,10 @@ to the front.
 | `srelens://cluster/<context>` | That context's cluster overview |
 | `srelens://resource/<context>/<namespace>/<kind>/<name>` | That resource's detail view |
 
-`<kind>` is the Kubernetes kind (`Pod`, `Deployment`, `Service`, …). For a
-cluster-scoped resource such as a Node, use `-` in place of the namespace:
+`<kind>` is the Kubernetes kind (`Pod`, `Deployment`, `Service`, …). Use `-` in
+place of the namespace for a **cluster-scoped** resource such as a Node; a
+namespaced kind must name its namespace, since searching every namespace could
+otherwise open the wrong object when the name is not unique:
 
 ```
 srelens://resource/prod-eu/kube-system/Pod/coredns-7db6d8ff4d-abcde
@@ -320,8 +322,9 @@ usually need this:
 srelens://cluster/default%2Fapi-example-com%3A6443%2Fdev
 ```
 
-A link naming a context you don't have, or a kind srelens has no view for, is
-reported and otherwise ignored.
+A link is reported and otherwise ignored when it names a context you don't
+have, a kind with no detail view (Events, for instance, are list-only), or a
+namespaced kind without a namespace.
 
 ## Window and session state
 


### PR DESCRIPTION
Closes #36.

## What's in it
- **single-instance** — a second launch focuses the running window instead of opening a rival one. Registered **before every other plugin**, as the plugin requires.
- **deep links** — `srelens://` is registered with the OS, and links route to the right cluster or resource.
- **window state** — size, position, and maximized state persist across restarts.
- **OS registration** — the scheme is declared in `tauri.conf.json`, from which Tauri generates the macOS `Info.plist` entry, the Linux `.desktop` MimeType, and the Windows installer registry keys.

| Link | Opens |
| --- | --- |
| `srelens://cluster/<context>` | That context's cluster overview |
| `srelens://resource/<context>/<namespace>/<kind>/<name>` | That resource's detail |

`-` stands in for the namespace on cluster-scoped kinds, since an empty path segment collapses when the URL is split.

## Three things worth reviewing closely

**A cold start through a link can't be lost.** Launching *via* a link hands the URL over while the WebView is still booting, so emitting an event would send it nowhere. The backend stashes the URL and emits only a nudge; both the nudge and the startup path **drain** the same slot, so a link is acted on exactly once whether the app was already running or not.

**Routing waits for contexts.** A link arriving mid-startup would otherwise be validated against an empty context list and rejected as naming a cluster that doesn't exist. It's held until `contexts` resolves.

**The URL grammar is validated, not trusted.** Any web page can ask the OS to open one of these. `parseDeepLink` is pure and separately tested: control characters and malformed percent-encoding are refused, unknown routes and wrong segment counts are inert rather than partially honoured, and segments are decoded *after* splitting so an encoded `/` inside an OpenShift context name (`default%2Fapi-example-com%3A6443%2Fdev`) stays a single segment instead of splitting the route apart.

## Interaction with existing code
`size_main_window` used to size and center the window on every launch, which would have undone a restored geometry every time. It now runs only when there's no saved window state — i.e. as a genuine first-launch default.

`openResource` was hardcoded to `activeCluster`; it's generalized to `openResourceIn(cluster, …)` so a link can target a context other than the one in front, with `openResource` delegating to it.

## Tests
9 parser tests covering both routes, the extra-slash spellings different platforms produce, encoded separators, query/fragment, and every rejection path. Full frontend suite 1080 passing, `cargo test -p srelens-desktop --lib` 180 passing, workspace builds clean, `tsc` clean.

## Not verifiable here
The end-to-end click-a-link-in-a-browser path needs packaged builds on all three platforms; a dev build self-registers the scheme at runtime (`register_all()` under `debug_assertions`) so it can be exercised with `tauri dev`, but the bundle-level registration only takes effect once installed.