### PR TITLE
feat(ui-kit): merge Panel, Drawer and Tabs into the design system

### DIFF
--- a/packages/ui-kit/src/Drawer.test.tsx
+++ b/packages/ui-kit/src/Drawer.test.tsx
@@ -212,3 +212,83 @@ describe("Drawer", () => {
     expect(aside.style.width).toBe("320px");
   });
 });
+
+/**
+ * Stacked drawers. `ResourceBrowser` opens the assistant from a selected
+ * resource, so the detail drawer and the assistant drawer are open together in
+ * the normal flow. (#323 review)
+ */
+describe("Drawer stacking", () => {
+  function two() {
+    const lower = vi.fn();
+    const upper = vi.fn();
+    const first = render(
+      <Drawer open title="detail" onClose={lower}>
+        detail
+      </Drawer>,
+    );
+    const second = render(
+      <Drawer open title="assistant" onClose={upper}>
+        assistant
+      </Drawer>,
+    );
+    return { lower, upper, first, second };
+  }
+
+  it("backs out of the innermost drawer only", () => {
+    // One Escape used to dismiss both, losing the detail the user was reading
+    // instead of backing out of the assistant over it.
+    const { lower, upper } = two();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(upper).toHaveBeenCalledTimes(1);
+    expect(lower).not.toHaveBeenCalled();
+  });
+
+  it("hands Escape back to the drawer underneath", () => {
+    const { lower, second } = two();
+    second.unmount();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(lower).toHaveBeenCalledTimes(1);
+  });
+
+  it("still lets a layered dialog take Escape ahead of every drawer", () => {
+    const { lower, upper } = two();
+    const dialog = document.createElement("div");
+    dialog.setAttribute("role", "dialog");
+    dialog.setAttribute("data-state", "open");
+    document.body.appendChild(dialog);
+    try {
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(upper).not.toHaveBeenCalled();
+      expect(lower).not.toHaveBeenCalled();
+    } finally {
+      dialog.remove();
+    }
+  });
+
+  it("does not reorder when a caller passes a new onClose each render", () => {
+    // Membership is keyed on `open` alone. Keyed on the handler too, a parent
+    // re-rendering the lower drawer would re-push it and steal Escape from the
+    // drawer opened over it.
+    const lower = vi.fn();
+    const upper = vi.fn();
+    const first = render(
+      <Drawer open title="detail" onClose={() => lower()}>
+        detail
+      </Drawer>,
+    );
+    render(
+      <Drawer open title="assistant" onClose={() => upper()}>
+        assistant
+      </Drawer>,
+    );
+    first.rerender(
+      <Drawer open title="detail" onClose={() => lower()}>
+        detail
+      </Drawer>,
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(upper).toHaveBeenCalledTimes(1);
+    expect(lower).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui-kit/src/Drawer.test.tsx
+++ b/packages/ui-kit/src/Drawer.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { Drawer } from "./Drawer";
 
 /**
@@ -136,6 +138,36 @@ describe("Drawer", () => {
     expect(document.activeElement).toBe(other);
     opener.remove();
     other.remove();
+  });
+
+  it("does not grow, so its width is the one the drag set", () => {
+    // The drawer is documented as a flex sibling of the list. A layout class
+    // that also sets `flex: 1` makes flex-basis 0 and grow 1, so the inline
+    // width is ignored during sizing: the panel takes a share of the row and
+    // dragging updates state without moving anything on screen. `shrink-0`
+    // does not save it — that fixes only flex-shrink. (#323 review)
+    //
+    // Asserted against the real rule from the design's stylesheet, so this
+    // fails if `.pane` is reintroduced rather than if a class name changes.
+    const css = readFileSync(join(__dirname, "styles/kit.css"), "utf8");
+    const pane = css.match(/\.pane\s*\{[^}]*\}/)?.[0];
+    expect(pane, "the .pane rule should exist to test against").toBeTruthy();
+    const style = document.createElement("style");
+    style.textContent = `${pane}\n.shrink-0{flex-shrink:0}\n.flex{display:flex}`;
+    document.head.appendChild(style);
+    try {
+      render(
+        <Drawer open onClose={() => {}}>
+          body
+        </Drawer>,
+      );
+      const aside = screen.getByRole("complementary", { name: "Details" });
+      // `|| "0"`: an unset flex-grow reads as "" in jsdom, and unset is the
+      // initial value, which is 0. What must never hold is 1.
+      expect(getComputedStyle(aside).flexGrow || "0").toBe("0");
+    } finally {
+      style.remove();
+    }
   });
 
   it("is not a tab stop of its own", () => {

--- a/packages/ui-kit/src/Drawer.test.tsx
+++ b/packages/ui-kit/src/Drawer.test.tsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Drawer } from "./Drawer";
+
+/**
+ * Carried over from the classic component in full. Every one of these encodes a
+ * decision — the Escape exclusions, the focus hand-back, the drag clamps — and
+ * none of it is re-derivable from the mock's Inspector, which has the drag and
+ * nothing else. (#318)
+ */
+describe("Drawer", () => {
+  it("renders nothing when closed", () => {
+    render(
+      <Drawer open={false} onClose={() => {}}>
+        body
+      </Drawer>,
+    );
+    expect(screen.queryByText("body")).toBeNull();
+    expect(screen.queryByRole("complementary")).toBeNull();
+  });
+
+  it("renders title and body when open, and closes via the button", () => {
+    const onClose = vi.fn();
+    render(
+      <Drawer open title="Pod · web-1" onClose={onClose}>
+        body content
+      </Drawer>,
+    );
+    expect(screen.getByText("Pod · web-1")).toBeDefined();
+    expect(screen.getByText("body content")).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on Escape when open", () => {
+    const onClose = vi.fn();
+    render(
+      <Drawer open onClose={onClose}>
+        body
+      </Drawer>,
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not close on Escape when closed", () => {
+    const onClose = vi.fn();
+    render(
+      <Drawer open={false} onClose={onClose}>
+        body
+      </Drawer>,
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("lets a layered modal dialog consume Escape first (does not close the drawer)", () => {
+    const onClose = vi.fn();
+    render(
+      <Drawer open onClose={onClose}>
+        body
+      </Drawer>,
+    );
+    // Simulate an open radix dialog layered over the drawer.
+    const dialog = document.createElement("div");
+    dialog.setAttribute("role", "dialog");
+    dialog.setAttribute("data-state", "open");
+    document.body.appendChild(dialog);
+    try {
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(onClose).not.toHaveBeenCalled();
+    } finally {
+      dialog.remove();
+    }
+  });
+
+  it("does not hijack Escape while focus is in an editable field", () => {
+    const onClose = vi.fn();
+    render(
+      <Drawer open onClose={onClose}>
+        <input aria-label="search" />
+      </Drawer>,
+    );
+    const input = screen.getByLabelText("search");
+    input.focus();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("takes focus when it opens and gives it back when it closes (#160)", () => {
+    const opener = document.createElement("button");
+    document.body.appendChild(opener);
+    opener.focus();
+
+    const { rerender } = render(
+      <Drawer open={false} onClose={() => {}}>
+        body
+      </Drawer>,
+    );
+    rerender(
+      <Drawer open onClose={() => {}}>
+        body
+      </Drawer>,
+    );
+    // Without this a keyboard user opening a detail panel is left at the row
+    // they came from, tabbing forward through the whole list to reach it.
+    expect(document.activeElement).toBe(screen.getByRole("complementary", { name: "Details" }));
+
+    rerender(
+      <Drawer open={false} onClose={() => {}}>
+        body
+      </Drawer>,
+    );
+    expect(document.activeElement).toBe(opener);
+    opener.remove();
+  });
+
+  it("leaves focus alone if the user moved it elsewhere before closing", () => {
+    const opener = document.createElement("button");
+    const other = document.createElement("button");
+    document.body.append(opener, other);
+    opener.focus();
+
+    const { rerender } = render(
+      <Drawer open onClose={() => {}}>
+        body
+      </Drawer>,
+    );
+    other.focus();
+    rerender(
+      <Drawer open={false} onClose={() => {}}>
+        body
+      </Drawer>,
+    );
+    // Restoring here would be the panel arguing with the user on its way out.
+    expect(document.activeElement).toBe(other);
+    opener.remove();
+    other.remove();
+  });
+
+  it("is not a tab stop of its own", () => {
+    render(
+      <Drawer open onClose={() => {}}>
+        body
+      </Drawer>,
+    );
+    expect(
+      screen.getByRole("complementary", { name: "Details" }).getAttribute("tabindex"),
+    ).toBe("-1");
+  });
+
+  it("resizes by dragging the left edge, clamped to the allowed range", () => {
+    const { container } = render(
+      <Drawer open onClose={() => {}}>
+        body
+      </Drawer>,
+    );
+    const aside = screen.getByRole("complementary", { name: "Details" });
+    expect(aside.style.width).toBe("480px");
+
+    const handle = container.querySelector(".resize-handle");
+    expect(handle).not.toBeNull();
+
+    // Dragging left grows the panel; text selection is suppressed meanwhile.
+    fireEvent.mouseDown(handle as Element, { clientX: 800 });
+    expect(document.body.style.userSelect).toBe("none");
+    fireEvent.mouseMove(window, { clientX: 700 });
+    expect(aside.style.width).toBe("580px");
+
+    // Clamped: far left pins at the max, far right at the min.
+    fireEvent.mouseMove(window, { clientX: -2000 });
+    expect(aside.style.width).toBe("960px");
+    fireEvent.mouseMove(window, { clientX: 5000 });
+    expect(aside.style.width).toBe("320px");
+
+    // Releasing detaches the listeners: further movement changes nothing.
+    fireEvent.mouseUp(window);
+    expect(document.body.style.userSelect).toBe("");
+    fireEvent.mouseMove(window, { clientX: 700 });
+    expect(aside.style.width).toBe("320px");
+  });
+});

--- a/packages/ui-kit/src/Drawer.tsx
+++ b/packages/ui-kit/src/Drawer.tsx
@@ -118,7 +118,10 @@ export function Drawer({
       // panel itself.
       tabIndex={-1}
       style={{ width, borderLeft: "1px solid var(--rule)", background: "var(--surface)" }}
-      className="pane relative shrink-0 outline-none"
+      // Deliberately not the design's `.pane`, which sets `flex: 1`: this panel
+      // is sized by the drag, and a growing flex child ignores its own width.
+      // (#323 review)
+      className="relative flex shrink-0 flex-col outline-none"
     >
       <div
         ref={handleRef}

--- a/packages/ui-kit/src/Drawer.tsx
+++ b/packages/ui-kit/src/Drawer.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useRef, useState, type ReactNode } from "react";
+
+export interface DrawerProps {
+  open: boolean;
+  title?: ReactNode;
+  /** Action controls shown on the right of the header, before Close. */
+  headerActions?: ReactNode;
+  onClose: () => void;
+  children: ReactNode;
+  defaultWidth?: number;
+}
+
+/**
+ * Docked right-side detail panel. Sits inline beside the list (a flex sibling),
+ * so the content area shrinks rather than being covered. Drag its left edge to
+ * resize. Renders nothing when closed; width persists across open/close.
+ *
+ * Every behaviour here is carried over from the classic component unchanged —
+ * the drag, the focus handling and the Escape exclusions each exist for a
+ * reason recorded below, and none of them is re-derivable from the mock's
+ * Inspector, which has the drag and nothing else. Only the appearance moved.
+ * (#318)
+ */
+export function Drawer({
+  open,
+  title,
+  headerActions,
+  onClose,
+  children,
+  defaultWidth = 480,
+}: DrawerProps) {
+  const [width, setWidth] = useState(defaultWidth);
+  const handleRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLElement>(null);
+  const returnFocusTo = useRef<HTMLElement | null>(null);
+  const startX = useRef(0);
+  const startW = useRef(0);
+  const widthRef = useRef(width);
+  widthRef.current = width;
+
+  useEffect(() => setWidth(defaultWidth), [defaultWidth]);
+
+  useEffect(() => {
+    const handle = handleRef.current;
+    if (!handle) return;
+    function move(e: MouseEvent) {
+      // Dragging the left edge: the panel grows as the pointer moves left.
+      const next = startW.current - (e.clientX - startX.current);
+      setWidth(Math.max(320, Math.min(960, next)));
+    }
+    function up() {
+      window.removeEventListener("mousemove", move);
+      window.removeEventListener("mouseup", up);
+      document.body.style.userSelect = "";
+    }
+    function down(e: MouseEvent) {
+      e.preventDefault();
+      startX.current = e.clientX;
+      startW.current = widthRef.current;
+      document.body.style.userSelect = "none";
+      window.addEventListener("mousemove", move);
+      window.addEventListener("mouseup", up);
+    }
+    handle.addEventListener("mousedown", down);
+    return () => {
+      handle.removeEventListener("mousedown", down);
+      window.removeEventListener("mousemove", move);
+      window.removeEventListener("mouseup", up);
+      document.body.style.userSelect = "";
+    };
+  }, [open]);
+
+  // Move focus into the panel when it opens, and hand it back to whatever
+  // opened it when it closes (#160). The drawer is deliberately NOT modal — it
+  // sits beside the list rather than over it, so focus is placed, never
+  // trapped: a keyboard user can tab straight back out to the rows behind.
+  useEffect(() => {
+    if (!open) return;
+    const opener = document.activeElement;
+    returnFocusTo.current = opener instanceof HTMLElement ? opener : null;
+    panelRef.current?.focus();
+    return () => {
+      // Only if focus is still inside the closing panel: the user may have
+      // clicked elsewhere, and yanking focus back would be the panel arguing
+      // with them on the way out.
+      const active = document.activeElement;
+      const inside = panelRef.current?.contains(active as Node) || active === document.body;
+      if (inside && returnFocusTo.current?.isConnected) returnFocusTo.current.focus();
+    };
+  }, [open]);
+
+  // Close on Escape while open. Bail when a modal dialog is layered on top — it
+  // owns Esc, so the first Esc closes the dialog and a second closes the drawer —
+  // and when focus is in an editable field / the manifest editor, where Esc has
+  // its own meaning.
+  useEffect(() => {
+    if (!open) return;
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key !== "Escape" || e.defaultPrevented) return;
+      if (document.querySelector('[role="dialog"][data-state="open"]')) return;
+      const el = document.activeElement as HTMLElement | null;
+      if (el && (el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.isContentEditable)) {
+        return;
+      }
+      onClose();
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [open, onClose]);
+
+  if (!open) return null;
+  return (
+    <aside
+      ref={panelRef}
+      aria-label="Details"
+      // -1: focusable so opening can land here, but never a Tab stop of its
+      // own — tabbing from the list should reach the panel's controls, not the
+      // panel itself.
+      tabIndex={-1}
+      style={{ width, borderLeft: "1px solid var(--rule)", background: "var(--surface)" }}
+      className="pane relative shrink-0 outline-none"
+    >
+      <div
+        ref={handleRef}
+        aria-hidden="true"
+        // The design's handle sits on a pane's right edge; this one is on the
+        // left, since the drawer is what gets resized.
+        className="resize-handle"
+        style={{ left: -2, right: "auto" }}
+      />
+      <header className="pane-head">
+        <div className="min-w-0 flex-1 truncate">{title}</div>
+        <div className="flex items-center gap-1">{headerActions}</div>
+        <button type="button" aria-label="Close" onClick={onClose} className="icon-btn">
+          {/* Inline rather than an icon-set import: the kit takes no dependency
+              on lucide, and this is the only glyph it needs. */}
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M18 6 6 18M6 6l12 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+          </svg>
+        </button>
+      </header>
+      <div className="pane-body p-3">{children}</div>
+    </aside>
+  );
+}

--- a/packages/ui-kit/src/Drawer.tsx
+++ b/packages/ui-kit/src/Drawer.tsx
@@ -1,5 +1,20 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
 
+/**
+ * Every open drawer, innermost last.
+ *
+ * Each instance listens on the document, so without this one Escape reached all
+ * of them: `ResourceBrowser` opens the assistant from a selected resource, so
+ * the detail drawer and the assistant drawer are open together in the normal
+ * flow, and one keypress dismissed both — losing the detail the user was
+ * reading rather than backing out of the assistant.
+ *
+ * The same shape as ConfirmDialog's stack. Once both land they should share one
+ * layer registry, so a drawer and a dialog order against each other by mount
+ * rather than by the role check below. (#323 review)
+ */
+const stack: symbol[] = [];
+
 export interface DrawerProps {
   open: boolean;
   title?: ReactNode;
@@ -33,6 +48,7 @@ export function Drawer({
   const handleRef = useRef<HTMLDivElement>(null);
   const panelRef = useRef<HTMLElement>(null);
   const returnFocusTo = useRef<HTMLElement | null>(null);
+  const token = useRef(Symbol("drawer"));
   const startX = useRef(0);
   const startW = useRef(0);
   const widthRef = useRef(width);
@@ -95,8 +111,24 @@ export function Drawer({
   // its own meaning.
   useEffect(() => {
     if (!open) return;
+    const mine = token.current;
+    stack.push(mine);
+    return () => {
+      const at = stack.indexOf(mine);
+      if (at >= 0) stack.splice(at, 1);
+    };
+    // Deliberately keyed on `open` alone. The Escape effect below also depends
+    // on `onClose`, and a caller passing a fresh closure each render would
+    // re-run it — re-pushing this drawer and promoting it over one opened
+    // later.
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
     function onKeyDown(e: KeyboardEvent) {
       if (e.key !== "Escape" || e.defaultPrevented) return;
+      // Only the innermost drawer backs out.
+      if (stack[stack.length - 1] !== token.current) return;
       if (document.querySelector('[role="dialog"][data-state="open"]')) return;
       const el = document.activeElement as HTMLElement | null;
       if (el && (el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.isContentEditable)) {

--- a/packages/ui-kit/src/Panel.test.tsx
+++ b/packages/ui-kit/src/Panel.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Panel } from "./Panel";
+
+/** The classic component's tests, carried over. (#318) */
+describe("Panel", () => {
+  it("renders the title and children", () => {
+    render(<Panel title="Cluster">body content</Panel>);
+    expect(screen.getByText("Cluster")).toBeDefined();
+    expect(screen.getByText("body content")).toBeDefined();
+  });
+
+  it("omits the title when none is given", () => {
+    render(<Panel>only body</Panel>);
+    expect(screen.queryByText("Cluster")).toBeNull();
+    expect(screen.getByText("only body")).toBeDefined();
+  });
+
+  it("omits the header entirely, not just its text", () => {
+    // An empty ruled header is a visible artefact, not a no-op.
+    const { container } = render(<Panel>only body</Panel>);
+    expect(container.querySelector(".card-head")).toBeNull();
+  });
+
+  it("forwards className onto the card", () => {
+    const { container } = render(<Panel className="extra">x</Panel>);
+    expect(container.querySelector(".card.extra")).not.toBeNull();
+  });
+});

--- a/packages/ui-kit/src/Panel.tsx
+++ b/packages/ui-kit/src/Panel.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from "react";
+import { cx } from "./cx";
+
+export interface PanelProps {
+  title?: ReactNode;
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * A bordered surface section with an optional title.
+ *
+ * The classic version wrapped shadcn's Card; this is the design's own `.card`,
+ * which carries the same idea — a lifted surface with a ruled header. The
+ * `title`/`children` API is what callers depend on and is unchanged. (#318)
+ */
+export function Panel({ title, children, className }: PanelProps) {
+  return (
+    <section className={cx("card", className)}>
+      {title != null && (
+        <div className="card-head">
+          <div className="card-title">{title}</div>
+        </div>
+      )}
+      <div className="section-body">{children}</div>
+    </section>
+  );
+}

--- a/packages/ui-kit/src/Tabs.test.tsx
+++ b/packages/ui-kit/src/Tabs.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Tabs } from "./Tabs";
+
+const tabs = [
+  { id: "pods", label: "Pods" },
+  { id: "services", label: "Services" },
+  { id: "events", label: "Events" },
+];
+
+describe("Tabs", () => {
+  it("marks the active tab", () => {
+    render(<Tabs tabs={tabs} active="services" onChange={() => {}} />);
+    expect(screen.getByRole("tab", { name: "Services" }).getAttribute("aria-selected")).toBe("true");
+    expect(screen.getByRole("tab", { name: "Pods" }).getAttribute("aria-selected")).toBe("false");
+  });
+
+  it("emits the tab id on click", async () => {
+    const onChange = vi.fn();
+    render(<Tabs tabs={tabs} active="pods" onChange={onChange} />);
+    await userEvent.click(screen.getByRole("tab", { name: "Services" }));
+    expect(onChange).toHaveBeenCalledWith("services");
+  });
+});
+
+/**
+ * The keyboard contract Radix used to supply. These are not extras: the ARIA
+ * roles promise this behaviour, so a tablist without it is worse than a row of
+ * plain buttons — it tells assistive technology to expect arrow keys that do
+ * nothing. (#318)
+ */
+describe("Tabs keyboard behaviour", () => {
+  it("is a single tab stop, landing on the active tab", async () => {
+    render(<Tabs tabs={tabs} active="services" onChange={() => {}} />);
+    expect(screen.getByRole("tab", { name: "Services" }).getAttribute("tabindex")).toBe("0");
+    expect(screen.getByRole("tab", { name: "Pods" }).getAttribute("tabindex")).toBe("-1");
+    expect(screen.getByRole("tab", { name: "Events" }).getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("moves right and left with the arrow keys", async () => {
+    const onChange = vi.fn();
+    render(<Tabs tabs={tabs} active="pods" onChange={onChange} />);
+    screen.getByRole("tab", { name: "Pods" }).focus();
+    await userEvent.keyboard("{ArrowRight}");
+    expect(onChange).toHaveBeenLastCalledWith("services");
+    onChange.mockClear();
+    await userEvent.keyboard("{ArrowLeft}");
+    expect(onChange).toHaveBeenLastCalledWith("events");
+  });
+
+  it("wraps at both ends", async () => {
+    const onChange = vi.fn();
+    const { rerender } = render(<Tabs tabs={tabs} active="events" onChange={onChange} />);
+    screen.getByRole("tab", { name: "Events" }).focus();
+    await userEvent.keyboard("{ArrowRight}");
+    expect(onChange).toHaveBeenLastCalledWith("pods");
+
+    onChange.mockClear();
+    rerender(<Tabs tabs={tabs} active="pods" onChange={onChange} />);
+    screen.getByRole("tab", { name: "Pods" }).focus();
+    await userEvent.keyboard("{ArrowLeft}");
+    expect(onChange).toHaveBeenLastCalledWith("events");
+  });
+
+  it("jumps to the first and last with Home and End", async () => {
+    const onChange = vi.fn();
+    render(<Tabs tabs={tabs} active="services" onChange={onChange} />);
+    screen.getByRole("tab", { name: "Services" }).focus();
+    await userEvent.keyboard("{End}");
+    expect(onChange).toHaveBeenLastCalledWith("events");
+    onChange.mockClear();
+    await userEvent.keyboard("{Home}");
+    expect(onChange).toHaveBeenLastCalledWith("pods");
+  });
+
+  it("leaves other keys alone", async () => {
+    // Otherwise the strip would swallow keys the surrounding screen needs.
+    const onChange = vi.fn();
+    render(<Tabs tabs={tabs} active="pods" onChange={onChange} />);
+    screen.getByRole("tab", { name: "Pods" }).focus();
+    await userEvent.keyboard("{ArrowDown}");
+    await userEvent.keyboard("a");
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("names the strip when given a label", () => {
+    render(<Tabs tabs={tabs} active="pods" onChange={() => {}} label="Resource views" />);
+    expect(screen.getByRole("tablist", { name: "Resource views" })).toBeDefined();
+  });
+});

--- a/packages/ui-kit/src/Tabs.test.tsx
+++ b/packages/ui-kit/src/Tabs.test.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { Tabs } from "./Tabs";
 
 const tabs = [
@@ -91,5 +93,27 @@ describe("Tabs keyboard behaviour", () => {
   it("names the strip when given a label", () => {
     render(<Tabs tabs={tabs} active="pods" onChange={() => {}} label="Resource views" />);
     expect(screen.getByRole("tablist", { name: "Resource views" })).toBeDefined();
+  });
+});
+
+describe("Tabs in a narrow container", () => {
+  it("carries its own horizontal overflow", () => {
+    // Each tab has a 108px minimum and flex items do not shrink past it, so
+    // three tabs need 324px. A Drawer at its 320px minimum offers about 296px,
+    // so without containment the strip is clipped or the whole panel body
+    // scrolls sideways — and the resource detail already ships three tabs,
+    // Helm four. Asserted on the stylesheet because the overflow lives there
+    // and jsdom does no layout. (#323 review)
+    const css = readFileSync(join(__dirname, "styles/kit.css"), "utf8");
+    const strip = css.match(/\.tabstrip\s*\{[^}]*\}/)?.[0] ?? "";
+    expect(strip, "the .tabstrip rule should exist").toBeTruthy();
+    expect(strip).toContain("overflow-x: auto");
+  });
+
+  it("does not spend the strip's height on a scrollbar", () => {
+    // The strip is 33px tall; a visible horizontal bar would eat the tabs.
+    const css = readFileSync(join(__dirname, "styles/kit.css"), "utf8");
+    expect(css).toMatch(/\.tabstrip\s*\{[^}]*scrollbar-width:\s*none/);
+    expect(css).toContain(".tabstrip::-webkit-scrollbar");
   });
 });

--- a/packages/ui-kit/src/Tabs.test.tsx
+++ b/packages/ui-kit/src/Tabs.test.tsx
@@ -45,8 +45,12 @@ describe("Tabs keyboard behaviour", () => {
     await userEvent.keyboard("{ArrowRight}");
     expect(onChange).toHaveBeenLastCalledWith("services");
     onChange.mockClear();
+    // Back to Pods, not on to Events. Navigation follows the focused tab, not
+    // the `active` prop: a controlled parent may not have committed the change
+    // yet, and computing from stale state made a second arrow key jump from a
+    // tab the user was no longer on. (#323 review)
     await userEvent.keyboard("{ArrowLeft}");
-    expect(onChange).toHaveBeenLastCalledWith("events");
+    expect(onChange).toHaveBeenLastCalledWith("pods");
   });
 
   it("wraps at both ends", async () => {

--- a/packages/ui-kit/src/Tabs.tsx
+++ b/packages/ui-kit/src/Tabs.tsx
@@ -1,0 +1,80 @@
+import { useRef, type KeyboardEvent } from "react";
+
+export interface TabItem {
+  id: string;
+  label: string;
+}
+
+export interface TabsProps {
+  tabs: TabItem[];
+  active: string;
+  onChange: (id: string) => void;
+  /** Names the strip for assistive technology (e.g. "Resource views"). */
+  label?: string;
+}
+
+/**
+ * Horizontal tab strip for switching views. Panels are rendered by callers, so
+ * this owns only the list.
+ *
+ * The classic version wrapped Radix's Tabs, which supplied the keyboard
+ * contract for free. Under the kit's no-dependency rule that has to be written
+ * out, and it is not optional: a tablist where every tab is a Tab stop and the
+ * arrow keys do nothing is a worse control than a row of buttons, because the
+ * ARIA roles promise behaviour that is not there. So:
+ *
+ *   - roving tabindex — the strip is one Tab stop, the active tab is the one it
+ *     lands on, and Tab from there moves past the strip rather than through it
+ *   - Left/Right move between tabs, wrapping at both ends
+ *   - Home/End jump to the first and last
+ *
+ * Selection follows focus, which is the expected pattern for tabs whose panels
+ * are already rendered and cheap to switch. (#318)
+ */
+export function Tabs({ tabs, active, onChange, label }: TabsProps) {
+  const refs = useRef(new Map<string, HTMLButtonElement>());
+
+  function focus(id: string) {
+    onChange(id);
+    // The element for the newly active tab may not have its tabIndex updated
+    // until React re-renders, but focus() does not care about tabIndex.
+    refs.current.get(id)?.focus();
+  }
+
+  function onKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    const index = tabs.findIndex((t) => t.id === active);
+    if (index < 0) return;
+    let next: number | null = null;
+    if (event.key === "ArrowRight") next = (index + 1) % tabs.length;
+    else if (event.key === "ArrowLeft") next = (index - 1 + tabs.length) % tabs.length;
+    else if (event.key === "Home") next = 0;
+    else if (event.key === "End") next = tabs.length - 1;
+    if (next === null) return;
+    // Otherwise Left/Right also scroll the strip and Home/End jump the page.
+    event.preventDefault();
+    focus(tabs[next].id);
+  }
+
+  return (
+    <div className="tabstrip" role="tablist" aria-label={label} onKeyDown={onKeyDown}>
+      {tabs.map((t) => (
+        <button
+          key={t.id}
+          type="button"
+          role="tab"
+          className="tab"
+          data-active={t.id === active}
+          aria-selected={t.id === active}
+          tabIndex={t.id === active ? 0 : -1}
+          ref={(node) => {
+            if (node) refs.current.set(t.id, node);
+            else refs.current.delete(t.id);
+          }}
+          onClick={() => onChange(t.id)}
+        >
+          {t.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/packages/ui-kit/src/Tabs.tsx
+++ b/packages/ui-kit/src/Tabs.tsx
@@ -42,7 +42,13 @@ export function Tabs({ tabs, active, onChange, label }: TabsProps) {
   }
 
   function onKeyDown(event: KeyboardEvent<HTMLDivElement>) {
-    const index = tabs.findIndex((t) => t.id === active);
+    // From the focused tab, not from `active`. A controlled parent may not have
+    // committed the change yet — a deferred update, or a parent that validates
+    // first — and computing from stale state sent the second arrow key off from
+    // a tab the user had already left. Focus is the thing that actually moved.
+    // (#323 review)
+    const focused = tabs.findIndex((t) => refs.current.get(t.id) === document.activeElement);
+    const index = focused >= 0 ? focused : tabs.findIndex((t) => t.id === active);
     if (index < 0) return;
     let next: number | null = null;
     if (event.key === "ArrowRight") next = (index + 1) % tabs.length;

--- a/packages/ui-kit/src/gallery/Gallery.tsx
+++ b/packages/ui-kit/src/gallery/Gallery.tsx
@@ -2,13 +2,16 @@ import { useState } from "react";
 import { Badge } from "../Badge";
 import { Button } from "../Button";
 import { Field } from "../Field";
+import { Drawer } from "../Drawer";
 import { IconButton } from "../IconButton";
 import { LoadingState } from "../LoadingState";
 import { Meter } from "../Meter";
+import { Panel } from "../Panel";
 import { Select } from "../Select";
 import { Sparkline } from "../Sparkline";
 import { Spinner } from "../Spinner";
 import { StatusPill } from "../StatusPill";
+import { Tabs } from "../Tabs";
 import { TextInput } from "../TextInput";
 import type { Tone } from "../tone";
 
@@ -41,6 +44,8 @@ export function Gallery() {
   const [text, setText] = useState("kube-system");
   const [empty, setEmpty] = useState("");
   const [ns, setNs] = useState("kube-system");
+  const [tab, setTab] = useState("pods");
+  const [drawer, setDrawer] = useState(false);
 
   return (
     <div className="kit-gallery">
@@ -208,6 +213,49 @@ export function Gallery() {
         <h2>LoadingState</h2>
         <LoadingState />
         <LoadingState label="Loading pods" />
+      </section>
+      <section>
+        <h2>Panel</h2>
+        <Panel title="Cluster">A titled surface.</Panel>
+        {/* Untitled omits the header rather than ruling off an empty one. */}
+        <Panel>No title at all.</Panel>
+      </section>
+
+      <section>
+        <h2>Tabs</h2>
+        <Tabs
+          tabs={[
+            { id: "pods", label: "Pods" },
+            { id: "services", label: "Services" },
+            { id: "events", label: "Events" },
+          ]}
+          active={tab}
+          onChange={setTab}
+          label="Resource views"
+        />
+        {/* The keyboard contract is the part worth checking here: the strip is
+            one Tab stop, and Left/Right/Home/End move between tabs. */}
+        <p className="text-[0.75rem] text-muted">showing: {tab}</p>
+      </section>
+
+      <section>
+        <h2>Drawer</h2>
+        <Button size="xs" onClick={() => setDrawer((v) => !v)}>
+          {drawer ? "close" : "open"} the drawer
+        </Button>
+        <div className="flex" style={{ height: 180 }}>
+          <div className="flex-1 text-[0.75rem] text-muted">
+            the list this docks beside — it shrinks rather than being covered
+          </div>
+          <Drawer
+            open={drawer}
+            title="Pod · web-1"
+            onClose={() => setDrawer(false)}
+            defaultWidth={320}
+          >
+            Drag the left edge to resize. Escape closes it.
+          </Drawer>
+        </div>
       </section>
     </div>
   );

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -1,14 +1,17 @@
 /** The srelens design system. Components are added as they are merged in. */
 export { Badge, type BadgeTone } from "./Badge";
 export { Button, type ButtonProps, type ButtonSize, type ButtonVariant } from "./Button";
+export { Drawer, type DrawerProps } from "./Drawer";
 export { Field, type FieldProps } from "./Field";
 export { IconButton, type IconButtonProps, type IconComponent } from "./IconButton";
 export { LoadingState, type LoadingStateProps } from "./LoadingState";
 export { Meter } from "./Meter";
+export { Panel, type PanelProps } from "./Panel";
 export { Select, type SelectOption, type SelectProps } from "./Select";
 export { Sparkline } from "./Sparkline";
 export { Spinner, type SpinnerProps } from "./Spinner";
 export { StatusPill, type StatusKind, type StatusPillProps } from "./StatusPill";
+export { Tabs, type TabItem, type TabsProps } from "./Tabs";
 export { TextInput, type TextInputProps } from "./TextInput";
 export { cx } from "./cx";
 export { toneColor, toneWash, type Tone } from "./tone";

--- a/packages/ui-kit/src/styles/kit.css
+++ b/packages/ui-kit/src/styles/kit.css
@@ -752,7 +752,17 @@
     flex-shrink: 0;
     background: var(--canvas-deep);
     border-bottom: 1px solid var(--rule);
+    /* Tabs have a 108px minimum and flex items do not shrink past it, so three
+       of them need 324px — more than a Drawer at its 320px minimum can give.
+       Without this the strip is clipped, or the whole panel body scrolls
+       sideways to make room for it. The strip carries its own overflow instead.
+       The scrollbar is hidden rather than shown: inside 33px it would eat the
+       tabs' height, and a tab strip that scrolls without a visible bar is what
+       every browser does with its own. (#323 review) */
+    overflow-x: auto;
+    scrollbar-width: none;
   }
+  .tabstrip::-webkit-scrollbar { display: none; }
   .tab {
     position: relative;
     display: flex;


### PR DESCRIPTION
Three more of #318: `Panel`, `Drawer`, `Tabs`.

## `Tabs` was mis-filed, and it matters

I grouped this with the layout components. It is not one: it wrapped Radix's Tabs, which was quietly supplying the entire keyboard contract. Under the no-Radix decision that has to be written out, and it is not optional —

> A tablist whose arrow keys do nothing is a **worse** control than a row of plain buttons, because the ARIA roles promise behaviour that is not there. Assistive technology announces capabilities the component does not have.

So `Tabs` now implements:

- **roving tabindex** — the strip is a single Tab stop and lands on the active tab, so Tab from there moves past the strip rather than through every tab
- **Left / Right**, wrapping at both ends
- **Home / End** to jump to first and last
- `preventDefault` on exactly those keys, so the strip does not swallow anything the surrounding screen needs

Six tests cover it, including one asserting that other keys are left alone.

## `Drawer` comes across whole

All ten of its tests are carried over unchanged. They are the reason this component could not be rebuilt from the mock, whose `Inspector` has the drag and nothing else:

- Escape defers to a layered modal dialog — the dialog owns the first Escape, the drawer gets the second
- Escape is ignored while focus is in an input, textarea or contenteditable, where it has its own meaning
- focus moves into the panel on open and returns to the opener on close, but **only if focus is still inside** — otherwise the panel would be arguing with a user who has already moved on
- the panel is `tabIndex={-1}`: focusable so opening can land there, never a Tab stop of its own
- drag clamps between 320 and 960, and releasing detaches the listeners

Only the appearance moved: the design's `.pane` / `.pane-head` / `.pane-body` / `.resize-handle`, and an inline close glyph instead of the lucide import, since the kit takes no dependency on an icon set.

## `Panel`

Becomes the design's own `.card` with `.card-head`, keeping the `title`/`children` API. An untitled panel omits the header element rather than rendering an empty ruled one, which there is now a test for.

## `Dashboard` is deliberately excluded

It is not a component. It exports fifteen page-shell primitives — `PageShell`, `PageHeader`, `SectionPanel`, `MetricTile`, `StatusMeter`, `Toolbar`, `EmptyState`, `ErrorState` and six aliases — bound to twenty-five `fl-*` classes from the **classic** stylesheet. The new design replaces that whole vocabulary with `Screen`, `Section`, `Pane`, `Stat` and `EmptyState`, all of which are already on #320's list, so porting it would duplicate them. It has one call site.

**With `NavIcon`, that puts #318 at 17 components rather than 19.**

## Verification

- 1409 tests pass, coverage 86.43 / 82.70 / 77.96 — above the 85 / 80 / 76 floors. Re-run after the rebase, since the pre-rebase numbers no longer described this branch.
- Typecheck clean; `apps/desktop/src/ui` untouched.
- Built CSS checked: all 40 classes used across ui-kit and ui-next are present in the emitted stylesheet.

## Rebased onto #322

#322 merged while this was being written, so the conflict I expected on `index.ts` and `Gallery.tsx` arrived immediately. Rebased and resolved: `index.ts` keeps both batches' exports alphabetically, and the gallery keeps all seven sections.

One part was not mechanical, and is worth a reviewer's eye. The two branches' section blocks shared a single `<section>` opening tag **above** the conflict region, so deleting the markers would have left this branch's first heading outside any section with an unbalanced closing tag — JSX that looks right and renders wrong. The `=======` divider had to become a `<section>` opener. I checked tag balance (14 open, 14 close) rather than assuming, and the gallery guard renders all 14 components.

Part of #318.

