### PR TITLE
fix(ui-kit): give MultiSelect the design's picker, not the classic one's

### DIFF
--- a/packages/ui-kit/src/MultiSelect.test.tsx
+++ b/packages/ui-kit/src/MultiSelect.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { useState } from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MultiSelect } from "./MultiSelect";
 
@@ -27,7 +27,9 @@ function open(props: Partial<Parameters<typeof MultiSelect>[0]> = {}) {
 }
 
 const trigger = () => screen.getByRole("combobox", { name: "Scope" });
-const rows = () => screen.getAllByRole("option").map((el) => el.textContent);
+// The option's accessible name rather than its text: rows carry a trailing
+// count or an "only" action, which are not part of what the option is called.
+const rows = () => screen.getAllByRole("option").map((el) => el.getAttribute("aria-label"));
 
 /** A caller that actually holds the selection, so toggling behaves as it does in an app. */
 function Live({ allLabel }: { allLabel?: string }) {
@@ -224,5 +226,88 @@ describe("MultiSelect's ordering", () => {
     await userEvent.click(trigger());
     expect(screen.queryByRole("option")).toBeNull();
     expect(screen.getByText("No results")).toBeDefined();
+  });
+});
+
+/**
+ * The design's own picker, which this took its API from but not its shape.
+ * #318's rule for a component both sides have is to keep the old behaviour and
+ * take the mock's visuals, and the first port kept the classic's: a check mark
+ * where the design has a checkbox, and none of the affordances around the list.
+ */
+describe("MultiSelect matches the design's picker", () => {
+  /** Render and open the popover, which is where all of this lives. */
+  async function opened(props: Partial<Parameters<typeof MultiSelect>[0]> = {}) {
+    const view = open(props);
+    await userEvent.click(trigger());
+    await screen.findByRole("listbox");
+    return view;
+  }
+
+  const row = (name: RegExp) => screen.getByRole("option", { name });
+
+  it("marks each option with a checkbox, not a check mark", async () => {
+    // Options you turn on and off independently read as checkboxes; a check
+    // mark is what a single-choice list uses, and Combobox is the one of those.
+    await opened();
+    expect(row(/alpha/).querySelector("[data-box]")).not.toBeNull();
+  });
+
+  it("says how many options there are on the all row", async () => {
+    await opened({ allLabel: "Everything" });
+    expect(row(/Everything/).textContent).toContain("3");
+  });
+
+  it("offers 'only' on a row, to narrow to a single option", async () => {
+    // The other move people make. Doing it by hand means clearing every other
+    // box first.
+    const onChange = vi.fn();
+    await opened({ onChange, selection: ["alpha", "gamma"] });
+    await userEvent.click(screen.getByRole("button", { name: "Only Beta service" }));
+    expect(onChange).toHaveBeenCalledWith(["beta"]);
+  });
+
+  it("closes after 'only', because that is the whole choice", async () => {
+    await opened({ selection: ["alpha"] });
+    await userEvent.click(screen.getByRole("button", { name: "Only alpha" }));
+    await waitFor(() => expect(screen.queryByRole("listbox")).toBeNull());
+  });
+
+  /** The footer's count, which the trigger's summary also happens to say. */
+  const footerCount = () => document.querySelector(".eyebrow")?.textContent;
+
+  it("counts the selection in a footer", async () => {
+    await opened({ selection: ["alpha", "gamma"] });
+    expect(footerCount()).toContain("2 selected");
+  });
+
+  it("says 'all' in the footer when nothing is selected", async () => {
+    // Not "0 selected": an empty selection is the filter switched off, not an
+    // empty result.
+    await opened();
+    expect(footerCount()).toContain("all selected");
+  });
+
+  it("selects every option at once", async () => {
+    const onChange = vi.fn();
+    await opened({ onChange });
+    await userEvent.click(screen.getByRole("button", { name: "Select all" }));
+    expect(onChange).toHaveBeenCalledWith(["alpha", "beta", "gamma"]);
+  });
+
+  it("resets to nothing selected", async () => {
+    const onChange = vi.fn();
+    await opened({ onChange, selection: ["alpha"] });
+    await userEvent.click(screen.getByRole("button", { name: "Reset" }));
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+
+  it("gives every control it owns an explicit button type", async () => {
+    // The footer sits inside a popover, which sits inside a toolbar, which
+    // sits inside a form often enough to matter.
+    await opened({ selection: ["alpha"] });
+    for (const name of ["Select all", "Reset", "Only alpha"]) {
+      expect(screen.getByRole("button", { name }).getAttribute("type")).toBe("button");
+    }
   });
 });

--- a/packages/ui-kit/src/MultiSelect.tsx
+++ b/packages/ui-kit/src/MultiSelect.tsx
@@ -96,11 +96,35 @@ export function MultiSelect({
       ariaLabel={ariaLabel}
       searchPlaceholder={searchPlaceholder}
       className={className}
+      footer={
+        <>
+          {/* What the list currently amounts to, in the design's label voice.
+              "all" rather than "0 selected", because an empty selection is not
+              an empty result — it is the filter switched off. */}
+          <span className="eyebrow flex-1">
+            {selection.length === 0 ? "all" : selection.length} selected
+          </span>
+          <button type="button" className="btn !py-0" onClick={() => onChange(options.map((o) => o.value))}>
+            Select all
+          </button>
+          <button type="button" className="btn !py-0" onClick={() => onChange([])}>
+            Reset
+          </button>
+        </>
+      }
     >
-      {() => (
+      {(close) => (
         <>
           {all !== undefined && (
-            <PickerRow value={all} label={all} checked={selection.length === 0} onSelect={() => onChange([])} />
+            <PickerRow
+              value={all}
+              label={all}
+              checked={selection.length === 0}
+              onSelect={() => onChange([])}
+              // A check, not a box: this is not one more thing to switch on
+              // beside the others, it is the absence of any of them.
+              trailing={<span className="path text-faint">{options.length}</span>}
+            />
           )}
           {ordered.map((option) => (
             <PickerRow
@@ -109,6 +133,24 @@ export function MultiSelect({
               label={optionLabel(option)}
               checked={chosen.has(option.value)}
               onSelect={() => toggle(option.value)}
+              mark="box"
+              // Narrowing to one option is the other thing people do with a
+              // list like this, and doing it by hand means turning every other
+              // one off first. It closes, because it is the whole choice.
+              trailing={
+                <button
+                  type="button"
+                  className="ns-only"
+                  aria-label={`Only ${optionLabel(option)}`}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onChange([option.value]);
+                    close();
+                  }}
+                >
+                  only
+                </button>
+              }
             />
           ))}
         </>

--- a/packages/ui-kit/src/picker.tsx
+++ b/packages/ui-kit/src/picker.tsx
@@ -2,6 +2,7 @@ import { useState, type ReactNode } from "react";
 import { Popover } from "radix-ui";
 import { Command } from "cmdk";
 import { cx } from "./cx";
+import { filled } from "./slot";
 
 export interface ComboboxOption {
   value: string;
@@ -14,6 +15,8 @@ export function optionLabel(option: ComboboxOption): string {
 }
 
 export interface PickerProps {
+  /** A row under the list, ruled off from it — counts and list-wide actions. */
+  footer?: ReactNode;
   /** What the trigger says about the current state — a value, a count, a stand-in. */
   summary: string;
   ariaLabel?: string;
@@ -44,7 +47,7 @@ export interface PickerProps {
  * solved. What is ours is the seam: which classes it wears, and the render prop
  * below. (#318)
  */
-export function Picker({ summary, ariaLabel, searchPlaceholder = "Search…", className, children }: PickerProps) {
+export function Picker({ summary, ariaLabel, searchPlaceholder = "Search…", className, footer, children }: PickerProps) {
   const [open, setOpen] = useState(false);
 
   return (
@@ -94,6 +97,11 @@ export function Picker({ summary, ariaLabel, searchPlaceholder = "Search…", cl
               <Command.Empty className="px-3 py-4 text-center text-[0.75rem] text-faint">No results</Command.Empty>
               {children(() => setOpen(false))}
             </Command.List>
+            {filled(footer) && (
+              // Ruled off above rather than below: it belongs to the list, and
+              // the rule is what stops it reading as one more option.
+              <div className="rule-t flex items-center gap-1.5 px-2 py-1.5">{footer}</div>
+            )}
           </Command>
         </Popover.Content>
       </Popover.Portal>
@@ -102,6 +110,23 @@ export function Picker({ summary, ariaLabel, searchPlaceholder = "Search…", cl
 }
 
 export interface PickerRowProps {
+  /**
+   * `check` for a list where one option wins, `box` for one where each is
+   * independent. The design draws the two differently because they mean
+   * different things, and a check mark on a multi-select reads as "this is the
+   * one" rather than "this is on". (#328)
+   */
+  mark?: "check" | "box";
+  /**
+   * Pinned to the row's end — a count, or an action on the option.
+   *
+   * An interactive one is a control inside a `role="option"`, which ARIA would
+   * rather it were not. It sits inside the row anyway because cmdk hides
+   * filtered rows by hiding the item, and a sibling would stay behind when its
+   * option was filtered away. The row carries an explicit `aria-label` so at
+   * least the option's own name stays clean. (#328)
+   */
+  trailing?: ReactNode;
   /** Identifies the row to cmdk's filter, and must be unique within the list. */
   value: string;
   label: string;
@@ -110,7 +135,7 @@ export interface PickerRowProps {
 }
 
 /** One row: a check that holds its column whether or not it is showing, and a label. */
-export function PickerRow({ value, label, checked, onSelect }: PickerRowProps) {
+export function PickerRow({ value, label, checked, onSelect, mark = "check", trailing }: PickerRowProps) {
   return (
     <Command.Item
       value={value}
@@ -118,6 +143,10 @@ export function PickerRow({ value, label, checked, onSelect }: PickerRowProps) {
       // whose label bears no resemblance to its value is still searchable.
       keywords={[label]}
       onSelect={onSelect}
+      // Named explicitly, because the name is otherwise computed from
+      // everything inside the row — so a trailing count or action would be read
+      // out as part of the option ("alpha only", "Everything 3").
+      aria-label={label}
       data-on={checked}
       // cmdk owns `aria-selected` on these rows and uses it for the highlight
       // that follows the pointer and the arrow keys, so it cannot also carry
@@ -130,20 +159,45 @@ export function PickerRow({ value, label, checked, onSelect }: PickerRowProps) {
       // same feedback the mouse does, which a plain `:hover` cannot give it.
       className="ns-row data-[selected=true]:bg-[var(--field)]"
     >
-      <svg
-        width="12"
-        height="12"
-        viewBox="0 0 24 24"
-        fill="none"
-        aria-hidden="true"
-        // Always rendered, never removed: the labels line up in a column, and a
-        // check appearing would otherwise shove the row it belongs to sideways.
-        className={cx("shrink-0", checked ? "opacity-100" : "opacity-0")}
-        style={{ color: "var(--accent)" }}
-      >
-        <path d="M20 6 9 17l-5-5" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
-      </svg>
-      <span className="truncate">{label}</span>
+      {mark === "box" ? (
+        <span
+          data-box
+          aria-hidden="true"
+          className="flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-[3px] border"
+          style={{
+            borderColor: checked ? "var(--accent)" : "var(--rule-strong)",
+            background: checked ? "var(--accent)" : "transparent",
+          }}
+        >
+          {checked && (
+            <svg width="10" height="10" viewBox="0 0 24 24" fill="none">
+              <path
+                d="M20 6 9 17l-5-5"
+                stroke="var(--accent-ink)"
+                strokeWidth="3"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          )}
+        </span>
+      ) : (
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 24 24"
+          fill="none"
+          aria-hidden="true"
+          // Always rendered, never removed: the labels line up in a column, and
+          // a check appearing would otherwise shove its row sideways.
+          className={cx("shrink-0", checked ? "opacity-100" : "opacity-0")}
+          style={{ color: "var(--accent)" }}
+        >
+          <path d="M20 6 9 17l-5-5" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      )}
+      <span className="flex-1 truncate">{label}</span>
+      {filled(trailing) && trailing}
     </Command.Item>
   );
 }


### PR DESCRIPTION
`MultiSelect` shipped in #326 wearing the wrong design. Reported from the gallery, and it is a rule violation rather than a preference: #318 says a component both designs have keeps the old API, behaviour and tests and takes **the mock's visuals**. This one kept the classic's.

Compared against the mock's `NamespacePicker`, five things were missing:

| The design has | #326 shipped | Now |
|---|---|---|
| A checkbox per row | A check mark | A box, filled accent when on |
| A count on the "all" row | — | The option count |
| **"only"** on each row | — | Narrows to that option and closes |
| A footer: *N selected* / Select all / Reset | — | All three |
| A capped, scrolling list | ✓ | unchanged |

`Combobox` deliberately keeps its check mark. The mark now follows what the list *means* rather than which component it is: a box where options are independent, a check where one wins. A check mark on a multi-select reads as "this is the one" instead of "this is on".

## Two judgment calls

**The footer says "all selected", not "0 selected".** An empty selection is the filter switched off, not an empty result — the same reading `allLabel` already gives the trigger.

**"only" is a button inside a `role="option"`,** which ARIA would rather it were not. It sits there anyway because cmdk hides a filtered row by hiding the item, so a sibling button would stay behind when its own option was filtered away. To limit the damage the row now carries an explicit `aria-label`: without it the option's name is computed from everything inside it, and a screen reader reads "alpha only" and "Everything 3". The tradeoff is written into the code rather than left for review to find.

## Verification

- 1620 tests across 186 files pass; coverage 86.93 / 83.01 / 78.08, above the floors.
- Typecheck and build clean.
- All nine new tests were RED first. Two existing tests changed: they asserted on row `textContent`, which now legitimately carries a count and an action, so they assert the option's accessible name instead. No behavioural expectation was altered.
