### PR TITLE
feat(ui-next): shell PRs 2–3 — the chrome, and the first two screens on real data

### DIFF
--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -10,6 +10,8 @@
     "core:webview:allow-set-webview-zoom",
     "core:window:allow-set-decorations",
     "core:window:allow-set-title-bar-style",
+    "core:window:allow-set-title",
+    "core:window:allow-start-dragging",
     "process:default",
     "deep-link:default",
     "window-state:default"

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -9,6 +9,7 @@
     "core:default",
     "core:webview:allow-set-webview-zoom",
     "core:window:allow-set-decorations",
+    "core:window:allow-set-title-bar-style",
     "process:default",
     "deep-link:default",
     "window-state:default"

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -157,6 +157,7 @@ vi.mock("./components/EditResourceTab", () => ({
 }));
 
 import { App } from "./App";
+import { HANDOFF_KEY } from "./design";
 
 const context = (name: string) => ({
   name,
@@ -418,5 +419,27 @@ describe("App", () => {
 
     expect(tauri.windowClose).toHaveBeenCalledTimes(1);
     delete (window as unknown as { __TAURI_INTERNALS__?: object }).__TAURI_INTERNALS__;
+  });
+
+  it("reopens the view the new design handed over, once the contexts are known", async () => {
+    // A design switch reloads the document, so the handoff rides in
+    // sessionStorage — and is consumed exactly once, here. Routed only after
+    // `contexts` resolves, mirroring the deep-link gate: a cold-start handoff
+    // judged against an empty list would be rejected as unknown.
+    sessionStorage.setItem(HANDOFF_KEY, JSON.stringify({ context: "prod", kind: "pods" }));
+    render(<App />);
+    // ResourceBrowser renders `{context}:{kind}` first; the rest is the
+    // mock's own buttons.
+    expect((await screen.findByTestId("browser")).textContent).toContain("prod:pods");
+  });
+
+  it("opens nothing for a handoff naming an unknown context, and still clears it", async () => {
+    // Keeping an unreadable handoff would reopen a view on every later launch;
+    // dropping it silently on an unknown name would hide that it was dropped.
+    sessionStorage.setItem(HANDOFF_KEY, JSON.stringify({ context: "ghost", kind: "pods" }));
+    render(<App />);
+    await waitFor(() => expect(sessionStorage.getItem(HANDOFF_KEY)).toBeNull());
+    expect(screen.queryByTestId("browser")).toBeNull();
+    expect(screen.queryByTestId("overview")).toBeNull();
   });
 });

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -18,6 +18,7 @@ import { AssistantTab } from "./components/AssistantTab";
 import { CommandPalette } from "./components/CommandPalette";
 import { ShortcutCheatSheet } from "./components/ShortcutCheatSheet";
 import { isTypingTarget, matchesShortcut } from "@srelens/core";
+import { takeHandoff } from "./design";
 import { McpConfirmDialog } from "./components/McpConfirmDialog";
 import { VaultGate } from "./components/VaultGate";
 import { Toaster } from "./components/ui/sonner";
@@ -263,6 +264,19 @@ export function App() {
       unlisten?.();
     };
   }, []);
+
+  // A design switch reloads the document, and the new design leaves a note
+  // about where it was. Consumed once the contexts are known — same gate as
+  // the deep links below, for the same reason — and consumed exactly once:
+  // takeHandoff clears as it reads, so a later launch starts at home.
+  useEffect(() => {
+    if (!contexts) return;
+    const handoff = takeHandoff();
+    if (!handoff) return;
+    if (contexts.some((c) => c.name === handoff.context)) {
+      openView(handoff.context, handoff.kind);
+    }
+  }, [contexts]);
 
   // Routed only once the contexts are known: a link that arrives during a cold
   // start would otherwise be judged against an empty context list and

--- a/apps/desktop/src/components/AppearanceSettingsSection.test.tsx
+++ b/apps/desktop/src/components/AppearanceSettingsSection.test.tsx
@@ -26,6 +26,21 @@ describe("AppearanceSettingsSection", () => {
     expect(screen.getByText(/most screens are not there yet/i)).toBeDefined();
   });
 
+  it("lists the screens that are already in the new design", () => {
+    // "Most screens are not there yet" is only actionable if it says which
+    // ones are. The list comes from PORTED_SCREENS, the same one the new
+    // design's Placeholder reads, so the two cannot disagree.
+    render(<AppearanceSettingsSection />);
+    const items = screen.getAllByRole("listitem").map((li) => li.textContent);
+    expect(items).toContain("Application log");
+    expect(items).toContain("Release notes");
+  });
+
+  it("introduces the list, so the names are not a bare list under the hint", () => {
+    render(<AppearanceSettingsSection />);
+    expect(screen.getByText(/in the new design so far/i)).toBeDefined();
+  });
+
   it("warns that switching reloads the window", () => {
     render(<AppearanceSettingsSection />);
     expect(screen.getByText(/reload/i)).toBeDefined();

--- a/apps/desktop/src/components/AppearanceSettingsSection.tsx
+++ b/apps/desktop/src/components/AppearanceSettingsSection.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Button } from "../ui";
-import { loadDesign, switchDesign, type Design } from "../design";
+import { PORTED_SCREENS, loadDesign, switchDesign, type Design } from "../design";
 
 /**
  * Settings → Appearance: the choice between the current design and the new one.
@@ -43,6 +43,12 @@ export function AppearanceSettingsSection() {
         screens are not there yet, and the ones that are may still change. Switching reloads
         the window, and you can switch back here at any time.
       </p>
+      <p className="fl-settings-hint">In the new design so far:</p>
+      <ul className="fl-settings-hint">
+        {PORTED_SCREENS.map((s) => (
+          <li key={s.route}>{s.name}</li>
+        ))}
+      </ul>
       {error && (
         <p className="fl-settings-hint" role="alert">
           Could not switch design. {error}

--- a/apps/desktop/src/design.chrome.test.ts
+++ b/apps/desktop/src/design.chrome.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from "vitest";
 
-const { isTauriMock, isApplePlatformMock, setTitleBarStyleMock } = vi.hoisted(() => ({
+const { isTauriMock, isApplePlatformMock, setTitleBarStyleMock, setTitleMock } = vi.hoisted(() => ({
   isTauriMock: vi.fn(),
   isApplePlatformMock: vi.fn(),
   setTitleBarStyleMock: vi.fn(),
+  setTitleMock: vi.fn(),
 }));
 vi.mock("@srelens/core", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@srelens/core")>()),
@@ -11,7 +12,7 @@ vi.mock("@srelens/core", async (importOriginal) => ({
   isApplePlatform: (platform?: string) => isApplePlatformMock(platform),
 }));
 vi.mock("@tauri-apps/api/window", () => ({
-  getCurrentWindow: () => ({ setTitleBarStyle: setTitleBarStyleMock }),
+  getCurrentWindow: () => ({ setTitleBarStyle: setTitleBarStyleMock, setTitle: setTitleMock }),
 }));
 
 import { applyNextDesignChrome, drawsOwnChrome } from "./design";
@@ -25,6 +26,7 @@ beforeEach(() => {
     platform === undefined ? true : /mac|iphone|ipad/i.test(platform),
   );
   setTitleBarStyleMock.mockReset().mockResolvedValue(undefined);
+  setTitleMock.mockReset().mockResolvedValue(undefined);
 });
 
 describe("drawsOwnChrome", () => {
@@ -49,19 +51,29 @@ describe("applyNextDesignChrome", () => {
     expect(setTitleBarStyleMock).toHaveBeenCalledWith("overlay");
   });
 
+  it("clears the native title, which macOS keeps painting over the overlay", async () => {
+    // Found on a real machine: with an overlay style the system still draws
+    // the window's own title — "srelens" from tauri.conf.json — on top of the
+    // webview, landing square on the workspace switcher.
+    await applyNextDesignChrome();
+    expect(setTitleMock).toHaveBeenCalledWith("");
+  });
+
   it("does nothing off Apple, where the mock's traffic lights would lie", async () => {
     isApplePlatformMock.mockReturnValue(false);
     await applyNextDesignChrome();
     expect(setTitleBarStyleMock).not.toHaveBeenCalled();
+    expect(setTitleMock).not.toHaveBeenCalled();
   });
 
   it("does nothing on web, where there is no window to dress", async () => {
     isTauriMock.mockReturnValue(false);
     await applyNextDesignChrome();
     expect(setTitleBarStyleMock).not.toHaveBeenCalled();
+    expect(setTitleMock).not.toHaveBeenCalled();
   });
 
-  it("survives a rejecting setTitleBarStyle rather than breaking boot", async () => {
+  it("survives a rejecting window call rather than breaking boot", async () => {
     // A build without `core:window:allow-set-title-bar-style` granted throws
     // here. The overlay is cosmetic; a rejected promise escaping this would
     // have left bootstrap awaiting forever and the window blank.

--- a/apps/desktop/src/design.chrome.test.ts
+++ b/apps/desktop/src/design.chrome.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from "vitest";
+
+const { isTauriMock, isApplePlatformMock, setTitleBarStyleMock } = vi.hoisted(() => ({
+  isTauriMock: vi.fn(),
+  isApplePlatformMock: vi.fn(),
+  setTitleBarStyleMock: vi.fn(),
+}));
+vi.mock("@srelens/core", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@srelens/core")>()),
+  isTauri: () => isTauriMock(),
+  isApplePlatform: (platform?: string) => isApplePlatformMock(platform),
+}));
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({ setTitleBarStyle: setTitleBarStyleMock }),
+}));
+
+import { applyNextDesignChrome, drawsOwnChrome } from "./design";
+
+beforeEach(() => {
+  isTauriMock.mockReset().mockReturnValue(true);
+  // Explicit strings go through the real matcher — what those tests pin IS
+  // the pass-through. An absent one means "the caller had no answer", which
+  // here stands in for jsdom's empty navigator.platform saying Mac.
+  isApplePlatformMock.mockReset().mockImplementation((platform?: string) =>
+    platform === undefined ? true : /mac|iphone|ipad/i.test(platform),
+  );
+  setTitleBarStyleMock.mockReset().mockResolvedValue(undefined);
+});
+
+describe("drawsOwnChrome", () => {
+  it("is true on Apple platforms", () => {
+    expect(drawsOwnChrome("MacIntel")).toBe(true);
+  });
+
+  it("is false on Windows and Linux, whose traffic lights are not macOS-shaped", () => {
+    expect(drawsOwnChrome("Win32")).toBe(false);
+    expect(drawsOwnChrome("Linux x86_64")).toBe(false);
+  });
+
+  it("asks core when no platform is given, so the runtime decides", () => {
+    drawsOwnChrome();
+    expect(isApplePlatformMock).toHaveBeenCalled();
+  });
+});
+
+describe("applyNextDesignChrome", () => {
+  it("sets the overlay titlebar exactly when Tauri and Apple", async () => {
+    await applyNextDesignChrome();
+    expect(setTitleBarStyleMock).toHaveBeenCalledWith("overlay");
+  });
+
+  it("does nothing off Apple, where the mock's traffic lights would lie", async () => {
+    isApplePlatformMock.mockReturnValue(false);
+    await applyNextDesignChrome();
+    expect(setTitleBarStyleMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing on web, where there is no window to dress", async () => {
+    isTauriMock.mockReturnValue(false);
+    await applyNextDesignChrome();
+    expect(setTitleBarStyleMock).not.toHaveBeenCalled();
+  });
+
+  it("survives a rejecting setTitleBarStyle rather than breaking boot", async () => {
+    // A build without `core:window:allow-set-title-bar-style` granted throws
+    // here. The overlay is cosmetic; a rejected promise escaping this would
+    // have left bootstrap awaiting forever and the window blank.
+    setTitleBarStyleMock.mockRejectedValue(new Error("permission not granted"));
+    await expect(applyNextDesignChrome()).resolves.toBeUndefined();
+  });
+});

--- a/apps/desktop/src/design.handoff.test.ts
+++ b/apps/desktop/src/design.handoff.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { HANDOFF_KEY, handoffFor, saveHandoff, takeHandoff } from "./design";
+
+describe("handoffFor", () => {
+  it("carries nothing when there is no cluster to land on", () => {
+    // A handoff is "reopen this place on this cluster"; without the cluster
+    // classic would have to guess, and guessing wrong is worse than not going.
+    expect(handoffFor("/k/pods")).toBeNull();
+    expect(handoffFor("/", undefined)).toBeNull();
+  });
+
+  it("maps a built-in kind slug to that kind", () => {
+    expect(handoffFor("/k/pods", "prod")).toEqual({ context: "prod", kind: "pods" });
+    expect(handoffFor("/k/configmaps", "prod")).toEqual({ context: "prod", kind: "configmaps" });
+  });
+
+  it("treats the overview slug as a plain overview", () => {
+    expect(handoffFor("/k/overview", "prod")).toEqual({ context: "prod", kind: "overview" });
+  });
+
+  it("falls back to an overview for a slug it does not know", () => {
+    expect(handoffFor("/k/nonsense", "prod")).toEqual({ context: "prod", kind: "overview" });
+  });
+
+  it("knows the app-scoped routes", () => {
+    expect(handoffFor("/events", "prod")).toEqual({ context: "prod", kind: "events" });
+    expect(handoffFor("/forwards", "prod")).toEqual({ context: "prod", kind: "portforwards" });
+    expect(handoffFor("/helm", "prod")).toEqual({ context: "prod", kind: "helmreleases" });
+  });
+
+  it("lands home and overview routes on the overview", () => {
+    expect(handoffFor("/", "prod")).toEqual({ context: "prod", kind: "overview" });
+    expect(handoffFor("/overview", "prod")).toEqual({ context: "prod", kind: "overview" });
+  });
+
+  it("lands anywhere else on the overview rather than dropping the cluster", () => {
+    // R-F: routes with no classic kind still hand off the cluster — classic's
+    // overview is the nearest place to stand while looking at it.
+    expect(handoffFor("/applog", "prod")).toEqual({ context: "prod", kind: "overview" });
+    expect(handoffFor("/settings", "prod")).toEqual({ context: "prod", kind: "overview" });
+  });
+});
+
+describe("saveHandoff and takeHandoff", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("round trips, and taking clears the key", () => {
+    saveHandoff("/k/pods", "prod");
+    expect(takeHandoff()).toEqual({ context: "prod", kind: "pods" });
+    // A handoff is for the one reload that follows; leaving it behind would
+    // reopen the same view on every future launch of classic.
+    expect(takeHandoff()).toBeNull();
+    expect(sessionStorage.getItem(HANDOFF_KEY)).toBeNull();
+  });
+
+  it("writes nothing when there is no context to hand off", () => {
+    saveHandoff("/");
+    expect(sessionStorage.getItem(HANDOFF_KEY)).toBeNull();
+  });
+
+  it("reads malformed JSON as nothing", () => {
+    sessionStorage.setItem(HANDOFF_KEY, "{not json");
+    expect(takeHandoff()).toBeNull();
+    expect(sessionStorage.getItem(HANDOFF_KEY)).toBeNull();
+  });
+});

--- a/apps/desktop/src/design.switch.test.ts
+++ b/apps/desktop/src/design.switch.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-const { isTauriMock, isApplePlatformMock, setTitleBarStyleMock, notifyErrorMock } = vi.hoisted(() => ({
+const { isTauriMock, isApplePlatformMock, setTitleBarStyleMock, setTitleMock, notifyErrorMock } = vi.hoisted(() => ({
   isTauriMock: vi.fn(),
   isApplePlatformMock: vi.fn(),
   setTitleBarStyleMock: vi.fn(),
+  setTitleMock: vi.fn(),
   notifyErrorMock: vi.fn(),
 }));
 vi.mock("@srelens/core", async (importOriginal) => ({
@@ -13,7 +14,7 @@ vi.mock("@srelens/core", async (importOriginal) => ({
   notify: { error: notifyErrorMock, success: vi.fn(), info: vi.fn() },
 }));
 vi.mock("@tauri-apps/api/window", () => ({
-  getCurrentWindow: () => ({ setDecorations: vi.fn(), setTitleBarStyle: setTitleBarStyleMock }),
+  getCurrentWindow: () => ({ setDecorations: vi.fn(), setTitleBarStyle: setTitleBarStyleMock, setTitle: setTitleMock }),
 }));
 
 import { DESIGN_KEY, switchDesign } from "./design";
@@ -25,6 +26,7 @@ beforeEach(() => {
   localStorage.clear();
   reload.mockClear();
   setTitleBarStyleMock.mockReset().mockResolvedValue(undefined);
+  setTitleMock.mockReset().mockResolvedValue(undefined);
   isApplePlatformMock.mockReset().mockReturnValue(true);
   notifyErrorMock.mockClear();
   isTauriMock.mockReturnValue(true);
@@ -56,10 +58,12 @@ describe("switchDesign", () => {
 
   it("hands the system titlebar back when leaving the new design on Apple", async () => {
     // Classic renders under system decorations; an overlay left behind there
-    // would double the chrome. Same failure policy as any cosmetic step:
-    // attempted, never allowed to block the switch.
+    // would double the chrome — and the native title cleared for the overlay
+    // has to come back, since classic draws no name of its own. Same failure
+    // policy as any cosmetic step: attempted, never allowed to block.
     await switchDesign("classic");
     expect(setTitleBarStyleMock).toHaveBeenCalledWith("visible");
+    expect(setTitleMock).toHaveBeenCalledWith("srelens");
     expect(reload).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/desktop/src/design.switch.test.ts
+++ b/apps/desktop/src/design.switch.test.ts
@@ -1,17 +1,19 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-const { isTauriMock, setDecorationsMock, notifyErrorMock } = vi.hoisted(() => ({
+const { isTauriMock, isApplePlatformMock, setTitleBarStyleMock, notifyErrorMock } = vi.hoisted(() => ({
   isTauriMock: vi.fn(),
-  setDecorationsMock: vi.fn(),
+  isApplePlatformMock: vi.fn(),
+  setTitleBarStyleMock: vi.fn(),
   notifyErrorMock: vi.fn(),
 }));
 vi.mock("@srelens/core", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@srelens/core")>()),
-  isTauri: isTauriMock,
+  isTauri: () => isTauriMock(),
+  isApplePlatform: (platform?: string) => isApplePlatformMock(platform),
   notify: { error: notifyErrorMock, success: vi.fn(), info: vi.fn() },
 }));
 vi.mock("@tauri-apps/api/window", () => ({
-  getCurrentWindow: () => ({ setDecorations: setDecorationsMock }),
+  getCurrentWindow: () => ({ setDecorations: vi.fn(), setTitleBarStyle: setTitleBarStyleMock }),
 }));
 
 import { DESIGN_KEY, switchDesign } from "./design";
@@ -22,7 +24,8 @@ let originalLocation: Location;
 beforeEach(() => {
   localStorage.clear();
   reload.mockClear();
-  setDecorationsMock.mockReset().mockResolvedValue(undefined);
+  setTitleBarStyleMock.mockReset().mockResolvedValue(undefined);
+  isApplePlatformMock.mockReset().mockReturnValue(true);
   notifyErrorMock.mockClear();
   isTauriMock.mockReturnValue(true);
   originalLocation = window.location;
@@ -42,13 +45,37 @@ describe("switchDesign", () => {
     expect(reload).toHaveBeenCalledTimes(1);
   });
 
-  it("leaves the system chrome alone while the new design has none of its own", async () => {
-    // NextApp is a heading, a paragraph and a button. Dropping the decorations
-    // now would leave a frameless window with no drag region and no window
-    // controls — unmovable, unminimisable, closable only by quitting. This
-    // flips when the design's own titlebar lands. (#314 review)
+  it("leaves the titlebar alone switching to next — its boot dresses the window", async () => {
+    // The overlay lands in applyNextDesignChrome after the reload, not here:
+    // one writer per direction, and boot is where "which design am I" has
+    // already been read.
     await switchDesign("next");
-    expect(setDecorationsMock).not.toHaveBeenCalled();
+    expect(setTitleBarStyleMock).not.toHaveBeenCalled();
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("hands the system titlebar back when leaving the new design on Apple", async () => {
+    // Classic renders under system decorations; an overlay left behind there
+    // would double the chrome. Same failure policy as any cosmetic step:
+    // attempted, never allowed to block the switch.
+    await switchDesign("classic");
+    expect(setTitleBarStyleMock).toHaveBeenCalledWith("visible");
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not touch the titlebar off Apple, whose chrome classic never drew over", async () => {
+    isApplePlatformMock.mockReturnValue(false);
+    await switchDesign("classic");
+    expect(setTitleBarStyleMock).not.toHaveBeenCalled();
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("still reloads when resetting the titlebar rejects", async () => {
+    // A build without the capability granted throws here; wrong chrome is a
+    // blemish, a switch that silently undoes itself is a broken setting.
+    setTitleBarStyleMock.mockRejectedValue(new Error("permission not granted"));
+    const result = await switchDesign("classic");
+    expect(result.ok).toBe(true);
     expect(reload).toHaveBeenCalledTimes(1);
   });
 
@@ -71,10 +98,10 @@ describe("switchDesign", () => {
     }
   });
 
-  it("reloads on web, where there are no decorations to set", async () => {
+  it("reloads on web, where there is no window chrome to set", async () => {
     isTauriMock.mockReturnValue(false);
-    await switchDesign("next");
-    expect(setDecorationsMock).not.toHaveBeenCalled();
+    await switchDesign("classic");
+    expect(setTitleBarStyleMock).not.toHaveBeenCalled();
     expect(reload).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/design.test.ts
+++ b/apps/desktop/src/design.test.ts
@@ -50,10 +50,14 @@ describe("the design preference", () => {
 });
 
 describe("the list of ported screens", () => {
-  it("exports the list of ported screens, empty until a screen lands", () => {
+  it("names the screens that exist in the new design, in the order they are shown", () => {
     // One list, read by classic's Settings and by the new design's Placeholder,
     // so the two cannot disagree about what has been ported. A screen is added
     // here in the PR that ports it.
-    expect(PORTED_SCREENS).toEqual([]);
+    expect(PORTED_SCREENS.map((s) => s.route)).toEqual(["/applog", "/notes"]);
+  });
+
+  it("gives every screen a name to show, since the route is not user-facing", () => {
+    expect(PORTED_SCREENS.map((s) => s.name)).toEqual(["Application log", "Release notes"]);
   });
 });

--- a/apps/desktop/src/design.theme.test.ts
+++ b/apps/desktop/src/design.theme.test.ts
@@ -1,20 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { getInitialThemeMock, resolvedThemeModeMock } = vi.hoisted(() => ({
+const { getInitialThemeMock, resolvedThemeModeMock, applyThemeMock } = vi.hoisted(() => ({
   getInitialThemeMock: vi.fn(),
   resolvedThemeModeMock: vi.fn(),
+  applyThemeMock: vi.fn(),
 }));
 vi.mock("./ui/theme", () => ({
   getInitialTheme: getInitialThemeMock,
   resolvedThemeMode: resolvedThemeModeMock,
+  applyTheme: applyThemeMock,
 }));
 
-import { applyNextDesignTheme } from "./design";
+import { applyNextDesignTheme, toggleNextDesignTheme } from "./design";
 
 beforeEach(() => {
   delete document.documentElement.dataset.theme;
   getInitialThemeMock.mockReturnValue({ name: "slate", mode: "dark" });
   resolvedThemeModeMock.mockImplementation((mode: string) => mode);
+  applyThemeMock.mockReset();
 });
 
 describe("applyNextDesignTheme", () => {
@@ -88,5 +91,43 @@ describe("applyNextDesignTheme", () => {
     applyNextDesignTheme();
     expect(listeners).toHaveLength(0);
     vi.unstubAllGlobals();
+  });
+});
+
+describe("toggleNextDesignTheme", () => {
+  it("flips dark to light through classic's applyTheme", () => {
+    // R-E: one stored preference drives both designs, so the toggle goes
+    // through the same applyTheme Settings uses rather than a private copy.
+    getInitialThemeMock.mockReturnValue({ name: "slate", mode: "dark" });
+    toggleNextDesignTheme();
+    expect(applyThemeMock).toHaveBeenCalledWith({ name: "slate", mode: "light" });
+  });
+
+  it("flips light to dark", () => {
+    getInitialThemeMock.mockReturnValue({ name: "slate", mode: "light" });
+    toggleNextDesignTheme();
+    expect(applyThemeMock).toHaveBeenCalledWith({ name: "slate", mode: "dark" });
+  });
+
+  it("resolves system before flipping, so a resolved-dark system goes light", () => {
+    getInitialThemeMock.mockReturnValue({ name: "slate", mode: "system" });
+    resolvedThemeModeMock.mockReturnValue("dark");
+    toggleNextDesignTheme();
+    expect(applyThemeMock).toHaveBeenCalledWith({ name: "slate", mode: "light" });
+  });
+
+  it("re-asserts the new design's data-theme convention after applying", () => {
+    // applyTheme writes classic's conventions (data-theme = palette name,
+    // data-theme-mode = mode); ui-next reads data-theme as the mode itself.
+    // Without the re-assert, one click left both designs reading garbage. The
+    // mock persists like the real one, since the re-assert reads the stored
+    // preference back through getInitialTheme.
+    getInitialThemeMock.mockReturnValue({ name: "slate", mode: "dark" });
+    applyThemeMock.mockImplementation((t: { name: string; mode: string }) => {
+      getInitialThemeMock.mockReturnValue(t);
+    });
+    document.documentElement.dataset.theme = "dark";
+    toggleNextDesignTheme();
+    expect(document.documentElement.dataset.theme).toBeUndefined();
   });
 });

--- a/apps/desktop/src/design.ts
+++ b/apps/desktop/src/design.ts
@@ -1,7 +1,7 @@
-import { isTauri } from "@srelens/core";
+import { isApplePlatform, isTauri } from "@srelens/core";
 // theme.ts imports only settingsStorage, so this does not drag the classic
 // stylesheet into the new design's chunk.
-import { getInitialTheme, resolvedThemeMode } from "./ui/theme";
+import { applyTheme, getInitialTheme, resolvedThemeMode } from "./ui/theme";
 
 /**
  * Which design the app renders.
@@ -57,16 +57,36 @@ export function saveDesign(design: Design): boolean {
 export type SwitchResult = { ok: true } | { ok: false; reason: string };
 
 /**
- * Whether the new design draws its own titlebar yet.
+ * Whether the new design draws its own titlebar here.
  *
- * It does not: `NextApp` is the tab strip over the tab bodies, and nothing
- * above it. Dropping the system decorations now would leave a frameless window
- * with no drag region and no window controls — unmovable, unminimisable, and
- * closable only by quitting the app. The design's own titlebar lands with the
- * rest of the chrome; this flips then, and needs an answer for Windows and
- * Linux at the same time, since the mock's traffic lights are macOS-shaped.
+ * The mock's traffic lights are macOS-shaped, so only Apple gets the overlay
+ * for now; Windows and Linux keep the system decorations until the design has
+ * an answer for their controls. Optional argument for the callers that already
+ * hold a platform string; the runtime answers for itself when they do not.
  */
-const NEXT_DESIGN_DRAWS_ITS_OWN_CHROME = false;
+export function drawsOwnChrome(platform?: string): boolean {
+  return isApplePlatform(platform);
+}
+
+/**
+ * Dress the window for the new design, once per boot of it.
+ *
+ * The titlebar goes overlay so the design's own Titlebar sits flush under the
+ * traffic lights without doubling the chrome. Cosmetic, and explicitly not
+ * allowed to block boot: on a build where
+ * `core:window:allow-set-title-bar-style` is not granted this throws, and a
+ * rejecting promise escaping would have left bootstrap awaiting forever — a
+ * blank window instead of an undressed one.
+ */
+export async function applyNextDesignChrome(): Promise<void> {
+  if (!isTauri() || !drawsOwnChrome()) return;
+  try {
+    const { getCurrentWindow } = await import("@tauri-apps/api/window");
+    await getCurrentWindow().setTitleBarStyle("overlay");
+  } catch {
+    // Wrong chrome is a blemish; a failed boot is a broken app.
+  }
+}
 
 export async function switchDesign(design: Design): Promise<SwitchResult> {
   if (!saveDesign(design)) {
@@ -79,15 +99,14 @@ export async function switchDesign(design: Design): Promise<SwitchResult> {
     // would have been invisible, and the button would have looked inert.
     return { ok: false, reason: "This device would not let srelens save the preference." };
   }
-  if (isTauri() && NEXT_DESIGN_DRAWS_ITS_OWN_CHROME) {
+  if (design === "classic" && isTauri() && drawsOwnChrome()) {
     try {
-      // Cosmetic, and explicitly not allowed to block the switch:
-      // `core:window:allow-set-decorations` has to be granted in the app's
-      // capabilities, and on a build where it is not, this throws. Letting
-      // that reject left the preference written and the window unchanged, so
-      // the design only appeared after a manual restart.
+      // Leaving the new design means handing the system titlebar back: classic
+      // renders under the real decorations, and an overlay left behind would
+      // double the chrome. Going the other way dresses nothing here — the next
+      // boot's applyNextDesignChrome owns that direction.
       const { getCurrentWindow } = await import("@tauri-apps/api/window");
-      await getCurrentWindow().setDecorations(design === "classic");
+      await getCurrentWindow().setTitleBarStyle("visible");
     } catch {
       // Wrong chrome is a blemish; not switching at all is a broken setting.
     }
@@ -108,24 +127,49 @@ export async function switchDesign(design: Design): Promise<SwitchResult> {
  *
  * Light is the absence of the attribute, matching ui-next's `:root` tokens.
  */
+/**
+ * The new design's reading of the stored preference, as an attribute on the
+ * root. Shared by boot, the system-appearance listener and the toggle — three
+ * writers of one convention is two too many.
+ *
+ * Light is the absence of the attribute, matching ui-next's `:root` tokens.
+ */
+function applyNextThemeAttribute(): void {
+  const root = document.documentElement;
+  if (resolvedThemeMode(getInitialTheme().mode) === "dark") {
+    root.dataset.theme = "dark";
+  } else {
+    delete root.dataset.theme;
+  }
+}
+
 export function applyNextDesignTheme(): () => void {
-  const apply = () => {
-    const root = document.documentElement;
-    if (resolvedThemeMode(getInitialTheme().mode) === "dark") {
-      root.dataset.theme = "dark";
-    } else {
-      delete root.dataset.theme;
-    }
-  };
-  apply();
+  applyNextThemeAttribute();
 
   // Someone on "system" changes appearance while the app is open, and the new
   // tree has no equivalent of the classic App's matchMedia effect, so it would
   // sit on a stale palette until the next reload. (#314 review)
   if (getInitialTheme().mode !== "system") return () => {};
   const query = window.matchMedia("(prefers-color-scheme: dark)");
+  const apply = () => applyNextThemeAttribute();
   query.addEventListener("change", apply);
   return () => query.removeEventListener("change", apply);
+}
+
+/**
+ * Flip light/dark for both designs at once.
+ *
+ * The write goes through classic's `applyTheme`, so one stored preference
+ * drives both designs; but that write leaves classic's conventions on the root
+ * (`data-theme` = palette name), which ui-next reads as a mode. Re-asserting
+ * our own attribute afterwards keeps the two designs' readings from fighting
+ * over the same element.
+ */
+export function toggleNextDesignTheme(): void {
+  const current = getInitialTheme();
+  const mode = resolvedThemeMode(current.mode);
+  applyTheme({ ...current, mode: mode === "dark" ? "light" : "dark" });
+  applyNextThemeAttribute();
 }
 
 /**

--- a/apps/desktop/src/design.ts
+++ b/apps/desktop/src/design.ts
@@ -134,4 +134,7 @@ export function applyNextDesignTheme(): () => void {
  * Placeholder shows it so the user knows what is there. One list, read by both,
  * so they cannot drift. A screen is added here in the PR that ports it.
  */
-export const PORTED_SCREENS: ReadonlyArray<{ route: string; name: string }> = [];
+export const PORTED_SCREENS: ReadonlyArray<{ route: string; name: string }> = [
+  { route: "/applog", name: "Application log" },
+  { route: "/notes", name: "Release notes" },
+];

--- a/apps/desktop/src/design.ts
+++ b/apps/desktop/src/design.ts
@@ -82,7 +82,13 @@ export async function applyNextDesignChrome(): Promise<void> {
   if (!isTauri() || !drawsOwnChrome()) return;
   try {
     const { getCurrentWindow } = await import("@tauri-apps/api/window");
-    await getCurrentWindow().setTitleBarStyle("overlay");
+    const win = getCurrentWindow();
+    // An overlay style keeps macOS painting the native title over the
+    // webview — "srelens" from tauri.conf.json landed square on the workspace
+    // switcher — so the name is cleared and the design's own Titlebar speaks
+    // for the window. switchDesign("classic") gives it back.
+    await win.setTitle("");
+    await win.setTitleBarStyle("overlay");
   } catch {
     // Wrong chrome is a blemish; a failed boot is a broken app.
   }
@@ -103,10 +109,14 @@ export async function switchDesign(design: Design): Promise<SwitchResult> {
     try {
       // Leaving the new design means handing the system titlebar back: classic
       // renders under the real decorations, and an overlay left behind would
-      // double the chrome. Going the other way dresses nothing here — the next
-      // boot's applyNextDesignChrome owns that direction.
+      // double the chrome. The native title comes back with it — it was
+      // cleared for the overlay, and classic draws no name of its own. Going
+      // the other way dresses nothing here — the next boot's
+      // applyNextDesignChrome owns that direction.
       const { getCurrentWindow } = await import("@tauri-apps/api/window");
-      await getCurrentWindow().setTitleBarStyle("visible");
+      const win = getCurrentWindow();
+      await win.setTitle("srelens");
+      await win.setTitleBarStyle("visible");
     } catch {
       // Wrong chrome is a blemish; not switching at all is a broken setting.
     }

--- a/apps/desktop/src/design.ts
+++ b/apps/desktop/src/design.ts
@@ -1,4 +1,4 @@
-import { isApplePlatform, isTauri } from "@srelens/core";
+import { isApplePlatform, isTauri, K8S_KIND, type ResourceKind } from "@srelens/core";
 // theme.ts imports only settingsStorage, so this does not drag the classic
 // stylesheet into the new design's chunk.
 import { applyTheme, getInitialTheme, resolvedThemeMode } from "./ui/theme";
@@ -182,3 +182,74 @@ export const PORTED_SCREENS: ReadonlyArray<{ route: string; name: string }> = [
   { route: "/applog", name: "Application log" },
   { route: "/notes", name: "Release notes" },
 ];
+
+/**
+ * Where classic should land after leaving the new design.
+ *
+ * The switch reloads the document, so the note rides `sessionStorage`: a
+ * handoff is for the one reload that follows, never for a later launch, and
+ * session scope makes the difference structural rather than remembered.
+ */
+export const HANDOFF_KEY = "srelens.design.handoff";
+
+export interface Handoff {
+  context: string;
+  kind: ResourceKind;
+}
+
+/**
+ * The classic view a route in the new design stands for.
+ *
+ * Pure per R-F: it carries `{ context, kind }` and nothing else. A route whose
+ * kind classic does not have — or cannot parse — still lands on the cluster's
+ * overview, because standing somewhere near where you were beats being dumped
+ * at home with no trace of the cluster you were looking at.
+ */
+export function handoffFor(route: string, context?: string): Handoff | null {
+  if (!context) return null;
+  const slug = /^\/k\/([^/]+)$/.exec(route)?.[1];
+  if (slug && slug !== "overview" && Object.prototype.hasOwnProperty.call(K8S_KIND, slug)) {
+    return { context, kind: slug as ResourceKind };
+  }
+  switch (route) {
+    case "/events":
+      return { context, kind: "events" };
+    case "/forwards":
+      return { context, kind: "portforwards" };
+    case "/helm":
+      return { context, kind: "helmreleases" };
+    default:
+      // `/`, `/overview`, and every route classic has no answer for.
+      return { context, kind: "overview" };
+  }
+}
+
+/** Note where the new design was, for classic to pick up after the reload. */
+export function saveHandoff(route: string, context?: string): void {
+  try {
+    const handoff = handoffFor(route, context);
+    if (handoff) sessionStorage.setItem(HANDOFF_KEY, JSON.stringify(handoff));
+  } catch {
+    // Session storage throws in some privacy modes; losing the handoff is
+    // landing on classic's overview, which is where it lands anyway.
+  }
+}
+
+/**
+ * Consume the handoff. Reading and removing are one action: a caller that
+ * reads without clearing would reopen the same view on every launch.
+ */
+export function takeHandoff(): Handoff | null {
+  try {
+    const raw = sessionStorage.getItem(HANDOFF_KEY);
+    sessionStorage.removeItem(HANDOFF_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<Handoff> | null;
+    if (parsed && typeof parsed.context === "string" && typeof parsed.kind === "string") {
+      return { context: parsed.context, kind: parsed.kind };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -55,7 +55,10 @@ async function bootstrap(root: HTMLElement): Promise<void> {
     createRoot(root).render(
       <NextApp
         ported={PORTED_SCREENS.map((s) => s.name)}
-        controls={drawsOwnChrome() ? "macos" : "none"}
+        // The overlay keeps macOS's real traffic lights, so the painted set
+        // would double them (found in smoke testing); the picture is only for
+        // an Apple browser, which has no window chrome of its own in the page.
+        controls={drawsOwnChrome() && !isTauri() ? "macos" : "none"}
         onToggleTheme={toggleNextDesignTheme}
         onExit={async (route, context) => {
           // Written before the switch, so classic knows where to reopen even

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -6,7 +6,15 @@ import { initializeSettingsStorage } from "@srelens/core";
 // The service layer says what to notify; this decides how. Installed before
 // render so a toast raised during startup is not dropped on the floor.
 import { installToastNotifier } from "./ui/notifier";
-import { PORTED_SCREENS, applyNextDesignTheme, loadDesign, switchDesign } from "./design";
+import {
+  PORTED_SCREENS,
+  applyNextDesignChrome,
+  applyNextDesignTheme,
+  drawsOwnChrome,
+  loadDesign,
+  switchDesign,
+  toggleNextDesignTheme,
+} from "./design";
 
 installToastNotifier();
 
@@ -31,6 +39,10 @@ async function bootstrap(root: HTMLElement): Promise<void> {
   if (loadDesign() === "next") {
     // Before the stylesheet, so the first paint is already the right mode.
     applyNextDesignTheme();
+    // The overlay titlebar goes on before anything renders, so the window is
+    // never seen with doubled chrome. A rejection inside is swallowed there:
+    // an undressed window beats a blank one.
+    await applyNextDesignChrome();
     // Started together, awaited together: the stylesheet and the tree are
     // independent downloads, and awaiting one before requesting the other
     // serialised them. index.html links no stylesheet, so the window stays
@@ -42,6 +54,8 @@ async function bootstrap(root: HTMLElement): Promise<void> {
     createRoot(root).render(
       <NextApp
         ported={PORTED_SCREENS.map((s) => s.name)}
+        controls={drawsOwnChrome() ? "macos" : "none"}
+        onToggleTheme={toggleNextDesignTheme}
         onExit={async () => {
           const result = await switchDesign("classic");
           return result.ok ? null : result.reason;

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -12,6 +12,7 @@ import {
   applyNextDesignTheme,
   drawsOwnChrome,
   loadDesign,
+  saveHandoff,
   switchDesign,
   toggleNextDesignTheme,
 } from "./design";
@@ -56,7 +57,10 @@ async function bootstrap(root: HTMLElement): Promise<void> {
         ported={PORTED_SCREENS.map((s) => s.name)}
         controls={drawsOwnChrome() ? "macos" : "none"}
         onToggleTheme={toggleNextDesignTheme}
-        onExit={async () => {
+        onExit={async (route, context) => {
+          // Written before the switch, so classic knows where to reopen even
+          // though the reload throws this document away.
+          saveHandoff(route, context);
           const result = await switchDesign("classic");
           return result.ok ? null : result.reason;
         }}

--- a/packages/ui-kit/src/Titlebar.test.tsx
+++ b/packages/ui-kit/src/Titlebar.test.tsx
@@ -70,6 +70,19 @@ describe("Titlebar's drag region", () => {
     expect(bar().querySelector("[data-drag-region]")).not.toBeNull();
   });
 
+  it("carries the attribute tauri's drag handling listens for", () => {
+    // The stylesheet's app-region rule is honoured by WebView2 and ignored by
+    // macOS's WKWebView — under an overlay titlebar there, only elements with
+    // `data-tauri-drag-region` start a native drag. On the header and its left
+    // row too: every click whose target *is* one of them should move the
+    // window, and clicks on children never reach these.
+    setup();
+    expect(bar().hasAttribute("data-tauri-drag-region")).toBe(true);
+    for (const el of bar().querySelectorAll("[data-tauri-drag-region]")) {
+      expect(el.closest("header")).toBe(bar());
+    }
+  });
+
   it("opts the control slots back out of it", () => {
     // jsdom keeps a property it does not recognise on the CSSOM object without
     // writing it into the style attribute, so this reads the object. In the

--- a/packages/ui-kit/src/Titlebar.test.tsx
+++ b/packages/ui-kit/src/Titlebar.test.tsx
@@ -70,17 +70,26 @@ describe("Titlebar's drag region", () => {
     expect(bar().querySelector("[data-drag-region]")).not.toBeNull();
   });
 
-  it("carries the attribute tauri's drag handling listens for", () => {
+  it("carries the attribute tauri's drag handling listens for on the header and its structural columns, but not on the interactive slots", () => {
     // The stylesheet's app-region rule is honoured by WebView2 and ignored by
     // macOS's WKWebView — under an overlay titlebar there, only elements with
-    // `data-tauri-drag-region` start a native drag. On the header and its left
-    // row too: every click whose target *is* one of them should move the
-    // window, and clicks on children never reach these.
+    // `data-tauri-drag-region` start a native drag. The header and its two
+    // bare columns (the leading row and the centre drag region) carry it; the
+    // slots holding what the caller passed must not, or a click there would
+    // start a window move instead of reaching the control.
     setup();
-    expect(bar().hasAttribute("data-tauri-drag-region")).toBe(true);
-    for (const el of bar().querySelectorAll("[data-tauri-drag-region]")) {
-      expect(el.closest("header")).toBe(bar());
-    }
+    const header = bar();
+    const leadingSlot = header.querySelector('[data-slot="leading"]') as HTMLElement;
+    const actionsSlot = header.querySelector('[data-slot="actions"]') as HTMLElement;
+    const leadingColumn = leadingSlot.parentElement as HTMLElement;
+    const titleColumn = header.querySelector("[data-drag-region]") as HTMLElement;
+
+    expect(header.hasAttribute("data-tauri-drag-region")).toBe(true);
+    expect(leadingColumn.hasAttribute("data-tauri-drag-region")).toBe(true);
+    expect(titleColumn.hasAttribute("data-tauri-drag-region")).toBe(true);
+
+    expect(leadingSlot.hasAttribute("data-tauri-drag-region")).toBe(false);
+    expect(actionsSlot.hasAttribute("data-tauri-drag-region")).toBe(false);
   });
 
   it("opts the control slots back out of it", () => {

--- a/packages/ui-kit/src/Titlebar.tsx
+++ b/packages/ui-kit/src/Titlebar.tsx
@@ -51,8 +51,15 @@ export interface TitlebarProps {
 export function Titlebar({ controls = "none", leading, title, actions, label = "Titlebar" }: TitlebarProps) {
   const macos = controls === "macos";
   return (
-    <header className="titlebar" aria-label={label}>
-      <div className="flex items-center gap-2 pl-3.5">
+    // `data-tauri-drag-region` is what makes these regions actually draggable
+    // under Tauri: its injected script starts a native drag when the mousedown
+    // *target* carries the attribute. `-webkit-app-region`, which the
+    // stylesheet also sets, is honoured by WebView2 and ignored by macOS's
+    // WKWebView — without the attribute the overlay titlebar drew beautifully
+    // and moved nothing. Children without the attribute stay interactive, so
+    // the slots opt out by being elements of their own.
+    <header className="titlebar" aria-label={label} data-tauri-drag-region>
+      <div className="flex items-center gap-2 pl-3.5" data-tauri-drag-region>
         {macos && (
           <span data-window-controls aria-hidden="true" className="flex items-center gap-2">
             {MACOS_LIGHTS.map((tone) => (
@@ -74,7 +81,7 @@ export function Titlebar({ controls = "none", leading, title, actions, label = "
 
       {/* Bare on purpose: this column is the part of the bar left for dragging
           the window, so nothing pressable goes in it. */}
-      <div data-drag-region className="path flex items-center gap-2 justify-self-center">
+      <div data-drag-region data-tauri-drag-region className="path flex items-center gap-2 justify-self-center">
         {title}
       </div>
 

--- a/packages/ui-next/package.json
+++ b/packages/ui-next/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "@srelens/core": "workspace:*",
-    "@srelens/ui-kit": "workspace:*"
+    "@srelens/ui-kit": "workspace:*",
+    "lucide-react": "^1.22.0"
   },
   "peerDependencies": {
     "react": "^19.0.0",

--- a/packages/ui-next/src/index.test.tsx
+++ b/packages/ui-next/src/index.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 // `vi.hoisted` because `vi.mock` is hoisted above every declaration in the
@@ -149,5 +149,46 @@ describe("NextApp", () => {
     window.location.hash = "";
     window.dispatchEvent(new HashChangeEvent("hashchange"));
     expect(await screen.findByRole("tablist")).toBeDefined();
+  });
+
+  it("takes the window's chrome down at the gallery, and puts it back after", async () => {
+    // The gallery demos TabStrips of its own — even one labelled Open tabs —
+    // so "no tablist anywhere" is not the claim. The claim is about the
+    // window's: queried inside the window host with hidden elements included,
+    // an unmounted strip is absent while a merely hidden one would still be
+    // found. The bodies stay mounted either way; that is what keeps the
+    // session alive across the trip.
+    const view = render(<NextApp onExit={() => null} />);
+    // The hidden wrapper around the Window — the host whose contents survive
+    // the gallery trip. Structural on purpose: it is this file's subject.
+    const windowHost = (view.container.firstElementChild as HTMLElement)
+      .firstElementChild as HTMLElement;
+    await within(windowHost).findByRole("tablist", { name: "Open tabs" });
+
+    window.location.hash = "#gallery";
+    window.dispatchEvent(new HashChangeEvent("hashchange"));
+    await screen.findByRole("heading", { name: /design system/i });
+    expect(windowHost.hidden).toBe(true);
+    expect(within(windowHost).queryByRole("tablist", { hidden: true })).toBeNull();
+    expect(windowHost.textContent).toContain("is not in the new design yet");
+
+    window.location.hash = "";
+    window.dispatchEvent(new HashChangeEvent("hashchange"));
+    await within(windowHost).findByRole("tablist", { name: "Open tabs" });
+  });
+
+  it("hands onExit the route and the cluster it is leaving", async () => {
+    // Classic reopens at the place the new design was on, so the way out has
+    // to carry more than a route: without the cluster, "Open in classic" from
+    // a pod list would land classic wherever it happened to be last. Boot's
+    // Default workspace makes the one context active, so no seeding is needed.
+    const onExit = vi.fn(() => null);
+    listContexts.mockResolvedValue({
+      contexts: [{ name: "prod", stableId: "prod", cluster: "prod", server: "", isCurrent: false }],
+    });
+    render(<NextApp onExit={onExit} />);
+    await screen.findByRole("tablist");
+    await userEvent.click(screen.getByRole("button", { name: /open in classic/i }));
+    expect(onExit).toHaveBeenCalledWith("/", "prod");
   });
 });

--- a/packages/ui-next/src/index.tsx
+++ b/packages/ui-next/src/index.tsx
@@ -1,6 +1,7 @@
 import { useState, useSyncExternalStore } from "react";
 import { Gallery } from "@srelens/ui-kit/gallery";
 import { Window } from "./shell/Window";
+import { ConsoleProvider } from "./console";
 
 export { ConsoleProvider, useConsole, type ConsoleValue } from "./console";
 
@@ -46,18 +47,22 @@ function useHash(): string {
 export function NextApp({
   onExit,
   ported = [],
+  onToggleTheme = () => {},
+  controls = "none",
 }: {
-  onExit: () => Promise<string | null> | string | null;
+  onExit: (route: string, context?: string) => Promise<string | null> | string | null;
   /** Display names of the screens that exist in the new design. */
   ported?: string[];
+  onToggleTheme?: () => void;
+  controls?: "macos" | "none";
 }) {
   const [error, setError] = useState<string | null>(null);
 
-  async function leave() {
+  async function leave(route: string, context?: string) {
     // Rendered here rather than raised as a toast: the toast host lives in the
     // classic tree, so a failure on the way out would have been invisible and
     // this button would have looked inert. (#314 review)
-    setError((await onExit()) ?? null);
+    setError((await onExit(route, context)) ?? null);
   }
 
   // A hash rather than a route: this tree has no router yet, and the gallery is
@@ -82,13 +87,20 @@ export function NextApp({
         screen reader — and `queryByRole` — sees.
       */}
       <div className="min-h-0 flex-1" hidden={gallery}>
-        <Window
-          ported={ported}
-          onOpenInClassic={() => void leave()}
-          onOpenGallery={() => {
-            window.location.hash = "#gallery";
-          }}
-        />
+        {/* The provider wraps the window, not the gallery: the gallery has no
+            console, and the dock is the window's own bottom edge. */}
+        <ConsoleProvider>
+          <Window
+            ported={ported}
+            active={!gallery}
+            controls={controls}
+            onToggleTheme={onToggleTheme}
+            onOpenInClassic={leave}
+            onOpenGallery={() => {
+              window.location.hash = "#gallery";
+            }}
+          />
+        </ConsoleProvider>
       </div>
       {gallery && (
         <div className="min-h-0 flex-1">

--- a/packages/ui-next/src/lib/appLogLines.test.ts
+++ b/packages/ui-next/src/lib/appLogLines.test.ts
@@ -28,20 +28,22 @@ describe("logLineLevel", () => {
 });
 
 describe("parseAppLog", () => {
-  it("splits the timestamp, the level and the message apart", () => {
+  it("puts only the time in ts — the date stays in raw", () => {
     const [entry] = parseAppLog(line("WARN", "context prod is unreachable"));
-    expect(entry).toEqual({
-      ts: "2026-08-21 09:12:03",
-      level: "WARN",
-      message: "context prod is unreachable",
-      raw: line("WARN", "context prod is unreachable"),
-    });
+    expect(entry.ts).toBe("09:12:03");
+    expect(entry.raw).toContain("2026-08-21");
+  });
+
+  it("extracts the log target into source", () => {
+    const [entry] = parseAppLog(line("INFO", "connected to prod"));
+    expect(entry.source).toBe("srelens::cluster");
   });
 
   it("keeps a line the logger did not write, whole", () => {
     const [entry] = parseAppLog("    at srelens::cluster::connect");
     expect(entry).toEqual({
       ts: "",
+      source: "",
       level: "INFO",
       message: "at srelens::cluster::connect",
       raw: "    at srelens::cluster::connect",
@@ -71,41 +73,49 @@ describe("filterLines", () => {
   );
 
   it("keeps everything at level 'all' with no text", () => {
-    expect(filterLines(lines, "", "all")).toHaveLength(3);
+    expect(filterLines(lines, "", "all").lines).toHaveLength(3);
+  });
+
+  it("reports total equal to the shown count when nothing is capped", () => {
+    expect(filterLines(lines, "", "all").total).toBe(3);
   });
 
   it("filters by level", () => {
-    expect(filterLines(lines, "", "ERROR").map((e) => e.message)).toEqual([
+    expect(filterLines(lines, "", "ERROR").lines.map((e) => e.message)).toEqual([
       "RBAC denied for Pods",
     ]);
   });
 
   it("filters by text, case-insensitively", () => {
-    expect(filterLines(lines, "RBAC", "all").map((e) => e.message)).toEqual([
+    expect(filterLines(lines, "RBAC", "all").lines.map((e) => e.message)).toEqual([
       "RBAC denied for Pods",
     ]);
-    expect(filterLines(lines, "rbac", "all").map((e) => e.message)).toEqual([
+    expect(filterLines(lines, "rbac", "all").lines.map((e) => e.message)).toEqual([
       "RBAC denied for Pods",
     ]);
   });
 
   it("applies text and level together", () => {
-    expect(filterLines(lines, "prod", "WARN").map((e) => e.message)).toEqual([
+    expect(filterLines(lines, "prod", "WARN").lines.map((e) => e.message)).toEqual([
       "slow response from prod",
     ]);
-    expect(filterLines(lines, "prod", "ERROR")).toEqual([]);
+    expect(filterLines(lines, "prod", "ERROR").lines).toEqual([]);
+    expect(filterLines(lines, "prod", "ERROR").total).toBe(0);
   });
 
-  it("keeps the newest MAX_RENDERED of a log that exceeds the cap", () => {
+  it("keeps the newest MAX_RENDERED of a log that exceeds the cap, and reports the pre-cap total", () => {
     const many = parseAppLog(
       Array.from({ length: MAX_RENDERED + 1 }, (_, i) => line("INFO", `entry ${i}`)).join("\n"),
     );
-    const capped = filterLines(many, "", "all");
+    const { lines: capped, total } = filterLines(many, "", "all");
     expect(MAX_RENDERED).toBe(5000);
     expect(capped).toHaveLength(MAX_RENDERED);
     // The oldest is the one dropped, so the window ends at the newest line.
     expect(capped[0].message).toBe("entry 1");
     expect(capped[capped.length - 1].message).toBe(`entry ${MAX_RENDERED}`);
+    // total is the pre-cap match count, not the (already-capped) shown count —
+    // this is what lets the screen tell a real cap apart from zero matches.
+    expect(total).toBe(MAX_RENDERED + 1);
   });
 });
 

--- a/packages/ui-next/src/lib/appLogLines.test.ts
+++ b/packages/ui-next/src/lib/appLogLines.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import {
+  LEVELS,
+  MAX_RENDERED,
+  filterLines,
+  logLineLevel,
+  parseAppLog,
+  type Level,
+} from "./appLogLines";
+
+/** A line in the shape tauri-plugin-log writes. */
+const line = (level: string, message: string, time = "09:12:03") =>
+  `[2026-08-21][${time}][srelens::cluster][${level}] ${message}`;
+
+describe("logLineLevel", () => {
+  it("reads every level the logger emits", () => {
+    for (const level of LEVELS) {
+      expect(logLineLevel(line(level, "something happened"))).toBe(level);
+    }
+  });
+
+  it("defaults to INFO for a line with no level bracket", () => {
+    expect(logLineLevel("    at srelens::cluster::connect")).toBe("INFO");
+    expect(logLineLevel("")).toBe("INFO");
+    // A bracket that is not one of the five is not a level either.
+    expect(logLineLevel("[2026-08-21][09:12:03][srelens][NOISE] hi")).toBe("INFO");
+  });
+});
+
+describe("parseAppLog", () => {
+  it("splits the timestamp, the level and the message apart", () => {
+    const [entry] = parseAppLog(line("WARN", "context prod is unreachable"));
+    expect(entry).toEqual({
+      ts: "2026-08-21 09:12:03",
+      level: "WARN",
+      message: "context prod is unreachable",
+      raw: line("WARN", "context prod is unreachable"),
+    });
+  });
+
+  it("keeps a line the logger did not write, whole", () => {
+    const [entry] = parseAppLog("    at srelens::cluster::connect");
+    expect(entry).toEqual({
+      ts: "",
+      level: "INFO",
+      message: "at srelens::cluster::connect",
+      raw: "    at srelens::cluster::connect",
+    });
+  });
+
+  it("drops blank lines and keeps the rest in order", () => {
+    const parsed = parseAppLog(
+      [line("INFO", "one"), "", line("ERROR", "two", "09:12:04"), ""].join("\n"),
+    );
+    expect(parsed.map((e) => e.message)).toEqual(["one", "two"]);
+    expect(parsed.map((e) => e.level)).toEqual(["INFO", "ERROR"]);
+  });
+
+  it("is empty for an empty log", () => {
+    expect(parseAppLog("")).toEqual([]);
+  });
+});
+
+describe("filterLines", () => {
+  const lines = parseAppLog(
+    [
+      line("INFO", "connected to prod"),
+      line("ERROR", "RBAC denied for Pods", "09:12:04"),
+      line("WARN", "slow response from prod", "09:12:05"),
+    ].join("\n"),
+  );
+
+  it("keeps everything at level 'all' with no text", () => {
+    expect(filterLines(lines, "", "all")).toHaveLength(3);
+  });
+
+  it("filters by level", () => {
+    expect(filterLines(lines, "", "ERROR").map((e) => e.message)).toEqual([
+      "RBAC denied for Pods",
+    ]);
+  });
+
+  it("filters by text, case-insensitively", () => {
+    expect(filterLines(lines, "RBAC", "all").map((e) => e.message)).toEqual([
+      "RBAC denied for Pods",
+    ]);
+    expect(filterLines(lines, "rbac", "all").map((e) => e.message)).toEqual([
+      "RBAC denied for Pods",
+    ]);
+  });
+
+  it("applies text and level together", () => {
+    expect(filterLines(lines, "prod", "WARN").map((e) => e.message)).toEqual([
+      "slow response from prod",
+    ]);
+    expect(filterLines(lines, "prod", "ERROR")).toEqual([]);
+  });
+
+  it("keeps the newest MAX_RENDERED of a log that exceeds the cap", () => {
+    const many = parseAppLog(
+      Array.from({ length: MAX_RENDERED + 1 }, (_, i) => line("INFO", `entry ${i}`)).join("\n"),
+    );
+    const capped = filterLines(many, "", "all");
+    expect(MAX_RENDERED).toBe(5000);
+    expect(capped).toHaveLength(MAX_RENDERED);
+    // The oldest is the one dropped, so the window ends at the newest line.
+    expect(capped[0].message).toBe("entry 1");
+    expect(capped[capped.length - 1].message).toBe(`entry ${MAX_RENDERED}`);
+  });
+});
+
+describe("LEVELS", () => {
+  it("is the logger's five, most severe first", () => {
+    const expected: Level[] = ["ERROR", "WARN", "INFO", "DEBUG", "TRACE"];
+    expect([...LEVELS]).toEqual(expected);
+  });
+});

--- a/packages/ui-next/src/lib/appLogLines.ts
+++ b/packages/ui-next/src/lib/appLogLines.ts
@@ -24,8 +24,20 @@ export const MAX_RENDERED = 5000;
 
 /** One parsed entry: the columns `LogLine` draws, plus the text it came from. */
 export interface AppLogLine {
-  /** `[date][time]` joined with a space, or `""` for a line with no prefix. */
+  /**
+   * The time from a `[date][time]` prefix — the clock only, no date. `LogLine`
+   * renders `ts` into a fixed ~12-character column; the date would eat that
+   * whole and truncate the one thing a triager reads. The date is not lost —
+   * it stays in `raw`, which Copy and the text filter both expose. `""` for a
+   * line with no prefix.
+   */
   ts: string;
+  /**
+   * The log target — third bracket of `[date][time][target][LEVEL]`, e.g.
+   * `srelens::cluster`. `LogLine`'s `source` gutter renders it; `""` for a
+   * line with no prefix.
+   */
+  source: string;
   level: Level;
   /** The text after the level bracket — a line with no bracket in full. */
   message: string;
@@ -46,6 +58,9 @@ const LEVEL_RE = /\]\[(TRACE|DEBUG|INFO|WARN|ERROR)\]/;
 /** `[date][time]` at the head of a line, if it has one. */
 const TS_RE = /^\[([^\]]*)\]\[([^\]]*)\]/;
 
+/** The third bracket — the log target — when the line opens with three. */
+const SOURCE_RE = /^\[[^\]]*\]\[[^\]]*\]\[([^\]]*)\]/;
+
 /** The level of a `[date][time][target][LEVEL] message` line (INFO if absent). */
 export function logLineLevel(line: string): Level {
   const match = line.match(LEVEL_RE);
@@ -65,13 +80,15 @@ export function parseAppLog(raw: string): AppLogLine[] {
     .filter((line) => line.trim() !== "")
     .map((line) => {
       const ts = line.match(TS_RE);
+      const source = line.match(SOURCE_RE);
       const level = line.match(LEVEL_RE);
       // After the level bracket when there is one; otherwise after the
       // timestamp, so a prefixed line the level regex missed still loses its
       // prefix rather than repeating it in the message column.
       const from = level ? level.index! + level[0].length : (ts?.[0].length ?? 0);
       return {
-        ts: ts ? `${ts[1]} ${ts[2]}` : "",
+        ts: ts ? ts[2] : "",
+        source: source ? source[1] : "",
         level: (level?.[1] as Level) ?? "INFO",
         message: line.slice(from).trim(),
         raw: line,
@@ -79,8 +96,23 @@ export function parseAppLog(raw: string): AppLogLine[] {
     });
 }
 
+/** The lines a filter leaves, capped, plus how many actually matched. */
+export interface FilteredLines {
+  /** Newest {@link MAX_RENDERED} of the matches, oldest dropped. */
+  lines: AppLogLine[];
+  /**
+   * How many lines matched before the cap trimmed them — `lines.length` when
+   * nothing was capped, larger than it when the cap bit. This is what lets a
+   * screen tell "your filter matched nothing" apart from "your filter matched
+   * more than we can render"; a caller that only sees `lines` cannot, because
+   * both end up looking at an empty or a 5000-long array.
+   */
+  total: number;
+}
+
 /**
- * The lines a filter leaves, newest {@link MAX_RENDERED} of them.
+ * The lines a filter leaves, newest {@link MAX_RENDERED} of them, and the
+ * pre-cap match count.
  *
  * The text is matched against the whole original line rather than the message,
  * so searching for a target (`srelens::cluster`) or a timestamp still works —
@@ -95,12 +127,14 @@ export function filterLines(
   lines: AppLogLine[],
   text: string,
   level: Level | "all",
-): AppLogLine[] {
+): FilteredLines {
   const query = text.toLowerCase();
   const matches = lines.filter((line) => {
     if (level !== "all" && line.level !== level) return false;
     if (query && !line.raw.toLowerCase().includes(query)) return false;
     return true;
   });
-  return matches.length > MAX_RENDERED ? matches.slice(matches.length - MAX_RENDERED) : matches;
+  const capped =
+    matches.length > MAX_RENDERED ? matches.slice(matches.length - MAX_RENDERED) : matches;
+  return { lines: capped, total: matches.length };
 }

--- a/packages/ui-next/src/lib/appLogLines.ts
+++ b/packages/ui-next/src/lib/appLogLines.ts
@@ -1,0 +1,106 @@
+/**
+ * Turning srelens's own log file into lines a screen can draw.
+ *
+ * The file is written by tauri-plugin-log, one entry per line, in the shape
+ * `[date][time][target][LEVEL] message`. The classic view (`AppLogView`)
+ * printed each line whole and only coloured it; the new design's `LogLine` has
+ * a column for the timestamp, one for the level and one for the message, so the
+ * line has to be taken apart before it can be drawn — which is why this module
+ * exists at all, and why it is pure: the taking-apart is the part worth testing,
+ * and it has nothing to do with React.
+ *
+ * Everything here is deliberately forgiving. A log file is a tail of whatever
+ * was on disk, so the first line is routinely half an entry, a panic writes a
+ * backtrace whose continuation lines carry no prefix, and neither should
+ * disappear from a diagnostic view because it did not match a regex.
+ */
+
+/** Log levels emitted by tauri-plugin-log, most→least severe. */
+export const LEVELS = ["ERROR", "WARN", "INFO", "DEBUG", "TRACE"] as const;
+export type Level = (typeof LEVELS)[number];
+
+/** Cap rendered lines so a large log can't balloon the DOM. */
+export const MAX_RENDERED = 5000;
+
+/** One parsed entry: the columns `LogLine` draws, plus the text it came from. */
+export interface AppLogLine {
+  /** `[date][time]` joined with a space, or `""` for a line with no prefix. */
+  ts: string;
+  level: Level;
+  /** The text after the level bracket — a line with no bracket in full. */
+  message: string;
+  /** The original line, which is what a text filter searches. */
+  raw: string;
+}
+
+/**
+ * Where the level bracket sits in a line, and which level it is.
+ *
+ * Anchored on the closing bracket of the preceding field rather than on the
+ * start of the line, because the target between the timestamp and the level is
+ * an arbitrary module path — carried over verbatim from the classic view so
+ * both designs agree on what an ERROR line is.
+ */
+const LEVEL_RE = /\]\[(TRACE|DEBUG|INFO|WARN|ERROR)\]/;
+
+/** `[date][time]` at the head of a line, if it has one. */
+const TS_RE = /^\[([^\]]*)\]\[([^\]]*)\]/;
+
+/** The level of a `[date][time][target][LEVEL] message` line (INFO if absent). */
+export function logLineLevel(line: string): Level {
+  const match = line.match(LEVEL_RE);
+  return (match?.[1] as Level) ?? "INFO";
+}
+
+/**
+ * The lines of a log file, split into columns.
+ *
+ * Blank lines are dropped — a trailing newline is not an entry — but anything
+ * with text on it survives, prefix or no prefix.
+ */
+export function parseAppLog(raw: string): AppLogLine[] {
+  if (!raw) return [];
+  return raw
+    .split("\n")
+    .filter((line) => line.trim() !== "")
+    .map((line) => {
+      const ts = line.match(TS_RE);
+      const level = line.match(LEVEL_RE);
+      // After the level bracket when there is one; otherwise after the
+      // timestamp, so a prefixed line the level regex missed still loses its
+      // prefix rather than repeating it in the message column.
+      const from = level ? level.index! + level[0].length : (ts?.[0].length ?? 0);
+      return {
+        ts: ts ? `${ts[1]} ${ts[2]}` : "",
+        level: (level?.[1] as Level) ?? "INFO",
+        message: line.slice(from).trim(),
+        raw: line,
+      };
+    });
+}
+
+/**
+ * The lines a filter leaves, newest {@link MAX_RENDERED} of them.
+ *
+ * The text is matched against the whole original line rather than the message,
+ * so searching for a target (`srelens::cluster`) or a timestamp still works —
+ * those columns are on screen, and a filter that ignores what the user can see
+ * reads as broken.
+ *
+ * The cap keeps the *newest* lines, because a log is read from the end: the
+ * thing that just went wrong is at the bottom, and a cap that kept the oldest
+ * would hide exactly the entries someone opened this screen for.
+ */
+export function filterLines(
+  lines: AppLogLine[],
+  text: string,
+  level: Level | "all",
+): AppLogLine[] {
+  const query = text.toLowerCase();
+  const matches = lines.filter((line) => {
+    if (level !== "all" && line.level !== level) return false;
+    if (query && !line.raw.toLowerCase().includes(query)) return false;
+    return true;
+  });
+  return matches.length > MAX_RENDERED ? matches.slice(matches.length - MAX_RENDERED) : matches;
+}

--- a/packages/ui-next/src/lib/icons.ts
+++ b/packages/ui-next/src/lib/icons.ts
@@ -1,0 +1,168 @@
+import {
+  ArrowLeftRight,
+  BellRing,
+  Bot,
+  Box,
+  BriefcaseBusiness,
+  Circle,
+  Clock3,
+  Compass,
+  Copy,
+  Cpu,
+  Database,
+  FileCog,
+  FilePlus,
+  FolderTree,
+  Gauge,
+  GitBranch,
+  HardDrive,
+  KeyRound,
+  Layers,
+  LayoutDashboard,
+  LayoutGrid,
+  ListOrdered,
+  Maximize,
+  Moon,
+  Network,
+  Plus,
+  Puzzle,
+  RadioTower,
+  Route,
+  ScrollText,
+  Search,
+  Server,
+  ServerCog,
+  Settings2,
+  Shield,
+  ShieldCheck,
+  ShipWheel,
+  Signpost,
+  SlidersHorizontal,
+  Scaling,
+  Sun,
+  Terminal,
+  TimerReset,
+  TriangleAlert,
+  UserRoundCheck,
+  UserRoundCog,
+  Waypoints,
+  Webhook,
+  Wrench,
+  X,
+  ZoomIn,
+  ZoomOut,
+} from "lucide-react";
+import type { IconComponent } from "@srelens/ui-kit";
+
+/**
+ * The shell's glyphs, in one place.
+ *
+ * Two reasons it is a map rather than an import at each call site. The kit
+ * takes no dependency on an icon set — it describes the hole an icon goes in
+ * with `IconComponent` and leaves the choosing to the app — so the choosing has
+ * to happen somewhere in ui-next, and spread across a dozen components it
+ * becomes a dozen places to look when the same concept is drawn two different
+ * ways. And the names here are the app's vocabulary, not lucide's: `workloads`
+ * and `access` say what the sidebar group is, while `Layers` and `ShieldCheck`
+ * say what the picture is, and the sidebar should not have to know the second
+ * to ask for the first.
+ *
+ * Typed as the kit's `IconComponent` rather than lucide's `LucideIcon`, so
+ * everything that consumes this map is typed against the hole and not against
+ * the icon set filling it — swapping sets, or hand-drawing one glyph as an
+ * inline SVG, is then a change to this file alone.
+ *
+ * The resource glyphs follow the classic app's (`apps/desktop/src/ui/NavIcon`)
+ * deliberately: the same kind should not be a box in one design and a cube in
+ * the other for someone who has both installed during the migration.
+ */
+export const Icons = {
+  // The titlebar and the window's own actions.
+  sun: Sun,
+  moon: Moon,
+  zoomIn: ZoomIn,
+  zoomOut: ZoomOut,
+  zoomReset: Maximize,
+  settings: Settings2,
+  workspace: LayoutGrid,
+  add: Plus,
+  close: X,
+  search: Search,
+  warn: TriangleAlert,
+
+  // The sidebar's groups. One per group in the resource tree.
+  cluster: Server,
+  workloads: Layers,
+  config: FileCog,
+  network: Network,
+  storage: HardDrive,
+  access: ShieldCheck,
+  crds: Puzzle,
+  investigate: Compass,
+
+  // Cluster.
+  overview: LayoutDashboard,
+  nodes: Server,
+  namespaces: FolderTree,
+  events: BellRing,
+
+  // Workloads.
+  pods: Box,
+  deployments: Layers,
+  statefulsets: Database,
+  daemonsets: ServerCog,
+  replicasets: Copy,
+  jobs: BriefcaseBusiness,
+  cronjobs: Clock3,
+
+  // Config.
+  configmaps: FileCog,
+  secrets: KeyRound,
+  resourcequotas: Gauge,
+  limitranges: SlidersHorizontal,
+  horizontalpodautoscalers: Scaling,
+  poddisruptionbudgets: ShieldCheck,
+  priorityclasses: ListOrdered,
+  runtimeclasses: Cpu,
+  leases: TimerReset,
+  mutatingwebhookconfigurations: Webhook,
+  validatingwebhookconfigurations: Webhook,
+
+  // Network.
+  services: Network,
+  endpoints: RadioTower,
+  endpointslices: GitBranch,
+  ingresses: Route,
+  ingressclasses: Signpost,
+  networkpolicies: Shield,
+  portforwards: ArrowLeftRight,
+
+  // Storage.
+  persistentvolumeclaims: HardDrive,
+  persistentvolumes: Database,
+  storageclasses: Layers,
+
+  // Access control.
+  serviceaccounts: UserRoundCog,
+  clusterroles: Shield,
+  roles: ShieldCheck,
+  clusterrolebindings: UserRoundCheck,
+  rolebindings: UserRoundCheck,
+
+  // Investigate, and the rest of the app's surfaces.
+  control: LayoutDashboard,
+  incidents: BellRing,
+  topology: Waypoints,
+  agent: Bot,
+  logs: ScrollText,
+  terminal: Terminal,
+  helmreleases: ShipWheel,
+  toolbox: Wrench,
+  newresource: FilePlus,
+
+  /** What a kind with no glyph of its own gets — a CRD, most often. */
+  fallback: Circle,
+} as const satisfies Record<string, IconComponent>;
+
+/** Every glyph this map knows, for a caller looking one up by name. */
+export type IconName = keyof typeof Icons;

--- a/packages/ui-next/src/lib/icons.ts
+++ b/packages/ui-next/src/lib/icons.ts
@@ -12,6 +12,7 @@ import {
   Database,
   FileCog,
   FilePlus,
+  FolderOpen,
   FolderTree,
   Gauge,
   GitBranch,
@@ -27,6 +28,7 @@ import {
   Plus,
   Puzzle,
   RadioTower,
+  RefreshCw,
   Route,
   ScrollText,
   Search,
@@ -159,6 +161,11 @@ export const Icons = {
   helmreleases: ShipWheel,
   toolbox: Wrench,
   newresource: FilePlus,
+
+  // The application log screen's own actions.
+  refresh: RefreshCw,
+  copy: Copy,
+  reveal: FolderOpen,
 
   /** What a kind with no glyph of its own gets — a CRD, most often. */
   fallback: Circle,

--- a/packages/ui-next/src/lib/marks.test.ts
+++ b/packages/ui-next/src/lib/marks.test.ts
@@ -36,12 +36,20 @@ describe("marks", () => {
 describe("marks the shell reads", () => {
   beforeEach(() => loadMarks(fakeStorage()));
 
-  it("keeps a renamed cluster's colours but not its stale name", () => {
+  it("lets a customised name outlive a rename, and follows the kubeconfig until there is one", () => {
     const s = fakeStorage();
     loadMarks(s);
-    setMark("prod", { ...defaultMark("prod-eu"), color: "var(--ok)" }, s);
+    // Nothing stored: the mark is called whatever the kubeconfig calls it, and
+    // it keeps up when that changes.
+    expect(getMark("prod", "prod-eu").name).toBe("prod-eu");
+    expect(getMark("prod", "prod-eu-1").name).toBe("prod-eu-1");
+
+    // Once the operator has typed a display name it is theirs, not a cache of
+    // the context's — the editor's name field would otherwise revert every
+    // keystroke to the kubeconfig's.
+    setMark("prod", { ...defaultMark("prod-eu"), name: "Production EU", color: "var(--ok)" }, s);
     const after = getMark("prod", "prod-eu-1");
-    expect(after.name).toBe("prod-eu-1");
+    expect(after.name).toBe("Production EU");
     expect(after.color).toBe("var(--ok)");
     expect(after.short).toBe("PE");
   });

--- a/packages/ui-next/src/lib/marks.test.ts
+++ b/packages/ui-next/src/lib/marks.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { defaultMark, getMark, setMark, resetMark, loadMarks, useMark, MARKS_KEY } from "./marks";
+
+function fakeStorage() {
+  const m = new Map<string, string>();
+  return { getItem: (k: string) => m.get(k) ?? null, setItem: (k: string, v: string) => void m.set(k, v), removeItem: (k: string) => void m.delete(k), m };
+}
+
+describe("marks", () => {
+  it("derives initials", () => {
+    expect(defaultMark("prod-eu").short).toBe("PE");
+    expect(defaultMark("staging").short).toBe("ST");
+    expect(defaultMark("a-b-c-d").short).toBe("AB");
+  });
+  it("persists a set mark and reads it back after a reload", () => {
+    const s = fakeStorage();
+    loadMarks(s);
+    setMark("prod", { ...defaultMark("prod-eu"), color: "var(--ok)" }, s);
+    expect(JSON.parse(s.m.get(MARKS_KEY)!).prod.color).toBe("var(--ok)");
+    loadMarks(fakeStorage()); // forget
+    loadMarks(s);
+    expect(getMark("prod", "prod-eu").color).toBe("var(--ok)");
+  });
+  it("resets to the default and survives a throwing storage", () => {
+    const s = fakeStorage();
+    loadMarks(s);
+    setMark("prod", { ...defaultMark("prod-eu"), short: "ZZ" }, s);
+    resetMark("prod", s);
+    expect(getMark("prod", "prod-eu").short).toBe("PE");
+    const bad = { getItem: () => { throw new Error("no"); }, setItem: () => { throw new Error("no"); }, removeItem: () => {} };
+    expect(() => loadMarks(bad)).not.toThrow();
+    expect(() => setMark("x", defaultMark("x"), bad)).not.toThrow();
+  });
+});
+
+describe("marks the shell reads", () => {
+  beforeEach(() => loadMarks(fakeStorage()));
+
+  it("keeps a renamed cluster's colours but not its stale name", () => {
+    const s = fakeStorage();
+    loadMarks(s);
+    setMark("prod", { ...defaultMark("prod-eu"), color: "var(--ok)" }, s);
+    const after = getMark("prod", "prod-eu-1");
+    expect(after.name).toBe("prod-eu-1");
+    expect(after.color).toBe("var(--ok)");
+    expect(after.short).toBe("PE");
+  });
+
+  it("returns the same object until the mark changes", () => {
+    // `useSyncExternalStore` re-renders forever on a snapshot that is a fresh
+    // object every read, and every unstored cluster reads a fresh default.
+    const s = fakeStorage();
+    loadMarks(s);
+    expect(getMark("prod", "prod-eu")).toBe(getMark("prod", "prod-eu"));
+    setMark("prod", { ...defaultMark("prod-eu"), color: "var(--ok)" }, s);
+    expect(getMark("prod", "prod-eu")).toBe(getMark("prod", "prod-eu"));
+  });
+
+  it("ignores a document that is not a map of marks", () => {
+    const s = fakeStorage();
+    for (const raw of ["[]", "null", "7", "{oops", '{"prod":3}']) {
+      s.m.set(MARKS_KEY, raw);
+      loadMarks(s);
+      expect(getMark("prod", "prod-eu").color).toBe("var(--accent)");
+    }
+  });
+
+  it("re-renders a subscriber when its mark is set and reset", async () => {
+    const { renderHook, act } = await import("@testing-library/react");
+    const s = fakeStorage();
+    loadMarks(s);
+    const { result } = renderHook(() => useMark("prod", "prod-eu"));
+    expect(result.current.color).toBe("var(--accent)");
+    act(() => setMark("prod", { ...defaultMark("prod-eu"), color: "var(--ok)" }, s));
+    expect(result.current.color).toBe("var(--ok)");
+    act(() => resetMark("prod", s));
+    expect(result.current.color).toBe("var(--accent)");
+  });
+});

--- a/packages/ui-next/src/lib/marks.ts
+++ b/packages/ui-next/src/lib/marks.ts
@@ -129,19 +129,27 @@ function save(storage: Storage) {
 }
 
 /**
- * The cluster's mark, under the name it goes by *now*.
+ * The cluster's mark: the stored appearance if there is one, and otherwise a
+ * default seeded from the name the kubeconfig gives the context.
  *
- * A stored mark keeps its colours through a rename but never its stale name,
- * which is the display string the kit draws beside the square. `short` is not
- * re-derived: initials are the operator's to change, and silently rewriting
- * them on a rename would undo an edit nobody asked to undo.
+ * A stored mark comes back exactly as stored, `name` included. That name is a
+ * display name the operator typed, not a cache of the context's. This used to
+ * overwrite it with the `name` argument on the way out, which made the editor's
+ * name field inert: every keystroke was stored and then reverted on the very
+ * next read (#325 review). `short` is not re-derived either, for the same
+ * reason — an edit nobody asked to undo should not be undone.
+ *
+ * So a cluster renamed in the kubeconfig follows that rename only while nobody
+ * has customised it, which is the case the rename mattered for; once someone
+ * has named it themselves, that is its name.
  */
 export function getMark(stableId: string, name: string): MarkAppearance {
+  // Keyed on both, because the unstored answer depends on the name. A stored
+  // mark ignores it, and every key then hands back that same one object.
   const key = `${stableId}\u0000${name}`;
   const cached = snapshots.get(key);
   if (cached) return cached;
-  const stored = marks[stableId];
-  const mark = !stored ? defaultMark(name) : stored.name === name ? stored : { ...stored, name };
+  const mark = marks[stableId] ?? defaultMark(name);
   snapshots.set(key, mark);
   return mark;
 }

--- a/packages/ui-next/src/lib/marks.ts
+++ b/packages/ui-next/src/lib/marks.ts
@@ -1,0 +1,172 @@
+import { useSyncExternalStore } from "react";
+import { settingsStorage } from "@srelens/core";
+import type { MarkAppearance } from "@srelens/ui-kit";
+import type { Storage } from "./tabsPersist";
+
+/**
+ * How each cluster's mark looks, remembered between launches.
+ *
+ * The kit draws a {@link MarkAppearance} and the shell has to decide what to
+ * hand it, so the decision lives here: one module-level record keyed by
+ * `ClusterContext.stableId` — the id, never the name, because the whole point
+ * is that a context renamed in the kubeconfig keeps the colour its operator
+ * gave it.
+ *
+ * Same shape as `tabsPersist`: `settingsStorage` by default so the desktop
+ * writes the backend's settings file and the web writes `localStorage`, but
+ * injectable so tests need a Map and no platform.
+ */
+export const MARKS_KEY = "srelens.next.marks";
+
+/**
+ * `prod-eu` → `PE`, `staging` → `ST`.
+ *
+ * The first letter of each of the first two parts, or the first two letters
+ * when there is only one part, so that a single-word name is still told apart
+ * from its neighbours. Capped at what {@link MarkAppearance.short} can draw.
+ */
+export function initials(name: string): string {
+  const parts = name.split(/[-_ ]+/).filter(Boolean);
+  if (parts.length === 0) return "";
+  const letters = parts.length === 1 ? parts[0].slice(0, 2) : parts[0][0] + parts[1][0];
+  return letters.toUpperCase().slice(0, 3);
+}
+
+/** What a cluster looks like before anyone has customised it. */
+export function defaultMark(name: string): MarkAppearance {
+  return { name, short: initials(name), color: "var(--accent)", mark: "text", withText: true };
+}
+
+const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null && !Array.isArray(v);
+const isString = (v: unknown): v is string => typeof v === "string";
+
+function parseMark(v: unknown): MarkAppearance | null {
+  if (!isRecord(v) || !isString(v.name) || !isString(v.short) || !isString(v.color)) return null;
+  if (v.mark !== "text" && v.mark !== "icon" && v.mark !== "image") return null;
+  const mark: MarkAppearance = { name: v.name, short: v.short, color: v.color, mark: v.mark, withText: v.withText !== false };
+  if (isString(v.icon)) mark.icon = v.icon;
+  if (isString(v.imageSrc)) mark.imageSrc = v.imageSrc;
+  return mark;
+}
+
+/**
+ * Anything but a map of marks reads as no marks at all.
+ *
+ * Unlike the workspaces there is no version here and nothing to migrate: the
+ * document is a flat `stableId -> appearance` map, and a mark this build
+ * cannot read is dropped on its own rather than taking the others with it —
+ * losing one cluster's colour is a nuisance, losing all of them is not.
+ */
+export function parseStoredMarks(raw: string | null): Record<string, MarkAppearance> {
+  if (!raw) return {};
+  let doc: unknown;
+  try {
+    doc = JSON.parse(raw);
+  } catch {
+    return {};
+  }
+  if (!isRecord(doc)) return {};
+  const marks: Record<string, MarkAppearance> = {};
+  for (const [id, value] of Object.entries(doc)) {
+    const mark = parseMark(value);
+    if (mark) marks[id] = mark;
+  }
+  return marks;
+}
+
+let marks: Record<string, MarkAppearance> = {};
+const listeners = new Set<() => void>();
+
+/**
+ * `getMark` composes its answer, so it has to hand back the *same* object
+ * every time nothing has changed: `useSyncExternalStore` tears down and
+ * re-renders forever on a snapshot that is a fresh object on every read, and
+ * both the unstored default and the rename patch below are fresh objects.
+ * Cleared whenever the record is replaced, so it cannot outgrow the clusters.
+ */
+const snapshots = new Map<string, MarkAppearance>();
+
+function emit() {
+  snapshots.clear();
+  for (const listener of listeners) listener();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/**
+ * Read the saved marks once at boot — and in tests, as often as they like.
+ *
+ * Guarded like every accessor in `tabsPersist`: `settingsStorage` falls back
+ * to raw `localStorage` when the backend file is unavailable, and
+ * `localStorage` throws outright in a WebView with storage disabled. Boot
+ * must reach `setBooted(true)`, so a refusing storage costs the colours and
+ * nothing else.
+ */
+export function loadMarks(storage: Storage = settingsStorage): void {
+  let next: Record<string, MarkAppearance> = {};
+  try {
+    next = parseStoredMarks(storage.getItem(MARKS_KEY));
+  } catch (error) {
+    console.error("could not read the saved cluster marks", error);
+  }
+  marks = next;
+  emit();
+}
+
+function save(storage: Storage) {
+  try {
+    storage.setItem(MARKS_KEY, JSON.stringify(marks));
+  } catch (error) {
+    // Best-effort, as `settingsStorage` itself is: an appearance that does not
+    // survive the session is better than an appearance that cannot be set.
+    console.error("could not persist the cluster marks", error);
+  }
+}
+
+/**
+ * The cluster's mark, under the name it goes by *now*.
+ *
+ * A stored mark keeps its colours through a rename but never its stale name,
+ * which is the display string the kit draws beside the square. `short` is not
+ * re-derived: initials are the operator's to change, and silently rewriting
+ * them on a rename would undo an edit nobody asked to undo.
+ */
+export function getMark(stableId: string, name: string): MarkAppearance {
+  const key = `${stableId}\u0000${name}`;
+  const cached = snapshots.get(key);
+  if (cached) return cached;
+  const stored = marks[stableId];
+  const mark = !stored ? defaultMark(name) : stored.name === name ? stored : { ...stored, name };
+  snapshots.set(key, mark);
+  return mark;
+}
+
+/** Give a cluster this appearance, and keep it. */
+export function setMark(stableId: string, mark: MarkAppearance, storage: Storage = settingsStorage): void {
+  marks = { ...marks, [stableId]: mark };
+  emit();
+  save(storage);
+}
+
+/** Forget a cluster's appearance, putting it back to {@link defaultMark}. */
+export function resetMark(stableId: string, storage: Storage = settingsStorage): void {
+  if (!(stableId in marks)) return;
+  const { [stableId]: _dropped, ...rest } = marks;
+  marks = rest;
+  emit();
+  save(storage);
+}
+
+/** The cluster's mark, re-rendering whoever reads it when the mark changes. */
+export function useMark(stableId: string, name: string): MarkAppearance {
+  return useSyncExternalStore(
+    subscribe,
+    () => getMark(stableId, name),
+    () => getMark(stableId, name),
+  );
+}

--- a/packages/ui-next/src/lib/probe.test.ts
+++ b/packages/ui-next/src/lib/probe.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { probeCluster, getInfo, useInfo, resetProbes } from "./probe";
+import { getView, resetView } from "./workspace";
+
+const ctx = { name: "prod-eu", stableId: "prod", cluster: "c", server: "", isCurrent: false };
+
+beforeEach(() => { resetView(); resetProbes(); });
+
+describe("probeCluster", () => {
+  it("marks connecting, then connected with the version", async () => {
+    let resolve!: (v: unknown) => void;
+    const connect = vi.fn(() => new Promise<never>((r) => { resolve = r as never; }));
+    const p = probeCluster(ctx, connect as never);
+    expect(getView().links.prod).toEqual({ state: "connecting" });
+    resolve({ context: "prod-eu", reachable: true, version: "v1.29.0" });
+    await p;
+    expect(getView().links.prod).toEqual({ state: "connected" });
+    expect(getInfo("prod")?.version).toBe("v1.29.0");
+  });
+  it("marks error with the message when unreachable with one, disconnected without", async () => {
+    await probeCluster(ctx, vi.fn().mockResolvedValue({ context: "prod-eu", reachable: false, error: "timeout" }) as never);
+    expect(getView().links.prod).toEqual({ state: "error", error: "timeout" });
+    await probeCluster(ctx, vi.fn().mockResolvedValue({ context: "prod-eu", reachable: false }) as never);
+    expect(getView().links.prod).toEqual({ state: "disconnected" });
+  });
+  it("calls connectCluster with the context NAME, never the stableId", async () => {
+    const connect = vi.fn().mockResolvedValue({ context: "prod-eu", reachable: true });
+    await probeCluster(ctx, connect as never);
+    expect(connect).toHaveBeenCalledWith("prod-eu");
+  });
+});
+
+describe("useInfo", () => {
+  it("re-renders with the info once the probe lands, and forgets it on reset", async () => {
+    const { result } = renderHook(() => useInfo("prod"));
+    expect(result.current).toBeUndefined();
+    const connect = vi.fn().mockResolvedValue({ context: "prod-eu", reachable: true, version: "v1.30.1" });
+    await act(async () => { await probeCluster(ctx, connect as never); });
+    expect(result.current?.version).toBe("v1.30.1");
+    act(() => resetProbes());
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/packages/ui-next/src/lib/probe.test.ts
+++ b/packages/ui-next/src/lib/probe.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
-import { probeCluster, getInfo, useInfo, resetProbes } from "./probe";
+import { probeCluster, getInfo, useInfo, useInfos, resetProbes } from "./probe";
 import { getView, resetView } from "./workspace";
 
 const ctx = { name: "prod-eu", stableId: "prod", cluster: "c", server: "", isCurrent: false };
@@ -40,5 +40,22 @@ describe("useInfo", () => {
     expect(result.current?.version).toBe("v1.30.1");
     act(() => resetProbes());
     expect(result.current).toBeUndefined();
+  });
+});
+
+describe("useInfos", () => {
+  it("hands back the whole store, with a new identity only when a probe lands", async () => {
+    const { result, rerender } = renderHook(() => useInfos());
+    expect(result.current).toEqual({});
+    const before = result.current;
+    // The snapshot has to survive a render that changed nothing, or
+    // `useSyncExternalStore` re-renders forever.
+    rerender();
+    expect(result.current).toBe(before);
+
+    const connect = vi.fn().mockResolvedValue({ context: "prod-eu", reachable: true, version: "v1.31.0" });
+    await act(async () => { await probeCluster(ctx, connect as never); });
+    expect(result.current.prod?.version).toBe("v1.31.0");
+    expect(result.current).not.toBe(before);
   });
 });

--- a/packages/ui-next/src/lib/probe.ts
+++ b/packages/ui-next/src/lib/probe.ts
@@ -1,0 +1,29 @@
+import { useSyncExternalStore } from "react";
+import { connectCluster, type ClusterContext, type ClusterInfo } from "@srelens/core";
+import { setLink } from "./workspace";
+
+let infos: Record<string, ClusterInfo> = {};
+const listeners = new Set<() => void>();
+const emit = () => { for (const l of listeners) l(); };
+
+export function getInfo(stableId: string): ClusterInfo | undefined { return infos[stableId]; }
+export function resetProbes(): void { infos = {}; emit(); }
+function subscribe(l: () => void) { listeners.add(l); return () => listeners.delete(l); }
+export function useInfo(stableId: string | null): ClusterInfo | undefined {
+  return useSyncExternalStore(subscribe, () => (stableId ? infos[stableId] : undefined), () => undefined);
+}
+
+/**
+ * Link state is derived, not invented: `connecting` while the call is out,
+ * then `connected` from `reachable`, `error` with the backend's message, or
+ * `disconnected` when it is unreachable and says nothing more.
+ */
+export async function probeCluster(ctx: ClusterContext, connect: typeof connectCluster = connectCluster): Promise<void> {
+  setLink(ctx.stableId, "connecting");
+  const info = await connect(ctx.name);
+  infos = { ...infos, [ctx.stableId]: info };
+  emit();
+  if (info.reachable) setLink(ctx.stableId, "connected");
+  else if (info.error) setLink(ctx.stableId, "error", info.error);
+  else setLink(ctx.stableId, "disconnected");
+}

--- a/packages/ui-next/src/lib/probe.ts
+++ b/packages/ui-next/src/lib/probe.ts
@@ -14,6 +14,21 @@ export function useInfo(stableId: string | null): ClusterInfo | undefined {
 }
 
 /**
+ * Every cluster's info at once, for a caller with a list rather than an id.
+ *
+ * `useInfo` cannot serve that: a hook per cluster is a hook count that changes
+ * with the list, and asking it about `null` to get the subscription alone is a
+ * subscription that never fires, because its snapshot is `undefined` whatever
+ * happens and `useSyncExternalStore` bails on an unchanged one (#325 review).
+ *
+ * The whole record is a sound snapshot because `infos` is replaced rather than
+ * mutated on every write, so its identity changes exactly when its contents do.
+ */
+export function useInfos(): Record<string, ClusterInfo> {
+  return useSyncExternalStore(subscribe, () => infos, () => infos);
+}
+
+/**
  * Link state is derived, not invented: `connecting` while the call is out,
  * then `connected` from `reachable`, `error` with the backend's message, or
  * `disconnected` when it is unreachable and says nothing more.

--- a/packages/ui-next/src/lib/routes.test.ts
+++ b/packages/ui-next/src/lib/routes.test.ts
@@ -1,6 +1,8 @@
 // @vitest-environment node
 import { describe as suite, it, expect } from "vitest";
 import { describe, isBuiltInKind, screenFor } from "./routes";
+import { AppLog } from "../screens/AppLog";
+import { ReleaseNotes } from "../screens/ReleaseNotes";
 
 suite("isBuiltInKind", () => {
   it("recognises a built-in list kind by its slug", () => {
@@ -68,11 +70,33 @@ suite("describe", () => {
 });
 
 suite("screenFor", () => {
-  it("knows no screens yet, so every route is a placeholder", () => {
-    // PR 3 registers /applog and /notes here. Until then this must be null for
-    // every route, including the home route.
-    for (const route of ["/", "/k/pods", "/applog", "/notes", "/settings"]) {
+  it("resolves the screens that have been ported", () => {
+    expect(screenFor("/applog")).toBe(AppLog);
+    expect(screenFor("/notes")).toBe(ReleaseNotes);
+  });
+
+  it("gives a route with no screen a placeholder", () => {
+    for (const route of ["/", "/k/pods", "/settings"]) {
       expect(screenFor(route), route).toBeNull();
     }
+  });
+
+  it("does not hand out Object.prototype members as screens", () => {
+    // A route is a string from a tab, which can come from a persisted session
+    // or a resource name. `SCREENS["constructor"]` on a plain object literal is
+    // a function, so `Body` would have rendered `Object` as a component.
+    for (const route of ["constructor", "/constructor", "toString", "__proto__", "hasOwnProperty"]) {
+      expect(screenFor(route), route).toBeNull();
+    }
+  });
+});
+
+suite("describe against inherited keys", () => {
+  it("falls through to the default title rather than a prototype member", () => {
+    // Same hole as `screenFor`: `APP_SCOPED["constructor"]` on a plain object
+    // literal is truthy, and spreading a function produced a title-less tab.
+    expect(describe("constructor", "c")).toMatchObject({ title: "constructor", kind: "control" });
+    expect(describe("/constructor", "c")).toMatchObject({ title: "constructor", kind: "control" });
+    expect(describe("toString", "c").title).toBe("toString");
   });
 });

--- a/packages/ui-next/src/lib/routes.ts
+++ b/packages/ui-next/src/lib/routes.ts
@@ -1,5 +1,7 @@
 import type { ComponentType } from "react";
 import { K8S_KIND, RESOURCE_LABELS, type ResourceKind } from "@srelens/core";
+import { AppLog } from "../screens/AppLog";
+import { ReleaseNotes } from "../screens/ReleaseNotes";
 
 /**
  * What a tab is about, for the strip's icon and for the context menu. The
@@ -29,31 +31,40 @@ export function isBuiltInKind(slug: string): slug is ResourceKind {
   return slug !== "overview" && Object.prototype.hasOwnProperty.call(K8S_KIND, slug);
 }
 
-/** Routes whose tab carries no cluster in its sub. */
-const APP_SCOPED: Record<string, Omit<RouteInfo, "route" | "sub">> = {
-  "/applog": { title: "Application log", kind: "applog" },
-  "/notes": { title: "Release notes", kind: "notes" },
-  "/settings": { title: "Settings", kind: "settings" },
-  "/connections": { title: "Connections", kind: "connections" },
-  "/connect": { title: "Connect a cluster", kind: "connect" },
-  "/toolbox": { title: "Toolbox", kind: "toolbox" },
-};
+/**
+ * Routes whose tab carries no cluster in its sub.
+ *
+ * Null-prototype, like every lookup below it: a route is a string that can
+ * arrive from a persisted session or a resource name, and on a plain object
+ * literal `APP_SCOPED["constructor"]` is `Object` — truthy, so the tab came
+ * back with no title at all.
+ */
+const APP_SCOPED: Record<string, Omit<RouteInfo, "route" | "sub">> =
+  Object.assign(Object.create(null), {
+    "/applog": { title: "Application log", kind: "applog" },
+    "/notes": { title: "Release notes", kind: "notes" },
+    "/settings": { title: "Settings", kind: "settings" },
+    "/connections": { title: "Connections", kind: "connections" },
+    "/connect": { title: "Connect a cluster", kind: "connect" },
+    "/toolbox": { title: "Toolbox", kind: "toolbox" },
+  });
 
 /** Routes whose tab names the cluster it is looking at. */
-const CLUSTER_SCOPED: Record<string, Omit<RouteInfo, "route" | "sub">> = {
-  "/": { title: "Control room", kind: "control", pinned: true },
-  "/incidents": { title: "Incidents", kind: "incidents" },
-  "/agent": { title: "Agent", kind: "agent" },
-  "/resources": { title: "Workloads", kind: "workloads" },
-  "/logs": { title: "Logs", kind: "logs" },
-  "/terminals": { title: "Shell", kind: "terminal" },
-  "/forwards": { title: "Port forwards", kind: "forwards" },
-  "/helm": { title: "Helm", kind: "helm" },
-  "/topology": { title: "Topology", kind: "topology" },
-  "/new": { title: "New resource", kind: "edit" },
-  "/events": { title: "Events", kind: "events" },
-  "/overview": { title: "Cluster overview", kind: "control" },
-};
+const CLUSTER_SCOPED: Record<string, Omit<RouteInfo, "route" | "sub">> =
+  Object.assign(Object.create(null), {
+    "/": { title: "Control room", kind: "control", pinned: true },
+    "/incidents": { title: "Incidents", kind: "incidents" },
+    "/agent": { title: "Agent", kind: "agent" },
+    "/resources": { title: "Workloads", kind: "workloads" },
+    "/logs": { title: "Logs", kind: "logs" },
+    "/terminals": { title: "Shell", kind: "terminal" },
+    "/forwards": { title: "Port forwards", kind: "forwards" },
+    "/helm": { title: "Helm", kind: "helm" },
+    "/topology": { title: "Topology", kind: "topology" },
+    "/new": { title: "New resource", kind: "edit" },
+    "/events": { title: "Events", kind: "events" },
+    "/overview": { title: "Cluster overview", kind: "control" },
+  });
 
 /**
  * Turn a route into what its tab shows. The cluster name is the real one,
@@ -85,8 +96,14 @@ export type ScreenComponent = ComponentType<{ route: string }>;
  * The only place that knows which screens exist. Adding a screen is one entry
  * here and nothing else; a route with no entry renders the Placeholder.
  */
-const SCREENS: Record<string, ScreenComponent> = {};
+const SCREENS: Record<string, ScreenComponent> = Object.assign(Object.create(null), {
+  "/applog": AppLog,
+  "/notes": ReleaseNotes,
+});
 
 export function screenFor(route: string): ScreenComponent | null {
-  return SCREENS[route] ?? null;
+  // `hasOwnProperty.call` as well as the null prototype: the table is the one
+  // thing standing between an arbitrary route string and something rendered as
+  // a component, and it costs nothing to say so twice.
+  return Object.prototype.hasOwnProperty.call(SCREENS, route) ? SCREENS[route] : null;
 }

--- a/packages/ui-next/src/lib/shortcuts.test.ts
+++ b/packages/ui-next/src/lib/shortcuts.test.ts
@@ -25,6 +25,16 @@ describe("matchWindowKey", () => {
     expect(matchWindowKey(ev("0", { metaKey: true }), true)).toEqual({ type: "zoom-reset" });
   });
 
+  it("zooms in on the shifted plus, which is how the key is really typed", () => {
+    // `+` is Shift+= on US/UK layouts, so the keydown carries shiftKey.
+    expect(matchWindowKey(ev("+", { metaKey: true, shiftKey: true }), true)).toEqual({
+      type: "zoom-in",
+    });
+    expect(matchWindowKey(ev("+", { ctrlKey: true, shiftKey: true }), false)).toEqual({
+      type: "zoom-in",
+    });
+  });
+
   it("leaves Ctrl+W alone on Apple", () => {
     expect(matchWindowKey(ev("w", { ctrlKey: true }), true)).toBeNull();
   });
@@ -52,5 +62,8 @@ describe("matchWindowKey", () => {
     expect(hint("new-tab", false)).toBe("Ctrl+T");
     // Core runs the modifiers in the order the chord lists them, so `Mod` first.
     expect(hint("reopen-tab", true)).toBe("⌘⇧T");
+    // The `=` row stays first, so the hint stays the unshifted form.
+    expect(hint("zoom-in", true)).toBe("⌘=");
+    expect(hint("zoom-in", false)).toBe("Ctrl+=");
   });
 });

--- a/packages/ui-next/src/lib/shortcuts.test.ts
+++ b/packages/ui-next/src/lib/shortcuts.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { matchWindowKey, hint } from "./shortcuts";
+
+const ev = (
+  key: string,
+  mods: Partial<{ metaKey: boolean; ctrlKey: boolean; shiftKey: boolean; altKey: boolean }> = {},
+) => ({ key, metaKey: false, ctrlKey: false, shiftKey: false, altKey: false, target: null, ...mods });
+
+describe("matchWindowKey", () => {
+  it("maps the table on Apple with Meta", () => {
+    expect(matchWindowKey(ev("w", { metaKey: true }), true)).toEqual({ type: "close-tab" });
+    expect(matchWindowKey(ev("t", { metaKey: true }), true)).toEqual({ type: "new-tab" });
+    expect(matchWindowKey(ev("T", { metaKey: true, shiftKey: true }), true)).toEqual({
+      type: "reopen-tab",
+    });
+    expect(matchWindowKey(ev("[", { metaKey: true }), true)).toEqual({ type: "prev-tab" });
+    expect(matchWindowKey(ev("]", { metaKey: true }), true)).toEqual({ type: "next-tab" });
+    expect(matchWindowKey(ev("3", { metaKey: true }), true)).toEqual({
+      type: "select-tab",
+      index: 2,
+    });
+    expect(matchWindowKey(ev("k", { metaKey: true }), true)).toEqual({ type: "console" });
+    expect(matchWindowKey(ev("=", { metaKey: true }), true)).toEqual({ type: "zoom-in" });
+    expect(matchWindowKey(ev("-", { metaKey: true }), true)).toEqual({ type: "zoom-out" });
+    expect(matchWindowKey(ev("0", { metaKey: true }), true)).toEqual({ type: "zoom-reset" });
+  });
+
+  it("leaves Ctrl+W alone on Apple", () => {
+    expect(matchWindowKey(ev("w", { ctrlKey: true }), true)).toBeNull();
+  });
+
+  it("uses Control elsewhere and ignores Meta there", () => {
+    expect(matchWindowKey(ev("w", { ctrlKey: true }), false)).toEqual({ type: "close-tab" });
+    expect(matchWindowKey(ev("w", { metaKey: true }), false)).toBeNull();
+  });
+
+  it("does not fire with Alt held or from a typing target", () => {
+    expect(matchWindowKey(ev("t", { metaKey: true, altKey: true }), true)).toBeNull();
+    const input = document.createElement("input");
+    expect(matchWindowKey({ ...ev("t", { metaKey: true }), target: input }, true)).toBeNull();
+  });
+
+  it("lets the console key through from a typing target", () => {
+    const input = document.createElement("input");
+    expect(matchWindowKey({ ...ev("k", { metaKey: true }), target: input }, true)).toEqual({
+      type: "console",
+    });
+  });
+
+  it("prints hints per platform", () => {
+    expect(hint("new-tab", true)).toBe("⌘T");
+    expect(hint("new-tab", false)).toBe("Ctrl+T");
+    // Core runs the modifiers in the order the chord lists them, so `Mod` first.
+    expect(hint("reopen-tab", true)).toBe("⌘⇧T");
+  });
+});

--- a/packages/ui-next/src/lib/shortcuts.ts
+++ b/packages/ui-next/src/lib/shortcuts.ts
@@ -33,7 +33,9 @@ const BINDINGS: Binding[] = [
   })),
   { chord: ["Mod", "K"], action: { type: "console" }, whileTyping: true },
   { chord: ["Mod", "="], action: { type: "zoom-in" } },
-  { chord: ["Mod", "+"], action: { type: "zoom-in" } },
+  // `+` is Shift+= on US/UK layouts, so the keydown really carries Shift; a
+  // chord without the token would be a row that can never fire.
+  { chord: ["Mod", "Shift", "+"], action: { type: "zoom-in" } },
   { chord: ["Mod", "-"], action: { type: "zoom-out" } },
   { chord: ["Mod", "0"], action: { type: "zoom-reset" } },
 ];

--- a/packages/ui-next/src/lib/shortcuts.ts
+++ b/packages/ui-next/src/lib/shortcuts.ts
@@ -1,0 +1,66 @@
+import { formatChord, isTypingTarget, type KeyEventLike, type KeyToken } from "@srelens/core";
+
+export type WindowAction =
+  | { type: "close-tab" }
+  | { type: "new-tab" }
+  | { type: "reopen-tab" }
+  | { type: "prev-tab" }
+  | { type: "next-tab" }
+  | { type: "select-tab"; index: number }
+  | { type: "console" }
+  | { type: "zoom-in" }
+  | { type: "zoom-out" }
+  | { type: "zoom-reset" };
+
+type Binding = { chord: KeyToken[]; action: WindowAction; whileTyping?: boolean };
+
+/**
+ * The window's accelerators, bound once in `Window`. Core's matcher treats
+ * `Mod` as Meta-or-Control, which is right for a palette and wrong here: on a
+ * Mac, Ctrl+W belongs to the terminal it was typed into, and the mock's
+ * `metaKey || ctrlKey` closed the document tab instead. So the modifier is
+ * strict per platform and only the hint formatting is shared with core.
+ */
+const BINDINGS: Binding[] = [
+  { chord: ["Mod", "W"], action: { type: "close-tab" } },
+  { chord: ["Mod", "T"], action: { type: "new-tab" } },
+  { chord: ["Mod", "Shift", "T"], action: { type: "reopen-tab" } },
+  { chord: ["Mod", "["], action: { type: "prev-tab" } },
+  { chord: ["Mod", "]"], action: { type: "next-tab" } },
+  ...Array.from({ length: 9 }, (_, i) => ({
+    chord: ["Mod", String(i + 1)],
+    action: { type: "select-tab", index: i } as WindowAction,
+  })),
+  { chord: ["Mod", "K"], action: { type: "console" }, whileTyping: true },
+  { chord: ["Mod", "="], action: { type: "zoom-in" } },
+  { chord: ["Mod", "+"], action: { type: "zoom-in" } },
+  { chord: ["Mod", "-"], action: { type: "zoom-out" } },
+  { chord: ["Mod", "0"], action: { type: "zoom-reset" } },
+];
+
+function matches(chord: KeyToken[], e: KeyEventLike, apple: boolean): boolean {
+  const mod = apple ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey;
+  const wantsShift = chord.includes("Shift");
+  const key = chord[chord.length - 1];
+  if (chord.includes("Mod") !== mod) return false;
+  if (e.altKey) return false;
+  if (wantsShift !== e.shiftKey) return false;
+  return e.key.toLowerCase() === key.toLowerCase();
+}
+
+export function matchWindowKey(
+  e: KeyEventLike & { target?: EventTarget | null },
+  apple: boolean,
+): WindowAction | null {
+  const typing = isTypingTarget(e.target ?? null);
+  for (const b of BINDINGS) {
+    if (typing && !b.whileTyping) continue;
+    if (matches(b.chord, e, apple)) return b.action;
+  }
+  return null;
+}
+
+export function hint(type: WindowAction["type"], apple: boolean): string {
+  const b = BINDINGS.find((x) => x.action.type === type);
+  return b ? formatChord(b.chord, apple) : "";
+}

--- a/packages/ui-next/src/lib/tabs.test.ts
+++ b/packages/ui-next/src/lib/tabs.test.ts
@@ -70,6 +70,11 @@ describe("defaultState", () => {
     expect(w.activeId).toBe(w.tabs[0].id);
   });
 
+  it("points at the first cluster", () => {
+    const s = defaultState([ctx("b"), ctx("a")]);
+    expect(s.workspaces[0].activeCluster).toBe("b");
+  });
+
   it("still makes a workspace when there are no clusters at all", () => {
     const state = defaultState([]);
     expect(state.workspaces).toHaveLength(1);
@@ -125,9 +130,24 @@ describe("reconcile", () => {
     expect(out.workspaces[0].closed[0].route).toBe("/resources/r0");
   });
 
+  it("clears an active cluster that vanished and picks the first that remains", () => {
+    const s = defaultState([ctx("a"), ctx("b")]);
+    s.workspaces[0].activeCluster = "a";
+    expect(reconcile(s, [ctx("b")]).workspaces[0].activeCluster).toBe("b");
+    expect(reconcile(s, []).workspaces[0].activeCluster).toBeUndefined();
+  });
+
+  it("adopts the first cluster for a workspace stored before there was an active one", () => {
+    // Storage version 1 predates the field, so the documents on disk have no
+    // `activeCluster`: boot has to fill it in or the rail comes up with
+    // clusters and nothing selected.
+    const state: TabsState = { workspaces: [ws({ clusters: ["a", "b"] })], currentId: "w1" };
+    expect(reconcile(state, [ctx("a"), ctx("b")]).workspaces[0].activeCluster).toBe("a");
+  });
+
   it("returns the same object when nothing needed changing", () => {
     // So a store can compare by identity and skip a save.
-    const w = ws({ clusters: ["a"] });
+    const w = ws({ clusters: ["a"], activeCluster: "a" });
     w.activeId = w.tabs[0].id;
     const state: TabsState = { workspaces: [w], currentId: "w1" };
     expect(reconcile(state, [ctx("a")])).toBe(state);

--- a/packages/ui-next/src/lib/tabs.ts
+++ b/packages/ui-next/src/lib/tabs.ts
@@ -18,6 +18,8 @@ export interface Workspace {
   name: string;
   /** `ClusterContext.stableId`s. Never display names — see #265. */
   clusters: string[];
+  /** The cluster the sidebar and status bar are about. A `stableId` in `clusters`. */
+  activeCluster?: string;
   tabs: Tab[];
   activeId: string;
   /** Recently closed, most recent first, for reopen-closed. */
@@ -72,14 +74,16 @@ function homeTab(): Tab {
  */
 export function defaultState(contexts: ClusterContext[]): TabsState {
   const home = homeTab();
+  const ids = contexts.map((c) => c.stableId);
   const w: Workspace = {
     id: newId(),
     name: "Default",
-    clusters: contexts.map((c) => c.stableId),
+    clusters: ids,
     tabs: [home],
     activeId: home.id,
     closed: [],
   };
+  if (ids[0]) w.activeCluster = ids[0];
   return { workspaces: [w], currentId: w.id };
 }
 
@@ -97,6 +101,16 @@ export function reconcile(state: TabsState, contexts: ClusterContext[]): TabsSta
     let next = w;
     const clusters = w.clusters.filter((id) => known.has(id));
     if (clusters.length !== w.clusters.length) next = { ...next, clusters };
+
+    // The active cluster follows its list: it survives if it is still there,
+    // and otherwise the first that remains takes over — including for a
+    // workspace stored before the field existed, which has none at all.
+    const active = w.activeCluster && clusters.includes(w.activeCluster) ? w.activeCluster : clusters[0];
+    if (active !== w.activeCluster) {
+      next = { ...next };
+      if (active) next.activeCluster = active;
+      else delete next.activeCluster;
+    }
 
     let tabs = next.tabs;
     if (tabs.length === 0) tabs = [homeTab()];

--- a/packages/ui-next/src/lib/tabsPersist.test.ts
+++ b/packages/ui-next/src/lib/tabsPersist.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { ClusterContext } from "@srelens/core";
 import { defaultState, makeTab, type TabsState } from "./tabs";
 import {
   STORAGE_KEY, STORAGE_VERSION, flushSave, loadTabsState, parseStoredState, saveTabsState, scheduleSave,
@@ -15,6 +16,10 @@ function memory(): Storage & { data: Map<string, string> } {
     removeItem: (k) => void data.delete(k),
   };
 }
+
+const ctx = (id: string): ClusterContext => ({
+  name: id, stableId: id, cluster: id, server: `https://${id}`, isCurrent: false,
+});
 
 const valid = (): TabsState => {
   const s = defaultState([]);
@@ -93,6 +98,21 @@ describe("parseStoredState", () => {
     delete doc.version;
     expect(parseStoredState(JSON.stringify(doc))).toBeNull();
     expect(parseStoredState(JSON.stringify({ ...doc, version: "1" }))).toBeNull();
+  });
+
+  it("round-trips activeCluster and drops one that is not a string", () => {
+    const s = defaultState([ctx("a")]);
+    s.workspaces[0].activeCluster = "a";
+    expect(parseStoredState(JSON.stringify({ version: 1, ...s }))?.workspaces[0].activeCluster).toBe("a");
+    const raw = JSON.stringify({ version: 1, ...s }).replace('"activeCluster":"a"', '"activeCluster":7');
+    expect(parseStoredState(raw)?.workspaces[0].activeCluster).toBeUndefined();
+  });
+
+  it("drops an activeCluster that names a cluster the workspace does not have", () => {
+    const s = defaultState([ctx("a")]);
+    s.workspaces[0].activeCluster = "a";
+    const raw = JSON.stringify({ version: 1, ...s }).replace('"activeCluster":"a"', '"activeCluster":"gone"');
+    expect(parseStoredState(raw)?.workspaces[0].activeCluster).toBeUndefined();
   });
 
   it("drops fields it does not know and tabs that are malformed", () => {

--- a/packages/ui-next/src/lib/tabsPersist.ts
+++ b/packages/ui-next/src/lib/tabsPersist.ts
@@ -36,14 +36,19 @@ function parseWorkspace(v: unknown): Workspace | null {
   if (!Array.isArray(v.clusters) || !Array.isArray(v.tabs)) return null;
   const tabs = v.tabs.map(parseTab).filter((t): t is Tab => t !== null);
   const closed = Array.isArray(v.closed) ? v.closed.map(parseTab).filter((t): t is Tab => t !== null) : [];
-  return {
+  const clusters = v.clusters.filter(isString);
+  const ws: Workspace = {
     id: v.id,
     name: v.name,
-    clusters: v.clusters.filter(isString),
+    clusters,
     tabs,
     activeId: v.activeId,
     closed,
   };
+  // Only a cluster the workspace actually has: the field is an index into
+  // `clusters`, and `reconcile` would drop a dangling one anyway.
+  if (isString(v.activeCluster) && clusters.includes(v.activeCluster)) ws.activeCluster = v.activeCluster;
+  return ws;
 }
 
 /**

--- a/packages/ui-next/src/lib/tabsStore.test.tsx
+++ b/packages/ui-next/src/lib/tabsStore.test.tsx
@@ -1,7 +1,12 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
+import type { ClusterContext } from "@srelens/core";
 import { defaultState, type TabsState } from "./tabs";
 import * as store from "./tabsStore";
+
+const ctx = (id: string): ClusterContext => ({
+  name: id, stableId: id, cluster: id, server: `https://${id}`, isCurrent: false,
+});
 
 function seed(over: Partial<TabsState> = {}) {
   const base = defaultState([]);
@@ -242,6 +247,56 @@ describe("workspaces", () => {
     const id = store.getState().currentId;
     store.setWorkspaceClusters(id, ["x", "y"]);
     expect(store.currentWorkspace().clusters).toEqual(["x", "y"]);
+  });
+});
+
+describe("activeCluster", () => {
+  it("setActiveCluster accepts a cluster of the workspace and nothing else", () => {
+    store.setState(defaultState([ctx("a"), ctx("b")]));
+    store.setActiveCluster("b");
+    expect(store.activeCluster()).toBe("b");
+    store.setActiveCluster("zzz");
+    expect(store.activeCluster()).toBe("b");
+    store.setActiveCluster(null);
+    expect(store.activeCluster()).toBeNull();
+  });
+
+  it("setActiveCluster does not notify for a no-op", () => {
+    store.setState(defaultState([ctx("a")]));
+    const spy = vi.fn();
+    const off = store.subscribe(spy);
+    store.setActiveCluster("a"); // already "a" from defaultState
+    expect(spy).not.toHaveBeenCalled();
+    off();
+  });
+
+  it("tells the hook", () => {
+    store.setState(defaultState([ctx("a"), ctx("b")]));
+    const { result } = renderHook(() => store.useActiveCluster());
+    expect(result.current).toBe("a");
+    act(() => store.setActiveCluster("b"));
+    expect(result.current).toBe("b");
+  });
+
+  it("is the first cluster of a workspace just created", () => {
+    // Otherwise a new workspace comes up with a full rail and nothing
+    // selected until the next `reconcile`, which only runs when the machine's
+    // contexts change.
+    store.createWorkspace("Prod", ["c1", "c2"]);
+    expect(store.activeCluster()).toBe("c1");
+    store.createWorkspace("Empty", []);
+    expect(store.activeCluster()).toBeNull();
+  });
+
+  it("stays valid when the workspace's clusters are replaced", () => {
+    store.setState(defaultState([ctx("a"), ctx("b")]));
+    const id = store.getState().currentId;
+    store.setWorkspaceClusters(id, ["b", "c"]);
+    expect(store.activeCluster()).toBe("b");
+    store.setWorkspaceClusters(id, ["c", "d"]);
+    expect(store.activeCluster()).toBe("c");
+    store.setWorkspaceClusters(id, []);
+    expect(store.activeCluster()).toBeNull();
   });
 });
 

--- a/packages/ui-next/src/lib/tabsStore.ts
+++ b/packages/ui-next/src/lib/tabsStore.ts
@@ -44,6 +44,19 @@ export function currentWorkspace(): Workspace {
   return state.workspaces.find((w) => w.id === state.currentId) ?? state.workspaces[0];
 }
 
+/**
+ * The cluster the sidebar and status bar are about, per workspace and
+ * persisted with it: which cluster you were looking at is worth surviving a
+ * restart, the way the open tabs are.
+ */
+export function activeCluster(): string | null {
+  return currentWorkspace().activeCluster ?? null;
+}
+
+export function useActiveCluster(): string | null {
+  return useSyncExternalStore(subscribe, activeCluster, activeCluster);
+}
+
 export function activeRoute(): string {
   const w = currentWorkspace();
   return w.tabs.find((t) => t.id === w.activeId)?.route ?? "/";
@@ -209,6 +222,7 @@ export function switchWorkspace(id: string): void {
 export function createWorkspace(name: string, clusters: string[]): string {
   const home = makeTab("/");
   const w: Workspace = { id: newId(), name, clusters, tabs: [home], activeId: home.id, closed: [] };
+  if (clusters[0]) w.activeCluster = clusters[0];
   emit({ workspaces: [...state.workspaces, w], currentId: w.id });
   return w.id;
 }
@@ -228,9 +242,31 @@ export function removeWorkspace(id: string): void {
 }
 
 export function setWorkspaceClusters(id: string, clusters: string[]): void {
-  patchWorkspace(id, (w) =>
-    w.clusters.length === clusters.length && w.clusters.every((c, i) => c === clusters[i])
-      ? w
-      : { ...w, clusters: [...clusters] },
-  );
+  patchWorkspace(id, (w) => {
+    const same = w.clusters.length === clusters.length && w.clusters.every((c, i) => c === clusters[i]);
+    // The active cluster is an index into this list, so taking a cluster away
+    // has to move it — `reconcile` only knows about clusters that vanished
+    // from the machine, not ones dropped from a workspace.
+    const active = w.activeCluster && clusters.includes(w.activeCluster) ? w.activeCluster : clusters[0];
+    if (same && active === w.activeCluster) return w;
+    const next: Workspace = { ...w, clusters: [...clusters] };
+    if (active) next.activeCluster = active;
+    else delete next.activeCluster;
+    return next;
+  });
+}
+
+/**
+ * `null` for "no cluster in focus"; anything the workspace does not have is
+ * refused rather than stored, so the field is always an id in `clusters`.
+ */
+export function setActiveCluster(id: string | null): void {
+  patchCurrent((w) => {
+    if (id !== null && !w.clusters.includes(id)) return w;
+    if ((w.activeCluster ?? null) === id) return w;
+    const next: Workspace = { ...w };
+    if (id === null) delete next.activeCluster;
+    else next.activeCluster = id;
+    return next;
+  });
 }

--- a/packages/ui-next/src/lib/tree.test.ts
+++ b/packages/ui-next/src/lib/tree.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "vitest";
+import { RESOURCE_LABELS, type CrdRef } from "@srelens/core";
+import type { ResourceNode } from "@srelens/ui-kit";
+import { crdNodes, INVESTIGATE, kindNodes, NAV_GROUPS, routeForNode } from "./tree";
+
+const labels = (nodes: ResourceNode[] | undefined) => (nodes ?? []).map((n) => n.label);
+const ids = (nodes: ResourceNode[] | undefined) => (nodes ?? []).map((n) => n.id);
+
+const crd = (name: string, group: string, kind: string): CrdRef => ({
+  name,
+  group,
+  version: "v1",
+  kind,
+  plural: name.split(".")[0],
+  namespaced: true,
+});
+
+const CERTS = crd("certificates.cert-manager.io", "cert-manager.io", "Certificate");
+const ISSUERS = crd("issuers.cert-manager.io", "cert-manager.io", "Issuer");
+const ARGO = crd("applications.argoproj.io", "argoproj.io", "Application");
+
+describe("kindNodes", () => {
+  it("is the six groups, in order", () => {
+    expect(labels(kindNodes())).toEqual(["Cluster", "Workloads", "Config", "Network", "Storage", "Access control"]);
+    expect(ids(kindNodes())).toEqual(NAV_GROUPS.map((g) => g.id));
+  });
+
+  it("labels every kind the way core does", () => {
+    const workloads = kindNodes().find((n) => n.id === "workloads");
+    expect(labels(workloads?.children)).toEqual([
+      RESOURCE_LABELS.pods,
+      RESOURCE_LABELS.deployments,
+      RESOURCE_LABELS.statefulsets,
+      RESOURCE_LABELS.daemonsets,
+      RESOURCE_LABELS.replicasets,
+      RESOURCE_LABELS.jobs,
+      RESOURCE_LABELS.cronjobs,
+    ]);
+    expect(ids(workloads?.children)).toEqual([
+      "kind:pods",
+      "kind:deployments",
+      "kind:statefulsets",
+      "kind:daemonsets",
+      "kind:replicasets",
+      "kind:jobs",
+      "kind:cronjobs",
+    ]);
+  });
+
+  it("carries a glyph on every group and every leaf", () => {
+    for (const group of kindNodes()) {
+      expect(group.icon).toBeTruthy();
+      for (const child of group.children ?? []) expect(child.icon).toBeTruthy();
+    }
+  });
+
+  it("puts overview, port forwards and helm in the Cluster group as routes, not kinds", () => {
+    const cluster = kindNodes()[0];
+    expect(ids(cluster.children)).toEqual([
+      "route:/overview",
+      "kind:nodes",
+      "kind:namespaces",
+      "kind:events",
+      "route:/forwards",
+      "route:/helm",
+    ]);
+    expect(labels(cluster.children)).toEqual([
+      RESOURCE_LABELS.overview,
+      RESOURCE_LABELS.nodes,
+      RESOURCE_LABELS.namespaces,
+      RESOURCE_LABELS.events,
+      RESOURCE_LABELS.portforwards,
+      RESOURCE_LABELS.helmreleases,
+    ]);
+  });
+
+  it("has no group that folds shut to begin with", () => {
+    for (const group of kindNodes()) expect(group.defaultExpanded).not.toBe(false);
+  });
+});
+
+describe("crdNodes", () => {
+  it("gathers a group's CRDs under one node", () => {
+    const nodes = crdNodes([CERTS, ISSUERS]);
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].id).toBe("crdgroup:cert-manager.io");
+    expect(nodes[0].label).toBe("cert-manager.io");
+    expect(labels(nodes[0].children)).toEqual(["Certificate", "Issuer"]);
+    expect(ids(nodes[0].children)).toEqual(["crd:certificates.cert-manager.io", "crd:issuers.cert-manager.io"]);
+  });
+
+  it("sorts the groups alphabetically", () => {
+    expect(ids(crdNodes([CERTS, ARGO, ISSUERS]))).toEqual(["crdgroup:argoproj.io", "crdgroup:cert-manager.io"]);
+  });
+
+  it("starts every group folded shut — there can be hundreds", () => {
+    for (const group of crdNodes([CERTS, ARGO])) expect(group.defaultExpanded).toBe(false);
+  });
+
+  it("is empty for no CRDs", () => {
+    expect(crdNodes([])).toEqual([]);
+  });
+});
+
+describe("routeForNode", () => {
+  const crds = [CERTS, ISSUERS];
+
+  it("sends a kind to its list", () => {
+    expect(routeForNode("kind:pods", crds)).toBe("/k/pods");
+  });
+
+  it("sends events to the events screen, which is not a list", () => {
+    expect(routeForNode("kind:events", crds)).toBe("/events");
+  });
+
+  it("sends a CRD to its list, by full name", () => {
+    expect(routeForNode("crd:certificates.cert-manager.io", crds)).toBe("/k/certificates.cert-manager.io");
+  });
+
+  it("refuses a CRD the cluster no longer has", () => {
+    expect(routeForNode("crd:certificates.cert-manager.io", [])).toBeNull();
+  });
+
+  it("passes a route node through", () => {
+    expect(routeForNode("route:/incidents", crds)).toBe("/incidents");
+  });
+
+  it("has nothing to open for a group", () => {
+    expect(routeForNode("crdgroup:x", crds)).toBeNull();
+    expect(routeForNode("workloads", crds)).toBeNull();
+  });
+});
+
+describe("INVESTIGATE", () => {
+  it("is the control room, incidents, topology and the agent", () => {
+    expect(INVESTIGATE.map((i) => [i.label, i.route])).toEqual([
+      ["Control room", "/"],
+      ["Incidents", "/incidents"],
+      ["Topology", "/topology"],
+      ["Agent", "/agent"],
+    ]);
+  });
+});

--- a/packages/ui-next/src/lib/tree.test.ts
+++ b/packages/ui-next/src/lib/tree.test.ts
@@ -129,6 +129,10 @@ describe("routeForNode", () => {
     expect(routeForNode("crdgroup:x", crds)).toBeNull();
     expect(routeForNode("workloads", crds)).toBeNull();
   });
+
+  it("has nothing to open for the CRD-discovery retry leaf", () => {
+    expect(routeForNode("crd-error", crds)).toBeNull();
+  });
 });
 
 describe("INVESTIGATE", () => {

--- a/packages/ui-next/src/lib/tree.ts
+++ b/packages/ui-next/src/lib/tree.ts
@@ -1,0 +1,185 @@
+import { RESOURCE_LABELS, type CrdRef, type ResourceKind } from "@srelens/core";
+import type { IconComponent, ResourceNode } from "@srelens/ui-kit";
+import { Icons } from "./icons";
+
+/**
+ * What the sidebar offers, as data.
+ *
+ * Pure on purpose: the tree the shell draws is a value, so the shape of the
+ * navigation can be asserted without rendering anything, and `Nav` is left with
+ * only the wiring — the store, the CRD load, the tab it opens. The kit's
+ * `ResourceTree` takes nodes and gives back ids; this module owns both ends of
+ * that conversation, `kindNodes`/`crdNodes` building the ids and
+ * {@link routeForNode} reading them back.
+ *
+ * Ids are prefixed by what they are — `kind:`, `crd:`, `crdgroup:`, `route:` —
+ * rather than being bare slugs. A tree that mixes built-in kinds, discovered
+ * custom resources and plain app routes in one flat namespace has no way to
+ * tell `pods` the kind from a CRD that happens to be called `pods`, and the
+ * prefix is what makes the reverse mapping total instead of a guess.
+ */
+
+/**
+ * The groups, mirroring the classic sidebar's `NAV_SECTIONS` so that someone
+ * running both builds during the migration finds the same kinds in the same
+ * places. Only the routes moved (see {@link CLUSTER_ROUTES}).
+ */
+export const NAV_GROUPS: ReadonlyArray<{ id: string; label: string; kinds: ResourceKind[] }> = [
+  { id: "cluster", label: "Cluster", kinds: ["nodes", "namespaces", "events"] },
+  {
+    id: "workloads",
+    label: "Workloads",
+    kinds: ["pods", "deployments", "statefulsets", "daemonsets", "replicasets", "jobs", "cronjobs"],
+  },
+  {
+    id: "config",
+    label: "Config",
+    kinds: [
+      "configmaps",
+      "secrets",
+      "resourcequotas",
+      "limitranges",
+      "horizontalpodautoscalers",
+      "poddisruptionbudgets",
+      "priorityclasses",
+      "runtimeclasses",
+      "leases",
+      "mutatingwebhookconfigurations",
+      "validatingwebhookconfigurations",
+    ],
+  },
+  {
+    id: "network",
+    label: "Network",
+    kinds: ["services", "endpointslices", "endpoints", "ingresses", "ingressclasses", "networkpolicies"],
+  },
+  { id: "storage", label: "Storage", kinds: ["persistentvolumeclaims", "persistentvolumes", "storageclasses"] },
+  {
+    id: "access",
+    label: "Access control",
+    kinds: ["serviceaccounts", "clusterroles", "roles", "clusterrolebindings", "rolebindings"],
+  },
+];
+
+/**
+ * The three rows in the Cluster group that are not kinds at all.
+ *
+ * Core lists `overview`, `portforwards` and `helmreleases` in `ResourceKind`
+ * for the classic sidebar's sake, but none of them has a Kubernetes kind behind
+ * it (`K8S_KIND` is `""` for all three) and none is a `/k/<kind>` list here:
+ * they are screens, at `/overview`, `/forwards` and `/helm`. They keep core's
+ * labels, because they are the same three things by another door.
+ */
+const CLUSTER_ROUTES: ReadonlyArray<{ kind: ResourceKind; route: string; before?: true }> = [
+  { kind: "overview", route: "/overview", before: true },
+  { kind: "portforwards", route: "/forwards" },
+  { kind: "helmreleases", route: "/helm" },
+];
+
+/** Where the app can be sent that is not a list of resources. */
+export const INVESTIGATE: ReadonlyArray<{ id: string; label: string; route: string }> = [
+  { id: "control", label: "Control room", route: "/" },
+  { id: "incidents", label: "Incidents", route: "/incidents" },
+  { id: "topology", label: "Topology", route: "/topology" },
+  { id: "agent", label: "Agent", route: "/agent" },
+];
+
+/**
+ * The glyph for a name in the app's vocabulary, or the fallback.
+ *
+ * `Icons` is keyed by concept — `pods`, `workloads`, `incidents` — and every id
+ * this module builds a node for is one of those concepts, so one lookup covers
+ * groups, kinds and destinations alike. A kind added to core before a glyph is
+ * chosen for it draws the fallback rather than nothing.
+ */
+export function glyph(name: string): IconComponent {
+  return (Icons as Record<string, IconComponent | undefined>)[name] ?? Icons.fallback;
+}
+
+const kindNode = (kind: ResourceKind): ResourceNode => ({
+  id: `kind:${kind}`,
+  label: RESOURCE_LABELS[kind],
+  icon: glyph(kind),
+});
+
+const routeNode = (kind: ResourceKind, route: string): ResourceNode => ({
+  id: `route:${route}`,
+  label: RESOURCE_LABELS[kind],
+  icon: glyph(kind),
+});
+
+/** The built-in half of the tree: the six groups, open to begin with. */
+export function kindNodes(): ResourceNode[] {
+  return NAV_GROUPS.map((group) => {
+    const kinds = group.kinds.map(kindNode);
+    const children =
+      group.id === "cluster"
+        ? [
+            ...CLUSTER_ROUTES.filter((r) => r.before).map((r) => routeNode(r.kind, r.route)),
+            ...kinds,
+            ...CLUSTER_ROUTES.filter((r) => !r.before).map((r) => routeNode(r.kind, r.route)),
+          ]
+        : kinds;
+    return { id: group.id, label: group.label, icon: glyph(group.id), children };
+  });
+}
+
+/**
+ * Discovered CRDs, gathered under their API group.
+ *
+ * Flat would be unusable: a cluster with cert-manager, Argo and an operator or
+ * two runs to a couple of hundred CRDs, and the group is the only thing that
+ * makes that list navigable. Groups and the CRDs inside them are both sorted,
+ * because discovery order is the backend's and changes between calls — a tree
+ * that reshuffles itself between refreshes cannot be learned.
+ *
+ * Every group starts folded shut. Expanding all of them by default would drown
+ * the built-in kinds above them the moment one operator is installed.
+ */
+export function crdNodes(crds: CrdRef[]): ResourceNode[] {
+  const groups = new Map<string, CrdRef[]>();
+  for (const crd of crds) {
+    const key = crd.group || "core";
+    const list = groups.get(key);
+    if (list) list.push(crd);
+    else groups.set(key, [crd]);
+  }
+  return [...groups.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([group, list]) => ({
+      id: `crdgroup:${group}`,
+      label: group,
+      icon: Icons.crds,
+      defaultExpanded: false,
+      children: [...list]
+        .sort((a, b) => a.kind.localeCompare(b.kind))
+        .map((crd) => ({ id: `crd:${crd.name}`, label: crd.kind, icon: Icons.fallback })),
+    }));
+}
+
+/**
+ * Where a node id goes, or `null` for a node that goes nowhere.
+ *
+ * The groups are the `null` cases: the kit's tree already treats a node with
+ * children as a fold rather than a destination, so this is the second line of
+ * that same rule — a caller that activates a group opens no tab instead of a
+ * tab at `/k/crdgroup:cert-manager.io`.
+ *
+ * A CRD is checked against the list it came from rather than trusted. Node ids
+ * outlive the CRDs behind them — a tree rendered before the operator was
+ * uninstalled, a persisted fold — and a route to a custom resource this cluster
+ * has never heard of is a tab that can only fail.
+ */
+export function routeForNode(id: string, crds: CrdRef[]): string | null {
+  if (id.startsWith("route:")) return id.slice("route:".length) || null;
+  if (id.startsWith("kind:")) {
+    const kind = id.slice("kind:".length);
+    // Events are a screen of their own, not a table of a kind.
+    return kind === "events" ? "/events" : `/k/${kind}`;
+  }
+  if (id.startsWith("crd:")) {
+    const name = id.slice("crd:".length);
+    return crds.some((crd) => crd.name === name) ? `/k/${name}` : null;
+  }
+  return null;
+}

--- a/packages/ui-next/src/lib/useResource.test.tsx
+++ b/packages/ui-next/src/lib/useResource.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useResource } from "./useResource";
+
+describe("useResource", () => {
+  it("goes loading → ready", async () => {
+    const { result } = renderHook(() => useResource(() => Promise.resolve([1]), []));
+    expect(result.current.status).toBe("loading");
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    expect(result.current.data).toEqual([1]);
+  });
+  it("reports empty by the default predicate and by a custom one", async () => {
+    const a = renderHook(() => useResource(() => Promise.resolve([]), []));
+    await waitFor(() => expect(a.result.current.status).toBe("empty"));
+    const b = renderHook(() => useResource(() => Promise.resolve({ n: 0 }), [], (v) => v.n === 0));
+    await waitFor(() => expect(b.result.current.status).toBe("empty"));
+  });
+  it("reports an error with its message and retries through reload", async () => {
+    const load = vi.fn().mockRejectedValueOnce(new Error("boom")).mockResolvedValueOnce("ok");
+    const { result } = renderHook(() => useResource(load, []));
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.error).toBe("boom");
+    act(() => result.current.reload());
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+  it("ignores a result that lands after a newer load began", async () => {
+    let resolveFirst!: (v: string) => void;
+    const load = vi.fn()
+      .mockImplementationOnce(() => new Promise<string>((r) => { resolveFirst = r; }))
+      .mockResolvedValueOnce("second");
+    const { result } = renderHook(() => useResource(load, []));
+    act(() => result.current.reload());
+    await waitFor(() => expect(result.current.data).toBe("second"));
+    // The late resolution has to be flushed *inside* act: an update React
+    // schedules outside act never reaches `result.current` before the
+    // assertion runs, so the check would pass even with the guard removed.
+    await act(async () => { resolveFirst("first"); await Promise.resolve(); });
+    expect(result.current.data).toBe("second");
+  });
+  it("ignores a result after unmount", async () => {
+    let resolve!: (v: string) => void;
+    // `result.current` freezes at the last render once the hook is unmounted,
+    // so it cannot witness a dropped result on its own. The predicate can:
+    // useResource only consults isEmpty for a result it intends to keep.
+    const isEmpty = vi.fn((v: string) => v === "");
+    const { result, unmount } = renderHook(() => useResource(() => new Promise<string>((r) => { resolve = r; }), [], isEmpty));
+    unmount();
+    await act(async () => { resolve("late"); await Promise.resolve(); });
+    expect(isEmpty).not.toHaveBeenCalled();
+    expect(result.current.status).toBe("loading");
+  });
+});

--- a/packages/ui-next/src/lib/useResource.ts
+++ b/packages/ui-next/src/lib/useResource.ts
@@ -1,0 +1,32 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type ResourceStatus = "loading" | "ready" | "empty" | "error";
+export interface Resource<T> { status: ResourceStatus; data?: T; error?: string; reload(): void }
+
+const defaultEmpty = (v: unknown) => v == null || v === "" || (Array.isArray(v) && v.length === 0);
+
+/**
+ * One loading pattern for every screen: loading, ready, empty, error, and a
+ * retry that re-invokes the loader. A result that arrives after the component
+ * unmounted, or after a newer load began, is dropped — the `gen` counter is
+ * what says which load is current.
+ */
+export function useResource<T>(load: () => Promise<T>, deps: unknown[], isEmpty: (v: T) => boolean = defaultEmpty): Resource<T> {
+  const [state, setState] = useState<Omit<Resource<T>, "reload">>({ status: "loading" });
+  const gen = useRef(0);
+  const [tick, setTick] = useState(0);
+  const reload = useCallback(() => setTick((t) => t + 1), []);
+
+  useEffect(() => {
+    const mine = ++gen.current;
+    setState({ status: "loading" });
+    load().then(
+      (data) => { if (gen.current === mine) setState(isEmpty(data) ? { status: "empty", data } : { status: "ready", data }); },
+      (e: unknown) => { if (gen.current === mine) setState({ status: "error", error: e instanceof Error ? e.message : String(e) }); },
+    );
+    return () => { if (gen.current === mine) gen.current++; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tick, ...deps]);
+
+  return { ...state, reload };
+}

--- a/packages/ui-next/src/lib/workspace.test.tsx
+++ b/packages/ui-next/src/lib/workspace.test.tsx
@@ -5,14 +5,14 @@ import * as ws from "./workspace";
 beforeEach(() => ws.resetView());
 
 describe("workspace view", () => {
-  it("starts with no active cluster, no links, nothing expanded", () => {
-    expect(ws.getView()).toEqual({ activeCluster: null, links: {}, expanded: [] });
+  it("starts with no links and nothing expanded", () => {
+    expect(ws.getView()).toEqual({ links: {}, expanded: [] });
   });
 
-  it("sets the active cluster and tells the hook", () => {
+  it("tells the hook when a link changes", () => {
     const { result } = renderHook(() => ws.useWorkspaceView());
-    act(() => ws.setActiveCluster("prod"));
-    expect(result.current.activeCluster).toBe("prod");
+    act(() => ws.setLink("prod", "connected"));
+    expect(result.current.links.prod).toEqual({ state: "connected" });
   });
 
   it("records a link state per cluster, with an error when there is one", () => {
@@ -48,7 +48,6 @@ describe("workspace view", () => {
     const { result } = renderHook(() => ws.useWorkspaceView());
     void result;
     const off = ws.subscribe(() => n++);
-    ws.setActiveCluster(null);
     ws.setLink("a", "connected");
     ws.setLink("a", "connected");
     expect(n).toBe(1);
@@ -72,7 +71,7 @@ describe("workspace view", () => {
     const off = ws.subscribe(() => n++);
     ws.resetView();
     expect(n).toBe(0);
-    ws.setActiveCluster("prod");
+    ws.setLink("prod", "connected");
     ws.resetView();
     expect(n).toBe(2);
     off();

--- a/packages/ui-next/src/lib/workspace.ts
+++ b/packages/ui-next/src/lib/workspace.ts
@@ -3,8 +3,6 @@ import { useSyncExternalStore } from "react";
 export type LinkState = "connected" | "connecting" | "disconnected" | "error";
 
 export interface WorkspaceView {
-  /** The cluster the sidebar and status bar are about. A `stableId`. */
-  activeCluster: string | null;
   /** Per cluster. Derived from `ClusterInfo.reachable` and in-flight connects; never persisted. */
   links: Record<string, { state: LinkState; error?: string }>;
   /** Which sidebar sections are open. Not persisted. */
@@ -13,13 +11,13 @@ export interface WorkspaceView {
 
 /**
  * What the current workspace looks like right now, as distinct from what it
- * contains. The tab store owns clusters and tabs and is written to disk; this
- * owns the active cluster, whether each cluster is reachable, and which
- * sections are open — none of which should outlive the window, because a
+ * contains. The tab store owns clusters, tabs and the active cluster and is
+ * written to disk; this owns whether each cluster is reachable and which
+ * sections are open — neither of which should outlive the window, because a
  * cluster's reachability is a fact about now and an expanded section is a
  * fact about this sitting.
  */
-const initial = (): WorkspaceView => ({ activeCluster: null, links: {}, expanded: [] });
+const initial = (): WorkspaceView => ({ links: {}, expanded: [] });
 let view: WorkspaceView = initial();
 const listeners = new Set<() => void>();
 
@@ -34,7 +32,7 @@ function sameExpanded(a: readonly string[], b: readonly string[]): boolean {
 }
 
 function isInitial(v: WorkspaceView): boolean {
-  return v.activeCluster === null && Object.keys(v.links).length === 0 && v.expanded.length === 0;
+  return Object.keys(v.links).length === 0 && v.expanded.length === 0;
 }
 
 export function getView(): WorkspaceView {
@@ -53,11 +51,6 @@ export function subscribe(listener: () => void): () => void {
 
 export function useWorkspaceView(): WorkspaceView {
   return useSyncExternalStore(subscribe, getView, getView);
-}
-
-export function setActiveCluster(id: string | null): void {
-  if (view.activeCluster === id) return;
-  emit({ ...view, activeCluster: id });
 }
 
 export function setLink(id: string, state: LinkState, error?: string): void {

--- a/packages/ui-next/src/lib/workspace.ts
+++ b/packages/ui-next/src/lib/workspace.ts
@@ -39,9 +39,34 @@ export function getView(): WorkspaceView {
   return view;
 }
 
+/**
+ * Whether {@link seedExpandedOnce} has already run for this window's
+ * lifetime. Module-level rather than a ref kept on `Nav`: a ref resets every
+ * time the component remounts, so a ref-guarded seed cannot tell "nothing has
+ * opened a group yet" from "the user just closed all of them" — both show up
+ * as an empty `expanded` on the next mount. A flag that survives remounts is
+ * what makes the two distinguishable. `resetView` clears it alongside the
+ * rest of the view because tests use one call to `resetView` as "a fresh
+ * window"; production never calls `resetView` at all.
+ */
+let seeded = false;
+
 export function resetView(): void {
+  seeded = false;
   if (isInitial(view)) return;
   emit(initial());
+}
+
+/**
+ * Seeds `expanded` with `ids`, but only the first time this is ever called
+ * for the running window — not once per mount of whatever calls it. Everything
+ * else about the sidebar's folds already works whether `Nav` is mounted once
+ * or remounted a dozen times; this is the one piece of it that must not.
+ */
+export function seedExpandedOnce(ids: string[]): void {
+  if (seeded) return;
+  seeded = true;
+  if (view.expanded.length === 0) setExpanded(ids);
 }
 
 export function subscribe(listener: () => void): () => void {

--- a/packages/ui-next/src/screens/AppLog.test.tsx
+++ b/packages/ui-next/src/screens/AppLog.test.tsx
@@ -54,7 +54,8 @@ describe("AppLog", () => {
       "INFO connected to prod",
       "ERROR RBAC denied for Pods",
     ]);
-    expect(within(region).getByText("2026-08-21 09:12:03")).toBeTruthy();
+    expect(within(region).getByText("09:12:03")).toBeTruthy();
+    expect(within(region).getAllByText("srelens::cluster")).not.toHaveLength(0);
   });
 
   it("says so when the log has nothing in it", async () => {
@@ -126,7 +127,23 @@ describe("AppLog", () => {
 
     await userEvent.clear(field);
     await userEvent.type(field, "no such line");
-    expect(screen.getByText("No lines match (showing at most 5 000)")).toBeTruthy();
+    expect(screen.getByText("No lines match")).toBeTruthy();
     expect(rendered(region)).toEqual([]);
+  });
+
+  it("says how many lines are shown when the cap truncates real matches", async () => {
+    const many = Array.from(
+      { length: 5001 },
+      (_, i) => `[2026-08-21][09:12:03][srelens::cluster][INFO] entry ${i}`,
+    ).join("\n");
+    core.readAppLog.mockResolvedValue(many);
+
+    render(<AppLog route="/logs" />);
+    const region = await screen.findByRole("log", { name: "Application log" });
+
+    // 5000 shown of 5001 real matches — not "no lines match", the opposite
+    // state, and not silent either: a truncated log must not look complete.
+    expect(await screen.findByText(/5 000 of 5 001 lines/)).toBeTruthy();
+    expect(rendered(region)).toHaveLength(5000);
   });
 });

--- a/packages/ui-next/src/screens/AppLog.test.tsx
+++ b/packages/ui-next/src/screens/AppLog.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AppLog } from "./AppLog";
+
+// The file, the path and the file manager are all core's, and all three need a
+// Tauri backend. Mocked wholesale: this suite is about what the screen does
+// with what core returns, and `isTauri` is a function so a test can move the
+// app to the browser between renders.
+const { core } = vi.hoisted(() => ({
+  core: {
+    readAppLog: vi.fn<() => Promise<string>>(),
+    appLogPath: vi.fn<() => Promise<string>>(),
+    revealAppLog: vi.fn<() => Promise<void>>(),
+    isTauri: vi.fn(() => true),
+  },
+}));
+vi.mock("@srelens/core", async (orig) => ({
+  ...(await orig<typeof import("@srelens/core")>()),
+  ...core,
+}));
+
+const PATH = "/Users/ada/Library/Logs/srelens/srelens.log";
+const LOG = [
+  "[2026-08-21][09:12:03][srelens::cluster][INFO] connected to prod",
+  "[2026-08-21][09:12:04][srelens::rbac][ERROR] RBAC denied for Pods",
+].join("\n");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // `clearAllMocks` forgets the calls, not the implementations — but these are
+  // set per test often enough that spelling the defaults out here keeps one
+  // test's rejection from leaking into the next.
+  core.isTauri.mockReturnValue(true);
+  core.readAppLog.mockResolvedValue(LOG);
+  core.appLogPath.mockResolvedValue(PATH);
+  core.revealAppLog.mockResolvedValue(undefined);
+});
+
+/** The rendered lines, in order, as `level → message`. */
+const rendered = (region: HTMLElement) =>
+  Array.from(region.querySelectorAll(".logline")).map(
+    (el) =>
+      `${el.querySelector("[data-slot=level]")?.textContent} ${el.querySelector("[data-slot=message]")?.textContent}`,
+  );
+
+describe("AppLog", () => {
+  it("loads the log and renders one line per entry, with its level", async () => {
+    render(<AppLog route="/logs" />);
+    expect(screen.getByRole("status", { name: "Loading the log" })).toBeTruthy();
+
+    const region = await screen.findByRole("log", { name: "Application log" });
+    expect(rendered(region)).toEqual([
+      "INFO connected to prod",
+      "ERROR RBAC denied for Pods",
+    ]);
+    expect(within(region).getByText("2026-08-21 09:12:03")).toBeTruthy();
+  });
+
+  it("says so when the log has nothing in it", async () => {
+    core.readAppLog.mockResolvedValue("");
+    render(<AppLog route="/logs" />);
+    expect(await screen.findByText("No log entries yet")).toBeTruthy();
+  });
+
+  it("reports a failed read, and retries it", async () => {
+    core.readAppLog.mockRejectedValueOnce(new Error("permission denied"));
+    render(<AppLog route="/logs" />);
+
+    const alert = await screen.findByRole("alert");
+    expect(within(alert).getByText(/permission denied/)).toBeTruthy();
+
+    await userEvent.click(within(alert).getByRole("button", { name: "Retry" }));
+    const region = await screen.findByRole("log", { name: "Application log" });
+    expect(rendered(region)).toHaveLength(2);
+    expect(core.readAppLog).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not read anything in the browser, and says where the log lives", async () => {
+    core.isTauri.mockReturnValue(false);
+    render(<AppLog route="/logs" />);
+
+    expect(
+      screen.getByText("The application log is a file on the machine running srelens"),
+    ).toBeTruthy();
+    // Not merely "not yet" — nothing schedules a read on a later tick either.
+    await waitFor(() => expect(core.readAppLog).not.toHaveBeenCalled());
+    expect(core.appLogPath).not.toHaveBeenCalled();
+  });
+
+  it("reveals the log file in the file manager", async () => {
+    render(<AppLog route="/logs" />);
+    await screen.findByRole("log", { name: "Application log" });
+
+    await userEvent.click(screen.getByRole("button", { name: "Reveal" }));
+    expect(core.revealAppLog).toHaveBeenCalledTimes(1);
+  });
+
+  it("copies the log file's path to the clipboard", async () => {
+    const writeText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined);
+    // jsdom ships no clipboard at all, so there is nothing to spy on.
+    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+
+    render(<AppLog route="/logs" />);
+    await screen.findByRole("log", { name: "Application log" });
+
+    await userEvent.click(screen.getByRole("button", { name: "Copy path" }));
+    expect(writeText).toHaveBeenCalledWith(PATH);
+  });
+
+  it("filters by level", async () => {
+    render(<AppLog route="/logs" />);
+    const region = await screen.findByRole("log", { name: "Application log" });
+
+    await userEvent.selectOptions(screen.getByRole("combobox", { name: "Log level" }), "ERROR");
+    expect(rendered(region)).toEqual(["ERROR RBAC denied for Pods"]);
+  });
+
+  it("filters by text, and says when nothing matches", async () => {
+    render(<AppLog route="/logs" />);
+    const region = await screen.findByRole("log", { name: "Application log" });
+
+    const field = screen.getByRole("searchbox", { name: "Filter log lines" });
+    await userEvent.type(field, "rbac");
+    expect(rendered(region)).toEqual(["ERROR RBAC denied for Pods"]);
+
+    await userEvent.clear(field);
+    await userEvent.type(field, "no such line");
+    expect(screen.getByText("No lines match (showing at most 5 000)")).toBeTruthy();
+    expect(rendered(region)).toEqual([]);
+  });
+});

--- a/packages/ui-next/src/screens/AppLog.tsx
+++ b/packages/ui-next/src/screens/AppLog.tsx
@@ -1,5 +1,4 @@
 import { useMemo, useState } from "react";
-import { Copy, FolderOpen, RefreshCw } from "lucide-react";
 import { appLogPath, isTauri, readAppLog, revealAppLog } from "@srelens/core";
 import {
   EmptyState,
@@ -12,7 +11,8 @@ import {
   Select,
 } from "@srelens/ui-kit";
 import { useResource } from "../lib/useResource";
-import { LEVELS, MAX_RENDERED, filterLines, parseAppLog, type Level } from "../lib/appLogLines";
+import { Icons } from "../lib/icons";
+import { LEVELS, filterLines, parseAppLog, type Level } from "../lib/appLogLines";
 
 const LEVEL_OPTIONS = [
   { value: "all", label: "All levels" },
@@ -20,12 +20,13 @@ const LEVEL_OPTIONS = [
 ];
 
 /**
- * The cap, grouped the way the design writes numbers, derived from the cap
- * itself so the sentence and the slice cannot drift apart. Grouped by hand
- * rather than through `toLocaleString`, which would put a comma in it under one
- * locale and a full stop under another.
+ * Grouped the way the design writes numbers — a space every three digits, by
+ * hand rather than through `toLocaleString`, which would put a comma in it
+ * under one locale and a full stop under another.
  */
-const CAP_TEXT = String(MAX_RENDERED).replace(/\B(?=(\d{3})+(?!\d))/g, " ");
+function groupNumber(n: number): string {
+  return String(n).replace(/\B(?=(\d{3})+(?!\d))/g, " ");
+}
 
 /**
  * srelens's own log: the tail of the rotating file it writes as it runs,
@@ -42,10 +43,6 @@ const CAP_TEXT = String(MAX_RENDERED).replace(/\B(?=(\d{3})+(?!\d))/g, " ");
  * has no log to show and says so rather than failing a read: `isTauri` is
  * checked inside the loader as well as in the render, so the web branch never
  * so much as schedules a command the backend cannot answer.
- *
- * The three glyphs come straight from lucide rather than from the shell's
- * `Icons` map, which is the vocabulary of the chrome — the sidebar's kinds and
- * the titlebar's actions — and has no entry for refresh, copy or reveal.
  */
 export function AppLog(_props: { route: string }) {
   const [text, setText] = useState("");
@@ -64,7 +61,10 @@ export function AppLog(_props: { route: string }) {
 
   const [raw = "", path = ""] = log.data ?? [];
   const lines = useMemo(() => parseAppLog(raw), [raw]);
-  const filtered = useMemo(() => filterLines(lines, text, level), [lines, text, level]);
+  const { lines: filtered, total } = useMemo(
+    () => filterLines(lines, text, level),
+    [lines, text, level],
+  );
 
   async function copyPath() {
     try {
@@ -102,13 +102,13 @@ export function AppLog(_props: { route: string }) {
       actions={
         <>
           <IconButton
-            icon={RefreshCw}
+            icon={Icons.refresh}
             label="Refresh"
             onClick={log.reload}
             disabled={log.status === "loading"}
           />
           <IconButton
-            icon={Copy}
+            icon={Icons.copy}
             label="Copy path"
             // The name stays short; the tooltip says which path, since the
             // screen has nowhere else to show it.
@@ -116,7 +116,7 @@ export function AppLog(_props: { route: string }) {
             onClick={() => void copyPath()}
             disabled={!path}
           />
-          <IconButton icon={FolderOpen} label="Reveal" onClick={() => void revealAppLog()} />
+          <IconButton icon={Icons.reveal} label="Reveal" onClick={() => void revealAppLog()} />
         </>
       }
     >
@@ -154,14 +154,32 @@ export function AppLog(_props: { route: string }) {
               hint="srelens writes to this file as it runs; there is nothing in it so far."
             />
           ) : filtered.length === 0 ? (
-            <EmptyState title={`No lines match (showing at most ${CAP_TEXT})`} />
+            <EmptyState title="No lines match" />
           ) : (
-            filtered.map((line, i) => (
-              // The index is the key: two identical lines a second apart are
-              // ordinary in a log, so nothing in the entry is a stable
-              // identity, and the list is rebuilt whole on every filter change.
-              <LogLine key={i} ts={line.ts} level={line.level} message={line.message} />
-            ))
+            <>
+              {total > filtered.length && (
+                // The cap bit: more lines matched than fit on screen. Said
+                // here rather than folded into the empty state above, because
+                // this is the one place a truncated log must not look
+                // complete — silence here would be the same defect the empty
+                // state's wrong wording used to cause the other way round.
+                <div className="px-2.5 py-1 text-[0.75rem] text-muted">
+                  Showing the newest {groupNumber(filtered.length)} of {groupNumber(total)} lines
+                </div>
+              )}
+              {filtered.map((line, i) => (
+                // The index is the key: two identical lines a second apart are
+                // ordinary in a log, so nothing in the entry is a stable
+                // identity, and the list is rebuilt whole on every filter change.
+                <LogLine
+                  key={i}
+                  ts={line.ts}
+                  source={line.source}
+                  level={line.level}
+                  message={line.message}
+                />
+              ))}
+            </>
           )}
         </div>
       )}

--- a/packages/ui-next/src/screens/AppLog.tsx
+++ b/packages/ui-next/src/screens/AppLog.tsx
@@ -1,0 +1,170 @@
+import { useMemo, useState } from "react";
+import { Copy, FolderOpen, RefreshCw } from "lucide-react";
+import { appLogPath, isTauri, readAppLog, revealAppLog } from "@srelens/core";
+import {
+  EmptyState,
+  ErrorState,
+  FilterBar,
+  IconButton,
+  LoadingState,
+  LogLine,
+  Screen,
+  Select,
+} from "@srelens/ui-kit";
+import { useResource } from "../lib/useResource";
+import { LEVELS, MAX_RENDERED, filterLines, parseAppLog, type Level } from "../lib/appLogLines";
+
+const LEVEL_OPTIONS = [
+  { value: "all", label: "All levels" },
+  ...LEVELS.map((level) => ({ value: level, label: level })),
+];
+
+/**
+ * The cap, grouped the way the design writes numbers, derived from the cap
+ * itself so the sentence and the slice cannot drift apart. Grouped by hand
+ * rather than through `toLocaleString`, which would put a comma in it under one
+ * locale and a full stop under another.
+ */
+const CAP_TEXT = String(MAX_RENDERED).replace(/\B(?=(\d{3})+(?!\d))/g, " ");
+
+/**
+ * srelens's own log: the tail of the rotating file it writes as it runs,
+ * filtered by level and text, with a way to refresh it, copy its path, or open
+ * it where it lives.
+ *
+ * This is the screen someone reaches *after* something went wrong — a cluster
+ * that would not connect, an RBAC denial, a panic — so the load is deliberately
+ * unclever: read the whole tail on mount, filter it in memory, and offer a
+ * refresh rather than a tail-follow. Nothing here streams, because the
+ * interesting entry was written before the screen was opened.
+ *
+ * The file only exists where srelens itself is running, so the browser build
+ * has no log to show and says so rather than failing a read: `isTauri` is
+ * checked inside the loader as well as in the render, so the web branch never
+ * so much as schedules a command the backend cannot answer.
+ *
+ * The three glyphs come straight from lucide rather than from the shell's
+ * `Icons` map, which is the vocabulary of the chrome — the sidebar's kinds and
+ * the titlebar's actions — and has no entry for refresh, copy or reveal.
+ */
+export function AppLog(_props: { route: string }) {
+  const [text, setText] = useState("");
+  const [level, setLevel] = useState<Level | "all">("all");
+
+  // The path is fetched with the text, in one round trip, because both are
+  // needed the moment the screen settles and neither is worth its own state.
+  const log = useResource(
+    () =>
+      isTauri()
+        ? Promise.all([readAppLog(), appLogPath()])
+        : Promise.resolve<[string, string]>(["", ""]),
+    [],
+    ([raw]) => raw.trim() === "",
+  );
+
+  const [raw = "", path = ""] = log.data ?? [];
+  const lines = useMemo(() => parseAppLog(raw), [raw]);
+  const filtered = useMemo(() => filterLines(lines, text, level), [lines, text, level]);
+
+  async function copyPath() {
+    try {
+      await navigator.clipboard.writeText(path);
+    } catch {
+      // No clipboard on a non-secure origin, and nothing to recover: the path
+      // is one refresh away from being read off the reveal dialog instead.
+    }
+  }
+
+  if (!isTauri()) {
+    return (
+      <Screen title="Application log" eyebrow="srelens" fill>
+        <EmptyState
+          title="The application log is a file on the machine running srelens"
+          hint="Read it there — in a container, its output is what docker logs prints."
+          // `fill` hands the body the whole area and leaves the centring to
+          // whatever is in it; without this the card sits at the top edge.
+          className="flex-1"
+        />
+      </Screen>
+    );
+  }
+
+  // `log.status` is "empty" for a file with nothing in it, but the rendering
+  // branch is `lines.length`: a file holding only whitespace loads as "ready"
+  // and still has no entries to draw.
+  const loaded = log.status === "ready" || log.status === "empty";
+
+  return (
+    <Screen
+      title="Application log"
+      eyebrow="srelens"
+      fill
+      actions={
+        <>
+          <IconButton
+            icon={RefreshCw}
+            label="Refresh"
+            onClick={log.reload}
+            disabled={log.status === "loading"}
+          />
+          <IconButton
+            icon={Copy}
+            label="Copy path"
+            // The name stays short; the tooltip says which path, since the
+            // screen has nowhere else to show it.
+            title={path ? `Copy path (${path})` : "Copy path"}
+            onClick={() => void copyPath()}
+            disabled={!path}
+          />
+          <IconButton icon={FolderOpen} label="Reveal" onClick={() => void revealAppLog()} />
+        </>
+      }
+    >
+      <FilterBar
+        value={text}
+        onValueChange={setText}
+        label="Filter log lines"
+        placeholder="Filter log lines…"
+      >
+        <Select
+          value={level}
+          onValueChange={(value) => setLevel(value as Level | "all")}
+          options={LEVEL_OPTIONS}
+          aria-label="Log level"
+        />
+      </FilterBar>
+
+      {log.status === "loading" && <LoadingState label="Loading the log" />}
+      {log.status === "error" && (
+        <ErrorState
+          title="Could not read the application log"
+          detail={log.error}
+          onRetry={log.reload}
+        />
+      )}
+      {loaded && (
+        <div
+          role="log"
+          aria-label="Application log"
+          className="scroll min-h-0 flex-1 py-1 font-mono text-[0.75rem] leading-relaxed"
+        >
+          {lines.length === 0 ? (
+            <EmptyState
+              title="No log entries yet"
+              hint="srelens writes to this file as it runs; there is nothing in it so far."
+            />
+          ) : filtered.length === 0 ? (
+            <EmptyState title={`No lines match (showing at most ${CAP_TEXT})`} />
+          ) : (
+            filtered.map((line, i) => (
+              // The index is the key: two identical lines a second apart are
+              // ordinary in a log, so nothing in the entry is a stable
+              // identity, and the list is rebuilt whole on every filter change.
+              <LogLine key={i} ts={line.ts} level={line.level} message={line.message} />
+            ))
+          )}
+        </div>
+      )}
+    </Screen>
+  );
+}

--- a/packages/ui-next/src/screens/Notes.test.tsx
+++ b/packages/ui-next/src/screens/Notes.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { parseReleaseNotes } from "@srelens/core";
+
+import { Notes } from "./Notes";
+
+// The parser is core's and has its own tests; what these check is the markup it
+// turns into — real headings, lists and paragraphs rather than a dump of the
+// raw text, and never markup built from the note text itself.
+
+describe("Notes", () => {
+  it("renders a heading as an h3", () => {
+    render(<Notes blocks={parseReleaseNotes("### What's new")} />);
+    expect(screen.getByRole("heading", { level: 3, name: "What's new" })).toBeDefined();
+  });
+
+  it("renders bullets as a list with one item each", () => {
+    const { container } = render(<Notes blocks={parseReleaseNotes("- one\n- two")} />);
+    const lists = container.querySelectorAll("ul");
+    expect(lists.length).toBe(1);
+    const items = [...lists[0].querySelectorAll("li")].map((li) => li.textContent);
+    expect(items).toEqual(["one", "two"]);
+  });
+
+  it("renders prose as a paragraph", () => {
+    const { container } = render(<Notes blocks={parseReleaseNotes("A plain line.")} />);
+    const paragraphs = [...container.querySelectorAll("p")].map((p) => p.textContent);
+    expect(paragraphs).toEqual(["A plain line."]);
+  });
+
+  it("renders a code span as a code element", () => {
+    const { container } = render(<Notes blocks={parseReleaseNotes("`x`")} />);
+    expect(container.innerHTML).toContain("<code>x</code>");
+  });
+
+  it("renders a bold span as a strong element", () => {
+    const { container } = render(<Notes blocks={parseReleaseNotes("**loud**")} />);
+    expect(container.innerHTML).toContain("<strong>loud</strong>");
+  });
+
+  it("keeps the text around a span, in order", () => {
+    const { container } = render(<Notes blocks={parseReleaseNotes("run `kubectl` now")} />);
+    expect(container.querySelector("p")?.textContent).toBe("run kubectl now");
+  });
+
+  it("renders markup in the notes as text, never as markup", () => {
+    const { container } = render(
+      <Notes blocks={parseReleaseNotes("Fixed <script>alert(1)</script> handling")} />,
+    );
+    expect(container.querySelector("script")).toBeNull();
+    expect(container.innerHTML).toContain("&lt;script&gt;");
+    expect(screen.getByText(/Fixed <script>alert\(1\)<\/script> handling/)).toBeDefined();
+  });
+
+  it("renders nothing when there are no blocks", () => {
+    const { container } = render(<Notes blocks={[]} />);
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/packages/ui-next/src/screens/Notes.tsx
+++ b/packages/ui-next/src/screens/Notes.tsx
@@ -1,0 +1,69 @@
+import { Fragment } from "react";
+import type { NoteBlock, NoteSpan } from "@srelens/core";
+
+/**
+ * The inline runs of one line. Plain text is a bare string rather than a
+ * wrapper element: a `<span>` per run would say nothing to a reader or to
+ * assistive technology, and it would put an element between `<code>` and the
+ * words around it for no reason.
+ */
+function Spans({ spans }: { spans: NoteSpan[] }) {
+  return (
+    <>
+      {spans.map((span, i) => {
+        if (span.kind === "code") return <code key={i}>{span.text}</code>;
+        if (span.kind === "strong") return <strong key={i}>{span.text}</strong>;
+        return <Fragment key={i}>{span.text}</Fragment>;
+      })}
+    </>
+  );
+}
+
+/**
+ * Release-note blocks as prose.
+ *
+ * Content markup, not a component of the design system: headings, lists and
+ * paragraphs are what the notes *are*, and the kit has no component that means
+ * "a paragraph of someone else's text". The elements are the semantic ones so
+ * the notes keep their outline — a reader navigating by heading finds the
+ * sections — and `h3` because the screen's title is the `h1` and these sit
+ * under it.
+ *
+ * Every span goes through React elements, never `dangerouslySetInnerHTML`, so
+ * angle brackets in a hand-edited GitHub release body render as the characters
+ * they are and cannot inject markup. The keys are indices because the blocks
+ * are a pure function of the note text: nothing reorders them, and there is no
+ * identity in them to key on.
+ */
+export function Notes({ blocks }: { blocks: NoteBlock[] }) {
+  if (blocks.length === 0) return null;
+  return (
+    <div className="flex flex-col gap-2 text-[0.8125rem] leading-relaxed">
+      {blocks.map((block, i) => {
+        if (block.kind === "heading") {
+          return (
+            <h3 key={i} className="mt-1 text-[0.875rem] font-medium">
+              <Spans spans={block.spans} />
+            </h3>
+          );
+        }
+        if (block.kind === "list") {
+          return (
+            <ul key={i} className="flex list-disc flex-col gap-1 pl-5">
+              {block.items.map((item, j) => (
+                <li key={j}>
+                  <Spans spans={item} />
+                </li>
+              ))}
+            </ul>
+          );
+        }
+        return (
+          <p key={i} className="text-muted">
+            <Spans spans={block.spans} />
+          </p>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/ui-next/src/screens/ReleaseNotes.test.tsx
+++ b/packages/ui-next/src/screens/ReleaseNotes.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { UpdateMeta } from "@srelens/core";
+
+const checkForUpdate = vi.fn();
+const installUpdate = vi.fn();
+const appVersion = vi.fn();
+const loadUpdateChannel = vi.fn();
+const isTauri = vi.fn();
+
+// Everything this screen does is a call into core; the screen is what is under
+// test, so core is a set of doubles.
+vi.mock("@srelens/core", async (orig) => ({
+  ...(await orig<typeof import("@srelens/core")>()),
+  checkForUpdate: (...args: unknown[]) => checkForUpdate(...args),
+  installUpdate: (...args: unknown[]) => installUpdate(...args),
+  appVersion: () => appVersion(),
+  loadUpdateChannel: () => loadUpdateChannel(),
+  isTauri: () => isTauri(),
+}));
+
+import { ReleaseNotes } from "./ReleaseNotes";
+
+const update = (over: Partial<UpdateMeta> = {}): UpdateMeta => ({
+  version: "0.8.0",
+  currentVersion: "0.7.2",
+  notes: "### Fixed\n- a crash on start",
+  external: false,
+  elevates: false,
+  ...over,
+});
+
+beforeEach(() => {
+  checkForUpdate.mockReset().mockResolvedValue(null);
+  installUpdate.mockReset().mockResolvedValue(undefined);
+  appVersion.mockReset().mockResolvedValue("0.7.2");
+  loadUpdateChannel.mockReset().mockReturnValue("stable");
+  isTauri.mockReset().mockReturnValue(true);
+});
+
+describe("ReleaseNotes", () => {
+  it("says which version is installed when there is no update", async () => {
+    render(<ReleaseNotes route="/release-notes" />);
+
+    expect(await screen.findByText("srelens is up to date")).toBeDefined();
+    expect(screen.getByText("Version 0.7.2")).toBeDefined();
+    expect(checkForUpdate).toHaveBeenCalledWith("stable");
+  });
+
+  it("renders the available version, its notes and an install button", async () => {
+    checkForUpdate.mockResolvedValue(update());
+    render(<ReleaseNotes route="/release-notes" />);
+
+    expect(await screen.findByText("Update to 0.8.0")).toBeDefined();
+    expect(screen.getByRole("heading", { level: 3, name: "Fixed" })).toBeDefined();
+    expect(screen.getByText("a crash on start")).toBeDefined();
+    expect(screen.getByRole("button", { name: /install/i })).toBeDefined();
+  });
+
+  it("installs on the stored channel and shows the progress it reports", async () => {
+    loadUpdateChannel.mockReturnValue("dev");
+    checkForUpdate.mockResolvedValue(update());
+    let report!: (percent: number | null) => void;
+    let finish!: () => void;
+    installUpdate.mockImplementation(
+      (_channel: unknown, onProgress: (percent: number | null) => void) =>
+        new Promise<void>((resolve) => {
+          report = onProgress;
+          finish = resolve;
+        }),
+    );
+    render(<ReleaseNotes route="/release-notes" />);
+
+    await userEvent.click(await screen.findByRole("button", { name: /install/i }));
+    expect(installUpdate).toHaveBeenCalledWith("dev", expect.any(Function));
+
+    await act(async () => report(42));
+    expect(screen.getByText("Installing… 42%")).toBeDefined();
+    expect(screen.getByRole("progressbar").getAttribute("aria-valuenow")).toBe("42");
+
+    await act(async () => {
+      finish();
+    });
+    expect(screen.getByText("Restart srelens to finish")).toBeDefined();
+    expect(screen.queryByRole("progressbar")).toBeNull();
+  });
+
+  it("offers no install when a package manager owns the install", async () => {
+    checkForUpdate.mockResolvedValue(update({ external: true }));
+    render(<ReleaseNotes route="/release-notes" />);
+
+    expect(
+      await screen.findByText("Installed by your package manager — update it there"),
+    ).toBeDefined();
+    expect(screen.queryByRole("button", { name: /install/i })).toBeNull();
+  });
+
+  it("warns before the install asks for a password", async () => {
+    checkForUpdate.mockResolvedValue(update({ elevates: true }));
+    render(<ReleaseNotes route="/release-notes" />);
+
+    expect(await screen.findByText("srelens will ask for your password")).toBeDefined();
+    expect(screen.getByRole("button", { name: /install/i })).toBeDefined();
+  });
+
+  it("shows the failure and checks again on retry", async () => {
+    checkForUpdate.mockRejectedValueOnce(new Error("network is unreachable"));
+    render(<ReleaseNotes route="/release-notes" />);
+
+    expect(await screen.findByRole("alert")).toBeDefined();
+    expect(screen.getByText("network is unreachable")).toBeDefined();
+
+    checkForUpdate.mockResolvedValue(update());
+    await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+
+    expect(await screen.findByText("Update to 0.8.0")).toBeDefined();
+    expect(checkForUpdate).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports an install that failed", async () => {
+    checkForUpdate.mockResolvedValue(update());
+    installUpdate.mockRejectedValue(new Error("no space left on device"));
+    render(<ReleaseNotes route="/release-notes" />);
+
+    await userEvent.click(await screen.findByRole("button", { name: /install/i }));
+
+    expect(await screen.findByText(/no space left on device/)).toBeDefined();
+    expect(screen.getByRole("button", { name: /install/i }).hasAttribute("disabled")).toBe(false);
+  });
+
+  it("leaves updates to the server in web mode", async () => {
+    isTauri.mockReturnValue(false);
+    render(<ReleaseNotes route="/release-notes" />);
+
+    expect(await screen.findByText("Updates are managed by the server")).toBeDefined();
+    expect(checkForUpdate).not.toHaveBeenCalled();
+    expect(screen.queryByRole("button", { name: /install/i })).toBeNull();
+  });
+});

--- a/packages/ui-next/src/screens/ReleaseNotes.tsx
+++ b/packages/ui-next/src/screens/ReleaseNotes.tsx
@@ -1,0 +1,143 @@
+import { useMemo, useState } from "react";
+import { Button, EmptyState, ErrorState, LoadingState, Progress, Screen } from "@srelens/ui-kit";
+import {
+  appVersion,
+  checkForUpdate,
+  installUpdate,
+  isTauri,
+  loadUpdateChannel,
+  parseReleaseNotes,
+  type UpdateMeta,
+} from "@srelens/core";
+import { useResource } from "../lib/useResource";
+import { Notes } from "./Notes";
+
+/** Where the install has got to. `percent` is null until a total size arrives. */
+type Install =
+  | { phase: "idle" }
+  | { phase: "installing"; percent: number | null }
+  | { phase: "done" }
+  | { phase: "failed"; message: string };
+
+/**
+ * What is in the update that is waiting, and the button that takes it.
+ *
+ * The check runs on mount rather than behind a "check now" button: the screen
+ * exists to answer one question, and making the user ask it twice — once by
+ * opening the screen, once by clicking — buys nothing. `useResource` owns the
+ * four states so a failed check offers a retry instead of an empty page.
+ *
+ * The installed version comes from the update's own `currentVersion` whenever
+ * there is an update, and only falls back to `appVersion()` when there is
+ * none: the updater already told us what it compared against, and a second
+ * round trip to ask the same question could answer differently.
+ *
+ * `route` is part of every screen's shape; this one has a single route and
+ * nothing to read out of it, so the prop is accepted and unused.
+ */
+export function ReleaseNotes(_props: { route: string }) {
+  // The server owns updates in web mode, so there is nothing here to check —
+  // and `update_check` is a desktop capability that would fail if we asked.
+  const web = !isTauri();
+  // Read once: the channel is a setting, and re-reading it every render would
+  // put a new value into the loader's dependencies on every render.
+  const channel = useMemo(() => loadUpdateChannel(), []);
+  const [install, setInstall] = useState<Install>({ phase: "idle" });
+
+  const found = useResource(
+    async () => {
+      if (web) return { update: null as UpdateMeta | null, current: "" };
+      const update = await checkForUpdate(channel);
+      return { update, current: update ? update.currentVersion : await appVersion() };
+    },
+    [web, channel],
+    (v) => v.update === null,
+  );
+
+  // Only a ready load carries data, so this is null in every other state.
+  const update = web ? null : (found.data?.update ?? null);
+
+  const start = async () => {
+    setInstall({ phase: "installing", percent: null });
+    try {
+      await installUpdate(channel, (percent) => setInstall({ phase: "installing", percent }));
+      setInstall({ phase: "done" });
+    } catch (cause) {
+      setInstall({
+        phase: "failed",
+        message: cause instanceof Error ? cause.message : String(cause),
+      });
+    }
+  };
+
+  return (
+    <Screen
+      title="Release notes"
+      eyebrow={update ? `Update to ${update.version}` : undefined}
+      description={update ? `You are on ${update.currentVersion}.` : undefined}
+    >
+      {web ? (
+        <EmptyState
+          title="Updates are managed by the server"
+          hint="srelens changes version when whoever runs it deploys a new one."
+        />
+      ) : found.status === "loading" ? (
+        <LoadingState label="Checking for updates" />
+      ) : found.status === "error" ? (
+        <ErrorState
+          title="Could not check for updates"
+          detail={found.error}
+          onRetry={found.reload}
+        />
+      ) : !update ? (
+        <EmptyState
+          title="srelens is up to date"
+          hint={found.data ? `Version ${found.data.current}` : undefined}
+        />
+      ) : (
+        <div className="flex flex-col gap-3">
+          <Notes blocks={parseReleaseNotes(update.notes)} />
+          {update.external ? (
+            // Nothing to press: the installed copy belongs to a package
+            // manager the updater cannot drive.
+            <p className="text-[0.8125rem] text-muted">
+              Installed by your package manager — update it there
+            </p>
+          ) : (
+            <div className="flex flex-col items-start gap-2">
+              {update.elevates && (
+                <p className="text-[0.8125rem] text-muted">srelens will ask for your password</p>
+              )}
+              <Button
+                type="button"
+                variant="primary"
+                disabled={install.phase === "installing" || install.phase === "done"}
+                onClick={() => void start()}
+              >
+                Install
+              </Button>
+            </div>
+          )}
+          {install.phase === "installing" && (
+            <div className="flex max-w-[320px] flex-col gap-1.5">
+              <p className="text-[0.8125rem] text-muted">
+                {install.percent === null ? "Installing…" : `Installing… ${install.percent}%`}
+              </p>
+              {install.percent !== null && (
+                <Progress value={install.percent} ariaLabel="Installing update" />
+              )}
+            </div>
+          )}
+          {install.phase === "done" && (
+            <p className="text-[0.8125rem]">Restart srelens to finish</p>
+          )}
+          {install.phase === "failed" && (
+            <p role="alert" className="text-[0.8125rem] text-sev">
+              Install failed: {install.message}
+            </p>
+          )}
+        </div>
+      )}
+    </Screen>
+  );
+}

--- a/packages/ui-next/src/shell/Chrome.test.tsx
+++ b/packages/ui-next/src/shell/Chrome.test.tsx
@@ -93,6 +93,16 @@ describe("Chrome", () => {
     expect(document.querySelector("[data-native-lights]")).toBeNull();
   });
 
+  it("never doubles up: a caller asking the kit for the picture under Tauri+Apple gets no gap too", () => {
+    // `controls="macos"` under real Tauri on Apple asks the kit to draw its
+    // own three lights. If the gap were derived independently of `controls`,
+    // this is exactly the case that redraws both — the doubling `ec024b5`
+    // exists to remove. desktop/platform default to true in beforeEach.
+    chrome({ controls: "macos" });
+    expect(document.querySelector("[data-native-lights]")).toBeNull();
+    expect(document.querySelectorAll("[data-light]")).toHaveLength(3);
+  });
+
   it("zooms through uiScale", async () => {
     chrome();
     await userEvent.click(screen.getByRole("button", { name: "Zoom in" }));

--- a/packages/ui-next/src/shell/Chrome.test.tsx
+++ b/packages/ui-next/src/shell/Chrome.test.tsx
@@ -9,6 +9,7 @@ import {
   openTab,
   setState,
   switchWorkspace,
+  togglePin,
 } from "../lib/tabsStore";
 import { defaultState } from "../lib/tabs";
 
@@ -103,6 +104,22 @@ describe("Chrome", () => {
     await userEvent.click(screen.getByRole("button", { name: /Remove Team/ }));
     expect(screen.queryByRole("dialog", { name: /Remove Team/ })).toBeNull();
     expect(getState().workspaces.some((w) => w.id === id)).toBe(false);
+  });
+
+  it("still asks when the tabs the user opened have been pinned", async () => {
+    // Pinning is the user saying a tab matters. A rule that skipped the
+    // question when every tab was pinned dropped exactly the tabs someone had
+    // marked as worth keeping, silently and with no undo. Only the seeded home
+    // tab — the single tab a workspace is born with — is nothing to lose.
+    const id = createWorkspace("Team", ["prod"]);
+    openTab("/k/pods");
+    togglePin(currentWorkspace().activeId);
+    switchWorkspace(getState().workspaces[0].id);
+    chrome();
+    await openSwitcher();
+    await userEvent.click(screen.getByRole("button", { name: /Remove Team/ }));
+    expect(screen.getByRole("dialog", { name: /Remove Team/ })).toBeDefined();
+    expect(getState().workspaces.some((w) => w.id === id)).toBe(true);
   });
 
   it("keeps the workspace when the confirmation is dismissed", async () => {

--- a/packages/ui-next/src/shell/Chrome.test.tsx
+++ b/packages/ui-next/src/shell/Chrome.test.tsx
@@ -28,9 +28,10 @@ if (!("ResizeObserver" in globalThis)) {
 // zoom. Both are mocked: this suite is about the buttons calling the right
 // thing with the right number, and `stepUiScale` stays real so the number is
 // the one the app would use.
-const { scale, desktop } = vi.hoisted(() => ({
+const { scale, desktop, platform } = vi.hoisted(() => ({
   scale: { get: vi.fn(() => 100), set: vi.fn((n: number) => n), apply: vi.fn() },
   desktop: vi.fn(() => true),
+  platform: vi.fn(() => true),
 }));
 vi.mock("@srelens/core", async (orig) => ({
   ...(await orig<typeof import("@srelens/core")>()),
@@ -38,6 +39,7 @@ vi.mock("@srelens/core", async (orig) => ({
   setUiScale: scale.set,
   applyUiScale: scale.apply,
   isTauri: desktop,
+  isApplePlatform: platform,
 }));
 
 const ctx = (id: string) => ({ name: id, stableId: id, cluster: id, server: "", isCurrent: false });
@@ -48,6 +50,7 @@ beforeEach(() => {
   // `clearAllMocks` forgets the calls, not the implementations — so a test that
   // asked for web mode would leak into the next one without this.
   desktop.mockReturnValue(true);
+  platform.mockReturnValue(true);
 });
 
 const chrome = (props: Partial<Parameters<typeof Chrome>[0]> = {}) =>
@@ -64,6 +67,30 @@ describe("Chrome", () => {
     chrome({ clusterName: "prod" });
     expect(screen.getByRole("button", { name: /Default/ })).toBeDefined();
     expect(screen.getByText("prod")).toBeDefined();
+  });
+
+  it("leaves room for the real traffic lights the overlay keeps", () => {
+    // Found on a real machine: with an overlay titlebar, macOS's own traffic
+    // lights stay and the painted ones doubled them. Under the overlay this
+    // bar paints none and starts its content past the natives instead.
+    chrome({ controls: "none" });
+    const gap = document.querySelector("[data-native-lights]");
+    expect(gap).not.toBeNull();
+    expect(gap?.hasAttribute("data-tauri-drag-region")).toBe(true);
+  });
+
+  it("paints the picture only where no real window has lights", () => {
+    // An Apple browser: no native lights in the page, so the kit's picture
+    // shows and the gap has nothing to clear.
+    desktop.mockReturnValue(false);
+    chrome({ controls: "macos" });
+    expect(document.querySelector("[data-native-lights]")).toBeNull();
+  });
+
+  it("gives a non-Apple window neither picture nor gap", () => {
+    platform.mockReturnValue(false);
+    chrome({ controls: "none" });
+    expect(document.querySelector("[data-native-lights]")).toBeNull();
   });
 
   it("zooms through uiScale", async () => {

--- a/packages/ui-next/src/shell/Chrome.test.tsx
+++ b/packages/ui-next/src/shell/Chrome.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Chrome } from "./Chrome";
+import {
+  createWorkspace,
+  currentWorkspace,
+  getState,
+  openTab,
+  setState,
+  switchWorkspace,
+} from "../lib/tabsStore";
+import { defaultState } from "../lib/tabs";
+
+// jsdom has no ResizeObserver and Radix's popper watches the trigger with one.
+// The same stub the kit's Radix-backed suites carry, kept here rather than in
+// the shared setup so the requirement stays visible.
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
+// Scale is core's, and core's writes it to storage and asks the webview to
+// zoom. Both are mocked: this suite is about the buttons calling the right
+// thing with the right number, and `stepUiScale` stays real so the number is
+// the one the app would use.
+const { scale, desktop } = vi.hoisted(() => ({
+  scale: { get: vi.fn(() => 100), set: vi.fn((n: number) => n), apply: vi.fn() },
+  desktop: vi.fn(() => true),
+}));
+vi.mock("@srelens/core", async (orig) => ({
+  ...(await orig<typeof import("@srelens/core")>()),
+  getUiScale: scale.get,
+  setUiScale: scale.set,
+  applyUiScale: scale.apply,
+  isTauri: desktop,
+}));
+
+const ctx = (id: string) => ({ name: id, stableId: id, cluster: id, server: "", isCurrent: false });
+
+beforeEach(() => {
+  setState(defaultState([ctx("prod")]));
+  vi.clearAllMocks();
+  // `clearAllMocks` forgets the calls, not the implementations — so a test that
+  // asked for web mode would leak into the next one without this.
+  desktop.mockReturnValue(true);
+});
+
+const chrome = (props: Partial<Parameters<typeof Chrome>[0]> = {}) =>
+  render(<Chrome controls="none" onToggleTheme={() => {}} onNewWorkspace={() => {}} {...props} />);
+
+/** The chip is the first button in the bar; the panel is portalled after it. */
+const openSwitcher = async () => {
+  await userEvent.click(screen.getByRole("button", { name: /Default/ }));
+  await screen.findByRole("dialog", { name: "Workspaces" });
+};
+
+describe("Chrome", () => {
+  it("names the workspace and the active cluster in the bar", () => {
+    chrome({ clusterName: "prod" });
+    expect(screen.getByRole("button", { name: /Default/ })).toBeDefined();
+    expect(screen.getByText("prod")).toBeDefined();
+  });
+
+  it("zooms through uiScale", async () => {
+    chrome();
+    await userEvent.click(screen.getByRole("button", { name: "Zoom in" }));
+    expect(scale.set).toHaveBeenCalledWith(110);
+    expect(scale.apply).toHaveBeenCalledWith(110);
+  });
+
+  it("switches workspaces from the switcher", async () => {
+    const id = createWorkspace("Team", ["prod"]);
+    setState({ ...getState(), currentId: getState().workspaces[0].id });
+    chrome();
+    await openSwitcher();
+    await userEvent.click(screen.getByRole("button", { name: /^Team/ }));
+    expect(currentWorkspace().id).toBe(id);
+  });
+
+  it("asks before removing a workspace holding tabs the user opened", async () => {
+    const id = createWorkspace("Team", ["prod"]);
+    // `createWorkspace` switches into it, so this tab lands in Team.
+    openTab("/k/pods");
+    switchWorkspace(getState().workspaces[0].id);
+    chrome();
+    await openSwitcher();
+    await userEvent.click(screen.getByRole("button", { name: /Remove Team/ }));
+    expect(screen.getByRole("dialog", { name: /Remove Team/ })).toBeDefined();
+    await userEvent.click(screen.getByRole("button", { name: "Remove" }));
+    expect(getState().workspaces.some((w) => w.id === id)).toBe(false);
+  });
+
+  it("removes a workspace holding only its pinned home tab without asking", async () => {
+    // Nothing to lose: a question here is a question about nothing.
+    const id = createWorkspace("Team", ["prod"]);
+    switchWorkspace(getState().workspaces[0].id);
+    chrome();
+    await openSwitcher();
+    await userEvent.click(screen.getByRole("button", { name: /Remove Team/ }));
+    expect(screen.queryByRole("dialog", { name: /Remove Team/ })).toBeNull();
+    expect(getState().workspaces.some((w) => w.id === id)).toBe(false);
+  });
+
+  it("keeps the workspace when the confirmation is dismissed", async () => {
+    const id = createWorkspace("Team", ["prod"]);
+    openTab("/k/pods");
+    switchWorkspace(getState().workspaces[0].id);
+    chrome();
+    await openSwitcher();
+    await userEvent.click(screen.getByRole("button", { name: /Remove Team/ }));
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: /Remove Team/ })).toBeNull());
+    expect(getState().workspaces.some((w) => w.id === id)).toBe(true);
+  });
+
+  it("offers no zoom controls in web mode, where the browser's own zoom applies", () => {
+    desktop.mockReturnValue(false);
+    chrome();
+    expect(screen.queryByRole("button", { name: "Zoom in" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Theme" })).toBeDefined();
+  });
+
+  it("opens Settings from the appearance action and calls the theme toggle", async () => {
+    const onToggleTheme = vi.fn();
+    chrome({ onToggleTheme });
+    await userEvent.click(screen.getByRole("button", { name: "Theme" }));
+    expect(onToggleTheme).toHaveBeenCalled();
+    await userEvent.click(screen.getByRole("button", { name: "Appearance settings" }));
+    expect(currentWorkspace().tabs.some((t) => t.route === "/settings")).toBe(true);
+  });
+
+  it("asks the switcher for a new workspace rather than making one itself", async () => {
+    const onNewWorkspace = vi.fn();
+    chrome({ onNewWorkspace });
+    await openSwitcher();
+    await userEvent.click(screen.getByRole("button", { name: "New workspace" }));
+    expect(onNewWorkspace).toHaveBeenCalledTimes(1);
+    expect(getState().workspaces).toHaveLength(1);
+  });
+});

--- a/packages/ui-next/src/shell/Chrome.tsx
+++ b/packages/ui-next/src/shell/Chrome.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { ConfirmDialog, IconButton, Titlebar, WorkspaceSwitcher } from "@srelens/ui-kit";
-import { applyUiScale, getUiScale, isTauri, setUiScale, stepUiScale } from "@srelens/core";
+import { applyUiScale, getUiScale, isApplePlatform, isTauri, setUiScale, stepUiScale } from "@srelens/core";
 import { Icons } from "../lib/icons";
 import { openTab, removeWorkspace, switchWorkspace, useTabs } from "../lib/tabsStore";
 
@@ -62,6 +62,11 @@ export function Chrome({ controls, clusterName, onToggleTheme, onNewWorkspace }:
   // in its message would otherwise be whatever it was when the dialog opened.
   const target = workspaces.find((w) => w.id === removing) ?? null;
   const desktop = isTauri();
+  // The overlay titlebar keeps macOS's real traffic lights. Painting the
+  // picture too drew two sets on a real machine (found in smoke testing), so
+  // the caller never asks for the picture here, and this bar clears the
+  // natives with a gap that drags like the rest of the bare titlebar.
+  const nativeLights = desktop && isApplePlatform();
 
   function askRemove(id: string) {
     const w = workspaces.find((x) => x.id === id);
@@ -78,19 +83,27 @@ export function Chrome({ controls, clusterName, onToggleTheme, onNewWorkspace }:
         controls={controls}
         label="Window"
         leading={
-          <WorkspaceSwitcher
-            icon={Icons.workspace}
-            workspaces={workspaces.map((w) => ({
-              id: w.id,
-              name: w.name,
-              clusters: w.clusters.length,
-              tabs: w.tabs.length,
-            }))}
-            activeId={workspace.id}
-            onSelect={switchWorkspace}
-            onRemove={askRemove}
-            onCreate={onNewWorkspace}
-          />
+          <>
+            {nativeLights && (
+              // Clears macOS's own traffic lights, which the overlay keeps.
+              // Carries the drag attribute so the dead space they leave still
+              // moves the window.
+              <span aria-hidden data-native-lights data-tauri-drag-region className="w-16 shrink-0 self-stretch" />
+            )}
+            <WorkspaceSwitcher
+              icon={Icons.workspace}
+              workspaces={workspaces.map((w) => ({
+                id: w.id,
+                name: w.name,
+                clusters: w.clusters.length,
+                tabs: w.tabs.length,
+              }))}
+              activeId={workspace.id}
+              onSelect={switchWorkspace}
+              onRemove={askRemove}
+              onCreate={onNewWorkspace}
+            />
+          </>
         }
         title={clusterName ?? "srelens"}
         actions={

--- a/packages/ui-next/src/shell/Chrome.tsx
+++ b/packages/ui-next/src/shell/Chrome.tsx
@@ -38,12 +38,17 @@ export function zoom(action: "in" | "out" | "reset") {
  *
  * That decision is the only judgement in the file. Removing a workspace has no
  * undo and takes every tab in it, so it asks — except when there is nothing to
- * ask about. A freshly created workspace holds exactly one tab, the pinned home
- * tab that every workspace is seeded with and that no close path will remove;
- * confirming the loss of a tab that was never opened and cannot be closed is a
- * dialog about nothing, and a dialog about nothing is what teaches people to
- * dismiss the ones that matter. So `every(t => t.pinned)` removes outright and
- * anything else confirms first.
+ * ask about. A workspace is seeded with exactly one tab, the pinned home tab it
+ * is born with; confirming the loss of a tab that was never opened is a dialog
+ * about nothing, and a dialog about nothing is what teaches people to dismiss
+ * the ones that matter. So one tab removes outright and anything else confirms.
+ *
+ * The test is the count, deliberately, and not "every tab is pinned" — which is
+ * what this first read as. Pinning is `togglePin`, a thing the user does to say
+ * a tab matters, so a workspace whose tabs had all been pinned was the case
+ * most worth asking about and the one that skipped the question: the tabs
+ * someone had marked as worth keeping went silently, with no undo, on the exact
+ * path the confirmation exists to guard.
  *
  * The zoom controls are desktop-only. `applyUiScale` asks the webview to zoom;
  * in web mode there is no webview to ask, the browser's own zoom already does
@@ -61,7 +66,7 @@ export function Chrome({ controls, clusterName, onToggleTheme, onNewWorkspace }:
   function askRemove(id: string) {
     const w = workspaces.find((x) => x.id === id);
     if (!w) return;
-    if (w.tabs.every((t) => t.pinned)) removeWorkspace(id);
+    if (w.tabs.length <= 1) removeWorkspace(id);
     else setRemoving(id);
   }
 

--- a/packages/ui-next/src/shell/Chrome.tsx
+++ b/packages/ui-next/src/shell/Chrome.tsx
@@ -1,0 +1,116 @@
+import { useState } from "react";
+import { ConfirmDialog, IconButton, Titlebar, WorkspaceSwitcher } from "@srelens/ui-kit";
+import { applyUiScale, getUiScale, isTauri, setUiScale, stepUiScale } from "@srelens/core";
+import { Icons } from "../lib/icons";
+import { openTab, removeWorkspace, switchWorkspace, useTabs } from "../lib/tabsStore";
+
+export interface ChromeProps {
+  controls: "macos" | "none";
+  /** The active cluster's display name — what this window is looking at. */
+  clusterName?: string;
+  onToggleTheme: () => void;
+  /** The window owns the create dialog; the chip only asks for it. */
+  onNewWorkspace: () => void;
+}
+
+/**
+ * Read, stepped, stored and applied in one place.
+ *
+ * Exported because the titlebar is not the only thing that zooms: the window
+ * binds Cmd/Ctrl +/-/0 to the same three actions, and two copies of this would
+ * be two chances for the keyboard and the buttons to disagree about what a step
+ * is or whether it was persisted. `setUiScale` clamps and returns what it
+ * stored, so what gets applied is what was saved rather than what was asked
+ * for — at the ends of the range those differ.
+ */
+export function zoom(action: "in" | "out" | "reset") {
+  const next = setUiScale(stepUiScale(getUiScale(), action));
+  applyUiScale(next);
+}
+
+/**
+ * The bar across the top of the window: which workspace you are in, which
+ * cluster this window is looking at, and the actions that act on the window.
+ *
+ * Everything visual is the kit's; what lives here is the wiring the kit is not
+ * allowed to know — the tab store, the scale in core's settings, and the
+ * decision about whether removing a workspace deserves a question.
+ *
+ * That decision is the only judgement in the file. Removing a workspace has no
+ * undo and takes every tab in it, so it asks — except when there is nothing to
+ * ask about. A freshly created workspace holds exactly one tab, the pinned home
+ * tab that every workspace is seeded with and that no close path will remove;
+ * confirming the loss of a tab that was never opened and cannot be closed is a
+ * dialog about nothing, and a dialog about nothing is what teaches people to
+ * dismiss the ones that matter. So `every(t => t.pinned)` removes outright and
+ * anything else confirms first.
+ *
+ * The zoom controls are desktop-only. `applyUiScale` asks the webview to zoom;
+ * in web mode there is no webview to ask, the browser's own zoom already does
+ * this, and three buttons that quietly do nothing are worse than three buttons
+ * that are not there.
+ */
+export function Chrome({ controls, clusterName, onToggleTheme, onNewWorkspace }: ChromeProps) {
+  const { workspace, workspaces } = useTabs();
+  const [removing, setRemoving] = useState<string | null>(null);
+  // Found rather than held, so the dialog reads the live workspace: the count
+  // in its message would otherwise be whatever it was when the dialog opened.
+  const target = workspaces.find((w) => w.id === removing) ?? null;
+  const desktop = isTauri();
+
+  function askRemove(id: string) {
+    const w = workspaces.find((x) => x.id === id);
+    if (!w) return;
+    if (w.tabs.every((t) => t.pinned)) removeWorkspace(id);
+    else setRemoving(id);
+  }
+
+  const openTabs = target ? target.tabs.length : 0;
+
+  return (
+    <>
+      <Titlebar
+        controls={controls}
+        label="Window"
+        leading={
+          <WorkspaceSwitcher
+            icon={Icons.workspace}
+            workspaces={workspaces.map((w) => ({
+              id: w.id,
+              name: w.name,
+              clusters: w.clusters.length,
+              tabs: w.tabs.length,
+            }))}
+            activeId={workspace.id}
+            onSelect={switchWorkspace}
+            onRemove={askRemove}
+            onCreate={onNewWorkspace}
+          />
+        }
+        title={clusterName ?? "srelens"}
+        actions={
+          <>
+            {desktop && <IconButton icon={Icons.zoomOut} label="Zoom out" onClick={() => zoom("out")} />}
+            {desktop && <IconButton icon={Icons.zoomReset} label="Reset zoom" onClick={() => zoom("reset")} />}
+            {desktop && <IconButton icon={Icons.zoomIn} label="Zoom in" onClick={() => zoom("in")} />}
+            <IconButton icon={Icons.sun} label="Theme" onClick={onToggleTheme} />
+            <IconButton icon={Icons.settings} label="Appearance settings" onClick={() => openTab("/settings")} />
+          </>
+        }
+      />
+      {target && (
+        <ConfirmDialog
+          title={`Remove ${target.name}?`}
+          message={`${openTabs} open ${openTabs === 1 ? "tab" : "tabs"} in this workspace will close. The clusters stay in your kubeconfig.`}
+          confirmLabel="Remove"
+          danger
+          onConfirm={() => {
+            removeWorkspace(target.id);
+            setRemoving(null);
+          }}
+          onCancel={() => setRemoving(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/packages/ui-next/src/shell/Chrome.tsx
+++ b/packages/ui-next/src/shell/Chrome.tsx
@@ -62,11 +62,16 @@ export function Chrome({ controls, clusterName, onToggleTheme, onNewWorkspace }:
   // in its message would otherwise be whatever it was when the dialog opened.
   const target = workspaces.find((w) => w.id === removing) ?? null;
   const desktop = isTauri();
-  // The overlay titlebar keeps macOS's real traffic lights. Painting the
-  // picture too drew two sets on a real machine (found in smoke testing), so
-  // the caller never asks for the picture here, and this bar clears the
-  // natives with a gap that drags like the rest of the bare titlebar.
-  const nativeLights = desktop && isApplePlatform();
+  // The overlay titlebar keeps macOS's real traffic lights whenever the
+  // window is Tauri+Apple, regardless of `controls`. The kit draws its own
+  // picture of them only when `controls === "macos"`; that flag and this gap
+  // must never both be true, or the OS's lights and the kit's painted ones
+  // stack (the doubling `ec024b5` removed). Deriving `nativeLights` from
+  // `controls` here — instead of a caller having to keep the two hand-synced
+  // — is what makes that invariant hold no matter what `controls` a caller
+  // passes: this bar reserves the gap exactly when it is NOT asking the kit
+  // for the picture but the OS is drawing the real thing anyway.
+  const nativeLights = controls !== "macos" && desktop && isApplePlatform();
 
   function askRemove(id: string) {
     const w = workspaces.find((x) => x.id === id);

--- a/packages/ui-next/src/shell/Console.test.tsx
+++ b/packages/ui-next/src/shell/Console.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Console } from "./Console";
+import { ConsoleProvider, useConsole } from "../console";
+
+/** Anything else on screen, putting a question to the console from outside it. */
+function Elsewhere() {
+  const { ask } = useConsole();
+  return (
+    <button type="button" onClick={() => ask("x")}>
+      Ask from elsewhere
+    </button>
+  );
+}
+
+function setup({ apple = true }: { apple?: boolean } = {}) {
+  return render(
+    <ConsoleProvider>
+      <Elsewhere />
+      <Console apple={apple} />
+    </ConsoleProvider>,
+  );
+}
+
+describe("Console", () => {
+  it("shows what was asked at the prompt", async () => {
+    const user = userEvent.setup();
+    setup();
+    await user.type(screen.getByRole("textbox", { name: "Console prompt" }), "why{Enter}");
+    expect(screen.getByText("You asked: why")).toBeDefined();
+  });
+
+  it("opens and answers a question asked from anywhere else", async () => {
+    const user = userEvent.setup();
+    setup();
+    // Closed to begin with: nothing to read, so no output region.
+    expect(screen.queryByRole("log")).toBeNull();
+    await user.click(screen.getByRole("button", { name: "Ask from elsewhere" }));
+    expect(screen.getByRole("log", { name: "Console output" })).toBeDefined();
+    expect(screen.getByText("You asked: x")).toBeDefined();
+  });
+
+  it("prints the console accelerator for the platform", () => {
+    setup({ apple: true });
+    expect(screen.getByText("⌘K")).toBeDefined();
+  });
+});

--- a/packages/ui-next/src/shell/Console.tsx
+++ b/packages/ui-next/src/shell/Console.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+import { ConsoleDock, EmptyState } from "@srelens/ui-kit";
+import { useConsole } from "../console";
+import { hint } from "../lib/shortcuts";
+
+/**
+ * The console docked along the bottom of the window: the kit's `ConsoleDock`
+ * joined to the provider's state, and standing in for an agent that has not
+ * been ported yet.
+ *
+ * It answers nothing, and says so. That is the point of mounting it now: the
+ * dock, the accelerator that opens it and the `ask()` path from every other
+ * screen are the parts the rest of the shell has to build against, and they
+ * can be finished and tested while the agent behind them is still classic's.
+ * A question asked here is acknowledged rather than dropped, so the seam
+ * reads as unfinished rather than broken. (#320)
+ *
+ * `registerSubmit` in an effect is what makes `ask()` from elsewhere land in
+ * this component; the provider holds a question asked before the dock has
+ * mounted and delivers it on registration, so there is no race to lose one to.
+ * The cleanup matters: unregistering on unmount is what stops a later question
+ * calling into a component that is gone.
+ */
+export function Console({ apple }: { apple: boolean }) {
+  const { open, setOpen, scope, registerSubmit } = useConsole();
+  const [value, setValue] = useState("");
+  const [asked, setAsked] = useState<string[]>([]);
+
+  function onSubmit(question: string) {
+    setAsked((prev) => [...prev, question]);
+    // The dock is controlled, so a submitted question stays at the prompt
+    // unless someone clears it. Clearing it is what makes the prompt ready
+    // for the next one.
+    setValue("");
+    setOpen(true);
+  }
+
+  useEffect(() => registerSubmit(onSubmit), [registerSubmit]);
+
+  const last = asked[asked.length - 1];
+
+  return (
+    <ConsoleDock
+      open={open}
+      onOpenChange={setOpen}
+      value={value}
+      onValueChange={setValue}
+      onSubmit={onSubmit}
+      mode="Agent"
+      // Empty rather than absent is a bordered chip with nothing in it, and
+      // the console is unscoped until something on screen scopes it.
+      context={scope || undefined}
+      shortcutHint={hint("console", apple)}
+      emptyLabel="Ask about the cluster you are looking at"
+      onClear={() => setAsked([])}
+    >
+      {last !== undefined && (
+        <EmptyState
+          title="The agent is not in the new design yet"
+          hint={`You asked: ${last}`}
+        />
+      )}
+    </ConsoleDock>
+  );
+}

--- a/packages/ui-next/src/shell/Nav.test.tsx
+++ b/packages/ui-next/src/shell/Nav.test.tsx
@@ -121,18 +121,22 @@ describe("Nav", () => {
     expect(screen.queryByRole("treeitem", { name: "Pods" })).toBeNull();
   });
 
-  it("reports a failed CRD discovery, and retries it", async () => {
+  it("keeps the whole tree when CRD discovery fails, and retries from inside Custom resources", async () => {
     listCrds.mockResolvedValue({ error: "crds forbidden" });
     render(<Nav contexts={[PROD]} />);
 
-    const alert = await screen.findByRole("alert");
-    expect(alert.textContent).toContain("crds forbidden");
-
-    listCrds.mockResolvedValue({ crds: [] });
-    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
-
+    // The built-ins are not RBAC-gated the way CRD discovery is: an ordinary
+    // user who cannot list CRDs must still get Pods and the rest of the tree.
     expect(await screen.findByRole("treeitem", { name: "Pods" })).toBeTruthy();
+
+    await userEvent.click(await screen.findByRole("treeitem", { name: "Custom resources" }));
+    const retry = await screen.findByRole("treeitem", { name: "Custom resources unavailable — retry" });
+
+    const before = currentWorkspace().tabs.length;
+    await userEvent.click(retry);
+
     expect(listCrds).toHaveBeenCalledTimes(2);
+    expect(currentWorkspace().tabs).toHaveLength(before);
   });
 
   it("asks the new cluster for its CRDs when the cluster changes", async () => {
@@ -144,5 +148,23 @@ describe("Nav", () => {
     rerender(<Nav contexts={[PROD, other]} />);
 
     await vi.waitFor(() => expect(listCrds).toHaveBeenCalledWith("staging"));
+  });
+
+  it("stays folded shut across a remount once the user has closed every group", async () => {
+    const { unmount } = render(<Nav contexts={[PROD]} />);
+    await screen.findByRole("treeitem", { name: "Pods" });
+
+    for (const label of ["Cluster", "Workloads", "Config", "Network", "Storage", "Access control", "Investigate"]) {
+      await userEvent.click(screen.getByRole("treeitem", { name: label }));
+    }
+    expect(screen.queryByRole("treeitem", { name: "Pods" })).toBeNull();
+
+    unmount();
+    render(<Nav contexts={[PROD]} />);
+
+    // A remount must not read "every group closed" as "nothing has been
+    // seeded yet" and reopen all six — that is the state the user just put
+    // the sidebar in on purpose.
+    expect(screen.queryByRole("treeitem", { name: "Pods" })).toBeNull();
   });
 });

--- a/packages/ui-next/src/shell/Nav.test.tsx
+++ b/packages/ui-next/src/shell/Nav.test.tsx
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ClusterContext, CrdRef } from "@srelens/core";
+import { Nav } from "./Nav";
+import { currentWorkspace, openTab, setState } from "../lib/tabsStore";
+import { defaultState } from "../lib/tabs";
+import { resetView, setLink } from "../lib/workspace";
+
+// The CRD list is the one thing here that talks to a cluster. Mocked at the
+// module boundary — partially, so `RESOURCE_LABELS` and the rest of core stay
+// real and the tree is labelled the way the app labels it.
+const { listCrds } = vi.hoisted(() => ({ listCrds: vi.fn() }));
+vi.mock("@srelens/core", async (orig) => ({
+  ...(await orig<typeof import("@srelens/core")>()),
+  listCrds,
+}));
+
+const ctx = (name: string): ClusterContext => ({
+  name,
+  stableId: `id:${name}`,
+  cluster: name,
+  server: "https://example",
+  isCurrent: false,
+});
+
+const PROD = ctx("prod-eu");
+
+const CERTS: CrdRef = {
+  name: "certificates.cert-manager.io",
+  group: "cert-manager.io",
+  version: "v1",
+  kind: "Certificate",
+  plural: "certificates",
+  namespaced: true,
+};
+
+beforeEach(() => {
+  setState(defaultState([PROD]));
+  resetView();
+  vi.clearAllMocks();
+  listCrds.mockResolvedValue({ crds: [] });
+});
+
+const tabFor = (route: string) => currentWorkspace().tabs.find((t) => t.route === route);
+
+describe("Nav", () => {
+  it("lists a built-in kind and previews it in a tab", async () => {
+    render(<Nav contexts={[PROD]} />);
+
+    await userEvent.click(await screen.findByRole("treeitem", { name: "Pods" }));
+
+    const tab = tabFor("/k/pods");
+    expect(tab?.preview).toBe(true);
+    expect(tab?.sub).toBe("prod-eu");
+    expect(currentWorkspace().activeId).toBe(tab?.id);
+  });
+
+  it("says so when no cluster is in focus", () => {
+    setState(defaultState([]));
+    render(<Nav contexts={[]} />);
+
+    expect(screen.getByText("No cluster selected")).toBeTruthy();
+    expect(screen.queryByRole("tree")).toBeNull();
+  });
+
+  it("shows a discovered CRD under Custom resources, by API group", async () => {
+    listCrds.mockResolvedValue({ crds: [CERTS] });
+    render(<Nav contexts={[PROD]} />);
+
+    // Both folds start shut: a cluster with a few operators would otherwise
+    // bury the built-in kinds under a few hundred custom ones.
+    await userEvent.click(await screen.findByRole("treeitem", { name: "Custom resources" }));
+    await userEvent.click(await screen.findByRole("treeitem", { name: "cert-manager.io" }));
+
+    expect(await screen.findByRole("treeitem", { name: "Certificate" })).toBeTruthy();
+    expect(listCrds).toHaveBeenCalledWith("prod-eu");
+  });
+
+  it("opens an app screen from the Investigate group", async () => {
+    render(<Nav contexts={[PROD]} />);
+
+    await userEvent.click(await screen.findByRole("treeitem", { name: "Incidents" }));
+
+    expect(tabFor("/incidents")?.preview).toBe(true);
+  });
+
+  it("names the cluster and how it is linked", async () => {
+    setLink(PROD.stableId, "connected");
+    render(<Nav contexts={[PROD]} />);
+
+    expect(await screen.findByText("prod-eu")).toBeTruthy();
+    expect(screen.getByText("Connected")).toBeTruthy();
+  });
+
+  it("marks the node whose route the active tab is on", async () => {
+    openTab("/k/deployments", { clusterName: PROD.name });
+    render(<Nav contexts={[PROD]} />);
+
+    const row = await screen.findByRole("treeitem", { name: "Deployments" });
+    expect(row.getAttribute("aria-selected")).toBe("true");
+    expect((await screen.findByRole("treeitem", { name: "Pods" })).getAttribute("aria-selected")).toBe("false");
+  });
+
+  it("opens no tab for a group", async () => {
+    render(<Nav contexts={[PROD]} />);
+    const before = currentWorkspace().tabs.length;
+
+    await userEvent.click(await screen.findByRole("treeitem", { name: "Workloads" }));
+
+    expect(currentWorkspace().tabs).toHaveLength(before);
+  });
+
+  it("filters the tree by the sidebar's search box", async () => {
+    render(<Nav contexts={[PROD]} />);
+    await screen.findByRole("treeitem", { name: "Pods" });
+
+    await userEvent.type(screen.getByRole("searchbox", { name: "Filter resources" }), "secre");
+
+    expect(screen.getByRole("treeitem", { name: "Secrets" })).toBeTruthy();
+    expect(screen.queryByRole("treeitem", { name: "Pods" })).toBeNull();
+  });
+
+  it("reports a failed CRD discovery, and retries it", async () => {
+    listCrds.mockResolvedValue({ error: "crds forbidden" });
+    render(<Nav contexts={[PROD]} />);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("crds forbidden");
+
+    listCrds.mockResolvedValue({ crds: [] });
+    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(await screen.findByRole("treeitem", { name: "Pods" })).toBeTruthy();
+    expect(listCrds).toHaveBeenCalledTimes(2);
+  });
+
+  it("asks the new cluster for its CRDs when the cluster changes", async () => {
+    const other = ctx("staging");
+    const { rerender } = render(<Nav contexts={[PROD, other]} />);
+    await screen.findByRole("treeitem", { name: "Pods" });
+
+    setState(defaultState([other]));
+    rerender(<Nav contexts={[PROD, other]} />);
+
+    await vi.waitFor(() => expect(listCrds).toHaveBeenCalledWith("staging"));
+  });
+});

--- a/packages/ui-next/src/shell/Nav.tsx
+++ b/packages/ui-next/src/shell/Nav.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { listCrds, type ClusterContext, type CrdRef } from "@srelens/core";
 import { Mark, ResourceTree, Sidebar, StatusPill, type ResourceNode, type StatusKind } from "@srelens/ui-kit";
 import { Icons } from "../lib/icons";
@@ -6,7 +6,10 @@ import { useMark } from "../lib/marks";
 import { openTab, useActiveCluster, useTabs } from "../lib/tabsStore";
 import { crdNodes, glyph, INVESTIGATE, kindNodes, NAV_GROUPS, routeForNode } from "../lib/tree";
 import { useResource } from "../lib/useResource";
-import { getView, setExpanded, toggleExpanded, useWorkspaceView, type LinkState } from "../lib/workspace";
+import { seedExpandedOnce, toggleExpanded, useWorkspaceView, type LinkState } from "../lib/workspace";
+
+/** The one leaf the "Custom resources" group holds when discovery has failed. */
+const CRD_ERROR_ID = "crd-error";
 
 export interface NavProps {
   /** Every cluster the machine knows. The active one is looked up in here by `stableId`. */
@@ -67,10 +70,12 @@ function nodeForRoute(nodes: ResourceNode[], crds: CrdRef[], route: string): str
  *
  * And the folds are stored, not defaulted. The kit's tree takes `expanded` as
  * the whole truth when it is given at all, so an empty list would mean every
- * group shut on first launch; the workspace view is therefore seeded once per
- * mount with the groups that should stand open. Once per mount rather than
- * whenever the list is empty, because "the user closed all six" is a state the
- * sidebar has to be able to stay in.
+ * group shut on first launch; the workspace view is therefore seeded, once
+ * ever for the window's lifetime (`seedExpandedOnce`, in `workspace.ts`) with
+ * the groups that should stand open. Once ever rather than once per mount,
+ * because "the user closed all six" is a state the sidebar has to be able to
+ * stay in across a remount, and a per-mount guard cannot tell that state apart
+ * from "nothing has opened anything yet" — both leave `expanded` empty.
  */
 export function Nav({ contexts }: NavProps) {
   const activeCluster = useActiveCluster();
@@ -98,10 +103,21 @@ export function Nav({ contexts }: NavProps) {
   );
   const crds = useMemo(() => discovery.data ?? [], [discovery.data]);
 
+  // A failed discovery is not rendered as the tree-level `error` — that kit
+  // prop replaces the whole tree with an announced failure, and CRD discovery
+  // commonly fails for a reason that has nothing to do with the built-in
+  // kinds (ordinary RBAC does not grant list on CRDs). The built-ins and
+  // Investigate must survive that; only "Custom resources" loses its
+  // contents, to one leaf that retries.
+  const crdChildren: ResourceNode[] =
+    discovery.status === "error"
+      ? [{ id: CRD_ERROR_ID, label: "Custom resources unavailable — retry", icon: Icons.warn }]
+      : crdNodes(crds);
+
   const nodes = useMemo<ResourceNode[]>(
     () => [
       ...kindNodes(),
-      { id: "crds", label: "Custom resources", icon: Icons.crds, defaultExpanded: false, children: crdNodes(crds) },
+      { id: "crds", label: "Custom resources", icon: Icons.crds, defaultExpanded: false, children: crdChildren },
       {
         id: "investigate",
         label: "Investigate",
@@ -109,14 +125,11 @@ export function Nav({ contexts }: NavProps) {
         children: INVESTIGATE.map((i) => ({ id: `route:${i.route}`, label: i.label, icon: glyph(i.id) })),
       },
     ],
-    [crds],
+    [crds, crdChildren],
   );
 
-  const seeded = useRef(false);
   useEffect(() => {
-    if (seeded.current) return;
-    seeded.current = true;
-    if (getView().expanded.length === 0) setExpanded(DEFAULT_EXPANDED);
+    seedExpandedOnce(DEFAULT_EXPANDED);
   }, []);
 
   const link = ctx ? (view.links[ctx.stableId] ? LINK[view.links[ctx.stableId].state] : UNKNOWN) : UNKNOWN;
@@ -153,21 +166,20 @@ export function Nav({ contexts }: NavProps) {
           nodes={nodes}
           active={nodeForRoute(nodes, crds, route)}
           onActivate={(id) => {
+            // Handled before `routeForNode` is even consulted: the retry leaf
+            // is not a destination, it is the group's own failure reporting
+            // itself, and `routeForNode` returns `null` for it precisely so a
+            // caller that forgot this branch opens no tab either.
+            if (id === CRD_ERROR_ID) {
+              discovery.reload();
+              return;
+            }
             const next = routeForNode(id, crds);
             if (next) openTab(next, { preview: true, clusterName: ctx.name });
           }}
           expanded={view.expanded}
           onExpandedChange={toggleExpanded}
           query={query}
-          error={
-            discovery.status === "error"
-              ? {
-                  title: "Could not read this cluster",
-                  detail: discovery.error,
-                  onRetry: discovery.reload,
-                }
-              : undefined
-          }
         />
       )}
     </Sidebar>

--- a/packages/ui-next/src/shell/Nav.tsx
+++ b/packages/ui-next/src/shell/Nav.tsx
@@ -1,0 +1,175 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { listCrds, type ClusterContext, type CrdRef } from "@srelens/core";
+import { Mark, ResourceTree, Sidebar, StatusPill, type ResourceNode, type StatusKind } from "@srelens/ui-kit";
+import { Icons } from "../lib/icons";
+import { useMark } from "../lib/marks";
+import { openTab, useActiveCluster, useTabs } from "../lib/tabsStore";
+import { crdNodes, glyph, INVESTIGATE, kindNodes, NAV_GROUPS, routeForNode } from "../lib/tree";
+import { useResource } from "../lib/useResource";
+import { getView, setExpanded, toggleExpanded, useWorkspaceView, type LinkState } from "../lib/workspace";
+
+export interface NavProps {
+  /** Every cluster the machine knows. The active one is looked up in here by `stableId`. */
+  contexts: ClusterContext[];
+}
+
+/** How each link state reads, and which of the kit's five kinds draws it. */
+const LINK: Record<LinkState, { word: string; kind: StatusKind }> = {
+  connected: { word: "Connected", kind: "success" },
+  connecting: { word: "Connecting", kind: "info" },
+  disconnected: { word: "Disconnected", kind: "neutral" },
+  error: { word: "Error", kind: "danger" },
+};
+
+/** Before anything has probed the cluster there is nothing to claim about it. */
+const UNKNOWN = { word: "Unknown", kind: "neutral" } as const;
+
+/**
+ * The groups that stand open the first time a window is used: everything the
+ * tree builds with children, minus the two that ask to start shut.
+ */
+const DEFAULT_EXPANDED = [...NAV_GROUPS.map((g) => g.id), "investigate"];
+
+/**
+ * The id of the node the active tab is on, or `undefined` when the tab is on
+ * something the tree does not offer (a resource detail, settings, a terminal).
+ *
+ * Found by asking each leaf where it goes rather than by turning the route back
+ * into an id: `routeForNode` is the one direction that has to be right, and a
+ * second mapping written the other way round is a second thing to keep in step.
+ */
+function nodeForRoute(nodes: ResourceNode[], crds: CrdRef[], route: string): string | undefined {
+  for (const node of nodes) {
+    if (node.children) {
+      const inside = nodeForRoute(node.children, crds, route);
+      if (inside) return inside;
+    } else if (routeForNode(node.id, crds) === route) {
+      return node.id;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * The sidebar: whose cluster this is, a filter, and everything in it worth
+ * opening — the built-in kinds, whatever CRDs this cluster has, and the app's
+ * own screens.
+ *
+ * All of the drawing is the kit's; what lives here is the wiring the kit is not
+ * allowed to know. The shape of the tree is `lib/tree.ts`, which is pure and
+ * tested as data; this reads the active cluster out of the tab store, asks core
+ * for the CRDs, opens tabs, and keeps the folds in the workspace view.
+ *
+ * Two decisions worth naming. Activating a row opens a *preview* tab, the way
+ * a single click in an editor's file tree does: walking down a sidebar is
+ * browsing, and browsing twenty kinds should not leave twenty tabs behind —
+ * `openTab` promotes the preview as soon as the row is opened for real.
+ *
+ * And the folds are stored, not defaulted. The kit's tree takes `expanded` as
+ * the whole truth when it is given at all, so an empty list would mean every
+ * group shut on first launch; the workspace view is therefore seeded once per
+ * mount with the groups that should stand open. Once per mount rather than
+ * whenever the list is empty, because "the user closed all six" is a state the
+ * sidebar has to be able to stay in.
+ */
+export function Nav({ contexts }: NavProps) {
+  const activeCluster = useActiveCluster();
+  const ctx = contexts.find((c) => c.stableId === activeCluster) ?? null;
+  const view = useWorkspaceView();
+  const [query, setQuery] = useState("");
+  const mark = useMark(ctx?.stableId ?? "", ctx?.name ?? "");
+
+  // Subscribes the sidebar to the strip: which row is highlighted is a fact
+  // about the active tab, and that changes from a dozen places that are not here.
+  const { tabs, activeId } = useTabs();
+  const route = tabs.find((t) => t.id === activeId)?.route ?? "/";
+
+  const name = ctx?.name;
+  const discovery = useResource<CrdRef[]>(
+    async () => {
+      if (!name) return [];
+      const out = await listCrds(name);
+      // `listCrds` reports failure in the result rather than by rejecting, and
+      // an empty tree is not the same news as "we were not allowed to look".
+      if (out.error) throw new Error(out.error);
+      return out.crds ?? [];
+    },
+    [name],
+  );
+  const crds = useMemo(() => discovery.data ?? [], [discovery.data]);
+
+  const nodes = useMemo<ResourceNode[]>(
+    () => [
+      ...kindNodes(),
+      { id: "crds", label: "Custom resources", icon: Icons.crds, defaultExpanded: false, children: crdNodes(crds) },
+      {
+        id: "investigate",
+        label: "Investigate",
+        icon: Icons.investigate,
+        children: INVESTIGATE.map((i) => ({ id: `route:${i.route}`, label: i.label, icon: glyph(i.id) })),
+      },
+    ],
+    [crds],
+  );
+
+  const seeded = useRef(false);
+  useEffect(() => {
+    if (seeded.current) return;
+    seeded.current = true;
+    if (getView().expanded.length === 0) setExpanded(DEFAULT_EXPANDED);
+  }, []);
+
+  const link = ctx ? (view.links[ctx.stableId] ? LINK[view.links[ctx.stableId].state] : UNKNOWN) : UNKNOWN;
+
+  return (
+    <Sidebar
+      label="Cluster navigation"
+      query={query}
+      onQueryChange={setQuery}
+      emptyTitle="No cluster selected"
+      emptyHint="Pick a cluster from the rail to browse what is in it."
+      header={
+        ctx && (
+          <div className="flex items-center gap-2">
+            <Mark
+              name={mark.name}
+              short={mark.short}
+              color={mark.color}
+              size="sm"
+              decorative
+              withBadge={mark.withText}
+              icon={mark.mark === "icon" && mark.icon ? glyph(mark.icon) : undefined}
+              imageSrc={mark.mark === "image" ? mark.imageSrc : undefined}
+            />
+            <span className="min-w-0 flex-1 truncate text-[0.8125rem] font-medium">{ctx.name}</span>
+            <StatusPill status={link.word} kind={link.kind} />
+          </div>
+        )
+      }
+    >
+      {ctx && (
+        <ResourceTree
+          label="Cluster resources"
+          nodes={nodes}
+          active={nodeForRoute(nodes, crds, route)}
+          onActivate={(id) => {
+            const next = routeForNode(id, crds);
+            if (next) openTab(next, { preview: true, clusterName: ctx.name });
+          }}
+          expanded={view.expanded}
+          onExpandedChange={toggleExpanded}
+          query={query}
+          error={
+            discovery.status === "error"
+              ? {
+                  title: "Could not read this cluster",
+                  detail: discovery.error,
+                  onRetry: discovery.reload,
+                }
+              : undefined
+          }
+        />
+      )}
+    </Sidebar>
+  );
+}

--- a/packages/ui-next/src/shell/Placeholder.test.tsx
+++ b/packages/ui-next/src/shell/Placeholder.test.tsx
@@ -20,7 +20,9 @@ describe("Placeholder", () => {
     const onOpenInClassic = vi.fn();
     render(<Placeholder route="/helm" ported={[]} onOpenInClassic={onOpenInClassic} />);
     fireEvent.click(screen.getByRole("button", { name: /open in classic/i }));
-    expect(onOpenInClassic).toHaveBeenCalledWith("/helm");
+    // The tab's cluster rides along when the tab has one, so classic can
+    // reopen at that cluster; a cluster-less placeholder passes nothing.
+    expect(onOpenInClassic).toHaveBeenCalledWith("/helm", undefined);
   });
 
   it("lists which screens are ported, when any are", () => {

--- a/packages/ui-next/src/shell/Placeholder.tsx
+++ b/packages/ui-next/src/shell/Placeholder.tsx
@@ -6,7 +6,7 @@ export interface PlaceholderProps {
   clusterName?: string;
   /** Display names of the screens that do exist in the new design. */
   ported: string[];
-  onOpenInClassic: (route: string) => void;
+  onOpenInClassic: (route: string, clusterName?: string) => void;
   /** Where the component gallery is, when this tree has one to offer. */
   onOpenGallery?: () => void;
 }
@@ -59,7 +59,7 @@ export function Placeholder({
         }
         action={
           <span className="flex gap-2">
-            <Button type="button" variant="secondary" size="sm" onClick={() => onOpenInClassic(route)}>
+            <Button type="button" variant="secondary" size="sm" onClick={() => onOpenInClassic(route, clusterName)}>
               Open in classic
             </Button>
             {onOpenGallery && (

--- a/packages/ui-next/src/shell/Rail.test.tsx
+++ b/packages/ui-next/src/shell/Rail.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ClusterContext } from "@srelens/core";
+import { Rail } from "./Rail";
+import { activeCluster, currentWorkspace, setState } from "../lib/tabsStore";
+import { defaultState } from "../lib/tabs";
+import { resetView, setLink } from "../lib/workspace";
+import { loadMarks } from "../lib/marks";
+import { resetProbes } from "../lib/probe";
+
+// jsdom has no ResizeObserver and Radix's popper — which the kit's Tooltip, and
+// so every rail button, sits on — watches its trigger with one. The same stub
+// Chrome.test.tsx carries, kept per file so the requirement stays visible.
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
+const ctx = (name: string): ClusterContext => ({
+  name,
+  stableId: name,
+  cluster: name,
+  server: `https://${name}.example`,
+  isCurrent: false,
+});
+
+const CONTEXTS = [ctx("prod-eu"), ctx("staging")];
+
+beforeEach(() => {
+  setState(defaultState(CONTEXTS));
+  resetView();
+  resetProbes();
+  // Marks persist through `settingsStorage`; the shared setup clears
+  // localStorage between tests, so this puts the in-memory copy back with it.
+  loadMarks();
+  vi.clearAllMocks();
+});
+
+function setup(props: Partial<Parameters<typeof Rail>[0]> = {}) {
+  const onConnect = vi.fn();
+  const view = render(<Rail contexts={CONTEXTS} onConnect={onConnect} {...props} />);
+  return { onConnect, ...view };
+}
+
+/** The drawer is the kit's `Drawer`: an aside named "Details". */
+const drawer = () => screen.getByRole("complementary", { name: "Details" });
+
+describe("Rail", () => {
+  it("lists the workspace's clusters and selects the one clicked", async () => {
+    setup();
+    expect(screen.getByRole("button", { name: "prod-eu" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "staging" })).toBeDefined();
+
+    await userEvent.click(screen.getByRole("button", { name: "staging" }));
+    expect(activeCluster()).toBe("staging");
+  });
+
+  it("says why a cluster is out of reach in its name", () => {
+    setLink("prod-eu", "error", "connection refused");
+    setup();
+    expect(screen.getByRole("button", { name: "prod-eu, connection refused" })).toBeDefined();
+  });
+
+  it("opens the cluster's drawer on the menu gesture and removes it from the workspace", async () => {
+    setup();
+    fireEvent.contextMenu(screen.getByRole("button", { name: "prod-eu" }));
+
+    const panel = drawer();
+    expect(panel.querySelector("header")?.textContent).toContain("prod-eu");
+
+    await userEvent.click(screen.getByRole("button", { name: "Remove from workspace" }));
+    expect(currentWorkspace().clusters).toEqual(["staging"]);
+    expect(screen.queryByRole("complementary", { name: "Details" })).toBeNull();
+  });
+
+  it("asks the app to connect a cluster", async () => {
+    const { onConnect } = setup();
+    await userEvent.click(screen.getByRole("button", { name: "Connect a cluster" }));
+    expect(onConnect).toHaveBeenCalled();
+  });
+});

--- a/packages/ui-next/src/shell/Rail.test.tsx
+++ b/packages/ui-next/src/shell/Rail.test.tsx
@@ -1,13 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { act, render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ClusterContext } from "@srelens/core";
 import { Rail } from "./Rail";
 import { activeCluster, currentWorkspace, setState } from "../lib/tabsStore";
 import { defaultState } from "../lib/tabs";
 import { resetView, setLink } from "../lib/workspace";
-import { loadMarks } from "../lib/marks";
-import { resetProbes } from "../lib/probe";
+import { defaultMark, loadMarks, setMark } from "../lib/marks";
+import { probeCluster, resetProbes } from "../lib/probe";
 
 // jsdom has no ResizeObserver and Radix's popper — which the kit's Tooltip, and
 // so every rail button, sits on — watches its trigger with one. The same stub
@@ -81,5 +81,50 @@ describe("Rail", () => {
     const { onConnect } = setup();
     await userEvent.click(screen.getByRole("button", { name: "Connect a cluster" }));
     expect(onConnect).toHaveBeenCalled();
+  });
+
+  it("draws a customised mark, and still names the button after the context", () => {
+    setMark("prod-eu", { ...defaultMark("prod-eu"), name: "Production EU", short: "PX" });
+    setup();
+    // The rail is a list of the workspace's contexts: what a button is called
+    // is the context's business, and what the square says is the mark's.
+    expect(screen.getByRole("button", { name: "prod-eu" })).toBeDefined();
+    expect(screen.getByText("PX")).toBeDefined();
+  });
+
+  it("draws a stored image mark", () => {
+    const png = "data:image/png;base64,iVBORw0KGgo=";
+    setMark("prod-eu", { ...defaultMark("prod-eu"), mark: "image", imageSrc: png });
+    const { container } = setup();
+    expect(container.querySelector("img")?.getAttribute("src")).toBe(png);
+  });
+
+  // The hint's contents, not the subscription: `probeCluster` always moves the
+  // link through `connecting` on its way, so the workspace store emits on every
+  // probe and this would pass on a rail subscribed to nothing at all. That the
+  // probe store is readable on its own is `probe.test.ts`'s `useInfos` test.
+  it("puts the version and the server in the hint once the probe lands", async () => {
+    setup();
+    const connect = vi.fn().mockResolvedValue({ context: "prod-eu", reachable: true, version: "v1.31.0" });
+    await act(async () => {
+      await probeCluster(CONTEXTS[0], connect as never);
+    });
+    // Focus rather than hover: Radix opens the tooltip on focus with no delay.
+    await act(async () => screen.getByRole("button", { name: "prod-eu" }).focus());
+    const tip = await screen.findAllByText("prod-eu — v1.31.0 · https://prod-eu.example");
+    expect(tip.length).toBeGreaterThan(0);
+  });
+
+  it("drops a drawer whose context has gone, and does not reopen it when it returns", () => {
+    const { rerender } = setup();
+    fireEvent.contextMenu(screen.getByRole("button", { name: "prod-eu" }));
+    expect(drawer()).toBeDefined();
+
+    rerender(<Rail contexts={[CONTEXTS[1]]} onConnect={() => {}} />);
+    expect(screen.queryByRole("complementary", { name: "Details" })).toBeNull();
+
+    // A kubeconfig that flickers must not reopen a panel nobody asked for.
+    rerender(<Rail contexts={CONTEXTS} onConnect={() => {}} />);
+    expect(screen.queryByRole("complementary", { name: "Details" })).toBeNull();
   });
 });

--- a/packages/ui-next/src/shell/Rail.tsx
+++ b/packages/ui-next/src/shell/Rail.tsx
@@ -1,8 +1,8 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { ClusterContext } from "@srelens/core";
 import { Button, ClusterRail, CustomizeMark, Drawer, Mark, type ClusterRailItem } from "@srelens/ui-kit";
 import { getMark, resetMark, setMark, useMark } from "../lib/marks";
-import { getInfo, useInfo } from "../lib/probe";
+import { useInfos } from "../lib/probe";
 import { setActiveCluster, setWorkspaceClusters, useActiveCluster, useTabs } from "../lib/tabsStore";
 import { useWorkspaceView } from "../lib/workspace";
 
@@ -52,13 +52,14 @@ const MAX_IMAGE_BYTES = 64 * 1024;
  * event, not a ref; the drawer is where the two things this menu would offer —
  * customise, remove — already live, so the gesture opens it directly.
  *
- * `useMark` and `useInfo` are called once each rather than once per cluster:
- * the number of clusters changes between renders, so a hook per item would be a
- * hook count that changes with the list, which React refuses. Both subscribe to
- * their store whatever id they are asked about, so one call each is what
- * re-renders this rail when any mark or any probe changes, and the items then
- * read the plain `getMark`/`getInfo` beside it. The `useMark` call is not a
- * spare: the drawer's editor needs the live value anyway.
+ * The marks and the probes are read once for the whole list rather than once
+ * per cluster: the number of clusters changes between renders, so a hook per
+ * item would be a hook count that changes with the list, which React refuses.
+ * `useInfos` is the probe store's whole-record snapshot, which exists for this.
+ * The marks have no such hook, so the subscription rides on the `useMark` call
+ * the drawer's editor needs anyway — that hook subscribes whatever id it is
+ * asked about, so it re-renders this rail on any mark change and the items then
+ * read the plain `getMark` beside it.
  */
 export function Rail({ contexts, onConnect }: RailProps) {
   const { workspace } = useTabs();
@@ -71,19 +72,41 @@ export function Rail({ contexts, onConnect }: RailProps) {
 
   // One subscription each, standing in for the per-item hooks — see above.
   const value = useMark(target?.stableId ?? "", target?.name ?? "");
-  useInfo(null);
+  const infos = useInfos();
+
+  // A context can leave while its drawer is open — a kubeconfig rewritten under
+  // the app. The drawer is already gone by then, since `target` cannot resolve;
+  // this forgets which cluster it was about, so a context that comes back does
+  // not bring a panel nobody asked for back with it.
+  const stale = editing !== null && !byId.has(editing);
+  useEffect(() => {
+    if (stale) setEditing(null);
+  }, [stale]);
 
   const items: ClusterRailItem[] = [];
   for (const id of workspace.clusters) {
     const ctx = byId.get(id);
     if (!ctx) continue;
     const mark = getMark(id, ctx.name);
-    const info = getInfo(id);
+    const info = infos[id];
     const link = links[id];
     items.push({
       id,
       name: ctx.name,
-      mark: <Mark decorative name={mark.name} short={mark.short} color={mark.color} size="sm" />,
+      // Named by the mark, which is where the initials come from when there is
+      // no short text; the item's own `name` stays the context's, because that
+      // is what the rail is a list of.
+      mark: (
+        <Mark
+          decorative
+          name={mark.name}
+          short={mark.short}
+          color={mark.color}
+          imageSrc={mark.mark === "image" ? mark.imageSrc : undefined}
+          withBadge={mark.withText}
+          size="sm"
+        />
+      ),
       // The version first, because the server is the long half and the hint
       // truncates from the end.
       detail: [info?.version, ctx.server].filter(Boolean).join(" · "),

--- a/packages/ui-next/src/shell/Rail.tsx
+++ b/packages/ui-next/src/shell/Rail.tsx
@@ -10,6 +10,13 @@ export interface RailProps {
   contexts: ClusterContext[];
   /** Opens /connect. The rail knows the gesture, the window knows the route. */
   onConnect: () => void;
+  /**
+   * Why the cluster list could not be read — a kubeconfig that failed to
+   * parse, usually. The saved cluster ids are kept and drawn once their
+   * contexts come back, but until then the rail would otherwise be silently
+   * empty with no way to tell "nothing configured" from "couldn't read it".
+   */
+  error?: string;
 }
 
 /**
@@ -61,7 +68,7 @@ const MAX_IMAGE_BYTES = 64 * 1024;
  * asked about, so it re-renders this rail on any mark change and the items then
  * read the plain `getMark` beside it.
  */
-export function Rail({ contexts, onConnect }: RailProps) {
+export function Rail({ contexts, onConnect, error }: RailProps) {
   const { workspace } = useTabs();
   const active = useActiveCluster();
   const { links } = useWorkspaceView();
@@ -140,6 +147,7 @@ export function Rail({ contexts, onConnect }: RailProps) {
         onSelect={setActiveCluster}
         onMenu={(id) => setEditing(id)}
         onAdd={onConnect}
+        error={error}
       />
       {target && (
         <Drawer open title={target.name} onClose={() => setEditing(null)}>

--- a/packages/ui-next/src/shell/Rail.tsx
+++ b/packages/ui-next/src/shell/Rail.tsx
@@ -1,0 +1,139 @@
+import { useState } from "react";
+import type { ClusterContext } from "@srelens/core";
+import { Button, ClusterRail, CustomizeMark, Drawer, Mark, type ClusterRailItem } from "@srelens/ui-kit";
+import { getMark, resetMark, setMark, useMark } from "../lib/marks";
+import { getInfo, useInfo } from "../lib/probe";
+import { setActiveCluster, setWorkspaceClusters, useActiveCluster, useTabs } from "../lib/tabsStore";
+import { useWorkspaceView } from "../lib/workspace";
+
+export interface RailProps {
+  contexts: ClusterContext[];
+  /** Opens /connect. The rail knows the gesture, the window knows the route. */
+  onConnect: () => void;
+}
+
+/**
+ * The colours a cluster may be marked with.
+ *
+ * Tokens rather than hex, so a mark set in the dark theme is not a colour that
+ * only worked there. Five, each named: {@link CustomizeMark} reads the label
+ * aloud, and "#b4342a" names nothing. The custom picker beside them is still
+ * there for anyone who wants a sixth.
+ */
+const PALETTE = [
+  { value: "var(--accent)", label: "Accent" },
+  { value: "var(--ok)", label: "Green" },
+  { value: "var(--info)", label: "Blue" },
+  { value: "var(--warn)", label: "Amber" },
+  { value: "var(--sev)", label: "Red" },
+];
+
+/** An image mark is inlined into the settings file, so it has to stay small. */
+const MAX_IMAGE_BYTES = 64 * 1024;
+
+/**
+ * The strip of cluster marks down the edge of the window, and the panel that
+ * edits one of them.
+ *
+ * Everything drawn is the kit's; what lives here is the four stores the kit is
+ * not allowed to see. The workspace says which clusters and in what order, the
+ * contexts resolve those ids to something with a name and a server, the link
+ * states say which are reachable, and the marks say what each one looks like.
+ * Items are built from all four and handed over already ordered — a rail that
+ * fetched any of it for itself would be a rail with one call site (#320).
+ *
+ * A cluster id with no matching context is skipped rather than drawn as a
+ * placeholder. `reconcile` already drops ids whose context has gone, so this
+ * only covers the window between a kubeconfig changing and the store catching
+ * up, and a mark for a cluster that is not there is worse than one mark fewer.
+ *
+ * The menu gesture opens the drawer rather than a context menu. The kit's
+ * ContextMenu needs an element ref to anchor to and the rail hands back an
+ * event, not a ref; the drawer is where the two things this menu would offer —
+ * customise, remove — already live, so the gesture opens it directly.
+ *
+ * `useMark` and `useInfo` are called once each rather than once per cluster:
+ * the number of clusters changes between renders, so a hook per item would be a
+ * hook count that changes with the list, which React refuses. Both subscribe to
+ * their store whatever id they are asked about, so one call each is what
+ * re-renders this rail when any mark or any probe changes, and the items then
+ * read the plain `getMark`/`getInfo` beside it. The `useMark` call is not a
+ * spare: the drawer's editor needs the live value anyway.
+ */
+export function Rail({ contexts, onConnect }: RailProps) {
+  const { workspace } = useTabs();
+  const active = useActiveCluster();
+  const { links } = useWorkspaceView();
+  const [editing, setEditing] = useState<string | null>(null);
+
+  const byId = new Map(contexts.map((c) => [c.stableId, c]));
+  const target = editing === null ? null : (byId.get(editing) ?? null);
+
+  // One subscription each, standing in for the per-item hooks — see above.
+  const value = useMark(target?.stableId ?? "", target?.name ?? "");
+  useInfo(null);
+
+  const items: ClusterRailItem[] = [];
+  for (const id of workspace.clusters) {
+    const ctx = byId.get(id);
+    if (!ctx) continue;
+    const mark = getMark(id, ctx.name);
+    const info = getInfo(id);
+    const link = links[id];
+    items.push({
+      id,
+      name: ctx.name,
+      mark: <Mark decorative name={mark.name} short={mark.short} color={mark.color} size="sm" />,
+      // The version first, because the server is the long half and the hint
+      // truncates from the end.
+      detail: [info?.version, ctx.server].filter(Boolean).join(" · "),
+      // A reason rather than a flag: the kit dims the mark and says the word,
+      // so the state is never told in opacity alone. An error with no message
+      // still has to say something.
+      unavailable:
+        link?.state === "error"
+          ? (link.error ?? "Unreachable")
+          : link?.state === "disconnected"
+            ? "Disconnected"
+            : undefined,
+      markers: link?.state === "connecting" ? [{ label: "Connecting", tone: "info" }] : [],
+      color: mark.color,
+    });
+  }
+
+  function remove(id: string) {
+    setWorkspaceClusters(
+      workspace.id,
+      workspace.clusters.filter((c) => c !== id),
+    );
+    setEditing(null);
+  }
+
+  return (
+    <>
+      <ClusterRail
+        items={items}
+        activeId={active ?? undefined}
+        onSelect={setActiveCluster}
+        onMenu={(id) => setEditing(id)}
+        onAdd={onConnect}
+      />
+      {target && (
+        <Drawer open title={target.name} onClose={() => setEditing(null)}>
+          <CustomizeMark
+            value={value}
+            onChange={(next) => setMark(target.stableId, next)}
+            onReset={() => resetMark(target.stableId)}
+            colors={PALETTE}
+            maxImageBytes={MAX_IMAGE_BYTES}
+          />
+          <div className="mt-3 flex justify-end px-3">
+            <Button variant="danger" size="sm" onClick={() => remove(target.stableId)}>
+              Remove from workspace
+            </Button>
+          </div>
+        </Drawer>
+      )}
+    </>
+  );
+}

--- a/packages/ui-next/src/shell/Status.test.tsx
+++ b/packages/ui-next/src/shell/Status.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { Status } from "./Status";
+import { ConsoleProvider, useConsole } from "../console";
+import { setState } from "../lib/tabsStore";
+import { defaultState } from "../lib/tabs";
+import { probeCluster, resetProbes } from "../lib/probe";
+import { resetView } from "../lib/workspace";
+
+// The forwards store is core's, module-level and driven by the backend, so the
+// count is faked at the boundary rather than by starting a real forward. The
+// getter hands back the same array until it is swapped, which is what
+// `useSyncExternalStore` requires of it.
+const forwards = vi.hoisted(() => ({ list: [] as unknown[], notify: new Set<() => void>() }));
+vi.mock("@srelens/core", async (orig) => ({
+  ...(await orig<typeof import("@srelens/core")>()),
+  getForwards: () => forwards.list,
+  subscribeForwards: (l: () => void) => {
+    forwards.notify.add(l);
+    return () => forwards.notify.delete(l);
+  },
+}));
+
+const ctx = { name: "prod-eu", stableId: "prod", cluster: "c", server: "", isCurrent: false };
+
+beforeEach(() => {
+  forwards.list = [];
+  resetView();
+  resetProbes();
+});
+
+/** Reads the console's open flag from outside the bar, the way the dock does. */
+function Peek() {
+  const { open } = useConsole();
+  return <span data-testid="console-open">{String(open)}</span>;
+}
+
+function mount(node: ReactNode) {
+  return render(
+    <ConsoleProvider>
+      {node}
+      <Peek />
+    </ConsoleProvider>,
+  );
+}
+
+/** Connect the cluster for real through the probe, so link state is derived. */
+async function connect(version: string | null) {
+  const connectCluster = vi.fn().mockResolvedValue({ context: ctx.name, reachable: true, version });
+  await act(async () => {
+    await probeCluster(ctx, connectCluster as never);
+  });
+}
+
+describe("Status", () => {
+  it("says so when no cluster is active", () => {
+    setState(defaultState([]));
+    mount(<Status contexts={[]} />);
+    expect(screen.getByText("No cluster")).toBeDefined();
+    // Nothing to say about a version nobody asked for.
+    expect(screen.queryByText("version unknown")).toBeNull();
+  });
+
+  it("names the active cluster, its version and its link", async () => {
+    setState(defaultState([ctx]));
+    mount(<Status contexts={[ctx]} />);
+    await connect("v1.29.0");
+    expect(screen.getByText("prod-eu")).toBeDefined();
+    expect(screen.getByText("v1.29.0")).toBeDefined();
+    expect(screen.getByText("Connected")).toBeDefined();
+  });
+
+  it("counts the port-forwards, in the plural the number calls for", () => {
+    setState(defaultState([ctx]));
+    forwards.list = [{ id: 1 }, { id: 2 }];
+    mount(<Status contexts={[ctx]} />);
+    expect(screen.getByRole("button", { name: "2 port-forwards" })).toBeDefined();
+  });
+
+  it("opens the console from Ask", async () => {
+    setState(defaultState([ctx]));
+    mount(<Status contexts={[ctx]} />);
+    expect(screen.getByTestId("console-open").textContent).toBe("false");
+    await userEvent.click(screen.getByRole("button", { name: "Ask" }));
+    expect(screen.getByTestId("console-open").textContent).toBe("true");
+  });
+});

--- a/packages/ui-next/src/shell/Status.tsx
+++ b/packages/ui-next/src/shell/Status.tsx
@@ -1,0 +1,104 @@
+import { useSyncExternalStore } from "react";
+import { getForwards, subscribeForwards, type ClusterContext } from "@srelens/core";
+import { StatusBar, type StatusSegment, type Tone } from "@srelens/ui-kit";
+import { useConsole } from "../console";
+import { useInfo } from "../lib/probe";
+import { openTab, useActiveCluster } from "../lib/tabsStore";
+import { useWorkspaceView, type LinkState } from "../lib/workspace";
+
+/**
+ * What the link says, in words. The mock said it in colour alone — a green dot
+ * for connected, a red one for unreachable — which is no readout at all for
+ * anyone who cannot separate the two. The kit's segment requires a string, so
+ * the words are the readout and the tone is the second channel. "Unreachable"
+ * rather than "Error" for `error`: the failure being reported is the cluster's,
+ * not the app's, and the person reading it wants to know which. (#320)
+ */
+const LINK_WORD: Record<LinkState, string> = {
+  connected: "Connected",
+  connecting: "Connecting",
+  disconnected: "Disconnected",
+  error: "Unreachable",
+};
+
+const LINK_TONE: Record<LinkState, Tone> = {
+  connected: "ok",
+  connecting: "info",
+  disconnected: "muted",
+  error: "sev",
+};
+
+/**
+ * The strip along the bottom of the window: which cluster this window is
+ * looking at, what version it runs, whether it is reachable, how many
+ * port-forwards are up, and the way in to the console.
+ *
+ * Every readout here is somebody else's fact — the tab store's active cluster,
+ * the probe's version, the workspace view's link state, core's forwards — so
+ * this component is only the place they meet. The kit draws them, and it is
+ * not allowed to know what a cluster or a forward is, which is why they arrive
+ * as segments rather than as props with those names on them.
+ *
+ * `contexts` is passed in rather than read from a store because the store holds
+ * `stableId`s and the strip shows names: the id survives a rename and the name
+ * is what a person recognises, and only the caller that listed the contexts can
+ * turn one into the other.
+ *
+ * The forwards count comes straight off core's module-level store rather than
+ * through a hook of ours. It is shared with the per-resource "Forward" action
+ * and must survive this component unmounting, so subscribing to it is the whole
+ * of the wiring — a copy in ui-next would be a second answer to the same
+ * question.
+ */
+export function Status({ contexts }: { contexts: ClusterContext[] }) {
+  const activeId = useActiveCluster();
+  const info = useInfo(activeId);
+  const { links } = useWorkspaceView();
+  const { setOpen } = useConsole();
+  const forwards = useSyncExternalStore(subscribeForwards, getForwards, getForwards);
+
+  // Found rather than assumed: the active id is persisted and the context list
+  // is whatever the machine has now, so an id can outlive the context it named.
+  const ctx = contexts.find((c) => c.stableId === activeId);
+  // Nothing has probed yet, or there is nothing to probe. Either way the link
+  // is not up, and "Disconnected" is the honest reading of that.
+  const state = (activeId ? links[activeId]?.state : undefined) ?? "disconnected";
+  const n = forwards.length;
+
+  const segments: StatusSegment[] = [
+    {
+      id: "ctx",
+      label: ctx?.name ?? "No cluster",
+      dot: true,
+      tone: LINK_TONE[state],
+      // Pressable only when there is a cluster to open. A "No cluster" button
+      // that opens an overview of nothing is a dead end dressed as a way out.
+      onSelect: ctx ? () => openTab("/overview", { clusterName: ctx.name }) : undefined,
+    },
+  ];
+  if (ctx) {
+    // The probe may not have landed, and a reachable cluster can still report
+    // no version. Both are "we do not know yet", said in words rather than by
+    // dropping the readout — a segment that comes and goes moves the ones after
+    // it along the strip every time a cluster is probed.
+    segments.push({ id: "ver", label: info?.version ?? "version unknown" });
+  }
+  // Pulsing only while connecting: the dot is animated for a readout that is
+  // still changing, not for one that merely happens to be current.
+  segments.push({ id: "link", label: LINK_WORD[state], pulse: state === "connecting" });
+
+  const end: StatusSegment[] = [
+    {
+      id: "pf",
+      label: `${n} port-forward${n === 1 ? "" : "s"}`,
+      tone: "info",
+      // A dot for "something is running", so the strip reads as live at a
+      // glance; none at zero, where there is nothing to be live about.
+      dot: n > 0,
+      onSelect: () => openTab("/forwards"),
+    },
+    { id: "ask", label: "Ask", tone: "accent", onSelect: () => setOpen(true) },
+  ];
+
+  return <StatusBar segments={segments} end={end} />;
+}

--- a/packages/ui-next/src/shell/Window.test.tsx
+++ b/packages/ui-next/src/shell/Window.test.tsx
@@ -1,21 +1,46 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { fireEvent } from "@testing-library/react";
 
 // `vi.hoisted` because `vi.mock` is hoisted above every declaration in the
 // file, and the tabsPersist factory reads these the moment `./Window` imports
 // the module — a plain `const` is still in its temporal dead zone by then.
-const { listContexts, loadTabsState, scheduleSave, installFlushOnUnload, flushSave } = vi.hoisted(() => ({
+const {
+  listContexts,
+  loadTabsState,
+  scheduleSave,
+  installFlushOnUnload,
+  flushSave,
+  connectCluster,
+  listCrds,
+  getForwards,
+  subscribeForwards,
+  isApplePlatform,
+} = vi.hoisted(() => ({
   listContexts: vi.fn(),
   loadTabsState: vi.fn(),
   scheduleSave: vi.fn(),
   installFlushOnUnload: vi.fn(() => () => {}),
   flushSave: vi.fn(),
+  connectCluster: vi.fn(),
+  listCrds: vi.fn(),
+  getForwards: vi.fn(() => []),
+  subscribeForwards: vi.fn(() => () => {}),
+  isApplePlatform: vi.fn(() => true),
 }));
 
 vi.mock("@srelens/core", async (importOriginal) => {
   const real = await importOriginal<typeof import("@srelens/core")>();
-  return { ...real, listContexts: (...a: unknown[]) => listContexts(...a) };
+  return {
+    ...real,
+    listContexts: (...a: unknown[]) => listContexts(...a),
+    connectCluster: (...a: unknown[]) => connectCluster(...a),
+    listCrds: (...a: unknown[]) => listCrds(...a),
+    getForwards: () => getForwards(),
+    subscribeForwards: (...a: Parameters<typeof subscribeForwards>) => subscribeForwards(...a),
+    isApplePlatform: () => isApplePlatform(),
+  };
 });
 
 vi.mock("../lib/tabsPersist", () => ({ loadTabsState, scheduleSave, installFlushOnUnload, flushSave }));
@@ -29,8 +54,11 @@ if (!("ResizeObserver" in globalThis)) {
   };
 }
 
+import { ConsoleProvider } from "../console";
 import { Window } from "./Window";
 import * as store from "../lib/tabsStore";
+import { resetProbes } from "../lib/probe";
+import { resetView } from "../lib/workspace";
 import { defaultState, makeTab } from "../lib/tabs";
 
 const ctx = (stableId: string, name = stableId) => ({ name, stableId, cluster: name, server: "", isCurrent: false });
@@ -39,15 +67,26 @@ beforeEach(() => {
   listContexts.mockReset().mockResolvedValue({ contexts: [ctx("prod")] });
   loadTabsState.mockReset().mockReturnValue(null);
   scheduleSave.mockReset();
+  connectCluster.mockReset().mockImplementation(async (name: string) => ({ context: name, reachable: true, version: "1.30" }));
+  listCrds.mockReset().mockResolvedValue({ crds: [] });
+  getForwards.mockReset().mockReturnValue([]);
+  subscribeForwards.mockReset().mockReturnValue(() => {});
+  isApplePlatform.mockReset().mockReturnValue(true);
   // Cleared so "flushes on unload" can actually fail: a spy that is never
   // cleared stays called from the first test in the file onwards.
   installFlushOnUnload.mockClear();
   flushSave.mockClear();
   store.setState(defaultState([]));
+  resetProbes();
+  resetView();
 });
 
 async function booted() {
-  render(<Window ported={[]} onOpenInClassic={() => {}} />);
+  render(
+    <ConsoleProvider>
+      <Window ported={[]} onOpenInClassic={() => {}} />
+    </ConsoleProvider>,
+  );
   await waitFor(() => expect(screen.getByRole("tablist")).toBeDefined());
 }
 
@@ -82,7 +121,11 @@ describe("Window boot", () => {
     saved.workspaces[0].activeId = saved.workspaces[0].tabs[0].id;
     loadTabsState.mockReturnValue(saved);
     listContexts.mockResolvedValue({ error: "kubeconfig unreadable" });
-    render(<Window ported={[]} onOpenInClassic={() => {}} />);
+    render(
+      <ConsoleProvider>
+        <Window ported={[]} onOpenInClassic={() => {}} />
+      </ConsoleProvider>,
+    );
     await screen.findByRole("tablist");
     // reconcile(saved, []) would have stripped "prod"; a transient failure must not.
     expect(store.currentWorkspace().clusters).toEqual(["prod"]);
@@ -91,7 +134,11 @@ describe("Window boot", () => {
   it("shows a loading state rather than the wrong tabs before boot resolves", () => {
     let resolve!: (v: unknown) => void;
     listContexts.mockReturnValue(new Promise((r) => (resolve = r)));
-    render(<Window ported={[]} onOpenInClassic={() => {}} />);
+    render(
+      <ConsoleProvider>
+        <Window ported={[]} onOpenInClassic={() => {}} />
+      </ConsoleProvider>,
+    );
     expect(screen.queryByRole("tablist")).toBeNull();
     expect(screen.getByText(/loading/i)).toBeDefined();
     act(() => resolve({ contexts: [] }));
@@ -120,7 +167,11 @@ describe("Window boot", () => {
     // Unmounting mid-debounce — the gallery round trip, a design switch —
     // dropped up to 300ms of changes: the unload listener never fires, so
     // taking it off without writing threw the pending state away.
-    const view = render(<Window ported={[]} onOpenInClassic={() => {}} />);
+    const view = render(
+      <ConsoleProvider>
+        <Window ported={[]} onOpenInClassic={() => {}} />
+      </ConsoleProvider>,
+    );
     await waitFor(() => expect(screen.getByRole("tablist")).toBeDefined());
     act(() => store.openTab("/k/pods"));
     expect(flushSave).not.toHaveBeenCalled();
@@ -161,25 +212,88 @@ describe("Window strip", () => {
     expect(store.currentWorkspace().tabs.map((t) => t.route)).toEqual(["/", "/"]);
   });
 
-  it("does not name an arbitrary cluster on a new tab", async () => {
-    // `contexts[0]` is whichever context the kubeconfig happens to list first
-    // — not the current one, and not necessarily even in this workspace — and
-    // `TabStrip` reads `sub` into the accessible name, so the tab announced
-    // itself as being on a cluster the user had not chosen. PR 2 wires the
-    // active cluster; until then a tab names no cluster at all.
+  it("names the workspace's active cluster on a new tab", async () => {
+    // `contexts[0]` would have been whichever context the kubeconfig lists
+    // first — not the current one, and not necessarily even in this
+    // workspace. The active cluster is what a new tab is about, so its name
+    // is what the tab carries.
     listContexts.mockResolvedValue({ contexts: [ctx("prod", "prod-eu")] });
     await booted();
     await userEvent.click(screen.getByRole("button", { name: /new tab/i }));
     const opened = store.currentWorkspace().tabs.at(-1)!;
-    expect(opened.sub).toBeUndefined();
-    expect(screen.getAllByRole("tab").at(-1)!.textContent).not.toContain("prod-eu");
+    expect(opened.sub).toBe("prod-eu");
   });
 
-  it("hands the Placeholder the way back to classic", async () => {
+  it("hands the Placeholder the way back to classic, with the cluster", async () => {
     const onOpenInClassic = vi.fn();
-    render(<Window ported={[]} onOpenInClassic={onOpenInClassic} />);
+    render(
+      <ConsoleProvider>
+        <Window ported={[]} onOpenInClassic={onOpenInClassic} />
+      </ConsoleProvider>,
+    );
     await waitFor(() => expect(screen.getByRole("tablist")).toBeDefined());
     await userEvent.click(screen.getByRole("button", { name: /open in classic/i }));
-    expect(onOpenInClassic).toHaveBeenCalledWith("/");
+    expect(onOpenInClassic).toHaveBeenCalledWith("/", "prod");
+  });
+});
+
+describe("Window accelerators", () => {
+  it("binds ⌘T to a new tab carrying the active cluster's name", async () => {
+    await booted();
+    fireEvent.keyDown(window, { key: "t", metaKey: true });
+    const tabs = store.currentWorkspace().tabs;
+    expect(tabs).toHaveLength(2);
+    expect(tabs.at(-1)!.sub).toBe("prod");
+  });
+
+  it("⌘W closes the active tab and ⌘⇧T reopens it", async () => {
+    await booted();
+    act(() => store.openTab("/k/pods"));
+    fireEvent.keyDown(window, { key: "w", metaKey: true });
+    expect(store.currentWorkspace().tabs).toHaveLength(1);
+    expect(store.currentWorkspace().closed).toHaveLength(1);
+    fireEvent.keyDown(window, { key: "T", metaKey: true, shiftKey: true });
+    expect(store.currentWorkspace().tabs).toHaveLength(2);
+  });
+
+  it("does nothing on Ctrl+W while Apple, since that chord belongs to the terminal", async () => {
+    await booted();
+    act(() => store.openTab("/k/pods"));
+    fireEvent.keyDown(window, { key: "w", ctrlKey: true });
+    expect(store.currentWorkspace().tabs).toHaveLength(2);
+  });
+
+  it("binds nothing while inactive, and takes the chrome down but not the bodies", async () => {
+    render(
+      <ConsoleProvider>
+        <Window ported={[]} onOpenInClassic={() => {}} active={false} />
+      </ConsoleProvider>,
+    );
+    await screen.findByText(/not in the new design yet/);
+    expect(screen.queryByRole("tablist")).toBeNull();
+    fireEvent.keyDown(window, { key: "t", metaKey: true });
+    expect(store.currentWorkspace().tabs).toHaveLength(1);
+  });
+
+  it("probes each cluster of the workspace once at boot", async () => {
+    listContexts.mockResolvedValue({ contexts: [ctx("prod"), ctx("dev")] });
+    render(
+      <ConsoleProvider>
+        <Window ported={[]} onOpenInClassic={() => {}} />
+      </ConsoleProvider>,
+    );
+    await screen.findByRole("tablist");
+    await waitFor(() => expect(connectCluster).toHaveBeenCalledTimes(2));
+    expect(connectCluster.mock.calls.map((c) => c[0])).toEqual(["prod", "dev"]);
+  });
+
+  it("offers Close others on a tab's context menu", async () => {
+    await booted();
+    act(() => store.openTab("/k/pods", { clusterName: "prod" }));
+    act(() => store.openTab("/events"));
+    fireEvent.contextMenu(screen.getByRole("tab", { name: /Pods/ }));
+    await userEvent.click(await screen.findByRole("menuitem", { name: "Close others" }));
+    // The pinned home tab survives by design; /events is what "others" means.
+    expect(store.currentWorkspace().tabs.map((t) => t.route)).toEqual(["/", "/k/pods"]);
   });
 });

--- a/packages/ui-next/src/shell/Window.test.tsx
+++ b/packages/ui-next/src/shell/Window.test.tsx
@@ -17,6 +17,10 @@ const {
   getForwards,
   subscribeForwards,
   isApplePlatform,
+  isTauri,
+  zoomSpy,
+  createWorkspaceSpy,
+  switchWorkspaceSpy,
 } = vi.hoisted(() => ({
   listContexts: vi.fn(),
   loadTabsState: vi.fn(),
@@ -28,6 +32,10 @@ const {
   getForwards: vi.fn(() => []),
   subscribeForwards: vi.fn(() => () => {}),
   isApplePlatform: vi.fn(() => true),
+  isTauri: vi.fn(() => true),
+  zoomSpy: vi.fn(),
+  createWorkspaceSpy: vi.fn(),
+  switchWorkspaceSpy: vi.fn(),
 }));
 
 vi.mock("@srelens/core", async (importOriginal) => {
@@ -40,10 +48,35 @@ vi.mock("@srelens/core", async (importOriginal) => {
     getForwards: () => getForwards(),
     subscribeForwards: (...a: Parameters<typeof subscribeForwards>) => subscribeForwards(...a),
     isApplePlatform: () => isApplePlatform(),
+    isTauri: () => isTauri(),
   };
 });
 
 vi.mock("../lib/tabsPersist", () => ({ loadTabsState, scheduleSave, installFlushOnUnload, flushSave }));
+
+// The zoom helper lives in Chrome (shared with its buttons); spied rather than
+// replaced outright so Chrome itself still renders for real.
+vi.mock("./Chrome", async (importOriginal) => {
+  const real = await importOriginal<typeof import("./Chrome")>();
+  return { ...real, zoom: (...a: Parameters<typeof real.zoom>) => zoomSpy(...a) };
+});
+
+// createWorkspace/switchWorkspace spied the same way — a pass-through so the
+// real store still drives every other test in this file.
+vi.mock("../lib/tabsStore", async (importOriginal) => {
+  const real = await importOriginal<typeof import("../lib/tabsStore")>();
+  return {
+    ...real,
+    createWorkspace: (...a: Parameters<typeof real.createWorkspace>) => {
+      createWorkspaceSpy(...a);
+      return real.createWorkspace(...a);
+    },
+    switchWorkspace: (...a: Parameters<typeof real.switchWorkspace>) => {
+      switchWorkspaceSpy(...a);
+      return real.switchWorkspace(...a);
+    },
+  };
+});
 
 // jsdom has no ResizeObserver; TabStrip's overflow Popover wants one.
 if (!("ResizeObserver" in globalThis)) {
@@ -72,6 +105,10 @@ beforeEach(() => {
   getForwards.mockReset().mockReturnValue([]);
   subscribeForwards.mockReset().mockReturnValue(() => {});
   isApplePlatform.mockReset().mockReturnValue(true);
+  isTauri.mockReset().mockReturnValue(true);
+  zoomSpy.mockReset();
+  createWorkspaceSpy.mockReset();
+  switchWorkspaceSpy.mockReset();
   // Cleared so "flushes on unload" can actually fail: a spy that is never
   // cleared stays called from the first test in the file onwards.
   installFlushOnUnload.mockClear();
@@ -295,5 +332,62 @@ describe("Window accelerators", () => {
     await userEvent.click(await screen.findByRole("menuitem", { name: "Close others" }));
     // The pinned home tab survives by design; /events is what "others" means.
     expect(store.currentWorkspace().tabs.map((t) => t.route)).toEqual(["/", "/k/pods"]);
+  });
+
+  it("marks every close item as destructive", async () => {
+    await booted();
+    act(() => store.openTab("/k/pods", { clusterName: "prod" }));
+    fireEvent.contextMenu(screen.getByRole("tab", { name: /Pods/ }));
+    for (const name of ["Close", "Close others", "Close to the right", "Close all"]) {
+      const item = await screen.findByRole("menuitem", { name });
+      expect(item.getAttribute("data-danger")).toBe("true");
+    }
+  });
+
+  it("zooms via the shared helper under Tauri, and eats the keystroke", async () => {
+    await booted();
+    const notCancelled = fireEvent.keyDown(window, { key: "=", metaKey: true });
+    expect(zoomSpy).toHaveBeenCalledWith("in");
+    // `false` means preventDefault() was called on a cancelable event.
+    expect(notCancelled).toBe(false);
+  });
+
+  it("leaves the browser's own zoom alone in web mode", async () => {
+    // Core's uiScale doc: in a browser the native zoom already does this, so
+    // the accelerator must neither dispatch nor preventDefault — a suppressed
+    // keystroke that does nothing is worse than one left alone.
+    isTauri.mockReturnValue(false);
+    await booted();
+    const notCancelled = fireEvent.keyDown(window, { key: "=", metaKey: true });
+    expect(zoomSpy).not.toHaveBeenCalled();
+    expect(notCancelled).toBe(true);
+  });
+});
+
+describe("Window new workspace", () => {
+  it("pins the drawer inside the row, not as a sibling of the status bar", async () => {
+    await booted();
+    await userEvent.click(screen.getByRole("button", { name: /Default/ }));
+    await userEvent.click(await screen.findByRole("button", { name: "New workspace" }));
+    const drawer = await screen.findByRole("complementary", { name: "Details" });
+    // The row is the middle `flex min-h-0 flex-1` that holds Rail/Nav/the tab
+    // column — an exact class match, since that string is unique to it.
+    const row = document.querySelector('div[class="flex min-h-0 flex-1"]');
+    expect(row).not.toBeNull();
+    expect(drawer.parentElement).toBe(row);
+  });
+
+  it("creates a workspace from the switcher with the name typed and the clusters picked", async () => {
+    listContexts.mockResolvedValue({ contexts: [ctx("prod"), ctx("dev")] });
+    await booted();
+    await userEvent.click(screen.getByRole("button", { name: /Default/ }));
+    await userEvent.click(await screen.findByRole("button", { name: "New workspace" }));
+    await userEvent.type(screen.getByRole("textbox", { name: "Workspace name" }), "Team");
+    // Both clusters start picked; unticking "prod" leaves only "dev".
+    await userEvent.click(screen.getByRole("checkbox", { name: "prod" }));
+    await userEvent.click(screen.getByRole("button", { name: "Create" }));
+    expect(createWorkspaceSpy).toHaveBeenCalledWith("Team", ["dev"]);
+    expect(store.currentWorkspace().name).toBe("Team");
+    expect(store.currentWorkspace().clusters).toEqual(["dev"]);
   });
 });

--- a/packages/ui-next/src/shell/Window.test.tsx
+++ b/packages/ui-next/src/shell/Window.test.tsx
@@ -93,6 +93,7 @@ import * as store from "../lib/tabsStore";
 import { resetProbes } from "../lib/probe";
 import { resetView } from "../lib/workspace";
 import { defaultState, makeTab } from "../lib/tabs";
+import { defaultMark, getMark, setMark, MARKS_KEY } from "../lib/marks";
 
 const ctx = (stableId: string, name = stableId) => ({ name, stableId, cluster: name, server: "", isCurrent: false });
 
@@ -193,6 +194,19 @@ describe("Window boot", () => {
     expect(store.getState().workspaces[0].clusters).toEqual(["prod"]);
   });
 
+  it("boots to a usable window when every saved workspace fails to parse and the cluster list also errors", async () => {
+    // `parseStoredState` can legitimately return zero workspaces (every stored
+    // one failed to parse). Before the fix, the `saved && outcome.error`
+    // branch installed that raw — bypassing `reconcile`, the only thing that
+    // restores a default workspace — and `currentWorkspace()` returning
+    // `undefined` threw at render.
+    loadTabsState.mockReturnValue({ workspaces: [], currentId: "gone" });
+    listContexts.mockResolvedValue({ error: "kubeconfig unreadable" });
+    await booted();
+    expect(store.getState().workspaces.length).toBeGreaterThan(0);
+    expect(screen.getByRole("tablist")).toBeDefined();
+  });
+
   it("saves on every store change after boot, and flushes on unload", async () => {
     await booted();
     expect(installFlushOnUnload).toHaveBeenCalled();
@@ -214,6 +228,41 @@ describe("Window boot", () => {
     expect(flushSave).not.toHaveBeenCalled();
     view.unmount();
     expect(flushSave).toHaveBeenCalled();
+  });
+});
+
+describe("Window marks", () => {
+  it("loads stored cluster marks at boot, so a colour set before this launch is not lost", async () => {
+    localStorage.setItem(
+      MARKS_KEY,
+      JSON.stringify({ prod: { name: "prod", short: "PR", color: "var(--ok)", mark: "text", withText: true } }),
+    );
+    await booted();
+    expect(getMark("prod", "prod").color).toBe("var(--ok)");
+  });
+
+  it("setting one cluster's mark does not erase another cluster's stored entry", async () => {
+    // Before the fix, the module started at `marks = {}` (nothing had ever
+    // loaded it), so the first `setMark` spread over an empty record and
+    // persisted that — every other cluster's stored mark vanished from disk.
+    localStorage.setItem(
+      MARKS_KEY,
+      JSON.stringify({ prod: { name: "prod", short: "PR", color: "var(--ok)", mark: "text", withText: true } }),
+    );
+    listContexts.mockResolvedValue({ contexts: [ctx("prod"), ctx("dev")] });
+    await booted();
+    act(() => setMark("dev", { ...defaultMark("dev"), color: "var(--warn)" }));
+    const stored = JSON.parse(localStorage.getItem(MARKS_KEY)!);
+    expect(stored.prod.color).toBe("var(--ok)");
+    expect(stored.dev.color).toBe("var(--warn)");
+  });
+});
+
+describe("Window cluster list error", () => {
+  it("surfaces a failed cluster list to the rail instead of just leaving it empty", async () => {
+    listContexts.mockResolvedValue({ error: "kubeconfig unreadable" });
+    await booted();
+    expect(screen.getByRole("img", { name: "kubeconfig unreadable" })).toBeDefined();
   });
 });
 
@@ -350,6 +399,18 @@ describe("Window accelerators", () => {
     expect(zoomSpy).toHaveBeenCalledWith("in");
     // `false` means preventDefault() was called on a cancelable event.
     expect(notCancelled).toBe(false);
+  });
+
+  it("leaves ⌘W alone in web mode too — the browser owns it, and closing the tab under it would look like data loss", async () => {
+    // A browser delivers ⌘W without letting the page cancel it; if `closeTab`
+    // still ran here, `installFlushOnUnload` would persist the close as the
+    // page unloads and the tab would be missing on the next visit.
+    isTauri.mockReturnValue(false);
+    await booted();
+    act(() => store.openTab("/k/pods"));
+    const notCancelled = fireEvent.keyDown(window, { key: "w", metaKey: true });
+    expect(store.currentWorkspace().tabs).toHaveLength(2);
+    expect(notCancelled).toBe(true);
   });
 
   it("leaves the browser's own zoom alone in web mode", async () => {

--- a/packages/ui-next/src/shell/Window.test.tsx
+++ b/packages/ui-next/src/shell/Window.test.tsx
@@ -74,6 +74,20 @@ describe("Window boot", () => {
     expect(store.getState().workspaces[0].clusters).toEqual([]);
   });
 
+  it("keeps the saved workspaces untouched when the cluster list errors", async () => {
+    const saved = {
+      workspaces: [{ id: "w1", name: "Team", clusters: ["prod"], tabs: [makeTab("/")], activeId: "", closed: [] }],
+      currentId: "w1",
+    };
+    saved.workspaces[0].activeId = saved.workspaces[0].tabs[0].id;
+    loadTabsState.mockReturnValue(saved);
+    listContexts.mockResolvedValue({ error: "kubeconfig unreadable" });
+    render(<Window ported={[]} onOpenInClassic={() => {}} />);
+    await screen.findByRole("tablist");
+    // reconcile(saved, []) would have stripped "prod"; a transient failure must not.
+    expect(store.currentWorkspace().clusters).toEqual(["prod"]);
+  });
+
   it("shows a loading state rather than the wrong tabs before boot resolves", () => {
     let resolve!: (v: unknown) => void;
     listContexts.mockReturnValue(new Promise((r) => (resolve = r)));

--- a/packages/ui-next/src/shell/Window.tsx
+++ b/packages/ui-next/src/shell/Window.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { isApplePlatform, isTauri, listContexts, type ClusterContext } from "@srelens/core";
 import { Button, Checkbox, Drawer, LoadingState, TabStrip, TextInput, type ContextMenuItem, type StripTab } from "@srelens/ui-kit";
+import { loadMarks } from "../lib/marks";
 import { defaultState, reconcile } from "../lib/tabs";
 import { flushSave, installFlushOnUnload, loadTabsState, scheduleSave } from "../lib/tabsPersist";
 import {
@@ -76,6 +77,10 @@ export function Window({
   // names, the sidebar looks up CRDs by name, and the new-tab action turns the
   // active cluster's id into the name a tab carries.
   const [contexts, setContexts] = useState<ClusterContext[]>([]);
+  // Kept rather than dropped once read: a failed list still preserves the
+  // saved cluster ids (see below), and the rail has to say why it cannot draw
+  // them rather than leaving the user to guess.
+  const [contextsError, setContextsError] = useState<string | undefined>(undefined);
   const [creating, setCreating] = useState(false);
   const [name, setName] = useState("");
   const [picked, setPicked] = useState<Set<string>>(new Set());
@@ -99,17 +104,31 @@ export function Window({
       // The contexts are read first so that `found` is already filled if the
       // saved state is what fails: the fallback is then a Default workspace
       // over the user's real clusters rather than an empty rail.
+      // Loaded before anything else in boot: it try/catches internally and
+      // cannot throw, so there is no reason to make the tabs/contexts work
+      // wait on it. Without this call the module never reads what is on disk
+      // — every mark starts at the default, and the first `setMark` then
+      // spreads over that empty record and persists it, erasing every other
+      // cluster's stored appearance.
+      loadMarks();
       let found: ClusterContext[] = [];
       try {
         const outcome = await listContexts();
         if (cancelled) return;
         found = outcome.contexts ?? [];
+        if (outcome.error) setContextsError(outcome.error);
         const saved = loadTabsState();
         if (saved && outcome.error) {
           // The list failed, not the clusters: reconciling against nothing would
           // strip every workspace's cluster ids and the next change would persist
-          // that. Trust the disk until the backend answers.
-          setState(saved);
+          // that. Trust the disk until the backend answers — unless there is
+          // nothing to trust: `parseStoredState` can legitimately return zero
+          // workspaces (every stored one failed to parse), and installing that
+          // raw skips `reconcile`, the only thing that restores a default
+          // workspace. `currentWorkspace()` on an empty list is `undefined`,
+          // and `useTabs` dereferencing it is a render-time crash — the one
+          // thing "boot must always reach `setBooted(true)`" exists to prevent.
+          setState(saved.workspaces.length > 0 ? saved : defaultState(found));
         } else {
           setState(saved ? reconcile(saved, found) : defaultState(found));
         }
@@ -200,11 +219,22 @@ export function Window({
     function onKey(e: KeyboardEvent) {
       const action = matchWindowKey(e, apple);
       if (!action) return;
-      // In web mode a zoom chord is the browser's own — neither dispatched
-      // nor preventDefault-ed, so Cmd/Ctrl +/-/0 falls through to it exactly
-      // as it would with no listener here at all.
-      const zooms = action.type === "zoom-in" || action.type === "zoom-out" || action.type === "zoom-reset";
-      if (zooms && !desktop) return;
+      // In web mode these chords are the browser's own — neither dispatched
+      // nor preventDefault-ed, so they fall through exactly as they would with
+      // no listener here at all. Zoom is the browser's native zoom (core's
+      // uiScale doc); ⌘W/⌘T/⌘1-9 are tab chords a page cannot cancel, so
+      // acting on them here would desync this workspace's tabs from the one
+      // the browser just closed/opened/switched to. `reopen-tab`,
+      // `prev-tab`/`next-tab` and `console` collide with nothing the browser
+      // owns, so they still fire.
+      const browserOwned =
+        action.type === "zoom-in" ||
+        action.type === "zoom-out" ||
+        action.type === "zoom-reset" ||
+        action.type === "close-tab" ||
+        action.type === "new-tab" ||
+        action.type === "select-tab";
+      if (browserOwned && !desktop) return;
       e.preventDefault();
       runRef.current(action);
     }
@@ -254,7 +284,7 @@ export function Window({
         />
       )}
       <div className="flex min-h-0 flex-1">
-        {active && <Rail contexts={contexts} onConnect={() => openTab("/connect")} />}
+        {active && <Rail contexts={contexts} error={contextsError} onConnect={() => openTab("/connect")} />}
         {active && <Nav contexts={contexts} />}
         <div className="flex min-h-0 flex-1 flex-col">
           {active && (

--- a/packages/ui-next/src/shell/Window.tsx
+++ b/packages/ui-next/src/shell/Window.tsx
@@ -1,32 +1,89 @@
-import { useEffect, useState } from "react";
-import { listContexts, type ClusterContext } from "@srelens/core";
-import { LoadingState, TabStrip } from "@srelens/ui-kit";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { isApplePlatform, listContexts, type ClusterContext } from "@srelens/core";
+import { Button, Checkbox, Drawer, LoadingState, TabStrip, TextInput, type ContextMenuItem, type StripTab } from "@srelens/ui-kit";
 import { defaultState, reconcile } from "../lib/tabs";
 import { flushSave, installFlushOnUnload, loadTabsState, scheduleSave } from "../lib/tabsPersist";
-import { activateTab, closeTab, getState, newTab, setState, subscribe, useTabs } from "../lib/tabsStore";
+import {
+  activateTab,
+  closeAll,
+  closeOthers,
+  closeTab,
+  closeToRight,
+  createWorkspace,
+  currentWorkspace,
+  cycleTab,
+  duplicateTab,
+  getState,
+  newTab,
+  openTab,
+  reopenClosed,
+  selectIndex,
+  setState,
+  subscribe,
+  switchWorkspace,
+  togglePin,
+  useActiveCluster,
+  useTabs,
+} from "../lib/tabsStore";
+import { useConsole } from "../console";
+import { getInfo, probeCluster } from "../lib/probe";
+import { hint, matchWindowKey, type WindowAction } from "../lib/shortcuts";
 import { Body } from "./Body";
+import { Chrome, zoom } from "./Chrome";
+import { Console } from "./Console";
+import { Nav } from "./Nav";
+import { Rail } from "./Rail";
+import { Status } from "./Status";
 import { TabSurface } from "./TabSurface";
 
 export interface WindowProps {
   /** Display names of the screens that exist in the new design. */
   ported: string[];
-  onOpenInClassic: (route: string) => void;
-  /** Handed to every Placeholder; see its doc comment for why it lives there. */
+  onOpenInClassic: (route: string, context?: string) => void;
   onOpenGallery?: () => void;
+  onToggleTheme?: () => void;
+  controls?: "macos" | "none";
+  /**
+   * False while the gallery is up: the chrome comes down and the accelerators
+   * stop listening, but the tab bodies stay mounted so the session survives.
+   */
+  active?: boolean;
 }
 
 /**
- * The new design's window: the tab strip over the tab bodies. PR 1 of the
- * shell — the rail, sidebar, titlebar, status bar and console arrive in PR 2,
- * each composed around this.
+ * The new design's window: the chrome composed around the tab strip over the
+ * tab bodies.
  *
  * Boot reads the saved tabs and the cluster list together, then either
  * reconciles the one against the other or builds a Default workspace from the
  * clusters. Nothing renders until that resolves: a flash of last session's
  * tabs being replaced by this session's would read as the app losing work.
+ *
+ * The accelerator table is bound here, once, rather than in every component
+ * that wants one — a chord bound twice is a chord that fires twice. It listens
+ * only while `active`, which is what keeps ⌘T out of the gallery's own inputs.
  */
-export function Window({ ported, onOpenInClassic, onOpenGallery }: WindowProps) {
+export function Window({
+  ported,
+  onOpenInClassic,
+  onOpenGallery,
+  onToggleTheme = () => {},
+  controls = "none",
+  active = true,
+}: WindowProps) {
   const [booted, setBooted] = useState(false);
+  // Kept from boot because half the chrome wants it: the rail resolves ids to
+  // names, the sidebar looks up CRDs by name, and the new-tab action turns the
+  // active cluster's id into the name a tab carries.
+  const [contexts, setContexts] = useState<ClusterContext[]>([]);
+  const [creating, setCreating] = useState(false);
+  const [name, setName] = useState("");
+  const [picked, setPicked] = useState<Set<string>>(new Set());
+  const apple = useMemo(() => isApplePlatform(), []);
+  const { setOpen } = useConsole();
+  const { tabs, activeId, workspace } = useTabs();
+  const activeIdCluster = useActiveCluster();
+  const activeCtx = contexts.find((c) => c.stableId === activeIdCluster) ?? null;
 
   useEffect(() => {
     let cancelled = false;
@@ -57,6 +114,7 @@ export function Window({ ported, onOpenInClassic, onOpenGallery }: WindowProps) 
         console.error("could not restore the workspaces", error);
         setState(defaultState(found));
       }
+      setContexts(found);
       setBooted(true);
     })();
     return () => {
@@ -80,37 +138,173 @@ export function Window({ ported, onOpenInClassic, onOpenGallery }: WindowProps) 
     };
   }, [booted]);
 
-  const { tabs, activeId } = useTabs();
+  // Every cluster you are looking at gets probed once, so the rail shows link
+  // state and the status bar shows a version without waiting to be asked. The
+  // effect runs per workspace rather than per render — switching away and back
+  // re-runs it, and the probe store's memory is what keeps it to once each.
+  const workspaceId = workspace.id;
+  useEffect(() => {
+    if (!booted) return;
+    if (!active) return;
+    const byId = new Map(contexts.map((c) => [c.stableId, c]));
+    for (const id of currentWorkspace().clusters) {
+      if (getInfo(id)) continue;
+      const ctx = byId.get(id);
+      if (ctx) void probeCluster(ctx);
+    }
+    // `contexts` rides along because a kubeconfig change replaces them; the
+    // workspace id is the trigger for the switch case.
+  }, [booted, contexts, workspaceId, active]);
+
+  // Read at call time rather than closed over: an effect installed once must
+  // act on whatever the strip shows now, not whatever it showed at mount.
+  function run(action: WindowAction) {
+    const w = currentWorkspace();
+    switch (action.type) {
+      case "close-tab":
+        return closeTab(w.activeId);
+      case "new-tab":
+        return newTab("/", activeCtx?.name);
+      case "reopen-tab":
+        return reopenClosed();
+      case "prev-tab":
+        return cycleTab(-1);
+      case "next-tab":
+        return cycleTab(1);
+      case "select-tab":
+        return selectIndex(action.index);
+      case "console":
+        return setOpen(true);
+      case "zoom-in":
+        return zoom("in");
+      case "zoom-out":
+        return zoom("out");
+      case "zoom-reset":
+        return zoom("reset");
+    }
+  }
+
+  // Read at call time rather than closed over: an effect installed once must
+  // act on whatever the strip shows now, not whatever it showed at mount.
+  const runRef = useRef(run);
+  useEffect(() => {
+    runRef.current = run;
+  });
+
+  useEffect(() => {
+    if (!active) return;
+    function onKey(e: KeyboardEvent) {
+      const action = matchWindowKey(e, apple);
+      if (!action) return;
+      e.preventDefault();
+      runRef.current(action);
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [active, apple]);
+
+  function menuFor(tab: StripTab): ContextMenuItem[] {
+    return [
+      { label: "Duplicate", onPick: () => duplicateTab(tab.id) },
+      { label: tab.pinned ? "Unpin" : "Pin", onPick: () => togglePin(tab.id) },
+      { kind: "sep" },
+      { label: "Close", hint: hint("close-tab", apple), danger: true, onPick: () => closeTab(tab.id) },
+      { label: "Close others", onPick: () => closeOthers(tab.id) },
+      { label: "Close to the right", onPick: () => closeToRight(tab.id) },
+      { label: "Close all", onPick: () => closeAll() },
+      { kind: "sep" },
+      { label: "Reopen closed", hint: hint("reopen-tab", apple), onPick: () => reopenClosed() },
+    ];
+  }
+
+  function openNewWorkspace() {
+    setName("");
+    setPicked(new Set(contexts.map((c) => c.stableId)));
+    setCreating(true);
+  }
+
+  function create() {
+    const ids = contexts.filter((c) => picked.has(c.stableId)).map((c) => c.stableId);
+    // An unnamed workspace still gets one — the strip and the switcher have to
+    // call it something, and an empty chip reads as a bug.
+    const id = createWorkspace(name.trim() || "New workspace", ids);
+    switchWorkspace(id);
+    setCreating(false);
+  }
 
   if (!booted) return <LoadingState label="Loading" />;
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <TabStrip
-        tabs={tabs}
-        activeId={activeId}
-        onSelect={activateTab}
-        onClose={closeTab}
-        // No cluster name: `contexts[0]` is whichever context the kubeconfig
-        // lists first, which is neither the current cluster nor necessarily
-        // one in this workspace, and `TabStrip` reads `sub` into the tab's
-        // accessible name. PR 2 wires the active cluster from `lib/workspace`.
-        onNew={() => newTab("/")}
-        label="Open tabs"
-      />
-      <div className="relative min-h-0 flex-1">
-        {tabs.map((tab) => (
-          <TabSurface key={tab.id} visible={tab.id === activeId}>
-            <Body
-              route={tab.route}
-              clusterName={tab.sub}
-              ported={ported}
-              onOpenInClassic={onOpenInClassic}
-              onOpenGallery={onOpenGallery}
+      {active && (
+        <Chrome
+          controls={controls}
+          clusterName={activeCtx?.name}
+          onToggleTheme={onToggleTheme}
+          onNewWorkspace={openNewWorkspace}
+        />
+      )}
+      <div className="flex min-h-0 flex-1">
+        {active && <Rail contexts={contexts} onConnect={() => openTab("/connect")} />}
+        {active && <Nav contexts={contexts} />}
+        <div className="flex min-h-0 flex-1 flex-col">
+          {active && (
+            <TabStrip
+              tabs={tabs}
+              activeId={activeId}
+              onSelect={activateTab}
+              onClose={closeTab}
+              menuFor={menuFor}
+              onNew={() => run({ type: "new-tab" })}
+              newHint={hint("new-tab", apple)}
+              label="Open tabs"
             />
-          </TabSurface>
-        ))}
+          )}
+          <div className="relative min-h-0 flex-1">
+            {tabs.map((tab) => (
+              <TabSurface key={tab.id} visible={tab.id === activeId}>
+                {/* A placeholder tab without a cluster of its own still leaves
+                    via the cluster this window is looking at — that is the
+                    context classic reopens onto. */}
+                <Body
+                  route={tab.route}
+                  clusterName={tab.sub ?? activeCtx?.name}
+                  ported={ported}
+                  onOpenInClassic={onOpenInClassic}
+                  onOpenGallery={onOpenGallery}
+                />
+              </TabSurface>
+            ))}
+          </div>
+          {active && <Console apple={apple} />}
+        </div>
       </div>
+      {active && <Status contexts={contexts} />}
+      <Drawer open={creating} title="New workspace" onClose={() => setCreating(false)}>
+        <div className="flex flex-col gap-3 px-3 py-3">
+          <TextInput value={name} onValueChange={setName} placeholder="Workspace name" aria-label="Workspace name" />
+          {contexts.map((c) => (
+            <Checkbox
+              key={c.stableId}
+              checked={picked.has(c.stableId)}
+              onChange={(checked) =>
+                setPicked((prev) => {
+                  const next = new Set(prev);
+                  if (checked) next.add(c.stableId);
+                  else next.delete(c.stableId);
+                  return next;
+                })
+              }
+              label={c.name}
+            />
+          ))}
+          <div className="flex justify-end">
+            <Button variant="primary" size="sm" onClick={() => create()}>
+              Create
+            </Button>
+          </div>
+        </div>
+      </Drawer>
     </div>
   );
 }

--- a/packages/ui-next/src/shell/Window.tsx
+++ b/packages/ui-next/src/shell/Window.tsx
@@ -44,7 +44,14 @@ export function Window({ ported, onOpenInClassic, onOpenGallery }: WindowProps) 
         if (cancelled) return;
         found = outcome.contexts ?? [];
         const saved = loadTabsState();
-        setState(saved ? reconcile(saved, found) : defaultState(found));
+        if (saved && outcome.error) {
+          // The list failed, not the clusters: reconciling against nothing would
+          // strip every workspace's cluster ids and the next change would persist
+          // that. Trust the disk until the backend answers.
+          setState(saved);
+        } else {
+          setState(saved ? reconcile(saved, found) : defaultState(found));
+        }
       } catch (error) {
         if (cancelled) return;
         console.error("could not restore the workspaces", error);

--- a/packages/ui-next/src/shell/Window.tsx
+++ b/packages/ui-next/src/shell/Window.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { isApplePlatform, listContexts, type ClusterContext } from "@srelens/core";
+import { isApplePlatform, isTauri, listContexts, type ClusterContext } from "@srelens/core";
 import { Button, Checkbox, Drawer, LoadingState, TabStrip, TextInput, type ContextMenuItem, type StripTab } from "@srelens/ui-kit";
 import { defaultState, reconcile } from "../lib/tabs";
 import { flushSave, installFlushOnUnload, loadTabsState, scheduleSave } from "../lib/tabsPersist";
@@ -80,6 +80,10 @@ export function Window({
   const [name, setName] = useState("");
   const [picked, setPicked] = useState<Set<string>>(new Set());
   const apple = useMemo(() => isApplePlatform(), []);
+  // Desktop only: `zoom` asks the webview to scale itself, which only exists
+  // under Tauri. In a browser the native zoom already does this (see core's
+  // uiScale doc), so a zoom chord here has to fall through to it untouched.
+  const desktop = useMemo(() => isTauri(), []);
   const { setOpen } = useConsole();
   const { tabs, activeId, workspace } = useTabs();
   const activeIdCluster = useActiveCluster();
@@ -196,12 +200,17 @@ export function Window({
     function onKey(e: KeyboardEvent) {
       const action = matchWindowKey(e, apple);
       if (!action) return;
+      // In web mode a zoom chord is the browser's own — neither dispatched
+      // nor preventDefault-ed, so Cmd/Ctrl +/-/0 falls through to it exactly
+      // as it would with no listener here at all.
+      const zooms = action.type === "zoom-in" || action.type === "zoom-out" || action.type === "zoom-reset";
+      if (zooms && !desktop) return;
       e.preventDefault();
       runRef.current(action);
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [active, apple]);
+  }, [active, apple, desktop]);
 
   function menuFor(tab: StripTab): ContextMenuItem[] {
     return [
@@ -209,9 +218,9 @@ export function Window({
       { label: tab.pinned ? "Unpin" : "Pin", onPick: () => togglePin(tab.id) },
       { kind: "sep" },
       { label: "Close", hint: hint("close-tab", apple), danger: true, onPick: () => closeTab(tab.id) },
-      { label: "Close others", onPick: () => closeOthers(tab.id) },
-      { label: "Close to the right", onPick: () => closeToRight(tab.id) },
-      { label: "Close all", onPick: () => closeAll() },
+      { label: "Close others", danger: true, onPick: () => closeOthers(tab.id) },
+      { label: "Close to the right", danger: true, onPick: () => closeToRight(tab.id) },
+      { label: "Close all", danger: true, onPick: () => closeAll() },
       { kind: "sep" },
       { label: "Reopen closed", hint: hint("reopen-tab", apple), onPick: () => reopenClosed() },
     ];
@@ -278,33 +287,33 @@ export function Window({
           </div>
           {active && <Console apple={apple} />}
         </div>
+        <Drawer open={creating} title="New workspace" onClose={() => setCreating(false)}>
+          <div className="flex flex-col gap-3 px-3 py-3">
+            <TextInput value={name} onValueChange={setName} placeholder="Workspace name" aria-label="Workspace name" />
+            {contexts.map((c) => (
+              <Checkbox
+                key={c.stableId}
+                checked={picked.has(c.stableId)}
+                onChange={(checked) =>
+                  setPicked((prev) => {
+                    const next = new Set(prev);
+                    if (checked) next.add(c.stableId);
+                    else next.delete(c.stableId);
+                    return next;
+                  })
+                }
+                label={c.name}
+              />
+            ))}
+            <div className="flex justify-end">
+              <Button variant="primary" size="sm" onClick={() => create()}>
+                Create
+              </Button>
+            </div>
+          </div>
+        </Drawer>
       </div>
       {active && <Status contexts={contexts} />}
-      <Drawer open={creating} title="New workspace" onClose={() => setCreating(false)}>
-        <div className="flex flex-col gap-3 px-3 py-3">
-          <TextInput value={name} onValueChange={setName} placeholder="Workspace name" aria-label="Workspace name" />
-          {contexts.map((c) => (
-            <Checkbox
-              key={c.stableId}
-              checked={picked.has(c.stableId)}
-              onChange={(checked) =>
-                setPicked((prev) => {
-                  const next = new Set(prev);
-                  if (checked) next.add(c.stableId);
-                  else next.delete(c.stableId);
-                  return next;
-                })
-              }
-              label={c.name}
-            />
-          ))}
-          <div className="flex justify-end">
-            <Button variant="primary" size="sm" onClick={() => create()}>
-              Create
-            </Button>
-          </div>
-        </div>
-      </Drawer>
     </div>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,6 +302,9 @@ importers:
       '@srelens/ui-kit':
         specifier: workspace:*
         version: link:../ui-kit
+      lucide-react:
+        specifier: ^1.22.0
+        version: 1.22.0(react@19.2.7)
     devDependencies:
       '@testing-library/react':
         specifier: ^16.3.2


### PR DESCRIPTION
PRs 2 and 3 of 3 for the new design's shell, in one branch. Part of #305, steps 2–3. Spec: `docs/superpowers/specs/2026-08-21-new-design-shell-design.md` (local, gitignored by convention). Follows #334.

**Why the two are one PR.** PR 2 was to be the chrome and PR 3 the first real-data screens. The chrome cannot be reviewed without a screen under it — a status bar with no cluster, a rail with no marks and a sidebar with no tree are three empty boxes — and each screen needed the chrome to be reachable at all. Splitting them would have meant a PR 2 that could not be exercised.

## What this makes possible

Switching the new design on now boots into a working app rather than a titled placeholder. Every piece of chrome is joined to real state:

- **Titlebar** — workspace switcher, window actions, and on macOS an overlay titlebar with the traffic lights the OS draws (and the theme toggle beside them).
- **Cluster rail** — the workspace's clusters as marks, each with its own colour, initials, icon or uploaded image, the link state from `connectCluster`, and a drawer to customise or remove one.
- **Sidebar** — the real resource tree, with the cluster's CRDs discovered and listed under Custom resources.
- **Status bar** — the active cluster, its link state, and the live port-forwards.
- **Console dock** — mounted under the console provider, so `ask()` from anywhere on screen lands in it.
- **Window accelerators** — one platform-strict table, bound once.

Two screens run on real data: **Release notes**, which shows the available update, and **Application log**. Settings lists them beside the design toggle, and switching back to classic reopens it at the route the new design was on.

## What carried over from #334

All three residuals that PR were left holding are closed here:

- `listContexts` erroring no longer reconciles every workspace's clusters away (`09fc38d`), and — found while reviewing this branch — no longer installs a saved state with zero workspaces raw, which skipped the only `reconcile` that restores a default and crashed at render.
- The gallery affordance is gated: the `Window` takes `active`, which is false while `#gallery` is up, so the chrome comes down and the accelerators stop answering rather than firing into the gallery's own inputs.
- `SCREENS` and `APP_SCOPED` are null-prototype and read through `hasOwnProperty.call`, closed before `SCREENS` gained its first entries.

## Decisions worth not relitigating

- **A stored mark's `name` is the operator's, not a cache of the context's.** `getMark` used to overwrite it on the way out, which made the drawer's name field inert — every keystroke stored and reverted on the next read. A cluster renamed in the kubeconfig now follows that rename only while nobody has customised it, which is the case the rename mattered for.
- **Marks are keyed by `stableId`**, for the same reason workspaces are (#265).
- **The chrome does not own the traffic lights where the OS draws them.** `nativeLights` requires `isTauri() && isApplePlatform()` *and* `controls !== "macos"`, so the kit's drawn lights and this bar's gap span cannot both be true whatever a caller passes.
- **CRD discovery failing costs the CRDs, not the tree.** Feeding it into `ResourceTree`'s tree-level error replaced the whole tree, so a user with ordinary RBAC lost the built-in kinds and Investigate too, and Retry kept failing against a tree that no longer existed. It is one leaf now, and activating it reloads.
- **The console dock does not answer yet.** A submitted question renders an EmptyState saying the agent is not in the new design, with the question echoed back — the seam reads as unfinished rather than broken.

## What review found, and what it cost

Per-task reviews plus a whole-branch pass; every finding fixed on the branch. The ones worth knowing about:

- **The marks were never read off disk.** Nothing called `loadMarks`, so every launch started from an empty record and the first `setMark` spread over it and persisted that — erasing every *other* cluster's stored colour. A data-loss bug that only shows on the second cluster.
- **Web mode swallowed ⌘W, ⌘T and ⌘1–9** into our tab model. A page cannot cancel those: the browser closed its tab anyway, `installFlushOnUnload` persisted our close on the way out, and the tab was gone on the next visit. They join the zoom chords as the browser's; `reopen-tab`, prev/next and the console still fire.
- **The zoom accelerators dispatched into core's `uiScale` and called `preventDefault` in a browser**, where native zoom already owns Cmd/Ctrl +/−/0.
- **The rail's probe subscription never fired.** It read the store through `useInfo(null)`, whose snapshot is `undefined` whatever happens, so the version reached the hint only on the workspace store's coat-tails. The probe store gained `useInfos()` for a caller holding a list rather than an id.
- **`AppLog` dropped the log target and showed a date-truncated timestamp**, and could not tell a truncated log from a filter that matched nothing.
- **The sidebar's fold seed reset on every remount**, so it could not tell "the user closed all six groups" from "first launch". It is a module-level flag now, reset by `resetView`.
- **A drag-region test asserted a tautology** — `el.closest("header") === bar()`, which every element satisfies. Replaced with the actual contract: which slots carry `data-tauri-drag-region` and which do not.

## Known gaps, stated

- The console dock is a seam, not an agent. #305 step 9.
- Only two routes have screens; every other route is still the Placeholder.
- Workspace membership is edited from the rail's drawer (remove) and the switcher (create); there is no reorder yet.

## Verification

- 2623 tests across 250 files pass; coverage 89.33 / 85.65 / 77.96, above the 85 / 80 / 76 floors.
- `pnpm -r typecheck` clean across all four projects; `pnpm build` clean, and `dist/index.html` still links no stylesheet — the one-stylesheet-per-document invariant #314 rests on.
- The macOS titlebar work was done against a live Tauri build (that is where the doubled traffic lights and the leftover native title were found); a fresh launch of the final tree is worth one pass before merge.
