### PR TITLE
feat(ui-kit): port Table — behaviour whole, presentation rebuilt

### DIFF
--- a/packages/ui-kit/src/Table.test.tsx
+++ b/packages/ui-kit/src/Table.test.tsx
@@ -1,0 +1,422 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Table, filterTableData, computeVisibleRange, type Column } from "./Table";
+
+/**
+ * Compact ages as seconds, standing in for core's `ageSeconds`, which the kit
+ * has no dependency on. What the test below is about is the Table honouring
+ * `getSortValue` when the visible text does not order correctly — "1y" against
+ * "300d" — not whether this parser is right; core tests that where it lives.
+ */
+function ageSeconds(age: string): number {
+  const [, n, unit] = /^(\d+)([smhdy])$/.exec(age) ?? [];
+  const scale: Record<string, number> = { s: 1, m: 60, h: 3600, d: 86400, y: 31536000 };
+  return Number(n) * (scale[unit] ?? 0);
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+/**
+ * The classic Table's tests, carried over whole. Every behavioural assertion is
+ * unchanged — virtualisation, the #298/#299 column-width pinning, sorting,
+ * selection, filtering. What moved is the class names the queries hang off:
+ * `fl-data-table__row` is now `tbl-row` and `fl-data-table--resized` is
+ * `tbl-resized`, because the presentation is rebuilt against the new design
+ * while the behaviour is not. (#319)
+ */
+
+describe("Table virtualization", () => {
+  const bigColumns: Column<{ name: string; phase: string }>[] = [
+    { key: "name", header: "Name" },
+    { key: "phase", header: "Phase" },
+  ];
+  const bigData = Array.from({ length: 1000 }, (_, i) => ({ name: `row-${i}`, phase: "x" }));
+
+  it("renders every row when layout can't be measured (jsdom fallback)", () => {
+    const { container } = render(
+      <Table columns={bigColumns} data={bigData} getRowKey={(r) => r.name} />,
+    );
+    // No measurable row height → degrade to rendering all rows.
+    expect(container.querySelectorAll("tbody tr.tbl-row").length).toBe(1000);
+  });
+
+  it("renders only a window of rows when the row height is measurable", () => {
+    // Simulate layout: each row 20px tall inside a 200px scroll viewport.
+    vi.spyOn(HTMLTableRowElement.prototype, "getBoundingClientRect").mockReturnValue({
+      height: 20,
+    } as DOMRect);
+    const { container } = render(
+      <div data-testid="scroll" style={{ overflowY: "auto" }}>
+        <Table columns={bigColumns} data={bigData} getRowKey={(r) => r.name} />
+      </div>,
+    );
+    const sp = screen.getByTestId("scroll");
+    Object.defineProperty(sp, "clientHeight", { value: 200, configurable: true });
+    Object.defineProperty(sp, "scrollTop", { value: 0, writable: true, configurable: true });
+    fireEvent.scroll(sp);
+
+    const rows = container.querySelectorAll("tbody tr.tbl-row");
+    expect(rows.length).toBeLessThan(100); // a window, not all 1000
+    expect(rows.length).toBeGreaterThan(0);
+    expect(screen.getByText("row-0")).toBeDefined();
+    expect(screen.queryByText("row-900")).toBeNull(); // far off-screen, not rendered
+  });
+
+  /** Simulate real layout: 20px rows, and header cells with natural widths. */
+  function mockLayout(headWidth = 140) {
+    vi.spyOn(HTMLTableRowElement.prototype, "getBoundingClientRect").mockReturnValue({
+      height: 20,
+    } as DOMRect);
+    vi.spyOn(HTMLTableCellElement.prototype, "getBoundingClientRect").mockReturnValue({
+      width: headWidth,
+    } as DOMRect);
+  }
+
+  function renderScrollable(data: { name: string; phase: string }[]) {
+    const utils = render(
+      <div data-testid="scroll" style={{ overflowY: "auto" }}>
+        <Table columns={bigColumns} data={data} getRowKey={(r) => r.name} />
+      </div>,
+    );
+    const sp = screen.getByTestId("scroll");
+    Object.defineProperty(sp, "clientHeight", { value: 200, configurable: true });
+    Object.defineProperty(sp, "scrollTop", { value: 0, writable: true, configurable: true });
+    fireEvent.scroll(sp);
+    return { ...utils, sp };
+  }
+
+  const colWidths = (container: HTMLElement) =>
+    Array.from(container.querySelectorAll("colgroup col")).map(
+      (col) => (col as HTMLTableColElement).style.width,
+    );
+
+  it("pins column widths once a long list virtualizes (#298)", () => {
+    mockLayout();
+    const { container } = renderScrollable(bigData);
+    // Without pinned widths the browser re-derives them from whichever rows are
+    // currently rendered, so the columns shift on every scroll.
+    expect(colWidths(container).every((w) => w !== "")).toBe(true);
+    expect(container.querySelector("table")?.className).toContain("tbl-resized");
+  });
+
+  it("keeps those widths identical across scrolls (#298)", () => {
+    mockLayout();
+    const { container, sp } = renderScrollable(bigData);
+    const before = colWidths(container);
+    expect(before.every((w) => w !== "")).toBe(true); // guard: not vacuously equal
+    Object.defineProperty(sp, "scrollTop", { value: 4000, writable: true, configurable: true });
+    fireEvent.scroll(sp);
+    expect(screen.queryByText("row-0")).toBeNull(); // the rendered window really moved
+    expect(colWidths(container)).toEqual(before);
+  });
+
+  it("pins short lists too, so every table behaves the same way (#298)", () => {
+    // CRDs, Services and most lists sit under the virtualization threshold.
+    // They must not size differently from the long ones.
+    mockLayout();
+    const { container } = renderScrollable(bigData.slice(0, 10));
+    expect(colWidths(container).every((w) => w !== "")).toBe(true);
+    expect(container.querySelector("table")?.className).toContain("tbl-resized");
+  });
+
+  it("keeps widths pinned when filtering drops a list below the threshold (#298)", () => {
+    // Narrowing a virtualized list past the threshold must not hand it back to
+    // automatic layout, or the columns snap as the user types.
+    mockLayout();
+    const { container, rerender } = render(
+      <div data-testid="scroll" style={{ overflowY: "auto" }}>
+        <Table columns={bigColumns} data={bigData} getRowKey={(r) => r.name} />
+      </div>,
+    );
+    const sp = screen.getByTestId("scroll");
+    Object.defineProperty(sp, "clientHeight", { value: 200, configurable: true });
+    Object.defineProperty(sp, "scrollTop", { value: 0, writable: true, configurable: true });
+    fireEvent.scroll(sp);
+    const before = colWidths(container);
+    expect(before.every((w) => w !== "")).toBe(true);
+
+    rerender(
+      <div data-testid="scroll" style={{ overflowY: "auto" }}>
+        <Table columns={bigColumns} data={bigData.slice(0, 5)} getRowKey={(r) => r.name} />
+      </div>,
+    );
+    expect(colWidths(container)).toEqual(before);
+  });
+
+  it("does not pin an empty table, so widths are measured from real rows", () => {
+    mockLayout();
+    const { container } = renderScrollable([]);
+    expect(container.querySelector("colgroup")).toBeNull(); // empty state, no table
+  });
+});
+
+describe("Table sorting", () => {
+  it("orders 64-bit integers exactly, beyond Number's safe range", () => {
+    // Number() collapses these two to the same value, so a numeric sort key
+    // cannot separate them. Negative, because string collation happens to get
+    // large positives right and would hide the gap: it compares "-...993"
+    // against "-...992" by magnitude and puts them the wrong way round.
+    // The comparator must also not use arithmetic on a bigint, which throws.
+    const rows = [
+      { id: "b", n: -9007199254740992n },
+      { id: "a", n: -9007199254740993n },
+    ];
+    const cols: Column<(typeof rows)[number]>[] = [
+      { key: "id", header: "Id" },
+      { key: "n", header: "N", getSortValue: (r) => r.n },
+    ];
+    render(<Table columns={cols} data={rows} getRowKey={(r) => r.id} />);
+    fireEvent.click(screen.getByRole("button", { name: "Sort by N" }));
+    const order = Array.from(document.querySelectorAll("tbody tr.tbl-row")).map(
+      (tr) => tr.textContent?.[0],
+    );
+    expect(order).toEqual(["a", "b"]);
+  });
+
+  it("sorts rows with no value below real ones when mixing bigint and number", () => {
+    const rows = [
+      { id: "big", n: 12n as bigint | number },
+      { id: "none", n: Number.NEGATIVE_INFINITY },
+      { id: "small", n: 3n },
+    ];
+    const cols: Column<(typeof rows)[number]>[] = [
+      { key: "id", header: "Id" },
+      { key: "n", header: "N", getSortValue: (r) => r.n },
+    ];
+    render(<Table columns={cols} data={rows} getRowKey={(r) => r.id} />);
+    fireEvent.click(screen.getByRole("button", { name: "Sort by N" }));
+    const order = Array.from(document.querySelectorAll("tbody tr.tbl-row")).map(
+      (tr) => tr.textContent?.slice(0, 5),
+    );
+    expect(order?.[0]).toContain("none");
+  });
+});
+
+describe("computeVisibleRange", () => {
+  it("returns the window of rows around the scroll position with overscan", () => {
+    // rowHeight 20, viewport 100 → 5 visible rows; scrolled to row 50; overscan 3.
+    const r = computeVisibleRange({ scrollTop: 1000, viewportHeight: 100, rowHeight: 20, total: 500, overscan: 3 });
+    expect(r.start).toBe(47); // 50 - 3
+    expect(r.end).toBe(58); // 50 + ceil(100/20)=5 + 3
+  });
+
+  it("clamps to the data bounds", () => {
+    expect(computeVisibleRange({ scrollTop: 0, viewportHeight: 100, rowHeight: 20, total: 500, overscan: 3 }).start).toBe(0);
+    const end = computeVisibleRange({ scrollTop: 999999, viewportHeight: 100, rowHeight: 20, total: 500, overscan: 3 });
+    expect(end.end).toBe(500);
+    expect(end.start).toBeLessThanOrEqual(500);
+  });
+
+  it("renders everything when the row height is unknown (0)", () => {
+    // jsdom / pre-measure: fall back to the full range rather than dividing by zero.
+    expect(computeVisibleRange({ scrollTop: 0, viewportHeight: 0, rowHeight: 0, total: 42, overscan: 3 })).toEqual({
+      start: 0,
+      end: 42,
+    });
+  });
+});
+
+interface Row {
+  name: string;
+  phase: string;
+}
+
+const columns: Column<Row>[] = [
+  { key: "name", header: "Name" },
+  { key: "phase", header: "Phase", render: (r) => <em>{r.phase}</em> },
+];
+
+const data: Row[] = [
+  { name: "web-1", phase: "Running" },
+  { name: "web-2", phase: "Pending" },
+];
+
+describe("Table", () => {
+  it("renders headers and rows, using custom cell renderers", () => {
+    render(<Table columns={columns} data={data} getRowKey={(r) => r.name} />);
+    expect(screen.getByText("Name")).toBeDefined();
+    expect(screen.getByText("web-1")).toBeDefined();
+    // custom render wraps phase in <em>
+    expect(screen.getByText("Running").tagName).toBe("EM");
+  });
+
+  it("fires onRowClick with the clicked row", () => {
+    const onRowClick = vi.fn();
+    render(
+      <Table columns={columns} data={data} getRowKey={(r) => r.name} onRowClick={onRowClick} />,
+    );
+    fireEvent.click(screen.getByText("web-2"));
+    expect(onRowClick).toHaveBeenCalledWith({ name: "web-2", phase: "Pending" });
+  });
+
+  it("marks the selected row via aria-selected", () => {
+    render(
+      <Table columns={columns} data={data} getRowKey={(r) => r.name} selectedKey="web-1" />,
+    );
+    const selected = screen.getByText("web-1").closest("tr");
+    expect(selected?.getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("shows empty text when there is no data", () => {
+    render(
+      <Table columns={columns} data={[]} getRowKey={(r) => r.name} emptyText="No pods" />,
+    );
+    expect(screen.getByText("No pods")).toBeDefined();
+  });
+
+  it("cycles column sorting through ascending, descending, and unsorted", () => {
+    render(<Table columns={columns} data={[...data].reverse()} getRowKey={(r) => r.name} />);
+    const sort = screen.getByRole("button", { name: "Sort by Name" });
+
+    fireEvent.click(sort);
+    expect(screen.getAllByRole("row")[1].textContent).toContain("web-1");
+    fireEvent.click(sort);
+    expect(screen.getAllByRole("row")[1].textContent).toContain("web-2");
+    fireEvent.click(sort);
+    expect(screen.getAllByRole("row")[1].textContent).toContain("web-2");
+  });
+
+  it("sorts by getSortValue while filtering stays on the visible text (#236)", () => {
+    const rows = [
+      { name: "old", age: "1y" },
+      { name: "older", age: "2y" },
+      { name: "recent", age: "300d" },
+    ];
+    const ageColumns = [
+      { key: "name", header: "Name" },
+      {
+        key: "age",
+        header: "Age",
+        getSortValue: (r: (typeof rows)[number]) => ageSeconds(r.age),
+      },
+    ];
+    render(<Table columns={ageColumns} data={rows} getRowKey={(r) => r.name} />);
+
+    // Ascending: 300d < 1y < 2y — numeric collation on the strings would
+    // have put both years first (1 < 2 < 300).
+    fireEvent.click(screen.getByRole("button", { name: "Sort by Age" }));
+    const names = screen.getAllByRole("row").slice(1).map((r) => r.textContent);
+    expect(names).toEqual(["recent300d", "old1y", "older2y"]);
+
+    // The filter still matches the display text, not the sort key.
+    expect(filterTableData(rows, ageColumns, "1y", null)).toEqual([{ name: "old", age: "1y" }]);
+  });
+
+  it("hands sort changes to the owner when controlled (#254)", () => {
+    // The tab owns the sort so it survives a switch; the table must not keep
+    // a private copy that silently diverges from what it was handed.
+    const onSortChange = vi.fn();
+    const { rerender } = render(
+      <Table
+        columns={columns}
+        data={data}
+        getRowKey={(r) => r.name}
+        sort={null}
+        onSortChange={onSortChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Sort by Name" }));
+    expect(onSortChange).toHaveBeenCalledWith({ key: "name", direction: "asc" });
+
+    // Still unsorted on screen until the owner feeds the new value back.
+    expect(screen.getAllByRole("row")[1].textContent).toContain("web-1");
+
+    rerender(
+      <Table
+        columns={columns}
+        data={[...data].reverse()}
+        getRowKey={(r) => r.name}
+        sort={{ key: "name", direction: "asc" }}
+        onSortChange={onSortChange}
+      />,
+    );
+    expect(screen.getAllByRole("row")[1].textContent).toContain("web-1");
+  });
+
+  it("keeps its own sort when uncontrolled", () => {
+    // Tables outside the tabbed workspace have no tab to store a sort on.
+    render(<Table columns={columns} data={[...data].reverse()} getRowKey={(r) => r.name} />);
+    fireEvent.click(screen.getByRole("button", { name: "Sort by Name" }));
+    expect(screen.getAllByRole("row")[1].textContent).toContain("web-1");
+  });
+
+  it("selects a column for the toolbar search", () => {
+    const onChange = vi.fn();
+    render(
+      <Table
+        columns={columns}
+        data={data}
+        getRowKey={(r) => r.name}
+        onActiveFilterKeyChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Filter search by Phase" }));
+    expect(onChange).toHaveBeenCalledWith("phase");
+  });
+
+  it("filters globally or by the selected column", () => {
+    expect(filterTableData(data, columns, "running", null)).toEqual([data[0]]);
+    expect(filterTableData(data, columns, "web", "phase")).toEqual([]);
+    expect(filterTableData(data, columns, "web-2", "name")).toEqual([data[1]]);
+  });
+
+  it("resizes a column with the keyboard and resets it on double click", () => {
+    render(<Table columns={columns} data={data} getRowKey={(r) => r.name} />);
+    const handle = screen.getByRole("separator", { name: "Resize Name column" });
+    const header = screen.getByText("Name").closest("th");
+
+    fireEvent.keyDown(handle, { key: "ArrowRight" });
+    expect(header?.closest("table")?.style.width).toBe("256px");
+    // Reset drops the user's widths and the table re-measures its natural ones
+    // (2 columns x the 120px jsdom fallback) rather than falling back to
+    // automatic layout, which no table uses any more.
+    fireEvent.doubleClick(handle);
+    expect(header?.closest("table")?.style.width).toBe("240px");
+  });
+});
+
+describe("Table multi-selection", () => {
+  const cols: Column<{ name: string }>[] = [{ key: "name", header: "Name" }];
+  const rows = [{ name: "a" }, { name: "b" }, { name: "c" }, { name: "d" }];
+
+  function renderWithSelection(selected = new Set<string>()) {
+    const onChange = vi.fn();
+    const utils = render(
+      <Table
+        columns={cols}
+        data={rows}
+        getRowKey={(r) => r.name}
+        selection={{ selected, onChange }}
+      />,
+    );
+    return { onChange, ...utils };
+  }
+
+  it("toggles a single row", () => {
+    const { onChange } = renderWithSelection();
+    fireEvent.click(screen.getByLabelText("Select b"));
+    expect([...onChange.mock.calls[0][0]]).toEqual(["b"]);
+  });
+
+  it("select-all header selects every (filtered) row", () => {
+    const { onChange } = renderWithSelection();
+    fireEvent.click(screen.getByLabelText("Select all"));
+    expect([...onChange.mock.calls[0][0]].sort()).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("shift-click selects the range from the anchor", () => {
+    const { onChange, rerender } = renderWithSelection();
+    fireEvent.click(screen.getByLabelText("Select a")); // anchor = a
+    const selected = onChange.mock.calls[0][0] as Set<string>;
+    rerender(
+      <Table columns={cols} data={rows} getRowKey={(r) => r.name} selection={{ selected, onChange }} />,
+    );
+    fireEvent.click(screen.getByLabelText("Select c"), { shiftKey: true });
+    expect([...onChange.mock.calls[1][0]].sort()).toEqual(["a", "b", "c"]);
+  });
+
+  it("header checkbox is checked when all rows are selected", () => {
+    renderWithSelection(new Set(["a", "b", "c", "d"]));
+    expect((screen.getByLabelText("Select all") as HTMLInputElement).checked).toBe(true);
+  });
+});

--- a/packages/ui-kit/src/Table.tsx
+++ b/packages/ui-kit/src/Table.tsx
@@ -1,0 +1,568 @@
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { cx } from "./cx";
+import { EmptyState } from "./EmptyState";
+
+
+/* Inline rather than an icon-set import: the kit takes no dependency on
+   lucide, and these four are the only glyphs it needs. */
+const glyph = { width: 12, height: 12, viewBox: "0 0 24 24", fill: "none", "aria-hidden": true } as const;
+
+function ArrowUpDown() {
+  return (
+    <svg {...glyph}>
+      <path d="m7 15 5 5 5-5M7 9l5-5 5 5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function ArrowUp() {
+  return (
+    <svg {...glyph}>
+      <path d="M12 19V5m-7 7 7-7 7 7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function ArrowDown() {
+  return (
+    <svg {...glyph}>
+      <path d="M12 5v14m7-7-7 7-7-7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function Filter() {
+  return (
+    <svg {...glyph}>
+      <path d="M3 5h18l-7 8v6l-4 2v-8Z" stroke="currentColor" strokeWidth="2" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+/**
+ * Which column a table is sorted by, and which way.
+ *
+ * Declared here rather than imported: `@srelens/core` has the same shape, for
+ * the tab view state it serializes into the session file, and the kit may not
+ * reach the service layer. Structurally identical, so the app hands core's
+ * straight in with no adapter. Two declarations until step 11 deletes the
+ * classic table that still imports core's. (#319)
+ */
+export interface TableSort {
+  key: string;
+  direction: "asc" | "desc";
+}
+
+/**
+ * The sort a header click produces: a new column starts ascending, the same
+ * column reverses, and a third click clears it. Cycling through "no sort" is
+ * what lets a user get back to the server's own order without reloading.
+ */
+export function nextSort(current: TableSort | null | undefined, key: string): TableSort | null {
+  if (!current || current.key !== key) return { key, direction: "asc" };
+  if (current.direction === "asc") return { key, direction: "desc" };
+  return null;
+}
+
+export interface Column<T> {
+  key: string;
+  header: ReactNode;
+  /** Render the cell for a row; defaults to `String(row[key])`. */
+  render?: (row: T) => ReactNode;
+  /** Value used for sorting and filtering when it differs from `row[key]`. */
+  getValue?: (row: T) => unknown;
+  /** Sort-only value, overriding `getValue`/`row[key]` for the comparator —
+   *  for columns whose display text doesn't order correctly (e.g. compact
+   *  ages, where "1y" must outrank "300d") while filtering stays on the
+   *  visible text. */
+  getSortValue?: (row: T) => unknown;
+  sortable?: boolean;
+  filterable?: boolean;
+  minWidth?: number;
+}
+
+/** Opt-in multi-selection: the parent holds the set of selected row keys, the
+ *  Table owns the interaction (toggle, shift-click range over the sorted order,
+ *  select-all-of-filtered) and reports the new set. */
+export interface TableSelection {
+  selected: Set<string>;
+  onChange: (next: Set<string>) => void;
+}
+
+export interface TableProps<T> {
+  columns: Column<T>[];
+  data: T[];
+  getRowKey: (row: T) => string;
+  onRowClick?: (row: T) => void;
+  /** Row key currently selected (highlighted). */
+  selectedKey?: string;
+  /** When set, renders a leading checkbox column for bulk selection. */
+  selection?: TableSelection;
+  /** Shown when `data` is empty. */
+  emptyText?: ReactNode;
+  /** Second line of the empty state: what the reader can do about it. */
+  emptyHint?: ReactNode;
+  /** Column currently used by the toolbar search; null searches every column. */
+  activeFilterKey?: string | null;
+  onActiveFilterKeyChange?: (key: string | null) => void;
+  /** Controlled sort. Supply both to own it (so it can live on the tab and
+   *  survive a switch, #254); omit them and the table keeps its own. */
+  sort?: TableSort | null;
+  onSortChange?: (sort: TableSort | null) => void;
+}
+
+/** Width of the leading bulk-selection column; mirrored in styles.css. */
+const CHECKBOX_COLUMN_WIDTH = 36;
+
+function getColumnValue<T>(row: T, column: Column<T>): unknown {
+  return column.getValue ? column.getValue(row) : (row as Record<string, unknown>)[column.key];
+}
+
+/**
+ * The slice of rows to render for a virtualized list. Returns the full range
+ * when `rowHeight` is unknown (0) — e.g. before measurement or in jsdom — so the
+ * table degrades to rendering everything rather than dividing by zero.
+ */
+export function computeVisibleRange({
+  scrollTop,
+  viewportHeight,
+  rowHeight,
+  total,
+  overscan,
+}: {
+  scrollTop: number;
+  viewportHeight: number;
+  rowHeight: number;
+  total: number;
+  overscan: number;
+}): { start: number; end: number } {
+  if (rowHeight <= 0) return { start: 0, end: total };
+  const firstVisible = Math.floor(scrollTop / rowHeight);
+  const visibleCount = Math.ceil(viewportHeight / rowHeight);
+  const end = Math.min(total, firstVisible + visibleCount + overscan);
+  const start = Math.min(Math.max(0, firstVisible - overscan), end);
+  return { start, end };
+}
+
+/** Apply the toolbar query to one selected column, or all searchable columns. */
+export function filterTableData<T>(
+  data: T[],
+  columns: Column<T>[],
+  query: string,
+  activeFilterKey: string | null,
+): T[] {
+  const normalized = query.trim().toLocaleLowerCase();
+  if (!normalized) return data;
+  const searchable = activeFilterKey
+    ? columns.filter((column) => column.key === activeFilterKey)
+    : columns.filter((column) => column.filterable !== false);
+  if (searchable.length === 0) return data;
+  return data.filter((row) =>
+    searchable.some((column) =>
+      String(getColumnValue(row, column) ?? "").toLocaleLowerCase().includes(normalized),
+    ),
+  );
+}
+
+/** Generic data table used for every resource list in the app (shadcn Table). */
+export function Table<T>({
+  columns,
+  data,
+  getRowKey,
+  onRowClick,
+  selectedKey,
+  selection,
+  emptyText = "No items",
+  emptyHint,
+  activeFilterKey = null,
+  onActiveFilterKeyChange,
+  sort: controlledSort,
+  onSortChange,
+}: TableProps<T>) {
+  // Controlled when a change handler is supplied, otherwise self-managed —
+  // tables outside the tabbed workspace (the MCP audit list, for instance)
+  // have no tab to store a sort on.
+  const [internalSort, setInternalSort] = useState<TableSort | null>(null);
+  const sort = onSortChange ? (controlledSort ?? null) : internalSort;
+  // Anchor for shift-click range selection (a key in sorted/visible order).
+  const selectionAnchor = useRef<string | null>(null);
+  const [columnWidths, setColumnWidths] = useState<Record<string, number>>({});
+  // Whether `columnWidths` was measured for the user (#298) rather than chosen
+  // by them. Auto-sized widths re-measure when the table is resized; widths the
+  // user dragged are theirs to keep.
+  const autoSized = useRef(false);
+  const containerWidth = useRef(0);
+  const columnSignature = columns.map((column) => column.key).join("|");
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [metrics, setMetrics] = useState({ scrollTop: 0, viewportHeight: 0, rowHeight: 0 });
+
+  useEffect(() => setColumnWidths({}), [columnSignature]);
+
+  const visibleData = useMemo(() => {
+    if (!sort) return data;
+    const column = columns.find((candidate) => candidate.key === sort.key);
+    if (!column) return data;
+    const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
+    return data
+      .map((row, index) => ({ row, index }))
+      .sort((a, b) => {
+        const left = column.getSortValue ? column.getSortValue(a.row) : getColumnValue(a.row, column);
+        const right = column.getSortValue ? column.getSortValue(b.row) : getColumnValue(b.row, column);
+        let result: number;
+        if (typeof left === "number" && typeof right === "number") result = left - right;
+        else if (typeof left === "bigint" || typeof right === "bigint") {
+          // Compare, never subtract: bigint arithmetic with a number throws,
+          // and columns mix the two (a bigint value against a -Infinity for
+          // "unset"). Relational operators are defined across both and stay
+          // exact past Number.MAX_SAFE_INTEGER, which string collation is not:
+          // it orders negatives by magnitude.
+          const l = left as bigint | number;
+          const r = right as bigint | number;
+          result = l < r ? -1 : l > r ? 1 : 0;
+        } else result = collator.compare(String(left ?? ""), String(right ?? ""));
+        return result ? result * (sort.direction === "asc" ? 1 : -1) : a.index - b.index;
+      })
+      .map(({ row }) => row);
+  }, [columns, data, sort]);
+
+  // Selection: keys in the order the user sees them (for shift-range + select-all).
+  const visibleKeys = useMemo(() => visibleData.map(getRowKey), [visibleData, getRowKey]);
+  const colCount = columns.length + (selection ? 1 : 0);
+  const allVisibleSelected =
+    !!selection && visibleKeys.length > 0 && visibleKeys.every((k) => selection.selected.has(k));
+
+  const toggleAllVisible = () => {
+    if (!selection) return;
+    const next = new Set(selection.selected);
+    if (allVisibleSelected) visibleKeys.forEach((k) => next.delete(k));
+    else visibleKeys.forEach((k) => next.add(k));
+    selection.onChange(next);
+  };
+
+  const toggleRow = (key: string, shift: boolean) => {
+    if (!selection) return;
+    const next = new Set(selection.selected);
+    const anchor = selectionAnchor.current;
+    const from = anchor ? visibleKeys.indexOf(anchor) : -1;
+    const to = visibleKeys.indexOf(key);
+    if (shift && from >= 0 && to >= 0) {
+      const [lo, hi] = from < to ? [from, to] : [to, from];
+      for (let i = lo; i <= hi; i++) next.add(visibleKeys[i]);
+    } else if (next.has(key)) {
+      next.delete(key);
+    } else {
+      next.add(key);
+    }
+    selectionAnchor.current = key;
+    selection.onChange(next);
+  };
+
+  const cycleSort = (key: string) => {
+    const next = nextSort(sort, key);
+    if (onSortChange) onSortChange(next);
+    else setInternalSort(next);
+  };
+
+  /** Current on-screen width of every column, for pinning into `columnWidths`. */
+  const measureColumns = (table: Element | null | undefined): Record<string, number> => {
+    const headers = table?.querySelectorAll<HTMLTableCellElement>("thead tr:first-child th");
+    // The checkbox column (when present) is th[0], so data columns are offset.
+    const headOffset = selection ? 1 : 0;
+    return Object.fromEntries(
+      columns.map((candidate, index) => [
+        candidate.key,
+        Math.round(
+          headers?.[index + headOffset]?.getBoundingClientRect().width ||
+            columnWidths[candidate.key] ||
+            120,
+        ),
+      ]),
+    );
+  };
+
+  const startColumnResize = (event: React.PointerEvent<HTMLDivElement>, column: Column<T>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const measured = measureColumns(event.currentTarget.closest("table"));
+    autoSized.current = false;
+    const startWidth = measured[column.key];
+    const startX = event.clientX;
+    setColumnWidths(measured);
+
+    const onMove = (moveEvent: PointerEvent) => {
+      const minWidth = column.minWidth ?? 72;
+      setColumnWidths((current) => ({
+        ...current,
+        [column.key]: Math.max(minWidth, startWidth + moveEvent.clientX - startX),
+      }));
+    };
+    const onUp = () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      document.body.classList.remove("fl-is-resizing-column");
+    };
+    document.body.classList.add("fl-is-resizing-column");
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+  };
+
+  const resizeColumnWithKeyboard = (
+    event: React.KeyboardEvent<HTMLDivElement>,
+    column: Column<T>,
+  ) => {
+    if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+    event.preventDefault();
+    const measured = measureColumns(event.currentTarget.closest("table"));
+    autoSized.current = false;
+    const delta = event.key === "ArrowRight" ? 16 : -16;
+    setColumnWidths((current) => {
+      const baseline = Object.keys(current).length ? current : measured;
+      return {
+        ...baseline,
+        [column.key]: Math.max(column.minWidth ?? 72, baseline[column.key] + delta),
+      };
+    });
+  };
+
+  // The checkbox column is fixed-width and never resizable, but it still takes
+  // up space: leaving it out made the declared table width narrower than the
+  // colgroup asks for, so fixed layout had to steal the difference back from
+  // the data columns.
+  const tableWidth = Object.keys(columnWidths).length
+    ? Object.values(columnWidths).reduce((total, width) => total + width, 0) +
+      (selection ? CHECKBOX_COLUMN_WIDTH : 0)
+    : undefined;
+
+  // Virtualize long lists: render only the rows near the viewport plus spacer
+  // rows that reserve the scroll height. Below the threshold — or before the row
+  // height can be measured (jsdom, first paint) — render everything.
+  const VIRTUALIZE_THRESHOLD = 60;
+  const OVERSCAN = 8;
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root || visibleData.length <= VIRTUALIZE_THRESHOLD) return;
+    let scrollParent: HTMLElement | null = root.parentElement;
+    while (scrollParent && scrollParent !== document.body) {
+      const overflowY = getComputedStyle(scrollParent).overflowY;
+      if (overflowY === "auto" || overflowY === "scroll") break;
+      scrollParent = scrollParent.parentElement;
+    }
+    if (!scrollParent) return;
+    const parent = scrollParent;
+    const measure = () => {
+      const firstRow = root.querySelector<HTMLElement>("tbody tr.tbl-row");
+      setMetrics({
+        scrollTop: parent.scrollTop,
+        viewportHeight: parent.clientHeight,
+        rowHeight: firstRow ? firstRow.getBoundingClientRect().height : 0,
+      });
+    };
+    measure();
+    parent.addEventListener("scroll", measure, { passive: true });
+    const observer = typeof ResizeObserver !== "undefined" ? new ResizeObserver(measure) : null;
+    observer?.observe(parent);
+    return () => {
+      parent.removeEventListener("scroll", measure);
+      observer?.disconnect();
+    };
+  }, [visibleData.length]);
+
+  const virtualize = visibleData.length > VIRTUALIZE_THRESHOLD && metrics.rowHeight > 0;
+  const range = virtualize
+    ? computeVisibleRange({
+        scrollTop: metrics.scrollTop,
+        viewportHeight: metrics.viewportHeight,
+        rowHeight: metrics.rowHeight,
+        total: visibleData.length,
+        overscan: OVERSCAN,
+      })
+    : { start: 0, end: visibleData.length };
+  const windowRows = virtualize ? visibleData.slice(range.start, range.end) : visibleData;
+  const topPad = virtualize ? range.start * metrics.rowHeight : 0;
+  const bottomPad = virtualize ? (visibleData.length - range.end) * metrics.rowHeight : 0;
+
+  const isEmpty = data.length === 0;
+
+  // Pin the natural column widths once the table has rows to measure.
+  //
+  // Automatic table layout sizes columns from the rows *currently rendered*.
+  // Virtualization swaps that set on every scroll, so a long list's columns
+  // visibly shifted as the user scrolled (#298). Measuring in a layout effect
+  // keeps it off-screen: the widths are read and applied before paint.
+  //
+  // This deliberately applies to every table, not just the ones long enough to
+  // virtualize. Pinning only above the threshold made short lists -- CRDs,
+  // Services, most views -- size by a different rule from long ones, and left a
+  // list that was filtered down past the threshold stranded with widths it
+  // could neither keep consistently nor recompute. Sizing every table the same
+  // way is both uniform and simpler.
+  useLayoutEffect(() => {
+    if (isEmpty || Object.keys(columnWidths).length > 0) return;
+    const table = rootRef.current?.querySelector("table");
+    // Nothing to measure until a real row exists: a table showing only the
+    // "no matching items" placeholder would freeze the placeholder's widths.
+    if (!table?.querySelector("tbody tr.tbl-row")) return;
+    setColumnWidths(measureColumns(table));
+    autoSized.current = true;
+    // measureColumns reads `columns`/`selection`, which `columnSignature` tracks.
+  }, [isEmpty, visibleData.length, columnWidths, columnSignature]);
+
+  // Pinned widths would otherwise survive a window resize, so an auto-sized
+  // table would stop tracking the space available to it. Drop the measurement
+  // when the container's width changes and the effect above re-takes it at the
+  // new size. Widths the user dragged are left alone.
+  useEffect(() => {
+    if (isEmpty) return;
+    const container = rootRef.current?.querySelector<HTMLElement>('[data-slot="table-container"]');
+    if (!container || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => {
+      if (container.clientWidth === containerWidth.current) return;
+      containerWidth.current = container.clientWidth;
+      if (autoSized.current) setColumnWidths({});
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [isEmpty]);
+
+  if (isEmpty) {
+    return <EmptyState title={emptyText} hint={emptyHint} />;
+  }
+  return (
+    <div ref={rootRef} style={{ display: "contents" }}>
+    <table
+      className={cx(
+        "tbl",
+        tableWidth ? "tbl-resized" : null,
+        onRowClick && "tbl-interactive",
+      )}
+      style={tableWidth ? { width: tableWidth, minWidth: "100%" } : undefined}
+    >
+      <colgroup>
+        {selection && <col style={{ width: CHECKBOX_COLUMN_WIDTH }} />}
+        {columns.map((column) => (
+          <col
+            key={column.key}
+            style={columnWidths[column.key] ? { width: columnWidths[column.key] } : undefined}
+          />
+        ))}
+      </colgroup>
+      <thead className="sticky top-0 z-10">
+        <tr className="hover:bg-transparent">
+          {selection && (
+            <th className="tbl-check">
+              <input
+                type="checkbox"
+                aria-label="Select all"
+                checked={allVisibleSelected}
+                ref={(el) => {
+                  if (el) el.indeterminate = !allVisibleSelected && visibleKeys.some((k) => selection.selected.has(k));
+                }}
+                onChange={toggleAllVisible}
+              />
+            </th>
+          )}
+          {columns.map((c) => (
+            <th key={c.key} >
+              <div className="th-head">
+                <button
+                  type="button"
+                  className="th-sort"
+                  onClick={() => cycleSort(c.key)}
+                  disabled={c.sortable === false}
+                  aria-label={`Sort by ${typeof c.header === "string" ? c.header : c.key}`}
+                >
+                  <span>{c.header}</span>
+                  {c.sortable !== false &&
+                    (sort?.key !== c.key ? (
+                      <ArrowUpDown />
+                    ) : sort.direction === "asc" ? (
+                      <ArrowUp />
+                    ) : (
+                      <ArrowDown />
+                    ))}
+                </button>
+                {c.filterable !== false && onActiveFilterKeyChange && (
+                  <button
+                    type="button"
+                    className={cx("th-filter", activeFilterKey === c.key && "is-active")}
+                    onClick={() => onActiveFilterKeyChange(activeFilterKey === c.key ? null : c.key)}
+                    aria-label={`Filter search by ${typeof c.header === "string" ? c.header : c.key}`}
+                    aria-pressed={activeFilterKey === c.key}
+                  >
+                    <Filter />
+                  </button>
+                )}
+              </div>
+              <div
+                role="separator"
+                aria-orientation="vertical"
+                aria-label={`Resize ${typeof c.header === "string" ? c.header : c.key} column`}
+                tabIndex={0}
+                className="th-resize"
+                onPointerDown={(event) => startColumnResize(event, c)}
+                onKeyDown={(event) => resizeColumnWithKeyboard(event, c)}
+                onDoubleClick={() => setColumnWidths({})}
+                title="Drag to resize; double-click to reset"
+              />
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {topPad > 0 && (
+          <tr aria-hidden="true" className="tbl-spacer">
+            <td colSpan={colCount} style={{ height: topPad, padding: 0, border: 0 }} />
+          </tr>
+        )}
+        {windowRows.map((row) => {
+          const rowKey = getRowKey(row);
+          const selected = selectedKey === rowKey;
+          const checked = selection?.selected.has(rowKey) ?? false;
+          return (
+            <tr
+              key={rowKey}
+              aria-selected={selected}
+              data-state={selected || checked ? "selected" : undefined}
+              onClick={onRowClick ? () => onRowClick(row) : undefined}
+              className={cx("tbl-row", onRowClick && "cursor-pointer")}
+            >
+              {selection && (
+                <td
+                  className="tbl-check"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <input
+                    type="checkbox"
+                    aria-label={`Select ${rowKey}`}
+                    checked={checked}
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => toggleRow(rowKey, (e.nativeEvent as MouseEvent).shiftKey)}
+                  />
+                </td>
+              )}
+              {columns.map((c) => (
+                <td key={c.key} >
+                  {c.render ? c.render(row) : String((row as Record<string, unknown>)[c.key])}
+                </td>
+              ))}
+            </tr>
+          );
+        })}
+        {bottomPad > 0 && (
+          <tr aria-hidden="true" className="tbl-spacer">
+            <td colSpan={colCount} style={{ height: bottomPad, padding: 0, border: 0 }} />
+          </tr>
+        )}
+        {visibleData.length === 0 && (
+          <tr>
+            <td colSpan={colCount} className="tbl-empty">
+              No matching items
+            </td>
+          </tr>
+        )}
+      </tbody>
+    </table>
+    </div>
+  );
+}

--- a/packages/ui-kit/src/gallery/Gallery.tsx
+++ b/packages/ui-kit/src/gallery/Gallery.tsx
@@ -23,6 +23,7 @@ import { Select } from "../Select";
 import { Sparkline } from "../Sparkline";
 import { Spinner } from "../Spinner";
 import { StatusPill } from "../StatusPill";
+import { Table, type Column } from "../Table";
 import { Tabs } from "../Tabs";
 import { TextInput } from "../TextInput";
 import { Toolbar } from "../Toolbar";
@@ -60,6 +61,8 @@ export function Gallery() {
   const [tab, setTab] = useState("pods");
   const [drawer, setDrawer] = useState(false);
   const [scope, setScope] = useState("kube-system");
+  const [sort, setSort] = useState<import("../Table").TableSort | null>(null);
+  const [picked2, setPicked2] = useState<Set<string>>(new Set());
   const [picked, setPicked] = useState<string[]>([]);
   const [hiddenColumns, setHiddenColumns] = useState<ReadonlySet<string>>(new Set(["age"]));
   const [manifest, setManifest] = useState("apiVersion: v1\nkind: Pod\nmetadata:\n  name: web-1\n");
@@ -498,6 +501,43 @@ export function Gallery() {
         </div>
         {/* Completions are the caller's: the kit knows CodeMirror, not what an
             apiVersion is. */}
+      </section>
+      <section>
+        <h2>Table</h2>
+        {/* The states worth seeing: a sortable column, a filterable one, bulk
+            selection, and a row that is clickable. Virtualisation only engages
+            past a threshold, so a gallery-sized list renders whole. */}
+        <Table
+          columns={
+            [
+              { key: "name", header: "Name", sortable: true, filterable: true },
+              { key: "phase", header: "Phase", sortable: true },
+              { key: "restarts", header: "Restarts", sortable: true },
+            ] as Column<{ name: string; phase: string; restarts: number }>[]
+          }
+          data={[
+            { name: "web-1", phase: "Running", restarts: 0 },
+            { name: "web-2", phase: "Pending", restarts: 3 },
+            { name: "api-0", phase: "CrashLoopBackOff", restarts: 17 },
+          ]}
+          getRowKey={(r) => r.name}
+          sort={sort}
+          onSortChange={setSort}
+          selection={{ selected: picked2, onChange: setPicked2 }}
+          onRowClick={() => {}}
+        />
+        <p className="text-[0.75rem] text-muted">
+          sorted: {sort ? `${sort.key} ${sort.direction}` : "(unsorted)"} · selected:{" "}
+          {picked2.size === 0 ? "(none)" : [...picked2].join(", ")}
+        </p>
+        {/* Empty is a state, not an absence: it says what would be here. */}
+        <Table
+          columns={[{ key: "name", header: "Name" }] as Column<{ name: string }>[]}
+          data={[]}
+          getRowKey={(r) => r.name}
+          emptyText="No pods"
+          emptyHint="Nothing is scheduled in this namespace."
+        />
       </section>
     </div>
   );

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -23,6 +23,7 @@ export { Select, type SelectOption, type SelectProps } from "./Select";
 export { Sparkline } from "./Sparkline";
 export { Spinner, type SpinnerProps } from "./Spinner";
 export { StatusPill, type StatusKind, type StatusPillProps } from "./StatusPill";
+export { Table, computeVisibleRange, filterTableData, nextSort, type Column, type TableProps, type TableSelection, type TableSort } from "./Table";
 export { Tabs, type TabItem, type TabsProps } from "./Tabs";
 export { TextInput, type TextInputProps } from "./TextInput";
 export { Toolbar, type ToolbarProps } from "./Toolbar";

--- a/packages/ui-kit/src/styles/kit.css
+++ b/packages/ui-kit/src/styles/kit.css
@@ -247,6 +247,63 @@
     vertical-align: middle;
     white-space: nowrap;
   }
+  /* The data table's own parts. `.tbl` above already carries the surface —
+     sticky head, row rules, hover, the selected wash — so these are only what
+     a sortable, resizable, selectable table adds on top of it. (#319) */
+  .tbl-interactive tbody tr { cursor: pointer; }
+  /* Once widths are pinned the table stops fitting itself to its container and
+     takes the measured total instead, which is what stops columns shifting
+     while a long list scrolls (#298). */
+  .tbl-resized { table-layout: fixed; }
+  .tbl-check { width: 36px; text-align: center; }
+  .tbl-check input { accent-color: var(--accent); vertical-align: middle; }
+  /* Holds the space the virtualized rows would occupy, so the scrollbar
+     describes the whole list rather than the window being rendered. */
+  .tbl-spacer { border: 0 !important; }
+  .tbl-spacer:hover { background: transparent !important; }
+  .tbl-empty {
+    padding: 1.25rem 0.7rem;
+    text-align: center;
+    color: var(--ink-muted);
+    font-size: 0.75rem;
+  }
+  .th-head { display: flex; align-items: center; gap: 0.25rem; }
+  .th-filter {
+    display: inline-flex;
+    align-items: center;
+    border-radius: 4px;
+    padding: 1px;
+    color: var(--ink-faint);
+    opacity: 0.65;
+  }
+  .th-filter:hover,
+  .th-filter:focus-visible { opacity: 1; color: var(--ink); }
+  .th-filter.is-active { opacity: 1; color: var(--accent); }
+  /* A grab strip on the column edge, positioned against the header cell —
+     which is a containing block already, being sticky. Wider than it looks,
+     because a 1px target is not one. */
+  .th-resize {
+    position: absolute;
+    top: 0;
+    right: -3px;
+    width: 7px;
+    height: 100%;
+    cursor: col-resize;
+    background: none;
+    border: 0;
+    padding: 0;
+  }
+  .th-resize::after {
+    content: "";
+    position: absolute;
+    top: 20%;
+    left: 3px;
+    width: 1px;
+    height: 60%;
+    background: var(--rule);
+  }
+  .th-resize:hover::after,
+  .th-resize:focus-visible::after { background: var(--accent); }
   .th-sort {
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
`Table` into the kit — behaviour whole, presentation rebuilt. Closes #319, and **gates step 5** (`Resources` and `ResourceDetail`).

## What ports and what does not

The behaviour is the asset, and none of it is re-derivable from the mock, which renders dummy rows through a `SortHeader` and a `ListRow`. All of this comes across untouched:

- **Virtualisation**, including the fallback that renders everything when the row height is unmeasurable — before first paint, and in jsdom.
- **The #298/#299 column-width pinning.** This fixed a user-reported bug: columns shifting left and right while a long list scrolled. It distinguishes widths *measured* for the user from widths the user *chose*, and it must stay uniform across every table type.
- **Sorting**, controlled or uncontrolled; **shift-click ranges** over the sorted order; **select-all-of-filtered**; **per-column filtering**.

All 27 tests come with it. Every behavioural assertion is unchanged — what moved is the class names the queries hang off, because that is the half being rebuilt.

## The presentation

shadcn's table primitives cannot come along: they live in `apps/desktop` against the classic Tailwind config. They are thin wrappers over the elements anyway, so this is the design's own `.tbl` — which already carries the sticky head, the row rules, the hover and the selected wash. The new CSS is only what a sortable, resizable, selectable table adds on top: the checkbox column, the resize handle, the filter toggle, the no-results row, and the virtualisation spacers.

The four lucide icons are inlined, as every glyph in the kit is.

## `nextSort` and `TableSort`

Declared in the kit rather than imported. `@srelens/core` has the same shape — it needs `TableSort` for the tab view state it serializes into the session file — and the kit may not reach the service layer.

They are structurally identical, so the app hands core's type straight in with no adapter. Moving them out of core was not an option: `apps/desktop/src/ui/Table.tsx` still imports them and stays frozen until step 11, which is also when this duplicate dies.

## Verification

- 1638 tests across 187 files pass; coverage 86.99 / 83.11 / 78.12, above the 85 / 80 / 76 floors.
- Typecheck clean across all four projects; `pnpm build` clean. Two type errors surfaced there that no test could catch — `EmptyState` takes `hint`, not `description`, and `cx` rejects the `0` that `tableWidth &&` produces. Exactly what #249 added the typecheck step for.
- The gallery test derives its checklist from the barrel, so the new export is confirmed to have a section — showing a sortable column, a filterable one, bulk selection, and the empty state.

`apps/desktop` is untouched.
