### PR TITLE
fix(release): size-baseline needs write to read a draft release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -699,9 +699,12 @@ jobs:
     needs: [version, build]
     if: ${{ always() && needs.build.result == 'success' && github.ref_name == 'main' && needs.version.outputs.release == 'true' }}
     runs-on: ubuntu-22.04
-    # Reads the Releases API to compare asset sizes; writes nothing.
+    # `contents: write` despite writing nothing: the release it compares is
+    # still a DRAFT at this point, and GitHub shows draft releases only to
+    # callers with push access. With `contents: read` the API reports the tag
+    # as not found and the job fails, which is what happened to v0.7.0.
     permissions:
-      contents: read
+      contents: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0


### PR DESCRIPTION
Fixes the `size-baseline` failure in the v0.7.0 release run.

```
No release found for tag srelens-v0.7.0. Is GITHUB_TOKEN set (drafts need auth)?
srelens/srelens has no release tagged srelens-v0.7.0 (drafts need GITHUB_TOKEN)
```

## My regression, from #289

The least-privilege pass gave `size-baseline` `contents: read` on the reasoning that it only *reads* the Releases API. That reasoning was wrong for this job specifically: **the release it compares is still a draft when it runs**, and GitHub shows draft releases only to callers with push access. `contents: write` is the scope that maps to push, so it's the only one that can see the draft.

The job still writes nothing — the comment now says so explicitly, because `write` on a read-only job looks like a mistake otherwise and the next person to audit permissions would be right to try tightening it again.

## The gate worked

`publish-release` depends on `size-baseline`, so the release **stayed a draft** rather than publishing unverified. That's the fail-safe behaving exactly as designed — the cost was a stuck draft, not a bad release.

## What this does not fix

v0.7.0 is currently a draft with all 27 assets built and signed. This PR stops it happening again; it does not unstick that draft, since the release workflow runs from `main`'s copy of the file and re-running failed jobs uses the original commit's workflow. Unsticking options are in the PR discussion.