### PR TITLE
feat(ui-next): the cluster overview, and the requests behind it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-executor"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -884,6 +896,23 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -7166,14 +7195,19 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
+ "async-compression",
  "base64 0.22.1",
  "bitflags 2.13.0",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "mime",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",

--- a/apps/desktop/src/components/AppearanceSettingsSection.test.tsx
+++ b/apps/desktop/src/components/AppearanceSettingsSection.test.tsx
@@ -56,6 +56,15 @@ describe("AppearanceSettingsSection", () => {
     expect(items).toContain("Events");
   });
 
+  it("lists the cluster overview, the first thing the new design's sidebar opens", () => {
+    // `/overview` is the sidebar's first cluster node, so a reader trying the
+    // new design lands on it before anything else. Leaving it off this list
+    // would tell them the screen they are looking at does not exist.
+    render(<AppearanceSettingsSection />);
+    const items = screen.getAllByRole("listitem").map((li) => li.textContent);
+    expect(items).toContain("Cluster overview");
+  });
+
   it("introduces the list, so the names are not a bare list under the hint", () => {
     render(<AppearanceSettingsSection />);
     expect(screen.getByText(/in the new design so far/i)).toBeDefined();

--- a/apps/desktop/src/design.test.ts
+++ b/apps/desktop/src/design.test.ts
@@ -60,6 +60,7 @@ describe("the list of ported screens", () => {
       "/resources",
       "/k",
       "/events",
+      "/overview",
     ]);
   });
 
@@ -70,6 +71,7 @@ describe("the list of ported screens", () => {
       "Workloads",
       "Resource lists and details",
       "Events",
+      "Cluster overview",
     ]);
   });
 });

--- a/apps/desktop/src/design.ts
+++ b/apps/desktop/src/design.ts
@@ -207,6 +207,10 @@ export const PORTED_SCREENS: ReadonlyArray<{ route: string; name: string }> = [
   // `/events` has its own chrome — the by-reason rail and the type filter —
   // and `/k/events` resolves to it too.
   { route: "/events", name: "Events" },
+  // The sidebar's first cluster node. Not one of the `/k` lists and not the
+  // control room: it is the cluster's own front page — the capacity strip, the
+  // nodes table, the unhealthy list and the At a glance rail.
+  { route: "/overview", name: "Cluster overview" },
 ];
 
 /**

--- a/crates/kube/Cargo.toml
+++ b/crates/kube/Cargo.toml
@@ -16,7 +16,14 @@ thiserror = "1"
 tokio = { version = "1", features = ["fs", "time", "net", "io-util", "process"] }
 # `ring` is explicit: kube 4 split the rustls crypto provider out of
 # `rustls-tls`, and without it rustls panics when it builds a TLS config.
-kube = { version = "4", default-features = false, features = ["client", "config", "rustls-tls", "ring", "runtime", "ws"] }
+# `gzip` asks every cluster for compressed responses (tower-http decodes them
+# transparently): on a 113-node cluster a metadata-only pod list carrying
+# managedFields runs ~55MB uncompressed vs ~3MB gzipped, and it was the
+# reason `k8s.podCount` missed its 3s Fleet budget. Measured on a real
+# cluster: request wall time dropped from ~5.2s to ~1.3s; on a local kind
+# cluster over loopback the payload is small enough that gzip is a wash
+# either way. Without this feature, kube-rs never sends `Accept-Encoding`.
+kube = { version = "4", default-features = false, features = ["client", "config", "rustls-tls", "ring", "runtime", "ws", "gzip"] }
 k8s-openapi = { version = "0.28", features = ["v1_34"] }
 futures = "0.3"
 base64 = "0.22"

--- a/crates/kube/src/connect.rs
+++ b/crates/kube/src/connect.rs
@@ -8,6 +8,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
+use k8s_openapi::api::core::v1::Node;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::APIGroupList;
+use kube::api::{Api, ListParams};
 use kube::config::{Config, KubeConfigOptions, Kubeconfig};
 use kube::Client;
 use schemars::JsonSchema;
@@ -504,6 +507,192 @@ pub fn test_cluster_connection_capability() -> Capability {
     )
 }
 
+// --- the cluster facts: provider, region, metrics server ---------------------
+//
+// Deliberately a capability of its own rather than more work on
+// `k8s.clusterInfo`: the reachability probe runs for every cluster in the rail
+// on every launch, and making it heavier to serve one screen is the wrong
+// trade. Reversible if the extra round trip ever costs more than the weight.
+
+/// The API group metrics-server serves.
+const METRICS_GROUP: &str = "metrics.k8s.io";
+
+/// The well-known node label carrying a cluster's cloud region.
+const REGION_LABEL: &str = "topology.kubernetes.io/region";
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ClusterFactsIn {
+    /// The kubeconfig context to read the facts from.
+    pub context: String,
+}
+
+/// Whether the cluster serves `metrics.k8s.io`.
+///
+/// `Absent` is an answer, and an important one: it means every meter on the
+/// overview has no numerator, and the screen says so once. `Unknown` means
+/// discovery could not be asked at all — a different thing, which must never
+/// be drawn as an absence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum MetricsServerState {
+    Present,
+    Absent,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MetricsServerFact {
+    pub state: MetricsServerState,
+    /// The group's preferred version (e.g. "v1beta1"). Empty unless present.
+    pub version: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ClusterFactsOut {
+    pub context: String,
+    /// The cloud the nodes' `spec.providerID` names. **Empty when the nodes
+    /// name none** — a cluster that has told us nothing has not told us it has
+    /// no provider, and the consumer omits the row rather than printing a word
+    /// like "unknown", which would look like an answer.
+    pub provider: String,
+    /// `topology.kubernetes.io/region`. Empty when no node carries it, for the
+    /// same reason as `provider`.
+    pub region: String,
+    pub metrics_server: MetricsServerFact,
+}
+
+/// The cloud a `spec.providerID` names, from its URL scheme.
+///
+/// An unrecognised scheme is reported verbatim: it is exactly what the cluster
+/// said, and a raw `openstack` is more use to a reader than a guess. A value
+/// with no scheme at all names nothing, and reports nothing.
+fn provider_from_provider_id(provider_id: &str) -> String {
+    let Some((scheme, _)) = provider_id.split_once("://") else {
+        return String::new();
+    };
+    match scheme.trim().to_ascii_lowercase().as_str() {
+        "" => String::new(),
+        "gce" => "GKE".to_string(),
+        "aws" => "EKS".to_string(),
+        "azure" => "AKS".to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// The one value the nodes agree on, or nothing.
+///
+/// A node that reports no value abstains rather than vetoes; nodes that report
+/// different values leave the cluster with no single answer, and nothing is the
+/// honest result — naming one of them would be reporting whichever node the
+/// apiserver happened to list first as the cluster's truth. Being a fold over
+/// every node rather than a `find`, the answer cannot depend on list order.
+fn agreed(values: impl Iterator<Item = String>) -> String {
+    let mut answer: Option<String> = None;
+    for value in values.filter(|value| !value.is_empty()) {
+        match &answer {
+            None => answer = Some(value),
+            Some(seen) if *seen == value => {}
+            Some(_) => return String::new(),
+        }
+    }
+    answer.unwrap_or_default()
+}
+
+/// The provider and region the nodes agree on, each possibly empty.
+fn facts_from_nodes(nodes: &[Node]) -> (String, String) {
+    let provider = agreed(nodes.iter().map(|node| {
+        node.spec
+            .as_ref()
+            .and_then(|spec| spec.provider_id.as_deref())
+            .map(provider_from_provider_id)
+            .unwrap_or_default()
+    }));
+    let region = agreed(nodes.iter().map(|node| {
+        node.metadata
+            .labels
+            .as_ref()
+            .and_then(|labels| labels.get(REGION_LABEL))
+            .map(|region| region.trim().to_string())
+            .unwrap_or_default()
+    }));
+    (provider, region)
+}
+
+/// Read metrics-server's availability out of a discovery listing that answered.
+fn metrics_server_from_groups(groups: &APIGroupList) -> MetricsServerFact {
+    match groups.groups.iter().find(|group| group.name == METRICS_GROUP) {
+        Some(group) => MetricsServerFact {
+            state: MetricsServerState::Present,
+            version: group
+                .preferred_version
+                .as_ref()
+                .or_else(|| group.versions.first())
+                .map(|version| version.version.clone())
+                .unwrap_or_default(),
+        },
+        None => MetricsServerFact {
+            state: MetricsServerState::Absent,
+            version: String::new(),
+        },
+    }
+}
+
+/// Read the facts for one context: the nodes carry provider and region,
+/// discovery carries metrics-server.
+///
+/// A cluster that cannot be reached is an error, not empty facts — empty facts
+/// mean "it answered and had nothing to say", and the caller must be able to
+/// tell those apart. Discovery failing on its own is not fatal: the nodes have
+/// already answered, so only metrics-server falls back to `Unknown`.
+async fn read_cluster_facts(cache: &ClientCache, context: &str) -> Result<ClusterFactsOut, String> {
+    let client = cache.get(context).await?;
+
+    let api: Api<Node> = Api::all(client.clone());
+    let nodes = tokio::time::timeout(request_timeout(), api.list(&ListParams::default()))
+        .await
+        .map_err(|_| "list nodes timed out".to_string())?
+        .map_err(|e| e.to_string())?;
+    let (provider, region) = facts_from_nodes(&nodes.items);
+
+    let metrics_server =
+        match tokio::time::timeout(request_timeout(), client.list_api_groups()).await {
+            Ok(Ok(groups)) => metrics_server_from_groups(&groups),
+            // Discovery refused, failed or timed out: we could not ask, which
+            // is not the same as the group not being there.
+            _ => MetricsServerFact {
+                state: MetricsServerState::Unknown,
+                version: String::new(),
+            },
+        };
+
+    Ok(ClusterFactsOut {
+        context: context.to_string(),
+        provider,
+        region,
+        metrics_server,
+    })
+}
+
+/// Build the `k8s.clusterFacts` capability — the overview rail's control-plane
+/// facts, separate from the reachability probe.
+pub fn cluster_facts_capability(cache: Arc<ClientCache>) -> Capability {
+    Capability::typed::<ClusterFactsIn, ClusterFactsOut, _, _>(
+        "k8s.clusterFacts",
+        "report a cluster's provider, region and metrics-server availability",
+        Annotations::READ_ONLY,
+        move |input: ClusterFactsIn| {
+            let cache = cache.clone();
+            async move {
+                read_cluster_facts(&cache, &input.context)
+                    .await
+                    .map_err(CapabilityError::Handler)
+            }
+        },
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -592,6 +781,8 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    use k8s_openapi::api::core::v1::NodeSpec;
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::{APIGroup, GroupVersionForDiscovery};
     use serde_json::json;
     use srelens_capability::Registry;
     use std::path::PathBuf;
@@ -876,5 +1067,155 @@ mod tests {
         assert_eq!(out["reachable"], false);
         assert!(out["error"].is_string());
         let _ = tokio::fs::remove_file(&path).await;
+    }
+
+    // --- the cluster facts: provider, region, metrics server -----------------
+
+    fn node_with(provider_id: Option<&str>, region: Option<&str>) -> Node {
+        let labels = region.map(|r| {
+            let mut labels = std::collections::BTreeMap::new();
+            labels.insert("topology.kubernetes.io/region".to_string(), r.to_string());
+            labels
+        });
+        Node {
+            metadata: kube::core::ObjectMeta {
+                name: Some("n".into()),
+                labels,
+                ..Default::default()
+            },
+            spec: Some(NodeSpec {
+                provider_id: provider_id.map(String::from),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn api_group_list(groups: &[(&str, &str)]) -> APIGroupList {
+        APIGroupList {
+            groups: groups
+                .iter()
+                .map(|(name, version)| APIGroup {
+                    name: (*name).to_string(),
+                    preferred_version: Some(GroupVersionForDiscovery {
+                        group_version: format!("{name}/{version}"),
+                        version: (*version).to_string(),
+                    }),
+                    versions: vec![GroupVersionForDiscovery {
+                        group_version: format!("{name}/{version}"),
+                        version: (*version).to_string(),
+                    }],
+                    ..Default::default()
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn each_known_provider_scheme_names_its_platform() {
+        assert_eq!(provider_from_provider_id("gce://acme-prod/europe-west4-a/gke-node-1"), "GKE");
+        assert_eq!(provider_from_provider_id("aws:///eu-west-1a/i-0abc1234"), "EKS");
+        assert_eq!(provider_from_provider_id("azure:///subscriptions/s/vm-1"), "AKS");
+        assert_eq!(
+            provider_from_provider_id("kind://docker/srelens-demo/srelens-demo-worker"),
+            "kind"
+        );
+    }
+
+    #[test]
+    fn an_unrecognised_scheme_reports_the_scheme_itself_not_a_guess() {
+        assert_eq!(provider_from_provider_id("openstack:///d9c1-4a/instance"), "openstack");
+        assert_eq!(provider_from_provider_id("hcloud://12345"), "hcloud");
+    }
+
+    #[test]
+    fn a_provider_id_that_names_no_scheme_reports_nothing() {
+        assert_eq!(provider_from_provider_id("i-0abc1234"), "");
+        assert_eq!(provider_from_provider_id(""), "");
+    }
+
+    #[test]
+    fn a_node_with_no_provider_id_reports_nothing_rather_than_unknown() {
+        let (provider, _) = facts_from_nodes(&[node_with(None, Some("europe-west4"))]);
+        assert_eq!(provider, "");
+    }
+
+    #[test]
+    fn the_region_label_on_a_node_is_the_clusters_region() {
+        let (_, region) = facts_from_nodes(&[node_with(Some("gce://p/z/n"), Some("europe-west4"))]);
+        assert_eq!(region, "europe-west4");
+    }
+
+    #[test]
+    fn no_region_label_reports_nothing_rather_than_unknown() {
+        let (_, region) = facts_from_nodes(&[node_with(Some("kind://docker/c/n"), None)]);
+        assert_eq!(region, "");
+    }
+
+    #[test]
+    fn a_fact_the_nodes_disagree_on_reports_nothing() {
+        // Half in europe-west4 and half in us-east-1 is not a cluster with a
+        // region; naming either would be picking one node's answer as the
+        // cluster's.
+        let nodes = [
+            node_with(Some("gce://p/z/n1"), Some("europe-west4")),
+            node_with(Some("aws:///us-east-1a/i-1"), Some("us-east-1")),
+        ];
+        assert_eq!(facts_from_nodes(&nodes), (String::new(), String::new()));
+    }
+
+    #[test]
+    fn the_answer_does_not_depend_on_which_node_answers_first() {
+        // A node carrying neither fact must not shadow the ones that carry
+        // both, whichever order the list arrives in.
+        let bare = node_with(None, None);
+        let a = node_with(Some("gce://p/z/a"), Some("europe-west4"));
+        let b = node_with(Some("gce://p/z/b"), Some("europe-west4"));
+        let forwards = facts_from_nodes(&[bare.clone(), a.clone(), b.clone()]);
+        let backwards = facts_from_nodes(&[b, a, bare]);
+        assert_eq!(forwards, ("GKE".to_string(), "europe-west4".to_string()));
+        assert_eq!(forwards, backwards);
+    }
+
+    #[test]
+    fn metrics_server_present_reports_the_api_groups_version() {
+        let list = api_group_list(&[("apps", "v1"), ("metrics.k8s.io", "v1beta1")]);
+        let fact = metrics_server_from_groups(&list);
+        assert_eq!(fact.state, MetricsServerState::Present);
+        assert_eq!(fact.version, "v1beta1");
+    }
+
+    #[test]
+    fn metrics_server_absent_is_an_answer_not_a_silence() {
+        // Discovery answered and the group is not there: every meter on the
+        // overview has no numerator, and the screen must be able to say so.
+        let fact = metrics_server_from_groups(&api_group_list(&[("apps", "v1")]));
+        assert_eq!(fact.state, MetricsServerState::Absent);
+        assert_eq!(fact.version, "");
+    }
+
+    #[test]
+    fn cluster_facts_capability_has_expected_id_and_annotations() {
+        let cap = cluster_facts_capability(ClientCache::new(PathBuf::from("/nonexistent")));
+        assert_eq!(cap.id, "k8s.clusterFacts");
+        assert!(cap.annotations.read_only);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_cluster_that_cannot_be_reached_fails_rather_than_reporting_empty_facts() {
+        // Empty facts would be indistinguishable from a cluster that answered
+        // and had nothing to say. "We could not ask" is its own outcome.
+        let path = write_temp_kubeconfig(
+            "facts-unreachable",
+            "apiVersion: v1\nkind: Config\nclusters:\n  - name: a\n    cluster: { server: https://127.0.0.1:1 }\ncontexts:\n  - name: ctx-a\n    context: { cluster: a }\n",
+        );
+        let mut reg = Registry::new();
+        reg.register(cluster_facts_capability(ClientCache::new(path.clone())));
+        let result = reg
+            .invoke("k8s.clusterFacts", json!({ "context": "does-not-exist" }))
+            .await;
+        let _ = std::fs::remove_file(&path);
+        let err = result.expect_err("an unreachable cluster must not read as facts");
+        assert!(!format!("{err:?}").is_empty());
     }
 }

--- a/crates/kube/src/connect.rs
+++ b/crates/kube/src/connect.rs
@@ -1166,15 +1166,34 @@ mod tests {
 
     #[test]
     fn the_answer_does_not_depend_on_which_node_answers_first() {
-        // A node carrying neither fact must not shadow the ones that carry
-        // both, whichever order the list arrives in.
+        // Two nodes that disagree, plus one carrying nothing. A first-wins
+        // `find` over the nodes would report europe-west4 for one ordering and
+        // us-east-1 for the other, publishing list order as the cluster's
+        // truth; the fold reports the same nothing either way. `find` reads
+        // more simply than a fold and will look like a tidy-up one day, so
+        // this is the test that has to say no.
         let bare = node_with(None, None);
-        let a = node_with(Some("gce://p/z/a"), Some("europe-west4"));
-        let b = node_with(Some("gce://p/z/b"), Some("europe-west4"));
-        let forwards = facts_from_nodes(&[bare.clone(), a.clone(), b.clone()]);
-        let backwards = facts_from_nodes(&[b, a, bare]);
-        assert_eq!(forwards, ("GKE".to_string(), "europe-west4".to_string()));
-        assert_eq!(forwards, backwards);
+        let west = node_with(Some("gce://p/z/a"), Some("europe-west4"));
+        let east = node_with(Some("aws:///us-east-1a/i-1"), Some("us-east-1"));
+        let forwards = facts_from_nodes(&[bare.clone(), west.clone(), east.clone()]);
+        let backwards = facts_from_nodes(&[east, west, bare]);
+        assert_eq!(forwards, backwards, "the answer must not follow list order");
+        assert_eq!(forwards, (String::new(), String::new()));
+    }
+
+    #[test]
+    fn a_node_carrying_nothing_abstains_rather_than_blanking_the_cluster() {
+        // A control-plane node with no `providerID` and no region label is a
+        // real shape; it must not veto the workers that carry both.
+        let nodes = [
+            node_with(None, None),
+            node_with(Some("gce://p/z/a"), Some("europe-west4")),
+            node_with(Some("gce://p/z/b"), Some("europe-west4")),
+        ];
+        assert_eq!(
+            facts_from_nodes(&nodes),
+            ("GKE".to_string(), "europe-west4".to_string())
+        );
     }
 
     #[test]

--- a/crates/kube/src/lib.rs
+++ b/crates/kube/src/lib.rs
@@ -123,6 +123,7 @@ pub mod networkpolicies;
 pub mod nodes;
 pub mod oidc_detect;
 pub mod persistentvolumes;
+pub mod pod_count;
 pub mod pvcs;
 pub mod resourcequotas;
 pub mod rolebindings;

--- a/crates/kube/src/lib.rs
+++ b/crates/kube/src/lib.rs
@@ -124,6 +124,7 @@ pub mod nodes;
 pub mod oidc_detect;
 pub mod persistentvolumes;
 pub mod pod_count;
+pub mod pod_overview;
 pub mod pvcs;
 pub mod resourcequotas;
 pub mod rolebindings;

--- a/crates/kube/src/metrics.rs
+++ b/crates/kube/src/metrics.rs
@@ -2,10 +2,8 @@
 //! Best-effort: returns an error if metrics-server is not installed.
 
 use std::sync::Arc;
-use std::time::Duration;
 
 use srelens_capability::{Annotations, Capability, CapabilityError};
-use k8s_openapi::api::core::v1::Pod;
 use kube::api::{Api, DynamicObject, ListParams};
 use kube::core::{ApiResource, GroupVersionKind};
 use schemars::JsonSchema;
@@ -178,68 +176,6 @@ pub fn pod_metrics_capability(cache: Arc<ClientCache>) -> Capability {
     )
 }
 
-/// Fleet's per-cluster pod count runs during a screen load where up to ten
-/// clusters answer in parallel; waiting the full per-request budget
-/// (`request_timeout()`, 8s by default) for each one would leave the
-/// section visibly unsettled long after the rest of the screen has
-/// painted. 3s comfortably covers a metadata-only list on a healthy
-/// cluster (sub-second in practice) while staying clearly shorter than a
-/// real query's budget, so one slow/unreachable cluster reports
-/// "unreachable" quickly rather than holding up its row — or the section.
-pub const POD_COUNT_TIMEOUT: Duration = Duration::from_secs(3);
-
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct PodCountIn {
-    pub context: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, JsonSchema)]
-pub struct PodCountOut {
-    pub running: i64,
-    pub total: i64,
-}
-
-/// Count a cluster's pods without listing them: two metadata-only requests
-/// (`list_metadata` — no containers, images, or spec/status bodies), one
-/// filtered server-side to `status.phase=Running` by field selector, run
-/// concurrently under a single timeout budget. A timeout is surfaced as an
-/// error, never as a count of zero — a cluster that didn't answer has not
-/// told us it has no pods.
-async fn count_pods(client: kube::Client, timeout: Duration) -> Result<PodCountOut, String> {
-    let api: Api<Pod> = Api::all(client);
-    let all = ListParams::default();
-    let running_only = ListParams::default().fields("status.phase=Running");
-    let total_fut = api.list_metadata(&all);
-    let running_fut = api.list_metadata(&running_only);
-    let (total, running) = tokio::time::timeout(timeout, futures::future::try_join(total_fut, running_fut))
-        .await
-        .map_err(|_| "pod count timed out".to_string())?
-        .map_err(|e| e.to_string())?;
-    Ok(PodCountOut {
-        total: total.items.len() as i64,
-        running: running.items.len() as i64,
-    })
-}
-
-/// `k8s.podCount` — running vs total pod counts for one context, for
-/// Fleet's per-cluster row. Counted, never listed: see [`count_pods`].
-pub fn pod_count_capability(cache: Arc<ClientCache>) -> Capability {
-    Capability::typed::<PodCountIn, PodCountOut, _, _>(
-        "k8s.podCount",
-        "running vs total pod counts for a cluster, counted without listing pod bodies",
-        Annotations::READ_ONLY,
-        move |input: PodCountIn| {
-            let cache = cache.clone();
-            async move {
-                let client = cache.get(&input.context).await.map_err(CapabilityError::Handler)?;
-                count_pods(client, POD_COUNT_TIMEOUT)
-                    .await
-                    .map_err(CapabilityError::Handler)
-            }
-        },
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -265,108 +201,5 @@ mod tests {
         let cache = ClientCache::new(PathBuf::from("/x"));
         assert_eq!(node_metrics_capability(cache.clone()).id, "k8s.nodeMetrics");
         assert_eq!(pod_metrics_capability(cache).id, "k8s.podMetrics");
-    }
-
-    #[test]
-    fn pod_count_capability_has_id() {
-        let cache = ClientCache::new(PathBuf::from("/x"));
-        assert_eq!(pod_count_capability(cache).id, "k8s.podCount");
-    }
-}
-
-/// Pod-count tests run against a bare, hand-rolled HTTP server rather than a
-/// mock K8s API client: `kube::Client::new` needs a `tower::Service`, and
-/// this crate carries no test double for one. A raw TCP listener that reads
-/// the request line and writes a canned JSON body is enough to prove: two
-/// requests go out (one plain, one field-selected), the response bodies are
-/// counted rather than re-listed with containers/images, an empty list
-/// counts zero, and a server that never answers surfaces as an error — never
-/// a zero count.
-#[cfg(test)]
-mod pod_count_tests {
-    use super::*;
-    use kube::{Client, Config};
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    use tokio::net::TcpListener;
-
-    fn pod_list_json(names: &[&str]) -> String {
-        let items: Vec<Value> = names
-            .iter()
-            .map(|n| serde_json::json!({ "metadata": { "name": n } }))
-            .collect();
-        serde_json::json!({ "apiVersion": "v1", "kind": "PodList", "items": items }).to_string()
-    }
-
-    /// A server that answers every connection: the plain list gets
-    /// `all_body`, and any request whose query string carries
-    /// `fieldSelector` (our running-phase request) gets `running_body`.
-    async fn fake_pod_server(all_body: String, running_body: String) -> (Client, tokio::task::JoinHandle<()>) {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let handle = tokio::spawn(async move {
-            loop {
-                let Ok((mut stream, _)) = listener.accept().await else {
-                    break;
-                };
-                let all_body = all_body.clone();
-                let running_body = running_body.clone();
-                tokio::spawn(async move {
-                    let mut buf = vec![0u8; 8192];
-                    let n = stream.read(&mut buf).await.unwrap_or(0);
-                    let req = String::from_utf8_lossy(&buf[..n]);
-                    let body = if req.contains("fieldSelector") { running_body } else { all_body };
-                    let response = format!(
-                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-                        body.len(),
-                        body
-                    );
-                    let _ = stream.write_all(response.as_bytes()).await;
-                });
-            }
-        });
-        let config = Config::new(format!("http://{addr}").parse().unwrap());
-        (Client::try_from(config).unwrap(), handle)
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn counts_running_and_total_by_phase_without_listing_bodies() {
-        let (client, handle) =
-            fake_pod_server(pod_list_json(&["a", "b", "c"]), pod_list_json(&["a", "b"])).await;
-        let out = count_pods(client, Duration::from_secs(5)).await.unwrap();
-        assert_eq!(out.total, 3);
-        assert_eq!(out.running, 2);
-        handle.abort();
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn an_empty_cluster_counts_zero() {
-        let (client, handle) = fake_pod_server(pod_list_json(&[]), pod_list_json(&[])).await;
-        let out = count_pods(client, Duration::from_secs(5)).await.unwrap();
-        assert_eq!(out.total, 0);
-        assert_eq!(out.running, 0);
-        handle.abort();
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn a_server_that_never_answers_is_an_error_not_a_zero_count() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let handle = tokio::spawn(async move {
-            // Accept connections but never write a response — simulates a
-            // cluster that is up but not answering in time.
-            while let Ok((stream, _)) = listener.accept().await {
-                tokio::spawn(async move {
-                    let _held = stream;
-                    tokio::time::sleep(Duration::from_secs(30)).await;
-                });
-            }
-        });
-        let config = Config::new(format!("http://{addr}").parse().unwrap());
-        let client = Client::try_from(config).unwrap();
-
-        let err = count_pods(client, Duration::from_millis(50)).await.unwrap_err();
-        assert!(err.contains("timed out"), "expected a timeout error, got: {err}");
-
-        handle.abort();
     }
 }

--- a/crates/kube/src/metrics.rs
+++ b/crates/kube/src/metrics.rs
@@ -2,8 +2,10 @@
 //! Best-effort: returns an error if metrics-server is not installed.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use srelens_capability::{Annotations, Capability, CapabilityError};
+use k8s_openapi::api::core::v1::Pod;
 use kube::api::{Api, DynamicObject, ListParams};
 use kube::core::{ApiResource, GroupVersionKind};
 use schemars::JsonSchema;
@@ -176,6 +178,68 @@ pub fn pod_metrics_capability(cache: Arc<ClientCache>) -> Capability {
     )
 }
 
+/// Fleet's per-cluster pod count runs during a screen load where up to ten
+/// clusters answer in parallel; waiting the full per-request budget
+/// (`request_timeout()`, 8s by default) for each one would leave the
+/// section visibly unsettled long after the rest of the screen has
+/// painted. 3s comfortably covers a metadata-only list on a healthy
+/// cluster (sub-second in practice) while staying clearly shorter than a
+/// real query's budget, so one slow/unreachable cluster reports
+/// "unreachable" quickly rather than holding up its row — or the section.
+pub const POD_COUNT_TIMEOUT: Duration = Duration::from_secs(3);
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct PodCountIn {
+    pub context: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, JsonSchema)]
+pub struct PodCountOut {
+    pub running: i64,
+    pub total: i64,
+}
+
+/// Count a cluster's pods without listing them: two metadata-only requests
+/// (`list_metadata` — no containers, images, or spec/status bodies), one
+/// filtered server-side to `status.phase=Running` by field selector, run
+/// concurrently under a single timeout budget. A timeout is surfaced as an
+/// error, never as a count of zero — a cluster that didn't answer has not
+/// told us it has no pods.
+async fn count_pods(client: kube::Client, timeout: Duration) -> Result<PodCountOut, String> {
+    let api: Api<Pod> = Api::all(client);
+    let all = ListParams::default();
+    let running_only = ListParams::default().fields("status.phase=Running");
+    let total_fut = api.list_metadata(&all);
+    let running_fut = api.list_metadata(&running_only);
+    let (total, running) = tokio::time::timeout(timeout, futures::future::try_join(total_fut, running_fut))
+        .await
+        .map_err(|_| "pod count timed out".to_string())?
+        .map_err(|e| e.to_string())?;
+    Ok(PodCountOut {
+        total: total.items.len() as i64,
+        running: running.items.len() as i64,
+    })
+}
+
+/// `k8s.podCount` — running vs total pod counts for one context, for
+/// Fleet's per-cluster row. Counted, never listed: see [`count_pods`].
+pub fn pod_count_capability(cache: Arc<ClientCache>) -> Capability {
+    Capability::typed::<PodCountIn, PodCountOut, _, _>(
+        "k8s.podCount",
+        "running vs total pod counts for a cluster, counted without listing pod bodies",
+        Annotations::READ_ONLY,
+        move |input: PodCountIn| {
+            let cache = cache.clone();
+            async move {
+                let client = cache.get(&input.context).await.map_err(CapabilityError::Handler)?;
+                count_pods(client, POD_COUNT_TIMEOUT)
+                    .await
+                    .map_err(CapabilityError::Handler)
+            }
+        },
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -201,5 +265,108 @@ mod tests {
         let cache = ClientCache::new(PathBuf::from("/x"));
         assert_eq!(node_metrics_capability(cache.clone()).id, "k8s.nodeMetrics");
         assert_eq!(pod_metrics_capability(cache).id, "k8s.podMetrics");
+    }
+
+    #[test]
+    fn pod_count_capability_has_id() {
+        let cache = ClientCache::new(PathBuf::from("/x"));
+        assert_eq!(pod_count_capability(cache).id, "k8s.podCount");
+    }
+}
+
+/// Pod-count tests run against a bare, hand-rolled HTTP server rather than a
+/// mock K8s API client: `kube::Client::new` needs a `tower::Service`, and
+/// this crate carries no test double for one. A raw TCP listener that reads
+/// the request line and writes a canned JSON body is enough to prove: two
+/// requests go out (one plain, one field-selected), the response bodies are
+/// counted rather than re-listed with containers/images, an empty list
+/// counts zero, and a server that never answers surfaces as an error — never
+/// a zero count.
+#[cfg(test)]
+mod pod_count_tests {
+    use super::*;
+    use kube::{Client, Config};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    fn pod_list_json(names: &[&str]) -> String {
+        let items: Vec<Value> = names
+            .iter()
+            .map(|n| serde_json::json!({ "metadata": { "name": n } }))
+            .collect();
+        serde_json::json!({ "apiVersion": "v1", "kind": "PodList", "items": items }).to_string()
+    }
+
+    /// A server that answers every connection: the plain list gets
+    /// `all_body`, and any request whose query string carries
+    /// `fieldSelector` (our running-phase request) gets `running_body`.
+    async fn fake_pod_server(all_body: String, running_body: String) -> (Client, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let all_body = all_body.clone();
+                let running_body = running_body.clone();
+                tokio::spawn(async move {
+                    let mut buf = vec![0u8; 8192];
+                    let n = stream.read(&mut buf).await.unwrap_or(0);
+                    let req = String::from_utf8_lossy(&buf[..n]);
+                    let body = if req.contains("fieldSelector") { running_body } else { all_body };
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(response.as_bytes()).await;
+                });
+            }
+        });
+        let config = Config::new(format!("http://{addr}").parse().unwrap());
+        (Client::try_from(config).unwrap(), handle)
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn counts_running_and_total_by_phase_without_listing_bodies() {
+        let (client, handle) =
+            fake_pod_server(pod_list_json(&["a", "b", "c"]), pod_list_json(&["a", "b"])).await;
+        let out = count_pods(client, Duration::from_secs(5)).await.unwrap();
+        assert_eq!(out.total, 3);
+        assert_eq!(out.running, 2);
+        handle.abort();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn an_empty_cluster_counts_zero() {
+        let (client, handle) = fake_pod_server(pod_list_json(&[]), pod_list_json(&[])).await;
+        let out = count_pods(client, Duration::from_secs(5)).await.unwrap();
+        assert_eq!(out.total, 0);
+        assert_eq!(out.running, 0);
+        handle.abort();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_server_that_never_answers_is_an_error_not_a_zero_count() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            // Accept connections but never write a response — simulates a
+            // cluster that is up but not answering in time.
+            while let Ok((stream, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    let _held = stream;
+                    tokio::time::sleep(Duration::from_secs(30)).await;
+                });
+            }
+        });
+        let config = Config::new(format!("http://{addr}").parse().unwrap());
+        let client = Client::try_from(config).unwrap();
+
+        let err = count_pods(client, Duration::from_millis(50)).await.unwrap_err();
+        assert!(err.contains("timed out"), "expected a timeout error, got: {err}");
+
+        handle.abort();
     }
 }

--- a/crates/kube/src/nodes.rs
+++ b/crates/kube/src/nodes.rs
@@ -38,6 +38,13 @@ pub struct NodeSummary {
     /// `status.allocatable.pods`.
     #[serde(rename = "allocatablePods")]
     pub allocatable_pods: i64,
+    /// The node's machine type, read from its `node.kubernetes.io/instance-type`
+    /// label, falling back to the deprecated `beta.kubernetes.io/instance-type`
+    /// when the modern one is absent. Empty when the node carries neither —
+    /// e.g. on kind, whose nodes are containers rather than cloud machines —
+    /// not a guessed or placeholder value.
+    #[serde(rename = "instanceType")]
+    pub instance_type: String,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -108,6 +115,20 @@ fn summarise(node: Node) -> NodeSummary {
         .and_then(|a| a.get("pods"))
         .map(|q| q.0.trim().parse::<f64>().unwrap_or(0.0) as i64)
         .unwrap_or(0);
+    // Modern label preferred; deprecated one is a fallback for older clusters.
+    // Neither present reports empty, not "unknown" — an empty column cell is
+    // the truthful answer for a node (e.g. on kind) that has no machine type.
+    let instance_type = node
+        .metadata
+        .labels
+        .as_ref()
+        .and_then(|labels| {
+            labels
+                .get("node.kubernetes.io/instance-type")
+                .or_else(|| labels.get("beta.kubernetes.io/instance-type"))
+        })
+        .cloned()
+        .unwrap_or_default();
     NodeSummary {
         name,
         status,
@@ -119,6 +140,7 @@ fn summarise(node: Node) -> NodeSummary {
         allocatable_cpu_millicores,
         allocatable_memory_mib,
         allocatable_pods,
+        instance_type,
     }
 }
 
@@ -241,6 +263,63 @@ mod tests {
         assert_eq!(summarise(node_with_no_status()).allocatable_cpu_millicores, 0);
         assert_eq!(summarise(node_with_no_status()).allocatable_memory_mib, 0);
         assert_eq!(summarise(node_with_no_status()).allocatable_pods, 0);
+    }
+
+    fn node_with_labels(labels: BTreeMap<String, String>) -> Node {
+        Node {
+            metadata: kube::core::ObjectMeta {
+                name: Some("n1".into()),
+                labels: Some(labels),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn reads_the_modern_instance_type_label() {
+        let mut labels = BTreeMap::new();
+        labels.insert(
+            "node.kubernetes.io/instance-type".to_string(),
+            "c3-standard-4".to_string(),
+        );
+        let s = summarise(node_with_labels(labels));
+        assert_eq!(s.instance_type, "c3-standard-4");
+    }
+
+    #[test]
+    fn falls_back_to_the_deprecated_beta_instance_type_label() {
+        let mut labels = BTreeMap::new();
+        labels.insert(
+            "beta.kubernetes.io/instance-type".to_string(),
+            "n2-standard-8".to_string(),
+        );
+        let s = summarise(node_with_labels(labels));
+        assert_eq!(s.instance_type, "n2-standard-8");
+    }
+
+    #[test]
+    fn prefers_the_modern_label_when_both_are_present() {
+        let mut labels = BTreeMap::new();
+        labels.insert(
+            "node.kubernetes.io/instance-type".to_string(),
+            "t2d-spot".to_string(),
+        );
+        labels.insert(
+            "beta.kubernetes.io/instance-type".to_string(),
+            "n2-standard-8".to_string(),
+        );
+        let s = summarise(node_with_labels(labels));
+        assert_eq!(s.instance_type, "t2d-spot");
+    }
+
+    #[test]
+    fn a_node_with_neither_instance_type_label_reports_empty_not_unknown() {
+        let s = summarise(node_with_labels(BTreeMap::new()));
+        assert_eq!(s.instance_type, "");
+
+        let s = summarise(node_with_no_status());
+        assert_eq!(s.instance_type, "");
     }
 
     #[test]

--- a/crates/kube/src/nodes.rs
+++ b/crates/kube/src/nodes.rs
@@ -29,6 +29,15 @@ pub struct NodeSummary {
     pub version: String,
     pub roles: String,
     pub age: String,
+    /// `status.allocatable.cpu`, converted to millicores — the unit metrics-server uses.
+    #[serde(rename = "allocatableCpuMillicores")]
+    pub allocatable_cpu_millicores: i64,
+    /// `status.allocatable.memory`, converted to MiB — the unit metrics-server uses.
+    #[serde(rename = "allocatableMemoryMiB")]
+    pub allocatable_memory_mib: i64,
+    /// `status.allocatable.pods`.
+    #[serde(rename = "allocatablePods")]
+    pub allocatable_pods: i64,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -83,6 +92,22 @@ fn summarise(node: Node) -> NodeSummary {
                 .count() as u32
         })
         .unwrap_or(0);
+    // A node that reports no allocatable at all reports zero, not a guess —
+    // the consumer downstream (packages/core/src/lib/k8sCapacity.ts) is what
+    // turns a zero denominator into "no reading".
+    let allocatable = node.status.as_ref().and_then(|s| s.allocatable.as_ref());
+    let allocatable_cpu_millicores = allocatable
+        .and_then(|a| a.get("cpu"))
+        .map(|q| crate::metrics::cpu_millicores(&q.0))
+        .unwrap_or(0);
+    let allocatable_memory_mib = allocatable
+        .and_then(|a| a.get("memory"))
+        .map(|q| crate::metrics::mem_mib(&q.0))
+        .unwrap_or(0);
+    let allocatable_pods = allocatable
+        .and_then(|a| a.get("pods"))
+        .map(|q| q.0.trim().parse::<f64>().unwrap_or(0.0) as i64)
+        .unwrap_or(0);
     NodeSummary {
         name,
         status,
@@ -91,6 +116,9 @@ fn summarise(node: Node) -> NodeSummary {
         version,
         roles,
         age: crate::humanize_age(node.metadata.creation_timestamp.as_ref()),
+        allocatable_cpu_millicores,
+        allocatable_memory_mib,
+        allocatable_pods,
     }
 }
 
@@ -163,6 +191,56 @@ mod tests {
         assert_eq!(s.roles, "control-plane");
         assert!(!s.unschedulable);
         assert_eq!(s.taints, 0);
+    }
+
+    fn node_with_allocatable(cpu: &str, memory: &str, pods: &str) -> Node {
+        use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+        let mut allocatable = BTreeMap::new();
+        allocatable.insert("cpu".to_string(), Quantity(cpu.to_string()));
+        allocatable.insert("memory".to_string(), Quantity(memory.to_string()));
+        allocatable.insert("pods".to_string(), Quantity(pods.to_string()));
+        Node {
+            metadata: kube::core::ObjectMeta {
+                name: Some("n1".into()),
+                ..Default::default()
+            },
+            status: Some(NodeStatus {
+                allocatable: Some(allocatable),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn node_with_no_status() -> Node {
+        Node {
+            metadata: kube::core::ObjectMeta {
+                name: Some("n1".into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn reads_allocatable_in_the_units_the_metrics_use() {
+        let node = node_with_allocatable("3800m", "16344820Ki", "110");
+        let s = summarise(node);
+        assert_eq!(s.allocatable_cpu_millicores, 3800);
+        assert_eq!(s.allocatable_memory_mib, 15961);
+        assert_eq!(s.allocatable_pods, 110);
+    }
+
+    #[test]
+    fn reads_a_whole_core_as_millicores() {
+        assert_eq!(summarise(node_with_allocatable("4", "0", "0")).allocatable_cpu_millicores, 4000);
+    }
+
+    #[test]
+    fn a_node_that_reports_no_allocatable_reports_zero_not_a_guess() {
+        assert_eq!(summarise(node_with_no_status()).allocatable_cpu_millicores, 0);
+        assert_eq!(summarise(node_with_no_status()).allocatable_memory_mib, 0);
+        assert_eq!(summarise(node_with_no_status()).allocatable_pods, 0);
     }
 
     #[test]

--- a/crates/kube/src/pod_count.rs
+++ b/crates/kube/src/pod_count.rs
@@ -32,18 +32,38 @@ pub struct PodCountIn {
 #[derive(Debug, Clone, PartialEq, Serialize, JsonSchema)]
 pub struct PodCountOut {
     pub running: i64,
+    /// Every pod that is still meant to be running — see [`STILL_RUNNING`]:
+    /// `Succeeded` pods are not in it.
     pub total: i64,
 }
 
+/// The denominator: every pod EXCEPT the ones that finished successfully.
+///
+/// A completed Job's pods stay in the cluster until something reaps them, and
+/// they are not down — they are done. On the demo cluster the raw counts are
+/// 30 Running out of 33 pods and all three of that gap are `Succeeded` Job
+/// pods, so a fleet row reading "30/33" says three pods are broken when
+/// nothing is; it is the first thing anyone would notice. The figure exists to
+/// say how much of the cluster is UP, so the denominator is what is supposed
+/// to be up.
+///
+/// **`Failed` stays counted.** A failed pod genuinely is a problem worth
+/// seeing, and it is the one phase whose exclusion would hide a real one.
+///
+/// Excluded server-side in the selector rather than by a third request
+/// subtracted from a plain total: two independently timed counts can disagree
+/// when a Job finishes between them, and the subtraction can then go negative.
+const STILL_RUNNING: &str = "status.phase!=Succeeded";
+
 /// Count a cluster's pods without listing them: two metadata-only requests
-/// (`list_metadata` — no containers, images, or spec/status bodies), one
-/// filtered server-side to `status.phase=Running` by field selector, run
-/// concurrently under a single timeout budget. A timeout is surfaced as an
-/// error, never as a count of zero — a cluster that didn't answer has not
-/// told us it has no pods.
+/// (`list_metadata` — no containers, images, or spec/status bodies), each
+/// filtered server-side by field selector — one to `status.phase=Running`, the
+/// other to everything [`STILL_RUNNING`] — run concurrently under a single
+/// timeout budget. A timeout is surfaced as an error, never as a count of
+/// zero: a cluster that didn't answer has not told us it has no pods.
 async fn count_pods(client: kube::Client, timeout: Duration) -> Result<PodCountOut, String> {
     let api: Api<Pod> = Api::all(client);
-    let all = ListParams::default();
+    let all = ListParams::default().fields(STILL_RUNNING);
     let running_only = ListParams::default().fields("status.phase=Running");
     let total_fut = api.list_metadata(&all);
     let running_fut = api.list_metadata(&running_only);
@@ -114,39 +134,41 @@ mod pod_count_tests {
         serde_json::json!({ "apiVersion": "v1", "kind": "PodList", "items": items }).to_string()
     }
 
-    /// A server that answers every connection: the plain list gets
-    /// `all_body`, and any request whose query string carries
-    /// `fieldSelector` (our running-phase request) gets `running_body`.
+    /// A server that answers every connection: the request selecting
+    /// `status.phase=Running` gets `running_body`, and the other — our total,
+    /// which selects everything that is not `Succeeded` — gets `total_body`.
     /// Returns the client, the listener task's handle, and a log of every
-    /// request's `Accept` header so a test can inspect *how* it asked, not
-    /// just what it got back.
+    /// request as `(request line, Accept header)` so a test can inspect *how*
+    /// it asked, not just what it got back.
     async fn fake_pod_server(
-        all_body: String,
+        total_body: String,
         running_body: String,
-    ) -> (Client, tokio::task::JoinHandle<()>, Arc<Mutex<Vec<String>>>) {
+    ) -> (Client, tokio::task::JoinHandle<()>, Arc<Mutex<Vec<(String, String)>>>) {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
-        let seen_accepts = Arc::new(Mutex::new(Vec::new()));
-        let seen_accepts_task = seen_accepts.clone();
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let seen_task = seen.clone();
         let handle = tokio::spawn(async move {
             loop {
                 let Ok((mut stream, _)) = listener.accept().await else {
                     break;
                 };
-                let all_body = all_body.clone();
+                let all_body = total_body.clone();
                 let running_body = running_body.clone();
-                let seen_accepts = seen_accepts_task.clone();
+                let seen = seen_task.clone();
                 tokio::spawn(async move {
                     let mut buf = vec![0u8; 8192];
                     let n = stream.read(&mut buf).await.unwrap_or(0);
                     let req = String::from_utf8_lossy(&buf[..n]).to_string();
+                    let line = req.lines().next().unwrap_or("").to_string();
                     let accept = req
                         .lines()
                         .find(|line| line.to_ascii_lowercase().starts_with("accept:"))
                         .unwrap_or("")
                         .to_string();
-                    seen_accepts.lock().unwrap().push(accept);
-                    let body = if req.contains("fieldSelector") { running_body } else { all_body };
+                    let running = line.contains("Running");
+                    seen.lock().unwrap().push((line, accept));
+                    let body = if running { running_body } else { all_body };
                     let response = format!(
                         "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
                         body.len(),
@@ -157,12 +179,12 @@ mod pod_count_tests {
             }
         });
         let config = Config::new(format!("http://{addr}").parse().unwrap());
-        (Client::try_from(config).unwrap(), handle, seen_accepts)
+        (Client::try_from(config).unwrap(), handle, seen)
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn counts_running_and_total_using_metadata_only_requests() {
-        let (client, handle, seen_accepts) =
+        let (client, handle, seen) =
             fake_pod_server(pod_list_json(&["a", "b", "c"]), pod_list_json(&["a", "b"])).await;
         let out = count_pods(client, Duration::from_secs(5)).await.unwrap();
         assert_eq!(out.total, 3);
@@ -173,14 +195,54 @@ mod pod_count_tests {
         // identical counts from this fixture while shipping every pod's
         // full body — this is the guard that makes reaching for it a
         // failing test, not a silent regression.
-        let accepts = seen_accepts.lock().unwrap().clone();
-        assert_eq!(accepts.len(), 2, "expected exactly two requests, got {accepts:?}");
-        for accept in &accepts {
+        let seen = seen.lock().unwrap().clone();
+        assert_eq!(seen.len(), 2, "expected exactly two requests, got {seen:?}");
+        for (_, accept) in &seen {
             assert!(
                 accept.contains("PartialObjectMetadataList"),
                 "expected a metadata-only Accept header, got: {accept}"
             );
         }
+        handle.abort();
+    }
+
+    /// A finished Job's pods stay in the cluster until something reaps them,
+    /// and they are not down — they are done. On the demo cluster the raw
+    /// counts are 30 Running out of 33 pods, and all three of that gap are
+    /// `Succeeded` Job pods: a rail reading "30/33 running" says three pods
+    /// are broken when nothing is. The figure exists to say how much of the
+    /// cluster is UP, so the denominator is every pod that is still meant to
+    /// be running.
+    ///
+    /// `Failed` deliberately stays counted. A failed pod genuinely is a
+    /// problem, and the one phase whose exclusion would hide a real one.
+    ///
+    /// The exclusion is server-side, in the field selector, rather than a
+    /// third request subtracted from the total: subtracting two independently
+    /// timed counts can go negative when a Job finishes between them.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn the_total_leaves_out_pods_that_finished_successfully() {
+        let (client, handle, seen) =
+            fake_pod_server(pod_list_json(&["a", "b", "c"]), pod_list_json(&["a", "b", "c"])).await;
+        let out = count_pods(client, Duration::from_secs(5)).await.unwrap();
+        assert_eq!(out.total, 3);
+
+        let seen = seen.lock().unwrap().clone();
+        let total_request = seen
+            .iter()
+            .map(|(line, _)| line.clone())
+            .find(|line| !line.contains("Running"))
+            .expect("expected a request for the total");
+        assert!(
+            total_request.contains("Succeeded"),
+            "the total must exclude Succeeded pods server-side, asked: {total_request}"
+        );
+        // Not an equality selector: `status.phase=Succeeded` would count only
+        // the finished pods, which is the opposite of what is wanted.
+        assert!(
+            total_request.contains("%21%3D") || total_request.contains("!="),
+            "expected a not-equals selector, asked: {total_request}"
+        );
         handle.abort();
     }
 

--- a/crates/kube/src/pod_count.rs
+++ b/crates/kube/src/pod_count.rs
@@ -1,0 +1,218 @@
+//! `k8s.podCount` — running vs total pod counts for one context, for Fleet's
+//! per-cluster row in the overview rail. A count, never a list: this counts
+//! pods without shipping their containers, images or spec/status bodies, and
+//! it does not depend on metrics-server (see `crate::metrics` for that).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use k8s_openapi::api::core::v1::Pod;
+use kube::api::{Api, ListParams};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use srelens_capability::{Annotations, Capability, CapabilityError};
+
+use crate::client_cache::ClientCache;
+
+/// Fleet's per-cluster pod count runs during a screen load where up to ten
+/// clusters answer in parallel; waiting the full per-request budget
+/// (`request_timeout()`, 8s by default) for each one would leave the
+/// section visibly unsettled long after the rest of the screen has
+/// painted. 3s comfortably covers a metadata-only list on a healthy
+/// cluster (sub-second in practice) while staying clearly shorter than a
+/// real query's budget, so one slow/unreachable cluster reports
+/// "unreachable" quickly rather than holding up its row — or the section.
+pub const POD_COUNT_TIMEOUT: Duration = Duration::from_secs(3);
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct PodCountIn {
+    pub context: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, JsonSchema)]
+pub struct PodCountOut {
+    pub running: i64,
+    pub total: i64,
+}
+
+/// Count a cluster's pods without listing them: two metadata-only requests
+/// (`list_metadata` — no containers, images, or spec/status bodies), one
+/// filtered server-side to `status.phase=Running` by field selector, run
+/// concurrently under a single timeout budget. A timeout is surfaced as an
+/// error, never as a count of zero — a cluster that didn't answer has not
+/// told us it has no pods.
+async fn count_pods(client: kube::Client, timeout: Duration) -> Result<PodCountOut, String> {
+    let api: Api<Pod> = Api::all(client);
+    let all = ListParams::default();
+    let running_only = ListParams::default().fields("status.phase=Running");
+    let total_fut = api.list_metadata(&all);
+    let running_fut = api.list_metadata(&running_only);
+    let (total, running) = tokio::time::timeout(timeout, futures::future::try_join(total_fut, running_fut))
+        .await
+        .map_err(|_| "pod count timed out".to_string())?
+        .map_err(|e| e.to_string())?;
+    Ok(PodCountOut {
+        total: total.items.len() as i64,
+        running: running.items.len() as i64,
+    })
+}
+
+/// `k8s.podCount` — running vs total pod counts for one context, for
+/// Fleet's per-cluster row. Counted, never listed: see [`count_pods`].
+pub fn pod_count_capability(cache: Arc<ClientCache>) -> Capability {
+    Capability::typed::<PodCountIn, PodCountOut, _, _>(
+        "k8s.podCount",
+        "running vs total pod counts for a cluster, counted without listing pod bodies",
+        Annotations::READ_ONLY,
+        move |input: PodCountIn| {
+            let cache = cache.clone();
+            async move {
+                let client = cache.get(&input.context).await.map_err(CapabilityError::Handler)?;
+                count_pods(client, POD_COUNT_TIMEOUT)
+                    .await
+                    .map_err(CapabilityError::Handler)
+            }
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn pod_count_capability_has_id() {
+        let cache = ClientCache::new(PathBuf::from("/x"));
+        assert_eq!(pod_count_capability(cache).id, "k8s.podCount");
+    }
+}
+
+/// Pod-count tests run against a bare, hand-rolled HTTP server rather than a
+/// mock K8s API client: `kube::Client::new` needs a `tower::Service`, and
+/// this crate carries no test double for one. A raw TCP listener that reads
+/// the request line and writes a canned JSON body is enough to prove: two
+/// requests go out (one plain, one field-selected), each asking for the
+/// metadata-only representation — not just that the resulting counts are
+/// right, since a full `Api::list` would produce the same counts from the
+/// same fixture while shipping every pod's spec/status across the wire — an
+/// empty list counts zero, and a server that never answers surfaces as an
+/// error, never a zero count.
+#[cfg(test)]
+mod pod_count_tests {
+    use super::*;
+    use kube::{Client, Config};
+    use std::sync::Mutex;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    fn pod_list_json(names: &[&str]) -> String {
+        let items: Vec<serde_json::Value> = names
+            .iter()
+            .map(|n| serde_json::json!({ "metadata": { "name": n } }))
+            .collect();
+        serde_json::json!({ "apiVersion": "v1", "kind": "PodList", "items": items }).to_string()
+    }
+
+    /// A server that answers every connection: the plain list gets
+    /// `all_body`, and any request whose query string carries
+    /// `fieldSelector` (our running-phase request) gets `running_body`.
+    /// Returns the client, the listener task's handle, and a log of every
+    /// request's `Accept` header so a test can inspect *how* it asked, not
+    /// just what it got back.
+    async fn fake_pod_server(
+        all_body: String,
+        running_body: String,
+    ) -> (Client, tokio::task::JoinHandle<()>, Arc<Mutex<Vec<String>>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let seen_accepts = Arc::new(Mutex::new(Vec::new()));
+        let seen_accepts_task = seen_accepts.clone();
+        let handle = tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let all_body = all_body.clone();
+                let running_body = running_body.clone();
+                let seen_accepts = seen_accepts_task.clone();
+                tokio::spawn(async move {
+                    let mut buf = vec![0u8; 8192];
+                    let n = stream.read(&mut buf).await.unwrap_or(0);
+                    let req = String::from_utf8_lossy(&buf[..n]).to_string();
+                    let accept = req
+                        .lines()
+                        .find(|line| line.to_ascii_lowercase().starts_with("accept:"))
+                        .unwrap_or("")
+                        .to_string();
+                    seen_accepts.lock().unwrap().push(accept);
+                    let body = if req.contains("fieldSelector") { running_body } else { all_body };
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(response.as_bytes()).await;
+                });
+            }
+        });
+        let config = Config::new(format!("http://{addr}").parse().unwrap());
+        (Client::try_from(config).unwrap(), handle, seen_accepts)
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn counts_running_and_total_using_metadata_only_requests() {
+        let (client, handle, seen_accepts) =
+            fake_pod_server(pod_list_json(&["a", "b", "c"]), pod_list_json(&["a", "b"])).await;
+        let out = count_pods(client, Duration::from_secs(5)).await.unwrap();
+        assert_eq!(out.total, 3);
+        assert_eq!(out.running, 2);
+
+        // The property this capability exists for: both requests must ask
+        // for the metadata-only representation. `Api::list` would produce
+        // identical counts from this fixture while shipping every pod's
+        // full body — this is the guard that makes reaching for it a
+        // failing test, not a silent regression.
+        let accepts = seen_accepts.lock().unwrap().clone();
+        assert_eq!(accepts.len(), 2, "expected exactly two requests, got {accepts:?}");
+        for accept in &accepts {
+            assert!(
+                accept.contains("PartialObjectMetadataList"),
+                "expected a metadata-only Accept header, got: {accept}"
+            );
+        }
+        handle.abort();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn an_empty_cluster_counts_zero() {
+        let (client, handle, _) = fake_pod_server(pod_list_json(&[]), pod_list_json(&[])).await;
+        let out = count_pods(client, Duration::from_secs(5)).await.unwrap();
+        assert_eq!(out.total, 0);
+        assert_eq!(out.running, 0);
+        handle.abort();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_server_that_never_answers_is_an_error_not_a_zero_count() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            // Accept connections but never write a response — simulates a
+            // cluster that is up but not answering in time.
+            while let Ok((stream, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    let _held = stream;
+                    tokio::time::sleep(Duration::from_secs(30)).await;
+                });
+            }
+        });
+        let config = Config::new(format!("http://{addr}").parse().unwrap());
+        let client = Client::try_from(config).unwrap();
+
+        let err = count_pods(client, Duration::from_millis(50)).await.unwrap_err();
+        assert!(err.contains("timed out"), "expected a timeout error, got: {err}");
+
+        handle.abort();
+    }
+}

--- a/crates/kube/src/pod_overview.rs
+++ b/crates/kube/src/pod_overview.rs
@@ -1,0 +1,794 @@
+//! `k8s.podOverview` — the cluster overview's three pod facts, answered
+//! without shipping the cluster's pod bodies.
+//!
+//! The overview asks three questions about pods at once: how many there are,
+//! how many are on each node, and which ones are not well. It used to answer
+//! all three from `k8s.listPods` with an empty namespace — every pod in the
+//! cluster, with its containers, images, ages and phases. On the demo cluster
+//! that is 33 pods and costs nothing. On the 113-node cluster this capability
+//! was written for it is 5 416 pods and **114 MB uncompressed**, which takes
+//! the API server 15-23 s to serve; the request budget is 8 s, so the screen
+//! got a timeout and the Pods tile, every node's Pods column and the rail's
+//! Pods count all read "No reading".
+//!
+//! ## What replaces it
+//!
+//! **The counts come from the Table representation** (`as=Table`,
+//! `includeObject=None`) — the server-side printer `kubectl get` itself uses.
+//! The server renders one row of cells per pod instead of an object, and its
+//! wide columns include NODE, so the whole cluster's pods-per-node grouping
+//! arrives in **1.6 MB and under a second**. That is 70× less than the list it
+//! replaces.
+//!
+//! **`list_metadata` cannot do this job**, which is worth stating because it
+//! is the obvious guess and it is wrong twice: `PartialObjectMetadata` carries
+//! `metadata` and nothing else, so there is no `spec.nodeName` in it to group
+//! by — and on this cluster a metadata-only pod list is still **55 MB**,
+//! because `managedFields` and annotations travel with the metadata. It is the
+//! right tool for [`crate::pod_count`], which only counts; it is not one here.
+//!
+//! **The unhealthy list still needs bodies**, and the interesting part is how
+//! few. `podStatus` in `@srelens/core` flags a pod when its phase is not
+//! `Running`/`Succeeded`, OR when a container is waiting with a reason — and
+//! that second half is the one that matters most, because a `CrashLoopBackOff`
+//! pod's phase is `Running`. No field selector can express it: pods support
+//! selectors on `metadata.*`, `spec.nodeName`, `spec.restartPolicy`,
+//! `spec.schedulerName`, `spec.serviceAccountName`, `status.phase`,
+//! `status.podIP` and `status.nominatedNodeName`, and not one of them looks at
+//! a container's state. So:
+//!
+//! 1. `status.phase!=Running` fetches every pod whose PHASE condemns it — 96
+//!    bodies out of 5 416 on that cluster, 1.5 MB.
+//! 2. A pod with a waiting container is never fully ready, so the Table's
+//!    READY column narrows the rest: only rows short of ready can be the
+//!    crash-loopers, and only the ones the first request did not already
+//!    bring back are fetched, by name. On that cluster that is **four**.
+//!
+//! Both halves are capped ([`UNSETTLED_CAP`]) and the cap is reported, because
+//! an unbounded list is the failure this module exists to end.
+//!
+//! **Nothing here decides whether a pod is healthy.** The READY column and the
+//! phase selector choose which pods are worth READING; `podStatus` in core
+//! decides what each one means, from the same `phase` and `waitingReason` it
+//! has always read. A pod this module fetched needlessly costs one small
+//! request; a pod it judged would be a second opinion contradicting core's.
+
+use std::collections::{BTreeMap, HashSet};
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::StreamExt;
+use http::Request;
+use k8s_openapi::api::core::v1::Pod;
+use kube::api::{Api, ListParams};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use srelens_capability::{Annotations, Capability, CapabilityError};
+
+use crate::client_cache::ClientCache;
+use crate::connect::request_timeout;
+use crate::workloads::{summarise_pod, PodSummary};
+
+/// The most pod bodies this capability will return, however sick the cluster.
+///
+/// The `Not ready` band is a dashboard summary, not an inventory — the nodes
+/// table above it caps at ten rows for the same reason. A cluster with three
+/// thousand `Failed` pods has one problem, not three thousand, and fetching
+/// every one of them to say so would rebuild the request this module deleted.
+/// Whenever the cap bites, [`PodOverviewOut::truncated`] says so, so the
+/// screen can report a short list as short rather than as the whole truth.
+pub const UNSETTLED_CAP: usize = 200;
+
+/// How many by-name pod fetches run at once.
+///
+/// These are the crash-loopers the phase selector could not reach — four on
+/// the cluster this was measured against, and rarely many more. Eight at a
+/// time keeps a sick cluster's tail from becoming a serial walk without
+/// opening a connection per pod on the API server.
+const CANDIDATE_CONCURRENCY: usize = 8;
+
+/// Every pod whose PHASE is enough to condemn it, in one server-side filter.
+///
+/// `Succeeded` is deliberately still in: core leaves a finished pod alone
+/// (`TERMINAL_POD_PHASES`), so it costs a row nobody flags — and excluding it
+/// here would leave its name out of the "already fetched" set, which is what
+/// stops the second pass from fetching all 53 of them one at a time.
+const NOT_RUNNING: &str = "status.phase!=Running";
+
+/// The server-side printer's own media type — what `kubectl get` asks for.
+const TABLE_ACCEPT: &str = "application/json;as=Table;v=v1;g=meta.k8s.io";
+
+/// Every pod in the cluster as printed rows, with no object attached.
+///
+/// `includeObject=None` is the whole point: `includeObject=Metadata` would
+/// staple a `PartialObjectMetadata` — `managedFields` and all — to every row
+/// and put the 55 MB straight back.
+const PODS_TABLE_PATH: &str = "/api/v1/pods?includeObject=None";
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct PodOverviewIn {
+    pub context: String,
+}
+
+/// How many pods one node is running.
+#[derive(Debug, Clone, PartialEq, Serialize, JsonSchema)]
+pub struct NodePodCount {
+    pub node: String,
+    pub pods: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PodOverviewOut {
+    /// Every pod in the cluster, whatever phase it is in.
+    pub total: i64,
+    /// One entry per node that is running at least one pod. A node absent
+    /// from this list is running none — the list is complete, which is what
+    /// lets the screen read a missing node as a genuine zero.
+    ///
+    /// Pods that have not been scheduled yet carry no node and are counted in
+    /// [`Self::total`] only; there is no node whose count they belong to.
+    pub by_node: Vec<NodePodCount>,
+    /// Every pod that is not simply running, for core to judge.
+    ///
+    /// Deliberately NOT "the unhealthy pods": this is a superset, and the
+    /// distinction is the point. `Succeeded` pods are in it and core flags
+    /// none of them. Whether a pod needs attention is `podStatus`'s to say,
+    /// from the `phase` and `waitingReason` on each summary here.
+    pub unsettled: Vec<PodSummary>,
+    /// Whether [`Self::unsettled`] is shorter than the truth — the cap bit, or
+    /// a pod the READY column singled out could not be read. The screen says
+    /// the list is short rather than presenting it as complete.
+    pub truncated: bool,
+}
+
+/// One column of a server-printed table.
+#[derive(Debug, Deserialize)]
+struct TableColumn {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct TableRow {
+    cells: Vec<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PodTable {
+    column_definitions: Vec<TableColumn>,
+    rows: Vec<TableRow>,
+}
+
+impl PodTable {
+    /// Where a named column sits, or an error naming the column that is
+    /// missing.
+    ///
+    /// Looked up by name on every request rather than assumed by position:
+    /// the printer owns the column set, and reading NODE out of index 6
+    /// because that is where it sits today would silently start counting
+    /// IP addresses the day it moves.
+    fn column(&self, name: &str) -> Result<usize, String> {
+        self.column_definitions
+            .iter()
+            .position(|c| c.name.eq_ignore_ascii_case(name))
+            .ok_or_else(|| format!("the pod table carried no {name} column"))
+    }
+
+    fn cell(&self, row: &TableRow, at: usize) -> String {
+        match row.cells.get(at) {
+            Some(Value::String(s)) => s.clone(),
+            Some(Value::Null) | None => String::new(),
+            Some(other) => other.to_string(),
+        }
+    }
+}
+
+/// The printer's word for "this pod is not on a node".
+const NO_NODE: &str = "<none>";
+
+/// Whether a READY cell (`1/1`, `0/2`) says a container is not ready.
+///
+/// A waiting container is never a ready one, so this is the necessary
+/// condition for the pods `status.phase!=Running` cannot reach. A cell that
+/// cannot be read counts as short of ready: fetching a pod needlessly costs
+/// one small request, and skipping one costs a crash-looping pod nobody sees.
+fn short_of_ready(cell: &str) -> bool {
+    let Some((ready, total)) = cell.split_once('/') else {
+        return true;
+    };
+    match (ready.trim().parse::<i64>(), total.trim().parse::<i64>()) {
+        (Ok(ready), Ok(total)) => ready < total,
+        _ => true,
+    }
+}
+
+/// Fetch every pod as a printed row: one request, no pod bodies.
+async fn pod_table(client: kube::Client) -> Result<PodTable, String> {
+    let req = Request::get(PODS_TABLE_PATH)
+        .header(http::header::ACCEPT, TABLE_ACCEPT)
+        .body(Vec::new())
+        .map_err(|e| e.to_string())?;
+    client.request::<PodTable>(req).await.map_err(|e| e.to_string())
+}
+
+/// The overview's pod facts. See the module docs for why each one is fetched
+/// the way it is.
+async fn overview(client: kube::Client, timeout: Duration) -> Result<PodOverviewOut, String> {
+    tokio::time::timeout(timeout, gather(client))
+        .await
+        .map_err(|_| "pod overview timed out".to_string())?
+}
+
+async fn gather(client: kube::Client) -> Result<PodOverviewOut, String> {
+    let api: Api<Pod> = Api::all(client.clone());
+    let phase_filtered = ListParams::default()
+        .fields(NOT_RUNNING)
+        .limit(UNSETTLED_CAP as u32);
+
+    // Concurrent: neither answer depends on the other, and the by-name pass
+    // below needs both before it can decide what is left to fetch.
+    let (table, not_running) = futures::future::join(
+        pod_table(client),
+        async { api.list(&phase_filtered).await.map_err(|e| e.to_string()) },
+    )
+    .await;
+    let table = table?;
+    let not_running = not_running?;
+
+    let name_at = table.column("Name")?;
+    let ready_at = table.column("Ready")?;
+    let node_at = table.column("Node")?;
+
+    let total = table.rows.len() as i64;
+    let mut counts: BTreeMap<String, i64> = BTreeMap::new();
+    let mut short: Vec<String> = Vec::new();
+    for row in &table.rows {
+        let node = table.cell(row, node_at);
+        if !node.is_empty() && node != NO_NODE {
+            *counts.entry(node).or_insert(0) += 1;
+        }
+        if short_of_ready(&table.cell(row, ready_at)) {
+            short.push(table.cell(row, name_at));
+        }
+    }
+    let by_node = counts
+        .into_iter()
+        .map(|(node, pods)| NodePodCount { node, pods })
+        .collect();
+
+    // The phase selector's page is truncated when the server handed back a
+    // continue token — with a field selector it does not send
+    // `remainingItemCount`, so the token is the only thing that says there is
+    // more, and a count of how much more is not available at any price.
+    let mut truncated = not_running
+        .metadata
+        .continue_
+        .as_deref()
+        .is_some_and(|token| !token.is_empty());
+    let mut unsettled: Vec<PodSummary> = not_running.items.into_iter().map(summarise_pod).collect();
+
+    let fetched: HashSet<(String, String)> = unsettled
+        .iter()
+        .map(|p| (p.namespace.clone(), p.name.clone()))
+        .collect();
+    let by_name: HashSet<String> = fetched.iter().map(|(_, name)| name.clone()).collect();
+    let mut names: Vec<String> = short.into_iter().filter(|n| !by_name.contains(n)).collect();
+    names.sort();
+    names.dedup();
+
+    let budget = UNSETTLED_CAP.saturating_sub(unsettled.len());
+    if names.len() > budget {
+        truncated = true;
+        names.truncate(budget);
+    }
+
+    // A name, not a namespace: `includeObject=None` keeps the rows free of
+    // objects, so the printed row has no namespace on it. `metadata.name=`
+    // across every namespace is what turns a name back into a pod, and it
+    // brings back both of them when two namespaces run the same name.
+    let results = futures::stream::iter(names.into_iter().map(|name| {
+        let api = api.clone();
+        async move {
+            api.list(&ListParams::default().fields(&format!("metadata.name={name}")))
+                .await
+        }
+    }))
+    .buffer_unordered(CANDIDATE_CONCURRENCY)
+    .collect::<Vec<_>>()
+    .await;
+
+    for result in results {
+        match result {
+            Ok(list) => {
+                for pod in list.items {
+                    let summary = summarise_pod(pod);
+                    if !fetched.contains(&(summary.namespace.clone(), summary.name.clone())) {
+                        unsettled.push(summary);
+                    }
+                }
+            }
+            // One pod we could not read is not a reason to lose the other
+            // 199, but it IS a reason the list may be short — and saying so
+            // is the whole difference between a summary and a claim.
+            Err(_) => truncated = true,
+        }
+    }
+
+    Ok(PodOverviewOut {
+        total,
+        by_node,
+        unsettled,
+        truncated,
+    })
+}
+
+/// `k8s.podOverview` — pod totals, per-node counts and the pods that are not
+/// simply running, for one context. See the module docs.
+pub fn pod_overview_capability(cache: Arc<ClientCache>) -> Capability {
+    Capability::typed::<PodOverviewIn, PodOverviewOut, _, _>(
+        "k8s.podOverview",
+        "pod totals, per-node counts and the pods that are not running, without listing pod bodies",
+        Annotations::READ_ONLY,
+        move |input: PodOverviewIn| {
+            let cache = cache.clone();
+            async move {
+                let client = cache
+                    .get(&input.context)
+                    .await
+                    .map_err(CapabilityError::Handler)?;
+                overview(client, request_timeout())
+                    .await
+                    .map_err(CapabilityError::Handler)
+            }
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn pod_overview_capability_has_id() {
+        let cache = ClientCache::new(PathBuf::from("/x"));
+        assert_eq!(pod_overview_capability(cache).id, "k8s.podOverview");
+    }
+
+    #[test]
+    fn a_ready_cell_that_is_short_is_the_only_one_worth_fetching() {
+        assert!(!short_of_ready("1/1"));
+        assert!(!short_of_ready("3/3"));
+        // No containers at all is not "one of them is waiting".
+        assert!(!short_of_ready("0/0"));
+        assert!(short_of_ready("0/1"));
+        assert!(short_of_ready("1/2"));
+        // A cell nobody can read is fetched rather than assumed healthy: one
+        // needless request against one crash-looping pod nobody sees.
+        assert!(short_of_ready(""));
+        assert!(short_of_ready("unknown"));
+    }
+}
+
+/// These tests run against a bare, hand-rolled HTTP server, for the reason
+/// [`crate::pod_count`]'s do: `kube::Client::new` needs a `tower::Service` and
+/// this crate carries no test double for one. The server routes on the request
+/// line, so a test can assert *how* the capability asked — which is the whole
+/// point here. Counting 5 416 pods correctly by listing all 5 416 of them
+/// would pass every assertion about the numbers while being exactly the bug
+/// this module was written to remove, so the requests themselves are pinned:
+/// one Table request, one phase-filtered list, and a by-name fetch only for
+/// the rows the READY column singled out.
+#[cfg(test)]
+mod pod_overview_tests {
+    use super::*;
+    use kube::{Client, Config};
+    use std::sync::Mutex;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    /// One printed row: name, ready, status, restarts, age, ip, node.
+    fn row(name: &str, ready: &str, status: &str, node: &str) -> serde_json::Value {
+        serde_json::json!({ "cells": [name, ready, status, "0", "3d", "10.0.0.1", node, "<none>", "<none>"] })
+    }
+
+    fn table(rows: Vec<serde_json::Value>) -> String {
+        serde_json::json!({
+            "kind": "Table",
+            "apiVersion": "meta.k8s.io/v1",
+            "columnDefinitions": [
+                { "name": "Name" }, { "name": "Ready" }, { "name": "Status" },
+                { "name": "Restarts" }, { "name": "Age" }, { "name": "IP" },
+                { "name": "Node" }, { "name": "Nominated Node" }, { "name": "Readiness Gates" },
+            ],
+            "rows": rows,
+        })
+        .to_string()
+    }
+
+    /// A pod body, as the API server would send it.
+    fn pod(name: &str, namespace: &str, phase: &str, waiting: Option<&str>) -> serde_json::Value {
+        let state = match waiting {
+            Some(reason) => serde_json::json!({ "waiting": { "reason": reason } }),
+            None => serde_json::json!({ "running": { "startedAt": "2024-01-01T00:00:00Z" } }),
+        };
+        serde_json::json!({
+            "metadata": { "name": name, "namespace": namespace },
+            "spec": { "nodeName": "n1" },
+            "status": {
+                "phase": phase,
+                "containerStatuses": [
+                    { "name": "c", "ready": waiting.is_none(), "restartCount": 0, "image": "acme/api:1", "imageID": "", "state": state }
+                ],
+            },
+        })
+    }
+
+    fn pod_list(pods: Vec<serde_json::Value>, continue_token: Option<&str>) -> String {
+        let mut meta = serde_json::Map::new();
+        if let Some(token) = continue_token {
+            meta.insert("continue".into(), serde_json::json!(token));
+        }
+        serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "PodList",
+            "metadata": serde_json::Value::Object(meta),
+            "items": pods,
+        })
+        .to_string()
+    }
+
+    /// What each kind of request gets back, and a log of every request line
+    /// and Accept header the capability actually sent.
+    struct Server {
+        client: Client,
+        handle: tokio::task::JoinHandle<()>,
+        seen: Arc<Mutex<Vec<(String, String)>>>,
+    }
+
+    impl Server {
+        fn lines(&self) -> Vec<String> {
+            self.seen.lock().unwrap().iter().map(|(line, _)| line.clone()).collect()
+        }
+
+        /// Request lines matching a substring — how a test says "and this is
+        /// the only request of that shape that went out".
+        fn asked(&self, needle: &str) -> Vec<String> {
+            self.lines().into_iter().filter(|l| l.contains(needle)).collect()
+        }
+
+        fn accept_for(&self, needle: &str) -> String {
+            self.seen
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|(line, _)| line.contains(needle))
+                .map(|(_, accept)| accept.clone())
+                .unwrap_or_default()
+        }
+    }
+
+    impl Drop for Server {
+        fn drop(&mut self) {
+            self.handle.abort();
+        }
+    }
+
+    async fn serve(table_body: String, not_running: String, by_name: String) -> Server {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let seen_task = seen.clone();
+        let handle = tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let table_body = table_body.clone();
+                let not_running = not_running.clone();
+                let by_name = by_name.clone();
+                let seen = seen_task.clone();
+                tokio::spawn(async move {
+                    let mut buf = vec![0u8; 16384];
+                    let n = stream.read(&mut buf).await.unwrap_or(0);
+                    let req = String::from_utf8_lossy(&buf[..n]).to_string();
+                    let line = req.lines().next().unwrap_or("").to_string();
+                    let accept = req
+                        .lines()
+                        .find(|l| l.to_ascii_lowercase().starts_with("accept:"))
+                        .unwrap_or("")
+                        .to_string();
+                    seen.lock().unwrap().push((line.clone(), accept.clone()));
+                    let body = if accept.contains("as=Table") {
+                        table_body
+                    } else if line.contains("metadata.name") {
+                        by_name
+                    } else {
+                        not_running
+                    };
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(response.as_bytes()).await;
+                });
+            }
+        });
+        let config = Config::new(format!("http://{addr}").parse().unwrap());
+        Server {
+            client: Client::try_from(config).unwrap(),
+            handle,
+            seen,
+        }
+    }
+
+    /// The property this module exists for: every pod is counted and grouped
+    /// by node, and NOT ONE pod body is listed to do it.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn counts_and_groups_every_pod_without_listing_one() {
+        let server = serve(
+            table(vec![
+                row("api-1", "1/1", "Running", "n1"),
+                row("api-2", "1/1", "Running", "n1"),
+                row("web-1", "1/1", "Running", "n2"),
+                // Not scheduled yet: counted in the total, on no node's row.
+                row("queue-0", "0/1", "Pending", "<none>"),
+            ]),
+            pod_list(vec![pod("queue-0", "payments", "Pending", None)], None),
+            pod_list(vec![], None),
+        )
+        .await;
+
+        let out = overview(server.client.clone(), Duration::from_secs(5)).await.unwrap();
+
+        assert_eq!(out.total, 4);
+        assert_eq!(
+            out.by_node,
+            vec![
+                NodePodCount { node: "n1".into(), pods: 2 },
+                NodePodCount { node: "n2".into(), pods: 1 },
+            ],
+            "a pod with no node belongs to no node's count"
+        );
+
+        // Exactly one request asked for the printed table, and it asked for
+        // rows with no objects stapled to them.
+        let table_requests = server.asked("includeObject=None");
+        assert_eq!(table_requests.len(), 1, "expected one table request, got {table_requests:?}");
+        assert!(
+            server.accept_for("includeObject=None").contains("as=Table"),
+            "the counts must come from the printed table, asked: {}",
+            server.accept_for("includeObject=None")
+        );
+
+        // And no request listed pods without narrowing them. `Api::list` with
+        // no selector would produce the same counts from the same cluster
+        // while shipping every pod's spec and status — this is the guard that
+        // makes reaching for it a failing test.
+        for line in server.lines() {
+            if line.contains("includeObject=None") || !line.contains("/api/v1/pods") {
+                continue;
+            }
+            assert!(
+                line.contains("fieldSelector"),
+                "a pod list went out with nothing narrowing it: {line}"
+            );
+        }
+    }
+
+    /// Every pod the PHASE condemns comes back with a body, so core can read
+    /// its phase and its waiting reason — one server-side filter, not a scan.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn carries_the_pods_whose_phase_is_not_running() {
+        let server = serve(
+            table(vec![
+                row("ok-web-0", "1/1", "Running", "n1"),
+                row("bb-queue-0", "0/1", "Pending", "n2"),
+                row("done-backup-0", "0/1", "Completed", "n2"),
+            ]),
+            pod_list(
+                vec![
+                    pod("bb-queue-0", "payments", "Pending", None),
+                    pod("done-backup-0", "ops", "Succeeded", None),
+                ],
+                None,
+            ),
+            pod_list(vec![], None),
+        )
+        .await;
+
+        let out = overview(server.client.clone(), Duration::from_secs(5)).await.unwrap();
+
+        let names: Vec<&str> = out.unsettled.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["bb-queue-0", "done-backup-0"]);
+        // A superset, deliberately: `Succeeded` is here and core flags none of
+        // them. What a pod MEANS is `podStatus`'s to say, not this module's.
+        assert_eq!(out.unsettled[1].phase, "Succeeded");
+        assert!(!out.truncated);
+
+        let asked = server.asked("fieldSelector");
+        assert_eq!(asked.len(), 1, "expected one filtered list, got {asked:?}");
+        assert!(
+            asked[0].contains("status.phase") && (asked[0].contains("%21%3D") || asked[0].contains("!=")),
+            "the phase filter must be server-side and a not-equals: {}",
+            asked[0]
+        );
+        // A healthy row is never fetched by name.
+        assert!(server.asked("metadata.name").is_empty());
+    }
+
+    /// The case the whole second pass exists for: a `CrashLoopBackOff` pod's
+    /// phase is `Running`, so `status.phase!=Running` cannot see it. The
+    /// READY column can, and the pod is fetched by name so core gets the
+    /// waiting reason it needs.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn fetches_the_crash_looping_pod_the_phase_filter_cannot_reach() {
+        let server = serve(
+            table(vec![
+                row("ok-web-0", "1/1", "Running", "n1"),
+                row("aa-worker-0", "0/1", "CrashLoopBackOff", "n3"),
+            ]),
+            pod_list(vec![], None),
+            pod_list(
+                vec![pod("aa-worker-0", "checkout", "Running", Some("CrashLoopBackOff"))],
+                None,
+            ),
+        )
+        .await;
+
+        let out = overview(server.client.clone(), Duration::from_secs(5)).await.unwrap();
+
+        assert_eq!(out.unsettled.len(), 1);
+        let pod = &out.unsettled[0];
+        assert_eq!(pod.name, "aa-worker-0");
+        assert_eq!(pod.namespace, "checkout");
+        // The two fields `podStatus` reads. Without the second one core draws
+        // this pod green.
+        assert_eq!(pod.phase, "Running");
+        assert_eq!(pod.waiting_reason, "CrashLoopBackOff");
+        assert!(!out.truncated);
+
+        let by_name = server.asked("metadata.name");
+        assert_eq!(by_name.len(), 1, "only the short-of-ready row is fetched: {by_name:?}");
+        assert!(by_name[0].contains("aa-worker-0"));
+    }
+
+    /// A pod the phase filter already brought back is not fetched a second
+    /// time — which is what keeps a cluster with fifty finished Job pods from
+    /// paying fifty extra requests for names it already has.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn never_fetches_a_pod_it_already_has() {
+        let server = serve(
+            table(vec![
+                row("done-1", "0/1", "Completed", "n1"),
+                row("done-2", "0/1", "Completed", "n1"),
+                row("done-3", "0/1", "Completed", "n2"),
+            ]),
+            pod_list(
+                vec![
+                    pod("done-1", "ops", "Succeeded", None),
+                    pod("done-2", "ops", "Succeeded", None),
+                    pod("done-3", "ops", "Succeeded", None),
+                ],
+                None,
+            ),
+            pod_list(vec![], None),
+        )
+        .await;
+
+        let out = overview(server.client.clone(), Duration::from_secs(5)).await.unwrap();
+
+        assert_eq!(out.unsettled.len(), 3);
+        assert!(
+            server.asked("metadata.name").is_empty(),
+            "every short-of-ready row was already fetched: {:?}",
+            server.asked("metadata.name")
+        );
+    }
+
+    /// A cap that bites is reported. A summary that is short and says nothing
+    /// is read as the whole truth, which is the failure this module replaces.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn says_so_when_there_is_more_than_it_will_return() {
+        let server = serve(
+            table(vec![row("sick-1", "0/1", "Error", "n1")]),
+            pod_list(vec![pod("sick-1", "ops", "Failed", None)], Some("more-please")),
+            pod_list(vec![], None),
+        )
+        .await;
+
+        let out = overview(server.client.clone(), Duration::from_secs(5)).await.unwrap();
+        assert!(out.truncated, "a continue token means the page was not the whole list");
+        assert_eq!(out.unsettled.len(), 1);
+    }
+
+    /// A pod the READY column singled out and the server then refused leaves
+    /// the list short — said out loud, not swallowed.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_pod_it_could_not_read_leaves_the_list_short_and_says_so() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let table_body = table(vec![row("aa-worker-0", "0/1", "CrashLoopBackOff", "n3")]);
+        let empty = pod_list(vec![], None);
+        let handle = tokio::spawn(async move {
+            while let Ok((mut stream, _)) = listener.accept().await {
+                let table_body = table_body.clone();
+                let empty = empty.clone();
+                tokio::spawn(async move {
+                    let mut buf = vec![0u8; 16384];
+                    let n = stream.read(&mut buf).await.unwrap_or(0);
+                    let req = String::from_utf8_lossy(&buf[..n]).to_string();
+                    let line = req.lines().next().unwrap_or("").to_string();
+                    let accept = req
+                        .lines()
+                        .find(|l| l.to_ascii_lowercase().starts_with("accept:"))
+                        .unwrap_or("")
+                        .to_string();
+                    let response = if line.contains("metadata.name") {
+                        "HTTP/1.1 403 Forbidden\r\nContent-Type: application/json\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}".to_string()
+                    } else {
+                        let body = if accept.contains("as=Table") { table_body } else { empty };
+                        format!(
+                            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                            body.len(),
+                            body
+                        )
+                    };
+                    let _ = stream.write_all(response.as_bytes()).await;
+                });
+            }
+        });
+        let config = Config::new(format!("http://{addr}").parse().unwrap());
+        let client = Client::try_from(config).unwrap();
+
+        let out = overview(client, Duration::from_secs(5)).await.unwrap();
+        // The counts still answered — one refused pod does not blank the
+        // Pods tile or the per-node column.
+        assert_eq!(out.total, 1);
+        assert!(out.unsettled.is_empty());
+        assert!(out.truncated, "a pod that could not be read makes the list short");
+        handle.abort();
+    }
+
+    /// A table with no NODE column is an error, never 113 nodes reading zero.
+    /// The printer owns the column set; a build that stopped sending NODE
+    /// would otherwise have every node quietly claim it runs nothing.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_table_without_a_node_column_is_an_error_not_a_row_of_zeroes() {
+        let narrow = serde_json::json!({
+            "kind": "Table",
+            "apiVersion": "meta.k8s.io/v1",
+            "columnDefinitions": [{ "name": "Name" }, { "name": "Ready" }, { "name": "Status" }],
+            "rows": [ { "cells": ["api-1", "1/1", "Running"] } ],
+        })
+        .to_string();
+        let server = serve(narrow, pod_list(vec![], None), pod_list(vec![], None)).await;
+
+        let err = overview(server.client.clone(), Duration::from_secs(5)).await.unwrap_err();
+        assert!(err.contains("Node"), "expected the missing column named, got: {err}");
+    }
+
+    /// A cluster that did not answer has not told us it has no pods.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_server_that_never_answers_is_an_error_not_an_empty_cluster() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    let _held = stream;
+                    tokio::time::sleep(Duration::from_secs(30)).await;
+                });
+            }
+        });
+        let config = Config::new(format!("http://{addr}").parse().unwrap());
+        let client = Client::try_from(config).unwrap();
+
+        let err = overview(client, Duration::from_millis(50)).await.unwrap_err();
+        assert!(err.contains("timed out"), "expected a timeout, got: {err}");
+        handle.abort();
+    }
+}

--- a/crates/registry/src/lib.rs
+++ b/crates/registry/src/lib.rs
@@ -240,6 +240,11 @@ pub fn build_registry_with_paths_and_settings(
     reg.register(srelens_kube::connect::cluster_info_capability(
         cache.clone(),
     ));
+    // The overview rail's control-plane facts. Deliberately separate from the
+    // reachability probe above, which runs for every cluster on every launch.
+    reg.register(srelens_kube::connect::cluster_facts_capability(
+        cache.clone(),
+    ));
     // Add-cluster form support (desktop + web): synthesize a kubeconfig from
     // form fields, and probe a kubeconfig's reachability before saving it.
     reg.register(srelens_kube::cluster_synth::synthesize_cluster_capability());

--- a/crates/registry/src/lib.rs
+++ b/crates/registry/src/lib.rs
@@ -337,6 +337,7 @@ pub fn build_registry_with_paths_and_settings(
         cache.clone(),
     ));
     reg.register(srelens_kube::metrics::pod_metrics_capability(cache.clone()));
+    reg.register(srelens_kube::metrics::pod_count_capability(cache.clone()));
     reg.register(srelens_kube::nodes::list_nodes_capability(cache.clone()));
     reg.register(srelens_kube::manifest::get_manifest_capability(
         cache.clone(),

--- a/crates/registry/src/lib.rs
+++ b/crates/registry/src/lib.rs
@@ -337,7 +337,7 @@ pub fn build_registry_with_paths_and_settings(
         cache.clone(),
     ));
     reg.register(srelens_kube::metrics::pod_metrics_capability(cache.clone()));
-    reg.register(srelens_kube::metrics::pod_count_capability(cache.clone()));
+    reg.register(srelens_kube::pod_count::pod_count_capability(cache.clone()));
     reg.register(srelens_kube::nodes::list_nodes_capability(cache.clone()));
     reg.register(srelens_kube::manifest::get_manifest_capability(
         cache.clone(),

--- a/crates/registry/src/lib.rs
+++ b/crates/registry/src/lib.rs
@@ -338,6 +338,9 @@ pub fn build_registry_with_paths_and_settings(
     ));
     reg.register(srelens_kube::metrics::pod_metrics_capability(cache.clone()));
     reg.register(srelens_kube::pod_count::pod_count_capability(cache.clone()));
+    reg.register(srelens_kube::pod_overview::pod_overview_capability(
+        cache.clone(),
+    ));
     reg.register(srelens_kube::nodes::list_nodes_capability(cache.clone()));
     reg.register(srelens_kube::manifest::get_manifest_capability(
         cache.clone(),

--- a/docs/mcp-catalog.md
+++ b/docs/mcp-catalog.md
@@ -5,16 +5,17 @@
 
 Everything this server exposes over MCP, generated from the live registry so it cannot drift. Written for someone wiring an agent to srelens; the narrative reference is [MCP.md](MCP.md).
 
-## Tools (84)
+## Tools (85)
 
 Argument schemas are not reproduced here — call `tools/list` for those, which cannot go stale.
 
-### Kubernetes — read-only (46)
+### Kubernetes — read-only (47)
 
 | Tool | Summary |
 | --- | --- |
 | `k8s.bindingsForServiceAccount` | list the RoleBindings and ClusterRoleBindings that reference a ServiceAccount |
 | `k8s.canI` | check whether the current user can perform actions (SelfSubjectAccessReview, batched) |
+| `k8s.clusterFacts` | report a cluster's provider, region and metrics-server availability |
 | `k8s.clusterInfo` | connect to a kube context and report server version and reachability |
 | `k8s.diffManifest` | diff a manifest against the cluster via server dry-run apply (per document) |
 | `k8s.getManifest` | fetch a resource's manifest as YAML (any supported kind) |

--- a/docs/mcp-catalog.md
+++ b/docs/mcp-catalog.md
@@ -5,11 +5,11 @@
 
 Everything this server exposes over MCP, generated from the live registry so it cannot drift. Written for someone wiring an agent to srelens; the narrative reference is [MCP.md](MCP.md).
 
-## Tools (86)
+## Tools (87)
 
 Argument schemas are not reproduced here — call `tools/list` for those, which cannot go stale.
 
-### Kubernetes — read-only (48)
+### Kubernetes — read-only (49)
 
 | Tool | Summary |
 | --- | --- |
@@ -55,6 +55,7 @@ Argument schemas are not reproduced here — call `tools/list` for those, which 
 | `k8s.podCount` | running vs total pod counts for a cluster, counted without listing pod bodies |
 | `k8s.podLogs` | fetch recent logs for a pod in a connected kube context |
 | `k8s.podMetrics` | pod CPU/memory usage (requires metrics-server) |
+| `k8s.podOverview` | pod totals, per-node counts and the pods that are not running, without listing pod bodies |
 | `k8s.podsForPvc` | list pods in a namespace that mount a given PersistentVolumeClaim |
 | `k8s.podsForSelector` | list pods matching a label selector (a workload's managed pods) |
 | `k8s.podsForServiceAccount` | list pods in a namespace running as a given ServiceAccount |

--- a/docs/mcp-catalog.md
+++ b/docs/mcp-catalog.md
@@ -5,11 +5,11 @@
 
 Everything this server exposes over MCP, generated from the live registry so it cannot drift. Written for someone wiring an agent to srelens; the narrative reference is [MCP.md](MCP.md).
 
-## Tools (85)
+## Tools (86)
 
 Argument schemas are not reproduced here — call `tools/list` for those, which cannot go stale.
 
-### Kubernetes — read-only (47)
+### Kubernetes — read-only (48)
 
 | Tool | Summary |
 | --- | --- |
@@ -52,6 +52,7 @@ Argument schemas are not reproduced here — call `tools/list` for those, which 
 | `k8s.listStorageClasses` | list StorageClasses of a connected kube context (cluster-scoped) |
 | `k8s.nodeMetrics` | node CPU/memory usage (requires metrics-server) |
 | `k8s.openApiSchema` | fetch the OpenAPI schema for a resource kind (for field autocomplete) |
+| `k8s.podCount` | running vs total pod counts for a cluster, counted without listing pod bodies |
 | `k8s.podLogs` | fetch recent logs for a pod in a connected kube context |
 | `k8s.podMetrics` | pod CPU/memory usage (requires metrics-server) |
 | `k8s.podsForPvc` | list pods in a namespace that mount a given PersistentVolumeClaim |

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,6 +31,7 @@ export * from "./lib/exec";
 export * from "./lib/files";
 export * from "./lib/forward";
 export * from "./lib/helm";
+export * from "./lib/k8sCapacity";
 export * from "./lib/k8sContainer";
 export * from "./lib/k8sHealth";
 export * from "./lib/k8sQuantity";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -58,6 +58,7 @@ export * from "./lib/overviewSnapshot";
 export * from "./lib/paletteActions";
 export * from "./lib/podContainers";
 export * from "./lib/podCount";
+export * from "./lib/podOverview";
 export * from "./lib/prompts";
 export * from "./lib/rbac";
 export * from "./lib/recents";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,6 +57,7 @@ export * from "./lib/openTabs";
 export * from "./lib/overviewSnapshot";
 export * from "./lib/paletteActions";
 export * from "./lib/podContainers";
+export * from "./lib/podCount";
 export * from "./lib/prompts";
 export * from "./lib/rbac";
 export * from "./lib/recents";

--- a/packages/core/src/lib/capability-catalog.json
+++ b/packages/core/src/lib/capability-catalog.json
@@ -310,6 +310,11 @@
     "destructive": false
   },
   {
+    "id": "k8s.podCount",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
     "id": "k8s.podLogs",
     "readOnly": true,
     "destructive": false

--- a/packages/core/src/lib/capability-catalog.json
+++ b/packages/core/src/lib/capability-catalog.json
@@ -325,6 +325,11 @@
     "destructive": false
   },
   {
+    "id": "k8s.podOverview",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
     "id": "k8s.podsForPvc",
     "readOnly": true,
     "destructive": false

--- a/packages/core/src/lib/capability-catalog.json
+++ b/packages/core/src/lib/capability-catalog.json
@@ -15,6 +15,11 @@
     "destructive": false
   },
   {
+    "id": "k8s.clusterFacts",
+    "readOnly": true,
+    "destructive": false
+  },
+  {
     "id": "k8s.clusterInfo",
     "readOnly": true,
     "destructive": false

--- a/packages/core/src/lib/clusters.test.ts
+++ b/packages/core/src/lib/clusters.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { listContexts, connectCluster } from "./clusters";
+import { listContexts, connectCluster, clusterFacts } from "./clusters";
 
 describe("listContexts", () => {
   it("returns the contexts on success", async () => {
@@ -49,5 +49,64 @@ describe("connectCluster", () => {
     );
     expect(info.reachable).toBe(false);
     expect(info.error).toContain("ipc unavailable");
+  });
+});
+
+describe("clusterFacts", () => {
+  it("passes the context through and returns the facts", async () => {
+    const invoke = vi.fn().mockResolvedValue({
+      context: "gke_acme_prod",
+      provider: "GKE",
+      region: "europe-west4",
+      metricsServer: { state: "present", version: "v1beta1" },
+    });
+    const facts = await clusterFacts("gke_acme_prod", invoke);
+    expect(invoke).toHaveBeenCalledWith("k8s.clusterFacts", { context: "gke_acme_prod" });
+    expect(facts.provider).toBe("GKE");
+    expect(facts.region).toBe("europe-west4");
+    expect(facts.metricsServer.state).toBe("present");
+    expect(facts.metricsServer.version).toBe("v1beta1");
+    expect(facts.error).toBeUndefined();
+  });
+
+  it("carries a fact with nothing behind it as an empty value, never a placeholder", async () => {
+    // The rail omits a row whose value is empty; "unknown" would look like an
+    // answer and would render a row that says nothing.
+    const invoke = vi.fn().mockResolvedValue({
+      context: "kind-srelens-demo",
+      provider: "kind",
+      region: "",
+      metricsServer: { state: "present", version: "v1beta1" },
+    });
+    const facts = await clusterFacts("kind-srelens-demo", invoke);
+    expect(facts.region).toBe("");
+  });
+
+  it("keeps an absent metrics server distinct from one we could not ask about", async () => {
+    const absent = await clusterFacts(
+      "no-metrics",
+      vi.fn().mockResolvedValue({
+        context: "no-metrics",
+        provider: "kind",
+        region: "",
+        metricsServer: { state: "absent", version: "" },
+      }),
+    );
+    expect(absent.metricsServer.state).toBe("absent");
+    expect(absent.error).toBeUndefined();
+
+    const unreachable = await clusterFacts("prod", () =>
+      Promise.reject(new Error("connection timed out")),
+    );
+    expect(unreachable.metricsServer.state).toBe("unknown");
+    expect(unreachable.error).toContain("connection timed out");
+  });
+
+  it("normalises an unreachable cluster into empty facts plus a reason", async () => {
+    const facts = await clusterFacts("prod", () => Promise.reject(new Error("ipc unavailable")));
+    expect(facts.context).toBe("prod");
+    expect(facts.provider).toBe("");
+    expect(facts.region).toBe("");
+    expect(facts.error).toContain("ipc unavailable");
   });
 });

--- a/packages/core/src/lib/clusters.ts
+++ b/packages/core/src/lib/clusters.ts
@@ -76,3 +76,65 @@ export async function deleteContext(
 ): Promise<{ success: boolean }> {
   return invoke<{ success: boolean }>("k8s.deleteContext", { context });
 }
+
+/**
+ * Whether the cluster serves `metrics.k8s.io`.
+ *
+ * `"absent"` is an answer and an important one — it means every meter on the
+ * overview has no numerator. `"unknown"` means we could not ask (the cluster
+ * was unreachable, or discovery itself failed), which is a different thing and
+ * must never be drawn as an absence.
+ */
+export type MetricsServerState = "present" | "absent" | "unknown";
+
+export interface MetricsServerFact {
+  state: MetricsServerState;
+  /** The group's preferred version (e.g. "v1beta1"). Empty unless present. */
+  version: string;
+}
+
+/**
+ * The overview rail's control-plane facts for one context.
+ *
+ * `provider` and `region` are **empty when the cluster named none**, and the
+ * rail omits the row. A word like "unknown" would look like an answer: a
+ * cluster whose nodes carry no region label has not told us it has no region,
+ * it has told us nothing, and silence is the honest rendering.
+ */
+export interface ClusterFacts {
+  context: string;
+  provider: string;
+  region: string;
+  metricsServer: MetricsServerFact;
+  /** Why the facts could not be read; absent on success. */
+  error?: string;
+}
+
+/**
+ * Read a cluster's provider, region and metrics-server availability via the
+ * `k8s.clusterFacts` capability.
+ *
+ * A deliberate second round trip rather than more work on `connectCluster`:
+ * the reachability probe runs for every cluster in the rail on every launch,
+ * and one screen's facts must not make it heavier.
+ *
+ * A failure normalises to empty facts plus a reason, with the metrics server
+ * `"unknown"` rather than `"absent"` — a cluster we could not reach has not
+ * told us metrics-server is missing.
+ */
+export async function clusterFacts(
+  context: string,
+  invoke: Invoker = invokeCapability,
+): Promise<ClusterFacts> {
+  try {
+    return await invoke<ClusterFacts>("k8s.clusterFacts", { context });
+  } catch (e) {
+    return {
+      context,
+      provider: "",
+      region: "",
+      metricsServer: { state: "unknown", version: "" },
+      error: String(e),
+    };
+  }
+}

--- a/packages/core/src/lib/k8sCapacity.test.ts
+++ b/packages/core/src/lib/k8sCapacity.test.ts
@@ -90,7 +90,7 @@ describe("nodeUsage — pods", () => {
 });
 
 describe("clusterCapacity — the ordinary case", () => {
-  it("sums usage and allocatable across every node reporting a metric", () => {
+  it("sums usage and allocatable across every node reporting a metric, and says all of them reported", () => {
     const nodes = [
       node({ name: "a", allocatableCpuMillicores: 4000, allocatableMemoryMiB: 16000 }),
       node({ name: "b", allocatableCpuMillicores: 4000, allocatableMemoryMiB: 16000 }),
@@ -102,39 +102,53 @@ describe("clusterCapacity — the ordinary case", () => {
     const capacity = clusterCapacity(nodes, metrics);
     expect(capacity.cpu).toEqual({ usedMillicores: 4000, allocatableMillicores: 8000 });
     expect(capacity.memory).toEqual({ usedMiB: 16000, allocatableMiB: 32000 });
+    expect(capacity.nodesReporting).toBe(2);
+    expect(capacity.nodesTotal).toBe(2);
   });
 });
 
 describe("clusterCapacity — no node has a metric", () => {
-  it("is null — the same absence rule as a single node, not a zero total", () => {
+  it("is null — the same absence rule as a single node, not a zero total — but still says how many nodes there are", () => {
     const nodes = [node({ name: "a" }), node({ name: "b" })];
     const capacity = clusterCapacity(nodes, []);
     expect(capacity.cpu).toBeNull();
     expect(capacity.memory).toBeNull();
+    expect(capacity.nodesReporting).toBe(0);
+    expect(capacity.nodesTotal).toBe(2);
   });
 });
 
 describe("clusterCapacity — an empty cluster", () => {
-  it("is null", () => {
+  it("is null, with zero of zero nodes reporting", () => {
     const capacity = clusterCapacity([], []);
     expect(capacity.cpu).toBeNull();
     expect(capacity.memory).toBeNull();
+    expect(capacity.nodesReporting).toBe(0);
+    expect(capacity.nodesTotal).toBe(0);
   });
 });
 
 describe("clusterCapacity — some nodes have metrics, others do not", () => {
-  it("sums only the nodes that reported, on both sides of the ratio, so the total stays internally consistent", () => {
+  it("pins the qualified partial: two of three nodes report, the sum covers only those two, and the counts say '2 of 3' right on the return value", () => {
     const nodes = [
       node({ name: "a", allocatableCpuMillicores: 4000, allocatableMemoryMiB: 16000 }),
-      // "b" has no metric — joined since the last scrape, say.
-      node({ name: "b", allocatableCpuMillicores: 6000, allocatableMemoryMiB: 24000 }),
+      node({ name: "b", allocatableCpuMillicores: 2000, allocatableMemoryMiB: 8000 }),
+      // "c" has no metric — joined since the last scrape, say.
+      node({ name: "c", allocatableCpuMillicores: 6000, allocatableMemoryMiB: 24000 }),
     ];
-    const metrics = [metric({ name: "a", cpuMillicores: 1000, memoryMiB: 4000 })];
+    const metrics = [
+      metric({ name: "a", cpuMillicores: 1000, memoryMiB: 4000 }),
+      metric({ name: "b", cpuMillicores: 500, memoryMiB: 2000 }),
+    ];
     const capacity = clusterCapacity(nodes, metrics);
-    // Node "b"'s 6000m/24000MiB of capacity is excluded entirely, not folded
+    // Node "c"'s 6000m/24000MiB of capacity is excluded entirely, not folded
     // in as an allocatable with zero usage — that would understate the
     // percentage by inventing a reading nobody took.
-    expect(capacity.cpu).toEqual({ usedMillicores: 1000, allocatableMillicores: 4000 });
-    expect(capacity.memory).toEqual({ usedMiB: 4000, allocatableMiB: 16000 });
+    expect(capacity.cpu).toEqual({ usedMillicores: 1500, allocatableMillicores: 6000 });
+    expect(capacity.memory).toEqual({ usedMiB: 6000, allocatableMiB: 24000 });
+    // The qualifier travels with the number: a consumer cannot show the 25%
+    // CPU figure above without "2 of 3" being right there to show beside it.
+    expect(capacity.nodesReporting).toBe(2);
+    expect(capacity.nodesTotal).toBe(3);
   });
 });

--- a/packages/core/src/lib/k8sCapacity.test.ts
+++ b/packages/core/src/lib/k8sCapacity.test.ts
@@ -14,6 +14,7 @@ function node(overrides: Partial<NodeSummary> = {}): NodeSummary {
     allocatableCpuMillicores: 4000,
     allocatableMemoryMiB: 16000,
     allocatablePods: 110,
+    instanceType: "c3-standard-4",
     ...overrides,
   };
 }

--- a/packages/core/src/lib/k8sCapacity.test.ts
+++ b/packages/core/src/lib/k8sCapacity.test.ts
@@ -152,3 +152,30 @@ describe("clusterCapacity — some nodes have metrics, others do not", () => {
     expect(capacity.nodesTotal).toBe(3);
   });
 });
+
+describe("clusterCapacity — a metric names a node that is not in the list", () => {
+  it("drops the ghost metric entirely, and nodesReporting never exceeds nodesTotal", () => {
+    const nodes = [
+      node({ name: "a", allocatableCpuMillicores: 4000, allocatableMemoryMiB: 16000 }),
+      node({ name: "b", allocatableCpuMillicores: 4000, allocatableMemoryMiB: 16000 }),
+    ];
+    const metrics = [
+      metric({ name: "a", cpuMillicores: 1000, memoryMiB: 4000 }),
+      metric({ name: "b", cpuMillicores: 1000, memoryMiB: 4000 }),
+      // "ghost" names no node in the list — metrics-server racing the node
+      // list, or holding a stale entry for a node that was just drained and
+      // removed. It must contribute to neither sum nor either count.
+      metric({ name: "ghost", cpuMillicores: 9999, memoryMiB: 9999 }),
+    ];
+    const capacity = clusterCapacity(nodes, metrics);
+    expect(capacity.cpu).toEqual({ usedMillicores: 2000, allocatableMillicores: 8000 });
+    expect(capacity.memory).toEqual({ usedMiB: 8000, allocatableMiB: 32000 });
+    // The invariant worth stating outright: however this is computed, the
+    // reporting count can never exceed the node count. A loop that iterates
+    // metrics instead of nodes can violate this silently — more nodes
+    // "reporting" than exist, and a percentage nobody can explain.
+    expect(capacity.nodesReporting).toBeLessThanOrEqual(capacity.nodesTotal);
+    expect(capacity.nodesReporting).toBe(2);
+    expect(capacity.nodesTotal).toBe(2);
+  });
+});

--- a/packages/core/src/lib/k8sCapacity.test.ts
+++ b/packages/core/src/lib/k8sCapacity.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import { nodeUsage, clusterCapacity } from "./k8sCapacity";
+import type { NodeSummary, NodeMetric } from "./manifest";
+
+function node(overrides: Partial<NodeSummary> = {}): NodeSummary {
+  return {
+    name: "node-1",
+    status: "Ready",
+    unschedulable: false,
+    taints: 0,
+    version: "v1.30.0",
+    roles: "worker",
+    age: "10d",
+    allocatableCpuMillicores: 4000,
+    allocatableMemoryMiB: 16000,
+    allocatablePods: 110,
+    ...overrides,
+  };
+}
+
+function metric(overrides: Partial<NodeMetric> = {}): NodeMetric {
+  return {
+    name: "node-1",
+    cpuMillicores: 2000,
+    memoryMiB: 8000,
+    ...overrides,
+  };
+}
+
+describe("nodeUsage — the ordinary case", () => {
+  it("divides usage by allocatable, as a percentage, unrounded", () => {
+    const usage = nodeUsage(node(), metric(), 31);
+    expect(usage.cpuPercent).toBe(50);
+    expect(usage.memoryPercent).toBe(50);
+    expect(usage.pods).toEqual({ used: 31, allocatable: 110 });
+  });
+
+  it("does not round — a third of allocatable stays a real fraction", () => {
+    const usage = nodeUsage(
+      node({ allocatableCpuMillicores: 3000 }),
+      metric({ cpuMillicores: 1000 }),
+      undefined,
+    );
+    expect(usage.cpuPercent).toBeCloseTo(33.333333, 5);
+  });
+});
+
+describe("nodeUsage — no metric for the node", () => {
+  it("is null, not zero — absence of a reading is not an idle reading", () => {
+    const usage = nodeUsage(node(), undefined, undefined);
+    expect(usage.cpuPercent).toBeNull();
+    expect(usage.memoryPercent).toBeNull();
+  });
+});
+
+describe("nodeUsage — allocatable of zero", () => {
+  it("is null, not a division by zero", () => {
+    const usage = nodeUsage(
+      node({ allocatableCpuMillicores: 0, allocatableMemoryMiB: 0 }),
+      metric(),
+      undefined,
+    );
+    expect(usage.cpuPercent).toBeNull();
+    expect(usage.memoryPercent).toBeNull();
+  });
+});
+
+describe("nodeUsage — usage above allocatable", () => {
+  it("reports honestly above 100, never clamped", () => {
+    const usage = nodeUsage(
+      node({ allocatableCpuMillicores: 1000, allocatableMemoryMiB: 1000 }),
+      metric({ cpuMillicores: 1400, memoryMiB: 1900 }),
+      undefined,
+    );
+    expect(usage.cpuPercent).toBe(140);
+    expect(usage.memoryPercent).toBe(190);
+  });
+});
+
+describe("nodeUsage — pods", () => {
+  it("is null when the pod count for the node is unknown", () => {
+    const usage = nodeUsage(node(), metric(), undefined);
+    expect(usage.pods).toBeNull();
+  });
+
+  it("carries the raw used/allocatable pair when a count is known", () => {
+    const usage = nodeUsage(node({ allocatablePods: 50 }), metric(), 31);
+    expect(usage.pods).toEqual({ used: 31, allocatable: 50 });
+  });
+});
+
+describe("clusterCapacity — the ordinary case", () => {
+  it("sums usage and allocatable across every node reporting a metric", () => {
+    const nodes = [
+      node({ name: "a", allocatableCpuMillicores: 4000, allocatableMemoryMiB: 16000 }),
+      node({ name: "b", allocatableCpuMillicores: 4000, allocatableMemoryMiB: 16000 }),
+    ];
+    const metrics = [
+      metric({ name: "a", cpuMillicores: 1000, memoryMiB: 4000 }),
+      metric({ name: "b", cpuMillicores: 3000, memoryMiB: 12000 }),
+    ];
+    const capacity = clusterCapacity(nodes, metrics);
+    expect(capacity.cpu).toEqual({ usedMillicores: 4000, allocatableMillicores: 8000 });
+    expect(capacity.memory).toEqual({ usedMiB: 16000, allocatableMiB: 32000 });
+  });
+});
+
+describe("clusterCapacity — no node has a metric", () => {
+  it("is null — the same absence rule as a single node, not a zero total", () => {
+    const nodes = [node({ name: "a" }), node({ name: "b" })];
+    const capacity = clusterCapacity(nodes, []);
+    expect(capacity.cpu).toBeNull();
+    expect(capacity.memory).toBeNull();
+  });
+});
+
+describe("clusterCapacity — an empty cluster", () => {
+  it("is null", () => {
+    const capacity = clusterCapacity([], []);
+    expect(capacity.cpu).toBeNull();
+    expect(capacity.memory).toBeNull();
+  });
+});
+
+describe("clusterCapacity — some nodes have metrics, others do not", () => {
+  it("sums only the nodes that reported, on both sides of the ratio, so the total stays internally consistent", () => {
+    const nodes = [
+      node({ name: "a", allocatableCpuMillicores: 4000, allocatableMemoryMiB: 16000 }),
+      // "b" has no metric — joined since the last scrape, say.
+      node({ name: "b", allocatableCpuMillicores: 6000, allocatableMemoryMiB: 24000 }),
+    ];
+    const metrics = [metric({ name: "a", cpuMillicores: 1000, memoryMiB: 4000 })];
+    const capacity = clusterCapacity(nodes, metrics);
+    // Node "b"'s 6000m/24000MiB of capacity is excluded entirely, not folded
+    // in as an allocatable with zero usage — that would understate the
+    // percentage by inventing a reading nobody took.
+    expect(capacity.cpu).toEqual({ usedMillicores: 1000, allocatableMillicores: 4000 });
+    expect(capacity.memory).toEqual({ usedMiB: 4000, allocatableMiB: 16000 });
+  });
+});

--- a/packages/core/src/lib/k8sCapacity.ts
+++ b/packages/core/src/lib/k8sCapacity.ts
@@ -1,0 +1,118 @@
+import type { NodeSummary, NodeMetric } from "./manifest";
+
+/**
+ * A node's usage against its allocatable capacity, computed once so the
+ * cluster-overview screen, the nodes list and the status bar's usage readout
+ * can never disagree about what a percentage means.
+ *
+ * `null` is not `0`. A cluster with no metrics-server has no numerator, and
+ * `0%` is a measurement — it says the cluster is idle. Absence must read as
+ * "no reading", never as an empty (0%) meter. The same holds for `pods`: an
+ * unknown count is `null`, not `{ used: 0, ... }`.
+ */
+export interface NodeUsage {
+  cpuPercent: number | null;
+  memoryPercent: number | null;
+  pods: { used: number; allocatable: number } | null;
+}
+
+/**
+ * `usage / allocatable`, as a percentage — deliberately unrounded.
+ *
+ * Not clamped to 100. A pod exceeding its request, or a node under memory
+ * pressure, genuinely uses more than it was allocated, and that is exactly
+ * the case a reader needs to see. The kit's `Meter` already clamps the bar
+ * it draws while keeping `aria-valuetext` truthful, so clamping here would
+ * lie in the one direction that hides a problem: a node at 140% would
+ * silently render as a full bar reading 100%, indistinguishable from a node
+ * exactly at its limit. Do not "tidy" this into a clamp.
+ *
+ * Rounding is left to the caller too — `Meter` rounds only what it shows and
+ * keeps full precision internally for its own clamping math (see its
+ * comment); rounding here first would throw that precision away before it
+ * gets there.
+ */
+function percentOf(used: number, allocatable: number): number | null {
+  if (allocatable === 0) return null;
+  return (used / allocatable) * 100;
+}
+
+/**
+ * A single node's usage against its own allocatable capacity.
+ *
+ * @param metric - This node's reading from `nodeMetrics`, or `undefined` if
+ *   metrics-server is absent, or the node joined since the last scrape.
+ * @param podsOnNode - The number of pods scheduled on this node, or
+ *   `undefined` if that count is not known to the caller.
+ */
+export function nodeUsage(
+  node: NodeSummary,
+  metric: NodeMetric | undefined,
+  podsOnNode: number | undefined,
+): NodeUsage {
+  return {
+    cpuPercent: metric ? percentOf(metric.cpuMillicores, node.allocatableCpuMillicores) : null,
+    memoryPercent: metric ? percentOf(metric.memoryMiB, node.allocatableMemoryMiB) : null,
+    pods: podsOnNode === undefined ? null : { used: podsOnNode, allocatable: node.allocatablePods },
+  };
+}
+
+/**
+ * Cluster-wide totals for the capacity strip: `312 / 460 cores`, `1.4 / 1.9
+ * TiB`. `null` when nothing can be said — an empty cluster, or one with no
+ * metrics-server anywhere.
+ */
+export interface ClusterCapacity {
+  cpu: { usedMillicores: number; allocatableMillicores: number } | null;
+  memory: { usedMiB: number; allocatableMiB: number } | null;
+}
+
+/**
+ * Sums usage and allocatable across nodes.
+ *
+ * The interesting case is a cluster where some nodes have a metric and
+ * others do not (metrics-server races the node list; a node can also just be
+ * down). This function's answer: a node without a metric is excluded
+ * entirely, from *both* the numerator and the denominator, not folded in as
+ * an allocatable node with zero usage. Adding its allocatable capacity to the
+ * denominator alone would silently understate the percentage — inventing a
+ * "used: 0" reading for a node nobody actually measured, which is the exact
+ * null-is-not-zero mistake this module exists to prevent, just moved up one
+ * level to the sum.
+ *
+ * The consequence: the total this returns describes only the nodes that
+ * reported, not the whole cluster's capacity. Nothing in the return type
+ * flags that as partial — callers showing this number alongside a node count
+ * or a "metrics unavailable" fact (the rail, per the overview spec) are what
+ * keeps a partial answer from silently reading as a whole one; this function
+ * cannot do that on its own with the shape it returns.
+ *
+ * When no node reports a metric, the sum would be over an empty set — that
+ * is `null`, the same "no answer" rule as a single node, not a `0` total.
+ */
+export function clusterCapacity(nodes: NodeSummary[], metrics: NodeMetric[]): ClusterCapacity {
+  const byName = new Map(metrics.map((m) => [m.name, m]));
+
+  let usedMillicores = 0;
+  let allocatableMillicores = 0;
+  let usedMiB = 0;
+  let allocatableMiB = 0;
+  let reporting = 0;
+
+  for (const node of nodes) {
+    const metric = byName.get(node.name);
+    if (!metric) continue;
+    reporting += 1;
+    usedMillicores += metric.cpuMillicores;
+    allocatableMillicores += node.allocatableCpuMillicores;
+    usedMiB += metric.memoryMiB;
+    allocatableMiB += node.allocatableMemoryMiB;
+  }
+
+  if (reporting === 0) return { cpu: null, memory: null };
+
+  return {
+    cpu: { usedMillicores, allocatableMillicores },
+    memory: { usedMiB, allocatableMiB },
+  };
+}

--- a/packages/core/src/lib/k8sCapacity.ts
+++ b/packages/core/src/lib/k8sCapacity.ts
@@ -61,10 +61,25 @@ export function nodeUsage(
  * Cluster-wide totals for the capacity strip: `312 / 460 cores`, `1.4 / 1.9
  * TiB`. `null` when nothing can be said — an empty cluster, or one with no
  * metrics-server anywhere.
+ *
+ * `nodesReporting` / `nodesTotal` travel with the sums because the sums are
+ * partial whenever they differ: `cpu`/`memory` are computed only from nodes
+ * that returned a metric (see `clusterCapacity`'s comment for why), so a
+ * cluster where two of three nodes report gives a percentage over those two
+ * — and a consumer that shows the resulting number without also showing
+ * `nodesReporting` of `nodesTotal` is presenting a partial answer as if it
+ * were a whole one. This was originally left for call sites to reassemble
+ * from a separate count; that convention is exactly what let one screen
+ * qualify a percentage while another didn't, so the qualifier now travels
+ * with the number instead of being left to each call site's discipline.
  */
 export interface ClusterCapacity {
   cpu: { usedMillicores: number; allocatableMillicores: number } | null;
   memory: { usedMiB: number; allocatableMiB: number } | null;
+  /** How many nodes contributed a metric to the sums above. */
+  nodesReporting: number;
+  /** How many nodes there are in total, reporting or not. */
+  nodesTotal: number;
 }
 
 /**
@@ -81,14 +96,15 @@ export interface ClusterCapacity {
  * level to the sum.
  *
  * The consequence: the total this returns describes only the nodes that
- * reported, not the whole cluster's capacity. Nothing in the return type
- * flags that as partial — callers showing this number alongside a node count
- * or a "metrics unavailable" fact (the rail, per the overview spec) are what
- * keeps a partial answer from silently reading as a whole one; this function
- * cannot do that on its own with the shape it returns.
+ * reported, not the whole cluster's capacity. `nodesReporting` and
+ * `nodesTotal` carry that fact on the return value itself, so a caller
+ * cannot show the percentage without the shortfall being right there to
+ * show alongside it.
  *
  * When no node reports a metric, the sum would be over an empty set — that
  * is `null`, the same "no answer" rule as a single node, not a `0` total.
+ * The counts are still reported in that case (`nodesReporting: 0`), since
+ * they are not part of the "no answer" the sums represent.
  */
 export function clusterCapacity(nodes: NodeSummary[], metrics: NodeMetric[]): ClusterCapacity {
   const byName = new Map(metrics.map((m) => [m.name, m]));
@@ -109,10 +125,16 @@ export function clusterCapacity(nodes: NodeSummary[], metrics: NodeMetric[]): Cl
     allocatableMiB += node.allocatableMemoryMiB;
   }
 
-  if (reporting === 0) return { cpu: null, memory: null };
+  const nodesTotal = nodes.length;
+
+  if (reporting === 0) {
+    return { cpu: null, memory: null, nodesReporting: 0, nodesTotal };
+  }
 
   return {
     cpu: { usedMillicores, allocatableMillicores },
     memory: { usedMiB, allocatableMiB },
+    nodesReporting: reporting,
+    nodesTotal,
   };
 }

--- a/packages/core/src/lib/manifest.ts
+++ b/packages/core/src/lib/manifest.ts
@@ -12,6 +12,12 @@ export interface NodeSummary {
   version: string;
   roles: string;
   age: string;
+  /** `status.allocatable.cpu`, in millicores — the unit metrics-server uses. */
+  allocatableCpuMillicores: number;
+  /** `status.allocatable.memory`, in MiB — the unit metrics-server uses. */
+  allocatableMemoryMiB: number;
+  /** `status.allocatable.pods`. */
+  allocatablePods: number;
 }
 
 /** Dynamic GVK + plural for a custom resource (CRD-backed kinds). */

--- a/packages/core/src/lib/manifest.ts
+++ b/packages/core/src/lib/manifest.ts
@@ -18,6 +18,13 @@ export interface NodeSummary {
   allocatableMemoryMiB: number;
   /** `status.allocatable.pods`. */
   allocatablePods: number;
+  /**
+   * The node's machine type, read from its `node.kubernetes.io/instance-type`
+   * label, falling back to the deprecated `beta.kubernetes.io/instance-type`.
+   * Empty when the node carries neither — e.g. on kind, whose nodes are
+   * containers rather than cloud machines — not a guessed placeholder.
+   */
+  instanceType: string;
 }
 
 /** Dynamic GVK + plural for a custom resource (CRD-backed kinds). */

--- a/packages/core/src/lib/podCount.test.ts
+++ b/packages/core/src/lib/podCount.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from "vitest";
+import { podCount } from "./podCount";
+
+describe("podCount", () => {
+  it("passes the context through and returns running/total", async () => {
+    const invoke = vi.fn().mockResolvedValue({ running: 1284, total: 1310 });
+    const outcome = await podCount("prod-eu", invoke);
+    expect(invoke).toHaveBeenCalledWith("k8s.podCount", { context: "prod-eu" });
+    expect(outcome.error).toBeUndefined();
+    expect(outcome.counts).toEqual({ running: 1284, total: 1310 });
+  });
+
+  it("passes through an empty cluster's zero counts", async () => {
+    const invoke = vi.fn().mockResolvedValue({ running: 0, total: 0 });
+    const outcome = await podCount("empty-cluster", invoke);
+    expect(outcome.error).toBeUndefined();
+    expect(outcome.counts).toEqual({ running: 0, total: 0 });
+  });
+
+  it("reports a timeout as an error, never as a zero count", async () => {
+    const outcome = await podCount("prod-eu", () => Promise.reject(new Error("pod count timed out")));
+    expect(outcome.counts).toBeUndefined();
+    expect(outcome.error).toContain("timed out");
+  });
+
+  it("normalises any transport failure into an error outcome", async () => {
+    const outcome = await podCount("prod-eu", () => Promise.reject(new Error("ipc unavailable")));
+    expect(outcome.counts).toBeUndefined();
+    expect(outcome.error).toContain("ipc unavailable");
+  });
+});

--- a/packages/core/src/lib/podCount.ts
+++ b/packages/core/src/lib/podCount.ts
@@ -2,11 +2,19 @@ import { invokeCapability, type Invoker } from "../transport/transport";
 
 /**
  * Fleet's per-cluster pod tally: pods in the `Running` phase over every pod
- * regardless of phase. A liveness figure, not a health one — a `Running` pod
- * can still be crash-looping.
+ * that is still meant to be running. A liveness figure, not a health one — a
+ * `Running` pod can still be crash-looping.
  */
 export interface PodCount {
   running: number;
+  /**
+   * **Excludes `Succeeded` pods**, and nothing else. A completed Job's pods
+   * stay in the cluster until something reaps them, and they are done rather
+   * than down: counting them would make a cluster whose Jobs all finished read
+   * as one with pods missing. `Failed` stays counted — a failed pod genuinely
+   * is a problem worth seeing. The exclusion is server-side, in the backend's
+   * field selector; see `STILL_RUNNING` in `crates/kube/src/pod_count.rs`.
+   */
   total: number;
 }
 

--- a/packages/core/src/lib/podCount.ts
+++ b/packages/core/src/lib/podCount.ts
@@ -1,0 +1,35 @@
+import { invokeCapability, type Invoker } from "../transport/transport";
+
+/**
+ * Fleet's per-cluster pod tally: pods in the `Running` phase over every pod
+ * regardless of phase. A liveness figure, not a health one — a `Running` pod
+ * can still be crash-looping.
+ */
+export interface PodCount {
+  running: number;
+  total: number;
+}
+
+export interface PodCountOutcome {
+  counts?: PodCount;
+  error?: string;
+}
+
+/**
+ * Load a cluster's running/total pod counts via the `k8s.podCount`
+ * capability. The backend counts without listing pod bodies and carries its
+ * own short timeout (3s — see `POD_COUNT_TIMEOUT` in `crates/kube/src/metrics.rs`),
+ * so a slow or unreachable cluster surfaces as `error`, never as `counts`
+ * with zeros: a cluster that didn't answer has not told us it has no pods.
+ */
+export async function podCount(
+  context: string,
+  invoke: Invoker = invokeCapability,
+): Promise<PodCountOutcome> {
+  try {
+    const counts = await invoke<PodCount>("k8s.podCount", { context });
+    return { counts };
+  } catch (e) {
+    return { error: String(e) };
+  }
+}

--- a/packages/core/src/lib/podOverview.test.ts
+++ b/packages/core/src/lib/podOverview.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from "vitest";
+import { podOverview } from "./podOverview";
+
+const OUT = {
+  total: 4,
+  byNode: [
+    { node: "n1", pods: 2 },
+    { node: "n2", pods: 1 },
+  ],
+  unsettled: [
+    {
+      name: "aa-worker-0",
+      namespace: "checkout",
+      phase: "Running",
+      ready: "0/1",
+      restarts: 4,
+      node: "n3",
+      age: "3d",
+      image: "acme/api:1",
+      waitingReason: "CrashLoopBackOff",
+    },
+  ],
+  truncated: false,
+};
+
+describe("podOverview", () => {
+  it("asks the backend for one context's pod facts", async () => {
+    const invoke = vi.fn().mockResolvedValue(OUT);
+    const outcome = await podOverview("prod-eu", invoke);
+    expect(invoke).toHaveBeenCalledWith("k8s.podOverview", { context: "prod-eu" });
+    expect(outcome.pods?.total).toBe(4);
+    expect(outcome.pods?.unsettled[0].waitingReason).toBe("CrashLoopBackOff");
+    expect(outcome.error).toBeUndefined();
+  });
+
+  it("keeps the per-node counts as the backend grouped them", async () => {
+    const outcome = await podOverview("prod-eu", vi.fn().mockResolvedValue(OUT));
+    expect(outcome.pods?.byNode).toEqual([
+      { node: "n1", pods: 2 },
+      { node: "n2", pods: 1 },
+    ]);
+  });
+
+  it("reads an empty cluster as an answer, because it is one", async () => {
+    const empty = { total: 0, byNode: [], unsettled: [], truncated: false };
+    const outcome = await podOverview("empty", vi.fn().mockResolvedValue(empty));
+    expect(outcome.pods).toEqual(empty);
+    expect(outcome.error).toBeUndefined();
+  });
+
+  it("returns the reason rather than a cluster with no pods when the call fails", async () => {
+    const outcome = await podOverview("prod-eu", () =>
+      Promise.reject(new Error("pod overview timed out")),
+    );
+    // A cluster that did not answer has not told us it has no pods: nothing
+    // downstream may read this as `total: 0`.
+    expect(outcome.pods).toBeUndefined();
+    expect(outcome.error).toContain("pod overview timed out");
+  });
+
+  it("carries the backend's truncation rather than presenting a short list as whole", async () => {
+    const short = { ...OUT, truncated: true };
+    const outcome = await podOverview("prod-eu", vi.fn().mockResolvedValue(short));
+    expect(outcome.pods?.truncated).toBe(true);
+  });
+});

--- a/packages/core/src/lib/podOverview.ts
+++ b/packages/core/src/lib/podOverview.ts
@@ -1,0 +1,61 @@
+import { invokeCapability, type Invoker } from "../transport/transport";
+import type { PodSummary } from "./workloads";
+
+/** How many pods one node is running. */
+export interface NodePodCount {
+  node: string;
+  pods: number;
+}
+
+/**
+ * The cluster overview's three pod facts, from one backend call that never
+ * lists the cluster's pod bodies — see `crates/kube/src/pod_overview.rs` for
+ * how each is fetched, and why `k8s.listPods` cannot serve them.
+ */
+export interface PodOverview {
+  /** Every pod in the cluster, whatever phase it is in. */
+  total: number;
+  /**
+   * One entry per node running at least one pod. **Complete**: a node absent
+   * from this list runs no pods, and that is a reading rather than a gap —
+   * which is what lets a node's Pods column show a truthful `0`.
+   */
+  byNode: NodePodCount[];
+  /**
+   * Every pod that is not simply running — a SUPERSET of the unhealthy ones,
+   * and deliberately so. `Succeeded` pods are in it and `podStatus` flags none
+   * of them. Whether a pod needs attention stays core's to decide, from the
+   * `phase` and `waitingReason` on each summary; nothing upstream judges.
+   */
+  unsettled: PodSummary[];
+  /**
+   * Whether {@link unsettled} is shorter than the truth — the backend's cap
+   * bit, or a pod it singled out could not be read. A short list presented as
+   * a whole one is the failure the cap would otherwise introduce.
+   */
+  truncated: boolean;
+}
+
+export interface PodOverviewOutcome {
+  pods?: PodOverview;
+  error?: string;
+}
+
+/**
+ * Load a cluster's pod totals, per-node counts and not-running pods through
+ * the `k8s.podOverview` capability.
+ *
+ * A failure surfaces as `error` with no `pods` at all, never as a `total` of
+ * zero: a cluster that did not answer has not told us it has no pods.
+ */
+export async function podOverview(
+  context: string,
+  invoke: Invoker = invokeCapability,
+): Promise<PodOverviewOutcome> {
+  try {
+    const pods = await invoke<PodOverview>("k8s.podOverview", { context });
+    return { pods };
+  } catch (e) {
+    return { error: String(e) };
+  }
+}

--- a/packages/ui-kit/src/EmptyState.test.tsx
+++ b/packages/ui-kit/src/EmptyState.test.tsx
@@ -65,3 +65,35 @@ describe("EmptyState", () => {
     expect(container.querySelector('[data-slot="action"]')).toBeNull();
   });
 });
+
+/**
+ * The rail-sized form. `py-10` around three wrapped lines in a 286px rail
+ * spends more height stating an absence than the section below it gets to
+ * exist in — the cluster overview's `Fleet` went below the fold behind one.
+ */
+describe("a compact empty state", () => {
+  it("spends a quarter of the padding, and a step less type", () => {
+    const { container } = render(<EmptyState title="No incident feed yet" hint="Not yet." compact />);
+    const root = container.firstElementChild;
+    expect(root?.getAttribute("data-compact")).toBe("true");
+    expect(root?.className).toContain("py-3");
+    expect(root?.className).not.toContain("py-10");
+  });
+
+  it("emits one padding, never two competing ones", () => {
+    // Both forms are utilities, and two utilities setting the same property
+    // are resolved by the generated stylesheet's order rather than by the
+    // order the JSX writes them. Exactly one set is emitted, so a caller
+    // cannot be surprised by which one wins.
+    const compact = render(<EmptyState title="t" compact />).container.firstElementChild;
+    expect(compact?.className).not.toContain("px-6");
+    expect(compact?.className).not.toContain("gap-1.5");
+  });
+
+  it("is the page-sized form unless asked", () => {
+    const { container } = render(<EmptyState title="No pods" />);
+    const root = container.firstElementChild;
+    expect(root?.getAttribute("data-compact")).toBeNull();
+    expect(root?.className).toContain("py-10");
+  });
+});

--- a/packages/ui-kit/src/EmptyState.tsx
+++ b/packages/ui-kit/src/EmptyState.tsx
@@ -8,6 +8,21 @@ export interface EmptyStateProps {
   hint?: ReactNode;
   /** A control the caller owns — usually the button that ends the emptiness. */
   action?: ReactNode;
+  /**
+   * The rail-sized form: a quarter of the padding and a step down in type.
+   *
+   * A prop rather than a `className` at the call site. Both forms are Tailwind
+   * utilities, and two utilities that set the same padding are resolved by the
+   * order of the generated stylesheet rather than by the order the JSX writes
+   * them — so an override from outside is a coin flip. Exactly one set is
+   * emitted here.
+   *
+   * It earns its place because the page-sized form is not neutral in a 286px
+   * rail: `py-10` around three wrapped lines spends more height stating an
+   * absence than the section below it gets to exist in, and the cluster
+   * overview's `Fleet` went below the fold behind one.
+   */
+  compact?: boolean;
   className?: string;
 }
 
@@ -26,17 +41,27 @@ export interface EmptyStateProps {
  * It stays silent to assistive technology: this is the resting state of a
  * region the reader navigated to, not an event worth announcing. (#318)
  */
-export function EmptyState({ title, hint, action, className }: EmptyStateProps) {
+export function EmptyState({ title, hint, action, compact, className }: EmptyStateProps) {
   return (
     <div
+      data-compact={compact ? "true" : undefined}
       className={cx(
-        "flex flex-col items-center justify-center gap-1.5 px-6 py-10 text-center",
+        "flex flex-col items-center justify-center text-center",
+        compact ? "gap-0.5 px-3 py-3" : "gap-1.5 px-6 py-10",
         className,
       )}
     >
-      <div className="text-[0.875rem] font-medium">{title}</div>
+      <div className={compact ? "text-[0.8125rem] font-medium" : "text-[0.875rem] font-medium"}>
+        {title}
+      </div>
       {filled(hint) && (
-        <div data-slot="hint" className="max-w-[42ch] text-[0.8125rem] leading-relaxed text-muted">
+        <div
+          data-slot="hint"
+          className={cx(
+            "max-w-[42ch] text-muted",
+            compact ? "text-[0.75rem] leading-snug" : "text-[0.8125rem] leading-relaxed",
+          )}
+        >
           {hint}
         </div>
       )}

--- a/packages/ui-kit/src/KV.test.tsx
+++ b/packages/ui-kit/src/KV.test.tsx
@@ -138,6 +138,34 @@ describe("the stacked row's rules", () => {
   });
 });
 
+describe("the key column's rules", () => {
+  const css = readFileSync(join(__dirname, "styles", "kit.css"), "utf8");
+  const components = css.slice(css.indexOf("@layer components {"), css.indexOf("@layer utilities {"));
+
+  it("truncates a key too long for its column instead of letting it paint over the value", () => {
+    // Found on the live cluster: the overview rail's Fleet section keys its
+    // rows on the kube CONTEXT name, and a real kubeconfig carries names like
+    // `kdev-1787048764-kubernetes-admin@cluster-...`. The key column is a
+    // `minmax(88px, 34%)` track — its max is fixed, so the track cannot grow —
+    // and a `white-space: nowrap` key with no `min-width: 0` and no overflow
+    // rule simply painted straight through the value column and out past the
+    // right edge of the 286px rail: "kind-srelens-dem30/30 running".
+    //
+    // An ellipsis rather than a wrap: every other name in this design that
+    // outgrows its space is clipped the same way — the tab strip's titles, the
+    // sidebar's cluster name — and a key that wraps to three lines pushes its
+    // own value off the row's baseline.
+    const rule = components.slice(components.indexOf("  .kv-k {"));
+    const body = rule.slice(0, rule.indexOf("}"));
+    // Without this the grid item's automatic minimum is its min-content size,
+    // which for a nowrap key is the whole string — the overflow rules below
+    // never get a chance to apply.
+    expect(body).toContain("min-width: 0");
+    expect(body).toContain("overflow: hidden");
+    expect(body).toContain("text-overflow: ellipsis");
+  });
+});
+
 describe("KVList", () => {
   const rows: Array<[string, string]> = [
     ["Kind", "Pod"],

--- a/packages/ui-kit/src/Meter.tsx
+++ b/packages/ui-kit/src/Meter.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { toneColor, type Tone } from "./tone";
+import { loadTone, toneColor, type Tone } from "./tone";
 import { filled } from "./slot";
 
 /**
@@ -42,7 +42,7 @@ type MeterProps = {
  * shows it above, a bare one beside, never both. (#318)
  */
 export function Meter({ value, tone, label, detail, ...naming }: MeterProps) {
-  const resolved: Tone = tone ?? (value > 80 ? "sev" : value > 65 ? "warn" : "ok");
+  const resolved: Tone = tone ?? loadTone(value);
   const width = Math.min(Math.max(value, 0), 100);
   // These figures are ratios — a third of three pods is 33.33333333333333 —
   // and fourteen decimal places crowd the bar on screen and are worse read

--- a/packages/ui-kit/src/Section.test.tsx
+++ b/packages/ui-kit/src/Section.test.tsx
@@ -244,6 +244,24 @@ describe("a section that heads a page", () => {
   });
 });
 
+describe("a sticky section head over a sticky table head", () => {
+  const css = readFileSync(join(__dirname, "styles", "kit.css"), "utf8");
+  const components = css.slice(css.indexOf("@layer components {"), css.indexOf("@layer utilities {"));
+
+  it("offsets the table's own sticky header below the section head, not under it", () => {
+    // Both `.subhead-caps` and `.tbl thead th` stick to `top: 0` of the same
+    // scrolling pane — the overview's Nodes band wraps a `Table` directly
+    // (`<Section title="Nodes" smallCaps padded={false}><Table .../></Section>`).
+    // Left alone, the table's own column names would stick to the identical
+    // coordinates the section head already occupies and lose to its higher
+    // z-index, painted over and hidden the moment the list scrolls. Offsetting
+    // the table head by the section head's own height (25px) stacks the two
+    // instead of collapsing them onto each other. Asserted on the stylesheet:
+    // jsdom does no layout, so nothing here can be observed by rendering.
+    expect(components).toContain(".subhead-caps ~ .tbl thead th { top: 25px; }");
+  });
+});
+
 describe("an unpadded band's rule", () => {
   const css = readFileSync(join(__dirname, "styles", "kit.css"), "utf8");
   const components = css.slice(css.indexOf("@layer components {"), css.indexOf("@layer utilities {"));

--- a/packages/ui-kit/src/Section.test.tsx
+++ b/packages/ui-kit/src/Section.test.tsx
@@ -195,3 +195,70 @@ describe("a run of sections", () => {
     expect(components).toContain(".section-caret[data-open=\"true\"]");
   });
 });
+
+/**
+ * The two shapes the design gives a run of sections. The detail body keeps
+ * what it had; the cluster overview's bands are headed in small caps and run
+ * their content to both edges of the surface (§7, §D's `padded: false`).
+ */
+describe("a section that heads a page", () => {
+  it("stays inset and bold unless asked otherwise", () => {
+    // Every call site that exists today is the detail pane's, and none of them
+    // passes either prop: the defaults have to be what they already had.
+    const { container } = render(<Section title="Conditions">rows</Section>);
+    const root = container.querySelector("section");
+    expect(root?.getAttribute("data-padded")).toBeNull();
+    expect(container.querySelector("h3")?.className).toContain("font-semibold");
+  });
+
+  it("heads the band in small caps when the frame asks for it", () => {
+    const { container } = render(
+      <Section title="Capacity" smallCaps>
+        rows
+      </Section>,
+    );
+    expect(container.querySelector("h3")?.className).toContain("subhead-caps");
+    // Still the block's name in the outline, and still the word itself in the
+    // DOM — the uppercase is CSS, so a screen reader hears "Capacity".
+    expect(screen.getByRole("heading", { level: 3, name: "Capacity" })).toBeDefined();
+  });
+
+  it("marks an unpadded band on the section, so the rule can drop the sides", () => {
+    const { container } = render(
+      <Section title="Nodes" padded={false}>
+        rows
+      </Section>,
+    );
+    expect(container.querySelector("section")?.getAttribute("data-padded")).toBe("false");
+  });
+
+  it("keeps the content its own direct children whether padded or not", () => {
+    // Unpadding must not be a wrapper. A caller lays a section's content out,
+    // and a box between that layout and the rows changes what it is placing.
+    const { container } = render(
+      <Section title="Nodes" padded={false}>
+        <KV k="Status" v="Running" />
+      </Section>,
+    );
+    expect(container.querySelector("section.section > .kv")).not.toBeNull();
+  });
+});
+
+describe("an unpadded band's rule", () => {
+  const css = readFileSync(join(__dirname, "styles", "kit.css"), "utf8");
+  const components = css.slice(css.indexOf("@layer components {"), css.indexOf("@layer utilities {"));
+
+  it("drops the sides only, and keeps the heading's inset", () => {
+    // The band runs edge to edge; the heading is a label sitting over it and
+    // lines up with nothing when it is flush to the window. The vertical
+    // padding is the rhythm between one band and the next and must survive.
+    expect(components).toContain(
+      '.section[data-padded="false"] { padding-left: 0; padding-right: 0; }',
+    );
+    expect(components).toContain(
+      '.section[data-padded="false"] > .section-title { padding-left: 0.75rem; padding-right: 0.75rem; }',
+    );
+    const rule = components.slice(components.indexOf('.section[data-padded="false"] {'));
+    expect(rule.slice(0, rule.indexOf("}"))).not.toContain("padding-top");
+  });
+});

--- a/packages/ui-kit/src/Section.tsx
+++ b/packages/ui-kit/src/Section.tsx
@@ -31,6 +31,27 @@ export interface SectionProps {
    * said otherwise, and there would be two answers to one question.
    */
   onToggle?: (next: boolean) => void;
+  /**
+   * Whether the CONTENT keeps the block's horizontal inset. `false` runs it to
+   * both edges of the surface — the design's own `padded: false`, which it
+   * names for "tables and list rows" (§D): a table inside an inset draws its
+   * hairlines short of the rules dividing the sections around it, and a run of
+   * list rows loses the full-width hover fill.
+   *
+   * The HEADING keeps the inset either way. It is a label sitting over the
+   * band rather than part of it, and a heading flush to the window edge lines
+   * up with nothing.
+   */
+  padded?: boolean;
+  /**
+   * Head the block in the design's small-caps section voice rather than the
+   * detail body's small bold line — `SubHead`'s two variants.
+   *
+   * Off by default because the detail pane, which is every call site this
+   * component was built for, draws the bold one. The cluster overview's bands
+   * are the frame that asks for the other.
+   */
+  smallCaps?: boolean;
 }
 
 /** Inline rather than an icon-set import: the kit takes no dependency on lucide. */
@@ -102,15 +123,27 @@ function Caret({ open }: { open: boolean }) {
  * `aria-controls` is its optional half, and it is the half almost no screen
  * reader acts on.
  */
-export function Section({ title, children, className, open = true, onToggle }: SectionProps) {
+export function Section({
+  title,
+  children,
+  className,
+  open = true,
+  onToggle,
+  padded = true,
+  smallCaps = false,
+}: SectionProps) {
   const headed = filled(title);
   const folds = headed && onToggle !== undefined;
   const showing = folds ? open : true;
 
   return (
-    <section className={cx("section", className)} data-open={folds ? showing : undefined}>
+    <section
+      className={cx("section", className)}
+      data-open={folds ? showing : undefined}
+      data-padded={padded ? undefined : "false"}
+    >
       {headed && (
-        <SubHead className="section-title">
+        <SubHead className="section-title" variant={smallCaps ? "caps" : "bold"}>
           {folds ? (
             <button
               // A bare button inside a form is a submit button (bd24d1a).

--- a/packages/ui-kit/src/SideRail.test.tsx
+++ b/packages/ui-kit/src/SideRail.test.tsx
@@ -89,3 +89,45 @@ describe("the rail's stylesheet", () => {
     expect(body).not.toMatch(/[^-]width:/);
   });
 });
+
+/**
+ * The design heads the MAIN region too on the cluster overview —
+ * `prod-eu · v1.31.4`, level with the rail's own `At a glance`.
+ */
+describe("SideRail's main head", () => {
+  it("draws the main region's head in the same strip the rail's wears", () => {
+    const { container } = render(
+      <SideRail head="At a glance" mainHead="prod-eu · v1.31.4" rail="r" width={286}>
+        main
+      </SideRail>,
+    );
+    const main = container.querySelector("[data-slot='rail-main']");
+    const head = main?.querySelector("[data-slot='main-head']");
+    expect(head?.textContent).toBe("prod-eu · v1.31.4");
+    // `.pane-head`, not a class of its own: it is the same small-caps bar, and
+    // a second copy of the recipe is a second thing to keep in step.
+    expect(head?.className).toContain("pane-head");
+  });
+
+  it("draws nothing at all when the screen has no head for its main region", () => {
+    // Most screens put a filter bar or a table straight under the toolbar. An
+    // empty strip is still a strip: it holds height and draws a rule.
+    const { container } = render(
+      <SideRail head="By reason" rail="r" width={250}>
+        main
+      </SideRail>,
+    );
+    expect(container.querySelector("[data-slot='main-head']")).toBeNull();
+  });
+
+  it("is not a second landmark", () => {
+    // The rail is `complementary` because it is material a reader may want to
+    // skip. The main region is where the reader already is.
+    render(
+      <SideRail head="At a glance" mainHead="prod-eu" rail="r" width={286}>
+        main
+      </SideRail>,
+    );
+    expect(screen.getAllByRole("complementary")).toHaveLength(1);
+  });
+});

--- a/packages/ui-kit/src/SideRail.tsx
+++ b/packages/ui-kit/src/SideRail.tsx
@@ -1,11 +1,23 @@
 import { useId, type ReactNode } from "react";
 import { cx } from "./cx";
+import { filled } from "./slot";
 
 export interface SideRailProps {
   /** The main region. Gets `min-w-0` so a wide table scrolls inside itself. */
   children: ReactNode;
   /** The rail's own heading, small caps. */
   head: ReactNode;
+  /**
+   * The MAIN region's heading, in the same small-caps strip — the cluster
+   * overview's `prod-eu · v1.31.4`, which the design draws level with the
+   * rail's own head.
+   *
+   * Optional because most screens put a filter bar or a table straight under
+   * the toolbar and have nothing to say twice. Not a landmark label the way
+   * {@link SideRailProps.head} is: the main region is where the reader already
+   * is, and a second `complementary` around it would be noise.
+   */
+  mainHead?: ReactNode;
   /** What the rail holds — a run of `Section`s. */
   rail: ReactNode;
   /** Per screen. Events 250, custom resources 264, overview 286, logs 272. */
@@ -59,12 +71,17 @@ export interface SideRailProps {
  * scrolls inside it (a table, a log) is the caller's and usually wants a
  * `.scroll` box of its own beneath a header that stays put.
  */
-export function SideRail({ children, head, rail, width, className }: SideRailProps) {
+export function SideRail({ children, head, mainHead, rail, width, className }: SideRailProps) {
   const headId = useId();
 
   return (
     <div className={cx("flex min-h-0 flex-1", className)}>
       <div data-slot="rail-main" className="flex min-h-0 min-w-0 flex-1 flex-col">
+        {filled(mainHead) && (
+          <div data-slot="main-head" className="pane-head">
+            {mainHead}
+          </div>
+        )}
         {children}
       </div>
       {/* Named by the head rather than by an `aria-label` prop: the head is a

--- a/packages/ui-kit/src/StatusRow.test.tsx
+++ b/packages/ui-kit/src/StatusRow.test.tsx
@@ -87,7 +87,13 @@ describe("StatusRow", () => {
     const { container } = render(<StatusRow status="Degraded" kind="danger" flagged name="checkout-api" />);
     const pill = container.querySelector(".status-row .status");
     expect(pill).not.toBeNull();
-    expect(pill?.querySelectorAll(".dot").length).toBe(1);
+    // Counted across the WHOLE row. Scoped to the inside of the pill
+    // (`pill.querySelectorAll(".dot")`) this asserts only that StatusPill
+    // draws one dot, which is StatusPill's own test's job, and the defect
+    // this test is named for -- a dot drawn by THIS row as a sibling of the
+    // pill -- is invisible to it. Mutation-checked: adding a second
+    // `<span className="dot" />` to `.status-row-verdict` reddens this line.
+    expect(container.querySelectorAll(".status-row .dot").length).toBe(1);
     // The kind reaches the pill, so the pill's own tone table is the only one.
     expect(pill?.getAttribute("data-kind")).toBe("danger");
   });

--- a/packages/ui-kit/src/StatusRow.test.tsx
+++ b/packages/ui-kit/src/StatusRow.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { StatusRow } from "./StatusRow";
+
+/**
+ * The overview's `NOT READY` list, which is deliberately not a table: no
+ * header, no sort, no selection. New with the cluster overview. (#331)
+ */
+describe("StatusRow", () => {
+  it("renders the status word, the name and the trailing facts", () => {
+    render(
+      <StatusRow status="Degraded" kind="danger" flagged name="checkout-api" facts={["checkout", "9/12"]} />,
+    );
+    expect(screen.getByText("Degraded")).toBeDefined();
+    expect(screen.getByText("checkout-api")).toBeDefined();
+    expect(screen.getByText("checkout")).toBeDefined();
+    expect(screen.getByText("9/12")).toBeDefined();
+  });
+
+  it("keeps the trailing facts in the order it was given them", () => {
+    // Namespace then ratio, not ratio then namespace: the caller's order is
+    // the design's column order, and a component that sorts or reverses it
+    // silently relabels every row.
+    const { container } = render(
+      <StatusRow status="Pending" kind="warning" flagged name="payments-dlq-drain" facts={["payments", "0/1"]} />,
+    );
+    const facts = Array.from(container.querySelectorAll(".status-row-fact")).map((el) => el.textContent);
+    expect(facts).toEqual(["payments", "0/1"]);
+  });
+
+  it("draws no facts box when there are none", () => {
+    // An empty wrapper still takes its share of the row's gap, so the row
+    // would sit indented against its neighbours for no reason.
+    const { container } = render(<StatusRow status="Unknown" kind="neutral" flagged={false} name="orphan" />);
+    expect(container.querySelector(".status-row-facts")).toBeNull();
+  });
+
+  it("is one activation target whose accessible name covers the status and the name", () => {
+    // The rule this row exists to keep: colour is never the only signal. A
+    // bare dot beside a separately-linked name announces itself as a link
+    // called "checkout-api" with the verdict nowhere in the name, and a
+    // reader who cannot see the dot never learns the pod is degraded.
+    render(
+      <StatusRow
+        status="Degraded"
+        kind="danger"
+        flagged
+        name="checkout-api"
+        facts={["checkout", "9/12"]}
+        onActivate={() => {}}
+      />,
+    );
+    const byStatus = screen.getByRole("button", { name: /Degraded/ });
+    const byName = screen.getByRole("button", { name: /checkout-api/ });
+    expect(byStatus).toBe(byName);
+  });
+
+  it("activates on a click", async () => {
+    const onActivate = vi.fn();
+    render(
+      <StatusRow status="CrashLoopBackOff" kind="danger" flagged name="search-indexer-0" onActivate={onActivate} />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /search-indexer-0/ }));
+    expect(onActivate).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not submit a form it happens to stand in", () => {
+    render(<StatusRow status="Degraded" kind="danger" flagged name="checkout-api" onActivate={() => {}} />);
+    expect(screen.getByRole("button", { name: /checkout-api/ }).getAttribute("type")).toBe("button");
+  });
+
+  it("is not a target at all without an activation", () => {
+    // A row that looks pressable and does nothing is worse than a plain one.
+    const { container } = render(<StatusRow status="Progressing" kind="warning" flagged name="payments-worker" />);
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(container.querySelector("button")).toBeNull();
+    expect(container.querySelector(".status-row")).not.toBeNull();
+  });
+
+  it("composes StatusPill rather than drawing a second dot of its own", () => {
+    // A second implementation of the dot/word asymmetry is exactly the
+    // duplication this project has spent the most time deleting — eight
+    // hand-paired label/tone tables so far.
+    const { container } = render(<StatusRow status="Degraded" kind="danger" flagged name="checkout-api" />);
+    const pill = container.querySelector(".status-row .status");
+    expect(pill).not.toBeNull();
+    expect(pill?.querySelectorAll(".dot").length).toBe(1);
+    // The kind reaches the pill, so the pill's own tone table is the only one.
+    expect(pill?.getAttribute("data-kind")).toBe("danger");
+  });
+
+  it("tones the dot whether the state is bad or not", () => {
+    // The dot is the tone's channel and is always coloured; only the word is
+    // rationed. A healthy row is a coloured dot beside plain grey text.
+    const { container } = render(<StatusRow status="Running" kind="success" flagged={false} name="checkout-api" />);
+    const dot = container.querySelector(".status .dot");
+    expect(dot?.getAttribute("style")).toContain("var(--ok)");
+  });
+
+  it("colours and weights the word only when the state is bad", () => {
+    const { container } = render(<StatusRow status="Degraded" kind="danger" flagged name="checkout-api" />);
+    const pill = container.querySelector(".status");
+    expect(pill?.getAttribute("data-bad")).toBe("true");
+    expect(pill?.getAttribute("style")).toContain("var(--sev)");
+  });
+
+  it("leaves a healthy word plain", () => {
+    const { container } = render(<StatusRow status="Running" kind="success" flagged={false} name="checkout-api" />);
+    const pill = container.querySelector(".status");
+    expect(pill?.getAttribute("data-bad")).toBeNull();
+    expect(pill?.getAttribute("style") ?? "").not.toContain("color");
+  });
+
+  it("takes the badness as data rather than deriving it from the tone", () => {
+    // Core enumerates the (tone, dot) pairs precisely because badness is not
+    // a function of the tone: a running Job is amber and NOT flagged, while a
+    // Pending pod is amber and IS. A row that tinted every amber word would
+    // shout at the first and be right only by accident.
+    const { container } = render(<StatusRow status="Running" kind="warning" flagged={false} name="nightly-report" />);
+    expect(container.querySelector(".status")?.getAttribute("data-bad")).toBeNull();
+  });
+
+  it("takes no tone, so a caller cannot pair a word with a colour by hand", () => {
+    // Compile-time, asserted in prose here and by `tsc` in the kit's
+    // typecheck: the API names `kind` (the verdict's vocabulary) and never
+    // `tone` (the palette's). The row below is the whole surface.
+    const props = { status: "Degraded", kind: "danger", flagged: true, name: "checkout-api" } as const;
+    render(<StatusRow {...props} />);
+    expect(screen.getByText("Degraded")).toBeDefined();
+  });
+});
+
+describe("the status row's stylesheet", () => {
+  const css = readFileSync(join(__dirname, "styles", "kit.css"), "utf8");
+  const components = css.slice(css.indexOf("@layer components {"), css.indexOf("@layer utilities {"));
+
+  it("styles the row in the components layer, so a utility still wins", () => {
+    expect(components).toContain("  .status-row {");
+  });
+
+  it("gives the name the slack and lets it shrink", () => {
+    // Without `min-width: 0` a flex item refuses to shrink below its content,
+    // so one long pod name pushes the trailing facts off the row.
+    const rule = components.slice(components.indexOf("  .status-row-name {"));
+    const body = rule.slice(0, rule.indexOf("}"));
+    expect(body).toContain("flex: 1");
+    expect(body).toContain("min-width: 0");
+  });
+
+  it("gives the verdict a minimum so the names line up down the list", () => {
+    // A minimum, never a fixed width: `CrashLoopBackOff` is longer than the
+    // column and pushes rather than being cut in half.
+    const rule = components.slice(components.indexOf("  .status-row-verdict {"));
+    const body = rule.slice(0, rule.indexOf("}"));
+    expect(body).toContain("min-width");
+    expect(body).not.toMatch(/[^-]width:/);
+  });
+});

--- a/packages/ui-kit/src/StatusRow.tsx
+++ b/packages/ui-kit/src/StatusRow.tsx
@@ -1,0 +1,114 @@
+import type { ReactNode } from "react";
+import { cx } from "./cx";
+import { filled } from "./slot";
+import { StatusPill, type StatusKind } from "./StatusPill";
+
+export interface StatusRowProps {
+  /**
+   * The kind's own status word — "Degraded", "CrashLoopBackOff",
+   * "Progressing". Whatever the resource's status derivation called the state
+   * it is in; this component never invents or rewords one.
+   */
+  status: ReactNode;
+  /**
+   * The verdict's severity, on the same five names the pills use. There is
+   * deliberately **no `tone` prop**: `Tone` is the palette's vocabulary, and a
+   * row that took one would let a caller hand-pair a word with a colour —
+   * a red word beside an amber dot, each side certain it was right. The kind
+   * comes off the status derivation with the word, and the pill owns the
+   * mapping to a colour. (#331)
+   */
+  kind: StatusKind;
+  /**
+   * Whether the subject needs attention. **Data, not a derivation**: badness
+   * is not a function of the tone, which is why the status derivation
+   * enumerates the (tone, dot) pairs rather than computing them. A running
+   * Job is amber and not flagged; a Pending pod is amber and is. A row that
+   * tinted every amber word would shout at the first and be right about the
+   * second only by accident.
+   *
+   * Required rather than defaulted: a default of `false` quietly draws a
+   * crash-looping pod as plain grey text for any caller who forgets, and a
+   * default of `true` shouts at a healthy one. The caller has the answer.
+   */
+  flagged: boolean;
+  /** What the row is about. Takes the slack between the verdict and the facts. */
+  name: ReactNode;
+  /**
+   * Right-aligned trailing facts, drawn in the order given — the design's
+   * namespace and ready ratio. The order is the caller's column order, so
+   * nothing here sorts or reverses it.
+   */
+  facts?: ReactNode[];
+  /** Opens what the row names. Without it the row is not a target at all. */
+  onActivate?: () => void;
+  className?: string;
+}
+
+/**
+ * One row of a list that is not a table: a toned dot, the status word in that
+ * tone, the name, then right-aligned trailing facts.
+ *
+ * The cluster overview's `NOT READY` section is the shape this exists for —
+ * unhealthy workloads and pods mixed in one list, ordered by severity rather
+ * than by kind. `Table` is too much for it (there is no header, no sort and no
+ * selection to hang off one) and `KV` is the wrong shape (a name and its
+ * value, not a verdict, a subject and its facts).
+ *
+ * **The left-hand half is {@link StatusPill}, not a redrawing of it.** The
+ * design's most consistent rule is asymmetric: the dot is always tone-coloured,
+ * while the word is coloured and given more weight only when the state is bad —
+ * a healthy value is a coloured dot beside plain grey text. `StatusPill` calls
+ * that `tinted` and already implements both channels, the colour off the tone
+ * and the weight off `.status[data-bad="true"]`. A second implementation of the
+ * same asymmetry is precisely the duplication this project has spent the most
+ * time removing; eight hand-paired label/tone tables have been deleted so far.
+ * So the row passes the verdict through and draws no dot of its own.
+ *
+ * **The whole row is one activation target, and its accessible name is its own
+ * text.** An earlier screen's design drew a status dot with an empty label
+ * beside a separately-linked name: that announces itself as a link called
+ * "checkout-api" with the verdict nowhere in the name, so a reader who cannot
+ * see the dot never learns the pod is degraded. Here the button contains the
+ * word, the name and the facts, so the name is computed from what is on
+ * screen — one string, and one that cannot drift from the row it labels.
+ *
+ * Without `onActivate` it is a plain `div`: a row that looks pressable and does
+ * nothing is worse than one that never offered.
+ */
+export function StatusRow({ status, kind, flagged, name, facts, onActivate, className }: StatusRowProps) {
+  const body = (
+    <>
+      {/* The verdict keeps a minimum width so the names line up down the
+          list, the way `LogLine`'s gutters keep a stream's messages in line.
+          A minimum and not a fixed size: `CrashLoopBackOff` is longer than the
+          column and pushes rather than being cut in half. */}
+      <span className="status-row-verdict">
+        <StatusPill status={status} kind={kind} tinted={flagged} />
+      </span>
+      <span className="status-row-name">{name}</span>
+      {filled(facts) && (
+        <span className="status-row-facts">
+          {facts?.map((fact, i) => (
+            // Indexed because the facts are a positional list — the namespace
+            // slot and the ratio slot — with no identity of their own, and
+            // nothing here reorders or removes one.
+            <span key={i} className="status-row-fact">
+              {fact}
+            </span>
+          ))}
+        </span>
+      )}
+    </>
+  );
+
+  if (!onActivate) return <div className={cx("status-row", className)}>{body}</div>;
+
+  return (
+    // Explicitly `type="button"`: these stand inside whatever the screen puts
+    // them in, and a button with no type submits a surrounding form.
+    <button type="button" className={cx("status-row", className)} onClick={onActivate}>
+      {body}
+    </button>
+  );
+}

--- a/packages/ui-kit/src/SubHead.test.tsx
+++ b/packages/ui-kit/src/SubHead.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { SubHead } from "./SubHead";
 
 /** New: the mock shipped this component with no tests at all. (#320) */
@@ -30,5 +32,58 @@ describe("SubHead", () => {
   it("forwards className", () => {
     const { container } = render(<SubHead className="mb-1">Labels</SubHead>);
     expect(container.querySelector("h3.mb-1")).not.toBeNull();
+  });
+});
+
+/**
+ * The design carries two voices for a block's name (§C.3): the detail body's
+ * small bold line, and the small-caps signpost the pane heads wear. The
+ * cluster overview's bands want the second.
+ */
+describe("SubHead's two voices", () => {
+  it("heads a block in small caps when asked, and only then", () => {
+    const { container, rerender } = render(<SubHead variant="caps">Capacity</SubHead>);
+    const caps = container.querySelector("h3");
+    expect(caps?.className).toContain("subhead-caps");
+
+    rerender(<SubHead>Capacity</SubHead>);
+    expect(container.querySelector("h3")?.className).not.toContain("subhead-caps");
+  });
+
+  it("emits one size and weight, never two competing ones", () => {
+    // The variants are not an override of each other. `text-[0.75rem]` and a
+    // caps size would both be utilities, and two utilities setting the same
+    // property are resolved by the generated stylesheet's order rather than by
+    // the order the JSX writes them — so the loser is a coin flip. Exactly one
+    // set is emitted, and the caps one is a components-layer class.
+    const { container } = render(<SubHead variant="caps">Nodes</SubHead>);
+    const head = container.querySelector("h3");
+    expect(head?.className).not.toContain("text-[0.75rem]");
+    expect(head?.className).not.toContain("font-semibold");
+  });
+
+  it("is still a level-3 heading in either voice", () => {
+    render(<SubHead variant="caps">Not ready</SubHead>);
+    expect(screen.getByRole("heading", { level: 3, name: "Not ready" })).toBeDefined();
+  });
+});
+
+describe("the small-caps voice's recipe", () => {
+  const css = readFileSync(join(__dirname, "styles", "kit.css"), "utf8");
+  const components = css.slice(css.indexOf("@layer components {"), css.indexOf("@layer utilities {"));
+
+  it("is the design's pane-head recipe, in the components layer", () => {
+    // §C.3: 10px / 600 / 0.07em / uppercase / --ink-faint — the same recipe
+    // `.pane-head` wears, so a section heading and the strip above it read as
+    // one system. Asserted on the stylesheet because jsdom does no layout.
+    const rule = components.slice(components.indexOf("\n  .subhead-caps {"));
+    const body = rule.slice(0, rule.indexOf("}"));
+    expect(body).toContain("font-size: 0.625rem");
+    expect(body).toContain("font-weight: 600");
+    expect(body).toContain("letter-spacing: 0.07em");
+    expect(body).toContain("text-transform: uppercase");
+    expect(body).toContain("color: var(--ink-faint)");
+    // Tokens, never a literal colour.
+    expect(body).not.toMatch(/#[0-9a-f]{3,8}/i);
   });
 });

--- a/packages/ui-kit/src/SubHead.test.tsx
+++ b/packages/ui-kit/src/SubHead.test.tsx
@@ -86,4 +86,39 @@ describe("the small-caps voice's recipe", () => {
     // Tokens, never a literal colour.
     expect(body).not.toMatch(/#[0-9a-f]{3,8}/i);
   });
+
+  it("sits on --surface-sunk with a bottom rule, not bare canvas", () => {
+    // §C.3, verbatim: ".pane-head and .section-head use the same ... recipe
+    // ON --surface-sunk, WITH A BOTTOM RULE". A band with no tint behind it
+    // reads as flatter than the design — this is the finding that sent the
+    // heads back to the recipe.
+    const rule = components.slice(components.indexOf("\n  .subhead-caps {"));
+    const body = rule.slice(0, rule.indexOf("}"));
+    expect(body).toContain("background: var(--surface-sunk)");
+    expect(body).toContain("border-bottom: 1px solid var(--rule)");
+  });
+
+  it("is 25px and sticky within its pane", () => {
+    // §C.3: "section heads are 25 px and sticky within their pane". A heading
+    // that scrolls away with the rows above it stops saying what the rows
+    // below it are — seen on a 113-row node table.
+    const rule = components.slice(components.indexOf("\n  .subhead-caps {"));
+    const body = rule.slice(0, rule.indexOf("}"));
+    expect(body).toContain("height: 25px");
+    expect(body).toContain("position: sticky");
+    expect(body).toContain("top: 0");
+  });
+
+  it("does not leave prose arguing for the background and rule it now wears", () => {
+    // Caught four times on this project: a comment defending behaviour the
+    // code no longer has. The old text argued the bands are "divided by the
+    // rule between them rather than framed by one of their own" — exactly
+    // the framing this recipe now draws.
+    const comment = components.slice(
+      components.indexOf("/* The design's section-head voice"),
+      components.indexOf("\n  .subhead-caps {"),
+    );
+    expect(comment).not.toContain("without the sunk");
+    expect(comment).not.toContain("divided by the rule between them rather than framed");
+  });
 });

--- a/packages/ui-kit/src/SubHead.tsx
+++ b/packages/ui-kit/src/SubHead.tsx
@@ -1,9 +1,24 @@
 import type { ReactNode } from "react";
 import { cx } from "./cx";
 
+/**
+ * The two voices the design gives a block's name.
+ *
+ * `bold` is the detail body's line — the resource pane's mock draws "a small
+ * bold section heading" and every call site in that pane wants it.
+ *
+ * `caps` is the design's structural signpost: 10 px, weight 600, `0.07em`,
+ * uppercase, `--ink-faint` — the same recipe `.pane-head` wears (design §C.3).
+ * The cluster overview's bands are headed in it, so a heading and the pane head
+ * above it read as one system rather than two.
+ */
+export type SubHeadVariant = "bold" | "caps";
+
 export interface SubHeadProps {
   children: ReactNode;
   className?: string;
+  /** Which of the two voices names this block. Defaults to `bold`. */
+  variant?: SubHeadVariant;
 }
 
 /**
@@ -19,7 +34,18 @@ export interface SubHeadProps {
  * in the design nests inside another. Preflight strips a heading's own size and
  * weight, so the utilities are what keep it looking like the mock's line rather
  * than a browser heading. (#320)
+ *
+ * The two variants emit DIFFERENT class sets rather than one overriding the
+ * other. Both would be Tailwind utilities in the same layer, where the winner
+ * is decided by the order the generated stylesheet happens to put them in and
+ * not by the order they are written — so an override of `text-[0.75rem]` from
+ * outside is a coin flip. `caps` is a components-layer class for the same
+ * reason, and nothing else here sets its size or weight.
  */
-export function SubHead({ children, className }: SubHeadProps) {
-  return <h3 className={cx("text-[0.75rem] font-semibold", className)}>{children}</h3>;
+export function SubHead({ children, className, variant = "bold" }: SubHeadProps) {
+  return (
+    <h3 className={cx(variant === "caps" ? "subhead-caps" : "text-[0.75rem] font-semibold", className)}>
+      {children}
+    </h3>
+  );
 }

--- a/packages/ui-kit/src/gallery/Gallery.tsx
+++ b/packages/ui-kit/src/gallery/Gallery.tsx
@@ -56,6 +56,7 @@ import { Spinner } from "../Spinner";
 import { Stat } from "../Stat";
 import { StatusBar } from "../StatusBar";
 import { StatusPill } from "../StatusPill";
+import { StatusRow } from "../StatusRow";
 import { SubHead } from "../SubHead";
 import { SurfaceToast } from "../SurfaceToast";
 import { Switch } from "../Switch";
@@ -343,6 +344,57 @@ export function Gallery() {
           <StatusPill status="Progressing" kind="warning" tinted />
           <StatusPill status="Running" kind="success" tinted />
           <StatusPill status="Unknown" tinted />
+        </div>
+      </section>
+
+      <section>
+        <h2>StatusRow</h2>
+        {/* The overview's `NOT READY` list: workloads and pods mixed in one
+            list, ordered by severity rather than by kind. Not a table — no
+            header, no sort, no selection. */}
+        <div className="flex flex-col">
+          <StatusRow
+            status="Degraded"
+            kind="danger"
+            flagged
+            name="checkout-api"
+            facts={["checkout", "9/12"]}
+            onActivate={() => {}}
+          />
+          <StatusRow
+            status="CrashLoopBackOff"
+            kind="danger"
+            flagged
+            name="checkout-api-7d9f4b8c6-x2mzp"
+            facts={["checkout", "0/1"]}
+            onActivate={() => {}}
+          />
+          <StatusRow
+            status="Progressing"
+            kind="warning"
+            flagged
+            name="payments-worker"
+            facts={["payments", "4/4"]}
+            onActivate={() => {}}
+          />
+          {/* A word longer than the verdict column pushes the name along
+              rather than being cut in half, and a name longer than its row
+              truncates rather than shoving the facts off the end. */}
+          <StatusRow
+            status="ContainerStatusUnknown"
+            kind="warning"
+            flagged
+            name="search-indexer-59c7d4f6b8-qm2xk-a-deliberately-overlong-name"
+            facts={["search", "0/1"]}
+            onActivate={() => {}}
+          />
+          {/* Healthy: a coloured dot beside a plain grey word. The asymmetry
+              is the point — a list where every row says something in colour
+              says nothing. */}
+          <StatusRow status="Running" kind="success" flagged={false} name="payments-api" facts={["payments", "3/3"]} />
+          {/* No facts and no activation: the row draws no empty facts box and
+              is not a target. */}
+          <StatusRow status="Unknown" kind="neutral" flagged={false} name="orphaned-replicaset" />
         </div>
       </section>
 

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -71,4 +71,4 @@ export { Tooltip, type TooltipProps } from "./Tooltip";
 export { WorkspaceSwitcher, type WorkspaceSummary, type WorkspaceSwitcherProps } from "./WorkspaceSwitcher";
 export { type ClusterLink, type WorkspaceCluster, WorkspaceTree, type WorkspaceTreeProps } from "./WorkspaceTree";
 export { cx } from "./cx";
-export { toneColor, toneWash, type Tone } from "./tone";
+export { loadTone, toneColor, toneWash, type Tone } from "./tone";

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -56,6 +56,7 @@ export { Spinner, type SpinnerProps } from "./Spinner";
 export { Stat, type StatProps } from "./Stat";
 export { StatusBar, type StatusBarProps, type StatusSegment } from "./StatusBar";
 export { StatusPill, statusTone, type StatusKind, type StatusPillProps } from "./StatusPill";
+export { StatusRow, type StatusRowProps } from "./StatusRow";
 export { SubHead, type SubHeadProps } from "./SubHead";
 export { SurfaceToast, type SurfaceToastProps } from "./SurfaceToast";
 export { Switch, type SwitchProps } from "./Switch";

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -57,7 +57,7 @@ export { Stat, type StatProps } from "./Stat";
 export { StatusBar, type StatusBarProps, type StatusSegment } from "./StatusBar";
 export { StatusPill, statusTone, type StatusKind, type StatusPillProps } from "./StatusPill";
 export { StatusRow, type StatusRowProps } from "./StatusRow";
-export { SubHead, type SubHeadProps } from "./SubHead";
+export { SubHead, type SubHeadProps, type SubHeadVariant } from "./SubHead";
 export { SurfaceToast, type SurfaceToastProps } from "./SurfaceToast";
 export { Switch, type SwitchProps } from "./Switch";
 export { Table, computeVisibleRange, filterTableData, nextSort, type Column, type TableProps, type TableSelection, type TableSort } from "./Table";

--- a/packages/ui-kit/src/styles/kit.css
+++ b/packages/ui-kit/src/styles/kit.css
@@ -677,6 +677,30 @@
   .section + .section { border-top: 1px solid var(--rule); }
   .section-title { margin-bottom: 0.3rem; }
 
+  /* `padded: false` — the content runs to both edges of the surface while the
+     heading keeps the inset it labels the band from. Only the sides go: the
+     vertical padding is the rhythm between one band and the next, and dropping
+     it would butt a table's header rule straight against the rule above it. */
+  .section[data-padded="false"] { padding-left: 0; padding-right: 0; }
+  .section[data-padded="false"] > .section-title { padding-left: 0.75rem; padding-right: 0.75rem; }
+
+  /* The design's section-head voice (§C.3) — the same 10px / 600 / 0.07em /
+     uppercase / --ink-faint recipe `.pane-head` wears, without the sunk
+     background and bottom rule, because these bands are divided by the rule
+     between them rather than framed by one of their own.
+
+     A components-layer class rather than utilities on the heading: the other
+     variant IS utilities, and two utilities that set the same property are
+     resolved by the generated stylesheet's order rather than by the order the
+     JSX writes them. See `SubHead`. */
+  .subhead-caps {
+    font-size: 0.625rem;
+    font-weight: 600;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+  }
+
   /* A section that folds: the heading itself is the control, so the whole
      line is clickable rather than a caret the size of a full stop beside it.
      Inherits the heading's own type — this is the same line it was, wearing a

--- a/packages/ui-kit/src/styles/kit.css
+++ b/packages/ui-kit/src/styles/kit.css
@@ -684,22 +684,49 @@
   .section[data-padded="false"] { padding-left: 0; padding-right: 0; }
   .section[data-padded="false"] > .section-title { padding-left: 0.75rem; padding-right: 0.75rem; }
 
-  /* The design's section-head voice (§C.3) — the same 10px / 600 / 0.07em /
-     uppercase / --ink-faint recipe `.pane-head` wears, without the sunk
-     background and bottom rule, because these bands are divided by the rule
-     between them rather than framed by one of their own.
+  /* The design's section-head voice (§C.3), recipe verbatim: the same 10px /
+     600 / 0.07em / uppercase / --ink-faint `.pane-head` wears, ON
+     --surface-sunk, WITH A BOTTOM RULE — and, unlike a pane head, 25px and
+     sticky within its pane rather than fixed. A band with no tint behind it
+     reads flatter than the design; this is what makes it read as a band.
+
+     Sticky matters past the cosmetics: the cluster overview's Nodes band can
+     hold over a hundred rows, and a heading that scrolls away with the rows
+     above it stops saying what the ones still on screen are. See
+     `.subhead-caps ~ .tbl thead th` below for the one place this collides
+     with another sticky head.
 
      A components-layer class rather than utilities on the heading: the other
      variant IS utilities, and two utilities that set the same property are
      resolved by the generated stylesheet's order rather than by the order the
      JSX writes them. See `SubHead`. */
   .subhead-caps {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    height: 25px;
+    background: var(--surface-sunk);
+    border-bottom: 1px solid var(--rule);
     font-size: 0.625rem;
     font-weight: 600;
     letter-spacing: 0.07em;
     text-transform: uppercase;
     color: var(--ink-faint);
   }
+
+  /* `.tbl thead th` is also sticky at `top: 0` (see `.tbl thead th` above) —
+     right for a table sitting alone in a pane, but the Nodes band wraps one
+     directly inside a `.subhead-caps` head (`<Section smallCaps padded={false}>`
+     around a `<Table>`). Left alone the two would stick to the identical
+     coordinates: same top, same scrolling ancestor, and the section head's
+     higher z-index would paint over the table's own column names the moment
+     the list scrolls, rather than sitting above them. Offsetting the table
+     head by the section head's fixed 25px height stacks the two instead of
+     collapsing them onto each other. Scoped to a `.subhead-caps` sibling only
+     — a table alone in a pane, under `.pane-head` instead, is unaffected. */
+  .subhead-caps ~ .tbl thead th { top: 25px; }
 
   /* A section that folds: the heading itself is the control, so the whole
      line is clickable rather than a caret the size of a full stop beside it.
@@ -721,23 +748,6 @@
      kept for content it no longer has goes with it. */
   .section[data-open="false"] .section-title { margin-bottom: 0; }
 
-  .section-head {
-    position: sticky;
-    top: 0;
-    z-index: 2;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    height: 25px;
-    padding: 0 0.6rem;
-    background: var(--surface-sunk);
-    border-bottom: 1px solid var(--rule);
-    font-size: 0.625rem;
-    font-weight: 600;
-    letter-spacing: 0.07em;
-    text-transform: uppercase;
-    color: var(--ink-faint);
-  }
   .section-body { padding: 0.6rem; }
 
   /* key/value rows: fixed label column, values left-aligned beside it */

--- a/packages/ui-kit/src/styles/kit.css
+++ b/packages/ui-kit/src/styles/kit.css
@@ -724,10 +724,25 @@
     gap: 0 0.75rem;
     padding: 0.22rem 0;
   }
+  /* The key column is a `minmax(88px, 34%)` track, so its max is fixed and the
+     track never grows to fit an outsized key. Without `min-width: 0` the grid
+     item's automatic minimum is its min-content size — for a `nowrap` key,
+     the entire string — and a long one painted straight through the value
+     column and out past the right edge of its surface. Seen on the overview
+     rail, whose Fleet rows are keyed on kube CONTEXT names: a real kubeconfig
+     carries `kdev-…-kubernetes-admin@cluster-…`, and the 286px rail rendered
+     "kind-srelens-dem30/30 running" with the tail hanging off the window.
+
+     Clipped rather than wrapped: a key that wraps to three lines drags its own
+     value off the row's baseline, and every other outsized name in this design
+     — the tab strip's titles, the sidebar's cluster name — is clipped too. */
   .kv-k {
     font-size: 0.75rem;
     color: var(--ink-muted);
     white-space: nowrap;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   .kv-v {
     font-size: 0.75rem;

--- a/packages/ui-kit/src/styles/kit.css
+++ b/packages/ui-kit/src/styles/kit.css
@@ -404,6 +404,51 @@
      see it, and the extra weight is the second channel. */
   .status[data-bad="true"] { font-weight: 500; }
 
+  /* status-row: a verdict, the subject it is about, and its trailing facts —
+     one row of a list that is not a table. */
+  .status-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    width: 100%;
+    padding: 0.3rem 0.5rem;
+    border-radius: 6px;
+    text-align: left;
+    font-size: 0.75rem;
+    color: var(--ink);
+  }
+  /* Only the pressable form reacts to a pointer. A plain row that lit up on
+     hover would promise something it does not do. */
+  button.status-row:hover { background: var(--field); }
+  /* A minimum, never a fixed width: it lines the names up down the list the
+     way LogLine's gutters keep a stream's messages in line, while a word
+     longer than the column (`CrashLoopBackOff`) pushes rather than clipping. */
+  .status-row-verdict {
+    flex-shrink: 0;
+    min-width: 9rem;
+  }
+  /* Takes the slack. `min-width: 0` because a flex item will not shrink below
+     its content without it, so one long pod name would shove the trailing
+     facts off the end of the row. */
+  .status-row-name {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .status-row-facts {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+    gap: 0.75rem;
+    color: var(--ink-muted);
+  }
+  .status-row-fact {
+    font-variant-numeric: tabular-nums;
+    font-feature-settings: "tnum";
+  }
+
   .row-ask {
     opacity: 0;
     display: inline-flex;

--- a/packages/ui-kit/src/tone.ts
+++ b/packages/ui-kit/src/tone.ts
@@ -26,6 +26,20 @@ const WASH: Record<Tone, string> = {
   muted: "transparent",
 };
 
+/**
+ * The tone a load reads at — the thresholds a percentage is coloured by.
+ *
+ * Here rather than inside {@link Meter} because two things draw the same
+ * reading: the meter on a node's row, and the figure a screen puts above it
+ * (the cluster overview's CPU and Memory tiles are toned by the cluster's own
+ * share). A second copy of `> 80` / `> 65` would let a tile call a cluster
+ * amber while the meters under it called it red — the same drift the status
+ * vocabulary in `@srelens/core` is kept in one place to avoid.
+ */
+export function loadTone(percent: number): Tone {
+  return percent > 80 ? "sev" : percent > 65 ? "warn" : "ok";
+}
+
 export function toneColor(tone: Tone): string {
   return COLOR[tone];
 }

--- a/packages/ui-next/src/lib/cachedResource.test.tsx
+++ b/packages/ui-next/src/lib/cachedResource.test.tsx
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import {
+  CACHE_TTL_MS,
+  clearResourceCache,
+  useCachedResource,
+  __cacheSizeForTests,
+} from "./cachedResource";
+
+beforeEach(() => {
+  clearResourceCache();
+  vi.useRealTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useCachedResource — returning to a tab", () => {
+  it("paints the last good answer on the next mount without loading again", async () => {
+    const load = vi.fn().mockResolvedValue(["a", "b"]);
+    const first = renderHook(() => useCachedResource("nodes|prod", load));
+    await waitFor(() => expect(first.result.current.status).toBe("ready"));
+    first.unmount();
+
+    const second = renderHook(() => useCachedResource("nodes|prod", load));
+    // No loading flash and no second call: this is what makes returning to
+    // the tab instant rather than a spinner over data we already have.
+    expect(second.result.current.status).toBe("ready");
+    expect(second.result.current.data).toEqual(["a", "b"]);
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the cached rows while it refreshes them once the TTL has passed", async () => {
+    const load = vi.fn().mockResolvedValueOnce(["old"]).mockResolvedValueOnce(["new"]);
+    const first = renderHook(() => useCachedResource("nodes|prod", load));
+    await waitFor(() => expect(first.result.current.data).toEqual(["old"]));
+    first.unmount();
+
+    const now = vi.spyOn(Date, "now");
+    now.mockReturnValue(Date.now() + CACHE_TTL_MS + 1);
+    const second = renderHook(() => useCachedResource("nodes|prod", load));
+    // Stale-while-revalidate: rows first, spinner never.
+    expect(second.result.current.status).toBe("ready");
+    expect(second.result.current.data).toEqual(["old"]);
+    await waitFor(() => expect(second.result.current.data).toEqual(["new"]));
+    expect(load).toHaveBeenCalledTimes(2);
+    now.mockRestore();
+  });
+
+  it("serves one load to every reader that asks for the same thing at once", async () => {
+    const load = vi.fn().mockResolvedValue(["a"]);
+    const a = renderHook(() => useCachedResource("nodes|prod", load));
+    const b = renderHook(() => useCachedResource("nodes|prod", load));
+    await waitFor(() => expect(a.result.current.status).toBe("ready"));
+    await waitFor(() => expect(b.result.current.status).toBe("ready"));
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps one cluster's answer out of another's", async () => {
+    const load = vi.fn((key: string) => Promise.resolve([key]));
+    const a = renderHook(() => useCachedResource("nodes|prod", () => load("prod")));
+    await waitFor(() => expect(a.result.current.data).toEqual(["prod"]));
+    const b = renderHook(() => useCachedResource("nodes|dev", () => load("dev")));
+    await waitFor(() => expect(b.result.current.data).toEqual(["dev"]));
+    expect(a.result.current.data).toEqual(["prod"]);
+  });
+});
+
+describe("useCachedResource — stale data says it is stale", () => {
+  it("keeps the rows when a refresh fails, and marks them no longer refreshing", async () => {
+    const load = vi
+      .fn()
+      .mockResolvedValueOnce(["a"])
+      .mockRejectedValueOnce(new Error("nodes is forbidden"));
+    const first = renderHook(() => useCachedResource("nodes|prod", load));
+    await waitFor(() => expect(first.result.current.data).toEqual(["a"]));
+    first.unmount();
+
+    const now = vi.spyOn(Date, "now");
+    now.mockReturnValue(Date.now() + CACHE_TTL_MS + 1);
+    const second = renderHook(() => useCachedResource("nodes|prod", load));
+    await waitFor(() => expect(second.result.current.stale).toBe(true));
+
+    // The rows the reader can see are still the last good ones — throwing
+    // them away for an error state loses information nobody asked to lose.
+    expect(second.result.current.data).toEqual(["a"]);
+    // And the screen is told, so it can say so rather than pretending the
+    // figures on it are current.
+    expect(second.result.current.error).toContain("forbidden");
+    now.mockRestore();
+  });
+
+  it("is an error, not stale data, when the first load fails with nothing cached", async () => {
+    const load = vi.fn().mockRejectedValue(new Error("nodes is forbidden"));
+    const { result } = renderHook(() => useCachedResource("nodes|prod", load));
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.stale).toBe(false);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("stops being stale once a refresh succeeds again", async () => {
+    const load = vi
+      .fn()
+      .mockResolvedValueOnce(["a"])
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce(["b"]);
+    const { result } = renderHook(() => useCachedResource("nodes|prod", load));
+    await waitFor(() => expect(result.current.data).toEqual(["a"]));
+
+    act(() => result.current.reload());
+    await waitFor(() => expect(result.current.stale).toBe(true));
+
+    act(() => result.current.reload());
+    await waitFor(() => expect(result.current.data).toEqual(["b"]));
+    expect(result.current.stale).toBe(false);
+    expect(result.current.error).toBeUndefined();
+  });
+});
+
+describe("useCachedResource — a late answer is never believed", () => {
+  it("discards a response for a context the reader has left", async () => {
+    let answerProd!: (v: string[]) => void;
+    const load = vi.fn((key: string) =>
+      key === "prod"
+        ? new Promise<string[]>((resolve) => {
+            answerProd = resolve;
+          })
+        : Promise.resolve(["dev-rows"]),
+    );
+
+    const { result, rerender } = renderHook(
+      ({ ctx }: { ctx: string }) => useCachedResource(`nodes|${ctx}`, () => load(ctx)),
+      { initialProps: { ctx: "prod" } },
+    );
+    rerender({ ctx: "dev" });
+    await waitFor(() => expect(result.current.data).toEqual(["dev-rows"]));
+
+    // Flushed inside `act`: an update React schedules outside it never
+    // reaches `result.current` before the assertion, so this test would pass
+    // with the guard removed.
+    await act(async () => {
+      answerProd(["prod-rows"]);
+      await Promise.resolve();
+    });
+    expect(result.current.data).toEqual(["dev-rows"]);
+  });
+
+  it("cannot have a cleared cache repopulated by a load already in flight", async () => {
+    let answer!: (v: string[]) => void;
+    const load = vi.fn(
+      () =>
+        new Promise<string[]>((resolve) => {
+          answer = resolve;
+        }),
+    );
+    const { unmount } = renderHook(() => useCachedResource("nodes|prod", load));
+    unmount();
+
+    clearResourceCache();
+    await act(async () => {
+      answer(["late"]);
+      await Promise.resolve();
+    });
+
+    // Deleting the pending promise cannot cancel its `.then`; only a
+    // generation captured at the start can stop a reset being undone.
+    expect(__cacheSizeForTests()).toBe(0);
+    const load2 = vi.fn().mockResolvedValue(["fresh"]);
+    const { result } = renderHook(() => useCachedResource("nodes|prod", load2));
+    expect(result.current.status).toBe("loading");
+    await waitFor(() => expect(result.current.data).toEqual(["fresh"]));
+  });
+});
+
+describe("useCachedResource — the cache is bounded", () => {
+  it("evicts the oldest entry rather than growing without end", async () => {
+    for (let i = 0; i < 45; i++) {
+      const { unmount } = renderHook(() =>
+        useCachedResource(`nodes|c${i}`, () => Promise.resolve([i])),
+      );
+      await waitFor(() => expect(__cacheSizeForTests()).toBeGreaterThan(0));
+      unmount();
+    }
+    expect(__cacheSizeForTests()).toBe(40);
+
+    // The oldest key is gone and loads again; the newest is still served.
+    const oldest = vi.fn().mockResolvedValue(["again"]);
+    const a = renderHook(() => useCachedResource("nodes|c0", oldest));
+    expect(a.result.current.status).toBe("loading");
+
+    const newest = vi.fn().mockResolvedValue(["unused"]);
+    const b = renderHook(() => useCachedResource("nodes|c44", newest));
+    expect(b.result.current.status).toBe("ready");
+    expect(newest).not.toHaveBeenCalled();
+  });
+
+  it("forces a refresh through reload even inside the TTL", async () => {
+    const load = vi.fn().mockResolvedValueOnce(["a"]).mockResolvedValueOnce(["b"]);
+    const { result } = renderHook(() => useCachedResource("nodes|prod", load));
+    await waitFor(() => expect(result.current.data).toEqual(["a"]));
+
+    act(() => result.current.reload());
+    await waitFor(() => expect(result.current.data).toEqual(["b"]));
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports an empty answer as empty, by the caller's own rule", async () => {
+    const a = renderHook(() => useCachedResource("k|1", () => Promise.resolve([])));
+    await waitFor(() => expect(a.result.current.status).toBe("empty"));
+    const b = renderHook(() =>
+      useCachedResource("k|2", () => Promise.resolve({ n: 0 }), (v) => v.n === 0),
+    );
+    await waitFor(() => expect(b.result.current.status).toBe("empty"));
+  });
+});

--- a/packages/ui-next/src/lib/cachedResource.ts
+++ b/packages/ui-next/src/lib/cachedResource.ts
@@ -1,0 +1,222 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Resource, ResourceStatus } from "./useResource";
+
+/**
+ * {@link useResource} with a memory of the last good answer.
+ *
+ * `useResource` refetches on every mount. That is right for a screen you open
+ * once; it is wrong for a tab you come back to, where it means a spinner over
+ * data the app already has and a whole cluster's worth of requests to arrive
+ * at the same numbers. This is the same hook with three things added, and each
+ * one is here because leaving it out broke something:
+ *
+ * 1. **A cache with a TTL.** Within {@link CACHE_TTL_MS} a remount paints the
+ *    cached answer and issues NO request at all; past it, the cached answer is
+ *    painted anyway and a refresh runs behind it. That second half is the
+ *    stale-while-revalidate `resourceList` already does for list rows, and it
+ *    is what makes returning to a tab feel instant rather than merely fast.
+ * 2. **In-flight de-duplication.** Two readers of the same key that mount in
+ *    the same frame — the overview's rail and its capacity strip both wanting
+ *    the pod facts — share one request instead of racing two.
+ * 3. **Two independent generation counters.** They guard different things and
+ *    neither substitutes for the other:
+ *    - a per-hook one, the rule {@link useResource} already has: a response
+ *      for a context the reader has LEFT is dropped rather than painted over
+ *      the cluster they are looking at now.
+ *    - a module-wide CLEAR generation: deleting a pending promise cannot
+ *      cancel its `.then`, so a request that was already in flight when the
+ *      cache was cleared must not write its answer into the fresh one.
+ *      Classic's overview learned this the hard way and its comment says so.
+ *
+ * **Nothing here is persisted** (R-6): a cache that survived a restart would
+ * paint a cluster's old numbers before its real ones, and this screen's whole
+ * argument is that a figure on it means what it says.
+ *
+ * ## Stale data is visibly stale
+ *
+ * Rows on screen plus a failed refresh is not an error state — throwing away
+ * the last good answer loses information nobody asked to lose — and it is not
+ * a healthy one either. It is {@link CachedResource.stale}: the data stays,
+ * the reason comes with it, and the screen is expected to SAY so. A screen
+ * that quietly kept showing figures that stopped refreshing would be lying by
+ * omission, which is the same failure as a `0` in place of "no reading".
+ */
+
+/**
+ * How long an answer counts as current.
+ *
+ * Classic's overview cache used the same thirty seconds and the figure has
+ * held up: long enough that flicking between tabs never refetches, short
+ * enough that nobody reads a minute-old node count as live. A reader who
+ * wants certainty has `reload`, which ignores this entirely.
+ */
+export const CACHE_TTL_MS = 30_000;
+
+/**
+ * The most keys the cache holds — `resourceList`'s own limit, and the same
+ * reasoning: a workspace of ten clusters times a handful of loaders each, with
+ * room to spare, and a hard stop rather than a map that grows for the life of
+ * the process.
+ */
+const CACHE_LIMIT = 40;
+
+interface Entry<T> {
+  data: T;
+  /** When this answer was fetched, for the TTL and for the screen to show. */
+  at: number;
+}
+
+let cache = new Map<string, Entry<unknown>>();
+let inflight = new Map<string, Promise<Entry<unknown>>>();
+
+/**
+ * Bumped by every clear. A request captures it before it starts and writes to
+ * the cache only if no clear happened in between.
+ */
+let clearGeneration = 0;
+
+/** Forget every cached answer. Exported for tests and for a workspace reset. */
+export function clearResourceCache(key?: string) {
+  clearGeneration++;
+  if (key !== undefined) {
+    cache.delete(key);
+    inflight.delete(key);
+    return;
+  }
+  cache = new Map();
+  inflight = new Map();
+}
+
+/** Test-only: how many answers the cache is holding. */
+export function __cacheSizeForTests(): number {
+  return cache.size;
+}
+
+function cacheSet(key: string, entry: Entry<unknown>) {
+  if (!cache.has(key) && cache.size >= CACHE_LIMIT) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+  // Re-inserted so the key is youngest in insertion order, which is the order
+  // eviction reads (Map preserves it).
+  cache.delete(key);
+  cache.set(key, entry);
+}
+
+const defaultEmpty = (v: unknown) => v == null || v === "" || (Array.isArray(v) && v.length === 0);
+
+/**
+ * One load per key at a time, cached, with the clear generation honoured.
+ *
+ * `force` skips the TTL — it does NOT skip a request already in flight, which
+ * is exactly what a reader pressing retry wants: the answer they are waiting
+ * for is already on its way.
+ */
+function request<T>(key: string, load: () => Promise<T>, force: boolean): Promise<Entry<T>> {
+  if (!force) {
+    const hit = cache.get(key);
+    if (hit && Date.now() - hit.at < CACHE_TTL_MS) return Promise.resolve(hit as Entry<T>);
+  }
+  const pending = inflight.get(key);
+  if (pending) return pending as Promise<Entry<T>>;
+
+  const generation = clearGeneration;
+  const running = load()
+    .then((data) => {
+      const entry: Entry<T> = { data, at: Date.now() };
+      if (clearGeneration === generation) cacheSet(key, entry as Entry<unknown>);
+      return entry;
+    })
+    .finally(() => {
+      inflight.delete(key);
+    });
+  inflight.set(key, running as Promise<Entry<unknown>>);
+  return running;
+}
+
+export interface CachedResource<T> extends Resource<T> {
+  /**
+   * The data on screen is the last good answer AND the refresh behind it
+   * failed. The rows are real and they are no longer being updated; the screen
+   * must say the second half rather than presenting the first as current.
+   */
+  stale: boolean;
+  /** When the data on screen was fetched — absent when there is none. */
+  updatedAt?: number;
+}
+
+type State<T> = { status: ResourceStatus; data?: T; error?: string; stale: boolean; updatedAt?: number };
+
+/**
+ * A cached, stale-while-revalidate resource. The `key` is the cache identity
+ * and the effect's only dependency, so **it must name everything the loader
+ * closes over** — the context above all. `load` is read through a ref, so it
+ * may be a fresh closure on every render without retriggering anything.
+ */
+export function useCachedResource<T>(
+  key: string,
+  load: () => Promise<T>,
+  isEmpty: (v: T) => boolean = defaultEmpty,
+): CachedResource<T> {
+  const loadRef = useRef(load);
+  loadRef.current = load;
+  const emptyRef = useRef(isEmpty);
+  emptyRef.current = isEmpty;
+
+  const settled = useCallback((entry: Entry<T>): State<T> => {
+    const status: ResourceStatus = emptyRef.current(entry.data) ? "empty" : "ready";
+    return { status, data: entry.data, stale: false, updatedAt: entry.at };
+  }, []);
+
+  const [state, setState] = useState<State<T>>(() => {
+    const hit = cache.get(key) as Entry<T> | undefined;
+    return hit ? settled(hit) : { status: "loading", stale: false };
+  });
+
+  const gen = useRef(0);
+  const [tick, setTick] = useState(0);
+  const forced = useRef(false);
+  const reload = useCallback(() => {
+    forced.current = true;
+    setTick((t) => t + 1);
+  }, []);
+
+  useEffect(() => {
+    const mine = ++gen.current;
+    const hit = cache.get(key) as Entry<T> | undefined;
+    const force = forced.current;
+    forced.current = false;
+
+    // The cached answer goes up FIRST, whether or not a refresh follows it.
+    // A spinner in front of data the app already has is the thing this hook
+    // exists to remove.
+    //
+    // Whether a refresh follows is `request`'s to decide and NOT repeated
+    // here: a second TTL check in this effect would be a rule with two homes
+    // that no test can tell apart — disabling either one on its own left the
+    // suite green, which is how the duplicate was found.
+    setState(hit ? settled(hit) : { status: "loading", stale: false });
+
+    request(key, () => loadRef.current(), force).then(
+      (entry) => {
+        if (gen.current !== mine) return;
+        setState(settled(entry));
+      },
+      (e: unknown) => {
+        if (gen.current !== mine) return;
+        const error = e instanceof Error ? e.message : String(e);
+        setState((prev) =>
+          prev.data === undefined
+            ? { status: "error", error, stale: false }
+            : { ...prev, error, stale: true },
+        );
+      },
+    );
+
+    return () => {
+      if (gen.current === mine) gen.current++;
+    };
+  }, [key, tick, settled]);
+
+  return { ...state, reload };
+}

--- a/packages/ui-next/src/lib/icons.ts
+++ b/packages/ui-next/src/lib/icons.ts
@@ -1,5 +1,6 @@
 import {
   ArrowLeftRight,
+  Ban,
   BellRing,
   Bot,
   Box,
@@ -56,6 +57,7 @@ import {
   TriangleAlert,
   UserRoundCheck,
   UserRoundCog,
+  Waves,
   Waypoints,
   Webhook,
   Wrench,
@@ -192,6 +194,10 @@ export const Icons = {
   scale: Scaling,
   restart: RotateCw,
   evict: LogOut,
+  /** Stop new pods being scheduled to a node — the design's crossed circle. */
+  cordon: Ban,
+  /** Move every pod off a node — the design's wave. */
+  drain: Waves,
   trash: Trash2,
   pause: Pause,
   play: Play,

--- a/packages/ui-next/src/lib/kinds/columns.test.ts
+++ b/packages/ui-next/src/lib/kinds/columns.test.ts
@@ -219,6 +219,7 @@ describe("node columns", () => {
     const memory = nodeColumns.find((c) => c.key === "memory")!;
     const node = {
       name: "n1", status: "Ready", roles: "worker", version: "1.30", age: "9d", taints: 0, unschedulable: false,
+      allocatableCpuMillicores: 4000, allocatableMemoryMiB: 8192, allocatablePods: 110,
     };
     const withCpu = { ...node, cpu: 2410 };
     const withMemory = { ...node, memory: 3174 };
@@ -239,7 +240,9 @@ describe("node columns", () => {
 describe("a node's pill and its unhealthy dot are one verdict", () => {
   const node = (over: Partial<NodeRow>): NodeRow => ({
     name: "n1", status: "Ready", roles: "worker", version: "1.30", age: "9d",
-    taints: 0, unschedulable: false, ...over,
+    taints: 0, unschedulable: false,
+    allocatableCpuMillicores: 4000, allocatableMemoryMiB: 8192, allocatablePods: 110,
+    ...over,
   });
   const statusColumn = nodeColumns.find((c) => c.key === "status")!;
   const pill = (n: NodeRow) => {
@@ -337,7 +340,10 @@ describe("flagged rows — the design's unhealthy dot, per kind", () => {
   // node asked "what is it using?" from its row and "why is it unhealthy?"
   // from its own pane. Both now read core's `nodeStatus`.
   it("flags a Node that is NotReady or cordoned, and neither when it is healthy and schedulable", () => {
-    const base = { name: "n1", roles: "worker", version: "1.30", age: "9d", taints: 0 };
+    const base = {
+      name: "n1", roles: "worker", version: "1.30", age: "9d", taints: 0,
+      allocatableCpuMillicores: 4000, allocatableMemoryMiB: 8192, allocatablePods: 110,
+    };
     expect(nodeFlagged({ ...base, status: "Ready", unschedulable: false })).toBe(false);
     expect(nodeFlagged({ ...base, status: "NotReady", unschedulable: false })).toBe(true);
     expect(nodeFlagged({ ...base, status: "Ready", unschedulable: true })).toBe(true);

--- a/packages/ui-next/src/lib/kinds/columns.test.ts
+++ b/packages/ui-next/src/lib/kinds/columns.test.ts
@@ -219,7 +219,7 @@ describe("node columns", () => {
     const memory = nodeColumns.find((c) => c.key === "memory")!;
     const node = {
       name: "n1", status: "Ready", roles: "worker", version: "1.30", age: "9d", taints: 0, unschedulable: false,
-      allocatableCpuMillicores: 4000, allocatableMemoryMiB: 8192, allocatablePods: 110,
+      allocatableCpuMillicores: 4000, allocatableMemoryMiB: 8192, allocatablePods: 110, instanceType: "",
     };
     const withCpu = { ...node, cpu: 2410 };
     const withMemory = { ...node, memory: 3174 };
@@ -241,7 +241,7 @@ describe("a node's pill and its unhealthy dot are one verdict", () => {
   const node = (over: Partial<NodeRow>): NodeRow => ({
     name: "n1", status: "Ready", roles: "worker", version: "1.30", age: "9d",
     taints: 0, unschedulable: false,
-    allocatableCpuMillicores: 4000, allocatableMemoryMiB: 8192, allocatablePods: 110,
+    allocatableCpuMillicores: 4000, allocatableMemoryMiB: 8192, allocatablePods: 110, instanceType: "",
     ...over,
   });
   const statusColumn = nodeColumns.find((c) => c.key === "status")!;
@@ -342,7 +342,7 @@ describe("flagged rows — the design's unhealthy dot, per kind", () => {
   it("flags a Node that is NotReady or cordoned, and neither when it is healthy and schedulable", () => {
     const base = {
       name: "n1", roles: "worker", version: "1.30", age: "9d", taints: 0,
-      allocatableCpuMillicores: 4000, allocatableMemoryMiB: 8192, allocatablePods: 110,
+      allocatableCpuMillicores: 4000, allocatableMemoryMiB: 8192, allocatablePods: 110, instanceType: "",
     };
     expect(nodeFlagged({ ...base, status: "Ready", unschedulable: false })).toBe(false);
     expect(nodeFlagged({ ...base, status: "NotReady", unschedulable: false })).toBe(true);

--- a/packages/ui-next/src/lib/kinds/rowAffordances.tsx
+++ b/packages/ui-next/src/lib/kinds/rowAffordances.tsx
@@ -22,6 +22,31 @@ export function askQuestion(name: string, flagged: boolean): string {
 }
 
 /**
+ * The design's unhealthy dot, and the word that has to go with it.
+ *
+ * Extracted from {@link withRowAffordances} because a second table draws the
+ * dot without the chip: the cluster overview's nodes table
+ * (`screens/Overview.tsx`) has a per-row action group where the ask chip
+ * would sit, so it takes half the pair. Two copies of six lines of markup is
+ * how one of them ends up tinted and silent.
+ *
+ * Never colour alone: the reason rides along as `sr-only` text, the same
+ * contract the cluster rail's `unavailable` follows (`ClusterRail.tsx`).
+ */
+export function UnhealthyDot() {
+  return (
+    <>
+      <span
+        aria-hidden="true"
+        className="h-1.5 w-1.5 shrink-0 rounded-full"
+        style={{ background: toneColor("sev") }}
+      />
+      <span className="sr-only">Needs attention</span>
+    </>
+  );
+}
+
+/**
  * The two row affordances the design mock has that the classic port lacked —
  * shared by every screen that lists rows, rather than duplicated per one.
  * `Resources.tsx` and `Workloads.tsx` each built this independently because
@@ -54,16 +79,7 @@ export function withRowAffordances<Row extends ListRow>(
       ...column,
       render: (row: Row) => (
         <span className="flex items-center gap-1.5">
-          {isFlagged(row) && (
-            <>
-              <span
-                aria-hidden="true"
-                className="h-1.5 w-1.5 shrink-0 rounded-full"
-                style={{ background: toneColor("sev") }}
-              />
-              <span className="sr-only">Needs attention</span>
-            </>
-          )}
+          {isFlagged(row) && <UnhealthyDot />}
           <span className="truncate">{render ? render(row) : row.name}</span>
         </span>
       ),

--- a/packages/ui-next/src/lib/overview.test.tsx
+++ b/packages/ui-next/src/lib/overview.test.tsx
@@ -1,0 +1,378 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ClusterFacts, NodeSummary, PodSummary } from "@srelens/core";
+
+// `vi.hoisted` because `vi.mock` is hoisted above every declaration in this
+// file — the same pattern resourceList.test.tsx uses. Only the six capability
+// wrappers are replaced; `nodeUsage`, `clusterCapacity` and `K8S_KIND` stay
+// real, so these tests assert against core's arithmetic rather than a copy.
+const core = vi.hoisted(() => ({
+  listNodes: vi.fn(),
+  nodeMetrics: vi.fn(),
+  listPods: vi.fn(),
+  listNamespaces: vi.fn(),
+  listResource: vi.fn(),
+  clusterFacts: vi.fn(),
+}));
+vi.mock("@srelens/core", async (orig) => ({
+  ...(await orig<typeof import("@srelens/core")>()),
+  ...core,
+}));
+
+import {
+  OVERVIEW_KINDS,
+  useClusterFacts,
+  useNamespaceCount,
+  useObjectCounts,
+  useOverview,
+  useOverviewNodes,
+  useOverviewPods,
+} from "./overview";
+
+function aNode(name: string, over: Partial<NodeSummary> = {}): NodeSummary {
+  return {
+    name,
+    status: "Ready",
+    unschedulable: false,
+    taints: 0,
+    version: "v1.31.4",
+    roles: "worker",
+    age: "10d",
+    allocatableCpuMillicores: 4000,
+    allocatableMemoryMiB: 16000,
+    allocatablePods: 50,
+    ...over,
+  };
+}
+
+function aPod(name: string, node: string, over: Partial<PodSummary> = {}): PodSummary {
+  return {
+    name,
+    namespace: "default",
+    phase: "Running",
+    ready: "1/1",
+    restarts: 0,
+    node,
+    age: "3d",
+    image: "acme/api:1",
+    ...over,
+  };
+}
+
+const NO_FACTS: ClusterFacts = {
+  context: "prod",
+  provider: "",
+  region: "",
+  metricsServer: { state: "unknown", version: "" },
+};
+
+/** Every loader answers something harmless; each test overrides what it cares about. */
+function allQuiet() {
+  core.listNodes.mockResolvedValue({ nodes: [] });
+  core.nodeMetrics.mockResolvedValue({ metrics: [] });
+  core.listPods.mockResolvedValue({ pods: [] });
+  core.listNamespaces.mockResolvedValue({ namespaces: [] });
+  core.listResource.mockResolvedValue({ items: [] });
+  core.clusterFacts.mockResolvedValue(NO_FACTS);
+}
+
+describe("useOverviewNodes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    allQuiet();
+  });
+
+  it("pairs each node with its usage against its own allocatable", async () => {
+    core.listNodes.mockResolvedValue({ nodes: [aNode("a1"), aNode("b2", { allocatableCpuMillicores: 8000 })] });
+    core.nodeMetrics.mockResolvedValue({
+      metrics: [
+        { name: "a1", cpuMillicores: 2000, memoryMiB: 8000 },
+        { name: "b2", cpuMillicores: 2000, memoryMiB: 4000 },
+      ],
+    });
+
+    const { result } = renderHook(() => useOverviewNodes("prod", undefined));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+
+    expect(result.current.nodes.map((n) => n.node.name)).toEqual(["a1", "b2"]);
+    expect(result.current.nodes[0].usage.cpuPercent).toBe(50);
+    expect(result.current.nodes[1].usage.cpuPercent).toBe(25);
+    expect(result.current.nodes[1].usage.memoryPercent).toBe(25);
+    expect(result.current.capacity).toEqual({
+      cpu: { usedMillicores: 4000, allocatableMillicores: 12000 },
+      memory: { usedMiB: 12000, allocatableMiB: 32000 },
+      nodesReporting: 2,
+      nodesTotal: 2,
+    });
+  });
+
+  it("keeps the rows when metrics-server is absent, and reads null rather than zero", async () => {
+    core.listNodes.mockResolvedValue({ nodes: [aNode("a1")] });
+    core.nodeMetrics.mockResolvedValue({ error: "the server could not find the requested resource" });
+
+    const { result } = renderHook(() => useOverviewNodes("prod", undefined));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+
+    expect(result.current.nodes).toHaveLength(1);
+    expect(result.current.nodes[0].usage.cpuPercent).toBeNull();
+    expect(result.current.nodes[0].usage.memoryPercent).toBeNull();
+    expect(result.current.metricsError).toContain("could not find");
+    // The node list itself did not fail, so the table is not in an error state.
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.capacity.nodesTotal).toBe(1);
+    expect(result.current.capacity.cpu).toBeNull();
+  });
+
+  it("reports a node above its allocatable unrounded and uncapped", async () => {
+    core.listNodes.mockResolvedValue({ nodes: [aNode("hot", { allocatableCpuMillicores: 1000 })] });
+    core.nodeMetrics.mockResolvedValue({ metrics: [{ name: "hot", cpuMillicores: 1400, memoryMiB: 1234 }] });
+
+    const { result } = renderHook(() => useOverviewNodes("prod", undefined));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+
+    expect(result.current.nodes[0].usage.cpuPercent).toBe(140);
+    expect(result.current.nodes[0].usage.memoryPercent).toBeCloseTo(7.7125, 6);
+  });
+
+  it("counts the pods on each node, and a node with none reads zero", async () => {
+    core.listNodes.mockResolvedValue({ nodes: [aNode("a1"), aNode("b2")] });
+    const pods = [aPod("p1", "a1"), aPod("p2", "a1"), aPod("p3", "b2")];
+
+    const { result } = renderHook(() => useOverviewNodes("prod", pods));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+
+    expect(result.current.nodes[0].usage.pods).toEqual({ used: 2, allocatable: 50 });
+    expect(result.current.nodes[1].usage.pods).toEqual({ used: 1, allocatable: 50 });
+
+    const empty = renderHook(() => useOverviewNodes("prod", [aPod("p1", "a1")]));
+    await waitFor(() => expect(empty.result.current.status).toBe("ready"));
+    expect(empty.result.current.nodes[1].usage.pods).toEqual({ used: 0, allocatable: 50 });
+  });
+
+  it("reads no pod count at all while the pod list is unknown", async () => {
+    core.listNodes.mockResolvedValue({ nodes: [aNode("a1")] });
+
+    const { result } = renderHook(() => useOverviewNodes("prod", undefined));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+
+    // Not `{ used: 0 }`: nobody has told us there are no pods on this node.
+    expect(result.current.nodes[0].usage.pods).toBeNull();
+  });
+
+  it("passes through a node that reports no allocatable pods rather than papering over it", async () => {
+    core.listNodes.mockResolvedValue({ nodes: [aNode("a1", { allocatablePods: 0 })] });
+
+    const { result } = renderHook(() => useOverviewNodes("prod", [aPod("p1", "a1"), aPod("p2", "a1")]));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+
+    expect(result.current.nodes[0].usage.pods).toEqual({ used: 2, allocatable: 0 });
+  });
+
+  it("empties the table and says why when the node list is refused", async () => {
+    core.listNodes.mockResolvedValue({ error: 'nodes is forbidden: User "dev" cannot list resource "nodes"' });
+    core.nodeMetrics.mockResolvedValue({ metrics: [{ name: "a1", cpuMillicores: 1, memoryMiB: 1 }] });
+
+    const { result } = renderHook(() => useOverviewNodes("prod", undefined));
+    await waitFor(() => expect(result.current.status).toBe("error"));
+
+    expect(result.current.nodes).toEqual([]);
+    expect(result.current.error).toContain("forbidden");
+  });
+
+  it("discards a node list that arrives after the reader moved to another cluster", async () => {
+    let settleFirst: (value: { nodes: NodeSummary[] }) => void = () => {};
+    core.listNodes.mockImplementationOnce(
+      () => new Promise<{ nodes: NodeSummary[] }>((resolve) => { settleFirst = resolve; }),
+    );
+    core.listNodes.mockResolvedValue({ nodes: [aNode("staging-1")] });
+
+    const { result, rerender } = renderHook(({ context }: { context: string }) => useOverviewNodes(context, undefined), {
+      initialProps: { context: "prod" },
+    });
+    rerender({ context: "staging" });
+    await waitFor(() => expect(result.current.nodes).toHaveLength(1));
+
+    await act(async () => {
+      settleFirst({ nodes: [aNode("prod-1"), aNode("prod-2")] });
+    });
+
+    expect(result.current.nodes.map((n) => n.node.name)).toEqual(["staging-1"]);
+  });
+});
+
+describe("useOverviewPods", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    allQuiet();
+  });
+
+  it("lists every namespace's pods, and holds `undefined` until it knows", async () => {
+    core.listPods.mockResolvedValue({ pods: [aPod("p1", "a1")] });
+
+    const { result } = renderHook(() => useOverviewPods("prod"));
+    expect(result.current.status).toBe("loading");
+    // Not `[]` while loading: an empty list would count as "no pods" to every
+    // consumer, which is the null-is-not-zero mistake one level up.
+    expect(result.current.pods).toBeUndefined();
+
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    expect(core.listPods).toHaveBeenCalledWith("prod", "");
+    expect(result.current.pods).toHaveLength(1);
+  });
+
+  it("reports a refusal without inventing an empty cluster", async () => {
+    core.listPods.mockResolvedValue({ error: "pods is forbidden" });
+
+    const { result } = renderHook(() => useOverviewPods("prod"));
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.pods).toBeUndefined();
+    expect(result.current.error).toContain("forbidden");
+  });
+});
+
+describe("useNamespaceCount", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    allQuiet();
+  });
+
+  it("counts them", async () => {
+    core.listNamespaces.mockResolvedValue({ namespaces: ["default", "kube-system", "checkout"] });
+
+    const { result } = renderHook(() => useNamespaceCount("prod"));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    expect(result.current.count).toBe(3);
+  });
+
+  it("has no count at all when the list is refused", async () => {
+    core.listNamespaces.mockResolvedValue({ error: "namespaces is forbidden" });
+
+    const { result } = renderHook(() => useNamespaceCount("prod"));
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.count).toBeNull();
+  });
+});
+
+describe("useObjectCounts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    allQuiet();
+  });
+
+  it("counts one kind per row, in the rail's order", async () => {
+    core.listResource.mockImplementation((_context: string, kind: string) =>
+      Promise.resolve({ items: kind === "Deployment" ? [{ name: "a" }, { name: "b" }] : [] }),
+    );
+
+    const { result } = renderHook(() => useObjectCounts("prod"));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+
+    expect(result.current.counts.map((c) => c.slug)).toEqual(OVERVIEW_KINDS);
+    expect(result.current.counts[0]).toEqual({ slug: "deployments", count: 2 });
+  });
+
+  it("keeps every other kind's count when one kind is refused", async () => {
+    core.listResource.mockImplementation((_context: string, kind: string) =>
+      kind === "Job"
+        ? Promise.resolve({ error: 'jobs is forbidden: User "dev" cannot list resource "jobs"' })
+        : Promise.resolve({ items: [{ name: "a" }] }),
+    );
+
+    const { result } = renderHook(() => useObjectCounts("prod"));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+
+    const jobs = result.current.counts.find((c) => c.slug === "jobs");
+    expect(jobs?.count).toBeNull();
+    expect(jobs?.error).toContain("forbidden");
+    for (const other of result.current.counts.filter((c) => c.slug !== "jobs")) {
+      expect(other.count).toBe(1);
+      expect(other.error).toBeUndefined();
+    }
+  });
+});
+
+describe("useClusterFacts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    allQuiet();
+  });
+
+  it("returns the control-plane facts", async () => {
+    core.clusterFacts.mockResolvedValue({
+      context: "prod",
+      provider: "GKE",
+      region: "europe-west4",
+      metricsServer: { state: "present", version: "v1beta1" },
+    });
+
+    const { result } = renderHook(() => useClusterFacts("prod"));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    expect(result.current.facts?.provider).toBe("GKE");
+    expect(result.current.facts?.metricsServer.version).toBe("v1beta1");
+  });
+
+  it("surfaces the wrapper's own error rather than presenting empty facts as an answer", async () => {
+    core.clusterFacts.mockResolvedValue({ ...NO_FACTS, error: "connection refused" });
+
+    const { result } = renderHook(() => useClusterFacts("prod"));
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.error).toContain("connection refused");
+  });
+});
+
+describe("useOverview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    allQuiet();
+  });
+
+  // The property this module exists for. Classic's ClusterOverview fires six
+  // calls in parallel and throws on the first error, so one refused list blanks
+  // the entire dashboard.
+  it("leaves every other section's data on screen when one loader fails", async () => {
+    core.listNodes.mockResolvedValue({ error: 'nodes is forbidden: User "dev" cannot list resource "nodes"' });
+    core.listPods.mockResolvedValue({ pods: [aPod("p1", "a1"), aPod("p2", "b2")] });
+    core.listNamespaces.mockResolvedValue({ namespaces: ["default", "checkout"] });
+    core.listResource.mockResolvedValue({ items: [{ name: "a" }, { name: "b" }, { name: "c" }] });
+    core.clusterFacts.mockResolvedValue({
+      context: "prod",
+      provider: "kind",
+      region: "",
+      metricsServer: { state: "present", version: "v1beta1" },
+    });
+
+    const { result } = renderHook(() => useOverview("prod"));
+    await waitFor(() => expect(result.current.nodes.status).toBe("error"));
+    await waitFor(() => expect(result.current.namespaces.status).toBe("ready"));
+
+    expect(result.current.nodes.nodes).toEqual([]);
+    expect(result.current.nodes.error).toContain("forbidden");
+
+    expect(result.current.pods.pods).toHaveLength(2);
+    expect(result.current.namespaces.count).toBe(2);
+    expect(result.current.objects.counts.every((c) => c.count === 3)).toBe(true);
+    expect(result.current.facts.facts?.provider).toBe("kind");
+  });
+
+  it("feeds the pod list into the nodes' pod counts without a second list call", async () => {
+    core.listNodes.mockResolvedValue({ nodes: [aNode("a1"), aNode("b2")] });
+    core.listPods.mockResolvedValue({ pods: [aPod("p1", "a1"), aPod("p2", "a1"), aPod("p3", "b2")] });
+
+    const { result } = renderHook(() => useOverview("prod"));
+    await waitFor(() => expect(result.current.nodes.nodes[0]?.usage.pods).toEqual({ used: 2, allocatable: 50 }));
+
+    expect(result.current.nodes.nodes[1].usage.pods).toEqual({ used: 1, allocatable: 50 });
+    expect(core.listPods).toHaveBeenCalledTimes(1);
+  });
+
+  it("reloads every section at once", async () => {
+    const { result } = renderHook(() => useOverview("prod"));
+    await waitFor(() => expect(result.current.facts.status).toBe("ready"));
+
+    act(() => result.current.reload());
+    await waitFor(() => expect(core.listNodes).toHaveBeenCalledTimes(2));
+    expect(core.listPods).toHaveBeenCalledTimes(2);
+    expect(core.listNamespaces).toHaveBeenCalledTimes(2);
+    expect(core.clusterFacts).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/ui-next/src/lib/overview.test.tsx
+++ b/packages/ui-next/src/lib/overview.test.tsx
@@ -33,7 +33,6 @@ import {
   OVERVIEW_KINDS,
   useClusterFacts,
   useNamespaceCount,
-  useObjectCounts,
   useOverview,
   useOverviewNodes,
   useOverviewPods,
@@ -289,6 +288,12 @@ describe("useNamespaceCount", () => {
   });
 });
 
+/**
+ * The counts now have two sources, so they are exercised through `useOverview`
+ * rather than alone: four of the six come off the loaders that already hold
+ * those kinds, and wiring them by hand in a test would be a second answer to
+ * the question the hook exists to settle.
+ */
 describe("useObjectCounts", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -296,15 +301,41 @@ describe("useObjectCounts", () => {
   });
 
   it("counts one kind per row, in the rail's order", async () => {
-    core.listResource.mockImplementation((_context: string, kind: string) =>
-      Promise.resolve({ items: kind === "Deployment" ? [{ name: "a" }, { name: "b" }] : [] }),
-    );
+    core.listDeployments.mockResolvedValue({ deployments: [aDeployment("a", "1/1"), aDeployment("b", "1/1")] });
+    core.listResource.mockResolvedValue({ items: [] });
 
-    const { result } = renderHook(() => useObjectCounts("prod"));
-    await waitFor(() => expect(result.current.status).toBe("ready"));
+    const { result } = renderHook(() => useOverview("prod"));
+    await waitFor(() => expect(result.current.objects.status).toBe("ready"));
 
-    expect(result.current.counts.map((c) => c.slug)).toEqual(OVERVIEW_KINDS);
-    expect(result.current.counts[0]).toEqual({ slug: "deployments", count: 2 });
+    expect(result.current.objects.counts.map((c) => c.slug)).toEqual(OVERVIEW_KINDS);
+    expect(result.current.objects.counts[0]).toEqual({ slug: "deployments", count: 2, error: undefined });
+  });
+
+  it("lists only the kinds nothing else on the screen loads", async () => {
+    core.listDeployments.mockResolvedValue({ deployments: [aDeployment("a", "1/1")] });
+    core.listStatefulSets.mockResolvedValue({ statefulsets: [aStatefulSet("b", "1/1")] });
+    core.listDaemonSets.mockResolvedValue({ daemonsets: [aDaemonSet("c", 1, 1)] });
+    core.listPods.mockResolvedValue({ pods: [aPod("p1", "n1"), aPod("p2", "n1")] });
+    core.listResource.mockResolvedValue({ items: [{ name: "x" }] });
+
+    const { result } = renderHook(() => useOverview("prod"));
+    await waitFor(() => expect(result.current.objects.status).toBe("ready"));
+
+    const count = (slug: string) => result.current.objects.counts.find((c) => c.slug === slug)?.count;
+    expect(count("deployments")).toBe(1);
+    expect(count("statefulsets")).toBe(1);
+    expect(count("daemonsets")).toBe(1);
+    expect(count("pods")).toBe(2);
+    expect(count("cronjobs")).toBe(1);
+    expect(count("jobs")).toBe(1);
+
+    // The collapse: four of the six kinds were already fetched, so the generic
+    // list goes out twice rather than six times — and the pod list, the
+    // largest of them, is fetched once for the whole screen.
+    expect(core.listResource).toHaveBeenCalledTimes(2);
+    expect(core.listResource.mock.calls.map((c: unknown[]) => c[1])).toEqual(["CronJob", "Job"]);
+    expect(core.listPods).toHaveBeenCalledTimes(1);
+    expect(core.listDeployments).toHaveBeenCalledTimes(1);
   });
 
   it("keeps every other kind's count when one kind is refused", async () => {
@@ -313,17 +344,34 @@ describe("useObjectCounts", () => {
         ? Promise.resolve({ error: 'jobs is forbidden: User "dev" cannot list resource "jobs"' })
         : Promise.resolve({ items: [{ name: "a" }] }),
     );
+    core.listDeployments.mockResolvedValue({ deployments: [aDeployment("a", "1/1")] });
 
-    const { result } = renderHook(() => useObjectCounts("prod"));
-    await waitFor(() => expect(result.current.status).toBe("ready"));
+    const { result } = renderHook(() => useOverview("prod"));
+    await waitFor(() => expect(result.current.objects.status).toBe("ready"));
 
-    const jobs = result.current.counts.find((c) => c.slug === "jobs");
+    const jobs = result.current.objects.counts.find((c) => c.slug === "jobs");
     expect(jobs?.count).toBeNull();
     expect(jobs?.error).toContain("forbidden");
-    for (const other of result.current.counts.filter((c) => c.slug !== "jobs")) {
-      expect(other.count).toBe(1);
-      expect(other.error).toBeUndefined();
-    }
+    expect(result.current.objects.counts.find((c) => c.slug === "cronjobs")?.count).toBe(1);
+    expect(result.current.objects.counts.find((c) => c.slug === "deployments")?.count).toBe(1);
+  });
+
+  it("carries a refused kind's own reason onto that kind's row alone", async () => {
+    core.listDeployments.mockResolvedValue({ error: 'deployments is forbidden: User "dev" cannot list' });
+    core.listPods.mockResolvedValue({ error: "pods is forbidden" });
+
+    const { result } = renderHook(() => useOverview("prod"));
+    await waitFor(() => expect(result.current.objects.status).toBe("ready"));
+
+    const row = (slug: string) => result.current.objects.counts.find((c) => c.slug === slug);
+    // Never `0`, which reads as a cluster with no Deployments at all.
+    expect(row("deployments")?.count).toBeNull();
+    expect(row("deployments")?.error).toContain("deployments is forbidden");
+    expect(row("pods")?.count).toBeNull();
+    expect(row("pods")?.error).toContain("pods is forbidden");
+    // The kinds that answered are untouched by either refusal.
+    expect(row("statefulsets")?.count).toBe(0);
+    expect(row("statefulsets")?.error).toBeUndefined();
   });
 });
 
@@ -391,15 +439,15 @@ describe("useOverviewWorkloads", () => {
     expect(result.current.daemonSets).toHaveLength(1);
     // Not an empty list, which would read as a cluster with no StatefulSets.
     expect(result.current.statefulSets).toBeUndefined();
-    expect(result.current.errors).toEqual([
-      'statefulsets is forbidden: User "dev" cannot list',
-    ]);
+    expect(result.current.refusals).toEqual({
+      statefulsets: 'statefulsets is forbidden: User "dev" cannot list',
+    });
   });
 
   it("carries no reasons at all when every kind answered", async () => {
     const { result } = renderHook(() => useOverviewWorkloads("prod"));
     await waitFor(() => expect(result.current.status).toBe("ready"));
-    expect(result.current.errors).toEqual([]);
+    expect(result.current.refusals).toEqual({});
   });
 });
 
@@ -433,7 +481,12 @@ describe("useOverview", () => {
 
     expect(result.current.pods.pods).toHaveLength(2);
     expect(result.current.namespaces.count).toBe(2);
-    expect(result.current.objects.counts.every((c) => c.count === 3)).toBe(true);
+    // The two kinds the rail lists for itself answered 3; the pod count came
+    // off the pod list this same render already has.
+    const count = (slug: string) => result.current.objects.counts.find((c) => c.slug === slug)?.count;
+    expect(count("cronjobs")).toBe(3);
+    expect(count("jobs")).toBe(3);
+    expect(count("pods")).toBe(2);
     expect(result.current.facts.facts?.provider).toBe("kind");
     expect(result.current.workloads.status).toBe("ready");
   });

--- a/packages/ui-next/src/lib/overview.test.tsx
+++ b/packages/ui-next/src/lib/overview.test.tsx
@@ -1,6 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
-import type { ClusterFacts, NodeSummary, PodSummary } from "@srelens/core";
+import type {
+  ClusterFacts,
+  DaemonSetSummary,
+  DeploymentSummary,
+  NodeSummary,
+  PodSummary,
+  StatefulSetSummary,
+} from "@srelens/core";
 
 // `vi.hoisted` because `vi.mock` is hoisted above every declaration in this
 // file — the same pattern resourceList.test.tsx uses. Only the six capability
@@ -12,6 +19,9 @@ const core = vi.hoisted(() => ({
   listPods: vi.fn(),
   listNamespaces: vi.fn(),
   listResource: vi.fn(),
+  listDeployments: vi.fn(),
+  listStatefulSets: vi.fn(),
+  listDaemonSets: vi.fn(),
   clusterFacts: vi.fn(),
 }));
 vi.mock("@srelens/core", async (orig) => ({
@@ -27,6 +37,7 @@ import {
   useOverview,
   useOverviewNodes,
   useOverviewPods,
+  useOverviewWorkloads,
 } from "./overview";
 
 function aNode(name: string, over: Partial<NodeSummary> = {}): NodeSummary {
@@ -41,6 +52,7 @@ function aNode(name: string, over: Partial<NodeSummary> = {}): NodeSummary {
     allocatableCpuMillicores: 4000,
     allocatableMemoryMiB: 16000,
     allocatablePods: 50,
+    instanceType: "",
     ...over,
   };
 }
@@ -59,6 +71,27 @@ function aPod(name: string, node: string, over: Partial<PodSummary> = {}): PodSu
   };
 }
 
+function aDeployment(name: string, ready: string): DeploymentSummary {
+  return { name, namespace: "checkout", ready, upToDate: 1, available: 1, age: "8d" };
+}
+
+function aStatefulSet(name: string, ready: string): StatefulSetSummary {
+  return { name, namespace: "payments", ready, updated: 1, service: "svc", age: "8d" };
+}
+
+function aDaemonSet(name: string, ready: number, desired: number): DaemonSetSummary {
+  return {
+    name,
+    namespace: "kube-system",
+    desired,
+    current: ready,
+    ready,
+    upToDate: ready,
+    available: ready,
+    age: "40d",
+  };
+}
+
 const NO_FACTS: ClusterFacts = {
   context: "prod",
   provider: "",
@@ -73,6 +106,9 @@ function allQuiet() {
   core.listPods.mockResolvedValue({ pods: [] });
   core.listNamespaces.mockResolvedValue({ namespaces: [] });
   core.listResource.mockResolvedValue({ items: [] });
+  core.listDeployments.mockResolvedValue({ deployments: [] });
+  core.listStatefulSets.mockResolvedValue({ statefulsets: [] });
+  core.listDaemonSets.mockResolvedValue({ daemonsets: [] });
   core.clusterFacts.mockResolvedValue(NO_FACTS);
 }
 
@@ -320,6 +356,53 @@ describe("useClusterFacts", () => {
   });
 });
 
+describe("useOverviewWorkloads", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    allQuiet();
+  });
+
+  it("lists the three scaling kinds across every namespace", async () => {
+    core.listDeployments.mockResolvedValue({ deployments: [aDeployment("checkout-api", "9/12")] });
+    core.listStatefulSets.mockResolvedValue({ statefulsets: [aStatefulSet("payments-db", "1/3")] });
+    core.listDaemonSets.mockResolvedValue({ daemonsets: [aDaemonSet("log-agent", 2, 4)] });
+
+    const { result } = renderHook(() => useOverviewWorkloads("prod"));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+
+    expect(result.current.deployments?.map((d) => d.name)).toEqual(["checkout-api"]);
+    expect(result.current.statefulSets?.map((s) => s.name)).toEqual(["payments-db"]);
+    expect(result.current.daemonSets?.map((d) => d.name)).toEqual(["log-agent"]);
+    // The empty namespace is "every namespace"; the overview is cluster-wide.
+    expect(core.listDeployments).toHaveBeenCalledWith("prod", "");
+    expect(core.listStatefulSets).toHaveBeenCalledWith("prod", "");
+    expect(core.listDaemonSets).toHaveBeenCalledWith("prod", "");
+  });
+
+  it("keeps the kinds that answered when one of them is refused", async () => {
+    core.listDeployments.mockResolvedValue({ deployments: [aDeployment("checkout-api", "9/12")] });
+    core.listStatefulSets.mockResolvedValue({ error: 'statefulsets is forbidden: User "dev" cannot list' });
+    core.listDaemonSets.mockResolvedValue({ daemonsets: [aDaemonSet("log-agent", 2, 4)] });
+
+    const { result } = renderHook(() => useOverviewWorkloads("prod"));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+
+    expect(result.current.deployments).toHaveLength(1);
+    expect(result.current.daemonSets).toHaveLength(1);
+    // Not an empty list, which would read as a cluster with no StatefulSets.
+    expect(result.current.statefulSets).toBeUndefined();
+    expect(result.current.errors).toEqual([
+      'statefulsets is forbidden: User "dev" cannot list',
+    ]);
+  });
+
+  it("carries no reasons at all when every kind answered", async () => {
+    const { result } = renderHook(() => useOverviewWorkloads("prod"));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    expect(result.current.errors).toEqual([]);
+  });
+});
+
 describe("useOverview", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -352,6 +435,7 @@ describe("useOverview", () => {
     expect(result.current.namespaces.count).toBe(2);
     expect(result.current.objects.counts.every((c) => c.count === 3)).toBe(true);
     expect(result.current.facts.facts?.provider).toBe("kind");
+    expect(result.current.workloads.status).toBe("ready");
   });
 
   it("feeds the pod list into the nodes' pod counts without a second list call", async () => {
@@ -373,6 +457,7 @@ describe("useOverview", () => {
     await waitFor(() => expect(core.listNodes).toHaveBeenCalledTimes(2));
     expect(core.listPods).toHaveBeenCalledTimes(2);
     expect(core.listNamespaces).toHaveBeenCalledTimes(2);
+    expect(core.listDeployments).toHaveBeenCalledTimes(2);
     expect(core.clusterFacts).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/ui-next/src/lib/overview.test.tsx
+++ b/packages/ui-next/src/lib/overview.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import type {
   ClusterFacts,
+  PodOverview,
   DaemonSetSummary,
   DeploymentSummary,
   NodeSummary,
@@ -16,7 +17,7 @@ import type {
 const core = vi.hoisted(() => ({
   listNodes: vi.fn(),
   nodeMetrics: vi.fn(),
-  listPods: vi.fn(),
+  podOverview: vi.fn(),
   listNamespaces: vi.fn(),
   listResource: vi.fn(),
   listDeployments: vi.fn(),
@@ -29,6 +30,7 @@ vi.mock("@srelens/core", async (orig) => ({
   ...core,
 }));
 
+import { clearResourceCache } from "./cachedResource";
 import {
   OVERVIEW_KINDS,
   useClusterFacts,
@@ -70,6 +72,31 @@ function aPod(name: string, node: string, over: Partial<PodSummary> = {}): PodSu
   };
 }
 
+/**
+ * A `podOverview` answer built from a list of pods — the counts grouped the
+ * way the backend groups them, so a fixture reads as a cluster rather than as
+ * three hand-written numbers that can drift from each other.
+ *
+ * `unsettled` is every pod that is not simply running, which is what the
+ * backend sends: a superset core then judges.
+ */
+function anOverview(pods: PodSummary[], over: Partial<PodOverview> = {}): PodOverview {
+  const byNode = new Map<string, number>();
+  for (const pod of pods) if (pod.node) byNode.set(pod.node, (byNode.get(pod.node) ?? 0) + 1);
+  return {
+    total: pods.length,
+    byNode: [...byNode].map(([node, count]) => ({ node, pods: count })),
+    unsettled: pods.filter((p) => p.phase !== "Running" || p.waitingReason),
+    truncated: false,
+    ...over,
+  };
+}
+
+/** The per-node map `useOverviewNodes` takes, from a list of pods. */
+function podsPerNode(pods: PodSummary[]): Map<string, number> {
+  return new Map(anOverview(pods).byNode.map((n) => [n.node, n.pods]));
+}
+
 function aDeployment(name: string, ready: string): DeploymentSummary {
   return { name, namespace: "checkout", ready, upToDate: 1, available: 1, age: "8d" };
 }
@@ -98,11 +125,19 @@ const NO_FACTS: ClusterFacts = {
   metricsServer: { state: "unknown", version: "" },
 };
 
+/**
+ * The loaders keep their last good answer in a module-level cache, so a test
+ * that did not clear it would be handed the previous test's cluster.
+ */
+beforeEach(() => {
+  clearResourceCache();
+});
+
 /** Every loader answers something harmless; each test overrides what it cares about. */
 function allQuiet() {
   core.listNodes.mockResolvedValue({ nodes: [] });
   core.nodeMetrics.mockResolvedValue({ metrics: [] });
-  core.listPods.mockResolvedValue({ pods: [] });
+  core.podOverview.mockResolvedValue({ pods: anOverview([]) });
   core.listNamespaces.mockResolvedValue({ namespaces: [] });
   core.listResource.mockResolvedValue({ items: [] });
   core.listDeployments.mockResolvedValue({ deployments: [] });
@@ -173,18 +208,20 @@ describe("useOverviewNodes", () => {
     core.listNodes.mockResolvedValue({ nodes: [aNode("a1"), aNode("b2")] });
     const pods = [aPod("p1", "a1"), aPod("p2", "a1"), aPod("p3", "b2")];
 
-    const { result } = renderHook(() => useOverviewNodes("prod", pods));
+    const { result } = renderHook(() => useOverviewNodes("prod", podsPerNode(pods)));
     await waitFor(() => expect(result.current.status).toBe("ready"));
 
     expect(result.current.nodes[0].usage.pods).toEqual({ used: 2, allocatable: 50 });
     expect(result.current.nodes[1].usage.pods).toEqual({ used: 1, allocatable: 50 });
 
-    const empty = renderHook(() => useOverviewNodes("prod", [aPod("p1", "a1")]));
+    // A node the grouping does not mention genuinely runs none: the map is
+    // complete, so its absence is a reading rather than a gap.
+    const empty = renderHook(() => useOverviewNodes("prod", podsPerNode([aPod("p1", "a1")])));
     await waitFor(() => expect(empty.result.current.status).toBe("ready"));
     expect(empty.result.current.nodes[1].usage.pods).toEqual({ used: 0, allocatable: 50 });
   });
 
-  it("reads no pod count at all while the pod list is unknown", async () => {
+  it("reads no pod count at all while the grouping is unknown", async () => {
     core.listNodes.mockResolvedValue({ nodes: [aNode("a1")] });
 
     const { result } = renderHook(() => useOverviewNodes("prod", undefined));
@@ -197,7 +234,9 @@ describe("useOverviewNodes", () => {
   it("passes through a node that reports no allocatable pods rather than papering over it", async () => {
     core.listNodes.mockResolvedValue({ nodes: [aNode("a1", { allocatablePods: 0 })] });
 
-    const { result } = renderHook(() => useOverviewNodes("prod", [aPod("p1", "a1"), aPod("p2", "a1")]));
+    const { result } = renderHook(() =>
+      useOverviewNodes("prod", podsPerNode([aPod("p1", "a1"), aPod("p2", "a1")])),
+    );
     await waitFor(() => expect(result.current.status).toBe("ready"));
 
     expect(result.current.nodes[0].usage.pods).toEqual({ used: 2, allocatable: 0 });
@@ -241,27 +280,68 @@ describe("useOverviewPods", () => {
     allQuiet();
   });
 
-  it("lists every namespace's pods, and holds `undefined` until it knows", async () => {
-    core.listPods.mockResolvedValue({ pods: [aPod("p1", "a1")] });
+  it("counts the cluster's pods rather than listing them", async () => {
+    core.podOverview.mockResolvedValue({
+      pods: anOverview([aPod("p1", "a1"), aPod("p2", "b2"), aPod("p3", "b2")]),
+    });
 
     const { result } = renderHook(() => useOverviewPods("prod"));
     expect(result.current.status).toBe("loading");
-    // Not `[]` while loading: an empty list would count as "no pods" to every
-    // consumer, which is the null-is-not-zero mistake one level up.
-    expect(result.current.pods).toBeUndefined();
+    // Not `0` while loading: a zero would count as "this cluster has no pods"
+    // to every consumer, which is the null-is-not-zero mistake one level up.
+    expect(result.current.total).toBeNull();
+    expect(result.current.byNode).toBeUndefined();
 
     await waitFor(() => expect(result.current.status).toBe("ready"));
-    expect(core.listPods).toHaveBeenCalledWith("prod", "");
-    expect(result.current.pods).toHaveLength(1);
+    expect(core.podOverview).toHaveBeenCalledWith("prod");
+    expect(result.current.total).toBe(3);
+    expect([...(result.current.byNode ?? [])]).toEqual([
+      ["a1", 1],
+      ["b2", 2],
+    ]);
+  });
+
+  it("carries only the pods that are not simply running", async () => {
+    const sick = aPod("crash", "a1", { waitingReason: "CrashLoopBackOff", ready: "0/1" });
+    core.podOverview.mockResolvedValue({ pods: anOverview([aPod("ok", "a1"), sick]) });
+
+    const { result } = renderHook(() => useOverviewPods("prod"));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+
+    // The total counts every pod; `unsettled` is the handful worth reading.
+    expect(result.current.total).toBe(2);
+    expect(result.current.unsettled?.map((p) => p.name)).toEqual(["crash"]);
   });
 
   it("reports a refusal without inventing an empty cluster", async () => {
-    core.listPods.mockResolvedValue({ error: "pods is forbidden" });
+    core.podOverview.mockResolvedValue({ error: "pods is forbidden" });
 
     const { result } = renderHook(() => useOverviewPods("prod"));
     await waitFor(() => expect(result.current.status).toBe("error"));
-    expect(result.current.pods).toBeUndefined();
+    // A cluster that did not answer has not told us it has no pods.
+    expect(result.current.total).toBeNull();
+    expect(result.current.byNode).toBeUndefined();
     expect(result.current.error).toContain("forbidden");
+  });
+
+  it("reads a cluster with no pods as an answer rather than an empty section", async () => {
+    core.podOverview.mockResolvedValue({ pods: anOverview([]) });
+
+    const { result } = renderHook(() => useOverviewPods("prod"));
+    await waitFor(() => expect(result.current.total).toBe(0));
+    // "empty" is a state the screen draws an EmptyState for; a cluster that
+    // answered zero has answered, and its tile shows the zero.
+    expect(result.current.status).toBe("ready");
+  });
+
+  it("carries the backend's cap rather than presenting a short list as whole", async () => {
+    core.podOverview.mockResolvedValue({
+      pods: anOverview([aPod("p1", "a1", { phase: "Failed" })], { truncated: true }),
+    });
+
+    const { result } = renderHook(() => useOverviewPods("prod"));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    expect(result.current.truncated).toBe(true);
   });
 });
 
@@ -315,7 +395,7 @@ describe("useObjectCounts", () => {
     core.listDeployments.mockResolvedValue({ deployments: [aDeployment("a", "1/1")] });
     core.listStatefulSets.mockResolvedValue({ statefulsets: [aStatefulSet("b", "1/1")] });
     core.listDaemonSets.mockResolvedValue({ daemonsets: [aDaemonSet("c", 1, 1)] });
-    core.listPods.mockResolvedValue({ pods: [aPod("p1", "n1"), aPod("p2", "n1")] });
+    core.podOverview.mockResolvedValue({ pods: anOverview([aPod("p1", "n1"), aPod("p2", "n1")]) });
     core.listResource.mockResolvedValue({ items: [{ name: "x" }] });
 
     const { result } = renderHook(() => useOverview("prod"));
@@ -330,11 +410,12 @@ describe("useObjectCounts", () => {
     expect(count("jobs")).toBe(1);
 
     // The collapse: four of the six kinds were already fetched, so the generic
-    // list goes out twice rather than six times — and the pod list, the
-    // largest of them, is fetched once for the whole screen.
+    // list goes out twice rather than six times — and the pod count, the one
+    // that used to cost a whole cluster's pod bodies, is a count the backend
+    // made and this screen asked for once.
     expect(core.listResource).toHaveBeenCalledTimes(2);
     expect(core.listResource.mock.calls.map((c: unknown[]) => c[1])).toEqual(["CronJob", "Job"]);
-    expect(core.listPods).toHaveBeenCalledTimes(1);
+    expect(core.podOverview).toHaveBeenCalledTimes(1);
     expect(core.listDeployments).toHaveBeenCalledTimes(1);
   });
 
@@ -358,7 +439,7 @@ describe("useObjectCounts", () => {
 
   it("carries a refused kind's own reason onto that kind's row alone", async () => {
     core.listDeployments.mockResolvedValue({ error: 'deployments is forbidden: User "dev" cannot list' });
-    core.listPods.mockResolvedValue({ error: "pods is forbidden" });
+    core.podOverview.mockResolvedValue({ error: "pods is forbidden" });
 
     const { result } = renderHook(() => useOverview("prod"));
     await waitFor(() => expect(result.current.objects.status).toBe("ready"));
@@ -462,7 +543,7 @@ describe("useOverview", () => {
   // the entire dashboard.
   it("leaves every other section's data on screen when one loader fails", async () => {
     core.listNodes.mockResolvedValue({ error: 'nodes is forbidden: User "dev" cannot list resource "nodes"' });
-    core.listPods.mockResolvedValue({ pods: [aPod("p1", "a1"), aPod("p2", "b2")] });
+    core.podOverview.mockResolvedValue({ pods: anOverview([aPod("p1", "a1"), aPod("p2", "b2")]) });
     core.listNamespaces.mockResolvedValue({ namespaces: ["default", "checkout"] });
     core.listResource.mockResolvedValue({ items: [{ name: "a" }, { name: "b" }, { name: "c" }] });
     core.clusterFacts.mockResolvedValue({
@@ -479,10 +560,10 @@ describe("useOverview", () => {
     expect(result.current.nodes.nodes).toEqual([]);
     expect(result.current.nodes.error).toContain("forbidden");
 
-    expect(result.current.pods.pods).toHaveLength(2);
+    expect(result.current.pods.total).toBe(2);
     expect(result.current.namespaces.count).toBe(2);
     // The two kinds the rail lists for itself answered 3; the pod count came
-    // off the pod list this same render already has.
+    // off the pod facts this same render already has.
     const count = (slug: string) => result.current.objects.counts.find((c) => c.slug === slug)?.count;
     expect(count("cronjobs")).toBe(3);
     expect(count("jobs")).toBe(3);
@@ -491,15 +572,67 @@ describe("useOverview", () => {
     expect(result.current.workloads.status).toBe("ready");
   });
 
-  it("feeds the pod list into the nodes' pod counts without a second list call", async () => {
+  it("feeds the backend's grouping into the nodes' pod counts, with one call", async () => {
     core.listNodes.mockResolvedValue({ nodes: [aNode("a1"), aNode("b2")] });
-    core.listPods.mockResolvedValue({ pods: [aPod("p1", "a1"), aPod("p2", "a1"), aPod("p3", "b2")] });
+    core.podOverview.mockResolvedValue({
+      pods: anOverview([aPod("p1", "a1"), aPod("p2", "a1"), aPod("p3", "b2")]),
+    });
 
     const { result } = renderHook(() => useOverview("prod"));
     await waitFor(() => expect(result.current.nodes.nodes[0]?.usage.pods).toEqual({ used: 2, allocatable: 50 }));
 
     expect(result.current.nodes.nodes[1].usage.pods).toEqual({ used: 1, allocatable: 50 });
-    expect(core.listPods).toHaveBeenCalledTimes(1);
+    // The Pods tile, the per-node column and the `Not ready` list, from one
+    // call that never listed a pod.
+    expect(core.podOverview).toHaveBeenCalledTimes(1);
+  });
+
+  it("paints the whole screen from cache when the reader comes back to it", async () => {
+    core.listNodes.mockResolvedValue({ nodes: [aNode("a1")] });
+    core.podOverview.mockResolvedValue({ pods: anOverview([aPod("p1", "a1")]) });
+
+    const first = renderHook(() => useOverview("prod"));
+    await waitFor(() => expect(first.result.current.nodes.status).toBe("ready"));
+    first.unmount();
+
+    const again = renderHook(() => useOverview("prod"));
+    // No loading state anywhere and not one extra request: this is what
+    // makes returning to the tab instant.
+    expect(again.result.current.nodes.status).toBe("ready");
+    expect(again.result.current.pods.total).toBe(1);
+    expect(core.listNodes).toHaveBeenCalledTimes(1);
+    expect(core.podOverview).toHaveBeenCalledTimes(1);
+    expect(core.clusterFacts).toHaveBeenCalledTimes(1);
+  });
+
+  it("never serves one cluster's cached answer for another", async () => {
+    core.listNodes.mockImplementation((context: string) =>
+      Promise.resolve({ nodes: [aNode(`${context}-1`)] }),
+    );
+
+    const prod = renderHook(() => useOverview("prod"));
+    await waitFor(() => expect(prod.result.current.nodes.nodes[0]?.node.name).toBe("prod-1"));
+
+    const staging = renderHook(() => useOverview("staging"));
+    await waitFor(() => expect(staging.result.current.nodes.nodes[0]?.node.name).toBe("staging-1"));
+    expect(prod.result.current.nodes.nodes[0].node.name).toBe("prod-1");
+  });
+
+  it("keeps the figures on screen when a refresh fails, and says they are stale", async () => {
+    core.listNodes.mockResolvedValueOnce({ nodes: [aNode("a1")] });
+    core.listNodes.mockResolvedValue({ error: 'nodes is forbidden: User "dev" cannot list' });
+
+    const { result } = renderHook(() => useOverview("prod"));
+    await waitFor(() => expect(result.current.nodes.nodes).toHaveLength(1));
+
+    act(() => result.current.reload());
+    await waitFor(() => expect(result.current.nodes.stale).toBe(true));
+
+    // The rows the reader can see are still real, and the screen is told
+    // they stopped refreshing rather than being left to present them as
+    // current.
+    expect(result.current.nodes.nodes.map((n) => n.node.name)).toEqual(["a1"]);
+    expect(result.current.staleReasons.join(" ")).toContain("forbidden");
   });
 
   it("reloads every section at once", async () => {
@@ -508,7 +641,7 @@ describe("useOverview", () => {
 
     act(() => result.current.reload());
     await waitFor(() => expect(core.listNodes).toHaveBeenCalledTimes(2));
-    expect(core.listPods).toHaveBeenCalledTimes(2);
+    expect(core.podOverview).toHaveBeenCalledTimes(2);
     expect(core.listNamespaces).toHaveBeenCalledTimes(2);
     expect(core.listDeployments).toHaveBeenCalledTimes(2);
     expect(core.clusterFacts).toHaveBeenCalledTimes(2);

--- a/packages/ui-next/src/lib/overview.ts
+++ b/packages/ui-next/src/lib/overview.ts
@@ -3,18 +3,24 @@ import {
   K8S_KIND,
   clusterCapacity,
   clusterFacts,
+  listDaemonSets,
+  listDeployments,
   listNamespaces,
   listNodes,
   listPods,
   listResource,
+  listStatefulSets,
   nodeMetrics,
   nodeUsage,
   type ClusterCapacity,
   type ClusterFacts,
+  type DaemonSetSummary,
+  type DeploymentSummary,
   type NodeSummary,
   type NodeUsage,
   type PodSummary,
   type ResourceKind,
+  type StatefulSetSummary,
 } from "@srelens/core";
 import { useResource, type ResourceStatus } from "./useResource";
 
@@ -257,6 +263,67 @@ export function useObjectCounts(context: string): ObjectCounts {
   };
 }
 
+export interface OverviewWorkloads {
+  status: ResourceStatus;
+  /**
+   * The kind's rows, or `undefined` when it could not be listed. Deliberately
+   * not `[]`: an empty array is the answer "this cluster runs no Deployments",
+   * and the `Not ready` list would then read a refusal as a clean bill of
+   * health — the one thing that section must never do.
+   */
+  deployments?: DeploymentSummary[];
+  statefulSets?: StatefulSetSummary[];
+  daemonSets?: DaemonSetSummary[];
+  /** One reason per kind that was refused. The kinds that answered still render. */
+  errors: string[];
+  error?: string;
+  reload(): void;
+}
+
+/**
+ * The three scaling kinds the `Not ready` list draws its workload rows from.
+ *
+ * Deployments, StatefulSets and DaemonSets — the kinds core's `scaledStatus`
+ * gives a ready-out-of-desired verdict for. Jobs and CronJobs are deliberately
+ * not here: a CronJob has no unhealthy state of its own (the health lives in
+ * the Jobs it spawns), and a failed Job's pods are already in the pod list as
+ * Pods, with the phase that says what went wrong.
+ *
+ * One `useResource` over three calls that cannot reject — every `list*`
+ * wrapper returns its error rather than throwing — so the fan-out is safe in
+ * the way classic's `Promise.all` was not: no branch can cancel the others.
+ */
+export function useOverviewWorkloads(context: string): OverviewWorkloads {
+  const loaded = useResource(
+    () =>
+      Promise.all([
+        // The empty namespace is every namespace: the overview is a whole
+        // cluster's view, and so is the list beneath it.
+        listDeployments(context, ""),
+        listStatefulSets(context, ""),
+        listDaemonSets(context, ""),
+      ]).then(([deployments, statefulSets, daemonSets]) => ({
+        deployments: deployments.deployments,
+        statefulSets: statefulSets.statefulsets,
+        daemonSets: daemonSets.daemonsets,
+        errors: [deployments.error, statefulSets.error, daemonSets.error].filter(
+          (reason): reason is string => reason !== undefined,
+        ),
+      })),
+    [context],
+  );
+
+  return {
+    status: loaded.status,
+    deployments: loaded.data?.deployments,
+    statefulSets: loaded.data?.statefulSets,
+    daemonSets: loaded.data?.daemonSets,
+    errors: loaded.data?.errors ?? [],
+    error: loaded.error,
+    reload: loaded.reload,
+  };
+}
+
 export interface OverviewFacts {
   status: ResourceStatus;
   /**
@@ -291,6 +358,7 @@ export function useClusterFacts(context: string): OverviewFacts {
 export interface Overview {
   nodes: OverviewNodes;
   pods: OverviewPods;
+  workloads: OverviewWorkloads;
   namespaces: NamespaceCount;
   objects: ObjectCounts;
   facts: OverviewFacts;
@@ -309,22 +377,25 @@ export interface Overview {
 export function useOverview(context: string): Overview {
   const pods = useOverviewPods(context);
   const nodes = useOverviewNodes(context, pods.pods);
+  const workloads = useOverviewWorkloads(context);
   const namespaces = useNamespaceCount(context);
   const objects = useObjectCounts(context);
   const facts = useClusterFacts(context);
 
   const reloadNodes = nodes.reload;
   const reloadPods = pods.reload;
+  const reloadWorkloads = workloads.reload;
   const reloadNamespaces = namespaces.reload;
   const reloadObjects = objects.reload;
   const reloadFacts = facts.reload;
   const reload = useCallback(() => {
     reloadNodes();
     reloadPods();
+    reloadWorkloads();
     reloadNamespaces();
     reloadObjects();
     reloadFacts();
-  }, [reloadNodes, reloadPods, reloadNamespaces, reloadObjects, reloadFacts]);
+  }, [reloadNodes, reloadPods, reloadWorkloads, reloadNamespaces, reloadObjects, reloadFacts]);
 
-  return { nodes, pods, namespaces, objects, facts, reload };
+  return { nodes, pods, workloads, namespaces, objects, facts, reload };
 }

--- a/packages/ui-next/src/lib/overview.ts
+++ b/packages/ui-next/src/lib/overview.ts
@@ -220,6 +220,24 @@ export const OVERVIEW_KINDS: ResourceKind[] = [
   "jobs",
 ];
 
+/**
+ * The kinds this screen has to LIST to count — the two nothing else on it
+ * loads.
+ *
+ * The other four of `OVERVIEW_KINDS` are already on screen: Deployments,
+ * StatefulSets and DaemonSets are the rows the `Not ready` list reads, and
+ * Pods is the list the Pods tile, the per-node counts and that same list all
+ * share. Counting them through `listResource` as well would be four extra
+ * whole-cluster list calls to produce four numbers the screen has already
+ * fetched — and on a cluster with 1 284 pods, the pod one is not a small
+ * request. So the counts are taken off the loaders that own those kinds, and
+ * only CronJobs and Jobs are listed here.
+ *
+ * The rail's ORDER is still `OVERVIEW_KINDS`; this is only about where each
+ * number comes from.
+ */
+const COUNTED_BY_LISTING: ResourceKind[] = ["cronjobs", "jobs"];
+
 export interface KindCount {
   slug: ResourceKind;
   /** `null` when this kind could not be counted. Never `0` for a refusal. */
@@ -236,18 +254,28 @@ export interface ObjectCounts {
 }
 
 /**
- * One list call per kind, each carrying its own failure.
+ * One row per kind, each carrying its own count or its own failure.
  *
- * The `Promise.all` here is safe in the way classic's was not: `listResource`
- * returns its error rather than throwing, so no branch of this fan-out can
- * reject and cancel the others. A kind the user cannot list becomes one row
- * with `count: null` and a reason; the other five keep their numbers.
+ * Two sources, and the seam between them is invisible to the rail: the four
+ * kinds the screen already loaded are counted off those loaders (see
+ * {@link COUNTED_BY_LISTING}), and the two it does not are listed here. The
+ * `Promise.all` over the second group is safe in the way classic's was not:
+ * `listResource` returns its error rather than throwing, so no branch of the
+ * fan-out can reject and cancel the others.
+ *
+ * A kind that could not be counted becomes `count: null` WITH the reason,
+ * never `0` — a refused list and an empty cluster are the same picture and
+ * opposite facts, and zero is the one a reader believes.
  */
-export function useObjectCounts(context: string): ObjectCounts {
-  const counts = useResource(
+export function useObjectCounts(
+  context: string,
+  workloads: OverviewWorkloads,
+  pods: OverviewPods,
+): ObjectCounts {
+  const listed = useResource(
     () =>
       Promise.all(
-        OVERVIEW_KINDS.map((slug) =>
+        COUNTED_BY_LISTING.map((slug) =>
           listResource(context, K8S_KIND[slug], "").then<KindCount>((o) =>
             o.error ? { slug, count: null, error: o.error } : { slug, count: (o.items ?? []).length },
           ),
@@ -255,12 +283,41 @@ export function useObjectCounts(context: string): ObjectCounts {
       ),
     [context],
   );
-  return {
-    status: counts.status,
-    counts: counts.data ?? [],
-    error: counts.error,
-    reload: counts.reload,
-  };
+
+  const data = listed.data;
+  const listedError = listed.error;
+  const counts = useMemo<KindCount[]>(() => {
+    /** A count off a list the screen already has, or the reason it has none. */
+    const shared = (slug: ResourceKind, rows: unknown[] | undefined, error?: string): KindCount => ({
+      slug,
+      count: rows ? rows.length : null,
+      error: rows ? undefined : error,
+    });
+
+    const already = new Map<ResourceKind, KindCount>([
+      ["deployments", shared("deployments", workloads.deployments, workloads.refusals.deployments ?? workloads.error)],
+      ["statefulsets", shared("statefulsets", workloads.statefulSets, workloads.refusals.statefulsets ?? workloads.error)],
+      ["daemonsets", shared("daemonsets", workloads.daemonSets, workloads.refusals.daemonsets ?? workloads.error)],
+      ["pods", shared("pods", pods.pods, pods.error)],
+    ]);
+    const byList = new Map((data ?? []).map((c) => [c.slug, c]));
+
+    return OVERVIEW_KINDS.map(
+      (slug) => already.get(slug) ?? byList.get(slug) ?? { slug, count: null, error: listedError },
+    );
+  }, [
+    workloads.deployments,
+    workloads.statefulSets,
+    workloads.daemonSets,
+    workloads.refusals,
+    workloads.error,
+    pods.pods,
+    pods.error,
+    data,
+    listedError,
+  ]);
+
+  return { status: listed.status, counts, error: listedError, reload: listed.reload };
 }
 
 export interface OverviewWorkloads {
@@ -274,8 +331,17 @@ export interface OverviewWorkloads {
   deployments?: DeploymentSummary[];
   statefulSets?: StatefulSetSummary[];
   daemonSets?: DaemonSetSummary[];
-  /** One reason per kind that was refused. The kinds that answered still render. */
-  errors: string[];
+  /**
+   * Why a kind has no rows, keyed by the slug the rail counts it under. The
+   * kinds that answered still render.
+   *
+   * Keyed rather than a flat list of reasons because two readers want
+   * different things from it: the `Not ready` list wants all of them at once,
+   * to say why it may be short, and the rail's count row for one kind wants
+   * that kind's own reason and no other. A flat array can serve the first and
+   * not the second.
+   */
+  refusals: Partial<Record<ResourceKind, string>>;
   error?: string;
   reload(): void;
 }
@@ -302,14 +368,18 @@ export function useOverviewWorkloads(context: string): OverviewWorkloads {
         listDeployments(context, ""),
         listStatefulSets(context, ""),
         listDaemonSets(context, ""),
-      ]).then(([deployments, statefulSets, daemonSets]) => ({
-        deployments: deployments.deployments,
-        statefulSets: statefulSets.statefulsets,
-        daemonSets: daemonSets.daemonsets,
-        errors: [deployments.error, statefulSets.error, daemonSets.error].filter(
-          (reason): reason is string => reason !== undefined,
-        ),
-      })),
+      ]).then(([deployments, statefulSets, daemonSets]) => {
+        const refusals: Partial<Record<ResourceKind, string>> = {};
+        if (deployments.error) refusals.deployments = deployments.error;
+        if (statefulSets.error) refusals.statefulsets = statefulSets.error;
+        if (daemonSets.error) refusals.daemonsets = daemonSets.error;
+        return {
+          deployments: deployments.deployments,
+          statefulSets: statefulSets.statefulsets,
+          daemonSets: daemonSets.daemonsets,
+          refusals,
+        };
+      }),
     [context],
   );
 
@@ -318,11 +388,18 @@ export function useOverviewWorkloads(context: string): OverviewWorkloads {
     deployments: loaded.data?.deployments,
     statefulSets: loaded.data?.statefulSets,
     daemonSets: loaded.data?.daemonSets,
-    errors: loaded.data?.errors ?? [],
+    refusals: loaded.data?.refusals ?? EMPTY_REFUSALS,
     error: loaded.error,
     reload: loaded.reload,
   };
 }
+
+/**
+ * One shared empty object rather than a fresh `{}` per render: it is a
+ * `useMemo` dependency in {@link useObjectCounts}, and a new identity every
+ * render would rebuild those counts every render.
+ */
+const EMPTY_REFUSALS: Partial<Record<ResourceKind, string>> = {};
 
 export interface OverviewFacts {
   status: ResourceStatus;
@@ -379,7 +456,8 @@ export function useOverview(context: string): Overview {
   const nodes = useOverviewNodes(context, pods.pods);
   const workloads = useOverviewWorkloads(context);
   const namespaces = useNamespaceCount(context);
-  const objects = useObjectCounts(context);
+  // Fed the two loaders whose kinds it would otherwise list a second time.
+  const objects = useObjectCounts(context, workloads, pods);
   const facts = useClusterFacts(context);
 
   const reloadNodes = nodes.reload;

--- a/packages/ui-next/src/lib/overview.ts
+++ b/packages/ui-next/src/lib/overview.ts
@@ -7,11 +7,11 @@ import {
   listDeployments,
   listNamespaces,
   listNodes,
-  listPods,
   listResource,
   listStatefulSets,
   nodeMetrics,
   nodeUsage,
+  podOverview,
   type ClusterCapacity,
   type ClusterFacts,
   type DaemonSetSummary,
@@ -22,7 +22,8 @@ import {
   type ResourceKind,
   type StatefulSetSummary,
 } from "@srelens/core";
-import { useResource, type ResourceStatus } from "./useResource";
+import { useCachedResource } from "./cachedResource";
+import type { ResourceStatus } from "./useResource";
 
 /**
  * The cluster overview's data layer: one loader per independent fact.
@@ -36,8 +37,8 @@ import { useResource, type ResourceStatus } from "./useResource";
  * A screen made of independent facts fails in independent pieces: a refused
  * `listNodes` empties the nodes table and says so, while the namespace count,
  * the object counts, the control-plane facts and Fleet stay on screen. Every
- * hook below therefore owns its own `useResource`, and nothing here ever
- * awaits two capabilities in a way that lets one fail the other.
+ * hook below therefore owns its own loader, and nothing here ever awaits two
+ * capabilities in a way that lets one fail the other.
  *
  * The second rule, running through all of it: **`null` is not zero.** A
  * percentage of `null` means "no reading" — metrics-server absent, or a node
@@ -50,13 +51,32 @@ import { useResource, type ResourceStatus } from "./useResource";
  * uncapped. `Meter` clamps the bar it draws while keeping `aria-valuetext`
  * truthful; clamping in between would make a node at 140% indistinguishable
  * from one exactly at its limit, hiding the case a reader most needs to see.
+ *
+ * ## Every loader is cached
+ *
+ * `useCachedResource`, not `useResource`: coming back to this tab paints the
+ * last good answer immediately and refreshes behind it, instead of spending a
+ * whole cluster's round trips to arrive at the same numbers. The cache keys
+ * below all carry the CONTEXT, because that is the one thing a cached cluster
+ * answer must never be shown for the wrong one of.
+ *
+ * The rule the cache does not get to break is the module's first one: a
+ * refresh that fails over rows already on screen leaves those rows there and
+ * reports `stale`, and every loader carries that flag up to the screen, which
+ * says so. Quietly serving figures that stopped refreshing is the same lie as
+ * a `0` in place of "no reading".
  */
 
-/** An outcome-shaped core call, turned into the rejection `useResource` reads. */
+/** An outcome-shaped core call, turned into the rejection the loader reads. */
 function unwrap<T>(value: T | undefined, error: string | undefined, what: string): T {
   if (error) throw new Error(error);
   if (value === undefined) throw new Error(`${what} returned no data`);
   return value;
+}
+
+/** The cache identity of one loader's answer for one cluster. */
+function key(what: string, context: string): string {
+  return `overview:${what}|${context}`;
 }
 
 /** One node, paired with its usage against its own allocatable capacity. */
@@ -78,6 +98,8 @@ export interface OverviewNodes {
    * the rail states the absence once rather than every column announcing it.
    */
   metricsError?: string;
+  /** These rows are the last good ones and are no longer refreshing. */
+  stale: boolean;
   reload(): void;
 }
 
@@ -90,44 +112,38 @@ export interface OverviewNodes {
  * losing the node list to that would be the exact all-or-nothing failure this
  * module is written against.
  *
- * @param pods - Every pod in the cluster, or `undefined` while that list is
- *   unknown or was refused. Passed in rather than listed here so the screen
- *   makes one `listPods` call for the pod tile, the unhealthy list and these
+ * @param byNode - How many pods each node is running, or `undefined` while
+ *   that is unknown or was refused. Passed in rather than derived here so the
+ *   screen makes one pod call for the Pods tile, the unhealthy list and these
  *   per-node counts, instead of three.
  */
-export function useOverviewNodes(context: string, pods: PodSummary[] | undefined): OverviewNodes {
-  const nodes = useResource(
-    () => listNodes(context).then((o) => unwrap(o.nodes, o.error, "listNodes")),
-    [context],
+export function useOverviewNodes(
+  context: string,
+  byNode: Map<string, number> | undefined,
+): OverviewNodes {
+  const nodes = useCachedResource(key("nodes", context), () =>
+    listNodes(context).then((o) => unwrap(o.nodes, o.error, "listNodes")),
   );
-  const metrics = useResource(
-    () => nodeMetrics(context).then((o) => unwrap(o.metrics, o.error, "nodeMetrics")),
-    [context],
+  const metrics = useCachedResource(key("nodeMetrics", context), () =>
+    nodeMetrics(context).then((o) => unwrap(o.metrics, o.error, "nodeMetrics")),
   );
 
   const list = nodes.data;
   const readings = metrics.data;
-
-  const podsByNode = useMemo(() => {
-    if (!pods) return undefined;
-    const counts = new Map<string, number>();
-    for (const pod of pods) counts.set(pod.node, (counts.get(pod.node) ?? 0) + 1);
-    return counts;
-  }, [pods]);
 
   const rows = useMemo<OverviewNode[]>(() => {
     if (!list) return [];
     const byName = new Map((readings ?? []).map((m) => [m.name, m]));
     return list.map((node) => ({
       node,
-      // The one place a `0` is legitimate: when `podsByNode` exists the pod
-      // list is KNOWN, and a node missing from it genuinely has no pods on it.
-      // When the map is `undefined` the count is unknown, and `undefined` is
-      // what `nodeUsage` turns into a `pods` of `null` — never `{ used: 0 }`,
-      // which would claim an empty node nobody counted.
-      usage: nodeUsage(node, byName.get(node.name), podsByNode ? (podsByNode.get(node.name) ?? 0) : undefined),
+      // The one place a `0` is legitimate: when `byNode` exists the grouping
+      // is KNOWN and complete, so a node missing from it genuinely has no pods
+      // on it. When the map is `undefined` the count is unknown, and
+      // `undefined` is what `nodeUsage` turns into a `pods` of `null` — never
+      // `{ used: 0 }`, which would claim an empty node nobody counted.
+      usage: nodeUsage(node, byName.get(node.name), byNode ? (byNode.get(node.name) ?? 0) : undefined),
     }));
-  }, [list, readings, podsByNode]);
+  }, [list, readings, byNode]);
 
   // Sums only over nodes that reported; `clusterCapacity` carries
   // `nodesReporting`/`nodesTotal` so the screen cannot show a partial total as
@@ -147,6 +163,7 @@ export function useOverviewNodes(context: string, pods: PodSummary[] | undefined
     capacity,
     error: nodes.error,
     metricsError: metrics.error,
+    stale: nodes.stale || metrics.stale,
     reload,
   };
 }
@@ -154,34 +171,71 @@ export function useOverviewNodes(context: string, pods: PodSummary[] | undefined
 export interface OverviewPods {
   status: ResourceStatus;
   /**
-   * Every pod in the cluster, or `undefined` when that is not known — loading,
-   * or refused. Deliberately not defaulted to `[]`: an empty array is the
-   * answer "this cluster has no pods", which would zero the pod tile and every
-   * node's pod column on a cluster that simply has not answered yet.
+   * Every pod in the cluster, or `null` when that is not known — loading, or
+   * refused. Deliberately not defaulted to `0`: a zero is the answer "this
+   * cluster has no pods", which is what a 113-node cluster's Pods tile used to
+   * be one coalesce away from claiming.
    */
-  pods?: PodSummary[];
+  total: number | null;
+  /**
+   * How many pods each node is running, or `undefined` when unknown.
+   *
+   * When it is present it is COMPLETE: a node absent from the map runs no
+   * pods, and that is a reading rather than a gap. That completeness is what
+   * lets a node's Pods column show a truthful `0`.
+   */
+  byNode?: Map<string, number>;
+  /**
+   * Every pod that is not simply running — a superset of the unhealthy ones,
+   * for core to judge. `undefined` when the cluster has not answered.
+   */
+  unsettled?: PodSummary[];
+  /** Whether {@link unsettled} is shorter than the truth — see `podOverview`. */
+  truncated: boolean;
   error?: string;
+  stale: boolean;
   reload(): void;
 }
 
 /**
- * The cluster's pods, listed once and shared.
+ * The cluster's pod facts, from one call that never lists its pods.
  *
  * Three sections need them — the Pods tile, the per-node `31/50` column and
- * the `NOT READY` list — and this is the call that serves all three. Counting
- * a pod list by `spec.nodeName` (`PodSummary.node`) is how pods-per-node is
- * derived; there is no cheaper source for it, and the list is being fetched
- * for the unhealthy section regardless, so it costs nothing extra here.
+ * the `NOT READY` list — and `k8s.podOverview` is the one call that serves all
+ * three: a server-printed table for the counts and the per-node grouping, and
+ * pod bodies only for the handful that are not simply running. `listPods` with
+ * an empty namespace used to serve them, and on a 113-node cluster that is
+ * 5 416 pods and 114 MB, which does not come back inside the request budget —
+ * so all three read "No reading" on the one cluster where they matter most.
+ * See `crates/kube/src/pod_overview.rs` for what replaced it and why.
  *
- * Fleet is the case that cannot afford this, which is why it counts through
- * the `podCount` capability per cluster instead of listing ten pod lists.
+ * Fleet counts through `podCount` per cluster for the same reason: neither
+ * screen can afford a pod list, and neither takes one.
  */
 export function useOverviewPods(context: string): OverviewPods {
-  const pods = useResource(
-    () => listPods(context, "").then((o) => unwrap(o.pods, o.error, "listPods")),
-    [context],
+  const pods = useCachedResource(
+    key("pods", context),
+    () => podOverview(context).then((o) => unwrap(o.pods, o.error, "podOverview")),
+    // A cluster with no pods at all has answered; it is not an empty section.
+    () => false,
   );
-  return { status: pods.status, pods: pods.data, error: pods.error, reload: pods.reload };
+
+  const data = pods.data;
+  const byNode = useMemo(() => {
+    if (!data) return undefined;
+    return new Map(data.byNode.map((n) => [n.node, n.pods]));
+  }, [data]);
+
+  return {
+    status: pods.status,
+    total: data ? data.total : null,
+    byNode,
+    unsettled: data?.unsettled,
+    truncated: data?.truncated ?? false,
+    error: pods.error,
+    stale: pods.stale,
+    reload: pods.reload,
+  };
 }
 
 export interface NamespaceCount {
@@ -189,19 +243,20 @@ export interface NamespaceCount {
   /** `null` when unknown — loading, or refused. Never `0` for either. */
   count: number | null;
   error?: string;
+  stale: boolean;
   reload(): void;
 }
 
 /** The Namespaces tile's number, and nothing else — the tile has no caption. */
 export function useNamespaceCount(context: string): NamespaceCount {
-  const namespaces = useResource(
-    () => listNamespaces(context).then((o) => unwrap(o.namespaces, o.error, "listNamespaces")),
-    [context],
+  const namespaces = useCachedResource(key("namespaces", context), () =>
+    listNamespaces(context).then((o) => unwrap(o.namespaces, o.error, "listNamespaces")),
   );
   return {
     status: namespaces.status,
     count: namespaces.data === undefined ? null : namespaces.data.length,
     error: namespaces.error,
+    stale: namespaces.stale,
     reload: namespaces.reload,
   };
 }
@@ -226,12 +281,12 @@ export const OVERVIEW_KINDS: ResourceKind[] = [
  *
  * The other four of `OVERVIEW_KINDS` are already on screen: Deployments,
  * StatefulSets and DaemonSets are the rows the `Not ready` list reads, and
- * Pods is the list the Pods tile, the per-node counts and that same list all
- * share. Counting them through `listResource` as well would be four extra
- * whole-cluster list calls to produce four numbers the screen has already
- * fetched — and on a cluster with 1 284 pods, the pod one is not a small
- * request. So the counts are taken off the loaders that own those kinds, and
- * only CronJobs and Jobs are listed here.
+ * Pods is the count `podOverview` already made. Counting them through
+ * `listResource` as well would be four extra whole-cluster list calls to
+ * produce four numbers the screen has already fetched — and on a cluster with
+ * 5 416 pods, the pod one is not a small request at all. So the counts are
+ * taken off the loaders that own those kinds, and only CronJobs and Jobs are
+ * listed here.
  *
  * The rail's ORDER is still `OVERVIEW_KINDS`; this is only about where each
  * number comes from.
@@ -250,6 +305,7 @@ export interface ObjectCounts {
   status: ResourceStatus;
   counts: KindCount[];
   error?: string;
+  stale: boolean;
   reload(): void;
 }
 
@@ -272,20 +328,20 @@ export function useObjectCounts(
   workloads: OverviewWorkloads,
   pods: OverviewPods,
 ): ObjectCounts {
-  const listed = useResource(
-    () =>
-      Promise.all(
-        COUNTED_BY_LISTING.map((slug) =>
-          listResource(context, K8S_KIND[slug], "").then<KindCount>((o) =>
-            o.error ? { slug, count: null, error: o.error } : { slug, count: (o.items ?? []).length },
-          ),
+  const listed = useCachedResource(key("objectCounts", context), () =>
+    Promise.all(
+      COUNTED_BY_LISTING.map((slug) =>
+        listResource(context, K8S_KIND[slug], "").then<KindCount>((o) =>
+          o.error ? { slug, count: null, error: o.error } : { slug, count: (o.items ?? []).length },
         ),
       ),
-    [context],
+    ),
   );
 
   const data = listed.data;
   const listedError = listed.error;
+  const podTotal = pods.total;
+  const podError = pods.error;
   const counts = useMemo<KindCount[]>(() => {
     /** A count off a list the screen already has, or the reason it has none. */
     const shared = (slug: ResourceKind, rows: unknown[] | undefined, error?: string): KindCount => ({
@@ -298,7 +354,9 @@ export function useObjectCounts(
       ["deployments", shared("deployments", workloads.deployments, workloads.refusals.deployments ?? workloads.error)],
       ["statefulsets", shared("statefulsets", workloads.statefulSets, workloads.refusals.statefulsets ?? workloads.error)],
       ["daemonsets", shared("daemonsets", workloads.daemonSets, workloads.refusals.daemonsets ?? workloads.error)],
-      ["pods", shared("pods", pods.pods, pods.error)],
+      // Counted, never listed — the whole point of `podOverview`. `null` is
+      // the refusal; `0` would be the claim that the cluster runs no pods.
+      ["pods", { slug: "pods", count: podTotal, error: podTotal === null ? podError : undefined }],
     ]);
     const byList = new Map((data ?? []).map((c) => [c.slug, c]));
 
@@ -311,13 +369,19 @@ export function useObjectCounts(
     workloads.daemonSets,
     workloads.refusals,
     workloads.error,
-    pods.pods,
-    pods.error,
+    podTotal,
+    podError,
     data,
     listedError,
   ]);
 
-  return { status: listed.status, counts, error: listedError, reload: listed.reload };
+  return {
+    status: listed.status,
+    counts,
+    error: listedError,
+    stale: listed.stale,
+    reload: listed.reload,
+  };
 }
 
 export interface OverviewWorkloads {
@@ -343,6 +407,7 @@ export interface OverviewWorkloads {
    */
   refusals: Partial<Record<ResourceKind, string>>;
   error?: string;
+  stale: boolean;
   reload(): void;
 }
 
@@ -355,32 +420,30 @@ export interface OverviewWorkloads {
  * the Jobs it spawns), and a failed Job's pods are already in the pod list as
  * Pods, with the phase that says what went wrong.
  *
- * One `useResource` over three calls that cannot reject — every `list*`
- * wrapper returns its error rather than throwing — so the fan-out is safe in
- * the way classic's `Promise.all` was not: no branch can cancel the others.
+ * One loader over three calls that cannot reject — every `list*` wrapper
+ * returns its error rather than throwing — so the fan-out is safe in the way
+ * classic's `Promise.all` was not: no branch can cancel the others.
  */
 export function useOverviewWorkloads(context: string): OverviewWorkloads {
-  const loaded = useResource(
-    () =>
-      Promise.all([
-        // The empty namespace is every namespace: the overview is a whole
-        // cluster's view, and so is the list beneath it.
-        listDeployments(context, ""),
-        listStatefulSets(context, ""),
-        listDaemonSets(context, ""),
-      ]).then(([deployments, statefulSets, daemonSets]) => {
-        const refusals: Partial<Record<ResourceKind, string>> = {};
-        if (deployments.error) refusals.deployments = deployments.error;
-        if (statefulSets.error) refusals.statefulsets = statefulSets.error;
-        if (daemonSets.error) refusals.daemonsets = daemonSets.error;
-        return {
-          deployments: deployments.deployments,
-          statefulSets: statefulSets.statefulsets,
-          daemonSets: daemonSets.daemonsets,
-          refusals,
-        };
-      }),
-    [context],
+  const loaded = useCachedResource(key("workloads", context), () =>
+    Promise.all([
+      // The empty namespace is every namespace: the overview is a whole
+      // cluster's view, and so is the list beneath it.
+      listDeployments(context, ""),
+      listStatefulSets(context, ""),
+      listDaemonSets(context, ""),
+    ]).then(([deployments, statefulSets, daemonSets]) => {
+      const refusals: Partial<Record<ResourceKind, string>> = {};
+      if (deployments.error) refusals.deployments = deployments.error;
+      if (statefulSets.error) refusals.statefulsets = statefulSets.error;
+      if (daemonSets.error) refusals.daemonsets = daemonSets.error;
+      return {
+        deployments: deployments.deployments,
+        statefulSets: statefulSets.statefulsets,
+        daemonSets: daemonSets.daemonsets,
+        refusals,
+      };
+    }),
   );
 
   return {
@@ -390,6 +453,7 @@ export function useOverviewWorkloads(context: string): OverviewWorkloads {
     daemonSets: loaded.data?.daemonSets,
     refusals: loaded.data?.refusals ?? EMPTY_REFUSALS,
     error: loaded.error,
+    stale: loaded.stale,
     reload: loaded.reload,
   };
 }
@@ -410,6 +474,7 @@ export interface OverviewFacts {
    */
   facts?: ClusterFacts;
   error?: string;
+  stale: boolean;
   reload(): void;
 }
 
@@ -422,12 +487,13 @@ export interface OverviewFacts {
  * being handed to the rail as six silently omitted rows.
  */
 export function useClusterFacts(context: string): OverviewFacts {
-  const facts = useResource(() => clusterFacts(context), [context]);
+  const facts = useCachedResource(key("facts", context), () => clusterFacts(context));
   const carried = facts.data?.error;
   return {
     status: carried ? "error" : facts.status,
     facts: facts.data,
     error: carried ?? facts.error,
+    stale: facts.stale,
     reload: facts.reload,
   };
 }
@@ -439,6 +505,16 @@ export interface Overview {
   namespaces: NamespaceCount;
   objects: ObjectCounts;
   facts: OverviewFacts;
+  /**
+   * Why some of the figures on screen are the last good ones rather than
+   * current ones — empty when everything on screen refreshed.
+   *
+   * The screen states this ONCE, at the top, rather than every band that could
+   * not refresh saying it: five tiles and two columns each announcing the same
+   * outage has said it seven times and explained it nowhere. That is the same
+   * rule the metrics-server absence follows.
+   */
+  staleReasons: string[];
   /** Retry every section. Each still succeeds or fails on its own. */
   reload(): void;
 }
@@ -453,12 +529,40 @@ export interface Overview {
  */
 export function useOverview(context: string): Overview {
   const pods = useOverviewPods(context);
-  const nodes = useOverviewNodes(context, pods.pods);
+  const nodes = useOverviewNodes(context, pods.byNode);
   const workloads = useOverviewWorkloads(context);
   const namespaces = useNamespaceCount(context);
   // Fed the two loaders whose kinds it would otherwise list a second time.
   const objects = useObjectCounts(context, workloads, pods);
   const facts = useClusterFacts(context);
+
+  const staleReasons = useMemo(
+    () =>
+      [
+        nodes.stale ? nodes.error : undefined,
+        nodes.stale ? nodes.metricsError : undefined,
+        pods.stale ? pods.error : undefined,
+        workloads.stale ? workloads.error : undefined,
+        namespaces.stale ? namespaces.error : undefined,
+        objects.stale ? objects.error : undefined,
+        facts.stale ? facts.error : undefined,
+      ].filter((reason): reason is string => reason !== undefined && reason !== ""),
+    [
+      nodes.stale,
+      nodes.error,
+      nodes.metricsError,
+      pods.stale,
+      pods.error,
+      workloads.stale,
+      workloads.error,
+      namespaces.stale,
+      namespaces.error,
+      objects.stale,
+      objects.error,
+      facts.stale,
+      facts.error,
+    ],
+  );
 
   const reloadNodes = nodes.reload;
   const reloadPods = pods.reload;
@@ -475,5 +579,5 @@ export function useOverview(context: string): Overview {
     reloadFacts();
   }, [reloadNodes, reloadPods, reloadWorkloads, reloadNamespaces, reloadObjects, reloadFacts]);
 
-  return { nodes, pods, workloads, namespaces, objects, facts, reload };
+  return { nodes, pods, workloads, namespaces, objects, facts, staleReasons, reload };
 }

--- a/packages/ui-next/src/lib/overview.ts
+++ b/packages/ui-next/src/lib/overview.ts
@@ -1,0 +1,330 @@
+import { useCallback, useMemo } from "react";
+import {
+  K8S_KIND,
+  clusterCapacity,
+  clusterFacts,
+  listNamespaces,
+  listNodes,
+  listPods,
+  listResource,
+  nodeMetrics,
+  nodeUsage,
+  type ClusterCapacity,
+  type ClusterFacts,
+  type NodeSummary,
+  type NodeUsage,
+  type PodSummary,
+  type ResourceKind,
+} from "@srelens/core";
+import { useResource, type ResourceStatus } from "./useResource";
+
+/**
+ * The cluster overview's data layer: one loader per independent fact.
+ *
+ * Classic's `ClusterOverview` fires six list calls through a single
+ * `Promise.all` and rethrows the first error it finds, so one refused list —
+ * `nodes` on a namespaced service account, say — blanks the whole dashboard,
+ * including the five answers that came back fine. That is the property this
+ * module exists not to have.
+ *
+ * A screen made of independent facts fails in independent pieces: a refused
+ * `listNodes` empties the nodes table and says so, while the namespace count,
+ * the object counts, the control-plane facts and Fleet stay on screen. Every
+ * hook below therefore owns its own `useResource`, and nothing here ever
+ * awaits two capabilities in a way that lets one fail the other.
+ *
+ * The second rule, running through all of it: **`null` is not zero.** A
+ * percentage of `null` means "no reading" — metrics-server absent, or a node
+ * that has not been scraped yet — and `0%` is a measurement that reads as an
+ * idle cluster. The same holds one level up: a namespace count of `null` is a
+ * refusal, not an empty cluster. Nothing between core's arithmetic and the
+ * screen may coalesce one into the other.
+ *
+ * Percentages leave here exactly as `nodeUsage` computed them: unrounded and
+ * uncapped. `Meter` clamps the bar it draws while keeping `aria-valuetext`
+ * truthful; clamping in between would make a node at 140% indistinguishable
+ * from one exactly at its limit, hiding the case a reader most needs to see.
+ */
+
+/** An outcome-shaped core call, turned into the rejection `useResource` reads. */
+function unwrap<T>(value: T | undefined, error: string | undefined, what: string): T {
+  if (error) throw new Error(error);
+  if (value === undefined) throw new Error(`${what} returned no data`);
+  return value;
+}
+
+/** One node, paired with its usage against its own allocatable capacity. */
+export interface OverviewNode {
+  node: NodeSummary;
+  usage: NodeUsage;
+}
+
+export interface OverviewNodes {
+  status: ResourceStatus;
+  nodes: OverviewNode[];
+  /** The cluster-wide sums for the capacity strip; carries its own `null`s. */
+  capacity: ClusterCapacity;
+  /** Why the node list is unavailable. The table is empty and says this. */
+  error?: string;
+  /**
+   * Why there are no readings — held apart from `error` on purpose. A cluster
+   * with no metrics-server still has a nodes table; it just has no meters, and
+   * the rail states the absence once rather than every column announcing it.
+   */
+  metricsError?: string;
+  reload(): void;
+}
+
+/**
+ * The nodes table's rows and the capacity strip's totals.
+ *
+ * Two capabilities, two loaders: `listNodes` and `nodeMetrics` fail
+ * independently, and neither empties the other. Metrics are the ones that go
+ * missing in practice (metrics-server is not installed on every cluster), and
+ * losing the node list to that would be the exact all-or-nothing failure this
+ * module is written against.
+ *
+ * @param pods - Every pod in the cluster, or `undefined` while that list is
+ *   unknown or was refused. Passed in rather than listed here so the screen
+ *   makes one `listPods` call for the pod tile, the unhealthy list and these
+ *   per-node counts, instead of three.
+ */
+export function useOverviewNodes(context: string, pods: PodSummary[] | undefined): OverviewNodes {
+  const nodes = useResource(
+    () => listNodes(context).then((o) => unwrap(o.nodes, o.error, "listNodes")),
+    [context],
+  );
+  const metrics = useResource(
+    () => nodeMetrics(context).then((o) => unwrap(o.metrics, o.error, "nodeMetrics")),
+    [context],
+  );
+
+  const list = nodes.data;
+  const readings = metrics.data;
+
+  const podsByNode = useMemo(() => {
+    if (!pods) return undefined;
+    const counts = new Map<string, number>();
+    for (const pod of pods) counts.set(pod.node, (counts.get(pod.node) ?? 0) + 1);
+    return counts;
+  }, [pods]);
+
+  const rows = useMemo<OverviewNode[]>(() => {
+    if (!list) return [];
+    const byName = new Map((readings ?? []).map((m) => [m.name, m]));
+    return list.map((node) => ({
+      node,
+      // The one place a `0` is legitimate: when `podsByNode` exists the pod
+      // list is KNOWN, and a node missing from it genuinely has no pods on it.
+      // When the map is `undefined` the count is unknown, and `undefined` is
+      // what `nodeUsage` turns into a `pods` of `null` — never `{ used: 0 }`,
+      // which would claim an empty node nobody counted.
+      usage: nodeUsage(node, byName.get(node.name), podsByNode ? (podsByNode.get(node.name) ?? 0) : undefined),
+    }));
+  }, [list, readings, podsByNode]);
+
+  // Sums only over nodes that reported; `clusterCapacity` carries
+  // `nodesReporting`/`nodesTotal` so the screen cannot show a partial total as
+  // if it were a whole one.
+  const capacity = useMemo(() => clusterCapacity(list ?? [], readings ?? []), [list, readings]);
+
+  const reloadNodes = nodes.reload;
+  const reloadMetrics = metrics.reload;
+  const reload = useCallback(() => {
+    reloadNodes();
+    reloadMetrics();
+  }, [reloadNodes, reloadMetrics]);
+
+  return {
+    status: nodes.status,
+    nodes: rows,
+    capacity,
+    error: nodes.error,
+    metricsError: metrics.error,
+    reload,
+  };
+}
+
+export interface OverviewPods {
+  status: ResourceStatus;
+  /**
+   * Every pod in the cluster, or `undefined` when that is not known — loading,
+   * or refused. Deliberately not defaulted to `[]`: an empty array is the
+   * answer "this cluster has no pods", which would zero the pod tile and every
+   * node's pod column on a cluster that simply has not answered yet.
+   */
+  pods?: PodSummary[];
+  error?: string;
+  reload(): void;
+}
+
+/**
+ * The cluster's pods, listed once and shared.
+ *
+ * Three sections need them — the Pods tile, the per-node `31/50` column and
+ * the `NOT READY` list — and this is the call that serves all three. Counting
+ * a pod list by `spec.nodeName` (`PodSummary.node`) is how pods-per-node is
+ * derived; there is no cheaper source for it, and the list is being fetched
+ * for the unhealthy section regardless, so it costs nothing extra here.
+ *
+ * Fleet is the case that cannot afford this, which is why it counts through
+ * the `podCount` capability per cluster instead of listing ten pod lists.
+ */
+export function useOverviewPods(context: string): OverviewPods {
+  const pods = useResource(
+    () => listPods(context, "").then((o) => unwrap(o.pods, o.error, "listPods")),
+    [context],
+  );
+  return { status: pods.status, pods: pods.data, error: pods.error, reload: pods.reload };
+}
+
+export interface NamespaceCount {
+  status: ResourceStatus;
+  /** `null` when unknown — loading, or refused. Never `0` for either. */
+  count: number | null;
+  error?: string;
+  reload(): void;
+}
+
+/** The Namespaces tile's number, and nothing else — the tile has no caption. */
+export function useNamespaceCount(context: string): NamespaceCount {
+  const namespaces = useResource(
+    () => listNamespaces(context).then((o) => unwrap(o.namespaces, o.error, "listNamespaces")),
+    [context],
+  );
+  return {
+    status: namespaces.status,
+    count: namespaces.data === undefined ? null : namespaces.data.length,
+    error: namespaces.error,
+    reload: namespaces.reload,
+  };
+}
+
+/**
+ * The kinds the rail's `OBJECTS BY KIND` section counts, in the design's
+ * order. Slugs, not Kubernetes kinds, so each row can open `/k/<slug>` and
+ * take its label from `RESOURCE_LABELS` without a second table.
+ */
+export const OVERVIEW_KINDS: ResourceKind[] = [
+  "deployments",
+  "pods",
+  "statefulsets",
+  "daemonsets",
+  "cronjobs",
+  "jobs",
+];
+
+export interface KindCount {
+  slug: ResourceKind;
+  /** `null` when this kind could not be counted. Never `0` for a refusal. */
+  count: number | null;
+  /** Why this one kind has no count. The other rows are unaffected. */
+  error?: string;
+}
+
+export interface ObjectCounts {
+  status: ResourceStatus;
+  counts: KindCount[];
+  error?: string;
+  reload(): void;
+}
+
+/**
+ * One list call per kind, each carrying its own failure.
+ *
+ * The `Promise.all` here is safe in the way classic's was not: `listResource`
+ * returns its error rather than throwing, so no branch of this fan-out can
+ * reject and cancel the others. A kind the user cannot list becomes one row
+ * with `count: null` and a reason; the other five keep their numbers.
+ */
+export function useObjectCounts(context: string): ObjectCounts {
+  const counts = useResource(
+    () =>
+      Promise.all(
+        OVERVIEW_KINDS.map((slug) =>
+          listResource(context, K8S_KIND[slug], "").then<KindCount>((o) =>
+            o.error ? { slug, count: null, error: o.error } : { slug, count: (o.items ?? []).length },
+          ),
+        ),
+      ),
+    [context],
+  );
+  return {
+    status: counts.status,
+    counts: counts.data ?? [],
+    error: counts.error,
+    reload: counts.reload,
+  };
+}
+
+export interface OverviewFacts {
+  status: ResourceStatus;
+  /**
+   * The control-plane facts. `provider` and `region` are empty when the
+   * cluster named none, and the rail omits those rows — "unknown" as a value
+   * would look like an answer.
+   */
+  facts?: ClusterFacts;
+  error?: string;
+  reload(): void;
+}
+
+/**
+ * The rail's Provider, Region and Metrics server rows.
+ *
+ * `clusterFacts` never rejects: it normalises a failure into empty facts plus
+ * a reason. Empty facts are indistinguishable from a cluster that named none,
+ * so a carried `error` is mapped back to an error status here rather than
+ * being handed to the rail as six silently omitted rows.
+ */
+export function useClusterFacts(context: string): OverviewFacts {
+  const facts = useResource(() => clusterFacts(context), [context]);
+  const carried = facts.data?.error;
+  return {
+    status: carried ? "error" : facts.status,
+    facts: facts.data,
+    error: carried ?? facts.error,
+    reload: facts.reload,
+  };
+}
+
+export interface Overview {
+  nodes: OverviewNodes;
+  pods: OverviewPods;
+  namespaces: NamespaceCount;
+  objects: ObjectCounts;
+  facts: OverviewFacts;
+  /** Retry every section. Each still succeeds or fails on its own. */
+  reload(): void;
+}
+
+/**
+ * Every loader the screen composes, in one call.
+ *
+ * A single entry point so the sections cannot be wired up inconsistently, but
+ * emphatically not a single request: each field below settles on its own
+ * schedule and carries its own error, and there is no combined status because
+ * there is no moment when "the overview" is loaded or failed as a whole.
+ */
+export function useOverview(context: string): Overview {
+  const pods = useOverviewPods(context);
+  const nodes = useOverviewNodes(context, pods.pods);
+  const namespaces = useNamespaceCount(context);
+  const objects = useObjectCounts(context);
+  const facts = useClusterFacts(context);
+
+  const reloadNodes = nodes.reload;
+  const reloadPods = pods.reload;
+  const reloadNamespaces = namespaces.reload;
+  const reloadObjects = objects.reload;
+  const reloadFacts = facts.reload;
+  const reload = useCallback(() => {
+    reloadNodes();
+    reloadPods();
+    reloadNamespaces();
+    reloadObjects();
+    reloadFacts();
+  }, [reloadNodes, reloadPods, reloadNamespaces, reloadObjects, reloadFacts]);
+
+  return { nodes, pods, namespaces, objects, facts, reload };
+}

--- a/packages/ui-next/src/lib/routes.test.ts
+++ b/packages/ui-next/src/lib/routes.test.ts
@@ -4,6 +4,7 @@ import { describe, isBuiltInKind, screenFor } from "./routes";
 import { AppLog } from "../screens/AppLog";
 import { Events } from "../screens/Events";
 import { ReleaseNotes } from "../screens/ReleaseNotes";
+import { Overview } from "../screens/Overview";
 import { ResourceDetailScreen, Resources } from "../screens/Resources";
 import { Workloads } from "../screens/Workloads";
 
@@ -121,6 +122,14 @@ suite("screenFor", () => {
 
   it("resolves /events to the Events screen", () => {
     expect(screenFor("/events")).toBe(Events);
+  });
+
+  it("resolves /overview to the cluster overview the sidebar already points at", () => {
+    // `lib/tree.ts`'s CLUSTER_ROUTES has mapped `overview` to `/overview`
+    // since the sidebar was built, so without an entry here the first node in
+    // the tree — the one a reader clicks before anything else — lands on the
+    // Placeholder while the screen sits there finished.
+    expect(screenFor("/overview")).toBe(Overview);
   });
 
   it("resolves /k/events to the Events screen rather than the generic resource list", () => {

--- a/packages/ui-next/src/lib/routes.ts
+++ b/packages/ui-next/src/lib/routes.ts
@@ -3,6 +3,7 @@ import { K8S_KIND, RESOURCE_LABELS, type ResourceKind } from "@srelens/core";
 import { parseDetailRoute } from "./detailRoute";
 import { AppLog } from "../screens/AppLog";
 import { Events } from "../screens/Events";
+import { Overview } from "../screens/Overview";
 import { ReleaseNotes } from "../screens/ReleaseNotes";
 import { ResourceDetailScreen, Resources } from "../screens/Resources";
 import { Workloads } from "../screens/Workloads";
@@ -121,6 +122,7 @@ const SCREENS: Record<string, ScreenComponent> = Object.assign(Object.create(nul
   "/notes": ReleaseNotes,
   "/resources": Workloads,
   "/events": Events,
+  "/overview": Overview,
 });
 
 /**

--- a/packages/ui-next/src/lib/workspace.ts
+++ b/packages/ui-next/src/lib/workspace.ts
@@ -1,8 +1,39 @@
 import { useSyncExternalStore } from "react";
 import { settingsStorage } from "@srelens/core";
+import type { Tone } from "@srelens/ui-kit";
 import type { Storage } from "./tabsPersist";
 
 export type LinkState = "connected" | "connecting" | "disconnected" | "error";
+
+/**
+ * What the link says, in words. The mock said it in colour alone — a green dot
+ * for connected, a red one for unreachable — which is no readout at all for
+ * anyone who cannot separate the two, so the words are the readout and the
+ * tone is the second channel. "Unreachable" rather than "Error" for `error`:
+ * the failure being reported is the cluster's, not the app's, and the person
+ * reading it wants to know which. (#320)
+ *
+ * It lives beside {@link LinkState} rather than in the status bar that first
+ * drew it, because there is now more than one readout of the same fact — the
+ * strip along the bottom and the overview rail's `Connection` row — and a
+ * second copy of this table is how the two start disagreeing about the same
+ * cluster. A link state is not a Kubernetes status, so core has no vocabulary
+ * for it; this is the one place that does, and the word and its tone are
+ * decided together here so no caller can pair them itself.
+ */
+export const LINK_WORD: Record<LinkState, string> = {
+  connected: "Connected",
+  connecting: "Connecting",
+  disconnected: "Disconnected",
+  error: "Unreachable",
+};
+
+export const LINK_TONE: Record<LinkState, Tone> = {
+  connected: "ok",
+  connecting: "info",
+  disconnected: "muted",
+  error: "sev",
+};
 
 export interface WorkspaceView {
   /** Per cluster. Derived from `ClusterInfo.reachable` and in-flight connects; never persisted. */

--- a/packages/ui-next/src/screens/Overview.test.tsx
+++ b/packages/ui-next/src/screens/Overview.test.tsx
@@ -9,7 +9,7 @@ import userEvent from "@testing-library/user-event";
 const core = vi.hoisted(() => ({
   listNodes: vi.fn(),
   nodeMetrics: vi.fn(),
-  listPods: vi.fn(),
+  podOverview: vi.fn(),
   listNamespaces: vi.fn(),
   listResource: vi.fn(),
   listDeployments: vi.fn(),
@@ -50,11 +50,13 @@ import {
   type DeploymentSummary,
   type K8sObject,
   type NodeSummary,
+  type PodOverview,
   type PodSummary,
   type ResourceKind,
   type StatefulSetSummary,
 } from "@srelens/core";
 import { Overview } from "./Overview";
+import { CACHE_TTL_MS, clearResourceCache } from "../lib/cachedResource";
 import { ConsoleProvider } from "../console";
 import { defaultState } from "../lib/tabs";
 import * as store from "../lib/tabsStore";
@@ -103,6 +105,27 @@ function aPod(name: string, node: string, over: Partial<PodSummary> = {}): PodSu
   };
 }
 
+/**
+ * A `podOverview` answer built from a list of pods.
+ *
+ * The screen never sees a pod list any more — the backend counts the cluster's
+ * pods and groups them by node server-side, and sends bodies only for the ones
+ * that are not simply running. A fixture that starts from pods and derives all
+ * three keeps the numbers in a test consistent with each other the way the
+ * backend keeps them consistent on a real cluster.
+ */
+function anOverview(pods: PodSummary[], over: Partial<PodOverview> = {}): PodOverview {
+  const byNode = new Map<string, number>();
+  for (const pod of pods) if (pod.node) byNode.set(pod.node, (byNode.get(pod.node) ?? 0) + 1);
+  return {
+    total: pods.length,
+    byNode: [...byNode].map(([node, count]) => ({ node, pods: count })),
+    unsettled: pods.filter((p) => p.phase !== "Running" || p.waitingReason),
+    truncated: false,
+    ...over,
+  };
+}
+
 /** The three-node cluster every test starts from: all Ready, all reporting. */
 const NODES = [aNode("n1"), aNode("n2"), aNode("n3")];
 const METRICS = NODES.map((n) => ({ name: n.name, cpuMillicores: 2800, memoryMiB: 12000 }));
@@ -146,7 +169,7 @@ const NO_FACTS: ClusterFacts = {
 function quiet() {
   core.listNodes.mockResolvedValue({ nodes: NODES });
   core.nodeMetrics.mockResolvedValue({ metrics: METRICS });
-  core.listPods.mockResolvedValue({ pods: PODS });
+  core.podOverview.mockResolvedValue({ pods: anOverview(PODS) });
   core.listNamespaces.mockResolvedValue({ namespaces: ["default", "kube-system", "prod", "obs"] });
   core.listResource.mockResolvedValue({ items: [] });
   core.listDeployments.mockResolvedValue({ deployments: [] });
@@ -160,6 +183,9 @@ function quiet() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // The loaders remember their last good answer, so a test that did not clear
+  // the cache would be handed the previous test's cluster.
+  clearResourceCache();
   quiet();
   resetContexts();
   setContexts([CTX]);
@@ -424,18 +450,46 @@ describe("Overview — the nodes table", () => {
     expect(pool).not.toContain("worker");
   });
 
-  it("keeps the table when the metrics fail, and empties it only when the node list does", async () => {
+  it("keeps the table when the metrics fail", async () => {
     core.nodeMetrics.mockResolvedValue({ error: "metrics API unavailable" });
-    const { unmount } = open();
+    open();
     await waitFor(() => expect(rowFor("n1")).toBeTruthy());
     expect(cells(rowFor("n1"))[3]).toBe("No reading");
-    unmount();
+  });
 
+  it("empties the table and says why when the node list is refused", async () => {
     core.listNodes.mockResolvedValue({ error: "nodes is forbidden" });
     open();
     await waitFor(() => expect(screen.getByText(/nodes is forbidden/)).toBeTruthy());
     // One refused list is one empty section: the namespace count is untouched.
     expect(value("Namespaces")).toBe("4");
+  });
+
+  /**
+   * The case the cache creates, and the one it must not get wrong: the reader
+   * has rows on screen from a minute ago and the refresh behind them just
+   * failed. Throwing the rows away would lose a real reading nobody asked to
+   * lose; keeping them silently would present a stale cluster as a live one.
+   */
+  it("keeps the last good rows when a refresh is refused, and says they stopped refreshing", async () => {
+    const { unmount } = open();
+    await waitFor(() => expect(rowFor("n1")).toBeTruthy());
+    unmount();
+
+    // Past the cache's TTL, so the next mount paints the cached rows AND
+    // refreshes behind them — inside it there is no refresh to fail.
+    const clock = vi.spyOn(Date, "now");
+    clock.mockReturnValue(Date.now() + CACHE_TTL_MS + 1);
+    core.listNodes.mockResolvedValue({ error: "nodes is forbidden" });
+    open();
+    // The rows are still the ones the cluster last gave, not an error state.
+    await waitFor(() => expect(rowFor("n1")).toBeTruthy());
+    expect(value("Nodes")).toBe("3");
+    // And the screen says so, once, with what the cluster actually said.
+    const notice = await waitFor(() => screen.getByText(/no longer refreshing/i));
+    expect(notice).toBeTruthy();
+    expect(screen.getByText(/nodes is forbidden/)).toBeTruthy();
+    clock.mockRestore();
   });
 });
 
@@ -536,7 +590,7 @@ function sick() {
   core.listDeployments.mockResolvedValue({ deployments: SICK_DEPLOYMENTS });
   core.listStatefulSets.mockResolvedValue({ statefulsets: SICK_STATEFULSETS });
   core.listDaemonSets.mockResolvedValue({ daemonsets: SICK_DAEMONSETS });
-  core.listPods.mockResolvedValue({ pods: SICK_PODS });
+  core.podOverview.mockResolvedValue({ pods: anOverview(SICK_PODS) });
 }
 
 function notReady(): HTMLElement {
@@ -702,7 +756,7 @@ describe("Overview — the not-ready list", () => {
 
   it("says that nothing is unhealthy rather than leaving a blank", async () => {
     // The default fixture's one crash-looping pod, taken away.
-    core.listPods.mockResolvedValue({ pods: PODS.filter((p) => !p.waitingReason) });
+    core.podOverview.mockResolvedValue({ pods: anOverview(PODS.filter((p) => !p.waitingReason)) });
     open();
     await waitFor(() => expect(within(notReady()).getByText("Nothing is unhealthy")).toBeTruthy());
 
@@ -711,7 +765,7 @@ describe("Overview — the not-ready list", () => {
   });
 
   it("does not read a refused list as a healthy cluster", async () => {
-    core.listPods.mockResolvedValue({ pods: [] });
+    core.podOverview.mockResolvedValue({ pods: anOverview([]) });
     core.listDeployments.mockResolvedValue({ error: 'deployments is forbidden: User "dev" cannot list' });
     open();
 
@@ -721,7 +775,7 @@ describe("Overview — the not-ready list", () => {
   });
 
   it("keeps the rows it does have when one kind is refused, and says which", async () => {
-    core.listPods.mockResolvedValue({ pods: SICK_PODS });
+    core.podOverview.mockResolvedValue({ pods: anOverview(SICK_PODS) });
     core.listStatefulSets.mockResolvedValue({ error: 'statefulsets is forbidden: User "dev" cannot list' });
     open();
 
@@ -921,14 +975,15 @@ describe("Overview — the rail's object counts", () => {
 
     await waitFor(() => expect(countRow("Deployment").textContent).toContain("2"));
     expect(countRow("StatefulSet").textContent).toContain("1");
-    // Four pods in the fixture, from the one `listPods` the screen makes.
+    // Four pods in the fixture — a count the backend made, not the length of
+    // a list this screen fetched.
     expect(countRow("Pod").textContent).toContain("4");
 
     // The collapse: Deployments, StatefulSets, DaemonSets and Pods are all
     // already on screen, so the generic list is called only for the two kinds
     // nothing else loads.
     expect(core.listDeployments).toHaveBeenCalledTimes(1);
-    expect(core.listPods).toHaveBeenCalledTimes(1);
+    expect(core.podOverview).toHaveBeenCalledTimes(1);
     expect(core.listResource).toHaveBeenCalledTimes(2);
     expect(core.listResource.mock.calls.map((c: unknown[]) => c[1])).toEqual(["CronJob", "Job"]);
   });
@@ -1322,5 +1377,153 @@ describe("Overview — a nodes band that stays a summary", () => {
     }
     // The words still say what the buttons do; the glyph is a second channel.
     expect(within(rowFor("n1")).getByRole("button", { name: "Drain" }).textContent).toBe("Drain");
+  });
+});
+
+/**
+ * The failure this whole change exists to end.
+ *
+ * On the user's 113-node cluster the screen asked for every pod in the
+ * cluster — 5 416 of them, 114 MB — for three figures, and the request did not
+ * come back inside its budget. The Pods tile, every node's Pods column and the
+ * rail's Pods count all read "No reading", which was HONEST and useless.
+ *
+ * Nothing downstream of the backend changed its mind about honesty: every
+ * assertion below that says "no reading" still has to hold. What changed is
+ * that on a cluster this size there is now a reading to show.
+ */
+describe("Overview — a cluster too big to list", () => {
+  /** 113 nodes and 5 416 pods, counted the way the backend counts them. */
+  const BIG_NODES = Array.from({ length: 113 }, (_, i) => aNode(`worker-${String(i).padStart(3, "0")}`));
+  const BIG_COUNTS: PodOverview = {
+    total: 5416,
+    byNode: BIG_NODES.map((n, i) => ({ node: n.name, pods: 40 + (i % 11) })),
+    unsettled: [
+      aPod("crash-0", "worker-000", { namespace: "checkout", ready: "0/1", waitingReason: "CrashLoopBackOff" }),
+      aPod("done-0", "worker-001", { namespace: "ops", phase: "Succeeded", ready: "0/1" }),
+    ],
+    truncated: false,
+  };
+
+  function big(over: Partial<PodOverview> = {}) {
+    core.listNodes.mockResolvedValue({ nodes: BIG_NODES });
+    core.nodeMetrics.mockResolvedValue({ metrics: [] });
+    core.podOverview.mockResolvedValue({ pods: { ...BIG_COUNTS, ...over } });
+  }
+
+  it("answers the Pods tile from a count, with no pod list anywhere", async () => {
+    big();
+    open();
+
+    await waitFor(() => expect(value("Pods")).toBe("5416"));
+    // One pod is crash-looping; the finished Job pod is not a problem, and
+    // core is what says which is which.
+    expect(caption("Pods")).toBe("1 not ready");
+    expect(tone("Pods")).toBe("sev");
+    expect(core.podOverview).toHaveBeenCalledWith("prod-eu");
+  });
+
+  it("fills every node's Pods column from the backend's grouping", async () => {
+    big();
+    open();
+
+    await waitFor(() => expect(rowFor("worker-000")).toBeTruthy());
+    // 40 of the node's own allocatable 50 — the ratio the design draws, on a
+    // cluster whose pod list could never have been fetched to build it.
+    expect(cells(rowFor("worker-000"))[5]).toBe("40/50");
+    expect(screen.queryAllByText("No reading").length).toBeGreaterThan(0);
+    expect(cells(rowFor("worker-000"))[5]).not.toBe("No reading");
+  });
+
+  it("counts the Pods row in the rail from the same count", async () => {
+    big();
+    open();
+
+    const row = await waitFor(() => {
+      const found = within(section("Objects by kind"))
+        .getAllByRole("button")
+        .find((b) => b.textContent?.startsWith(K8S_KIND.pods));
+      if (!found) throw new Error("no Pod row");
+      return found;
+    });
+    expect(row.textContent).toContain("5416");
+    expect(within(section("Objects by kind")).queryByText(/could not count Pod/i)).toBeNull();
+  });
+
+  it("still reads a cluster that did not answer as no reading, never as no pods", async () => {
+    core.listNodes.mockResolvedValue({ nodes: BIG_NODES });
+    core.podOverview.mockResolvedValue({ error: "pod overview timed out" });
+    open();
+
+    await waitFor(() => expect(value("Pods")).toBe("No reading"));
+    // The lie the whole null-is-not-zero chain exists to prevent.
+    expect(value("Pods")).not.toBe("0");
+    await waitFor(() => expect(rowFor("worker-000")).toBeTruthy());
+    expect(cells(rowFor("worker-000"))[5]).toBe("No reading");
+  });
+
+  it("says the not-ready list is short rather than presenting a cap as the whole truth", async () => {
+    big({ truncated: true });
+    open();
+
+    await waitFor(() => expect(within(notReady()).getByText(/more pods need a look/i)).toBeTruthy());
+    // And the tile stops claiming an exact figure it cannot have.
+    expect(caption("Pods")).toBe("at least 1 not ready");
+  });
+
+  it("never says every pod is ready off a list that was cut short", async () => {
+    big({ unsettled: [], truncated: true });
+    open();
+
+    await waitFor(() => expect(value("Pods")).toBe("5416"));
+    // "all ready" is a claim about every pod, and a capped list has not seen
+    // every pod. Silence is what it actually knows.
+    expect(caption("Pods")).toBeNull();
+    expect(within(notReady()).queryByText("Nothing is unhealthy")).toBeNull();
+  });
+});
+
+describe("Overview — coming back to the tab", () => {
+  it("paints the cluster from the last reading instead of loading it again", async () => {
+    const { unmount } = open();
+    await waitFor(() => expect(rowFor("n1")).toBeTruthy());
+    const calls = {
+      nodes: core.listNodes.mock.calls.length,
+      pods: core.podOverview.mock.calls.length,
+      facts: core.clusterFacts.mock.calls.length,
+    };
+    unmount();
+
+    open();
+    // Already there, on the first render, with no spinner in between.
+    expect(rowFor("n1")).toBeTruthy();
+    expect(value("Pods")).toBe("4");
+    expect(screen.queryByText("Loading nodes")).toBeNull();
+    expect(core.listNodes).toHaveBeenCalledTimes(calls.nodes);
+    expect(core.podOverview).toHaveBeenCalledTimes(calls.pods);
+    expect(core.clusterFacts).toHaveBeenCalledTimes(calls.facts);
+  });
+
+  it("never shows one cluster's cached figures for another", async () => {
+    core.listNodes.mockImplementation((context: string) =>
+      Promise.resolve({ nodes: [aNode(`${context}-1`)] }),
+    );
+    const other: ClusterContext = { ...CTX, name: "staging-eu", stableId: "staging" };
+    setContexts([CTX, other]);
+    store.setState(defaultState([CTX, other]));
+
+    const { unmount } = open();
+    await waitFor(() => expect(rowFor("prod-eu-1")).toBeTruthy());
+    unmount();
+
+    store.setState({ ...defaultState([other]), });
+    store.openTab(ROUTE);
+    render(
+      <ConsoleProvider>
+        <Overview route={ROUTE} />
+      </ConsoleProvider>,
+    );
+    await waitFor(() => expect(rowFor("staging-eu-1")).toBeTruthy());
+    expect(screen.queryByText("prod-eu-1")).toBeNull();
   });
 });

--- a/packages/ui-next/src/screens/Overview.test.tsx
+++ b/packages/ui-next/src/screens/Overview.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 // Only the capability wrappers are replaced. `nodeUsage`, `clusterCapacity`,
@@ -40,7 +40,10 @@ proto.setPointerCapture ??= () => {};
 proto.releasePointerCapture ??= () => {};
 
 import {
+  K8S_KIND,
+  RESOURCE_LABELS,
   resourceStatusLine,
+  scaledStatus,
   type ClusterContext,
   type ClusterFacts,
   type DaemonSetSummary,
@@ -48,6 +51,7 @@ import {
   type K8sObject,
   type NodeSummary,
   type PodSummary,
+  type ResourceKind,
   type StatefulSetSummary,
 } from "@srelens/core";
 import { Overview } from "./Overview";
@@ -890,6 +894,23 @@ describe("Overview — the rail's object counts", () => {
   const countRow = (label: string) =>
     within(section("Objects by kind")).getByRole("button", { name: new RegExp(`^${label}`) });
 
+  it("names the kind, singular, and not the sidebar's list label", async () => {
+    open();
+    await waitFor(() => expect(countRow("Deployment")).toBeTruthy());
+
+    // §7 writes `Deployment 25`: the row names the KIND its number counts,
+    // where the sidebar's plural names a list you are about to open. Core
+    // holds both tables (`K8S_KIND` and `RESOURCE_LABELS`) side by side, so
+    // this is a choice between them and not a table of the screen's own.
+    const labels = Array.from(
+      section("Objects by kind").querySelectorAll<HTMLElement>(".ns-row"),
+    ).map((row) => row.firstElementChild?.textContent ?? "");
+    expect(labels).toEqual(["Deployment", "Pod", "StatefulSet", "DaemonSet", "CronJob", "Job"]);
+    for (const [slug, label] of Object.entries(K8S_KIND)) {
+      if (labels.includes(label)) expect(RESOURCE_LABELS[slug as ResourceKind]).not.toBe(label);
+    }
+  });
+
   it("counts a kind off the list the screen already loaded, without asking twice", async () => {
     core.listDeployments.mockResolvedValue({
       deployments: [aDeployment("a", "1/1"), aDeployment("b", "1/1")],
@@ -898,10 +919,10 @@ describe("Overview — the rail's object counts", () => {
     core.listResource.mockResolvedValue({ items: [{ name: "x" }] });
     open();
 
-    await waitFor(() => expect(countRow("Deployments").textContent).toContain("2"));
-    expect(countRow("StatefulSets").textContent).toContain("1");
+    await waitFor(() => expect(countRow("Deployment").textContent).toContain("2"));
+    expect(countRow("StatefulSet").textContent).toContain("1");
     // Four pods in the fixture, from the one `listPods` the screen makes.
-    expect(countRow("Pods").textContent).toContain("4");
+    expect(countRow("Pod").textContent).toContain("4");
 
     // The collapse: Deployments, StatefulSets, DaemonSets and Pods are all
     // already on screen, so the generic list is called only for the two kinds
@@ -914,16 +935,16 @@ describe("Overview — the rail's object counts", () => {
 
   it("opens that kind's list when a row is activated", async () => {
     open();
-    await waitFor(() => expect(countRow("Deployments")).toBeTruthy());
+    await waitFor(() => expect(countRow("Deployment")).toBeTruthy());
 
-    await userEvent.click(countRow("Deployments"));
+    await userEvent.click(countRow("Deployment"));
     expect(store.activeRoute()).toBe("/k/deployments");
 
-    await userEvent.click(countRow("CronJobs"));
+    await userEvent.click(countRow("CronJob"));
     expect(store.activeRoute()).toBe("/k/cronjobs");
   });
 
-  it("shows no number for a kind it could not count, and says why", async () => {
+  it("shows no number for a kind it could not count, and says why on that row", async () => {
     core.listResource.mockImplementation((_context: string, kind: string) =>
       Promise.resolve(
         kind === "Job"
@@ -933,21 +954,29 @@ describe("Overview — the rail's object counts", () => {
     );
     open();
 
-    await waitFor(() => expect(countRow("CronJobs").textContent).toContain("2"));
+    await waitFor(() => expect(countRow("CronJob").textContent).toContain("2"));
     // Zero is a number a reader will believe. A refusal is not a count.
-    expect(countRow("Jobs").textContent).not.toContain("0");
-    expect(countRow("Jobs").textContent).toContain("—");
-    expect(section("Objects by kind").textContent).toContain("Jobs");
-    expect(within(section("Objects by kind")).getByText(/could not count/i)).toBeTruthy();
+    expect(countRow("Job").textContent).not.toContain("0");
+    expect(countRow("Job").textContent).toContain("—");
+
+    // The reason belongs to the row that could not answer — the treatment
+    // `Fleet` gives an unreachable cluster — not to a paragraph under the
+    // section naming the kinds a second time. It sits beside its own row and
+    // carries what the cluster actually said.
+    const reason = within(section("Objects by kind")).getByText(/could not count job/i);
+    expect(reason.textContent).toContain("jobs is forbidden");
+    expect(reason.previousElementSibling).toBe(countRow("Job"));
+    // And it is the only one: the kinds that answered say nothing.
+    expect(within(section("Objects by kind")).getAllByText(/could not count/i)).toHaveLength(1);
   });
 
   it("does not count a refused workload list as a cluster with none of that kind", async () => {
     core.listDeployments.mockResolvedValue({ error: "deployments is forbidden" });
     open();
 
-    await waitFor(() => expect(countRow("Pods").textContent).toContain("4"));
-    expect(countRow("Deployments").textContent).not.toContain("0");
-    expect(countRow("Deployments").textContent).toContain("—");
+    await waitFor(() => expect(countRow("Pod").textContent).toContain("4"));
+    expect(countRow("Deployment").textContent).not.toContain("0");
+    expect(countRow("Deployment").textContent).toContain("—");
   });
 });
 
@@ -982,5 +1011,316 @@ describe("Overview — the rail's incidents and fleet", () => {
     // Fleet is a courtesy; the overview is about this cluster.
     expect(value("Nodes")).toBe("3");
     expect(rowFor("n1")).toBeTruthy();
+  });
+});
+
+/* ------------------------------------------------------- the screen's shape */
+
+/** The left-hand column of bands — the sibling run `.section + .section` rules. */
+const leftColumn = () =>
+  (document.querySelector('[data-slot="rail-main"] .scroll') ?? undefined) as HTMLElement | undefined;
+
+const railBody = () =>
+  (document.querySelector('[data-slot="rail-body"]') ?? undefined) as HTMLElement | undefined;
+
+const bandTitles = (host: HTMLElement) =>
+  Array.from(host.querySelectorAll(":scope > section.section > h3")).map((h) => h.textContent ?? "");
+
+describe("Overview — a flat surface, not a stack of cards", () => {
+  it("draws no card anywhere on the screen", async () => {
+    sick();
+    open();
+    await waitFor(() => expect(rowFor("n1")).toBeTruthy());
+
+    // The user settled this for the resource detail pane and it is the same
+    // decision: "flat sections win — the mock is a flat run of sections
+    // separated by hairline rules… Drop the cards." A card has a border, a
+    // lifted surface and a ruled head, and three of them read as three boxes
+    // on a page rather than one continuous surface.
+    expect(document.querySelectorAll(".card")).toHaveLength(0);
+    expect(document.querySelectorAll(".card-head")).toHaveLength(0);
+  });
+
+  it("makes the bands direct siblings of one box, in both columns", async () => {
+    sick();
+    open();
+    await waitFor(() => expect(rowFor("n1")).toBeTruthy());
+
+    // `.section + .section` is what draws the hairlines. A wrapper per band —
+    // one div each to hang a class on — silently removes every rule while
+    // leaving the screen looking almost right, so this is pinned rather than
+    // trusted. The kit's own suite pins the CSS; this pins the adjacency.
+    expect(bandTitles(leftColumn()!)).toEqual(["Capacity", "Nodes", "Not ready"]);
+    expect(bandTitles(railBody()!)).toEqual([
+      "Control plane",
+      "Objects by kind",
+      "Open incidents",
+      "Fleet",
+    ]);
+    for (const host of [leftColumn()!, railBody()!]) {
+      expect([...host.children].every((el) => el.matches("section.section"))).toBe(true);
+    }
+  });
+
+  it("puts no gap and no padding between the bands", async () => {
+    open();
+    await waitFor(() => expect(rowFor("n1")).toBeTruthy());
+
+    // The design's bands sit directly against each other, divided by one
+    // hairline. A `gap` puts daylight either side of that rule and a `p-3`
+    // insets every band inside a second margin the rail beside it has not
+    // got — which is what made the build read as three boxes.
+    const column = leftColumn()!.className;
+    expect(column).not.toMatch(/\bgap-\d/);
+    expect(column).not.toMatch(/\bp-\d/);
+  });
+
+  it("heads every band in the design's small caps", async () => {
+    open();
+    await waitFor(() => expect(rowFor("n1")).toBeTruthy());
+
+    // §C.3's structural signpost, the same recipe the pane heads wear. The
+    // uppercase is CSS, so the outline and a screen reader still hear the
+    // words themselves.
+    for (const host of [leftColumn()!, railBody()!]) {
+      for (const head of Array.from(host.querySelectorAll(":scope > section.section > h3"))) {
+        expect(head.className, head.textContent ?? "").toContain("subhead-caps");
+      }
+    }
+  });
+
+  it("runs the tables and the row lists to both edges, and keeps the fact list inset", async () => {
+    sick();
+    open();
+    await waitFor(() => expect(rowFor("n1")).toBeTruthy());
+
+    const unpadded = (title: string) =>
+      screen
+        .getAllByRole("heading", { name: title })[0]
+        .closest("section")
+        ?.getAttribute("data-padded");
+
+    // §D names it: `padded: false` for tables and list rows. A table inside an
+    // inset draws its hairlines short of the rules dividing the bands around
+    // it.
+    expect(unpadded("Capacity")).toBe("false");
+    expect(unpadded("Nodes")).toBe("false");
+    expect(unpadded("Not ready")).toBe("false");
+    expect(unpadded("Objects by kind")).toBe("false");
+    // The key/value bands keep theirs: a `.kv` row is not a full-width row.
+    expect(unpadded("Control plane")).toBeNull();
+    expect(unpadded("Fleet")).toBeNull();
+  });
+
+  it("heads the left column with the cluster and its server version", async () => {
+    await probed("v1.31.4");
+    open();
+
+    // §7's `prod-eu · v1.31.4`, level with the rail's own head. The version is
+    // the probe's — the same reading the rail's `Version` row takes, not a
+    // second call.
+    await waitFor(() =>
+      expect(document.querySelector('[data-slot="main-head"]')?.textContent).toBe(
+        "prod-eu · v1.31.4",
+      ),
+    );
+  });
+
+  it("heads it with the name alone until something has probed the cluster", async () => {
+    open();
+    // Not "prod-eu · " — a separator with nothing after it reads as a fact
+    // that failed to load rather than as one nobody has asked for yet.
+    await waitFor(() =>
+      expect(document.querySelector('[data-slot="main-head"]')?.textContent).toBe("prod-eu"),
+    );
+  });
+});
+
+describe("Overview — a context name too long for the toolbar", () => {
+  const LONG = "m01-1786968575165/kubernetes-admin@cluster.local";
+  const crumb = () => document.querySelector(".crumb")?.textContent ?? "";
+
+  beforeEach(() => {
+    const ctx = { ...CTX, name: LONG };
+    resetContexts();
+    setContexts([ctx]);
+    store.setState(defaultState([ctx]));
+  });
+
+  it("keeps both ends of the name, and cuts the middle", async () => {
+    open();
+    await waitFor(() => expect(crumb()).toBeTruthy());
+
+    // Cutting the TAIL is the one form that must not be used: every kubeadm
+    // context in a fleet ends `@cluster.local`, so two clusters truncated that
+    // way are indistinguishable. Cutting the head loses the other half. The
+    // middle goes, and both ends that tell one cluster from another survive.
+    expect(crumb().length).toBeLessThan(LONG.length);
+    expect(crumb()).toContain("…");
+    expect(crumb().startsWith("m01-")).toBe(true);
+    expect(crumb().endsWith("cluster.local")).toBe(true);
+    expect(crumb()).not.toContain("kubernetes-admin");
+  });
+
+  it("tells two clusters apart that differ only at one end", async () => {
+    open();
+    const first = crumb();
+    cleanup();
+
+    const other = { ...CTX, name: "m02-1786968575165/kubernetes-admin@cluster.local" };
+    resetContexts();
+    setContexts([other]);
+    store.setState(defaultState([other]));
+    open();
+    await waitFor(() => expect(crumb()).toBeTruthy());
+    expect(crumb()).not.toBe(first);
+  });
+
+  it("leaves a name that already fits exactly as it is", async () => {
+    resetContexts();
+    setContexts([CTX]);
+    store.setState(defaultState([CTX]));
+    open();
+    await waitFor(() => expect(crumb()).toBeTruthy());
+    expect(crumb()).toBe("prod-eu");
+    expect(crumb()).not.toContain("…");
+  });
+
+  it("still carries the whole name in the rail, where there is room for it", async () => {
+    open();
+    // Nothing is hidden by the cut: the header is a label and the rail is the
+    // record.
+    await waitFor(() => expect(factValue("Context")).toBe(LONG));
+  });
+});
+
+/* -------------------------------------------------- the nodes band's shape */
+
+/** The node names the table drew, in the order it drew them — the name alone,
+ *  without the flagged node's `sr-only` "Needs attention". */
+const nodeNames = () =>
+  Array.from(document.querySelectorAll("tbody tr.tbl-row td:first-child span.truncate")).map(
+    (el) => el.textContent?.trim() ?? "",
+  );
+
+describe("Overview — a nodes band that stays a summary", () => {
+  /** A fleet big enough that drawing all of it is the bug. */
+  const many = (count: number) =>
+    Array.from({ length: count }, (_, i) => aNode(`node-${String(i).padStart(3, "0")}`));
+
+  it("caps the rows, and says what it is not showing", async () => {
+    core.listNodes.mockResolvedValue({ nodes: many(113) });
+    core.nodeMetrics.mockResolvedValue({ metrics: [] });
+    open();
+    await waitFor(() => expect(nodeNames().length).toBeGreaterThan(0));
+
+    // 113 rows pushed `Not ready` — the band that says what is actually wrong
+    // — entirely off the screen on a real cluster. `/k/nodes` is the screen
+    // for the whole inventory; this one is a summary of it.
+    expect(nodeNames()).toHaveLength(10);
+    // Silently truncating is the part that would be dishonest.
+    expect(screen.getByText(/Showing 10 of 113 nodes/)).toBeTruthy();
+    // And the whole list is one click away.
+    await userEvent.click(screen.getByRole("button", { name: /Showing 10 of 113 nodes/ }));
+    expect(store.activeRoute()).toBe("/k/nodes");
+  });
+
+  it("says nothing about a cap when there is nothing to hide", async () => {
+    open();
+    await waitFor(() => expect(nodeNames()).toHaveLength(3));
+    expect(screen.queryByText(/Showing \d+ of/)).toBeNull();
+  });
+
+  it("picks the rows worth looking at, not the first ten alphabetically", async () => {
+    const rest = many(20);
+    core.listNodes.mockResolvedValue({
+      nodes: [
+        ...rest,
+        // Two nodes core has an opinion about, named so that alphabetical
+        // order buries both of them at the very end of 22.
+        aNode("zz-broken", { status: "NotReady" }),
+        aNode("zy-cordoned", { unschedulable: true }),
+      ],
+    });
+    // And one core is content with, running hot.
+    core.nodeMetrics.mockResolvedValue({
+      metrics: [{ name: "node-019", cpuMillicores: 3760, memoryMiB: 2000 }],
+    });
+    open();
+    await waitFor(() => expect(nodeNames()).toHaveLength(10));
+
+    // core's verdict first — a NotReady node above a cordoned one, which is
+    // `nodeVerdict`'s own ordering and not a reading of this file's — then
+    // the hottest of the ones core is content with.
+    expect(nodeNames().slice(0, 3)).toEqual(["zz-broken", "zy-cordoned", "node-019"]);
+    // The point of it: this is NOT what the list arrived in.
+    expect(nodeNames()[0]).not.toBe("node-000");
+  });
+
+  it("counts the whole cluster in the capacity tile, not the ten it drew", async () => {
+    core.listNodes.mockResolvedValue({
+      nodes: [...many(112), aNode("zz-broken", { status: "NotReady" })],
+    });
+    core.nodeMetrics.mockResolvedValue({ metrics: [] });
+    open();
+
+    // The cap is the TABLE's. A tile that counted the rows on screen would
+    // report a 113-node cluster as a ten-node one.
+    await waitFor(() => expect(value("Nodes")).toBe("113"));
+    expect(caption("Nodes")).toBe("1 not ready");
+  });
+
+  it("gives the meters room to show their tone", async () => {
+    core.listNodes.mockResolvedValue({ nodes: [aNode("n1")] });
+    core.nodeMetrics.mockResolvedValue({
+      metrics: [{ name: "n1", cpuMillicores: 3520, memoryMiB: 6560 }],
+    });
+    open();
+    await waitFor(() => expect(rowFor("n1")).toBeTruthy());
+
+    // `Meter`'s bar is `w-full`, which has no intrinsic width, so a table cell
+    // sized by its content collapsed the column onto the percentage beside it
+    // and drew a 40px stub. At that size the tone — 88% red against 41% green
+    // — is the one thing the column exists to show and the one thing nobody
+    // can see. The width goes on the CONTENT, where auto layout can act on it.
+    for (const label of ["n1 CPU", "n1 memory"]) {
+      const meter = within(rowFor("n1")).getByRole("meter", { name: label });
+      const cell = meter.closest("td");
+      expect(cell?.firstElementChild?.className, label).toContain("min-w-[10rem]");
+    }
+  });
+
+  it("asks for that room before the metrics have landed", async () => {
+    // The node list answers well before `nodeMetrics` does, and `Table`
+    // measures the natural column widths on the FIRST render that has rows,
+    // then pins them. A width that arrived with the meters arrived after the
+    // columns had been fixed at the width of the words "No reading", and the
+    // meters drew straight across the columns beside them.
+    core.listNodes.mockResolvedValue({ nodes: [aNode("n1")] });
+    core.nodeMetrics.mockResolvedValue({ error: "metrics API unavailable" });
+    open();
+    await waitFor(() => expect(rowFor("n1")).toBeTruthy());
+
+    const row = rowFor("n1");
+    expect(cells(row)[3]).toBe("No reading");
+    expect(within(row).queryByRole("meter")).toBeNull();
+    for (const index of [3, 4]) {
+      const cell = row.querySelectorAll("td")[index];
+      expect(cell.firstElementChild?.className, String(index)).toContain("min-w-[10rem]");
+    }
+  });
+
+  it("marks the two node actions with the design's glyphs", async () => {
+    open();
+    await waitFor(() => expect(rowFor("n1")).toBeTruthy());
+
+    // A crossed circle on Cordon, a wave on Drain. From `lib/icons` — the
+    // app's vocabulary — because the kit takes no icon-set dependency.
+    for (const label of ["Cordon", "Drain"]) {
+      const button = within(rowFor("n1")).getByRole("button", { name: label });
+      expect(button.querySelector("svg"), label).not.toBeNull();
+    }
+    // The words still say what the buttons do; the glyph is a second channel.
+    expect(within(rowFor("n1")).getByRole("button", { name: "Drain" }).textContent).toBe("Drain");
   });
 });

--- a/packages/ui-next/src/screens/Overview.test.tsx
+++ b/packages/ui-next/src/screens/Overview.test.tsx
@@ -16,6 +16,7 @@ const core = vi.hoisted(() => ({
   listStatefulSets: vi.fn(),
   listDaemonSets: vi.fn(),
   clusterFacts: vi.fn(),
+  podCount: vi.fn(),
   cordonNode: vi.fn(),
   drainNode: vi.fn(),
   copyKubectlCommand: vi.fn(),
@@ -54,6 +55,8 @@ import { ConsoleProvider } from "../console";
 import { defaultState } from "../lib/tabs";
 import * as store from "../lib/tabsStore";
 import { resetContexts, setContexts, setKubeconfigFiles } from "../lib/clusters";
+import { probeCluster, resetProbes } from "../lib/probe";
+import { resetView, setLink, type LinkState } from "../lib/workspace";
 
 const CTX: ClusterContext = {
   name: "prod-eu",
@@ -146,6 +149,7 @@ function quiet() {
   core.listStatefulSets.mockResolvedValue({ statefulsets: [] });
   core.listDaemonSets.mockResolvedValue({ daemonsets: [] });
   core.clusterFacts.mockResolvedValue(NO_FACTS);
+  core.podCount.mockResolvedValue({ counts: { running: 4, total: 4 } });
   core.cordonNode.mockResolvedValue({ ok: true });
   core.drainNode.mockResolvedValue({ evicted: 3, skipped: 0 });
 }
@@ -157,6 +161,10 @@ beforeEach(() => {
   setContexts([CTX]);
   setKubeconfigFiles(["/home/u/.kube/config"]);
   store.setState(defaultState([CTX]));
+  // The rail reads both: the probe for the server version, the workspace view
+  // for the link. Neither survives a test.
+  resetProbes();
+  resetView();
 });
 
 function open() {
@@ -718,6 +726,261 @@ describe("Overview — the not-ready list", () => {
     // The refusal is stated, not swallowed: the list is short for a reason.
     expect(within(notReady()).getByText(/statefulsets is forbidden/)).toBeTruthy();
     // And it stays one section's failure — the nodes table is untouched.
+    expect(rowFor("n1")).toBeTruthy();
+  });
+});
+
+/* --------------------------------------------------------------- the rail */
+
+/** The `At a glance` rail, as the landmark its own head names. */
+const rail = () => screen.getByRole("complementary", { name: "At a glance" });
+
+/** One rail section, by the heading over it. */
+function section(title: string): HTMLElement {
+  const heading = within(rail()).getByRole("heading", { name: title });
+  const found = heading.closest("section");
+  if (!found) throw new Error(`no ${title} section in the rail`);
+  return found as HTMLElement;
+}
+
+/** The control-plane facts as `label -> value`, in the order the rail draws them. */
+function controlPlane(): Array<[string, string]> {
+  return Array.from(section("Control plane").querySelectorAll(".kv")).map((kv) => [
+    kv.querySelector(".kv-k")?.textContent ?? "",
+    kv.querySelector(".kv-v")?.textContent ?? "",
+  ]);
+}
+
+const factLabels = () => controlPlane().map(([k]) => k);
+const factValue = (label: string) => controlPlane().find(([k]) => k === label)?.[1];
+
+/** Seed the probe store the way the shell does, without a real connect call. */
+async function probed(version: string | null) {
+  await probeCluster(CTX, async () => ({ context: CTX.name, reachable: true, version }));
+}
+
+const SOME_FACTS: ClusterFacts = {
+  context: "prod-eu",
+  provider: "GKE",
+  region: "europe-west4",
+  metricsServer: { state: "present", version: "v1beta1" },
+};
+
+describe("Overview — the rail's control plane", () => {
+  it("omits a fact the cluster did not report rather than calling it unknown", async () => {
+    // The live case, not an edge one: no node on a kind cluster carries a
+    // region label, and `clusterFacts` reports that as an empty string.
+    core.clusterFacts.mockResolvedValue({ ...SOME_FACTS, provider: "", region: "" });
+    open();
+    await waitFor(() => expect(factValue("Context")).toBe("prod-eu"));
+
+    expect(factLabels()).not.toContain("Provider");
+    expect(factLabels()).not.toContain("Region");
+    // And nothing standing in for them: "unknown" and an em dash both read as
+    // answers, and the cluster gave none.
+    expect(section("Control plane").textContent).not.toMatch(/unknown/i);
+    expect(section("Control plane").textContent).not.toContain("—");
+  });
+
+  it("draws the facts the cluster did report, in the design's order", async () => {
+    core.clusterFacts.mockResolvedValue(SOME_FACTS);
+    await probed("v1.31.4");
+    setLink(CTX.stableId, "connected");
+    open();
+
+    await waitFor(() => expect(factValue("Provider")).toBe("GKE"));
+    expect(factLabels()).toEqual([
+      "Version",
+      "Provider",
+      "Region",
+      "Context",
+      "Connection",
+      "Metrics server",
+    ]);
+    expect(factValue("Version")).toBe("v1.31.4");
+    expect(factValue("Region")).toBe("europe-west4");
+  });
+
+  it("takes the connection's word from the one table the status bar reads", async () => {
+    // Four states, not one: a fixture with a single link state cannot tell a
+    // right table from a wrong one. The words are `LINK_WORD`'s, shared with
+    // the status bar, so the rail and the strip cannot disagree about the
+    // same cluster.
+    const cases: Array<[LinkState, string]> = [
+      ["connected", "Connected"],
+      ["connecting", "Connecting"],
+      ["disconnected", "Disconnected"],
+      ["error", "Unreachable"],
+    ];
+    for (const [state, word] of cases) {
+      setLink(CTX.stableId, state);
+      const { unmount } = open();
+      await waitFor(() => expect(factValue("Connection")).toBe(word));
+      unmount();
+    }
+  });
+
+  it("says nothing about the connection until something has probed it", async () => {
+    open();
+    await waitFor(() => expect(factValue("Context")).toBe("prod-eu"));
+    // No link state is not "Disconnected" — it is nobody having asked yet.
+    expect(factLabels()).not.toContain("Connection");
+    // Same for the version, which arrives with the probe.
+    expect(factLabels()).not.toContain("Version");
+  });
+
+  it("reads the metrics server's API group version, not a component version", async () => {
+    core.clusterFacts.mockResolvedValue(SOME_FACTS);
+    open();
+
+    await waitFor(() => expect(factValue("Metrics server")).toBe("v1beta1"));
+    // The mock's `v0.7.2 · reporting` is two claims this screen cannot make:
+    // the component version needs an RBAC-sensitive read of the deployment's
+    // image, and an aggregated APIService stays in discovery while its backing
+    // deployment is down — so "present" is not "answering".
+    expect(section("Control plane").textContent).not.toContain("reporting");
+    expect(section("Control plane").textContent).not.toContain("v0.7.2");
+  });
+
+  it("states a missing metrics server once, in the rail, and nowhere else", async () => {
+    core.clusterFacts.mockResolvedValue({
+      ...SOME_FACTS,
+      metricsServer: { state: "absent", version: "" },
+    });
+    // The same cluster's metrics call fails too, which is what a missing
+    // metrics-server does — every tile and column reads "No reading".
+    core.nodeMetrics.mockResolvedValue({ error: "the server could not find the requested resource" });
+    open();
+
+    await waitFor(() => expect(factValue("Metrics server")).toContain("Not installed"));
+    expect(value("CPU")).toBe("No reading");
+
+    // Once. Five tiles and two columns each announcing it would have said it
+    // seven times and explained it nowhere.
+    expect(screen.getAllByText(/not installed/i)).toHaveLength(1);
+  });
+
+  it("does not call the metrics server absent when only the request failed", async () => {
+    // Discovery says the group is there; the reading failed anyway — a
+    // throttled apiserver, a transient refusal. Two different questions with
+    // the same visible answer, and the rail must read the discovery one.
+    core.clusterFacts.mockResolvedValue(SOME_FACTS);
+    core.nodeMetrics.mockResolvedValue({ error: "the server is currently unable to handle the request" });
+    open();
+
+    await waitFor(() => expect(factValue("Metrics server")).toBe("v1beta1"));
+    expect(screen.queryByText(/not installed/i)).toBeNull();
+    // The tiles still say there is no reading — they just do not say why.
+    expect(value("CPU")).toBe("No reading");
+  });
+
+  it("omits the metrics-server row when nobody could ask", async () => {
+    // `unknown` is not `absent`: an unreachable cluster has not told us
+    // metrics-server is missing, and drawing that as an absence would be the
+    // rail inventing the one fact it exists to report.
+    core.clusterFacts.mockResolvedValue({ ...SOME_FACTS, metricsServer: { state: "unknown", version: "" } });
+    open();
+
+    await waitFor(() => expect(factValue("Provider")).toBe("GKE"));
+    expect(factLabels()).not.toContain("Metrics server");
+  });
+});
+
+describe("Overview — the rail's object counts", () => {
+  const countRow = (label: string) =>
+    within(section("Objects by kind")).getByRole("button", { name: new RegExp(`^${label}`) });
+
+  it("counts a kind off the list the screen already loaded, without asking twice", async () => {
+    core.listDeployments.mockResolvedValue({
+      deployments: [aDeployment("a", "1/1"), aDeployment("b", "1/1")],
+    });
+    core.listStatefulSets.mockResolvedValue({ statefulsets: [aStatefulSet("c", "1/1")] });
+    core.listResource.mockResolvedValue({ items: [{ name: "x" }] });
+    open();
+
+    await waitFor(() => expect(countRow("Deployments").textContent).toContain("2"));
+    expect(countRow("StatefulSets").textContent).toContain("1");
+    // Four pods in the fixture, from the one `listPods` the screen makes.
+    expect(countRow("Pods").textContent).toContain("4");
+
+    // The collapse: Deployments, StatefulSets, DaemonSets and Pods are all
+    // already on screen, so the generic list is called only for the two kinds
+    // nothing else loads.
+    expect(core.listDeployments).toHaveBeenCalledTimes(1);
+    expect(core.listPods).toHaveBeenCalledTimes(1);
+    expect(core.listResource).toHaveBeenCalledTimes(2);
+    expect(core.listResource.mock.calls.map((c: unknown[]) => c[1])).toEqual(["CronJob", "Job"]);
+  });
+
+  it("opens that kind's list when a row is activated", async () => {
+    open();
+    await waitFor(() => expect(countRow("Deployments")).toBeTruthy());
+
+    await userEvent.click(countRow("Deployments"));
+    expect(store.activeRoute()).toBe("/k/deployments");
+
+    await userEvent.click(countRow("CronJobs"));
+    expect(store.activeRoute()).toBe("/k/cronjobs");
+  });
+
+  it("shows no number for a kind it could not count, and says why", async () => {
+    core.listResource.mockImplementation((_context: string, kind: string) =>
+      Promise.resolve(
+        kind === "Job"
+          ? { error: 'jobs is forbidden: User "dev" cannot list resource "jobs"' }
+          : { items: [{ name: "x" }, { name: "y" }] },
+      ),
+    );
+    open();
+
+    await waitFor(() => expect(countRow("CronJobs").textContent).toContain("2"));
+    // Zero is a number a reader will believe. A refusal is not a count.
+    expect(countRow("Jobs").textContent).not.toContain("0");
+    expect(countRow("Jobs").textContent).toContain("—");
+    expect(section("Objects by kind").textContent).toContain("Jobs");
+    expect(within(section("Objects by kind")).getByText(/could not count/i)).toBeTruthy();
+  });
+
+  it("does not count a refused workload list as a cluster with none of that kind", async () => {
+    core.listDeployments.mockResolvedValue({ error: "deployments is forbidden" });
+    open();
+
+    await waitFor(() => expect(countRow("Pods").textContent).toContain("4"));
+    expect(countRow("Deployments").textContent).not.toContain("0");
+    expect(countRow("Deployments").textContent).toContain("—");
+  });
+});
+
+describe("Overview — the rail's incidents and fleet", () => {
+  it("names the incidents section rather than leaving a hole", async () => {
+    open();
+    const incidents = await waitFor(() => section("Open incidents"));
+
+    // A silent absence reads as a bug. This one says what it is: no
+    // Kubernetes API returns an incident's title, severity or trend, and
+    // Incidents is scheduled as its own feature.
+    expect(incidents.textContent).toMatch(/incident/i);
+    expect(incidents.textContent).toMatch(/srelens/);
+    expect(incidents.textContent).not.toMatch(/SEV-\d/);
+  });
+
+  it("counts this cluster's pods in the fleet, whatever else is in the workspace", async () => {
+    core.podCount.mockResolvedValue({ counts: { running: 30, total: 33 } });
+    open();
+
+    const fleet = await waitFor(() => section("Fleet"));
+    await waitFor(() => expect(fleet.textContent).toContain("30/33 running"));
+    expect(within(fleet).getByText("prod-eu")).toBeTruthy();
+    expect(core.podCount).toHaveBeenCalledWith("prod-eu");
+  });
+
+  it("keeps the rest of the screen when the fleet cannot answer", async () => {
+    core.podCount.mockResolvedValue({ error: "pod count timed out" });
+    open();
+
+    await waitFor(() => expect(section("Fleet").textContent).toContain("Unreachable"));
+    // Fleet is a courtesy; the overview is about this cluster.
+    expect(value("Nodes")).toBe("3");
     expect(rowFor("n1")).toBeTruthy();
   });
 });

--- a/packages/ui-next/src/screens/Overview.test.tsx
+++ b/packages/ui-next/src/screens/Overview.test.tsx
@@ -12,6 +12,9 @@ const core = vi.hoisted(() => ({
   listPods: vi.fn(),
   listNamespaces: vi.fn(),
   listResource: vi.fn(),
+  listDeployments: vi.fn(),
+  listStatefulSets: vi.fn(),
+  listDaemonSets: vi.fn(),
   clusterFacts: vi.fn(),
   cordonNode: vi.fn(),
   drainNode: vi.fn(),
@@ -39,9 +42,12 @@ import {
   resourceStatusLine,
   type ClusterContext,
   type ClusterFacts,
+  type DaemonSetSummary,
+  type DeploymentSummary,
   type K8sObject,
   type NodeSummary,
   type PodSummary,
+  type StatefulSetSummary,
 } from "@srelens/core";
 import { Overview } from "./Overview";
 import { ConsoleProvider } from "../console";
@@ -71,6 +77,7 @@ function aNode(name: string, over: Partial<NodeSummary> = {}): NodeSummary {
     allocatableCpuMillicores: 4000,
     allocatableMemoryMiB: 16000,
     allocatablePods: 50,
+    instanceType: "",
     ...over,
   };
 }
@@ -101,6 +108,27 @@ const PODS = [
   aPod("worker-1", "n3", { phase: "Running", ready: "0/1", waitingReason: "CrashLoopBackOff" }),
 ];
 
+function aDeployment(name: string, ready: string, namespace = "checkout"): DeploymentSummary {
+  return { name, namespace, ready, upToDate: 1, available: 1, age: "8d" };
+}
+
+function aStatefulSet(name: string, ready: string, namespace = "payments"): StatefulSetSummary {
+  return { name, namespace, ready, updated: 1, service: "svc", age: "8d" };
+}
+
+function aDaemonSet(name: string, ready: number, desired: number, namespace = "kube-system"): DaemonSetSummary {
+  return {
+    name,
+    namespace,
+    desired,
+    current: ready,
+    ready,
+    upToDate: ready,
+    available: ready,
+    age: "40d",
+  };
+}
+
 const NO_FACTS: ClusterFacts = {
   context: "prod-eu",
   provider: "",
@@ -114,6 +142,9 @@ function quiet() {
   core.listPods.mockResolvedValue({ pods: PODS });
   core.listNamespaces.mockResolvedValue({ namespaces: ["default", "kube-system", "prod", "obs"] });
   core.listResource.mockResolvedValue({ items: [] });
+  core.listDeployments.mockResolvedValue({ deployments: [] });
+  core.listStatefulSets.mockResolvedValue({ statefulsets: [] });
+  core.listDaemonSets.mockResolvedValue({ daemonsets: [] });
   core.clusterFacts.mockResolvedValue(NO_FACTS);
   core.cordonNode.mockResolvedValue({ ok: true });
   core.drainNode.mockResolvedValue({ evicted: 3, skipped: 0 });
@@ -355,8 +386,22 @@ describe("Overview — the nodes table", () => {
     expect(meter.getAttribute("aria-valuenow")).toBe("100");
   });
 
+  it("reads Pool from the node's own machine type", async () => {
+    core.listNodes.mockResolvedValue({
+      nodes: [aNode("eu-w4-c3-standard-a1", { instanceType: "c3-standard-8" })],
+    });
+    open();
+    await waitFor(() => expect(rowFor("eu-w4-c3-standard-a1")).toBeTruthy());
+
+    expect(cells(rowFor("eu-w4-c3-standard-a1"))[1]).toBe("c3-standard-8");
+  });
+
   it("shows nothing in Pool rather than guessing one", async () => {
-    core.listNodes.mockResolvedValue({ nodes: [aNode("eu-w4-c3-standard-a1", { roles: "worker" })] });
+    // The node carries neither instance-type label — kind's nodes are
+    // containers, not cloud machines — so it named no pool at all.
+    core.listNodes.mockResolvedValue({
+      nodes: [aNode("eu-w4-c3-standard-a1", { roles: "worker", instanceType: "" })],
+    });
     open();
     await waitFor(() => expect(rowFor("eu-w4-c3-standard-a1")).toBeTruthy());
 
@@ -434,5 +479,245 @@ describe("Overview — the node actions", () => {
     await waitFor(() => expect(within(dialog()!).getByText(/nodes\/eviction is forbidden/)).toBeTruthy());
     // Still open, so nothing reads as having succeeded.
     expect(dialog()).toBeTruthy();
+  });
+});
+
+/* --------------------------------------------------------------- not ready */
+
+/**
+ * A cluster in several kinds of trouble at once.
+ *
+ * Deliberately not one shape of failure repeated: a fixture where every
+ * unhealthy row is a Degraded workload cannot tell a right table of status
+ * words from a wrong one, because both agree on the only case in it. This one
+ * spans all three severities core can flag (danger, warning and the neutral
+ * "we do not recognise this state"), four kinds, and — for each kind — one
+ * subject core calls healthy or at rest, which must NOT appear.
+ */
+const SICK_DEPLOYMENTS: DeploymentSummary[] = [
+  // 9 of 12 ready: core says Degraded, danger, flagged.
+  aDeployment("zz-checkout-api", "9/12"),
+  // Scaled to zero: neutral and NOT flagged. Amber-adjacent states like this
+  // are why `flagged` is data rather than a reading of the tone.
+  aDeployment("idle-batch", "0/0"),
+];
+const SICK_STATEFULSETS: StatefulSetSummary[] = [
+  aStatefulSet("mm-payments-db", "1/3"),
+  aStatefulSet("ok-cache", "3/3"),
+];
+const SICK_DAEMONSETS: DaemonSetSummary[] = [
+  aDaemonSet("cc-log-agent", 2, 4),
+  // Matches no node: "Not scheduled", and doing exactly what it was asked.
+  aDaemonSet("nn-gpu-agent", 0, 0),
+];
+const SICK_PODS: PodSummary[] = [
+  aPod("aa-worker-0", "n1", { namespace: "checkout", ready: "0/1", waitingReason: "CrashLoopBackOff" }),
+  aPod("bb-queue-0", "n2", { namespace: "payments", phase: "Pending", ready: "0/1" }),
+  // A phase core's table does not know: neutral, and still flagged — not
+  // recognising a state is not the same as knowing it is fine.
+  aPod("dd-mystery-0", "n3", { namespace: "search", phase: "Terminating", ready: "0/1" }),
+  aPod("ok-web-0", "n1", { namespace: "checkout" }),
+  aPod("done-backup-0", "n2", { namespace: "ops", phase: "Succeeded", ready: "0/1" }),
+];
+
+function sick() {
+  core.listDeployments.mockResolvedValue({ deployments: SICK_DEPLOYMENTS });
+  core.listStatefulSets.mockResolvedValue({ statefulsets: SICK_STATEFULSETS });
+  core.listDaemonSets.mockResolvedValue({ daemonsets: SICK_DAEMONSETS });
+  core.listPods.mockResolvedValue({ pods: SICK_PODS });
+}
+
+function notReady(): HTMLElement {
+  const heading = screen.getByRole("heading", { name: "Not ready" });
+  const card = heading.closest("section");
+  if (!card) throw new Error("no Not ready section on screen");
+  return card as HTMLElement;
+}
+
+const notReadyNames = () =>
+  Array.from(notReady().querySelectorAll(".status-row-name")).map((el) => el.textContent ?? "");
+
+const notReadyRow = (name: string) =>
+  Array.from(notReady().querySelectorAll<HTMLElement>(".status-row")).find(
+    (row) => row.querySelector(".status-row-name")?.textContent === name,
+  );
+
+const factsOf = (row: HTMLElement) =>
+  Array.from(row.querySelectorAll(".status-row-fact")).map((el) => el.textContent ?? "");
+
+/** The same subject as a fetched object, read by the function a detail pane reads. */
+const asObject = (kind: string, spec: unknown, status: unknown): K8sObject =>
+  ({ apiVersion: "v1", kind, metadata: { name: "x" }, spec, status }) as unknown as K8sObject;
+
+describe("Overview — the not-ready list", () => {
+  it("puts the worst thing first, whatever kind it happens to be", async () => {
+    sick();
+    open();
+    await waitFor(() => expect(notReadyNames()).toHaveLength(6));
+
+    // Danger first (alphabetically within the band, so the order is stable
+    // across three lists that settle in whatever order they settle), then the
+    // warning, then the state core could not read.
+    expect(notReadyNames()).toEqual([
+      "aa-worker-0",
+      "cc-log-agent",
+      "mm-payments-db",
+      "zz-checkout-api",
+      "bb-queue-0",
+      "dd-mystery-0",
+    ]);
+
+    // And the point of the section: this is NOT the order a list grouped by
+    // kind would produce. A Pod leads three workloads, and two more Pods
+    // follow them.
+    expect(notReadyNames()).not.toEqual([
+      "zz-checkout-api",
+      "mm-payments-db",
+      "cc-log-agent",
+      "aa-worker-0",
+      "bb-queue-0",
+      "dd-mystery-0",
+    ]);
+  });
+
+  it("lists what core calls unhealthy, and nothing else", async () => {
+    sick();
+    open();
+    await waitFor(() => expect(notReadyNames()).toHaveLength(6));
+
+    // Healthy, finished, scaled to zero, and matching no node: four subjects
+    // core does not flag, in four different tones. A section that read
+    // badness off the tone would pick up at least one of them.
+    for (const quiet of ["idle-batch", "ok-cache", "nn-gpu-agent", "ok-web-0", "done-backup-0"]) {
+      expect(notReadyRow(quiet)).toBeUndefined();
+    }
+
+    // The sharpest form of it: two subjects core gives the SAME tone, one
+    // flagged and one not. `idle-batch` (scaled to zero) and `dd-mystery-0`
+    // (a phase core does not recognise) are both neutral; only the second is
+    // in the list, which no reading of the colour could have produced.
+    expect(notReadyRow("dd-mystery-0")?.querySelector(".status")?.getAttribute("data-kind")).toBe(
+      "neutral",
+    );
+  });
+
+  it("takes every word and every tone from core, across all three severities", async () => {
+    sick();
+    open();
+    await waitFor(() => expect(notReadyNames()).toHaveLength(6));
+
+    const expected: [name: string, line: ReturnType<typeof resourceStatusLine>][] = [
+      ["zz-checkout-api", resourceStatusLine("Deployment", asObject("Deployment", { replicas: 12 }, { readyReplicas: 9 }))],
+      ["mm-payments-db", resourceStatusLine("StatefulSet", asObject("StatefulSet", { replicas: 3 }, { readyReplicas: 1 }))],
+      ["cc-log-agent", resourceStatusLine("DaemonSet", asObject("DaemonSet", {}, { numberReady: 2, desiredNumberScheduled: 4 }))],
+      [
+        "aa-worker-0",
+        resourceStatusLine(
+          "Pod",
+          asObject("Pod", {}, {
+            phase: "Running",
+            containerStatuses: [{ ready: false, state: { waiting: { reason: "CrashLoopBackOff" } } }],
+          }),
+        ),
+      ],
+      ["bb-queue-0", resourceStatusLine("Pod", asObject("Pod", {}, { phase: "Pending" }))],
+      ["dd-mystery-0", resourceStatusLine("Pod", asObject("Pod", {}, { phase: "Terminating" }))],
+    ];
+
+    // Three distinct tones among them, so a single wrong tone cannot pass by
+    // agreeing with the one case the fixture happens to contain.
+    expect(new Set(expected.map(([, line]) => line!.health))).toEqual(
+      new Set(["danger", "warning", "neutral"]),
+    );
+
+    for (const [name, line] of expected) {
+      const row = notReadyRow(name);
+      expect(row, `${name} should be in the not-ready list`).toBeTruthy();
+      const pill = row!.querySelector(".status");
+      expect(pill?.textContent, name).toBe(line!.status);
+      expect(pill?.getAttribute("data-kind"), name).toBe(line!.health);
+      // `flagged` is passed as data, not derived from the tone: every row
+      // here is one core flagged, including the amber and the grey ones.
+      expect(line!.flagged, name).toBe(true);
+      // It reaches the pill as `tinted`. The kit colours the two tones the
+      // design colours and leaves neutral plain — its own asymmetry, tested
+      // in `StatusPill`; what matters here is that a flagged warning row is
+      // coloured, which a caller passing `kind === "danger"` would have lost.
+      if (line!.health !== "neutral") {
+        expect(pill?.getAttribute("data-bad"), name).toBe("true");
+      }
+    }
+  });
+
+  it("names every trailing fact, so a reader hears more than 'checkout 9/12'", async () => {
+    sick();
+    open();
+    await waitFor(() => expect(notReadyNames()).toHaveLength(6));
+
+    // `StatusRow` takes `ReactNode`s and cannot know what a fact means; the
+    // noun is the caller's job, and this is the assertion that keeps it done.
+    for (const row of Array.from(notReady().querySelectorAll<HTMLElement>(".status-row"))) {
+      const facts = factsOf(row);
+      expect(facts).toHaveLength(2);
+      for (const fact of facts) {
+        expect(fact, `"${fact}" says nothing about what it is`).toMatch(/\b(namespace|ready)\b/);
+      }
+    }
+
+    // And in the accessible name of the row itself, not merely somewhere in
+    // the markup: the whole row is one button, and its name is its text.
+    const row = within(notReady()).getByRole("button", { name: /zz-checkout-api/ });
+    expect(row.textContent).toContain("Degraded");
+    expect(row.textContent).toContain("namespace checkout");
+    expect(row.textContent).toContain("9/12 ready");
+    expect(within(notReady()).getByRole("button", { name: /bb-queue-0 namespace payments/ })).toBeTruthy();
+
+    // The namespace comes before the ratio — the design's own column order.
+    expect(factsOf(notReadyRow("cc-log-agent")!)).toEqual(["namespace kube-system", "2/4 ready"]);
+  });
+
+  it("opens the object's own detail when a row is activated", async () => {
+    sick();
+    open();
+    await waitFor(() => expect(notReadyNames()).toHaveLength(6));
+
+    await userEvent.click(within(notReady()).getByRole("button", { name: /zz-checkout-api/ }));
+    expect(store.activeRoute()).toBe("/k/Deployment/checkout/zz-checkout-api");
+
+    await userEvent.click(within(notReady()).getByRole("button", { name: /aa-worker-0/ }));
+    expect(store.activeRoute()).toBe("/k/Pod/checkout/aa-worker-0");
+  });
+
+  it("says that nothing is unhealthy rather than leaving a blank", async () => {
+    // The default fixture's one crash-looping pod, taken away.
+    core.listPods.mockResolvedValue({ pods: PODS.filter((p) => !p.waitingReason) });
+    open();
+    await waitFor(() => expect(within(notReady()).getByText("Nothing is unhealthy")).toBeTruthy());
+
+    expect(notReadyNames()).toEqual([]);
+    expect(within(notReady()).getByText(/prod-eu/)).toBeTruthy();
+  });
+
+  it("does not read a refused list as a healthy cluster", async () => {
+    core.listPods.mockResolvedValue({ pods: [] });
+    core.listDeployments.mockResolvedValue({ error: 'deployments is forbidden: User "dev" cannot list' });
+    open();
+
+    await waitFor(() => expect(within(notReady()).getByText(/forbidden/)).toBeTruthy());
+    // "Nothing is unhealthy" would be a claim nobody checked.
+    expect(within(notReady()).queryByText("Nothing is unhealthy")).toBeNull();
+  });
+
+  it("keeps the rows it does have when one kind is refused, and says which", async () => {
+    core.listPods.mockResolvedValue({ pods: SICK_PODS });
+    core.listStatefulSets.mockResolvedValue({ error: 'statefulsets is forbidden: User "dev" cannot list' });
+    open();
+
+    await waitFor(() => expect(notReadyRow("aa-worker-0")).toBeTruthy());
+    expect(notReadyNames()).toEqual(["aa-worker-0", "bb-queue-0", "dd-mystery-0"]);
+    // The refusal is stated, not swallowed: the list is short for a reason.
+    expect(within(notReady()).getByText(/statefulsets is forbidden/)).toBeTruthy();
+    // And it stays one section's failure — the nodes table is untouched.
+    expect(rowFor("n1")).toBeTruthy();
   });
 });

--- a/packages/ui-next/src/screens/Overview.test.tsx
+++ b/packages/ui-next/src/screens/Overview.test.tsx
@@ -1,0 +1,438 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Only the capability wrappers are replaced. `nodeUsage`, `clusterCapacity`,
+// `nodeStatus`, `podStatus` and `resourceStatusLine` stay real, so every
+// assertion below is against core's own arithmetic and core's own status
+// vocabulary rather than a copy of either.
+const core = vi.hoisted(() => ({
+  listNodes: vi.fn(),
+  nodeMetrics: vi.fn(),
+  listPods: vi.fn(),
+  listNamespaces: vi.fn(),
+  listResource: vi.fn(),
+  clusterFacts: vi.fn(),
+  cordonNode: vi.fn(),
+  drainNode: vi.fn(),
+  copyKubectlCommand: vi.fn(),
+}));
+vi.mock("@srelens/core", async (orig) => ({
+  ...(await orig<typeof import("@srelens/core")>()),
+  ...core,
+}));
+
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+const proto = window.HTMLElement.prototype as unknown as Record<string, unknown>;
+proto.scrollIntoView ??= () => {};
+proto.hasPointerCapture ??= () => false;
+proto.setPointerCapture ??= () => {};
+proto.releasePointerCapture ??= () => {};
+
+import {
+  resourceStatusLine,
+  type ClusterContext,
+  type ClusterFacts,
+  type K8sObject,
+  type NodeSummary,
+  type PodSummary,
+} from "@srelens/core";
+import { Overview } from "./Overview";
+import { ConsoleProvider } from "../console";
+import { defaultState } from "../lib/tabs";
+import * as store from "../lib/tabsStore";
+import { resetContexts, setContexts, setKubeconfigFiles } from "../lib/clusters";
+
+const CTX: ClusterContext = {
+  name: "prod-eu",
+  stableId: "prod",
+  cluster: "prod",
+  server: "https://prod",
+  isCurrent: true,
+};
+
+const ROUTE = "/overview";
+
+function aNode(name: string, over: Partial<NodeSummary> = {}): NodeSummary {
+  return {
+    name,
+    status: "Ready",
+    unschedulable: false,
+    taints: 0,
+    version: "v1.31.4",
+    roles: "worker",
+    age: "10d",
+    allocatableCpuMillicores: 4000,
+    allocatableMemoryMiB: 16000,
+    allocatablePods: 50,
+    ...over,
+  };
+}
+
+function aPod(name: string, node: string, over: Partial<PodSummary> = {}): PodSummary {
+  return {
+    name,
+    namespace: "default",
+    phase: "Running",
+    ready: "1/1",
+    restarts: 0,
+    node,
+    age: "3d",
+    image: "acme/api:1",
+    ...over,
+  };
+}
+
+/** The three-node cluster every test starts from: all Ready, all reporting. */
+const NODES = [aNode("n1"), aNode("n2"), aNode("n3")];
+const METRICS = NODES.map((n) => ({ name: n.name, cpuMillicores: 2800, memoryMiB: 12000 }));
+const PODS = [
+  aPod("api-1", "n1"),
+  aPod("api-2", "n1"),
+  aPod("web-1", "n2"),
+  // Phase `Running` with a waiting container: core calls this
+  // `CrashLoopBackOff` and flags it, which is the one unhealthy pod here.
+  aPod("worker-1", "n3", { phase: "Running", ready: "0/1", waitingReason: "CrashLoopBackOff" }),
+];
+
+const NO_FACTS: ClusterFacts = {
+  context: "prod-eu",
+  provider: "",
+  region: "",
+  metricsServer: { state: "unknown", version: "" },
+};
+
+function quiet() {
+  core.listNodes.mockResolvedValue({ nodes: NODES });
+  core.nodeMetrics.mockResolvedValue({ metrics: METRICS });
+  core.listPods.mockResolvedValue({ pods: PODS });
+  core.listNamespaces.mockResolvedValue({ namespaces: ["default", "kube-system", "prod", "obs"] });
+  core.listResource.mockResolvedValue({ items: [] });
+  core.clusterFacts.mockResolvedValue(NO_FACTS);
+  core.cordonNode.mockResolvedValue({ ok: true });
+  core.drainNode.mockResolvedValue({ evicted: 3, skipped: 0 });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  quiet();
+  resetContexts();
+  setContexts([CTX]);
+  setKubeconfigFiles(["/home/u/.kube/config"]);
+  store.setState(defaultState([CTX]));
+});
+
+function open() {
+  store.openTab(ROUTE);
+  return render(
+    <ConsoleProvider>
+      <Overview route={ROUTE} />
+    </ConsoleProvider>,
+  );
+}
+
+/** One tile of the capacity strip, found by the label above its figure. */
+function tile(label: string): HTMLElement {
+  const strip = document.querySelector('[data-slot="capacity"]');
+  if (!strip) throw new Error("no capacity strip on screen");
+  const found = within(strip as HTMLElement).getByText(label).closest(".stat");
+  if (!found) throw new Error(`no ${label} tile`);
+  return found as HTMLElement;
+}
+
+const value = (label: string) => tile(label).querySelector(".stat-value")?.textContent;
+const caption = (label: string) => {
+  const parts = Array.from(tile(label).children);
+  // The delta is the third child when there is one — label, value, delta.
+  return parts.length > 2 ? (parts[2].textContent ?? null) : null;
+};
+const tone = (label: string) => tile(label).getAttribute("data-tone");
+
+const rowFor = (name: string) => screen.getByText(name).closest("tr") as HTMLElement;
+const headers = () =>
+  Array.from(document.querySelectorAll("thead th")).map((th) => th.textContent?.trim() ?? "");
+const cells = (row: HTMLElement) => Array.from(row.querySelectorAll("td")).map((td) => td.textContent?.trim() ?? "");
+const dialog = () => document.querySelector('[data-slot="dialog-content"]') as HTMLElement | null;
+
+describe("Overview — the capacity strip", () => {
+  it("counts the cluster, and says in the caption what is wrong with it", async () => {
+    open();
+    await waitFor(() => expect(value("Nodes")).toBe("3"));
+
+    // Every node is Ready: the caption says so, in the ok tone.
+    expect(caption("Nodes")).toBe("all ready");
+    expect(tone("Nodes")).toBe("ok");
+
+    // One of the four pods is in CrashLoopBackOff, which core flags.
+    expect(value("Pods")).toBe("4");
+    expect(caption("Pods")).toBe("1 not ready");
+    expect(tone("Pods")).toBe("sev");
+
+    // The one tile the design gives no caption at all.
+    expect(value("Namespaces")).toBe("4");
+    expect(caption("Namespaces")).toBeNull();
+  });
+
+  it("says how many nodes are not ready rather than that they all are", async () => {
+    core.listNodes.mockResolvedValue({
+      nodes: [aNode("n1"), aNode("n2", { status: "NotReady" }), aNode("n3", { status: "NotReady" })],
+    });
+    open();
+
+    await waitFor(() => expect(caption("Nodes")).toBe("2 not ready"));
+    expect(tone("Nodes")).toBe("sev");
+  });
+
+  it("reads a cordoned node as cordoned, not as not ready", async () => {
+    core.listNodes.mockResolvedValue({
+      nodes: [aNode("n1"), aNode("n2"), aNode("n3", { unschedulable: true })],
+    });
+    open();
+
+    await waitFor(() => expect(caption("Nodes")).toBe("1 cordoned"));
+    expect(tone("Nodes")).toBe("warn");
+  });
+
+  it("shows CPU and memory as a share of what the cluster allocated", async () => {
+    open();
+
+    // 3 nodes x 2800m of 4000m allocatable.
+    await waitFor(() => expect(value("CPU")).toBe("70%"));
+    expect(caption("CPU")).toBe("8.4 / 12 cores");
+    expect(tone("CPU")).toBe("warn");
+
+    // 3 nodes x 12000MiB of 16000MiB allocatable.
+    expect(value("Memory")).toBe("75%");
+    expect(caption("Memory")).toBe("35.2Gi / 46.9Gi");
+    expect(tone("Memory")).toBe("warn");
+  });
+
+  it("qualifies a partial total instead of showing it as the whole cluster", async () => {
+    // Two of three nodes reported: the sums describe those two only.
+    core.nodeMetrics.mockResolvedValue({ metrics: METRICS.slice(0, 2) });
+    open();
+
+    await waitFor(() => expect(value("CPU")).toBe("70%"));
+    expect(caption("CPU")).toBe("5.6 / 8 cores · 2 of 3 nodes reporting");
+    expect(caption("Memory")).toBe("23.4Gi / 31.3Gi · 2 of 3 nodes reporting");
+  });
+
+  it("reads a cluster with no metrics as no reading, never as 0%", async () => {
+    core.nodeMetrics.mockResolvedValue({ error: "the server could not find the requested resource" });
+    open();
+
+    await waitFor(() => expect(value("CPU")).toBe("No reading"));
+    expect(value("Memory")).toBe("No reading");
+    // No figure at all, and no caption pretending to a total.
+    expect(caption("CPU")).toBeNull();
+    expect(caption("Memory")).toBeNull();
+    expect(screen.queryByText("0%")).toBeNull();
+    // The absence is the rail's to state, once — not five tiles announcing it.
+    expect(screen.queryByText(/metrics-server/i)).toBeNull();
+  });
+
+  it("does not count a refused list as an empty cluster", async () => {
+    core.listNamespaces.mockResolvedValue({ error: "namespaces is forbidden" });
+    open();
+
+    await waitFor(() => expect(value("Namespaces")).toBe("No reading"));
+    // The other tiles are untouched by that one refusal.
+    expect(value("Nodes")).toBe("3");
+    expect(value("Pods")).toBe("4");
+  });
+});
+
+describe("Overview — the nodes table", () => {
+  it("draws the design's columns, in its order", async () => {
+    open();
+    await waitFor(() => expect(rowFor("n1")).toBeTruthy());
+    expect(headers()).toEqual(["Name", "Pool", "State", "CPU", "Memory", "Pods", ""]);
+  });
+
+  it("reads each node's own state, usage and pod count", async () => {
+    core.listNodes.mockResolvedValue({ nodes: [aNode("n1")] });
+    core.nodeMetrics.mockResolvedValue({
+      metrics: [{ name: "n1", cpuMillicores: 3520, memoryMiB: 11840 }],
+    });
+    open();
+
+    await waitFor(() => expect(rowFor("n1")).toBeTruthy());
+    const row = rowFor("n1");
+    // 3520/4000 = 88%, 11840/16000 = 74%, two of the four pods are on n1.
+    expect(within(row).getByRole("meter", { name: "n1 CPU" }).getAttribute("aria-valuetext")).toBe("88%");
+    expect(within(row).getByRole("meter", { name: "n1 memory" }).getAttribute("aria-valuetext")).toBe("74%");
+    expect(cells(row)[5]).toBe("2/50");
+    expect(within(row).getByText("Ready")).toBeTruthy();
+  });
+
+  it("takes the state word and its tone from core, never from a table of its own", async () => {
+    core.listNodes.mockResolvedValue({
+      nodes: [aNode("n1", { unschedulable: true }), aNode("n2", { status: "NotReady" }), aNode("n3")],
+    });
+    open();
+    await waitFor(() => expect(rowFor("n1")).toBeTruthy());
+
+    /** The same node as a fetched object, read by the function a detail pane reads. */
+    const asObject = (ready: boolean, unschedulable: boolean): K8sObject =>
+      ({
+        apiVersion: "v1",
+        kind: "Node",
+        metadata: { name: "n" },
+        spec: { unschedulable },
+        status: { conditions: [{ type: "Ready", status: ready ? "True" : "False" }] },
+      }) as unknown as K8sObject;
+
+    const cordoned = resourceStatusLine("Node", asObject(true, true));
+    const broken = resourceStatusLine("Node", asObject(false, false));
+    const healthy = resourceStatusLine("Node", asObject(true, false));
+    expect([cordoned, broken, healthy].every(Boolean)).toBe(true);
+
+    // The word AND the tone, for all three states core distinguishes: a
+    // cordoned node is warning, a NotReady one is danger, and a hand-paired
+    // table that called them both "not Ready, so warn" would disagree here.
+    const pill = (node: string, word: string) =>
+      within(rowFor(node)).getByText(word).closest(".status");
+    expect(pill("n1", cordoned!.status)?.getAttribute("data-kind")).toBe(cordoned!.health);
+    expect(pill("n2", broken!.status)?.getAttribute("data-kind")).toBe(broken!.health);
+    expect(pill("n3", healthy!.status)?.getAttribute("data-kind")).toBe(healthy!.health);
+    expect(cordoned!.health).not.toBe(broken!.health);
+
+    // Coloured and bold only where core called the state bad.
+    expect(pill("n1", cordoned!.status)?.getAttribute("data-bad")).toBe("true");
+    expect(pill("n2", broken!.status)?.getAttribute("data-bad")).toBe("true");
+    expect(pill("n3", healthy!.status)?.getAttribute("data-bad")).toBeNull();
+  });
+
+  it("marks only the node that needs attention", async () => {
+    core.listNodes.mockResolvedValue({ nodes: [aNode("n1"), aNode("n2", { status: "NotReady" })] });
+    open();
+    await waitFor(() => expect(rowFor("n2")).toBeTruthy());
+
+    expect(within(rowFor("n2")).getByText("Needs attention")).toBeTruthy();
+    expect(within(rowFor("n1")).queryByText("Needs attention")).toBeNull();
+  });
+
+  it("reads a node with no metric as no reading, not as an idle node", async () => {
+    core.nodeMetrics.mockResolvedValue({ metrics: [METRICS[0]] });
+    open();
+    await waitFor(() => expect(rowFor("n2")).toBeTruthy());
+
+    const row = rowFor("n2");
+    expect(cells(row)[3]).toBe("No reading");
+    expect(cells(row)[4]).toBe("No reading");
+    // Not an empty meter, which reads as a measured zero.
+    expect(within(row).queryByRole("meter")).toBeNull();
+    // The node that did report still has both of its meters.
+    expect(within(rowFor("n1")).getByRole("meter", { name: "n1 CPU" })).toBeTruthy();
+  });
+
+  it("reads a node that reported no allocatable pods as no reading, not as 2/0", async () => {
+    core.listNodes.mockResolvedValue({ nodes: [aNode("n1", { allocatablePods: 0 })] });
+    open();
+    await waitFor(() => expect(rowFor("n1")).toBeTruthy());
+
+    expect(cells(rowFor("n1"))[5]).toBe("No reading");
+    expect(within(rowFor("n1")).queryByText("2/0")).toBeNull();
+  });
+
+  it("passes a node over its limit through at its true percentage", async () => {
+    core.listNodes.mockResolvedValue({ nodes: [aNode("n1")] });
+    core.nodeMetrics.mockResolvedValue({
+      metrics: [{ name: "n1", cpuMillicores: 5600, memoryMiB: 8000 }],
+    });
+    open();
+    await waitFor(() => expect(rowFor("n1")).toBeTruthy());
+
+    const meter = within(rowFor("n1")).getByRole("meter", { name: "n1 CPU" });
+    // The reading is honest; only the bar the meter draws is clamped.
+    expect(meter.getAttribute("aria-valuetext")).toBe("140%");
+    expect(meter.getAttribute("aria-valuenow")).toBe("100");
+  });
+
+  it("shows nothing in Pool rather than guessing one", async () => {
+    core.listNodes.mockResolvedValue({ nodes: [aNode("eu-w4-c3-standard-a1", { roles: "worker" })] });
+    open();
+    await waitFor(() => expect(rowFor("eu-w4-c3-standard-a1")).toBeTruthy());
+
+    const pool = cells(rowFor("eu-w4-c3-standard-a1"))[1];
+    expect(pool).toBe("—");
+    // Neither the naming convention in the node's name nor its roles.
+    expect(pool).not.toContain("c3-standard");
+    expect(pool).not.toContain("worker");
+  });
+
+  it("keeps the table when the metrics fail, and empties it only when the node list does", async () => {
+    core.nodeMetrics.mockResolvedValue({ error: "metrics API unavailable" });
+    const { unmount } = open();
+    await waitFor(() => expect(rowFor("n1")).toBeTruthy());
+    expect(cells(rowFor("n1"))[3]).toBe("No reading");
+    unmount();
+
+    core.listNodes.mockResolvedValue({ error: "nodes is forbidden" });
+    open();
+    await waitFor(() => expect(screen.getByText(/nodes is forbidden/)).toBeTruthy());
+    // One refused list is one empty section: the namespace count is untouched.
+    expect(value("Namespaces")).toBe("4");
+  });
+});
+
+describe("Overview — the node actions", () => {
+  it("does not drain a node until the drain is confirmed", async () => {
+    open();
+    await waitFor(() => expect(rowFor("n1")).toBeTruthy());
+
+    await userEvent.click(within(rowFor("n1")).getByRole("button", { name: "Drain" }));
+    expect(core.drainNode).not.toHaveBeenCalled();
+
+    const box = dialog();
+    expect(box).toBeTruthy();
+    // The confirm says what will happen, and shows the kubectl it stands for.
+    expect(within(box!).getByText(/evicts every pod/i)).toBeTruthy();
+    expect(
+      within(box!).getByText(
+        "kubectl drain n1 --ignore-daemonsets --delete-emptydir-data --force --context prod-eu",
+      ),
+    ).toBeTruthy();
+
+    await userEvent.click(within(box!).getByRole("button", { name: "Drain" }));
+    await waitFor(() => expect(core.drainNode).toHaveBeenCalledWith("prod-eu", "n1"));
+    expect(core.drainNode).toHaveBeenCalledTimes(1);
+  });
+
+  it("cordons behind a confirm, and offers to uncordon a node already cordoned", async () => {
+    core.listNodes.mockResolvedValue({ nodes: [aNode("n1"), aNode("n2", { unschedulable: true })] });
+    open();
+    await waitFor(() => expect(rowFor("n1")).toBeTruthy());
+
+    await userEvent.click(within(rowFor("n1")).getByRole("button", { name: "Cordon" }));
+    expect(core.cordonNode).not.toHaveBeenCalled();
+    expect(within(dialog()!).getByText("kubectl cordon n1 --context prod-eu")).toBeTruthy();
+    await userEvent.click(within(dialog()!).getByRole("button", { name: "Cordon" }));
+    await waitFor(() => expect(core.cordonNode).toHaveBeenCalledWith("prod-eu", "n1", true));
+
+    // The cordoned node is offered the other direction, not the same one again.
+    expect(within(rowFor("n2")).queryByRole("button", { name: "Cordon" })).toBeNull();
+    await userEvent.click(within(rowFor("n2")).getByRole("button", { name: "Uncordon" }));
+    await userEvent.click(within(dialog()!).getByRole("button", { name: "Uncordon" }));
+    await waitFor(() => expect(core.cordonNode).toHaveBeenCalledWith("prod-eu", "n2", false));
+  });
+
+  it("keeps the dialog open with the reason when a drain fails", async () => {
+    core.drainNode.mockResolvedValue({ error: "nodes/eviction is forbidden" });
+    open();
+    await waitFor(() => expect(rowFor("n1")).toBeTruthy());
+
+    await userEvent.click(within(rowFor("n1")).getByRole("button", { name: "Drain" }));
+    await userEvent.click(within(dialog()!).getByRole("button", { name: "Drain" }));
+
+    await waitFor(() => expect(within(dialog()!).getByText(/nodes\/eviction is forbidden/)).toBeTruthy());
+    // Still open, so nothing reads as having succeeded.
+    expect(dialog()).toBeTruthy();
+  });
+});

--- a/packages/ui-next/src/screens/Overview.tsx
+++ b/packages/ui-next/src/screens/Overview.tsx
@@ -1,0 +1,617 @@
+import { useCallback, useMemo, useState } from "react";
+import {
+  copyKubectlCommand,
+  cordonNode,
+  drainNode,
+  formatStorageSize,
+  notify,
+  podStatus,
+  toKubectl,
+  type ClusterCapacity,
+  type ClusterContext,
+  type HealthKind,
+  type NodeSummary,
+  type NodeUsage,
+  type PodSummary,
+} from "@srelens/core";
+import {
+  ActionBar,
+  Button,
+  ConfirmDialog,
+  ErrorState,
+  KubectlPreview,
+  LoadingState,
+  Meter,
+  Panel,
+  Screen,
+  Stat,
+  StatusPill,
+  Table,
+  loadTone,
+  statusTone,
+  type ActionBarAction,
+  type Column,
+  type Tone,
+} from "@srelens/ui-kit";
+import { useConsole } from "../console";
+import { useActiveContext } from "../lib/clusters";
+import { detailRoute } from "../lib/detailRoute";
+import { Icons } from "../lib/icons";
+import { nodeVerdict, podFlagged } from "../lib/kinds/columns";
+import { ROW_ACTION_LABEL } from "../lib/kinds/rowActions";
+import { UnhealthyDot } from "../lib/kinds/rowAffordances";
+import { useOverview, type Overview as OverviewData, type OverviewNodes } from "../lib/overview";
+import { describe } from "../lib/routes";
+import { openTab } from "../lib/tabsStore";
+import { NoClusterScreen } from "./resourceShell";
+
+/**
+ * What a figure says when there is no reading behind it.
+ *
+ * `null` from `nodeUsage`/`clusterCapacity` means nobody measured — no
+ * metrics-server, a node that has not been scraped, a list that was refused.
+ * `0%` is a measurement, and it reads as an idle cluster; an empty meter reads
+ * as one too. This screen is the last layer, and the place the distinction
+ * would be lost, so absence gets words rather than a zero.
+ *
+ * The words say only that there is no reading, never why. WHY is the rail's to
+ * state, once — a screen where five tiles and two columns each announce a
+ * missing metrics-server has said it seven times and explained it nowhere.
+ */
+const NO_READING = "No reading";
+
+/** A fact the cluster did not carry. Never a guess in its place. */
+const UNKNOWN = "—";
+
+/** The header's one action, verbatim from the design (§7). */
+const SUMMARISE_LABEL = "Summarise";
+const SUMMARISE = "Summarise the health of this cluster";
+
+/** This screen's own words for the two node actions. Nothing else renders them. */
+const NODE_ACTION_LABEL = {
+  cordon: "Cordon",
+  uncordon: "Uncordon",
+  drain: "Drain",
+} as const;
+
+/** One node, flattened so the table can key, sort and filter on its fields. */
+type NodeRow = NodeSummary & { usage: NodeUsage };
+
+/**
+ * `/overview` — the cluster overview (§7).
+ *
+ * Two of its three left-hand sections are here: the capacity strip and the
+ * nodes table. `Not ready` and the `At a glance` rail arrive with their own
+ * tasks and slot in where this file says so.
+ *
+ * Split in two the way `Events.tsx` and `Workloads.tsx` are: with no cluster
+ * in focus there is no context name to load anything for, and a hook cannot be
+ * skipped, so the guard returns before any of them runs.
+ */
+export function Overview({ route }: { route: string }) {
+  const context = useActiveContext();
+  const title = describe(route, context?.name).title;
+
+  if (!context) {
+    return <NoClusterScreen title={title} noun="nodes" />;
+  }
+
+  return <ClusterOverview title={title} context={context} />;
+}
+
+function ClusterOverview({ title, context }: { title: string; context: ClusterContext }) {
+  // Core takes a context *name*; the workspace holds a `stableId`. The two are
+  // never interchangeable — see `lib/clusters`.
+  const name = context.name;
+  const overview = useOverview(name);
+  const { ask } = useConsole();
+  const Sparkle = Icons.ask;
+
+  // `<cluster name> / <provider>`, and just the name until the facts answer.
+  // A provider row that said "unknown" would look like an answer; an absent
+  // one says nothing, which is what the cluster said.
+  const provider = overview.facts.facts?.provider ?? "";
+
+  return (
+    <Screen
+      title={title}
+      eyebrow={provider ? `${name} / ${provider}` : name}
+      actions={
+        // Exactly one header action, per §7. A `Button` rather than the row's
+        // `AskChip` for the reason `Events.tsx` gives: the chip is invisible
+        // until its row is hovered, which is right for one of forty rows and
+        // invisible on a toolbar. The visible word is the design's; the
+        // question it will actually send is the accessible name.
+        <Button
+          type="button"
+          size="sm"
+          aria-label={`${SUMMARISE_LABEL}: ${SUMMARISE}`}
+          title={`${SUMMARISE_LABEL}: ${SUMMARISE}`}
+          onClick={() => ask(SUMMARISE)}
+        >
+          <Sparkle size={12} aria-hidden="true" />
+          {SUMMARISE_LABEL}
+        </Button>
+      }
+    >
+      {/* A column of sections. The `Not ready` list belongs after the table,
+          and the `At a glance` rail wraps this column — each with its own
+          task, and neither needs any state held here. */}
+      <div className="flex flex-col gap-3">
+        <Capacity overview={overview} />
+        <Nodes context={name} nodes={overview.nodes} />
+      </div>
+    </Screen>
+  );
+}
+
+/* ---------------------------------------------------------------- capacity */
+
+/** A tile's figure, and the caption that carries the tone. */
+interface Tile {
+  value: string;
+  caption?: string;
+  tone?: Tone;
+}
+
+/**
+ * The five figures across the top: Nodes, Pods, Namespaces, CPU, Memory.
+ *
+ * **The caption carries the tone, never the figure.** `Stat` spends its tone
+ * on the delta alone for the same reason: a row of five coloured numbers shows
+ * the reader nothing about which one to look at, and the judgement — `all
+ * ready`, `8 not ready`, `312 / 460 cores` — is what the colour belongs to.
+ *
+ * Every section reads its own loader, so a refused namespace list empties one
+ * tile and leaves the other four with their numbers.
+ */
+function Capacity({ overview }: { overview: OverviewData }) {
+  const nodes = nodesTile(overview.nodes);
+  const pods = podsTile(overview.pods.pods);
+  const namespaces = overview.namespaces.count;
+  const cpu = cpuTile(overview.nodes.capacity);
+  const memory = memoryTile(overview.nodes.capacity);
+
+  return (
+    <Panel title="Capacity">
+      {/* The row sizes the tiles rather than each tile sizing itself: `Stat`
+          cannot be given a width through `className` (two utilities that both
+          set `flex` resolve by stylesheet order), so the grid does it. */}
+      <div data-slot="capacity" className="grid grid-cols-5 gap-3">
+        <Stat label="Nodes" value={nodes.value} delta={nodes.caption} tone={nodes.tone} />
+        <Stat label="Pods" value={pods.value} delta={pods.caption} tone={pods.tone} />
+        {/* The one tile the design gives no caption: a namespace count has no
+            judgement attached to it. */}
+        <Stat label="Namespaces" value={namespaces === null ? NO_READING : String(namespaces)} />
+        <Stat label="CPU" value={cpu.value} delta={cpu.caption} tone={cpu.tone} />
+        <Stat label="Memory" value={memory.value} delta={memory.caption} tone={memory.tone} />
+      </div>
+    </Panel>
+  );
+}
+
+/**
+ * How many nodes there are, and what is the matter with them.
+ *
+ * The partition and the tone both come from core's `nodeStatus` (through
+ * `nodeVerdict`), never from a word this file pairs with a colour: a NotReady
+ * node is `danger` there and a cordoned one is `warning`, and calling a
+ * cordoned node "not ready" would be a second, wronger reading of a verdict
+ * core already made. `statusTone` maps the health to the kit's token, and is
+ * exported precisely so nobody keeps a private copy of that map.
+ */
+function nodesTile(nodes: OverviewNodes): Tile {
+  if (nodes.status === "loading" || nodes.error) return { value: NO_READING };
+
+  const verdicts = nodes.nodes.map((row) => nodeVerdict(row.node));
+  if (verdicts.length === 0) return { value: "0" };
+
+  const value = String(verdicts.length);
+  const notReady = verdicts.filter((v) => v.health === "danger").length;
+  if (notReady > 0) return { value, caption: `${notReady} not ready`, tone: statusTone("danger") };
+
+  const cordoned = verdicts.filter((v) => v.flagged).length;
+  if (cordoned > 0) return { value, caption: `${cordoned} cordoned`, tone: statusTone("warning") };
+
+  return { value, caption: "all ready", tone: statusTone("success") };
+}
+
+/**
+ * How many pods there are, and how many need a second look.
+ *
+ * `podFlagged` is core's `podStatus` — the same reading the pod list's dot and
+ * the pod detail's header take, so a pod counted here as unhealthy is the one
+ * the `Not ready` list will name. `undefined` pods means the list has not
+ * answered (or was refused), which is not an empty cluster.
+ */
+function podsTile(pods: PodSummary[] | undefined): Tile {
+  if (!pods) return { value: NO_READING };
+  const value = String(pods.length);
+  if (pods.length === 0) return { value };
+
+  const flagged = pods.filter(podFlagged);
+  if (flagged.length === 0) return { value, caption: "all ready", tone: statusTone("success") };
+  return { value, caption: `${flagged.length} not ready`, tone: statusTone(worst(flagged)) };
+}
+
+/**
+ * The worst health among the pods that are flagged — what tones their count.
+ *
+ * Read off the same `podStatus` that flagged them: a Pending pod is amber and
+ * a crash-looping one is red, and a count that mixed them takes the redder of
+ * the two rather than a colour this file chose.
+ */
+function worst(flagged: PodSummary[]): HealthKind {
+  return flagged.some((pod) => podStatus(pod.phase, pod.waitingReason).health === "danger")
+    ? "danger"
+    : "warning";
+}
+
+function cpuTile(capacity: ClusterCapacity): Tile {
+  const cpu = capacity.cpu;
+  if (!cpu || cpu.allocatableMillicores === 0) return { value: NO_READING };
+  const percent = (cpu.usedMillicores / cpu.allocatableMillicores) * 100;
+  return {
+    value: `${Math.round(percent)}%`,
+    caption: `${cores(cpu.usedMillicores)} / ${cores(cpu.allocatableMillicores)} cores${partial(capacity)}`,
+    tone: loadTone(percent),
+  };
+}
+
+function memoryTile(capacity: ClusterCapacity): Tile {
+  const memory = capacity.memory;
+  if (!memory || memory.allocatableMiB === 0) return { value: NO_READING };
+  const percent = (memory.usedMiB / memory.allocatableMiB) * 100;
+  return {
+    value: `${Math.round(percent)}%`,
+    caption: `${mib(memory.usedMiB)} / ${mib(memory.allocatableMiB)}${partial(capacity)}`,
+    tone: loadTone(percent),
+  };
+}
+
+/**
+ * What qualifies a total that is not the whole cluster's.
+ *
+ * `clusterCapacity` sums only the nodes that reported a metric — a node with
+ * no reading is left out of both halves of the ratio rather than folded in as
+ * an idle one — so whenever `nodesReporting` falls short of `nodesTotal` the
+ * figure above describes part of the cluster. It carries the shortfall on the
+ * return value for exactly this: a partial total shown bare reads as a whole
+ * one, and nothing else on screen would contradict it.
+ */
+function partial(capacity: ClusterCapacity): string {
+  if (capacity.nodesReporting >= capacity.nodesTotal) return "";
+  return ` · ${capacity.nodesReporting} of ${capacity.nodesTotal} nodes reporting`;
+}
+
+/** Millicores as cores, to one decimal place and no trailing zero: `8.4`, `12`. */
+function cores(millicores: number): string {
+  return String(Math.round(millicores / 100) / 10);
+}
+
+/** MiB through core's own binary-size formatter, so `35.2Gi` reads as it does elsewhere. */
+function mib(value: number): string {
+  return formatStorageSize(`${value}Mi`);
+}
+
+/* ------------------------------------------------------------------- nodes */
+
+function Nodes({ context, nodes }: { context: string; nodes: OverviewNodes }) {
+  const [pending, setPending] = useState<Pending | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  const rows: NodeRow[] = nodes.nodes.map(({ node, usage }) => ({ ...node, usage }));
+
+  // Stable, so the column set below is built once per context rather than per
+  // render — `Table` re-sorts whenever its `columns` identity changes.
+  const open = useCallback((next: Pending) => {
+    setError("");
+    setPending(next);
+  }, []);
+  const columns = useMemo(() => nodeColumns(context, open), [context, open]);
+
+  function close() {
+    setPending(null);
+    setError("");
+  }
+
+  /**
+   * The action itself, taken only from the confirm.
+   *
+   * Nothing in `actions` below calls core: every pick opens the dialog, and
+   * only this runs. That is what makes "no node is cordoned or drained
+   * without a confirm" true by construction rather than by each button
+   * remembering — the same split `ResourceMenu`'s `pending` makes for the row
+   * menu's destructive entries, and the reason `ConfirmDialog` and
+   * `KubectlPreview` are the kit's rather than this screen's own.
+   */
+  async function confirm() {
+    if (!pending) return;
+    setBusy(true);
+    setError("");
+
+    if (pending.type === "drain") {
+      const out = await drainNode(context, pending.name);
+      setBusy(false);
+      // A refused write leaves the dialog up with the reason in it, rather
+      // than closing as if the node had been drained.
+      if (out.error) {
+        setError(out.error);
+        return;
+      }
+      notify.success(`Drained ${pending.name}`, `${out.evicted ?? 0} evicted, ${out.skipped ?? 0} skipped`);
+    } else {
+      const out = await cordonNode(context, pending.name, pending.unschedulable);
+      setBusy(false);
+      if (out.error) {
+        setError(out.error);
+        return;
+      }
+      notify.success(`${pending.unschedulable ? "Cordoned" : "Uncordoned"} ${pending.name}`);
+    }
+
+    close();
+    // The node's own `unschedulable` has changed; the table is what shows it.
+    nodes.reload();
+  }
+
+  return (
+    <Panel title="Nodes">
+      {nodes.status === "loading" ? (
+        <LoadingState label="Loading nodes" />
+      ) : nodes.error ? (
+        // The node list, and only it. A missing metrics-server is held apart
+        // by the loader (`metricsError`) precisely so it cannot empty this
+        // table; those rows keep their columns and read as no reading.
+        <ErrorState
+          title={`Could not list nodes on ${context}`}
+          detail={nodes.error}
+          onRetry={nodes.reload}
+        />
+      ) : (
+        <Table
+          columns={columns}
+          data={rows}
+          getRowKey={(row) => row.name}
+          emptyText="No nodes"
+          emptyHint={`Nothing in ${context} reported a node.`}
+        />
+      )}
+      {pending && (
+        <NodeConfirm
+          pending={pending}
+          context={context}
+          busy={busy}
+          error={error}
+          onConfirm={() => void confirm()}
+          onCancel={close}
+        />
+      )}
+    </Panel>
+  );
+}
+
+/**
+ * The node's pool — the machine type it was created from.
+ *
+ * `NodeSummary` carries name, status, taints, version, roles, age and the
+ * allocatable trio, and no labels at all, so the
+ * `node.kubernetes.io/instance-type` label this column reads is not on the
+ * wire today and every cell shows nothing. That is the design's own answer for
+ * a node without the label, and the column is deliberately NOT filled from
+ * something else that happens to be present: the mock's pools (`c3-standard`
+ * out of `eu-w4-c3-standard-a1`) are a naming convention, and `roles` is a
+ * different fact entirely. A guess here would be read as the machine type the
+ * cluster is billed for. One label on `NodeSummary` fills it in.
+ */
+function pool(_node: NodeRow): string {
+  return "";
+}
+
+/** The percentage a meter draws, or the words that say there is none. */
+function reading(percent: number | null, ariaLabel: string) {
+  if (percent === null) return NO_READING;
+  // Straight through, unrounded and uncapped. `Meter` clamps the bar it draws
+  // while keeping `aria-valuetext` truthful and rounds only what it shows, so
+  // rounding or clamping here would make a node at 140% indistinguishable
+  // from one exactly at its limit — hiding the case worth seeing.
+  return <Meter value={percent} ariaLabel={ariaLabel} />;
+}
+
+/** `31/50`, or no reading — including for a node that reported no capacity. */
+function podsRead(pods: NodeUsage["pods"]): string {
+  // `{ used: 31, allocatable: 0 }` is a node that reported no allocatable pod
+  // capacity. `31/0` is not a ratio, and it reads as a node overrun rather
+  // than as a denominator nobody supplied.
+  if (!pods || pods.allocatable === 0) return NO_READING;
+  return `${pods.used}/${pods.allocatable}`;
+}
+
+function nodeColumns(context: string, open: (pending: Pending) => void): Column<NodeRow>[] {
+  return [
+    {
+      key: "name",
+      header: "Name",
+      sortable: true,
+      render: (row) => (
+        <span className="flex items-center gap-1.5">
+          {nodeVerdict(row).flagged ? (
+            <UnhealthyDot />
+          ) : (
+            // The dot's width, kept so a healthy node's name lines up under a
+            // flagged one's rather than sliding left.
+            <span aria-hidden="true" className="h-1.5 w-1.5 shrink-0" />
+          )}
+          <span className="truncate">{row.name}</span>
+        </span>
+      ),
+    },
+    { key: "pool", header: "Pool", sortable: true, getValue: pool, render: (row) => pool(row) || UNKNOWN },
+    {
+      key: "state",
+      header: "State",
+      sortable: true,
+      getValue: (row) => nodeVerdict(row).status,
+      // The word AND the tone are core's `nodeStatus`, through the same
+      // `nodeVerdict` the nodes list reads — including the cordoned case,
+      // which it spells the way kubectl does. `tinted` is the design's
+      // asymmetry: the word is coloured only when core called the state bad.
+      render: (row) => {
+        const verdict = nodeVerdict(row);
+        return <StatusPill status={verdict.status} kind={verdict.health} tinted />;
+      },
+    },
+    {
+      key: "cpu",
+      header: "CPU",
+      sortable: true,
+      // `-1` puts a node with no reading below every real one, rather than in
+      // among the idle ones — the same rule the nodes list sorts metrics by.
+      getSortValue: (row) => row.usage.cpuPercent ?? -1,
+      render: (row) => reading(row.usage.cpuPercent, `${row.name} CPU`),
+    },
+    {
+      key: "memory",
+      header: "Memory",
+      sortable: true,
+      getSortValue: (row) => row.usage.memoryPercent ?? -1,
+      render: (row) => reading(row.usage.memoryPercent, `${row.name} memory`),
+    },
+    {
+      key: "pods",
+      header: "Pods",
+      sortable: true,
+      align: "end",
+      getSortValue: (row) => row.usage.pods?.used ?? -1,
+      render: (row) => podsRead(row.usage.pods),
+    },
+    {
+      key: "actions",
+      header: "",
+      sortable: false,
+      filterable: false,
+      render: (row) => (
+        <ActionBar actions={nodeActions(context, row, open)} label={`Actions for ${row.name}`} max={2} />
+      ),
+    },
+  ];
+}
+
+/**
+ * The row's actions: two on the bar and the rest behind the overflow, which is
+ * the design's own shape for this table.
+ *
+ * A cordoned node is offered the other direction rather than the same action
+ * again — the state is on the row, so the button can say what it will do.
+ * `Node shell` is in the design's overflow and is not here: it needs the
+ * ephemeral debug-pod flow, which this screen has no path to, and an action
+ * that cannot work is worse than one that is absent.
+ */
+function nodeActions(context: string, row: NodeRow, open: (pending: Pending) => void): ActionBarAction[] {
+  const kubectlBase = { kind: "Node", name: row.name, namespace: null, context } as const;
+  return [
+    row.unschedulable
+      ? {
+          id: "uncordon",
+          label: NODE_ACTION_LABEL.uncordon,
+          onSelect: () => open({ type: "cordon", name: row.name, unschedulable: false }),
+        }
+      : {
+          id: "cordon",
+          label: NODE_ACTION_LABEL.cordon,
+          onSelect: () => open({ type: "cordon", name: row.name, unschedulable: true }),
+        },
+    {
+      id: "drain",
+      label: NODE_ACTION_LABEL.drain,
+      // Danger-toned because it is: every pod on the node is evicted.
+      danger: true,
+      onSelect: () => open({ type: "drain", name: row.name }),
+    },
+    {
+      id: "open",
+      label: ROW_ACTION_LABEL.openTab,
+      onSelect: () => openTab(detailRoute("Node", null, row.name), { clusterName: context }),
+    },
+    {
+      id: "copy",
+      label: ROW_ACTION_LABEL.copy,
+      onSelect: () => void copyKubectlCommand(toKubectl({ ...kubectlBase, action: "get", output: "yaml" })),
+    },
+  ];
+}
+
+/* ---------------------------------------------------------------- confirms */
+
+/** What a picked action is waiting to do, once the confirm is taken. */
+type Pending =
+  | { type: "cordon"; name: string; unschedulable: boolean }
+  | { type: "drain"; name: string };
+
+function NodeConfirm({
+  pending,
+  context,
+  busy,
+  error,
+  onConfirm,
+  onCancel,
+}: {
+  pending: Pending;
+  context: string;
+  busy: boolean;
+  error: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  const drain = pending.type === "drain";
+  const label = drain
+    ? NODE_ACTION_LABEL.drain
+    : pending.unschedulable
+      ? NODE_ACTION_LABEL.cordon
+      : NODE_ACTION_LABEL.uncordon;
+  const command = toKubectl({
+    action: drain ? "drain" : pending.unschedulable ? "cordon" : "uncordon",
+    kind: "Node",
+    name: pending.name,
+    namespace: null,
+    context,
+  });
+
+  return (
+    <ConfirmDialog
+      title={`${label} node?`}
+      // Cordoning is a reversible scheduling change with a button that undoes
+      // it; draining evicts every pod on the node. Only one of the two is
+      // destructive, and colouring both would say nothing about either.
+      danger={drain}
+      busy={busy}
+      confirmLabel={label}
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+      message={
+        <>
+          <p style={{ marginTop: 0 }}>
+            {drain ? (
+              <>
+                Drain <code>{pending.name}</code>? This evicts every pod on the node and stops new
+                ones being scheduled to it.
+              </>
+            ) : pending.unschedulable ? (
+              <>
+                Cordon <code>{pending.name}</code>? No new pods will be scheduled to it; the pods
+                already running there stay.
+              </>
+            ) : (
+              <>
+                Uncordon <code>{pending.name}</code>? It becomes schedulable again.
+              </>
+            )}
+          </p>
+          <KubectlPreview command={command} onCopy={() => void copyKubectlCommand(command)} />
+          {error && <p style={{ color: "var(--sev)" }}>Error: {error}</p>}
+        </>
+      }
+    />
+  );
+}

--- a/packages/ui-next/src/screens/Overview.tsx
+++ b/packages/ui-next/src/screens/Overview.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState, type ReactNode } from "react";
 import {
-  RESOURCE_LABELS,
+  K8S_KIND,
   copyKubectlCommand,
   cordonNode,
   drainNode,
@@ -28,7 +28,6 @@ import {
   KubectlPreview,
   LoadingState,
   Meter,
-  Panel,
   Screen,
   Section,
   SideRail,
@@ -95,6 +94,36 @@ const SUMMARISE = "Summarise the health of this cluster";
 /** §7's rail width, and this screen's alone — see `SideRail`'s note on widths. */
 const RAIL_WIDTH = 286;
 
+/**
+ * How much of a context name the toolbar's eyebrow carries.
+ *
+ * The design's is `PROD-EU / GKE` — two short words. Real kubeconfig contexts
+ * are not: `m01-1786968575165/kubernetes-admin@cluster.local` rendered in full
+ * swamps the bar and pushes the screen's own title along with it.
+ *
+ * A number rather than a CSS truncation because the ellipsis has to fall in the
+ * MIDDLE — see {@link shorten}. `text-overflow` only cuts the tail.
+ */
+const EYEBROW_MAX = 30;
+
+/**
+ * A context name cut to fit, keeping both ends.
+ *
+ * Cutting the tail is the one form that must not be used here: kubeadm names
+ * end `…@cluster.local` on every cluster in a fleet, so `m01-178696…` and
+ * `m02-178701…` are still told apart while `…@cluster.local` on both is not.
+ * Cutting the head loses the opposite half. So the middle goes, and both ends
+ * that distinguish one cluster from another survive.
+ *
+ * Nothing is hidden by it: the rail's `Context` row carries the whole name, one
+ * region away, which is why the header does not need to.
+ */
+function shorten(text: string, max = EYEBROW_MAX): string {
+  if (text.length <= max) return text;
+  const head = Math.ceil((max - 1) / 2);
+  return `${text.slice(0, head)}…${text.slice(text.length - (max - 1 - head))}`;
+}
+
 /** This screen's own words for the two node actions. Nothing else renders them. */
 const NODE_ACTION_LABEL = {
   cordon: "Cordon",
@@ -133,6 +162,10 @@ function ClusterOverview({ title, context }: { title: string; context: ClusterCo
   const overview = useOverview(name);
   const { ask } = useConsole();
   const Sparkle = Icons.ask;
+  // The server version, from the probe the shell already ran at launch — the
+  // same reading the rail's `Version` row takes, not a second call. Absent
+  // until it lands, and the head then reads the cluster's name alone.
+  const version = useInfo(context.stableId)?.version ?? "";
 
   // `<cluster name> / <provider>`, and just the name until the facts answer.
   // A provider row that said "unknown" would look like an answer; an absent
@@ -142,7 +175,7 @@ function ClusterOverview({ title, context }: { title: string; context: ClusterCo
   return (
     <Screen
       title={title}
-      eyebrow={provider ? `${name} / ${provider}` : name}
+      eyebrow={provider ? `${shorten(name)} / ${provider}` : shorten(name)}
       // The rail is full height beside the main column, so the body fills and
       // the column below scrolls inside itself rather than the page scrolling
       // the rail away with it.
@@ -165,9 +198,24 @@ function ClusterOverview({ title, context }: { title: string; context: ClusterCo
         </Button>
       }
     >
-      <SideRail head="At a glance" width={RAIL_WIDTH} rail={<AtAGlance context={context} overview={overview} />}>
-        {/* The column of sections, scrolling inside itself. */}
-        <div className="scroll flex min-h-0 flex-1 flex-col gap-3 p-3">
+      <SideRail
+        head="At a glance"
+        // §7 heads the left pane too, level with the rail's own head:
+        // `<name> · <version>`. The separator goes with the version, so a
+        // cluster nobody has probed yet reads as its name rather than as a
+        // name trailing a dot.
+        mainHead={version ? `${name} · ${version}` : name}
+        width={RAIL_WIDTH}
+        rail={<AtAGlance context={context} overview={overview} />}
+      >
+        {/* The column of bands, scrolling inside itself.
+
+            NO PADDING AND NO GAP, and both are the design rather than an
+            oversight. The bands are direct siblings so `.section + .section`
+            rules between them; a gap would put daylight where the design has
+            one hairline, and a pad would inset every band inside a second
+            margin the rail beside it does not have. */}
+        <div className="scroll flex min-h-0 flex-1 flex-col">
           <Capacity overview={overview} />
           <Nodes context={name} nodes={overview.nodes} />
           <NotReady context={name} overview={overview} />
@@ -206,7 +254,7 @@ function AtAGlance({ context, overview }: { context: ClusterContext; overview: O
       <ControlPlane context={context} facts={overview.facts} />
       <ObjectsByKind context={context.name} objects={overview.objects} />
       <OpenIncidents />
-      <Section title="Fleet">
+      <Section title="Fleet" smallCaps>
         <Fleet clusters={clusters} active={context} />
       </Section>
     </>
@@ -287,7 +335,7 @@ function ControlPlane({ context, facts }: { context: ClusterContext; facts: Over
   if (metrics) rows.push(["Metrics server", metrics]);
 
   return (
-    <Section title="Control plane">
+    <Section title="Control plane" smallCaps>
       <KVList rows={rows} />
       {/* The facts call itself failing is not the same as a cluster that named
           none, and the rows above cannot tell the reader which happened. */}
@@ -301,44 +349,50 @@ function ControlPlane({ context, facts }: { context: ClusterContext; facts: Over
  *
  * A button per row rather than a `KV`: §7 draws the counts as a navigation
  * list, and the accessible name is computed from the words already on screen
- * ("Deployments 25") rather than from a second string that can drift from
+ * ("Deployment 25") rather than from a second string that can drift from
  * them. `ReasonRail` settled the same shape for the events rail.
  *
- * **A kind that could not be counted shows no number and says so.** `0` is a
- * number a reader will believe, and a refused list and an empty cluster are
- * the same picture with opposite meanings. The em dash asks the question and
- * the line beneath answers it.
+ * **The label is the KIND, singular — `K8S_KIND`, not `RESOURCE_LABELS`.**
+ * The sidebar's plurals name a list you are about to open; a row here names
+ * the kind the number counts, and the design writes `Deployment 25`. The two
+ * tables already exist in core beside each other, so this is a choice of which
+ * question is being answered rather than a table of this screen's own.
+ *
+ * **A kind that could not be counted shows no number and says so on its own
+ * row.** `0` is a number a reader will believe, and a refused list and an
+ * empty cluster are the same picture with opposite meanings. The em dash asks
+ * the question, and the reason sits under the row that could not answer —
+ * beside it, the way `Fleet` puts an unreachable cluster's reason on that
+ * cluster's row, rather than as a paragraph under the section naming kinds a
+ * second time.
  */
 function ObjectsByKind({ context, objects }: { context: string; objects: ObjectCounts }) {
-  const refused = objects.counts.filter((count) => count.error);
-
   return (
-    <Section title="Objects by kind">
-      {/* Pulled back out to the section's own inset, so the row's text lines
-          up with the label column of the `Control plane` rows above it and
-          the hover fill still bleeds the full width of the block. */}
-      <div className="-mx-2">
-        {objects.counts.map(({ slug, count }) => (
+    <Section title="Objects by kind" smallCaps padded={false}>
+      {objects.counts.map(({ slug, count, error }) => (
+        <div key={slug}>
           <Button
-            key={slug}
             type="button"
             variant="ghost"
             // `.ns-row` is the design's flat row and follows `.btn` in the
             // stylesheet, so the row's padding, width and alignment win while
             // `ghost` keeps the border off — see `ReasonRail`.
-            className="ns-row rounded font-normal"
+            // `px-3` rather than `.ns-row`'s own 0.5rem: the band is unpadded,
+            // so the row itself has to hold the 0.75rem inset that lines this
+            // label up with the `Control plane` keys above it. A utility beats
+            // a components-layer class by layer order, not by source order, so
+            // this is decided rather than a coin flip.
+            className="ns-row rounded px-3 font-normal"
             onClick={() => openTab(`/k/${slug}`, { clusterName: context })}
           >
-            <span className="flex min-w-0 flex-1 truncate">{RESOURCE_LABELS[slug]}</span>
+            <span className="flex min-w-0 flex-1 truncate">{K8S_KIND[slug]}</span>
             <span className="path text-faint">{count === null ? UNKNOWN : count}</span>
           </Button>
-        ))}
-      </div>
-      {refused.length > 0 && (
-        <p className="text-faint">
-          Could not count {refused.map(({ slug }) => RESOURCE_LABELS[slug]).join(", ")}.
-        </p>
-      )}
+          {error && (
+            <p className="path px-3 pb-1 text-faint">Could not count {K8S_KIND[slug]}: {error}</p>
+          )}
+        </div>
+      ))}
     </Section>
   );
 }
@@ -359,10 +413,15 @@ function ObjectsByKind({ context, objects }: { context: string; objects: ObjectC
  */
 function OpenIncidents() {
   return (
-    <Section title="Open incidents">
+    <Section title="Open incidents" smallCaps padded={false}>
+      {/* The rail-sized form. The page-sized one spends `py-10` on padding
+          around three wrapped lines, and in a 286px rail that is enough to
+          push `Fleet` below the fold — a section stating an absence taking
+          the space from one with something to say. */}
       <EmptyState
+        compact
         title="No incident feed yet"
-        hint="Kubernetes reports no incident's title, severity or trend. srelens will grow its own incidents; until then this stays empty on purpose."
+        hint="Kubernetes reports no incident's title, severity or trend. srelens will grow its own."
       />
     </Section>
   );
@@ -396,11 +455,15 @@ function Capacity({ overview }: { overview: OverviewData }) {
   const memory = memoryTile(overview.nodes.capacity);
 
   return (
-    <Panel title="Capacity">
+    <Section title="Capacity" smallCaps padded={false}>
       {/* The row sizes the tiles rather than each tile sizing itself: `Stat`
           cannot be given a width through `className` (two utilities that both
-          set `flex` resolve by stylesheet order), so the grid does it. */}
-      <div data-slot="capacity" className="grid grid-cols-5 gap-3">
+          set `flex` resolve by stylesheet order), so the grid does it.
+
+          NO GAP. `.stat + .stat` draws a hairline between the tiles, which is
+          the design's divider; a gap would put daylight either side of it and
+          turn one strip into five cells. */}
+      <div data-slot="capacity" className="grid grid-cols-5">
         <Stat label="Nodes" value={nodes.value} delta={nodes.caption} tone={nodes.tone} />
         <Stat label="Pods" value={pods.value} delta={pods.caption} tone={pods.tone} />
         {/* The one tile the design gives no caption: a namespace count has no
@@ -409,7 +472,7 @@ function Capacity({ overview }: { overview: OverviewData }) {
         <Stat label="CPU" value={cpu.value} delta={cpu.caption} tone={cpu.tone} />
         <Stat label="Memory" value={memory.value} delta={memory.caption} tone={memory.tone} />
       </div>
-    </Panel>
+    </Section>
   );
 }
 
@@ -519,12 +582,65 @@ function mib(value: number): string {
 
 /* ------------------------------------------------------------------- nodes */
 
+/**
+ * How many node rows this band draws before it stops.
+ *
+ * **A dashboard section is not an inventory.** The design's frame shows five
+ * rows; a live cluster the user ran this against has 113, and every one of
+ * them rendered — which pushed `Not ready`, the section that says what is
+ * actually wrong, entirely off the screen. `/k/nodes` is the screen for the
+ * whole list, and this one is a summary of it.
+ *
+ * Ten rather than five: five is the frame's own count on a 42-node cluster,
+ * and a summary that shows fewer rows than the design drew is its own
+ * regression on the ordinary case.
+ */
+const NODE_ROWS = 10;
+
+/**
+ * The order a summary of nodes has to be in: the ones worth looking at first.
+ *
+ * Alphabetical is what a list of 113 nodes arrives in, and the first ten of
+ * those tell a reader nothing — the cordoned node and the one at 94% are as
+ * likely to be at the end as anywhere. So the band sorts before it caps, and
+ * what it sorts by is:
+ *
+ * 1. **core's verdict**, through the same `nodeVerdict` the State column
+ *    draws — a NotReady node above a cordoned one above a healthy one. Not a
+ *    predicate of this file's: `SEVERITY` is the `Not ready` list's own order
+ *    over `HealthKind`, reused rather than restated.
+ * 2. **the hotter of its two readings**, so among nodes core is content with,
+ *    the one at 94% CPU comes before the one at 8%. A node with NO reading
+ *    sorts as `-1` — below every measured node rather than among the idle
+ *    ones — which is the rule the CPU column already sorts by.
+ * 3. **the name**, so the order is stable between renders.
+ *
+ * The reader can still sort the table by any column; that reorders the rows
+ * this chose, and the caption underneath says how many were chosen out of how
+ * many there are.
+ */
+function worstFirst(a: NodeRow, b: NodeRow): number {
+  const health = SEVERITY[nodeVerdict(a).health] - SEVERITY[nodeVerdict(b).health];
+  if (health !== 0) return health;
+  const load = hottest(b) - hottest(a);
+  if (load !== 0) return load;
+  return a.name.localeCompare(b.name);
+}
+
+/** The higher of a node's two readings, or `-1` when it reported neither. */
+function hottest(row: NodeRow): number {
+  return Math.max(row.usage.cpuPercent ?? -1, row.usage.memoryPercent ?? -1);
+}
+
 function Nodes({ context, nodes }: { context: string; nodes: OverviewNodes }) {
   const [pending, setPending] = useState<Pending | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
 
-  const rows: NodeRow[] = nodes.nodes.map(({ node, usage }) => ({ ...node, usage }));
+  const all: NodeRow[] = nodes.nodes.map(({ node, usage }) => ({ ...node, usage }));
+  // Sorted on a copy: `nodes.nodes` is the loader's array and shared with the
+  // capacity tiles, which count off it.
+  const rows = [...all].sort(worstFirst).slice(0, NODE_ROWS);
 
   // Stable, so the column set below is built once per context rather than per
   // render — `Table` re-sorts whenever its `columns` identity changes.
@@ -580,7 +696,7 @@ function Nodes({ context, nodes }: { context: string; nodes: OverviewNodes }) {
   }
 
   return (
-    <Panel title="Nodes">
+    <Section title="Nodes" smallCaps padded={false}>
       {nodes.status === "loading" ? (
         <LoadingState label="Loading nodes" />
       ) : nodes.error ? (
@@ -593,13 +709,31 @@ function Nodes({ context, nodes }: { context: string; nodes: OverviewNodes }) {
           onRetry={nodes.reload}
         />
       ) : (
-        <Table
-          columns={columns}
-          data={rows}
-          getRowKey={(row) => row.name}
-          emptyText="No nodes"
-          emptyHint={`Nothing in ${context} reported a node.`}
-        />
+        <>
+          <Table
+            columns={columns}
+            data={rows}
+            getRowKey={(row) => row.name}
+            emptyText="No nodes"
+            emptyHint={`Nothing in ${context} reported a node.`}
+          />
+          {/* A cap the reader cannot see is a lie by omission: the band would
+              look like the whole cluster. It says what it is showing, what it
+              chose them by, and offers the screen that has the rest. */}
+          {all.length > rows.length && (
+            <Button
+              type="button"
+              variant="ghost"
+              className="ns-row rounded px-3 font-normal"
+              onClick={() => openTab("/k/nodes", { clusterName: context })}
+            >
+              <span className="flex min-w-0 flex-1 truncate text-faint">
+                {`Showing ${rows.length} of ${all.length} nodes, worst first`}
+              </span>
+              <span className="path">All nodes</span>
+            </Button>
+          )}
+        </>
       )}
       {pending && (
         <NodeConfirm
@@ -611,7 +745,7 @@ function Nodes({ context, nodes }: { context: string; nodes: OverviewNodes }) {
           onCancel={close}
         />
       )}
-    </Panel>
+    </Section>
   );
 }
 
@@ -636,14 +770,48 @@ function pool(node: NodeRow): string {
   return node.instanceType;
 }
 
+/**
+ * How much room a reading gets, whether or not there is one yet.
+ *
+ * `Meter`'s bar is `w-full`, which has no intrinsic width of its own, so a
+ * table cell sized by its content collapsed the column onto the percentage
+ * beside it and drew a 40px stub. At that size the tone is the one thing the
+ * column exists to show and the one thing nobody can see — 88% red and 41%
+ * green are two short marks. The design gives CPU and MEMORY a wide column
+ * each; ten rems is as much as this table can spare before the row scrolls
+ * sideways.
+ *
+ * **Declared on every cell, including the ones with no reading.** `Table`
+ * measures the natural column widths on the first render that has rows and
+ * PINS them (`table-layout: fixed` from then on), and the node list answers
+ * well before the metrics do — so the first render is all "No reading", and a
+ * width that arrived with the meters arrived after the columns had already
+ * been fixed at the width of those two words. The meters then drew straight
+ * across the columns beside them. Whatever the cell is going to hold, it asks
+ * for the same room from the start.
+ *
+ * On the CONTENT rather than on the column because that is what a table's auto
+ * layout reads: `Column.minWidth` is the floor a drag stops at, and it is not
+ * consulted when the browser sizes the columns.
+ */
+const READING_WIDTH = "min-w-[10rem]";
+
 /** The percentage a meter draws, or the words that say there is none. */
 function reading(percent: number | null, ariaLabel: string) {
-  if (percent === null) return NO_READING;
-  // Straight through, unrounded and uncapped. `Meter` clamps the bar it draws
-  // while keeping `aria-valuetext` truthful and rounds only what it shows, so
-  // rounding or clamping here would make a node at 140% indistinguishable
-  // from one exactly at its limit — hiding the case worth seeing.
-  return <Meter value={percent} ariaLabel={ariaLabel} />;
+  return (
+    <div className={READING_WIDTH}>
+      {percent === null ? (
+        NO_READING
+      ) : (
+        // Straight through, unrounded and uncapped. `Meter` clamps the bar it
+        // draws while keeping `aria-valuetext` truthful and rounds only what
+        // it shows, so rounding or clamping here would make a node at 140%
+        // indistinguishable from one exactly at its limit — hiding the case
+        // worth seeing.
+        <Meter value={percent} ariaLabel={ariaLabel} />
+      )}
+    </div>
+  );
 }
 
 /** `31/50`, or no reading — including for a node that reported no capacity. */
@@ -742,16 +910,24 @@ function nodeActions(context: string, row: NodeRow, open: (pending: Pending) => 
       ? {
           id: "uncordon",
           label: NODE_ACTION_LABEL.uncordon,
+          // The same glyph as `Cordon`, because it is the same switch: the
+          // label is what says which way it is being thrown, and a second
+          // picture for the reverse of one action is a second thing to read.
+          icon: Icons.cordon,
           onSelect: () => open({ type: "cordon", name: row.name, unschedulable: false }),
         }
       : {
           id: "cordon",
+          // The design's crossed circle — nothing new gets scheduled here.
           label: NODE_ACTION_LABEL.cordon,
+          icon: Icons.cordon,
           onSelect: () => open({ type: "cordon", name: row.name, unschedulable: true }),
         },
     {
       id: "drain",
       label: NODE_ACTION_LABEL.drain,
+      // The design's wave — everything flows off the node.
+      icon: Icons.drain,
       // Danger-toned because it is: every pod on the node is evicted.
       danger: true,
       onSelect: () => open({ type: "drain", name: row.name }),
@@ -917,7 +1093,7 @@ function NotReady({ context, overview }: { context: string; overview: OverviewDa
   };
 
   return (
-    <Panel title="Not ready">
+    <Section title="Not ready" smallCaps padded={false}>
       {workloads.status === "loading" || pods.status === "loading" ? (
         <LoadingState label="Checking workloads and pods" />
       ) : failures.length > 0 && rows.length === 0 ? (
@@ -961,7 +1137,7 @@ function NotReady({ context, overview }: { context: string; overview: OverviewDa
           )}
         </>
       )}
-    </Panel>
+    </Section>
   );
 }
 

--- a/packages/ui-next/src/screens/Overview.tsx
+++ b/packages/ui-next/src/screens/Overview.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState, type ReactNode } from "react";
 import {
+  RESOURCE_LABELS,
   copyKubectlCommand,
   cordonNode,
   drainNode,
@@ -10,6 +11,7 @@ import {
   type ClusterCapacity,
   type ClusterContext,
   type HealthKind,
+  type MetricsServerFact,
   type NodeSummary,
   type NodeUsage,
   type PodSummary,
@@ -22,11 +24,14 @@ import {
   ConfirmDialog,
   EmptyState,
   ErrorState,
+  KVList,
   KubectlPreview,
   LoadingState,
   Meter,
   Panel,
   Screen,
+  Section,
+  SideRail,
   Stat,
   StatusPill,
   StatusRow,
@@ -38,7 +43,7 @@ import {
   type Tone,
 } from "@srelens/ui-kit";
 import { useConsole } from "../console";
-import { useActiveContext } from "../lib/clusters";
+import { useActiveContext, useContexts } from "../lib/clusters";
 import { detailRoute } from "../lib/detailRoute";
 import { Icons } from "../lib/icons";
 import {
@@ -52,12 +57,17 @@ import { ROW_ACTION_LABEL } from "../lib/kinds/rowActions";
 import { UnhealthyDot } from "../lib/kinds/rowAffordances";
 import {
   useOverview,
+  type ObjectCounts,
   type Overview as OverviewData,
+  type OverviewFacts,
   type OverviewNodes,
   type OverviewWorkloads,
 } from "../lib/overview";
+import { useInfo } from "../lib/probe";
 import { describe } from "../lib/routes";
-import { openTab } from "../lib/tabsStore";
+import { openTab, useTabs } from "../lib/tabsStore";
+import { LINK_WORD, useWorkspaceView } from "../lib/workspace";
+import { Fleet } from "./overview/Fleet";
 import { NoClusterScreen } from "./resourceShell";
 
 /**
@@ -82,6 +92,9 @@ const UNKNOWN = "—";
 const SUMMARISE_LABEL = "Summarise";
 const SUMMARISE = "Summarise the health of this cluster";
 
+/** §7's rail width, and this screen's alone — see `SideRail`'s note on widths. */
+const RAIL_WIDTH = 286;
+
 /** This screen's own words for the two node actions. Nothing else renders them. */
 const NODE_ACTION_LABEL = {
   cordon: "Cordon",
@@ -95,9 +108,8 @@ type NodeRow = NodeSummary & { usage: NodeUsage };
 /**
  * `/overview` — the cluster overview (§7).
  *
- * All three of its left-hand sections are here: the capacity strip, the nodes
- * table and the `Not ready` list. The `At a glance` rail arrives with its own
- * task and slots in where this file says so.
+ * Its three left-hand sections are here — the capacity strip, the nodes table
+ * and the `Not ready` list — beside the `At a glance` rail's four.
  *
  * Split in two the way `Events.tsx` and `Workloads.tsx` are: with no cluster
  * in focus there is no context name to load anything for, and a hook cannot be
@@ -131,6 +143,10 @@ function ClusterOverview({ title, context }: { title: string; context: ClusterCo
     <Screen
       title={title}
       eyebrow={provider ? `${name} / ${provider}` : name}
+      // The rail is full height beside the main column, so the body fills and
+      // the column below scrolls inside itself rather than the page scrolling
+      // the rail away with it.
+      fill
       actions={
         // Exactly one header action, per §7. A `Button` rather than the row's
         // `AskChip` for the reason `Events.tsx` gives: the chip is invisible
@@ -149,14 +165,206 @@ function ClusterOverview({ title, context }: { title: string; context: ClusterCo
         </Button>
       }
     >
-      {/* A column of sections. The `At a glance` rail wraps this column —
-          its own task, and it needs no state held here. */}
-      <div className="flex flex-col gap-3">
-        <Capacity overview={overview} />
-        <Nodes context={name} nodes={overview.nodes} />
-        <NotReady context={name} overview={overview} />
-      </div>
+      <SideRail head="At a glance" width={RAIL_WIDTH} rail={<AtAGlance context={context} overview={overview} />}>
+        {/* The column of sections, scrolling inside itself. */}
+        <div className="scroll flex min-h-0 flex-1 flex-col gap-3 p-3">
+          <Capacity overview={overview} />
+          <Nodes context={name} nodes={overview.nodes} />
+          <NotReady context={name} overview={overview} />
+        </div>
+      </SideRail>
     </Screen>
+  );
+}
+
+/* -------------------------------------------------------------- the rail */
+
+/**
+ * `At a glance` — the facts about the cluster that are not measurements.
+ *
+ * Four `Section`s and nothing around them. `SideRail` drops what it is handed
+ * straight into one box and `.section + .section` is what rules between them,
+ * so a wrapper per child would break that adjacency and the rail would read as
+ * one undivided block. `AboutKind` renders its sections the same way and for
+ * the same reason; the kit's suite pins it.
+ */
+function AtAGlance({ context, overview }: { context: ClusterContext; overview: OverviewData }) {
+  const contexts = useContexts();
+  const { workspace } = useTabs();
+
+  // The workspace's own order, resolved through the context list — the same
+  // derivation the cluster rail down the edge of the window makes. An id whose
+  // context has gone is skipped rather than drawn as a placeholder; `Fleet`
+  // then puts this cluster back at the head if the list has lost it.
+  const byId = new Map(contexts.map((c) => [c.stableId, c]));
+  const clusters = workspace.clusters
+    .map((id) => byId.get(id))
+    .filter((c): c is ClusterContext => c !== undefined);
+
+  return (
+    <>
+      <ControlPlane context={context} facts={overview.facts} />
+      <ObjectsByKind context={context.name} objects={overview.objects} />
+      <OpenIncidents />
+      <Section title="Fleet">
+        <Fleet clusters={clusters} active={context} />
+      </Section>
+    </>
+  );
+}
+
+/**
+ * What the metrics server row says, or `null` for no row at all.
+ *
+ * **`v1beta1` is the API GROUP's version, and the mock's `v0.7.2` is the
+ * component's.** They are different facts. The component version lives in the
+ * image tag of a Deployment in `kube-system`, which is a read many readers of
+ * this screen are not granted and which would fail differently from everything
+ * around it; that trade was ruled not worth making. Discovery already carries
+ * the group version, it costs nothing, and it is the version that says what
+ * this app will actually be talking to.
+ *
+ * **The mock's `· reporting` is not rendered off this field.** An aggregated
+ * APIService stays registered in discovery while the deployment behind it is
+ * down, so `present` means "the group is registered", not "metrics-server is
+ * answering". The tiles and the node columns are where a missing ANSWER shows
+ * up, as "No reading".
+ *
+ * `unknown` gets no row. It is not `absent`: a cluster nobody could reach has
+ * not told us metrics-server is missing, and drawing that as an absence would
+ * be the rail inventing the one fact it is here to report.
+ */
+function metricsServerRow(fact: MetricsServerFact | undefined): ReactNode {
+  if (!fact) return null;
+  if (fact.state === "absent") {
+    return (
+      <>
+        Not installed
+        {/* Said once, here. The tiles and the node columns read "No reading"
+            and deliberately do not each explain why — a screen where five
+            tiles and two columns announce this has said it seven times and
+            explained it nowhere. */}
+        <span className="block text-faint">No CPU or memory readings without it.</span>
+      </>
+    );
+  }
+  if (fact.state === "present") return fact.version || "Installed";
+  return null;
+}
+
+/**
+ * `Control plane` — six facts about the cluster, of which as many are drawn as
+ * the cluster actually reported.
+ *
+ * **A FACT WITH NOTHING BEHIND IT OMITS ITS ROW.** `provider` and `region`
+ * arrive as empty strings when no node carried them, and on the live cluster
+ * no node carries a region label at all — so this is the ordinary case rather
+ * than an edge one. "Unknown" in the value would look like an answer, and an
+ * em dash reads as one too; silence is what the cluster said.
+ *
+ * The version and the connection come from the probe the shell already ran at
+ * launch, not from a call of this screen's own: `clusterInfo` runs for every
+ * cluster in the rail on every launch, and asking again here would be a second
+ * round trip for a fact already on the machine. Both are absent until it lands,
+ * and absent is honest — nobody has asked yet, which is not the same as
+ * "Disconnected".
+ */
+function ControlPlane({ context, facts }: { context: ClusterContext; facts: OverviewFacts }) {
+  const info = useInfo(context.stableId);
+  const { links } = useWorkspaceView();
+  const link = links[context.stableId];
+
+  const rows: Array<[key: string, value: ReactNode]> = [];
+  if (info?.version) rows.push(["Version", info.version]);
+  if (facts.facts?.provider) rows.push(["Provider", facts.facts.provider]);
+  if (facts.facts?.region) rows.push(["Region", facts.facts.region]);
+  // The one row that is always there: the context is how this screen was
+  // opened, so there is no cluster for which it is unknown.
+  rows.push(["Context", context.name]);
+  // The status bar's own word for the same link, from the one table both read.
+  if (link) rows.push(["Connection", LINK_WORD[link.state]]);
+  const metrics = metricsServerRow(facts.facts?.metricsServer);
+  if (metrics) rows.push(["Metrics server", metrics]);
+
+  return (
+    <Section title="Control plane">
+      <KVList rows={rows} />
+      {/* The facts call itself failing is not the same as a cluster that named
+          none, and the rows above cannot tell the reader which happened. */}
+      {facts.error && <p className="text-faint">Could not read the cluster's facts: {facts.error}</p>}
+    </Section>
+  );
+}
+
+/**
+ * `Objects by kind` — six counts, each a way into that kind's list.
+ *
+ * A button per row rather than a `KV`: §7 draws the counts as a navigation
+ * list, and the accessible name is computed from the words already on screen
+ * ("Deployments 25") rather than from a second string that can drift from
+ * them. `ReasonRail` settled the same shape for the events rail.
+ *
+ * **A kind that could not be counted shows no number and says so.** `0` is a
+ * number a reader will believe, and a refused list and an empty cluster are
+ * the same picture with opposite meanings. The em dash asks the question and
+ * the line beneath answers it.
+ */
+function ObjectsByKind({ context, objects }: { context: string; objects: ObjectCounts }) {
+  const refused = objects.counts.filter((count) => count.error);
+
+  return (
+    <Section title="Objects by kind">
+      {/* Pulled back out to the section's own inset, so the row's text lines
+          up with the label column of the `Control plane` rows above it and
+          the hover fill still bleeds the full width of the block. */}
+      <div className="-mx-2">
+        {objects.counts.map(({ slug, count }) => (
+          <Button
+            key={slug}
+            type="button"
+            variant="ghost"
+            // `.ns-row` is the design's flat row and follows `.btn` in the
+            // stylesheet, so the row's padding, width and alignment win while
+            // `ghost` keeps the border off — see `ReasonRail`.
+            className="ns-row rounded font-normal"
+            onClick={() => openTab(`/k/${slug}`, { clusterName: context })}
+          >
+            <span className="flex min-w-0 flex-1 truncate">{RESOURCE_LABELS[slug]}</span>
+            <span className="path text-faint">{count === null ? UNKNOWN : count}</span>
+          </Button>
+        ))}
+      </div>
+      {refused.length > 0 && (
+        <p className="text-faint">
+          Could not count {refused.map(({ slug }) => RESOURCE_LABELS[slug]).join(", ")}.
+        </p>
+      )}
+    </Section>
+  );
+}
+
+/**
+ * `Open incidents` — a named empty state, and the reason it is empty.
+ *
+ * The mock draws three incidents with titles, severity badges and sparklines.
+ * **No Kubernetes API returns any of that.** There is no object whose title is
+ * "5xx rate rising", no field that says SEV-2, and no series behind the
+ * sparkline; incidents are a product feature the migration plan schedules on
+ * its own, not something this screen could derive from the cluster if it tried
+ * harder. Events come closest and are a different thing — they are per-object,
+ * they expire in an hour, and a list of them is already a screen.
+ *
+ * So the section says what it is. A hole where the mock has content is read as
+ * a bug and reported as one; a stated absence is read as a decision.
+ */
+function OpenIncidents() {
+  return (
+    <Section title="Open incidents">
+      <EmptyState
+        title="No incident feed yet"
+        hint="Kubernetes reports no incident's title, severity or trend. srelens will grow its own incidents; until then this stays empty on purpose."
+      />
+    </Section>
   );
 }
 
@@ -697,9 +905,9 @@ function NotReady({ context, overview }: { context: string; overview: OverviewDa
   const { workloads, pods } = overview;
   const rows = notReadyRows(workloads, pods.pods);
 
-  // `workloads.error` is the whole fan-out failing; `workloads.errors` is one
-  // kind of it. Both are reasons this list may be shorter than the truth.
-  const failures = [pods.error, workloads.error, ...workloads.errors].filter(
+  // `workloads.error` is the whole fan-out failing; `workloads.refusals` is
+  // one kind of it. Both are reasons this list may be shorter than the truth.
+  const failures = [pods.error, workloads.error, ...Object.values(workloads.refusals)].filter(
     (reason): reason is string => reason !== undefined && reason !== "",
   );
 

--- a/packages/ui-next/src/screens/Overview.tsx
+++ b/packages/ui-next/src/screens/Overview.tsx
@@ -13,11 +13,14 @@ import {
   type NodeSummary,
   type NodeUsage,
   type PodSummary,
+  type StatusVerdict,
 } from "@srelens/core";
 import {
   ActionBar,
+  Alert,
   Button,
   ConfirmDialog,
+  EmptyState,
   ErrorState,
   KubectlPreview,
   LoadingState,
@@ -26,6 +29,7 @@ import {
   Screen,
   Stat,
   StatusPill,
+  StatusRow,
   Table,
   loadTone,
   statusTone,
@@ -37,10 +41,21 @@ import { useConsole } from "../console";
 import { useActiveContext } from "../lib/clusters";
 import { detailRoute } from "../lib/detailRoute";
 import { Icons } from "../lib/icons";
-import { nodeVerdict, podFlagged } from "../lib/kinds/columns";
+import {
+  daemonSetVerdict,
+  deploymentVerdict,
+  nodeVerdict,
+  podFlagged,
+  statefulSetVerdict,
+} from "../lib/kinds/columns";
 import { ROW_ACTION_LABEL } from "../lib/kinds/rowActions";
 import { UnhealthyDot } from "../lib/kinds/rowAffordances";
-import { useOverview, type Overview as OverviewData, type OverviewNodes } from "../lib/overview";
+import {
+  useOverview,
+  type Overview as OverviewData,
+  type OverviewNodes,
+  type OverviewWorkloads,
+} from "../lib/overview";
 import { describe } from "../lib/routes";
 import { openTab } from "../lib/tabsStore";
 import { NoClusterScreen } from "./resourceShell";
@@ -80,9 +95,9 @@ type NodeRow = NodeSummary & { usage: NodeUsage };
 /**
  * `/overview` — the cluster overview (§7).
  *
- * Two of its three left-hand sections are here: the capacity strip and the
- * nodes table. `Not ready` and the `At a glance` rail arrive with their own
- * tasks and slot in where this file says so.
+ * All three of its left-hand sections are here: the capacity strip, the nodes
+ * table and the `Not ready` list. The `At a glance` rail arrives with its own
+ * task and slots in where this file says so.
  *
  * Split in two the way `Events.tsx` and `Workloads.tsx` are: with no cluster
  * in focus there is no context name to load anything for, and a hook cannot be
@@ -134,12 +149,12 @@ function ClusterOverview({ title, context }: { title: string; context: ClusterCo
         </Button>
       }
     >
-      {/* A column of sections. The `Not ready` list belongs after the table,
-          and the `At a glance` rail wraps this column — each with its own
-          task, and neither needs any state held here. */}
+      {/* A column of sections. The `At a glance` rail wraps this column —
+          its own task, and it needs no state held here. */}
       <div className="flex flex-col gap-3">
         <Capacity overview={overview} />
         <Nodes context={name} nodes={overview.nodes} />
+        <NotReady context={name} overview={overview} />
       </div>
     </Screen>
   );
@@ -395,18 +410,22 @@ function Nodes({ context, nodes }: { context: string; nodes: OverviewNodes }) {
 /**
  * The node's pool — the machine type it was created from.
  *
- * `NodeSummary` carries name, status, taints, version, roles, age and the
- * allocatable trio, and no labels at all, so the
- * `node.kubernetes.io/instance-type` label this column reads is not on the
- * wire today and every cell shows nothing. That is the design's own answer for
- * a node without the label, and the column is deliberately NOT filled from
- * something else that happens to be present: the mock's pools (`c3-standard`
- * out of `eu-w4-c3-standard-a1`) are a naming convention, and `roles` is a
- * different fact entirely. A guess here would be read as the machine type the
- * cluster is billed for. One label on `NodeSummary` fills it in.
+ * `NodeSummary.instanceType` is the backend's reading of
+ * `node.kubernetes.io/instance-type` (falling back to the deprecated
+ * `beta.kubernetes.io/instance-type`), and an empty string when the node
+ * carries neither. Empty stays empty here and renders as the em dash every
+ * other absent fact on this screen uses: the node said nothing, and a word in
+ * its place would look like an answer.
+ *
+ * Deliberately NOT filled from something else that happens to be present. The
+ * mock's pools (`c3-standard` out of `eu-w4-c3-standard-a1`) are a naming
+ * convention, and `roles` is a different fact entirely; either guess would be
+ * read as the machine type the cluster is billed for. kind's nodes are
+ * containers rather than cloud machines and carry neither label, so an
+ * em-dashed column there is the correct answer rather than a missing one.
  */
-function pool(_node: NodeRow): string {
-  return "";
+function pool(node: NodeRow): string {
+  return node.instanceType;
 }
 
 /** The percentage a meter draws, or the words that say there is none. */
@@ -540,6 +559,202 @@ function nodeActions(context: string, row: NodeRow, open: (pending: Pending) => 
       onSelect: () => void copyKubectlCommand(toKubectl({ ...kubectlBase, action: "get", output: "yaml" })),
     },
   ];
+}
+
+/* --------------------------------------------------------------- not ready */
+
+/**
+ * How bad, as an order.
+ *
+ * Emphatically NOT a ninth hand-paired label/tone table: no word and no colour
+ * is named here. Core has already decided both, and this only says which of
+ * core's verdicts an operator wants to read first — red before amber, and
+ * amber before a state nobody recognised.
+ *
+ * Total over `HealthKind` rather than over the three flagged tones, so a tone
+ * core starts flagging tomorrow sorts somewhere defined instead of `NaN`.
+ */
+const SEVERITY: Record<HealthKind, number> = {
+  danger: 0,
+  warning: 1,
+  neutral: 2,
+  info: 3,
+  success: 4,
+};
+
+/** One unhealthy thing, whatever kind it is. */
+interface NotReadyRow {
+  /** The Kubernetes kind, as `detailRoute` spells it. */
+  kind: string;
+  name: string;
+  namespace: string;
+  /** The word, the tone and the dot — core's, decided together. */
+  verdict: StatusVerdict;
+  /** Ready out of desired, as the row itself reports it: `9/12`. */
+  ratio: string;
+}
+
+/**
+ * The trailing facts, each carrying the noun that says what it is.
+ *
+ * `StatusRow` takes `ReactNode`s and genuinely cannot know what a fact means;
+ * naming them is the caller's job and nobody else's. The design draws the
+ * bare figures of the mock — `checkout   9/12` — which reads to a screen
+ * reader as a row called "Degraded checkout-api checkout 9/12": two values,
+ * no nouns, and no way to tell a namespace from a ratio. `Inspector` settled
+ * the same argument the same way, and for the same reason its facts read
+ * "9/12 ready" rather than "9/12".
+ */
+function facts(row: NotReadyRow): string[] {
+  return [`namespace ${row.namespace}`, `${row.ratio} ready`];
+}
+
+/**
+ * Every unhealthy workload and pod, worst first.
+ *
+ * Two rules, and the section is the two of them:
+ *
+ * **Which rows qualify is core's `flagged`, never a predicate of this file's.**
+ * The verdicts come off `deploymentVerdict`/`statefulSetVerdict`/
+ * `daemonSetVerdict`/`podStatus`, which are the same `scaledStatus` and
+ * `podStatus` that `resourceStatusLine` calls for a fetched object — so a row
+ * here and the detail pane a click away cannot disagree about the same thing.
+ * Badness is read as data, not off the colour: a Deployment scaled to zero is
+ * neutral and absent, a Pending pod is amber and present, and a pod in a phase
+ * core does not recognise is grey and present, because not recognising a state
+ * is not the same as knowing it is fine.
+ *
+ * **The order is severity, not kind.** A list that put every Deployment above
+ * every Pod would bury a crash-looping pod under four healthy-ish rollouts,
+ * and the whole point of the section is that the worst thing is at the top.
+ * Ties break on the name — the three workload lists and the pod list settle
+ * independently, so concatenation order is not stable between renders, and a
+ * list that reshuffled itself under the reader's cursor would be its own bug.
+ */
+function notReadyRows(workloads: OverviewWorkloads, pods: PodSummary[] | undefined): NotReadyRow[] {
+  const rows: NotReadyRow[] = [];
+
+  for (const row of workloads.deployments ?? []) {
+    rows.push({
+      kind: "Deployment",
+      name: row.name,
+      namespace: row.namespace,
+      verdict: deploymentVerdict(row),
+      ratio: row.ready,
+    });
+  }
+  for (const row of workloads.statefulSets ?? []) {
+    rows.push({
+      kind: "StatefulSet",
+      name: row.name,
+      namespace: row.namespace,
+      verdict: statefulSetVerdict(row),
+      ratio: row.ready,
+    });
+  }
+  for (const row of workloads.daemonSets ?? []) {
+    rows.push({
+      kind: "DaemonSet",
+      name: row.name,
+      namespace: row.namespace,
+      verdict: daemonSetVerdict(row),
+      // A DaemonSet reports two numbers where a Deployment reports the string.
+      ratio: `${row.ready}/${row.desired}`,
+    });
+  }
+  for (const row of pods ?? []) {
+    rows.push({
+      kind: "Pod",
+      name: row.name,
+      namespace: row.namespace,
+      verdict: podStatus(row.phase, row.waitingReason),
+      ratio: row.ready,
+    });
+  }
+
+  return rows
+    .filter((row) => row.verdict.flagged)
+    .sort(
+      (a, b) =>
+        SEVERITY[a.verdict.health] - SEVERITY[b.verdict.health] || a.name.localeCompare(b.name),
+    );
+}
+
+/**
+ * `NOT READY` — the unhealthy workloads and pods, in one list.
+ *
+ * It reads two loaders and adds no fetch of its own: the pod list is the one
+ * the Pods tile and the per-node counts already share.
+ *
+ * A refusal never reads as good news. "Nothing is unhealthy" is a claim about
+ * everything that was checked, so a kind that could not be listed is said out
+ * loud — beside the rows when some kinds answered, and in place of them when
+ * none did. Silently showing three rows out of a possible six, or an empty
+ * state for a cluster nobody was allowed to look at, is the failure this
+ * section would be worst at.
+ */
+function NotReady({ context, overview }: { context: string; overview: OverviewData }) {
+  const { workloads, pods } = overview;
+  const rows = notReadyRows(workloads, pods.pods);
+
+  // `workloads.error` is the whole fan-out failing; `workloads.errors` is one
+  // kind of it. Both are reasons this list may be shorter than the truth.
+  const failures = [pods.error, workloads.error, ...workloads.errors].filter(
+    (reason): reason is string => reason !== undefined && reason !== "",
+  );
+
+  const reload = () => {
+    workloads.reload();
+    pods.reload();
+  };
+
+  return (
+    <Panel title="Not ready">
+      {workloads.status === "loading" || pods.status === "loading" ? (
+        <LoadingState label="Checking workloads and pods" />
+      ) : failures.length > 0 && rows.length === 0 ? (
+        <ErrorState
+          title={`Could not check every workload on ${context}`}
+          detail={failures.join(" · ")}
+          onRetry={reload}
+        />
+      ) : (
+        <>
+          {failures.length > 0 && (
+            <Alert tone="warn" title="Some kinds could not be checked">
+              {failures.join(" · ")}
+            </Alert>
+          )}
+          {rows.length === 0 ? (
+            <EmptyState
+              title="Nothing is unhealthy"
+              hint={`Every workload and pod in ${context} is where it should be.`}
+            />
+          ) : (
+            <div className="flex flex-col">
+              {rows.map((row) => (
+                <StatusRow
+                  // Kind and namespace as well as the name: a Deployment and
+                  // its own pod share a prefix, and two namespaces may each
+                  // run a `web`.
+                  key={`${row.kind}/${row.namespace}/${row.name}`}
+                  status={row.verdict.status}
+                  kind={row.verdict.health}
+                  // Data, not a reading of the tone — see `StatusRow`'s prop.
+                  flagged={row.verdict.flagged}
+                  name={row.name}
+                  facts={facts(row)}
+                  onActivate={() =>
+                    openTab(detailRoute(row.kind, row.namespace, row.name), { clusterName: context })
+                  }
+                />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </Panel>
+  );
 }
 
 /* ---------------------------------------------------------------- confirms */

--- a/packages/ui-next/src/screens/Overview.tsx
+++ b/packages/ui-next/src/screens/Overview.tsx
@@ -60,6 +60,7 @@ import {
   type Overview as OverviewData,
   type OverviewFacts,
   type OverviewNodes,
+  type OverviewPods,
   type OverviewWorkloads,
 } from "../lib/overview";
 import { useInfo } from "../lib/probe";
@@ -216,12 +217,44 @@ function ClusterOverview({ title, context }: { title: string; context: ClusterCo
             one hairline, and a pad would inset every band inside a second
             margin the rail beside it does not have. */}
         <div className="scroll flex min-h-0 flex-1 flex-col">
+          <Stale overview={overview} />
           <Capacity overview={overview} />
           <Nodes context={name} nodes={overview.nodes} />
           <NotReady context={name} overview={overview} />
         </div>
       </SideRail>
     </Screen>
+  );
+}
+
+/**
+ * The one line that says the figures below it have stopped refreshing.
+ *
+ * Every loader on this screen keeps its last good answer in memory, so coming
+ * back to the tab paints the cluster instantly instead of spending a whole
+ * round of requests to arrive at the same numbers. The cost of that is a state
+ * the screen did not have before: **real rows, no longer being updated.**
+ *
+ * That state is not an error — throwing away the last good answer loses
+ * information nobody asked to lose, and an `ErrorState` where a cluster used
+ * to be is worse than the cluster as it was a minute ago. It is not health
+ * either. So it gets a sentence, and the sentence is the whole point: figures
+ * that quietly stopped refreshing are the same lie as a `0` in place of "no
+ * reading", and this screen already refuses that one.
+ *
+ * **Said once, at the top.** A stale nodes list and a stale namespace count
+ * are one outage, and five bands each announcing it has said it five times and
+ * explained it nowhere — the rule `metricsServerRow` follows for a missing
+ * metrics-server, applied to the same problem.
+ */
+function Stale({ overview }: { overview: OverviewData }) {
+  if (overview.staleReasons.length === 0) return null;
+  return (
+    <div className="p-3 pb-0">
+      <Alert tone="warn" title="Showing the last reading — this is no longer refreshing">
+        {overview.staleReasons.join(" · ")}
+      </Alert>
+    </div>
   );
 }
 
@@ -449,7 +482,7 @@ interface Tile {
  */
 function Capacity({ overview }: { overview: OverviewData }) {
   const nodes = nodesTile(overview.nodes);
-  const pods = podsTile(overview.pods.pods);
+  const pods = podsTile(overview.pods);
   const namespaces = overview.namespaces.count;
   const cpu = cpuTile(overview.nodes.capacity);
   const memory = memoryTile(overview.nodes.capacity);
@@ -487,7 +520,13 @@ function Capacity({ overview }: { overview: OverviewData }) {
  * exported precisely so nobody keeps a private copy of that map.
  */
 function nodesTile(nodes: OverviewNodes): Tile {
-  if (nodes.status === "loading" || nodes.error) return { value: NO_READING };
+  // No rows AND no answer is no reading. Rows plus a failed refresh is the
+  // last good reading, and `Stale` says at the top that it stopped
+  // refreshing — blanking a real figure here would lose it and explain
+  // nothing. An answer of no nodes at all is still an answer, and reads `0`.
+  if (nodes.nodes.length === 0 && (nodes.status === "loading" || nodes.error)) {
+    return { value: NO_READING };
+  }
 
   const verdicts = nodes.nodes.map((row) => nodeVerdict(row.node));
   if (verdicts.length === 0) return { value: "0" };
@@ -505,19 +544,32 @@ function nodesTile(nodes: OverviewNodes): Tile {
 /**
  * How many pods there are, and how many need a second look.
  *
+ * The figure is a COUNT the backend made server-side, not the length of a list
+ * this screen fetched — `podOverview` counts 5 416 pods without shipping one of
+ * them. A `total` of `null` means nobody counted, which is not an empty
+ * cluster; `0` here is the cluster's own answer.
+ *
  * `podFlagged` is core's `podStatus` — the same reading the pod list's dot and
  * the pod detail's header take, so a pod counted here as unhealthy is the one
- * the `Not ready` list will name. `undefined` pods means the list has not
- * answered (or was refused), which is not an empty cluster.
+ * the `Not ready` list will name. It reads `unsettled`, which holds every pod
+ * that is not simply running, so nothing core would flag is missing from it.
+ *
+ * **Unless the backend capped it.** A capped list can only say how many it
+ * FOUND, so the caption says "at least" — and "all ready" is withheld
+ * entirely, because a clean bill of health is a claim about every pod and a
+ * capped list has not seen every pod.
  */
-function podsTile(pods: PodSummary[] | undefined): Tile {
-  if (!pods) return { value: NO_READING };
-  const value = String(pods.length);
-  if (pods.length === 0) return { value };
+function podsTile(pods: OverviewPods): Tile {
+  if (pods.total === null) return { value: NO_READING };
+  const value = String(pods.total);
+  if (pods.total === 0) return { value };
 
-  const flagged = pods.filter(podFlagged);
-  if (flagged.length === 0) return { value, caption: "all ready", tone: statusTone("success") };
-  return { value, caption: `${flagged.length} not ready`, tone: statusTone(worst(flagged)) };
+  const flagged = (pods.unsettled ?? []).filter(podFlagged);
+  if (flagged.length === 0) {
+    return pods.truncated ? { value } : { value, caption: "all ready", tone: statusTone("success") };
+  }
+  const count = pods.truncated ? `at least ${flagged.length}` : String(flagged.length);
+  return { value, caption: `${count} not ready`, tone: statusTone(worst(flagged)) };
 }
 
 /**
@@ -697,12 +749,17 @@ function Nodes({ context, nodes }: { context: string; nodes: OverviewNodes }) {
 
   return (
     <Section title="Nodes" smallCaps padded={false}>
-      {nodes.status === "loading" ? (
+      {nodes.status === "loading" && all.length === 0 ? (
         <LoadingState label="Loading nodes" />
-      ) : nodes.error ? (
+      ) : nodes.error && all.length === 0 ? (
         // The node list, and only it. A missing metrics-server is held apart
         // by the loader (`metricsError`) precisely so it cannot empty this
         // table; those rows keep their columns and read as no reading.
+        //
+        // And only when there is nothing to show. A refused REFRESH over rows
+        // already on screen keeps the rows: the screen says once, at the top,
+        // that they stopped refreshing, and an `ErrorState` where a cluster
+        // used to be tells the reader strictly less.
         <ErrorState
           title={`Could not list nodes on ${context}`}
           detail={nodes.error}
@@ -1015,7 +1072,7 @@ function facts(row: NotReadyRow): string[] {
  * independently, so concatenation order is not stable between renders, and a
  * list that reshuffled itself under the reader's cursor would be its own bug.
  */
-function notReadyRows(workloads: OverviewWorkloads, pods: PodSummary[] | undefined): NotReadyRow[] {
+function notReadyRows(workloads: OverviewWorkloads, unsettled: PodSummary[] | undefined): NotReadyRow[] {
   const rows: NotReadyRow[] = [];
 
   for (const row of workloads.deployments ?? []) {
@@ -1046,7 +1103,10 @@ function notReadyRows(workloads: OverviewWorkloads, pods: PodSummary[] | undefin
       ratio: `${row.ready}/${row.desired}`,
     });
   }
-  for (const row of pods ?? []) {
+  // Every pod that is not simply running — `Succeeded` ones included, which
+  // core then leaves unflagged. The filter below is the only thing that
+  // decides, and it is core's.
+  for (const row of unsettled ?? []) {
     rows.push({
       kind: "Pod",
       name: row.name,
@@ -1079,13 +1139,21 @@ function notReadyRows(workloads: OverviewWorkloads, pods: PodSummary[] | undefin
  */
 function NotReady({ context, overview }: { context: string; overview: OverviewData }) {
   const { workloads, pods } = overview;
-  const rows = notReadyRows(workloads, pods.pods);
+  const rows = notReadyRows(workloads, pods.unsettled);
 
   // `workloads.error` is the whole fan-out failing; `workloads.refusals` is
   // one kind of it. Both are reasons this list may be shorter than the truth.
-  const failures = [pods.error, workloads.error, ...Object.values(workloads.refusals)].filter(
-    (reason): reason is string => reason !== undefined && reason !== "",
-  );
+  //
+  // A reason belongs here only when the thing it explains is ACTUALLY MISSING.
+  // A failed refresh over rows this section already has is a different fact —
+  // the rows are real, they are just not current — and `Stale` states that
+  // once at the top of the screen. Repeating it here would be the same outage
+  // announced twice and explained neither time.
+  const failures = [
+    pods.unsettled === undefined ? pods.error : undefined,
+    workloads.deployments === undefined ? workloads.error : undefined,
+    ...Object.values(workloads.refusals),
+  ].filter((reason): reason is string => reason !== undefined && reason !== "");
 
   const reload = () => {
     workloads.reload();
@@ -1109,7 +1177,18 @@ function NotReady({ context, overview }: { context: string; overview: OverviewDa
               {failures.join(" · ")}
             </Alert>
           )}
-          {rows.length === 0 ? (
+          {/* A cap is not a failure, so it is not in `failures` — but it is
+              the same kind of fact: the list is short, and a short list that
+              does not say so is read as the whole truth. The backend stops
+              fetching pod bodies past its cap rather than rebuilding the
+              whole-cluster list this screen was rewritten to stop making. */}
+          {pods.truncated && (
+            <Alert tone="warn" title="More pods need a look than this list shows">
+              This band is a summary, and it stops before the whole list. The pod list has all of
+              them.
+            </Alert>
+          )}
+          {rows.length === 0 && pods.truncated ? null : rows.length === 0 ? (
             <EmptyState
               title="Nothing is unhealthy"
               hint={`Every workload and pod in ${context} is where it should be.`}

--- a/packages/ui-next/src/screens/overview/Fleet.test.tsx
+++ b/packages/ui-next/src/screens/overview/Fleet.test.tsx
@@ -10,7 +10,8 @@ vi.mock("@srelens/core", async (orig) => ({
   ...core,
 }));
 
-import type { ClusterContext } from "@srelens/core";
+import { scaledStatus, type ClusterContext } from "@srelens/core";
+import { statusTone, toneColor } from "@srelens/ui-kit";
 import { Fleet } from "./Fleet";
 
 function aContext(name: string): ClusterContext {
@@ -146,5 +147,81 @@ describe("Fleet", () => {
     await waitFor(() => expect(row("staging")).toBeTruthy());
     expect(document.querySelectorAll(".kv")).toHaveLength(2);
     expect(core.podCount).toHaveBeenCalledTimes(2);
+  });
+});
+
+/**
+ * The count's colour. §7 draws `1 284 / 1 310` in red beside `1 702 / 1 702`
+ * in green, and that is what makes the section scannable.
+ *
+ * Three states in the fixture, not one. A table that paired the wrong colour
+ * with the wrong state has passed a two-state suite before on this project,
+ * because the fixture only ever contained the case both readings agreed on.
+ */
+describe("Fleet's tone", () => {
+  const colour = (name: string) =>
+    row(name).querySelector<HTMLElement>(".kv-v span")?.style.color ?? "";
+
+  /** What core says about the same two numbers, read the way the screen reads it. */
+  const fromCore = (running: number, total: number) =>
+    statusTone(scaledStatus("Cluster", running, total).health);
+
+  it("takes the colour from core's verdict on the same two numbers", async () => {
+    core.podCount.mockImplementation((context: string) =>
+      Promise.resolve(
+        context === "prod-eu"
+          ? { counts: { running: 1284, total: 1310 } }
+          : context === "staging"
+            ? { counts: { running: 1702, total: 1702 } }
+            : // Every countable pod gone — `total` excludes `Succeeded`, so a
+              // cluster whose Jobs have all finished lands here. Core calls it
+              // neither well nor broken, and so does the row.
+              { counts: { running: 0, total: 0 } },
+      ),
+    );
+    render(<Fleet clusters={[PROD, STAGING, DR]} active={PROD} />);
+
+    await waitFor(() => expect(row("prod-eu").textContent).toContain("1284/1310 running"));
+
+    // Three distinct answers, so a single wrong pairing cannot pass by
+    // agreeing with the one case the fixture happens to contain.
+    expect(new Set([fromCore(1284, 1310), fromCore(1702, 1702), fromCore(0, 0)]).size).toBe(3);
+
+    expect(colour("prod-eu")).toBe(toneColor(fromCore(1284, 1310)));
+    expect(colour("staging")).toBe(toneColor(fromCore(1702, 1702)));
+    expect(colour("dr-us")).toBe(toneColor(fromCore(0, 0)));
+
+    // And what core actually says, spelled out: a shortfall is danger and a
+    // whole count is ok. Written as core's own constants rather than as
+    // literals, so this asserts the wiring and not a second copy of the rule.
+    expect(colour("prod-eu")).toBe(toneColor(statusTone("danger")));
+    expect(colour("staging")).toBe(toneColor(statusTone("success")));
+  });
+
+  it("names no colour of its own — every one is a token", async () => {
+    core.podCount.mockResolvedValue({ counts: { running: 3, total: 4 } });
+    render(<Fleet clusters={[PROD]} active={PROD} />);
+    await waitFor(() => expect(row("prod-eu").textContent).toContain("3/4 running"));
+
+    expect(colour("prod-eu")).toMatch(/^var\(--/);
+  });
+
+  it("keeps the figure in words, so the colour is never the only channel", async () => {
+    core.podCount.mockResolvedValue({ counts: { running: 1284, total: 1310 } });
+    render(<Fleet clusters={[PROD]} active={PROD} />);
+    await waitFor(() =>
+      expect(row("prod-eu").querySelector(".kv-v")?.textContent).toBe("1284/1310 running"),
+    );
+  });
+
+  it("colours nothing at all for a cluster that did not answer", async () => {
+    // There is no count to tone. A red "Unreachable" would be a judgement
+    // about a cluster nobody reached.
+    core.podCount.mockResolvedValue({ error: "pod count timed out" });
+    render(<Fleet clusters={[PROD]} active={PROD} />);
+    await waitFor(() => expect(row("prod-eu").textContent).toContain("Unreachable"));
+
+    expect(row("prod-eu").textContent).not.toContain("0/0");
+    expect(colour("prod-eu")).toBe("");
   });
 });

--- a/packages/ui-next/src/screens/overview/Fleet.test.tsx
+++ b/packages/ui-next/src/screens/overview/Fleet.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+
+// Only the capability wrapper is replaced. `podCount` is the one call this
+// section makes, and every property below is about how its answers — and its
+// non-answers — reach the rail.
+const core = vi.hoisted(() => ({ podCount: vi.fn() }));
+vi.mock("@srelens/core", async (orig) => ({
+  ...(await orig<typeof import("@srelens/core")>()),
+  ...core,
+}));
+
+import type { ClusterContext } from "@srelens/core";
+import { Fleet } from "./Fleet";
+
+function aContext(name: string): ClusterContext {
+  return { name, stableId: name, cluster: name, server: `https://${name}`, isCurrent: false };
+}
+
+const PROD = aContext("prod-eu");
+const STAGING = aContext("staging");
+const DR = aContext("dr-us");
+
+/** A promise that never settles: the cluster that is up but not answering. */
+function neverAnswers(): Promise<never> {
+  return new Promise(() => {});
+}
+
+/** One cluster's row, found by the name it is keyed under. */
+function row(name: string): HTMLElement {
+  const found = screen.getByText(name).closest(".kv");
+  if (!found) throw new Error(`no fleet row for ${name}`);
+  return found as HTMLElement;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  core.podCount.mockResolvedValue({ counts: { running: 1, total: 1 } });
+});
+
+describe("Fleet", () => {
+  it("reads each cluster's pods as a named ratio, not a bare pair of numbers", async () => {
+    core.podCount.mockImplementation((context: string) =>
+      Promise.resolve(
+        context === "prod-eu"
+          ? { counts: { running: 30, total: 33 } }
+          : { counts: { running: 5, total: 5 } },
+      ),
+    );
+    render(<Fleet clusters={[PROD, STAGING]} active={PROD} />);
+
+    await waitFor(() => expect(within(row("prod-eu")).getByText(/30\/33/)).toBeTruthy());
+    // The noun is the caller's job: "30/33" alone says nothing about what was
+    // counted, the same finding the not-ready list's trailing facts came from.
+    expect(row("prod-eu").textContent).toContain("30/33 running");
+    expect(row("staging").textContent).toContain("5/5 running");
+  });
+
+  it("keeps every other cluster's count when one of them is unreachable", async () => {
+    core.podCount.mockImplementation((context: string) =>
+      Promise.resolve(
+        context === "staging"
+          ? { error: "dial tcp 10.1.2.3:6443: connect: connection refused" }
+          : { counts: { running: 7, total: 9 } },
+      ),
+    );
+    render(<Fleet clusters={[PROD, STAGING, DR]} active={PROD} />);
+
+    // One cluster's failure is one row's failure — the whole point of the
+    // section. The two that answered keep their numbers.
+    await waitFor(() => expect(row("staging").textContent).toContain("connection refused"));
+    expect(row("prod-eu").textContent).toContain("7/9 running");
+    expect(row("dr-us").textContent).toContain("7/9 running");
+
+    // And it says the cluster is unreachable, rather than only printing a
+    // stack of transport text with no verdict on it.
+    expect(row("staging").textContent).toContain("Unreachable");
+    // Never a count: a cluster that did not answer has not said it has no pods.
+    expect(row("staging").textContent).not.toContain("/");
+  });
+
+  it("does not read a timeout as a cluster with no pods", async () => {
+    core.podCount.mockImplementation((context: string) =>
+      Promise.resolve(
+        context === "dr-us"
+          ? { error: "pod count timed out" }
+          : { counts: { running: 4, total: 4 } },
+      ),
+    );
+    render(<Fleet clusters={[PROD, DR]} active={PROD} />);
+
+    await waitFor(() => expect(row("dr-us").textContent).toContain("timed out"));
+    // The exact failure this section is written against: `0/0` for a cluster
+    // that never answered is a lie the reader has no way to catch.
+    expect(row("dr-us").textContent).not.toContain("0");
+    expect(row("dr-us").textContent).toContain("Unreachable");
+  });
+
+  it("lets the clusters that answered render while a slow one is still counting", async () => {
+    core.podCount.mockImplementation((context: string) =>
+      context === "staging" ? neverAnswers() : Promise.resolve({ counts: { running: 12, total: 12 } }),
+    );
+    render(<Fleet clusters={[PROD, STAGING, DR]} active={PROD} />);
+
+    await waitFor(() => expect(row("prod-eu").textContent).toContain("12/12 running"));
+    expect(row("dr-us").textContent).toContain("12/12 running");
+
+    // NO AGGREGATE SPINNER. One over the section would let the slowest cluster
+    // hide the two that answered, which is exactly what this asserts is not
+    // happening: there is one loading indicator on screen and it is inside the
+    // row that is still waiting.
+    const loading = screen.getAllByRole("status");
+    expect(loading).toHaveLength(1);
+    expect(row("staging").contains(loading[0])).toBe(true);
+  });
+
+  it("asks every cluster at once rather than one after another", async () => {
+    core.podCount.mockImplementation(() => neverAnswers());
+    render(<Fleet clusters={[PROD, STAGING, DR]} active={PROD} />);
+
+    // Three calls out with nothing having come back. A section that awaited
+    // each cluster in turn would have made exactly one.
+    await waitFor(() => expect(core.podCount).toHaveBeenCalledTimes(3));
+    expect(core.podCount.mock.calls.map((c: unknown[]) => c[0])).toEqual([
+      "prod-eu",
+      "staging",
+      "dr-us",
+    ]);
+    expect(screen.queryByText(/running/)).toBeNull();
+  });
+
+  it("shows this cluster even when the workspace list has lost it", async () => {
+    // The row that must never be missing: the overview is about this cluster,
+    // and a Fleet section that omitted it would be a summary of everywhere
+    // except the place the reader is looking.
+    render(<Fleet clusters={[STAGING]} active={PROD} />);
+
+    await waitFor(() => expect(row("prod-eu")).toBeTruthy());
+    const names = Array.from(document.querySelectorAll(".kv-k")).map((el) => el.textContent);
+    expect(names).toEqual(["prod-eu", "staging"]);
+  });
+
+  it("lists a cluster once, whichever list it came from", async () => {
+    render(<Fleet clusters={[PROD, STAGING]} active={PROD} />);
+
+    await waitFor(() => expect(row("staging")).toBeTruthy());
+    expect(document.querySelectorAll(".kv")).toHaveLength(2);
+    expect(core.podCount).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/ui-next/src/screens/overview/Fleet.tsx
+++ b/packages/ui-next/src/screens/overview/Fleet.tsx
@@ -1,5 +1,5 @@
-import { podCount, type ClusterContext, type PodCount } from "@srelens/core";
-import { KV, Spinner } from "@srelens/ui-kit";
+import { podCount, scaledStatus, type ClusterContext, type PodCount } from "@srelens/core";
+import { KV, Spinner, statusTone, toneColor } from "@srelens/ui-kit";
 import { useResource, type Resource } from "../../lib/useResource";
 import { LINK_WORD } from "../../lib/workspace";
 
@@ -37,6 +37,9 @@ export interface FleetProps {
  * no way to catch. {@link count} below is what keeps it: an outcome carrying
  * an error becomes a rejection, never a count.
  *
+ * **The count's colour is core's verdict, not a comparison written here.**
+ * See {@link countTone}.
+ *
  * **This cluster is in the list.** `active` is prepended when the workspace's
  * own list has lost it — a window between a kubeconfig changing and the store
  * reconciling — because a fleet summary that omits the cluster the reader is
@@ -56,6 +59,33 @@ export function Fleet({ clusters, active }: FleetProps) {
       ))}
     </>
   );
+}
+
+/**
+ * The tone a row's count reads in — core's verdict on it, never a comparison
+ * of this file's own.
+ *
+ * `scaledStatus` is the rule every ready-out-of-desired figure on this screen
+ * already takes: it is what `deploymentVerdict`, `statefulSetVerdict` and
+ * `daemonSetVerdict` hand the `Not ready` list, and what the detail header
+ * asks about the same object. A cluster is not a workload, so the `kind`
+ * argument only picks the WORD for a cluster with nothing running, which this
+ * row never draws; the health is the whole of what is read.
+ *
+ * **What core actually says, stated so nobody has to guess.** Any shortfall is
+ * `Degraded` and danger; a whole count is `Running` and ok; a cluster whose
+ * countable pods are all gone — `total` is zero — is `AT_REST`, neither, and
+ * reads plain. Core has no separate opinion about a POD-COUNT shortfall
+ * specifically: it has one opinion about a ready-out-of-desired shortfall, and
+ * this is it. Softening it here ("a couple missing is only amber") would be a
+ * threshold this file invented, which is the fault ten hand-paired label/tone
+ * tables were removed from this project for.
+ *
+ * The colour is a SECOND channel over a figure that is already in words. The
+ * row reads `1284/1310 running` whether or not anyone can see the red.
+ */
+function countTone(counts: PodCount) {
+  return statusTone(scaledStatus("Cluster", counts.running, counts.total).health);
 }
 
 /** An outcome-shaped count, turned into the rejection `useResource` reads. */
@@ -109,5 +139,9 @@ function Reading({
   // `total` excludes `Succeeded` pods — the backend does that, see
   // `crates/kube/src/pod_count.rs` — so a cluster whose Jobs have all
   // finished reads 30/30 rather than claiming three pods are down.
-  return <>{`${counts.data.running}/${counts.data.total} running`}</>;
+  return (
+    <span className="num" style={{ color: toneColor(countTone(counts.data)) }}>
+      {`${counts.data.running}/${counts.data.total} running`}
+    </span>
+  );
 }

--- a/packages/ui-next/src/screens/overview/Fleet.tsx
+++ b/packages/ui-next/src/screens/overview/Fleet.tsx
@@ -1,0 +1,113 @@
+import { podCount, type ClusterContext, type PodCount } from "@srelens/core";
+import { KV, Spinner } from "@srelens/ui-kit";
+import { useResource, type Resource } from "../../lib/useResource";
+import { LINK_WORD } from "../../lib/workspace";
+
+export interface FleetProps {
+  /** Every cluster in this workspace, in the rail's own order. */
+  clusters: ClusterContext[];
+  /** The cluster this overview is about. Always drawn, see below. */
+  active: ClusterContext;
+}
+
+/**
+ * `Fleet` — one row per cluster in the workspace, with how much of each is up.
+ *
+ * **THE FAILURE MODES ARE THE DESIGN.** Everything below follows from one
+ * sentence: the overview is about THIS cluster, and Fleet is a courtesy.
+ *
+ * **Concurrent, and isolated.** There is no fan-out here to fail — no
+ * `Promise.all`, no gathered list, nothing that awaits one cluster before
+ * asking the next. Every row is its own component with its own `useResource`,
+ * so the calls all leave in the same effect flush and each answer lands in the
+ * row it belongs to. One cluster's refusal is one row's refusal, and a cluster
+ * that never answers holds up nothing at all — not this section, and not the
+ * capacity strip or the nodes table beside it.
+ *
+ * **Each row owns its state, and there is deliberately NO aggregate spinner.**
+ * A "Loading fleet" over the section would let the one unreachable cluster
+ * hide the nine that answered in half a second, which is the opposite of what
+ * a summary is for. A row is either counting, a count, or unreachable with the
+ * reason it gave.
+ *
+ * **A cluster that did not answer is never a zero.** `podCount` carries its
+ * own 3-second timeout in the backend and reports a timeout as an error rather
+ * than as `{ running: 0, total: 0 }`; that distinction is preserved all the
+ * way here, because "0/0" for a cluster nobody reached is a lie the reader has
+ * no way to catch. {@link count} below is what keeps it: an outcome carrying
+ * an error becomes a rejection, never a count.
+ *
+ * **This cluster is in the list.** `active` is prepended when the workspace's
+ * own list has lost it — a window between a kubeconfig changing and the store
+ * reconciling — because a fleet summary that omits the cluster the reader is
+ * looking at is a summary of everywhere except here.
+ */
+export function Fleet({ clusters, active }: FleetProps) {
+  const rows = clusters.some((c) => c.stableId === active.stableId)
+    ? clusters
+    : [active, ...clusters];
+
+  // A fragment, so the rows land as direct children of whatever laid the
+  // section out — the same reason `KVList` has no wrapper of its own.
+  return (
+    <>
+      {rows.map((ctx) => (
+        <FleetRow key={ctx.stableId} context={ctx} />
+      ))}
+    </>
+  );
+}
+
+/** An outcome-shaped count, turned into the rejection `useResource` reads. */
+async function count(context: string): Promise<PodCount> {
+  const out = await podCount(context);
+  // Never `?? { running: 0, total: 0 }`. See the note above.
+  if (out.error) throw new Error(out.error);
+  if (!out.counts) throw new Error("podCount returned no counts");
+  return out.counts;
+}
+
+/**
+ * One cluster's row, and the whole of its isolation.
+ *
+ * A component per row rather than a loop over one hook: the number of clusters
+ * changes between renders, and a hook per item would be a hook count that
+ * changes with the list, which React refuses. It is also what makes the
+ * isolation structural rather than remembered — there is no shared state for
+ * one cluster's failure to reach.
+ */
+function FleetRow({ context }: { context: ClusterContext }) {
+  const counts = useResource(() => count(context.name), [context.name]);
+
+  return <KV k={context.name} v={<Reading name={context.name} counts={counts} />} />;
+}
+
+function Reading({
+  name,
+  counts,
+}: {
+  name: string;
+  counts: Resource<PodCount>;
+}) {
+  if (counts.error) {
+    return (
+      <>
+        {/* The same word the status bar uses for a cluster it could not
+            reach, from the same table — a second word for the same fact is
+            how two readouts of one cluster start disagreeing. */}
+        {LINK_WORD.error}
+        <span className="block text-faint">{counts.error}</span>
+      </>
+    );
+  }
+  if (!counts.data) {
+    // This row's own indicator, named for this row's own cluster.
+    return <Spinner label={`Counting pods on ${name}`} />;
+  }
+  // Named, not a bare pair of numbers: "30/33" says nothing about what was
+  // counted, and the not-ready list's trailing facts settled the same point.
+  // `total` excludes `Succeeded` pods — the backend does that, see
+  // `crates/kube/src/pod_count.rs` — so a cluster whose Jobs have all
+  // finished reads 30/30 rather than claiming three pods are down.
+  return <>{`${counts.data.running}/${counts.data.total} running`}</>;
+}

--- a/packages/ui-next/src/shell/Status.tsx
+++ b/packages/ui-next/src/shell/Status.tsx
@@ -1,32 +1,12 @@
 import { useSyncExternalStore } from "react";
 import { getForwards, subscribeForwards, type ClusterContext } from "@srelens/core";
-import { StatusBar, type StatusSegment, type Tone } from "@srelens/ui-kit";
+import { StatusBar, type StatusSegment } from "@srelens/ui-kit";
 import { useConsole } from "../console";
 import { useInfo } from "../lib/probe";
 import { openTab, useActiveCluster } from "../lib/tabsStore";
-import { useWorkspaceView, type LinkState } from "../lib/workspace";
-
-/**
- * What the link says, in words. The mock said it in colour alone — a green dot
- * for connected, a red one for unreachable — which is no readout at all for
- * anyone who cannot separate the two. The kit's segment requires a string, so
- * the words are the readout and the tone is the second channel. "Unreachable"
- * rather than "Error" for `error`: the failure being reported is the cluster's,
- * not the app's, and the person reading it wants to know which. (#320)
- */
-const LINK_WORD: Record<LinkState, string> = {
-  connected: "Connected",
-  connecting: "Connecting",
-  disconnected: "Disconnected",
-  error: "Unreachable",
-};
-
-const LINK_TONE: Record<LinkState, Tone> = {
-  connected: "ok",
-  connecting: "info",
-  disconnected: "muted",
-  error: "sev",
-};
+// The words and their tones live beside `LinkState` rather than here: the
+// overview rail reads the same link and must say the same thing about it.
+import { LINK_TONE, LINK_WORD, useWorkspaceView } from "../lib/workspace";
 
 /**
  * The strip along the bottom of the window: which cluster this window is

--- a/scripts/screenshot.mjs
+++ b/scripts/screenshot.mjs
@@ -146,7 +146,17 @@ if (!flags["no-build"] && (flags.build || stale)) {
   console.error("· building the frontend…");
   run("pnpm", ["--filter", "@srelens/desktop", "build"]);
 }
-if (!existsSync(SERVER_BIN)) {
+// The BACKEND goes stale the same way the frontend does, and far more quietly.
+// Existence alone is not enough: a binary built before a new capability was
+// registered answers `capability not found` for it, and the screen photographs
+// as a page of errors and NaNs that look exactly like a bug in the screen. That
+// happened — a whole overview shot with `k8s.clusterFacts` missing and every
+// meter reading NaN%, against code where all of it worked. Cargo would no-op a
+// fresh build in seconds, so the mtime check only saves the link step.
+const serverStale =
+  !existsSync(SERVER_BIN) ||
+  newestMtime(path.join(ROOT, "crates")) > statSync(SERVER_BIN).mtimeMs;
+if (serverStale) {
   // Debug build on purpose: rust-embed reads apps/desktop/dist from disk in a
   // debug build and bakes it into the binary in a release one, so a debug
   // server picks up a frontend rebuild with no recompile.


### PR DESCRIPTION
Step 6 of the migration epic (#305), second of three specs — the cluster overview at `/overview`. Follows #338, which brought Events and the custom-resource rail.

A capacity strip, a nodes table with live CPU and memory meters, a list of what is not ready, and a rail of control-plane facts, object counts and a per-cluster fleet summary.

## The finding it turns on

The design's percentages had been catalogued as invented, on the grounds that *"metrics-server gives raw usage, not a percent of allocatable"*. True, and only half the story: **raw usage is what we already had**, and the denominator was one field away. A node's `status.allocatable` carries cpu, memory *and* pods — every denominator the screen needs.

So most of this screen was one backend field, not a data problem.

## It was too slow to use, and on a large cluster it did not work at all

The screen fetched every pod in the cluster — bodies, containers, images — to answer three questions: a count, a per-node count, and which pods are unhealthy. Fine at 33 pods. Against a **113-node, 5,416-pod cluster** it never returned.

Measured through the real app, against real clusters:

| | 113 nodes / 5,416 pods | 11 nodes / 307 pods |
|---|---|---|
| the pod call, before | **timed out at 8s, no data** | 0.58–0.78s, 84 KB |
| after | **0.59–0.74s, 34 KB** | 0.31–0.94s, 2.1 KB |
| cold load | **never → 7.0–9.0s** | 7.0–8.9s → 4.5–4.9s |
| re-entering a cluster already seen | **never → 18 ms, 1 call** | **2,473 ms / 11 calls → 15 ms / 1 call** |

Two changes did it: a capability that counts pods and groups them by node **without listing their bodies**, and a stale-while-revalidate cache so a screen already loaded comes back immediately.

**And `kube-rs` was compiled without gzip.** Every response from every cluster travelled uncompressed. Enabling it is one line and it is not specific to this screen:

- wire size on that cluster: **54.9 MB → 3.0 MB**, 18×
- wall time: **~5.17s → ~1.30s**
- over loopback to a local kind cluster: a wash, as expected, and no regression

That also brought Fleet's per-cluster count inside its 3-second budget — 5.1–5.4s before, ~1.3s after — **without widening the budget**, which was argued from fanning out across ten clusters on one screen load.

## What it refuses to guess

- **A missing metrics-server means "No reading", never `0%`.** A zero is a measurement; on a 113-node cluster it would say the cluster is idle. That distinction runs unbroken from the arithmetic through the loaders to every cell, and the large cluster is where it was finally exercised.
- **A partial cluster total says so.** Where only some nodes report, the figure sums those and the caption reads `2 of 3 nodes reporting`. Folding a silent node in as capacity-with-zero-usage would invent a measurement nobody took.
- **Usage above 100% is reported honestly.** The meter clamps its own bar and keeps its accessible value truthful; clamping the arithmetic would make a node at 140% indistinguishable from one exactly at its limit.
- **Provider and region are read, never guessed** — folded across every node, so a node with no value abstains rather than vetoes and **nodes that disagree yield nothing**. A cluster spanning two regions has no region. On a kind cluster no node carries a region label, so that row is simply absent.
- **`Open incidents` states its own absence.** No Kubernetes API returns an incident's title, severity or trend; Incidents is scheduled as its own feature.

## Fleet

One row per connected cluster, each owning its own request — so there is no fan-out to fail and no shared state for one failure to reach. Verified against a kubeconfig with fifteen contexts: five answered concurrently, eight failed with 401s, missing auth binaries and timeouts, **every failure stayed in its own row**, and not one rendered as `0/0`.

`total` excludes `Succeeded` pods, in the backend rather than by client-side subtraction — two independently timed counts go negative when a Job finishes between them. Without it the demo cluster read `30/33` and implied three pods were down when they had completed.

## Matching the design

The first build used bordered cards where the design is one continuous banded surface. Corrected: flat sections, small-caps heads on their own tinted band with a bottom rule and sticky within the pane, wide meters whose tone is legible, singular kind labels, glyphs on the node actions.

Two defects found by looking rather than by testing:

- **A screenshot that lied.** The capture script only checked whether the server binary existed, so it photographed a backend three tasks out of date — every meter `NaN%`, the rail reading `capability not found`. It would have done that on every future check.
- **The CPU bar ran into the memory column.** `Table` pins column widths on the first render with rows, and the node list answers before the metrics do, so the columns were fixed at the width of `No reading`. The second time this pinning behaviour has produced a visibly broken table that every test passed.

## Gates

3,097 tests across core, the kit and ui-next; 730 in classic, unchanged; 370 in the kube crate and 45 in the registry; four projects typechecking; a clean build linking no stylesheet.

## Known, and deliberate

- **Fleet's tone is core's opinion.** Any shortfall is a shortfall, so `305/306` reads danger — matching the design frame, which reds `1 284 / 1 310`. On a large cluster one pending pod out of 1,310 will do the same. If that is wrong for a liveness count, the fix belongs in core's vocabulary, not this screen.
- **`Metrics server` shows the API-group version** (`v1beta1`), not the component version the design draws. The latter needs an RBAC-sensitive read of a deployment's image tag.
- **A crash-looping pod flickers out of `NOT READY` between crashes** — the shared health rule reads phase plus waiting reason, and between restarts there is neither. It affects every list in the app; the owning Deployment stays `Degraded` throughout, so nothing is hidden. Worth its own issue.
- **An unreachable cluster prints a raw API error** down the rail — a Rust struct shown to a reader. Pre-existing, same shape as the reaped-Job error in #338.
- **`listDeployments` is now the screen's largest request** and has no cap.
- Two commits in this branch do not compile on their own: a registry line landed a commit before the function it references, from a concurrent-agent mishap. HEAD is correct and green; a bisect through those two is not.
