### PR TITLE
release: dev → main (0.7.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,19 @@ on:
   pull_request:
     branches: [dev, main]
 
+# Pull requests share a per-ref group and cancel each other: a superseded run
+# tests a commit nobody will merge, so killing it saves minutes and loses
+# nothing.
+#
+# Pushes get a group of their OWN, keyed on the commit. Grouping them per-ref
+# was what made the badge read "failing" — every merge to dev is a push to the
+# same ref, so each one cancelled the run before it, and those merge commits
+# were never tested. Turning off cancel-in-progress alone does NOT fix that:
+# a group holds one pending run, so a third push still evicts the queued
+# second one. Only a unique group per commit lets every merge run.
 concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  group: ci-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -699,9 +699,12 @@ jobs:
     needs: [version, build]
     if: ${{ always() && needs.build.result == 'success' && github.ref_name == 'main' && needs.version.outputs.release == 'true' }}
     runs-on: ubuntu-22.04
-    # Reads the Releases API to compare asset sizes; writes nothing.
+    # `contents: write` despite writing nothing: the release it compares is
+    # still a DRAFT at this point, and GitHub shows draft releases only to
+    # callers with push access. With `contents: read` the API reports the tag
+    # as not found and the job fails, which is what happened to v0.7.0.
     permissions:
-      contents: read
+      contents: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "anyhow"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +166,12 @@ dependencies = [
  "cpufeatures 0.2.17",
  "password-hash",
 ]
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "arrayvec"
@@ -383,7 +406,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.24.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -412,14 +435,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
+name = "backon"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
 dependencies = [
- "getrandom 0.2.17",
- "instant",
- "rand 0.8.6",
+ "fastrand",
+ "gloo-timers",
+ "tokio",
 ]
 
 [[package]]
@@ -554,7 +577,7 @@ checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
 dependencies = [
  "borsh-derive",
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
 ]
 
 [[package]]
@@ -779,6 +802,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
@@ -1206,6 +1235,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1535,6 +1595,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fba3fe847045ecff794b9c138293a80db914678c453ad63fbf0c6a9eb6e00b22"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,11 +1709,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -1696,7 +1773,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
- "memoffset 0.9.1",
+ "memoffset",
  "rustc_version",
 ]
 
@@ -1745,15 +1822,6 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
-]
-
-[[package]]
-name = "fluent-uri"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2069,9 +2137,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2184,6 +2254,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "gobject-sys"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2192,6 +2274,16 @@ dependencies = [
  "glib-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "granit-parser"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d03f81ad4732830d85cfd417a9f62cde6dadda4354d37d078a6084a19560aa2d"
+dependencies = [
+ "arraydeque",
+ "smallvec",
 ]
 
 [[package]]
@@ -2271,10 +2363,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash 0.8.12",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
@@ -2285,6 +2373,17 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -2300,30 +2399,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "headers"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "headers-core",
- "http",
- "httpdate",
- "mime",
- "sha1",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
-dependencies = [
- "http",
 ]
 
 [[package]]
@@ -2375,6 +2450,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2460,25 +2546,6 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
-]
-
-[[package]]
-name = "hyper-http-proxy"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8021e0ae20c08eadc94d0bdafdeda66d4f0858541c146ae6e46b219bfe58497e"
-dependencies = [
- "bytes",
- "futures-util",
- "headers",
- "http",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "pin-project-lite",
- "tokio",
- "tokio-rustls",
- "tower-service",
 ]
 
 [[package]]
@@ -2721,24 +2788,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "ioctl-rs"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7970510895cee30b3e9128319f2cefd4bde883a39f38baa279567ba3a7eb97d"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2799,6 +2848,42 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2888,18 +2973,6 @@ dependencies = [
 
 [[package]]
 name = "json-patch"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1fb8864823fad91877e6caea0baca82e49e8db50f8e5c9f9a453e27d3330fc"
-dependencies = [
- "jsonptr 0.4.7",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "json-patch"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "863726d7afb6bc2590eeff7135d923545e5e964f004c2ccf8716c25e70a86f08"
@@ -2911,29 +2984,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonpath-rust"
-version = "0.5.1"
+name = "json-patch"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d8fe85bd70ff715f31ce8c739194b423d79811a19602115d611a3ec85d6200"
+checksum = "7421438de105a0827e44fadd05377727847d717c80ce29a229f85fd04c427b72"
 dependencies = [
- "lazy_static",
- "once_cell",
+ "jsonptr 0.7.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "jsonpath-rust"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e07021eefc09f897611b067ba7897b5e9266edfc902768418968772e5bb06a7"
+dependencies = [
  "pest",
  "pest_derive",
  "regex",
  "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "jsonptr"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c6e529149475ca0b2820835d3dce8fcc41c6b943ca608d32f35b449255e4627"
-dependencies = [
- "fluent-uri",
- "serde",
- "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2947,15 +3019,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "k8s-openapi"
-version = "0.23.0"
+name = "jsonptr"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8847402328d8301354c94d605481f25a6bdc1ed65471fd96af8eca71141b13"
+checksum = "a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "k8s-openapi"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c6922f6afe80418dd6019818af5d0d34584c371780ff09b9752370c25b4abb"
 dependencies = [
  "base64 0.22.1",
- "chrono",
+ "jiff",
  "serde",
- "serde-value",
  "serde_json",
 ]
 
@@ -2988,9 +3069,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.96.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efffeb3df0bd4ef3e5d65044573499c0e4889b988070b08c50b25b1329289a1f"
+checksum = "208d7fe1380066abb194812a8a8e303cb896a33bb3d7b3177b71bd03ff39bf18"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -3000,38 +3081,35 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.96.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf471ece8ff8d24735ce78dac4d091e9fcb8d74811aeb6b75de4d1c3f5de0f1"
+checksum = "31e940a73033a7c5c7918b5ece7851d84571b58be25e937198da37fa13f116d3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "chrono",
  "either",
  "futures",
- "home",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-http-proxy",
  "hyper-rustls",
  "hyper-timeout",
  "hyper-util",
+ "jiff",
  "jsonpath-rust",
  "k8s-openapi",
  "kube-core",
  "pem",
- "rand 0.8.6",
  "rustls",
- "rustls-pemfile",
+ "rustls-platform-verifier",
  "secrecy",
  "serde",
+ "serde-saphyr",
  "serde_json",
- "serde_yaml",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3040,44 +3118,44 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.96.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f42346d30bb34d1d7adc5c549b691bce7aa3a1e60254e68fab7e2d7b26fe3d77"
+checksum = "a9d2353c118cf3462c352ee0b5bd5b0cf17990af456dfd8662d136ff9812eeb4"
 dependencies = [
- "chrono",
+ "derive_more",
  "form_urlencoded",
  "http",
- "json-patch 2.0.0",
+ "jiff",
+ "json-patch 4.2.0",
  "k8s-openapi",
  "serde",
  "serde-value",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "kube-runtime"
-version = "0.96.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fbf1f6ffa98e65f1d2a9a69338bb60605d46be7edf00237784b89e62c9bd44"
+checksum = "3eb064ef71c7bea55e934a443960da9e9ec31fbb2ba63e47e4aeca32603d5cc7"
 dependencies = [
  "ahash 0.8.12",
  "async-broadcast",
  "async-stream",
- "async-trait",
- "backoff",
+ "backon",
  "educe",
  "futures",
- "hashbrown 0.14.5",
- "json-patch 2.0.0",
- "jsonptr 0.4.7",
+ "hashbrown 0.16.1",
+ "hostname",
+ "json-patch 4.2.0",
  "k8s-openapi",
  "kube-client",
  "parking_lot",
  "pin-project",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -3241,15 +3319,6 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -3353,16 +3422,14 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
-version = "0.25.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "autocfg",
- "bitflags 1.3.2",
+ "bitflags 2.13.0",
  "cfg-if",
+ "cfg_aliases 0.1.1",
  "libc",
- "memoffset 0.6.5",
- "pin-utils",
 ]
 
 [[package]]
@@ -3373,10 +3440,16 @@ checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
- "memoffset 0.9.1",
+ "memoffset",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "num"
@@ -4111,12 +4184,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "piper"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4162,9 +4229,9 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
@@ -4237,10 +4304,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "portable-pty"
-version = "0.8.1"
+name = "portable-atomic"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806ee80c2a03dbe1a9fb9534f8d19e4c0546b790cde8fd1fea9d6390644cb0be"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
@@ -4249,8 +4331,8 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "nix 0.25.1",
- "serial",
+ "nix 0.28.0",
+ "serial2",
  "shared_library",
  "shell-words",
  "winapi",
@@ -4380,9 +4462,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -4394,7 +4476,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -4435,7 +4517,7 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2",
@@ -4477,8 +4559,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4503,12 +4595,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -4912,15 +5023,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5179,6 +5281,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-saphyr"
+version = "0.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd22781911de0ca6debda95f073c8f18bec65d1a94f1fa9573f3102e514cea4"
+dependencies = [
+ "ahash 0.8.12",
+ "annotate-snippets",
+ "base64 0.22.1",
+ "encoding_rs_io",
+ "getrandom 0.3.4",
+ "granit-parser",
+ "nohash-hasher",
+ "num-traits",
+ "serde_core",
+ "smallvec",
+ "zmij",
+]
+
+[[package]]
 name = "serde-untagged"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5352,45 +5473,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "serial"
-version = "0.4.0"
+name = "serial2"
+version = "0.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1237a96570fc377c13baa1b88c7589ab66edced652e43ffb17088f003db3e86"
+checksum = "b16809bc35793b19ce4e0c53924bc0dce3937f15487997cfdaed936004180730"
 dependencies = [
- "serial-core",
- "serial-unix",
- "serial-windows",
-]
-
-[[package]]
-name = "serial-core"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f46209b345401737ae2125fe5b19a77acce90cd53e1658cda928e4fe9a64581"
-dependencies = [
+ "cfg-if",
  "libc",
-]
-
-[[package]]
-name = "serial-unix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03fbca4c9d866e24a459cbca71283f545a37f8e3e002ad8c70593871453cab7"
-dependencies = [
- "ioctl-rs",
- "libc",
- "serial-core",
- "termios",
-]
-
-[[package]]
-name = "serial-windows"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c6d3b776267a75d31bbdfd5d36c0ca051251caafc285827052bc53bcdc8162"
-dependencies = [
- "libc",
- "serial-core",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6685,15 +6775,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termios"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "thirtyfour"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6913,7 +6994,19 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.24.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -7179,6 +7272,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.5",
+ "sha1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7202,7 +7311,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
- "memoffset 0.9.1",
+ "memoffset",
  "tempfile",
  "windows-sys 0.61.2",
 ]
@@ -7286,6 +7395,12 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "universal-hash"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5902,7 +5902,7 @@ dependencies = [
 
 [[package]]
 name = "srelens-agent"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -5910,7 +5910,7 @@ dependencies = [
 
 [[package]]
 name = "srelens-capability"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -5921,7 +5921,7 @@ dependencies = [
 
 [[package]]
 name = "srelens-desktop"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5962,7 +5962,7 @@ dependencies = [
 
 [[package]]
 name = "srelens-kube"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5988,7 +5988,7 @@ dependencies = [
 
 [[package]]
 name = "srelens-llm"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "srelens-mcp"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -6021,7 +6021,7 @@ dependencies = [
 
 [[package]]
 name = "srelens-registry"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "dirs",
  "reqwest 0.13.4",
@@ -6037,7 +6037,7 @@ dependencies = [
 
 [[package]]
 name = "srelens-server"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "srelens-streams"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "portable-pty",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/agent", "crates/capability", "crates/mcp", "crates/kube", "cr
 
 [workspace.package]
 edition = "2021"
-version = "0.6.0"
+version = "0.7.0"
 license = "MIT"
 
 # Fast-feedback profile for the CI WebDriver smoke job (issue #30): dev

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "srelens",
   "mainBinaryName": "srelens",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "identifier": "app.srelens.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/crates/kube/Cargo.toml
+++ b/crates/kube/Cargo.toml
@@ -14,7 +14,9 @@ serde_json = "1"
 schemars = "0.8"
 thiserror = "1"
 tokio = { version = "1", features = ["fs", "time", "net", "io-util", "process"] }
-kube = { version = "4", default-features = false, features = ["client", "config", "rustls-tls", "runtime", "ws"] }
+# `ring` is explicit: kube 4 split the rustls crypto provider out of
+# `rustls-tls`, and without it rustls panics when it builds a TLS config.
+kube = { version = "4", default-features = false, features = ["client", "config", "rustls-tls", "ring", "runtime", "ws"] }
 k8s-openapi = { version = "0.28", features = ["v1_34"] }
 futures = "0.3"
 base64 = "0.22"

--- a/crates/kube/Cargo.toml
+++ b/crates/kube/Cargo.toml
@@ -14,8 +14,8 @@ serde_json = "1"
 schemars = "0.8"
 thiserror = "1"
 tokio = { version = "1", features = ["fs", "time", "net", "io-util", "process"] }
-kube = { version = "0.96", default-features = false, features = ["client", "config", "rustls-tls", "runtime", "ws"] }
-k8s-openapi = { version = "0.23", features = ["latest"] }
+kube = { version = "4", default-features = false, features = ["client", "config", "rustls-tls", "runtime", "ws"] }
+k8s-openapi = { version = "0.28", features = ["v1_34"] }
 futures = "0.3"
 base64 = "0.22"
 flate2 = "1"

--- a/crates/kube/src/actions.rs
+++ b/crates/kube/src/actions.rs
@@ -264,7 +264,7 @@ pub fn rollout_restart_capability(cache: Arc<ClientCache>) -> Capability {
             async move {
                 let client = cache.get(&input.context).await.map_err(CapabilityError::Handler)?;
                 let api = dynamic_api(client, &input.kind, &input.namespace)?;
-                let now = k8s_openapi::chrono::Utc::now().to_rfc3339();
+                let now = k8s_openapi::jiff::Timestamp::now().to_string();
                 let patch = json!({
                     "spec": { "template": { "metadata": { "annotations": {
                         "kubectl.kubernetes.io/restartedAt": now

--- a/crates/kube/src/connect.rs
+++ b/crates/kube/src/connect.rs
@@ -508,6 +508,20 @@ pub fn test_cluster_connection_capability() -> Capability {
 mod tests {
     use super::*;
 
+    /// kube's `rustls-tls` feature no longer selects a crypto provider on its
+    /// own -- kube 4 split `ring` and `aws-lc-rs` out into separate features.
+    /// Without one of them rustls cannot resolve a process-level provider and
+    /// `Client::try_from` panics the first time it builds a TLS config.
+    ///
+    /// This only bites when the crate is built on its own: a workspace build
+    /// unifies `ring` in from a sibling crate and hides it. CI runs the
+    /// kind-bound suites as `cargo test -p srelens-kube`, so guard that.
+    #[tokio::test]
+    async fn building_a_client_selects_a_rustls_crypto_provider() {
+        let config = kube::Config::new("https://127.0.0.1:6443".parse().expect("uri"));
+        Client::try_from(config).expect("client builds without a rustls provider panic");
+    }
+
     fn tmp_dir(label: &str) -> PathBuf {
         static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
         let dir = std::env::temp_dir().join(format!(

--- a/crates/kube/src/connect.rs
+++ b/crates/kube/src/connect.rs
@@ -173,16 +173,17 @@ fn standalone_context_yaml(mut config: Kubeconfig, context: &str) -> Result<Stri
         .context
         .clone()
         .ok_or_else(|| format!("context '{context}' has no cluster/user"))?;
+    let inner_user = inner.user.clone().unwrap_or_default();
     // A split config might not carry this context's cluster/user in this file.
     if !config.clusters.iter().any(|c| c.name == inner.cluster)
-        || !config.auth_infos.iter().any(|a| a.name == inner.user)
+        || !config.auth_infos.iter().any(|a| a.name == inner_user)
     {
         return Err(format!("context '{context}' is missing its cluster or user here"));
     }
 
     config.contexts.retain(|c| c.name == context);
     config.clusters.retain(|c| c.name == inner.cluster);
-    config.auth_infos.retain(|a| a.name == inner.user);
+    config.auth_infos.retain(|a| a.name == inner_user);
     config.current_context = Some(context.to_string());
     if config.kind.is_none() {
         config.kind = Some("Config".to_string());
@@ -284,7 +285,7 @@ fn set_context_bearer(kc: &mut Kubeconfig, in_config_ctx: &str, bearer: &str) {
         .iter()
         .find(|c| c.name == in_config_ctx)
         .and_then(|c| c.context.as_ref())
-        .map(|c| c.user.clone());
+        .map(|c| c.user.clone().unwrap_or_default());
     if let Some(user_name) = user_name {
         for named in kc.auth_infos.iter_mut() {
             if named.name == user_name {
@@ -442,7 +443,7 @@ async fn probe_cluster_from_yaml(yaml: &str, context: &str) -> ClusterInfoOut {
         .iter()
         .find(|c| c.name == context)
         .and_then(|c| c.context.as_ref())
-        .map(|c| c.user.clone());
+        .map(|c| c.user.clone().unwrap_or_default());
     match user_name {
         Some(user_name) => {
             for named in kc.auth_infos.iter_mut() {

--- a/crates/kube/src/context_resolve.rs
+++ b/crates/kube/src/context_resolve.rs
@@ -108,7 +108,7 @@ pub fn resolve_from(configs: &[SourceConfig]) -> Vec<ResolvedContext> {
 
             let context = named.context.clone().unwrap_or_default();
             let cluster_name = context.cluster;
-            let user_name = context.user;
+            let user_name = context.user.unwrap_or_default();
             let server = sc
                 .config
                 .clusters

--- a/crates/kube/src/cronjobs.rs
+++ b/crates/kube/src/cronjobs.rs
@@ -230,7 +230,7 @@ mod tests {
     use super::*;
     use k8s_openapi::api::batch::v1::{CronJobSpec, CronJobStatus};
     use k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;
-    use k8s_openapi::chrono::Utc;
+    use k8s_openapi::jiff::Timestamp;
     use std::path::PathBuf;
 
     #[test]
@@ -271,7 +271,7 @@ mod tests {
             }),
             status: Some(CronJobStatus {
                 active: Some(vec![Default::default(), Default::default()]),
-                last_schedule_time: Some(Time(Utc::now())),
+                last_schedule_time: Some(Time(Timestamp::now())),
                 ..Default::default()
             }),
         };

--- a/crates/kube/src/forward.rs
+++ b/crates/kube/src/forward.rs
@@ -379,7 +379,7 @@ mod tests {
 
     fn pod_with(phase: Option<&str>, deleted: bool) -> Pod {
         let deletion_timestamp = deleted.then(|| {
-            k8s_openapi::apimachinery::pkg::apis::meta::v1::Time(k8s_openapi::chrono::Utc::now())
+            k8s_openapi::apimachinery::pkg::apis::meta::v1::Time(k8s_openapi::jiff::Timestamp::now())
         });
         Pod {
             metadata: kube::core::ObjectMeta {

--- a/crates/kube/src/jobs.rs
+++ b/crates/kube/src/jobs.rs
@@ -55,7 +55,7 @@ pub(crate) fn summarise(job: Job) -> JobSummary {
         status.and_then(|s| s.start_time.as_ref()),
         status.and_then(|s| s.completion_time.as_ref()),
     ) {
-        (Some(start), Some(end)) => crate::format_age((end.0 - start.0).num_seconds()),
+        (Some(start), Some(end)) => crate::format_age(end.0.duration_since(start.0).as_secs()),
         _ => String::new(),
     };
     JobSummary {
@@ -101,7 +101,7 @@ mod tests {
     use super::*;
     use k8s_openapi::api::batch::v1::{JobSpec, JobStatus};
     use k8s_openapi::apimachinery::pkg::apis::meta::v1::{OwnerReference, Time};
-    use k8s_openapi::chrono::{TimeZone, Utc};
+    use k8s_openapi::jiff::Timestamp;
     use std::path::PathBuf;
 
     #[test]
@@ -113,8 +113,8 @@ mod tests {
 
     #[test]
     fn summarises_completions_owner_and_duration() {
-        let start = Utc.with_ymd_and_hms(2026, 1, 1, 10, 0, 0).unwrap();
-        let end = Utc.with_ymd_and_hms(2026, 1, 1, 10, 2, 30).unwrap();
+        let start: Timestamp = "2026-01-01T10:00:00Z".parse().unwrap();
+        let end: Timestamp = "2026-01-01T10:02:30Z".parse().unwrap();
         let job = Job {
             metadata: kube::core::ObjectMeta {
                 name: Some("backup-123".into()),

--- a/crates/kube/src/lib.rs
+++ b/crates/kube/src/lib.rs
@@ -2,7 +2,7 @@
 //! cluster model, and kube-related capabilities.
 
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;
-use k8s_openapi::chrono::Utc;
+use k8s_openapi::jiff::Timestamp;
 use kube::core::NamespaceResourceScope;
 use kube::{Api, Client, Resource};
 
@@ -26,7 +26,7 @@ pub(crate) fn format_age(secs: i64) -> String {
 /// Compact age of a resource from its `creationTimestamp` ("-" if unset).
 pub(crate) fn humanize_age(creation: Option<&Time>) -> String {
     match creation {
-        Some(t) => format_age((Utc::now() - t.0).num_seconds()),
+        Some(t) => format_age(Timestamp::now().duration_since(t.0).as_secs()),
         None => "-".to_string(),
     }
 }

--- a/crates/kube/src/manifest.rs
+++ b/crates/kube/src/manifest.rs
@@ -1223,12 +1223,13 @@ metadata:
 
     #[test]
     fn apply_doc_from_result_409_becomes_conflict() {
-        let err = kube::Error::Api(kube::core::ErrorResponse {
-            status: "Failure".into(),
+        let err = kube::Error::Api(Box::new(kube::core::Status {
+            status: Some(kube::core::response::StatusSummary::Failure),
             message: "conflict with \"kubectl\": .spec.replicas".into(),
             reason: "Conflict".into(),
             code: 409,
-        });
+            ..Default::default()
+        }));
         let doc = apply_doc_from_result("Deployment".into(), "web".into(), Err(err));
         assert!(!doc.applied);
         assert!(doc.error.is_none());
@@ -1238,12 +1239,13 @@ metadata:
 
     #[test]
     fn apply_doc_from_result_other_error_is_cleaned() {
-        let err = kube::Error::Api(kube::core::ErrorResponse {
-            status: "Failure".into(),
+        let err = kube::Error::Api(Box::new(kube::core::Status {
+            status: Some(kube::core::response::StatusSummary::Failure),
             message: "boom".into(),
             reason: "InternalError".into(),
             code: 500,
-        });
+            ..Default::default()
+        }));
         let doc = apply_doc_from_result("Deployment".into(), "web".into(), Err(err));
         assert!(!doc.applied);
         assert!(doc.conflict.is_none());

--- a/crates/kube/src/networkpolicies.rs
+++ b/crates/kube/src/networkpolicies.rs
@@ -63,7 +63,8 @@ pub(crate) fn summarise(np: NetworkPolicy) -> NetworkPolicySummary {
     let namespace = np.metadata.namespace.clone().unwrap_or_default();
     let spec = np.spec.as_ref();
     let pod_selector = spec
-        .map(|s| summarise_selector(&s.pod_selector))
+        .and_then(|s| s.pod_selector.as_ref())
+        .map(summarise_selector)
         .unwrap_or_else(|| "all pods".into());
     let ingress = spec.and_then(|s| s.ingress.as_ref()).map_or(0, |r| r.len()) as i32;
     let egress = spec.and_then(|s| s.egress.as_ref()).map_or(0, |r| r.len()) as i32;
@@ -138,10 +139,10 @@ mod tests {
                 ..Default::default()
             },
             spec: Some(NetworkPolicySpec {
-                pod_selector: LabelSelector {
+                pod_selector: Some(LabelSelector {
                     match_labels: Some(match_labels),
                     ..Default::default()
-                },
+                }),
                 ingress: Some(vec![NetworkPolicyIngressRule::default()]),
                 egress: Some(vec![
                     NetworkPolicyEgressRule::default(),

--- a/crates/kube/src/statefulsets.rs
+++ b/crates/kube/src/statefulsets.rs
@@ -41,7 +41,7 @@ pub(crate) fn summarise(sts: StatefulSet) -> StatefulSetSummary {
     let service = sts
         .spec
         .as_ref()
-        .map(|s| s.service_name.clone())
+        .and_then(|s| s.service_name.clone())
         .unwrap_or_default();
     let status = sts.status.as_ref();
     let ready = status.and_then(|s| s.ready_replicas).unwrap_or(0);
@@ -105,7 +105,7 @@ mod tests {
             },
             spec: Some(StatefulSetSpec {
                 replicas: Some(3),
-                service_name: "pg-headless".into(),
+                service_name: Some("pg-headless".into()),
                 ..Default::default()
             }),
             status: Some(StatefulSetStatus {

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 [dependencies]
 srelens-capability = { path = "../capability" }
 srelens-kube = { path = "../kube" }
-kube = { version = "0.96", default-features = false, features = ["config"] }
+kube = { version = "4", default-features = false, features = ["config"] }
 srelens-registry = { path = "../registry" }
 srelens-streams = { path = "../streams" }
 serde = { version = "1", features = ["derive"] }

--- a/crates/server/src/cluster_registry.rs
+++ b/crates/server/src/cluster_registry.rs
@@ -44,7 +44,7 @@ impl ClusterOidcRegistry {
             // A context is OIDC if its user is OIDC.
             for ctx in &kc.contexts {
                 if let Some(c) = &ctx.context {
-                    if let Some(cfg) = oidc_users.get(&c.user) {
+                    if let Some(cfg) = c.user.as_deref().and_then(|u| oidc_users.get(u)) {
                         let key = cfg.key();
                         reg.by_key.entry(key.clone()).or_insert_with(|| cfg.clone());
                         reg.key_by_context.insert(ctx.name.clone(), key);

--- a/crates/streams/Cargo.toml
+++ b/crates/streams/Cargo.toml
@@ -8,7 +8,7 @@ srelens-kube = { path = "../kube" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt", "sync", "io-util", "process", "time"] }
-portable-pty = "0.8"
+portable-pty = "0.9"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time"] }

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,121 @@
+# Suppressions for the OSSF Scorecard "Vulnerabilities" check (code-scanning
+# alert #32) and any local `osv-scanner scan source --lockfile=Cargo.lock`.
+#
+# Everything listed here is a transitive advisory we cannot act on: the crate is
+# pinned by an upstream dependency, or no fixed version exists. Advisories we
+# *can* fix are fixed instead of being listed -- see the git history for this
+# file. Every entry carries `ignoreUntil` so the suppression expires and forces
+# a re-review rather than silently hiding a vulnerability forever.
+#
+# To re-audit: `osv-scanner scan source --lockfile=Cargo.lock`
+
+# --- gtk-rs GTK3 bindings: unmaintained, no fixed version ---------------------
+# Pulled in only on Linux via tauri -> muda/tray-icon -> gtk 0.18 (webkit2gtk
+# backend). These are "crate is unmaintained" advisories with no CVE and no
+# upstream release to move to; clearing them requires Tauri to migrate to GTK4.
+# RUSTSEC-2024-0429 (glib unsoundness, fixed in 0.20) is likewise unreachable
+# for us because tauri 2.x pins gtk 0.18, which pins glib 0.18.
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0411"  # gdkwayland-sys
+reason = "Unmaintained GTK3 binding pinned by tauri's Linux backend; no fixed version exists."
+ignoreUntil = 2027-02-18
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0412"  # gdk
+reason = "Unmaintained GTK3 binding pinned by tauri's Linux backend; no fixed version exists."
+ignoreUntil = 2027-02-18
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0413"  # atk
+reason = "Unmaintained GTK3 binding pinned by tauri's Linux backend; no fixed version exists."
+ignoreUntil = 2027-02-18
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0414"  # gdkx11-sys
+reason = "Unmaintained GTK3 binding pinned by tauri's Linux backend; no fixed version exists."
+ignoreUntil = 2027-02-18
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0415"  # gtk
+reason = "Unmaintained GTK3 binding pinned by tauri's Linux backend; no fixed version exists."
+ignoreUntil = 2027-02-18
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0416"  # atk-sys
+reason = "Unmaintained GTK3 binding pinned by tauri's Linux backend; no fixed version exists."
+ignoreUntil = 2027-02-18
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0417"  # gdkx11
+reason = "Unmaintained GTK3 binding pinned by tauri's Linux backend; no fixed version exists."
+ignoreUntil = 2027-02-18
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0418"  # gdk-sys
+reason = "Unmaintained GTK3 binding pinned by tauri's Linux backend; no fixed version exists."
+ignoreUntil = 2027-02-18
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0419"  # gtk3-macros
+reason = "Unmaintained GTK3 binding pinned by tauri's Linux backend; no fixed version exists."
+ignoreUntil = 2027-02-18
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0420"  # gtk-sys
+reason = "Unmaintained GTK3 binding pinned by tauri's Linux backend; no fixed version exists."
+ignoreUntil = 2027-02-18
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0429"  # glib -- alias GHSA-wrw7-89jp-8q8g
+reason = "glib 0.18 Iterator unsoundness; fixed in 0.20 but tauri 2.x pins gtk 0.18 -> glib 0.18. Not upgradable from here."
+ignoreUntil = 2027-02-18
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0370"  # proc-macro-error
+reason = "Unmaintained; build-time proc-macro reached only via glib-macros in the same pinned GTK3 stack. No fixed version."
+ignoreUntil = 2027-02-18
+
+# --- unic-*: unmaintained, reached via tauri-utils -> urlpattern --------------
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0075"  # unic-char-range
+reason = "Unmaintained crate advisory; pinned by tauri-utils -> urlpattern. No fixed version."
+ignoreUntil = 2027-02-18
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0080"  # unic-common
+reason = "Unmaintained crate advisory; pinned by tauri-utils -> urlpattern. No fixed version."
+ignoreUntil = 2027-02-18
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0081"  # unic-char-property
+reason = "Unmaintained crate advisory; pinned by tauri-utils -> urlpattern. No fixed version."
+ignoreUntil = 2027-02-18
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0098"  # unic-ucd-version
+reason = "Unmaintained crate advisory; pinned by tauri-utils -> urlpattern. No fixed version."
+ignoreUntil = 2027-02-18
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0100"  # unic-ucd-ident
+reason = "Unmaintained crate advisory; pinned by tauri-utils -> urlpattern. No fixed version."
+ignoreUntil = 2027-02-18
+
+# --- remaining transitive advisories with no fix -----------------------------
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0436"  # paste
+reason = "Unmaintained proc-macro reached only via thirtyfour, a dev-dependency of srelens-desktop. Compile-time only and never linked into a shipped binary."
+ignoreUntil = 2027-02-18
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0235"  # rkyv
+reason = "rkyv 0.7 archive validation. Reached via tauri-plugin-log -> byte-unit, whose optional `rkyv` feature we do not enable, so the code is never compiled. byte-unit pins 0.7; the fix is 0.8."
+ignoreUntil = 2027-02-18
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2023-0071"  # rsa -- Marvin timing sidechannel
+reason = "No fixed version of the rsa crate exists. Reached via openidconnect for OIDC token verification; srelens performs public-key signature verification, not RSA private-key decryption, so the key-recovery oracle does not apply."
+ignoreUntil = 2027-02-18


### PR DESCRIPTION
Promoted `dev` to `main`. **Shipped as [srelens-v0.7.1](https://github.com/srelens/srelens/releases/tag/srelens-v0.7.1)** — five patch-level commits since `srelens-v0.7.0`, no `feat` and no breaking change, so auto-versioning computed 0.7.1 as expected and committed the bump back to `main` in `0a9b0ac`.

## Contents

| Commit | |
|---|---|
| `fix(release)` | size-baseline needs write permission to read a draft release |
| `ci` | don't cancel runs on dev and main (#290) |
| `fix(deps)` | clear 7 RUSTSEC advisories from the Cargo lockfile (#294) |
| `chore(security)` | document the 20 unfixable OSV advisories (#294) |
| `fix(kube)` | select the rustls ring provider explicitly (#295) |

## Highlights

**Code-scanning alert #32 is cleared.** Scorecard's Vulnerabilities check reported 27 open RUSTSEC advisories; `osv-scanner scan source --lockfile=Cargo.lock` now exits 0. Seven were fixed by upgrading (`event-listener`, `plist`/`quick-xml`, `portable-pty`, and `kube` 0.96 → 4.2 which dropped `backoff`, `instant` and `rustls-pemfile`); the remaining 20 are transitive with no fixed version and are documented in `osv-scanner.toml`, each carrying an `ignoreUntil` so the suppression expires rather than hiding the advisory permanently.

**The kube upgrade is the substantive change in this release.** It carried `k8s-openapi` 0.23 → 0.28, which meant migrating chrono → jiff, handling `Context::user` / `StatefulSetSpec::service_name` / `NetworkPolicySpec::pod_selector` becoming optional, and `kube::Error::Api` now carrying a `Box<Status>`. Each was written to preserve existing behaviour, with one deliberate exception worth remembering: `k8s-openapi` 0.28 removed the `latest` feature, so **the target Kubernetes API version is now pinned explicitly to `v1_34`**.

`fix(kube)` repairs a regression that upgrade introduced — kube 4 split the rustls crypto provider out of `rustls-tls`, which broke the kind-bound suites in isolated builds while the workspace suite stayed green. It ships with a regression test that reproduces the panic without needing a cluster.

## Not included

Opened before these existed, and merged without them:

- #299 — table column-width stability and the checkbox ellipsis fix
- #300 — CRD `additionalPrinterColumns` (#267)

Both target `dev` and will go out in the next promotion.

## Follow-up

`main` carries the `0.7.1` bump that `dev` does not, so `dev` still reports `0.7.0` and needs a back-merge — the same sync #297 did for `0.7.0`.

Note #297 was squash-merged, which is why `main`'s release commits show as absent from `dev` even though the version file was synced. Back-merges want a merge commit, otherwise each release leaves the two branches a little further apart in history.
