### PR TITLE
feat(ui-next): link the component gallery from the placeholder

### DIFF
--- a/packages/ui-kit/src/styles/kit.css
+++ b/packages/ui-kit/src/styles/kit.css
@@ -1114,6 +1114,16 @@
   color: var(--ink-muted);
 }
 
+.next-placeholder a {
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent-line);
+}
+
+.next-placeholder a:hover {
+  border-bottom-color: var(--accent);
+}
+
 .next-placeholder button {
   padding: 7px 14px;
   border: 1px solid var(--rule-strong);

--- a/packages/ui-next/src/index.test.tsx
+++ b/packages/ui-next/src/index.test.tsx
@@ -1,9 +1,15 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { NextApp } from "./index";
 
 describe("NextApp", () => {
+  // jsdom keeps one window.location for the whole file, so a test that
+  // navigates hands the next one a gallery instead of the placeholder.
+  beforeEach(() => {
+    window.location.hash = "";
+  });
+
   it("says what it is, so nobody thinks the app is broken", () => {
     // The whole new design is one placeholder at this point. Someone who opts
     // in has to be told that, not left guessing.
@@ -50,5 +56,21 @@ describe("NextApp", () => {
     window.location.hash = "";
     window.dispatchEvent(new HashChangeEvent("hashchange"));
     expect(await screen.findByRole("heading", { name: /new design/i })).toBeDefined();
+  });
+  it("offers a way into the component gallery", async () => {
+    // The gallery has been reachable at #gallery since #317, and nothing said
+    // so: switching the new design on showed a page announcing that nothing is
+    // built, with twenty-four built components one hash away. A surface nobody
+    // can find is one nobody reviews. (#318)
+    render(<NextApp onExit={() => null} />);
+    await userEvent.click(screen.getByRole("link", { name: /component gallery/i }));
+    expect(await screen.findByRole("heading", { name: /design system/i })).toBeDefined();
+  });
+
+  it("says the gallery is a developer surface, not a screen", async () => {
+    // So that finding it does not read as "this is what the new design is".
+    render(<NextApp onExit={() => null} />);
+    expect(screen.getByRole("link", { name: /component gallery/i }).textContent).toMatch(/gallery/i);
+    expect(screen.getByText(/still being written/i)).toBeDefined();
   });
 });

--- a/packages/ui-next/src/index.tsx
+++ b/packages/ui-next/src/index.tsx
@@ -26,9 +26,12 @@ function useHash(): string {
 /**
  * The new design's root.
  *
- * A placeholder for now. This package exists so the design switch has a real
- * second tree to load, with its own stylesheet — which is what proves the two
- * designs never share a document. The shell and screens arrive in later steps.
+ * A placeholder for the screens, which arrive in later steps. This package
+ * exists so the design switch has a real second tree to load, with its own
+ * stylesheet — which is what proves the two designs never share a document.
+ *
+ * It is not empty, though: the component gallery lives here, and is linked
+ * from the placeholder rather than left to whoever already knows the hash.
  *
  * It carries its own way back to the classic design on purpose: Settings does
  * not exist here yet, so without this button someone who opts in would have no
@@ -56,6 +59,16 @@ export function NextApp({ onExit }: { onExit: () => Promise<string | null> | str
       <p>
         Nothing is built here yet. You are seeing this because the new design is
         switched on in Settings — the screens are still being written.
+      </p>
+      {/* The kit has been reachable at #gallery since #317 and nothing said so,
+          which left this page announcing that nothing is built with two dozen
+          built components one hash away. A review surface nobody can find is
+          one nobody reviews. An anchor rather than a button because it goes
+          somewhere: middle-click and copy-link work, and the hash is the
+          address. (#318) */}
+      <p>
+        <a href="#gallery">Component gallery</a> — every component in the design
+        system, in its states. A developer surface rather than a screen.
       </p>
       <button type="button" onClick={() => void leave()}>
         Back to the classic design


### PR DESCRIPTION
Switching the new design on shows a page saying nothing is built here yet. Two dozen components *are* built, and the gallery that shows them has been reachable at `#gallery` since #317 — but nothing on the page said so, so it was findable only by someone who already knew the hash, which is nobody who needed telling.

A review surface nobody can find is one nobody reviews. This links it.

## What it does not do

It does not make the gallery the landing content. The placeholder's message is accurate — no *screens* are built — and the gallery is a developer surface. Presenting it as what the new design is would be a nicer screenshot and a worse claim.

## Details

- An anchor rather than a button, because it goes somewhere: the hash is the address, so middle-click and copy-link behave as expected.
- Named as a developer surface in the same sentence, so finding it does not read as "this is the new design".
- `.next-placeholder` had no rule for links. The one link on it would have rendered browser-blue — on a page whose entire job is to prove the design's own stylesheet reached the document and that the two designs never share one. It now uses the accent and the accent line.

## Verification

- 1609 tests across 186 files pass; coverage 86.9 / 82.97 / 78.04, above the floors.
- Typecheck clean across all four projects; `pnpm build` clean.
- Both new tests sabotage-checked: removing the link fails them.
- The five pre-existing `NextApp` tests are unchanged. I did reword the placeholder copy at first and broke one of them — the wording is a contract, so it went back.
- Added a `beforeEach` resetting `window.location.hash`: jsdom keeps one location for a whole file, so a test that navigates handed the next one a gallery instead of the placeholder.
