### PR TITLE
feat(ui-kit): WorkspaceSwitcher and TabStrip, both reachable

### DIFF
--- a/packages/ui-kit/src/TabStrip.test.tsx
+++ b/packages/ui-kit/src/TabStrip.test.tsx
@@ -1,0 +1,430 @@
+import { describe, it, expect, vi } from "vitest";
+import { useState, type FormEvent } from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TabStrip, type StripTab } from "./TabStrip";
+
+// jsdom has no ResizeObserver, and Radix's popper watches the trigger and the
+// content with one. The kit's shared setup does not stub it, and that setup is
+// not this file's to edit, so the stub lives here. Inert: jsdom does no layout,
+// so there is never a resize to report. (ColumnPicker.test.tsx and
+// ContextMenu.test.tsx carry the same stub, as does apps/desktop's setup.)
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
+function Boxes({ className, ...rest }: { size?: number; className?: string }) {
+  return <svg data-testid="tab-icon" className={className} viewBox="0 0 24 24" {...rest} />;
+}
+
+const TABS: StripTab[] = [
+  { id: "pods", title: "Pods", sub: "prod-eu", icon: Boxes },
+  { id: "logs", title: "checkout-api", sub: "logs" },
+  { id: "shell", title: "nginx-7d4b" },
+];
+
+function setup(props: Partial<Parameters<typeof TabStrip>[0]> = {}) {
+  const onSelect = vi.fn();
+  const view = render(<TabStrip tabs={TABS} activeId="pods" onSelect={onSelect} {...props} />);
+  return { onSelect, ...view };
+}
+
+/** By the leading title, since the accessible name carries the sub too. */
+const tab = (title: string) => screen.getByRole("tab", { name: new RegExp(`^${title}`) });
+
+/**
+ * The app's document tabs: the strip along the top of the window holding every
+ * resource, log stream and shell that is open.
+ *
+ * Not the kit's `Tabs`, which switches views inside one screen. These close,
+ * pin, carry a cluster tag, overflow into a menu and answer a right-click, and
+ * the two share only a word and a stylesheet. (#332)
+ *
+ * The mock had no keyboard contract at all behind its `role="tablist"` — its
+ * tabs were `<div role="tab">` with a click handler and no `tabIndex`, so the
+ * document tab bar of a desktop app could not be reached, never mind operated,
+ * without a mouse. Most of what is asserted below is that fix.
+ */
+describe("TabStrip", () => {
+  it("renders a tab per entry and marks the active one", () => {
+    setup({ activeId: "logs" });
+    expect(screen.getAllByRole("tab")).toHaveLength(3);
+    expect(tab("checkout-api").getAttribute("aria-selected")).toBe("true");
+    expect(tab("Pods").getAttribute("aria-selected")).toBe("false");
+    expect(tab("nginx-7d4b").getAttribute("aria-selected")).toBe("false");
+  });
+
+  it("names the strip", () => {
+    setup({ label: "Open documents" });
+    expect(screen.getByRole("tablist", { name: "Open documents" })).toBeDefined();
+  });
+
+  it("selects on click", async () => {
+    const { onSelect } = setup();
+    await userEvent.click(tab("checkout-api"));
+    expect(onSelect).toHaveBeenCalledWith("logs");
+  });
+
+  it("names a tab by its title and its sub, and carries no title attribute", () => {
+    // The mock put the whole name in `title=`, which is a tooltip: it is not
+    // reachable from a keyboard, not announced reliably, and not the tab's
+    // accessible name. The name is the name. (#332)
+    setup();
+    expect(screen.getByRole("tab", { name: "Pods · prod-eu" })).toBeDefined();
+    expect(tab("Pods").hasAttribute("title")).toBe(false);
+  });
+
+  it("omits the sub element on a tab without one", () => {
+    setup();
+    expect(tab("nginx-7d4b").querySelector(".tab-sub")).toBeNull();
+    expect(tab("Pods").querySelector(".tab-sub")?.textContent).toBe("prod-eu");
+  });
+
+  it("renders a caller's icon, hidden from assistive technology", () => {
+    // Which glyph means "workloads" is the product's vocabulary. The mock kept
+    // a kind→icon map in the component; the kit takes the icon per tab, the
+    // way NavIcon does. (#332)
+    setup();
+    const icon = screen.getByTestId("tab-icon");
+    expect(tab("Pods").contains(icon)).toBe(true);
+    expect(icon.getAttribute("aria-hidden")).toBe("true");
+  });
+});
+
+/**
+ * The contract `role="tablist"` promises and the mock did not keep. Manual
+ * activation rather than the selection-follows-focus that `Tabs` uses: these
+ * panels are terminals, log streams and editors, and arrowing past one to reach
+ * the next should not open it.
+ */
+describe("TabStrip keyboard behaviour", () => {
+  it("is a single tab stop, landing on the active tab", async () => {
+    setup({ activeId: "logs" });
+    expect(tab("checkout-api").getAttribute("tabindex")).toBe("0");
+    expect(tab("Pods").getAttribute("tabindex")).toBe("-1");
+    expect(tab("nginx-7d4b").getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("takes one Tab to enter and one to leave, whatever is open", async () => {
+    render(
+      <>
+        <button type="button">before</button>
+        <TabStrip tabs={TABS} activeId="pods" onSelect={() => {}} onClose={() => {}} onNew={() => {}} />
+      </>,
+    );
+    screen.getByRole("button", { name: "before" }).focus();
+    await userEvent.tab();
+    expect(document.activeElement).toBe(tab("Pods"));
+    // Not the next tab, and not the close button inside this one: the strip is
+    // one stop, and the controls after it are the strip's own.
+    await userEvent.tab();
+    expect(document.activeElement).toBe(screen.getByRole("button", { name: "New tab" }));
+  });
+
+  it("moves focus right and left without selecting", async () => {
+    const { onSelect } = setup();
+    tab("Pods").focus();
+    await userEvent.keyboard("{ArrowRight}");
+    expect(document.activeElement).toBe(tab("checkout-api"));
+    await userEvent.keyboard("{ArrowRight}");
+    expect(document.activeElement).toBe(tab("nginx-7d4b"));
+    await userEvent.keyboard("{ArrowLeft}");
+    expect(document.activeElement).toBe(tab("checkout-api"));
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("moves the tab stop along with the focus", async () => {
+    setup();
+    tab("Pods").focus();
+    await userEvent.keyboard("{ArrowRight}");
+    expect(tab("checkout-api").getAttribute("tabindex")).toBe("0");
+    expect(tab("Pods").getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("does not wrap at either end", async () => {
+    // Unlike `Tabs`. See the component's comment: this strip scrolls, holds
+    // however many documents are open, and wrapping would yank it end to end.
+    setup();
+    tab("Pods").focus();
+    await userEvent.keyboard("{ArrowLeft}");
+    expect(document.activeElement).toBe(tab("Pods"));
+    await userEvent.keyboard("{End}");
+    await userEvent.keyboard("{ArrowRight}");
+    expect(document.activeElement).toBe(tab("nginx-7d4b"));
+  });
+
+  it("jumps to the first and last with Home and End", async () => {
+    const { onSelect } = setup({ activeId: "logs" });
+    tab("checkout-api").focus();
+    await userEvent.keyboard("{End}");
+    expect(document.activeElement).toBe(tab("nginx-7d4b"));
+    await userEvent.keyboard("{Home}");
+    expect(document.activeElement).toBe(tab("Pods"));
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("selects the focused tab with Enter and with Space", async () => {
+    const { onSelect } = setup();
+    tab("nginx-7d4b").focus();
+    await userEvent.keyboard("{Enter}");
+    expect(onSelect).toHaveBeenLastCalledWith("shell");
+    onSelect.mockClear();
+    await userEvent.keyboard(" ");
+    expect(onSelect).toHaveBeenLastCalledWith("shell");
+  });
+
+  it("leaves other keys alone", async () => {
+    // Otherwise the strip swallows keys the window needs.
+    const onSelect = vi.fn();
+    const onClose = vi.fn();
+    render(<TabStrip tabs={TABS} activeId="pods" onSelect={onSelect} onClose={onClose} />);
+    tab("Pods").focus();
+    await userEvent.keyboard("{ArrowDown}");
+    await userEvent.keyboard("a");
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(tab("Pods"));
+  });
+
+  it("binds nothing at the window", async () => {
+    // The mock installed six accelerators per instance — ⌘W, ⌘T, ⌘⇧T, ⌘[, ⌘]
+    // and ⌘1-9 — so two strips answered the same keystroke and the app could
+    // not tell what else the component had taken. Stripped for the same reason
+    // ConsoleDock's ⌘K was: the window's keys belong to the window. (#332)
+    const onClose = vi.fn();
+    const onNew = vi.fn();
+    const onSelect = vi.fn();
+    render(<TabStrip tabs={TABS} activeId="pods" onSelect={onSelect} onClose={onClose} onNew={onNew} />);
+    document.body.focus();
+    await userEvent.keyboard("{Meta>}w{/Meta}");
+    await userEvent.keyboard("{Meta>}t{/Meta}");
+    await userEvent.keyboard("{Meta>}]{/Meta}");
+    await userEvent.keyboard("{Meta>}2{/Meta}");
+    expect(onClose).not.toHaveBeenCalled();
+    expect(onNew).not.toHaveBeenCalled();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Closing. The mock's only keyboard route to it was a window-level ⌘W, which
+ * the component no longer owns — so the close affordance needs one of its own,
+ * and Delete/Backspace on the focused tab is what the ARIA practices guide
+ * recommends for exactly this.
+ */
+describe("TabStrip closing", () => {
+  it("closes the focused tab with Delete and with Backspace", async () => {
+    const onClose = vi.fn();
+    render(<TabStrip tabs={TABS} activeId="pods" onSelect={() => {}} onClose={onClose} />);
+    tab("checkout-api").focus();
+    await userEvent.keyboard("{Delete}");
+    expect(onClose).toHaveBeenLastCalledWith("logs");
+    onClose.mockClear();
+    await userEvent.keyboard("{Backspace}");
+    expect(onClose).toHaveBeenLastCalledWith("logs");
+  });
+
+  it("closes the focused tab, not the selected one", async () => {
+    const onClose = vi.fn();
+    render(<TabStrip tabs={TABS} activeId="pods" onSelect={() => {}} onClose={onClose} />);
+    tab("Pods").focus();
+    await userEvent.keyboard("{ArrowRight}{ArrowRight}");
+    await userEvent.keyboard("{Delete}");
+    expect(onClose).toHaveBeenCalledWith("shell");
+  });
+
+  it("does not close a pinned tab", async () => {
+    // A pin is the user saying "not this one". It shows no close button, so
+    // Delete must not be the way around that.
+    const onClose = vi.fn();
+    const pinned: StripTab[] = [{ id: "pods", title: "Pods", pinned: true }, ...TABS.slice(1)];
+    render(<TabStrip tabs={pinned} activeId="logs" onSelect={() => {}} onClose={onClose} />);
+    tab("Pods").focus();
+    await userEvent.keyboard("{Delete}");
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.queryByRole("button", { name: /^Close Pods/ })).toBeNull();
+  });
+
+  it("does nothing on Delete when the caller offers no close", async () => {
+    setup();
+    tab("Pods").focus();
+    await userEvent.keyboard("{Delete}");
+    expect(screen.getAllByRole("tab")).toHaveLength(3);
+  });
+
+  it("offers a named close button on each closable tab", async () => {
+    const onClose = vi.fn();
+    render(<TabStrip tabs={TABS} activeId="pods" onSelect={() => {}} onClose={onClose} />);
+    await userEvent.click(screen.getByRole("button", { name: "Close checkout-api" }));
+    expect(onClose).toHaveBeenCalledWith("logs");
+  });
+
+  it("does not select the tab it closes", async () => {
+    // The close button sits inside the tab, so its click reaches the tab's own
+    // handler unless stopped — and closing the tab you were not on should not
+    // first switch you to it.
+    const onSelect = vi.fn();
+    const onClose = vi.fn();
+    render(<TabStrip tabs={TABS} activeId="pods" onSelect={onSelect} onClose={onClose} />);
+    await userEvent.click(screen.getByRole("button", { name: "Close checkout-api" }));
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("keeps the close button out of the tab order", async () => {
+    // Pointer-operable, but not a stop of its own: the tab stays one focusable
+    // node rather than three, and Delete is the keyboard's way to it.
+    const onClose = vi.fn();
+    render(<TabStrip tabs={TABS} activeId="pods" onSelect={() => {}} onClose={onClose} />);
+    for (const name of ["Close Pods", "Close checkout-api", "Close nginx-7d4b"]) {
+      expect(screen.getByRole("button", { name }).getAttribute("tabindex")).toBe("-1");
+    }
+  });
+
+  it("closes on a middle click", async () => {
+    // Kept from the mock, where it was the only way to close without the
+    // window accelerator. It is a shortcut now rather than the sole route.
+    const onClose = vi.fn();
+    render(<TabStrip tabs={TABS} activeId="pods" onSelect={() => {}} onClose={onClose} />);
+    await userEvent.pointer({ keys: "[MouseMiddle]", target: tab("checkout-api") });
+    expect(onClose).toHaveBeenCalledWith("logs");
+  });
+
+  it("moves focus to a neighbour when the focused tab goes away", async () => {
+    // Otherwise focus falls to the body and a keyboard user is back at the top
+    // of the window after every close.
+    function Harness() {
+      const [tabs, setTabs] = useState(TABS);
+      return (
+        <TabStrip
+          tabs={tabs}
+          activeId="pods"
+          onSelect={() => {}}
+          onClose={(id) => setTabs((rest) => rest.filter((t) => t.id !== id))}
+        />
+      );
+    }
+    render(<Harness />);
+    tab("checkout-api").focus();
+    await userEvent.keyboard("{Delete}");
+    expect(screen.queryByRole("tab", { name: /^checkout-api/ })).toBeNull();
+    expect(document.activeElement).toBe(tab("nginx-7d4b"));
+  });
+
+  it("shows a pin instead of a close on a pinned tab", () => {
+    const pinned: StripTab[] = [{ id: "pods", title: "Pods", pinned: true }, ...TABS.slice(1)];
+    render(<TabStrip tabs={pinned} activeId="pods" onSelect={() => {}} onClose={() => {}} />);
+    expect(tab("Pods").querySelector(".tab-pin")).not.toBeNull();
+    expect(tab("checkout-api").querySelector(".tab-pin")).toBeNull();
+  });
+});
+
+/** The two controls at the end of the strip, and what the mock made of them. */
+describe("TabStrip controls", () => {
+  it("offers no new-tab control unless the caller wants one", () => {
+    setup();
+    expect(screen.queryByRole("button", { name: "New tab" })).toBeNull();
+  });
+
+  it("names the new-tab control and reports it", async () => {
+    const onNew = vi.fn();
+    render(<TabStrip tabs={TABS} activeId="pods" onSelect={() => {}} onNew={onNew} newLabel="Open resource" />);
+    await userEvent.click(screen.getByRole("button", { name: "Open resource" }));
+    expect(onNew).toHaveBeenCalled();
+  });
+
+  it("shows the accelerator as a hint without folding it into the name", async () => {
+    // The keystroke is the app's to bind; the strip only says what it is. Kept
+    // out of the accessible name for the reason ContextMenu keeps its hints
+    // out: "New tab command T" is not what the control does.
+    render(<TabStrip tabs={TABS} activeId="pods" onSelect={() => {}} onNew={() => {}} newHint="⌘T" />);
+    const button = screen.getByRole("button", { name: "New tab" });
+    expect(button.getAttribute("title")).toContain("⌘T");
+  });
+
+  it("does not submit the form it is standing in", async () => {
+    // A bare <button> inside a form submits it, and the tab bar of a desktop
+    // app stands above whatever screen is open.
+    const onSubmit = vi.fn((e: FormEvent) => e.preventDefault());
+    render(
+      <form onSubmit={onSubmit}>
+        <TabStrip tabs={TABS} activeId="pods" onSelect={() => {}} onClose={() => {}} onNew={() => {}} />
+      </form>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "New tab" }));
+    await userEvent.click(screen.getByRole("button", { name: "Close Pods" }));
+    await userEvent.click(screen.getByRole("button", { name: "All open tabs" }));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("opens every tab in the overflow list and selects from it", async () => {
+    // The mock's trigger was a `<span title="All open tabs">`: not focusable,
+    // not a button, named only by a tooltip. Same fault WorkspaceSwitcher and
+    // ActionBar both had. (#332)
+    const { onSelect } = setup();
+    const trigger = screen.getByRole("button", { name: "All open tabs" });
+    expect(trigger.tagName).toBe("BUTTON");
+    await userEvent.click(trigger);
+    const panel = await screen.findByRole("dialog");
+    for (const title of ["Pods", "checkout-api", "nginx-7d4b"]) {
+      expect(screen.getByRole("button", { name: new RegExp(`^${title}`) })).toBeDefined();
+    }
+    await userEvent.click(screen.getByRole("button", { name: /^nginx-7d4b/ }));
+    expect(onSelect).toHaveBeenCalledWith("shell");
+    expect(panel.isConnected).toBe(false);
+  });
+
+  it("marks the active tab in the overflow list", async () => {
+    setup({ activeId: "logs" });
+    await userEvent.click(screen.getByRole("button", { name: "All open tabs" }));
+    await screen.findByRole("dialog");
+    expect(screen.getByRole("button", { name: /^checkout-api/ }).getAttribute("aria-current")).toBe("true");
+  });
+});
+
+/** Per-tab actions, supplied by the caller rather than known here. */
+describe("TabStrip context menu", () => {
+  it("opens the caller's menu on a right-click and reports a pick", async () => {
+    const onPick = vi.fn();
+    setup({ menuFor: (t: StripTab) => [{ label: `Duplicate ${t.title}`, onPick }] });
+    fireEvent.contextMenu(tab("checkout-api"));
+    await screen.findByRole("menu");
+    await userEvent.click(screen.getByRole("menuitem", { name: "Duplicate checkout-api" }));
+    expect(onPick).toHaveBeenCalled();
+  });
+
+  it("has no menu when the caller supplies none", async () => {
+    setup();
+    fireEvent.contextMenu(tab("Pods"));
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("leaves the tab a tab, wrapped or not", () => {
+    // Radix's trigger clones its child, and a component that swallowed the
+    // roving tabIndex or the role would render correctly and never work.
+    setup({ menuFor: () => [{ label: "Close", onPick: () => {} }] });
+    expect(tab("Pods").getAttribute("role")).toBe("tab");
+    expect(tab("Pods").getAttribute("tabindex")).toBe("0");
+  });
+});
+
+describe("TabStrip with nothing open", () => {
+  it("renders an empty strip that is still a strip", () => {
+    render(<TabStrip tabs={[]} activeId="" onSelect={() => {}} onNew={() => {}} />);
+    expect(screen.getByRole("tablist")).toBeDefined();
+    expect(screen.queryAllByRole("tab")).toHaveLength(0);
+    expect(screen.getByRole("button", { name: "New tab" })).toBeDefined();
+    // Nothing to list, so no list.
+    expect(screen.queryByRole("button", { name: "All open tabs" })).toBeNull();
+  });
+
+  it("stays reachable when the active id matches nothing", () => {
+    // A caller mid-transition, or an id that has just been closed. The strip
+    // must still have a tab stop, or it drops out of the tab order entirely.
+    render(<TabStrip tabs={TABS} activeId="gone" onSelect={() => {}} />);
+    expect(tab("Pods").getAttribute("tabindex")).toBe("0");
+  });
+});

--- a/packages/ui-kit/src/TabStrip.tsx
+++ b/packages/ui-kit/src/TabStrip.tsx
@@ -1,0 +1,413 @@
+import { useEffect, useRef, useState, type KeyboardEvent } from "react";
+import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
+import { cx } from "./cx";
+import type { IconComponent } from "./IconButton";
+import { NavIcon } from "./NavIcon";
+import { Popover } from "./Popover";
+import { filled } from "./slot";
+import { toneColor } from "./tone";
+
+export interface StripTab {
+  id: string;
+  /** What the tab is called, and the front of its accessible name. */
+  title: string;
+  /** The quiet tag after the title — the cluster, the namespace, "logs". */
+  sub?: string;
+  /**
+   * The glyph for this tab. Taken per tab rather than mapped from a kind:
+   * which icon means "workloads" is the product's vocabulary, not the design
+   * system's, the same way {@link NavIcon} renders whatever it is handed.
+   */
+  icon?: IconComponent;
+  /** Pinned tabs show a pin instead of a close, and refuse to be closed. */
+  pinned?: boolean;
+  /** A peek rather than a commitment — drawn in italic by the stylesheet. */
+  preview?: boolean;
+}
+
+export interface TabStripProps {
+  tabs: StripTab[];
+  /** The document on screen. An id matching nothing is tolerated. */
+  activeId: string;
+  /**
+   * Fires for a tab that is already active too, so a caller that promotes a
+   * preview tab on a second open has somewhere to do it.
+   */
+  onSelect: (id: string) => void;
+  /** Offered per tab when given, and never on a pinned one. Left out, no close at all. */
+  onClose?: (id: string) => void;
+  /** Offered at the end of the strip when given. */
+  onNew?: () => void;
+  /** The right-click menu for one tab. Left out, tabs answer no right-click. */
+  menuFor?: (tab: StripTab) => ContextMenuItem[];
+  /** Names the strip. */
+  label?: string;
+  newLabel?: string;
+  /** The accelerator for a new tab, as printed. The app binds it; see below. */
+  newHint?: string;
+  overflowLabel?: string;
+  className?: string;
+}
+
+/* Inline rather than an icon-set import: the kit takes no dependency on lucide,
+   and these are the only three glyphs it needs. */
+
+const CloseGlyph = () => (
+  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <path d="M18 6 6 18M6 6l12 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+  </svg>
+);
+
+const PlusGlyph = () => (
+  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <path d="M12 5v14M5 12h14" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+  </svg>
+);
+
+const ChevronGlyph = () => (
+  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <path d="m6 9 6 6 6-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+/**
+ * The full name, said rather than truncated.
+ *
+ * The mock hung this off `title=`, which is a tooltip: not reachable from a
+ * keyboard, announced inconsistently, and not the tab's accessible name. Set
+ * explicitly here for a second reason — the close button lives inside the tab,
+ * and a name computed from the contents would read "Pods prod-eu Close Pods".
+ * Pinned is in the name because it is why Delete does nothing.
+ */
+function tabName(tab: StripTab): string {
+  return `${tab.title}${filled(tab.sub) ? ` · ${tab.sub}` : ""}${tab.pinned ? ", pinned" : ""}`;
+}
+
+/**
+ * The app's document tabs: the strip along the top of the window holding every
+ * resource, log stream, shell and editor that is open.
+ *
+ * Not the kit's `Tabs`, despite the shared word and the shared stylesheet.
+ * `Tabs` is a view switcher inside one screen — a fixed handful of labels, all
+ * of them cheap, none of them dismissable. These are documents. They arrive and
+ * leave as the user works, they close, they pin, they carry the cluster they
+ * belong to, they spill past the width of the window into a list, and each one
+ * answers a right-click. #318 recorded this as a restyle of `Tabs`, which is
+ * the mistake #332 exists to correct: the two share no behaviour worth sharing.
+ *
+ * The keyboard is most of what changed from the mock, where there was none. Its
+ * tabs were `<div role="tab">` with a click handler and no `tabIndex`, so the
+ * document tab bar of a desktop application could not be reached at all without
+ * a mouse, while `role="tablist"` promised assistive technology arrow keys that
+ * did nothing. The strip is one tab stop landing on the active tab, Left and
+ * Right move the focus within it, Home and End go to the ends, and Enter or
+ * Space opens what the focus is on.
+ *
+ * Activation is manual, unlike `Tabs`, which selects as focus moves. There the
+ * panels are already rendered and switching is free; here a tab is a terminal
+ * session or a log stream, and arrowing past three of them to reach the fourth
+ * must not open three documents on the way.
+ *
+ * Arrowing does not wrap, and that is a deliberate departure from its sibling.
+ * `Tabs` holds three or four labels that are all on screen at once, so wrapping
+ * is a shortcut. This strip scrolls: it holds as many documents as the user has
+ * opened, most of them out of view, and the browser scrolls the focused tab
+ * into view as it goes. Wrapping there means one arrow key at the last tab
+ * yanks the whole strip back to the start — the tab bar equivalent of a cursor
+ * jumping to the top of the file — and Home and End already reach the ends
+ * deliberately. The ARIA practices leave the choice open; a scrolling strip is
+ * the case where the ends should feel like ends.
+ *
+ * Delete and Backspace close the focused tab, which is the practices guide's
+ * own recommendation for closable tabs and the only reason the close affordance
+ * has a keyboard equivalent at all. The visible close button stays where it is
+ * and stays pointer-operable, but out of the tab order at `tabIndex={-1}`. That
+ * is the same reckoning `WorkspaceTree` made when it declined `role="tree"` —
+ * a tab, like a treeitem, is one focusable node, and three controls do not fit
+ * in one — except that here the pattern is worth keeping and the extra control
+ * is what gives way. Tab reaches the strip and then leaves it; the close is
+ * reached by pointer or by Delete, and closing moves the focus to a neighbour
+ * rather than dropping it on the body.
+ *
+ * No accelerator is installed. The mock bound six of them at the window per
+ * instance — ⌘W, ⌘T, ⌘⇧T, ⌘[, ⌘] and ⌘1-9 — which `ConsoleDock` already had
+ * stripped out for the reason that applies here twice over: a window-level key
+ * belongs to whatever owns the window, a component cannot know what else the
+ * app has bound, and two strips on screen both answer the same keystroke. The
+ * hints are rendered, through `newHint` and through the menu items the caller
+ * supplies; the app does the binding.
+ *
+ * Everything the mock read out of `useTabs()` and did by calling into the store
+ * — activate, close, open, duplicate, pin, close others, close to the right,
+ * reopen — is a prop or a caller-supplied menu item now. The kit holds no app
+ * state. `menuFor` is the seam for the long tail of it: the strip knows a tab
+ * can be right-clicked, not what the product offers when it is. (#332)
+ */
+export function TabStrip({
+  tabs,
+  activeId,
+  onSelect,
+  onClose,
+  onNew,
+  menuFor,
+  label = "Open tabs",
+  newLabel = "New tab",
+  newHint,
+  overflowLabel = "All open tabs",
+  className,
+}: TabStripProps) {
+  const listRef = useRef<HTMLDivElement>(null);
+  const refs = useRef(new Map<string, HTMLDivElement>());
+  // Where the roving tab stop sits while the strip has the focus. Separate from
+  // `activeId` precisely because activation is manual: the two are the same
+  // until the user starts arrowing, and the point of arrowing is that they part.
+  const [focusedId, setFocusedId] = useState<string | null>(null);
+  // The tab to land on once the caller has actually removed the one being
+  // closed. Held in a ref rather than state: nothing renders differently for
+  // it, and it must survive the render that the close causes.
+  const pending = useRef<{ closed: string; next: string } | null>(null);
+
+  const closable = onClose !== undefined;
+
+  // Falls back through active to the first tab, so the strip keeps a tab stop
+  // even when the caller hands over an id that matches nothing — mid-transition,
+  // or one that has just been closed. A strip with no stop is out of the tab
+  // order entirely, which is the fault this component exists to fix.
+  const roving =
+    tabs.find((t) => t.id === focusedId)?.id ??
+    tabs.find((t) => t.id === activeId)?.id ??
+    tabs[0]?.id;
+
+  useEffect(() => {
+    const move = pending.current;
+    if (!move) return;
+    pending.current = null;
+    // The caller may have declined to close it. Leave the focus alone.
+    if (tabs.some((t) => t.id === move.closed)) return;
+    const node = refs.current.get(move.next);
+    if (!node) return;
+    setFocusedId(move.next);
+    node.focus();
+  }, [tabs]);
+
+  function requestClose(tab: StripTab) {
+    // Pinned is the user saying "not this one", and a pinned tab shows no close
+    // button — so Delete must not be the way around it.
+    if (!onClose || tab.pinned) return;
+    const at = tabs.findIndex((t) => t.id === tab.id);
+    const neighbour = tabs[at + 1] ?? tabs[at - 1];
+    // Only when the strip is where the focus already is: closing a tab from a
+    // menu somewhere else should not pull the focus back here.
+    const holdsFocus = listRef.current?.contains(document.activeElement) ?? false;
+    pending.current = holdsFocus && neighbour ? { closed: tab.id, next: neighbour.id } : null;
+    onClose(tab.id);
+  }
+
+  function onKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    // From the tab the focus is on, not from `activeId`: with manual activation
+    // those differ by design, and the close button inside a tab can be the
+    // focus too — its keys are not the strip's.
+    const target = (event.target as HTMLElement).closest('[role="tab"]');
+    const from = tabs.findIndex((t) => refs.current.get(t.id) === target);
+    if (from < 0) return;
+
+    if (event.key === "Enter" || event.key === " ") {
+      // A div is not a button, so neither key clicks it, and Space would scroll
+      // the page instead.
+      event.preventDefault();
+      onSelect(tabs[from].id);
+      return;
+    }
+    if (event.key === "Delete" || event.key === "Backspace") {
+      // Backspace is browser history in some hosts, and neither should reach
+      // whatever is behind the strip.
+      event.preventDefault();
+      requestClose(tabs[from]);
+      return;
+    }
+
+    let next = from;
+    if (event.key === "ArrowRight") next = Math.min(from + 1, tabs.length - 1);
+    else if (event.key === "ArrowLeft") next = Math.max(from - 1, 0);
+    else if (event.key === "Home") next = 0;
+    else if (event.key === "End") next = tabs.length - 1;
+    else return;
+    // At either end the key is left alone rather than swallowed: nothing moved,
+    // and no wrapping — see the doc comment.
+    if (next === from) return;
+    event.preventDefault();
+    setFocusedId(tabs[next].id);
+    refs.current.get(tabs[next].id)?.focus();
+  }
+
+  return (
+    <div className={cx("tabstrip", className)}>
+      {/*
+        The tablist is the scrolling half rather than the whole bar, for two
+        reasons: a tablist owns tabs and nothing else, so the new and overflow
+        controls cannot be inside it; and those two should stay put while the
+        tabs scroll under them.
+      */}
+      <div
+        ref={listRef}
+        role="tablist"
+        aria-label={label}
+        className="flex min-w-0 flex-1 overflow-x-auto"
+        onKeyDown={onKeyDown}
+        onBlur={(event) => {
+          // Focus has left the strip: the tab stop goes back to the active tab,
+          // so returning to the strip lands on the document being read rather
+          // than wherever the last arrow key stopped.
+          if (!event.currentTarget.contains(event.relatedTarget)) setFocusedId(null);
+        }}
+      >
+        {tabs.map((tab) => {
+          const current = tab.id === activeId;
+          const node = (
+            <div
+              key={tab.id}
+              ref={(el) => {
+                if (el) refs.current.set(tab.id, el);
+                else refs.current.delete(tab.id);
+              }}
+              role="tab"
+              className="tab"
+              data-active={current}
+              data-preview={tab.preview ? "true" : undefined}
+              data-pinned={tab.pinned ? "true" : undefined}
+              aria-selected={current}
+              aria-label={tabName(tab)}
+              tabIndex={tab.id === roving ? 0 : -1}
+              onFocus={() => setFocusedId(tab.id)}
+              onClick={() => onSelect(tab.id)}
+              // Kept from the mock, where it was the only way to close a tab
+              // that did not go through a window accelerator. It is a shortcut
+              // now rather than the sole route, which is what made it a fault.
+              onAuxClick={(event) => {
+                if (event.button === 1) requestClose(tab);
+              }}
+            >
+              {tab.icon && (
+                // Tinted by the tab rather than by the icon: `currentColor`
+                // carries it down, so a caller's plain SVG needs to know
+                // nothing about the active state. The slot guarantees the
+                // icon is hidden, the way ContextMenu's does.
+                <span
+                  className="flex shrink-0 items-center"
+                  style={{ color: current ? toneColor("accent") : "var(--ink-faint)" }}
+                >
+                  <NavIcon icon={tab.icon} />
+                </span>
+              )}
+              <span className="truncate">{tab.title}</span>
+              {filled(tab.sub) && <span className="tab-sub truncate">{tab.sub}</span>}
+              {tab.pinned ? (
+                // A dot in the stylesheet, not a glyph. Hidden: the tab's own
+                // name says "pinned", which is where it is any use.
+                <span className="tab-pin" aria-hidden="true" />
+              ) : (
+                closable && (
+                  <button
+                    type="button"
+                    className="tab-close"
+                    // Pointer-operable, out of the tab order. See the doc
+                    // comment: the tab stays one focusable node, and Delete is
+                    // the keyboard's way to this.
+                    tabIndex={-1}
+                    aria-label={`Close ${tab.title}`}
+                    onClick={(event) => {
+                      // The button sits inside the tab, so its click reaches
+                      // the tab's own handler otherwise — and closing a tab you
+                      // were not on should not first switch you to it.
+                      event.stopPropagation();
+                      requestClose(tab);
+                    }}
+                  >
+                    <CloseGlyph />
+                  </button>
+                )
+              )}
+            </div>
+          );
+
+          return menuFor ? (
+            <ContextMenu key={tab.id} items={menuFor(tab)} label={`${tab.title} actions`}>
+              {node}
+            </ContextMenu>
+          ) : (
+            node
+          );
+        })}
+      </div>
+
+      {filled(onNew ? newLabel : null) && (
+        <button
+          type="button"
+          className="tab-new"
+          // The keystroke is shown, never folded into the name: "New tab
+          // command T" is not what the control does, and not what a
+          // speech-input user would say to reach it. Same reasoning as
+          // ContextMenu's hints.
+          aria-label={newLabel}
+          title={filled(newHint) ? `${newLabel}  ${newHint}` : newLabel}
+          onClick={onNew}
+        >
+          <PlusGlyph />
+        </button>
+      )}
+
+      {tabs.length > 0 && (
+        // Always offered rather than only when the strip actually overflows:
+        // knowing that needs a measurement on every render and every resize,
+        // and a control that appears and disappears under the pointer is worse
+        // than one that is always in the same place.
+        <Popover
+          label={overflowLabel}
+          align="end"
+          className="w-[268px] py-1"
+          trigger={
+            <span className="tab-new">
+              <ChevronGlyph />
+              {/* The mock's trigger was a `<span title="All open tabs">`: not
+                  focusable, not a button, named only by a tooltip. Popover
+                  gives it the button; the name has to come from what it shows,
+                  and it shows a chevron. */}
+              <span className="sr-only">{overflowLabel}</span>
+            </span>
+          }
+        >
+          {(close) => (
+            <>
+              {tabs.map((tab) => {
+                const current = tab.id === activeId;
+                return (
+                  <button
+                    key={tab.id}
+                    type="button"
+                    className="ns-row"
+                    data-on={current}
+                    // Which one you are on, said rather than only shown.
+                    aria-current={current || undefined}
+                    onClick={() => {
+                      onSelect(tab.id);
+                      close();
+                    }}
+                  >
+                    <span
+                      className="flex w-[12px] shrink-0 items-center justify-center"
+                      style={{ color: current ? toneColor("accent") : "var(--ink-faint)" }}
+                    >
+                      {tab.icon && <NavIcon icon={tab.icon} />}
+                    </span>
+                    <span className="flex-1 truncate text-left">{tab.title}</span>
+                    {filled(tab.sub) && <span className="path shrink-0 text-faint">{tab.sub}</span>}
+                  </button>
+                );
+              })}
+            </>
+          )}
+        </Popover>
+      )}
+    </div>
+  );
+}

--- a/packages/ui-kit/src/WorkspaceSwitcher.test.tsx
+++ b/packages/ui-kit/src/WorkspaceSwitcher.test.tsx
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi } from "vitest";
+import type { FormEvent } from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { WorkspaceSwitcher } from "./WorkspaceSwitcher";
+
+// jsdom has no ResizeObserver and Radix's popper watches with one. Same stub
+// the other Radix-backed suites carry, kept here rather than in the shared
+// setup so the requirement stays visible.
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
+const WORKSPACES = [
+  { id: "prod", name: "Production", clusters: 2, tabs: 11 },
+  { id: "local", name: "Local & staging", clusters: 5, tabs: 2 },
+  { id: "platform", name: "Platform", clusters: 4, tabs: 3 },
+];
+
+function setup(props: Partial<Parameters<typeof WorkspaceSwitcher>[0]> = {}) {
+  const onSelect = vi.fn();
+  const view = render(
+    <WorkspaceSwitcher
+      workspaces={WORKSPACES}
+      activeId="local"
+      onSelect={onSelect}
+      {...props}
+    />,
+  );
+  return { onSelect, ...view };
+}
+
+/**
+ * The chip itself. Named by the active workspace, which the active row in the
+ * open panel is called too — and the panel is portalled to the end of the
+ * document, so the chip is the first of the two.
+ */
+const trigger = () => screen.getAllByRole("button")[0];
+
+async function open(props: Partial<Parameters<typeof WorkspaceSwitcher>[0]> = {}) {
+  const view = setup(props);
+  await userEvent.click(trigger());
+  await screen.findByRole("dialog");
+  return view;
+}
+
+/** A row inside the open panel, as distinct from the chip. */
+const row = (name: RegExp) =>
+  screen.getAllByRole("button", { name }).find((el) => el.classList.contains("ns-row"))!;
+
+/**
+ * The chip at the left of the titlebar and the panel it opens.
+ *
+ * The mock's version was a `<span class="ws-chip">` inside a Popover trigger —
+ * so the control that switches everything you are looking at could not be
+ * reached by keyboard at all. That, and the fact that it read `useTabs()` and
+ * called three store mutators directly, is what this is fixing. (#332)
+ */
+describe("WorkspaceSwitcher", () => {
+  it("names the current workspace on the trigger", () => {
+    setup();
+    expect(trigger().textContent).toContain("Local & staging");
+  });
+
+  it("is a button, so it can be reached and pressed from the keyboard", async () => {
+    // The mock's trigger was a span. Focusable by nothing, operable by nothing.
+    setup();
+    await userEvent.tab();
+    expect(document.activeElement).toBe(trigger());
+    await userEvent.keyboard("{Enter}");
+    expect(await screen.findByRole("dialog")).toBeDefined();
+  });
+
+  it("does not submit a form it is standing in", async () => {
+    const onSubmit = vi.fn((e: FormEvent) => e.preventDefault());
+    render(
+      <form onSubmit={onSubmit}>
+        <WorkspaceSwitcher workspaces={WORKSPACES} activeId="local" onSelect={() => {}} />
+      </form>,
+    );
+    await userEvent.click(trigger());
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("lists every workspace with what it holds", async () => {
+    await open();
+    const production = row(/Production/);
+    expect(production.textContent).toContain("2 clusters");
+    expect(production.textContent).toContain("11 tabs");
+  });
+
+  it("counts one cluster and one tab in the singular", async () => {
+    // "1 clusters · 1 tabs" is the kind of thing that survives a mock and
+    // embarrasses a product.
+    await open({ workspaces: [{ id: "a", name: "Solo", clusters: 1, tabs: 1 }], activeId: "a" });
+    const solo = row(/Solo/);
+    expect(solo.textContent).toContain("1 cluster ");
+    expect(solo.textContent).not.toContain("1 clusters");
+    expect(solo.textContent).toContain("1 tab");
+    expect(solo.textContent).not.toContain("1 tabs");
+  });
+
+  it("says which one you are in, not only in colour", async () => {
+    await open();
+    expect(row(/Local & staging/).getAttribute("aria-current")).toBe("true");
+    expect(row(/Production/).getAttribute("aria-current")).toBeNull();
+  });
+
+  it("reports the workspace that was chosen, and closes", async () => {
+    const { onSelect } = await open();
+    await userEvent.click(row(/Production/));
+    expect(onSelect).toHaveBeenCalledWith("prod");
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+  });
+
+  it("offers no remove control when there is only one workspace", async () => {
+    // Removing the last one leaves nothing to be in.
+    const onRemove = vi.fn();
+    await open({ workspaces: [{ id: "a", name: "Solo", clusters: 1, tabs: 1 }], activeId: "a", onRemove });
+    expect(screen.queryByRole("button", { name: /Remove/ })).toBeNull();
+  });
+
+  it("offers no remove control when the caller cannot remove", async () => {
+    await open();
+    expect(screen.queryByRole("button", { name: /Remove/ })).toBeNull();
+  });
+
+  it("says what removing a workspace would cost, in the control's own name", async () => {
+    // One click, no undo, and eleven tabs inside it. The name is the only
+    // warning a screen-reader user gets before pressing it. (#332)
+    const onRemove = vi.fn();
+    await open({ onRemove });
+    const remove = screen.getByRole("button", { name: /Remove Production/ });
+    expect(remove.getAttribute("aria-label")).toContain("2 clusters");
+    expect(remove.getAttribute("aria-label")).toContain("11 tabs");
+    await userEvent.click(remove);
+    expect(onRemove).toHaveBeenCalledWith("prod");
+  });
+
+  it("does not switch workspace when the remove beside it is pressed", async () => {
+    const onRemove = vi.fn();
+    const { onSelect } = await open({ onRemove });
+    await userEvent.click(screen.getByRole("button", { name: /Remove Production/ }));
+    expect(onRemove).toHaveBeenCalledWith("prod");
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("offers a way to make a new workspace, and closes after", async () => {
+    const onCreate = vi.fn();
+    await open({ onCreate });
+    await userEvent.click(screen.getByRole("button", { name: "New workspace" }));
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+  });
+
+  it("omits the footer entirely when there is no creating to do", async () => {
+    // An empty ruled band under the list is a visible artefact.
+    const { container } = await open();
+    expect(container.ownerDocument.querySelector('[data-slot="workspace-new"]')).toBeNull();
+  });
+
+  it("names the panel", async () => {
+    await open();
+    expect(screen.getByRole("dialog", { name: "Workspaces" })).toBeDefined();
+  });
+
+  it("closes on Escape", async () => {
+    await open();
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+  });
+
+  it("says so when there are no workspaces at all", async () => {
+    // In the panel as well as on the chip: the chip falls back to it because
+    // there is no name to show, and the panel says it because an empty list
+    // that renders nothing looks like a panel that failed to load.
+    await open({ workspaces: [], activeId: "", emptyLabel: "No workspaces" });
+    const panel = screen.getByRole("dialog");
+    expect(panel.textContent).toContain("No workspaces");
+    expect(trigger().textContent).toContain("No workspaces");
+  });
+});

--- a/packages/ui-kit/src/WorkspaceSwitcher.tsx
+++ b/packages/ui-kit/src/WorkspaceSwitcher.tsx
@@ -1,0 +1,177 @@
+import { cx } from "./cx";
+import { filled } from "./slot";
+import { IconButton, type IconComponent } from "./IconButton";
+import { Popover } from "./Popover";
+
+export interface WorkspaceSummary {
+  id: string;
+  name: string;
+  /** How many clusters it holds, and how many tabs are open in it. */
+  clusters: number;
+  tabs: number;
+}
+
+export interface WorkspaceSwitcherProps {
+  workspaces: WorkspaceSummary[];
+  activeId: string;
+  onSelect: (id: string) => void;
+  /** Offered per workspace when given, and never on the last one. */
+  onRemove?: (id: string) => void;
+  /** Offered under the list when given. */
+  onCreate?: () => void;
+  createLabel?: string;
+  /** Marks the chip — a grid, a mark, whatever the app uses for a workspace. */
+  icon?: IconComponent;
+  emptyLabel?: string;
+  /** Names the panel. */
+  label?: string;
+  className?: string;
+}
+
+/* Inline rather than an icon-set import: the kit takes no dependency on
+   lucide, and these are the only two glyphs it needs. */
+const ChevronGlyph = () => (
+  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" aria-hidden="true" className="shrink-0">
+    <path d="m6 9 6 6 6-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+const CloseGlyph: IconComponent = ({ size = 11, className, "aria-hidden": hidden }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" className={className} aria-hidden={hidden}>
+    <path d="M18 6 6 18M6 6l12 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+  </svg>
+);
+
+/** "2 clusters · 11 tabs", and "1 cluster · 1 tab". */
+function summarize({ clusters, tabs }: WorkspaceSummary): string {
+  const plural = (n: number, word: string) => `${n} ${word}${n === 1 ? "" : "s"}`;
+  return `${plural(clusters, "cluster")} · ${plural(tabs, "tab")}`;
+}
+
+/**
+ * The chip at the left of the title bar, and the panel of workspaces it opens.
+ *
+ * A workspace is the largest thing a switch can change — which clusters are in
+ * reach and which tabs are open — so the control that changes it has to be
+ * reachable. The mock's was a `<span class="ws-chip">` handed to a popover as
+ * its trigger: not focusable, not operable by keyboard, and not announced as a
+ * control at all. It is a button here, which is the whole of the fix and most
+ * of the reason this component exists. (#332)
+ *
+ * Everything it knew, it now takes. The mock read `useTabs()` and called
+ * `switchWorkspace`, `createWorkspace` and `removeWorkspace` straight out of a
+ * click; the kit may not hold app state, and a summary of each workspace plus
+ * three callbacks is all the panel ever needed.
+ *
+ * Removing a workspace is one click, has no undo, and takes every tab in it.
+ * Whether to ask first is the caller's — a confirmation this component put up
+ * would be one the app could not skip — but the weight of it belongs in the
+ * control's own name, so "Remove Production, 2 clusters and 11 tabs" is what a
+ * screen reader says before the press rather than after. The last workspace
+ * offers no remove at all: there would be nothing left to be in.
+ */
+export function WorkspaceSwitcher({
+  workspaces,
+  activeId,
+  onSelect,
+  onRemove,
+  onCreate,
+  createLabel = "New workspace",
+  icon: Icon,
+  emptyLabel = "No workspaces",
+  label = "Workspaces",
+  className,
+}: WorkspaceSwitcherProps) {
+  const active = workspaces.find((workspace) => workspace.id === activeId);
+  // Never on the last one, whatever the caller passes: removing it leaves the
+  // app with no workspace to be in and no way back to one.
+  const removable = onRemove !== undefined && workspaces.length > 1;
+
+  return (
+    <Popover
+      label={label}
+      className={cx("w-[262px] py-1", className)}
+      trigger={
+        <span className="ws-chip">
+          {Icon && <Icon size={12} aria-hidden="true" />}
+          <span className="max-w-[110px] truncate">{active?.name ?? emptyLabel}</span>
+          <ChevronGlyph />
+        </span>
+      }
+    >
+      {(close) => (
+        <>
+          <div className="px-2 pb-1">
+            <span className="eyebrow">{label}</span>
+          </div>
+          {workspaces.length === 0 ? (
+            <p className="px-2 py-3 text-center text-[0.75rem] text-muted">{emptyLabel}</p>
+          ) : (
+            workspaces.map((workspace) => {
+              const current = workspace.id === activeId;
+              return (
+                <div key={workspace.id} className="flex items-center">
+                  <button
+                    type="button"
+                    className="ns-row"
+                    data-on={current}
+                    // Which one you are in, said rather than only shown: the
+                    // mock marked it with a tick at opacity 1 and nothing else.
+                    aria-current={current || undefined}
+                    onClick={() => {
+                      onSelect(workspace.id);
+                      close();
+                    }}
+                  >
+                    <svg
+                      width="12"
+                      height="12"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      aria-hidden="true"
+                      // Always rendered: a tick appearing would shove the name
+                      // it belongs to sideways.
+                      className={cx("shrink-0", current ? "opacity-100" : "opacity-0")}
+                      style={{ color: "var(--accent)" }}
+                    >
+                      <path d="M20 6 9 17l-5-5" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                    <span className="min-w-0 flex-1 text-left">
+                      <span className="block truncate">{workspace.name}</span>
+                      <span className="path block truncate text-faint">{summarize(workspace)}</span>
+                    </span>
+                  </button>
+                  {removable && (
+                    <IconButton
+                      icon={CloseGlyph}
+                      // The whole cost, in the name. This is destructive, it
+                      // has no undo, and the count is the part worth knowing.
+                      label={`Remove ${workspace.name}, ${summarize(workspace).replace(" · ", " and ")}`}
+                      title="Remove workspace"
+                      className="mr-1 shrink-0"
+                      onClick={() => onRemove?.(workspace.id)}
+                    />
+                  )}
+                </div>
+              );
+            })
+          )}
+          {filled(onCreate ? createLabel : null) && (
+            <div data-slot="workspace-new" className="rule-t mt-1 p-1.5">
+              <button
+                type="button"
+                className="btn w-full justify-center"
+                onClick={() => {
+                  onCreate?.();
+                  close();
+                }}
+              >
+                {createLabel}
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </Popover>
+  );
+}

--- a/packages/ui-kit/src/gallery/Gallery.tsx
+++ b/packages/ui-kit/src/gallery/Gallery.tsx
@@ -55,6 +55,7 @@ import { SubHead } from "../SubHead";
 import { SurfaceToast } from "../SurfaceToast";
 import { Switch } from "../Switch";
 import { Table, type Column } from "../Table";
+import { TabStrip } from "../TabStrip";
 import { Tabs } from "../Tabs";
 import { TextInput } from "../TextInput";
 import { Titlebar } from "../Titlebar";
@@ -135,6 +136,12 @@ export function Gallery() {
   const [tab, setTab] = useState("pods");
   const [drawer, setDrawer] = useState(false);
   const [workspace, setWorkspace] = useState("local");
+  const [openTabs, setOpenTabs] = useState([
+    { id: "control", title: "Control room", sub: "prod-eu", pinned: true },
+    { id: "workloads", title: "Workloads", sub: "prod-eu" },
+    { id: "logs", title: "checkout-api logs", sub: "prod-eu", preview: true },
+  ]);
+  const [openTab, setOpenTab] = useState("workloads");
   const [boxes, setBoxes] = useState({ a: true, b: false });
   const [refresh, setRefresh] = useState("30");
   const [live, setLive] = useState(true);
@@ -1576,6 +1583,35 @@ export function Gallery() {
         />
         {/* Nothing yet: the chip falls back to the empty label. */}
         <WorkspaceSwitcher workspaces={[]} activeId="" onSelect={() => {}} />
+      </section>
+      <section>
+        <h2>TabStrip</h2>
+        {/* The app's document tabs, not the view switcher above. One tab stop
+            for the strip; arrows move focus without opening anything, because
+            a tab here can be a live log stream; Enter opens; Delete closes the
+            focused one, which is what gives the × a keyboard equivalent. */}
+        <TabStrip
+          tabs={openTabs}
+          activeId={openTab}
+          onSelect={setOpenTab}
+          onClose={(id) => setOpenTabs((t) => t.filter((tab) => tab.id !== id))}
+          onNew={() =>
+            setOpenTabs((t) => [...t, { id: `tab-${t.length}`, title: "Pods", sub: "prod-eu" }])
+          }
+          newHint="⌘T"
+          menuFor={(tab) => [
+            { label: "Duplicate tab", onPick: () => {} },
+            { label: tab.pinned ? "Unpin tab" : "Pin tab", onPick: () => {} },
+            { kind: "sep" },
+            { label: "Close tab", hint: "⌘W", danger: true, onPick: () => {} },
+          ]}
+        />
+        <p className="text-[0.75rem] text-muted">
+          open: {openTab} · {openTabs.length} tab{openTabs.length === 1 ? "" : "s"}
+        </p>
+        {/* The pinned tab shows a pin rather than a close, and Delete refuses
+            it. Nothing open is still a strip. */}
+        <TabStrip tabs={[]} activeId="" onSelect={() => {}} onNew={() => {}} />
       </section>
     </div>
   );

--- a/packages/ui-kit/src/gallery/Gallery.tsx
+++ b/packages/ui-kit/src/gallery/Gallery.tsx
@@ -61,6 +61,7 @@ import { Titlebar } from "../Titlebar";
 import { Toast } from "../Toast";
 import { Toolbar } from "../Toolbar";
 import { Tooltip } from "../Tooltip";
+import { WorkspaceSwitcher } from "../WorkspaceSwitcher";
 import { WorkspaceTree } from "../WorkspaceTree";
 import type { Tone } from "../tone";
 
@@ -133,6 +134,7 @@ export function Gallery() {
   const [ns, setNs] = useState("kube-system");
   const [tab, setTab] = useState("pods");
   const [drawer, setDrawer] = useState(false);
+  const [workspace, setWorkspace] = useState("local");
   const [boxes, setBoxes] = useState({ a: true, b: false });
   const [refresh, setRefresh] = useState("30");
   const [live, setLive] = useState(true);
@@ -1546,6 +1548,34 @@ export function Gallery() {
             <p className="relative p-3 text-[0.75rem] text-muted">and another</p>
           </div>
         </div>
+      </section>
+      <section>
+        <h2>WorkspaceSwitcher</h2>
+        {/* The chip is a button, not the mock's span: a workspace switch
+            changes which clusters are in reach and which tabs are open, so the
+            control for it has to be reachable. */}
+        <WorkspaceSwitcher
+          workspaces={[
+            { id: "prod", name: "Production", clusters: 2, tabs: 11 },
+            { id: "local", name: "Local & staging", clusters: 5, tabs: 2 },
+            { id: "platform", name: "Platform", clusters: 4, tabs: 3 },
+          ]}
+          activeId={workspace}
+          onSelect={setWorkspace}
+          onRemove={() => {}}
+          onCreate={() => {}}
+        />
+        <p className="text-[0.75rem] text-muted">in: {workspace}</p>
+        {/* The last workspace offers no remove — there would be nothing left
+            to be in — and one of each counts in the singular. */}
+        <WorkspaceSwitcher
+          workspaces={[{ id: "solo", name: "Solo", clusters: 1, tabs: 1 }]}
+          activeId="solo"
+          onSelect={() => {}}
+          onRemove={() => {}}
+        />
+        {/* Nothing yet: the chip falls back to the empty label. */}
+        <WorkspaceSwitcher workspaces={[]} activeId="" onSelect={() => {}} />
       </section>
     </div>
   );

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -61,6 +61,7 @@ export { Titlebar, type TitlebarProps } from "./Titlebar";
 export { Toast, type ToastProps } from "./Toast";
 export { Toolbar, type ToolbarProps } from "./Toolbar";
 export { Tooltip, type TooltipProps } from "./Tooltip";
+export { WorkspaceSwitcher, type WorkspaceSummary, type WorkspaceSwitcherProps } from "./WorkspaceSwitcher";
 export { type ClusterLink, type WorkspaceCluster, WorkspaceTree, type WorkspaceTreeProps } from "./WorkspaceTree";
 export { cx } from "./cx";
 export { toneColor, toneWash, type Tone } from "./tone";

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -56,6 +56,7 @@ export { SurfaceToast, type SurfaceToastProps } from "./SurfaceToast";
 export { Switch, type SwitchProps } from "./Switch";
 export { Table, computeVisibleRange, filterTableData, nextSort, type Column, type TableProps, type TableSelection, type TableSort } from "./Table";
 export { Tabs, type TabItem, type TabsProps } from "./Tabs";
+export { TabStrip, type StripTab, type TabStripProps } from "./TabStrip";
 export { TextInput, type TextInputProps } from "./TextInput";
 export { Titlebar, type TitlebarProps } from "./Titlebar";
 export { Toast, type ToastProps } from "./Toast";


### PR DESCRIPTION
Closes #332. The two components the titlebar needs and the kit did not have — reported from a screenshot of the mock's chrome beside what #331 shipped.

## How each was missed

**`WorkspaceSwitcher`** is declared `function`, not `export function`. #320's component list was built from the mock's exports, so a file-local component was invisible to it. I checked the other seven locals: `Row`/`Section` are the trees', `Suggestions`/`CommandList`/`Thread` are console app-behaviour, `TabButton`/`TabOverflow` belong to this strip. So it was the only gap of that kind.

**`TabStrip` is a mapping error in #318**, not an oversight. That issue's table lists it as a mock counterpart of the kit's `Tabs`, i.e. a restyle. They share a word and nothing else:

| | `Tabs` | `TabStrip` |
|---|---|---|
| what | a view switcher inside one screen | the app's open documents |
| API | `tabs`, `active`, `onChange`, `label` | tabs that close, pin, badge, overflow |
| plus | — | a per-tab context menu |

## Both were unreachable by keyboard, in the same way

`WorkspaceSwitcher`'s trigger was a `<span class="ws-chip">` handed to a popover — so the control that changes which clusters are in reach and which tabs are open could not be focused or pressed. It is a button now, which is most of why the component exists.

`TabStrip` was worse: it claimed `role="tablist"` with `<div role="tab">` children that had a click handler and no `tabIndex`, so the entire tab bar was unreachable while announcing itself as a tab list.

**The strip is a real tablist now.** One tab stop roving to the active tab, Left/Right and Home/End within it, and **Delete or Backspace closes the focused tab** — the ARIA APG's answer for closable tabs, and what gives the × a keyboard equivalent. The × stays pointer-operable at `tabIndex={-1}`, so a tab remains one focusable node rather than three. That is the mirror of the call `WorkspaceTree` made in #331: there, rows carrying three peer controls declined the tree pattern; here the pattern is kept and the secondary control leaves the tab order, because a tab genuinely is one thing you select.

## Three contract decisions worth review

**Arrows move focus without selecting**, unlike `Tabs`. `Tabs` may select as focus moves because its panels are already rendered and free. A tab here can be a terminal session or a live log stream, and arrowing past three to reach the fourth must not open three of them. It is also what makes "Delete closes the *focused* tab" a coherent sentence.

**The ends do not wrap**, where `Tabs` does. The strip scrolls and holds every open document, and because arrowing moves DOM focus the browser scrolls the focused tab into view — so wrapping would yank the strip from one end to the other on a single keypress with nothing to explain it. Home and End reach the ends deliberately. At a boundary the key is not `preventDefault`ed, since nothing moved.

**The six window accelerators do not come with it** (⌘W, ⌘T, ⌘⇧T, ⌘[, ⌘], ⌘1-9). Same reason #331 stripped ⌘K from `ConsoleDock`: a window-level key belongs to whatever owns the window, a component cannot know what else is bound, and two strips would answer the same keystroke. The hints are rendered; the app binds the keys.

## Faults found

**A crash, not a defect.** `tabIcon[tab.kind]` has no fallback, so a tab kind added to `lib/tabs` without a matching map entry renders `<undefined />` and takes the whole tab bar down — a white screen. The icon is per-tab and caller-supplied now, which removes the class of bug rather than the instance, and which glyph means "workloads" was never the kit's to know.

Others:

- **The context menu captured a stale tab.** `setMenu({ x, y, tab: t })` snapshotted the tab *object* into state, so a rename, a pin toggle or a close by something else while the menu was open left it acting on the old one.
- **`e.metaKey || e.ctrlKey` on macOS** meant Ctrl+W — a common terminal keystroke — closed the document tab.
- **The `⌘⇧T` / `⌘T` ordering was load-bearing and unmarked**: reordering two lines silently broke reopen-closed.
- **`TabOverflow`'s trigger was a `<span title="All open tabs">`** — not focusable, named only by `title`. The same fault `WorkspaceSwitcher` and `ActionBar` had.
- **Removing a workspace** is one click with no undo that takes every tab inside it. Whether to confirm is the caller's — one baked in here could not be skipped — but the weight belongs in the control's own name, so a screen reader hears "Remove Production, 2 clusters and 11 tabs" before the press. The last workspace offers no remove at all.
- **"1 clusters · 1 tabs"** — counts read in the singular now.
- Both components read app state directly (`useTabs()` and five mutators between them). Presentation over props, as everything else in the kit.

## Known gaps, stated rather than hidden

- **Selecting an off-screen tab from the overflow menu does not scroll it into view.** The keyboard path gets this free because focus scrolls; the pointer path would need `scrollIntoView`, which jsdom does not implement, so it would ship untested. Worth a follow-up if the app hits it.
- **`role="tab"` carries no `aria-controls`.** Neither this nor the existing `Tabs` points a tab at its panel, because the panels are the caller's — a known gap in both, not introduced here.
- **`Badge` was not reused for the cluster tag**, though it was on the list. `.tab-sub` already exists for exactly this, and a bordered washed pill does not fit a 33px strip.

## Verification

- 2316 tests across 225 files pass; coverage 88.6 / 84.81 / 77.0, above the 85 / 80 / 76 floors.
- Typecheck clean across all four projects; `pnpm build` clean.
- Both written test-first with the RED confirmed. Where tests passed vacuously against a stub — negative assertions a null render satisfies for free — that is said rather than counted.
- The gallery test derives its checklist from the barrel, so both new exports have a section showing states: a single workspace that cannot be removed, an empty one, a pinned tab, and an empty strip.
