### PR TITLE
fix(ui-next): the four review findings on the logs screen, and one already shipped in the detail pane

### DIFF
--- a/crates/kube/src/workloads.rs
+++ b/crates/kube/src/workloads.rs
@@ -185,12 +185,42 @@ pub fn list_pods_capability(cache: Arc<ClientCache>) -> Capability {
     )
 }
 
+/// One `matchExpressions` entry of a Kubernetes `LabelSelector`.
+///
+/// Spelled as the API spells it — `operator` is one of `In`, `NotIn`,
+/// `Exists`, `DoesNotExist`, **case-sensitively**, so a workload's
+/// `spec.selector.matchExpressions` can be handed over untouched. Anything
+/// else is refused rather than guessed at: a selector rendered wrongly returns
+/// the wrong pods and says nothing about it.
+#[derive(Debug, Clone, PartialEq, Deserialize, JsonSchema)]
+pub struct LabelSelectorRequirement {
+    /// The label key the requirement is about, e.g. `app.kubernetes.io/name`.
+    pub key: String,
+    /// `In`, `NotIn`, `Exists`, or `DoesNotExist`.
+    pub operator: String,
+    /// The set for `In`/`NotIn`; empty (or absent) for the existence
+    /// operators, which refuse a set.
+    #[serde(default)]
+    pub values: Vec<String>,
+}
+
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct PodsForSelectorIn {
     pub context: String,
     pub namespace: String,
-    /// Equality label selector as a map, e.g. `{ "app": "web" }`.
+    /// Equality label selector as a map, e.g. `{ "app": "web" }` — a
+    /// `LabelSelector`'s `matchLabels` half.
     pub selector: std::collections::BTreeMap<String, String>,
+    /// The set-based half, a `LabelSelector`'s `matchExpressions`. Optional:
+    /// a caller with only equality labels omits it and nothing changes.
+    ///
+    /// The two halves are a **conjunction** — a pod matches when it satisfies
+    /// every entry of `selector` *and* every requirement here — which is what
+    /// makes sending only `matchLabels` for a workload that has both a bug
+    /// rather than an approximation: it queries a strictly wider set than the
+    /// workload owns.
+    #[serde(default, rename = "matchExpressions")]
+    pub match_expressions: Vec<LabelSelectorRequirement>,
 }
 
 /// Build a kube equality label selector string ("k1=v1,k2=v2") from a map.
@@ -200,6 +230,102 @@ pub(crate) fn label_selector(selector: &std::collections::BTreeMap<String, Strin
         .map(|(k, v)| format!("{k}={v}"))
         .collect::<Vec<_>>()
         .join(",")
+}
+
+/// Refuse a key or value that carries the selector grammar's own punctuation.
+///
+/// The query goes to the API server as a *string*, so a comma or a paren in a
+/// value is read as syntax and silently widens what comes back. Kubernetes'
+/// own label syntax allows none of these characters in a key or a value, so
+/// nothing legitimate is turned away — `/`, `.`, `-` and `_` all pass.
+fn ensure_selector_safe(part: &str, what: &str) -> Result<(), CapabilityError> {
+    if part.is_empty() {
+        return Err(CapabilityError::InvalidInput(format!(
+            "label selector {what} must not be empty"
+        )));
+    }
+    if part
+        .chars()
+        .any(|c| c.is_whitespace() || matches!(c, ',' | '(' | ')' | '!' | '=' | '<' | '>'))
+    {
+        return Err(CapabilityError::InvalidInput(format!(
+            "label selector {what} {part:?} contains selector syntax"
+        )));
+    }
+    Ok(())
+}
+
+/// The label-selector string to ask the API server for, or `None` when the
+/// request must answer with no pods without asking at all.
+///
+/// `None` covers the two ways a selector has nothing to ask:
+///
+/// - **It constrains nothing.** An empty selector matches *every* pod in the
+///   namespace, which is never what a caller asking for a workload's pods
+///   wants; returning nothing is the deliberate answer. A `NotIn ()` term
+///   constrains nothing either — every pod is outside the empty set — so it
+///   drops out, and a selector left with no terms lands here.
+/// - **It can never match.** `In ()` is membership of the empty set, false for
+///   every pod, so the whole conjunction is false and no query is needed.
+///
+/// A selector made only of `matchExpressions` is *not* one of those cases: it
+/// constrains plenty, and answering it with no pods would report a workload as
+/// having none when it has every one of them.
+pub(crate) fn selector_query(
+    labels: &std::collections::BTreeMap<String, String>,
+    expressions: &[LabelSelectorRequirement],
+) -> Result<Option<String>, CapabilityError> {
+    let mut terms: Vec<String> = Vec::new();
+    if !labels.is_empty() {
+        terms.push(label_selector(labels));
+    }
+
+    for req in expressions {
+        ensure_selector_safe(&req.key, "key")?;
+        let key = &req.key;
+        match req.operator.as_str() {
+            "In" | "NotIn" => {
+                if req.values.is_empty() {
+                    // `In ()` is unsatisfiable, so the conjunction is; `NotIn ()`
+                    // is satisfied by everything, so the term simply goes.
+                    if req.operator == "In" {
+                        return Ok(None);
+                    }
+                    continue;
+                }
+                for v in &req.values {
+                    ensure_selector_safe(v, "value")?;
+                }
+                let set = req.values.join(",");
+                let op = if req.operator == "In" { "in" } else { "notin" };
+                terms.push(format!("{key} {op} ({set})"));
+            }
+            "Exists" | "DoesNotExist" => {
+                if !req.values.is_empty() {
+                    return Err(CapabilityError::InvalidInput(format!(
+                        "label selector operator {} takes no values",
+                        req.operator
+                    )));
+                }
+                terms.push(if req.operator == "Exists" {
+                    key.to_string()
+                } else {
+                    format!("!{key}")
+                });
+            }
+            other => {
+                return Err(CapabilityError::InvalidInput(format!(
+                    "unknown label selector operator {other:?}; expected In, NotIn, Exists, or DoesNotExist"
+                )))
+            }
+        }
+    }
+
+    Ok(if terms.is_empty() {
+        None
+    } else {
+        Some(terms.join(","))
+    })
 }
 
 /// `k8s.podsForSelector` — pods in a namespace matching a label selector, used
@@ -212,16 +338,19 @@ pub fn pods_for_selector_capability(cache: Arc<ClientCache>) -> Capability {
         move |input: PodsForSelectorIn| {
             let cache = cache.clone();
             async move {
-                // An empty selector would match every pod; return nothing instead.
-                if input.selector.is_empty() {
+                // Decided before a client is touched: a selector with nothing to
+                // ask (see `selector_query`) returns nothing rather than every pod
+                // in the namespace, and a malformed one is refused rather than
+                // rendered into a query that quietly matches the wrong pods.
+                let Some(query) = selector_query(&input.selector, &input.match_expressions)? else {
                     return Ok(ListPodsOut { pods: vec![] });
-                }
+                };
                 let client = cache
                     .get(&input.context)
                     .await
                     .map_err(CapabilityError::Handler)?;
                 let api: Api<Pod> = crate::scoped_api(client, &input.namespace);
-                let params = ListParams::default().labels(&label_selector(&input.selector));
+                let params = ListParams::default().labels(&query);
                 let list = tokio::time::timeout(request_timeout(), api.list(&params))
                     .await
                     .map_err(|_| CapabilityError::Handler("list pods timed out".into()))?
@@ -259,6 +388,155 @@ mod tests {
         m.insert("app".to_string(), "web".to_string());
         m.insert("tier".to_string(), "frontend".to_string());
         assert_eq!(label_selector(&m), "app=web,tier=frontend");
+    }
+
+    /// `matchLabels` for a selector fixture, so an expression test can state
+    /// the equality half in one line.
+    fn labels(pairs: &[(&str, &str)]) -> std::collections::BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    fn req(key: &str, operator: &str, values: &[&str]) -> LabelSelectorRequirement {
+        LabelSelectorRequirement {
+            key: key.to_string(),
+            operator: operator.to_string(),
+            values: values.iter().map(|v| v.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn renders_each_set_based_operator_in_kubernetes_syntax() {
+        // Deliberately no `matchLabels`: an expression rendered by accident
+        // through the equality half would show up here as a missing term.
+        let none = labels(&[]);
+        assert_eq!(
+            selector_query(&none, &[req("track", "In", &["canary", "stable"])]).unwrap(),
+            Some("track in (canary,stable)".to_string())
+        );
+        assert_eq!(
+            selector_query(&none, &[req("track", "NotIn", &["canary"])]).unwrap(),
+            Some("track notin (canary)".to_string())
+        );
+        assert_eq!(
+            selector_query(&none, &[req("track", "Exists", &[])]).unwrap(),
+            Some("track".to_string())
+        );
+        assert_eq!(
+            selector_query(&none, &[req("track", "DoesNotExist", &[])]).unwrap(),
+            Some("!track".to_string())
+        );
+    }
+
+    #[test]
+    fn conjoins_both_halves_of_the_selector() {
+        // `app=web` alone would select the canary pods too, so a query that
+        // drops the expression is visibly different from this one.
+        let q = selector_query(
+            &labels(&[("app", "web")]),
+            &[req("track", "NotIn", &["canary"])],
+        )
+        .unwrap();
+        assert_eq!(q, Some("app=web,track notin (canary)".to_string()));
+    }
+
+    #[test]
+    fn an_expression_only_selector_still_queries() {
+        // The empty-`matchLabels` guard must not swallow a workload whose
+        // selector is expressed entirely in `matchExpressions`.
+        let q = selector_query(&labels(&[]), &[req("app", "In", &["web"])]).unwrap();
+        assert_eq!(q, Some("app in (web)".to_string()));
+    }
+
+    #[test]
+    fn a_selector_with_neither_half_asks_for_nothing() {
+        assert_eq!(selector_query(&labels(&[]), &[]).unwrap(), None);
+    }
+
+    #[test]
+    fn in_with_no_values_can_never_match() {
+        // Membership of the empty set is false for every pod — including the
+        // ones `app=web` would otherwise have selected.
+        assert_eq!(
+            selector_query(&labels(&[("app", "web")]), &[req("track", "In", &[])]).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn notin_with_no_values_constrains_nothing() {
+        // Every pod is outside the empty set, so the term drops out — but the
+        // rest of the selector stands.
+        assert_eq!(
+            selector_query(&labels(&[("app", "web")]), &[req("track", "NotIn", &[])]).unwrap(),
+            Some("app=web".to_string())
+        );
+        // ...and on its own it leaves a selector that matches the whole
+        // namespace, which asks for nothing.
+        assert_eq!(
+            selector_query(&labels(&[]), &[req("track", "NotIn", &[])]).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn refuses_an_operator_the_api_does_not_spell_that_way() {
+        // Case-sensitive: "in" is not `In`, and a selector we render wrongly
+        // returns the wrong pods silently.
+        for operator in ["in", "IN", "NOTIN", "exists", "Contains", ""] {
+            let out = selector_query(&labels(&[]), &[req("track", operator, &["canary"])]);
+            assert!(
+                matches!(out, Err(CapabilityError::InvalidInput(_))),
+                "expected {operator:?} to be refused, got {out:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn refuses_values_on_an_existence_operator() {
+        for operator in ["Exists", "DoesNotExist"] {
+            let out = selector_query(&labels(&[]), &[req("track", operator, &["canary"])]);
+            assert!(
+                matches!(out, Err(CapabilityError::InvalidInput(_))),
+                "expected {operator} with values to be refused, got {out:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn refuses_a_key_or_value_that_would_break_the_selector_grammar() {
+        // A comma or paren in a key or value would be read as syntax by the
+        // API server, quietly widening the query.
+        let broken = [
+            req("track,app", "In", &["canary"]),
+            req("track", "In", &["canary),app in (web"]),
+            req("", "Exists", &[]),
+            req("track", "In", &[""]),
+            req("tr ack", "Exists", &[]),
+        ];
+        for r in broken {
+            let out = selector_query(&labels(&[]), std::slice::from_ref(&r));
+            assert!(
+                matches!(out, Err(CapabilityError::InvalidInput(_))),
+                "expected {r:?} to be refused, got {out:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn keeps_a_qualified_label_key_intact() {
+        // Real selectors use `/` and `.` in keys; refusing those would refuse
+        // most of the cluster.
+        assert_eq!(
+            selector_query(
+                &labels(&[]),
+                &[req("app.kubernetes.io/name", "In", &["web"])]
+            )
+            .unwrap(),
+            Some("app.kubernetes.io/name in (web)".to_string())
+        );
     }
 
     #[test]

--- a/packages/core/src/lib/workloads.test.ts
+++ b/packages/core/src/lib/workloads.test.ts
@@ -171,7 +171,7 @@ describe("listReplicaSets", () => {
 describe("podsForSelector", () => {
   it("passes context+namespace+selector and returns pods", async () => {
     const invoke = vi.fn().mockResolvedValue({ pods: [{ name: "web-1" }] });
-    const outcome = await podsForSelector("kind-dev", "default", { app: "web" }, invoke);
+    const outcome = await podsForSelector("kind-dev", "default", { app: "web" }, [], invoke);
     expect(invoke).toHaveBeenCalledWith("k8s.podsForSelector", {
       context: "kind-dev",
       namespace: "default",
@@ -180,8 +180,34 @@ describe("podsForSelector", () => {
     expect(outcome.pods).toEqual([{ name: "web-1" }]);
   });
 
+  it("sends the set-based half of the selector when there is one", async () => {
+    const invoke = vi.fn().mockResolvedValue({ pods: [{ name: "web-1" }] });
+    // `app=web` alone would select the canary pods too — the expression is
+    // what narrows the query, so it has to reach the backend.
+    await podsForSelector(
+      "kind-dev",
+      "default",
+      { app: "web" },
+      [{ key: "track", operator: "NotIn", values: ["canary"] }],
+      invoke,
+    );
+    expect(invoke).toHaveBeenCalledWith("k8s.podsForSelector", {
+      context: "kind-dev",
+      namespace: "default",
+      selector: { app: "web" },
+      matchExpressions: [{ key: "track", operator: "NotIn", values: ["canary"] }],
+    });
+  });
+
+  it("leaves the wire untouched when there are no expressions", async () => {
+    const invoke = vi.fn().mockResolvedValue({ pods: [] });
+    await podsForSelector("kind-dev", "default", { app: "web" }, [], invoke);
+    const [, payload] = invoke.mock.calls[0] as [string, Record<string, unknown>];
+    expect(Object.keys(payload).sort()).toEqual(["context", "namespace", "selector"]);
+  });
+
   it("normalises errors", async () => {
-    const outcome = await podsForSelector("x", "default", {}, () =>
+    const outcome = await podsForSelector("x", "default", {}, [], () =>
       Promise.reject(new Error("forbidden")),
     );
     expect(outcome.pods).toBeUndefined();

--- a/packages/core/src/lib/workloads.ts
+++ b/packages/core/src/lib/workloads.ts
@@ -156,11 +156,43 @@ export async function listReplicaSets(
   }
 }
 
-/** Pods matching a label selector (a workload's pods) via `k8s.podsForSelector`. */
+/**
+ * One `matchExpressions` entry of a Kubernetes `LabelSelector` — the set-based
+ * half of a workload's selector.
+ *
+ * `operator` is `"In"`, `"NotIn"`, `"Exists"`, or `"DoesNotExist"`, spelled
+ * exactly as the Kubernetes API spells them: the backend is the one place that
+ * renders a selector, and it refuses an operator it does not recognise rather
+ * than guessing at what was meant. `values` belongs to `In`/`NotIn` only.
+ *
+ * Typed as `string` rather than a union on purpose — a requirement read off a
+ * live object is passed through as it was found, so a spec we cannot render
+ * comes back as an error instead of being quietly corrected into a selector
+ * that names different pods.
+ */
+export interface LabelSelectorRequirement {
+  key: string;
+  operator: string;
+  values?: string[];
+}
+
+/**
+ * Pods matching a label selector (a workload's pods) via `k8s.podsForSelector`.
+ *
+ * A `LabelSelector` has two halves and a pod matches only when it satisfies
+ * **both**: `selector` is `matchLabels`, `expressions` is `matchExpressions`.
+ * Sending only the first is not an approximation — it queries a strictly wider
+ * set than the workload owns, and for a selector written entirely in
+ * expressions it queries nothing at all.
+ *
+ * `expressions` is omitted from the payload when empty, so a caller with only
+ * equality labels sends exactly what it always did.
+ */
 export async function podsForSelector(
   context: string,
   namespace: string,
   selector: Record<string, string>,
+  expressions: LabelSelectorRequirement[] = [],
   invoke: Invoker = invokeCapability,
 ): Promise<PodsOutcome> {
   try {
@@ -168,6 +200,7 @@ export async function podsForSelector(
       context,
       namespace,
       selector,
+      ...(expressions.length === 0 ? {} : { matchExpressions: expressions }),
     });
     return { pods: out.pods };
   } catch (e) {

--- a/packages/ui-next/src/lib/logStream.test.ts
+++ b/packages/ui-next/src/lib/logStream.test.ts
@@ -393,6 +393,43 @@ describe("useLogStream", () => {
     expect(startLogStream).toHaveBeenCalledTimes(2);
   });
 
+  it("ignores a line from a stream cancelled by a dependency change before its connect promise settles", async () => {
+    // Narrowing `sinceSeconds` (or changing container/tailLines) tears down
+    // the in-flight connect and starts a new one. The old stream's connect
+    // promise has not resolved yet, so cleanup cannot call `stop()` on it —
+    // there is nothing to stop yet. If the old stream's initial tail line
+    // arrives on the channel before its stray `.then()` gets around to
+    // stopping it, that line must NOT land in the buffer the new effect just
+    // cleared.
+    const s1 = fakeStream();
+    const { result, rerender } = renderHook(
+      ({ sinceSeconds }: { sinceSeconds?: number }) =>
+        useLogStream("kind-dev", "default", [target], { sinceSeconds }),
+      { initialProps: { sinceSeconds: undefined as number | undefined } },
+    );
+    expect(startLogStream).toHaveBeenCalledTimes(1);
+    // s1's connect promise is deliberately left unresolved here.
+
+    const s2 = fakeStream();
+    rerender({ sinceSeconds: 300 });
+    expect(startLogStream).toHaveBeenCalledTimes(2);
+
+    // The stale stream's initial tail line lands after the dependency change
+    // cancelled it, but before its connect promise resolves and stop() runs.
+    act(() => s1.line("", "stale-tail-line"));
+
+    await s2.connect();
+    act(() => s2.line("", "fresh-line"));
+    await waitFor(() => expect(result.current.lines).toHaveLength(1));
+    expect(result.current.lines[0].text).toBe("fresh-line");
+
+    // The stale stream resolving late must still be stopped (existing
+    // behaviour), but must not have contributed any lines.
+    await s1.connect();
+    expect(s1.stop).toHaveBeenCalledTimes(1);
+    expect(result.current.lines).toHaveLength(1);
+  });
+
   it("clears the buffer on demand without restarting the stream", async () => {
     const s = fakeStream();
     const { result } = renderHook(() => useLogStream("kind-dev", "default", [target]));

--- a/packages/ui-next/src/lib/logStream.ts
+++ b/packages/ui-next/src/lib/logStream.ts
@@ -291,11 +291,22 @@ export function useLogStream(
     const total = sources.size;
     const seen = new Map<string, LogStatus>();
 
+    // Effect-scoped, unlike `onLine` itself: a dependency change (since,
+    // container, tail length, ...) cancels THIS run before its connect
+    // promise settles, and the old stream's initial tail lines can still
+    // arrive on the channel in the gap before its `.then()` gets around to
+    // calling `stop()`. Without this guard those lines land, through the
+    // shared `onLine`, in the buffer the new effect already cleared.
+    const guardedOnLine = (source: string, text: string) => {
+      if (cancelled) return;
+      onLine(source, text);
+    };
+
     startLogStream(
       context,
       namespace,
       streamTargets,
-      onLine,
+      guardedOnLine,
       (s, source) => {
         if (cancelled) return;
         seen.set(source, s);

--- a/packages/ui-next/src/lib/logSubject.test.ts
+++ b/packages/ui-next/src/lib/logSubject.test.ts
@@ -444,3 +444,131 @@ describe("resolveLogSubject's previous instances", () => {
     expect(result.previous).toEqual([]);
   });
 });
+
+/**
+ * What `k8s.podsForSelector` is sent — both halves of the workload's
+ * `LabelSelector`, because a pod matches only when it satisfies both.
+ */
+interface SelectorPayload {
+  context: string;
+  namespace: string;
+  selector: Record<string, string>;
+  matchExpressions?: { key: string; operator: string; values?: string[] }[];
+}
+
+/** A workload object whose selector carries whatever halves a test needs. */
+const workloadSelecting = (selector: Record<string, unknown>) => ({ spec: { selector } });
+
+/**
+ * A fake `invoke` whose `k8s.podsForSelector` answers from the selector it was
+ * actually sent, the way a cluster does — so a test can distinguish a query
+ * that carried the whole selector from one that carried half of it. Every pod
+ * it names answers `getObject` with a single `app` container.
+ */
+function invokeSelecting(
+  workload: unknown,
+  pods: (payload: SelectorPayload) => { name: string }[] | Error,
+): { invoke: Invoker; sent: SelectorPayload[] } {
+  const sent: SelectorPayload[] = [];
+  const invoke = (async (id: string, input?: unknown): Promise<unknown> => {
+    if (id === "k8s.getObject") {
+      const { kind } = input as { kind: string };
+      if (kind === "Deployment") return { object: workload };
+      return { object: podObject(["app"]) };
+    }
+    if (id === "k8s.podsForSelector") {
+      const payload = input as SelectorPayload;
+      sent.push(payload);
+      const answer = pods(payload);
+      if (answer instanceof Error) throw answer;
+      return { pods: answer };
+    }
+    throw new Error(`unexpected capability ${id}`);
+  }) as Invoker;
+  return { invoke, sent };
+}
+
+describe("resolveLogSubject's selector", () => {
+  it("sends both halves of a workload's selector", async () => {
+    const { invoke, sent } = invokeSelecting(
+      workloadSelecting({
+        matchLabels: { app: "web" },
+        matchExpressions: [{ key: "track", operator: "NotIn", values: ["canary"] }],
+      }),
+      () => [{ name: "web-abc" }],
+    );
+    await resolveLogSubject(workloadSubject, invoke);
+    expect(sent).toHaveLength(1);
+    expect(sent[0].selector).toEqual({ app: "web" });
+    expect(sent[0].matchExpressions).toEqual([
+      { key: "track", operator: "NotIn", values: ["canary"] },
+    ]);
+  });
+
+  it("follows only the pods the whole selector names, not the wider matchLabels set", async () => {
+    // The cluster's answer differs by which halves arrived: `app=web` alone
+    // selects the canary pod too, and only the expression excludes it. A
+    // resolution that dropped the expression would follow two pods here.
+    const { invoke } = invokeSelecting(
+      workloadSelecting({
+        matchLabels: { app: "web" },
+        matchExpressions: [{ key: "track", operator: "NotIn", values: ["canary"] }],
+      }),
+      (payload) =>
+        (payload.matchExpressions ?? []).length > 0
+          ? [{ name: "web-stable" }]
+          : [{ name: "web-stable" }, { name: "web-canary" }],
+    );
+    const result = await resolveLogSubject(workloadSubject, invoke);
+    expect(result.status).toBe("resolved");
+    if (result.status !== "resolved") throw new Error("expected resolved");
+    expect(result.targets.map((t) => t.pod)).toEqual(["web-stable"]);
+  });
+
+  it("resolves a workload whose selector is expressions alone", async () => {
+    // No `matchLabels` at all. The backend answers an unconstrained selector
+    // with no pods on purpose, so a resolution that sent only the equality
+    // half would report this workload as having none.
+    const { invoke } = invokeSelecting(
+      workloadSelecting({
+        matchExpressions: [{ key: "app", operator: "In", values: ["web"] }],
+      }),
+      (payload) =>
+        Object.keys(payload.selector).length === 0 && (payload.matchExpressions ?? []).length === 0
+          ? []
+          : [{ name: "web-abc" }],
+    );
+    const result = await resolveLogSubject(workloadSubject, invoke);
+    expect(result.status).toBe("resolved");
+    if (result.status !== "resolved") throw new Error("expected resolved");
+    expect(result.targets.map((t) => t.pod)).toEqual(["web-abc"]);
+  });
+
+  it("passes a requirement through verbatim, so the backend can refuse what it cannot render", async () => {
+    // Operators are case-sensitive; "notin" is not one. Nothing here corrects
+    // it — a corrected selector is a different selector, and following the
+    // wrong pods silently is the outcome this whole path exists to avoid.
+    const { invoke, sent } = invokeSelecting(
+      workloadSelecting({
+        matchExpressions: [{ key: "track", operator: "notin", values: ["canary"] }],
+      }),
+      () => new Error("unknown label selector operator \"notin\""),
+    );
+    const result = await resolveLogSubject(workloadSubject, invoke);
+    expect(sent[0].matchExpressions).toEqual([
+      { key: "track", operator: "notin", values: ["canary"] },
+    ]);
+    expect(result.status).toBe("error");
+    if (result.status !== "error") throw new Error("expected error");
+    expect(result.error.detail.length).toBeGreaterThan(0);
+  });
+
+  it("sends no expressions for a selector that has none", async () => {
+    const { invoke, sent } = invokeSelecting(
+      workloadSelecting({ matchLabels: { app: "web" } }),
+      () => [{ name: "web-abc" }],
+    );
+    await resolveLogSubject(workloadSubject, invoke);
+    expect(sent[0].matchExpressions).toBeUndefined();
+  });
+});

--- a/packages/ui-next/src/lib/logSubject.ts
+++ b/packages/ui-next/src/lib/logSubject.ts
@@ -10,9 +10,9 @@ import {
   type HealthKind,
   type Invoker,
   type K8sObject,
-  type LabelSelectorRequirement,
   type LogTarget,
 } from "@srelens/core";
+import { selectorOf } from "./workloadSelector";
 
 /**
  * A route's subject, resolved to the pods and containers a stream can open
@@ -194,49 +194,6 @@ function terminationOf(
     ...(typeof reason === "string" && reason !== "" ? { reason } : {}),
     ...(typeof finishedAt === "string" && finishedAt !== "" ? { finishedAt } : {}),
   };
-}
-
-/**
- * A workload's whole `LabelSelector`, both halves.
- *
- * `matchExpressions` is not optional detail: a pod is owned by the workload
- * only when it satisfies the equality labels **and** every expression, so
- * reading `matchLabels` alone is wrong twice over — a workload selected
- * entirely by expressions resolves to an empty selector, which the backend
- * deliberately answers with no pods (an empty selector would otherwise match
- * the whole namespace), and a workload with both halves resolves to a
- * selector broader than the real one, which streams lines from pods the
- * workload never owned.
- */
-interface WorkloadSelector {
-  matchLabels: Record<string, string>;
-  matchExpressions: LabelSelectorRequirement[];
-}
-
-/**
- * The selector on a workload's spec, read loosely so a spec that doesn't have
- * one just yields no pods.
- *
- * Requirements are passed on as they were found — the key and operator
- * verbatim, values narrowed to the strings among them. Nothing here corrects
- * an operator's spelling or drops a requirement it doesn't recognise: the
- * backend renders selectors, and it refuses one it cannot render. An error is
- * a far better outcome than a corrected selector, which is simply a different
- * selector naming different pods.
- */
-function selectorOf(object: unknown): WorkloadSelector {
-  const spec = asRecord(asRecord(object).spec);
-  const selector = asRecord(spec.selector);
-  const matchLabels = (selector.matchLabels ?? {}) as Record<string, string>;
-  const matchExpressions = asArray(selector.matchExpressions).map((entry) => {
-    const requirement = asRecord(entry);
-    return {
-      key: typeof requirement.key === "string" ? requirement.key : "",
-      operator: typeof requirement.operator === "string" ? requirement.operator : "",
-      values: asArray(requirement.values).filter((v): v is string => typeof v === "string"),
-    };
-  });
-  return { matchLabels, matchExpressions };
 }
 
 /** The pod names in scope for `subject` — itself for a pod, or its

--- a/packages/ui-next/src/lib/logSubject.ts
+++ b/packages/ui-next/src/lib/logSubject.ts
@@ -10,6 +10,7 @@ import {
   type HealthKind,
   type Invoker,
   type K8sObject,
+  type LabelSelectorRequirement,
   type LogTarget,
 } from "@srelens/core";
 
@@ -44,7 +45,7 @@ export interface PodSubject {
 /**
  * A workload, named by kind + name. `kind` is whatever `getObject`
  * understands — Deployment, StatefulSet, DaemonSet, ReplicaSet, Job, or any
- * kind whose `spec.selector.matchLabels` names its pods.
+ * kind whose `spec.selector` names its pods.
  */
 export interface WorkloadSubject {
   type: "workload";
@@ -195,12 +196,47 @@ function terminationOf(
   };
 }
 
-/** The label a matchLabels selector would carry on a workload's spec, read
- *  loosely so a spec that doesn't have one just yields no pods. */
-function selectorOf(object: unknown): Record<string, string> {
+/**
+ * A workload's whole `LabelSelector`, both halves.
+ *
+ * `matchExpressions` is not optional detail: a pod is owned by the workload
+ * only when it satisfies the equality labels **and** every expression, so
+ * reading `matchLabels` alone is wrong twice over — a workload selected
+ * entirely by expressions resolves to an empty selector, which the backend
+ * deliberately answers with no pods (an empty selector would otherwise match
+ * the whole namespace), and a workload with both halves resolves to a
+ * selector broader than the real one, which streams lines from pods the
+ * workload never owned.
+ */
+interface WorkloadSelector {
+  matchLabels: Record<string, string>;
+  matchExpressions: LabelSelectorRequirement[];
+}
+
+/**
+ * The selector on a workload's spec, read loosely so a spec that doesn't have
+ * one just yields no pods.
+ *
+ * Requirements are passed on as they were found — the key and operator
+ * verbatim, values narrowed to the strings among them. Nothing here corrects
+ * an operator's spelling or drops a requirement it doesn't recognise: the
+ * backend renders selectors, and it refuses one it cannot render. An error is
+ * a far better outcome than a corrected selector, which is simply a different
+ * selector naming different pods.
+ */
+function selectorOf(object: unknown): WorkloadSelector {
   const spec = asRecord(asRecord(object).spec);
-  const matchLabels = asRecord(spec.selector).matchLabels;
-  return (matchLabels ?? {}) as Record<string, string>;
+  const selector = asRecord(spec.selector);
+  const matchLabels = (selector.matchLabels ?? {}) as Record<string, string>;
+  const matchExpressions = asArray(selector.matchExpressions).map((entry) => {
+    const requirement = asRecord(entry);
+    return {
+      key: typeof requirement.key === "string" ? requirement.key : "",
+      operator: typeof requirement.operator === "string" ? requirement.operator : "",
+      values: asArray(requirement.values).filter((v): v is string => typeof v === "string"),
+    };
+  });
+  return { matchLabels, matchExpressions };
 }
 
 /** The pod names in scope for `subject` — itself for a pod, or its
@@ -214,7 +250,14 @@ async function podsInScope(
   const workload = await getObject(subject.context, subject.kind, subject.namespace, subject.name, invoke);
   if (workload.error !== undefined) return { error: workload.error };
 
-  const out = await podsForSelector(subject.context, subject.namespace, selectorOf(workload.object), invoke);
+  const selector = selectorOf(workload.object);
+  const out = await podsForSelector(
+    subject.context,
+    subject.namespace,
+    selector.matchLabels,
+    selector.matchExpressions,
+    invoke,
+  );
   if (out.error !== undefined) return { error: out.error };
   return { pods: (out.pods ?? []).map((p) => p.name) };
 }

--- a/packages/ui-next/src/lib/workloadSelector.test.ts
+++ b/packages/ui-next/src/lib/workloadSelector.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { hasSelector, requirementText, selectorOf } from "./workloadSelector";
+
+/** A workload object whose selector carries whatever halves a case needs. */
+const workload = (selector: unknown) => ({ spec: { selector } });
+
+describe("selectorOf", () => {
+  it("reads both halves of a selector", () => {
+    expect(
+      selectorOf(
+        workload({
+          matchLabels: { app: "web" },
+          matchExpressions: [{ key: "track", operator: "NotIn", values: ["canary"] }],
+        }),
+      ),
+    ).toEqual({
+      matchLabels: { app: "web" },
+      matchExpressions: [{ key: "track", operator: "NotIn", values: ["canary"] }],
+    });
+  });
+
+  it("reads a selector written entirely in expressions", () => {
+    // The half that used to vanish: `matchLabels` is absent, and reading it
+    // alone yields `{}` — which the backend answers with no pods on purpose.
+    const selector = selectorOf(workload({ matchExpressions: [{ key: "app", operator: "Exists" }] }));
+    expect(selector.matchLabels).toEqual({});
+    expect(selector.matchExpressions).toEqual([{ key: "app", operator: "Exists", values: [] }]);
+  });
+
+  it("keeps a requirement's operator verbatim, however it was spelled", () => {
+    // "notin" is not one of the four operators; the backend refuses what it
+    // cannot render, and an error beats a corrected selector — which is
+    // simply a different selector, naming different pods.
+    const selector = selectorOf(
+      workload({ matchExpressions: [{ key: "track", operator: "notin", values: ["canary"] }] }),
+    );
+    expect(selector.matchExpressions).toEqual([
+      { key: "track", operator: "notin", values: ["canary"] },
+    ]);
+  });
+
+  it("keeps only the strings among a requirement's values", () => {
+    const selector = selectorOf(
+      workload({ matchExpressions: [{ key: "tier", operator: "In", values: ["web", 7, null] }] }),
+    );
+    expect(selector.matchExpressions[0].values).toEqual(["web"]);
+  });
+
+  it("yields two empty halves for a spec with no selector at all", () => {
+    expect(selectorOf({ spec: {} })).toEqual({ matchLabels: {}, matchExpressions: [] });
+    expect(selectorOf(undefined)).toEqual({ matchLabels: {}, matchExpressions: [] });
+  });
+});
+
+describe("hasSelector", () => {
+  it("counts a selector of expressions alone as a selector", () => {
+    // The gate the Pods panel hangs on. Reading `matchLabels` alone did not
+    // merely empty that panel for such a workload — it removed it.
+    expect(hasSelector({ matchLabels: {}, matchExpressions: [{ key: "app", operator: "Exists" }] })).toBe(
+      true,
+    );
+  });
+
+  it("counts a selector of equality labels alone as a selector", () => {
+    expect(hasSelector({ matchLabels: { app: "web" }, matchExpressions: [] })).toBe(true);
+  });
+
+  it("says no only when both halves are empty", () => {
+    expect(hasSelector({ matchLabels: {}, matchExpressions: [] })).toBe(false);
+  });
+});
+
+describe("requirementText", () => {
+  it("writes each operator the way Kubernetes writes it", () => {
+    expect(requirementText({ key: "app", operator: "In", values: ["web", "api"] })).toBe(
+      "app in (web, api)",
+    );
+    expect(requirementText({ key: "track", operator: "NotIn", values: ["canary"] })).toBe(
+      "track notin (canary)",
+    );
+    expect(requirementText({ key: "logging", operator: "Exists" })).toBe("logging");
+    expect(requirementText({ key: "legacy", operator: "DoesNotExist" })).toBe("!legacy");
+  });
+
+  it("prints an operator it does not know as it was spelled, rather than dropping the row", () => {
+    // The row must show what the object says, including the part the cluster
+    // will refuse — the same rule the reader follows.
+    // Deliberately not "notin": that spelling would read the same as the
+    // operator this row does NOT have, and a case that cannot tell the two
+    // apart proves nothing about which branch ran.
+    expect(requirementText({ key: "track", operator: "NOTIN", values: ["canary"] })).toBe(
+      "track NOTIN (canary)",
+    );
+    expect(requirementText({ key: "track", operator: "Nonsense" })).toBe("track Nonsense");
+  });
+});

--- a/packages/ui-next/src/lib/workloadSelector.ts
+++ b/packages/ui-next/src/lib/workloadSelector.ts
@@ -1,0 +1,93 @@
+import { asArray, asRecord, type LabelSelectorRequirement } from "@srelens/core";
+
+/**
+ * Reading a workload's `LabelSelector` — the one question "which pods are
+ * this workload's?" always comes down to.
+ *
+ * It lived inside `logSubject` when only the Logs screen asked it, and the
+ * resource detail screen answered it separately by reading `matchLabels`
+ * alone — the very half-answer this module exists to prevent. Whose pods a
+ * workload owns is not a logs concern, so the reader sits here, once, and
+ * both screens call it.
+ */
+
+/**
+ * A workload's whole `LabelSelector`, both halves.
+ *
+ * `matchExpressions` is not optional detail: a pod is owned by the workload
+ * only when it satisfies the equality labels **and** every expression, so
+ * reading `matchLabels` alone is wrong twice over — a workload selected
+ * entirely by expressions resolves to an empty selector, which the backend
+ * deliberately answers with no pods (an empty selector would otherwise match
+ * the whole namespace), and a workload with both halves resolves to a
+ * selector broader than the real one, which names pods the workload never
+ * owned.
+ */
+export interface WorkloadSelector {
+  matchLabels: Record<string, string>;
+  matchExpressions: LabelSelectorRequirement[];
+}
+
+/**
+ * The selector on a workload's spec, read loosely so a spec that doesn't have
+ * one just yields no pods.
+ *
+ * Requirements are passed on as they were found — the key and operator
+ * verbatim, values narrowed to the strings among them. Nothing here corrects
+ * an operator's spelling or drops a requirement it doesn't recognise: the
+ * backend renders selectors, and it refuses one it cannot render. An error is
+ * a far better outcome than a corrected selector, which is simply a different
+ * selector naming different pods.
+ */
+export function selectorOf(object: unknown): WorkloadSelector {
+  const spec = asRecord(asRecord(object).spec);
+  const selector = asRecord(spec.selector);
+  const matchLabels = (selector.matchLabels ?? {}) as Record<string, string>;
+  const matchExpressions = asArray(selector.matchExpressions).map((entry) => {
+    const requirement = asRecord(entry);
+    return {
+      key: typeof requirement.key === "string" ? requirement.key : "",
+      operator: typeof requirement.operator === "string" ? requirement.operator : "",
+      values: asArray(requirement.values).filter((v): v is string => typeof v === "string"),
+    };
+  });
+  return { matchLabels, matchExpressions };
+}
+
+/**
+ * Whether the selector names anything at all — EITHER half is enough.
+ *
+ * What the panels gate on: a selector's absence means there are no pods to
+ * ask for, and a workload written entirely in expressions has a selector like
+ * any other. Gating on `matchLabels` alone is how such a workload lost its
+ * Pods panel outright rather than merely showing it empty.
+ */
+export function hasSelector(selector: WorkloadSelector): boolean {
+  return Object.keys(selector.matchLabels).length > 0 || selector.matchExpressions.length > 0;
+}
+
+/**
+ * One requirement in Kubernetes' own selector syntax — `app in (web, api)`,
+ * `track notin (canary)`, `logging`, `!legacy` — for a reader's eyes only.
+ *
+ * DISPLAY ONLY. The requirement itself still travels to the backend exactly
+ * as it was found; this never becomes a query. An operator this does not
+ * recognise is printed as it was spelled rather than dropped or corrected,
+ * for the same reason the reader above passes it through: the row must show
+ * what the object actually says, including the part the cluster will refuse.
+ */
+export function requirementText(requirement: LabelSelectorRequirement): string {
+  const values = (requirement.values ?? []).join(", ");
+  switch (requirement.operator) {
+    case "Exists":
+      return requirement.key;
+    case "DoesNotExist":
+      return `!${requirement.key}`;
+    case "In":
+      return `${requirement.key} in (${values})`;
+    case "NotIn":
+      return `${requirement.key} notin (${values})`;
+    default:
+      return values ? `${requirement.key} ${requirement.operator} (${values})` : `${requirement.key} ${requirement.operator}`;
+  }
+}

--- a/packages/ui-next/src/screens/Logs.test.tsx
+++ b/packages/ui-next/src/screens/Logs.test.tsx
@@ -408,16 +408,23 @@ describe("Logs", () => {
     // not red on one screen and grey on the next. The screen passes the word
     // and no `tone`, so what comes out is the kit's own mapping — asserted
     // against `toneColor`, not against a hex the screen could have written.
-    const region = await (draw(), body());
+    await (draw(), body());
     push(...LINES);
-    const levels = Array.from(region.querySelectorAll<HTMLElement>("[data-slot=level]"));
-    expect(levels.map((el) => el.style.color)).toEqual([
-      toneColor("info"),
-      toneColor("warn"),
-      toneColor("sev"),
-      // No level word: the kit's fallback, not a tone the screen chose.
-      toneColor("muted"),
-    ]);
+    // Re-query the region rather than holding the one `body()` returned: a
+    // resolution still in flight can re-render and replace that node, and a
+    // detached element answers every query with nothing. This failed about
+    // one run in a hundred, under full-package load, as an empty array.
+    await waitFor(() => {
+      const region = screen.getByRole("log", { name: /logs/i });
+      const levels = Array.from(region.querySelectorAll<HTMLElement>("[data-slot=level]"));
+      expect(levels.map((el) => el.style.color)).toEqual([
+        toneColor("info"),
+        toneColor("warn"),
+        toneColor("sev"),
+        // No level word: the kit's fallback, not a tone the screen chose.
+        toneColor("muted"),
+      ]);
+    });
   });
 
   it("names the source of a single-target stream, which arrives unlabelled", async () => {

--- a/packages/ui-next/src/screens/Logs.test.tsx
+++ b/packages/ui-next/src/screens/Logs.test.tsx
@@ -350,6 +350,21 @@ describe("the logs route", () => {
     expect(parseLogsRoute("/logs/checkout")).toBeNull();
     expect(parseLogsRoute("/k/pods/checkout/api-7")).toBeNull();
   });
+
+  it("refuses a segment that cannot be decoded, rather than throwing", () => {
+    // `decodeURIComponent` THROWS on a malformed escape, and this parser runs
+    // during render on every restored tab — `describe` and `screenFor` both
+    // call it, and tab routes are persisted. One corrupted route in storage
+    // would take the whole window down on boot. "Unrecognised route" is
+    // already a normal outcome of this function; a bad escape is one more of
+    // them, not a new path.
+    expect(parseLogsRoute("/logs/Pod/checkout/%zz")).toBeNull();
+    expect(parseLogsRoute("/logs/%e0%a4%a/checkout/api-7")).toBeNull();
+    expect(parseLogsRoute("/logs/Pod/%/api-7")).toBeNull();
+    // The last segment decodes fine; the parser must still refuse the route
+    // rather than returning a half-decoded subject.
+    expect(parseLogsRoute("/logs/Pod/%zz/api-7")).toBeNull();
+  });
 });
 
 describe("Logs", () => {
@@ -421,6 +436,26 @@ describe("Logs", () => {
     expect(rendered(region)).toEqual(["|api-7 · api||a line with no timestamp on it"]);
   });
 
+  it("names a target carrying no container by its pod alone, separator and all", async () => {
+    // `LogTarget.container` is optional: a stream can be opened against a pod
+    // and let the API pick its only container. There is then no container
+    // name to say — and a gutter that draws the separator anyway prints
+    // `api-7 · `, which an export turns into `api-7/ | …`. Both read as a
+    // truncated fact rather than an absent one.
+    h.resolve.mockResolvedValue({
+      status: "resolved",
+      targets: [{ pod: "api-7", label: "" }],
+      pods: [{ name: "api-7", health: "success" }],
+      previous: [],
+    });
+    const region = await (draw(logsRoute("Pod", "checkout", "api-7")), body());
+    push({ source: "", text: "a line from a container nobody named" });
+    expect(rendered(region)).toEqual(["|api-7||a line from a container nobody named"]);
+
+    // And nothing to filter by, so the select is not offered at all.
+    expect(screen.queryByRole("combobox", { name: /container/i })).toBeNull();
+  });
+
   it("filters on the message and on the severity word, either case", async () => {
     const region = await (draw(), body());
     push(...LINES);
@@ -441,6 +476,84 @@ describe("Logs", () => {
     push(...LINES);
     await userEvent.selectOptions(screen.getByRole("combobox", { name: /container/i }), "otel-sidecar");
     expect(rendered(region).map((r) => r.split("|")[3])).toEqual(["warn exporter queue is full"]);
+  });
+
+  it("filters by container when the label names the pod alone", async () => {
+    // The ORDINARY workload: a Deployment with three replicas of one
+    // container. Every in-scope target shares that container name, so
+    // `resolveLogSubject` labels each line with the POD ALONE — naming the
+    // container on every row would repeat one word down the whole gutter.
+    //
+    // That is a decision about the DISPLAY. The container is still a fact
+    // about the line, and the select is populated from the targets, which
+    // carry it. Recovering the container by splitting the label finds no
+    // slash, calls it `""`, and then picking `web` from the dropdown matches
+    // no row at all: the screen goes blank on the commonest case there is.
+    h.resolve.mockResolvedValue({
+      status: "resolved",
+      targets: [
+        { pod: "web-0", container: "web", label: "web-0" },
+        { pod: "web-1", container: "web", label: "web-1" },
+      ],
+      pods: [
+        { name: "web-0", health: "success" },
+        { name: "web-1", health: "success" },
+      ],
+      previous: [],
+    });
+    const region = await (draw(logsRoute("Deployment", "checkout", "web")), body());
+    push(
+      line("web-0", "14:07:41.208000000", "info serving on :8080"),
+      line("web-1", "14:07:42.100000000", "warn upstream slow"),
+    );
+
+    await userEvent.selectOptions(screen.getByRole("combobox", { name: /container/i }), "web");
+    expect(rendered(region)).toEqual([
+      // Still there — and the gutter still names the pod ALONE, because the
+      // fix carries the container as data beside the label rather than
+      // putting it back into the string the reader sees.
+      "14:07:41.208|web-0|info|info serving on :8080",
+      "14:07:42.100|web-1|warn|warn upstream slow",
+    ]);
+  });
+
+  it("hides the other container when a pod-only label is in play", async () => {
+    // The other half of the same seam: a pod-only label must not become a
+    // wildcard that matches EVERY container either. Two pods, one of which
+    // also runs a sidecar, so the labels are `pod/container` — and one whose
+    // line arrives under a pod-only label because it is the only target of
+    // its kind. Picking `api` must drop the sidecar's line.
+    h.resolve.mockResolvedValue({
+      status: "resolved",
+      targets: [
+        { pod: "api-7", container: "api", label: "api-7" },
+        { pod: "api-8", container: "api", label: "api-8" },
+      ],
+      pods: [
+        { name: "api-7", health: "success" },
+        { name: "api-8", health: "success" },
+      ],
+      previous: [],
+    });
+    const region = await (draw(), body());
+    push(
+      line("api-7", "14:07:41.208000000", "info from api-7"),
+      // A line whose source matches no target at all — the stream tagged it
+      // with something this screen never handed out. It must not be claimed
+      // by a container filter that never named it.
+      line("ghost-0/sidecar", "14:07:42.100000000", "warn from a stranger"),
+    );
+
+    await userEvent.selectOptions(screen.getByRole("combobox", { name: /container/i }), "api");
+    expect(rendered(region).map((r) => r.split("|")[3])).toEqual(["info from api-7"]);
+  });
+
+  it("falls back to the placeholder on an undecodable route rather than dying", async () => {
+    // What a corrupted persisted tab actually does to the window: the parser
+    // is called during render, so a throw here is an unmounted app, not a
+    // blank pane.
+    draw("/logs/Pod/checkout/%zz");
+    expect(await screen.findByText("Pick a workload or a pod to follow")).toBeTruthy();
   });
 
   it("wires the since select to what the stream is asked to tail", async () => {

--- a/packages/ui-next/src/screens/Logs.test.tsx
+++ b/packages/ui-next/src/screens/Logs.test.tsx
@@ -288,12 +288,26 @@ function draw(route = ROUTE) {
 }
 
 /** The rendered lines as `ts|source|level|message`, in order. */
-const rendered = (region: HTMLElement) =>
-  Array.from(region.querySelectorAll(".logline")).map((el) =>
+/**
+ * The drawn rows, read from the log region that is in the document NOW.
+ *
+ * The node is re-read rather than trusted: `body()` hands back the element as
+ * it was, and a resolution still in flight can re-render and replace it. A
+ * detached node answers every query with nothing, so the assertion sees an
+ * empty body and reads as "the screen drew none of them" — which is how three
+ * tests in this file flaked under parallel load while passing alone every
+ * time. The argument is kept because it reads naturally at the call sites,
+ * and used only while it is still attached.
+ */
+const rendered = (region?: HTMLElement) => {
+  const live = region?.isConnected ? region : screen.queryByRole("log", { name: /logs/i });
+  if (!live) return [];
+  return Array.from(live.querySelectorAll(".logline")).map((el) =>
     ["ts", "source", "level", "message"]
       .map((slot) => el.querySelector(`[data-slot=${slot}]`)?.textContent ?? "")
       .join("|"),
   );
+};
 
 /** Push lines into the buffer the screen is rendering. */
 function push(...lines: { source: string; text: string }[]) {
@@ -303,7 +317,25 @@ function push(...lines: { source: string; text: string }[]) {
   });
 }
 
-const body = () => screen.findByRole("log", { name: /logs/i });
+/**
+ * The log region, after the screen has settled.
+ *
+ * `findByRole` alone returns the element as soon as one appears, which is
+ * before `resolveLogSubject` has settled — and when it does settle, React can
+ * replace that node. Tests then held a DETACHED element: `querySelectorAll`
+ * answers nothing, and a `clientHeight` defined on it is lost, so the window
+ * sees a zero-height viewport and draws no rows at all. That surfaced as four
+ * different tests in this file failing about one run in six, each passing
+ * alone, and it is why the flakes moved around rather than sitting still.
+ *
+ * Flushing pending promises first, then re-querying, hands back the node the
+ * screen actually settled on.
+ */
+const body = async () => {
+  await screen.findByRole("log", { name: /logs/i });
+  await act(async () => {});
+  return screen.getByRole("log", { name: /logs/i });
+};
 
 /** The last options the screen asked the stream hook for. */
 const lastOptions = () => h.seen[h.seen.length - 1].options;

--- a/packages/ui-next/src/screens/Logs.tsx
+++ b/packages/ui-next/src/screens/Logs.tsx
@@ -107,11 +107,23 @@ export function parseLogsRoute(route: string): LogsRouteParts | null {
   const [empty, prefix, rawKind, rawNamespace, rawName] = segments;
   if (empty !== "" || prefix !== "logs") return null;
   if (!rawKind || !rawNamespace || !rawName) return null;
-  return {
-    kind: decodeURIComponent(rawKind),
-    namespace: decodeURIComponent(rawNamespace),
-    name: decodeURIComponent(rawName),
-  };
+  try {
+    return {
+      kind: decodeURIComponent(rawKind),
+      namespace: decodeURIComponent(rawNamespace),
+      name: decodeURIComponent(rawName),
+    };
+  } catch {
+    // `decodeURIComponent` THROWS a `URIError` on a malformed escape — `%zz`,
+    // or a truncated multi-byte sequence. This parser runs DURING RENDER
+    // (`describe` and `screenFor` both call it) over routes that are
+    // persisted and restored, so a throw here is not a bad tab: it is the
+    // whole new-design window failing to boot off one corrupted string in
+    // storage. `null` is the contract's existing answer for a route this
+    // function cannot make a subject of, and a route whose segments are not
+    // decodable is one of those.
+    return null;
+  }
 }
 
 /** The `since` windows the design offers, and what each one means in seconds. */
@@ -238,8 +250,28 @@ const RFC3339 = /^\d{4}-\d{2}-\d{2}T(\d{2}:\d{2}:\d{2})(\.\d+)?(?:Z|[+-]\d{2}:?\
 interface Row {
   /** `14:07:41.208`, or `""` for a line that arrived without a stamp. */
   ts: string;
+  /** Which pod wrote the line. DATA — read off the target, not the label. */
   pod: string;
+  /**
+   * Which container wrote it. DATA, and the reason it does not come out of
+   * the line's `source` string: that string is the target's **display**
+   * label, and `resolveLogSubject` drops the container from it whenever every
+   * target in scope shares one container name — the ordinary Deployment with
+   * three replicas of one container. Recovering the container by splitting
+   * the label there yields `""` for every line, while the container select is
+   * populated from the targets, which carry the real name: the reader picks
+   * their container and the screen goes blank. The label is a decision about
+   * what to SHOW; this is what the line IS, and they do not travel in one
+   * string.
+   */
   container: string;
+  /**
+   * Whether the source gutter names the container as well as the pod — the
+   * display half of the same fact, taken from the shape of the label rather
+   * than recomputed here. A stream whose targets all run one container says
+   * the pod alone; repeating that one word down a 200px gutter is noise.
+   */
+  namesContainer: boolean;
   /**
    * The level word AS THE LINE SPELLS IT — `error`, `WARNING`, `warn`,
    * `debug` — from {@link logLineLevel}, or `""` when the line carries none.
@@ -271,32 +303,50 @@ interface Row {
 /** The line's origin as one string: `api-7 · api` on screen, `api-7/api` in a
  *  file, and the pod alone for a stream with no container to disambiguate. */
 function sourceOf(row: Row, separator: string): string {
-  return row.container === ""
-    ? row.pod
-    : `${row.pod}${separator}${row.container}`;
+  return row.namesContainer && row.container !== ""
+    ? `${row.pod}${separator}${row.container}`
+    : row.pod;
+}
+
+/**
+ * Every target under the label its lines arrive tagged with — the index
+ * {@link toRow} recovers a line's pod and container through.
+ *
+ * The labels are unique by construction: `resolveLogSubject` emits `pod` alone
+ * only when one container name is shared across the whole scope (so one target
+ * per pod), `pod/container` when they differ, and `""` only when there is
+ * exactly one target altogether — which is why the empty key resolves that
+ * lone target rather than standing for "unknown".
+ */
+function indexTargets(targets: readonly LogTarget[]): ReadonlyMap<string, LogTarget> {
+  return new Map(targets.map((t) => [t.label ?? "", t]));
 }
 
 /**
  * Split a stream line into the columns the design draws.
  *
- * `source` is the target's own `label`, which `resolveLogSubject` leaves empty
- * when there is exactly one target — so a single-container stream falls back
- * to that target rather than drawing a nameless source.
+ * The line's `source` is its target's **display label**, so the pod and the
+ * container are looked up through {@link indexTargets} rather than parsed back
+ * out of it — see {@link Row.container} for what parsing it costs. Splitting on
+ * `/` survives only as the fallback for a source no target claims, which is a
+ * line the screen did not ask for; naming it from its own string beats drawing
+ * it nameless.
  */
-function toRow(line: StreamLine, only: LogTarget | undefined): Row {
+function toRow(line: StreamLine, byLabel: ReadonlyMap<string, LogTarget>): Row {
   const stamp = line.text.match(RFC3339);
   const ts = stamp ? `${stamp[1]}${(stamp[2] ?? "").slice(0, 4)}` : "";
   const message = stamp ? line.text.slice(stamp[0].length) : line.text;
   const slash = line.source.indexOf("/");
+  const target = byLabel.get(line.source);
   const pod =
-    line.source === ""
-      ? (only?.pod ?? "")
+    target !== undefined
+      ? target.pod
       : slash < 0
         ? line.source
         : line.source.slice(0, slash);
   const container =
-    line.source === ""
-      ? (only?.container ?? "")
+    target !== undefined
+      ? (target.container ?? "")
       : slash < 0
         ? ""
         : line.source.slice(slash + 1);
@@ -305,6 +355,10 @@ function toRow(line: StreamLine, only: LogTarget | undefined): Row {
     ts,
     pod,
     container,
+    // An unlabelled line is the single-target stream, whose gutter would
+    // otherwise be blank; a labelled one shows the container exactly when its
+    // label carried it.
+    namesContainer: line.source === "" || slash >= 0,
     level: logLineLevel(message) ?? "",
     health,
     message,
@@ -741,10 +795,10 @@ function LogsStream({
     tailLines: TAIL_LINES,
   });
 
-  const only = targets.length === 1 ? targets[0] : undefined;
+  const byLabel = useMemo(() => indexTargets(targets), [targets]);
   const liveRows = useMemo(
-    () => stream.lines.map((l) => toRow(l, only)),
-    [stream.lines, only],
+    () => stream.lines.map((l) => toRow(l, byLabel)),
+    [stream.lines, byLabel],
   );
 
   /**
@@ -815,8 +869,8 @@ function LogsStream({
   }, [previous, terminated, context, namespace, targets]);
 
   const previousRows = useMemo(
-    () => (snapshot.status === "ready" ? snapshot.lines.map((l) => toRow(l, only)) : []),
-    [snapshot, only],
+    () => (snapshot.status === "ready" ? snapshot.lines.map((l) => toRow(l, byLabel)) : []),
+    [snapshot, byLabel],
   );
 
   /**

--- a/packages/ui-next/src/screens/detail/GenericBody.test.tsx
+++ b/packages/ui-next/src/screens/detail/GenericBody.test.tsx
@@ -337,7 +337,7 @@ describe("GenericBody", () => {
       );
       await waitFor(() => expect(screen.getByText("Pods")).toBeDefined());
       await waitFor(() => expect(screen.getByText("svc-pod-1")).toBeDefined());
-      expect(podsForSelector).toHaveBeenCalledWith("ctx", "default", { app: "web" });
+      expect(podsForSelector).toHaveBeenCalledWith("ctx", "default", { app: "web" }, []);
     });
 
     it("does not render related pods for a kind relatedPodSelector finds none for", () => {

--- a/packages/ui-next/src/screens/detail/GenericBody.tsx
+++ b/packages/ui-next/src/screens/detail/GenericBody.tsx
@@ -137,8 +137,17 @@ export function GenericBody({
   const meta = object.metadata ?? {};
   const namespace = str(meta.namespace);
   const conditions = asArray(asRecord(object.status).conditions) as unknown as Condition[];
-  const podSelector = relatedPodSelector(kind, object);
-  const hasPodSelector = Object.keys(podSelector).length > 0;
+  // Core's `relatedPodSelector` answers with the equality half only — it is
+  // also classic's reader, and classic is frozen — so the requirements half
+  // is empty here rather than absent: the section takes a whole
+  // `LabelSelector`, and an empty `matchExpressions` sends exactly the
+  // payload this always sent. A DaemonSet, Job, PodDisruptionBudget or
+  // NetworkPolicy written with `matchExpressions` still resolves through that
+  // reader's equality half alone — a narrower instance of the same gap
+  // WorkloadBody just closed, left because widening core's reader changes
+  // what the frozen app sends.
+  const podSelector = { matchLabels: relatedPodSelector(kind, object), matchExpressions: [] };
+  const hasPodSelector = Object.keys(podSelector.matchLabels).length > 0;
 
   return (
     <>

--- a/packages/ui-next/src/screens/detail/WorkloadBody.test.tsx
+++ b/packages/ui-next/src/screens/detail/WorkloadBody.test.tsx
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
-import type { K8sObject, PodSummary, PodMetric, ReplicaSetSummary } from "@srelens/core";
+import type {
+  K8sObject,
+  LabelSelectorRequirement,
+  PodSummary,
+  PodMetric,
+  ReplicaSetSummary,
+} from "@srelens/core";
 
 // `WorkloadDetailsBody`'s "Pods" section reads live pods/metrics for the
 // workload's selector, and a Deployment's "Deploy Revisions" section reads
@@ -9,7 +15,17 @@ import type { K8sObject, PodSummary, PodMetric, ReplicaSetSummary } from "@srele
 // said" without one. `importOriginal` keeps every reader
 // (`updateStrategy`, `str`, `asRecord`, ...) intact.
 const { podsForSelector, podMetrics, listReplicaSets } = vi.hoisted(() => ({
-  podsForSelector: vi.fn(async (): Promise<{ pods?: PodSummary[]; error?: string }> => ({ pods: [] })),
+  // Typed with the arguments core's own `podsForSelector` takes, so a case
+  // below can answer FROM the selector it was sent rather than from a fixed
+  // list — see `answersFromLabels`.
+  podsForSelector: vi.fn(
+    async (
+      _context: string,
+      _namespace: string,
+      _selector?: Record<string, string>,
+      _expressions?: LabelSelectorRequirement[],
+    ): Promise<{ pods?: PodSummary[]; error?: string }> => ({ pods: [] }),
+  ),
   podMetrics: vi.fn(async (): Promise<{ metrics?: PodMetric[]; error?: string }> => ({ metrics: [] })),
   listReplicaSets: vi.fn(async (): Promise<{ replicasets?: ReplicaSetSummary[]; error?: string }> => ({
     replicasets: [],
@@ -100,6 +116,59 @@ const POD_A: PodSummary = {
   age: "2d",
   image: "app:1.0",
 };
+
+/** The canary of the same app: `app=web` alone selects it, and only the
+ *  `track NotIn canary` requirement keeps it out. */
+const POD_CANARY: PodSummary = { ...POD_A, name: "web-canary-9" };
+
+/** Two pods and the labels they carry — the cluster `answersFromLabels`
+ *  serves. */
+const LABELLED_PODS: { pod: PodSummary; labels: Record<string, string> }[] = [
+  { pod: POD_A, labels: { app: "web", track: "stable" } },
+  { pod: POD_CANARY, labels: { app: "web", track: "canary" } },
+];
+
+/** One requirement, applied the way the API server applies it. */
+function satisfies(labels: Record<string, string>, requirement: LabelSelectorRequirement): boolean {
+  const value = labels[requirement.key];
+  const values = requirement.values ?? [];
+  switch (requirement.operator) {
+    case "In":
+      return value !== undefined && values.includes(value);
+    case "NotIn":
+      return value === undefined || !values.includes(value);
+    case "Exists":
+      return value !== undefined;
+    case "DoesNotExist":
+      return value === undefined;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Answer `podsForSelector` FROM the selector it was actually sent, the way a
+ * cluster does.
+ *
+ * A mock resolving a fixed list hands back the same pods whether or not the
+ * expressions arrived, so it cannot tell a query that carried the whole
+ * selector from one that carried half of it — the accident these cases must
+ * not rest on. An empty selector answers with nothing, which is the backend's
+ * own deliberate rule: an unconstrained selector would otherwise match the
+ * whole namespace.
+ */
+function answersFromLabels() {
+  podsForSelector.mockImplementation(async (_context, _namespace, selector = {}, expressions = []) => {
+    if (Object.keys(selector).length === 0 && expressions.length === 0) return { pods: [] };
+    return {
+      pods: LABELLED_PODS.filter(
+        ({ labels }) =>
+          Object.entries(selector).every(([k, v]) => labels[k] === v) &&
+          expressions.every((requirement) => satisfies(labels, requirement)),
+      ).map(({ pod }) => pod),
+    };
+  });
+}
 
 /** The label column of one flat block, in the order it reads. `heading`
  *  names the block; without one, the pane's first block — which the design
@@ -450,7 +519,7 @@ describe("WorkloadDetailsBody", () => {
         />,
       );
       await waitFor(() => expect(screen.getByText("web-abc-1")).toBeDefined());
-      expect(podsForSelector).toHaveBeenCalledWith("ctx", "default", { app: "web" });
+      expect(podsForSelector).toHaveBeenCalledWith("ctx", "default", { app: "web" }, []);
       expect(screen.getAllByText("node-a").length).toBeGreaterThan(0);
       expect(screen.queryByRole("button", { name: /^Open / })).toBeNull();
     });
@@ -546,6 +615,123 @@ describe("WorkloadDetailsBody", () => {
       );
       expect(screen.getByText("Loading pods")).toBeDefined();
       expect([...container.children].every((el) => el.classList.contains("section"))).toBe(true);
+    });
+  });
+
+  /**
+   * A `LabelSelector` is the CONJUNCTION of its two halves: a pod belongs to
+   * the workload only when it satisfies the equality labels AND every
+   * requirement. Reading `matchLabels` alone was wrong twice over — a
+   * workload selected entirely by expressions resolved to an empty selector,
+   * which the backend deliberately answers with no pods, and a workload with
+   * both halves resolved to a selector WIDER than the real one, so this table
+   * listed pods the workload does not own under its name.
+   *
+   * Every case here answers from the selector it was sent
+   * (`answersFromLabels`): a fixture whose `matchLabels` alone would select
+   * the same pods proves nothing, because dropping the expression would leave
+   * it green.
+   */
+  describe("the whole selector, both halves", () => {
+    const NOT_CANARY: LabelSelectorRequirement = { key: "track", operator: "NotIn", values: ["canary"] };
+    const APP_IN_WEB: LabelSelectorRequirement = { key: "app", operator: "In", values: ["web"] };
+
+    it("lists only the pods the whole selector names, not the wider matchLabels set", async () => {
+      answersFromLabels();
+      render(
+        <WorkloadDetailsBody
+          object={workload("Deployment", {
+            replicas: 1,
+            selector: { matchLabels: { app: "web" }, matchExpressions: [NOT_CANARY] },
+          })}
+          context="ctx"
+        />,
+      );
+      await waitFor(() => expect(screen.getByText("web-abc-1")).toBeDefined());
+      // The canary carries `app=web` too. It is in this table exactly when the
+      // requirement was dropped on the way to the cluster.
+      expect(screen.queryByText("web-canary-9")).toBeNull();
+      expect(podsForSelector).toHaveBeenCalledWith("ctx", "default", { app: "web" }, [NOT_CANARY]);
+    });
+
+    it("finds the pods of a workload selected entirely by expressions", async () => {
+      answersFromLabels();
+      render(
+        <WorkloadDetailsBody
+          object={workload("Deployment", { replicas: 2, selector: { matchExpressions: [APP_IN_WEB] } })}
+          context="ctx"
+        />,
+      );
+      // The Pods panel is not merely empty without the expressions — it is
+      // absent, because the selector read as `{}` and the panel is gated on
+      // having one.
+      await waitFor(() => expect(screen.getByText("web-abc-1")).toBeDefined());
+      expect(screen.getByText("web-canary-9")).toBeDefined();
+      expect(podsForSelector).toHaveBeenCalledWith("ctx", "default", {}, [APP_IN_WEB]);
+    });
+
+    it("re-reads the pods when only the expressions change", async () => {
+      answersFromLabels();
+      const withRequirement = (requirement: LabelSelectorRequirement) =>
+        workload("Deployment", {
+          replicas: 1,
+          selector: { matchLabels: { app: "web" }, matchExpressions: [requirement] },
+        });
+      const { rerender } = render(
+        <WorkloadDetailsBody object={withRequirement(NOT_CANARY)} context="ctx" />,
+      );
+      await waitFor(() => expect(screen.getByText("web-abc-1")).toBeDefined());
+      rerender(
+        <WorkloadDetailsBody
+          object={withRequirement({ key: "track", operator: "In", values: ["canary"] })}
+          context="ctx"
+        />,
+      );
+      // The equality half did not move, so a re-fetch keyed on `matchLabels`
+      // alone would leave the stable pod on screen under the canary selector.
+      await waitFor(() => expect(screen.getByText("web-canary-9")).toBeDefined());
+      expect(screen.queryByText("web-abc-1")).toBeNull();
+    });
+
+    it("reads the requirements in the Selector row beside the equality labels", () => {
+      render(
+        <WorkloadDetailsBody
+          object={workload("Deployment", {
+            replicas: 1,
+            selector: { matchLabels: { app: "web" }, matchExpressions: [NOT_CANARY] },
+          })}
+          context="ctx"
+        />,
+      );
+      expect(screen.getByText("app=")).toBeDefined();
+      expect(screen.getByText("track notin (canary)")).toBeDefined();
+    });
+
+    it("still gives a Selector row to a workload whose selector is expressions alone", () => {
+      const { container } = render(
+        <WorkloadDetailsBody
+          object={workload("Deployment", {
+            replicas: 1,
+            selector: { matchExpressions: [{ key: "app", operator: "In", values: ["web", "api"] }] },
+          })}
+          context="ctx"
+        />,
+      );
+      expect(factLabels(container)).toContain("Selector");
+      expect(screen.getByText("app in (web, api)")).toBeDefined();
+    });
+
+    it("reads a DaemonSet's requirements in its Scheduling block", () => {
+      const { container } = render(
+        <WorkloadDetailsBody
+          object={workload("DaemonSet", {
+            selector: { matchExpressions: [{ key: "logging", operator: "Exists" }] },
+          })}
+          context="ctx"
+        />,
+      );
+      expect(factLabels(container, "Scheduling")).toContain("Selector");
+      expect(screen.getByText("logging")).toBeDefined();
     });
   });
 
@@ -717,7 +903,7 @@ describe("WorkloadDetailsBody", () => {
       // a bare `getByText`.
       expect(screen.getAllByRole("heading", { name: "Pods" })).toHaveLength(1);
       expect(podsForSelector).toHaveBeenCalledTimes(1);
-      expect(podsForSelector).toHaveBeenCalledWith("ctx", "kube-system", { app: "logging" });
+      expect(podsForSelector).toHaveBeenCalledWith("ctx", "kube-system", { app: "logging" }, []);
     });
   });
 

--- a/packages/ui-next/src/screens/detail/WorkloadBody.tsx
+++ b/packages/ui-next/src/screens/detail/WorkloadBody.tsx
@@ -20,6 +20,7 @@ import {
   StringList,
 } from "./sections";
 import { SELF_DESCRIBING_KINDS } from "./GenericBody";
+import { hasSelector, requirementText, selectorOf, type WorkloadSelector } from "../../lib/workloadSelector";
 
 /** The annotation a Deployment records its current rollout number in. */
 const REVISION_ANNOTATION = "deployment.kubernetes.io/revision";
@@ -51,6 +52,25 @@ function updateStrategyText(strategy: Record<string, unknown>): string {
   if (maxSurge != null) parts.push(`surge ${maxSurge}`);
   if (maxUnavailable != null) parts.push(`unavailable ${maxUnavailable}`);
   return [type, ...parts].join(" · ");
+}
+
+/**
+ * A selector as the pane reads it: the equality labels as `k=v` pairs, with
+ * each requirement under them in Kubernetes' own syntax.
+ *
+ * BOTH halves, because a row that shows only the labels describes a wider set
+ * of pods than the table below it lists — and a workload selected entirely by
+ * expressions had no Selector row at all, on a pane that now finds its pods.
+ */
+function SelectorValue({ selector }: { selector: WorkloadSelector }) {
+  return (
+    <>
+      <PairList pairs={Object.entries(selector.matchLabels)} breakValues />
+      {selector.matchExpressions.length > 0 && (
+        <StringList items={selector.matchExpressions.map(requirementText)} />
+      )}
+    </>
+  );
 }
 
 /** The images a workload's pod template runs, each named once. */
@@ -190,7 +210,7 @@ export const workloadFacts: FactsFor = ({ kind, object, revisions }) => {
   const meta = object.metadata ?? {};
   const spec = asRecord(object.spec);
   const status = asRecord(object.status);
-  const selector = asRecord(asRecord(spec.selector).matchLabels) as Record<string, string>;
+  const selector = selectorOf(object);
   const owners = meta.ownerReferences ?? [];
   const created = str(meta.creationTimestamp);
 
@@ -225,8 +245,8 @@ export const workloadFacts: FactsFor = ({ kind, object, revisions }) => {
   ];
   if (strategy) facts.push({ label: "Strategy", value: strategy });
   if (revision) facts.push({ label: "Revision", value: revisionText });
-  if (Object.keys(selector).length > 0) {
-    facts.push({ label: "Selector", value: <PairList pairs={Object.entries(selector)} breakValues /> });
+  if (hasSelector(selector)) {
+    facts.push({ label: "Selector", value: <SelectorValue selector={selector} /> });
   }
   if (spec.minReadySeconds != null) {
     facts.push({ label: "Min ready seconds", value: str(spec.minReadySeconds) });
@@ -262,7 +282,7 @@ export const workloadFacts: FactsFor = ({ kind, object, revisions }) => {
 function DaemonSetSchedulingSection({ object }: { object: K8sObject }) {
   const spec = asRecord(object.spec);
   const status = asRecord(object.status);
-  const selector = asRecord(asRecord(spec.selector).matchLabels) as Record<string, string>;
+  const selector = selectorOf(object);
   const strategyText = updateStrategyText(asRecord(spec.updateStrategy));
 
   return (
@@ -273,9 +293,7 @@ function DaemonSetSchedulingSection({ object }: { object: K8sObject }) {
       {status.updatedNumberScheduled != null && <KV k="Up-to-date" v={str(status.updatedNumberScheduled)} />}
       {status.numberAvailable != null && <KV k="Available" v={str(status.numberAvailable)} />}
       {strategyText && <KV k="Update strategy" v={strategyText} />}
-      {Object.keys(selector).length > 0 && (
-        <KV k="Selector" v={<PairList pairs={Object.entries(selector)} breakValues />} />
-      )}
+      {hasSelector(selector) && <KV k="Selector" v={<SelectorValue selector={selector} />} />}
     </Section>
   );
 }
@@ -336,8 +354,7 @@ export function WorkloadDetailsBody({
   const meta = object.metadata ?? {};
   const spec = asRecord(object.spec);
   const namespace = str(meta.namespace);
-  const selector = asRecord(asRecord(spec.selector).matchLabels) as Record<string, string>;
-  const hasSelector = Object.keys(selector).length > 0;
+  const selector = selectorOf(object);
   const selfDescribing = SELF_DESCRIBING_KINDS.has(kind);
   const conditions = asArray(asRecord(object.status).conditions) as unknown as Condition[];
 
@@ -349,7 +366,7 @@ export function WorkloadDetailsBody({
           other wrapped kind gets. */}
       {kind === "DaemonSet" && <DaemonSetSchedulingSection object={object} />}
       <DeployRevisionsSection state={revisions} />
-      {hasSelector && namespace && selfDescribing && (
+      {hasSelector(selector) && namespace && selfDescribing && (
         <RelatedPodsSection context={context} namespace={namespace} selector={selector} />
       )}
       {selfDescribing && <ConditionsSection conditions={conditions} />}

--- a/packages/ui-next/src/screens/detail/sections.tsx
+++ b/packages/ui-next/src/screens/detail/sections.tsx
@@ -34,6 +34,7 @@ import {
 } from "@srelens/ui-kit";
 import { Section } from "./Section";
 import { formatCpu, formatMemory } from "../../lib/kinds/columns";
+import type { WorkloadSelector } from "../../lib/workloadSelector";
 
 /**
  * A formatted list, one item per line — a pod's IPs, an owner reference, a
@@ -365,18 +366,23 @@ export function RelatedPodsSection({
 }: {
   context: string;
   namespace: string;
-  selector: Record<string, string>;
+  /** The workload's WHOLE `LabelSelector`. Both halves, because a pod is the
+   *  workload's only when it satisfies both — see {@link WorkloadSelector}. */
+  selector: WorkloadSelector;
 }) {
   const [state, setState] = useState<{ status: "loading" | "ready" | "error"; pods?: RelatedPod[] }>({
     status: "loading",
   });
-  const selectorKey = JSON.stringify(selector);
+  // Both halves, so a workload whose requirements changed under an unchanged
+  // set of equality labels is re-read rather than left showing the pods of
+  // the selector before it.
+  const selectorKey = JSON.stringify([selector.matchLabels, selector.matchExpressions]);
 
   useEffect(() => {
     let active = true;
     setState({ status: "loading" });
     Promise.all([
-      podsForSelector(context, namespace, selector),
+      podsForSelector(context, namespace, selector.matchLabels, selector.matchExpressions),
       // Metrics are best-effort: a missing metrics-server must not hide pods.
       podMetrics(context, namespace).catch((): { metrics?: PodMetric[] } => ({ metrics: [] })),
     ]).then(([podsOut, metricsOut]) => {


### PR DESCRIPTION
The four P2s Codex raised on #344, which merged before these landed. All four were verified in the code first; all four were real. Plus the root cause of some flaky tests in the screen #344 shipped.

## 1. The container filter blanked the screen on the commonest case

`resolveLogSubject` labels a target with **the pod name alone** when every target shares one container name — an ordinary Deployment with three replicas. `toRow` recovered the container by splitting that label on `/`, so `row.container` was empty for every line, while the container select is populated from the **targets**, which do carry it.

Open logs on any ordinary multi-replica Deployment, pick your container, and every line disappears with nothing to explain it.

The label is a **display** decision; the container is **data**. Carrying both in one string is what made this possible. The container now comes off the matched target and `Row.namesContainer` carries the display half, so the gutter still shows the pod alone where the container would repeat one word down every row — the earlier decision is preserved rather than undone. Splitting on `/` survives only as the fallback for a source no target claims.

## 2. A workload's selector was read in half

`matchLabels` was read and `matchExpressions` discarded. A `LabelSelector` is the conjunction of both, so this was wrong twice over: a workload with both halves resolved to a selector **broader than the real one**, streaming lines from pods it does not own; and one written **entirely in expressions** resolved to an empty selector, which the backend deliberately answers with no pods.

Fixed on both sides — `k8s.podsForSelector` now renders requirements in Kubernetes' own syntax (`key in (a,b)`, `!key`). The field is optional and defaulted, and `PodsForSelectorIn` has no `deny_unknown_fields`, so every existing payload deserialises identically; the four other callers (three in classic, one in ui-next) send a byte-identical payload, asserted by a test rather than argued.

Empty sets are defined rather than accidental: `In ()` is unsatisfiable, so the selector matches nothing and no query is made; `NotIn ()` constrains nothing, so the term drops out.

### The same bug was already shipped in the detail screen

Following the finding rather than the file: `WorkloadBody` read `matchLabels` in **three** places and handed that to Related pods, so the detail pane has listed pods a workload does not own since #337.

The expression-only case was worse than it looked — the panel gated on `matchLabels` being non-empty, so such a workload lost its **Pods panel outright** rather than showing it empty. The Selector row now shows the requirements too.

`selectorOf` moves into `lib/workloadSelector`: whose pods a workload owns is not a logs concern.

**`GenericBody` still reads the equality half alone** — its selector comes from core's `relatedPodSelector`, which frozen classic also calls. Documented in place as a narrower instance of the same gap.

## 3. Lines from a cancelled connection landed in the new buffer

The unmount-while-starting guard checked `cancelled` in the **status** callback but not in `onLine`, which is the hook's shared callback.

Narrow the `since` window and the old promise's initial tail lines arrive after the new effect has cleared the buffer — so **narrowing the window could show lines older than the window**, the one thing that control exists to do. A guard scoped inside the effect; the shared callback and its ref-write burst path are untouched.

## 4. One malformed persisted route crashed the window

`parseLogsRoute` called `decodeURIComponent`, which throws on `%zz`. Both `describe` and `screenFor` call it during render and tab routes are persisted, so a single corrupt route took down the whole new-design window on boot. It now falls back to `null`, which the function's contract already treats as a normal outcome.

## The flaky tests, and why the first two fixes were wrong

Four tests in `Logs.test.tsx` failed roughly one run in six and passed alone every time. I fixed two of them on a theory about stale nodes; the flake moved to a third, then a fourth. The theory was half right and aimed at symptoms.

`body()` returned the log element as soon as one appeared — **before `resolveLogSubject` settles**. When it settles, React replaces that node, and the test holds a detached one: `querySelectorAll` answers nothing, and a `clientHeight` defined on it is lost, so the window sees a zero-height viewport and draws no rows at all.

One cause, four faces — an empty body, a rail badge counting none, a windowing assertion getting zero. `body()` now flushes pending promises and re-queries.

Twelve consecutive full sweeps green.

## Gates

3,460 tests across core, the kit and ui-next; 727 in classic, unchanged; 380 in the kube crate; four projects typechecking.

## Note on the mutation pass

Each fix mutated its own assertions afterwards, and two found real gaps: an unlabelled target with **no container** rendered `api-7 · ` with a dangling separator and `api-7/ |` in an export, which no fixture had; and a selector fixture whose `matchLabels` alone would have selected the same pods, which would have proved nothing about the expressions. The second one's fake now answers from the payload it was actually sent, so a dropped expression yields a visibly different pod list.
