### PR TITLE
feat(ui-kit): merge the last five components, and keep the editor out of the service layer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,16 @@
 name: CI
 
-# Run the test suites on every push/PR to dev or main so nothing lands red.
+# Run the test suites on every push/PR to a shared branch so nothing lands red.
+#
+# `feat/ui-next` is one of those: the new-design migration merges there rather
+# than into dev until it lands, and a branch missing from this list gets no CI
+# at all — not a red check, no checks, which GitHub reports as mergeable. PR
+# #326 was opened against it and sat green with zero checks having run. (#318)
 on:
   push:
-    branches: [dev, main]
+    branches: [dev, main, feat/ui-next]
   pull_request:
-    branches: [dev, main]
+    branches: [dev, main, feat/ui-next]
 
 # Pull requests share a per-ref group and cancel each other: a superseded run
 # tests a commit nobody will merge, so killing it saves minutes and loses

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -31,6 +31,17 @@
     "vitest": "^3.2.7"
   },
   "dependencies": {
-    "radix-ui": "^1.6.0"
+    "@codemirror/autocomplete": "^6.20.3",
+    "@codemirror/commands": "^6.10.4",
+    "@codemirror/lang-yaml": "^6.1.3",
+    "@codemirror/language": "^6.12.4",
+    "@codemirror/lint": "^6.9.7",
+    "@codemirror/search": "^6.7.1",
+    "@codemirror/state": "^6.7.0",
+    "@codemirror/view": "^6.43.4",
+    "@lezer/highlight": "^1.2.3",
+    "cmdk": "^1.1.1",
+    "radix-ui": "^1.6.0",
+    "yaml": "^2.9.0"
   }
 }

--- a/packages/ui-kit/src/CodeEditor.lint.test.ts
+++ b/packages/ui-kit/src/CodeEditor.lint.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import { yamlDiagnostics, documentDiagnostics } from "./CodeEditor";
+
+/**
+ * The two pure functions behind the editor's linting, carried over from the
+ * classic component with `k8sDiagnostics` renamed. What it does is map
+ * document-indexed messages onto ranges in a multi-document YAML file, which is
+ * not a Kubernetes idea — and the kit does not carry the product's vocabulary,
+ * the same call already made for NavIcon's resource map. (#318)
+ */
+describe("yamlDiagnostics", () => {
+  it("returns no diagnostics for valid YAML", () => {
+    const yaml = "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: my-app\n";
+    expect(yamlDiagnostics(yaml)).toHaveLength(0);
+  });
+
+  it("returns none for empty/whitespace input", () => {
+    expect(yamlDiagnostics("")).toHaveLength(0);
+    expect(yamlDiagnostics("   \n  ")).toHaveLength(0);
+  });
+
+  it("flags a YAML syntax error with a position and message", () => {
+    // Nested mapping in a compact/inline position is invalid YAML.
+    const bad = "spec:\n  foo: bar: baz\n";
+    const diags = yamlDiagnostics(bad);
+    expect(diags.length).toBeGreaterThan(0);
+    expect(diags[0].severity).toBe("error");
+    expect(diags[0].to).toBeGreaterThan(diags[0].from);
+    expect(typeof diags[0].message).toBe("string");
+  });
+
+  it("flags an unterminated flow sequence", () => {
+    const diags = yamlDiagnostics("ports: [80, 443\n");
+    expect(diags.some((d) => d.severity === "error")).toBe(true);
+  });
+
+  it("returns no diagnostics for a valid two-document manifest", () => {
+    const doc1 = "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: my-app\n";
+    const doc2 = "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: my-app-2\n";
+    const twoDoc = `${doc1}---\n${doc2}`;
+    expect(yamlDiagnostics(twoDoc)).toHaveLength(0);
+  });
+
+  it("locates a syntax error in the SECOND document of a multi-doc manifest", () => {
+    const doc1 = "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: my-app\n";
+    const separator = "---\n";
+    const badDoc2 = "spec:\n  foo: bar: baz\n";
+    const twoDoc = `${doc1}${separator}${badDoc2}`;
+    const secondDocOffset = doc1.length + separator.length;
+    const diags = yamlDiagnostics(twoDoc);
+    expect(diags.length).toBeGreaterThan(0);
+    expect(diags[0].severity).toBe("error");
+    // The offending line lives inside the second document, not at/before the `---`.
+    expect(diags[0].from).toBeGreaterThanOrEqual(secondDocOffset);
+  });
+});
+
+const manifest = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  replicas: -1
+  foo: bar
+`;
+
+describe("documentDiagnostics (server validation → editor positions)", () => {
+  it("positions an unknown-field error at that field in the YAML", () => {
+    const diags = documentDiagnostics(manifest, [{ docIndex: 0, message: 'strict decoding error: unknown field "spec.foo"' }]);
+    expect(diags).toHaveLength(1);
+    // The range should cover the `foo: bar` value, not the top of the doc.
+    const at = manifest.indexOf("bar");
+    expect(diags[0].from).toBeLessThanOrEqual(at);
+    expect(diags[0].to).toBeGreaterThanOrEqual(at);
+    expect(diags[0].message).toContain("unknown field");
+  });
+
+  it("positions an invalid-value error at the offending field", () => {
+    const diags = documentDiagnostics(manifest, [
+      { docIndex: 0, message: 'Deployment.apps "my-app" is invalid: spec.replicas: Invalid value: -1: must be >= 0' },
+    ]);
+    expect(diags).toHaveLength(1);
+    const at = manifest.indexOf("-1");
+    expect(diags[0].from).toBeLessThanOrEqual(at);
+    expect(diags[0].to).toBeGreaterThanOrEqual(at);
+  });
+
+  it("falls back to the top of the document when no field can be located", () => {
+    const diags = documentDiagnostics(manifest, [{ docIndex: 0, message: "admission webhook denied the request" }]);
+    expect(diags).toHaveLength(1);
+    expect(diags[0].from).toBe(0);
+    expect(diags[0].message).toContain("admission webhook");
+  });
+
+  it("returns nothing for no messages or empty text", () => {
+    expect(documentDiagnostics(manifest, [])).toHaveLength(0);
+    expect(documentDiagnostics("", [{ docIndex: 0, message: "some error" }])).toHaveLength(0);
+  });
+
+  it("maps a field that exists only in the SECOND document to a range inside it", () => {
+    const doc1 = "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: my-app\nspec:\n  replicas: 1\n";
+    const separator = "---\n";
+    const doc2 = "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: my-app-2\nspec:\n  replicas: 1\n  foo: bar\n";
+    const twoDoc = `${doc1}${separator}${doc2}`;
+    const separatorOffset = doc1.length;
+    const diags = documentDiagnostics(twoDoc, [{ docIndex: 1, message: 'strict decoding error: unknown field "spec.foo"' }]);
+    expect(diags).toHaveLength(1);
+    expect(diags[0].from).toBeGreaterThan(separatorOffset);
+    const at = twoDoc.indexOf("bar");
+    expect(diags[0].from).toBeLessThanOrEqual(at);
+    expect(diags[0].to).toBeGreaterThanOrEqual(at);
+  });
+
+  it("uses docIndex to target the SECOND document when the field exists in BOTH", () => {
+    // `spec.replicas` is present in BOTH documents. An error tagged docIndex:1
+    // must land in the SECOND document, not the first — a first-match-wins
+    // implementation would wrongly point at doc 1's replicas.
+    const doc1 = "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: my-app\nspec:\n  replicas: 1\n";
+    const separator = "---\n";
+    const doc2 = "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: my-app-2\nspec:\n  replicas: 2\n";
+    const twoDoc = `${doc1}${separator}${doc2}`;
+    const separatorOffset = doc1.length;
+    const diags = documentDiagnostics(twoDoc, [
+      { docIndex: 1, message: 'Deployment.apps "my-app-2" is invalid: spec.replicas: Invalid value: 2: bad' },
+    ]);
+    expect(diags).toHaveLength(1);
+    // Must point into the SECOND document (past the `---`), i.e. at doc2's replicas.
+    expect(diags[0].from).toBeGreaterThan(separatorOffset);
+    const secondReplicas = twoDoc.indexOf("replicas: 2");
+    expect(diags[0].from).toBeGreaterThanOrEqual(secondReplicas);
+  });
+});

--- a/packages/ui-kit/src/CodeEditor.test.tsx
+++ b/packages/ui-kit/src/CodeEditor.test.tsx
@@ -47,4 +47,30 @@ describe("CodeEditor", () => {
     const { container } = render(<CodeEditor value="a: 1" fill minHeight={100} maxHeight={400} />);
     expect(container.querySelector(".cm-editor")).not.toBeNull();
   });
+  it("does not report a prop-driven value change as a user edit", () => {
+    // Reset and reload replace the document from outside. The dispatch that
+    // does it changes the doc, so an unconditional listener reports it as
+    // typing — marking a form dirty, or invalidating a preview, on a change
+    // the caller made itself. (#326 review)
+    const onChange = vi.fn();
+    const { rerender } = render(<CodeEditor value="a: 1" onChange={onChange} />);
+    rerender(<CodeEditor value="b: 2" onChange={onChange} />);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("re-lints when the validator changes, without waiting for an edit", async () => {
+    // Switching cluster context swaps the validator while the same document
+    // stays mounted. Updating the ref alone schedules nothing, so the previous
+    // validator's diagnostics sit there until someone types. (#326 review)
+    const first = vi.fn(async () => []);
+    const second = vi.fn(async () => []);
+    const { rerender } = render(<CodeEditor value="a: 1" schemaValidate={first} />);
+    // Let the document settle on the first validator. Without this the swap
+    // happens before the debounced first lint ever runs, and the test passes
+    // whether or not anything re-lints.
+    await vi.waitFor(() => expect(first).toHaveBeenCalled(), { timeout: 3000 });
+
+    rerender(<CodeEditor value="a: 1" schemaValidate={second} />);
+    await vi.waitFor(() => expect(second).toHaveBeenCalled(), { timeout: 3000 });
+  });
 });

--- a/packages/ui-kit/src/CodeEditor.test.tsx
+++ b/packages/ui-kit/src/CodeEditor.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { CodeEditor } from "./CodeEditor";
+
+describe("CodeEditor", () => {
+  it("mounts a CodeMirror editor showing the initial value", () => {
+    const { container } = render(<CodeEditor value="kind: Pod" ariaLabel="Manifest YAML" />);
+    expect(container.querySelector(".cm-editor")).not.toBeNull();
+    expect(container.querySelector(".cm-content")?.textContent).toContain("kind: Pod");
+    // The label goes on the editable content, which is what a screen reader
+    // lands on — not on the wrapper.
+    expect(container.querySelector('[aria-label="Manifest YAML"]')).not.toBeNull();
+  });
+
+  it("does not call onChange while read-only", () => {
+    const onChange = vi.fn();
+    const { container } = render(<CodeEditor value="a: 1" readOnly onChange={onChange} />);
+    expect(container.querySelector(".cm-editor")).not.toBeNull();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("pushes an external value change into the editor", () => {
+    // Reset and reload replace the document from outside; the editor is
+    // mounted imperatively, so this is the one direction that needs wiring.
+    const { container, rerender } = render(<CodeEditor value="a: 1" />);
+    rerender(<CodeEditor value="b: 2" />);
+    expect(container.querySelector(".cm-content")?.textContent).toContain("b: 2");
+  });
+
+  it("takes completions as an injected source, knowing nothing of what they mean", () => {
+    // The classic editor resolved Kubernetes schemas itself, importing four
+    // helpers and a type from @srelens/core. The kit may not: `tokens-only`
+    // forbids the service layer, and a design system has no business knowing
+    // what an apiVersion is. The caller supplies a CodeMirror completion
+    // source and keeps that knowledge. (#318)
+    const completions = vi.fn(() => null);
+    const { container } = render(<CodeEditor value="a: 1" completions={completions} />);
+    expect(container.querySelector(".cm-editor")).not.toBeNull();
+  });
+
+  it("accepts the sizing options without recreating itself into a broken state", () => {
+    // What `fill`, `minHeight` and `maxHeight` actually do is not assertable
+    // here: CodeMirror compiles a theme into a generated stylesheet with
+    // hashed class names rather than inline styles, and jsdom applies no CSS.
+    // Said plainly rather than asserting on a generated class name, which
+    // would pin CodeMirror's internals and still prove nothing about layout.
+    const { container } = render(<CodeEditor value="a: 1" fill minHeight={100} maxHeight={400} />);
+    expect(container.querySelector(".cm-editor")).not.toBeNull();
+  });
+});

--- a/packages/ui-kit/src/CodeEditor.tsx
+++ b/packages/ui-kit/src/CodeEditor.tsx
@@ -1,0 +1,365 @@
+import { useEffect, useRef } from "react";
+import { EditorState } from "@codemirror/state";
+import {
+  EditorView,
+  keymap,
+  lineNumbers,
+  highlightActiveLine,
+  highlightActiveLineGutter,
+  drawSelection,
+  dropCursor,
+} from "@codemirror/view";
+import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirror/commands";
+import {
+  syntaxHighlighting,
+  HighlightStyle,
+  indentOnInput,
+  bracketMatching,
+  foldGutter,
+  foldKeymap,
+} from "@codemirror/language";
+import { highlightSelectionMatches, searchKeymap } from "@codemirror/search";
+import { yaml } from "@codemirror/lang-yaml";
+import { linter, lintGutter, type Diagnostic } from "@codemirror/lint";
+import { autocompletion, completionKeymap, type CompletionSource } from "@codemirror/autocomplete";
+import { parseAllDocuments } from "yaml";
+import { tags as t } from "@lezer/highlight";
+
+/**
+ * Parse YAML (one or more `---`-separated documents) and return syntax
+ * errors/warnings across ALL documents as diagnostics. The `yaml` package
+ * reports absolute offsets into the full source, so ranges from later
+ * documents still land correctly without any per-document adjustment.
+ * Pure + tested.
+ */
+export function yamlDiagnostics(text: string): Diagnostic[] {
+  const len = text.length;
+  if (!text.trim()) return [];
+  const clamp = (n: number) => Math.max(0, Math.min(n, len));
+  try {
+    const docs = parseAllDocuments(text, { prettyErrors: false });
+    const asDiag = (issue: { pos?: [number, number, number?]; message: string }, severity: "error" | "warning"): Diagnostic => {
+      const [from, to] = issue.pos ?? [0, 1];
+      return { from: clamp(from), to: Math.max(clamp(to), clamp(from) + 1), severity, message: issue.message };
+    };
+    const diagnostics: Diagnostic[] = [];
+    for (const doc of docs) {
+      diagnostics.push(...doc.errors.map((e) => asDiag(e, "error")));
+      diagnostics.push(...doc.warnings.map((w) => asDiag(w, "warning")));
+    }
+    return diagnostics;
+  } catch (e) {
+    return [{ from: 0, to: len, severity: "error", message: String(e) }];
+  }
+}
+
+/** Split a dotted field path ("spec.template.spec.containers[0].image") into
+ *  getIn segments (["spec","template",…,"containers",0,"image"]). */
+function fieldSegments(path: string): (string | number)[] {
+  const segs: (string | number)[] = [];
+  for (const part of path.split(".")) {
+    const name = part.replace(/\[\d+\]/g, "");
+    if (name) segs.push(name);
+    for (const m of part.matchAll(/\[(\d+)\]/g)) segs.push(Number(m[1]));
+  }
+  return segs;
+}
+
+/** Field paths mentioned in a validation message (unknown field / invalid value). */
+function extractFieldPaths(message: string): string[] {
+  const paths = new Set<string>();
+  for (const m of message.matchAll(/unknown field "([^"]+)"/g)) paths.add(m[1]);
+  for (const m of message.matchAll(
+    /\b([a-zA-Z_][\w-]*(?:\.[\w-]+|\[\d+\])*)\s*:\s*(?:Invalid value|Required value|Unsupported value|Forbidden|Duplicate value|Too long)/g,
+  )) {
+    paths.add(m[1]);
+  }
+  return [...paths];
+}
+
+/**
+ * Map document-indexed validation messages onto editor ranges. Positions each
+ * message at the offending field when it can be located in the YAML, else at
+ * the top of the document — so the error is always shown. Pure + tested.
+ *
+ * Called `k8sDiagnostics` in the classic component, which named the caller
+ * rather than the work: whoever produced the messages, this locates a field
+ * path inside a multi-document YAML file. The kit does not carry the product's
+ * vocabulary — the same call made for NavIcon's resource map. (#318)
+ */
+export function documentDiagnostics(text: string, errors: Array<{ docIndex: number; message: string }>): Diagnostic[] {
+  if (!errors.length || !text.trim()) return [];
+  const len = text.length;
+  const clamp = (n: number) => Math.max(0, Math.min(n, len));
+  let docs: ReturnType<typeof parseAllDocuments> = [];
+  try {
+    // Match the backend's split (which skips empty documents) so docIndex aligns.
+    // Cast: `.filter()` widens the yaml package's generic Document union in a
+    // way `docs`'s ReturnType<typeof parseAllDocuments> annotation doesn't
+    // structurally match, even though every filtered element is still one of
+    // the same Document instances `parseAllDocuments` produced.
+    docs = parseAllDocuments(text).filter((d) => d.contents != null) as typeof docs;
+  } catch {
+    docs = [];
+  }
+  const diagnostics: Diagnostic[] = [];
+  for (const { docIndex, message } of errors) {
+    const doc = docs[docIndex];
+    const ranges = doc
+      ? extractFieldPaths(message)
+          .map((p) => {
+            const node = doc.getIn(fieldSegments(p), true) as { range?: [number, number] } | undefined;
+            return node?.range ? ([node.range[0], node.range[1]] as [number, number]) : null;
+          })
+          .filter((r): r is [number, number] => !!r)
+      : [];
+    if (ranges.length) {
+      for (const [from, to] of ranges) {
+        diagnostics.push({ from: clamp(from), to: Math.max(clamp(to), clamp(from) + 1), severity: "error", message });
+      }
+    } else {
+      // Fall back to the START of the target document (not the whole-text top).
+      const docStart = (doc?.contents as { range?: [number, number] } | undefined)?.range?.[0] ?? 0;
+      const nl = text.indexOf("\n", docStart);
+      const to = nl === -1 ? len : nl;
+      diagnostics.push({ from: clamp(docStart), to: Math.max(clamp(to), clamp(docStart) + 1), severity: "error", message });
+    }
+  }
+  return diagnostics;
+}
+
+/**
+ * Syntax colours, sourced from CSS tokens so the editor tracks the app theme
+ * (light/dark) automatically. Keys are on-brand teal, the most scannable cue in
+ * a manifest.
+ */
+const highlightStyle = HighlightStyle.define([
+  { tag: [t.definition(t.propertyName), t.propertyName, t.labelName], color: "var(--accent)" },
+  { tag: [t.string, t.special(t.string)], color: "var(--ink-soft)" },
+  { tag: [t.number, t.integer, t.float], color: "var(--info)" },
+  { tag: [t.bool, t.null, t.keyword, t.atom], color: "var(--info)" },
+  { tag: [t.comment, t.lineComment, t.blockComment], color: "var(--ink-faint)", fontStyle: "italic" },
+  { tag: [t.meta, t.punctuation, t.separator], color: "var(--ink-muted)" },
+]);
+
+/** Editor chrome, themed from CSS tokens (so light/dark just works). */
+function editorTheme(minHeight: number, maxHeight: number, fill: boolean) {
+  return EditorView.theme({
+    "&": {
+      color: "var(--ink)",
+      backgroundColor: "var(--surface)",
+      fontSize: "12px",
+      border: "1px solid var(--rule)",
+      borderRadius: "var(--radius-tile)",
+      // `fill` makes the editor take its container's full height (scrolling
+      // internally); otherwise it grows with content up to `maxHeight`.
+      ...(fill ? { height: "100%" } : { maxHeight: `${maxHeight}px` }),
+    },
+    "&.cm-focused": { outline: "none", borderColor: "var(--accent)" },
+    ".cm-scroller": { fontFamily: "var(--font-mono)", lineHeight: "1.55", overflow: "auto" },
+    ".cm-content": { minHeight: fill ? "0" : `${minHeight}px`, caretColor: "var(--accent)" },
+    ".cm-cursor, .cm-dropCursor": { borderLeftColor: "var(--accent)" },
+    ".cm-gutters": {
+      backgroundColor: "var(--surface-sunk)",
+      color: "var(--ink-muted)",
+      border: "none",
+      borderRight: "1px solid var(--rule)",
+    },
+    ".cm-activeLineGutter": { backgroundColor: "var(--field)", color: "var(--ink)" },
+    ".cm-activeLine": { backgroundColor: "var(--field)" },
+    ".cm-foldPlaceholder": {
+      backgroundColor: "var(--field)",
+      border: "none",
+      color: "var(--ink-muted)",
+    },
+    "&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection": {
+      backgroundColor: "color-mix(in srgb, var(--accent) 25%, transparent)",
+    },
+    ".cm-selectionMatch": { backgroundColor: "color-mix(in srgb, var(--accent) 18%, transparent)" },
+    ".cm-matchingBracket, &.cm-focused .cm-matchingBracket": {
+      backgroundColor: "color-mix(in srgb, var(--accent) 22%, transparent)",
+      outline: "1px solid var(--accent)",
+    },
+    ".cm-panels": { backgroundColor: "var(--surface-sunk)", color: "var(--ink)" },
+    ".cm-searchMatch": { backgroundColor: "color-mix(in srgb, var(--warn) 30%, transparent)" },
+    ".cm-tooltip": { maxWidth: "480px" },
+    ".cm-tooltip.cm-tooltip-lint": {
+      backgroundColor: "var(--surface-sunk)",
+      border: "1px solid var(--rule)",
+      borderRadius: "var(--radius-tile)",
+      boxShadow: "0 4px 16px color-mix(in srgb, var(--canvas-deep) 60%, transparent)",
+      color: "var(--ink)",
+      maxWidth: "480px",
+    },
+    ".cm-diagnostic": {
+      padding: "6px 10px",
+      whiteSpace: "normal",
+      maxHeight: "240px",
+      overflowY: "auto",
+      fontSize: "12px",
+      lineHeight: "1.45",
+    },
+    ".cm-diagnostic-error": { borderLeft: "3px solid var(--sev)" },
+    ".cm-tooltip.cm-tooltip-autocomplete": {
+      backgroundColor: "var(--surface-sunk)",
+      border: "1px solid var(--rule)",
+      borderRadius: "var(--radius-tile)",
+      boxShadow: "0 4px 16px color-mix(in srgb, var(--canvas-deep) 60%, transparent)",
+    },
+    ".cm-tooltip-autocomplete > ul > li": {
+      padding: "2px 8px",
+      fontFamily: "var(--font-mono)",
+      fontSize: "12px",
+      color: "var(--ink)",
+    },
+    ".cm-tooltip-autocomplete > ul > li[aria-selected]": {
+      backgroundColor: "var(--accent)",
+      color: "var(--accent-ink)",
+    },
+    ".cm-completionDetail": { color: "var(--ink-muted)", fontStyle: "italic", marginLeft: "6px" },
+    ".cm-lint-marker": { width: "0.9em", height: "0.9em" },
+  });
+}
+
+export interface CodeEditorProps {
+  value: string;
+  onChange?: (value: string) => void;
+  /** YAML language + syntax highlighting (default true). */
+  language?: "yaml" | "none";
+  readOnly?: boolean;
+  ariaLabel?: string;
+  minHeight?: number;
+  maxHeight?: number;
+  /** Fill the parent's height (scroll internally) instead of growing to content. */
+  fill?: boolean;
+  /**
+   * Validation the caller performs, given the YAML, resolving to messages
+   * against a document index (empty = valid). When set, the editor lints with
+   * it in addition to YAML syntax — syntax first and locally, so a document
+   * that does not parse never costs a round trip.
+   *
+   * Structural on purpose: what validates, and where, is the caller's. In this
+   * app that is a server-side dry-run against the API server.
+   */
+  schemaValidate?: (yaml: string) => Promise<Array<{ docIndex: number; message: string }>>;
+  /**
+   * Autocomplete, supplied by the caller.
+   *
+   * The classic editor resolved Kubernetes schemas itself. The kit cannot: it
+   * may not reach the service layer, and a design system has no business
+   * knowing what an apiVersion is. This is CodeMirror's own completion source
+   * type, so the caller keeps that knowledge and hands over only the result.
+   * (#318)
+   */
+  completions?: CompletionSource;
+}
+
+/**
+ * A real code editor (CodeMirror 6): line numbers, YAML syntax highlighting,
+ * fold gutter, bracket matching, undo/redo, and find (Cmd/Ctrl-F). Mounted
+ * imperatively and kept in sync with `value`; `onChange` fires on user edits.
+ */
+export function CodeEditor({
+  value,
+  onChange,
+  language = "yaml",
+  readOnly = false,
+  ariaLabel,
+  minHeight = 320,
+  maxHeight = 520,
+  fill = false,
+  schemaValidate,
+  completions,
+}: CodeEditorProps) {
+  const parentRef = useRef<HTMLDivElement>(null);
+  const viewRef = useRef<EditorView | null>(null);
+  // Keep the latest onChange/validate without re-creating the editor on every render.
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+  const validateRef = useRef(schemaValidate);
+  validateRef.current = schemaValidate;
+  const completionsRef = useRef(completions);
+  completionsRef.current = completions;
+
+  useEffect(() => {
+    const parent = parentRef.current;
+    if (!parent) return;
+
+    const extensions = [
+      lineNumbers(),
+      highlightActiveLineGutter(),
+      highlightActiveLine(),
+      foldGutter(),
+      history(),
+      drawSelection(),
+      dropCursor(),
+      indentOnInput(),
+      bracketMatching(),
+      highlightSelectionMatches(),
+      keymap.of([...completionKeymap, ...defaultKeymap, ...historyKeymap, ...searchKeymap, ...foldKeymap, indentWithTab]),
+      editorTheme(minHeight, maxHeight, fill),
+      syntaxHighlighting(highlightStyle),
+      EditorView.editable.of(!readOnly),
+      EditorState.readOnly.of(readOnly),
+      EditorView.updateListener.of((u) => {
+        if (u.docChanged) onChangeRef.current?.(u.state.doc.toString());
+      }),
+    ];
+    if (language === "yaml") {
+      // Lint YAML syntax first (local, instant); if it parses, validate against
+      // the caller's validator (debounced via the linter delay) for deeper errors.
+      const yamlLinter = linter(
+        async (view) => {
+          const text = view.state.doc.toString();
+          const syntax = yamlDiagnostics(text);
+          if (syntax.length) return syntax;
+          const validate = validateRef.current;
+          if (!validate || !text.trim()) return [];
+          try {
+            return documentDiagnostics(text, await validate(text));
+          } catch {
+            return [];
+          }
+        },
+        { delay: 500 },
+      );
+      extensions.push(yaml(), yamlLinter, lintGutter());
+
+      // Whatever the caller knows how to complete. `override` rather than
+      // `addTo`, so nothing else offers suggestions behind their back.
+      //
+      // Registered unconditionally and read through the ref on each call: the
+      // editor is only rebuilt when a structural option changes, and a caller
+      // that resolves its completion source from the cluster hands it over
+      // after mount. Gating on its presence here would mean it never arrived.
+      extensions.push(
+        autocompletion({ override: [(ctx) => completionsRef.current?.(ctx) ?? null] }),
+      );
+    }
+    if (ariaLabel) extensions.push(EditorView.contentAttributes.of({ "aria-label": ariaLabel }));
+
+    const view = new EditorView({
+      state: EditorState.create({ doc: value, extensions }),
+      parent,
+    });
+    viewRef.current = view;
+    return () => {
+      view.destroy();
+      viewRef.current = null;
+    };
+    // Re-create only when structural options change, not on every value/onChange.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [readOnly, language, ariaLabel, minHeight, maxHeight, fill]);
+
+  // Push external value changes into the editor (e.g. after Reset or reload).
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    const current = view.state.doc.toString();
+    if (value !== current) {
+      view.dispatch({ changes: { from: 0, to: current.length, insert: value } });
+    }
+  }, [value]);
+
+  return <div ref={parentRef} className="h-full w-full [&_.cm-editor]:h-full [&_.cm-scroller]:overflow-auto" />;
+}

--- a/packages/ui-kit/src/CodeEditor.tsx
+++ b/packages/ui-kit/src/CodeEditor.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { EditorState } from "@codemirror/state";
+import { Annotation, EditorState, StateEffect } from "@codemirror/state";
 import {
   EditorView,
   keymap,
@@ -76,6 +76,23 @@ function extractFieldPaths(message: string): string[] {
   }
   return [...paths];
 }
+
+/**
+ * Marks a transaction as this component syncing the document to `value`,
+ * rather than the user typing. Both change the document, and only one of them
+ * is an edit. (#326 review)
+ */
+const sync = Annotation.define<boolean>();
+
+/**
+ * Asks the linter to look again at a document that has not changed.
+ *
+ * `forceLinting` will not do it: it acts only when a run is already pending,
+ * so once the initial lint has settled it is a no-op. `needsRefresh` is the
+ * hook meant for this — the linter re-runs when a transaction carries this.
+ * (#326 review)
+ */
+const revalidate = StateEffect.define<null>();
 
 /**
  * Map document-indexed validation messages onto editor ranges. Positions each
@@ -302,7 +319,12 @@ export function CodeEditor({
       EditorView.editable.of(!readOnly),
       EditorState.readOnly.of(readOnly),
       EditorView.updateListener.of((u) => {
-        if (u.docChanged) onChangeRef.current?.(u.state.doc.toString());
+        if (!u.docChanged) return;
+        // A reset or a reload replaces the document from outside. That is the
+        // caller telling us, not the user typing, and reporting it back as an
+        // edit marks their own form dirty. (#326 review)
+        if (u.transactions.some((t) => t.annotation(sync))) return;
+        onChangeRef.current?.(u.state.doc.toString());
       }),
     ];
     if (language === "yaml") {
@@ -321,7 +343,13 @@ export function CodeEditor({
             return [];
           }
         },
-        { delay: 500 },
+        {
+          delay: 500,
+          // What is valid depends on which cluster is answering, so a new
+          // validator has to be asked about the document already on screen.
+          needsRefresh: (update) =>
+            update.transactions.some((t) => t.effects.some((e) => e.is(revalidate))),
+        },
       );
       extensions.push(yaml(), yamlLinter, lintGutter());
 
@@ -351,13 +379,25 @@ export function CodeEditor({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [readOnly, language, ariaLabel, minHeight, maxHeight, fill]);
 
+  // A new validator has to be asked about the document already on screen.
+  // Swapping it changes what is true — a different cluster, a different set of
+  // CRDs — but the linter is scheduled by edits, so without this the previous
+  // validator's diagnostics stay up until someone types. (#326 review)
+  useEffect(() => {
+    const view = viewRef.current;
+    if (view && language === "yaml") view.dispatch({ effects: revalidate.of(null) });
+  }, [schemaValidate, language]);
+
   // Push external value changes into the editor (e.g. after Reset or reload).
   useEffect(() => {
     const view = viewRef.current;
     if (!view) return;
     const current = view.state.doc.toString();
     if (value !== current) {
-      view.dispatch({ changes: { from: 0, to: current.length, insert: value } });
+      view.dispatch({
+        changes: { from: 0, to: current.length, insert: value },
+        annotations: sync.of(true),
+      });
     }
   }, [value]);
 

--- a/packages/ui-kit/src/ColumnPicker.test.tsx
+++ b/packages/ui-kit/src/ColumnPicker.test.tsx
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ColumnPicker, type ColumnOption } from "./ColumnPicker";
+
+// jsdom has no ResizeObserver, and Radix's popper watches the trigger and the
+// content with one. The kit's shared setup does not stub it — nothing in the
+// kit was positioned against an anchor before this — and that setup is not this
+// file's to edit, so the stub lives here. Inert: jsdom does no layout, so there
+// is never a resize to report. (apps/desktop's setup carries the same stub.)
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
+const COLUMNS: ColumnOption[] = [
+  { key: "name", label: "Name" },
+  { key: "namespace", label: "Namespace" },
+  { key: "status", label: "Status" },
+  { key: "age", label: "Age" },
+];
+
+function setup(props: Partial<Parameters<typeof ColumnPicker>[0]> = {}) {
+  const onToggle = vi.fn();
+  const view = render(
+    <ColumnPicker
+      columns={COLUMNS}
+      hidden={new Set<string>()}
+      onToggle={onToggle}
+      pinnedKey="name"
+      {...props}
+    />,
+  );
+  return { onToggle, ...view };
+}
+
+const trigger = () => screen.getByRole("button", { name: /Columns/ });
+
+async function open(props: Partial<Parameters<typeof ColumnPicker>[0]> = {}) {
+  const view = setup(props);
+  await userEvent.click(trigger());
+  await screen.findByRole("group");
+  return view;
+}
+
+const box = (label: string) => screen.getByRole("checkbox", { name: label }) as HTMLInputElement;
+
+/**
+ * What this component owns: the visibility contract it presents to a table —
+ * every column offered, the pinned one held on, a key handed back per toggle —
+ * and its wiring to Radix's Popover.
+ *
+ * Deliberately absent: focus trapping inside the panel, outside-click
+ * dismissal, collision flipping. Those are the library's, and asserting a
+ * dependency's internals through our component only pins the version we happen
+ * to have. Escape is here because it is the one dismissal path a keyboard user
+ * has no alternative to, so losing it would be a real regression rather than a
+ * library upgrade. (#318)
+ */
+describe("ColumnPicker", () => {
+  it("keeps the panel shut until the trigger is used", () => {
+    setup();
+    expect(screen.queryByRole("group")).toBeNull();
+    expect(screen.queryByRole("checkbox")).toBeNull();
+  });
+
+  it("opens from the trigger and lists every column, in order", async () => {
+    await open();
+    expect(screen.getAllByRole("checkbox").map((b) => b.parentElement?.textContent)).toEqual([
+      "Name",
+      "Namespace",
+      "Status",
+      "Age",
+    ]);
+  });
+
+  it("reports its open state on the trigger", async () => {
+    setup();
+    expect(trigger().getAttribute("aria-expanded")).toBe("false");
+    await userEvent.click(trigger());
+    await waitFor(() => expect(trigger().getAttribute("aria-expanded")).toBe("true"));
+  });
+
+  it("names the group of options", async () => {
+    await open();
+    // Without a name the panel is a bare pile of checkboxes: a screen-reader
+    // user arrives at "Name, checkbox" with nothing saying what turning it off
+    // would do.
+    expect(screen.getByRole("group", { name: "Toggle columns" })).toBeDefined();
+  });
+
+  it("renders the panel in a portal, out of the toolbar it was declared in", async () => {
+    const { container } = await open();
+    expect(container.contains(screen.getByRole("group"))).toBe(false);
+  });
+});
+
+describe("ColumnPicker toggling", () => {
+  it("hands back the key of the column that was clicked", async () => {
+    const { onToggle } = await open();
+    await userEvent.click(box("Status"));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    expect(onToggle).toHaveBeenCalledWith("status");
+  });
+
+  it("shows hidden columns unchecked and visible ones checked", async () => {
+    await open({ hidden: new Set(["status", "age"]) });
+    expect(box("Namespace").checked).toBe(true);
+    expect(box("Status").checked).toBe(false);
+    expect(box("Age").checked).toBe(false);
+  });
+
+  it("stays open across a toggle, so several can be changed in one visit", async () => {
+    const { onToggle } = await open();
+    await userEvent.click(box("Status"));
+    await userEvent.click(box("Age"));
+    expect(onToggle.mock.calls).toEqual([["status"], ["age"]]);
+  });
+});
+
+/**
+ * The pinned column is the row identifier. A table whose rows lost their name
+ * is not a table any more, so this is a hard invariant, not a default.
+ */
+describe("ColumnPicker and the pinned column", () => {
+  it("offers it checked and disabled", async () => {
+    await open();
+    expect(box("Name").checked).toBe(true);
+    expect(box("Name").disabled).toBe(true);
+  });
+
+  it("refuses to toggle it", async () => {
+    // Fired directly rather than through userEvent, which would decline to
+    // click a disabled control and so assert nothing about this component. The
+    // pin is ours to keep, not the attribute's: this is the change event
+    // arriving anyway, and the answer still has to be no.
+    const { onToggle } = await open();
+    fireEvent.click(box("Name"));
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it("holds it on even when the caller's hidden set names it", async () => {
+    // The set is the caller's state and may be stale — a persisted layout from
+    // before this column was pinned, say. The pin wins.
+    await open({ hidden: new Set(["name"]) });
+    expect(box("Name").checked).toBe(true);
+  });
+
+  it("marks the row disabled to assistive technology, not only the input", async () => {
+    await open();
+    expect(box("Name").closest("label")?.getAttribute("aria-disabled")).toBe("true");
+    expect(box("Status").closest("label")?.hasAttribute("aria-disabled")).toBe(false);
+  });
+});
+
+describe("ColumnPicker's count", () => {
+  it("says how many columns are showing once any are hidden", async () => {
+    setup({ hidden: new Set(["status"]) });
+    expect(trigger().textContent).toContain("(3)");
+  });
+
+  it("does not count the pinned column as hidden", async () => {
+    // It is never off, so a stale set naming it must not make the trigger
+    // claim a column is missing.
+    setup({ hidden: new Set(["name"]) });
+    expect(trigger().textContent).not.toContain("(");
+  });
+
+  it("stays quiet while everything is visible", () => {
+    setup();
+    expect(trigger().textContent).not.toContain("(");
+  });
+
+  it("announces the count, rather than showing it to sighted users only", () => {
+    setup({ hidden: new Set(["status", "age"]) });
+    expect(screen.getByRole("button", { name: /Columns\s*\(2\)/ })).toBeDefined();
+  });
+});
+
+describe("ColumnPicker's trigger", () => {
+  it("takes its accessible name from its visible label", () => {
+    // Matching what is on screen is what lets speech-input users say it, so
+    // the label is the name rather than a separate aria-label saying something
+    // else. (#318 review)
+    setup({ label: "Fields" });
+    expect(screen.getByRole("button", { name: "Fields" })).toBeDefined();
+  });
+
+  it("still has a name when the label is empty", () => {
+    setup({ label: "" });
+    expect(screen.getByRole("button", { name: "Choose columns" }).textContent).toBe("");
+  });
+
+  it("does not submit the form it is standing in", async () => {
+    // This control lives in toolbars, and a toolbar sits inside a form often
+    // enough that a bare <button> submitting on open is a live bug. The kit's
+    // Button does not default the type, so this component sets it.
+    const onSubmit = vi.fn((e: React.FormEvent) => e.preventDefault());
+    render(
+      <form onSubmit={onSubmit}>
+        <ColumnPicker columns={COLUMNS} hidden={new Set()} onToggle={() => {}} pinnedKey="name" />
+      </form>,
+    );
+    expect(trigger().getAttribute("type")).toBe("button");
+    await userEvent.click(trigger());
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("carries a decorative glyph that adds nothing to the name", () => {
+    // Inlined rather than imported from lucide: the kit takes no dependency on
+    // an icon set.
+    setup();
+    const glyph = trigger().querySelector("svg");
+    expect(glyph).not.toBeNull();
+    expect(glyph?.getAttribute("aria-hidden")).toBe("true");
+  });
+});
+
+describe("ColumnPicker dismissal", () => {
+  it("closes on Escape", async () => {
+    await open();
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => expect(screen.queryByRole("group")).toBeNull());
+  });
+});
+
+describe("ColumnPicker's appearance", () => {
+  it("dresses the panel in the design's own popover surface", async () => {
+    await open();
+    const panel = screen.getByRole("group").parentElement;
+    expect(panel?.className).toContain("popover");
+  });
+
+  it("leaves the panel in flow so the popper can measure it", async () => {
+    // `.popover` is written for a panel that positions itself: `position:
+    // fixed`. Radix already fixes and translates a wrapper around the content,
+    // and a fixed child leaves that wrapper zero-sized — which is what the
+    // collision logic measures, so the panel would flip and shift against a
+    // box of nothing. Structural, because jsdom does no layout. (#318 review)
+    await open();
+    const panel = screen.getByRole("group").parentElement as HTMLElement;
+    expect(panel.style.position).toBe("relative");
+  });
+});

--- a/packages/ui-kit/src/ColumnPicker.tsx
+++ b/packages/ui-kit/src/ColumnPicker.tsx
@@ -1,0 +1,147 @@
+import { Popover } from "radix-ui";
+import { Button } from "./Button";
+import { cx } from "./cx";
+import { filled } from "./slot";
+
+export interface ColumnOption {
+  key: string;
+  label: string;
+}
+
+export interface ColumnPickerProps {
+  columns: ColumnOption[];
+  hidden: ReadonlySet<string>;
+  onToggle: (key: string) => void;
+  /** The row identifier: always shown, and never offered as a toggle. */
+  pinnedKey?: string;
+  /** Text on the trigger. Empty leaves an icon-only button. */
+  label?: string;
+}
+
+/**
+ * Toolbar control for choosing which table columns are visible. Each column is
+ * a checkbox; the `pinnedKey` column is the row identifier, so it is held on —
+ * a table whose rows lost their name is not a table any more. Visibility is the
+ * caller's state, passed in as the set of hidden keys and changed only through
+ * `onToggle`, so the same layout can be persisted and applied to the table
+ * itself. (#318)
+ *
+ * On Radix's Popover rather than shadcn's, which cannot come along: it lives in
+ * `apps/desktop` and is written against the classic Tailwind config. Radix is
+ * what shadcn's was wrapping, so this is the same behaviour with one layer
+ * removed — the anchoring, the portal, the outside-click and Escape dismissal,
+ * and the `aria-expanded`/`aria-controls` pair on the trigger. That contract is
+ * the same one ConfirmDialog explains at length: it is library-sized, and
+ * hand-writing it here would repeat a mistake this kit has already paid for.
+ *
+ * What is ours is the trigger's count and the pin. Both read the caller's
+ * hidden set through the pin, because that set outlives the layout it was
+ * written for — a persisted set can still name a column that has since become
+ * the identifier, and neither the checkbox nor the count may believe it.
+ */
+export function ColumnPicker({
+  columns,
+  hidden,
+  onToggle,
+  pinnedKey,
+  label = "Columns",
+}: ColumnPickerProps) {
+  const hiddenCount = columns.filter((c) => c.key !== pinnedKey && hidden.has(c.key)).length;
+  // `filled` rather than a truthiness check, so an empty label is the caller
+  // asking for an icon-only button rather than a button with no name at all:
+  // the visible text is the accessible name whenever there is any, since a name
+  // matching what is on screen is what lets a speech-input user say it, and the
+  // fallback appears only when nothing is on screen to say. (#318 review)
+  const named = filled(label);
+  return (
+    <Popover.Root>
+      <Popover.Trigger asChild>
+        {/* Explicitly type="button": the kit's Button deliberately does not
+            default it, and this control sits in toolbars that sit inside
+            forms — where a bare button submits on the click that opens it. */}
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          aria-label={named ? undefined : "Choose columns"}
+        >
+          {/* Inline rather than an icon-set import: the kit takes no dependency
+              on lucide, and this is the only glyph it needs. */}
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <rect
+              x="3"
+              y="3"
+              width="18"
+              height="18"
+              rx="2"
+              stroke="currentColor"
+              strokeWidth="2"
+            />
+            <path d="M9 3v18M15 3v18" stroke="currentColor" strokeWidth="2" />
+          </svg>
+          {named && label}
+          {/* Left in the accessible name rather than hidden from it: how many
+              columns survived the last visit is the reason to open the panel,
+              and it is no less useful read aloud than seen. */}
+          {hiddenCount > 0 && (
+            <span className="tabular-nums opacity-70">({columns.length - hiddenCount})</span>
+          )}
+        </Button>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content
+          align="end"
+          sideOffset={6}
+          className="popover p-1"
+          // `.popover` is written for a panel that places itself: `position:
+          // fixed`. Radix already fixes and translates a wrapper around this
+          // content, and a fixed child leaves that wrapper zero-sized — which
+          // is the box the collision logic measures, so the panel would flip
+          // and shift against nothing. Relative rather than static keeps the
+          // stylesheet's z-index doing its job. (#318 review)
+          style={{ position: "relative" }}
+        >
+          <div role="group" aria-label="Toggle columns" className="flex flex-col">
+            {columns.map((column) => {
+              const pinned = column.key === pinnedKey;
+              const checked = pinned || !hidden.has(column.key);
+              return (
+                <label
+                  key={column.key}
+                  // `.ns-row` is the design's row inside a popover, and
+                  // `data-on` is how it marks the live one — so a visible
+                  // column reads stronger than a hidden one without a second
+                  // rule being invented for this panel.
+                  className={cx("ns-row rounded", pinned && "opacity-60")}
+                  data-on={checked}
+                  // On the row, not only the input: the row is what a pointer
+                  // and a screen reader both meet first, and the disabled
+                  // checkbox inside it says nothing about why.
+                  aria-disabled={pinned || undefined}
+                >
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    disabled={pinned}
+                    // Guarded as well as disabled. `disabled` is the browser
+                    // enforcing the pin, and it enforces it well — a disabled
+                    // control takes no click and no focus. But the invariant
+                    // belongs to this component, not to the attribute: swap
+                    // `disabled` for `aria-disabled` one day, as an a11y
+                    // review may well ask for, and the identifier column
+                    // becomes toggleable with nothing failing. (#318 review)
+                    onChange={() => {
+                      if (!pinned) onToggle(column.key);
+                    }}
+                    style={{ accentColor: "var(--accent)" }}
+                  />
+                  <span>{column.label}</span>
+                </label>
+              );
+            })}
+          </div>
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}

--- a/packages/ui-kit/src/Combobox.test.tsx
+++ b/packages/ui-kit/src/Combobox.test.tsx
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Combobox } from "./Combobox";
+
+/**
+ * jsdom does not implement the two browser APIs a floating, scrolling list is
+ * built on: Radix positions the popover with a ResizeObserver watching the
+ * trigger, and cmdk scrolls the highlighted row into view. Both are stubbed
+ * here rather than in `test-setup.ts` because these two suites are the only
+ * ones in the kit that open a popover, and a global stub hides from the next
+ * component that it needs one.
+ */
+if (!("ResizeObserver" in window)) {
+  (window as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+const proto = window.HTMLElement.prototype as unknown as Record<string, unknown>;
+proto.scrollIntoView ??= () => {};
+proto.hasPointerCapture ??= () => false;
+proto.setPointerCapture ??= () => {};
+proto.releasePointerCapture ??= () => {};
+
+const options = [
+  { value: "", label: "Everything" },
+  { value: "alpha" },
+  { value: "beta", label: "Beta service" },
+  { value: "gamma" },
+];
+
+function open(props: Partial<Parameters<typeof Combobox>[0]> = {}) {
+  const result = render(
+    <Combobox value="alpha" onValueChange={() => {}} options={options} ariaLabel="Scope" {...props} />,
+  );
+  return result;
+}
+
+const trigger = () => screen.getByRole("combobox", { name: "Scope" });
+const rows = () => screen.getAllByRole("option").map((el) => el.textContent);
+
+/**
+ * What this component owns: the trigger's summary, the value-first change
+ * contract, and closing on a choice. Deliberately absent are cmdk's scoring
+ * algorithm and Radix's outside-click and focus handling — this suite checks
+ * that the libraries are wired up and that the seams around them behave, not
+ * how they work inside. (#318)
+ */
+describe("Combobox", () => {
+  it("names the trigger with ariaLabel", () => {
+    open({ ariaLabel: "Namespace filter" });
+    expect(screen.getByRole("combobox", { name: "Namespace filter" })).toBeDefined();
+  });
+
+  it("summarises the current value on the trigger, preferring the option's label", () => {
+    const { rerender } = open({ value: "beta" });
+    expect(trigger().textContent).toContain("Beta service");
+    rerender(<Combobox value="alpha" onValueChange={() => {}} options={options} ariaLabel="Scope" />);
+    expect(trigger().textContent).toContain("alpha");
+  });
+
+  it("summarises an empty-string value like any other, when an option carries it", () => {
+    // `""` is a real value here, not a sentinel for "nothing chosen": callers
+    // use it for the option that means "no filter".
+    open({ value: "" });
+    expect(trigger().textContent).toContain("Everything");
+  });
+
+  it("falls back to the placeholder when the value matches no option", () => {
+    open({ value: "nothing-like-this", placeholder: "Pick one…" });
+    expect(trigger().textContent).toContain("Pick one…");
+  });
+
+  it("gives the trigger an explicit button type", () => {
+    // These sit in toolbars, and a toolbar can stand inside a form; a bare
+    // button would submit it.
+    open();
+    expect(trigger().getAttribute("type")).toBe("button");
+  });
+
+  it("merges the caller's className onto the trigger", () => {
+    open({ className: "w-40" });
+    expect(trigger().className).toContain("w-40");
+  });
+
+  it("opens the popover and lists every option", async () => {
+    open();
+    expect(screen.queryByRole("option")).toBeNull();
+    await userEvent.click(trigger());
+    expect(rows()).toEqual(["Everything", "alpha", "Beta service", "gamma"]);
+  });
+
+  it("announces on the trigger whether the popover is open", async () => {
+    open();
+    expect(trigger().getAttribute("aria-expanded")).toBe("false");
+    await userEvent.click(trigger());
+    expect(trigger().getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("reports the chosen option's value, not the label it was shown under", async () => {
+    const onValueChange = vi.fn();
+    open({ onValueChange });
+    await userEvent.click(trigger());
+    await userEvent.click(screen.getByRole("option", { name: "Beta service" }));
+    expect(onValueChange).toHaveBeenCalledWith("beta");
+  });
+
+  it("closes once an option is chosen", async () => {
+    open();
+    await userEvent.click(trigger());
+    await userEvent.click(screen.getByRole("option", { name: "gamma" }));
+    expect(screen.queryByRole("option")).toBeNull();
+    expect(trigger().getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("marks the current option as checked", async () => {
+    open({ value: "beta" });
+    await userEvent.click(trigger());
+    // cmdk owns `aria-selected` on these rows — it means "highlighted", and it
+    // follows the pointer and the arrow keys. So the chosen row says so with
+    // `aria-checked`, which nothing else is using.
+    expect(screen.getByRole("option", { name: "Beta service" }).getAttribute("aria-checked")).toBe("true");
+    expect(screen.getByRole("option", { name: "gamma" }).getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("offers a search box named by searchPlaceholder", async () => {
+    open({ searchPlaceholder: "Search scopes…" });
+    await userEvent.click(trigger());
+    expect(screen.getByPlaceholderText("Search scopes…")).toBeDefined();
+  });
+
+  it("shows the empty state when there is nothing to choose from", async () => {
+    open({ options: [] });
+    await userEvent.click(trigger());
+    expect(screen.queryByRole("option")).toBeNull();
+    expect(screen.getByText("No results")).toBeDefined();
+  });
+
+  it("caps the list's height and scrolls it", async () => {
+    // The point of reaching for this over `Select`: the option set is large.
+    // Structural, because jsdom does no layout. (#318)
+    open();
+    await userEvent.click(trigger());
+    const list = screen.getByRole("option", { name: "alpha" }).closest("[cmdk-list]");
+    expect(list?.className).toContain("max-h-[240px]");
+    expect(list?.className).toContain("scroll");
+  });
+
+  it("dresses the popover in the design's own surface, without fixing it in place", async () => {
+    open();
+    await userEvent.click(trigger());
+    const panel = screen.getByRole("dialog");
+    expect(panel.className).toContain("popover");
+    // `.popover` positions itself with `position: fixed`, which Radix's popper
+    // cannot work with: it fixes and translates a wrapper of its own, and a
+    // fixed child collapses that wrapper to nothing — the very box the
+    // collision logic measures. Pinned because losing it is invisible in jsdom
+    // and shows up only as a popover placed against the wrong edge. (#318)
+    expect(panel.style.position).toBe("relative");
+  });
+});

--- a/packages/ui-kit/src/Combobox.tsx
+++ b/packages/ui-kit/src/Combobox.tsx
@@ -1,0 +1,71 @@
+import { Picker, PickerRow, optionLabel, type ComboboxOption } from "./picker";
+
+// The option shape is shared with `MultiSelect` and so is declared alongside
+// the shell they share, but it is named for this component and belongs to its
+// public surface — so it is exported from here, where a caller expects it.
+export type { ComboboxOption } from "./picker";
+
+export interface ComboboxProps {
+  value: string;
+  onValueChange: (value: string) => void;
+  options: ComboboxOption[];
+  placeholder?: string;
+  searchPlaceholder?: string;
+  ariaLabel?: string;
+  className?: string;
+}
+
+/**
+ * A searchable, height-capped single select.
+ *
+ * Reach for it over `Select` when the option set is long enough that a native
+ * dropdown stops being a list and becomes a wall: the trigger reads like a
+ * select, but behind it is a search box over a bounded, scrolling list. The
+ * classic API is unchanged — a value in, a value out — because every call site
+ * is written against it. (#318)
+ *
+ * `""` is an ordinary value here and not a sentinel for "nothing chosen": the
+ * app's own callers use it for the option meaning "no filter", and `Select`
+ * made the same call for the same reason. So the trigger shows the placeholder
+ * only when no option claims the current value at all, rather than whenever the
+ * value is empty.
+ *
+ * Choosing closes the popover, which is what separates this from `MultiSelect`
+ * and is the only behavioural difference between them; the shell they share
+ * lives in `picker`. (#318)
+ */
+export function Combobox({
+  value,
+  onValueChange,
+  options,
+  placeholder = "Select…",
+  searchPlaceholder,
+  ariaLabel,
+  className,
+}: ComboboxProps) {
+  const selected = options.find((option) => option.value === value);
+
+  return (
+    <Picker
+      summary={selected ? optionLabel(selected) : placeholder}
+      ariaLabel={ariaLabel}
+      searchPlaceholder={searchPlaceholder}
+      className={className}
+    >
+      {(close) =>
+        options.map((option) => (
+          <PickerRow
+            key={option.value}
+            value={option.value}
+            label={optionLabel(option)}
+            checked={option.value === value}
+            onSelect={() => {
+              onValueChange(option.value);
+              close();
+            }}
+          />
+        ))
+      }
+    </Picker>
+  );
+}

--- a/packages/ui-kit/src/KubectlPreview.test.tsx
+++ b/packages/ui-kit/src/KubectlPreview.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { KubectlPreview } from "./KubectlPreview";
+
+/** The classic component's tests, carried over. (#318) */
+describe("KubectlPreview", () => {
+  it("labels and renders the command", () => {
+    render(<KubectlPreview command="kubectl get pods web-0 --context prod" />);
+    expect(screen.getByText("Equivalent kubectl:")).toBeDefined();
+    expect(screen.getByText("kubectl get pods web-0 --context prod")).toBeDefined();
+  });
+
+  it("renders a note instead of a command when there's no clean equivalent", () => {
+    render(<KubectlPreview note="No single-line kubectl equivalent." />);
+    expect(screen.getByText("No single-line kubectl equivalent.")).toBeDefined();
+    expect(screen.queryByText("Equivalent kubectl:")).toBeNull();
+  });
+
+  it("omits the copy button when no onCopy handler is given", () => {
+    render(<KubectlPreview command="kubectl get pods web-0 --context prod" />);
+    expect(screen.queryByRole("button", { name: "Copy kubectl command" })).toBeNull();
+  });
+
+  it("fires onCopy when the copy button is clicked", () => {
+    const onCopy = vi.fn();
+    render(<KubectlPreview command="kubectl get pods web-0 --context prod" onCopy={onCopy} />);
+    fireEvent.click(screen.getByRole("button", { name: "Copy kubectl command" }));
+    expect(onCopy).toHaveBeenCalledTimes(1);
+  });
+
+  it("names the copy control for a pointer as well as a screen reader", () => {
+    render(<KubectlPreview command="kubectl delete pod web-0" onCopy={() => {}} />);
+    const button = screen.getByRole("button", { name: "Copy kubectl command" });
+    expect(button.getAttribute("title")).toBe("Copy kubectl command");
+  });
+
+  it("hides the copy glyph from assistive tech", () => {
+    // The button already carries the name; an unlabelled graphic announced
+    // beside it would be read twice.
+    const { container } = render(
+      <KubectlPreview command="kubectl delete pod web-0" onCopy={() => {}} />,
+    );
+    const glyph = container.querySelector("svg");
+    expect(glyph).not.toBeNull();
+    expect(glyph?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("gives the copy control an explicit type", () => {
+    // This preview lives inside confirm dialogs, which are forms; a bare
+    // button submits the one it is standing in, confirming the action the
+    // user was only reading about. (#318)
+    render(<KubectlPreview command="kubectl delete pod web-0" onCopy={() => {}} />);
+    expect(screen.getByRole("button", { name: "Copy kubectl command" }).getAttribute("type")).toBe(
+      "button",
+    );
+  });
+
+  it("renders the command in the design's monospace class", () => {
+    const { container } = render(<KubectlPreview command="kubectl get pods" />);
+    expect(container.querySelector("code.code")?.textContent).toBe("kubectl get pods");
+  });
+
+  it("renders nothing at all when there is neither a command nor a note", () => {
+    // An empty paragraph still takes its top margin, so the dialog gets a gap
+    // where a preview was declined. (#318)
+    const { container } = render(<KubectlPreview />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when the note resolved to false", () => {
+    // `note={hasNote && text}` is the ordinary way to make the slot
+    // conditional, and it hands over `false`. (#318)
+    const { container } = render(<KubectlPreview note={false as unknown as string} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("forwards className onto the preview", () => {
+    const { container } = render(<KubectlPreview command="kubectl get pods" className="extra" />);
+    expect(container.querySelector(".extra")).not.toBeNull();
+  });
+
+  it("forwards className onto the note form too", () => {
+    const { container } = render(<KubectlPreview note="No equivalent." className="extra" />);
+    expect(container.querySelector(".extra")?.textContent).toBe("No equivalent.");
+  });
+});

--- a/packages/ui-kit/src/KubectlPreview.tsx
+++ b/packages/ui-kit/src/KubectlPreview.tsx
@@ -1,0 +1,59 @@
+import { cx } from "./cx";
+import { filled } from "./slot";
+import { IconButton, type IconComponent } from "./IconButton";
+
+export interface KubectlPreviewProps {
+  /** The kubectl-equivalent command. Omit (and pass `note` instead) when there's no faithful one-liner. */
+  command?: string;
+  /** Shown instead of a command when no clean kubectl equivalent exists (e.g. evict). */
+  note?: string;
+  /** Copy-to-clipboard handler; renders a copy affordance next to `command` when set. */
+  onCopy?: () => void;
+  className?: string;
+}
+
+/* Inline rather than an icon-set import: the kit takes no dependency on
+   lucide, and this is the only glyph it needs. */
+const CopyGlyph: IconComponent = ({ size = 14, ...rest }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" {...rest}>
+    <rect x="9" y="9" width="12" height="12" rx="2" stroke="currentColor" strokeWidth="2" />
+    <path
+      d="M5 15H4a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v1"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * The kubectl command an action stands for, shown inside the confirm dialog
+ * that action opens.
+ *
+ * It is here so that a destructive click is never a black box: the user reads
+ * the one-liner they would otherwise have typed, and can take it away with
+ * them. Not every action has a faithful equivalent — evict is an API call with
+ * no kubectl verb of its own — so `note` says as much in the same place, rather
+ * than leaving the dialog quietly silent about what it is about to do.
+ *
+ * The classic version coloured itself with `text-muted-foreground` and laid
+ * itself out with inline styles; the new design's equivalents are `text-muted`
+ * and Tailwind utilities, and the command itself wears the design's own `.code`
+ * instead of rebuilding a monospace look. Given neither a command nor a note it
+ * renders nothing, where the classic left an empty paragraph still holding its
+ * top margin. Commands are long and dialogs are narrow, so the line wraps
+ * rather than truncating — a preview you cannot finish reading is not one. (#318)
+ */
+export function KubectlPreview({ command, note, onCopy, className }: KubectlPreviewProps) {
+  if (!filled(command)) {
+    if (!filled(note)) return null;
+    return <p className={cx("mt-2 text-xs text-muted", className)}>{note}</p>;
+  }
+  return (
+    <p className={cx("mt-2 flex flex-wrap items-center gap-1 text-xs text-muted", className)}>
+      <span>Equivalent kubectl:</span>
+      <code className="code min-w-0 break-words">{command}</code>
+      {onCopy && <IconButton icon={CopyGlyph} label="Copy kubectl command" onClick={onCopy} />}
+    </p>
+  );
+}

--- a/packages/ui-kit/src/MultiSelect.test.tsx
+++ b/packages/ui-kit/src/MultiSelect.test.tsx
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi } from "vitest";
+import { useState } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MultiSelect } from "./MultiSelect";
+
+/** See the note in Combobox.test.tsx — same two jsdom gaps, same stubs. */
+if (!("ResizeObserver" in window)) {
+  (window as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+const proto = window.HTMLElement.prototype as unknown as Record<string, unknown>;
+proto.scrollIntoView ??= () => {};
+proto.hasPointerCapture ??= () => false;
+proto.setPointerCapture ??= () => {};
+proto.releasePointerCapture ??= () => {};
+
+const options = [{ value: "alpha" }, { value: "beta", label: "Beta service" }, { value: "gamma" }];
+
+function open(props: Partial<Parameters<typeof MultiSelect>[0]> = {}) {
+  return render(
+    <MultiSelect options={options} selection={[]} onChange={() => {}} ariaLabel="Scope" {...props} />,
+  );
+}
+
+const trigger = () => screen.getByRole("combobox", { name: "Scope" });
+const rows = () => screen.getAllByRole("option").map((el) => el.textContent);
+
+/** A caller that actually holds the selection, so toggling behaves as it does in an app. */
+function Live({ allLabel }: { allLabel?: string }) {
+  const [selection, setSelection] = useState<string[]>([]);
+  return (
+    <MultiSelect
+      options={options}
+      selection={selection}
+      onChange={setSelection}
+      allLabel={allLabel}
+      ariaLabel="Scope"
+    />
+  );
+}
+
+describe("MultiSelect", () => {
+  it("names the trigger with ariaLabel", () => {
+    open({ ariaLabel: "Scope filter" });
+    expect(screen.getByRole("combobox", { name: "Scope filter" })).toBeDefined();
+  });
+
+  it("gives the trigger an explicit button type", () => {
+    open();
+    expect(trigger().getAttribute("type")).toBe("button");
+  });
+
+  it("merges the caller's className onto the trigger", () => {
+    open({ className: "w-40" });
+    expect(trigger().className).toContain("w-40");
+  });
+
+  it("summarises one selection by name and several by count", () => {
+    const { rerender } = open({ selection: ["beta"] });
+    expect(trigger().textContent).toContain("Beta service");
+    rerender(
+      <MultiSelect options={options} selection={["beta", "gamma"]} onChange={() => {}} ariaLabel="Scope" />,
+    );
+    expect(trigger().textContent).toContain("2 selected");
+  });
+
+  it("summarises an empty selection as allLabel when there is one", () => {
+    open({ allLabel: "Everything" });
+    expect(trigger().textContent).toContain("Everything");
+  });
+
+  it("summarises an empty selection as the placeholder when there is no allLabel", () => {
+    open({ placeholder: "Nothing picked" });
+    expect(trigger().textContent).toContain("Nothing picked");
+  });
+
+  it("opens the popover and lists every option", async () => {
+    open();
+    expect(screen.queryByRole("option")).toBeNull();
+    await userEvent.click(trigger());
+    expect(rows()).toEqual(["alpha", "Beta service", "gamma"]);
+  });
+
+  it("adds an option to the selection when toggled on", async () => {
+    const onChange = vi.fn();
+    open({ onChange });
+    await userEvent.click(trigger());
+    await userEvent.click(screen.getByRole("option", { name: "Beta service" }));
+    expect(onChange).toHaveBeenCalledWith(["beta"]);
+  });
+
+  it("removes an option from the selection when toggled off", async () => {
+    const onChange = vi.fn();
+    open({ onChange, selection: ["alpha", "beta"] });
+    await userEvent.click(trigger());
+    await userEvent.click(screen.getByRole("option", { name: "alpha" }));
+    expect(onChange).toHaveBeenCalledWith(["beta"]);
+  });
+
+  it("marks the selected rows as checked", async () => {
+    open({ selection: ["beta"] });
+    await userEvent.click(trigger());
+    expect(screen.getByRole("option", { name: "Beta service" }).getAttribute("aria-checked")).toBe("true");
+    expect(screen.getByRole("option", { name: "gamma" }).getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("stays open while toggling, so several can be picked at once", async () => {
+    render(<Live />);
+    await userEvent.click(trigger());
+    await userEvent.click(screen.getByRole("option", { name: "alpha" }));
+    // Still open, and still showing the same list.
+    expect(screen.getByRole("option", { name: "gamma" })).toBeDefined();
+    await userEvent.click(screen.getByRole("option", { name: "gamma" }));
+    expect(screen.getAllByRole("option").length).toBe(3);
+    expect(trigger().textContent).toContain("2 selected");
+  });
+
+  it("offers a search box named by searchPlaceholder", async () => {
+    open({ searchPlaceholder: "Search scopes…" });
+    await userEvent.click(trigger());
+    expect(screen.getByPlaceholderText("Search scopes…")).toBeDefined();
+  });
+});
+
+/**
+ * `allLabel` is the general form of the classic picker's "an empty selection
+ * means everything" sentinel: opt in by naming the row, leave it out and an
+ * empty selection is simply an empty selection.
+ */
+describe("MultiSelect's all row", () => {
+  it("leads the list when allLabel is given", async () => {
+    open({ allLabel: "Everything" });
+    await userEvent.click(trigger());
+    expect(rows()).toEqual(["Everything", "alpha", "Beta service", "gamma"]);
+  });
+
+  it("clears the selection", async () => {
+    const onChange = vi.fn();
+    open({ onChange, selection: ["alpha"], allLabel: "Everything" });
+    await userEvent.click(trigger());
+    await userEvent.click(screen.getByRole("option", { name: "Everything" }));
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+
+  it("is checked exactly when nothing is selected", async () => {
+    const { rerender } = open({ allLabel: "Everything" });
+    await userEvent.click(trigger());
+    expect(screen.getByRole("option", { name: "Everything" }).getAttribute("aria-checked")).toBe("true");
+    rerender(
+      <MultiSelect
+        options={options}
+        selection={["alpha"]}
+        onChange={() => {}}
+        allLabel="Everything"
+        ariaLabel="Scope"
+      />,
+    );
+    expect(screen.getByRole("option", { name: "Everything" }).getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("is absent when allLabel is not given", async () => {
+    open();
+    await userEvent.click(trigger());
+    expect(screen.getAllByRole("option").length).toBe(options.length);
+  });
+
+  it("is absent for a label that renders nothing", async () => {
+    // `allLabel={showAll && "Everything"}` is how a caller makes the row
+    // conditional, and it hands over `false`, not nothing. An emptiness test
+    // that only looks for null would leave an unlabelled row in the list.
+    open({ allLabel: "" });
+    await userEvent.click(trigger());
+    expect(screen.getAllByRole("option").length).toBe(options.length);
+    expect(trigger().textContent).toContain("Select…");
+  });
+
+  it("survives an option list with nothing in it", async () => {
+    // Clearing the selection has to stay reachable even when the options have
+    // not arrived yet.
+    open({ options: [], allLabel: "Everything", selection: ["alpha"] });
+    await userEvent.click(trigger());
+    expect(rows()).toEqual(["Everything"]);
+  });
+});
+
+/**
+ * Selected first, in the order the caller gave them, then the rest — a
+ * selection made from dozens of options must not be lost among them.
+ */
+describe("MultiSelect's ordering", () => {
+  it("hoists the selected options above the unselected ones", async () => {
+    open({ selection: ["gamma"] });
+    await userEvent.click(trigger());
+    expect(rows()).toEqual(["gamma", "alpha", "Beta service"]);
+  });
+
+  it("keeps the selected options in the order they were given", async () => {
+    open({ selection: ["gamma", "alpha"] });
+    await userEvent.click(trigger());
+    expect(rows()).toEqual(["gamma", "alpha", "Beta service"]);
+  });
+
+  it("leaves the caller's order alone when nothing is selected", async () => {
+    open({ selection: [] });
+    await userEvent.click(trigger());
+    expect(rows()).toEqual(["alpha", "Beta service", "gamma"]);
+  });
+
+  it("ignores selected values that are not among the options", async () => {
+    // A stale selection outlives the option list it was made from — a filter
+    // restored from storage, an option that has since disappeared. It must not
+    // conjure a row of its own.
+    open({ selection: ["ghost", "gamma"] });
+    await userEvent.click(trigger());
+    expect(rows()).toEqual(["gamma", "alpha", "Beta service"]);
+  });
+
+  it("shows the empty state when there is nothing to choose from", async () => {
+    open({ options: [] });
+    await userEvent.click(trigger());
+    expect(screen.queryByRole("option")).toBeNull();
+    expect(screen.getByText("No results")).toBeDefined();
+  });
+});

--- a/packages/ui-kit/src/MultiSelect.tsx
+++ b/packages/ui-kit/src/MultiSelect.tsx
@@ -1,0 +1,118 @@
+import { Picker, PickerRow, optionLabel, type ComboboxOption } from "./picker";
+import { filled } from "./slot";
+
+export interface MultiSelectProps {
+  options: ComboboxOption[];
+  selection: string[];
+  onChange: (selection: string[]) => void;
+  /**
+   * Names the row that clears the selection, and what an empty selection reads
+   * as on the trigger. Leave it out and an empty selection is just empty.
+   */
+  allLabel?: string;
+  placeholder?: string;
+  searchPlaceholder?: string;
+  ariaLabel?: string;
+  className?: string;
+}
+
+/**
+ * A searchable multi select: `Combobox`'s twin, differing only in that a row
+ * toggles rather than chooses, and that the popover stays open while it does.
+ * Staying open is deliberate and is the whole point of the control — picking
+ * six things out of a list of sixty should not cost six round trips through the
+ * trigger. They share their shell; see `picker`. (#318)
+ *
+ * The classic version of this was a picker for one particular kind of thing,
+ * and it hard-coded that vocabulary twice: in its prop names, and in the
+ * sentinel that an empty selection means "all of them". The vocabulary stays in
+ * the app — the same call `NavIcon` made when its icon map did not come across
+ * — and the sentinel generalises into `allLabel`. A caller that wants the
+ * sentinel names the row and gets it; a caller for whom "none selected" is a
+ * real, different state simply leaves it out and never sees the row. (#318)
+ *
+ * Selected options are hoisted to the top, in the order they were given, then
+ * the rest. Carried over from the classic version and for its reason: a
+ * selection made from dozens of options is otherwise lost among them, and a
+ * list that reorders under you as you scan it is worse than one that does not.
+ * The hoist is computed from the selection prop, so it settles between renders
+ * rather than while the pointer is over a row.
+ */
+export function MultiSelect({
+  options,
+  selection,
+  onChange,
+  allLabel,
+  placeholder = "Select…",
+  searchPlaceholder,
+  ariaLabel,
+  className,
+}: MultiSelectProps) {
+  // A Set, so a repeated value cannot produce two rows with the same key, and
+  // iterating it still yields the caller's order.
+  const chosen = new Set(selection);
+  const byValue = new Map(options.map((option) => [option.value, option]));
+
+  // `filled` rather than `allLabel != null`: `allLabel={scoped && "Everything"}`
+  // is how a caller makes the row conditional, and it hands over `false`, which
+  // renders nothing but would still buy a row and a place on the trigger. The
+  // second comparison below is TypeScript's rather than ours — `filled` answers
+  // with a boolean, not a type guard.
+  const all = filled(allLabel) ? allLabel : undefined;
+
+  const ordered =
+    chosen.size === 0
+      ? options
+      : [
+          // A selection can outlive the options it was made from — restored
+          // from storage, or naming something that has since disappeared. Those
+          // values still count towards the summary, but they get no row.
+          ...[...chosen].map((value) => byValue.get(value)).filter((option) => option !== undefined),
+          ...options.filter((option) => !chosen.has(option.value)),
+        ];
+
+  const toggle = (value: string) => {
+    const next = new Set(chosen);
+    if (next.has(value)) next.delete(value);
+    else next.add(value);
+    onChange([...next]);
+  };
+
+  const summarize = (): string => {
+    if (selection.length === 0) return all ?? placeholder;
+    // One selection reads better as itself than as "1 selected"; past that the
+    // names stop fitting and the count is the useful fact. The label is
+    // preferred over the value for the same reason the rows show it.
+    if (selection.length === 1) {
+      const only = byValue.get(selection[0]);
+      return only ? optionLabel(only) : selection[0];
+    }
+    return `${selection.length} selected`;
+  };
+
+  return (
+    <Picker
+      summary={summarize()}
+      ariaLabel={ariaLabel}
+      searchPlaceholder={searchPlaceholder}
+      className={className}
+    >
+      {() => (
+        <>
+          {all !== undefined && (
+            <PickerRow value={all} label={all} checked={selection.length === 0} onSelect={() => onChange([])} />
+          )}
+          {ordered.map((option) => (
+            <PickerRow
+              key={option.value}
+              value={option.value}
+              label={optionLabel(option)}
+              checked={chosen.has(option.value)}
+              onSelect={() => toggle(option.value)}
+            />
+          ))}
+        </>
+      )}
+    </Picker>
+  );
+}

--- a/packages/ui-kit/src/gallery/Gallery.tsx
+++ b/packages/ui-kit/src/gallery/Gallery.tsx
@@ -1,14 +1,19 @@
 import { useEffect, useState } from "react";
 import { Badge } from "../Badge";
 import { Button } from "../Button";
+import { CodeEditor } from "../CodeEditor";
+import { ColumnPicker } from "../ColumnPicker";
+import { Combobox } from "../Combobox";
 import { ConfirmDialog } from "../ConfirmDialog";
 import { Drawer } from "../Drawer";
 import { EmptyState } from "../EmptyState";
 import { ErrorState } from "../ErrorState";
 import { Field } from "../Field";
 import { IconButton } from "../IconButton";
+import { KubectlPreview } from "../KubectlPreview";
 import { LoadingState } from "../LoadingState";
 import { Meter } from "../Meter";
+import { MultiSelect } from "../MultiSelect";
 import { MetricTile } from "../MetricTile";
 import { NavIcon } from "../NavIcon";
 import { Panel } from "../Panel";
@@ -54,6 +59,10 @@ export function Gallery() {
   const [ns, setNs] = useState("kube-system");
   const [tab, setTab] = useState("pods");
   const [drawer, setDrawer] = useState(false);
+  const [scope, setScope] = useState("kube-system");
+  const [picked, setPicked] = useState<string[]>([]);
+  const [hiddenColumns, setHiddenColumns] = useState<ReadonlySet<string>>(new Set(["age"]));
+  const [manifest, setManifest] = useState("apiVersion: v1\nkind: Pod\nmetadata:\n  name: web-1\n");
   const [dialog, setDialog] = useState<null | "plain" | "danger" | "busy">(null);
   // The busy dialog is deliberately undismissable — that is the state being
   // shown — so the catalogue releases it rather than trapping whoever opened it.
@@ -408,6 +417,87 @@ export function Gallery() {
             <NavIcon icon={DotIcon} /> Deployments
           </span>
         </div>
+      </section>
+      <section>
+        <h2>Combobox</h2>
+        {/* Use over Select when the list is long enough to want searching. */}
+        <Combobox
+          value={scope}
+          onValueChange={setScope}
+          options={[
+            { value: "kube-system" },
+            { value: "default" },
+            { value: "monitoring" },
+            { value: "cert-manager" },
+          ]}
+          ariaLabel="Scope"
+        />
+        <p className="text-[0.75rem] text-muted">chosen: {scope}</p>
+      </section>
+
+      <section>
+        <h2>MultiSelect</h2>
+        {/* Stays open while toggling, so several can be picked in one visit.
+            `allLabel` is how a filter says "no filter" without a sentinel
+            value the caller has to invent. */}
+        <MultiSelect
+          options={[{ value: "default" }, { value: "kube-system" }, { value: "monitoring" }]}
+          selection={picked}
+          onChange={setPicked}
+          allLabel="All namespaces"
+          ariaLabel="Namespaces"
+        />
+        <p className="text-[0.75rem] text-muted">
+          selected: {picked.length === 0 ? "(all)" : picked.join(", ")}
+        </p>
+      </section>
+
+      <section>
+        <h2>ColumnPicker</h2>
+        {/* The pinned column is the row identifier: offered, but never off. */}
+        <ColumnPicker
+          columns={[
+            { key: "name", label: "Name" },
+            { key: "namespace", label: "Namespace" },
+            { key: "status", label: "Status" },
+            { key: "age", label: "Age" },
+          ]}
+          hidden={hiddenColumns}
+          pinnedKey="name"
+          onToggle={(key) =>
+            setHiddenColumns((current) => {
+              const next = new Set(current);
+              if (next.has(key)) next.delete(key);
+              else next.add(key);
+              return next;
+            })
+          }
+        />
+        <p className="text-[0.75rem] text-muted">
+          hidden: {hiddenColumns.size === 0 ? "(none)" : [...hiddenColumns].join(", ")}
+        </p>
+      </section>
+
+      <section>
+        <h2>KubectlPreview</h2>
+        <KubectlPreview command="kubectl delete pod web-1 -n default" onCopy={() => {}} />
+        {/* Not every action has a faithful one-liner; the note says so in the
+            same place rather than leaving the dialog silent. */}
+        <KubectlPreview note="Eviction is an API call with no kubectl verb of its own." />
+      </section>
+
+      <section>
+        <h2>CodeEditor</h2>
+        <div style={{ height: 200 }}>
+          <CodeEditor
+            value={manifest}
+            onChange={setManifest}
+            ariaLabel="Manifest YAML"
+            fill
+          />
+        </div>
+        {/* Completions are the caller's: the kit knows CodeMirror, not what an
+            apiVersion is. */}
       </section>
     </div>
   );

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -1,15 +1,20 @@
 /** The srelens design system. Components are added as they are merged in. */
 export { Badge, type BadgeTone } from "./Badge";
 export { Button, type ButtonProps, type ButtonSize, type ButtonVariant } from "./Button";
+export { CodeEditor, documentDiagnostics, yamlDiagnostics, type CodeEditorProps } from "./CodeEditor";
+export { ColumnPicker, type ColumnOption, type ColumnPickerProps } from "./ColumnPicker";
+export { Combobox, type ComboboxOption, type ComboboxProps } from "./Combobox";
 export { ConfirmDialog, type ConfirmDialogProps } from "./ConfirmDialog";
 export { Drawer, type DrawerProps } from "./Drawer";
 export { EmptyState, type EmptyStateProps } from "./EmptyState";
 export { ErrorState, type ErrorStateProps } from "./ErrorState";
 export { Field, type FieldProps } from "./Field";
 export { IconButton, type IconButtonProps, type IconComponent } from "./IconButton";
+export { KubectlPreview, type KubectlPreviewProps } from "./KubectlPreview";
 export { LoadingState, type LoadingStateProps } from "./LoadingState";
 export { Meter } from "./Meter";
 export { MetricTile, type MetricTileProps } from "./MetricTile";
+export { MultiSelect, type MultiSelectProps } from "./MultiSelect";
 export { NavIcon, type NavIconProps } from "./NavIcon";
 export { Panel, type PanelProps } from "./Panel";
 export { Screen, type ScreenProps } from "./Screen";

--- a/packages/ui-kit/src/picker.tsx
+++ b/packages/ui-kit/src/picker.tsx
@@ -1,0 +1,149 @@
+import { useState, type ReactNode } from "react";
+import { Popover } from "radix-ui";
+import { Command } from "cmdk";
+import { cx } from "./cx";
+
+export interface ComboboxOption {
+  value: string;
+  label?: string;
+}
+
+/** What an option is called. The label is optional because most values read fine on their own. */
+export function optionLabel(option: ComboboxOption): string {
+  return option.label ?? option.value;
+}
+
+export interface PickerProps {
+  /** What the trigger says about the current state — a value, a count, a stand-in. */
+  summary: string;
+  ariaLabel?: string;
+  searchPlaceholder?: string;
+  className?: string;
+  /** The rows, given a way to close the popover — which single-select wants and multi-select does not. */
+  children: (close: () => void) => ReactNode;
+}
+
+/**
+ * The shell both pickers are built out of: a trigger that summarises the
+ * current state, and a popover holding a search box over a bounded, scrolling
+ * list.
+ *
+ * `Combobox` and `MultiSelect` are the same control with a different answer to
+ * one question — what a row click does. Everything else is identical, and in
+ * the classic app it was identical by copy: two files with the same trigger
+ * markup, the same popover, the same command list, drifting independently. It
+ * lives here once instead, and the two components are left holding only what
+ * actually differs between them: the summary, the rows, and whether choosing
+ * closes.
+ *
+ * Radix's Popover and cmdk's Command do the work, for the same reason
+ * `ConfirmDialog` leans on Radix's Dialog — positioning against a trigger that
+ * may be near a viewport edge, dismissing on an outside click, moving focus to
+ * the search box and back to the trigger, and arrow-key navigation over a
+ * filtered list are each a library-sized problem, and all four are already
+ * solved. What is ours is the seam: which classes it wears, and the render prop
+ * below. (#318)
+ */
+export function Picker({ summary, ariaLabel, searchPlaceholder = "Search…", className, children }: PickerProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Popover.Root open={open} onOpenChange={setOpen}>
+      <Popover.Trigger asChild>
+        {/* Explicitly a button: these stand in toolbars, a toolbar can stand in
+            a form, and a button without a type submits it. Radix supplies
+            aria-expanded, aria-controls and data-state; the combobox role is
+            ours, because a popover full of options is not the generic dialog
+            Radix assumes. */}
+        <button type="button" role="combobox" aria-label={ariaLabel} className={cx("btn justify-between", className)}>
+          <span className="min-w-0 truncate">{summary}</span>
+          {/* Inline rather than an icon-set import: the kit takes no dependency
+              on lucide, and these are the only two glyphs it needs. */}
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" aria-hidden="true" className="shrink-0 opacity-60">
+            <path d="m7 15 5 5 5-5M7 9l5-5 5 5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+          </svg>
+        </button>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content
+          align="start"
+          sideOffset={4}
+          className="popover w-[268px]"
+          // `.popover` is written for a panel that places itself: `position:
+          // fixed`. Radix already fixes and translates a wrapper around this
+          // content, and a fixed child leaves that wrapper zero-sized — which
+          // is the box the collision logic measures, so the panel would flip
+          // and shift against nothing. Relative rather than static keeps the
+          // stylesheet's z-index doing its job.
+          style={{ position: "relative" }}
+        >
+          <Command>
+            <div className="rule-b flex items-center gap-1.5 px-2 py-1.5">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" aria-hidden="true" className="shrink-0 text-faint">
+                <circle cx="11" cy="11" r="7" stroke="currentColor" strokeWidth="2" />
+                <path d="m20 20-3.6-3.6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+              </svg>
+              <Command.Input
+                placeholder={searchPlaceholder}
+                className="w-full bg-transparent text-[0.8125rem] outline-none placeholder:text-faint"
+              />
+            </div>
+            {/* Capped and scrolling: the whole reason to reach for this over a
+                plain select is that the option set is too long to show. */}
+            <Command.List className="scroll max-h-[240px]">
+              <Command.Empty className="px-3 py-4 text-center text-[0.75rem] text-faint">No results</Command.Empty>
+              {children(() => setOpen(false))}
+            </Command.List>
+          </Command>
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}
+
+export interface PickerRowProps {
+  /** Identifies the row to cmdk's filter, and must be unique within the list. */
+  value: string;
+  label: string;
+  checked: boolean;
+  onSelect: () => void;
+}
+
+/** One row: a check that holds its column whether or not it is showing, and a label. */
+export function PickerRow({ value, label, checked, onSelect }: PickerRowProps) {
+  return (
+    <Command.Item
+      value={value}
+      // The row is found by what it says as well as by its value, so an option
+      // whose label bears no resemblance to its value is still searchable.
+      keywords={[label]}
+      onSelect={onSelect}
+      data-on={checked}
+      // cmdk owns `aria-selected` on these rows and uses it for the highlight
+      // that follows the pointer and the arrow keys, so it cannot also carry
+      // the chosen state. `aria-checked` is free, and is what a row with a
+      // check mark on it means.
+      aria-checked={checked}
+      // `.ns-row` is the design's row inside a popover, and `data-on` is how it
+      // marks the live one. The extra rule is for cmdk's highlight, which
+      // follows the pointer and the arrow keys alike — so the keyboard gets the
+      // same feedback the mouse does, which a plain `:hover` cannot give it.
+      className="ns-row data-[selected=true]:bg-[var(--field)]"
+    >
+      <svg
+        width="12"
+        height="12"
+        viewBox="0 0 24 24"
+        fill="none"
+        aria-hidden="true"
+        // Always rendered, never removed: the labels line up in a column, and a
+        // check appearing would otherwise shove the row it belongs to sideways.
+        className={cx("shrink-0", checked ? "opacity-100" : "opacity-0")}
+        style={{ color: "var(--accent)" }}
+      >
+        <path d="M20 6 9 17l-5-5" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+      <span className="truncate">{label}</span>
+    </Command.Item>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,9 +220,42 @@ importers:
 
   packages/ui-kit:
     dependencies:
+      '@codemirror/autocomplete':
+        specifier: ^6.20.3
+        version: 6.20.3
+      '@codemirror/commands':
+        specifier: ^6.10.4
+        version: 6.10.4
+      '@codemirror/lang-yaml':
+        specifier: ^6.1.3
+        version: 6.1.3
+      '@codemirror/language':
+        specifier: ^6.12.4
+        version: 6.12.4
+      '@codemirror/lint':
+        specifier: ^6.9.7
+        version: 6.9.7
+      '@codemirror/search':
+        specifier: ^6.7.1
+        version: 6.7.1
+      '@codemirror/state':
+        specifier: ^6.7.0
+        version: 6.7.0
+      '@codemirror/view':
+        specifier: ^6.43.4
+        version: 6.43.4
+      '@lezer/highlight':
+        specifier: ^1.2.3
+        version: 1.2.3
+      cmdk:
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       radix-ui:
         specifier: ^1.6.0
         version: 1.6.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@testing-library/react':
         specifier: ^16.3.2


### PR DESCRIPTION
The last five components. **#318 is complete: 19 of 19.** Part of #318.

## The one that could not be a migration

`CodeEditor` imported a type and four helpers from `@srelens/core` to resolve Kubernetes schemas for autocomplete. The kit may not — `tokens-only.test.ts` asserts it — and that is not a rule to work around: a design system has no business knowing what an `apiVersion` is.

So `schemaSource` becomes **`completions`**, CodeMirror's own `CompletionSource`. The caller resolves schemas and hands over the result; the kit knows CodeMirror and nothing else. `schemaValidate` was already structural and survives, though its doc pointed at `k8s.validateManifest`, an app API that does not exist here.

`k8sDiagnostics` becomes **`documentDiagnostics`**. What it does is locate a field path inside a multi-document YAML file — not a Kubernetes idea. The old name described its caller rather than its work. Its twelve tests came across with it.

The theme's sixteen `--fl-*` tokens map onto the design's, and five raw `rgba()` values become `color-mix` over tokens, as `ConfirmDialog`'s overlay already does. Syntax colours follow the mock's editor: keys accent, numbers and bools info, comments faint.

## `NamespaceMultiSelect` arrives as `MultiSelect`

Same call as `NavIcon`, whose Kubernetes icon map stayed in the app: which resources have namespaces is the product's vocabulary. The "empty selection means all namespaces" sentinel generalises to `allLabel`, and the summary from `"N namespaces"` to `"N selected"`. No product vocabulary in the component, its types, its comments or its tests.

`Combobox` and `MultiSelect` were the same control asking one question differently — what a row click does. In the classic app that was two files with byte-identical trigger, popover and command list, free to drift. The shell is one internal module now, handing its children a `close` callback; what is left in each component is its own decision.

Rows carry chosen state in `aria-checked`, not `aria-selected`: cmdk uses `aria-selected` to mean *highlighted*, so it cannot also mean *picked*.

## Two things the popover migration had to work out

**`.popover` sets `position: fixed`.** It was written for a panel that places itself. Radix already fixes and translates a wrapper around its content, and a fixed child leaves that wrapper zero-sized — which is the box floating-ui measures, so the panel would flip and shift against nothing. Overridden to `relative`, not `static`, so the stylesheet's `z-index: 45` still applies. Two people hit this independently and converged on the same fix, which is some evidence it is real rather than one theory.

**A disabled checkbox still fires `onChange`.** React delivers the synthetic event from a click even on a disabled input. Not a live bug — a browser never dispatches that click — but `ColumnPicker`'s pinned-column invariant was living in an HTML attribute rather than in the component, so an accessibility review swapping `disabled` for `aria-disabled` would have made the row identifier toggleable with nothing failing. Guarded in `onChange` too.

`ColumnPicker`'s trigger also drops the classic's hardcoded `aria-label="Choose columns"` whenever it has a visible label, so the accessible name matches what is on screen — which is what lets a speech-input user say it. The `aria-label` survives only for an icon-only trigger.

## Dependencies

`cmdk`, `yaml`, `@lezer/highlight` and eight `@codemirror/*` packages become ui-kit dependencies, all at the versions `apps/desktop` already pinned. A code editor is a UI component, and a searchable listbox with keyboard navigation is the library-sized problem #324 taught this kit not to hand-write.

## What is not covered, said plainly

- **The late-arriving `completions` fix has no test.** I first gated `autocompletion` on the prop being present at mount; the editor is rebuilt only when a *structural* option changes, and a caller resolving completions from the cluster supplies them afterwards — so it would silently never register. Fixed by registering unconditionally and reading through a ref. Driving CodeMirror's completion machinery in jsdom is not practical, so the reasoning is a comment rather than an assertion.
- **`fill` / `minHeight` / `maxHeight` are not asserted.** CodeMirror compiles its theme into a generated stylesheet with hashed class names, and jsdom applies no CSS. A test on a generated class name would pin CodeMirror's internals and still prove nothing about layout, so the test says what it does not cover instead.
- **`ColumnPicker` does not use the shared picker shell.** It is not a searchable picker, so it is not an obvious client — but the trigger and popover-surface handling now exist in two places. Worth revisiting if a third popover component appears.

## Verification

- 1607 tests across 186 files pass; coverage 86.86 / 82.96 / 77.97, above the 85 / 80 / 76 floors.
- Typecheck clean across all four projects; `pnpm build` clean.
- `tokens-only` passes, including its `@srelens/core` assertion — the kit still cannot reach the service layer.
- The gallery test derives its checklist from the barrel, so all five new exports are confirmed to have a section.
- Every component written test-first, with the RED step confirmed as real assertion failures rather than module-not-found.

`apps/desktop` is untouched: the classic tree stays frozen until step 11.
