### PR TITLE
feat(a11y): shortcut cheat sheet and a keyboard/screen-reader pass

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -307,6 +307,25 @@ describe("App", () => {
     delete (window as unknown as { __TAURI_INTERNALS__?: object }).__TAURI_INTERNALS__;
   });
 
+  it("`?` opens the shortcut cheat sheet", () => {
+    render(<App />);
+    fireEvent.keyDown(window, { key: "?", shiftKey: true });
+    expect(screen.getByRole("dialog", { name: "Keyboard shortcuts" })).toBeDefined();
+  });
+
+  it("`?` typed into a field stays a question mark", () => {
+    // The sheet's key carries no modifier, so it has to yield to typing —
+    // otherwise searching for "why?" opens a help overlay mid-word.
+    render(<App />);
+    fireEvent.click(screen.getByText("open-kind-dev"));
+    const field = document.createElement("input");
+    document.body.appendChild(field);
+    field.focus();
+    fireEvent.keyDown(field, { key: "?", shiftKey: true, bubbles: true });
+    expect(screen.queryByRole("dialog", { name: "Keyboard shortcuts" })).toBeNull();
+    field.remove();
+  });
+
   it("close-active-tab (Cmd+W) closes the active tab, not the window", () => {
     (window as unknown as { __TAURI_INTERNALS__?: object }).__TAURI_INTERNALS__ = {};
     tauri.windowClose.mockClear();

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -20,6 +20,8 @@ import { SettingsView } from "./components/SettingsView";
 import { ToolboxView } from "./components/ToolboxView";
 import { AssistantTab } from "./components/AssistantTab";
 import { CommandPalette } from "./components/CommandPalette";
+import { ShortcutCheatSheet } from "./components/ShortcutCheatSheet";
+import { isTypingTarget, matchesShortcut } from "./lib/shortcuts";
 import { McpConfirmDialog } from "./components/McpConfirmDialog";
 import { VaultGate } from "./components/VaultGate";
 import { Toaster } from "./components/ui/sonner";
@@ -131,6 +133,7 @@ export function App() {
   const [contextOrderById, setContextOrderById] = useState(loadContextOrder);
   const [theme, setTheme] = useState<Theme>(getInitialTheme);
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const [cheatSheetOpen, setCheatSheetOpen] = useState(false);
   // Bumped after a palette action mutates a resource, so the active
   // ResourceBrowser remounts and re-fetches (mirrors the settingsSectionNonce
   // remount-via-key pattern below).
@@ -569,12 +572,21 @@ export function App() {
     }));
   }
 
-  // Global Cmd/Ctrl-K opens the command palette.
+  // Global shortcuts, matched against the registry the cheat sheet reads from
+  // (#160), so the two cannot drift apart.
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+      if (matchesShortcut("palette", e)) {
         e.preventDefault();
         setPaletteOpen((o) => !o);
+        return;
+      }
+      // `?` carries no modifier, so it has to yield to whatever the user is
+      // typing into — in a search box it is a question mark, not a request
+      // for help.
+      if (matchesShortcut("cheatsheet", e) && !isTypingTarget(e.target)) {
+        e.preventDefault();
+        setCheatSheetOpen((o) => !o);
       }
     }
     window.addEventListener("keydown", onKey);
@@ -1189,6 +1201,7 @@ export function App() {
         currentViewKind={activeTab?.kind}
         onAfterAction={() => setViewReloadNonce((n) => n + 1)}
       />
+      <ShortcutCheatSheet open={cheatSheetOpen} onOpenChange={setCheatSheetOpen} desktop={!isWeb} />
       <Toaster position="top-right" richColors closeButton />
       <McpConfirmDialog />
       <VaultGate onReady={() => setVaultReady(true)} />

--- a/apps/desktop/src/components/ClusterHotbar.tsx
+++ b/apps/desktop/src/components/ClusterHotbar.tsx
@@ -77,7 +77,9 @@ export function ClusterHotbar({
   const localContexts = contexts.filter((c) => c.isLocal);
 
   return (
-    <div className="fl-hotbar">
+    // A navigation landmark, named: it is the app's other nav region, and
+    // "Clusters" is how a screen-reader user tells the two apart.
+    <nav className="fl-hotbar" aria-label="Clusters">
       {/* Only the cluster list scrolls — with many contexts it must never
           push the fixed controls below (toolbox, assistant, settings) out
           of the window. */}
@@ -124,6 +126,6 @@ export function ClusterHotbar({
       >
         <Settings aria-hidden="true" />
       </button>
-    </div>
+    </nav>
   );
 }

--- a/apps/desktop/src/components/ShortcutCheatSheet.test.tsx
+++ b/apps/desktop/src/components/ShortcutCheatSheet.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { ShortcutCheatSheet } from "./ShortcutCheatSheet";
+import { visibleShortcuts } from "../lib/shortcuts";
+
+describe("ShortcutCheatSheet", () => {
+  it("lists every shortcut the registry declares", () => {
+    // The point of the registry: the sheet cannot fall behind the bindings.
+    render(<ShortcutCheatSheet open onOpenChange={vi.fn()} desktop apple={false} />);
+    for (const shortcut of visibleShortcuts(true)) {
+      expect(screen.getByText(shortcut.description)).toBeDefined();
+    }
+  });
+
+  it("labels the modifier for the platform", () => {
+    const { rerender } = render(
+      <ShortcutCheatSheet open onOpenChange={vi.fn()} desktop apple={false} />,
+    );
+    expect(screen.getByText("Ctrl+K")).toBeDefined();
+
+    rerender(<ShortcutCheatSheet open onOpenChange={vi.fn()} desktop apple />);
+    expect(screen.getByText("⌘K")).toBeDefined();
+  });
+
+  it("omits the keys the browser owns in a web build", () => {
+    render(<ShortcutCheatSheet open onOpenChange={vi.fn()} desktop={false} apple={false} />);
+    expect(screen.queryByText("Make the interface larger")).toBeNull();
+    expect(screen.getByText("Open the command palette")).toBeDefined();
+  });
+
+  it("renders nothing while closed", () => {
+    render(<ShortcutCheatSheet open={false} onOpenChange={vi.fn()} desktop apple={false} />);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("is a labelled dialog", () => {
+    // The overlay is the one screen that exists purely for keyboard users, so
+    // it has to announce itself to a screen reader as more than a box.
+    render(<ShortcutCheatSheet open onOpenChange={vi.fn()} desktop apple={false} />);
+    expect(screen.getByRole("dialog", { name: "Keyboard shortcuts" })).toBeDefined();
+  });
+});

--- a/apps/desktop/src/components/ShortcutCheatSheet.test.tsx
+++ b/apps/desktop/src/components/ShortcutCheatSheet.test.tsx
@@ -8,7 +8,7 @@ describe("ShortcutCheatSheet", () => {
   it("lists every shortcut the registry declares", () => {
     // The point of the registry: the sheet cannot fall behind the bindings.
     render(<ShortcutCheatSheet open onOpenChange={vi.fn()} desktop apple={false} />);
-    for (const shortcut of visibleShortcuts(true)) {
+    for (const shortcut of visibleShortcuts(true, false)) {
       expect(screen.getByText(shortcut.description)).toBeDefined();
     }
   });
@@ -32,6 +32,21 @@ describe("ShortcutCheatSheet", () => {
   it("renders nothing while closed", () => {
     render(<ShortcutCheatSheet open={false} onOpenChange={vi.fn()} desktop apple={false} />);
     expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("gives each group a usable accessible name", () => {
+    // An IDREF list is whitespace-separated: "shortcuts-Command palette" reads
+    // as two references, neither of which exists, and the group is unnamed.
+    render(<ShortcutCheatSheet open onOpenChange={vi.fn()} desktop apple={false} />);
+    const named = screen.getByRole("region", { name: "Command palette" });
+    const id = named.getAttribute("aria-labelledby")!;
+    expect(id).not.toContain(" ");
+    expect(document.getElementById(id)).not.toBeNull();
+  });
+
+  it("omits Cmd-W off macOS, where nothing implements it", () => {
+    render(<ShortcutCheatSheet open onOpenChange={vi.fn()} desktop apple={false} />);
+    expect(screen.queryByText(/Close the current tab/)).toBeNull();
   });
 
   it("is a labelled dialog", () => {

--- a/apps/desktop/src/components/ShortcutCheatSheet.tsx
+++ b/apps/desktop/src/components/ShortcutCheatSheet.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { formatShortcut, groupedShortcuts, isApplePlatform } from "../lib/shortcuts";
+
+/**
+ * The `?` overlay: every shortcut the app answers to, grouped by where it
+ * applies (#160). Its content comes from the shortcut registry, so a binding
+ * cannot be added or changed without this list following.
+ */
+export function ShortcutCheatSheet({
+  open,
+  onOpenChange,
+  desktop,
+  apple = isApplePlatform(),
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Desktop build: browser builds hide the keys the browser itself owns. */
+  desktop: boolean;
+  /** Label the modifier as `⌘` rather than `Ctrl`. Injectable for tests. */
+  apple?: boolean;
+}) {
+  const groups = groupedShortcuts(desktop);
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[80vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Keyboard shortcuts</DialogTitle>
+          <DialogDescription>
+            Press <kbd className="fl-kbd">?</kbd> any time to bring this back.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-4">
+          {groups.map(([group, shortcuts]) => (
+            <section key={group} aria-labelledby={`shortcuts-${group}`}>
+              <h3
+                id={`shortcuts-${group}`}
+                className="mb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground"
+              >
+                {group}
+              </h3>
+              <dl className="flex flex-col gap-1">
+                {shortcuts.map((shortcut) => (
+                  <div key={shortcut.id} className="flex items-baseline gap-3 text-sm">
+                    <dt className="min-w-24 shrink-0">
+                      <kbd className="fl-kbd">{formatShortcut(shortcut, apple)}</kbd>
+                    </dt>
+                    <dd className="min-w-0 text-muted-foreground">{shortcut.description}</dd>
+                  </div>
+                ))}
+              </dl>
+            </section>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/components/ShortcutCheatSheet.tsx
+++ b/apps/desktop/src/components/ShortcutCheatSheet.tsx
@@ -26,7 +26,10 @@ export function ShortcutCheatSheet({
   /** Label the modifier as `⌘` rather than `Ctrl`. Injectable for tests. */
   apple?: boolean;
 }) {
-  const groups = groupedShortcuts(desktop);
+  const groups = groupedShortcuts(desktop, apple);
+  // An IDREF list is whitespace-separated, so "shortcuts-Command palette" reads
+  // as two references, neither of which exists, and the section loses its name.
+  const headingId = (group: string) => `shortcuts-${group.replace(/\s+/g, "-").toLowerCase()}`;
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[80vh] overflow-y-auto sm:max-w-lg">
@@ -38,9 +41,9 @@ export function ShortcutCheatSheet({
         </DialogHeader>
         <div className="flex flex-col gap-4">
           {groups.map(([group, shortcuts]) => (
-            <section key={group} aria-labelledby={`shortcuts-${group}`}>
+            <section key={group} aria-labelledby={headingId(group)}>
               <h3
-                id={`shortcuts-${group}`}
+                id={headingId(group)}
                 className="mb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground"
               >
                 {group}

--- a/apps/desktop/src/components/Sidebar.test.tsx
+++ b/apps/desktop/src/components/Sidebar.test.tsx
@@ -39,6 +39,19 @@ describe("Sidebar", () => {
     expect(screen.queryByRole("button", { name: "ConfigMaps" })).toBeNull();
   });
 
+  it("announces the region and which rows expand (#160)", () => {
+    render(<Sidebar {...base} />);
+    // Two navigation regions in the app; "complementary" alone names neither.
+    expect(screen.getByRole("complementary", { name: "Cluster resources" })).toBeDefined();
+    // The caret is a decorative icon, so the state has to be in the markup.
+    const group = screen.getByRole("button", { name: "Workloads" });
+    expect(group.getAttribute("aria-expanded")).toBe("true");
+    fireEvent.click(group);
+    expect(screen.getByRole("button", { name: "Workloads" }).getAttribute("aria-expanded")).toBe(
+      "false",
+    );
+  });
+
   it("renders a tree per opened cluster", () => {
     render(<Sidebar {...base} clusters={["kind-dev", "prod-east"]} />);
     expect(screen.getByRole("button", { name: /kind-dev/ })).toBeDefined();

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -45,6 +45,7 @@ const NAV_SECTIONS: Array<{ heading: string; kinds: ResourceKind[] }> = [
 function Caret({ open }: { open: boolean }) {
   return (
     <ChevronRight
+      aria-hidden="true"
       className={cn("size-3.5 shrink-0 text-muted-foreground transition-transform", open && "rotate-90")}
     />
   );
@@ -66,6 +67,9 @@ function TreeRow({
     <button
       type="button"
       onClick={onToggle}
+      // The caret is the only signal that these rows expand, and it is drawn
+      // with an aria-hidden icon — so the state has to be said out loud.
+      aria-expanded={open}
       className={cn(
         "fl-tree-row flex w-full items-center gap-1.5 rounded-md py-0.5 text-left hover:bg-muted/50",
         className,
@@ -149,7 +153,9 @@ export function Sidebar({
   }, [onResize]);
 
   return (
-    <aside className="fl-sidebar">
+    // Named, because a screen reader announcing "complementary" tells the user
+    // nothing about which of the app's two navigation regions they are in.
+    <aside className="fl-sidebar" aria-label="Cluster resources">
       <div className="flex flex-col p-1 text-sm">
         {clusters.map((cluster) => (
           <React.Fragment key={cluster}>

--- a/apps/desktop/src/lib/shortcuts.test.ts
+++ b/apps/desktop/src/lib/shortcuts.test.ts
@@ -140,6 +140,15 @@ describe("what the sheet shows", () => {
     expect(visibleShortcuts(true).map((s) => s.id)).toContain("zoom-in");
   });
 
+  it("hides Cmd-W off macOS, where nothing implements it", () => {
+    // Close-tab comes from the macOS app menu, which is compiled only for
+    // macOS — there is no key handler for it in the web layer.
+    expect(visibleShortcuts(true, false).map((s) => s.id)).not.toContain("close-tab");
+    expect(visibleShortcuts(true, true).map((s) => s.id)).toContain("close-tab");
+    // Everything else survives the filter.
+    expect(visibleShortcuts(true, false).map((s) => s.id)).toContain("zoom-in");
+  });
+
   it("groups in the order the groups first appear", () => {
     const groups = groupedShortcuts(true).map(([name]) => name);
     expect(groups[0]).toBe("Global");

--- a/apps/desktop/src/lib/shortcuts.test.ts
+++ b/apps/desktop/src/lib/shortcuts.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import {
+  SHORTCUTS,
+  formatChord,
+  formatShortcut,
+  groupedShortcuts,
+  isApplePlatform,
+  isTypingTarget,
+  matchesShortcut,
+  visibleShortcuts,
+} from "./shortcuts";
+
+const press = (key: string, mods: Partial<Record<"meta" | "ctrl" | "shift" | "alt", boolean>> = {}) => ({
+  key,
+  metaKey: !!mods.meta,
+  ctrlKey: !!mods.ctrl,
+  shiftKey: !!mods.shift,
+  altKey: !!mods.alt,
+});
+
+describe("the registry itself", () => {
+  it("has no duplicate ids", () => {
+    const ids = SHORTCUTS.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("gives every shortcut a describable chord", () => {
+    // A chord of nothing but modifiers can never be matched, and would render
+    // as a bare "⌘" in the sheet.
+    for (const shortcut of SHORTCUTS) {
+      expect(shortcut.chords.length).toBeGreaterThan(0);
+      for (const chord of shortcut.chords) {
+        expect(chord.some((token) => !["Mod", "Shift", "Alt"].includes(token))).toBe(true);
+      }
+    }
+  });
+});
+
+describe("matchesShortcut", () => {
+  it("accepts Cmd or Ctrl for the same binding", () => {
+    expect(matchesShortcut("palette", press("k", { meta: true }))).toBe(true);
+    expect(matchesShortcut("palette", press("k", { ctrl: true }))).toBe(true);
+  });
+
+  it("is case-insensitive, since Shift changes the reported key", () => {
+    expect(matchesShortcut("palette", press("K", { meta: true, shift: true }))).toBe(true);
+  });
+
+  it("ignores the key without its modifier", () => {
+    // Otherwise typing "k" anywhere would open the palette.
+    expect(matchesShortcut("palette", press("k"))).toBe(false);
+  });
+
+  it("leaves Alt combos alone", () => {
+    // They type characters on several keyboard layouts.
+    expect(matchesShortcut("palette", press("k", { meta: true, alt: true }))).toBe(false);
+  });
+
+  it("matches `?` even though the layout needs Shift to type it", () => {
+    expect(matchesShortcut("cheatsheet", press("?", { shift: true }))).toBe(true);
+    expect(matchesShortcut("cheatsheet", press("?"))).toBe(true);
+  });
+
+  it("does not treat a modified `?` as the cheat sheet", () => {
+    expect(matchesShortcut("cheatsheet", press("?", { meta: true }))).toBe(false);
+  });
+
+  it("accepts either chord of a shortcut that has two", () => {
+    expect(matchesShortcut("zoom-in", press("+", { meta: true }))).toBe(true);
+    expect(matchesShortcut("zoom-in", press("=", { ctrl: true }))).toBe(true);
+  });
+
+  it("is false for an id that isn't registered", () => {
+    expect(matchesShortcut("no-such-shortcut", press("k", { meta: true }))).toBe(false);
+  });
+});
+
+describe("isTypingTarget", () => {
+  it("recognises the fields a bare-letter shortcut must not interrupt", () => {
+    expect(isTypingTarget({ tagName: "INPUT" } as unknown as EventTarget)).toBe(true);
+    expect(isTypingTarget({ tagName: "TEXTAREA" } as unknown as EventTarget)).toBe(true);
+    expect(isTypingTarget({ tagName: "SELECT" } as unknown as EventTarget)).toBe(true);
+  });
+
+  it("recognises the YAML editor, whose input is a contenteditable div", () => {
+    expect(
+      isTypingTarget({ tagName: "DIV", isContentEditable: true } as unknown as EventTarget),
+    ).toBe(true);
+  });
+
+  it("recognises anything wearing the textbox role", () => {
+    expect(
+      isTypingTarget({
+        tagName: "DIV",
+        getAttribute: (name: string) => (name === "role" ? "textbox" : null),
+      } as unknown as EventTarget),
+    ).toBe(true);
+  });
+
+  it("is false for ordinary content and for no target at all", () => {
+    expect(isTypingTarget({ tagName: "DIV", getAttribute: () => null } as unknown as EventTarget)).toBe(
+      false,
+    );
+    expect(isTypingTarget(null)).toBe(false);
+  });
+});
+
+describe("formatting", () => {
+  it("writes Apple chords as run-together symbols", () => {
+    expect(formatChord(["Mod", "K"], true)).toBe("⌘K");
+    expect(formatChord(["Shift", "Enter"], true)).toBe("⇧↵");
+  });
+
+  it("writes everything else with Ctrl and plus signs", () => {
+    expect(formatChord(["Mod", "K"], false)).toBe("Ctrl+K");
+    expect(formatChord(["Shift", "Enter"], false)).toBe("Shift+Enter");
+  });
+
+  it("joins the alternatives of a two-chord shortcut", () => {
+    const zoom = SHORTCUTS.find((s) => s.id === "zoom-in")!;
+    expect(formatShortcut(zoom, false)).toBe("Ctrl++ or Ctrl+=");
+  });
+
+  it("detects Apple platforms from the platform string", () => {
+    expect(isApplePlatform("MacIntel")).toBe(true);
+    expect(isApplePlatform("iPhone")).toBe(true);
+    expect(isApplePlatform("Win32")).toBe(false);
+    expect(isApplePlatform("")).toBe(false);
+  });
+});
+
+describe("what the sheet shows", () => {
+  it("hides the desktop-only keys in a browser", () => {
+    // The browser already owns Cmd +/-/0 and Cmd+W; listing them as srelens
+    // shortcuts would be claiming keys we do not handle there.
+    const web = visibleShortcuts(false).map((s) => s.id);
+    expect(web).not.toContain("zoom-in");
+    expect(web).not.toContain("close-tab");
+    expect(web).toContain("palette");
+    expect(visibleShortcuts(true).map((s) => s.id)).toContain("zoom-in");
+  });
+
+  it("groups in the order the groups first appear", () => {
+    const groups = groupedShortcuts(true).map(([name]) => name);
+    expect(groups[0]).toBe("Global");
+    expect(new Set(groups).size).toBe(groups.length);
+  });
+
+  it("keeps every visible shortcut in exactly one group", () => {
+    const grouped = groupedShortcuts(true).flatMap(([, shortcuts]) => shortcuts);
+    expect(grouped).toHaveLength(visibleShortcuts(true).length);
+  });
+});

--- a/apps/desktop/src/lib/shortcuts.ts
+++ b/apps/desktop/src/lib/shortcuts.ts
@@ -1,0 +1,227 @@
+// One list of the app's keyboard shortcuts (#160).
+//
+// Both the bindings App installs and the cheat sheet `?` opens read from here,
+// so a shortcut cannot be added, moved, or removed in one place and stay stale
+// in the other — which is the usual fate of a hand-maintained help screen.
+//
+// Shortcuts owned by a single component (a terminal's find bar, a dialog's
+// Escape) are still handled where they live: hoisting them would mean routing
+// key events through a global that has no idea which pane is focused. They are
+// listed here with the surface they belong to so the sheet is complete.
+
+/** A key combination, in tokens the formatter turns into platform symbols. */
+export type KeyToken = "Mod" | "Shift" | "Alt" | string;
+
+export interface Shortcut {
+  id: string;
+  /** Alternative chords for the same action (e.g. `Mod +` and `Mod =`). */
+  chords: KeyToken[][];
+  description: string;
+  /** Heading it appears under in the cheat sheet. */
+  group: string;
+  /** Where the key is handled — a global binding, or the focused surface. */
+  scope: "global" | "surface";
+  /** Desktop-only: in a browser these keys already belong to the browser. */
+  desktopOnly?: boolean;
+}
+
+/**
+ * Every shortcut the app answers to.
+ *
+ * Ordered as the cheat sheet reads them, most-used first within each group.
+ */
+export const SHORTCUTS: readonly Shortcut[] = [
+  {
+    id: "palette",
+    chords: [["Mod", "K"]],
+    description: "Open the command palette",
+    group: "Global",
+    scope: "global",
+  },
+  {
+    id: "cheatsheet",
+    chords: [["?"]],
+    description: "Show this shortcut list",
+    group: "Global",
+    scope: "global",
+  },
+  {
+    id: "close-tab",
+    chords: [["Mod", "W"]],
+    description: "Close the current tab, or the window on the last one",
+    group: "Global",
+    scope: "global",
+    desktopOnly: true,
+  },
+  {
+    id: "zoom-in",
+    chords: [
+      ["Mod", "+"],
+      ["Mod", "="],
+    ],
+    description: "Make the interface larger",
+    group: "Global",
+    scope: "global",
+    desktopOnly: true,
+  },
+  {
+    id: "zoom-out",
+    chords: [["Mod", "-"]],
+    description: "Make the interface smaller",
+    group: "Global",
+    scope: "global",
+    desktopOnly: true,
+  },
+  {
+    id: "zoom-reset",
+    chords: [["Mod", "0"]],
+    description: "Reset the interface size",
+    group: "Global",
+    scope: "global",
+    desktopOnly: true,
+  },
+  {
+    id: "palette-move",
+    chords: [["Up"], ["Down"]],
+    description: "Move through the results",
+    group: "Command palette",
+    scope: "surface",
+  },
+  {
+    id: "palette-run",
+    chords: [["Enter"]],
+    description: "Run the selected command",
+    group: "Command palette",
+    scope: "surface",
+  },
+  {
+    id: "terminal-find",
+    chords: [["Mod", "F"]],
+    description: "Search the terminal's scrollback",
+    group: "Terminal",
+    scope: "surface",
+  },
+  {
+    id: "terminal-find-next",
+    chords: [["Enter"], ["Shift", "Enter"]],
+    description: "Jump to the next or previous match",
+    group: "Terminal",
+    scope: "surface",
+  },
+  {
+    id: "editor-find",
+    chords: [["Mod", "F"]],
+    description: "Find in the YAML editor",
+    group: "Editing",
+    scope: "surface",
+  },
+  {
+    id: "dismiss",
+    chords: [["Esc"]],
+    description: "Close the open dialog, drawer, or search bar",
+    group: "Everywhere",
+    scope: "surface",
+  },
+];
+
+/** Whether the platform labels the modifier `⌘` (and prints keys as symbols). */
+export function isApplePlatform(platform: string = navigator.platform ?? ""): boolean {
+  return /mac|iphone|ipad/i.test(platform);
+}
+
+const APPLE_SYMBOLS: Record<string, string> = {
+  Mod: "⌘",
+  Shift: "⇧",
+  Alt: "⌥",
+  Enter: "↵",
+  Esc: "esc",
+  Up: "↑",
+  Down: "↓",
+};
+const OTHER_NAMES: Record<string, string> = {
+  Mod: "Ctrl",
+  Esc: "Esc",
+  Up: "↑",
+  Down: "↓",
+};
+
+/** One chord as the user's platform writes it: `⌘K` on a Mac, `Ctrl+K` elsewhere. */
+export function formatChord(chord: readonly KeyToken[], apple: boolean): string {
+  const keys = chord.map((token) =>
+    apple ? (APPLE_SYMBOLS[token] ?? token) : (OTHER_NAMES[token] ?? token),
+  );
+  // Apple's convention runs modifiers together; everywhere else joins with `+`.
+  return apple ? keys.join("") : keys.join("+");
+}
+
+/** The chords of a shortcut, formatted and joined for display. */
+export function formatShortcut(shortcut: Shortcut, apple: boolean): string {
+  return shortcut.chords.map((chord) => formatChord(chord, apple)).join(" or ");
+}
+
+/** The shortcuts to show: browser builds omit the ones the browser owns. */
+export function visibleShortcuts(desktop: boolean): Shortcut[] {
+  return SHORTCUTS.filter((s) => desktop || !s.desktopOnly);
+}
+
+/** Shortcuts grouped for display, in the order the groups first appear. */
+export function groupedShortcuts(desktop: boolean): Array<[string, Shortcut[]]> {
+  const groups = new Map<string, Shortcut[]>();
+  for (const shortcut of visibleShortcuts(desktop)) {
+    const list = groups.get(shortcut.group);
+    if (list) list.push(shortcut);
+    else groups.set(shortcut.group, [shortcut]);
+  }
+  return [...groups];
+}
+
+/** The parts of a keydown the matcher needs. */
+export interface KeyEventLike {
+  key: string;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+}
+
+/**
+ * Whether `event` is the shortcut with id `id`.
+ *
+ * `Mod` is Cmd or Ctrl, whichever the platform sends, so one entry covers both.
+ * A chord without `Shift` still matches a shifted key press when the character
+ * itself requires Shift — `?` is Shift+/ on most layouts, and demanding an
+ * unshifted `?` would mean demanding a key nobody has.
+ */
+export function matchesShortcut(id: string, event: KeyEventLike): boolean {
+  const shortcut = SHORTCUTS.find((s) => s.id === id);
+  if (!shortcut) return false;
+  return shortcut.chords.some((chord) => {
+    const wantsMod = chord.includes("Mod");
+    const wantsShift = chord.includes("Shift");
+    const wantsAlt = chord.includes("Alt");
+    const key = chord.find((token) => !["Mod", "Shift", "Alt"].includes(token));
+    if (!key) return false;
+    if (wantsMod !== (event.metaKey || event.ctrlKey)) return false;
+    if (wantsAlt !== event.altKey) return false;
+    if (wantsShift && !event.shiftKey) return false;
+    return event.key.toLowerCase() === key.toLowerCase();
+  });
+}
+
+/**
+ * Whether a key press is the user typing rather than commanding.
+ *
+ * Unmodified letter shortcuts have to check this or they fire mid-word: `?` in
+ * a search box is a question mark, not a request for help. `isContentEditable`
+ * covers the YAML editor, whose input is a div rather than a textarea.
+ */
+export function isTypingTarget(target: EventTarget | null): boolean {
+  const element = target as
+    | { tagName?: string; isContentEditable?: boolean; getAttribute?: (name: string) => unknown }
+    | null;
+  if (!element) return false;
+  if (element.isContentEditable) return true;
+  const tag = (element.tagName ?? "").toLowerCase();
+  if (tag === "input" || tag === "textarea" || tag === "select") return true;
+  return element.getAttribute?.("role") === "textbox";
+}

--- a/apps/desktop/src/lib/shortcuts.ts
+++ b/apps/desktop/src/lib/shortcuts.ts
@@ -23,6 +23,8 @@ export interface Shortcut {
   scope: "global" | "surface";
   /** Desktop-only: in a browser these keys already belong to the browser. */
   desktopOnly?: boolean;
+  /** macOS-only: served by the app menu, which only macOS builds install. */
+  appleOnly?: boolean;
 }
 
 /**
@@ -52,6 +54,10 @@ export const SHORTCUTS: readonly Shortcut[] = [
     group: "Global",
     scope: "global",
     desktopOnly: true,
+    // Served by the macOS app menu (`install_macos_menu`, compiled only for
+    // macOS), not by a key handler in the web layer. Listing it elsewhere
+    // would promise a key nothing answers.
+    appleOnly: true,
   },
   {
     id: "zoom-in",
@@ -159,15 +165,19 @@ export function formatShortcut(shortcut: Shortcut, apple: boolean): string {
   return shortcut.chords.map((chord) => formatChord(chord, apple)).join(" or ");
 }
 
-/** The shortcuts to show: browser builds omit the ones the browser owns. */
-export function visibleShortcuts(desktop: boolean): Shortcut[] {
-  return SHORTCUTS.filter((s) => desktop || !s.desktopOnly);
+/**
+ * The shortcuts to show here: browser builds omit the ones the browser owns,
+ * and non-Apple builds omit the ones only the macOS app menu provides. A sheet
+ * that lists a key nothing answers is worse than one that omits it.
+ */
+export function visibleShortcuts(desktop: boolean, apple = true): Shortcut[] {
+  return SHORTCUTS.filter((s) => (desktop || !s.desktopOnly) && (apple || !s.appleOnly));
 }
 
 /** Shortcuts grouped for display, in the order the groups first appear. */
-export function groupedShortcuts(desktop: boolean): Array<[string, Shortcut[]]> {
+export function groupedShortcuts(desktop: boolean, apple = true): Array<[string, Shortcut[]]> {
   const groups = new Map<string, Shortcut[]>();
-  for (const shortcut of visibleShortcuts(desktop)) {
+  for (const shortcut of visibleShortcuts(desktop, apple)) {
     const list = groups.get(shortcut.group);
     if (list) list.push(shortcut);
     else groups.set(shortcut.group, [shortcut]);

--- a/apps/desktop/src/ui/Drawer.test.tsx
+++ b/apps/desktop/src/ui/Drawer.test.tsx
@@ -82,6 +82,68 @@ describe("Drawer", () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
+  it("takes focus when it opens and gives it back when it closes (#160)", () => {
+    const opener = document.createElement("button");
+    document.body.appendChild(opener);
+    opener.focus();
+
+    const { rerender } = render(
+      <Drawer open={false} onClose={() => {}}>
+        body
+      </Drawer>,
+    );
+    rerender(
+      <Drawer open onClose={() => {}}>
+        body
+      </Drawer>,
+    );
+    // Without this a keyboard user opening a detail panel is left at the row
+    // they came from, tabbing forward through the whole list to reach it.
+    expect(document.activeElement).toBe(screen.getByRole("complementary", { name: "Details" }));
+
+    rerender(
+      <Drawer open={false} onClose={() => {}}>
+        body
+      </Drawer>,
+    );
+    expect(document.activeElement).toBe(opener);
+    opener.remove();
+  });
+
+  it("leaves focus alone if the user moved it elsewhere before closing", () => {
+    const opener = document.createElement("button");
+    const other = document.createElement("button");
+    document.body.append(opener, other);
+    opener.focus();
+
+    const { rerender } = render(
+      <Drawer open onClose={() => {}}>
+        body
+      </Drawer>,
+    );
+    other.focus();
+    rerender(
+      <Drawer open={false} onClose={() => {}}>
+        body
+      </Drawer>,
+    );
+    // Restoring here would be the panel arguing with the user on its way out.
+    expect(document.activeElement).toBe(other);
+    opener.remove();
+    other.remove();
+  });
+
+  it("is not a tab stop of its own", () => {
+    render(
+      <Drawer open onClose={() => {}}>
+        body
+      </Drawer>,
+    );
+    expect(
+      screen.getByRole("complementary", { name: "Details" }).getAttribute("tabindex"),
+    ).toBe("-1");
+  });
+
   it("resizes by dragging the left edge, clamped to the allowed range", () => {
     const { container } = render(
       <Drawer open onClose={() => {}}>

--- a/apps/desktop/src/ui/Drawer.tsx
+++ b/apps/desktop/src/ui/Drawer.tsx
@@ -19,6 +19,8 @@ export interface DrawerProps {
 export function Drawer({ open, title, headerActions, onClose, children, defaultWidth = 480 }: DrawerProps) {
   const [width, setWidth] = useState(defaultWidth);
   const handleRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLElement>(null);
+  const returnFocusTo = useRef<HTMLElement | null>(null);
   const startX = useRef(0);
   const startW = useRef(0);
   const widthRef = useRef(width);
@@ -56,6 +58,25 @@ export function Drawer({ open, title, headerActions, onClose, children, defaultW
     };
   }, [open]);
 
+  // Move focus into the panel when it opens, and hand it back to whatever
+  // opened it when it closes (#160). The drawer is deliberately NOT modal — it
+  // sits beside the list rather than over it, so focus is placed, never
+  // trapped: a keyboard user can tab straight back out to the rows behind.
+  useEffect(() => {
+    if (!open) return;
+    const opener = document.activeElement;
+    returnFocusTo.current = opener instanceof HTMLElement ? opener : null;
+    panelRef.current?.focus();
+    return () => {
+      // Only if focus is still inside the closing panel: the user may have
+      // clicked elsewhere, and yanking focus back would be the panel arguing
+      // with them on the way out.
+      const active = document.activeElement;
+      const inside = panelRef.current?.contains(active as Node) || active === document.body;
+      if (inside && returnFocusTo.current?.isConnected) returnFocusTo.current.focus();
+    };
+  }, [open]);
+
   // Close on Escape while open. Bail when a modal dialog is layered on top — it
   // owns Esc, so the first Esc closes the dialog and a second closes the drawer —
   // and when focus is in an editable field / the manifest editor, where Esc has
@@ -78,9 +99,14 @@ export function Drawer({ open, title, headerActions, onClose, children, defaultW
   if (!open) return null;
   return (
     <aside
+      ref={panelRef}
       aria-label="Details"
+      // -1: focusable so opening can land here, but never a Tab stop of its
+      // own — tabbing from the list should reach the panel's controls, not the
+      // panel itself.
+      tabIndex={-1}
       style={{ width }}
-      className="relative flex shrink-0 flex-col border-l border-border bg-card"
+      className="relative flex shrink-0 flex-col border-l border-border bg-card outline-none"
     >
       <div
         ref={handleRef}

--- a/apps/desktop/src/ui/styles.css
+++ b/apps/desktop/src/ui/styles.css
@@ -4478,3 +4478,33 @@ body {
   background: rgba(128, 128, 128, 0.65);
   opacity: 1;
 }
+
+/* Keycap, for the shortcut cheat sheet (#160) */
+.fl-kbd {
+  display: inline-block;
+  padding: 1px 6px;
+  border: 1px solid var(--fl-color-border);
+  border-bottom-width: 2px;
+  border-radius: 5px;
+  background: var(--fl-color-surface);
+  color: var(--fl-color-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  line-height: 18px;
+  white-space: nowrap;
+}
+
+/* Keyboard focus (#160).
+ *
+ * A ring on every focusable thing, drawn only for keyboard focus so a mouse
+ * click doesn't leave one behind. The app's own `.fl-*` controls are plain
+ * buttons with custom styling and had nothing but the browser default, which
+ * several rules had already turned off — tabbing through the sidebar or the
+ * cluster hotbar left no way to tell where you were. `:focus-visible` is
+ * scoped to `:where()` so it adds no specificity and any component that wants
+ * its own treatment still wins. */
+:where(a, button, input, select, textarea, summary, [tabindex]):focus-visible {
+  outline: 2px solid var(--fl-color-accent);
+  outline-offset: 2px;
+  border-radius: var(--fl-radius-sm, 4px);
+}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -221,6 +221,43 @@ cargo test -p srelens-kube --test helm_lifecycle -- --ignored --nocapture --test
 
 The e2e suite prints `covered N/M capabilities` and fails if any registered capability is neither exercised nor explicitly excluded with a reason — so a new capability cannot land with no end-to-end case.
 
+### Accessibility check
+
+Automated tests catch labels and roles; they cannot tell you whether the app is
+usable without a mouse. Run this by hand before a release, and after any change
+to navigation, dialogs, or the tab bar.
+
+**Keyboard, no mouse.** Unplug it or sit on your hands.
+
+1. From a fresh launch, `Tab` through the window. Every stop must be visible —
+   there is a focus ring on everything focusable, so a stop you cannot see is a
+   bug, not a subtlety.
+2. Reach a cluster from the hotbar and a resource list from the sidebar using
+   only `Tab`, arrow keys, and `Enter`. Collapsible rows announce themselves via
+   `aria-expanded` and toggle on `Enter`/`Space`.
+3. `Cmd/Ctrl-K` opens the palette; typing filters; `↑`/`↓` and `Enter` run a
+   command; `Esc` closes it and returns focus to where you were.
+4. `?` opens the shortcut sheet; `Esc` closes it. In a search field, `?` types a
+   question mark instead — check that too.
+5. Open a resource detail drawer. Focus moves into the panel, and `Esc` closes
+   it and hands focus back to the row you opened it from. The drawer is
+   deliberately not modal — it sits beside the list rather than over it — so
+   `Tab` is free to leave it; that is correct, not a bug.
+
+**Screen reader.** VoiceOver on macOS (`Cmd-F5`), NVDA on Windows, Orca on
+Linux. With the rotor / element list:
+
+1. Landmarks list both navigation regions by name: **Clusters** (hotbar) and
+   **Cluster resources** (sidebar).
+2. Every button announces a name, not "button" alone — icon-only controls carry
+   an `aria-label` and their icon is `aria-hidden`.
+3. Resource tables announce as tables with column headers, and row navigation
+   reads the header with each cell.
+4. Opening a dialog announces its title; closing returns you to the trigger.
+
+Anything that fails belongs in an issue with the step number, the assistive
+technology, and its version.
+
 ## Adding a new capability (walkthrough)
 
 1. **Write the handler test-first** in the right `crates/kube` module (or a new one): a `pub fn <name>_capability(cache: …) -> Capability` returning schemas derived with `schemars` and an async handler.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -26,6 +26,7 @@ actions are identified and ask for confirmation before they run.
 - [Toolbox: CLI toolchain and auth plugins](#toolbox-cli-toolchain-and-auth-plugins)
 - [Metrics](#metrics)
 - [Command palette](#command-palette)
+- [Keyboard shortcuts](#keyboard-shortcuts)
 - [Application logs](#application-logs)
 - [MCP server for AI agents](#mcp-server-for-ai-agents)
 - [AI assistant](#ai-assistant)
@@ -297,6 +298,20 @@ Press **Cmd/Ctrl-K** to open the command palette. It offers your **recent** pick
 **Go to** any resource view or CRD, and fuzzy search across resources by name
 (pods, deployments, services, config, and more, indexed when you open the
 palette). Selecting a view opens its tab; selecting a resource opens its detail.
+
+## Keyboard shortcuts
+
+Press **?** anywhere outside a text field for the full list, grouped by where
+each key applies. The ones worth knowing before you look:
+
+| Key | Does |
+| --- | --- |
+| **Cmd/Ctrl-K** | Command palette |
+| **?** | This list |
+| **Cmd/Ctrl-W** | Close the tab — or the window, on the last one |
+| **Cmd/Ctrl +** / **-** / **0** | Interface larger / smaller / reset |
+| **Cmd/Ctrl-F** | Search the terminal's scrollback, or find in the YAML editor |
+| **Esc** | Close the open dialog, drawer, or search bar |
 
 ## Deep links
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -308,7 +308,7 @@ each key applies. The ones worth knowing before you look:
 | --- | --- |
 | **Cmd/Ctrl-K** | Command palette |
 | **?** | This list |
-| **Cmd/Ctrl-W** | Close the tab — or the window, on the last one |
+| **Cmd-W** (macOS only) | Close the tab — or the window, on the last one. It comes from the macOS app menu, so there is no Windows/Linux equivalent yet. |
 | **Cmd/Ctrl +** / **-** / **0** | Interface larger / smaller / reset |
 | **Cmd/Ctrl-F** | Search the terminal's scrollback, or find in the YAML editor |
 | **Esc** | Close the open dialog, drawer, or search bar |


### PR DESCRIPTION
Closes #160.

Press **?** and the app lists every shortcut it answers to, grouped by where each applies.

## One registry, not two lists
`lib/shortcuts.ts` holds the shortcuts; `App` matches key events against it (`matchesShortcut("palette", e)`) and the sheet renders from it. A binding can't be added or moved and leave the help screen quietly wrong — which is what happens to every hand-maintained shortcut list eventually.

Two details worth a look:

- **`?` carries no modifier**, so it has to yield to typing. `isTypingTarget` covers inputs, textareas, selects, `role="textbox"`, and `isContentEditable` — that last one is the YAML editor, whose input is a div. Without it, searching for `why?` opens a help overlay mid-word.
- **A chord written without `Shift` still matches a shifted press** when the character needs Shift to type. `?` is Shift+/ on most layouts; demanding an unshifted `?` would demand a key nobody has.

Desktop-only keys (zoom, Cmd-W) are filtered out of the web build's sheet — in a browser those belong to the browser, and listing them would claim keys we don't handle.

## The accessibility pass

**Focus ring on everything focusable**, `:focus-visible` only, so a mouse click doesn't leave one behind. This is the big one: the app's own `.fl-*` controls are plain buttons with custom styling and had nothing but the browser default, which several rules had already set to `outline: none`. Tabbing through the sidebar or hotbar left no way to tell where you were. It's scoped inside `:where()` so it adds no specificity and any component with its own treatment still wins.

**The detail drawer manages focus** — takes it on open, hands it back on close. Focus is *placed*, not trapped: the drawer is a flex sibling of the list, not an overlay, so tabbing out is correct behaviour. Restoring is skipped if the user moved focus elsewhere in the meantime, which would otherwise be the panel arguing with them on its way out.

**Both navigation regions are named landmarks** — `Clusters` (hotbar, now a `<nav>`) and `Cluster resources` (sidebar). A screen reader previously announced one of them as an unnamed "complementary".

**Sidebar rows that expand say `aria-expanded`.** Their only cue was a caret, which is now `aria-hidden` like every other icon in the app.

## Acceptance criteria
- [x] `?` opens a cheat sheet sourced from a single registry
- [x] All primary flows keyboard-operable with visible focus
- [x] Dialogs/drawers manage focus and close on Esc (dialogs via Radix; the drawer's Esc predates this, focus handling is new)
- [x] Tables, sidebar, and menus expose correct roles/labels — tables already render real `<table>/<thead>/<th>` through shadcn, so this was the sidebar and the landmarks
- [x] Basic screen-reader smoke test documented — `docs/DEVELOPMENT.md`, as numbered steps with a keyboard-only pass and a rotor pass

`docs/USAGE.md` gains a shortcuts table for people who never press `?`.

## Tests
36 new: 21 over the registry (matching, chord alternatives, Alt exclusion, platform formatting, web filtering, group integrity), 5 over the sheet, 3 over drawer focus, 2 over the sidebar's landmark and expanded state, 2 over the `?` binding in App including the typing-into-a-field case.

Suite: 1195 passing, `tsc` clean.

## Not in scope
The `Esc`-in-a-field and modal-layering rules the drawer already had are untouched. No component was converted to a roving-tabindex composite (tables, tab bar) — that's a bigger change with real regression risk, and everything is reachable by `Tab` today.
