### PR TITLE
feat(pods): choose the container when opening a shell

### DIFF
--- a/apps/desktop/src/components/DetailActions.test.tsx
+++ b/apps/desktop/src/components/DetailActions.test.tsx
@@ -221,6 +221,49 @@ describe("PodActions", () => {
     expect(titleOf(items[2])).toBe("Shell into generate-tls-certs (not running)");
   });
 
+  it("re-reads the containers when the menu opens", async () => {
+    // A pod's containers aren't fixed for its lifetime: they restart, and
+    // ephemeral debug containers get attached (by the button next to this one).
+    // A snapshot from whenever the drawer opened goes stale.
+    const twoContainers = {
+      object: {
+        spec: { containers: [{ name: "mongodb" }, { name: "metrics" }] },
+        status: {
+          containerStatuses: [
+            { name: "mongodb", state: { running: {} } },
+            { name: "metrics", state: { running: {} } },
+          ],
+        },
+      },
+    };
+    getObjectMock.mockResolvedValueOnce(twoContainers).mockResolvedValue({
+      object: {
+        spec: {
+          containers: [{ name: "mongodb" }, { name: "metrics" }],
+          ephemeralContainers: [{ name: "debugger-abc12" }],
+        },
+        status: {
+          containerStatuses: [
+            { name: "mongodb", state: { running: {} } },
+            { name: "metrics", state: { running: {} } },
+          ],
+          ephemeralContainerStatuses: [{ name: "debugger-abc12", state: { running: {} } }],
+        },
+      },
+    });
+    render(<PodActions context="kind-dev" pod={pod} onOpenTerminal={vi.fn()} />);
+    await waitFor(() => expect(getObjectMock).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole("button", { name: "Shell" }));
+    await waitFor(async () =>
+      expect((await screen.findAllByRole("menuitem")).map((i) => i.textContent)).toEqual([
+        "mongodb",
+        "metrics",
+        "debugger-abc12",
+      ]),
+    );
+  });
+
   it("falls back to the old behaviour when the pod can't be read", async () => {
     // An RBAC-restricted get must not disable the shell button: without a
     // container the API server picks, exactly as before the picker existed.

--- a/apps/desktop/src/components/DetailActions.test.tsx
+++ b/apps/desktop/src/components/DetailActions.test.tsx
@@ -119,6 +119,125 @@ describe("PodActions", () => {
     expect(onOpenTerminal).toHaveBeenCalledWith({ context: "kind-dev", namespace: "default", pod: "web-1" });
   });
 
+  it("asks which container to open a shell into on a multi-container pod", async () => {
+    getObjectMock.mockResolvedValue({
+      object: {
+        spec: { containers: [{ name: "istio-proxy" }, { name: "app" }] },
+        status: {
+          containerStatuses: [
+            { name: "istio-proxy", state: { running: {} } },
+            { name: "app", state: { running: {} } },
+          ],
+        },
+      },
+    });
+    const onOpenTerminal = vi.fn();
+    render(<PodActions context="kind-dev" pod={pod} onOpenTerminal={onOpenTerminal} />);
+    await waitFor(() => expect(getObjectMock).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole("button", { name: "Shell" }));
+    fireEvent.click(await screen.findByRole("menuitem", { name: /^app/ }));
+    expect(onOpenTerminal).toHaveBeenCalledWith({
+      context: "kind-dev",
+      namespace: "default",
+      pod: "web-1",
+      container: "app",
+    });
+  });
+
+  it("opens the annotated default container without asking on a single-container pod", async () => {
+    // One container means there is no choice to make; the annotation still
+    // decides, because the API server ignores it and would pick spec order.
+    getObjectMock.mockResolvedValue({
+      object: {
+        metadata: { annotations: { "kubectl.kubernetes.io/default-container": "app" } },
+        spec: { containers: [{ name: "app" }] },
+        status: { containerStatuses: [{ name: "app", state: { running: {} } }] },
+      },
+    });
+    const onOpenTerminal = vi.fn();
+    render(<PodActions context="kind-dev" pod={pod} onOpenTerminal={onOpenTerminal} />);
+    await waitFor(() => expect(getObjectMock).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole("button", { name: "Shell" }));
+    expect(screen.queryByRole("menu")).toBeNull();
+    await waitFor(() =>
+      expect(onOpenTerminal).toHaveBeenCalledWith({
+        context: "kind-dev",
+        namespace: "default",
+        pod: "web-1",
+        container: "app",
+      }),
+    );
+  });
+
+  it("does not ask when the only other container is a finished init step", async () => {
+    getObjectMock.mockResolvedValue({
+      object: {
+        spec: { containers: [{ name: "app" }], initContainers: [{ name: "migrate" }] },
+        status: {
+          containerStatuses: [{ name: "app", state: { running: {} } }],
+          initContainerStatuses: [{ name: "migrate", state: { terminated: { exitCode: 0 } } }],
+        },
+      },
+    });
+    const onOpenTerminal = vi.fn();
+    render(<PodActions context="kind-dev" pod={pod} onOpenTerminal={onOpenTerminal} />);
+    await waitFor(() => expect(getObjectMock).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole("button", { name: "Shell" }));
+    expect(screen.queryByRole("menu")).toBeNull();
+    expect(onOpenTerminal).toHaveBeenCalledWith({
+      context: "kind-dev",
+      namespace: "default",
+      pod: "web-1",
+      container: "app",
+    });
+  });
+
+  it("lists every container in the menu, including ones that aren't running", async () => {
+    getObjectMock.mockResolvedValue({
+      object: {
+        spec: {
+          containers: [{ name: "mongodb" }, { name: "metrics" }],
+          initContainers: [{ name: "generate-tls-certs" }],
+        },
+        status: {
+          containerStatuses: [
+            { name: "mongodb", state: { running: {} } },
+            { name: "metrics", state: { running: {} } },
+          ],
+          initContainerStatuses: [{ name: "generate-tls-certs", state: { terminated: {} } }],
+        },
+      },
+    });
+    render(<PodActions context="kind-dev" pod={pod} onOpenTerminal={vi.fn()} />);
+    await waitFor(() => expect(getObjectMock).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole("button", { name: "Shell" }));
+    const items = await screen.findAllByRole("menuitem");
+    expect(items.map((i) => i.textContent)).toEqual(["mongodb", "metrics", "generate-tls-certs"]);
+    // The finished init container is shown but marked, not silently dropped.
+    expect(titleOf(items[2])).toBe("Shell into generate-tls-certs (not running)");
+  });
+
+  it("falls back to the old behaviour when the pod can't be read", async () => {
+    // An RBAC-restricted get must not disable the shell button: without a
+    // container the API server picks, exactly as before the picker existed.
+    getObjectMock.mockResolvedValue({ error: "forbidden" });
+    const onOpenTerminal = vi.fn();
+    render(<PodActions context="kind-dev" pod={pod} onOpenTerminal={onOpenTerminal} />);
+    await waitFor(() => expect(getObjectMock).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole("button", { name: "Shell" }));
+    expect(screen.queryByRole("menu")).toBeNull();
+    expect(onOpenTerminal).toHaveBeenCalledWith({
+      context: "kind-dev",
+      namespace: "default",
+      pod: "web-1",
+    });
+  });
+
   it("confirms and deletes the pod", async () => {
     deletePodMock.mockResolvedValue({ deleted: true });
     const onDeleted = vi.fn();

--- a/apps/desktop/src/components/DetailActions.tsx
+++ b/apps/desktop/src/components/DetailActions.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import {
   ArrowLeftRight,
   Bot,
@@ -25,9 +25,16 @@ import {
 import { notify } from "../lib/notify";
 import { useAccess, rbac, kindToResource, denyReason, reportActionError, type AccessCheck } from "../lib/access";
 import { getObject } from "../lib/manifest";
+import {
+  defaultContainer,
+  execCandidates,
+  podContainerChoices,
+  type ContainerChoice,
+} from "../lib/podContainers";
 import { IconButton, ConfirmDialog, TextInput, KubectlPreview } from "../ui";
 import { Input } from "@/components/ui/input";
 import { Slider } from "@/components/ui/slider";
+import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
 import { ForwardDialog } from "./ForwardDialog";
 import { CopyAsKubectlButton } from "./CopyAsKubectlButton";
 import { toKubectl } from "../lib/kubectlMapper";
@@ -91,6 +98,13 @@ export function PodActions({
   const [error, setError] = useState("");
   const [debugImage, setDebugImage] = useState("busybox");
   const [debugTarget, setDebugTarget] = useState("");
+  // Containers to choose between when opening a shell (#262). Empty until the
+  // pod object arrives, and for a pod we couldn't read — in both cases the
+  // Shell button behaves as it always did and lets the API server choose.
+  const [containers, setContainers] = useState<ContainerChoice[]>([]);
+  /** The container the annotation (or the running state) nominates. */
+  const [preferred, setPreferred] = useState<string | undefined>(undefined);
+  const [containerMenu, setContainerMenu] = useState(false);
 
   const deleteCheck = rbac.deletePod(pod.namespace);
   const evictCheck = rbac.evictPod(pod.namespace);
@@ -98,6 +112,33 @@ export function PodActions({
   const access = useAccess(context, [deleteCheck, evictCheck, editCheck]);
 
   const target = { context, namespace: pod.namespace, pod: pod.name };
+
+  // Read the pod's containers up front so the Shell button knows whether there
+  // is a choice to offer. The header stays interactive while this is in flight;
+  // a failure just leaves the old single-shot behaviour in place.
+  useEffect(() => {
+    let current = true;
+    setContainers([]);
+    setPreferred(undefined);
+    void getObject(context, "Pod", pod.namespace, pod.name).then((r) => {
+      if (!current || !r.object) return;
+      const choices = podContainerChoices(r.object);
+      setContainers(choices);
+      setPreferred(defaultContainer(r.object, choices));
+    });
+    return () => {
+      current = false;
+    };
+  }, [context, pod.namespace, pod.name]);
+
+  function openShell() {
+    // Nothing to choose between (or a pod we couldn't read) → no menu.
+    if (execCandidates(containers).length < 2) {
+      onOpenTerminal?.(preferred ? { ...target, container: preferred } : target);
+      return;
+    }
+    setContainerMenu((open) => !open);
+  }
 
   async function doDelete() {
     setBusy(true);
@@ -149,7 +190,41 @@ export function PodActions({
   return (
     <>
       <IconButton icon={Logs} label="Logs" onClick={() => onOpenLogs?.(target)} />
-      <IconButton icon={SquareTerminal} label="Shell" onClick={() => onOpenTerminal?.(target)} />
+      <Popover open={containerMenu} onOpenChange={setContainerMenu}>
+        <PopoverAnchor asChild>
+          <span className="inline-flex">
+            <IconButton
+              icon={SquareTerminal}
+              label="Shell"
+              title={containers.length > 1 ? `Shell — ${containers.length} containers` : "Shell"}
+              onClick={openShell}
+            />
+          </span>
+        </PopoverAnchor>
+        <PopoverContent align="start" role="menu" className="w-auto min-w-44 gap-0 p-1">
+          {containers.map((c) => (
+            <button
+              key={c.name}
+              type="button"
+              role="menuitem"
+              title={`Shell into ${c.name}${c.running ? "" : " (not running)"}`}
+              className={`flex w-full items-center gap-2 rounded px-2 py-1 text-left hover:bg-accent hover:text-accent-foreground ${
+                c.running ? "" : "text-muted-foreground"
+              }`}
+              onClick={() => {
+                setContainerMenu(false);
+                onOpenTerminal?.({ ...target, container: c.name });
+              }}
+            >
+              <span
+                aria-hidden="true"
+                className={`size-2 shrink-0 rounded-xs ${c.running ? "bg-emerald-500" : "bg-muted-foreground/40"}`}
+              />
+              <span className="min-w-0 truncate">{c.name}</span>
+            </button>
+          ))}
+        </PopoverContent>
+      </Popover>
       <CopyAsKubectlButton kind="Pod" name={pod.name} namespace={pod.namespace} context={context} />
       <IconButton
         icon={Zap}

--- a/apps/desktop/src/components/DetailActions.tsx
+++ b/apps/desktop/src/components/DetailActions.tsx
@@ -105,6 +105,8 @@ export function PodActions({
   /** The container the annotation (or the running state) nominates. */
   const [preferred, setPreferred] = useState<string | undefined>(undefined);
   const [containerMenu, setContainerMenu] = useState(false);
+  /** Bumped to re-read the containers: a pod's are not fixed for its lifetime. */
+  const [containerReload, setContainerReload] = useState(0);
 
   const deleteCheck = rbac.deletePod(pod.namespace);
   const evictCheck = rbac.evictPod(pod.namespace);
@@ -113,13 +115,18 @@ export function PodActions({
 
   const target = { context, namespace: pod.namespace, pod: pod.name };
 
+  // Switching to a different pod must not leave the previous pod's containers
+  // on screen for the moment the fetch below takes.
+  useEffect(() => {
+    setContainers([]);
+    setPreferred(undefined);
+  }, [context, pod.namespace, pod.name]);
+
   // Read the pod's containers up front so the Shell button knows whether there
   // is a choice to offer. The header stays interactive while this is in flight;
   // a failure just leaves the old single-shot behaviour in place.
   useEffect(() => {
     let current = true;
-    setContainers([]);
-    setPreferred(undefined);
     void getObject(context, "Pod", pod.namespace, pod.name).then((r) => {
       if (!current || !r.object) return;
       const choices = podContainerChoices(r.object);
@@ -129,7 +136,7 @@ export function PodActions({
     return () => {
       current = false;
     };
-  }, [context, pod.namespace, pod.name]);
+  }, [context, pod.namespace, pod.name, containerReload]);
 
   function openShell() {
     // Nothing to choose between (or a pod we couldn't read) → no menu.
@@ -137,6 +144,11 @@ export function PodActions({
       onOpenTerminal?.(preferred ? { ...target, container: preferred } : target);
       return;
     }
+    // Re-read while the menu opens rather than showing a snapshot from whenever
+    // the drawer happened to open: containers restart, and ephemeral debug
+    // containers get attached — including by the Debug button next to this one.
+    // The list fills in from the previous read and corrects itself in place.
+    setContainerReload((n) => n + 1);
     setContainerMenu((open) => !open);
   }
 
@@ -167,6 +179,9 @@ export function PodActions({
     }
     setDialog(null);
     notify.success(`Debug container ${out.container} added to ${pod.name}`);
+    // The pod now has a container it didn't a moment ago; the shell menu has to
+    // know about it.
+    setContainerReload((n) => n + 1);
     onOpenTerminal?.({ context, namespace: pod.namespace, pod: pod.name, container: out.container });
   }
 

--- a/apps/desktop/src/components/Dock.test.tsx
+++ b/apps/desktop/src/components/Dock.test.tsx
@@ -44,6 +44,19 @@ describe("Dock", () => {
     expect(screen.getByTestId("terminal").textContent).toBe("web-1");
   });
 
+  it("distinguishes two shells into different containers of one pod", () => {
+    // Both tabs would otherwise read "web-1" and the user couldn't tell the
+    // sidecar's shell from the app's (#262).
+    renderDock({
+      sessions: [
+        { id: 1, kind: "terminal", context: "c", namespace: "default", pod: "web-1", container: "app" },
+        { id: 2, kind: "terminal", context: "c", namespace: "default", pod: "web-1", container: "istio-proxy" },
+      ],
+    });
+    expect(screen.getByRole("tab", { name: /web-1 · app/ })).toBeDefined();
+    expect(screen.getByRole("tab", { name: /web-1 · istio-proxy/ })).toBeDefined();
+  });
+
   it("keeps every session mounted and shows only the active one", () => {
     renderDock({ activeId: 2 });
     // Both panes are mounted (so terminals/streams survive tab switches)…

--- a/apps/desktop/src/components/Dock.tsx
+++ b/apps/desktop/src/components/Dock.tsx
@@ -32,6 +32,9 @@ export interface DockSession {
 function sessionLabel(s: DockSession): string {
   if (s.kind === "shell") return `kubectl · ${s.context}`;
   if (s.kind === "helm") return s.helm?.title ?? "Helm";
+  // Two shells into the same multi-container pod are different sessions, so
+  // the container has to be in the label or the tabs are indistinguishable.
+  if (s.pod && s.kind === "terminal" && s.container) return `${s.pod} · ${s.container}`;
   if (s.pod) return s.pod;
   if (s.workload) return `${s.workload.kind}/${s.workload.name}`;
   return "session";

--- a/apps/desktop/src/lib/podContainers.test.ts
+++ b/apps/desktop/src/lib/podContainers.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import { defaultContainer, execCandidates, podContainerChoices } from "./podContainers";
+
+const running = (name: string) => ({ name, state: { running: { startedAt: "now" } } });
+const terminated = (name: string) => ({ name, state: { terminated: { exitCode: 0 } } });
+const waiting = (name: string) => ({ name, state: { waiting: { reason: "CrashLoopBackOff" } } });
+
+describe("podContainerChoices", () => {
+  it("lists app containers with their running state", () => {
+    const pod = {
+      spec: { containers: [{ name: "app" }, { name: "sidecar" }] },
+      status: { containerStatuses: [running("app"), waiting("sidecar")] },
+    };
+    expect(podContainerChoices(pod)).toEqual([
+      { name: "app", kind: "app", running: true },
+      { name: "sidecar", kind: "app", running: false },
+    ]);
+  });
+
+  it("keeps a crash-looping container in the list", () => {
+    // The one you most want a shell into is often the broken one; the caller
+    // shows why it can't attach rather than pretending it isn't there.
+    const pod = {
+      spec: { containers: [{ name: "broken" }] },
+      status: { containerStatuses: [waiting("broken")] },
+    };
+    expect(podContainerChoices(pod)).toEqual([{ name: "broken", kind: "app", running: false }]);
+  });
+
+  it("lists a finished init container, marked as not running", () => {
+    // Shown rather than hidden: a menu that omits half the pod is harder to
+    // trust than one that says which parts are up.
+    const pod = {
+      spec: { containers: [{ name: "app" }], initContainers: [{ name: "migrate" }] },
+      status: { containerStatuses: [running("app")], initContainerStatuses: [terminated("migrate")] },
+    };
+    expect(podContainerChoices(pod)).toEqual([
+      { name: "app", kind: "app", running: true },
+      { name: "migrate", kind: "init", running: false },
+    ]);
+  });
+
+  it("offers a native sidecar, which is an init container that stays up", () => {
+    const pod = {
+      spec: {
+        containers: [{ name: "app" }],
+        initContainers: [{ name: "proxy", restartPolicy: "Always" }],
+      },
+      status: { containerStatuses: [running("app")], initContainerStatuses: [running("proxy")] },
+    };
+    expect(podContainerChoices(pod)).toContainEqual({ name: "proxy", kind: "init", running: true });
+  });
+
+  it("offers ephemeral debug containers", () => {
+    const pod = {
+      spec: { containers: [{ name: "app" }], ephemeralContainers: [{ name: "debugger" }] },
+      status: {
+        containerStatuses: [running("app")],
+        ephemeralContainerStatuses: [running("debugger")],
+      },
+    };
+    expect(podContainerChoices(pod)).toContainEqual({
+      name: "debugger",
+      kind: "ephemeral",
+      running: true,
+    });
+  });
+
+  it("returns nothing for a pod that hasn't loaded, rather than throwing", () => {
+    expect(podContainerChoices(undefined)).toEqual([]);
+    expect(podContainerChoices({})).toEqual([]);
+    expect(podContainerChoices({ spec: { containers: "not-a-list" } })).toEqual([]);
+  });
+});
+
+describe("execCandidates", () => {
+  it("ignores a finished init container, so a plain app pod asks nothing", () => {
+    const pod = {
+      spec: { containers: [{ name: "app" }], initContainers: [{ name: "migrate" }] },
+      status: { containerStatuses: [running("app")], initContainerStatuses: [terminated("migrate")] },
+    };
+    expect(execCandidates(podContainerChoices(pod)).map((c) => c.name)).toEqual(["app"]);
+  });
+
+  it("counts a sidecar that is still up", () => {
+    const pod = {
+      spec: { containers: [{ name: "app" }], initContainers: [{ name: "proxy" }] },
+      status: { containerStatuses: [running("app")], initContainerStatuses: [running("proxy")] },
+    };
+    expect(execCandidates(podContainerChoices(pod)).map((c) => c.name)).toEqual(["app", "proxy"]);
+  });
+
+  it("keeps an app container that isn't running", () => {
+    // Otherwise a pod whose only container is crash-looping would look like it
+    // has nowhere to exec, when trying is exactly what the user wants.
+    const pod = {
+      spec: { containers: [{ name: "app" }] },
+      status: { containerStatuses: [waiting("app")] },
+    };
+    expect(execCandidates(podContainerChoices(pod)).map((c) => c.name)).toEqual(["app"]);
+  });
+});
+
+describe("defaultContainer", () => {
+  it("honours the annotation kubectl uses", () => {
+    // The API server ignores this annotation, so without resolving it here the
+    // shell lands on whichever container the manifest happens to list first.
+    const pod = {
+      metadata: { annotations: { "kubectl.kubernetes.io/default-container": "app" } },
+      spec: { containers: [{ name: "istio-proxy" }, { name: "app" }] },
+      status: { containerStatuses: [running("istio-proxy"), running("app")] },
+    };
+    expect(defaultContainer(pod, podContainerChoices(pod))).toBe("app");
+  });
+
+  it("ignores an annotation naming a container that isn't there", () => {
+    const pod = {
+      metadata: { annotations: { "kubectl.kubernetes.io/default-container": "removed" } },
+      spec: { containers: [{ name: "app" }] },
+      status: { containerStatuses: [running("app")] },
+    };
+    expect(defaultContainer(pod, podContainerChoices(pod))).toBe("app");
+  });
+
+  it("skips a leading container that isn't running", () => {
+    const pod = {
+      spec: { containers: [{ name: "crashed" }, { name: "app" }] },
+      status: { containerStatuses: [waiting("crashed"), running("app")] },
+    };
+    expect(defaultContainer(pod, podContainerChoices(pod))).toBe("app");
+  });
+
+  it("falls back to the first container when none is running", () => {
+    const pod = {
+      spec: { containers: [{ name: "a" }, { name: "b" }] },
+      status: { containerStatuses: [waiting("a"), waiting("b")] },
+    };
+    expect(defaultContainer(pod, podContainerChoices(pod))).toBe("a");
+  });
+
+  it("never prefers an ephemeral container over an app container", () => {
+    // Debug containers accumulate on a pod and can't be removed; picking the
+    // newest one by default would quietly hijack every later shell.
+    const pod = {
+      spec: { containers: [{ name: "app" }], ephemeralContainers: [{ name: "debugger" }] },
+      status: {
+        containerStatuses: [waiting("app")],
+        ephemeralContainerStatuses: [running("debugger")],
+      },
+    };
+    expect(defaultContainer(pod, podContainerChoices(pod))).toBe("app");
+  });
+
+  it("is undefined when there is nothing to pick", () => {
+    expect(defaultContainer({}, [])).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/lib/podContainers.ts
+++ b/apps/desktop/src/lib/podContainers.ts
@@ -1,0 +1,99 @@
+// Which containers of a pod a shell can actually be opened into, and which one
+// to offer first (#262).
+//
+// `kubectl exec` with no `-c` picks the first container in the spec, so on a
+// multi-container pod the shell button lands wherever the manifest happens to
+// start — often a sidecar with no shell at all. Kubernetes' answer to that is
+// the `kubectl.kubernetes.io/default-container` annotation, which kubectl
+// honours client-side; the API server does not, so we resolve it here.
+
+/** The annotation kubectl uses to pick a container when none is given. */
+export const DEFAULT_CONTAINER_ANNOTATION = "kubectl.kubernetes.io/default-container";
+
+/** A container the user could exec into. */
+export interface ContainerChoice {
+  name: string;
+  /** Which section of the pod spec it came from. */
+  kind: "app" | "init" | "ephemeral";
+  /** Whether the container is currently running, i.e. exec can attach. */
+  running: boolean;
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function array(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function names(list: unknown): string[] {
+  return array(list)
+    .map((entry) => record(entry).name)
+    .filter((name): name is string => typeof name === "string" && name !== "");
+}
+
+/** Names of containers reported as running in one of the status lists. */
+function runningNames(status: Record<string, unknown>): Set<string> {
+  const running = new Set<string>();
+  for (const key of ["containerStatuses", "initContainerStatuses", "ephemeralContainerStatuses"]) {
+    for (const entry of array(status[key])) {
+      const s = record(entry);
+      if (typeof s.name === "string" && "running" in record(s.state)) running.add(s.name);
+    }
+  }
+  return running;
+}
+
+/**
+ * Every container of `pod`, in menu order: app containers, then init
+ * containers (native sidecars among them), then ephemeral debug containers.
+ *
+ * Containers that aren't running are listed too, marked rather than hidden. A
+ * finished init container and a crash-looping app container are both things
+ * the user is looking for when they open this menu, and a list that silently
+ * omits half the pod is harder to trust than one that shows what is up.
+ */
+export function podContainerChoices(pod: unknown): ContainerChoice[] {
+  const spec = record(record(pod).spec);
+  const running = runningNames(record(record(pod).status));
+  const of = (kind: ContainerChoice["kind"]) => (name: string) => ({
+    name,
+    kind,
+    running: running.has(name),
+  });
+  return [
+    ...names(spec.containers).map(of("app")),
+    ...names(spec.initContainers).map(of("init")),
+    ...names(spec.ephemeralContainers).map(of("ephemeral")),
+  ];
+}
+
+/**
+ * Containers worth asking the user about: the pod's own containers, plus any
+ * init or ephemeral container still running.
+ *
+ * A finished init container is listed in the menu but doesn't count here — a
+ * pod that is one app container and a completed migration step is not a choice,
+ * and making the user pick every time would be noise.
+ */
+export function execCandidates(choices: readonly ContainerChoice[]): ContainerChoice[] {
+  return choices.filter((c) => c.kind === "app" || c.running);
+}
+
+/**
+ * The container to open by default: the one the pod's author nominated through
+ * the annotation, else the first running app container, else the first listed.
+ *
+ * Preferring a running container over the spec's first entry matters on pods
+ * whose leading container has crashed — the default should be somewhere a shell
+ * can actually land.
+ */
+export function defaultContainer(pod: unknown, choices: ContainerChoice[]): string | undefined {
+  const annotated = record(record(record(pod).metadata).annotations)[DEFAULT_CONTAINER_ANNOTATION];
+  if (typeof annotated === "string" && choices.some((c) => c.name === annotated)) return annotated;
+  const app = choices.filter((c) => c.kind === "app");
+  return (app.find((c) => c.running) ?? app[0] ?? choices[0])?.name;
+}


### PR DESCRIPTION
Closes #262.

Clicking **Shell** on a pod with more than one container now drops a small menu under the button:

```
▣ mongodb
▣ metrics
▢ generate-tls-certs
```

A filled dot means the container is running. Picking one opens a shell into it, and the dock tab is labelled `pod · container` so two shells into the same pod stay distinguishable.

## Why it was wrong before
The button opened an exec with no container, so the API server picked `spec.containers[0]` — wherever the manifest happens to start, often a sidecar with no shell in its image. (That is also a plausible trigger for #263: a shell-less sidecar refuses the exec, and before that fix the terminal retried forever.)

## Details worth reviewing

**The menu only appears when there is a real choice.** A pod whose only other container is a finished init step opens straight through — `execCandidates` counts app containers plus anything still running, so a completed migration container doesn't turn every shell into a two-click operation. A crash-looping *app* container still counts: trying is exactly what the user wants there.

**Non-running containers are listed, not hidden.** They're marked instead. A menu that silently omits half the pod is harder to trust than one that says which parts are up, and after #263 a refused exec now reports its reason promptly.

**The no-menu path now resolves the container the way kubectl does** — `kubectl.kubernetes.io/default-container` when the pod carries it, else the first *running* container. The API server ignores that annotation (kubectl applies it client-side), so on pods whose authors set it we were previously ignoring it too.

**The fetch can't break the button.** While `getObject` is in flight, or when it's refused by RBAC, `containers` stays empty and the shell opens exactly as before, letting the API server choose. There's a test for the forbidden case.

## Tests
`podContainers.ts` is pure, so the interesting rules are unit-tested directly (15 cases: sidecars vs finished init containers, ephemeral debug containers, annotation resolution and its bad inputs, malformed objects). Four component tests cover the menu, the direct-open paths, and the tab labelling.

Suite: 1154 passing, `tsc` clean.
