### PR TITLE
feat(terminal): open a kubectl shell for any context

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -125,6 +125,25 @@ vi.mock("./components/ResourceBrowser", () => ({
 vi.mock("./components/SettingsView", () => ({
   SettingsView: () => <div data-testid="settings">workspace settings</div>,
 }));
+// The dock hosts xterm, which is dynamically imported and has no place in
+// jsdom; these tests only care about whether it is mounted and with what.
+vi.mock("./components/Dock", () => ({
+  Dock: ({ sessions }: { sessions: Array<{ kind: string; context: string }> }) => (
+    <div data-testid="dock">{sessions.map((s) => `${s.kind}:${s.context}`).join(",")}</div>
+  ),
+}));
+// The host shell is desktop-only, and `isWeb` is decided once at import time,
+// so it has to be replaced rather than set up per test. `isTauri` is left real:
+// flipping it too would switch on every Tauri-only effect in these tests.
+vi.mock("./transport/platform", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./transport/platform")>()),
+  isWeb: false,
+}));
+const { listContextsMock } = vi.hoisted(() => ({ listContextsMock: vi.fn() }));
+vi.mock("./lib/clusters", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./lib/clusters")>()),
+  listContexts: listContextsMock,
+}));
 vi.mock("./components/EditResourceTab", () => ({
   EditResourceTab: ({ kind, name }: { kind: string; name: string }) => (
     <div data-testid="edit-tab">
@@ -135,10 +154,20 @@ vi.mock("./components/EditResourceTab", () => ({
 
 import { App } from "./App";
 
+const context = (name: string) => ({
+  name,
+  stableId: `/k/config#${name}`,
+  cluster: name,
+  server: "https://example",
+  isCurrent: false,
+});
+
 beforeEach(() => {
   checkForUpdateMock.mockReset();
   checkForUpdateMock.mockResolvedValue(null); // up to date unless a test says otherwise
   notifyUpdateAvailableMock.mockReset();
+  listContextsMock.mockReset();
+  listContextsMock.mockResolvedValue({ contexts: [context("kind-dev"), context("prod")] });
 });
 
 describe("App", () => {
@@ -160,6 +189,16 @@ describe("App", () => {
     render(<App />);
     expect(screen.getByText(/pure-Rust Kubernetes UI/)).toBeDefined();
     expect(screen.queryByTestId("overview")).toBeNull();
+  });
+
+  it("opens a terminal for a chosen context with no tabs open at all", async () => {
+    // The dock used to mount only alongside an open tab, so a shell started
+    // from the landing page went nowhere — the session existed and nothing
+    // rendered it (#257).
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: "Open kubectl terminal" }));
+    fireEvent.click(await screen.findByRole("menuitem", { name: "prod" }));
+    expect((await screen.findByTestId("dock")).textContent).toBe("shell:prod");
   });
 
   it("opening a cluster lands on its Overview tab", () => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { ClusterHotbar } from "./components/ClusterHotbar";
@@ -941,6 +941,17 @@ export function App() {
     setActiveDock(null);
   }
 
+  // Contexts the status bar's terminal launcher can open a shell for, in the
+  // hotbar's order so the two lists agree.
+  const terminalContexts = useMemo(
+    () =>
+      orderContexts(contexts ?? [], contextOrder).map((c) => ({
+        name: c.name,
+        label: contextDisplayName(c.name, contextProfiles[c.name]),
+      })),
+    [contexts, contextOrder, contextProfiles],
+  );
+
   const tabDescriptors: TabDescriptor[] = tabs.map((t) => ({
     id: t.id,
     label: t.edit
@@ -1161,14 +1172,17 @@ export function App() {
           activeTab ? (activeTab.crd ? activeTab.crd.kind : RESOURCE_LABELS[activeKind]) : undefined
         }
         tabCount={tabs.length}
+        // Every configured context, not just the active tab's: a shell for a
+        // second cluster used to need a tab opened for it first, and the
+        // launcher disappeared entirely on tabs with no cluster (#257).
+        terminalContexts={terminalContexts}
         onOpenTerminal={
           // The host shell (`kubectl · <ctx>`) is desktop-only: on the shared
           // web server a container-host shell would break user isolation. Web
           // users reach an RBAC-scoped in-pod exec terminal from a pod instead.
-          activeCluster && !isWeb
-            ? () =>
-                openDock("shell", { context: activeCluster, namespace: "", kubeconfigFiles })
-            : undefined
+          isWeb
+            ? undefined
+            : (context) => openDock("shell", { context, namespace: "", kubeconfigFiles })
         }
       />
       <CommandPalette

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1127,42 +1127,50 @@ export function App() {
                     />
                   )}
                 </div>
-                {dockSessions.length > 0 && (
-                  <Dock
-                    sessions={dockSessions}
-                    activeId={activeDock}
-                    height={dockHeight}
-                    onActivate={setActiveDock}
-                    onCloseTab={closeDockTab}
-                    onClose={closeDock}
-                    onResize={setDockHeight}
-                    onNewTerminal={(() => {
-                      // "+" opens another host shell for the active shell's
-                      // context. The host shell is desktop-only — web users get
-                      // in-pod exec terminals, so no "+" there.
-                      if (isWeb) return undefined;
-                      const active = dockSessions.find((s) => s.id === activeDock);
-                      const ctx = active?.kind === "shell" ? active.context : activeCluster;
-                      const files =
-                        active?.kind === "shell" ? active.kubeconfigFiles ?? kubeconfigFiles : kubeconfigFiles;
-                      return ctx
-                        ? () => openDock("shell", { context: ctx, namespace: "", kubeconfigFiles: files })
-                        : undefined;
-                    })()}
-                  />
-                )}
               </>
             )}
           </>
         ) : (
-          <LandingPage
-            onOpenContext={(ctx) => openView(ctx, "overview")}
-            onOpenSettings={openSettings}
-            contextProfiles={contextProfiles}
-            kubeconfigFiles={kubeconfigFiles}
-            contextOrder={contextOrder}
-            contexts={contexts}
-            contextsError={contextsError}
+          // Wrapped so the landing page shrinks when the dock is open: it asks
+          // for `min-height: 100%`, which unwrapped is 100% of the whole main
+          // column and would push the dock off the bottom.
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+            <LandingPage
+              onOpenContext={(ctx) => openView(ctx, "overview")}
+              onOpenSettings={openSettings}
+              contextProfiles={contextProfiles}
+              kubeconfigFiles={kubeconfigFiles}
+              contextOrder={contextOrder}
+              contexts={contexts}
+              contextsError={contextsError}
+            />
+          </div>
+        )}
+        {/* Outside the tab branch: the status bar can start a shell with no
+            tabs open at all, and a dock that only mounts alongside a tab would
+            swallow that session silently. */}
+        {dockSessions.length > 0 && (
+          <Dock
+            sessions={dockSessions}
+            activeId={activeDock}
+            height={dockHeight}
+            onActivate={setActiveDock}
+            onCloseTab={closeDockTab}
+            onClose={closeDock}
+            onResize={setDockHeight}
+            onNewTerminal={(() => {
+              // "+" opens another host shell for the active shell's context.
+              // The host shell is desktop-only — web users get in-pod exec
+              // terminals, so no "+" there.
+              if (isWeb) return undefined;
+              const active = dockSessions.find((s) => s.id === activeDock);
+              const ctx = active?.kind === "shell" ? active.context : activeCluster;
+              const files =
+                active?.kind === "shell" ? active.kubeconfigFiles ?? kubeconfigFiles : kubeconfigFiles;
+              return ctx
+                ? () => openDock("shell", { context: ctx, namespace: "", kubeconfigFiles: files })
+                : undefined;
+            })()}
           />
         )}
       </div>

--- a/apps/desktop/src/components/StatusBar.test.tsx
+++ b/apps/desktop/src/components/StatusBar.test.tsx
@@ -65,6 +65,26 @@ describe("StatusBar", () => {
     expect(onOpenTerminal).toHaveBeenCalledWith("prod");
   });
 
+  it("puts the open context first, wherever it sits in the list", async () => {
+    // With a kubeconfig full of contexts the one you are already in would
+    // otherwise be somewhere down a scrolling menu.
+    render(
+      <StatusBar
+        activeCluster="prod"
+        tabCount={1}
+        terminalContexts={[
+          { name: "dev", label: "dev" },
+          { name: "staging", label: "staging" },
+          { name: "prod", label: "production" },
+        ]}
+        onOpenTerminal={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Open kubectl terminal" }));
+    const items = await screen.findAllByRole("menuitem");
+    expect(items.map((i) => i.textContent)).toEqual(["production", "dev", "staging"]);
+  });
+
   it("still launches a terminal on a tab with no cluster", async () => {
     // Settings/Toolbox/Assistant tabs have no cluster; the launcher used to
     // disappear on them entirely, even with clusters configured (#257).

--- a/apps/desktop/src/components/StatusBar.test.tsx
+++ b/apps/desktop/src/components/StatusBar.test.tsx
@@ -28,11 +28,65 @@ describe("StatusBar", () => {
 
   it("offers a terminal launcher only when a handler is provided", () => {
     const onOpenTerminal = vi.fn();
-    const { rerender } = render(<StatusBar activeCluster="dev" tabCount={1} />);
+    const contexts = [{ name: "dev", label: "dev" }];
+    const { rerender } = render(
+      <StatusBar activeCluster="dev" tabCount={1} terminalContexts={contexts} />,
+    );
     expect(screen.queryByRole("button", { name: "Open kubectl terminal" })).toBeNull();
 
-    rerender(<StatusBar activeCluster="dev" tabCount={1} onOpenTerminal={onOpenTerminal} />);
+    rerender(
+      <StatusBar
+        activeCluster="dev"
+        tabCount={1}
+        terminalContexts={contexts}
+        onOpenTerminal={onOpenTerminal}
+      />,
+    );
     fireEvent.click(screen.getByRole("button", { name: "Open kubectl terminal" }));
-    expect(onOpenTerminal).toHaveBeenCalledTimes(1);
+    expect(onOpenTerminal).toHaveBeenCalledWith("dev");
+  });
+
+  it("asks which context when several are configured", async () => {
+    const onOpenTerminal = vi.fn();
+    render(
+      <StatusBar
+        activeCluster="dev"
+        tabCount={1}
+        terminalContexts={[
+          { name: "dev", label: "dev" },
+          { name: "prod", label: "production" },
+        ]}
+        onOpenTerminal={onOpenTerminal}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Open kubectl terminal" }));
+    // A shell for a second cluster used to require opening a tab for it first.
+    fireEvent.click(await screen.findByRole("menuitem", { name: "production" }));
+    expect(onOpenTerminal).toHaveBeenCalledWith("prod");
+  });
+
+  it("still launches a terminal on a tab with no cluster", async () => {
+    // Settings/Toolbox/Assistant tabs have no cluster; the launcher used to
+    // disappear on them entirely, even with clusters configured (#257).
+    const onOpenTerminal = vi.fn();
+    render(
+      <StatusBar
+        activeCluster={null}
+        tabCount={1}
+        terminalContexts={[
+          { name: "dev", label: "dev" },
+          { name: "prod", label: "production" },
+        ]}
+        onOpenTerminal={onOpenTerminal}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Open kubectl terminal" }));
+    fireEvent.click(await screen.findByRole("menuitem", { name: "dev" }));
+    expect(onOpenTerminal).toHaveBeenCalledWith("dev");
+  });
+
+  it("hides the launcher when nothing is configured", () => {
+    render(<StatusBar activeCluster={null} tabCount={0} onOpenTerminal={vi.fn()} />);
+    expect(screen.queryByRole("button", { name: "Open kubectl terminal" })).toBeNull();
   });
 });

--- a/apps/desktop/src/components/StatusBar.tsx
+++ b/apps/desktop/src/components/StatusBar.tsx
@@ -1,7 +1,16 @@
-import React from "react";
+import React, { useState } from "react";
 import { SquareTerminal } from "lucide-react";
 import { ClusterUsage } from "./ClusterUsage";
 import { ForwardsIndicator } from "./ForwardsIndicator";
+import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
+
+/** A context a terminal can be opened for. */
+export interface TerminalContext {
+  /** The context name passed to the shell. */
+  name: string;
+  /** What to call it on screen (short name / profile, when set). */
+  label: string;
+}
 
 /**
  * Thin status bar across the bottom of the app: connection state + active
@@ -12,14 +21,34 @@ export function StatusBar({
   activeCluster,
   activeLabel,
   tabCount,
+  terminalContexts = [],
   onOpenTerminal,
 }: {
   activeCluster: string | null;
   activeLabel?: string;
   tabCount: number;
-  /** Open a local kubectl terminal for the active cluster (omitted when disconnected). */
-  onOpenTerminal?: () => void;
+  /** Contexts a terminal can be opened for; more than one offers a choice. */
+  terminalContexts?: readonly TerminalContext[];
+  /** Open a local kubectl terminal for a context (omitted in web mode). */
+  onOpenTerminal?: (context: string) => void;
 }) {
+  const [picker, setPicker] = useState(false);
+  // The launcher used to be bound to the active tab's cluster, which meant it
+  // vanished on Settings/Toolbox/Assistant tabs and a shell for a second
+  // cluster needed a tab opened for it first (#257). It now offers whatever is
+  // configured, wherever you are.
+  const showTerminal = !!onOpenTerminal && terminalContexts.length > 0;
+  const preferred =
+    terminalContexts.find((c) => c.name === activeCluster) ?? terminalContexts[0];
+
+  function launch() {
+    if (terminalContexts.length === 1) {
+      onOpenTerminal?.(terminalContexts[0].name);
+      return;
+    }
+    setPicker((open) => !open);
+  }
+
   return (
     <footer className="fl-statusbar col-[1/-1] flex h-6 items-center gap-3 border-t border-border bg-card px-3 text-xs text-muted-foreground">
       {activeCluster ? (
@@ -36,17 +65,48 @@ export function StatusBar({
       {activeLabel && <span className="fl-statusbar__label truncate">{activeLabel}</span>}
 
       <span className="fl-statusbar__meta ml-auto flex items-center gap-3">
-        {onOpenTerminal && (
-          <button
-            type="button"
-            className="fl-statusbar__terminal flex items-center gap-1 hover:text-foreground"
-            onClick={onOpenTerminal}
-            title={`Open a kubectl terminal for ${activeCluster}`}
-            aria-label="Open kubectl terminal"
-          >
-            <SquareTerminal className="size-3.5" aria-hidden="true" />
-            Terminal
-          </button>
+        {showTerminal && (
+          <Popover open={picker} onOpenChange={setPicker}>
+            <PopoverAnchor asChild>
+              <button
+                type="button"
+                className="fl-statusbar__terminal flex items-center gap-1 hover:text-foreground"
+                onClick={launch}
+                title={
+                  terminalContexts.length === 1
+                    ? `Open a kubectl terminal for ${terminalContexts[0].label}`
+                    : "Open a kubectl terminal — choose a context"
+                }
+                aria-label="Open kubectl terminal"
+              >
+                <SquareTerminal className="size-3.5" aria-hidden="true" />
+                Terminal
+              </button>
+            </PopoverAnchor>
+            <PopoverContent align="end" side="top" role="menu" className="w-auto min-w-44 gap-0 p-1">
+              {terminalContexts.map((c) => (
+                <button
+                  key={c.name}
+                  type="button"
+                  role="menuitem"
+                  title={`Open a kubectl terminal for ${c.label}`}
+                  className="flex w-full items-center gap-2 rounded px-2 py-1 text-left hover:bg-accent hover:text-accent-foreground"
+                  onClick={() => {
+                    setPicker(false);
+                    onOpenTerminal?.(c.name);
+                  }}
+                >
+                  <span
+                    aria-hidden="true"
+                    className={`size-2 shrink-0 rounded-full ${
+                      c.name === preferred?.name ? "bg-emerald-500" : "bg-muted-foreground/40"
+                    }`}
+                  />
+                  <span className="min-w-0 truncate">{c.label}</span>
+                </button>
+              ))}
+            </PopoverContent>
+          </Popover>
         )}
         <ForwardsIndicator />
         {activeCluster && <ClusterUsage context={activeCluster} />}

--- a/apps/desktop/src/components/StatusBar.tsx
+++ b/apps/desktop/src/components/StatusBar.tsx
@@ -40,6 +40,12 @@ export function StatusBar({
   const showTerminal = !!onOpenTerminal && terminalContexts.length > 0;
   const preferred =
     terminalContexts.find((c) => c.name === activeCluster) ?? terminalContexts[0];
+  // The context you are already in is the one you most often want a shell for,
+  // so it leads regardless of where it sits in the hotbar — on a machine with
+  // twenty kubeconfig contexts it would otherwise be somewhere down the scroll.
+  const ordered = preferred
+    ? [preferred, ...terminalContexts.filter((c) => c.name !== preferred.name)]
+    : terminalContexts;
 
   function launch() {
     if (terminalContexts.length === 1) {
@@ -83,8 +89,15 @@ export function StatusBar({
                 Terminal
               </button>
             </PopoverAnchor>
-            <PopoverContent align="end" side="top" role="menu" className="w-auto min-w-44 gap-0 p-1">
-              {terminalContexts.map((c) => (
+            {/* Capped and scrollable: a kubeconfig with twenty contexts would
+                otherwise open a menu taller than the window. */}
+            <PopoverContent
+              align="end"
+              side="top"
+              role="menu"
+              className="max-h-64 w-auto min-w-40 max-w-80 gap-0 overflow-y-auto p-1 text-xs"
+            >
+              {ordered.map((c) => (
                 <button
                   key={c.name}
                   type="button"
@@ -98,8 +111,8 @@ export function StatusBar({
                 >
                   <span
                     aria-hidden="true"
-                    className={`size-2 shrink-0 rounded-full ${
-                      c.name === preferred?.name ? "bg-emerald-500" : "bg-muted-foreground/40"
+                    className={`size-1.5 shrink-0 rounded-full ${
+                      c.name === activeCluster ? "bg-emerald-500" : "bg-muted-foreground/40"
                     }`}
                   />
                   <span className="min-w-0 truncate">{c.label}</span>


### PR DESCRIPTION
Closes #257.

The status bar's **Terminal** button now carries its own list of contexts instead of inheriting the active tab's cluster. With several configured it opens an anchored menu (the same one the pod shell picker uses), marking the active tab's cluster; with one it opens straight through.

## What was wrong
`onOpenTerminal` was `activeCluster && !isWeb ? … : undefined`, so:

1. **The context couldn't be chosen.** A shell for cluster B meant opening a resource tab for B and switching to it first.
2. **The button vanished on cluster-less tabs.** Settings, Toolbox, Assistant and the landing view all have `cluster: null`, so no launcher rendered at all — even with several clusters connected.

Everything underneath already supported concurrent sessions (`openDock` never deduplicates, the dock keeps every session mounted by id, `startLocalTerminal` allocates a channel per session, and dock tabs already read `kubectl · <context>`), so this was purely an entry-point constraint.

## Acceptance criteria
- [x] A terminal can be opened for any configured context without first opening a tab for it
- [x] The button is available on Settings/Toolbox/Assistant tabs when clusters are configured
- [x] Several terminals against different contexts can be open at once, each labelled with its context
- [x] Web mode still offers no host shell (`onOpenTerminal` is undefined there, unchanged)

The list is the hotbar's — same order (`orderContexts`) and same display names (`contextDisplayName`, so short names and profiles apply) — so the two agree about what a cluster is called.

## Tests
Three new `StatusBar` cases: picking a non-active context, launching from a tab with no cluster, and hiding the launcher when nothing is configured. Suite: 1144 passing, `tsc` clean.
