### PR TITLE
fix(core): tighten the two ambiguous patterns #313 missed

### DIFF
--- a/packages/core/src/lib/regex-shapes.test.ts
+++ b/packages/core/src/lib/regex-shapes.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * No pattern in the service layer may put `\s` next to a `.` capture.
+ *
+ * They overlap on every space, so the engine has more than one way to split a
+ * run of them, and a line the pattern ultimately rejects is re-tried at each
+ * split. That is the shape behind all nine `js/polynomial-redos` findings
+ * (#43-#51), one of which took 52 seconds on a 4KB input.
+ *
+ * Asserted on the source because the fix in #313 missed two of them: the
+ * patterns in `assistantMarkdown.ts` are named constants and were tightened,
+ * while the two in `releaseNotes.ts` are written inline and were not. Both
+ * modules parse markdown-ish lines, so the pair drifted apart silently and
+ * only a re-scan caught it. A grep is a poor substitute for the analyser, but
+ * it runs on every commit rather than on GitHub's schedule.
+ *
+ * `[^\S\n]` is the intended replacement for `\s` and `[^\n]` for `.`, which is
+ * what the patterns meant in the first place.
+ */
+const AMBIGUOUS = /\\s[+*][^/\n]*\(?\.\*/;
+
+function sources(dir: string): string[] {
+  return readdirSync(dir).filter((f) => f.endsWith(".ts") && !f.endsWith(".test.ts"));
+}
+
+describe("regex shapes in the service layer", () => {
+  const dir = __dirname;
+
+  it("has sources to check", () => {
+    // Guards the guard: an empty listing would pass vacuously.
+    expect(sources(dir).length).toBeGreaterThan(0);
+  });
+
+  it("never places \\s beside a dot-star capture", () => {
+    const offenders: string[] = [];
+    for (const file of sources(dir)) {
+      const lines = readFileSync(join(dir, file), "utf8").split("\n");
+      lines.forEach((line, index) => {
+        // Skip comments: the rule is discussed in prose in several places.
+        if (/^\s*(\/\/|\*)/.test(line)) return;
+        if (AMBIGUOUS.test(line)) offenders.push(`${file}:${index + 1}  ${line.trim()}`);
+      });
+    }
+    expect(offenders, `ambiguous patterns:\n  ${offenders.join("\n  ")}`).toEqual([]);
+  });
+});

--- a/packages/core/src/lib/releaseNotes.ts
+++ b/packages/core/src/lib/releaseNotes.ts
@@ -70,13 +70,18 @@ export function parseReleaseNotes(notes: string): NoteBlock[] {
       flushAll();
       continue;
     }
-    const heading = /^#{1,6}\s+(.*)$/.exec(line);
+    // `[^\S\n]`/`[^\n]` rather than `\s`/`.`: those two overlap on every
+    // space, so a line the pattern ultimately rejects can be split many ways
+    // (js/polynomial-redos, #50 and #51). The equivalents in
+    // assistantMarkdown.ts were tightened in #313; these were missed because
+    // they are inline rather than named constants.
+    const heading = /^#{1,6}[^\S\n]+([^\n]*)$/.exec(line);
     if (heading) {
       flushAll();
       blocks.push({ kind: "heading", spans: parseSpans(heading[1]) });
       continue;
     }
-    const bullet = /^[-*]\s+(.*)$/.exec(line);
+    const bullet = /^[-*][^\S\n]+([^\n]*)$/.exec(line);
     if (bullet) {
       // A bullet ends a paragraph but continues any run of bullets above it.
       flushParagraph();


### PR DESCRIPTION
Closes code-scanning alerts [#50](https://github.com/srelens/srelens/security/code-scanning/50) and [#51](https://github.com/srelens/srelens/security/code-scanning/51).

## What happened

Seven of the nine `js/polynomial-redos` alerts closed when #313 merged. These two did not, and the reason is worth recording: the fix reached the patterns in `assistantMarkdown.ts` but not the two in `releaseNotes.ts`.

Both modules parse the same markdown-ish line shapes. One holds its patterns as **named constants**, the other writes them **inline**, so an edit aimed at the constants left the inline pair behind — and a scan of the source at the time would have found them, which is the part I should have done.

```diff
-const heading = /^#{1,6}\s+(.*)$/.exec(line);
+const heading = /^#{1,6}[^\S\n]+([^\n]*)$/.exec(line);
-const bullet  = /^[-*]\s+(.*)$/.exec(line);
+const bullet  = /^[-*][^\S\n]+([^\n]*)$/.exec(line);
```

`\s` and `.` overlap on every space, so the engine has more than one way to split a run of them. `[^\S\n]` and `[^\n]` are what the patterns meant in the first place.

## These are still not live bugs

As in #313, neither reproduced under load — their callers split on newlines before the pattern sees the text, so backtracking has nothing to chew on. I am not claiming a fixed vulnerability. They are fixed because the ambiguity is real, and because leaving two alerts open makes the other seven closing look like noise rather than a result.

## The guard

`regex-shapes.test.ts` scans the service layer for `\s` next to a dot-star capture — the shape behind all nine findings, one of which took 52 seconds on a 4KB input.

A grep is a poor substitute for the analyser. What it has over CodeQL is that it runs on every commit rather than on GitHub's schedule, and it fails naming the file and line. It is aimed squarely at what happened here: two files with the same job drifting apart because one was edited and the other looked different enough to miss.

Verified it fails on the shape it targets by restoring the old pattern and watching it report `releaseNotes.ts:78`.

## Verification

```
pnpm test          # 1310 passed, coverage 86.00 / 82.36 / 77.83
pnpm -r typecheck  # clean
```

Release-notes parsing behaviour is unchanged — its own suite still passes in full.
