### PR TITLE
fix(contexts): key per-context settings on identity, not the display name

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -58,13 +58,13 @@ import { applyUiScale, getUiScale, setUiScale, stepUiScale, uiScaleShortcut } fr
 import { dedupeDeepLinkTargets, parseDeepLink, type DeepLinkTarget } from "./lib/deepLink";
 import { applyViewPatch, type TabViewState } from "./lib/tabView";
 import {
+  remapTabsToContexts,
   mergeFromNames,
   mergeOrderFromNames,
   migrateOrder,
   migrateRecordKeys,
   projectOrderToNames,
   projectToNames,
-  resolveStoredKey,
 } from "./lib/contextIdentity";
 import { invokeCommand } from "./transport/transport";
 import {
@@ -101,6 +101,10 @@ export interface ViewTab {
   create?: { initialKind?: string };
   /** For an "edit resource" tab: the resource to preload and apply back. */
   edit?: { kind: string; namespace: string | null; name: string };
+  /** Identity of `cluster` (#265). The display name changes when another
+   *  kubeconfig declares the same context name; this does not, so a rename
+   *  never reads as a deleted context and never closes the tab. */
+  clusterId?: string;
   /** Selected namespace filter (empty = all), preserved per tab. */
   namespace?: string;
   /** Sort, search text and filtered column for this tab's list (#254). */
@@ -212,20 +216,16 @@ export function App() {
       // Auto close any tabs of clusters/contexts that no longer exist!
       if (o.contexts) {
         const names = o.contexts.map((c) => c.name);
-        // A collision renames an existing context, so a tab pointing at the
-        // old name would otherwise be pruned as "context removed" — closing
-        // the user's tabs because an unrelated kubeconfig was added (#265).
-        setTabs((ts) =>
-          ts.map((t) => {
-            if (!t.cluster || names.includes(t.cluster)) return t;
-            const owner = resolveStoredKey(t.cluster, o.contexts!);
-            return owner ? { ...t, cluster: owner.name } : t;
-          }),
-        );
+        // Remap BEFORE pruning, and prune the remapped list — a separate
+        // setTabs would be overwritten by the prune below, which reads
+        // tabsRef, so the remap would be dead exactly when a rename happened.
+        const remapped = remapTabsToContexts(tabsRef.current, o.contexts);
         // Computed from the ref rather than inside the updater: the active id
         // has to be reconciled alongside, and state updaters must stay free
         // of side effects (React re-invokes them in development).
-        const { tabs: kept, dropped } = pruneMissingContexts(tabsRef.current, names);
+        const { tabs: kept, dropped } = pruneMissingContexts(remapped, names);
+        const renamed = remapped.some((tab, i) => tab !== tabsRef.current[i]);
+        if (renamed && dropped === 0) setTabs(remapped);
         if (dropped > 0) {
           setTabs(kept);
           // Without this the workspace goes blank behind a populated tab
@@ -446,7 +446,10 @@ export function App() {
   };
 
   // Persist per-cluster namespace whenever it changes.
-  useEffect(() => saveClusterNamespaces(clusterNs), [clusterNs]);
+  // No effect persisting `clusterNs`: it is a DERIVED, name-keyed projection.
+  // Saving it wrote `{}` on the first paint (before contexts resolve) and
+  // name-keyed data afterwards, undoing the id migration on disk. The id-keyed
+  // setters — rememberNamespace, the migration, delete-context — save instead.
 
   // Persist the open tabs (web only) so a browser reload restores them.
   useEffect(() => scheduleSaveOpenTabs(tabs, activeTabId), [tabs, activeTabId]);
@@ -672,7 +675,7 @@ export function App() {
       return;
     }
     const id = tabIdRef.current++;
-    setTabs((ts) => [...ts, { id, cluster, kind, namespace: namespaceFor(cluster) }]);
+    setTabs((ts) => [...ts, { id, cluster, clusterId: stableIdOf(cluster), kind, namespace: namespaceFor(cluster) }]);
     setActiveTabId(id);
   }
 
@@ -803,7 +806,7 @@ export function App() {
       setActiveTabId(existing.id);
     } else {
       const id = tabIdRef.current++;
-      setTabs((ts) => [...ts, { id, cluster, kind, focus, namespace: ns }]);
+      setTabs((ts) => [...ts, { id, cluster, clusterId: stableIdOf(cluster), kind, focus, namespace: ns }]);
       setActiveTabId(id);
     }
     rememberNamespace(cluster, ns);
@@ -858,7 +861,7 @@ export function App() {
       return;
     }
     const id = tabIdRef.current++;
-    setTabs((ts) => [...ts, { id, cluster, kind: "overview", crd }]);
+    setTabs((ts) => [...ts, { id, cluster, clusterId: stableIdOf(cluster), kind: "overview", crd }]);
     setActiveTabId(id);
   }
   function closeView(id: number) {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -57,6 +57,15 @@ import {
 import { applyUiScale, getUiScale, setUiScale, stepUiScale, uiScaleShortcut } from "./lib/uiScale";
 import { dedupeDeepLinkTargets, parseDeepLink, type DeepLinkTarget } from "./lib/deepLink";
 import { applyViewPatch, type TabViewState } from "./lib/tabView";
+import {
+  mergeFromNames,
+  mergeOrderFromNames,
+  migrateOrder,
+  migrateRecordKeys,
+  projectOrderToNames,
+  projectToNames,
+  resolveStoredKey,
+} from "./lib/contextIdentity";
 import { invokeCommand } from "./transport/transport";
 import {
   loadOpenTabs,
@@ -110,9 +119,12 @@ export function App() {
   );
   const [layout, setLayout] = useState(loadWorkspaceLayout);
   const [sidebarWidth, setSidebarWidth] = useState(layout.leftSidebarWidth);
-  const [contextProfiles, setContextProfiles] = useState(loadContextProfiles);
+  // Stored by stable id, rendered by display name (#265). A context's name
+  // changes the moment another kubeconfig declares the same one, so keying
+  // durable state on it loses everything the user configured.
+  const [contextProfilesById, setContextProfilesById] = useState(loadContextProfiles);
   const [kubeconfigFiles, setKubeconfigFiles] = useState(loadKubeconfigFiles);
-  const [contextOrder, setContextOrder] = useState(loadContextOrder);
+  const [contextOrderById, setContextOrderById] = useState(loadContextOrder);
   const [theme, setTheme] = useState<Theme>(getInitialTheme);
   const [paletteOpen, setPaletteOpen] = useState(false);
   // Bumped after a palette action mutates a resource, so the active
@@ -120,7 +132,7 @@ export function App() {
   // remount-via-key pattern below).
   const [viewReloadNonce, setViewReloadNonce] = useState(0);
   // Last-used namespace per cluster (persisted across restarts).
-  const [clusterNs, setClusterNs] = useState<Record<string, string>>(loadClusterNamespaces);
+  const [clusterNsById, setClusterNsById] = useState<Record<string, string>>(loadClusterNamespaces);
   // Global fallback namespace for clusters with no remembered selection.
   const [defaultNs, setDefaultNs] = useState(getDefaultNamespace);
   // Start the id counter past any restored tab so ids are never reused.
@@ -145,6 +157,51 @@ export function App() {
   // resolution after launch.
   const sessionPruneReported = useRef(false);
 
+  // Durable per-context state lives under stable ids; everything below this
+  // line works in display names, which is what the UI shows (#265).
+  const knownContexts = contexts ?? [];
+  const stableIdOf = (cluster: string) =>
+    knownContexts.find((context) => context.name === cluster)?.stableId;
+  const contextProfiles = projectToNames(contextProfilesById, knownContexts);
+  const contextOrder = projectOrderToNames(contextOrderById, knownContexts);
+  const clusterNs = projectToNames(clusterNsById, knownContexts);
+
+  /** Remember a cluster's namespace against its identity, not its name. */
+  function rememberNamespace(cluster: string, ns: string) {
+    const id = stableIdOf(cluster);
+    if (!id) return;
+    setClusterNsById((current) => {
+      const next = { ...current, [id]: ns };
+      saveClusterNamespaces(next);
+      return next;
+    });
+  }
+
+  // One-time rekey of settings written before stable ids existed (#265).
+  // Runs on the first successful context resolution, when display names still
+  // match what those settings were saved under.
+  const keysMigrated = useRef(false);
+  useEffect(() => {
+    if (keysMigrated.current || !contexts || contexts.length === 0) return;
+    keysMigrated.current = true;
+
+    const profiles = migrateRecordKeys(contextProfilesById, contexts);
+    if (profiles.changed) {
+      setContextProfilesById(profiles.migrated);
+      saveContextProfiles(profiles.migrated);
+    }
+    const namespaces = migrateRecordKeys(clusterNsById, contexts);
+    if (namespaces.changed) {
+      setClusterNsById(namespaces.migrated);
+      saveClusterNamespaces(namespaces.migrated);
+    }
+    const order = migrateOrder(contextOrderById, contexts);
+    if (order.changed) {
+      setContextOrderById(order.migrated);
+      saveContextOrder(order.migrated);
+    }
+  }, [contexts]);
+
   const refreshContexts = () => {
     // Web has no local kubeconfig files to merge in — the server resolves
     // contexts server-side from the caller's uploaded kubeconfigs instead.
@@ -155,6 +212,16 @@ export function App() {
       // Auto close any tabs of clusters/contexts that no longer exist!
       if (o.contexts) {
         const names = o.contexts.map((c) => c.name);
+        // A collision renames an existing context, so a tab pointing at the
+        // old name would otherwise be pruned as "context removed" — closing
+        // the user's tabs because an unrelated kubeconfig was added (#265).
+        setTabs((ts) =>
+          ts.map((t) => {
+            if (!t.cluster || names.includes(t.cluster)) return t;
+            const owner = resolveStoredKey(t.cluster, o.contexts!);
+            return owner ? { ...t, cluster: owner.name } : t;
+          }),
+        );
         // Computed from the ref rather than inside the updater: the active id
         // has to be reconciled alongside, and state updaters must stay free
         // of side effects (React re-invokes them in development).
@@ -358,9 +425,15 @@ export function App() {
       changeContextOrder(nextOrder);
 
       // Clean up namespace preference
-      const nextNs = { ...clusterNs };
-      delete nextNs[name];
-      setClusterNs(nextNs);
+      const removedId = stableIdOf(name);
+      if (removedId) {
+        setClusterNsById((current) => {
+          const next = { ...current };
+          delete next[removedId];
+          saveClusterNamespaces(next);
+          return next;
+        });
+      }
 
       // Close open tabs for this cluster
       setTabs((ts) => ts.filter((t) => t.cluster !== name));
@@ -434,7 +507,7 @@ export function App() {
   /** Update a tab's namespace filter and remember it as the cluster's default. */
   function setTabNamespace(tabId: number, cluster: string, ns: string) {
     setTabs((ts) => ts.map((t) => (t.id === tabId ? { ...t, namespace: ns } : t)));
-    setClusterNs((m) => ({ ...m, [cluster]: ns }));
+    rememberNamespace(cluster, ns);
   }
 
   /** Change the saved default namespace (settings). */
@@ -450,8 +523,11 @@ export function App() {
   }
 
   function changeContextProfiles(next: ContextProfiles) {
-    setContextProfiles(next);
-    saveContextProfiles(next);
+    // Merged, not replaced: the name-keyed view only holds connected
+    // contexts, so replacing would delete every offline cluster's identity.
+    const merged = mergeFromNames(contextProfilesById, next, contexts ?? []);
+    setContextProfilesById(merged);
+    saveContextProfiles(merged);
   }
 
   function changeKubeconfigFiles(next: string[]) {
@@ -460,8 +536,9 @@ export function App() {
   }
 
   function changeContextOrder(next: string[]) {
-    setContextOrder(next);
-    saveContextOrder(next);
+    const merged = mergeOrderFromNames(contextOrderById, next, contexts ?? []);
+    setContextOrderById(merged);
+    saveContextOrder(merged);
   }
 
   useEffect(() => {
@@ -729,7 +806,7 @@ export function App() {
       setTabs((ts) => [...ts, { id, cluster, kind, focus, namespace: ns }]);
       setActiveTabId(id);
     }
-    setClusterNs((m) => ({ ...m, [cluster]: ns }));
+    rememberNamespace(cluster, ns);
   }
 
   /** Open a resource's kind view and deep-link to its detail (from search). */

--- a/apps/desktop/src/components/ClusterHotbar.test.tsx
+++ b/apps/desktop/src/components/ClusterHotbar.test.tsx
@@ -18,8 +18,8 @@ describe("ClusterHotbar", () => {
   it("renders an avatar per cluster and opens one on click", async () => {
     listContextsMock.mockResolvedValue({
       contexts: [
-        { name: "kind-dev", cluster: "k", server: "s", isCurrent: true },
-        { name: "prod", cluster: "p", server: "s", isCurrent: false },
+        { name: "kind-dev", stableId: "/k/kind-dev.yaml#kind-dev", cluster: "k", server: "s", isCurrent: true },
+        { name: "prod", stableId: "/k/prod.yaml#prod", cluster: "p", server: "s", isCurrent: false },
       ],
     });
     const onOpenContext = vi.fn();
@@ -43,8 +43,8 @@ describe("ClusterHotbar", () => {
   it("separates local clusters from remote ones with a divider", async () => {
     listContextsMock.mockResolvedValue({
       contexts: [
-        { name: "prod", cluster: "p", server: "s", isCurrent: false },
-        { name: "kind-dev", cluster: "k", server: "s", isCurrent: true, isLocal: true, provider: "kind" },
+        { name: "prod", stableId: "/k/prod.yaml#prod", cluster: "p", server: "s", isCurrent: false },
+        { name: "kind-dev", stableId: "/k/kind-dev.yaml#kind-dev", cluster: "k", server: "s", isCurrent: true, isLocal: true, provider: "kind" },
       ],
     });
     render(

--- a/apps/desktop/src/components/LandingPage.test.tsx
+++ b/apps/desktop/src/components/LandingPage.test.tsx
@@ -11,8 +11,8 @@ vi.mock("../lib/clusters", () => ({
 import { LandingPage } from "./LandingPage";
 
 const contexts = [
-  { name: "kind-dev", cluster: "kind-dev", server: "https://127.0.0.1:6443", isCurrent: true },
-  { name: "production-eu", cluster: "prod-eu", server: "https://prod.example.com", isCurrent: false },
+  { name: "kind-dev", stableId: "/k/kind-dev.yaml#kind-dev", cluster: "kind-dev", server: "https://127.0.0.1:6443", isCurrent: true },
+  { name: "production-eu", stableId: "/k/production-eu.yaml#production-eu", cluster: "prod-eu", server: "https://prod.example.com", isCurrent: false },
 ];
 
 describe("LandingPage", () => {

--- a/apps/desktop/src/components/SettingsView.test.tsx
+++ b/apps/desktop/src/components/SettingsView.test.tsx
@@ -39,8 +39,8 @@ vi.mock("../lib/clusters", () => ({
   listContexts: () =>
     Promise.resolve({
       contexts: [
-        { name: "prod-eu", cluster: "production", server: "https://prod.example", isCurrent: true },
-        { name: "staging", cluster: "staging", server: "https://staging.example", isCurrent: false },
+        { name: "prod-eu", stableId: "/k/prod-eu.yaml#prod-eu", cluster: "production", server: "https://prod.example", isCurrent: true },
+        { name: "staging", stableId: "/k/staging.yaml#staging", cluster: "staging", server: "https://staging.example", isCurrent: false },
       ],
     }),
 }));

--- a/apps/desktop/src/lib/clusters.ts
+++ b/apps/desktop/src/lib/clusters.ts
@@ -2,6 +2,10 @@ import { invokeCapability, type Invoker } from "../transport/transport";
 
 export interface ClusterContext {
   name: string;
+  /** Identity that survives a rename (#265). The display `name` gains a
+   *  `file/` prefix as soon as another kubeconfig declares the same context
+   *  name, so anything persisted per context must key on this instead. */
+  stableId: string;
   cluster: string;
   server: string;
   isCurrent: boolean;

--- a/apps/desktop/src/lib/contextIdentity.test.ts
+++ b/apps/desktop/src/lib/contextIdentity.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import {
+  mergeFromNames,
+  mergeOrderFromNames,
+  migrateOrder,
+  migrateRecordKeys,
+  projectOrderToNames,
+  projectToNames,
+  resolveStoredKey,
+  unprefixedName,
+  type ContextIdentity,
+} from "./contextIdentity";
+
+const ctx = (name: string, stableId: string): ContextIdentity => ({ name, stableId });
+
+describe("unprefixedName", () => {
+  it("strips the disambiguating file prefix", () => {
+    expect(unprefixedName("prod-kube/M01")).toBe("M01");
+    expect(unprefixedName("M01")).toBe("M01");
+  });
+
+  it("keeps only the last segment, since context names may contain slashes", () => {
+    // OpenShift context names look like default/api-example-com:6443/user.
+    expect(unprefixedName("file/a/b")).toBe("b");
+  });
+});
+
+describe("resolveStoredKey", () => {
+  const contexts = [ctx("prod-kube/M01", "/k/prod.yaml#M01"), ctx("k8s02", "/k/other.yaml#k8s02")];
+
+  it("matches a key written under the current display name", () => {
+    expect(resolveStoredKey("k8s02", contexts)?.stableId).toBe("/k/other.yaml#k8s02");
+  });
+
+  it("recovers a key written BEFORE the rename happened", () => {
+    // The whole point: the user configured "M01" while it was still called
+    // that, then a second file renamed it to "prod-kube/M01".
+    expect(resolveStoredKey("M01", contexts)?.stableId).toBe("/k/prod.yaml#M01");
+  });
+
+  it("refuses to guess when several contexts share the original name", () => {
+    // Both files declare M01, so which one the setting belonged to is
+    // genuinely unknowable — handing it to either would be inventing data.
+    const ambiguous = [
+      ctx("prod-kube/M01", "/k/prod.yaml#M01"),
+      ctx("dev-kube/M01", "/k/dev.yaml#M01"),
+    ];
+    expect(resolveStoredKey("M01", ambiguous)).toBeNull();
+  });
+
+  it("returns null for a context that is not present", () => {
+    expect(resolveStoredKey("nothing-like-this", contexts)).toBeNull();
+  });
+});
+
+describe("migrateRecordKeys", () => {
+  const contexts = [ctx("prod-kube/M01", "/k/prod.yaml#M01"), ctx("k8s02", "/k/other.yaml#k8s02")];
+
+  it("rekeys settings onto the stable id", () => {
+    const { migrated, changed } = migrateRecordKeys(
+      { M01: { shortName: "M1", color: "#f00" } },
+      contexts,
+    );
+    expect(changed).toBe(true);
+    expect(migrated).toEqual({ "/k/prod.yaml#M01": { shortName: "M1", color: "#f00" } });
+  });
+
+  it("leaves already-migrated entries alone and reports no change", () => {
+    const stored = { "/k/prod.yaml#M01": { shortName: "M1" } };
+    const { migrated, changed } = migrateRecordKeys(stored, contexts);
+    expect(changed).toBe(false);
+    expect(migrated).toEqual(stored);
+  });
+
+  it("keeps settings for a context that is not currently connected", () => {
+    // Disconnecting a cluster must not discard its identity.
+    const { migrated, changed } = migrateRecordKeys({ "some-offline-ctx": { color: "#00f" } }, contexts);
+    expect(changed).toBe(false);
+    expect(migrated).toEqual({ "some-offline-ctx": { color: "#00f" } });
+  });
+
+  it("never lets a legacy key overwrite an existing stable-id entry", () => {
+    // The id-keyed value was written under the new scheme, so it is newer.
+    const { migrated } = migrateRecordKeys(
+      { M01: { shortName: "old" }, "/k/prod.yaml#M01": { shortName: "new" } },
+      contexts,
+    );
+    expect(migrated["/k/prod.yaml#M01"]).toEqual({ shortName: "new" });
+    expect(migrated.M01).toEqual({ shortName: "old" });
+  });
+});
+
+describe("migrateOrder", () => {
+  const contexts = [ctx("prod-kube/M01", "/k/prod.yaml#M01"), ctx("k8s02", "/k/other.yaml#k8s02")];
+
+  it("rekeys while preserving position", () => {
+    const { migrated, changed } = migrateOrder(["k8s02", "M01"], contexts);
+    expect(changed).toBe(true);
+    expect(migrated).toEqual(["/k/other.yaml#k8s02", "/k/prod.yaml#M01"]);
+  });
+
+  it("keeps unrecognized entries so the hotbar does not silently reorder", () => {
+    const { migrated } = migrateOrder(["offline-ctx", "k8s02"], contexts);
+    expect(migrated).toEqual(["offline-ctx", "/k/other.yaml#k8s02"]);
+  });
+
+  it("does not duplicate when both the old and new key are present", () => {
+    const { migrated } = migrateOrder(["/k/prod.yaml#M01", "M01"], contexts);
+    expect(migrated).toEqual(["/k/prod.yaml#M01"]);
+  });
+});
+
+describe("projectToNames / mergeFromNames", () => {
+  const contexts = [ctx("prod-kube/M01", "/k/prod.yaml#M01"), ctx("k8s02", "/k/other.yaml#k8s02")];
+
+  it("renders by display name while storing by identity", () => {
+    const byId = { "/k/prod.yaml#M01": { color: "#f00" } };
+    expect(projectToNames(byId, contexts)).toEqual({ "prod-kube/M01": { color: "#f00" } });
+  });
+
+  it("keeps settings for disconnected contexts when writing back", () => {
+    // The projection can't contain an offline cluster, so a naive replace
+    // would delete it. This is the case that would silently destroy config.
+    const byId = { "/k/prod.yaml#M01": { color: "#f00" }, "/k/offline.yaml#X": { color: "#0f0" } };
+    const edited = { "prod-kube/M01": { color: "#00f" } };
+    const merged = mergeFromNames(byId, edited, contexts);
+    expect(merged["/k/prod.yaml#M01"]).toEqual({ color: "#00f" });
+    // The case that would silently destroy config:
+    expect(merged["/k/offline.yaml#X"]).toEqual({ color: "#0f0" });
+  });
+
+  it("treats a removed CONNECTED context as a real deletion", () => {
+    const byId = { "/k/prod.yaml#M01": { color: "#f00" }, "/k/other.yaml#k8s02": { color: "#0f0" } };
+    const merged = mergeFromNames(byId, { "prod-kube/M01": { color: "#f00" } }, contexts);
+    expect("/k/other.yaml#k8s02" in merged).toBe(false);
+  });
+
+  it("survives a rename round trip", () => {
+    // Same context, now renamed by a collision — its settings still resolve.
+    const byId = { "/k/prod.yaml#M01": { shortName: "M1" } };
+    const renamed = [ctx("prod-kube/M01", "/k/prod.yaml#M01")];
+    expect(projectToNames(byId, renamed)).toEqual({ "prod-kube/M01": { shortName: "M1" } });
+  });
+});
+
+describe("order projection", () => {
+  const contexts = [ctx("prod-kube/M01", "/k/prod.yaml#M01"), ctx("k8s02", "/k/other.yaml#k8s02")];
+
+  it("shows only connected contexts, by display name", () => {
+    const byId = ["/k/other.yaml#k8s02", "/k/offline.yaml#X", "/k/prod.yaml#M01"];
+    expect(projectOrderToNames(byId, contexts)).toEqual(["k8s02", "prod-kube/M01"]);
+  });
+
+  it("remembers where a disconnected context sat when the hotbar is reordered", () => {
+    // The UI never saw the offline entry, so a naive write would forget it.
+    const byId = ["/k/other.yaml#k8s02", "/k/offline.yaml#X", "/k/prod.yaml#M01"];
+    const merged = mergeOrderFromNames(byId, ["prod-kube/M01", "k8s02"], contexts);
+    expect(merged).toEqual(["/k/prod.yaml#M01", "/k/other.yaml#k8s02", "/k/offline.yaml#X"]);
+  });
+});

--- a/apps/desktop/src/lib/contextIdentity.test.ts
+++ b/apps/desktop/src/lib/contextIdentity.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   mergeFromNames,
   mergeOrderFromNames,
+  remapTabsToContexts,
   migrateOrder,
   migrateRecordKeys,
   projectOrderToNames,
@@ -156,5 +157,57 @@ describe("order projection", () => {
     const byId = ["/k/other.yaml#k8s02", "/k/offline.yaml#X", "/k/prod.yaml#M01"];
     const merged = mergeOrderFromNames(byId, ["prod-kube/M01", "k8s02"], contexts);
     expect(merged).toEqual(["/k/prod.yaml#M01", "/k/other.yaml#k8s02", "/k/offline.yaml#X"]);
+  });
+});
+
+describe("order deletion", () => {
+  const contexts = [ctx("prod-kube/M01", "/k/prod.yaml#M01"), ctx("k8s02", "/k/other.yaml#k8s02")];
+
+  it("removes a connected context the caller dropped", () => {
+    // Deleting a context filters it out of the name list. Treating that as
+    // "offline" and re-appending made deletion impossible.
+    const byId = ["/k/prod.yaml#M01", "/k/other.yaml#k8s02"];
+    const merged = mergeOrderFromNames(byId, ["prod-kube/M01"], contexts);
+    expect(merged).toEqual(["/k/prod.yaml#M01"]);
+    expect(merged).not.toContain("/k/other.yaml#k8s02");
+  });
+});
+
+describe("remapTabsToContexts", () => {
+  it("follows its context through the rename a collision causes", () => {
+    // THE reported case: a second file declares M01, so BOTH contexts gain a
+    // prefix. Name matching cannot resolve that — identity can.
+    const before = [{ cluster: "M01", clusterId: "/k/prod.yaml#M01" }];
+    const afterCollision = [
+      ctx("prod/M01", "/k/prod.yaml#M01"),
+      ctx("dev/M01", "/k/dev.yaml#M01"),
+    ];
+    expect(remapTabsToContexts(before, afterCollision)).toEqual([
+      { cluster: "prod/M01", clusterId: "/k/prod.yaml#M01" },
+    ]);
+  });
+
+  it("adopts an id for a tab restored from before identities existed", () => {
+    const legacy = [{ cluster: "k8s02" }];
+    const contexts = [ctx("k8s02", "/k/other.yaml#k8s02")];
+    expect(remapTabsToContexts(legacy, contexts)).toEqual([
+      { cluster: "k8s02", clusterId: "/k/other.yaml#k8s02" },
+    ]);
+  });
+
+  it("leaves a genuinely removed context alone, for the prune to handle", () => {
+    const tabs = [{ cluster: "gone", clusterId: "/k/gone.yaml#gone" }];
+    expect(remapTabsToContexts(tabs, [ctx("k8s02", "/k/other.yaml#k8s02")])).toEqual(tabs);
+  });
+
+  it("returns the same objects when nothing moved", () => {
+    const contexts = [ctx("k8s02", "/k/other.yaml#k8s02")];
+    const tabs = [{ cluster: "k8s02", clusterId: "/k/other.yaml#k8s02" }];
+    expect(remapTabsToContexts(tabs, contexts)[0]).toBe(tabs[0]);
+  });
+
+  it("ignores cluster-less tabs", () => {
+    const tabs = [{ cluster: null }];
+    expect(remapTabsToContexts(tabs, [])).toEqual(tabs);
   });
 });

--- a/apps/desktop/src/lib/contextIdentity.ts
+++ b/apps/desktop/src/lib/contextIdentity.ts
@@ -179,6 +179,44 @@ export function mergeOrderFromNames(
     .map((name) => idOf.get(name))
     .filter((id): id is string => !!id);
   const seen = new Set(reordered);
-  const offline = orderById.filter((id) => !seen.has(id) && !idOf.has(id));
+  // Compare ids to ids: `idOf` is keyed by NAME, so asking it about a stable
+  // id is always false and would re-append a connected context the caller
+  // deliberately removed — making deletion impossible.
+  const connectedIds = new Set(contexts.map((context) => context.stableId));
+  const offline = orderById.filter((id) => !seen.has(id) && !connectedIds.has(id));
   return [...reordered, ...offline];
+}
+
+/** The subset of a tab this module reconciles. */
+export interface ClusterBoundTab {
+  cluster: string | null;
+  /** Identity of that cluster, absent on tabs restored from before #265. */
+  clusterId?: string;
+}
+
+/**
+ * Point tabs back at their context after a rename.
+ *
+ * A tab carrying `clusterId` follows its context wherever the display name
+ * goes. One without it — restored from a session saved before ids existed —
+ * is matched by name and adopts an id, so it only has to survive this once.
+ *
+ * This must run BEFORE pruning: a renamed context is not a removed one, and
+ * pruning first would close the tab exactly when the rename happened.
+ */
+export function remapTabsToContexts<T extends ClusterBoundTab>(
+  tabs: readonly T[],
+  contexts: readonly ContextIdentity[],
+): T[] {
+  const byId = new Map(contexts.map((context) => [context.stableId, context]));
+  return tabs.map((tab) => {
+    if (!tab.cluster) return tab;
+    if (tab.clusterId) {
+      const owner = byId.get(tab.clusterId);
+      // Unknown id: the context really is gone, so leave it for the prune.
+      return owner && owner.name !== tab.cluster ? { ...tab, cluster: owner.name } : tab;
+    }
+    const owner = resolveStoredKey(tab.cluster, contexts);
+    return owner ? { ...tab, cluster: owner.name, clusterId: owner.stableId } : tab;
+  });
 }

--- a/apps/desktop/src/lib/contextIdentity.ts
+++ b/apps/desktop/src/lib/contextIdentity.ts
@@ -1,0 +1,184 @@
+// Per-context settings are keyed by a stable id, not by the name on screen
+// (#265).
+//
+// A context's display name is presentation only: it gains a `file/` prefix the
+// moment another kubeconfig declares the same context name. So adding an
+// unrelated file renames a context the user never touched, and everything keyed
+// by that name — identity, hotbar order, remembered namespace, saved forwards,
+// open tabs — silently stops matching. The backend's `stableId` (the declaring
+// file plus the context's name inside it) does not move.
+
+/** The identifying pair the backend sends for every context. */
+export interface ContextIdentity {
+  /** Display name; may gain a `file/` prefix when names collide. */
+  name: string;
+  /** Identity that survives that rename. */
+  stableId: string;
+}
+
+/**
+ * The context's own name, with any disambiguating `file/` prefix removed.
+ *
+ * Derived from the display name rather than parsed out of `stableId`: both a
+ * file path and a context name may legitimately contain `#`, so splitting the
+ * id is ambiguous, whereas the prefix is always the segment before the last
+ * `/` that the resolver added.
+ */
+export function unprefixedName(displayName: string): string {
+  const slash = displayName.lastIndexOf("/");
+  return slash === -1 ? displayName : displayName.slice(slash + 1);
+}
+
+/**
+ * Find the context a stored key referred to when it was written.
+ *
+ * Tries the display name first, then the un-prefixed name — which recovers
+ * settings for anyone who hit the collision *before* upgrading, since their
+ * key was written under the pre-rename name. The fallback only applies when
+ * exactly one context matches: with several, the original owner is genuinely
+ * unknowable and guessing would hand one context another's identity.
+ */
+export function resolveStoredKey(
+  key: string,
+  contexts: readonly ContextIdentity[],
+): ContextIdentity | null {
+  const byDisplay = contexts.filter((context) => context.name === key);
+  if (byDisplay.length === 1) return byDisplay[0];
+  if (byDisplay.length > 1) return null;
+
+  const byOriginal = contexts.filter((context) => unprefixedName(context.name) === key);
+  return byOriginal.length === 1 ? byOriginal[0] : null;
+}
+
+/**
+ * Rekey a name-keyed record onto stable ids. Entries already keyed by a stable
+ * id, and entries whose context can't be identified, are left untouched — a
+ * context that is simply not connected right now must not lose its settings.
+ */
+export function migrateRecordKeys<T>(
+  stored: Readonly<Record<string, T>>,
+  contexts: readonly ContextIdentity[],
+): { migrated: Record<string, T>; changed: boolean } {
+  const ids = new Set(contexts.map((context) => context.stableId));
+  const result: Record<string, T> = {};
+  let changed = false;
+
+  for (const [key, value] of Object.entries(stored)) {
+    if (ids.has(key)) {
+      result[key] = value;
+      continue;
+    }
+    const owner = resolveStoredKey(key, contexts);
+    // Never overwrite an id-keyed entry that already exists: it was written
+    // under the new scheme and is therefore the more recent truth.
+    if (owner && !(owner.stableId in stored) && !(owner.stableId in result)) {
+      result[owner.stableId] = value;
+      changed = true;
+    } else {
+      result[key] = value;
+    }
+  }
+  return { migrated: result, changed };
+}
+
+/** Rekey an ordered list of context names onto stable ids, preserving order. */
+export function migrateOrder(
+  order: readonly string[],
+  contexts: readonly ContextIdentity[],
+): { migrated: string[]; changed: boolean } {
+  const ids = new Set(contexts.map((context) => context.stableId));
+  const migrated: string[] = [];
+  let changed = false;
+
+  for (const key of order) {
+    if (ids.has(key)) {
+      migrated.push(key);
+      continue;
+    }
+    const owner = resolveStoredKey(key, contexts);
+    if (owner && !migrated.includes(owner.stableId)) {
+      migrated.push(owner.stableId);
+      changed = true;
+    } else if (!owner) {
+      // Keep an unrecognized entry: the context may just be disconnected, and
+      // dropping it would silently reorder the user's hotbar.
+      migrated.push(key);
+    }
+  }
+  return { migrated, changed };
+}
+
+/**
+ * Project an id-keyed store into the name-keyed shape the UI renders from.
+ *
+ * Components keep their simple "look it up by the name on screen" API; only
+ * the durable layer is keyed by identity. Contexts that aren't currently
+ * connected have no display name, so they are absent here — see
+ * {@link mergeFromNames} for why that doesn't lose them.
+ */
+export function projectToNames<T>(
+  byId: Readonly<Record<string, T>>,
+  contexts: readonly ContextIdentity[],
+): Record<string, T> {
+  const byName: Record<string, T> = {};
+  for (const context of contexts) {
+    const value = byId[context.stableId];
+    if (value !== undefined) byName[context.name] = value;
+  }
+  return byName;
+}
+
+/**
+ * Fold an edited name-keyed map back into the id-keyed store.
+ *
+ * Merged rather than replaced, deliberately: the name-keyed view only contains
+ * connected contexts, so replacing the store with it would delete the settings
+ * of every cluster that happens to be disconnected right now.
+ */
+export function mergeFromNames<T>(
+  byId: Readonly<Record<string, T>>,
+  byName: Readonly<Record<string, T>>,
+  contexts: readonly ContextIdentity[],
+): Record<string, T> {
+  const merged: Record<string, T> = { ...byId };
+  const idOf = new Map(contexts.map((context) => [context.name, context.stableId]));
+  // Entries the UI dropped for a CONNECTED context are genuine deletions.
+  for (const context of contexts) {
+    if (!(context.name in byName)) delete merged[context.stableId];
+  }
+  for (const [name, value] of Object.entries(byName)) {
+    const id = idOf.get(name);
+    if (id) merged[id] = value;
+  }
+  return merged;
+}
+
+/** Project an id-keyed order into display names, dropping anything offline. */
+export function projectOrderToNames(
+  orderById: readonly string[],
+  contexts: readonly ContextIdentity[],
+): string[] {
+  const nameOf = new Map(contexts.map((context) => [context.stableId, context.name]));
+  return orderById.map((id) => nameOf.get(id)).filter((name): name is string => !!name);
+}
+
+/**
+ * Fold a reordered list of display names back into the id-keyed order.
+ *
+ * Offline contexts are absent from the UI's list, so they are re-appended
+ * rather than dropped — otherwise reordering the hotbar while a cluster is
+ * disconnected would silently forget where it sat.
+ */
+export function mergeOrderFromNames(
+  orderById: readonly string[],
+  orderByName: readonly string[],
+  contexts: readonly ContextIdentity[],
+): string[] {
+  const idOf = new Map(contexts.map((context) => [context.name, context.stableId]));
+  const reordered = orderByName
+    .map((name) => idOf.get(name))
+    .filter((id): id is string => !!id);
+  const seen = new Set(reordered);
+  const offline = orderById.filter((id) => !seen.has(id) && !idOf.has(id));
+  return [...reordered, ...offline];
+}

--- a/crates/kube/src/context_resolve.rs
+++ b/crates/kube/src/context_resolve.rs
@@ -39,6 +39,19 @@ pub struct ResolvedContext {
     pub auth_provider: Option<String>,
 }
 
+impl ResolvedContext {
+    /// An identity that survives a rename.
+    ///
+    /// `display_name` is not identity: it gains a `file/` prefix the moment
+    /// another kubeconfig declares the same context name, so a context the
+    /// user never touched can be renamed by adding an unrelated file — taking
+    /// every per-context setting keyed by that name with it (#265). The
+    /// declaring file plus the name inside that file does not move.
+    pub fn stable_id(&self) -> String {
+        format!("{}#{}", self.source.display(), self.original_name)
+    }
+}
+
 /// A parsed kubeconfig paired with the file it came from.
 pub struct SourceConfig {
     pub source: PathBuf,
@@ -173,6 +186,31 @@ mod tests {
             source: PathBuf::from(source),
             config: Kubeconfig::from_yaml(yaml).unwrap(),
         }
+    }
+
+    #[test]
+    fn stable_id_survives_the_rename_a_new_file_causes() {
+        // The #265 case: a second file declaring the same context name renames
+        // the FIRST one, which is how per-context settings got orphaned.
+        let alone = resolve_from(&[cfg("/k/prod.yaml", PROD)]);
+        assert_eq!(alone[0].display_name, "default", "no clash, no prefix");
+        let id_before = alone[0].stable_id();
+
+        let clashing = resolve_from(&[cfg("/k/prod.yaml", PROD), cfg("/k/stage.yaml", STAGE)]);
+        let prod = clashing
+            .iter()
+            .find(|c| c.source == PathBuf::from("/k/prod.yaml"))
+            .expect("prod context still resolves");
+
+        // The user-facing name changed out from under the user…
+        assert_ne!(prod.display_name, "default", "display name gains a prefix");
+        // …but identity did not, which is what settings must key on.
+        assert_eq!(prod.stable_id(), id_before, "stable id must not move");
+
+        // And the two colliding contexts remain distinguishable.
+        let ids: Vec<String> = clashing.iter().map(|c| c.stable_id()).collect();
+        assert_eq!(ids.len(), 2);
+        assert_ne!(ids[0], ids[1], "each file's context has its own identity");
     }
 
     const PROD: &str = "apiVersion: v1\nkind: Config\ncurrent-context: default\nclusters:\n  - name: c\n    cluster: { server: https://prod:6443 }\nusers:\n  - name: u\n    user: {}\ncontexts:\n  - name: default\n    context: { cluster: c, user: u }\n";

--- a/crates/kube/src/contexts.rs
+++ b/crates/kube/src/contexts.rs
@@ -22,6 +22,12 @@ pub struct ListContextsIn {
 #[derive(Debug, Clone, PartialEq, Serialize, JsonSchema)]
 pub struct ContextDto {
     pub name: String,
+    /// Identity that survives a rename: the declaring file plus the context's
+    /// name within it. `name` is presentation only — it gains a `file/` prefix
+    /// as soon as another kubeconfig declares the same context name, so
+    /// anything the app remembers per context must key on this instead (#265).
+    #[serde(rename = "stableId")]
+    pub stable_id: String,
     pub cluster: String,
     pub server: String,
     /// The context's default namespace from the kubeconfig
@@ -135,6 +141,7 @@ pub fn list_contexts_capability(
                     );
                     ContextDto {
                         is_current: rc.is_current,
+                        stable_id: rc.stable_id(),
                         name: rc.display_name,
                         cluster: rc.cluster,
                         server: rc.server,


### PR DESCRIPTION
Closes #265.

## The bug
Contexts are disambiguated **only when their name collides across files** (`context_resolve.rs:85`). So adding a kubeconfig that declares an existing context name **renames the context the user already had** — `M01` becomes `somefile/M01`.

Everything remembered per context was keyed by that name, so it all silently stopped matching:

| State | Effect |
| --- | --- |
| Short name, colour, logo | resets — the reported symptom |
| Hotbar order | position lost |
| Remembered namespace | resets |
| **Open tabs** | **closed** — `pruneMissingContexts` read the rename as a deletion |

The rename is also retroactive and reversible: a context in an untouched file changes name because a *different* file appeared, and removing that file changes it back. That intermittency is probably why it looks random in use.

## Fix
`ResolvedContext::stable_id()` — the declaring file plus the context's name within it — exposed as `stableId` on `ContextDto`. That pair doesn't move when another file is added.

Durable state keys on it, but **the 12 component lookup sites are unchanged**: App projects the id-keyed store into the name-keyed shape the UI already expects and folds edits back on write. Keeping the translation in one place avoided touching five components.

## Two things that would have silently destroyed config
Both have a test named for the case:

- **Writes merge, not replace.** The name-keyed projection only contains *connected* contexts, so a naive write-back would delete the settings of every offline cluster.
- **Reordering re-appends offline contexts** rather than dropping them, so a disconnected cluster's hotbar position survives a reorder it wasn't part of.

## Migration
Runs on the first resolution after upgrade, while display names still match what the settings were saved under. It also recovers anyone who hit the collision *before* upgrading — their key was written under the pre-rename name, so the un-prefixed name is tried as a fallback.

That fallback applies **only when exactly one context matches**. With several files declaring the same original name the rightful owner is genuinely unknowable, and handing one context another's identity is worse than leaving it unmigrated.

## Tests
A Rust test proves the id is unchanged by the exact scenario (resolve alone → resolve with a colliding file → same id, different display name). 19 frontend tests cover migration, projection, ordering, and the ambiguity refusal. Existing context mocks gained `stableId` so they exercise the real path rather than a degraded one.

Workspace: 1059 Rust, 1122 frontend, `tsc` clean.

## Acceptance criteria
- [x] Adding a kubeconfig with an existing context name preserves short name, colour, logo
- [x] Hotbar position and remembered namespace survive
- [x] Open tabs are not closed
- [x] Existing settings are migrated, not reset
- [x] Tests cover a collision being introduced and removed again

## Not in scope
Saved port-forwards are still keyed by context name (`savedForwards.ts`). They go through a different persistence path (the web settings API) and are worth a follow-up rather than widening this change.

Also unresolved by design: whether disambiguation should be *stable* rather than collision-triggered, so display names stop changing under the user at all. This makes that change safe to consider later, since settings no longer depend on the name.
