### PR TITLE
chore(docker): pin base images by digest and keep them moving

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,20 @@ version: 2
 # per dependency on top of that would bury the updates that actually need a
 # human to look at them.
 updates:
+  # The Dockerfile's base images are pinned by digest, which freezes them at
+  # whatever was current the day they were pinned — including the CVEs. A pin
+  # without something moving it forward is worse than a tag, so the docker
+  # ecosystem is watched here too.
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: "chore(docker)"
+    labels:
+      - dependencies
+
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # ---- Stage 1: build the frontend bundle -------------------------------------
-FROM node:24-slim AS frontend
+FROM node:24-slim@sha256:3638d9a6fe4030bd716be989438248074489337ba3275657f93595428be4fc03 AS frontend
 RUN corepack enable && corepack prepare pnpm@9 --activate
 WORKDIR /src
 COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
@@ -11,7 +11,7 @@ COPY apps/desktop apps/desktop
 RUN pnpm --filter @srelens/desktop build
 
 # ---- Stage 2: build the headless server binary ------------------------------
-FROM rust:1-slim-bookworm AS backend
+FROM rust:1-slim-bookworm@sha256:2775a09d208ff0d7c1f50490c45b62db929e87ba1dcbc3f2132ac71a704bcdd3 AS backend
 WORKDIR /src
 # Only C toolchain + perl are needed (no GTK/webkit — this binary isn't Tauri).
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -25,7 +25,7 @@ RUN cargo build --release -p srelens-server --bin srelens-server
 RUN strip target/release/srelens-server
 
 # ---- Stage 3: slim runtime --------------------------------------------------
-FROM debian:bookworm-slim AS runtime
+FROM debian:bookworm-slim@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241 AS runtime
 ARG KUBECTL_VERSION=v1.36.3
 # Helm is pinned to the 3.x line on purpose: Helm 4 has breaking CLI/behavior
 # changes the helm capabilities aren't validated against yet.


### PR DESCRIPTION
Closes code-scanning alert #31 (Scorecard **Pinned-Dependencies**, 3 instances).

The Dockerfile built from floating tags, so what shipped in an image depended on what Docker Hub served that day — the same class of problem the action pinning in #230 fixed for CI. All three stages are now pinned by digest, with the tag kept alongside so the line still reads as `debian:bookworm-slim@sha256:…`.

The debian digest matches the one Scorecard suggested in its remediation tip; the other two were resolved the same way, straight from the registry manifest.

**Dependabot now watches `docker` too.** A digest freezes the image at whatever was current the day it was pinned — CVEs included — so pinning with nothing to move it forward just trades a supply-chain risk for a patching one.

Verified with a full `docker build`: succeeds on the pinned images.