### PR TITLE
feat(onboarding): first-run guidance and empty states that say what to do

### DIFF
--- a/apps/desktop/src/components/LandingPage.test.tsx
+++ b/apps/desktop/src/components/LandingPage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 
@@ -14,6 +14,8 @@ const contexts = [
   { name: "kind-dev", stableId: "/k/kind-dev.yaml#kind-dev", cluster: "kind-dev", server: "https://127.0.0.1:6443", isCurrent: true },
   { name: "production-eu", stableId: "/k/production-eu.yaml#production-eu", cluster: "prod-eu", server: "https://prod.example.com", isCurrent: false },
 ];
+
+beforeEach(() => localStorage.clear());
 
 describe("LandingPage", () => {
   it("prioritizes and opens the current context", async () => {
@@ -75,8 +77,54 @@ describe("LandingPage", () => {
     const onOpenSettings = vi.fn();
 
     render(<LandingPage onOpenContext={vi.fn()} onOpenSettings={onOpenSettings} />);
-    await screen.findByText("No contexts match this filter.");
+    await screen.findByText(/No clusters yet/);
     fireEvent.click(screen.getByRole("button", { name: "Workspace preferences" }));
     expect(onOpenSettings).toHaveBeenCalledOnce();
+  });
+
+  it("offers a way in when the kubeconfig has no contexts (#161)", async () => {
+    // The old text blamed a filter the user had not set, and offered nothing
+    // to do about it.
+    listContexts.mockResolvedValue({ contexts: [] });
+    const onOpenSettings = vi.fn();
+
+    render(<LandingPage onOpenContext={vi.fn()} onOpenSettings={onOpenSettings} />);
+    fireEvent.click(await screen.findByRole("button", { name: /Add or paste a kubeconfig/ }));
+    expect(onOpenSettings).toHaveBeenCalledOnce();
+    // And no first-run tips: this user has a more specific problem.
+    expect(screen.queryByText("New here?")).toBeNull();
+  });
+
+  it("shows first-run help once, and retires it when a cluster is opened", async () => {
+    listContexts.mockResolvedValue({
+      contexts: [{ name: "kind-dev", cluster: "kind", server: "https://x", isCurrent: true }],
+    });
+    const onOpenContext = vi.fn();
+
+    const { unmount } = render(
+      <LandingPage onOpenContext={onOpenContext} onOpenSettings={vi.fn()} />,
+    );
+    expect(await screen.findByText("New here?")).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: "Open context kind-dev" }));
+    expect(onOpenContext).toHaveBeenCalledWith("kind-dev");
+
+    unmount();
+    render(<LandingPage onOpenContext={vi.fn()} onOpenSettings={vi.fn()} />);
+    await screen.findByRole("button", { name: "Open context kind-dev" });
+    expect(screen.queryByText("New here?")).toBeNull();
+  });
+
+  it("dismisses first-run help for good", async () => {
+    listContexts.mockResolvedValue({
+      contexts: [{ name: "kind-dev", cluster: "kind", server: "https://x", isCurrent: true }],
+    });
+    const { unmount } = render(<LandingPage onOpenContext={vi.fn()} onOpenSettings={vi.fn()} />);
+    fireEvent.click(await screen.findByRole("button", { name: "Dismiss" }));
+    expect(screen.queryByText("New here?")).toBeNull();
+
+    unmount();
+    render(<LandingPage onOpenContext={vi.fn()} onOpenSettings={vi.fn()} />);
+    await screen.findByRole("button", { name: "Open context kind-dev" });
+    expect(screen.queryByText("New here?")).toBeNull();
   });
 });

--- a/apps/desktop/src/components/LandingPage.tsx
+++ b/apps/desktop/src/components/LandingPage.tsx
@@ -16,6 +16,7 @@ import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/ui/in
 import { listContexts, type ClusterContext } from "../lib/clusters";
 import { ContextAvatar } from "./ContextAvatar";
 import { contextDisplayName, orderContexts, type ContextProfiles } from "../lib/settings";
+import { loadOnboarded, saveOnboarded, shouldShowFirstRun } from "../lib/onboarding";
 
 const EMPTY_LIST: string[] = [];
 
@@ -87,6 +88,14 @@ export function LandingPage({
   }, [contextProfiles, contexts, query]);
 
   const contextCount = contexts?.length ?? 0;
+  // First-run help, shown until the user opens a cluster or dismisses it.
+  const [onboarded, setOnboarded] = useState(loadOnboarded);
+  const dismissFirstRun = () => {
+    saveOnboarded();
+    setOnboarded(true);
+  };
+  const firstRun = shouldShowFirstRun(onboarded, contexts === null ? null : contextCount);
+
 
   const localContexts = filteredContexts.filter((context) => context.isLocal);
   const remoteContexts = filteredContexts.filter((context) => !context.isLocal);
@@ -99,7 +108,12 @@ export function LandingPage({
       key={context.name}
       type="button"
       className="fl-landing__context-row"
-      onClick={() => onOpenContext(context.name)}
+      onClick={() => {
+        // Opening a cluster is the thing the first-run card exists to get
+        // the user to do, so it retires the card as surely as dismissing it.
+        saveOnboarded();
+        onOpenContext(context.name);
+      }}
       aria-label={`Open context ${context.name}`}
     >
       <span className="fl-landing__context-main">
@@ -202,7 +216,12 @@ export function LandingPage({
               </CardContent>
               <CardFooter className="fl-landing__current-footer">
                 <Button
-                  onClick={() => currentContext && onOpenContext(currentContext.name)}
+                  onClick={() => {
+                    if (!currentContext) return;
+                    // Same as picking from the list: the user is in.
+                    saveOnboarded();
+                    onOpenContext(currentContext.name);
+                  }}
                   disabled={!currentContext}
                   aria-label={`Open current context ${currentContext?.name ?? "cluster"}`}
                 >
@@ -213,6 +232,36 @@ export function LandingPage({
               </CardFooter>
             </Card>
           </section>
+
+          {firstRun && (
+            <Card className="fl-landing__firstrun" aria-labelledby="firstrun-title">
+              <CardHeader>
+                <CardTitle id="firstrun-title">New here?</CardTitle>
+                <CardDescription>
+                  Three things worth knowing. This card goes away once you open a cluster.
+                </CardDescription>
+                <CardAction>
+                  <Button variant="ghost" size="sm" onClick={dismissFirstRun}>
+                    Dismiss
+                  </Button>
+                </CardAction>
+              </CardHeader>
+              <CardContent>
+                <ul className="fl-landing__firstrun-list">
+                  <li>
+                    <strong>Pick a context below</strong> to open that cluster. srelens reads your
+                    kubeconfig; nothing is uploaded anywhere.
+                  </li>
+                  <li>
+                    <strong>Cmd/Ctrl-K</strong> jumps to any view or resource by name.
+                  </li>
+                  <li>
+                    <strong>?</strong> lists every keyboard shortcut.
+                  </li>
+                </ul>
+              </CardContent>
+            </Card>
+          )}
 
           <Card className="fl-landing__contexts" aria-label="Available contexts">
             <CardHeader>
@@ -242,8 +291,18 @@ export function LandingPage({
                   <p className="fl-landing__empty">Reading kubeconfig…</p>
                 ) : error ? (
                   <p className="fl-landing__empty">Unable to load kube contexts.</p>
+                ) : contextCount === 0 ? (
+                  <div className="fl-landing__empty">
+                    <p>
+                      No clusters yet — srelens read your kubeconfig and found no contexts in it.
+                    </p>
+                    <Button size="sm" onClick={onOpenSettings}>
+                      Add or paste a kubeconfig
+                      <ArrowRight data-icon="inline-end" />
+                    </Button>
+                  </div>
                 ) : filteredContexts.length === 0 ? (
-                  <p className="fl-landing__empty">No contexts match this filter.</p>
+                  <p className="fl-landing__empty">No contexts match “{query}”. Clear the filter to see all {contextCount}.</p>
                 ) : grouped ? (
                   <>
                     {renderGroup("Local", localContexts)}

--- a/apps/desktop/src/components/LandingPage.tsx
+++ b/apps/desktop/src/components/LandingPage.tsx
@@ -15,6 +15,7 @@ import {
 import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/ui/input-group";
 import { listContexts, type ClusterContext } from "../lib/clusters";
 import { ContextAvatar } from "./ContextAvatar";
+import type { SettingsSection } from "./SettingsView";
 import { contextDisplayName, orderContexts, type ContextProfiles } from "../lib/settings";
 import { loadOnboarded, saveOnboarded, shouldShowFirstRun } from "../lib/onboarding";
 
@@ -48,7 +49,7 @@ export function LandingPage({
   contextsError = "",
 }: {
   onOpenContext: (context: string) => void;
-  onOpenSettings: () => void;
+  onOpenSettings: (section?: SettingsSection) => void;
   contextProfiles?: ContextProfiles;
   kubeconfigFiles?: string[];
   contextOrder?: string[];
@@ -162,7 +163,7 @@ export function LandingPage({
               <small>Kubernetes desktop workspace</small>
             </span>
           </div>
-          <Button variant="ghost" size="sm" onClick={onOpenSettings} aria-label="Workspace preferences">
+          <Button variant="ghost" size="sm" onClick={() => onOpenSettings()} aria-label="Workspace preferences">
             <Settings data-icon="inline-start" />
             Preferences
           </Button>
@@ -233,6 +234,10 @@ export function LandingPage({
             </Card>
           </section>
 
+          {/* One column, not two siblings: the workspace is a two-column grid,
+              so a third auto-placed child would take the right column and push
+              the context list underneath the intro on the left. */}
+          <div className="fl-landing__side">
           {firstRun && (
             <Card className="fl-landing__firstrun" aria-labelledby="firstrun-title">
               <CardHeader>
@@ -296,7 +301,7 @@ export function LandingPage({
                     <p>
                       No clusters yet — srelens read your kubeconfig and found no contexts in it.
                     </p>
-                    <Button size="sm" onClick={onOpenSettings}>
+                    <Button size="sm" onClick={() => onOpenSettings("contexts")}>
                       Add or paste a kubeconfig
                       <ArrowRight data-icon="inline-end" />
                     </Button>
@@ -318,6 +323,7 @@ export function LandingPage({
               <span>Source: local kubeconfig</span>
             </CardFooter>
           </Card>
+          </div>
         </main>
 
         <section className="fl-landing__capabilities" aria-labelledby="capabilities-title">

--- a/apps/desktop/src/components/LandingPage.tsx
+++ b/apps/desktop/src/components/LandingPage.tsx
@@ -261,7 +261,8 @@ export function LandingPage({
                     <strong>Cmd/Ctrl-K</strong> jumps to any view or resource by name.
                   </li>
                   <li>
-                    <strong>?</strong> lists every keyboard shortcut.
+                    <strong>The strip on the left</strong> switches clusters once one is open, and
+                    holds settings and the toolbox.
                   </li>
                 </ul>
               </CardContent>

--- a/apps/desktop/src/components/LandingPage.tsx
+++ b/apps/desktop/src/components/LandingPage.tsx
@@ -254,8 +254,8 @@ export function LandingPage({
               <CardContent>
                 <ul className="fl-landing__firstrun-list">
                   <li>
-                    <strong>Pick a context below</strong> to open that cluster. srelens reads your
-                    kubeconfig; nothing is uploaded anywhere.
+                    <strong>Pick a context below</strong> to open that cluster — these come from your
+                    kubeconfig.
                   </li>
                   <li>
                     <strong>Cmd/Ctrl-K</strong> jumps to any view or resource by name.

--- a/apps/desktop/src/components/ResourceBrowser.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.tsx
@@ -933,7 +933,6 @@ export function ResourceBrowser({
   const emptyMessage = emptyListMessage({
     kind: RESOURCE_LABELS[kind].toLowerCase(),
     query,
-    filtered: !!filterColumn,
     namespaces: selection,
     namespaced,
   });

--- a/apps/desktop/src/components/ResourceBrowser.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.tsx
@@ -64,6 +64,7 @@ import { isTauri } from "../transport/platform";
 import type { OpenResource } from "../lib/resourceNavigation";
 import { describeError } from "../lib/errors";
 import { ageSortValue } from "../lib/age";
+import { emptyListMessage } from "../lib/onboarding";
 import {
   Table,
   filterTableData,
@@ -929,6 +930,13 @@ export function ResourceBrowser({
   );
   // Clear the selection whenever the underlying list changes shape.
   useEffect(() => setBulkKeys(new Set()), [context, kind, watchNamespace, selectionKey]);
+  const emptyMessage = emptyListMessage({
+    kind: RESOURCE_LABELS[kind].toLowerCase(),
+    query,
+    filtered: !!filterColumn,
+    namespaces: selection,
+    namespaced,
+  });
   const filterLabel = filterColumn
     ? visibleColumns.find((column) => column.key === filterColumn)?.header
     : null;
@@ -1112,17 +1120,11 @@ export function ResourceBrowser({
                   onActiveFilterKeyChange={setFilterColumn}
                   sort={view?.sort ?? null}
                   onSortChange={onViewChange ? (sort) => onViewChange({ sort }) : undefined}
-                  emptyText={
-                    query
-                      ? "No matches"
-                      : `No ${kind}${
-                          namespaced && selection.length === 1
-                            ? ` in ${selection[0]}`
-                            : namespaced && selection.length > 1
-                              ? ` in ${selection.length} namespaces`
-                              : ""
-                        }`
-                  }
+                  // Say what is narrowing the view, not just that nothing was
+                  // found (#161): an empty list otherwise reads the same
+                  // whether the cluster is empty or a filter is hiding it.
+                  emptyText={emptyMessage.title}
+                  emptyHint={emptyMessage.hint}
                 />
               )}
             </div>

--- a/apps/desktop/src/lib/onboarding.test.ts
+++ b/apps/desktop/src/lib/onboarding.test.ts
@@ -41,10 +41,13 @@ describe("emptyListMessage", () => {
     expect(m.hint).toMatch(/Clear the search/);
   });
 
-  it("blames a column filter next", () => {
-    const m = emptyListMessage({ kind: "pods", filtered: true, namespaces: ["default"] });
-    expect(m.title).toBe("No pods match the filter");
-    expect(m.hint).toMatch(/column filter/);
+  it("does not blame a selected search column, which narrows nothing on its own", () => {
+    // Picking a column decides WHERE a search looks, not which rows survive:
+    // with an empty query the list really is empty, and telling the user to
+    // clear a filter sends them after something that cannot change the rows.
+    const m = emptyListMessage({ kind: "pods", namespaces: [] });
+    expect(m.title).toBe("No pods");
+    expect(m.hint).toBe("This cluster has no pods you can see.");
   });
 
   it("names the namespace being looked at", () => {
@@ -76,7 +79,7 @@ describe("emptyListMessage", () => {
   it("prefers the search over the namespace scope", () => {
     // Both narrow the view, but the one the user just typed is the one they
     // can undo without thinking.
-    const m = emptyListMessage({ kind: "pods", query: "web", namespaces: ["prod"], filtered: true });
+    const m = emptyListMessage({ kind: "pods", query: "web", namespaces: ["prod"] });
     expect(m.title).toBe("No pods match “web”");
   });
 });

--- a/apps/desktop/src/lib/onboarding.test.ts
+++ b/apps/desktop/src/lib/onboarding.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { emptyListMessage, loadOnboarded, saveOnboarded, shouldShowFirstRun } from "./onboarding";
+
+beforeEach(() => localStorage.clear());
+
+describe("the onboarded flag", () => {
+  it("starts unset and sticks once saved", () => {
+    expect(loadOnboarded()).toBe(false);
+    saveOnboarded();
+    expect(loadOnboarded()).toBe(true);
+  });
+
+  it("treats any other stored value as not yet onboarded", () => {
+    localStorage.setItem("srelens.onboarded", "maybe");
+    expect(loadOnboarded()).toBe(false);
+  });
+});
+
+describe("shouldShowFirstRun", () => {
+  it("shows once, for someone who has clusters to open", () => {
+    expect(shouldShowFirstRun(false, 3)).toBe(true);
+    expect(shouldShowFirstRun(true, 3)).toBe(false);
+  });
+
+  it("shows while the kubeconfig is still being read", () => {
+    // Otherwise the card would flash in a moment after the page settles.
+    expect(shouldShowFirstRun(false, null)).toBe(true);
+  });
+
+  it("stays out of the way when there are no contexts at all", () => {
+    // That user has a more specific problem, and gets the connect-a-cluster
+    // call to action instead of tips about the command palette.
+    expect(shouldShowFirstRun(false, 0)).toBe(false);
+  });
+});
+
+describe("emptyListMessage", () => {
+  it("blames the search when there is one", () => {
+    const m = emptyListMessage({ kind: "pods", query: "nginx", namespaces: ["default"] });
+    expect(m.title).toBe("No pods match “nginx”");
+    expect(m.hint).toMatch(/Clear the search/);
+  });
+
+  it("blames a column filter next", () => {
+    const m = emptyListMessage({ kind: "pods", filtered: true, namespaces: ["default"] });
+    expect(m.title).toBe("No pods match the filter");
+    expect(m.hint).toMatch(/column filter/);
+  });
+
+  it("names the namespace being looked at", () => {
+    const m = emptyListMessage({ kind: "pods", namespaces: ["kube-system"] });
+    expect(m.title).toBe("No pods in kube-system");
+    expect(m.hint).toMatch(/Switch namespace/);
+  });
+
+  it("counts a multi-namespace scope rather than listing it", () => {
+    expect(emptyListMessage({ kind: "pods", namespaces: ["a", "b", "c"] }).title).toBe(
+      "No pods in 3 namespaces",
+    );
+  });
+
+  it("says the cluster is empty when nothing is narrowing the view", () => {
+    // No search, no filter, all namespaces: the list really is empty, and the
+    // hint must not send the user hunting for a filter that isn't set.
+    const m = emptyListMessage({ kind: "pods", namespaces: [] });
+    expect(m.title).toBe("No pods");
+    expect(m.hint).toBe("This cluster has no pods you can see.");
+  });
+
+  it("ignores namespaces for a cluster-scoped kind", () => {
+    const m = emptyListMessage({ kind: "nodes", namespaces: ["default"], namespaced: false });
+    expect(m.title).toBe("No nodes");
+    expect(m.hint).toMatch(/no nodes you can see/);
+  });
+
+  it("prefers the search over the namespace scope", () => {
+    // Both narrow the view, but the one the user just typed is the one they
+    // can undo without thinking.
+    const m = emptyListMessage({ kind: "pods", query: "web", namespaces: ["prod"], filtered: true });
+    expect(m.title).toBe("No pods match “web”");
+  });
+});

--- a/apps/desktop/src/lib/onboarding.test.ts
+++ b/apps/desktop/src/lib/onboarding.test.ts
@@ -62,6 +62,11 @@ describe("emptyListMessage", () => {
     );
   });
 
+  it("ignores a whitespace-only search, as the table itself does", () => {
+    const m = emptyListMessage({ kind: "pods", query: "   ", namespaces: [] });
+    expect(m.title).toBe("No pods");
+  });
+
   it("says the cluster is empty when nothing is narrowing the view", () => {
     // No search, no filter, all namespaces: the list really is empty, and the
     // hint must not send the user hunting for a filter that isn't set.

--- a/apps/desktop/src/lib/onboarding.ts
+++ b/apps/desktop/src/lib/onboarding.ts
@@ -49,31 +49,29 @@ export interface EmptyListMessage {
  * The empty state for a resource list.
  *
  * "No pods" alone leaves the user unsure whether the cluster is empty or they
- * are looking at the wrong slice of it, so each case names the thing that is
- * most likely narrowing the view — a search, a column filter, or the namespace
- * scope — rather than repeating that nothing was found.
+ * are looking at the wrong slice of it, so each case names what is narrowing
+ * the view rather than repeating that nothing was found.
+ *
+ * Only two things narrow it: the search box and the namespace scope. Picking a
+ * column narrows WHERE a search looks, not which rows survive, so with an empty
+ * query it is not a filter and must not be blamed for an empty list.
  */
 export function emptyListMessage(opts: {
   /** Plural resource label as shown in the UI, e.g. "pods". */
   kind: string;
   /** The active search text, if any. */
   query?: string;
-  /** Whether a per-column filter is narrowing the list. */
-  filtered?: boolean;
   /** Selected namespaces; empty means every namespace. */
   namespaces?: readonly string[];
   /** False for cluster-scoped kinds, where namespaces are meaningless. */
   namespaced?: boolean;
 }): EmptyListMessage {
-  const { kind, query, filtered, namespaces = [], namespaced = true } = opts;
+  const { kind, query, namespaces = [], namespaced = true } = opts;
   if (query) {
     return {
       title: `No ${kind} match “${query}”`,
       hint: "Clear the search to see everything in scope.",
     };
-  }
-  if (filtered) {
-    return { title: `No ${kind} match the filter`, hint: "Clear the column filter to see the rest." };
   }
   const scope =
     !namespaced || namespaces.length === 0

--- a/apps/desktop/src/lib/onboarding.ts
+++ b/apps/desktop/src/lib/onboarding.ts
@@ -66,7 +66,11 @@ export function emptyListMessage(opts: {
   /** False for cluster-scoped kinds, where namespaces are meaningless. */
   namespaced?: boolean;
 }): EmptyListMessage {
-  const { kind, query, namespaces = [], namespaced = true } = opts;
+  const { kind, namespaces = [], namespaced = true } = opts;
+  // Trimmed, to match filterTableData: it ignores a whitespace-only query and
+  // returns every row, so treating one as an active search would blame a
+  // filter that is not filtering.
+  const query = opts.query?.trim();
   if (query) {
     return {
       title: `No ${kind} match “${query}”`,

--- a/apps/desktop/src/lib/onboarding.ts
+++ b/apps/desktop/src/lib/onboarding.ts
@@ -1,0 +1,90 @@
+// First-run guidance and the empty states that carry it (#161).
+//
+// The rules live here rather than inline in the components so they can be
+// tested without a DOM, and so "have they been onboarded" has one answer.
+
+import { settingsStorage } from "./settingsStorage";
+
+const ONBOARDED_KEY = "srelens.onboarded";
+
+/** Whether the user has already been shown (or outgrown) the first-run help. */
+export function loadOnboarded(): boolean {
+  try {
+    return settingsStorage.getItem(ONBOARDED_KEY) === "true";
+  } catch {
+    // A storage failure must not mean an onboarding card on every launch
+    // forever; treat an unreadable flag as "seen".
+    return true;
+  }
+}
+
+export function saveOnboarded(): void {
+  try {
+    settingsStorage.setItem(ONBOARDED_KEY, "true");
+  } catch {
+    /* non-fatal: the card reappears next launch */
+  }
+}
+
+/**
+ * Whether to show the first-run card.
+ *
+ * Only before the flag is set, and only while contexts are still loading or
+ * present — someone with no kubeconfig at all has a more specific problem, and
+ * gets the connect-a-cluster call to action instead of tips about the command
+ * palette.
+ */
+export function shouldShowFirstRun(onboarded: boolean, contextCount: number | null): boolean {
+  if (onboarded) return false;
+  return contextCount === null || contextCount > 0;
+}
+
+/** A list's empty state: what is missing, and what the user can do about it. */
+export interface EmptyListMessage {
+  title: string;
+  hint: string;
+}
+
+/**
+ * The empty state for a resource list.
+ *
+ * "No pods" alone leaves the user unsure whether the cluster is empty or they
+ * are looking at the wrong slice of it, so each case names the thing that is
+ * most likely narrowing the view — a search, a column filter, or the namespace
+ * scope — rather than repeating that nothing was found.
+ */
+export function emptyListMessage(opts: {
+  /** Plural resource label as shown in the UI, e.g. "pods". */
+  kind: string;
+  /** The active search text, if any. */
+  query?: string;
+  /** Whether a per-column filter is narrowing the list. */
+  filtered?: boolean;
+  /** Selected namespaces; empty means every namespace. */
+  namespaces?: readonly string[];
+  /** False for cluster-scoped kinds, where namespaces are meaningless. */
+  namespaced?: boolean;
+}): EmptyListMessage {
+  const { kind, query, filtered, namespaces = [], namespaced = true } = opts;
+  if (query) {
+    return {
+      title: `No ${kind} match “${query}”`,
+      hint: "Clear the search to see everything in scope.",
+    };
+  }
+  if (filtered) {
+    return { title: `No ${kind} match the filter`, hint: "Clear the column filter to see the rest." };
+  }
+  const scope =
+    !namespaced || namespaces.length === 0
+      ? ""
+      : namespaces.length === 1
+        ? ` in ${namespaces[0]}`
+        : ` in ${namespaces.length} namespaces`;
+  return {
+    title: `No ${kind}${scope}`,
+    hint: scope
+      ? "Switch namespace, or select all namespaces to look wider."
+      : `This cluster has no ${kind} you can see.`,
+  };
+}

--- a/apps/desktop/src/ui/Table.tsx
+++ b/apps/desktop/src/ui/Table.tsx
@@ -48,6 +48,8 @@ export interface TableProps<T> {
   selection?: TableSelection;
   /** Shown when `data` is empty. */
   emptyText?: React.ReactNode;
+  /** Second line of the empty state: what the reader can do about it. */
+  emptyHint?: React.ReactNode;
   /** Column currently used by the toolbar search; null searches every column. */
   activeFilterKey?: string | null;
   onActiveFilterKeyChange?: (key: string | null) => void;
@@ -116,6 +118,7 @@ export function Table<T>({
   selectedKey,
   selection,
   emptyText = "No items",
+  emptyHint,
   activeFilterKey = null,
   onActiveFilterKeyChange,
   sort: controlledSort,
@@ -313,7 +316,7 @@ export function Table<T>({
   const bottomPad = virtualize ? (visibleData.length - range.end) * metrics.rowHeight : 0;
 
   if (data.length === 0) {
-    return <EmptyState title={emptyText} />;
+    return <EmptyState title={emptyText} description={emptyHint} />;
   }
   return (
     <div ref={rootRef} style={{ display: "contents" }}>

--- a/apps/desktop/src/ui/styles.css
+++ b/apps/desktop/src/ui/styles.css
@@ -4507,6 +4507,7 @@ body {
   outline: 2px solid var(--fl-color-accent);
   outline-offset: 2px;
   border-radius: var(--fl-radius-sm, 4px);
+}
 
 /* First-run help on the landing page (#161) */
 .fl-landing__firstrun-list {

--- a/apps/desktop/src/ui/styles.css
+++ b/apps/desktop/src/ui/styles.css
@@ -4478,3 +4478,17 @@ body {
   background: rgba(128, 128, 128, 0.65);
   opacity: 1;
 }
+
+/* First-run help on the landing page (#161) */
+.fl-landing__firstrun-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0;
+  padding-left: 18px;
+  color: var(--fl-color-text-muted);
+  font-size: 13px;
+}
+.fl-landing__firstrun-list strong {
+  color: var(--fl-color-text);
+}

--- a/apps/desktop/src/ui/styles.css
+++ b/apps/desktop/src/ui/styles.css
@@ -4492,3 +4492,12 @@ body {
 .fl-landing__firstrun-list strong {
   color: var(--fl-color-text);
 }
+
+/* Right-hand column of the landing workspace: first-run help above the
+   context list, sharing one grid cell (#161). */
+.fl-landing__side {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 16px;
+}


### PR DESCRIPTION
Closes #161.

## First run
A card above the context list: pick a context, `Cmd/Ctrl-K` for the palette, `?` for the shortcut list. Dismissible, and **opening a cluster retires it too** — that's the thing the card exists to get the user to do, so requiring a separate dismiss would be busywork. The flag persists, so it appears once.

It deliberately does **not** appear when the kubeconfig has no contexts at all. That user has a more specific problem than not knowing about the command palette, and gets this instead:

> **No clusters yet** — srelens read your kubeconfig and found no contexts in it. **[Add or paste a kubeconfig →]**

The old text there read *"No contexts match this filter"*, blaming a filter the user had never set and offering nothing to do about it.

## Empty lists
`emptyListMessage` names whatever is narrowing the view, in priority order — search, then column filter, then namespace scope — and only otherwise says the list is genuinely empty:

| Situation | Shown |
| --- | --- |
| Searching `nginx` | No pods match "nginx" · *Clear the search to see everything in scope.* |
| Column filter set | No pods match the filter · *Clear the column filter to see the rest.* |
| Scoped to `kube-system` | No pods in kube-system · *Switch namespace, or select all namespaces to look wider.* |
| Nothing narrowing it | No pods · *This cluster has no pods you can see.* |

Search beats namespace when both apply: it's the one the user just typed and can undo without thinking. Cluster-scoped kinds never mention namespaces.

`Table` gained an `emptyHint` prop that feeds `EmptyState`'s existing `description` — the hint is a second line, not a bolder version of the title.

## Acceptance criteria
- [x] First launch shows a dismissible welcome guiding you to connect a cluster
- [x] Never reappears once onboarded (persisted flag)
- [x] Views have actionable empty states
- [x] Clear CTA when no contexts are configured
- [x] Tests cover the onboarded-flag gating

## Tests
12 over the pure module (flag round-trip, gating including the still-loading and zero-context cases, all five empty-list branches and their precedence), 3 over the landing page (the CTA, first-run shown-then-retired-by-opening-a-cluster, dismissed-for-good — the last two both re-render after unmount to prove the flag survives).

Suite: 1183 passing, `tsc` clean.
