### PR TITLE
fix(terminal): stop the pod shell reconnecting forever

### DIFF
--- a/apps/desktop/src/components/TerminalPane.tsx
+++ b/apps/desktop/src/components/TerminalPane.tsx
@@ -6,6 +6,7 @@ import {
   type ExitReason,
   type TermStatus,
   nextStatusOnExit,
+  sessionEarnedRetryReset,
   reconnectDelayMs,
 } from "../lib/terminalReconnect";
 
@@ -39,6 +40,8 @@ export function TerminalPane({ driver, banner }: { driver: TerminalDriver; banne
     let term: any = null;
     let conn: TerminalConnection | null = null;
     let attempt = 0;
+    /** When the current session went live, for judging whether it worked. */
+    let liveSince: number | null = null;
     let reconnectTimer: number | undefined;
     let cleanupExtra: (() => void) | undefined;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -49,11 +52,23 @@ export function TerminalPane({ driver, banner }: { driver: TerminalDriver; banne
     const handleExit = (reason: ExitReason) => {
       if (disposed || !term) return;
       conn = null;
+      // A session that stayed up and then dropped gets its full retry budget
+      // back; one that died on arrival keeps counting, so a shell that can
+      // never start stops retrying and shows why (#263).
+      const lived = liveSince === null ? 0 : Date.now() - liveSince;
+      liveSince = null;
+      if (sessionEarnedRetryReset(lived)) attempt = 0;
       const next = nextStatusOnExit(reason, driver.reconnectable, attempt);
       setStatus(next);
       if (next.kind === "reconnecting") {
         attempt = next.attempt;
+        // Show the cause on every attempt, not only once the budget runs out:
+        // if the shell can never start, the reason is the useful part and the
+        // user should not have to wait through the backoff to read it.
         term.write(divider(`reconnecting… (attempt ${attempt})`));
+        if (reason.kind === "error" && reason.message) {
+          term.write(`\x1b[2m${reason.message}\x1b[0m\r\n`);
+        }
         reconnectTimer = window.setTimeout(() => void connect(true), reconnectDelayMs(attempt) ?? 0);
       } else if (reason.kind === "error") {
         term.write(`${divider("disconnected")}${reason.message}\r\n`);
@@ -82,12 +97,17 @@ export function TerminalPane({ driver, banner }: { driver: TerminalDriver; banne
       }
       conn = opened;
       if (isReconnect) term.write(divider("reconnected (new shell)"));
-      attempt = 0;
+      // NOT a retry-budget reset: connecting only means the session was
+      // spawned. Whether it works is decided by how long it survives, which
+      // handleExit judges.
+      liveSince = Date.now();
       setStatus({ kind: "live" });
     };
 
     controls.current = {
       reconnect: () => {
+        // An explicit reconnect is a fresh decision by the user, so it does
+        // start the budget over.
         if (reconnectTimer) clearTimeout(reconnectTimer);
         attempt = 0;
         void connect(true);

--- a/apps/desktop/src/components/TerminalPane.tsx
+++ b/apps/desktop/src/components/TerminalPane.tsx
@@ -40,8 +40,11 @@ export function TerminalPane({ driver, banner }: { driver: TerminalDriver; banne
     let term: any = null;
     let conn: TerminalConnection | null = null;
     let attempt = 0;
-    /** When the current session went live, for judging whether it worked. */
-    let liveSince: number | null = null;
+    /**
+     * When the current session first produced output — the earliest proof a
+     * shell was really there. Null until it does (and for one that never does).
+     */
+    let usableSince: number | null = null;
     let reconnectTimer: number | undefined;
     let cleanupExtra: (() => void) | undefined;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -52,12 +55,12 @@ export function TerminalPane({ driver, banner }: { driver: TerminalDriver; banne
     const handleExit = (reason: ExitReason) => {
       if (disposed || !term) return;
       conn = null;
-      // A session that stayed up and then dropped gets its full retry budget
-      // back; one that died on arrival keeps counting, so a shell that can
-      // never start stops retrying and shows why (#263).
-      const lived = liveSince === null ? 0 : Date.now() - liveSince;
-      liveSince = null;
-      if (sessionEarnedRetryReset(lived)) attempt = 0;
+      // A shell that ran and then dropped gets its full retry budget back; one
+      // that never became usable keeps counting, so a shell that can never
+      // start stops retrying and shows why (#263).
+      const usable = usableSince === null ? 0 : Date.now() - usableSince;
+      usableSince = null;
+      if (sessionEarnedRetryReset(usable)) attempt = 0;
       const next = nextStatusOnExit(reason, driver.reconnectable, attempt);
       setStatus(next);
       if (next.kind === "reconnecting") {
@@ -81,9 +84,17 @@ export function TerminalPane({ driver, banner }: { driver: TerminalDriver; banne
       if (disposed || !term) return;
       setStatus(isReconnect ? { kind: "reconnecting", attempt: Math.max(attempt, 1) } : { kind: "connecting" });
       let opened: TerminalConnection;
+      usableSince = null;
       try {
         opened = await driver.connect({
-          onData: (chunk) => term?.write(chunk),
+          onData: (chunk) => {
+            // First byte back is when the session became a shell. The connect
+            // call resolving is not: the backend spawns the attach and reports
+            // its failure later, so timing from there would count the wait for
+            // a refusal as uptime.
+            usableSince ??= Date.now();
+            term?.write(chunk);
+          },
           onExit: handleExit,
           initialSize: { cols: term.cols, rows: term.rows },
         });
@@ -98,9 +109,8 @@ export function TerminalPane({ driver, banner }: { driver: TerminalDriver; banne
       conn = opened;
       if (isReconnect) term.write(divider("reconnected (new shell)"));
       // NOT a retry-budget reset: connecting only means the session was
-      // spawned. Whether it works is decided by how long it survives, which
-      // handleExit judges.
-      liveSince = Date.now();
+      // spawned. Whether it worked is decided by what comes back on the wire,
+      // which onData records and handleExit judges.
       setStatus({ kind: "live" });
     };
 

--- a/apps/desktop/src/lib/terminalReconnect.test.ts
+++ b/apps/desktop/src/lib/terminalReconnect.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
+  sessionEarnedRetryReset,
+  HEALTHY_SESSION_MS,
   reconnectDelayMs,
   shouldAutoReconnect,
   nextStatusOnExit,
@@ -41,5 +43,48 @@ describe("nextStatusOnExit", () => {
       kind: "disconnected",
       reason: "boom",
     });
+  });
+});
+
+describe("sessionEarnedRetryReset", () => {
+  it("does not reward a session that died on arrival", () => {
+    // The #263 loop: the backend returns a session id as soon as the task is
+    // spawned, so a shell that is refused still "connects". Resetting the
+    // budget on that meant reconnecting forever instead of reporting the
+    // error.
+    expect(sessionEarnedRetryReset(0)).toBe(false);
+    expect(sessionEarnedRetryReset(200)).toBe(false);
+    expect(sessionEarnedRetryReset(HEALTHY_SESSION_MS - 1)).toBe(false);
+  });
+
+  it("rewards a session the user actually had", () => {
+    expect(sessionEarnedRetryReset(HEALTHY_SESSION_MS)).toBe(true);
+    expect(sessionEarnedRetryReset(60_000)).toBe(true);
+  });
+
+  it("exhausts the schedule when every attempt dies immediately", () => {
+    // Walk the real policy: without a reset, attempts climb and stop.
+    let attempt = 0;
+    const statuses: string[] = [];
+    for (let i = 0; i < RECONNECT_DELAYS_MS.length + 1; i++) {
+      if (sessionEarnedRetryReset(50)) attempt = 0;
+      const next = nextStatusOnExit({ kind: "error", message: "boom" }, true, attempt);
+      statuses.push(next.kind);
+      if (next.kind === "reconnecting") attempt = next.attempt;
+    }
+    expect(statuses.filter((s) => s === "reconnecting")).toHaveLength(RECONNECT_DELAYS_MS.length);
+    expect(statuses.at(-1)).toBe("disconnected");
+  });
+
+  it("keeps retrying indefinitely if a healthy session keeps dropping", () => {
+    // The behaviour we still want: a working shell that loses its connection
+    // gets the full schedule again each time.
+    let attempt = 0;
+    for (let i = 0; i < 20; i++) {
+      if (sessionEarnedRetryReset(30_000)) attempt = 0;
+      const next = nextStatusOnExit({ kind: "error", message: "drop" }, true, attempt);
+      expect(next.kind).toBe("reconnecting");
+      if (next.kind === "reconnecting") attempt = next.attempt;
+    }
   });
 });

--- a/apps/desktop/src/lib/terminalReconnect.test.ts
+++ b/apps/desktop/src/lib/terminalReconnect.test.ts
@@ -57,17 +57,27 @@ describe("sessionEarnedRetryReset", () => {
     expect(sessionEarnedRetryReset(HEALTHY_SESSION_MS - 1)).toBe(false);
   });
 
+  it("does not reward a session that never produced output, however slowly it failed", () => {
+    // A refusal can take longer than the healthy threshold to come back — a
+    // stalled API server, a slow authorization webhook. The caller passes 0 for
+    // a session that never emitted a byte, so the wait for that failure can't
+    // masquerade as uptime and hand back the budget.
+    expect(sessionEarnedRetryReset(0)).toBe(false);
+  });
+
   it("rewards a session the user actually had", () => {
     expect(sessionEarnedRetryReset(HEALTHY_SESSION_MS)).toBe(true);
     expect(sessionEarnedRetryReset(60_000)).toBe(true);
   });
 
-  it("exhausts the schedule when every attempt dies immediately", () => {
-    // Walk the real policy: without a reset, attempts climb and stop.
+  it("exhausts the schedule when a shell can never start, even on slow failures", () => {
+    // Walk the real policy for a shell that is always refused: the pane passes
+    // 0 because nothing ever came back on the wire, however long each refusal
+    // took, so attempts climb and the terminal stops.
     let attempt = 0;
     const statuses: string[] = [];
     for (let i = 0; i < RECONNECT_DELAYS_MS.length + 1; i++) {
-      if (sessionEarnedRetryReset(50)) attempt = 0;
+      if (sessionEarnedRetryReset(0)) attempt = 0;
       const next = nextStatusOnExit({ kind: "error", message: "boom" }, true, attempt);
       statuses.push(next.kind);
       if (next.kind === "reconnecting") attempt = next.attempt;

--- a/apps/desktop/src/lib/terminalReconnect.ts
+++ b/apps/desktop/src/lib/terminalReconnect.ts
@@ -21,6 +21,28 @@ export type TermStatus =
 /** Backoff before each successive reconnect attempt; length caps the retries. */
 export const RECONNECT_DELAYS_MS = [500, 1000, 2000, 4000, 8000];
 
+/**
+ * How long a session must stay up to count as having worked.
+ *
+ * Opening an exec session and *keeping* one are different things: the backend
+ * returns a session id as soon as the task is spawned, so a shell that is
+ * refused (RBAC, a container that is not running, an image without a shell)
+ * still connects successfully and only fails a moment later. Treating that as
+ * a healthy connection reset the retry budget every cycle, so the terminal
+ * reconnected forever instead of stopping and showing the error (#263).
+ */
+export const HEALTHY_SESSION_MS = 5000;
+
+/**
+ * Whether a session that has just ended earned a fresh retry budget.
+ *
+ * A shell the user actually used and lost deserves the full backoff schedule
+ * again; one that died on arrival does not, or the schedule never runs out.
+ */
+export function sessionEarnedRetryReset(livedMs: number): boolean {
+  return livedMs >= HEALTHY_SESSION_MS;
+}
+
 /** Delay before reconnect attempt `attempt` (1-based), or null when exhausted. */
 export function reconnectDelayMs(attempt: number): number | null {
   if (attempt < 1 || attempt > RECONNECT_DELAYS_MS.length) return null;

--- a/apps/desktop/src/lib/terminalReconnect.ts
+++ b/apps/desktop/src/lib/terminalReconnect.ts
@@ -22,7 +22,8 @@ export type TermStatus =
 export const RECONNECT_DELAYS_MS = [500, 1000, 2000, 4000, 8000];
 
 /**
- * How long a session must stay up to count as having worked.
+ * How long a session must keep running *after its first output* to count as
+ * having worked.
  *
  * Opening an exec session and *keeping* one are different things: the backend
  * returns a session id as soon as the task is spawned, so a shell that is
@@ -36,11 +37,20 @@ export const HEALTHY_SESSION_MS = 5000;
 /**
  * Whether a session that has just ended earned a fresh retry budget.
  *
- * A shell the user actually used and lost deserves the full backoff schedule
- * again; one that died on arrival does not, or the schedule never runs out.
+ * `usableMs` is time since the session's first byte of output — the earliest
+ * proof that a shell was actually there. Measuring from the connect call
+ * instead would count the wait for a *failed* attach, so a refusal that takes
+ * more than {@link HEALTHY_SESSION_MS} to come back (an unresponsive API
+ * server, a slow authorization webhook) would keep clearing the budget and the
+ * terminal would still retry forever.
+ *
+ * Both halves are needed: a session that never emitted anything was never
+ * usable, and one that printed an error and died immediately hasn't earned
+ * another full schedule either. A shell the user really had and lost gets the
+ * budget back.
  */
-export function sessionEarnedRetryReset(livedMs: number): boolean {
-  return livedMs >= HEALTHY_SESSION_MS;
+export function sessionEarnedRetryReset(usableMs: number): boolean {
+  return usableMs > 0 && usableMs >= HEALTHY_SESSION_MS;
 }
 
 /** Delay before reconnect attempt `attempt` (1-based), or null when exhausted. */


### PR DESCRIPTION
Closes #263 — "pod shell keeps showing reconnecting".

## Root cause
The retry budget was reset whenever `driver.connect()` resolved:

```ts
if (isReconnect) term.write(divider("reconnected (new shell)"));
attempt = 0;          // <- treats "spawned" as "working"
setStatus({ kind: "live" });
```

But connecting and *staying* connected are different things. `start_pod_exec` returns a session id as soon as the task is spawned, so a shell that is refused — RBAC, a container that isn't running, an image with no shell — still connects successfully and fails a moment later via `exec:exit`.

So every cycle reset `attempt` to 0, the five-step backoff never ran out, and the terminal reconnected **indefinitely**. The bounded schedule that was supposed to stop it could never be reached.

## Fix
The budget now resets on *evidence the session worked* — it stayed up for `HEALTHY_SESSION_MS` — rather than on the connect call returning.

- A shell the user actually had and lost still gets the full schedule back.
- One that dies on arrival exhausts it and lands on `disconnected` with the reason.
- An explicit **Reconnect** from the toolbar still resets the budget: that's a fresh decision by the user, not an automatic retry.

## Also: show the reason during retries
Previously the error was only written once the budget was spent, so during the loop the user saw `reconnecting…` and nothing else — the least useful thing on screen. When a shell can never start, that message *is* the answer, so it's now written on every attempt.

## Tests
The policy is a pure function, so the loop is testable directly: one test walks the real schedule with every session dying immediately and asserts it reaches `disconnected` after exactly `RECONNECT_DELAYS_MS.length` attempts; another asserts a repeatedly-dropping *healthy* session still retries indefinitely, so the fix doesn't break genuine reconnection.

Suite: 1132 passing, `tsc` clean.

## Related
#262 (no container picker) is likely the same user's underlying trigger: on a multi-container pod the exec targets the first container, which may be a sidecar with no shell. That's a separate change; this one makes the failure visible and finite either way.
