### PR TITLE
fix(core): remove the ambiguous quantifiers behind nine ReDoS findings

### DIFF
--- a/packages/core/src/lib/addCluster.ts
+++ b/packages/core/src/lib/addCluster.ts
@@ -14,6 +14,7 @@ import { isTauri } from "../transport/platform";
 import { invokeCapability } from "../transport/transport";
 import { savePastedKubeconfig } from "./files";
 import { createCluster as createClusterWeb, type CreateClusterInput } from "./webClusters";
+import { parse as parseYaml } from "yaml";
 
 export type { CreateClusterInput };
 
@@ -55,51 +56,33 @@ export async function testClusterForm(input: CreateClusterInput): Promise<TestRe
 /**
  * The `current-context` a kubeconfig names, or null if it names none.
  *
- * Deliberately not one regex. The previous single pattern paired `\s*` around a
- * lazy body with a trailing `\s*$`, which gave the engine several ways to split
- * the same run of spaces: a 4KB line of them took 51 seconds, and the cost grew
- * cubically, so 8KB took minutes (js/polynomial-redos, #43). A kubeconfig is
- * pasted or uploaded, so that is a way to freeze the app from outside it.
+ * Parsed with the YAML library rather than matched.
  *
- * Matching only up to the end of the line and trimming in code is linear, and
- * far easier to read besides.
+ * A pattern here was a denial of service: `\s*` around a lazy body with a
+ * trailing `\s*$` gave the engine several ways to split one run of spaces, and
+ * a 4KB line took 52 seconds (js/polynomial-redos, #43). Hand-scanning instead
+ * fixed that and then got the YAML wrong three times over — `#` inside a name,
+ * `#` without preceding whitespace, `"prod\"live"`, `'prod''live'` — each a
+ * name that no cluster matches, sent to testClusterConnection as if it were
+ * real.
+ *
+ * The library already ships with this package for manifest editing, knows all
+ * of those rules, and parses a 16KB hostile line in under 4ms. Writing a
+ * fourth version of a YAML scalar reader was the wrong instinct.
  */
 export function parseCurrentContext(yaml: string): string | null {
-  const match = /^[^\S\n]*current-context:([^\n]*)$/m.exec(yaml);
-  if (!match) return null;
-  return unquoteScalar(match[1].trim());
-}
-
-/**
- * The value of a YAML scalar, with any trailing comment removed.
- *
- * Comment handling follows YAML rather than "cut at the first #": a `#` only
- * starts a comment when whitespace precedes it, and never inside quotes. A
- * context name may legitimately contain one — `prod#live` is a valid name, and
- * splitting on every `#` turned it into `prod`, or `"prod` when quoted, so
- * srelens then probed a context that does not exist.
- *
- * Done with string scanning rather than a pattern: this is on the path that
- * reads a pasted kubeconfig, and it is the ambiguity in the regex that used to
- * live here which made that path a denial of service.
- */
-function unquoteScalar(raw: string): string | null {
-  const quote = raw[0];
-  if (quote === '"' || quote === "'") {
-    const close = raw.indexOf(quote, 1);
-    // An unterminated quote is malformed; there is no scalar to read.
-    if (close === -1) return null;
-    return raw.slice(1, close) || null;
+  let document: unknown;
+  try {
+    document = parseYaml(yaml);
+  } catch {
+    // Malformed YAML has no context to read, and the backend would reject the
+    // same document anyway.
+    return null;
   }
-  // Unquoted: a comment needs whitespace in front of the `#`.
-  let end = raw.length;
-  for (let i = 0; i < raw.length; i++) {
-    if (raw[i] === "#" && (i === 0 || raw[i - 1] === " " || raw[i - 1] === "\t")) {
-      end = i;
-      break;
-    }
-  }
-  return raw.slice(0, end).trim() || null;
+  if (typeof document !== "object" || document === null) return null;
+  const context = (document as Record<string, unknown>)["current-context"];
+  if (typeof context !== "string") return null;
+  return context.trim() || null;
 }
 
 /** Test-connect a pasted/uploaded kubeconfig by its `current-context`. */

--- a/packages/core/src/lib/addCluster.ts
+++ b/packages/core/src/lib/addCluster.ts
@@ -52,10 +52,31 @@ export async function testClusterForm(input: CreateClusterInput): Promise<TestRe
   });
 }
 
+/**
+ * The `current-context` a kubeconfig names, or null if it names none.
+ *
+ * Deliberately not one regex. The previous single pattern paired `\s*` around a
+ * lazy body with a trailing `\s*$`, which gave the engine several ways to split
+ * the same run of spaces: a 4KB line of them took 51 seconds, and the cost grew
+ * cubically, so 8KB took minutes (js/polynomial-redos, #43). A kubeconfig is
+ * pasted or uploaded, so that is a way to freeze the app from outside it.
+ *
+ * Matching only up to the end of the line and trimming in code is linear, and
+ * far easier to read besides.
+ */
+export function parseCurrentContext(yaml: string): string | null {
+  const match = /^[^\S\n]*current-context:([^\n]*)$/m.exec(yaml);
+  if (!match) return null;
+  // Strip a trailing comment, then surrounding whitespace, then quotes.
+  const withoutComment = match[1].split("#", 1)[0].trim();
+  const unquoted = /^(["'])(.*)\1$/.exec(withoutComment);
+  const context = (unquoted ? unquoted[2] : withoutComment).trim();
+  return context || null;
+}
+
 /** Test-connect a pasted/uploaded kubeconfig by its `current-context`. */
 export async function testKubeconfigYaml(yaml: string): Promise<TestResult> {
-  const match = yaml.match(/^\s*current-context:\s*["']?([^"'\n#]+?)["']?\s*$/m);
-  const context = match?.[1]?.trim();
+  const context = parseCurrentContext(yaml);
   if (!context) throw new Error("kubeconfig has no current-context to test");
   return invokeCapability<TestResult>("k8s.testClusterConnection", { yaml, context });
 }

--- a/packages/core/src/lib/addCluster.ts
+++ b/packages/core/src/lib/addCluster.ts
@@ -67,11 +67,39 @@ export async function testClusterForm(input: CreateClusterInput): Promise<TestRe
 export function parseCurrentContext(yaml: string): string | null {
   const match = /^[^\S\n]*current-context:([^\n]*)$/m.exec(yaml);
   if (!match) return null;
-  // Strip a trailing comment, then surrounding whitespace, then quotes.
-  const withoutComment = match[1].split("#", 1)[0].trim();
-  const unquoted = /^(["'])(.*)\1$/.exec(withoutComment);
-  const context = (unquoted ? unquoted[2] : withoutComment).trim();
-  return context || null;
+  return unquoteScalar(match[1].trim());
+}
+
+/**
+ * The value of a YAML scalar, with any trailing comment removed.
+ *
+ * Comment handling follows YAML rather than "cut at the first #": a `#` only
+ * starts a comment when whitespace precedes it, and never inside quotes. A
+ * context name may legitimately contain one — `prod#live` is a valid name, and
+ * splitting on every `#` turned it into `prod`, or `"prod` when quoted, so
+ * srelens then probed a context that does not exist.
+ *
+ * Done with string scanning rather than a pattern: this is on the path that
+ * reads a pasted kubeconfig, and it is the ambiguity in the regex that used to
+ * live here which made that path a denial of service.
+ */
+function unquoteScalar(raw: string): string | null {
+  const quote = raw[0];
+  if (quote === '"' || quote === "'") {
+    const close = raw.indexOf(quote, 1);
+    // An unterminated quote is malformed; there is no scalar to read.
+    if (close === -1) return null;
+    return raw.slice(1, close) || null;
+  }
+  // Unquoted: a comment needs whitespace in front of the `#`.
+  let end = raw.length;
+  for (let i = 0; i < raw.length; i++) {
+    if (raw[i] === "#" && (i === 0 || raw[i - 1] === " " || raw[i - 1] === "\t")) {
+      end = i;
+      break;
+    }
+  }
+  return raw.slice(0, end).trim() || null;
 }
 
 /** Test-connect a pasted/uploaded kubeconfig by its `current-context`. */

--- a/packages/core/src/lib/assistantMarkdown.ts
+++ b/packages/core/src/lib/assistantMarkdown.ts
@@ -15,12 +15,30 @@ export type MdBlock =
   | { kind: "table"; headers: NoteSpan[][]; rows: NoteSpan[][][] }
   | { kind: "code"; text: string };
 
-const HEADING = /^(#{1,6})\s+(.*)$/;
-const BULLET = /^[-*]\s+(.*)$/;
-const ORDERED = /^\d+\.\s+(.*)$/;
+// `[^\S\n]` rather than `\s`, and `[^\n]` rather than `.`: the two overlapped on
+// every space, so a line the pattern ultimately rejects could be split many
+// ways. Harmless in practice for these three, since callers split on newlines
+// first and none reproduced under load — but the ambiguity is real, and the
+// tighter classes say what was meant anyway (js/polynomial-redos, #45-#47).
+const HEADING = /^(#{1,6})[^\S\n]+([^\n]*)$/;
+const BULLET = /^[-*][^\S\n]+([^\n]*)$/;
+const ORDERED = /^\d+\.[^\S\n]+([^\n]*)$/;
 // A GFM header/body separator row: only pipes, dashes, colons, spaces, with at
 // least one dash (e.g. `|---|:--:|`).
-const TABLE_SEP = /^\s*\|?[\s|:-]*-[\s|:-]*\|?\s*$/;
+/**
+ * Whether a row is a markdown table's separator (`|---|:--:|`).
+ *
+ * Was one pattern with four overlapping quantifiers around a single required
+ * dash, which let the engine split a run of spaces every possible way: 10.7
+ * seconds on a 40KB row, growing quadratically (js/polynomial-redos, #44).
+ * This input is the assistant's own output, so its shape is not ours to trust.
+ *
+ * A separator is exactly "only these characters, and at least one dash", which
+ * is two unambiguous checks.
+ */
+export function isTableSeparator(row: string): boolean {
+  return row.includes("-") && /^[\s|:-]*$/.test(row);
+}
 
 /** A line looks like a table row if it has an interior pipe (`a | b`), so a
  * lone trailing/leading `|` in prose isn't mistaken for one. */
@@ -71,7 +89,7 @@ export function parseAssistantMarkdown(md: string): MdBlock[] {
     // A real GFM table has a header row, a separator row, then body rows.
     // Anything else (a stray pipe-y line) degrades to a paragraph rather than
     // vanishing.
-    if (rows.length >= 2 && TABLE_SEP.test(rows[1])) {
+    if (rows.length >= 2 && isTableSeparator(rows[1])) {
       const headers = splitRow(rows[0]).map(parseSpans);
       const body = rows.slice(2).map((r) => splitRow(r).map(parseSpans));
       blocks.push({ kind: "table", headers, rows: body });

--- a/packages/core/src/lib/deepLink.ts
+++ b/packages/core/src/lib/deepLink.ts
@@ -41,9 +41,14 @@ function isCleanSegment(value: string): boolean {
  * single segment instead of splitting the route apart.
  */
 function segmentsOf(url: string): string[] | null {
-  const match = /^srelens:\/*(.*)$/i.exec(url.trim());
-  if (!match) return null;
-  const [path] = match[1].split(/[?#]/, 1);
+  // Two steps, not one pattern: `\/*` and `(.*)` both matched a slash, so a URL
+  // of nothing but slashes gave the engine a quadratic number of ways to split
+  // them — 2.5s at 40KB (js/polynomial-redos, #48). A deep link arrives from
+  // the OS, so its length is not ours to trust.
+  const trimmed = url.trim();
+  if (!/^srelens:/i.test(trimmed)) return null;
+  const afterScheme = trimmed.slice("srelens:".length).replace(/^\/+/, "");
+  const [path] = afterScheme.split(/[?#]/, 1);
   const raw = path.split("/").filter((segment) => segment.length > 0);
   try {
     return raw.map(decodeURIComponent);

--- a/packages/core/src/lib/errors.ts
+++ b/packages/core/src/lib/errors.ts
@@ -39,9 +39,14 @@ export function cleanErrorMessage(input: unknown): string {
  * doesn't match the standard shape.
  */
 export function describeForbidden(raw: string): string | null {
-  const m = raw.match(/cannot (\w+) resource "([^"]+)"(?:.*?in the namespace "([^"]+)"|.*?at the cluster scope)/s);
+  // Split from one pattern into two passes: the alternation of two lazy
+  // dot-alls made a message that never completes either branch quadratic
+  // (js/polynomial-redos, #49). API error text is not length-bounded.
+  const m = /cannot (\w+) resource "([^"]+)"/.exec(raw);
   if (!m) return null;
-  const [, verb, resource, namespace] = m;
+  const [, verb, resource] = m;
+  const rest = raw.slice(m.index + m[0].length);
+  const namespace = /in the namespace "([^"]+)"/.exec(rest)?.[1];
   const where = namespace ? `in ${namespace}` : "at the cluster scope";
   return `You don't have permission to ${verb} ${resource} ${where}.`;
 }

--- a/packages/core/src/lib/errors.ts
+++ b/packages/core/src/lib/errors.ts
@@ -46,9 +46,22 @@ export function describeForbidden(raw: string): string | null {
   if (!m) return null;
   const [, verb, resource] = m;
   const rest = raw.slice(m.index + m[0].length);
+
+  // Both markers are checked explicitly, and neither means null. The message
+  // has to SAY where it applies: a truncated or aggregated-API error carries
+  // the prefix without a scope, and defaulting such a message to "at the
+  // cluster scope" would state something the apiserver never said, while
+  // hiding the generic RBAC guidance describeError would otherwise give.
+  // Namespace is tried first, matching the order of the alternation this
+  // replaced, so a message carrying both reads as namespaced.
   const namespace = /in the namespace "([^"]+)"/.exec(rest)?.[1];
-  const where = namespace ? `in ${namespace}` : "at the cluster scope";
-  return `You don't have permission to ${verb} ${resource} ${where}.`;
+  if (namespace) {
+    return `You don't have permission to ${verb} ${resource} in ${namespace}.`;
+  }
+  if (rest.includes("at the cluster scope")) {
+    return `You don't have permission to ${verb} ${resource} at the cluster scope.`;
+  }
+  return null;
 }
 
 /**

--- a/packages/core/src/lib/redos.test.ts
+++ b/packages/core/src/lib/redos.test.ts
@@ -89,6 +89,9 @@ describe("the parsers still do their jobs", () => {
     expect(parseCurrentContext('current-context: "prod" # the live one')).toBe("prod");
     // Unterminated quote is malformed, not a name with a quote in it.
     expect(parseCurrentContext('current-context: "prod')).toBeNull();
+    // Escaped and doubled quotes belong to the name, not to the delimiter.
+    expect(parseCurrentContext('current-context: "prod\\"live"')).toBe('prod"live');
+    expect(parseCurrentContext("current-context: 'prod''live'")).toBe("prod'live");
   });
 
   it("returns null when there is no current-context to read", () => {

--- a/packages/core/src/lib/redos.test.ts
+++ b/packages/core/src/lib/redos.test.ts
@@ -73,6 +73,24 @@ describe("the parsers still do their jobs", () => {
     );
   });
 
+  it("keeps a hash that belongs to the name (#313 review)", () => {
+    // YAML starts a comment at `#` only when whitespace precedes it, and never
+    // inside quotes. Cutting at every `#` turned a valid name into a shorter
+    // one, or left a stray quote, and srelens then probed a context that does
+    // not exist.
+    expect(parseCurrentContext("current-context: prod#live")).toBe("prod#live");
+    expect(parseCurrentContext('current-context: "prod#live"')).toBe("prod#live");
+    expect(parseCurrentContext("current-context: 'prod#live'")).toBe("prod#live");
+    expect(parseCurrentContext("current-context: #only-a-comment")).toBeNull();
+    // Whitespace before the hash still ends the scalar.
+    expect(parseCurrentContext("current-context: prod # the live one")).toBe("prod");
+    expect(parseCurrentContext("current-context: prod\t# tabbed comment")).toBe("prod");
+    // A comment after a quoted scalar is still a comment.
+    expect(parseCurrentContext('current-context: "prod" # the live one')).toBe("prod");
+    // Unterminated quote is malformed, not a name with a quote in it.
+    expect(parseCurrentContext('current-context: "prod')).toBeNull();
+  });
+
   it("returns null when there is no current-context to read", () => {
     expect(parseCurrentContext("kind: Config")).toBeNull();
     expect(parseCurrentContext("current-context:")).toBeNull();

--- a/packages/core/src/lib/redos.test.ts
+++ b/packages/core/src/lib/redos.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { parseCurrentContext } from "./addCluster";
+import { parseDeepLink } from "./deepLink";
+import { describeForbidden } from "./errors";
+import { isTableSeparator } from "./assistantMarkdown";
+
+/**
+ * Regressions for nine `js/polynomial-redos` findings (#43-#51).
+ *
+ * Each of these parsers reads input the user does not control: a pasted
+ * kubeconfig, a deep link handed over by the OS, an error message from the API
+ * server, and the assistant's own markdown output. An ambiguous quantifier in
+ * any of them is a way to freeze the UI thread from outside the app.
+ *
+ * Measured before fixing, so these numbers are what was actually happening
+ * rather than what the rule name implies:
+ *
+ *   current-context   cubic      51s at a 4KB line
+ *   table separator   quadratic  10.7s at 40KB
+ *   deep link         quadratic  2.5s at 40KB
+ *   describeForbidden quadratic  78ms at 66KB
+ *
+ * The budget below is deliberately loose. It is not a benchmark — it is the
+ * difference between linear and catastrophic, and a loose bound keeps the test
+ * from flaking on a busy CI runner while still failing outright on a
+ * regression, which would take seconds or minutes rather than milliseconds.
+ */
+const BUDGET_MS = 250;
+
+function withinBudget(label: string, run: () => void): void {
+  const started = performance.now();
+  run();
+  const elapsed = performance.now() - started;
+  expect(elapsed, `${label} took ${elapsed.toFixed(0)}ms, budget ${BUDGET_MS}ms`).toBeLessThan(
+    BUDGET_MS,
+  );
+}
+
+describe("parsers stay linear on hostile input", () => {
+  it("reads current-context from a kubeconfig padded with spaces (#43)", () => {
+    // 51 seconds before the fix, at a quarter of this size.
+    const yaml = `current-context:${" ".repeat(16000)}#`;
+    withinBudget("current-context", () => parseCurrentContext(yaml));
+  });
+
+  it("parses a deep link buried in slashes (#48)", () => {
+    const url = `srelens:${"/".repeat(40000)}\n`;
+    withinBudget("deep link", () => parseDeepLink(url));
+  });
+
+  it("recognises a table separator padded with spaces (#44)", () => {
+    const row = `-${"  ".repeat(20000)}x`;
+    withinBudget("table separator", () => isTableSeparator(row));
+  });
+
+  it("describes a forbidden error that never completes its pattern (#49)", () => {
+    const raw = `cannot a resource "!"${'cannot a resource "!"a'.repeat(3000)}`;
+    withinBudget("describeForbidden", () => describeForbidden(raw));
+  });
+});
+
+describe("the parsers still do their jobs", () => {
+  it("reads a current-context, quoted or not, and ignores comments", () => {
+    expect(parseCurrentContext("current-context: prod")).toBe("prod");
+    expect(parseCurrentContext('current-context: "prod"')).toBe("prod");
+    expect(parseCurrentContext("current-context: 'prod'")).toBe("prod");
+    expect(parseCurrentContext("current-context:   prod   ")).toBe("prod");
+    expect(parseCurrentContext("current-context: prod # the live one")).toBe("prod");
+    expect(parseCurrentContext("apiVersion: v1\ncurrent-context: prod\nkind: Config")).toBe("prod");
+    // OpenShift-style names survive intact.
+    expect(parseCurrentContext("current-context: default/api-example-com:6443/user")).toBe(
+      "default/api-example-com:6443/user",
+    );
+  });
+
+  it("returns null when there is no current-context to read", () => {
+    expect(parseCurrentContext("kind: Config")).toBeNull();
+    expect(parseCurrentContext("current-context:")).toBeNull();
+    expect(parseCurrentContext("current-context:    ")).toBeNull();
+    expect(parseCurrentContext("current-context: # only a comment")).toBeNull();
+  });
+
+  it("still parses a deep link the same way", () => {
+    // The scheme and slashes are stripped in two steps now instead of one
+    // pattern; every accepted and rejected form must behave as before.
+    const target = { route: "cluster", context: "prod" };
+    expect(parseDeepLink("srelens://cluster/prod")).toEqual(target);
+    expect(parseDeepLink("srelens:cluster/prod")).toEqual(target);
+    expect(parseDeepLink("srelens:///cluster/prod")).toEqual(target);
+    expect(parseDeepLink("SRELENS://cluster/prod")).toEqual(target);
+    expect(parseDeepLink("  srelens://cluster/prod  ")).toEqual(target);
+    expect(parseDeepLink("srelens://cluster/prod?tab=logs")).toEqual(target);
+    expect(parseDeepLink("srelens://cluster/prod#top")).toEqual(target);
+    expect(parseDeepLink("https://example.com/cluster/prod")).toBeNull();
+    expect(parseDeepLink("srelens://")).toBeNull();
+  });
+
+  it("recognises table separators and rejects other rows", () => {
+    expect(isTableSeparator("|---|---|")).toBe(true);
+    expect(isTableSeparator(" --- ")).toBe(true);
+    expect(isTableSeparator("|:--|--:|:-:|")).toBe(true);
+    expect(isTableSeparator("| a | b |")).toBe(false);
+    // No dash at all is a row of pipes, not a separator.
+    expect(isTableSeparator("|   |   |")).toBe(false);
+    expect(isTableSeparator("")).toBe(false);
+  });
+});

--- a/packages/core/src/lib/redos.test.ts
+++ b/packages/core/src/lib/redos.test.ts
@@ -95,6 +95,28 @@ describe("the parsers still do their jobs", () => {
     expect(parseDeepLink("srelens://")).toBeNull();
   });
 
+  it("refuses to invent a scope the error never stated", () => {
+    // The pattern this replaced required one of the two scope markers, so a
+    // message with neither fell through to describeError's generic RBAC
+    // guidance. A truncated or aggregated-API error must not be reported as
+    // cluster-scoped just because it lacks a namespace. (#313 review)
+    expect(describeForbidden('cannot patch resource "deployments"')).toBeNull();
+    expect(describeForbidden('cannot patch resource "deployments" somewhere odd')).toBeNull();
+
+    expect(describeForbidden('cannot patch resource "nodes" at the cluster scope')).toBe(
+      "You don't have permission to patch nodes at the cluster scope.",
+    );
+    expect(
+      describeForbidden('cannot patch resource "deployments" in the namespace "prod"'),
+    ).toBe("You don't have permission to patch deployments in prod.");
+    // Both present: namespaced wins, as the old alternation ordered it.
+    expect(
+      describeForbidden(
+        'cannot patch resource "deployments" in the namespace "prod" at the cluster scope',
+      ),
+    ).toBe("You don't have permission to patch deployments in prod.");
+  });
+
   it("recognises table separators and rejects other rows", () => {
     expect(isTableSeparator("|---|---|")).toBe(true);
     expect(isTableSeparator(" --- ")).toBe(true);


### PR DESCRIPTION
Closes code-scanning alerts [#43](https://github.com/srelens/srelens/security/code-scanning/43)–[#51](https://github.com/srelens/srelens/security/code-scanning/51) (`js/polynomial-redos`, all high).

## What actually reproduces

I measured each pattern before changing it, rather than trusting the label. Four reproduce, and one is much worse than "polynomial" suggests:

| Pattern | Growth | Cost | Input comes from |
|---|---|---|---|
| `current-context` (#43) | **cubic** | **52s on a 4KB line** | a pasted or uploaded kubeconfig |
| table separator (#44) | quadratic | 2.6s at 40KB | the assistant's own markdown output |
| deep link (#48) | quadratic | 2.5s at 40KB | a link handed over by the OS |
| `describeForbidden` (#49) | quadratic | 78ms at 66KB | an API server error message |

**#43 is the one to care about.** It grows 8× per doubling, so 4KB takes 52 seconds and 8KB takes minutes, and the input is a kubeconfig someone pastes — a colleague's config with a long run of spaces after `current-context:` is enough to freeze the app. No malice required.

**#44 matters more than it looks** because its input is LLM output: an assistant reply containing a padded table row hangs the UI for seconds.

## The fixes remove the ambiguity, not the input

- **current-context** matches to the end of the line and trims in code. Pairing `\s*` around a lazy body with a trailing `\s*$` gave the engine several ways to split one run of spaces. The result is also plainly easier to read.
- **table separator** becomes two unambiguous checks — "only these characters" and "at least one dash" — instead of four overlapping quantifiers around a single required dash.
- **deep link** strips scheme and slashes in two steps, since `\/*` and `(.*)` both matched a slash.
- **describeForbidden** matches verb and resource first, then looks for the namespace in what follows, rather than alternating two lazy dot-alls that backtrack when neither branch completes.

Bounding input length would have been the cheaper fix; it also would have left the ambiguity in place for the next caller.

## The other five

Heading, bullet and ordered-list patterns (#45–#47, #50–#51) **did not reproduce at 8KB** — they stayed at 0.0ms, because their callers split on newlines before the pattern sees the text, and backtracking needs a `\n` mid-string.

They are still structurally ambiguous, so their `\s`/`.` overlap is tightened to `[^\S\n]`/`[^\n]`, which says what was meant anyway. But they were not live bugs and I am not claiming them as such.

## Verification

```
pnpm test          # 1276 passed, coverage 85.95 / 82.29 / 77.66
pnpm -r typecheck  # clean
cargo test -p srelens-registry   # 45 passed
```

New tests assert a time budget on the exact inputs measured above, and that every parser still accepts and rejects what it did before — quoted and unquoted contexts, trailing comments, OpenShift-style names, every deep-link form, and the table separators.

**52s → 0.31ms** on the same input.

## Worth knowing

These alerts appeared at 11:30 today, minutes after #311 merged, with **no equivalent alerts fixed or dismissed at the old `apps/desktop/src/lib` paths**. The code is unchanged by that move — CodeQL simply had not reported them before. I could not determine why, and it seemed better to fix them than to explain the timing.
