### PR TITLE
fix(docker): install pnpm with npm, since Node 26 has no corepack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,10 @@
 
 # ---- Stage 1: build the frontend bundle -------------------------------------
 FROM node:26-slim@sha256:4ebb5ace66f15a24c14c492e01a8beeed4fddf970a856109f5126e703e5fe503 AS frontend
-RUN corepack enable && corepack prepare pnpm@9 --activate
+# pnpm via npm, not corepack: Node 26 ships without corepack (it was unbundled
+# upstream), so `corepack enable` is a command-not-found in this image. The
+# pinned major is what pnpm-lock.yaml was written by.
+RUN npm install -g pnpm@9
 WORKDIR /src
 COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
 COPY apps/desktop/package.json apps/desktop/package.json


### PR DESCRIPTION
Fixes the two `docker image` job failures in the [dev release run](https://github.com/srelens/srelens/actions/runs/32146408067).

## What broke

```
/bin/sh: 1: corepack: not found
process "/bin/sh -c corepack enable && corepack prepare pnpm@9 --activate"
did not complete successfully: exit code: 127
```

Node unbundled corepack, so it is simply absent from `node:26-slim`. Confirmed by running both images:

| Image | node | corepack |
| --- | --- | --- |
| `node:24-slim@sha256:3638d9…` | v24.19.0 | `/usr/local/bin/corepack` |
| `node:26-slim@sha256:4ebb5a…` | v26.7.0 | **not found** |

## Where it came from

The 24 → 26 bump (46f9065) was a dependabot PR — opened because #281 added the `docker` ecosystem to dependabot. The pin gained a way to move forward, and the first thing it moved to removed the tool the build depended on. That's the mechanism working as intended; it just wasn't comfortable.

## Fix

```diff
-RUN corepack enable && corepack prepare pnpm@9 --activate
+RUN npm install -g pnpm@9
```

npm ships in every Node image and isn't going anywhere. The major is pinned to what `pnpm-lock.yaml` was written by, so nothing about resolution changes, and `--frozen-lockfile` still governs the install.

## Verification

Built the `frontend` stage locally against the pinned digest — succeeds.

## Context: the rest of that release run was healthy

Worth recording, since this was the dry run for the new release machinery:

| | |
| --- | --- |
| all four desktop builds (Win, macOS ×2, Linux) | **pass** |
| `sign-artifacts` — first real GPG signing run (#33) | **pass** |
| `updater-manifest`, `release-notes` | **pass** |
| `version` under the new least-privilege token (#289) | **pass** |
| docker images | fail (this PR) |

`docker manifest` and `publish-release` skipped as downstream consequences, not independent failures. So the pipeline changes that had never run in CI all worked; the only casualty was a base-image bump.