### PR TITLE
chore: back-merge main into dev (srelens-v0.7.2 version bump)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5902,7 +5902,7 @@ dependencies = [
 
 [[package]]
 name = "srelens-agent"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -5910,7 +5910,7 @@ dependencies = [
 
 [[package]]
 name = "srelens-capability"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -5921,7 +5921,7 @@ dependencies = [
 
 [[package]]
 name = "srelens-desktop"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5962,7 +5962,7 @@ dependencies = [
 
 [[package]]
 name = "srelens-kube"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5988,7 +5988,7 @@ dependencies = [
 
 [[package]]
 name = "srelens-llm"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "futures",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "srelens-mcp"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -6021,7 +6021,7 @@ dependencies = [
 
 [[package]]
 name = "srelens-registry"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "dirs",
  "reqwest 0.13.4",
@@ -6037,7 +6037,7 @@ dependencies = [
 
 [[package]]
 name = "srelens-server"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "srelens-streams"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "portable-pty",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/agent", "crates/capability", "crates/mcp", "crates/kube", "cr
 
 [workspace.package]
 edition = "2021"
-version = "0.7.1"
+version = "0.7.2"
 license = "MIT"
 
 # Fast-feedback profile for the CI WebDriver smoke job (issue #30): dev

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "srelens",
   "mainBinaryName": "srelens",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "identifier": "app.srelens.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Syncs `main` back into `dev` after the 0.7.2 release, so the version bump does not sit stranded on `main`.

**Merge with a merge commit — do not squash.** Squashing #297 is what left the branches four commits out of step until #301 repaired it; a squash here would restart that.

## What's in it

| Commit | |
|---|---|
| `Merge pull request #303 from srelens/dev` | the 0.7.2 promotion |
| `chore(release): srelens-v0.7.2 [skip ci]` | the version bump the release workflow committed |

## Effect on dev

```
Cargo.toml                             version 0.7.1 -> 0.7.2
apps/desktop/src-tauri/tauri.conf.json version 0.7.1 -> 0.7.2
Cargo.lock                             srelens-* crate versions follow
```

Version metadata only — no source changes.

Two commits rather than four this time: #301 restored the shared ancestry, so only the new release shows up.
