### PR TITLE
ci(release): least-privilege GITHUB_TOKEN in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,11 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
+# Read-only by default; the jobs that publish declare `contents: write` for
+# themselves (#38). A job added later therefore starts with no write access
+# rather than silently inheriting it.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   # Auto-versioning (main only): compute the next semver from Conventional
@@ -41,6 +44,9 @@ jobs:
   # so it doesn't re-trigger). Outputs the new version + whether to release.
   version:
     runs-on: ubuntu-22.04
+    # Commits the version bump back to main.
+    permissions:
+      contents: write
     outputs:
       version: ${{ steps.compute.outputs.version }}
       release: ${{ steps.compute.outputs.release }}
@@ -192,6 +198,9 @@ jobs:
     needs: version
     if: needs.version.outputs.release == 'true' && github.ref_name == 'main'
     runs-on: ubuntu-22.04
+    # Builds and drives the app against kind; touches nothing in the repo.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Linux dependencies
@@ -690,6 +699,9 @@ jobs:
     needs: [version, build]
     if: ${{ always() && needs.build.result == 'success' && github.ref_name == 'main' && needs.version.outputs.release == 'true' }}
     runs-on: ubuntu-22.04
+    # Reads the Releases API to compare asset sizes; writes nothing.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -933,6 +945,12 @@ jobs:
     # plain HTTPS, which only works once the release is out of draft.
     needs: [version, build, publish-release]
     if: ${{ github.ref_name == 'main' && needs.publish-release.result == 'success' && needs.version.outputs.release == 'true' }}
+    # The called workflow declares `contents: read` for itself; the AUR push
+    # authenticates with its own SSH deploy key, not GITHUB_TOKEN. Repeated
+    # here because a reusable workflow cannot be granted more than its caller
+    # holds, so this is the ceiling, not a duplicate.
+    permissions:
+      contents: read
     uses: ./.github/workflows/aur-publish.yml
     with:
       version: ${{ needs.version.outputs.version }}


### PR DESCRIPTION
Closes code-scanning alert #38 (Scorecard **Token-Permissions**, high, 6 instances).

## The actual problem
The workflow set `contents: write` at the **top level**, so every job held the right to commit to the repository whether it needed it or not — and a job added later would inherit it silently. That last part is what the check is really about; the five publishing jobs that already declared write were never the issue.

## After

```
top-level          contents: read
├─ version         write   commits the version bump back to main
├─ build           write   tauri-action uploads installers
├─ release-notes   write   gh release edit / prunes old pre-releases
├─ updater-manifest write  uploads latest.json
├─ sign-artifacts  write   uploads .asc signatures
├─ publish-release write   flips the draft to published
├─ smoke-full      read
├─ size-baseline   read    reads the Releases API only
└─ aur             read
```

**No job is left inheriting** — `version`, `smoke-full`, `size-baseline` and `aur` previously had no block at all.

Two things worth a look:

- **The six `contents: write` jobs keep it.** There is no narrower scope for release assets; `contents: write` is the minimum that lets a job create or edit a release, and Scorecard doesn't penalise it on jobs doing recognised packaging work.
- **`aur` states `contents: read` at the call site** even though the called workflow declares it too. A reusable workflow cannot be granted more than its caller holds, so this is the ceiling rather than a duplicate. The AUR push authenticates with its own SSH deploy key, not `GITHUB_TOKEN`.

`docker` and `docker-manifest` were already correct (`contents: read` + `packages: write`) and are untouched.

## How to verify — please read
**Nothing here runs on a pull request.** This workflow is exercised by a release, so CI on this PR proves nothing about it. The safe sequence is to merge and let the **next dev pre-release** (the daily 18:00 UTC run) exercise the whole path — build, upload, manifest, signing — at no cost, and treat that as the acceptance test before a stable release goes near it.

I verified the structure by parsing the YAML and enumerating every job's resolved scope, which is what the table above is; I could not verify runtime behaviour.