### PR TITLE
fix: say what went wrong, and stop losing a crash-looping pod

### DIFF
--- a/packages/core/src/lib/errors.test.ts
+++ b/packages/core/src/lib/errors.test.ts
@@ -43,6 +43,30 @@ describe("cleanErrorMessage", () => {
     expect(cleanErrorMessage(new Error("boom"))).toBe("boom");
   });
 
+  it("strips the class name String() prints in front of a stringified Error", () => {
+    // `podCount`, `getManifest`, `clusters` and every other lib wrapper report
+    // a rejection as `{ error: String(e) }`, and `String(new Error(m))` is
+    // `Error: ${m}`. The handler prefix is anchored at the start, so that one
+    // word was enough to stop it matching — which is how the overview's Fleet
+    // rows came to print `Error: handler error: ApiError: …` verbatim.
+    expect(cleanErrorMessage("Error: handler error: list pods timed out")).toBe(
+      "list pods timed out",
+    );
+  });
+
+  it("keeps stripping while the prefixes stack", () => {
+    expect(cleanErrorMessage("Error: Error: handler error: nope")).toBe("nope");
+  });
+
+  it("strips a prefix, not a word that happens to start the message", () => {
+    // Only the two known prefixes, and only with their colon. A message that
+    // opens with a word ending in "error" is the message, not a wrapper.
+    expect(cleanErrorMessage("Errors were found in the manifest")).toBe(
+      "Errors were found in the manifest",
+    );
+    expect(cleanErrorMessage("ApiError: Unauthorized")).toBe("ApiError: Unauthorized");
+  });
+
   it("coerces non-string, non-Error values safely", () => {
     expect(cleanErrorMessage(null)).toBe("");
     expect(cleanErrorMessage(undefined)).toBe("");
@@ -77,6 +101,17 @@ describe("describeError", () => {
     );
   });
 
+  it("classifies hyper's own opaque connect failure, which is what a cluster being down looks like", () => {
+    // Verbatim from `k8s.listNodes` against a kind cluster whose container is
+    // stopped. `kubectl` says "connection refused"; the backend's stack has
+    // already thrown that away by the time the string reaches the UI, and
+    // "Something went wrong" for the most ordinary failure there is was the
+    // least useful answer this function gave.
+    const result = describeError("handler error: ServiceError: client error (Connect)");
+    expect(result.title).toBe("Can't reach the cluster");
+    expect(result.detail).toMatch(/Make sure the cluster is running/);
+  });
+
   it("classifies an unresolved host", () => {
     expect(describeError("failed to lookup address information: no such host").title).toBe(
       "Cluster address not found",
@@ -86,6 +121,26 @@ describe("describeError", () => {
   it("classifies auth failures distinctly", () => {
     expect(describeError("Unauthorized").title).toBe("Not authorized");
     expect(describeError("forbidden: pods is forbidden").title).toBe("Access denied");
+  });
+
+  it("classifies the apiserver's whole 401 as a 401, and keeps the struct only in raw", () => {
+    // Verbatim from a real context in the user's kubeconfig, as `podCount`
+    // hands it to the overview's Fleet rows: `String(e)` over a
+    // `CapabilityError` wrapping kube-rs's `ApiError` Display. Every earlier
+    // branch has to decline it — `unreachable`, `dns` and `self.signed` are
+    // all substring tests, and this string is 300 characters of struct.
+    const raw =
+      'Error: handler error: ApiError: Unauthorized: Unauthorized (Status { status: Some("Failure"), ' +
+      "metadata: Some(ListMeta { continue_: None, remaining_item_count: None, resource_version: None, " +
+      'self_link: None }), reason: Some("Unauthorized"), code: Some(401), message: Some("Unauthorized") })';
+    const result = describeError(raw);
+    expect(result.title).toBe("Not authorized");
+    expect(result.detail).toMatch(/rejected your credentials/);
+    // The reader is never shown the struct in the copy — but it is not thrown
+    // away either, and it no longer carries either wrapper prefix.
+    expect(result.detail).not.toMatch(/ListMeta|handler error/);
+    expect(result.raw).toContain("ListMeta");
+    expect(result.raw.startsWith("ApiError:")).toBe(true);
   });
 
   it("classifies a cluster-login marker as a distinct sign-in prompt, not generic unauthorized", () => {

--- a/packages/core/src/lib/errors.ts
+++ b/packages/core/src/lib/errors.ts
@@ -24,13 +24,34 @@ export interface FriendlyError {
   raw: string;
 }
 
-/** `CapabilityError`'s Display prefix; internal noise the user shouldn't see. */
-const HANDLER_PREFIX = /^\s*handler error:\s*/i;
+/**
+ * The two wrappers that get printed in front of a message on the way here,
+ * neither of which is news to anyone:
+ *
+ * - `handler error:` is `CapabilityError`'s Display prefix.
+ * - `Error:` is what `String()` puts in front of an `Error`'s message, and
+ *   `{ error: String(e) }` is how every lib wrapper — `podCount`,
+ *   `getManifest`, `clusters` — reports a rejection. The two stack, so what
+ *   actually arrived at the cluster overview's Fleet rows was
+ *   `Error: handler error: ApiError: …`; with the pattern anchored and applied
+ *   once, that leading `Error: ` was enough to stop the handler prefix
+ *   matching at all, and the whole string went to the reader verbatim.
+ *
+ * Both need their colon, so a message that merely opens with the word — an
+ * apiserver's `ApiError: …`, a manifest's `Errors were found …` — is left
+ * whole. Nothing further is stripped: the rest is what the cluster said.
+ */
+const NOISE_PREFIX = /^\s*(?:handler error|Error):\s*/i;
 
 /** Normalize any thrown value to a clean message, stripping internal prefixes. */
 export function cleanErrorMessage(input: unknown): string {
-  const raw = input instanceof Error ? input.message : String(input ?? "");
-  return raw.replace(HANDLER_PREFIX, "").trim();
+  let raw = input instanceof Error ? input.message : String(input ?? "");
+  // Until it stops changing, rather than once: the wrappers nest, and a single
+  // pass leaves whichever one was outermost standing in front of the message.
+  for (let stripped = raw.replace(NOISE_PREFIX, ""); stripped !== raw; stripped = raw.replace(NOISE_PREFIX, "")) {
+    raw = stripped;
+  }
+  return raw.trim();
 }
 
 /**
@@ -124,11 +145,17 @@ export function describeError(input: unknown): FriendlyError {
       raw,
     };
   }
-  if (/connection refused|failed to connect|connect error|no route to host|network is unreachable|unreachable/.test(lower)) {
+  // `client error (connect)` is hyper's own Display for a connector that never
+  // got a socket, and it is what the backend actually returns for a cluster
+  // that is simply down — `ServiceError: client error (Connect)`, with the
+  // refused/unreachable/handshake distinction already discarded by the time it
+  // reaches us. It was falling through to "Something went wrong", which is how
+  // the most ordinary failure there is came to be the least explained one.
+  if (/connection refused|failed to connect|connect error|\(connect\)|no route to host|network is unreachable|unreachable/.test(lower)) {
     return {
       title: "Can't reach the cluster",
       detail:
-        "The connection to the API server was refused. Make sure the cluster is running and the server address in your kubeconfig context is correct.",
+        "The connection to the API server could not be made. Make sure the cluster is running and the server address in your kubeconfig context is correct.",
       raw,
     };
   }

--- a/packages/core/src/lib/k8sHealth.test.ts
+++ b/packages/core/src/lib/k8sHealth.test.ts
@@ -136,6 +136,101 @@ describe("conditionKind", () => {
   });
 });
 
+/**
+ * Every condition type this rule claims to know, paired with the status that
+ * means the resource is WELL — the whole polarity table in one place, walked
+ * from both ends.
+ *
+ * Both directions are asserted for every row, and that is the point rather
+ * than thoroughness for its own sake. A polarity bug is invisible from one
+ * side: a rule that answered "danger" to everything would satisfy every
+ * `True → danger` row in the negative half, and a rule that answered
+ * "success" to everything would satisfy every `True → success` row in the
+ * positive half. Only asserting the OTHER status of the same type catches
+ * either. It is also why the positive half is here at all: the negative half
+ * is matched by SUBSTRING, so an alternative added for one type silently
+ * re-tones every type that happens to contain it, and the positive rows are
+ * the only thing standing between this rule and that mistake.
+ */
+const POLARITY: [type: string, wellWhen: "True" | "False", note: string][] = [
+  // ---- Positive types: True is the healthy answer. --------------------
+  ["Ready", "True", "core/v1 Pod + Node"],
+  ["Initialized", "True", "core/v1 Pod"],
+  ["ContainersReady", "True", "core/v1 Pod"],
+  ["PodScheduled", "True", "core/v1 Pod"],
+  ["PodReadyToStartContainers", "True", "core/v1 Pod"],
+  ["Available", "True", "apps/v1 Deployment"],
+  ["Progressing", "True", "apps/v1 Deployment"],
+  ["Complete", "True", "batch/v1 Job"],
+  ["SuccessCriteriaMet", "True", "batch/v1 Job"],
+  ["Approved", "True", "certificates/v1 CSR"],
+  ["Established", "True", "apiextensions CRD"],
+  ["NamesAccepted", "True", "apiextensions CRD"],
+  ["DisruptionAllowed", "True", "policy/v1 PodDisruptionBudget"],
+  // The collision guard, and it is not hypothetical: "Installed" CONTAINS
+  // "Stalled" (i-n-**s-t-a-l-l-e-d**), so the kstatus/Flux convention's
+  // `Stalled` cannot be added to the substring family without painting every
+  // operator's `Installed: True` red — the exact inversion this rule keeps
+  // being fixed for, in the other direction. See NEGATIVE_CONDITION.
+  ["Installed", "True", "OLM / operator convention — contains 'Stalled'"],
+  ["Uninstalled", "True", "same substring trap"],
+
+  // ---- Negative types: False is the healthy answer. -------------------
+  ["MemoryPressure", "False", "core/v1 Node"],
+  ["DiskPressure", "False", "core/v1 Node"],
+  ["PIDPressure", "False", "core/v1 Node"],
+  ["NetworkUnavailable", "False", "core/v1 Node"],
+  ["ReplicaFailure", "False", "apps/v1 Deployment + ReplicaSet"],
+  ["Failed", "False", "batch/v1 Job, certificates/v1 CSR"],
+  ["FailureTarget", "False", "batch/v1 Job"],
+  ["NamespaceDeletionContentFailure", "False", "core/v1 Namespace"],
+  ["NamespaceDeletionDiscoveryFailure", "False", "core/v1 Namespace"],
+  ["NamespaceDeletionGroupVersionParsingFailure", "False", "core/v1 Namespace"],
+  // The two the previous round left behind on the very resource it fixed:
+  // the namespace controller sets these True while deletion is blocked, and
+  // False with "All content successfully removed" once it is not.
+  ["NamespaceContentRemaining", "False", "core/v1 Namespace — deletion blocked"],
+  ["NamespaceFinalizersRemaining", "False", "core/v1 Namespace — deletion blocked"],
+  ["Dangling", "False", "flowcontrol FlowSchema"],
+  ["Degraded", "False", "KEP-1623 / operator convention"],
+  ["DisruptionTarget", "False", "core/v1 Pod — about to be evicted"],
+  ["Denied", "False", "certificates/v1 CSR"],
+  ["ControllerResizeError", "False", "core/v1 PersistentVolumeClaim"],
+  ["NodeResizeError", "False", "core/v1 PersistentVolumeClaim"],
+  ["ModifyVolumeError", "False", "core/v1 PersistentVolumeClaim"],
+];
+
+describe("conditionKind — the polarity of every type it claims to know", () => {
+  it.each(POLARITY)("reads %s (%s is well — %s) from both ends", (type, wellWhen) => {
+    const ill = wellWhen === "True" ? "False" : "True";
+    expect({ type, status: wellWhen, kind: conditionKind({ type, status: wellWhen }) }).toEqual({
+      type,
+      status: wellWhen,
+      kind: "success",
+    });
+    expect({ type, status: ill, kind: conditionKind({ type, status: ill }) }).toEqual({
+      type,
+      status: ill,
+      kind: "danger",
+    });
+  });
+
+  it("keeps Unknown amber for every one of them, whichever way the type points", () => {
+    // The status trumps the polarity: nobody knows, so nobody is condemned.
+    for (const [type] of POLARITY) {
+      expect({ type, kind: conditionKind({ type, status: "Unknown" }) }).toEqual({ type, kind: "warning" });
+    }
+  });
+
+  it("covers both polarities, so neither half can be satisfied by a constant answer", () => {
+    // The table is only a polarity test while it holds rows of both kinds —
+    // a defect on the previous plan survived its first pass because a fixture
+    // held one state and a wrong rule agreed with the right one by accident.
+    expect(POLARITY.filter(([, well]) => well === "True").length).toBeGreaterThan(0);
+    expect(POLARITY.filter(([, well]) => well === "False").length).toBeGreaterThan(0);
+  });
+});
+
 // The new design's opt-in extension of `conditionKind`: same rule, plus a
 // reason read for the types that need one. Classic must never call this.
 describe("conditionKindWithReason", () => {

--- a/packages/core/src/lib/k8sHealth.ts
+++ b/packages/core/src/lib/k8sHealth.ts
@@ -18,8 +18,14 @@ export type HealthKind = "neutral" | "success" | "warning" | "danger" | "info";
  * either design passes the result straight into its own pill.
  *
  * `Ready`/`NotReady` are here because a Node reports readiness where a Pod
- * reports a phase, and both go through this one table; a Pod never reports
- * either, and a Node never reports `Running`.
+ * reports a phase, and both go through this one table; a Node never reports
+ * `Running`.
+ *
+ * `NotReady` is no longer a Node's word alone. `podStatus` reaches for it for
+ * a pod that is up and short of ready — a crash-looper caught between
+ * restarts, which the API gives no phase and no waiting reason for — because
+ * the fact is the same fact, and a second word for it would be a second
+ * entry in this table to keep in step with the first.
  */
 export function phaseKind(phase: string): HealthKind {
   switch (phase) {

--- a/packages/core/src/lib/k8sHealth.ts
+++ b/packages/core/src/lib/k8sHealth.ts
@@ -58,8 +58,31 @@ export interface Condition {
  * ReplicaSet's `ReplicaFailure`, a Namespace's three `…Failure` conditions,
  * and a Job's `FailureTarget` — painting a healthy `ReplicaFailure: False`
  * red, which is what the design mock caught.
+ *
+ * The alternatives after `Dangling` are the second round of the same lesson.
+ * `Error` and `Remaining` are families for the same reason `Fail` is —
+ * `Error` covers a PVC's `ControllerResizeError`, `NodeResizeError` AND its
+ * `ModifyVolumeError`, and `Remaining` covers a Namespace's
+ * `NamespaceContentRemaining` and `NamespaceFinalizersRemaining`, the two the
+ * `Fail` round left behind on the very resource it fixed (the namespace
+ * controller sets both `True` while deletion is blocked, and `False` with
+ * "All content successfully removed" once it is not). The other three are
+ * single types because nothing conjugates them: `Degraded` is the one
+ * condition in the KEP-1623 vocabulary whose `True` is the bad state,
+ * `DisruptionTarget` says a pod is about to be evicted, and `Denied` on a
+ * CertificateSigningRequest says the request was refused.
+ *
+ * **A substring is a claim about every type that contains it**, which is the
+ * cost of the family form and the reason one candidate is deliberately NOT
+ * here. kstatus's (and Flux's) `Stalled` is exactly this shape — `True` means
+ * reconciliation has given up — but "Installed" CONTAINS "stalled"
+ * (i-n-**s-t-a-l-l-e-d**), so adding it would paint every operator's
+ * `Installed: True` red: the same inversion this constant keeps being fixed
+ * for, pointed the other way. Landing `Stalled` needs a whole-type match
+ * rather than a substring one, and no type in srelens's reach needs it yet.
+ * The test file's `POLARITY` table holds `Installed` as a live guard.
  */
-const NEGATIVE_CONDITION = /Pressure|Unavailable|Fail|Dangling/i;
+const NEGATIVE_CONDITION = /Pressure|Unavailable|Fail|Dangling|Error|Remaining|Degraded|DisruptionTarget|Denied/i;
 
 /**
  * A condition's tone from its type and status alone. The rule both designs

--- a/packages/core/src/lib/k8sStatus.test.ts
+++ b/packages/core/src/lib/k8sStatus.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from "vitest";
-import { cronJobStatus, eventVerdict, jobStatus, nodeStatus, podStatus, resourceStatusLine, scaledStatus } from "./k8sStatus";
+import {
+  cronJobStatus,
+  eventVerdict,
+  jobStatus,
+  nodeStatus,
+  podStatus,
+  resourceStatusLine,
+  scaledStatus,
+  type PodVitals,
+} from "./k8sStatus";
 import type { K8sObject } from "./manifest";
 
 /** A Deployment-shaped object: `spec.replicas` desired, the rest on `status`. */
@@ -18,10 +27,10 @@ const pod = (status: Record<string, unknown>, spec: Record<string, unknown> = {}
 });
 
 /** One container status, as kubelet reports it. */
-const container = (name: string, state: Record<string, unknown>, ready: boolean) => ({
+const container = (name: string, state: Record<string, unknown>, ready: boolean, restartCount = 0) => ({
   name,
   ready,
-  restartCount: 0,
+  restartCount,
   state,
 });
 
@@ -372,12 +381,33 @@ describe("resourceStatusLine — kinds with no status line", () => {
   });
 });
 
+/**
+ * One pod row's vitals — the four fields `PodSummary` carries, defaulted to a
+ * plain healthy pod so each test states only the facts it is about.
+ *
+ * The defaults are the healthy ones on purpose: a test that means "not ready"
+ * has to SAY "0/1", so no assertion below passes because a fixture happened to
+ * agree with it.
+ */
+const vitals = (over: Partial<PodVitals> & { phase: string }): PodVitals => ({
+  waitingReason: "",
+  ready: "1/1",
+  restarts: 0,
+  ...over,
+});
+
 describe("podStatus — the one reading a list row and a fetched object share", () => {
   it("gives a crash-looping pod the same verdict the header derives from the object", () => {
-    // The whole point of the shared function: `PodSummary` carries the phase
-    // and the waiting reason, `K8sObject` carries the container statuses those
-    // were summarised from, and both arrive here.
-    expect(podStatus("Running", "CrashLoopBackOff")).toEqual({
+    // The whole point of the shared function: `PodSummary` carries the phase,
+    // the waiting reason and the ready count, `K8sObject` carries the
+    // container statuses those were summarised from, and both arrive here.
+    const backingOff = vitals({
+      phase: "Running",
+      waitingReason: "CrashLoopBackOff",
+      ready: "0/1",
+      restarts: 1123,
+    });
+    expect(podStatus(backingOff)).toEqual({
       status: "CrashLoopBackOff",
       health: "danger",
       flagged: true,
@@ -386,40 +416,41 @@ describe("podStatus — the one reading a list row and a fetched object share", 
       kind: "Pod",
       status: {
         phase: "Running",
-        containerStatuses: [{ name: "api", ready: false, state: { waiting: { reason: "CrashLoopBackOff" } } }],
+        containerStatuses: [
+          { name: "api", ready: false, restartCount: 1123, state: { waiting: { reason: "CrashLoopBackOff" } } },
+        ],
       },
     };
     const line = resourceStatusLine("Pod", object)!;
     const { readyText, ...verdict } = line;
-    expect(verdict).toEqual(podStatus("Running", "CrashLoopBackOff"));
+    expect(verdict).toEqual(podStatus(backingOff));
     expect(readyText).toBe("0/1 ready");
   });
 
   it("warns rather than fails for a pod still pulling or creating", () => {
-    expect(podStatus("Pending", "ContainerCreating")).toEqual({
+    expect(podStatus(vitals({ phase: "Pending", waitingReason: "ContainerCreating", ready: "0/1" }))).toEqual({
       status: "ContainerCreating",
       health: "warning",
       flagged: true,
     });
-    expect(podStatus("Pending", "ImagePullBackOff")).toEqual({
+    expect(podStatus(vitals({ phase: "Pending", waitingReason: "ImagePullBackOff", ready: "0/1" }))).toEqual({
       status: "ImagePullBackOff",
       health: "danger",
       flagged: true,
     });
   });
 
-  it("falls back to the phase when no container is waiting", () => {
-    expect(podStatus("Running", "")).toEqual({ status: "Running", health: "success", flagged: false });
-    expect(podStatus("Running")).toEqual({ status: "Running", health: "success", flagged: false });
+  it("falls back to the phase when no container is waiting and every one is ready", () => {
+    expect(podStatus(vitals({ phase: "Running" }))).toEqual({ status: "Running", health: "success", flagged: false });
   });
 
   it("keeps a finished pod finished, whatever a stale waiting entry says", () => {
-    expect(podStatus("Succeeded", "CrashLoopBackOff")).toEqual({
+    expect(podStatus(vitals({ phase: "Succeeded", waitingReason: "CrashLoopBackOff", ready: "0/1" }))).toEqual({
       status: "Succeeded",
       health: "success",
       flagged: false,
     });
-    expect(podStatus("Failed", "CrashLoopBackOff")).toEqual({
+    expect(podStatus(vitals({ phase: "Failed", waitingReason: "CrashLoopBackOff", ready: "0/1" }))).toEqual({
       status: "Failed",
       health: "danger",
       flagged: true,
@@ -427,14 +458,220 @@ describe("podStatus — the one reading a list row and a fetched object share", 
   });
 
   it("calls an empty phase Unknown rather than rendering a blank pill", () => {
-    expect(podStatus("", "")).toEqual({ status: "Unknown", health: "danger", flagged: true });
+    expect(podStatus(vitals({ phase: "" }))).toEqual({ status: "Unknown", health: "danger", flagged: true });
   });
 
   it("flags a phase word it does not recognise without inventing a colour for it", () => {
     // `podFlagged`'s rule verbatim: anything the phase table does not call
     // healthy earns the dot. The tone stays neutral because nothing has told
     // us it is red.
-    expect(podStatus("Evicted", "")).toEqual({ status: "Evicted", health: "neutral", flagged: true });
+    expect(podStatus(vitals({ phase: "Evicted" }))).toEqual({ status: "Evicted", health: "neutral", flagged: true });
+  });
+});
+
+/**
+ * The flicker, and the property that ends it.
+ *
+ * Written against a real pod: `legacy-adapter-857bf965b8-4wclg` in `payments`
+ * on `kind-srelens-demo`, restart count 1123, back-off 5m0s. A `kubectl get -w`
+ * on it publishes exactly three shapes, and they are worth reading rather than
+ * reasoning about, because the middle one is not the shape the docs suggest:
+ *
+ *     phase=Running ready=false restarts=1125 state=waiting(CrashLoopBackOff)
+ *     phase=Running ready=false restarts=1126 state=terminated(Error)
+ *     phase=Running ready=false restarts=1126 state=waiting(CrashLoopBackOff)
+ *
+ * The middle event is the flicker window. The container is NOT waiting there,
+ * so `waitingReason` is `""` and the phase is still `Running` — and the old
+ * rule, with nothing else to read, called the pod well. (Polling for it does
+ * not work: at 0.25s intervals, 1400 samples never caught it. The window is
+ * one status publish wide, which is why it took a watch.)
+ *
+ * Note the two columns that do NOT move across all three events: `ready` is
+ * `false` in every one, and `restartCount` never goes down. That pair is the
+ * signal, and the fixtures below are built out of it. The container state is
+ * deliberately NOT: a pod caught mid-restart may be `terminated` (as here) or
+ * `running` (as a slower container would be), and a rule keyed on which one
+ * would have swapped one flicker for another.
+ */
+describe("podStatus — a persistently unready pod does not flicker out of the list", () => {
+  /** The same pod, at the two moments a poll can catch it. */
+  const BACKING_OFF = vitals({
+    phase: "Running",
+    waitingReason: "CrashLoopBackOff",
+    ready: "0/1",
+    restarts: 1123,
+  });
+  const BETWEEN_RESTARTS = vitals({ phase: "Running", waitingReason: "", ready: "0/1", restarts: 1123 });
+
+  it("condemns the pod at BOTH moments, on the same tone and the same dot", () => {
+    const backingOff = podStatus(BACKING_OFF);
+    const between = podStatus(BETWEEN_RESTARTS);
+    // Membership of every unhealthy list, and the tone that list counts by —
+    // `Overview`'s `worst()` reads `health`, so a tone that moved would
+    // flicker the tile's colour even with the row still present.
+    expect({ flagged: between.flagged, health: between.health }).toEqual({ flagged: true, health: "danger" });
+    expect({ flagged: backingOff.flagged, health: backingOff.health }).toEqual({ flagged: true, health: "danger" });
+  });
+
+  it("says NotReady in the moment there is no waiting reason to name", () => {
+    // The word is the one fact that legitimately differs: between restarts the
+    // kubelet is reporting no reason, so there is none to show. `NotReady` is
+    // the ready ratio read aloud, and it goes through `phaseKind` — which
+    // already tones that exact word danger for a Node — rather than pairing a
+    // word with a colour here.
+    expect(podStatus(BETWEEN_RESTARTS).status).toBe("NotReady");
+    expect(podStatus(BACKING_OFF).status).toBe("CrashLoopBackOff");
+  });
+
+  it("leaves a pod that is legitimately starting alone", () => {
+    // A container up for two seconds and not yet past its readiness probe is
+    // normal, and is NOT the same thing as one that is failing. The restart
+    // count is what separates them, and it is the only in-snapshot evidence
+    // there is: a row carries no clock, so "not ready yet" and "not ready for
+    // an hour" are the same row. A pod that has never restarted has not
+    // failed at anything.
+    expect(podStatus(vitals({ phase: "Running", ready: "0/1", restarts: 0 }))).toEqual({
+      status: "Running",
+      health: "success",
+      flagged: false,
+    });
+    expect(podStatus(vitals({ phase: "Running", ready: "1/2", restarts: 0 }))).toEqual({
+      status: "Running",
+      health: "success",
+      flagged: false,
+    });
+  });
+
+  it("leaves a pod that has restarted but recovered alone", () => {
+    // Restarts alone condemn nothing: the pod is ready NOW, which is the
+    // question. Only the pair — restarted, and still not ready — is a crash
+    // loop caught mid-breath.
+    expect(podStatus(vitals({ phase: "Running", ready: "1/1", restarts: 1123 }))).toEqual({
+      status: "Running",
+      health: "success",
+      flagged: false,
+    });
+    expect(podStatus(vitals({ phase: "Running", ready: "2/2", restarts: 4 }))).toEqual({
+      status: "Running",
+      health: "success",
+      flagged: false,
+    });
+  });
+
+  it("does NOT resurrect a Succeeded pod, however unready and however restarted", () => {
+    // The old bug this file was refactored around: a `Succeeded` pod with a
+    // green pill and a red dot. Its containers are TERMINATED, so its ready
+    // ratio is `0/1` forever — reading that ratio without stopping at the
+    // terminal phases would flag every finished pod in the cluster, which on
+    // the demo cluster is 53 of them.
+    expect(podStatus(vitals({ phase: "Succeeded", ready: "0/1", restarts: 0 }))).toEqual({
+      status: "Succeeded",
+      health: "success",
+      flagged: false,
+    });
+    expect(podStatus(vitals({ phase: "Succeeded", ready: "0/3", restarts: 7 }))).toEqual({
+      status: "Succeeded",
+      health: "success",
+      flagged: false,
+    });
+  });
+
+  it("does not re-word a Failed pod, which already has a word of its own", () => {
+    expect(podStatus(vitals({ phase: "Failed", ready: "0/1", restarts: 9 }))).toEqual({
+      status: "Failed",
+      health: "danger",
+      flagged: true,
+    });
+  });
+
+  it("keeps a Pending pod's own word rather than overriding it with the ratio", () => {
+    // Pending is already amber and already flagged; the ratio adds nothing
+    // and `NotReady` would lose the reader the fact that it is unscheduled.
+    expect(podStatus(vitals({ phase: "Pending", ready: "0/1", restarts: 2 }))).toEqual({
+      status: "Pending",
+      health: "warning",
+      flagged: true,
+    });
+  });
+
+  it("keeps an unrecognised phase word, which the ratio has no standing to overrule", () => {
+    expect(podStatus(vitals({ phase: "Evicted", ready: "0/1", restarts: 3 }))).toEqual({
+      status: "Evicted",
+      health: "neutral",
+      flagged: true,
+    });
+  });
+
+  it("reads a ratio it cannot parse as no reading, never as unready", () => {
+    // "0/0" is what the backend sends for a pod the kubelet has reported no
+    // containers for, and an empty or malformed cell is what a fixture sends.
+    // None of the three is evidence a pod is unready, and inventing a dot
+    // from an absence is how a healthy pod gets condemned.
+    for (const ready of ["0/0", "", "—", "1", "x/y"]) {
+      expect({ ready, verdict: podStatus(vitals({ phase: "Running", ready, restarts: 5 })) }).toEqual({
+        ready,
+        verdict: { status: "Running", health: "success", flagged: false },
+      });
+    }
+  });
+
+  it("derives the same verdict off a fetched object as off the row", () => {
+    // The two readings that must never disagree — the pods list row and the
+    // detail header, on the same pod at the same moment.
+    const object: K8sObject = {
+      kind: "Pod",
+      status: {
+        phase: "Running",
+        containerStatuses: [
+          {
+            name: "adapter",
+            ready: false,
+            restartCount: 1123,
+            // The live shape: terminated with exit code 1, no waiting entry.
+            state: { terminated: { exitCode: 1, reason: "Error", finishedAt: "2026-08-24T13:28:18Z" } },
+          },
+        ],
+      },
+    };
+    const line = resourceStatusLine("Pod", object)!;
+    expect(line).toEqual({ status: "NotReady", health: "danger", flagged: true, readyText: "0/1 ready" });
+    const { readyText, ...verdict } = line;
+    expect(verdict).toEqual(podStatus(BETWEEN_RESTARTS));
+  });
+
+  it("sums restarts across containers when reading an object, as the row does", () => {
+    // `summarise_pod` sums `restart_count` over every container status; a
+    // header that read only the first would disagree with its own row on a
+    // sidecar pod.
+    const object: K8sObject = {
+      kind: "Pod",
+      status: {
+        phase: "Running",
+        containerStatuses: [
+          { name: "app", ready: true, restartCount: 0, state: { running: {} } },
+          { name: "envoy", ready: false, restartCount: 12, state: { running: {} } },
+        ],
+      },
+    };
+    expect(resourceStatusLine("Pod", object)).toEqual({
+      status: "NotReady",
+      health: "danger",
+      flagged: true,
+      readyText: "1/2 ready",
+    });
+  });
+
+  it("leaves a pod the kubelet has not reported containers for alone", () => {
+    // No container statuses at all: `0/0`, no ratio to show, and nothing that
+    // says the pod is unready — only that nobody has looked yet.
+    const object: K8sObject = { kind: "Pod", status: { phase: "Running" } };
+    expect(resourceStatusLine("Pod", object)).toEqual({
+      status: "Running",
+      health: "success",
+      flagged: false,
+      readyText: null,
+    });
   });
 });
 
@@ -463,6 +700,9 @@ describe("the tone and the dot are paired structurally", () => {
       // in a back-off, and one merely on its way up.
       ["Pod", pod({ phase: "Running", containerStatuses: [container("a", { waiting: { reason: "CrashLoopBackOff" } }, false)] })],
       ["Pod", pod({ phase: "Pending", containerStatuses: [container("a", { waiting: { reason: "ContainerCreating" } }, false)] })],
+      // The unready branch, which neither the phase nor a waiting reason
+      // reaches: a crash-looper caught between restarts, up and not ready.
+      ["Pod", pod({ phase: "Running", containerStatuses: [container("a", { running: {} }, false, 1123)] })],
       // A word the phase table does not know — the only producer of UNREADABLE.
       ["Pod", pod({ phase: "Evicted" })],
       ["Deployment", deployment({ replicas: 3 }, { readyReplicas: 3 })],

--- a/packages/core/src/lib/k8sStatus.ts
+++ b/packages/core/src/lib/k8sStatus.ts
@@ -148,6 +148,47 @@ function daemonSetStatusLine(object: K8sObject): ResourceStatusLine {
 const TERMINAL_POD_PHASES = ["Succeeded", "Failed"];
 
 /**
+ * The facts one pod carries, wherever it is read from.
+ *
+ * Taken as a record rather than as positional arguments because a
+ * `PodSummary` — and every row type built on one — is already this shape, so
+ * every call site hands over the whole row and CANNOT omit a field it does
+ * not happen to be thinking about. That is not a style preference: the
+ * flicker below existed because the two facts that were passed were the only
+ * two the signature asked for, and the fact that would have settled it was
+ * sitting unread on the same row.
+ */
+export interface PodVitals {
+  /** `status.phase` — "Running", "Pending", "Succeeded", "Failed", "Unknown". */
+  phase: string;
+  /** Why the first waiting container is waiting; `""` or absent when none is. */
+  waitingReason?: string;
+  /**
+   * Ready containers out of reported ones, exactly as a row prints it and
+   * kubectl's READY column shows it: `"1/1"`, `"0/2"`. `"0/0"` means the
+   * kubelet has reported no containers, which is an absence and not a
+   * reading.
+   */
+  ready: string;
+  /** Restarts summed across the pod's containers, as `summarise_pod` sums them. */
+  restarts: number;
+}
+
+/**
+ * Whether a READY cell says a container is short of ready.
+ *
+ * Anything that does not parse as two numbers is NOT short: `"0/0"` (nothing
+ * reported), `""` (a fixture), a dash. Reading an absence as a failure is how
+ * a healthy pod gets a red dot, and the backend's own `short_of_ready` errs
+ * the other way for the opposite reason — there, a cell it cannot read is
+ * worth one extra fetch; here, it would be worth a wrong verdict.
+ */
+function shortOfReady(cell: string): boolean {
+  const [have, want] = cell.split("/").map(Number);
+  return have < want;
+}
+
+/**
  * `podFlagged`'s rule as a verdict: anything the phase table does not call
  * healthy earns the dot, and keeps its own tone while doing so.
  */
@@ -160,9 +201,8 @@ function phaseVerdict(phase: string): Verdict {
 }
 
 /**
- * A pod's status word, tone and dot, from the two facts a list row and a
- * fetched object can both supply: the phase, and the reason a container is
- * waiting (`""` when none is).
+ * A pod's status word, tone and dot, from the facts a list row and a fetched
+ * object can both supply — see {@link PodVitals}.
  *
  * `status.phase` alone is not enough, and this is not a nicety: a pod whose
  * only container sits in `CrashLoopBackOff` still reports phase `Running`, so
@@ -171,22 +211,64 @@ function phaseVerdict(phase: string): Verdict {
  * we — in the list and in the detail header, through this one function, so the
  * two can never say different things about the same pod.
  *
- * A terminal pod is left alone: its containers are terminated, and a stale
- * waiting entry must not drag a finished pod back to unhealthy.
+ * **The waiting reason is not enough either, because a crash-looping pod is
+ * not always waiting.** Between restarts the container is genuinely up: phase
+ * `Running`, no waiting reason, nothing to read — and the pod fell out of
+ * every unhealthy list for that instant and came back when the container
+ * failed again. On a real cluster two of four consecutive screenshots of the
+ * overview showed the same pod in `NOT READY` and two did not, with nothing
+ * changed but the moment of the capture. The waiting reason names a state the
+ * pod is only intermittently in; the READY ratio names the state it is
+ * actually in, and does not move between the two moments.
+ *
+ * So a pod that is up, short of ready, AND has restarted is `NotReady`. The
+ * restart count is doing real work in that sentence and is not belt-and-
+ * braces: a container that has been up for two seconds and has not yet passed
+ * its readiness probe is a NORMAL pod mid-rollout, and the ratio alone cannot
+ * tell it from a crash-looper — a row carries no clock, so "not ready yet"
+ * and "not ready for an hour" are the same row. Having died at least once is
+ * the only evidence in the snapshot that this is failure rather than
+ * start-up. (A pod that has never restarted and never becomes ready — a
+ * readiness probe that never passes — is therefore still read as healthy
+ * here. That is a different bug with a different signal, and guessing at it
+ * from these fields would cost every rolling update a red dot.)
+ *
+ * `NotReady` is not a word invented beside a colour: it is the word
+ * {@link nodeStatus} already uses for the same fact, and `phaseKind` already
+ * tones it, so the branch below picks a verdict by name like every other one
+ * in this file.
+ *
+ * A terminal pod is left alone, and the ratio must not reach it. Its
+ * containers are TERMINATED, so a `Succeeded` pod reports `0/1` forever —
+ * reading that as "not ready" would flag every finished pod in the cluster,
+ * and put a green pill beside a red dot on each of them, which is the exact
+ * bug this file's `Verdict` union exists to prevent.
  */
-export function podStatus(phase: string, waitingReason = ""): StatusVerdict {
-  const word = phase || "Unknown";
-  if (waitingReason && !TERMINAL_POD_PHASES.includes(word)) {
-    return verdict(waitingReason, waitingKind(waitingReason) === "danger" ? BROKEN : UNSETTLED);
+export function podStatus(pod: PodVitals): StatusVerdict {
+  const word = pod.phase || "Unknown";
+  if (TERMINAL_POD_PHASES.includes(word)) return verdict(word, phaseVerdict(word));
+  if (pod.waitingReason) {
+    return verdict(pod.waitingReason, waitingKind(pod.waitingReason) === "danger" ? BROKEN : UNSETTLED);
+  }
+  // Only where the phase would otherwise say the pod is well. A Pending pod is
+  // already amber and already flagged, and an unrecognised word already earns
+  // its dot; overriding either with the ratio would lose the reader the more
+  // specific fact for no gain in the verdict.
+  //
+  // Compared on the tone rather than on {@link WELL}'s identity, for the same
+  // reason {@link nodeStatus} is: everything else in this file is safe by
+  // construction, and an identity check would be safe only by coincidence.
+  if (phaseVerdict(word).health === "success" && shortOfReady(pod.ready) && pod.restarts > 0) {
+    return verdict("NotReady", phaseVerdict("NotReady"));
   }
   return verdict(word, phaseVerdict(word));
 }
 
 /**
- * The same reading, off a fetched Pod: pull the phase and the first waiting
- * reason out of the object — the two fields `summarise_pod` puts on a
- * `PodSummary` — and hand them to `podStatus`, then add the ready count only
- * a detail header shows.
+ * The same reading, off a fetched Pod: pull the phase, the first waiting
+ * reason, the ready ratio and the restart total out of the object — the four
+ * fields `summarise_pod` puts on a `PodSummary` — and hand them to
+ * `podStatus`, then add the ready phrase only a detail header shows.
  */
 function podStatusLine(object: K8sObject): ResourceStatusLine {
   const status = asRecord(object.status);
@@ -197,10 +279,19 @@ function podStatusLine(object: K8sObject): ResourceStatusLine {
   const readyText = statuses.length > 0 ? `${ready}/${statuses.length} ready` : null;
   // First waiting container, in container order — the same one the backend
   // summarises onto a row.
-  const waiting = statuses
+  const waitingReason = statuses
     .map((c) => str(asRecord(asRecord(c.state).waiting).reason))
     .find((reason) => reason !== "");
-  return { ...podStatus(str(status.phase), waiting), readyText };
+  const vitals: PodVitals = {
+    phase: str(status.phase),
+    waitingReason,
+    ready: `${ready}/${statuses.length}`,
+    // Summed across containers, as `summarise_pod` sums `restart_count`: a
+    // header that read only the first container would disagree with its own
+    // row on a sidecar pod.
+    restarts: statuses.reduce((total, c) => total + count(c.restartCount), 0),
+  };
+  return { ...podStatus(vitals), readyText };
 }
 
 /**

--- a/packages/ui-kit/src/ErrorState.test.tsx
+++ b/packages/ui-kit/src/ErrorState.test.tsx
@@ -126,4 +126,34 @@ describe("ErrorState", () => {
     const { container } = render(<ErrorState title="Could not load pods" detail={false} />);
     expect(container.querySelector('[data-slot="detail"]')).toBeNull();
   });
+
+  it("folds the original message away under the detail rather than dropping it", () => {
+    const raw = "ApiError: Unauthorized (Status { code: Some(401) })";
+    const { container } = render(
+      <ErrorState
+        title="Could not list pods on prod-eu"
+        detail="The cluster rejected your credentials."
+        raw={raw}
+      />,
+    );
+    const disclosure = container.querySelector('[data-slot="raw"]') as HTMLDetailsElement;
+    expect(disclosure).not.toBeNull();
+    expect(disclosure.open).toBe(false);
+    expect(disclosure.textContent).toContain(raw);
+    // And nowhere in an attribute — the rule PairList and KV settled. (#331)
+    for (const node of Array.from(container.querySelectorAll("*"))) {
+      for (const attribute of Array.from(node.attributes)) {
+        expect(attribute.value).not.toContain(raw);
+      }
+    }
+  });
+
+  it("shows no disclosure when the detail IS the original message", () => {
+    // A caller whose `describeError` fell through to the generic case has the
+    // same string in both fields; drawing it twice reads as two problems.
+    const { container } = render(
+      <ErrorState title="Could not load pods" detail="connection refused" />,
+    );
+    expect(container.querySelector('[data-slot="raw"]')).toBeNull();
+  });
 });

--- a/packages/ui-kit/src/ErrorState.tsx
+++ b/packages/ui-kit/src/ErrorState.tsx
@@ -1,11 +1,23 @@
 import type { ReactNode } from "react";
 import { Button } from "./Button";
 import { cx } from "./cx";
+import { RawError } from "./RawError";
 import { filled } from "./slot";
 
 export interface ErrorStateProps {
   title: ReactNode;
   detail?: ReactNode;
+  /**
+   * The message the backend actually sent, when `detail` is a rewriting of it
+   * rather than the thing itself — folded away behind a word, see
+   * {@link RawError}.
+   *
+   * Separate from `detail` rather than appended to it because they are for
+   * different readers: the detail is what to do about the failure, and this is
+   * what to paste into a bug report. A caller whose detail IS the original
+   * message passes nothing here — the same string twice reads as two problems.
+   */
+  raw?: string;
   onRetry?: () => void;
   retryLabel?: string;
   /** An optional secondary action (e.g. "Diagnose in Toolbox"). */
@@ -31,6 +43,7 @@ export interface ErrorStateProps {
 export function ErrorState({
   title,
   detail,
+  raw,
   onRetry,
   retryLabel = "Retry",
   action,
@@ -68,6 +81,10 @@ export function ErrorState({
           {detail}
         </p>
       )}
+      {/* Unconditional: `RawError` renders nothing for an empty string, so
+          there is one place that decides what "no original to show" looks
+          like rather than two that can disagree. */}
+      <RawError text={raw ?? ""} className="w-full" />
       {(onRetry || action) && (
         <div data-slot="actions" className="flex flex-wrap justify-center gap-2">
           {/* `Button` deliberately leaves `type` alone, so a bare one submits

--- a/packages/ui-kit/src/RawError.test.tsx
+++ b/packages/ui-kit/src/RawError.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { RawError } from "./RawError";
+
+const STRUCT =
+  'ApiError: Unauthorized (Status { reason: Some("Unauthorized"), code: Some(401) })';
+
+describe("RawError", () => {
+  it("keeps the original message out of sight until it is asked for", () => {
+    render(<RawError text={STRUCT} />);
+    const details = screen.getByText("Original error").closest("details") as HTMLDetailsElement;
+    expect(details.open).toBe(false);
+    // In the DOM but not rendered: `details` collapses its own content, which
+    // is the whole point — nothing is thrown away and nothing is shouted.
+    expect(screen.getByText(STRUCT)).toBeDefined();
+  });
+
+  it("is a disclosure the keyboard can reach, not a hover affordance", () => {
+    render(<RawError text={STRUCT} />);
+    // `summary` is focusable and toggles on Enter/Space by the UA's own
+    // behaviour; what this pins is that the text hangs off one, rather than
+    // off a hover-only surface a keyboard user never opens.
+    expect(screen.getByText("Original error").tagName).toBe("SUMMARY");
+  });
+
+  it("never writes the message into an attribute", () => {
+    // The rule `PairList` and `KV` settled: a second, unredacted copy of a
+    // string must not sit in the markup where nothing on screen says it is
+    // there. This component exists BECAUSE `title` is not available. (#331)
+    const { container } = render(<RawError text={STRUCT} />);
+    for (const node of Array.from(container.querySelectorAll("*"))) {
+      for (const attribute of Array.from(node.attributes)) {
+        expect(
+          attribute.value,
+          `${node.tagName}.${attribute.name} carries the message`,
+        ).not.toContain(STRUCT);
+      }
+    }
+  });
+
+  it("offers no way to put the message back into an attribute", () => {
+    // Guards the guard, the way KV.test.tsx does: an opt-in is a flag someone
+    // eventually passes.
+    const source = readFileSync(join(__dirname, "RawError.tsx"), "utf8");
+    expect(source.replace(/\/\*[\s\S]*?\*\/|\/\/.*/g, "")).not.toContain("title=");
+  });
+
+  it("renders nothing at all when there is no original to show", () => {
+    // A bare disclosure that opens onto an empty box is worse than no word:
+    // the reader spends a click learning the app has nothing.
+    const { container } = render(<RawError text="" />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("takes the caller's word for the disclosure", () => {
+    render(<RawError text={STRUCT} label="What the cluster said" />);
+    expect(screen.getByText("What the cluster said")).toBeDefined();
+  });
+});

--- a/packages/ui-kit/src/RawError.tsx
+++ b/packages/ui-kit/src/RawError.tsx
@@ -1,0 +1,64 @@
+import { cx } from "./cx";
+import { filled } from "./slot";
+
+export interface RawErrorProps {
+  /**
+   * The message as the backend actually sent it — `describeError`'s `raw`.
+   * Empty renders nothing, so a caller can pass whatever it has.
+   */
+  text: string;
+  /** The word on the disclosure. */
+  label?: string;
+  className?: string;
+}
+
+/**
+ * The original error, folded away behind a word.
+ *
+ * A classified failure is shown to the reader as a sentence they can act on —
+ * "The cluster rejected your credentials" — and the string the cluster
+ * actually sent is 300 characters of `Status { metadata: Some(ListMeta { … })`.
+ * Both are needed by different people at different moments, and neither can
+ * stand in for the other: the sentence is useless in a bug report and the
+ * struct is useless on screen.
+ *
+ * **A disclosure, and specifically not a `title` attribute.** The kit removed
+ * value-carrying `title`s from `PairList` and `KV` after a `kubectl
+ * apply`-managed Secret leaked through one, and there is no prop to put them
+ * back (4132850, 255bcc7). The rule those two settled is that a second,
+ * unredacted copy of a string must never sit in the markup where nothing on
+ * screen says it is there. A `details` is the opposite of that in every
+ * respect: it is one copy, the reader asks for it, it is a Tab stop, it
+ * announces itself as expandable, and the text can be selected and pasted —
+ * which is the entire reason anyone wants it.
+ *
+ * A `Tooltip` was the other candidate, and it is what `ClusterRail` uses for
+ * a failure with 46px to say it in. It loses on this surface for the reason it
+ * wins on that one: a hint is short, transient and hard to copy from, and this
+ * is a long string whose only use is being copied.
+ *
+ * Closed by default, and it stays closed on its own — no state, no memory. The
+ * reader who wants it opens it; every other reader sees one quiet word.
+ */
+export function RawError({ text, label = "Original error", className }: RawErrorProps) {
+  if (!filled(text)) return null;
+  return (
+    <details data-slot="raw" className={cx("text-left", className)}>
+      {/* `list-none` because the marker's own triangle is drawn by the UA in a
+          colour and size nothing here controls; the caret is the caller's
+          type, which follows the theme. */}
+      <summary className="cursor-pointer list-none text-[0.75rem] text-faint underline decoration-dotted underline-offset-2">
+        {label}
+      </summary>
+      {/* `pre` rather than a paragraph: this is machine output, and the line
+          breaks a Rust struct or a stack of causes arrives with are part of
+          reading it. `whitespace-pre-wrap` keeps them without also letting a
+          400-character single line push the surface sideways, and the cap
+          means a long chain scrolls inside the disclosure rather than
+          swallowing the panel it opened in. */}
+      <pre className="scroll mt-1 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded bg-canvas-deep p-2 font-mono text-[0.6875rem] leading-relaxed text-faint">
+        {text}
+      </pre>
+    </details>
+  );
+}

--- a/packages/ui-kit/src/gallery/Gallery.tsx
+++ b/packages/ui-kit/src/gallery/Gallery.tsx
@@ -43,6 +43,7 @@ import { Panel } from "../Panel";
 import { Popover } from "../Popover";
 import { Progress } from "../Progress";
 import { Radio } from "../Radio";
+import { RawError } from "../RawError";
 import { ResizeHandle } from "../ResizeHandle";
 import { ResourceTree, type ResourceNode } from "../ResourceTree";
 import { Screen } from "../Screen";
@@ -73,6 +74,17 @@ import { WorkspaceTree } from "../WorkspaceTree";
 import type { Tone } from "../tone";
 
 const TONES: Tone[] = ["muted", "ok", "info", "accent", "warn", "sev"];
+
+/**
+ * What a cluster's refusal actually looks like on the wire — kube-rs's
+ * `ApiError` Display, as `podCount` hands it to the overview. Written out in
+ * full because the catalogue's job is to show the states that break on a real
+ * cluster, and this is the one that used to be printed at the reader.
+ */
+const API_ERROR =
+  'ApiError: Unauthorized: Unauthorized (Status { status: Some("Failure"), metadata: ' +
+  "Some(ListMeta { continue_: None, remaining_item_count: None, resource_version: None, " +
+  'self_link: None }), reason: Some("Unauthorized"), code: Some(401), message: Some("Unauthorized") })';
 
 /**
  * A stand-in for a real icon. The kit does not depend on an icon set — callers
@@ -654,6 +666,22 @@ export function Gallery() {
           onRetry={() => {}}
           action={{ label: "Diagnose in Toolbox", onClick: () => {} }}
         />
+        {/* The shape a classified failure takes: a sentence the reader can act
+            on, with what the cluster actually said folded away under it. */}
+        <ErrorState
+          title="Could not list pods on prod-eu"
+          detail="The cluster rejected your credentials. Your token or client certificate may have expired — refresh your kubeconfig credentials and try again."
+          raw={API_ERROR}
+          onRetry={() => {}}
+        />
+      </section>
+
+      <section>
+        <h2>RawError</h2>
+        {/* Standing on its own, for a surface too narrow for a paragraph: the
+            overview's Fleet rows are 286px and say one word plus this. */}
+        <RawError text={API_ERROR} />
+        <RawError text={API_ERROR} label="What the cluster said" />
       </section>
 
       <section>

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -43,6 +43,7 @@ export { Panel, type PanelProps } from "./Panel";
 export { Popover, type PopoverProps } from "./Popover";
 export { Progress, type ProgressProps } from "./Progress";
 export { Radio, type RadioProps } from "./Radio";
+export { RawError, type RawErrorProps } from "./RawError";
 export { ResizeHandle, type ResizeEdge, type ResizeHandleProps } from "./ResizeHandle";
 export { type ResourceNode, ResourceTree, type ResourceTreeProps, filterResourceNodes, useFolds } from "./ResourceTree";
 export { Screen, type ScreenProps } from "./Screen";

--- a/packages/ui-next/src/lib/errorCopy.test.tsx
+++ b/packages/ui-next/src/lib/errorCopy.test.tsx
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { describeError } from "@srelens/core";
+import { FailureAlert, FailureState, FailureWord, friendly, summarise } from "./errorCopy";
+
+/** The 401 the overview's Fleet rail was printing at the reader, verbatim. */
+const API_401 =
+  'Error: handler error: ApiError: Unauthorized: Unauthorized (Status { status: Some("Failure"), ' +
+  "metadata: Some(ListMeta { continue_: None, remaining_item_count: None, resource_version: None, " +
+  'self_link: None }), reason: Some("Unauthorized"), code: Some(401), message: Some("Unauthorized") })';
+
+/** `redactSecretManifest`'s fail-closed copy: this package's own words. */
+const REDACTION_REFUSED =
+  "This Secret's manifest is not shown, because it could not be redacted: it uses YAML aliases, " +
+  "which could re-expose a redacted value.";
+
+describe("friendly", () => {
+  it("classifies rather than repeating what the cluster said", () => {
+    const copy = friendly(API_401);
+    expect(copy.title).toBe("Not authorized");
+    expect(copy.detail).toMatch(/rejected your credentials/);
+    expect(copy.detail).not.toMatch(/ListMeta/);
+  });
+
+  it("keeps the original when the copy replaced it", () => {
+    expect(friendly(API_401).raw).toContain("ListMeta");
+  });
+
+  it("offers no original when the copy IS the original", () => {
+    // The generic case returns the cleaned message as the detail. A
+    // disclosure that opens onto the line above it costs a click and teaches
+    // nothing.
+    const copy = friendly("something nobody has classified");
+    expect(copy.detail).toBe("something nobody has classified");
+    expect(copy.raw).toBeUndefined();
+  });
+
+  it("passes this package's own refusals through as written", () => {
+    // `redactSecretManifest` fails closed with sentences chosen so that no
+    // error message quotes the Secret's source. They are not cluster errors
+    // and match no branch, so they arrive whole — and, crucially, the SCREEN
+    // keeps its own title, so the reader is never told "Something went wrong"
+    // about the most careful message this codebase writes.
+    const copy = friendly(REDACTION_REFUSED);
+    expect(copy.detail).toBe(REDACTION_REFUSED);
+    expect(copy.raw).toBeUndefined();
+  });
+});
+
+describe("summarise", () => {
+  it("says one outage once", () => {
+    // Six kinds refused by one expired token is one problem, not six.
+    const { detail } = summarise([API_401, API_401, API_401]);
+    expect(detail).toBe(describeError(API_401).detail);
+  });
+
+  it("keeps genuinely different failures apart", () => {
+    const { detail } = summarise([API_401, "dial tcp 10.1.2.3:6443: connect: connection refused"]);
+    expect(detail).toMatch(/rejected your credentials/);
+    expect(detail).toMatch(/connection to the API server could not be made/);
+    expect(detail).toContain(" · ");
+  });
+
+  it("drops the empty reasons the callers filter on", () => {
+    expect(summarise([]).detail).toBe("");
+    expect(summarise(["", ""]).detail).toBe("");
+  });
+
+  it("carries every original, separated so two structs cannot read as one", () => {
+    const raw = summarise([API_401, "x509: certificate signed by unknown authority"]).raw ?? "";
+    expect(raw).toContain("ListMeta");
+    expect(raw).toContain("x509");
+    expect(raw.split("\n\n")).toHaveLength(2);
+  });
+});
+
+describe("FailureState", () => {
+  it("keeps the screen's own title and replaces only the detail", () => {
+    const { container } = render(
+      <FailureState title="Could not list pods on prod-eu" error={API_401} />,
+    );
+    expect(screen.getByText("Could not list pods on prod-eu")).toBeDefined();
+    expect(screen.getByText(/rejected your credentials/)).toBeDefined();
+    // The struct is reachable (see below) but it is not the copy: the two
+    // slots the reader actually reads carry none of it.
+    expect(container.querySelector('[data-slot="detail"]')?.textContent).not.toMatch(/ListMeta/);
+    expect(screen.getByRole("alert").firstElementChild?.textContent).not.toMatch(/ListMeta/);
+  });
+
+  it("still has the original, folded away", () => {
+    const { container } = render(<FailureState title="Could not list pods" error={API_401} />);
+    const disclosure = container.querySelector('[data-slot="raw"]') as HTMLDetailsElement;
+    expect(disclosure.open).toBe(false);
+    expect(disclosure.textContent).toContain("ListMeta");
+  });
+
+  it("falls back to the classification's headline when the screen has no title of its own", () => {
+    render(<FailureState error={API_401} />);
+    expect(screen.getByText("Not authorized")).toBeDefined();
+  });
+
+  it("prints a Secret redaction refusal exactly as it was written", () => {
+    render(
+      <FailureState title="Could not load secret/db-creds's manifest" error={REDACTION_REFUSED} />,
+    );
+    expect(screen.getByText("Could not load secret/db-creds's manifest")).toBeDefined();
+    expect(screen.getByText(REDACTION_REFUSED)).toBeDefined();
+    expect(screen.queryByText("Something went wrong")).toBeNull();
+  });
+});
+
+describe("FailureAlert", () => {
+  it("keeps the caller's sentence about the rows and rewrites only the reason", () => {
+    render(<FailureAlert title="These pods are stale" error={API_401} />);
+    expect(screen.getByText("These pods are stale")).toBeDefined();
+    expect(screen.getByText(/rejected your credentials/)).toBeDefined();
+  });
+
+  it("is a warning over surviving rows, not an alert that stops the screen", () => {
+    const { container } = render(<FailureAlert title="These pods are stale" error={API_401} />);
+    expect(container.querySelector('[role="status"]')).not.toBeNull();
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it("carries the original under it", () => {
+    const { container } = render(<FailureAlert title="These pods are stale" error={API_401} />);
+    expect(container.querySelector('[data-slot="raw"]')?.textContent).toContain("ListMeta");
+  });
+});
+
+describe("FailureWord", () => {
+  it("is the headline and nothing else, for a surface with no room for a paragraph", () => {
+    render(<FailureWord error={API_401} />);
+    expect(screen.getByText("Not authorized")).toBeDefined();
+    expect(screen.queryByText(/rejected your credentials/)).toBeNull();
+  });
+
+  it("still reaches the original, which is the whole reason it is not a title attribute", () => {
+    const { container } = render(<FailureWord error={API_401} />);
+    const disclosure = container.querySelector('[data-slot="raw"]') as HTMLDetailsElement;
+    expect(disclosure.open).toBe(false);
+    expect(disclosure.textContent).toContain("ListMeta");
+    for (const node of Array.from(container.querySelectorAll("*"))) {
+      for (const attribute of Array.from(node.attributes)) {
+        expect(attribute.value).not.toContain("ListMeta");
+      }
+    }
+  });
+
+  it("puts a disclosure in flow markup, not inside phrasing content", () => {
+    // `details` is flow content. Nested in a `span` the parser rewrites the
+    // tree underneath the component, which is how a row loses its layout on
+    // one browser and keeps it on another.
+    const { container } = render(<FailureWord error={API_401} />);
+    expect((container.firstElementChild as HTMLElement).tagName).toBe("DIV");
+  });
+
+  it("still offers the original when nothing classified it", () => {
+    // The narrow surfaces print the TITLE, and an unclassified failure's title
+    // is "Something went wrong" — the message itself is only in `raw`. A row
+    // that said "Something went wrong" and stopped there would be telling the
+    // reader LESS than the raw string it replaced, which is the one thing this
+    // change is not allowed to do.
+    const { container } = render(<FailureWord error="etcdserver: leader changed" />);
+    expect(screen.getByText(/Something went wrong/)).toBeDefined();
+    const disclosure = container.querySelector('[data-slot="raw"]') as HTMLDetailsElement;
+    expect(disclosure).not.toBeNull();
+    expect(disclosure.textContent).toContain("etcdserver: leader changed");
+  });
+
+  it("takes a lead so a row can say what it is about", () => {
+    render(<FailureWord error={API_401} lead="Could not count Pod: " />);
+    expect(screen.getByText(/Could not count Pod: Not authorized/)).toBeDefined();
+  });
+});

--- a/packages/ui-next/src/lib/errorCopy.tsx
+++ b/packages/ui-next/src/lib/errorCopy.tsx
@@ -1,0 +1,195 @@
+import type { ReactNode } from "react";
+import { describeError } from "@srelens/core";
+import { Alert, ErrorState, RawError, type Tone } from "@srelens/ui-kit";
+
+/**
+ * The new design's error vocabulary: one way to turn a backend refusal into
+ * something a person can act on, and one place that decides what happens to
+ * the string the cluster actually sent.
+ *
+ * **Why this exists at all.** `describeError` has classified cluster failures
+ * since classic — exec-auth, timeouts, DNS, 401, 403, TLS — and it is
+ * platform-aware, because the remedy for an exec plugin that cannot run is a
+ * different sentence on the desktop than in the web container. Every one of
+ * its call sites was in `apps/desktop`. This package had none, so every screen
+ * here printed whatever Rust said: the cluster overview's Fleet rail was
+ * showing `ApiError: Unauthorized (Status { metadata: Some(ListMeta { … })` at
+ * the reader, in a column 286px wide.
+ *
+ * **The contextual title stays; the DETAIL is what `describeError` replaces.**
+ * This is the one deliberate departure from classic's call sites, which pass
+ * `title={describeError(e).title}`. Classic's error cards had no title of
+ * their own to lose. This package's do — "Could not list pods on prod-eu",
+ * "Could not load secret/db-creds's manifest" — and that half of the message
+ * is the half `describeError` can never know: it is handed a string, not a
+ * screen. "Not authorized" is also not a fact the detail withholds; the first
+ * sentence under it says "The cluster rejected your credentials" in words.
+ * Dropping the context to gain the classification would trade a fact for a
+ * paraphrase.
+ *
+ * It also keeps a copy this package writes ITSELF from being overwritten.
+ * `redactSecretManifest` fails closed with hand-written sentences — "This
+ * Secret's manifest is not shown, because it could not be redacted: it uses
+ * YAML aliases" — which are deliberately not cluster errors and match none of
+ * `describeError`'s branches. They come back through the generic case, so a
+ * screen passing `friendly.title` would title the Secret pane's most careful
+ * refusal "Something went wrong". With the contextual title kept, that message
+ * arrives exactly as written.
+ *
+ * **Nothing is dropped.** `describeError` keeps the original in `raw` for
+ * precisely this, and every surface below offers it — folded away behind a
+ * word, never in a `title` attribute. See {@link RawError} for why that
+ * distinction is not a detail.
+ */
+
+/** A classified failure, plus the one rule about when its original is worth offering. */
+export interface FriendlyCopy {
+  title: string;
+  detail: string;
+  /**
+   * The original message — `undefined` when it is the same string as `detail`,
+   * which is what the generic case returns. Showing it twice reads as two
+   * problems, and a disclosure that opens onto the line above it is a click
+   * spent learning nothing.
+   */
+  raw: string | undefined;
+}
+
+/** {@link describeError}, with the "is the original worth offering" rule applied. */
+export function friendly(error: unknown): FriendlyCopy {
+  const { title, detail, raw } = describeError(error);
+  return { title, detail, raw: raw === detail ? undefined : raw };
+}
+
+/**
+ * Several failures at once, as one piece of copy.
+ *
+ * The overview's fan-out sections are the shape this is for: `Not ready`
+ * checks six kinds and any subset of them can refuse, and `Stale` collects a
+ * reason from every loader that stopped refreshing. Deduplicated, because one
+ * expired token refuses all six and "your credentials expired" said six times
+ * is not six problems.
+ */
+export function summarise(errors: string[]): { detail: string; raw: string | undefined } {
+  const copies = errors.filter((e) => e !== "").map(friendly);
+  const details = [...new Set(copies.map((c) => c.detail))];
+  // The originals are kept apart by a blank line rather than the separator the
+  // sentences use: each one is a struct that already contains punctuation, and
+  // running two together makes a third thing that is neither.
+  const raws = [...new Set(copies.map((c) => c.raw).filter((r): r is string => r !== undefined))];
+  const detail = details.join(" · ");
+  const raw = raws.join("\n\n");
+  return { detail, raw: raw === "" || raw === detail ? undefined : raw };
+}
+
+export interface FailureStateProps {
+  /**
+   * What failed, in this screen's own words. Left out, the classification's
+   * own headline is used — which is what a surface with no context to add
+   * should do, and what classic's call sites all do.
+   */
+  title?: ReactNode;
+  error: unknown;
+  onRetry?: () => void;
+  retryLabel?: string;
+  action?: { label: string; onClick: () => void };
+  className?: string;
+}
+
+/** A content area whose load failed, said in words the reader can act on. */
+export function FailureState({ title, error, ...rest }: FailureStateProps) {
+  const copy = friendly(error);
+  return <ErrorState title={title ?? copy.title} detail={copy.detail} raw={copy.raw} {...rest} />;
+}
+
+export interface FailureAlertProps {
+  /**
+   * The banner's own headline — "These pods are stale", "Namespaces could not
+   * be listed". Required, and never taken from the classification: these
+   * banners sit over rows that are still on screen, and the sentence that
+   * makes them worth reading is about the ROWS, not about the failure.
+   */
+  title: ReactNode;
+  error: unknown;
+  /** `warn` by default: a banner over surviving rows is a warning, not a stop. */
+  tone?: Tone;
+  className?: string;
+}
+
+/**
+ * A warning over content that is still there — a stale list, a kind that could
+ * not be checked, a namespace picker that may be short.
+ *
+ * Deliberately NOT an error state: the rows above and below it are real, and
+ * replacing them with a card would throw away the only information the reader
+ * has. The title is the caller's for the same reason — those sentences were
+ * written on purpose and this only changes what sits under them.
+ */
+export function FailureAlert({ title, error, tone = "warn", className }: FailureAlertProps) {
+  const copy = friendly(error);
+  return (
+    <Alert tone={tone} title={title} className={className}>
+      {copy.detail}
+      <RawError text={copy.raw ?? ""} className="mt-1" />
+    </Alert>
+  );
+}
+
+/**
+ * A failure with room for a word and nothing more — the overview's Fleet rows
+ * (286px), a per-kind count that could not be taken, a cluster in the rail.
+ *
+ * The headline alone: `Not authorized`, `Can't reach the cluster`. A paragraph
+ * here would push the nine clusters that answered off the bottom of the rail,
+ * which is exactly what the struct was doing. The original is still one click
+ * away, and closed it costs a single quiet word.
+ */
+/**
+ * A failure in a place that has room for the sentence but no room for chrome —
+ * the line under a confirm dialog's kubectl preview, where the dialog itself
+ * has already said which action was refused.
+ *
+ * The detail rather than the headline, because this surface is wide: "Not
+ * authorized" under a Drain confirmation says less than "The cluster rejected
+ * your credentials — refresh your kubeconfig credentials and try again", and
+ * there is space for the second.
+ */
+export function FailureLine({ error, className }: { error: unknown; className?: string }) {
+  const copy = friendly(error);
+  return (
+    <div className={className}>
+      {copy.detail}
+      <RawError text={copy.raw ?? ""} className="mt-0.5" />
+    </div>
+  );
+}
+
+export function FailureWord({
+  error,
+  lead,
+  className,
+}: {
+  error: unknown;
+  /** What the row is about, when the word alone would not say — "Could not count Pod: ". */
+  lead?: ReactNode;
+  className?: string;
+}) {
+  // `describeError` rather than `friendly`, and the difference matters here.
+  // `friendly` withholds the original when it is the same string as the
+  // DETAIL, which is what the generic case returns — the right rule for every
+  // surface that prints the detail. This one prints the TITLE, so for an
+  // unclassified failure the title is "Something went wrong" and the message
+  // is only in `raw`: applying that rule here would leave a row saying
+  // "Something went wrong" and nothing else, which is less than the row said
+  // before any of this. The original is always offered.
+  const { title, raw } = describeError(error);
+  // A `div` rather than a `span`: `details` is flow content, and a disclosure
+  // inside phrasing markup is a shape the parser rewrites underneath you.
+  return (
+    <div className={className}>
+      {lead}
+      {title}
+      <RawError text={raw} className="mt-0.5" />
+    </div>
+  );
+}

--- a/packages/ui-next/src/lib/kinds/columns.test.ts
+++ b/packages/ui-next/src/lib/kinds/columns.test.ts
@@ -151,6 +151,44 @@ describe("pod columns", () => {
     expect(pill.props.kind).toBe("danger");
   });
 
+  it("keeps flagging that same pod in the instant it is BETWEEN restarts", () => {
+    // The second moment of the very pod above, and the one no fixture in this
+    // repo used to hold: the container is briefly up, so the kubelet reports
+    // no waiting reason at all and the phase is still "Running". The row used
+    // to lose its dot for that instant and get it back a moment later — on a
+    // real cluster, two of four consecutive screenshots.
+    //
+    // Only `waitingReason` differs from the row above. The ready ratio and the
+    // restart count do not move between the two moments, which is exactly why
+    // the verdict is now derived from them.
+    const between = { name: "checkout-api-7d", namespace: "d", phase: "Running", ready: "0/1", restarts: 7, node: "n", age: "1d", image: "acme/checkout-api:4f2a1c", waitingReason: "" };
+    expect(podFlagged(between)).toBe(true);
+    const phase = podColumns.find((c) => c.key === "phase")!;
+    const pill = phase.render!(between) as { props: { status: string; kind: string } };
+    expect(pill.props.status).toBe("NotReady");
+    expect(pill.props.kind).toBe("danger");
+    // The dot and the tone are what must not move; the word legitimately does,
+    // because between restarts there is no reason for the kubelet to name.
+    const backingOff = { ...between, waitingReason: "CrashLoopBackOff" };
+    expect(podFlagged(backingOff)).toBe(podFlagged(between));
+    const other = phase.render!(backingOff) as { props: { status: string; kind: string } };
+    expect(other.props.kind).toBe(pill.props.kind);
+  });
+
+  it("does not flag a pod that is merely starting up, restarts or no ready containers yet", () => {
+    // The other half of the same rule, and the reason the restart count is
+    // read at all: a container two seconds old that has not yet passed its
+    // readiness probe is a normal pod mid-rollout, not a failing one. A row
+    // carries no clock, so having died at least once is the only evidence in
+    // the snapshot that separates them.
+    const starting = { name: "web-9", namespace: "d", phase: "Running", ready: "0/1", restarts: 0, node: "n", age: "2s", image: "redis:7.4-alpine", waitingReason: "" };
+    expect(podFlagged(starting)).toBe(false);
+    const phase = podColumns.find((c) => c.key === "phase")!;
+    const pill = phase.render!(starting) as { props: { status: string; kind: string } };
+    expect(pill.props.status).toBe("Running");
+    expect(pill.props.kind).toBe("success");
+  });
+
   it("shows an image-pull failure the same way, and sorts the column on what it shows", () => {
     const pulling = { name: "web-0", namespace: "d", phase: "Pending", ready: "0/1", restarts: 0, node: "n", age: "1d", image: "acme/missing:1", waitingReason: "ImagePullBackOff" };
     const phase = podColumns.find((c) => c.key === "phase")!;

--- a/packages/ui-next/src/lib/kinds/columns.tsx
+++ b/packages/ui-next/src/lib/kinds/columns.tsx
@@ -82,7 +82,7 @@ const metricSort = (value: number | undefined) => value ?? -1;
  * disagree — they once did, on a crash-looping pod, because this read
  * `row.phase` alone and a pod in `CrashLoopBackOff` still reports "Running".
  */
-export const podFlagged = (row: PodRow): boolean => podStatus(row.phase, row.waitingReason).flagged;
+export const podFlagged = (row: PodRow): boolean => podStatus(row).flagged;
 
 export const podColumns: Column<PodRow>[] = [
   { key: "name", header: "Name", sortable: true },
@@ -91,13 +91,13 @@ export const podColumns: Column<PodRow>[] = [
   {
     key: "phase", header: "Status", sortable: true,
     render: (p) => {
-      const { status, health } = podStatus(p.phase, p.waitingReason);
+      const { status, health } = podStatus(p);
       return <StatusPill status={status} kind={health} />;
     },
     // Sorts on what the pill shows, not on the raw phase underneath it:
     // otherwise every waiting pod scatters under "Pending" and "Running"
     // instead of grouping with the other pods in the same trouble.
-    getSortValue: (p) => podStatus(p.phase, p.waitingReason).status,
+    getSortValue: (p) => podStatus(p).status,
   },
   { key: "restarts", header: "Restarts", sortable: true, align: "end" },
   { key: "cpu", header: "CPU", sortable: true, align: "end", render: (p) => metric(p.cpu, formatCpu), getSortValue: (p) => metricSort(p.cpu) },

--- a/packages/ui-next/src/screens/Events.test.tsx
+++ b/packages/ui-next/src/screens/Events.test.tsx
@@ -390,8 +390,14 @@ describe("Events", () => {
     await waitFor(() => expect(watchResource).toHaveBeenCalledTimes(1));
     await act(async () => stream.error("watch closed: 401"));
 
+    // The screen's own title, which names WHAT failed, plus the
+    // classification, which says what to do about it. The watch's own words
+    // are folded away rather than dropped.
     expect(screen.getByText("Could not list events on prod-eu")).toBeTruthy();
-    expect(screen.getByText("watch closed: 401")).toBeTruthy();
+    expect(screen.getByText(/rejected your credentials/)).toBeTruthy();
+    const folded = document.querySelector('[data-slot="raw"]') as HTMLDetailsElement;
+    expect(folded.open).toBe(false);
+    expect(folded.textContent).toContain("watch closed: 401");
 
     initialRows = EVENTS;
     await user.click(screen.getByRole("button", { name: "Retry" }));

--- a/packages/ui-next/src/screens/Events.tsx
+++ b/packages/ui-next/src/screens/Events.tsx
@@ -8,10 +8,8 @@ import {
 } from "@srelens/core";
 import { useNamespaceOptions } from "@srelens/core/react";
 import {
-  Alert,
   Button,
   ColumnPicker,
-  ErrorState,
   Eyebrow,
   FilterBar,
   LiveSignal,
@@ -27,6 +25,7 @@ import { useConsole } from "../console";
 import { getKubeconfigFiles, useActiveContext } from "../lib/clusters";
 import { useHiddenColumns } from "../lib/columnPrefs";
 import { detailRoute } from "../lib/detailRoute";
+import { FailureAlert, FailureState } from "../lib/errorCopy";
 import { Icons } from "../lib/icons";
 import {
   EVENT_DESCRIPTOR,
@@ -349,18 +348,16 @@ function EventList({
           // table rather than inside it — a "these rows are stale" warning the
           // reader scrolls past no longer warns anyone. The table runs flush to
           // the panel, so the alert carries its own inset.
-          <Alert tone="warn" title={`These ${lower} are stale`} className="mx-3 mt-3 mb-3">
-            {list.error}
-          </Alert>
+          <FailureAlert title={`These ${lower} are stale`} error={list.error} className="mx-3 mt-3 mb-3" />
         )}
 
         <div className="scroll min-h-0 flex-1">
           {list.status === "loading" ? (
             <LoadingState label={`Loading ${lower}`} />
           ) : list.status === "error" ? (
-            <ErrorState
+            <FailureState
               title={`Could not list ${lower} on ${name}`}
-              detail={list.error}
+              error={list.error}
               onRetry={list.reload}
             />
           ) : (

--- a/packages/ui-next/src/screens/Overview.test.tsx
+++ b/packages/ui-next/src/screens/Overview.test.tsx
@@ -113,14 +113,26 @@ function aPod(name: string, node: string, over: Partial<PodSummary> = {}): PodSu
  * that are not simply running. A fixture that starts from pods and derives all
  * three keeps the numbers in a test consistent with each other the way the
  * backend keeps them consistent on a real cluster.
+ *
+ * `unsettled` mirrors `crates/kube/src/pod_overview.rs`: the union of the
+ * `status.phase!=Running` field selector and every pod the printed pod table's
+ * READY column shows short of ready. It used to read `phase !== "Running" ||
+ * p.waitingReason`, which is a NARROWER list than the backend actually sends —
+ * a crash-looping pod between restarts has phase `Running` and no waiting
+ * reason, and the real `short_of_ready` still fetches it by name. Modelling
+ * the backend as narrower than it is hid the very pod this screen was losing.
  */
 function anOverview(pods: PodSummary[], over: Partial<PodOverview> = {}): PodOverview {
   const byNode = new Map<string, number>();
   for (const pod of pods) if (pod.node) byNode.set(pod.node, (byNode.get(pod.node) ?? 0) + 1);
+  const shortOfReady = (ready: string) => {
+    const [have, want] = ready.split("/").map(Number);
+    return !(have >= want);
+  };
   return {
     total: pods.length,
     byNode: [...byNode].map(([node, count]) => ({ node, pods: count })),
-    unsettled: pods.filter((p) => p.phase !== "Running" || p.waitingReason),
+    unsettled: pods.filter((p) => p.phase !== "Running" || shortOfReady(p.ready)),
     truncated: false,
     ...over,
   };
@@ -713,6 +725,62 @@ describe("Overview — the not-ready list", () => {
         expect(pill?.getAttribute("data-bad"), name).toBe("true");
       }
     }
+  });
+
+  it("holds a crash-looping pod in the list through the instant it is not backing off", async () => {
+    // The flicker, at the screen it was observed on. `aa-worker-0` is the same
+    // pod as in the fixture above with one field changed — the waiting reason
+    // the kubelet stops reporting while the container is briefly up. Nothing
+    // else about the pod moves: still 0/1 ready, still 41 restarts, still
+    // phase "Running". Two of four consecutive screenshots of this list caught
+    // it and two did not.
+    const between = SICK_PODS.map((p) =>
+      p.name === "aa-worker-0" ? { ...p, waitingReason: "", restarts: 41 } : p,
+    );
+    core.listDeployments.mockResolvedValue({ deployments: SICK_DEPLOYMENTS });
+    core.listStatefulSets.mockResolvedValue({ statefulsets: SICK_STATEFULSETS });
+    core.listDaemonSets.mockResolvedValue({ daemonsets: SICK_DAEMONSETS });
+    core.podOverview.mockResolvedValue({ pods: anOverview(between) });
+    open();
+
+    // Same six rows, same order: the pod holds its place at the top of the
+    // danger band rather than vanishing and re-appearing under the reader.
+    await waitFor(() => expect(notReadyNames()).toHaveLength(6));
+    expect(notReadyNames()).toEqual([
+      "aa-worker-0",
+      "cc-log-agent",
+      "mm-payments-db",
+      "zz-checkout-api",
+      "bb-queue-0",
+      "dd-mystery-0",
+    ]);
+    const row = notReadyRow("aa-worker-0")!;
+    expect(row.querySelector(".status")?.getAttribute("data-kind")).toBe("danger");
+    expect(row.querySelector(".status")?.textContent).toBe("NotReady");
+
+    // And the two pods that must NOT be dragged in with it, both of which are
+    // also short of ready: one finished, one never started.
+    expect(notReadyRow("done-backup-0")).toBeUndefined();
+    expect(notReadyRow("ok-web-0")).toBeUndefined();
+  });
+
+  it("counts that pod in the pods tile too, at the same severity", async () => {
+    // The tile reads `podFlagged` over the same list, so a pod that fell out
+    // of the rows fell out of the count and its colour with it — "4 not ready"
+    // one second and "3 not ready" the next, on an unchanged cluster.
+    const between = SICK_PODS.map((p) =>
+      p.name === "aa-worker-0" ? { ...p, waitingReason: "", restarts: 41 } : p,
+    );
+    core.podOverview.mockResolvedValue({ pods: anOverview(between) });
+    core.listDeployments.mockResolvedValue({ deployments: SICK_DEPLOYMENTS });
+    core.listStatefulSets.mockResolvedValue({ statefulsets: SICK_STATEFULSETS });
+    core.listDaemonSets.mockResolvedValue({ daemonsets: SICK_DAEMONSETS });
+    open();
+
+    await waitFor(() => expect(notReadyNames()).toHaveLength(6));
+    // Three pods flagged — the crash-looper, the Pending one and the one in a
+    // phase core cannot read — and NOT the Succeeded or the healthy one.
+    expect(screen.getByText("3 not ready")).toBeTruthy();
   });
 
   it("names every trailing fact, so a reader hears more than 'checkout 9/12'", async () => {

--- a/packages/ui-next/src/screens/Overview.test.tsx
+++ b/packages/ui-next/src/screens/Overview.test.tsx
@@ -74,6 +74,12 @@ const CTX: ClusterContext = {
 
 const ROUTE = "/overview";
 
+/** A 401 as `String(e)` over a `CapabilityError` actually delivers it. */
+const API_401 =
+  'Error: handler error: ApiError: Unauthorized: Unauthorized (Status { status: Some("Failure"), ' +
+  "metadata: Some(ListMeta { continue_: None, remaining_item_count: None, resource_version: None, " +
+  'self_link: None }), reason: Some("Unauthorized"), code: Some(401), message: Some("Unauthorized") })';
+
 function aNode(name: string, over: Partial<NodeSummary> = {}): NodeSummary {
   return {
     name,
@@ -497,11 +503,65 @@ describe("Overview — the nodes table", () => {
     // The rows are still the ones the cluster last gave, not an error state.
     await waitFor(() => expect(rowFor("n1")).toBeTruthy());
     expect(value("Nodes")).toBe("3");
-    // And the screen says so, once, with what the cluster actually said.
+    // And the screen says so, once, in words the reader can act on — the
+    // sentence about the rows is this screen's and does not change, the
+    // reason under it is the classification, and what the cluster actually
+    // said is folded away rather than dropped.
     const notice = await waitFor(() => screen.getByText(/no longer refreshing/i));
     expect(notice).toBeTruthy();
-    expect(screen.getByText(/nodes is forbidden/)).toBeTruthy();
+    expect(screen.getByText(/Check your RBAC roles/)).toBeTruthy();
+    const folded = document.querySelector('[data-slot="raw"]') as HTMLDetailsElement;
+    expect(folded.open).toBe(false);
+    expect(folded.textContent).toContain("nodes is forbidden");
     clock.mockRestore();
+  });
+
+  /**
+   * The rail is 286px wide, and every one of these rows used to print a
+   * whole apiserver `Status { … }` into it.
+   */
+  it("says why a count is missing in a phrase, not in the apiserver's struct", async () => {
+    // `listResource` is called with the kind LABEL, which is what the rail
+    // prints — `COUNTED_BY_LISTING` is CronJob and Job.
+    core.listResource.mockImplementation(async (_c: string, kind: string) =>
+      kind === "Job" ? { error: API_401 } : { items: [] },
+    );
+    open();
+
+    const row = await waitFor(() => screen.getByText(/Could not count Job/));
+    // The copy, with the folded-away original taken out: a closed `details`
+    // keeps its content in the DOM — that is what makes it a disclosure and
+    // not a deletion — so reading straight through `textContent` would pass
+    // whether or not the struct was being printed at the reader.
+    const copy = row.cloneNode(true) as HTMLElement;
+    copy.querySelector('[data-slot="raw"]')?.remove();
+    expect(copy.textContent).toBe("Could not count Job: Not authorized");
+    // Still reachable, still closed, still nowhere near an attribute.
+    const folded = row.querySelector('[data-slot="raw"]') as HTMLDetailsElement;
+    expect(folded.open).toBe(false);
+    expect(folded.textContent).toContain("ListMeta");
+    for (const node of Array.from(row.querySelectorAll("*"))) {
+      for (const attribute of Array.from(node.attributes)) {
+        expect(attribute.value).not.toContain("ListMeta");
+      }
+    }
+  });
+
+  it("says one outage once when it refused every kind at the same time", async () => {
+    // Six kinds behind one expired credential is one problem. Repeating the
+    // same sentence six times says it six times and explains it nowhere.
+    core.listNodes.mockResolvedValue({ error: API_401 });
+    core.podOverview.mockResolvedValue({ error: API_401 });
+    core.listDeployments.mockResolvedValue({ error: API_401 });
+    core.listStatefulSets.mockResolvedValue({ error: API_401 });
+    core.listDaemonSets.mockResolvedValue({ error: API_401 });
+    open();
+
+    const card = await waitFor(() => screen.getByText(/Could not check every workload/));
+    const detail = card.parentElement?.querySelector('[data-slot="detail"]');
+    expect(detail?.textContent).toBe(
+      "The cluster rejected your credentials. Your token or client certificate may have expired — refresh your kubeconfig credentials and try again.",
+    );
   });
 });
 

--- a/packages/ui-next/src/screens/Overview.tsx
+++ b/packages/ui-next/src/screens/Overview.tsx
@@ -24,6 +24,7 @@ import {
   ConfirmDialog,
   EmptyState,
   ErrorState,
+  RawError,
   KVList,
   KubectlPreview,
   LoadingState,
@@ -44,6 +45,7 @@ import {
 import { useConsole } from "../console";
 import { useActiveContext, useContexts } from "../lib/clusters";
 import { detailRoute } from "../lib/detailRoute";
+import { FailureLine, FailureState, FailureWord, summarise } from "../lib/errorCopy";
 import { Icons } from "../lib/icons";
 import {
   daemonSetVerdict,
@@ -248,11 +250,16 @@ function ClusterOverview({ title, context }: { title: string; context: ClusterCo
  * metrics-server, applied to the same problem.
  */
 function Stale({ overview }: { overview: OverviewData }) {
+  const stale = summarise(overview.staleReasons);
   if (overview.staleReasons.length === 0) return null;
   return (
     <div className="p-3 pb-0">
+      {/* The sentence is the deliberate part and stays exactly as written; the
+          reasons under it are classified, and deduplicated, because one
+          expired token stops all seven loaders and is one outage. */}
       <Alert tone="warn" title="Showing the last reading — this is no longer refreshing">
-        {overview.staleReasons.join(" · ")}
+        {stale.detail}
+        <RawError text={stale.raw ?? ""} className="mt-1" />
       </Alert>
     </div>
   );
@@ -372,7 +379,13 @@ function ControlPlane({ context, facts }: { context: ClusterContext; facts: Over
       <KVList rows={rows} />
       {/* The facts call itself failing is not the same as a cluster that named
           none, and the rows above cannot tell the reader which happened. */}
-      {facts.error && <p className="text-faint">Could not read the cluster's facts: {facts.error}</p>}
+      {facts.error && (
+        <FailureWord
+          error={facts.error}
+          lead="Could not read the cluster's facts: "
+          className="text-faint"
+        />
+      )}
     </Section>
   );
 }
@@ -422,7 +435,13 @@ function ObjectsByKind({ context, objects }: { context: string; objects: ObjectC
             <span className="path text-faint">{count === null ? UNKNOWN : count}</span>
           </Button>
           {error && (
-            <p className="path px-3 pb-1 text-faint">Could not count {K8S_KIND[slug]}: {error}</p>
+            // The row is as wide as the rail, which is to say not wide enough
+            // for a paragraph — the headline, and the original a click away.
+            <FailureWord
+              error={error}
+              lead={`Could not count ${K8S_KIND[slug]}: `}
+              className="path px-3 pb-1 text-faint"
+            />
           )}
         </div>
       ))}
@@ -760,9 +779,9 @@ function Nodes({ context, nodes }: { context: string; nodes: OverviewNodes }) {
         // already on screen keeps the rows: the screen says once, at the top,
         // that they stopped refreshing, and an `ErrorState` where a cluster
         // used to be tells the reader strictly less.
-        <ErrorState
+        <FailureState
           title={`Could not list nodes on ${context}`}
-          detail={nodes.error}
+          error={nodes.error}
           onRetry={nodes.reload}
         />
       ) : (
@@ -1154,6 +1173,8 @@ function NotReady({ context, overview }: { context: string; overview: OverviewDa
     workloads.deployments === undefined ? workloads.error : undefined,
     ...Object.values(workloads.refusals),
   ].filter((reason): reason is string => reason !== undefined && reason !== "");
+  // Six kinds refused by one expired credential is one sentence, not six.
+  const refusals = summarise(failures);
 
   const reload = () => {
     workloads.reload();
@@ -1167,14 +1188,16 @@ function NotReady({ context, overview }: { context: string; overview: OverviewDa
       ) : failures.length > 0 && rows.length === 0 ? (
         <ErrorState
           title={`Could not check every workload on ${context}`}
-          detail={failures.join(" · ")}
+          detail={refusals.detail}
+          raw={refusals.raw}
           onRetry={reload}
         />
       ) : (
         <>
           {failures.length > 0 && (
             <Alert tone="warn" title="Some kinds could not be checked">
-              {failures.join(" · ")}
+              {refusals.detail}
+              <RawError text={refusals.raw ?? ""} className="mt-1" />
             </Alert>
           )}
           {/* A cap is not a failure, so it is not in `failures` — but it is
@@ -1287,7 +1310,9 @@ function NodeConfirm({
             )}
           </p>
           <KubectlPreview command={command} onCopy={() => void copyKubectlCommand(command)} />
-          {error && <p style={{ color: "var(--sev)" }}>Error: {error}</p>}
+          {/* The dialog stays open on a refusal, so this is the whole of what
+              the reader is told about why the action did not happen. */}
+          {error && <FailureLine error={error} className="text-sev" />}
         </>
       }
     />

--- a/packages/ui-next/src/screens/Overview.tsx
+++ b/packages/ui-next/src/screens/Overview.tsx
@@ -580,7 +580,7 @@ function podsTile(pods: OverviewPods): Tile {
  * the two rather than a colour this file chose.
  */
 function worst(flagged: PodSummary[]): HealthKind {
-  return flagged.some((pod) => podStatus(pod.phase, pod.waitingReason).health === "danger")
+  return flagged.some((pod) => podStatus(pod).health === "danger")
     ? "danger"
     : "warning";
 }
@@ -1111,7 +1111,7 @@ function notReadyRows(workloads: OverviewWorkloads, unsettled: PodSummary[] | un
       kind: "Pod",
       name: row.name,
       namespace: row.namespace,
-      verdict: podStatus(row.phase, row.waitingReason),
+      verdict: podStatus(row),
       ratio: row.ready,
     });
   }

--- a/packages/ui-next/src/screens/ResourceBulk.tsx
+++ b/packages/ui-next/src/screens/ResourceBulk.tsx
@@ -8,6 +8,7 @@ import {
   type BulkOutcome,
 } from "@srelens/core";
 import { ActionBar, ConfirmDialog, type ActionBarAction } from "@srelens/ui-kit";
+import { FailureWord } from "../lib/errorCopy";
 import type { KindDescriptor, ListRow } from "../lib/kinds/types";
 
 export interface ResourceBulkProps {
@@ -191,9 +192,27 @@ export function ResourceBulk({ selected, kind, descriptor, context, rows, onDone
             <ul>
               {report.outcomes.map((outcome) => (
                 <li key={keyOf(outcome.item)}>
-                  <code>{rowLabel(outcome.item)}</code>
-                  {" — "}
-                  {outcome.status === "ok" ? PAST[report.type] : `failed: ${outcome.error}`}
+                  {outcome.status === "ok" ? (
+                    <>
+                      <code>{rowLabel(outcome.item)}</code>
+                      {" — "}
+                      {PAST[report.type]}
+                    </>
+                  ) : (
+                    // One line per row, so the headline is what fits — a
+                    // paragraph beside forty rows is a report nobody reads.
+                    // The row's own name leads it, and the cluster's words
+                    // are one click under it.
+                    <FailureWord
+                      error={outcome.error}
+                      lead={
+                        <>
+                          <code>{rowLabel(outcome.item)}</code>
+                          {" — failed: "}
+                        </>
+                      }
+                    />
+                  )}
                 </li>
               ))}
             </ul>

--- a/packages/ui-next/src/screens/ResourceMenu.tsx
+++ b/packages/ui-next/src/screens/ResourceMenu.tsx
@@ -4,6 +4,7 @@ import {
   cronjobSetSuspend,
   cronjobTriggerNow,
   deleteResource,
+  describeError,
   evictPod,
   notify,
   rolloutRestart,
@@ -13,6 +14,7 @@ import {
 } from "@srelens/core";
 import { ConfirmDialog, KubectlPreview, TextInput, type ContextMenuItem } from "@srelens/ui-kit";
 import { detailRoute } from "../lib/detailRoute";
+import { FailureLine } from "../lib/errorCopy";
 import { Icons } from "../lib/icons";
 import { ROW_ACTION_LABEL } from "../lib/kinds/rowActions";
 import type { KindActions, ListRow } from "../lib/kinds/types";
@@ -87,7 +89,10 @@ export function useRowMenu({ context, kind, actions }: UseRowMenuArgs): {
   async function runNow(row: ListRow) {
     const out = await cronjobTriggerNow(context, row.namespace ?? "", row.name);
     if (out.error) {
-      notify.error(`Failed to run ${row.name}`, out.error);
+      // The same shape core's own `reportActionError` gives classic's toasts:
+      // a toast is read once, in passing, and a Rust struct in one is noise
+      // nobody can act on before it fades.
+      notify.error(`Failed to run ${row.name}`, describeError(out.error).detail);
       return;
     }
     notify.success(`Triggered ${row.name}`, out.jobName ? `Created job ${out.jobName}` : undefined);
@@ -359,7 +364,12 @@ function PendingDialog({
             />
           )}
           <KubectlPreview command={command} note={note} onCopy={command ? () => void copyKubectlCommand(command) : undefined} />
-          {error && <p style={{ color: "var(--sev)" }}>Error: {error}</p>}
+          {/* The dialog stays open on a refusal rather than closing as if the
+              write had happened, so this line is the whole of what the reader
+              is told about why. A validation message this component wrote
+              itself ("Enter a non-negative replica count.") matches no
+              classification and arrives exactly as written. */}
+          {error && <FailureLine error={error} className="text-sev" />}
         </>
       }
     />

--- a/packages/ui-next/src/screens/Resources.test.tsx
+++ b/packages/ui-next/src/screens/Resources.test.tsx
@@ -661,7 +661,12 @@ describe("Resources", () => {
     open("/k/pods");
 
     expect(await screen.findByText("Namespaces could not be listed")).toBeTruthy();
-    expect(screen.getByText("namespaces: etcd timeout")).toBeTruthy();
+    // The sentence about the picker is this screen's and stays; what sits
+    // under it is the classification, not the apiserver's own words.
+    expect(screen.getByText(/didn't respond in time/)).toBeTruthy();
+    const folded = document.querySelector('[data-slot="raw"]') as HTMLDetailsElement;
+    expect(folded.open).toBe(false);
+    expect(folded.textContent).toContain("namespaces: etcd timeout");
     // Non-fatal: the picker keeps whatever namespaces it has, and the rows load.
     expect(screen.getByRole("combobox", { name: "Namespaces" })).toBeTruthy();
     await waitFor(() => expect(rowNames()).toEqual(["web-1", "api-7"]));
@@ -886,6 +891,9 @@ describe("Resources", () => {
 
     const alert = await screen.findByRole("alert");
     expect(alert.textContent).toContain("Could not look up widgets.example.com");
+    // A Forbidden that names no verb or resource falls to the generic RBAC
+    // guidance rather than repeating the apiserver's phrasing at the reader.
+    expect(alert.textContent).toContain("Check your RBAC roles");
     expect(alert.textContent).toContain("customresourcedefinitions is forbidden");
 
     listCrds.mockResolvedValueOnce({ crds: [WIDGETS] });

--- a/packages/ui-next/src/screens/Resources.tsx
+++ b/packages/ui-next/src/screens/Resources.tsx
@@ -8,7 +8,6 @@ import {
 } from "@srelens/core";
 import { useNamespaceOptions } from "@srelens/core/react";
 import {
-  Alert,
   ColumnPicker,
   ErrorState,
   FilterBar,
@@ -35,6 +34,7 @@ import { describe, isBuiltInKind } from "../lib/routes";
 import { openTab } from "../lib/tabsStore";
 import { useResource } from "../lib/useResource";
 import { setNamespaces, useNamespaces } from "../lib/workspace";
+import { FailureAlert, FailureState } from "../lib/errorCopy";
 import { AboutKind } from "./crd/AboutKind";
 import { ResourceDetailView } from "./detail/ResourceDetailView";
 import { ResourceTabView } from "./detail/ResourceTabView";
@@ -275,9 +275,9 @@ function KindList({
         {!builtIn && discovery.status === "loading" ? (
           <LoadingState label={`Looking for ${slug}`} />
         ) : discovery.status === "error" ? (
-          <ErrorState
+          <FailureState
             title={`Could not look up ${slug}`}
-            detail={discovery.error}
+            error={discovery.error}
             onRetry={discovery.reload}
           />
         ) : (
@@ -338,9 +338,9 @@ function KindList({
         {list.status === "loading" ? (
           <LoadingState label={`Loading ${lower}`} />
         ) : list.status === "error" ? (
-          <ErrorState
+          <FailureState
             title={`Could not list ${lower} on ${name}`}
-            detail={list.error}
+            error={list.error}
             onRetry={list.reload}
           />
         ) : (
@@ -470,9 +470,7 @@ function KindList({
         // rows are stale" warning the reader scrolls past no longer warns
         // anyone. The table runs flush to the panel, so the alert carries
         // its own inset rather than borrowing the container's.
-        <Alert tone="warn" title={`These ${lower} are stale`} className="mx-3 mt-3 mb-3">
-          {list.error}
-        </Alert>
+        <FailureAlert title={`These ${lower} are stale`} error={list.error} className="mx-3 mt-3 mb-3" />
       )}
       {showRows && (
         // Same reason as the alert above: selection actions that scroll out

--- a/packages/ui-next/src/screens/Workloads.test.tsx
+++ b/packages/ui-next/src/screens/Workloads.test.tsx
@@ -165,6 +165,29 @@ describe("Workloads", () => {
     expect(within(row).queryByText("Running")).toBeNull();
   });
 
+  it("keeps that same pod flagged in the instant it is between restarts", async () => {
+    // The moment the row above never modelled: no waiting reason, phase still
+    // "Running", ready still 0/1. The row used to drop its dot and read a
+    // plain green "Running" until the container failed again.
+    watchResource.mockImplementation(
+      async (_c: string, _n: string, kind: string, onRows: (rows: unknown[]) => void) => {
+        onRows(
+          kind === "pods"
+            ? [{ name: "web-1", namespace: "default", phase: "Running", ready: "0/1", restarts: 7, node: "n1", age: "2d", image: "acme/web:1", waitingReason: "" }]
+            : [],
+        );
+        return { stop };
+      },
+    );
+    open();
+
+    await waitFor(() => expect(rowNames()).toEqual(["Needs attentionweb-1"]));
+    const row = screen.getByText("web-1").closest("tr")!;
+    expect(within(row).getByText("Needs attention")).toBeTruthy();
+    expect(within(row).getByText("NotReady")).toBeTruthy();
+    expect(within(row).queryByText("Running")).toBeNull();
+  });
+
   it("leaves a healthy pod reading its phase", async () => {
     open();
     await waitFor(() => expect(rowNames()).toHaveLength(5));

--- a/packages/ui-next/src/screens/Workloads.test.tsx
+++ b/packages/ui-next/src/screens/Workloads.test.tsx
@@ -299,7 +299,10 @@ describe("Workloads", () => {
     open();
 
     expect(await screen.findByText("Namespaces could not be listed")).toBeTruthy();
-    expect(screen.getByText("namespaces: etcd timeout")).toBeTruthy();
+    expect(screen.getByText(/didn't respond in time/)).toBeTruthy();
+    expect(document.querySelector('[data-slot="raw"]')?.textContent).toContain(
+      "namespaces: etcd timeout",
+    );
     expect(screen.getByRole("combobox", { name: "Namespaces" })).toBeTruthy();
     await waitFor(() => expect(rowNames()).toHaveLength(5));
   });
@@ -333,6 +336,13 @@ describe("Workloads", () => {
     expect(within(scrollBody).queryByText(/could not list deployments/i)).toBeNull();
     // Still rendered — pinned above the scrolling body, not gone.
     expect(screen.getByText(/could not list deployments/i)).toBeTruthy();
+    // And the kind that refused says what to do about it, not what the
+    // apiserver called it. Four kinds still answered; this is a banner over
+    // real rows, so it stays a warning rather than becoming an error state.
+    expect(screen.getByText(/Check your RBAC roles/)).toBeTruthy();
+    expect(document.querySelector('[data-slot="raw"]')?.textContent).toContain(
+      "forbidden: cannot list deployments",
+    );
   });
 
   // A union row's actions differ by kind — this is the per-row correctness

--- a/packages/ui-next/src/screens/Workloads.tsx
+++ b/packages/ui-next/src/screens/Workloads.tsx
@@ -162,7 +162,7 @@ function fromPod(row: ListRow): WorkloadRow {
   // its own unhealthy dot — which comes from `podFlagged`, which asks this
   // same function. One reading, so the dot and the word cannot disagree.
   return {
-    ...fromVerdict(p, "Pod", p.ready, podStatus(p.phase, p.waitingReason)),
+    ...fromVerdict(p, "Pod", p.ready, podStatus(p)),
     restarts: p.restarts,
     cpu: p.cpu,
     memory: p.memory,

--- a/packages/ui-next/src/screens/Workloads.tsx
+++ b/packages/ui-next/src/screens/Workloads.tsx
@@ -13,7 +13,6 @@ import {
 } from "@srelens/core";
 import { useNamespaceOptions } from "@srelens/core/react";
 import {
-  Alert,
   ColumnPicker,
   FilterBar,
   LiveSignal,
@@ -32,6 +31,7 @@ import { useConsole } from "../console";
 import { getKubeconfigFiles, useActiveContext } from "../lib/clusters";
 import { useHiddenColumns } from "../lib/columnPrefs";
 import { detailRoute } from "../lib/detailRoute";
+import { FailureAlert } from "../lib/errorCopy";
 import {
   cronJobVerdict,
   daemonSetVerdict,
@@ -472,24 +472,20 @@ function WorkloadList({
               that failed or went stale; a banner that scrolls away with the
               rows no longer warns anyone. */}
           {failed.map((k) => (
-            <Alert
+            <FailureAlert
               key={k.key}
-              tone="warn"
               title={`Could not list ${k.label.toLocaleLowerCase()}s`}
+              error={k.list.error}
               className="mx-3 mt-3 mb-3"
-            >
-              {k.list.error}
-            </Alert>
+            />
           ))}
           {stale.map((k) => (
-            <Alert
+            <FailureAlert
               key={k.key}
-              tone="warn"
               title={`These ${k.label.toLocaleLowerCase()}s are stale`}
+              error={k.list.error}
               className="mx-3 mt-3 mb-3"
-            >
-              {k.list.error}
-            </Alert>
+            />
           ))}
           <div className="scroll min-h-0 flex-1">
             <Table

--- a/packages/ui-next/src/screens/detail/PodBody.test.tsx
+++ b/packages/ui-next/src/screens/detail/PodBody.test.tsx
@@ -310,6 +310,50 @@ describe("PodDetailsBody", () => {
       expect(screen.queryByText("Running")).toBeNull();
     });
 
+    it("keeps the header's word off the phase between restarts, when there is no reason to show", () => {
+      // The same pod a moment later: the container is genuinely running, so
+      // there is no waiting reason on the object at all — only `ready: false`
+      // and a restart count. The header used to read a plain "Running" here
+      // while the pod was still failing every few seconds.
+      renderFacts(
+        pod(
+          { containers: [APP_CONTAINER] },
+          {
+            phase: "Running",
+            containerStatuses: [
+              {
+                name: "app",
+                ready: false,
+                restartCount: 7,
+                state: { running: { startedAt: "2026-08-24T13:28:18Z" } },
+                lastState: { terminated: { exitCode: 1, reason: "Error" } },
+              },
+            ],
+          },
+        ),
+      );
+      expect(screen.getByText("NotReady")).toBeDefined();
+      expect(screen.queryByText("Running")).toBeNull();
+    });
+
+    it("still reads a pod that has simply not become ready yet as Running", () => {
+      // The carve-out, at the header: no restarts, so nothing says this is
+      // failure rather than a container that started two seconds ago.
+      renderFacts(
+        pod(
+          { containers: [APP_CONTAINER] },
+          {
+            phase: "Running",
+            containerStatuses: [
+              { name: "app", ready: false, restartCount: 0, state: { running: { startedAt: "2026-08-24T13:28:18Z" } } },
+            ],
+          },
+        ),
+      );
+      expect(screen.getByText("Running")).toBeDefined();
+      expect(screen.queryByText("NotReady")).toBeNull();
+    });
+
     it("shows the remaining facts as plain text, with nothing that navigates", () => {
       renderFacts(FULL_POD);
       expect(screen.getByText("default")).toBeDefined();

--- a/packages/ui-next/src/screens/detail/ResourceDetailView.test.tsx
+++ b/packages/ui-next/src/screens/detail/ResourceDetailView.test.tsx
@@ -1070,6 +1070,19 @@ describe("ResourceDetailView", () => {
       await waitFor(() => expect(getByRole("alert")).toBeDefined());
       expect(documentContains(FIXTURE_B64)).toBe(false);
       expect(container.querySelector(".cm-content")).toBeNull();
+
+      // The redactor's refusals are this package's own careful sentences, and
+      // they are careful precisely because no error message here may quote the
+      // source it failed on. They are not cluster errors and match no
+      // classification, so routing this pane through `describeError` must
+      // leave them exactly as written — and, because the pane keeps its own
+      // title, the reader is never told "Something went wrong" about them.
+      const alert = getByRole("alert");
+      expect(alert.textContent).toContain("Could not load Secret default/s-1's manifest");
+      expect(alert.textContent).toContain("it could not be parsed");
+      expect(alert.textContent).not.toContain("Something went wrong");
+      // Nothing was reformatted into a second copy of anything, either.
+      expect(alert.querySelector('[data-slot="raw"]')).toBeNull();
     });
 
     it("leaves a non-Secret kind's manifest untouched, with no redaction notice", async () => {

--- a/packages/ui-next/src/screens/detail/ResourceDetailView.tsx
+++ b/packages/ui-next/src/screens/detail/ResourceDetailView.tsx
@@ -2,13 +2,13 @@ import type { ReactNode } from "react";
 import { ageFromTimestamp, type K8sObject, type ResourceStatusLine } from "@srelens/core";
 import {
   Button,
-  ErrorState,
   Inspector,
   KV,
   LoadingState,
   type InspectorProps,
   type TabItem,
 } from "@srelens/ui-kit";
+import { FailureState } from "../../lib/errorCopy";
 import { Icons } from "../../lib/icons";
 import { CUSTOM_RESOURCE_ACTIONS } from "../../lib/kinds/custom";
 import { DetailActions } from "./DetailActions";
@@ -217,7 +217,7 @@ export function ResourceDetailView({ context, kind, namespace, name, peek }: Res
     // open at once, and a bare failure doesn't say which one broke.
     return (
       <Inspector name={name} subtitle={subtitle} actions={actions} onClose={peek?.onClose}>
-        <ErrorState title={`Could not load ${describeTarget(kind, namespace, name)}`} detail={error} />
+        <FailureState title={`Could not load ${describeTarget(kind, namespace, name)}`} error={error} />
       </Inspector>
     );
   }

--- a/packages/ui-next/src/screens/detail/ResourceTabView.tsx
+++ b/packages/ui-next/src/screens/detail/ResourceTabView.tsx
@@ -11,7 +11,6 @@ import {
 } from "@srelens/core";
 import {
   Breadcrumb,
-  ErrorState,
   KV,
   LoadingState,
   Stat,
@@ -20,6 +19,7 @@ import {
   type StatProps,
   type TabItem,
 } from "@srelens/ui-kit";
+import { FailureState } from "../../lib/errorCopy";
 import { CUSTOM_RESOURCE_ACTIONS } from "../../lib/kinds/custom";
 import { formatCpu, formatMemory } from "../../lib/kinds/columns";
 import { DetailActions } from "./DetailActions";
@@ -226,7 +226,7 @@ export function ResourceTabView({ context, kind, namespace, name }: ResourceTabV
     return <LoadingState label={`Loading ${describeTarget(kind, namespace, name)}`} />;
   }
   if (status === "error" || !object) {
-    return <ErrorState title={`Could not load ${describeTarget(kind, namespace, name)}`} detail={error} />;
+    return <FailureState title={`Could not load ${describeTarget(kind, namespace, name)}`} error={error} />;
   }
 
   const tiles = metricTiles(statusLine, object, usageTiles(usage.data?.cpu, usage.data?.memory));

--- a/packages/ui-next/src/screens/detail/WorkloadBody.test.tsx
+++ b/packages/ui-next/src/screens/detail/WorkloadBody.test.tsx
@@ -474,6 +474,24 @@ describe("WorkloadDetailsBody", () => {
       expect(screen.queryByText("Running")).toBeNull();
     });
 
+    it("keeps that same pod condemned in the table between its restarts", async () => {
+      // Same pod, one moment later: the container is up, so there is no
+      // waiting reason to print, and the table used to fall back to a green
+      // "Running" — in a table the reader opened BECAUSE the Deployment above
+      // it was degraded, which is the worst place to lose the fact.
+      podsForSelector.mockResolvedValue({
+        pods: [{ ...POD_A, ready: "0/1", restarts: 7, waitingReason: "" }],
+      });
+      render(
+        <WorkloadDetailsBody
+          object={workload("Deployment", { replicas: 1, selector: { matchLabels: { app: "web" } } })}
+          context="ctx"
+        />,
+      );
+      await waitFor(() => expect(screen.getByText("NotReady")).toBeDefined());
+      expect(screen.queryByText("Running")).toBeNull();
+    });
+
     it("formats CPU and memory the way the list and the Workloads table do, not a second way", async () => {
       // One pod read "2 410m" / "3.1 Gi" in the list and "2.410" / "3174 Mi"
       // in this very table, two panes apart, because this column set did its

--- a/packages/ui-next/src/screens/detail/detailData.tsx
+++ b/packages/ui-next/src/screens/detail/detailData.tsx
@@ -16,13 +16,13 @@ import {
 import {
   Alert,
   CodeEditor,
-  ErrorState,
   LoadingState,
   StatusPill,
   Table,
   type Column,
   type TabItem,
 } from "@srelens/ui-kit";
+import { FailureState } from "../../lib/errorCopy";
 import { descriptorFor } from "../../lib/kinds/descriptors";
 import { useObject } from "../../lib/useObject";
 import { ConfigDetailsBody } from "./ConfigBody";
@@ -594,7 +594,10 @@ function YamlPane({
   }
   if (state.status === "error" || state.data === undefined) {
     return (
-      <ErrorState title={`Could not load ${describeTarget(kind, namespace, name)}'s manifest`} detail={state.error} />
+      <FailureState
+        title={`Could not load ${describeTarget(kind, namespace, name)}'s manifest`}
+        error={state.error}
+      />
     );
   }
   // The height, which the pane got wrong until #331's second round. Three
@@ -678,7 +681,10 @@ function EventsPane({
   }
   if (state.status === "error" || state.data === undefined) {
     return (
-      <ErrorState title={`Could not load events for ${describeTarget(kind, namespace, name)}`} detail={state.error} />
+      <FailureState
+        title={`Could not load events for ${describeTarget(kind, namespace, name)}`}
+        error={state.error}
+      />
     );
   }
   // `Table` renders `emptyText` itself for a genuinely empty list — an early

--- a/packages/ui-next/src/screens/detail/sections.tsx
+++ b/packages/ui-next/src/screens/detail/sections.tsx
@@ -335,7 +335,7 @@ const RELATED_POD_COLUMNS: Column<RelatedPod>[] = [
     key: "status",
     header: "Status",
     render: (p) => {
-      const status = podStatus(p.phase, p.waitingReason);
+      const status = podStatus(p);
       return <StatusPill status={status.status} kind={status.health} tinted />;
     },
   },

--- a/packages/ui-next/src/screens/overview/Fleet.test.tsx
+++ b/packages/ui-next/src/screens/overview/Fleet.test.tsx
@@ -18,6 +18,12 @@ function aContext(name: string): ClusterContext {
   return { name, stableId: name, cluster: name, server: `https://${name}`, isCurrent: false };
 }
 
+/** A 401 as it actually reaches this component, from a real kubeconfig context. */
+const API_401 =
+  'Error: handler error: ApiError: Unauthorized: Unauthorized (Status { status: Some("Failure"), ' +
+  "metadata: Some(ListMeta { continue_: None, remaining_item_count: None, resource_version: None, " +
+  'self_link: None }), reason: Some("Unauthorized"), code: Some(401), message: Some("Unauthorized") })';
+
 const PROD = aContext("prod-eu");
 const STAGING = aContext("staging");
 const DR = aContext("dr-us");
@@ -32,6 +38,21 @@ function row(name: string): HTMLElement {
   const found = screen.getByText(name).closest(".kv");
   if (!found) throw new Error(`no fleet row for ${name}`);
   return found as HTMLElement;
+}
+
+/**
+ * What the row actually SAYS — its copy with the folded-away original taken
+ * out. `textContent` alone cannot tell the two apart: a closed `details` keeps
+ * its content in the DOM, which is exactly what makes it a disclosure and not
+ * a deletion, and a test that reads through it would pass whether or not the
+ * struct was being printed at the reader.
+ */
+function reading(name: string): string {
+  const cell = row(name).querySelector(".kv-v");
+  if (!cell) throw new Error(`no value cell for ${name}`);
+  const copy = cell.cloneNode(true) as HTMLElement;
+  copy.querySelector('[data-slot="raw"]')?.remove();
+  return copy.textContent ?? "";
 }
 
 beforeEach(() => {
@@ -69,7 +90,9 @@ describe("Fleet", () => {
 
     // One cluster's failure is one row's failure — the whole point of the
     // section. The two that answered keep their numbers.
-    await waitFor(() => expect(row("staging").textContent).toContain("connection refused"));
+    await waitFor(() => expect(reading("staging")).toContain("Can't reach the cluster"));
+    // The transport's own words are not thrown away, only folded up.
+    expect(row("staging").textContent).toContain("connection refused");
     expect(row("prod-eu").textContent).toContain("7/9 running");
     expect(row("dr-us").textContent).toContain("7/9 running");
 
@@ -90,7 +113,7 @@ describe("Fleet", () => {
     );
     render(<Fleet clusters={[PROD, DR]} active={PROD} />);
 
-    await waitFor(() => expect(row("dr-us").textContent).toContain("timed out"));
+    await waitFor(() => expect(reading("dr-us")).toContain("Request timed out"));
     // The exact failure this section is written against: `0/0` for a cluster
     // that never answered is a lie the reader has no way to catch.
     expect(row("dr-us").textContent).not.toContain("0");
@@ -212,6 +235,44 @@ describe("Fleet's tone", () => {
     await waitFor(() =>
       expect(row("prod-eu").querySelector(".kv-v")?.textContent).toBe("1284/1310 running"),
     );
+  });
+
+  it("says why in a phrase, and never prints the apiserver's struct into the rail", async () => {
+    // The finding this whole vocabulary came from. `podCount` reports a
+    // rejection as `{ error: String(e) }`, so a 401 arrived here as
+    // `Error: handler error: ApiError: … (Status { … })` — three hundred
+    // characters wrapping down a 286px column, pushing every cluster below it
+    // off the rail. One unreachable cluster hid the nine that answered, which
+    // is the failure this section exists to prevent, arriving through the copy
+    // instead of through the fetch.
+    core.podCount.mockResolvedValue({ error: API_401 });
+    render(<Fleet clusters={[PROD]} active={PROD} />);
+
+    await waitFor(() => expect(reading("prod-eu")).toContain("Not authorized"));
+    // The state word the status bar uses is still there — this is not a second
+    // vocabulary for the same fact, it is a reason under the existing one.
+    expect(reading("prod-eu")).toContain("Unreachable");
+    // And none of the struct is in the copy.
+    expect(reading("prod-eu")).not.toContain("ListMeta");
+    expect(reading("prod-eu")).not.toContain("handler error");
+  });
+
+  it("keeps the original reachable, closed, and out of every attribute", async () => {
+    core.podCount.mockResolvedValue({ error: API_401 });
+    render(<Fleet clusters={[PROD]} active={PROD} />);
+    await waitFor(() => expect(reading("prod-eu")).toContain("Not authorized"));
+
+    const disclosure = row("prod-eu").querySelector('[data-slot="raw"]') as HTMLDetailsElement;
+    expect(disclosure).not.toBeNull();
+    expect(disclosure.open).toBe(false);
+    expect(disclosure.textContent).toContain("ListMeta");
+    // Not a `title` attribute, and not any other one: the rule PairList and KV
+    // settled after a Secret leaked through one. (#331)
+    for (const node of Array.from(row("prod-eu").querySelectorAll("*"))) {
+      for (const attribute of Array.from(node.attributes)) {
+        expect(attribute.value).not.toContain("ListMeta");
+      }
+    }
   });
 
   it("colours nothing at all for a cluster that did not answer", async () => {

--- a/packages/ui-next/src/screens/overview/Fleet.tsx
+++ b/packages/ui-next/src/screens/overview/Fleet.tsx
@@ -1,5 +1,6 @@
 import { podCount, scaledStatus, type ClusterContext, type PodCount } from "@srelens/core";
 import { KV, Spinner, statusTone, toneColor } from "@srelens/ui-kit";
+import { FailureWord } from "../../lib/errorCopy";
 import { useResource, type Resource } from "../../lib/useResource";
 import { LINK_WORD } from "../../lib/workspace";
 
@@ -126,7 +127,15 @@ function Reading({
             reach, from the same table — a second word for the same fact is
             how two readouts of one cluster start disagreeing. */}
         {LINK_WORD.error}
-        <span className="block text-faint">{counts.error}</span>
+        {/* And under it, WHY, in one line. This row is 286px wide and used to
+            print the apiserver's whole `Status { … }` struct into it: a dozen
+            wrapped lines that pushed every cluster below it off the rail, so
+            one unreachable cluster hid the nine that answered — the exact
+            failure this section is built to prevent, arriving through the
+            copy instead of through the fetch. The headline is what fits; the
+            struct is still one click away, which is what someone filing a bug
+            actually needs. */}
+        <FailureWord error={counts.error} className="text-faint" />
       </>
     );
   }

--- a/packages/ui-next/src/screens/resourceShell.tsx
+++ b/packages/ui-next/src/screens/resourceShell.tsx
@@ -1,5 +1,6 @@
 import { Alert, Button, EmptyState, MultiSelect, Screen, Spinner, type Column, type TableSort } from "@srelens/ui-kit";
 import { toggleColumn } from "../lib/columnPrefs";
+import { FailureAlert } from "../lib/errorCopy";
 import { setTabView, useTabs, useTabView } from "../lib/tabsStore";
 
 /**
@@ -80,10 +81,16 @@ export function NamespacePicker({
  */
 export function NamespaceErrorAlert({ error }: { error: string }) {
   if (!error) return null;
+  // The sentence stays; what sits under it is the classification rather than
+  // whatever the apiserver's Go or Rust layer happened to print. A 403 on
+  // namespaces is the ordinary case here, and "You don't have permission to
+  // list namespaces at the cluster scope" is a thing a reader can act on.
   return (
-    <Alert tone="warn" title="Namespaces could not be listed" className="mx-3 mt-3 mb-3">
-      {error}
-    </Alert>
+    <FailureAlert
+      title="Namespaces could not be listed"
+      error={error}
+      className="mx-3 mt-3 mb-3"
+    />
   );
 }
 

--- a/packages/ui-next/src/shell/Rail.test.tsx
+++ b/packages/ui-next/src/shell/Rail.test.tsx
@@ -70,10 +70,33 @@ describe("Rail", () => {
     expect(activeCluster()).toBe("staging");
   });
 
-  it("says why a cluster is out of reach in its name", () => {
-    setLink("prod-eu", "error", "connection refused");
+  it("says why a cluster is out of reach in its name, classified rather than quoted", () => {
+    setLink("prod-eu", "error", "dial tcp 10.1.2.3:6443: connect: connection refused");
     setup();
-    expect(screen.getByRole("button", { name: "prod-eu, connection refused" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "prod-eu, Can't reach the cluster" })).toBeDefined();
+  });
+
+  it("never reads a cluster's raw refusal out as the name of a button", () => {
+    // The rail is 46px wide and this string is not drawn — it joins the mark's
+    // accessible name. What was reaching a screen reader was three hundred
+    // characters of `Status { metadata: Some(ListMeta { … })` announced as the
+    // name of a button; two words say the same thing. (The original is not
+    // lost — the overview's Fleet row for this cluster has it.)
+    setLink(
+      "prod-eu",
+      "error",
+      'Error: handler error: ApiError: Unauthorized: Unauthorized (Status { code: Some(401), ' +
+        "metadata: Some(ListMeta { continue_: None, resource_version: None }) })",
+    );
+    setup();
+    expect(screen.getByRole("button", { name: "prod-eu, Not authorized" })).toBeDefined();
+    expect(screen.queryByRole("button", { name: /ListMeta/ })).toBeNull();
+  });
+
+  it("still says something for a failure that arrived with no message", () => {
+    setLink("prod-eu", "error", "");
+    setup();
+    expect(screen.getByRole("button", { name: "prod-eu, Unreachable" })).toBeDefined();
   });
 
   it("opens a context menu on the menu gesture, not a drawer", async () => {

--- a/packages/ui-next/src/shell/Rail.tsx
+++ b/packages/ui-next/src/shell/Rail.tsx
@@ -11,6 +11,7 @@ import {
   type ContextMenuItem,
   type IconComponent,
 } from "@srelens/ui-kit";
+import { friendly } from "../lib/errorCopy";
 import { Icons } from "../lib/icons";
 import { getMark, resetMark, setMark, useMark } from "../lib/marks";
 import { useInfos } from "../lib/probe";
@@ -185,9 +186,19 @@ export function Rail({ contexts, onConnect, error }: RailProps) {
       // A reason rather than a flag: the kit dims the mark and says the word,
       // so the state is never told in opacity alone. An error with no message
       // still has to say something.
+      //
+      // The CLASSIFICATION, not the cluster's own words. This string is not
+      // drawn — the rail is 46px wide — it joins the mark's accessible name,
+      // and what was reaching a screen reader was three hundred characters of
+      // `Status { metadata: Some(ListMeta { … })` read out as the name of a
+      // button. "Not authorized" is the same fact in two words. The original
+      // is not offered here because there is nowhere in a 46px strip to offer
+      // it from; the overview's Fleet row for the same cluster has it.
       unavailable:
         link?.state === "error"
-          ? (link.error ?? "Unreachable")
+          ? link.error
+            ? friendly(link.error).title
+            : "Unreachable"
           : link?.state === "disconnected"
             ? "Disconnected"
             : undefined,


### PR DESCRIPTION
Follow-ups carried out of #337, #338 and #339. Five commits, no new features — all of it defects in shipped code, and most of it visible on screens this migration has not touched.

## The new design had no error vocabulary

`describeError` turns a backend failure into something a person can act on, and it is platform-aware: the guidance for an exec-auth failure differs between the desktop app and the web container, because only one of them can run a credential plugin.

**It had sixteen call sites and every one was in classic.** `packages/ui-next` used it nowhere, so every failure path in the new design printed whatever the backend said. The worst of it, in the cluster overview's Fleet rail:

```
Error: handler error: ApiError: Unauthorized: Unauthorized (Status {
status: Some(Failure), metadata: Some(ListMeta { continue_: None,
remaining_item_count: None, resource_version: None, self_link: None }),
reason: "Unauthorized", code: 401, message: ...
```

Twelve wrapped lines of Rust struct, shown to a reader. It pushed the other clusters off the rail — only three of six rows were visible.

22 error surfaces found, 20 routed through `describeError`. Two left alone deliberately: the application log and release notes are not cluster errors, and a missing log file's `no such file or directory` matches the exec-auth classifier, which would have told the reader their auth plugin failed.

Those rows now read `Not authorized`, `Can't reach the cluster`, `This cluster needs OIDC sign-in` — with the original folded behind a link, and all six clusters fitting.

## Two defects in `errors.ts` itself, found while reading it

Both degraded classic too, just less visibly.

- **`cleanErrorMessage` was anchored and single-pass**, so `String(e)`'s `Error: ` prefix stopped `handler error:` from matching at all. That is literally the `Error: handler error:` above.
- **A stopped cluster read "Something went wrong."** `ServiceError: client error (Connect)` — hyper's opaque error, and what the backend actually returns when a cluster is down — matched no branch. Confirmed against a real failing context.

## A crash-looping pod vanished from every unhealthy list between restarts

`podStatus` read a pod's phase and its first waiting container's reason. Between restarts there is neither: the phase is `Running` and nothing is waiting, so the rule said the pod was fine. It reappeared when the container failed again.

Two of four consecutive screenshots showed the pod in `NOT READY` and two did not, with nothing changing but the moment of capture. The same rule feeds the pods list, the related-pods tables and the detail header, so the flicker was everywhere.

Investigating it live is worth recording: **polling never caught the window** — 1,400 samples at 0.25s. A watch caught it instantly, and the intermediate state is not `running` but `terminated(Error)`; the container exits too fast for the kubelet to publish a running state.

The signal that does not flicker is the ready ratio. `podStatus` now takes the whole row rather than two positional strings, so **no caller can omit a fact it was not thinking about** — which is how this happened. A terminal phase returns before the ratio is consulted, so a `Succeeded` pod (which reports `0/1` forever) is untouched, and `restarts > 0` separates a crash-looper from a pod that started two seconds ago.

Applied to all 33 pods on a live cluster: zero verdict changes, zero false positives.

### The part worth reading twice

**No downstream test expectation moved, and that is the finding.** No fixture in the repo had ever modelled the second moment — every crash-loop fixture set `waitingReason` *alongside* `ready: "0/1"`, so a dozen tests across five surfaces agreed with a rule that was wrong half the time. The fixtures encoded the same blind spot as the code.

One test double was wrong too: the overview's fake built its unhealthy set more narrowly than the backend does, hiding the very pod the screen was losing. The backend had been right; core threw the verdict away.

## Nine condition types read with inverted polarity

Painted red for being healthy, or green for being broken. A previous round fixed five of the `Fail` family; four more were known and left as new vocabulary rather than inflections.

All four confirmed — `Degraded`, `DisruptionTarget`, `Denied`, and the PVC resize pair, which is actually a **trio** (`ModifyVolumeError`). Sweeping turned up two more on a resource that round had already visited: `NamespaceContentRemaining` and `NamespaceFinalizersRemaining`, so **a namespace stuck terminating read green on the two conditions that say why**.

One was **declined**: `Stalled`, because `"Installed"` contains `"stalled"` — adding it to a substring family would paint every operator's `Installed: True` red. The same inversion pointed the other way, spotted before it was dug. It is documented in the constant and guarded by live `Installed`/`Uninstalled` rows in the test table.

## Gates

3,192 tests across core, the kit and ui-next; 730 in classic, unchanged; 370 in the kube crate; four projects typechecking.

## Known

- **Toasts keep only the friendly detail**, following core's own `reportActionError` — the one surface where the original is genuinely gone.
- **The status *word* still flickers** between `NotReady` and `CrashLoopBackOff`. The dot, the tone and list membership do not, which is the property that mattered.
- **A pod that never crashes but never becomes ready still reads green.** Distinguishing it from one that is starting needs a clock the row does not carry; documented rather than guessed at.
- `NotReady` is now shared between Pod and Node vocabulary — a small softening of the file's "one kind's vocabulary is not another's" line.
