### PR TITLE
docs(readme): drop the beta framing from the project status

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
   <img alt="Rust core" src="https://img.shields.io/badge/core-Rust-8b5cf6">
   <img alt="Tauri v2" src="https://img.shields.io/badge/desktop-Tauri_v2-e457c2">
   <img alt="MCP server" src="https://img.shields.io/badge/agents-MCP-fb923c">
-  <img alt="Project status: beta" src="https://img.shields.io/badge/status-beta-f59e0b">
+  <img alt="Project status: stable" src="https://img.shields.io/badge/status-stable-22c55e">
 </p>
 
 ---
@@ -109,7 +109,7 @@ See the [user guide](docs/USAGE.md) for how to use each of these.
 
 ## Install
 
-Download the latest beta for your platform from
+Download the latest release for your platform from
 [GitHub Releases](https://github.com/srelens/srelens/releases/latest).
 
 | Platform | Packages | Notes |
@@ -247,12 +247,13 @@ docs/                    Installation, usage, development, and project documenta
 
 ## Project status
 
-srelens is currently in **beta**. It is ready for evaluation and everyday testing,
-but users should review release notes and take extra care when using it with
-critical clusters.
+srelens is **stable and in active development**, with regular releases for macOS,
+Linux, and Windows. macOS builds are Developer ID signed and notarized, and
+supported packages update in place through the in-app updater.
 
-Breaking changes may still occur before a stable release. Feedback, bug reports,
-and reproducible troubleshooting details are welcome.
+New capabilities land continuously, so the release notes are worth a glance when
+you upgrade. Feedback, bug reports, and reproducible troubleshooting details are
+always welcome.
 
 - [Latest release](https://github.com/srelens/srelens/releases/latest)
 - [All releases](https://github.com/srelens/srelens/releases)


### PR DESCRIPTION
srelens is mature and generally available, and the website already reflects that — this brings the README into line.

## Changes
- **Status badge**: `status-beta` (amber) → `status-stable` (green)
- **Install**: "Download the latest **beta** for your platform" → "the latest **release**"
- **Project status section**: rewritten. Drops "currently in beta", "ready for evaluation and everyday testing", the instruction to "take extra care when using it with critical clusters", and "breaking changes may still occur before a stable release".

## One thing I deliberately did not claim
My first draft said releases are "built, signed, and notarized for macOS, Linux, and Windows". That isn't true: the install table in the same README notes Windows shows a SmartScreen prompt because code signing is still open (#32), and notarization is macOS-only. Removing a hedge is not a licence to overclaim, so the wording now states what actually holds — regular releases for all three platforms, macOS Developer ID signed and notarized, and in-app updates for the packages that support them (AppImage on Linux).

## Scope
Every other `beta` in the tree is a Kubernetes `v1beta1` API version, a Gemini `v1beta` endpoint path, or test fixture data — none of those are product-status claims and none are touched. The two "pre-release" mentions in the docs refer to the **Dev** release channel and remain accurate. The GitHub repo description was already clean.