### PR TITLE
fix(mcp): attribute subscription audit records to the calling transport

### DIFF
--- a/crates/mcp/src/http.rs
+++ b/crates/mcp/src/http.rs
@@ -359,7 +359,12 @@ async fn rpc(
         // never deliver.
         let sessions = st.push.sessions.lock().unwrap_or_else(|e| e.into_inner());
         match sessions.get(&session) {
-            Some(c) => handle_subscription(&st.server, &c.subs, &c.dirty, &c.wake, &req, method),
+            Some(c) => {
+                handle_subscription(
+                    &st.server, &c.subs, &c.dirty, &c.wake, &req, method,
+                    crate::Transport::Http,
+                )
+            }
             None => req.get("id").cloned().map(|id| {
                 json!({"jsonrpc": "2.0", "id": id, "error": {"code": -32002, "message":
                     "no notification stream is connected for this session: open GET /mcp \
@@ -666,6 +671,35 @@ mod tests {
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn a_subscription_over_http_is_audited_as_http() {
+        // The audit log is how an operator attributes an action to a caller, so
+        // a networked subscribe recorded as stdio is worse than not logging it.
+        #[derive(Default)]
+        struct Spy(Mutex<Vec<(String, crate::Transport)>>);
+        impl crate::audit::AuditSink for Spy {
+            fn record(&self, rec: crate::audit::AuditRecord) {
+                self.0.lock().unwrap().push((rec.tool, rec.transport));
+            }
+        }
+        let spy = Arc::new(Spy::default());
+        let joins = Arc::new(Mutex::new(Vec::new()));
+        let app = router(subscribable_server(joins).with_audit(spy.clone()));
+
+        // A stream must exist for the subscribe to reach the handler at all.
+        let stream_resp = app.clone().oneshot(sse_get()).await.unwrap();
+        assert_eq!(stream_resp.status(), StatusCode::OK);
+        let _ = app.clone().oneshot(subscribe_post("k8s://c/ns/Pod/web-0")).await.unwrap();
+
+        let seen = spy.0.lock().unwrap().clone();
+        let subscribes: Vec<_> =
+            seen.iter().filter(|(tool, _)| tool == "resources/subscribe").collect();
+        assert!(!subscribes.is_empty(), "the subscribe must be audited: {seen:?}");
+        for (tool, transport) in subscribes {
+            assert_eq!(*transport, crate::Transport::Http, "{tool} attributed to the wrong transport");
+        }
     }
 
     #[tokio::test]

--- a/crates/mcp/src/stdio.rs
+++ b/crates/mcp/src/stdio.rs
@@ -401,6 +401,10 @@ pub(crate) fn handle_subscription(
     wake: &tokio::sync::mpsc::Sender<()>,
     req: &Value,
     method: &str,
+    // Both transports route subscriptions through here, so the caller's own
+    // transport has to travel with them: an audit record naming the wrong
+    // one misattributes the action, which is the whole point of the log.
+    transport: crate::Transport,
 ) -> Option<Value> {
     let id = req.get("id").cloned()?;
     let uri_str = req
@@ -413,7 +417,7 @@ pub(crate) fn handle_subscription(
         Ok(u) => u,
         Err(message) => {
             server.audit().record(crate::audit::AuditRecord {
-                transport: crate::Transport::Stdio,
+                transport,
                 tool: method.to_string(),
                 args: crate::audit::redact(&json!({"uri": uri_str}), false),
                 decision: "auto",
@@ -429,7 +433,7 @@ pub(crate) fn handle_subscription(
     if method == "resources/unsubscribe" {
         subs.remove(&canonical);
         server.audit().record(crate::audit::AuditRecord {
-            transport: crate::Transport::Stdio,
+            transport,
             tool: method.to_string(),
             args: crate::audit::redact(&json!({"uri": uri_str}), false),
             decision: "auto",
@@ -441,7 +445,7 @@ pub(crate) fn handle_subscription(
 
     if let Err(message) = crate::resources::is_subscribable(&uri) {
         server.audit().record(crate::audit::AuditRecord {
-            transport: crate::Transport::Stdio,
+            transport,
             tool: method.to_string(),
             args: crate::audit::redact(&json!({"uri": uri_str}), false),
             decision: "auto",
@@ -460,7 +464,7 @@ pub(crate) fn handle_subscription(
     // eventual read agree on what's addressable.
     if let Err(message) = crate::resources::plan_read(&uri, server.kind_resolver().as_ref()) {
         server.audit().record(crate::audit::AuditRecord {
-            transport: crate::Transport::Stdio,
+            transport,
             tool: method.to_string(),
             args: crate::audit::redact(&json!({"uri": uri_str}), false),
             decision: "auto",
@@ -538,7 +542,7 @@ pub(crate) fn handle_subscription(
         Ok(h) => h,
         Err(message) => {
             server.audit().record(crate::audit::AuditRecord {
-                transport: crate::Transport::Stdio,
+                transport,
                 tool: method.to_string(),
                 args: crate::audit::redact(&json!({"uri": uri_str}), false),
                 decision: "auto",
@@ -558,7 +562,7 @@ pub(crate) fn handle_subscription(
         handle.abort();
         let message = format!("the watch ended immediately: {reason}");
         server.audit().record(crate::audit::AuditRecord {
-            transport: crate::Transport::Stdio,
+            transport,
             tool: method.to_string(),
             args: crate::audit::redact(&json!({"uri": uri_str}), false),
             decision: "auto",
@@ -571,7 +575,7 @@ pub(crate) fn handle_subscription(
         Ok(generation) => generation,
         Err(message) => {
             server.audit().record(crate::audit::AuditRecord {
-                transport: crate::Transport::Stdio,
+                transport,
                 tool: method.to_string(),
                 args: crate::audit::redact(&json!({"uri": uri_str}), false),
                 decision: "auto",
@@ -593,7 +597,7 @@ pub(crate) fn handle_subscription(
         subs.remove_if(&canonical, generation);
         let message = format!("the watch ended immediately: {reason}");
         server.audit().record(crate::audit::AuditRecord {
-            transport: crate::Transport::Stdio,
+            transport,
             tool: method.to_string(),
             args: crate::audit::redact(&json!({"uri": uri_str}), false),
             decision: "auto",
@@ -603,7 +607,7 @@ pub(crate) fn handle_subscription(
         return Some(err(id, -32603, &message));
     }
     server.audit().record(crate::audit::AuditRecord {
-        transport: crate::Transport::Stdio,
+        transport,
         tool: method.to_string(),
         args: crate::audit::redact(&json!({"uri": uri_str}), false),
         decision: "auto",
@@ -700,7 +704,7 @@ where
                 // HTTP transport, which has no channel to push notifications and
                 // must keep answering -32601.
                 let resp = if method == "resources/subscribe" || method == "resources/unsubscribe" {
-                    handle_subscription(server, subs, dirty, wake_tx, &req, method)
+                    handle_subscription(server, subs, dirty, wake_tx, &req, method, crate::Transport::Stdio)
                 } else {
                     handle_request(server, &req, crate::Transport::Stdio).await
                 };
@@ -1895,7 +1899,7 @@ mod tests {
         let req = json!({"jsonrpc":"2.0","id":1,"method":"resources/subscribe",
             "params":{"uri":"k8s://c/ns/Pod/web-0"}});
         let resp =
-            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe")
+            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe", crate::Transport::Stdio)
                 .unwrap();
         let message = resp["error"]["message"].as_str().unwrap_or_default();
         assert!(message.contains("ended immediately"), "got: {resp}");
@@ -1942,7 +1946,7 @@ mod tests {
         let req = json!({"jsonrpc":"2.0","id":1,"method":"resources/subscribe",
             "params":{"uri":"k8s://c/ns/Pod/web-0"}});
         let resp =
-            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe")
+            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe", crate::Transport::Stdio)
                 .unwrap();
         assert!(resp.get("error").is_none(), "the live subscribe succeeds: {resp}");
 
@@ -1997,13 +2001,13 @@ mod tests {
             "params":{"uri":"k8s://c/ns/Pod/web-0"}});
 
         let first =
-            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe")
+            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe", crate::Transport::Stdio)
                 .unwrap();
         assert!(first.get("error").is_none(), "the first subscribe succeeds: {first}");
 
         // The re-subscribe's replacement watch is stillborn.
         let second =
-            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe")
+            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe", crate::Transport::Stdio)
                 .unwrap();
         assert!(
             second["error"]["message"].as_str().unwrap_or_default().contains("ended immediately"),
@@ -2056,7 +2060,7 @@ mod tests {
         // Subscribe twice: the second replaces the first in the registry.
         for _ in 0..2 {
             let resp =
-                handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe")
+                handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe", crate::Transport::Stdio)
                     .unwrap();
             assert!(resp.get("error").is_none(), "subscribe succeeds: {resp}");
         }
@@ -2363,7 +2367,7 @@ mod tests {
             "params":{"uri":"k8s://c/ns/Pod/web-0"}});
 
         let resp =
-            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe")
+            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe", crate::Transport::Stdio)
                 .unwrap();
         assert!(resp.get("error").is_none(), "the subscribe succeeds: {resp}");
 
@@ -2391,7 +2395,7 @@ mod tests {
             "params":{"uri":"k8s://catalog"}});
 
         let resp =
-            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe")
+            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe", crate::Transport::Stdio)
                 .unwrap();
         assert_eq!(resp["error"]["code"], -32602, "got {resp}");
 
@@ -2418,7 +2422,7 @@ mod tests {
             "params":{"uri":"k8s://c/ns/Secret/shared"}});
 
         let resp =
-            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe")
+            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe", crate::Transport::Stdio)
                 .unwrap();
         assert_eq!(resp["error"]["code"], -32602, "got {resp}");
 
@@ -2467,7 +2471,7 @@ mod tests {
             "params":{"uri":"k8s://c/ns/Pod/web-0"}});
 
         let resp =
-            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe")
+            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe", crate::Transport::Stdio)
                 .unwrap();
         assert_eq!(resp["error"]["code"], -32602, "got {resp}");
 
@@ -2495,7 +2499,7 @@ mod tests {
             "params":{"uri":"k8s://c/ns/Pod/one-too-many"}});
 
         let resp =
-            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe")
+            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe", crate::Transport::Stdio)
                 .unwrap();
         assert_eq!(resp["error"]["code"], -32602, "got {resp}");
 
@@ -2517,7 +2521,7 @@ mod tests {
             "params":{"uri":"k8s://c/ns/Pod/web-0"}});
 
         let resp =
-            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/unsubscribe")
+            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/unsubscribe", crate::Transport::Stdio)
                 .unwrap();
         assert!(resp.get("error").is_none(), "unsubscribe succeeds: {resp}");
 


### PR DESCRIPTION
Every `resources/subscribe` and `resources/unsubscribe` made by a networked MCP client was audit-logged as if it had arrived over stdio.

## The bug

`handle_subscription` (`stdio.rs`) stamped all nine audit records it emits with a hardcoded `Transport::Stdio`. But both transports route through that helper — `http.rs:352` dispatches the two subscription methods there deliberately, because they need the caller's own push machinery (session registry, dirty set, stream wakeup) rather than the generic `handle_request` path.

Attribution is the entire purpose of the audit log, which makes a wrong transport worse than a missing record. It reads as authoritative, sends an operator filtering by transport to the wrong caller, and silently omits exactly the remote traffic the log exists to account for. On a change whose own issue (#198) is labelled `type/security`, that matters.

## The fix

The caller's transport becomes a parameter: `Transport::Http` from the HTTP route, `Transport::Stdio` from the stdio serve loop, used by all nine records. No behaviour changes beyond what the records say.

## Verification

- New test `a_subscription_over_http_is_audited_as_http` opens an SSE stream, subscribes over HTTP, and asserts every resulting record names `Http`. It fails on the previous code with `left: Stdio, right: Http`.
- `cargo test -p srelens-mcp` — 239 passed.
- `cargo test --workspace` — **1091 passed, 0 failed**; `cargo check --workspace --all-targets` clean, no unused warnings.

## How it reached dev

Raised by automated review on #283 and marked resolved there without the change being made, so it merged. Worth knowing that thread resolution on that PR did not imply the finding was addressed.

Given #283 is already on `dev` and unreleased, merging this before the next promotion keeps the defect out of a shipped version entirely.
