### PR TITLE
fix(kube): select the rustls ring provider explicitly

### DIFF
--- a/crates/kube/Cargo.toml
+++ b/crates/kube/Cargo.toml
@@ -14,7 +14,9 @@ serde_json = "1"
 schemars = "0.8"
 thiserror = "1"
 tokio = { version = "1", features = ["fs", "time", "net", "io-util", "process"] }
-kube = { version = "4", default-features = false, features = ["client", "config", "rustls-tls", "runtime", "ws"] }
+# `ring` is explicit: kube 4 split the rustls crypto provider out of
+# `rustls-tls`, and without it rustls panics when it builds a TLS config.
+kube = { version = "4", default-features = false, features = ["client", "config", "rustls-tls", "ring", "runtime", "ws"] }
 k8s-openapi = { version = "0.28", features = ["v1_34"] }
 futures = "0.3"
 base64 = "0.22"

--- a/crates/kube/src/connect.rs
+++ b/crates/kube/src/connect.rs
@@ -508,6 +508,20 @@ pub fn test_cluster_connection_capability() -> Capability {
 mod tests {
     use super::*;
 
+    /// kube's `rustls-tls` feature no longer selects a crypto provider on its
+    /// own -- kube 4 split `ring` and `aws-lc-rs` out into separate features.
+    /// Without one of them rustls cannot resolve a process-level provider and
+    /// `Client::try_from` panics the first time it builds a TLS config.
+    ///
+    /// This only bites when the crate is built on its own: a workspace build
+    /// unifies `ring` in from a sibling crate and hides it. CI runs the
+    /// kind-bound suites as `cargo test -p srelens-kube`, so guard that.
+    #[tokio::test]
+    async fn building_a_client_selects_a_rustls_crypto_provider() {
+        let config = kube::Config::new("https://127.0.0.1:6443".parse().expect("uri"));
+        Client::try_from(config).expect("client builds without a rustls provider panic");
+    }
+
     fn tmp_dir(label: &str) -> PathBuf {
         static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
         let dir = std::env::temp_dir().join(format!(


### PR DESCRIPTION
Fixes the `backend` job on `dev`, red since #294 merged. A regression I introduced there.

## What broke

`cargo llvm-cov -p srelens-kube --test helm_lifecycle` panics:

```
thread 'full_helm_lifecycle_with_values' panicked at rustls-0.23.41/src/crypto/mod.rs:249:
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
```

## Root cause

kube 4 split the rustls crypto provider out of `rustls-tls` into separate opt-in features:

```toml
aws-lc-rs = ["hyper-rustls?/aws-lc-rs"]
ring      = ["hyper-rustls?/ring"]
rustls-tls = ["rustls", "hyper-rustls", ...]   # no provider
```

The kube 0.96 → 4.2 upgrade in 018dda6 carried `rustls-tls` across unchanged, so no provider was selected and rustls panicked the first time it built a TLS config. Comparing the resolved feature set for `-p srelens-kube` shows it directly:

| | rustls features |
|---|---|
| before (kube 0.96) | `... ring, tls12, std` |
| after (kube 4.2) | `... tls12, std` — **no provider** |

## Why CI caught it and local runs didn't

`cargo test --workspace` unifies `hyper-rustls/ring` in from a sibling crate, which masks the gap completely. CI builds `-p srelens-kube` in isolation for the kind-bound suites, where nothing supplies it — so the workspace suite stayed green (1067 passing) while the isolated build panicked. `helm_lifecycle` is also `--ignored` and needs a cluster, so it never ran locally either.

## The fix

Enable `ring` explicitly, restoring what kube 0.96's `rustls-tls` used to imply. `ring` rather than `aws-lc-rs` keeps the existing crypto backend and build profile.

Also adds a regression test that builds a client through `Client::try_from`, the same call the failing test reaches. It reproduces the panic in milliseconds with no cluster, so the isolated build stays guarded even though `helm_lifecycle` can only run in CI. I verified it genuinely guards the fix by reverting the feature — it panics without it and passes with it.

## Verification

- `cargo test -p srelens-kube` (the isolated configuration that was failing) — **307 passed, 0 failed**.
- `cargo test --workspace` — **1068 passed, 0 failed**.
- `cargo check --workspace --all-targets` — clean.
- `osv-scanner scan source --lockfile=Cargo.lock` — still exit 0, alert #32 stays cleared.
- No `Cargo.lock` churn; this only changes feature selection.

## Noted, not fixed

`srelens-llm` also resolves rustls with no provider. It's untouched by this change and CI never builds it in isolation (only `--workspace`, `-p srelens-desktop`, `-p srelens-kube`), so it's latent rather than breaking anything today — worth a follow-up if that crate ever gets its own test target.
