### PR TITLE
feat(ui-next): port forwards and the toolbox

### DIFF
--- a/apps/desktop/src-tauri/src/external.rs
+++ b/apps/desktop/src-tauri/src/external.rs
@@ -1,0 +1,115 @@
+//! Open an address in the user's own default browser.
+//!
+//! The WebView cannot do this itself: Tauri doesn't patch `window.open`, and
+//! wry's `WKUIDelegate` returns nil for a new window unless the app installs a
+//! new-window handler — srelens installs none, so `window.open` and
+//! `<a target="_blank">` are silent no-ops on the desktop (#348). The same
+//! shape as `files::save_text_file`, which exists because `<a download>` is
+//! silently dead in a WebView for the same kind of reason.
+//!
+//! `tauri-plugin-opener` is already a dependency and already registered.
+//! Reaching it from a Rust command needs no JS package and no capability
+//! permission: capabilities gate JS-to-plugin calls, not Rust-to-plugin ones.
+
+use tauri::{AppHandle, Runtime};
+use tauri_plugin_opener::OpenerExt;
+
+/// Open `url` in the default browser.
+///
+/// The frontend only ever calls this with an address srelens itself built from
+/// a live forward, and [`checked_http_url`] is what keeps that true from this
+/// side as well: this must not become a way for a string that arrived from a
+/// cluster to reach the OS's URL handlers.
+#[tauri::command]
+pub async fn open_external<R: Runtime>(app: AppHandle<R>, url: String) -> Result<(), String> {
+    let url = checked_http_url(&url)?;
+    app.opener()
+        .open_url(url, None::<&str>)
+        .map_err(|error| error.to_string())
+}
+
+/// `url` back, if it is an absolute http(s) URL with a non-empty authority and
+/// nothing in it that a URL cannot contain.
+///
+/// Deliberately not a repair: a bare `localhost:12492` is refused rather than
+/// given a scheme, so the only thing this command can do is open a URL a
+/// caller had already decided on. `browsable` in `packages/core` is where an
+/// address becomes one, in front of the same gate.
+fn checked_http_url(url: &str) -> Result<String, String> {
+    const REFUSED: &str = "srelens only opens http and https addresses.";
+    if url.chars().any(|c| c.is_whitespace() || c.is_control()) {
+        return Err(REFUSED.to_string());
+    }
+    let lower = url.to_ascii_lowercase();
+    let after_scheme = lower
+        .strip_prefix("http://")
+        .or_else(|| lower.strip_prefix("https://"))
+        .ok_or(REFUSED)?;
+    // The authority runs to the first `/`, `?` or `#`; an empty one is not a
+    // host, so `http://` on its own is not a URL either.
+    let authority = after_scheme.find(['/', '?', '#']).unwrap_or(after_scheme.len());
+    if authority == 0 {
+        return Err(REFUSED.to_string());
+    }
+    Ok(url.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn passes_an_absolute_http_or_https_url_through_untouched() {
+        for url in [
+            "http://localhost:12492",
+            "http://127.0.0.1:8080/metrics",
+            "https://srelens.example/pf/7/",
+            // The scheme is matched case-insensitively, and the URL is handed
+            // on exactly as it arrived rather than normalised.
+            "HTTPS://srelens.example/pf/7/",
+        ] {
+            assert_eq!(checked_http_url(url).unwrap(), url);
+        }
+    }
+
+    #[test]
+    fn refuses_every_other_scheme() {
+        // The whole point of the gate: this command is given a URL srelens
+        // built from a live forward, never arbitrary text from a cluster, and
+        // it must not be usable as a general "hand anything to the OS" path.
+        for url in [
+            "file:///etc/passwd",
+            "javascript:alert(1)",
+            "data:text/html,<script>alert(1)</script>",
+            "srelens://open",
+            "smb://fileserver/share",
+            "mailto:someone@example.com",
+        ] {
+            assert!(checked_http_url(url).is_err(), "should have been refused: {url}");
+        }
+    }
+
+    #[test]
+    fn refuses_a_bare_authority_and_an_empty_one() {
+        // `forwardAddress` answers `localhost:12492` on the desktop. That is
+        // not a URL, and repairing it here is the frontend's job (`browsable`)
+        // so that this side stays a gate rather than a fixer-upper.
+        for url in ["localhost:12492", "/pf/7/", "", "http://", "https://", "http:/localhost"] {
+            assert!(checked_http_url(url).is_err(), "should have been refused: {url}");
+        }
+    }
+
+    #[test]
+    fn refuses_whitespace_and_control_characters() {
+        // A newline in an argument handed to a launcher is how one URL becomes
+        // two commands.
+        for url in [
+            "http://localhost:12492 --bad",
+            "http://localhost:12492\nhttp://evil.example",
+            "http://localhost:12492\u{0}",
+            "http://local host:12492",
+        ] {
+            assert!(checked_http_url(url).is_err(), "should have been refused: {url:?}");
+        }
+    }
+}

--- a/apps/desktop/src-tauri/src/forward.rs
+++ b/apps/desktop/src-tauri/src/forward.rs
@@ -7,7 +7,8 @@
 
 use std::sync::Arc;
 
-use srelens_streams::forward::{ForwardInfo, ForwardManager};
+use serde::Serialize;
+use srelens_streams::forward::{ForwardEntry, ForwardInfo, ForwardManager};
 use tauri::{AppHandle, Runtime, State};
 
 use crate::sink::TauriSink;
@@ -47,6 +48,25 @@ pub async fn stop_port_forward(id: u64, manager: State<'_, ForwardManager>) -> R
     Ok(())
 }
 
+/// The response shape for `list_forwards`, shared with the web command of
+/// the same name.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListForwardsResponse {
+    pub forwards: Vec<ForwardEntry>,
+}
+
+/// List every forward the manager currently holds. On desktop the process
+/// dies with the app, so this manager never outlives the frontend store —
+/// but the command exists here too so a client has exactly one way to ask,
+/// on both platforms, rather than a web-only special case.
+#[tauri::command]
+pub fn list_forwards(manager: State<'_, ForwardManager>) -> ListForwardsResponse {
+    ListForwardsResponse {
+        forwards: manager.list(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -77,5 +97,20 @@ mod tests {
 
         stop_port_forward(info.id, app.state()).await.unwrap();
         stop_port_forward(info.id + 1, app.state()).await.unwrap();
+    }
+
+    /// list_forwards is what the frontend store rehydrates from, so it must
+    /// hand back exactly what the manager holds — not an empty stand-in.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn list_forwards_returns_what_the_manager_holds() {
+        let app = tauri::test::mock_app();
+        app.manage(ForwardManager::new(ClientCache::new_many(vec![])));
+        let manager: State<ForwardManager> = app.state();
+        manager.insert_test_forward(7, 55555);
+
+        let resp = list_forwards(app.state());
+        assert_eq!(resp.forwards.len(), 1);
+        assert_eq!(resp.forwards[0].id, 7);
+        assert_eq!(resp.forwards[0].local_port, 55555);
     }
 }

--- a/apps/desktop/src-tauri/src/forward.rs
+++ b/apps/desktop/src-tauri/src/forward.rs
@@ -94,6 +94,7 @@ mod tests {
         .await
         .unwrap();
         assert_ne!(info.local_port, 0, "an ephemeral port must have been bound");
+        assert!(info.started_at > 0, "the start response must carry its stamp");
 
         stop_port_forward(info.id, app.state()).await.unwrap();
         stop_port_forward(info.id + 1, app.state()).await.unwrap();

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -34,7 +34,7 @@ use app_log::{app_log_path, read_app_log, reveal_app_log};
 use bridge::{invoke_capability, AppRegistry};
 use exec::{exec_close, exec_input, exec_resize, start_pod_exec};
 use files::{pick_kubeconfig_files, save_pasted_kubeconfig, save_text_file};
-use forward::{start_port_forward, stop_port_forward};
+use forward::{list_forwards, start_port_forward, stop_port_forward};
 use helm::{helm_op_close, start_helm_op};
 use logs::{start_log_stream, stop_log_stream};
 use mcp::{
@@ -468,6 +468,7 @@ pub fn run() {
             exec_close,
             start_port_forward,
             stop_port_forward,
+            list_forwards,
             start_log_stream,
             stop_log_stream,
             save_text_file,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ mod cluster_oidc_cmd;
 mod llm_agent;
 mod llm_config;
 mod exec;
+mod external;
 mod files;
 mod forward;
 mod helm;
@@ -33,6 +34,7 @@ mod watch;
 use app_log::{app_log_path, read_app_log, reveal_app_log};
 use bridge::{invoke_capability, AppRegistry};
 use exec::{exec_close, exec_input, exec_resize, start_pod_exec};
+use external::open_external;
 use files::{pick_kubeconfig_files, save_pasted_kubeconfig, save_text_file};
 use forward::{list_forwards, start_port_forward, stop_port_forward};
 use helm::{helm_op_close, start_helm_op};
@@ -472,6 +474,7 @@ pub fn run() {
             start_log_stream,
             stop_log_stream,
             save_text_file,
+            open_external,
             pick_kubeconfig_files,
             save_pasted_kubeconfig,
             start_tool_install,

--- a/apps/desktop/src/components/AppearanceSettingsSection.test.tsx
+++ b/apps/desktop/src/components/AppearanceSettingsSection.test.tsx
@@ -74,6 +74,23 @@ describe("AppearanceSettingsSection", () => {
     expect(items).toContain("Logs");
   });
 
+  it("lists port forwards, which run on regardless of which screen is open", () => {
+    // A tunnel outlives the tab that started it — someone weighing the toggle
+    // is weighing whether they can see and stop the ones they have running.
+    render(<AppearanceSettingsSection />);
+    const items = screen.getAllByRole("listitem").map((li) => li.textContent);
+    expect(items).toContain("Port forwards");
+  });
+
+  it("lists the toolbox, the only screen that is about the machine and not a cluster", () => {
+    // The managed kubectl, helm and krew under ~/.srelens/bin, plus what a
+    // context's exec-auth needs. Nothing about it is cluster-scoped, so a
+    // reader who does not see it named assumes it did not come along.
+    render(<AppearanceSettingsSection />);
+    const items = screen.getAllByRole("listitem").map((li) => li.textContent);
+    expect(items).toContain("Toolbox");
+  });
+
   it("introduces the list, so the names are not a bare list under the hint", () => {
     render(<AppearanceSettingsSection />);
     expect(screen.getByText(/in the new design so far/i)).toBeDefined();

--- a/apps/desktop/src/design.test.ts
+++ b/apps/desktop/src/design.test.ts
@@ -62,6 +62,8 @@ describe("the list of ported screens", () => {
       "/events",
       "/overview",
       "/logs",
+      "/forwards",
+      "/toolbox",
     ]);
   });
 
@@ -74,6 +76,8 @@ describe("the list of ported screens", () => {
       "Events",
       "Cluster overview",
       "Logs",
+      "Port forwards",
+      "Toolbox",
     ]);
   });
 });

--- a/apps/desktop/src/design.ts
+++ b/apps/desktop/src/design.ts
@@ -216,6 +216,14 @@ export const PORTED_SCREENS: ReadonlyArray<{ route: string; name: string }> = [
   // Its deeper `/logs/<kind>/<namespace>/<name>` shape is the same screen with
   // a subject in it, so "/logs" names both here.
   { route: "/logs", name: "Logs" },
+  // A tunnel outlives the tab that opened it, so this screen is where the ones
+  // already running are seen and stopped — not a view of a cluster's state but
+  // of this process's own.
+  { route: "/forwards", name: "Port forwards" },
+  // The only screen here that is about the machine rather than a cluster: the
+  // managed kubectl, helm and krew under ~/.srelens/bin, and what the active
+  // context's exec-auth needs on PATH.
+  { route: "/toolbox", name: "Toolbox" },
 ];
 
 /**

--- a/crates/kube/src/forward.rs
+++ b/crates/kube/src/forward.rs
@@ -4,13 +4,16 @@
 
 use std::fmt;
 use std::io::ErrorKind;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
 use k8s_openapi::api::core::v1::{Pod, Service, ServicePort};
 use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
 use kube::api::ListParams;
 use kube::Api;
-use tokio::io::copy_bidirectional;
+use tokio::io::{copy_bidirectional, AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::TcpListener;
 
 use crate::client_cache::ClientCache;
@@ -73,6 +76,93 @@ pub async fn connect_pod_api(
     Ok(Api::namespaced(client, namespace))
 }
 
+/// Bytes that have crossed one forward, counted as they pass rather than
+/// when a connection closes. `copy_bidirectional` reports its totals too, but
+/// only once the connection is over: a tunnel holding one long-lived
+/// connection — a database session, a websocket — would report nothing for as
+/// long as it stays open, so a busy tunnel would read as idle for hours.
+///
+/// The count belongs to the *forward*, not to a connection: `accept_loop`
+/// spawns a task per accepted connection, so the caller owns the `Arc` and a
+/// tunnel's total survives any one connection closing.
+///
+/// `Relaxed` is deliberate. A reporter task in another crate reads this while
+/// the pipes write to it, but it is a monotonic statistic rather than a
+/// synchronisation point — nothing is published through it, so no ordering
+/// beyond the atomicity of the add itself is needed.
+#[derive(Debug, Default)]
+pub struct TrafficCounter(AtomicU64);
+
+impl TrafficCounter {
+    pub fn add(&self, n: u64) {
+        self.0.fetch_add(n, Ordering::Relaxed);
+    }
+
+    pub fn total(&self) -> u64 {
+        self.0.load(Ordering::Relaxed)
+    }
+}
+
+/// A stream that adds whatever each poll actually moved to a `TrafficCounter`.
+///
+/// Only the *local* side is wrapped, and that counts both directions: every
+/// byte the client sends arrives as a read on it, and every byte the client
+/// receives leaves as a write to it. Wrapping the upstream too would double
+/// the number.
+struct Counted<S> {
+    inner: S,
+    counter: Arc<TrafficCounter>,
+}
+
+impl<S> Counted<S> {
+    fn new(inner: S, counter: Arc<TrafficCounter>) -> Self {
+        Self { inner, counter }
+    }
+}
+
+impl<S: AsyncRead + Unpin> AsyncRead for Counted<S> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let this = self.get_mut();
+        let before = buf.filled().len();
+        let res = Pin::new(&mut this.inner).poll_read(cx, buf);
+        if matches!(res, Poll::Ready(Ok(()))) {
+            this.counter
+                .add(buf.filled().len().saturating_sub(before) as u64);
+        }
+        res
+    }
+}
+
+// `is_write_vectored` is left at its `false` default on purpose: reporting
+// true would route writes through `poll_write_vectored`, and a default
+// implementation of that would move bytes this wrapper never sees.
+impl<S: AsyncWrite + Unpin> AsyncWrite for Counted<S> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let this = self.get_mut();
+        let res = Pin::new(&mut this.inner).poll_write(cx, buf);
+        if let Poll::Ready(Ok(n)) = res {
+            this.counter.add(n as u64);
+        }
+        res
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_shutdown(cx)
+    }
+}
+
 /// Accept loop for a bound listener: every inbound local connection opens its
 /// own port-forward stream to `pod:remote_port` and is piped bidirectionally.
 /// Runs until the listener errors, the target pod monitor detects the pod is
@@ -94,9 +184,10 @@ pub async fn serve_pod_forward(
     api: Api<Pod>,
     pod: String,
     remote_port: u16,
+    traffic: Arc<TrafficCounter>,
 ) -> Result<(), String> {
     tokio::select! {
-        res = accept_loop(listener, api.clone(), pod.clone(), remote_port) => res,
+        res = accept_loop(listener, api.clone(), pod.clone(), remote_port, traffic) => res,
         res = monitor_target_pod(api, pod) => res,
     }
 }
@@ -106,17 +197,22 @@ async fn accept_loop(
     api: Api<Pod>,
     pod: String,
     remote_port: u16,
+    traffic: Arc<TrafficCounter>,
 ) -> Result<(), String> {
     loop {
-        let (mut local, _peer) = listener.accept().await.map_err(|e| e.to_string())?;
+        let (local, _peer) = listener.accept().await.map_err(|e| e.to_string())?;
         let api = api.clone();
         let pod = pod.clone();
+        // Cloned per connection so every connection of this forward adds to
+        // the one total the caller holds.
+        let traffic = traffic.clone();
         tokio::spawn(async move {
             let mut pf = match api.portforward(&pod, &[remote_port]).await {
                 Ok(pf) => pf,
                 Err(_) => return,
             };
             if let Some(mut upstream) = pf.take_stream(remote_port) {
+                let mut local = Counted::new(local, traffic);
                 let _ = copy_bidirectional(&mut local, &mut upstream).await;
             }
         });
@@ -264,6 +360,109 @@ pub fn pick_ready_pod(pods: &[Pod]) -> Option<&Pod> {
 mod tests {
     use super::*;
     use k8s_openapi::api::core::v1::{Container, ContainerPort, PodSpec, PodStatus};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpStream;
+    use tokio::task::JoinHandle;
+
+    /// A loopback echo server, standing in for whatever listens on the far
+    /// side of the tunnel: it sends back every byte it is given, so a client
+    /// that writes N and reads N back has moved 2N across the local stream.
+    async fn echo_server() -> std::net::SocketAddr {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            while let Ok((mut sock, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    let (mut r, mut w) = sock.split();
+                    let _ = tokio::io::copy(&mut r, &mut w).await;
+                });
+            }
+        });
+        addr
+    }
+
+    /// The per-connection body of `accept_loop`, with a real echo upstream in
+    /// place of a port-forward stream: an accepted local connection wrapped in
+    /// `Counted` and piped bidirectionally. Returns the client end and the
+    /// pipe's handle so a test can decide whether to close the connection.
+    async fn counted_pipe(counter: Arc<TrafficCounter>) -> (TcpStream, JoinHandle<()>) {
+        let upstream_addr = echo_server().await;
+        let listener = bind_local(0).await.expect("bind");
+        let local_addr = listener.local_addr().unwrap();
+        let client = TcpStream::connect(local_addr).await.expect("connect");
+        let (local, _peer) = listener.accept().await.expect("accept");
+        let mut upstream = TcpStream::connect(upstream_addr).await.expect("upstream");
+        let handle = tokio::spawn(async move {
+            let mut local = Counted::new(local, counter);
+            let _ = copy_bidirectional(&mut local, &mut upstream).await;
+        });
+        (client, handle)
+    }
+
+    /// Write `payload`, read the echo back, then close: the whole exchange,
+    /// start to finish. Returns the number of bytes that came back.
+    async fn echo_through_counted_stream(counter: Arc<TrafficCounter>, payload: &[u8]) -> usize {
+        let (mut client, handle) = counted_pipe(counter).await;
+        client.write_all(payload).await.expect("write");
+        let mut back = vec![0u8; payload.len()];
+        client.read_exact(&mut back).await.expect("read back");
+        assert_eq!(back, payload, "the echo came back intact");
+        drop(client);
+        let _ = handle.await;
+        back.len()
+    }
+
+    /// Write `payload` and read the echo back, but leave everything open —
+    /// the client and the pipe are handed back alive.
+    async fn write_through_counted_stream(
+        counter: Arc<TrafficCounter>,
+        payload: &[u8],
+    ) -> (TcpStream, JoinHandle<()>) {
+        let (mut client, handle) = counted_pipe(counter).await;
+        client.write_all(payload).await.expect("write");
+        let mut back = vec![0u8; payload.len()];
+        client.read_exact(&mut back).await.expect("read back");
+        (client, handle)
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn counts_bytes_in_both_directions() {
+        // An echo upstream, so a client that writes N and reads N back moves
+        // 2N: counting only the local side sees both directions.
+        let counter = Arc::new(TrafficCounter::default());
+        let moved = echo_through_counted_stream(counter.clone(), b"hello world").await;
+        assert_eq!(moved, 11, "wrote 11 bytes");
+        assert_eq!(counter.total(), 22, "11 up and 11 back down");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_connection_still_open_has_already_counted_what_it_moved() {
+        // The property the whole task exists for: a long-lived connection must
+        // report before it closes, or a database tunnel reads 0 for hours.
+        // `copy_bidirectional`'s return value cannot satisfy this — it only
+        // arrives once the connection is over.
+        let counter = Arc::new(TrafficCounter::default());
+        let (_client, held) = write_through_counted_stream(counter.clone(), b"first").await;
+        assert!(!held.is_finished(), "the connection is still open");
+        assert!(
+            counter.total() >= 5,
+            "counted while the connection is still open, saw {}",
+            counter.total()
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn one_counter_spans_every_connection_of_a_forward() {
+        // Counters belong to a forward, not to a connection: `accept_loop`
+        // spawns per connection, so a tunnel's total must not reset when one
+        // of its connections closes.
+        let counter = Arc::new(TrafficCounter::default());
+        echo_through_counted_stream(counter.clone(), b"one").await;
+        let after_first = counter.total();
+        echo_through_counted_stream(counter.clone(), b"two").await;
+        assert_eq!(after_first, 6, "3 up and 3 back down");
+        assert_eq!(counter.total(), 12, "the second connection added to the first");
+    }
 
     fn svc_port(port: i32, target: Option<IntOrString>) -> ServicePort {
         ServicePort {

--- a/crates/kube/src/toolbox.rs
+++ b/crates/kube/src/toolbox.rs
@@ -417,7 +417,13 @@ pub fn krew_bin_dir() -> PathBuf {
 const MANAGED_TOOLS: [&str; 3] = ["kubectl", "krew", "helm"];
 
 /// One managed tool's inventory entry for the Toolbox "Tools" section.
+///
+/// `camelCase` because every other DTO the frontend reads is camelCase, and
+/// `size_bytes` is the first field here with two words in it — the existing
+/// five are single words, so the rename changes nothing about them and only
+/// stops this one arriving as `size_bytes` in TypeScript.
 #[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct ToolStatusDto {
     pub name: String,
     pub installed: bool,
@@ -1163,13 +1169,13 @@ users:
         assert_eq!(kubectl["version"], "v1.30.2");
         assert!(kubectl["path"].as_str().unwrap().ends_with("/kubectl"));
         // `b"#!/bin/sh\n"` is 10 bytes on disk.
-        assert_eq!(kubectl["size_bytes"], 10);
+        assert_eq!(kubectl["sizeBytes"], 10);
         // krew + helm absent: no reading, not a zero.
         assert_eq!(tools[1]["installed"], false);
         assert_eq!(tools[1]["version"], serde_json::Value::Null);
-        assert_eq!(tools[1]["size_bytes"], serde_json::Value::Null);
+        assert_eq!(tools[1]["sizeBytes"], serde_json::Value::Null);
         assert_eq!(tools[2]["installed"], false);
-        assert_eq!(tools[2]["size_bytes"], serde_json::Value::Null);
+        assert_eq!(tools[2]["sizeBytes"], serde_json::Value::Null);
     }
 
     #[tokio::test]
@@ -1193,7 +1199,7 @@ users:
         reg.register(cap);
         let out = reg.invoke("toolbox.status", json!({})).await.unwrap();
         let tools = out["tools"].as_array().unwrap();
-        assert_eq!(tools[0]["size_bytes"], 5000);
+        assert_eq!(tools[0]["sizeBytes"], 5000);
     }
 
     #[tokio::test]
@@ -1213,7 +1219,7 @@ users:
         let tools = out["tools"].as_array().unwrap();
         // Located and reported installed, but no size was actually read.
         assert_eq!(tools[0]["installed"], true);
-        assert_eq!(tools[0]["size_bytes"], serde_json::Value::Null);
+        assert_eq!(tools[0]["sizeBytes"], serde_json::Value::Null);
     }
 
     #[tokio::test]

--- a/crates/kube/src/toolbox.rs
+++ b/crates/kube/src/toolbox.rs
@@ -425,6 +425,11 @@ pub struct ToolStatusDto {
     pub version: Option<String>,
     /// `managed` (srelens installed it under a managed dir) or `system`.
     pub source: Option<String>,
+    /// The size in bytes of the file at `path`. `None` when the tool isn't
+    /// installed (no path to size) and also `None` when it is but the path
+    /// can't be stat'd (dangling symlink, permission error) — a missing
+    /// reading is never reported as `0`.
+    pub size_bytes: Option<u64>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -468,6 +473,21 @@ fn tool_source(path: &Path, managed_dirs: &[PathBuf]) -> &'static str {
     }
 }
 
+/// The size in bytes of the file at `path`, or `None` if it can't be read.
+///
+/// Uses `fs::metadata`, which follows symlinks, deliberately: entries under
+/// `~/.srelens/bin` and `/usr/local/bin` are frequently symlinks (a Homebrew
+/// shim, a version-pinned install), and a link's own length is a handful of
+/// bytes — a number that looks like a real answer and is wrong. We want the
+/// size of the binary the tool actually runs, so we follow the link.
+/// `symlink_metadata` (which reports the link itself) would be wrong here.
+///
+/// `None` on any error (missing file, dangling symlink, permission denied) —
+/// never `unwrap_or(0)`: a size that wasn't read is not a size of zero.
+fn tool_size(path: &Path) -> Option<u64> {
+    std::fs::metadata(path).ok().map(|m| m.len())
+}
+
 /// Read-only capability: inventory the managed CLI toolchain (kubectl, krew,
 /// helm) — whether each is installed, where, its version, and whether srelens
 /// manages it. The resolution environment is injected so it's deterministic
@@ -504,6 +524,7 @@ pub fn status_capability(
                                 installed: true,
                                 version: version_of(name, path),
                                 source: Some(tool_source(path, &managed_dirs).to_string()),
+                                size_bytes: tool_size(path),
                                 path: Some(found.path),
                             }
                         }
@@ -513,6 +534,7 @@ pub fn status_capability(
                             path: None,
                             version: None,
                             source: None,
+                            size_bytes: None,
                         },
                     })
                     .collect();
@@ -1140,10 +1162,58 @@ users:
         assert_eq!(kubectl["source"], "managed");
         assert_eq!(kubectl["version"], "v1.30.2");
         assert!(kubectl["path"].as_str().unwrap().ends_with("/kubectl"));
-        // krew + helm absent.
+        // `b"#!/bin/sh\n"` is 10 bytes on disk.
+        assert_eq!(kubectl["size_bytes"], 10);
+        // krew + helm absent: no reading, not a zero.
         assert_eq!(tools[1]["installed"], false);
         assert_eq!(tools[1]["version"], serde_json::Value::Null);
+        assert_eq!(tools[1]["size_bytes"], serde_json::Value::Null);
         assert_eq!(tools[2]["installed"], false);
+        assert_eq!(tools[2]["size_bytes"], serde_json::Value::Null);
+    }
+
+    #[tokio::test]
+    async fn status_follows_a_symlink_to_report_the_targets_size_not_the_links() {
+        let dir = tempfile::tempdir().unwrap();
+        let managed = dir.path().join(".srelens/bin");
+        std::fs::create_dir_all(&managed).unwrap();
+        // `~/.srelens/bin` entries are typically symlinks to a real download;
+        // the link itself is only a handful of bytes.
+        let target = dir.path().join("kubectl-v1.30.2");
+        std::fs::write(&target, vec![0u8; 5000]).unwrap();
+        std::os::unix::fs::symlink(&target, managed.join("kubectl")).unwrap();
+
+        let cap = status_capability(
+            SearchPaths { app_path: managed.to_string_lossy().into_owned(), system_path: String::new() },
+            vec![managed.clone()],
+            |p| p.is_file(),
+            |_name, _p| None,
+        );
+        let mut reg = Registry::new();
+        reg.register(cap);
+        let out = reg.invoke("toolbox.status", json!({})).await.unwrap();
+        let tools = out["tools"].as_array().unwrap();
+        assert_eq!(tools[0]["size_bytes"], 5000);
+    }
+
+    #[tokio::test]
+    async fn status_reports_no_size_when_a_located_path_cannot_be_stat_d() {
+        // A fake resolver that claims a path exists (mirroring a dangling
+        // symlink or permission error under a real filesystem) while nothing
+        // is actually there for `fs::metadata` to read.
+        let cap = status_capability(
+            SearchPaths { app_path: "/does/not/exist".to_string(), system_path: String::new() },
+            vec![],
+            |_p| true,
+            |_name, _p| None,
+        );
+        let mut reg = Registry::new();
+        reg.register(cap);
+        let out = reg.invoke("toolbox.status", json!({})).await.unwrap();
+        let tools = out["tools"].as_array().unwrap();
+        // Located and reported installed, but no size was actually read.
+        assert_eq!(tools[0]["installed"], true);
+        assert_eq!(tools[0]["size_bytes"], serde_json::Value::Null);
     }
 
     #[tokio::test]

--- a/crates/server/src/api_command.rs
+++ b/crates/server/src/api_command.rs
@@ -308,7 +308,7 @@ async fn run(
                 )
                 .await
                 .map_err(|e| command_error(&e))?;
-            json!({ "id": info.id, "localPort": info.local_port })
+            json!({ "id": info.id, "localPort": info.local_port, "startedAt": info.started_at })
         }
         "stop_port_forward" => {
             let a: IdArg = parse(body)?;
@@ -544,6 +544,77 @@ mod tests {
         assert_eq!(
             body["error"],
             json!("helm repo/plugin operations are not available in web mode")
+        );
+    }
+
+    /// POST one `/api/command/<name>` call through the real router and hand
+    /// back its status and decoded JSON body. A small helper because
+    /// `start_port_forward` and `list_forwards` both need it below, and
+    /// hand-building the request twice would be the same boilerplate with
+    /// more chances to drift.
+    async fn post_command(
+        state: &AppState,
+        token: &str,
+        name: &str,
+        body: Value,
+    ) -> (StatusCode, Value) {
+        let resp = router(state.clone())
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/command/{name}"))
+                    .header("content-type", "application/json")
+                    .header("cookie", format!("srelens_session={token}"))
+                    .header("x-srelens-csrf", "1")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = resp.status();
+        let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        (status, serde_json::from_slice(&bytes).unwrap())
+    }
+
+    #[tokio::test]
+    async fn start_port_forward_returns_the_stamp_list_will_later_agree_with() {
+        // The whole point of Task 4b: the start response carries the same
+        // `startedAt` a later `list_forwards` reports, so the frontend never
+        // has to make a second call just to date what it started.
+        let state = AppState::for_tests(Arc::new(Registry::new())).await;
+        let user = state.db.upsert_user("i", "s", "u@x", "U", 1).await.unwrap();
+        let token = state
+            .db
+            .create_session(user.id, crate::unix_now())
+            .await
+            .unwrap();
+
+        let (status, body) = post_command(
+            &state,
+            &token,
+            "start_port_forward",
+            json!({
+                "context": "no-such-context",
+                "namespace": "ns",
+                "kind": "Pod",
+                "name": "pod-a",
+                "remotePort": 8080,
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(body["id"].is_u64());
+        assert!(body["localPort"].as_u64().unwrap() > 0);
+        let started_at = body["startedAt"].as_u64().expect("startedAt is numeric");
+        assert!(started_at > 0, "the response must carry a real stamp");
+
+        let (_, list_body) = post_command(&state, &token, "list_forwards", json!({})).await;
+        assert_eq!(
+            list_body["forwards"][0]["startedAt"],
+            json!(started_at),
+            "list must agree with what start already answered"
         );
     }
 

--- a/crates/server/src/api_command.rs
+++ b/crates/server/src/api_command.rs
@@ -315,6 +315,13 @@ async fn run(
             env.streams.forward.stop(a.id);
             json!(null)
         }
+        "list_forwards" => {
+            // A read, not a mutator, and must stay off WEB_DENIED_COMMANDS: a
+            // browser reload empties the frontend's module-level store while
+            // this manager keeps forwarding, and this is the only way a web
+            // client has to ask what is still live.
+            json!({ "forwards": env.streams.forward.list() })
+        }
         "start_terminal" => {
             let a: TerminalStart = parse(body)?;
             let id = env
@@ -381,11 +388,11 @@ async fn run(
 
 #[cfg(test)]
 mod tests {
-    use super::helm_args_denied;
+    use super::{helm_args_denied, WEB_DENIED_COMMANDS};
     use crate::{router, AppState};
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
-    use serde_json::json;
+    use serde_json::{json, Value};
     use srelens_capability::Registry;
     use std::sync::Arc;
     use tower::ServiceExt;
@@ -538,6 +545,52 @@ mod tests {
             body["error"],
             json!("helm repo/plugin operations are not available in web mode")
         );
+    }
+
+    #[test]
+    fn list_forwards_is_not_in_the_web_deny_list() {
+        // Denying it would reinstate the leak it closes: a web reload would
+        // empty the frontend store with no way to ask the server what is
+        // still running.
+        assert!(!WEB_DENIED_COMMANDS.contains(&"list_forwards"));
+    }
+
+    #[tokio::test]
+    async fn list_forwards_is_reachable_on_web_and_returns_the_managers_list() {
+        let state = AppState::for_tests(Arc::new(Registry::new())).await;
+        let user = state.db.upsert_user("i", "s", "u@x", "U", 1).await.unwrap();
+        let env = state
+            .user_envs
+            .env_for(&state.db, &state.master_key, user.id)
+            .await
+            .unwrap();
+        env.streams.forward.insert_test_forward(9, 44444);
+        let token = state
+            .db
+            .create_session(user.id, crate::unix_now())
+            .await
+            .unwrap();
+
+        let resp = router(state.clone())
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/command/list_forwards")
+                    .header("content-type", "application/json")
+                    .header("cookie", format!("srelens_session={token}"))
+                    .header("x-srelens-csrf", "1")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["forwards"][0]["id"], json!(9));
+        assert_eq!(body["forwards"][0]["localPort"], json!(44444));
     }
 
     #[tokio::test]

--- a/crates/streams/src/forward.rs
+++ b/crates/streams/src/forward.rs
@@ -288,13 +288,19 @@ pub struct ForwardManager {
     forwards: Mutex<HashMap<u64, Forward>>,
 }
 
-/// What `start` returns: the forward's id and the actual local port it bound
-/// to (the OS picks one when the caller passes no preference).
+/// What `start` returns: the forward's id, the actual local port it bound to
+/// (the OS picks one when the caller passes no preference), and the epoch
+/// millis it was stamped with. That stamp is the SAME value `list` reports
+/// for this forward later — read once here, off `FixedFacts.started_at` — so
+/// a row this session started and a row recovered after a reload agree on
+/// the tunnel's age instead of a caller having to ask `list` a second time
+/// just to date what it already started.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ForwardInfo {
     pub id: u64,
     pub local_port: u16,
+    pub started_at: u64,
 }
 
 /// The parts of a forward that are settled once and never change again.
@@ -434,6 +440,11 @@ impl ForwardManager {
             );
         });
 
+        // Stamped once, here, and read back for both the response and the
+        // stored fact — never a second call to `epoch_millis()` for the same
+        // forward, so `start`'s answer and a later `list` can't disagree.
+        let started_at = epoch_millis();
+
         self.forwards.lock().unwrap().insert(
             id,
             Forward {
@@ -447,13 +458,14 @@ impl ForwardManager {
                     name,
                     remote_port,
                     local_port: bound,
-                    started_at: epoch_millis(),
+                    started_at,
                 },
             },
         );
         Ok(ForwardInfo {
             id,
             local_port: bound,
+            started_at,
         })
     }
 
@@ -1020,6 +1032,60 @@ mod tests {
         assert!(
             manager.list().is_empty(),
             "a stopped tunnel is not still forwarding"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn start_returns_the_same_started_at_that_list_later_reports() {
+        // One value, stamped once: whatever `start` hands back for this
+        // forward must be the exact number `list` reports for it later, not
+        // a second reading that merely happens to be close.
+        let manager = ForwardManager::new(ClientCache::new_many(vec![]));
+        let sink = Arc::new(TestSink::default());
+        let before = epoch_millis();
+        let info = manager
+            .start(
+                sink,
+                "nope".into(),
+                "ns".into(),
+                "Pod".into(),
+                "pod-a".into(),
+                8080,
+                None,
+            )
+            .await
+            .expect("bind succeeds locally");
+
+        assert!(
+            info.started_at >= before,
+            "start's own started_at {} predates the call at {before}",
+            info.started_at
+        );
+        let entry = manager.list().remove(0);
+        assert_eq!(
+            info.started_at, entry.started_at,
+            "the start response and list must agree on the same stamp"
+        );
+        manager.stop(info.id);
+    }
+
+    #[test]
+    fn forward_info_serialises_started_at_alongside_id_and_local_port() {
+        // What the desktop command and the server command hand back to the
+        // frontend; a rename or a dropped field here is a silent contract
+        // break with `packages/core`.
+        let info = ForwardInfo {
+            id: 4,
+            local_port: 51234,
+            started_at: 1_700_000_000_000,
+        };
+        assert_eq!(
+            serde_json::to_value(&info).expect("a forward info is serialisable"),
+            serde_json::json!({
+                "id": 4,
+                "localPort": 51234,
+                "startedAt": 1_700_000_000_000u64,
+            })
         );
     }
 

--- a/crates/streams/src/forward.rs
+++ b/crates/streams/src/forward.rs
@@ -2,8 +2,11 @@
 //! service's backing pod) via kube-rs, and tracks the running forwards.
 
 use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use serde::Serialize;
 use srelens_kube::client_cache::ClientCache;
@@ -14,7 +17,14 @@ use crate::sink::EventSink;
 
 struct Forward {
     handle: JoinHandle<()>,
-    local_port: u16,
+    /// The one counter for this forward, shared with the serving task and its
+    /// reporter. Created with the forward, never per attempt — see
+    /// `reconnect_loop`.
+    traffic: Arc<forward::TrafficCounter>,
+    /// Everything about this forward that can't change after `start`. The
+    /// byte total isn't among them, so `list` reads that from `traffic`
+    /// rather than from a copy that goes stale the moment a packet crosses.
+    fixed: FixedFacts,
 }
 
 /// Reconnect policy: a handful of attempts with a short capped exponential
@@ -34,12 +44,29 @@ const MAX_ATTEMPTS: u32 = 5;
 const BASE_BACKOFF_MS: u64 = 15;
 const MAX_BACKOFF_MS: u64 = 150;
 
+/// How often a forward reports its byte total. A per-packet event would
+/// flood the channel on a busy tunnel — the same reasoning that made the log
+/// stream report status on transitions rather than once per line. A second is
+/// slow enough to be free and fast enough that a number on screen still looks
+/// live.
+const TRAFFIC_INTERVAL: Duration = Duration::from_secs(1);
+
 fn backoff_for(attempt: u32) -> std::time::Duration {
     let multiplier = 1u64.checked_shl(attempt).unwrap_or(u64::MAX);
     let ms = BASE_BACKOFF_MS
         .saturating_mul(multiplier)
         .min(MAX_BACKOFF_MS);
     std::time::Duration::from_millis(ms)
+}
+
+/// Wall-clock milliseconds since the epoch. Milliseconds rather than a
+/// `SystemTime` because this crosses to a JavaScript frontend, which dates
+/// things that way and would otherwise have to reassemble one from parts.
+fn epoch_millis() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|since| since.as_millis() as u64)
+        .unwrap_or(0)
 }
 
 /// Outcome of one failed connect/serve attempt: whether the reconnect loop
@@ -89,6 +116,171 @@ fn status_payload(state: &str, attempt: u32, error: Option<&str>) -> serde_json:
     })
 }
 
+/// The channel a forward reports its byte total on. A named function rather
+/// than an inline `format!` because this string is a contract with the
+/// frontend store, and a typo in it would be silent on both sides.
+fn traffic_channel(id: u64) -> String {
+    format!("forward:traffic:{id}")
+}
+
+fn traffic_payload(bytes: u64) -> serde_json::Value {
+    serde_json::json!({ "bytes": bytes })
+}
+
+/// Emit `forward:traffic:<id>` on `interval`, and only when the total moved.
+/// An idle tunnel therefore says nothing at all rather than repeating the
+/// same number once a second forever. Never returns: it is driven inside the
+/// forward's own task (see `start`), so it stops exactly when the forward
+/// does — including when a `stop(id)` aborts that task mid-tick.
+async fn report_traffic(
+    sink: &dyn EventSink,
+    channel: &str,
+    traffic: &forward::TrafficCounter,
+    interval: Duration,
+) {
+    let mut reported = 0u64;
+    loop {
+        tokio::time::sleep(interval).await;
+        let total = traffic.total();
+        if total != reported {
+            reported = total;
+            sink.emit(channel, traffic_payload(total));
+        }
+    }
+}
+
+/// What one connect-and-serve attempt did: whether it reached a live target
+/// (which is what resets the consecutive-failure count, see
+/// `next_reconnect_state`) and how the serving ended.
+struct AttemptOutcome {
+    established: bool,
+    result: Result<(), String>,
+}
+
+type AttemptFuture = Pin<Box<dyn Future<Output = AttemptOutcome> + Send>>;
+
+/// One attempt, handed the forward's traffic counter to count into.
+/// Production hands over `serve_once`; tests substitute a closure, which is
+/// the only way to drive the reconnect loop without a live cluster.
+type Attempt = Box<dyn FnMut(Arc<forward::TrafficCounter>) -> AttemptFuture + Send>;
+
+/// Everything one attempt needs to resolve and serve the target, behind one
+/// `Arc` so an attempt clones a pointer instead of five strings.
+struct AttemptCtx {
+    cache: Arc<ClientCache>,
+    sink: Arc<dyn EventSink>,
+    listener: tokio::net::TcpListener,
+    status_channel: String,
+    context: String,
+    namespace: String,
+    kind: String,
+    name: String,
+    remote_port: u16,
+}
+
+/// Resolve the target, then serve it until the connection drops. Emits
+/// `active` itself rather than leaving it to the loop, because the moment
+/// worth reporting is when the tunnel becomes usable — not after it ends.
+async fn serve_once(ctx: Arc<AttemptCtx>, traffic: Arc<forward::TrafficCounter>) -> AttemptOutcome {
+    fn failed(error: String) -> AttemptOutcome {
+        AttemptOutcome {
+            established: false,
+            result: Err(error),
+        }
+    }
+
+    // Re-resolve Service targets every attempt so a replacement pod is picked
+    // up; a Pod target's name never changes.
+    let resolved = if ctx.kind.eq_ignore_ascii_case("service") {
+        forward::resolve_service_target(
+            ctx.cache.clone(),
+            &ctx.context,
+            &ctx.namespace,
+            &ctx.name,
+            Some(i32::from(ctx.remote_port)),
+        )
+        .await
+    } else {
+        Ok((ctx.name.clone(), ctx.remote_port))
+    };
+    let (pod, target_port) = match resolved {
+        Ok(target) => target,
+        Err(e) => return failed(e),
+    };
+
+    let api = match forward::connect_pod_api(ctx.cache.clone(), &ctx.context, &ctx.namespace).await
+    {
+        Ok(api) => api,
+        Err(e) => return failed(e),
+    };
+
+    // Building the Api handle does no I/O, so it isn't evidence the target
+    // works. Probe readiness first: only a pod that's actually present +
+    // Running counts as "established". Otherwise a permanently-dead target
+    // would reset the failure counter to 1 every attempt and never reach the
+    // give-up threshold.
+    if !forward::pod_is_ready(&api, &pod).await {
+        return failed(format!("target pod {pod} is not ready"));
+    }
+
+    // `active` always reports attempt:0 — reaching "active" means there's no
+    // consecutive-failure streak to report; see `next_reconnect_state` for
+    // how a later failure of THIS session is counted (always restarts at 1).
+    ctx.sink
+        .emit(&ctx.status_channel, status_payload("active", 0, None));
+    let result = forward::serve_pod_forward(&ctx.listener, api, pod, target_port, traffic).await;
+    AttemptOutcome {
+        established: true,
+        result,
+    }
+}
+
+/// Serve, and on failure back off and serve again, until an attempt ends
+/// cleanly or `MAX_ATTEMPTS` consecutive failures give up. Returns the error
+/// it gave up on, if any.
+///
+/// `traffic` is the FORWARD's counter, taken as a parameter and cloned into
+/// each attempt on purpose. A counter created inside this loop would reset a
+/// tunnel's running total on every reconnect, and nothing would reveal it
+/// until a reconnect happened: a busy tunnel would quietly read as a fresh
+/// one every time its pod restarted.
+async fn reconnect_loop(
+    sink: &dyn EventSink,
+    status_channel: &str,
+    traffic: Arc<forward::TrafficCounter>,
+    mut attempt: Attempt,
+) -> Option<String> {
+    let mut consecutive_failures: u32 = 0;
+    loop {
+        let outcome = attempt(traffic.clone()).await;
+
+        let err = match outcome.result {
+            // An attempt only returns on error; a clean Ok is not expected in
+            // practice, but treat it as a terminal, error-free close rather
+            // than looping forever.
+            Ok(()) => break None,
+            Err(e) => e,
+        };
+
+        let decision = next_reconnect_state(outcome.established, consecutive_failures);
+        consecutive_failures = decision.attempt;
+
+        if decision.give_up {
+            sink.emit(
+                status_channel,
+                status_payload("failed", decision.attempt, Some(&err)),
+            );
+            break Some(err);
+        }
+
+        sink.emit(
+            status_channel,
+            status_payload("reconnecting", decision.attempt, Some(&err)),
+        );
+        tokio::time::sleep(backoff_for(decision.attempt)).await;
+    }
+}
+
 /// Owns running port-forwards (keyed by numeric id).
 pub struct ForwardManager {
     cache: Arc<ClientCache>,
@@ -103,6 +295,58 @@ pub struct ForwardManager {
 pub struct ForwardInfo {
     pub id: u64,
     pub local_port: u16,
+}
+
+/// The parts of a forward that are settled once and never change again.
+#[derive(Debug, Clone)]
+struct FixedFacts {
+    id: u64,
+    context: String,
+    namespace: String,
+    kind: String,
+    name: String,
+    remote_port: u16,
+    local_port: u16,
+    started_at: u64,
+}
+
+impl FixedFacts {
+    fn with_bytes(&self, bytes: u64) -> ForwardEntry {
+        ForwardEntry {
+            id: self.id,
+            context: self.context.clone(),
+            namespace: self.namespace.clone(),
+            kind: self.kind.clone(),
+            name: self.name.clone(),
+            remote_port: self.remote_port,
+            local_port: self.local_port,
+            started_at: self.started_at,
+            bytes,
+        }
+    }
+}
+
+/// One forward the manager is currently running, as `list` reports it —
+/// everything a client needs to draw a row for a tunnel it did not start
+/// itself.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ForwardEntry {
+    pub id: u64,
+    pub context: String,
+    pub namespace: String,
+    /// "Pod" or "Service".
+    pub kind: String,
+    pub name: String,
+    pub remote_port: u16,
+    pub local_port: u16,
+    /// Epoch milliseconds, stamped when the forward was created. A client
+    /// that rehydrates after a reload dates the tunnel from this, so its age
+    /// is the tunnel's real age rather than how long that client has known
+    /// about it — two different facts that would otherwise share a column.
+    pub started_at: u64,
+    /// Bytes moved since the forward started, read live from its counter.
+    pub bytes: u64,
 }
 
 impl ForwardManager {
@@ -123,7 +367,8 @@ impl ForwardManager {
     /// `reconnecting` with backoff between attempts, `failed` after
     /// `MAX_ATTEMPTS`), and emit `forward:closed:<id>` when it gives up (a
     /// user `stop(id)` aborts the task outright and never reaches that
-    /// point).
+    /// point). Alongside it, `forward:traffic:<id>` carries the running byte
+    /// total once a second whenever it has moved.
     pub async fn start(
         &self,
         sink: Arc<dyn EventSink>,
@@ -134,8 +379,6 @@ impl ForwardManager {
         remote_port: u16,
         local_port: Option<u16>,
     ) -> Result<ForwardInfo, String> {
-        let cache = self.cache.clone();
-
         let listener = forward::bind_local(local_port.unwrap_or(0))
             .await
             .map_err(|e| e.to_string())?;
@@ -144,79 +387,45 @@ impl ForwardManager {
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
         let closed_channel = format!("forward:closed:{id}");
         let status_channel = format!("forward:status:{id}");
+        let traffic_channel = traffic_channel(id);
+
+        // One counter for the life of the forward, created here rather than
+        // inside the reconnect loop so a reconnect adds to a tunnel's total
+        // instead of restarting it.
+        let traffic = Arc::new(forward::TrafficCounter::default());
+
+        let ctx = Arc::new(AttemptCtx {
+            cache: self.cache.clone(),
+            sink: sink.clone(),
+            listener,
+            status_channel: status_channel.clone(),
+            context: context.clone(),
+            namespace: namespace.clone(),
+            kind: kind.clone(),
+            name: name.clone(),
+            remote_port,
+        });
+        let attempt: Attempt = Box::new(move |traffic| Box::pin(serve_once(ctx.clone(), traffic)));
+
+        let loop_traffic = traffic.clone();
         let handle = tokio::spawn(async move {
-            let mut consecutive_failures: u32 = 0;
-            let final_error = loop {
-                let mut established_this_session = false;
-
-                // Re-resolve Service targets every attempt so a replacement
-                // pod is picked up; a Pod target's name never changes.
-                let resolved = if kind.eq_ignore_ascii_case("service") {
-                    forward::resolve_service_target(
-                        cache.clone(),
-                        &context,
-                        &namespace,
-                        &name,
-                        Some(i32::from(remote_port)),
-                    )
-                    .await
-                } else {
-                    Ok((name.clone(), remote_port))
-                };
-
-                let attempt_result = match resolved {
-                    Ok((pod, target_port)) => {
-                        match forward::connect_pod_api(cache.clone(), &context, &namespace).await {
-                            Ok(api) => {
-                                // Building the Api handle does no I/O, so it isn't
-                                // evidence the target works. Probe readiness first:
-                                // only a pod that's actually present + Running counts
-                                // as "established". Otherwise a permanently-dead
-                                // target would reset the failure counter to 1 every
-                                // attempt and never reach the give-up threshold.
-                                if forward::pod_is_ready(&api, &pod).await {
-                                    established_this_session = true;
-                                    // `active` always reports attempt:0 — reaching
-                                    // "active" means there's no consecutive-failure
-                                    // streak to report; see `next_reconnect_state`
-                                    // for how a later failure of THIS session is
-                                    // counted (always restarts at 1).
-                                    sink.emit(&status_channel, status_payload("active", 0, None));
-                                    forward::serve_pod_forward(&listener, api, pod, target_port).await
-                                } else {
-                                    Err(format!("target pod {pod} is not ready"))
-                                }
-                            }
-                            Err(e) => Err(e),
-                        }
-                    }
-                    Err(e) => Err(e),
-                };
-
-                let err = match attempt_result {
-                    // The accept loop only returns on error; a clean Ok is
-                    // not expected in practice, but treat it as a terminal,
-                    // error-free close rather than looping forever.
-                    Ok(()) => break None,
-                    Err(e) => e,
-                };
-
-                let decision = next_reconnect_state(established_this_session, consecutive_failures);
-                consecutive_failures = decision.attempt;
-
-                if decision.give_up {
-                    sink.emit(
-                        &status_channel,
-                        status_payload("failed", decision.attempt, Some(&err)),
-                    );
-                    break Some(err);
-                }
-
-                sink.emit(
+            let final_error = tokio::select! {
+                gave_up = reconnect_loop(
+                    sink.as_ref(),
                     &status_channel,
-                    status_payload("reconnecting", decision.attempt, Some(&err)),
-                );
-                tokio::time::sleep(backoff_for(decision.attempt)).await;
+                    loop_traffic.clone(),
+                    attempt,
+                ) => gave_up,
+                // Never completes on its own. It lives in this task so it
+                // shares the forward's lifetime exactly: the forward ending
+                // drops it, and a `stop(id)` aborting this task stops the
+                // reporting with it.
+                () = report_traffic(
+                    sink.as_ref(),
+                    &traffic_channel,
+                    loop_traffic.as_ref(),
+                    TRAFFIC_INTERVAL,
+                ) => None,
             };
 
             sink.emit(
@@ -225,10 +434,23 @@ impl ForwardManager {
             );
         });
 
-        self.forwards
-            .lock()
-            .unwrap()
-            .insert(id, Forward { handle, local_port: bound });
+        self.forwards.lock().unwrap().insert(
+            id,
+            Forward {
+                handle,
+                traffic,
+                fixed: FixedFacts {
+                    id,
+                    context,
+                    namespace,
+                    kind,
+                    name,
+                    remote_port,
+                    local_port: bound,
+                    started_at: epoch_millis(),
+                },
+            },
+        );
         Ok(ForwardInfo {
             id,
             local_port: bound,
@@ -242,10 +464,33 @@ impl ForwardManager {
         }
     }
 
+    /// What the manager is currently forwarding, oldest id first. This is
+    /// what closes the web leak: the frontend store is module-level and dies
+    /// with a browser reload, while this manager does not, so without it a
+    /// user reloads into an empty table with live tunnels behind it and no
+    /// way to stop them. Ordered because a HashMap hands out its values in
+    /// whatever order it likes, and a table that reshuffles on every poll is
+    /// unreadable.
+    pub fn list(&self) -> Vec<ForwardEntry> {
+        let mut entries: Vec<ForwardEntry> = self
+            .forwards
+            .lock()
+            .unwrap()
+            .values()
+            .map(|f| f.fixed.with_bytes(f.traffic.total()))
+            .collect();
+        entries.sort_by_key(|e| e.id);
+        entries
+    }
+
     /// The bound loopback port for a live forward id (used by the web
     /// reverse proxy), or None if the id is unknown or already stopped.
     pub fn local_port(&self, id: u64) -> Option<u16> {
-        self.forwards.lock().unwrap().get(&id).map(|f| f.local_port)
+        self.forwards
+            .lock()
+            .unwrap()
+            .get(&id)
+            .map(|f| f.fixed.local_port)
     }
 
     /// How many port-forwards are currently running. Used to keep a user's
@@ -258,13 +503,30 @@ impl ForwardManager {
     /// Register a forward id → local port directly (no live cluster).
     /// Intended for tests of downstream consumers such as the web reverse
     /// proxy, which need a fake forward without standing up a real cluster.
-    pub fn insert_test_forward(&self, id: u64, local_port: u16) {
+    /// Returns the forward's traffic counter so a caller can move fake bytes
+    /// through it.
+    pub fn insert_test_forward(&self, id: u64, local_port: u16) -> Arc<forward::TrafficCounter> {
         // A never-completing handle stands in for the real serve loop.
         let handle = tokio::spawn(async { std::future::pending::<()>().await });
-        self.forwards
-            .lock()
-            .unwrap()
-            .insert(id, Forward { handle, local_port });
+        let traffic = Arc::new(forward::TrafficCounter::default());
+        self.forwards.lock().unwrap().insert(
+            id,
+            Forward {
+                handle,
+                traffic: traffic.clone(),
+                fixed: FixedFacts {
+                    id,
+                    context: "test".into(),
+                    namespace: "test".into(),
+                    kind: "Pod".into(),
+                    name: "test".into(),
+                    remote_port: 0,
+                    local_port,
+                    started_at: epoch_millis(),
+                },
+            },
+        );
+        traffic
     }
 
     /// Abort every running port-forward (used when a user's environment is
@@ -351,6 +613,15 @@ mod tests {
     // helpers), which is out of scope here. A separate follow-up issue
     // tracks building that cluster harness. See the task report for this
     // gap.
+    //
+    // The traffic reporting has the same seam. `reconnect_loop` and
+    // `report_traffic` are driven directly below, which is what proves the
+    // counter survives a reconnect and that reports land on the tick, but
+    // the wiring `start` does between them cannot be observed end-to-end
+    // without a cluster: against an empty cache the forward gives up after
+    // ~400ms, so the production one-second tick never arrives. What is
+    // pinned instead is the channel name (`traffic_channel`), which is the
+    // part of that wiring the frontend depends on.
 
     #[tokio::test(flavor = "multi_thread")]
     async fn forward_retries_then_marks_failed() {
@@ -478,7 +749,15 @@ mod tests {
         let manager = ForwardManager::new(ClientCache::new_many(vec![]));
         let sink = Arc::new(TestSink::default());
         let info = manager
-            .start(sink, "nope".into(), "ns".into(), "Pod".into(), "pod-a".into(), 8080, None)
+            .start(
+                sink,
+                "nope".into(),
+                "ns".into(),
+                "Pod".into(),
+                "pod-a".into(),
+                8080,
+                None,
+            )
             .await
             .expect("bind succeeds locally");
         assert_eq!(manager.local_port(info.id), Some(info.local_port));
@@ -495,5 +774,313 @@ mod tests {
         assert_eq!(manager.active_count(), 1);
         manager.stop(1);
         assert_eq!(manager.active_count(), 0);
+    }
+
+    /// The reporter's tempo in tests. Production reports once a second, and a
+    /// test that waited on that would be a second slower for every tick it
+    /// needed to observe.
+    const TEST_TICK: std::time::Duration = std::time::Duration::from_millis(25);
+
+    fn spawn_reporter(
+        sink: Arc<TestSink>,
+        channel: &str,
+        traffic: Arc<forward::TrafficCounter>,
+    ) -> JoinHandle<()> {
+        let channel = channel.to_string();
+        tokio::spawn(async move {
+            report_traffic(sink.as_ref(), &channel, &traffic, TEST_TICK).await;
+        })
+    }
+
+    fn reported_bytes(sink: &TestSink, channel: &str) -> Vec<u64> {
+        sink.payloads_for(channel)
+            .iter()
+            .map(|p| {
+                p.get("bytes")
+                    .and_then(|b| b.as_u64())
+                    .expect("every traffic payload carries a numeric `bytes`")
+            })
+            .collect()
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_reconnecting_forward_reports_the_sum_of_everything_it_moved() {
+        // The trap this test exists for: a counter created per ATTEMPT would
+        // reset a busy tunnel's total every time it reconnected, and nothing
+        // would show it until a reconnect happened. Three attempts move 100,
+        // 150 and 50 bytes; the tunnel has moved 300, not 50.
+        let sink = Arc::new(TestSink::default());
+        let traffic = Arc::new(forward::TrafficCounter::default());
+        let calls = Arc::new(AtomicU64::new(0));
+        let seen = calls.clone();
+        let attempt: Attempt = Box::new(move |traffic: Arc<forward::TrafficCounter>| {
+            let call = seen.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async move {
+                traffic.add([100u64, 150, 50][call.min(2) as usize]);
+                AttemptOutcome {
+                    established: true,
+                    // The first two attempts drop the connection, which is
+                    // what forces the reconnects this test is about.
+                    result: if call < 2 {
+                        Err(format!("attempt {call} dropped"))
+                    } else {
+                        Ok(())
+                    },
+                }
+            })
+        });
+
+        let reporter = spawn_reporter(sink.clone(), "forward:traffic:7", traffic.clone());
+        let final_error =
+            reconnect_loop(sink.as_ref(), "forward:status:7", traffic.clone(), attempt).await;
+        assert_eq!(final_error, None, "the third attempt ends cleanly");
+        // Let a tick land after the last attempt so the final total is out.
+        tokio::time::sleep(TEST_TICK * 3).await;
+        reporter.abort();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 3, "three attempts ran");
+        let reconnecting = sink.payloads_for("forward:status:7");
+        assert_eq!(
+            reconnecting.len(),
+            2,
+            "two dropped attempts means two reconnects actually happened"
+        );
+        assert_eq!(
+            traffic.total(),
+            300,
+            "one counter across all three attempts"
+        );
+        assert_eq!(
+            reported_bytes(&sink, "forward:traffic:7").last().copied(),
+            Some(300),
+            "the last report is the tunnel's running total, not the last attempt's share"
+        );
+    }
+
+    #[test]
+    fn traffic_is_reported_on_the_forwards_own_channel() {
+        // The name the frontend store subscribes to, spelled out here rather
+        // than rebuilt from the same format string it is being checked
+        // against.
+        assert_eq!(traffic_channel(7), "forward:traffic:7");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn an_idle_forward_reports_no_traffic_at_all() {
+        let sink = Arc::new(TestSink::default());
+        let traffic = Arc::new(forward::TrafficCounter::default());
+        let reporter = spawn_reporter(sink.clone(), "forward:traffic:1", traffic);
+        tokio::time::sleep(TEST_TICK * 4).await;
+        reporter.abort();
+        assert!(
+            sink.payloads_for("forward:traffic:1").is_empty(),
+            "a tunnel nothing has crossed stays silent"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn traffic_is_reported_again_only_when_the_total_changed() {
+        let sink = Arc::new(TestSink::default());
+        let traffic = Arc::new(forward::TrafficCounter::default());
+        let reporter = spawn_reporter(sink.clone(), "forward:traffic:2", traffic.clone());
+
+        traffic.add(10);
+        tokio::time::sleep(TEST_TICK * 2).await;
+        assert_eq!(reported_bytes(&sink, "forward:traffic:2"), vec![10]);
+
+        // Several ticks with nothing crossing: the channel must stay quiet.
+        tokio::time::sleep(TEST_TICK * 4).await;
+        assert_eq!(
+            reported_bytes(&sink, "forward:traffic:2"),
+            vec![10],
+            "an unchanged total is not news"
+        );
+
+        traffic.add(5);
+        tokio::time::sleep(TEST_TICK * 2).await;
+        reporter.abort();
+        assert_eq!(
+            reported_bytes(&sink, "forward:traffic:2"),
+            vec![10, 15],
+            "the report carries the running total, not the delta"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_busy_tunnel_reports_on_the_tick_not_on_every_packet() {
+        // A per-packet event would flood the channel; the timer is the whole
+        // point. 40 writes spread over roughly two ticks must coalesce into
+        // roughly two reports.
+        let sink = Arc::new(TestSink::default());
+        let traffic = Arc::new(forward::TrafficCounter::default());
+        let reporter = spawn_reporter(sink.clone(), "forward:traffic:3", traffic.clone());
+
+        let writer = traffic.clone();
+        for _ in 0..40 {
+            writer.add(1);
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        }
+        tokio::time::sleep(TEST_TICK * 2).await;
+        reporter.abort();
+
+        let reports = reported_bytes(&sink, "forward:traffic:3");
+        assert!(
+            reports.len() <= 5,
+            "40 writes should coalesce onto the tick, got {} reports: {reports:?}",
+            reports.len()
+        );
+        assert_eq!(
+            reports.last().copied(),
+            Some(40),
+            "the last report is the full total"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn list_returns_the_live_forward_with_its_target_and_ports() {
+        let manager = ForwardManager::new(ClientCache::new_many(vec![]));
+        let sink = Arc::new(TestSink::default());
+        let info = manager
+            .start(
+                sink,
+                "ctx-a".into(),
+                "ns-a".into(),
+                "Service".into(),
+                "web".into(),
+                8080,
+                None,
+            )
+            .await
+            .expect("bind succeeds locally");
+
+        let listed = manager.list();
+        assert_eq!(listed.len(), 1);
+        let entry = &listed[0];
+        assert_eq!(entry.id, info.id);
+        assert_eq!(entry.context, "ctx-a");
+        assert_eq!(entry.namespace, "ns-a");
+        assert_eq!(entry.kind, "Service");
+        assert_eq!(entry.name, "web");
+        assert_eq!(entry.remote_port, 8080);
+        assert_eq!(entry.local_port, info.local_port);
+        assert_eq!(entry.bytes, 0, "nothing has crossed it yet");
+        manager.stop(info.id);
+    }
+
+    #[test]
+    fn a_forward_entry_serialises_the_names_the_frontend_reads() {
+        // A rehydrating store reads these keys by name, so the casing is a
+        // contract rather than a detail of how the struct happens to be
+        // written.
+        let entry = FixedFacts {
+            id: 4,
+            context: "ctx".into(),
+            namespace: "ns".into(),
+            kind: "Pod".into(),
+            name: "api".into(),
+            remote_port: 8080,
+            local_port: 51234,
+            started_at: 1_700_000_000_000,
+        }
+        .with_bytes(2048);
+        assert_eq!(
+            serde_json::to_value(&entry).expect("a forward entry is serialisable"),
+            serde_json::json!({
+                "id": 4,
+                "context": "ctx",
+                "namespace": "ns",
+                "kind": "Pod",
+                "name": "api",
+                "remotePort": 8080,
+                "localPort": 51234,
+                "startedAt": 1_700_000_000_000u64,
+                "bytes": 2048,
+            })
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn list_drops_a_forward_the_user_stopped() {
+        let manager = ForwardManager::new(ClientCache::new_many(vec![]));
+        let sink = Arc::new(TestSink::default());
+        let info = manager
+            .start(
+                sink,
+                "nope".into(),
+                "ns".into(),
+                "Pod".into(),
+                "pod-a".into(),
+                8080,
+                None,
+            )
+            .await
+            .expect("bind succeeds locally");
+        assert_eq!(manager.list().len(), 1);
+        manager.stop(info.id);
+        assert!(
+            manager.list().is_empty(),
+            "a stopped tunnel is not still forwarding"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn list_stamps_the_start_time_when_the_forward_was_created() {
+        // A rehydrating client dates the forward from this, so it has to be
+        // when the tunnel started rather than when someone asked about it.
+        let manager = ForwardManager::new(ClientCache::new_many(vec![]));
+        let sink = Arc::new(TestSink::default());
+        let before = epoch_millis();
+        let info = manager
+            .start(
+                sink,
+                "nope".into(),
+                "ns".into(),
+                "Pod".into(),
+                "pod-a".into(),
+                8080,
+                None,
+            )
+            .await
+            .expect("bind succeeds locally");
+
+        tokio::time::sleep(std::time::Duration::from_millis(60)).await;
+        let asked_at = epoch_millis();
+        let entry = manager.list().remove(0);
+        assert!(
+            entry.started_at >= before,
+            "started_at {} predates the start call at {before}",
+            entry.started_at
+        );
+        assert!(
+            entry.started_at + 40 < asked_at,
+            "started_at {} looks like the time of the list call ({asked_at}), not of the start",
+            entry.started_at
+        );
+        manager.stop(info.id);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn list_reports_the_live_byte_total() {
+        let manager = ForwardManager::new(ClientCache::new_many(vec![]));
+        let traffic = manager.insert_test_forward(1, 12345);
+        assert_eq!(manager.list()[0].bytes, 0);
+        traffic.add(4096);
+        assert_eq!(
+            manager.list()[0].bytes,
+            4096,
+            "bytes are read from the forward's counter, not from a copy taken at start"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn list_is_ordered_by_id() {
+        // A table that reshuffles every time it is polled is unreadable, and
+        // a HashMap hands out its values in whatever order it likes.
+        let manager = ForwardManager::new(ClientCache::new_many(vec![]));
+        for id in [3u64, 1, 2] {
+            manager.insert_test_forward(id, 10000 + id as u16);
+        }
+        let ids: Vec<u64> = manager.list().iter().map(|e| e.id).collect();
+        assert_eq!(ids, vec![1, 2, 3]);
     }
 }

--- a/crates/streams/src/forward.rs
+++ b/crates/streams/src/forward.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use serde::Serialize;
@@ -25,6 +25,56 @@ struct Forward {
     /// byte total isn't among them, so `list` reads that from `traffic`
     /// rather than from a copy that goes stale the moment a packet crosses.
     fixed: FixedFacts,
+    /// This forward's terminal state, written once by its own task. See
+    /// [`Ended`].
+    ended: Ended,
+}
+
+/// Whether a forward's task has finished, and why.
+///
+/// Unset while the tunnel is running; set exactly once, by the task itself,
+/// at the moment it gives up — `None` for a loop that ended without an error,
+/// `Some(reason)` for one that exhausted its retries.
+///
+/// **This is what a reloading client has instead of the event it missed.** A
+/// forward that gives up emits `forward:closed:<id>` and then stays in the
+/// manager's map until someone calls `stop`, because only the client knows
+/// whether its reader has seen the bad news yet. A page that reloads after
+/// that event has no way to learn it happened: the event is gone and the
+/// frontend store that recorded it died with the page. Without this, `list`
+/// described a dead tunnel exactly like a live one and the reloaded page drew
+/// it green.
+///
+/// A `OnceLock` rather than a `Mutex<Option<..>>` because it is written once
+/// and read on every listing, and "set" is itself the fact being reported —
+/// `get()` returning `None` means still running, and there is no second flag
+/// that could disagree with it.
+type Ended = Arc<OnceLock<Option<String>>>;
+
+impl Forward {
+    /// True once this forward's own task has stopped for good.
+    fn has_ended(&self) -> bool {
+        self.ended.get().is_some()
+    }
+
+    /// This forward as `list` reports it, byte total and terminal state read
+    /// live rather than from copies taken at start.
+    fn entry(&self) -> ForwardEntry {
+        let ended = self.ended.get();
+        ForwardEntry {
+            id: self.fixed.id,
+            context: self.fixed.context.clone(),
+            namespace: self.fixed.namespace.clone(),
+            kind: self.fixed.kind.clone(),
+            name: self.fixed.name.clone(),
+            remote_port: self.fixed.remote_port,
+            local_port: self.fixed.local_port,
+            started_at: self.fixed.started_at,
+            bytes: self.traffic.total(),
+            ended: ended.is_some(),
+            error: ended.and_then(|reason| reason.clone()),
+        }
+    }
 }
 
 /// Reconnect policy: a handful of attempts with a short capped exponential
@@ -316,25 +366,9 @@ struct FixedFacts {
     started_at: u64,
 }
 
-impl FixedFacts {
-    fn with_bytes(&self, bytes: u64) -> ForwardEntry {
-        ForwardEntry {
-            id: self.id,
-            context: self.context.clone(),
-            namespace: self.namespace.clone(),
-            kind: self.kind.clone(),
-            name: self.name.clone(),
-            remote_port: self.remote_port,
-            local_port: self.local_port,
-            started_at: self.started_at,
-            bytes,
-        }
-    }
-}
-
-/// One forward the manager is currently running, as `list` reports it —
-/// everything a client needs to draw a row for a tunnel it did not start
-/// itself.
+/// One forward the manager is holding, as `list` reports it — everything a
+/// client needs to draw a row for a tunnel it did not start itself, including
+/// one that has already died (`ended`).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ForwardEntry {
@@ -353,6 +387,13 @@ pub struct ForwardEntry {
     pub started_at: u64,
     /// Bytes moved since the forward started, read live from its counter.
     pub bytes: u64,
+    /// True once this forward's task has given up — see [`Ended`]. The
+    /// manager still holds it, and still reports it, precisely so a client
+    /// that was not listening when it died can draw the row that says so.
+    pub ended: bool,
+    /// Why it gave up, when the loop had a reason to give. `None` both for a
+    /// forward that is still running and for one that ended without an error.
+    pub error: Option<String>,
 }
 
 impl ForwardManager {
@@ -414,6 +455,8 @@ impl ForwardManager {
         let attempt: Attempt = Box::new(move |traffic| Box::pin(serve_once(ctx.clone(), traffic)));
 
         let loop_traffic = traffic.clone();
+        let ended: Ended = Arc::new(OnceLock::new());
+        let task_ended = ended.clone();
         let handle = tokio::spawn(async move {
             let final_error = tokio::select! {
                 gave_up = reconnect_loop(
@@ -434,6 +477,10 @@ impl ForwardManager {
                 ) => None,
             };
 
+            // Recorded BEFORE the event goes out, so a client that reacts
+            // to `forward:closed` by listing cannot be told the forward is
+            // still live by the very call it made because it heard it wasn't.
+            let _ = task_ended.set(final_error.clone());
             sink.emit(
                 &closed_channel,
                 serde_json::to_value(final_error).unwrap_or(serde_json::Value::Null),
@@ -460,6 +507,7 @@ impl ForwardManager {
                     local_port: bound,
                     started_at,
                 },
+                ended,
             },
         );
         Ok(ForwardInfo {
@@ -476,40 +524,56 @@ impl ForwardManager {
         }
     }
 
-    /// What the manager is currently forwarding, oldest id first. This is
-    /// what closes the web leak: the frontend store is module-level and dies
-    /// with a browser reload, while this manager does not, so without it a
-    /// user reloads into an empty table with live tunnels behind it and no
-    /// way to stop them. Ordered because a HashMap hands out its values in
-    /// whatever order it likes, and a table that reshuffles on every poll is
-    /// unreadable.
+    /// What the manager is holding, oldest id first. This is what closes the
+    /// web leak: the frontend store is module-level and dies with a browser
+    /// reload, while this manager does not, so without it a user reloads into
+    /// an empty table with live tunnels behind it and no way to stop them.
+    /// Ordered because a HashMap hands out its values in whatever order it
+    /// likes, and a table that reshuffles on every poll is unreadable.
+    ///
+    /// **Holding, not running.** A forward that gave up is still listed, with
+    /// `ended` set and its reason attached, because the reload this exists
+    /// for is exactly the case that missed the `forward:closed` event — see
+    /// [`Ended`]. `local_port` and `active_count` answer the other
+    /// question, "is this tunnel carrying traffic", and both say no.
     pub fn list(&self) -> Vec<ForwardEntry> {
         let mut entries: Vec<ForwardEntry> = self
             .forwards
             .lock()
             .unwrap()
             .values()
-            .map(|f| f.fixed.with_bytes(f.traffic.total()))
+            .map(Forward::entry)
             .collect();
         entries.sort_by_key(|e| e.id);
         entries
     }
 
-    /// The bound loopback port for a live forward id (used by the web
-    /// reverse proxy), or None if the id is unknown or already stopped.
+    /// The bound loopback port for a LIVE forward id (used by the web
+    /// reverse proxy), or None if the id is unknown, already stopped, or has
+    /// given up. The last of those matters: the listener is dropped with the
+    /// task that owned it, so the port a dead forward was bound to is free
+    /// for anything on the machine to take — proxying to it is at best a
+    /// connection to nothing.
     pub fn local_port(&self, id: u64) -> Option<u16> {
         self.forwards
             .lock()
             .unwrap()
             .get(&id)
+            .filter(|f| !f.has_ended())
             .map(|f| f.fixed.local_port)
     }
 
     /// How many port-forwards are currently running. Used to keep a user's
     /// environment alive across a WebSocket disconnect while they still have
-    /// forwards in use (proxied over plain HTTP, not the WS).
+    /// forwards in use (proxied over plain HTTP, not the WS). One that gave
+    /// up is not in use, however long its row stays on someone's screen.
     pub fn active_count(&self) -> usize {
-        self.forwards.lock().unwrap().len()
+        self.forwards
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|f| !f.has_ended())
+            .count()
     }
 
     /// Register a forward id → local port directly (no live cluster).
@@ -536,6 +600,9 @@ impl ForwardManager {
                     local_port,
                     started_at: epoch_millis(),
                 },
+                // Never set: the stand-in handle above never completes, which
+                // is what a live forward looks like.
+                ended: Arc::new(OnceLock::new()),
             },
         );
         traffic
@@ -984,7 +1051,7 @@ mod tests {
         // A rehydrating store reads these keys by name, so the casing is a
         // contract rather than a detail of how the struct happens to be
         // written.
-        let entry = FixedFacts {
+        let entry = ForwardEntry {
             id: 4,
             context: "ctx".into(),
             namespace: "ns".into(),
@@ -993,8 +1060,10 @@ mod tests {
             remote_port: 8080,
             local_port: 51234,
             started_at: 1_700_000_000_000,
-        }
-        .with_bytes(2048);
+            bytes: 2048,
+            ended: false,
+            error: None,
+        };
         assert_eq!(
             serde_json::to_value(&entry).expect("a forward entry is serialisable"),
             serde_json::json!({
@@ -1007,8 +1076,21 @@ mod tests {
                 "localPort": 51234,
                 "startedAt": 1_700_000_000_000u64,
                 "bytes": 2048,
+                "ended": false,
+                "error": null,
             })
         );
+
+        // The dead form, whose two extra keys are the whole of what a
+        // reloading client has to go on.
+        let gone = ForwardEntry {
+            ended: true,
+            error: Some("pod web-1 not found".into()),
+            ..entry
+        };
+        let json = serde_json::to_value(&gone).expect("a forward entry is serialisable");
+        assert_eq!(json["ended"], serde_json::json!(true));
+        assert_eq!(json["error"], serde_json::json!("pod web-1 not found"));
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1148,5 +1230,129 @@ mod tests {
         }
         let ids: Vec<u64> = manager.list().iter().map(|e| e.id).collect();
         assert_eq!(ids, vec![1, 2, 3]);
+    }
+    /// Wait until a forward's `forward:closed:<id>` has fired — the moment
+    /// its task has given up for good. The task records the terminal state
+    /// BEFORE it emits, so once this returns the manager's own answers about
+    /// the forward are settled and nothing below is racing the loop.
+    async fn wait_for_close(sink: &TestSink, id: u64) {
+        let channel = format!("forward:closed:{id}");
+        for _ in 0..200 {
+            if !sink.payloads_for(&channel).is_empty() {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        panic!("forward:closed:{id} never arrived");
+    }
+
+    async fn start_doomed(manager: &ForwardManager, sink: Arc<TestSink>) -> ForwardInfo {
+        // Empty cache: every connect attempt fails, so the loop walks its
+        // retries and gives up in a few hundred milliseconds.
+        manager
+            .start(
+                sink,
+                "nope".into(),
+                "ns".into(),
+                "Pod".into(),
+                "pod-a".into(),
+                8080,
+                None,
+            )
+            .await
+            .expect("bind succeeds locally")
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn list_reports_a_forward_that_gave_up_as_ended_with_its_reason() {
+        // The half of the vanishing-tunnel defect that no amount of frontend
+        // bookkeeping can reach. A forward that exhausts its retries emits
+        // `forward:closed:<id>` and then STAYS in this map until someone
+        // calls `stop`. `list` used to describe it exactly like a live one,
+        // so a page that reloaded after that event had already fired adopted
+        // a dead tunnel as `active` — a green row for a tunnel that cannot
+        // carry a byte, and in web mode a `/pf/<id>/` URL that will never
+        // answer. The frontend's dropped-id set cannot help: it is
+        // module-level JavaScript that the reload wiped.
+        let manager = ForwardManager::new(ClientCache::new_many(vec![]));
+        let sink = Arc::new(TestSink::default());
+        let info = start_doomed(&manager, sink.clone()).await;
+
+        // Said before AND after, because "ended" asserted only at the end
+        // passes just as well for a `list` that hardcodes it.
+        let trying = manager.list();
+        assert_eq!(trying.len(), 1);
+        assert!(!trying[0].ended, "a forward still retrying has not ended");
+        assert_eq!(trying[0].error, None);
+
+        wait_for_close(&sink, info.id).await;
+
+        let listed = manager.list();
+        assert_eq!(
+            listed.len(),
+            1,
+            "the entry stays, so a client that reloaded still learns the tunnel died"
+        );
+        assert!(listed[0].ended, "a forward that gave up is listed as ended");
+        assert!(
+            listed[0].error.is_some(),
+            "and with the reason the loop gave up, so the row can say why"
+        );
+
+        manager.stop(info.id);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_forward_that_gave_up_is_neither_routable_nor_counted() {
+        // `list` keeps reporting a dead forward on purpose; the other two
+        // readers of the map must not. The web reverse proxy resolves
+        // `/pf/<id>/` through `local_port`, and the loopback port a dead
+        // forward was bound to is released the moment its task ends — so
+        // routing to it reaches nothing at best, and whatever took the port
+        // next at worst. `active_count` keeps a user's environment alive for
+        // forwards "in use", which a dead one is not.
+        let manager = ForwardManager::new(ClientCache::new_many(vec![]));
+        let sink = Arc::new(TestSink::default());
+        let info = start_doomed(&manager, sink.clone()).await;
+
+        assert_eq!(manager.local_port(info.id), Some(info.local_port));
+        assert_eq!(manager.active_count(), 1);
+
+        wait_for_close(&sink, info.id).await;
+
+        assert_eq!(
+            manager.local_port(info.id),
+            None,
+            "the proxy must not route to a port nothing is listening on"
+        );
+        assert_eq!(
+            manager.active_count(),
+            0,
+            "a tunnel that gave up is not a tunnel in use"
+        );
+        // And it is still listed — the two answers are deliberately different.
+        assert_eq!(manager.list().len(), 1);
+
+        manager.stop(info.id);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stopping_a_forward_that_gave_up_forgets_it_for_good() {
+        // How a reader gets a dead row off their screen permanently. The
+        // frontend dismisses it by calling `stop_port_forward`, because a
+        // dropped-id set in the page cannot survive the reload that would
+        // otherwise raise the row again from this listing.
+        let manager = ForwardManager::new(ClientCache::new_many(vec![]));
+        let sink = Arc::new(TestSink::default());
+        let info = start_doomed(&manager, sink.clone()).await;
+        wait_for_close(&sink, info.id).await;
+        assert_eq!(manager.list().len(), 1);
+
+        manager.stop(info.id);
+
+        assert!(
+            manager.list().is_empty(),
+            "a dismissed tunnel does not come back on the next listing"
+        );
     }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -56,6 +56,7 @@ export * from "./lib/namespaces";
 export * from "./lib/network";
 export * from "./lib/notify";
 export * from "./lib/onboarding";
+export * from "./lib/openExternal";
 export * from "./lib/openTabs";
 export * from "./lib/overviewSnapshot";
 export * from "./lib/paletteActions";

--- a/packages/core/src/lib/forward.test.ts
+++ b/packages/core/src/lib/forward.test.ts
@@ -89,7 +89,8 @@ beforeEach(() => {
         startedAt: BACKEND_EPOCH + id,
         bytes: 0,
       });
-      return { id, localPort: backend[backend.length - 1].localPort };
+      const started = backend[backend.length - 1];
+      return { id, localPort: started.localPort, startedAt: started.startedAt };
     }
     if (command === "list_forwards") {
       if (listFails) throw new Error(String(listFails));
@@ -375,16 +376,18 @@ describe("rehydrateForwards", () => {
     expect(getForwards()).toHaveLength(0);
   });
 
-  it("adopts a tunnel whose start could not be dated", async () => {
+  it("starts a forward with no follow-up list_forwards call, even when listing would fail", async () => {
+    // The start response carries its own startedAt now, so a broken
+    // list_forwards must not be able to break a start that is otherwise
+    // fine — the whole point of dropping the follow-up read.
     listFails = "handler error: list forwards timed out";
-    await expect(startPortForward(req)).rejects.toThrow();
-    expect(getForwards()).toHaveLength(0);
 
-    listFails = null;
-    await rehydrateForwards();
+    const fwd = await startPortForward(req);
 
+    expect(fwd.startedAt).toBe(BACKEND_EPOCH + 1);
     expect(getForwards()).toHaveLength(1);
-    expect(getForwards()[0]).toMatchObject({ id: 1, name: "web-1", startedAt: BACKEND_EPOCH + 1 });
+    expect(invokeCommandMock).toHaveBeenCalledTimes(1);
+    expect(invokeCommandMock).toHaveBeenCalledWith("start_port_forward", expect.anything());
   });
 });
 

--- a/packages/core/src/lib/forward.test.ts
+++ b/packages/core/src/lib/forward.test.ts
@@ -12,37 +12,98 @@ vi.mock("../transport/transport", () => ({
 import {
   startPortForward,
   stopPortForward,
+  rehydrateForwards,
   getForwards,
   subscribeForwards,
   forwardUrl,
   forwardAddress,
-  type ActiveForward,
+  __resetForwardStoreForTests,
 } from "./forward";
+import { describeError } from "./errors";
 
-// Capture the `forward:closed:<id>` / `forward:status:<id>` handlers so tests
-// can fire the events.
-const closedHandlers = new Map<string, () => void>();
-const statusHandlers = new Map<string, (payload: unknown) => void>();
+vi.mock("./notify", () => ({ notify: { error: vi.fn(), success: vi.fn(), info: vi.fn() } }));
+import { notify } from "./notify";
 
-beforeEach(async () => {
+/** What `list_forwards` hands back, as the Rust `ForwardEntry` serialises it. */
+interface BackendEntry {
+  id: number;
+  context: string;
+  namespace: string;
+  kind: string;
+  name: string;
+  remotePort: number;
+  localPort: number;
+  startedAt: number;
+  bytes: number;
+}
+
+// Deliberately in the past: a `startedAt` sourced from the local clock would
+// land in the present day and fail every assertion that names this constant.
+const BACKEND_EPOCH = 1_700_000_000_000;
+
+// Every `forward:*` handler the store registers, so tests can fire the events.
+const handlers = new Map<string, (payload?: unknown) => void>();
+
+// A minimal stand-in for `ForwardManager`: `start_port_forward` registers an
+// entry, `list_forwards` reports what it holds, `stop_port_forward` drops one.
+// Tests reach into `backend` directly to set up the cases that matter — a
+// tunnel this client never started, or one the manager still holds after the
+// store gave up on it.
+let backend: BackendEntry[] = [];
+let nextId = 1;
+let listFails: unknown = null;
+
+function fire(channel: string, payload?: unknown) {
+  const handler = handlers.get(channel);
+  if (!handler) throw new Error(`nothing is listening on ${channel}`);
+  handler(payload);
+}
+
+const traffic = (id: number, bytes: number) => fire(`forward:traffic:${id}`, { bytes });
+const closed = (id: number) => fire(`forward:closed:${id}`);
+const statusEvent = (id: number, state: string) => fire(`forward:status:${id}`, { state });
+
+beforeEach(() => {
   invokeCommandMock.mockReset();
   onMock.mockReset();
-  closedHandlers.clear();
-  statusHandlers.clear();
+  handlers.clear();
   onMock.mockImplementation((channel: string, handler: (payload?: unknown) => void) => {
-    if (channel.startsWith("forward:status:")) {
-      statusHandlers.set(channel, handler);
-      return () => statusHandlers.delete(channel);
-    }
-    closedHandlers.set(channel, handler);
-    return () => closedHandlers.delete(channel);
+    handlers.set(channel, handler);
+    return () => handlers.delete(channel);
   });
-  // Drain any forwards left over from a previous test.
-  for (const f of [...getForwards()]) {
-    invokeCommandMock.mockResolvedValueOnce(undefined);
-    await stopPortForward(f.id);
-  }
-  invokeCommandMock.mockReset();
+
+  backend = [];
+  nextId = 1;
+  listFails = null;
+  invokeCommandMock.mockImplementation(async (command: string, args?: Record<string, unknown>) => {
+    if (command === "start_port_forward") {
+      const id = nextId++;
+      backend.push({
+        id,
+        context: String(args?.context),
+        namespace: String(args?.namespace),
+        kind: String(args?.kind),
+        name: String(args?.name),
+        remotePort: Number(args?.remotePort),
+        localPort: (args?.localPort as number | null) ?? 50000 + id,
+        startedAt: BACKEND_EPOCH + id,
+        bytes: 0,
+      });
+      return { id, localPort: backend[backend.length - 1].localPort };
+    }
+    if (command === "list_forwards") {
+      if (listFails) throw new Error(String(listFails));
+      return { forwards: backend.map((e) => ({ ...e })) };
+    }
+    if (command === "stop_port_forward") {
+      backend = backend.filter((e) => e.id !== args?.id);
+      return undefined;
+    }
+    throw new Error(`unexpected command ${command}`);
+  });
+
+  vi.mocked(notify.error).mockClear();
+  __resetForwardStoreForTests();
 });
 
 const req = {
@@ -53,17 +114,32 @@ const req = {
   remotePort: 80,
 };
 
+const otherReq = { ...req, name: "api-2", remotePort: 8080 };
+
+function entry(over: Partial<BackendEntry> & { id: number }): BackendEntry {
+  return {
+    context: "kind-dev",
+    namespace: "default",
+    kind: "Service",
+    name: "redis",
+    remotePort: 6379,
+    localPort: 61000 + over.id,
+    startedAt: BACKEND_EPOCH + over.id,
+    bytes: 0,
+    ...over,
+  };
+}
+
 describe("forward store", () => {
   it("adds a forward and notifies subscribers", async () => {
-    const notify = vi.fn();
-    const unsub = subscribeForwards(notify);
-    invokeCommandMock.mockResolvedValueOnce({ id: 1, localPort: 54321 });
+    const changed = vi.fn();
+    const unsub = subscribeForwards(changed);
 
     const fwd = await startPortForward(req);
 
-    expect(fwd).toMatchObject({ id: 1, localPort: 54321, name: "web-1", remotePort: 80 });
+    expect(fwd).toMatchObject({ id: 1, localPort: 50001, name: "web-1", remotePort: 80 });
     expect(getForwards()).toHaveLength(1);
-    expect(notify).toHaveBeenCalled();
+    expect(changed).toHaveBeenCalled();
     expect(invokeCommandMock).toHaveBeenCalledWith("start_port_forward", {
       context: "kind-dev",
       namespace: "default",
@@ -76,56 +152,239 @@ describe("forward store", () => {
   });
 
   it("stops a forward and removes it from the store", async () => {
-    invokeCommandMock.mockResolvedValueOnce({ id: 2, localPort: 5000 });
-    await startPortForward(req);
+    const fwd = await startPortForward(req);
     expect(getForwards()).toHaveLength(1);
 
-    invokeCommandMock.mockResolvedValueOnce(undefined);
-    await stopPortForward(2);
+    await stopPortForward(fwd.id);
 
     expect(getForwards()).toHaveLength(0);
-    expect(invokeCommandMock).toHaveBeenLastCalledWith("stop_port_forward", { id: 2 });
+    expect(invokeCommandMock).toHaveBeenCalledWith("stop_port_forward", { id: fwd.id });
   });
 
   it("auto-removes a forward when the backend emits forward:closed", async () => {
-    invokeCommandMock.mockResolvedValueOnce({ id: 3, localPort: 5001 });
-    await startPortForward(req);
+    const fwd = await startPortForward(req);
     expect(getForwards()).toHaveLength(1);
 
     // Simulate the backend serve-loop ending.
-    closedHandlers.get("forward:closed:3")?.();
+    closed(fwd.id);
 
     expect(getForwards()).toHaveLength(0);
   });
 
   it("defaults a new forward's status to active", async () => {
-    invokeCommandMock.mockResolvedValueOnce({ id: 5, localPort: 5002 });
     const fwd = await startPortForward(req);
     expect(fwd.status).toBe("active");
     expect(getForwards()[0].status).toBe("active");
   });
 
   it("flips status to reconnecting when the backend emits forward:status", async () => {
-    const notify = vi.fn();
-    invokeCommandMock.mockResolvedValueOnce({ id: 6, localPort: 5003 });
-    await startPortForward(req);
-    const unsub = subscribeForwards(notify);
+    const changed = vi.fn();
+    const fwd = await startPortForward(req);
+    const unsub = subscribeForwards(changed);
 
-    statusHandlers.get("forward:status:6")?.({ state: "reconnecting", attempt: 1, error: null });
+    statusEvent(fwd.id, "reconnecting");
 
     expect(getForwards()[0].status).toBe("reconnecting");
-    expect(notify).toHaveBeenCalled();
+    expect(changed).toHaveBeenCalled();
     unsub();
   });
 
   it("passes a preferred local port through", async () => {
-    invokeCommandMock.mockResolvedValueOnce({ id: 4, localPort: 8080 });
-    const withLocal: ActiveForward = { ...req, id: 0, localPort: 0, status: "active" };
-    await startPortForward({ ...withLocal, localPort: 8080 });
+    const fwd = await startPortForward({ ...req, localPort: 8080 });
+    expect(fwd.localPort).toBe(8080);
     expect(invokeCommandMock).toHaveBeenCalledWith(
       "start_port_forward",
       expect.objectContaining({ localPort: 8080 }),
     );
+  });
+});
+
+describe("a forward's age", () => {
+  it("dates a forward this session started from the backend, not the local clock", async () => {
+    const fwd = await startPortForward(req);
+
+    expect(fwd.startedAt).toBe(BACKEND_EPOCH + 1);
+    expect(getForwards()[0].startedAt).toBe(BACKEND_EPOCH + 1);
+  });
+
+  it("starts a new forward's traffic at what the backend has counted", async () => {
+    const fwd = await startPortForward(req);
+    expect(fwd.bytesMoved).toBe(0);
+    expect(getForwards()[0].bytesMoved).toBe(0);
+  });
+});
+
+describe("traffic", () => {
+  it("updates one forward's bytesMoved and leaves the others untouched", async () => {
+    const a = await startPortForward(req);
+    const b = await startPortForward(otherReq);
+    const before = getForwards();
+    const bBefore = before.find((f) => f.id === b.id);
+
+    traffic(a.id, 2048);
+
+    const after = getForwards();
+    expect(after).not.toBe(before);
+    expect(after.find((f) => f.id === a.id)?.bytesMoved).toBe(2048);
+    // The untouched row keeps its identity, so a memoised row does not re-render.
+    expect(after.find((f) => f.id === b.id)).toBe(bBefore);
+  });
+
+  it("takes the event's total as the total, not as a delta", async () => {
+    const fwd = await startPortForward(req);
+
+    traffic(fwd.id, 1024);
+    traffic(fwd.id, 4096);
+
+    expect(getForwards()[0].bytesMoved).toBe(4096);
+  });
+
+  it("emits nothing and keeps the snapshot when the total has not changed", async () => {
+    const fwd = await startPortForward(req);
+    traffic(fwd.id, 4096);
+    const snapshot = getForwards();
+    const changed = vi.fn();
+    const unsub = subscribeForwards(changed);
+
+    // The same running total the store already holds — the backend only fires
+    // on a change, but a repeat must not wake `useSyncExternalStore`.
+    traffic(fwd.id, 4096);
+
+    expect(changed).not.toHaveBeenCalled();
+    expect(getForwards()).toBe(snapshot);
+    unsub();
+  });
+
+  it("ignores a traffic event with no usable byte count", async () => {
+    const fwd = await startPortForward(req);
+    traffic(fwd.id, 512);
+    const snapshot = getForwards();
+
+    fire(`forward:traffic:${fwd.id}`, { bytes: "lots" });
+    fire(`forward:traffic:${fwd.id}`, null);
+
+    expect(getForwards()).toBe(snapshot);
+    expect(getForwards()[0].bytesMoved).toBe(512);
+  });
+});
+
+describe("rehydrateForwards", () => {
+  it("populates the store from the backend", async () => {
+    backend = [entry({ id: 9, name: "redis", bytes: 8192 }), entry({ id: 10, name: "pg" })];
+    const changed = vi.fn();
+    const unsub = subscribeForwards(changed);
+
+    await rehydrateForwards();
+
+    expect(getForwards()).toHaveLength(2);
+    expect(getForwards()[0]).toMatchObject({
+      id: 9,
+      kind: "Service",
+      name: "redis",
+      namespace: "default",
+      remotePort: 6379,
+      localPort: 61009,
+      startedAt: BACKEND_EPOCH + 9,
+      bytesMoved: 8192,
+      status: "active",
+    });
+    expect(changed).toHaveBeenCalled();
+    unsub();
+  });
+
+  it("does not duplicate a forward this session already knows", async () => {
+    const mine = await startPortForward(req);
+    backend.push(entry({ id: 42 }));
+    const before = getForwards().find((f) => f.id === mine.id);
+
+    await rehydrateForwards();
+
+    expect(getForwards().map((f) => f.id).sort()).toEqual([mine.id, 42].sort());
+    expect(getForwards().filter((f) => f.id === mine.id)).toHaveLength(1);
+    // The row this session owns keeps its identity rather than being replaced.
+    expect(getForwards().find((f) => f.id === mine.id)).toBe(before);
+  });
+
+  it("does not resurrect a forward that gave up and was dropped", async () => {
+    const fwd = await startPortForward(req);
+    // A forward that exhausts its retries emits `forward:closed` but stays in
+    // the manager's map until `stop` is called, so `list` still reports it.
+    closed(fwd.id);
+    expect(getForwards()).toHaveLength(0);
+    expect(backend.map((e) => e.id)).toEqual([fwd.id]);
+
+    await rehydrateForwards();
+
+    expect(getForwards()).toHaveLength(0);
+  });
+
+  it("does not resurrect a stopped forward from a list call already in flight", async () => {
+    const fwd = await startPortForward(req);
+    await stopPortForward(fwd.id);
+    // The snapshot a concurrent `list_forwards` took before the stop landed.
+    backend = [entry({ id: fwd.id, kind: "Pod", name: "web-1" })];
+
+    await rehydrateForwards();
+
+    expect(getForwards()).toHaveLength(0);
+  });
+
+  it("keeps the snapshot when the backend reports only what the store holds", async () => {
+    await startPortForward(req);
+    const snapshot = getForwards();
+    const changed = vi.fn();
+    const unsub = subscribeForwards(changed);
+
+    await rehydrateForwards();
+
+    expect(getForwards()).toBe(snapshot);
+    expect(changed).not.toHaveBeenCalled();
+    unsub();
+  });
+
+  it("watches a rehydrated forward's traffic and closure", async () => {
+    backend = [entry({ id: 9 })];
+    await rehydrateForwards();
+
+    traffic(9, 65536);
+    expect(getForwards()[0].bytesMoved).toBe(65536);
+
+    closed(9);
+    expect(getForwards()).toHaveLength(0);
+  });
+
+  it("stops a rehydrated forward through the same command", async () => {
+    backend = [entry({ id: 9 })];
+    await rehydrateForwards();
+
+    await stopPortForward(9);
+
+    expect(getForwards()).toHaveLength(0);
+    expect(invokeCommandMock).toHaveBeenCalledWith("stop_port_forward", { id: 9 });
+  });
+
+  it("reports a failed listing through describeError instead of throwing", async () => {
+    listFails = "handler error: list forwards timed out";
+
+    await expect(rehydrateForwards()).resolves.toBeUndefined();
+
+    expect(notify.error).toHaveBeenCalledWith(
+      expect.any(String),
+      describeError("handler error: list forwards timed out").detail,
+    );
+    expect(getForwards()).toHaveLength(0);
+  });
+
+  it("adopts a tunnel whose start could not be dated", async () => {
+    listFails = "handler error: list forwards timed out";
+    await expect(startPortForward(req)).rejects.toThrow();
+    expect(getForwards()).toHaveLength(0);
+
+    listFails = null;
+    await rehydrateForwards();
+
+    expect(getForwards()).toHaveLength(1);
+    expect(getForwards()[0]).toMatchObject({ id: 1, name: "web-1", startedAt: BACKEND_EPOCH + 1 });
   });
 });
 

--- a/packages/core/src/lib/forward.test.ts
+++ b/packages/core/src/lib/forward.test.ts
@@ -17,6 +17,7 @@ import {
   subscribeForwards,
   forwardUrl,
   forwardAddress,
+  isForwardEnded,
   __resetForwardStoreForTests,
 } from "./forward";
 import { describeError } from "./errors";
@@ -35,6 +36,10 @@ interface BackendEntry {
   localPort: number;
   startedAt: number;
   bytes: number;
+  /** True once the manager's own task has given up on this tunnel. */
+  ended: boolean;
+  /** Why it gave up, when the loop had a reason. */
+  error: string | null;
 }
 
 // Deliberately in the past: a `startedAt` sourced from the local clock would
@@ -60,8 +65,10 @@ function fire(channel: string, payload?: unknown) {
 }
 
 const traffic = (id: number, bytes: number) => fire(`forward:traffic:${id}`, { bytes });
-const closed = (id: number) => fire(`forward:closed:${id}`);
-const statusEvent = (id: number, state: string) => fire(`forward:status:${id}`, { state });
+/** `forward:closed:<id>` carries the loop's final error, or null for a clean end. */
+const closed = (id: number, reason?: string) => fire(`forward:closed:${id}`, reason ?? null);
+const statusEvent = (id: number, state: string, error?: string) =>
+  fire(`forward:status:${id}`, { state, attempt: 5, error: error ?? null });
 
 beforeEach(() => {
   invokeCommandMock.mockReset();
@@ -88,6 +95,8 @@ beforeEach(() => {
         localPort: (args?.localPort as number | null) ?? 50000 + id,
         startedAt: BACKEND_EPOCH + id,
         bytes: 0,
+        ended: false,
+        error: null,
       });
       const started = backend[backend.length - 1];
       return { id, localPort: started.localPort, startedAt: started.startedAt };
@@ -127,6 +136,8 @@ function entry(over: Partial<BackendEntry> & { id: number }): BackendEntry {
     localPort: 61000 + over.id,
     startedAt: BACKEND_EPOCH + over.id,
     bytes: 0,
+    ended: false,
+    error: null,
     ...over,
   };
 }
@@ -162,14 +173,19 @@ describe("forward store", () => {
     expect(invokeCommandMock).toHaveBeenCalledWith("stop_port_forward", { id: fwd.id });
   });
 
-  it("auto-removes a forward when the backend emits forward:closed", async () => {
+  it("keeps a forward the backend closed, marked failed rather than deleted", async () => {
+    // The defect this file used to assert. A tunnel that dies underneath the
+    // reader is NEWS: deleting the row left a fifteen-minute-old forward
+    // gone from the screen with no trace, and the reader assuming a tunnel
+    // they depend on is fine when it is dead.
     const fwd = await startPortForward(req);
     expect(getForwards()).toHaveLength(1);
 
     // Simulate the backend serve-loop ending.
     closed(fwd.id);
 
-    expect(getForwards()).toHaveLength(0);
+    expect(getForwards()).toHaveLength(1);
+    expect(getForwards()[0].status).toBe("failed");
   });
 
   it("defaults a new forward's status to active", async () => {
@@ -306,17 +322,37 @@ describe("rehydrateForwards", () => {
     expect(getForwards().find((f) => f.id === mine.id)).toBe(before);
   });
 
-  it("does not resurrect a forward that gave up and was dropped", async () => {
+  it("does not duplicate a tunnel it already knows has died", async () => {
     const fwd = await startPortForward(req);
     // A forward that exhausts its retries emits `forward:closed` but stays in
-    // the manager's map until `stop` is called, so `list` still reports it.
+    // the manager's map until `stop` is called, so `list` still reports it —
+    // now saying, itself, that it has ended.
+    statusEvent(fwd.id, "failed", "pod web-1 was deleted");
     closed(fwd.id);
-    expect(getForwards()).toHaveLength(0);
-    expect(backend.map((e) => e.id)).toEqual([fwd.id]);
+    backend = [entry({ id: fwd.id, kind: "Pod", name: "web-1", ended: true, error: "pod web-1 was deleted" })];
 
     await rehydrateForwards();
 
-    expect(getForwards()).toHaveLength(0);
+    expect(getForwards()).toHaveLength(1);
+    expect(getForwards()[0].status).toBe("failed");
+    expect(getForwards()[0].error).toBe("pod web-1 was deleted");
+  });
+
+  it("adopts a tunnel that died before this page existed as dead, not as active", async () => {
+    // The case no bookkeeping in this module can reach. `dropped` is
+    // module-level JavaScript that a browser reload wipes, and the
+    // `forward:closed` event fired before the page existed — so a store with
+    // nothing dropped meets a manager still holding a tunnel that gave up.
+    // It used to adopt it as `active`: a green row for a tunnel that cannot
+    // carry a byte, and a `/pf/<id>/` URL that will never answer.
+    backend = [entry({ id: 9, name: "redis", ended: true, error: "connection refused" })];
+
+    await rehydrateForwards();
+
+    expect(getForwards()).toHaveLength(1);
+    expect(getForwards()[0].status).toBe("failed");
+    expect(getForwards()[0].error).toBe("connection refused");
+    expect(isForwardEnded(getForwards()[0])).toBe(true);
   });
 
   it("does not resurrect a stopped forward from a list call already in flight", async () => {
@@ -350,8 +386,10 @@ describe("rehydrateForwards", () => {
     traffic(9, 65536);
     expect(getForwards()[0].bytesMoved).toBe(65536);
 
-    closed(9);
-    expect(getForwards()).toHaveLength(0);
+    closed(9, "the pod went away");
+    expect(getForwards()).toHaveLength(1);
+    expect(getForwards()[0].status).toBe("failed");
+    expect(getForwards()[0].error).toBe("the pod went away");
   });
 
   it("stops a rehydrated forward through the same command", async () => {
@@ -388,6 +426,160 @@ describe("rehydrateForwards", () => {
     expect(getForwards()).toHaveLength(1);
     expect(invokeCommandMock).toHaveBeenCalledTimes(1);
     expect(invokeCommandMock).toHaveBeenCalledWith("start_port_forward", expect.anything());
+  });
+});
+
+describe("a tunnel that dies on its own", () => {
+  /** The backend's own sequence when a forward exhausts its retries. */
+  async function giveUp(reason: string) {
+    const fwd = await startPortForward(req);
+    statusEvent(fwd.id, "failed", reason);
+    closed(fwd.id, reason);
+    return fwd;
+  }
+
+  it("keeps the reason the backend gave, so the row can say why", async () => {
+    await giveUp("connection refused connecting to 10.1.2.3:80");
+
+    expect(getForwards()[0].error).toBe("connection refused connecting to 10.1.2.3:80");
+  });
+
+  it("keeps the reason from the failed status when the closure carries none", async () => {
+    const fwd = await startPortForward(req);
+    statusEvent(fwd.id, "failed", "pod web-1 was deleted");
+
+    // `forward:closed` fires a moment later with nothing attached.
+    closed(fwd.id);
+
+    expect(getForwards()[0].status).toBe("failed");
+    expect(getForwards()[0].error).toBe("pod web-1 was deleted");
+  });
+
+  it("takes the reason from the closure itself when that is all there is", async () => {
+    const fwd = await startPortForward(req);
+
+    // No `failed` status first: the serve loop ended on its own terms.
+    closed(fwd.id, "the pod went away");
+
+    expect(getForwards()[0].status).toBe("failed");
+    expect(getForwards()[0].error).toBe("the pod went away");
+  });
+
+  it("invents no reason for a close that came without one", async () => {
+    const fwd = await startPortForward(req);
+
+    closed(fwd.id);
+
+    expect(getForwards()[0].status).toBe("failed");
+    expect(getForwards()[0].error).toBeUndefined();
+  });
+
+  it("clears a stale reason when the tunnel comes back", async () => {
+    const fwd = await startPortForward(req);
+    statusEvent(fwd.id, "reconnecting", "connection reset by peer");
+    expect(getForwards()[0].error).toBe("connection reset by peer");
+
+    statusEvent(fwd.id, "active");
+
+    // A live tunnel carrying last week's excuse would be read as broken.
+    expect(getForwards()[0].error).toBeUndefined();
+  });
+
+  it("wakes nobody when the closure only confirms the status before it", async () => {
+    // The backend's own sequence: `forward:status` with `failed` and the
+    // reason, then `forward:closed` a moment later saying the same thing.
+    // The second event tells the store nothing it does not already hold, and
+    // `getForwards` must hand back the SAME array — `useSyncExternalStore`
+    // re-renders forever otherwise, and a mutation that rebuilt the row
+    // unconditionally survived the rest of this file.
+    const fwd = await startPortForward(req);
+    statusEvent(fwd.id, "failed", "connection refused");
+    const snapshot = getForwards();
+    const row = snapshot[0];
+    const changed = vi.fn();
+    const unsub = subscribeForwards(changed);
+
+    closed(fwd.id, "connection refused");
+
+    expect(changed).not.toHaveBeenCalled();
+    expect(getForwards()).toBe(snapshot);
+    expect(getForwards()[0]).toBe(row);
+    unsub();
+  });
+
+  it("stops listening to a tunnel that has stopped", async () => {
+    const fwd = await giveUp("connection refused");
+
+    // Nothing further is coming, and an unclosed subscription per dead row is
+    // a leak the reader pays for by leaving the screen open.
+    expect(handlers.has(`forward:closed:${fwd.id}`)).toBe(false);
+    expect(handlers.has(`forward:status:${fwd.id}`)).toBe(false);
+    expect(handlers.has(`forward:traffic:${fwd.id}`)).toBe(false);
+  });
+
+  it("keeps the snapshot when a rehydrate meets a tunnel it already knows is dead", async () => {
+    // `getForwards` must hand back the SAME array until something really
+    // changed: `useSyncExternalStore` re-renders forever otherwise, and every
+    // mount of the forwards screen rehydrates.
+    const fwd = await giveUp("connection refused");
+    backend = [entry({ id: fwd.id, kind: "Pod", name: "web-1", ended: true, error: "connection refused" })];
+    const snapshot = getForwards();
+    const changed = vi.fn();
+    const unsub = subscribeForwards(changed);
+
+    await rehydrateForwards();
+    await rehydrateForwards();
+
+    expect(changed).not.toHaveBeenCalled();
+    expect(getForwards()).toBe(snapshot);
+    unsub();
+  });
+
+  it("leaves every other row's identity alone", async () => {
+    const a = await startPortForward(req);
+    const b = await startPortForward(otherReq);
+    const bBefore = getForwards().find((f) => f.id === b.id);
+
+    closed(a.id, "connection refused");
+
+    expect(getForwards().find((f) => f.id === b.id)).toBe(bBefore);
+    expect(getForwards().find((f) => f.id === a.id)?.status).toBe("failed");
+  });
+
+  it("is dead, where a reconnecting one is not", async () => {
+    const flapping = await startPortForward(req);
+    const dying = await startPortForward(otherReq);
+    statusEvent(flapping.id, "reconnecting", "connection reset by peer");
+    closed(dying.id, "connection refused");
+
+    const [live, dead] = getForwards();
+    // A tunnel that is reconnecting is coming back; one that gave up is gone.
+    expect(isForwardEnded(live)).toBe(false);
+    expect(isForwardEnded(dead)).toBe(true);
+  });
+
+  it("goes for good when the reader dismisses it, and tells the backend so", async () => {
+    // Dismissal is `stop_port_forward`, not a local delete: the manager keeps
+    // a gave-up forward in its map until `stop` is called, and a set of
+    // dropped ids in this module cannot outlive the page that holds it.
+    const fwd = await giveUp("connection refused");
+    expect(getForwards()).toHaveLength(1);
+
+    await stopPortForward(fwd.id);
+
+    expect(getForwards()).toHaveLength(0);
+    expect(invokeCommandMock).toHaveBeenCalledWith("stop_port_forward", { id: fwd.id });
+  });
+
+  it("stays gone when a listing already in flight still reports it", async () => {
+    const fwd = await giveUp("connection refused");
+    await stopPortForward(fwd.id);
+    // The snapshot a concurrent `list_forwards` took before the stop landed.
+    backend = [entry({ id: fwd.id, kind: "Pod", name: "web-1", ended: true, error: "connection refused" })];
+
+    await rehydrateForwards();
+
+    expect(getForwards()).toHaveLength(0);
   });
 });
 

--- a/packages/core/src/lib/forward.ts
+++ b/packages/core/src/lib/forward.ts
@@ -79,22 +79,34 @@ export function getForwards(): ActiveForward[] {
 
 /** Start a port-forward and track it; auto-removes if the backend loop ends. */
 export async function startPortForward(req: ForwardRequest): Promise<ActiveForward> {
-  const info = await invokeCommand<{ id: number; localPort: number }>("start_port_forward", {
+  const info = await invokeCommand<{ id: number; localPort: number; startedAt: number }>(
+    "start_port_forward",
+    {
+      context: req.context,
+      namespace: req.namespace,
+      kind: req.kind,
+      name: req.name,
+      remotePort: req.remotePort,
+      localPort: req.localPort ?? null,
+    },
+  );
+  // The start response carries its own startedAt now — the same stamp
+  // `list_forwards` would report for this forward, taken once on the
+  // backend rather than read back with a second call. No follow-up
+  // `list_forwards` here: a tunnel that started fine no longer fails on a
+  // read that has nothing to do with whether it's running.
+  const fwd: ActiveForward = {
+    id: info.id,
     context: req.context,
     namespace: req.namespace,
     kind: req.kind,
     name: req.name,
     remotePort: req.remotePort,
-    localPort: req.localPort ?? null,
-  });
-  // The start command answers with the id and the bound port; the start time
-  // comes from `list_forwards`, the same place a rehydrated forward's does, so
-  // an age is one measurement rather than two that happen to agree. If that
-  // read fails the tunnel is live but undated, and this throws rather than
-  // dating it from the local clock — `rehydrateForwards` adopts it next look.
-  const entry = (await listForwards()).find((e) => e.id === info.id);
-  if (!entry) throw new Error(`the backend started forward ${info.id} but does not list it`);
-  const fwd = fromEntry(entry);
+    localPort: info.localPort,
+    status: "active",
+    bytesMoved: 0,
+    startedAt: info.startedAt,
+  };
   forwards = [...forwards, fwd];
   watchForward(info.id);
   emit();

--- a/packages/core/src/lib/forward.ts
+++ b/packages/core/src/lib/forward.ts
@@ -1,5 +1,7 @@
 import { invokeCommand, on } from "../transport/transport";
 import { isTauri } from "../transport/platform";
+import { describeError } from "./errors";
+import { notify } from "./notify";
 
 /** A live port-forward: a local port piped to a Pod or Service. */
 export interface ActiveForward {
@@ -13,6 +15,14 @@ export interface ActiveForward {
   localPort: number;
   /** Live state, driven by `forward:status:<id>` events from the backend. */
   status: "active" | "reconnecting" | "failed";
+  /** Bytes moved since this forward started, as the backend counts them. A
+   *  running total, not a delta: `forward:traffic:<id>` carries the whole
+   *  number each time. */
+  bytesMoved: number;
+  /** Epoch millis, stamped by the backend when the forward was created — for
+   *  every forward, including ones this session started, so an age means the
+   *  same thing in every row rather than "since I noticed it" in some. */
+  startedAt: number;
 }
 
 export interface ForwardRequest {
@@ -25,11 +35,32 @@ export interface ForwardRequest {
   localPort?: number;
 }
 
+/** One live forward as `list_forwards` reports it (Rust `ForwardEntry`). */
+interface ForwardEntry {
+  id: number;
+  context: string;
+  namespace: string;
+  kind: string;
+  name: string;
+  remotePort: number;
+  localPort: number;
+  startedAt: number;
+  bytes: number;
+}
+
 // Module-level store so active forwards survive component remounts and are
 // shared between the per-resource "Forward" action and the status-bar list.
 let forwards: ActiveForward[] = [];
 const listeners = new Set<() => void>();
 const closers = new Map<number, () => void>();
+
+// Ids this store has deliberately dropped. A forward that exhausts its retries
+// emits `forward:closed:<id>` — which drops the row — but stays in
+// `ForwardManager`'s map until `stop` is called, so `list_forwards` keeps
+// reporting it. Without this, a rehydrate landing after a give-up would raise a
+// dead tunnel back into the table it was just correctly removed from. It also
+// covers a `list_forwards` already in flight when a stop lands.
+const dropped = new Set<number>();
 
 function emit() {
   for (const l of listeners) l();
@@ -56,19 +87,16 @@ export async function startPortForward(req: ForwardRequest): Promise<ActiveForwa
     remotePort: req.remotePort,
     localPort: req.localPort ?? null,
   });
-  const fwd: ActiveForward = { ...req, id: info.id, localPort: info.localPort, status: "active" };
+  // The start command answers with the id and the bound port; the start time
+  // comes from `list_forwards`, the same place a rehydrated forward's does, so
+  // an age is one measurement rather than two that happen to agree. If that
+  // read fails the tunnel is live but undated, and this throws rather than
+  // dating it from the local clock — `rehydrateForwards` adopts it next look.
+  const entry = (await listForwards()).find((e) => e.id === info.id);
+  if (!entry) throw new Error(`the backend started forward ${info.id} but does not list it`);
+  const fwd = fromEntry(entry);
   forwards = [...forwards, fwd];
-  const unsubClosed = on(`forward:closed:${info.id}`, () => removeForward(info.id));
-  const unsubStatus = on(`forward:status:${info.id}`, (payload) => {
-    const state = (payload as { state?: unknown } | null)?.state;
-    if (state === "active" || state === "reconnecting" || state === "failed") {
-      setForwardStatus(info.id, state);
-    }
-  });
-  closers.set(info.id, () => {
-    unsubClosed();
-    unsubStatus();
-  });
+  watchForward(info.id);
   emit();
   return fwd;
 }
@@ -77,6 +105,32 @@ export async function startPortForward(req: ForwardRequest): Promise<ActiveForwa
 export async function stopPortForward(id: number): Promise<void> {
   await invokeCommand("stop_port_forward", { id });
   removeForward(id);
+}
+
+/**
+ * Adopt every forward the backend is still running. This store is module-level
+ * and dies with a browser reload; `ForwardManager` does not, so without this a
+ * web user reloads into an empty table while their tunnels keep running.
+ *
+ * A forward the store already knows keeps its existing row — identity included,
+ * so a rehydrate on mount doesn't re-render every row — and one it dropped on
+ * purpose stays dropped. Resolves even when the listing fails: that failure is
+ * reported to the reader, not thrown at a mount effect.
+ */
+export async function rehydrateForwards(): Promise<void> {
+  let entries: ForwardEntry[];
+  try {
+    entries = await listForwards();
+  } catch (e) {
+    notify.error("Couldn't list active port forwards", describeError(e).detail);
+    return;
+  }
+  const known = new Set(forwards.map((f) => f.id));
+  const added = entries.filter((e) => !known.has(e.id) && !dropped.has(e.id)).map(fromEntry);
+  if (added.length === 0) return;
+  forwards = [...forwards, ...added];
+  for (const f of added) watchForward(f.id);
+  emit();
 }
 
 /** Where a live port-forward is reachable from the current UI: the bound
@@ -95,8 +149,66 @@ export function forwardAddress(info: { id: number; localPort: number }): string 
     : `${window.location.origin}/pf/${info.id}/`;
 }
 
+async function listForwards(): Promise<ForwardEntry[]> {
+  const res = await invokeCommand<{ forwards?: ForwardEntry[] }>("list_forwards");
+  return res?.forwards ?? [];
+}
+
+/** A backend entry as a store row. A forward the manager still holds is being
+ *  served, so it starts `active`; a `forward:status` event corrects that the
+ *  moment the tunnel flaps. */
+function fromEntry(e: ForwardEntry): ActiveForward {
+  return {
+    id: e.id,
+    context: e.context,
+    namespace: e.namespace,
+    kind: e.kind,
+    name: e.name,
+    remotePort: e.remotePort,
+    localPort: e.localPort,
+    status: "active",
+    bytesMoved: e.bytes,
+    startedAt: e.startedAt,
+  };
+}
+
+/** Listen for one forward's closure, status and traffic. Idempotent, so a
+ *  rehydrate that re-meets a known forward doesn't subscribe twice. */
+function watchForward(id: number) {
+  if (closers.has(id)) return;
+  const unsubClosed = on(`forward:closed:${id}`, () => removeForward(id));
+  const unsubStatus = on(`forward:status:${id}`, (payload) => {
+    const state = (payload as { state?: unknown } | null)?.state;
+    if (state === "active" || state === "reconnecting" || state === "failed") {
+      setForwardStatus(id, state);
+    }
+  });
+  const unsubTraffic = on(`forward:traffic:${id}`, (payload) => {
+    const bytes = (payload as { bytes?: unknown } | null)?.bytes;
+    if (typeof bytes === "number" && Number.isFinite(bytes)) setForwardBytes(id, bytes);
+  });
+  closers.set(id, () => {
+    unsubClosed();
+    unsubStatus();
+    unsubTraffic();
+  });
+}
+
 function setForwardStatus(id: number, status: ActiveForward["status"]) {
   const next = forwards.map((f) => (f.id === id && f.status !== status ? { ...f, status } : f));
+  if (next.some((f, i) => f !== forwards[i])) {
+    forwards = next;
+    emit();
+  }
+}
+
+/** Record a forward's running byte total. The event fires about once a second,
+ *  so an unchanged total must leave both the row and the array identity alone —
+ *  otherwise `useSyncExternalStore` wakes every subscriber every second. */
+function setForwardBytes(id: number, bytesMoved: number) {
+  const next = forwards.map((f) =>
+    f.id === id && f.bytesMoved !== bytesMoved ? { ...f, bytesMoved } : f,
+  );
   if (next.some((f, i) => f !== forwards[i])) {
     forwards = next;
     emit();
@@ -106,9 +218,18 @@ function setForwardStatus(id: number, status: ActiveForward["status"]) {
 function removeForward(id: number) {
   closers.get(id)?.();
   closers.delete(id);
+  dropped.add(id);
   const next = forwards.filter((f) => f.id !== id);
   if (next.length !== forwards.length) {
     forwards = next;
     emit();
   }
+}
+
+/** Reset the module-level store between tests. */
+export function __resetForwardStoreForTests(): void {
+  for (const close of closers.values()) close();
+  closers.clear();
+  dropped.clear();
+  forwards = [];
 }

--- a/packages/core/src/lib/forward.ts
+++ b/packages/core/src/lib/forward.ts
@@ -13,8 +13,27 @@ export interface ActiveForward {
   name: string;
   remotePort: number;
   localPort: number;
-  /** Live state, driven by `forward:status:<id>` events from the backend. */
+  /**
+   * Live state, driven by `forward:status:<id>` events from the backend and
+   * by `forward:closed:<id>`.
+   *
+   * `failed` is the ENDED state: the tunnel exhausted its retries, or its
+   * serve loop stopped. `reconnecting` is not — that one is still coming
+   * back. See {@link isForwardEnded}, which is the only thing allowed to
+   * decide which of the two a row is.
+   */
   status: "active" | "reconnecting" | "failed";
+  /**
+   * Why the tunnel is in trouble, exactly as the backend said it — the raw
+   * `error` off a `forward:status` event or the reason on `forward:closed`.
+   * `undefined` while nothing has gone wrong, and cleared again when a
+   * tunnel comes back, so a live row cannot carry a stale excuse.
+   *
+   * Raw on purpose: it is a backend string, and the surface that shows it
+   * runs it through `describeError` rather than printing a Rust struct at
+   * the reader.
+   */
+  error?: string;
   /** Bytes moved since this forward started, as the backend counts them. A
    *  running total, not a delta: `forward:traffic:<id>` carries the whole
    *  number each time. */
@@ -46,6 +65,10 @@ interface ForwardEntry {
   localPort: number;
   startedAt: number;
   bytes: number;
+  /** True once the manager's own task has given up on this tunnel. */
+  ended?: boolean;
+  /** Why it gave up, when the loop had a reason to give. */
+  error?: string | null;
 }
 
 // Module-level store so active forwards survive component remounts and are
@@ -54,12 +77,21 @@ let forwards: ActiveForward[] = [];
 const listeners = new Set<() => void>();
 const closers = new Map<number, () => void>();
 
-// Ids this store has deliberately dropped. A forward that exhausts its retries
-// emits `forward:closed:<id>` — which drops the row — but stays in
-// `ForwardManager`'s map until `stop` is called, so `list_forwards` keeps
-// reporting it. Without this, a rehydrate landing after a give-up would raise a
-// dead tunnel back into the table it was just correctly removed from. It also
-// covers a `list_forwards` already in flight when a stop lands.
+/**
+ * Ids the READER has taken off the screen — a tunnel they stopped, or a dead
+ * row they dismissed. Both of those also tell the backend to forget the
+ * forward, so this set has exactly one job left: a `list_forwards` that was
+ * already in flight when the removal landed must not put the row back.
+ *
+ * It used to carry more, and it could not. A forward that gives up stays in
+ * `ForwardManager`'s map until `stop` is called, and this store used to drop
+ * such a row and remember the id so a rehydrate could not resurrect it — but
+ * this is module-level JavaScript that a browser reload wipes, and the
+ * `forward:closed` event that filled it fired before the reloaded page
+ * existed. A reload therefore adopted the dead tunnel as `active`. That case
+ * is answered where it can be: `list_forwards` now reports `ended` and the
+ * reason with it, and {@link fromEntry} reads them.
+ */
 const dropped = new Set<number>();
 
 function emit() {
@@ -72,12 +104,26 @@ export function subscribeForwards(listener: () => void): () => void {
   return () => listeners.delete(listener);
 }
 
-/** Current active forwards (stable reference until the next change). */
+/** Current forwards, live and dead (stable reference until the next change). */
 export function getForwards(): ActiveForward[] {
   return forwards;
 }
 
-/** Start a port-forward and track it; auto-removes if the backend loop ends. */
+/**
+ * Has this tunnel given up?
+ *
+ * The one place the difference is decided, because more than one surface has
+ * to agree about it: the forwards table counts its live rows, the status bar
+ * counts port-forwards for the whole window, and a dead row's action is a
+ * dismissal rather than a stop. A tunnel that is `reconnecting` is still
+ * alive and still counts; only one that has stopped trying is dead.
+ */
+export function isForwardEnded(forward: Pick<ActiveForward, "status">): boolean {
+  return forward.status === "failed";
+}
+
+/** Start a port-forward and track it. A backend loop that ends leaves the row
+ *  behind, marked as ended — see {@link endForward}. */
 export async function startPortForward(req: ForwardRequest): Promise<ActiveForward> {
   const info = await invokeCommand<{ id: number; localPort: number; startedAt: number }>(
     "start_port_forward",
@@ -113,7 +159,15 @@ export async function startPortForward(req: ForwardRequest): Promise<ActiveForwa
   return fwd;
 }
 
-/** Stop a forward and drop it from the store. */
+/**
+ * Stop a forward and drop it from the store.
+ *
+ * Also how a reader DISMISSES a dead row, and deliberately so. A forward that
+ * gave up on its own stays in `ForwardManager`'s map — and in its listing —
+ * until `stop` is called, so a dismissal that only deleted the row here would
+ * be undone by the next reload. There is nothing left to abort in that case;
+ * `stop` is what makes the backend forget the tunnel.
+ */
 export async function stopPortForward(id: number): Promise<void> {
   await invokeCommand("stop_port_forward", { id });
   removeForward(id);
@@ -141,7 +195,9 @@ export async function rehydrateForwards(): Promise<void> {
   const added = entries.filter((e) => !known.has(e.id) && !dropped.has(e.id)).map(fromEntry);
   if (added.length === 0) return;
   forwards = [...forwards, ...added];
-  for (const f of added) watchForward(f.id);
+  // Only the live ones: a tunnel the backend already reports as ended has no
+  // further events to send, and its row is already saying so.
+  for (const f of added) if (!isForwardEnded(f)) watchForward(f.id);
   emit();
 }
 
@@ -166,9 +222,15 @@ async function listForwards(): Promise<ForwardEntry[]> {
   return res?.forwards ?? [];
 }
 
-/** A backend entry as a store row. A forward the manager still holds is being
- *  served, so it starts `active`; a `forward:status` event corrects that the
- *  moment the tunnel flaps. */
+/**
+ * A backend entry as a store row.
+ *
+ * The listing says whether the manager's own task is still trying, so a
+ * forward it reports as `ended` becomes a dead row here with the reason
+ * attached — which is the whole of what a page that reloaded after the
+ * `forward:closed` event has to go on. Anything else starts `active`; a
+ * `forward:status` event corrects that the moment the tunnel flaps.
+ */
 function fromEntry(e: ForwardEntry): ActiveForward {
   return {
     id: e.id,
@@ -178,21 +240,30 @@ function fromEntry(e: ForwardEntry): ActiveForward {
     name: e.name,
     remotePort: e.remotePort,
     localPort: e.localPort,
-    status: "active",
+    status: e.ended === true ? "failed" : "active",
+    error: reasonOf(e.error),
     bytesMoved: e.bytes,
     startedAt: e.startedAt,
   };
+}
+
+/** A reason worth keeping, or nothing. The backend says `null` for "no reason
+ *  to give", and an empty string is not a sentence either. */
+function reasonOf(error: unknown): string | undefined {
+  return typeof error === "string" && error !== "" ? error : undefined;
 }
 
 /** Listen for one forward's closure, status and traffic. Idempotent, so a
  *  rehydrate that re-meets a known forward doesn't subscribe twice. */
 function watchForward(id: number) {
   if (closers.has(id)) return;
-  const unsubClosed = on(`forward:closed:${id}`, () => removeForward(id));
+  // The payload is the loop's final error, or null for a clean end.
+  const unsubClosed = on(`forward:closed:${id}`, (payload) => endForward(id, reasonOf(payload)));
   const unsubStatus = on(`forward:status:${id}`, (payload) => {
-    const state = (payload as { state?: unknown } | null)?.state;
+    const event = payload as { state?: unknown; error?: unknown } | null;
+    const state = event?.state;
     if (state === "active" || state === "reconnecting" || state === "failed") {
-      setForwardStatus(id, state);
+      setForwardStatus(id, state, reasonOf(event?.error));
     }
   });
   const unsubTraffic = on(`forward:traffic:${id}`, (payload) => {
@@ -206,8 +277,48 @@ function watchForward(id: number) {
   });
 }
 
-function setForwardStatus(id: number, status: ActiveForward["status"]) {
-  const next = forwards.map((f) => (f.id === id && f.status !== status ? { ...f, status } : f));
+/** Record a forward's live state and the reason that came with it. The reason
+ *  is replaced rather than merged, so a tunnel that comes back does not keep
+ *  the excuse from the attempt before. */
+function setForwardStatus(id: number, status: ActiveForward["status"], error?: string) {
+  const next = forwards.map((f) =>
+    f.id === id && (f.status !== status || f.error !== error) ? { ...f, status, error } : f,
+  );
+  if (next.some((f, i) => f !== forwards[i])) {
+    forwards = next;
+    emit();
+  }
+}
+
+/**
+ * The backend has closed this tunnel. The row STAYS, marked as ended.
+ *
+ * A tunnel the reader stopped is gone from the screen at once, because they
+ * did it and do not need it reported back. One that died underneath them is
+ * news: this used to delete the row, so a forward that had been up for
+ * fifteen minutes vanished with no trace and the reader went on depending on
+ * a tunnel that was dead.
+ *
+ * `reason` is the closure's own; a reason already recorded by the `failed`
+ * status that preceded it survives a closure that carries none.
+ *
+ * Nothing is rebuilt when nothing changed, and that guard is reached on the
+ * ordinary path rather than a defensive one: the backend's give-up sequence
+ * is a `failed` status carrying the reason and THEN a closure saying the same
+ * thing, so the second event routinely tells this store nothing it does not
+ * hold. Rebuilding the row for it would wake every subscriber to
+ * `getForwards`, which is how `useSyncExternalStore` ends up looping.
+ */
+function endForward(id: number, reason: string | undefined) {
+  // Nothing further will be reported about a tunnel that has stopped.
+  closers.get(id)?.();
+  closers.delete(id);
+  const next = forwards.map((f) => {
+    if (f.id !== id) return f;
+    const error = reason ?? f.error;
+    if (f.status === "failed" && f.error === error) return f;
+    return { ...f, status: "failed" as const, error };
+  });
   if (next.some((f, i) => f !== forwards[i])) {
     forwards = next;
     emit();

--- a/packages/core/src/lib/kubectlMapper.test.ts
+++ b/packages/core/src/lib/kubectlMapper.test.ts
@@ -222,4 +222,64 @@ describe("kubectlMapper", () => {
       ).toBe("kubectl get pods web-0 -n default --context prod");
     });
   });
+
+  describe("port-forward", () => {
+    it("maps a Service to svc/<name>", () => {
+      expect(
+        toKubectl({
+          action: "port-forward",
+          kind: "Service",
+          namespace: "prod",
+          name: "checkout-api",
+          context: "prod",
+          localPort: 8080,
+          remotePort: 80,
+        }),
+      ).toBe("kubectl --context prod -n prod port-forward svc/checkout-api 8080:80");
+    });
+
+    it("maps a Pod to pod/<name>", () => {
+      expect(
+        toKubectl({
+          action: "port-forward",
+          kind: "Pod",
+          namespace: "prod",
+          name: "checkout-api-5c8b7f2d9-mk3wl",
+          context: "prod",
+          localPort: 5432,
+          remotePort: 5432,
+        }),
+      ).toBe("kubectl --context prod -n prod port-forward pod/checkout-api-5c8b7f2d9-mk3wl 5432:5432");
+    });
+
+    it("single-quotes a context carrying command substitution, same as every other action", () => {
+      // Not just "has a space" — a fixture like that would also pass under
+      // naive double-quoting and prove nothing about which quoting tier ran.
+      expect(
+        toKubectl({
+          action: "port-forward",
+          kind: "Pod",
+          namespace: "prod",
+          name: "web-0",
+          context: "$(touch /tmp/pwn)",
+          localPort: 8080,
+          remotePort: 80,
+        }),
+      ).toBe("kubectl --context '$(touch /tmp/pwn)' -n prod port-forward pod/web-0 8080:80");
+    });
+
+    it("keeps distinct local and remote ports in local:remote order", () => {
+      expect(
+        toKubectl({
+          action: "port-forward",
+          kind: "Service",
+          namespace: "prod",
+          name: "checkout-api",
+          context: "prod",
+          localPort: 9999,
+          remotePort: 443,
+        }),
+      ).toBe("kubectl --context prod -n prod port-forward svc/checkout-api 9999:443");
+    });
+  });
 });

--- a/packages/core/src/lib/kubectlMapper.test.ts
+++ b/packages/core/src/lib/kubectlMapper.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { toKubectl } from "./kubectlMapper";
+import { kindToForwardTarget, toKubectl } from "./kubectlMapper";
 
 describe("kubectlMapper", () => {
   describe("read-only commands", () => {
@@ -284,6 +284,35 @@ describe("kubectlMapper", () => {
           remotePort: 443,
         }),
       ).toBe("kubectl --context prod -n prod port-forward svc/checkout-api 9999:443");
+    });
+  });
+
+  describe("kindToForwardTarget", () => {
+    // Exported because the UI names a forward with it too — the forwards
+    // table's Target cell and the New forward dialog's options — and three
+    // consumers of one rule beats three copies that can drift apart.
+    it("gives kubectl's own short forms for the two kinds a forward can have", () => {
+      expect(kindToForwardTarget("Service")).toBe("svc");
+      expect(kindToForwardTarget("Pod")).toBe("pod");
+      // Not the API plurals `kindToResource` would hand back.
+      expect(kindToForwardTarget("Service")).not.toBe("services");
+    });
+
+    it("lowercases anything else rather than guessing a short form", () => {
+      expect(kindToForwardTarget("StatefulSet")).toBe("statefulset");
+    });
+
+    it("is the same mapping the command itself carries", () => {
+      const command = toKubectl({
+        action: "port-forward",
+        kind: "Service",
+        name: "checkout-api",
+        context: "prod",
+        namespace: "prod",
+        localPort: 8080,
+        remotePort: 80,
+      });
+      expect(command).toContain(`port-forward ${kindToForwardTarget("Service")}/checkout-api`);
     });
   });
 });

--- a/packages/core/src/lib/kubectlMapper.test.ts
+++ b/packages/core/src/lib/kubectlMapper.test.ts
@@ -246,10 +246,14 @@ describe("kubectlMapper", () => {
           namespace: "prod",
           name: "checkout-api-5c8b7f2d9-mk3wl",
           context: "prod",
-          localPort: 5432,
+          // Deliberately different: equal ports make the assertion pass whether
+          // the pair is rendered local:remote or remote:local, so a swap would
+          // go unnoticed here and the test would prove only half of what it
+          // is named for.
+          localPort: 15432,
           remotePort: 5432,
         }),
-      ).toBe("kubectl --context prod -n prod port-forward pod/checkout-api-5c8b7f2d9-mk3wl 5432:5432");
+      ).toBe("kubectl --context prod -n prod port-forward pod/checkout-api-5c8b7f2d9-mk3wl 15432:5432");
     });
 
     it("single-quotes a context carrying command substitution, same as every other action", () => {

--- a/packages/core/src/lib/kubectlMapper.test.ts
+++ b/packages/core/src/lib/kubectlMapper.test.ts
@@ -238,6 +238,23 @@ describe("kubectlMapper", () => {
       ).toBe("kubectl --context prod -n prod port-forward svc/checkout-api 8080:80");
     });
 
+    it("writes a random local port the way kubectl does, as :<remote>", () => {
+      // `kubectl port-forward svc/x :8443` is kubectl's own spelling for "any
+      // free local port" — the same thing omitting `localPort` asks the
+      // backend for. Rendering `undefined:8443` would be a command that
+      // cannot be pasted.
+      expect(
+        toKubectl({
+          action: "port-forward",
+          kind: "Service",
+          name: "checkout-api",
+          context: "prod",
+          namespace: "checkout",
+          remotePort: 8443,
+        }),
+      ).toBe("kubectl --context prod -n checkout port-forward svc/checkout-api :8443");
+    });
+
     it("maps a Pod to pod/<name>", () => {
       expect(
         toKubectl({

--- a/packages/core/src/lib/kubectlMapper.ts
+++ b/packages/core/src/lib/kubectlMapper.ts
@@ -18,7 +18,8 @@ export interface KubectlInput {
     | "drain"
     | "cronjob-suspend"
     | "cronjob-resume"
-    | "cronjob-trigger";
+    | "cronjob-trigger"
+    | "port-forward";
   kind: string;
   name: string;
   context: string;
@@ -27,6 +28,20 @@ export interface KubectlInput {
   output?: string;
   /** For scale: target replica count. */
   replicas?: number;
+  /** For port-forward: the local machine's port. */
+  localPort?: number;
+  /** For port-forward: the port on the target pod/service. */
+  remotePort?: number;
+}
+
+// kubectl's short target forms, not the API resource plurals `kindToResource`
+// returns ("services", "pods") — `kubectl port-forward services/foo` isn't
+// what anyone types or expects to read. Only Pod and Service ever back a
+// forward; anything else falls back to the lowercased kind.
+function kindToForwardTarget(kind: string): string {
+  if (kind === "Service") return "svc";
+  if (kind === "Pod") return "pod";
+  return kind.toLowerCase();
 }
 
 // Resource names are DNS-1123 and always shell-safe in practice, but
@@ -97,13 +112,27 @@ function shellQuote(value: string, what: string, windows: boolean): string {
  * `KubectlPreview`'s `note` prop).
  */
 export function toKubectl(input: KubectlInput, windows: boolean = IS_WINDOWS): string {
-  const { action, kind, name, context, namespace, output, replicas } = input;
+  const { action, kind, name, context, namespace, output, replicas, localPort, remotePort } = input;
   // Prefer the authoritative kind→resource table (mirrors the backend's own
   // GVR mapping) over a bare lowercase, which drifts for kinds whose plural
   // isn't just "+s" (Ingress → ingresses). Falls back to lowercasing for
   // CRDs/unknown kinds not in the table.
   const kindLower = kindToResource(kind)?.resource ?? kind.toLowerCase();
   const ns = namespace || "";
+
+  // Ordered differently from every other action below: the design writes
+  // `--context <c> -n <ns>` before the verb, matching how people actually
+  // type a port-forward, so this is handled separately rather than falling
+  // through the shared "verb first, -n/--context appended last" assembly.
+  if (action === "port-forward") {
+    const qName = shellQuote(name, "name", windows);
+    const parts: string[] = ["kubectl", "--context", shellQuote(context, "context", windows)];
+    if (ns) {
+      parts.push("-n", shellQuote(ns, "namespace", windows));
+    }
+    parts.push("port-forward", `${kindToForwardTarget(kind)}/${qName}`, `${localPort}:${remotePort}`);
+    return parts.join(" ");
+  }
 
   const parts: string[] = ["kubectl"];
 

--- a/packages/core/src/lib/kubectlMapper.ts
+++ b/packages/core/src/lib/kubectlMapper.ts
@@ -34,11 +34,20 @@ export interface KubectlInput {
   remotePort?: number;
 }
 
-// kubectl's short target forms, not the API resource plurals `kindToResource`
-// returns ("services", "pods") — `kubectl port-forward services/foo` isn't
-// what anyone types or expects to read. Only Pod and Service ever back a
-// forward; anything else falls back to the lowercased kind.
-function kindToForwardTarget(kind: string): string {
+/**
+ * kubectl's short target forms, not the API resource plurals `kindToResource`
+ * returns ("services", "pods") — `kubectl port-forward services/foo` isn't
+ * what anyone types or expects to read. Only Pod and Service ever back a
+ * forward; anything else falls back to the lowercased kind.
+ *
+ * Exported because it is a NAME the UI shows as well as a token the command
+ * carries: the forwards table's Target cell, the New forward dialog's target
+ * options and this mapper's own `port-forward` line all say `svc/checkout-api`
+ * about the same object. Two of those used to keep their own `{ Service: "svc",
+ * Pod: "pod" }` table, which is two answers to one question and one drift away
+ * from a row whose name and whose copied command disagree about what it is.
+ */
+export function kindToForwardTarget(kind: string): string {
   if (kind === "Service") return "svc";
   if (kind === "Pod") return "pod";
   return kind.toLowerCase();

--- a/packages/core/src/lib/kubectlMapper.ts
+++ b/packages/core/src/lib/kubectlMapper.ts
@@ -139,7 +139,11 @@ export function toKubectl(input: KubectlInput, windows: boolean = IS_WINDOWS): s
     if (ns) {
       parts.push("-n", shellQuote(ns, "namespace", windows));
     }
-    parts.push("port-forward", `${kindToForwardTarget(kind)}/${qName}`, `${localPort}:${remotePort}`);
+    // An omitted local port is `:<remote>` — kubectl's own spelling for "any
+    // free one", and exactly what omitting `localPort` asks the backend for.
+    // Rendering `undefined:8443` would be a command nobody could paste.
+    const ports = localPort == null ? `:${remotePort}` : `${localPort}:${remotePort}`;
+    parts.push("port-forward", `${kindToForwardTarget(kind)}/${qName}`, ports);
     return parts.join(" ");
   }
 

--- a/packages/core/src/lib/openExternal.test.ts
+++ b/packages/core/src/lib/openExternal.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { invokeCommandMock } = vi.hoisted(() => ({ invokeCommandMock: vi.fn() }));
+vi.mock("../transport/transport", () => ({ invokeCommand: invokeCommandMock }));
+
+const platform = vi.hoisted(() => ({ isTauri: vi.fn(() => true) }));
+vi.mock("../transport/platform", () => ({
+  isTauri: platform.isTauri,
+  get isWeb() {
+    return !platform.isTauri();
+  },
+}));
+
+import { browsable, openExternal } from "./openExternal";
+
+let opened: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  platform.isTauri.mockReturnValue(true);
+  invokeCommandMock.mockResolvedValue(null);
+  opened = vi.fn();
+  Object.defineProperty(window, "open", { value: opened, configurable: true, writable: true });
+});
+
+describe("browsable", () => {
+  it("gives a bare authority the scheme a browser needs", () => {
+    // `forwardAddress` answers `localhost:12492` on the desktop, which is not
+    // a URL: opened verbatim it is a relative path or a search term.
+    expect(browsable("localhost:12492")).toBe("http://localhost:12492");
+    expect(browsable("127.0.0.1:8080")).toBe("http://127.0.0.1:8080");
+  });
+
+  it("leaves an absolute URL exactly as it found it", () => {
+    expect(browsable("http://localhost:9090/metrics")).toBe("http://localhost:9090/metrics");
+    // And never downgrades one: a proxy served over TLS stays over TLS.
+    expect(browsable("https://srelens.example/pf/7/")).toBe("https://srelens.example/pf/7/");
+    expect(browsable("HTTPS://srelens.example/pf/7/")).toBe("HTTPS://srelens.example/pf/7/");
+  });
+});
+
+describe("openExternal — the desktop", () => {
+  it("hands the URL to the Rust command, because the WebView opens nothing", async () => {
+    // `window.open` and `<a target="_blank">` are silent no-ops in a Tauri
+    // WebView (#348): wry's new-window delegate returns nil unless a handler
+    // is installed, and srelens installs none.
+    await openExternal("http://localhost:12492");
+    expect(invokeCommandMock).toHaveBeenCalledWith("open_external", {
+      url: "http://localhost:12492",
+    });
+    expect(opened).not.toHaveBeenCalled();
+  });
+
+  it("reports what the backend refused, rather than swallowing it", async () => {
+    invokeCommandMock.mockRejectedValue(new Error("no default browser"));
+    await expect(openExternal("http://localhost:12492")).rejects.toThrow(/no default browser/);
+  });
+});
+
+describe("openExternal — web mode", () => {
+  it("opens a tab, where the page really is in a browser", async () => {
+    platform.isTauri.mockReturnValue(false);
+    await openExternal(`${window.location.origin}/pf/7/`);
+    // The mechanism, not the string: jsdom's own origin contains "localhost",
+    // so a web assertion written against the address alone would still hold
+    // for a desktop-shaped answer.
+    expect(opened).toHaveBeenCalledWith(
+      `${window.location.origin}/pf/7/`,
+      "_blank",
+      "noopener,noreferrer",
+    );
+    expect(invokeCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("does not read `window.open`'s return value", async () => {
+    // With `noopener` the spec says the call returns null EVEN WHEN THE TAB
+    // OPENED. A null check here would reject every successful web open.
+    platform.isTauri.mockReturnValue(false);
+    opened.mockReturnValue(null);
+    await expect(openExternal("https://srelens.example/pf/7/")).resolves.toBeUndefined();
+  });
+});
+
+describe("openExternal — what it refuses", () => {
+  const refused = [
+    "javascript:alert(1)",
+    "file:///etc/passwd",
+    "data:text/html,<script>alert(1)</script>",
+    // The bare authority itself: `browsable` is the caller's job, and a
+    // command that quietly fixed it up would be a general "open any string".
+    "localhost:12492",
+    "/pf/7/",
+    "",
+  ];
+
+  for (const url of refused) {
+    it(`refuses ${JSON.stringify(url)} on both platforms`, async () => {
+      for (const desktop of [true, false]) {
+        vi.clearAllMocks();
+        platform.isTauri.mockReturnValue(desktop);
+        await expect(openExternal(url)).rejects.toThrow(/http/i);
+        expect(invokeCommandMock).not.toHaveBeenCalled();
+        expect(opened).not.toHaveBeenCalled();
+      }
+    });
+  }
+});

--- a/packages/core/src/lib/openExternal.ts
+++ b/packages/core/src/lib/openExternal.ts
@@ -1,0 +1,81 @@
+/**
+ * Opening an address in the reader's own browser.
+ *
+ * **`window.open` and `<a target="_blank">` do nothing at all on the desktop,
+ * and do it silently.** Tauri does not patch `window.open`, and wry's
+ * `WKUIDelegate` returns nil for a new window unless the app installs a
+ * new-window handler — srelens installs none. A link written the obvious way
+ * therefore ships looking live and is dead on click (#348); classic's
+ * `PortForwardsView` has that exact defect today.
+ *
+ * So the desktop goes through Rust, the same shape `saveTextFile` uses for the
+ * same reason (`<a download>` does not save in a WebView either): the
+ * `open_external` command hands the URL to `tauri-plugin-opener`, which is
+ * already a dependency and already registered. Calling the plugin from a Rust
+ * command needs no JS package and no capability permission — capabilities gate
+ * JS→plugin calls, not Rust→plugin ones.
+ *
+ * In web mode the page genuinely is in a browser, `window.open` genuinely
+ * works, and that is what it uses.
+ */
+
+import { invokeCommand } from "../transport/transport";
+import { isTauri } from "../transport/platform";
+
+/**
+ * An absolute http(s) URL — scheme, `//`, and an authority with something in
+ * it. Anchored, and the authority may not be empty, so `http://` on its own is
+ * not a URL either.
+ */
+const ABSOLUTE_HTTP = /^https?:\/\/[^/?#\s]+/i;
+
+/**
+ * Anything a URL cannot contain: space, tab, newline, and the control
+ * characters on either side of printable ASCII. Written as the printable
+ * set NEGATED, so the pattern itself holds no control character.
+ */
+const NOT_IN_A_URL = /[^\u0021-\u007E\u00A0-\uFFFF]/;
+
+/**
+ * An address as something a browser can be sent to.
+ *
+ * `forwardAddress` answers in two shapes — a bare `host:port` authority on the
+ * desktop and a full `http(s)://…/pf/<id>/` URL in web mode — because the
+ * places that PRINT it want the short form. A browser wants a scheme, and a
+ * bare `localhost:9090` handed to `window.open` resolves against the current
+ * page rather than opening the tunnel.
+ *
+ * Deliberately separate from {@link openExternal} rather than folded into it:
+ * an opener that quietly repaired whatever it was handed would be a general
+ * "open any string" path, and the one thing this must never become is a way
+ * for a value that arrived from a cluster to reach the OS.
+ */
+export function browsable(address: string): string {
+  return /^https?:\/\//i.test(address) ? address : `http://${address}`;
+}
+
+/**
+ * Open `url` in the reader's default browser.
+ *
+ * **Only ever pass an address srelens itself built** — a live forward's, via
+ * `forwardAddress` and {@link browsable}. Never a string that arrived from a
+ * cluster.
+ *
+ * Rejects anything that is not an absolute http(s) URL, on BOTH platforms, so
+ * the refusal is the same wherever it is read: the Rust command applies the
+ * same gate again, because that side is the one holding the handle to the OS.
+ * Rejections are thrown for the caller to word through `describeError`.
+ */
+export async function openExternal(url: string): Promise<void> {
+  if (!ABSOLUTE_HTTP.test(url) || NOT_IN_A_URL.test(url)) {
+    throw new Error("srelens only opens http and https addresses.");
+  }
+  if (isTauri()) {
+    await invokeCommand<null>("open_external", { url });
+    return;
+  }
+  // The return value is NOT checked: with `noopener` the spec has
+  // `window.open` return null even when the tab opened, so a null check here
+  // would report every successful open as a failure.
+  window.open(url, "_blank", "noopener,noreferrer");
+}

--- a/packages/core/src/lib/toolbox.ts
+++ b/packages/core/src/lib/toolbox.ts
@@ -10,6 +10,14 @@ export interface ToolStatus {
   version?: string | null;
   /** "managed" (srelens installed it) or "system". */
   source?: string | null;
+  /**
+   * The size in bytes of the file at `path`, following symlinks.
+   *
+   * Absent when the tool is not installed, and absent again when it is but the
+   * path cannot be stat'd — a dangling symlink, a permission error. Never `0`:
+   * a zero is a measurement, and neither of those was measured.
+   */
+  sizeBytes?: number | null;
 }
 
 export type RequirementKind = "kubectl" | "krew-plugin" | "external";

--- a/packages/ui-next/src/lib/kinds/descriptors.ts
+++ b/packages/ui-next/src/lib/kinds/descriptors.ts
@@ -113,7 +113,9 @@ const TYPED: Partial<Record<ResourceKind, KindDescriptor<ListRow>>> = {
     // only reads `phase`, a field `ListRow` does not promise.
     flagged: podFlagged as (row: ListRow) => boolean,
     // Task 10 ported `PodContainersBody` off classic's `ContainerCard` — the
-    // detail shell only offers the Containers tab where this is set.
+    // detail shell only offers the Containers tab where this is set. The
+    // pane's ports are also the way into a port forward, which is why `Pod`
+    // sets both this and `actions.forward`.
     panes: { containers: true },
   },
   deployments: {

--- a/packages/ui-next/src/lib/numbers.test.ts
+++ b/packages/ui-next/src/lib/numbers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { groupNumber } from "./numbers";
+import { formatBytes, groupNumber } from "./numbers";
 
 describe("groupNumber", () => {
   it("leaves anything under a thousand alone", () => {
@@ -37,5 +37,37 @@ describe("groupNumber", () => {
     expect(groupNumber(-120000)).toBe("-120 000");
     expect(groupNumber(-1200)).toBe("-1 200");
     expect(groupNumber(-1234567)).toBe("-1 234 567");
+  });
+});
+
+describe("formatBytes", () => {
+  it("writes the units the design writes", () => {
+    // §13 and §17 spell these decimal — `54.2 MB` is kubectl, which is ~54 MB
+    // decimal and ~51 MiB. So 1000, not 1024: the design is describing what a
+    // download says, not what a filesystem does.
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(512)).toBe("512 B");
+    expect(formatBytes(312_000)).toBe("312 KB");
+    expect(formatBytes(1_200_000)).toBe("1.2 MB");
+    expect(formatBytes(54_200_000)).toBe("54.2 MB");
+    expect(formatBytes(12_000_000)).toBe("12.0 MB");
+  });
+
+  it("keeps a whole megabyte's trailing zero, so a column stays in line", () => {
+    // `12.0 MB` not `12 MB`: these are tabular figures in a right-aligned
+    // column, and a row that drops its decimal shifts against its neighbours.
+    expect(formatBytes(12_000_000)).toBe("12.0 MB");
+    expect(formatBytes(2_000_000)).toBe("2.0 MB");
+  });
+
+  it("carries on past a gigabyte rather than reading as thousands of MB", () => {
+    expect(formatBytes(4_500_000_000)).toBe("4.5 GB");
+  });
+
+  it("says nothing about a reading it does not have", () => {
+    // A missing metric is never zero. A tool with no readable path has no
+    // size, and `0 B` would be a measurement nobody took.
+    expect(formatBytes(undefined)).toBe("");
+    expect(formatBytes(null)).toBe("");
   });
 });

--- a/packages/ui-next/src/lib/numbers.ts
+++ b/packages/ui-next/src/lib/numbers.ts
@@ -26,3 +26,27 @@
 export function groupNumber(n: number): string {
   return String(n).replace(/\B(?=(\d{3})+(?!\d))/g, " ");
 }
+
+/**
+ * A size the way the design writes one — `512 B`, `312 KB`, `54.2 MB`.
+ *
+ * Decimal, not binary. §17 gives kubectl `54.2 MB`, which is what a download
+ * page says about a binary that a filesystem would call 51 MiB — the design
+ * is describing the number people quote, not the one `ls` prints.
+ *
+ * Megabytes and gigabytes keep one decimal even when it is zero, because
+ * these sit in a right-aligned tabular column and a row that drops its
+ * decimal shifts against every row above it. Bytes and kilobytes have none:
+ * `312.0 KB` implies a precision the figure does not carry.
+ *
+ * A missing size renders as nothing at all. `0 B` is a measurement, and a
+ * tool whose path cannot be read has not been measured — the same rule that
+ * makes an absent metrics-server read "No reading" rather than 0%.
+ */
+export function formatBytes(bytes: number | null | undefined): string {
+  if (bytes == null) return "";
+  if (bytes < 1_000) return `${bytes} B`;
+  if (bytes < 1_000_000) return `${Math.round(bytes / 1_000)} KB`;
+  if (bytes < 1_000_000_000) return `${(bytes / 1_000_000).toFixed(1)} MB`;
+  return `${(bytes / 1_000_000_000).toFixed(1)} GB`;
+}

--- a/packages/ui-next/src/lib/routes.test.ts
+++ b/packages/ui-next/src/lib/routes.test.ts
@@ -5,8 +5,10 @@ import { AppLog } from "../screens/AppLog";
 import { Events } from "../screens/Events";
 import { ReleaseNotes } from "../screens/ReleaseNotes";
 import { Overview } from "../screens/Overview";
+import { Forwards } from "../screens/Forwards";
 import { Logs, logsRoute } from "../screens/Logs";
 import { ResourceDetailScreen, Resources } from "../screens/Resources";
+import { Toolbox } from "../screens/Toolbox";
 import { Workloads } from "../screens/Workloads";
 
 suite("isBuiltInKind", () => {
@@ -157,6 +159,28 @@ suite("screenFor", () => {
     expect(screenFor("/logs")).toBe(Logs);
     expect(screenFor(logsRoute("Deployment", "checkout", "checkout-api"))).toBe(Logs);
     expect(screenFor(logsRoute("Pod", "kube-system", "weird/name"))).toBe(Logs);
+  });
+
+  it("resolves /forwards to the port forwards screen", () => {
+    // The route has parsed to `kind: "forwards"` since the tab strip was
+    // built; without an entry here it rendered the Placeholder while the
+    // screen sat there finished.
+    expect(screenFor("/forwards")).toBe(Forwards);
+  });
+
+  it("resolves /toolbox to the toolbox screen", () => {
+    // App-scoped, not cluster-scoped: the managed tools are the machine's,
+    // not any one cluster's.
+    expect(screenFor("/toolbox")).toBe(Toolbox);
+  });
+
+  it("leaves the row menu's /resources/<name>/forward shape on the Placeholder", () => {
+    // `ResourceMenu.tsx` mints this shape and it carries neither a namespace
+    // nor a port — so it cannot name a tunnel, and routing it to Forwards
+    // would open the whole-cluster list under a title claiming one resource.
+    // Exactly the dead end `/resources/<name>/logs` is, pinned as a known one
+    // rather than papered over: reconciling the two shapes is its own step.
+    expect(screenFor("/resources/web-1/forward")).toBeNull();
   });
 
   it("leaves the row menu's older /resources/<name>/logs shape on the Placeholder", () => {

--- a/packages/ui-next/src/lib/routes.test.ts
+++ b/packages/ui-next/src/lib/routes.test.ts
@@ -72,10 +72,13 @@ suite("describe", () => {
     expect(describe("/k/Node/-/worker-1", "c")).toMatchObject({ title: "worker-1", kind: "resource", sub: "c" });
   });
 
-  it("titles the row menu's logs/shell/forward tabs distinctly from the bare resource tab and from each other", () => {
+  it("titles the /resources/<name>/logs|shell|forward shapes distinctly from the bare resource tab", () => {
     // Same prefix as the bare resource route, so without a distinct title and
     // kind for each suffix, opening a pod three ways (Open in new tab, Follow
     // logs, Open shell) produced three indistinguishable tabs in the strip.
+    // Only `shell` is still minted by the row menu; the other two are shapes a
+    // session persisted before Logs and Port forward got real front doors, and
+    // a restored tab still has to be able to name itself.
     expect(describe("/resources/web-1/logs", "c")).toMatchObject({ title: "web-1 · logs", kind: "logs", sub: "c" });
     expect(describe("/resources/web-1/shell", "c")).toMatchObject({
       title: "web-1 · shell",
@@ -174,12 +177,15 @@ suite("screenFor", () => {
     expect(screenFor("/toolbox")).toBe(Toolbox);
   });
 
-  it("leaves the row menu's /resources/<name>/forward shape on the Placeholder", () => {
-    // `ResourceMenu.tsx` mints this shape and it carries neither a namespace
-    // nor a port — so it cannot name a tunnel, and routing it to Forwards
-    // would open the whole-cluster list under a title claiming one resource.
-    // Exactly the dead end `/resources/<name>/logs` is, pinned as a known one
-    // rather than papered over: reconciling the two shapes is its own step.
+  it("leaves the retired /resources/<name>/forward shape on the Placeholder", () => {
+    // NOTHING MINTS THIS ANY MORE. `ResourceMenu.tsx`'s `Port forward` used to,
+    // and it carried neither a namespace nor a port — so it could not name a
+    // tunnel, and routing it to Forwards would have opened the whole-cluster
+    // list under a title claiming one resource. That entry opens §A.4's dialog
+    // on the row instead, so the only way to arrive here now is a tab
+    // persisted by an older session. It still parses (the strip has to be able
+    // to title a restored tab) and it still renders the Placeholder rather
+    // than the wrong screen.
     expect(screenFor("/resources/web-1/forward")).toBeNull();
   });
 

--- a/packages/ui-next/src/lib/routes.ts
+++ b/packages/ui-next/src/lib/routes.ts
@@ -83,11 +83,15 @@ export function describe(route: string, clusterName?: string): RouteInfo {
   if (route.startsWith("/resources/")) {
     const [, , rawName, suffix] = route.split("/");
     const name = decodeURIComponent(rawName ?? "");
-    // The row menu (`ResourceMenu.tsx`) mints `/resources/<name>/logs|shell|forward`
-    // alongside the bare `/resources/<name>` — same prefix, so without this a
-    // pod opened three ways ("Open in new tab", "Follow logs", "Open shell")
-    // got three tabs with the identical title and kind, indistinguishable in
-    // the strip.
+    // `/resources/<name>/logs|shell|forward` shares the bare
+    // `/resources/<name>` prefix — so without this a pod opened three ways
+    // ("Open in new tab", "Follow logs", "Open shell") got three tabs with the
+    // identical title and kind, indistinguishable in the strip.
+    //
+    // Only `shell` is still minted (`ResourceMenu.tsx`). Logs and Port forward
+    // have real front doors now — `logsRoute` and §A.4's dialog — and the
+    // other two shapes survive here only so a tab a previous session
+    // persisted can still name itself in the strip.
     if (suffix === "logs") return { route, title: `${name} · logs`, sub, kind: "logs" };
     if (suffix === "shell") return { route, title: `${name} · shell`, sub, kind: "terminal" };
     if (suffix === "forward") return { route, title: `${name} · forward`, sub, kind: "forwards" };

--- a/packages/ui-next/src/lib/routes.ts
+++ b/packages/ui-next/src/lib/routes.ts
@@ -3,10 +3,12 @@ import { K8S_KIND, RESOURCE_LABELS, type ResourceKind } from "@srelens/core";
 import { parseDetailRoute } from "./detailRoute";
 import { AppLog } from "../screens/AppLog";
 import { Events } from "../screens/Events";
+import { Forwards } from "../screens/Forwards";
 import { Logs, parseLogsRoute } from "../screens/Logs";
 import { Overview } from "../screens/Overview";
 import { ReleaseNotes } from "../screens/ReleaseNotes";
 import { ResourceDetailScreen, Resources } from "../screens/Resources";
+import { Toolbox } from "../screens/Toolbox";
 import { Workloads } from "../screens/Workloads";
 
 /**
@@ -137,6 +139,13 @@ const SCREENS: Record<string, ScreenComponent> = Object.assign(Object.create(nul
   // the same screen through `parseLogsRoute` in `screenFor` — one screen, two
   // shapes, because telling them apart is the screen's own job.
   "/logs": Logs,
+  // Cluster-scoped in the strip, but the screen lists every tunnel this
+  // process holds — the store behind it is module-level and does not partition
+  // by context, and a forward outlives the tab that started it.
+  "/forwards": Forwards,
+  // App-scoped: the managed kubectl, helm and krew are the machine's, and the
+  // exec-auth rail is the only part of it that looks at a context at all.
+  "/toolbox": Toolbox,
 });
 
 /**

--- a/packages/ui-next/src/screens/Forwards.test.tsx
+++ b/packages/ui-next/src/screens/Forwards.test.tsx
@@ -1,0 +1,413 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+/**
+ * The forwards store is core's — module-level, driven by the backend — so the
+ * rows are supplied at that boundary rather than by starting a real tunnel.
+ * The getter hands back the same array until it is swapped, which is what
+ * `useSyncExternalStore` requires of it.
+ *
+ * **`forwardAddress` and `toKubectl` stay REAL.** They are the two things this
+ * screen is forbidden from re-deriving, and a test that mocked them would
+ * assert the screen calls a stub rather than that a web reader gets an address
+ * they can actually open. The platform is flipped one layer lower instead —
+ * `@srelens/core/platform` resolves to the same module `forward.ts` imports
+ * `isTauri` from — so `forwardAddress` computes for real on both platforms.
+ * `describeError` stays real for the same reason.
+ */
+const platform = vi.hoisted(() => ({ isTauri: vi.fn(() => true) }));
+vi.mock("@srelens/core/platform", async (orig) => ({
+  ...(await orig<typeof import("@srelens/core/platform")>()),
+  isTauri: platform.isTauri,
+}));
+
+const store = vi.hoisted(() => ({
+  list: [] as unknown[],
+  listeners: new Set<() => void>(),
+}));
+const core = vi.hoisted(() => ({
+  stopPortForward: vi.fn(),
+  rehydrateForwards: vi.fn(),
+}));
+vi.mock("@srelens/core", async (orig) => ({
+  ...(await orig<typeof import("@srelens/core")>()),
+  getForwards: () => store.list,
+  subscribeForwards: (l: () => void) => {
+    store.listeners.add(l);
+    return () => store.listeners.delete(l);
+  },
+  ...core,
+}));
+
+import { type ActiveForward, toKubectl } from "@srelens/core";
+import { Forwards } from "./Forwards";
+
+const ROUTE = "/forwards";
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+
+/**
+ * §13's own four rows: four tunnels across three clusters, one of them
+ * flapping, and a Pod among the Services so the target prefix has something to
+ * be wrong about.
+ *
+ * The byte totals are chosen so the sum matches NO individual row — 54.5 MB is
+ * not 1.2, 44.1, 0.312 or 8.9 — because a traffic badge asserted against a
+ * single-row fixture passes whether it sums or merely echoes.
+ */
+function fixture(now: number): ActiveForward[] {
+  return [
+    {
+      id: 1,
+      context: "prod-eu",
+      namespace: "checkout",
+      kind: "Service",
+      name: "checkout-api",
+      localPort: 8080,
+      remotePort: 8080,
+      status: "active",
+      bytesMoved: 1_200_000,
+      startedAt: now - 18 * MINUTE,
+    },
+    {
+      id: 2,
+      context: "prod-eu",
+      namespace: "observability",
+      kind: "Service",
+      name: "prometheus",
+      localPort: 9090,
+      remotePort: 9090,
+      status: "active",
+      bytesMoved: 44_100_000,
+      startedAt: now - 2 * HOUR - 4 * MINUTE,
+    },
+    {
+      id: 3,
+      context: "prod-us",
+      namespace: "search",
+      kind: "Pod",
+      name: "search-indexer-0",
+      localPort: 6060,
+      remotePort: 6060,
+      status: "active",
+      bytesMoved: 312_000,
+      startedAt: now - 6 * MINUTE,
+    },
+    {
+      id: 4,
+      context: "staging",
+      namespace: "identity",
+      kind: "Service",
+      // The one row whose ports differ from each other, so a cell that printed
+      // the wrong one of the two would be caught rather than agree by accident.
+      name: "identity-gateway",
+      localPort: 8443,
+      remotePort: 443,
+      status: "reconnecting",
+      bytesMoved: 8_900_000,
+      startedAt: now - 51 * MINUTE,
+    },
+  ];
+}
+
+let NOW = 0;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  platform.isTauri.mockReturnValue(true);
+  core.stopPortForward.mockResolvedValue(undefined);
+  core.rehydrateForwards.mockResolvedValue(undefined);
+  NOW = Date.now();
+  store.list = fixture(NOW);
+  store.listeners.clear();
+});
+
+/** Swap the array the way the store does — a new identity, then a notify. */
+function setForwards(next: ActiveForward[]) {
+  act(() => {
+    store.list = next;
+    for (const l of store.listeners) l();
+  });
+}
+
+function open() {
+  return render(<Forwards route={ROUTE} />);
+}
+
+const headers = () =>
+  Array.from(document.querySelectorAll("thead th")).map((th) => th.textContent?.trim() ?? "");
+const rowFor = (name: string) => screen.getByText(name).closest("tr") as HTMLElement;
+const cells = (row: HTMLElement) =>
+  Array.from(row.querySelectorAll("td")).map((td) => td.textContent?.trim() ?? "");
+const cell = (row: HTMLElement, i: number) => row.querySelectorAll("td")[i] as HTMLElement;
+
+/** jsdom ships no clipboard at all, so there is nothing to spy on. */
+function stubClipboard() {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+  return writeText;
+}
+
+describe("Forwards — the table", () => {
+  it("draws §13's columns in §13's order", () => {
+    open();
+    expect(headers()).toEqual([
+      "Target",
+      "Cluster",
+      "Local",
+      "Remote",
+      "State",
+      "Traffic",
+      "Age",
+      "",
+    ]);
+  });
+
+  it("names the target the way kubectl does, over its namespace", () => {
+    open();
+    const svc = cell(rowFor("svc/checkout-api"), 0);
+    expect(within(svc).getByText("svc/checkout-api")).toBeTruthy();
+    expect(within(svc).getByText("checkout")).toBeTruthy();
+
+    // A Pod is `pod/`, not `svc/` — the prefix is read off the kind, not
+    // assumed from the commoner case.
+    const pod = cell(rowFor("pod/search-indexer-0"), 0);
+    expect(within(pod).getByText("pod/search-indexer-0")).toBeTruthy();
+    expect(within(pod).getByText("search")).toBeTruthy();
+  });
+
+  it("gives each row its cluster, ports, traffic and age", () => {
+    open();
+    expect(cells(rowFor("svc/identity-gateway")).slice(1, 7)).toEqual([
+      "staging",
+      // Desktop: the address really is the loopback port.
+      "localhost:8443",
+      ":443",
+      "Reconnecting",
+      "8.9 MB",
+      "51m",
+    ]);
+    expect(cells(rowFor("pod/search-indexer-0")).slice(5, 7)).toEqual(["312 KB", "6m"]);
+    expect(cells(rowFor("svc/prometheus")).slice(5, 7)).toEqual(["44.1 MB", "2h"]);
+  });
+
+  it("counts the tunnels and the clusters they cross", () => {
+    open();
+    // Four forwards, three distinct contexts — the count is over the contexts
+    // present, not over the rows.
+    expect(screen.getByText(/Active tunnels · 4 across 3 clusters/i)).toBeTruthy();
+  });
+
+  it("says a single cluster in the singular", () => {
+    setForwardsBeforeMount([fixture(NOW)[0]]);
+    open();
+    expect(screen.getByText(/Active tunnels · 1 across 1 cluster$/i)).toBeTruthy();
+  });
+
+  it("badges the traffic every tunnel has moved, added up", () => {
+    open();
+    // 1.2 + 44.1 + 0.312 + 8.9 MB. Deliberately not equal to any one row.
+    expect(screen.getByText("54.5 MB moved")).toBeTruthy();
+  });
+
+  it("re-renders when the store changes", () => {
+    open();
+    expect(screen.queryByText("svc/prometheus")).toBeTruthy();
+    setForwards(fixture(NOW).filter((f) => f.id !== 2));
+    expect(screen.queryByText("svc/prometheus")).toBeNull();
+    expect(screen.getByText(/Active tunnels · 3 across 3 clusters/i)).toBeTruthy();
+  });
+});
+
+describe("Forwards — the state word", () => {
+  it("reads a healthy tunnel plainly and a flapping one in the warning tone", () => {
+    open();
+    const active = cell(rowFor("svc/checkout-api"), 4).querySelector(".status") as HTMLElement;
+    expect(active.textContent).toBe("Active");
+    expect(active.getAttribute("data-kind")).toBe("success");
+    // §13's asymmetric colouring rule: a good state is not worth the ink.
+    expect(active.getAttribute("data-bad")).toBeNull();
+
+    const flapping = cell(rowFor("svc/identity-gateway"), 4).querySelector(
+      ".status",
+    ) as HTMLElement;
+    expect(flapping.textContent).toBe("Reconnecting");
+    expect(flapping.getAttribute("data-kind")).toBe("warning");
+    expect(flapping.getAttribute("data-bad")).toBe("true");
+  });
+
+  it("reads a forward that gave up as failed, in the severe tone", () => {
+    // §13 draws only `active` and `reconnecting` and says "else warn". `failed`
+    // is core's third status and it is not a warning — the tunnel is gone.
+    const failed = fixture(NOW).map((f) => (f.id === 4 ? { ...f, status: "failed" as const } : f));
+    setForwardsBeforeMount(failed);
+    open();
+    const gone = cell(rowFor("svc/identity-gateway"), 4).querySelector(".status") as HTMLElement;
+    expect(gone.textContent).toBe("Failed");
+    expect(gone.getAttribute("data-kind")).toBe("danger");
+    expect(gone.getAttribute("data-bad")).toBe("true");
+  });
+});
+
+describe("Forwards — the row's actions", () => {
+  it("copies the kubectl command core writes, not one assembled here", async () => {
+    const writeText = stubClipboard();
+    open();
+    await userEvent.click(
+      within(rowFor("svc/checkout-api")).getByRole("button", {
+        name: /copy kubectl command/i,
+      }),
+    );
+    expect(writeText).toHaveBeenCalledWith(
+      toKubectl({
+        action: "port-forward",
+        kind: "Service",
+        name: "checkout-api",
+        context: "prod-eu",
+        namespace: "checkout",
+        localPort: 8080,
+        remotePort: 8080,
+      }),
+    );
+    // And the command really is the port-forward one, so the assertion above
+    // is not two identical mistakes agreeing.
+    expect(writeText.mock.calls[0][0]).toContain("port-forward svc/checkout-api 8080:8080");
+  });
+
+  it("copies the loopback address on the desktop", async () => {
+    const writeText = stubClipboard();
+    open();
+    await userEvent.click(
+      within(rowFor("svc/checkout-api")).getByRole("button", { name: /copy address/i }),
+    );
+    expect(writeText).toHaveBeenCalledWith("localhost:8080");
+  });
+
+  it("copies the proxy address in the browser, where a container's loopback is unreachable", async () => {
+    // The whole reason §13's literal `http://localhost:<local>` is not shipped.
+    platform.isTauri.mockReturnValue(false);
+    const writeText = stubClipboard();
+    open();
+    await userEvent.click(
+      within(rowFor("svc/checkout-api")).getByRole("button", { name: /copy address/i }),
+    );
+    const copied = writeText.mock.calls[0][0] as string;
+    expect(copied).toBe(`${window.location.origin}/pf/1/`);
+    // Said twice on purpose: jsdom's own origin contains "localhost", so the
+    // equality above would still hold for a screen that had hardcoded the
+    // desktop answer at some other port. This is the property.
+    expect(copied).toContain("/pf/1/");
+    expect(copied).not.toBe("localhost:8080");
+  });
+
+  it("shows the reachable address in the Local cell, the same one it copies", async () => {
+    platform.isTauri.mockReturnValue(false);
+    const writeText = stubClipboard();
+    open();
+    const shown = cells(rowFor("svc/checkout-api"))[2];
+    expect(shown).toBe(`${window.location.origin}/pf/1/`);
+    await userEvent.click(
+      within(rowFor("svc/checkout-api")).getByRole("button", { name: /copy address/i }),
+    );
+    expect(writeText).toHaveBeenCalledWith(shown);
+  });
+
+  it("stops the forward the button is standing in, by id", async () => {
+    open();
+    await userEvent.click(
+      within(rowFor("svc/identity-gateway")).getByRole("button", { name: /stop forwarding/i }),
+    );
+    // Id 4, not the first row's 1 and not the row's index.
+    expect(core.stopPortForward).toHaveBeenCalledWith(4);
+    expect(core.stopPortForward).toHaveBeenCalledTimes(1);
+  });
+
+  it("says why a stop was refused, in words rather than in Rust", async () => {
+    core.stopPortForward.mockRejectedValue(
+      new Error("ApiError: Unauthorized (Status { metadata: Some(ListMeta { .. }) })"),
+    );
+    open();
+    await userEvent.click(
+      within(rowFor("svc/checkout-api")).getByRole("button", { name: /stop forwarding/i }),
+    );
+    await waitFor(() =>
+      expect(screen.getByText(/Could not stop svc\/checkout-api/i)).toBeTruthy(),
+    );
+    // `describeError`'s own classification, not the struct.
+    expect(screen.getByText(/rejected your credentials/i)).toBeTruthy();
+    const raw = document.querySelector('[data-slot="raw"]');
+    expect(raw?.textContent).toContain("ApiError");
+    // The struct appears ONLY inside the disclosure — never as the message.
+    const alert = screen.getByText(/rejected your credentials/i).closest("[data-tone]");
+    expect(alert?.querySelector('[data-slot="raw"]')).toBeTruthy();
+  });
+
+  it("puts no address, port or command in a title attribute", () => {
+    open();
+    const titles = Array.from(document.querySelectorAll("[title]")).map(
+      (el) => el.getAttribute("title") ?? "",
+    );
+    // The buttons DO carry names — that is what makes four rows of identical
+    // glyphs navigable. What they must not carry is a value: the rule
+    // `PairList` and `KV` were stripped for.
+    expect(titles.length).toBeGreaterThan(0);
+    const joined = titles.join("\n");
+    // The address, either platform's form.
+    expect(joined).not.toContain("localhost:");
+    expect(joined).not.toContain("/pf/");
+    // The command — its flags, its target and its port pair.
+    expect(joined).not.toContain("--context");
+    expect(joined).not.toContain("port-forward");
+    // Any port at all: the ports these four rows are bound to.
+    for (const port of ["8080", "9090", "6060", "8443", "443"]) {
+      expect(joined).not.toContain(port);
+    }
+  });
+});
+
+describe("Forwards — the screen around the table", () => {
+  it("adopts the forwards the backend is still running, once, on mount", async () => {
+    open();
+    // The web-mode leak this screen exists to close: the store is module-level
+    // JavaScript and a reload empties it while the server keeps forwarding.
+    await waitFor(() => expect(core.rehydrateForwards).toHaveBeenCalledTimes(1));
+  });
+
+  it("offers the New forward action from the header", () => {
+    open();
+    const actions = document.querySelector('[data-slot="screen-actions"]') as HTMLElement;
+    expect(within(actions).getByRole("button", { name: "New forward" })).toBeTruthy();
+  });
+
+  it("ships the empty state §13 defines and never renders", () => {
+    setForwardsBeforeMount([]);
+    open();
+    expect(screen.getByText("No port forwards")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Forward a service port to reach it from this machine. Nothing is exposed outside your laptop.",
+      ),
+    ).toBeTruthy();
+    // The way out of the emptiness, which is the whole point of the slot.
+    const empty = screen.getByText("No port forwards").closest("div")?.parentElement as HTMLElement;
+    expect(within(empty).getByRole("button", { name: "New forward" })).toBeTruthy();
+  });
+
+  it("heads nothing over an empty screen", () => {
+    setForwardsBeforeMount([]);
+    open();
+    // No pane head counting tunnels that are not there, and no badge claiming
+    // a total that nothing moved. (`headers()` is not the assertion: `Table`
+    // draws its own empty state over an empty `data`, so a screen that never
+    // branched at all would still report no columns here.)
+    expect(document.querySelector(".pane-head")).toBeNull();
+    expect(screen.queryByText(/moved/)).toBeNull();
+  });
+});
+
+/** Seed the store before the screen mounts, for the cases about first paint. */
+function setForwardsBeforeMount(next: ActiveForward[]) {
+  store.list = next;
+}

--- a/packages/ui-next/src/screens/Forwards.test.tsx
+++ b/packages/ui-next/src/screens/Forwards.test.tsx
@@ -202,6 +202,23 @@ describe("Forwards — the table", () => {
     expect(within(pod).getByText("search")).toBeTruthy();
   });
 
+  it("keeps a long context name inside its own cell", () => {
+    // A kubeconfig context is user-chosen and routinely long. Seen against a
+    // real cluster, `m01-1786968575165/kubernetes-admin@cluster.local` drew
+    // straight over the Local cell beside it and both were unreadable.
+    //
+    // `truncate` sets `overflow: hidden`, which does nothing to an inline box,
+    // so the cell has to be a block for the ellipsis to happen at all. jsdom
+    // lays nothing out, so this asserts the mechanism rather than the pixels —
+    // the third time column overflow has shipped on this project, and every
+    // time it was invisible to the suite.
+    render(<Forwards route="/forwards" />);
+    const cluster = rowFor("svc/checkout-api").querySelectorAll("td")[1];
+    const inner = cluster.querySelector("span");
+    expect(inner?.className).toContain("truncate");
+    expect(inner?.className).toContain("block");
+  });
+
   it("gives each row its cluster, ports, traffic and age", () => {
     open();
     expect(cells(rowFor("svc/identity-gateway")).slice(1, 7)).toEqual([

--- a/packages/ui-next/src/screens/Forwards.test.tsx
+++ b/packages/ui-next/src/screens/Forwards.test.tsx
@@ -29,6 +29,7 @@ const store = vi.hoisted(() => ({
 const core = vi.hoisted(() => ({
   stopPortForward: vi.fn(),
   rehydrateForwards: vi.fn(),
+  openExternal: vi.fn(),
   // Only so the mounted dialog has something to list. What it does with them
   // is `NewForwardDialog.test.tsx`'s business; this file only cares that both
   // `New forward` buttons reach it.
@@ -119,12 +120,18 @@ function fixture(now: number): ActiveForward[] {
 }
 
 let NOW = 0;
+let windowOpen: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   vi.clearAllMocks();
   platform.isTauri.mockReturnValue(true);
   core.stopPortForward.mockResolvedValue(undefined);
   core.rehydrateForwards.mockResolvedValue(undefined);
+  core.openExternal.mockResolvedValue(undefined);
+  // A spy only so it can be asserted UNREACHED: `window.open` opens nothing at
+  // all inside a Tauri WebView, and does it silently (#348).
+  windowOpen = vi.fn();
+  Object.defineProperty(window, "open", { value: windowOpen, configurable: true, writable: true });
   core.listNamespaces.mockResolvedValue({ namespaces: ["checkout"] });
   core.listServices.mockResolvedValue({ services: [] });
   core.listPods.mockResolvedValue({ pods: [] });
@@ -471,6 +478,87 @@ describe("Forwards — the screen around the table", () => {
     // branched at all would still report no columns here.)
     expect(document.querySelector(".pane-head")).toBeNull();
     expect(screen.queryByText(/moved/)).toBeNull();
+  });
+});
+
+describe("Forwards — the Local cell opens", () => {
+  const localCell = (target: string) => cell(rowFor(target), 2);
+
+  it("is a control, not a label", () => {
+    open();
+    // A span with an onClick would satisfy "the address is on screen and
+    // clicking it works" and would be reachable by neither Tab nor Enter.
+    // Named by the address it shows, the way a link is named by its text —
+    // `getByRole`'s name is the computed accessible name, not the markup.
+    const button = within(localCell("svc/checkout-api")).getByRole("button", {
+      name: "localhost:8080",
+    });
+    expect(button.tagName).toBe("BUTTON");
+  });
+
+  it("keeps the column's mono face, and keeps a long address inside the cell", () => {
+    platform.isTauri.mockReturnValue(false);
+    open();
+    // §13's Local column is a `code` cell. Making it a control must not cost
+    // it the face that makes a host:port readable.
+    const mono = localCell("svc/checkout-api").querySelector(".code") as HTMLElement;
+    expect(mono.textContent).toBe(`${window.location.origin}/pf/1/`);
+    // A proxy URL is long and the button is a flex box, whose items refuse to
+    // shrink below their content without `min-w-0`. jsdom lays nothing out, so
+    // this asserts the mechanism — the same way the Cluster cell's does, after
+    // column overflow shipped unnoticed three times on this project.
+    expect(mono.className).toContain("truncate");
+    expect(mono.className).toContain("min-w-0");
+  });
+
+  it("opens the desktop address with the scheme a browser needs", async () => {
+    open();
+    await userEvent.click(within(localCell("svc/prometheus")).getByRole("button"));
+    await waitFor(() => expect(core.openExternal).toHaveBeenCalledTimes(1));
+    // `forwardAddress` answers a bare `localhost:9090` here. A bare authority
+    // is NOT a URL: opened verbatim it resolves against the current page.
+    expect(core.openExternal).toHaveBeenCalledWith("http://localhost:9090");
+    // And it goes through core rather than the WebView's own dead `window.open`.
+    expect(windowOpen).not.toHaveBeenCalled();
+  });
+
+  it("opens the proxy address in web mode, not a loopback the browser cannot reach", async () => {
+    platform.isTauri.mockReturnValue(false);
+    open();
+    await userEvent.click(within(localCell("svc/checkout-api")).getByRole("button"));
+    await waitFor(() => expect(core.openExternal).toHaveBeenCalledTimes(1));
+    const url = core.openExternal.mock.calls[0][0] as string;
+    expect(url).toBe(`${window.location.origin}/pf/1/`);
+    // Said twice on purpose: jsdom's own origin contains "localhost", so the
+    // equality above would still hold for a screen that had hardcoded the
+    // desktop answer at some other port. This is the property.
+    expect(url).toContain("/pf/1/");
+    expect(url).not.toContain("localhost:8080");
+  });
+
+  it("opens the address the row it was clicked in is showing", async () => {
+    open();
+    await userEvent.click(within(localCell("svc/identity-gateway")).getByRole("button"));
+    await waitFor(() => expect(core.openExternal).toHaveBeenCalledTimes(1));
+    // The LOCAL port, 8443 — not the row's remote 443 and not the first row's.
+    expect(core.openExternal).toHaveBeenCalledWith("http://localhost:8443");
+  });
+
+  it("says why an open was refused, in words rather than in Rust", async () => {
+    core.openExternal.mockRejectedValue(
+      new Error("handler error: No such file or directory (os error 2)"),
+    );
+    open();
+    await userEvent.click(within(localCell("svc/checkout-api")).getByRole("button"));
+    const title = await screen.findByText(/Could not open svc\/checkout-api/i);
+    const alert = title.closest("[data-tone]") as HTMLElement;
+    // The screen's own error surface, in its severe tone — not a raw backend
+    // string dropped into a cell.
+    expect(alert.getAttribute("data-tone")).toBe("sev");
+    // `describeError`'s cleaning: `handler error:` is `CapabilityError`'s
+    // Display prefix and is news to nobody.
+    expect(alert.textContent).toContain("No such file or directory");
+    expect(alert.textContent).not.toContain("handler error:");
   });
 });
 

--- a/packages/ui-next/src/screens/Forwards.test.tsx
+++ b/packages/ui-next/src/screens/Forwards.test.tsx
@@ -29,6 +29,12 @@ const store = vi.hoisted(() => ({
 const core = vi.hoisted(() => ({
   stopPortForward: vi.fn(),
   rehydrateForwards: vi.fn(),
+  // Only so the mounted dialog has something to list. What it does with them
+  // is `NewForwardDialog.test.tsx`'s business; this file only cares that both
+  // `New forward` buttons reach it.
+  listNamespaces: vi.fn(),
+  listServices: vi.fn(),
+  listPods: vi.fn(),
 }));
 vi.mock("@srelens/core", async (orig) => ({
   ...(await orig<typeof import("@srelens/core")>()),
@@ -40,7 +46,7 @@ vi.mock("@srelens/core", async (orig) => ({
   ...core,
 }));
 
-import { type ActiveForward, toKubectl } from "@srelens/core";
+import { type ActiveForward, kindToForwardTarget, toKubectl } from "@srelens/core";
 import { Forwards } from "./Forwards";
 
 const ROUTE = "/forwards";
@@ -119,6 +125,9 @@ beforeEach(() => {
   platform.isTauri.mockReturnValue(true);
   core.stopPortForward.mockResolvedValue(undefined);
   core.rehydrateForwards.mockResolvedValue(undefined);
+  core.listNamespaces.mockResolvedValue({ namespaces: ["checkout"] });
+  core.listServices.mockResolvedValue({ services: [] });
+  core.listPods.mockResolvedValue({ pods: [] });
   NOW = Date.now();
   store.list = fixture(NOW);
   store.listeners.clear();
@@ -163,6 +172,21 @@ describe("Forwards — the table", () => {
       "Age",
       "",
     ]);
+  });
+
+  it("names the target through core's mapping, not a second copy of it", () => {
+    open();
+    // The mapping this screen used to keep its own `{ Service: "svc" }` table
+    // for. Read from core so a drift between the cell and the copied command
+    // is not possible rather than merely unlikely.
+    expect(kindToForwardTarget("Service")).toBe("svc");
+    expect(kindToForwardTarget("Pod")).toBe("pod");
+    expect(cells(rowFor("svc/checkout-api"))[0]).toContain(
+      `${kindToForwardTarget("Service")}/checkout-api`,
+    );
+    expect(cells(rowFor("pod/search-indexer-0"))[0]).toContain(
+      `${kindToForwardTarget("Pod")}/search-indexer-0`,
+    );
   });
 
   it("names the target the way kubectl does, over its namespace", () => {
@@ -379,6 +403,32 @@ describe("Forwards — the screen around the table", () => {
     open();
     const actions = document.querySelector('[data-slot="screen-actions"]') as HTMLElement;
     expect(within(actions).getByRole("button", { name: "New forward" })).toBeTruthy();
+  });
+
+  it("opens §A.4's dialog from the header action", async () => {
+    open();
+    expect(screen.queryByRole("dialog")).toBeNull();
+    const actions = document.querySelector('[data-slot="screen-actions"]') as HTMLElement;
+    await userEvent.click(within(actions).getByRole("button", { name: "New forward" }));
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("New port forward")).toBeTruthy();
+    await userEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+  });
+
+  it("opens the SAME dialog from the empty state's way out", async () => {
+    // The two buttons share one handler, and the dialog is mounted beside the
+    // body rather than inside either branch — so a reader with no tunnels gets
+    // the dialog too. An assertion on the header alone would pass either way.
+    setForwardsBeforeMount([]);
+    open();
+    const empty = screen.getByText("No port forwards").closest("div")
+      ?.parentElement as HTMLElement;
+    await userEvent.click(within(empty).getByRole("button", { name: "New forward" }));
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("New port forward")).toBeTruthy();
+    // And the emptiness is still behind it.
+    expect(screen.getByText("No port forwards")).toBeTruthy();
   });
 
   it("ships the empty state §13 defines and never renders", () => {

--- a/packages/ui-next/src/screens/Forwards.test.tsx
+++ b/packages/ui-next/src/screens/Forwards.test.tsx
@@ -209,6 +209,26 @@ describe("Forwards — the table", () => {
     expect(within(pod).getByText("search")).toBeTruthy();
   });
 
+  it("stops offering to open a dead tunnel's address", async () => {
+    // The address of a tunnel that has given up answers nothing. Leaving it
+    // pressable is the #348 shape this branch keeps removing — a control that
+    // looks like it works and does not — and here it is worse than a no-op,
+    // because it would raise a browser tab onto a refused connection.
+    open();
+    expect(screen.getByRole("button", { name: "localhost:8080" })).toBeTruthy();
+
+    store.list = fixture(NOW).map((f) =>
+      f.id === 1 ? { ...f, status: "failed" as const } : f,
+    );
+    for (const l of store.listeners) l();
+
+    await waitFor(() => expect(screen.queryByRole("button", { name: "localhost:8080" })).toBeNull());
+    // Still readable — the reader has to see WHICH tunnel died.
+    expect(screen.getByText("localhost:8080")).toBeTruthy();
+    // And the live ones are untouched.
+    expect(screen.getByRole("button", { name: "localhost:9090" })).toBeTruthy();
+  });
+
   it("keeps a long context name inside its own cell", () => {
     // A kubeconfig context is user-chosen and routinely long. Seen against a
     // real cluster, `m01-1786968575165/kubernetes-admin@cluster.local` drew

--- a/packages/ui-next/src/screens/Forwards.test.tsx
+++ b/packages/ui-next/src/screens/Forwards.test.tsx
@@ -299,6 +299,136 @@ describe("Forwards — the state word", () => {
   });
 });
 
+/**
+ * A tunnel that gave up, as the backend leaves it: `failed`, with the raw
+ * string the cluster actually said attached. Row 4, so the fixture around it
+ * still has three live tunnels across two clusters to be counted apart from.
+ */
+const GAVE_UP = "ApiError: Unauthorized (Status { metadata: Some(ListMeta { .. }) })";
+
+function withDeadGateway(now: number): ActiveForward[] {
+  return fixture(now).map((f) =>
+    f.id === 4 ? { ...f, status: "failed" as const, error: GAVE_UP } : f,
+  );
+}
+
+describe("Forwards — a tunnel that died on its own", () => {
+  it("says why, in words rather than in Rust", () => {
+    setForwardsBeforeMount(withDeadGateway(NOW));
+    open();
+    const state = cell(rowFor("svc/identity-gateway"), 4);
+    expect(within(state).getByText("Failed")).toBeTruthy();
+    // `describeError`'s classification, not the struct the cluster sent.
+    expect(within(state).getByText("Not authorized")).toBeTruthy();
+    // The struct is offered, folded away — never printed at the reader and
+    // never in a title attribute, which is the rule a Secret leaked through.
+    const raw = state.querySelector('[data-slot="raw"]');
+    expect(raw?.textContent).toContain("ApiError");
+    // Said as "nowhere but inside the disclosure", because `textContent`
+    // reads a closed `details` too: a cell that printed the struct beside
+    // the word would satisfy any weaker form of this.
+    const outsideTheDisclosure = state.cloneNode(true) as HTMLElement;
+    outsideTheDisclosure.querySelector('[data-slot="raw"]')?.remove();
+    expect(outsideTheDisclosure.textContent).toContain("Not authorized");
+    expect(outsideTheDisclosure.textContent).not.toContain("ApiError");
+    expect(outsideTheDisclosure.textContent).not.toContain("Status { metadata");
+  });
+
+  it("says nothing about a tunnel that is merely flapping", () => {
+    // Row 4 is `reconnecting`, and it HAS a reason: the backend sends its
+    // error with every retry, and the store keeps the latest. Saying it
+    // matters — a fixture with no error on this row passes for a screen that
+    // prints the reason under any row that has one, which is a tunnel that
+    // is coming back captioned as one that is gone.
+    setForwardsBeforeMount(
+      fixture(NOW).map((f) => (f.id === 4 ? { ...f, error: "connection reset by peer" } : f)),
+    );
+    open();
+    const state = cell(rowFor("svc/identity-gateway"), 4);
+    expect(state.querySelector('[data-slot="raw"]')).toBeNull();
+    expect(state.textContent).toBe("Reconnecting");
+  });
+
+  it("keeps a reasonless failure to the one word it has", () => {
+    // `forward:closed` can arrive with nothing attached. "Failed" alone is
+    // the whole of what is known, and inventing a sentence under it would be
+    // worse than the silence.
+    setForwardsBeforeMount(
+      fixture(NOW).map((f) => (f.id === 4 ? { ...f, status: "failed" as const } : f)),
+    );
+    open();
+    const state = cell(rowFor("svc/identity-gateway"), 4);
+    expect(state.textContent).toBe("Failed");
+    expect(state.querySelector('[data-slot="raw"]')).toBeNull();
+  });
+
+  it("offers a dismissal, where a live tunnel is offered a stop", async () => {
+    setForwardsBeforeMount(withDeadGateway(NOW));
+    open();
+    const dead = within(rowFor("svc/identity-gateway"));
+    // Nothing left to stop: the tunnel already stopped itself.
+    expect(dead.queryByRole("button", { name: /stop forwarding/i })).toBeNull();
+    expect(dead.getByRole("button", { name: /dismiss/i })).toBeTruthy();
+
+    const live = within(rowFor("svc/checkout-api"));
+    expect(live.getByRole("button", { name: /stop forwarding/i })).toBeTruthy();
+    expect(live.queryByRole("button", { name: /dismiss/i })).toBeNull();
+  });
+
+  it("dismisses by id, telling the backend to forget the tunnel", async () => {
+    setForwardsBeforeMount(withDeadGateway(NOW));
+    open();
+    await userEvent.click(
+      within(rowFor("svc/identity-gateway")).getByRole("button", { name: /dismiss/i }),
+    );
+    // `stopPortForward`, not a local delete: the manager holds a gave-up
+    // forward until `stop` is called, and a set of dropped ids in the page
+    // cannot survive the reload that would raise the row again.
+    expect(core.stopPortForward).toHaveBeenCalledWith(4);
+    expect(core.stopPortForward).toHaveBeenCalledTimes(1);
+  });
+
+  it("says why a dismissal was refused, in words rather than in Rust", async () => {
+    core.stopPortForward.mockRejectedValue(new Error("handler error: no such forward"));
+    setForwardsBeforeMount(withDeadGateway(NOW));
+    open();
+    await userEvent.click(
+      within(rowFor("svc/identity-gateway")).getByRole("button", { name: /dismiss/i }),
+    );
+    const title = await screen.findByText(/Could not dismiss svc\/identity-gateway/i);
+    const alert = title.closest("[data-tone]") as HTMLElement;
+    expect(alert.textContent).toContain("no such forward");
+    expect(alert.textContent).not.toContain("handler error:");
+  });
+
+  it("counts the live tunnels, and the dead one apart from them", () => {
+    setForwardsBeforeMount(withDeadGateway(NOW));
+    open();
+    // Four rows, three live, across TWO live clusters — staging's only
+    // tunnel is the dead one. Every number here differs from the number a
+    // count over all four rows would give.
+    expect(screen.getByText(/Active tunnels · 3 across 2 clusters · 1 failed/i)).toBeTruthy();
+    expect(document.querySelectorAll("tbody tr")).toHaveLength(4);
+  });
+
+  it("keeps the dead tunnel's traffic in the total it moved", () => {
+    setForwardsBeforeMount(withDeadGateway(NOW));
+    open();
+    // 8.9 MB really crossed that tunnel before it died. A badge that dropped
+    // it would read as data loss on the way to reading as a smaller total.
+    expect(screen.getByText("54.5 MB moved")).toBeTruthy();
+  });
+
+  it("puts the reason in no title attribute", () => {
+    setForwardsBeforeMount(withDeadGateway(NOW));
+    open();
+    const titles = Array.from(document.querySelectorAll("[title]")).map(
+      (el) => el.getAttribute("title") ?? "",
+    );
+    expect(titles.join("\n")).not.toContain("ApiError");
+  });
+});
+
 describe("Forwards — the row's actions", () => {
   it("copies the kubectl command core writes, not one assembled here", async () => {
     const writeText = stubClipboard();

--- a/packages/ui-next/src/screens/Forwards.tsx
+++ b/packages/ui-next/src/screens/Forwards.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import {
   ageFromTimestamp,
+  browsable,
   copyKubectlCommand,
   forwardAddress,
   getForwards,
   kindToForwardTarget,
   notify,
+  openExternal,
   plural,
   rehydrateForwards,
   stopPortForward,
@@ -163,8 +165,13 @@ export function Forwards(_props: { route: string }) {
     return () => clearInterval(tick);
   }, []);
 
-  /** The last stop that was refused, and which tunnel it was about. */
-  const [stopFailure, setStopFailure] = useState<{ target: string; error: unknown } | null>(null);
+  /**
+   * The last thing this screen was refused, in the words the reader gets.
+   *
+   * One slot rather than two: a stop and an open cannot both be the most
+   * recent, and a second banner over a table is a row of the table gone.
+   */
+  const [failure, setFailure] = useState<{ title: string; error: unknown } | null>(null);
 
   const rows = useMemo<ForwardRow[]>(
     () =>
@@ -217,11 +224,30 @@ export function Forwards(_props: { route: string }) {
   );
 
   async function stop(row: ForwardRow) {
-    setStopFailure(null);
+    setFailure(null);
     try {
       await stopPortForward(row.id);
     } catch (e) {
-      setStopFailure({ target: row.target, error: e });
+      setFailure({ title: `Could not stop ${row.target}`, error: e });
+    }
+  }
+
+  /**
+   * Open a tunnel in the reader's own browser.
+   *
+   * `openExternal`, never an `<a target="_blank">` and never `window.open`:
+   * both of those are silent no-ops inside the Tauri WebView (#348), which is
+   * exactly the shape of dead link this migration keeps deleting. The address
+   * is the row's own — the one `forwardAddress` produced and the cell prints —
+   * through `browsable`, because the desktop's answer is a bare authority and
+   * a bare authority is not a URL.
+   */
+  async function openAddress(row: ForwardRow) {
+    setFailure(null);
+    try {
+      await openExternal(browsable(row.address));
+    } catch (e) {
+      setFailure({ title: `Could not open ${row.target}`, error: e });
     }
   }
 
@@ -237,7 +263,9 @@ export function Forwards(_props: { route: string }) {
   }
 
   const columns: Column<ForwardRow>[] = [
-    ...COLUMNS,
+    // `void`, the way every other handler on this screen discards its
+    // promise: the failure is already the banner's business.
+    ...forwardColumns((row) => void openAddress(row)),
     {
       // §13's unnamed trailing column. Three compact controls rather than the
       // inline `CopyCommand` §13 names: that component prints the whole command
@@ -291,13 +319,9 @@ export function Forwards(_props: { route: string }) {
           onClose={() => setNewForwardOpen(false)}
         />
       )}
-      {stopFailure && (
+      {failure && (
         <div className="p-3 pb-0">
-          <FailureAlert
-            tone="sev"
-            title={`Could not stop ${stopFailure.target}`}
-            error={stopFailure.error}
-          />
+          <FailureAlert tone="sev" title={failure.title} error={failure.error} />
         </div>
       )}
       {rows.length === 0 ? (
@@ -330,79 +354,111 @@ export function Forwards(_props: { route: string }) {
 /**
  * §13's columns, in §13's order.
  *
- * Module-level and free of handlers so the sort and filter values are read off
- * the same strings the reader sees — a filter for `staging` that matched
- * nothing because the cell was built from a different field is the sort of
- * mismatch nobody reports. The two numeric columns are the exception and say
- * why at each one.
+ * Module-level so the sort and filter values are read off the same strings the
+ * reader sees — a filter for `staging` that matched nothing because the cell
+ * was built from a different field is the sort of mismatch nobody reports. The
+ * two numeric columns are the exception and say why at each one.
+ *
+ * It takes ONE handler, for the one cell that does something: the Local
+ * address opens. A factory rather than a spliced-in column, so the order stays
+ * §13's order in one readable list rather than depending on an index.
  */
-const COLUMNS: Column<ForwardRow>[] = [
-  {
-    key: "target",
-    header: "Target",
-    // Both lines are searchable: a reader looking for `checkout` means either
-    // the service or the namespace and should not have to know which.
-    getValue: (row) => `${row.target} ${row.namespace}`,
-    render: (row) => (
-      <div className="flex min-w-0 flex-col">
-        <span className="truncate font-medium">{row.target}</span>
-        <span className="path truncate">{row.namespace}</span>
-      </div>
-    ),
-  },
-  {
-    key: "cluster",
-    header: "Cluster",
-    // `block`, not a bare span: `truncate` sets `overflow: hidden`, which does
-    // nothing to an inline box. A kubeconfig context name is user-chosen and
-    // routinely long — `m01-1786968575165/kubernetes-admin@cluster.local` —
-    // and without this it draws straight over the Local cell beside it.
-    render: (row) => <span className="path block truncate">{row.cluster}</span>,
-  },
-  {
-    key: "address",
-    header: "Local",
-    render: (row) => <span className="code block truncate">{row.address}</span>,
-  },
-  {
-    key: "remote",
-    header: "Remote",
-    // Sorted as the number it is: `:443` beside `:8080` and `:9090` orders
-    // 443, 8080, 9090 numerically and "443", "8080", "9090" the same way by
-    // luck — `:6060` and `:443` do not.
-    getSortValue: (row) => Number(row.remote.slice(1)),
-    render: (row) => <span className="tabular-nums">{row.remote}</span>,
-  },
-  {
-    key: "state",
-    header: "State",
-    // Sorted and searched on the word the reader can see, not on the internal
-    // status behind it.
-    getValue: (row) => FORWARD_VERDICT[row.status].word,
-    render: (row) => (
-      <StatusPill
-        status={FORWARD_VERDICT[row.status].word}
-        kind={FORWARD_VERDICT[row.status].kind}
-        tinted
-      />
-    ),
-  },
-  {
-    key: "traffic",
-    header: "Traffic",
-    align: "end",
-    // The bytes, not the words: `312 KB` sorts above `44.1 MB` as text.
-    getSortValue: (row) => row.bytesMoved,
-    render: (row) => <span className="tabular-nums">{row.traffic}</span>,
-  },
-  {
-    key: "age",
-    header: "Age",
-    align: "end",
-    // The start stamp, not the compact age: `2h` sorts below `51m` as text,
-    // which is the defect `ageSeconds` exists for — and this row has the
-    // original millis, so it does not need to parse its own words back.
-    getSortValue: (row) => row.startedAt,
-    render: (row) => <span className="tabular-nums text-muted">{row.age}</span>,
-  },
-];
+function forwardColumns(openAddress: (row: ForwardRow) => void): Column<ForwardRow>[] {
+  return [
+    {
+      key: "target",
+      header: "Target",
+      // Both lines are searchable: a reader looking for `checkout` means either
+      // the service or the namespace and should not have to know which.
+      getValue: (row) => `${row.target} ${row.namespace}`,
+      render: (row) => (
+        <div className="flex min-w-0 flex-col">
+          <span className="truncate font-medium">{row.target}</span>
+          <span className="path truncate">{row.namespace}</span>
+        </div>
+      ),
+    },
+    {
+      key: "cluster",
+      header: "Cluster",
+      // `block`, not a bare span: `truncate` sets `overflow: hidden`, which does
+      // nothing to an inline box. A kubeconfig context name is user-chosen and
+      // routinely long — `m01-1786968575165/kubernetes-admin@cluster.local` —
+      // and without this it draws straight over the Local cell beside it.
+      render: (row) => <span className="path block truncate">{row.cluster}</span>,
+    },
+    {
+      key: "address",
+      header: "Local",
+      /**
+       * The one cell that is a control.
+       *
+       * A `Button`, not an anchor: `<a target="_blank">` opens NOTHING in the
+       * Tauri WebView and says nothing about it (#348) — classic's
+       * `PortForwardsView` ships that exact dead link today. The kit has no link
+       * variant, and `ghost` is the borderless one, so the cell keeps the column's
+       * `code` face and reads as text that can be pressed rather than as a box
+       * around every row.
+       *
+       * Its accessible name is the address it shows, which is what a link's would
+       * be. No `title`: the address is already on screen, and a value in a title
+       * is the rule a Secret once leaked through.
+       */
+      render: (row) => (
+        <Button
+          variant="ghost"
+          size="xs"
+          className="-mx-1 max-w-full text-[0.8125rem] text-accent"
+          onClick={() => openAddress(row)}
+        >
+          {/* `min-w-0` as well as `truncate`: a flex item's implicit
+              `min-width: auto` refuses to shrink below its content, so without
+              it a long proxy URL widens the button instead of ellipsing —
+              invisible in jsdom, which is why the class is asserted. */}
+          <span className="code min-w-0 truncate">{row.address}</span>
+        </Button>
+      ),
+    },
+    {
+      key: "remote",
+      header: "Remote",
+      // Sorted as the number it is: `:443` beside `:8080` and `:9090` orders
+      // 443, 8080, 9090 numerically and "443", "8080", "9090" the same way by
+      // luck — `:6060` and `:443` do not.
+      getSortValue: (row) => Number(row.remote.slice(1)),
+      render: (row) => <span className="tabular-nums">{row.remote}</span>,
+    },
+    {
+      key: "state",
+      header: "State",
+      // Sorted and searched on the word the reader can see, not on the internal
+      // status behind it.
+      getValue: (row) => FORWARD_VERDICT[row.status].word,
+      render: (row) => (
+        <StatusPill
+          status={FORWARD_VERDICT[row.status].word}
+          kind={FORWARD_VERDICT[row.status].kind}
+          tinted
+        />
+      ),
+    },
+    {
+      key: "traffic",
+      header: "Traffic",
+      align: "end",
+      // The bytes, not the words: `312 KB` sorts above `44.1 MB` as text.
+      getSortValue: (row) => row.bytesMoved,
+      render: (row) => <span className="tabular-nums">{row.traffic}</span>,
+    },
+    {
+      key: "age",
+      header: "Age",
+      align: "end",
+      // The start stamp, not the compact age: `2h` sorts below `51m` as text,
+      // which is the defect `ageSeconds` exists for — and this row has the
+      // original millis, so it does not need to parse its own words back.
+      getSortValue: (row) => row.startedAt,
+      render: (row) => <span className="tabular-nums text-muted">{row.age}</span>,
+    },
+  ];
+}

--- a/packages/ui-next/src/screens/Forwards.tsx
+++ b/packages/ui-next/src/screens/Forwards.tsx
@@ -1,0 +1,397 @@
+import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
+import {
+  ageFromTimestamp,
+  copyKubectlCommand,
+  forwardAddress,
+  getForwards,
+  notify,
+  plural,
+  rehydrateForwards,
+  stopPortForward,
+  subscribeForwards,
+  toKubectl,
+  type ActiveForward,
+} from "@srelens/core";
+import {
+  Badge,
+  Button,
+  EmptyState,
+  IconButton,
+  Screen,
+  StatusPill,
+  Table,
+  type Column,
+  type StatusKind,
+} from "@srelens/ui-kit";
+import { FailureAlert } from "../lib/errorCopy";
+import { Icons } from "../lib/icons";
+import { formatBytes } from "../lib/numbers";
+
+/**
+ * THE ONE HAND-PAIRED WORD/TONE TABLE ON THIS SCREEN, AND IT IS MARKED BECAUSE
+ * IT SHOULD NOT HAVE TO EXIST.
+ *
+ * `packages/core` has no verdict for a port-forward's status. It has one for a
+ * log stream's connection (`logConnectionStatus`) and two for Kubernetes
+ * resources (`k8sStatus`, `k8sHealth`), and a tunnel is none of those three:
+ * its states are `active | reconnecting | failed`, which is a different union
+ * from `connecting | live | reconnecting | error` and means different things —
+ * a log stream that is "live" is being read, a forward that is "active" may
+ * have moved nothing all day. Widening either of the existing unions to cover
+ * this would put four words on a screen that can only ever show three.
+ * **If a `forwardStatus` verdict is ever added to `packages/core`, delete this
+ * and call it** — and do not spell `status === "active" ? … : …` anywhere else.
+ *
+ * §13's rule is "`active`→ok, else warn + bold". `failed` is shipped as
+ * `danger` rather than `warning` on purpose: §13 draws only the first two
+ * states and its "else" was written about `reconnecting`. A tunnel that is
+ * reconnecting is coming back; one that has failed is gone, and the row's Stop
+ * button is the only thing left to do about it. Amber for both would say the
+ * two are the same news.
+ *
+ * `tinted` follows the design's asymmetric colouring rule, which
+ * {@link StatusPill} owns: the bad states colour and embolden the word, the
+ * good one reads plain. It is decided here, beside the word, so a copy-paste
+ * cannot pair "Active" with the emphasis a failure gets.
+ */
+const FORWARD_VERDICT: Record<ActiveForward["status"], { word: string; kind: StatusKind }> = {
+  active: { word: "Active", kind: "success" },
+  reconnecting: { word: "Reconnecting", kind: "warning" },
+  failed: { word: "Failed", kind: "danger" },
+};
+
+/**
+ * kubectl's own short target forms, which is what §13 writes in the Target
+ * column (`svc/checkout-api`, `pod/search-indexer-0`).
+ *
+ * A second marked duplicate, and a smaller one: `kindToForwardTarget` in
+ * `packages/core/src/lib/kubectlMapper.ts` is this exact table and is module
+ * private, so the command in the row's clipboard and the name in the row's
+ * first cell are derived twice. It is a NAME, not a status word — no colour
+ * hangs off it — but it is still two answers to one question. **Export
+ * `kindToForwardTarget` from core and delete this.** The fallback matches
+ * core's: anything that is not a Pod or a Service, which the backend never
+ * forwards today, reads as its own lowercased kind rather than as a guess.
+ */
+const TARGET_PREFIX: Record<string, string> = { Service: "svc", Pod: "pod" };
+
+function targetOf(kind: string, name: string): string {
+  return `${TARGET_PREFIX[kind] ?? kind.toLowerCase()}/${name}`;
+}
+
+/**
+ * How often the Age column recomputes.
+ *
+ * A screen of live tunnels is the one place in the app where a frozen age is a
+ * lie the reader would act on — "18m" under a forward that died an hour ago.
+ * Every other Age in the app is re-read when its list is re-fetched; nothing
+ * re-fetches here, because the store is pushed to. A second is the resolution
+ * of core's own age words below a minute, and the backend already pushes a
+ * traffic total about that often, so this costs nothing a live forward was not
+ * already costing.
+ */
+const AGE_TICK_MS = 1_000;
+
+/** One row of §13's table: every cell already resolved to what it renders. */
+interface ForwardRow {
+  id: number;
+  /** `svc/checkout-api` — kubectl's name for the thing, not Kubernetes's. */
+  target: string;
+  namespace: string;
+  cluster: string;
+  /**
+   * Where this forward is reachable FROM THE MACHINE READING THIS PAGE —
+   * `forwardAddress`, never a locally assembled `localhost:<port>`. See
+   * {@link Forwards}.
+   */
+  address: string;
+  remote: string;
+  status: ActiveForward["status"];
+  traffic: string;
+  bytesMoved: number;
+  age: string;
+  startedAt: number;
+  command: string;
+}
+
+/**
+ * `/forwards` — the design's Port forwards screen (§13).
+ *
+ * A port-forward pipes a local port to a Pod or a Service; this is the list of
+ * the ones that are live, and the only place in the app that can stop one.
+ * There is no fetch here: `packages/core`'s forwards store is module-level and
+ * pushed to by the backend, so the table is a `useSyncExternalStore` over it.
+ *
+ * **Two things §13 asks for are deliberately not shipped as written.**
+ *
+ * §13's Copy URL writes `http://localhost:<local>`. That is the DESKTOP answer
+ * and only the desktop answer: in web mode srelens runs in a container whose
+ * loopback the browser cannot reach, and the address is a same-origin
+ * `/pf/<id>/` proxy instead. `forwardAddress` in core already decides this, and
+ * the button and the Local cell both read it rather than re-deriving it — so
+ * what the row shows and what the clipboard gets cannot disagree. The Local
+ * column shows that same address for the same reason: a column headed `Local`
+ * printing a port nothing on this machine is listening on is worse than a long
+ * URL.
+ *
+ * §13 also says, in as many words, that the design defines an empty state for
+ * this screen in the Components gallery and never renders it here. It renders
+ * here. A reader with no tunnels needs the sentence about what a forward is
+ * and the button that makes one far more than a reader with four does.
+ *
+ * **The age ticks.** See {@link AGE_TICK_MS}.
+ */
+export function Forwards(_props: { route: string }) {
+  const forwards = useSyncExternalStore(subscribeForwards, getForwards, getForwards);
+
+  /**
+   * Adopt whatever the backend is still forwarding.
+   *
+   * This is what makes the screen honest after a browser reload. The store is
+   * module-level JavaScript and a reload empties it; `ForwardManager` on the
+   * other side does not die, so without this a web reader reloads into an
+   * empty table while their tunnels keep running and nothing in the app can
+   * stop them. `rehydrateForwards` never rejects — a failed listing is
+   * reported to the reader by core itself — which is why it is called bare.
+   */
+  useEffect(() => {
+    void rehydrateForwards();
+  }, []);
+
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const tick = setInterval(() => setNow(Date.now()), AGE_TICK_MS);
+    return () => clearInterval(tick);
+  }, []);
+
+  /** The last stop that was refused, and which tunnel it was about. */
+  const [stopFailure, setStopFailure] = useState<{ target: string; error: unknown } | null>(null);
+
+  const rows = useMemo<ForwardRow[]>(
+    () =>
+      forwards.map((f) => ({
+        id: f.id,
+        target: targetOf(f.kind, f.name),
+        namespace: f.namespace,
+        cluster: f.context,
+        address: forwardAddress({ id: f.id, localPort: f.localPort }),
+        // The remote port reads as a port, `:443`, which is how the design
+        // writes the far end of a forward and how kubectl's own output does.
+        remote: `:${f.remotePort}`,
+        status: f.status,
+        traffic: formatBytes(f.bytesMoved),
+        bytesMoved: f.bytesMoved,
+        // Core's compact age, from the backend's own start stamp. §13 writes
+        // `2h 04m`; every other Age in this app is one value and one unit, and
+        // a screen that spelled minutes-past-the-hour here would be the only
+        // one — the extra precision is not worth a second way of saying an age.
+        age: ageFromTimestamp(new Date(f.startedAt).toISOString(), now),
+        startedAt: f.startedAt,
+        command: toKubectl({
+          action: "port-forward",
+          kind: f.kind,
+          name: f.name,
+          context: f.context,
+          namespace: f.namespace,
+          localPort: f.localPort,
+          remotePort: f.remotePort,
+        }),
+      })),
+    [forwards, now],
+  );
+
+  const clusters = useMemo(() => new Set(rows.map((r) => r.cluster)).size, [rows]);
+  const moved = useMemo(() => rows.reduce((sum, r) => sum + r.bytesMoved, 0), [rows]);
+
+  /**
+   * TASK 7'S SEAM. §A.4's `New port forward` dialog is Task 7's, and this is
+   * the one function it changes: it becomes `setNewForwardOpen(true)`, with the
+   * dialog mounted at the marked point below. Until then the action is a
+   * deliberate no-op — the button has its home, its copy and both of its call
+   * sites (the header and the empty state's way out), so the dialog lands as
+   * one addition rather than as a redesign of this header.
+   */
+  const openNewForward = () => {};
+
+  const newForwardButton = (
+    <Button variant="primary" size="sm" onClick={openNewForward}>
+      New forward
+    </Button>
+  );
+
+  async function stop(row: ForwardRow) {
+    setStopFailure(null);
+    try {
+      await stopPortForward(row.id);
+    } catch (e) {
+      setStopFailure({ target: row.target, error: e });
+    }
+  }
+
+  async function copyAddress(row: ForwardRow) {
+    try {
+      await navigator.clipboard.writeText(row.address);
+      notify.success("Copied the forward's address");
+    } catch {
+      // No clipboard on a non-secure origin, and nothing to recover: the
+      // address is rendered in full in the row's own Local cell and can be
+      // selected. Saying "Copied" when nothing was copied is the only real harm.
+    }
+  }
+
+  const columns: Column<ForwardRow>[] = [
+    ...COLUMNS,
+    {
+      // §13's unnamed trailing column. Three compact controls rather than the
+      // inline `CopyCommand` §13 names: that component prints the whole command
+      // beside its button and refuses to truncate it, which is right in a rail
+      // and is a paragraph per row in a 128px column. The command is still one
+      // click away, and it is still core's `toKubectl` string verbatim.
+      key: "actions",
+      header: "",
+      sortable: false,
+      filterable: false,
+      align: "end",
+      minWidth: 128,
+      render: (row) => (
+        <div className="flex items-center justify-end gap-0.5">
+          <IconButton
+            icon={Icons.terminal}
+            // Named per row: four rows all offering "Copy" name nothing at all.
+            // The name carries the TARGET, which the row already shows — never
+            // the command or the address, which it must not hide in a title.
+            label={`Copy kubectl command for ${row.target}`}
+            onClick={() => void copyKubectlCommand(row.command)}
+          />
+          <IconButton
+            icon={Icons.copy}
+            label={`Copy address for ${row.target}`}
+            onClick={() => void copyAddress(row)}
+          />
+          <IconButton
+            icon={Icons.close}
+            danger
+            label={`Stop forwarding ${row.target}`}
+            onClick={() => void stop(row)}
+          />
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <Screen title="Port forwards" eyebrow="all clusters" actions={newForwardButton} fill>
+      {/* TASK 7 MOUNTS `NewForwardDialog` HERE — inside the screen and beside
+          the body, so the header action and the empty state's action open the
+          same dialog. See `openNewForward` above. */}
+      {stopFailure && (
+        <div className="p-3 pb-0">
+          <FailureAlert
+            tone="sev"
+            title={`Could not stop ${stopFailure.target}`}
+            error={stopFailure.error}
+          />
+        </div>
+      )}
+      {rows.length === 0 ? (
+        <EmptyState
+          title="No port forwards"
+          hint="Forward a service port to reach it from this machine. Nothing is exposed outside your laptop."
+          action={newForwardButton}
+          // `fill` hands the body the whole area and leaves the centring to
+          // whatever is in it; without this the state sits at the top edge.
+          className="flex-1"
+        />
+      ) : (
+        <>
+          <div className="pane-head">
+            <span>{`Active tunnels · ${rows.length} across ${plural(clusters, "cluster")}`}</span>
+            {/* Pushes the badge to the far end without either side needing to
+                know how wide the other is. */}
+            <span className="flex-1" />
+            <Badge tone="ok">{`${formatBytes(moved)} moved`}</Badge>
+          </div>
+          <div className="scroll min-h-0 flex-1">
+            <Table columns={columns} data={rows} getRowKey={(row) => String(row.id)} />
+          </div>
+        </>
+      )}
+    </Screen>
+  );
+}
+
+/**
+ * §13's columns, in §13's order.
+ *
+ * Module-level and free of handlers so the sort and filter values are read off
+ * the same strings the reader sees — a filter for `staging` that matched
+ * nothing because the cell was built from a different field is the sort of
+ * mismatch nobody reports. The two numeric columns are the exception and say
+ * why at each one.
+ */
+const COLUMNS: Column<ForwardRow>[] = [
+  {
+    key: "target",
+    header: "Target",
+    // Both lines are searchable: a reader looking for `checkout` means either
+    // the service or the namespace and should not have to know which.
+    getValue: (row) => `${row.target} ${row.namespace}`,
+    render: (row) => (
+      <div className="flex min-w-0 flex-col">
+        <span className="truncate font-medium">{row.target}</span>
+        <span className="path truncate">{row.namespace}</span>
+      </div>
+    ),
+  },
+  {
+    key: "cluster",
+    header: "Cluster",
+    render: (row) => <span className="path">{row.cluster}</span>,
+  },
+  {
+    key: "address",
+    header: "Local",
+    render: (row) => <span className="code truncate">{row.address}</span>,
+  },
+  {
+    key: "remote",
+    header: "Remote",
+    // Sorted as the number it is: `:443` beside `:8080` and `:9090` orders
+    // 443, 8080, 9090 numerically and "443", "8080", "9090" the same way by
+    // luck — `:6060` and `:443` do not.
+    getSortValue: (row) => Number(row.remote.slice(1)),
+    render: (row) => <span className="tabular-nums">{row.remote}</span>,
+  },
+  {
+    key: "state",
+    header: "State",
+    // Sorted and searched on the word the reader can see, not on the internal
+    // status behind it.
+    getValue: (row) => FORWARD_VERDICT[row.status].word,
+    render: (row) => (
+      <StatusPill
+        status={FORWARD_VERDICT[row.status].word}
+        kind={FORWARD_VERDICT[row.status].kind}
+        tinted
+      />
+    ),
+  },
+  {
+    key: "traffic",
+    header: "Traffic",
+    align: "end",
+    // The bytes, not the words: `312 KB` sorts above `44.1 MB` as text.
+    getSortValue: (row) => row.bytesMoved,
+    render: (row) => <span className="tabular-nums">{row.traffic}</span>,
+  },
+  {
+    key: "age",
+    header: "Age",
+    align: "end",
+    // The start stamp, not the compact age: `2h` sorts below `51m` as text,
+    // which is the defect `ageSeconds` exists for — and this row has the
+    // original millis, so it does not need to parse its own words back.
+    getSortValue: (row) => row.startedAt,
+    render: (row) => <span className="tabular-nums text-muted">{row.age}</span>,
+  },
+];

--- a/packages/ui-next/src/screens/Forwards.tsx
+++ b/packages/ui-next/src/screens/Forwards.tsx
@@ -353,12 +353,16 @@ const COLUMNS: Column<ForwardRow>[] = [
   {
     key: "cluster",
     header: "Cluster",
-    render: (row) => <span className="path">{row.cluster}</span>,
+    // `block`, not a bare span: `truncate` sets `overflow: hidden`, which does
+    // nothing to an inline box. A kubeconfig context name is user-chosen and
+    // routinely long — `m01-1786968575165/kubernetes-admin@cluster.local` —
+    // and without this it draws straight over the Local cell beside it.
+    render: (row) => <span className="path block truncate">{row.cluster}</span>,
   },
   {
     key: "address",
     header: "Local",
-    render: (row) => <span className="code truncate">{row.address}</span>,
+    render: (row) => <span className="code block truncate">{row.address}</span>,
   },
   {
     key: "remote",

--- a/packages/ui-next/src/screens/Forwards.tsx
+++ b/packages/ui-next/src/screens/Forwards.tsx
@@ -4,6 +4,7 @@ import {
   copyKubectlCommand,
   forwardAddress,
   getForwards,
+  kindToForwardTarget,
   notify,
   plural,
   rehydrateForwards,
@@ -23,9 +24,11 @@ import {
   type Column,
   type StatusKind,
 } from "@srelens/ui-kit";
+import { useActiveContext } from "../lib/clusters";
 import { FailureAlert } from "../lib/errorCopy";
 import { Icons } from "../lib/icons";
 import { formatBytes } from "../lib/numbers";
+import { NewForwardDialog } from "./forwards/NewForwardDialog";
 
 /**
  * THE ONE HAND-PAIRED WORD/TONE TABLE ON THIS SCREEN, AND IT IS MARKED BECAUSE
@@ -64,19 +67,14 @@ const FORWARD_VERDICT: Record<ActiveForward["status"], { word: string; kind: Sta
  * kubectl's own short target forms, which is what §13 writes in the Target
  * column (`svc/checkout-api`, `pod/search-indexer-0`).
  *
- * A second marked duplicate, and a smaller one: `kindToForwardTarget` in
- * `packages/core/src/lib/kubectlMapper.ts` is this exact table and is module
- * private, so the command in the row's clipboard and the name in the row's
- * first cell are derived twice. It is a NAME, not a status word — no colour
- * hangs off it — but it is still two answers to one question. **Export
- * `kindToForwardTarget` from core and delete this.** The fallback matches
- * core's: anything that is not a Pod or a Service, which the backend never
- * forwards today, reads as its own lowercased kind rather than as a guess.
+ * Core's `kindToForwardTarget`, which is also what `toKubectl` puts in the
+ * command this row copies and what §A.4's dialog names its options with. This
+ * screen used to keep a private `{ Service: "svc", Pod: "pod" }` table beside
+ * it; three consumers of one rule beats three copies of it, and a drift would
+ * have had the cell and the clipboard disagreeing about what a row is.
  */
-const TARGET_PREFIX: Record<string, string> = { Service: "svc", Pod: "pod" };
-
 function targetOf(kind: string, name: string): string {
-  return `${TARGET_PREFIX[kind] ?? kind.toLowerCase()}/${name}`;
+  return `${kindToForwardTarget(kind)}/${name}`;
 }
 
 /**
@@ -143,6 +141,7 @@ interface ForwardRow {
  */
 export function Forwards(_props: { route: string }) {
   const forwards = useSyncExternalStore(subscribeForwards, getForwards, getForwards);
+  const cluster = useActiveContext();
 
   /**
    * Adopt whatever the backend is still forwarding.
@@ -204,14 +203,12 @@ export function Forwards(_props: { route: string }) {
   const moved = useMemo(() => rows.reduce((sum, r) => sum + r.bytesMoved, 0), [rows]);
 
   /**
-   * TASK 7'S SEAM. §A.4's `New port forward` dialog is Task 7's, and this is
-   * the one function it changes: it becomes `setNewForwardOpen(true)`, with the
-   * dialog mounted at the marked point below. Until then the action is a
-   * deliberate no-op — the button has its home, its copy and both of its call
-   * sites (the header and the empty state's way out), so the dialog lands as
-   * one addition rather than as a redesign of this header.
+   * §A.4's dialog, opened from the header action and from the empty state's
+   * way out — one handler behind both, so a reader with no tunnels reaches the
+   * same dialog as one with four.
    */
-  const openNewForward = () => {};
+  const [newForwardOpen, setNewForwardOpen] = useState(false);
+  const openNewForward = () => setNewForwardOpen(true);
 
   const newForwardButton = (
     <Button variant="primary" size="sm" onClick={openNewForward}>
@@ -281,9 +278,19 @@ export function Forwards(_props: { route: string }) {
 
   return (
     <Screen title="Port forwards" eyebrow="all clusters" actions={newForwardButton} fill>
-      {/* TASK 7 MOUNTS `NewForwardDialog` HERE — inside the screen and beside
-          the body, so the header action and the empty state's action open the
-          same dialog. See `openNewForward` above. */}
+      {/* Beside the body rather than inside either branch of it, so the dialog
+          opens the same from a populated screen and an empty one. */}
+      {newForwardOpen && (
+        <NewForwardDialog
+          // The cluster in focus. A forward is made in one cluster even though
+          // this screen lists every cluster's, and the rail's selection is the
+          // only answer the app has to *which*; the dialog says so itself when
+          // there is none rather than being opened against an empty context.
+          context={cluster?.name ?? ""}
+          namespace={cluster?.namespace}
+          onClose={() => setNewForwardOpen(false)}
+        />
+      )}
       {stopFailure && (
         <div className="p-3 pb-0">
           <FailureAlert

--- a/packages/ui-next/src/screens/Forwards.tsx
+++ b/packages/ui-next/src/screens/Forwards.tsx
@@ -480,20 +480,29 @@ function forwardColumns(openAddress: (row: ForwardRow) => void): Column<ForwardR
        * be. No `title`: the address is already on screen, and a value in a title
        * is the rule a Secret once leaked through.
        */
-      render: (row) => (
-        <Button
-          variant="ghost"
-          size="xs"
-          className="-mx-1 max-w-full text-[0.8125rem] text-accent"
-          onClick={() => openAddress(row)}
-        >
-          {/* `min-w-0` as well as `truncate`: a flex item's implicit
-              `min-width: auto` refuses to shrink below its content, so without
-              it a long proxy URL widens the button instead of ellipsing —
-              invisible in jsdom, which is why the class is asserted. */}
-          <span className="code min-w-0 truncate">{row.address}</span>
-        </Button>
-      ),
+      render: (row) =>
+        // A dead tunnel's address answers nothing, so it stops being a
+        // control — offering to open it is the #348 shape this screen exists
+        // to avoid, and worse than a no-op: it would raise a browser tab onto
+        // a refused connection. It stays readable, because the reader has to
+        // see WHICH tunnel died.
+        row.dead ? (
+          <span className="code block truncate text-muted">{row.address}</span>
+        ) : (
+          <Button
+            variant="ghost"
+            size="xs"
+            className="-mx-1 max-w-full text-[0.8125rem] text-accent"
+            onClick={() => openAddress(row)}
+          >
+            {/* `min-w-0` as well as `truncate`: a flex item's implicit
+                `min-width: auto` refuses to shrink below its content, so
+                without it a long proxy URL widens the button instead of
+                ellipsing — invisible in jsdom, which is why the class is
+                asserted. */}
+            <span className="code min-w-0 truncate">{row.address}</span>
+          </Button>
+        ),
     },
     {
       key: "remote",

--- a/packages/ui-next/src/screens/Forwards.tsx
+++ b/packages/ui-next/src/screens/Forwards.tsx
@@ -5,6 +5,7 @@ import {
   copyKubectlCommand,
   forwardAddress,
   getForwards,
+  isForwardEnded,
   kindToForwardTarget,
   notify,
   openExternal,
@@ -27,7 +28,7 @@ import {
   type StatusKind,
 } from "@srelens/ui-kit";
 import { useActiveContext } from "../lib/clusters";
-import { FailureAlert } from "../lib/errorCopy";
+import { FailureAlert, FailureWord } from "../lib/errorCopy";
 import { Icons } from "../lib/icons";
 import { formatBytes } from "../lib/numbers";
 import { NewForwardDialog } from "./forwards/NewForwardDialog";
@@ -50,9 +51,13 @@ import { NewForwardDialog } from "./forwards/NewForwardDialog";
  * §13's rule is "`active`→ok, else warn + bold". `failed` is shipped as
  * `danger` rather than `warning` on purpose: §13 draws only the first two
  * states and its "else" was written about `reconnecting`. A tunnel that is
- * reconnecting is coming back; one that has failed is gone, and the row's Stop
- * button is the only thing left to do about it. Amber for both would say the
+ * reconnecting is coming back; one that has failed is gone, and dismissing
+ * the row is the only thing left to do about it. Amber for both would say the
  * two are the same news.
+ *
+ * `failed` needed no new word for the dead row: it IS the dead state — core's
+ * `isForwardEnded` says so, and this table already had the word for it. A
+ * second entry saying "Ended" would have been the same news under two names.
  *
  * `tinted` follows the design's asymmetric colouring rule, which
  * {@link StatusPill} owns: the bad states colour and embolden the word, the
@@ -107,6 +112,16 @@ interface ForwardRow {
   address: string;
   remote: string;
   status: ActiveForward["status"];
+  /**
+   * This tunnel has given up: it is on the screen to be READ, not used. Core
+   * decides it — the status bar counts the same rows and must agree — and the
+   * row asks it here rather than spelling out a status comparison, which is
+   * the rule {@link FORWARD_VERDICT} states.
+   */
+  dead: boolean;
+  /** Why it gave up, raw, when the backend said. `describeError` turns it
+   *  into a sentence at the cell; see {@link forwardColumns}. */
+  error: string | undefined;
   traffic: string;
   bytesMoved: number;
   age: string;
@@ -118,9 +133,16 @@ interface ForwardRow {
  * `/forwards` — the design's Port forwards screen (§13).
  *
  * A port-forward pipes a local port to a Pod or a Service; this is the list of
- * the ones that are live, and the only place in the app that can stop one.
- * There is no fetch here: `packages/core`'s forwards store is module-level and
- * pushed to by the backend, so the table is a `useSyncExternalStore` over it.
+ * them, and the only place in the app that can stop one. There is no fetch
+ * here: `packages/core`'s forwards store is module-level and pushed to by the
+ * backend, so the table is a `useSyncExternalStore` over it.
+ *
+ * **A tunnel that dies stays listed.** One the reader stopped disappears at
+ * once — they did it, and it does not need reporting back — but one that gave
+ * up underneath them is news, and deleting the row left a forward that had
+ * been up for fifteen minutes gone with no trace and its reader still
+ * depending on it. Such a row reads `Failed`, says why, counts against
+ * neither of the two live counts, and offers a dismissal in place of a stop.
  *
  * **Two things §13 asks for are deliberately not shipped as written.**
  *
@@ -185,6 +207,8 @@ export function Forwards(_props: { route: string }) {
         // writes the far end of a forward and how kubectl's own output does.
         remote: `:${f.remotePort}`,
         status: f.status,
+        dead: isForwardEnded(f),
+        error: f.error,
         traffic: formatBytes(f.bytesMoved),
         bytesMoved: f.bytesMoved,
         // Core's compact age, from the backend's own start stamp. §13 writes
@@ -206,7 +230,22 @@ export function Forwards(_props: { route: string }) {
     [forwards, now],
   );
 
-  const clusters = useMemo(() => new Set(rows.map((r) => r.cluster)).size, [rows]);
+  /**
+   * The head counts LIVE tunnels, and says how many died apart from them.
+   *
+   * A dead row is on the screen so it can be read, not because anything is
+   * being forwarded through it — so "Active tunnels · 4" over three live ones
+   * and a corpse would be exactly the reassurance this screen exists to stop
+   * giving. The cluster count follows the same rows for the same reason: the
+   * sentence is about what is up, and a cluster whose only tunnel is dead has
+   * nothing up in it.
+   */
+  const live = useMemo(() => rows.filter((r) => !r.dead), [rows]);
+  const dead = rows.length - live.length;
+  const clusters = useMemo(() => new Set(live.map((r) => r.cluster)).size, [live]);
+  // Every row, including the dead ones: those bytes really crossed those
+  // tunnels, and a total that shrank when a forward died would read as data
+  // lost rather than as a tunnel gone.
   const moved = useMemo(() => rows.reduce((sum, r) => sum + r.bytesMoved, 0), [rows]);
 
   /**
@@ -229,6 +268,26 @@ export function Forwards(_props: { route: string }) {
       await stopPortForward(row.id);
     } catch (e) {
       setFailure({ title: `Could not stop ${row.target}`, error: e });
+    }
+  }
+
+  /**
+   * Take a dead row off the screen.
+   *
+   * The SAME command as a stop, and that is not laziness. A forward that gave
+   * up on its own stays in the backend's map — and in the listing this screen
+   * rehydrates from — until `stop` is called, so a dismissal that only
+   * dropped the row here would be undone by the reader's next reload. There
+   * is nothing left to abort; `stop` is what makes the backend forget it.
+   * Only the words differ, because only the words are different: the reader
+   * is not stopping anything, they are acknowledging news.
+   */
+  async function dismiss(row: ForwardRow) {
+    setFailure(null);
+    try {
+      await stopPortForward(row.id);
+    } catch (e) {
+      setFailure({ title: `Could not dismiss ${row.target}`, error: e });
     }
   }
 
@@ -293,12 +352,24 @@ export function Forwards(_props: { route: string }) {
             label={`Copy address for ${row.target}`}
             onClick={() => void copyAddress(row)}
           />
-          <IconButton
-            icon={Icons.close}
-            danger
-            label={`Stop forwarding ${row.target}`}
-            onClick={() => void stop(row)}
-          />
+          {/* A tunnel that died has nothing left to stop, and a Stop that
+              stops nothing is the kind of control this migration keeps
+              deleting. Not `danger` either: dismissing news is not a
+              destructive act, and the row is already red where it counts. */}
+          {row.dead ? (
+            <IconButton
+              icon={Icons.close}
+              label={`Dismiss ${row.target}`}
+              onClick={() => void dismiss(row)}
+            />
+          ) : (
+            <IconButton
+              icon={Icons.close}
+              danger
+              label={`Stop forwarding ${row.target}`}
+              onClick={() => void stop(row)}
+            />
+          )}
         </div>
       ),
     },
@@ -336,7 +407,12 @@ export function Forwards(_props: { route: string }) {
       ) : (
         <>
           <div className="pane-head">
-            <span>{`Active tunnels · ${rows.length} across ${plural(clusters, "cluster")}`}</span>
+            <span>
+              {`Active tunnels · ${live.length} across ${plural(clusters, "cluster")}` +
+                // Said only when there is one to say: a permanent `· 0 failed`
+                // is a readout nobody needs and one more thing to skip past.
+                (dead > 0 ? ` · ${dead} failed` : "")}
+            </span>
             {/* Pushes the badge to the far end without either side needing to
                 know how wide the other is. */}
             <span className="flex-1" />
@@ -431,15 +507,40 @@ function forwardColumns(openAddress: (row: ForwardRow) => void): Column<ForwardR
     {
       key: "state",
       header: "State",
+      // Room for the sentence under a dead tunnel's word. Without it the
+      // column sizes to "Reconnecting" and the reason wraps a word per line.
+      minWidth: 160,
       // Sorted and searched on the word the reader can see, not on the internal
       // status behind it.
       getValue: (row) => FORWARD_VERDICT[row.status].word,
+      /**
+       * The word, and under a dead tunnel the reason it gave.
+       *
+       * `FailureWord` is the kit's answer for a failure in a narrow place: it
+       * prints `describeError`'s CLASSIFICATION — "Not authorized", "Can't
+       * reach the cluster" — and folds the string the cluster actually sent
+       * away behind a disclosure. The raw form is `ApiError: Unauthorized
+       * (Status { metadata: Some(ListMeta { … })`, which is unreadable in a
+       * table cell and is exactly what a reader needs in a bug report; a
+       * `title` attribute would be neither, and is the rule a Secret leaked
+       * through.
+       *
+       * Only when the tunnel is dead AND said why. A reconnecting tunnel is
+       * coming back and a reason under it would read as gone, and a closure
+       * that carried no reason gets the one word it has rather than an
+       * invented sentence.
+       */
       render: (row) => (
-        <StatusPill
-          status={FORWARD_VERDICT[row.status].word}
-          kind={FORWARD_VERDICT[row.status].kind}
-          tinted
-        />
+        <div className="flex min-w-0 flex-col items-start">
+          <StatusPill
+            status={FORWARD_VERDICT[row.status].word}
+            kind={FORWARD_VERDICT[row.status].kind}
+            tinted
+          />
+          {row.dead && row.error !== undefined && (
+            <FailureWord error={row.error} className="mt-1 text-[0.75rem] text-muted" />
+          )}
+        </div>
       ),
     },
     {

--- a/packages/ui-next/src/screens/ResourceMenu.test.tsx
+++ b/packages/ui-next/src/screens/ResourceMenu.test.tsx
@@ -26,6 +26,15 @@ const { deleteResource, scaleResource, rolloutRestart, evictPod, cronjobSetSuspe
 // parameter to receive it. A bare reference is structurally assignable to
 // the real (many-parameter) core signature — a mock that ignores its
 // arguments is still a valid stand-in for a function that takes some.
+// What §A.4's forward dialog reaches for, once `Port forward` opens it rather
+// than minting a tab. `toKubectl` and `kindToForwardTarget` stay real.
+const forwardCore = vi.hoisted(() => ({
+  listNamespaces: vi.fn(async () => ({ namespaces: ["kube-system", "default"] })),
+  listServices: vi.fn(async () => ({ services: [] })),
+  listPods: vi.fn(async () => ({ pods: [{ name: "web-0", namespace: "kube-system" }] })),
+  startPortForward: vi.fn(async () => ({ id: 1, localPort: 9090 })),
+}));
+
 vi.mock("@srelens/core", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@srelens/core")>()),
   deleteResource,
@@ -34,6 +43,7 @@ vi.mock("@srelens/core", async (importOriginal) => ({
   evictPod,
   cronjobSetSuspend,
   cronjobTriggerNow,
+  ...forwardCore,
 }));
 
 import { useRowMenu, type UseRowMenuArgs } from "./ResourceMenu";
@@ -146,6 +156,61 @@ describe("useRowMenu", () => {
     render(<Harness args={POD_ARGS} row={POD_ROW} />);
     await userEvent.click(screen.getByRole("button", { name: "Follow logs" }));
     expect(store.currentWorkspace().tabs.some((t) => t.route === "/logs/Pod/kube-system/web-0")).toBe(true);
+  });
+
+  /**
+   * `Port forward` used to mint `/resources/<name>/forward` — a route no
+   * screen is registered for, so the menu's own entry opened a Placeholder.
+   * That is the mistake the Logs entry above shipped with and had fixed later
+   * (#346); this is the same front door, on the same menu.
+   *
+   * The dialog goes through the hook's `dialog` slot, which every write action
+   * here already uses — so the peek's and the tab's action bars, which render
+   * that slot too, get the door for free rather than growing a second one.
+   */
+  it("opens §A.4's forward dialog on Port forward, rather than a placeholder tab", async () => {
+    render(<Harness args={POD_ARGS} row={POD_ROW} />);
+    // Nothing is mounted until the entry is picked: a dialog that were always
+    // there would pass every assertion below.
+    expect(screen.queryByRole("dialog")).toBeNull();
+    await userEvent.click(screen.getByRole("button", { name: "Port forward" }));
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("New port forward")).toBeDefined();
+    expect(store.currentWorkspace().tabs.some((t) => t.route.endsWith("/forward"))).toBe(false);
+  });
+
+  it("hands the dialog the row it was picked on — the kind, the name, the namespace", async () => {
+    render(<Harness args={POD_ARGS} row={POD_ROW} />);
+    await userEvent.click(screen.getByRole("button", { name: "Port forward" }));
+    await screen.findByRole("dialog");
+    // `pod/`, from the list's KIND through `kindToForwardTarget`.
+    await waitFor(() =>
+      expect((screen.getByLabelText("Target") as HTMLSelectElement).value).toBe("pod/web-0"),
+    );
+    await waitFor(() =>
+      expect((screen.getByLabelText("Namespace") as HTMLSelectElement).value).toBe("kube-system"),
+    );
+    // A list row knows no ports, so BOTH are the reader's to name — and the
+    // dialog is where they name them.
+    expect((screen.getByLabelText("Remote port") as HTMLInputElement).value).toBe("");
+    expect((screen.getByLabelText("Local port") as HTMLInputElement).value).toBe("");
+  });
+
+  it("starts nothing on the pick, and closes on Cancel", async () => {
+    render(<Harness args={POD_ARGS} row={POD_ROW} />);
+    await userEvent.click(screen.getByRole("button", { name: "Port forward" }));
+    await screen.findByRole("dialog");
+    expect(forwardCore.startPortForward).not.toHaveBeenCalled();
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+  });
+
+  it("still opens a shell in a tab — only the forward entry changed", async () => {
+    render(<Harness args={POD_ARGS} row={POD_ROW} />);
+    await userEvent.click(screen.getByRole("button", { name: "Open shell" }));
+    expect(
+      store.currentWorkspace().tabs.some((t) => t.route === "/resources/web-0/shell"),
+    ).toBe(true);
   });
 
   it("opens a cluster-scoped resource with the placeholder namespace segment", async () => {

--- a/packages/ui-next/src/screens/ResourceMenu.tsx
+++ b/packages/ui-next/src/screens/ResourceMenu.tsx
@@ -19,6 +19,7 @@ import { Icons } from "../lib/icons";
 import { ROW_ACTION_LABEL } from "../lib/kinds/rowActions";
 import type { KindActions, ListRow } from "../lib/kinds/types";
 import { openTab } from "../lib/tabsStore";
+import { NewForwardDialog } from "./forwards/NewForwardDialog";
 import { logsRoute } from "./Logs";
 
 export interface UseRowMenuArgs {
@@ -45,15 +46,17 @@ function isSuspended(row: ListRow): boolean {
 }
 
 /**
- * The row menu's shell/forward tabs — placeholders for screens that do not
- * exist yet. Deliberately NOT `detailRoute`: designing their real route model
- * is a later step's job, not this one's.
+ * The row menu's shell tab — a placeholder for a screen that does not exist
+ * yet. Deliberately NOT `detailRoute`: designing its real route model is a
+ * later step's job, not this one's.
  *
- * Logs no longer comes through here. This shape carries a name and nothing
- * else, so it cannot say which kind or namespace the subject is in — which was
- * survivable while every one of these rendered a Placeholder, and stopped being
- * so the moment Logs became a real screen: the front door opened onto an empty
- * pane. It mints {@link logsRoute} instead.
+ * Neither Logs nor Port forward comes through here any more. This shape
+ * carries a name and nothing else, so it cannot say which kind or namespace
+ * the subject is in — which was survivable while every one of these rendered a
+ * Placeholder, and stopped being so the moment those screens became real: the
+ * front door opened onto an empty pane. Logs mints {@link logsRoute}; Port
+ * forward opens §A.4's dialog on the row itself, through the same `dialog`
+ * slot every write action here uses.
  */
 const nav = (name: string, suffix: string) => `/resources/${encodeURIComponent(name)}/${suffix}`;
 
@@ -78,6 +81,15 @@ export function useRowMenu({ context, kind, actions }: UseRowMenuArgs): {
   dialog: ReactNode;
 } {
   const [pending, setPending] = useState<Pending | null>(null);
+  /**
+   * The row whose `Port forward` was picked, if any.
+   *
+   * A slot of its own rather than a `Pending` variant: every member of that
+   * union is a question with a confirm behind it, and §A.4's dialog IS the
+   * confirm — it has its own fields, its own equivalent command and its own
+   * error line, none of which `PendingDialog` has a shape for.
+   */
+  const [forwarding, setForwarding] = useState<ListRow | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
   const [replicas, setReplicas] = useState("");
@@ -169,7 +181,11 @@ export function useRowMenu({ context, kind, actions }: UseRowMenuArgs): {
       list.push({
         label: ROW_ACTION_LABEL.forward,
         icon: Icons.portforwards,
-        onPick: () => openTab(nav(row.name, "forward"), { clusterName: context }),
+        // Opens §A.4's dialog on this row rather than minting
+        // `/resources/<name>/forward`, which no screen is registered for and
+        // which therefore rendered a Placeholder — the menu offering a way in
+        // to a dead end. The same mistake Follow logs shipped with (#346).
+        onPick: () => setForwarding(row),
       });
     }
     list.push({
@@ -221,7 +237,19 @@ export function useRowMenu({ context, kind, actions }: UseRowMenuArgs): {
     return list;
   }
 
-  const dialog = pending ? <PendingDialog pending={pending} kind={kind} context={context} busy={busy} error={error} replicas={replicas} onReplicasChange={setReplicas} onConfirm={() => void confirm()} onCancel={close} /> : null;
+  const dialog = pending ? (
+    <PendingDialog pending={pending} kind={kind} context={context} busy={busy} error={error} replicas={replicas} onReplicasChange={setReplicas} onConfirm={() => void confirm()} onCancel={close} />
+  ) : forwarding ? (
+    // The row's own kind and identity, prefilled. A list row knows no ports,
+    // so the remote one is the reader's to name — and the dialog stays fully
+    // editable either way: a prefill is a starting point.
+    <NewForwardDialog
+      context={context}
+      namespace={forwarding.namespace}
+      target={{ kind, name: forwarding.name }}
+      onClose={() => setForwarding(null)}
+    />
+  ) : null;
 
   return { items, dialog };
 }

--- a/packages/ui-next/src/screens/Toolbox.test.tsx
+++ b/packages/ui-next/src/screens/Toolbox.test.tsx
@@ -1,0 +1,314 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Only the two capability wrappers and the platform check are replaced.
+// `describeError` stays real, so the error assertions below are against core's
+// own classification rather than a copy of it, and `plural` stays real so the
+// skew sentence is counted by core's arithmetic.
+const core = vi.hoisted(() => ({
+  toolboxStatus: vi.fn(),
+  startToolInstall: vi.fn(),
+  isTauri: vi.fn(() => true),
+}));
+vi.mock("@srelens/core", async (orig) => ({
+  ...(await orig<typeof import("@srelens/core")>()),
+  ...core,
+}));
+
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
+import type { ClusterContext } from "@srelens/core";
+// Chat exports a `ToolStatus` too; the toolbox one is the DTO these rows are.
+import type { ToolStatus } from "@srelens/core/lib/toolbox";
+import { Toolbox } from "./Toolbox";
+import { resetContexts, setContexts } from "../lib/clusters";
+import { probeCluster, resetProbes } from "../lib/probe";
+import { defaultState } from "../lib/tabs";
+import * as store from "../lib/tabsStore";
+import { resetView } from "../lib/workspace";
+
+const ROUTE = "/toolbox";
+
+const CTX: ClusterContext = {
+  name: "prod-eu",
+  stableId: "prod",
+  cluster: "prod",
+  server: "https://prod",
+  isCurrent: true,
+};
+
+/**
+ * The three tools `toolbox.status` actually reports (`MANAGED_TOOLS` in
+ * `crates/kube/src/toolbox.rs`), one in each of the three states the screen
+ * can tell apart: srelens's own copy, somebody else's copy on the PATH, and
+ * nothing at all.
+ */
+const MANAGED: ToolStatus = {
+  name: "kubectl",
+  installed: true,
+  path: "/Users/ada/.srelens/bin/kubectl",
+  version: "v1.31.4",
+  source: "managed",
+};
+const SYSTEM: ToolStatus = {
+  name: "helm",
+  installed: true,
+  path: "/opt/homebrew/bin/helm",
+  version: "v3.16.3",
+  source: "system",
+};
+const ABSENT: ToolStatus = {
+  name: "krew",
+  installed: false,
+  path: null,
+  version: null,
+  source: null,
+};
+
+const TOOLS = [MANAGED, SYSTEM, ABSENT];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  core.isTauri.mockReturnValue(true);
+  core.toolboxStatus.mockResolvedValue({ data: TOOLS });
+  core.startToolInstall.mockResolvedValue({
+    data: { tool: "krew", version: "v0.4.4", path: "/Users/ada/.krew/bin/krew" },
+  });
+  resetContexts();
+  setContexts([CTX]);
+  store.setState(defaultState([CTX]));
+  resetProbes();
+  resetView();
+});
+
+/** Probe the active cluster so the screen has a server version to compare with. */
+const probe = (version: string) =>
+  probeCluster(CTX, async () => ({ context: CTX.name, reachable: true, version }));
+
+function open() {
+  store.openTab(ROUTE);
+  return render(<Toolbox route={ROUTE} />);
+}
+
+const headers = () =>
+  Array.from(document.querySelectorAll("thead th")).map((th) => th.textContent?.trim() ?? "");
+const rowFor = (name: string) => screen.getByText(name).closest("tr") as HTMLElement;
+const cells = (row: HTMLElement) =>
+  Array.from(row.querySelectorAll("td")).map((td) => td.textContent?.trim() ?? "");
+/** The State cell's verdict word and the severity the pill drew it at. */
+const verdict = (row: HTMLElement) => {
+  const pill = row.querySelector(".status");
+  return { word: pill?.textContent?.trim() ?? "", kind: pill?.getAttribute("data-kind") ?? "" };
+};
+/** The Note cell, addressed by column position so a moved column fails loudly. */
+const note = (row: HTMLElement) => cells(row)[headers().indexOf("Note")];
+
+describe("Toolbox — the inventory", () => {
+  it("says it is loading while the binaries are being located", async () => {
+    let release: (v: { data: ToolStatus[] }) => void = () => {};
+    core.toolboxStatus.mockReturnValue(
+      new Promise<{ data: ToolStatus[] }>((resolve) => {
+        release = resolve;
+      }),
+    );
+    open();
+
+    // Not instant: `toolbox.status` shells out to every tool it knows about.
+    expect(screen.getByRole("status", { name: "Locating the toolchain" })).toBeTruthy();
+    expect(screen.queryByText("kubectl")).toBeNull();
+
+    release({ data: TOOLS });
+    expect(await screen.findByText("kubectl")).toBeTruthy();
+  });
+
+  it("heads the pane with where srelens keeps what it installs", async () => {
+    open();
+    await screen.findByText("kubectl");
+    expect(screen.getByText("Managed tools · installed under ~/.srelens/bin")).toBeTruthy();
+  });
+
+  it("renders one row per tool, with its version and its state", async () => {
+    open();
+    await screen.findByText("kubectl");
+
+    expect(cells(rowFor("kubectl"))[headers().indexOf("Version")]).toBe("v1.31.4");
+    expect(verdict(rowFor("kubectl"))).toEqual({ word: "Installed", kind: "success" });
+
+    // A tool nobody has installed has no version to show either — an absence,
+    // rendered as one.
+    expect(cells(rowFor("krew"))[headers().indexOf("Version")]).toBe("—");
+    expect(verdict(rowFor("krew"))).toEqual({ word: "Missing", kind: "neutral" });
+  });
+
+  it("tells a copy on the PATH apart from the copy srelens installed", async () => {
+    open();
+    await screen.findByText("helm");
+
+    // The distinction is the point: `helm` IS installed and IS usable, so the
+    // row must not read the same as kubectl's, which srelens put there and can
+    // replace. Asserted against the managed row so a state table that
+    // collapsed the two fails here rather than passing on a word.
+    expect(verdict(rowFor("helm"))).toEqual({ word: "Unmanaged", kind: "neutral" });
+    expect(verdict(rowFor("helm"))).not.toEqual(verdict(rowFor("kubectl")));
+    expect(note(rowFor("helm"))).toContain("on PATH");
+
+    // And srelens's own copy claims nothing about the PATH.
+    expect(note(rowFor("kubectl"))).not.toContain("on PATH");
+  });
+
+  it("shows no size for anything, because nothing measures one", async () => {
+    open();
+    await screen.findByText("kubectl");
+
+    // `ToolStatusDto` carries no size, so every figure in a Size column would
+    // be a measurement nobody took — and `0 B` for the missing one would be the
+    // worst of them. The column is not drawn at all.
+    expect(headers()).not.toContain("Size");
+    expect(screen.queryByText(/\b0 B\b/)).toBeNull();
+    // The installed row has no invented figure either — its cells are exactly
+    // the columns that have a source.
+    expect(cells(rowFor("kubectl"))).toHaveLength(headers().length);
+    expect(cells(rowFor("krew")).join(" ")).not.toMatch(/\d+(\.\d+)?\s?[KMG]?B/);
+  });
+});
+
+describe("Toolbox — kubectl against the cluster", () => {
+  it("says kubectl matches the server when the minors agree", async () => {
+    await probe("v1.31.4");
+    open();
+    await screen.findByText("kubectl");
+
+    expect(note(rowFor("kubectl"))).toContain("matches prod-eu server version");
+  });
+
+  it("names the skew when kubectl runs ahead of the server", async () => {
+    await probe("v1.29.8");
+    open();
+    await screen.findByText("kubectl");
+
+    // v1.31 client, v1.29 server: two minors, and the direction is part of the
+    // fact. "matches" must be gone, not merely joined by a second sentence.
+    expect(note(rowFor("kubectl"))).toContain("2 minors ahead of prod-eu");
+    expect(note(rowFor("kubectl"))).not.toContain("matches");
+  });
+
+  it("names the skew, and its direction, when kubectl runs behind the server", async () => {
+    core.toolboxStatus.mockResolvedValue({
+      data: [{ ...MANAGED, version: "v1.30.1" }, SYSTEM, ABSENT],
+    });
+    await probe("v1.31.4");
+    open();
+    await screen.findByText("kubectl");
+
+    expect(note(rowFor("kubectl"))).toContain("1 minor behind prod-eu");
+    expect(note(rowFor("kubectl"))).not.toContain("ahead");
+  });
+
+  it("claims no skew when nothing has read a server version", async () => {
+    // No probe: the screen is app-scoped and can be opened before any cluster
+    // answers. A note that guessed "matches" here would be an assertion about
+    // a cluster nobody asked.
+    open();
+    await screen.findByText("kubectl");
+
+    expect(note(rowFor("kubectl"))).toBe("");
+  });
+
+  it("compares nothing but kubectl against the server", async () => {
+    await probe("v1.31.4");
+    open();
+    await screen.findByText("helm");
+
+    // helm v3.16 is not "13 minors ahead of prod-eu", and it does not "differ
+    // from the prod-eu server version" either: its versions have nothing to do
+    // with the API server's, so the cluster is not named on its row at all.
+    // Asserted as the WHOLE cell rather than as a pattern — a comparison that
+    // ran on every tool would land here as extra text, whatever words it
+    // chose, and a pattern only catches the words it thought of.
+    expect(note(rowFor("helm"))).toBe("on PATH");
+    expect(note(rowFor("krew"))).toBe("");
+  });
+});
+
+describe("Toolbox — what can be done, and where", () => {
+  it("offers an install on the desktop, and runs the real one", async () => {
+    open();
+    await screen.findByText("krew");
+
+    expect(headers()).toEqual(["Tool", "Version", "State", "Note", ""]);
+    // The missing tool is offered an install; the managed one a replacement.
+    expect(screen.getByRole("button", { name: "Install krew" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Reinstall kubectl" })).toBeTruthy();
+
+    await userEvent.click(screen.getByRole("button", { name: "Install krew" }));
+    expect(core.startToolInstall).toHaveBeenCalledWith("krew", expect.any(Function));
+    // And the inventory is read again, so the row stops saying Missing.
+    await waitFor(() => expect(core.toolboxStatus).toHaveBeenCalledTimes(2));
+  });
+
+  it("reports an install that failed, and leaves the rows standing", async () => {
+    core.startToolInstall.mockResolvedValue({ error: "Error: handler error: checksum mismatch" });
+    open();
+    await screen.findByText("krew");
+
+    await userEvent.click(screen.getByRole("button", { name: "Install krew" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(within(alert).getByText(/checksum mismatch/)).toBeTruthy();
+    // Classified, not echoed: the two wrapper prefixes never reach the reader.
+    expect(alert.textContent).not.toContain("handler error:");
+    expect(rowFor("kubectl")).toBeTruthy();
+  });
+
+  it("draws no action column in the browser, and says once why", async () => {
+    core.isTauri.mockReturnValue(false);
+    open();
+    await screen.findByText("krew");
+
+    // Every per-row button here is a `WEB_DENIED_CAPABILITIES` entry, so none
+    // is drawn — the column is gone, not disabled.
+    expect(headers()).toEqual(["Tool", "Version", "State", "Note"]);
+    expect(cells(rowFor("krew"))).toHaveLength(4);
+    expect(screen.queryByRole("button", { name: /^(Install|Reinstall)/ })).toBeNull();
+
+    // Said once, for the whole table, rather than per row.
+    expect(screen.getAllByText("Tools are managed where srelens runs")).toHaveLength(1);
+    // And the inventory itself still reads: `toolbox.status` is allowed on web.
+    expect(screen.getByText("v1.31.4")).toBeTruthy();
+  });
+});
+
+describe("Toolbox — when the inventory cannot be taken", () => {
+  it("reports a failed status in words, and retries it", async () => {
+    core.toolboxStatus.mockResolvedValueOnce({
+      error: "Error: handler error: PATH could not be read",
+    });
+    open();
+
+    const alert = await screen.findByRole("alert");
+    expect(within(alert).getByText("Could not inventory the toolchain")).toBeTruthy();
+    // `describeError`'s cleaning, not the raw string: both wrapper prefixes are
+    // stripped before anything reaches the reader.
+    expect(within(alert).getByText("PATH could not be read")).toBeTruthy();
+    expect(alert.textContent).not.toContain("handler error:");
+    expect(alert.textContent).not.toContain("Error: Error:");
+
+    await userEvent.click(within(alert).getByRole("button", { name: "Retry" }));
+    expect(await screen.findByText("kubectl")).toBeTruthy();
+    expect(core.toolboxStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it("says so when the backend reports no tools at all", async () => {
+    core.toolboxStatus.mockResolvedValue({ data: [] });
+    open();
+
+    expect(await screen.findByText("No tools reported")).toBeTruthy();
+  });
+});

--- a/packages/ui-next/src/screens/Toolbox.test.tsx
+++ b/packages/ui-next/src/screens/Toolbox.test.tsx
@@ -56,6 +56,7 @@ const MANAGED: ToolStatus = {
   path: "/Users/ada/.srelens/bin/kubectl",
   version: "v1.31.4",
   source: "managed",
+  sizeBytes: 54_200_000,
 };
 const SYSTEM: ToolStatus = {
   name: "helm",
@@ -63,6 +64,10 @@ const SYSTEM: ToolStatus = {
   path: "/opt/homebrew/bin/helm",
   version: "v3.16.3",
   source: "system",
+  // Installed, on the PATH, and its path could not be stat'd — a dangling
+  // symlink or a permission error. Distinct from "not installed", and the
+  // reason the cell must not read `0 B`.
+  sizeBytes: null,
 };
 const ABSENT: ToolStatus = {
   name: "krew",
@@ -70,6 +75,7 @@ const ABSENT: ToolStatus = {
   path: null,
   version: null,
   source: null,
+  sizeBytes: null,
 };
 
 const TOOLS = [MANAGED, SYSTEM, ABSENT];
@@ -163,19 +169,19 @@ describe("Toolbox — the inventory", () => {
     expect(note(rowFor("kubectl"))).not.toContain("on PATH");
   });
 
-  it("shows no size for anything, because nothing measures one", async () => {
+  it("sizes what it can measure, and dashes what it cannot", async () => {
     open();
     await screen.findByText("kubectl");
 
-    // `ToolStatusDto` carries no size, so every figure in a Size column would
-    // be a measurement nobody took — and `0 B` for the missing one would be the
-    // worst of them. The column is not drawn at all.
-    expect(headers()).not.toContain("Size");
+    expect(headers()).toContain("Size");
+    // Measured.
+    expect(cells(rowFor("kubectl"))).toContain("54.2 MB");
+    // Installed but unreadable, and not installed at all: two different
+    // reasons for the same answer, and neither of them is `0 B`. A zero is a
+    // measurement, and nobody took one.
+    expect(cells(rowFor("helm"))).toContain("\u2014");
+    expect(cells(rowFor("krew"))).toContain("\u2014");
     expect(screen.queryByText(/\b0 B\b/)).toBeNull();
-    // The installed row has no invented figure either — its cells are exactly
-    // the columns that have a source.
-    expect(cells(rowFor("kubectl"))).toHaveLength(headers().length);
-    expect(cells(rowFor("krew")).join(" ")).not.toMatch(/\d+(\.\d+)?\s?[KMG]?B/);
   });
 });
 
@@ -242,7 +248,7 @@ describe("Toolbox — what can be done, and where", () => {
     open();
     await screen.findByText("krew");
 
-    expect(headers()).toEqual(["Tool", "Version", "State", "Note", ""]);
+    expect(headers()).toEqual(["Tool", "Version", "State", "Note", "Size", ""]);
     // The missing tool is offered an install; the managed one a replacement.
     expect(screen.getByRole("button", { name: "Install krew" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Reinstall kubectl" })).toBeTruthy();
@@ -274,8 +280,8 @@ describe("Toolbox — what can be done, and where", () => {
 
     // Every per-row button here is a `WEB_DENIED_CAPABILITIES` entry, so none
     // is drawn — the column is gone, not disabled.
-    expect(headers()).toEqual(["Tool", "Version", "State", "Note"]);
-    expect(cells(rowFor("krew"))).toHaveLength(4);
+    expect(headers()).toEqual(["Tool", "Version", "State", "Note", "Size"]);
+    expect(cells(rowFor("krew"))).toHaveLength(5);
     expect(screen.queryByRole("button", { name: /^(Install|Reinstall)/ })).toBeNull();
 
     // Said once, for the whole table, rather than per row.

--- a/packages/ui-next/src/screens/Toolbox.tsx
+++ b/packages/ui-next/src/screens/Toolbox.tsx
@@ -1,0 +1,367 @@
+import { useMemo, useState } from "react";
+import { isTauri, plural, startToolInstall, toolboxStatus } from "@srelens/core";
+// Named the same as chat's `ToolStatus` (an assistant tool call's state), so
+// taken from its own module rather than from the barrel, where the two collide.
+import type { ToolStatus } from "@srelens/core/lib/toolbox";
+import {
+  Alert,
+  Button,
+  LoadingState,
+  Screen,
+  StatusPill,
+  Table,
+  type Column,
+  type StatusKind,
+} from "@srelens/ui-kit";
+import { useActiveContext } from "../lib/clusters";
+import { FailureAlert, FailureState } from "../lib/errorCopy";
+import { useInfo } from "../lib/probe";
+import { useResource } from "../lib/useResource";
+
+/** §17's pane head, verbatim — `SearchPaths` really does add that directory. */
+const PANE_HEAD = "Managed tools · installed under ~/.srelens/bin";
+
+/** What a cell shows in place of a fact nobody has. */
+const ABSENT = "—";
+
+/**
+ * The tools `toolbox.status` reports that srelens can also *install*.
+ *
+ * `MANAGED_TOOLS` in `crates/kube/src/toolbox.rs` and `startToolInstall`'s own
+ * union are the same three today, and this is deliberately the narrower of the
+ * two: a fourth entry added to the inventory with no installer behind it gets
+ * an inventory row and no button, rather than a button whose click rejects on
+ * an unknown tool name. A control that cannot work is not drawn.
+ */
+const INSTALLABLE = new Set(["kubectl", "helm", "krew"]);
+type InstallableTool = "kubectl" | "helm" | "krew";
+
+/**
+ * What the screen can actually tell apart about a tool. **Three values, not
+ * four.**
+ *
+ * §17 draws a fourth, `update` — a newer version exists upstream — and there is
+ * no source for it anywhere in this app. Nothing queries a release feed, and a
+ * kubeconfig never states a minimum version for the binary it names, so an
+ * `update` state could only ever be inferred. It is not inferred here.
+ *
+ * `unmanaged` is the one §17 does not draw and this does: a tool that IS
+ * installed and IS usable, but that somebody else put on the PATH. It matters
+ * because the pane head promises `~/.srelens/bin`, and a row reading plain
+ * `Installed` for a Homebrew helm quietly claims srelens put it there.
+ */
+type ToolState = "installed" | "unmanaged" | "missing";
+
+function toolState(tool: ToolStatus): ToolState {
+  if (!tool.installed) return "missing";
+  return tool.source === "system" ? "unmanaged" : "installed";
+}
+
+/**
+ * THE ONE HAND-PAIRED WORD/TONE TABLE IN THIS SCREEN, AND IT IS MARKED
+ * BECAUSE IT SHOULD NOT HAVE TO EXIST.
+ *
+ * Every other status word in this app comes off a derivation in
+ * `@srelens/core` — `podStatus`, `nodeStatus`, `eventVerdict`,
+ * `logConnectionStatus` — precisely so a word and the colour beside it cannot
+ * drift apart in two places. `packages/core/src/lib/toolbox.ts` has no such
+ * derivation: it wraps the capability and returns the DTO unchanged, and there
+ * is no `toolVerdict` anywhere to import. This task owns one screen file, so
+ * the verdict cannot be added to core from here.
+ *
+ * So it lives here, once, next to the state it names, and it is the ONLY place
+ * in this file that pairs a word with a severity. **If a `toolVerdict` is ever
+ * added to core, delete this and call it** — do not add a second table beside
+ * it, and do not spell `state === "missing" ? … : …` anywhere else in this
+ * file.
+ *
+ * The severities are §17's own rule (`installed` → ok, everything else muted),
+ * with `update`'s `warn` gone along with the state it belonged to. A missing
+ * tool is not an incident: srelens talks to the API server itself, and the row
+ * beside the word already offers the install.
+ */
+const VERDICT: Record<ToolState, { word: string; kind: StatusKind }> = {
+  installed: { word: "Installed", kind: "success" },
+  unmanaged: { word: "Unmanaged", kind: "neutral" },
+  missing: { word: "Missing", kind: "neutral" },
+};
+
+/** A `vMAJOR.MINOR…` string as the pair Kubernetes measures skew in. */
+function minorVersion(text: string): { major: number; minor: number } | null {
+  const m = /^v?(\d+)\.(\d+)(?:[.+-]|$)/.exec(text.trim());
+  return m ? { major: Number(m[1]), minor: Number(m[2]) } : null;
+}
+
+/**
+ * kubectl's distance from the API server it will be pointed at, in the units
+ * Kubernetes states its own skew policy in: minor versions.
+ *
+ * Empty when either side is unreadable or unread — an app-scoped screen can be
+ * opened before any cluster has answered, and a note that said "matches" with
+ * no server version in hand would be an assertion about a cluster nobody
+ * asked. The comparison is deliberately *only* between kubectl and the server:
+ * helm's `v3.16` has nothing to do with the API server's `v1.31`, and counting
+ * the difference would produce thirteen minors of nonsense.
+ *
+ * It names the skew and stops there. Whether a given distance is *supported*
+ * is upstream policy that changes release to release, and this screen has no
+ * copy of it — the number and its direction are the facts.
+ */
+function skewNote(clientVersion: string, serverVersion: string, context: string): string {
+  const client = minorVersion(clientVersion);
+  const server = minorVersion(serverVersion);
+  if (!client || !server) return "";
+  if (client.major !== server.major) return `differs from ${context} server version`;
+  const skew = client.minor - server.minor;
+  if (skew === 0) return `matches ${context} server version`;
+  return skew > 0
+    ? `${plural(skew, "minor")} ahead of ${context}`
+    : `${plural(-skew, "minor")} behind ${context}`;
+}
+
+/**
+ * The Note column — **derived facts only.**
+ *
+ * Two of them, and they are the two this machine can answer: where the binary
+ * came from, and how far kubectl is from the cluster in focus. §17's other
+ * notes are not shipped, on purpose:
+ *
+ * - `optional · multi-pod log tailing` and `cluster add-on · absent on
+ *   edge-apac` are opinions about what a tool is FOR, not facts about this
+ *   machine, and they would be the same words on every install of srelens.
+ * - `12 plugins` costs a whole krew index search: `toolbox.searchPlugins`
+ *   returns `{ name, description, installed }` per result and there is no
+ *   count behind it, so the number would be paid for by walking the index
+ *   every time this screen opened. A figure that expensive does not belong in
+ *   a table cell.
+ */
+function noteFor(tool: ToolStatus, serverVersion: string, context: string): string {
+  const notes: string[] = [];
+  // Said as the note rather than as the state word: `Unmanaged` says srelens
+  // did not put it there, and this says where it is instead.
+  if (tool.installed && tool.source === "system") notes.push("on PATH");
+  if (tool.name === "kubectl" && tool.version && serverVersion && context) {
+    const skew = skewNote(tool.version, serverVersion, context);
+    if (skew) notes.push(skew);
+  }
+  return notes.join(" · ");
+}
+
+interface ToolRow {
+  name: string;
+  version: string;
+  state: ToolState;
+  note: string;
+  installed: boolean;
+}
+
+/**
+ * `/toolbox` — the design's Toolbox screen (§17).
+ *
+ * The one screen in the app that never touches a cluster: it inventories the
+ * command-line tools srelens drives, says which of them srelens itself
+ * installed, and on the desktop offers to (re)install them. Its only reference
+ * to Kubernetes is the one derived fact kubectl has that the others do not —
+ * how far its minor version is from the server of the cluster in focus, read
+ * from the probe the shell already ran at launch rather than from a request of
+ * its own.
+ *
+ * **Three things §17 asks for are deliberately absent.** Each is argued where
+ * it would have gone: the `update` state ({@link ToolState}), most of the Note
+ * column ({@link noteFor}), and the Size column ({@link COLUMNS}). The fourth
+ * departure is the action column, which exists on the desktop and not in the
+ * browser — see {@link Toolbox} below.
+ *
+ * **Loading is a real state here.** `toolbox.status` shells out to locate each
+ * binary and run it for its version; on a cold PATH that is not instant, and a
+ * table that appeared empty first and filled in later would read as "nothing
+ * installed".
+ */
+export function Toolbox(_props: { route: string }) {
+  const context = useActiveContext();
+  // The server version, from the probe the shell already ran at launch — the
+  // same source the cluster overview's head reads. Nothing here connects.
+  const serverVersion = useInfo(context?.stableId ?? null)?.version ?? "";
+
+  const inventory = useResource(async () => {
+    const result = await toolboxStatus();
+    // `toolboxStatus` reports a rejection as `{ error }` rather than throwing,
+    // so it is turned back into one: `useResource` owns the four states, and
+    // an error smuggled through the data channel would render as a ready table
+    // with no rows in it.
+    if (result.error) throw new Error(result.error);
+    return result.data ?? [];
+  }, []);
+
+  /** Which tool is being installed, and how far the download has got. */
+  const [busy, setBusy] = useState<string | null>(null);
+  const [percent, setPercent] = useState<number | null>(null);
+  const [installError, setInstallError] = useState<{ tool: string; error: unknown } | null>(null);
+
+  const desktop = isTauri();
+
+  const rows = useMemo<ToolRow[]>(
+    () =>
+      (inventory.data ?? []).map((tool) => ({
+        name: tool.name,
+        version: tool.version || ABSENT,
+        state: toolState(tool),
+        note: noteFor(tool, serverVersion, context?.name ?? ""),
+        installed: tool.installed,
+      })),
+    [inventory.data, serverVersion, context?.name],
+  );
+
+  async function install(name: string) {
+    setBusy(name);
+    setPercent(null);
+    setInstallError(null);
+    const result = await startToolInstall(name as InstallableTool, setPercent);
+    setBusy(null);
+    setPercent(null);
+    if (result.error) setInstallError({ tool: name, error: result.error });
+    // Re-read either way: a failed install can still have moved the binary,
+    // and the row's own words are the only honest report of where it ended up.
+    inventory.reload();
+  }
+
+  const columns: Column<ToolRow>[] = desktop
+    ? [
+        ...COLUMNS,
+        {
+          // §17's unnamed trailing column. One button, whose word is what it
+          // will actually do: `Install` for a tool that is not there, and
+          // `Reinstall` for one that is — including an unmanaged copy, where
+          // installing puts srelens's own under `~/.srelens/bin`. §17's third
+          // label, `Update`, went with the state it depended on.
+          key: "action",
+          header: "",
+          sortable: false,
+          filterable: false,
+          align: "end",
+          minWidth: 96,
+          render: (row) => {
+            if (!INSTALLABLE.has(row.name)) return null;
+            const verb = row.installed ? "Reinstall" : "Install";
+            const running = busy === row.name;
+            return (
+              <Button
+                variant="secondary"
+                size="sm"
+                // The word on the button changes while the download runs, so
+                // the accessible name is spelled out and stays put — three
+                // rows all offering "Install" name nothing at all.
+                aria-label={`${verb} ${row.name}`}
+                disabled={busy !== null}
+                onClick={() => void install(row.name)}
+              >
+                {running ? progressLabel(percent) : verb}
+              </Button>
+            );
+          },
+        },
+      ]
+    : COLUMNS;
+
+  return (
+    <Screen title="Toolbox" eyebrow="workspace / binaries" fill>
+      {/* Task 9 wraps this pair in `SideRail` (head `Exec auth check`, 288px)
+          and drops the rail in beside it. Left as the bare pane for now: a
+          rail with nothing in it is a 288px column of empty. */}
+      <div className="pane-head">{PANE_HEAD}</div>
+      <div className="scroll flex min-h-0 flex-1 flex-col gap-3 p-3">
+        {!desktop && (
+          /* Said ONCE, for the whole table, rather than as a disabled button on
+             every row. `installKubectl`, `installHelm`, `installKrew`,
+             `installPlugin`, `upgradePlugin` and `removePlugin` are all in the
+             server's `WEB_DENIED_CAPABILITIES`, so every one of §17's per-row
+             buttons would fail here — and a row of controls that reject on
+             click is worse than a table that reads as the inventory it is. */
+          <Alert tone="info" title="Tools are managed where srelens runs">
+            This lists what that machine has. Installing and updating them happens in the srelens
+            desktop app.
+          </Alert>
+        )}
+        {installError && (
+          <FailureAlert
+            tone="sev"
+            title={`Could not install ${installError.tool}`}
+            error={installError.error}
+          />
+        )}
+        {inventory.status === "loading" ? (
+          <LoadingState label="Locating the toolchain" />
+        ) : inventory.status === "error" ? (
+          <FailureState
+            title="Could not inventory the toolchain"
+            error={inventory.error}
+            onRetry={inventory.reload}
+          />
+        ) : (
+          <Table
+            columns={columns}
+            data={rows}
+            getRowKey={(row) => row.name}
+            emptyText="No tools reported"
+            emptyHint="srelens found no entry for kubectl, helm or krew — not even a missing one."
+          />
+        )}
+      </div>
+    </Screen>
+  );
+}
+
+/** What the button says while an install is running. */
+function progressLabel(percent: number | null): string {
+  // Null covers both halves of the operation the percentage cannot describe:
+  // a download whose total size the server never sent, and the verify-and-move
+  // that happens after the last byte arrives.
+  return percent === null ? "Installing…" : `Downloading… ${percent}%`;
+}
+
+/**
+ * The columns every platform draws, in §17's order — **minus `Size`.**
+ *
+ * §17 puts a right-aligned size on every row (`54.2 MB`, `48.9 MB`, `9.1 MB`).
+ * `ToolStatusDto` is `{ name, installed, path, version, source }`: it carries
+ * no size, no capability in the catalog reports a file's size, and nothing in
+ * this app can stat a path. So there is no reading to render — not for the
+ * missing tool, and not for the installed ones either.
+ *
+ * A missing tool renders its absence and never `0 B`; that rule has held from
+ * the cluster overview through every screen since, because a zero is a
+ * measurement claimed rather than taken. The same reasoning finishes the job
+ * here: if EVERY cell would be an absence, the column is not a column, and
+ * drawing one headed `Size` with a dash in every row states that a size was
+ * looked for and not found. Nothing looked. The column is dropped, and this
+ * comment is the record of why — when `ToolStatusDto` grows a size, add it
+ * back and give the missing row its dash.
+ */
+const COLUMNS: Column<ToolRow>[] = [
+  {
+    key: "name",
+    header: "Tool",
+    render: (row) => <span className="font-medium">{row.name}</span>,
+  },
+  {
+    key: "version",
+    header: "Version",
+    render: (row) => <span className="tabular-nums">{row.version}</span>,
+  },
+  {
+    key: "state",
+    header: "State",
+    // Sorted and searched on the word the reader can see, not on the internal
+    // id behind it — a filter for "missing" that matched nothing because the
+    // cell says `Missing` is the sort of mismatch nobody reports.
+    getValue: (row) => VERDICT[row.state].word,
+    render: (row) => (
+      <StatusPill status={VERDICT[row.state].word} kind={VERDICT[row.state].kind} />
+    ),
+  },
+  {
+    key: "note",
+    header: "Note",
+    render: (row) => <span className="text-muted">{row.note}</span>,
+  },
+];

--- a/packages/ui-next/src/screens/Toolbox.tsx
+++ b/packages/ui-next/src/screens/Toolbox.tsx
@@ -8,15 +8,21 @@ import {
   Button,
   LoadingState,
   Screen,
+  SideRail,
   StatusPill,
   Table,
   type Column,
-  type StatusKind,
 } from "@srelens/ui-kit";
-import { useActiveContext } from "../lib/clusters";
+import { useActiveContext, useContexts } from "../lib/clusters";
 import { FailureAlert, FailureState } from "../lib/errorCopy";
 import { useInfo } from "../lib/probe";
 import { useResource } from "../lib/useResource";
+import {
+  ExecAuthRail,
+  EXEC_AUTH_RAIL_WIDTH,
+  TOOL_VERDICT,
+  type ToolState,
+} from "./toolbox/ExecAuthRail";
 
 /** §17's pane head, verbatim — `SearchPaths` really does add that directory. */
 const PANE_HEAD = "Managed tools · installed under ~/.srelens/bin";
@@ -37,54 +43,25 @@ const INSTALLABLE = new Set(["kubectl", "helm", "krew"]);
 type InstallableTool = "kubectl" | "helm" | "krew";
 
 /**
- * What the screen can actually tell apart about a tool. **Three values, not
- * four.**
+ * What the screen can tell apart about a tool, and the word it draws for each
+ * — {@link TOOL_VERDICT}, which lives beside the rail because the rail needs
+ * the same four words and one table is the rule.
  *
- * §17 draws a fourth, `update` — a newer version exists upstream — and there is
- * no source for it anywhere in this app. Nothing queries a release feed, and a
- * kubeconfig never states a minimum version for the binary it names, so an
- * `update` state could only ever be inferred. It is not inferred here.
+ * §17 draws a fifth state, `update` — a newer version exists upstream — and
+ * there is no source for it anywhere in this app. Nothing queries a release
+ * feed, and a kubeconfig never states a minimum version for the binary it
+ * names, so an `update` state could only ever be inferred. It is not inferred
+ * here, and its `Update` button went with it.
  *
  * `unmanaged` is the one §17 does not draw and this does: a tool that IS
  * installed and IS usable, but that somebody else put on the PATH. It matters
  * because the pane head promises `~/.srelens/bin`, and a row reading plain
  * `Installed` for a Homebrew helm quietly claims srelens put it there.
  */
-type ToolState = "installed" | "unmanaged" | "missing";
-
 function toolState(tool: ToolStatus): ToolState {
   if (!tool.installed) return "missing";
   return tool.source === "system" ? "unmanaged" : "installed";
 }
-
-/**
- * THE ONE HAND-PAIRED WORD/TONE TABLE IN THIS SCREEN, AND IT IS MARKED
- * BECAUSE IT SHOULD NOT HAVE TO EXIST.
- *
- * Every other status word in this app comes off a derivation in
- * `@srelens/core` — `podStatus`, `nodeStatus`, `eventVerdict`,
- * `logConnectionStatus` — precisely so a word and the colour beside it cannot
- * drift apart in two places. `packages/core/src/lib/toolbox.ts` has no such
- * derivation: it wraps the capability and returns the DTO unchanged, and there
- * is no `toolVerdict` anywhere to import. This task owns one screen file, so
- * the verdict cannot be added to core from here.
- *
- * So it lives here, once, next to the state it names, and it is the ONLY place
- * in this file that pairs a word with a severity. **If a `toolVerdict` is ever
- * added to core, delete this and call it** — do not add a second table beside
- * it, and do not spell `state === "missing" ? … : …` anywhere else in this
- * file.
- *
- * The severities are §17's own rule (`installed` → ok, everything else muted),
- * with `update`'s `warn` gone along with the state it belonged to. A missing
- * tool is not an incident: srelens talks to the API server itself, and the row
- * beside the word already offers the install.
- */
-const VERDICT: Record<ToolState, { word: string; kind: StatusKind }> = {
-  installed: { word: "Installed", kind: "success" },
-  unmanaged: { word: "Unmanaged", kind: "neutral" },
-  missing: { word: "Missing", kind: "neutral" },
-};
 
 /** A `vMAJOR.MINOR…` string as the pair Kubernetes measures skew in. */
 function minorVersion(text: string): { major: number; minor: number } | null {
@@ -183,6 +160,14 @@ export function Toolbox(_props: { route: string }) {
   // same source the cluster overview's head reads. Nothing here connects.
   const serverVersion = useInfo(context?.stableId ?? null)?.version ?? "";
 
+  // EVERY context, not the active one. A tool this cluster is fine without is
+  // exactly what stops the next cluster answering, and the reader with a
+  // broken context cannot select it to find that out — selecting it is what
+  // fails. The rail memoizes on the names so the store's identity churn does
+  // not re-diagnose the kubeconfig on every notification.
+  const all = useContexts();
+  const contextNames = useMemo(() => all.map((c) => c.name), [all]);
+
   const inventory = useResource(async () => {
     const result = await toolboxStatus();
     // `toolboxStatus` reports a rejection as `{ error }` rather than throwing,
@@ -265,48 +250,55 @@ export function Toolbox(_props: { route: string }) {
 
   return (
     <Screen title="Toolbox" eyebrow="workspace / binaries" fill>
-      {/* Task 9 wraps this pair in `SideRail` (head `Exec auth check`, 288px)
-          and drops the rail in beside it. Left as the bare pane for now: a
-          rail with nothing in it is a 288px column of empty. */}
-      <div className="pane-head">{PANE_HEAD}</div>
-      <div className="scroll flex min-h-0 flex-1 flex-col gap-3 p-3">
-        {!desktop && (
-          /* Said ONCE, for the whole table, rather than as a disabled button on
-             every row. `installKubectl`, `installHelm`, `installKrew`,
-             `installPlugin`, `upgradePlugin` and `removePlugin` are all in the
-             server's `WEB_DENIED_CAPABILITIES`, so every one of §17's per-row
-             buttons would fail here — and a row of controls that reject on
-             click is worse than a table that reads as the inventory it is. */
-          <Alert tone="info" title="Tools are managed where srelens runs">
-            This lists what that machine has. Installing and updating them happens in the srelens
-            desktop app.
-          </Alert>
-        )}
-        {installError && (
-          <FailureAlert
-            tone="sev"
-            title={`Could not install ${installError.tool}`}
-            error={installError.error}
-          />
-        )}
-        {inventory.status === "loading" ? (
-          <LoadingState label="Locating the toolchain" />
-        ) : inventory.status === "error" ? (
-          <FailureState
-            title="Could not inventory the toolchain"
-            error={inventory.error}
-            onRetry={inventory.reload}
-          />
-        ) : (
-          <Table
-            columns={columns}
-            data={rows}
-            getRowKey={(row) => row.name}
-            emptyText="No tools reported"
-            emptyHint="srelens found no entry for kubectl, helm or krew — not even a missing one."
-          />
-        )}
-      </div>
+      {/* The inventory answers "what does this machine have"; the rail answers
+          "and can each context still authenticate", which is the question a
+          cluster that will not open is actually asking. `mainHead` keeps §17's
+          pane head level with the rail's own. */}
+      <SideRail
+        head="Exec auth check"
+        mainHead={PANE_HEAD}
+        width={EXEC_AUTH_RAIL_WIDTH}
+        rail={<ExecAuthRail contexts={contextNames} />}
+      >
+        <div className="scroll flex min-h-0 flex-1 flex-col gap-3 p-3">
+          {!desktop && (
+            /* Said ONCE, for the whole table, rather than as a disabled button on
+               every row. `installKubectl`, `installHelm`, `installKrew`,
+               `installPlugin`, `upgradePlugin` and `removePlugin` are all in the
+               server's `WEB_DENIED_CAPABILITIES`, so every one of §17's per-row
+               buttons would fail here — and a row of controls that reject on
+               click is worse than a table that reads as the inventory it is. */
+            <Alert tone="info" title="Tools are managed where srelens runs">
+              This lists what that machine has. Installing and updating them happens in the srelens
+              desktop app.
+            </Alert>
+          )}
+          {installError && (
+            <FailureAlert
+              tone="sev"
+              title={`Could not install ${installError.tool}`}
+              error={installError.error}
+            />
+          )}
+          {inventory.status === "loading" ? (
+            <LoadingState label="Locating the toolchain" />
+          ) : inventory.status === "error" ? (
+            <FailureState
+              title="Could not inventory the toolchain"
+              error={inventory.error}
+              onRetry={inventory.reload}
+            />
+          ) : (
+            <Table
+              columns={columns}
+              data={rows}
+              getRowKey={(row) => row.name}
+              emptyText="No tools reported"
+              emptyHint="srelens found no entry for kubectl, helm or krew — not even a missing one."
+            />
+          )}
+        </div>
+      </SideRail>
     </Screen>
   );
 }
@@ -354,9 +346,9 @@ const COLUMNS: Column<ToolRow>[] = [
     // Sorted and searched on the word the reader can see, not on the internal
     // id behind it — a filter for "missing" that matched nothing because the
     // cell says `Missing` is the sort of mismatch nobody reports.
-    getValue: (row) => VERDICT[row.state].word,
+    getValue: (row) => TOOL_VERDICT[row.state].word,
     render: (row) => (
-      <StatusPill status={VERDICT[row.state].word} kind={VERDICT[row.state].kind} />
+      <StatusPill status={TOOL_VERDICT[row.state].word} kind={TOOL_VERDICT[row.state].kind} />
     ),
   },
   {

--- a/packages/ui-next/src/screens/Toolbox.tsx
+++ b/packages/ui-next/src/screens/Toolbox.tsx
@@ -15,6 +15,7 @@ import {
 } from "@srelens/ui-kit";
 import { useActiveContext, useContexts } from "../lib/clusters";
 import { FailureAlert, FailureState } from "../lib/errorCopy";
+import { formatBytes } from "../lib/numbers";
 import { useInfo } from "../lib/probe";
 import { useResource } from "../lib/useResource";
 import {
@@ -129,6 +130,7 @@ interface ToolRow {
   version: string;
   state: ToolState;
   note: string;
+  size: string;
   installed: boolean;
 }
 
@@ -190,6 +192,7 @@ export function Toolbox(_props: { route: string }) {
       (inventory.data ?? []).map((tool) => ({
         name: tool.name,
         version: tool.version || ABSENT,
+        size: formatBytes(tool.sizeBytes) || ABSENT,
         state: toolState(tool),
         note: noteFor(tool, serverVersion, context?.name ?? ""),
         installed: tool.installed,
@@ -315,19 +318,14 @@ function progressLabel(percent: number | null): string {
  * The columns every platform draws, in §17's order — **minus `Size`.**
  *
  * §17 puts a right-aligned size on every row (`54.2 MB`, `48.9 MB`, `9.1 MB`).
- * `ToolStatusDto` is `{ name, installed, path, version, source }`: it carries
- * no size, no capability in the catalog reports a file's size, and nothing in
- * this app can stat a path. So there is no reading to render — not for the
- * missing tool, and not for the installed ones either.
+ * `Size` reads the byte length of the file at `path`, following symlinks —
+ * these entries are usually symlinks, and a link's own length is a handful of
+ * bytes: a plausible-looking wrong number, which is worse than none.
  *
- * A missing tool renders its absence and never `0 B`; that rule has held from
- * the cluster overview through every screen since, because a zero is a
- * measurement claimed rather than taken. The same reasoning finishes the job
- * here: if EVERY cell would be an absence, the column is not a column, and
- * drawing one headed `Size` with a dash in every row states that a size was
- * looked for and not found. Nothing looked. The column is dropped, and this
- * comment is the record of why — when `ToolStatusDto` grows a size, add it
- * back and give the missing row its dash.
+ * A tool with no readable size renders a dash, never `0 B`. A zero is a
+ * measurement, and a tool that is not installed — or whose path cannot be
+ * stat'd — has not been measured. That rule has held from the cluster overview
+ * through every screen since.
  */
 const COLUMNS: Column<ToolRow>[] = [
   {
@@ -355,5 +353,11 @@ const COLUMNS: Column<ToolRow>[] = [
     key: "note",
     header: "Note",
     render: (row) => <span className="text-muted">{row.note}</span>,
+  },
+  {
+    key: "size",
+    header: "Size",
+    align: "end",
+    render: (row) => <span className="tabular-nums text-muted">{row.size}</span>,
   },
 ];

--- a/packages/ui-next/src/screens/detail/ConfigBody.tsx
+++ b/packages/ui-next/src/screens/detail/ConfigBody.tsx
@@ -23,9 +23,10 @@ function ConfigEntry({ name, value }: { name: string; value: string }) {
 /**
  * A ConfigMap's Details pane: its `data` keys and values — classic's
  * `ConfigBody`, minus the inline edit/save affordance (`ConfigDataEditor`):
- * ui-next's Details panes are read-only, the same call `ServiceBody`'s Ports
- * table and `PodBody`'s Containers pane made for their own write affordances
- * (an inline port-forward button neither wires). `binaryData` is not read
+ * this pane is read-only. `ServiceBody`'s Ports table and `PodBody`'s
+ * Containers pane once made the same call about classic's inline port-forward
+ * button; both offer it now, into §A.4's dialog — editing a ConfigMap in place
+ * is a different question and still unanswered. `binaryData` is not read
  * here either — classic's own `ConfigBody` never read it.
  */
 export function ConfigDetailsBody({ object }: { object: K8sObject }) {

--- a/packages/ui-next/src/screens/detail/PodBody.test.tsx
+++ b/packages/ui-next/src/screens/detail/PodBody.test.tsx
@@ -254,7 +254,8 @@ describe("a container's ports as the way in to a forward", () => {
     await waitFor(() => expect(dialogSelect("Target").value).toBe("pod/web-1"));
     await waitFor(() => expect(dialogSelect("Namespace").value).toBe("default"));
     expect(dialogInput("Remote port").value).toBe("5432");
-    expect(dialogInput("Local port").value).toBe("");
+    // Offered, not demanded — see NewForwardDialog on the stepping.
+    expect(dialogInput("Local port").value).toBe("5432");
   });
 
   it("names the Pod as a Pod — pod/, from its kind, not the container's name", async () => {
@@ -266,6 +267,7 @@ describe("a container's ports as the way in to a forward", () => {
     );
     await userEvent.click(screen.getByRole("button", { name: "Forward http: 9376/TCP on api" }));
     await screen.findByRole("dialog");
+    await userEvent.clear(screen.getByLabelText("Local port"));
     await userEvent.type(screen.getByLabelText("Local port"), "9091");
     await waitFor(() =>
       expect(screen.getByText(/port-forward pod\/web-1 9091:9376/)).toBeDefined(),

--- a/packages/ui-next/src/screens/detail/PodBody.test.tsx
+++ b/packages/ui-next/src/screens/detail/PodBody.test.tsx
@@ -1,9 +1,26 @@
-import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { K8sObject } from "@srelens/core";
 import { KV } from "@srelens/ui-kit";
+
+// What §A.4's dialog reaches for once a container's port opens it. This file
+// has no cluster; every formatter (`portText`, `containerStateText`, …) and
+// both forward rules (`toKubectl`, `kindToForwardTarget`) stay REAL, since
+// "a Pod is `pod/`, not `svc/`" is one of the things under test.
+const forwardCore = vi.hoisted(() => ({
+  listNamespaces: vi.fn(async () => ({ namespaces: ["default"] })),
+  listServices: vi.fn(async () => ({ services: [] })),
+  listPods: vi.fn(async () => ({ pods: [{ name: "web-1", namespace: "default" }] })),
+  startPortForward: vi.fn(async () => ({ id: 1, localPort: 9090 })),
+}));
+vi.mock("@srelens/core", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@srelens/core")>()),
+  ...forwardCore,
+}));
+
 import { Section } from "./Section";
-import { PodContainersBody, PodDetailsBody, podFacts } from "./PodBody";
+import { PodContainersBody, PodContainersTable, PodDetailsBody, podFacts } from "./PodBody";
 
 const APP_CONTAINER = {
   name: "app",
@@ -52,6 +69,7 @@ describe("PodContainersBody", () => {
   it("names every container", () => {
     render(
       <PodContainersBody
+        context="ctx"
         object={pod(
           { containers: [APP_CONTAINER, SIDECAR_CONTAINER] },
           { containerStatuses: [APP_STATUS, SIDECAR_STATUS] },
@@ -65,6 +83,7 @@ describe("PodContainersBody", () => {
   it("shows a container's state and its restart count", () => {
     render(
       <PodContainersBody
+        context="ctx"
         object={pod({ containers: [APP_CONTAINER] }, { containerStatuses: [APP_STATUS] })}
       />,
     );
@@ -76,6 +95,7 @@ describe("PodContainersBody", () => {
   it("shows ports, probes, environment and mounts for a container that has them", () => {
     render(
       <PodContainersBody
+        context="ctx"
         object={pod({ containers: [APP_CONTAINER] }, { containerStatuses: [APP_STATUS] })}
       />,
     );
@@ -93,6 +113,7 @@ describe("PodContainersBody", () => {
   it("omits ports, probes, environment and mounts for a container that has none", () => {
     render(
       <PodContainersBody
+        context="ctx"
         object={pod({ containers: [SIDECAR_CONTAINER] }, { containerStatuses: [SIDECAR_STATUS] })}
       />,
     );
@@ -106,7 +127,7 @@ describe("PodContainersBody", () => {
   });
 
   it("shows No containers when the pod has none", () => {
-    render(<PodContainersBody object={pod({})} />);
+    render(<PodContainersBody context="ctx" object={pod({})} />);
     expect(screen.getByText("No containers")).toBeDefined();
   });
 
@@ -120,6 +141,7 @@ describe("PodContainersBody", () => {
     };
     render(
       <PodContainersBody
+        context="ctx"
         object={pod({ containers: [APP_CONTAINER] }, { containerStatuses: [status] })}
       />,
     );
@@ -135,7 +157,7 @@ describe("PodContainersBody", () => {
 
   it("shows which container an ephemeral container is debugging", () => {
     const debugContainer = { name: "debugger", image: "busybox", targetContainerName: "app" };
-    render(<PodContainersBody object={pod({ ephemeralContainers: [debugContainer] })} />);
+    render(<PodContainersBody context="ctx" object={pod({ ephemeralContainers: [debugContainer] })} />);
     expect(screen.getByText("Ephemeral containers")).toBeDefined();
     expect(screen.getByText("debugger")).toBeDefined();
     expect(screen.getByText("Debugging")).toBeDefined();
@@ -146,6 +168,7 @@ describe("PodContainersBody", () => {
     const commandContainer = { ...APP_CONTAINER, command: ["/bin/sh", "-c"], args: ["sleep 3600"] };
     render(
       <PodContainersBody
+        context="ctx"
         object={pod({ containers: [commandContainer] }, { containerStatuses: [APP_STATUS] })}
       />,
     );
@@ -156,11 +179,149 @@ describe("PodContainersBody", () => {
   it("omits Debugging and Command when a container has neither", () => {
     render(
       <PodContainersBody
+        context="ctx"
         object={pod({ containers: [SIDECAR_CONTAINER] }, { containerStatuses: [SIDECAR_STATUS] })}
       />,
     );
     expect(screen.queryByText("Debugging")).toBeNull();
     expect(screen.queryByText("Command")).toBeNull();
+  });
+});
+
+/**
+ * A container's ports, on both surfaces that draw them.
+ *
+ * Two ports on two containers, and NEITHER number is one of §A.4's own
+ * placeholders (9090 local, 8080 remote) — so a prefill that came from the
+ * field's default rather than from the click cannot pass.
+ */
+const PORTED_CONTAINER = {
+  name: "api",
+  image: "ghcr.io/example/api:2",
+  ports: [
+    { name: "http", containerPort: 9376, protocol: "TCP" },
+    { name: "metrics", containerPort: 5432, protocol: "TCP" },
+  ],
+};
+
+const PORTED_STATUS = {
+  name: "api",
+  ready: true,
+  restartCount: 0,
+  state: { running: { startedAt: "2026-08-20T00:00:00Z" } },
+};
+
+const dialogSelect = (name: string) => screen.getByLabelText(name) as HTMLSelectElement;
+const dialogInput = (name: string) => screen.getByLabelText(name) as HTMLInputElement;
+
+/**
+ * The container's ports are the other place the reader is already looking at
+ * the exact port they want. They used to be a run of inert strings — on the
+ * peek's pane a list, on the full tab's table one comma-joined cell — with the
+ * affordance classic offers inline missing from both.
+ */
+describe("a container's ports as the way in to a forward", () => {
+  it("makes every port of every container its own forward, on the peek's pane", async () => {
+    render(
+      <PodContainersBody
+        context="ctx"
+        object={pod(
+          { containers: [PORTED_CONTAINER, SIDECAR_CONTAINER] },
+          { containerStatuses: [PORTED_STATUS, SIDECAR_STATUS] },
+        )}
+      />,
+    );
+    // Core's own `portText`, still — the words did not change, only what they
+    // are attached to.
+    expect(screen.getByRole("button", { name: "Forward http: 9376/TCP on api" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Forward metrics: 5432/TCP on api" })).toBeDefined();
+    // A container with no ports gains no affordance and no empty row.
+    expect(screen.queryByRole("button", { name: /on sidecar/ })).toBeNull();
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("opens §A.4's dialog on this POD, in its namespace, on the port that was clicked", async () => {
+    render(
+      <PodContainersBody
+        context="ctx"
+        object={pod({ containers: [PORTED_CONTAINER] }, { containerStatuses: [PORTED_STATUS] })}
+      />,
+    );
+    // The SECOND port, so a cell that always handed over its first cannot pass.
+    await userEvent.click(screen.getByRole("button", { name: "Forward metrics: 5432/TCP on api" }));
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("New port forward")).toBeDefined();
+    await waitFor(() => expect(dialogSelect("Target").value).toBe("pod/web-1"));
+    await waitFor(() => expect(dialogSelect("Namespace").value).toBe("default"));
+    expect(dialogInput("Remote port").value).toBe("5432");
+    expect(dialogInput("Local port").value).toBe("");
+  });
+
+  it("names the Pod as a Pod — pod/, from its kind, not the container's name", async () => {
+    render(
+      <PodContainersBody
+        context="ctx"
+        object={pod({ containers: [PORTED_CONTAINER] }, { containerStatuses: [PORTED_STATUS] })}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Forward http: 9376/TCP on api" }));
+    await screen.findByRole("dialog");
+    await userEvent.type(screen.getByLabelText("Local port"), "9091");
+    await waitFor(() =>
+      expect(screen.getByText(/port-forward pod\/web-1 9091:9376/)).toBeDefined(),
+    );
+    expect(screen.queryByText(/port-forward pod\/api/)).toBeNull();
+  });
+
+  it("does the same in the full tab's containers table, where they were one joined string", async () => {
+    render(
+      <PodContainersTable
+        context="ctx"
+        object={pod({ containers: [PORTED_CONTAINER] }, { containerStatuses: [PORTED_STATUS] })}
+      />,
+    );
+    expect(screen.queryByRole("dialog")).toBeNull();
+    await userEvent.click(screen.getByRole("button", { name: "Forward metrics: 5432/TCP on api" }));
+    await screen.findByRole("dialog");
+    await waitFor(() => expect(dialogSelect("Target").value).toBe("pod/web-1"));
+    expect(dialogInput("Remote port").value).toBe("5432");
+  });
+
+  it("still says a portless container has no ports, on both surfaces", () => {
+    const { unmount } = render(
+      <PodContainersTable
+        context="ctx"
+        object={pod({ containers: [SIDECAR_CONTAINER] }, { containerStatuses: [SIDECAR_STATUS] })}
+      />,
+    );
+    // The Ports cell's own dash — several columns render one for a container
+    // this bare, so the count is what says the cell did not vanish.
+    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+    unmount();
+    render(
+      <PodContainersBody
+        context="ctx"
+        object={pod({ containers: [SIDECAR_CONTAINER] }, { containerStatuses: [SIDECAR_STATUS] })}
+      />,
+    );
+    expect(screen.queryByText("Ports")).toBeNull();
+  });
+
+  it("puts no port or command in a title attribute", async () => {
+    render(
+      <PodContainersBody
+        context="ctx"
+        object={pod({ containers: [PORTED_CONTAINER] }, { containerStatuses: [PORTED_STATUS] })}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Forward http: 9376/TCP on api" }));
+    await screen.findByRole("dialog");
+    const joined = Array.from(document.querySelectorAll("[title]"))
+      .map((el) => el.getAttribute("title") ?? "")
+      .join("\n");
+    for (const leak of ["9376", "5432", "port-forward", "--context"]) {
+      expect(joined).not.toContain(leak);
+    }
   });
 });
 

--- a/packages/ui-next/src/screens/detail/PodBody.test.tsx
+++ b/packages/ui-next/src/screens/detail/PodBody.test.tsx
@@ -254,8 +254,12 @@ describe("a container's ports as the way in to a forward", () => {
     await waitFor(() => expect(dialogSelect("Target").value).toBe("pod/web-1"));
     await waitFor(() => expect(dialogSelect("Namespace").value).toBe("default"));
     expect(dialogInput("Remote port").value).toBe("5432");
-    // Offered, not demanded — see NewForwardDialog on the stepping.
-    expect(dialogInput("Local port").value).toBe("5432");
+    // Offered, not demanded, and NOT the far end again — a free port from a
+    // range nothing claims by convention. The property, not the draw.
+    const offered = Number(dialogInput("Local port").value);
+    expect(offered).toBeGreaterThanOrEqual(10000);
+    expect(offered).toBeLessThanOrEqual(32767);
+    expect(offered).not.toBe(5432);
   });
 
   it("names the Pod as a Pod — pod/, from its kind, not the container's name", async () => {

--- a/packages/ui-next/src/screens/detail/PodBody.tsx
+++ b/packages/ui-next/src/screens/detail/PodBody.tsx
@@ -32,6 +32,7 @@ import {
   Table,
   type Column,
 } from "@srelens/ui-kit";
+import { ForwardAction } from "../forwards/ForwardAction";
 import { Section } from "./Section";
 import { ConditionsSection, StringList } from "./sections";
 import type { DetailFact, FactsFor } from "./facts";
@@ -303,6 +304,76 @@ export function PodDetailsBody({ object }: { object: K8sObject }) {
   return <>{sections}</>;
 }
 
+/** The highest port a TCP socket can bind. */
+const MAX_PORT = 65_535;
+
+/** Where a container's ports are being drawn, so a forward opened from one
+ *  knows what it is a port OF. A container is not a forward target; the pod
+ *  around it is. */
+interface PortsSubject {
+  context: string;
+  namespace: string;
+  /** The POD's name — `kubectl port-forward pod/<name>`. */
+  pod: string;
+  /** The container the ports belong to, which is what tells two identical
+   *  port numbers on one pod apart in an accessible name. */
+  container: string;
+}
+
+/**
+ * A container's ports, each one a way into a forward.
+ *
+ * THE ONE RENDERING OF A CONTAINER'S PORTS, drawn by both surfaces that show
+ * them — the peek's Containers pane down a column, the full tab's table across
+ * a cell. They used to be two inert renderings of core's `portText`: a
+ * `StringList` in one and `ports.map(portText).join(", ")` in the other. The
+ * words are still core's, unchanged; what changed is that each one is now the
+ * control that forwards it, rather than a string with no way to act on it.
+ *
+ * A port is a chip and not a button beside a string on purpose: a row of
+ * "Forward" buttons next to `http: 8080/TCP, metrics: 9090/TCP` would make the
+ * reader match a verb to a number by position.
+ *
+ * A port with no number a socket could bind — a malformed spec — renders as
+ * the same text it always did rather than as a control that could not work.
+ */
+function ContainerPorts({
+  ports,
+  subject,
+}: {
+  ports: Record<string, unknown>[];
+  subject?: PortsSubject;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      {ports.map((port, i) => {
+        const text = portText(port);
+        const number = Number(str(port.containerPort));
+        const forwardable =
+          subject && Number.isInteger(number) && number > 0 && number <= MAX_PORT;
+        return forwardable ? (
+          <ForwardAction
+            key={`${text}-${i}`}
+            context={subject.context}
+            namespace={subject.namespace}
+            kind="Pod"
+            name={subject.pod}
+            remotePort={number}
+            // Contains the chip's own words, so the spoken name and the drawn
+            // one are one label — and carries the container, because two
+            // containers in a pod may well publish the same port.
+            label={`Forward ${text} on ${subject.container}`}
+          >
+            {text}
+          </ForwardAction>
+        ) : (
+          <span key={`${text}-${i}`}>{text}</span>
+        );
+      })}
+    </div>
+  );
+}
+
 /**
  * One container's block — app, init or ephemeral. State and restart count come
  * from its `containerStatuses` entry (absent while the pod is still being
@@ -320,9 +391,13 @@ export function PodDetailsBody({ object }: { object: K8sObject }) {
 function ContainerCard({
   container,
   status,
+  subject,
 }: {
   container: Record<string, unknown>;
   status?: Record<string, unknown>;
+  /** Absent only where the pane cannot say which pod in which cluster it is
+   *  drawing, which is what a forward would need. */
+  subject?: Omit<PortsSubject, "container">;
 }) {
   const name = str(container.name);
   const state = status ? containerStateText(status) : undefined;
@@ -355,7 +430,12 @@ function ContainerCard({
       {lastRestart && <KV k="Last restart" v={timestampWithAge(lastRestart, Date.now())} />}
       {runningSince && <KV k="Running since" v={timestampWithAge(runningSince, Date.now())} />}
       {image && <KV k="Image" v={image} mono />}
-      {ports.length > 0 && <KV k="Ports" v={<StringList items={ports.map(portText)} />} />}
+      {ports.length > 0 && (
+        <KV
+          k="Ports"
+          v={<ContainerPorts ports={ports} subject={subject && { ...subject, container: name }} />}
+        />
+      )}
       {env.length > 0 && <KV k="Environment" v={<StringList items={env.map(envText)} />} />}
       {mounts.length > 0 && <KV k="Mounts" v={<StringList items={mounts.map(mountText)} />} />}
       {Object.keys(liveness).length > 0 && <KV k="Liveness" v={<StringList items={probeChips(liveness)} />} />}
@@ -372,17 +452,24 @@ function ContainerGroup({
   title,
   containers,
   statuses,
+  subject,
 }: {
   title: string;
   containers: Record<string, unknown>[];
   statuses: Map<string, Record<string, unknown>>;
+  subject?: Omit<PortsSubject, "container">;
 }) {
   if (containers.length === 0) return null;
   return (
     <Section title={title}>
       <div className="flex flex-col gap-4">
         {containers.map((c) => (
-          <ContainerCard key={str(c.name)} container={c} status={statuses.get(str(c.name))} />
+          <ContainerCard
+            key={str(c.name)}
+            container={c}
+            status={statuses.get(str(c.name))}
+            subject={subject}
+          />
         ))}
       </div>
     </Section>
@@ -394,18 +481,37 @@ function statusesByName(list: unknown): Map<string, Record<string, unknown>> {
 }
 
 /**
+ * What a container's ports can be forwarded AS, or `undefined` where they
+ * cannot be forwarded at all.
+ *
+ * One derivation for both surfaces, so the peek's pane and the tab's table
+ * cannot come to disagree about which pod a port belongs to. A pod with no
+ * namespace or no name — or a screen with no cluster in focus — has nothing to
+ * point a forward at, and the ports render as the text they always were.
+ */
+function forwardSubject(
+  object: K8sObject,
+  context: string,
+): Omit<PortsSubject, "container"> | undefined {
+  const namespace = str(object.metadata?.namespace);
+  const pod = str(object.metadata?.name);
+  return context && namespace && pod ? { context, namespace, pod } : undefined;
+}
+
+/**
  * A pod's Containers pane: every container named, its runtime state and
  * restart count, its ports, probes, environment and mounts. Ported from
  * classic's `ContainerCard`/`PodDetailView` — the largest single body in
- * `ResourceOverview.tsx` — onto kit components; the interactive port-forward
- * affordance classic offers inline is not wired here, since neither ui-next
- * nor the kit has a forward dialog yet (see the task report).
+ * `ResourceOverview.tsx` — onto kit components. The interactive port-forward
+ * affordance classic offers inline IS wired now, through
+ * {@link ContainerPorts}: each port is the control that forwards it, into
+ * §A.4's dialog.
  *
  * Flat blocks, like the Details pane beside it: the two panes are read in the
  * same 352px column, and a card here beside a rule there is two answers to
  * one question.
  */
-export function PodContainersBody({ object }: { object: K8sObject }) {
+export function PodContainersBody({ object, context }: { object: K8sObject; context: string }) {
   const spec = asRecord(object.spec);
   const status = asRecord(object.status);
   const containers = asArray(spec.containers).map(asRecord);
@@ -417,6 +523,7 @@ export function PodContainersBody({ object }: { object: K8sObject }) {
   }
 
   const containerStatuses = statusesByName(status.containerStatuses);
+  const subject = forwardSubject(object, context);
 
   return (
     <>
@@ -424,6 +531,7 @@ export function PodContainersBody({ object }: { object: K8sObject }) {
         title="Init containers"
         containers={initContainers}
         statuses={statusesByName(status.initContainerStatuses)}
+        subject={subject}
       />
       {/* Always open, never conditional on this pod having init or ephemeral
           containers beside it. It is the pane's subject — a reader who clicks
@@ -441,7 +549,12 @@ export function PodContainersBody({ object }: { object: K8sObject }) {
         ) : (
           <div className="flex flex-col gap-4">
             {containers.map((c) => (
-              <ContainerCard key={str(c.name)} container={c} status={containerStatuses.get(str(c.name))} />
+              <ContainerCard
+                key={str(c.name)}
+                container={c}
+                status={containerStatuses.get(str(c.name))}
+                subject={subject}
+              />
             ))}
           </div>
         )}
@@ -450,6 +563,7 @@ export function PodContainersBody({ object }: { object: K8sObject }) {
         title="Ephemeral containers"
         containers={ephemeralContainers}
         statuses={statusesByName(status.ephemeralContainerStatuses)}
+        subject={subject}
       />
     </>
   );
@@ -481,15 +595,36 @@ function probeSummary(container: Record<string, unknown>): string {
   return "—";
 }
 
-const CONTAINER_COLUMNS: Column<ContainerRow>[] = [
+/**
+ * The summary table's columns, built against the pod they are drawn for.
+ *
+ * A function rather than a module-level constant because ONE of these cells is
+ * interactive — a port has to know which pod it would forward — and the reason
+ * the rest of this app keeps its columns module-level (so sort and filter read
+ * the same strings the reader sees) is not in play for a cell holding
+ * controls: that column is neither sortable nor filterable, and says so.
+ */
+function containerColumns(subject?: Omit<PortsSubject, "container">): Column<ContainerRow>[] {
+  return [
   { key: "name", header: "Name", render: (r) => <span className="font-mono">{str(r.container.name)}</span> },
   { key: "image", header: "Image", render: (r) => <span className="font-mono">{str(r.container.image) || "—"}</span> },
   {
     key: "ports",
     header: "Ports",
+    // Controls, not text: there is nothing here for a comparator to order or a
+    // search to match, and a header that sorted by rendered nodes would sort
+    // by nothing at all.
+    sortable: false,
+    filterable: false,
     render: (r) => {
       const ports = asArray(r.container.ports).map(asRecord);
-      return ports.length > 0 ? ports.map(portText).join(", ") : "—";
+      if (ports.length === 0) return "—";
+      return (
+        <ContainerPorts
+          ports={ports}
+          subject={subject && { ...subject, container: str(r.container.name) }}
+        />
+      );
     },
   },
   // `cpu · memory` in one cell, the design's own form — `resourceSummary` is
@@ -518,7 +653,8 @@ const CONTAINER_COLUMNS: Column<ContainerRow>[] = [
       return <StatusPill status={state.text} kind={state.kind} tinted />;
     },
   },
-];
+  ];
+}
 
 /**
  * A pod's containers as one table, the way the full tab reads them inline on
@@ -540,7 +676,7 @@ const CONTAINER_COLUMNS: Column<ContainerRow>[] = [
  * app containers, and the peek's pane is where a finished migration step or an
  * attached debug container is read in full.
  */
-export function PodContainersTable({ object }: { object: K8sObject }) {
+export function PodContainersTable({ object, context }: { object: K8sObject; context: string }) {
   const spec = asRecord(object.spec);
   const containers = asArray(spec.containers).map(asRecord);
   if (containers.length === 0) return null;
@@ -552,7 +688,7 @@ export function PodContainersTable({ object }: { object: K8sObject }) {
   return (
     <Section title="Containers">
       <Table
-        columns={CONTAINER_COLUMNS}
+        columns={containerColumns(forwardSubject(object, context))}
         data={rows}
         getRowKey={(r) => str(r.container.name)}
       />

--- a/packages/ui-next/src/screens/detail/ServiceBody.test.tsx
+++ b/packages/ui-next/src/screens/detail/ServiceBody.test.tsx
@@ -216,9 +216,14 @@ describe("ServiceDetailsBody", () => {
       await waitFor(() => expect(select("Target").value).toBe("svc/checkout"));
       await waitFor(() => expect(select("Namespace").value).toBe("default"));
       expect(input("Remote port").value).toBe("6379");
-      // Offered, not demanded: the same number on this side is what a person
-      // reaches for, and it is only stepped up if srelens already holds it.
-      expect(input("Local port").value).toBe("6379");
+      // Offered, not demanded, and NOT the far end again: a free port drawn
+      // from a range nothing claims by convention. Asserted as the property
+      // rather than a number, so this test says what it means without
+      // pinning the draw.
+      const offered = Number(input("Local port").value);
+      expect(offered).toBeGreaterThanOrEqual(10000);
+      expect(offered).toBeLessThanOrEqual(32767);
+      expect(offered).not.toBe(6379);
     });
 
     it("forwards the service's port, not the targetPort behind it", async () => {

--- a/packages/ui-next/src/screens/detail/ServiceBody.test.tsx
+++ b/packages/ui-next/src/screens/detail/ServiceBody.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { EndpointSliceSummary, K8sObject, PodMetric, PodSummary } from "@srelens/core";
 
 // The "Endpoint Slices" section reads live EndpointSlices for the Service's
@@ -17,11 +18,23 @@ const { listEndpointSlices, podsForSelector, podMetrics } = vi.hoisted(() => ({
   podMetrics: vi.fn(async (): Promise<{ metrics?: PodMetric[]; error?: string }> => ({ metrics: [] })),
 }));
 
+// What §A.4's dialog reaches for once a Ports row opens it. Stubbed for the
+// same reason as the three above: this file has no cluster. `toKubectl` and
+// `kindToForwardTarget` stay REAL — they are what decides that a Service reads
+// `svc/`, which is half of what these tests are about.
+const forwardCore = vi.hoisted(() => ({
+  listNamespaces: vi.fn(async () => ({ namespaces: ["default"] })),
+  listServices: vi.fn(async () => ({ services: [{ name: "checkout", namespace: "default" }] })),
+  listPods: vi.fn(async () => ({ pods: [] })),
+  startPortForward: vi.fn(async () => ({ id: 1, localPort: 9090 })),
+}));
+
 vi.mock("@srelens/core", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@srelens/core")>()),
   listEndpointSlices,
   podsForSelector,
   podMetrics,
+  ...forwardCore,
 }));
 
 import { GenericBody } from "./GenericBody";
@@ -160,6 +173,84 @@ describe("ServiceDetailsBody", () => {
     it("omits the Ports section for a service with no ports", () => {
       render(<ServiceDetailsBody object={service({ type: "ExternalName" })} context="ctx" />);
       expect(screen.queryByText("Ports")).toBeNull();
+    });
+  });
+
+  /**
+   * The Ports table is where the reader is already looking at the exact port
+   * they want to forward, and until now it could only be read. Every row is a
+   * way into §A.4's dialog, prefilled with this Service and THAT row's port.
+   *
+   * Nothing starts here: the dialog is where the local port is named, the
+   * equivalent command is read and the browser switch lives.
+   */
+  describe("Ports — the way in to a forward", () => {
+    /** Two ports, neither of them the dialog's own placeholders (9090/8080),
+     *  so a prefill can only have come from the row that was clicked. */
+    const TWO_PORTS = service({
+      ports: [
+        { name: "postgres", port: 5432, targetPort: 9999, protocol: "TCP" },
+        { name: "redis", port: 6379, targetPort: 6380, protocol: "TCP" },
+      ],
+    });
+
+    const select = (name: string) => screen.getByLabelText(name) as HTMLSelectElement;
+    const input = (name: string) => screen.getByLabelText(name) as HTMLInputElement;
+
+    it("offers a forward on every port row, and opens nothing until one is picked", () => {
+      render(<ServiceDetailsBody object={TWO_PORTS} context="ctx" />);
+      expect(screen.getByRole("button", { name: "Forward port 5432" })).toBeDefined();
+      expect(screen.getByRole("button", { name: "Forward port 6379" })).toBeDefined();
+      // The half that makes every assertion below mean something: a dialog
+      // that were always mounted would pass them all.
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+
+    it("opens §A.4's dialog on this Service, in its namespace, on THAT row's port", async () => {
+      render(<ServiceDetailsBody object={TWO_PORTS} context="ctx" />);
+      // The SECOND row, so a table that always handed over its first port
+      // cannot pass.
+      await userEvent.click(screen.getByRole("button", { name: "Forward port 6379" }));
+      const dialog = await screen.findByRole("dialog");
+      expect(within(dialog).getByText("New port forward")).toBeDefined();
+      await waitFor(() => expect(select("Target").value).toBe("svc/checkout"));
+      await waitFor(() => expect(select("Namespace").value).toBe("default"));
+      expect(input("Remote port").value).toBe("6379");
+      // The OS picks the local port. Prefilling it with the remote one is how
+      // forwarding a port already open here hits the clash error.
+      expect(input("Local port").value).toBe("");
+    });
+
+    it("forwards the service's port, not the targetPort behind it", async () => {
+      // `kubectl port-forward svc/x L:R` takes the SERVICE port and resolves
+      // the targetPort itself. 9999 is what a cell-reading mistake would grab.
+      render(<ServiceDetailsBody object={TWO_PORTS} context="ctx" />);
+      await userEvent.click(screen.getByRole("button", { name: "Forward port 5432" }));
+      await screen.findByRole("dialog");
+      expect(input("Remote port").value).toBe("5432");
+      expect(input("Remote port").value).not.toBe("9999");
+    });
+
+    it("names the Service as a Service — svc/, from its kind", async () => {
+      render(<ServiceDetailsBody object={TWO_PORTS} context="ctx" />);
+      await userEvent.click(screen.getByRole("button", { name: "Forward port 5432" }));
+      await screen.findByRole("dialog");
+      await userEvent.type(screen.getByLabelText("Local port"), "9091");
+      await waitFor(() =>
+        expect(screen.getByText(/port-forward svc\/checkout 9091:5432/)).toBeDefined(),
+      );
+    });
+
+    it("puts no port or command in a title attribute", async () => {
+      render(<ServiceDetailsBody object={TWO_PORTS} context="ctx" />);
+      await userEvent.click(screen.getByRole("button", { name: "Forward port 5432" }));
+      await screen.findByRole("dialog");
+      const joined = Array.from(document.querySelectorAll("[title]"))
+        .map((el) => el.getAttribute("title") ?? "")
+        .join("\n");
+      for (const leak of ["5432", "9999", "port-forward", "--context"]) {
+        expect(joined).not.toContain(leak);
+      }
     });
   });
 

--- a/packages/ui-next/src/screens/detail/ServiceBody.test.tsx
+++ b/packages/ui-next/src/screens/detail/ServiceBody.test.tsx
@@ -216,9 +216,9 @@ describe("ServiceDetailsBody", () => {
       await waitFor(() => expect(select("Target").value).toBe("svc/checkout"));
       await waitFor(() => expect(select("Namespace").value).toBe("default"));
       expect(input("Remote port").value).toBe("6379");
-      // The OS picks the local port. Prefilling it with the remote one is how
-      // forwarding a port already open here hits the clash error.
-      expect(input("Local port").value).toBe("");
+      // Offered, not demanded: the same number on this side is what a person
+      // reaches for, and it is only stepped up if srelens already holds it.
+      expect(input("Local port").value).toBe("6379");
     });
 
     it("forwards the service's port, not the targetPort behind it", async () => {
@@ -235,6 +235,7 @@ describe("ServiceDetailsBody", () => {
       render(<ServiceDetailsBody object={TWO_PORTS} context="ctx" />);
       await userEvent.click(screen.getByRole("button", { name: "Forward port 5432" }));
       await screen.findByRole("dialog");
+      await userEvent.clear(screen.getByLabelText("Local port"));
       await userEvent.type(screen.getByLabelText("Local port"), "9091");
       await waitFor(() =>
         expect(screen.getByText(/port-forward svc\/checkout 9091:5432/)).toBeDefined(),

--- a/packages/ui-next/src/screens/detail/ServiceBody.tsx
+++ b/packages/ui-next/src/screens/detail/ServiceBody.tsx
@@ -8,6 +8,7 @@ import {
   type K8sObject,
 } from "@srelens/core";
 import { KV, PairList, Table, type Column } from "@srelens/ui-kit";
+import { ForwardAction } from "../forwards/ForwardAction";
 import { Section } from "./Section";
 import { StringList } from "./sections";
 
@@ -46,9 +47,22 @@ interface PortRow {
   key: string;
   name: string;
   port: string;
+  /**
+   * The Service port ITSELF, as a number — what a forward is pointed at.
+   *
+   * Separate from `port`, which folds the node port in for display
+   * ("80:30080") and cannot be parsed back, and deliberately not `target`:
+   * `kubectl port-forward svc/x <local>:<remote>` takes the SERVICE port and
+   * resolves the `targetPort` behind it on its own. `null` for a port that is
+   * not a number a socket could bind, which is nothing this table can forward.
+   */
+  forwardPort: number | null;
   target: string;
   protocol: string;
 }
+
+/** The highest port a TCP socket can bind. */
+const MAX_PORT = 65_535;
 
 const PORT_COLUMNS: Column<PortRow>[] = [
   { key: "name", header: "Name", render: (p) => p.name },
@@ -60,28 +74,71 @@ const PORT_COLUMNS: Column<PortRow>[] = [
 /**
  * The Service's own ports — classic's "Ports" table, shown only when the
  * Service declares any (an ExternalName service, for instance, has none).
- * "Port" folds in the node port the way classic does ("80:30080"). Classic
- * also offers an inline port-forward button on this table when the Service
- * has a selector; that is a WRITE affordance, and neither ui-next nor the
- * kit has a forward dialog yet — `PodBody`'s Containers pane made the same
- * call for a container's ports (see the task report).
+ * "Port" folds in the node port the way classic does ("80:30080").
+ *
+ * **Every row is a way into a forward**, which is the affordance classic
+ * offers inline here and ui-next could not, having had no forward dialog when
+ * this body was ported. It has one now (§A.4), and this is the obvious place
+ * for it: the row is already showing the reader the exact port they want.
+ * The row does not START anything — {@link ForwardAction} opens the dialog
+ * prefilled and the reader confirms there.
  */
-function PortsSection({ object }: { object: K8sObject }) {
+function PortsSection({ object, context }: { object: K8sObject; context: string }) {
   const spec = asRecord(object.spec);
+  const namespace = str(object.metadata?.namespace);
+  const name = str(object.metadata?.name);
   const ports: PortRow[] = asArray(spec.ports).map((p, i) => {
     const pr = asRecord(p);
+    const number = Number(str(pr.port));
     return {
       key: str(pr.name) || `port-${i}`,
       name: str(pr.name) || "—",
       port: str(pr.port) + (pr.nodePort ? `:${str(pr.nodePort)}` : ""),
+      forwardPort: Number.isInteger(number) && number > 0 && number <= MAX_PORT ? number : null,
       target: str(pr.targetPort),
       protocol: str(pr.protocol) || "TCP",
     };
   });
   if (ports.length === 0) return null;
+
+  // No cluster, or a Service the API server named neither — there is nothing
+  // to point a forward AT, and a control that opened a dialog which could not
+  // say what it was forwarding is worse than no control.
+  const canForward = Boolean(context && namespace && name);
+  const columns: Column<PortRow>[] = canForward
+    ? [
+        ...PORT_COLUMNS,
+        {
+          // §13's own unnamed trailing column, for the same reason: the header
+          // would name a verb the cells already say.
+          key: "forward",
+          header: "",
+          sortable: false,
+          filterable: false,
+          align: "end",
+          render: (p) =>
+            p.forwardPort === null ? null : (
+              <ForwardAction
+                context={context}
+                namespace={namespace}
+                kind="Service"
+                name={name}
+                remotePort={p.forwardPort}
+                // Named per row: a table of "Forward" names nothing. The PORT
+                // is what tells the rows apart, and the row shows it already —
+                // this is not a value hidden in an attribute.
+                label={`Forward port ${p.forwardPort}`}
+              >
+                Forward
+              </ForwardAction>
+            ),
+        },
+      ]
+    : PORT_COLUMNS;
+
   return (
     <Section title="Ports">
-      <Table columns={PORT_COLUMNS} data={ports} getRowKey={(p) => p.key} />
+      <Table columns={columns} data={ports} getRowKey={(p) => p.key} />
     </Section>
   );
 }
@@ -138,7 +195,7 @@ export function ServiceDetailsBody({ object, context }: { object: K8sObject; con
   return (
     <>
       <ConnectionSection object={object} />
-      <PortsSection object={object} />
+      <PortsSection object={object} context={context} />
       <EndpointSlicesSection context={context} object={object} />
     </>
   );

--- a/packages/ui-next/src/screens/detail/detailData.tsx
+++ b/packages/ui-next/src/screens/detail/detailData.tsx
@@ -234,7 +234,10 @@ const METRICS_BODY: Record<string, PaneBody> = {};
  * table rather than a broken one, which is the same answer the peek gives for
  * a missing `CONTAINERS_BODY`.
  */
-const CONTAINERS_TABLE: Record<string, (props: { object: K8sObject }) => ReactNode> = {
+const CONTAINERS_TABLE: Record<
+  string,
+  (props: { object: K8sObject; context: string }) => ReactNode
+> = {
   Pod: PodContainersTable,
 };
 
@@ -433,7 +436,11 @@ export function useDetailSubject({
     ),
     containersPane: bodyProps && ContainersBody ? createElement(ContainersBody, bodyProps) : null,
     containersTable:
-      hasContainers && object && ContainersTable ? createElement(ContainersTable, { object }) : null,
+      hasContainers && object && ContainersTable
+        ? // The context travels with the object: the table's Ports cells open
+          // a forward, and a forward is made in ONE cluster.
+          createElement(ContainersTable, { object, context })
+        : null,
     metricsPane: bodyProps && MetricsBody ? createElement(MetricsBody, bodyProps) : null,
     labels: <LabelsSection labels={meta.labels ?? {}} />,
     annotations: <AnnotationsSection kind={kind} annotations={meta.annotations ?? {}} />,

--- a/packages/ui-next/src/screens/forwards/ForwardAction.tsx
+++ b/packages/ui-next/src/screens/forwards/ForwardAction.tsx
@@ -1,0 +1,83 @@
+import { useState, type ReactNode } from "react";
+import { Button } from "@srelens/ui-kit";
+import { NewForwardDialog } from "./NewForwardDialog";
+
+export interface ForwardActionProps {
+  /** The cluster the forward is made in — a kubeconfig context NAME. */
+  context: string;
+  namespace: string;
+  /** The KUBERNETES kind — `Service`, `Pod`. `kindToForwardTarget` inside the
+   *  dialog turns it into `svc/`/`pod/`; nothing here spells either. */
+  kind: string;
+  name: string;
+  /** The port on the far end: the one this control is standing next to. */
+  remotePort: number;
+  /**
+   * The control's accessible name, which has to distinguish it from every
+   * other forward on the surface — a Ports table has one per row and a
+   * containers table one per port per container, and "Forward" four times over
+   * names nothing at all.
+   *
+   * It must CONTAIN whatever {@link children} draws, so the name a reader sees
+   * and the name a screen reader speaks are not two different labels for one
+   * control.
+   */
+  label: string;
+  /** What the control draws — a word on a table row, the port itself on a
+   *  container's chip. */
+  children: ReactNode;
+}
+
+/**
+ * A control that opens §A.4's `New port forward` on the thing beside it,
+ * prefilled.
+ *
+ * **The one affordance behind every door except the row menu's**, which
+ * already has its own dialog slot (`useRowMenu`). A Service's Ports row and a
+ * container's port both sit right next to the exact number the reader wants
+ * forwarded, and until now both were text: the row menu offered `Port forward`
+ * and minted a route that rendered a Placeholder, so there was no way to start
+ * a forward from anywhere but the forwards screen's own header.
+ *
+ * **Nothing starts here.** This opens the dialog and stops. The local port is
+ * the reader's to name (or the OS's to pick), the equivalent command is theirs
+ * to read, and the browser switch is theirs to set — all of which live in the
+ * dialog, and none of which a one-click "forward this now" would give them.
+ *
+ * The dialog is mounted only while open, per control. Radix portals it, so
+ * where in the table this sits does not decide where it draws, and a control
+ * that is never clicked costs a boolean.
+ */
+export function ForwardAction({
+  context,
+  namespace,
+  kind,
+  name,
+  remotePort,
+  label,
+  children,
+}: ForwardActionProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="ghost"
+        size="xs"
+        aria-label={label}
+        onClick={() => setOpen(true)}
+      >
+        {children}
+      </Button>
+      {open && (
+        <NewForwardDialog
+          context={context}
+          namespace={namespace}
+          target={{ kind, name, remotePort }}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/packages/ui-next/src/screens/forwards/NewForwardDialog.test.tsx
+++ b/packages/ui-next/src/screens/forwards/NewForwardDialog.test.tsx
@@ -24,6 +24,7 @@ const store = vi.hoisted(() => ({
 }));
 const core = vi.hoisted(() => ({
   startPortForward: vi.fn(),
+  openExternal: vi.fn(),
   listNamespaces: vi.fn(),
   listPods: vi.fn(),
   listServices: vi.fn(),
@@ -87,6 +88,10 @@ beforeEach(() => {
   // half of it.
   store.list = [holding(8080)];
   store.listeners.clear();
+  core.openExternal.mockResolvedValue(undefined);
+  // Not the mechanism any more — the spy is here to prove it is NOT reached.
+  // `window.open` is a silent no-op inside a Tauri WebView (#348), so a switch
+  // that called it would look wired up and open nothing on the desktop.
   opened = vi.fn();
   Object.defineProperty(window, "open", { value: opened, configurable: true, writable: true });
 });
@@ -343,17 +348,23 @@ describe("NewForwardDialog — the browser switch", () => {
     await fillIn();
     await userEvent.click(startButton());
     await waitFor(() => expect(core.notify.success).toHaveBeenCalled());
+    expect(core.openExternal).not.toHaveBeenCalled();
     expect(opened).not.toHaveBeenCalled();
   });
 
-  it("opens the desktop's loopback when it is on", async () => {
+  it("opens the desktop's loopback when it is on — through core, never window.open", async () => {
     core.startPortForward.mockResolvedValue({ id: 7, localPort: 9091 });
     open();
     await fillIn({ local: "9090" });
     await userEvent.click(screen.getByRole("switch", { name: "Open in browser when it comes up" }));
     await userEvent.click(startButton());
-    await waitFor(() => expect(opened).toHaveBeenCalledTimes(1));
-    expect(opened.mock.calls[0][0]).toBe("http://localhost:9091");
+    await waitFor(() => expect(core.openExternal).toHaveBeenCalledTimes(1));
+    // With the scheme: `forwardAddress` answers a bare authority here, and a
+    // bare `localhost:9091` is not a URL — it resolves against the page.
+    expect(core.openExternal.mock.calls[0][0]).toBe("http://localhost:9091");
+    // The switch used to call this directly, which does nothing at all in a
+    // Tauri WebView and does it without an error (#348).
+    expect(opened).not.toHaveBeenCalled();
   });
 
   it("opens the SAME address it promised in web mode, not a hardcoded localhost", async () => {
@@ -362,11 +373,34 @@ describe("NewForwardDialog — the browser switch", () => {
     await fillIn({ local: "9090" });
     await userEvent.click(screen.getByRole("switch", { name: "Open in browser when it comes up" }));
     await userEvent.click(startButton());
-    await waitFor(() => expect(opened).toHaveBeenCalledTimes(1));
-    const url = opened.mock.calls[0][0] as string;
+    await waitFor(() => expect(core.openExternal).toHaveBeenCalledTimes(1));
+    const url = core.openExternal.mock.calls[0][0] as string;
     expect(url).toBe(`${window.location.origin}/pf/7/`);
+    // Said twice: jsdom's own origin contains "localhost", so the equality
+    // above would still hold for a dialog that had hardcoded the desktop
+    // answer at some other port. This is the property.
     expect(url).toContain("/pf/7/");
     expect(url).not.toContain("localhost:9090");
+  });
+
+  it("says the browser could not be opened without losing the forward that started", async () => {
+    // The tunnel is up either way. Turning a browser that would not open into
+    // a banner over a dialog that is closing would report the wrong failure.
+    core.openExternal.mockRejectedValue(new Error("handler error: no default browser"));
+    const onClose = open();
+    await fillIn({ local: "9090" });
+    await userEvent.click(screen.getByRole("switch", { name: "Open in browser when it comes up" }));
+    await userEvent.click(startButton());
+    await waitFor(() => expect(core.notify.error).toHaveBeenCalledTimes(1));
+    const [title, detail] = core.notify.error.mock.calls[0] as [string, string];
+    expect(title).toMatch(/browser/i);
+    // `describeError`'s wording, and the internal prefix stripped off it.
+    expect(detail).toContain("no default browser");
+    expect(detail).not.toContain("handler error:");
+    // The forward itself still succeeded, and the dialog still got out of the
+    // way.
+    expect(core.notify.success).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
   });
 
   it("hints the desktop address §A.4 writes, for the port in the field", async () => {

--- a/packages/ui-next/src/screens/forwards/NewForwardDialog.test.tsx
+++ b/packages/ui-next/src/screens/forwards/NewForwardDialog.test.tsx
@@ -410,3 +410,137 @@ describe("NewForwardDialog — what it must not leak", () => {
     for (const port of ["9090", "8080"]) expect(joined).not.toContain(port);
   });
 });
+
+/**
+ * The dialog reached from a Service's Ports row, a container's port chip or
+ * the row menu's `Port forward` — the three doors that used to be dead ends.
+ *
+ * What a prefill must be: a STARTING POINT. The target and both ports stay
+ * editable, and the local port stays EMPTY — the OS picks a free one, and
+ * seeding it with the remote port is how forwarding a port you already hold
+ * locally walks straight into §A.4's clash error on the commonest case there
+ * is.
+ */
+describe("NewForwardDialog — opened from the thing being forwarded", () => {
+  /**
+   * §A.4's own fixture lists this pod LAST, and 9376 is neither the Remote
+   * port field's placeholder (8080) nor any port the fixture mentions — so a
+   * dialog that merely defaulted to its first option, or left its fields
+   * alone, cannot pass the assertions below by accident.
+   */
+  const POD_TARGET = { kind: "Pod", name: "checkout-api-5c8b7f2d9-mk3wl", remotePort: 9376 };
+
+  function openOn(
+    target: { kind: string; name: string; remotePort?: number },
+    onClose = vi.fn(),
+  ) {
+    render(
+      <NewForwardDialog context={CONTEXT} namespace="checkout" target={target} onClose={onClose} />,
+    );
+    return onClose;
+  }
+
+  const select = (name: string) => field(name) as HTMLSelectElement;
+  const input = (name: string) => field(name) as HTMLInputElement;
+
+  it("starts on the target it was handed, named the way its KIND is named", async () => {
+    openOn(POD_TARGET);
+    await screen.findByRole("dialog");
+    await waitFor(() => expect(select("Target").value).toBe("pod/checkout-api-5c8b7f2d9-mk3wl"));
+    // `pod/`, from `kindToForwardTarget` — not `svc/`, which is what a prefill
+    // that ignored the kind and guessed would produce.
+    expect(select("Target").value.startsWith("pod/")).toBe(true);
+    await waitFor(() => expect(select("Namespace").value).toBe("checkout"));
+  });
+
+  it("prefills the remote port that was clicked, and leaves the local one empty", async () => {
+    openOn(POD_TARGET);
+    await screen.findByRole("dialog");
+    expect(input("Remote port").value).toBe("9376");
+    // The value came from the click, not from the field: its placeholder says
+    // something else entirely.
+    expect(input("Remote port").placeholder).toBe("8080");
+    expect(input("Local port").value).toBe("");
+  });
+
+  it("prefills nothing when there is no target — the screen's own way in, unchanged", async () => {
+    open();
+    await screen.findByRole("dialog");
+    expect(select("Target").value).toBe("");
+    expect(input("Remote port").value).toBe("");
+  });
+
+  it("writes a Service's command with svc/, a Pod's with pod/", async () => {
+    openOn({ kind: "Service", name: "checkout-api", remotePort: 9376 });
+    await screen.findByRole("dialog");
+    await userEvent.type(field("Local port"), "9091");
+    const expected = toKubectl({
+      action: "port-forward",
+      kind: "Service",
+      name: "checkout-api",
+      context: CONTEXT,
+      namespace: "checkout",
+      localPort: 9091,
+      remotePort: 9376,
+    });
+    await waitFor(() => expect(screen.getByText(expected)).toBeTruthy());
+    expect(expected).toContain("port-forward svc/checkout-api 9091:9376");
+  });
+
+  it("is a starting point, not a lock: target and both ports stay editable", async () => {
+    openOn(POD_TARGET);
+    await screen.findByRole("dialog");
+    // The prefill is really there first — without this the rest of the test
+    // is just the dialog being filled in by hand, which it always allowed.
+    await waitFor(() => expect(select("Target").value).toBe("pod/checkout-api-5c8b7f2d9-mk3wl"));
+    expect(input("Remote port").value).toBe("9376");
+    await waitFor(() =>
+      expect(within(field("Target")).queryByRole("option", { name: "svc/checkout-web" })).toBeTruthy(),
+    );
+    await userEvent.selectOptions(field("Target"), "svc/checkout-web");
+    await userEvent.clear(field("Remote port"));
+    await userEvent.type(field("Remote port"), "443");
+    await userEvent.type(field("Local port"), "9091");
+    await waitFor(() =>
+      expect(screen.getByText(/port-forward svc\/checkout-web 9091:443/)).toBeTruthy(),
+    );
+  });
+
+  it("keeps offering the handed target when the listing that would name it refuses", async () => {
+    // The reader got here by clicking the thing itself; a Pods listing that
+    // came back forbidden is not a reason to forget what they clicked.
+    core.listPods.mockResolvedValue({ error: "ApiError: forbidden" });
+    openOn(POD_TARGET);
+    await screen.findByRole("dialog");
+    await waitFor(() => expect(core.listPods).toHaveBeenCalled());
+    await waitFor(() => expect(select("Target").value).toBe("pod/checkout-api-5c8b7f2d9-mk3wl"));
+  });
+
+  it("starts exactly the forward the reader arrived with, once they name a local port", async () => {
+    openOn(POD_TARGET);
+    await screen.findByRole("dialog");
+    await userEvent.type(field("Local port"), "9091");
+    await waitFor(() => expect(startButton().disabled).toBe(false));
+    await userEvent.click(startButton());
+    await waitFor(() => expect(core.startPortForward).toHaveBeenCalledTimes(1));
+    expect(core.startPortForward).toHaveBeenCalledWith({
+      context: CONTEXT,
+      namespace: "checkout",
+      kind: "Pod",
+      name: "checkout-api-5c8b7f2d9-mk3wl",
+      localPort: 9091,
+      remotePort: 9376,
+    });
+  });
+
+  it("drops the prefilled target when the reader moves to another namespace", async () => {
+    openOn(POD_TARGET);
+    await screen.findByRole("dialog");
+    await waitFor(() => expect(select("Target").value).toBe("pod/checkout-api-5c8b7f2d9-mk3wl"));
+    core.listServices.mockResolvedValue({ services: [] });
+    core.listPods.mockResolvedValue({ pods: [] });
+    await userEvent.selectOptions(field("Namespace"), "payments");
+    await waitFor(() => expect(core.listPods).toHaveBeenCalledWith(CONTEXT, "payments"));
+    await waitFor(() => expect(select("Target").value).toBe(""));
+  });
+});

--- a/packages/ui-next/src/screens/forwards/NewForwardDialog.test.tsx
+++ b/packages/ui-next/src/screens/forwards/NewForwardDialog.test.tsx
@@ -40,7 +40,7 @@ vi.mock("@srelens/core", async (orig) => ({
 }));
 
 import { type ActiveForward, toKubectl } from "@srelens/core";
-import { NewForwardDialog } from "./NewForwardDialog";
+import { NewForwardDialog, OFFER_HIGH, OFFER_LOW, offerLocalPort } from "./NewForwardDialog";
 
 const CONTEXT = "prod-eu";
 
@@ -453,27 +453,37 @@ describe("NewForwardDialog — opened from the thing being forwarded", () => {
     await waitFor(() => expect(select("Namespace").value).toBe("checkout"));
   });
 
-  it("prefills both ports, offering the same number on this side", async () => {
+  it("prefills the remote port, and offers a local one that is not it", async () => {
+    // Drawn at random from a range nothing claims by convention, rather than
+    // mirroring the far end — a port worth forwarding is one this machine
+    // plausibly already serves, and only srelens' own forwards can be seen
+    // from here.
+    vi.spyOn(Math, "random").mockReturnValue(0);
     openOn(POD_TARGET);
     await screen.findByRole("dialog");
     expect(input("Remote port").value).toBe("9376");
-    // The values came from the click, not from the fields: both placeholders
-    // say something else entirely.
+    // The values came from the click and the draw, not from the fields: both
+    // placeholders say something else entirely.
     expect(input("Remote port").placeholder).toBe("8080");
     expect(input("Local port").placeholder).toBe("9090");
-    // `9376:9376` is what a person reaches for, so it is what is offered.
-    expect(input("Local port").value).toBe("9376");
+    expect(input("Local port").value).toBe(String(OFFER_LOW));
+    expect(input("Local port").value).not.toBe(input("Remote port").value);
   });
 
-  it("steps the offer past a port srelens is already forwarding", async () => {
-    // Arriving from a port whose number this app already holds must not greet
-    // the reader with the clash error — the number is walked up until it is
-    // free, and 9377 is free only because 9376 is taken.
-    store.list = [holding(9376), holding(9377)];
-    openOn(POD_TARGET);
-    await screen.findByRole("dialog");
-    expect(input("Local port").value).toBe("9378");
-    expect(screen.queryByText(/already forwarded/)).toBeNull();
+  it("draws only from the offer range", () => {
+    // The unit, so the range is pinned without a component in the way. Below
+    // 49152 the OS is not handing the same numbers out for outbound sockets;
+    // above 1023 nothing well-known is being trodden on.
+    expect(offerLocalPort([], () => 0)).toBe(OFFER_LOW);
+    expect(offerLocalPort([], () => 0.9999999)).toBe(OFFER_HIGH);
+  });
+
+  it("passes over a port srelens is already forwarding, and wraps", () => {
+    const held = [holding(OFFER_LOW), holding(OFFER_LOW + 1)] as ActiveForward[];
+    expect(offerLocalPort(held, () => 0)).toBe(OFFER_LOW + 2);
+    // Drawn at the very top with the top held, it comes round rather than
+    // running off the end of the range.
+    expect(offerLocalPort([holding(OFFER_HIGH)] as ActiveForward[], () => 0.9999999)).toBe(OFFER_LOW);
   });
 
   it("asks only for what is missing, not for the target it was handed", async () => {
@@ -551,6 +561,7 @@ describe("NewForwardDialog — opened from the thing being forwarded", () => {
   });
 
   it("starts exactly the forward the reader arrived with, without touching a field", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
     openOn(POD_TARGET);
     await screen.findByRole("dialog");
     // Nothing typed: the offer is enough to start on.
@@ -562,7 +573,7 @@ describe("NewForwardDialog — opened from the thing being forwarded", () => {
       namespace: "checkout",
       kind: "Pod",
       name: "checkout-api-5c8b7f2d9-mk3wl",
-      localPort: 9376,
+      localPort: OFFER_LOW,
       remotePort: 9376,
     });
   });

--- a/packages/ui-next/src/screens/forwards/NewForwardDialog.test.tsx
+++ b/packages/ui-next/src/screens/forwards/NewForwardDialog.test.tsx
@@ -463,6 +463,17 @@ describe("NewForwardDialog — opened from the thing being forwarded", () => {
     expect(input("Local port").value).toBe("");
   });
 
+  it("asks only for what is missing, not for the target it was handed", async () => {
+    // Opened from a port's Forward, everything but the local port arrives
+    // filled. A line reading "choose a target and both ports" then asks the
+    // reader for two things they already have, and it is the first thing they
+    // read under the command they came to copy.
+    openOn(POD_TARGET);
+    await screen.findByRole("dialog");
+    expect(screen.getByText("Fill in a local port to see it.")).toBeTruthy();
+    expect(screen.queryByText(/a target/)).toBeNull();
+  });
+
   it("prefills nothing when there is no target — the screen's own way in, unchanged", async () => {
     open();
     await screen.findByRole("dialog");

--- a/packages/ui-next/src/screens/forwards/NewForwardDialog.test.tsx
+++ b/packages/ui-next/src/screens/forwards/NewForwardDialog.test.tsx
@@ -453,14 +453,27 @@ describe("NewForwardDialog — opened from the thing being forwarded", () => {
     await waitFor(() => expect(select("Namespace").value).toBe("checkout"));
   });
 
-  it("prefills the remote port that was clicked, and leaves the local one empty", async () => {
+  it("prefills both ports, offering the same number on this side", async () => {
     openOn(POD_TARGET);
     await screen.findByRole("dialog");
     expect(input("Remote port").value).toBe("9376");
-    // The value came from the click, not from the field: its placeholder says
-    // something else entirely.
+    // The values came from the click, not from the fields: both placeholders
+    // say something else entirely.
     expect(input("Remote port").placeholder).toBe("8080");
-    expect(input("Local port").value).toBe("");
+    expect(input("Local port").placeholder).toBe("9090");
+    // `9376:9376` is what a person reaches for, so it is what is offered.
+    expect(input("Local port").value).toBe("9376");
+  });
+
+  it("steps the offer past a port srelens is already forwarding", async () => {
+    // Arriving from a port whose number this app already holds must not greet
+    // the reader with the clash error — the number is walked up until it is
+    // free, and 9377 is free only because 9376 is taken.
+    store.list = [holding(9376), holding(9377)];
+    openOn(POD_TARGET);
+    await screen.findByRole("dialog");
+    expect(input("Local port").value).toBe("9378");
+    expect(screen.queryByText(/already forwarded/)).toBeNull();
   });
 
   it("asks only for what is missing, not for the target it was handed", async () => {
@@ -468,9 +481,15 @@ describe("NewForwardDialog — opened from the thing being forwarded", () => {
     // filled. A line reading "choose a target and both ports" then asks the
     // reader for two things they already have, and it is the first thing they
     // read under the command they came to copy.
+    // Arriving from a port, nothing is missing — the command is there to copy
+    // rather than a sentence asking for fields the reader already handed over.
     openOn(POD_TARGET);
     await screen.findByRole("dialog");
-    expect(screen.getByText("Fill in a local port to see it.")).toBeTruthy();
+    expect(screen.queryByText(/Fill in/)).toBeNull();
+
+    // Clear the one field that can be cleared, and it names that field alone.
+    await userEvent.clear(field("Local port"));
+    expect(await screen.findByText("Fill in a local port to see it.")).toBeTruthy();
     expect(screen.queryByText(/a target/)).toBeNull();
   });
 
@@ -484,6 +503,9 @@ describe("NewForwardDialog — opened from the thing being forwarded", () => {
   it("writes a Service's command with svc/, a Pod's with pod/", async () => {
     openOn({ kind: "Service", name: "checkout-api", remotePort: 9376 });
     await screen.findByRole("dialog");
+    // Cleared first: the field arrives with the offer in it, so typing alone
+    // would append to it.
+    await userEvent.clear(field("Local port"));
     await userEvent.type(field("Local port"), "9091");
     const expected = toKubectl({
       action: "port-forward",
@@ -511,6 +533,7 @@ describe("NewForwardDialog — opened from the thing being forwarded", () => {
     await userEvent.selectOptions(field("Target"), "svc/checkout-web");
     await userEvent.clear(field("Remote port"));
     await userEvent.type(field("Remote port"), "443");
+    await userEvent.clear(field("Local port"));
     await userEvent.type(field("Local port"), "9091");
     await waitFor(() =>
       expect(screen.getByText(/port-forward svc\/checkout-web 9091:443/)).toBeTruthy(),
@@ -527,10 +550,10 @@ describe("NewForwardDialog — opened from the thing being forwarded", () => {
     await waitFor(() => expect(select("Target").value).toBe("pod/checkout-api-5c8b7f2d9-mk3wl"));
   });
 
-  it("starts exactly the forward the reader arrived with, once they name a local port", async () => {
+  it("starts exactly the forward the reader arrived with, without touching a field", async () => {
     openOn(POD_TARGET);
     await screen.findByRole("dialog");
-    await userEvent.type(field("Local port"), "9091");
+    // Nothing typed: the offer is enough to start on.
     await waitFor(() => expect(startButton().disabled).toBe(false));
     await userEvent.click(startButton());
     await waitFor(() => expect(core.startPortForward).toHaveBeenCalledTimes(1));
@@ -539,7 +562,7 @@ describe("NewForwardDialog — opened from the thing being forwarded", () => {
       namespace: "checkout",
       kind: "Pod",
       name: "checkout-api-5c8b7f2d9-mk3wl",
-      localPort: 9091,
+      localPort: 9376,
       remotePort: 9376,
     });
   });

--- a/packages/ui-next/src/screens/forwards/NewForwardDialog.test.tsx
+++ b/packages/ui-next/src/screens/forwards/NewForwardDialog.test.tsx
@@ -1,0 +1,412 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+/**
+ * **`forwardAddress`, `toKubectl` and `describeError` stay REAL.** They are the
+ * three rules this dialog is forbidden from restating — where a forward is
+ * reachable from, what the equivalent command reads, and how a failure is
+ * worded — and a test that stubbed them would assert the dialog calls a stub.
+ * The platform is flipped one layer lower instead, on the same module
+ * `forward.ts` reads `isTauri` from, so `forwardAddress` computes for real on
+ * both platforms. Same arrangement as `Forwards.test.tsx`.
+ */
+const platform = vi.hoisted(() => ({ isTauri: vi.fn(() => true) }));
+vi.mock("@srelens/core/platform", async (orig) => ({
+  ...(await orig<typeof import("@srelens/core/platform")>()),
+  isTauri: platform.isTauri,
+}));
+
+/** The forwards store is core's, and it is what the clash check reads. */
+const store = vi.hoisted(() => ({
+  list: [] as unknown[],
+  listeners: new Set<() => void>(),
+}));
+const core = vi.hoisted(() => ({
+  startPortForward: vi.fn(),
+  listNamespaces: vi.fn(),
+  listPods: vi.fn(),
+  listServices: vi.fn(),
+  notify: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+vi.mock("@srelens/core", async (orig) => ({
+  ...(await orig<typeof import("@srelens/core")>()),
+  getForwards: () => store.list,
+  subscribeForwards: (l: () => void) => {
+    store.listeners.add(l);
+    return () => store.listeners.delete(l);
+  },
+  ...core,
+}));
+
+import { type ActiveForward, toKubectl } from "@srelens/core";
+import { NewForwardDialog } from "./NewForwardDialog";
+
+const CONTEXT = "prod-eu";
+
+/** §A.4's own namespaces. */
+const NAMESPACES = ["checkout", "payments", "observability", "identity"];
+
+/** §A.4's own targets, split across the two kinds that can back a forward. */
+const SERVICES = [
+  { name: "checkout-api", namespace: "checkout" },
+  { name: "checkout-web", namespace: "checkout" },
+];
+const PODS = [{ name: "checkout-api-5c8b7f2d9-mk3wl", namespace: "checkout" }];
+
+/** A live forward holding port 8080, so a clash has something to clash WITH. */
+function holding(localPort: number): ActiveForward {
+  return {
+    id: 1,
+    context: "prod-eu",
+    namespace: "checkout",
+    kind: "Service",
+    name: "checkout-web",
+    localPort,
+    remotePort: 80,
+    status: "active",
+    bytesMoved: 0,
+    startedAt: Date.now(),
+  };
+}
+
+let opened: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  platform.isTauri.mockReturnValue(true);
+  core.listNamespaces.mockResolvedValue({ namespaces: NAMESPACES });
+  core.listServices.mockResolvedValue({ services: SERVICES });
+  core.listPods.mockResolvedValue({ pods: PODS });
+  core.startPortForward.mockImplementation(async (req: { localPort?: number }) => ({
+    id: 7,
+    localPort: req.localPort ?? 0,
+  }));
+  // A forwards store with something in it by default: a clash test whose
+  // fixture has no live forwards cannot fail, and neither can the "no clash"
+  // half of it.
+  store.list = [holding(8080)];
+  store.listeners.clear();
+  opened = vi.fn();
+  Object.defineProperty(window, "open", { value: opened, configurable: true, writable: true });
+});
+
+function open(onClose = vi.fn()) {
+  render(<NewForwardDialog context={CONTEXT} onClose={onClose} />);
+  return onClose;
+}
+
+const field = (name: string) => screen.getByLabelText(name) as HTMLElement;
+const startButton = () => screen.getByRole("button", { name: "Start forward" }) as HTMLButtonElement;
+
+/** Wait for the namespace list to land, then fill §A.4's four fields. */
+async function fillIn({ local = "9090", remote = "8080", target = "svc/checkout-api" } = {}) {
+  await waitFor(() => expect(core.listNamespaces).toHaveBeenCalled());
+  await userEvent.selectOptions(field("Namespace"), "checkout");
+  await waitFor(() => expect(core.listServices).toHaveBeenCalled());
+  await waitFor(() =>
+    expect(within(field("Target")).queryByRole("option", { name: target })).toBeTruthy(),
+  );
+  await userEvent.selectOptions(field("Target"), target);
+  await userEvent.clear(field("Local port"));
+  if (local) await userEvent.type(field("Local port"), local);
+  await userEvent.clear(field("Remote port"));
+  if (remote) await userEvent.type(field("Remote port"), remote);
+}
+
+describe("NewForwardDialog — §A.4's frame", () => {
+  it("is the design's 480px dialog with §A.4's four fields and its two controls", async () => {
+    open();
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("New port forward")).toBeTruthy();
+    expect((dialog as HTMLElement).style.maxWidth).toBe("480px");
+    for (const label of ["Target", "Namespace", "Local port", "Remote port"]) {
+      expect(field(label)).toBeTruthy();
+    }
+    expect(screen.getByRole("switch", { name: "Open in browser when it comes up" })).toBeTruthy();
+    expect(screen.getByText("Equivalent command")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
+    expect(startButton()).toBeTruthy();
+  });
+
+  it("closes on Cancel without starting anything", async () => {
+    const onClose = open();
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(core.startPortForward).not.toHaveBeenCalled();
+  });
+});
+
+describe("NewForwardDialog — what it offers to forward", () => {
+  it("lists the cluster's namespaces, from core", async () => {
+    open();
+    await waitFor(() => expect(core.listNamespaces).toHaveBeenCalledWith(CONTEXT));
+    await waitFor(() =>
+      expect(within(field("Namespace")).getByRole("option", { name: "observability" })).toBeTruthy(),
+    );
+    // All four, not just the one the assertion above happened to name.
+    for (const ns of NAMESPACES) {
+      expect(within(field("Namespace")).getByRole("option", { name: ns })).toBeTruthy();
+    }
+  });
+
+  it("names the chosen namespace's services and pods the way kubectl does", async () => {
+    open();
+    await waitFor(() => expect(core.listNamespaces).toHaveBeenCalled());
+    await userEvent.selectOptions(field("Namespace"), "checkout");
+    await waitFor(() => expect(core.listServices).toHaveBeenCalledWith(CONTEXT, "checkout"));
+    expect(core.listPods).toHaveBeenCalledWith(CONTEXT, "checkout");
+    const target = field("Target");
+    await waitFor(() =>
+      expect(within(target).getByRole("option", { name: "svc/checkout-api" })).toBeTruthy(),
+    );
+    // The prefix is read off the kind: a Pod is `pod/`, not `svc/`.
+    expect(within(target).getByRole("option", { name: "svc/checkout-web" })).toBeTruthy();
+    expect(
+      within(target).getByRole("option", { name: "pod/checkout-api-5c8b7f2d9-mk3wl" }),
+    ).toBeTruthy();
+    expect(within(target).queryByRole("option", { name: "svc/checkout-api-5c8b7f2d9-mk3wl" })).toBeNull();
+  });
+
+  it("asks for a cluster instead of listing an empty context's namespaces", async () => {
+    render(<NewForwardDialog context="" onClose={vi.fn()} />);
+    await screen.findByRole("dialog");
+    expect(
+      within(field("Namespace")).getByRole("option", { name: "Pick a cluster in the rail first" }),
+    ).toBeTruthy();
+    // The point: nothing goes to the backend to be told there is no cluster.
+    expect(core.listNamespaces).not.toHaveBeenCalled();
+    expect(startButton().disabled).toBe(true);
+  });
+
+  it("says so when the namespaces cannot be listed, in words rather than in Rust", async () => {
+    // `listNamespaces` REPORTS by returning an error field; it does not throw,
+    // and a try/catch around it would catch nothing.
+    core.listNamespaces.mockResolvedValue({
+      error: "ApiError: Unauthorized (Status { metadata: Some(ListMeta { .. }) })",
+    });
+    open();
+    expect(await screen.findByText(/rejected your credentials/i)).toBeTruthy();
+    // The struct appears ONLY inside the disclosure, never as the sentence.
+    const alert = screen.getByText(/rejected your credentials/i).closest("[data-tone]");
+    const raw = alert?.querySelector('[data-slot="raw"]');
+    expect(raw?.textContent).toContain("ApiError");
+    expect(screen.getByText("Could not list this cluster's namespaces")).toBeTruthy();
+  });
+});
+
+describe("NewForwardDialog — the port clash", () => {
+  it("refuses a local port another forward already holds, in §A.4's words", async () => {
+    open();
+    await fillIn({ local: "8080" });
+    expect(screen.getByText("Port 8080 is already forwarded.")).toBeTruthy();
+    expect(startButton().disabled).toBe(true);
+    // And it is decided HERE: no request goes out to be refused.
+    expect(core.startPortForward).not.toHaveBeenCalled();
+  });
+
+  it("lets a free port through — the same form, one digit apart", async () => {
+    // The half that makes the assertion above mean something: a Start button
+    // that were disabled always would pass the clash test on its own.
+    open();
+    await fillIn({ local: "8081" });
+    expect(screen.queryByText(/already forwarded/)).toBeNull();
+    expect(startButton().disabled).toBe(false);
+  });
+
+  it("frees the port again when the forward holding it goes", async () => {
+    open();
+    await fillIn({ local: "8080" });
+    expect(startButton().disabled).toBe(true);
+    // The store is pushed to, and the clash is read off it live.
+    store.list = [];
+    for (const l of store.listeners) l();
+    await waitFor(() => expect(startButton().disabled).toBe(false));
+    expect(screen.queryByText(/already forwarded/)).toBeNull();
+  });
+
+  it("will not start without both ports", async () => {
+    open();
+    await fillIn({ local: "9090", remote: "" });
+    expect(startButton().disabled).toBe(true);
+  });
+});
+
+describe("NewForwardDialog — the equivalent command", () => {
+  it("is core's command for the fields as they stand", async () => {
+    open();
+    await fillIn({ local: "9090", remote: "8080" });
+    const expected = toKubectl({
+      action: "port-forward",
+      kind: "Service",
+      name: "checkout-api",
+      context: CONTEXT,
+      namespace: "checkout",
+      localPort: 9090,
+      remotePort: 8080,
+    });
+    expect(screen.getByText(expected)).toBeTruthy();
+    // And it really is the port-forward command, so the line above is not two
+    // identical mistakes agreeing.
+    expect(expected).toContain("port-forward svc/checkout-api 9090:8080");
+  });
+
+  it("follows the fields as they change", async () => {
+    open();
+    await fillIn({ local: "9090", remote: "8080" });
+    expect(screen.getByText(/9090:8080/)).toBeTruthy();
+    await userEvent.clear(field("Remote port"));
+    await userEvent.type(field("Remote port"), "443");
+    await waitFor(() => expect(screen.getByText(/9090:443/)).toBeTruthy());
+    expect(screen.queryByText(/9090:8080/)).toBeNull();
+    await userEvent.selectOptions(field("Target"), "pod/checkout-api-5c8b7f2d9-mk3wl");
+    await waitFor(() =>
+      expect(screen.getByText(/port-forward pod\/checkout-api-5c8b7f2d9-mk3wl 9090:443/)).toBeTruthy(),
+    );
+  });
+});
+
+describe("NewForwardDialog — starting the forward", () => {
+  it("asks core for exactly the forward the fields describe", async () => {
+    open();
+    await fillIn({ local: "9090", remote: "8080", target: "pod/checkout-api-5c8b7f2d9-mk3wl" });
+    await userEvent.click(startButton());
+    await waitFor(() => expect(core.startPortForward).toHaveBeenCalledTimes(1));
+    expect(core.startPortForward).toHaveBeenCalledWith({
+      context: CONTEXT,
+      namespace: "checkout",
+      // The KIND, not the `pod/` prefix the select shows.
+      kind: "Pod",
+      name: "checkout-api-5c8b7f2d9-mk3wl",
+      localPort: 9090,
+      remotePort: 8080,
+    });
+  });
+
+  it("closes once the tunnel is up", async () => {
+    const onClose = open();
+    await fillIn();
+    await userEvent.click(startButton());
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+  });
+
+  it("says where the forward is, on the desktop, using the port the BACKEND bound", async () => {
+    // The backend may not get the port that was asked for. The toast reports
+    // what came back, never what was typed.
+    core.startPortForward.mockResolvedValue({ id: 7, localPort: 9091 });
+    open();
+    await fillIn({ local: "9090" });
+    await userEvent.click(startButton());
+    await waitFor(() => expect(core.notify.success).toHaveBeenCalledTimes(1));
+    expect(core.notify.success).toHaveBeenCalledWith(
+      "Forwarding localhost:9091 to svc/checkout-api",
+    );
+  });
+
+  it("says the proxy address in the browser, where a container's loopback is unreachable", async () => {
+    platform.isTauri.mockReturnValue(false);
+    open();
+    await fillIn({ local: "9090" });
+    await userEvent.click(startButton());
+    await waitFor(() => expect(core.notify.success).toHaveBeenCalledTimes(1));
+    const said = core.notify.success.mock.calls[0][0] as string;
+    expect(said).toBe(`Forwarding ${window.location.origin}/pf/7/ to svc/checkout-api`);
+    // Said a second way on purpose: jsdom's own origin contains "localhost",
+    // so the equality above would still hold for a dialog that had hardcoded
+    // §A.4's desktop answer at some other port. THIS is the property.
+    expect(said).toContain("/pf/7/");
+    expect(said).not.toContain("localhost:9090");
+  });
+
+  it("reports a refused start in words, and stays open", async () => {
+    const onClose = vi.fn();
+    core.startPortForward.mockRejectedValue(
+      new Error("ApiError: Unauthorized (Status { metadata: Some(ListMeta { .. }) })"),
+    );
+    open(onClose);
+    await fillIn();
+    await userEvent.click(startButton());
+    expect(await screen.findByText(/rejected your credentials/i)).toBeTruthy();
+    // `describeError`'s classification, not the struct — and the struct only
+    // inside the disclosure.
+    const alert = screen.getByText(/rejected your credentials/i).closest("[data-tone]");
+    expect(alert?.querySelector('[data-slot="raw"]')?.textContent).toContain("ApiError");
+    expect(screen.getByText(/Could not forward svc\/checkout-api/i)).toBeTruthy();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(core.notify.success).not.toHaveBeenCalled();
+  });
+});
+
+describe("NewForwardDialog — the browser switch", () => {
+  it("opens nothing when it is off", async () => {
+    open();
+    await fillIn();
+    await userEvent.click(startButton());
+    await waitFor(() => expect(core.notify.success).toHaveBeenCalled());
+    expect(opened).not.toHaveBeenCalled();
+  });
+
+  it("opens the desktop's loopback when it is on", async () => {
+    core.startPortForward.mockResolvedValue({ id: 7, localPort: 9091 });
+    open();
+    await fillIn({ local: "9090" });
+    await userEvent.click(screen.getByRole("switch", { name: "Open in browser when it comes up" }));
+    await userEvent.click(startButton());
+    await waitFor(() => expect(opened).toHaveBeenCalledTimes(1));
+    expect(opened.mock.calls[0][0]).toBe("http://localhost:9091");
+  });
+
+  it("opens the SAME address it promised in web mode, not a hardcoded localhost", async () => {
+    platform.isTauri.mockReturnValue(false);
+    open();
+    await fillIn({ local: "9090" });
+    await userEvent.click(screen.getByRole("switch", { name: "Open in browser when it comes up" }));
+    await userEvent.click(startButton());
+    await waitFor(() => expect(opened).toHaveBeenCalledTimes(1));
+    const url = opened.mock.calls[0][0] as string;
+    expect(url).toBe(`${window.location.origin}/pf/7/`);
+    expect(url).toContain("/pf/7/");
+    expect(url).not.toContain("localhost:9090");
+  });
+
+  it("hints the desktop address §A.4 writes, for the port in the field", async () => {
+    open();
+    await fillIn({ local: "9090" });
+    const hint = document.getElementById(
+      screen
+        .getByRole("switch", { name: "Open in browser when it comes up" })
+        .getAttribute("aria-describedby") ?? "",
+    );
+    expect(hint?.textContent).toBe("http://localhost:9090");
+  });
+
+  it("hints the proxy's shape in web mode, without inventing an id", async () => {
+    platform.isTauri.mockReturnValue(false);
+    open();
+    await fillIn({ local: "9090" });
+    const hint = document.getElementById(
+      screen
+        .getByRole("switch", { name: "Open in browser when it comes up" })
+        .getAttribute("aria-describedby") ?? "",
+    );
+    expect(hint?.textContent).toBe(`${window.location.origin}/pf/<id>/`);
+    // Not the desktop hint, and not a made-up number where the id goes.
+    expect(hint?.textContent).not.toContain("localhost:9090");
+    expect(hint?.textContent).not.toContain("/pf/-");
+  });
+});
+
+describe("NewForwardDialog — what it must not leak", () => {
+  it("puts no address, port or command in a title attribute", async () => {
+    open();
+    await fillIn({ local: "9090", remote: "8080" });
+    const joined = Array.from(document.querySelectorAll("[title]"))
+      .map((el) => el.getAttribute("title") ?? "")
+      .join("\n");
+    expect(joined).not.toContain("localhost");
+    expect(joined).not.toContain("/pf/");
+    expect(joined).not.toContain("port-forward");
+    expect(joined).not.toContain("--context");
+    for (const port of ["9090", "8080"]) expect(joined).not.toContain(port);
+  });
+});

--- a/packages/ui-next/src/screens/forwards/NewForwardDialog.test.tsx
+++ b/packages/ui-next/src/screens/forwards/NewForwardDialog.test.tsx
@@ -504,6 +504,40 @@ describe("NewForwardDialog — opened from the thing being forwarded", () => {
     expect(input("Local port").value).not.toBe(input("Remote port").value);
   });
 
+  it("lets a cleared local port mean 'any free one', which is what it promised", async () => {
+    // The offer is an offer. Clearing it asks the backend to choose, which is
+    // the only answer that cannot collide with something outside srelens —
+    // and it was the documented fallback while being impossible to reach:
+    // `portOf` returns null for blank AND for invalid, so a cleared field
+    // disabled Start exactly as "abc" did.
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    openOn(POD_TARGET);
+    await screen.findByRole("dialog");
+    await userEvent.clear(field("Local port"));
+
+    // kubectl's own spelling for a random local port.
+    await waitFor(() =>
+      expect(screen.getByText(/port-forward pod\/checkout-api-5c8b7f2d9-mk3wl :9376$/)).toBeTruthy(),
+    );
+    await waitFor(() => expect(startButton().disabled).toBe(false));
+    await userEvent.click(startButton());
+    await waitFor(() => expect(core.startPortForward).toHaveBeenCalledTimes(1));
+    // No `localPort` key at all — not `undefined`, not 0.
+    expect(core.startPortForward.mock.calls[0][0]).not.toHaveProperty("localPort");
+  });
+
+  it("still refuses a number that is not a port", async () => {
+    // Blank and invalid must not collapse back together: an empty field is a
+    // decision, 99999 is a mistake. The field is `type="number"`, so letters
+    // cannot be entered at all — out of range is the invalid case that is
+    // actually reachable.
+    openOn(POD_TARGET);
+    await screen.findByRole("dialog");
+    await userEvent.clear(field("Local port"));
+    await userEvent.type(field("Local port"), "99999");
+    await waitFor(() => expect(startButton().disabled).toBe(true));
+  });
+
   it("draws only from the offer range", () => {
     // The unit, so the range is pinned without a component in the way. Below
     // 49152 the OS is not handing the same numbers out for outbound sockets;
@@ -531,9 +565,11 @@ describe("NewForwardDialog — opened from the thing being forwarded", () => {
     await screen.findByRole("dialog");
     expect(screen.queryByText(/Fill in/)).toBeNull();
 
-    // Clear the one field that can be cleared, and it names that field alone.
-    await userEvent.clear(field("Local port"));
-    expect(await screen.findByText("Fill in a local port to see it.")).toBeTruthy();
+    // Clearing the LOCAL port is not a gap — it asks for any free one. The
+    // remote port has no such fallback, so that is the one that can go
+    // missing, and it is named alone.
+    await userEvent.clear(field("Remote port"));
+    expect(await screen.findByText("Fill in a remote port to see it.")).toBeTruthy();
     expect(screen.queryByText(/a target/)).toBeNull();
   });
 

--- a/packages/ui-next/src/screens/forwards/NewForwardDialog.tsx
+++ b/packages/ui-next/src/screens/forwards/NewForwardDialog.tsx
@@ -88,11 +88,34 @@ function plannedAddress(localPort: number): string {
   return browsable(address.replace(`/pf/${PLACEHOLDER_ID}/`, "/pf/<id>/"));
 }
 
+/**
+ * The thing a reader was already looking at when they asked to forward it —
+ * a Service's Ports row, a container's port, a row in a list.
+ *
+ * `kind` is the KUBERNETES kind (`Service`, `Pod`), never kubectl's short
+ * form: `kindToForwardTarget` owns that mapping, and it is what decides
+ * whether the equivalent command reads `svc/` or `pod/`.
+ *
+ * `remotePort` is the port on the far end — the one that was clicked. There
+ * is deliberately no local port here: see {@link NewForwardDialog}.
+ */
+export interface ForwardTarget {
+  kind: string;
+  name: string;
+  remotePort?: number;
+}
+
 export interface NewForwardDialogProps {
   /** The cluster the forward is made in — a kubeconfig context NAME. */
   context: string;
   /** Where the namespace select starts, when the caller knows a good answer. */
   namespace?: string;
+  /**
+   * What the reader arrived from, when they came through one of the doors
+   * that already knows the answer. Absent from `/forwards`' own header
+   * action, which starts on nothing.
+   */
+  target?: ForwardTarget;
   /** Cancel, escape, the header's control, and a forward that came up. */
   onClose: () => void;
 }
@@ -130,16 +153,56 @@ export interface NewForwardDialogProps {
  * RETURNING an error rather than throwing, so nothing here wraps them in a
  * try/catch and calls that error handling; the field is read. `startPortForward`
  * does throw, and that one is caught.
+ *
+ * **A `target` is a starting point, not a lock.** Every door that opens this
+ * with one — a Service's Ports row, a container's port, the row menu's
+ * `Port forward` — is handing over what the reader was looking at, and they
+ * may well want a different one; the target select and both port fields stay
+ * exactly as editable as they are from the header action. And a prefilled
+ * `remotePort` is NOT a prefilled `localPort`: left empty, the OS picks a free
+ * port, whereas seeding it with the same number walks the commonest case there
+ * is — forwarding a port already open on this machine — straight into the
+ * clash error above.
  */
-export function NewForwardDialog({ context, namespace: initial, onClose }: NewForwardDialogProps) {
+export function NewForwardDialog({
+  context,
+  namespace: initial,
+  target: arrivedFrom,
+  onClose,
+}: NewForwardDialogProps) {
   const forwards = useSyncExternalStore(subscribeForwards, getForwards, getForwards);
 
+  /**
+   * The handed-over target as an OPTION — the same shape the listings produce,
+   * so nothing downstream has to know which of the two it came from.
+   *
+   * Memoised on the primitives rather than on the prop object, because every
+   * door passes an object literal that is new on each of its own renders.
+   */
+  const prefilled = useMemo<Target | null>(
+    () =>
+      arrivedFrom
+        ? {
+            value: `${kindToForwardTarget(arrivedFrom.kind)}/${arrivedFrom.name}`,
+            kind: arrivedFrom.kind,
+            name: arrivedFrom.name,
+          }
+        : null,
+    [arrivedFrom?.kind, arrivedFrom?.name],
+  );
+  /** The namespace a prefilled target belongs to — the one it was opened on. */
+  const homeNamespace = initial ?? "";
+
   const [namespaces, setNamespaces] = useState<string[] | null>(null);
-  const [namespace, setNamespace] = useState(initial ?? "");
+  const [namespace, setNamespace] = useState(homeNamespace);
   const [targets, setTargets] = useState<Target[] | null>(null);
-  const [target, setTarget] = useState("");
+  const [target, setTarget] = useState(prefilled?.value ?? "");
   const [localText, setLocalText] = useState("");
-  const [remoteText, setRemoteText] = useState("");
+  // The remote port only. See {@link NewForwardDialog} on why the local one
+  // starts empty even when the far end is known.
+  const [remoteText, setRemoteText] = useState(
+    arrivedFrom?.remotePort == null ? "" : String(arrivedFrom.remotePort),
+  );
   const [inBrowser, setInBrowser] = useState(false);
   const [busy, setBusy] = useState(false);
 
@@ -150,6 +213,13 @@ export function NewForwardDialog({ context, namespace: initial, onClose }: NewFo
    * a short window, and the reader only ever acts on the most recent one.
    */
   const [failure, setFailure] = useState<{ title: string; error: unknown } | null>(null);
+
+  /**
+   * The one target value a listing is not allowed to clear — the prefilled
+   * one, and only while the reader is still in the namespace it came from.
+   * `""` (which no option ever holds) when there is nothing to protect.
+   */
+  const keptOnArrival = prefilled && namespace === homeNamespace ? prefilled.value : "";
 
   useEffect(() => {
     let live = true;
@@ -184,7 +254,6 @@ export function NewForwardDialog({ context, namespace: initial, onClose }: NewFo
     }
     let live = true;
     setTargets(null);
-    setTarget("");
     void Promise.all([listServices(context, namespace), listPods(context, namespace)]).then(
       ([services, pods]) => {
         if (!live) return;
@@ -194,7 +263,7 @@ export function NewForwardDialog({ context, namespace: initial, onClose }: NewFo
         }
         // Whatever answered is still worth offering: a cluster that lists its
         // Services but refuses its Pods can still forward a Service.
-        setTargets([
+        const listed: Target[] = [
           ...(services.services ?? []).map((s) => ({
             value: `${kindToForwardTarget("Service")}/${s.name}`,
             kind: "Service",
@@ -205,15 +274,44 @@ export function NewForwardDialog({ context, namespace: initial, onClose }: NewFo
             kind: "Pod",
             name: p.name,
           })),
-        ]);
+        ];
+        setTargets(listed);
+        // The selection is reconciled against what this namespace actually
+        // has, rather than cleared the moment the namespace changes: clearing
+        // up front would wipe a prefilled target before its own listing had a
+        // chance to confirm it. A target the reader ARRIVED with survives a
+        // listing that never named it (see `offered`) — but only in its own
+        // namespace.
+        setTarget((current) =>
+          current === keptOnArrival || listed.some((t) => t.value === current) ? current : "",
+        );
       },
     );
     return () => {
       live = false;
     };
-  }, [context, namespace]);
+  }, [context, namespace, keptOnArrival]);
 
-  const chosen = useMemo(() => targets?.find((t) => t.value === target), [targets, target]);
+  /**
+   * Everything the target select offers: what the namespace listed, plus the
+   * target the reader arrived from when that listing did not name it.
+   *
+   * A Pods listing that came back forbidden — or has simply not landed yet —
+   * is not a reason to forget what was clicked. The reader got here from the
+   * thing itself, so it is a target whether or not a list agrees.
+   */
+  const offered = useMemo<Target[]>(() => {
+    const listed = targets ?? [];
+    if (!prefilled || namespace !== homeNamespace) return listed;
+    return listed.some((t) => t.value === prefilled.value) ? listed : [prefilled, ...listed];
+  }, [targets, prefilled, namespace, homeNamespace]);
+
+  // Gated on the namespace as well as the value: a prefilled target is offered
+  // before any listing lands, and a forward with no namespace is not a forward.
+  const chosen = useMemo(
+    () => (namespace ? offered.find((t) => t.value === target) : undefined),
+    [offered, target, namespace],
+  );
   const localPort = portOf(localText);
   const remotePort = portOf(remoteText);
 
@@ -261,7 +359,7 @@ export function NewForwardDialog({ context, namespace: initial, onClose }: NewFo
   }
 
   const namespaceOptions = (namespaces ?? []).map((n) => ({ value: n }));
-  const targetOptions = (targets ?? []).map((t) => ({ value: t.value }));
+  const targetOptions = offered.map((t) => ({ value: t.value }));
 
   return (
     <Dialog
@@ -292,7 +390,9 @@ export function NewForwardDialog({ context, namespace: initial, onClose }: NewFo
               onValueChange={setTarget}
               options={targetOptions}
               className="w-full"
-              disabled={!namespace || targets === null}
+              // A prefilled target is offered before any listing lands, so
+              // the control it is showing must not be dead in the meantime.
+              disabled={!namespace || (targets === null && targetOptions.length === 0)}
               placeholder={
                 !namespace
                   ? "Pick a namespace first"

--- a/packages/ui-next/src/screens/forwards/NewForwardDialog.tsx
+++ b/packages/ui-next/src/screens/forwards/NewForwardDialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import {
+  type ActiveForward,
   forwardAddress,
   getForwards,
   kindToForwardTarget,
@@ -158,12 +159,34 @@ export interface NewForwardDialogProps {
  * with one — a Service's Ports row, a container's port, the row menu's
  * `Port forward` — is handing over what the reader was looking at, and they
  * may well want a different one; the target select and both port fields stay
- * exactly as editable as they are from the header action. And a prefilled
- * `remotePort` is NOT a prefilled `localPort`: left empty, the OS picks a free
- * port, whereas seeding it with the same number walks the commonest case there
- * is — forwarding a port already open on this machine — straight into the
- * clash error above.
+ * exactly as editable as they are from the header action.
+ *
+ * **The local port is offered, not demanded.** It starts at the remote port —
+ * `8443:8443` is what everybody reaches for — stepped up past anything srelens
+ * is already forwarding, so arriving from a port whose number is taken does
+ * not greet the reader with the clash error above. Clearing the field sends no
+ * local port at all and lets the OS choose, which is the answer that still
+ * works when the obvious number is held by something outside srelens.
  */
+/**
+ * The local port to offer for a remote one: the same number, which is what
+ * everybody reaches for, moved up until it is one srelens is not already
+ * forwarding.
+ *
+ * Only OUR forwards are consulted, because they are all this process knows —
+ * another program holding the port is invisible here and surfaces as a failed
+ * start instead. That is why the field stays clearable: emptied, no local port
+ * is sent and the OS picks a free one itself, which is the reliable answer
+ * when the obvious one is taken by something outside srelens.
+ */
+function offerLocalPort(remote: number, taken: readonly ActiveForward[]): number {
+  const held = new Set(taken.map((f) => f.localPort));
+  let port = remote;
+  // 65535 is the last valid port; stop rather than wrap into nonsense.
+  while (held.has(port) && port < 65535) port += 1;
+  return port;
+}
+
 export function NewForwardDialog({
   context,
   namespace: initial,
@@ -197,9 +220,11 @@ export function NewForwardDialog({
   const [namespace, setNamespace] = useState(homeNamespace);
   const [targets, setTargets] = useState<Target[] | null>(null);
   const [target, setTarget] = useState(prefilled?.value ?? "");
-  const [localText, setLocalText] = useState("");
-  // The remote port only. See {@link NewForwardDialog} on why the local one
-  // starts empty even when the far end is known.
+  const [localText, setLocalText] = useState(() =>
+    arrivedFrom?.remotePort == null
+      ? ""
+      : String(offerLocalPort(arrivedFrom.remotePort, getForwards())),
+  );
   const [remoteText, setRemoteText] = useState(
     arrivedFrom?.remotePort == null ? "" : String(arrivedFrom.remotePort),
   );

--- a/packages/ui-next/src/screens/forwards/NewForwardDialog.tsx
+++ b/packages/ui-next/src/screens/forwards/NewForwardDialog.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import {
   type ActiveForward,
+  browsable,
+  describeError,
   forwardAddress,
   getForwards,
   kindToForwardTarget,
@@ -8,6 +10,7 @@ import {
   listPods,
   listServices,
   notify,
+  openExternal,
   startPortForward,
   subscribeForwards,
   toKubectl,
@@ -55,19 +58,6 @@ function portOf(text: string): number | null {
   if (!trimmed) return null;
   const n = Number(trimmed);
   return Number.isInteger(n) && n > 0 && n <= MAX_PORT ? n : null;
-}
-
-/**
- * An address as something a browser can be sent to.
- *
- * `forwardAddress` answers in two shapes — a bare `host:port` authority on the
- * desktop and a full `http(s)://…/pf/<id>/` URL in web mode — because the
- * places that print it want the short form. A browser wants a scheme, and
- * `window.open("localhost:9090")` resolves against the current page rather than
- * opening the tunnel.
- */
-function browsable(address: string): string {
-  return /^https?:\/\//i.test(address) ? address : `http://${address}`;
 }
 
 /**
@@ -407,7 +397,18 @@ export function NewForwardDialog({
       // whenever the request could not have the port it asked for.
       const address = forwardAddress({ id: started.id, localPort: started.localPort });
       notify.success(`Forwarding ${address} to ${chosen.value}`);
-      if (inBrowser) window.open(browsable(address), "_blank", "noopener,noreferrer");
+      // Core's opener, not `window.open`: inside a Tauri WebView that call
+      // returns without opening anything and without failing, so the switch
+      // read as wired up and did nothing (#348). A browser that will not open
+      // is a TOAST rather than the banner above — the tunnel is up either way,
+      // and the dialog it would be drawn in is already closing.
+      if (inBrowser) {
+        try {
+          await openExternal(browsable(address));
+        } catch (e) {
+          notify.error("Couldn't open the forward in your browser", describeError(e).detail);
+        }
+      }
       onClose();
     } catch (e) {
       setFailure({ title: `Could not forward ${chosen.value}`, error: e });

--- a/packages/ui-next/src/screens/forwards/NewForwardDialog.tsx
+++ b/packages/ui-next/src/screens/forwards/NewForwardDialog.tsx
@@ -318,6 +318,15 @@ export function NewForwardDialog({
   /** §A.4's one field error, decided against the live store. */
   const clash = localPort !== null && forwards.some((f) => f.localPort === localPort);
 
+  /** The fields the equivalent command still wants, in the order they are read. */
+  const missingForCommand = [
+    target ? null : "a target",
+    localPort === null ? "a local port" : null,
+    remotePort === null ? "a remote port" : null,
+  ]
+    .filter((f): f is string => f !== null)
+    .join(" and ");
+
   const command =
     chosen && localPort !== null && remotePort !== null
       ? toKubectl({
@@ -461,9 +470,12 @@ export function NewForwardDialog({
             {command ? (
               <CopyCommand command={command} />
             ) : (
-              <span className="text-[0.75rem] text-muted">
-                Choose a target and both ports to see it.
-              </span>
+              /* Names what is actually missing, rather than listing every
+                 field. Opened from a port's `Forward` the target, namespace
+                 and remote port all arrive filled, and a line reading "choose
+                 a target" then asks the reader for the one thing they have
+                 already done. */
+              <span className="text-[0.75rem] text-muted">{`Fill in ${missingForCommand} to see it.`}</span>
             )}
           </div>
         </div>

--- a/packages/ui-next/src/screens/forwards/NewForwardDialog.tsx
+++ b/packages/ui-next/src/screens/forwards/NewForwardDialog.tsx
@@ -161,30 +161,53 @@ export interface NewForwardDialogProps {
  * may well want a different one; the target select and both port fields stay
  * exactly as editable as they are from the header action.
  *
- * **The local port is offered, not demanded.** It starts at the remote port —
- * `8443:8443` is what everybody reaches for — stepped up past anything srelens
- * is already forwarding, so arriving from a port whose number is taken does
- * not greet the reader with the clash error above. Clearing the field sends no
- * local port at all and lets the OS choose, which is the answer that still
- * works when the obvious number is held by something outside srelens.
+ * **The local port is offered, not demanded** — and it is a free port drawn
+ * at random rather than the remote one again. See {@link offerLocalPort}: a
+ * port worth forwarding is one this machine plausibly already serves, and
+ * srelens can only see its own forwards. Clearing the field sends no local
+ * port at all and lets the OS choose, which is the answer that cannot
+ * collide.
  */
 /**
- * The local port to offer for a remote one: the same number, which is what
- * everybody reaches for, moved up until it is one srelens is not already
- * forwarding.
+ * The low and high ends of the range a suggested local port is drawn from.
  *
- * Only OUR forwards are consulted, because they are all this process knows —
- * another program holding the port is invisible here and surfaces as a failed
- * start instead. That is why the field stays clearable: emptied, no local port
- * is sent and the OS picks a free one itself, which is the reliable answer
- * when the obvious one is taken by something outside srelens.
+ * Above the well-known (0-1023) and the bulk of the registered service ports,
+ * so a suggestion does not land on something a developer runs by habit; and
+ * below 49152, where the OS assigns its own ephemeral ports for outbound
+ * connections, so a listener bound here is not competing with the kernel for
+ * the same number.
  */
-function offerLocalPort(remote: number, taken: readonly ActiveForward[]): number {
+export const OFFER_LOW = 10000;
+export const OFFER_HIGH = 32767;
+
+/**
+ * A local port to offer: a free one at random, not the remote port again.
+ *
+ * Mirroring the far end reads well — `50051:50051` — and is the more likely
+ * of the two to fail, because a port worth forwarding is a port something on
+ * this machine plausibly already serves. Only srelens' own forwards can be
+ * checked from here; anything else holding the number is invisible until the
+ * start fails. A number drawn from a range nothing claims by convention is
+ * far likelier to be free on the first try.
+ *
+ * `random` is a parameter so a test can pin the draw. Clearing the field
+ * sends no local port at all and lets the OS choose, which remains the answer
+ * that cannot collide.
+ */
+export function offerLocalPort(
+  taken: readonly ActiveForward[],
+  random: () => number = Math.random,
+): number {
   const held = new Set(taken.map((f) => f.localPort));
-  let port = remote;
-  // 65535 is the last valid port; stop rather than wrap into nonsense.
-  while (held.has(port) && port < 65535) port += 1;
-  return port;
+  const span = OFFER_HIGH - OFFER_LOW + 1;
+  const first = OFFER_LOW + Math.floor(random() * span);
+  // Walk on from the draw rather than re-drawing, so this terminates even if
+  // the random source is degenerate, and wrap so the whole range is reachable.
+  for (let i = 0; i < span; i += 1) {
+    const port = OFFER_LOW + ((first - OFFER_LOW + i) % span);
+    if (!held.has(port)) return port;
+  }
+  return first;
 }
 
 export function NewForwardDialog({
@@ -223,7 +246,7 @@ export function NewForwardDialog({
   const [localText, setLocalText] = useState(() =>
     arrivedFrom?.remotePort == null
       ? ""
-      : String(offerLocalPort(arrivedFrom.remotePort, getForwards())),
+      : String(offerLocalPort(getForwards())),
   );
   const [remoteText, setRemoteText] = useState(
     arrivedFrom?.remotePort == null ? "" : String(arrivedFrom.remotePort),

--- a/packages/ui-next/src/screens/forwards/NewForwardDialog.tsx
+++ b/packages/ui-next/src/screens/forwards/NewForwardDialog.tsx
@@ -1,0 +1,373 @@
+import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
+import {
+  forwardAddress,
+  getForwards,
+  kindToForwardTarget,
+  listNamespaces,
+  listPods,
+  listServices,
+  notify,
+  startPortForward,
+  subscribeForwards,
+  toKubectl,
+} from "@srelens/core";
+import {
+  Button,
+  CopyCommand,
+  Dialog,
+  Field,
+  Select,
+  SubHead,
+  Switch,
+  TextInput,
+} from "@srelens/ui-kit";
+import { FailureAlert } from "../../lib/errorCopy";
+
+/** §A.4's width, in px. */
+const WIDTH = 480;
+
+/** The highest port a TCP socket can bind. */
+const MAX_PORT = 65_535;
+
+/**
+ * The id handed to `forwardAddress` to ask *where would a forward on this port
+ * be reachable from*, before there is a forward to ask about.
+ *
+ * Negative because no forward can ever carry it, so the answer it produces is
+ * unmistakably a template rather than a real address that happens to be wrong.
+ * See {@link plannedAddress}.
+ */
+const PLACEHOLDER_ID = -1;
+
+/** One thing in the namespace that a forward can be pointed at. */
+interface Target {
+  /** kubectl's own name for it — `svc/checkout-api` — and the select's value. */
+  value: string;
+  /** The Kubernetes kind, which is what `startPortForward` and `toKubectl` take. */
+  kind: string;
+  name: string;
+}
+
+/** The port a field holds, or null when it holds nothing a socket could bind. */
+function portOf(text: string): number | null {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  const n = Number(trimmed);
+  return Number.isInteger(n) && n > 0 && n <= MAX_PORT ? n : null;
+}
+
+/**
+ * An address as something a browser can be sent to.
+ *
+ * `forwardAddress` answers in two shapes — a bare `host:port` authority on the
+ * desktop and a full `http(s)://…/pf/<id>/` URL in web mode — because the
+ * places that print it want the short form. A browser wants a scheme, and
+ * `window.open("localhost:9090")` resolves against the current page rather than
+ * opening the tunnel.
+ */
+function browsable(address: string): string {
+  return /^https?:\/\//i.test(address) ? address : `http://${address}`;
+}
+
+/**
+ * Where a forward on this local port WILL be reachable from, in the form the
+ * switch's hint shows and the switch itself will open.
+ *
+ * §A.4 writes the hint as a literal `http://localhost:{local}`, which is the
+ * desktop answer and only the desktop answer — the same defect as §13's Copy
+ * URL. `forwardAddress` is the one place that decides between the two
+ * platforms, and it needs an id that does not exist until the start returns,
+ * so it is asked with {@link PLACEHOLDER_ID} and the stand-in is put back as
+ * `<id>`. On the desktop the id never appears in the answer and the hint is
+ * exact — §A.4's line, verbatim. In web mode the reader gets the proxy's real
+ * shape instead of a loopback their browser cannot reach or an id nothing has
+ * assigned yet. Either way the hint and the toast come from ONE rule.
+ */
+function plannedAddress(localPort: number): string {
+  const address = forwardAddress({ id: PLACEHOLDER_ID, localPort });
+  return browsable(address.replace(`/pf/${PLACEHOLDER_ID}/`, "/pf/<id>/"));
+}
+
+export interface NewForwardDialogProps {
+  /** The cluster the forward is made in — a kubeconfig context NAME. */
+  context: string;
+  /** Where the namespace select starts, when the caller knows a good answer. */
+  namespace?: string;
+  /** Cancel, escape, the header's control, and a forward that came up. */
+  onClose: () => void;
+}
+
+/**
+ * §A.4's `New port forward` — the one way to start a tunnel.
+ *
+ * **The clash check runs here, not on the backend.** §A.4's error is
+ * `Port <n> is already forwarded.` and core's forwards store already knows
+ * every live `localPort`, so the answer is on this side of the wire: the field
+ * says so as the digits are typed and `Start forward` is dead while it holds.
+ * Letting the request go out to be refused would be a slower way to learn the
+ * same thing, and the sentence that came back would be about a bind error
+ * rather than about the other tunnel. The store is subscribed to rather than
+ * read once, so stopping the forward that holds the port frees it here without
+ * the reader retyping anything.
+ *
+ * **The address is never assembled here.** §A.4's `http://localhost:{local}`
+ * hint and its `Forwarding localhost:<n> to <target>` toast are both written
+ * against the desktop, where the tunnel really is on this machine's loopback;
+ * in web mode srelens runs in a container whose loopback the browser cannot
+ * reach and the forward is served from a same-origin `/pf/<id>/` proxy.
+ * `forwardAddress` decides that, and the hint, the toast and the browser
+ * switch all read it — so the switch opens exactly the address the hint
+ * promised. The toast can only ask after the start returns, because that is
+ * when the id exists; the hint asks with a placeholder id
+ * ({@link plannedAddress}).
+ *
+ * The target list is the namespace's Services and Pods, named the way kubectl
+ * names them through core's `kindToForwardTarget` — the same function the
+ * equivalent command and the forwards table's Target cell go through. The
+ * `kind` travels beside the label rather than being parsed back out of it.
+ *
+ * `listNamespaces`, `listServices` and `listPods` all report failure by
+ * RETURNING an error rather than throwing, so nothing here wraps them in a
+ * try/catch and calls that error handling; the field is read. `startPortForward`
+ * does throw, and that one is caught.
+ */
+export function NewForwardDialog({ context, namespace: initial, onClose }: NewForwardDialogProps) {
+  const forwards = useSyncExternalStore(subscribeForwards, getForwards, getForwards);
+
+  const [namespaces, setNamespaces] = useState<string[] | null>(null);
+  const [namespace, setNamespace] = useState(initial ?? "");
+  const [targets, setTargets] = useState<Target[] | null>(null);
+  const [target, setTarget] = useState("");
+  const [localText, setLocalText] = useState("");
+  const [remoteText, setRemoteText] = useState("");
+  const [inBrowser, setInBrowser] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  /**
+   * The last thing that went wrong, whichever it was: a listing that came back
+   * with an error field, or a start that threw. One slot rather than three —
+   * the dialog is small enough that a second banner would push the footer off
+   * a short window, and the reader only ever acts on the most recent one.
+   */
+  const [failure, setFailure] = useState<{ title: string; error: unknown } | null>(null);
+
+  useEffect(() => {
+    let live = true;
+    setNamespaces(null);
+    // A forward is made in ONE cluster, and the rail's selection is the only
+    // answer the app has to which. With no cluster in focus there is nothing
+    // to list, and `listNamespaces("")` would go to the backend to be told so;
+    // the empty options say it here, in the control that would have offered
+    // them. See the Namespace placeholder below.
+    if (!context) {
+      setNamespaces([]);
+      return;
+    }
+    void listNamespaces(context).then((outcome) => {
+      if (!live) return;
+      if (outcome.error) {
+        setFailure({ title: "Could not list this cluster's namespaces", error: outcome.error });
+        setNamespaces([]);
+        return;
+      }
+      setNamespaces(outcome.namespaces ?? []);
+    });
+    return () => {
+      live = false;
+    };
+  }, [context]);
+
+  useEffect(() => {
+    if (!namespace) {
+      setTargets(null);
+      return;
+    }
+    let live = true;
+    setTargets(null);
+    setTarget("");
+    void Promise.all([listServices(context, namespace), listPods(context, namespace)]).then(
+      ([services, pods]) => {
+        if (!live) return;
+        const error = services.error || pods.error;
+        if (error) {
+          setFailure({ title: `Could not list what ${namespace} can forward`, error });
+        }
+        // Whatever answered is still worth offering: a cluster that lists its
+        // Services but refuses its Pods can still forward a Service.
+        setTargets([
+          ...(services.services ?? []).map((s) => ({
+            value: `${kindToForwardTarget("Service")}/${s.name}`,
+            kind: "Service",
+            name: s.name,
+          })),
+          ...(pods.pods ?? []).map((p) => ({
+            value: `${kindToForwardTarget("Pod")}/${p.name}`,
+            kind: "Pod",
+            name: p.name,
+          })),
+        ]);
+      },
+    );
+    return () => {
+      live = false;
+    };
+  }, [context, namespace]);
+
+  const chosen = useMemo(() => targets?.find((t) => t.value === target), [targets, target]);
+  const localPort = portOf(localText);
+  const remotePort = portOf(remoteText);
+
+  /** §A.4's one field error, decided against the live store. */
+  const clash = localPort !== null && forwards.some((f) => f.localPort === localPort);
+
+  const command =
+    chosen && localPort !== null && remotePort !== null
+      ? toKubectl({
+          action: "port-forward",
+          kind: chosen.kind,
+          name: chosen.name,
+          context,
+          namespace,
+          localPort,
+          remotePort,
+        })
+      : null;
+
+  const ready = command !== null && !clash && !busy;
+
+  async function start() {
+    if (!chosen || localPort === null || remotePort === null || clash) return;
+    setFailure(null);
+    setBusy(true);
+    try {
+      const started = await startPortForward({
+        context,
+        namespace,
+        kind: chosen.kind,
+        name: chosen.name,
+        localPort,
+        remotePort,
+      });
+      // The port the BACKEND bound, not the one that was typed: the two differ
+      // whenever the request could not have the port it asked for.
+      const address = forwardAddress({ id: started.id, localPort: started.localPort });
+      notify.success(`Forwarding ${address} to ${chosen.value}`);
+      if (inBrowser) window.open(browsable(address), "_blank", "noopener,noreferrer");
+      onClose();
+    } catch (e) {
+      setFailure({ title: `Could not forward ${chosen.value}`, error: e });
+      setBusy(false);
+    }
+  }
+
+  const namespaceOptions = (namespaces ?? []).map((n) => ({ value: n }));
+  const targetOptions = (targets ?? []).map((t) => ({ value: t.value }));
+
+  return (
+    <Dialog
+      title="New port forward"
+      maxWidth={WIDTH}
+      onClose={onClose}
+      footer={
+        <>
+          <Button variant="secondary" size="sm" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button variant="primary" size="sm" disabled={!ready} onClick={() => void start()}>
+            Start forward
+          </Button>
+        </>
+      }
+    >
+      <div className="flex flex-col gap-3 p-3">
+        {failure && <FailureAlert tone="sev" title={failure.title} error={failure.error} />}
+
+        {/* §A.4's two-column grid, in §A.4's order. Target and Namespace share
+            a row, so the target select sitting first costs nothing: both are on
+            screen at once and the target one says what it still needs. */}
+        <div className="grid grid-cols-2 gap-x-3">
+          <Field label="Target">
+            <Select
+              value={target}
+              onValueChange={setTarget}
+              options={targetOptions}
+              className="w-full"
+              disabled={!namespace || targets === null}
+              placeholder={
+                !namespace
+                  ? "Pick a namespace first"
+                  : targets === null
+                    ? "Loading…"
+                    : targetOptions.length === 0
+                      ? "Nothing here to forward"
+                      : "Choose a target"
+              }
+            />
+          </Field>
+          <Field label="Namespace">
+            <Select
+              value={namespace}
+              onValueChange={setNamespace}
+              options={namespaceOptions}
+              className="w-full"
+              disabled={namespaces === null || !context}
+              placeholder={
+                !context
+                  ? "Pick a cluster in the rail first"
+                  : namespaces === null
+                    ? "Loading…"
+                    : "Choose a namespace"
+              }
+            />
+          </Field>
+          <Field
+            label="Local port"
+            // §A.4's wording, exactly. The banner slot above is for failures
+            // that came from somewhere else; this one belongs to the field.
+            error={clash ? `Port ${localPort} is already forwarded.` : undefined}
+          >
+            <TextInput
+              value={localText}
+              onValueChange={setLocalText}
+              type="number"
+              invalid={clash}
+              placeholder="9090"
+            />
+          </Field>
+          <Field label="Remote port">
+            <TextInput
+              value={remoteText}
+              onValueChange={setRemoteText}
+              type="number"
+              placeholder="8080"
+            />
+          </Field>
+        </div>
+
+        <Switch
+          on={inBrowser}
+          onChange={setInBrowser}
+          label="Open in browser when it comes up"
+          hint={
+            localPort === null
+              ? "Name a local port and this is where it opens."
+              : plannedAddress(localPort)
+          }
+        />
+
+        <div>
+          <SubHead variant="caps">Equivalent command</SubHead>
+          <div className="mt-1">
+            {command ? (
+              <CopyCommand command={command} />
+            ) : (
+              <span className="text-[0.75rem] text-muted">
+                Choose a target and both ports to see it.
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/packages/ui-next/src/screens/forwards/NewForwardDialog.tsx
+++ b/packages/ui-next/src/screens/forwards/NewForwardDialog.tsx
@@ -352,6 +352,15 @@ export function NewForwardDialog({
   );
   const localPort = portOf(localText);
   const remotePort = portOf(remoteText);
+  /**
+   * Blank is a DECISION, not a mistake — it asks the backend for any free
+   * port, which is the one answer that cannot collide with something outside
+   * srelens. `portOf` cannot tell the two apart: it answers null for an empty
+   * field and for "abc" alike, which is how the documented fallback ended up
+   * unreachable.
+   */
+  const localBlank = localText.trim() === "";
+  const localUsable = localBlank || localPort !== null;
 
   /** §A.4's one field error, decided against the live store. */
   const clash = localPort !== null && forwards.some((f) => f.localPort === localPort);
@@ -359,21 +368,21 @@ export function NewForwardDialog({
   /** The fields the equivalent command still wants, in the order they are read. */
   const missingForCommand = [
     target ? null : "a target",
-    localPort === null ? "a local port" : null,
+    localUsable ? null : "a local port",
     remotePort === null ? "a remote port" : null,
   ]
     .filter((f): f is string => f !== null)
     .join(" and ");
 
   const command =
-    chosen && localPort !== null && remotePort !== null
+    chosen && localUsable && remotePort !== null
       ? toKubectl({
           action: "port-forward",
           kind: chosen.kind,
           name: chosen.name,
           context,
           namespace,
-          localPort,
+          ...(localPort === null ? {} : { localPort }),
           remotePort,
         })
       : null;
@@ -381,7 +390,7 @@ export function NewForwardDialog({
   const ready = command !== null && !clash && !busy;
 
   async function start() {
-    if (!chosen || localPort === null || remotePort === null || clash) return;
+    if (!chosen || !localUsable || remotePort === null || clash) return;
     setFailure(null);
     setBusy(true);
     try {
@@ -390,7 +399,9 @@ export function NewForwardDialog({
         namespace,
         kind: chosen.kind,
         name: chosen.name,
-        localPort,
+        // Omitted entirely when the field is blank: `ForwardRequest.localPort`
+        // is optional and the backend binds a free port when it is absent.
+        ...(localPort === null ? {} : { localPort }),
         remotePort,
       });
       // The port the BACKEND bound, not the one that was typed: the two differ
@@ -507,9 +518,11 @@ export function NewForwardDialog({
           onChange={setInBrowser}
           label="Open in browser when it comes up"
           hint={
-            localPort === null
-              ? "Name a local port and this is where it opens."
-              : plannedAddress(localPort)
+            localBlank
+              ? "srelens picks a free port, and opens it when it comes up."
+              : localPort === null
+                ? "Name a local port and this is where it opens."
+                : plannedAddress(localPort)
           }
         />
 

--- a/packages/ui-next/src/screens/toolbox/ExecAuthRail.test.tsx
+++ b/packages/ui-next/src/screens/toolbox/ExecAuthRail.test.tsx
@@ -315,13 +315,30 @@ describe("ExecAuthRail — the check itself", () => {
     });
     rail(["edge-apac"]);
 
-    const section = await waitFor(() => sectionFor("edge-apac"));
+    // A context that could not be checked goes to the collapsed section rather
+    // than getting one of its own — but it is still NAMED there, so a reader
+    // can tell whether the context they came for is among them.
+    const section = await waitFor(() => sectionFor("1 context not checked"));
+    expect(section.textContent).toContain("edge-apac");
     // `describeError`'s own sentence, not the struct.
     expect(section.textContent).toMatch(/rejected your credentials/i);
     // The struct is still reachable — behind a disclosure, which is the whole
     // reason it is not a `title`.
     const raw = section.querySelector('[data-slot="raw"]');
     expect(raw?.textContent).toContain("Status { code: 401 }");
+  });
+
+  it("says the same refusal once, however many contexts it arrives for", async () => {
+    // Eleven contexts refusing identically is one fact, not eleven. Drawn a
+    // card each they fill a 288px column and push the actionable finding off
+    // the bottom — the shape that made the cluster overview unreadable when a
+    // raw API error took four rows per cluster.
+    core.diagnoseContext.mockResolvedValue({ error: "handler error: unknown context: x" });
+    rail(["a", "b", "c"]);
+
+    await waitFor(() => expect(headings()).toEqual(["3 contexts not checked"]));
+    const section = sectionFor("3 contexts not checked");
+    expect(section.textContent).toContain("a, b, c");
   });
 
   it("does not certify health when the check itself blew up", async () => {
@@ -342,8 +359,13 @@ describe("ExecAuthRail — the check itself", () => {
     );
     rail(["edge-apac", "prod-eu"]);
 
-    await waitFor(() => expect(headings()).toEqual(["edge-apac", "prod-eu"]));
+    // The actionable context keeps its own section and its remedy; the one
+    // that could not be checked is reported after it, not instead of it. That
+    // ordering is the property: a failure must never cost the reader the
+    // finding this rail exists to show.
+    await waitFor(() => expect(headings()).toEqual(["prod-eu", "1 context not checked"]));
     expect(within(sectionFor("prod-eu")).getByRole("button", { name: /install/i })).toBeTruthy();
+    expect(sectionFor("1 context not checked").textContent).toContain("edge-apac");
   });
 });
 

--- a/packages/ui-next/src/screens/toolbox/ExecAuthRail.test.tsx
+++ b/packages/ui-next/src/screens/toolbox/ExecAuthRail.test.tsx
@@ -1,0 +1,422 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+/**
+ * Only the capability wrappers and the platform check are replaced.
+ * `describeError` stays real, so the failure assertion below is against core's
+ * own classification rather than a copy of it, and `plural` stays real so the
+ * healthy line is counted by core's arithmetic.
+ */
+const core = vi.hoisted(() => ({
+  diagnoseContext: vi.fn(),
+  installPlugin: vi.fn(),
+  startToolInstall: vi.fn(),
+  toolboxStatus: vi.fn(),
+  isTauri: vi.fn(() => true),
+}));
+vi.mock("@srelens/core", async (orig) => ({
+  ...(await orig<typeof import("@srelens/core")>()),
+  ...core,
+}));
+
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
+import type { ClusterContext } from "@srelens/core";
+import type { DiagnosisReport, RequirementResult } from "@srelens/core/lib/toolbox";
+import { ExecAuthRail } from "./ExecAuthRail";
+import { Toolbox } from "../Toolbox";
+import { resetContexts, setContexts } from "../../lib/clusters";
+import { resetProbes } from "../../lib/probe";
+import { defaultState } from "../../lib/tabs";
+import * as store from "../../lib/tabsStore";
+import { resetView } from "../../lib/workspace";
+
+/**
+ * The three resolutions the backend models, as `RequirementStatusDto` sends
+ * them (`crates/kube/src/toolbox.rs`).
+ *
+ * `OFF_PATH` is deliberately an **installable** tool that is present but off
+ * the app's PATH: that is the pair the rail exists to tell apart, and a rail
+ * that keyed its button off `installable` alone would draw an Install here.
+ */
+const MISSING: RequirementResult = {
+  binary: "kubectl-oidc_login",
+  kind: "krew-plugin",
+  plugin: "oidc-login",
+  installable: true,
+  status: "missing",
+  path: null,
+  version: null,
+};
+const OFF_PATH: RequirementResult = {
+  binary: "kubectl",
+  kind: "kubectl",
+  plugin: null,
+  installable: true,
+  status: "not-on-app-path",
+  path: "/opt/homebrew/bin/kubectl",
+  version: null,
+};
+const EXTERNAL: RequirementResult = {
+  binary: "gke-gcloud-auth-plugin",
+  kind: "external",
+  plugin: null,
+  installable: false,
+  status: "missing",
+  path: null,
+  version: null,
+};
+/** Resolved, and carrying the one version the backend ever fills in. */
+const FOUND: RequirementResult = {
+  binary: "kubectl",
+  kind: "kubectl",
+  plugin: null,
+  installable: true,
+  status: "found",
+  path: "/Users/ada/.srelens/bin/kubectl",
+  version: "v1.31.4",
+};
+
+const report = (context: string, items: RequirementResult[]): { data: DiagnosisReport } => ({
+  data: { context, items },
+});
+
+/** Answer each context with its own report, by name. */
+function reports(byContext: Record<string, RequirementResult[]>) {
+  core.diagnoseContext.mockImplementation((name: string) =>
+    Promise.resolve(report(name, byContext[name] ?? [])),
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  core.isTauri.mockReturnValue(true);
+  core.installPlugin.mockResolvedValue({ data: { plugin: "oidc-login", output: "installed" } });
+  core.startToolInstall.mockResolvedValue({
+    data: { tool: "kubectl", version: "v1.31.4", path: "/Users/ada/.srelens/bin/kubectl" },
+  });
+  core.toolboxStatus.mockResolvedValue({ data: [] });
+  reports({});
+  resetContexts();
+  resetProbes();
+  resetView();
+});
+
+const rail = (contexts: string[]) => render(<ExecAuthRail contexts={contexts} />);
+
+/** The block a context's own heading owns. */
+const sectionFor = (context: string) =>
+  screen.getByRole("heading", { name: context }).closest("section") as HTMLElement;
+
+const headings = () =>
+  screen.queryAllByRole("heading").map((h) => h.textContent?.trim() ?? "");
+
+/** The resolution word and the severity the pill drew it at. */
+const verdict = (scope: HTMLElement) => {
+  const pill = scope.querySelector(".status");
+  return { word: pill?.textContent?.trim() ?? "", kind: pill?.getAttribute("data-kind") ?? "" };
+};
+
+describe("ExecAuthRail — a tool that is not there", () => {
+  it("offers to install a binary srelens cannot find and can install", async () => {
+    reports({ "edge-apac": [MISSING] });
+    rail(["edge-apac"]);
+
+    const section = await waitFor(() => sectionFor("edge-apac"));
+    const button = within(section).getByRole("button", { name: /install kubectl-oidc_login/i });
+    await userEvent.click(button);
+
+    // The krew plugin's own name, not the binary the plugin installs as.
+    expect(core.installPlugin).toHaveBeenCalledWith("oidc-login");
+  });
+
+  it("installs kubectl itself through the managed installer", async () => {
+    reports({ "edge-apac": [{ ...OFF_PATH, status: "missing", path: null }] });
+    rail(["edge-apac"]);
+
+    const section = await waitFor(() => sectionFor("edge-apac"));
+    await userEvent.click(within(section).getByRole("button", { name: /install kubectl/i }));
+
+    expect(core.startToolInstall).toHaveBeenCalledWith("kubectl", expect.anything());
+    expect(core.installPlugin).not.toHaveBeenCalled();
+  });
+
+  it("says so, rather than offering a button, for a tool srelens does not install", async () => {
+    reports({ "edge-apac": [EXTERNAL] });
+    rail(["edge-apac"]);
+
+    const section = await waitFor(() => sectionFor("edge-apac"));
+    expect(section.textContent).toContain("gke-gcloud-auth-plugin");
+    expect(within(section).queryByRole("button", { name: /install/i })).toBeNull();
+    expect(section.textContent).toMatch(/does not install this one/i);
+  });
+});
+
+describe("ExecAuthRail — a tool that is there but not visible", () => {
+  it("explains an off-PATH binary instead of offering an install that changes nothing", async () => {
+    // Both cases in one render, so a rail that collapsed them has to disagree
+    // with one of these two assertions.
+    reports({ "edge-apac": [OFF_PATH], "prod-eu": [MISSING] });
+    rail(["edge-apac", "prod-eu"]);
+
+    const off = await waitFor(() => sectionFor("edge-apac"));
+    const gone = sectionFor("prod-eu");
+
+    // `OFF_PATH.installable` is true. Installing it again would put a second
+    // copy somewhere the app already searches and leave this one where it is,
+    // so the button is not drawn — the remedy is the PATH.
+    expect(within(off).queryByRole("button", { name: /install/i })).toBeNull();
+    expect(within(gone).getByRole("button", { name: /install/i })).toBeTruthy();
+
+    expect(off.textContent).toMatch(/not on the PATH srelens/i);
+    // The location is the actionable half, and it is on screen rather than in
+    // an attribute nobody can see.
+    expect(off.textContent).toContain("/opt/homebrew/bin/kubectl");
+
+    // Two resolutions, two words. A rail that mapped both to "Missing" fails
+    // here even though every sentence above it still rendered.
+    expect(verdict(off).word).not.toBe(verdict(gone).word);
+    expect(verdict(gone).word).toMatch(/missing/i);
+  });
+});
+
+describe("ExecAuthRail — a context with nothing to report", () => {
+  it("reports a context that needs no external tool as healthy, not absent", async () => {
+    reports({ "prod-eu": [] });
+    const { container } = rail(["prod-eu"]);
+
+    // `ContextRequirements` calls this a healthy state in as many words: the
+    // user has no exec block, so nothing external is needed.
+    expect(await screen.findByText(/every context's auth resolves/i)).toBeTruthy();
+    // Counted by core's `plural`, so the sentence says a check happened.
+    await waitFor(() => expect(container.textContent).toContain("1 context"));
+    // And no blank card for the context that had nothing to say.
+    expect(headings()).not.toContain("prod-eu");
+  });
+
+  it("counts a context whose every requirement resolved as healthy too", async () => {
+    reports({ "prod-eu": [FOUND] });
+    rail(["prod-eu"]);
+
+    expect(await screen.findByText(/every context's auth resolves/i)).toBeTruthy();
+    expect(headings()).not.toContain("prod-eu");
+  });
+
+  it("does not claim health when there is no context to check", async () => {
+    const { container } = rail([]);
+
+    await waitFor(() => expect(container.textContent).toMatch(/no context/i));
+    expect(container.textContent).not.toMatch(/every context's auth resolves/i);
+    expect(core.diagnoseContext).not.toHaveBeenCalled();
+  });
+});
+
+describe("ExecAuthRail — several contexts", () => {
+  it("gives every context that has something to report its own section, and no others", async () => {
+    reports({ "edge-apac": [MISSING], "prod-eu": [OFF_PATH], dev: [] });
+    rail(["edge-apac", "prod-eu", "dev"]);
+
+    await waitFor(() => expect(headings()).toEqual(["edge-apac", "prod-eu"]));
+    expect(core.diagnoseContext).toHaveBeenCalledTimes(3);
+    // Each section speaks for its own context, not for the first one answered.
+    expect(sectionFor("edge-apac").textContent).toContain("kubectl-oidc_login");
+    expect(sectionFor("prod-eu").textContent).not.toContain("kubectl-oidc_login");
+  });
+
+  it("counts one context's unresolved requirements, not its requirements", async () => {
+    // `edge-apac` has THREE requirements and two problems. A count taken over
+    // the whole list would read "3 issues" while listing two, and a count
+    // taken over the rail would read "3 issues" on both sections.
+    reports({ "edge-apac": [MISSING, EXTERNAL, FOUND], "prod-eu": [OFF_PATH] });
+    rail(["edge-apac", "prod-eu"]);
+
+    await waitFor(() => expect(sectionFor("edge-apac").textContent).toContain("2 issues"));
+    expect(sectionFor("edge-apac").textContent).not.toContain("3 issues");
+    expect(sectionFor("prod-eu").textContent).toContain("1 issue");
+
+    // And the resolved requirement is not one of the rows being counted.
+    expect(within(sectionFor("edge-apac")).queryByText("Installed")).toBeNull();
+  });
+});
+
+describe("ExecAuthRail — what it does not claim", () => {
+  it("states the resolution and says nothing about versions", async () => {
+    // Every requirement here carries a version, INCLUDING the two the rail
+    // draws. `status_fields` sends `None` for an unresolved requirement today,
+    // so a fixture of realistic data would pass this test by accident — the
+    // only versioned row would be the resolved one the rail filters out, and a
+    // rail that printed `{binary} {version}` on every row would survive. The
+    // property under test is that this rail never renders a version, whatever
+    // the payload carries, because §17's sentence is what appears the moment
+    // it does.
+    reports({
+      "edge-apac": [
+        { ...MISSING, version: "v1.32.0" },
+        { ...OFF_PATH, version: "v1.31.0" },
+        FOUND,
+      ],
+    });
+    const { container } = rail(["edge-apac"]);
+
+    await waitFor(() => expect(headings()).toContain("edge-apac"));
+    const text = container.textContent ?? "";
+
+    // A kubeconfig records WHICH binary a context execs and never which
+    // version, so §17's "needs kubelogin v1.32.0 · the installed v1.31.0
+    // cannot refresh its token" is unbackable — every part of it.
+    expect(text).not.toMatch(/v\d+\.\d+/);
+    expect(text).not.toMatch(/\bversion\b/i);
+    expect(text).not.toMatch(/\bupdate\b/i);
+
+    // The resolution itself IS stated, so the assertions above are not passing
+    // on an empty rail.
+    expect(text).toMatch(/not on the PATH srelens/i);
+    expect(verdict(sectionFor("edge-apac")).word).toBeTruthy();
+  });
+
+  it("puts no path or error in a title attribute", async () => {
+    reports({ "edge-apac": [OFF_PATH] });
+    const { container } = rail(["edge-apac"]);
+
+    await waitFor(() => expect(headings()).toContain("edge-apac"));
+    // The rule `PairList` and `KV` were stripped for. A resolution carries a
+    // filesystem path, which is exactly the kind of value that must not hide
+    // in an attribute nothing on screen announces.
+    expect(container.querySelectorAll("[title]")).toHaveLength(0);
+  });
+});
+
+describe("ExecAuthRail — the check itself", () => {
+  it("says it is checking while the contexts are being diagnosed", async () => {
+    let release: (v: { data: DiagnosisReport }) => void = () => {};
+    core.diagnoseContext.mockReturnValue(
+      new Promise<{ data: DiagnosisReport }>((resolve) => {
+        release = resolve;
+      }),
+    );
+    rail(["edge-apac"]);
+
+    expect(screen.getByRole("status", { name: /checking exec auth/i })).toBeTruthy();
+
+    release(report("edge-apac", [MISSING]));
+    expect(await screen.findByRole("heading", { name: "edge-apac" })).toBeTruthy();
+  });
+
+  it("reports a context whose check failed in words, with the original folded away", async () => {
+    core.diagnoseContext.mockResolvedValue({
+      error: "handler error: ApiError: Unauthorized (401): Status { code: 401 }",
+    });
+    rail(["edge-apac"]);
+
+    const section = await waitFor(() => sectionFor("edge-apac"));
+    // `describeError`'s own sentence, not the struct.
+    expect(section.textContent).toMatch(/rejected your credentials/i);
+    // The struct is still reachable — behind a disclosure, which is the whole
+    // reason it is not a `title`.
+    const raw = section.querySelector('[data-slot="raw"]');
+    expect(raw?.textContent).toContain("Status { code: 401 }");
+  });
+
+  it("does not certify health when the check itself blew up", async () => {
+    core.diagnoseContext.mockRejectedValue(new Error("boom"));
+    const { container } = rail(["edge-apac"]);
+
+    // The dangerous failure mode: with no data in hand, "every context's auth
+    // resolves" is the sentence that would otherwise render.
+    await waitFor(() => expect(container.textContent).toMatch(/could not check exec auth/i));
+    expect(container.textContent).not.toMatch(/every context's auth resolves/i);
+  });
+
+  it("keeps one context's failure from hiding another context's answer", async () => {
+    core.diagnoseContext.mockImplementation((name: string) =>
+      name === "edge-apac"
+        ? Promise.resolve({ error: "handler error: unknown context: edge-apac" })
+        : Promise.resolve(report(name, [MISSING])),
+    );
+    rail(["edge-apac", "prod-eu"]);
+
+    await waitFor(() => expect(headings()).toEqual(["edge-apac", "prod-eu"]));
+    expect(within(sectionFor("prod-eu")).getByRole("button", { name: /install/i })).toBeTruthy();
+  });
+});
+
+describe("ExecAuthRail — where installs can run", () => {
+  it("offers no install in the browser, where the capability is denied", async () => {
+    core.isTauri.mockReturnValue(false);
+    reports({ "edge-apac": [MISSING] });
+    rail(["edge-apac"]);
+
+    const section = await waitFor(() => sectionFor("edge-apac"));
+    expect(within(section).queryByRole("button", { name: /install/i })).toBeNull();
+    expect(section.textContent).toMatch(/srelens desktop app/i);
+  });
+
+  it("re-checks the context once an install has run", async () => {
+    // Without this the rail keeps saying `Missing` about a binary that is now
+    // on the PATH, for as long as the screen stays open — and the reader's
+    // only way to find out it worked is to close the screen and come back.
+    core.diagnoseContext
+      .mockResolvedValueOnce(report("edge-apac", [MISSING]))
+      .mockResolvedValue(
+        report("edge-apac", [
+          { ...MISSING, status: "found", path: "/Users/ada/.krew/bin/kubectl-oidc_login" },
+        ]),
+      );
+    rail(["edge-apac"]);
+
+    const section = await waitFor(() => sectionFor("edge-apac"));
+    await userEvent.click(within(section).getByRole("button", { name: /install/i }));
+
+    expect(await screen.findByText(/every context's auth resolves/i)).toBeTruthy();
+    expect(core.diagnoseContext).toHaveBeenCalledTimes(2);
+  });
+
+  it("says what went wrong when an install is refused", async () => {
+    core.installPlugin.mockResolvedValue({ error: "handler error: krew is not installed" });
+    reports({ "edge-apac": [MISSING] });
+    rail(["edge-apac"]);
+
+    const section = await waitFor(() => sectionFor("edge-apac"));
+    await userEvent.click(within(section).getByRole("button", { name: /install/i }));
+
+    await waitFor(() =>
+      expect(sectionFor("edge-apac").textContent).toMatch(/could not install kubectl-oidc_login/i),
+    );
+  });
+});
+
+describe("Toolbox mounts the rail", () => {
+  const CTX: ClusterContext = {
+    name: "prod-eu",
+    stableId: "prod",
+    cluster: "prod",
+    server: "https://prod",
+    isCurrent: true,
+  };
+
+  it("puts it beside the inventory without losing the pane head", async () => {
+    setContexts([CTX]);
+    store.setState(defaultState([CTX]));
+    reports({ "prod-eu": [MISSING] });
+    store.openTab("/toolbox");
+    const { container } = render(<Toolbox route="/toolbox" />);
+
+    // The rail is a landmark named by its own head.
+    const aside = await waitFor(() =>
+      screen.getByRole("complementary", { name: "Exec auth check" }),
+    );
+    expect((aside as HTMLElement).style.width).toBe("288px");
+    // §17's pane head survives the move into `SideRail.mainHead`.
+    expect(screen.getByText("Managed tools · installed under ~/.srelens/bin")).toBeTruthy();
+    // And it diagnoses the contexts this window knows about.
+    await waitFor(() => expect(within(aside as HTMLElement).getByRole("heading", { name: "prod-eu" })).toBeTruthy());
+    expect(container.querySelectorAll("[title]")).toHaveLength(0);
+  });
+});

--- a/packages/ui-next/src/screens/toolbox/ExecAuthRail.tsx
+++ b/packages/ui-next/src/screens/toolbox/ExecAuthRail.tsx
@@ -220,12 +220,42 @@ export function ExecAuthRail({ contexts }: ExecAuthRailProps) {
     );
   }
 
+  // A context srelens could not check at all is a different fact from one whose
+  // auth needs a tool, and it repeats: the same refusal arrives once per
+  // context. Drawn one card each, eleven of them push the finding this rail
+  // exists for off the bottom of a 288px column — the shape that made the
+  // cluster overview unreadable when a raw API error took four rows per
+  // cluster. They collapse into one section; the actionable ones keep theirs.
+  const unchecked = rows.filter((check) => check.error !== undefined);
+  const actionable = rows.filter((check) => check.error === undefined);
+
   return (
     <>
-      {rows.map((check) => (
+      {actionable.map((check) => (
         <ContextSection key={check.context} check={check} onInstalled={checks.reload} />
       ))}
+      {unchecked.length > 0 && <UncheckedSection checks={unchecked} />}
     </>
+  );
+}
+
+/**
+ * The contexts srelens could not check, together.
+ *
+ * One card names its context and says why; several say the same sentence over
+ * and over, and the reason belongs to all of them. The first error is shown
+ * because a repeated failure has a repeated cause — and the names are listed
+ * so a reader can tell whether the contexts they care about are among them.
+ */
+function UncheckedSection({ checks }: { checks: ContextCheck[] }) {
+  return (
+    <Section title={`${plural(checks.length, "context")} not checked`}>
+      <div className="flex flex-col gap-1 text-[0.8125rem]">
+        <div>srelens could not read the exec auth for {checks.length === 1 ? "this context" : "these contexts"}.</div>
+        <div className="text-muted">{checks.map((c) => c.context).join(", ")}</div>
+        <FailureLine error={checks[0].error ?? ""} className="text-muted" />
+      </div>
+    </Section>
   );
 }
 

--- a/packages/ui-next/src/screens/toolbox/ExecAuthRail.tsx
+++ b/packages/ui-next/src/screens/toolbox/ExecAuthRail.tsx
@@ -1,0 +1,346 @@
+import { useState, type ReactNode } from "react";
+import { diagnoseContext, installPlugin, isTauri, plural, startToolInstall } from "@srelens/core";
+import type { RequirementResult, RequirementStatus } from "@srelens/core/lib/toolbox";
+import {
+  Badge,
+  Button,
+  EmptyState,
+  LoadingState,
+  Section,
+  StatusPill,
+  type StatusKind,
+} from "@srelens/ui-kit";
+import { FailureAlert, FailureLine, FailureState } from "../../lib/errorCopy";
+import { useResource } from "../../lib/useResource";
+
+/**
+ * §17's rail width, and this screen's alone — see `SideRail`'s note on why the
+ * width is a number per screen rather than a scale. Exported so the screen and
+ * this file cannot hold two different answers to the same question.
+ */
+export const EXEC_AUTH_RAIL_WIDTH = 288;
+
+/**
+ * What the Toolbox can actually tell apart about a tool. **Four values.**
+ *
+ * THE ONE HAND-PAIRED WORD/TONE TABLE IN THIS SCREEN, AND IT IS MARKED BECAUSE
+ * IT SHOULD NOT HAVE TO EXIST. It was written by Task 8 in `Toolbox.tsx` and
+ * MOVED here rather than copied: this rail needs a word for a resolution too,
+ * and a second table beside the first is exactly the drift — an amber word and
+ * a grey one for the same fact — that the "every status word comes from core"
+ * rule exists to stop. It lives in this file because `Toolbox` imports this
+ * rail to mount it, so this is the direction the import can run without a
+ * cycle. **If a `toolVerdict` is ever added to `packages/core`, delete this and
+ * call it** — and do not spell `status === "missing" ? … : …` anywhere else.
+ *
+ * Task 8's three states are unchanged. `off-path` is the fourth, and it is a
+ * genuinely different fact from both of the ones already here: `unmanaged`
+ * means somebody else installed it and it WORKS, `missing` means it is not on
+ * the machine, and this means it is on the machine and srelens still cannot
+ * run it. Collapsing it into either one loses the only thing the reader needs
+ * to know — which of two completely different remedies applies.
+ *
+ * The severities are §17's own rule (`installed` → ok, everything else muted).
+ * A missing exec-auth tool IS the reason a cluster cannot be reached, which
+ * argues for `warning` — but the severity of a state is not a property of the
+ * pane it is drawn in, and the same word must not be amber in the rail and
+ * grey in the table six inches to its left. The urgency is carried where it
+ * belongs: in the section's own sentence, which says the cluster cannot be
+ * reached, and in the count beside its heading.
+ */
+export type ToolState = "installed" | "unmanaged" | "off-path" | "missing";
+
+export const TOOL_VERDICT: Record<ToolState, { word: string; kind: StatusKind }> = {
+  installed: { word: "Installed", kind: "success" },
+  unmanaged: { word: "Unmanaged", kind: "neutral" },
+  "off-path": { word: "Not on PATH", kind: "neutral" },
+  missing: { word: "Missing", kind: "neutral" },
+};
+
+/**
+ * The backend's three resolutions, named in the vocabulary above.
+ *
+ * Not a second word/tone table: it pairs one core vocabulary with another and
+ * carries neither a word nor a colour of its own. `found` is `installed`
+ * because that is what a binary the app can execute is — the pane head's
+ * `~/.srelens/bin` promise is the table's business, not this rail's.
+ */
+const RESOLVED: Record<RequirementStatus, ToolState> = {
+  found: "installed",
+  "not-on-app-path": "off-path",
+  missing: "missing",
+};
+
+/** One context's answer — or the reason it has none. */
+interface ContextCheck {
+  context: string;
+  items: RequirementResult[];
+  /** Set when `toolbox.diagnoseContext` refused for this context alone. */
+  error?: string;
+}
+
+/** A requirement srelens cannot satisfy right now. */
+function unresolved(item: RequirementResult): boolean {
+  return item.status !== "found";
+}
+
+/** Whether a context has anything to say beyond "everything resolves". */
+function reportable(check: ContextCheck): boolean {
+  return check.error !== undefined || check.items.some(unresolved);
+}
+
+/**
+ * The install srelens can actually run for a requirement, or null.
+ *
+ * **`installable` alone is not the answer, and that is the whole point of this
+ * function.** The backend sets it for kubectl and for krew plugins — a fact
+ * about the TOOL — while whether installing would help is a fact about the
+ * RESOLUTION. A binary sitting at `/opt/homebrew/bin/kubectl` that the app
+ * cannot see is `installable: true`, and installing it would put a second copy
+ * under `~/.srelens/bin` and leave this one exactly where it is. That is a
+ * button that appears to work and changes nothing, which is worse than no
+ * button: the reader clicks it, watches it succeed, and still cannot reach the
+ * cluster.
+ */
+function installAction(item: RequirementResult): (() => Promise<{ error?: string }>) | null {
+  if (item.status !== "missing" || !item.installable) return null;
+  if (item.kind === "kubectl") return () => startToolInstall("kubectl", () => {});
+  const plugin = item.plugin;
+  // A krew requirement with no plugin name is a shape the backend does not
+  // produce; a click on it would reject on an empty argument, so it is not
+  // drawn. A control that cannot work is not drawn.
+  if (item.kind === "krew-plugin" && plugin) return () => installPlugin(plugin);
+  return null;
+}
+
+/** What a requirement says about itself, in the resolution's own terms. */
+function sentence(item: RequirementResult): string {
+  if (item.status === "not-on-app-path") {
+    return (
+      "Present on this machine, but not on the PATH srelens runs commands with. " +
+      "Installing it again would not change that — put this copy on that PATH, " +
+      "or link it into ~/.srelens/bin."
+    );
+  }
+  return "srelens did not find it on the PATH it runs commands with, nor anywhere else it looked.";
+}
+
+export interface ExecAuthRailProps {
+  /**
+   * Every context this window knows about, by the name `toolbox.diagnoseContext`
+   * takes. One call each: the capability reads a context's own exec block out
+   * of the kubeconfig that owns it, and there is no batched form.
+   */
+  contexts: readonly string[];
+}
+
+/**
+ * §17's right rail: which kubeconfig contexts cannot authenticate, and why.
+ *
+ * A context can name an external binary in its user's `exec` block —
+ * `kubectl-oidc_login`, `aws`, `gke-gcloud-auth-plugin` — and when srelens
+ * cannot run that binary the cluster is simply unreachable, with nothing on
+ * screen saying so. Every other symptom (an empty resource list, a rail of red
+ * clusters) is a consequence. This is the one surface that names the cause.
+ *
+ * **IT REPORTS RESOLUTION, NOT VERSION ADEQUACY.** §17's copy for this rail
+ * reads "needs kubelogin v1.32.0. The installed v1.31.0 cannot refresh its
+ * token, so watches will drop after an hour", and not one clause of that can
+ * be backed. A kubeconfig `exec` block records a command and its arguments;
+ * `Requirement` is `{ binary, kind }` accordingly. Kubernetes records WHICH
+ * binary a context runs and never which version, nothing in this app queries a
+ * release feed, and no token lifetime is reported anywhere. The rail says the
+ * true thing instead: this context wants a tool that is missing, or one that
+ * is present but not where srelens looks. The suite asserts no version string
+ * appears here at all, with a resolved requirement's `v1.31.4` in the fixture
+ * so the assertion has something to catch.
+ *
+ * **A context with nothing to report is healthy, not empty.**
+ * `ContextRequirements` says it in as many words — a context whose user has no
+ * exec block needs nothing external, which is a healthy state and not an
+ * absence — and the same is true of one whose every requirement resolved. Both
+ * fold into one sentence for the whole rail rather than a blank card each.
+ * Sections are for contexts that have something to say.
+ */
+export function ExecAuthRail({ contexts }: ExecAuthRailProps) {
+  const checks = useResource<ContextCheck[]>(
+    async () =>
+      Promise.all(
+        contexts.map(async (context): Promise<ContextCheck> => {
+          const result = await diagnoseContext(context);
+          // Kept per context rather than thrown. `diagnoseContext` refuses one
+          // context at a time — an unknown name, a kubeconfig that no longer
+          // parses — and one unreadable context must not take the other nine
+          // contexts' answers off the rail with it.
+          return { context, items: result.data?.items ?? [], error: result.error };
+        }),
+      ),
+    // The list, not its identity: `useContexts` hands back a new array on every
+    // store notification, and depending on the reference would re-diagnose
+    // every context each time anything in the window changed.
+    [JSON.stringify(contexts)],
+  );
+
+  if (checks.status === "loading") {
+    return <LoadingState label="Checking exec auth" className="py-6" />;
+  }
+  if (checks.status === "error") {
+    // Nothing in `diagnoseContext` rejects today — it reports a refusal as
+    // `{ error }` — so this is the guard against that changing underneath us.
+    // The alternative is worse than an error card: with no data, the healthy
+    // sentence below is what would render, and the rail would certify auth it
+    // never managed to check.
+    return (
+      <FailureState
+        title="Could not check exec auth"
+        error={checks.error}
+        onRetry={checks.reload}
+        className="py-6"
+      />
+    );
+  }
+
+  const rows = (checks.data ?? []).filter(reportable);
+
+  if (rows.length === 0) {
+    return contexts.length === 0 ? (
+      <EmptyState
+        compact
+        title="No contexts to check"
+        hint="srelens has no kubeconfig context loaded, so there is no exec auth to resolve."
+      />
+    ) : (
+      <EmptyState
+        compact
+        title="Every context's auth resolves"
+        // Counted by core's `plural`, and said out loud: the reader needs to
+        // know a check happened, not merely that nothing is on screen.
+        hint={`${plural(contexts.length, "context")} checked. None of them runs a tool srelens cannot.`}
+      />
+    );
+  }
+
+  return (
+    <>
+      {rows.map((check) => (
+        <ContextSection key={check.context} check={check} onInstalled={checks.reload} />
+      ))}
+    </>
+  );
+}
+
+/** One context that cannot authenticate, and what would fix it. */
+function ContextSection({
+  check,
+  onInstalled,
+}: {
+  check: ContextCheck;
+  onInstalled: () => void;
+}) {
+  const items = check.items.filter(unresolved);
+
+  return (
+    <Section title={check.context}>
+      {check.error !== undefined ? (
+        <div className="flex flex-col gap-1 text-[0.8125rem]">
+          <div>srelens could not check this context.</div>
+          <FailureLine error={check.error} className="text-muted" />
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          <div>
+            {/* §17's action badge. The word is core's `plural`, the tone is the
+                Badge's own default — a count is a figure, not a verdict, and
+                colouring one here would be the second hand-paired table this
+                file exists to avoid. */}
+            <Badge>{plural(items.length, "issue")}</Badge>
+          </div>
+          <p className="text-[0.8125rem] leading-snug text-muted">
+            This context authenticates by running an external tool. srelens cannot reach the
+            cluster until each tool below resolves.
+          </p>
+          {items.map((item) => (
+            <Requirement
+              key={item.binary}
+              item={item}
+              onInstalled={onInstalled}
+            />
+          ))}
+        </div>
+      )}
+    </Section>
+  );
+}
+
+/** One binary a context wants, and the remedy its resolution actually has. */
+function Requirement({ item, onInstalled }: { item: RequirementResult; onInstalled: () => void }) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<unknown>(null);
+
+  const verdict = TOOL_VERDICT[RESOLVED[item.status]];
+  const run = installAction(item);
+
+  async function install() {
+    if (!run) return;
+    setBusy(true);
+    setError(null);
+    const result = await run();
+    setBusy(false);
+    if (result.error) setError(result.error);
+    // Re-check either way: a failed install can still have moved a binary, and
+    // the resolution is the only honest report of where it ended up.
+    else onInstalled();
+  }
+
+  let remedy: ReactNode = null;
+  if (run === null && item.status === "missing" && !item.installable) {
+    remedy = (
+      <p className="text-[0.8125rem] leading-snug text-muted">
+        srelens does not install this one — install it yourself and put it on the PATH.
+      </p>
+    );
+  } else if (run !== null && !isTauri()) {
+    // Said rather than drawn disabled: `toolbox.installKubectl` and
+    // `toolbox.installPlugin` are both in the server's
+    // `WEB_DENIED_CAPABILITIES`, so the button would reject on click.
+    remedy = (
+      <p className="text-[0.8125rem] leading-snug text-muted">
+        Installing happens in the srelens desktop app.
+      </p>
+    );
+  } else if (run !== null) {
+    remedy = (
+      <Button
+        className="w-full"
+        size="sm"
+        // Three sections can each offer an "Install"; the accessible name says
+        // which binary this one is for.
+        aria-label={`Install ${item.binary}`}
+        disabled={busy}
+        onClick={() => void install()}
+      >
+        {busy ? "Installing…" : `Install ${item.binary}`}
+      </Button>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center justify-between gap-2">
+        <span className="truncate font-medium">{item.binary}</span>
+        <StatusPill status={verdict.word} kind={verdict.kind} />
+      </div>
+      <p className="text-[0.8125rem] leading-snug text-muted">{sentence(item)}</p>
+      {/* On screen, in the open. A resolution's path is a value, and the rule
+          `PairList` and `KV` were stripped for is that a value never hides in
+          a `title` attribute nothing announces. */}
+      {item.path ? (
+        <div className="break-all font-mono text-[0.6875rem] text-faint">{item.path}</div>
+      ) : null}
+      {remedy}
+      {error !== null && (
+        <FailureAlert tone="sev" title={`Could not install ${item.binary}`} error={error} />
+      )}
+    </div>
+  );
+}

--- a/packages/ui-next/src/shell/Status.test.tsx
+++ b/packages/ui-next/src/shell/Status.test.tsx
@@ -79,6 +79,37 @@ describe("Status", () => {
     expect(screen.getByRole("button", { name: "2 port-forwards" })).toBeDefined();
   });
 
+  it("counts only the tunnels that are still alive", () => {
+    setState(defaultState([ctx]));
+    // A tunnel that gave up is not a tunnel in use. Two rows, one of them
+    // dead — and the singular the remaining one calls for, which a count over
+    // both would get wrong twice.
+    forwards.list = [
+      { id: 1, status: "active" },
+      { id: 2, status: "failed" },
+    ];
+    mount(<Status contexts={[ctx]} />);
+    expect(screen.getByRole("button", { name: "1 port-forward" })).toBeDefined();
+  });
+
+  it("says so on the strip when a tunnel has died", () => {
+    setState(defaultState([ctx]));
+    // The readout the reader actually had when a fifteen-minute-old forward
+    // died: `0 PORT-FORWARDS` and nothing else. The count alone still says
+    // nothing about the tunnel they are depending on.
+    forwards.list = [{ id: 1, status: "failed" }];
+    mount(<Status contexts={[ctx]} />);
+    expect(screen.getByRole("button", { name: "0 port-forwards" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "1 forward failed" })).toBeDefined();
+  });
+
+  it("says nothing about failures when nothing has failed", () => {
+    setState(defaultState([ctx]));
+    forwards.list = [{ id: 1, status: "active" }];
+    mount(<Status contexts={[ctx]} />);
+    expect(screen.queryByRole("button", { name: /failed/i })).toBeNull();
+  });
+
   it("opens the console from Ask", async () => {
     setState(defaultState([ctx]));
     mount(<Status contexts={[ctx]} />);

--- a/packages/ui-next/src/shell/Status.tsx
+++ b/packages/ui-next/src/shell/Status.tsx
@@ -1,5 +1,11 @@
 import { useSyncExternalStore } from "react";
-import { getForwards, subscribeForwards, type ClusterContext } from "@srelens/core";
+import {
+  getForwards,
+  isForwardEnded,
+  plural,
+  subscribeForwards,
+  type ClusterContext,
+} from "@srelens/core";
 import { StatusBar, type StatusSegment } from "@srelens/ui-kit";
 import { useConsole } from "../console";
 import { useInfo } from "../lib/probe";
@@ -43,7 +49,13 @@ export function Status({ contexts }: { contexts: ClusterContext[] }) {
   // Nothing has probed yet, or there is nothing to probe. Either way the link
   // is not up, and "Disconnected" is the honest reading of that.
   const state = (activeId ? links[activeId]?.state : undefined) ?? "disconnected";
-  const n = forwards.length;
+  // Split rather than counted blind. A tunnel that gave up is still in the
+  // store — it stays on the forwards screen until its reader dismisses it —
+  // and counting it here would report a dead tunnel as one of the ones
+  // carrying traffic, which is the assumption that made a dead forward
+  // dangerous in the first place.
+  const dead = forwards.filter(isForwardEnded).length;
+  const n = forwards.length - dead;
 
   const segments: StatusSegment[] = [
     {
@@ -67,7 +79,23 @@ export function Status({ contexts }: { contexts: ClusterContext[] }) {
   // still changing, not for one that merely happens to be current.
   segments.push({ id: "link", label: LINK_WORD[state], pulse: state === "connecting" });
 
-  const end: StatusSegment[] = [
+  const end: StatusSegment[] = [];
+  // Only when there is one, and this is the exception to the rule the version
+  // segment states above: a readout that comes and goes moves what follows it
+  // along the strip, which is a cost worth paying exactly once — for the news
+  // that a tunnel the reader is depending on has died. The count beside it
+  // cannot carry that: a forward that dies takes the strip to `0
+  // port-forwards`, which is what a reader with no forwards at all sees.
+  if (dead > 0) {
+    end.push({
+      id: "pf-dead",
+      label: `${plural(dead, "forward")} failed`,
+      tone: "sev",
+      dot: true,
+      onSelect: () => openTab("/forwards"),
+    });
+  }
+  end.push(
     {
       id: "pf",
       label: `${n} port-forward${n === 1 ? "" : "s"}`,
@@ -78,7 +106,7 @@ export function Status({ contexts }: { contexts: ClusterContext[] }) {
       onSelect: () => openTab("/forwards"),
     },
     { id: "ask", label: "Ask", tone: "accent", onSelect: () => setOpen(true) },
-  ];
+  );
 
   return <StatusBar segments={segments} end={end} />;
 }

--- a/packages/ui-next/src/shell/Window.test.tsx
+++ b/packages/ui-next/src/shell/Window.test.tsx
@@ -15,6 +15,7 @@ const {
   connectCluster,
   listCrds,
   getForwards,
+  rehydrateForwards,
   subscribeForwards,
   isApplePlatform,
   isTauri,
@@ -31,6 +32,7 @@ const {
   connectCluster: vi.fn(),
   listCrds: vi.fn(),
   getForwards: vi.fn(() => []),
+  rehydrateForwards: vi.fn(async () => {}),
   subscribeForwards: vi.fn(() => () => {}),
   isApplePlatform: vi.fn(() => true),
   isTauri: vi.fn(() => true),
@@ -48,6 +50,7 @@ vi.mock("@srelens/core", async (importOriginal) => {
     connectCluster: (...a: unknown[]) => connectCluster(...a),
     listCrds: (...a: unknown[]) => listCrds(...a),
     getForwards: () => getForwards(),
+    rehydrateForwards: () => rehydrateForwards(),
     subscribeForwards: (...a: Parameters<typeof subscribeForwards>) => subscribeForwards(...a),
     isApplePlatform: () => isApplePlatform(),
     isTauri: () => isTauri(),
@@ -469,5 +472,17 @@ describe("Window contexts", () => {
   it("passes the configured kubeconfig files to listContexts", async () => {
     await booted();
     expect(listContexts).toHaveBeenCalledWith(["/home/u/.kube/config", "/home/u/.kube/other"]);
+  });
+});
+
+describe("Window — what boot has to ask for", () => {
+  it("asks the backend what is still forwarding, whatever route it opens on", async () => {
+    // The forwards store is module-level JavaScript and a browser reload
+    // empties it while the server keeps forwarding. Rehydrating only when
+    // `/forwards` mounts leaves the status bar reading `0 port-forwards`
+    // — on every other route — while tunnels are live and the `/pf/<id>/`
+    // proxies still answer. Boot is the only place that runs regardless.
+    await booted();
+    await waitFor(() => expect(rehydrateForwards).toHaveBeenCalled());
   });
 });

--- a/packages/ui-next/src/shell/Window.tsx
+++ b/packages/ui-next/src/shell/Window.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { isApplePlatform, isTauri, listContexts, loadKubeconfigFiles, type ClusterContext } from "@srelens/core";
+import {
+  isApplePlatform,
+  isTauri,
+  listContexts,
+  loadKubeconfigFiles,
+  rehydrateForwards,
+  type ClusterContext,
+} from "@srelens/core";
 import { Button, Checkbox, Drawer, LoadingState, TabStrip, TextInput, type ContextMenuItem, type StripTab } from "@srelens/ui-kit";
 import { setContexts, setKubeconfigFiles, useContexts } from "../lib/clusters";
 import { loadColumnPrefs } from "../lib/columnPrefs";
@@ -140,6 +147,13 @@ export function Window({
       // the first subject followed then spreads over an empty list and erases
       // every earlier one, exactly as `loadMarks` above describes.
       loadRecentLogSubjects();
+      // And what the backend is still forwarding. The forwards store is
+      // module-level JavaScript: a browser reload empties it while the server
+      // keeps the tunnels up, so without this the status bar reads
+      // `0 port-forwards` on every route but `/forwards` — which is the one
+      // route that rehydrates itself, and the one a reader is least likely to
+      // reload onto. It never rejects, so it needs no guard of its own.
+      void rehydrateForwards();
       // Classic threads these through every call for a reason: a context that
       // came from an additional kubeconfig file cannot have a client built for
       // it until the backend has been told the file's path, and the list races

--- a/scripts/screenshot.mjs
+++ b/scripts/screenshot.mjs
@@ -400,6 +400,7 @@ const TITLES = {
   "/logs": ["Logs", "logs"],
   "/helm": ["Helm", "helm"],
   "/forwards": ["Port forwards", "forwards"],
+  "/toolbox": ["Toolbox", "toolbox"],
   "/topology": ["Topology", "topology"],
   "/incidents": ["Incidents", "incidents"],
 };
@@ -416,7 +417,10 @@ function tabFor(r, id) {
   const tab = { id, route: r, title, kind };
   if (r === "/") tab.pinned = true;
   const name = contexts.find((c) => c.stableId === activeCluster)?.name;
-  if (name && r !== "/applog" && r !== "/notes") tab.sub = name;
+  // App-scoped routes carry no cluster in their sub — `APP_SCOPED` in
+  // packages/ui-next/src/lib/routes.ts is the list, and the toolbox is on it:
+  // the managed tools are the machine's, not any one cluster's.
+  if (name && !["/applog", "/notes", "/toolbox"].includes(r)) tab.sub = name;
   return tab;
 }
 


### PR DESCRIPTION
Step 7 of the migration epic (#305), the first of three specs — `/forwards` and `/toolbox`. Spec 2 takes Terminals and settles the dock the Logs spec deferred; spec 3 takes Helm.

These two are paired because they are the same *shape* of work — a table of long-lived things with row actions — not merely because both are small. Toolbox is also the only screen in this migration that never touches a cluster.

## Most of the hard part was already done

`packages/core/src/lib/forward.ts` already owned a module-level store of live forwards, already consumed by the status bar through `useSyncExternalStore` — that is the `0 PORT-FORWARDS` in every screenshot since #336. **No new state machinery.** The store was also already platform-aware where the design is not: `forwardUrl` returns `localhost:<port>` on the desktop and `/pf/<id>/` on web, because a container's loopback is unreachable from a browser. §13 specifies the literal `http://localhost:<local>`; ours goes through `forwardAddress`.

## What the design asks for that nothing served

| | |
|---|---|
| `Traffic` + the `55.4 MB moved` badge | **built** — the tunnel now counts bytes |
| `Age` | **built** — the backend stamps a start time |
| toolbox `Size` | **built** — the file at each tool's path is stat'd, following symlinks |
| toolbox `State: update` | **declined** — nothing knows an upstream version and a kubeconfig never states a minimum |
| the exec-auth rail's version claim | **declined** — `Requirement` is `{binary, kind}`: Kubernetes records *which* binary a context needs, never which version |

The rail still ships. It reports **resolution** — missing, present-but-off-our-PATH, found — which is the true and useful thing, and distinguishes the two cases that need different remedies: installing does not fix a binary that is already on the system but off the path srelens execs with.

## Counting the bytes, and the shortcut that would have looked right

`crates/kube/src/forward.rs` ended its tunnel with:

```rust
let _ = copy_bidirectional(&mut local, &mut upstream).await;
```

That call **returns the byte counts** and the line discards them. Capturing the return looks like the whole task — and would have reintroduced the bug, because `copy_bidirectional` returns only when the connection *closes*. A tunnel holding one long-lived connection to a database would have read zero for hours while the screen called it idle.

It is a counting wrapper instead. The mutation proving this is worth stating: the return-value-only version **passed two of the three tests**; only `a_connection_still_open_has_already_counted_what_it_moved` caught it.

The counter is created once per forward, not per reconnect attempt — a counter inside the reconnect loop resets a tunnel's total on every reconnect, which is the same bug at a coarser grain and only visible *after* a reconnect. Pinned by a test scripting three attempts moving 100/150/50 and requiring 300.

## The leak this screen would have exposed

There was no `list_forwards` and the store never rehydrated. On the desktop that is correct — the Rust process dies with the app, so the forwards genuinely die. **On web the server survives a browser reload**, so a reader reloaded into an empty table while tunnels were still running, with no way to stop them.

Fixed rather than filed, because a screen titled "Port forwards" must not be where someone discovers it lies. Both screenshots of a live tunnel in this branch came through **rehydration on a wiped browser profile**, so the path is proven end to end.

`startedAt` comes from the backend for every forward, stamped once in `ForwardManager::start` and reused for both the start response and `list()`. Pinned by a test that makes the two **disagree** and fails.

## Starting a forward from the thing you are looking at

The user found this: none of the natural doors worked. The row menu's `Port forward` minted `/resources/<name>/forward`, which rendered a Placeholder; a Service's Ports table and a Pod's container ports were text with no action.

**This is the Logs mistake, second occurrence** — that screen shipped in #344 with its front door rendering a Placeholder and needed #346 to fix it. Task 10 flagged the contradiction here and it was recorded as out-of-scope sweep-up, which was the wrong call: "out of scope" is how the same defect ships twice.

All three doors now open the `New forward` dialog prefilled. The pod's comma-joined ports cell became one shared `ContainerPorts` where each port is the control, which also closed the same gap on the peek's Containers pane.

**The local port is offered, not asked for** — and drawn at random from 10000-32767 rather than mirroring the remote. Mirroring reads well (`50051:50051`) and is the likelier of the two to fail: a port worth forwarding is one this machine plausibly already serves, and srelens can only see its own forwards. The range sits above the well-known and registered service ports and **below 49152**, where the OS hands out its own ephemeral ports for outbound sockets. Clearing the field sends no local port and lets the OS choose — the only answer that cannot collide.

## Web mode

The server already denies every toolbox mutator, so §17's per-row Install button would fail on every row there. The column is absent and the screen says once that tools are managed where srelens runs — the same rule that kept `Export` off the Logs screen until it worked.

## Three things found by looking, not by testing

- **The exec-auth rail was eleven identical cards** — "srelens could not check this context", one per context, filling a 288px column and pushing the finding it exists for off the bottom. Same shape as the overview when a raw API error took four rows per cluster. They collapse into one section now; actionable contexts keep theirs and are drawn first.
- **A long context name drew straight over the cell beside it** — `m01-…/kubernetes-adminlocalhost:1249r2`, both unreadable. The cell was a bare inline span, and `truncate` sets `overflow: hidden`, which does nothing to an inline box. **Third occurrence of column overflow here**, after the events Message column and the overview's CPU meter, and all three were invisible to the suite because jsdom lays nothing out.
- **The dialog asked for a target it had just been handed.** Under `Equivalent command` it read "Choose a target and both ports" with the target selected above it.

## Mutation testing

Every task ran a pass, and they found real gaps the suites had agreed with. The two worth reading:

- **A test written to stop §17's invented version copy could not have failed.** The backend sends `version: null` for unresolved requirements, so the only versioned row in a realistic fixture was the resolved one the rail filters out — a mutant rendering `{binary} {version}` on every row passed.
- **`headers()).toEqual([])`** for an empty screen, which `Table` satisfies on its own over empty data, so a screen that never branched on row count kept it green.

Also caught: a badge counting the wrong set because its fixture made two counts equal by accident; a `port-forward` fixture using `5432:5432`, where a swapped pair reads identically; and a `severity` fixture the text scan would have found anyway.

## Opening the address

Clicking a tunnel's `Local` cell opens it in the real browser, and the dialog's `Open in browser when it comes up` switch does too. Neither can be an anchor: `window.open` and `<a target="_blank">` reach a wry delegate that returns nil, because srelens never installs a new-window handler.

It goes through Rust instead, the way `saveTextFile` already does for the same reason — `<a download>` does not trigger a save in a Tauri webview either. `tauri-plugin-opener` was already a dependency, already registered, and **already used**: OIDC cluster sign-in raises the browser through it.

`browsable()` moved into core beside `openExternal` rather than being copied — `forwardAddress` returns a bare authority on the desktop (`localhost:12492`), which is not a URL and would be read as a relative path. Both the TypeScript and the Rust **refuse** anything that is not `http(s)://<authority>` rather than repairing it, so `javascript:`, `file:`, `data:` and a bare authority are rejected on both sides of the boundary.

## Gates

3,597 tests across core, the kit and ui-next; 729 in classic, unchanged; 385 + 183 + 134 + 35 across the Rust crates; four projects typechecking; coverage 91.7 / 88.1 / 80.9 against floors of 85 / 80 / 76 on a green run; `dist/index.html` links no stylesheet.

## Known

- **A tunnel that dies on its own vanishes instead of saying so.** The backend emits `status: failed` with the reason and then `forward:closed`; the store sets the status and then removes the row, so `failed` — a state the design defines and the backend sends — is never visible, and the session-permanent `dropped` set stops rehydration bringing it back. A reader is left assuming a dead tunnel is fine. **Filed, and the next change on this branch.**
- **The desktop leg of the clickable address is unverified.** The screenshot harness runs web mode, so `isTauri()` is false there and `open_external` is never taken. It follows a path already proven in this app — OIDC sign-in raises the browser the same way (`cluster_oidc_cmd.rs:160`) — but nobody has watched this one open. Wants `pnpm dev`, a live forward, and a click.
- **The clickable cell has never been looked at.** `-mx-1`, the ghost hover box in a 13px row and long-URL truncation are asserted as class names only; the harness cannot start a forward, so no picture exists.
- **`window.open` still does nothing on the desktop** (#348), which is why the address goes through Rust. Classic's `<a target="_blank">` takes the identical dead path and is left alone — that app is frozen.
- **Web mode lists the server's own kubeconfig contexts** (#347) — the app knew 17 where the user had uploaded 6. That is what made the rail noisy, it makes the cluster rail show unusable clusters, and on a shared deployment those names leak.
- **The traffic figure is application payload across the local socket**, not wire bytes — port-forward framing and TLS to the API server are excluded. It will not match a packet capture.
- **The screenshot harness's staleness gate is still not sufficient.** It mtime-checks `crates/` and reported "fresh"; running the build by hand recompiled two crates anyway, because `-p/--bin` resolves features differently from a workspace build. Cheapest fix is to always invoke cargo and let its fingerprinting decide.
- **`/resources/<name>/forward` is no longer minted** but still parses, so a tab persisted by an older session can name itself.
