### PR TITLE
feat(design): switch between the classic and new designs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,11 @@ COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
 # package.json is not in the image.
 COPY apps/desktop/package.json apps/desktop/package.json
 COPY packages/core/package.json packages/core/package.json
+COPY packages/ui-next/package.json packages/ui-next/package.json
 RUN pnpm install --frozen-lockfile
 # Sources after install, so a source-only change does not re-run install.
 COPY packages/core packages/core
+COPY packages/ui-next packages/ui-next
 COPY apps/desktop apps/desktop
 RUN pnpm --filter @srelens/desktop build
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -23,6 +23,7 @@
     "@lezer/highlight": "^1.2.3",
     "@peculiar/x509": "^2.0.0",
     "@srelens/core": "workspace:*",
+    "@srelens/ui-next": "workspace:*",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@xterm/addon-fit": "^0.10.0",

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -8,6 +8,7 @@
   "permissions": [
     "core:default",
     "core:webview:allow-set-webview-zoom",
+    "core:window:allow-set-decorations",
     "process:default",
     "deep-link:default",
     "window-state:default"

--- a/apps/desktop/src/components/AppearanceSettingsSection.test.tsx
+++ b/apps/desktop/src/components/AppearanceSettingsSection.test.tsx
@@ -11,7 +11,7 @@ vi.mock("../design", async (importOriginal) => ({
 import { AppearanceSettingsSection } from "./AppearanceSettingsSection";
 
 beforeEach(() => {
-  switchDesignMock.mockClear();
+  switchDesignMock.mockReset().mockResolvedValue({ ok: true });
   localStorage.clear();
 });
 
@@ -50,5 +50,21 @@ describe("AppearanceSettingsSection", () => {
     render(<AppearanceSettingsSection />);
     await userEvent.click(screen.getByRole("button", { name: /classic design/i }));
     expect(switchDesignMock).not.toHaveBeenCalled();
+  });
+
+  it("re-enables the buttons and says why when a switch is refused", async () => {
+    // A successful switch reloads, so only a refusal returns here. Leaving
+    // busy set disabled both buttons for good, which read as broken rather
+    // than unavailable. (#314 review)
+    switchDesignMock.mockResolvedValue({ ok: false, reason: "storage refused it" });
+    render(<AppearanceSettingsSection />);
+    const next = screen.getByRole("button", { name: /new design/i });
+    await userEvent.click(next);
+
+    expect(screen.getByRole("alert").textContent).toContain("storage refused it");
+    expect(next.hasAttribute("disabled")).toBe(false);
+    // And it can be retried, rather than needing a manual reload.
+    await userEvent.click(next);
+    expect(switchDesignMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/desktop/src/components/AppearanceSettingsSection.test.tsx
+++ b/apps/desktop/src/components/AppearanceSettingsSection.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const { switchDesignMock } = vi.hoisted(() => ({ switchDesignMock: vi.fn() }));
+vi.mock("../design", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../design")>()),
+  switchDesign: switchDesignMock,
+}));
+
+import { AppearanceSettingsSection } from "./AppearanceSettingsSection";
+
+beforeEach(() => {
+  switchDesignMock.mockClear();
+  localStorage.clear();
+});
+
+describe("AppearanceSettingsSection", () => {
+  it("says the new design is unfinished, before anyone opts in", () => {
+    // Shipping a half-built UI behind a toggle is only defensible if the
+    // toggle says so. Someone who opts in and finds empty screens should have
+    // been told, not surprised.
+    render(<AppearanceSettingsSection />);
+    // Said in the description, not only in the button label — someone scanning
+    // the setting should learn it without reading the options.
+    expect(screen.getByText(/most screens are not there yet/i)).toBeDefined();
+  });
+
+  it("warns that switching reloads the window", () => {
+    render(<AppearanceSettingsSection />);
+    expect(screen.getByText(/reload/i)).toBeDefined();
+  });
+
+  it("switches to the new design when asked", async () => {
+    render(<AppearanceSettingsSection />);
+    await userEvent.click(screen.getByRole("button", { name: /new design/i }));
+    expect(switchDesignMock).toHaveBeenCalledWith("next");
+  });
+
+  it("marks the design in use, so the current state is visible", () => {
+    render(<AppearanceSettingsSection />);
+    // No jest-dom in this project, so read the attribute directly.
+    expect(
+      screen.getByRole("button", { name: /classic design/i }).getAttribute("aria-pressed"),
+    ).toBe("true");
+  });
+
+  it("does not reload when the chosen design is already active", async () => {
+    // Re-picking the current design should be inert, not a pointless reload.
+    render(<AppearanceSettingsSection />);
+    await userEvent.click(screen.getByRole("button", { name: /classic design/i }));
+    expect(switchDesignMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/components/AppearanceSettingsSection.tsx
+++ b/apps/desktop/src/components/AppearanceSettingsSection.tsx
@@ -18,12 +18,21 @@ export function AppearanceSettingsSection() {
   // the component is mounted.
   const [current] = useState<Design>(loadDesign);
   const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  function choose(design: Design) {
+  async function choose(design: Design) {
     // Re-picking the design already in use would reload for nothing.
     if (design === current || busy) return;
     setBusy(true);
-    void switchDesign(design);
+    setError(null);
+    const result = await switchDesign(design);
+    // A successful switch reloads, so only a refusal ever gets here. Clearing
+    // busy matters: without it both buttons stayed disabled for good, and the
+    // setting looked broken rather than unavailable. (#314 review)
+    if (!result.ok) {
+      setError(result.reason);
+      setBusy(false);
+    }
   }
 
   return (
@@ -34,10 +43,15 @@ export function AppearanceSettingsSection() {
         screens are not there yet, and the ones that are may still change. Switching reloads
         the window, and you can switch back here at any time.
       </p>
+      {error && (
+        <p className="fl-settings-hint" role="alert">
+          Could not switch design. {error}
+        </p>
+      )}
       <div role="group" aria-label="Design">
         <Button
           type="button"
-          onClick={() => choose("classic")}
+          onClick={() => void choose("classic")}
           aria-pressed={current === "classic"}
           disabled={busy}
         >
@@ -45,7 +59,7 @@ export function AppearanceSettingsSection() {
         </Button>
         <Button
           type="button"
-          onClick={() => choose("next")}
+          onClick={() => void choose("next")}
           aria-pressed={current === "next"}
           disabled={busy}
         >

--- a/apps/desktop/src/components/AppearanceSettingsSection.tsx
+++ b/apps/desktop/src/components/AppearanceSettingsSection.tsx
@@ -1,0 +1,57 @@
+import { useState } from "react";
+import { Button } from "../ui";
+import { loadDesign, switchDesign, type Design } from "../design";
+
+/**
+ * Settings → Appearance: the choice between the current design and the new one.
+ *
+ * Sits beside the theme controls rather than in a section of its own, because
+ * from the user's side it is the same kind of decision — how the app looks.
+ *
+ * The copy is deliberately blunt about the new design being unfinished.
+ * Shipping a half-built UI behind a toggle is only defensible if the toggle
+ * says so; someone who opts in and finds empty screens should have been told,
+ * not surprised.
+ */
+export function AppearanceSettingsSection() {
+  // Read once: switching reloads the window, so this cannot go stale while
+  // the component is mounted.
+  const [current] = useState<Design>(loadDesign);
+  const [busy, setBusy] = useState(false);
+
+  function choose(design: Design) {
+    // Re-picking the design already in use would reload for nothing.
+    if (design === current || busy) return;
+    setBusy(true);
+    void switchDesign(design);
+  }
+
+  return (
+    <div className="fl-settings-field">
+      <h3>Design</h3>
+      <p className="fl-settings-hint">
+        srelens is being rebuilt in a new design. It is <strong>in progress</strong>: most
+        screens are not there yet, and the ones that are may still change. Switching reloads
+        the window, and you can switch back here at any time.
+      </p>
+      <div role="group" aria-label="Design">
+        <Button
+          type="button"
+          onClick={() => choose("classic")}
+          aria-pressed={current === "classic"}
+          disabled={busy}
+        >
+          Classic design
+        </Button>
+        <Button
+          type="button"
+          onClick={() => choose("next")}
+          aria-pressed={current === "next"}
+          disabled={busy}
+        >
+          New design (in progress)
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/SettingsView.tsx
+++ b/apps/desktop/src/components/SettingsView.tsx
@@ -73,6 +73,7 @@ import { ContextAvatar, CONTEXT_LOGO_OPTIONS } from "./ContextAvatar";
 import { McpSettingsSection } from "./McpSettingsSection";
 import { AssistantSettingsSection } from "./AssistantSettingsSection";
 import { SecuritySettingsSection } from "./SecuritySettingsSection";
+import { AppearanceSettingsSection } from "./AppearanceSettingsSection";
 import { AppLogView } from "./AppLogView";
 import { pickKubeconfigFiles, savePastedKubeconfig } from "@srelens/core";
 import { checkForUpdate, installUpdate, type UpdateMeta } from "@srelens/core";
@@ -585,6 +586,7 @@ export function SettingsView({
                   </button>
                 ))}
               </div>
+              <AppearanceSettingsSection />
             </SectionPanel>
           )}
 

--- a/apps/desktop/src/coverage-config.test.ts
+++ b/apps/desktop/src/coverage-config.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest";
 // each package alone sits below floors calibrated for the combined codebase,
 // so the two are measured together. This canary follows it there.
 import config from "../../../vitest.config";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
 // Canary for issue #29: vitest 1.x silently ignored thresholds placed at the
@@ -39,20 +39,23 @@ describe("coverage threshold config", () => {
     expect(coverage?.functions).toBeUndefined();
   });
 
-  it("measures both packages, not just the app", () => {
-    // Measuring one package alone would report a floor that no longer covers
-    // most of the frontend.
-    const projects = (config as { test?: { projects?: string[] } }).test?.projects;
+  it("measures every workspace package, not a hardcoded pair", () => {
+    // Naming the packages here is how packages/ui-next came to be silently
+    // untested: it was added to the workspace, its suite passed locally under
+    // its own script, and the root run never loaded it while reporting green.
+    // Enumerating them from disk means the next package cannot repeat that.
+    const projects = (config as { test?: { projects?: string[] } }).test?.projects ?? [];
+    const dir = join(__dirname, "../../../packages");
+    const members = readdirSync(dir).filter((name) =>
+      existsSync(join(dir, name, "vitest.config.ts")),
+    );
+    expect(members.length).toBeGreaterThan(0);
+    for (const name of members) {
+      expect(projects, `packages/${name} is not in the root vitest projects`).toContain(
+        `packages/${name}`,
+      );
+    }
     expect(projects).toContain("apps/desktop");
-    expect(projects).toContain("packages/core");
   });
 
-  it("is actually invoked by CI", () => {
-    // `pnpm -r test` skips the workspace root, so CI running it would execute
-    // both packages' suites and enforce nothing — green, with the gate off.
-    // Caught in review on #311; asserted here so it cannot recur silently.
-    const ci = readFileSync(join(__dirname, "../../../.github/workflows/ci.yml"), "utf8");
-    expect(ci).toMatch(/^\s+run: pnpm test$/m);
-    expect(ci).not.toMatch(/^\s+run: pnpm -r test$/m);
-  });
 });

--- a/apps/desktop/src/design.switch.test.ts
+++ b/apps/desktop/src/design.switch.test.ts
@@ -1,10 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-const { isTauriMock, setDecorationsMock } = vi.hoisted(() => ({
+const { isTauriMock, setDecorationsMock, notifyErrorMock } = vi.hoisted(() => ({
   isTauriMock: vi.fn(),
   setDecorationsMock: vi.fn(),
+  notifyErrorMock: vi.fn(),
 }));
-vi.mock("@srelens/core/platform", () => ({ isTauri: isTauriMock, isWeb: () => false }));
+vi.mock("@srelens/core", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@srelens/core")>()),
+  isTauri: isTauriMock,
+  notify: { error: notifyErrorMock, success: vi.fn(), info: vi.fn() },
+}));
 vi.mock("@tauri-apps/api/window", () => ({
   getCurrentWindow: () => ({ setDecorations: setDecorationsMock }),
 }));
@@ -18,6 +23,7 @@ beforeEach(() => {
   localStorage.clear();
   reload.mockClear();
   setDecorationsMock.mockReset().mockResolvedValue(undefined);
+  notifyErrorMock.mockClear();
   isTauriMock.mockReturnValue(true);
   originalLocation = window.location;
   Object.defineProperty(window, "location", {
@@ -36,24 +42,30 @@ describe("switchDesign", () => {
     expect(reload).toHaveBeenCalledTimes(1);
   });
 
-  it("drops the window decorations for the new design and restores them for classic", async () => {
+  it("leaves the system chrome alone while the new design has none of its own", async () => {
+    // NextApp is a heading, a paragraph and a button. Dropping the decorations
+    // now would leave a frameless window with no drag region and no window
+    // controls — unmovable, unminimisable, closable only by quitting. This
+    // flips when the design's own titlebar lands. (#314 review)
     await switchDesign("next");
-    expect(setDecorationsMock).toHaveBeenCalledWith(false);
-    setDecorationsMock.mockClear();
-    await switchDesign("classic");
-    expect(setDecorationsMock).toHaveBeenCalledWith(true);
+    expect(setDecorationsMock).not.toHaveBeenCalled();
+    expect(reload).toHaveBeenCalledTimes(1);
   });
 
-  it("still reloads when setting the decorations fails", async () => {
-    // `core:window:allow-set-decorations` is not granted by default, so this
-    // call throws on a build whose capabilities have not been updated. The
-    // decorations are cosmetic; the switch is not, and a rejected promise here
-    // left the user staring at an unchanged window with the preference already
-    // written — the design would only appear on the next manual restart.
-    setDecorationsMock.mockRejectedValue(new Error("window.set_decorations not allowed"));
-    await switchDesign("next");
-    expect(localStorage.getItem(DESIGN_KEY)).toBe("next");
-    expect(reload).toHaveBeenCalledTimes(1);
+  it("does not reload when the choice could not be saved", async () => {
+    // Reloading would come back on the old design, since the next boot reads
+    // no preference — a switch that silently undoes itself. (#314 review)
+    const original = Storage.prototype.setItem;
+    Storage.prototype.setItem = () => {
+      throw new Error("denied");
+    };
+    try {
+      await switchDesign("next");
+      expect(reload).not.toHaveBeenCalled();
+      expect(notifyErrorMock).toHaveBeenCalled();
+    } finally {
+      Storage.prototype.setItem = original;
+    }
   });
 
   it("reloads on web, where there are no decorations to set", async () => {

--- a/apps/desktop/src/design.switch.test.ts
+++ b/apps/desktop/src/design.switch.test.ts
@@ -37,7 +37,7 @@ afterEach(() => {
 
 describe("switchDesign", () => {
   it("saves the choice and reloads", async () => {
-    await switchDesign("next");
+    expect((await switchDesign("next")).ok).toBe(true);
     expect(localStorage.getItem(DESIGN_KEY)).toBe("next");
     expect(reload).toHaveBeenCalledTimes(1);
   });
@@ -60,9 +60,12 @@ describe("switchDesign", () => {
       throw new Error("denied");
     };
     try {
-      await switchDesign("next");
+      const result = await switchDesign("next");
       expect(reload).not.toHaveBeenCalled();
-      expect(notifyErrorMock).toHaveBeenCalled();
+      // Reported back rather than toasted: the toast host lives in the classic
+      // tree, so a failure while leaving the new design would be invisible.
+      expect(result.ok).toBe(false);
+      expect(result.ok === false && result.reason).toBeTruthy();
     } finally {
       Storage.prototype.setItem = original;
     }

--- a/apps/desktop/src/design.switch.test.ts
+++ b/apps/desktop/src/design.switch.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { isTauriMock, setDecorationsMock } = vi.hoisted(() => ({
+  isTauriMock: vi.fn(),
+  setDecorationsMock: vi.fn(),
+}));
+vi.mock("@srelens/core/platform", () => ({ isTauri: isTauriMock, isWeb: () => false }));
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({ setDecorations: setDecorationsMock }),
+}));
+
+import { DESIGN_KEY, switchDesign } from "./design";
+
+const reload = vi.fn();
+let originalLocation: Location;
+
+beforeEach(() => {
+  localStorage.clear();
+  reload.mockClear();
+  setDecorationsMock.mockReset().mockResolvedValue(undefined);
+  isTauriMock.mockReturnValue(true);
+  originalLocation = window.location;
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { ...originalLocation, reload },
+  });
+});
+afterEach(() => {
+  Object.defineProperty(window, "location", { configurable: true, value: originalLocation });
+});
+
+describe("switchDesign", () => {
+  it("saves the choice and reloads", async () => {
+    await switchDesign("next");
+    expect(localStorage.getItem(DESIGN_KEY)).toBe("next");
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops the window decorations for the new design and restores them for classic", async () => {
+    await switchDesign("next");
+    expect(setDecorationsMock).toHaveBeenCalledWith(false);
+    setDecorationsMock.mockClear();
+    await switchDesign("classic");
+    expect(setDecorationsMock).toHaveBeenCalledWith(true);
+  });
+
+  it("still reloads when setting the decorations fails", async () => {
+    // `core:window:allow-set-decorations` is not granted by default, so this
+    // call throws on a build whose capabilities have not been updated. The
+    // decorations are cosmetic; the switch is not, and a rejected promise here
+    // left the user staring at an unchanged window with the preference already
+    // written — the design would only appear on the next manual restart.
+    setDecorationsMock.mockRejectedValue(new Error("window.set_decorations not allowed"));
+    await switchDesign("next");
+    expect(localStorage.getItem(DESIGN_KEY)).toBe("next");
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("reloads on web, where there are no decorations to set", async () => {
+    isTauriMock.mockReturnValue(false);
+    await switchDesign("next");
+    expect(setDecorationsMock).not.toHaveBeenCalled();
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/design.test.ts
+++ b/apps/desktop/src/design.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { DESIGN_KEY, loadDesign, saveDesign } from "./design";
+
+beforeEach(() => localStorage.clear());
+
+describe("the design preference", () => {
+  it("defaults to classic, so an untouched install is unchanged", () => {
+    expect(loadDesign()).toBe("classic");
+  });
+
+  it("round-trips a choice", () => {
+    saveDesign("next");
+    expect(loadDesign()).toBe("next");
+    saveDesign("classic");
+    expect(loadDesign()).toBe("classic");
+  });
+
+  it("falls back to classic on a value it does not recognise", () => {
+    // Written by a future version, or by hand. Never leave someone on a design
+    // that does not exist — they would get a blank window with no way back.
+    localStorage.setItem(DESIGN_KEY, "hologram");
+    expect(loadDesign()).toBe("classic");
+  });
+
+  it("survives storage being unavailable", () => {
+    // Storage throws in some privacy modes. A preference is not worth failing
+    // to boot over.
+    const original = Storage.prototype.getItem;
+    Storage.prototype.getItem = () => {
+      throw new Error("denied");
+    };
+    try {
+      expect(loadDesign()).toBe("classic");
+    } finally {
+      Storage.prototype.getItem = original;
+    }
+  });
+
+  it("does not throw when the choice cannot be saved", () => {
+    const original = Storage.prototype.setItem;
+    Storage.prototype.setItem = () => {
+      throw new Error("quota");
+    };
+    try {
+      expect(() => saveDesign("next")).not.toThrow();
+    } finally {
+      Storage.prototype.setItem = original;
+    }
+  });
+});

--- a/apps/desktop/src/design.theme.test.ts
+++ b/apps/desktop/src/design.theme.test.ts
@@ -49,4 +49,44 @@ describe("applyNextDesignTheme", () => {
     applyNextDesignTheme();
     expect(document.documentElement.dataset.theme).not.toBe("slate");
   });
+
+  it("follows the OS while the app is open, for a system preference", () => {
+    // The classic tree has a matchMedia effect for this; without an equivalent
+    // the new tree sat on a stale palette until a reload. (#314 review)
+    const listeners: Array<() => void> = [];
+    const removed: Array<() => void> = [];
+    vi.stubGlobal("matchMedia", () => ({
+      matches: false,
+      addEventListener: (_: string, fn: () => void) => listeners.push(fn),
+      removeEventListener: (_: string, fn: () => void) => removed.push(fn),
+    }));
+    getInitialThemeMock.mockReturnValue({ name: "slate", mode: "system" });
+    resolvedThemeModeMock.mockReturnValue("light");
+
+    const stop = applyNextDesignTheme();
+    expect(document.documentElement.dataset.theme).toBeUndefined();
+    expect(listeners).toHaveLength(1);
+
+    // The OS goes dark; the attribute must follow without a reload.
+    resolvedThemeModeMock.mockReturnValue("dark");
+    listeners[0]();
+    expect(document.documentElement.dataset.theme).toBe("dark");
+
+    stop();
+    expect(removed).toHaveLength(1);
+    vi.unstubAllGlobals();
+  });
+
+  it("does not subscribe when the mode is fixed", () => {
+    const listeners: Array<() => void> = [];
+    vi.stubGlobal("matchMedia", () => ({
+      matches: false,
+      addEventListener: (_: string, fn: () => void) => listeners.push(fn),
+      removeEventListener: () => {},
+    }));
+    getInitialThemeMock.mockReturnValue({ name: "slate", mode: "dark" });
+    applyNextDesignTheme();
+    expect(listeners).toHaveLength(0);
+    vi.unstubAllGlobals();
+  });
 });

--- a/apps/desktop/src/design.theme.test.ts
+++ b/apps/desktop/src/design.theme.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { getInitialThemeMock, resolvedThemeModeMock } = vi.hoisted(() => ({
+  getInitialThemeMock: vi.fn(),
+  resolvedThemeModeMock: vi.fn(),
+}));
+vi.mock("./ui/theme", () => ({
+  getInitialTheme: getInitialThemeMock,
+  resolvedThemeMode: resolvedThemeModeMock,
+}));
+
+import { applyNextDesignTheme } from "./design";
+
+beforeEach(() => {
+  delete document.documentElement.dataset.theme;
+  getInitialThemeMock.mockReturnValue({ name: "slate", mode: "dark" });
+  resolvedThemeModeMock.mockImplementation((mode: string) => mode);
+});
+
+describe("applyNextDesignTheme", () => {
+  it("carries a dark preference into the new design's convention", () => {
+    // The classic default IS dark, so getting this wrong sends most users to a
+    // bright UI on every launch. The two designs disagree about data-theme:
+    // classic puts the palette name there, ui-next reads it as the mode.
+    applyNextDesignTheme();
+    expect(document.documentElement.dataset.theme).toBe("dark");
+  });
+
+  it("uses the absence of the attribute for light, matching :root", () => {
+    getInitialThemeMock.mockReturnValue({ name: "slate", mode: "light" });
+    document.documentElement.dataset.theme = "dark";
+    applyNextDesignTheme();
+    expect(document.documentElement.dataset.theme).toBeUndefined();
+  });
+
+  it("resolves a system preference rather than passing it through", () => {
+    // "system" is not one of ui-next's selectors; leaving it would match none
+    // of them and silently fall back to light.
+    getInitialThemeMock.mockReturnValue({ name: "slate", mode: "system" });
+    resolvedThemeModeMock.mockReturnValue("dark");
+    applyNextDesignTheme();
+    expect(resolvedThemeModeMock).toHaveBeenCalledWith("system");
+    expect(document.documentElement.dataset.theme).toBe("dark");
+  });
+
+  it("never leaves the classic palette name where ui-next reads a mode", () => {
+    // `data-theme="slate"` matches none of ui-next's blocks.
+    getInitialThemeMock.mockReturnValue({ name: "slate", mode: "dark" });
+    applyNextDesignTheme();
+    expect(document.documentElement.dataset.theme).not.toBe("slate");
+  });
+});

--- a/apps/desktop/src/design.ts
+++ b/apps/desktop/src/design.ts
@@ -1,4 +1,7 @@
 import { isTauri, notify } from "@srelens/core";
+// theme.ts imports only settingsStorage, so this does not drag the classic
+// stylesheet into the new design's chunk.
+import { getInitialTheme, resolvedThemeMode } from "./ui/theme";
 
 /**
  * Which design the app renders.
@@ -88,4 +91,25 @@ export async function switchDesign(design: Design): Promise<void> {
     }
   }
   window.location.reload();
+}
+
+/**
+ * Carry the user's light/dark choice into the new design.
+ *
+ * The two designs disagree about what `data-theme` means: the classic one puts
+ * the palette name there (`slate`) and the mode in `data-theme-mode`, while
+ * ui-next's stylesheet reads `data-theme="dark"` as the mode itself. Nothing
+ * translates between them, and a reload starts from a bare document — so
+ * without this the new design always rendered light, including for the many
+ * users on the classic default, which is dark. (#314 review)
+ *
+ * Light is the absence of the attribute, matching ui-next's `:root` tokens.
+ */
+export function applyNextDesignTheme(): void {
+  const root = document.documentElement;
+  if (resolvedThemeMode(getInitialTheme().mode) === "dark") {
+    root.dataset.theme = "dark";
+  } else {
+    delete root.dataset.theme;
+  }
 }

--- a/apps/desktop/src/design.ts
+++ b/apps/desktop/src/design.ts
@@ -1,4 +1,4 @@
-import { isTauri } from "@srelens/core/platform";
+import { isTauri, notify } from "@srelens/core";
 
 /**
  * Which design the app renders.
@@ -29,11 +29,15 @@ export function loadDesign(): Design {
   }
 }
 
-export function saveDesign(design: Design): void {
+/** Persist the choice. Returns false if storage refused it. */
+export function saveDesign(design: Design): boolean {
   try {
     localStorage.setItem(DESIGN_KEY, design);
+    return true;
   } catch {
-    // Nothing useful to do. The switch below still applies for this session.
+    // Restricted or private storage. The caller must not reload on this: the
+    // next boot would read no preference and come back on the old design.
+    return false;
   }
 }
 
@@ -46,12 +50,33 @@ export function saveDesign(design: Design): void {
  * something the platform offers. A reload on a deliberate, rare action is a
  * fair price for removing a whole class of style-bleed bug.
  */
+/**
+ * Whether the new design draws its own titlebar yet.
+ *
+ * It does not: `NextApp` is a heading, a paragraph and a button. Dropping the
+ * system decorations now would leave a frameless window with no drag region and
+ * no window controls — unmovable, unminimisable, and closable only by quitting
+ * the app. The design's own titlebar lands with its shell; this flips then, and
+ * needs an answer for Windows and Linux at the same time, since the mock's
+ * traffic lights are macOS-shaped.
+ */
+const NEXT_DESIGN_DRAWS_ITS_OWN_CHROME = false;
+
 export async function switchDesign(design: Design): Promise<void> {
-  saveDesign(design);
-  if (isTauri()) {
+  if (!saveDesign(design)) {
+    // The choice could not be persisted, so a reload would come back on the
+    // old design — and on desktop it could do so with the chrome already
+    // changed. Better to leave everything alone and say nothing changed than
+    // to reload into a window that contradicts the setting.
+    notify.error(
+      "Could not switch design",
+      "This device would not let srelens save the preference.",
+    );
+    return;
+  }
+  if (isTauri() && NEXT_DESIGN_DRAWS_ITS_OWN_CHROME) {
     try {
-      // The new design draws its own titlebar; the classic one uses the
-      // system's. Cosmetic, and explicitly not allowed to block the switch:
+      // Cosmetic, and explicitly not allowed to block the switch:
       // `core:window:allow-set-decorations` has to be granted in the app's
       // capabilities, and on a build where it is not, this throws. Letting
       // that reject left the preference written and the window unchanged, so

--- a/apps/desktop/src/design.ts
+++ b/apps/desktop/src/design.ts
@@ -1,4 +1,4 @@
-import { isTauri, notify } from "@srelens/core";
+import { isTauri } from "@srelens/core";
 // theme.ts imports only settingsStorage, so this does not drag the classic
 // stylesheet into the new design's chunk.
 import { getInitialTheme, resolvedThemeMode } from "./ui/theme";
@@ -53,6 +53,9 @@ export function saveDesign(design: Design): boolean {
  * something the platform offers. A reload on a deliberate, rare action is a
  * fair price for removing a whole class of style-bleed bug.
  */
+/** Whether a design switch went through, and why not when it did not. */
+export type SwitchResult = { ok: true } | { ok: false; reason: string };
+
 /**
  * Whether the new design draws its own titlebar yet.
  *
@@ -65,17 +68,16 @@ export function saveDesign(design: Design): boolean {
  */
 const NEXT_DESIGN_DRAWS_ITS_OWN_CHROME = false;
 
-export async function switchDesign(design: Design): Promise<void> {
+export async function switchDesign(design: Design): Promise<SwitchResult> {
   if (!saveDesign(design)) {
     // The choice could not be persisted, so a reload would come back on the
     // old design — and on desktop it could do so with the chrome already
-    // changed. Better to leave everything alone and say nothing changed than
-    // to reload into a window that contradicts the setting.
-    notify.error(
-      "Could not switch design",
-      "This device would not let srelens save the preference.",
-    );
-    return;
+    // changed. Leave everything alone and report it.
+    //
+    // Reported to the caller rather than raised as a toast: the toast host
+    // lives in the classic tree, so a failure while leaving the new design
+    // would have been invisible, and the button would have looked inert.
+    return { ok: false, reason: "This device would not let srelens save the preference." };
   }
   if (isTauri() && NEXT_DESIGN_DRAWS_ITS_OWN_CHROME) {
     try {
@@ -91,6 +93,7 @@ export async function switchDesign(design: Design): Promise<void> {
     }
   }
   window.location.reload();
+  return { ok: true };
 }
 
 /**
@@ -105,11 +108,22 @@ export async function switchDesign(design: Design): Promise<void> {
  *
  * Light is the absence of the attribute, matching ui-next's `:root` tokens.
  */
-export function applyNextDesignTheme(): void {
-  const root = document.documentElement;
-  if (resolvedThemeMode(getInitialTheme().mode) === "dark") {
-    root.dataset.theme = "dark";
-  } else {
-    delete root.dataset.theme;
-  }
+export function applyNextDesignTheme(): () => void {
+  const apply = () => {
+    const root = document.documentElement;
+    if (resolvedThemeMode(getInitialTheme().mode) === "dark") {
+      root.dataset.theme = "dark";
+    } else {
+      delete root.dataset.theme;
+    }
+  };
+  apply();
+
+  // Someone on "system" changes appearance while the app is open, and the new
+  // tree has no equivalent of the classic App's matchMedia effect, so it would
+  // sit on a stale palette until the next reload. (#314 review)
+  if (getInitialTheme().mode !== "system") return () => {};
+  const query = window.matchMedia("(prefers-color-scheme: dark)");
+  query.addEventListener("change", apply);
+  return () => query.removeEventListener("change", apply);
 }

--- a/apps/desktop/src/design.ts
+++ b/apps/desktop/src/design.ts
@@ -49,9 +49,18 @@ export function saveDesign(design: Design): void {
 export async function switchDesign(design: Design): Promise<void> {
   saveDesign(design);
   if (isTauri()) {
-    // The new design draws its own titlebar; the classic one uses the system's.
-    const { getCurrentWindow } = await import("@tauri-apps/api/window");
-    await getCurrentWindow().setDecorations(design === "classic");
+    try {
+      // The new design draws its own titlebar; the classic one uses the
+      // system's. Cosmetic, and explicitly not allowed to block the switch:
+      // `core:window:allow-set-decorations` has to be granted in the app's
+      // capabilities, and on a build where it is not, this throws. Letting
+      // that reject left the preference written and the window unchanged, so
+      // the design only appeared after a manual restart.
+      const { getCurrentWindow } = await import("@tauri-apps/api/window");
+      await getCurrentWindow().setDecorations(design === "classic");
+    } catch {
+      // Wrong chrome is a blemish; not switching at all is a broken setting.
+    }
   }
   window.location.reload();
 }

--- a/apps/desktop/src/design.ts
+++ b/apps/desktop/src/design.ts
@@ -1,0 +1,57 @@
+import { isTauri } from "@srelens/core/platform";
+
+/**
+ * Which design the app renders.
+ *
+ * Read synchronously before React mounts, so it lives in localStorage rather
+ * than the settings store, which is async. It describes the person using the
+ * app, not the cluster they are looking at, so it is not scoped to a context
+ * or a workspace.
+ *
+ * This module deliberately sits outside `main.tsx`: importing the entry module
+ * from a component or a test would run its side effects — installing the
+ * notifier and starting the app.
+ */
+export const DESIGN_KEY = "srelens.design";
+
+export type Design = "classic" | "next";
+
+export function loadDesign(): Design {
+  try {
+    // Anything unrecognised means classic. A preference written by a future
+    // version must never leave someone on a design that does not exist, since
+    // a blank window has no way back to Settings.
+    return localStorage.getItem(DESIGN_KEY) === "next" ? "next" : "classic";
+  } catch {
+    // Storage throws in some privacy modes; a preference is not worth failing
+    // to boot over.
+    return "classic";
+  }
+}
+
+export function saveDesign(design: Design): void {
+  try {
+    localStorage.setItem(DESIGN_KEY, design);
+  } catch {
+    // Nothing useful to do. The switch below still applies for this session.
+  }
+}
+
+/**
+ * Apply a design choice.
+ *
+ * Reloads rather than swapping trees in place: the two designs' stylesheets
+ * cannot share a document — both import Tailwind, use different dark-mode
+ * conventions and write global rules — and unloading one at runtime is not
+ * something the platform offers. A reload on a deliberate, rare action is a
+ * fair price for removing a whole class of style-bleed bug.
+ */
+export async function switchDesign(design: Design): Promise<void> {
+  saveDesign(design);
+  if (isTauri()) {
+    // The new design draws its own titlebar; the classic one uses the system's.
+    const { getCurrentWindow } = await import("@tauri-apps/api/window");
+    await getCurrentWindow().setDecorations(design === "classic");
+  }
+  window.location.reload();
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -1,13 +1,12 @@
-import "./styles/globals.css"; // Tailwind + shadcn tokens — must load first.
 import React from "react";
 import { createRoot } from "react-dom/client";
-import AppGate from "./AppGate";
 import { applyPersistedTimeout } from "@srelens/core";
 import { isTauri } from "@srelens/core/platform";
 import { initializeSettingsStorage } from "@srelens/core";
 // The service layer says what to notify; this decides how. Installed before
 // render so a toast raised during startup is not dropped on the floor.
 import { installToastNotifier } from "./ui/notifier";
+import { loadDesign, switchDesign } from "./design";
 
 installToastNotifier();
 
@@ -24,6 +23,19 @@ if (!container) throw new Error("Root element #root not found");
 async function bootstrap(root: HTMLElement): Promise<void> {
   await initializeSettingsStorage();
   if (isTauri()) void applyPersistedTimeout();
+  // Both the stylesheet AND the tree are imported dynamically. Only the
+  // stylesheet is not enough: ui/index.ts imports ui/styles.css, so a
+  // statically imported AppGate drags that into the entry chunk, which
+  // index.html then links unconditionally — and the classic design's CSS would
+  // load underneath the new one. Verified against a real build.
+  if (loadDesign() === "next") {
+    await import("@srelens/ui-next/styles");
+    const { NextApp } = await import("@srelens/ui-next");
+    createRoot(root).render(<NextApp onExit={() => void switchDesign("classic")} />);
+    return;
+  }
+  await import("./styles/globals.css");
+  const { default: AppGate } = await import("./AppGate");
   createRoot(root).render(<AppGate />);
 }
 

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -6,7 +6,7 @@ import { initializeSettingsStorage } from "@srelens/core";
 // The service layer says what to notify; this decides how. Installed before
 // render so a toast raised during startup is not dropped on the floor.
 import { installToastNotifier } from "./ui/notifier";
-import { loadDesign, switchDesign } from "./design";
+import { applyNextDesignTheme, loadDesign, switchDesign } from "./design";
 
 installToastNotifier();
 
@@ -29,6 +29,8 @@ async function bootstrap(root: HTMLElement): Promise<void> {
   // index.html then links unconditionally — and the classic design's CSS would
   // load underneath the new one. Verified against a real build.
   if (loadDesign() === "next") {
+    // Before the stylesheet, so the first paint is already the right mode.
+    applyNextDesignTheme();
     await import("@srelens/ui-next/styles");
     const { NextApp } = await import("@srelens/ui-next");
     createRoot(root).render(<NextApp onExit={() => void switchDesign("classic")} />);

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -31,8 +31,14 @@ async function bootstrap(root: HTMLElement): Promise<void> {
   if (loadDesign() === "next") {
     // Before the stylesheet, so the first paint is already the right mode.
     applyNextDesignTheme();
-    await import("@srelens/ui-next/styles");
-    const { NextApp } = await import("@srelens/ui-next");
+    // Started together, awaited together: the stylesheet and the tree are
+    // independent downloads, and awaiting one before requesting the other
+    // serialised them. index.html links no stylesheet, so the window stays
+    // blank until both land — that wait is the whole startup screen.
+    const [, { NextApp }] = await Promise.all([
+      import("@srelens/ui-next/styles"),
+      import("@srelens/ui-next"),
+    ]);
     createRoot(root).render(
       <NextApp
         onExit={async () => {
@@ -43,8 +49,10 @@ async function bootstrap(root: HTMLElement): Promise<void> {
     );
     return;
   }
-  await import("./styles/globals.css");
-  const { default: AppGate } = await import("./AppGate");
+  const [, { default: AppGate }] = await Promise.all([
+    import("./styles/globals.css"),
+    import("./AppGate"),
+  ]);
   createRoot(root).render(<AppGate />);
 }
 

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -33,7 +33,14 @@ async function bootstrap(root: HTMLElement): Promise<void> {
     applyNextDesignTheme();
     await import("@srelens/ui-next/styles");
     const { NextApp } = await import("@srelens/ui-next");
-    createRoot(root).render(<NextApp onExit={() => void switchDesign("classic")} />);
+    createRoot(root).render(
+      <NextApp
+        onExit={async () => {
+          const result = await switchDesign("classic");
+          return result.ok ? null : result.reason;
+        }}
+      />,
+    );
     return;
   }
   await import("./styles/globals.css");

--- a/apps/desktop/src/one-stylesheet.test.ts
+++ b/apps/desktop/src/one-stylesheet.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment node
+// (reads the entry module's source from disk; jsdom buys nothing here)
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * The two designs cannot share a document: both import Tailwind, use different
+ * dark-mode conventions (`.dark` versus `[data-theme=dark]`), and each writes
+ * global `body` and `*` rules.
+ *
+ * The isolation rests on one property — neither design's stylesheet nor its
+ * root is imported statically from the entry — so Vite keeps each in its own
+ * chunk and `index.html` links no stylesheet at all.
+ *
+ * A static import would be a one-word change with no symptom in `pnpm dev`,
+ * because dev-mode Vite injects styles differently, and a visibly broken new
+ * design in the built app. So it is asserted on the source, where it is cheap.
+ *
+ * Established by building the real app: a statically imported AppGate pulls
+ * ui/index.ts's `ui/styles.css` into the entry chunk, and that chunk is linked
+ * unconditionally.
+ */
+const main = readFileSync(join(__dirname, "main.tsx"), "utf8");
+
+describe("the app entry", () => {
+  it("imports no stylesheet statically", () => {
+    const statics = [...main.matchAll(/^import\s+["']([^"']+\.css)["']/gm)].map((m) => m[1]);
+    expect(statics, `static stylesheet imports in main.tsx: ${statics.join(", ")}`).toEqual([]);
+  });
+
+  it("imports neither design's root statically", () => {
+    // AppGate drags the classic stylesheet in with it; NextApp drags the new
+    // one. Either as a top-level import defeats the split.
+    expect(main).not.toMatch(/^import\s+AppGate\b/m);
+    expect(main).not.toMatch(/^import\s+\{[^}]*\bNextApp\b[^}]*\}/m);
+  });
+
+  it("loads both designs dynamically, and only one per boot", () => {
+    expect(main).toMatch(/await import\(["']@srelens\/ui-next\/styles["']\)/);
+    expect(main).toMatch(/await import\(["']@srelens\/ui-next["']\)/);
+    expect(main).toMatch(/await import\(["']\.\/styles\/globals\.css["']\)/);
+    expect(main).toMatch(/await import\(["']\.\/AppGate["']\)/);
+    // The next-design branch must return, or the classic tree would render on
+    // top of it and pull its stylesheet into the same document.
+    const branch = main.slice(main.indexOf('loadDesign() === "next"'));
+    expect(branch.slice(0, branch.indexOf("await import(\"./styles/globals.css\")"))).toMatch(
+      /\breturn;/,
+    );
+  });
+});

--- a/apps/desktop/src/one-stylesheet.test.ts
+++ b/apps/desktop/src/one-stylesheet.test.ts
@@ -37,15 +37,24 @@ describe("the app entry", () => {
   });
 
   it("loads both designs dynamically, and only one per boot", () => {
-    expect(main).toMatch(/await import\(["']@srelens\/ui-next\/styles["']\)/);
-    expect(main).toMatch(/await import\(["']@srelens\/ui-next["']\)/);
-    expect(main).toMatch(/await import\(["']\.\/styles\/globals\.css["']\)/);
-    expect(main).toMatch(/await import\(["']\.\/AppGate["']\)/);
+    // Written as `import(...)` inside Promise.all rather than `await import`,
+    // so each design's stylesheet and tree download together instead of one
+    // after the other.
+    expect(main).toMatch(/import\(["']@srelens\/ui-next\/styles["']\)/);
+    expect(main).toMatch(/import\(["']@srelens\/ui-next["']\)/);
+    expect(main).toMatch(/import\(["']\.\/styles\/globals\.css["']\)/);
+    expect(main).toMatch(/import\(["']\.\/AppGate["']\)/);
     // The next-design branch must return, or the classic tree would render on
     // top of it and pull its stylesheet into the same document.
     const branch = main.slice(main.indexOf('loadDesign() === "next"'));
-    expect(branch.slice(0, branch.indexOf("await import(\"./styles/globals.css\")"))).toMatch(
-      /\breturn;/,
-    );
+    expect(branch.slice(0, branch.indexOf('import("./styles/globals.css")'))).toMatch(/\breturn;/);
+  });
+
+  it("does not serialise a design's stylesheet behind its tree", () => {
+    // Both are needed before the first paint and neither depends on the other,
+    // so awaiting one before requesting the second only lengthens the blank
+    // window. (#314 review)
+    const serial = /await import\([^)]*\);\s*(?:const[^;]*=\s*)?await import\(/.test(main);
+    expect(serial, "main.tsx awaits one import before starting the next").toBe(false);
   });
 });

--- a/apps/desktop/src/ui-next-styles.d.ts
+++ b/apps/desktop/src/ui-next-styles.d.ts
@@ -1,0 +1,7 @@
+/**
+ * `@srelens/ui-next/styles` resolves to a CSS file behind a package export.
+ * `vite/client` types bare `*.css` specifiers, but not a subpath export that
+ * happens to point at one, so TypeScript needs telling it is importable for
+ * its side effect alone.
+ */
+declare module "@srelens/ui-next/styles";

--- a/packages/ui-next/package.json
+++ b/packages/ui-next/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@srelens/ui-next",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.tsx",
+    "./styles": "./src/styles/app.css"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@srelens/core": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/node": "^26.1.1",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "jsdom": "^24.0.0",
+    "react": "19.2.7",
+    "react-dom": "19.2.7",
+    "tailwindcss": "^4.3.1",
+    "typescript": "^5.4.0",
+    "vite": "^6.4.3",
+    "vitest": "^3.2.7"
+  }
+}

--- a/packages/ui-next/src/index.test.tsx
+++ b/packages/ui-next/src/index.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextApp } from "./index";
+
+describe("NextApp", () => {
+  it("says what it is, so nobody thinks the app is broken", () => {
+    // The whole new design is one placeholder at this point. Someone who opts
+    // in has to be told that, not left guessing.
+    render(<NextApp onExit={() => {}} />);
+    expect(screen.getByRole("heading", { name: /new design/i })).toBeDefined();
+    expect(screen.getByText(/not.*(built|there)/i)).toBeDefined();
+  });
+
+  it("offers a way back without going through Settings", () => {
+    // Settings does not exist here yet, so this button is the only exit.
+    render(<NextApp onExit={() => {}} />);
+    expect(screen.getByRole("button", { name: /classic design/i })).toBeDefined();
+  });
+
+  it("calls back when asked to leave", async () => {
+    const onExit = vi.fn();
+    render(<NextApp onExit={onExit} />);
+    await userEvent.click(screen.getByRole("button", { name: /classic design/i }));
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui-next/src/index.test.tsx
+++ b/packages/ui-next/src/index.test.tsx
@@ -7,21 +7,32 @@ describe("NextApp", () => {
   it("says what it is, so nobody thinks the app is broken", () => {
     // The whole new design is one placeholder at this point. Someone who opts
     // in has to be told that, not left guessing.
-    render(<NextApp onExit={() => {}} />);
+    render(<NextApp onExit={() => null} />);
     expect(screen.getByRole("heading", { name: /new design/i })).toBeDefined();
     expect(screen.getByText(/not.*(built|there)/i)).toBeDefined();
   });
 
   it("offers a way back without going through Settings", () => {
     // Settings does not exist here yet, so this button is the only exit.
-    render(<NextApp onExit={() => {}} />);
+    render(<NextApp onExit={() => null} />);
     expect(screen.getByRole("button", { name: /classic design/i })).toBeDefined();
   });
 
   it("calls back when asked to leave", async () => {
-    const onExit = vi.fn();
+    const onExit = vi.fn().mockReturnValue(null);
     render(<NextApp onExit={onExit} />);
     await userEvent.click(screen.getByRole("button", { name: /classic design/i }));
     expect(onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows why it could not leave, since there is no toast host here", () => {
+    // The Toaster lives in the classic tree, so a failure on the way out would
+    // be invisible and the button would look inert. (#314 review)
+    render(<NextApp onExit={() => "storage refused the preference"} />);
+    return userEvent
+      .click(screen.getByRole("button", { name: /classic design/i }))
+      .then(() => {
+        expect(screen.getByRole("alert").textContent).toContain("storage refused");
+      });
   });
 });

--- a/packages/ui-next/src/index.tsx
+++ b/packages/ui-next/src/index.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 /**
  * The new design's root.
  *
@@ -9,7 +11,16 @@
  * not exist here yet, so without this button someone who opts in would have no
  * route out of the app except editing localStorage.
  */
-export function NextApp({ onExit }: { onExit: () => void }) {
+export function NextApp({ onExit }: { onExit: () => Promise<string | null> | string | null }) {
+  const [error, setError] = useState<string | null>(null);
+
+  async function leave() {
+    // Rendered here rather than raised as a toast: the toast host lives in the
+    // classic tree, so a failure on the way out would have been invisible and
+    // this button would have looked inert. (#314 review)
+    setError((await onExit()) ?? null);
+  }
+
   return (
     <main className="next-placeholder">
       <h1>The new design</h1>
@@ -17,9 +28,10 @@ export function NextApp({ onExit }: { onExit: () => void }) {
         Nothing is built here yet. You are seeing this because the new design is
         switched on in Settings — the screens are still being written.
       </p>
-      <button type="button" onClick={onExit}>
+      <button type="button" onClick={() => void leave()}>
         Back to the classic design
       </button>
+      {error && <p role="alert">Could not switch design. {error}</p>}
     </main>
   );
 }

--- a/packages/ui-next/src/index.tsx
+++ b/packages/ui-next/src/index.tsx
@@ -1,0 +1,25 @@
+/**
+ * The new design's root.
+ *
+ * A placeholder for now. This package exists so the design switch has a real
+ * second tree to load, with its own stylesheet — which is what proves the two
+ * designs never share a document. The shell and screens arrive in later steps.
+ *
+ * It carries its own way back to the classic design on purpose: Settings does
+ * not exist here yet, so without this button someone who opts in would have no
+ * route out of the app except editing localStorage.
+ */
+export function NextApp({ onExit }: { onExit: () => void }) {
+  return (
+    <main className="next-placeholder">
+      <h1>The new design</h1>
+      <p>
+        Nothing is built here yet. You are seeing this because the new design is
+        switched on in Settings — the screens are still being written.
+      </p>
+      <button type="button" onClick={onExit}>
+        Back to the classic design
+      </button>
+    </main>
+  );
+}

--- a/packages/ui-next/src/styles/app.css
+++ b/packages/ui-next/src/styles/app.css
@@ -1051,3 +1051,48 @@
     }
   }
 }
+
+/* ---------------------------------------------------------------
+   The placeholder shown while the new design has no screens yet.
+   Uses the design's own tokens, so it doubles as a visible check
+   that this stylesheet — and only this one — reached the document.
+   --------------------------------------------------------------- */
+.next-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 14px;
+  height: 100%;
+  max-width: 46rem;
+  margin: 0 auto;
+  padding: 0 32px;
+}
+
+.next-placeholder h1 {
+  font-size: 28px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+}
+
+.next-placeholder p {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--ink-muted);
+}
+
+.next-placeholder button {
+  padding: 7px 14px;
+  border: 1px solid var(--rule-strong);
+  border-radius: 7px;
+  background: var(--surface);
+  color: var(--ink);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.next-placeholder button:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}

--- a/packages/ui-next/src/styles/app.css
+++ b/packages/ui-next/src/styles/app.css
@@ -1,0 +1,1053 @@
+@import "./tokens.css";
+
+@layer base {
+  * { border-color: var(--rule); }
+
+  html, body, #root { height: 100%; }
+
+  html { font-size: 16px; }
+
+  body {
+    background: var(--canvas);
+    color: var(--ink);
+    font-family: var(--font-sans);
+    -webkit-font-smoothing: antialiased;
+    overflow: hidden;
+  }
+
+  ::selection { background: var(--accent-line); color: var(--ink); }
+
+  a:focus-visible,
+  button:focus-visible,
+  input:focus-visible,
+  select:focus-visible,
+  textarea:focus-visible,
+  [role="tab"]:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+    border-radius: 3px;
+  }
+  div:focus,
+  div:focus-visible,
+  section:focus,
+  section:focus-visible { outline: none; }
+
+  ::-webkit-scrollbar { width: 10px; height: 10px; }
+  ::-webkit-scrollbar-thumb {
+    background: var(--rule-strong);
+    border: 3px solid transparent;
+    background-clip: content-box;
+    border-radius: 99px;
+  }
+  ::-webkit-scrollbar-track { background: transparent; }
+}
+
+@layer components {
+  /* --- surfaces ------------------------------------------------ */
+  .card {
+    background: var(--surface);
+    border: 1px solid var(--rule);
+    border-radius: var(--radius-card);
+    box-shadow: var(--shadow-lift);
+  }
+  .card-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.5rem 0.75rem;
+    border-bottom: 1px solid var(--rule);
+  }
+  .card-title {
+    font-size: 0.8125rem;
+    font-weight: 600;
+  }
+
+  /* --- the label voice ----------------------------------------- */
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: 0.625rem;
+    font-weight: 500;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--ink-muted);
+  }
+  /* list data: identifiers, counts, versions — UI face, tabular figures */
+  .path {
+    font-size: 0.75rem;
+    color: var(--ink-muted);
+    font-variant-numeric: tabular-nums;
+    font-feature-settings: "tnum";
+  }
+  /* labels: breadcrumbs and section markers — the tracked uppercase voice */
+  .crumb {
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-muted);
+  }
+  .num {
+    font-variant-numeric: tabular-nums;
+    font-feature-settings: "tnum";
+  }
+  .code {
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* --- the drill rail (signature) ------------------------------ */
+  .rail { display: grid; grid-auto-flow: column; grid-auto-columns: 1fr; }
+  .rail-step {
+    position: relative;
+    display: flex;
+    align-items: baseline;
+    gap: 0.55rem;
+    padding: 0.6rem 0.9rem;
+    border-right: 1px solid var(--rule);
+    border-bottom: 2px solid transparent;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--ink-muted);
+    text-align: left;
+    transition: background 120ms ease, color 120ms ease;
+  }
+  .rail-step:last-child { border-right: 0; }
+  .rail-step:hover { background: var(--surface-sunk); color: var(--ink-soft); }
+  .rail-step[data-active="true"] {
+    background: var(--accent-wash);
+    border-bottom-color: var(--accent);
+    color: var(--ink);
+    font-weight: 600;
+  }
+  .rail-step .idx {
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    color: var(--ink-faint);
+  }
+  .rail-step[data-active="true"] .idx { color: var(--accent); }
+
+  /* --- stat pairs ---------------------------------------------- */
+  .stat { padding: 0.6rem 0.85rem; }
+  .stat + .stat { border-left: 1px solid var(--rule); }
+  .stat-value {
+    margin-top: 0.15rem;
+    font-size: 1.125rem;
+    font-weight: 600;
+    letter-spacing: -0.015em;
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* --- controls ------------------------------------------------- */
+  .ghost {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    width: 100%;
+    padding: 0.55rem 0.75rem;
+    border: 1px solid var(--rule);
+    border-radius: var(--radius-tile);
+    background: var(--surface);
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--ink);
+    transition: border-color 120ms ease, background 120ms ease;
+  }
+  .ghost:hover { border-color: var(--accent-line); background: var(--accent-wash); }
+  .ghost .arrow { color: var(--accent); transition: transform 160ms cubic-bezier(.2,.7,.3,1); }
+  .ghost:hover .arrow { transform: translateX(3px); }
+
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.28rem 0.55rem;
+    border-radius: 6px;
+    border: 1px solid var(--rule);
+    background: var(--surface);
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--ink-soft);
+    transition: border-color 120ms ease, color 120ms ease, background 120ms ease;
+  }
+  .btn:hover { border-color: var(--rule-strong); color: var(--ink); }
+  .btn-accent {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: var(--accent-ink);
+  }
+  .btn-accent:hover { background: var(--accent); border-color: var(--accent); filter: brightness(1.08); }
+  .btn-danger { color: var(--sev); border-color: color-mix(in srgb, var(--sev) 32%, transparent); }
+  .btn-danger:hover { background: var(--sev-wash); border-color: var(--sev); color: var(--sev); }
+
+  /* --- badges --------------------------------------------------- */
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.2rem 0.5rem;
+    border: 1px solid;
+    border-radius: 6px;
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    font-weight: 500;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  /* --- tables --------------------------------------------------- */
+  .tbl { width: 100%; border-collapse: collapse; }
+  .tbl thead th {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    padding: 0.35rem 0.7rem;
+    background: var(--surface);
+    border-bottom: 1px solid var(--rule);
+    font-size: 0.625rem;
+    font-weight: 600;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+    text-align: left;
+    white-space: nowrap;
+  }
+  .tbl tbody tr { border-bottom: 1px solid color-mix(in srgb, var(--rule) 55%, transparent); }
+  .tbl tbody tr:last-child { border-bottom: 0; }
+  .tbl tbody tr:hover { background: var(--surface-sunk); }
+  .tbl tbody tr:hover .row-ask { opacity: 1; }
+  .tbl tbody tr[data-selected="true"] { background: var(--accent-wash); }
+  .tbl td {
+    padding: var(--pad-y) 0.7rem;
+    height: var(--row-h);
+    font-size: 0.8125rem;
+    vertical-align: middle;
+    white-space: nowrap;
+  }
+  .th-sort {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    color: inherit;
+    font: inherit;
+    letter-spacing: inherit;
+    text-transform: inherit;
+  }
+  .th-sort:hover { color: var(--ink); }
+  .th-caret { opacity: 0; }
+  .th-sort[data-on="true"] .th-caret { opacity: 1; color: var(--accent); }
+
+  /* segmented control — the native way to offer a small exclusive choice */
+  .seg {
+    display: inline-flex;
+    padding: 2px;
+    border: 1px solid var(--rule);
+    border-radius: 7px;
+    background: var(--surface-sunk);
+  }
+  .seg-btn {
+    padding: 0.15rem 0.5rem;
+    border-radius: 5px;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--ink-muted);
+    white-space: nowrap;
+  }
+  .seg-btn:hover { color: var(--ink); }
+  .seg-btn[data-on="true"] {
+    background: var(--surface);
+    color: var(--ink);
+    box-shadow: 0 1px 2px rgba(20, 18, 25, 0.08);
+  }
+  [data-theme="dark"] .seg-btn[data-on="true"] { box-shadow: none; background: var(--surface-raised); }
+
+  /* status: a dot and a word. Colour is reserved for what is wrong. */
+  .status {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.75rem;
+    color: var(--ink-muted);
+  }
+  .status .dot { width: 6px; height: 6px; border-radius: 99px; flex-shrink: 0; }
+  .status[data-bad="true"] { font-weight: 500; }
+
+  .row-ask {
+    opacity: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.15rem 0.45rem;
+    border: 1px solid var(--accent-line);
+    border-radius: 6px;
+    background: var(--accent-wash);
+    color: var(--accent);
+    font-family: var(--font-mono);
+    font-size: 0.625rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    transition: opacity 120ms ease;
+  }
+  .row-ask:hover { filter: brightness(0.97); }
+
+  /* --- nav ------------------------------------------------------ */
+  .nav-item {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    width: 100%;
+    padding: 0.26rem 0.5rem;
+    border-radius: 6px;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: var(--ink-muted);
+    text-align: left;
+    transition: background 110ms ease, color 110ms ease;
+  }
+  .nav-item:hover { background: var(--field); color: var(--ink); }
+  .nav-item[data-active="true"] {
+    background: var(--accent-wash);
+    color: var(--accent);
+    font-weight: 600;
+  }
+
+
+
+
+
+  /* --- manifest editor --------------------------------------------- */
+  .editor { position: relative; overflow: hidden; }
+  .editor-layer,
+  .editor-input {
+    margin: 0;
+    padding: 6px 0;
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    line-height: 1.7;
+    tab-size: 2;
+    white-space: pre;
+    overflow: auto;
+  }
+  .editor-layer {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    color: var(--ink);
+  }
+  .editor-input {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    resize: none;
+    border: 0;
+    outline: none;
+    background: transparent;
+    color: transparent;
+    caret-color: var(--accent);
+    padding-left: 46px;
+  }
+  .editor-input::selection { background: var(--accent-line); }
+  .editor-line { display: flex; align-items: baseline; }
+  .editor-line[data-current="true"] { background: var(--field); }
+  .editor-gutter {
+    position: sticky;
+    left: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 3px;
+    width: 46px;
+    flex-shrink: 0;
+    padding-right: 8px;
+    background: var(--surface);
+    user-select: none;
+  }
+  .editor-num {
+    font-size: 0.625rem;
+    color: var(--ink-faint);
+    font-variant-numeric: tabular-nums;
+  }
+  .editor-code { flex: 1; }
+
+  /* --- popovers, tooltips, skeletons ------------------------------- */
+  .popover {
+    position: fixed;
+    z-index: 45;
+    min-width: 240px;
+    border: 1px solid var(--rule-strong);
+    border-radius: 8px;
+    background: var(--surface-raised);
+    box-shadow: 0 10px 34px rgba(20, 18, 25, 0.16), 0 1px 2px rgba(20, 18, 25, 0.08);
+    overflow: hidden;
+  }
+  [data-theme="dark"] .popover,
+  [data-theme="midnight"] .popover { box-shadow: 0 12px 40px rgba(0, 0, 0, 0.6); }
+
+  .tip { position: relative; display: inline-flex; }
+  .tip::after {
+    content: attr(data-tip);
+    position: absolute;
+    bottom: calc(100% + 5px);
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 0.2rem 0.4rem;
+    border-radius: 5px;
+    background: var(--ink);
+    color: var(--surface);
+    font-size: 0.6875rem;
+    white-space: nowrap;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 100ms ease;
+    z-index: 50;
+  }
+  .tip:hover::after, .tip:focus-within::after { opacity: 1; }
+
+  .skeleton {
+    display: inline-block;
+    border-radius: 4px;
+    background: linear-gradient(90deg, var(--field) 25%, var(--rule) 37%, var(--field) 63%);
+    background-size: 400% 100%;
+    animation: shimmer 1.3s ease infinite;
+  }
+  @keyframes shimmer { from { background-position: 100% 0; } to { background-position: 0 0; } }
+
+  .ns-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.8125rem;
+    color: var(--ink-soft);
+    text-align: left;
+  }
+  .ns-row:hover { background: var(--field); }
+  .ns-row[data-on="true"] { color: var(--ink); font-weight: 500; }
+  .ns-only {
+    opacity: 0;
+    font-size: 0.625rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--accent);
+  }
+  .ns-row:hover .ns-only { opacity: 1; }
+
+  /* --- panes ------------------------------------------------------
+     Desktop layout is flush regions divided by hairlines, each scrolling
+     on its own. No gutters, no floating cards, no page scroll. */
+  .panes { display: flex; min-height: 0; flex: 1; background: var(--surface); }
+  .pane {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    min-height: 0;
+    flex: 1;
+  }
+  .pane + .pane { border-left: 1px solid var(--rule); }
+  .pane-head {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    height: var(--pane-head-h);
+    flex-shrink: 0;
+    padding: 0 0.6rem;
+    background: var(--surface-sunk);
+    border-bottom: 1px solid var(--rule);
+    font-size: 0.625rem;
+    font-weight: 600;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+  }
+  .pane-body { flex: 1; min-height: 0; overflow: auto; }
+
+  .section + .section { border-top: 1px solid var(--rule); }
+  .section-head {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    height: 25px;
+    padding: 0 0.6rem;
+    background: var(--surface-sunk);
+    border-bottom: 1px solid var(--rule);
+    font-size: 0.625rem;
+    font-weight: 600;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+  }
+  .section-body { padding: 0.6rem; }
+
+  /* key/value rows: fixed label column, values left-aligned beside it */
+  .kv {
+    display: grid;
+    grid-template-columns: minmax(88px, 34%) 1fr;
+    align-items: baseline;
+    gap: 0 0.75rem;
+    padding: 0.22rem 0;
+  }
+  .kv-k {
+    font-size: 0.75rem;
+    color: var(--ink-muted);
+    white-space: nowrap;
+  }
+  .kv-v {
+    font-size: 0.75rem;
+    color: var(--ink);
+    min-width: 0;
+    overflow-wrap: anywhere;
+    font-variant-numeric: tabular-nums;
+  }
+  .kv-v.code { font-size: 0.6875rem; }
+
+  /* a quiet field label — sentence case, no tracking */
+  .field-label {
+    display: block;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--ink-muted);
+  }
+
+  /* labels and annotations read as key=value, the way kubectl prints them */
+  .pairs {
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    line-height: 1.75;
+  }
+  .pairs .k { color: var(--ink-muted); }
+  .pairs .v { color: var(--ink); }
+
+  /* --- resource tree ---------------------------------------------- */
+  .tree-group {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    width: 100%;
+    padding-top: 0.28rem;
+    padding-bottom: 0.28rem;
+    padding-right: 0.5rem;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    color: var(--ink-soft);
+    text-align: left;
+  }
+  .tree-group:hover { background: var(--field); }
+  .tree-caret { transition: transform 120ms ease; color: var(--ink-faint); }
+  .tree-caret[data-open="true"] { transform: rotate(90deg); }
+
+  .tree-row {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    width: 100%;
+    padding-top: var(--pad-y);
+    padding-bottom: var(--pad-y);
+    padding-right: 0.5rem;
+    font-size: 0.75rem;
+    color: var(--ink-muted);
+    text-align: left;
+  }
+  .tree-row:hover { background: var(--field); color: var(--ink); }
+  .tree-row[data-active="true"] {
+    background: var(--accent-wash);
+    color: var(--accent);
+    font-weight: 500;
+    box-shadow: inset 2px 0 0 var(--accent);
+  }
+  .focus-back {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    width: 100%;
+    padding: 0.3rem 0.6rem;
+    background: var(--accent-wash);
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--accent);
+    text-align: left;
+  }
+  .focus-back:hover { filter: brightness(0.97); }
+
+  .drill-in {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 15px;
+    height: 15px;
+    flex-shrink: 0;
+    border-radius: 4px;
+    color: var(--ink-faint);
+    opacity: 0;
+  }
+  .tree-cluster:hover .drill-in { opacity: 1; }
+  .drill-in:hover { background: var(--accent-wash); color: var(--accent); }
+
+  .tree-cluster {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    width: 100%;
+    padding-top: 0.2rem;
+    padding-bottom: 0.2rem;
+    padding-right: 0.5rem;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: var(--ink-soft);
+    text-align: left;
+  }
+  .tree-cluster:hover { background: var(--field); }
+  .caret-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 15px;
+    height: 15px;
+    flex-shrink: 0;
+    border-radius: 3px;
+    color: var(--ink-faint);
+  }
+  .caret-btn:hover { background: var(--rule); color: var(--ink); }
+  .tree-cluster[data-active="true"] {
+    background: var(--accent-wash);
+    color: var(--ink);
+    font-weight: 600;
+    box-shadow: inset 2px 0 0 var(--accent);
+  }
+  .tree-cluster[data-off="true"] { opacity: 0.5; }
+  .tree-cluster[data-off="true"]:hover { opacity: 0.85; }
+
+  .tree-count {
+    font-size: 0.6875rem;
+    font-variant-numeric: tabular-nums;
+    color: var(--ink-faint);
+  }
+
+  /* label=value pairs, as a key/value pill */
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    max-width: 100%;
+    padding: 0.1rem 0.4rem;
+    border: 1px solid var(--rule);
+    border-radius: 5px;
+    background: var(--surface-sunk);
+    font-size: 0.6875rem;
+    color: var(--ink-soft);
+    white-space: nowrap;
+    overflow: hidden;
+  }
+  .chip > span { overflow: hidden; text-overflow: ellipsis; }
+
+  .conn-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 99px;
+    flex-shrink: 0;
+    display: inline-block;
+  }
+  .conn-dot[data-kind="team"] { background: var(--accent); }
+  .conn-dot[data-kind="file"] { background: var(--info); }
+  .conn-dot[data-kind="local"] { background: var(--ink-faint); }
+
+  /* --- topology ---------------------------------------------------- */
+  .lane {
+    font-family: var(--font-mono);
+    font-size: 9px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    fill: var(--ink-faint);
+  }
+  .node-kind {
+    font-family: var(--font-mono);
+    font-size: 8px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    fill: var(--ink-faint);
+  }
+  .node-label {
+    font-size: 11.5px;
+    font-weight: 600;
+    fill: var(--ink);
+  }
+  .node-metric {
+    font-family: var(--font-mono);
+    font-size: 8.5px;
+    text-anchor: end;
+    font-variant-numeric: tabular-nums;
+  }
+  .edge-label {
+    font-family: var(--font-mono);
+    font-size: 8.5px;
+    text-anchor: middle;
+  }
+  .flow {
+    stroke-dasharray: 5 4;
+    animation: flow 900ms linear infinite;
+  }
+  @keyframes flow { to { stroke-dashoffset: -18; } }
+
+  /* --- window chrome --------------------------------------------- */
+  .titlebar {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    height: 32px;
+    flex-shrink: 0;
+    background: var(--canvas-deep);
+    border-bottom: 1px solid var(--rule);
+    -webkit-app-region: drag;
+  }
+  .titlebar .light {
+    width: 11px;
+    height: 11px;
+    border-radius: 99px;
+    box-shadow: inset 0 0 0 0.5px rgba(0, 0, 0, 0.12);
+  }
+  .icon-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 22px;
+    border-radius: 5px;
+    color: var(--ink-muted);
+    -webkit-app-region: no-drag;
+  }
+  .icon-btn:hover { background: var(--field); color: var(--ink); }
+
+  .tabstrip {
+    display: flex;
+    align-items: stretch;
+    height: 33px;
+    flex-shrink: 0;
+    background: var(--canvas-deep);
+    border-bottom: 1px solid var(--rule);
+  }
+  .tab {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    min-width: 108px;
+    max-width: 220px;
+    padding: 0 0.5rem 0 0.65rem;
+    border-right: 1px solid var(--rule);
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--ink-muted);
+    cursor: default;
+    user-select: none;
+  }
+  .tab:hover { background: var(--field); }
+  .tab[data-active="true"] {
+    background: var(--surface);
+    color: var(--ink);
+    margin-bottom: -1px;
+    padding-bottom: 1px;
+  }
+  .tab[data-active="true"]::before {
+    content: "";
+    position: absolute;
+    inset: 0 auto auto 0;
+    width: 100%;
+    height: 2px;
+    background: var(--accent);
+  }
+  .tab[data-preview="true"] { font-style: italic; }
+  .tab-sub {
+    font-family: var(--font-mono);
+    font-size: 0.5625rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+  }
+  .tab-close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    border-radius: 4px;
+    color: var(--ink-faint);
+    opacity: 0;
+    flex-shrink: 0;
+  }
+  .tab:hover .tab-close,
+  .tab[data-active="true"] .tab-close { opacity: 1; }
+  .tab-close:hover { background: var(--rule-strong); color: var(--ink); }
+  .tab-pin {
+    width: 5px;
+    height: 5px;
+    border-radius: 99px;
+    background: var(--ink-faint);
+    flex-shrink: 0;
+    margin-right: 5px;
+  }
+  .ws-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    height: 20px;
+    padding: 0 0.4rem;
+    border: 1px solid transparent;
+    border-radius: 5px;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    color: var(--ink-soft);
+    white-space: nowrap;
+    -webkit-app-region: no-drag;
+  }
+  .ws-chip:hover, .ws-chip[data-open="true"] {
+    background: var(--surface);
+    border-color: var(--rule);
+    color: var(--ink);
+  }
+
+  .tab[data-pinned="true"] { min-width: 0; }
+
+  .tab-new {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 30px;
+    flex-shrink: 0;
+    color: var(--ink-muted);
+    border-left: 1px solid var(--rule);
+  }
+  .tab-new:hover { background: var(--field); color: var(--ink); }
+
+  .toolbar {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    height: 34px;
+    flex-shrink: 0;
+    padding: 0 0.6rem;
+    background: var(--surface);
+    border-bottom: 1px solid var(--rule);
+  }
+  .toolbar-title {
+    font-size: 0.8125rem;
+    font-weight: 600;
+  }
+
+  .statusbar {
+    display: flex;
+    align-items: center;
+    gap: 0.15rem;
+    height: 22px;
+    flex-shrink: 0;
+    padding: 0 0.4rem;
+    background: var(--canvas-deep);
+    border-top: 1px solid var(--rule);
+  }
+  .status-seg {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    height: 16px;
+    padding: 0 0.4rem;
+    border-radius: 4px;
+    font-family: var(--font-mono);
+    font-size: 0.5625rem;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--ink-muted);
+    white-space: nowrap;
+  }
+  button.status-seg:hover { background: var(--field); color: var(--ink); }
+
+  .resize-handle {
+    position: absolute;
+    top: 0;
+    right: -2px;
+    width: 5px;
+    height: 100%;
+    cursor: col-resize;
+    z-index: 5;
+    border-right: 1px solid var(--rule);
+  }
+  .resize-handle:hover { border-right-color: var(--accent); }
+
+  /* --- context menu ----------------------------------------------- */
+  .ctx-menu {
+    position: fixed;
+    z-index: 60;
+    min-width: 216px;
+    padding: 4px;
+    border: 1px solid var(--rule-strong);
+    border-radius: 8px;
+    background: var(--surface-raised);
+    box-shadow: 0 10px 34px rgba(20, 18, 25, 0.16), 0 1px 2px rgba(20, 18, 25, 0.08);
+  }
+  [data-theme="dark"] .ctx-menu { box-shadow: 0 12px 40px rgba(0, 0, 0, 0.6); }
+  .ctx-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0.3rem 0.5rem;
+    border-radius: 5px;
+    font-size: 0.8125rem;
+    color: var(--ink-soft);
+  }
+  .ctx-item:hover { background: var(--accent); color: var(--accent-ink); }
+  .ctx-item:hover .ctx-hint { color: var(--accent-ink); opacity: 0.7; }
+  .ctx-item[data-danger="true"] { color: var(--sev); }
+  .ctx-item[data-danger="true"]:hover { background: var(--sev); color: #fff; }
+  .ctx-hint {
+    font-family: var(--font-mono);
+    font-size: 0.625rem;
+    color: var(--ink-faint);
+  }
+  .ctx-sep { height: 1px; margin: 4px 2px; background: var(--rule); }
+
+  /* --- docked console --------------------------------------------- */
+  .console-dock {
+    flex-shrink: 0;
+    background: var(--surface);
+    border-top: 1px solid var(--rule);
+  }
+
+  /* --- console (signature) -------------------------------------- */
+  .console-shell {
+    background: var(--surface);
+    border: 1px solid var(--rule-strong);
+    border-radius: 12px;
+    box-shadow: 0 8px 30px rgba(20, 18, 25, 0.09), 0 1px 2px rgba(20, 18, 25, 0.05);
+  }
+  [data-theme="dark"] .console-shell {
+    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.55);
+  }
+  .console-input {
+    flex: 1;
+    background: transparent;
+    border: 0;
+    outline: 0;
+    font-size: 0.9375rem;
+    color: var(--ink);
+  }
+  .console-input::placeholder { color: var(--ink-faint); }
+
+  .kbd {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.25rem;
+    height: 1.25rem;
+    padding: 0 0.3rem;
+    border: 1px solid var(--rule);
+    border-bottom-width: 2px;
+    border-radius: 5px;
+    background: var(--surface-sunk);
+    font-family: var(--font-mono);
+    font-size: 0.625rem;
+    color: var(--ink-muted);
+  }
+
+  /* --- agent ---------------------------------------------------- */
+  .tool-call {
+    border: 1px solid var(--rule);
+    border-left: 2px solid var(--accent-line);
+    border-radius: 8px;
+    background: var(--surface-sunk);
+    padding: 0.55rem 0.75rem;
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+  }
+  .agent-mark {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 6px;
+    background: var(--accent);
+    color: var(--accent-ink);
+    flex-shrink: 0;
+  }
+
+  .logline:hover { background: var(--field); }
+  .logline:hover .row-ask { opacity: 1; }
+
+  .scroll { overflow: auto; scrollbar-gutter: stable; }
+}
+
+@layer utilities {
+  .rule-t { border-top: 1px solid var(--rule); }
+  .rule-b { border-bottom: 1px solid var(--rule); }
+  .rule-l { border-left: 1px solid var(--rule); }
+  .rule-r { border-right: 1px solid var(--rule); }
+
+  @keyframes pulse-dot {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: 0.45; transform: scale(0.86); }
+  }
+  .live-dot { animation: pulse-dot 2.2s ease-in-out infinite; }
+
+  @keyframes shakex {
+    10%, 90% { transform: translateX(-1px); }
+    20%, 80% { transform: translateX(2px); }
+    30%, 50%, 70% { transform: translateX(-4px); }
+    40%, 60% { transform: translateX(4px); }
+  }
+  .shake { animation: shakex 420ms cubic-bezier(.36,.07,.19,.97) both; }
+
+  .ring-pulse {
+    position: absolute;
+    inset: 0;
+    border-radius: 999px;
+    border: 2px solid;
+    animation: ringout 1.1s ease-out infinite;
+  }
+  @keyframes ringout {
+    from { transform: scale(0.7); opacity: 0.8; }
+    to { transform: scale(1.35); opacity: 0; }
+  }
+
+  @keyframes rise {
+    from { opacity: 0; transform: translateY(6px); }
+    to { opacity: 1; transform: none; }
+  }
+  .rise { animation: rise 260ms cubic-bezier(.2,.7,.3,1) both; }
+
+  @keyframes sweep {
+    from { stroke-dashoffset: 260; }
+    to { stroke-dashoffset: 0; }
+  }
+
+  [data-motion="reduced"] *,
+  [data-motion="reduced"] *::before,
+  [data-motion="reduced"] *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
+
+  [data-focus="always"] :is(a, button, input, select, textarea):focus {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+  }
+
+  [data-underline="on"] a { text-decoration: underline; }
+
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+      animation-duration: 0.001ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.001ms !important;
+    }
+  }
+}

--- a/packages/ui-next/src/styles/tokens.css
+++ b/packages/ui-next/src/styles/tokens.css
@@ -1,0 +1,205 @@
+@import "tailwindcss";
+
+@custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
+
+/* ---------------------------------------------------------------
+   srelens design tokens — "instrument paper"
+   Light: lavender paper, white instruments, one violet accent.
+   Dark:  ink-violet control room, same rules, same rhythm.
+   --------------------------------------------------------------- */
+:root {
+  --canvas: #f5f4f8;
+  --canvas-deep: #eceaf2;
+  --surface: #ffffff;
+  --surface-sunk: #fafaFc;
+  --surface-raised: #ffffff;
+
+  --ink: #141219;
+  --ink-soft: #443f52;
+  --ink-muted: #6b6678;
+  --ink-faint: #9b97a6;
+
+  --rule: #e7e5ed;
+  --rule-strong: #d7d4e0;
+
+  --accent: #4b3bd6;
+  --accent-ink: #ffffff;
+  --accent-wash: #efedfd;
+  --accent-line: #c9c2f7;
+
+  --sev: #b4342a;
+  --sev-wash: #fdefee;
+  --warn: #a2670f;
+  --warn-wash: #fdf4e6;
+  --ok: #1f7a52;
+  --ok-wash: #e9f6ef;
+  --info: #2a5fa8;
+  --info-wash: #ecf2fb;
+
+  --field: rgba(20, 18, 25, 0.05);
+  --shadow-lift: 0 1px 0 rgba(20, 18, 25, 0.02);
+}
+
+[data-theme="dark"] {
+  --canvas: #0d0c12;
+  --canvas-deep: #08080c;
+  --surface: #16151d;
+  --surface-sunk: #121118;
+  --surface-raised: #1c1b24;
+
+  --ink: #f3f1f8;
+  --ink-soft: #cbc7d6;
+  --ink-muted: #8f8a9d;
+  --ink-faint: #6a6577;
+
+  --rule: #272531;
+  --rule-strong: #35323f;
+
+  --accent: #8f80ff;
+  --accent-ink: #100e1a;
+  --accent-wash: #1d1a30;
+  --accent-line: #3b3468;
+
+  --sev: #f2776c;
+  --sev-wash: #2a1917;
+  --warn: #dda446;
+  --warn-wash: #2a2015;
+  --ok: #55cd97;
+  --ok-wash: #12241c;
+  --info: #7aa9ea;
+  --info-wash: #151d2b;
+
+  --field: rgba(255, 255, 255, 0.05);
+  --shadow-lift: none;
+}
+
+
+/* --- paper: warm light, easier under office lighting ---------------- */
+[data-theme="paper"] {
+  --canvas: #f4f1ea;
+  --canvas-deep: #eae5da;
+  --surface: #fffdf9;
+  --surface-sunk: #f8f5ee;
+  --surface-raised: #fffdf9;
+  --ink: #1b1712;
+  --ink-soft: #453d33;
+  --ink-muted: #6d6255;
+  --ink-faint: #9b8f7f;
+  --rule: #e4ded1;
+  --rule-strong: #d3ccbb;
+  --accent-wash: #efecfb;
+  --accent-line: #cbc3f5;
+  --field: rgba(27, 23, 18, 0.05);
+}
+
+/* --- midnight: near black, for a dark room -------------------------- */
+[data-theme="midnight"] {
+  --canvas: #000105;
+  --canvas-deep: #000000;
+  --surface: #0a0b10;
+  --surface-sunk: #06070b;
+  --surface-raised: #101219;
+  --ink: #eef0f6;
+  --ink-soft: #c2c6d4;
+  --ink-muted: #838999;
+  --ink-faint: #5d6273;
+  --rule: #1b1d26;
+  --rule-strong: #282b37;
+  --accent: #9184ff;
+  --accent-ink: #07070e;
+  --accent-wash: #14142a;
+  --accent-line: #302a5e;
+  --sev: #f2776c;
+  --sev-wash: #24120f;
+  --warn: #dda446;
+  --warn-wash: #241b0f;
+  --ok: #55cd97;
+  --ok-wash: #0c1c15;
+  --info: #7aa9ea;
+  --info-wash: #0f1622;
+  --field: rgba(255, 255, 255, 0.06);
+  --shadow-lift: none;
+}
+
+/* --- contrast: WCAG AAA text, heavier rules, no washes -------------- */
+[data-theme="contrast"] {
+  --canvas: #ffffff;
+  --canvas-deep: #ffffff;
+  --surface: #ffffff;
+  --surface-sunk: #f2f2f2;
+  --surface-raised: #ffffff;
+  --ink: #000000;
+  --ink-soft: #1a1a1a;
+  --ink-muted: #3d3d3d;
+  --ink-faint: #565656;
+  --rule: #767676;
+  --rule-strong: #000000;
+  --accent: #2b1ba8;
+  --accent-ink: #ffffff;
+  --accent-wash: #e8e5ff;
+  --accent-line: #2b1ba8;
+  --sev: #970d00;
+  --sev-wash: #ffecea;
+  --warn: #6b3f00;
+  --warn-wash: #fff2dc;
+  --ok: #0a5c38;
+  --ok-wash: #e3f6ec;
+  --info: #10387a;
+  --info-wash: #e7eefc;
+  --field: rgba(0, 0, 0, 0.09);
+  --shadow-lift: none;
+}
+
+/* --- accent axis: independent of the theme -------------------------- */
+[data-accent="blue"]   { --accent: #1f5fd0; --accent-wash: #e9f0fd; --accent-line: #b7cdf5; }
+[data-accent="teal"]   { --accent: #0d7068; --accent-wash: #e4f4f2; --accent-line: #a8ded8; }
+[data-accent="amber"]  { --accent: #9a5c05; --accent-wash: #fdf1de; --accent-line: #efd0a0; }
+[data-accent="rose"]   { --accent: #ad2456; --accent-wash: #fdeaf1; --accent-line: #f0bbcf; }
+
+[data-theme="dark"][data-accent="blue"],
+[data-theme="midnight"][data-accent="blue"]  { --accent: #7fa8f5; --accent-wash: #141c2e; --accent-line: #2c3f66; }
+[data-theme="dark"][data-accent="teal"],
+[data-theme="midnight"][data-accent="teal"]  { --accent: #55c9bd; --accent-wash: #0f2422; --accent-line: #235049; }
+[data-theme="dark"][data-accent="amber"],
+[data-theme="midnight"][data-accent="amber"] { --accent: #e0a94e; --accent-wash: #26200f; --accent-line: #574326; }
+[data-theme="dark"][data-accent="rose"],
+[data-theme="midnight"][data-accent="rose"]  { --accent: #ef7fa4; --accent-wash: #2a1620; --accent-line: #5c2f43; }
+
+/* --- density: row height and padding, independent of zoom ----------- */
+:root { --row-h: 27px; --pad-y: 0.2rem; --pane-head-h: 27px; }
+[data-density="compact"]     { --row-h: 22px; --pad-y: 0.1rem; --pane-head-h: 24px; }
+[data-density="comfortable"] { --row-h: 29px; --pad-y: 0.24rem; --pane-head-h: 28px; }
+
+@theme inline {
+  --color-canvas: var(--canvas);
+  --color-canvas-deep: var(--canvas-deep);
+  --color-surface: var(--surface);
+  --color-sunk: var(--surface-sunk);
+  --color-raised: var(--surface-raised);
+  --color-ink: var(--ink);
+  --color-soft: var(--ink-soft);
+  --color-muted: var(--ink-muted);
+  --color-faint: var(--ink-faint);
+  --color-rule: var(--rule);
+  --color-rule-strong: var(--rule-strong);
+  --color-accent: var(--accent);
+  --color-accent-ink: var(--accent-ink);
+  --color-accent-wash: var(--accent-wash);
+  --color-accent-line: var(--accent-line);
+  --color-sev: var(--sev);
+  --color-sev-wash: var(--sev-wash);
+  --color-warn: var(--warn);
+  --color-warn-wash: var(--warn-wash);
+  --color-ok: var(--ok);
+  --color-ok-wash: var(--ok-wash);
+  --color-info: var(--info);
+  --color-info-wash: var(--info-wash);
+
+  --font-sans: system-ui, -apple-system, "SF Pro Text", "Segoe UI Variable Text",
+    "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", "Cascadia Mono",
+    "Roboto Mono", Menlo, Consolas, monospace;
+
+  --radius-card: 9px;
+  --radius-tile: 7px;
+}

--- a/packages/ui-next/src/test-setup.ts
+++ b/packages/ui-next/src/test-setup.ts
@@ -1,0 +1,12 @@
+import { afterEach } from "vitest";
+import { cleanup } from "@testing-library/react";
+
+// Unmount React trees between tests so repeated render() calls don't stack —
+// without this a query for a button finds every previous test's copy too.
+afterEach(() => cleanup());
+
+// The design preference lives in localStorage, so one test's writes must not
+// leak into the next.
+afterEach(() => {
+  if (typeof localStorage !== "undefined") localStorage.clear();
+});

--- a/packages/ui-next/tsconfig.json
+++ b/packages/ui-next/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node", "vite/client"]
+  },
+  "include": ["src"]
+}

--- a/packages/ui-next/vitest.config.ts
+++ b/packages/ui-next/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+// No react plugin: esbuild compiles JSX from tsconfig's `jsx: react-jsx`, the
+// same way apps/desktop's config does. No coverage block either — the root
+// vitest.config.ts owns the gate, because the floors are measured across every
+// package together.
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    setupFiles: ["./src/test-setup.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@srelens/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@srelens/ui-next':
+        specifier: workspace:*
+        version: link:../../packages/ui-next
       '@tauri-apps/api':
         specifier: ^2.0.0
         version: 2.11.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,6 +215,49 @@ importers:
         specifier: ^3.2.7
         version: 3.2.7(@types/node@26.1.1)(jiti@2.7.0)(jsdom@24.1.3)(lightningcss@1.32.0)(yaml@2.9.0)
 
+  packages/ui-next:
+    dependencies:
+      '@srelens/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/node':
+        specifier: ^26.1.1
+        version: 26.1.1
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      jsdom:
+        specifier: ^24.0.0
+        version: 24.1.3
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
+      tailwindcss:
+        specifier: ^4.3.1
+        version: 4.3.1
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+      vite:
+        specifier: ^6.4.3
+        version: 6.4.3(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
+      vitest:
+        specifier: ^3.2.7
+        version: 3.2.7(@types/node@26.1.1)(jiti@2.7.0)(jsdom@24.1.3)(lightningcss@1.32.0)(yaml@2.9.0)
+
 packages:
 
   '@ampproject/remapping@2.3.0':

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,12 +14,18 @@ import { defineConfig } from "vitest/config";
  */
 export default defineConfig({
   test: {
-    projects: ["apps/desktop", "packages/core"],
+    // Every workspace member with tests. A package missing here is silently
+    // untested: the root run reports green while never loading its suites.
+    projects: ["apps/desktop", "packages/core", "packages/ui-next"],
     coverage: {
       provider: "v8",
       // Never lower any of these.
       thresholds: { lines: 85, branches: 80, functions: 76 },
-      include: ["apps/desktop/src/**/*.{ts,tsx}", "packages/core/src/**/*.ts"],
+      include: [
+        "apps/desktop/src/**/*.{ts,tsx}",
+        "packages/core/src/**/*.ts",
+        "packages/ui-next/src/**/*.{ts,tsx}",
+      ],
       exclude: [
         "**/*.test.{ts,tsx}",
         "apps/desktop/src/main.tsx",
@@ -28,6 +34,7 @@ export default defineConfig({
         "apps/desktop/src/components/PodTerminal.tsx",
         "packages/core/src/index.ts",
         "packages/core/src/react.ts",
+        "packages/ui-next/src/test-setup.ts",
       ],
     },
   },


### PR DESCRIPTION
Closes #312. Part of #305, step 2 — the switch half. The component-library merge and the new design's screens follow separately; this builds only the mechanism, so the riskiest infrastructure is proven before any design work depends on it.

## What ships

Settings → Appearance now offers a choice of design. Choosing the new one reloads into `@srelens/ui-next`, which is currently a single honest placeholder. **The default is unchanged** — anyone who never opens Settings sees exactly what they see today.

## The property everything rests on

The two designs' stylesheets cannot share a document: both import Tailwind, use different dark-mode conventions (`.dark` vs `[data-theme=dark]`), and each writes global `body`/`*` rules.

A spike on the real app found the spec's rule was subtly wrong. Making only the **stylesheet** dynamic is not enough — `src/ui/index.ts` statically imports `ui/styles.css`, so a statically imported `AppGate` drags it into the entry chunk, which `index.html` links unconditionally. The classic design's CSS would have loaded underneath the new one.

Making **both the stylesheet and the tree** dynamic fixes it completely. In the built output now:

```
index.html links 0 stylesheets
dist/assets/app-*.css       83.79 kB   ← new design, loads with NextApp
dist/assets/globals-*.css   87.33 kB   ← classic
dist/assets/AppGate-*.css   89.18 kB   ← classic
```

So the rule is "each design's root is dynamically imported", not "no module imports CSS", and `ui/index.ts` needs no change.

`one-stylesheet.test.ts` asserts this on `main.tsx`'s source rather than the build, because a static import is a one-word change with **no symptom in `pnpm dev`** — dev-mode Vite injects styles differently — and a visibly broken new design once built.

## Details worth a look

- **`switchDesign` lives in `design.ts`, not `main.tsx`.** Importing the entry module from a component or test would run its side effects — installing the notifier and starting the app.
- **The preference falls back to classic** for any unrecognised value. A preference written by a future version must not leave someone on a design that does not exist, because a blank window has no route back to Settings.
- **The placeholder carries its own way out.** Settings does not exist in that tree yet, so without that button an opted-in user would have no exit except editing localStorage.
- **The Appearance section already existed**, holding the theme controls, so the toggle renders inside it rather than as a new top-level section — both answer "how should this look".
- **The Dockerfile guard from #311 caught the new package by itself**, requiring the two `COPY` lines for `packages/ui-next` before it would pass. That is exactly what it was written for.

## Verification

```
pnpm test                     # 1283 passed, coverage 85.94 / 82.29 / 77.68
pnpm -r typecheck             # clean, three packages
cargo test --workspace        # 1091 passed
npx vite build && grep -c stylesheet dist/index.html   # 0
```

## Not verified

**The manual run in the plan's final task has not been done** — I cannot see the window. Before merging, worth checking by hand:

1. Classic design opens unchanged, with native decorations.
2. Switching shows the placeholder on the **new design's canvas colour**, not the classic background — the latter would mean both stylesheets loaded.
3. The placeholder's button returns to classic, and decorations come back.
4. The choice survives a restart.

Also unverified: **window decorations are macOS-shaped**. `setDecorations(false)` gives the new design its frameless window; Windows and Linux need their own answer before it could ever become the default, though not before this lands.
