### PR TITLE
feat(ui-kit): merge the form primitives into the design system

### DIFF
--- a/packages/ui-kit/src/Button.test.tsx
+++ b/packages/ui-kit/src/Button.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Button } from "./Button";
+
+/**
+ * The first three are the classic component's own tests, carried over
+ * unchanged: the merge rule for a component both designs have is that the API
+ * and behaviour survive and only the appearance moves. (#318)
+ */
+describe("Button", () => {
+  it("renders children and fires onClick", () => {
+    const onClick = vi.fn();
+    render(<Button onClick={onClick}>Save</Button>);
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders each variant as a button", () => {
+    const { rerender } = render(<Button>X</Button>);
+    expect(screen.getByRole("button", { name: "X" })).toBeDefined();
+    rerender(<Button variant="ghost">X</Button>);
+    expect(screen.getByRole("button", { name: "X" })).toBeDefined();
+    rerender(<Button variant="danger">X</Button>);
+    expect(screen.getByRole("button", { name: "X" })).toBeDefined();
+  });
+
+  it("does not fire onClick when disabled and forwards className", () => {
+    const onClick = vi.fn();
+    render(
+      <Button disabled className="extra" onClick={onClick}>
+        X
+      </Button>,
+    );
+    const btn = screen.getByRole("button");
+    fireEvent.click(btn);
+    expect(onClick).not.toHaveBeenCalled();
+    expect(btn.className).toContain("extra");
+  });
+
+  it("carries the design's button classes rather than utilities", () => {
+    // The kit's stylesheet owns the appearance; a component that spells its own
+    // padding and colour out in utilities drifts from the rest of the system.
+    const { rerender } = render(<Button variant="primary">X</Button>);
+    expect(screen.getByRole("button").className).toContain("btn");
+    expect(screen.getByRole("button").className).toContain("btn-accent");
+    rerender(<Button variant="danger">X</Button>);
+    expect(screen.getByRole("button").className).toContain("btn-danger");
+    rerender(<Button variant="ghost">X</Button>);
+    expect(screen.getByRole("button").className).toContain("btn-ghost");
+    rerender(<Button variant="secondary">X</Button>);
+    expect(screen.getByRole("button").className).toBe("btn");
+  });
+
+  it("exposes the size on the element for the stylesheet to act on", () => {
+    const { rerender } = render(<Button size="xs">X</Button>);
+    expect(screen.getByRole("button").dataset.size).toBe("xs");
+    rerender(<Button size="icon-sm">X</Button>);
+    expect(screen.getByRole("button").dataset.size).toBe("icon-sm");
+  });
+
+  it("leaves the button type alone", () => {
+    // Defaulting to type="button" would stop every Button inside a form from
+    // submitting it, which is a behaviour change the classic component did not
+    // make. Callers that need it pass it.
+    render(<Button>X</Button>);
+    expect(screen.getByRole("button").getAttribute("type")).toBeNull();
+  });
+});

--- a/packages/ui-kit/src/Button.tsx
+++ b/packages/ui-kit/src/Button.tsx
@@ -1,0 +1,52 @@
+import type { ButtonHTMLAttributes } from "react";
+import { cx } from "./cx";
+
+export type ButtonVariant = "primary" | "secondary" | "ghost" | "danger" | "outline";
+
+export type ButtonSize =
+  | "xs"
+  | "sm"
+  | "default"
+  | "lg"
+  | "icon"
+  | "icon-xs"
+  | "icon-sm"
+  | "icon-lg";
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+}
+
+/**
+ * The design's button.
+ *
+ * The classic component wrapped shadcn's, which cannot come along: it lives in
+ * `apps/desktop` and is written against the classic Tailwind config. The API is
+ * what callers depend on, so `variant` and `size` survive unchanged and only
+ * the appearance moves. (#318)
+ *
+ * `secondary` and `outline` both render the plain `.btn` — the new design has
+ * one bordered surface button where shadcn had two. `data-variant` keeps the
+ * caller's intent on the element so the stylesheet can separate them later
+ * without touching a single call site.
+ *
+ * The size is an attribute rather than a set of utility classes because the
+ * kit's stylesheet owns the appearance; see `tokens-only.test.ts`.
+ */
+export function Button({ variant = "primary", size = "default", className, ...rest }: ButtonProps) {
+  return (
+    <button
+      data-variant={variant}
+      data-size={size}
+      className={cx(
+        "btn",
+        variant === "primary" && "btn-accent",
+        variant === "danger" && "btn-danger",
+        variant === "ghost" && "btn-ghost",
+        className,
+      )}
+      {...rest}
+    />
+  );
+}

--- a/packages/ui-kit/src/Field.test.tsx
+++ b/packages/ui-kit/src/Field.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Field } from "./Field";
+import { TextInput } from "./TextInput";
+
+describe("Field", () => {
+  it("labels the control it wraps", () => {
+    // Implicit association: the classic component rendered the label as a bare
+    // sibling with no htmlFor, so nothing tied the two together and clicking
+    // the label did nothing. Wrapping is what the new design's markup does.
+    render(
+      <Field label="Namespace">
+        <TextInput value="" onValueChange={() => {}} />
+      </Field>,
+    );
+    expect(screen.getByLabelText("Namespace")).toBeDefined();
+  });
+
+  it("shows a hint under the control", () => {
+    render(
+      <Field label="Name" hint="Lowercase letters only">
+        <input />
+      </Field>,
+    );
+    expect(screen.getByText("Lowercase letters only")).toBeDefined();
+  });
+
+  it("shows the error instead of the hint, never both", () => {
+    // Two lines of small print under one control, one of them stale advice,
+    // reads as a rendering fault.
+    render(
+      <Field label="Name" hint="Lowercase letters only" error="Already taken">
+        <input />
+      </Field>,
+    );
+    expect(screen.getByText("Already taken")).toBeDefined();
+    expect(screen.queryByText("Lowercase letters only")).toBeNull();
+  });
+
+  it("keeps an action outside the label element", () => {
+    // A <button> is a labelable element, so nesting it inside the <label> makes
+    // a label click activate it and swallows its name into the label's name
+    // computation. Carried over from the classic component, which documented
+    // this and got it right.
+    render(
+      <Field label="Manifest" action={<button>Preview</button>}>
+        <input />
+      </Field>,
+    );
+    const action = screen.getByRole("button", { name: "Preview" });
+    expect(action.closest("label")).toBeNull();
+  });
+
+  it("forwards className", () => {
+    const { container } = render(
+      <Field label="X" className="extra">
+        <input />
+      </Field>,
+    );
+    expect(container.querySelector(".extra")).not.toBeNull();
+  });
+});

--- a/packages/ui-kit/src/Field.tsx
+++ b/packages/ui-kit/src/Field.tsx
@@ -1,0 +1,68 @@
+import type { ReactNode } from "react";
+import { cx } from "./cx";
+
+export interface FieldProps {
+  label: ReactNode;
+  /**
+   * Optional control shown opposite the label (e.g. a "Preview" button).
+   * Rendered as a SIBLING of the `<label>`, never inside it: a `<button>` is a
+   * labelable element, so nesting it would make label clicks activate it and
+   * would swallow its accessible name into the label's name computation.
+   */
+  action?: ReactNode;
+  /** Helper text under the control. */
+  hint?: ReactNode;
+  /** Replaces the hint when the field has failed validation. */
+  error?: ReactNode;
+  children: ReactNode;
+  className?: string;
+}
+
+/** The small print under a control: the error if there is one, else the hint. */
+function Note({ hint, error }: { hint?: ReactNode; error?: ReactNode }) {
+  // Never both. Two lines of small print under one control, one of them advice
+  // the user has already failed to follow, reads as a rendering fault.
+  if (error) {
+    return (
+      <div className="mt-1 text-[0.75rem]" style={{ color: "var(--sev)" }}>
+        {error}
+      </div>
+    );
+  }
+  if (hint) return <div className="mt-1 text-[0.75rem] text-muted">{hint}</div>;
+  return null;
+}
+
+/**
+ * A labelled form control: label above, control, optional hint or error below.
+ *
+ * Wraps the control in the `<label>` rather than rendering the two as siblings,
+ * which is both what the new design's markup does and an association the
+ * classic component never had — it emitted a bare `<label>` with no `htmlFor`,
+ * so clicking the text did nothing and assistive technology had to guess from
+ * proximity. (#318)
+ *
+ * With an `action` the wrapper cannot be the `<label>`, for the reason given on
+ * the prop, so that form keeps the classic component's arrangement.
+ */
+export function Field({ label, action, hint, error, children, className }: FieldProps) {
+  if (action) {
+    return (
+      <div className={cx("py-1", className)}>
+        <div className="mb-0.5 flex items-center justify-between gap-2">
+          <span className="field-label">{label}</span>
+          {action}
+        </div>
+        {children}
+        <Note hint={hint} error={error} />
+      </div>
+    );
+  }
+  return (
+    <label className={cx("block py-1", className)}>
+      <span className="field-label mb-0.5">{label}</span>
+      {children}
+      <Note hint={hint} error={error} />
+    </label>
+  );
+}

--- a/packages/ui-kit/src/IconButton.test.tsx
+++ b/packages/ui-kit/src/IconButton.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { IconButton } from "./IconButton";
+
+// Forwards props, as lucide's icons do — an icon that swallowed them would
+// make the aria-hidden assertion below pass without the component doing
+// anything.
+function Dot(props: { "aria-hidden"?: boolean | "true" | "false" }) {
+  return <svg data-testid="icon" {...props} />;
+}
+
+describe("IconButton", () => {
+  it("names itself from the label, since the icon cannot", () => {
+    render(<IconButton icon={Dot} label="Delete" />);
+    expect(screen.getByRole("button", { name: "Delete" })).toBeDefined();
+  });
+
+  it("uses the label as the tooltip unless one is given", () => {
+    const { rerender } = render(<IconButton icon={Dot} label="Logs" />);
+    expect(screen.getByRole("button").title).toBe("Logs");
+    // The override exists to explain why a button is disabled.
+    rerender(<IconButton icon={Dot} label="Logs" title="No container selected" disabled />);
+    expect(screen.getByRole("button").title).toBe("No container selected");
+  });
+
+  it("hides the icon from assistive technology", () => {
+    // The button already has a name; the icon announcing itself repeats it.
+    render(<IconButton icon={Dot} label="Delete" />);
+    expect(screen.getByTestId("icon").getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("fires onClick, and does not when disabled", () => {
+    const onClick = vi.fn();
+    const { rerender } = render(<IconButton icon={Dot} label="Go" onClick={onClick} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+    rerender(<IconButton icon={Dot} label="Go" onClick={onClick} disabled />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("is a button, never a submit", () => {
+    // Icon buttons sit inside forms all over the app — a delete icon that
+    // submits the form it is standing in is a data-loss bug.
+    render(<IconButton icon={Dot} label="Delete" />);
+    expect(screen.getByRole("button").getAttribute("type")).toBe("button");
+  });
+
+  it("tints with the severity token when danger", () => {
+    render(<IconButton icon={Dot} label="Delete" danger />);
+    expect(screen.getByRole("button").style.color).toContain("--sev");
+  });
+});

--- a/packages/ui-kit/src/IconButton.tsx
+++ b/packages/ui-kit/src/IconButton.tsx
@@ -1,0 +1,60 @@
+import type { ComponentType } from "react";
+import { cx } from "./cx";
+
+/**
+ * Structural rather than lucide's `LucideIcon`, so the kit does not take a
+ * dependency on an icon set to describe a hole an icon goes in. Lucide's icons
+ * satisfy this, and so does a plain SVG component.
+ */
+export type IconComponent = ComponentType<{
+  size?: number;
+  className?: string;
+  "aria-hidden"?: boolean | "true" | "false";
+}>;
+
+export interface IconButtonProps {
+  icon: IconComponent;
+  /** Accessible name + default tooltip (e.g. "Logs", "Delete"). */
+  label: string;
+  onClick?: () => void;
+  /** Tints the icon with the danger colour (e.g. Delete). */
+  danger?: boolean;
+  disabled?: boolean;
+  /** Tooltip override (defaults to `label`; used to explain a disabled reason). */
+  title?: string;
+  className?: string;
+}
+
+/**
+ * A compact icon-only button.
+ *
+ * The label is both the accessible name and the hover tooltip unless `title`
+ * overrides it, so the icon never stands alone — carried over from the classic
+ * component along with the rest of its API. (#318)
+ *
+ * `type="button"` is explicit: these sit inside forms throughout the app, and a
+ * delete icon that submits the form it is standing in loses work.
+ */
+export function IconButton({
+  icon: Icon,
+  label,
+  onClick,
+  danger,
+  disabled,
+  title,
+  className,
+}: IconButtonProps) {
+  return (
+    <button
+      type="button"
+      className={cx("icon-btn", className)}
+      aria-label={label}
+      title={title ?? label}
+      onClick={onClick}
+      disabled={disabled}
+      style={danger ? { color: "var(--sev)" } : undefined}
+    >
+      <Icon size={14} aria-hidden="true" />
+    </button>
+  );
+}

--- a/packages/ui-kit/src/TextInput.test.tsx
+++ b/packages/ui-kit/src/TextInput.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { TextInput } from "./TextInput";
+
+/** The first three are the classic component's tests, carried over. (#318) */
+describe("TextInput", () => {
+  it("renders the value and emits value-first changes", () => {
+    const onValueChange = vi.fn();
+    render(<TextInput value="abc" onValueChange={onValueChange} />);
+    const input = screen.getByDisplayValue("abc");
+    fireEvent.change(input, { target: { value: "abcd" } });
+    expect(onValueChange).toHaveBeenCalledWith("abcd");
+  });
+
+  it("calls onEnter when Enter is pressed", () => {
+    const onEnter = vi.fn();
+    render(<TextInput value="" onValueChange={() => {}} onEnter={onEnter} />);
+    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Enter" });
+    expect(onEnter).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not throw on Enter without an onEnter handler", () => {
+    render(<TextInput value="" onValueChange={() => {}} />);
+    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Enter" });
+    // no assertion needed; absence of a thrown error is the contract
+  });
+
+  it("calls onEscape when Escape is pressed", () => {
+    const onEscape = vi.fn();
+    render(<TextInput value="" onValueChange={() => {}} onEscape={onEscape} />);
+    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Escape" });
+    expect(onEscape).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks itself invalid for assistive technology, not just in colour", () => {
+    // The mock signals an invalid field by reddening its border, which a screen
+    // reader cannot see and a colour-blind user may not either.
+    render(<TextInput value="" onValueChange={() => {}} invalid aria-label="Name" />);
+    expect(screen.getByRole("textbox").getAttribute("aria-invalid")).toBe("true");
+  });
+
+  it("does not claim to be valid when nothing said it was", () => {
+    // aria-invalid="false" on every field is noise; the attribute belongs only
+    // on a field that has actually been judged.
+    render(<TextInput value="" onValueChange={() => {}} aria-label="Name" />);
+    expect(screen.getByRole("textbox").getAttribute("aria-invalid")).toBeNull();
+  });
+});

--- a/packages/ui-kit/src/TextInput.tsx
+++ b/packages/ui-kit/src/TextInput.tsx
@@ -1,0 +1,65 @@
+import { cx } from "./cx";
+
+export interface TextInputProps {
+  value: string;
+  onValueChange: (value: string) => void;
+  /** Called when the user presses Enter. */
+  onEnter?: () => void;
+  /** Called when the user presses Escape. */
+  onEscape?: () => void;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+  type?: "text" | "search" | "number" | "password";
+  autoFocus?: boolean;
+  /** Marks the field as failing validation, in colour and to assistive tech. */
+  invalid?: boolean;
+  "aria-label"?: string;
+}
+
+/**
+ * Single-line text input with a value-first change contract.
+ *
+ * The classic component wrapped shadcn's Input; the value-first API, `onEnter`
+ * and `onEscape` are what callers depend on and survive unchanged. (#318)
+ *
+ * `aria-invalid` is set only when the field has actually been judged invalid.
+ * The mock passes the flag straight through, which puts `aria-invalid="false"`
+ * on every untouched field — noise that says a field has been checked and
+ * passed when nothing has checked it.
+ */
+export function TextInput({
+  value,
+  onValueChange,
+  onEnter,
+  onEscape,
+  placeholder,
+  disabled,
+  className,
+  type = "text",
+  autoFocus,
+  invalid,
+  "aria-label": ariaLabel,
+}: TextInputProps) {
+  return (
+    <input
+      value={value}
+      onChange={(e) => onValueChange(e.target.value)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" && onEnter) onEnter();
+        if (e.key === "Escape" && onEscape) onEscape();
+      }}
+      placeholder={placeholder}
+      disabled={disabled}
+      type={type}
+      autoFocus={autoFocus}
+      aria-label={ariaLabel}
+      aria-invalid={invalid ? true : undefined}
+      className={cx("w-full rounded-md border px-2 py-1 text-[0.8125rem] outline-none", className)}
+      style={{
+        background: "var(--surface-sunk)",
+        borderColor: invalid ? "var(--sev)" : "var(--rule)",
+      }}
+    />
+  );
+}

--- a/packages/ui-kit/src/cx.ts
+++ b/packages/ui-kit/src/cx.ts
@@ -1,0 +1,9 @@
+/**
+ * Join class names, dropping anything falsy.
+ *
+ * Local rather than `clsx`, which would be the kit's first runtime dependency
+ * for eleven lines of logic. (#318)
+ */
+export function cx(...parts: Array<string | false | null | undefined>): string {
+  return parts.filter(Boolean).join(" ");
+}

--- a/packages/ui-kit/src/gallery/Gallery.tsx
+++ b/packages/ui-kit/src/gallery/Gallery.tsx
@@ -1,9 +1,26 @@
+import { useState } from "react";
 import { Badge } from "../Badge";
+import { Button } from "../Button";
+import { Field } from "../Field";
+import { IconButton } from "../IconButton";
 import { Meter } from "../Meter";
 import { Sparkline } from "../Sparkline";
+import { TextInput } from "../TextInput";
 import type { Tone } from "../tone";
 
 const TONES: Tone[] = ["muted", "ok", "info", "accent", "warn", "sev"];
+
+/**
+ * A stand-in for a real icon. The kit does not depend on an icon set — callers
+ * pass their own — so the catalogue brings its own shape to show the hole.
+ */
+function DotIcon({ size = 14, ...rest }: { size?: number; "aria-hidden"?: boolean | "true" | "false" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" {...rest}>
+      <circle cx="8" cy="8" r="5" fill="currentColor" />
+    </svg>
+  );
+}
 
 /**
  * The kit's living catalogue, and the only visual review surface this design
@@ -15,6 +32,11 @@ const TONES: Tone[] = ["muted", "ok", "info", "accent", "warn", "sev"];
  * reporting a figure nobody designed for.
  */
 export function Gallery() {
+  // The inputs are controlled, so the catalogue has to hold their value; typing
+  // into a component that never updates is not a working example of it.
+  const [text, setText] = useState("kube-system");
+  const [empty, setEmpty] = useState("");
+
   return (
     <div className="kit-gallery">
       <h1>Design system</h1>
@@ -56,6 +78,75 @@ export function Gallery() {
         <Sparkline points={[7]} tone="warn" ariaLabel="a single sample" />
         {/* The normal state of a chart that has just been opened. */}
         <Sparkline points={[]} ariaLabel="no samples yet" />
+      </section>
+
+      <section>
+        <h2>Button</h2>
+        <div className="kit-gallery__row">
+          <Button>primary</Button>
+          <Button variant="secondary">secondary</Button>
+          <Button variant="outline">outline</Button>
+          <Button variant="ghost">ghost</Button>
+          <Button variant="danger">danger</Button>
+        </div>
+        <div className="kit-gallery__row">
+          <Button size="xs">xs</Button>
+          <Button size="sm">sm</Button>
+          <Button size="default">default</Button>
+          <Button size="lg">lg</Button>
+        </div>
+        {/* Disabled is not a rare state: half the toolbar is disabled until a
+            resource is selected. */}
+        <div className="kit-gallery__row">
+          <Button disabled>disabled</Button>
+          <Button variant="danger" disabled>
+            disabled danger
+          </Button>
+        </div>
+      </section>
+
+      <section>
+        <h2>IconButton</h2>
+        <div className="kit-gallery__row">
+          <IconButton icon={DotIcon} label="Logs" />
+          <IconButton icon={DotIcon} label="Delete" danger />
+          {/* The disabled form carries its reason, which is the whole point of
+              the title override. */}
+          <IconButton icon={DotIcon} label="Restart" disabled title="No pod selected" />
+        </div>
+      </section>
+
+      <section>
+        <h2>TextInput</h2>
+        <div className="kit-gallery__row">
+          <TextInput value={text} onValueChange={setText} aria-label="a filled input" />
+          <TextInput
+            value={empty}
+            onValueChange={setEmpty}
+            placeholder="namespace"
+            aria-label="an empty input"
+          />
+          <TextInput value="bad name" onValueChange={() => {}} invalid aria-label="an invalid input" />
+          <TextInput value="frozen" onValueChange={() => {}} disabled aria-label="a disabled input" />
+        </div>
+      </section>
+
+      <section>
+        <h2>Field</h2>
+        <Field label="Namespace">
+          <TextInput value={text} onValueChange={setText} />
+        </Field>
+        <Field label="Name" hint="Lowercase letters, numbers and dashes">
+          <TextInput value={empty} onValueChange={setEmpty} />
+        </Field>
+        {/* The error replaces the hint rather than joining it. */}
+        <Field label="Name" hint="Lowercase letters, numbers and dashes" error="Already taken">
+          <TextInput value="prod" onValueChange={() => {}} invalid />
+        </Field>
+        {/* With an action the label cannot wrap the control; see the component. */}
+        <Field label="Manifest" action={<Button size="xs">Preview</Button>}>
+          <TextInput value={empty} onValueChange={setEmpty} />
+        </Field>
       </section>
     </div>
   );

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -1,5 +1,10 @@
 /** The srelens design system. Components are added as they are merged in. */
 export { Badge, type BadgeTone } from "./Badge";
+export { Button, type ButtonProps, type ButtonSize, type ButtonVariant } from "./Button";
+export { Field, type FieldProps } from "./Field";
+export { IconButton, type IconButtonProps, type IconComponent } from "./IconButton";
 export { Meter } from "./Meter";
 export { Sparkline } from "./Sparkline";
+export { TextInput, type TextInputProps } from "./TextInput";
+export { cx } from "./cx";
 export { toneColor, toneWash, type Tone } from "./tone";

--- a/packages/ui-kit/src/styles/kit.css
+++ b/packages/ui-kit/src/styles/kit.css
@@ -183,6 +183,25 @@
   .btn-danger { color: var(--sev); border-color: color-mix(in srgb, var(--sev) 32%, transparent); }
   .btn-danger:hover { background: var(--sev-wash); border-color: var(--sev); color: var(--sev); }
 
+  /* A borderless button for toolbars and row affordances, where a bordered one
+     would draw a box around every action. The classic kit's `ghost` variant;
+     distinct from `.ghost`, which is the full-width row button with an arrow. */
+  .btn-ghost { background: transparent; border-color: transparent; }
+  .btn-ghost:hover { background: var(--field); border-color: transparent; }
+
+  /* Sizes come off the element's data-size so call sites keep the classic API
+     and the measurements stay here with the rest of the appearance. */
+  .btn[data-size="xs"] { padding: 0.15rem 0.4rem; font-size: 0.6875rem; }
+  .btn[data-size="sm"] { padding: 0.22rem 0.45rem; }
+  .btn[data-size="lg"] { padding: 0.4rem 0.8rem; font-size: 0.8125rem; }
+  .btn[data-size^="icon"] { padding: 0; justify-content: center; gap: 0; }
+  .btn[data-size="icon-xs"] { width: 20px; height: 18px; }
+  .btn[data-size="icon-sm"] { width: 24px; height: 22px; }
+  .btn[data-size="icon"] { width: 28px; height: 26px; }
+  .btn[data-size="icon-lg"] { width: 32px; height: 30px; }
+
+  .btn:disabled, .icon-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
   /* --- badges --------------------------------------------------- */
   .badge {
     display: inline-flex;


### PR DESCRIPTION
The first four of the nineteen in #318: `Button`, `IconButton`, `TextInput`, `Field`.

## The merge rule these follow

From #305: for a component both designs have, **the API and behaviour survive and only the appearance moves.** `Button`'s and `TextInput`'s existing tests are carried over unchanged as the evidence of that.

## Why they were reimplemented rather than moved

The classic versions wrap shadcn — `@/components/ui/button`, `input`, `label` — which lives in `apps/desktop` and is written against the classic Tailwind config, so it cannot cross into the kit. Per the decision on #318 the kit stays dependency-free, so these are rebuilt against the design's own `.btn`, `.icon-btn` and `.field-label` rules.

Sizes are driven off `data-size` rather than utility classes, so the measurements stay in the stylesheet with the rest of the appearance. `secondary` and `outline` both render the plain `.btn` — the new design has one bordered surface button where shadcn had two — but `data-variant` keeps the caller's intent on the element, so the stylesheet can separate them later without touching a call site.

## Three logic changes, none of them visible

- **`Field` wraps its control in the `<label>`**, so clicking the label focuses the input. The classic component emitted a bare `<label>` with no `htmlFor`, so nothing tied the two together. The `action` form keeps the classic arrangement, for the reason that component documented: a `<button>` is a labelable element, so nesting it would make label clicks activate it.
- **`TextInput` sets `aria-invalid` only when the field is actually invalid.** The mock passes the flag straight through, which puts `aria-invalid="false"` on every untouched field — that says a field has been checked and passed when nothing has checked it.
- **`IconButton` is explicitly `type="button"`.** These sit inside forms throughout the app, and a delete icon that submits the form it is standing in loses work.

`Button` deliberately does *not* default its type, which would stop every button inside a form from submitting it — a behaviour change the classic component never made. There is a test for that.

## Verification

- 1365 tests pass (+23), coverage 86.23 / 82.56 / 77.93 — above the 85 / 80 / 76 floors.
- Typecheck clean across all four packages.
- `apps/desktop/src/ui` is untouched; the classic design still uses its own components, frozen until step 11.
- **Built CSS checked, not assumed.** Every utility the new components use, and all eight `data-size` rules, are in the emitted stylesheet. After #317 this is routine — and it nearly gave a false negative again, since the minifier writes `[data-size=xs]` without quotes.

## Notes for review

- The gallery guard from #317 required all four to be added with their states, including the disabled and invalid forms.
- `cx` is eleven lines rather than a `clsx` dependency, which would have been the kit's first.
- `IconComponent` is structural rather than lucide's `LucideIcon`, so the kit does not take a dependency on an icon set to describe a hole an icon goes in.

Part of #318.
