### PR TITLE
ci: don't cancel runs on dev and main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,18 @@ on:
   pull_request:
     branches: [dev, main]
 
-# Cancel superseded runs on pull requests only. On dev and main every merge is
-# a push to the SAME ref, so cancelling there meant each merge killed the run
-# started by the one before it: the badge read "failing" (GitHub scores a
-# cancelled run as not-success) and, worse, those merge commits were never
-# actually tested — the tree only got a verdict when a merge happened to be the
-# last one for a while.
+# Pull requests share a per-ref group and cancel each other: a superseded run
+# tests a commit nobody will merge, so killing it saves minutes and loses
+# nothing.
+#
+# Pushes get a group of their OWN, keyed on the commit. Grouping them per-ref
+# was what made the badge read "failing" — every merge to dev is a push to the
+# same ref, so each one cancelled the run before it, and those merge commits
+# were never tested. Turning off cancel-in-progress alone does NOT fix that:
+# a group holds one pending run, so a third push still evicts the queued
+# second one. Only a unique group per commit lets every merge run.
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,15 @@ on:
   pull_request:
     branches: [dev, main]
 
+# Cancel superseded runs on pull requests only. On dev and main every merge is
+# a push to the SAME ref, so cancelling there meant each merge killed the run
+# started by the one before it: the badge read "failing" (GitHub scores a
+# cancelled run as not-success) and, worse, those merge commits were never
+# actually tested — the tree only got a verdict when a merge happened to be the
+# last one for a while.
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
The README badge reads **failing** while nothing is broken.

The last completed runs on `dev` were `cancelled`, not failed, and GitHub scores a cancelled run as not-success — so the badge flips.

## Cause

```yaml
concurrency:
  group: ci-${{ github.ref }}
  cancel-in-progress: true
```

Every merge to `dev` is a push to the **same ref**, so the group key is identical for all of them. Merging #287, #288 and #289 in quick succession meant each merge cancelled the run the previous one had started. The busier the merge queue, the more runs die — which is why it looks like it fails *always*.

## The part that matters more than the badge

A cancelled run means **that merge commit was never tested**. The tree only gets a real verdict when a merge happens to be the last one for a while. The badge is just the visible symptom of a gap in coverage of `dev` itself.

## Fix

```yaml
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Pull requests still cancel superseded runs — that's where a stale result is genuinely worthless and where the CI minutes are worth saving. Pushes to `dev` and `main` always run to completion.

`release.yml` and `aur-publish.yml` already set `cancel-in-progress: false` for their own reasons (a half-cancelled release leaves partial assets), so `ci.yml` was the only workflow with this.

## Verification

This PR's own run exercises the pull-request side: it still cancels on a force-push. The push side is verified by the first merge to `dev` after this lands running to completion instead of being cancelled by the next one — and the badge going green with it.