### PR TITLE
feat(linux): package metadata, launcher entry, and an honest update story

### DIFF
--- a/apps/desktop/src-tauri/linux/srelens.desktop
+++ b/apps/desktop/src-tauri/linux/srelens.desktop
@@ -1,0 +1,32 @@
+{{!
+  Desktop entry for the .deb and .rpm packages (#35).
+
+  A copy of tauri-bundler's default template plus GenericName and Keywords,
+  which it has no fields for — those are what make the app findable by what it
+  does ("kubernetes", "k8s", "cluster") rather than only by its name in GNOME's
+  overview and KDE's launcher.
+
+  Everything else is deliberately identical to the default, including
+  StartupWMClass, which the bundler already emits so the running window is
+  matched to this entry instead of showing a generic icon, and the mime_type
+  block, which carries the srelens:// scheme handler that makes deep links work.
+
+  Variables available: categories, comment, exec, icon, name, mime_type,
+  long_description.
+}}
+[Desktop Entry]
+Categories={{categories}}
+{{#if comment}}
+Comment={{comment}}
+{{/if}}
+Exec={{exec}} %u
+StartupWMClass={{exec}}
+Icon={{icon}}
+Name={{name}}
+GenericName=Kubernetes Workspace
+Keywords=kubernetes;k8s;kubectl;cluster;container;devops;sre;helm;
+Terminal=false
+Type=Application
+{{#if mime_type}}
+MimeType={{mime_type}}
+{{/if}}

--- a/apps/desktop/src-tauri/src/updater.rs
+++ b/apps/desktop/src-tauri/src/updater.rs
@@ -49,6 +49,17 @@ fn self_updatable(os: &str, bundle: Option<BundleType>, has_dpkg: bool, has_rpm:
     }
 }
 
+/// Whether installing the update will ask for administrator rights.
+///
+/// The AppImage is rewritten in place and macOS/Windows installers run as the
+/// user, but a .deb or .rpm is applied with `dpkg -i` / `rpm -U` through
+/// pkexec (falling back to a graphical or terminal sudo). Saying so beforehand
+/// is the difference between an expected password prompt and one that appears
+/// out of nowhere over a Kubernetes console.
+fn needs_privileges(os: &str, bundle: Option<BundleType>) -> bool {
+    os == "linux" && matches!(bundle, Some(BundleType::Deb) | Some(BundleType::Rpm))
+}
+
 fn externally_managed() -> bool {
     let rpm_db = std::path::Path::new("/var/lib/rpm").exists()
         || std::path::Path::new("/usr/lib/sysimage/rpm").exists();
@@ -69,6 +80,10 @@ pub struct UpdateMeta {
     /// can't drive (e.g. pacman for the AUR package) — the UI should point at
     /// that manager instead of offering an in-app install.
     pub external: bool,
+    /// True when applying the update needs administrator rights (a .deb or
+    /// .rpm install, which runs `dpkg -i` / `rpm -U` under pkexec or sudo), so
+    /// the UI can warn before a password prompt appears unannounced.
+    pub elevates: bool,
 }
 
 #[derive(Serialize, Clone)]
@@ -102,6 +117,7 @@ pub async fn update_check(app: AppHandle, channel: String) -> Result<Option<Upda
         current_version: u.current_version.clone(),
         notes: u.body.clone(),
         external: externally_managed(),
+        elevates: needs_privileges(std::env::consts::OS, tauri::utils::platform::bundle_type()),
     }))
 }
 
@@ -179,6 +195,22 @@ mod tests {
     #[test]
     fn unknown_linux_packaging_is_externally_managed() {
         assert!(!self_updatable("linux", None, true, true));
+    }
+
+    #[test]
+    fn deb_and_rpm_updates_need_a_password_prompt() {
+        // dpkg/rpm run under pkexec or sudo; the AppImage rewrites itself in
+        // place and needs nothing.
+        assert!(needs_privileges("linux", Some(BundleType::Deb)));
+        assert!(needs_privileges("linux", Some(BundleType::Rpm)));
+        assert!(!needs_privileges("linux", Some(BundleType::AppImage)));
+    }
+
+    #[test]
+    fn other_platforms_never_prompt_for_a_password() {
+        assert!(!needs_privileges("macos", Some(BundleType::App)));
+        assert!(!needs_privileges("windows", Some(BundleType::Nsis)));
+        assert!(!needs_privileges("linux", None));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -45,16 +45,41 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "publisher": "srelens",
+    "homepage": "https://srelens.com",
+    "license": "MIT",
+    "copyright": "Copyright (c) srelens contributors",
+    "category": "DeveloperTool",
+    "shortDescription": "Kubernetes desktop workspace",
+    "longDescription": "srelens is a local-first Kubernetes desktop workspace for SREs, platform engineers, and DevOps engineers. Browse live cluster resources, inspect manifests and events, follow logs, open pod shells and port forwards, manage Helm releases, and take confirmation-gated cluster actions from one application. Cluster access uses your local kubeconfig and connects directly to the API server.",
     "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",
+      "icons/64x64.png",
       "icons/128x128.png",
       "icons/128x128@2x.png",
+      "icons/icon.png",
       "icons/icon.icns",
       "icons/icon.ico"
     ],
     "android": {
       "debugApplicationIdSuffix": ".debug"
+    },
+    "linux": {
+      "deb": {
+        "depends": [
+          "libwebkit2gtk-4.1-0",
+          "libgtk-3-0"
+        ],
+        "desktopTemplate": "linux/srelens.desktop"
+      },
+      "rpm": {
+        "depends": [
+          "webkit2gtk4.1",
+          "gtk3"
+        ],
+        "desktopTemplate": "linux/srelens.desktop"
+      }
     }
   }
 }

--- a/apps/desktop/src/components/SettingsView.test.tsx
+++ b/apps/desktop/src/components/SettingsView.test.tsx
@@ -436,6 +436,39 @@ describe("SettingsView", () => {
     expect(screen.queryByRole("button", { name: /Download & install/ })).toBeNull();
   });
 
+  it("warns before a .deb/.rpm update asks for a password (#35)", async () => {
+    updaterMocks.checkForUpdate.mockResolvedValue({
+      version: "0.2.0",
+      currentVersion: "0.1.0",
+      notes: "New things",
+      elevates: true,
+    });
+    render(
+      <SettingsView
+        theme={{ name: "slate", mode: "dark" }}
+        onThemeNameChange={() => {}}
+        onThemeModeChange={() => {}}
+        defaultNamespace=""
+        onDefaultNamespaceChange={() => {}}
+        layout={DEFAULT_WORKSPACE_LAYOUT}
+        onLayoutChange={() => {}}
+        contextProfiles={{}}
+        onContextProfilesChange={() => {}}
+        kubeconfigFiles={[]}
+        onKubeconfigFilesChange={() => {}}
+        contextOrder={[]}
+        onContextOrderChange={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Updates/ }));
+    fireEvent.click(await screen.findByRole("button", { name: "Check for updates" }));
+    expect(await screen.findByText(/0\.2\.0/)).toBeDefined();
+    // The install still goes ahead in-app; the point is that the system's
+    // password prompt doesn't arrive unannounced.
+    expect(screen.getByText(/administrator rights/)).toBeDefined();
+    expect(screen.getByRole("button", { name: /Download & install/ })).toBeDefined();
+  });
+
   it("surfaces update check failures", async () => {
     updaterMocks.checkForUpdate.mockRejectedValue(new Error("endpoint unreachable"));
     render(

--- a/apps/desktop/src/components/SettingsView.tsx
+++ b/apps/desktop/src/components/SettingsView.tsx
@@ -1128,13 +1128,21 @@ export function SettingsView({
                     {updateState.update.notes && <ReleaseNotes notes={updateState.update.notes} />}
                     {updateState.update.external ? (
                       <p className="fl-settings-update__status">
-                        This install is managed by your system package manager — update it there
-                        (AUR: <code>paru -Syu</code> or <code>yay -Syu</code>).
+                        This install is managed by your system package manager — update it there.
+                        On Arch (AUR): <code>paru -Syu</code> or <code>yay -Syu</code>.
                       </p>
                     ) : (
-                      <Button onClick={() => void startInstall()}>
-                        <Download data-icon="inline-start" /> Download &amp; install
-                      </Button>
+                      <>
+                        {updateState.update.elevates && (
+                          <p className="fl-settings-update__status">
+                            Installing a package update needs administrator rights, so your system
+                            will ask for your password.
+                          </p>
+                        )}
+                        <Button onClick={() => void startInstall()}>
+                          <Download data-icon="inline-start" /> Download &amp; install
+                        </Button>
+                      </>
                     )}
                   </div>
                 )}

--- a/apps/desktop/src/lib/updateNotifier.test.ts
+++ b/apps/desktop/src/lib/updateNotifier.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect, vi } from "vitest";
 import { checkForUpdateAndNotify } from "./updateNotifier";
 import type { UpdateMeta } from "./updater";
 
-const update: UpdateMeta = { version: "0.3.0", currentVersion: "0.2.0", notes: "", external: false };
+const update: UpdateMeta = {
+  version: "0.3.0",
+  currentVersion: "0.2.0",
+  notes: "",
+  external: false,
+  elevates: false,
+};
 
 describe("checkForUpdateAndNotify", () => {
   it("notifies when a newer version is available", async () => {

--- a/apps/desktop/src/lib/updater.test.ts
+++ b/apps/desktop/src/lib/updater.test.ts
@@ -29,6 +29,7 @@ describe("checkForUpdate", () => {
       current_version: "0.1.0",
       notes: "### Features\n- things",
       external: false,
+      elevates: true,
     });
     const meta = await checkForUpdate("dev");
     expect(invokeCommandMock).toHaveBeenCalledWith("update_check", { channel: "dev" });
@@ -37,7 +38,14 @@ describe("checkForUpdate", () => {
       currentVersion: "0.1.0",
       notes: "### Features\n- things",
       external: false,
+      elevates: true,
     });
+  });
+
+  it("treats a backend that says nothing about privileges as needing none", async () => {
+    // Defaulting the other way would warn about a password prompt on macOS.
+    invokeCommandMock.mockResolvedValue({ version: "0.2.0", current_version: "0.1.0", notes: null });
+    expect((await checkForUpdate("stable"))?.elevates).toBe(false);
   });
 
   it("defaults notes to an empty string", async () => {

--- a/apps/desktop/src/lib/updater.ts
+++ b/apps/desktop/src/lib/updater.ts
@@ -11,6 +11,12 @@ export interface UpdateMeta {
    * (e.g. pacman for the AUR package) — offer guidance, not an install button.
    */
   external: boolean;
+  /**
+   * Applying the update needs administrator rights — a .deb or .rpm install,
+   * which runs `dpkg -i` / `rpm -U` under pkexec or sudo. Warn first, so the
+   * password prompt isn't a surprise.
+   */
+  elevates: boolean;
 }
 
 interface RawUpdateMeta {
@@ -18,6 +24,7 @@ interface RawUpdateMeta {
   current_version: string;
   notes: string | null;
   external?: boolean;
+  elevates?: boolean;
 }
 
 interface RawProgress {
@@ -34,6 +41,7 @@ export async function checkForUpdate(channel: UpdateChannel): Promise<UpdateMeta
     currentVersion: meta.current_version,
     notes: meta.notes ?? "",
     external: meta.external ?? false,
+    elevates: meta.elevates ?? false,
   };
 }
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -215,10 +215,28 @@ works this out for itself rather than asking you:
 | `.deb` / `.rpm` | Downloads the new package and applies it with `dpkg -i` / `rpm -U`. This needs administrator rights, so your desktop will ask for your password; Settings warns you before the prompt appears. |
 | AUR (`srelens-bin`) | Not offered. pacman owns the files, so srelens points you at `paru -Syu` / `yay -Syu` instead of desyncing its database. |
 
-If a package update fails — no `pkexec`, no polkit agent, a locked package
-database — nothing is left half-applied: download the new `.deb`/`.rpm` from
+A package update can fail in two different ways, and they need different
+answers.
+
+**Before anything is applied** — no `pkexec` or polkit agent, the password
+prompt cancelled, a locked package database. Nothing has changed; download the
+new `.deb`/`.rpm` from
 [Releases](https://github.com/srelens/srelens/releases/latest) and install it
-the same way you installed the first one.
+the way you installed the first one.
+
+**Part-way through** — `dpkg`/`rpm` accepted the package and then failed while
+unpacking or configuring it (a full disk, an unmet dependency, a failing
+maintainer script). The package is left unpacked or unconfigured and srelens may
+not start until the package manager finishes the job:
+
+```bash
+sudo dpkg --configure -a        # Debian/Ubuntu: finish a half-configured install
+sudo apt --fix-broken install   # …and pull in whatever it was missing
+sudo dnf reinstall srelens      # Fedora/RHEL
+```
+
+The error `dpkg` or `rpm` printed names the actual cause; fix that first, since
+the commands above will otherwise stop at the same point.
 
 ## Uninstalling
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -32,8 +32,7 @@ Pick the package for your distribution:
 | Fedora/RHEL | `srelens-<version>-1.x86_64.rpm` | `sudo dnf install ./srelens-*.rpm` |
 
 Requires a WebKitGTK runtime (`webkit2gtk-4.1`); the deb/rpm pull it in
-automatically. The in-app updater applies to the **AppImage** build; update
-deb/rpm installs by downloading the new package.
+automatically. See [Updating](#updating) for how each format updates itself.
 
 The AppImage deliberately does **not** bundle the Wayland client libraries
 (`libwayland-client/cursor/egl/server`) — bundling them breaks EGL on hosts with
@@ -205,8 +204,21 @@ srelens checks for updates from **Settings → Updates**:
 - **Stable** — released versions (default).
 - **Dev** — rolling pre-releases for early access.
 
-Updates are cryptographically signed and verified before install. On Linux, the
-in-app updater applies to the AppImage build only.
+Updates are cryptographically signed and verified before install.
+
+On Linux what happens next depends on how srelens was installed, and the app
+works this out for itself rather than asking you:
+
+| Install | In-app update |
+| --- | --- |
+| AppImage | Replaces the AppImage in place. Nothing else needed. |
+| `.deb` / `.rpm` | Downloads the new package and applies it with `dpkg -i` / `rpm -U`. This needs administrator rights, so your desktop will ask for your password; Settings warns you before the prompt appears. |
+| AUR (`srelens-bin`) | Not offered. pacman owns the files, so srelens points you at `paru -Syu` / `yay -Syu` instead of desyncing its database. |
+
+If a package update fails — no `pkexec`, no polkit agent, a locked package
+database — nothing is left half-applied: download the new `.deb`/`.rpm` from
+[Releases](https://github.com/srelens/srelens/releases/latest) and install it
+the same way you installed the first one.
 
 ## Uninstalling
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -232,8 +232,12 @@ not start until the package manager finishes the job:
 ```bash
 sudo dpkg --configure -a        # Debian/Ubuntu: finish a half-configured install
 sudo apt --fix-broken install   # …and pull in whatever it was missing
-sudo dnf reinstall srelens      # Fedora/RHEL
+sudo dnf reinstall ./srelens-*.rpm   # Fedora/RHEL, from the downloaded file
 ```
+
+srelens is distributed as a downloaded package rather than from a repository,
+so the `dnf` line needs the `.rpm` file itself — plain `dnf reinstall srelens`
+has nowhere to fetch it from and fails.
 
 The error `dpkg` or `rpm` printed names the actual cause; fix that first, since
 the commands above will otherwise stop at the same point.


### PR DESCRIPTION
Closes #35 (except the last bullet — see the end).

## Package metadata
`apt show srelens` was nearly empty: no description, homepage, license, maintainer, or category. Added `publisher`, `homepage`, `license`, `copyright`, `category`, `shortDescription`, `longDescription`, plus the WebKitGTK/GTK runtime dependencies under each distribution's own package names.

## Launcher entry
A `desktopTemplate` — tauri-bundler's default plus two things it has no config fields for:

- **`Keywords`** (`kubernetes;k8s;kubectl;cluster;…`) and **`GenericName`**, so the app is findable by what it does rather than only by name.
- **`Exec={{exec}} %u`**. The entry already advertises `x-scheme-handler/srelens` in `MimeType` (from `deep_link_protocols`), but without `%u` the URL is never passed to the process — a `srelens://` link would launch the app and drop what it was pointing at.

`StartupWMClass` was already in the bundler's default template, so that bullet needed nothing. The icon list gains 64px and 512px so the installed hicolor set covers what launchers actually request.

The template is a verbatim copy of the upstream default plus those lines, including the `{{#if mime_type}}` block — dropping that would silently break deep links.

## The update story was wrong
`docs/INSTALL.md` said the in-app updater is AppImage-only. That stopped being true: `compose-latest.cjs` publishes `linux-x86_64-deb` and `linux-x86_64-rpm` entries, the plugin looks up `{os}-{arch}-{installer}` before `{os}-{arch}`, and `install_deb`/`install_rpm` apply them with `dpkg -i` / `rpm -U`.

What it *didn't* do is say that this needs root. `try_install_with_privileges` runs `pkexec`, then a graphical sudo, then terminal sudo — so the first sign a user got was a password prompt appearing over a Kubernetes console. `update_check` now reports `elevates`, and Settings warns before the button.

| Install | In-app update |
| --- | --- |
| AppImage | Replaced in place |
| `.deb` / `.rpm` | Applied with `dpkg -i` / `rpm -U`, asks for a password |
| AUR | Not offered — points at `paru -Syu` (this predates the PR) |

## Tests
2 Rust cases over `needs_privileges`, 2 frontend cases (the Settings warning, and that a backend which says nothing about privileges defaults to *not* warning — the other default would warn on macOS).

Rust: updater suite green. Frontend: 1170 passing, `tsc` clean.

## Left open
**AppImage update end-to-end** can't be verified without cutting a release — it needs a published `latest.json` and a real older build to update *from*. Worth doing as part of the next release rather than claiming it here. Everything else in the issue is done, so I'd suggest closing on merge and tracking the verification with the release.
