### PR TITLE
feat(services): show the external IP in the list and the detail

### DIFF
--- a/apps/desktop/src/components/ResourceBrowser.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.tsx
@@ -393,6 +393,7 @@ const serviceColumns: Column<ServiceSummary>[] = [
   { key: "namespace", header: "Namespace", render: (s) => <span className="fl-link">{s.namespace}</span> },
   { key: "type", header: "Type" },
   { key: "clusterIP", header: "Cluster IP", render: (s) => <Muted>{s.clusterIP}</Muted> },
+  { key: "externalIP", header: "External IP", render: (s) => <Muted>{s.externalIP || "—"}</Muted> },
   { key: "ports", header: "Ports" },
   { key: "age", header: "Age", getSortValue: ageSortValue, render: (s) => <Muted>{s.age}</Muted> },
 ];

--- a/apps/desktop/src/components/ResourceOverview.tsx
+++ b/apps/desktop/src/components/ResourceOverview.tsx
@@ -3,6 +3,7 @@ import { ArrowLeftRight, ChevronDown, ChevronUp, ScrollText, SquareTerminal } fr
 import type { X509Certificate } from "@peculiar/x509";
 import { getObject, getSecret, type K8sObject } from "../lib/manifest";
 import { listEndpointSlices } from "../lib/network";
+import { serviceExternalAddress } from "../lib/serviceAddress";
 import { podsForPvc, formatStorageSize } from "../lib/storage";
 import { bindingsForServiceAccount, podsForServiceAccount, type SaBinding } from "../lib/rbac";
 import { updateConfigData } from "../lib/actions";
@@ -1296,6 +1297,7 @@ function ServiceBody({
           pairs={[
             ["Type", str(spec.type) || "ClusterIP"],
             ["Cluster IP", <span className="fl-mono">{str(spec.clusterIP)}</span>],
+            ["External IP", <span className="fl-mono">{serviceExternalAddress(obj) || "—"}</span>],
             ["Session affinity", str(spec.sessionAffinity)],
             ["Selector", <Chips key="s" map={selector} />],
           ]}

--- a/apps/desktop/src/lib/serviceAddress.test.ts
+++ b/apps/desktop/src/lib/serviceAddress.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { serviceExternalAddress } from "./serviceAddress";
+
+describe("serviceExternalAddress", () => {
+  it("reads a load balancer's ip", () => {
+    expect(
+      serviceExternalAddress({
+        spec: { type: "LoadBalancer" },
+        status: { loadBalancer: { ingress: [{ ip: "34.1.2.3" }] } },
+      }),
+    ).toBe("34.1.2.3");
+  });
+
+  it("reads a load balancer's hostname", () => {
+    // AWS publishes a hostname rather than an ip; without this a fully
+    // provisioned service looks like it has no address.
+    expect(
+      serviceExternalAddress({
+        spec: { type: "LoadBalancer" },
+        status: { loadBalancer: { ingress: [{ hostname: "a1b2.elb.amazonaws.com" }] } },
+      }),
+    ).toBe("a1b2.elb.amazonaws.com");
+  });
+
+  it("separates a pending load balancer from having no address at all", () => {
+    expect(serviceExternalAddress({ spec: { type: "LoadBalancer" } })).toBe("<pending>");
+    expect(serviceExternalAddress({ spec: { type: "ClusterIP" } })).toBe("");
+  });
+
+  it("includes manually assigned external IPs on any type", () => {
+    expect(
+      serviceExternalAddress({ spec: { type: "NodePort", externalIPs: ["192.0.2.1", "192.0.2.2"] } }),
+    ).toBe("192.0.2.1, 192.0.2.2");
+  });
+
+  it("shows the load balancer and the assigned addresses together", () => {
+    expect(
+      serviceExternalAddress({
+        spec: { type: "LoadBalancer", externalIPs: ["192.0.2.1"] },
+        status: { loadBalancer: { ingress: [{ ip: "34.1.2.3" }] } },
+      }),
+    ).toBe("34.1.2.3, 192.0.2.1");
+  });
+
+  it("resolves an ExternalName to what it points at", () => {
+    expect(
+      serviceExternalAddress({ spec: { type: "ExternalName", externalName: "db.example.com" } }),
+    ).toBe("db.example.com");
+  });
+
+  it("treats a service with no type as ClusterIP, as the API does", () => {
+    expect(serviceExternalAddress({ spec: {} })).toBe("");
+  });
+
+  it("survives an object that hasn't loaded or is malformed", () => {
+    expect(serviceExternalAddress(undefined)).toBe("");
+    expect(serviceExternalAddress({ spec: { type: "LoadBalancer" }, status: "nonsense" })).toBe(
+      "<pending>",
+    );
+    expect(
+      serviceExternalAddress({
+        spec: { type: "LoadBalancer" },
+        status: { loadBalancer: { ingress: [{}] } },
+      }),
+    ).toBe("<pending>");
+  });
+});

--- a/apps/desktop/src/lib/serviceAddress.ts
+++ b/apps/desktop/src/lib/serviceAddress.ts
@@ -1,0 +1,47 @@
+// The external address of a Service, for the detail view (#264).
+//
+// The list gets this field from `k8s.listServices`, which computes it in Rust;
+// the detail view renders the raw object, so the same rule lives here. It
+// follows `kubectl get svc`'s EXTERNAL-IP column.
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function array(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function text(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+/**
+ * Where the service can be reached from outside the cluster.
+ *
+ * A LoadBalancer publishes ingress entries in `status`, each carrying an ip or
+ * a hostname (AWS gives hostnames, most others ips); `spec.externalIPs` is a
+ * separate, manually assigned set that any service type may carry, and both are
+ * shown. An ExternalName has no address of its own — it resolves to the name it
+ * points at, which is what kubectl prints here.
+ *
+ * A LoadBalancer with nothing yet is `<pending>` rather than empty: waiting on
+ * a cloud provider and having no external address at all are different states,
+ * and only the first resolves itself.
+ */
+export function serviceExternalAddress(service: unknown): string {
+  const spec = record(record(service).spec);
+  const type = text(spec.type) || "ClusterIP";
+  if (type === "ExternalName") return text(spec.externalName);
+
+  const ingress = array(record(record(record(service).status).loadBalancer).ingress)
+    .map((entry) => text(record(entry).ip) || text(record(entry).hostname))
+    .filter((address) => address !== "");
+  const assigned = array(spec.externalIPs).map(text).filter((address) => address !== "");
+  const addresses = [...ingress, ...assigned];
+
+  if (addresses.length > 0) return addresses.join(", ");
+  return type === "LoadBalancer" ? "<pending>" : "";
+}

--- a/apps/desktop/src/lib/workloads.ts
+++ b/apps/desktop/src/lib/workloads.ts
@@ -39,6 +39,9 @@ export interface ServiceSummary {
   namespace: string;
   type: string;
   clusterIP: string;
+  /** Load-balancer address, assigned external IPs, or an ExternalName target;
+   *  empty when there is none, `<pending>` while a LoadBalancer waits. */
+  externalIP: string;
   ports: string;
   age: string;
 }

--- a/crates/kube/src/services.rs
+++ b/crates/kube/src/services.rs
@@ -26,8 +26,53 @@ pub struct ServiceSummary {
     pub type_: String,
     #[serde(rename = "clusterIP")]
     pub cluster_ip: String,
+    /// The address the service is reachable on from outside the cluster:
+    /// load-balancer ingress, explicit `spec.externalIPs`, or the target of an
+    /// ExternalName. Empty when the service has none; `<pending>` while a
+    /// LoadBalancer waits on its provider.
+    #[serde(rename = "externalIP")]
+    pub external_ip: String,
     pub ports: String,
     pub age: String,
+}
+
+/// The service's external address, following `kubectl get svc`'s EXTERNAL-IP.
+///
+/// A LoadBalancer publishes ingress entries in `status`, each carrying an ip or
+/// a hostname (AWS gives hostnames, most others ips); `spec.externalIPs` is a
+/// separate, manually assigned set that any service type may carry, and both
+/// are shown. An ExternalName has no address of its own — it resolves to the
+/// name it points at, which is what kubectl prints in this column.
+///
+/// A LoadBalancer with nothing yet is `<pending>` rather than empty: waiting on
+/// a cloud provider and having no external address at all are different states,
+/// and the first is the one that resolves itself.
+pub(crate) fn external_ip(svc: &Service) -> String {
+    let spec = svc.spec.as_ref();
+    let type_ = spec.and_then(|s| s.type_.as_deref()).unwrap_or("ClusterIP");
+    if type_ == "ExternalName" {
+        return spec.and_then(|s| s.external_name.clone()).unwrap_or_default();
+    }
+    let mut addresses: Vec<String> = svc
+        .status
+        .as_ref()
+        .and_then(|st| st.load_balancer.as_ref())
+        .and_then(|lb| lb.ingress.as_ref())
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|i| i.ip.clone().or_else(|| i.hostname.clone()))
+                .collect()
+        })
+        .unwrap_or_default();
+    addresses.extend(spec.and_then(|s| s.external_ips.clone()).unwrap_or_default());
+    if !addresses.is_empty() {
+        return addresses.join(", ");
+    }
+    if type_ == "LoadBalancer" {
+        return "<pending>".into();
+    }
+    String::new()
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -36,6 +81,7 @@ pub struct ListServicesOut {
 }
 
 pub(crate) fn summarise(svc: Service) -> ServiceSummary {
+    let external_ip = external_ip(&svc);
     let name = svc.metadata.name.clone().unwrap_or_default();
     let namespace = svc.metadata.namespace.clone().unwrap_or_default();
     let spec = svc.spec.as_ref();
@@ -63,6 +109,7 @@ pub(crate) fn summarise(svc: Service) -> ServiceSummary {
         namespace,
         type_,
         cluster_ip,
+        external_ip,
         ports,
         age: crate::humanize_age(svc.metadata.creation_timestamp.as_ref()),
     }
@@ -97,7 +144,9 @@ pub fn list_services_capability(cache: Arc<ClientCache>) -> Capability {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use k8s_openapi::api::core::v1::{ServicePort, ServiceSpec};
+    use k8s_openapi::api::core::v1::{
+        LoadBalancerIngress, LoadBalancerStatus, ServicePort, ServiceSpec, ServiceStatus,
+    };
     use std::path::PathBuf;
 
     #[test]
@@ -131,5 +180,124 @@ mod tests {
         assert_eq!(s.type_, "ClusterIP");
         assert_eq!(s.cluster_ip, "10.0.0.1");
         assert_eq!(s.ports, "80/TCP");
+        assert_eq!(s.external_ip, "");
+    }
+
+    fn svc(spec: ServiceSpec, status: Option<ServiceStatus>) -> Service {
+        Service {
+            metadata: kube::core::ObjectMeta {
+                name: Some("api".into()),
+                namespace: Some("default".into()),
+                ..Default::default()
+            },
+            spec: Some(spec),
+            status,
+        }
+    }
+
+    fn lb_status(ingress: Vec<LoadBalancerIngress>) -> ServiceStatus {
+        ServiceStatus {
+            load_balancer: Some(LoadBalancerStatus {
+                ingress: Some(ingress),
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn reports_a_load_balancer_ip() {
+        let s = summarise(svc(
+            ServiceSpec {
+                type_: Some("LoadBalancer".into()),
+                ..Default::default()
+            },
+            Some(lb_status(vec![LoadBalancerIngress {
+                ip: Some("34.1.2.3".into()),
+                ..Default::default()
+            }])),
+        ));
+        assert_eq!(s.external_ip, "34.1.2.3");
+    }
+
+    #[test]
+    fn reports_a_load_balancer_hostname() {
+        // AWS publishes a hostname instead of an ip; the column is empty
+        // without this even though the service is fully provisioned.
+        let s = summarise(svc(
+            ServiceSpec {
+                type_: Some("LoadBalancer".into()),
+                ..Default::default()
+            },
+            Some(lb_status(vec![LoadBalancerIngress {
+                hostname: Some("a1b2.elb.amazonaws.com".into()),
+                ..Default::default()
+            }])),
+        ));
+        assert_eq!(s.external_ip, "a1b2.elb.amazonaws.com");
+    }
+
+    #[test]
+    fn distinguishes_a_pending_load_balancer_from_having_no_address() {
+        // Waiting on a provider is a state that resolves itself; a ClusterIP
+        // with no external address never will. Both would otherwise be blank.
+        let pending = summarise(svc(
+            ServiceSpec {
+                type_: Some("LoadBalancer".into()),
+                ..Default::default()
+            },
+            None,
+        ));
+        assert_eq!(pending.external_ip, "<pending>");
+        let never = summarise(svc(
+            ServiceSpec {
+                type_: Some("ClusterIP".into()),
+                ..Default::default()
+            },
+            None,
+        ));
+        assert_eq!(never.external_ip, "");
+    }
+
+    #[test]
+    fn joins_manually_assigned_external_ips() {
+        // spec.externalIPs is set by hand and is independent of the type.
+        let s = summarise(svc(
+            ServiceSpec {
+                type_: Some("NodePort".into()),
+                external_ips: Some(vec!["192.0.2.1".into(), "192.0.2.2".into()]),
+                ..Default::default()
+            },
+            None,
+        ));
+        assert_eq!(s.external_ip, "192.0.2.1, 192.0.2.2");
+    }
+
+    #[test]
+    fn shows_both_the_load_balancer_and_the_assigned_addresses() {
+        let s = summarise(svc(
+            ServiceSpec {
+                type_: Some("LoadBalancer".into()),
+                external_ips: Some(vec!["192.0.2.1".into()]),
+                ..Default::default()
+            },
+            Some(lb_status(vec![LoadBalancerIngress {
+                ip: Some("34.1.2.3".into()),
+                ..Default::default()
+            }])),
+        ));
+        assert_eq!(s.external_ip, "34.1.2.3, 192.0.2.1");
+    }
+
+    #[test]
+    fn an_external_name_resolves_to_what_it_points_at() {
+        let s = summarise(svc(
+            ServiceSpec {
+                type_: Some("ExternalName".into()),
+                external_name: Some("db.example.com".into()),
+                ..Default::default()
+            },
+            None,
+        ));
+        assert_eq!(s.external_ip, "db.example.com");
     }
 }


### PR DESCRIPTION
Closes #264.

The service list gains an **External IP** column, and the service detail's Connection section a matching row. Both follow what `kubectl get svc` prints in that column:

| Case | Shown |
| --- | --- |
| LoadBalancer with ingress | `34.1.2.3` / `a1b2.elb.amazonaws.com` |
| LoadBalancer, nothing yet | `<pending>` |
| `spec.externalIPs` (any type) | joined, alongside any LB address |
| ExternalName | the name it resolves to |
| Otherwise | `—` |

## Details worth reviewing

**Hostnames, not just IPs.** A LoadBalancer ingress entry carries `ip` *or* `hostname` — AWS publishes hostnames — so reading only `.ip` would leave a fully provisioned service looking unassigned. There's a test for each.

**`<pending>` is deliberate.** A LoadBalancer waiting on its provider and a ClusterIP that will never have an external address would both be blank, but only the first resolves itself, and that difference is the reason someone opens this column at all.

**The rule exists twice, on purpose.** The list value comes from `k8s.listServices` (computed in `crates/kube/src/services.rs`), and the detail renders the raw object client-side, so `lib/serviceAddress.ts` expresses the same rule for that path. Both have their own tests over the same six cases. The alternative — refetching the summary for the detail, or plumbing the list row into the drawer — costs more than the duplication does.

## Tests
6 new Rust cases in `services.rs` and 8 in `serviceAddress.test.ts`, covering LB ip, LB hostname, pending vs never, manually assigned IPs, both together, ExternalName, and (on the TS side) malformed objects.

Rust: 306 passing, clippy clean. Frontend: 1141 passing, `tsc` clean.
