### PR TITLE
fix(crds): show the columns a CRD asks to have displayed

### DIFF
--- a/apps/desktop/src/components/CustomResourceBrowser.test.tsx
+++ b/apps/desktop/src/components/CustomResourceBrowser.test.tsx
@@ -44,6 +44,35 @@ describe("CustomResourceBrowser", () => {
     expect(screen.getByText("Widget")).toBeDefined();
   });
 
+  it("renders the columns the CRD asks for, between the name and Age (#267)", async () => {
+    const withColumns = {
+      ...crd,
+      printerColumns: [
+        { name: "Health", jsonPath: ".status.health", type: "string" },
+        { name: "Nodes", jsonPath: ".spec.nodes", type: "integer" },
+      ],
+    };
+    listCustomResourceMock.mockResolvedValue({
+      items: [{ name: "demo-widget", namespace: "default", age: "1m", columns: ["GREEN", "3"] }],
+    });
+    render(<CustomResourceBrowser context="kind-dev" crd={withColumns} />);
+    await waitFor(() => expect(screen.getByText("demo-widget")).toBeDefined());
+    // Headings from the CRD, and the resolved values on the row.
+    expect(screen.getByText("Health")).toBeDefined();
+    expect(screen.getByText("Nodes")).toBeDefined();
+    expect(screen.getByText("GREEN")).toBeDefined();
+    expect(screen.getByText("3")).toBeDefined();
+  });
+
+  it("still lists a CRD that declares no printer columns (#267)", async () => {
+    listCustomResourceMock.mockResolvedValue({
+      items: [{ name: "demo-widget", namespace: "default", age: "1m" }],
+    });
+    render(<CustomResourceBrowser context="kind-dev" crd={crd} />);
+    await waitFor(() => expect(screen.getByText("demo-widget")).toBeDefined());
+    expect(screen.getByText("Age")).toBeDefined();
+  });
+
   it("shows an error when listing fails", async () => {
     listCustomResourceMock.mockResolvedValue({ error: "the server could not find the requested resource" });
     render(<CustomResourceBrowser context="kind-dev" crd={crd} />);

--- a/apps/desktop/src/components/CustomResourceBrowser.tsx
+++ b/apps/desktop/src/components/CustomResourceBrowser.tsx
@@ -1,6 +1,12 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { RefreshCw } from "lucide-react";
-import { listCustomResource, type CrdRef, type CustomRow } from "../lib/crds";
+import {
+  listCustomResource,
+  printerColumnKeys,
+  printerSortValue,
+  type CrdRef,
+  type CustomRow,
+} from "../lib/crds";
 import { listNamespaces } from "../lib/workloads";
 import { YamlView } from "./YamlView";
 import { Table, filterTableData, Select, Button, ColumnPicker, useColumnVisibility, Spinner, Drawer, TextInput, type Column } from "../ui";
@@ -69,6 +75,11 @@ export function CustomResourceBrowser({
     };
   }, [context, crd, namespace, reloadKey]);
 
+  const printerKeys = useMemo(
+    () => printerColumnKeys(crd.printerColumns ?? []),
+    [crd.printerColumns],
+  );
+
   const columns: Column<CustomRow>[] = [
     { key: "name", header: crd.kind, render: (r) => <strong>{r.name}</strong> },
     ...(crd.namespaced
@@ -83,10 +94,13 @@ export function CustomResourceBrowser({
     // Whatever the CRD asks to have shown, between the identity columns and
     // Age — the order kubectl uses. `columns` is positional, so index by the
     // CRD's declaration order rather than by name (headings need not be unique).
+    // Values stay positional -- the backend returns them in declaration order --
+    // but the key must not be, since it outlives any one CRD revision.
     ...(crd.printerColumns ?? []).map((column, index) => ({
-      key: `printer:${index}`,
+      key: printerKeys[index],
       header: column.name,
       getValue: (r: CustomRow) => r.columns?.[index] ?? "",
+      getSortValue: (r: CustomRow) => printerSortValue(column.type, r.columns?.[index] ?? ""),
       render: (r: CustomRow) => <span>{r.columns?.[index] ?? ""}</span>,
     })),
     { key: "age", header: "Age", getSortValue: ageSortValue, render: (r) => <span className="text-muted-foreground">{r.age}</span> },

--- a/apps/desktop/src/components/CustomResourceBrowser.tsx
+++ b/apps/desktop/src/components/CustomResourceBrowser.tsx
@@ -100,7 +100,8 @@ export function CustomResourceBrowser({
       key: printerKeys[index],
       header: column.name,
       getValue: (r: CustomRow) => r.columns?.[index] ?? "",
-      getSortValue: (r: CustomRow) => printerSortValue(column.type, r.columns?.[index] ?? ""),
+      getSortValue: (r: CustomRow) =>
+        printerSortValue(column.type, r.columns?.[index] ?? "", r.sortKeys?.[index] ?? ""),
       render: (r: CustomRow) => <span>{r.columns?.[index] ?? ""}</span>,
     })),
     { key: "age", header: "Age", getSortValue: ageSortValue, render: (r) => <span className="text-muted-foreground">{r.age}</span> },

--- a/apps/desktop/src/components/CustomResourceBrowser.tsx
+++ b/apps/desktop/src/components/CustomResourceBrowser.tsx
@@ -80,6 +80,15 @@ export function CustomResourceBrowser({
           },
         ]
       : []),
+    // Whatever the CRD asks to have shown, between the identity columns and
+    // Age — the order kubectl uses. `columns` is positional, so index by the
+    // CRD's declaration order rather than by name (headings need not be unique).
+    ...(crd.printerColumns ?? []).map((column, index) => ({
+      key: `printer:${index}`,
+      header: column.name,
+      getValue: (r: CustomRow) => r.columns?.[index] ?? "",
+      render: (r: CustomRow) => <span>{r.columns?.[index] ?? ""}</span>,
+    })),
     { key: "age", header: "Age", getSortValue: ageSortValue, render: (r) => <span className="text-muted-foreground">{r.age}</span> },
   ];
 

--- a/apps/desktop/src/lib/crds.test.ts
+++ b/apps/desktop/src/lib/crds.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { printerColumnKeys, printerSortValue } from "./crds";
+import { ageSeconds } from "./age";
 
 const col = (name: string, jsonPath: string, type = "string") => ({ name, jsonPath, type });
 
@@ -39,6 +40,27 @@ describe("printerSortValue", () => {
     // "10d" vs "2h": text collation puts 10d first by leading digit.
     expect(printerSortValue("date", "2h")).toBeLessThan(printerSortValue("date", "10d") as number);
     expect(printerSortValue("date", "300d")).toBeLessThan(printerSortValue("date", "1y") as number);
+  });
+
+  it("separates dates that render as the same age (#267 review)", () => {
+    // 65 and 115 minutes old both display "1h"; only the raw value can order them.
+    const now = Date.parse("2026-01-01T12:00:00Z");
+    const older = printerSortValue("date", "1h", "2026-01-01T10:05:00Z", now) as number;
+    const newer = printerSortValue("date", "1h", "2026-01-01T10:55:00Z", now) as number;
+    expect(older).toBeGreaterThan(newer); // larger = older, as ageSeconds orders
+  });
+
+  it("sorts raw timestamps in the same direction as compact ages", () => {
+    // A mixed list must not reverse when some rows carry a raw value.
+    const now = Date.parse("2026-01-01T12:00:00Z");
+    const raw = printerSortValue("date", "2h", "2026-01-01T10:00:00Z", now) as number;
+    expect(raw).toBeGreaterThan(ageSeconds("1h"));
+    expect(raw).toBeLessThan(ageSeconds("10d"));
+  });
+
+  it("falls back to the rendered age when no raw value is present", () => {
+    expect(printerSortValue("date", "2h", "")).toBe(ageSeconds("2h"));
+    expect(printerSortValue("date", "2h", "not a date")).toBe(ageSeconds("2h"));
   });
 
   it("groups unset and unparseable values below real ones", () => {

--- a/apps/desktop/src/lib/crds.test.ts
+++ b/apps/desktop/src/lib/crds.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { printerColumnKeys, printerSortValue } from "./crds";
+
+const col = (name: string, jsonPath: string, type = "string") => ({ name, jsonPath, type });
+
+describe("printerColumnKeys", () => {
+  it("identifies a column by its definition, not its position", () => {
+    // An operator upgrade that prepends a column must not change the key of the
+    // ones already there: those keys persist hidden/sort/filter state.
+    const before = printerColumnKeys([col("Ready", ".status.ready"), col("Version", ".spec.version")]);
+    const after = printerColumnKeys([
+      col("Phase", ".status.phase"),
+      col("Ready", ".status.ready"),
+      col("Version", ".spec.version"),
+    ]);
+    expect(after.slice(1)).toEqual(before);
+  });
+
+  it("distinguishes columns sharing a heading but reading different fields", () => {
+    const keys = printerColumnKeys([col("Status", ".status.a"), col("Status", ".status.b")]);
+    expect(new Set(keys).size).toBe(2);
+  });
+
+  it("still disambiguates genuinely identical definitions", () => {
+    const keys = printerColumnKeys([col("Ready", ".status.ready"), col("Ready", ".status.ready")]);
+    expect(new Set(keys).size).toBe(2);
+  });
+});
+
+describe("printerSortValue", () => {
+  it("orders signed and decimal numbers numerically", () => {
+    // The table's collator gets both of these backwards on the rendered text.
+    expect(printerSortValue("integer", "-10")).toBeLessThan(printerSortValue("integer", "-2") as number);
+    expect(printerSortValue("number", "1.15")).toBeLessThan(printerSortValue("number", "1.2") as number);
+    expect(printerSortValue("integer", "2")).toBeLessThan(printerSortValue("integer", "10") as number);
+  });
+
+  it("orders dates by duration, not by the text of the age", () => {
+    // "10d" vs "2h": text collation puts 10d first by leading digit.
+    expect(printerSortValue("date", "2h")).toBeLessThan(printerSortValue("date", "10d") as number);
+    expect(printerSortValue("date", "300d")).toBeLessThan(printerSortValue("date", "1y") as number);
+  });
+
+  it("groups unset and unparseable values below real ones", () => {
+    expect(printerSortValue("integer", "")).toBe(Number.NEGATIVE_INFINITY);
+    expect(printerSortValue("number", "n/a")).toBe(Number.NEGATIVE_INFINITY);
+    expect(printerSortValue("date", "-")).toBe(-1);
+  });
+
+  it("leaves string columns as text", () => {
+    expect(printerSortValue("string", "GREEN")).toBe("GREEN");
+  });
+});

--- a/apps/desktop/src/lib/crds.test.ts
+++ b/apps/desktop/src/lib/crds.test.ts
@@ -4,6 +4,9 @@ import { ageSeconds } from "./age";
 
 const col = (name: string, jsonPath: string, type = "string") => ({ name, jsonPath, type });
 
+/** printerSortValue narrowed to bigint, for the integer cases. */
+const intKey = (text: string) => printerSortValue("integer", text) as bigint;
+
 describe("printerColumnKeys", () => {
   it("identifies a column by its definition, not its position", () => {
     // An operator upgrade that prepends a column must not change the key of the
@@ -31,9 +34,24 @@ describe("printerColumnKeys", () => {
 describe("printerSortValue", () => {
   it("orders signed and decimal numbers numerically", () => {
     // The table's collator gets both of these backwards on the rendered text.
-    expect(printerSortValue("integer", "-10")).toBeLessThan(printerSortValue("integer", "-2") as number);
+    expect(intKey("-10") < intKey("-2")).toBe(true);
     expect(printerSortValue("number", "1.15")).toBeLessThan(printerSortValue("number", "1.2") as number);
-    expect(printerSortValue("integer", "2")).toBeLessThan(printerSortValue("integer", "10") as number);
+    expect(intKey("2") < intKey("10")).toBe(true);
+  });
+
+  it("keeps 64-bit integers exact (#267 review)", () => {
+    // Number() maps both of these to 9007199254740992, tying the two rows.
+    const lo = intKey("9007199254740992");
+    const hi = intKey("9007199254740993");
+    expect(lo).not.toBe(hi);
+    expect(lo < hi).toBe(true);
+    expect(intKey("-9007199254740993") < lo).toBe(true);
+  });
+
+  it("falls back for integer text that is not an integer", () => {
+    // A decimal in an `integer` column is malformed; BigInt() would throw.
+    expect(printerSortValue("integer", "1.5")).toBe(Number.NEGATIVE_INFINITY);
+    expect(printerSortValue("integer", "n/a")).toBe(Number.NEGATIVE_INFINITY);
   });
 
   it("orders dates by duration, not by the text of the age", () => {

--- a/apps/desktop/src/lib/crds.ts
+++ b/apps/desktop/src/lib/crds.ts
@@ -1,5 +1,17 @@
 import { invokeCapability, type Invoker } from "../transport/transport";
 
+/**
+ * One column a CRD asks tools to display, from its `additionalPrinterColumns`
+ * — the same metadata `kubectl get` renders. Custom resources share no fields
+ * beyond name/namespace/age, so this is the only way to show anything useful
+ * about them (health, phase, version, replica counts…).
+ */
+export interface PrinterColumn {
+  name: string;
+  jsonPath: string;
+  type: string;
+}
+
 /** A discovered CustomResourceDefinition, enough to list/view its instances. */
 export interface CrdRef {
   name: string;
@@ -8,12 +20,16 @@ export interface CrdRef {
   kind: string;
   plural: string;
   namespaced: boolean;
+  /** Optional: older backends and hand-built refs in tests may omit it. */
+  printerColumns?: PrinterColumn[];
 }
 
 export interface CustomRow {
   name: string;
   namespace: string;
   age: string;
+  /** Values for the CRD's printer columns, in declaration order. */
+  columns?: string[];
 }
 
 /** Discover installed CRDs in a cluster via `k8s.listCRDs`. */
@@ -45,6 +61,7 @@ export async function listCustomResource(
       kind: crd.kind,
       namespaced: crd.namespaced,
       namespace: namespace ?? "",
+      printerColumns: crd.printerColumns ?? [],
     });
     return { items: out.items };
   } catch (e) {

--- a/apps/desktop/src/lib/crds.ts
+++ b/apps/desktop/src/lib/crds.ts
@@ -31,6 +31,8 @@ export interface CustomRow {
   age: string;
   /** Values for the CRD's printer columns, in declaration order. */
   columns?: string[];
+  /** Raw values for columns whose rendered text does not sort correctly. */
+  sortKeys?: string[];
 }
 
 /**
@@ -59,7 +61,12 @@ export function printerColumnKeys(columns: PrinterColumn[]): string[] {
  * decimal numbers, and `date` columns have already been rendered as compact
  * ages ("2h", "10d") whose text does not order chronologically.
  */
-export function printerSortValue(type: string, value: string): number | string {
+export function printerSortValue(
+  type: string,
+  value: string,
+  sortKey = "",
+  now: number = Date.now(),
+): number | string {
   if (type === "integer" || type === "number") {
     const text = value.trim();
     // Unset or unparseable values group below every real number. Check for
@@ -69,7 +76,15 @@ export function printerSortValue(type: string, value: string): number | string {
     const parsed = Number(text);
     return Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY;
   }
-  if (type === "date") return ageSeconds(value);
+  if (type === "date") {
+    // Prefer the raw timestamp: two rows inside the same displayed unit both
+    // render "1h" and would otherwise tie. Convert it to an age rather than
+    // using the epoch value directly, so it sorts in the same direction as
+    // `ageSeconds` — larger means older, for both this and the Age column.
+    const parsed = sortKey ? Date.parse(sortKey) : NaN;
+    if (Number.isFinite(parsed)) return (now - parsed) / 1000;
+    return ageSeconds(value);
+  }
   return value;
 }
 

--- a/apps/desktop/src/lib/crds.ts
+++ b/apps/desktop/src/lib/crds.ts
@@ -1,4 +1,5 @@
 import { invokeCapability, type Invoker } from "../transport/transport";
+import { ageSeconds } from "./age";
 
 /**
  * One column a CRD asks tools to display, from its `additionalPrinterColumns`
@@ -30,6 +31,46 @@ export interface CustomRow {
   age: string;
   /** Values for the CRD's printer columns, in declaration order. */
   columns?: string[];
+}
+
+/**
+ * Stable table keys for a CRD's printer columns.
+ *
+ * These keys persist: `useColumnVisibility` stores hidden columns under them,
+ * and the tab keeps sort and filter state by key. A positional key would
+ * therefore silently change meaning when an operator upgrade inserts or
+ * reorders `additionalPrinterColumns` — a column the user hid or sorted would
+ * come back as a different one. Identify a column by what it *is* instead, and
+ * add an occurrence suffix only for genuinely duplicate definitions.
+ */
+export function printerColumnKeys(columns: PrinterColumn[]): string[] {
+  const seen = new Map<string, number>();
+  return columns.map((column) => {
+    const base = `printer:${column.name}:${column.jsonPath}`;
+    const occurrence = (seen.get(base) ?? 0) + 1;
+    seen.set(base, occurrence);
+    return occurrence === 1 ? base : `${base}#${occurrence}`;
+  });
+}
+
+/**
+ * Sort key for a printer column's rendered text, honouring the type the CRD
+ * declared. The table's collator handles plain digit strings, but not signed or
+ * decimal numbers, and `date` columns have already been rendered as compact
+ * ages ("2h", "10d") whose text does not order chronologically.
+ */
+export function printerSortValue(type: string, value: string): number | string {
+  if (type === "integer" || type === "number") {
+    const text = value.trim();
+    // Unset or unparseable values group below every real number. Check for
+    // empty first: Number("") is 0, which would interleave blank cells with
+    // real zeros and negatives.
+    if (text === "") return Number.NEGATIVE_INFINITY;
+    const parsed = Number(text);
+    return Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY;
+  }
+  if (type === "date") return ageSeconds(value);
+  return value;
 }
 
 /** Discover installed CRDs in a cluster via `k8s.listCRDs`. */

--- a/apps/desktop/src/lib/crds.ts
+++ b/apps/desktop/src/lib/crds.ts
@@ -60,19 +60,31 @@ export function printerColumnKeys(columns: PrinterColumn[]): string[] {
  * declared. The table's collator handles plain digit strings, but not signed or
  * decimal numbers, and `date` columns have already been rendered as compact
  * ages ("2h", "10d") whose text does not order chronologically.
+ *
+ * `integer` yields a bigint, since Kubernetes integers are 64-bit and Number
+ * cannot represent them all exactly. The table compares bigints relationally.
  */
 export function printerSortValue(
   type: string,
   value: string,
   sortKey = "",
   now: number = Date.now(),
-): number | string {
+): number | string | bigint {
   if (type === "integer" || type === "number") {
     const text = value.trim();
     // Unset or unparseable values group below every real number. Check for
     // empty first: Number("") is 0, which would interleave blank cells with
     // real zeros and negatives.
     if (text === "") return Number.NEGATIVE_INFINITY;
+    if (type === "integer") {
+      // Kubernetes integers are 64-bit, and Number cannot hold them exactly:
+      // 9007199254740993 collapses onto ...992, tying two distinct rows.
+      try {
+        return BigInt(text);
+      } catch {
+        return Number.NEGATIVE_INFINITY;
+      }
+    }
     const parsed = Number(text);
     return Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY;
   }

--- a/apps/desktop/src/lib/openTabs.test.ts
+++ b/apps/desktop/src/lib/openTabs.test.ts
@@ -258,6 +258,31 @@ describe("reconcileCrdTabs", () => {
     expect(result.tabs[0]).toBe(tabs[0]);
     expect(result.dropped).toBe(0);
   });
+
+  const cols = [{ name: "Ready", jsonPath: ".status.ready", type: "string" }];
+
+  it("adopts printer columns a restored tab predates (#267)", () => {
+    // A tab serialized before printer columns existed carries a ref without
+    // them. Its GVK is unchanged, so nothing else marks it stale -- but keeping
+    // it would mean the columns never appear until the tab is reopened.
+    const result = reconcileCrdTabs([crdTab(1)], "prod", [crd({ printerColumns: cols })]);
+    expect(result.tabs[0].crd?.printerColumns).toEqual(cols);
+  });
+
+  it("adopts printer columns changed without a version bump (#267)", () => {
+    const stale = { ...tab({ id: 1, cluster: "prod" }), crd: crd({ printerColumns: cols }) } as Tab;
+    const renamed = [{ name: "Health", jsonPath: ".status.health", type: "string" }];
+    const result = reconcileCrdTabs([stale], "prod", [crd({ printerColumns: renamed })]);
+    expect(result.tabs[0].crd?.printerColumns).toEqual(renamed);
+  });
+
+  it("keeps tab identity when the printer columns are equal", () => {
+    // The ref feeds a fetch effect, so a fresh object each reconcile would
+    // refetch forever.
+    const tabs = [{ ...tab({ id: 1, cluster: "prod" }), crd: crd({ printerColumns: cols }) } as Tab];
+    const result = reconcileCrdTabs(tabs, "prod", [crd({ printerColumns: [{ ...cols[0] }] })]);
+    expect(result.tabs[0]).toBe(tabs[0]);
+  });
 });
 
 describe("coalesced session persistence", () => {

--- a/apps/desktop/src/lib/openTabs.ts
+++ b/apps/desktop/src/lib/openTabs.ts
@@ -157,6 +157,34 @@ export function reconcileActiveTab(tabs: ViewTab[], activeTabId: number | null):
  * Only ever called with a SUCCESSFUL discovery result: an unreachable cluster
  * must not be read as "this CRD is gone" and silently delete the workspace.
  */
+/**
+ * Whether two printer-column lists describe the same columns.
+ *
+ * A persisted tab keeps whatever ref it was serialized with, so a tab restored
+ * from before printer columns existed has none at all, and an operator can
+ * change `additionalPrinterColumns` without touching the CRD version. Neither
+ * shows up in the GVK, so the columns have to be compared directly or the tab
+ * keeps rendering by a definition the cluster has moved on from.
+ *
+ * Compared field by field rather than by reference: the ref feeds a fetch
+ * effect, and handing back a fresh object on every reconcile would refetch
+ * forever.
+ */
+function samePrinterColumns(
+  live: CrdRef["printerColumns"],
+  saved: CrdRef["printerColumns"],
+): boolean {
+  const a = live ?? [];
+  const b = saved ?? [];
+  if (a.length !== b.length) return false;
+  return a.every(
+    (column, index) =>
+      column.name === b[index].name &&
+      column.jsonPath === b[index].jsonPath &&
+      column.type === b[index].type,
+  );
+}
+
 export function reconcileCrdTabs(
   tabs: ViewTab[],
   context: string,
@@ -175,7 +203,10 @@ export function reconcileCrdTabs(
       dropped += 1;
       continue;
     }
-    const stale = live.version !== t.crd.version || live.plural !== t.crd.plural;
+    const stale =
+      live.version !== t.crd.version ||
+      live.plural !== t.crd.plural ||
+      !samePrinterColumns(live.printerColumns, t.crd.printerColumns);
     kept.push(stale ? { ...t, crd: live } : t);
   }
   return { tabs: kept, dropped };

--- a/apps/desktop/src/ui/Table.test.tsx
+++ b/apps/desktop/src/ui/Table.test.tsx
@@ -131,6 +131,48 @@ describe("Table virtualization", () => {
   });
 });
 
+describe("Table sorting", () => {
+  it("orders 64-bit integers exactly, beyond Number's safe range", () => {
+    // Number() collapses these two to the same value, so a numeric sort key
+    // cannot separate them. Negative, because string collation happens to get
+    // large positives right and would hide the gap: it compares "-...993"
+    // against "-...992" by magnitude and puts them the wrong way round.
+    // The comparator must also not use arithmetic on a bigint, which throws.
+    const rows = [
+      { id: "b", n: -9007199254740992n },
+      { id: "a", n: -9007199254740993n },
+    ];
+    const cols: Column<(typeof rows)[number]>[] = [
+      { key: "id", header: "Id" },
+      { key: "n", header: "N", getSortValue: (r) => r.n },
+    ];
+    render(<Table columns={cols} data={rows} getRowKey={(r) => r.id} />);
+    fireEvent.click(screen.getByRole("button", { name: "Sort by N" }));
+    const order = Array.from(document.querySelectorAll("tbody tr.fl-data-table__row")).map(
+      (tr) => tr.textContent?.[0],
+    );
+    expect(order).toEqual(["a", "b"]);
+  });
+
+  it("sorts rows with no value below real ones when mixing bigint and number", () => {
+    const rows = [
+      { id: "big", n: 12n as bigint | number },
+      { id: "none", n: Number.NEGATIVE_INFINITY },
+      { id: "small", n: 3n },
+    ];
+    const cols: Column<(typeof rows)[number]>[] = [
+      { key: "id", header: "Id" },
+      { key: "n", header: "N", getSortValue: (r) => r.n },
+    ];
+    render(<Table columns={cols} data={rows} getRowKey={(r) => r.id} />);
+    fireEvent.click(screen.getByRole("button", { name: "Sort by N" }));
+    const order = Array.from(document.querySelectorAll("tbody tr.fl-data-table__row")).map(
+      (tr) => tr.textContent?.slice(0, 5),
+    );
+    expect(order?.[0]).toContain("none");
+  });
+});
+
 describe("computeVisibleRange", () => {
   it("returns the window of rows around the scroll position with overscan", () => {
     // rowHeight 20, viewport 100 → 5 visible rows; scrolled to row 50; overscan 3.

--- a/apps/desktop/src/ui/Table.tsx
+++ b/apps/desktop/src/ui/Table.tsx
@@ -158,7 +158,16 @@ export function Table<T>({
         const right = column.getSortValue ? column.getSortValue(b.row) : getColumnValue(b.row, column);
         let result: number;
         if (typeof left === "number" && typeof right === "number") result = left - right;
-        else result = collator.compare(String(left ?? ""), String(right ?? ""));
+        else if (typeof left === "bigint" || typeof right === "bigint") {
+          // Compare, never subtract: bigint arithmetic with a number throws,
+          // and columns mix the two (a bigint value against a -Infinity for
+          // "unset"). Relational operators are defined across both and stay
+          // exact past Number.MAX_SAFE_INTEGER, which string collation is not:
+          // it orders negatives by magnitude.
+          const l = left as bigint | number;
+          const r = right as bigint | number;
+          result = l < r ? -1 : l > r ? 1 : 0;
+        } else result = collator.compare(String(left ?? ""), String(right ?? ""));
         return result ? result * (sort.direction === "asc" ? 1 : -1) : a.index - b.index;
       })
       .map(({ row }) => row);

--- a/crates/kube/src/crds.rs
+++ b/crates/kube/src/crds.rs
@@ -216,6 +216,15 @@ fn whole_object(object: &DynamicObject) -> serde_json::Value {
     value
 }
 
+/// The raw value behind a cell, where rendering it would lose ordering.
+fn column_sort_key(object: &serde_json::Value, column: &PrinterColumn) -> String {
+    if column.column_type == "date" {
+        resolve_json_path(object, &column.json_path)
+    } else {
+        String::new()
+    }
+}
+
 /// Render one cell, humanizing `type: date` columns the way ages are shown
 /// elsewhere so a raw RFC 3339 timestamp never reaches the table.
 fn render_column(object: &serde_json::Value, column: &PrinterColumn) -> String {
@@ -306,6 +315,10 @@ pub struct CustomRow {
     /// Values for the requested printer columns, in the order they were asked
     /// for. Empty when none were requested.
     pub columns: Vec<String>,
+    /// Unrendered values for the columns whose display text loses ordering
+    /// information -- `type: date`, where timestamps 65 and 115 minutes old both
+    /// render "1h" and would otherwise tie. Empty where the text sorts fine.
+    pub sort_keys: Vec<String>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -354,17 +367,21 @@ pub fn list_custom_resource_capability(cache: Arc<ClientCache>) -> Capability {
                     .items
                     .into_iter()
                     .map(|o| {
-                        let values = if columns.is_empty() {
-                            Vec::new()
+                        let (values, sort_keys) = if columns.is_empty() {
+                            (Vec::new(), Vec::new())
                         } else {
                             let object = whole_object(&o);
-                            columns.iter().map(|c| render_column(&object, c)).collect()
+                            columns
+                                .iter()
+                                .map(|c| (render_column(&object, c), column_sort_key(&object, c)))
+                                .unzip()
                         };
                         CustomRow {
                             name: o.metadata.name.clone().unwrap_or_default(),
                             namespace: o.metadata.namespace.clone().unwrap_or_default(),
                             age: crate::humanize_age(o.metadata.creation_timestamp.as_ref()),
                             columns: values,
+                            sort_keys,
                         }
                     })
                     .collect();
@@ -530,6 +547,28 @@ mod tests {
         // Compact age (e.g. "6y"), never the raw RFC 3339 string.
         assert!(!rendered.contains("2020-01-01"), "got {rendered}");
         assert!(rendered.ends_with('y'), "got {rendered}");
+    }
+
+    #[test]
+    fn date_columns_carry_the_raw_timestamp_for_sorting() {
+        let object = serde_json::json!({
+            "status": {"since": "2020-01-01T00:00:00Z", "health": "GREEN"}
+        });
+        let date = PrinterColumn {
+            name: "Since".into(),
+            json_path: ".status.since".into(),
+            column_type: "date".into(),
+        };
+        let text = PrinterColumn {
+            name: "Health".into(),
+            json_path: ".status.health".into(),
+            column_type: "string".into(),
+        };
+        // Two timestamps inside the same displayed unit render alike, so the
+        // raw value has to travel alongside for the table to order them.
+        assert_eq!(column_sort_key(&object, &date), "2020-01-01T00:00:00Z");
+        // Text columns already sort by what is shown; no second value needed.
+        assert_eq!(column_sort_key(&object, &text), "");
     }
 
     #[test]

--- a/crates/kube/src/crds.rs
+++ b/crates/kube/src/crds.rs
@@ -204,14 +204,25 @@ fn unquote(text: &str) -> &str {
     text.trim_matches(|c| c == '\'' || c == '"')
 }
 
-/// Put a DynamicObject back together as one JSON value. `kube` splits typed
-/// metadata out of `data`, but printer columns address the whole resource, so
-/// `.metadata.labels[...]` has to resolve like any other path.
+/// Put a DynamicObject back together as one JSON value.
+///
+/// `kube` splits an object across three places -- `types` (apiVersion, kind),
+/// typed `metadata`, and everything else in `data` -- but a printer column
+/// addresses the resource as the API serves it, so all three have to be
+/// reunited or paths like `.metadata.labels[...]` and `.kind` resolve empty.
 fn whole_object(object: &DynamicObject) -> serde_json::Value {
     let mut value = object.data.clone();
-    if let (Some(map), Ok(metadata)) = (value.as_object_mut(), serde_json::to_value(&object.metadata))
-    {
+    let Some(map) = value.as_object_mut() else {
+        return value;
+    };
+    if let Ok(metadata) = serde_json::to_value(&object.metadata) {
         map.insert("metadata".to_string(), metadata);
+    }
+    // TypeMeta serializes flat, as apiVersion + kind beside the other fields.
+    if let Some(types) = object.types.as_ref() {
+        if let Ok(serde_json::Value::Object(fields)) = serde_json::to_value(types) {
+            map.extend(fields);
+        }
     }
     value
 }
@@ -631,6 +642,25 @@ mod tests {
         let rendered: Vec<String> =
             columns.iter().map(|c| render_column(&release, c)).collect();
         assert_eq!(rendered, vec!["True", "Release reconciliation succeeded"]);
+    }
+
+    #[test]
+    fn type_paths_resolve_even_though_kube_splits_them_out_too() {
+        // kube keeps apiVersion/kind in `types`, separate from both `data` and
+        // `metadata`, so a column addressing them needs all three put back.
+        let object: DynamicObject = serde_json::from_value(serde_json::json!({
+            "apiVersion": "db.example.com/v1",
+            "kind": "Cluster",
+            "metadata": {"name": "c1"},
+            "spec": {"version": "4.1.2"},
+        }))
+        .expect("dynamic object");
+        let whole = whole_object(&object);
+        assert_eq!(resolve_json_path(&whole, ".kind"), "Cluster");
+        assert_eq!(resolve_json_path(&whole, ".apiVersion"), "db.example.com/v1");
+        // The other two sources still resolve.
+        assert_eq!(resolve_json_path(&whole, ".metadata.name"), "c1");
+        assert_eq!(resolve_json_path(&whole, ".spec.version"), "4.1.2");
     }
 
     #[test]

--- a/crates/kube/src/crds.rs
+++ b/crates/kube/src/crds.rs
@@ -17,8 +17,25 @@ pub struct ListCrdsIn {
     pub context: String,
 }
 
+/// One column a CRD asks tools to display, from
+/// `spec.versions[].additionalPrinterColumns` -- the same metadata `kubectl get`
+/// renders. Without these a custom resource list can only show name/namespace/age,
+/// because nothing else is common to every kind.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PrinterColumn {
+    /// Column heading, e.g. "Health".
+    pub name: String,
+    /// Restricted JSONPath into the resource, e.g. ".status.health".
+    pub json_path: String,
+    /// OpenAPI type: string, integer, number, boolean or date.
+    #[serde(rename = "type", default)]
+    pub column_type: String,
+}
+
 /// A discovered CustomResourceDefinition, enough to list its instances.
 #[derive(Debug, Clone, PartialEq, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct CrdDescriptor {
     /// Metadata name, e.g. "gateways.gateway.networking.k8s.io".
     pub name: String,
@@ -27,6 +44,8 @@ pub struct CrdDescriptor {
     pub kind: String,
     pub plural: String,
     pub namespaced: bool,
+    /// Columns this CRD asks to have displayed, in declaration order.
+    pub printer_columns: Vec<PrinterColumn>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -38,20 +57,157 @@ fn handler_err(e: impl ToString) -> CapabilityError {
     CapabilityError::Handler(e.to_string())
 }
 
-/// Choose the storage version, else the first served version, else the first.
-fn pick_version(spec: &serde_json::Value) -> String {
-    let versions = match spec["versions"].as_array() {
-        Some(v) => v,
-        None => return String::new(),
-    };
+/// The storage version, else the first served version, else the first.
+fn chosen_version(spec: &serde_json::Value) -> Option<&serde_json::Value> {
+    let versions = spec["versions"].as_array()?;
     versions
         .iter()
         .find(|v| v["storage"].as_bool().unwrap_or(false))
         .or_else(|| versions.iter().find(|v| v["served"].as_bool().unwrap_or(false)))
         .or_else(|| versions.first())
+}
+
+/// Choose the storage version, else the first served version, else the first.
+fn pick_version(spec: &serde_json::Value) -> String {
+    chosen_version(spec)
         .and_then(|v| v["name"].as_str())
         .unwrap_or_default()
         .to_string()
+}
+
+/// The printer columns worth showing for the chosen version.
+///
+/// Drops two kinds that would only add noise: `priority > 0` is `kubectl -o
+/// wide` territory, and a column reading `.metadata.creationTimestamp` merely
+/// duplicates the Age column every list already renders.
+fn printer_columns(spec: &serde_json::Value) -> Vec<PrinterColumn> {
+    let Some(version) = chosen_version(spec) else {
+        return Vec::new();
+    };
+    let Some(columns) = version["additionalPrinterColumns"].as_array() else {
+        return Vec::new();
+    };
+    columns
+        .iter()
+        .filter(|c| c["priority"].as_i64().unwrap_or(0) == 0)
+        .filter_map(|c| {
+            let json_path = c["jsonPath"].as_str()?.to_string();
+            if json_path == ".metadata.creationTimestamp" {
+                return None;
+            }
+            Some(PrinterColumn {
+                name: c["name"].as_str()?.to_string(),
+                json_path,
+                column_type: c["type"].as_str().unwrap_or_default().to_string(),
+            })
+        })
+        .collect()
+}
+
+/// Read a CRD `jsonPath` out of a resource, rendering the leaf as display text.
+///
+/// CRDs use a small JSONPath subset rather than the full grammar, so this walks
+/// it directly instead of pulling in an engine. Supported segments:
+///
+/// - `.foo` and `['foo']` / `["foo"]` — object keys (the bracket form is what
+///   label keys need, since they contain dots and slashes)
+/// - `[0]` — array index
+/// - `[?(@.type=="Ready")]` — first array element whose field equals a literal,
+///   which is how Flux, cert-manager and most operators surface a condition
+///
+/// Anything absent, null, or not a scalar renders empty — an empty cell reads
+/// better than a blob of JSON.
+fn resolve_json_path(value: &serde_json::Value, path: &str) -> String {
+    let mut current = value;
+    let mut rest = path.trim_start_matches('.');
+    while !rest.is_empty() {
+        let (segment, remainder) = match rest.strip_prefix('[') {
+            Some(open) => {
+                let Some(close) = open.find(']') else { return String::new() };
+                (Segment::bracket(&open[..close]), open[close + 1..].trim_start_matches('.'))
+            }
+            None => {
+                let end = rest.find(['.', '[']).unwrap_or(rest.len());
+                (Segment::Key(rest[..end].to_string()), rest[end..].trim_start_matches('.'))
+            }
+        };
+        let Some(next) = segment.apply(current) else { return String::new() };
+        current = next;
+        rest = remainder;
+    }
+    match current {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        _ => String::new(),
+    }
+}
+
+/// One step of a CRD jsonPath.
+enum Segment {
+    Key(String),
+    Index(usize),
+    /// `[?(@.field=="literal")]` — the first array element that matches.
+    Filter { field: String, literal: String },
+}
+
+impl Segment {
+    /// Parse the inside of a `[...]`.
+    fn bracket(inner: &str) -> Segment {
+        let trimmed = inner.trim();
+        if let Some(expression) = trimmed.strip_prefix("?(").and_then(|e| e.strip_suffix(')')) {
+            if let Some((left, right)) = expression.split_once("==") {
+                return Segment::Filter {
+                    field: left.trim().trim_start_matches('@').trim_start_matches('.').to_string(),
+                    literal: unquote(right.trim()).to_string(),
+                };
+            }
+        }
+        if let Ok(index) = trimmed.parse::<usize>() {
+            return Segment::Index(index);
+        }
+        Segment::Key(unquote(trimmed).to_string())
+    }
+
+    fn apply<'v>(&self, value: &'v serde_json::Value) -> Option<&'v serde_json::Value> {
+        match self {
+            Segment::Key(key) => value.get(key),
+            Segment::Index(index) => value.get(index),
+            Segment::Filter { field, literal } => value
+                .as_array()?
+                .iter()
+                .find(|item| resolve_json_path(item, field) == *literal),
+        }
+    }
+}
+
+fn unquote(text: &str) -> &str {
+    text.trim_matches(|c| c == '\'' || c == '"')
+}
+
+/// Put a DynamicObject back together as one JSON value. `kube` splits typed
+/// metadata out of `data`, but printer columns address the whole resource, so
+/// `.metadata.labels[...]` has to resolve like any other path.
+fn whole_object(object: &DynamicObject) -> serde_json::Value {
+    let mut value = object.data.clone();
+    if let (Some(map), Ok(metadata)) = (value.as_object_mut(), serde_json::to_value(&object.metadata))
+    {
+        map.insert("metadata".to_string(), metadata);
+    }
+    value
+}
+
+/// Render one cell, humanizing `type: date` columns the way ages are shown
+/// elsewhere so a raw RFC 3339 timestamp never reaches the table.
+fn render_column(object: &serde_json::Value, column: &PrinterColumn) -> String {
+    let raw = resolve_json_path(object, &column.json_path);
+    if column.column_type != "date" || raw.is_empty() {
+        return raw;
+    }
+    match raw.parse::<k8s_openapi::jiff::Timestamp>() {
+        Ok(ts) => crate::humanize_age(Some(&k8s_openapi::apimachinery::pkg::apis::meta::v1::Time(ts))),
+        Err(_) => raw,
+    }
 }
 
 /// `k8s.listCRDs` — discover installed CustomResourceDefinitions.
@@ -94,6 +250,7 @@ pub fn list_crds_capability(cache: Arc<ClientCache>) -> Capability {
                             kind,
                             plural,
                             namespaced,
+                            printer_columns: printer_columns(spec),
                         })
                     })
                     .collect();
@@ -105,6 +262,7 @@ pub fn list_crds_capability(cache: Arc<ClientCache>) -> Capability {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct ListCustomIn {
     pub context: String,
     pub group: String,
@@ -114,13 +272,21 @@ pub struct ListCustomIn {
     pub namespaced: bool,
     #[serde(default)]
     pub namespace: String,
+    /// Columns to resolve per item, from the CRD's `additionalPrinterColumns`.
+    /// Callers that omit these get just name/namespace/age, as before.
+    #[serde(default)]
+    pub printer_columns: Vec<PrinterColumn>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct CustomRow {
     pub name: String,
     pub namespace: String,
     pub age: String,
+    /// Values for the requested printer columns, in the order they were asked
+    /// for. Empty when none were requested.
+    pub columns: Vec<String>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -164,13 +330,23 @@ pub fn list_custom_resource_capability(cache: Arc<ClientCache>) -> Capability {
                     .await
                     .map_err(|_| CapabilityError::Handler("list custom resource timed out".into()))?
                     .map_err(handler_err)?;
+                let columns = input.printer_columns;
                 let items = list
                     .items
                     .into_iter()
-                    .map(|o| CustomRow {
-                        name: o.metadata.name.unwrap_or_default(),
-                        namespace: o.metadata.namespace.unwrap_or_default(),
-                        age: crate::humanize_age(o.metadata.creation_timestamp.as_ref()),
+                    .map(|o| {
+                        let values = if columns.is_empty() {
+                            Vec::new()
+                        } else {
+                            let object = whole_object(&o);
+                            columns.iter().map(|c| render_column(&object, c)).collect()
+                        };
+                        CustomRow {
+                            name: o.metadata.name.clone().unwrap_or_default(),
+                            namespace: o.metadata.namespace.clone().unwrap_or_default(),
+                            age: crate::humanize_age(o.metadata.creation_timestamp.as_ref()),
+                            columns: values,
+                        }
                     })
                     .collect();
                 Ok(ListCustomOut { items })
@@ -200,6 +376,194 @@ mod tests {
             ]
         });
         assert_eq!(pick_version(&spec), "v1beta1");
+    }
+
+    fn obj() -> serde_json::Value {
+        serde_json::json!({
+            "spec": { "version": "4.1.2", "nodes": 3, "paused": false },
+            "status": { "health": "GREEN", "conditions": [{"type": "Ready"}], "empty": null },
+            "metadata": { "labels": { "app.kubernetes.io/name": "cassandra" } },
+        })
+    }
+
+    #[test]
+    fn resolves_dotted_paths_to_scalars() {
+        assert_eq!(resolve_json_path(&obj(), ".status.health"), "GREEN");
+        assert_eq!(resolve_json_path(&obj(), ".spec.version"), "4.1.2");
+        // Numbers and bools render as text, not JSON-quoted.
+        assert_eq!(resolve_json_path(&obj(), ".spec.nodes"), "3");
+        assert_eq!(resolve_json_path(&obj(), ".spec.paused"), "false");
+    }
+
+    #[test]
+    fn resolves_bracket_segments_for_keys_containing_dots() {
+        assert_eq!(
+            resolve_json_path(&obj(), ".metadata.labels['app.kubernetes.io/name']"),
+            "cassandra"
+        );
+    }
+
+    /// Flux's HelmRelease, cert-manager and many operators address a condition
+    /// by type rather than by index, so the filter form is not exotic.
+    fn fluxish() -> serde_json::Value {
+        serde_json::json!({
+            "status": { "conditions": [
+                {"type": "Stalled", "status": "False", "message": "nope"},
+                {"type": "Ready", "status": "True", "message": "Release reconciliation succeeded"},
+            ]},
+            "spec": { "ports": [{"port": 80}, {"port": 443}] },
+        })
+    }
+
+    #[test]
+    fn resolves_filter_expressions_by_field_equality() {
+        assert_eq!(
+            resolve_json_path(&fluxish(), ".status.conditions[?(@.type==\"Ready\")].status"),
+            "True"
+        );
+        assert_eq!(
+            resolve_json_path(&fluxish(), ".status.conditions[?(@.type==\"Ready\")].message"),
+            "Release reconciliation succeeded"
+        );
+    }
+
+    #[test]
+    fn filter_expressions_accept_single_quotes_and_spacing() {
+        assert_eq!(
+            resolve_json_path(&fluxish(), ".status.conditions[?(@.type == 'Stalled')].status"),
+            "False"
+        );
+    }
+
+    #[test]
+    fn a_filter_matching_nothing_renders_empty() {
+        assert_eq!(
+            resolve_json_path(&fluxish(), ".status.conditions[?(@.type==\"Missing\")].status"),
+            ""
+        );
+    }
+
+    #[test]
+    fn resolves_numeric_array_indexes() {
+        assert_eq!(resolve_json_path(&fluxish(), ".spec.ports[1].port"), "443");
+        assert_eq!(resolve_json_path(&fluxish(), ".spec.ports[9].port"), "");
+    }
+
+    #[test]
+    fn missing_null_and_non_scalar_paths_render_empty() {
+        assert_eq!(resolve_json_path(&obj(), ".status.nope"), "");
+        assert_eq!(resolve_json_path(&obj(), ".status.empty"), "");
+        // kubectl renders arrays/objects poorly; an empty cell beats noise.
+        assert_eq!(resolve_json_path(&obj(), ".status.conditions"), "");
+        assert_eq!(resolve_json_path(&obj(), ".spec"), "");
+    }
+
+    fn spec_with_columns() -> serde_json::Value {
+        serde_json::json!({
+            "versions": [{
+                "name": "v1", "served": true, "storage": true,
+                "additionalPrinterColumns": [
+                    {"name": "Health", "type": "string", "jsonPath": ".status.health"},
+                    {"name": "Version", "type": "string", "jsonPath": ".spec.version"},
+                    {"name": "Verbose", "type": "string", "jsonPath": ".spec.x", "priority": 1},
+                    {"name": "Age", "type": "date", "jsonPath": ".metadata.creationTimestamp"},
+                ],
+            }]
+        })
+    }
+
+    #[test]
+    fn takes_printer_columns_from_the_chosen_version() {
+        let cols = printer_columns(&spec_with_columns());
+        // Priority > 0 is `kubectl -o wide` only, and the table already has its
+        // own Age column, so neither should reach the UI.
+        assert_eq!(
+            cols.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
+            vec!["Health", "Version"]
+        );
+        assert_eq!(cols[0].json_path, ".status.health");
+    }
+
+    #[test]
+    fn a_crd_without_printer_columns_yields_none() {
+        let spec = serde_json::json!({"versions": [{"name": "v1", "storage": true}]});
+        assert!(printer_columns(&spec).is_empty());
+    }
+
+    #[test]
+    fn date_columns_render_as_an_age_not_a_timestamp() {
+        let object = serde_json::json!({"status": {"since": "2020-01-01T00:00:00Z"}});
+        let column = PrinterColumn {
+            name: "Since".into(),
+            json_path: ".status.since".into(),
+            column_type: "date".into(),
+        };
+        let rendered = render_column(&object, &column);
+        // Compact age (e.g. "6y"), never the raw RFC 3339 string.
+        assert!(!rendered.contains("2020-01-01"), "got {rendered}");
+        assert!(rendered.ends_with('y'), "got {rendered}");
+    }
+
+    #[test]
+    fn unparseable_date_falls_back_to_the_raw_value() {
+        let object = serde_json::json!({"status": {"since": "not a date"}});
+        let column = PrinterColumn {
+            name: "Since".into(),
+            json_path: ".status.since".into(),
+            column_type: "date".into(),
+        };
+        assert_eq!(render_column(&object, &column), "not a date");
+    }
+
+    #[test]
+    fn metadata_paths_resolve_even_though_kube_splits_metadata_out() {
+        let object: DynamicObject = serde_json::from_value(serde_json::json!({
+            "apiVersion": "db.example.com/v1",
+            "kind": "Cluster",
+            "metadata": {"name": "c1", "labels": {"app.kubernetes.io/name": "cassandra"}},
+            "spec": {"version": "4.1.2"},
+        }))
+        .expect("dynamic object");
+        let whole = whole_object(&object);
+        assert_eq!(
+            resolve_json_path(&whole, ".metadata.labels['app.kubernetes.io/name']"),
+            "cassandra"
+        );
+        assert_eq!(resolve_json_path(&whole, ".spec.version"), "4.1.2");
+    }
+
+    /// End-to-end over Flux's HelmRelease, which is where the empty Ready and
+    /// Status cells were first seen: its columns are filter expressions, and it
+    /// declares its own Age that would otherwise duplicate the built-in one.
+    #[test]
+    fn renders_flux_helmrelease_columns() {
+        let spec = serde_json::json!({
+            "versions": [{
+                "name": "v2", "served": true, "storage": true,
+                "additionalPrinterColumns": [
+                    {"name": "Age", "type": "date", "jsonPath": ".metadata.creationTimestamp"},
+                    {"name": "Ready", "type": "string",
+                     "jsonPath": ".status.conditions[?(@.type==\"Ready\")].status"},
+                    {"name": "Status", "type": "string",
+                     "jsonPath": ".status.conditions[?(@.type==\"Ready\")].message"},
+                ],
+            }]
+        });
+        let columns = printer_columns(&spec);
+        assert_eq!(
+            columns.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
+            vec!["Ready", "Status"],
+        );
+
+        let release = serde_json::json!({
+            "status": {"conditions": [
+                {"type": "Released", "status": "True", "message": "Helm install succeeded"},
+                {"type": "Ready", "status": "True", "message": "Release reconciliation succeeded"},
+            ]}
+        });
+        let rendered: Vec<String> =
+            columns.iter().map(|c| render_column(&release, c)).collect();
+        assert_eq!(rendered, vec!["True", "Release reconciliation succeeded"]);
     }
 
     #[test]

--- a/crates/kube/src/crds.rs
+++ b/crates/kube/src/crds.rs
@@ -109,8 +109,8 @@ fn printer_columns(spec: &serde_json::Value) -> Vec<PrinterColumn> {
 /// CRDs use a small JSONPath subset rather than the full grammar, so this walks
 /// it directly instead of pulling in an engine. Supported segments:
 ///
-/// - `.foo` and `['foo']` / `["foo"]` — object keys (the bracket form is what
-///   label keys need, since they contain dots and slashes)
+/// - `.foo`, `.a\.b` and `['foo']` / `["foo"]` — object keys; both the escape
+///   and the bracket form let a key contain dots, as label keys do
 /// - `[0]` — array index
 /// - `[?(@.type=="Ready")]` — first array element whose field equals a literal,
 ///   which is how Flux, cert-manager and most operators surface a condition
@@ -127,8 +127,27 @@ fn resolve_json_path(value: &serde_json::Value, path: &str) -> String {
                 (Segment::bracket(&open[..close]), open[close + 1..].trim_start_matches('.'))
             }
             None => {
-                let end = rest.find(['.', '[']).unwrap_or(rest.len());
-                (Segment::Key(rest[..end].to_string()), rest[end..].trim_start_matches('.'))
+                // Scan to the next *unescaped* separator. `\.` keeps a literal dot
+                // inside the key, which is how a CRD can address a label such as
+                // `app\.kubernetes\.io/name` without bracket notation.
+                let mut key = String::new();
+                let mut end = rest.len();
+                let mut chars = rest.char_indices();
+                while let Some((index, ch)) = chars.next() {
+                    match ch {
+                        '\\' => {
+                            if let Some((_, escaped)) = chars.next() {
+                                key.push(escaped);
+                            }
+                        }
+                        '.' | '[' => {
+                            end = index;
+                            break;
+                        }
+                        _ => key.push(ch),
+                    }
+                }
+                (Segment::Key(key), rest[end..].trim_start_matches('.'))
             }
         };
         let Some(next) = segment.apply(current) else { return String::new() };
@@ -393,6 +412,15 @@ mod tests {
         // Numbers and bools render as text, not JSON-quoted.
         assert_eq!(resolve_json_path(&obj(), ".spec.nodes"), "3");
         assert_eq!(resolve_json_path(&obj(), ".spec.paused"), "false");
+    }
+
+    #[test]
+    fn resolves_backslash_escaped_dots_in_key_names() {
+        // A CRD may address a dotted label key without bracket notation.
+        assert_eq!(
+            resolve_json_path(&obj(), r".metadata.labels.app\.kubernetes\.io/name"),
+            "cassandra"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #267.

A custom resource list showed only name, namespace and age. There is no fixed set of extra fields that would help, because custom resources share nothing beyond metadata — the columns worth showing differ per CRD.

Kubernetes already solves this: every CRD declares `spec.versions[].additionalPrinterColumns`, and that is exactly what `kubectl get` renders. We fetch the whole CRD in `k8s.listCRDs` and were throwing the field away — `pick_version` read only the version name. **The information was already on the wire and simply discarded**, which is why this lands as a fix rather than a feature. It also means each CRD gets its own correct columns, instead of four hardcoded headings that would be blank for everything that isn't the operator in the issue.

## Backend (`crates/kube/src/crds.rs`)

- `CrdDescriptor` carries `printerColumns`; `pick_version` is refactored so the version name and its columns come from the same chosen version.
- `k8s.listCustomResource` accepts the columns as input, so listing needs no second round trip to re-read the CRD. Callers that omit them — existing MCP consumers — get exactly the previous `name`/`namespace`/`age`.
- Filtered out: `priority > 0` (that is `kubectl -o wide` territory) and any column reading `.metadata.creationTimestamp`, which merely duplicates the Age column every list already renders.
- `resolve_json_path` walks the subset CRDs actually use rather than adding a JSONPath engine: object keys, the `['key']` form label keys need, array indexes, and `[?(@.type=="Ready")]` filters. Absent, null and non-scalar values render empty; `type: date` columns are humanized so a raw RFC 3339 string never reaches a cell.
- `kube` splits typed metadata out of a `DynamicObject`'s `data`, so the two are recombined before resolving — otherwise `.metadata.labels[...]` columns come back silently empty.

## Frontend

`CrdRef` carries `printerColumns`, `CustomRow` carries `columns`, and `CustomResourceBrowser` renders **Name → [Namespace] → declared columns → Age**, the order kubectl uses. Columns are keyed positionally (`printer:<index>`) because CRD headings are not guaranteed unique, and they take part in the existing `ColumnPicker`, search and sort.

## On filter expressions

The first cut supported only dotted and bracketed keys. Testing against a real cluster showed Flux HelmRelease headers appearing with **empty values**, because Flux addresses conditions by type:

```yaml
jsonPath: .status.conditions[?(@.type=="Ready")].status
```

Filter expressions are not an edge case — they are how Flux, cert-manager and most operators surface a condition. The resolver now parses them, and recursion means a filter's own field lookup goes through the same code path.

## Verification

- Rust: **1081 passed, 0 failed** (16 in `crds`).
- Frontend: **1223 passed**, `tsc --noEmit` clean, coverage gate green.
- Tests were written failing first. The three filter tests reproduced the empty cells before the fix.
- Includes an end-to-end test over Flux's real HelmRelease CRD asserting `Ready → "True"` and `Status → "Release reconciliation succeeded"`, plus coverage for single/double quotes, spacing around `==`, a filter matching nothing, array indexes, `type: date` humanizing, unparseable dates falling back to the raw value, and metadata paths resolving through a real `DynamicObject`.

## Reviewer notes

- A CRD declaring no printer columns is unchanged — still name/namespace/age.
- Columns using a jsonPath form outside this subset (recursive descent `..`, wildcards, slices) will render empty rather than error. Extending the resolver is straightforward if any real CRD needs it.
