### PR TITLE
fix(kubeconfig): discover and watch the app's kubeconfigs folder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5876,6 +5876,7 @@ version = "0.6.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
+ "dirs",
  "flate2",
  "futures",
  "hex",

--- a/apps/desktop/src-tauri/src/capabilities.rs
+++ b/apps/desktop/src-tauri/src/capabilities.rs
@@ -8,6 +8,7 @@
 
 pub use srelens_registry::{
     build_registry, build_registry_with, build_registry_with_paths,
-    build_registry_with_paths_and_settings, default_kubeconfig_paths, default_settings_path,
+    all_kubeconfig_paths, build_registry_with_paths_and_settings, default_kubeconfig_paths,
+    default_settings_path,
     run_tool,
 };

--- a/apps/desktop/src-tauri/src/helm.rs
+++ b/apps/desktop/src-tauri/src/helm.rs
@@ -22,7 +22,7 @@ pub async fn start_helm_op(
     app: AppHandle,
     manager: State<'_, HelmManager>,
 ) -> Result<u64, String> {
-    let mut paths = crate::capabilities::default_kubeconfig_paths();
+    let mut paths = crate::capabilities::all_kubeconfig_paths();
     paths.extend(extra_kubeconfigs.iter().map(std::path::PathBuf::from));
     manager
         .start(

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -179,11 +179,25 @@ async fn watch_kubeconfig_files(app_handle: tauri::AppHandle, cache: std::sync::
     use std::time::SystemTime;
     use tauri::Emitter;
 
+    // The cache's paths plus everything in the app's own kubeconfig folder.
+    // Polling the cache alone only ever compares files it already knows about,
+    // so a config pasted in — or dropped there by hand — was invisible until a
+    // restart (#256). Enumerating the folder is what makes creation and
+    // deletion observable at all.
+    async fn watched_paths(cache: &ClientCache) -> Vec<PathBuf> {
+        let mut paths = cache.paths().await;
+        for managed in srelens_registry::managed_kubeconfig_files() {
+            if !paths.contains(&managed) {
+                paths.push(managed);
+            }
+        }
+        paths
+    }
+
     let mut last_modified: HashMap<PathBuf, Option<SystemTime>> = HashMap::new();
 
     // Initialize the map with current files
-    let initial_paths = cache.paths().await;
-    for path in initial_paths {
+    for path in watched_paths(&cache).await {
         let modified = tokio::fs::metadata(&path)
             .await
             .and_then(|m| m.modified())
@@ -194,7 +208,7 @@ async fn watch_kubeconfig_files(app_handle: tauri::AppHandle, cache: std::sync::
     loop {
         tokio::time::sleep(tokio::time::Duration::from_millis(1500)).await;
 
-        let current_paths = cache.paths().await;
+        let current_paths = watched_paths(&cache).await;
         let mut changed = false;
 
         let mut next_modified = HashMap::new();

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -194,6 +194,7 @@ async fn watch_kubeconfig_files(app_handle: tauri::AppHandle, cache: std::sync::
         paths
     }
 
+
     let mut last_modified: HashMap<PathBuf, Option<SystemTime>> = HashMap::new();
 
     // Initialize the map with current files
@@ -260,7 +261,7 @@ pub fn run() {
 
     // One shared client cache: request/response capabilities AND live watches
     // reuse the same authenticated kube-rs clients.
-    let cache = ClientCache::new_many(capabilities::default_kubeconfig_paths());
+    let cache = ClientCache::new_many(capabilities::all_kubeconfig_paths());
     let registry = capabilities::build_registry_with(cache.clone());
 
     // single-instance is registered BEFORE every other plugin, as the plugin
@@ -359,7 +360,7 @@ pub fn run() {
                 .map_err(|e| e.to_string())
                 .map(|dir| dir.join("cluster-oidc"))
                 .and_then(|config_dir| {
-                    let paths = capabilities::default_kubeconfig_paths();
+                    let paths = capabilities::all_kubeconfig_paths();
                     let yamls = cluster_oidc::read_kubeconfig_yamls(&paths);
                     tauri::async_runtime::block_on(cluster_oidc::DesktopClusterOidc::build(
                         &config_dir,

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -225,7 +225,7 @@ fn run_mcp_http(
         // connections, and could diverge from the read path on credential
         // refresh.
         let cache = srelens_kube::client_cache::ClientCache::new_many(
-            srelens_registry::default_kubeconfig_paths(),
+            srelens_registry::all_kubeconfig_paths(),
         );
         let registry = srelens_desktop_lib::build_registry_with_paths_and_settings(
             cache.clone(),
@@ -290,7 +290,7 @@ fn run_mcp_stdio(allow_destructive: bool, allow_sensitive_reads: bool) {
         // share it between the registry and the watcher rather than letting
         // `build_registry` create one it doesn't expose.
         let cache = srelens_kube::client_cache::ClientCache::new_many(
-            srelens_registry::default_kubeconfig_paths(),
+            srelens_registry::all_kubeconfig_paths(),
         );
         let registry = srelens_desktop_lib::build_registry_with_paths_and_settings(
             cache.clone(),

--- a/apps/desktop/src-tauri/src/terminal.rs
+++ b/apps/desktop/src-tauri/src/terminal.rs
@@ -22,7 +22,7 @@ pub async fn start_terminal(
     app: AppHandle,
     manager: State<'_, TerminalManager>,
 ) -> Result<u64, String> {
-    let mut paths = crate::capabilities::default_kubeconfig_paths();
+    let mut paths = crate::capabilities::all_kubeconfig_paths();
     paths.extend(extra_kubeconfigs.iter().map(std::path::PathBuf::from));
     manager
         .start(

--- a/crates/kube/Cargo.toml
+++ b/crates/kube/Cargo.toml
@@ -6,6 +6,8 @@ edition.workspace = true
 [dependencies]
 srelens-capability = { path = "../capability" }
 async-trait = "0.1"
+# Locates the app's own kubeconfig folder (see connect::default_kubeconfig_dir).
+dirs = "6"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1"

--- a/crates/kube/src/connect.rs
+++ b/crates/kube/src/connect.rs
@@ -3,7 +3,7 @@
 //! reachability. Authentication (client certs, tokens, exec plugins) is handled
 //! by kube-rs from the kubeconfig.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -63,6 +63,56 @@ pub fn init_timeout_from_env() -> u64 {
         }
     }
     request_timeout_secs()
+}
+
+/// The folder the app owns for kubeconfigs it manages itself — where a pasted
+/// config is saved. Tied to the bundle identifier, like `settings.json`, so it
+/// survives dev/installed builds and binary renames.
+pub fn default_kubeconfig_dir() -> Option<PathBuf> {
+    Some(
+        dirs::config_dir()?
+            .join("app.srelens.desktop")
+            .join("kubeconfigs"),
+    )
+}
+
+/// Kubeconfigs currently in the app's own folder, sorted for a stable order.
+///
+/// Enumerated on every call rather than captured once: a config pasted in, or
+/// dropped there by hand, is one the app should resolve without anyone
+/// registering it separately, and one deleted should stop resolving (#256). An
+/// unreadable folder or entry is simply absent — discovery is best-effort and
+/// must never fail a listing.
+pub fn managed_kubeconfig_files() -> Vec<PathBuf> {
+    let Some(dir) = default_kubeconfig_dir() else {
+        return Vec::new();
+    };
+    kubeconfig_files_in(&dir)
+}
+
+/// The enumeration itself, taking the directory so it is testable without the
+/// platform config dir (the same seam pattern used elsewhere for path-bound
+/// code). An unreadable folder or entry yields nothing rather than an error:
+/// discovery is best-effort and must never fail a context listing.
+pub fn kubeconfig_files_in(dir: &Path) -> Vec<PathBuf> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut files: Vec<PathBuf> = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| {
+            // Skip dotfiles: editors and sync tools leave partial copies
+            // (.foo.yaml.swp, .DS_Store) that are not kubeconfigs.
+            path.is_file()
+                && !path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with('.'))
+        })
+        .collect();
+    files.sort();
+    files
 }
 
 /// Build an authenticated kube-rs client for a named kubeconfig context.
@@ -456,6 +506,77 @@ pub fn test_cluster_connection_capability() -> Capability {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn tmp_dir(label: &str) -> PathBuf {
+        static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "srelens-kubecfg-{label}-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn a_file_created_after_startup_is_discovered() {
+        // The whole point of #256: enumerating the folder, rather than
+        // remembering a snapshot, is what makes a pasted or hand-dropped
+        // kubeconfig visible without a restart.
+        let dir = tmp_dir("created");
+        assert!(kubeconfig_files_in(&dir).is_empty());
+
+        std::fs::write(dir.join("team.yaml"), b"apiVersion: v1\n").unwrap();
+        let found = kubeconfig_files_in(&dir);
+        assert_eq!(found.len(), 1);
+        assert!(found[0].ends_with("team.yaml"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_deleted_file_stops_being_discovered() {
+        let dir = tmp_dir("deleted");
+        let path = dir.join("gone.yaml");
+        std::fs::write(&path, b"apiVersion: v1\n").unwrap();
+        assert_eq!(kubeconfig_files_in(&dir).len(), 1);
+
+        std::fs::remove_file(&path).unwrap();
+        assert!(kubeconfig_files_in(&dir).is_empty());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn dotfiles_and_subdirectories_are_ignored() {
+        // Editors and sync tools leave partial copies beside real files.
+        let dir = tmp_dir("noise");
+        std::fs::write(dir.join("real.yaml"), b"apiVersion: v1\n").unwrap();
+        std::fs::write(dir.join(".real.yaml.swp"), b"junk").unwrap();
+        std::fs::write(dir.join(".DS_Store"), b"junk").unwrap();
+        std::fs::create_dir_all(dir.join("nested")).unwrap();
+
+        let found = kubeconfig_files_in(&dir);
+        assert_eq!(found.len(), 1, "only the real file: {found:?}");
+        assert!(found[0].ends_with("real.yaml"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn discovery_is_sorted_and_survives_a_missing_folder() {
+        let dir = tmp_dir("sorted");
+        for name in ["c.yaml", "a.yaml", "b.yaml"] {
+            std::fs::write(dir.join(name), b"apiVersion: v1\n").unwrap();
+        }
+        let names: Vec<String> = kubeconfig_files_in(&dir)
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(names, ["a.yaml", "b.yaml", "c.yaml"], "stable order");
+
+        // A folder that was never created must not be an error.
+        assert!(kubeconfig_files_in(&dir.join("nonexistent")).is_empty());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     use serde_json::json;
     use srelens_capability::Registry;
     use std::path::PathBuf;

--- a/crates/kube/src/contexts.rs
+++ b/crates/kube/src/contexts.rs
@@ -69,35 +69,44 @@ pub fn list_contexts_capability(
             let default_paths = default_paths.clone();
             let managed_dir = managed_dir.clone();
             async move {
-                if let Some(additional) = input.paths {
-                    let mut paths = default_paths;
-                    for path in additional.into_iter().map(PathBuf::from) {
-                        if !paths.contains(&path) {
-                            paths.push(path);
-                        }
-                    }
-                    // Read HERE, not captured at registry-build time: the
-                    // folder's contents change while the app runs, and a
-                    // startup snapshot would miss anything pasted or dropped
-                    // in afterwards (#256).
-                    if let Some(dir) = &managed_dir {
-                        for managed in crate::connect::kubeconfig_files_in(dir) {
-                            if !paths.contains(&managed) {
-                                paths.push(managed);
+                // A caller that names its own files rebuilds from the static
+                // defaults; one that doesn't keeps whatever is already active,
+                // so an MCP `{}` call never discards paths the desktop set.
+                let mut paths = match input.paths {
+                    Some(additional) => {
+                        let mut paths = default_paths;
+                        for path in additional.into_iter().map(PathBuf::from) {
+                            if !paths.contains(&path) {
+                                paths.push(path);
                             }
                         }
+                        paths
                     }
-                    // `default_paths` is a snapshot taken when the registry was
-                    // built, so a kubeconfig deleted while the app runs would
-                    // otherwise be reintroduced on every call and sit in the
-                    // cache forever — where `load_kubeconfigs` is strict and
-                    // fails the merged-resolution fallback on the missing file.
-                    // Only ABSENT files are dropped: one that exists but is
-                    // malformed still reaches the reader and surfaces its parse
-                    // error, which the caller needs to see.
-                    paths.retain(|path| path.exists());
-                    cache.set_paths(paths).await;
+                    None => cache.paths().await,
+                };
+                // Both branches then reconcile with the disk, so discovery
+                // behaves the same however the capability is invoked.
+                //
+                // Read HERE, not captured at registry-build time: the folder's
+                // contents change while the app runs, and a startup snapshot
+                // would miss anything pasted or dropped in afterwards (#256).
+                if let Some(dir) = &managed_dir {
+                    for managed in crate::connect::kubeconfig_files_in(dir) {
+                        if !paths.contains(&managed) {
+                            paths.push(managed);
+                        }
+                    }
                 }
+                // `default_paths` and the cache seed are both snapshots, so a
+                // kubeconfig deleted while the app runs would otherwise be
+                // reintroduced on every call and sit in the cache forever —
+                // where `load_kubeconfigs` is strict and fails the
+                // merged-resolution fallback on the missing file. Only ABSENT
+                // files are dropped: one that exists but is malformed still
+                // reaches the reader and surfaces its parse error, which the
+                // caller needs to see.
+                paths.retain(|path| path.exists());
+                cache.set_paths(paths).await;
                 // Enumerate every context across all files with duplicate-name
                 // disambiguation, so contexts that share a name (e.g. `default`
                 // across per-cluster kubeconfigs) are all visible and each
@@ -533,6 +542,45 @@ users:
             !active.contains(&pasted),
             "deleted kubeconfig still active: {active:?}"
         );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn discovery_self_heals_for_a_caller_that_sends_no_paths() {
+        // An MCP client calls k8s.listContexts with {}. Reconciliation used to
+        // run only when `paths` was present, so such a caller kept whatever
+        // the startup cache seed held — including files since deleted.
+        let dir = std::env::temp_dir().join(format!("srelens-nopaths-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let base = dir.join("base.yaml");
+        std::fs::write(&base, "clusters:\n- name: a\n  cluster: { server: https://a }\ncontexts:\n- name: ctx-a\n  context: { cluster: a, user: user-a }\n").unwrap();
+        let managed = dir.join("managed");
+        std::fs::create_dir_all(&managed).unwrap();
+        let seeded = managed.join("seeded.yaml");
+        std::fs::write(&seeded, "clusters:\n- name: b\n  cluster: { server: https://b }\ncontexts:\n- name: ctx-b\n  context: { cluster: b, user: user-b }\n").unwrap();
+
+        // Cache seeded at startup with the managed file, as the desktop does.
+        let cache = ClientCache::new_many(vec![base.clone(), seeded.clone()]);
+        let mut reg = Registry::new();
+        reg.register(list_contexts_capability(
+            cache.clone(),
+            vec![base.clone()],
+            Some(managed.clone()),
+        ));
+
+        // A NEW file appears, and the seeded one is deleted.
+        std::fs::write(managed.join("added.yaml"), "clusters:\n- name: c\n  cluster: { server: https://c }\ncontexts:\n- name: ctx-c\n  context: { cluster: c, user: user-c }\n").unwrap();
+        std::fs::remove_file(&seeded).unwrap();
+
+        // Invoked with NO paths key at all.
+        let out = reg.invoke("k8s.listContexts", json!({})).await.unwrap();
+        let names: Vec<String> = out["contexts"].as_array().unwrap().iter()
+            .map(|c| c["name"].as_str().unwrap().to_string()).collect();
+        assert!(names.iter().any(|n| n == "ctx-c"), "new file not discovered: {names:?}");
+        assert!(!names.iter().any(|n| n == "ctx-b"), "deleted file lingered: {names:?}");
+
+        let active = cache.paths().await;
+        assert!(!active.contains(&seeded), "deleted path still active: {active:?}");
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/kube/src/contexts.rs
+++ b/crates/kube/src/contexts.rs
@@ -49,7 +49,17 @@ pub struct ListContextsOut {
 
 /// Build the capability over the shared cache. Supplying `paths` replaces the
 /// additional kubeconfig files and invalidates authenticated clients.
-pub fn list_contexts_capability(cache: Arc<ClientCache>, default_paths: Vec<PathBuf>) -> Capability {
+/// `managed_dir` is the app's own kubeconfig folder, or `None` to disable that
+/// discovery. It is passed in rather than looked up globally so the capability
+/// stays hermetic — a global lookup makes every test depend on whatever is in
+/// the developer's real config directory. The DIRECTORY is fixed but its
+/// CONTENTS are read on each call, which is what lets a config pasted or
+/// dropped in while the app runs resolve without a restart (#256).
+pub fn list_contexts_capability(
+    cache: Arc<ClientCache>,
+    default_paths: Vec<PathBuf>,
+    managed_dir: Option<PathBuf>,
+) -> Capability {
     Capability::typed::<ListContextsIn, ListContextsOut, _, _>(
         "k8s.listContexts",
         "list the kube contexts available in the kubeconfig",
@@ -57,12 +67,24 @@ pub fn list_contexts_capability(cache: Arc<ClientCache>, default_paths: Vec<Path
         move |input: ListContextsIn| {
             let cache = cache.clone();
             let default_paths = default_paths.clone();
+            let managed_dir = managed_dir.clone();
             async move {
                 if let Some(additional) = input.paths {
                     let mut paths = default_paths;
                     for path in additional.into_iter().map(PathBuf::from) {
                         if !paths.contains(&path) {
                             paths.push(path);
+                        }
+                    }
+                    // Read HERE, not captured at registry-build time: the
+                    // folder's contents change while the app runs, and a
+                    // startup snapshot would miss anything pasted or dropped
+                    // in afterwards (#256).
+                    if let Some(dir) = &managed_dir {
+                        for managed in crate::connect::kubeconfig_files_in(dir) {
+                            if !paths.contains(&managed) {
+                                paths.push(managed);
+                            }
                         }
                     }
                     cache.set_paths(paths).await;
@@ -292,7 +314,7 @@ mod tests {
     #[test]
     fn capability_has_expected_id_and_annotations() {
         let path = PathBuf::from("/nonexistent");
-        let cap = list_contexts_capability(ClientCache::new(path.clone()), vec![path]);
+        let cap = list_contexts_capability(ClientCache::new(path.clone()), vec![path], None);
         assert_eq!(cap.id, "k8s.listContexts");
         assert!(cap.annotations.read_only);
     }
@@ -309,7 +331,7 @@ mod tests {
         .unwrap();
 
         let mut reg = Registry::new();
-        reg.register(list_contexts_capability(ClientCache::new(path.clone()), vec![path.clone()]));
+        reg.register(list_contexts_capability(ClientCache::new(path.clone()), vec![path.clone()], None));
         let out = reg.invoke("k8s.listContexts", json!({})).await.unwrap();
 
         assert_eq!(out["contexts"][0]["name"], "ctx-a");
@@ -321,7 +343,7 @@ mod tests {
     async fn missing_file_is_a_handler_error() {
         let mut reg = Registry::new();
         let path = PathBuf::from("/no/such/kubeconfig");
-        reg.register(list_contexts_capability(ClientCache::new(path.clone()), vec![path]));
+        reg.register(list_contexts_capability(ClientCache::new(path.clone()), vec![path], None));
         let err = reg.invoke("k8s.listContexts", json!({})).await.unwrap_err();
         assert!(matches!(err, CapabilityError::Handler(_)));
     }
@@ -354,7 +376,7 @@ users:
         .unwrap();
 
         let mut reg = Registry::new();
-        reg.register(list_contexts_capability(ClientCache::new(path.clone()), vec![path.clone()]));
+        reg.register(list_contexts_capability(ClientCache::new(path.clone()), vec![path.clone()], None));
         let out = reg.invoke("k8s.listContexts", json!({})).await.unwrap();
         let contexts = out["contexts"].as_array().unwrap();
 
@@ -403,7 +425,7 @@ users:
         .unwrap();
 
         let mut reg = Registry::new();
-        reg.register(list_contexts_capability(ClientCache::new(path.clone()), vec![path.clone()]));
+        reg.register(list_contexts_capability(ClientCache::new(path.clone()), vec![path.clone()], None));
         let out = reg.invoke("k8s.listContexts", json!({})).await.unwrap();
         let contexts = out["contexts"].as_array().unwrap();
 
@@ -417,6 +439,55 @@ users:
         assert!(eks["provider"].is_null());
 
         let _ = tokio::fs::remove_file(&path).await;
+    }
+
+    #[tokio::test]
+    async fn a_kubeconfig_dropped_into_the_managed_folder_resolves_without_a_restart() {
+        // The #256 case: the capability is built once at startup, and the file
+        // appears afterwards. Reading the folder per call — rather than
+        // capturing its contents — is what makes it visible.
+        let dir = std::env::temp_dir().join(format!("srelens-managed-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let base = dir.join("base.yaml");
+        tokio::fs::write(
+            &base,
+            "clusters:\n- name: a\n  cluster: { server: https://a }\ncontexts:\n- name: ctx-a\n  context: { cluster: a, user: user-a }\n",
+        ).await.unwrap();
+
+        let managed = dir.join("managed");
+        std::fs::create_dir_all(&managed).unwrap();
+
+        let cache = ClientCache::new(base.clone());
+        let mut reg = Registry::new();
+        reg.register(list_contexts_capability(
+            cache,
+            vec![base.clone()],
+            Some(managed.clone()),
+        ));
+
+        // Registered while the folder is empty.
+        let before = reg.invoke("k8s.listContexts", json!({ "paths": [] })).await.unwrap();
+        assert_eq!(before["contexts"].as_array().unwrap().len(), 1);
+
+        // Now a config is pasted in, long after the capability was built.
+        tokio::fs::write(
+            managed.join("pasted.yaml"),
+            "clusters:\n- name: b\n  cluster: { server: https://b }\ncontexts:\n- name: ctx-b\n  context: { cluster: b, user: user-b }\n",
+        ).await.unwrap();
+
+        let after = reg.invoke("k8s.listContexts", json!({ "paths": [] })).await.unwrap();
+        let names: Vec<String> = after["contexts"].as_array().unwrap().iter()
+            .map(|c| c["name"].as_str().unwrap().to_string()).collect();
+        assert!(names.iter().any(|n| n == "ctx-b"), "pasted context missing: {names:?}");
+
+        // …and removing it takes the context away again, no restart either.
+        std::fs::remove_file(managed.join("pasted.yaml")).unwrap();
+        let removed = reg.invoke("k8s.listContexts", json!({ "paths": [] })).await.unwrap();
+        let names: Vec<String> = removed["contexts"].as_array().unwrap().iter()
+            .map(|c| c["name"].as_str().unwrap().to_string()).collect();
+        assert!(!names.iter().any(|n| n == "ctx-b"), "deleted context lingered: {names:?}");
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
@@ -435,7 +506,7 @@ users:
 
         let cache = ClientCache::new(first.clone());
         let mut reg = Registry::new();
-        reg.register(list_contexts_capability(cache, vec![first.clone()]));
+        reg.register(list_contexts_capability(cache, vec![first.clone()], None));
         let out = reg.invoke(
             "k8s.listContexts",
             json!({ "paths": [second.to_string_lossy()] }),
@@ -469,7 +540,7 @@ users:
         let cache = ClientCache::new(path.clone());
         let mut reg = Registry::new();
         reg.register(delete_context_capability(cache.clone()));
-        reg.register(list_contexts_capability(cache.clone(), vec![path.clone()]));
+        reg.register(list_contexts_capability(cache.clone(), vec![path.clone()], None));
 
         // Delete the context
         let out = reg.invoke("k8s.deleteContext", json!({ "context": "ctx-a" })).await.unwrap();

--- a/crates/kube/src/contexts.rs
+++ b/crates/kube/src/contexts.rs
@@ -87,6 +87,15 @@ pub fn list_contexts_capability(
                             }
                         }
                     }
+                    // `default_paths` is a snapshot taken when the registry was
+                    // built, so a kubeconfig deleted while the app runs would
+                    // otherwise be reintroduced on every call and sit in the
+                    // cache forever — where `load_kubeconfigs` is strict and
+                    // fails the merged-resolution fallback on the missing file.
+                    // Only ABSENT files are dropped: one that exists but is
+                    // malformed still reaches the reader and surfaces its parse
+                    // error, which the caller needs to see.
+                    paths.retain(|path| path.exists());
                     cache.set_paths(paths).await;
                 }
                 // Enumerate every context across all files with duplicate-name
@@ -487,6 +496,43 @@ users:
             .map(|c| c["name"].as_str().unwrap().to_string()).collect();
         assert!(!names.iter().any(|n| n == "ctx-b"), "deleted context lingered: {names:?}");
 
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn a_managed_file_deleted_at_runtime_leaves_the_active_path_set() {
+        let dir = std::env::temp_dir().join(format!("srelens-repro-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let base = dir.join("base.yaml");
+        std::fs::write(&base, "clusters:\n- name: a\n  cluster: { server: https://a }\ncontexts:\n- name: ctx-a\n  context: { cluster: a, user: user-a }\n").unwrap();
+        let managed = dir.join("managed");
+        std::fs::create_dir_all(&managed).unwrap();
+        let pasted = managed.join("pasted.yaml");
+        std::fs::write(&pasted, "clusters:\n- name: b\n  cluster: { server: https://b }\ncontexts:\n- name: ctx-b\n  context: { cluster: b, user: user-b }\n").unwrap();
+
+        // Startup: default_kubeconfig_paths() included the managed file.
+        let startup_paths = vec![base.clone(), pasted.clone()];
+        let cache = ClientCache::new(base.clone());
+        let mut reg = Registry::new();
+        reg.register(list_contexts_capability(cache.clone(), startup_paths, Some(managed.clone())));
+
+        // The user deletes it while the app runs.
+        std::fs::remove_file(&pasted).unwrap();
+
+        let out = reg.invoke("k8s.listContexts", json!({ "paths": [] })).await.unwrap();
+        let names: Vec<String> = out["contexts"].as_array().unwrap().iter()
+            .map(|c| c["name"].as_str().unwrap().to_string()).collect();
+        assert_eq!(names, ["ctx-a"], "the deleted context must be gone");
+
+        // The important half: default_paths is a startup SNAPSHOT that still
+        // holds the deleted file, so without pruning it would be reintroduced
+        // on every call and linger in the cache — where the strict merged
+        // fallback in load_kubeconfigs fails on the missing file.
+        let active = cache.paths().await;
+        assert!(
+            !active.contains(&pasted),
+            "deleted kubeconfig still active: {active:?}"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/registry/src/lib.rs
+++ b/crates/registry/src/lib.rs
@@ -31,18 +31,28 @@ pub fn capability_catalog() -> Vec<CatalogEntry> {
     catalog_of(&build_registry())
 }
 
-/// Resolve kubeconfig paths: every `$KUBECONFIG` entry, else `$HOME/.kube/config`.
+pub use srelens_kube::connect::{default_kubeconfig_dir, managed_kubeconfig_files};
+
+/// Resolve kubeconfig paths: every `$KUBECONFIG` entry, else `$HOME/.kube/config`,
+/// plus anything in the app's own kubeconfig folder.
 pub fn default_kubeconfig_paths() -> Vec<PathBuf> {
-    if let Some(value) = std::env::var_os("KUBECONFIG") {
-        let paths = std::env::split_paths(&value)
+    let mut paths = if let Some(value) = std::env::var_os("KUBECONFIG") {
+        std::env::split_paths(&value)
             .filter(|path| !path.as_os_str().is_empty())
-            .collect::<Vec<_>>();
-        if !paths.is_empty() {
-            return paths;
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+    if paths.is_empty() {
+        let home = std::env::var("HOME").unwrap_or_default();
+        paths.push(PathBuf::from(home).join(".kube").join("config"));
+    }
+    for managed in srelens_kube::connect::managed_kubeconfig_files() {
+        if !paths.contains(&managed) {
+            paths.push(managed);
         }
     }
-    let home = std::env::var("HOME").unwrap_or_default();
-    vec![PathBuf::from(home).join(".kube").join("config")]
+    paths
 }
 
 #[cfg(test)]
@@ -172,6 +182,7 @@ pub fn build_registry_with_paths_and_settings(
     reg.register(srelens_kube::contexts::list_contexts_capability(
         cache.clone(),
         kubeconfig_paths.clone(),
+        srelens_kube::connect::default_kubeconfig_dir(),
     ));
     reg.register(srelens_kube::contexts::delete_context_capability(
         cache.clone(),

--- a/crates/registry/src/lib.rs
+++ b/crates/registry/src/lib.rs
@@ -33,20 +33,37 @@ pub fn capability_catalog() -> Vec<CatalogEntry> {
 
 pub use srelens_kube::connect::{default_kubeconfig_dir, managed_kubeconfig_files};
 
-/// Resolve kubeconfig paths: every `$KUBECONFIG` entry, else `$HOME/.kube/config`,
-/// plus anything in the app's own kubeconfig folder.
+/// The STATIC kubeconfig sources: every `$KUBECONFIG` entry, else
+/// `$HOME/.kube/config`.
+///
+/// Deliberately excludes the app's managed folder. That folder's contents
+/// change while the app runs, and this result gets captured by long-lived
+/// consumers — the capability registry snapshots it once at build time — so
+/// folding volatile content in here means a file deleted at runtime is
+/// reintroduced on every later call and never goes away. Callers that want the
+/// managed folder as well should use [`all_kubeconfig_paths`], which resolves
+/// it at call time.
 pub fn default_kubeconfig_paths() -> Vec<PathBuf> {
-    let mut paths = if let Some(value) = std::env::var_os("KUBECONFIG") {
-        std::env::split_paths(&value)
+    if let Some(value) = std::env::var_os("KUBECONFIG") {
+        let paths = std::env::split_paths(&value)
             .filter(|path| !path.as_os_str().is_empty())
-            .collect::<Vec<_>>()
-    } else {
-        Vec::new()
-    };
-    if paths.is_empty() {
-        let home = std::env::var("HOME").unwrap_or_default();
-        paths.push(PathBuf::from(home).join(".kube").join("config"));
+            .collect::<Vec<_>>();
+        if !paths.is_empty() {
+            return paths;
+        }
     }
+    let home = std::env::var("HOME").unwrap_or_default();
+    vec![PathBuf::from(home).join(".kube").join("config")]
+}
+
+/// Every kubeconfig source as of RIGHT NOW: the static ones plus whatever is
+/// currently in the app's managed folder.
+///
+/// For callers that resolve paths per operation (a terminal, a helm command,
+/// the initial client cache). Anything that captures its result for later
+/// reuse wants [`default_kubeconfig_paths`] plus a live folder read instead.
+pub fn all_kubeconfig_paths() -> Vec<PathBuf> {
+    let mut paths = default_kubeconfig_paths();
     for managed in srelens_kube::connect::managed_kubeconfig_files() {
         if !paths.contains(&managed) {
             paths.push(managed);

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -68,9 +68,14 @@ look.
 **Kubeconfig sources.** Your default kubeconfig / `KUBECONFIG` is loaded first;
 additional files merge in order. Use **Add files** to pick more kubeconfig files,
 or **Paste** to paste raw YAML (with an optional name) — pasted configs are saved
-into the srelens application directory. Each added file appears as a chip you can
-remove. srelens watches these files and refreshes automatically when they change
-on disk.
+into srelens's own `kubeconfigs` folder in the application directory. Each added
+file appears as a chip you can remove.
+
+srelens watches all of these and refreshes automatically — both when a file
+changes on disk and when one is **created or deleted**. That includes its own
+`kubeconfigs` folder, so a config you drop in there by hand is picked up without
+restarting, and one you delete disappears the same way. Only the app's folder is
+scanned like this; files you add from elsewhere are tracked individually.
 
 **Context identity.** Select a context to give it a recognisable identity without
 touching your kubeconfig:


### PR DESCRIPTION
Closes #256 — reported from real use: a pasted kubeconfig doesn't appear until the app is reloaded.

## Root cause
Two gaps, both confirmed in the code:

- **`watch_kubeconfig_files` never enumerated a directory.** It polled mtimes of paths the cache already knew, so it could see a *tracked* file change but never that one had appeared or been removed.
- **The app's own `kubeconfigs` folder wasn't a source.** `default_kubeconfig_paths()` resolved only `$KUBECONFIG` or `~/.kube/config`, so the folder pasted configs are written to was reachable only through the separately persisted path list — and a file dropped in by hand was invisible entirely.

## Fix
The folder is now enumerated. The watcher unions it with the cache's paths, so **creation and deletion are both observable**, and `listContexts` reads it **on every call** rather than from a startup snapshot — the distinction that matters here, since the capability is built once at launch and the file appears afterwards.

This also makes the behaviour self-correcting: even if a frontend refresh is missed, the watcher notices within its poll interval and emits `kubeconfig-changed`.

## A design fault the tests caught
My first attempt had the capability call `managed_kubeconfig_files()` directly. That made it read the **developer's real config directory** — `merges_additional_kubeconfig_files` started failing with 10 contexts instead of 2, because it had picked up my own pasted kubeconfigs.

The directory is now injected: tests pass `None` and stay hermetic, the desktop passes the real folder. The *directory* is fixed while its *contents* are not, so injection costs nothing in freshness.

## Deliberate details
- Discovery is best-effort — an unreadable folder or entry yields nothing rather than failing a context listing.
- Dotfiles are skipped, so an editor's `.swp` or a stray `.DS_Store` isn't treated as a kubeconfig.
- Only the app's own folder is scanned; files added from elsewhere stay individually tracked, so removing one still works as before.

## Tests
Five new: a file created after startup is discovered, a deleted one stops being, dotfiles and subdirectories are ignored, discovery is sorted and survives a missing folder, and — at the capability level — a config dropped in *after registration* resolves and then disappears when removed. Workspace: 1056 passing.

## Acceptance criteria
- [x] Pasting a kubeconfig shows its contexts without a reload
- [x] A file added to the folder externally is picked up without a restart
- [x] Deleting such a file removes its contexts without a restart
- [x] Tests cover discovery of a newly created file in a watched directory