### PR TITLE
fix(tabs): keep sort, search and column filter on the tab

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -325,6 +325,25 @@ describe("App", () => {
     delete (window as unknown as { __TAURI_INTERNALS__?: object }).__TAURI_INTERNALS__;
   });
 
+  it("persists the post-close session when Cmd+W closes the last tab (#254)", async () => {
+    // closeView only SCHEDULES the state change, and the window close fires in
+    // the same callback — so without queueing the post-close snapshot first,
+    // the flush writes the pre-close one and the closed tab returns on the
+    // next launch.
+    (window as unknown as { __TAURI_INTERNALS__?: object }).__TAURI_INTERNALS__ = {};
+    localStorage.clear();
+    render(<App />);
+    fireEvent.click(screen.getByText("open-kind-dev"));
+
+    tauri.handlers.get("close-active-tab")?.({ payload: null });
+    // Drive the close the way Tauri would, so the flush runs.
+    await tauri.closeRequestedHandler?.({ preventDefault: vi.fn() });
+
+    // Nothing to restore: the user closed their last tab deliberately.
+    expect(localStorage.getItem("srelens.openTabs")).toBeNull();
+    delete (window as unknown as { __TAURI_INTERNALS__?: object }).__TAURI_INTERNALS__;
+  });
+
   it("close-active-tab (Cmd+W) closes the window when the last tab is closed", () => {
     (window as unknown as { __TAURI_INTERNALS__?: object }).__TAURI_INTERNALS__ = {};
     tauri.windowClose.mockClear();

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -7,9 +7,12 @@ import React from "react";
 const tauri = vi.hoisted(() => {
   const handlers = new Map<string, (e: { payload: unknown }) => void>();
   const windowClose = vi.fn();
+  const windowDestroy = vi.fn();
   return {
     handlers,
     windowClose,
+    windowDestroy,
+    closeRequestedHandler: null as null | ((event: { preventDefault: () => void }) => unknown),
     listen: vi.fn((name: string, cb: (e: { payload: unknown }) => void) => {
       handlers.set(name, cb);
       return Promise.resolve(() => handlers.delete(name));
@@ -18,7 +21,17 @@ const tauri = vi.hoisted(() => {
 });
 vi.mock("@tauri-apps/api/event", () => ({ listen: tauri.listen }));
 vi.mock("@tauri-apps/api/window", () => ({
-  getCurrentWindow: () => ({ close: tauri.windowClose }),
+  getCurrentWindow: () => ({
+    close: tauri.windowClose,
+    destroy: tauri.windowDestroy,
+    // Capture the handler so a test can drive the close-request path.
+    onCloseRequested: (handler: (event: { preventDefault: () => void }) => unknown) => {
+      tauri.closeRequestedHandler = handler;
+      return Promise.resolve(() => {
+        tauri.closeRequestedHandler = null;
+      });
+    },
+  }),
 }));
 
 const { checkForUpdateMock, notifyUpdateAvailableMock } = vi.hoisted(() => ({
@@ -240,6 +253,26 @@ describe("App", () => {
     fireEvent.click(screen.getByText("open-assistant"));
     expect(screen.queryByTestId("assistant-tab")).toBeNull();
     expect(screen.queryByRole("tab", { name: /^Assistant$/ })).toBeNull();
+  });
+
+  it("waits for the settings write before letting the window close (#254)", async () => {
+    // The durable write is an async IPC round trip; an unload handler returns
+    // immediately and the WebView is torn down mid-write, losing the last
+    // sort/search. The close is intercepted and resumed instead.
+    (window as unknown as { __TAURI_INTERNALS__?: object }).__TAURI_INTERNALS__ = {};
+    tauri.windowDestroy.mockClear();
+    render(<App />);
+    fireEvent.click(screen.getByText("open-kind-dev"));
+
+    expect(tauri.closeRequestedHandler).toBeTypeOf("function");
+    const preventDefault = vi.fn();
+    await tauri.closeRequestedHandler!({ preventDefault });
+
+    // The default close is cancelled, then re-issued as destroy() once the
+    // write has drained — close() would re-enter this handler and loop.
+    expect(preventDefault).toHaveBeenCalled();
+    expect(tauri.windowDestroy).toHaveBeenCalled();
+    delete (window as unknown as { __TAURI_INTERNALS__?: object }).__TAURI_INTERNALS__;
   });
 
   it("close-active-tab (Cmd+W) closes the active tab, not the window", () => {

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -97,16 +97,22 @@ vi.mock("./components/ResourceBrowser", () => ({
   ResourceBrowser: ({
     context,
     kind,
+    query,
+    onViewChange,
     onOpenResource,
     onOpenEdit,
   }: {
     context: string;
     kind: string;
+    query?: string;
+    onViewChange?: (patch: { query?: string }) => void;
     onOpenResource?: (target: { kind: string; namespace: string | null; name: string }) => void;
     onOpenEdit?: (kind: string, namespace: string | null, name: string) => void;
   }) => (
     <div data-testid="browser">
       {context}:{kind}
+      <span data-testid="browser-query">{query ?? ""}</span>
+      <button onClick={() => onViewChange?.({ query: "nginx" })}>set-query</button>
       <button
         onClick={() => onOpenResource?.({ kind: "Pod", namespace: "default", name: "web-1" })}
       >
@@ -182,6 +188,32 @@ describe("App", () => {
     fireEvent.click(screen.getByText("nav-services"));
     fireEvent.click(screen.getByText("linked-pod"));
     expect(screen.getByTestId("browser").textContent).toContain("kind-dev:pods");
+  });
+
+  it("clears only the target tab's search when focusing a resource in it (#254)", () => {
+    // The detail opens from the UNFILTERED rows, so a leftover search would
+    // leave the user on a list that doesn't contain what they navigated to
+    // once the drawer closes.
+    render(<App />);
+    fireEvent.click(screen.getByText("open-kind-dev"));
+    fireEvent.click(screen.getByText("nav-services"));
+    fireEvent.click(screen.getByText("linked-pod")); // creates the pods tab
+    expect(screen.getByTestId("browser").textContent).toContain("kind-dev:pods");
+
+    fireEvent.click(screen.getByText("set-query"));
+    expect(screen.getByTestId("browser-query").textContent).toBe("nginx");
+
+    // Navigate to a pod again from Services: the existing pods tab is reused
+    // and its search must be cleared so the focused row is actually listed.
+    fireEvent.click(screen.getByRole("tab", { name: /Services/ }));
+    fireEvent.click(screen.getByText("set-query")); // Services keeps its own
+    fireEvent.click(screen.getByText("linked-pod"));
+    expect(screen.getByTestId("browser").textContent).toContain("kind-dev:pods");
+    expect(screen.getByTestId("browser-query").textContent).toBe("");
+
+    // The Services tab's own search survived — only the target was cleared.
+    fireEvent.click(screen.getByRole("tab", { name: /Services/ }));
+    expect(screen.getByTestId("browser-query").textContent).toBe("nginx");
   });
 
   it("opens an edit tab from a resource and de-dupes re-edits", () => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -56,6 +56,7 @@ import {
 } from "./lib/settings";
 import { applyUiScale, getUiScale, setUiScale, stepUiScale, uiScaleShortcut } from "./lib/uiScale";
 import { dedupeDeepLinkTargets, parseDeepLink, type DeepLinkTarget } from "./lib/deepLink";
+import { applyViewPatch, type TabViewState } from "./lib/tabView";
 import { invokeCommand } from "./transport/transport";
 import {
   loadOpenTabs,
@@ -88,6 +89,8 @@ export interface ViewTab {
   edit?: { kind: string; namespace: string | null; name: string };
   /** Selected namespace filter (empty = all), preserved per tab. */
   namespace?: string;
+  /** Sort, search text and filtered column for this tab's list (#254). */
+  view?: TabViewState;
 }
 
 export function App() {
@@ -100,7 +103,6 @@ export function App() {
   const [activeTabId, setActiveTabId] = useState<number | null>(
     () => restored?.activeTabId ?? null,
   );
-  const [query, setQuery] = useState("");
   const [layout, setLayout] = useState(loadWorkspaceLayout);
   const [sidebarWidth, setSidebarWidth] = useState(layout.leftSidebarWidth);
   const [contextProfiles, setContextProfiles] = useState(loadContextProfiles);
@@ -485,6 +487,18 @@ export function App() {
 
   const activeTab = tabs.find((t) => t.id === activeTabId) ?? null;
   const activeCluster = activeTab?.cluster ?? null;
+  // Sort, search text and filtered column belong to the ACTIVE tab (#254).
+  // Previously sort/filter lived in the unmounted-on-switch view components
+  // and the search box was one App-level value shared by every tab, so the
+  // first vanished on a switch and the second leaked across tabs.
+  const activeView = activeTab?.view;
+  const query = activeView?.query ?? "";
+  const updateActiveView = (patch: Partial<TabViewState>) => {
+    if (activeTabId == null) return;
+    setTabs((ts) =>
+      ts.map((t) => (t.id === activeTabId ? { ...t, view: applyViewPatch(t.view, patch) } : t)),
+    );
+  };
   const activeKind: ResourceKind = activeTab?.kind ?? "pods";
   const activeCrd = activeTab?.crd ?? null;
   const clusters = orderContexts(
@@ -521,7 +535,6 @@ export function App() {
     const id = tabIdRef.current++;
     setTabs((ts) => [...ts, { id, cluster, kind, namespace: namespaceFor(cluster) }]);
     setActiveTabId(id);
-    setQuery("");
   }
 
   /** Open the single workspace-level Settings tab, optionally at a section. */
@@ -540,7 +553,6 @@ export function App() {
     const id = tabIdRef.current++;
     setTabs((ts) => [...ts, { id, cluster: null, kind: "settings" }]);
     setActiveTabId(id);
-    setQuery("");
   }
 
   /** Open (or focus) the single workspace-level Toolbox tab. When `context` is
@@ -556,7 +568,6 @@ export function App() {
     const id = tabIdRef.current++;
     setTabs((ts) => [...ts, { id, cluster: null, kind: "toolbox" }]);
     setActiveTabId(id);
-    setQuery("");
   }
 
   /** Open (or focus) the single workspace-level Assistant tab: a full-tab,
@@ -577,7 +588,6 @@ export function App() {
     const id = tabIdRef.current++;
     setTabs((ts) => [...ts, { id, cluster: null, kind: "assistant", namespace: "" }]);
     setActiveTabId(id);
-    setQuery("");
   }
   // Keep a stable handle to openSettings so the update-check effect's toast
   // action always uses the current tab state, not a stale closure.
@@ -642,7 +652,6 @@ export function App() {
       setActiveTabId(id);
     }
     setClusterNs((m) => ({ ...m, [cluster]: ns }));
-    setQuery("");
   }
 
   /** Open a resource's kind view and deep-link to its detail (from search). */
@@ -696,7 +705,6 @@ export function App() {
     const id = tabIdRef.current++;
     setTabs((ts) => [...ts, { id, cluster, kind: "overview", crd }]);
     setActiveTabId(id);
-    setQuery("");
   }
   function closeView(id: number) {
     setTabs((ts) => {
@@ -867,7 +875,9 @@ export function App() {
                       context={activeCluster}
                       crd={activeTab.crd}
                       query={query}
-                      onQueryChange={setQuery}
+                      onQueryChange={(q) => updateActiveView({ query: q })}
+                      view={activeView}
+                      onViewChange={updateActiveView}
                       detailDrawerWidth={layout.rightSidebarWidth}
                     />
                   ) : activeCluster && activeKind === "overview" ? (
@@ -913,7 +923,9 @@ export function App() {
                       context={activeCluster}
                       kind={activeKind}
                       query={query}
-                      onQueryChange={setQuery}
+                      onQueryChange={(q) => updateActiveView({ query: q })}
+                      view={activeView}
+                      onViewChange={updateActiveView}
                       onOpenTerminal={(s) => openDock("terminal", s)}
                       onOpenLogs={(s) => openDock("logs", s)}
                       onOpenEdit={openEditResource}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -67,6 +67,7 @@ import {
   reconcileActiveTab,
   reconcileCrdTabs,
 } from "./lib/openTabs";
+import { flushSettingsWrites } from "./lib/settingsStorage";
 import { startMcpHttp } from "./lib/mcp";
 import { checkForUpdateAndNotify } from "./lib/updateNotifier";
 import { notify } from "./lib/notify";
@@ -75,6 +76,9 @@ import type { SettingsSection } from "./components/SettingsView";
 import { listContexts, deleteContext, type ClusterContext } from "./lib/clusters";
 import { deletePod } from "./lib/workloads";
 import { clearAccessCache } from "./lib/access";
+
+/** How long a closing window waits for the settings write to land. */
+const CLOSE_WRITE_TIMEOUT_MS = 2000;
 
 export interface ViewTab {
   id: number;
@@ -373,8 +377,10 @@ export function App() {
 
   // Persist the open tabs (web only) so a browser reload restores them.
   useEffect(() => scheduleSaveOpenTabs(tabs, activeTabId), [tabs, activeTabId]);
-  // A coalesced session must still reach disk if the window goes away first.
+
+  // Web: localStorage writes are synchronous, so unload handlers suffice.
   useEffect(() => {
+    if (isTauri()) return;
     const flush = () => flushSaveOpenTabs();
     window.addEventListener("beforeunload", flush);
     window.addEventListener("pagehide", flush);
@@ -385,6 +391,41 @@ export function App() {
     // Deliberately no flush on unmount: the real teardown is the window going
     // away, which fires the events above. Flushing here would also write on
     // every test/HMR unmount, persisting a session the next mount restores.
+  }, []);
+
+  // Desktop: the durable write is an async IPC round trip, which an unload
+  // handler cannot wait for — it returns immediately and the WebView is torn
+  // down mid-write. Intercept the close instead, drain the queue, then close.
+  useEffect(() => {
+    if (!isTauri()) return;
+    const win = getCurrentWindow();
+    // Older runtimes (and the test harness) may not expose this; losing the
+    // close-time flush is far better than failing to mount the app.
+    if (typeof win?.onCloseRequested !== "function") return;
+    let unlisten: (() => void) | undefined;
+    let disposed = false;
+    void win
+      .onCloseRequested(async (event) => {
+        event.preventDefault();
+        flushSaveOpenTabs();
+        // Bounded: a stuck or slow write must never leave the user unable to
+        // quit, so the close proceeds either way.
+        await Promise.race([
+          flushSettingsWrites(),
+          new Promise((resolve) => setTimeout(resolve, CLOSE_WRITE_TIMEOUT_MS)),
+        ]);
+        // destroy(), not close() — close() re-emits this event and would loop.
+        await win.destroy();
+      })
+      .then((fn) => {
+        if (disposed) fn();
+        else unlisten = fn;
+      })
+      .catch(() => {});
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
   }, []);
 
   /** The namespace a new tab in `cluster` should start on. */

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -699,7 +699,23 @@ export function App() {
     const ns = namespace ?? "";
     const existing = tabs.find((t) => t.cluster === cluster && t.kind === kind && !t.crd);
     if (existing) {
-      setTabs((ts) => ts.map((t) => (t.id === existing.id ? { ...t, focus, namespace: ns } : t)));
+      setTabs((ts) =>
+        ts.map((t) =>
+          t.id === existing.id
+            ? {
+                ...t,
+                focus,
+                namespace: ns,
+                // Clear THIS tab's search only. The detail opens from the
+                // unfiltered rows, so a leftover query would leave the user
+                // on a list that doesn't contain what they navigated to once
+                // the drawer closes. Sort and filter column are unaffected,
+                // and other tabs keep their own searches.
+                view: applyViewPatch(t.view, { query: "" }),
+              }
+            : t,
+        ),
+      );
       setActiveTabId(existing.id);
     } else {
       const id = tabIdRef.current++;

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -60,7 +60,8 @@ import { applyViewPatch, type TabViewState } from "./lib/tabView";
 import { invokeCommand } from "./transport/transport";
 import {
   loadOpenTabs,
-  saveOpenTabs,
+  scheduleSaveOpenTabs,
+  flushSaveOpenTabs,
   nextTabId,
   pruneMissingContexts,
   reconcileActiveTab,
@@ -371,7 +372,20 @@ export function App() {
   useEffect(() => saveClusterNamespaces(clusterNs), [clusterNs]);
 
   // Persist the open tabs (web only) so a browser reload restores them.
-  useEffect(() => saveOpenTabs(tabs, activeTabId), [tabs, activeTabId]);
+  useEffect(() => scheduleSaveOpenTabs(tabs, activeTabId), [tabs, activeTabId]);
+  // A coalesced session must still reach disk if the window goes away first.
+  useEffect(() => {
+    const flush = () => flushSaveOpenTabs();
+    window.addEventListener("beforeunload", flush);
+    window.addEventListener("pagehide", flush);
+    return () => {
+      window.removeEventListener("beforeunload", flush);
+      window.removeEventListener("pagehide", flush);
+    };
+    // Deliberately no flush on unmount: the real teardown is the window going
+    // away, which fires the events above. Flushing here would also write on
+    // every test/HMR unmount, persisting a session the next mount restores.
+  }, []);
 
   /** The namespace a new tab in `cluster` should start on. */
   const namespaceFor = (cluster: string) => clusterNs[cluster] ?? defaultNs;

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -902,6 +902,8 @@ export function App() {
                       initialNamespace={activeTab.namespace ?? ""}
                       onNamespaceChange={(ns) => setTabNamespace(activeTab.id, activeCluster, ns)}
                       kubeconfigFiles={kubeconfigFiles}
+                      view={activeView}
+                      onViewChange={updateActiveView}
                     />
                   ) : activeCluster && activeKind === "newresource" ? (
                     <NewResourceEditor

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -529,7 +529,14 @@ export function App() {
       const id = activeTabIdRef.current;
       if (id != null) {
         const closingLastTab = tabsRef.current.length === 1 && tabsRef.current[0]?.id === id;
+        const remaining = tabsRef.current.filter((t) => t.id !== id);
         closeView(id);
+        // `closeView` only SCHEDULES the state change; the close below fires
+        // in this same callback, before React has re-rendered and run the
+        // persistence effect. Without queueing the post-close snapshot here,
+        // the close-request flush would write the pre-close one and the tab
+        // the user just closed would come back on the next launch.
+        scheduleSaveOpenTabs(remaining, remaining.at(-1)?.id ?? null);
         if (closingLastTab) void getCurrentWindow().close();
       } else {
         void getCurrentWindow().close();

--- a/apps/desktop/src/components/CustomResourceBrowser.tsx
+++ b/apps/desktop/src/components/CustomResourceBrowser.tsx
@@ -5,6 +5,7 @@ import { listNamespaces } from "../lib/workloads";
 import { YamlView } from "./YamlView";
 import { Table, filterTableData, Select, Button, ColumnPicker, useColumnVisibility, Spinner, Drawer, TextInput, type Column } from "../ui";
 import { ageSortValue } from "../lib/age";
+import type { TabViewState } from "../lib/tabView";
 
 interface Selected {
   name: string;
@@ -22,12 +23,17 @@ export function CustomResourceBrowser({
   query = "",
   onQueryChange,
   detailDrawerWidth = 480,
+  view,
+  onViewChange,
 }: {
   context: string;
   crd: CrdRef;
   query?: string;
   onQueryChange?: (q: string) => void;
   detailDrawerWidth?: number;
+  /** Sort + filtered column owned by the tab, so they survive a switch (#254). */
+  view?: TabViewState;
+  onViewChange?: (patch: Partial<TabViewState>) => void;
 }) {
   const [namespaces, setNamespaces] = useState<string[]>([]);
   const [namespace, setNamespace] = useState("");
@@ -35,7 +41,13 @@ export function CustomResourceBrowser({
   const [error, setError] = useState("");
   const [reloadKey, setReloadKey] = useState(0);
   const [selected, setSelected] = useState<Selected | null>(null);
-  const [filterColumn, setFilterColumn] = useState<string | null>(null);
+  // Tab-owned when a change handler is supplied; local otherwise.
+  const [localFilterColumn, setLocalFilterColumn] = useState<string | null>(null);
+  const filterColumn = onViewChange ? (view?.filterColumn ?? null) : localFilterColumn;
+  const setFilterColumn = (next: string | null) => {
+    if (onViewChange) onViewChange({ filterColumn: next });
+    else setLocalFilterColumn(next);
+  };
 
   useEffect(() => {
     if (!crd.namespaced) return;
@@ -141,6 +153,8 @@ export function CustomResourceBrowser({
               onRowClick={(r) => setSelected({ name: r.name, namespace: r.namespace })}
               activeFilterKey={filterColumn}
               onActiveFilterKeyChange={setFilterColumn}
+              sort={view?.sort ?? null}
+              onSortChange={onViewChange ? (sort) => onViewChange({ sort }) : undefined}
               emptyText={query ? "No matches" : `No ${crd.kind} resources`}
             />
           )}

--- a/apps/desktop/src/components/HelmReleasesView.tsx
+++ b/apps/desktop/src/components/HelmReleasesView.tsx
@@ -10,6 +10,7 @@ import {
   type HelmReleaseDetail,
 } from "../lib/helm";
 import { ageFromTimestamp, absoluteTimestamp, Section, KV } from "./ResourceOverview";
+import type { TabViewState } from "../lib/tabView";
 import {
   Table,
   filterTableData,
@@ -66,6 +67,8 @@ export function HelmReleasesView({
   initialNamespace,
   onNamespaceChange,
   kubeconfigFiles = [],
+  view,
+  onViewChange,
 }: {
   context: string;
   detailDrawerWidth?: number;
@@ -74,6 +77,9 @@ export function HelmReleasesView({
   initialNamespace?: string;
   /** Notified when the namespace filter changes, so the parent can preserve it. */
   onNamespaceChange?: (namespace: string) => void;
+  /** Sort + search owned by the tab, so they survive a switch (#254). */
+  view?: TabViewState;
+  onViewChange?: (patch: Partial<TabViewState>) => void;
   /**
    * All configured kubeconfig files (default path + pasted/additional). Used to
    * register their paths in the backend client cache before we build a client
@@ -108,7 +114,14 @@ export function HelmReleasesView({
     if (nsScope) setSelection([nsScope]);
   }, [nsScope]);
   const scopeNs = watchNamespaceForSelection(selection);
-  const [query, setQuery] = useState("");
+  // Tab-owned when a change handler is supplied (#254), so sorting or
+  // searching releases survives a tab switch like every other list.
+  const [localQuery, setLocalQuery] = useState("");
+  const query = onViewChange ? (view?.query ?? "") : localQuery;
+  const setQuery = (next: string) => {
+    if (onViewChange) onViewChange({ query: next });
+    else setLocalQuery(next);
+  };
   const [detail, setDetail] = useState<HelmReleaseDetail | null>(null);
   const [detailError, setDetailError] = useState("");
 
@@ -276,6 +289,8 @@ export function HelmReleasesView({
               getRowKey={(r) => `${r.namespace}/${r.name}`}
               onRowClick={setSelected}
               selectedKey={selected ? `${selected.namespace}/${selected.name}` : undefined}
+              sort={view?.sort ?? null}
+              onSortChange={onViewChange ? (sort) => onViewChange({ sort }) : undefined}
             />
           )}
         </div>

--- a/apps/desktop/src/components/ResourceBrowser.test.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.test.tsx
@@ -161,6 +161,29 @@ describe("ResourceBrowser", () => {
     expect(screen.getByRole("button", { name: "Choose columns" })).toBeDefined();
   });
 
+  it("does not wipe a tab-restored search column on mount (#254)", async () => {
+    // The browser is keyed by tab id, so it remounts on every tab switch. A
+    // mount-time reset would patch filterColumn: null straight back into the
+    // tab and silently undo the state this feature exists to preserve.
+    listNamespacesMock.mockResolvedValue({ namespaces: ["default"] });
+    watchResourceMock.mockImplementation(watchWith([pod]));
+    const onViewChange = vi.fn();
+
+    render(
+      <ResourceBrowser
+        context="kind-dev"
+        kind="pods"
+        view={{ filterColumn: "name" }}
+        onViewChange={onViewChange}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText("web-1")).toBeDefined());
+
+    expect(onViewChange).not.toHaveBeenCalledWith(
+      expect.objectContaining({ filterColumn: null }),
+    );
+  });
+
   it("re-opening a tab shows cached rows instantly instead of a full re-fetch", async () => {
     listNamespacesMock.mockResolvedValue({ namespaces: ["default"] });
     watchResourceMock.mockImplementation(watchWith([pod]));

--- a/apps/desktop/src/components/ResourceBrowser.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.tsx
@@ -673,7 +673,16 @@ export function ResourceBrowser({
 
   const namespaced = isNamespaced(kind);
 
-  useEffect(() => setFilterColumn(null), [kind]);
+  // Reset the search column only when the kind genuinely CHANGES in place —
+  // not on mount. This component is keyed by tab id, so it remounts on every
+  // tab switch, and a mount-time reset would patch `filterColumn: null` into
+  // the tab and wipe the very value #254 restores.
+  const previousKindRef = useRef(kind);
+  useEffect(() => {
+    if (previousKindRef.current === kind) return;
+    previousKindRef.current = kind;
+    setFilterColumn(null);
+  }, [kind]);
 
   useEffect(() => {
     if (namespaced && namespaces === null) return; // wait for the namespace list

--- a/apps/desktop/src/components/ResourceBrowser.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.tsx
@@ -47,6 +47,7 @@ import {
 type NodeRow = NodeSummary & { cpu?: number; memory?: number };
 type PodRow = PodSummary & { cpu?: number; memory?: number };
 import { watchResource, WATCHABLE_KINDS, type WatchHandle, type WatchStatus } from "../lib/watch";
+import type { TabViewState } from "../lib/tabView";
 import {
   parseNamespaceSelection,
   serializeNamespaceSelection,
@@ -582,11 +583,17 @@ export function ResourceBrowser({
   onNamespaceChange,
   detailDrawerWidth = 480,
   kubeconfigFiles = [],
+  view,
+  onViewChange,
 }: {
   context: string;
   kind: ResourceKind;
   query?: string;
   onQueryChange?: (q: string) => void;
+  /** Sort + filtered column, owned by the tab so they survive a switch (#254).
+   *  Absent means the browser keeps them itself, as it used to. */
+  view?: TabViewState;
+  onViewChange?: (patch: Partial<TabViewState>) => void;
   onOpenTerminal?: (s: {
     context: string;
     namespace: string;
@@ -652,7 +659,14 @@ export function ResourceBrowser({
   const [bulkKeys, setBulkKeys] = useState<Set<string>>(new Set());
   // Bumped after a write action so the open detail overview re-fetches.
   const [detailReload, setDetailReload] = useState(0);
-  const [filterColumn, setFilterColumn] = useState<string | null>(null);
+  // Owned by the tab when it supplies a change handler; otherwise local, so
+  // the component still works standalone (tests, and any non-tabbed caller).
+  const [localFilterColumn, setLocalFilterColumn] = useState<string | null>(null);
+  const filterColumn = onViewChange ? (view?.filterColumn ?? null) : localFilterColumn;
+  const setFilterColumn = (next: string | null) => {
+    if (onViewChange) onViewChange({ filterColumn: next });
+    else setLocalFilterColumn(next);
+  };
   // Per-pod CPU/memory (millicores / MiB), merged into the pods table.
   const [podCpuMem, setPodCpuMem] = useState<Map<string, { cpu: number; mem: number }>>(new Map());
   const viewKeyRef = useRef("");
@@ -1086,6 +1100,8 @@ export function ResourceBrowser({
                   onRowClick={kind === "events" ? undefined : onRowClick}
                   activeFilterKey={filterColumn}
                   onActiveFilterKeyChange={setFilterColumn}
+                  sort={view?.sort ?? null}
+                  onSortChange={onViewChange ? (sort) => onViewChange({ sort }) : undefined}
                   emptyText={
                     query
                       ? "No matches"

--- a/apps/desktop/src/lib/openTabs.test.ts
+++ b/apps/desktop/src/lib/openTabs.test.ts
@@ -1,8 +1,10 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CrdRef } from "./crds";
 import {
   loadOpenTabs,
   saveOpenTabs,
+  scheduleSaveOpenTabs,
+  flushSaveOpenTabs,
   nextTabId,
   pruneMissingContexts,
   reconcileActiveTab,
@@ -255,5 +257,51 @@ describe("reconcileCrdTabs", () => {
     const result = reconcileCrdTabs(tabs, "prod", [crd()]);
     expect(result.tabs[0]).toBe(tabs[0]);
     expect(result.dropped).toBe(0);
+  });
+});
+
+describe("coalesced session persistence", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    flushSaveOpenTabs();
+    vi.useRealTimers();
+    localStorage.clear();
+  });
+
+  it("writes once for a burst, carrying the newest snapshot", () => {
+    // Search text lives on the tab, so a burst here is one per keystroke.
+    // Each write is a full settings.json rewrite ending in fsync, so they
+    // must not go one-per-change.
+    scheduleSaveOpenTabs([tab({ id: 1 })], 1);
+    scheduleSaveOpenTabs([tab({ id: 1 }), tab({ id: 2 })], 2);
+    scheduleSaveOpenTabs([tab({ id: 1 }), tab({ id: 2 }), tab({ id: 3 })], 3);
+    // Nothing written yet.
+    expect(localStorage.getItem("srelens.openTabs")).toBeNull();
+
+    vi.advanceTimersByTime(400);
+    const stored = JSON.parse(localStorage.getItem("srelens.openTabs") ?? "{}");
+    expect(stored.tabs.map((t: { id: number }) => t.id)).toEqual([1, 2, 3]);
+    expect(stored.activeTabId).toBe(3);
+  });
+
+  it("does not restart the timer, so continuous typing still reaches disk", () => {
+    scheduleSaveOpenTabs([tab({ id: 1 })], 1);
+    // A change every 300ms would starve a restarting debounce forever.
+    vi.advanceTimersByTime(300);
+    scheduleSaveOpenTabs([tab({ id: 2 })], 2);
+    vi.advanceTimersByTime(300);
+    expect(localStorage.getItem("srelens.openTabs")).not.toBeNull();
+  });
+
+  it("flushes a pending write immediately, for a closing window", () => {
+    scheduleSaveOpenTabs([tab({ id: 9 })], 9);
+    expect(localStorage.getItem("srelens.openTabs")).toBeNull();
+    flushSaveOpenTabs();
+    expect(JSON.parse(localStorage.getItem("srelens.openTabs") ?? "{}").activeTabId).toBe(9);
+  });
+
+  it("flushing with nothing pending is a no-op", () => {
+    flushSaveOpenTabs();
+    expect(localStorage.getItem("srelens.openTabs")).toBeNull();
   });
 });

--- a/apps/desktop/src/lib/openTabs.test.ts
+++ b/apps/desktop/src/lib/openTabs.test.ts
@@ -115,6 +115,30 @@ describe("openTabs on desktop", () => {
   });
 });
 
+describe("view state round trip", () => {
+  afterEach(() => localStorage.clear());
+
+  it("carries sort, search and filter column through a save/load cycle (#254)", () => {
+    // Tabs are already serialized, so putting view state on the tab makes it
+    // survive a restart for free — this locks that in.
+    const withView = {
+      ...tab({ id: 1 }),
+      view: { sort: { key: "age", direction: "desc" }, query: "nginx", filterColumn: "name" },
+    } as Tab;
+    saveOpenTabs([withView], 1);
+    expect(loadOpenTabs()?.tabs[0]).toMatchObject({
+      view: { sort: { key: "age", direction: "desc" }, query: "nginx", filterColumn: "name" },
+    });
+  });
+
+  it("restores a tab that never had view state without inventing one", () => {
+    saveOpenTabs([tab({ id: 2 })], 2);
+    const restored = loadOpenTabs()?.tabs[0];
+    expect(restored).toBeDefined();
+    expect(restored && "view" in restored).toBe(false);
+  });
+});
+
 describe("session restore opt-out", () => {
   afterEach(() => {
     localStorage.clear();

--- a/apps/desktop/src/lib/openTabs.ts
+++ b/apps/desktop/src/lib/openTabs.ts
@@ -85,6 +85,52 @@ export function saveOpenTabs(tabs: ViewTab[], activeTabId: number | null): void 
 }
 
 /**
+ * How long to gather tab changes before writing the session.
+ *
+ * Search text lives on the tab (#254), so every keystroke mutates `tabs`.
+ * Writing per keystroke means a full read-modify-rewrite of settings.json —
+ * under an interprocess lock, ending in `sync_all` — for each character, which
+ * queues fsyncs behind each other and delays unrelated settings writes.
+ */
+const SAVE_DEBOUNCE_MS = 400;
+
+let pendingSave: { tabs: ViewTab[]; activeTabId: number | null } | null = null;
+let saveTimer: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Persist the session, coalescing bursts. The in-memory state is untouched —
+ * only the durable write is delayed — so the UI stays instant.
+ *
+ * The timer is NOT restarted by later changes: the write lands a fixed delay
+ * after the first change of a burst, carrying the newest snapshot. A restarting
+ * debounce would starve during continuous typing and never write at all.
+ */
+export function scheduleSaveOpenTabs(tabs: ViewTab[], activeTabId: number | null): void {
+  pendingSave = { tabs, activeTabId };
+  if (saveTimer) return;
+  saveTimer = setTimeout(() => {
+    saveTimer = null;
+    const snapshot = pendingSave;
+    pendingSave = null;
+    if (snapshot) saveOpenTabs(snapshot.tabs, snapshot.activeTabId);
+  }, SAVE_DEBOUNCE_MS);
+}
+
+/**
+ * Write any coalesced session immediately. Called when the window is going
+ * away, so the last keystrokes before a quit are not lost with the timer.
+ */
+export function flushSaveOpenTabs(): void {
+  if (saveTimer) {
+    clearTimeout(saveTimer);
+    saveTimer = null;
+  }
+  const snapshot = pendingSave;
+  pendingSave = null;
+  if (snapshot) saveOpenTabs(snapshot.tabs, snapshot.activeTabId);
+}
+
+/**
  * Drop restored tabs whose cluster is no longer among the discovered
  * contexts, returning the survivors and how many were dropped. Cluster-less
  * tabs (Settings, Toolbox, the landing view) are always kept — they do not

--- a/apps/desktop/src/lib/tabView.test.ts
+++ b/apps/desktop/src/lib/tabView.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { applyViewPatch, nextSort } from "./tabView";
+
+describe("nextSort", () => {
+  it("cycles ascending, descending, then unsorted", () => {
+    const first = nextSort(null, "name");
+    expect(first).toEqual({ key: "name", direction: "asc" });
+    const second = nextSort(first, "name");
+    expect(second).toEqual({ key: "name", direction: "desc" });
+    expect(nextSort(second, "name")).toBeNull();
+  });
+
+  it("starts a different column ascending, whatever the previous one was", () => {
+    expect(nextSort({ key: "name", direction: "desc" }, "age")).toEqual({
+      key: "age",
+      direction: "asc",
+    });
+  });
+
+  it("treats undefined like unsorted", () => {
+    expect(nextSort(undefined, "age")).toEqual({ key: "age", direction: "asc" });
+  });
+});
+
+describe("applyViewPatch", () => {
+  it("merges a patch into existing view state", () => {
+    const result = applyViewPatch({ query: "nginx" }, { sort: { key: "age", direction: "asc" } });
+    expect(result).toEqual({ query: "nginx", sort: { key: "age", direction: "asc" } });
+  });
+
+  it("returns undefined when nothing is left, so empty tabs stay clean", () => {
+    // Otherwise every untouched tab would serialize a `"view": {}` into the
+    // session file for no reason.
+    expect(applyViewPatch(undefined, {})).toBeUndefined();
+    expect(applyViewPatch({ query: "x" }, { query: "" })).toBeUndefined();
+    expect(applyViewPatch({ sort: { key: "a", direction: "asc" } }, { sort: null })).toBeUndefined();
+  });
+
+  it("drops cleared fields rather than storing empty placeholders", () => {
+    const result = applyViewPatch(
+      { query: "nginx", filterColumn: "name", sort: { key: "age", direction: "asc" } },
+      { filterColumn: null },
+    );
+    expect(result).toEqual({ query: "nginx", sort: { key: "age", direction: "asc" } });
+    expect(result && "filterColumn" in result).toBe(false);
+  });
+
+  it("keeps unrelated fields when one is patched", () => {
+    const result = applyViewPatch(
+      { query: "nginx", sort: { key: "age", direction: "desc" } },
+      { query: "coredns" },
+    );
+    expect(result).toEqual({ query: "coredns", sort: { key: "age", direction: "desc" } });
+  });
+});

--- a/apps/desktop/src/lib/tabView.ts
+++ b/apps/desktop/src/lib/tabView.ts
@@ -1,0 +1,54 @@
+// Per-tab list view state (#254).
+//
+// Sort, the search text, and the filtered column used to live in component
+// state, which meant they died the moment a tab was switched away — App
+// renders only the active tab, keyed by its id, so the previous view is
+// unmounted outright. Search had the opposite problem: one App-level value
+// shared by every tab, so it leaked from one list into another.
+//
+// Holding them on the tab fixes both, and because tabs are already serialized
+// (lib/openTabs.ts) it also makes them survive a restart.
+
+/** A table's sort column and direction; null means "unsorted". */
+export interface TableSort {
+  key: string;
+  direction: "asc" | "desc";
+}
+
+/** The slice of a tab's state that belongs to its list view. */
+export interface TabViewState {
+  sort?: TableSort | null;
+  /** Column the search box is scoped to; null searches every column. */
+  filterColumn?: string | null;
+  query?: string;
+}
+
+/**
+ * The sort a header click should produce: ascending, then descending, then
+ * back to unsorted. Pure so the cycle is testable without a rendered table,
+ * and so a controlled table can compute it from the value it was handed.
+ */
+export function nextSort(current: TableSort | null | undefined, key: string): TableSort | null {
+  if (!current || current.key !== key) return { key, direction: "asc" };
+  if (current.direction === "asc") return { key, direction: "desc" };
+  return null;
+}
+
+/**
+ * Apply a patch to a tab's view state, returning undefined when the result
+ * carries nothing. Dropping an empty object keeps it out of the serialized
+ * tab, so a session file isn't littered with `"view": {}` for every tab the
+ * user never sorted or searched.
+ */
+export function applyViewPatch(
+  current: TabViewState | undefined,
+  patch: Partial<TabViewState>,
+): TabViewState | undefined {
+  const next: TabViewState = { ...current, ...patch };
+  // An explicitly cleared field is dropped rather than stored as a null/empty
+  // that would round-trip through the session file to no effect.
+  if (next.sort == null) delete next.sort;
+  if (next.filterColumn == null) delete next.filterColumn;
+  if (!next.query) delete next.query;
+  return Object.keys(next).length > 0 ? next : undefined;
+}

--- a/apps/desktop/src/ui/Table.test.tsx
+++ b/apps/desktop/src/ui/Table.test.tsx
@@ -154,6 +154,44 @@ describe("Table", () => {
     expect(filterTableData(rows, ageColumns, "1y", null)).toEqual([{ name: "old", age: "1y" }]);
   });
 
+  it("hands sort changes to the owner when controlled (#254)", () => {
+    // The tab owns the sort so it survives a switch; the table must not keep
+    // a private copy that silently diverges from what it was handed.
+    const onSortChange = vi.fn();
+    const { rerender } = render(
+      <Table
+        columns={columns}
+        data={data}
+        getRowKey={(r) => r.name}
+        sort={null}
+        onSortChange={onSortChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Sort by Name" }));
+    expect(onSortChange).toHaveBeenCalledWith({ key: "name", direction: "asc" });
+
+    // Still unsorted on screen until the owner feeds the new value back.
+    expect(screen.getAllByRole("row")[1].textContent).toContain("web-1");
+
+    rerender(
+      <Table
+        columns={columns}
+        data={[...data].reverse()}
+        getRowKey={(r) => r.name}
+        sort={{ key: "name", direction: "asc" }}
+        onSortChange={onSortChange}
+      />,
+    );
+    expect(screen.getAllByRole("row")[1].textContent).toContain("web-1");
+  });
+
+  it("keeps its own sort when uncontrolled", () => {
+    // Tables outside the tabbed workspace have no tab to store a sort on.
+    render(<Table columns={columns} data={[...data].reverse()} getRowKey={(r) => r.name} />);
+    fireEvent.click(screen.getByRole("button", { name: "Sort by Name" }));
+    expect(screen.getAllByRole("row")[1].textContent).toContain("web-1");
+  });
+
   it("selects a column for the toolbar search", () => {
     const onChange = vi.fn();
     render(

--- a/apps/desktop/src/ui/Table.tsx
+++ b/apps/desktop/src/ui/Table.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
 import { EmptyState } from "./Dashboard";
+import { nextSort, type TableSort } from "@/lib/tabView";
 
 export interface Column<T> {
   key: string;
@@ -50,6 +51,10 @@ export interface TableProps<T> {
   /** Column currently used by the toolbar search; null searches every column. */
   activeFilterKey?: string | null;
   onActiveFilterKeyChange?: (key: string | null) => void;
+  /** Controlled sort. Supply both to own it (so it can live on the tab and
+   *  survive a switch, #254); omit them and the table keeps its own. */
+  sort?: TableSort | null;
+  onSortChange?: (sort: TableSort | null) => void;
 }
 
 function getColumnValue<T>(row: T, column: Column<T>): unknown {
@@ -113,8 +118,14 @@ export function Table<T>({
   emptyText = "No items",
   activeFilterKey = null,
   onActiveFilterKeyChange,
+  sort: controlledSort,
+  onSortChange,
 }: TableProps<T>) {
-  const [sort, setSort] = useState<{ key: string; direction: "asc" | "desc" } | null>(null);
+  // Controlled when a change handler is supplied, otherwise self-managed —
+  // tables outside the tabbed workspace (the MCP audit list, for instance)
+  // have no tab to store a sort on.
+  const [internalSort, setInternalSort] = useState<TableSort | null>(null);
+  const sort = onSortChange ? (controlledSort ?? null) : internalSort;
   // Anchor for shift-click range selection (a key in sorted/visible order).
   const selectionAnchor = useRef<string | null>(null);
   const [columnWidths, setColumnWidths] = useState<Record<string, number>>({});
@@ -175,11 +186,9 @@ export function Table<T>({
   };
 
   const cycleSort = (key: string) => {
-    setSort((current) => {
-      if (!current || current.key !== key) return { key, direction: "asc" };
-      if (current.direction === "asc") return { key, direction: "desc" };
-      return null;
-    });
+    const next = nextSort(sort, key);
+    if (onSortChange) onSortChange(next);
+    else setInternalSort(next);
   };
 
   const startColumnResize = (event: React.PointerEvent<HTMLDivElement>, column: Column<T>) => {

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -332,6 +332,11 @@ The window's size, position, and maximized state are remembered across
 restarts, as are your open tabs and the active one — see
 [Reopen tabs on launch](#settings-reference) to turn the tab part off.
 
+Each tab also keeps its own **sort, search text, and column filter**, so
+switching between tabs no longer resets them and a search typed in one list
+never carries into another. These are restored along with the tabs themselves.
+Column show/hide choices remain shared by every tab of the same kind.
+
 ## Application logs
 
 srelens keeps its own rotating log file so you can diagnose problems after they

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -332,10 +332,11 @@ The window's size, position, and maximized state are remembered across
 restarts, as are your open tabs and the active one — see
 [Reopen tabs on launch](#settings-reference) to turn the tab part off.
 
-Each tab also keeps its own **sort, search text, and column filter**, so
-switching between tabs no longer resets them and a search typed in one list
-never carries into another. These are restored along with the tabs themselves.
-Column show/hide choices remain shared by every tab of the same kind.
+Each tab also keeps its own **sort, search text, and column filter** — across
+resource lists, custom resources, and Helm releases — so switching between tabs
+no longer resets them and a search typed in one list never carries into another.
+These are restored along with the tabs themselves. Column show/hide choices
+remain shared by every tab of the same kind.
 
 ## Application logs
 


### PR DESCRIPTION
Closes #254 — reported from real use: sort a list, switch tabs, come back, and the sort is gone.

## The two halves of the bug
`App` renders only the active tab, keyed by its id, so switching **unmounts** the previous view and everything in its component state goes with it — sort and filter column included. Nothing was resetting them; they simply never survived the unmount.

Search had the *opposite* fault: a single App-level `query` shared by every tab, cleared by `setQuery("")` on some navigation paths but not when you clicked a tab. So text typed in one list silently filtered another.

Per-view state was global; per-tab state was transient. Both are now on the tab.

## Change
- `ViewTab.view` holds `sort`, `filterColumn`, and `query`, beside `namespace` — which already demonstrated this pattern.
- `Table`'s sort becomes **optionally controlled**: pass `onSortChange` to own it, omit it and the table keeps its own. Tables outside the tabbed workspace (the MCP audit list) are untouched.
- Both browsers accept `view`/`onViewChange` and fall back to local state when absent, so they still work standalone in tests.
- The scattered `setQuery("")` calls are gone: a new tab has no query, and returning to a tab restores the one it had.

## Free consequence worth noting
Tabs are already serialized by `lib/openTabs.ts` (#159), so putting view state on the tab makes sort and search survive a **restart** too. A round-trip test pins that, plus one asserting an untouched tab doesn't gain a `"view": {}` in the session file — `applyViewPatch` drops cleared fields and returns undefined when nothing remains.

## Scope decided deliberately, per the issue
| State | Scope | Why |
| --- | --- | --- |
| Sort, search, filter column | **per tab** | What the report is about |
| Column show/hide | per kind (unchanged) | Already worked that way |
| Scroll position, bulk selection | **left transient** | Restoring a stale selection ahead of a bulk action is a hazard, not a convenience |

## Tests
7 for `nextSort`/`applyViewPatch`, 2 for controlled vs uncontrolled `Table` sort (including that a controlled table doesn't move until its owner feeds the value back), 2 for the restart round trip. Suite: 1095 passing, `tsc` clean.