### PR TITLE
feat(ui-next): terminals, and the dock that turned out not to exist

### DIFF
--- a/apps/desktop/src/components/AppearanceSettingsSection.test.tsx
+++ b/apps/desktop/src/components/AppearanceSettingsSection.test.tsx
@@ -82,6 +82,15 @@ describe("AppearanceSettingsSection", () => {
     expect(items).toContain("Port forwards");
   });
 
+  it("lists terminals, whose sessions outlive the tab that started them", () => {
+    // `/terminals` is where a shell opened from a resource row lands, and its
+    // sessions keep running after the tab closes. A reader weighing the toggle
+    // is weighing whether they can get a shell at all.
+    render(<AppearanceSettingsSection />);
+    const items = screen.getAllByRole("listitem").map((li) => li.textContent);
+    expect(items).toContain("Terminals");
+  });
+
   it("lists the toolbox, the only screen that is about the machine and not a cluster", () => {
     // The managed kubectl, helm and krew under ~/.srelens/bin, plus what a
     // context's exec-auth needs. Nothing about it is cluster-scoped, so a

--- a/apps/desktop/src/design.test.ts
+++ b/apps/desktop/src/design.test.ts
@@ -63,6 +63,7 @@ describe("the list of ported screens", () => {
       "/overview",
       "/logs",
       "/forwards",
+      "/terminals",
       "/toolbox",
     ]);
   });
@@ -77,6 +78,7 @@ describe("the list of ported screens", () => {
       "Cluster overview",
       "Logs",
       "Port forwards",
+      "Terminals",
       "Toolbox",
     ]);
   });

--- a/apps/desktop/src/design.ts
+++ b/apps/desktop/src/design.ts
@@ -220,6 +220,10 @@ export const PORTED_SCREENS: ReadonlyArray<{ route: string; name: string }> = [
   // already running are seen and stopped — not a view of a cluster's state but
   // of this process's own.
   { route: "/forwards", name: "Port forwards" },
+  // The session rail and the live shell one of them is. Listed after forwards
+  // because it shares their shape — a session outlives the tab that started
+  // it, so this screen is where the ones already running are seen and ended.
+  { route: "/terminals", name: "Terminals" },
   // The only screen here that is about the machine rather than a cluster: the
   // managed kubectl, helm and krew under ~/.srelens/bin, and what the active
   // context's exec-auth needs on PATH.

--- a/crates/kube/src/exec.rs
+++ b/crates/kube/src/exec.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use k8s_openapi::api::core::v1::Pod;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::Status;
 use kube::api::{AttachParams, TerminalSize};
 use kube::Api;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -70,6 +71,32 @@ async fn wait_for_running(
     }
 }
 
+/// The exec protocol's status channel, read as an error or as nothing.
+///
+/// A container without the shell we asked for still *opens* the connection —
+/// the API call succeeds, the command fails inside the container, and stdout
+/// closes at once. Only this channel distinguishes that from a reader typing
+/// `exit`, so it is the sole place a dead shell can be named.
+///
+/// Silent unless the cluster said `Failure`: a clean exit is not an error, and
+/// a status that never arrived (older server, connection dropped during
+/// teardown) is an absence of evidence rather than evidence of a failure.
+/// The wording returned is the cluster's own, unwrapped, because the frontend
+/// classifies the sentence and a prefix of ours would hide it.
+pub fn status_error(status: Option<&Status>) -> Option<String> {
+    let status = status?;
+    if !status.status.as_deref().is_some_and(|s| s.eq_ignore_ascii_case("Failure")) {
+        return None;
+    }
+    let said = |field: &Option<String>| field.as_deref().filter(|s| !s.is_empty()).map(str::to_string);
+    // A failure the cluster worded poorly is still a failure, so fall through
+    // its own words before settling for ours — going silent here would restore
+    // the blank pane this exists to prevent.
+    said(&status.message)
+        .or_else(|| said(&status.reason))
+        .or_else(|| Some("exec: command failed".to_string()))
+}
+
 /// Open an interactive exec session. `on_output` receives stdout chunks
 /// (lossy UTF-8); `input_rx` yields stdin keystrokes. Runs until either side
 /// closes or the task is aborted.
@@ -126,6 +153,11 @@ where
         let _ = tx.try_send(terminal_size(cols, rows));
     }
 
+    // Taken before the loop because `join()` below drops the receiver: the
+    // status frame arrives as the remote command ends, and awaiting it after
+    // the join is what turns a shell that never started into a reason.
+    let status = attached.take_status();
+
     let mut stdout = attached.stdout().ok_or_else(|| "exec: no stdout".to_string())?;
     let mut stdin = attached.stdin().ok_or_else(|| "exec: no stdin".to_string())?;
     let mut buf = vec![0u8; 8192];
@@ -162,8 +194,18 @@ where
         }
     }
 
+    // Join first: it drops the streams the background task may still be
+    // writing to, so the task can finish and post its status. Awaiting the
+    // status before that would deadlock against a full stdout buffer.
     let _ = attached.join().await;
-    Ok(())
+    let status = match status {
+        Some(status) => status.await,
+        None => None,
+    };
+    match status_error(status.as_ref()) {
+        Some(reason) => Err(reason),
+        None => Ok(()),
+    }
 }
 
 #[cfg(test)]
@@ -210,5 +252,60 @@ mod tests {
         assert!(!container_running(&waiting, Some("app")));
 
         assert!(!container_running(&pod_with(serde_json::json!({})), None));
+    }
+
+    fn status_with(json: serde_json::Value) -> Status {
+        serde_json::from_value(json).unwrap()
+    }
+
+    #[test]
+    fn status_error_reports_the_clusters_own_sentence_on_failure() {
+        // The coredns case: no /bin/sh in the image. The exec API call itself
+        // succeeded, so only this channel says why the shell never started.
+        let status = status_with(serde_json::json!({
+            "status": "Failure",
+            "message": "command terminated with exit code 126",
+            "reason": "NonZeroExitCode",
+        }));
+        // Verbatim: `describeError` on the frontend classifies this wording,
+        // so a prefix here would hide the sentence it needs to read.
+        assert_eq!(
+            status_error(Some(&status)).as_deref(),
+            Some("command terminated with exit code 126")
+        );
+    }
+
+    #[test]
+    fn status_error_stays_silent_on_a_clean_exit() {
+        // A reader who typed `exit` has not hit an error, and an alert on the
+        // commonest possible action would be pure noise.
+        let status = status_with(serde_json::json!({ "status": "Success" }));
+        assert_eq!(status_error(Some(&status)), None);
+    }
+
+    #[test]
+    fn status_error_treats_a_missing_status_as_no_evidence() {
+        // An older server, or a connection dropped mid-teardown, yields nothing
+        // on the channel. An absence is not a failure — same rule that makes a
+        // missing metric read "no reading" rather than zero.
+        assert_eq!(status_error(None), None);
+        // Likewise a status object that never says which way it went.
+        let unsaid = status_with(serde_json::json!({ "message": "" }));
+        assert_eq!(status_error(Some(&unsaid)), None);
+    }
+
+    #[test]
+    fn status_error_falls_back_to_the_reason_when_the_message_is_empty() {
+        // A failure the cluster worded poorly is still a failure; reporting it
+        // silently would put us right back to the blank pane. `reason` is still
+        // the cluster's own word, so prefer it before anything we invent.
+        let no_message = status_with(serde_json::json!({
+            "status": "Failure",
+            "reason": "InternalError",
+        }));
+        assert_eq!(status_error(Some(&no_message)).as_deref(), Some("InternalError"));
+
+        let wordless = status_with(serde_json::json!({ "status": "Failure" }));
+        assert_eq!(status_error(Some(&wordless)).as_deref(), Some("exec: command failed"));
     }
 }

--- a/crates/server/src/users.rs
+++ b/crates/server/src/users.rs
@@ -255,6 +255,8 @@ mod tests {
     use crate::db::Db;
     use serde_json::json;
     use srelens_capability::Capability;
+    use srelens_streams::exec::ExecOpts;
+    use srelens_streams::test_util::TestSink;
 
     fn factory() -> RegistryFactory {
         Arc::new(|_cache, paths: Vec<PathBuf>| {
@@ -479,6 +481,138 @@ mod tests {
         // Teardown was skipped: the env is still cached as the same Arc.
         let env_again = envs.env_for(&db, &k, user.id).await.unwrap();
         assert!(Arc::ptr_eq(&env, &env_again));
+
+        let _ = std::fs::remove_dir_all(&data_dir);
+    }
+
+    /// A user's live exec session, so a teardown test has something real to
+    /// close rather than passing against an empty manager by accident.
+    async fn start_test_exec_session(env: &UserEnv) {
+        env.streams
+            .exec
+            .start(
+                Arc::new(TestSink::default()),
+                "nope".into(),
+                "ns".into(),
+                "pod-a".into(),
+                ExecOpts::default(),
+            )
+            .await
+            .expect("exec session allocates an id even against an empty client cache");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn last_connection_dropping_closes_the_users_exec_sessions() {
+        let db = Db::open_in_memory().await.unwrap();
+        let k = key();
+        let data_dir = test_data_dir();
+        let user = db.upsert_user("i", "u", "", "", 1).await.unwrap();
+        db.put_kubeconfig(user.id, "kc", &k, "apiVersion: v1", 1)
+            .await
+            .unwrap();
+
+        let envs = Arc::new(UserEnvs::new(factory(), data_dir.clone(), "http://127.0.0.1:8080".into()));
+        let hub = Arc::new(crate::ws::hub::WsHub::new());
+
+        let env = envs.env_for(&db, &k, user.id).await.unwrap();
+        start_test_exec_session(&env).await;
+
+        // A Weak that fails to upgrade proves the last strong ref to the
+        // user's stream bundle was dropped, which is what runs
+        // `UserStreams::drop` -> `exec.shutdown_all()` and actually ends the
+        // pod exec sessions (not just the materialized kubeconfig files).
+        let streams_weak = Arc::downgrade(&env.streams);
+        drop(env);
+
+        assert_eq!(hub.user_connection_count(user.id), 0);
+        teardown_streams_if_disconnected(hub.clone(), envs.clone(), user.id, Duration::ZERO).await;
+
+        assert!(
+            streams_weak.upgrade().is_none(),
+            "last connection gone must close the user's exec sessions"
+        );
+
+        let _ = std::fs::remove_dir_all(&data_dir);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_second_live_connection_keeps_the_users_exec_sessions() {
+        let db = Db::open_in_memory().await.unwrap();
+        let k = key();
+        let data_dir = test_data_dir();
+        let user = db.upsert_user("i", "u", "", "", 1).await.unwrap();
+        db.put_kubeconfig(user.id, "kc", &k, "apiVersion: v1", 1)
+            .await
+            .unwrap();
+
+        let envs = Arc::new(UserEnvs::new(factory(), data_dir.clone(), "http://127.0.0.1:8080".into()));
+        let hub = Arc::new(crate::ws::hub::WsHub::new());
+
+        // Two tabs: register both, then only one drops.
+        let (_tab_a, _rx_a) = hub.register(user.id);
+        let (_tab_b, _rx_b) = hub.register(user.id);
+
+        let env = envs.env_for(&db, &k, user.id).await.unwrap();
+        start_test_exec_session(&env).await;
+        let streams_weak = Arc::downgrade(&env.streams);
+        drop(env);
+
+        // One tab's disconnect handler runs; the other tab is still live, so
+        // this must NOT be treated as the user's last connection.
+        assert_eq!(hub.user_connection_count(user.id), 2);
+        teardown_streams_if_disconnected(hub.clone(), envs.clone(), user.id, Duration::ZERO).await;
+
+        assert!(
+            streams_weak.upgrade().is_some(),
+            "a second live connection must keep the user's exec sessions"
+        );
+
+        let _ = std::fs::remove_dir_all(&data_dir);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn one_users_disconnect_does_not_touch_anothers_exec_sessions() {
+        let db = Db::open_in_memory().await.unwrap();
+        let k = key();
+        let data_dir = test_data_dir();
+        let alice = db.upsert_user("i", "alice", "", "", 1).await.unwrap();
+        let bob = db.upsert_user("i", "bob", "", "", 1).await.unwrap();
+        db.put_kubeconfig(alice.id, "a", &k, "apiVersion: v1", 1)
+            .await
+            .unwrap();
+        db.put_kubeconfig(bob.id, "b", &k, "apiVersion: v1", 1)
+            .await
+            .unwrap();
+
+        let envs = Arc::new(UserEnvs::new(factory(), data_dir.clone(), "http://127.0.0.1:8080".into()));
+        let hub = Arc::new(crate::ws::hub::WsHub::new());
+
+        // Bob is still connected; Alice is not.
+        let (_bob_conn, _rx) = hub.register(bob.id);
+
+        let alice_env = envs.env_for(&db, &k, alice.id).await.unwrap();
+        start_test_exec_session(&alice_env).await;
+        let alice_weak = Arc::downgrade(&alice_env.streams);
+        drop(alice_env);
+
+        let bob_env = envs.env_for(&db, &k, bob.id).await.unwrap();
+        start_test_exec_session(&bob_env).await;
+        let bob_weak = Arc::downgrade(&bob_env.streams);
+
+        // Only Alice's disconnect handler runs.
+        assert_eq!(hub.user_connection_count(alice.id), 0);
+        teardown_streams_if_disconnected(hub.clone(), envs.clone(), alice.id, Duration::ZERO).await;
+
+        assert!(
+            alice_weak.upgrade().is_none(),
+            "alice's last connection gone must close her exec sessions"
+        );
+        assert!(
+            bob_weak.upgrade().is_some(),
+            "alice's disconnect must not touch bob's exec sessions"
+        );
+        let bob_env_again = envs.env_for(&db, &k, bob.id).await.unwrap();
+        assert!(Arc::ptr_eq(&bob_env, &bob_env_again));
 
         let _ = std::fs::remove_dir_all(&data_dir);
     }

--- a/packages/ui-next/package.json
+++ b/packages/ui-next/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@srelens/core": "workspace:*",
     "@srelens/ui-kit": "workspace:*",
+    "@xterm/xterm": "^5.5.0",
     "lucide-react": "^1.22.0"
   },
   "peerDependencies": {

--- a/packages/ui-next/package.json
+++ b/packages/ui-next/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@srelens/core": "workspace:*",
     "@srelens/ui-kit": "workspace:*",
+    "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",
     "lucide-react": "^1.22.0"
   },

--- a/packages/ui-next/src/lib/routes.test.ts
+++ b/packages/ui-next/src/lib/routes.test.ts
@@ -1,4 +1,7 @@
-// @vitest-environment node
+// jsdom, not node: this module's graph reaches the Terminals screen through
+// `screenFor`, and `@xterm/addon-fit` is a UMD bundle that reads `self` while
+// it evaluates. A route table that can name every screen necessarily imports
+// browser-only code, so the environment has to be one.
 import { describe as suite, it, expect } from "vitest";
 import { describe, isBuiltInKind, screenFor } from "./routes";
 import { AppLog } from "../screens/AppLog";
@@ -8,6 +11,7 @@ import { Overview } from "../screens/Overview";
 import { Forwards } from "../screens/Forwards";
 import { Logs, logsRoute } from "../screens/Logs";
 import { ResourceDetailScreen, Resources } from "../screens/Resources";
+import { Terminals } from "../screens/Terminals";
 import { Toolbox } from "../screens/Toolbox";
 import { Workloads } from "../screens/Workloads";
 
@@ -76,9 +80,10 @@ suite("describe", () => {
     // Same prefix as the bare resource route, so without a distinct title and
     // kind for each suffix, opening a pod three ways (Open in new tab, Follow
     // logs, Open shell) produced three indistinguishable tabs in the strip.
-    // Only `shell` is still minted by the row menu; the other two are shapes a
-    // session persisted before Logs and Port forward got real front doors, and
-    // a restored tab still has to be able to name itself.
+    // NONE of the three is minted any more: Logs and Port forward got real
+    // front doors, and `Open shell` now starts a session and opens
+    // `/terminals` on it. All three survive here only so a tab a previous
+    // session persisted can still name itself in the strip.
     expect(describe("/resources/web-1/logs", "c")).toMatchObject({ title: "web-1 · logs", kind: "logs", sub: "c" });
     expect(describe("/resources/web-1/shell", "c")).toMatchObject({
       title: "web-1 · shell",
@@ -171,6 +176,13 @@ suite("screenFor", () => {
     expect(screenFor("/forwards")).toBe(Forwards);
   });
 
+  it("resolves /terminals to the terminals screen", () => {
+    // The row menu's `Open shell` starts a session and then opens this route.
+    // Without an entry here it landed the reader on the Placeholder with a
+    // live PTY running behind it and nothing on screen to attach to.
+    expect(screenFor("/terminals")).toBe(Terminals);
+  });
+
   it("resolves /toolbox to the toolbox screen", () => {
     // App-scoped, not cluster-scoped: the managed tools are the machine's,
     // not any one cluster's.
@@ -190,11 +202,12 @@ suite("screenFor", () => {
   });
 
   it("leaves the row menu's older /resources/<name>/logs shape on the Placeholder", () => {
-    // `ResourceMenu.tsx` still mints this shape, and it carries neither a kind
-    // nor a namespace — so it cannot resolve a subject and must NOT be routed
-    // to Logs, which would strand the reader on an unresolvable stream instead
-    // of the Placeholder that says the screen is not wired up. Reconciling the
-    // two shapes is its own step; this pins the dead end as a known one.
+    // NOTHING MINTS THIS ANY MORE either — `Follow logs` opens `logsRoute`.
+    // The shape carries neither a kind nor a namespace, so it cannot resolve a
+    // subject and must NOT be routed to Logs, which would strand the reader on
+    // an unresolvable stream instead of the Placeholder. A tab persisted by an
+    // older session is the only way to arrive here; this pins the dead end as
+    // a known one.
     expect(screenFor("/resources/web-1/logs")).toBeNull();
   });
 

--- a/packages/ui-next/src/lib/routes.ts
+++ b/packages/ui-next/src/lib/routes.ts
@@ -8,6 +8,7 @@ import { Logs, parseLogsRoute } from "../screens/Logs";
 import { Overview } from "../screens/Overview";
 import { ReleaseNotes } from "../screens/ReleaseNotes";
 import { ResourceDetailScreen, Resources } from "../screens/Resources";
+import { Terminals } from "../screens/Terminals";
 import { Toolbox } from "../screens/Toolbox";
 import { Workloads } from "../screens/Workloads";
 
@@ -88,10 +89,11 @@ export function describe(route: string, clusterName?: string): RouteInfo {
     // ("Open in new tab", "Follow logs", "Open shell") got three tabs with the
     // identical title and kind, indistinguishable in the strip.
     //
-    // Only `shell` is still minted (`ResourceMenu.tsx`). Logs and Port forward
-    // have real front doors now — `logsRoute` and §A.4's dialog — and the
-    // other two shapes survive here only so a tab a previous session
-    // persisted can still name itself in the strip.
+    // None of the three is minted any more. Logs and Port forward have real
+    // front doors — `logsRoute` and §A.4's dialog — and `Open shell` starts a
+    // session and opens `/terminals` on it, so all three shapes survive here
+    // only so a tab a previous session persisted can still name itself in the
+    // strip.
     if (suffix === "logs") return { route, title: `${name} · logs`, sub, kind: "logs" };
     if (suffix === "shell") return { route, title: `${name} · shell`, sub, kind: "terminal" };
     if (suffix === "forward") return { route, title: `${name} · forward`, sub, kind: "forwards" };
@@ -147,6 +149,14 @@ const SCREENS: Record<string, ScreenComponent> = Object.assign(Object.create(nul
   // process holds — the store behind it is module-level and does not partition
   // by context, and a forward outlives the tab that started it.
   "/forwards": Forwards,
+  // Cluster-scoped in the strip for the same reason as `/forwards` and with
+  // the same caveat: the store behind it is module-level, a session outlives
+  // the tab that opened it, and the rail lists every one this process holds.
+  // The route is reached from the strip, from the status bar's live-session
+  // count, and from the resource row menu's `Open shell` — which starts the
+  // session first and opens this tab on it, so without this entry that action
+  // left a live PTY running behind a Placeholder.
+  "/terminals": Terminals,
   // App-scoped: the managed kubectl, helm and krew are the machine's, and the
   // exec-auth rail is the only part of it that looks at a context at all.
   "/toolbox": Toolbox,

--- a/packages/ui-next/src/lib/sessions.test.ts
+++ b/packages/ui-next/src/lib/sessions.test.ts
@@ -3,6 +3,8 @@ import type { Terminal } from "@xterm/xterm";
 
 const startPodExec = vi.fn();
 const startLocalTerminal = vi.fn();
+const deletePod = vi.fn();
+const notifyError = vi.fn();
 
 vi.mock("@srelens/core", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@srelens/core")>();
@@ -10,6 +12,8 @@ vi.mock("@srelens/core", async (importOriginal) => {
     ...actual,
     startPodExec: (...args: unknown[]) => startPodExec(...args),
     startLocalTerminal: (...args: unknown[]) => startLocalTerminal(...args),
+    deletePod: (...args: unknown[]) => deletePod(...args),
+    notify: { ...actual.notify, error: notifyError },
   };
 });
 
@@ -96,9 +100,20 @@ const pod = {
   container: "api",
 };
 
+const nodeDebugPod = {
+  context: "kind-srelens-demo",
+  namespace: "srelens-debug",
+  pod: "srelens-node-debug-x1",
+  container: "debug",
+  kind: "node" as const,
+};
+
 beforeEach(() => {
   startPodExec.mockReset();
   startLocalTerminal.mockReset();
+  deletePod.mockReset();
+  deletePod.mockResolvedValue({ deleted: true });
+  notifyError.mockReset();
   __resetSessionsForTests();
 });
 
@@ -358,6 +373,76 @@ describe("the session store", () => {
     vi.advanceTimersByTime(SESSION_IDLE_AFTER_MS * 2);
 
     expect(getSessions()[0].state).toBe("closed");
+  });
+});
+
+describe("a node session's debug pod", () => {
+  it("deletes the debug pod when the session ends", async () => {
+    fakeBackend();
+    const id = await startPodSession(nodeDebugPod);
+
+    endSession(id);
+
+    await vi.waitFor(() => {
+      expect(deletePod).toHaveBeenCalledWith(
+        "kind-srelens-demo",
+        "srelens-debug",
+        "srelens-node-debug-x1",
+      );
+    });
+  });
+
+  it("deletes nothing when an ordinary pod session ends", async () => {
+    fakeBackend();
+    const id = await startPodSession(pod);
+
+    endSession(id);
+    // Give any stray async cleanup a turn before asserting the negative.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(deletePod).not.toHaveBeenCalled();
+  });
+
+  it("deletes nothing when a local session ends", async () => {
+    fakeBackend();
+    const id = await startLocalSession({ context: "kind-srelens-demo" });
+
+    endSession(id);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(deletePod).not.toHaveBeenCalled();
+  });
+
+  it("deletes the debug pod once, even though endSession is called twice", async () => {
+    fakeBackend();
+    const id = await startPodSession(nodeDebugPod);
+
+    endSession(id);
+    endSession(id);
+
+    await vi.waitFor(() => expect(deletePod).toHaveBeenCalledTimes(1));
+    // Hold the assertion past the first resolution, so a second delete fired
+    // a tick later would still be caught.
+    await Promise.resolve();
+    expect(deletePod).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a failed delete through describeError, without stranding the row", async () => {
+    deletePod.mockResolvedValue({ error: 'handler error: pods "srelens-node-debug-x1" not found' });
+    fakeBackend();
+    const id = await startPodSession(nodeDebugPod);
+
+    endSession(id);
+
+    // The row is gone immediately — ending a session is the reader's own act
+    // and does not wait on cleanup to complete.
+    expect(getSessions()).toEqual([]);
+    await vi.waitFor(() => expect(notifyError).toHaveBeenCalled());
+    const [, detail] = notifyError.mock.calls[0] as [string, string];
+    expect(detail).not.toContain("handler error:");
+    expect(detail).toContain("not found");
   });
 });
 

--- a/packages/ui-next/src/lib/sessions.test.ts
+++ b/packages/ui-next/src/lib/sessions.test.ts
@@ -1,0 +1,464 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Terminal } from "@xterm/xterm";
+
+const startPodExec = vi.fn();
+const startLocalTerminal = vi.fn();
+
+vi.mock("@srelens/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@srelens/core")>();
+  return {
+    ...actual,
+    startPodExec: (...args: unknown[]) => startPodExec(...args),
+    startLocalTerminal: (...args: unknown[]) => startLocalTerminal(...args),
+  };
+});
+
+// Imported after the mock so the store binds the doubles rather than the real
+// Tauri-backed session openers.
+const {
+  SESSION_IDLE_AFTER_MS,
+  __resetSessionsForTests,
+  endSession,
+  getSessions,
+  startLocalSession,
+  startPodSession,
+  subscribeSessions,
+  terminalFor,
+} = await import("./sessions");
+
+/**
+ * A `startPodExec`/`startLocalTerminal` double. The test drives the backend
+ * side through `out`/`exit`, and asserts on the handle the store was given.
+ */
+function fakeBackend() {
+  let onData!: (chunk: string) => void;
+  let onExit!: (error: string | null) => void;
+  const handle = { send: vi.fn(), resize: vi.fn(), close: vi.fn() };
+  const capture = (data: (c: string) => void, exit: (e: string | null) => void) => {
+    onData = data;
+    onExit = exit;
+    return Promise.resolve(handle);
+  };
+  startPodExec.mockImplementation(
+    (
+      _context: string,
+      _namespace: string,
+      _pod: string,
+      data: (c: string) => void,
+      exit: (e: string | null) => void,
+    ) => capture(data, exit),
+  );
+  startLocalTerminal.mockImplementation(
+    (
+      _context: string,
+      _extra: string[],
+      data: (c: string) => void,
+      exit: () => void,
+    ) => capture(data, () => exit()),
+  );
+  return {
+    handle,
+    out: (chunk: string) => onData(chunk),
+    exit: (error: string | null = null) => onExit(error),
+  };
+}
+
+/** The same double, but the test decides when the backend finishes opening —
+ *  the window in which a session exists but has no far end yet. */
+function deferredBackend() {
+  let onData!: (chunk: string) => void;
+  const handle = { send: vi.fn(), resize: vi.fn(), close: vi.fn() };
+  let open!: () => void;
+  const opened = new Promise<typeof handle>((resolve) => {
+    open = () => resolve(handle);
+  });
+  startPodExec.mockImplementation(
+    (_c: string, _n: string, _p: string, data: (c: string) => void) => {
+      onData = data;
+      return opened;
+    },
+  );
+  return { handle, out: (chunk: string) => onData(chunk), open: () => open() };
+}
+
+/** What the emulator has actually rendered, top line first. */
+function screenOf(term: Terminal | undefined, lines = 1): string[] {
+  const buffer = term?.buffer.active;
+  return Array.from({ length: lines }, (_, i) =>
+    (buffer?.getLine(i)?.translateToString(true) ?? "").trimEnd(),
+  );
+}
+
+const pod = {
+  context: "kind-srelens-demo",
+  namespace: "shop",
+  pod: "checkout-api-5c8b7f2d9-mk3wl",
+  container: "api",
+};
+
+beforeEach(() => {
+  startPodExec.mockReset();
+  startLocalTerminal.mockReset();
+  __resetSessionsForTests();
+});
+
+afterEach(() => {
+  __resetSessionsForTests();
+  vi.useRealTimers();
+});
+
+describe("the session store", () => {
+  it("lists a session it started, with the pod and container in its title", async () => {
+    fakeBackend();
+    const id = await startPodSession(pod);
+
+    expect(getSessions()).toHaveLength(1);
+    const row = getSessions()[0];
+    expect(row.id).toBe(id);
+    expect(row.kind).toBe("pod");
+    expect(row.title).toBe("checkout-api-5c8b7f2d9-mk3wl · api");
+    expect(row.context).toBe("kind-srelens-demo");
+    expect(row.namespace).toBe("shop");
+    expect(row.state).toBe("attached");
+    expect(row.error).toBeUndefined();
+    expect(row.startedAt).toBeGreaterThan(0);
+  });
+
+  it("starts a local shell with no namespace of its own", async () => {
+    fakeBackend();
+    const id = await startLocalSession({ context: "kind-srelens-demo" });
+
+    const row = getSessions()[0];
+    expect(row.id).toBe(id);
+    expect(row.kind).toBe("local");
+    expect(row.namespace).toBe("");
+    expect(row.state).toBe("attached");
+  });
+
+  it("hands out the same emulator every time it is asked", async () => {
+    fakeBackend();
+    const id = await startPodSession(pod);
+
+    const first = terminalFor(id);
+    const second = terminalFor(id);
+    expect(first).toBeDefined();
+    // Identity, not equality: a store that built a fresh Terminal per call
+    // would satisfy any structural check and still lose the scrollback.
+    expect(second).toBe(first);
+  });
+
+  it("has no emulator for an id it never started", () => {
+    expect(terminalFor(404)).toBeUndefined();
+  });
+
+  it("writes the backend's output into that session's emulator", async () => {
+    const backend = fakeBackend();
+    const id = await startPodSession(pod);
+
+    backend.out("total 4\r\ndrwxr-xr-x  app\r\n");
+
+    await vi.waitFor(() => {
+      expect(screenOf(terminalFor(id), 2)).toEqual(["total 4", "drwxr-xr-x  app"]);
+    });
+  });
+
+  it("keeps each session's output in its own emulator", async () => {
+    const first = fakeBackend();
+    const idA = await startPodSession(pod);
+    const second = fakeBackend();
+    const idB = await startPodSession({ ...pod, pod: "web-7" });
+
+    first.out("from A\r\n");
+    second.out("from B\r\n");
+
+    await vi.waitFor(() => {
+      expect(screenOf(terminalFor(idA))).toEqual(["from A"]);
+      expect(screenOf(terminalFor(idB))).toEqual(["from B"]);
+    });
+  });
+
+  it("sends what the reader types in the emulator to the session", async () => {
+    const backend = fakeBackend();
+    const id = await startPodSession(pod);
+
+    terminalFor(id)?.input("ls\r");
+
+    expect(backend.handle.send).toHaveBeenCalledWith("ls\r");
+  });
+
+  it("tells the PTY when the emulator is resized", async () => {
+    const backend = fakeBackend();
+    const id = await startPodSession(pod);
+
+    terminalFor(id)?.resize(142, 44);
+
+    expect(backend.handle.resize).toHaveBeenCalledWith(142, 44);
+  });
+
+  it("opens the PTY at the emulator's own size", async () => {
+    const backend = fakeBackend();
+    const id = await startPodSession(pod);
+
+    const term = terminalFor(id);
+    expect(startPodExec).toHaveBeenCalledWith(
+      "kind-srelens-demo",
+      "shop",
+      "checkout-api-5c8b7f2d9-mk3wl",
+      expect.any(Function),
+      expect.any(Function),
+      "api",
+      undefined,
+      { cols: term?.cols, rows: term?.rows },
+    );
+    expect(backend.handle.close).not.toHaveBeenCalled();
+  });
+
+  it("keeps a session that ended listed as closed, carrying why", async () => {
+    const backend = fakeBackend();
+    const id = await startPodSession(pod);
+
+    backend.exit("handler error: container api is not running");
+
+    expect(getSessions()).toHaveLength(1);
+    const row = getSessions()[0];
+    expect(row.id).toBe(id);
+    expect(row.state).toBe("closed");
+    // Through describeError: the reader never sees the handler prefix.
+    expect(row.error).not.toContain("handler error:");
+    expect(row.error).toContain("container api is not running");
+  });
+
+  it("keeps the scrollback of a session that ended", async () => {
+    const backend = fakeBackend();
+    const id = await startPodSession(pod);
+
+    backend.out("last words\r\n");
+    await vi.waitFor(() => expect(screenOf(terminalFor(id))).toEqual(["last words"]));
+    backend.exit("gone");
+
+    expect(getSessions()[0].state).toBe("closed");
+    expect(screenOf(terminalFor(id))).toEqual(["last words"]);
+  });
+
+  it("closes cleanly with no reason when the shell simply exited", async () => {
+    const backend = fakeBackend();
+    await startPodSession(pod);
+
+    backend.exit(null);
+
+    expect(getSessions()[0].state).toBe("closed");
+    expect(getSessions()[0].error).toBeUndefined();
+  });
+
+  it("leaves a closed row behind when the session could not be started", async () => {
+    startPodExec.mockRejectedValue(new Error("handler error: pods is forbidden"));
+
+    const id = await startPodSession(pod);
+
+    const row = getSessions()[0];
+    expect(row.id).toBe(id);
+    expect(row.state).toBe("closed");
+    // Through describeError: neither the handler prefix nor the apiserver's
+    // own word for it survives to the reader.
+    expect(row.error).not.toContain("handler error:");
+    expect(row.error).not.toContain("forbidden");
+    expect(row.error).toContain("permission");
+  });
+
+  it("has an emulator ready before the backend has finished opening", async () => {
+    const backend = deferredBackend();
+    const started = startPodSession(pod);
+
+    // The row and its emulator exist while the connect is still in flight, so
+    // the first prompt has somewhere to land.
+    const id = getSessions()[0].id;
+    backend.out("first prompt\r\n");
+    backend.open();
+    await started;
+
+    await vi.waitFor(() => expect(screenOf(terminalFor(id))).toEqual(["first prompt"]));
+  });
+
+  it("closes a session the reader ended while it was still opening", async () => {
+    const backend = deferredBackend();
+    const started = startPodSession(pod);
+    const id = getSessions()[0].id;
+
+    endSession(id);
+    backend.open();
+    await started;
+
+    // The PTY the backend went on to open has no row left to belong to; it is
+    // closed rather than left running with nothing pointing at it.
+    expect(backend.handle.close).toHaveBeenCalledTimes(1);
+    expect(getSessions()).toEqual([]);
+  });
+
+  it("removes a session the reader ended, and disposes its emulator", async () => {
+    const backend = fakeBackend();
+    const id = await startPodSession(pod);
+    const term = terminalFor(id);
+    // Our own listener, not the store's: unwiring the store's would silence
+    // its own handler and leave this one firing, so only a real dispose can
+    // make the emulator inert here.
+    const typed: string[] = [];
+    term?.onData((d) => typed.push(d));
+
+    endSession(id);
+
+    expect(getSessions()).toEqual([]);
+    expect(backend.handle.close).toHaveBeenCalledTimes(1);
+    expect(terminalFor(id)).toBeUndefined();
+    term?.input("x");
+    expect(typed).toEqual([]);
+  });
+
+  it("ends a session only once, however often the reader asks", async () => {
+    const backend = fakeBackend();
+    const id = await startPodSession(pod);
+
+    endSession(id);
+    endSession(id);
+
+    expect(backend.handle.close).toHaveBeenCalledTimes(1);
+    expect(getSessions()).toEqual([]);
+  });
+
+  it("removes a closed row when the reader dismisses it", async () => {
+    const backend = fakeBackend();
+    const id = await startPodSession(pod);
+    backend.exit("gone");
+
+    endSession(id);
+
+    expect(getSessions()).toEqual([]);
+    expect(terminalFor(id)).toBeUndefined();
+  });
+
+  it("reports a session that goes idle, and again when it speaks", async () => {
+    vi.useFakeTimers({ now: new Date("2026-08-25T10:00:00.000Z") });
+    const backend = fakeBackend();
+    const id = await startPodSession(pod);
+
+    vi.advanceTimersByTime(SESSION_IDLE_AFTER_MS);
+    expect(getSessions()[0].state).toBe("idle");
+
+    backend.out("$ ");
+    expect(getSessions()[0].state).toBe("attached");
+    expect(getSessions()[0].lastOutputAt).toBe(Math.floor(Date.now() / 1000) * 1000);
+    expect(terminalFor(id)).toBeDefined();
+  });
+
+  it("does not wake a closed session back up with an idle timer", async () => {
+    vi.useFakeTimers({ now: new Date("2026-08-25T10:00:00.000Z") });
+    const backend = fakeBackend();
+    await startPodSession(pod);
+
+    backend.exit("gone");
+    vi.advanceTimersByTime(SESSION_IDLE_AFTER_MS * 2);
+
+    expect(getSessions()[0].state).toBe("closed");
+  });
+});
+
+describe("the store's snapshot", () => {
+  it("is the same reference until something changes", async () => {
+    fakeBackend();
+    await startPodSession(pod);
+
+    const before = getSessions();
+    expect(getSessions()).toBe(before);
+  });
+
+  it("survives a chatty second of output", async () => {
+    vi.useFakeTimers({ now: new Date("2026-08-25T10:00:00.000Z") });
+    const backend = fakeBackend();
+    await startPodSession(pod);
+    backend.out("line 1\r\n");
+    const before = getSessions();
+    const notified = vi.fn();
+    subscribeSessions(notified);
+
+    // A shell tailing a log: many chunks, spread across real milliseconds,
+    // inside one second. Firing them on a frozen clock would prove nothing —
+    // millisecond stamps would hold their identity too.
+    for (let i = 0; i < 50; i++) {
+      vi.advanceTimersByTime(10);
+      backend.out(`line ${i + 2}\r\n`);
+    }
+    expect(Date.now() - before[0].lastOutputAt).toBeGreaterThan(400);
+
+    expect(getSessions()).toBe(before);
+    expect(notified).not.toHaveBeenCalled();
+  });
+
+  it("re-stamps a running session once the second has turned", async () => {
+    vi.useFakeTimers({ now: new Date("2026-08-25T10:00:00.000Z") });
+    const backend = fakeBackend();
+    await startPodSession(pod);
+    backend.out("line 1\r\n");
+    const before = getSessions();
+    const notified = vi.fn();
+    subscribeSessions(notified);
+
+    vi.advanceTimersByTime(1000);
+    backend.out("line 2\r\n");
+    backend.out("line 3\r\n");
+
+    const after = getSessions();
+    expect(after).not.toBe(before);
+    expect(after[0].lastOutputAt).toBe(before[0].lastOutputAt + 1000);
+    expect(notified).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves an untouched row alone when another session changes", async () => {
+    const first = fakeBackend();
+    await startPodSession(pod);
+    const second = fakeBackend();
+    await startPodSession({ ...pod, pod: "web-7" });
+    const before = getSessions();
+
+    second.exit("gone");
+
+    const after = getSessions();
+    expect(after).not.toBe(before);
+    // The row that did not change keeps its identity, so a rail row that is
+    // not involved does not re-render.
+    expect(after[0]).toBe(before[0]);
+    expect(after[1]).not.toBe(before[1]);
+    expect(after[1].state).toBe("closed");
+    expect(first.handle.close).not.toHaveBeenCalled();
+  });
+
+  it("does not rebuild itself for a closure it has already recorded", async () => {
+    const backend = fakeBackend();
+    await startPodSession(pod);
+    backend.exit("gone");
+    const before = getSessions();
+    const notified = vi.fn();
+    subscribeSessions(notified);
+
+    backend.exit("gone");
+
+    expect(getSessions()).toBe(before);
+    expect(notified).not.toHaveBeenCalled();
+  });
+
+  it("wakes subscribers when a session starts, ends and is removed", async () => {
+    const backend = fakeBackend();
+    const notified = vi.fn();
+    const unsubscribe = subscribeSessions(notified);
+
+    const id = await startPodSession(pod);
+    expect(notified).toHaveBeenCalledTimes(1);
+    backend.exit("gone");
+    expect(notified).toHaveBeenCalledTimes(2);
+    endSession(id);
+    expect(notified).toHaveBeenCalledTimes(3);
+
+    unsubscribe();
+    fakeBackend();
+    await startPodSession(pod);
+    expect(notified).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/ui-next/src/lib/sessions.ts
+++ b/packages/ui-next/src/lib/sessions.ts
@@ -1,6 +1,8 @@
 import { Terminal } from "@xterm/xterm";
 import {
+  deletePod,
   describeError,
+  notify,
   startLocalTerminal,
   startPodExec,
   type TerminalConnection,
@@ -35,8 +37,9 @@ import {
  */
 
 /** What kind of shell a session is. `node` is a pod exec into the privileged
- *  debug pod srelens created for a node — the cleanup that makes it different
- *  is the store's, and lands with Task 2. */
+ *  debug pod srelens created for a node — the store deletes that pod when the
+ *  session ends (see {@link endSession}), which is the cleanup a pod exec and
+ *  a local shell have nothing to do. */
 export type SessionKind = "pod" | "node" | "local";
 
 /**
@@ -125,6 +128,18 @@ const handles = new Map<number, TerminalConnection>();
 /** Everything wired to a session's emulator, unwired when the row goes. */
 const unwires = new Map<number, () => void>();
 const idleTimers = new Map<number, ReturnType<typeof setTimeout>>();
+/**
+ * The privileged debug pod a `kind: "node"` session is exec'd into — the
+ * object `k8s.createNodeDebugPod` left on the cluster, and the store's own to
+ * delete. Absent for a pod exec or a local shell, neither of which created
+ * anything: deleting a pod the reader is merely looking at would be the wrong
+ * kind of cleanup.
+ *
+ * Entries come out the moment {@link endSession} acts on them, which is also
+ * what keeps the delete to once: a second `endSession` on the same id finds
+ * nothing left to clean up.
+ */
+const nodeDebugPods = new Map<number, { context: string; namespace: string; pod: string }>();
 
 /** Ids are the store's own: a pod exec and a local PTY number themselves
  *  independently on the backend, so their ids collide. */
@@ -167,12 +182,20 @@ export function terminalFor(id: number): Terminal | undefined {
  *  `closed` row carrying the reason, because a failure the reader can read is
  *  worth more than one they have to catch. */
 export async function startPodSession(req: PodSessionRequest): Promise<number> {
+  const kind = req.kind ?? "pod";
   const id = register({
-    kind: req.kind ?? "pod",
+    kind,
     title: req.title ?? titleOf(req.pod, req.container),
     context: req.context,
     namespace: req.namespace,
   });
+  // `req.pod` for a node session IS the debug pod: `k8s.createNodeDebugPod`
+  // made it, this exec runs `nsenter` inside it, and nothing else knows its
+  // name. Recorded before the connect, same as the row itself, so a session
+  // the reader ends while it is still opening (see `connect`) still cleans up.
+  if (kind === "node") {
+    nodeDebugPods.set(id, { context: req.context, namespace: req.namespace, pod: req.pod });
+  }
   await connect(id, (onData, onExit, size) =>
     startPodExec(
       req.context,
@@ -218,13 +241,37 @@ export function endSession(id: number): void {
   disconnect(id);
   emulators.get(id)?.dispose();
   emulators.delete(id);
+  // Taken out of the map here, synchronously, rather than after the delete
+  // resolves: that is what makes a second `endSession(id)` — the row is
+  // already gone, but nothing stops the reader clicking again — find nothing
+  // left to delete, instead of racing the first delete or firing a second one.
+  const debugPod = nodeDebugPods.get(id);
+  nodeDebugPods.delete(id);
+  if (debugPod) void deleteDebugPod(debugPod);
   commit(sessions.filter((s) => s.id !== id));
+}
+
+/**
+ * Delete the debug pod a finished node session leaves behind.
+ *
+ * The row is already gone by the time this runs — `endSession` does not wait
+ * on it — so a failure has nowhere on screen to land. It goes to `notify`
+ * instead, described rather than raw: the pod may already be gone, or the
+ * reader may lack permission to delete it, and either way `deletePod` itself
+ * never throws, so the row is never left stranded waiting on this.
+ */
+async function deleteDebugPod(target: { context: string; namespace: string; pod: string }): Promise<void> {
+  const out = await deletePod(target.context, target.namespace, target.pod);
+  if (out.error) {
+    notify.error(`Couldn't delete debug pod ${target.pod}`, describeError(out.error).detail);
+  }
 }
 
 /** Reset the module-level store between tests. */
 export function __resetSessionsForTests(): void {
   for (const id of [...emulators.keys()]) endSession(id);
   for (const id of [...handles.keys()]) disconnect(id);
+  nodeDebugPods.clear();
   sessions = [];
   listeners.clear();
   seq = 0;

--- a/packages/ui-next/src/lib/sessions.ts
+++ b/packages/ui-next/src/lib/sessions.ts
@@ -1,0 +1,412 @@
+import { Terminal } from "@xterm/xterm";
+import {
+  describeError,
+  startLocalTerminal,
+  startPodExec,
+  type TerminalConnection,
+} from "@srelens/core";
+
+/**
+ * The terminal sessions this window is running — what is live, the emulator
+ * each one is writing into, and the cleanup each one owes.
+ *
+ * **Why this store is in `ui-next` and not in core**, where port-forwards keep
+ * theirs: it holds the xterm instance. An emulator created by the pane would
+ * die with the pane, and a reader who closed the Terminals tab and came back
+ * would find an attached shell with no scrollback — a shell whose last command
+ * it cannot show them. Sessions outliving the screen means nothing unless the
+ * transcript outlives it too. core holds no DOM (`no-react.test.ts` walks its
+ * import graph), so the owner has to live here, next to the emulator, holding
+ * core's session handle beside it.
+ *
+ * **The whole data path is wired here.** The store writes the backend's output
+ * into the emulator, and wires the emulator's input and resize back to the PTY.
+ * A component that attaches the emulator to the DOM therefore does not have to
+ * hold a session handle at all — {@link terminalFor} is the only thing it
+ * needs, and an unmount that forgets to unwire something cannot cut a live
+ * shell's keystrokes.
+ *
+ * **`terminalFor` hands out an instance the caller must not dispose.** The
+ * store disposes it, in {@link endSession}, and only there.
+ *
+ * Shaped after `packages/core/src/lib/forward.ts`: module-level state, a
+ * listener set, and a snapshot that keeps its reference until something in it
+ * actually changed, so `useSyncExternalStore` has a stable value to compare.
+ */
+
+/** What kind of shell a session is. `node` is a pod exec into the privileged
+ *  debug pod srelens created for a node — the cleanup that makes it different
+ *  is the store's, and lands with Task 2. */
+export type SessionKind = "pod" | "node" | "local";
+
+/**
+ * A session's live state.
+ *
+ * `attached` and `idle` are both RUNNING — the difference is whether the shell
+ * has said anything lately (see {@link SESSION_IDLE_AFTER_MS}), which is what
+ * the rail's state dot is reporting. Only `closed` means the far end is gone.
+ *
+ * No word or tone for these lives here. core has no verdict for a shell's
+ * state — `k8sStatus`/`k8sHealth` speak about Kubernetes resources and
+ * `logConnectionStatus` about a log stream's connection — and this module
+ * holds state, not vocabulary.
+ */
+export type SessionState = "attached" | "idle" | "closed";
+
+/** One session, as a rail row reads it. */
+export interface TerminalSessionRow {
+  id: number;
+  kind: SessionKind;
+  /** "checkout-api-5c8b7f2d9-mk3wl · api" — the pod and the container it
+   *  attached to, or the local shell's own name. */
+  title: string;
+  context: string;
+  /** Empty for a local shell, which is not in a namespace. */
+  namespace: string;
+  state: SessionState;
+  /**
+   * Why it ended, when it ended badly. Already through `describeError`: a
+   * session's reason is read straight off the row by whatever renders it, so
+   * a raw Rust string turned into a sentence here rather than at each reader.
+   */
+  error?: string;
+  /** Epoch millis when this session was opened. */
+  startedAt: number;
+  /**
+   * Epoch millis of the last output — what the rail's idle time counts from.
+   * Stamped at start, so a shell that has never printed a prompt still ages
+   * from somewhere real.
+   *
+   * Rounded down to the second, and that is load-bearing rather than tidy: a
+   * shell tailing a log emits many chunks a second, and a row rebuilt on each
+   * one would hand `useSyncExternalStore` a new snapshot on every byte. At
+   * second resolution a busy session rebuilds its row once a second — the
+   * same rate the forwards store accepts for its byte counter — and an idle
+   * time measured in seconds loses nothing by it.
+   */
+  lastOutputAt: number;
+}
+
+/** How long a running session must stay quiet before it reads as `idle`.
+ *  A shell with a prompt sitting on it is doing nothing; a shell that printed
+ *  a line a second ago is being used. */
+export const SESSION_IDLE_AFTER_MS = 60_000;
+
+/** What a pod (or node) shell needs to open. */
+export interface PodSessionRequest {
+  context: string;
+  namespace: string;
+  pod: string;
+  /** The container to attach to; the pod's default when omitted. */
+  container?: string;
+  /** Overrides the shell the backend would pick — a node shell's `nsenter`. */
+  command?: string[];
+  /** `node` for a shell that reached a node through a debug pod. */
+  kind?: "pod" | "node";
+  /** Overrides the title the pod and container would compose. */
+  title?: string;
+}
+
+/** What a local shell needs to open. */
+export interface LocalSessionRequest {
+  context: string;
+  /** Extra kubeconfigs to put on the shell's KUBECONFIG. */
+  extraKubeconfigs?: string[];
+  title?: string;
+}
+
+let sessions: TerminalSessionRow[] = [];
+const listeners = new Set<() => void>();
+/** The emulators this store owns, one per session, alive until the reader
+ *  removes the row. */
+const emulators = new Map<number, Terminal>();
+/** The far end of each session, for as long as there is one to talk to. */
+const handles = new Map<number, TerminalConnection>();
+/** Everything wired to a session's emulator, unwired when the row goes. */
+const unwires = new Map<number, () => void>();
+const idleTimers = new Map<number, ReturnType<typeof setTimeout>>();
+
+/** Ids are the store's own: a pod exec and a local PTY number themselves
+ *  independently on the backend, so their ids collide. */
+let seq = 0;
+
+function emit() {
+  for (const listener of listeners) listener();
+}
+
+/** Subscribe to store changes (for `useSyncExternalStore`). */
+export function subscribeSessions(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+/**
+ * Every session this window knows about — running and closed.
+ *
+ * A stable reference until something in it changes: `useSyncExternalStore`
+ * compares snapshots by identity and re-renders forever when handed a fresh
+ * array each read.
+ */
+export function getSessions(): TerminalSessionRow[] {
+  return sessions;
+}
+
+/**
+ * This session's emulator — the live one, with its scrollback.
+ *
+ * **The caller must not dispose it.** It is the store's, it survives the
+ * screen that shows it, and disposing it on unmount undoes the reason this
+ * store exists.
+ */
+export function terminalFor(id: number): Terminal | undefined {
+  return emulators.get(id);
+}
+
+/** Open a shell inside a pod (or, with `kind: "node"`, inside a node's debug
+ *  pod) and track it. Never throws: a session that could not be opened is a
+ *  `closed` row carrying the reason, because a failure the reader can read is
+ *  worth more than one they have to catch. */
+export async function startPodSession(req: PodSessionRequest): Promise<number> {
+  const id = register({
+    kind: req.kind ?? "pod",
+    title: req.title ?? titleOf(req.pod, req.container),
+    context: req.context,
+    namespace: req.namespace,
+  });
+  await connect(id, (onData, onExit, size) =>
+    startPodExec(
+      req.context,
+      req.namespace,
+      req.pod,
+      onData,
+      onExit,
+      req.container,
+      req.command,
+      size,
+    ),
+  );
+  return id;
+}
+
+/** Open a shell on the user's own machine, scoped to a context, and track it.
+ *  Never throws, for the same reason {@link startPodSession} does not. */
+export async function startLocalSession(req: LocalSessionRequest): Promise<number> {
+  const id = register({
+    kind: "local",
+    title: req.title ?? "Local shell",
+    context: req.context,
+    // A local shell is not in a namespace, and saying so with an empty string
+    // is honest where naming the cluster's current one would not be.
+    namespace: "",
+  });
+  await connect(id, (onData, onExit, size) =>
+    startLocalTerminal(req.context, req.extraKubeconfigs ?? [], onData, () => onExit(null), size),
+  );
+  return id;
+}
+
+/**
+ * The reader is done with this session: close the far end, drop the row, and
+ * dispose the emulator.
+ *
+ * The one place a row leaves the screen. A session that ends on its own stays
+ * listed as `closed` with its reason — #349's vanishing port-forward is what
+ * happens otherwise, a reader carrying on as though a dead thing were fine.
+ * Removing it is the reader's own act, and they do not need it reported back.
+ */
+export function endSession(id: number): void {
+  disconnect(id);
+  emulators.get(id)?.dispose();
+  emulators.delete(id);
+  commit(sessions.filter((s) => s.id !== id));
+}
+
+/** Reset the module-level store between tests. */
+export function __resetSessionsForTests(): void {
+  for (const id of [...emulators.keys()]) endSession(id);
+  for (const id of [...handles.keys()]) disconnect(id);
+  sessions = [];
+  listeners.clear();
+  seq = 0;
+}
+
+/** "pod · container", or just the pod when it has only the one. */
+function titleOf(pod: string, container?: string): string {
+  return container ? `${pod} · ${container}` : pod;
+}
+
+/**
+ * Put the row and its emulator in place, before anything is connected.
+ *
+ * Deliberately ahead of the backend call: `startPodExec` resolves only after a
+ * round trip, and output can arrive the moment it does. An emulator built
+ * after the await would be built after the first prompt had nowhere to land.
+ */
+function register(row: Pick<TerminalSessionRow, "kind" | "title" | "context" | "namespace">): number {
+  const id = ++seq;
+  const now = Date.now();
+  const stamp = wholeSecond(now);
+  // No theme and no font here: those are the pane's, and come from tokens
+  // where there is a DOM to read them from. `convertEol` matches the classic
+  // pane — a backend that sends a bare newline still starts the next line at
+  // column zero.
+  emulators.set(id, new Terminal({ convertEol: true, scrollback: 10_000 }));
+  sessions = [
+    ...sessions,
+    { id, ...row, state: "attached", startedAt: now, lastOutputAt: stamp },
+  ];
+  scheduleIdle(id);
+  emit();
+  return id;
+}
+
+/**
+ * Open the far end and wire it to the emulator in both directions.
+ *
+ * The failure path leaves the row standing as `closed` rather than throwing:
+ * a shell that RBAC refused is exactly the thing a reader needs to see said,
+ * and `describeError` is what says it.
+ */
+async function connect(
+  id: number,
+  open: (
+    onData: (chunk: string) => void,
+    onExit: (error: string | null) => void,
+    size: { cols: number; rows: number },
+  ) => Promise<TerminalConnection>,
+): Promise<void> {
+  const term = emulators.get(id);
+  if (!term) return;
+  let handle: TerminalConnection;
+  try {
+    handle = await open(
+      (chunk) => receive(id, chunk),
+      (error) => close(id, error),
+      // The PTY starts the size the emulator already is, so the first prompt
+      // wraps where the reader will see it. The pane refits once it is on
+      // screen, and `onResize` below carries that through.
+      { cols: term.cols, rows: term.rows },
+    );
+  } catch (e) {
+    // Raw, not described: `close` describes exactly once, and a sentence run
+    // through `describeError` twice is classified on its own wording.
+    close(id, e);
+    return;
+  }
+  // A session the reader ended while the connect was still in flight has no
+  // row left to attach to; close what just opened rather than leaking a PTY.
+  if (!emulators.has(id)) {
+    handle.close();
+    return;
+  }
+  handles.set(id, handle);
+  const data = term.onData((input) => handle.send(input));
+  const resize = term.onResize(({ cols, rows }) => handle.resize(cols, rows));
+  unwires.set(id, () => {
+    data.dispose();
+    resize.dispose();
+  });
+}
+
+/** A chunk from the far end: into the emulator, and the session is awake. */
+function receive(id: number, chunk: string) {
+  emulators.get(id)?.write(chunk);
+  markActive(id);
+}
+
+/**
+ * Note that this session just spoke.
+ *
+ * Output arrives constantly, and the snapshot must survive it: a store that
+ * rebuilt its array for every chunk would wake every `useSyncExternalStore`
+ * subscriber on every byte. Only a session that was `idle`, or whose last
+ * output was in an earlier second, changes anything here — and a session
+ * whose far end is gone cannot be woken at all.
+ */
+function markActive(id: number) {
+  const stamp = wholeSecond(Date.now());
+  const next = sessions.map((s) => {
+    if (s.id !== id || s.state === "closed") return s;
+    if (s.state === "attached" && s.lastOutputAt === stamp) return s;
+    return { ...s, state: "attached" as const, lastOutputAt: stamp };
+  });
+  scheduleIdle(id);
+  commit(next);
+}
+
+/** An epoch stamp at second resolution. See {@link TerminalSessionRow.lastOutputAt}. */
+function wholeSecond(millis: number): number {
+  return Math.floor(millis / 1000) * 1000;
+}
+
+/** Start (or restart) this session's quiet clock. */
+function scheduleIdle(id: number) {
+  clearTimeout(idleTimers.get(id));
+  idleTimers.set(
+    id,
+    setTimeout(() => markIdle(id), SESSION_IDLE_AFTER_MS),
+  );
+}
+
+/** The session has been quiet long enough to read as idle. Still running. */
+function markIdle(id: number) {
+  idleTimers.delete(id);
+  commit(sessions.map((s) => (s.id === id && s.state === "attached" ? { ...s, state: "idle" as const } : s)));
+}
+
+/**
+ * The far end is gone. The row STAYS, marked `closed`, carrying why.
+ *
+ * `reason` is whatever the backend gave — a clean exit gives nothing, and a
+ * row that already recorded a reason keeps it rather than being overwritten by
+ * a second, emptier notice of the same death. Nothing is rebuilt when nothing
+ * changed: the store must not wake its subscribers for a closure it already
+ * knows about.
+ */
+function close(id: number, reason: unknown) {
+  disconnect(id);
+  const error = describedReason(reason);
+  commit(
+    sessions.map((s) => {
+      if (s.id !== id) return s;
+      const kept = error ?? s.error;
+      if (s.state === "closed" && s.error === kept) return s;
+      return { ...s, state: "closed" as const, error: kept };
+    }),
+  );
+}
+
+/** Stop talking to the far end: close the session, unwire the emulator, and
+ *  stop its clock. The emulator itself stays — its scrollback is the whole
+ *  reason a closed row is still worth opening. Idempotent. */
+function disconnect(id: number) {
+  clearTimeout(idleTimers.get(id));
+  idleTimers.delete(id);
+  unwires.get(id)?.();
+  unwires.delete(id);
+  handles.get(id)?.close();
+  handles.delete(id);
+}
+
+/** A reason worth showing, said the way a reader can use it — a backend
+ *  string, or a thrown value from a session that never opened. `describeError`
+ *  strips the wrappers either arrives in and classifies what is left; nothing
+ *  at all, or an empty reason, is not a sentence and stays nothing. */
+function describedReason(reason: unknown): string | undefined {
+  if (reason === null || reason === undefined) return undefined;
+  if (typeof reason === "string" && reason.trim() === "") return undefined;
+  return describeError(reason).detail;
+}
+
+/**
+ * The one way the snapshot changes: take a rebuilt list only if some row in it
+ * actually changed, or a row left it. Identity is the snapshot's contract, and
+ * a no-op assignment breaks it — but so does a length change that every
+ * surviving row happens to match, which is what dropping the LAST row looks
+ * like to a positional comparison alone.
+ */
+function commit(next: TerminalSessionRow[]) {
+  if (next.length === sessions.length && !next.some((s, i) => s !== sessions[i])) return;
+  sessions = next;
+  emit();
+}

--- a/packages/ui-next/src/lib/tabs.test.ts
+++ b/packages/ui-next/src/lib/tabs.test.ts
@@ -1,4 +1,5 @@
-// @vitest-environment node
+// jsdom, not node: `./tabs` imports `./routes`, whose screen table reaches
+// `@xterm/addon-fit` — a UMD bundle that reads `self` as it evaluates.
 import { describe, it, expect, vi, afterEach } from "vitest";
 import type { ClusterContext } from "@srelens/core";
 import { CLOSED_CAP, defaultState, makeTab, newId, reconcile, type TabsState, type Workspace } from "./tabs";

--- a/packages/ui-next/src/lib/tabsPersist.test.ts
+++ b/packages/ui-next/src/lib/tabsPersist.test.ts
@@ -1,4 +1,5 @@
-// @vitest-environment node
+// jsdom, not node: `./tabs` imports `./routes`, whose screen table reaches
+// `@xterm/addon-fit` — a UMD bundle that reads `self` as it evaluates.
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { ClusterContext } from "@srelens/core";
 import { defaultState, makeTab, type TabsState } from "./tabs";

--- a/packages/ui-next/src/screens/Logs.tsx
+++ b/packages/ui-next/src/screens/Logs.tsx
@@ -458,6 +458,10 @@ function LogsScreen({
   );
 }
 
+/** The question the header's ask control sends, named because the control
+ *  now states it in its accessible name as well as sending it. */
+const SUMMARISE_QUESTION = "Summarise the last 500 log lines and group errors by cause";
+
 export function Logs({ route }: { route: string }) {
   const cluster = useActiveContext();
   const parts = parseLogsRoute(route);
@@ -1114,11 +1118,20 @@ function LogsStream({
       eyebrow={`${clusterName} / ${namespace} / ${name} · ${podCount(targets)}`}
       actions={
         <>
-          <AskChip
-            label="Summarise this stream"
-            question="Summarise the last 500 log lines and group errors by cause"
-            onAsk={ask}
-          />
+          {/* A `Button`, not the row's `AskChip`, for the reason `Events.tsx`
+              and `Overview.tsx` both give: `.row-ask` is `opacity: 0` until a
+              `.tbl tbody tr` is hovered, which is right for one of forty rows
+              and invisible in a header, where there is no row to hover. This
+              header advertised an action nobody could see from #344 until it
+              was measured on a real screen. */}
+          <Button
+            type="button"
+            size="sm"
+            aria-label={`Summarise this stream: ${SUMMARISE_QUESTION}`}
+            onClick={() => ask(SUMMARISE_QUESTION)}
+          >
+            Summarise this stream
+          </Button>
           {/* Disabled while a previous instance is on screen, and it says why
               in its own accessible name: `previous` forbids following because
               the API cannot follow a terminated container, not because this

--- a/packages/ui-next/src/screens/ResourceMenu.test.tsx
+++ b/packages/ui-next/src/screens/ResourceMenu.test.tsx
@@ -7,8 +7,8 @@ import userEvent from "@testing-library/user-event";
 // demand — the dialog's error path is the whole point of half these tests.
 type ActionResult = { ok?: boolean; error?: string };
 
-const { deleteResource, scaleResource, rolloutRestart, evictPod, cronjobSetSuspend, cronjobTriggerNow } = vi.hoisted(
-  () => ({
+const { deleteResource, scaleResource, rolloutRestart, evictPod, cronjobSetSuspend, cronjobTriggerNow, getObject } =
+  vi.hoisted(() => ({
     deleteResource: vi.fn(async (): Promise<ActionResult> => ({ ok: true })),
     scaleResource: vi.fn(async (): Promise<ActionResult> => ({ ok: true })),
     rolloutRestart: vi.fn(async (): Promise<ActionResult> => ({ ok: true })),
@@ -17,8 +17,22 @@ const { deleteResource, scaleResource, rolloutRestart, evictPod, cronjobSetSuspe
     cronjobTriggerNow: vi.fn(async (): Promise<{ jobName?: string; error?: string }> => ({
       jobName: "nightly-manual-1",
     })),
-  }),
-);
+    // `Open shell` looks the pod up fresh, off the live cluster, to find out
+    // which containers are worth asking about — a list row carries no
+    // container names. Real by default (one running "app" container); tests
+    // that care about the shape override it per-call.
+    getObject: vi.fn(
+      async (): Promise<{ object?: { spec: { containers: { name: string }[] } }; error?: string }> => ({
+        object: { spec: { containers: [{ name: "app" }] } },
+      }),
+    ),
+  }));
+
+// `Open shell` starts a session in the module-level store rather than
+// minting a route — mocked so a test can see exactly what it was asked to
+// start, without a real xterm instance or a real PTY behind it.
+const startPodSession = vi.hoisted(() => vi.fn(async () => 1));
+vi.mock("../lib/sessions", () => ({ startPodSession }));
 
 // Direct references, not `(...a) => fn(...a)` wrappers: each mock above is
 // typed by its own implementation (zero declared params), and TypeScript
@@ -43,6 +57,7 @@ vi.mock("@srelens/core", async (importOriginal) => ({
   evictPod,
   cronjobSetSuspend,
   cronjobTriggerNow,
+  getObject,
   ...forwardCore,
 }));
 
@@ -205,12 +220,72 @@ describe("useRowMenu", () => {
     await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
   });
 
-  it("still opens a shell in a tab — only the forward entry changed", async () => {
+  /**
+   * `Open shell` used to mint `/resources/<name>/shell` — a route no screen
+   * is registered for, the same dead end Follow logs and Port forward shipped
+   * with (#346, #349). Sessions live in a module-level store, so the fix is
+   * to start one there and open the screen that shows it, not to design the
+   * route the other two needed.
+   *
+   * Both effects are asserted, deliberately: a test that checked only the
+   * `/terminals` tab would still pass with the session start deleted, and a
+   * test that checked only `startPodSession` would still pass with the
+   * navigation deleted. Neither promise implies the other.
+   */
+  it("starts a session for the pod and opens /terminals on it — a one-container pod is not interrogated", async () => {
+    render(<Harness args={POD_ARGS} row={POD_ROW} />);
+    expect(screen.queryByRole("dialog")).toBeNull();
+    await userEvent.click(screen.getByRole("button", { name: "Open shell" }));
+
+    await waitFor(() =>
+      expect(startPodSession).toHaveBeenCalledWith({
+        context: "prod",
+        namespace: "kube-system",
+        pod: "web-0",
+        container: "app",
+      }),
+    );
+    expect(store.currentWorkspace().tabs.some((t) => t.route === "/terminals")).toBe(true);
+    // The pod has one candidate container — nothing was asked.
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("asks which container on a pod with more than one, and starts nothing until the pick is confirmed", async () => {
+    getObject.mockResolvedValueOnce({
+      object: { spec: { containers: [{ name: "app" }, { name: "proxy" }] } },
+    });
     render(<Harness args={POD_ARGS} row={POD_ROW} />);
     await userEvent.click(screen.getByRole("button", { name: "Open shell" }));
-    expect(
-      store.currentWorkspace().tabs.some((t) => t.route === "/resources/web-0/shell"),
-    ).toBe(true);
+
+    const dialog = within(await screen.findByRole("dialog"));
+    expect(startPodSession).not.toHaveBeenCalled();
+    // No annotation and neither container reported running: the first app
+    // container is the default offered.
+    await waitFor(() => expect((dialog.getByLabelText("Container") as HTMLSelectElement).value).toBe("app"));
+
+    await userEvent.selectOptions(dialog.getByLabelText("Container"), "proxy");
+    await userEvent.click(dialog.getByRole("button", { name: "Open" }));
+
+    await waitFor(() =>
+      expect(startPodSession).toHaveBeenCalledWith({
+        context: "prod",
+        namespace: "kube-system",
+        pod: "web-0",
+        container: "proxy",
+      }),
+    );
+    expect(store.currentWorkspace().tabs.some((t) => t.route === "/terminals")).toBe(true);
+  });
+
+  it("reports the pod lookup's failure through describeError, and starts nothing", async () => {
+    getObject.mockResolvedValueOnce({ error: "pods \"web-0\" is forbidden" });
+    render(<Harness args={POD_ARGS} row={POD_ROW} />);
+    await userEvent.click(screen.getByRole("button", { name: "Open shell" }));
+
+    await waitFor(() => expect(getObject).toHaveBeenCalled());
+    expect(startPodSession).not.toHaveBeenCalled();
+    expect(store.currentWorkspace().tabs.some((t) => t.route === "/terminals")).toBe(false);
+    expect(screen.queryByRole("dialog")).toBeNull();
   });
 
   it("opens a cluster-scoped resource with the placeholder namespace segment", async () => {

--- a/packages/ui-next/src/screens/ResourceMenu.tsx
+++ b/packages/ui-next/src/screens/ResourceMenu.tsx
@@ -3,21 +3,27 @@ import {
   copyKubectlCommand,
   cronjobSetSuspend,
   cronjobTriggerNow,
+  defaultContainer,
   deleteResource,
   describeError,
   evictPod,
+  execCandidates,
+  getObject,
   notify,
+  podContainerChoices,
   rolloutRestart,
   scaleResource,
   toKubectl,
+  type ContainerChoice,
   type KubectlInput,
 } from "@srelens/core";
-import { ConfirmDialog, KubectlPreview, TextInput, type ContextMenuItem } from "@srelens/ui-kit";
+import { ConfirmDialog, KubectlPreview, Select, TextInput, type ContextMenuItem } from "@srelens/ui-kit";
 import { detailRoute } from "../lib/detailRoute";
 import { FailureLine } from "../lib/errorCopy";
 import { Icons } from "../lib/icons";
 import { ROW_ACTION_LABEL } from "../lib/kinds/rowActions";
 import type { KindActions, ListRow } from "../lib/kinds/types";
+import { startPodSession } from "../lib/sessions";
 import { openTab } from "../lib/tabsStore";
 import { NewForwardDialog } from "./forwards/NewForwardDialog";
 import { logsRoute } from "./Logs";
@@ -45,20 +51,23 @@ function isSuspended(row: ListRow): boolean {
   return typeof value === "boolean" && value;
 }
 
+/** What `Open shell` is waiting on, once the pod turned out to run more than
+ *  one container worth asking about. See {@link startShell}. */
+interface ShellPick {
+  row: ListRow;
+  namespace: string;
+  choices: ContainerChoice[];
+  container: string;
+}
+
 /**
- * The row menu's shell tab — a placeholder for a screen that does not exist
- * yet. Deliberately NOT `detailRoute`: designing its real route model is a
- * later step's job, not this one's.
- *
- * Neither Logs nor Port forward comes through here any more. This shape
- * carries a name and nothing else, so it cannot say which kind or namespace
- * the subject is in — which was survivable while every one of these rendered a
- * Placeholder, and stopped being so the moment those screens became real: the
- * front door opened onto an empty pane. Logs mints {@link logsRoute}; Port
- * forward opens §A.4's dialog on the row itself, through the same `dialog`
- * slot every write action here uses.
+ * Nothing mints `/resources/<name>/logs|shell|forward` from this menu any
+ * more — the last of the three, `shell`, is repointed by {@link startShell}
+ * below. The shape survives only in `routes.ts`, so a tab a previous session
+ * persisted can still name itself in the strip; a fresh pick never reaches it.
+ * Logs mints {@link logsRoute}; Port forward opens §A.4's dialog on the row
+ * itself, through the same `dialog` slot every write action here uses.
  */
-const nav = (name: string, suffix: string) => `/resources/${encodeURIComponent(name)}/${suffix}`;
 
 /**
  * The row menu and the one dialog every write action in it shares.
@@ -90,6 +99,15 @@ export function useRowMenu({ context, kind, actions }: UseRowMenuArgs): {
    * error line, none of which `PendingDialog` has a shape for.
    */
   const [forwarding, setForwarding] = useState<ListRow | null>(null);
+  /**
+   * The pod `Open shell` was picked on, waiting on which container to attach
+   * to — set only when {@link startShell} found more than one candidate worth
+   * asking about. A one-container pod never reaches this: it starts straight
+   * away. A slot of its own for the same reason `forwarding` has one: this is
+   * a question with its own fields, not a `Pending` variant.
+   */
+  const [shellPick, setShellPick] = useState<ShellPick | null>(null);
+  const [shellBusy, setShellBusy] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
   const [replicas, setReplicas] = useState("");
@@ -115,6 +133,63 @@ export function useRowMenu({ context, kind, actions }: UseRowMenuArgs): {
       return;
     }
     notify.success(`Triggered ${row.name}`, out.jobName ? `Created job ${out.jobName}` : undefined);
+  }
+
+  /**
+   * `Open shell` was picked. Starts a session in `sessions.ts` and opens
+   * `/terminals` on it, rather than minting `/resources/<name>/shell` — a
+   * route no screen renders, the exact dead end Follow logs and Port forward
+   * shipped with first (#346, #349). The store is module-level, so unlike
+   * `logsRoute` this needs no route of its own to carry the subject through:
+   * starting the session here is enough for the terminals screen to find it.
+   *
+   * Which container to attach to is looked up fresh, off the live pod, rather
+   * than guessed from the row: a list row carries no container names (only a
+   * comma-joined image string and a ready count), and `kubectl exec` with no
+   * `-c` lands on the manifest's FIRST container — often a sidecar with no
+   * shell at all — not the one the reader meant. A pod with exactly one
+   * candidate starts right away; a pod with more than one is asked, because
+   * landing in the wrong container silently is worse than one extra click.
+   */
+  async function startShell(row: ListRow) {
+    const namespace = row.namespace ?? "";
+    const result = await getObject(context, kind, namespace || null, row.name);
+    if (result.error || !result.object) {
+      notify.error(`Couldn't open a shell in ${row.name}`, describeError(result.error ?? "Pod not found").detail);
+      return;
+    }
+    const choices = execCandidates(podContainerChoices(result.object));
+    if (choices.length === 0) {
+      notify.error(`Couldn't open a shell in ${row.name}`, "No running container to attach to.");
+      return;
+    }
+    if (choices.length > 1) {
+      setShellPick({
+        row,
+        namespace,
+        choices,
+        container: defaultContainer(result.object, choices) ?? choices[0].name,
+      });
+      return;
+    }
+    await launchShell(row, namespace, choices[0].name);
+  }
+
+  /** Starts the session and opens the screen that shows it. Two separate
+   *  effects — a session that failed to open is still a `closed` row on
+   *  `/terminals`, worth showing rather than hiding behind a tab that never
+   *  opens. */
+  async function launchShell(row: ListRow, namespace: string, container: string) {
+    await startPodSession({ context, namespace, pod: row.name, container });
+    openTab("/terminals", { clusterName: context });
+  }
+
+  async function confirmShell() {
+    if (!shellPick) return;
+    setShellBusy(true);
+    await launchShell(shellPick.row, shellPick.namespace, shellPick.container);
+    setShellBusy(false);
+    setShellPick(null);
   }
 
   async function confirm() {
@@ -175,7 +250,7 @@ export function useRowMenu({ context, kind, actions }: UseRowMenuArgs): {
       });
     }
     if (actions.shell) {
-      list.push({ label: ROW_ACTION_LABEL.shell, icon: Icons.terminal, onPick: () => openTab(nav(row.name, "shell"), { clusterName: context }) });
+      list.push({ label: ROW_ACTION_LABEL.shell, icon: Icons.terminal, onPick: () => void startShell(row) });
     }
     if (actions.forward) {
       list.push({
@@ -248,6 +323,27 @@ export function useRowMenu({ context, kind, actions }: UseRowMenuArgs): {
       namespace={forwarding.namespace}
       target={{ kind, name: forwarding.name }}
       onClose={() => setForwarding(null)}
+    />
+  ) : shellPick ? (
+    <ConfirmDialog
+      title="Open shell"
+      confirmLabel="Open"
+      busy={shellBusy}
+      onConfirm={() => void confirmShell()}
+      onCancel={() => setShellPick(null)}
+      message={
+        <>
+          <p style={{ marginTop: 0 }}>
+            <code>{shellPick.row.name}</code> runs more than one container — which one?
+          </p>
+          <Select
+            value={shellPick.container}
+            onValueChange={(container) => setShellPick((prev) => (prev ? { ...prev, container } : prev))}
+            options={shellPick.choices.map((c) => ({ value: c.name, label: c.name }))}
+            aria-label="Container"
+          />
+        </>
+      }
     />
   ) : null;
 

--- a/packages/ui-next/src/screens/Terminals.test.tsx
+++ b/packages/ui-next/src/screens/Terminals.test.tsx
@@ -163,6 +163,19 @@ afterEach(() => {
 });
 
 describe("Terminals", () => {
+  it("draws an ask control that is actually visible", () => {
+    // `AskChip` is the ROW chip: `.row-ask` is `opacity: 0` until a `.tbl
+    // tbody tr` is hovered, which is right for one of forty rows and
+    // invisible on a header, where there is no row to hover. `Events.tsx` and
+    // `Overview.tsx` already use a `Button` here and say why.
+    //
+    // jsdom does not apply the stylesheet, so this asserts the mechanism: the
+    // header's control is not the row chip.
+    draw();
+    const ask = screen.getByRole("button", { name: /Draft a command/i });
+    expect(ask.className).not.toContain("row-ask");
+  });
+
   it("shows the session the rail selected, neither the first nor the newest", async () => {
     const first = await openPod("checkout-api-5c8b7f2d9-mk3wl");
     const middle = await openPod("search-indexer-0", "search", "indexer");

--- a/packages/ui-next/src/screens/Terminals.test.tsx
+++ b/packages/ui-next/src/screens/Terminals.test.tsx
@@ -163,6 +163,21 @@ afterEach(() => {
 });
 
 describe("Terminals", () => {
+  it("lets the pane shrink, so the rail is not pushed off the window", async () => {
+    // xterm sizes its content in explicit pixels, and a flex item's implicit
+    // `min-width: auto` refuses to shrink below its content — so without
+    // `min-w-0` the pane grows to the terminal's width and the 230px rail
+    // goes off the right edge. Seen on a real screen: the rail read
+    // "SESSIONS · 1 ATTACHE" with the D cut off.
+    //
+    // jsdom lays nothing out, so this asserts the mechanism. Fifth time this
+    // property has bitten on this migration.
+    draw();
+    await openPod("checkout-api-5c8b7f2d9-mk3wl");
+    const view = document.querySelector('[data-slot="terminal-body"]');
+    expect(view?.className ?? "").toContain("min-w-0");
+  });
+
   it("draws an ask control that is actually visible", () => {
     // `AskChip` is the ROW chip: `.row-ask` is `opacity: 0` until a `.tbl
     // tbody tr` is hovered, which is right for one of forty rows and

--- a/packages/ui-next/src/screens/Terminals.test.tsx
+++ b/packages/ui-next/src/screens/Terminals.test.tsx
@@ -1,0 +1,367 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, render, screen, cleanup, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+/**
+ * Only the BACKEND boundary is doubled. The session store, its emulators and
+ * `describeError` all stay real — this screen's whole job is composing them,
+ * and a test that stubbed the store would prove the screen calls a stub. Same
+ * arrangement `TerminalView.test.tsx` uses, extended with the listing calls
+ * `NewSessionMenu` makes when the header opens it.
+ */
+const core = vi.hoisted(() => ({
+  startPodExec: vi.fn(),
+  startLocalTerminal: vi.fn(),
+  deletePod: vi.fn(),
+  listNamespaces: vi.fn(),
+  listPods: vi.fn(),
+  listNodes: vi.fn(),
+  getObject: vi.fn(),
+  createNodeDebugPod: vi.fn(),
+  isTauri: vi.fn(() => true),
+  notify: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+vi.mock("@srelens/core", async (orig) => ({
+  ...(await orig<typeof import("@srelens/core")>()),
+  ...core,
+}));
+
+/**
+ * `@xterm/addon-fit` measures a real canvas, which jsdom cannot do. Doubled so
+ * mounting the pane does not depend on a measurement that is always zero here;
+ * the emulator itself stays the real xterm instance, because the theme this
+ * screen dresses it in is read back off that instance.
+ */
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: class {
+    activate() {}
+    dispose() {}
+    fit() {}
+  },
+}));
+
+import type { ClusterContext } from "@srelens/core";
+import { ConsoleProvider, useConsole } from "../console";
+import { resetContexts, setContexts } from "../lib/clusters";
+import {
+  __resetSessionsForTests,
+  endSession,
+  getSessions,
+  startPodSession,
+  terminalFor,
+} from "../lib/sessions";
+import { defaultState } from "../lib/tabs";
+import * as tabs from "../lib/tabsStore";
+import { Terminals } from "./Terminals";
+
+const CTX: ClusterContext = {
+  name: "prod-eu",
+  stableId: "prod",
+  cluster: "prod",
+  server: "https://prod",
+  isCurrent: true,
+};
+
+/** jsdom has no `matchMedia`; xterm's `CoreBrowserService` reads it on open(). */
+function stubMatchMedia(target: typeof globalThis) {
+  (target as unknown as { matchMedia: (query: string) => MediaQueryList }).matchMedia = (
+    query: string,
+  ) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }) as unknown as MediaQueryList;
+}
+stubMatchMedia(globalThis);
+if (typeof window !== "undefined") stubMatchMedia(window as unknown as typeof globalThis);
+
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
+/** The far end of a session: what `startPodExec` resolves to. */
+function handle() {
+  return { send: vi.fn(), resize: vi.fn(), close: vi.fn() };
+}
+
+let asked: string[] = [];
+
+/** Records what the ask chip put to the console, which has no dock here. */
+function AskSpy() {
+  const console_ = useConsole();
+  console_.registerSubmit((question) => {
+    asked.push(question);
+  });
+  return null;
+}
+
+function draw() {
+  asked = [];
+  return render(
+    <ConsoleProvider>
+      <AskSpy />
+      <Terminals route="/terminals" />
+    </ConsoleProvider>,
+  );
+}
+
+/** A pod session through the real store, so the row carries a real kind and title. */
+async function openPod(pod: string, namespace = "checkout", container = "api") {
+  return act(() => startPodSession({ context: CTX.name, namespace, pod, container }));
+}
+
+const paneHead = () => document.querySelector('[data-slot="main-head"]') as HTMLElement;
+/**
+ * A rail row, found INSIDE the rail. Scoped rather than global because the ask
+ * chip's accessible name carries the active session's title too — a global
+ * query for a session's name matches both, and which of them it happened to
+ * find would be the assertion.
+ */
+const railRow = (name: RegExp) =>
+  within(document.querySelector('[data-slot="rail-body"]') as HTMLElement).getByRole("button", {
+    name,
+  });
+const sessionName = () => document.querySelector('[data-slot="session-name"]') as HTMLElement;
+const headerActions = () =>
+  document.querySelector('[data-slot="screen-actions"]') as HTMLElement;
+/** Every xterm root currently in the document — one pane, one emulator. */
+const attached = () => Array.from(document.querySelectorAll(".xterm"));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  core.isTauri.mockReturnValue(true);
+  core.startPodExec.mockImplementation(async () => handle());
+  core.startLocalTerminal.mockImplementation(async () => handle());
+  core.deletePod.mockResolvedValue({});
+  core.listNamespaces.mockResolvedValue({ namespaces: [] });
+  core.listPods.mockResolvedValue({ pods: [] });
+  core.listNodes.mockResolvedValue({ nodes: [] });
+  core.createNodeDebugPod.mockResolvedValue({});
+  __resetSessionsForTests();
+  resetContexts();
+  setContexts([CTX]);
+  tabs.setState(defaultState([CTX]));
+  document.documentElement.removeAttribute("data-theme");
+  document.documentElement.removeAttribute("style");
+});
+
+afterEach(() => {
+  cleanup();
+  __resetSessionsForTests();
+  document.documentElement.removeAttribute("data-theme");
+  document.documentElement.removeAttribute("style");
+});
+
+describe("Terminals", () => {
+  it("shows the session the rail selected, neither the first nor the newest", async () => {
+    const first = await openPod("checkout-api-5c8b7f2d9-mk3wl");
+    const middle = await openPod("search-indexer-0", "search", "indexer");
+    const newest = await openPod("otel-collector-0", "observability", "otel");
+    const user = userEvent.setup();
+    draw();
+
+    // The MIDDLE row, on purpose: with three sessions on screen, "shows the
+    // active one" agrees with neither "shows the first one" nor "shows the
+    // last one", so the assertion cannot pass by position.
+    await user.click(railRow(/search-indexer-0/));
+
+    expect(sessionName().textContent).toBe("search-indexer-0 · indexer");
+    // And the pane is attached to THAT session's emulator, not merely titled
+    // with its name: one xterm root on screen, and it is the middle one's.
+    expect(attached()).toEqual([terminalFor(middle)?.element]);
+    expect(attached()).not.toContain(terminalFor(first)?.element);
+    expect(attached()).not.toContain(terminalFor(newest)?.element);
+  });
+
+  it("opens on the newest session, so one started from a row menu is what the tab shows", async () => {
+    await openPod("checkout-api-5c8b7f2d9-mk3wl");
+    const newest = await openPod("search-indexer-0", "search", "indexer");
+    draw();
+
+    expect(sessionName().textContent).toBe("search-indexer-0 · indexer");
+    expect(attached()).toEqual([terminalFor(newest)?.element]);
+  });
+
+  it("keeps the active session when the rows around it come and go", async () => {
+    const alpha = await openPod("alpha");
+    const bravo = await openPod("bravo");
+    const charlie = await openPod("charlie");
+    const user = userEvent.setup();
+    draw();
+
+    await user.click(railRow(/bravo/));
+    expect(sessionName().textContent).toBe("bravo · api");
+
+    // Both neighbours go, from both ends: `charlie` shortens the array under
+    // the pane and `alpha` shifts every index in it. A pane holding a position
+    // rather than an id would follow the shuffle instead of the reader.
+    await act(async () => endSession(charlie));
+    expect(sessionName().textContent).toBe("bravo · api");
+    await act(async () => endSession(alpha));
+
+    expect(sessionName().textContent).toBe("bravo · api");
+    expect(attached()).toEqual([terminalFor(bravo)?.element]);
+  });
+
+  it("names the active session in normal case, beside its state badge", async () => {
+    await openPod("checkout-api-5c8b7f2d9-mk3wl");
+    draw();
+
+    // §14 asks for the pane head's name in normal case, against this design's
+    // usual uppercase `.pane-head` — a class assertion, because the case is a
+    // stylesheet property and the text node reads the same either way.
+    expect(sessionName().classList.contains("normal-case")).toBe(true);
+    expect(within(paneHead()).getByText("Attached")).toBeTruthy();
+  });
+
+  it("says in the footer that a shell is not gated", async () => {
+    await openPod("checkout-api-5c8b7f2d9-mk3wl");
+    draw();
+
+    expect(
+      screen.getByText(
+        "Destructive commands inside a shell are not gated — the shell is your own session",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("Clear clears the emulator and leaves the session running", async () => {
+    const id = await openPod("checkout-api-5c8b7f2d9-mk3wl");
+    const term = terminalFor(id);
+    if (!term) throw new Error("expected a live emulator");
+    const clear = vi.spyOn(term, "clear");
+    const far = await core.startPodExec.mock.results[0].value;
+    const user = userEvent.setup();
+    draw();
+
+    await user.click(screen.getByRole("button", { name: "Clear" }));
+
+    expect(clear).toHaveBeenCalledTimes(1);
+    // A Clear that ended the session would pass the assertion above. These
+    // are what tell the two apart.
+    expect(getSessions().map((s) => s.id)).toEqual([id]);
+    expect(getSessions()[0].state).toBe("attached");
+    expect(terminalFor(id)).toBe(term);
+    expect(far.close).not.toHaveBeenCalled();
+  });
+
+  it("Detach ends the session, cleanup and all", async () => {
+    const id = await act(() =>
+      startPodSession({
+        context: CTX.name,
+        namespace: "kube-system",
+        pod: "node-debug-abc",
+        container: "debug",
+        kind: "node",
+        title: "eu-w4-c3-standard-a1",
+      }),
+    );
+    const far = await core.startPodExec.mock.results[0].value;
+    const user = userEvent.setup();
+    draw();
+
+    await user.click(screen.getByRole("button", { name: "Detach" }));
+
+    expect(getSessions()).toHaveLength(0);
+    expect(far.close).toHaveBeenCalled();
+    expect(terminalFor(id)).toBeUndefined();
+    // Detach is `endSession`, not a row removal that happens to look like it:
+    // the privileged debug pod a node shell left on the cluster goes with it.
+    expect(core.deletePod).toHaveBeenCalledWith(CTX.name, "kube-system", "node-debug-abc");
+  });
+
+  it("reports a session that never opened in described words, not the backend's", async () => {
+    core.startPodExec.mockRejectedValueOnce("403 Forbidden");
+    await openPod("locked-down");
+    draw();
+
+    expect(
+      screen.getByText(/Your account doesn't have permission for this on the cluster/),
+    ).toBeTruthy();
+    expect(document.body.textContent ?? "").not.toContain("403 Forbidden");
+    // Still selectable, still showing its transcript: the row is why it ended.
+    expect(attached()).toHaveLength(1);
+  });
+
+  it("names the active session's cluster and namespace above the title", async () => {
+    await openPod("checkout-api-5c8b7f2d9-mk3wl", "checkout");
+    draw();
+
+    expect(screen.getByRole("heading", { name: "Terminals" })).toBeTruthy();
+    expect(document.querySelector(".crumb")?.textContent).toBe("prod-eu / checkout");
+  });
+
+  it("renders an empty state when nothing is open", () => {
+    draw();
+
+    expect(screen.getByText("No shell open")).toBeTruthy();
+    expect(paneHead()).toBeNull();
+    expect(attached()).toHaveLength(0);
+  });
+
+  it("opens the new-session menu from the header", async () => {
+    const user = userEvent.setup();
+    draw();
+
+    await user.click(within(headerActions()).getByRole("button", { name: "New session" }));
+
+    expect(await screen.findByRole("button", { name: "Start session" })).toBeTruthy();
+  });
+
+  it("hands the console a question about the session on screen", async () => {
+    await openPod("checkout-api-5c8b7f2d9-mk3wl");
+    const user = userEvent.setup();
+    draw();
+
+    await user.click(within(headerActions()).getByRole("button", { name: /Draft a command/ }));
+
+    expect(asked).toHaveLength(1);
+    expect(asked[0]).toContain("checkout-api-5c8b7f2d9-mk3wl · api");
+  });
+
+  it("dresses the emulator from the app's tokens rather than colours of its own", async () => {
+    document.documentElement.style.setProperty("--surface-sunk", "#101014");
+    document.documentElement.style.setProperty("--ink-soft", "#443f52");
+    document.documentElement.style.setProperty("--accent", "#4b3bd6");
+    document.documentElement.style.setProperty("--font-mono", '"Test Mono", monospace');
+    const id = await openPod("checkout-api-5c8b7f2d9-mk3wl");
+    draw();
+
+    await waitFor(() => {
+      expect(terminalFor(id)?.options.theme?.background).toBe("#101014");
+    });
+    expect(terminalFor(id)?.options.theme?.foreground).toBe("#443f52");
+    expect(terminalFor(id)?.options.theme?.cursor).toBe("#4b3bd6");
+    expect(terminalFor(id)?.options.fontFamily).toBe('"Test Mono", monospace');
+  });
+
+  it("re-reads the tokens when the theme changes under it", async () => {
+    document.documentElement.style.setProperty("--surface-sunk", "#fafafc");
+    const id = await openPod("checkout-api-5c8b7f2d9-mk3wl");
+    draw();
+    await waitFor(() => {
+      expect(terminalFor(id)?.options.theme?.background).toBe("#fafafc");
+    });
+
+    // What a theme switch does: the same token, a different value, announced
+    // by the attribute `applyNextThemeAttribute` writes on the root.
+    await act(async () => {
+      document.documentElement.style.setProperty("--surface-sunk", "#121118");
+      document.documentElement.dataset.theme = "dark";
+    });
+
+    await waitFor(() => {
+      expect(terminalFor(id)?.options.theme?.background).toBe("#121118");
+    });
+  });
+});

--- a/packages/ui-next/src/screens/Terminals.tsx
+++ b/packages/ui-next/src/screens/Terminals.tsx
@@ -1,0 +1,336 @@
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
+import type { ITheme } from "@xterm/xterm";
+import {
+  Alert,
+  AskChip,
+  Badge,
+  Button,
+  EmptyState,
+  Screen,
+  SideRail,
+  statusTone,
+} from "@srelens/ui-kit";
+import { useConsole } from "../console";
+import { useActiveContext } from "../lib/clusters";
+import {
+  endSession,
+  getSessions,
+  subscribeSessions,
+  terminalFor,
+  type TerminalSessionRow,
+} from "../lib/sessions";
+import { NewSessionMenu } from "./terminals/NewSessionMenu";
+import {
+  SESSION_RAIL_WIDTH,
+  SESSION_VERDICT,
+  SessionRail,
+  sessionRailHead,
+} from "./terminals/SessionRail";
+import { TerminalView } from "./terminals/TerminalView";
+
+/**
+ * §14's footer eyebrow, verbatim.
+ *
+ * **Do not soften this and do not move it into documentation.** Every other
+ * write path in srelens is gated — a confirm dialog with the kubectl
+ * equivalent printed in it, for a delete, a drain, a scale. A shell is
+ * deliberately not: srelens cannot tell `ls` from `rm -rf /` inside a PTY, and
+ * pretending to would be a gate that gates nothing. Saying so where the shell
+ * IS, rather than in a document nobody has open at the moment it matters, is
+ * the honest place for it.
+ */
+const NOT_GATED =
+  "Destructive commands inside a shell are not gated — the shell is your own session";
+
+/**
+ * The design tokens the emulator is dressed from.
+ *
+ * xterm paints its own canvas and knows nothing about this app's stylesheet,
+ * so unlike every other surface here it cannot simply inherit. Left alone it
+ * draws its own dark palette in a white pane, in a font that matches no other
+ * monospace surface in the app — which is what a terminal that reads as
+ * foreign looks like.
+ *
+ * **The token NAMES are here; the values are not.** They are read off the
+ * document at {@link terminalDress}, so a theme change, a palette change or a
+ * token edit carries into the transcript without this file knowing any colour.
+ * That is the same rule `toneColor` follows for everything drawn in CSS; this
+ * is the one place that has to resolve a token to a value rather than hand the
+ * browser a `var()`, because a canvas cannot take one.
+ *
+ * The ANSI half maps only the four colours the token set has an honest answer
+ * for — a program's `red` means "bad" and so does `--sev`. `cyan` is left to
+ * xterm's own palette: there is no token that means cyan, and pointing it at
+ * `--info` would be inventing a meaning for someone else's output. The black
+ * and white ends come from the ink ramp rather than literal black and white,
+ * which is what keeps a program's `white` legible on a light theme — the one
+ * place a terminal's defaults are actively wrong here.
+ */
+const TERMINAL_TOKENS: Readonly<Partial<Record<keyof ITheme, string>>> = {
+  // §14 draws the transcript as a SUNK surface, not the pane's own.
+  background: "--surface-sunk",
+  foreground: "--ink-soft",
+  // §14: "a pulsing accent block cursor sits on the last line".
+  cursor: "--accent",
+  cursorAccent: "--surface-sunk",
+  selectionBackground: "--accent-wash",
+  black: "--ink",
+  red: "--sev",
+  green: "--ok",
+  yellow: "--warn",
+  blue: "--info",
+  magenta: "--accent",
+  white: "--ink-muted",
+  brightBlack: "--ink-faint",
+  brightRed: "--sev",
+  brightGreen: "--ok",
+  brightYellow: "--warn",
+  brightBlue: "--info",
+  brightMagenta: "--accent",
+  brightWhite: "--ink",
+};
+
+/** The token the app's monospace surfaces already share. */
+const FONT_TOKEN = "--font-mono";
+
+/**
+ * Resolve {@link TERMINAL_TOKENS} against the document root.
+ *
+ * The root rather than the pane, deliberately: `:root` is where the token
+ * block is declared and `data-theme` is where the mode is written
+ * (`applyNextDesignTheme` in `apps/desktop/src/design.ts`), so this reads the
+ * same element both of them speak about.
+ *
+ * A token that resolves to nothing is left out rather than written as an empty
+ * string — xterm treats `""` as a colour and throws parsing it, and a document
+ * with no stylesheet attached (a unit test, a first paint) is a real state.
+ * Left out, xterm keeps its own default for that one key.
+ */
+function terminalDress(root: Element): { theme: ITheme; fontFamily?: string } {
+  const style = getComputedStyle(root);
+  const read = (token: string) => style.getPropertyValue(token).trim();
+  const theme: Record<string, string> = {};
+  for (const [key, token] of Object.entries(TERMINAL_TOKENS)) {
+    const value = read(token);
+    if (value) theme[key] = value;
+  }
+  const fontFamily = read(FONT_TOKEN);
+  return { theme, fontFamily: fontFamily || undefined };
+}
+
+/**
+ * Keep the session on screen wearing the app's tokens.
+ *
+ * Re-run when the theme attribute changes, because that is a theme switch:
+ * the tokens under it now resolve to different values and the emulator has
+ * already read the old ones. Nothing else observes `data-theme` — the rest of
+ * the app is CSS and follows on its own — which is exactly why the one canvas
+ * in the app has to.
+ */
+function useTokenDress(sessionId: number | null): void {
+  useEffect(() => {
+    if (sessionId === null) return undefined;
+    const root = document.documentElement;
+    const dress = () => {
+      const term = terminalFor(sessionId);
+      if (!term) return;
+      const { theme, fontFamily } = terminalDress(root);
+      term.options.theme = theme;
+      if (fontFamily) term.options.fontFamily = fontFamily;
+    };
+    dress();
+    const observer = new MutationObserver(dress);
+    observer.observe(root, { attributes: true, attributeFilter: ["data-theme"] });
+    return () => observer.disconnect();
+  }, [sessionId]);
+}
+
+/**
+ * §14's Ask chip, asked about the shell that is actually open.
+ *
+ * §14's own question — "Write the kubectl command to check the pool size in
+ * this pod" — is mock content: "this pod" names nothing an agent could act on,
+ * and "pool size" is the mock's example workload. The chip's WORD is §14's;
+ * the question carries the subject on screen instead, which is the same
+ * treatment every other ask chip in this app gets.
+ */
+function askQuestion(session: TerminalSessionRow | undefined, context: string): string {
+  if (!session) {
+    return `Draft a kubectl command to run against ${context || "the current cluster"}`;
+  }
+  if (session.kind === "local") {
+    return `Draft a kubectl command to run against ${session.context}`;
+  }
+  const where = session.namespace ? ` in namespace ${session.namespace}` : "";
+  return `Draft a shell command to run inside ${session.title}${where}`;
+}
+
+/**
+ * `/terminals` — §14's session rail and the live shell one of them is.
+ *
+ * **The sessions are not this screen's.** They live in `lib/sessions.ts`,
+ * module-level, with their emulators; this screen subscribes, draws whichever
+ * one is selected, and is otherwise free to unmount without taking a shell
+ * with it. That is why `Detach` calls `endSession` rather than doing anything
+ * itself: ending a session closes the far end, disposes the emulator and —
+ * for a node shell — deletes the privileged debug pod srelens put on the
+ * cluster. A row removal that merely looked like a detach would leave that pod
+ * running.
+ *
+ * **A `closed` session is still selectable and still shows its transcript.**
+ * That is why it stays in the rail at all (#349's vanishing port-forward): the
+ * scrollback is what the reader came back for, and the row's `error` is why it
+ * ended. `Clear` and `Detach` both still make sense on one — clearing a
+ * transcript is not ending anything, and detaching is how the row leaves.
+ *
+ * **The active session is an id, never a position.** The store's array
+ * shortens whenever a row is detached and grows whenever one is started, from
+ * this screen or from the resource row menu — and a pane keyed on `[0]` or on
+ * the last index would follow that shuffle instead of following the reader.
+ */
+export function Terminals(_props: { route: string }) {
+  const sessions = useSyncExternalStore(subscribeSessions, getSessions, getSessions);
+  const cluster = useActiveContext();
+  const { ask } = useConsole();
+  const [picked, setPicked] = useState<number | null>(null);
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  /**
+   * A session started anywhere — this screen's menu, or the resource row
+   * menu's `Open shell`, which starts one and then opens this tab — becomes
+   * the one on screen. Ids are the store's own monotonic counter, so "the last
+   * row" is "the newest session", and following it is what makes `Open shell`
+   * land on the shell it just opened rather than on whatever was already here.
+   *
+   * Held in a ref rather than compared against `picked`, so it fires once per
+   * new session: a reader who then selects an older row keeps it.
+   */
+  const newest = sessions.length > 0 ? sessions[sessions.length - 1].id : null;
+  const followed = useRef<number | null>(null);
+  useEffect(() => {
+    if (newest === null || newest === followed.current) return;
+    followed.current = newest;
+    setPicked(newest);
+  }, [newest]);
+
+  // The selection, resolved against the rows that actually exist. A detached
+  // session leaves an id behind that names nothing; the newest row is what a
+  // reader is most likely to want next, and it is also what the effect above
+  // would have chosen.
+  const active =
+    sessions.find((s) => s.id === picked) ??
+    (sessions.length > 0 ? sessions[sessions.length - 1] : undefined);
+  useTokenDress(active?.id ?? null);
+
+  const context = active?.context ?? cluster?.name ?? "";
+  const namespace = active?.namespace ?? cluster?.namespace ?? "";
+  const verdict = active ? SESSION_VERDICT[active.state] : undefined;
+
+  return (
+    <Screen
+      title="Terminals"
+      // §14's sub, `prod-eu / checkout`, read off the session on screen rather
+      // than off the cluster rail: a shell keeps talking to the cluster it was
+      // opened in, and the rail's selection can move away from it.
+      eyebrow={[context, namespace].filter(Boolean).join(" / ")}
+      fill
+      actions={
+        <>
+          <AskChip label="Draft a command" question={askQuestion(active, context)} onAsk={ask} />
+          <Button variant="primary" size="sm" onClick={() => setMenuOpen(true)}>
+            New session
+          </Button>
+        </>
+      }
+    >
+      {menuOpen && (
+        <NewSessionMenu
+          // The cluster in focus, not the active session's: a new session is
+          // started where the reader is, and the menu says so itself when
+          // there is no cluster rather than opening on an empty context.
+          context={cluster?.name ?? ""}
+          namespace={cluster?.namespace}
+          onStarted={setPicked}
+          onClose={() => setMenuOpen(false)}
+        />
+      )}
+      <SideRail
+        head={sessionRailHead(sessions)}
+        width={SESSION_RAIL_WIDTH}
+        rail={
+          <SessionRail
+            sessions={sessions}
+            activeId={active?.id ?? null}
+            onSelect={setPicked}
+            onNewSession={() => setMenuOpen(true)}
+          />
+        }
+        mainHead={
+          active && verdict ? (
+            <>
+              {/* §14 asks for the name in normal case, against the uppercase
+                  `.pane-head` wears everywhere else — a pod name is an
+                  identifier the reader will compare against `kubectl get pods`,
+                  and uppercasing it makes it a different string on sight. */}
+              <span
+                data-slot="session-name"
+                className="min-w-0 truncate normal-case tracking-normal text-[0.75rem] text-ink"
+              >
+                {active.title}
+              </span>
+              <span className="flex-1" />
+              {/* The rail's own verdict, not a second reading of the same
+                  state: `Attached` in the head and `Idle` in the rail, on one
+                  session, would be two answers to one question. */}
+              <Badge tone={statusTone(verdict.kind)}>{verdict.word}</Badge>
+            </>
+          ) : undefined
+        }
+      >
+        {active ? (
+          <div className="flex min-h-0 flex-1 flex-col">
+            {active.error && (
+              <Alert tone="sev" title="This session ended" className="m-3 mb-0">
+                {/* Already through `describeError` — the store describes a
+                    session's reason once, where it arrives, so a sentence is
+                    never classified twice on its own wording. */}
+                {active.error}
+              </Alert>
+            )}
+            {/* Keyed on the session, so switching pulls the whole pane down and
+                puts the next emulator's element in a fresh container. Without
+                it the old element stays where it was appended and two
+                transcripts stack in one pane. */}
+            <TerminalView key={active.id} sessionId={active.id} />
+            <div className="flex shrink-0 items-center gap-2 border-t border-rule bg-sunk px-2.5 py-1.5">
+              {/* Not an `Eyebrow`: that voice is 10px tracked uppercase mono,
+                  which is right over a figure and unreadable across a
+                  seventy-character sentence. The words are §14's, verbatim;
+                  the voice is the one that can actually be read at the moment
+                  it matters. */}
+              <span className="min-w-0 text-[0.75rem] text-muted">{NOT_GATED}</span>
+              <span className="flex-1" />
+              {/* Clears the TRANSCRIPT. The session keeps running — there is
+                  no `Clear` that also detaches, and a reader tidying the
+                  screen must not lose their shell to it. */}
+              <Button variant="secondary" size="xs" onClick={() => terminalFor(active.id)?.clear()}>
+                Clear
+              </Button>
+              <Button variant="danger" size="xs" onClick={() => endSession(active.id)}>
+                Detach
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <EmptyState
+            title="No shell open"
+            hint="Start a session to open a shell inside a pod, on a node, or on this machine. Sessions keep running while you are on another tab."
+            // `fill` hands the body the whole area and leaves the centring to
+            // whatever is in it; without this the state sits at the top edge.
+            className="flex-1"
+          />
+        )}
+      </SideRail>
+    </Screen>
+  );
+}

--- a/packages/ui-next/src/screens/Terminals.tsx
+++ b/packages/ui-next/src/screens/Terminals.tsx
@@ -300,8 +300,14 @@ export function Terminals(_props: { route: string }) {
           ) : undefined
         }
       >
+        {/* The pane carries `min-w-0` as well as `min-h-0`. A flex item's
+            implicit `min-width: auto` refuses to shrink below its content, and
+            xterm sizes its content in explicit pixels — so without it the pane
+            grows to the terminal's width and pushes the 230px rail off the
+            right edge of the window. Fifth time this property has bitten on
+            this migration, and jsdom can see none of them. */}
         {active ? (
-          <div className="flex min-h-0 flex-1 flex-col">
+          <div data-slot="terminal-body" className="flex min-h-0 min-w-0 flex-1 flex-col">
             {active.error && (
               <Alert tone="sev" title="This session ended" className="m-3 mb-0">
                 {/* Already through `describeError` — the store describes a

--- a/packages/ui-next/src/screens/Terminals.tsx
+++ b/packages/ui-next/src/screens/Terminals.tsx
@@ -236,7 +236,20 @@ export function Terminals(_props: { route: string }) {
       fill
       actions={
         <>
-          <AskChip label="Draft a command" question={askQuestion(active, context)} onAsk={ask} />
+          {/* A `Button`, not the row's `AskChip`, for the reason `Events.tsx`
+              and `Overview.tsx` both give: `.row-ask` is `opacity: 0` until a
+              `.tbl tbody tr` is hovered, which is right for one of forty rows
+              and invisible in a header, where there is no row to hover. The
+              visible word is the design's; the question it will actually send
+              goes in the accessible name — the same split the chip makes. */}
+          <Button
+            type="button"
+            size="sm"
+            aria-label={`Draft a command: ${askQuestion(active, context)}`}
+            onClick={() => ask(askQuestion(active, context))}
+          >
+            Draft a command
+          </Button>
           <Button variant="primary" size="sm" onClick={() => setMenuOpen(true)}>
             New session
           </Button>

--- a/packages/ui-next/src/screens/terminals/NewSessionMenu.test.tsx
+++ b/packages/ui-next/src/screens/terminals/NewSessionMenu.test.tsx
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+/**
+ * `isTauri` moved per-test the way `AppLog.test.tsx` does: it is a function
+ * this component calls directly, so flipping it on the mocked `@srelens/core`
+ * module between renders is enough — no second mocking scheme is needed for
+ * one function.
+ *
+ * `podContainerChoices`, `execCandidates` and `defaultContainer` stay REAL:
+ * "execCandidates decides which containers are offered" is a property of
+ * THOSE functions, and a test that stubbed them would only prove the menu
+ * calls a stub. Only the network-shaped calls are doubled.
+ */
+const core = vi.hoisted(() => ({
+  isTauri: vi.fn(() => true),
+  listNamespaces: vi.fn(),
+  listPods: vi.fn(),
+  listNodes: vi.fn(),
+  getObject: vi.fn(),
+  createNodeDebugPod: vi.fn(),
+}));
+vi.mock("@srelens/core", async (orig) => ({
+  ...(await orig<typeof import("@srelens/core")>()),
+  ...core,
+}));
+
+/** The session store is `../../lib/sessions`, not core — see `sessions.ts`'s
+ *  own note on why it lives in `ui-next`. Doubled wholesale: this file's job
+ *  is proving the menu calls it with the right request, not what the store
+ *  does with one. */
+const sessions = vi.hoisted(() => ({
+  startPodSession: vi.fn(),
+  startLocalSession: vi.fn(),
+}));
+vi.mock("../../lib/sessions", () => sessions);
+
+import { NewSessionMenu } from "./NewSessionMenu";
+
+const CONTEXT = "prod-eu";
+const NAMESPACE = "checkout";
+const POD = "checkout-api-5c8b7f2d9-mk3wl";
+
+/** An app container and a container-shaped finished init container — the
+ *  fixture `podContainers.test.ts` uses to prove `execCandidates` drops the
+ *  one that already exited. */
+const POD_OBJECT = {
+  metadata: { name: POD, namespace: NAMESPACE },
+  spec: {
+    containers: [{ name: "api" }, { name: "proxy" }],
+    initContainers: [{ name: "migrate" }],
+  },
+  status: {
+    containerStatuses: [
+      { name: "api", state: { running: {} } },
+      { name: "proxy", state: { running: {} } },
+    ],
+    initContainerStatuses: [{ name: "migrate", state: { terminated: {} } }],
+  },
+};
+
+let onStarted: ReturnType<typeof vi.fn>;
+let onClose: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  core.isTauri.mockReturnValue(true);
+  core.listNamespaces.mockResolvedValue({ namespaces: [NAMESPACE, "payments"] });
+  core.listPods.mockResolvedValue({ pods: [{ name: POD, namespace: NAMESPACE }] });
+  core.listNodes.mockResolvedValue({ nodes: [{ name: "eu-w4-c3-standard-a1" }] });
+  core.getObject.mockResolvedValue({ object: POD_OBJECT });
+  core.createNodeDebugPod.mockResolvedValue({ namespace: "kube-system", pod: "node-debug-abc12" });
+  sessions.startPodSession.mockResolvedValue(9);
+  sessions.startLocalSession.mockResolvedValue(11);
+  onStarted = vi.fn();
+  onClose = vi.fn();
+});
+
+/** The namespace select starts prefilled from the `namespace` prop, so this
+ *  only has to wait for it to load and drive the pod and container selects
+ *  underneath it. */
+async function pickPodAndContainer(user: ReturnType<typeof userEvent.setup>) {
+  await waitFor(() => expect((screen.getByLabelText("Pod") as HTMLSelectElement).disabled).toBe(false));
+  await user.selectOptions(screen.getByLabelText("Pod"), POD);
+  await waitFor(() => expect((screen.getByLabelText("Container") as HTMLSelectElement).disabled).toBe(false));
+}
+
+describe("NewSessionMenu", () => {
+  it("offers a local shell on the desktop", () => {
+    core.isTauri.mockReturnValue(true);
+    render(
+      <NewSessionMenu context={CONTEXT} namespace={NAMESPACE} onStarted={onStarted} onClose={onClose} />,
+    );
+
+    expect(screen.getByRole("button", { name: "Local shell" })).not.toBeNull();
+  });
+
+  it("does not offer a local shell in the browser, and says once why", () => {
+    core.isTauri.mockReturnValue(false);
+    render(
+      <NewSessionMenu context={CONTEXT} namespace={NAMESPACE} onStarted={onStarted} onClose={onClose} />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Local shell" })).toBeNull();
+    // Said once for the whole menu — not a sentence that would have to repeat
+    // itself for Pod and again for Node.
+    expect(
+      screen.getAllByText(/does not offer|only session kind the browser build does not offer/).length,
+    ).toBe(1);
+  });
+
+  it("offers only the containers execCandidates keeps, dropping the finished init container", async () => {
+    const user = userEvent.setup();
+    render(
+      <NewSessionMenu context={CONTEXT} namespace={NAMESPACE} onStarted={onStarted} onClose={onClose} />,
+    );
+
+    await pickPodAndContainer(user);
+
+    const containerSelect = screen.getByLabelText("Container") as HTMLSelectElement;
+    const optionLabels = within(containerSelect)
+      .getAllByRole("option")
+      .map((o) => o.textContent);
+    expect(optionLabels).toContain("api");
+    expect(optionLabels).toContain("proxy");
+    expect(optionLabels).not.toContain("migrate");
+  });
+
+  it("starting a pod session sends the chosen container", async () => {
+    const user = userEvent.setup();
+    render(
+      <NewSessionMenu context={CONTEXT} namespace={NAMESPACE} onStarted={onStarted} onClose={onClose} />,
+    );
+
+    await pickPodAndContainer(user);
+    await user.selectOptions(screen.getByLabelText("Container"), "proxy");
+    await user.click(screen.getByRole("button", { name: "Start session" }));
+
+    await waitFor(() => expect(sessions.startPodSession).toHaveBeenCalledTimes(1));
+    expect(sessions.startPodSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: CONTEXT,
+        namespace: NAMESPACE,
+        pod: POD,
+        container: "proxy",
+      }),
+    );
+    expect(onStarted).toHaveBeenCalledWith(9);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("starting a node session creates its debug pod, then attaches a shell tagged node", async () => {
+    const user = userEvent.setup();
+    render(
+      <NewSessionMenu context={CONTEXT} namespace={NAMESPACE} onStarted={onStarted} onClose={onClose} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Node" }));
+    await waitFor(() => expect((screen.getByLabelText("Node") as HTMLSelectElement).disabled).toBe(false));
+    await user.selectOptions(screen.getByLabelText("Node"), "eu-w4-c3-standard-a1");
+    await user.click(screen.getByRole("button", { name: "Start session" }));
+
+    await waitFor(() => expect(sessions.startPodSession).toHaveBeenCalledTimes(1));
+    expect(core.createNodeDebugPod).toHaveBeenCalledWith(CONTEXT, "eu-w4-c3-standard-a1");
+    expect(sessions.startPodSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: CONTEXT,
+        namespace: "kube-system",
+        pod: "node-debug-abc12",
+        kind: "node",
+      }),
+    );
+    expect(onStarted).toHaveBeenCalledWith(9);
+  });
+
+  it("starting a local session on the desktop scopes it to the context", async () => {
+    const user = userEvent.setup();
+    render(
+      <NewSessionMenu context={CONTEXT} namespace={NAMESPACE} onStarted={onStarted} onClose={onClose} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Local shell" }));
+    await user.click(screen.getByRole("button", { name: "Start session" }));
+
+    await waitFor(() => expect(sessions.startLocalSession).toHaveBeenCalledTimes(1));
+    expect(sessions.startLocalSession).toHaveBeenCalledWith(
+      expect.objectContaining({ context: CONTEXT }),
+    );
+    expect(onStarted).toHaveBeenCalledWith(11);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui-next/src/screens/terminals/NewSessionMenu.tsx
+++ b/packages/ui-next/src/screens/terminals/NewSessionMenu.tsx
@@ -1,0 +1,376 @@
+import { useEffect, useState } from "react";
+import {
+  createNodeDebugPod,
+  defaultContainer,
+  execCandidates,
+  getObject,
+  isTauri,
+  listNamespaces,
+  listNodes,
+  listPods,
+  podContainerChoices,
+  type ContainerChoice,
+} from "@srelens/core";
+import { Alert, Button, Dialog, Field, Select } from "@srelens/ui-kit";
+import { FailureAlert } from "../../lib/errorCopy";
+import { startLocalSession, startPodSession } from "../../lib/sessions";
+
+/** §14's dialog width — narrow, three fields deep at most. */
+const WIDTH = 420;
+
+/**
+ * Enter the host's namespaces from the privileged debug pod for a real node
+ * shell — run via `exec`, the pod itself just stays alive holding it open.
+ * Mirrors classic's `NodeCordonAction.NODE_SHELL_COMMAND`, which this
+ * replaces: that component is `apps/desktop`'s, and this screen does not
+ * reach across into it for one array.
+ */
+const NODE_SHELL_COMMAND = [
+  "nsenter",
+  "--target",
+  "1",
+  "--mount",
+  "--uts",
+  "--ipc",
+  "--net",
+  "--pid",
+  "--",
+  "/bin/sh",
+];
+
+/** The container name `k8s.createNodeDebugPod` always attaches under. */
+const NODE_DEBUG_CONTAINER = "debug";
+
+type Kind = "pod" | "node" | "local";
+
+const KIND_LABEL: Record<Kind, string> = { pod: "Pod", node: "Node", local: "Local shell" };
+
+export interface NewSessionMenuProps {
+  /** The cluster to start a session in — a kubeconfig context name. */
+  context: string;
+  /** Where the namespace select starts, when the caller knows a good one. */
+  namespace?: string;
+  /** A session came up: its id, so the caller can make it the active one. */
+  onStarted: (id: number) => void;
+  /** Cancel, escape, the header's control, and a session that came up. */
+  onClose: () => void;
+}
+
+/**
+ * §14's `New session` — what can be started here, and where.
+ *
+ * **The local shell is drawn only on the desktop.** `WEB_DENIED_COMMANDS` is
+ * `["start_terminal"]` — the local PTY is the one command the web surface
+ * refuses, because it is a shell on the SHARED HOST, running as the server
+ * process's own UID, with no cluster and no RBAC between the reader and it.
+ * Pod and node exec are both a shell inside something the cluster already
+ * decided the reader may enter, so both stay offered everywhere. Rather than
+ * draw the control and let every click fail, the kind selector simply does
+ * not offer `local` in the browser (see {@link kindsFor}), and the one
+ * sentence explaining why is said once, near the top of the menu — not
+ * discovered per click, and not repeated once per kind. Same rule as the
+ * Toolbox's absent install column.
+ *
+ * **A node shell needs a debug pod before it needs a session.**
+ * `k8s.createNodeDebugPod` is the privileged pod srelens creates to reach the
+ * host namespaces via `nsenter`; the session store's own note on
+ * {@link import("../../lib/sessions").endSession} is what deletes it again
+ * when the shell ends. Starting a node session is therefore two calls where
+ * a pod session is one, and only the first of those can fail before there is
+ * anything to hand the store — that failure is shown here, in the dialog,
+ * because no row exists yet to carry it.
+ *
+ * **A pod session never fails here.** `startPodSession` never throws: a shell
+ * RBAC refused, or a container with no shell in it, becomes a `closed` row in
+ * the rail rather than an error in this dialog. So picking a pod and a
+ * container closes the menu immediately and hands the new (possibly already
+ * closed) id to the caller — the rail is where that failure is read.
+ *
+ * **`execCandidates` decides which containers are offered**, not this file: a
+ * finished init container is listed by `podContainerChoices` but dropped by
+ * `execCandidates`, and the container select only ever sees what survives
+ * that filter.
+ */
+export function NewSessionMenu({ context, namespace: initial, onStarted, onClose }: NewSessionMenuProps) {
+  const desktop = isTauri();
+  const [kind, setKind] = useState<Kind>("pod");
+
+  const [namespaces, setNamespaces] = useState<string[] | null>(null);
+  const [namespace, setNamespace] = useState(initial ?? "");
+  const [pods, setPods] = useState<string[] | null>(null);
+  const [pod, setPod] = useState("");
+  const [containers, setContainers] = useState<ContainerChoice[] | null>(null);
+  const [container, setContainer] = useState("");
+
+  const [nodes, setNodes] = useState<string[] | null>(null);
+  const [node, setNode] = useState("");
+
+  const [busy, setBusy] = useState(false);
+  const [failure, setFailure] = useState<{ title: string; error: unknown } | null>(null);
+
+  // Namespaces, up front: the pod kind is where the menu opens, and a
+  // namespace picked before the pod kind is even shown would waste the round
+  // trip a `kind === "pod"` gate would only defer.
+  useEffect(() => {
+    if (!context) {
+      setNamespaces([]);
+      return;
+    }
+    let live = true;
+    setNamespaces(null);
+    void listNamespaces(context).then((out) => {
+      if (!live) return;
+      if (out.error) setFailure({ title: "Could not list this cluster's namespaces", error: out.error });
+      setNamespaces(out.namespaces ?? []);
+    });
+    return () => {
+      live = false;
+    };
+  }, [context]);
+
+  useEffect(() => {
+    if (!namespace) {
+      setPods(null);
+      setPod("");
+      return;
+    }
+    let live = true;
+    setPods(null);
+    void listPods(context, namespace).then((out) => {
+      if (!live) return;
+      if (out.error) setFailure({ title: `Could not list pods in ${namespace}`, error: out.error });
+      const names = (out.pods ?? []).map((p) => p.name);
+      setPods(names);
+      setPod((current) => (names.includes(current) ? current : ""));
+    });
+    return () => {
+      live = false;
+    };
+  }, [context, namespace]);
+
+  useEffect(() => {
+    if (!namespace || !pod) {
+      setContainers(null);
+      setContainer("");
+      return;
+    }
+    let live = true;
+    setContainers(null);
+    void getObject(context, "Pod", namespace, pod).then((out) => {
+      if (!live) return;
+      if (out.error || !out.object) {
+        setFailure({ title: `Could not read ${pod}'s containers`, error: out.error ?? "no object returned" });
+        setContainers([]);
+        return;
+      }
+      const choices = execCandidates(podContainerChoices(out.object));
+      setContainers(choices);
+      setContainer(defaultContainer(out.object, choices) ?? choices[0]?.name ?? "");
+    });
+    return () => {
+      live = false;
+    };
+  }, [context, namespace, pod]);
+
+  useEffect(() => {
+    if (kind !== "node" || !context) return;
+    let live = true;
+    setNodes(null);
+    void listNodes(context).then((out) => {
+      if (!live) return;
+      if (out.error) setFailure({ title: "Could not list this cluster's nodes", error: out.error });
+      setNodes((out.nodes ?? []).map((n) => n.name));
+    });
+    return () => {
+      live = false;
+    };
+  }, [context, kind]);
+
+  async function startPod() {
+    if (!namespace || !pod) return;
+    setBusy(true);
+    const id = await startPodSession({ context, namespace, pod, container: container || undefined });
+    setBusy(false);
+    onStarted(id);
+    onClose();
+  }
+
+  async function startNode() {
+    if (!node) return;
+    setFailure(null);
+    setBusy(true);
+    const created = await createNodeDebugPod(context, node);
+    if (created.error || !created.pod || !created.namespace) {
+      setBusy(false);
+      setFailure({ title: `Could not open a shell on ${node}`, error: created.error ?? "no debug pod created" });
+      return;
+    }
+    const id = await startPodSession({
+      context,
+      namespace: created.namespace,
+      pod: created.pod,
+      container: NODE_DEBUG_CONTAINER,
+      command: NODE_SHELL_COMMAND,
+      kind: "node",
+      title: node,
+    });
+    setBusy(false);
+    onStarted(id);
+    onClose();
+  }
+
+  async function startLocal() {
+    setBusy(true);
+    const id = await startLocalSession({ context });
+    setBusy(false);
+    onStarted(id);
+    onClose();
+  }
+
+  function start() {
+    if (kind === "pod") void startPod();
+    else if (kind === "node") void startNode();
+    else void startLocal();
+  }
+
+  const ready =
+    !busy &&
+    (kind === "pod" ? Boolean(namespace && pod) : kind === "node" ? Boolean(node) : true);
+
+  const namespaceOptions = (namespaces ?? []).map((n) => ({ value: n }));
+  const podOptions = (pods ?? []).map((p) => ({ value: p }));
+  const containerOptions = (containers ?? []).map((c) => ({
+    value: c.name,
+    label: c.running ? c.name : `${c.name} (not running)`,
+  }));
+  const nodeOptions = (nodes ?? []).map((n) => ({ value: n }));
+
+  return (
+    <Dialog
+      title="New session"
+      maxWidth={WIDTH}
+      onClose={onClose}
+      footer={
+        <>
+          <Button variant="secondary" size="sm" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button variant="primary" size="sm" disabled={!ready} onClick={start}>
+            Start session
+          </Button>
+        </>
+      }
+    >
+      <div className="flex flex-col gap-3 p-3">
+        {failure && <FailureAlert tone="sev" title={failure.title} error={failure.error} />}
+
+        <Field label="Kind">
+          <div className="flex gap-1.5" role="group" aria-label="Session kind">
+            {kindsFor(desktop).map((k) => (
+              <Button
+                key={k}
+                type="button"
+                variant={kind === k ? "primary" : "secondary"}
+                size="sm"
+                aria-pressed={kind === k}
+                onClick={() => setKind(k)}
+              >
+                {KIND_LABEL[k]}
+              </Button>
+            ))}
+          </div>
+        </Field>
+
+        {!desktop && (
+          // Said once for the whole menu, not per kind: a local shell is not
+          // drawn at all above (see `kindsFor`), so this is the one place the
+          // reason lives rather than something discovered per click.
+          <Alert tone="info" title="No local shell in the browser">
+            A local shell runs as srelens's own process on the machine it is running on — outside the
+            cluster and unbounded by its RBAC — so it is the only session kind the browser build does
+            not offer. Pod and node shells stay available: both are bounded by what the cluster lets
+            you do.
+          </Alert>
+        )}
+
+        {kind === "pod" && (
+          <div className="grid grid-cols-2 gap-x-3">
+            <Field label="Namespace">
+              <Select
+                value={namespace}
+                onValueChange={setNamespace}
+                options={namespaceOptions}
+                className="w-full"
+                disabled={namespaces === null}
+                placeholder={namespaces === null ? "Loading…" : "Choose a namespace"}
+              />
+            </Field>
+            <Field label="Pod">
+              <Select
+                value={pod}
+                onValueChange={setPod}
+                options={podOptions}
+                className="w-full"
+                disabled={!namespace || pods === null}
+                placeholder={
+                  !namespace ? "Pick a namespace first" : pods === null ? "Loading…" : "Choose a pod"
+                }
+              />
+            </Field>
+            <Field label="Container" className="col-span-2">
+              <Select
+                value={container}
+                onValueChange={setContainer}
+                options={containerOptions}
+                className="w-full"
+                disabled={!pod || containers === null}
+                placeholder={
+                  !pod
+                    ? "Pick a pod first"
+                    : containers === null
+                      ? "Loading…"
+                      : containerOptions.length === 0
+                        ? "Nothing here to shell into"
+                        : "Choose a container"
+                }
+              />
+            </Field>
+          </div>
+        )}
+
+        {kind === "node" && (
+          <Field label="Node">
+            <Select
+              value={node}
+              onValueChange={setNode}
+              options={nodeOptions}
+              className="w-full"
+              disabled={nodes === null}
+              placeholder={nodes === null ? "Loading…" : "Choose a node"}
+            />
+          </Field>
+        )}
+
+        {kind === "node" && (
+          <div className="text-[0.75rem] text-muted">
+            Creates a privileged debug pod on the node and enters its host namespaces; the shell
+            deletes it when the session ends.
+          </div>
+        )}
+
+        {kind === "local" && (
+          <div className="text-[0.75rem] text-muted">
+            {`Opens a shell on this machine, with KUBECONFIG scoped to ${context || "the active cluster"}.`}
+          </div>
+        )}
+      </div>
+    </Dialog>
+  );
+}
+
+/** The kinds this platform can actually start. `local` never appears in the
+ *  browser — see the component doc for why drawing it there would be wrong
+ *  even disabled. */
+function kindsFor(desktop: boolean): Kind[] {
+  return desktop ? ["pod", "node", "local"] : ["pod", "node"];
+}

--- a/packages/ui-next/src/screens/terminals/SessionRail.test.tsx
+++ b/packages/ui-next/src/screens/terminals/SessionRail.test.tsx
@@ -47,6 +47,22 @@ describe("SessionRail", () => {
     expect(screen.getByText("local · 22m")).not.toBeNull();
   });
 
+  it("gives the session's name a line of its own", () => {
+    // The rail is 230px and a row carries four things: a glyph, the name, the
+    // kind and idle time, and a state pill. Laid out on ONE line the name got
+    // 44px of 229 — two pods from the same namespace were told apart by four
+    // characters. §14 shows these stacked, and the widths are why.
+    //
+    // jsdom lays nothing out, so this asserts the mechanism: the name is not a
+    // flex sibling of the kind and the pill. Fourth time on this migration a
+    // width problem has been invisible to the suite.
+    const only = row();
+    render(<SessionRail sessions={[only]} activeId={only.id} onSelect={() => {}} onNewSession={() => {}} />);
+    const name = screen.getByText(only.title);
+    const kind = screen.getByText(/pod exec ·/);
+    expect(name.parentElement).not.toBe(kind.parentElement);
+  });
+
   it("marks the active session and no other, with more than one row on screen", () => {
     const sessions = [
       row({ id: 1, title: "first" }),

--- a/packages/ui-next/src/screens/terminals/SessionRail.test.tsx
+++ b/packages/ui-next/src/screens/terminals/SessionRail.test.tsx
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { TerminalSessionRow } from "../../lib/sessions";
+import { SessionRail, SESSION_RAIL_WIDTH, sessionRailHead } from "./SessionRail";
+
+/** A session row with every field a real one carries, overridable per test. */
+function row(overrides: Partial<TerminalSessionRow> = {}): TerminalSessionRow {
+  return {
+    id: 1,
+    kind: "pod",
+    title: "checkout-api-5c8b7f2d9-mk3wl · api",
+    context: "prod-eu",
+    namespace: "checkout",
+    state: "attached",
+    startedAt: 0,
+    lastOutputAt: 0,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("SessionRail", () => {
+  it("draws a row per session, its kind, and how long since it last spoke", () => {
+    const now = new Date("2026-08-25T00:10:00Z").getTime();
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    const sessions = [
+      row({ id: 1, kind: "pod", title: "checkout-api-5c8b7f2d9-mk3wl · api", state: "attached", lastOutputAt: now - 12_000 }),
+      row({ id: 2, kind: "node", title: "eu-w4-c3-standard-a1", state: "attached", lastOutputAt: now - 4 * 60_000 }),
+      row({ id: 3, kind: "local", title: "prod-eu context shell", state: "idle", lastOutputAt: now - 22 * 60_000 }),
+    ];
+
+    render(<SessionRail sessions={sessions} activeId={1} onSelect={vi.fn()} onNewSession={vi.fn()} />);
+
+    expect(screen.getByText("checkout-api-5c8b7f2d9-mk3wl · api")).not.toBeNull();
+    expect(screen.getByText("eu-w4-c3-standard-a1")).not.toBeNull();
+    expect(screen.getByText("prod-eu context shell")).not.toBeNull();
+    expect(screen.getByText("pod · 12s")).not.toBeNull();
+    expect(screen.getByText("node · 4m")).not.toBeNull();
+    expect(screen.getByText("local · 22m")).not.toBeNull();
+  });
+
+  it("marks the active session and no other, with more than one row on screen", () => {
+    const sessions = [
+      row({ id: 1, title: "first" }),
+      row({ id: 2, title: "second" }),
+      row({ id: 3, title: "third" }),
+    ];
+    render(<SessionRail sessions={sessions} activeId={2} onSelect={vi.fn()} onNewSession={vi.fn()} />);
+
+    const active = screen.getByRole("button", { current: true });
+    expect(active.textContent).toContain("second");
+    // Only one row carries the marker.
+    expect(screen.getAllByRole("button", { current: true })).toHaveLength(1);
+    const others = screen.getAllByRole("button").filter((b) => b !== active);
+    expect(others.every((b) => b.getAttribute("aria-current") !== "true")).toBe(true);
+  });
+
+  it("keeps a closed session listed, reading Closed rather than vanishing", () => {
+    const sessions = [
+      row({ id: 1, title: "still going", state: "attached" }),
+      row({ id: 2, title: "gave up", state: "closed", error: "exit 137" }),
+    ];
+    render(<SessionRail sessions={sessions} activeId={1} onSelect={vi.fn()} onNewSession={vi.fn()} />);
+
+    expect(screen.getByText("gave up")).not.toBeNull();
+    expect(screen.getByText("Closed")).not.toBeNull();
+  });
+
+  it("draws attached, idle and closed with three different verdicts, not one collapsed state", () => {
+    const sessions = [
+      row({ id: 1, title: "a", state: "attached" }),
+      row({ id: 2, title: "b", state: "idle" }),
+      row({ id: 3, title: "c", state: "closed" }),
+    ];
+    const { container } = render(
+      <SessionRail sessions={sessions} activeId={null} onSelect={vi.fn()} onNewSession={vi.fn()} />,
+    );
+
+    expect(container.querySelectorAll("[data-kind='success']")).toHaveLength(1);
+    expect(container.querySelectorAll("[data-kind='warning']")).toHaveLength(1);
+    expect(container.querySelectorAll("[data-kind='neutral']")).toHaveLength(1);
+  });
+
+  it("selecting a row hands the screen that session's id, not any other's", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    const sessions = [
+      row({ id: 11, title: "alpha" }),
+      row({ id: 22, title: "bravo" }),
+      row({ id: 33, title: "charlie" }),
+    ];
+    render(<SessionRail sessions={sessions} activeId={11} onSelect={onSelect} onNewSession={vi.fn()} />);
+
+    await user.click(screen.getByText("charlie"));
+
+    expect(onSelect).toHaveBeenCalledExactlyOnceWith(33);
+  });
+
+  it("an empty rail offers New session and says why it's empty", async () => {
+    const user = userEvent.setup();
+    const onNewSession = vi.fn();
+    render(<SessionRail sessions={[]} activeId={null} onSelect={vi.fn()} onNewSession={onNewSession} />);
+
+    expect(screen.getByText(/no sessions/i)).not.toBeNull();
+    const button = screen.getByRole("button", { name: "New session" });
+    await user.click(button);
+    expect(onNewSession).toHaveBeenCalledOnce();
+  });
+
+  it("names no width of its own beyond the exported constant", () => {
+    expect(SESSION_RAIL_WIDTH).toBe(230);
+  });
+});
+
+describe("sessionRailHead", () => {
+  it("counts only attached sessions, not idle or closed ones", () => {
+    const sessions = [
+      row({ id: 1, state: "attached" }),
+      row({ id: 2, state: "attached" }),
+      row({ id: 3, state: "idle" }),
+      row({ id: 4, state: "closed" }),
+    ];
+    expect(sessionRailHead(sessions)).toBe("Sessions · 2 attached");
+  });
+
+  it("reads zero attached rather than omitting the count", () => {
+    expect(sessionRailHead([row({ id: 1, state: "closed" })])).toBe("Sessions · 0 attached");
+  });
+
+  it("reads zero attached for an empty rail", () => {
+    expect(sessionRailHead([])).toBe("Sessions · 0 attached");
+  });
+});

--- a/packages/ui-next/src/screens/terminals/SessionRail.test.tsx
+++ b/packages/ui-next/src/screens/terminals/SessionRail.test.tsx
@@ -40,8 +40,10 @@ describe("SessionRail", () => {
     expect(screen.getByText("checkout-api-5c8b7f2d9-mk3wl · api")).not.toBeNull();
     expect(screen.getByText("eu-w4-c3-standard-a1")).not.toBeNull();
     expect(screen.getByText("prod-eu context shell")).not.toBeNull();
-    expect(screen.getByText("pod · 12s")).not.toBeNull();
-    expect(screen.getByText("node · 4m")).not.toBeNull();
+    // §14's own prose for the kind, off `SESSION_KIND_LABEL` — `pod` beside a
+    // pod's own name says nothing that `pod exec` does not say better.
+    expect(screen.getByText("pod exec · 12s")).not.toBeNull();
+    expect(screen.getByText("node shell · 4m")).not.toBeNull();
     expect(screen.getByText("local · 22m")).not.toBeNull();
   });
 

--- a/packages/ui-next/src/screens/terminals/SessionRail.tsx
+++ b/packages/ui-next/src/screens/terminals/SessionRail.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useState } from "react";
+import { ageFromTimestamp } from "@srelens/core";
+import { Button, EmptyState, Section, StatusPill, toneColor, toneWash, type StatusKind } from "@srelens/ui-kit";
+import { Icons } from "../../lib/icons";
+import type { SessionState, TerminalSessionRow } from "../../lib/sessions";
+
+/**
+ * §14's rail width, and this screen's alone — see `SideRail`'s note on why the
+ * width is a number per screen rather than a scale. Exported so the screen and
+ * this file cannot hold two different answers to the same question.
+ */
+export const SESSION_RAIL_WIDTH = 230;
+
+/**
+ * §14's rail head. A pure function of the rows rather than something this
+ * component prints itself: the head sits in `SideRail`'s own `head` slot,
+ * which the screen that mounts this rail owns, and a head computed in two
+ * places is two places that can disagree about what "attached" counts. This
+ * is the one place it is counted.
+ *
+ * Counts `attached` only — an `idle` session is still running but has not
+ * said anything lately, and §14's own worked example counts it out (four
+ * sessions, one idle, one closed, and the head still reads "2 attached").
+ */
+export function sessionRailHead(sessions: readonly TerminalSessionRow[]): string {
+  const attached = sessions.filter((s) => s.state === "attached").length;
+  return `Sessions · ${attached} attached`;
+}
+
+/**
+ * The word and tone this rail draws for each session state.
+ *
+ * THE ONE HAND-PAIRED WORD/TONE TABLE IN THIS FILE, AND IT IS MARKED BECAUSE
+ * IT SHOULD NOT HAVE TO EXIST. `../../lib/sessions.ts` says so on
+ * `SessionState` itself: core has a verdict for a Kubernetes resource
+ * (`k8sStatus`/`k8sHealth`) and for a log stream's connection
+ * (`logConnectionStatus`), and neither speaks about a shell session. Until
+ * core grows a `sessionStatus`, the pairing lives here — shaped the way
+ * `Toolbox.tsx`'s `TOOL_VERDICT` and `Forwards.tsx`'s `FORWARD_VERDICT`
+ * already are. **If a `sessionStatus` is ever added to `packages/core`,
+ * delete this and call it** — and do not add a second copy of it, here or
+ * anywhere else in this file.
+ *
+ * The severities follow §14's own dot colours: `attached` is the healthy
+ * state and reads ok; `idle` is still a running shell that has gone quiet,
+ * which is worth a glance rather than an alarm, so it reads warn rather than
+ * danger; `closed` is neither good nor bad, just over, so it reads neutral —
+ * the "faint" the design asks for is `StatusPill`'s own untinted plain text
+ * for a state `BAD` does not cover, not a fourth tone invented for it.
+ */
+export const SESSION_VERDICT: Record<SessionState, { word: string; kind: StatusKind }> = {
+  attached: { word: "Attached", kind: "success" },
+  idle: { word: "Idle", kind: "warning" },
+  closed: { word: "Closed", kind: "neutral" },
+};
+
+/** How often the idle time recomputes. Same resolution `Forwards`' Age column
+ *  ticks at, and for the same reason: a screen of live sessions is where a
+ *  frozen idle time is a lie the reader would act on. */
+const IDLE_TICK_MS = 1_000;
+
+/** "12s", "4m", "1h" — core's own compact age words, read off how long ago
+ *  this session last said anything. Not a duration this file invents: the
+ *  same `ageFromTimestamp` the Forwards screen's Age column already ticks. */
+function idleFor(lastOutputAt: number, now: number): string {
+  return ageFromTimestamp(new Date(lastOutputAt).toISOString(), now);
+}
+
+function SessionRow({
+  session,
+  active,
+  now,
+  onSelect,
+}: {
+  session: TerminalSessionRow;
+  active: boolean;
+  now: number;
+  onSelect: () => void;
+}) {
+  const verdict = SESSION_VERDICT[session.state];
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-current={active || undefined}
+      className="flex w-full items-center gap-1.5 rounded px-1 py-1.5 text-left"
+      style={{ background: active ? toneWash("accent") : undefined }}
+    >
+      <Icons.terminal
+        size={14}
+        aria-hidden="true"
+        className="shrink-0"
+        style={{ color: active ? toneColor("accent") : toneColor("muted") }}
+      />
+      <span className="min-w-0 flex-1 truncate text-[0.8125rem] font-medium">{session.title}</span>
+      <span className="shrink-0 text-[0.75rem] text-muted">
+        {session.kind} · {idleFor(session.lastOutputAt, now)}
+      </span>
+      <StatusPill status={verdict.word} kind={verdict.kind} tinted />
+    </button>
+  );
+}
+
+export interface SessionRailProps {
+  /** Every session this window knows about, running and closed, in the
+   *  order the store carries them — the store appends, so this is start
+   *  order and the rail draws it as given rather than re-sorting it. */
+  sessions: readonly TerminalSessionRow[];
+  /** The session the terminal pane is showing, or none. */
+  activeId: number | null;
+  /** A row was picked — make it the active session. */
+  onSelect: (id: number) => void;
+  /** "New session" was picked, from the empty state. */
+  onNewSession: () => void;
+}
+
+/**
+ * §14's left rail: every terminal session this window is holding open, and
+ * which one the pane is showing.
+ *
+ * **This is rail CONTENT, not the rail's frame.** Like `StreamRail` before it,
+ * it renders no `aside` and claims no width of its own beyond the
+ * {@link SESSION_RAIL_WIDTH} it exports — the screen wraps it in `SideRail`,
+ * heads it with {@link sessionRailHead}, and hands this component nothing but
+ * props. That is what "standalone" buys here: this file has no opinion about
+ * the terminal pane beside it, and nothing it does can go wrong from a screen
+ * that has not been written yet.
+ *
+ * **A closed session stays listed.** §349's lesson, arriving again: a vanished
+ * row is how a reader ends up assuming a dead session is fine. It draws with
+ * the same shape as any other row — its own {@link SESSION_VERDICT}, `Closed`,
+ * read plainly rather than dropped from the list.
+ *
+ * **The idle time ticks.** `lastOutputAt` is rounded to the second in the
+ * store precisely so a ticking display here does not churn its snapshot —
+ * this component owns the clock the store deliberately does not.
+ */
+export function SessionRail({ sessions, activeId, onSelect, onNewSession }: SessionRailProps) {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const tick = setInterval(() => setNow(Date.now()), IDLE_TICK_MS);
+    return () => clearInterval(tick);
+  }, []);
+
+  if (sessions.length === 0) {
+    return (
+      <EmptyState
+        compact
+        title="No sessions"
+        hint="Open a shell into a pod, a node, or this machine."
+        action={
+          <Button size="xs" onClick={onNewSession}>
+            New session
+          </Button>
+        }
+      />
+    );
+  }
+
+  return (
+    <Section padded={false}>
+      {sessions.map((session) => (
+        <SessionRow
+          key={session.id}
+          session={session}
+          active={session.id === activeId}
+          now={now}
+          onSelect={() => onSelect(session.id)}
+        />
+      ))}
+    </Section>
+  );
+}

--- a/packages/ui-next/src/screens/terminals/SessionRail.tsx
+++ b/packages/ui-next/src/screens/terminals/SessionRail.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { ageFromTimestamp } from "@srelens/core";
 import { Button, EmptyState, Section, StatusPill, toneColor, toneWash, type StatusKind } from "@srelens/ui-kit";
 import { Icons } from "../../lib/icons";
-import type { SessionState, TerminalSessionRow } from "../../lib/sessions";
+import type { SessionKind, SessionState, TerminalSessionRow } from "../../lib/sessions";
 
 /**
  * §14's rail width, and this screen's alone — see `SideRail`'s note on why the
@@ -54,6 +54,31 @@ export const SESSION_VERDICT: Record<SessionState, { word: string; kind: StatusK
   closed: { word: "Closed", kind: "neutral" },
 };
 
+/**
+ * §14's own prose for what a session IS — `pod exec`, `node shell`, `local`.
+ *
+ * **THIS IS NOT THE ELEVENTH HAND-PAIRED TABLE, and the difference is the
+ * tone.** The rule this migration keeps — the one that removed ten tables —
+ * is that every status WORD AND ITS SEVERITY comes from core: each of those
+ * ten paired a state with a meaning (healthy, degraded, failing), and a second
+ * copy of such a pairing is how a red dot ends up beside an amber word. A kind
+ * pairs with nothing. It says which of three things a session is, exactly the
+ * way a column header says what a column holds; there is no verdict in it, no
+ * tone to disagree with, and nothing core could ever be asked to decide —
+ * `SessionKind` is this store's own union, declared next to the emulator it
+ * belongs to. {@link SESSION_VERDICT} above is the table that carries tone,
+ * and it is the only one in this file.
+ *
+ * It exists at all because rendering the raw union member put `pod` on a row
+ * §14 writes as `pod exec` — and "pod" beside a pod's own name says nothing,
+ * where "pod exec" says what kind of shell the reader is looking at.
+ */
+export const SESSION_KIND_LABEL: Record<SessionKind, string> = {
+  pod: "pod exec",
+  node: "node shell",
+  local: "local",
+};
+
 /** How often the idle time recomputes. Same resolution `Forwards`' Age column
  *  ticks at, and for the same reason: a screen of live sessions is where a
  *  frozen idle time is a lie the reader would act on. */
@@ -94,7 +119,7 @@ function SessionRow({
       />
       <span className="min-w-0 flex-1 truncate text-[0.8125rem] font-medium">{session.title}</span>
       <span className="shrink-0 text-[0.75rem] text-muted">
-        {session.kind} · {idleFor(session.lastOutputAt, now)}
+        {SESSION_KIND_LABEL[session.kind]} · {idleFor(session.lastOutputAt, now)}
       </span>
       <StatusPill status={verdict.word} kind={verdict.kind} tinted />
     </button>

--- a/packages/ui-next/src/screens/terminals/SessionRail.tsx
+++ b/packages/ui-next/src/screens/terminals/SessionRail.tsx
@@ -108,20 +108,31 @@ function SessionRow({
       type="button"
       onClick={onSelect}
       aria-current={active || undefined}
-      className="flex w-full items-center gap-1.5 rounded px-1 py-1.5 text-left"
+      className="flex w-full items-start gap-1.5 rounded px-1 py-1.5 text-left"
       style={{ background: active ? toneWash("accent") : undefined }}
     >
       <Icons.terminal
         size={14}
         aria-hidden="true"
-        className="shrink-0"
+        className="mt-0.5 shrink-0"
         style={{ color: active ? toneColor("accent") : toneColor("muted") }}
       />
-      <span className="min-w-0 flex-1 truncate text-[0.8125rem] font-medium">{session.title}</span>
-      <span className="shrink-0 text-[0.75rem] text-muted">
-        {SESSION_KIND_LABEL[session.kind]} · {idleFor(session.lastOutputAt, now)}
+      {/* Stacked, because the rail is 230px and the row carries four things.
+          Laid out on one line the name got 44px of 229 — two pods from the
+          same namespace were told apart by four characters, which is no
+          telling apart at all. §14 draws these stacked and the widths are
+          why. `min-w-0` as well as `truncate`: a flex item's implicit
+          `min-width: auto` refuses to shrink below its content, so a long pod
+          name would widen the column rather than ellipsing. */}
+      <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="truncate text-[0.8125rem] font-medium">{session.title}</span>
+        <span className="flex items-center gap-1.5">
+          <span className="truncate text-[0.75rem] text-muted">
+            {SESSION_KIND_LABEL[session.kind]} · {idleFor(session.lastOutputAt, now)}
+          </span>
+          <StatusPill status={verdict.word} kind={verdict.kind} tinted />
+        </span>
       </span>
-      <StatusPill status={verdict.word} kind={verdict.kind} tinted />
     </button>
   );
 }

--- a/packages/ui-next/src/screens/terminals/TerminalView.test.tsx
+++ b/packages/ui-next/src/screens/terminals/TerminalView.test.tsx
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+
+/**
+ * The emulator this pane attaches is `terminalFor(id)` off the real session
+ * store — module-level, backed by core's `startPodExec`/`startLocalTerminal`.
+ * Only the backend boundary is faked (the same shape `lib/sessions.test.ts`
+ * uses); the store and the `Terminal` instance it hands out stay real, because
+ * this file's whole job is proving what happens to THAT instance across
+ * mount, resize and unmount.
+ */
+const startPodExec = vi.fn();
+const startLocalTerminal = vi.fn();
+vi.mock("@srelens/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@srelens/core")>();
+  return {
+    ...actual,
+    startPodExec: (...args: unknown[]) => startPodExec(...args),
+    startLocalTerminal: (...args: unknown[]) => startLocalTerminal(...args),
+  };
+});
+
+/**
+ * `@xterm/addon-fit` computes cell dimensions off a real canvas measurement,
+ * which jsdom cannot do — `proposeDimensions` reads `0` cell width there and
+ * `fit()` quietly no-ops (that's the "benign" half of jsdom's xterm warning).
+ * A real FitAddon would make "does the pane fit on mount / on resize" untestable
+ * here, so the addon itself is doubled with a spy; everything else about the
+ * emulator (attach, buffer, dispose) stays the real xterm instance.
+ */
+const { fitSpy } = vi.hoisted(() => ({ fitSpy: vi.fn() }));
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: class {
+    activate() {}
+    dispose() {}
+    fit() {
+      fitSpy();
+    }
+  },
+}));
+
+const {
+  __resetSessionsForTests,
+  startLocalSession,
+  terminalFor,
+} = await import("../../lib/sessions");
+const { TerminalView } = await import("./TerminalView");
+
+// jsdom has no `matchMedia`; xterm's `CoreBrowserService` reads it on open()
+// to watch the display's device pixel ratio, and throws without it.
+function stubMatchMedia(target: typeof globalThis) {
+  (target as unknown as { matchMedia: (query: string) => MediaQueryList }).matchMedia = (
+    query: string,
+  ) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }) as unknown as MediaQueryList;
+}
+stubMatchMedia(globalThis);
+if (typeof window !== "undefined") stubMatchMedia(window as unknown as typeof globalThis);
+
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
+/**
+ * Captures the callback every `ResizeObserver` created during a test was
+ * given, so a test can fire one by hand — jsdom never resizes anything on its
+ * own for a real observer to report.
+ */
+function fakeResizeObserver() {
+  const callbacks: Array<() => void> = [];
+  class FakeResizeObserver {
+    #cb: () => void;
+    constructor(cb: () => void) {
+      this.#cb = cb;
+      callbacks.push(cb);
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+  return { fire: () => callbacks.forEach((cb) => cb()) };
+}
+
+/** A session with a backend double that never resolves anything further —
+ *  enough for the store to hand out a live emulator to attach to. */
+async function openSession(): Promise<number> {
+  startLocalTerminal.mockImplementation(() => Promise.resolve({ send: vi.fn(), resize: vi.fn(), close: vi.fn() }));
+  return startLocalSession({ context: "kind-srelens-demo" });
+}
+
+beforeEach(() => {
+  startPodExec.mockReset();
+  startLocalTerminal.mockReset();
+  fitSpy.mockClear();
+  __resetSessionsForTests();
+});
+
+afterEach(() => {
+  cleanup();
+  __resetSessionsForTests();
+  vi.unstubAllGlobals();
+});
+
+describe("TerminalView", () => {
+  it("attaches the session's emulator to its own container", async () => {
+    const id = await openSession();
+    const term = terminalFor(id);
+
+    const { container } = render(<TerminalView sessionId={id} />);
+
+    // xterm's own root node, planted inside OUR div — proof `open()` (or the
+    // reattach path) actually ran against this pane's container, not just
+    // that the component rendered something.
+    expect(container.querySelector(".xterm")).not.toBeNull();
+    expect(term?.element?.parentElement).toBe(container.firstElementChild);
+  });
+
+  it("fits the pane on mount", async () => {
+    const id = await openSession();
+
+    render(<TerminalView sessionId={id} />);
+
+    expect(fitSpy).toHaveBeenCalled();
+  });
+
+  it("re-fits when the pane resizes", async () => {
+    const observer = fakeResizeObserver();
+    const id = await openSession();
+    render(<TerminalView sessionId={id} />);
+    fitSpy.mockClear();
+
+    observer.fire();
+
+    expect(fitSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not dispose the emulator on unmount, and a remount shows what was already written", async () => {
+    const id = await openSession();
+    const term = terminalFor(id);
+    if (!term) throw new Error("expected a live emulator");
+    const disposeSpy = vi.spyOn(term, "dispose");
+
+    const first = render(<TerminalView sessionId={id} />);
+    await new Promise<void>((resolve) => term.write("already here\r\n", resolve));
+    first.unmount();
+
+    // The whole property this task exists to protect: closing the pane must
+    // not touch the emulator the store owns.
+    expect(disposeSpy).not.toHaveBeenCalled();
+    // And the instance handed out is still the very same one — a store that
+    // rebuilt it would satisfy the dispose assertion by accident.
+    expect(terminalFor(id)).toBe(term);
+
+    // xterm's own render is debounced onto a `requestAnimationFrame`, so the
+    // buffer holding the line is not the same instant as the DOM showing it.
+    const second = render(<TerminalView sessionId={id} />);
+    await vi.waitFor(() => {
+      const line = second.container.querySelector(".xterm-rows")?.children[0]?.textContent;
+      expect(line).toContain("already here");
+    });
+  });
+});

--- a/packages/ui-next/src/screens/terminals/TerminalView.tsx
+++ b/packages/ui-next/src/screens/terminals/TerminalView.tsx
@@ -1,0 +1,62 @@
+import { useLayoutEffect, useRef } from "react";
+import { FitAddon } from "@xterm/addon-fit";
+import "@xterm/xterm/css/xterm.css";
+import { terminalFor } from "../../lib/sessions";
+
+/**
+ * The pane a live shell is drawn in — a pod exec, a node shell, or a local
+ * terminal, whichever session is selected.
+ *
+ * The emulator itself is `terminalFor(sessionId)`, owned by `lib/sessions.ts`.
+ * That store already wires the whole data path: `term.onData` reaches the
+ * PTY, `term.onResize` reaches it too, and the backend's output is written
+ * into the emulator as it arrives. This component's entire job is the DOM
+ * side of that: attach the emulator to this pane, keep it fit to the pane's
+ * size (which is what makes `onResize` fire with the right numbers), and let
+ * go of it on unmount.
+ *
+ * **Never call `.dispose()` here.** The emulator, and its scrollback, belong
+ * to the store — that is the whole reason a closed Terminals tab does not
+ * lose the shell's history. Only `endSession` may dispose it.
+ */
+export function TerminalView({ sessionId }: { sessionId: number }) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const term = terminalFor(sessionId);
+    const container = ref.current;
+    if (!term || !container) return undefined;
+
+    if (term.element) {
+      // Reattaching a session the reader left running: xterm's own `open()`
+      // no-ops once an emulator already has an element (it only adjusts
+      // which window it thinks it is in), so the existing node — with its
+      // rendered scrollback — is moved into this pane by hand instead of
+      // asking xterm to build a new one it would silently refuse to move.
+      container.appendChild(term.element);
+    } else {
+      term.open(container);
+    }
+
+    const fit = new FitAddon();
+    term.loadAddon(fit);
+    // Sets the emulator's cols/rows from this pane's own size, which fires
+    // `onResize` — already wired, by the store, to the PTY.
+    fit.fit();
+
+    const observer =
+      typeof ResizeObserver === "undefined" ? null : new ResizeObserver(() => fit.fit());
+    observer?.observe(container);
+
+    return () => {
+      observer?.disconnect();
+      // Unregisters the fit addon only — `FitAddon` has no state of its own
+      // worth keeping across a remount, and leaving it loaded would pile a
+      // fresh one onto the emulator every time this pane opens. The emulator
+      // itself is untouched: no `term.dispose()`, ever, here.
+      fit.dispose();
+    };
+  }, [sessionId]);
+
+  return <div ref={ref} className="min-h-0 flex-1" />;
+}

--- a/packages/ui-next/src/screens/terminals/TerminalView.tsx
+++ b/packages/ui-next/src/screens/terminals/TerminalView.tsx
@@ -58,5 +58,9 @@ export function TerminalView({ sessionId }: { sessionId: number }) {
     };
   }, [sessionId]);
 
-  return <div ref={ref} className="min-h-0 flex-1" />;
+  // `min-w-0` for the same reason as `min-h-0`: this box holds an element
+  // xterm sizes in explicit pixels, and a flex item's implicit
+  // `min-width: auto` would refuse to shrink below it — widening the pane
+  // instead of letting `FitAddon` narrow the terminal to fit.
+  return <div ref={ref} className="min-h-0 min-w-0 flex-1" />;
 }

--- a/packages/ui-next/src/shell/Nav.test.tsx
+++ b/packages/ui-next/src/shell/Nav.test.tsx
@@ -45,13 +45,31 @@ beforeEach(() => {
 const tabFor = (route: string) => currentWorkspace().tabs.find((t) => t.route === route);
 
 describe("Nav", () => {
-  it("lists a built-in kind and previews it in a tab", async () => {
+  it("keeps a tab per kind, so clicking four leaves four", async () => {
+    // The property, not the flag. Under the preview pattern each click
+    // replaced the last, so comparing four kinds left one tab — which is the
+    // opposite of what a tab strip is for.
+    render(<Nav contexts={[PROD]} />);
+
+    for (const kind of ["Pods", "Deployments", "Services", "Nodes"]) {
+      await userEvent.click(await screen.findByRole("treeitem", { name: kind }));
+    }
+
+    const routes = currentWorkspace().tabs.map((t) => t.route);
+    expect(routes).toContain("/k/pods");
+    expect(routes).toContain("/k/deployments");
+    expect(routes).toContain("/k/services");
+    expect(routes).toContain("/k/nodes");
+  });
+
+  it("lists a built-in kind and opens it in a tab of its own", async () => {
     render(<Nav contexts={[PROD]} />);
 
     await userEvent.click(await screen.findByRole("treeitem", { name: "Pods" }));
 
     const tab = tabFor("/k/pods");
-    expect(tab?.preview).toBe(true);
+    // Not a preview: a second kind must not replace the first.
+    expect(tab?.preview).toBeFalsy();
     expect(tab?.sub).toBe("prod-eu");
     expect(currentWorkspace().activeId).toBe(tab?.id);
   });
@@ -82,7 +100,7 @@ describe("Nav", () => {
 
     await userEvent.click(await screen.findByRole("treeitem", { name: "Incidents" }));
 
-    expect(tabFor("/incidents")?.preview).toBe(true);
+    expect(tabFor("/incidents")?.preview).toBeFalsy();
   });
 
   it("names the cluster and how it is linked", async () => {

--- a/packages/ui-next/src/shell/Nav.tsx
+++ b/packages/ui-next/src/shell/Nav.tsx
@@ -175,7 +175,12 @@ export function Nav({ contexts }: NavProps) {
               return;
             }
             const next = routeForNode(id, crds);
-            if (next) openTab(next, { preview: true, clusterName: ctx.name });
+            // A tab of its own, not a preview. The preview pattern — one
+            // italic tab the next click replaces — keeps a strip tidy while
+            // browsing, and it costs the reader the thing the strip is for:
+            // clicking four kinds to compare them left one tab, not four.
+            // The strip scrolls, so accumulating is affordable.
+            if (next) openTab(next, { clusterName: ctx.name });
           }}
           expanded={view.expanded}
           onExpandedChange={toggleExpanded}

--- a/packages/ui-next/src/shell/Status.test.tsx
+++ b/packages/ui-next/src/shell/Status.test.tsx
@@ -23,10 +23,24 @@ vi.mock("@srelens/core", async (orig) => ({
   },
 }));
 
+// The session store is ui-next's own (it holds the xterm instance core may
+// not depend on), but it is read the same way the forwards store is: a
+// module-level snapshot faked at the boundary rather than a real session
+// stood up through xterm.
+const sessions = vi.hoisted(() => ({ list: [] as unknown[], notify: new Set<() => void>() }));
+vi.mock("../lib/sessions", () => ({
+  getSessions: () => sessions.list,
+  subscribeSessions: (l: () => void) => {
+    sessions.notify.add(l);
+    return () => sessions.notify.delete(l);
+  },
+}));
+
 const ctx = { name: "prod-eu", stableId: "prod", cluster: "c", server: "", isCurrent: false };
 
 beforeEach(() => {
   forwards.list = [];
+  sessions.list = [];
   resetView();
   resetProbes();
 });
@@ -108,6 +122,40 @@ describe("Status", () => {
     forwards.list = [{ id: 1, status: "active" }];
     mount(<Status contexts={[ctx]} />);
     expect(screen.queryByRole("button", { name: /failed/i })).toBeNull();
+  });
+
+  it("counts idle sessions as live, alongside attached ones", () => {
+    setState(defaultState([ctx]));
+    // One of each running state. A count that only recognised `attached`
+    // would say "1 shell" here — the same number a bug that forgot `idle`
+    // would print — so this is the fixture that tells the two apart.
+    sessions.list = [
+      { id: 1, state: "attached" },
+      { id: 2, state: "idle" },
+    ];
+    mount(<Status contexts={[ctx]} />);
+    expect(screen.getByRole("button", { name: "2 shells" })).toBeDefined();
+  });
+
+  it("does not count a session that has closed", () => {
+    setState(defaultState([ctx]));
+    // Three rows, two live. The closed one stays out of the count but (unlike
+    // a dead forward, which this file has its own segment for) does not get
+    // one of its own here — the rail is where a reader goes to see why it died.
+    sessions.list = [
+      { id: 1, state: "attached" },
+      { id: 2, state: "idle" },
+      { id: 3, state: "closed" },
+    ];
+    mount(<Status contexts={[ctx]} />);
+    expect(screen.getByRole("button", { name: "2 shells" })).toBeDefined();
+  });
+
+  it("says nothing about shells when none are live", () => {
+    setState(defaultState([ctx]));
+    sessions.list = [{ id: 1, state: "closed" }];
+    mount(<Status contexts={[ctx]} />);
+    expect(screen.queryByRole("button", { name: /shell/i })).toBeNull();
   });
 
   it("opens the console from Ask", async () => {

--- a/packages/ui-next/src/shell/Status.tsx
+++ b/packages/ui-next/src/shell/Status.tsx
@@ -9,6 +9,7 @@ import {
 import { StatusBar, type StatusSegment } from "@srelens/ui-kit";
 import { useConsole } from "../console";
 import { useInfo } from "../lib/probe";
+import { getSessions, subscribeSessions } from "../lib/sessions";
 import { openTab, useActiveCluster } from "../lib/tabsStore";
 // The words and their tones live beside `LinkState` rather than here: the
 // overview rail reads the same link and must say the same thing about it.
@@ -17,7 +18,8 @@ import { LINK_TONE, LINK_WORD, useWorkspaceView } from "../lib/workspace";
 /**
  * The strip along the bottom of the window: which cluster this window is
  * looking at, what version it runs, whether it is reachable, how many
- * port-forwards are up, and the way in to the console.
+ * port-forwards are up, how many shells are still running, and the way in to
+ * the console.
  *
  * Every readout here is somebody else's fact — the tab store's active cluster,
  * the probe's version, the workspace view's link state, core's forwards — so
@@ -35,6 +37,11 @@ import { LINK_TONE, LINK_WORD, useWorkspaceView } from "../lib/workspace";
  * and must survive this component unmounting, so subscribing to it is the whole
  * of the wiring — a copy in ui-next would be a second answer to the same
  * question.
+ *
+ * The shell count follows the same shape, off `lib/sessions`' store instead —
+ * that one is ui-next's own rather than core's (it holds the xterm instance),
+ * but read the same way: `useSyncExternalStore` over a module-level snapshot,
+ * so a session outliving the Terminals screen keeps being counted here too.
  */
 export function Status({ contexts }: { contexts: ClusterContext[] }) {
   const activeId = useActiveCluster();
@@ -42,6 +49,7 @@ export function Status({ contexts }: { contexts: ClusterContext[] }) {
   const { links } = useWorkspaceView();
   const { setOpen } = useConsole();
   const forwards = useSyncExternalStore(subscribeForwards, getForwards, getForwards);
+  const sessions = useSyncExternalStore(subscribeSessions, getSessions, getSessions);
 
   // Found rather than assumed: the active id is persisted and the context list
   // is whatever the machine has now, so an id can outlive the context it named.
@@ -56,6 +64,11 @@ export function Status({ contexts }: { contexts: ClusterContext[] }) {
   // dangerous in the first place.
   const dead = forwards.filter(isForwardEnded).length;
   const n = forwards.length - dead;
+  // Idle is running — a session naps after a minute of quiet and is still
+  // there to type into. Only `closed` is dead, and a closed row stays on the
+  // rail to show what died and why; counting it here would say a shell is
+  // alive when it is not, the same lesson the tunnel above already carries.
+  const liveSessions = sessions.filter((s) => s.state !== "closed").length;
 
   const segments: StatusSegment[] = [
     {
@@ -95,18 +108,28 @@ export function Status({ contexts }: { contexts: ClusterContext[] }) {
       onSelect: () => openTab("/forwards"),
     });
   }
-  end.push(
-    {
-      id: "pf",
-      label: `${n} port-forward${n === 1 ? "" : "s"}`,
+  end.push({
+    id: "pf",
+    label: `${n} port-forward${n === 1 ? "" : "s"}`,
+    tone: "info",
+    // A dot for "something is running", so the strip reads as live at a
+    // glance; none at zero, where there is nothing to be live about.
+    dot: n > 0,
+    onSelect: () => openTab("/forwards"),
+  });
+  // Absent at zero, same as the dead-forward segment above: a `0 shells`
+  // readout is noise on a strip already carrying five of them, and there is
+  // nothing live to send the reader to `/terminals` for.
+  if (liveSessions > 0) {
+    end.push({
+      id: "shells",
+      label: plural(liveSessions, "shell"),
       tone: "info",
-      // A dot for "something is running", so the strip reads as live at a
-      // glance; none at zero, where there is nothing to be live about.
-      dot: n > 0,
-      onSelect: () => openTab("/forwards"),
-    },
-    { id: "ask", label: "Ask", tone: "accent", onSelect: () => setOpen(true) },
-  );
+      dot: true,
+      onSelect: () => openTab("/terminals"),
+    });
+  }
+  end.push({ id: "ask", label: "Ask", tone: "accent", onSelect: () => setOpen(true) });
 
   return <StatusBar segments={segments} end={end} />;
 }

--- a/packages/ui-next/src/shell/Window.test.tsx
+++ b/packages/ui-next/src/shell/Window.test.tsx
@@ -475,6 +475,22 @@ describe("Window contexts", () => {
   });
 });
 
+describe("Window — the shell's own widths", () => {
+  it("lets the screen column shrink, so the tab strip scrolls instead of overflowing", async () => {
+    // `TabStrip`'s tablist is `overflow-x-auto` and is meant to scroll under
+    // the new-tab and overflow controls. It never got the chance: this column
+    // had no `min-w-0`, so a wide screen widened it, the strip grew with it,
+    // and the controls went off the right edge of the window. Photographed
+    // with eight tabs open and a terminal on screen.
+    //
+    // jsdom lays nothing out, so this pins the mechanism. Sixth time this
+    // exact property has bitten on this migration.
+    await booted();
+    const column = document.querySelector('[data-slot="screen-column"]');
+    expect(column?.className ?? "").toContain("min-w-0");
+  });
+});
+
 describe("Window — what boot has to ask for", () => {
   it("asks the backend what is still forwarding, whatever route it opens on", async () => {
     // The forwards store is module-level JavaScript and a browser reload

--- a/packages/ui-next/src/shell/Window.tsx
+++ b/packages/ui-next/src/shell/Window.tsx
@@ -335,7 +335,14 @@ export function Window({
       <div className="flex min-h-0 flex-1">
         {active && <Rail contexts={contexts} error={contextsError} onConnect={() => openTab("/connect")} />}
         {active && <Nav contexts={contexts} />}
-        <div className="flex min-h-0 flex-1 flex-col">
+        {/* `min-w-0` as well as `min-h-0`. This column holds the tab strip
+            and the screen, and a flex item's implicit `min-width: auto`
+            refuses to shrink below its content — so a wide screen widens the
+            column, and `TabStrip`'s `overflow-x-auto` never engages because
+            the box it would scroll inside has grown to fit. The strip then
+            pushes its own new-tab and overflow controls off the window, which
+            is where the user meets it. */}
+        <div data-slot="screen-column" className="flex min-h-0 min-w-0 flex-1 flex-col">
           {active && (
             <TabStrip
               tabs={tabs}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,6 +311,9 @@ importers:
       '@srelens/ui-kit':
         specifier: workspace:*
         version: link:../ui-kit
+      '@xterm/xterm':
+        specifier: ^5.5.0
+        version: 5.5.0
       lucide-react:
         specifier: ^1.22.0
         version: 1.22.0(react@19.2.7)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,6 +311,9 @@ importers:
       '@srelens/ui-kit':
         specifier: workspace:*
         version: link:../ui-kit
+      '@xterm/addon-fit':
+        specifier: ^0.10.0
+        version: 0.10.0(@xterm/xterm@5.5.0)
       '@xterm/xterm':
         specifier: ^5.5.0
         version: 5.5.0

--- a/scripts/screenshot.mjs
+++ b/scripts/screenshot.mjs
@@ -400,6 +400,9 @@ const TITLES = {
   "/logs": ["Logs", "logs"],
   "/helm": ["Helm", "helm"],
   "/forwards": ["Port forwards", "forwards"],
+  // "Shell", not "Terminals": the tab strip names what the tab IS, and the
+  // screen's own heading is the longer word. `CLUSTER_SCOPED` in routes.ts.
+  "/terminals": ["Shell", "terminal"],
   "/toolbox": ["Toolbox", "toolbox"],
   "/topology": ["Topology", "topology"],
   "/incidents": ["Incidents", "incidents"],


### PR DESCRIPTION
Step 7 of the migration epic (#305), the second of three specs — Terminals at `/terminals`. Follows #349 (port forwards, toolbox). Spec 3 takes Helm, the last of classic's dock kinds.

A rail of shell sessions and a live PTY: into a pod, onto a node, or on this machine.

## The dock question the Logs spec deferred, answered by the design

The Logs spec left this open: *"Classic's Logs is one tab of a bottom dock beside terminals and Helm ops. Those are step 7 and step 9; this screen does not build a dock for itself."*

§1 describes the shell as **titlebar → (hotbar | sidebar | [tab strip → screen → agent dock]) → status bar**, and §7, §8, §12 and §15 each say "no bottom dock" outright. The only dock in the new design is the **agent** dock — a ⌘K prompt with a transcript, which is step 9's.

**So classic's `Dock` is not ported. It is dispersed**, and two thirds of that had already happened: `logs` became a screen in #344, `helm` becomes spec 3. Its tab strip reappears as §14's 230px session rail. The container disappears; nothing it held does.

## Sessions outlive the screen

Closing the Terminals tab leaves your shells running; reopening shows them. A PTY holds a `cd`, exported variables, a running `psql` — losing that to a tab close is a real loss, and classic's dock never did it.

**That is why the store keeps the xterm instance, and why it is in `ui-next` rather than core.** The spec said "a module-level store, the way port-forwards do" — forwards' store is in core, and core holds no DOM. An emulator disposed on unmount takes its scrollback with it, so a reopened tab would show an attached shell with no history: exactly the outcome the spec used to argue against adopting orphaned sessions. The plan corrected the spec on this.

Two consequences, both from #349's lessons arriving early:

- **The status bar counts live shells** (`N shells`), because a running shell nobody can see is how an orphaned process happens. `idle` is live; only `closed` is dead.
- **A session that ends stays listed as `closed`, carrying why** — deleting the row is how a reader assumes a dead thing is fine.

## Two backend truths that shaped this

**The local shell is the only web-denied command in the entire application:**

```rust
pub const WEB_DENIED_COMMANDS: &[&str] = &["start_terminal"];
```

A *local* PTY on the server is a shell on the shared host as the server's UID — it escapes the cluster and no RBAC bounds it. Pod exec is different: a shell inside a container, which the cluster decides you may have. So pod and node sessions are offered everywhere and a local shell is desktop-only, drawn only where it works.

**And a spec decision turned out to be already true.** The spec said an orphaned session should be closed rather than adopted. `crates/server/src/users.rs:246` has done exactly that since July — `user_connection_count(user_id) == 0 && !has_active_forwards(user_id)`, with a grace period and a guard this branch did not ask for. The task added the exec-specific coverage that was missing and changed no production code.

## A node shell leaves an object in your cluster

A node shell runs `nsenter` in a **privileged debug pod srelens creates**. It must be deleted when the session ends, and now that sessions outlive the screen, that obligation moved into the store.

This is the only cleanup here that leaves something **in the cluster** if missed; every other leak is a local process. The store captures the pod's identity *before* awaiting the connect, so a session ended mid-open still cleans up, and reads-and-deletes its map entry synchronously so a second `endSession` cannot double-delete.

## A dead shell now says why

Opening a shell into coredns — which has no `/bin/sh` — gave a blank pane, a grey `CLOSED`, and no reason.

`crates/kube/src/exec.rs` broke its loop when stdout closed and returned `Ok(())`, never consulting the Kubernetes exec protocol's **status channel**. A shell that failed to start was indistinguishable from a clean `exit`. It now reads the status and surfaces the cluster's own sentence — `command terminated with exit code 126` — unrewritten, so `describeError` can classify it and the reader can see it is the image, not their permissions.

A clean exit stays clean, and a *missing* status invents nothing: an absence is not evidence, the same rule that makes a missing metric read "no reading" rather than zero.

## Four things found by looking, not by testing

- **The session rail shipped broken.** Four items across 230px gave the pod name 44px of 229 — two pods from one namespace told apart by four characters. §14 stacks them and the widths are why.
- **The terminal pane pushed the rail off the window.** It carried `min-h-0` and not `min-w-0`; xterm sizes its content in explicit pixels, so the pane grew to the terminal's width. `FitAddon` could never narrow it, because the box it measures was being widened by the thing it was measuring.
- **The tab strip overflowed instead of scrolling.** `TabStrip` was already built to scroll — its tablist is `min-w-0 flex-1 overflow-x-auto` with comments explaining that tabs scroll under the controls. The column holding it lacked `min-w-0`, so a wide screen widened the column and `overflow-x-auto` had nothing to overflow. The strip's design was right; what it sat in was not.
- **Both headers advertised an action nobody could see.** `AskChip` is the *row* chip: `.row-ask` is `opacity: 0` until a table row is hovered, and a header has no row. `Events.tsx` and `Overview.tsx` already use a `Button` and say why; **Logs has carried the invisible chip since #344**.

Those are the third through sixth instances of one property on this migration — a flex item's implicit `min-width: auto` refusing to shrink below its content — after the events Message column and the overview's CPU meter. jsdom lays nothing out, so every one was invisible to a green suite. The tests pin the mechanism; the screenshots are the check.

## Also

**Each resource opens its own tab.** The sidebar opened every route as a preview — one italic tab the next click replaced — so clicking Pods, then Deployments, then Services left one tab and two kinds could never be compared. Not a regression from this work: the preview call predates it. It is a decision reversed, and the scroll fix above is what made reversing it affordable.

**`Open shell` reaches a live session**, verified end to end: boot with only `/` and `/k/pods`, right-click a pod, pick `Open shell` — `/terminals` opens with `SESSIONS · 1 ATTACHED` and a prompt in the transcript. This dead-route shape has shipped broken twice (#344 needed #346; #349 needed a follow-up inside itself) and this is the first spec to fix it before release. A multi-container pod asks which container; a single-container pod does not.

## Gates

3,721 tests across core, the kit and ui-next; 730 in classic, unchanged; 389 + 137 + 38 across the Rust crates; four projects typechecking; coverage 91.9 / 88.1 / 81.3 against floors of 85 / 80 / 76; `dist/index.html` links no stylesheet.

## Known

- **The tab-strip scroll is reasoned and test-pinned, not photographed.** The screenshot harness drives controls by visible text and the new-tab control is an icon, so the many-tab case could not be reproduced to capture. The cause is unambiguous and the fix is one property, but the confirming look is outstanding.
- **The dead-shell fix is not exercised against a live cluster.** `status_error` is unit-tested and the wiring was verified by reading kube-rs's vendored source, not by a real exec into a shell-less container. Worth a manual pass.
- **`Terminals.tsx` titles the alert "This session ended"**, which reads oddly for a shell that never *started*. Driving it from `describeError(...).title` would read better.
- **A `Logs.test.tsx` flake** reddens roughly one full-suite run in six. Pre-existing and unrelated to this branch, but it can redden CI here.
- **`/resources/<name>/shell` still parses** though nothing mints it, so a tab persisted by an older session can still name itself.
