### PR TITLE
release: dev → main (0.7.2)

### DIFF
--- a/apps/desktop/src/components/CustomResourceBrowser.test.tsx
+++ b/apps/desktop/src/components/CustomResourceBrowser.test.tsx
@@ -44,6 +44,35 @@ describe("CustomResourceBrowser", () => {
     expect(screen.getByText("Widget")).toBeDefined();
   });
 
+  it("renders the columns the CRD asks for, between the name and Age (#267)", async () => {
+    const withColumns = {
+      ...crd,
+      printerColumns: [
+        { name: "Health", jsonPath: ".status.health", type: "string" },
+        { name: "Nodes", jsonPath: ".spec.nodes", type: "integer" },
+      ],
+    };
+    listCustomResourceMock.mockResolvedValue({
+      items: [{ name: "demo-widget", namespace: "default", age: "1m", columns: ["GREEN", "3"] }],
+    });
+    render(<CustomResourceBrowser context="kind-dev" crd={withColumns} />);
+    await waitFor(() => expect(screen.getByText("demo-widget")).toBeDefined());
+    // Headings from the CRD, and the resolved values on the row.
+    expect(screen.getByText("Health")).toBeDefined();
+    expect(screen.getByText("Nodes")).toBeDefined();
+    expect(screen.getByText("GREEN")).toBeDefined();
+    expect(screen.getByText("3")).toBeDefined();
+  });
+
+  it("still lists a CRD that declares no printer columns (#267)", async () => {
+    listCustomResourceMock.mockResolvedValue({
+      items: [{ name: "demo-widget", namespace: "default", age: "1m" }],
+    });
+    render(<CustomResourceBrowser context="kind-dev" crd={crd} />);
+    await waitFor(() => expect(screen.getByText("demo-widget")).toBeDefined());
+    expect(screen.getByText("Age")).toBeDefined();
+  });
+
   it("shows an error when listing fails", async () => {
     listCustomResourceMock.mockResolvedValue({ error: "the server could not find the requested resource" });
     render(<CustomResourceBrowser context="kind-dev" crd={crd} />);

--- a/apps/desktop/src/components/CustomResourceBrowser.tsx
+++ b/apps/desktop/src/components/CustomResourceBrowser.tsx
@@ -1,6 +1,12 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { RefreshCw } from "lucide-react";
-import { listCustomResource, type CrdRef, type CustomRow } from "../lib/crds";
+import {
+  listCustomResource,
+  printerColumnKeys,
+  printerSortValue,
+  type CrdRef,
+  type CustomRow,
+} from "../lib/crds";
 import { listNamespaces } from "../lib/workloads";
 import { YamlView } from "./YamlView";
 import { Table, filterTableData, Select, Button, ColumnPicker, useColumnVisibility, Spinner, Drawer, TextInput, type Column } from "../ui";
@@ -69,6 +75,11 @@ export function CustomResourceBrowser({
     };
   }, [context, crd, namespace, reloadKey]);
 
+  const printerKeys = useMemo(
+    () => printerColumnKeys(crd.printerColumns ?? []),
+    [crd.printerColumns],
+  );
+
   const columns: Column<CustomRow>[] = [
     { key: "name", header: crd.kind, render: (r) => <strong>{r.name}</strong> },
     ...(crd.namespaced
@@ -80,6 +91,19 @@ export function CustomResourceBrowser({
           },
         ]
       : []),
+    // Whatever the CRD asks to have shown, between the identity columns and
+    // Age — the order kubectl uses. `columns` is positional, so index by the
+    // CRD's declaration order rather than by name (headings need not be unique).
+    // Values stay positional -- the backend returns them in declaration order --
+    // but the key must not be, since it outlives any one CRD revision.
+    ...(crd.printerColumns ?? []).map((column, index) => ({
+      key: printerKeys[index],
+      header: column.name,
+      getValue: (r: CustomRow) => r.columns?.[index] ?? "",
+      getSortValue: (r: CustomRow) =>
+        printerSortValue(column.type, r.columns?.[index] ?? "", r.sortKeys?.[index] ?? ""),
+      render: (r: CustomRow) => <span>{r.columns?.[index] ?? ""}</span>,
+    })),
     { key: "age", header: "Age", getSortValue: ageSortValue, render: (r) => <span className="text-muted-foreground">{r.age}</span> },
   ];
 

--- a/apps/desktop/src/lib/crds.test.ts
+++ b/apps/desktop/src/lib/crds.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { printerColumnKeys, printerSortValue } from "./crds";
+import { ageSeconds } from "./age";
+
+const col = (name: string, jsonPath: string, type = "string") => ({ name, jsonPath, type });
+
+/** printerSortValue narrowed to bigint, for the integer cases. */
+const intKey = (text: string) => printerSortValue("integer", text) as bigint;
+
+describe("printerColumnKeys", () => {
+  it("identifies a column by its definition, not its position", () => {
+    // An operator upgrade that prepends a column must not change the key of the
+    // ones already there: those keys persist hidden/sort/filter state.
+    const before = printerColumnKeys([col("Ready", ".status.ready"), col("Version", ".spec.version")]);
+    const after = printerColumnKeys([
+      col("Phase", ".status.phase"),
+      col("Ready", ".status.ready"),
+      col("Version", ".spec.version"),
+    ]);
+    expect(after.slice(1)).toEqual(before);
+  });
+
+  it("distinguishes columns sharing a heading but reading different fields", () => {
+    const keys = printerColumnKeys([col("Status", ".status.a"), col("Status", ".status.b")]);
+    expect(new Set(keys).size).toBe(2);
+  });
+
+  it("still disambiguates genuinely identical definitions", () => {
+    const keys = printerColumnKeys([col("Ready", ".status.ready"), col("Ready", ".status.ready")]);
+    expect(new Set(keys).size).toBe(2);
+  });
+});
+
+describe("printerSortValue", () => {
+  it("orders signed and decimal numbers numerically", () => {
+    // The table's collator gets both of these backwards on the rendered text.
+    expect(intKey("-10") < intKey("-2")).toBe(true);
+    expect(printerSortValue("number", "1.15")).toBeLessThan(printerSortValue("number", "1.2") as number);
+    expect(intKey("2") < intKey("10")).toBe(true);
+  });
+
+  it("keeps 64-bit integers exact (#267 review)", () => {
+    // Number() maps both of these to 9007199254740992, tying the two rows.
+    const lo = intKey("9007199254740992");
+    const hi = intKey("9007199254740993");
+    expect(lo).not.toBe(hi);
+    expect(lo < hi).toBe(true);
+    expect(intKey("-9007199254740993") < lo).toBe(true);
+  });
+
+  it("falls back for integer text that is not an integer", () => {
+    // A decimal in an `integer` column is malformed; BigInt() would throw.
+    expect(printerSortValue("integer", "1.5")).toBe(Number.NEGATIVE_INFINITY);
+    expect(printerSortValue("integer", "n/a")).toBe(Number.NEGATIVE_INFINITY);
+  });
+
+  it("orders dates by duration, not by the text of the age", () => {
+    // "10d" vs "2h": text collation puts 10d first by leading digit.
+    expect(printerSortValue("date", "2h")).toBeLessThan(printerSortValue("date", "10d") as number);
+    expect(printerSortValue("date", "300d")).toBeLessThan(printerSortValue("date", "1y") as number);
+  });
+
+  it("separates dates that render as the same age (#267 review)", () => {
+    // 65 and 115 minutes old both display "1h"; only the raw value can order them.
+    const now = Date.parse("2026-01-01T12:00:00Z");
+    const older = printerSortValue("date", "1h", "2026-01-01T10:05:00Z", now) as number;
+    const newer = printerSortValue("date", "1h", "2026-01-01T10:55:00Z", now) as number;
+    expect(older).toBeGreaterThan(newer); // larger = older, as ageSeconds orders
+  });
+
+  it("sorts raw timestamps in the same direction as compact ages", () => {
+    // A mixed list must not reverse when some rows carry a raw value.
+    const now = Date.parse("2026-01-01T12:00:00Z");
+    const raw = printerSortValue("date", "2h", "2026-01-01T10:00:00Z", now) as number;
+    expect(raw).toBeGreaterThan(ageSeconds("1h"));
+    expect(raw).toBeLessThan(ageSeconds("10d"));
+  });
+
+  it("falls back to the rendered age when no raw value is present", () => {
+    expect(printerSortValue("date", "2h", "")).toBe(ageSeconds("2h"));
+    expect(printerSortValue("date", "2h", "not a date")).toBe(ageSeconds("2h"));
+  });
+
+  it("groups unset and unparseable values below real ones", () => {
+    expect(printerSortValue("integer", "")).toBe(Number.NEGATIVE_INFINITY);
+    expect(printerSortValue("number", "n/a")).toBe(Number.NEGATIVE_INFINITY);
+    expect(printerSortValue("date", "-")).toBe(-1);
+  });
+
+  it("leaves string columns as text", () => {
+    expect(printerSortValue("string", "GREEN")).toBe("GREEN");
+  });
+});

--- a/apps/desktop/src/lib/crds.ts
+++ b/apps/desktop/src/lib/crds.ts
@@ -1,4 +1,17 @@
 import { invokeCapability, type Invoker } from "../transport/transport";
+import { ageSeconds } from "./age";
+
+/**
+ * One column a CRD asks tools to display, from its `additionalPrinterColumns`
+ * — the same metadata `kubectl get` renders. Custom resources share no fields
+ * beyond name/namespace/age, so this is the only way to show anything useful
+ * about them (health, phase, version, replica counts…).
+ */
+export interface PrinterColumn {
+  name: string;
+  jsonPath: string;
+  type: string;
+}
 
 /** A discovered CustomResourceDefinition, enough to list/view its instances. */
 export interface CrdRef {
@@ -8,12 +21,83 @@ export interface CrdRef {
   kind: string;
   plural: string;
   namespaced: boolean;
+  /** Optional: older backends and hand-built refs in tests may omit it. */
+  printerColumns?: PrinterColumn[];
 }
 
 export interface CustomRow {
   name: string;
   namespace: string;
   age: string;
+  /** Values for the CRD's printer columns, in declaration order. */
+  columns?: string[];
+  /** Raw values for columns whose rendered text does not sort correctly. */
+  sortKeys?: string[];
+}
+
+/**
+ * Stable table keys for a CRD's printer columns.
+ *
+ * These keys persist: `useColumnVisibility` stores hidden columns under them,
+ * and the tab keeps sort and filter state by key. A positional key would
+ * therefore silently change meaning when an operator upgrade inserts or
+ * reorders `additionalPrinterColumns` — a column the user hid or sorted would
+ * come back as a different one. Identify a column by what it *is* instead, and
+ * add an occurrence suffix only for genuinely duplicate definitions.
+ */
+export function printerColumnKeys(columns: PrinterColumn[]): string[] {
+  const seen = new Map<string, number>();
+  return columns.map((column) => {
+    const base = `printer:${column.name}:${column.jsonPath}`;
+    const occurrence = (seen.get(base) ?? 0) + 1;
+    seen.set(base, occurrence);
+    return occurrence === 1 ? base : `${base}#${occurrence}`;
+  });
+}
+
+/**
+ * Sort key for a printer column's rendered text, honouring the type the CRD
+ * declared. The table's collator handles plain digit strings, but not signed or
+ * decimal numbers, and `date` columns have already been rendered as compact
+ * ages ("2h", "10d") whose text does not order chronologically.
+ *
+ * `integer` yields a bigint, since Kubernetes integers are 64-bit and Number
+ * cannot represent them all exactly. The table compares bigints relationally.
+ */
+export function printerSortValue(
+  type: string,
+  value: string,
+  sortKey = "",
+  now: number = Date.now(),
+): number | string | bigint {
+  if (type === "integer" || type === "number") {
+    const text = value.trim();
+    // Unset or unparseable values group below every real number. Check for
+    // empty first: Number("") is 0, which would interleave blank cells with
+    // real zeros and negatives.
+    if (text === "") return Number.NEGATIVE_INFINITY;
+    if (type === "integer") {
+      // Kubernetes integers are 64-bit, and Number cannot hold them exactly:
+      // 9007199254740993 collapses onto ...992, tying two distinct rows.
+      try {
+        return BigInt(text);
+      } catch {
+        return Number.NEGATIVE_INFINITY;
+      }
+    }
+    const parsed = Number(text);
+    return Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY;
+  }
+  if (type === "date") {
+    // Prefer the raw timestamp: two rows inside the same displayed unit both
+    // render "1h" and would otherwise tie. Convert it to an age rather than
+    // using the epoch value directly, so it sorts in the same direction as
+    // `ageSeconds` — larger means older, for both this and the Age column.
+    const parsed = sortKey ? Date.parse(sortKey) : NaN;
+    if (Number.isFinite(parsed)) return (now - parsed) / 1000;
+    return ageSeconds(value);
+  }
+  return value;
 }
 
 /** Discover installed CRDs in a cluster via `k8s.listCRDs`. */
@@ -45,6 +129,7 @@ export async function listCustomResource(
       kind: crd.kind,
       namespaced: crd.namespaced,
       namespace: namespace ?? "",
+      printerColumns: crd.printerColumns ?? [],
     });
     return { items: out.items };
   } catch (e) {

--- a/apps/desktop/src/lib/openTabs.test.ts
+++ b/apps/desktop/src/lib/openTabs.test.ts
@@ -258,6 +258,31 @@ describe("reconcileCrdTabs", () => {
     expect(result.tabs[0]).toBe(tabs[0]);
     expect(result.dropped).toBe(0);
   });
+
+  const cols = [{ name: "Ready", jsonPath: ".status.ready", type: "string" }];
+
+  it("adopts printer columns a restored tab predates (#267)", () => {
+    // A tab serialized before printer columns existed carries a ref without
+    // them. Its GVK is unchanged, so nothing else marks it stale -- but keeping
+    // it would mean the columns never appear until the tab is reopened.
+    const result = reconcileCrdTabs([crdTab(1)], "prod", [crd({ printerColumns: cols })]);
+    expect(result.tabs[0].crd?.printerColumns).toEqual(cols);
+  });
+
+  it("adopts printer columns changed without a version bump (#267)", () => {
+    const stale = { ...tab({ id: 1, cluster: "prod" }), crd: crd({ printerColumns: cols }) } as Tab;
+    const renamed = [{ name: "Health", jsonPath: ".status.health", type: "string" }];
+    const result = reconcileCrdTabs([stale], "prod", [crd({ printerColumns: renamed })]);
+    expect(result.tabs[0].crd?.printerColumns).toEqual(renamed);
+  });
+
+  it("keeps tab identity when the printer columns are equal", () => {
+    // The ref feeds a fetch effect, so a fresh object each reconcile would
+    // refetch forever.
+    const tabs = [{ ...tab({ id: 1, cluster: "prod" }), crd: crd({ printerColumns: cols }) } as Tab];
+    const result = reconcileCrdTabs(tabs, "prod", [crd({ printerColumns: [{ ...cols[0] }] })]);
+    expect(result.tabs[0]).toBe(tabs[0]);
+  });
 });
 
 describe("coalesced session persistence", () => {

--- a/apps/desktop/src/lib/openTabs.ts
+++ b/apps/desktop/src/lib/openTabs.ts
@@ -157,6 +157,34 @@ export function reconcileActiveTab(tabs: ViewTab[], activeTabId: number | null):
  * Only ever called with a SUCCESSFUL discovery result: an unreachable cluster
  * must not be read as "this CRD is gone" and silently delete the workspace.
  */
+/**
+ * Whether two printer-column lists describe the same columns.
+ *
+ * A persisted tab keeps whatever ref it was serialized with, so a tab restored
+ * from before printer columns existed has none at all, and an operator can
+ * change `additionalPrinterColumns` without touching the CRD version. Neither
+ * shows up in the GVK, so the columns have to be compared directly or the tab
+ * keeps rendering by a definition the cluster has moved on from.
+ *
+ * Compared field by field rather than by reference: the ref feeds a fetch
+ * effect, and handing back a fresh object on every reconcile would refetch
+ * forever.
+ */
+function samePrinterColumns(
+  live: CrdRef["printerColumns"],
+  saved: CrdRef["printerColumns"],
+): boolean {
+  const a = live ?? [];
+  const b = saved ?? [];
+  if (a.length !== b.length) return false;
+  return a.every(
+    (column, index) =>
+      column.name === b[index].name &&
+      column.jsonPath === b[index].jsonPath &&
+      column.type === b[index].type,
+  );
+}
+
 export function reconcileCrdTabs(
   tabs: ViewTab[],
   context: string,
@@ -175,7 +203,10 @@ export function reconcileCrdTabs(
       dropped += 1;
       continue;
     }
-    const stale = live.version !== t.crd.version || live.plural !== t.crd.plural;
+    const stale =
+      live.version !== t.crd.version ||
+      live.plural !== t.crd.plural ||
+      !samePrinterColumns(live.printerColumns, t.crd.printerColumns);
     kept.push(stale ? { ...t, crd: live } : t);
   }
   return { tabs: kept, dropped };

--- a/apps/desktop/src/ui/Table.test.tsx
+++ b/apps/desktop/src/ui/Table.test.tsx
@@ -42,6 +42,62 @@ describe("Table virtualization", () => {
     expect(screen.getByText("row-0")).toBeDefined();
     expect(screen.queryByText("row-900")).toBeNull(); // far off-screen, not rendered
   });
+
+  /** Simulate real layout: 20px rows, and header cells with natural widths. */
+  function mockLayout(headWidth = 140) {
+    vi.spyOn(HTMLTableRowElement.prototype, "getBoundingClientRect").mockReturnValue({
+      height: 20,
+    } as DOMRect);
+    vi.spyOn(HTMLTableCellElement.prototype, "getBoundingClientRect").mockReturnValue({
+      width: headWidth,
+    } as DOMRect);
+  }
+
+  function renderScrollable(data: { name: string; phase: string }[]) {
+    const utils = render(
+      <div data-testid="scroll" style={{ overflowY: "auto" }}>
+        <Table columns={bigColumns} data={data} getRowKey={(r) => r.name} />
+      </div>,
+    );
+    const sp = screen.getByTestId("scroll");
+    Object.defineProperty(sp, "clientHeight", { value: 200, configurable: true });
+    Object.defineProperty(sp, "scrollTop", { value: 0, writable: true, configurable: true });
+    fireEvent.scroll(sp);
+    return { ...utils, sp };
+  }
+
+  const colWidths = (container: HTMLElement) =>
+    Array.from(container.querySelectorAll("colgroup col")).map(
+      (col) => (col as HTMLTableColElement).style.width,
+    );
+
+  it("pins column widths once a long list virtualizes (#298)", () => {
+    mockLayout();
+    const { container } = renderScrollable(bigData);
+    // Without pinned widths the browser re-derives them from whichever rows are
+    // currently rendered, so the columns shift on every scroll.
+    expect(colWidths(container).every((w) => w !== "")).toBe(true);
+    expect(container.querySelector("table")?.className).toContain("fl-data-table--resized");
+  });
+
+  it("keeps those widths identical across scrolls (#298)", () => {
+    mockLayout();
+    const { container, sp } = renderScrollable(bigData);
+    const before = colWidths(container);
+    expect(before.every((w) => w !== "")).toBe(true); // guard: not vacuously equal
+    Object.defineProperty(sp, "scrollTop", { value: 4000, writable: true, configurable: true });
+    fireEvent.scroll(sp);
+    expect(screen.queryByText("row-0")).toBeNull(); // the rendered window really moved
+    expect(colWidths(container)).toEqual(before);
+  });
+
+  it("leaves short lists auto-sized so they still adapt to content (#298)", () => {
+    mockLayout();
+    const shortData = bigData.slice(0, 10);
+    const { container } = renderScrollable(shortData);
+    expect(colWidths(container).every((w) => w === "")).toBe(true);
+    expect(container.querySelector("table")?.className).not.toContain("fl-data-table--resized");
+  });
 });
 
 describe("computeVisibleRange", () => {

--- a/apps/desktop/src/ui/Table.test.tsx
+++ b/apps/desktop/src/ui/Table.test.tsx
@@ -91,12 +91,43 @@ describe("Table virtualization", () => {
     expect(colWidths(container)).toEqual(before);
   });
 
-  it("leaves short lists auto-sized so they still adapt to content (#298)", () => {
+  it("pins short lists too, so every table behaves the same way (#298)", () => {
+    // CRDs, Services and most lists sit under the virtualization threshold.
+    // They must not size differently from the long ones.
     mockLayout();
-    const shortData = bigData.slice(0, 10);
-    const { container } = renderScrollable(shortData);
-    expect(colWidths(container).every((w) => w === "")).toBe(true);
-    expect(container.querySelector("table")?.className).not.toContain("fl-data-table--resized");
+    const { container } = renderScrollable(bigData.slice(0, 10));
+    expect(colWidths(container).every((w) => w !== "")).toBe(true);
+    expect(container.querySelector("table")?.className).toContain("fl-data-table--resized");
+  });
+
+  it("keeps widths pinned when filtering drops a list below the threshold (#298)", () => {
+    // Narrowing a virtualized list past the threshold must not hand it back to
+    // automatic layout, or the columns snap as the user types.
+    mockLayout();
+    const { container, rerender } = render(
+      <div data-testid="scroll" style={{ overflowY: "auto" }}>
+        <Table columns={bigColumns} data={bigData} getRowKey={(r) => r.name} />
+      </div>,
+    );
+    const sp = screen.getByTestId("scroll");
+    Object.defineProperty(sp, "clientHeight", { value: 200, configurable: true });
+    Object.defineProperty(sp, "scrollTop", { value: 0, writable: true, configurable: true });
+    fireEvent.scroll(sp);
+    const before = colWidths(container);
+    expect(before.every((w) => w !== "")).toBe(true);
+
+    rerender(
+      <div data-testid="scroll" style={{ overflowY: "auto" }}>
+        <Table columns={bigColumns} data={bigData.slice(0, 5)} getRowKey={(r) => r.name} />
+      </div>,
+    );
+    expect(colWidths(container)).toEqual(before);
+  });
+
+  it("does not pin an empty table, so widths are measured from real rows", () => {
+    mockLayout();
+    const { container } = renderScrollable([]);
+    expect(container.querySelector("colgroup")).toBeNull(); // empty state, no table
   });
 });
 
@@ -275,8 +306,11 @@ describe("Table", () => {
 
     fireEvent.keyDown(handle, { key: "ArrowRight" });
     expect(header?.closest("table")?.style.width).toBe("256px");
+    // Reset drops the user's widths and the table re-measures its natural ones
+    // (2 columns x the 120px jsdom fallback) rather than falling back to
+    // automatic layout, which no table uses any more.
     fireEvent.doubleClick(handle);
-    expect(header?.closest("table")?.style.width).toBe("");
+    expect(header?.closest("table")?.style.width).toBe("240px");
   });
 });
 

--- a/apps/desktop/src/ui/Table.test.tsx
+++ b/apps/desktop/src/ui/Table.test.tsx
@@ -131,6 +131,48 @@ describe("Table virtualization", () => {
   });
 });
 
+describe("Table sorting", () => {
+  it("orders 64-bit integers exactly, beyond Number's safe range", () => {
+    // Number() collapses these two to the same value, so a numeric sort key
+    // cannot separate them. Negative, because string collation happens to get
+    // large positives right and would hide the gap: it compares "-...993"
+    // against "-...992" by magnitude and puts them the wrong way round.
+    // The comparator must also not use arithmetic on a bigint, which throws.
+    const rows = [
+      { id: "b", n: -9007199254740992n },
+      { id: "a", n: -9007199254740993n },
+    ];
+    const cols: Column<(typeof rows)[number]>[] = [
+      { key: "id", header: "Id" },
+      { key: "n", header: "N", getSortValue: (r) => r.n },
+    ];
+    render(<Table columns={cols} data={rows} getRowKey={(r) => r.id} />);
+    fireEvent.click(screen.getByRole("button", { name: "Sort by N" }));
+    const order = Array.from(document.querySelectorAll("tbody tr.fl-data-table__row")).map(
+      (tr) => tr.textContent?.[0],
+    );
+    expect(order).toEqual(["a", "b"]);
+  });
+
+  it("sorts rows with no value below real ones when mixing bigint and number", () => {
+    const rows = [
+      { id: "big", n: 12n as bigint | number },
+      { id: "none", n: Number.NEGATIVE_INFINITY },
+      { id: "small", n: 3n },
+    ];
+    const cols: Column<(typeof rows)[number]>[] = [
+      { key: "id", header: "Id" },
+      { key: "n", header: "N", getSortValue: (r) => r.n },
+    ];
+    render(<Table columns={cols} data={rows} getRowKey={(r) => r.id} />);
+    fireEvent.click(screen.getByRole("button", { name: "Sort by N" }));
+    const order = Array.from(document.querySelectorAll("tbody tr.fl-data-table__row")).map(
+      (tr) => tr.textContent?.slice(0, 5),
+    );
+    expect(order?.[0]).toContain("none");
+  });
+});
+
 describe("computeVisibleRange", () => {
   it("returns the window of rows around the scroll position with overscan", () => {
     // rowHeight 20, viewport 100 → 5 visible rows; scrolled to row 50; overscan 3.

--- a/apps/desktop/src/ui/Table.tsx
+++ b/apps/desktop/src/ui/Table.tsx
@@ -158,7 +158,16 @@ export function Table<T>({
         const right = column.getSortValue ? column.getSortValue(b.row) : getColumnValue(b.row, column);
         let result: number;
         if (typeof left === "number" && typeof right === "number") result = left - right;
-        else result = collator.compare(String(left ?? ""), String(right ?? ""));
+        else if (typeof left === "bigint" || typeof right === "bigint") {
+          // Compare, never subtract: bigint arithmetic with a number throws,
+          // and columns mix the two (a bigint value against a -Infinity for
+          // "unset"). Relational operators are defined across both and stay
+          // exact past Number.MAX_SAFE_INTEGER, which string collation is not:
+          // it orders negatives by magnitude.
+          const l = left as bigint | number;
+          const r = right as bigint | number;
+          result = l < r ? -1 : l > r ? 1 : 0;
+        } else result = collator.compare(String(left ?? ""), String(right ?? ""));
         return result ? result * (sort.direction === "asc" ? 1 : -1) : a.index - b.index;
       })
       .map(({ row }) => row);

--- a/apps/desktop/src/ui/Table.tsx
+++ b/apps/desktop/src/ui/Table.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { ArrowDown, ArrowUp, ArrowUpDown, Filter } from "lucide-react";
 import {
   Table as ShadTable,
@@ -58,6 +58,9 @@ export interface TableProps<T> {
   sort?: TableSort | null;
   onSortChange?: (sort: TableSort | null) => void;
 }
+
+/** Width of the leading bulk-selection column; mirrored in styles.css. */
+const CHECKBOX_COLUMN_WIDTH = 36;
 
 function getColumnValue<T>(row: T, column: Column<T>): unknown {
   return column.getValue ? column.getValue(row) : (row as Record<string, unknown>)[column.key];
@@ -132,6 +135,11 @@ export function Table<T>({
   // Anchor for shift-click range selection (a key in sorted/visible order).
   const selectionAnchor = useRef<string | null>(null);
   const [columnWidths, setColumnWidths] = useState<Record<string, number>>({});
+  // Whether `columnWidths` was measured for the user (#298) rather than chosen
+  // by them. Auto-sized widths re-measure when the table is resized; widths the
+  // user dragged are theirs to keep.
+  const autoSized = useRef(false);
+  const containerWidth = useRef(0);
   const columnSignature = columns.map((column) => column.key).join("|");
   const rootRef = useRef<HTMLDivElement>(null);
   const [metrics, setMetrics] = useState({ scrollTop: 0, viewportHeight: 0, rowHeight: 0 });
@@ -194,14 +202,12 @@ export function Table<T>({
     else setInternalSort(next);
   };
 
-  const startColumnResize = (event: React.PointerEvent<HTMLDivElement>, column: Column<T>) => {
-    event.preventDefault();
-    event.stopPropagation();
-    const table = event.currentTarget.closest("table");
+  /** Current on-screen width of every column, for pinning into `columnWidths`. */
+  const measureColumns = (table: Element | null | undefined): Record<string, number> => {
     const headers = table?.querySelectorAll<HTMLTableCellElement>("thead tr:first-child th");
     // The checkbox column (when present) is th[0], so data columns are offset.
     const headOffset = selection ? 1 : 0;
-    const measured = Object.fromEntries(
+    return Object.fromEntries(
       columns.map((candidate, index) => [
         candidate.key,
         Math.round(
@@ -211,6 +217,13 @@ export function Table<T>({
         ),
       ]),
     );
+  };
+
+  const startColumnResize = (event: React.PointerEvent<HTMLDivElement>, column: Column<T>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const measured = measureColumns(event.currentTarget.closest("table"));
+    autoSized.current = false;
     const startWidth = measured[column.key];
     const startX = event.clientX;
     setColumnWidths(measured);
@@ -238,20 +251,8 @@ export function Table<T>({
   ) => {
     if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
     event.preventDefault();
-    const table = event.currentTarget.closest("table");
-    const headers = table?.querySelectorAll<HTMLTableCellElement>("thead tr:first-child th");
-    // The checkbox column (when present) is th[0], so data columns are offset.
-    const headOffset = selection ? 1 : 0;
-    const measured = Object.fromEntries(
-      columns.map((candidate, index) => [
-        candidate.key,
-        Math.round(
-          headers?.[index + headOffset]?.getBoundingClientRect().width ||
-            columnWidths[candidate.key] ||
-            120,
-        ),
-      ]),
-    );
+    const measured = measureColumns(event.currentTarget.closest("table"));
+    autoSized.current = false;
     const delta = event.key === "ArrowRight" ? 16 : -16;
     setColumnWidths((current) => {
       const baseline = Object.keys(current).length ? current : measured;
@@ -262,8 +263,13 @@ export function Table<T>({
     });
   };
 
+  // The checkbox column is fixed-width and never resizable, but it still takes
+  // up space: leaving it out made the declared table width narrower than the
+  // colgroup asks for, so fixed layout had to steal the difference back from
+  // the data columns.
   const tableWidth = Object.keys(columnWidths).length
-    ? Object.values(columnWidths).reduce((total, width) => total + width, 0)
+    ? Object.values(columnWidths).reduce((total, width) => total + width, 0) +
+      (selection ? CHECKBOX_COLUMN_WIDTH : 0)
     : undefined;
 
   // Virtualize long lists: render only the rows near the viewport plus spacer
@@ -315,7 +321,42 @@ export function Table<T>({
   const topPad = virtualize ? range.start * metrics.rowHeight : 0;
   const bottomPad = virtualize ? (visibleData.length - range.end) * metrics.rowHeight : 0;
 
-  if (data.length === 0) {
+  // Pin the natural column widths as soon as a list starts virtualizing.
+  // Automatic table layout sizes columns from the rows currently rendered, and
+  // virtualization swaps that set on every scroll, so without pinned widths the
+  // columns visibly shift as the user scrolls (#298). Measuring in a layout
+  // effect keeps it off-screen: the widths are read and applied before paint.
+  //
+  // Short lists are deliberately left auto-sized -- they render every row, so
+  // their widths are already stable and stay adaptive to their content.
+  useLayoutEffect(() => {
+    if (!virtualize || Object.keys(columnWidths).length > 0) return;
+    const table = rootRef.current?.querySelector("table");
+    if (!table) return;
+    setColumnWidths(measureColumns(table));
+    autoSized.current = true;
+    // measureColumns reads `columns`/`selection`, which `columnSignature` tracks.
+  }, [virtualize, columnWidths, columnSignature]);
+
+  // Pinned widths would otherwise survive a window resize, so an auto-sized
+  // table would stop tracking the space available to it. Drop the measurement
+  // when the container's width changes and the effect above re-takes it at the
+  // new size. Widths the user dragged are left alone.
+  const isEmpty = data.length === 0;
+  useEffect(() => {
+    if (isEmpty) return;
+    const container = rootRef.current?.querySelector<HTMLElement>('[data-slot="table-container"]');
+    if (!container || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => {
+      if (container.clientWidth === containerWidth.current) return;
+      containerWidth.current = container.clientWidth;
+      if (autoSized.current) setColumnWidths({});
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [isEmpty]);
+
+  if (isEmpty) {
     return <EmptyState title={emptyText} description={emptyHint} />;
   }
   return (
@@ -329,7 +370,7 @@ export function Table<T>({
       style={tableWidth ? { width: tableWidth, minWidth: "100%" } : undefined}
     >
       <colgroup>
-        {selection && <col style={{ width: 36 }} />}
+        {selection && <col style={{ width: CHECKBOX_COLUMN_WIDTH }} />}
         {columns.map((column) => (
           <col
             key={column.key}

--- a/apps/desktop/src/ui/Table.tsx
+++ b/apps/desktop/src/ui/Table.tsx
@@ -321,28 +321,36 @@ export function Table<T>({
   const topPad = virtualize ? range.start * metrics.rowHeight : 0;
   const bottomPad = virtualize ? (visibleData.length - range.end) * metrics.rowHeight : 0;
 
-  // Pin the natural column widths as soon as a list starts virtualizing.
-  // Automatic table layout sizes columns from the rows currently rendered, and
-  // virtualization swaps that set on every scroll, so without pinned widths the
-  // columns visibly shift as the user scrolls (#298). Measuring in a layout
-  // effect keeps it off-screen: the widths are read and applied before paint.
+  const isEmpty = data.length === 0;
+
+  // Pin the natural column widths once the table has rows to measure.
   //
-  // Short lists are deliberately left auto-sized -- they render every row, so
-  // their widths are already stable and stay adaptive to their content.
+  // Automatic table layout sizes columns from the rows *currently rendered*.
+  // Virtualization swaps that set on every scroll, so a long list's columns
+  // visibly shifted as the user scrolled (#298). Measuring in a layout effect
+  // keeps it off-screen: the widths are read and applied before paint.
+  //
+  // This deliberately applies to every table, not just the ones long enough to
+  // virtualize. Pinning only above the threshold made short lists -- CRDs,
+  // Services, most views -- size by a different rule from long ones, and left a
+  // list that was filtered down past the threshold stranded with widths it
+  // could neither keep consistently nor recompute. Sizing every table the same
+  // way is both uniform and simpler.
   useLayoutEffect(() => {
-    if (!virtualize || Object.keys(columnWidths).length > 0) return;
+    if (isEmpty || Object.keys(columnWidths).length > 0) return;
     const table = rootRef.current?.querySelector("table");
-    if (!table) return;
+    // Nothing to measure until a real row exists: a table showing only the
+    // "no matching items" placeholder would freeze the placeholder's widths.
+    if (!table?.querySelector("tbody tr.fl-data-table__row")) return;
     setColumnWidths(measureColumns(table));
     autoSized.current = true;
     // measureColumns reads `columns`/`selection`, which `columnSignature` tracks.
-  }, [virtualize, columnWidths, columnSignature]);
+  }, [isEmpty, visibleData.length, columnWidths, columnSignature]);
 
   // Pinned widths would otherwise survive a window resize, so an auto-sized
   // table would stop tracking the space available to it. Drop the measurement
   // when the container's width changes and the effect above re-takes it at the
   // new size. Widths the user dragged are left alone.
-  const isEmpty = data.length === 0;
   useEffect(() => {
     if (isEmpty) return;
     const container = rootRef.current?.querySelector<HTMLElement>('[data-slot="table-container"]');

--- a/apps/desktop/src/ui/styles.css
+++ b/apps/desktop/src/ui/styles.css
@@ -3742,10 +3742,16 @@ body {
   overflow: auto;
 }
 /* Checkbox column in the data table. */
-.fl-data-table__checkbox {
+/* Scoped to beat .fl-data-table__cell / __head, which are declared later in
+   this file with the same specificity and would otherwise win. They set
+   `padding: 0 14px`, which left this 36px column an 8px content box -- the
+   checkbox overflowed it and __cell's `text-overflow: ellipsis` drew a "..."
+   next to every checkbox. A cell holding a control should never ellipsize. */
+.fl-data-table .fl-data-table__checkbox {
   width: 36px;
   text-align: center;
-  padding-right: 0;
+  padding: 0;
+  text-overflow: clip;
 }
 .fl-data-table__checkbox input {
   cursor: pointer;

--- a/crates/kube/src/crds.rs
+++ b/crates/kube/src/crds.rs
@@ -17,8 +17,25 @@ pub struct ListCrdsIn {
     pub context: String,
 }
 
+/// One column a CRD asks tools to display, from
+/// `spec.versions[].additionalPrinterColumns` -- the same metadata `kubectl get`
+/// renders. Without these a custom resource list can only show name/namespace/age,
+/// because nothing else is common to every kind.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PrinterColumn {
+    /// Column heading, e.g. "Health".
+    pub name: String,
+    /// Restricted JSONPath into the resource, e.g. ".status.health".
+    pub json_path: String,
+    /// OpenAPI type: string, integer, number, boolean or date.
+    #[serde(rename = "type", default)]
+    pub column_type: String,
+}
+
 /// A discovered CustomResourceDefinition, enough to list its instances.
 #[derive(Debug, Clone, PartialEq, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct CrdDescriptor {
     /// Metadata name, e.g. "gateways.gateway.networking.k8s.io".
     pub name: String,
@@ -27,6 +44,8 @@ pub struct CrdDescriptor {
     pub kind: String,
     pub plural: String,
     pub namespaced: bool,
+    /// Columns this CRD asks to have displayed, in declaration order.
+    pub printer_columns: Vec<PrinterColumn>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -38,20 +57,196 @@ fn handler_err(e: impl ToString) -> CapabilityError {
     CapabilityError::Handler(e.to_string())
 }
 
-/// Choose the storage version, else the first served version, else the first.
-fn pick_version(spec: &serde_json::Value) -> String {
-    let versions = match spec["versions"].as_array() {
-        Some(v) => v,
-        None => return String::new(),
-    };
+/// The storage version, else the first served version, else the first.
+fn chosen_version(spec: &serde_json::Value) -> Option<&serde_json::Value> {
+    let versions = spec["versions"].as_array()?;
     versions
         .iter()
         .find(|v| v["storage"].as_bool().unwrap_or(false))
         .or_else(|| versions.iter().find(|v| v["served"].as_bool().unwrap_or(false)))
         .or_else(|| versions.first())
+}
+
+/// Choose the storage version, else the first served version, else the first.
+fn pick_version(spec: &serde_json::Value) -> String {
+    chosen_version(spec)
         .and_then(|v| v["name"].as_str())
         .unwrap_or_default()
         .to_string()
+}
+
+/// The printer columns worth showing for the chosen version.
+///
+/// Drops two kinds that would only add noise: `priority > 0` is `kubectl -o
+/// wide` territory, and a column reading `.metadata.creationTimestamp` merely
+/// duplicates the Age column every list already renders.
+fn printer_columns(spec: &serde_json::Value) -> Vec<PrinterColumn> {
+    let Some(version) = chosen_version(spec) else {
+        return Vec::new();
+    };
+    let Some(columns) = version["additionalPrinterColumns"].as_array() else {
+        return Vec::new();
+    };
+    columns
+        .iter()
+        .filter(|c| c["priority"].as_i64().unwrap_or(0) == 0)
+        .filter_map(|c| {
+            let json_path = c["jsonPath"].as_str()?.to_string();
+            if json_path == ".metadata.creationTimestamp" {
+                return None;
+            }
+            Some(PrinterColumn {
+                name: c["name"].as_str()?.to_string(),
+                json_path,
+                column_type: c["type"].as_str().unwrap_or_default().to_string(),
+            })
+        })
+        .collect()
+}
+
+/// Read a CRD `jsonPath` out of a resource, rendering the leaf as display text.
+///
+/// CRDs use a small JSONPath subset rather than the full grammar, so this walks
+/// it directly instead of pulling in an engine. Supported segments:
+///
+/// - `.foo`, `.a\.b` and `['foo']` / `["foo"]` — object keys; both the escape
+///   and the bracket form let a key contain dots, as label keys do
+/// - `[0]` — array index
+/// - `[?(@.type=="Ready")]` — first array element whose field equals a literal,
+///   which is how Flux, cert-manager and most operators surface a condition
+///
+/// Anything absent, null, or not a scalar renders empty — an empty cell reads
+/// better than a blob of JSON.
+fn resolve_json_path(value: &serde_json::Value, path: &str) -> String {
+    let mut current = value;
+    let mut rest = path.trim_start_matches('.');
+    while !rest.is_empty() {
+        let (segment, remainder) = match rest.strip_prefix('[') {
+            Some(open) => {
+                let Some(close) = open.find(']') else { return String::new() };
+                (Segment::bracket(&open[..close]), open[close + 1..].trim_start_matches('.'))
+            }
+            None => {
+                // Scan to the next *unescaped* separator. `\.` keeps a literal dot
+                // inside the key, which is how a CRD can address a label such as
+                // `app\.kubernetes\.io/name` without bracket notation.
+                let mut key = String::new();
+                let mut end = rest.len();
+                let mut chars = rest.char_indices();
+                while let Some((index, ch)) = chars.next() {
+                    match ch {
+                        '\\' => {
+                            if let Some((_, escaped)) = chars.next() {
+                                key.push(escaped);
+                            }
+                        }
+                        '.' | '[' => {
+                            end = index;
+                            break;
+                        }
+                        _ => key.push(ch),
+                    }
+                }
+                (Segment::Key(key), rest[end..].trim_start_matches('.'))
+            }
+        };
+        let Some(next) = segment.apply(current) else { return String::new() };
+        current = next;
+        rest = remainder;
+    }
+    match current {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        _ => String::new(),
+    }
+}
+
+/// One step of a CRD jsonPath.
+enum Segment {
+    Key(String),
+    Index(usize),
+    /// `[?(@.field=="literal")]` — the first array element that matches.
+    Filter { field: String, literal: String },
+}
+
+impl Segment {
+    /// Parse the inside of a `[...]`.
+    fn bracket(inner: &str) -> Segment {
+        let trimmed = inner.trim();
+        if let Some(expression) = trimmed.strip_prefix("?(").and_then(|e| e.strip_suffix(')')) {
+            if let Some((left, right)) = expression.split_once("==") {
+                return Segment::Filter {
+                    field: left.trim().trim_start_matches('@').trim_start_matches('.').to_string(),
+                    literal: unquote(right.trim()).to_string(),
+                };
+            }
+        }
+        if let Ok(index) = trimmed.parse::<usize>() {
+            return Segment::Index(index);
+        }
+        Segment::Key(unquote(trimmed).to_string())
+    }
+
+    fn apply<'v>(&self, value: &'v serde_json::Value) -> Option<&'v serde_json::Value> {
+        match self {
+            Segment::Key(key) => value.get(key),
+            Segment::Index(index) => value.get(index),
+            Segment::Filter { field, literal } => value
+                .as_array()?
+                .iter()
+                .find(|item| resolve_json_path(item, field) == *literal),
+        }
+    }
+}
+
+fn unquote(text: &str) -> &str {
+    text.trim_matches(|c| c == '\'' || c == '"')
+}
+
+/// Put a DynamicObject back together as one JSON value.
+///
+/// `kube` splits an object across three places -- `types` (apiVersion, kind),
+/// typed `metadata`, and everything else in `data` -- but a printer column
+/// addresses the resource as the API serves it, so all three have to be
+/// reunited or paths like `.metadata.labels[...]` and `.kind` resolve empty.
+fn whole_object(object: &DynamicObject) -> serde_json::Value {
+    let mut value = object.data.clone();
+    let Some(map) = value.as_object_mut() else {
+        return value;
+    };
+    if let Ok(metadata) = serde_json::to_value(&object.metadata) {
+        map.insert("metadata".to_string(), metadata);
+    }
+    // TypeMeta serializes flat, as apiVersion + kind beside the other fields.
+    if let Some(types) = object.types.as_ref() {
+        if let Ok(serde_json::Value::Object(fields)) = serde_json::to_value(types) {
+            map.extend(fields);
+        }
+    }
+    value
+}
+
+/// The raw value behind a cell, where rendering it would lose ordering.
+fn column_sort_key(object: &serde_json::Value, column: &PrinterColumn) -> String {
+    if column.column_type == "date" {
+        resolve_json_path(object, &column.json_path)
+    } else {
+        String::new()
+    }
+}
+
+/// Render one cell, humanizing `type: date` columns the way ages are shown
+/// elsewhere so a raw RFC 3339 timestamp never reaches the table.
+fn render_column(object: &serde_json::Value, column: &PrinterColumn) -> String {
+    let raw = resolve_json_path(object, &column.json_path);
+    if column.column_type != "date" || raw.is_empty() {
+        return raw;
+    }
+    match raw.parse::<k8s_openapi::jiff::Timestamp>() {
+        Ok(ts) => crate::humanize_age(Some(&k8s_openapi::apimachinery::pkg::apis::meta::v1::Time(ts))),
+        Err(_) => raw,
+    }
 }
 
 /// `k8s.listCRDs` — discover installed CustomResourceDefinitions.
@@ -94,6 +289,7 @@ pub fn list_crds_capability(cache: Arc<ClientCache>) -> Capability {
                             kind,
                             plural,
                             namespaced,
+                            printer_columns: printer_columns(spec),
                         })
                     })
                     .collect();
@@ -105,6 +301,7 @@ pub fn list_crds_capability(cache: Arc<ClientCache>) -> Capability {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct ListCustomIn {
     pub context: String,
     pub group: String,
@@ -114,13 +311,25 @@ pub struct ListCustomIn {
     pub namespaced: bool,
     #[serde(default)]
     pub namespace: String,
+    /// Columns to resolve per item, from the CRD's `additionalPrinterColumns`.
+    /// Callers that omit these get just name/namespace/age, as before.
+    #[serde(default)]
+    pub printer_columns: Vec<PrinterColumn>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct CustomRow {
     pub name: String,
     pub namespace: String,
     pub age: String,
+    /// Values for the requested printer columns, in the order they were asked
+    /// for. Empty when none were requested.
+    pub columns: Vec<String>,
+    /// Unrendered values for the columns whose display text loses ordering
+    /// information -- `type: date`, where timestamps 65 and 115 minutes old both
+    /// render "1h" and would otherwise tie. Empty where the text sorts fine.
+    pub sort_keys: Vec<String>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -164,13 +373,27 @@ pub fn list_custom_resource_capability(cache: Arc<ClientCache>) -> Capability {
                     .await
                     .map_err(|_| CapabilityError::Handler("list custom resource timed out".into()))?
                     .map_err(handler_err)?;
+                let columns = input.printer_columns;
                 let items = list
                     .items
                     .into_iter()
-                    .map(|o| CustomRow {
-                        name: o.metadata.name.unwrap_or_default(),
-                        namespace: o.metadata.namespace.unwrap_or_default(),
-                        age: crate::humanize_age(o.metadata.creation_timestamp.as_ref()),
+                    .map(|o| {
+                        let (values, sort_keys) = if columns.is_empty() {
+                            (Vec::new(), Vec::new())
+                        } else {
+                            let object = whole_object(&o);
+                            columns
+                                .iter()
+                                .map(|c| (render_column(&object, c), column_sort_key(&object, c)))
+                                .unzip()
+                        };
+                        CustomRow {
+                            name: o.metadata.name.clone().unwrap_or_default(),
+                            namespace: o.metadata.namespace.clone().unwrap_or_default(),
+                            age: crate::humanize_age(o.metadata.creation_timestamp.as_ref()),
+                            columns: values,
+                            sort_keys,
+                        }
                     })
                     .collect();
                 Ok(ListCustomOut { items })
@@ -200,6 +423,244 @@ mod tests {
             ]
         });
         assert_eq!(pick_version(&spec), "v1beta1");
+    }
+
+    fn obj() -> serde_json::Value {
+        serde_json::json!({
+            "spec": { "version": "4.1.2", "nodes": 3, "paused": false },
+            "status": { "health": "GREEN", "conditions": [{"type": "Ready"}], "empty": null },
+            "metadata": { "labels": { "app.kubernetes.io/name": "cassandra" } },
+        })
+    }
+
+    #[test]
+    fn resolves_dotted_paths_to_scalars() {
+        assert_eq!(resolve_json_path(&obj(), ".status.health"), "GREEN");
+        assert_eq!(resolve_json_path(&obj(), ".spec.version"), "4.1.2");
+        // Numbers and bools render as text, not JSON-quoted.
+        assert_eq!(resolve_json_path(&obj(), ".spec.nodes"), "3");
+        assert_eq!(resolve_json_path(&obj(), ".spec.paused"), "false");
+    }
+
+    #[test]
+    fn resolves_backslash_escaped_dots_in_key_names() {
+        // A CRD may address a dotted label key without bracket notation.
+        assert_eq!(
+            resolve_json_path(&obj(), r".metadata.labels.app\.kubernetes\.io/name"),
+            "cassandra"
+        );
+    }
+
+    #[test]
+    fn resolves_bracket_segments_for_keys_containing_dots() {
+        assert_eq!(
+            resolve_json_path(&obj(), ".metadata.labels['app.kubernetes.io/name']"),
+            "cassandra"
+        );
+    }
+
+    /// Flux's HelmRelease, cert-manager and many operators address a condition
+    /// by type rather than by index, so the filter form is not exotic.
+    fn fluxish() -> serde_json::Value {
+        serde_json::json!({
+            "status": { "conditions": [
+                {"type": "Stalled", "status": "False", "message": "nope"},
+                {"type": "Ready", "status": "True", "message": "Release reconciliation succeeded"},
+            ]},
+            "spec": { "ports": [{"port": 80}, {"port": 443}] },
+        })
+    }
+
+    #[test]
+    fn resolves_filter_expressions_by_field_equality() {
+        assert_eq!(
+            resolve_json_path(&fluxish(), ".status.conditions[?(@.type==\"Ready\")].status"),
+            "True"
+        );
+        assert_eq!(
+            resolve_json_path(&fluxish(), ".status.conditions[?(@.type==\"Ready\")].message"),
+            "Release reconciliation succeeded"
+        );
+    }
+
+    #[test]
+    fn filter_expressions_accept_single_quotes_and_spacing() {
+        assert_eq!(
+            resolve_json_path(&fluxish(), ".status.conditions[?(@.type == 'Stalled')].status"),
+            "False"
+        );
+    }
+
+    #[test]
+    fn a_filter_matching_nothing_renders_empty() {
+        assert_eq!(
+            resolve_json_path(&fluxish(), ".status.conditions[?(@.type==\"Missing\")].status"),
+            ""
+        );
+    }
+
+    #[test]
+    fn resolves_numeric_array_indexes() {
+        assert_eq!(resolve_json_path(&fluxish(), ".spec.ports[1].port"), "443");
+        assert_eq!(resolve_json_path(&fluxish(), ".spec.ports[9].port"), "");
+    }
+
+    #[test]
+    fn missing_null_and_non_scalar_paths_render_empty() {
+        assert_eq!(resolve_json_path(&obj(), ".status.nope"), "");
+        assert_eq!(resolve_json_path(&obj(), ".status.empty"), "");
+        // kubectl renders arrays/objects poorly; an empty cell beats noise.
+        assert_eq!(resolve_json_path(&obj(), ".status.conditions"), "");
+        assert_eq!(resolve_json_path(&obj(), ".spec"), "");
+    }
+
+    fn spec_with_columns() -> serde_json::Value {
+        serde_json::json!({
+            "versions": [{
+                "name": "v1", "served": true, "storage": true,
+                "additionalPrinterColumns": [
+                    {"name": "Health", "type": "string", "jsonPath": ".status.health"},
+                    {"name": "Version", "type": "string", "jsonPath": ".spec.version"},
+                    {"name": "Verbose", "type": "string", "jsonPath": ".spec.x", "priority": 1},
+                    {"name": "Age", "type": "date", "jsonPath": ".metadata.creationTimestamp"},
+                ],
+            }]
+        })
+    }
+
+    #[test]
+    fn takes_printer_columns_from_the_chosen_version() {
+        let cols = printer_columns(&spec_with_columns());
+        // Priority > 0 is `kubectl -o wide` only, and the table already has its
+        // own Age column, so neither should reach the UI.
+        assert_eq!(
+            cols.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
+            vec!["Health", "Version"]
+        );
+        assert_eq!(cols[0].json_path, ".status.health");
+    }
+
+    #[test]
+    fn a_crd_without_printer_columns_yields_none() {
+        let spec = serde_json::json!({"versions": [{"name": "v1", "storage": true}]});
+        assert!(printer_columns(&spec).is_empty());
+    }
+
+    #[test]
+    fn date_columns_render_as_an_age_not_a_timestamp() {
+        let object = serde_json::json!({"status": {"since": "2020-01-01T00:00:00Z"}});
+        let column = PrinterColumn {
+            name: "Since".into(),
+            json_path: ".status.since".into(),
+            column_type: "date".into(),
+        };
+        let rendered = render_column(&object, &column);
+        // Compact age (e.g. "6y"), never the raw RFC 3339 string.
+        assert!(!rendered.contains("2020-01-01"), "got {rendered}");
+        assert!(rendered.ends_with('y'), "got {rendered}");
+    }
+
+    #[test]
+    fn date_columns_carry_the_raw_timestamp_for_sorting() {
+        let object = serde_json::json!({
+            "status": {"since": "2020-01-01T00:00:00Z", "health": "GREEN"}
+        });
+        let date = PrinterColumn {
+            name: "Since".into(),
+            json_path: ".status.since".into(),
+            column_type: "date".into(),
+        };
+        let text = PrinterColumn {
+            name: "Health".into(),
+            json_path: ".status.health".into(),
+            column_type: "string".into(),
+        };
+        // Two timestamps inside the same displayed unit render alike, so the
+        // raw value has to travel alongside for the table to order them.
+        assert_eq!(column_sort_key(&object, &date), "2020-01-01T00:00:00Z");
+        // Text columns already sort by what is shown; no second value needed.
+        assert_eq!(column_sort_key(&object, &text), "");
+    }
+
+    #[test]
+    fn unparseable_date_falls_back_to_the_raw_value() {
+        let object = serde_json::json!({"status": {"since": "not a date"}});
+        let column = PrinterColumn {
+            name: "Since".into(),
+            json_path: ".status.since".into(),
+            column_type: "date".into(),
+        };
+        assert_eq!(render_column(&object, &column), "not a date");
+    }
+
+    #[test]
+    fn metadata_paths_resolve_even_though_kube_splits_metadata_out() {
+        let object: DynamicObject = serde_json::from_value(serde_json::json!({
+            "apiVersion": "db.example.com/v1",
+            "kind": "Cluster",
+            "metadata": {"name": "c1", "labels": {"app.kubernetes.io/name": "cassandra"}},
+            "spec": {"version": "4.1.2"},
+        }))
+        .expect("dynamic object");
+        let whole = whole_object(&object);
+        assert_eq!(
+            resolve_json_path(&whole, ".metadata.labels['app.kubernetes.io/name']"),
+            "cassandra"
+        );
+        assert_eq!(resolve_json_path(&whole, ".spec.version"), "4.1.2");
+    }
+
+    /// End-to-end over Flux's HelmRelease, which is where the empty Ready and
+    /// Status cells were first seen: its columns are filter expressions, and it
+    /// declares its own Age that would otherwise duplicate the built-in one.
+    #[test]
+    fn renders_flux_helmrelease_columns() {
+        let spec = serde_json::json!({
+            "versions": [{
+                "name": "v2", "served": true, "storage": true,
+                "additionalPrinterColumns": [
+                    {"name": "Age", "type": "date", "jsonPath": ".metadata.creationTimestamp"},
+                    {"name": "Ready", "type": "string",
+                     "jsonPath": ".status.conditions[?(@.type==\"Ready\")].status"},
+                    {"name": "Status", "type": "string",
+                     "jsonPath": ".status.conditions[?(@.type==\"Ready\")].message"},
+                ],
+            }]
+        });
+        let columns = printer_columns(&spec);
+        assert_eq!(
+            columns.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
+            vec!["Ready", "Status"],
+        );
+
+        let release = serde_json::json!({
+            "status": {"conditions": [
+                {"type": "Released", "status": "True", "message": "Helm install succeeded"},
+                {"type": "Ready", "status": "True", "message": "Release reconciliation succeeded"},
+            ]}
+        });
+        let rendered: Vec<String> =
+            columns.iter().map(|c| render_column(&release, c)).collect();
+        assert_eq!(rendered, vec!["True", "Release reconciliation succeeded"]);
+    }
+
+    #[test]
+    fn type_paths_resolve_even_though_kube_splits_them_out_too() {
+        // kube keeps apiVersion/kind in `types`, separate from both `data` and
+        // `metadata`, so a column addressing them needs all three put back.
+        let object: DynamicObject = serde_json::from_value(serde_json::json!({
+            "apiVersion": "db.example.com/v1",
+            "kind": "Cluster",
+            "metadata": {"name": "c1"},
+            "spec": {"version": "4.1.2"},
+        }))
+        .expect("dynamic object");
+        let whole = whole_object(&object);
+        assert_eq!(resolve_json_path(&whole, ".kind"), "Cluster");
+        assert_eq!(resolve_json_path(&whole, ".apiVersion"), "db.example.com/v1");
+        // The other two sources still resolve.
+        assert_eq!(resolve_json_path(&whole, ".metadata.name"), "c1");
+        assert_eq!(resolve_json_path(&whole, ".spec.version"), "4.1.2");
     }
 
     #[test]

--- a/crates/mcp/src/http.rs
+++ b/crates/mcp/src/http.rs
@@ -359,7 +359,12 @@ async fn rpc(
         // never deliver.
         let sessions = st.push.sessions.lock().unwrap_or_else(|e| e.into_inner());
         match sessions.get(&session) {
-            Some(c) => handle_subscription(&st.server, &c.subs, &c.dirty, &c.wake, &req, method),
+            Some(c) => {
+                handle_subscription(
+                    &st.server, &c.subs, &c.dirty, &c.wake, &req, method,
+                    crate::Transport::Http,
+                )
+            }
             None => req.get("id").cloned().map(|id| {
                 json!({"jsonrpc": "2.0", "id": id, "error": {"code": -32002, "message":
                     "no notification stream is connected for this session: open GET /mcp \
@@ -666,6 +671,35 @@ mod tests {
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn a_subscription_over_http_is_audited_as_http() {
+        // The audit log is how an operator attributes an action to a caller, so
+        // a networked subscribe recorded as stdio is worse than not logging it.
+        #[derive(Default)]
+        struct Spy(Mutex<Vec<(String, crate::Transport)>>);
+        impl crate::audit::AuditSink for Spy {
+            fn record(&self, rec: crate::audit::AuditRecord) {
+                self.0.lock().unwrap().push((rec.tool, rec.transport));
+            }
+        }
+        let spy = Arc::new(Spy::default());
+        let joins = Arc::new(Mutex::new(Vec::new()));
+        let app = router(subscribable_server(joins).with_audit(spy.clone()));
+
+        // A stream must exist for the subscribe to reach the handler at all.
+        let stream_resp = app.clone().oneshot(sse_get()).await.unwrap();
+        assert_eq!(stream_resp.status(), StatusCode::OK);
+        let _ = app.clone().oneshot(subscribe_post("k8s://c/ns/Pod/web-0")).await.unwrap();
+
+        let seen = spy.0.lock().unwrap().clone();
+        let subscribes: Vec<_> =
+            seen.iter().filter(|(tool, _)| tool == "resources/subscribe").collect();
+        assert!(!subscribes.is_empty(), "the subscribe must be audited: {seen:?}");
+        for (tool, transport) in subscribes {
+            assert_eq!(*transport, crate::Transport::Http, "{tool} attributed to the wrong transport");
+        }
     }
 
     #[tokio::test]

--- a/crates/mcp/src/stdio.rs
+++ b/crates/mcp/src/stdio.rs
@@ -411,17 +411,43 @@ pub(crate) fn handle_subscription(
 
     let uri = match crate::resources::ResourceUri::parse(uri_str) {
         Ok(u) => u,
-        Err(message) => return Some(err(id, -32602, &message)),
+        Err(message) => {
+            server.audit().record(crate::audit::AuditRecord {
+                transport: crate::Transport::Stdio,
+                tool: method.to_string(),
+                args: crate::audit::redact(&json!({"uri": uri_str}), false),
+                decision: "auto",
+                outcome: "error",
+                error: Some(message.clone()),
+            });
+            return Some(err(id, -32602, &message));
+        }
     };
     // Canonical form, so two spellings of one object cannot make two watches.
     let canonical = uri.to_string();
 
     if method == "resources/unsubscribe" {
         subs.remove(&canonical);
+        server.audit().record(crate::audit::AuditRecord {
+            transport: crate::Transport::Stdio,
+            tool: method.to_string(),
+            args: crate::audit::redact(&json!({"uri": uri_str}), false),
+            decision: "auto",
+            outcome: "ok",
+            error: None,
+        });
         return Some(ok(id, json!({})));
     }
 
     if let Err(message) = crate::resources::is_subscribable(&uri) {
+        server.audit().record(crate::audit::AuditRecord {
+            transport: crate::Transport::Stdio,
+            tool: method.to_string(),
+            args: crate::audit::redact(&json!({"uri": uri_str}), false),
+            decision: "auto",
+            outcome: "error",
+            error: Some(message.clone()),
+        });
         return Some(err(id, -32602, &message));
     }
     // `plan_read` is entirely offline: it validates the URI's shape, scope,
@@ -433,6 +459,14 @@ pub(crate) fn handle_subscription(
     // resolver `plan_read` and the real read path both use, so this and the
     // eventual read agree on what's addressable.
     if let Err(message) = crate::resources::plan_read(&uri, server.kind_resolver().as_ref()) {
+        server.audit().record(crate::audit::AuditRecord {
+            transport: crate::Transport::Stdio,
+            tool: method.to_string(),
+            args: crate::audit::redact(&json!({"uri": uri_str}), false),
+            decision: "auto",
+            outcome: "error",
+            error: Some(message.clone()),
+        });
         return Some(err(id, -32602, &message));
     }
 
@@ -502,7 +536,17 @@ pub(crate) fn handle_subscription(
 
     let handle = match server.watcher().watch(&uri, on_change, on_dead) {
         Ok(h) => h,
-        Err(message) => return Some(err(id, -32602, &message)),
+        Err(message) => {
+            server.audit().record(crate::audit::AuditRecord {
+                transport: crate::Transport::Stdio,
+                tool: method.to_string(),
+                args: crate::audit::redact(&json!({"uri": uri_str}), false),
+                decision: "auto",
+                outcome: "error",
+                error: Some(message.clone()),
+            });
+            return Some(err(id, -32602, &message));
+        }
     };
     // Death BEFORE commitment: check before `insert`, because on a
     // re-subscribe `insert` replaces AND ABORTS the prior still-live watch —
@@ -512,11 +556,30 @@ pub(crate) fn handle_subscription(
     // here since it never reaches the registry's ownership.
     if let Some(reason) = dead.lock().unwrap_or_else(|e| e.into_inner()).take() {
         handle.abort();
-        return Some(err(id, -32603, &format!("the watch ended immediately: {reason}")));
+        let message = format!("the watch ended immediately: {reason}");
+        server.audit().record(crate::audit::AuditRecord {
+            transport: crate::Transport::Stdio,
+            tool: method.to_string(),
+            args: crate::audit::redact(&json!({"uri": uri_str}), false),
+            decision: "auto",
+            outcome: "error",
+            error: Some(message.clone()),
+        });
+        return Some(err(id, -32603, &message));
     }
     let generation = match subs.insert(canonical.clone(), handle) {
         Ok(generation) => generation,
-        Err(message) => return Some(err(id, -32602, &message)),
+        Err(message) => {
+            server.audit().record(crate::audit::AuditRecord {
+                transport: crate::Transport::Stdio,
+                tool: method.to_string(),
+                args: crate::audit::redact(&json!({"uri": uri_str}), false),
+                decision: "auto",
+                outcome: "error",
+                error: Some(message.clone()),
+            });
+            return Some(err(id, -32602, &message));
+        }
     };
     *my_generation.lock().unwrap_or_else(|e| e.into_inner()) = Some(generation);
     if let Some(reason) = dead.lock().unwrap_or_else(|e| e.into_inner()).take() {
@@ -528,8 +591,25 @@ pub(crate) fn handle_subscription(
         // cost of `watch` being synchronous; the client still learns the
         // truth from the error response.
         subs.remove_if(&canonical, generation);
-        return Some(err(id, -32603, &format!("the watch ended immediately: {reason}")));
+        let message = format!("the watch ended immediately: {reason}");
+        server.audit().record(crate::audit::AuditRecord {
+            transport: crate::Transport::Stdio,
+            tool: method.to_string(),
+            args: crate::audit::redact(&json!({"uri": uri_str}), false),
+            decision: "auto",
+            outcome: "error",
+            error: Some(message.clone()),
+        });
+        return Some(err(id, -32603, &message));
     }
+    server.audit().record(crate::audit::AuditRecord {
+        transport: crate::Transport::Stdio,
+        tool: method.to_string(),
+        args: crate::audit::redact(&json!({"uri": uri_str}), false),
+        decision: "auto",
+        outcome: "ok",
+        error: None,
+    });
     Some(ok(id, json!({})))
 }
 
@@ -2241,5 +2321,213 @@ mod tests {
             v["error"]["message"].as_str().unwrap().contains("no cluster watcher"),
             "the message must explain no watcher is wired, got {text}"
         );
+    }
+
+    // --- Issue #198: subscribe/unsubscribe write an audit record. ----------
+    //
+    // Every other capability-backed path (tools/call, resources/read) is
+    // audited, but the subscription methods never were — an agent could hold
+    // up to `MAX_SUBSCRIPTIONS` concurrent watches with nothing left in the
+    // log. Subscribe is stdio-only (the HTTP transport advertises
+    // `subscribe: false`), so every record here is `Transport::Stdio`, and it
+    // is not consent-gated, so `decision` is always `"auto"` (mirroring the
+    // resources/read auto path). The URI goes through `redact` for consistency
+    // even though Secrets are not addressable, so it is not sensitive. `tool`
+    // holds the method name.
+
+    /// Full-record spy: unlike the lighter `(tool, decision, outcome)` spies
+    /// above, keeps the whole `AuditRecord` so the redacted `args` and the
+    /// `error` message are assertable.
+    #[derive(Default)]
+    struct AuditSpy(std::sync::Mutex<Vec<crate::audit::AuditRecord>>);
+    impl crate::audit::AuditSink for AuditSpy {
+        fn record(&self, rec: crate::audit::AuditRecord) {
+            self.0.lock().unwrap().push(rec);
+        }
+    }
+
+    /// A subscribe-capable server (kinds resolver + live stub watcher) whose
+    /// audit records land in `spy`.
+    fn audited_subscribe_server(spy: &Arc<AuditSpy>) -> Arc<McpServer> {
+        Arc::new(server_with_kinds().with_audit(spy.clone()))
+    }
+
+    #[tokio::test]
+    async fn a_successful_subscribe_is_audited() {
+        let spy = Arc::new(AuditSpy::default());
+        let server = audited_subscribe_server(&spy);
+        let subs = Arc::new(crate::subscriptions::SubscriptionRegistry::new());
+        let dirty = Arc::new(std::sync::Mutex::new(std::collections::BTreeSet::new()));
+        let (wake_tx, _wake_rx) = tokio::sync::mpsc::channel(1);
+        let req = json!({"jsonrpc":"2.0","id":1,"method":"resources/subscribe",
+            "params":{"uri":"k8s://c/ns/Pod/web-0"}});
+
+        let resp =
+            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe")
+                .unwrap();
+        assert!(resp.get("error").is_none(), "the subscribe succeeds: {resp}");
+
+        let seen = spy.0.lock().unwrap().clone();
+        assert_eq!(seen.len(), 1, "expected one audit record, got {seen:?}");
+        assert_eq!(seen[0].transport, crate::Transport::Stdio);
+        assert_eq!(seen[0].tool, "resources/subscribe");
+        assert_eq!(seen[0].decision, "auto");
+        assert_eq!(seen[0].outcome, "ok");
+        assert_eq!(seen[0].args, json!({"uri": "k8s://c/ns/Pod/web-0"}));
+        assert!(seen[0].error.is_none(), "a success carries no error");
+    }
+
+    /// The issue's point is to record the OUTCOME, not just the attempt — a
+    /// rejected subscribe is as interesting as a successful one. Here the
+    /// rejection is `is_subscribable`: `k8s://catalog` is static.
+    #[tokio::test]
+    async fn a_subscribe_rejected_for_a_non_subscribable_uri_is_audited_as_an_error() {
+        let spy = Arc::new(AuditSpy::default());
+        let server = audited_subscribe_server(&spy);
+        let subs = Arc::new(crate::subscriptions::SubscriptionRegistry::new());
+        let dirty = Arc::new(std::sync::Mutex::new(std::collections::BTreeSet::new()));
+        let (wake_tx, _wake_rx) = tokio::sync::mpsc::channel(1);
+        let req = json!({"jsonrpc":"2.0","id":1,"method":"resources/subscribe",
+            "params":{"uri":"k8s://catalog"}});
+
+        let resp =
+            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe")
+                .unwrap();
+        assert_eq!(resp["error"]["code"], -32602, "got {resp}");
+
+        let seen = spy.0.lock().unwrap().clone();
+        assert_eq!(seen.len(), 1, "expected one audit record, got {seen:?}");
+        assert_eq!(seen[0].tool, "resources/subscribe");
+        assert_eq!(seen[0].decision, "auto");
+        assert_eq!(seen[0].outcome, "error");
+        assert_eq!(seen[0].args, json!({"uri": "k8s://catalog"}));
+        let message = seen[0].error.as_deref().unwrap_or_default();
+        assert!(message.contains("static"), "the reason must survive, got: {message}");
+    }
+
+    /// A second rejection branch: `plan_read` refuses Secrets before any watch
+    /// starts, so the audit must say so rather than pretending success.
+    #[tokio::test]
+    async fn a_subscribe_rejected_for_an_unaddressable_secret_is_audited_as_an_error() {
+        let spy = Arc::new(AuditSpy::default());
+        let server = audited_subscribe_server(&spy);
+        let subs = Arc::new(crate::subscriptions::SubscriptionRegistry::new());
+        let dirty = Arc::new(std::sync::Mutex::new(std::collections::BTreeSet::new()));
+        let (wake_tx, _wake_rx) = tokio::sync::mpsc::channel(1);
+        let req = json!({"jsonrpc":"2.0","id":1,"method":"resources/subscribe",
+            "params":{"uri":"k8s://c/ns/Secret/shared"}});
+
+        let resp =
+            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe")
+                .unwrap();
+        assert_eq!(resp["error"]["code"], -32602, "got {resp}");
+
+        let seen = spy.0.lock().unwrap().clone();
+        assert_eq!(seen.len(), 1, "expected one audit record, got {seen:?}");
+        assert_eq!(seen[0].outcome, "error");
+        let message = seen[0].error.as_deref().unwrap_or_default();
+        assert!(
+            message.contains("not addressable"),
+            "the Secret refusal must survive, got: {message}"
+        );
+    }
+
+    /// A third rejection branch the issue names explicitly: the watcher itself
+    /// refuses (unknown context, RBAC Forbidden, stream failure at setup).
+    #[tokio::test]
+    async fn a_subscribe_whose_watch_errors_is_audited_as_an_error() {
+        struct RefusingWatcher;
+        impl crate::resources::ObjectWatcher for RefusingWatcher {
+            fn watch(
+                &self,
+                _uri: &crate::resources::ResourceUri,
+                _on_change: Box<dyn FnMut() + Send>,
+                _on_dead: Box<dyn FnOnce(String) + Send>,
+            ) -> Result<tokio::task::AbortHandle, String> {
+                Err("the cluster refused to watch".to_string())
+            }
+        }
+        struct Kinds;
+        impl crate::resources::KindResolver for Kinds {
+            fn scope(&self, kind: &str) -> Option<crate::resources::KindScope> {
+                (kind == "Pod").then_some(crate::resources::KindScope::Namespaced)
+            }
+        }
+        let spy = Arc::new(AuditSpy::default());
+        let server = Arc::new(
+            server_with_ping()
+                .with_kind_resolver(Arc::new(Kinds))
+                .with_watcher(Arc::new(RefusingWatcher))
+                .with_audit(spy.clone()),
+        );
+        let subs = Arc::new(crate::subscriptions::SubscriptionRegistry::new());
+        let dirty = Arc::new(std::sync::Mutex::new(std::collections::BTreeSet::new()));
+        let (wake_tx, _wake_rx) = tokio::sync::mpsc::channel(1);
+        let req = json!({"jsonrpc":"2.0","id":1,"method":"resources/subscribe",
+            "params":{"uri":"k8s://c/ns/Pod/web-0"}});
+
+        let resp =
+            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe")
+                .unwrap();
+        assert_eq!(resp["error"]["code"], -32602, "got {resp}");
+
+        let seen = spy.0.lock().unwrap().clone();
+        assert_eq!(seen.len(), 1, "expected one audit record, got {seen:?}");
+        assert_eq!(seen[0].outcome, "error");
+        let message = seen[0].error.as_deref().unwrap_or_default();
+        assert!(message.contains("refused"), "the reason must survive, got: {message}");
+    }
+
+    /// The fourth rejection branch the issue names: the 32-watch cap. The
+    /// registry is pre-filled so the subscribe fails its `insert`.
+    #[tokio::test]
+    async fn a_subscribe_rejected_for_the_watch_cap_is_audited_as_an_error() {
+        let spy = Arc::new(AuditSpy::default());
+        let server = audited_subscribe_server(&spy);
+        let subs = Arc::new(crate::subscriptions::SubscriptionRegistry::new());
+        for i in 0..crate::subscriptions::MAX_SUBSCRIPTIONS {
+            let handle = tokio::spawn(async { std::future::pending::<()>().await }).abort_handle();
+            subs.insert(format!("k8s://c/ns/Pod/p{i}"), handle).unwrap();
+        }
+        let dirty = Arc::new(std::sync::Mutex::new(std::collections::BTreeSet::new()));
+        let (wake_tx, _wake_rx) = tokio::sync::mpsc::channel(1);
+        let req = json!({"jsonrpc":"2.0","id":1,"method":"resources/subscribe",
+            "params":{"uri":"k8s://c/ns/Pod/one-too-many"}});
+
+        let resp =
+            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe")
+                .unwrap();
+        assert_eq!(resp["error"]["code"], -32602, "got {resp}");
+
+        let seen = spy.0.lock().unwrap().clone();
+        assert_eq!(seen.len(), 1, "expected one audit record, got {seen:?}");
+        assert_eq!(seen[0].outcome, "error");
+        let message = seen[0].error.as_deref().unwrap_or_default();
+        assert!(message.contains("too many"), "the reason must survive, got: {message}");
+    }
+
+    #[tokio::test]
+    async fn an_unsubscribe_is_audited() {
+        let spy = Arc::new(AuditSpy::default());
+        let server = audited_subscribe_server(&spy);
+        let subs = Arc::new(crate::subscriptions::SubscriptionRegistry::new());
+        let dirty = Arc::new(std::sync::Mutex::new(std::collections::BTreeSet::new()));
+        let (wake_tx, _wake_rx) = tokio::sync::mpsc::channel(1);
+        let req = json!({"jsonrpc":"2.0","id":1,"method":"resources/unsubscribe",
+            "params":{"uri":"k8s://c/ns/Pod/web-0"}});
+
+        let resp =
+            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/unsubscribe")
+                .unwrap();
+        assert!(resp.get("error").is_none(), "unsubscribe succeeds: {resp}");
+
+        let seen = spy.0.lock().unwrap().clone();
+        assert_eq!(seen.len(), 1, "expected one audit record, got {seen:?}");
+        assert_eq!(seen[0].transport, crate::Transport::Stdio);
+        assert_eq!(seen[0].tool, "resources/unsubscribe");
+        assert_eq!(seen[0].decision, "auto");
+        assert_eq!(seen[0].outcome, "ok");
+        assert_eq!(seen[0].args, json!({"uri": "k8s://c/ns/Pod/web-0"}));
+        assert!(seen[0].error.is_none(), "an unsubscribe carries no error");
     }
 }

--- a/crates/mcp/src/stdio.rs
+++ b/crates/mcp/src/stdio.rs
@@ -401,6 +401,10 @@ pub(crate) fn handle_subscription(
     wake: &tokio::sync::mpsc::Sender<()>,
     req: &Value,
     method: &str,
+    // Both transports route subscriptions through here, so the caller's own
+    // transport has to travel with them: an audit record naming the wrong
+    // one misattributes the action, which is the whole point of the log.
+    transport: crate::Transport,
 ) -> Option<Value> {
     let id = req.get("id").cloned()?;
     let uri_str = req
@@ -413,7 +417,7 @@ pub(crate) fn handle_subscription(
         Ok(u) => u,
         Err(message) => {
             server.audit().record(crate::audit::AuditRecord {
-                transport: crate::Transport::Stdio,
+                transport,
                 tool: method.to_string(),
                 args: crate::audit::redact(&json!({"uri": uri_str}), false),
                 decision: "auto",
@@ -429,7 +433,7 @@ pub(crate) fn handle_subscription(
     if method == "resources/unsubscribe" {
         subs.remove(&canonical);
         server.audit().record(crate::audit::AuditRecord {
-            transport: crate::Transport::Stdio,
+            transport,
             tool: method.to_string(),
             args: crate::audit::redact(&json!({"uri": uri_str}), false),
             decision: "auto",
@@ -441,7 +445,7 @@ pub(crate) fn handle_subscription(
 
     if let Err(message) = crate::resources::is_subscribable(&uri) {
         server.audit().record(crate::audit::AuditRecord {
-            transport: crate::Transport::Stdio,
+            transport,
             tool: method.to_string(),
             args: crate::audit::redact(&json!({"uri": uri_str}), false),
             decision: "auto",
@@ -460,7 +464,7 @@ pub(crate) fn handle_subscription(
     // eventual read agree on what's addressable.
     if let Err(message) = crate::resources::plan_read(&uri, server.kind_resolver().as_ref()) {
         server.audit().record(crate::audit::AuditRecord {
-            transport: crate::Transport::Stdio,
+            transport,
             tool: method.to_string(),
             args: crate::audit::redact(&json!({"uri": uri_str}), false),
             decision: "auto",
@@ -538,7 +542,7 @@ pub(crate) fn handle_subscription(
         Ok(h) => h,
         Err(message) => {
             server.audit().record(crate::audit::AuditRecord {
-                transport: crate::Transport::Stdio,
+                transport,
                 tool: method.to_string(),
                 args: crate::audit::redact(&json!({"uri": uri_str}), false),
                 decision: "auto",
@@ -558,7 +562,7 @@ pub(crate) fn handle_subscription(
         handle.abort();
         let message = format!("the watch ended immediately: {reason}");
         server.audit().record(crate::audit::AuditRecord {
-            transport: crate::Transport::Stdio,
+            transport,
             tool: method.to_string(),
             args: crate::audit::redact(&json!({"uri": uri_str}), false),
             decision: "auto",
@@ -571,7 +575,7 @@ pub(crate) fn handle_subscription(
         Ok(generation) => generation,
         Err(message) => {
             server.audit().record(crate::audit::AuditRecord {
-                transport: crate::Transport::Stdio,
+                transport,
                 tool: method.to_string(),
                 args: crate::audit::redact(&json!({"uri": uri_str}), false),
                 decision: "auto",
@@ -593,7 +597,7 @@ pub(crate) fn handle_subscription(
         subs.remove_if(&canonical, generation);
         let message = format!("the watch ended immediately: {reason}");
         server.audit().record(crate::audit::AuditRecord {
-            transport: crate::Transport::Stdio,
+            transport,
             tool: method.to_string(),
             args: crate::audit::redact(&json!({"uri": uri_str}), false),
             decision: "auto",
@@ -603,7 +607,7 @@ pub(crate) fn handle_subscription(
         return Some(err(id, -32603, &message));
     }
     server.audit().record(crate::audit::AuditRecord {
-        transport: crate::Transport::Stdio,
+        transport,
         tool: method.to_string(),
         args: crate::audit::redact(&json!({"uri": uri_str}), false),
         decision: "auto",
@@ -700,7 +704,7 @@ where
                 // HTTP transport, which has no channel to push notifications and
                 // must keep answering -32601.
                 let resp = if method == "resources/subscribe" || method == "resources/unsubscribe" {
-                    handle_subscription(server, subs, dirty, wake_tx, &req, method)
+                    handle_subscription(server, subs, dirty, wake_tx, &req, method, crate::Transport::Stdio)
                 } else {
                     handle_request(server, &req, crate::Transport::Stdio).await
                 };
@@ -1895,7 +1899,7 @@ mod tests {
         let req = json!({"jsonrpc":"2.0","id":1,"method":"resources/subscribe",
             "params":{"uri":"k8s://c/ns/Pod/web-0"}});
         let resp =
-            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe")
+            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe", crate::Transport::Stdio)
                 .unwrap();
         let message = resp["error"]["message"].as_str().unwrap_or_default();
         assert!(message.contains("ended immediately"), "got: {resp}");
@@ -1942,7 +1946,7 @@ mod tests {
         let req = json!({"jsonrpc":"2.0","id":1,"method":"resources/subscribe",
             "params":{"uri":"k8s://c/ns/Pod/web-0"}});
         let resp =
-            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe")
+            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe", crate::Transport::Stdio)
                 .unwrap();
         assert!(resp.get("error").is_none(), "the live subscribe succeeds: {resp}");
 
@@ -1997,13 +2001,13 @@ mod tests {
             "params":{"uri":"k8s://c/ns/Pod/web-0"}});
 
         let first =
-            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe")
+            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe", crate::Transport::Stdio)
                 .unwrap();
         assert!(first.get("error").is_none(), "the first subscribe succeeds: {first}");
 
         // The re-subscribe's replacement watch is stillborn.
         let second =
-            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe")
+            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe", crate::Transport::Stdio)
                 .unwrap();
         assert!(
             second["error"]["message"].as_str().unwrap_or_default().contains("ended immediately"),
@@ -2056,7 +2060,7 @@ mod tests {
         // Subscribe twice: the second replaces the first in the registry.
         for _ in 0..2 {
             let resp =
-                handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe")
+                handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe", crate::Transport::Stdio)
                     .unwrap();
             assert!(resp.get("error").is_none(), "subscribe succeeds: {resp}");
         }
@@ -2363,7 +2367,7 @@ mod tests {
             "params":{"uri":"k8s://c/ns/Pod/web-0"}});
 
         let resp =
-            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe")
+            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe", crate::Transport::Stdio)
                 .unwrap();
         assert!(resp.get("error").is_none(), "the subscribe succeeds: {resp}");
 
@@ -2391,7 +2395,7 @@ mod tests {
             "params":{"uri":"k8s://catalog"}});
 
         let resp =
-            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe")
+            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe", crate::Transport::Stdio)
                 .unwrap();
         assert_eq!(resp["error"]["code"], -32602, "got {resp}");
 
@@ -2418,7 +2422,7 @@ mod tests {
             "params":{"uri":"k8s://c/ns/Secret/shared"}});
 
         let resp =
-            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe")
+            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe", crate::Transport::Stdio)
                 .unwrap();
         assert_eq!(resp["error"]["code"], -32602, "got {resp}");
 
@@ -2467,7 +2471,7 @@ mod tests {
             "params":{"uri":"k8s://c/ns/Pod/web-0"}});
 
         let resp =
-            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe")
+            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe", crate::Transport::Stdio)
                 .unwrap();
         assert_eq!(resp["error"]["code"], -32602, "got {resp}");
 
@@ -2495,7 +2499,7 @@ mod tests {
             "params":{"uri":"k8s://c/ns/Pod/one-too-many"}});
 
         let resp =
-            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe")
+            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/subscribe", crate::Transport::Stdio)
                 .unwrap();
         assert_eq!(resp["error"]["code"], -32602, "got {resp}");
 
@@ -2517,7 +2521,7 @@ mod tests {
             "params":{"uri":"k8s://c/ns/Pod/web-0"}});
 
         let resp =
-            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/unsubscribe")
+            handle_subscription(&server, &subs, &dirty, &wake_tx, &req, "resources/unsubscribe", crate::Transport::Stdio)
                 .unwrap();
         assert!(resp.get("error").is_none(), "unsubscribe succeeds: {resp}");
 


### PR DESCRIPTION
Promotes `dev` to `main`. Seven commits since `srelens-v0.7.1`, all patch-level.

**Merge with a merge commit — do not squash.** The pipeline derives the version from the individual Conventional Commit subjects, which a squash would flatten.

No `feat` and no breaking change, so auto-versioning should compute **0.7.2** from 0.7.1 and commit the bump back to `main` with `[skip ci]`.

## Contents

| Commit | |
|---|---|
| `fix(table)` | pin column widths so virtualized lists stop re-flowing (#299) |
| `fix(table)` | stop the checkbox column rendering an ellipsis (#299) |
| `fix(table)` | size every table the same way, not just virtualized ones (#299) |
| `fix(crds)` | show the columns a CRD asks to have displayed (#300) |
| `fix(mcp)` | audit-log resources/subscribe and unsubscribe (#283) |
| `fix(mcp)` | attribute subscription audit records to the calling transport (#302) |

## Highlights

**Tables size consistently everywhere** (#299, closes #298). Column widths shifted as you scrolled a long list, because virtualization swaps the rendered rows underneath automatic table layout. Widths are now measured once and pinned, for every table rather than only the ones long enough to virtualize — CRDs, Services and most views sat under that threshold and sized by a different rule. Also fixes a stray "..." beside every checkbox, which turned out to be a CSS cascade bug leaving the 36px column an 8px content box.

**Custom resources show their real columns** (#300, closes #267). A CRD list showed only name, namespace and age. Kubernetes already publishes the answer in `spec.versions[].additionalPrinterColumns` — the same metadata `kubectl get` renders — and srelens was fetching it and discarding it. Each CRD now gets the columns it declares, with a resolver covering the jsonPath subset real operators use, including the `[?(@.type=="Ready")]` filters Flux and cert-manager rely on.

**Subscription auditing is correctly attributed** (#302). `resources/subscribe` from a networked MCP client was logged as stdio, because both transports share one helper that hardcoded `Transport::Stdio`. Caught and fixed before it ever shipped.

## Release note

`srelens-v0.7.1` cleared [code-scanning alert #32](https://github.com/srelens/srelens/security/code-scanning/32) (27 open RUSTSEC advisories); GitHub now reports it **fixed**. Nothing in this release changes that — `osv-scanner scan source --lockfile=Cargo.lock` still exits 0.

## State

- `dev` is 10 commits ahead of `main` and 0 behind — the back-merge in #301 cleared the drift left by squash-merging #297.
- CI on `dev` at `aeea5a1` was still running when this was opened; worth confirming green before merging.


## Thanks

- **@sidsri14** for `fix(mcp): audit-log resources/subscribe and unsubscribe` (#283), closing #198 — subscription methods now leave an audit trail like every other MCP call. Following #204 earlier this month, that is the second MCP change from you in this area.
- **@Parul1411** for reviewing and merging through this batch (#299, #301), including the back-merge that untangled the `main`/`dev` version drift.

Thanks also to the automated review on #299 and #300, which caught ten issues across the two — several of them, notably the restored-tab reconciliation in #300, would have shipped looking fine in a fresh tab while being broken for every existing user.
