### PR TITLE
feat(ui-next): the helm screen

### DIFF
--- a/apps/desktop/src/components/AppearanceSettingsSection.test.tsx
+++ b/apps/desktop/src/components/AppearanceSettingsSection.test.tsx
@@ -91,6 +91,15 @@ describe("AppearanceSettingsSection", () => {
     expect(items).toContain("Terminals");
   });
 
+  it("lists Helm, whose operations run on after the dialog that started them", () => {
+    // The release table, the diff pane and the four operations. An upgrade or
+    // a rollback outlives its dialog, so a reader weighing the toggle is
+    // weighing whether they can drive Helm at all in the new design.
+    render(<AppearanceSettingsSection />);
+    const items = screen.getAllByRole("listitem").map((li) => li.textContent);
+    expect(items).toContain("Helm");
+  });
+
   it("lists the toolbox, the only screen that is about the machine and not a cluster", () => {
     // The managed kubectl, helm and krew under ~/.srelens/bin, plus what a
     // context's exec-auth needs. Nothing about it is cluster-scoped, so a

--- a/apps/desktop/src/design.test.ts
+++ b/apps/desktop/src/design.test.ts
@@ -64,6 +64,7 @@ describe("the list of ported screens", () => {
       "/logs",
       "/forwards",
       "/terminals",
+      "/helm",
       "/toolbox",
     ]);
   });
@@ -79,6 +80,7 @@ describe("the list of ported screens", () => {
       "Logs",
       "Port forwards",
       "Terminals",
+      "Helm",
       "Toolbox",
     ]);
   });

--- a/apps/desktop/src/design.ts
+++ b/apps/desktop/src/design.ts
@@ -224,6 +224,11 @@ export const PORTED_SCREENS: ReadonlyArray<{ route: string; name: string }> = [
   // because it shares their shape — a session outlives the tab that started
   // it, so this screen is where the ones already running are seen and ended.
   { route: "/terminals", name: "Terminals" },
+  // The release table, the rendered diff between two revisions, and the four
+  // operations. Listed with forwards and terminals because it shares their
+  // shape: an upgrade or a rollback outlives the dialog that started it, and
+  // the status strip counts the ones still running.
+  { route: "/helm", name: "Helm" },
   // The only screen here that is about the machine rather than a cluster: the
   // managed kubectl, helm and krew under ~/.srelens/bin, and what the active
   // context's exec-auth needs on PATH.

--- a/crates/kube/src/helm.rs
+++ b/crates/kube/src/helm.rs
@@ -149,6 +149,11 @@ pub struct GetHelmReleaseIn {
     pub context: String,
     pub namespace: String,
     pub name: String,
+    /// The revision to read. Omitted means the current one, exactly as
+    /// before this field existed — every caller that doesn't know about
+    /// revisions keeps getting what it always got.
+    #[serde(default)]
+    pub revision: Option<i64>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -179,6 +184,25 @@ pub struct HelmReleaseDetail {
     pub notes: String,
     /// All revisions, newest first.
     pub history: Vec<HelmRevision>,
+}
+
+/// Pick one revision's decoded release object out of a release's history
+/// (`revisions` is newest first). `None` asks for the current revision —
+/// `revisions[0]`, exactly what this capability returned before it could
+/// be asked for anything else. `Some(n)` for a revision that isn't in the
+/// list is an error, not a fallback to the current one: silently returning
+/// the current revision would make a diff of two revisions compare a
+/// manifest with itself and report no changes on a release that changed.
+fn pick_revision(revisions: &[Value], requested: Option<i64>) -> Result<&Value, CapabilityError> {
+    match requested {
+        None => revisions
+            .first()
+            .ok_or_else(|| CapabilityError::Handler("no revisions available".to_string())),
+        Some(rev) => revisions
+            .iter()
+            .find(|v| v.get("version").and_then(Value::as_i64) == Some(rev))
+            .ok_or_else(|| CapabilityError::Handler(format!("revision {rev} not found"))),
+    }
 }
 
 /// `k8s.getHelmRelease` — full detail of a release: values, manifest, history.
@@ -217,7 +241,7 @@ pub fn get_helm_release_capability(cache: Arc<ClientCache>) -> Capability {
                     })
                     .collect();
 
-                let current = &revisions[0];
+                let current = pick_revision(&revisions, input.revision)?;
                 let sum = summarise_release(current);
                 let values_yaml = match current.get("config") {
                     Some(cfg) if !cfg.is_null() => serde_yaml::to_string(cfg).unwrap_or_default(),
@@ -270,6 +294,60 @@ mod tests {
         let raw = STANDARD.encode(r#"{"name":"nginx","version":1}"#).into_bytes();
         let v = decode_release(&raw).unwrap();
         assert_eq!(v["name"], "nginx");
+    }
+
+    fn revision_json(version: i64, manifest: &str) -> Value {
+        serde_json::from_str(&format!(
+            r#"{{"name":"redis","namespace":"cache","version":{version},
+                "info":{{"status":"deployed","last_deployed":"2026-07-01T00:00:00Z"}},
+                "manifest":"{manifest}"}}"#
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn get_helm_release_in_defaults_revision_to_none_when_absent() {
+        // The wire shape existing callers already send — no `revision` key at
+        // all. This must keep deserialising exactly as it did before this
+        // field existed.
+        let input: GetHelmReleaseIn = serde_json::from_str(
+            r#"{"context":"kind-dev","namespace":"cache","name":"redis"}"#,
+        )
+        .unwrap();
+        assert_eq!(input.revision, None);
+    }
+
+    #[test]
+    fn pick_revision_returns_the_named_revision() {
+        let revisions = vec![revision_json(119, "manifest-119"), revision_json(118, "manifest-118")];
+        let picked = pick_revision(&revisions, Some(118)).unwrap();
+        assert_eq!(picked["manifest"], "manifest-118");
+        assert_eq!(picked["version"], 118);
+    }
+
+    #[test]
+    fn pick_revision_omitted_returns_the_current_one() {
+        // Newest-first, exactly as `k8s.getHelmRelease` has always returned
+        // when no revision was asked for.
+        let revisions = vec![revision_json(119, "manifest-119"), revision_json(118, "manifest-118")];
+        let picked = pick_revision(&revisions, None).unwrap();
+        assert_eq!(picked["manifest"], "manifest-119");
+        assert_eq!(picked["version"], 119);
+    }
+
+    #[test]
+    fn pick_revision_missing_reports_the_error_instead_of_falling_back() {
+        // The property that matters most: a revision that does not exist
+        // must not silently resolve to the current one. That would make the
+        // diff pane compare a manifest with itself and render "no changes"
+        // about a release that changed.
+        let revisions = vec![revision_json(119, "manifest-119"), revision_json(118, "manifest-118")];
+        let err = pick_revision(&revisions, Some(42)).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("42"), "error should name the missing revision: {msg}");
+
+        // The load-bearing part: never the current revision's manifest.
+        assert!(pick_revision(&revisions, Some(42)).is_err());
     }
 
     #[test]

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,6 +31,7 @@ export * from "./lib/exec";
 export * from "./lib/files";
 export * from "./lib/forward";
 export * from "./lib/helm";
+export * from "./lib/helmStatus";
 export * from "./lib/k8sCapacity";
 export * from "./lib/k8sContainer";
 export * from "./lib/k8sHealth";

--- a/packages/core/src/lib/helm.test.ts
+++ b/packages/core/src/lib/helm.test.ts
@@ -13,7 +13,7 @@ vi.mock("../transport/transport", async (importOriginal) => {
   };
 });
 
-import { helmUpgrade, helmRollback, helmVersion, helmSearchRepo, diffTextLines, startHelmOp } from "./helm";
+import { helmUpgrade, helmRollback, helmVersion, helmSearchRepo, diffTextLines, startHelmOp, getHelmRelease } from "./helm";
 
 beforeEach(() => {
   invokeCommandMock.mockReset();
@@ -67,6 +67,28 @@ describe("helm write wrappers", () => {
     const invoke = vi.fn().mockRejectedValue(new Error("helm not found on PATH"));
     const r = await helmSearchRepo("ctx", "nginx", invoke);
     expect(r.error).toContain("helm not found");
+  });
+});
+
+describe("getHelmRelease", () => {
+  it("omits the revision key entirely when none is given", async () => {
+    const invoke = vi.fn().mockResolvedValue({ name: "web" });
+    await getHelmRelease("ctx", "apps", "web", invoke);
+    expect(invoke).toHaveBeenCalledWith("k8s.getHelmRelease", { context: "ctx", namespace: "apps", name: "web" });
+    const payload = invoke.mock.calls[0][1] as Record<string, unknown>;
+    expect("revision" in payload).toBe(false);
+  });
+
+  it("passes a given revision through to the payload", async () => {
+    const invoke = vi.fn().mockResolvedValue({ name: "web" });
+    await getHelmRelease("ctx", "apps", "web", invoke, 118);
+    expect(invoke).toHaveBeenCalledWith("k8s.getHelmRelease", { context: "ctx", namespace: "apps", name: "web", revision: 118 });
+  });
+
+  it("surfaces errors", async () => {
+    const invoke = vi.fn().mockRejectedValue(new Error("release not found"));
+    const r = await getHelmRelease("ctx", "apps", "web", invoke);
+    expect(r.error).toContain("release not found");
   });
 });
 

--- a/packages/core/src/lib/helm.ts
+++ b/packages/core/src/lib/helm.ts
@@ -44,18 +44,23 @@ export async function listHelmReleases(
   }
 }
 
-/** Fetch a Helm release's values, manifest, and history via `k8s.getHelmRelease`. */
+/** Fetch a Helm release's values, manifest, and history via `k8s.getHelmRelease`.
+ * Omitting `revision` sends no `revision` key at all, so the wire is
+ * byte-identical for every caller that never asked for a specific revision —
+ * the backend's `#[serde(default)]` only treats an *absent* key as "current". */
 export async function getHelmRelease(
   context: string,
   namespace: string,
   name: string,
   invoke: Invoker = invokeCapability,
+  revision?: number,
 ): Promise<{ release?: HelmReleaseDetail; error?: string }> {
   try {
     const release = await invoke<HelmReleaseDetail>("k8s.getHelmRelease", {
       context,
       namespace,
       name,
+      ...(revision != null ? { revision } : {}),
     });
     return { release };
   } catch (e) {

--- a/packages/core/src/lib/helmStatus.test.ts
+++ b/packages/core/src/lib/helmStatus.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { helmStatus } from "./helmStatus";
+
+describe("helmStatus", () => {
+  it("reads a deployed release as healthy", () => {
+    expect(helmStatus("deployed")).toEqual({ word: "deployed", health: "success" });
+  });
+
+  it("reads a failed release as danger", () => {
+    expect(helmStatus("failed")).toEqual({ word: "failed", health: "danger" });
+  });
+
+  it.each(["pending-install", "pending-upgrade", "pending-rollback"])(
+    "reads %s as in-progress — neither healthy nor broken",
+    (status) => {
+      const { health } = helmStatus(status);
+      expect(health).not.toBe("success");
+      expect(health).not.toBe("danger");
+      expect(health).toBe("warning");
+    },
+  );
+
+  it("reads uninstalling as in-progress, the same tone as the pending-* states", () => {
+    expect(helmStatus("uninstalling").health).toBe("warning");
+  });
+
+  it("does not read superseded as a failure — an older revision replaced is ordinary", () => {
+    const { health } = helmStatus("superseded");
+    expect(health).not.toBe("danger");
+    expect(health).toBe("neutral");
+  });
+
+  it("does not read uninstalled as a failure either — the release is simply gone", () => {
+    const { health } = helmStatus("uninstalled");
+    expect(health).not.toBe("danger");
+    expect(health).toBe("neutral");
+  });
+
+  it("renders an unfamiliar status as the word Helm gave, toned neutral", () => {
+    // Deliberately free of "fail" and "deploy" as substrings: a fixture that
+    // happened to contain either would pass even if the fallback secretly
+    // matched on substring rather than on the full word.
+    expect(helmStatus("canary-preview")).toEqual({ word: "canary-preview", health: "neutral" });
+  });
+
+  it("does not crash on the empty string, and reads it neutral", () => {
+    expect(helmStatus("")).toEqual({ word: "", health: "neutral" });
+  });
+
+  it("never invents a word — the word is always exactly what was passed in", () => {
+    expect(helmStatus("deployed").word).toBe("deployed");
+    expect(helmStatus("pending-upgrade").word).toBe("pending-upgrade");
+    expect(helmStatus("something-new").word).toBe("something-new");
+  });
+});

--- a/packages/core/src/lib/helmStatus.ts
+++ b/packages/core/src/lib/helmStatus.ts
@@ -1,0 +1,69 @@
+/**
+ * A Helm release's status word and tone.
+ *
+ * Follows `packages/core/src/lib/k8sStatus.ts`'s shape, but for a narrower
+ * reason: a Kubernetes resource's status is srelens's own reading of raw
+ * fields, so that file invents words ("Degraded", "Not scheduled") and pairs
+ * them with a tone it decides. A Helm release's status is not srelens's to
+ * invent — `info.status` in the release Secret is Helm's own vocabulary, and
+ * `crates/kube/src/helm.rs` passes it straight through with no enum in
+ * between. This module never renames it; it only tones it.
+ *
+ * Helm's documented statuses are `deployed`, `failed`, `pending-install`,
+ * `pending-upgrade`, `pending-rollback`, `superseded`, `uninstalling`,
+ * `uninstalled`. That set is Helm's to extend, not srelens's to close: a
+ * future Helm release could add a ninth word to that Secret tomorrow, and
+ * this module must not pretend to recognise one it does not.
+ */
+import type { HealthKind } from "./k8sHealth";
+
+/** A release's status word and its tone. */
+export interface HelmVerdict {
+  /** Exactly the string Helm gave — never renamed, never paraphrased. */
+  word: string;
+  /** Tone for the word. */
+  health: HealthKind;
+}
+
+/**
+ * Tone for each of Helm's eight documented statuses.
+ *
+ * `deployed` is the only state this reads as healthy, and `failed` the only
+ * one it reads as broken. Everything else is a state in between, toned by
+ * what it actually means rather than by a blanket "anything but deployed is
+ * bad" rule:
+ *
+ * - The three `pending-*` states and `uninstalling` are a mutation in
+ *   progress — not yet a success, not yet a failure. Reading them as
+ *   `danger` would paint a normal `helm upgrade` mid-flight as broken.
+ * - `superseded` means an older revision was replaced by a newer one — the
+ *   ordinary shape of a release with history, not a problem with this one.
+ * - `uninstalled` is a release that is simply gone, not a release that
+ *   failed to be gone.
+ *
+ * A status not in this table is one this build has never heard of, and is
+ * toned the same as those two: neutral. Not healthy — it might be a failure
+ * this table has no name for — and not broken — it might be perfectly fine.
+ * The same rule that leaves a missing metric reading "no reading" rather
+ * than `0%`.
+ */
+const HELM_HEALTH: Record<string, HealthKind> = {
+  deployed: "success",
+  failed: "danger",
+  "pending-install": "warning",
+  "pending-upgrade": "warning",
+  "pending-rollback": "warning",
+  uninstalling: "warning",
+  superseded: "neutral",
+  uninstalled: "neutral",
+};
+
+/**
+ * A release's status word and tone. `status` is returned verbatim as
+ * `word` — this function never invents or paraphrases Helm's word — and
+ * `health` comes from {@link HELM_HEALTH}; anything not in that table,
+ * including the empty string, reads neutral rather than throwing.
+ */
+export function helmStatus(status: string): HelmVerdict {
+  return { word: status, health: HELM_HEALTH[status] ?? "neutral" };
+}

--- a/packages/ui-kit/src/DiffLines.test.tsx
+++ b/packages/ui-kit/src/DiffLines.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { DiffLines, type DiffRow } from "./DiffLines";
+
+/**
+ * `DiffLines` draws a `DiffRow[]` — same/insert/delete/replace — in the
+ * design's tones. The trap this exists to catch: a `replace` row carries
+ * *both* `left` and `right` on one object, and a component that does not
+ * special-case it will either drop a side or render it in the wrong tone.
+ */
+describe("DiffLines", () => {
+  const line = (container: HTMLElement, i: number) =>
+    container.querySelectorAll('[data-slot="line"]')[i] as HTMLElement;
+
+  it("renders context lines in the ink-soft tone, unmarked", () => {
+    const rows: DiffRow[] = [{ tag: "same", left: "replicaCount: 12", right: "replicaCount: 12" }];
+    const { container } = render(<DiffLines rows={rows} />);
+    const el = line(container, 0);
+    expect(el.textContent).toContain("replicaCount: 12");
+    expect(el.style.color).toContain("var(--ink-soft)");
+    expect(el.getAttribute("data-tag")).toBe("same");
+  });
+
+  it("renders an insert on the ok wash, in ok", () => {
+    const rows: DiffRow[] = [{ tag: "insert", left: null, right: 'tag: "4f2a1c"' }];
+    const { container } = render(<DiffLines rows={rows} />);
+    const el = line(container, 0);
+    expect(el.textContent).toContain('tag: "4f2a1c"');
+    expect(el.style.color).toContain("var(--ok)");
+    expect(el.style.backgroundColor || el.style.background).toContain("var(--ok-wash)");
+  });
+
+  it("renders a delete on the sev wash, in sev", () => {
+    const rows: DiffRow[] = [{ tag: "delete", left: 'tag: "118a7e"', right: null }];
+    const { container } = render(<DiffLines rows={rows} />);
+    const el = line(container, 0);
+    expect(el.textContent).toContain('tag: "118a7e"');
+    expect(el.style.color).toContain("var(--sev)");
+    expect(el.style.backgroundColor || el.style.background).toContain("var(--sev-wash)");
+  });
+
+  it("draws a replace row as its own deletion followed by its own addition, from one row", () => {
+    // The row-shape trap: one DiffRow with both sides present, not a pair of
+    // rows in the array. Two lines come out, but from a single input row.
+    const rows: DiffRow[] = [{ tag: "replace", left: "DB_POOL_MAX: \"40\"", right: "DB_POOL_MAX: \"5\"" }];
+    const { container } = render(<DiffLines rows={rows} />);
+    const lines = container.querySelectorAll('[data-slot="line"]');
+    expect(lines.length).toBe(2);
+
+    const del = lines[0] as HTMLElement;
+    expect(del.getAttribute("data-tag")).toBe("delete");
+    expect(del.textContent).toContain('DB_POOL_MAX: "40"');
+    expect(del.style.color).toContain("var(--sev)");
+
+    const ins = lines[1] as HTMLElement;
+    expect(ins.getAttribute("data-tag")).toBe("insert");
+    expect(ins.textContent).toContain('DB_POOL_MAX: "5"');
+    expect(ins.style.color).toContain("var(--ok)");
+  });
+
+  it("does not double a normal delete/insert pair that already arrives as two rows", () => {
+    // The common case: diffTextLines' LCS path never emits "replace" — a
+    // changed line already arrives as a delete row followed by an insert row.
+    // Those must stay exactly two lines, not four.
+    const rows: DiffRow[] = [
+      { tag: "delete", left: 'DB_POOL_MAX: "40"', right: null },
+      { tag: "insert", left: null, right: 'DB_POOL_MAX: "5"' },
+    ];
+    const { container } = render(<DiffLines rows={rows} />);
+    expect(container.querySelectorAll('[data-slot="line"]').length).toBe(2);
+  });
+
+  it("renders nothing rather than an empty frame for an empty list", () => {
+    const { container } = render(<DiffLines rows={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("wraps rather than forcing the pane to scroll horizontally", () => {
+    const longLine = "x".repeat(400);
+    const rows: DiffRow[] = [{ tag: "same", left: longLine, right: longLine }];
+    const { container } = render(<DiffLines rows={rows} />);
+    const el = line(container, 0);
+    expect(el.className).toMatch(/whitespace-pre-wrap/);
+  });
+
+  it("sets no title attribute anywhere in the tree", () => {
+    // A Secret leaked through a `title` attribute before; a diff line is
+    // exactly the kind of content that could carry one again.
+    const rows: DiffRow[] = [
+      { tag: "same", left: "a", right: "a" },
+      { tag: "delete", left: "b", right: null },
+      { tag: "insert", left: null, right: "c" },
+      { tag: "replace", left: "d", right: "e" },
+    ];
+    const { container } = render(<DiffLines rows={rows} />);
+    expect(container.querySelectorAll("[title]").length).toBe(0);
+  });
+
+  it("keeps rows in order across a mixed hunk", () => {
+    const rows: DiffRow[] = [
+      { tag: "same", left: "env:", right: "env:" },
+      { tag: "replace", left: 'DB_POOL_MAX: "40"', right: 'DB_POOL_MAX: "5"' },
+      { tag: "same", left: "DB_POOL_TIMEOUT: \"30s\"", right: "DB_POOL_TIMEOUT: \"30s\"" },
+    ];
+    const { container } = render(<DiffLines rows={rows} />);
+    const lines = container.querySelectorAll('[data-slot="line"]');
+    expect(lines.length).toBe(4);
+    expect(lines[0].textContent).toContain("env:");
+    expect(lines[1].getAttribute("data-tag")).toBe("delete");
+    expect(lines[2].getAttribute("data-tag")).toBe("insert");
+    expect(lines[3].textContent).toContain("DB_POOL_TIMEOUT");
+  });
+});

--- a/packages/ui-kit/src/DiffLines.tsx
+++ b/packages/ui-kit/src/DiffLines.tsx
@@ -1,0 +1,104 @@
+import { cx } from "./cx";
+import { toneColor, toneWash } from "./tone";
+
+/**
+ * Local copy of core's `DiffRow` shape, not an import of it.
+ *
+ * The kit does not depend on `@srelens/core` — `tokens-only.test.ts` asserts
+ * that kit-wide — so this is the same four fields, structurally, rather than
+ * a reference to the type `diffTextLines` returns. Anything that already
+ * produces a `core` `DiffRow[]` is assignable here without a cast.
+ */
+export interface DiffRow {
+  tag: "same" | "insert" | "delete" | "replace";
+  left: string | null;
+  right: string | null;
+}
+
+export interface DiffLinesProps {
+  rows: DiffRow[];
+  className?: string;
+}
+
+interface Line {
+  key: string;
+  tag: "same" | "insert" | "delete";
+  text: string;
+}
+
+/**
+ * One `DiffRow` becomes one printed line, except `replace`.
+ *
+ * `replace` is the row-shape trap this component exists to get right: it is
+ * ONE row with both `left` and `right` present, emitted when a line changed
+ * rather than being purely added or purely removed. Read only for its tag —
+ * `left`/`right`'s mere presence is not enough, because a `same` row also
+ * carries both — it becomes its own deletion line (from `left`) immediately
+ * followed by its own addition line (from `right`), matching exactly how a
+ * changed line already reads when `diffTextLines`' ordinary path hands it
+ * over as an adjacent delete/insert pair instead. Two lines come out, but
+ * from the one row that carried them; a delete row and an insert row
+ * elsewhere in the same list are left as the single line each already is.
+ */
+function toLines(rows: DiffRow[]): Line[] {
+  const lines: Line[] = [];
+  rows.forEach((row, i) => {
+    if (row.tag === "same") {
+      lines.push({ key: `${i}`, tag: "same", text: row.left ?? row.right ?? "" });
+    } else if (row.tag === "delete") {
+      lines.push({ key: `${i}`, tag: "delete", text: row.left ?? "" });
+    } else if (row.tag === "insert") {
+      lines.push({ key: `${i}`, tag: "insert", text: row.right ?? "" });
+    } else {
+      if (row.left !== null) lines.push({ key: `${i}-del`, tag: "delete", text: row.left });
+      if (row.right !== null) lines.push({ key: `${i}-ins`, tag: "insert", text: row.right });
+    }
+  });
+  return lines;
+}
+
+const MARK: Record<Line["tag"], string> = { same: " ", delete: "-", insert: "+" };
+
+/**
+ * A text diff — `DiffRow[]` from a revision-to-revision compare — drawn in
+ * the design's tones: additions on `--ok-wash` in `--ok`, deletions on
+ * `--sev-wash` in `--sev`, context in `--ink-soft`, monospace at 11px. (§16)
+ *
+ * This is not classic's `DiffView`. That component takes a `DiffDoc` and
+ * draws a manifest dry-run — a resource heading, a `New resource` badge, a
+ * `No changes` state — none of which a revision diff wants, and it is styled
+ * in classic's own classes rather than these tokens. This one knows nothing
+ * beyond the rows it is handed.
+ *
+ * An empty list renders nothing rather than an empty frame, the same rule
+ * `RawError` and `PairList` follow: a diff pane with nothing to say should
+ * not leave a blank box behind for its caller to notice and hide.
+ */
+export function DiffLines({ rows, className }: DiffLinesProps) {
+  const lines = toLines(rows);
+  if (lines.length === 0) return null;
+
+  return (
+    <div className={cx("flex flex-col font-mono text-[0.6875rem] leading-relaxed", className)}>
+      {lines.map((l) => (
+        <div
+          key={l.key}
+          data-slot="line"
+          data-tag={l.tag}
+          className="flex gap-2 whitespace-pre-wrap break-all px-2 py-px"
+          style={
+            l.tag === "same"
+              ? { color: "var(--ink-soft)" }
+              : {
+                  color: toneColor(l.tag === "insert" ? "ok" : "sev"),
+                  background: toneWash(l.tag === "insert" ? "ok" : "sev"),
+                }
+          }
+        >
+          <span className="shrink-0 select-none opacity-70">{MARK[l.tag]}</span>
+          <span className="min-w-0 flex-1">{l.text}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/ui-kit/src/StatusBar.test.tsx
+++ b/packages/ui-kit/src/StatusBar.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent, within } from "@testing-library/react";
 import { StatusBar, type StatusSegment } from "./StatusBar";
@@ -201,5 +203,42 @@ describe("StatusBar's quieter detail", () => {
     // caller makes it conditional, and that hands over `false` or `0`.
     setup({ segments: [{ id: "watch", label: "live", detail: "" }], end: [] });
     expect(seg("live").textContent).toBe("live");
+  });
+});
+
+describe("the strip at a narrow window", () => {
+  // MEASURED, not estimated. The worst-case set this strip can carry — a
+  // 20-character cluster name, a version, the link word, a dead forward, a
+  // plural forward count, live shells, a failed helm operation and a running
+  // one, and `Ask` — was rendered in the real app at the window's own 960px
+  // minimum (`minWidth` in apps/desktop/src-tauri/tauri.conf.json). The strip's
+  // `clientWidth` was 960 and its `scrollWidth` 1036: 76px over. `Ask` ran from
+  // 1005px to 1036px, entirely past the right edge, and `elementFromPoint` at
+  // its own midpoint did not find it — the way into the console was not merely
+  // ugly but unclickable.
+  //
+  // It could not be scrolled to either: `.statusbar` declared no overflow, so
+  // the overflow escaped to the document, where `body { overflow: hidden }`
+  // clipped it. So the strip carries its own overflow, the way `.tabstrip`
+  // already does for the same reason.
+  //
+  // Asserted on the stylesheet because that is where the policy lives and
+  // jsdom does no layout.
+  const css = readFileSync(join(__dirname, "styles/kit.css"), "utf8");
+  // Matched to the rule's own closing brace at its own indentation, not to the
+  // first `}` in the text: the rule carries a comment that quotes CSS, and a
+  // `[^}]*` scan stops inside it and reports the whole declaration missing.
+  const body = /\n {2}\.statusbar \{[\s\S]*?\n {2}\}/.exec(css)?.[0] ?? "";
+
+  it("scrolls rather than clipping the segments it cannot fit", () => {
+    expect(body, "the .statusbar rule should exist").toBeTruthy();
+    expect(body).toContain("overflow-x: auto");
+  });
+
+  it("does not spend the strip's 22px height on a scrollbar", () => {
+    // Shorter than the tab strip's 33px, so a visible bar would leave less
+    // room for the readouts than the bar itself takes.
+    expect(body).toContain("scrollbar-width: none");
+    expect(css).toContain(".statusbar::-webkit-scrollbar");
   });
 });

--- a/packages/ui-kit/src/Table.test.tsx
+++ b/packages/ui-kit/src/Table.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { Table, filterTableData, computeVisibleRange, type Column } from "./Table";
+import { Table, filterTableData, computeVisibleRange, rowPitch, type Column } from "./Table";
 
 /**
  * Compact ages as seconds, standing in for core's `ageSeconds`, which the kit
@@ -151,6 +151,133 @@ describe("Table virtualization", () => {
   });
 });
 
+/**
+ * MEASURED in Chrome, 1500 rows, dpr 1, against `packages/ui-kit/src/styles/kit.css`:
+ * every rendered row reports `getBoundingClientRect().height` 27.375 EXCEPT the
+ * one sitting directly under the top spacer, which reports 27.000. The table is
+ * `border-collapse: collapse` and `.tbl-spacer` declares `border: 0 !important`,
+ * so the boundary row has no rule to share with the row above it and comes out a
+ * fraction of a pixel shorter than every other row in the list.
+ *
+ * That is the row the virtualizer used to sample, and the sample is multiplied by
+ * the number of rows the window skips. Measured consequence: the scroll
+ * container's `scrollHeight` flipped between 41089 and 40544 — 545px — as the
+ * sampled row moved in and out of the spacer's shadow, on every scroll, which is
+ * the scrollbar resizing under the reader's thumb.
+ *
+ * The mock below reproduces exactly that geometry: heights, and the tops that
+ * follow from them.
+ */
+function mockCollapsedBorderLayout() {
+  const BOUNDARY = 27;
+  const INTERIOR = 27.375;
+  vi.spyOn(HTMLTableRowElement.prototype, "getBoundingClientRect").mockImplementation(
+    function (this: HTMLTableRowElement) {
+      const rows = Array.from(this.parentElement?.querySelectorAll("tr.tbl-row") ?? []);
+      const index = rows.indexOf(this);
+      // Only the row under a spacer is short; without one, every row is interior.
+      const shortFirst = Boolean(
+        (rows[0] as HTMLElement | undefined)?.previousElementSibling?.classList.contains(
+          "tbl-spacer",
+        ),
+      );
+      const height = index === 0 && shortFirst ? BOUNDARY : INTERIOR;
+      const top =
+        index <= 0 ? 0 : (shortFirst ? BOUNDARY : INTERIOR) + (index - 1) * INTERIOR;
+      return { height, top, width: 140 } as DOMRect;
+    },
+  );
+  vi.spyOn(HTMLTableCellElement.prototype, "getBoundingClientRect").mockReturnValue({
+    width: 140,
+  } as DOMRect);
+}
+
+/** Every `<td style="height: …">` a spacer row reserves, in pixels. */
+function padHeight(container: HTMLElement): number {
+  return Array.from(container.querySelectorAll("tr.tbl-spacer td")).reduce(
+    (total, td) => total + parseFloat((td as HTMLTableCellElement).style.height || "0"),
+    0,
+  );
+}
+
+/** The whole list's height as the DOM reports it: the pads, plus the real rows. */
+function scrollExtent(container: HTMLElement): number {
+  const rows = Array.from(container.querySelectorAll("tbody tr.tbl-row")).reduce(
+    (total, row) => total + row.getBoundingClientRect().height,
+    0,
+  );
+  return padHeight(container) + rows;
+}
+
+describe("Table virtual scroll extent", () => {
+  const cols: Column<{ name: string; phase: string }>[] = [
+    { key: "name", header: "Name" },
+    { key: "phase", header: "Phase" },
+  ];
+  const data = Array.from({ length: 1000 }, (_, i) => ({ name: `row-${i}`, phase: "x" }));
+
+  function scrolled(to: number) {
+    const utils = render(
+      <div data-testid="scroll" style={{ overflowY: "auto" }}>
+        <Table columns={cols} data={data} getRowKey={(r) => r.name} />
+      </div>,
+    );
+    const sp = screen.getByTestId("scroll");
+    Object.defineProperty(sp, "clientHeight", { value: 200, configurable: true });
+    Object.defineProperty(sp, "scrollTop", { value: 0, writable: true, configurable: true });
+    fireEvent.scroll(sp);
+    Object.defineProperty(sp, "scrollTop", { value: to, writable: true, configurable: true });
+    // Twice: `measure` reads the DOM the *previous* render left behind, so the
+    // first scroll to a new position still sees the window it is replacing. The
+    // second is the one that samples a row under a spacer — which is exactly the
+    // steady state a reader scrolling a long list is in.
+    fireEvent.scroll(sp);
+    fireEvent.scroll(sp);
+    return { ...utils, sp };
+  }
+
+  it("reserves the interior row pitch per skipped row, not the boundary row's height", () => {
+    mockCollapsedBorderLayout();
+    const { container } = scrolled(4000);
+    const { start } = computeVisibleRange({
+      scrollTop: 4000,
+      viewportHeight: 200,
+      rowHeight: 27.375,
+      total: 1000,
+      overscan: 8,
+    });
+    const top = parseFloat(
+      (container.querySelector("tr.tbl-spacer td") as HTMLTableCellElement).style.height,
+    );
+    expect(top).toBeCloseTo(start * 27.375, 3);
+    // Guard: the two units really do disagree, so this is not vacuously true.
+    expect(start * 27.375).not.toBeCloseTo(
+      computeVisibleRange({
+        scrollTop: 4000,
+        viewportHeight: 200,
+        rowHeight: 27,
+        total: 1000,
+        overscan: 8,
+      }).start * 27,
+      3,
+    );
+  });
+
+  it("keeps the scroll extent steady as the list scrolls", () => {
+    mockCollapsedBorderLayout();
+    const { container, sp } = scrolled(0);
+    const atTop = scrollExtent(container);
+    expect(atTop).toBeGreaterThan(20000); // guard: a real extent, not zero
+    Object.defineProperty(sp, "scrollTop", { value: 4000, writable: true, configurable: true });
+    fireEvent.scroll(sp);
+    fireEvent.scroll(sp);
+    // 1px of slack: the boundary row genuinely is 0.375px shorter than the rest.
+    // The defect this pins moved the extent by 375px on this list, and by a
+    // measured 545px on the 1500-row list it was found on.
+    expect(scrollExtent(container)).toBeCloseTo(atTop, 0);
+  });
+});
+
 describe("Table sorting", () => {
   it("orders 64-bit integers exactly, beyond Number's safe range", () => {
     // Number() collapses these two to the same value, so a numeric sort key
@@ -190,6 +317,26 @@ describe("Table sorting", () => {
       (tr) => tr.textContent?.slice(0, 5),
     );
     expect(order?.[0]).toContain("none");
+  });
+});
+
+describe("rowPitch", () => {
+  it("takes the distance between two interior rows, not the first gap", () => {
+    // Chrome's own numbers: a 27.000 boundary row, then 27.375 all the way down.
+    expect(rowPitch([0, 27, 54.375, 81.75], 27)).toBeCloseTo(27.375, 5);
+  });
+
+  it("falls back to the row's own height when there is no interior gap to read", () => {
+    expect(rowPitch([0, 27], 27)).toBe(27);
+    expect(rowPitch([0], 27)).toBe(27);
+    expect(rowPitch([], 27)).toBe(27);
+  });
+
+  it("falls back when the tops are not measurable, which is jsdom", () => {
+    // Every rect is zeroed there, so the distance is 0 and the table renders
+    // every row rather than dividing the list up by nothing.
+    expect(rowPitch([0, 0, 0], 0)).toBe(0);
+    expect(rowPitch([NaN, NaN, NaN], 20)).toBe(20);
   });
 });
 

--- a/packages/ui-kit/src/Table.tsx
+++ b/packages/ui-kit/src/Table.tsx
@@ -183,6 +183,35 @@ export function computeVisibleRange({
   return { start, end };
 }
 
+/**
+ * How far down the list one row advances it — the unit the spacer rows reserve
+ * space in.
+ *
+ * Taken from the distance between two *interior* rows, not from the height of
+ * the first rendered one, which is what this used to read and is a different
+ * number. The table is `border-collapse: collapse`, so every rule is shared
+ * between the two rows it separates; `.tbl-spacer` declares `border: 0`, so the
+ * row directly under the top spacer has no rule to share and comes out shorter
+ * than the rest. MEASURED in Chrome on a 1500-row pod list: 27.000 for that one
+ * row against 27.375 for every other, at every scroll position.
+ *
+ * `topPad`/`bottomPad` multiply this by the number of rows the window skips, so
+ * sampling the short row scaled a 0.375px error to 545px of `scrollHeight`, and
+ * the extent flipped between the two values as the sampled row moved in and out
+ * of the spacer's shadow — the scrollbar resizing under the reader's thumb on
+ * every scroll, which is what "scroll is not smooth" was.
+ *
+ * `tops` is the top of each of the first few rendered rows, in order.
+ * `fallbackHeight` is the first row's own height, used when there are too few
+ * rows to take a distance from, and when the tops are not real numbers — which
+ * is jsdom, where every rect is zeroed and the table renders every row anyway.
+ */
+export function rowPitch(tops: readonly number[], fallbackHeight: number): number {
+  // tops[2] - tops[1], never tops[1] - tops[0]: the first gap is the short one.
+  const pitch = tops.length >= 3 ? tops[2] - tops[1] : NaN;
+  return Number.isFinite(pitch) && pitch > 0 ? pitch : fallbackHeight;
+}
+
 /** Apply the toolbar query to one selected column, or all searchable columns. */
 export function filterTableData<T>(
   data: T[],
@@ -399,11 +428,20 @@ export function Table<T>({
     if (!scrollParent) return;
     const parent = scrollParent;
     const measure = () => {
-      const firstRow = root.querySelector<HTMLElement>("tbody tr.tbl-row");
+      // Three rects, not one: `rowPitch` needs two interior tops, and three is
+      // as many forced layouts as this is allowed to cost on a scroll tick.
+      const sample = Array.from(root.querySelectorAll<HTMLElement>("tbody tr.tbl-row"))
+        .slice(0, 3)
+        .map((row) => row.getBoundingClientRect());
       setMetrics({
         scrollTop: parent.scrollTop,
         viewportHeight: parent.clientHeight,
-        rowHeight: firstRow ? firstRow.getBoundingClientRect().height : 0,
+        rowHeight: sample.length
+          ? rowPitch(
+              sample.map((rect) => rect.top),
+              sample[0].height,
+            )
+          : 0,
       });
     };
     measure();

--- a/packages/ui-kit/src/gallery/Gallery.tsx
+++ b/packages/ui-kit/src/gallery/Gallery.tsx
@@ -15,6 +15,7 @@ import { Combobox } from "../Combobox";
 import { Checkbox } from "../Checkbox";
 import { ConfirmDialog } from "../ConfirmDialog";
 import { Dialog } from "../Dialog";
+import { DiffLines, type DiffRow } from "../DiffLines";
 import { ConsoleDock } from "../ConsoleDock";
 import { ContextMenu } from "../ContextMenu";
 import { CopyCommand } from "../CopyCommand";
@@ -1301,6 +1302,34 @@ export function Gallery() {
           {/* A blank row in a stream is indistinguishable from a fault. */}
           <LogLine ts="14:02:15.001" source="checkout-api" level="debug" message="" />
         </div>
+      </section>
+
+      <section>
+        <h2>DiffLines</h2>
+        {/* §16's fixture: two lines changed between revision 118 and 119. Each
+            is one "replace" row carrying both sides — not a delete row and an
+            insert row rendered separately, which would double the hunk. */}
+        <div className="card overflow-hidden">
+          <DiffLines
+            rows={
+              [
+                { tag: "same", left: "replicaCount: 12", right: "replicaCount: 12" },
+                { tag: "same", left: "image:", right: "image:" },
+                {
+                  tag: "same",
+                  left: "  repository: acme/checkout-api",
+                  right: "  repository: acme/checkout-api",
+                },
+                { tag: "replace", left: '  tag: "118a7e"', right: '  tag: "4f2a1c"' },
+                { tag: "same", left: "env:", right: "env:" },
+                { tag: "replace", left: '  DB_POOL_MAX: "40"', right: '  DB_POOL_MAX: "5"' },
+                { tag: "same", left: '  DB_POOL_TIMEOUT: "30s"', right: '  DB_POOL_TIMEOUT: "30s"' },
+              ] satisfies DiffRow[]
+            }
+          />
+        </div>
+        {/* An empty list renders nothing — no empty frame left behind. */}
+        <DiffLines rows={[]} />
       </section>
 
       <section>

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -19,6 +19,7 @@ export { ContextMenu, type ContextMenuItem, type ContextMenuProps } from "./Cont
 export { CopyCommand, type CopyCommandProps } from "./CopyCommand";
 export { CustomizeMark, type CustomizeMarkProps, type MarkAppearance } from "./CustomizeMark";
 export { Dialog, type DialogProps } from "./Dialog";
+export { DiffLines, type DiffLinesProps, type DiffRow } from "./DiffLines";
 export { Drawer, type DrawerProps } from "./Drawer";
 export { DrillCard, type DrillCardProps, type DrillStep } from "./DrillCard";
 export { EmptyState, type EmptyStateProps } from "./EmptyState";

--- a/packages/ui-kit/src/styles/kit.css
+++ b/packages/ui-kit/src/styles/kit.css
@@ -1204,7 +1204,26 @@
     padding: 0 0.4rem;
     background: var(--canvas-deep);
     border-top: 1px solid var(--rule);
+    /* MEASURED at the window's own 960px minimum (`minWidth` in
+       apps/desktop/src-tauri/tauri.conf.json), with every readout the strip can
+       carry at once: a 20-character cluster name, a version, the link word, a
+       dead forward, a plural forward count, live shells, a failed helm
+       operation and a running one, and `Ask`. `clientWidth` 960, `scrollWidth`
+       1036 — 76px over. `Ask` ran from 1005px to 1036px and `elementFromPoint`
+       at its own midpoint did not find it: the way into the console was off the
+       window and unclickable, not merely cramped.
+
+       And unreachable, because the segments are `white-space: nowrap` with no
+       `min-width`, so flex's `min-width: auto` keeps them at their full size and
+       the overflow escaped to the document, where `body { overflow: hidden }`
+       clipped it. The strip carries its own overflow instead, exactly as
+       `.tabstrip` does above and for the same reason. The scrollbar is hidden:
+       inside 22px — shorter than the tab strip's 33px — a visible bar would take
+       more room than the readouts it makes room for. */
+    overflow-x: auto;
+    scrollbar-width: none;
   }
+  .statusbar::-webkit-scrollbar { display: none; }
   .status-seg {
     display: inline-flex;
     align-items: center;

--- a/packages/ui-kit/src/styles/kit.css
+++ b/packages/ui-kit/src/styles/kit.css
@@ -244,12 +244,21 @@
   .tbl tbody tr:hover { background: var(--surface-sunk); }
   .tbl tbody tr:hover .row-ask { opacity: 1; }
   .tbl tbody tr[data-selected="true"] { background: var(--accent-wash); }
+  /* Tabular figures, because these cells hold live numbers. CPU, MEMORY,
+     RESTARTS and AGE refresh on a poll while the reader is looking at the list,
+     and `--font-sans` (system-ui) spaces its digits proportionally: measured at
+     13px, the advances run 5.954px for "1" to 8.290px for "4". End-aligned, a
+     single changed digit drags every digit before it along — one MEMORY cell's
+     text sat at 1194.28, 1195.75 and 1197.13 across three polls. Twenty-five
+     rows doing that at once is a table that will not hold still. */
   .tbl td {
     padding: var(--pad-y) 0.7rem;
     height: var(--row-h);
     font-size: 0.8125rem;
     vertical-align: middle;
     white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+    font-feature-settings: "tnum";
   }
   /* The 0.7rem padding above is symmetric, so an end-aligned cell keeps its
      trailing breathing room instead of hugging the next column's rule. */

--- a/packages/ui-kit/src/tokens-only.test.ts
+++ b/packages/ui-kit/src/tokens-only.test.ts
@@ -86,3 +86,28 @@ describe("the toolbar's height", () => {
     expect(body).not.toMatch(/[^-]height:/);
   });
 });
+
+/**
+ * A live number must not move sideways when it changes.
+ *
+ * MEASURED in Chrome against `--font-sans` (system-ui → SF Pro Text on macOS) at
+ * the table's own 13px: the digit advances run from 5.954px for "1" to 8.290px
+ * for "4" — 2.3px of spread per digit. Every resource list refreshes CPU,
+ * MEMORY, RESTARTS and AGE on a poll while the reader is looking at it, and
+ * those columns are `text-align: end`, so a changed digit drags every digit
+ * before it along with it. Sampling one MEMORY cell across polls put its text's
+ * left edge at 1194.28, 1195.75, 1197.13 — 2.85px of wobble, on twenty-five rows
+ * at once. Proportional figures are the whole of it: nothing about the column
+ * widths moved.
+ *
+ * On `.tbl td` rather than only on the end-aligned ones: a pod name carries
+ * digits too, and one rule cannot drift from the other.
+ */
+describe("a table cell's figures", () => {
+  it("are tabular, so live values do not shift as they change", () => {
+    const css = readFileSync(join(__dirname, "styles", "kit.css"), "utf8");
+    const rule = css.slice(css.indexOf("  .tbl td {"));
+    const body = rule.slice(0, rule.indexOf("}"));
+    expect(body).toContain("font-variant-numeric: tabular-nums");
+  });
+});

--- a/packages/ui-next/src/lib/clusters.test.ts
+++ b/packages/ui-next/src/lib/clusters.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import type { ClusterContext } from "@srelens/core";
-import { contextFor, getContexts, resetContexts, setContexts } from "./clusters";
+import {
+  contextFor,
+  getContexts,
+  getContextsError,
+  getContextsStatus,
+  resetContexts,
+  setContexts,
+} from "./clusters";
 
 const ctx = (stableId: string, name = stableId): ClusterContext => ({
   name, stableId, cluster: name, server: "", isCurrent: false,
@@ -23,5 +30,54 @@ describe("contexts store", () => {
   it("hands back the same array until it is replaced, so a subscriber cannot tear", () => {
     setContexts([ctx("prod-1")]);
     expect(getContexts()).toBe(getContexts());
+  });
+});
+
+/**
+ * An empty list is three different facts, and the screens were reading it as
+ * one: nothing selected, nothing listed yet, and a listing that failed all
+ * arrived as `[]`. The store is the only place that knows which — `Window` is
+ * where the difference is observed, and every screen reads it back from here.
+ */
+describe("contexts store — listed, not listed yet, or refused", () => {
+  beforeEach(resetContexts);
+
+  it("starts out not yet loaded, because an empty list before boot is evidence of nothing", () => {
+    expect(getContextsStatus()).toBe("loading");
+    expect(getContextsError()).toBe("");
+    expect(getContexts()).toEqual([]);
+  });
+
+  it("is loaded once a listing has answered, even when the answer is none", () => {
+    setContexts([]);
+    expect(getContextsStatus()).toBe("loaded");
+    expect(getContextsError()).toBe("");
+  });
+
+  it("is failed, with the backend's reason kept, when the listing could not be made", () => {
+    setContexts([], "kubeconfig unreadable");
+    expect(getContextsStatus()).toBe("failed");
+    expect(getContextsError()).toBe("kubeconfig unreadable");
+  });
+
+  it("holds a partial list and its reason together, since some contexts can arrive alongside a refusal", () => {
+    setContexts([ctx("prod-1")], "kubeconfig unreadable");
+    expect(getContexts()).toHaveLength(1);
+    expect(getContextsStatus()).toBe("failed");
+  });
+
+  it("clears an earlier failure when a later listing succeeds", () => {
+    setContexts([], "kubeconfig unreadable");
+    setContexts([ctx("prod-1")]);
+    expect(getContextsStatus()).toBe("loaded");
+    expect(getContextsError()).toBe("");
+  });
+
+  it("resets the status and the reason too, so one test's failure cannot leak into the next", () => {
+    setContexts([ctx("prod-1")], "kubeconfig unreadable");
+    resetContexts();
+    expect(getContextsStatus()).toBe("loading");
+    expect(getContextsError()).toBe("");
+    expect(getContexts()).toEqual([]);
   });
 });

--- a/packages/ui-next/src/lib/clusters.ts
+++ b/packages/ui-next/src/lib/clusters.ts
@@ -18,12 +18,57 @@ import { useActiveCluster } from "./tabsStore";
 let contexts: ClusterContext[] = [];
 const listeners = new Set<() => void>();
 
+/**
+ * Whether the list above has been asked for yet, and what came back.
+ *
+ * An empty `contexts` is three different facts and the screens were reading it
+ * as one. A user with `K8SM01-ADMIN` on every tab was told "No cluster in
+ * focus — pick a cluster in the rail", because `listContexts` had refused and
+ * `Window` deliberately keeps the saved cluster ids when it does (see the
+ * comment at its `saved && outcome.error` branch): the cluster *is* in focus,
+ * the rail cannot fix it, and srelens already knew the real reason. The same
+ * screen also appeared for the ordinary race of a slow listing.
+ *
+ * So the store says which of the three it is, and the shared no-cluster screen
+ * says only what is true: still listing, could not list, or genuinely nothing
+ * picked.
+ */
+export type ContextsStatus = "loading" | "loaded" | "failed";
+
+let status: ContextsStatus = "loading";
+let failure = "";
+
 export function getContexts(): ClusterContext[] {
   return contexts;
 }
 
-export function setContexts(next: ClusterContext[]): void {
+/** The store's own read of itself — a string, deliberately not a `{ status,
+ *  error }` object. `useSyncExternalStore` re-reads its snapshot after every
+ *  render and compares it by identity, so a getter that allocates per call
+ *  never settles: "Maximum update depth exceeded", which this package has
+ *  already shipped once. Two primitives, two getters, no allocation. */
+export function getContextsStatus(): ContextsStatus {
+  return status;
+}
+
+/** The raw message a failed listing came back with, for `describeError` to
+ *  classify at the point it is shown. Empty unless {@link getContextsStatus}
+ *  reads `failed`. */
+export function getContextsError(): string {
+  return failure;
+}
+
+/**
+ * The result of one listing: what came back, and the reason if it refused.
+ *
+ * One call rather than a separate `setContextsError`, so the three states can
+ * never be observed half-changed — a list installed before its error, or an
+ * error left standing over a list that has since succeeded.
+ */
+export function setContexts(next: ClusterContext[], error = ""): void {
   contexts = next;
+  status = error === "" ? "loaded" : "failed";
+  failure = error;
   for (const listener of listeners) listener();
 }
 
@@ -42,10 +87,16 @@ export function getKubeconfigFiles(): string[] {
   return files;
 }
 
-/** Test-only: put the store back to an empty list. */
+/** Test-only: put the store back to how it boots — nothing listed, and no
+ *  listing attempted yet. `setContexts([])` would say the opposite (a listing
+ *  that answered with none), and a leftover `failed` from one test would
+ *  otherwise render every later test's no-cluster screen as an error. */
 export function resetContexts(): void {
   files = [];
-  setContexts([]);
+  contexts = [];
+  status = "loading";
+  failure = "";
+  for (const listener of listeners) listener();
 }
 
 function subscribe(listener: () => void): () => void {
@@ -59,6 +110,16 @@ export function useContexts(): ClusterContext[] {
   return useSyncExternalStore(subscribe, getContexts, getContexts);
 }
 
+/** Whether the contexts have been listed yet, and whether the listing worked. */
+export function useContextsStatus(): ContextsStatus {
+  return useSyncExternalStore(subscribe, getContextsStatus, getContextsStatus);
+}
+
+/** Why the listing refused, when it did. */
+export function useContextsError(): string {
+  return useSyncExternalStore(subscribe, getContextsError, getContextsError);
+}
+
 /** The context a workspace's cluster id stands for, if the kubeconfig still has it. */
 export function contextFor(stableId: string | null | undefined): ClusterContext | undefined {
   if (!stableId) return undefined;
@@ -69,6 +130,11 @@ export function contextFor(stableId: string | null | undefined): ClusterContext 
  * The active cluster's context, re-rendering on a change to either the store or
  * the active cluster. A screen with no answer here renders its "no cluster"
  * state rather than calling core with an empty context name.
+ *
+ * `undefined` says only that the two halves did not meet — it does not say
+ * which half was missing, and the three ways that happens want three different
+ * sentences. {@link ContextsStatus} is how a screen tells them apart; see
+ * `NoClusterScreen`.
  */
 export function useActiveContext(): ClusterContext | undefined {
   const active = useActiveCluster();

--- a/packages/ui-next/src/lib/helmOps.test.ts
+++ b/packages/ui-next/src/lib/helmOps.test.ts
@@ -235,6 +235,31 @@ describe("an operation in flight", () => {
   });
 });
 
+describe("an operation that ends before its start resolves", () => {
+  it("stops watching instead of parking a subscription nothing closes", async () => {
+    // Core registers both stream listeners before it invokes, so an operation
+    // that fails instantly can call `onExit` while `startHelmOp` is still
+    // pending. The handle arrives after the row has already settled.
+    const handle = { close: vi.fn() };
+    startHelmOp.mockImplementation(
+      (
+        _context: string,
+        _args: string[],
+        _data: (line: string) => void,
+        exit: (err: string | null) => void,
+      ) => {
+        exit("handler error: Error: UNINSTALL FAILED: release: not found");
+        return Promise.resolve(handle);
+      },
+    );
+
+    await startHelmOperation({ ...upgrade, kind: "uninstall" });
+
+    expect(getHelmOps()[0].state).toBe("failed");
+    expect(handle.close).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("the store's snapshot", () => {
   it("is the same reference until something changes", async () => {
     fakeHelm();
@@ -297,6 +322,49 @@ describe("the store's snapshot", () => {
     turnTheSecond();
     expect(getHelmOps()[0].output).toEqual(["line 1", "line 2", "line 3"]);
     expect(notified).toHaveBeenCalledTimes(2);
+  });
+
+  it("still lands the first line of the second after a timer-driven flush", async () => {
+    vi.useFakeTimers({ now: new Date("2026-08-26T10:00:00.000Z") });
+    const helm = fakeHelm();
+    await startHelmOperation(upgrade);
+    helm.out("line 1");
+    vi.advanceTimersByTime(500);
+    helm.out("line 2");
+    // The tail lands on the boundary, by timer rather than by a new line.
+    turnTheSecond();
+    expect(getHelmOps()[0].output).toEqual(["line 1", "line 2"]);
+
+    vi.advanceTimersByTime(20);
+    helm.out("line 3");
+
+    // That flush closed the FIRST second; it must not have spent the new one.
+    // A `helm upgrade --wait` narrating a rollout would otherwise go quiet on
+    // screen for a whole second after every batch, for as long as it ran.
+    expect(getHelmOps()[0].output).toEqual(["line 1", "line 2", "line 3"]);
+  });
+
+  it("keeps each operation's tail on its own timer", async () => {
+    vi.useFakeTimers({ now: new Date("2026-08-26T10:00:00.000Z") });
+    const first = fakeHelm();
+    await startHelmOperation(upgrade);
+    const second = fakeHelm();
+    await startHelmOperation({ ...upgrade, release: "web" });
+
+    first.out("a1");
+    second.out("b1");
+    vi.advanceTimersByTime(10);
+    // Both now buffering inside the same second, each needing its own timer to
+    // land its tail: one shared timer, and whichever flushed first would
+    // cancel the other's, stranding those lines with nothing left to land them.
+    first.out("a2");
+    second.out("b2");
+    turnTheSecond();
+
+    expect(getHelmOps().map((o) => o.output)).toEqual([
+      ["a1", "a2"],
+      ["b1", "b2"],
+    ]);
   });
 
   it("leaves an untouched row alone when another operation changes", async () => {

--- a/packages/ui-next/src/lib/helmOps.test.ts
+++ b/packages/ui-next/src/lib/helmOps.test.ts
@@ -1,0 +1,352 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const startHelmOp = vi.fn();
+
+vi.mock("@srelens/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@srelens/core")>();
+  return {
+    ...actual,
+    startHelmOp: (...args: unknown[]) => startHelmOp(...args),
+  };
+});
+
+// Imported after the mock so the store binds the double rather than the real
+// Tauri-backed streamer.
+const helmOps = await import("./helmOps");
+const {
+  __resetHelmOpsForTests,
+  dismissHelmOp,
+  getHelmOps,
+  startHelmOperation,
+  subscribeHelmOps,
+} = helmOps;
+
+/**
+ * A `startHelmOp` double. The test drives the backend side through
+ * `out`/`exit`, and asserts on the handle the store was given.
+ */
+function fakeHelm() {
+  let onData!: (line: string) => void;
+  let onExit!: (err: string | null) => void;
+  const handle = { close: vi.fn() };
+  startHelmOp.mockImplementation(
+    (
+      _context: string,
+      _args: string[],
+      data: (line: string) => void,
+      exit: (err: string | null) => void,
+    ) => {
+      onData = data;
+      onExit = exit;
+      return Promise.resolve(handle);
+    },
+  );
+  return {
+    handle,
+    out: (line: string) => onData(line),
+    exit: (err: string | null = null) => onExit(err),
+  };
+}
+
+const upgrade = {
+  kind: "upgrade" as const,
+  release: "checkout-api",
+  namespace: "payments",
+  context: "prod",
+  args: ["upgrade", "checkout-api", "charts/api", "--wait"],
+};
+
+/** Push past the second the store is coalescing output into, so whatever it
+ *  buffered lands in the snapshot. */
+function turnTheSecond() {
+  vi.advanceTimersByTime(1000);
+}
+
+beforeEach(() => {
+  __resetHelmOpsForTests();
+  startHelmOp.mockReset();
+});
+
+afterEach(() => {
+  __resetHelmOpsForTests();
+  vi.useRealTimers();
+});
+
+describe("starting an operation", () => {
+  it("lists it as running, saying what it is", async () => {
+    fakeHelm();
+
+    const id = await startHelmOperation(upgrade);
+
+    expect(getHelmOps()).toEqual([
+      {
+        id,
+        kind: "upgrade",
+        release: "checkout-api",
+        namespace: "payments",
+        context: "prod",
+        state: "running",
+        output: [],
+        startedAt: expect.any(Number),
+      },
+    ]);
+  });
+
+  it("hands core the context, argv, kubeconfigs and values it was given", async () => {
+    fakeHelm();
+
+    await startHelmOperation({ ...upgrade, extraKubeconfigs: ["/tmp/kc"], values: "replicaCount: 2" });
+
+    const [context, args, , , extra, values] = startHelmOp.mock.calls[0] as [
+      string,
+      string[],
+      unknown,
+      unknown,
+      string[],
+      string,
+    ];
+    expect(context).toBe("prod");
+    expect(args).toEqual(["upgrade", "checkout-api", "charts/api", "--wait"]);
+    expect(extra).toEqual(["/tmp/kc"]);
+    expect(values).toBe("replicaCount: 2");
+  });
+
+  it("leaves a failed row carrying the reason when the backend refuses to start", async () => {
+    startHelmOp.mockRejectedValue(new Error("handler error: helm binary not found"));
+
+    const id = await startHelmOperation(upgrade);
+
+    const [row] = getHelmOps();
+    expect(row.id).toBe(id);
+    expect(row.state).toBe("failed");
+    // Through `describeError`: the backend's wrappers are not the reader's
+    // problem.
+    expect(row.error).not.toContain("handler error:");
+    expect(row.error).toContain("helm binary not found");
+  });
+});
+
+describe("what the operation prints", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ now: new Date("2026-08-26T10:00:00.000Z") });
+  });
+
+  it("accumulates every line, in order", async () => {
+    const helm = fakeHelm();
+    await startHelmOperation(upgrade);
+
+    helm.out("Release \"checkout-api\" has been upgraded.");
+    helm.out("NAME: checkout-api");
+    helm.out("LAST DEPLOYED: Wed Aug 26");
+    turnTheSecond();
+
+    expect(getHelmOps()[0].output).toEqual([
+      "Release \"checkout-api\" has been upgraded.",
+      "NAME: checkout-api",
+      "LAST DEPLOYED: Wed Aug 26",
+    ]);
+  });
+
+  it("keeps the last lines a finished operation printed, without waiting for a clock", async () => {
+    const helm = fakeHelm();
+    await startHelmOperation(upgrade);
+
+    helm.out("first");
+    helm.out("second");
+    helm.exit(null);
+
+    const [row] = getHelmOps();
+    expect(row.state).toBe("done");
+    expect(row.output).toEqual(["first", "second"]);
+  });
+});
+
+describe("how an operation ends", () => {
+  it("moves to done on a clean exit and stops watching", async () => {
+    const helm = fakeHelm();
+    await startHelmOperation(upgrade);
+
+    helm.exit(null);
+
+    expect(getHelmOps()[0].state).toBe("done");
+    expect(getHelmOps()[0].error).toBeUndefined();
+    // `close()` unsubscribes this window from the stream. The cluster
+    // mutation, clean or not, was over before this ran.
+    expect(helm.handle.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("moves to failed and keeps the reason, described, beside the output", async () => {
+    const helm = fakeHelm();
+    await startHelmOperation(upgrade);
+
+    helm.out("Error: UPGRADE FAILED: another operation is in progress");
+    helm.exit("handler error: Error: UPGRADE FAILED: another operation is in progress");
+
+    const [row] = getHelmOps();
+    expect(row.state).toBe("failed");
+    expect(row.error).not.toContain("handler error:");
+    expect(row.error).toBe("UPGRADE FAILED: another operation is in progress");
+    // The output is the only place a failed upgrade's reason is spelled out.
+    expect(row.output).toEqual(["Error: UPGRADE FAILED: another operation is in progress"]);
+  });
+
+  it("leaves a failed operation listed until the reader dismisses it", async () => {
+    const helm = fakeHelm();
+    const id = await startHelmOperation(upgrade);
+    helm.exit("boom");
+    expect(getHelmOps()).toHaveLength(1);
+
+    dismissHelmOp(id);
+
+    expect(getHelmOps()).toEqual([]);
+  });
+
+  it("dismisses a finished operation and drops nothing else", async () => {
+    const first = fakeHelm();
+    const firstId = await startHelmOperation(upgrade);
+    fakeHelm();
+    await startHelmOperation({ ...upgrade, release: "web", kind: "install" });
+    first.exit(null);
+
+    dismissHelmOp(firstId);
+
+    expect(getHelmOps().map((o) => o.release)).toEqual(["web"]);
+  });
+});
+
+describe("an operation in flight", () => {
+  it("stays listed when the reader tries to dismiss it, because nothing here cancels", async () => {
+    const helm = fakeHelm();
+    const id = await startHelmOperation(upgrade);
+
+    dismissHelmOp(id);
+
+    // A `helm upgrade` keeps mutating the cluster whether srelens watches or
+    // not. Removing the row would read as a cancel, and it is not one.
+    expect(getHelmOps()).toHaveLength(1);
+    expect(getHelmOps()[0].state).toBe("running");
+    expect(helm.handle.close).not.toHaveBeenCalled();
+  });
+
+  it("exports no name that offers to cancel one", () => {
+    const named = Object.keys(helmOps);
+    expect(named).not.toHaveLength(0);
+    expect(named.filter((n) => /cancel|abort|kill|terminate/i.test(n))).toEqual([]);
+  });
+});
+
+describe("the store's snapshot", () => {
+  it("is the same reference until something changes", async () => {
+    fakeHelm();
+    await startHelmOperation(upgrade);
+
+    const before = getHelmOps();
+    expect(getHelmOps()).toBe(before);
+  });
+
+  it("survives a chatty second of output, and loses none of it", async () => {
+    vi.useFakeTimers({ now: new Date("2026-08-26T10:00:00.000Z") });
+    const helm = fakeHelm();
+    await startHelmOperation(upgrade);
+    helm.out("line 1");
+    const before = getHelmOps();
+    const notified = vi.fn();
+    subscribeHelmOps(notified);
+
+    // A `helm upgrade --wait` narrating itself: many lines, spread across real
+    // milliseconds, inside one second. Firing them on a frozen clock would
+    // prove nothing — millisecond-resolution coalescing would hold its
+    // identity too.
+    for (let i = 0; i < 50; i++) {
+      vi.advanceTimersByTime(10);
+      helm.out(`line ${i + 2}`);
+    }
+    expect(Date.now() - before[0].startedAt).toBeGreaterThan(400);
+
+    expect(getHelmOps()).toBe(before);
+    expect(before[0].output).toEqual(["line 1"]);
+    expect(notified).not.toHaveBeenCalled();
+
+    // Buffered, not dropped: the reader sees all 51 once the second turns.
+    turnTheSecond();
+    expect(getHelmOps()[0].output).toHaveLength(51);
+    expect(getHelmOps()[0].output[50]).toBe("line 51");
+    expect(notified).toHaveBeenCalledTimes(1);
+  });
+
+  it("rebuilds once the second has turned, and once per second only", async () => {
+    vi.useFakeTimers({ now: new Date("2026-08-26T10:00:00.000Z") });
+    const helm = fakeHelm();
+    await startHelmOperation(upgrade);
+    helm.out("line 1");
+    const before = getHelmOps();
+    const notified = vi.fn();
+    subscribeHelmOps(notified);
+
+    vi.advanceTimersByTime(1000);
+    helm.out("line 2");
+    helm.out("line 3");
+
+    const after = getHelmOps();
+    expect(after).not.toBe(before);
+    // The second turned, so line 2 lands at once; line 3 shares its second and
+    // waits for the next turn rather than waking every subscriber again.
+    expect(after[0].output).toEqual(["line 1", "line 2"]);
+    expect(notified).toHaveBeenCalledTimes(1);
+
+    turnTheSecond();
+    expect(getHelmOps()[0].output).toEqual(["line 1", "line 2", "line 3"]);
+    expect(notified).toHaveBeenCalledTimes(2);
+  });
+
+  it("leaves an untouched row alone when another operation changes", async () => {
+    const first = fakeHelm();
+    await startHelmOperation(upgrade);
+    const second = fakeHelm();
+    await startHelmOperation({ ...upgrade, release: "web" });
+    const before = getHelmOps();
+
+    second.exit("gone");
+
+    const after = getHelmOps();
+    expect(after).not.toBe(before);
+    // The row that did not change keeps its identity, so a strip row that is
+    // not involved does not re-render.
+    expect(after[0]).toBe(before[0]);
+    expect(after[1]).not.toBe(before[1]);
+    expect(after[1].state).toBe("failed");
+    expect(first.handle.close).not.toHaveBeenCalled();
+  });
+
+  it("does not rebuild itself for an ending it has already recorded", async () => {
+    const helm = fakeHelm();
+    await startHelmOperation(upgrade);
+    helm.exit("gone");
+    const before = getHelmOps();
+    const notified = vi.fn();
+    subscribeHelmOps(notified);
+
+    helm.exit("gone");
+
+    expect(getHelmOps()).toBe(before);
+    expect(notified).not.toHaveBeenCalled();
+  });
+
+  it("wakes subscribers when an operation starts, ends and is dismissed", async () => {
+    const helm = fakeHelm();
+    const notified = vi.fn();
+    const unsubscribe = subscribeHelmOps(notified);
+
+    const id = await startHelmOperation(upgrade);
+    expect(notified).toHaveBeenCalledTimes(1);
+    helm.exit("boom");
+    expect(notified).toHaveBeenCalledTimes(2);
+    dismissHelmOp(id);
+    expect(notified).toHaveBeenCalledTimes(3);
+
+    unsubscribe();
+    fakeHelm();
+    await startHelmOperation(upgrade);
+    expect(notified).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/ui-next/src/lib/helmOps.test.ts
+++ b/packages/ui-next/src/lib/helmOps.test.ts
@@ -170,8 +170,9 @@ describe("how an operation ends", () => {
 
     expect(getHelmOps()[0].state).toBe("done");
     expect(getHelmOps()[0].error).toBeUndefined();
-    // `close()` unsubscribes this window from the stream. The cluster
-    // mutation, clean or not, was over before this ran.
+    // Closing is what the store does with an operation that is over, and it
+    // is safe here for the reason it is only ever safe: `onExit` has fired, so
+    // the helm process this abort would have killed has already exited.
     expect(helm.handle.close).toHaveBeenCalledTimes(1);
   });
 
@@ -232,6 +233,63 @@ describe("an operation in flight", () => {
     const named = Object.keys(helmOps);
     expect(named).not.toHaveLength(0);
     expect(named.filter((n) => /cancel|abort|kill|terminate/i.test(n))).toEqual([]);
+  });
+
+  it("is left watching by every live way into this module", async () => {
+    const helm = fakeHelm();
+    const id = await startHelmOperation(upgrade);
+    const other = fakeHelm();
+    const otherId = await startHelmOperation({ ...upgrade, release: "web", kind: "install" });
+
+    // Every entry point this module offers a caller, aimed at operations that
+    // are still running: a start that resolved, output arriving, a reader
+    // subscribing and reading, a dismiss on a running row, and a dismiss on an
+    // id that is not here at all.
+    helm.out("Waiting for deployment rollout to finish");
+    const unsubscribe = subscribeHelmOps(() => {});
+    getHelmOps();
+    dismissHelmOp(id);
+    dismissHelmOp(otherId);
+    dismissHelmOp(9999);
+    unsubscribe();
+
+    // Not one of them may have closed a handle. `close()` is not a quiet
+    // unsubscribe: it reaches `helm_op_close`, which aborts the task that owns
+    // the `tokio::process::Child`, and that child was spawned
+    // `kill_on_drop(true)` — so closing SIGKILLs helm in the middle of a
+    // cluster mutation. See the note in `helmOps.ts`.
+    expect(getHelmOps().map((o) => o.state)).toEqual(["running", "running"]);
+    expect(helm.handle.close).not.toHaveBeenCalled();
+    expect(other.handle.close).not.toHaveBeenCalled();
+  });
+
+  it("offers exactly the five names that were traced against that rule", () => {
+    // A surface pin, not a style rule. The claim in `helmOps.ts` is that NO
+    // live path closes a running operation's handle, and that claim was
+    // established by walking these five exports. A sixth cannot be added
+    // without this failing, which is the point: whoever adds it has to come
+    // here, read why, and check their own path before the list grows.
+    expect(Object.keys(helmOps).sort()).toEqual([
+      "__resetHelmOpsForTests",
+      "dismissHelmOp",
+      "getHelmOps",
+      "startHelmOperation",
+      "subscribeHelmOps",
+    ]);
+  });
+
+  it("is closed only by the test reset, which no running app reaches", async () => {
+    const helm = fakeHelm();
+    await startHelmOperation(upgrade);
+    expect(helm.handle.close).not.toHaveBeenCalled();
+
+    __resetHelmOpsForTests();
+
+    // Named rather than hidden: this is the one path in the module that closes
+    // a handle while its operation is running, and it exists so a suite does
+    // not leak subscriptions between cases. Under vitest the handle is a
+    // double and nothing dies. It must not gain a caller outside a test.
+    expect(helm.handle.close).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/ui-next/src/lib/helmOps.ts
+++ b/packages/ui-next/src/lib/helmOps.ts
@@ -147,10 +147,17 @@ export async function startHelmOperation(req: HelmOpRequest): Promise<number> {
     settle(id, e);
     return id;
   }
-  // Dismissed while the start was still in flight — there is no row left to
-  // report into, so stop watching what just opened rather than leaking a
-  // subscription. The operation itself carries on; nothing here could stop it.
-  if (!ops.some((o) => o.id === id)) {
+  // The row already ended, or is gone, while the start was still in flight.
+  // Core registers both stream listeners BEFORE it invokes, so an operation
+  // that fails instantly — `helm uninstall` of a release that is not there —
+  // can reach `settle` ahead of this await; `forget` ran then and found no
+  // handle to close, so storing this one would park a subscription nothing
+  // ever closes. (A row that has left entirely is the test reset's doing:
+  // `dismissHelmOp` declines every `running` row, and the row is `running` for
+  // this whole window.) Stop watching what just opened. The operation itself
+  // carries on regardless; nothing here could stop it.
+  const row = ops.find((o) => o.id === id);
+  if (!row || row.state !== "running") {
     handle.close();
     return id;
   }
@@ -225,11 +232,12 @@ function register(req: HelmOpRequest): number {
  * problem millisecond stamps caused in `sessions.ts`, arriving here through
  * the output array instead of a timestamp.
  *
- * The first line of any second lands at once, so an operation that has just
- * started printing is visibly printing; the rest of that second's lines wait
- * together. Nothing is lost by waiting: {@link scheduleFlush} lands the tail
- * when the output stops, and {@link settle} lands it immediately when the
- * operation ends.
+ * The first line of any second lands at once — including the second right
+ * after a timer-driven flush, which is charged to the second it closed, not
+ * the one it woke in — so an operation that is printing keeps looking like it
+ * is. The rest of each second's lines wait together. Nothing is lost by
+ * waiting: {@link scheduleFlush} lands the tail when the output stops, and
+ * {@link settle} lands it immediately when the operation ends.
  */
 function receive(id: number, line: string) {
   const buffered = pending.get(id);
@@ -239,25 +247,43 @@ function receive(id: number, line: string) {
   else flush(id);
 }
 
-/** Land the tail of a mid-second burst once the second turns. Only ever one
- *  timer per operation: a later line in the same second joins the buffer the
- *  pending timer will flush. */
+/**
+ * Land the tail of a mid-second burst once the second turns.
+ *
+ * One timer per operation, keyed by id — a shared timer would let one
+ * operation's flush cancel another's and strand its buffered lines with
+ * nothing left to land them. A later line in the same second joins the buffer
+ * this timer will flush.
+ *
+ * The second being closed is captured here rather than read back when the
+ * timer fires: the timer fires ON the boundary, and a flush that stamped the
+ * second it woke up in would spend a budget nothing had used yet, leaving the
+ * first line of the new second invisible for another whole second.
+ */
 function scheduleFlush(id: number) {
   if (flushTimers.has(id)) return;
   const now = Date.now();
+  const second = wholeSecond(now);
   flushTimers.set(
     id,
-    setTimeout(() => flush(id), wholeSecond(now) + 1000 - now),
+    setTimeout(() => flush(id, second), second + 1000 - now),
   );
 }
 
-/** Fold whatever this operation has buffered into the snapshot. */
-function flush(id: number) {
+/**
+ * Fold whatever this operation has buffered into the snapshot, and record the
+ * second that fold is charged to.
+ *
+ * `second` is the second the flushed lines belong to. It defaults to the
+ * current one — right for a flush a line or an ending drove — and
+ * {@link scheduleFlush} passes the older, closing second instead.
+ */
+function flush(id: number, second: number = wholeSecond(Date.now())) {
   clearTimeout(flushTimers.get(id));
   flushTimers.delete(id);
   const buffered = pending.get(id);
   pending.delete(id);
-  lastFlush.set(id, wholeSecond(Date.now()));
+  lastFlush.set(id, second);
   if (!buffered || buffered.length === 0) return;
   commit(ops.map((o) => (o.id === id ? { ...o, output: [...o.output, ...buffered] } : o)));
 }
@@ -294,6 +320,9 @@ function forget(id: number) {
   clearTimeout(flushTimers.get(id));
   flushTimers.delete(id);
   pending.delete(id);
+  // Ids never repeat, so a stamp left behind here is one dead number kept for
+  // the life of the window per operation ever started.
+  lastFlush.delete(id);
   handles.get(id)?.close();
   handles.delete(id);
 }

--- a/packages/ui-next/src/lib/helmOps.ts
+++ b/packages/ui-next/src/lib/helmOps.ts
@@ -1,0 +1,328 @@
+import { describeError, startHelmOp } from "@srelens/core";
+
+/**
+ * The helm operations this window has started — what each one is doing, every
+ * line it has printed, and how it ended.
+ *
+ * **Why a store and not a modal.** `helm upgrade --wait` runs for minutes, and
+ * a dialog held open for the duration stops the reader looking at the pods it
+ * is restarting. The dialog submits and closes; this owns what happens next,
+ * so the release list, the strip and the pane can all read the same operation
+ * without any of them having to be on screen when it finishes.
+ *
+ * **Nothing here cancels anything, and no name in this file may suggest it.**
+ * A shell dies with its process and a tunnel dies with its socket, so their
+ * stores can honestly offer to end one. A `helm upgrade` is a cluster mutation
+ * that continues whether srelens watches or not: core's `close()` unsubscribes
+ * this window from the stream and touches the release not at all. That is why
+ * {@link dismissHelmOp} declines to remove a `running` row — a row that
+ * disappeared under a dismiss button would read as a cancel, and it is not
+ * one.
+ *
+ * **No status word or tone lives here.** This module holds state; the words
+ * for it come from core, the same way every other screen in this migration
+ * gets them.
+ *
+ * Shaped after `sessions.ts`, which is shaped after `packages/core/src/lib/
+ * forward.ts`: module-level state, a listener set, and a snapshot that keeps
+ * its reference until something in it actually changed, so
+ * `useSyncExternalStore` has a stable value to compare.
+ */
+
+/** Which of the four operations a row is. */
+export type HelmOpKind = "install" | "upgrade" | "rollback" | "uninstall";
+
+/**
+ * How an operation stands.
+ *
+ * `running` until the backend says otherwise — including after the reader has
+ * closed every view of it, because the cluster is still changing. `done` and
+ * `failed` are both final, and both stay listed until dismissed.
+ */
+export type HelmOpState = "running" | "done" | "failed";
+
+/** One operation, as the pane and the strip read it. */
+export interface HelmOpRow {
+  id: number;
+  kind: HelmOpKind;
+  release: string;
+  namespace: string;
+  context: string;
+  state: HelmOpState;
+  /**
+   * Every line the operation has printed, oldest first.
+   *
+   * Lines are coalesced into the snapshot at second resolution — see
+   * {@link receive}. A finished operation's output is complete regardless:
+   * {@link settle} flushes whatever the current second was still holding.
+   */
+  output: string[];
+  /**
+   * Why it failed. Already through `describeError`: a failed upgrade's reason
+   * is read straight off the row by whatever renders it, so a raw Rust string
+   * is turned into a sentence here rather than at each reader.
+   */
+  error?: string;
+  /** Epoch millis when the operation was started. */
+  startedAt: number;
+}
+
+/** What starting an operation needs. `args` is the helm argv exactly as core
+ *  will run it — this store composes no commands, it only owns the one it was
+ *  handed. */
+export interface HelmOpRequest {
+  kind: HelmOpKind;
+  release: string;
+  namespace: string;
+  context: string;
+  args: string[];
+  /** Extra kubeconfigs to put on helm's KUBECONFIG. */
+  extraKubeconfigs?: string[];
+  /** A values.yaml body, for the operations that take one. */
+  values?: string;
+}
+
+let ops: HelmOpRow[] = [];
+const listeners = new Set<() => void>();
+/** The stream subscription for each operation still being watched. */
+const handles = new Map<number, { close: () => void }>();
+/** Lines that have arrived but are not in the snapshot yet — see
+ *  {@link receive}. */
+const pending = new Map<number, string[]>();
+/** The whole second each operation's output was last folded into the snapshot
+ *  at. A line landing in a later second may rebuild the row; one landing in
+ *  the same second waits. */
+const lastFlush = new Map<number, number>();
+/** The timer that lands a buffered tail when the output stops mid-second, so
+ *  the last thing a quiet operation said is never held back. */
+const flushTimers = new Map<number, ReturnType<typeof setTimeout>>();
+
+/** Ids are the store's own, not the backend's channel numbers. */
+let seq = 0;
+
+function emit() {
+  for (const listener of listeners) listener();
+}
+
+/** Subscribe to store changes (for `useSyncExternalStore`). */
+export function subscribeHelmOps(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+/**
+ * Every operation this window has started — running and finished.
+ *
+ * A stable reference until something in it changes: `useSyncExternalStore`
+ * compares snapshots by identity and re-renders forever when handed a fresh
+ * array each read, and a streamed operation prints often enough to make that
+ * a hang rather than a waste.
+ */
+export function getHelmOps(): HelmOpRow[] {
+  return ops;
+}
+
+/**
+ * Start one of the four operations and watch it.
+ *
+ * Never throws: an operation the backend refused to start is a `failed` row
+ * carrying the reason, because a failure the reader can read is worth more
+ * than one they have to catch. Returns the row's id either way.
+ */
+export async function startHelmOperation(req: HelmOpRequest): Promise<number> {
+  const id = register(req);
+  let handle: { close: () => void };
+  try {
+    handle = await startHelmOp(
+      req.context,
+      req.args,
+      (line) => receive(id, line),
+      (err) => settle(id, err),
+      req.extraKubeconfigs ?? [],
+      req.values ?? "",
+    );
+  } catch (e) {
+    // Raw, not described: `settle` describes exactly once, and a sentence run
+    // through `describeError` twice is classified on its own wording.
+    settle(id, e);
+    return id;
+  }
+  // Dismissed while the start was still in flight — there is no row left to
+  // report into, so stop watching what just opened rather than leaking a
+  // subscription. The operation itself carries on; nothing here could stop it.
+  if (!ops.some((o) => o.id === id)) {
+    handle.close();
+    return id;
+  }
+  handles.set(id, handle);
+  return id;
+}
+
+/**
+ * The reader is done with a finished operation: drop the row.
+ *
+ * The one place a row leaves the screen, and only for a `done` or `failed`
+ * one. An operation that ended on its own stays listed with its output —
+ * #349's vanishing port-forward is what happens otherwise, a reader carrying
+ * on as though a dead thing were fine, and a failed upgrade's output is the
+ * only place its reason exists.
+ *
+ * A `running` row is left exactly where it is. See this module's note: there
+ * is no cancel to offer, so there is no removal to honour either.
+ */
+export function dismissHelmOp(id: number): void {
+  const row = ops.find((o) => o.id === id);
+  if (!row || row.state === "running") return;
+  forget(id);
+  commit(ops.filter((o) => o.id !== id));
+}
+
+/** Reset the module-level store between tests. */
+export function __resetHelmOpsForTests(): void {
+  for (const id of [...handles.keys()]) forget(id);
+  for (const id of [...flushTimers.keys()]) forget(id);
+  ops = [];
+  listeners.clear();
+  pending.clear();
+  lastFlush.clear();
+  seq = 0;
+}
+
+/**
+ * Put the row in place, before anything is started.
+ *
+ * Deliberately ahead of the backend call: `startHelmOp` resolves only after a
+ * round trip, and output can arrive the moment it does. A row built after the
+ * await would be built after the first line had nowhere to land.
+ */
+function register(req: HelmOpRequest): number {
+  const id = ++seq;
+  const now = Date.now();
+  ops = [
+    ...ops,
+    {
+      id,
+      kind: req.kind,
+      release: req.release,
+      namespace: req.namespace,
+      context: req.context,
+      state: "running",
+      output: [],
+      startedAt: now,
+    },
+  ];
+  emit();
+  return id;
+}
+
+/**
+ * A line from the operation.
+ *
+ * Buffered rather than committed, and folded into the snapshot at most once a
+ * second. `helm upgrade --wait` narrates itself continuously while it waits on
+ * a rollout, and a store that rebuilt its array for every line would wake
+ * every `useSyncExternalStore` subscriber several times a second — the same
+ * problem millisecond stamps caused in `sessions.ts`, arriving here through
+ * the output array instead of a timestamp.
+ *
+ * The first line of any second lands at once, so an operation that has just
+ * started printing is visibly printing; the rest of that second's lines wait
+ * together. Nothing is lost by waiting: {@link scheduleFlush} lands the tail
+ * when the output stops, and {@link settle} lands it immediately when the
+ * operation ends.
+ */
+function receive(id: number, line: string) {
+  const buffered = pending.get(id);
+  if (buffered) buffered.push(line);
+  else pending.set(id, [line]);
+  if (lastFlush.get(id) === wholeSecond(Date.now())) scheduleFlush(id);
+  else flush(id);
+}
+
+/** Land the tail of a mid-second burst once the second turns. Only ever one
+ *  timer per operation: a later line in the same second joins the buffer the
+ *  pending timer will flush. */
+function scheduleFlush(id: number) {
+  if (flushTimers.has(id)) return;
+  const now = Date.now();
+  flushTimers.set(
+    id,
+    setTimeout(() => flush(id), wholeSecond(now) + 1000 - now),
+  );
+}
+
+/** Fold whatever this operation has buffered into the snapshot. */
+function flush(id: number) {
+  clearTimeout(flushTimers.get(id));
+  flushTimers.delete(id);
+  const buffered = pending.get(id);
+  pending.delete(id);
+  lastFlush.set(id, wholeSecond(Date.now()));
+  if (!buffered || buffered.length === 0) return;
+  commit(ops.map((o) => (o.id === id ? { ...o, output: [...o.output, ...buffered] } : o)));
+}
+
+/**
+ * The operation is over. The row STAYS, `done` or `failed`, carrying its
+ * output and — when it failed — why.
+ *
+ * `reason` is whatever the backend gave; a clean exit gives nothing. A row
+ * that has already ended is left alone rather than rebuilt, so the store does
+ * not wake its subscribers for an ending it already knows about.
+ */
+function settle(id: number, reason: unknown) {
+  flush(id);
+  forget(id);
+  const error = describedReason(reason);
+  commit(
+    ops.map((o) => {
+      if (o.id !== id) return o;
+      const state = error ? "failed" : "done";
+      if (o.state === state && o.error === error) return o;
+      return { ...o, state, error };
+    }),
+  );
+}
+
+/**
+ * Stop watching this operation and drop its buffers. Idempotent.
+ *
+ * Watching is all this ends. `close()` unsubscribes from the stream; the helm
+ * process and the cluster mutation behind it are entirely unaffected.
+ */
+function forget(id: number) {
+  clearTimeout(flushTimers.get(id));
+  flushTimers.delete(id);
+  pending.delete(id);
+  handles.get(id)?.close();
+  handles.delete(id);
+}
+
+/** An epoch stamp at second resolution. See {@link receive}. */
+function wholeSecond(millis: number): number {
+  return Math.floor(millis / 1000) * 1000;
+}
+
+/** A reason worth showing, said the way a reader can use it — a backend
+ *  string, or a thrown value from an operation that never started.
+ *  `describeError` strips the wrappers either arrives in and classifies what
+ *  is left; nothing at all, or an empty reason, is not a sentence and stays
+ *  nothing, which is what a clean exit gives. */
+function describedReason(reason: unknown): string | undefined {
+  if (reason === null || reason === undefined) return undefined;
+  if (typeof reason === "string" && reason.trim() === "") return undefined;
+  return describeError(reason).detail;
+}
+
+/**
+ * The one way the snapshot changes: take a rebuilt list only if some row in it
+ * actually changed, or a row left it. Identity is the snapshot's contract, and
+ * a no-op assignment breaks it — but so does a length change that every
+ * surviving row happens to match, which is what dropping the LAST row looks
+ * like to a positional comparison alone.
+ */
+function commit(next: HelmOpRow[]) {
+  if (next.length === ops.length && !next.some((o, i) => o !== ops[i])) return;
+  ops = next;
+  emit();
+}

--- a/packages/ui-next/src/lib/helmOps.ts
+++ b/packages/ui-next/src/lib/helmOps.ts
@@ -13,11 +13,36 @@ import { describeError, startHelmOp } from "@srelens/core";
  * **Nothing here cancels anything, and no name in this file may suggest it.**
  * A shell dies with its process and a tunnel dies with its socket, so their
  * stores can honestly offer to end one. A `helm upgrade` is a cluster mutation
- * that continues whether srelens watches or not: core's `close()` unsubscribes
- * this window from the stream and touches the release not at all. That is why
- * {@link dismissHelmOp} declines to remove a `running` row — a row that
+ * partway through, and there is no honest way to take it back — which is why
+ * {@link dismissHelmOp} declines to remove a `running` row: a row that
  * disappeared under a dismiss button would read as a cancel, and it is not
  * one.
+ *
+ * **`close()` is not a quiet unsubscribe. It kills helm.** The handle core
+ * hands back invokes `helm_op_close`, which aborts the tokio task owning the
+ * `tokio::process::Child` — and that child is spawned `kill_on_drop(true)`, so
+ * dropping the aborted future SIGKILLs helm wherever it had reached. A release
+ * left half-upgraded, its Secret mid-write, and no output saying why, because
+ * the process that would have said it is gone. `crates/streams/src/helm.rs`
+ * calls it "best-effort abort" and means exactly that.
+ *
+ * **So the rule this module keeps: never close a handle whose row is still
+ * `running`.** Every call obeys it today — {@link settle} closes after the
+ * process has already exited, {@link dismissHelmOp} declines a `running` row
+ * outright, the late-handle guard in {@link startHelmOperation} closes only a
+ * row that has already settled, and `__resetHelmOpsForTests` runs under vitest
+ * alone. Nothing in a running app reaches {@link forget} while an operation is
+ * in flight, and that is a property to keep rather than one to rely on
+ * accidentally: a new caller of `forget`, or a new export of any kind, must
+ * check the row's state and leave a `running` one watching. There is no "just
+ * stop listening" to reach for here — from this side, stopping listening IS
+ * the kill. `helmOps.test.ts` pins both halves: that no live entry point
+ * closes a running handle, and that the export list is the one that claim was
+ * traced across.
+ *
+ * (The backend's `HelmManager::shutdown_all` aborts the same way when a user's
+ * environment is dropped. That is out of this module's hands and deliberate
+ * there; it is not licence to do it from here.)
  *
  * **No status word or tone lives here.** This module holds state; the words
  * for it come from core, the same way every other screen in this migration
@@ -154,8 +179,10 @@ export async function startHelmOperation(req: HelmOpRequest): Promise<number> {
   // handle to close, so storing this one would park a subscription nothing
   // ever closes. (A row that has left entirely is the test reset's doing:
   // `dismissHelmOp` declines every `running` row, and the row is `running` for
-  // this whole window.) Stop watching what just opened. The operation itself
-  // carries on regardless; nothing here could stop it.
+  // this whole window.) Closing here is safe for the one reason closing is
+  // ever safe in this module: the guard runs only when the row has already
+  // settled, so the helm process this would kill has already exited. A
+  // `running` row keeps its handle and falls through.
   const row = ops.find((o) => o.id === id);
   if (!row || row.state !== "running") {
     handle.close();
@@ -184,7 +211,15 @@ export function dismissHelmOp(id: number): void {
   commit(ops.filter((o) => o.id !== id));
 }
 
-/** Reset the module-level store between tests. */
+/**
+ * Reset the module-level store between tests.
+ *
+ * The one place that closes a `running` operation's handle, and therefore the
+ * one exception to this module's rule. It is safe only because it never runs
+ * outside vitest, where the handle is a double and no helm process exists to
+ * kill. Do not call it from app code, and do not copy its shape into a
+ * "clear everything" the shell could reach.
+ */
 export function __resetHelmOpsForTests(): void {
   for (const id of [...handles.keys()]) forget(id);
   for (const id of [...flushTimers.keys()]) forget(id);
@@ -298,6 +333,8 @@ function flush(id: number, second: number = wholeSecond(Date.now())) {
  */
 function settle(id: number, reason: unknown) {
   flush(id);
+  // Safe to close here, and only here by default: `onExit` fired, so the helm
+  // process is gone and there is nothing left for the abort to kill.
   forget(id);
   const error = describedReason(reason);
   commit(
@@ -311,10 +348,14 @@ function settle(id: number, reason: unknown) {
 }
 
 /**
- * Stop watching this operation and drop its buffers. Idempotent.
+ * Let go of this operation: drop its buffers and close its stream handle.
+ * Idempotent.
  *
- * Watching is all this ends. `close()` unsubscribes from the stream; the helm
- * process and the cluster mutation behind it are entirely unaffected.
+ * **Callers must have established that the operation is no longer `running`.**
+ * `close()` kills the helm process — see the rule in this module's header —
+ * so this is a function for an operation that has already ended, not a way to
+ * stop caring about one that has not. The three callers that reach a live row
+ * each check first, and the fourth is the test reset.
  */
 function forget(id: number) {
   clearTimeout(flushTimers.get(id));

--- a/packages/ui-next/src/lib/routes.test.ts
+++ b/packages/ui-next/src/lib/routes.test.ts
@@ -12,6 +12,7 @@ import { Forwards } from "../screens/Forwards";
 import { Logs, logsRoute } from "../screens/Logs";
 import { ResourceDetailScreen, Resources } from "../screens/Resources";
 import { Terminals } from "../screens/Terminals";
+import { Helm } from "../screens/Helm";
 import { Toolbox } from "../screens/Toolbox";
 import { Workloads } from "../screens/Workloads";
 
@@ -181,6 +182,14 @@ suite("screenFor", () => {
     // Without an entry here it landed the reader on the Placeholder with a
     // live PTY running behind it and nothing on screen to attach to.
     expect(screenFor("/terminals")).toBe(Terminals);
+  });
+
+  it("resolves /helm to the helm screen", () => {
+    // Cluster-scoped, and the only route that reaches the release table, the
+    // diff pane and the four operations. Without an entry here `/helm` titled
+    // itself correctly in the strip and then rendered the Placeholder — the
+    // sidebar's Helm node led nowhere.
+    expect(screenFor("/helm")).toBe(Helm);
   });
 
   it("resolves /toolbox to the toolbox screen", () => {

--- a/packages/ui-next/src/lib/routes.ts
+++ b/packages/ui-next/src/lib/routes.ts
@@ -4,6 +4,7 @@ import { parseDetailRoute } from "./detailRoute";
 import { AppLog } from "../screens/AppLog";
 import { Events } from "../screens/Events";
 import { Forwards } from "../screens/Forwards";
+import { Helm } from "../screens/Helm";
 import { Logs, parseLogsRoute } from "../screens/Logs";
 import { Overview } from "../screens/Overview";
 import { ReleaseNotes } from "../screens/ReleaseNotes";
@@ -157,6 +158,11 @@ const SCREENS: Record<string, ScreenComponent> = Object.assign(Object.create(nul
   // session first and opens this tab on it, so without this entry that action
   // left a live PTY running behind a Placeholder.
   "/terminals": Terminals,
+  // Cluster-scoped, and the last of the three screens whose work outlives the
+  // tab: an upgrade or a rollback started here keeps running in `helmOps`
+  // after its dialog closes, and the status strip counts it from there. The
+  // sidebar's Helm node points at this route and nothing else does.
+  "/helm": Helm,
   // App-scoped: the managed kubectl, helm and krew are the machine's, and the
   // exec-auth rail is the only part of it that looks at a context at all.
   "/toolbox": Toolbox,

--- a/packages/ui-next/src/screens/Helm.test.tsx
+++ b/packages/ui-next/src/screens/Helm.test.tsx
@@ -347,16 +347,34 @@ describe("Helm — the header", () => {
     );
   });
 
-  it("opens the install dialog on a release name, never an empty one", async () => {
+  /**
+   * **The name is the reader's, not a fixture's.** This screen used to open
+   * the install dialog on `new-release` — the design's own placeholder — and
+   * the dialog had no field to change it with. Every install was therefore
+   * called `new-release`, and the second one helm refused outright: "cannot
+   * re-use a name that is still in use". The same defect as §A.5's
+   * "Twelve pods" alert, which this branch caught and this did not.
+   */
+  it("opens the install dialog on an empty name field, not on the mock's fixture", async () => {
     open();
     await ready();
     await userEvent.click(screen.getByRole("button", { name: "Install chart" }));
 
     const dialog = await screen.findByRole("dialog");
-    expect(within(dialog).getByText("Install new-release")).toBeTruthy();
-    // The gate that proves the name is a prop and not a field: an empty
-    // release can never open it.
-    expect(within(dialog).getByLabelText("Chart")).toBeTruthy();
+    expect(within(dialog).queryByText("Install new-release")).toBeNull();
+    expect((within(dialog).getByLabelText("Release name") as HTMLInputElement).value).toBe("");
+    // The context's own namespace, prefilled and editable.
+    expect((within(dialog).getByLabelText("Namespace") as HTMLInputElement).value).toBe("platform");
+    // Nothing to install until the reader says what to call it.
+    expect((within(dialog).getByRole("button", { name: "Install" }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+
+    await userEvent.type(within(dialog).getByLabelText("Release name"), "checkout-api");
+    await userEvent.type(within(dialog).getByLabelText("Chart"), "bitnami/nginx");
+    expect(document.querySelector(".copy-command-text")?.textContent).toBe(
+      "helm install checkout-api bitnami/nginx --namespace platform --create-namespace",
+    );
   });
 });
 

--- a/packages/ui-next/src/screens/Helm.test.tsx
+++ b/packages/ui-next/src/screens/Helm.test.tsx
@@ -151,6 +151,18 @@ const MANIFESTS: Record<string, Record<number, string>> = {
 };
 
 /**
+ * The values each release was actually installed with — what `helm get values`
+ * answers, and what an upgrade must not throw away.
+ *
+ * `checkout` carries a body no chart default would produce, so a dialog that
+ * opened on the chart's defaults instead cannot look right by accident.
+ */
+const VALUES: Record<string, string> = {
+  "checkout/checkout": "replicaCount: 12\nimage:\n  tag: \"4f2a1c\"\nresources:\n  limits:\n    cpu: 500m",
+  "payments/payments": "replicas: 4",
+};
+
+/**
  * What helm reports about each release's revisions — what `lastGoodRevision`
  * reads, and the only thing that stops the rollback dialog opening blank.
  *
@@ -181,7 +193,9 @@ beforeEach(() => {
       const history = HISTORIES[key] ?? [];
       // No revision named: the screen asking what this release's revisions are,
       // which is what a rollback dialog opens on.
-      if (revision === undefined) return { release: { name, manifest: "", history } };
+      if (revision === undefined) {
+        return { release: { name, manifest: "", history, valuesYaml: VALUES[key] ?? "" } };
+      }
       const manifest = MANIFESTS[key]?.[revision];
       if (manifest === undefined) return { error: `no revision ${revision} of ${name}` };
       return { release: { name, manifest, history } };
@@ -523,6 +537,49 @@ describe("Helm — the operations", () => {
     expect((hintedField("Target revision") as HTMLInputElement).value).toBe("");
   });
 
+  /**
+   * **The defect.** `helm upgrade <rel> <chart>` with neither `-f` nor
+   * `--reuse-values` applies the chart's DEFAULTS: every value the release was
+   * installed with is discarded. A dialog opened on an empty editor is that
+   * command, one click away, with nothing on screen saying so.
+   */
+  it("opens the upgrade dialog on the values the release is actually running", async () => {
+    open();
+    await ready();
+    await userEvent.click(
+      within(rowFor("checkout", "checkout")).getByRole("button", { name: "Upgrade checkout" }),
+    );
+
+    await screen.findByRole("dialog");
+    await waitFor(() =>
+      expect(document.querySelector(".cm-content")?.textContent).toContain("replicaCount: 12"),
+    );
+    expect(document.querySelector(".cm-content")?.textContent).toContain("cpu: 500m");
+  });
+
+  /**
+   * The degrade, and the whole point of the fix: a refused `helm get values`
+   * must NOT fall through to an empty editor, because an empty editor is the
+   * defect. `--reuse-values` keeps what is on the release, and the reader is
+   * told why the box is empty.
+   */
+  it("tells helm to reuse the release's values when srelens cannot read them", async () => {
+    core.getHelmRelease.mockResolvedValue({
+      error: "ApiError: Unauthorized (Status { code: 401 })",
+    });
+    open();
+    await ready();
+    await userEvent.click(
+      within(rowFor("checkout", "checkout")).getByRole("button", { name: "Upgrade checkout" }),
+    );
+
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText(/could not read/i)).toBeTruthy();
+    // core's classification, not the raw Rust string.
+    expect(within(dialog).getByText(/rejected your credentials/i)).toBeTruthy();
+    expect(document.querySelector(".copy-command-text")?.textContent).toContain("--reuse-values");
+  });
+
   it("opens the values editor as an upgrade of the selected release", async () => {
     open();
     await ready();
@@ -532,6 +589,11 @@ describe("Helm — the operations", () => {
     await userEvent.click(screen.getByRole("button", { name: "Values editor" }));
     const dialog = await screen.findByRole("dialog");
     expect(within(dialog).getByText("Upgrade payments")).toBeTruthy();
+    // The footer button is named for the editor, so it had better open on the
+    // release's own values — it is the same upgrade path as the row action.
+    await waitFor(() =>
+      expect(document.querySelector(".cm-content")?.textContent).toContain("replicas: 4"),
+    );
   });
 });
 

--- a/packages/ui-next/src/screens/Helm.test.tsx
+++ b/packages/ui-next/src/screens/Helm.test.tsx
@@ -29,11 +29,11 @@ if (!("ResizeObserver" in globalThis)) {
   };
 }
 
-import type { ClusterContext, HelmReleaseSummary } from "@srelens/core";
+import type { ClusterContext, HelmReleaseSummary, HelmRevision } from "@srelens/core";
 import { Helm } from "./Helm";
 import { ConsoleProvider } from "../console";
 import { resetContexts, setContexts } from "../lib/clusters";
-import { __resetHelmOpsForTests } from "../lib/helmOps";
+import { __resetHelmOpsForTests, startHelmOperation } from "../lib/helmOps";
 import { defaultState } from "../lib/tabs";
 import * as store from "../lib/tabsStore";
 import { resetView } from "../lib/workspace";
@@ -106,28 +106,85 @@ const REDIS: HelmReleaseSummary = {
   updated: iso(41 * DAY),
 };
 
-const RELEASES = [INGRESS, CHECKOUT, PAYMENTS, REDIS];
+/**
+ * A SECOND release called `checkout`, in another namespace.
+ *
+ * Helm scopes a release name to a namespace, so `checkout/checkout` and
+ * `staging/checkout` are two different releases that happen to share a name —
+ * the ordinary shape of a cluster running staging beside production. It is
+ * here because the other four share namespaces but no names, which leaves the
+ * load-bearing half of the row key unexercised: with a name-only key, clicking
+ * this row would diff PRODUCTION's release and the pane's `Roll back` would
+ * then operate on the row the lookup found rather than the row the reader
+ * clicked. On a screen with an Uninstall button that is the worst failure it
+ * has.
+ */
+const STAGING_CHECKOUT: HelmReleaseSummary = {
+  name: "checkout",
+  namespace: "staging",
+  revision: 7,
+  status: "deployed",
+  chart: "acme-service",
+  chartVersion: "2.3.0",
+  appVersion: "0a91bb",
+  updated: iso(2 * DAY),
+};
 
-/** Two rendered manifests per release, so the pane has something to diff. */
+const RELEASES = [INGRESS, CHECKOUT, PAYMENTS, REDIS, STAGING_CHECKOUT];
+
+/**
+ * Two rendered manifests per release, keyed the way helm scopes a release:
+ * `<namespace>/<name>`. Production's `checkout` and staging's have different
+ * revisions AND different manifests, so a pane showing the wrong one cannot
+ * look right by accident.
+ */
 const MANIFESTS: Record<string, Record<number, string>> = {
-  checkout: {
+  "checkout/checkout": {
     118: 'replicaCount: 12\nimage:\n  tag: "118a7e"',
     119: 'replicaCount: 12\nimage:\n  tag: "4f2a1c"',
     120: 'replicaCount: 12\nimage:\n  tag: "9de110"',
   },
-  payments: { 61: "replicas: 1", 62: "replicas: 4" },
-  "ingress-nginx": { 13: "replicas: 1", 14: "replicas: 2" },
-  "redis-session": { 4: "replicas: 1", 5: "replicas: 2" },
+  "payments/payments": { 59: "replicas: 1", 60: "replicas: 2", 61: "replicas: 3", 62: "replicas: 4" },
+  "platform/ingress-nginx": { 13: "replicas: 1", 14: "replicas: 2" },
+  "checkout/redis-session": { 4: "replicas: 1", 5: "replicas: 2" },
+  "staging/checkout": { 6: "replicaCount: 1", 7: "replicaCount: 2" },
+};
+
+/**
+ * What helm reports about each release's revisions — what `lastGoodRevision`
+ * reads, and the only thing that stops the rollback dialog opening blank.
+ *
+ * `checkout` is the ordinary shape: the revision before the current one is
+ * `superseded`, so the newest revision helm does not report failed IS the one
+ * §16's footer names. `payments` is the shape where the two diverge: its
+ * revision 61 failed, so the footer names 61 and the dialog offers 60.
+ */
+const HISTORIES: Record<string, HelmRevision[]> = {
+  "checkout/checkout": [
+    { revision: 117, status: "superseded", updated: iso(3 * DAY), chartVersion: "2.3.9", description: "Upgrade complete" },
+    { revision: 118, status: "superseded", updated: iso(1 * DAY), chartVersion: "2.4.0", description: "Upgrade complete" },
+    { revision: 119, status: "failed", updated: iso(6 * 60_000), chartVersion: "2.4.1", description: "Upgrade failed" },
+  ],
+  "payments/payments": [
+    { revision: 60, status: "superseded", updated: iso(9 * DAY), chartVersion: "2.3.8", description: "Upgrade complete" },
+    { revision: 61, status: "failed", updated: iso(7 * DAY), chartVersion: "2.4.0", description: "Upgrade failed" },
+    { revision: 62, status: "pending-upgrade", updated: iso(5 * DAY), chartVersion: "2.4.1", description: "Upgrade in progress" },
+  ],
 };
 
 beforeEach(() => {
   vi.clearAllMocks();
   core.listHelmReleases.mockResolvedValue({ releases: RELEASES });
   core.getHelmRelease.mockImplementation(
-    async (_ctx: string, _ns: string, name: string, _invoke?: unknown, revision?: number) => {
-      const manifest = MANIFESTS[name]?.[revision ?? -1];
+    async (_ctx: string, ns: string, name: string, _invoke?: unknown, revision?: number) => {
+      const key = `${ns}/${name}`;
+      const history = HISTORIES[key] ?? [];
+      // No revision named: the screen asking what this release's revisions are,
+      // which is what a rollback dialog opens on.
+      if (revision === undefined) return { release: { name, manifest: "", history } };
+      const manifest = MANIFESTS[key]?.[revision];
       if (manifest === undefined) return { error: `no revision ${revision} of ${name}` };
-      return { release: { name, manifest, history: [] } };
+      return { release: { name, manifest, history } };
     },
   );
   core.startHelmOp.mockResolvedValue({ close: vi.fn() });
@@ -156,14 +213,15 @@ const headers = () =>
  * both a release name and a namespace, so a whole-document text query finds
  * two nodes in the same row and a third in another.
  */
-const rowFor = (name: string) =>
-  Array.from(document.querySelectorAll("tbody tr")).find(
-    (tr) => tr.querySelector("td")?.textContent?.trim() === name,
-  ) as HTMLElement;
+const rowFor = (name: string, namespace?: string) =>
+  Array.from(document.querySelectorAll("tbody tr")).find((tr) => {
+    const td = Array.from(tr.querySelectorAll("td")).map((c) => c.textContent?.trim() ?? "");
+    return td[0] === name && (namespace === undefined || td[1] === namespace);
+  }) as HTMLElement;
 
 /** Select a release the way the reader does: a click on its row. */
-const select = (name: string) =>
-  userEvent.click(rowFor(name).querySelector("td") as HTMLElement);
+const select = (name: string, namespace?: string) =>
+  userEvent.click(rowFor(name, namespace).querySelector("td") as HTMLElement);
 const cells = (row: HTMLElement) =>
   Array.from(row.querySelectorAll("td")).map((td) => td.textContent?.trim() ?? "");
 const cell = (row: HTMLElement, column: string) => cells(row)[headers().indexOf(column)];
@@ -191,6 +249,50 @@ const railHead = () => heads()[1] ?? "";
 
 async function ready() {
   await screen.findByText("ingress-nginx");
+}
+
+/**
+ * Arm the backend so the next helm operation can be ended on demand.
+ *
+ * `fire` settles it: `null` is a clean exit, anything else is the reason it
+ * failed.
+ */
+function armOperation(): { fire: (reason: unknown) => Promise<void> } {
+  let onExit: ((reason: unknown) => void) | undefined;
+  core.startHelmOp.mockImplementation(
+    async (
+      _ctx: string,
+      _args: string[],
+      _onData: (line: string) => void,
+      exit: (reason: unknown) => void,
+    ) => {
+      onExit = exit;
+      return { close: vi.fn() };
+    },
+  );
+  return {
+    fire: async (reason: unknown) => {
+      await act(async () => {
+        onExit?.(reason);
+      });
+    },
+  };
+}
+
+/**
+ * Run an operation to completion through the store rather than through the
+ * screen — an upgrade started somewhere else, or on another cluster.
+ */
+async function settleElsewhere(context: string) {
+  const armed = armOperation();
+  await startHelmOperation({
+    kind: "upgrade",
+    release: "checkout",
+    namespace: "checkout",
+    context,
+    args: ["upgrade", "checkout"],
+  });
+  await armed.fire(null);
 }
 
 describe("Helm — the header", () => {
@@ -223,7 +325,7 @@ describe("Helm — the header", () => {
       "Explain: Which Helm releases on prod-eu need attention?",
     );
 
-    await select("checkout");
+    await select("checkout", "checkout");
     await waitFor(() =>
       expect(screen.getByRole("button", { name: /^Explain: / }).getAttribute("aria-label")).toBe(
         "Explain: What did checkout release 119 change?",
@@ -248,7 +350,7 @@ describe("Helm — the release table", () => {
   it("heads the pane with how many releases this cluster has", async () => {
     open();
     await ready();
-    expect(heads()[0]).toBe("Releases · 4 in this cluster");
+    expect(heads()[0]).toBe("Releases · 5 in this cluster");
   });
 
   it("renders §16's columns in §16's order", async () => {
@@ -283,7 +385,7 @@ describe("Helm — the release table", () => {
     open();
     await ready();
     expect(verdict(rowFor("ingress-nginx"))).toEqual({ word: "deployed", kind: "success" });
-    expect(verdict(rowFor("checkout"))).toEqual({ word: "failed", kind: "danger" });
+    expect(verdict(rowFor("checkout", "checkout"))).toEqual({ word: "failed", kind: "danger" });
     expect(verdict(rowFor("payments"))).toEqual({ word: "pending-upgrade", kind: "warning" });
     // Helm's set is Helm's to extend: the word Helm gave, toned neutral.
     expect(verdict(rowFor("redis-session"))).toEqual({ word: "quiescing", kind: "neutral" });
@@ -308,7 +410,7 @@ describe("Helm — the release table", () => {
   it("offers §16's three operations on every row, with the release named", async () => {
     open();
     await ready();
-    const row = rowFor("checkout");
+    const row = rowFor("checkout", "checkout");
     expect(within(row).getByRole("button", { name: "Upgrade checkout" })).toBeTruthy();
     expect(within(row).getByRole("button", { name: "Roll back checkout" })).toBeTruthy();
     expect(within(row).getByRole("button", { name: "Uninstall checkout" })).toBeTruthy();
@@ -319,7 +421,7 @@ describe("Helm — the operations", () => {
   it("opens the dialog in upgrade mode, on the row's own chart", async () => {
     open();
     await ready();
-    await userEvent.click(screen.getByRole("button", { name: "Upgrade checkout" }));
+    await userEvent.click(within(rowFor("checkout", "checkout")).getByRole("button", { name: "Upgrade checkout" }));
 
     const dialog = await screen.findByRole("dialog");
     expect(within(dialog).getByText("Upgrade checkout")).toBeTruthy();
@@ -330,7 +432,7 @@ describe("Helm — the operations", () => {
   it("opens the dialog in rollback mode", async () => {
     open();
     await ready();
-    await userEvent.click(screen.getByRole("button", { name: "Roll back checkout" }));
+    await userEvent.click(within(rowFor("checkout", "checkout")).getByRole("button", { name: "Roll back checkout" }));
 
     const dialog = await screen.findByRole("dialog");
     expect(within(dialog).getByText("Roll back checkout")).toBeTruthy();
@@ -340,7 +442,7 @@ describe("Helm — the operations", () => {
   it("opens the dialog in uninstall mode, behind the typed gate", async () => {
     open();
     await ready();
-    await userEvent.click(screen.getByRole("button", { name: "Uninstall checkout" }));
+    await userEvent.click(within(rowFor("checkout", "checkout")).getByRole("button", { name: "Uninstall checkout" }));
 
     const dialog = await screen.findByRole("dialog");
     expect(within(dialog).getByText("Uninstall checkout")).toBeTruthy();
@@ -349,23 +451,75 @@ describe("Helm — the operations", () => {
   });
 
   /**
-   * §16's footer names the diff's left-hand revision — 118, one before what is
-   * running. The dialog's own default target is `lastGoodRevision`, a
-   * different question with a different answer, and the two are NOT
-   * reconciled: the pane says which revision it is showing you, the dialog
-   * says which one it is safe to return to.
+   * A control must honour its own label. §16's footer reads `Roll back to 118`,
+   * and the dialog behind it has to open on 118 — not on a blank field asking
+   * the reader to type back the number they just clicked.
    */
-  it("rolls back from the pane's footer without overriding the dialog's own target", async () => {
+  it("opens the pane's `Roll back to 118` on 118", async () => {
     open();
     await ready();
-    await select("checkout");
+    await select("checkout", "checkout");
     await waitFor(() => expect(railHead()).toContain("118 → 119"));
 
     await userEvent.click(screen.getByRole("button", { name: "Roll back to 118" }));
     const dialog = await screen.findByRole("dialog");
     expect(within(dialog).getByText("Roll back checkout")).toBeTruthy();
-    // The screen passes no history, so the dialog has no revision it can
-    // vouch for and says so rather than filling in 118 on the pane's say-so.
+    expect((hintedField("Target revision") as HTMLInputElement).value).toBe("118");
+  });
+
+  /**
+   * The row action asked for no particular revision, so the dialog's own
+   * default stands — which on this release is the same number, because helm
+   * reports 118 superseded and `lastGoodRevision` picks the newest revision it
+   * does not report failed.
+   */
+  it("opens the row's `Roll back` on the dialog's own default", async () => {
+    open();
+    await ready();
+    await userEvent.click(
+      within(rowFor("checkout", "checkout")).getByRole("button", { name: "Roll back checkout" }),
+    );
+
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("Roll back checkout")).toBeTruthy();
+    expect((hintedField("Target revision") as HTMLInputElement).value).toBe("118");
+  });
+
+  /**
+   * **And the two numbers are still not reconciled.**
+   *
+   * `payments` is at 62 and its revision 61 FAILED. The pane names 61 —
+   * "here is the revision the diff on screen is comparing against" — and the
+   * dialog offers 60 — "here is the newest revision that is safe to return
+   * to". Different questions, different answers, and nothing in this screen
+   * makes either say the other's number.
+   */
+  it("lets the dialog offer an older revision when the one the pane names failed", async () => {
+    open();
+    await ready();
+    await select("payments");
+    await waitFor(() => expect(railHead()).toContain("61 → 62"));
+
+    const footer = screen.getByRole("button", { name: "Roll back to 61" });
+    await userEvent.click(footer);
+    const dialog = await screen.findByRole("dialog");
+    expect((hintedField("Target revision") as HTMLInputElement).value).toBe("60");
+    // The hint says which revision it chose and what helm reports about it —
+    // core's word, not this screen's.
+    expect(within(dialog).getByText(/Revision 60 .*it reads superseded/)).toBeTruthy();
+  });
+
+  /** A refused history is the dialog's own degrade, not a broken dialog. */
+  it("still opens the rollback dialog when the revisions cannot be read", async () => {
+    core.getHelmRelease.mockResolvedValue({ error: "boom" });
+    open();
+    await ready();
+    await userEvent.click(
+      within(rowFor("checkout", "checkout")).getByRole("button", { name: "Roll back checkout" }),
+    );
+
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("Roll back checkout")).toBeTruthy();
     expect((hintedField("Target revision") as HTMLInputElement).value).toBe("");
   });
 
@@ -401,9 +555,34 @@ describe("Helm — the pane", () => {
     await waitFor(() => expect(railHead()).toContain("payments · 61 → 62"));
     expect(railHead()).not.toContain("ingress-nginx");
 
-    await select("checkout");
+    await select("checkout", "checkout");
     await waitFor(() => expect(railHead()).toContain("checkout · 118 → 119"));
     expect(railHead()).not.toContain("payments");
+  });
+
+  /**
+   * The namespace half of the row key, which is the half that is load-bearing.
+   *
+   * `checkout/checkout` and `staging/checkout` are two releases with one name.
+   * A name-only key resolves both to whichever came back first, so clicking
+   * staging's row would diff PRODUCTION's release — and the footer's
+   * `Roll back to N`, which reads the same lookup, would then offer to operate
+   * on it.
+   */
+  it("follows the row the reader clicked when two releases share a name", async () => {
+    open();
+    await ready();
+
+    await select("checkout", "staging");
+    await waitFor(() => expect(railHead()).toContain("checkout · 6 → 7"));
+    expect(railHead()).not.toContain("119");
+    // The footer acts on the row that was clicked, not on the one the lookup
+    // happened to find.
+    expect(screen.getByRole("button", { name: "Roll back to 6" })).toBeTruthy();
+
+    await select("checkout", "checkout");
+    await waitFor(() => expect(railHead()).toContain("checkout · 118 → 119"));
+    expect(screen.getByRole("button", { name: "Roll back to 118" })).toBeTruthy();
   });
 
   it("tones the pane's badge with core's verdict for the selected release", async () => {
@@ -419,39 +598,62 @@ describe("Helm — the pane", () => {
    * upgrade leaves the pane diffing 118 → 119 — the pair from BEFORE the
    * upgrade — on a release that is now at 120.
    */
-  it("refreshes the revision when an operation finishes, so the diff moves on", async () => {
-    let exit: ((reason: unknown) => void) | undefined;
-    core.startHelmOp.mockImplementation(
-      async (
-        _ctx: string,
-        _args: string[],
-        _onData: (line: string) => void,
-        onExit: (reason: unknown) => void,
-      ) => {
-        exit = onExit;
-        return { close: vi.fn() };
-      },
-    );
-
-    open();
-    await ready();
-    await select("checkout");
+  /** Start an upgrade of production's `checkout` from the table, and arm it. */
+  async function upgradeCheckout() {
+    const armed = armOperation();
+    await select("checkout", "checkout");
     await waitFor(() => expect(railHead()).toContain("118 → 119"));
-
-    await userEvent.click(screen.getByRole("button", { name: "Upgrade checkout" }));
+    await userEvent.click(
+      within(rowFor("checkout", "checkout")).getByRole("button", { name: "Upgrade checkout" }),
+    );
     await screen.findByRole("dialog");
     await userEvent.click(screen.getByRole("button", { name: "Upgrade" }));
     await waitFor(() => expect(core.startHelmOp).toHaveBeenCalled());
+    return armed;
+  }
+
+  /** What helm left behind: `checkout` moved on, at whatever status it reached. */
+  function moved(revision: number, status: string) {
+    return {
+      releases: RELEASES.map((r) =>
+        r.name === "checkout" && r.namespace === "checkout" ? { ...r, revision, status } : r,
+      ),
+    };
+  }
+
+  it("refreshes the revision when an operation finishes, so the diff moves on", async () => {
+    open();
+    await ready();
+    const armed = await upgradeCheckout();
 
     // The upgrade lands: helm moved the release to 120.
-    core.listHelmReleases.mockResolvedValue({
-      releases: RELEASES.map((r) => (r.name === "checkout" ? { ...r, revision: 120 } : r)),
-    });
-    await act(async () => {
-      exit?.(null);
-    });
+    core.listHelmReleases.mockResolvedValue(moved(120, "deployed"));
+    await armed.fire(null);
 
     await waitFor(() => expect(railHead()).toContain("119 → 120"));
+  });
+
+  /**
+   * **A failed operation refreshes too.**
+   *
+   * `helm upgrade --wait` writes revision 120 and THEN gives up waiting for it
+   * to come up. The revision exists, at `failed`. A refresh that only listened
+   * for clean exits would leave the table reading `119 / deployed` over a
+   * release that is neither, with the failure banner as the reader's only clue
+   * that anything moved at all — which is the stale pair this effect exists to
+   * prevent, arriving by the other door.
+   */
+  it("refreshes when an operation fails, because a failed upgrade still writes a revision", async () => {
+    open();
+    await ready();
+    const armed = await upgradeCheckout();
+
+    core.listHelmReleases.mockResolvedValue(moved(120, "failed"));
+    await armed.fire("timed out waiting for the condition");
+
+    const row = () => rowFor("checkout", "checkout");
+    await waitFor(() => expect(cell(row(), "Rev")).toBe("120"));
+    expect(verdict(row())).toEqual({ word: "failed", kind: "danger" });
   });
 });
 
@@ -514,5 +716,36 @@ describe("Helm — the three states §16 leaves out", () => {
     open();
     expect(screen.getByText("No cluster in focus")).toBeTruthy();
     expect(core.listHelmReleases).not.toHaveBeenCalled();
+  });
+});
+
+describe("Helm — when to list again", () => {
+  it("lists once on a mount that already has a settled operation behind it", async () => {
+    // The ops store is module-level and outlives the screen: an upgrade
+    // started here, finished while the reader was on another tab, and still
+    // sitting in the store when they come back.
+    await settleElsewhere(CTX.name);
+    core.listHelmReleases.mockClear();
+
+    open();
+    await ready();
+    await act(async () => {});
+
+    // One listing, not the mount's racing the settle effect's.
+    expect(core.listHelmReleases).toHaveBeenCalledTimes(1);
+  });
+
+  it("lists again for this cluster's operations and no one else's", async () => {
+    open();
+    await ready();
+    core.listHelmReleases.mockClear();
+
+    // Another cluster's upgrade changes nothing in the list on screen.
+    await settleElsewhere("edge-apac");
+    expect(core.listHelmReleases).not.toHaveBeenCalled();
+
+    // This one's does.
+    await settleElsewhere(CTX.name);
+    await waitFor(() => expect(core.listHelmReleases).toHaveBeenCalledTimes(1));
   });
 });

--- a/packages/ui-next/src/screens/Helm.test.tsx
+++ b/packages/ui-next/src/screens/Helm.test.tsx
@@ -928,7 +928,11 @@ describe("Helm — the three states §16 leaves out", () => {
   });
 
   it("has nothing to list without a cluster in focus", () => {
+    // Listed, and there genuinely are none — which is the one state where
+    // "pick a cluster in the rail" is true. `resetContexts` alone means "not
+    // listed yet", and that renders the spinner rather than the sentence.
     resetContexts();
+    setContexts([]);
     store.setState(defaultState([]));
     open();
     expect(screen.getByText("No cluster in focus")).toBeTruthy();

--- a/packages/ui-next/src/screens/Helm.test.tsx
+++ b/packages/ui-next/src/screens/Helm.test.tsx
@@ -1,0 +1,518 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+/**
+ * **Only the three capability wrappers are replaced.**
+ *
+ * `helmStatus` stays real, so every status assertion below is against core's
+ * own verdict rather than a copy of it — that is the whole point of Task 2,
+ * and a stubbed one would let a hand-paired table on the screen pass.
+ * `describeError`, `ageFromTimestamp` and `plural` stay real for the same
+ * reason: the failure copy, the ages and the counts are core's arithmetic.
+ */
+const core = vi.hoisted(() => ({
+  listHelmReleases: vi.fn(),
+  getHelmRelease: vi.fn(),
+  startHelmOp: vi.fn(),
+}));
+vi.mock("@srelens/core", async (orig) => ({
+  ...(await orig<typeof import("@srelens/core")>()),
+  ...core,
+}));
+
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
+import type { ClusterContext, HelmReleaseSummary } from "@srelens/core";
+import { Helm } from "./Helm";
+import { ConsoleProvider } from "../console";
+import { resetContexts, setContexts } from "../lib/clusters";
+import { __resetHelmOpsForTests } from "../lib/helmOps";
+import { defaultState } from "../lib/tabs";
+import * as store from "../lib/tabsStore";
+import { resetView } from "../lib/workspace";
+
+const ROUTE = "/helm";
+
+const CTX: ClusterContext = {
+  name: "prod-eu",
+  stableId: "prod",
+  cluster: "prod",
+  server: "https://prod",
+  isCurrent: true,
+  namespace: "platform",
+};
+
+const DAY = 86_400_000;
+const iso = (ago: number) => new Date(Date.now() - ago).toISOString();
+
+/**
+ * §16's releases, trimmed to four — and the four are chosen so that every
+ * branch of core's verdict is on screen at once: `deployed` is the only
+ * healthy word, `failed` the only broken one, `pending-upgrade` is a mutation
+ * in flight, and `quiescing` is a word this build has never heard of.
+ *
+ * `quiescing` is not a Helm status. That is deliberate: Helm's set is Helm's
+ * to extend, and a screen that kept its own label table would either render
+ * nothing for it or invent a word. Core renders it verbatim, toned neutral.
+ */
+const INGRESS: HelmReleaseSummary = {
+  name: "ingress-nginx",
+  namespace: "platform",
+  revision: 14,
+  status: "deployed",
+  chart: "ingress-nginx",
+  chartVersion: "4.12.0",
+  appVersion: "1.12.0",
+  updated: iso(9 * DAY),
+};
+
+const CHECKOUT: HelmReleaseSummary = {
+  name: "checkout",
+  namespace: "checkout",
+  revision: 119,
+  status: "failed",
+  chart: "acme-service",
+  chartVersion: "2.4.1",
+  appVersion: "4f2a1c",
+  updated: iso(6 * 60_000),
+};
+
+const PAYMENTS: HelmReleaseSummary = {
+  name: "payments",
+  namespace: "payments",
+  revision: 62,
+  status: "pending-upgrade",
+  chart: "acme-service",
+  chartVersion: "2.4.1",
+  appVersion: "9.1.3",
+  updated: iso(5 * DAY),
+};
+
+const REDIS: HelmReleaseSummary = {
+  name: "redis-session",
+  namespace: "checkout",
+  revision: 5,
+  status: "quiescing",
+  chart: "redis",
+  chartVersion: "20.6.1",
+  appVersion: "7.4.1",
+  updated: iso(41 * DAY),
+};
+
+const RELEASES = [INGRESS, CHECKOUT, PAYMENTS, REDIS];
+
+/** Two rendered manifests per release, so the pane has something to diff. */
+const MANIFESTS: Record<string, Record<number, string>> = {
+  checkout: {
+    118: 'replicaCount: 12\nimage:\n  tag: "118a7e"',
+    119: 'replicaCount: 12\nimage:\n  tag: "4f2a1c"',
+    120: 'replicaCount: 12\nimage:\n  tag: "9de110"',
+  },
+  payments: { 61: "replicas: 1", 62: "replicas: 4" },
+  "ingress-nginx": { 13: "replicas: 1", 14: "replicas: 2" },
+  "redis-session": { 4: "replicas: 1", 5: "replicas: 2" },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  core.listHelmReleases.mockResolvedValue({ releases: RELEASES });
+  core.getHelmRelease.mockImplementation(
+    async (_ctx: string, _ns: string, name: string, _invoke?: unknown, revision?: number) => {
+      const manifest = MANIFESTS[name]?.[revision ?? -1];
+      if (manifest === undefined) return { error: `no revision ${revision} of ${name}` };
+      return { release: { name, manifest, history: [] } };
+    },
+  );
+  core.startHelmOp.mockResolvedValue({ close: vi.fn() });
+  __resetHelmOpsForTests();
+  resetContexts();
+  setContexts([CTX]);
+  store.setState(defaultState([CTX]));
+  resetView();
+});
+
+function open() {
+  store.openTab(ROUTE);
+  return render(
+    <ConsoleProvider>
+      <Helm route={ROUTE} />
+    </ConsoleProvider>,
+  );
+}
+
+const headers = () =>
+  Array.from(document.querySelectorAll("thead th")).map((th) => th.textContent?.trim() ?? "");
+/**
+ * A row by its Release cell.
+ *
+ * By the first cell rather than by text: `checkout` and `payments` are each
+ * both a release name and a namespace, so a whole-document text query finds
+ * two nodes in the same row and a third in another.
+ */
+const rowFor = (name: string) =>
+  Array.from(document.querySelectorAll("tbody tr")).find(
+    (tr) => tr.querySelector("td")?.textContent?.trim() === name,
+  ) as HTMLElement;
+
+/** Select a release the way the reader does: a click on its row. */
+const select = (name: string) =>
+  userEvent.click(rowFor(name).querySelector("td") as HTMLElement);
+const cells = (row: HTMLElement) =>
+  Array.from(row.querySelectorAll("td")).map((td) => td.textContent?.trim() ?? "");
+const cell = (row: HTMLElement, column: string) => cells(row)[headers().indexOf(column)];
+
+/**
+ * A field whose `Field` carries a hint.
+ *
+ * No word boundary: the kit renders the hint INSIDE the label, so the computed
+ * accessible name runs the two together.
+ */
+const hintedField = (label: string) => screen.getByLabelText(new RegExp(`^${label}`)) as HTMLElement;
+
+/** The status word and the severity the pill drew it at. */
+const verdict = (row: HTMLElement) => {
+  const pill = row.querySelector(".status");
+  return { word: pill?.textContent?.trim() ?? "", kind: pill?.getAttribute("data-kind") ?? "" };
+};
+
+/** Every pane head on screen, in document order: the table's, then §16's rail. */
+const heads = () =>
+  Array.from(document.querySelectorAll(".pane-head")).map((h) => h.textContent?.trim() ?? "");
+
+/** The 420px rail's own head — the second one. */
+const railHead = () => heads()[1] ?? "";
+
+async function ready() {
+  await screen.findByText("ingress-nginx");
+}
+
+describe("Helm — the header", () => {
+  it("titles the screen and names the cluster it is listing", async () => {
+    open();
+    await ready();
+    expect(screen.getByRole("heading", { level: 1 }).textContent).toBe("Helm");
+    expect(screen.getByText("prod-eu / releases")).toBeTruthy();
+  });
+
+  /**
+   * #352's defect, pointed at this screen. `.row-ask` is `opacity: 0` until a
+   * `.tbl tbody tr` is hovered and a header has no row to hover, so an
+   * `AskChip` here would ship an invisible control — which Logs did.
+   */
+  it("asks with a Button rather than the row chip, which a header cannot reveal", async () => {
+    const { container } = open();
+    await ready();
+    const explain = screen.getByRole("button", { name: /^Explain: / });
+    expect(explain.className).not.toContain("row-ask");
+    expect(container.querySelector(".row-ask")).toBeNull();
+  });
+
+  it("asks about the release the reader is looking at", async () => {
+    open();
+    await ready();
+    // Nothing selected: the question is about the cluster, because there is no
+    // release to name.
+    expect(screen.getByRole("button", { name: /^Explain: / }).getAttribute("aria-label")).toBe(
+      "Explain: Which Helm releases on prod-eu need attention?",
+    );
+
+    await select("checkout");
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /^Explain: / }).getAttribute("aria-label")).toBe(
+        "Explain: What did checkout release 119 change?",
+      ),
+    );
+  });
+
+  it("opens the install dialog on a release name, never an empty one", async () => {
+    open();
+    await ready();
+    await userEvent.click(screen.getByRole("button", { name: "Install chart" }));
+
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("Install new-release")).toBeTruthy();
+    // The gate that proves the name is a prop and not a field: an empty
+    // release can never open it.
+    expect(within(dialog).getByLabelText("Chart")).toBeTruthy();
+  });
+});
+
+describe("Helm — the release table", () => {
+  it("heads the pane with how many releases this cluster has", async () => {
+    open();
+    await ready();
+    expect(heads()[0]).toBe("Releases · 4 in this cluster");
+  });
+
+  it("renders §16's columns in §16's order", async () => {
+    open();
+    await ready();
+    expect(headers().slice(0, 6)).toEqual([
+      "Release",
+      "Namespace",
+      "Chart",
+      "Rev",
+      "Status",
+      "Updated",
+    ]);
+  });
+
+  it("renders a row per release, with its chart, revision and age", async () => {
+    open();
+    await ready();
+    const row = rowFor("ingress-nginx");
+    expect(cell(row, "Namespace")).toBe("platform");
+    expect(cell(row, "Chart")).toBe("ingress-nginx-4.12.0");
+    expect(cell(row, "Rev")).toBe("14");
+    expect(cell(row, "Updated")).toBe("9d ago");
+  });
+
+  /**
+   * The load-bearing one. Every word and tone here is core's `helmStatus`, and
+   * the unknown status is what makes a hand-paired table on this screen fail
+   * rather than pass — it has no entry for `quiescing` to have.
+   */
+  it("takes every status word and tone from core's verdict", async () => {
+    open();
+    await ready();
+    expect(verdict(rowFor("ingress-nginx"))).toEqual({ word: "deployed", kind: "success" });
+    expect(verdict(rowFor("checkout"))).toEqual({ word: "failed", kind: "danger" });
+    expect(verdict(rowFor("payments"))).toEqual({ word: "pending-upgrade", kind: "warning" });
+    // Helm's set is Helm's to extend: the word Helm gave, toned neutral.
+    expect(verdict(rowFor("redis-session"))).toEqual({ word: "quiescing", kind: "neutral" });
+  });
+
+  /**
+   * `min-width: auto` has shipped seven times on this migration and jsdom sees
+   * none of them, so the classes are asserted instead. A 420px pane beside a
+   * table whose chart column is unbounded is exactly the setup that pushes the
+   * pane off the window.
+   */
+  it("lets the table shrink instead of pushing the 420px pane off the window", async () => {
+    const { container } = open();
+    await ready();
+    const main = container.querySelector('[data-slot="release-main"]');
+    expect(main?.className).toContain("min-w-0");
+    const chart = container.querySelector('[data-slot="chart-name"]');
+    expect(chart?.className).toContain("truncate");
+    expect(chart?.className).toContain("max-w-[200px]");
+  });
+
+  it("offers §16's three operations on every row, with the release named", async () => {
+    open();
+    await ready();
+    const row = rowFor("checkout");
+    expect(within(row).getByRole("button", { name: "Upgrade checkout" })).toBeTruthy();
+    expect(within(row).getByRole("button", { name: "Roll back checkout" })).toBeTruthy();
+    expect(within(row).getByRole("button", { name: "Uninstall checkout" })).toBeTruthy();
+  });
+});
+
+describe("Helm — the operations", () => {
+  it("opens the dialog in upgrade mode, on the row's own chart", async () => {
+    open();
+    await ready();
+    await userEvent.click(screen.getByRole("button", { name: "Upgrade checkout" }));
+
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("Upgrade checkout")).toBeTruthy();
+    expect((within(dialog).getByLabelText("Chart") as HTMLInputElement).value).toBe("acme-service");
+    expect((within(dialog).getByLabelText("Chart version") as HTMLInputElement).value).toBe("2.4.1");
+  });
+
+  it("opens the dialog in rollback mode", async () => {
+    open();
+    await ready();
+    await userEvent.click(screen.getByRole("button", { name: "Roll back checkout" }));
+
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("Roll back checkout")).toBeTruthy();
+    expect(hintedField("Target revision")).toBeTruthy();
+  });
+
+  it("opens the dialog in uninstall mode, behind the typed gate", async () => {
+    open();
+    await ready();
+    await userEvent.click(screen.getByRole("button", { name: "Uninstall checkout" }));
+
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("Uninstall checkout")).toBeTruthy();
+    // The gate exists only because `release` is a non-empty prop.
+    expect(within(dialog).getByLabelText("Type checkout to confirm")).toBeTruthy();
+  });
+
+  /**
+   * §16's footer names the diff's left-hand revision — 118, one before what is
+   * running. The dialog's own default target is `lastGoodRevision`, a
+   * different question with a different answer, and the two are NOT
+   * reconciled: the pane says which revision it is showing you, the dialog
+   * says which one it is safe to return to.
+   */
+  it("rolls back from the pane's footer without overriding the dialog's own target", async () => {
+    open();
+    await ready();
+    await select("checkout");
+    await waitFor(() => expect(railHead()).toContain("118 → 119"));
+
+    await userEvent.click(screen.getByRole("button", { name: "Roll back to 118" }));
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("Roll back checkout")).toBeTruthy();
+    // The screen passes no history, so the dialog has no revision it can
+    // vouch for and says so rather than filling in 118 on the pane's say-so.
+    expect((hintedField("Target revision") as HTMLInputElement).value).toBe("");
+  });
+
+  it("opens the values editor as an upgrade of the selected release", async () => {
+    open();
+    await ready();
+    await select("payments");
+    await waitFor(() => expect(railHead()).toContain("payments"));
+
+    await userEvent.click(screen.getByRole("button", { name: "Values editor" }));
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("Upgrade payments")).toBeTruthy();
+  });
+});
+
+describe("Helm — the pane", () => {
+  it("starts with nothing selected and says so", async () => {
+    open();
+    await ready();
+    expect(screen.getByText("No release selected")).toBeTruthy();
+  });
+
+  /**
+   * The other load-bearing one: the pane follows the SELECTED row. A pane
+   * hard-wired to the first release — which is what §16's own mock does —
+   * passes every other assertion in this file.
+   */
+  it("follows the selected row rather than the first one", async () => {
+    open();
+    await ready();
+
+    await select("payments");
+    await waitFor(() => expect(railHead()).toContain("payments · 61 → 62"));
+    expect(railHead()).not.toContain("ingress-nginx");
+
+    await select("checkout");
+    await waitFor(() => expect(railHead()).toContain("checkout · 118 → 119"));
+    expect(railHead()).not.toContain("payments");
+  });
+
+  it("tones the pane's badge with core's verdict for the selected release", async () => {
+    open();
+    await ready();
+    await select("redis-session");
+    await waitFor(() => expect(railHead()).toContain("redis-session"));
+    expect(railHead()).toContain("quiescing");
+  });
+
+  /**
+   * Requirement 1 from the previous tasks: without a refresh, a successful
+   * upgrade leaves the pane diffing 118 → 119 — the pair from BEFORE the
+   * upgrade — on a release that is now at 120.
+   */
+  it("refreshes the revision when an operation finishes, so the diff moves on", async () => {
+    let exit: ((reason: unknown) => void) | undefined;
+    core.startHelmOp.mockImplementation(
+      async (
+        _ctx: string,
+        _args: string[],
+        _onData: (line: string) => void,
+        onExit: (reason: unknown) => void,
+      ) => {
+        exit = onExit;
+        return { close: vi.fn() };
+      },
+    );
+
+    open();
+    await ready();
+    await select("checkout");
+    await waitFor(() => expect(railHead()).toContain("118 → 119"));
+
+    await userEvent.click(screen.getByRole("button", { name: "Upgrade checkout" }));
+    await screen.findByRole("dialog");
+    await userEvent.click(screen.getByRole("button", { name: "Upgrade" }));
+    await waitFor(() => expect(core.startHelmOp).toHaveBeenCalled());
+
+    // The upgrade lands: helm moved the release to 120.
+    core.listHelmReleases.mockResolvedValue({
+      releases: RELEASES.map((r) => (r.name === "checkout" ? { ...r, revision: 120 } : r)),
+    });
+    await act(async () => {
+      exit?.(null);
+    });
+
+    await waitFor(() => expect(railHead()).toContain("119 → 120"));
+  });
+});
+
+describe("Helm — the three states §16 leaves out", () => {
+  it("says it is listing while the releases are on their way", async () => {
+    let release: (v: { releases: HelmReleaseSummary[] }) => void = () => {};
+    core.listHelmReleases.mockReturnValue(
+      new Promise<{ releases: HelmReleaseSummary[] }>((resolve) => {
+        release = resolve;
+      }),
+    );
+    open();
+
+    expect(screen.getByRole("status", { name: "Listing Helm releases" })).toBeTruthy();
+    expect(screen.queryByText("ingress-nginx")).toBeNull();
+
+    await act(async () => {
+      release({ releases: RELEASES });
+    });
+    expect(await screen.findByText("ingress-nginx")).toBeTruthy();
+  });
+
+  /** A cluster with no releases is ordinary, not a failure. */
+  it("treats a cluster with no releases as ordinary", async () => {
+    core.listHelmReleases.mockResolvedValue({ releases: [] });
+    open();
+
+    expect(await screen.findByText("No Helm releases")).toBeTruthy();
+    expect(screen.getByText("prod-eu has no Helm releases.")).toBeTruthy();
+    expect(heads()[0]).toBe("Releases · 0 in this cluster");
+    // Nothing here says anything failed.
+    expect(screen.queryByText(/Could not list/)).toBeNull();
+  });
+
+  it("says why the listing failed, in core's words rather than the backend's", async () => {
+    core.listHelmReleases.mockResolvedValue({
+      error: "ApiError: Unauthorized (Status { code: 401 })",
+    });
+    open();
+
+    expect(await screen.findByText("Could not list Helm releases on prod-eu")).toBeTruthy();
+    // `describeError`'s classification, not the raw Rust string.
+    expect(screen.getByText(/rejected your credentials/i)).toBeTruthy();
+    expect(screen.queryByText("ingress-nginx")).toBeNull();
+  });
+
+  it("offers a retry that lists again", async () => {
+    core.listHelmReleases.mockResolvedValue({ error: "boom" });
+    open();
+    await screen.findByText("Could not list Helm releases on prod-eu");
+
+    core.listHelmReleases.mockResolvedValue({ releases: RELEASES });
+    await userEvent.click(screen.getByRole("button", { name: /retry|try again/i }));
+    expect(await screen.findByText("ingress-nginx")).toBeTruthy();
+  });
+
+  it("has nothing to list without a cluster in focus", () => {
+    resetContexts();
+    store.setState(defaultState([]));
+    open();
+    expect(screen.getByText("No cluster in focus")).toBeTruthy();
+    expect(core.listHelmReleases).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui-next/src/screens/Helm.test.tsx
+++ b/packages/ui-next/src/screens/Helm.test.tsx
@@ -47,6 +47,7 @@ proto.scrollIntoView ??= () => {};
 
 import type { ClusterContext, HelmReleaseSummary, HelmRevision } from "@srelens/core";
 import { Helm } from "./Helm";
+import { Status } from "../shell/Status";
 import { ConsoleProvider } from "../console";
 import { resetContexts, setContexts, setKubeconfigFiles } from "../lib/clusters";
 import { __resetHelmOpsForTests, startHelmOperation } from "../lib/helmOps";
@@ -1239,5 +1240,203 @@ describe("Helm — the namespace selector", () => {
     await userEvent.click(screen.getByRole("button", { name: "Show all namespaces" }));
     await waitFor(() => expect(getView().namespaces.prod).toBeUndefined());
     await waitFor(() => expect(drawn()).toHaveLength(5));
+  });
+});
+
+/**
+ * **A failure the reader cannot select is a failure they cannot read.**
+ *
+ * `Install chart` with a typo in the chart name: helm refuses before it
+ * creates anything, so `listHelmReleases` never returns that release, no row
+ * exists to click, and the pane — which is gated on the selection and then on
+ * an exact context/namespace/release match — has nothing to show. The strip
+ * meanwhile counts the failure for the life of the window and offers to open
+ * `/helm` for it, which is a summons to a screen that cannot hold it.
+ *
+ * The register below is scoped exactly the way the strip's segment is: every
+ * `failed` row on THIS cluster, whatever the table is listing and whatever the
+ * reader has selected. Anything narrower reintroduces the gap through a
+ * different door — a namespace filter, a text filter, or a selection on some
+ * other release.
+ */
+describe("Helm — failures the table cannot show", () => {
+  /** `helm install` refusing a mistyped chart, which never reaches the cluster. */
+  const TYPO = 'Error: chart "bitnmai/redis" not found';
+  /**
+   * The same reason as the store holds it: core stripped helm's `Error:`
+   * wrapper on the way in and classified it once. Asserting on THIS is what
+   * pins that the screen prints the row verbatim rather than describing an
+   * already-described sentence a second time.
+   */
+  const REASON = 'chart "bitnmai/redis" not found';
+
+  /** Start an operation through the store and fail it with `reason`. */
+  async function failOperation(
+    over: Partial<Parameters<typeof startHelmOperation>[0]> = {},
+    reason: unknown = TYPO,
+  ) {
+    const armed = armOperation();
+    await startHelmOperation({
+      kind: "install",
+      release: "cache",
+      namespace: "platform",
+      context: CTX.name,
+      args: ["install", "cache", "bitnmai/redis"],
+      ...over,
+    });
+    await armed.fire(reason);
+  }
+
+  /** The screen with the shell's strip beside it, reading the same store. */
+  function openWithStrip() {
+    store.openTab(ROUTE);
+    return render(
+      <ConsoleProvider>
+        <Helm route={ROUTE} />
+        <Status contexts={[CTX]} />
+      </ConsoleProvider>,
+    );
+  }
+
+  /** Every failure the register is offering to dismiss. */
+  const dismissals = () =>
+    screen
+      .queryAllByRole("button", { name: /^Dismiss the failed / })
+      .map((b) => b.getAttribute("aria-label") ?? "");
+
+  it("shows the reason for a failure whose release was never created", async () => {
+    open();
+    await ready();
+    await failOperation();
+
+    // There is no row to click: helm refused before any release existed.
+    expect(rowFor("cache")).toBeUndefined();
+    expect(await screen.findByText("install of cache in platform failed")).toBeTruthy();
+    // The reason itself, verbatim — `helmOps` already described it.
+    expect(screen.getByText(REASON)).toBeTruthy();
+    // And the pane is untouched: nothing is selected, so it still says so.
+    expect(railHead()).toBe("Release");
+    expect(screen.getByText(/No release selected/i)).toBeTruthy();
+  });
+
+  /**
+   * The reason is one sentence; the lines helm printed before it gave up are
+   * usually the only description of what it was doing, and for a release the
+   * table cannot list there is no other surface carrying them. Folded away
+   * behind a word — the kit's own {@link RawError}, which is where every other
+   * screen puts machine output — so five failures do not bury the table.
+   */
+  it("keeps helm's own output reachable behind the reason", async () => {
+    open();
+    await ready();
+    const armed = armOperation();
+    await startHelmOperation({
+      kind: "upgrade",
+      release: "cache",
+      namespace: "platform",
+      context: CTX.name,
+      args: ["upgrade", "cache", "bitnami/redis"],
+    });
+    const onData = core.startHelmOp.mock.calls[0][2] as (line: string) => void;
+    await act(async () => {
+      onData('Release "cache" does not exist. Run helm install.');
+      onData("Error: UPGRADE FAILED: release: not found");
+    });
+    await armed.fire("UPGRADE FAILED: release: not found");
+
+    expect(await screen.findByText("2 lines from helm")).toBeTruthy();
+    const raw = document.querySelector('[data-slot="helm-failures"] [data-slot="raw"]');
+    expect(raw?.textContent).toContain('Release "cache" does not exist. Run helm install.');
+    expect(raw?.textContent).toContain("Error: UPGRADE FAILED: release: not found");
+  });
+
+  it("dismisses it, and the strip's summons goes with it", async () => {
+    openWithStrip();
+    await ready();
+    await failOperation();
+
+    expect(await screen.findByRole("button", { name: "1 helm operation failed" })).toBeTruthy();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Dismiss the failed install of cache" }),
+    );
+
+    expect(screen.queryByText(REASON)).toBeNull();
+    expect(dismissals()).toEqual([]);
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: /helm operation.* failed/ })).toBeNull(),
+    );
+  });
+
+  it("surfaces every failure the strip counts, and no other cluster's", async () => {
+    openWithStrip();
+    await ready();
+    // One whose release the table HAS, one it never will, and one belonging to
+    // a cluster this strip is not naming.
+    await failOperation(
+      { kind: "upgrade", release: "checkout", namespace: "checkout" },
+      "timed out waiting for the condition",
+    );
+    await failOperation();
+    await failOperation({ context: "edge-apac", release: "sensors", namespace: "edge" });
+
+    expect(await screen.findByRole("button", { name: "2 helm operations failed" })).toBeTruthy();
+    await waitFor(() => expect(dismissals()).toHaveLength(2));
+    expect(dismissals()).toEqual([
+      "Dismiss the failed install of cache",
+      "Dismiss the failed upgrade of checkout",
+    ]);
+    expect(screen.queryByText(/sensors/)).toBeNull();
+  });
+
+  /**
+   * The pane retires a failure a later attempt superseded; the strip does not,
+   * and neither does this. The two answer different questions — "what is worth
+   * looking at now" against "what has happened that you have not acknowledged"
+   * — and a register that retired would leave the strip counting a failure the
+   * screen had quietly dropped, which is this defect again.
+   */
+  it("keeps a failure a later attempt has retired from the pane", async () => {
+    openWithStrip();
+    await ready();
+    await failOperation(
+      { kind: "upgrade", release: "checkout", namespace: "checkout" },
+      "expired token",
+    );
+    const armed = armOperation();
+    await startHelmOperation({
+      kind: "upgrade",
+      release: "checkout",
+      namespace: "checkout",
+      context: CTX.name,
+      args: ["upgrade", "checkout"],
+    });
+    await armed.fire(null);
+
+    await select("checkout", "checkout");
+    // The pane has moved on to the diff, exactly as before.
+    await waitFor(() => expect(railHead()).toContain("rendered diff"));
+    // The register has not, because the strip has not.
+    expect(dismissals()).toEqual(["Dismiss the failed upgrade of checkout"]);
+    expect(screen.getByRole("button", { name: "1 helm operation failed" })).toBeTruthy();
+  });
+
+  it("offers nothing to dismiss for an operation still running", async () => {
+    openWithStrip();
+    await ready();
+    armOperation();
+    await startHelmOperation({
+      kind: "upgrade",
+      release: "cache",
+      namespace: "platform",
+      context: CTX.name,
+      args: ["upgrade", "cache"],
+    });
+
+    // The strip says one operation is in flight, and the screen shows no way
+    // to put it away: `dismissHelmOp` declines a `running` row by design, and
+    // a control that looked like a cancel would be worse than none.
+    expect(await screen.findByRole("button", { name: "1 helm operation" })).toBeTruthy();
+    expect(dismissals()).toEqual([]);
+    expect(document.querySelector('[data-slot="helm-failures"]')).toBeNull();
   });
 });

--- a/packages/ui-next/src/screens/Helm.test.tsx
+++ b/packages/ui-next/src/screens/Helm.test.tsx
@@ -21,6 +21,18 @@ vi.mock("@srelens/core", async (orig) => ({
   ...core,
 }));
 
+/**
+ * The namespace options, doubled the way `Workloads.test.tsx` and
+ * `Resources.test.tsx` double them: this screen must ask the SHARED hook for
+ * them rather than growing a Helm-local list, and a stub is what makes the
+ * loading, forbidden and failed branches reachable from a test at all.
+ */
+const { useNamespaceOptions } = vi.hoisted(() => ({ useNamespaceOptions: vi.fn() }));
+vi.mock("@srelens/core/react", async (orig) => ({
+  ...(await orig<typeof import("@srelens/core/react")>()),
+  useNamespaceOptions: (...a: unknown[]) => useNamespaceOptions(...a),
+}));
+
 if (!("ResizeObserver" in globalThis)) {
   (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
     observe() {}
@@ -28,15 +40,19 @@ if (!("ResizeObserver" in globalThis)) {
     disconnect() {}
   };
 }
+// The picker's popover keeps its highlighted row in view, and jsdom has no
+// such method — the same stand-in `Workloads.test.tsx` installs.
+const proto = window.HTMLElement.prototype as unknown as Record<string, unknown>;
+proto.scrollIntoView ??= () => {};
 
 import type { ClusterContext, HelmReleaseSummary, HelmRevision } from "@srelens/core";
 import { Helm } from "./Helm";
 import { ConsoleProvider } from "../console";
-import { resetContexts, setContexts } from "../lib/clusters";
+import { resetContexts, setContexts, setKubeconfigFiles } from "../lib/clusters";
 import { __resetHelmOpsForTests, startHelmOperation } from "../lib/helmOps";
 import { defaultState } from "../lib/tabs";
 import * as store from "../lib/tabsStore";
-import { resetView } from "../lib/workspace";
+import { getView, resetView, setNamespaces } from "../lib/workspace";
 
 const ROUTE = "/helm";
 
@@ -132,6 +148,18 @@ const STAGING_CHECKOUT: HelmReleaseSummary = {
 
 const RELEASES = [INGRESS, CHECKOUT, PAYMENTS, REDIS, STAGING_CHECKOUT];
 
+/** The namespaces the cluster has, as the shared hook answers with them. */
+const NAMESPACES = ["checkout", "payments", "platform", "staging"];
+
+/**
+ * The kubeconfigs this window was started with.
+ *
+ * Two of them, and neither is `~/.kube/config`: a machine whose contexts came
+ * from srelens-imported files or from `KUBECONFIG` is exactly the machine on
+ * which an operation started without these fails to build a client at all.
+ */
+const FILES = ["/home/u/.config/srelens/imported.yaml", "/home/u/work/kubeconfig.yaml"];
+
 /**
  * Two rendered manifests per release, keyed the way helm scopes a release:
  * `<namespace>/<name>`. Production's `checkout` and staging's have different
@@ -186,7 +214,17 @@ const HISTORIES: Record<string, HelmRevision[]> = {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  core.listHelmReleases.mockResolvedValue({ releases: RELEASES });
+  // **The backend honours the namespace it is given**, the way the real one
+  // does. A screen that fetched every namespace and threw most of it away
+  // would still draw the right rows against a stub that ignored the argument,
+  // which is precisely the escape this implementation has to be denied: on a
+  // cluster with 383 releases, listing all of them to draw six is the common
+  // case rather than the edge one.
+  core.listHelmReleases.mockImplementation(
+    async (_ctx: string, namespace?: string | null) => ({
+      releases: namespace ? RELEASES.filter((r) => r.namespace === namespace) : RELEASES,
+    }),
+  );
   core.getHelmRelease.mockImplementation(
     async (_ctx: string, ns: string, name: string, _invoke?: unknown, revision?: number) => {
       const key = `${ns}/${name}`;
@@ -202,9 +240,12 @@ beforeEach(() => {
     },
   );
   core.startHelmOp.mockResolvedValue({ close: vi.fn() });
+  useNamespaceOptions.mockReturnValue({ namespaces: NAMESPACES, scope: "", error: "" });
   __resetHelmOpsForTests();
   resetContexts();
   setContexts([CTX]);
+  // After `resetContexts`, which clears them.
+  setKubeconfigFiles(FILES);
   store.setState(defaultState([CTX]));
   resetView();
 });
@@ -239,6 +280,29 @@ const select = (name: string, namespace?: string) =>
 const cells = (row: HTMLElement) =>
   Array.from(row.querySelectorAll("td")).map((td) => td.textContent?.trim() ?? "");
 const cell = (row: HTMLElement, column: string) => cells(row)[headers().indexOf(column)];
+
+/**
+ * Every release on screen as `<namespace>/<name>` — helm's own identity for a
+ * release, and the only way to tell production's `checkout` from staging's.
+ */
+const drawn = () =>
+  Array.from(document.querySelectorAll("tbody tr.tbl-row")).map((tr) => {
+    const td = Array.from(tr.querySelectorAll("td")).map((c) => c.textContent?.trim() ?? "");
+    return `${td[1]}/${td[0]}`;
+  });
+
+/** The namespace picker's trigger. */
+const picker = () => screen.getByRole("combobox", { name: "Namespaces" });
+
+/** Narrow to one namespace the way the reader does: the row's own `only`. */
+async function pickOnly(namespace: string) {
+  await userEvent.click(picker());
+  await userEvent.click(await screen.findByRole("button", { name: `Only ${namespace}` }));
+}
+
+/** The namespaces the last listing was scoped to — `null` for every namespace. */
+const listedNamespaces = () =>
+  core.listHelmReleases.mock.calls.map((call) => (call[1] as string | null) ?? null);
 
 /**
  * A field whose `Field` carries a hint.
@@ -439,6 +503,37 @@ describe("Helm — the release table", () => {
     expect(chart?.className).toContain("max-w-[200px]");
   });
 
+  /**
+   * **The eighth `min-width: auto`-family defect, seen on a real cluster.**
+   *
+   * A screenshot of `K8SM01-ADMIN` shows every row ending in a clipped `U`
+   * where the 420px pane begins: `Uninstall` — the one destructive control on
+   * this screen — reduced to a sliver of a letter, and mistakable for part of
+   * `Roll back`'s group. Release names there are `cnips-abena-…` long and the
+   * namespaces `m01-cnips-01-dataservices` long, so the two text columns take
+   * the width and the action group is what falls off the end.
+   *
+   * The two text columns absorb the loss instead: they are the ones a reader
+   * can recover by widening the column or reading the pane, and a truncated
+   * name is not a control they cannot press. The group itself refuses to
+   * shrink at all, so nothing inside the cell can be clipped either.
+   */
+  it("caps the wide text columns rather than letting the action group be clipped", async () => {
+    const { container } = open();
+    await ready();
+    const release = container.querySelector('[data-slot="release-name"]');
+    expect(release?.className).toContain("truncate");
+    expect(release?.className).toMatch(/max-w-\[\d+px\]/);
+    const namespace = container.querySelector('[data-slot="release-namespace"]');
+    expect(namespace?.className).toContain("truncate");
+    expect(namespace?.className).toMatch(/max-w-\[\d+px\]/);
+    // `flex` items shrink by default, and these three carry the only
+    // irreversible action on the screen.
+    const actions = container.querySelector('[data-slot="release-actions"]');
+    expect(actions?.className).toContain("shrink-0");
+    expect(actions?.className).toContain("whitespace-nowrap");
+  });
+
   it("offers §16's three operations on every row, with the release named", async () => {
     open();
     await ready();
@@ -596,6 +691,48 @@ describe("Helm — the operations", () => {
     // core's classification, not the raw Rust string.
     expect(within(dialog).getByText(/rejected your credentials/i)).toBeTruthy();
     expect(document.querySelector(".copy-command-text")?.textContent).toContain("--reuse-values");
+  });
+
+  /**
+   * **A verified escape: deleting `extraKubeconfigs` from this screen left all
+   * 31 tests passing.**
+   *
+   * The store's own suite proves the store forwards them to core; nothing
+   * proved the SCREEN supplied them. On a machine whose contexts come from
+   * srelens-imported files or from `KUBECONFIG` rather than `~/.kube/config`,
+   * every operation started here would fail to build a client — and every
+   * assertion in this file would still be green.
+   *
+   * The argv is pinned in the same breath, and against the command the dialog
+   * SHOWED the reader rather than against a copy of the dialog's own format:
+   * a copy button that prints one command while srelens runs another is the
+   * defect worth catching, and this cannot pass unless the two agree.
+   */
+  it("runs the argv it showed the reader, with this window's kubeconfigs", async () => {
+    open();
+    await ready();
+    await userEvent.click(
+      within(rowFor("checkout", "checkout")).getByRole("button", { name: "Uninstall checkout" }),
+    );
+
+    const dialog = await screen.findByRole("dialog");
+    await userEvent.type(within(dialog).getByLabelText("Type checkout to confirm"), "checkout");
+    const shown = document.querySelector(".copy-command-text")?.textContent ?? "";
+    expect(shown).toContain("uninstall checkout");
+
+    await userEvent.click(within(dialog).getByRole("button", { name: "Uninstall" }));
+    await waitFor(() => expect(core.startHelmOp).toHaveBeenCalled());
+
+    const [context, args, , , extraKubeconfigs] = core.startHelmOp.mock.calls[0] as [
+      string,
+      string[],
+      unknown,
+      unknown,
+      string[],
+    ];
+    expect(context).toBe("prod-eu");
+    expect(`helm ${args.join(" ")}`).toBe(shown);
+    expect(extraKubeconfigs).toEqual(FILES);
   });
 
   it("opens the values editor as an upgrade of the selected release", async () => {
@@ -827,5 +964,276 @@ describe("Helm — when to list again", () => {
     // This one's does.
     await settleElsewhere(CTX.name);
     await waitFor(() => expect(core.listHelmReleases).toHaveBeenCalledTimes(1));
+  });
+
+  /**
+   * The re-list guard is keyed on the CLUSTER, and a namespace change must not
+   * re-arm it: an operation that settles after the reader has narrowed the
+   * view still has to refresh the list — once, scoped to what they are now
+   * looking at.
+   */
+  it("keeps refreshing on a settled operation after the namespace moved", async () => {
+    open();
+    await ready();
+    await pickOnly("checkout");
+    await waitFor(() => expect(drawn()).toEqual(["checkout/checkout", "checkout/redis-session"]));
+    core.listHelmReleases.mockClear();
+
+    await settleElsewhere(CTX.name);
+    await waitFor(() => expect(core.listHelmReleases).toHaveBeenCalledTimes(1));
+    // Scoped to the namespace on screen, not back to the whole cluster.
+    expect(listedNamespaces()).toEqual(["checkout"]);
+  });
+});
+
+/**
+ * **The defect the user reported: "namespace selector is missing in helm
+ * releases".**
+ *
+ * This screen listed every namespace with a Namespace column and no way to
+ * filter — a regression against classic, and the one ported screen without the
+ * control. On the reporter's own cluster that is 383 releases across dozens of
+ * namespaces in one undifferentiated list.
+ *
+ * The selection is the SHARED, per-cluster one every other screen uses, not a
+ * Helm-local filter: a namespace picked on Workloads carries to Helm and back.
+ */
+describe("Helm — the namespace selector", () => {
+  it("offers the cluster's namespaces in the filter bar above the table", async () => {
+    open();
+    await ready();
+    const bar = screen.getByRole("search", { name: /Filter/ });
+    expect(within(bar).getByRole("combobox", { name: "Namespaces" })).toBeTruthy();
+  });
+
+  /**
+   * **The backend call is scoped, not just the render.** Fetching 383 releases
+   * to draw two is what this screen did on every keystroke of the reader's
+   * attention; classic has always scoped the call for a single selection.
+   */
+  it("scopes the listing to a single selected namespace", async () => {
+    open();
+    await ready();
+    core.listHelmReleases.mockClear();
+
+    await pickOnly("checkout");
+
+    await waitFor(() => expect(listedNamespaces()).toEqual(["checkout"]));
+    expect(drawn()).toEqual(["checkout/checkout", "checkout/redis-session"]);
+  });
+
+  /**
+   * The multi-select case, which is the one helm itself cannot answer: `helm
+   * list --namespace` takes one namespace, so several means fetching every
+   * namespace and narrowing here — classic's own rule.
+   */
+  it("fetches every namespace and narrows here when several are selected", async () => {
+    open();
+    await ready();
+    await pickOnly("checkout");
+    await waitFor(() => expect(drawn()).toEqual(["checkout/checkout", "checkout/redis-session"]));
+    core.listHelmReleases.mockClear();
+
+    act(() => setNamespaces(CTX.stableId, ["checkout", "staging"]));
+
+    await waitFor(() =>
+      expect(drawn()).toEqual([
+        "checkout/checkout",
+        "checkout/redis-session",
+        "staging/checkout",
+      ]),
+    );
+    // One listing, unscoped — and the platform and payments releases it
+    // returned are gone from the table.
+    expect(listedNamespaces()).toEqual([null]);
+    expect(rowFor("ingress-nginx")).toBeUndefined();
+  });
+
+  /**
+   * The other half of that rule: narrowing a whole-cluster listing to several
+   * namespaces asks helm for nothing new. The releases are already here — the
+   * only thing that changed is how many of them are drawn.
+   */
+  it("does not re-list when the listing it already has covers the new selection", async () => {
+    open();
+    await ready();
+    core.listHelmReleases.mockClear();
+
+    act(() => setNamespaces(CTX.stableId, ["checkout", "staging"]));
+
+    await waitFor(() => expect(drawn()).toHaveLength(3));
+    expect(core.listHelmReleases).not.toHaveBeenCalled();
+  });
+
+  /**
+   * **Per cluster, in the shared store — not per screen.** Local state here
+   * would pass every assertion above and lose the reader's namespace the
+   * moment they walked to Workloads and back.
+   */
+  it("writes the pick to the cluster's shared selection", async () => {
+    open();
+    await ready();
+
+    await pickOnly("payments");
+
+    await waitFor(() => expect(getView().namespaces.prod).toEqual(["payments"]));
+  });
+
+  it("opens on the namespace another screen on this cluster already chose", async () => {
+    setNamespaces(CTX.stableId, ["payments"]);
+
+    open();
+
+    // The FIRST listing is already scoped: the remembered selection is read
+    // before anything is fetched, not applied to rows that arrived unscoped.
+    await waitFor(() => expect(drawn()).toEqual(["payments/payments"]));
+    expect(listedNamespaces()).toEqual(["payments"]);
+  });
+
+  /** One listing per change of mind — not the mount's racing the re-list. */
+  it("lists exactly once when the namespace changes", async () => {
+    open();
+    await ready();
+    core.listHelmReleases.mockClear();
+
+    await pickOnly("platform");
+    await waitFor(() => expect(drawn()).toEqual(["platform/ingress-nginx"]));
+    await act(async () => {});
+
+    expect(core.listHelmReleases).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * **A late answer must not paint over a fresh one.** The reader narrows to
+   * `checkout`, the cluster is slow, they widen back to everything — and the
+   * two-row answer for `checkout` lands after the five-row answer for the
+   * whole cluster. Without the sequence guard the table ends up showing two
+   * rows under a head that says the cluster has two.
+   */
+  it("discards a listing that arrives after the reader moved on", async () => {
+    const pending = new Map<string, (value: { releases: HelmReleaseSummary[] }) => void>();
+    core.listHelmReleases.mockImplementation(
+      (_ctx: string, namespace?: string | null) =>
+        new Promise<{ releases: HelmReleaseSummary[] }>((resolve) => {
+          pending.set(namespace ?? "", resolve);
+        }),
+    );
+
+    setNamespaces(CTX.stableId, ["checkout"]);
+    open();
+    await waitFor(() => expect(pending.has("checkout")).toBe(true));
+
+    act(() => setNamespaces(CTX.stableId, []));
+    await waitFor(() => expect(pending.has("")).toBe(true));
+
+    // The fresh answer first…
+    await act(async () => {
+      pending.get("")?.({ releases: RELEASES });
+    });
+    await ready();
+
+    // …then the stale one, for a namespace nobody is looking at any more.
+    await act(async () => {
+      pending.get("checkout")?.({ releases: [CHECKOUT, REDIS] });
+    });
+
+    expect(drawn()).toHaveLength(5);
+    expect(rowFor("ingress-nginx")).toBeTruthy();
+    expect(heads()[0]).toBe("Releases · 5 in this cluster");
+  });
+
+  /**
+   * A head that counts the whole cluster above a table showing one namespace
+   * is a string asserting more than the view holds — the same class of defect
+   * this branch keeps finding.
+   */
+  it("heads the pane with what the reader is looking at, not with the cluster's total", async () => {
+    open();
+    await ready();
+    expect(heads()[0]).toBe("Releases · 5 in this cluster");
+
+    await pickOnly("checkout");
+    await waitFor(() => expect(heads()[0]).toBe("Releases · 2 in checkout"));
+
+    act(() => setNamespaces(CTX.stableId, ["checkout", "staging"]));
+    await waitFor(() => expect(heads()[0]).toBe("Releases · 3 in 2 namespaces"));
+  });
+
+  it("says a namespace has no releases without blaming a failure", async () => {
+    setNamespaces(CTX.stableId, ["platform"]);
+    core.listHelmReleases.mockResolvedValue({ releases: [] });
+
+    open();
+
+    expect(await screen.findByText("No Helm releases")).toBeTruthy();
+    expect(
+      screen.getByText("prod-eu has no Helm releases in the namespaces you are looking at."),
+    ).toBeTruthy();
+    expect(screen.queryByText(/Could not list/)).toBeNull();
+  });
+
+  it("filters the releases on screen by text, and says which filter is hiding them", async () => {
+    open();
+    await ready();
+
+    await userEvent.type(screen.getByRole("searchbox", { name: "Filter releases" }), "redis");
+    await waitFor(() => expect(drawn()).toEqual(["checkout/redis-session"]));
+
+    await userEvent.clear(screen.getByRole("searchbox", { name: "Filter releases" }));
+    await userEvent.type(screen.getByRole("searchbox", { name: "Filter releases" }), "zzz");
+    expect(await screen.findByText("No Helm releases match this filter")).toBeTruthy();
+    expect(screen.getByText("Clear the filter to see all 5.")).toBeTruthy();
+  });
+
+  it("follows the namespace a restricted credential is scoped to", async () => {
+    useNamespaceOptions.mockReturnValue({ namespaces: ["payments"], scope: "payments", error: "" });
+
+    open();
+
+    // Written to the shared store, so every screen on this cluster follows.
+    await waitFor(() => expect(getView().namespaces.prod).toEqual(["payments"]));
+    await waitFor(() => expect(drawn()).toEqual(["payments/payments"]));
+    expect(listedNamespaces()).toContain("payments");
+  });
+
+  it("shows the picker as loading rather than empty before the namespaces arrive", async () => {
+    useNamespaceOptions.mockReturnValue({ namespaces: null, scope: "", error: "" });
+
+    open();
+    await ready();
+
+    expect(screen.queryByRole("combobox", { name: "Namespaces" })).toBeNull();
+    const placeholder = screen.getByRole("button", { name: "Namespaces" }) as HTMLButtonElement;
+    expect(placeholder.disabled).toBe(true);
+    expect(within(placeholder).getByRole("status", { name: "Loading namespaces" })).toBeTruthy();
+  });
+
+  it("warns when the namespaces cannot be listed, without hiding the picker or the releases", async () => {
+    useNamespaceOptions.mockReturnValue({
+      namespaces: NAMESPACES,
+      scope: "",
+      error: "namespaces: etcd timeout",
+    });
+
+    open();
+
+    expect(await screen.findByText("Namespaces could not be listed")).toBeTruthy();
+    // core's classification, not the apiserver's own words.
+    expect(screen.getByText(/didn't respond in time/)).toBeTruthy();
+    expect(screen.getByRole("combobox", { name: "Namespaces" })).toBeTruthy();
+    await waitFor(() => expect(drawn()).toHaveLength(5));
+  });
+
+  it("explains a remembered namespace that is gone, and offers the way back", async () => {
+    setNamespaces(CTX.stableId, ["deleted-ns"]);
+
+    open();
+
+    expect(await screen.findByText("Remembered namespaces are gone")).toBeTruthy();
+    expect(screen.getByText("deleted-ns no longer exist on this cluster.")).toBeTruthy();
+
+    await userEvent.click(screen.getByRole("button", { name: "Show all namespaces" }));
+    await waitFor(() => expect(getView().namespaces.prod).toBeUndefined());
+    await waitFor(() => expect(drawn()).toHaveLength(5));
   });
 });

--- a/packages/ui-next/src/screens/Helm.tsx
+++ b/packages/ui-next/src/screens/Helm.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import {
   ageFromTimestamp,
   getHelmRelease,
@@ -13,9 +21,11 @@ import {
 } from "@srelens/core";
 import { useNamespaceOptions } from "@srelens/core/react";
 import {
+  Alert,
   Button,
   FilterBar,
   LoadingState,
+  RawError,
   Screen,
   StatusPill,
   Table,
@@ -25,7 +35,13 @@ import {
 import { useConsole } from "../console";
 import { getKubeconfigFiles, useActiveContext } from "../lib/clusters";
 import { FailureState, friendly } from "../lib/errorCopy";
-import { getHelmOps, subscribeHelmOps, type HelmOpKind } from "../lib/helmOps";
+import {
+  dismissHelmOp,
+  getHelmOps,
+  subscribeHelmOps,
+  type HelmOpKind,
+  type HelmOpRow,
+} from "../lib/helmOps";
 import { Icons } from "../lib/icons";
 import { describe } from "../lib/routes";
 import { setNamespaces, useNamespaces } from "../lib/workspace";
@@ -94,6 +110,105 @@ interface Pending {
    * field. See {@link HelmReleases}.
    */
   history?: readonly HelmRevision[];
+}
+
+/**
+ * **Every operation this cluster has failed, whatever the table is listing.**
+ *
+ * The status strip counts `failed` rows for the active cluster and offers to
+ * open `/helm` for them, on the rule that a segment counts what the screen it
+ * opens can show. Until this existed the screen could not: the pane is the
+ * only view of an operation, and it is gated first on a selection and then on
+ * an exact context/namespace/release match. An `Install chart` with a typo in
+ * the chart name is refused by helm before any release exists, so
+ * `listHelmReleases` never returns one, no row can be clicked, and the reason
+ * — the only place it exists — had nowhere to be read. The strip went on
+ * saying `1 helm operation failed` for the life of the window and its segment
+ * led to a screen that could not hold it.
+ *
+ * **Scoped exactly the way that segment is: `failed`, on this context, all of
+ * them.** Not the selection, not the namespace picker, not the text filter,
+ * and — deliberately — not `currentOp`'s retirement rule
+ * (`helm/ReleasePane`). Every one of
+ * those would reopen the same gap through a different door, and the last would
+ * reopen it invisibly: the pane retires a failure a later attempt superseded
+ * because it answers "what is worth looking at now", while the strip and this
+ * answer "what has happened that you have not acknowledged". A row leaves both
+ * at the same moment and only one way — the reader dismisses it.
+ *
+ * **Nothing here removes a row on its own initiative, and `running` is not
+ * offered at all.** A failure that vanished by itself is how a reader comes to
+ * assume a half-finished mutation was fine (#349's port-forward), and
+ * `dismissHelmOp` declines a `running` row by design because there is no
+ * cancel to offer — see `lib/helmOps`'s header for what stopping the watch
+ * would actually do to helm.
+ *
+ * The tone is `sev`, the same one the strip gives the news and the same one
+ * the pane's own banner uses. It is not a status word and wants none from
+ * core: `helmStatus` tones the word Helm writes in a release Secret, and this
+ * is srelens's own record of what this window ran.
+ */
+function FailedOps({
+  ops,
+  onDismiss,
+}: {
+  ops: readonly HelmOpRow[];
+  onDismiss: (id: number) => void;
+}) {
+  const headId = useId();
+  if (ops.length === 0) return null;
+  return (
+    <section
+      aria-labelledby={headId}
+      data-slot="helm-failures"
+      // `shrink-0` so a tall table cannot squeeze this to nothing, and the cap
+      // below is what keeps that honest: five failures scroll inside the box
+      // rather than pushing the releases off the screen. `min-w-0` and
+      // `break-words` for the same reason every box on this screen has them —
+      // a helm error is an unbounded string, and a flex child's
+      // `min-width: auto` floor turns one into a sideways scroll of the whole
+      // window.
+      className="flex min-w-0 shrink-0 flex-col gap-1.5 border-b border-rule bg-sunk px-3 py-2"
+    >
+      <div id={headId} className="min-w-0 truncate text-[0.75rem] font-medium text-muted">
+        {/* The strip's own words, so the reader arriving from its segment can
+            see that this is what they were sent for. */}
+        {`${plural(ops.length, "helm operation")} failed`}
+      </div>
+      <div className="scroll flex max-h-40 min-w-0 flex-col gap-1.5">
+        {ops.map((o) => (
+          <Alert
+            key={o.id}
+            tone="sev"
+            className="min-w-0"
+            // Named per operation, the way the row actions are: four alerts
+            // all offering "Dismiss" name nothing, and this is the control
+            // that makes the strip's count go down.
+            title={`${o.kind} of ${o.release} in ${o.namespace} failed`}
+            dismissLabel={`Dismiss the failed ${o.kind} of ${o.release}`}
+            onDismiss={() => onDismiss(o.id)}
+          >
+            <span className="block min-w-0 break-words">
+              {/* `o.error` verbatim. `helmOps` described it already, and a
+                  described sentence run through `describeError` again is
+                  classified on its own wording. */}
+              {o.error ?? "helm gave no reason."}
+            </span>
+            {/* The lines helm printed before it gave up — usually the only
+                description of what it was doing, and for a release the table
+                cannot list there is no other surface carrying them. Folded
+                away behind a word, where every other screen puts machine
+                output; `RawError` renders nothing when there is none. */}
+            <RawError
+              text={o.output.join("\n")}
+              label={`${plural(o.output.length, "line")} from helm`}
+              className="mt-1"
+            />
+          </Alert>
+        ))}
+      </div>
+    </section>
+  );
 }
 
 /** Where the release listing stands. */
@@ -292,6 +407,28 @@ function HelmReleases({ title, context }: { title: string; context: ClusterConte
     for (const o of settled) seen.ids.add(o.id);
     void reload();
   }, [ops, name, reload]);
+
+  /**
+   * The failures this cluster is carrying, newest first — see {@link FailedOps}.
+   *
+   * Derived here in the component body, and never inside the snapshot getter:
+   * a `.filter()` in there hands `useSyncExternalStore` a fresh array on every
+   * read, which it compares by identity, and this screen re-renders for every
+   * line a running upgrade prints.
+   *
+   * Newest first because a failure that has just happened is the news, and the
+   * store appends — its own order buries a fresh one under every older one
+   * inside a box that scrolls. Ties go to the higher id: two operations
+   * started inside the same millisecond are ordered by the sequence that
+   * registered them rather than by whatever the array happens to hold.
+   */
+  const failedOps = useMemo(
+    () =>
+      ops
+        .filter((o) => o.context === name && o.state === "failed")
+        .sort((a, b) => b.startedAt - a.startedAt || b.id - a.id),
+    [ops, name],
+  );
 
   const releases = list.status === "ready" ? list.releases : [];
   const at = list.status === "ready" ? list.at : 0;
@@ -729,6 +866,12 @@ function HelmReleases({ title, context }: { title: string; context: ClusterConte
         namespaces={namespaces}
         onReset={() => setNamespaces(context.stableId, [])}
       />
+
+      {/* Above both panes, because it is about neither: a failure listed here
+          may have no release in the table and no revision to diff. The store's
+          own `dismissHelmOp` is handed over directly — it is module-level and
+          stable, and it is the only thing that takes a row off the strip. */}
+      <FailedOps ops={failedOps} onDismiss={dismissHelmOp} />
 
       <div className="flex min-h-0 flex-1">
         {/* `min-w-0`, and it is load-bearing. A flex item's implicit

--- a/packages/ui-next/src/screens/Helm.tsx
+++ b/packages/ui-next/src/screens/Helm.tsx
@@ -4,20 +4,40 @@ import {
   getHelmRelease,
   helmStatus,
   listHelmReleases,
+  plural,
+  rowInSelection,
+  watchNamespaceForSelection,
   type ClusterContext,
   type HelmReleaseSummary,
   type HelmRevision,
 } from "@srelens/core";
-import { Button, LoadingState, Screen, StatusPill, Table, type Column } from "@srelens/ui-kit";
+import { useNamespaceOptions } from "@srelens/core/react";
+import {
+  Button,
+  FilterBar,
+  LoadingState,
+  Screen,
+  StatusPill,
+  Table,
+  filterTableData,
+  type Column,
+} from "@srelens/ui-kit";
 import { useConsole } from "../console";
 import { getKubeconfigFiles, useActiveContext } from "../lib/clusters";
 import { FailureState, friendly } from "../lib/errorCopy";
 import { getHelmOps, subscribeHelmOps, type HelmOpKind } from "../lib/helmOps";
 import { Icons } from "../lib/icons";
 import { describe } from "../lib/routes";
+import { setNamespaces, useNamespaces } from "../lib/workspace";
 import { HelmOpDialog } from "./helm/HelmOpDialog";
 import { ReleasePane, type PaneRelease } from "./helm/ReleasePane";
-import { NoClusterScreen } from "./resourceShell";
+import {
+  NamespaceErrorAlert,
+  NamespacePicker,
+  NoClusterScreen,
+  StaleSelectionAlert,
+  emptyTableCopy,
+} from "./resourceShell";
 
 /**
  * §16's header ask: the visible word, and the question actually sent.
@@ -130,23 +150,83 @@ function HelmReleases({ title, context }: { title: string; context: ClusterConte
   const [list, setList] = useState<ListLoad>({ status: "loading" });
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const [pending, setPending] = useState<Pending | null>(null);
+  const [filter, setFilter] = useState("");
 
   /**
-   * List the cluster's releases.
+   * **The namespace selection is the cluster's, not this screen's.**
    *
-   * Stable across renders — this screen re-renders on every line a running
-   * `helm upgrade` prints, and a handler rebuilt each time would re-fire the
-   * effects that depend on it.
+   * §16 draws no namespace control, which is why neither the spec nor the plan
+   * asked for one — the mock is a single tidy screenful. The reporter's own
+   * cluster has 383 releases across dozens of namespaces, which is the shape
+   * this screen actually meets, and listing all of them under a Namespace
+   * column with no way to filter is both a regression against classic and the
+   * one ported screen without the control.
+   *
+   * Read from and written to the shared workspace store — the same record
+   * `Workloads`, `Resources` and `Events` read — so a namespace chosen on one
+   * screen carries to this one and back. A Helm-local filter would be a fifth
+   * place to choose a namespace and the only one nothing else can see.
+   */
+  const selection = useNamespaces(context.stableId);
+  const { namespaces, scope, error: namespaceError } = useNamespaceOptions(name, files);
+
+  /**
+   * The namespace the BACKEND is asked for: one selected namespace scopes the
+   * call, none or many fetch everything and are narrowed below.
+   *
+   * `helm list --namespace` takes exactly one, so this is not a choice about
+   * tidiness — it is the only scoping helm itself offers, and it is classic's
+   * own rule (`HelmReleasesView.tsx:195-198`). Fetching 383 releases to draw
+   * six is the common case on the cluster this defect was reported from.
+   */
+  const listNamespace = watchNamespaceForSelection(selection);
+
+  // A namespace-restricted credential has one namespace and no way to ask for
+  // another — the same rule every other screen follows, written to the shared
+  // store so they all agree about it.
+  useEffect(() => {
+    if (scope) setNamespaces(context.stableId, [scope]);
+  }, [scope, context.stableId]);
+
+  /**
+   * Which listing is the current one.
+   *
+   * The same idiom as {@link openSeq} below, for the same reason: a reader who
+   * narrows to a namespace and widens again while the cluster is slow must not
+   * have the fresh, whole-cluster answer painted over by the late answer for a
+   * namespace they have left. The table would end up showing that namespace's
+   * rows under a head counting them as the cluster's.
+   */
+  const listSeq = useRef(0);
+
+  /**
+   * List the releases in scope.
+   *
+   * Stable except for what it asks for — this screen re-renders on every line
+   * a running `helm upgrade` prints, and a handler rebuilt each time would
+   * re-fire the effects that depend on it. `listNamespace` is in the deps
+   * BECAUSE changing it must re-list: that is what makes the picker fetch
+   * again rather than merely re-render the rows it already has.
    */
   const reload = useCallback(async () => {
-    const out = await listHelmReleases(name);
+    const seq = ++listSeq.current;
+    const out = await listHelmReleases(name, listNamespace || null);
+    if (seq !== listSeq.current) return;
     if (out.error !== undefined || !out.releases) {
       setList({ status: "error", error: out.error ?? "helm returned no releases" });
       return;
     }
     setList({ status: "ready", releases: out.releases, at: Date.now() });
-  }, [name]);
+  }, [name, listNamespace]);
 
+  /**
+   * The mount's listing — and every re-listing a change of scope asks for,
+   * because `reload`'s identity carries the namespace it fetches.
+   *
+   * The selection is dropped with it: a release the reader had selected may be
+   * in a namespace they have just looked away from, and a pane diffing a row
+   * the table no longer has is a pane about nothing.
+   */
   useEffect(() => {
     setList({ status: "loading" });
     setSelectedKey(null);
@@ -173,6 +253,14 @@ function HelmReleases({ title, context }: { title: string; context: ClusterConte
    * round trip nobody asked for.
    */
   const relisted = useRef<{ context: string; ids: Set<number> } | null>(null);
+  // **Keyed on the cluster, and NOT on the namespace.** An operation that
+  // settled while the reader was looking at one namespace is still news when
+  // they narrow to another — re-seeding this on a namespace change would mark
+  // it seen without ever having listed for it. Nothing below fires twice for
+  // it either: every settled id is added to `ids` as it is handled, so the
+  // effect's re-run under a new `reload` finds nothing left to act on and the
+  // scope change's own listing above is the only one.
+  //
   // Seeded during render, and re-seeded whenever the cluster changes. The ops
   // store is module-level and outlives this screen, so a mount that started
   // with settled operations in it would fire the effect below for news it never
@@ -210,25 +298,30 @@ function HelmReleases({ title, context }: { title: string; context: ClusterConte
 
   const rows = useMemo<ReleaseRow[]>(
     () =>
-      releases.map((r) => {
-        const age = ageFromTimestamp(r.updated, at);
-        return {
-          key: `${r.namespace}/${r.name}`,
-          name: r.name,
-          namespace: r.namespace,
-          // §16's cell, and what classic's Helm list has always shown.
-          chart: `${r.chart}-${r.chartVersion}`,
-          chartName: r.chart,
-          chartVersion: r.chartVersion,
-          revision: r.revision,
-          status: r.status,
-          // `— ago` is not a sentence: a release with no timestamp has an
-          // unknown age, not an age of nothing.
-          updated: age === "—" ? age : `${age} ago`,
-          updatedAt: r.updated,
-        };
-      }),
-    [releases, at],
+      releases
+        // A no-op for the single-namespace case — the backend already scoped
+        // that one — and the whole of the narrowing for the multi-select case,
+        // where helm's own `--namespace` cannot express what was asked for.
+        .filter((r) => rowInSelection(r.namespace, selection))
+        .map((r) => {
+          const age = ageFromTimestamp(r.updated, at);
+          return {
+            key: `${r.namespace}/${r.name}`,
+            name: r.name,
+            namespace: r.namespace,
+            // §16's cell, and what classic's Helm list has always shown.
+            chart: `${r.chart}-${r.chartVersion}`,
+            chartName: r.chart,
+            chartVersion: r.chartVersion,
+            revision: r.revision,
+            status: r.status,
+            // `— ago` is not a sentence: a release with no timestamp has an
+            // unknown age, not an age of nothing.
+            updated: age === "—" ? age : `${age} ago`,
+            updatedAt: r.updated,
+          };
+        }),
+    [releases, at, selection],
   );
 
   /**
@@ -378,12 +471,29 @@ function HelmReleases({ title, context }: { title: string; context: ClusterConte
     {
       key: "name",
       header: "Release",
-      render: (row) => <span className="block truncate font-medium">{row.name}</span>,
+      /**
+       * Capped for the same reason the Chart cell is, and with the same
+       * mechanism — see that cell's note. The cap is what stops a table of
+       * `cnips-abena-…`-length release names growing wider than the space
+       * beside the 420px pane and pushing the action column off the end of it.
+       */
+      render: (row) => (
+        <span data-slot="release-name" className="block max-w-[220px] truncate font-medium">
+          {row.name}
+        </span>
+      ),
     },
     {
       key: "namespace",
       header: "Namespace",
-      render: (row) => <span className="path block truncate">{row.namespace}</span>,
+      // `m01-cnips-01-dataservices` is a real namespace on the cluster this
+      // was reported from, and it is already truncating — capped so it does so
+      // by design rather than by whatever width was left over.
+      render: (row) => (
+        <span data-slot="release-namespace" className="path block max-w-[180px] truncate">
+          {row.namespace}
+        </span>
+      ),
     },
     {
       key: "chart",
@@ -444,8 +554,23 @@ function HelmReleases({ title, context }: { title: string; context: ClusterConte
       filterable: false,
       align: "end",
       minWidth: 210,
+      /**
+       * **The action group is the one thing here that may not be clipped.**
+       *
+       * On a real cluster every row ended in a cut-off `U` where the pane
+       * begins: `Uninstall` — the only irreversible control on this screen —
+       * reduced to a sliver, and readable as part of `Roll back`'s group. Flex
+       * items shrink by default, so `shrink-0` is what refuses the loss inside
+       * the cell; the capped Release, Namespace and Chart cells above are what
+       * absorb it instead, because a truncated name is recoverable by widening
+       * a column and a clipped button is not. jsdom sees none of this, hence
+       * the class assertion in the suite.
+       */
       render: (row) => (
-        <div className="flex items-center justify-end gap-1">
+        <div
+          data-slot="release-actions"
+          className="flex shrink-0 items-center justify-end gap-1 whitespace-nowrap"
+        >
           {/* Named per row. Six rows all offering "Upgrade" name nothing at
               all; the accessible name carries the release, which the row
               already shows, so nothing is hidden in it. */}
@@ -477,6 +602,30 @@ function HelmReleases({ title, context }: { title: string; context: ClusterConte
       ),
     },
   ];
+
+  /**
+   * What the table actually draws: the namespace scope, then the text filter.
+   *
+   * Not memoized, because `columns` is rebuilt every render anyway and a
+   * `useMemo` keyed on it would recompute every time regardless — an honest
+   * call is cheaper than a cache that never hits.
+   */
+  const visible = filterTableData(rows, columns, filter, null);
+
+  /**
+   * §16's pane head, made to describe what the reader is looking at.
+   *
+   * `383 in this cluster` over a table showing six releases in one namespace
+   * is a string asserting more than the view holds — the class of defect this
+   * migration keeps finding — so the count is what is drawn and the words say
+   * what it was drawn from.
+   */
+  const scopeWord =
+    selection.length === 0
+      ? "this cluster"
+      : selection.length === 1
+        ? selection[0]
+        : plural(selection.length, "namespace");
 
   const Sparkle = Icons.ask;
 
@@ -554,6 +703,33 @@ function HelmReleases({ title, context }: { title: string; context: ClusterConte
         />
       )}
 
+      {/* Above both panes rather than inside the table's, the way
+          `Resources.tsx` composes its own: the bar filters the list, and the
+          rail beside it is about whatever the list is showing. */}
+      <FilterBar
+        value={filter}
+        onValueChange={setFilter}
+        label="Filter releases"
+        placeholder="Filter releases…"
+      >
+        <NamespacePicker
+          namespaces={namespaces}
+          selection={selection}
+          onChange={(next) => setNamespaces(context.stableId, next)}
+        />
+      </FilterBar>
+
+      {/* Non-fatal: the picker keeps whatever namespaces it had, and the
+          releases below it are unaffected — this only says the list behind the
+          control may be short. */}
+      <NamespaceErrorAlert error={namespaceError} />
+
+      <StaleSelectionAlert
+        selection={selection}
+        namespaces={namespaces}
+        onReset={() => setNamespaces(context.stableId, [])}
+      />
+
       <div className="flex min-h-0 flex-1">
         {/* `min-w-0`, and it is load-bearing. A flex item's implicit
             `min-width: auto` refuses to shrink below its content, so without
@@ -564,7 +740,7 @@ function HelmReleases({ title, context }: { title: string; context: ClusterConte
           <div className="pane-head">
             <span className="min-w-0 truncate">
               {list.status === "ready"
-                ? `Releases · ${rows.length} in this cluster`
+                ? `Releases · ${visible.length} in ${scopeWord}`
                 : "Releases"}
             </span>
           </div>
@@ -580,7 +756,7 @@ function HelmReleases({ title, context }: { title: string; context: ClusterConte
             ) : (
               <Table
                 columns={columns}
-                data={rows}
+                data={visible}
                 getRowKey={(row) => row.key}
                 selectedKey={selectedKey ?? undefined}
                 // §16's own pane is hard-wired to one release and says a row
@@ -589,10 +765,17 @@ function HelmReleases({ title, context }: { title: string; context: ClusterConte
                 // the release the reader is asking about.
                 onRowClick={(row) => setSelectedKey(row.key)}
                 onRowActivate={(row) => setSelectedKey(row.key)}
-                // A cluster with no releases is ordinary, not a failure: there
-                // is no filter on this screen to blame and nothing to clear.
-                emptyText="No Helm releases"
-                emptyHint={`${name} has no Helm releases.`}
+                // Nothing here is ever "no releases, and no reason": a scope
+                // with none is ordinary and says which scope, a filter that
+                // matches none says how many it is hiding. The screen now HAS
+                // filters to blame, which is why this is no longer one fixed
+                // sentence.
+                {...emptyTableCopy(
+                  rows.length,
+                  "Helm releases",
+                  name,
+                  selection.length === 0 ? "" : " in the namespaces you are looking at",
+                )}
               />
             )}
           </div>

--- a/packages/ui-next/src/screens/Helm.tsx
+++ b/packages/ui-next/src/screens/Helm.tsx
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import {
   ageFromTimestamp,
+  getHelmRelease,
   helmStatus,
   listHelmReleases,
   type ClusterContext,
   type HelmReleaseSummary,
+  type HelmRevision,
 } from "@srelens/core";
 import { Button, LoadingState, Screen, StatusPill, Table, type Column } from "@srelens/ui-kit";
 import { useConsole } from "../console";
@@ -68,6 +70,14 @@ interface Pending {
   chartVersion: string;
   /** The revision running now, for rollback's own arithmetic. */
   revision?: number;
+  /**
+   * The release's revisions, fetched before a rollback dialog is opened.
+   *
+   * Only rollback carries one: it is the only mode with a target to default,
+   * and the fetch is what stops §16's `Roll back to 118` opening on a blank
+   * field. See {@link HelmReleases}.
+   */
+  history?: readonly HelmRevision[];
 }
 
 /** Where the release listing stands. */
@@ -97,14 +107,11 @@ export function Helm({ route }: { route: string }) {
 /**
  * §16's two panes: the release table, and the fixed 420px pane beside it.
  *
- * **Everything this screen knows about a release comes from
- * `listHelmReleases`.** It makes no `getHelmRelease` call of its own — the
- * pane makes the two the diff needs, and nothing here would be improved by a
- * third. That is also why the rollback dialog is opened with no `history`: the
- * dialog was built to degrade honestly without one ("srelens has no history
- * for this release, so name the revision yourself"), and fetching a release's
- * whole manifest, values and history to pre-fill one number is a round trip
- * per selection for a field the reader can type.
+ * **The table is `listHelmReleases` and nothing else.** The pane makes the two
+ * `getHelmRelease` calls its diff needs; this screen makes exactly one of its
+ * own, and only when a rollback dialog is opened — see {@link operate}. Not
+ * per selection, and never for the table: a release's revisions are what
+ * rollback's target defaults from, and nothing else on this screen wants them.
  *
  * **No status word or tone is invented here.** `helmStatus` is the only thing
  * that turns Helm's word into a tone, on the rows and in the pane's badge
@@ -168,13 +175,38 @@ function HelmReleases({ title, context }: { title: string; context: ClusterConte
    * anything having happened in the cluster, and a listing per dismissal is a
    * round trip nobody asked for.
    */
-  const relisted = useRef(new Set<number>());
+  const relisted = useRef<{ context: string; ids: Set<number> } | null>(null);
+  // Seeded during render, and re-seeded whenever the cluster changes. The ops
+  // store is module-level and outlives this screen, so a mount that started
+  // with settled operations in it would fire the effect below for news it never
+  // showed — a second `listHelmReleases` racing the mount effect's, two
+  // unordered writes of the same data. Everything already settled counts as
+  // seen; only what settles from here on is news.
+  if (relisted.current?.context !== name) {
+    relisted.current = {
+      context: name,
+      // Settled only. An operation still RUNNING at mount is news that has not
+      // happened yet: it will settle under this screen and must re-list then.
+      ids: new Set(
+        getHelmOps()
+          .filter((o) => o.state !== "running")
+          .map((o) => o.id),
+      ),
+    };
+  }
   useEffect(() => {
-    const settled = ops.filter((o) => o.state !== "running" && !relisted.current.has(o.id));
+    const seen = relisted.current;
+    if (!seen || seen.context !== name) return;
+    // Scoped to THIS cluster. An upgrade finishing on another context changes
+    // nothing in the list on screen, and re-listing for it is a round trip
+    // spent on somebody else's news.
+    const settled = ops.filter(
+      (o) => o.context === name && o.state !== "running" && !seen.ids.has(o.id),
+    );
     if (settled.length === 0) return;
-    for (const o of settled) relisted.current.add(o.id);
+    for (const o of settled) seen.ids.add(o.id);
     void reload();
-  }, [ops, reload]);
+  }, [ops, name, reload]);
 
   const releases = list.status === "ready" ? list.releases : [];
   const at = list.status === "ready" ? list.at : 0;
@@ -226,10 +258,19 @@ function HelmReleases({ title, context }: { title: string; context: ClusterConte
     ? `What did ${selected.name} release ${selected.revision} change?`
     : `Which Helm releases on ${name} need attention?`;
 
+  /**
+   * Which rollback request is the current one.
+   *
+   * A rollback waits on a round trip before its dialog can open, and a reader
+   * who clicks `Roll back` on two rows in quick succession must get the second
+   * one — not whichever history answered first.
+   */
+  const rollbackSeq = useRef(0);
+
   /** Open the dialog on a row, and follow that row in the pane. */
   function operate(kind: HelmOpKind, row: ReleaseRow) {
     setSelectedKey(row.key);
-    setPending({
+    const base: Pending = {
       kind,
       release: row.name,
       namespace: row.namespace,
@@ -240,7 +281,41 @@ function HelmReleases({ title, context }: { title: string; context: ClusterConte
       chart: row.chartName,
       chartVersion: row.chartVersion,
       revision: row.revision,
-    });
+    };
+    if (kind !== "rollback") {
+      setPending(base);
+      return;
+    }
+    /**
+     * **Rollback reads the release's revisions first, and opens on the answer.**
+     *
+     * This is the one round trip this screen makes for itself, and it is what
+     * stops a control lying about its own label. §16's pane footer reads
+     * `Roll back to 118`; with no history the dialog's `lastGoodRevision` has
+     * nothing to work from, so it opened on a blank field over "srelens has no
+     * history for this release" — the reader clicked a button naming a number
+     * and was asked to type that number back in.
+     *
+     * The two numbers are still NOT reconciled. Nothing here overrides the
+     * dialog's target: helm's own record is handed over and `lastGoodRevision`
+     * decides. It lands on `revision - 1` whenever helm's record supports it —
+     * which is the ordinary case, and is why the button now honours its label —
+     * and on an older one when that revision is itself failed or unfinished,
+     * with the hint saying which and why. That divergence is the point: the
+     * footer says what the reader is LOOKING at, the dialog says what is safe
+     * to return to.
+     *
+     * Opened after the answer rather than before it: the dialog fixes its
+     * target field on mount, so a history that arrived later would be a default
+     * the reader never sees. A refused fetch opens on no history, which is the
+     * degrade the dialog was built with.
+     */
+    const seq = ++rollbackSeq.current;
+    void (async () => {
+      const out = await getHelmRelease(name, row.namespace, row.name);
+      if (seq !== rollbackSeq.current) return;
+      setPending({ ...base, history: out.release?.history ?? [] });
+    })();
   }
 
   /**
@@ -248,12 +323,14 @@ function HelmReleases({ title, context }: { title: string; context: ClusterConte
    *
    * The number the pane hands over is `revision - 1` — the revision the diff
    * on screen is comparing against, which is what makes the button read
-   * `Roll back to 118`. **It is deliberately not forced into the dialog.**
-   * The dialog's own default target is `lastGoodRevision`: the newest revision
-   * helm does not report as failed or unfinished, which on a release whose
-   * last two upgrades failed is a different and better number. They answer
-   * different questions — "what am I looking at" and "what is safe to return
-   * to" — and reconciling them would mean one of the two lying.
+   * `Roll back to 118`. **It is still not forced into the dialog**, and the
+   * unused parameter is the point: {@link operate} hands helm's own record
+   * over and `lastGoodRevision` decides. It agrees with the button whenever
+   * helm's record supports it, so the button honours its label; it offers an
+   * older revision when the one the pane names is itself failed, which is the
+   * divergence worth keeping. The footer says what the reader is LOOKING at;
+   * the dialog says what is safe to return to. Making either say the other's
+   * number would mean one of the two lying.
    */
   function rollbackFromPane() {
     const row = rows.find((r) => r.key === selectedKey);
@@ -426,6 +503,7 @@ function HelmReleases({ title, context }: { title: string; context: ClusterConte
           release={pending.release}
           chart={pending.chart}
           chartVersion={pending.chartVersion}
+          history={pending.history}
           revision={pending.revision}
           extraKubeconfigs={files}
           onClose={() => setPending(null)}

--- a/packages/ui-next/src/screens/Helm.tsx
+++ b/packages/ui-next/src/screens/Helm.tsx
@@ -30,17 +30,6 @@ import { NoClusterScreen } from "./resourceShell";
  */
 const EXPLAIN_LABEL = "Explain";
 
-/**
- * The name §16's `Install chart` opens its dialog on.
- *
- * A PROP, never a blank field. `HelmOpDialog` takes the release name as a
- * prop in all four modes, and its uninstall gate compares what was typed to
- * `release` with an explicit `release !== ""` guard — an empty name is a gate
- * that can never be passed. There is no install-mode field for it either, so a
- * blank here would build `helm install "" <chart>`.
- */
-const NEW_RELEASE = "new-release";
-
 /** One row of §16's release table, every cell already resolved to what it draws. */
 interface ReleaseRow {
   /** Helm scopes a release name to a namespace, so both are the identity. */
@@ -522,9 +511,19 @@ function HelmReleases({ title, context }: { title: string; context: ClusterConte
             onClick={() =>
               setPending({
                 kind: "install",
-                release: NEW_RELEASE,
-                // The context's own default namespace, which is where `helm
-                // install` with no `--namespace` would have gone anyway.
+                // **Empty, and the dialog asks.** This opened on
+                // `new-release` — §A.5's own fixture — over a dialog with no
+                // field to change it with, so every install srelens could
+                // make was called `new-release` and the second one helm
+                // refused outright. The name is the reader's; install mode
+                // has a field for it, and its own gate refuses a name helm
+                // would not take. Nothing else is weakened by the blank:
+                // uninstall's typed gate reads this prop and guards
+                // `release !== ""`, and this is not uninstall.
+                release: "",
+                // Where the field starts. The context's own default
+                // namespace, which is where `helm install` with no
+                // `--namespace` would have gone anyway.
                 namespace: context.namespace || "default",
                 chart: "",
                 chartVersion: "",

--- a/packages/ui-next/src/screens/Helm.tsx
+++ b/packages/ui-next/src/screens/Helm.tsx
@@ -11,7 +11,7 @@ import {
 import { Button, LoadingState, Screen, StatusPill, Table, type Column } from "@srelens/ui-kit";
 import { useConsole } from "../console";
 import { getKubeconfigFiles, useActiveContext } from "../lib/clusters";
-import { FailureState } from "../lib/errorCopy";
+import { FailureState, friendly } from "../lib/errorCopy";
 import { getHelmOps, subscribeHelmOps, type HelmOpKind } from "../lib/helmOps";
 import { Icons } from "../lib/icons";
 import { describe } from "../lib/routes";
@@ -71,6 +71,13 @@ interface Pending {
   /** The revision running now, for rollback's own arithmetic. */
   revision?: number;
   /**
+   * The values the release is running, fetched before an upgrade dialog is
+   * opened — see {@link HelmReleases}.
+   */
+  values?: string;
+  /** Why those values could not be read, when they could not be. */
+  valuesUnavailable?: string;
+  /**
    * The release's revisions, fetched before a rollback dialog is opened.
    *
    * Only rollback carries one: it is the only mode with a target to default,
@@ -109,9 +116,10 @@ export function Helm({ route }: { route: string }) {
  *
  * **The table is `listHelmReleases` and nothing else.** The pane makes the two
  * `getHelmRelease` calls its diff needs; this screen makes exactly one of its
- * own, and only when a rollback dialog is opened — see {@link operate}. Not
- * per selection, and never for the table: a release's revisions are what
- * rollback's target defaults from, and nothing else on this screen wants them.
+ * own, and only when an upgrade or a rollback dialog is opened — see
+ * {@link operate}. Not per selection, and never for the table: the two
+ * mutations that need the release itself are the two that ask for it, and
+ * nothing else on this screen wants either answer.
  *
  * **No status word or tone is invented here.** `helmStatus` is the only thing
  * that turns Helm's word into a tone, on the rows and in the pane's badge
@@ -259,13 +267,13 @@ function HelmReleases({ title, context }: { title: string; context: ClusterConte
     : `Which Helm releases on ${name} need attention?`;
 
   /**
-   * Which rollback request is the current one.
+   * Which dialog request is the current one.
    *
-   * A rollback waits on a round trip before its dialog can open, and a reader
-   * who clicks `Roll back` on two rows in quick succession must get the second
-   * one — not whichever history answered first.
+   * Both upgrade and rollback wait on a round trip before their dialog can
+   * open, and a reader who clicks on two rows in quick succession must get the
+   * second one — not whichever release answered first.
    */
-  const rollbackSeq = useRef(0);
+  const openSeq = useRef(0);
 
   /** Open the dialog on a row, and follow that row in the pane. */
   function operate(kind: HelmOpKind, row: ReleaseRow) {
@@ -282,15 +290,36 @@ function HelmReleases({ title, context }: { title: string; context: ClusterConte
       chartVersion: row.chartVersion,
       revision: row.revision,
     };
-    if (kind !== "rollback") {
+    if (kind === "install" || kind === "uninstall") {
       setPending(base);
       return;
     }
     /**
-     * **Rollback reads the release's revisions first, and opens on the answer.**
+     * **Upgrade and rollback read the release first, and open on the answer.**
      *
-     * This is the one round trip this screen makes for itself, and it is what
-     * stops a control lying about its own label. §16's pane footer reads
+     * Upgrade wants its values; rollback wants its revisions. One
+     * `getHelmRelease` carries both, and both are things the dialog fixes on
+     * mount — so the answer has to arrive before it opens, not after.
+     *
+     * **Why upgrade cannot skip this.** `helm upgrade <rel> <chart>` with
+     * neither `--values` nor `--reuse-values` does not keep the release's
+     * values: helm applies the CHART's defaults over them. A dialog that
+     * opened on an empty editor was therefore one click from discarding every
+     * value the release was installed with, with nothing on screen saying so.
+     * The editor opens on what the release is actually running, so the reader
+     * changes a chart version while LOOKING at the values that will be
+     * reapplied.
+     *
+     * **A refused read is not an empty one.** `values: ""` would be the defect
+     * again, wearing the degrade's clothes, so the two are kept apart: no
+     * release back means the values are unknown, and the dialog is told why —
+     * it says so and adds `--reuse-values`, which is helm's own answer to
+     * "keep what is there". `describeError` runs here rather than in the
+     * dialog, so what crosses the boundary is a sentence rather than a Rust
+     * string.
+     *
+     * **Why rollback cannot skip it either.** It is what stops a control
+     * lying about its own label. §16's pane footer reads
      * `Roll back to 118`; with no history the dialog's `lastGoodRevision` has
      * nothing to work from, so it opened on a blank field over "srelens has no
      * history for this release" — the reader clicked a button naming a number
@@ -310,11 +339,25 @@ function HelmReleases({ title, context }: { title: string; context: ClusterConte
      * the reader never sees. A refused fetch opens on no history, which is the
      * degrade the dialog was built with.
      */
-    const seq = ++rollbackSeq.current;
+    const seq = ++openSeq.current;
     void (async () => {
       const out = await getHelmRelease(name, row.namespace, row.name);
-      if (seq !== rollbackSeq.current) return;
-      setPending({ ...base, history: out.release?.history ?? [] });
+      if (seq !== openSeq.current) return;
+      if (kind === "rollback") {
+        setPending({ ...base, history: out.release?.history ?? [] });
+        return;
+      }
+      setPending(
+        out.release
+          ? // An empty body here is a real answer: a release installed with no
+            // values of its own has none to keep, and the editor says so by
+            // being empty.
+            { ...base, values: out.release.valuesYaml ?? "" }
+          : {
+              ...base,
+              valuesUnavailable: friendly(out.error ?? "helm returned no release").detail,
+            },
+      );
     })();
   }
 
@@ -503,6 +546,8 @@ function HelmReleases({ title, context }: { title: string; context: ClusterConte
           release={pending.release}
           chart={pending.chart}
           chartVersion={pending.chartVersion}
+          values={pending.values}
+          valuesUnavailable={pending.valuesUnavailable}
           history={pending.history}
           revision={pending.revision}
           extraKubeconfigs={files}

--- a/packages/ui-next/src/screens/Helm.tsx
+++ b/packages/ui-next/src/screens/Helm.tsx
@@ -1,0 +1,497 @@
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
+import {
+  ageFromTimestamp,
+  helmStatus,
+  listHelmReleases,
+  type ClusterContext,
+  type HelmReleaseSummary,
+} from "@srelens/core";
+import { Button, LoadingState, Screen, StatusPill, Table, type Column } from "@srelens/ui-kit";
+import { useConsole } from "../console";
+import { getKubeconfigFiles, useActiveContext } from "../lib/clusters";
+import { FailureState } from "../lib/errorCopy";
+import { getHelmOps, subscribeHelmOps, type HelmOpKind } from "../lib/helmOps";
+import { Icons } from "../lib/icons";
+import { describe } from "../lib/routes";
+import { HelmOpDialog } from "./helm/HelmOpDialog";
+import { ReleasePane, type PaneRelease } from "./helm/ReleasePane";
+import { NoClusterScreen } from "./resourceShell";
+
+/**
+ * §16's header ask: the visible word, and the question actually sent.
+ *
+ * The question names the release the reader is looking at — §16 writes it for
+ * its own fixture (`What did checkout release 119 change?`) and the shape is
+ * what generalises. With nothing selected there is no release to name, so the
+ * question is about the cluster instead rather than about a release the reader
+ * has not chosen.
+ */
+const EXPLAIN_LABEL = "Explain";
+
+/**
+ * The name §16's `Install chart` opens its dialog on.
+ *
+ * A PROP, never a blank field. `HelmOpDialog` takes the release name as a
+ * prop in all four modes, and its uninstall gate compares what was typed to
+ * `release` with an explicit `release !== ""` guard — an empty name is a gate
+ * that can never be passed. There is no install-mode field for it either, so a
+ * blank here would build `helm install "" <chart>`.
+ */
+const NEW_RELEASE = "new-release";
+
+/** One row of §16's release table, every cell already resolved to what it draws. */
+interface ReleaseRow {
+  /** Helm scopes a release name to a namespace, so both are the identity. */
+  key: string;
+  name: string;
+  namespace: string;
+  /** `ingress-nginx-4.12.0` — §16's Chart cell, which is the two fields joined. */
+  chart: string;
+  /** The chart's own name, for the dialog's Chart field. */
+  chartName: string;
+  chartVersion: string;
+  revision: number;
+  /** Helm's own status word, untouched. Toned by core, never by this file. */
+  status: string;
+  /** `9d ago`, or `—` when the backend gave no timestamp. */
+  updated: string;
+  /** The raw stamp, so the column sorts as time rather than as text. */
+  updatedAt: string;
+}
+
+/** What the dialog is about, decided when it is opened and not before. */
+interface Pending {
+  kind: HelmOpKind;
+  release: string;
+  namespace: string;
+  chart: string;
+  chartVersion: string;
+  /** The revision running now, for rollback's own arithmetic. */
+  revision?: number;
+}
+
+/** Where the release listing stands. */
+type ListLoad =
+  | { status: "loading" }
+  | { status: "ready"; releases: HelmReleaseSummary[]; at: number }
+  | { status: "error"; error: string };
+
+/**
+ * `/helm` — the design's Helm screen (§16).
+ *
+ * Split in two the way `Events.tsx` is: with no cluster in focus there is no
+ * context name to list against, and a hook cannot be skipped, so the guard is
+ * a `return` before any hook runs.
+ */
+export function Helm({ route }: { route: string }) {
+  const context = useActiveContext();
+  const title = describe(route, context?.name).title;
+
+  if (!context) {
+    return <NoClusterScreen title={title} noun="Helm releases" />;
+  }
+
+  return <HelmReleases title={title} context={context} />;
+}
+
+/**
+ * §16's two panes: the release table, and the fixed 420px pane beside it.
+ *
+ * **Everything this screen knows about a release comes from
+ * `listHelmReleases`.** It makes no `getHelmRelease` call of its own — the
+ * pane makes the two the diff needs, and nothing here would be improved by a
+ * third. That is also why the rollback dialog is opened with no `history`: the
+ * dialog was built to degrade honestly without one ("srelens has no history
+ * for this release, so name the revision yourself"), and fetching a release's
+ * whole manifest, values and history to pre-fill one number is a round trip
+ * per selection for a field the reader can type.
+ *
+ * **No status word or tone is invented here.** `helmStatus` is the only thing
+ * that turns Helm's word into a tone, on the rows and in the pane's badge
+ * alike. Task 2 exists so this screen is not the fourth to keep its own table.
+ *
+ * **The pane is dropped in beside the table with no wrapper.** `ReleasePane`
+ * owns its own 420px frame — `aside.side-rail`, head, body and footer — so a
+ * `SideRail` around it would be a second rail around the first.
+ */
+function HelmReleases({ title, context }: { title: string; context: ClusterContext }) {
+  // Core takes a context *name*; the workspace holds a `stableId`. The two are
+  // never interchangeable — see `lib/clusters`.
+  const name = context.name;
+  const files = getKubeconfigFiles();
+  const { ask } = useConsole();
+
+  const ops = useSyncExternalStore(subscribeHelmOps, getHelmOps, getHelmOps);
+
+  const [list, setList] = useState<ListLoad>({ status: "loading" });
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [pending, setPending] = useState<Pending | null>(null);
+
+  /**
+   * List the cluster's releases.
+   *
+   * Stable across renders — this screen re-renders on every line a running
+   * `helm upgrade` prints, and a handler rebuilt each time would re-fire the
+   * effects that depend on it.
+   */
+  const reload = useCallback(async () => {
+    const out = await listHelmReleases(name);
+    if (out.error !== undefined || !out.releases) {
+      setList({ status: "error", error: out.error ?? "helm returned no releases" });
+      return;
+    }
+    setList({ status: "ready", releases: out.releases, at: Date.now() });
+  }, [name]);
+
+  useEffect(() => {
+    setList({ status: "loading" });
+    setSelectedKey(null);
+    void reload();
+  }, [reload]);
+
+  /**
+   * **Re-list once an operation settles**, so the pane stops diffing the pair
+   * from before it.
+   *
+   * A successful `helm upgrade` moves the release to a new revision, and the
+   * pane's diff is `revision - 1 → revision` off the row in this list: without
+   * this, an upgrade that landed leaves the reader looking at the diff of the
+   * revision BEFORE the one they just created, under a status word that is
+   * also stale.
+   *
+   * Every settled operation, not only the successful ones — a failed
+   * `helm upgrade` still writes a revision, with `failed` on it, and that is
+   * exactly the row a reader needs to see change.
+   *
+   * Keyed on ids already acted on rather than on the settled ids themselves:
+   * dismissing a finished row changes the set of settled operations without
+   * anything having happened in the cluster, and a listing per dismissal is a
+   * round trip nobody asked for.
+   */
+  const relisted = useRef(new Set<number>());
+  useEffect(() => {
+    const settled = ops.filter((o) => o.state !== "running" && !relisted.current.has(o.id));
+    if (settled.length === 0) return;
+    for (const o of settled) relisted.current.add(o.id);
+    void reload();
+  }, [ops, reload]);
+
+  const releases = list.status === "ready" ? list.releases : [];
+  const at = list.status === "ready" ? list.at : 0;
+
+  const rows = useMemo<ReleaseRow[]>(
+    () =>
+      releases.map((r) => {
+        const age = ageFromTimestamp(r.updated, at);
+        return {
+          key: `${r.namespace}/${r.name}`,
+          name: r.name,
+          namespace: r.namespace,
+          // §16's cell, and what classic's Helm list has always shown.
+          chart: `${r.chart}-${r.chartVersion}`,
+          chartName: r.chart,
+          chartVersion: r.chartVersion,
+          revision: r.revision,
+          status: r.status,
+          // `— ago` is not a sentence: a release with no timestamp has an
+          // unknown age, not an age of nothing.
+          updated: age === "—" ? age : `${age} ago`,
+          updatedAt: r.updated,
+        };
+      }),
+    [releases, at],
+  );
+
+  /**
+   * The release the pane is about — looked up in the CURRENT list rather than
+   * held in state.
+   *
+   * This is what makes the revision refresh above reach the pane: the
+   * selection is a key, and the numbers behind it are whatever the last
+   * listing said. A `PaneRelease` copied into state at click time would still
+   * carry the revision the release had when it was clicked.
+   */
+  const selected = useMemo<PaneRelease | null>(() => {
+    const row = rows.find((r) => r.key === selectedKey);
+    if (!row) return null;
+    return {
+      name: row.name,
+      namespace: row.namespace,
+      revision: row.revision,
+      status: row.status,
+    };
+  }, [rows, selectedKey]);
+
+  const question = selected
+    ? `What did ${selected.name} release ${selected.revision} change?`
+    : `Which Helm releases on ${name} need attention?`;
+
+  /** Open the dialog on a row, and follow that row in the pane. */
+  function operate(kind: HelmOpKind, row: ReleaseRow) {
+    setSelectedKey(row.key);
+    setPending({
+      kind,
+      release: row.name,
+      namespace: row.namespace,
+      // The chart and version the release is ON. §16's own upgrade path is the
+      // pane's `Values editor`, which re-renders the SAME chart with new
+      // values, so the current pair is the right place for both fields to
+      // start; a reader moving version changes one number.
+      chart: row.chartName,
+      chartVersion: row.chartVersion,
+      revision: row.revision,
+    });
+  }
+
+  /**
+   * §16's pane footer: roll back to the diff's left-hand revision.
+   *
+   * The number the pane hands over is `revision - 1` — the revision the diff
+   * on screen is comparing against, which is what makes the button read
+   * `Roll back to 118`. **It is deliberately not forced into the dialog.**
+   * The dialog's own default target is `lastGoodRevision`: the newest revision
+   * helm does not report as failed or unfinished, which on a release whose
+   * last two upgrades failed is a different and better number. They answer
+   * different questions — "what am I looking at" and "what is safe to return
+   * to" — and reconciling them would mean one of the two lying.
+   */
+  function rollbackFromPane() {
+    const row = rows.find((r) => r.key === selectedKey);
+    if (row) operate("rollback", row);
+  }
+
+  function valuesEditor() {
+    const row = rows.find((r) => r.key === selectedKey);
+    if (row) operate("upgrade", row);
+  }
+
+  const columns: Column<ReleaseRow>[] = [
+    {
+      key: "name",
+      header: "Release",
+      render: (row) => <span className="block truncate font-medium">{row.name}</span>,
+    },
+    {
+      key: "namespace",
+      header: "Namespace",
+      render: (row) => <span className="path block truncate">{row.namespace}</span>,
+    },
+    {
+      key: "chart",
+      header: "Chart",
+      /**
+       * §16 truncates this at 200px, and the cap is what keeps the 420px pane
+       * on the window.
+       *
+       * A cell's intrinsic width is its content's, and `truncate` alone does
+       * not change that — `white-space: nowrap` makes the min-content width the
+       * whole string. `max-w-[200px]` is what caps the contribution, and
+       * `block` is what makes `overflow: hidden` apply at all: `truncate` on an
+       * inline box does nothing. A chart named
+       * `kube-prometheus-stack-67.2.0` is already past 200px, and jsdom sees
+       * none of this — hence the class assertion in the suite.
+       */
+      render: (row) => (
+        <span data-slot="chart-name" className="path block max-w-[200px] truncate">
+          {row.chart}
+        </span>
+      ),
+    },
+    {
+      key: "revision",
+      header: "Rev",
+      align: "end",
+      render: (row) => <span className="tabular-nums">{row.revision}</span>,
+    },
+    {
+      key: "status",
+      header: "Status",
+      /**
+       * Core's verdict, word and tone. `tinted` is the design's asymmetric
+       * colouring rule — §16 draws `deployed` plain and everything worse
+       * coloured and bold — and `StatusPill` owns which kinds that covers, so
+       * this file decides nothing about it.
+       */
+      render: (row) => {
+        const v = helmStatus(row.status);
+        return <StatusPill status={v.word} kind={v.health} tinted />;
+      },
+      // Sorted and searched on the word the reader can see.
+      getValue: (row) => helmStatus(row.status).word,
+    },
+    {
+      key: "updated",
+      header: "Updated",
+      align: "end",
+      // The stamp, not the compact age: `2h` sorts below `51m` as text.
+      getSortValue: (row) => row.updatedAt,
+      render: (row) => <span className="tabular-nums text-muted">{row.updated}</span>,
+    },
+    {
+      // §16's unnamed trailing column: the three operations, in its order.
+      key: "actions",
+      header: "",
+      sortable: false,
+      filterable: false,
+      align: "end",
+      minWidth: 210,
+      render: (row) => (
+        <div className="flex items-center justify-end gap-1">
+          {/* Named per row. Six rows all offering "Upgrade" name nothing at
+              all; the accessible name carries the release, which the row
+              already shows, so nothing is hidden in it. */}
+          <Button
+            size="xs"
+            variant="secondary"
+            aria-label={`Upgrade ${row.name}`}
+            onClick={() => operate("upgrade", row)}
+          >
+            Upgrade
+          </Button>
+          <Button
+            size="xs"
+            variant="secondary"
+            aria-label={`Roll back ${row.name}`}
+            onClick={() => operate("rollback", row)}
+          >
+            Roll back
+          </Button>
+          <Button
+            size="xs"
+            variant="danger"
+            aria-label={`Uninstall ${row.name}`}
+            onClick={() => operate("uninstall", row)}
+          >
+            Uninstall
+          </Button>
+        </div>
+      ),
+    },
+  ];
+
+  const Sparkle = Icons.ask;
+
+  return (
+    <Screen
+      title={title}
+      // §16's sub. The releases are this cluster's; the word says which list
+      // the title is about.
+      eyebrow={`${name} / releases`}
+      fill
+      actions={
+        <>
+          {/* A `Button`, not `AskChip`. `.row-ask` is `opacity: 0` until a
+              `.tbl tbody tr` is hovered and a header has no row to hover —
+              `Events.tsx` and `Overview.tsx` both say so, and Logs shipped an
+              invisible one until #352. The visible word is §16's; the question
+              that will actually be sent is the accessible name, which is the
+              same split the chip itself makes. */}
+          <Button
+            type="button"
+            size="sm"
+            aria-label={`${EXPLAIN_LABEL}: ${question}`}
+            title={`${EXPLAIN_LABEL}: ${question}`}
+            onClick={() => ask(question)}
+          >
+            <Sparkle size={12} aria-hidden="true" />
+            {EXPLAIN_LABEL}
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={() =>
+              setPending({
+                kind: "install",
+                release: NEW_RELEASE,
+                // The context's own default namespace, which is where `helm
+                // install` with no `--namespace` would have gone anyway.
+                namespace: context.namespace || "default",
+                chart: "",
+                chartVersion: "",
+              })
+            }
+          >
+            Install chart
+          </Button>
+        </>
+      }
+    >
+      {/* Beside the panes rather than inside either, so it opens the same from
+          a row, from the pane's footer and from the header. */}
+      {pending && (
+        <HelmOpDialog
+          kind={pending.kind}
+          context={name}
+          namespace={pending.namespace}
+          release={pending.release}
+          chart={pending.chart}
+          chartVersion={pending.chartVersion}
+          revision={pending.revision}
+          extraKubeconfigs={files}
+          onClose={() => setPending(null)}
+        />
+      )}
+
+      <div className="flex min-h-0 flex-1">
+        {/* `min-w-0`, and it is load-bearing. A flex item's implicit
+            `min-width: auto` refuses to shrink below its content, so without
+            it a table with a long chart name pushes the 420px pane off the
+            window and the whole screen scrolls sideways. Seven defects on this
+            migration, none of them visible in jsdom. */}
+        <div data-slot="release-main" className="flex min-h-0 min-w-0 flex-1 flex-col">
+          <div className="pane-head">
+            <span className="min-w-0 truncate">
+              {list.status === "ready"
+                ? `Releases · ${rows.length} in this cluster`
+                : "Releases"}
+            </span>
+          </div>
+          <div className="scroll min-h-0 min-w-0 flex-1">
+            {list.status === "loading" ? (
+              <LoadingState label="Listing Helm releases" />
+            ) : list.status === "error" ? (
+              <FailureState
+                title={`Could not list Helm releases on ${name}`}
+                error={list.error}
+                onRetry={() => void reload()}
+              />
+            ) : (
+              <Table
+                columns={columns}
+                data={rows}
+                getRowKey={(row) => row.key}
+                selectedKey={selectedKey ?? undefined}
+                // §16's own pane is hard-wired to one release and says a row
+                // click does nothing. This one follows the selection, which is
+                // the only way the diff and the operation output can be about
+                // the release the reader is asking about.
+                onRowClick={(row) => setSelectedKey(row.key)}
+                onRowActivate={(row) => setSelectedKey(row.key)}
+                // A cluster with no releases is ordinary, not a failure: there
+                // is no filter on this screen to blame and nothing to clear.
+                emptyText="No Helm releases"
+                emptyHint={`${name} has no Helm releases.`}
+              />
+            )}
+          </div>
+        </div>
+
+        {/* No wrapper: `ReleasePane` is its own `aside.side-rail` at 420px.
+            `ops` is the store's snapshot passed straight through — filtering or
+            mapping it here would hand `useSyncExternalStore` a fresh array per
+            render, which is "Maximum update depth exceeded" rather than a waste.
+            No `invoke` either: core's own default is a module constant, and an
+            inline one would be a new identity every render on a screen that
+            re-renders for every line a running upgrade prints — re-firing both
+            of the pane's `getHelmRelease` round trips each time. */}
+        <ReleasePane
+          context={name}
+          release={selected}
+          ops={ops}
+          onRollback={rollbackFromPane}
+          onValuesEditor={valuesEditor}
+        />
+      </div>
+    </Screen>
+  );
+}

--- a/packages/ui-next/src/screens/helm/HelmOpDialog.test.tsx
+++ b/packages/ui-next/src/screens/helm/HelmOpDialog.test.tsx
@@ -217,6 +217,54 @@ describe("HelmOpDialog — the equivalent command", () => {
   });
 });
 
+describe("HelmOpDialog — the values note", () => {
+  /**
+   * **The defect this block exists for.** The backend appends `--values
+   * <path>` itself once a values body is sent — `helmArgv`'s own note says so
+   * — so the printed line is not what actually runs whenever the Values panel
+   * carries a body. A reader who copies the printed line and runs it gets an
+   * upgrade with no values at all, which is destructive on its own: helm's
+   * default for `helm upgrade <rel> <chart>` with no values flag discards the
+   * release's values and applies the chart's defaults.
+   */
+  it("says the values are sent separately when the panel carries a body", async () => {
+    open({ kind: "upgrade", values: "replicaCount: 12" });
+    await screen.findByRole("dialog");
+    expect(screen.getByText(/temporary file/i)).toBeTruthy();
+    expect(screen.getByText(/--values/)).toBeTruthy();
+  });
+
+  it("says nothing about values when the panel is empty", async () => {
+    open({ kind: "upgrade" });
+    await screen.findByRole("dialog");
+    expect(screen.queryByText(/temporary file/i)).toBeNull();
+  });
+
+  it("says nothing about values when the panel is only whitespace", async () => {
+    open({ kind: "upgrade", values: "   \n  " });
+    await screen.findByRole("dialog");
+    expect(screen.queryByText(/temporary file/i)).toBeNull();
+  });
+
+  it("says it on install too, which sends a body the same way", async () => {
+    open({ kind: "install", values: "replicaCount: 12" });
+    await screen.findByRole("dialog");
+    expect(screen.getByText(/temporary file/i)).toBeTruthy();
+  });
+
+  it("never says it on rollback, which has no values panel to send", async () => {
+    open({ kind: "rollback", history: HISTORY, revision: 4 });
+    await screen.findByRole("dialog");
+    expect(screen.queryByText(/temporary file/i)).toBeNull();
+  });
+
+  it("never says it on uninstall, even carrying a values prop it will not send", async () => {
+    open({ kind: "uninstall", values: "replicaCount: 12" });
+    await screen.findByRole("dialog");
+    expect(screen.queryByText(/temporary file/i)).toBeNull();
+  });
+});
+
 describe("HelmOpDialog — install names its own release", () => {
   /**
    * **A deliberate departure from §A.5**, which lists Chart and Chart version

--- a/packages/ui-next/src/screens/helm/HelmOpDialog.test.tsx
+++ b/packages/ui-next/src/screens/helm/HelmOpDialog.test.tsx
@@ -261,12 +261,16 @@ describe("HelmOpDialog — uninstall's gate", () => {
     // words — and that no object is named as being in this particular release.
     // Pinning only the fixture's own tokens would let "three pods and a
     // Service" through, which is the same lie in different words.
-    const counted =
-      /\b(\d+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|a few|several|dozens?)\b/i;
-    expect(alert.textContent).not.toMatch(counted);
-    const named =
-      /\b(pods?|services?|ingress(es)?|configmaps?|secrets?|deployments?|statefulsets?|jobs?)\b/i;
-    expect(alert.textContent).not.toMatch(named);
+    // Digits, and the objects a count would have to be OF. The object half is
+    // the load-bearing one: a fabricated count cannot avoid naming the things
+    // it counts, so this catches §A.5's sentence and every rewrite of it. A
+    // spelled-out-number alternation was tried here and taken out again — it
+    // caught nothing this does not, and it forbade ordinary prose ("in one
+    // pass", "one click", "at once") in a sentence nobody had written yet.
+    expect(alert.textContent).not.toMatch(/\d/);
+    expect(alert.textContent).not.toMatch(
+      /\b(pods?|services?|ingress(es)?|configmaps?|secrets?|deployments?|statefulsets?|jobs?)\b/i,
+    );
   });
 });
 
@@ -320,6 +324,54 @@ describe("HelmOpDialog — rollback's gate", () => {
     });
     await screen.findByRole("dialog");
     expect(button("Roll back to 2")).toBeTruthy();
+  });
+
+  it("says which of the three reasons it has no revision to offer", async () => {
+    // No history at all.
+    const first = render(
+      <HelmOpDialog kind="rollback" context={CONTEXT} namespace={NAMESPACE} release={RELEASE} onClose={vi.fn()} />,
+    );
+    expect(screen.getByText(/no history for this release/i)).toBeTruthy();
+    first.unmount();
+
+    // A history with nothing in it but the revision running now: true, and a
+    // different fact from having no history.
+    const second = render(
+      <HelmOpDialog
+        kind="rollback"
+        context={CONTEXT}
+        namespace={NAMESPACE}
+        release={RELEASE}
+        revision={1}
+        history={[HISTORY[0]].map((r) => ({ ...r, revision: 1, status: "deployed" }))}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/only the revision running now/i)).toBeTruthy();
+    expect(screen.queryByText(/no history for this release/i)).toBeNull();
+    second.unmount();
+
+    // A history of earlier revisions, none of them safe to offer. This is the
+    // case the old single sentence lied about, and the one where the reader
+    // most needs to be told the truth: the release HAS history, and none of it
+    // is a way out.
+    open({
+      kind: "rollback",
+      revision: 3,
+      history: [
+        { revision: 1, status: "failed", updated: "2026-08-01", chartVersion: "18.0.0", description: "Install failed" },
+        { revision: 2, status: "quiesced", updated: "2026-08-10", chartVersion: "18.1.0", description: "Something new" },
+        { revision: 3, status: "failed", updated: "2026-08-20", chartVersion: "18.2.0", description: "Upgrade failed" },
+      ],
+    });
+    await screen.findByRole("dialog");
+    expect(screen.getByText(/no earlier revision is safe to offer/i)).toBeTruthy();
+    expect(screen.queryByText(/no history for this release/i)).toBeNull();
+    // The rest of the degrade path stays as it was: nothing filled in, no
+    // command printed, and the button dead.
+    expect((hintedField("Target revision") as HTMLInputElement).value).toBe("");
+    expect(screen.getByText("Name a revision to see it.")).toBeTruthy();
+    expect(button("Roll back").disabled).toBe(true);
   });
 
   it("takes another revision when the reader names one", async () => {

--- a/packages/ui-next/src/screens/helm/HelmOpDialog.test.tsx
+++ b/packages/ui-next/src/screens/helm/HelmOpDialog.test.tsx
@@ -16,7 +16,7 @@ vi.mock("../../lib/helmOps", async (orig) => ({
 }));
 
 import type { HelmRevision } from "@srelens/core";
-import { HelmOpDialog, helmArgv, helmCommand } from "./HelmOpDialog";
+import { HelmOpDialog, helmArgv, helmCommand, releaseNameError } from "./HelmOpDialog";
 
 const CONTEXT = "prod-eu";
 const NAMESPACE = "checkout";
@@ -130,8 +130,11 @@ describe("HelmOpDialog — §A.5's frame", () => {
 
 describe("HelmOpDialog — the equivalent command", () => {
   it("reads the argv helm will be given, for each of the four", () => {
+    // `--create-namespace` on install, the way classic's dialog has always
+    // sent it: a first install into a namespace that does not exist yet is the
+    // ordinary case, and helm's own default is to fail it.
     expect(helmCommand({ kind: "install", release: RELEASE, namespace: NAMESPACE, chart: CHART, chartVersion: "", revision: null, atomic: false, wait: false, reuseValues: false })).toBe(
-      `helm install ${RELEASE} ${CHART} --namespace ${NAMESPACE}`,
+      `helm install ${RELEASE} ${CHART} --namespace ${NAMESPACE} --create-namespace`,
     );
     expect(helmCommand({ kind: "upgrade", release: RELEASE, namespace: NAMESPACE, chart: CHART, chartVersion: "18.3.0", revision: null, atomic: true, wait: true, reuseValues: false })).toBe(
       `helm upgrade ${RELEASE} ${CHART} --namespace ${NAMESPACE} --version 18.3.0 --atomic --wait`,
@@ -168,7 +171,7 @@ describe("HelmOpDialog — the equivalent command", () => {
     const onClose = open({ chart: "./charts/my chart" });
     await screen.findByRole("dialog");
     expect(shown()).toBe(
-      `helm install ${RELEASE} './charts/my chart' --namespace ${NAMESPACE}`,
+      `helm install ${RELEASE} './charts/my chart' --namespace ${NAMESPACE} --create-namespace`,
     );
     await userEvent.click(button("Install"));
     await waitFor(() => expect(store.startHelmOperation).toHaveBeenCalled());
@@ -178,6 +181,7 @@ describe("HelmOpDialog — the equivalent command", () => {
       "./charts/my chart",
       "--namespace",
       NAMESPACE,
+      "--create-namespace",
     ]);
     expect(onClose).toHaveBeenCalled();
   });
@@ -191,7 +195,7 @@ describe("HelmOpDialog — the equivalent command", () => {
     open({ chart: "./charts/dev's chart" });
     await screen.findByRole("dialog");
     expect(shown()).toBe(
-      `helm install ${RELEASE} './charts/dev'\\''s chart' --namespace ${NAMESPACE}`,
+      `helm install ${RELEASE} './charts/dev'\\''s chart' --namespace ${NAMESPACE} --create-namespace`,
     );
     await userEvent.click(button("Install"));
     await waitFor(() => expect(store.startHelmOperation).toHaveBeenCalled());
@@ -210,6 +214,103 @@ describe("HelmOpDialog — the equivalent command", () => {
     await waitFor(() => expect(store.startHelmOperation).toHaveBeenCalled());
     const { args } = store.startHelmOperation.mock.calls[0][0];
     expect(["helm", ...args].join(" ")).toBe(displayed);
+  });
+});
+
+describe("HelmOpDialog — install names its own release", () => {
+  /**
+   * **A deliberate departure from §A.5**, which lists Chart and Chart version
+   * and nothing else — because the mock only ever depicts ONE install, of a
+   * fixture called `new-release`. Shipped as drawn, srelens could install
+   * exactly one chart per cluster: the second `helm install new-release` is
+   * refused, "cannot re-use a name that is still in use". The name and the
+   * namespace are the reader's to choose.
+   */
+  it("asks for the release name and the namespace, which §A.5 draws neither of", async () => {
+    open({ kind: "install", release: "", namespace: "default" });
+    await screen.findByRole("dialog");
+    expect((field("Release name") as HTMLInputElement).value).toBe("");
+    expect((field("Namespace") as HTMLInputElement).value).toBe("default");
+    // Nothing to install under no name.
+    expect(button("Install").disabled).toBe(true);
+    expect(screen.getByText("Name the release to see it.")).toBeTruthy();
+
+    await userEvent.type(field("Release name"), "checkout-api");
+    await userEvent.clear(field("Namespace"));
+    await userEvent.type(field("Namespace"), "checkout");
+    // The title follows the name, because the reader chose it.
+    expect(screen.getByText("Install checkout-api")).toBeTruthy();
+    expect(shown()).toBe(
+      `helm install checkout-api ${CHART} --namespace checkout --create-namespace`,
+    );
+    expect(button("Install").disabled).toBe(false);
+  });
+
+  it("installs into the namespace the reader named, and creates it", async () => {
+    open({ kind: "install", release: "", namespace: "default" });
+    await screen.findByRole("dialog");
+    await userEvent.type(field("Release name"), "checkout-api");
+    await userEvent.clear(field("Namespace"));
+    // An empty namespace is not a command: helm would silently use whatever
+    // the kubeconfig's current namespace is, which is not what the field says.
+    expect(button("Install").disabled).toBe(true);
+    await userEvent.type(field("Namespace"), "brand-new");
+    await userEvent.click(button("Install"));
+    await waitFor(() => expect(store.startHelmOperation).toHaveBeenCalled());
+    const call = store.startHelmOperation.mock.calls[0][0];
+    expect(call.args).toEqual([
+      "install",
+      "checkout-api",
+      CHART,
+      "--namespace",
+      "brand-new",
+      "--create-namespace",
+    ]);
+    // The store follows the fields, not the props the dialog opened on.
+    expect(call.release).toBe("checkout-api");
+    expect(call.namespace).toBe("brand-new");
+  });
+
+  /**
+   * helm's own rule, and it refuses the name rather than the install: DNS-1123
+   * and at most 53 characters. A name helm will reject is worth catching here,
+   * where the reader is looking at the field, rather than as a failed
+   * operation in the strip a minute later.
+   */
+  it("judges a release name the way helm judges it", () => {
+    // helm's rule, clause by clause, on the exported function rather than
+    // through 170 keystrokes: DNS-1123, lower case, at most 53 characters.
+    expect(releaseNameError("checkout-api")).toBeNull();
+    expect(releaseNameError("checkout.api-2")).toBeNull();
+    expect(releaseNameError("a".repeat(53))).toBeNull();
+    expect(releaseNameError("")).toBe("A release needs a name.");
+    expect(releaseNameError("a".repeat(54))).toContain("53 characters");
+    for (const bad of ["Checkout", "-checkout", "checkout-", "check_out", "check out", ".checkout"]) {
+      expect(releaseNameError(bad)).toBeTruthy();
+    }
+  });
+
+  it("will not submit a name helm would refuse", async () => {
+    open({ kind: "install", release: "", namespace: "default" });
+    await screen.findByRole("dialog");
+    await userEvent.type(hintedField("Release name"), "Checkout");
+    expect(button("Install").disabled).toBe(true);
+    // The reason is under the field, not only in a disabled button.
+    expect(screen.getByText(/Lower-case letters/)).toBeTruthy();
+
+    await userEvent.clear(hintedField("Release name"));
+    await userEvent.type(hintedField("Release name"), "checkout");
+    expect(button("Install").disabled).toBe(false);
+  });
+
+  it("gives the other three no name field, because their release already exists", async () => {
+    open({ kind: "upgrade" });
+    await screen.findByRole("dialog");
+    expect(screen.queryByLabelText(/^Release name/)).toBeNull();
+    expect(screen.queryByLabelText(/^Namespace/)).toBeNull();
+    // And no `--create-namespace`: the namespace is where the release already
+    // lives, so there is nothing to create.
+    expect(shown()).not.toContain("--create-namespace");
   });
 });
 
@@ -261,7 +362,9 @@ describe("HelmOpDialog — the release's current values", () => {
   it("never offers to reuse values on an install, which has none to reuse", async () => {
     open({ kind: "install", valuesUnavailable: "boom" });
     await screen.findByRole("dialog");
-    expect(shown()).toBe(`helm install ${RELEASE} ${CHART} --namespace ${NAMESPACE}`);
+    expect(shown()).toBe(
+      `helm install ${RELEASE} ${CHART} --namespace ${NAMESPACE} --create-namespace`,
+    );
     expect(screen.queryByText(/could not read/i)).toBeNull();
   });
 });

--- a/packages/ui-next/src/screens/helm/HelmOpDialog.test.tsx
+++ b/packages/ui-next/src/screens/helm/HelmOpDialog.test.tsx
@@ -253,20 +253,36 @@ describe("HelmOpDialog — uninstall's gate", () => {
     open({ kind: "uninstall" });
     const alert = await screen.findByRole("alert");
     expect(alert.textContent).toContain("every object in the release");
-    expect(alert.textContent).toMatch(/persistent volume claims are kept/i);
-    expect(alert.textContent).toMatch(/unless the chart marks them for deletion/i);
-    // §A.5's "Twelve pods, one Service, one Ingress and two ConfigMaps" is the
-    // design's fixture. Nothing has counted this release's objects, so the
-    // PROPERTY to hold is that no count is stated at all — in digits or in
-    // words — and that no object is named as being in this particular release.
-    // Pinning only the fixture's own tokens would let "three pods and a
-    // Service" through, which is the same lie in different words.
-    // Digits, and the objects a count would have to be OF. The object half is
-    // the load-bearing one: a fabricated count cannot avoid naming the things
-    // it counts, so this catches §A.5's sentence and every rewrite of it. A
-    // spelled-out-number alternation was tried here and taken out again — it
-    // caught nothing this does not, and it forbade ordinary prose ("in one
-    // pass", "one click", "at once") in a sentence nobody had written yet.
+
+    /**
+     * **The exact sentence, on purpose.** A change-detector test over copy is
+     * normally a smell — it fails on edits that broke nothing and teaches
+     * people to update expectations without reading them. Here that is the
+     * mechanism, not the cost.
+     *
+     * srelens has not counted this release's objects and must not say how many
+     * there are, and this is the one screen in the app where being confidently
+     * wrong cannot be undone. Every property-shaped pin tried here leaked: a
+     * spelled-out-number alternation forbade ordinary prose ("in one pass"),
+     * and dropping it let "a dozen objects", "twelve things" and "several
+     * resources go" through — a fabricated quantity CAN avoid naming a
+     * Kubernetes kind, by counting a generic noun instead. So the pin is the
+     * whole sentence: any edit to this alert fails this test, whoever makes it
+     * comes back here, re-reads why the count is absent, and updates the
+     * expectation deliberately.
+     *
+     * A narrow, well-justified exception for one irreversible screen. It is
+     * not a pattern to spread to other copy.
+     */
+    const body = alert.querySelector('[data-slot="alert-body"]');
+    expect(body?.textContent?.replace(/\s+/g, " ").trim()).toBe(
+      "Everything helm created for it goes, and nothing here can undo it. " +
+        "Persistent volume claims are kept unless the chart marks them for deletion.",
+    );
+
+    // The secondary net, kept for what it says rather than for what it adds:
+    // no digit anywhere in the alert, and no Kubernetes kind named as being in
+    // this particular release.
     expect(alert.textContent).not.toMatch(/\d/);
     expect(alert.textContent).not.toMatch(
       /\b(pods?|services?|ingress(es)?|configmaps?|secrets?|deployments?|statefulsets?|jobs?)\b/i,

--- a/packages/ui-next/src/screens/helm/HelmOpDialog.test.tsx
+++ b/packages/ui-next/src/screens/helm/HelmOpDialog.test.tsx
@@ -1,0 +1,321 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+/**
+ * **The store is the only thing stubbed.** `helmArgv` stays real, because the
+ * argv it builds is what the cluster will actually be told to do, and a test
+ * that stubbed it would assert the dialog calls a stub. `helmStatus` stays real
+ * for the same reason the rest of this migration keeps it real: the word in
+ * rollback's hint is core's, not this file's.
+ */
+const store = vi.hoisted(() => ({ startHelmOperation: vi.fn() }));
+vi.mock("../../lib/helmOps", async (orig) => ({
+  ...(await orig<typeof import("../../lib/helmOps")>()),
+  startHelmOperation: store.startHelmOperation,
+}));
+
+import type { HelmRevision } from "@srelens/core";
+import { HelmOpDialog, helmArgv, helmCommand } from "./HelmOpDialog";
+
+const CONTEXT = "prod-eu";
+const NAMESPACE = "checkout";
+const RELEASE = "checkout-api";
+const CHART = "bitnami/nginx";
+
+/**
+ * A release that has been upgraded twice and whose latest revision failed —
+ * the shape a reader is actually in when they reach for rollback.
+ */
+const HISTORY: HelmRevision[] = [
+  { revision: 1, status: "superseded", updated: "2026-08-01", chartVersion: "18.0.0", description: "Install complete" },
+  { revision: 2, status: "superseded", updated: "2026-08-10", chartVersion: "18.1.0", description: "Upgrade complete" },
+  { revision: 3, status: "deployed", updated: "2026-08-20", chartVersion: "18.2.0", description: "Upgrade complete" },
+  { revision: 4, status: "failed", updated: "2026-08-24", chartVersion: "18.3.0", description: "Upgrade failed" },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  store.startHelmOperation.mockResolvedValue(1);
+});
+
+/** The command the dialog is showing, exactly as the reader reads it. */
+function shown(): string {
+  const node = document.querySelector(".copy-command-text");
+  return node?.textContent ?? "";
+}
+
+function open(props: Partial<Parameters<typeof HelmOpDialog>[0]> = {}) {
+  const onClose = vi.fn();
+  render(
+    <HelmOpDialog
+      kind="install"
+      context={CONTEXT}
+      namespace={NAMESPACE}
+      release={RELEASE}
+      chart={CHART}
+      onClose={onClose}
+      {...props}
+    />,
+  );
+  return onClose;
+}
+
+function button(name: string): HTMLButtonElement {
+  return screen.getByRole("button", { name }) as HTMLButtonElement;
+}
+
+function field(label: string): HTMLElement {
+  return screen.getByLabelText(label) as HTMLElement;
+}
+
+/**
+ * A field whose `Field` carries a hint.
+ *
+ * The kit renders the hint INSIDE the `<label>`, so the control's accessible
+ * name is the label followed by the hint; an exact match would never find it.
+ */
+function hintedField(label: string): HTMLElement {
+  // No word boundary: the label and the hint are adjacent spans, so the
+  // computed name runs the two together with nothing between them.
+  return screen.getByLabelText(new RegExp(`^${label}`)) as HTMLElement;
+}
+
+describe("HelmOpDialog — §A.5's frame", () => {
+  it("installs in a 620px dialog titled for the operation, with §A.5's fields", async () => {
+    open();
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText(`Install ${RELEASE}`)).toBeTruthy();
+    expect((dialog as HTMLElement).style.maxWidth).toBe("620px");
+    expect(field("Chart")).toBeTruthy();
+    expect(field("Chart version")).toBeTruthy();
+    expect(screen.getByRole("tablist", { name: "Panel" })).toBeTruthy();
+    expect(screen.getByRole("tab", { name: "Values" })).toBeTruthy();
+    expect(screen.getByRole("tab", { name: "Rendered diff" })).toBeTruthy();
+    expect(screen.getByRole("switch", { name: "atomic" })).toBeTruthy();
+    expect(screen.getByRole("switch", { name: "wait" })).toBeTruthy();
+    expect(screen.getByText("Equivalent command")).toBeTruthy();
+    expect(button("Cancel")).toBeTruthy();
+    expect(button("Install")).toBeTruthy();
+  });
+
+  it("titles and names each of the other three the way §A.5 writes them", async () => {
+    open({ kind: "upgrade" });
+    expect(await screen.findByText(`Upgrade ${RELEASE}`)).toBeTruthy();
+    expect(button("Upgrade")).toBeTruthy();
+  });
+
+  it("names rollback's button for the revision it will land on", async () => {
+    open({ kind: "rollback", history: HISTORY, revision: 4 });
+    expect(await screen.findByText(`Roll back ${RELEASE}`)).toBeTruthy();
+    expect(button("Roll back to 3")).toBeTruthy();
+    // §A.5 gives rollback no chart fields and no panel.
+    expect(screen.queryByLabelText("Chart")).toBeNull();
+    expect(screen.queryByRole("tablist", { name: "Panel" })).toBeNull();
+  });
+
+  it("draws uninstall's own button as the destructive one", async () => {
+    open({ kind: "uninstall" });
+    expect(await screen.findByText(`Uninstall ${RELEASE}`)).toBeTruthy();
+    expect(button("Uninstall").dataset.variant).toBe("danger");
+  });
+
+  it("closes on Cancel without starting anything", async () => {
+    const onClose = open();
+    await userEvent.click(button("Cancel"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(store.startHelmOperation).not.toHaveBeenCalled();
+  });
+});
+
+describe("HelmOpDialog — the equivalent command", () => {
+  it("reads the argv helm will be given, for each of the four", () => {
+    expect(helmCommand({ kind: "install", release: RELEASE, namespace: NAMESPACE, chart: CHART, chartVersion: "", revision: null, atomic: false, wait: false })).toBe(
+      `helm install ${RELEASE} ${CHART} --namespace ${NAMESPACE}`,
+    );
+    expect(helmCommand({ kind: "upgrade", release: RELEASE, namespace: NAMESPACE, chart: CHART, chartVersion: "18.3.0", revision: null, atomic: true, wait: true })).toBe(
+      `helm upgrade ${RELEASE} ${CHART} --namespace ${NAMESPACE} --version 18.3.0 --atomic --wait`,
+    );
+    expect(helmCommand({ kind: "rollback", release: RELEASE, namespace: NAMESPACE, chart: "", chartVersion: "", revision: 3, atomic: false, wait: false })).toBe(
+      `helm rollback ${RELEASE} 3 --namespace ${NAMESPACE}`,
+    );
+    expect(helmCommand({ kind: "uninstall", release: RELEASE, namespace: NAMESPACE, chart: "", chartVersion: "", revision: null, atomic: false, wait: false })).toBe(
+      `helm uninstall ${RELEASE} --namespace ${NAMESPACE}`,
+    );
+  });
+
+  it("follows the fields as they change", async () => {
+    open({ kind: "upgrade" });
+    await screen.findByRole("dialog");
+    expect(shown()).toBe(`helm upgrade ${RELEASE} ${CHART} --namespace ${NAMESPACE}`);
+    await userEvent.type(field("Chart version"), "18.3.0");
+    expect(shown()).toContain("--version 18.3.0");
+    await userEvent.click(screen.getByRole("switch", { name: "atomic" }));
+    expect(shown()).toBe(
+      `helm upgrade ${RELEASE} ${CHART} --namespace ${NAMESPACE} --version 18.3.0 --atomic`,
+    );
+    await userEvent.clear(field("Chart version"));
+    expect(shown()).toBe(`helm upgrade ${RELEASE} ${CHART} --namespace ${NAMESPACE} --atomic`);
+  });
+
+  it("quotes a value a shell would otherwise split, and still submits it as one argument", async () => {
+    const onClose = open({ chart: "./charts/my chart" });
+    await screen.findByRole("dialog");
+    expect(shown()).toBe(
+      `helm install ${RELEASE} './charts/my chart' --namespace ${NAMESPACE}`,
+    );
+    await userEvent.click(button("Install"));
+    await waitFor(() => expect(store.startHelmOperation).toHaveBeenCalled());
+    expect(store.startHelmOperation.mock.calls[0][0].args).toEqual([
+      "install",
+      RELEASE,
+      "./charts/my chart",
+      "--namespace",
+      NAMESPACE,
+    ]);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("submits exactly the argv it displayed", async () => {
+    open({ kind: "upgrade" });
+    await screen.findByRole("dialog");
+    await userEvent.type(field("Chart version"), "18.3.0");
+    await userEvent.click(screen.getByRole("switch", { name: "wait" }));
+    const displayed = shown();
+    await userEvent.click(button("Upgrade"));
+    await waitFor(() => expect(store.startHelmOperation).toHaveBeenCalled());
+    const { args } = store.startHelmOperation.mock.calls[0][0];
+    expect(["helm", ...args].join(" ")).toBe(displayed);
+  });
+});
+
+describe("HelmOpDialog — uninstall's gate", () => {
+  it("stays shut until the release name is typed exactly", async () => {
+    open({ kind: "uninstall" });
+    await screen.findByRole("dialog");
+    const input = field(`Type ${RELEASE} to confirm`);
+    expect(button("Uninstall").disabled).toBe(true);
+
+    // A prefix is not the name.
+    await userEvent.type(input, "checkout-ap");
+    expect(button("Uninstall").disabled).toBe(true);
+
+    // Nor is the name with something after it.
+    await userEvent.clear(input);
+    await userEvent.type(input, `${RELEASE}-web`);
+    expect(button("Uninstall").disabled).toBe(true);
+
+    // Nor is the name with a stray space, which is what a paste leaves.
+    await userEvent.clear(input);
+    await userEvent.type(input, `${RELEASE} `);
+    expect(button("Uninstall").disabled).toBe(true);
+
+    // Nor the same letters in another case.
+    await userEvent.clear(input);
+    await userEvent.type(input, RELEASE.toUpperCase());
+    expect(button("Uninstall").disabled).toBe(true);
+
+    await userEvent.clear(input);
+    await userEvent.type(input, RELEASE);
+    expect(button("Uninstall").disabled).toBe(false);
+  });
+
+  it("says what an uninstall removes without inventing a count of it", async () => {
+    open({ kind: "uninstall" });
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("every object in the release");
+    expect(alert.textContent).toMatch(/persistent volume claims are kept/i);
+    expect(alert.textContent).toMatch(/unless the chart marks them for deletion/i);
+    // §A.5's "Twelve pods, one Service, one Ingress and two ConfigMaps" is the
+    // design's fixture. Nothing has counted this release's objects, so nothing
+    // here may say how many there are.
+    expect(alert.textContent).not.toMatch(/\d/);
+    expect(alert.textContent?.toLowerCase()).not.toContain("twelve");
+    expect(alert.textContent?.toLowerCase()).not.toContain("configmap");
+  });
+});
+
+describe("HelmOpDialog — rollback's gate", () => {
+  it("asks once, without typing, and names the last revision that reached deployed", async () => {
+    open({ kind: "rollback", history: HISTORY, revision: 4 });
+    await screen.findByRole("dialog");
+    // No typed confirmation anywhere: rollback is recoverable, and the reader
+    // is here because something is already broken.
+    expect(screen.queryByLabelText(`Type ${RELEASE} to confirm`)).toBeNull();
+
+    const hint = screen.getByText(/newest one helm does not report failed/i);
+    expect(hint.textContent).toContain("Revision 3");
+    // The word is core's `helmStatus`, not a table in the dialog.
+    expect(hint.textContent).toContain("deployed");
+
+    const confirm = screen.getByRole("checkbox");
+    expect(button("Roll back to 3").disabled).toBe(true);
+    await userEvent.click(confirm);
+    expect(button("Roll back to 3").disabled).toBe(false);
+  });
+
+  it("takes another revision when the reader names one", async () => {
+    open({ kind: "rollback", history: HISTORY, revision: 4 });
+    await screen.findByRole("dialog");
+    const target = hintedField("Target revision");
+    await userEvent.clear(target);
+    await userEvent.type(target, "2");
+    expect(shown()).toBe(`helm rollback ${RELEASE} 2 --namespace ${NAMESPACE}`);
+    expect(button("Roll back to 2")).toBeTruthy();
+    await userEvent.clear(target);
+    expect(button("Roll back").disabled).toBe(true);
+  });
+});
+
+describe("HelmOpDialog — submitting", () => {
+  it("hands the store the operation and closes without waiting for it", async () => {
+    // A promise that never settles: the dialog must close anyway. Waiting for
+    // the operation is the whole thing the store exists to avoid.
+    store.startHelmOperation.mockReturnValue(new Promise<number>(() => {}));
+    const onClose = open({ kind: "upgrade", values: "replicaCount: 2", extraKubeconfigs: ["/tmp/extra"] });
+    await screen.findByRole("dialog");
+    await userEvent.click(button("Upgrade"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(store.startHelmOperation).toHaveBeenCalledTimes(1);
+    expect(store.startHelmOperation.mock.calls[0][0]).toMatchObject({
+      kind: "upgrade",
+      release: RELEASE,
+      namespace: NAMESPACE,
+      context: CONTEXT,
+      values: "replicaCount: 2",
+      extraKubeconfigs: ["/tmp/extra"],
+      args: helmArgv({
+        kind: "upgrade",
+        release: RELEASE,
+        namespace: NAMESPACE,
+        chart: CHART,
+        chartVersion: "",
+        revision: null,
+        atomic: false,
+        wait: false,
+      }),
+    });
+  });
+
+  it("sends no values body for the two operations that take none", async () => {
+    open({ kind: "uninstall", values: "replicaCount: 2" });
+    await screen.findByRole("dialog");
+    await userEvent.type(field(`Type ${RELEASE} to confirm`), RELEASE);
+    await userEvent.click(button("Uninstall"));
+    await waitFor(() => expect(store.startHelmOperation).toHaveBeenCalled());
+    expect(store.startHelmOperation.mock.calls[0][0].values).toBeUndefined();
+  });
+
+  it("shows the caller's rendered diff on the panel that asks for one", async () => {
+    open({
+      kind: "upgrade",
+      diff: [
+        { tag: "same", left: "replicas: 1", right: "replicas: 1" },
+        { tag: "replace", left: "image: nginx:1.25", right: "image: nginx:1.27" },
+      ],
+    });
+    await screen.findByRole("dialog");
+    await userEvent.click(screen.getByRole("tab", { name: "Rendered diff" }));
+    expect(screen.getByText(/image: nginx:1\.27/)).toBeTruthy();
+  });
+});

--- a/packages/ui-next/src/screens/helm/HelmOpDialog.test.tsx
+++ b/packages/ui-next/src/screens/helm/HelmOpDialog.test.tsx
@@ -130,16 +130,22 @@ describe("HelmOpDialog — §A.5's frame", () => {
 
 describe("HelmOpDialog — the equivalent command", () => {
   it("reads the argv helm will be given, for each of the four", () => {
-    expect(helmCommand({ kind: "install", release: RELEASE, namespace: NAMESPACE, chart: CHART, chartVersion: "", revision: null, atomic: false, wait: false })).toBe(
+    expect(helmCommand({ kind: "install", release: RELEASE, namespace: NAMESPACE, chart: CHART, chartVersion: "", revision: null, atomic: false, wait: false, reuseValues: false })).toBe(
       `helm install ${RELEASE} ${CHART} --namespace ${NAMESPACE}`,
     );
-    expect(helmCommand({ kind: "upgrade", release: RELEASE, namespace: NAMESPACE, chart: CHART, chartVersion: "18.3.0", revision: null, atomic: true, wait: true })).toBe(
+    expect(helmCommand({ kind: "upgrade", release: RELEASE, namespace: NAMESPACE, chart: CHART, chartVersion: "18.3.0", revision: null, atomic: true, wait: true, reuseValues: false })).toBe(
       `helm upgrade ${RELEASE} ${CHART} --namespace ${NAMESPACE} --version 18.3.0 --atomic --wait`,
     );
-    expect(helmCommand({ kind: "rollback", release: RELEASE, namespace: NAMESPACE, chart: "", chartVersion: "", revision: 3, atomic: false, wait: false })).toBe(
+    // `--reuse-values` is upgrade's alone, and it rides WITH a values body
+    // rather than instead of one: helm merges `--values` over what it reused,
+    // so an override the reader types lands on top of the release's values.
+    expect(helmCommand({ kind: "upgrade", release: RELEASE, namespace: NAMESPACE, chart: CHART, chartVersion: "", revision: null, atomic: false, wait: false, reuseValues: true })).toBe(
+      `helm upgrade ${RELEASE} ${CHART} --namespace ${NAMESPACE} --reuse-values`,
+    );
+    expect(helmCommand({ kind: "rollback", release: RELEASE, namespace: NAMESPACE, chart: "", chartVersion: "", revision: 3, atomic: false, wait: false, reuseValues: false })).toBe(
       `helm rollback ${RELEASE} 3 --namespace ${NAMESPACE}`,
     );
-    expect(helmCommand({ kind: "uninstall", release: RELEASE, namespace: NAMESPACE, chart: "", chartVersion: "", revision: null, atomic: false, wait: false })).toBe(
+    expect(helmCommand({ kind: "uninstall", release: RELEASE, namespace: NAMESPACE, chart: "", chartVersion: "", revision: null, atomic: false, wait: false, reuseValues: false })).toBe(
       `helm uninstall ${RELEASE} --namespace ${NAMESPACE}`,
     );
   });
@@ -204,6 +210,59 @@ describe("HelmOpDialog — the equivalent command", () => {
     await waitFor(() => expect(store.startHelmOperation).toHaveBeenCalled());
     const { args } = store.startHelmOperation.mock.calls[0][0];
     expect(["helm", ...args].join(" ")).toBe(displayed);
+  });
+});
+
+describe("HelmOpDialog — the release's current values", () => {
+  /**
+   * **The defect this block exists for.** `helm upgrade <rel> <chart>` with no
+   * `-f` and no `--reuse-values` does not keep the release's values: it applies
+   * the chart's defaults over them. A dialog that opens on an empty editor and
+   * sends no body is therefore an upgrade that silently discards every value
+   * the release was installed with — 200 lines of them, with nothing on screen
+   * saying so.
+   */
+  it("opens the editor on the values it was handed, and sends them back", async () => {
+    open({ kind: "upgrade", values: "replicaCount: 12\nimage:\n  tag: 4f2a1c" });
+    await screen.findByRole("dialog");
+    await waitFor(() =>
+      expect(document.querySelector(".cm-content")?.textContent).toContain("replicaCount: 12"),
+    );
+    await userEvent.click(button("Upgrade"));
+    await waitFor(() => expect(store.startHelmOperation).toHaveBeenCalled());
+    const call = store.startHelmOperation.mock.calls[0][0];
+    expect(call.values).toContain("replicaCount: 12");
+    // Seeded values are the body; there is nothing for helm to reuse.
+    expect(call.args).not.toContain("--reuse-values");
+  });
+
+  /**
+   * The degrade, and it is a LOUD one. A refused `helm get values` is exactly
+   * the case that must not fall through to "no values", because "no values" IS
+   * the defect. `--reuse-values` is the flag helm has for precisely this: keep
+   * what is on the release and merge anything given here over it.
+   */
+  it("keeps the release's values with --reuse-values when they could not be read", async () => {
+    open({ kind: "upgrade", valuesUnavailable: "The cluster rejected your credentials." });
+    await screen.findByRole("dialog");
+    expect(screen.getByText(/could not read/i)).toBeTruthy();
+    // The reason travels: the reader is told WHY, in the caller's words.
+    expect(screen.getByText(/rejected your credentials/i)).toBeTruthy();
+    expect(shown()).toBe(
+      `helm upgrade ${RELEASE} ${CHART} --namespace ${NAMESPACE} --reuse-values`,
+    );
+    await userEvent.click(button("Upgrade"));
+    await waitFor(() => expect(store.startHelmOperation).toHaveBeenCalled());
+    const call = store.startHelmOperation.mock.calls[0][0];
+    expect(call.args).toContain("--reuse-values");
+    expect(call.values).toBeUndefined();
+  });
+
+  it("never offers to reuse values on an install, which has none to reuse", async () => {
+    open({ kind: "install", valuesUnavailable: "boom" });
+    await screen.findByRole("dialog");
+    expect(shown()).toBe(`helm install ${RELEASE} ${CHART} --namespace ${NAMESPACE}`);
+    expect(screen.queryByText(/could not read/i)).toBeNull();
   });
 });
 
@@ -429,6 +488,7 @@ describe("HelmOpDialog — submitting", () => {
         revision: null,
         atomic: false,
         wait: false,
+        reuseValues: false,
       }),
     });
   });

--- a/packages/ui-next/src/screens/helm/HelmOpDialog.test.tsx
+++ b/packages/ui-next/src/screens/helm/HelmOpDialog.test.tsx
@@ -176,6 +176,24 @@ describe("HelmOpDialog — the equivalent command", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
+  it("escapes an apostrophe rather than closing the quote it opened", async () => {
+    // The wrapping half of `quoted` is not the whole of it. Left unescaped,
+    // the displayed line reads `'./charts/dev's chart'`, which a shell splices
+    // into `./charts/devs chart` — no error, and a DIFFERENT path than the one
+    // srelens ran. That silent divergence is exactly what showing the command
+    // is for.
+    open({ chart: "./charts/dev's chart" });
+    await screen.findByRole("dialog");
+    expect(shown()).toBe(
+      `helm install ${RELEASE} './charts/dev'\\''s chart' --namespace ${NAMESPACE}`,
+    );
+    await userEvent.click(button("Install"));
+    await waitFor(() => expect(store.startHelmOperation).toHaveBeenCalled());
+    // The argv is unquoted either way: quoting is a fact about shells, and
+    // nothing between here and helm is one.
+    expect(store.startHelmOperation.mock.calls[0][0].args[2]).toBe("./charts/dev's chart");
+  });
+
   it("submits exactly the argv it displayed", async () => {
     open({ kind: "upgrade" });
     await screen.findByRole("dialog");
@@ -220,6 +238,17 @@ describe("HelmOpDialog — uninstall's gate", () => {
     expect(button("Uninstall").disabled).toBe(false);
   });
 
+  it("stays shut when there is no release name to type", async () => {
+    // Task 8 can mount this before a selection resolves, or on a release whose
+    // name failed to load. Without the guard `complete` is true, the field
+    // reads `Type  to confirm`, and `typed === release` is `"" === ""` — so the
+    // danger button opens the moment the dialog does, with nothing typed, and
+    // one click submits `helm uninstall "" --namespace <ns>`.
+    open({ kind: "uninstall", release: "" });
+    await screen.findByRole("dialog");
+    expect(button("Uninstall").disabled).toBe(true);
+  });
+
   it("says what an uninstall removes without inventing a count of it", async () => {
     open({ kind: "uninstall" });
     const alert = await screen.findByRole("alert");
@@ -227,11 +256,17 @@ describe("HelmOpDialog — uninstall's gate", () => {
     expect(alert.textContent).toMatch(/persistent volume claims are kept/i);
     expect(alert.textContent).toMatch(/unless the chart marks them for deletion/i);
     // §A.5's "Twelve pods, one Service, one Ingress and two ConfigMaps" is the
-    // design's fixture. Nothing has counted this release's objects, so nothing
-    // here may say how many there are.
-    expect(alert.textContent).not.toMatch(/\d/);
-    expect(alert.textContent?.toLowerCase()).not.toContain("twelve");
-    expect(alert.textContent?.toLowerCase()).not.toContain("configmap");
+    // design's fixture. Nothing has counted this release's objects, so the
+    // PROPERTY to hold is that no count is stated at all — in digits or in
+    // words — and that no object is named as being in this particular release.
+    // Pinning only the fixture's own tokens would let "three pods and a
+    // Service" through, which is the same lie in different words.
+    const counted =
+      /\b(\d+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|a few|several|dozens?)\b/i;
+    expect(alert.textContent).not.toMatch(counted);
+    const named =
+      /\b(pods?|services?|ingress(es)?|configmaps?|secrets?|deployments?|statefulsets?|jobs?)\b/i;
+    expect(alert.textContent).not.toMatch(named);
   });
 });
 
@@ -252,6 +287,39 @@ describe("HelmOpDialog — rollback's gate", () => {
     expect(button("Roll back to 3").disabled).toBe(true);
     await userEvent.click(confirm);
     expect(button("Roll back to 3").disabled).toBe(false);
+  });
+
+  it("will not default to a revision whose status this build cannot read", async () => {
+    // core's `neutral` is its UNKNOWN bucket as well as its `superseded` one —
+    // "it might be a failure this table has no name for". A status word helm
+    // adds tomorrow must not become the default target of a rollback, and
+    // neither must a revision left behind by `uninstall --keep-history`.
+    open({
+      kind: "rollback",
+      revision: 6,
+      history: [
+        ...HISTORY,
+        { revision: 5, status: "uninstalled", updated: "2026-08-25", chartVersion: "18.3.0", description: "Uninstalled" },
+        { revision: 6, status: "quiesced", updated: "2026-08-26", chartVersion: "18.4.0", description: "Something new" },
+      ],
+    });
+    await screen.findByRole("dialog");
+    // Revision 3 — the newest one that is actually deployed — not 5 and not 6.
+    expect(button("Roll back to 3")).toBeTruthy();
+    expect((hintedField("Target revision") as HTMLInputElement).value).toBe("3");
+  });
+
+  it("keeps a superseded revision, which is what a good one becomes", async () => {
+    // The other half of the same rule: `superseded` shares core's `neutral`
+    // bucket with the unknowns, and it is the ordinary state of every revision
+    // that WAS deployed and then replaced — the usual thing to roll back to.
+    open({
+      kind: "rollback",
+      revision: 3,
+      history: HISTORY.filter((r) => r.revision !== 4),
+    });
+    await screen.findByRole("dialog");
+    expect(button("Roll back to 2")).toBeTruthy();
   });
 
   it("takes another revision when the reader names one", async () => {

--- a/packages/ui-next/src/screens/helm/HelmOpDialog.tsx
+++ b/packages/ui-next/src/screens/helm/HelmOpDialog.tsx
@@ -368,6 +368,19 @@ export function HelmOpDialog({
    */
   const reuseValues = kind === "upgrade" && valuesUnavailable !== undefined;
 
+  /**
+   * Whether a values body will actually leave this dialog — install and
+   * upgrade only, and only once the panel holds more than whitespace.
+   *
+   * The one derivation for two jobs, same shape as {@link plan}: what
+   * `submit` sends as `values`, and whether the command area needs to say the
+   * printed line does not include it. See `helmArgv`'s note on `--values` —
+   * the backend appends the flag itself, against a temp file this dialog
+   * never names, so a body sent this way is the one case where the printed
+   * command is not what runs.
+   */
+  const valuesBody = takesChart && values.trim() !== "" ? values : undefined;
+
   /** Why helm would refuse the name in the field, or null. Install only. */
   const nameError = takesName ? releaseNameError(name) : null;
 
@@ -411,7 +424,6 @@ export function HelmOpDialog({
 
   function submit() {
     if (!ready) return;
-    const body = takesChart && values.trim() !== "" ? values : undefined;
     // Fired and left to run: the store owns what happens next, and the reader
     // gets the screen back. `startHelmOperation` never throws.
     void startHelmOperation({
@@ -423,7 +435,7 @@ export function HelmOpDialog({
       context,
       args: helmArgv(plan),
       ...(extraKubeconfigs ? { extraKubeconfigs } : {}),
-      ...(body === undefined ? {} : { values: body }),
+      ...(valuesBody === undefined ? {} : { values: valuesBody }),
     }).then((id) => onStarted?.(id));
     onClose();
   }
@@ -628,6 +640,17 @@ export function HelmOpDialog({
               <span className="text-[0.75rem] text-muted">{incomplete}</span>
             )}
           </div>
+          {valuesBody !== undefined && (
+            // See `helmArgv`'s note on `--values`: the backend appends it
+            // itself, against a temp file this dialog never names, so the
+            // printed line above is not what actually runs whenever a values
+            // body is sent. Said here rather than left to the comment that
+            // used to be the only place it was true.
+            <div className="mt-1 break-words text-[0.75rem] text-muted">
+              srelens writes the values above to a temporary file and passes
+              it to helm with --values.
+            </div>
+          )}
           {/* The context is not a flag on the command — see `helmArgv` — so the
               cluster it runs against is said in words instead. */}
           <div className="mt-1 break-words text-[0.75rem] text-muted">

--- a/packages/ui-next/src/screens/helm/HelmOpDialog.tsx
+++ b/packages/ui-next/src/screens/helm/HelmOpDialog.tsx
@@ -112,13 +112,20 @@ export function helmCommand(plan: HelmPlan): string {
  * than the one running now, that helm does not report as failed or as still
  * in flight.
  *
- * The judgement is core's, not this file's. `helmStatus` classifies helm's own
- * vocabulary — `deployed` is `success`, `failed` is `danger`, the `pending-*`
- * states are `warning`, and a revision that was deployed and then replaced
- * reads `superseded`, which is `neutral`. A revision worth rolling back to is
- * one of the two that are neither broken nor unfinished, and that test is read
- * off core's health rather than off a list of status words kept here. Ten of
- * those have been removed on this migration.
+ * `deployed` is read from core: `helmStatus` classifies helm's own vocabulary,
+ * and `success` is the one health that means this revision is up right now.
+ *
+ * `superseded` is named here, and ONLY `superseded`, because core's `neutral`
+ * cannot be trusted as a positive answer. That bucket holds `superseded`,
+ * `uninstalled` AND every status word this build has never heard of —
+ * `helmStatus` documents the fallback as "it might be a failure this table has
+ * no name for". Accepting the bucket wholesale would make a helm status added
+ * tomorrow, or an `uninstalled` revision left behind by
+ * `helm uninstall --keep-history`, the DEFAULT target of a rollback, under a
+ * hint promising it is the newest one helm does not report failed. So the one
+ * neutral word that actually means "this was deployed, then replaced" is named,
+ * and the unknown ones are left out. That is not a status-word table: nothing
+ * here renames or tones anything, and the health still comes from core.
  */
 export function lastGoodRevision(
   history: readonly HelmRevision[],
@@ -126,10 +133,7 @@ export function lastGoodRevision(
 ): HelmRevision | null {
   const candidates = history
     .filter((r) => r.revision !== current)
-    .filter((r) => {
-      const health = helmStatus(r.status).health;
-      return health === "success" || health === "neutral";
-    });
+    .filter((r) => helmStatus(r.status).health === "success" || r.status === "superseded");
   if (candidates.length === 0) return null;
   return candidates.reduce((best, r) => (r.revision > best.revision ? r : best));
 }
@@ -300,9 +304,9 @@ export function HelmOpDialog({
             {/* No counts. See this component's note: srelens has not asked the
                 cluster what is in this release, so it says what is true of any
                 release rather than what would sound specific. */}
-            Everything helm created for it goes, in one pass and with nothing to
-            undo it. Persistent volume claims are kept unless the chart marks
-            them for deletion.
+            Everything helm created for it goes, and nothing here can undo it.
+            Persistent volume claims are kept unless the chart marks them for
+            deletion.
           </Alert>
         )}
 
@@ -424,7 +428,7 @@ export function HelmOpDialog({
           </div>
           {/* The context is not a flag on the command — see `helmArgv` — so the
               cluster it runs against is said in words instead. */}
-          <div className="mt-1 text-[0.75rem] text-muted">
+          <div className="mt-1 break-words text-[0.75rem] text-muted">
             srelens runs this against {context}.
           </div>
         </div>

--- a/packages/ui-next/src/screens/helm/HelmOpDialog.tsx
+++ b/packages/ui-next/src/screens/helm/HelmOpDialog.tsx
@@ -1,0 +1,442 @@
+import { useMemo, useState } from "react";
+import { type DiffRow, type HelmRevision, helmStatus } from "@srelens/core";
+import {
+  Alert,
+  Button,
+  Checkbox,
+  CodeEditor,
+  CopyCommand,
+  DiffLines,
+  Dialog,
+  Field,
+  SubHead,
+  Switch,
+  Tabs,
+  TextInput,
+} from "@srelens/ui-kit";
+import { type HelmOpKind, startHelmOperation } from "../../lib/helmOps";
+
+/** §A.5's width, in px. */
+const WIDTH = 620;
+
+/**
+ * Everything the four operations can be told to do, as one value.
+ *
+ * The dialog's fields collapse to this and nothing else reads the fields, so
+ * there is exactly one description of the operation in flight — see
+ * {@link helmArgv}.
+ */
+export interface HelmPlan {
+  kind: HelmOpKind;
+  release: string;
+  namespace: string;
+  /** The chart ref, for the two operations that take one. */
+  chart: string;
+  /** `--version`, blank for whatever the repo calls latest. */
+  chartVersion: string;
+  /** Rollback's target revision; `null` until there is one. */
+  revision: number | null;
+  atomic: boolean;
+  wait: boolean;
+}
+
+/**
+ * The helm argv this plan runs as — the ONE derivation.
+ *
+ * **The store composes no commands.** `startHelmOperation` hands `args`
+ * straight to `helm`, and nothing on either side of the wire checks that
+ * `args[0]` agrees with `kind`; this array is the whole of what the cluster
+ * will be told to do. The `Equivalent command` the dialog prints comes from
+ * {@link helmCommand}, which calls this function rather than restating it — two
+ * hand-maintained copies of a destructive command is how a screen ends up
+ * showing one thing and running another.
+ *
+ * **No `--kube-context`.** The backend runs helm against a kubeconfig written
+ * for this context alone, with `current-context` pinned to it, and that file
+ * carries the context's IN-FILE name — which is not always the name srelens
+ * shows, because duplicate context names across merged kubeconfigs are
+ * disambiguated for display. A `--kube-context` built from the display name
+ * would fail to resolve on exactly the machines that need it most. The cluster
+ * is named in words beside the command instead.
+ *
+ * **No `--values` either.** The backend writes the values body to a temporary
+ * file and appends `--values <path>` itself, and a path that does not exist
+ * yet is not a flag this side can honestly print.
+ */
+export function helmArgv(plan: HelmPlan): string[] {
+  const scope = ["--namespace", plan.namespace];
+  const version = plan.chartVersion.trim();
+  const flags = [
+    ...(version ? ["--version", version] : []),
+    ...(plan.atomic ? ["--atomic"] : []),
+    ...(plan.wait ? ["--wait"] : []),
+  ];
+  switch (plan.kind) {
+    case "install":
+      return ["install", plan.release, plan.chart.trim(), ...scope, ...flags];
+    case "upgrade":
+      return ["upgrade", plan.release, plan.chart.trim(), ...scope, ...flags];
+    case "rollback":
+      return [
+        "rollback",
+        plan.release,
+        ...(plan.revision === null ? [] : [String(plan.revision)]),
+        ...scope,
+      ];
+    case "uninstall":
+      return ["uninstall", plan.release, ...scope];
+  }
+}
+
+/** Characters a shell leaves alone; anything else earns quotes. */
+const BARE = /^[A-Za-z0-9_@%+=:,./-]+$/;
+
+/** One argv element as a shell would have to be given it. */
+function quoted(arg: string): string {
+  if (arg !== "" && BARE.test(arg)) return arg;
+  return `'${arg.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * The plan as a line the reader can run themselves — {@link helmArgv}, quoted.
+ *
+ * Derived, never written twice. Break the argv and this line breaks with it,
+ * which is the point.
+ */
+export function helmCommand(plan: HelmPlan): string {
+  return ["helm", ...helmArgv(plan)].map(quoted).join(" ");
+}
+
+/**
+ * The revision a rollback should land on by default: the newest one, other
+ * than the one running now, that helm does not report as failed or as still
+ * in flight.
+ *
+ * The judgement is core's, not this file's. `helmStatus` classifies helm's own
+ * vocabulary — `deployed` is `success`, `failed` is `danger`, the `pending-*`
+ * states are `warning`, and a revision that was deployed and then replaced
+ * reads `superseded`, which is `neutral`. A revision worth rolling back to is
+ * one of the two that are neither broken nor unfinished, and that test is read
+ * off core's health rather than off a list of status words kept here. Ten of
+ * those have been removed on this migration.
+ */
+export function lastGoodRevision(
+  history: readonly HelmRevision[],
+  current: number | undefined,
+): HelmRevision | null {
+  const candidates = history
+    .filter((r) => r.revision !== current)
+    .filter((r) => {
+      const health = helmStatus(r.status).health;
+      return health === "success" || health === "neutral";
+    });
+  if (candidates.length === 0) return null;
+  return candidates.reduce((best, r) => (r.revision > best.revision ? r : best));
+}
+
+export interface HelmOpDialogProps {
+  /** Which of the four this is. */
+  kind: HelmOpKind;
+  /** The cluster it runs in — a kubeconfig context NAME. */
+  context: string;
+  namespace: string;
+  /** The release being installed, upgraded, rolled back or removed. */
+  release: string;
+  /** Where the chart field starts, for install and upgrade. */
+  chart?: string;
+  /** Where the chart version field starts; blank means whatever is latest. */
+  chartVersion?: string;
+  /** The values body the editor opens on. Sent only for install and upgrade. */
+  values?: string;
+  /** The release's revisions — rollback's target and the hint under it. */
+  history?: readonly HelmRevision[];
+  /** The revision running now: the one a rollback moves away from. */
+  revision?: number;
+  /**
+   * The rendered-manifest diff, when the caller has one. Rendering a chart is
+   * a round trip this dialog does not make; the screen that opens it does.
+   */
+  diff?: readonly DiffRow[];
+  /** Extra kubeconfigs to put on helm's KUBECONFIG. */
+  extraKubeconfigs?: string[];
+  /** Cancel, escape, the header's control, and a submitted operation. */
+  onClose: () => void;
+  /** The store's id for the operation just started, for a caller that follows it. */
+  onStarted?: (id: number) => void;
+}
+
+/** §A.5's title, and the word on its button. */
+const TITLE: Record<HelmOpKind, string> = {
+  install: "Install",
+  upgrade: "Upgrade",
+  rollback: "Roll back",
+  uninstall: "Uninstall",
+};
+
+/**
+ * §A.5's `<Op> <release>` — the one place srelens changes a Helm release.
+ *
+ * **Two gates, and they are deliberately different sizes.** Uninstall demands
+ * the release name typed out, character for character: it is the only
+ * irreversible thing in this migration, and a dialog whose destructive button
+ * is one click from the button that opened it is a dialog that gets clicked
+ * through. Rollback asks once, with a checkbox, and asks for no typing at all —
+ * it is recoverable (roll forward again), and it is reached when something is
+ * already broken and the reader is in a hurry. Classic gated neither.
+ *
+ * **The uninstall alert states the general truth and fetches nothing.** §A.5
+ * writes "Twelve pods, one Service, one Ingress and two ConfigMaps", which is
+ * the design's fixture: nothing here has counted this release's objects, and
+ * this build does not count them. What it says instead is true of every
+ * release — every object in it goes, and PVCs survive unless the chart marks
+ * them for deletion. A made-up count on the one irreversible screen in the app
+ * is the worst possible place to be confidently wrong.
+ *
+ * **Submitting closes the dialog.** `helm upgrade --wait` runs for minutes, and
+ * a modal held open for the duration stops the reader watching the pods it is
+ * restarting. The operation goes to `helmOps`, which owns the output, the
+ * status and the failure from there — which is why nothing here catches
+ * anything: `startHelmOperation` never throws, and a refused start is a failed
+ * row carrying its own reason, already through `describeError`.
+ */
+export function HelmOpDialog({
+  kind,
+  context,
+  namespace,
+  release,
+  chart: initialChart = "",
+  chartVersion: initialVersion = "",
+  values: initialValues = "",
+  history = [],
+  revision: current,
+  diff,
+  extraKubeconfigs,
+  onClose,
+  onStarted,
+}: HelmOpDialogProps) {
+  const takesChart = kind === "install" || kind === "upgrade";
+
+  const suggested = useMemo(() => lastGoodRevision(history, current), [history, current]);
+
+  const [chart, setChart] = useState(initialChart);
+  const [chartVersion, setChartVersion] = useState(initialVersion);
+  const [values, setValues] = useState(initialValues);
+  const [panel, setPanel] = useState("values");
+  const [atomic, setAtomic] = useState(false);
+  const [wait, setWait] = useState(false);
+  const [targetText, setTargetText] = useState(suggested ? String(suggested.revision) : "");
+  const [acknowledged, setAcknowledged] = useState(false);
+  /**
+   * The typed confirmation, compared to the release name EXACTLY.
+   *
+   * Not trimmed, not lower-cased. A trailing space is what a paste leaves
+   * behind, and a reader who pasted the name is precisely the one who has not
+   * read it; the whole value of this gate is that it takes a moment of
+   * attention, and every softening of the comparison gives that moment back.
+   */
+  const [typed, setTyped] = useState("");
+
+  const target = revisionOf(targetText);
+
+  const plan: HelmPlan = {
+    kind,
+    release,
+    namespace,
+    chart,
+    chartVersion,
+    revision: target,
+    atomic,
+    wait,
+  };
+
+  /** Does the argv have everything it needs to be a command at all? */
+  const complete = takesChart ? chart.trim() !== "" : kind === "rollback" ? target !== null : true;
+  /** Has the reader passed this operation's gate? */
+  const confirmed =
+    kind === "uninstall" ? typed === release && release !== "" : kind === "rollback" ? acknowledged : true;
+  const ready = complete && confirmed;
+
+  function submit() {
+    if (!ready) return;
+    const body = takesChart && values.trim() !== "" ? values : undefined;
+    // Fired and left to run: the store owns what happens next, and the reader
+    // gets the screen back. `startHelmOperation` never throws.
+    void startHelmOperation({
+      kind,
+      release,
+      namespace,
+      context,
+      args: helmArgv(plan),
+      ...(extraKubeconfigs ? { extraKubeconfigs } : {}),
+      ...(body === undefined ? {} : { values: body }),
+    }).then((id) => onStarted?.(id));
+    onClose();
+  }
+
+  return (
+    <Dialog
+      title={`${TITLE[kind]} ${release}`}
+      maxWidth={WIDTH}
+      onClose={onClose}
+      footer={
+        <>
+          <Button variant="secondary" size="sm" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            variant={kind === "uninstall" ? "danger" : "primary"}
+            size="sm"
+            disabled={!ready}
+            onClick={submit}
+          >
+            {kind === "rollback" && target !== null ? `Roll back to ${target}` : TITLE[kind]}
+          </Button>
+        </>
+      }
+    >
+      <div className="flex min-w-0 flex-col gap-3 p-3">
+        {kind === "uninstall" && (
+          <Alert tone="sev" title="This removes every object in the release">
+            {/* No counts. See this component's note: srelens has not asked the
+                cluster what is in this release, so it says what is true of any
+                release rather than what would sound specific. */}
+            Everything helm created for it goes, in one pass and with nothing to
+            undo it. Persistent volume claims are kept unless the chart marks
+            them for deletion.
+          </Alert>
+        )}
+
+        {kind === "rollback" && (
+          <Alert tone="warn" title="Rolling back replaces what is running now">
+            The target revision's chart and values are applied over the current
+            one, which stays in the release's history — so you can roll forward
+            again.
+          </Alert>
+        )}
+
+        {takesChart && (
+          <div className="grid min-w-0 grid-cols-2 gap-x-3">
+            <Field label="Chart" className="min-w-0">
+              <TextInput value={chart} onValueChange={setChart} placeholder="bitnami/nginx" />
+            </Field>
+            {/* No hint here: the kit's `Field` renders one INSIDE the label,
+                so a hint becomes part of the control's accessible name — the
+                placeholder says the same thing without renaming the field. */}
+            <Field label="Chart version" className="min-w-0">
+              <TextInput value={chartVersion} onValueChange={setChartVersion} placeholder="18.3.0" />
+            </Field>
+          </div>
+        )}
+
+        {takesChart && (
+          <div className="min-w-0">
+            <Tabs
+              variant="segmented"
+              label="Panel"
+              active={panel}
+              onChange={setPanel}
+              tabs={[
+                { id: "values", label: "Values" },
+                { id: "diff", label: "Rendered diff" },
+              ]}
+            />
+            <div className="mt-2 min-w-0">
+              {panel === "values" ? (
+                <CodeEditor
+                  value={values}
+                  onChange={setValues}
+                  language="yaml"
+                  ariaLabel="Values"
+                  minHeight={140}
+                  maxHeight={220}
+                />
+              ) : diff && diff.length > 0 ? (
+                <DiffLines rows={[...diff]} />
+              ) : (
+                <span className="text-[0.75rem] text-muted">
+                  srelens has not rendered this chart, so there is nothing to
+                  compare yet.
+                </span>
+              )}
+            </div>
+          </div>
+        )}
+
+        {takesChart && (
+          <div className="flex min-w-0 flex-col gap-2">
+            <Switch
+              on={atomic}
+              onChange={setAtomic}
+              label="atomic"
+              hint="Roll the release back itself if this one does not come up."
+            />
+            <Switch
+              on={wait}
+              onChange={setWait}
+              label="wait"
+              hint="Hold the operation open until every object reports ready."
+            />
+          </div>
+        )}
+
+        {kind === "rollback" && (
+          <>
+            <Field
+              label="Target revision"
+              className="min-w-0"
+              hint={
+                suggested
+                  ? `Revision ${suggested.revision} is the newest one helm does not report failed; it reads ${helmStatus(suggested.status).word}.`
+                  : "srelens has no history for this release, so name the revision yourself."
+              }
+            >
+              <TextInput value={targetText} onValueChange={setTargetText} type="number" />
+            </Field>
+            {/* Asked once, and never typed out. See this component's note. */}
+            <Checkbox
+              checked={acknowledged}
+              onChange={setAcknowledged}
+              label={
+                target === null
+                  ? `Yes, roll ${release} back.`
+                  : `Yes, roll ${release} back to revision ${target}.`
+              }
+            />
+          </>
+        )}
+
+        {kind === "uninstall" && (
+          <Field label={`Type ${release} to confirm`} className="min-w-0">
+            <TextInput value={typed} onValueChange={setTyped} autoFocus />
+          </Field>
+        )}
+
+        <div className="min-w-0">
+          <SubHead variant="caps">Equivalent command</SubHead>
+          <div className="mt-1 min-w-0">
+            {complete ? (
+              <CopyCommand command={helmCommand(plan)} />
+            ) : (
+              <span className="text-[0.75rem] text-muted">
+                {takesChart ? "Name a chart to see it." : "Name a revision to see it."}
+              </span>
+            )}
+          </div>
+          {/* The context is not a flag on the command — see `helmArgv` — so the
+              cluster it runs against is said in words instead. */}
+          <div className="mt-1 text-[0.75rem] text-muted">
+            srelens runs this against {context}.
+          </div>
+        </div>
+      </div>
+    </Dialog>
+  );
+}
+
+/** A revision the field holds, or null when it holds nothing helm could use. */
+function revisionOf(text: string): number | null {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  const n = Number(trimmed);
+  return Number.isInteger(n) && n > 0 ? n : null;
+}

--- a/packages/ui-next/src/screens/helm/HelmOpDialog.tsx
+++ b/packages/ui-next/src/screens/helm/HelmOpDialog.tsx
@@ -84,7 +84,18 @@ export function helmArgv(plan: HelmPlan): string[] {
   ];
   switch (plan.kind) {
     case "install":
-      return ["install", plan.release, plan.chart.trim(), ...scope, ...flags];
+      return [
+        "install",
+        plan.release,
+        plan.chart.trim(),
+        ...scope,
+        // Classic has always sent this, and helm's own default is to fail an
+        // install into a namespace that does not exist yet — which is the
+        // ordinary case for a first install. Install only: the other three
+        // operate on a release that is already somewhere.
+        "--create-namespace",
+        ...flags,
+      ];
     case "upgrade":
       return [
         "upgrade",
@@ -106,6 +117,31 @@ export function helmArgv(plan: HelmPlan): string[] {
     case "uninstall":
       return ["uninstall", plan.release, ...scope];
   }
+}
+
+/**
+ * helm's own release-name rule, copied from `ValidateReleaseName`: a DNS-1123
+ * name, lower case, at most 53 characters.
+ *
+ * Checked here rather than left to helm because the reader is looking at the
+ * field now, and a rejected name comes back as a failed operation in the strip
+ * a minute later — by which time the dialog, and the values typed into it, are
+ * gone. Nothing about it is a srelens house rule: every clause is helm's, and
+ * the 53 is helm's own `maxReleaseNameLen`.
+ */
+const RELEASE_NAME = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
+const MAX_RELEASE_NAME = 53;
+
+/** Why helm would refuse this release name, or null when it would take it. */
+export function releaseNameError(name: string): string | null {
+  if (name === "") return "A release needs a name.";
+  if (name.length > MAX_RELEASE_NAME) {
+    return `helm allows ${MAX_RELEASE_NAME} characters; this is ${name.length}.`;
+  }
+  if (!RELEASE_NAME.test(name)) {
+    return "Lower-case letters, digits, - and . only, starting and ending with a letter or digit.";
+  }
+  return null;
 }
 
 /** Characters a shell leaves alone; anything else earns quotes. */
@@ -163,8 +199,17 @@ export interface HelmOpDialogProps {
   kind: HelmOpKind;
   /** The cluster it runs in — a kubeconfig context NAME. */
   context: string;
+  /** Where the release lives — and, for install, where its own field starts. */
   namespace: string;
-  /** The release being installed, upgraded, rolled back or removed. */
+  /**
+   * The release being upgraded, rolled back or removed.
+   *
+   * In install mode this is only where the `Release name` FIELD starts — the
+   * reader names the release, and everything downstream reads the field. Empty
+   * is the ordinary case there and nowhere else: uninstall's gate compares
+   * what was typed to this prop and guards `release !== ""`, so an empty name
+   * is a gate that can never be passed.
+   */
   release: string;
   /** Where the chart field starts, for install and upgrade. */
   chart?: string;
@@ -252,6 +297,19 @@ export function HelmOpDialog({
   onStarted,
 }: HelmOpDialogProps) {
   const takesChart = kind === "install" || kind === "upgrade";
+  /**
+   * **Install names its own release, which §A.5 does not draw.**
+   *
+   * The design lists Chart and Chart version and nothing else, because the
+   * mock only ever depicts one install — of a fixture called `new-release`.
+   * Built as drawn, srelens could create exactly one release per cluster: the
+   * second `helm install new-release` is refused, "cannot re-use a name that
+   * is still in use". The namespace is here for the same reason — a fixed one
+   * installs everything into `default` — and `--create-namespace` with it,
+   * which classic has always sent, because helm's own default is to fail an
+   * install into a namespace that does not exist yet.
+   */
+  const takesName = kind === "install";
 
   const suggested = useMemo(() => lastGoodRevision(history, current), [history, current]);
   /**
@@ -275,6 +333,10 @@ export function HelmOpDialog({
     return "No earlier revision is safe to offer: each one is failed, unfinished, gone, or in a state this build does not recognise. Name the revision yourself.";
   }, [history, current]);
 
+  // Install's own two fields. Seeded from the props, and read by everything
+  // downstream from there: the title, the argv, and what the store is told.
+  const [name, setName] = useState(release);
+  const [ns, setNs] = useState(namespace);
   const [chart, setChart] = useState(initialChart);
   const [chartVersion, setChartVersion] = useState(initialVersion);
   const [values, setValues] = useState(initialValues);
@@ -306,10 +368,13 @@ export function HelmOpDialog({
    */
   const reuseValues = kind === "upgrade" && valuesUnavailable !== undefined;
 
+  /** Why helm would refuse the name in the field, or null. Install only. */
+  const nameError = takesName ? releaseNameError(name) : null;
+
   const plan: HelmPlan = {
     kind,
-    release,
-    namespace,
+    release: takesName ? name : release,
+    namespace: takesName ? ns.trim() : namespace,
     chart,
     chartVersion,
     revision: target,
@@ -318,8 +383,27 @@ export function HelmOpDialog({
     reuseValues,
   };
 
-  /** Does the argv have everything it needs to be a command at all? */
-  const complete = takesChart ? chart.trim() !== "" : kind === "rollback" ? target !== null : true;
+  /**
+   * Why the argv is not a command helm could run yet, or null when it is one.
+   *
+   * One derivation for two jobs — what the command area says instead of a
+   * command, and whether the button is dead — so the two can never disagree
+   * about whether this dialog is ready. The name's own reason is under its
+   * field rather than here: that is where the reader is looking.
+   */
+  const incomplete: string | null =
+    takesName && nameError !== null
+      ? "Name the release to see it."
+      : takesName && ns.trim() === ""
+        ? // Not "helm will use the current namespace": the field says which
+          // namespace this goes to, and an empty one makes it say nothing.
+          "Name a namespace to see it."
+        : takesChart && chart.trim() === ""
+          ? "Name a chart to see it."
+          : kind === "rollback" && target === null
+            ? "Name a revision to see it."
+            : null;
+  const complete = incomplete === null;
   /** Has the reader passed this operation's gate? */
   const confirmed =
     kind === "uninstall" ? typed === release && release !== "" : kind === "rollback" ? acknowledged : true;
@@ -332,8 +416,10 @@ export function HelmOpDialog({
     // gets the screen back. `startHelmOperation` never throws.
     void startHelmOperation({
       kind,
-      release,
-      namespace,
+      // The plan's, not the props': install's release and namespace are the
+      // reader's fields, and the store must follow the same pair the argv did.
+      release: plan.release,
+      namespace: plan.namespace,
       context,
       args: helmArgv(plan),
       ...(extraKubeconfigs ? { extraKubeconfigs } : {}),
@@ -342,9 +428,20 @@ export function HelmOpDialog({
     onClose();
   }
 
+  /**
+   * §A.5's `<Op> <release>` — and, before an install has been named, the word
+   * on the control that opened it. "Install " with nothing after it reads as a
+   * rendering fault.
+   */
+  const heading = takesName
+    ? name.trim() === ""
+      ? "Install chart"
+      : `Install ${name}`
+    : `${TITLE[kind]} ${release}`;
+
   return (
     <Dialog
-      title={`${TITLE[kind]} ${release}`}
+      title={heading}
       maxWidth={WIDTH}
       onClose={onClose}
       footer={
@@ -394,6 +491,35 @@ export function HelmOpDialog({
             release keeps the values it has, and anything typed here is merged
             over them.
           </Alert>
+        )}
+
+        {takesName && (
+          /* `min-w-0` on the cells as well as the grid: a grid item's implicit
+             `min-width: auto` refuses to shrink below its content, and a long
+             release name would push this 620px dialog wider than it says it
+             is. Seven defects on this migration, none of them visible in
+             jsdom. */
+          <div className="grid min-w-0 grid-cols-2 gap-x-3">
+            <Field
+              label="Release name"
+              className="min-w-0"
+              // Only once there is something to be wrong about: an error under
+              // an untouched empty field is a scolding for not having typed
+              // yet. The button is dead either way.
+              error={name !== "" && nameError !== null ? nameError : undefined}
+            >
+              <TextInput
+                value={name}
+                onValueChange={setName}
+                placeholder="checkout-api"
+                invalid={name !== "" && nameError !== null}
+                autoFocus
+              />
+            </Field>
+            <Field label="Namespace" className="min-w-0">
+              <TextInput value={ns} onValueChange={setNs} placeholder="default" />
+            </Field>
+          </div>
         )}
 
         {takesChart && (
@@ -499,9 +625,7 @@ export function HelmOpDialog({
             {complete ? (
               <CopyCommand command={helmCommand(plan)} />
             ) : (
-              <span className="text-[0.75rem] text-muted">
-                {takesChart ? "Name a chart to see it." : "Name a revision to see it."}
-              </span>
+              <span className="text-[0.75rem] text-muted">{incomplete}</span>
             )}
           </div>
           {/* The context is not a flag on the command — see `helmArgv` — so the

--- a/packages/ui-next/src/screens/helm/HelmOpDialog.tsx
+++ b/packages/ui-next/src/screens/helm/HelmOpDialog.tsx
@@ -221,6 +221,26 @@ export function HelmOpDialog({
   const takesChart = kind === "install" || kind === "upgrade";
 
   const suggested = useMemo(() => lastGoodRevision(history, current), [history, current]);
+  /**
+   * What the hint says when {@link lastGoodRevision} offers nothing.
+   *
+   * Three different facts, and only one of them is "srelens has no history".
+   * Saying that one for all three was false in the two cases that matter most:
+   * a release whose history is entirely failed revisions HAS a history, and
+   * telling the reader otherwise hides the very thing they came to find out.
+   * The rest of the degrade path is already honest and stays — no target is
+   * filled in, and the command area says there is nothing to show rather than
+   * printing a command nobody asked for.
+   */
+  const noDefault = useMemo(() => {
+    if (history.length === 0) {
+      return "srelens has no history for this release, so name the revision yourself.";
+    }
+    if (history.every((r) => r.revision === current)) {
+      return "This release has only the revision running now, so there is nothing earlier to return to.";
+    }
+    return "No earlier revision is safe to offer: each one is failed, unfinished, gone, or in a state this build does not recognise. Name the revision yourself.";
+  }, [history, current]);
 
   const [chart, setChart] = useState(initialChart);
   const [chartVersion, setChartVersion] = useState(initialVersion);
@@ -391,7 +411,7 @@ export function HelmOpDialog({
               hint={
                 suggested
                   ? `Revision ${suggested.revision} is the newest one helm does not report failed; it reads ${helmStatus(suggested.status).word}.`
-                  : "srelens has no history for this release, so name the revision yourself."
+                  : noDefault
               }
             >
               <TextInput value={targetText} onValueChange={setTargetText} type="number" />

--- a/packages/ui-next/src/screens/helm/HelmOpDialog.tsx
+++ b/packages/ui-next/src/screens/helm/HelmOpDialog.tsx
@@ -38,6 +38,17 @@ export interface HelmPlan {
   revision: number | null;
   atomic: boolean;
   wait: boolean;
+  /**
+   * `--reuse-values`, and upgrade's alone.
+   *
+   * **Helm's default is not "keep what is there".** `helm upgrade <rel>
+   * <chart>` with no values body applies the CHART's defaults over the release,
+   * which silently throws away every value it was installed with. Whenever
+   * srelens could not read those values back, this is what stops that: helm
+   * keeps the release's own values and merges anything sent with `--values`
+   * over them. It rides WITH a body rather than instead of one.
+   */
+  reuseValues: boolean;
 }
 
 /**
@@ -75,7 +86,16 @@ export function helmArgv(plan: HelmPlan): string[] {
     case "install":
       return ["install", plan.release, plan.chart.trim(), ...scope, ...flags];
     case "upgrade":
-      return ["upgrade", plan.release, plan.chart.trim(), ...scope, ...flags];
+      return [
+        "upgrade",
+        plan.release,
+        plan.chart.trim(),
+        ...scope,
+        // Only upgrade: an install has no earlier values to reuse, and helm
+        // rejects the flag outright.
+        ...(plan.reuseValues ? ["--reuse-values"] : []),
+        ...flags,
+      ];
     case "rollback":
       return [
         "rollback",
@@ -152,6 +172,18 @@ export interface HelmOpDialogProps {
   chartVersion?: string;
   /** The values body the editor opens on. Sent only for install and upgrade. */
   values?: string;
+  /**
+   * Why the caller has no current values to open on — already through
+   * `describeError`, because it is shown to the reader as it arrives.
+   *
+   * Present means "this release HAS values and srelens could not read them",
+   * which is a different fact from an empty body and must never be rendered as
+   * one: an upgrade with no values body applies the chart's defaults over
+   * whatever the release was installed with. Set, an upgrade says so and adds
+   * `--reuse-values` so helm keeps them. Absent — the ordinary case — the
+   * editor's contents are the whole of what will be applied.
+   */
+  valuesUnavailable?: string;
   /** The release's revisions — rollback's target and the hint under it. */
   history?: readonly HelmRevision[];
   /** The revision running now: the one a rollback moves away from. */
@@ -211,6 +243,7 @@ export function HelmOpDialog({
   chart: initialChart = "",
   chartVersion: initialVersion = "",
   values: initialValues = "",
+  valuesUnavailable,
   history = [],
   revision: current,
   diff,
@@ -262,6 +295,17 @@ export function HelmOpDialog({
 
   const target = revisionOf(targetText);
 
+  /**
+   * Ask helm to keep what the release already has.
+   *
+   * Upgrade only, and only when the caller says the current values could not
+   * be read: with them in hand the editor IS the answer, and adding the flag
+   * would merge the release's values under an editor the reader can see and
+   * trust — including a line they deliberately deleted, which would then not
+   * go away.
+   */
+  const reuseValues = kind === "upgrade" && valuesUnavailable !== undefined;
+
   const plan: HelmPlan = {
     kind,
     release,
@@ -271,6 +315,7 @@ export function HelmOpDialog({
     revision: target,
     atomic,
     wait,
+    reuseValues,
   };
 
   /** Does the argv have everything it needs to be a command at all? */
@@ -335,6 +380,19 @@ export function HelmOpDialog({
             The target revision's chart and values are applied over the current
             one, which stays in the release's history — so you can roll forward
             again.
+          </Alert>
+        )}
+
+        {reuseValues && (
+          <Alert tone="warn" title="srelens could not read this release's current values">
+            {/* The one thing that must not happen here is a blank editor with
+                no explanation: an upgrade sending no values applies the
+                CHART's defaults over the release. `--reuse-values` is on the
+                command below, so helm keeps what the release has. */}
+            {valuesUnavailable} The editor below therefore starts empty and
+            helm is told <code className="code">--reuse-values</code>: the
+            release keeps the values it has, and anything typed here is merged
+            over them.
           </Alert>
         )}
 

--- a/packages/ui-next/src/screens/helm/ReleasePane.test.tsx
+++ b/packages/ui-next/src/screens/helm/ReleasePane.test.tsx
@@ -113,6 +113,32 @@ describe("currentOp", () => {
     expect(currentOp([running, failed], CONTEXT, CHECKOUT)?.id).toBe(1);
   });
 
+  it("retires a failure that a later attempt has superseded", () => {
+    // 10:00 upgrade fails on an expired token; the reader refreshes their
+    // kubeconfig and the 10:05 retry succeeds. The failure is spent, and the
+    // pane must go back to diffing the revision the retry produced.
+    const failed = op({ id: 1, state: "failed", error: "expired token", startedAt: 1_000 });
+    const done = op({ id: 2, state: "done", startedAt: 9_000 });
+    expect(currentOp([failed, done], CONTEXT, CHECKOUT)).toBeNull();
+    expect(currentOp([done, failed], CONTEXT, CHECKOUT)).toBeNull();
+  });
+
+  it("keeps a failure that nothing has been attempted since", () => {
+    // The mirror of the case above, and the reason it is not simply "drop
+    // every failure that has a `done` beside it": the 10:00 success is not
+    // evidence about the 10:05 failure.
+    const done = op({ id: 1, state: "done", startedAt: 1_000 });
+    const failed = op({ id: 2, state: "failed", error: "expired token", startedAt: 9_000 });
+    expect(currentOp([done, failed], CONTEXT, CHECKOUT)?.id).toBe(2);
+    expect(currentOp([failed, done], CONTEXT, CHECKOUT)?.id).toBe(2);
+  });
+
+  it("retires a failure a running retry has superseded, without losing the retry", () => {
+    const failed = op({ id: 1, state: "failed", error: "expired token", startedAt: 1_000 });
+    const retry = op({ id: 2, state: "running", startedAt: 9_000 });
+    expect(currentOp([failed, retry], CONTEXT, CHECKOUT)?.id).toBe(2);
+  });
+
   it("takes the newest of several failures", () => {
     const older = op({ id: 1, state: "failed", error: "older", startedAt: 1_000 });
     const newer = op({ id: 2, state: "failed", error: "newer", startedAt: 2_000 });
@@ -191,6 +217,23 @@ describe("ReleasePane — an operation outranks the diff", () => {
     expect(screen.queryByText('tag: "4f2a1c"')).toBeNull();
   });
 
+  it("goes back to the diff once a later attempt has superseded the failure", async () => {
+    const { invoke } = mount({
+      ops: [
+        op({ id: 1, state: "failed", error: "expired token", startedAt: 1_000, output: ["gone stale"] }),
+        op({ id: 2, state: "done", startedAt: 9_000, output: ["Release has been upgraded."] }),
+      ],
+    });
+
+    // The effect must actually run: a retired failure that still set
+    // `held` would leave the pane stuck on "Rendering checkout" forever.
+    await waitFor(() => expect(screen.getByText('tag: "4f2a1c"')).toBeTruthy());
+    expect(screen.queryByText("expired token")).toBeNull();
+    expect(screen.queryByText("gone stale")).toBeNull();
+    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(head()).toContain("rendered diff");
+  });
+
   it("lets a failed operation be dismissed, and only then", async () => {
     const onDismiss = vi.fn();
     mount({ ops: [op({ id: 7, state: "failed", error: "no such release" })], onDismiss });
@@ -237,6 +280,11 @@ describe("ReleasePane — the diff", () => {
     expect(screen.queryByText(/render the same manifest/i)).toBeNull();
     expect(invoke).not.toHaveBeenCalled();
     expect(document.querySelector('[data-slot="line"]')).toBeNull();
+    // The head must not collapse the two claims either: `fresh · 0 → 1 ·
+    // rendered diff` names a diff that does not exist and a revision 0 that
+    // never did, directly above a body saying there is nothing to compare.
+    expect(head()).not.toContain("rendered diff");
+    expect(head()).not.toContain("0 → 1");
   });
 
   it("says two identical revisions match, which is a different claim", async () => {
@@ -304,6 +352,45 @@ describe("ReleasePane — the diff", () => {
     await waitFor(() =>
       expect(screen.getByText(/The connection to the API server could not be made/)).toBeTruthy(),
     );
+  });
+
+  /** A `k8s.getHelmRelease` that answers with nothing at all for one revision. */
+  function hollow(at: number) {
+    return vi.fn(async (_id: string, input?: unknown) => {
+      const req = input as { name: string; revision?: number };
+      if (req.revision === at) return undefined;
+      return {
+        name: req.name,
+        namespace: req.name,
+        revision: req.revision,
+        status: "deployed",
+        chart: "acme-service",
+        chartVersion: "2.4.1",
+        appVersion: "4f2a1c",
+        updated: "2026-08-24",
+        valuesYaml: "",
+        manifest: MANIFESTS[req.name]?.[req.revision ?? -1] ?? "",
+        notes: "",
+        history: [],
+      };
+    }) as unknown as Invoker;
+  }
+
+  it("names the earlier revision when THAT is the side helm did not return", async () => {
+    mount({ invoke: hollow(118) });
+    await waitFor(() => expect(screen.getByText(/no revision 118 of checkout/)).toBeTruthy());
+    expect(screen.getByText("Could not diff checkout")).toBeTruthy();
+    // Not left on the spinner: an unguarded payload throws inside the async
+    // body and nothing ever resets the state.
+    expect(screen.queryByText(/Rendering checkout/)).toBeNull();
+  });
+
+  it("names the current revision when that is the side that vanished", async () => {
+    // The release was uninstalled between the list refresh and this fetch, so
+    // 119 is the one that is gone. Blaming 118 sends the reader to history.
+    mount({ invoke: hollow(119) });
+    await waitFor(() => expect(screen.getByText(/no revision 119 of checkout/)).toBeTruthy());
+    expect(screen.queryByText(/no revision 118 of checkout/)).toBeNull();
   });
 
   it("has nothing to show until a release is selected", () => {

--- a/packages/ui-next/src/screens/helm/ReleasePane.test.tsx
+++ b/packages/ui-next/src/screens/helm/ReleasePane.test.tsx
@@ -1,0 +1,353 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Invoker } from "@srelens/core";
+import { ReleasePane, currentOp, type PaneRelease } from "./ReleasePane";
+import type { HelmOpRow } from "../../lib/helmOps";
+
+const CONTEXT = "prod-eu";
+
+const CHECKOUT: PaneRelease = {
+  name: "checkout",
+  namespace: "checkout",
+  revision: 119,
+  status: "failed",
+};
+
+const PAYMENTS: PaneRelease = {
+  name: "payments",
+  namespace: "payments",
+  revision: 62,
+  status: "deployed",
+};
+
+/**
+ * Two rendered manifests that differ in exactly the two places §16's diff
+ * differs in. The strings on either side are unique to their side, so a test
+ * asserting the diff is NOT on screen cannot be satisfied by the other pane.
+ */
+const REV_118 = ['replicaCount: 12', 'image:', '  tag: "118a7e"', 'env:', '  DB_POOL_MAX: "40"'].join("\n");
+const REV_119 = ['replicaCount: 12', 'image:', '  tag: "4f2a1c"', 'env:', '  DB_POOL_MAX: "5"'].join("\n");
+
+const MANIFESTS: Record<string, Record<number, string>> = {
+  checkout: { 118: REV_118, 119: REV_119 },
+  payments: { 61: "replicas: 1", 62: "replicas: 4" },
+};
+
+/** A `k8s.getHelmRelease` that answers out of {@link MANIFESTS}. */
+function invoker() {
+  return vi.fn(async (id: string, input?: unknown) => {
+    if (id !== "k8s.getHelmRelease") throw new Error(`unexpected capability ${id}`);
+    const req = input as { name: string; revision?: number };
+    const manifest = MANIFESTS[req.name]?.[req.revision ?? -1];
+    if (manifest === undefined) throw new Error(`no revision ${req.revision} of ${req.name}`);
+    return {
+      name: req.name,
+      namespace: req.name,
+      revision: req.revision,
+      status: "deployed",
+      chart: "acme-service",
+      chartVersion: "2.4.1",
+      appVersion: "4f2a1c",
+      updated: "2026-08-24",
+      valuesYaml: "",
+      manifest,
+      notes: "",
+      history: [],
+    };
+  }) as unknown as Invoker;
+}
+
+function op(over: Partial<HelmOpRow> = {}): HelmOpRow {
+  return {
+    id: 1,
+    kind: "upgrade",
+    release: "checkout",
+    namespace: "checkout",
+    context: CONTEXT,
+    state: "running",
+    output: [],
+    startedAt: 1_000,
+    ...over,
+  };
+}
+
+function mount(props: Partial<Parameters<typeof ReleasePane>[0]> = {}) {
+  const invoke = props.invoke ?? invoker();
+  const view = render(
+    <ReleasePane context={CONTEXT} release={CHECKOUT} {...props} invoke={invoke} />,
+  );
+  return { ...view, invoke };
+}
+
+/** The pane's head, as the reader reads it. */
+function head(): string {
+  return document.querySelector(".pane-head")?.textContent ?? "";
+}
+
+describe("currentOp", () => {
+  it("ignores an operation belonging to another release", () => {
+    const other = op({ release: "payments", namespace: "payments" });
+    expect(currentOp([other], CONTEXT, CHECKOUT)).toBeNull();
+  });
+
+  it("ignores an operation in another cluster", () => {
+    expect(currentOp([op({ context: "edge-apac" })], CONTEXT, CHECKOUT)).toBeNull();
+  });
+
+  it("ignores a same-named release in another namespace", () => {
+    // Helm scopes a release name to a namespace, so `checkout/checkout` and
+    // `staging/checkout` are two releases. Matching on the name alone would
+    // put staging's upgrade output over production's diff.
+    expect(currentOp([op({ namespace: "staging" })], CONTEXT, CHECKOUT)).toBeNull();
+  });
+
+  it("ignores an operation that finished cleanly", () => {
+    expect(currentOp([op({ state: "done" })], CONTEXT, CHECKOUT)).toBeNull();
+  });
+
+  it("prefers the running operation over the failed one, whichever started first", () => {
+    const failed = op({ id: 2, state: "failed", error: "boom", startedAt: 9_000 });
+    const running = op({ id: 1, state: "running", startedAt: 1_000 });
+    expect(currentOp([failed, running], CONTEXT, CHECKOUT)?.id).toBe(1);
+    expect(currentOp([running, failed], CONTEXT, CHECKOUT)?.id).toBe(1);
+  });
+
+  it("takes the newest of several failures", () => {
+    const older = op({ id: 1, state: "failed", error: "older", startedAt: 1_000 });
+    const newer = op({ id: 2, state: "failed", error: "newer", startedAt: 2_000 });
+    expect(currentOp([newer, older], CONTEXT, CHECKOUT)?.id).toBe(2);
+  });
+
+  it("has nothing to consider when no release is selected", () => {
+    expect(currentOp([op()], CONTEXT, null)).toBeNull();
+  });
+});
+
+describe("ReleasePane — an operation outranks the diff", () => {
+  it("shows a running operation's output instead of the diff", async () => {
+    const { invoke } = mount({
+      ops: [op({ output: ["Release \"checkout\" has been upgraded.", "REVISION: 120"] })],
+    });
+
+    expect(screen.getByText('Release "checkout" has been upgraded.')).toBeTruthy();
+    expect(screen.getByText("REVISION: 120")).toBeTruthy();
+    // The diff for this release is fetchable and still loses.
+    expect(screen.queryByText('tag: "4f2a1c"')).toBeNull();
+    expect(screen.queryByText('tag: "118a7e"')).toBeNull();
+    expect(invoke).not.toHaveBeenCalled();
+    expect(head()).toContain("upgrade");
+    expect(head()).not.toContain("rendered diff");
+  });
+
+  it("says an operation is live rather than leaving it to the output", () => {
+    mount({ ops: [op({ output: ["waiting for rollout"] })] });
+    // A live region, so a stream that starts or stops is announced rather than
+    // silently redrawn — and it names the operation, not just its colour.
+    expect(screen.getByRole("status").textContent).toMatch(/upgrade running/i);
+  });
+
+  it("says nothing is live once the operation has failed", () => {
+    mount({ ops: [op({ state: "failed", error: "no such release", output: [] })] });
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("draws no dismiss control on a running operation, because there is no cancel", () => {
+    const onDismiss = vi.fn();
+    mount({ ops: [op({ output: ["waiting"] })], onDismiss });
+    expect(screen.queryByRole("button", { name: /dismiss/i })).toBeNull();
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  /**
+   * `describeError`'s own copy for a 401 — exactly what the store writes into
+   * `error`, character for character.
+   *
+   * Chosen because it is the case where describing a described sentence does
+   * visible damage: this text contains "client certificate", the TLS branch
+   * matches on it, and a second pass turns a rejected token into a complaint
+   * about the cluster's certificate. Anything shorter would be re-described
+   * into itself and the mistake would not show.
+   */
+  const DESCRIBED =
+    "The cluster rejected your credentials. Your token or client certificate may have expired — refresh your kubeconfig credentials and try again.";
+
+  it("keeps a failed operation's reason on screen, with its output", () => {
+    mount({
+      ops: [
+        op({
+          state: "failed",
+          error: DESCRIBED,
+          output: ["Error: UPGRADE FAILED: timed out waiting for the condition"],
+        }),
+      ],
+    });
+
+    // Verbatim: `helmOps` already ran this through `describeError`, and a
+    // sentence described twice is classified on its own wording.
+    expect(screen.getByText(DESCRIBED)).toBeTruthy();
+    expect(screen.queryByText(/TLS certificate couldn't be verified/)).toBeNull();
+    expect(screen.getByText("Error: UPGRADE FAILED: timed out waiting for the condition")).toBeTruthy();
+    expect(screen.queryByText('tag: "4f2a1c"')).toBeNull();
+  });
+
+  it("lets a failed operation be dismissed, and only then", async () => {
+    const onDismiss = vi.fn();
+    mount({ ops: [op({ id: 7, state: "failed", error: "no such release" })], onDismiss });
+    await userEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+    expect(onDismiss).toHaveBeenCalledWith(7);
+  });
+});
+
+describe("ReleasePane — the diff", () => {
+  it("renders the selected release's last revision against the one before it", async () => {
+    const { invoke } = mount();
+
+    await waitFor(() => expect(screen.getByText('tag: "4f2a1c"')).toBeTruthy());
+    expect(screen.getByText('tag: "118a7e"')).toBeTruthy();
+    expect(screen.getByText('DB_POOL_MAX: "5"')).toBeTruthy();
+    expect(head()).toContain("checkout · 118 → 119 · rendered diff");
+    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(invoke).toHaveBeenCalledWith(
+      "k8s.getHelmRelease",
+      expect.objectContaining({ context: CONTEXT, name: "checkout", revision: 118 }),
+    );
+    expect(invoke).toHaveBeenCalledWith(
+      "k8s.getHelmRelease",
+      expect.objectContaining({ context: CONTEXT, name: "checkout", revision: 119 }),
+    );
+  });
+
+  it("tones the head badge with core's verdict for helm's own word", async () => {
+    mount();
+    await waitFor(() => expect(screen.getByText('tag: "4f2a1c"')).toBeTruthy());
+    const badge = document.querySelector(".pane-head .badge");
+    expect(badge?.textContent).toBe("failed");
+    expect(badge?.getAttribute("data-tone")).toBe("sev");
+  });
+
+  it("says a one-revision release has nothing to compare, and asks the cluster nothing", async () => {
+    const { invoke } = mount({
+      release: { name: "fresh", namespace: "default", revision: 1, status: "deployed" },
+    });
+
+    expect(screen.getByText(/nothing to compare/i)).toBeTruthy();
+    expect(screen.getByText(/revision 1, its first/i)).toBeTruthy();
+    // The claim is NOT "no changes" — that says the two revisions matched.
+    expect(screen.queryByText(/render the same manifest/i)).toBeNull();
+    expect(invoke).not.toHaveBeenCalled();
+    expect(document.querySelector('[data-slot="line"]')).toBeNull();
+  });
+
+  it("says two identical revisions match, which is a different claim", async () => {
+    const invoke = vi.fn(async () => ({
+      name: "steady",
+      namespace: "default",
+      revision: 4,
+      status: "deployed",
+      chart: "c",
+      chartVersion: "1",
+      appVersion: "1",
+      updated: "",
+      valuesYaml: "",
+      manifest: "replicas: 1\n",
+      notes: "",
+      history: [],
+    })) as unknown as Invoker;
+
+    mount({
+      release: { name: "steady", namespace: "default", revision: 4, status: "deployed" },
+      invoke,
+    });
+
+    await waitFor(() => expect(screen.getByText(/render the same manifest/i)).toBeTruthy());
+    // ...and NOT the sentence a first revision gets.
+    expect(screen.queryByText(/nothing to compare/i)).toBeNull();
+    expect(screen.queryByText(/its first/i)).toBeNull();
+    // Nor the manifest itself printed back as context lines, which is what
+    // `diffTextLines` hands over for an unchanged pair.
+    expect(document.querySelector('[data-slot="line"]')).toBeNull();
+  });
+
+  it("follows the selection rather than staying on one release", async () => {
+    const invoke = invoker();
+    const { rerender } = render(
+      <ReleasePane context={CONTEXT} release={CHECKOUT} invoke={invoke} ops={[]} />,
+    );
+    await waitFor(() => expect(screen.getByText('tag: "4f2a1c"')).toBeTruthy());
+
+    rerender(<ReleasePane context={CONTEXT} release={PAYMENTS} invoke={invoke} ops={[]} />);
+    await waitFor(() => expect(screen.getByText("replicas: 4")).toBeTruthy());
+    expect(screen.queryByText('tag: "4f2a1c"')).toBeNull();
+    expect(head()).toContain("payments · 61 → 62 · rendered diff");
+  });
+
+  it("changes which operation is considered when the selection changes", async () => {
+    const invoke = invoker();
+    const rows = [op({ output: ["upgrading checkout"] })];
+    const { rerender } = render(
+      <ReleasePane context={CONTEXT} release={CHECKOUT} invoke={invoke} ops={rows} />,
+    );
+    expect(screen.getByText("upgrading checkout")).toBeTruthy();
+
+    rerender(<ReleasePane context={CONTEXT} release={PAYMENTS} invoke={invoke} ops={rows} />);
+    await waitFor(() => expect(screen.getByText("replicas: 4")).toBeTruthy());
+    expect(screen.queryByText("upgrading checkout")).toBeNull();
+  });
+
+  it("describes a refused read rather than printing what the backend said", async () => {
+    const invoke = vi.fn(async () => {
+      throw new Error("ServiceError: client error (Connect): connection refused");
+    }) as unknown as Invoker;
+    mount({ invoke });
+
+    await waitFor(() =>
+      expect(screen.getByText(/The connection to the API server could not be made/)).toBeTruthy(),
+    );
+  });
+
+  it("has nothing to show until a release is selected", () => {
+    const { invoke } = mount({ release: null });
+    expect(screen.getByText(/No release selected/i)).toBeTruthy();
+    expect(invoke).not.toHaveBeenCalled();
+  });
+});
+
+describe("ReleasePane — the frame", () => {
+  it("is §16's fixed 420px column", () => {
+    mount({ release: null });
+    const pane = document.querySelector("aside");
+    expect(pane?.style.width).toBe("420px");
+  });
+
+  it("scrolls its body rather than the whole pane", () => {
+    mount({ release: null });
+    expect(document.querySelector('[data-slot="pane-body"]')?.className).toContain("side-rail-body");
+  });
+
+  it("offers §16's footer only where a rollback target exists", async () => {
+    const onRollback = vi.fn();
+    const onValuesEditor = vi.fn();
+    mount({ onRollback, onValuesEditor });
+    await waitFor(() => expect(screen.getByText('tag: "4f2a1c"')).toBeTruthy());
+
+    await userEvent.click(screen.getByRole("button", { name: "Roll back to 118" }));
+    expect(onRollback).toHaveBeenCalledWith(118);
+    await userEvent.click(screen.getByRole("button", { name: "Values editor" }));
+    expect(onValuesEditor).toHaveBeenCalled();
+  });
+
+  it("offers no rollback on a release that has never been upgraded", () => {
+    mount({
+      release: { name: "fresh", namespace: "default", revision: 1, status: "deployed" },
+      onRollback: vi.fn(),
+      onValuesEditor: vi.fn(),
+    });
+    expect(screen.queryByRole("button", { name: /Roll back/ })).toBeNull();
+  });
+
+  it("offers no rollback while an operation holds the pane", () => {
+    mount({ ops: [op({ output: ["working"] })], onRollback: vi.fn(), onValuesEditor: vi.fn() });
+    expect(screen.queryByRole("button", { name: /Roll back/ })).toBeNull();
+  });
+});

--- a/packages/ui-next/src/screens/helm/ReleasePane.tsx
+++ b/packages/ui-next/src/screens/helm/ReleasePane.tsx
@@ -22,6 +22,16 @@ import { type HelmOpRow, dismissHelmOp } from "../../lib/helmOps";
 /** §16's second pane, in px. */
 const WIDTH = 420;
 
+/**
+ * The default `ops`, hoisted.
+ *
+ * A `[]` written in the parameter list is a fresh array on every render, which
+ * is the one case where the `useMemo` below can never hit: the default caller
+ * — a screen with no operations in flight — would re-run `currentOp` for every
+ * keystroke anywhere above it.
+ */
+const NO_OPS: readonly HelmOpRow[] = [];
+
 /** The release the pane is looking at — one row of §16's release table. */
 export interface PaneRelease {
   name: string;
@@ -71,10 +81,22 @@ export interface ReleasePaneProps {
  * only place its reason exists, because nothing else on the screen carries it.
  * A diff of two revisions is true whenever it is asked for and can wait.
  *
- * **A `done` operation is not considered at all.** It succeeded, the release
- * moved on, and the diff of the revision it produced says more about it than
- * its own output does. It stays in the store, listed and dismissable
- * elsewhere; it just does not take this pane.
+ * **A `done` operation never takes the pane, but it does retire a failure.**
+ * Those are two different rules and collapsing them into one is a bug the
+ * reader cannot get out of. Who-wins: a success moved the release on, and the
+ * diff of the revision it produced says more than its own output does, so it
+ * yields. Retirement: an attempt that started AFTER a failure — `done` or
+ * `running` — is evidence that failure is spent, so it drops out of the pool
+ * rather than holding the pane forever. Without the second rule a 10:00
+ * upgrade that failed on an expired token keeps a red banner and its stale
+ * output over a release the 10:05 retry left `deployed`, with the diff of the
+ * revision that retry produced unreachable and Dismiss the only way out.
+ *
+ * **Retiring a failure here does not retire the ROW.** The store keeps it
+ * until the reader dismisses it and the status strip goes on counting it,
+ * deliberately: the strip answers "a failure happened and you have not
+ * acknowledged it", this pane answers "here is what is worth looking at right
+ * now". Dismissing clears both. Nothing in this function touches the store.
  *
  * Ties go to the newest start, then to the higher id — two operations started
  * inside the same millisecond are ordered by the sequence that registered
@@ -90,11 +112,25 @@ export function currentOp(
     (o) => o.context === context && o.namespace === release.namespace && o.release === release.name,
   );
   const running = mine.filter((o) => o.state === "running");
-  const pool = running.length > 0 ? running : mine.filter((o) => o.state === "failed");
-  if (pool.length === 0) return null;
-  return pool.reduce((best, o) =>
-    o.startedAt > best.startedAt || (o.startedAt === best.startedAt && o.id > best.id) ? o : best,
+  if (running.length > 0) return newest(running);
+  // Every attempt that is not itself a failure. A failure with one of these
+  // after it has been superseded and no longer holds the pane.
+  const attempts = mine.filter((o) => o.state !== "failed");
+  const unspent = mine.filter(
+    (o) => o.state === "failed" && !attempts.some((later) => startedAfter(later, o)),
   );
+  if (unspent.length === 0) return null;
+  return newest(unspent);
+}
+
+/** Did `a` start after `b`? The tie-break is the store's id, which only rises. */
+function startedAfter(a: HelmOpRow, b: HelmOpRow): boolean {
+  return a.startedAt > b.startedAt || (a.startedAt === b.startedAt && a.id > b.id);
+}
+
+/** The latest-started row of a non-empty list. */
+function newest(rows: readonly HelmOpRow[]): HelmOpRow {
+  return rows.reduce((best, o) => (startedAfter(o, best) ? o : best));
 }
 
 /** Where the diff stands. */
@@ -139,7 +175,7 @@ type DiffLoad =
 export function ReleasePane({
   context,
   release,
-  ops = [],
+  ops = NO_OPS,
   onDismiss = dismissHelmOp,
   onRollback,
   onValuesEditor,
@@ -182,7 +218,13 @@ export function ReleasePane({
         return;
       }
       if (!before.release || !after.release) {
-        setDiff({ status: "error", error: `helm returned no revision ${previous} of ${name}` });
+        // Name the side that actually came back empty. Blaming the left
+        // revision for the right one's absence sends the reader digging
+        // through history for a release that was uninstalled between the list
+        // refresh and this fetch. Both sides missing names the earlier one,
+        // which is the first thing to go looking for either way.
+        const missing = before.release ? revision : previous;
+        setDiff({ status: "error", error: `helm returned no revision ${missing} of ${name}` });
         return;
       }
       setDiff({

--- a/packages/ui-next/src/screens/helm/ReleasePane.tsx
+++ b/packages/ui-next/src/screens/helm/ReleasePane.tsx
@@ -1,0 +1,346 @@
+import { useEffect, useId, useMemo, useState } from "react";
+import {
+  type DiffRow,
+  type Invoker,
+  diffTextLines,
+  getHelmRelease,
+  helmStatus,
+} from "@srelens/core";
+import {
+  Alert,
+  Badge,
+  Button,
+  DiffLines,
+  EmptyState,
+  LiveSignal,
+  LoadingState,
+  statusTone,
+} from "@srelens/ui-kit";
+import { FailureState } from "../../lib/errorCopy";
+import { type HelmOpRow, dismissHelmOp } from "../../lib/helmOps";
+
+/** §16's second pane, in px. */
+const WIDTH = 420;
+
+/** The release the pane is looking at — one row of §16's release table. */
+export interface PaneRelease {
+  name: string;
+  namespace: string;
+  /** The revision running now: the diff's right-hand side. */
+  revision: number;
+  /** Helm's own status word. Toned by core's `helmStatus`, never by this file. */
+  status: string;
+}
+
+export interface ReleasePaneProps {
+  /** The cluster the release lives in — a kubeconfig context NAME. */
+  context: string;
+  /**
+   * The selected release, or `null` when nothing is selected.
+   *
+   * §16's own pane is hard-wired to `checkout` and says clicking a release row
+   * does nothing. This one follows the selection, which changes both the diff
+   * and which operation is considered.
+   */
+  release: PaneRelease | null;
+  /**
+   * Every operation this window has started. The pane picks its own out of
+   * them — see {@link currentOp}.
+   *
+   * A prop rather than a subscription of its own: the screen above already
+   * reads the store for its table and its status strip, and three
+   * `useSyncExternalStore` subscriptions to one module is three renders per
+   * printed line.
+   */
+  ops?: readonly HelmOpRow[];
+  /** Drop a finished operation's row. The store's own by default. */
+  onDismiss?: (id: number) => void;
+  /** §16's footer: roll back to the diff's left-hand revision. */
+  onRollback?: (revision: number) => void;
+  /** §16's footer: open the values editor — the dialog in `upgrade` mode. */
+  onValuesEditor?: () => void;
+  /** The capability invoker; core's default when omitted. */
+  invoke?: Invoker;
+}
+
+/**
+ * The operation this pane is about, out of everything the window is running.
+ *
+ * **Running outranks failed, and both outrank the diff.** A `helm upgrade`
+ * still in flight is the thing the reader came to look at; a failure is the
+ * only place its reason exists, because nothing else on the screen carries it.
+ * A diff of two revisions is true whenever it is asked for and can wait.
+ *
+ * **A `done` operation is not considered at all.** It succeeded, the release
+ * moved on, and the diff of the revision it produced says more about it than
+ * its own output does. It stays in the store, listed and dismissable
+ * elsewhere; it just does not take this pane.
+ *
+ * Ties go to the newest start, then to the higher id — two operations started
+ * inside the same millisecond are ordered by the sequence that registered
+ * them rather than by the order the array happens to be in.
+ */
+export function currentOp(
+  ops: readonly HelmOpRow[],
+  context: string,
+  release: PaneRelease | null,
+): HelmOpRow | null {
+  if (!release) return null;
+  const mine = ops.filter(
+    (o) => o.context === context && o.namespace === release.namespace && o.release === release.name,
+  );
+  const running = mine.filter((o) => o.state === "running");
+  const pool = running.length > 0 ? running : mine.filter((o) => o.state === "failed");
+  if (pool.length === 0) return null;
+  return pool.reduce((best, o) =>
+    o.startedAt > best.startedAt || (o.startedAt === best.startedAt && o.id > best.id) ? o : best,
+  );
+}
+
+/** Where the diff stands. */
+type DiffLoad =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "ready"; left: number; right: number; rows: DiffRow[] }
+  | { status: "error"; error: string };
+
+/**
+ * §16's second pane: **a helm operation where the diff would be**.
+ *
+ * Two things can fill it and only one of them at a time. A running or failed
+ * operation for the selected release wins — see {@link currentOp} — and
+ * otherwise the pane diffs the release's current revision against the one
+ * before it.
+ *
+ * **A release with one revision has nothing to diff, and says so.** This is
+ * the commonest case on a freshly installed chart, and it is NOT the same
+ * claim as an empty diff: "no changes" says srelens compared two manifests
+ * and found them equal, which on revision 1 it did not do — there was no
+ * left-hand side to compare with. Both sentences exist below and neither is
+ * reachable from the other's state.
+ *
+ * **Nothing here cancels anything.** `dismissHelmOp` declines to remove a
+ * `running` row by design, so this pane draws no dismiss control on one: a
+ * button that looks like it stops a `helm upgrade` and does not would be worse
+ * than no button, and the upgrade continues whether srelens watches or not.
+ *
+ * **A failed operation's reason is printed as the store wrote it.** `helmOps`
+ * already ran it through `describeError`; running the resulting sentence
+ * through it a second time classifies it on its own wording. Everything this
+ * file fetches for itself does go through `describeError`, via
+ * {@link FailureState}.
+ *
+ * **No status word or tone is invented here.** The head's badge is
+ * `helmStatus`'s verdict on Helm's own word, tone included. The one thing this
+ * file says about an operation — that it is live — is said by `LiveSignal`,
+ * which is a `status` region, rather than by a word looked up in a table of
+ * this file's own; ten of those were removed on this migration.
+ */
+export function ReleasePane({
+  context,
+  release,
+  ops = [],
+  onDismiss = dismissHelmOp,
+  onRollback,
+  onValuesEditor,
+  invoke,
+}: ReleasePaneProps) {
+  const headId = useId();
+  const op = useMemo(() => currentOp(ops, context, release), [ops, context, release]);
+
+  // Primitives, not the object: the screen above rebuilds its row objects on
+  // every list refresh, and an effect keyed on identity would re-fetch both
+  // manifests each time the table polled.
+  const name = release?.name ?? "";
+  const namespace = release?.namespace ?? "";
+  const revision = release?.revision ?? 0;
+  const held = op !== null;
+  /** The revision the diff reads from, when there is an earlier one at all. */
+  const previous = revision > 1 ? revision - 1 : null;
+
+  const [diff, setDiff] = useState<DiffLoad>({ status: "idle" });
+
+  useEffect(() => {
+    // Nothing is fetched while an operation holds the pane: the round trip
+    // would be spent on something the reader cannot see, and the effect runs
+    // again the moment the operation settles or is dismissed.
+    if (name === "" || held || previous === null) {
+      setDiff({ status: "idle" });
+      return;
+    }
+    let live = true;
+    setDiff({ status: "loading" });
+    void (async () => {
+      const [before, after] = await Promise.all([
+        getHelmRelease(context, namespace, name, invoke, previous),
+        getHelmRelease(context, namespace, name, invoke, revision),
+      ]);
+      if (!live) return;
+      const failure = before.error ?? after.error;
+      if (failure !== undefined) {
+        setDiff({ status: "error", error: failure });
+        return;
+      }
+      if (!before.release || !after.release) {
+        setDiff({ status: "error", error: `helm returned no revision ${previous} of ${name}` });
+        return;
+      }
+      setDiff({
+        status: "ready",
+        left: previous,
+        right: revision,
+        rows: diffTextLines(before.release.manifest, after.release.manifest),
+      });
+    })();
+    return () => {
+      live = false;
+    };
+  }, [context, namespace, name, revision, previous, held, invoke]);
+
+  const verdict = release ? helmStatus(release.status) : null;
+  const headText = !release
+    ? "Release"
+    : op
+      ? `${release.name} · ${op.kind} · output`
+      : previous === null
+        ? // No third segment. §16's is `· rendered diff`, and there is no diff
+          // here to name — writing it anyway would promise the thing the body
+          // is about to say does not exist.
+          `${release.name} · revision ${revision}`
+        : `${release.name} · ${previous} → ${revision} · rendered diff`;
+
+  /** §16's footer is about the diff; a rollback target it does not have is not offered. */
+  const footer =
+    !op && previous !== null && (onRollback || onValuesEditor) ? (
+      <div
+        data-slot="pane-footer"
+        className="flex min-w-0 shrink-0 items-center gap-2 border-t border-rule bg-sunk px-2.5 py-1.5"
+      >
+        {onRollback && (
+          <Button variant="danger" size="sm" onClick={() => onRollback(previous)}>
+            Roll back to {previous}
+          </Button>
+        )}
+        {onValuesEditor && (
+          <Button variant="secondary" size="sm" onClick={onValuesEditor}>
+            Values editor
+          </Button>
+        )}
+      </div>
+    ) : null;
+
+  return (
+    // `min-w-0` on every box below that holds a diff line or a printed one:
+    // this column is 420px and the text in it is unbounded, and a flex child's
+    // `min-width: auto` floor is what turns a long line into a sideways scroll
+    // of the whole window rather than a wrap inside the pane.
+    <aside aria-labelledby={headId} className="side-rail" style={{ width: WIDTH }}>
+      <div id={headId} className="pane-head">
+        <span className="min-w-0 flex-1 truncate">{headText}</span>
+        {op?.state === "running" && (
+          <LiveSignal label={`${op.kind} running`} tone="info" className="shrink-0" />
+        )}
+        {verdict && (
+          <span className="shrink-0">
+            <Badge tone={statusTone(verdict.health)}>{verdict.word}</Badge>
+          </span>
+        )}
+      </div>
+
+      <div data-slot="pane-body" className="side-rail-body min-w-0">
+        {!release ? (
+          <EmptyState
+            title="No release selected"
+            hint="Pick a release to see what its last revision changed."
+            compact
+          />
+        ) : op ? (
+          <Operation op={op} onDismiss={onDismiss} />
+        ) : previous === null ? (
+          <EmptyState
+            title="Nothing to compare"
+            hint={`${release.name} is at revision ${revision}, its first — there is no earlier revision to diff it against.`}
+            compact
+          />
+        ) : diff.status === "loading" || diff.status === "idle" ? (
+          <LoadingState label={`Rendering ${release.name}`} />
+        ) : diff.status === "error" ? (
+          <FailureState
+            title={`Could not diff ${release.name}`}
+            error={diff.error}
+            className="px-3"
+          />
+        ) : !diff.rows.some((r) => r.tag !== "same") ? (
+          /* Not `rows.length === 0`. Two identical manifests do not produce an
+             empty list — they produce a full one of `same` rows, and printing
+             it renders the whole manifest as context, which reads as "here is
+             what is deployed" rather than "nothing changed". The claim is
+             about whether anything DIFFERS, so that is what is asked. */
+          <EmptyState
+            title="No changes"
+            hint={`Revisions ${diff.left} and ${diff.right} of ${release.name} render the same manifest.`}
+            compact
+          />
+        ) : (
+          <DiffLines rows={diff.rows} className="min-w-0 py-1" />
+        )}
+      </div>
+
+      {footer}
+    </aside>
+  );
+}
+
+/**
+ * What an operation is saying — its output, and, when it failed, why.
+ *
+ * The failure is a banner over the output rather than in place of it: the
+ * lines helm printed before it gave up are usually the only description of
+ * what it was doing, and #349's vanishing port-forward is what happens when a
+ * dead thing is quietly cleared away instead.
+ */
+function Operation({ op, onDismiss }: { op: HelmOpRow; onDismiss: (id: number) => void }) {
+  return (
+    <div className="flex min-w-0 flex-col gap-2 py-2">
+      {op.state === "failed" && (
+        <div className="min-w-0 break-words px-2.5">
+          {/* `op.error` verbatim. `helmOps` described it already; describing a
+              described sentence classifies it on its own wording. */}
+          <Alert tone="sev" title={`${op.kind} of ${op.release} failed`}>
+            {op.error ?? "helm gave no reason."}
+          </Alert>
+          <Button
+            variant="secondary"
+            size="sm"
+            className="mt-2"
+            onClick={() => onDismiss(op.id)}
+          >
+            Dismiss
+          </Button>
+        </div>
+      )}
+      {op.output.length === 0 ? (
+        <div className="px-2.5 text-[0.75rem] text-muted">
+          {op.state === "running"
+            ? "helm has not printed anything yet."
+            : "helm printed nothing before it stopped."}
+        </div>
+      ) : (
+        <div className="flex min-w-0 flex-col font-mono text-[0.6875rem] leading-relaxed">
+          {op.output.map((line, i) => (
+            <div
+              // The store only ever appends, so a line's position is stable for
+              // the life of the row.
+              key={i}
+              data-slot="op-line"
+              className="min-w-0 whitespace-pre-wrap break-all px-2.5"
+              style={{ color: "var(--ink-soft)" }}
+            >
+              {line}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/ui-next/src/screens/helm/ReleasePane.tsx
+++ b/packages/ui-next/src/screens/helm/ReleasePane.tsx
@@ -93,10 +93,14 @@ export interface ReleasePaneProps {
  * revision that retry produced unreachable and Dismiss the only way out.
  *
  * **Retiring a failure here does not retire the ROW.** The store keeps it
- * until the reader dismisses it and the status strip goes on counting it,
- * deliberately: the strip answers "a failure happened and you have not
- * acknowledged it", this pane answers "here is what is worth looking at right
- * now". Dismissing clears both. Nothing in this function touches the store.
+ * until the reader dismisses it; the status strip goes on counting it and the
+ * Helm screen's own failures register goes on listing it, deliberately. Those
+ * two answer "a failure happened and you have not acknowledged it"; this pane
+ * answers "here is what is worth looking at right now". A retired failure is
+ * therefore still readable and still dismissable — on the screen above, which
+ * is what keeps the strip's segment honest for an operation this function
+ * never returns. Dismissing clears all three. Nothing in this function touches
+ * the store.
  *
  * Ties go to the newest start, then to the higher id — two operations started
  * inside the same millisecond are ordered by the sequence that registered
@@ -155,10 +159,24 @@ type DiffLoad =
  * left-hand side to compare with. Both sentences exist below and neither is
  * reachable from the other's state.
  *
- * **Nothing here cancels anything.** `dismissHelmOp` declines to remove a
- * `running` row by design, so this pane draws no dismiss control on one: a
- * button that looks like it stops a `helm upgrade` and does not would be worse
- * than no button, and the upgrade continues whether srelens watches or not.
+ * **Nothing here cancels anything, and the reason is NOT that srelens could
+ * quietly look away.** `dismissHelmOp` declines to remove a `running` row by
+ * design, so this pane draws no dismiss control on one. This comment used to
+ * justify that with "the upgrade continues whether srelens watches or not",
+ * which read as: closing our view of it is harmless. It is not. The store's
+ * only lever over a live operation is the handle's `close()`, and that is not
+ * an unsubscribe — it aborts the task owning helm's child process, which the
+ * backend spawns `kill_on_drop(true)`, so it SIGKILLs helm wherever it had
+ * reached: a release left half-upgraded, its Secret mid-write, and no output
+ * saying why, because the process that would have said it is gone. See
+ * `lib/helmOps`'s header, and `crates/streams/src/helm.rs`, which calls it a
+ * "best-effort abort" and means it.
+ *
+ * So the two buttons this pane could draw on a running operation are one that
+ * does nothing and one that maims the release under a word meaning "stop
+ * watching". Neither is a cancel, and a control that looked like one would be
+ * worse than no control at all. The row stays, watched, until helm ends it;
+ * only then is there anything to dismiss.
  *
  * **A failed operation's reason is printed as the store wrote it.** `helmOps`
  * already ran it through `describeError`; running the resulting sentence
@@ -340,6 +358,13 @@ export function ReleasePane({
  * lines helm printed before it gave up are usually the only description of
  * what it was doing, and #349's vanishing port-forward is what happens when a
  * dead thing is quietly cleared away instead.
+ *
+ * The Dismiss below is not the only one on the screen — the failures register
+ * above the table carries one per failed operation, because a release the
+ * table cannot list has no row to select and so never reaches this pane. Both
+ * call the same `dismissHelmOp`, and the row leaves every surface at once.
+ * This one stays because this is where the whole output is, unfolded, for the
+ * release the reader actually has open.
  */
 function Operation({ op, onDismiss }: { op: HelmOpRow; onDismiss: (id: number) => void }) {
   return (

--- a/packages/ui-next/src/screens/resourceShell.test.tsx
+++ b/packages/ui-next/src/screens/resourceShell.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+
+import {
+  resetContexts,
+  setContexts,
+  useContextsError,
+  useContextsStatus,
+} from "../lib/clusters";
+import { NoClusterScreen } from "./resourceShell";
+
+/**
+ * `NoClusterScreen` is what `Events`, `Workloads`, `Resources`, `Overview`,
+ * `Logs` and `Helm` all fall back to, so a sentence that overstates here
+ * overstates on six screens at once — which is exactly how a user came to be
+ * told to "pick a cluster in the rail" while the title bar read
+ * `k8sm01-admin` and every tab carried its chip.
+ *
+ * The three cases it has to keep apart are the contexts store's three states,
+ * not one boolean: nothing selected (the reader's turn), nothing listed yet
+ * (srelens's turn), and a listing that failed (the backend's turn, and the
+ * only one where srelens already knows the reason).
+ */
+
+const shown = () => <NoClusterScreen title="Helm" noun="Helm releases" />;
+
+describe("NoClusterScreen", () => {
+  beforeEach(resetContexts);
+
+  it("asks the reader to pick, but only once the clusters have actually been listed", () => {
+    setContexts([]);
+    render(shown());
+    expect(screen.getByText("No cluster in focus")).toBeTruthy();
+    expect(screen.getByText("Pick a cluster in the rail to list its Helm releases.")).toBeTruthy();
+    expect(screen.queryByRole("status")).toBeNull();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("says it is still listing rather than blaming the reader, before the clusters have loaded", () => {
+    render(shown());
+    expect(screen.getByRole("status", { name: "Loading clusters" })).toBeTruthy();
+    expect(screen.getByText("Loading clusters")).toBeTruthy();
+    // The accusation is the whole defect: a cluster can be in focus here and
+    // the reader has nothing to fix.
+    expect(screen.queryByText("No cluster in focus")).toBeNull();
+    expect(screen.queryByText(/Pick a cluster in the rail/)).toBeNull();
+  });
+
+  it("reports why the clusters could not be listed instead of asking for a pick", () => {
+    setContexts([], "ServiceError: client error (Connect)");
+    render(shown());
+    expect(screen.getByRole("alert")).toBeTruthy();
+    expect(screen.getByText("Clusters could not be listed")).toBeTruthy();
+    expect(screen.queryByText("No cluster in focus")).toBeNull();
+    expect(screen.queryByText(/Pick a cluster in the rail/)).toBeNull();
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("classifies the failure through describeError rather than printing the backend's struct", () => {
+    setContexts([], "ServiceError: client error (Connect)");
+    render(shown());
+    expect(
+      screen.getByText(/The connection to the API server could not be made/),
+    ).toBeTruthy();
+    // Nothing is dropped: the original is still one disclosure away.
+    expect(screen.getByText("ServiceError: client error (Connect)")).toBeTruthy();
+  });
+
+  it("follows the store from listing, through a refusal, to a real pick — one mount, three states", () => {
+    render(shown());
+    expect(screen.getByRole("status", { name: "Loading clusters" })).toBeTruthy();
+
+    act(() => setContexts([], "ServiceError: client error (Connect)"));
+    expect(screen.getByText("Clusters could not be listed")).toBeTruthy();
+    expect(screen.queryByRole("status")).toBeNull();
+
+    act(() => setContexts([]));
+    expect(screen.getByText("No cluster in focus")).toBeTruthy();
+    expect(screen.queryByRole("alert")).toBeNull();
+
+    // The screen's own title bar survives all three.
+    expect(screen.getByRole("heading", { level: 1 }).textContent).toBe("Helm");
+  });
+
+  it("names the caller's own noun in the pick sentence", () => {
+    setContexts([]);
+    render(<NoClusterScreen title="Events" noun="events" />);
+    expect(screen.getByText("Pick a cluster in the rail to list its events.")).toBeTruthy();
+  });
+});
+
+/**
+ * Lives here rather than in `clusters.test.ts` because the failure it guards
+ * against only exists in React: `useSyncExternalStore` re-reads the snapshot
+ * after every render, and a getter that allocates per call never settles —
+ * "Maximum update depth exceeded", which this codebase has already shipped
+ * once. A plain `getStatus() === getStatus()` assertion cannot see it, because
+ * the two states this adds are primitives right up until someone bundles them
+ * into an object.
+ */
+describe("contexts store snapshots under useSyncExternalStore", () => {
+  beforeEach(resetContexts);
+
+  it("settles in one render rather than re-reading a freshly allocated snapshot forever", () => {
+    let renders = 0;
+    function Probe() {
+      renders += 1;
+      const status = useContextsStatus();
+      const error = useContextsError();
+      return <span data-testid="probe">{`${status}|${error}`}</span>;
+    }
+    render(<Probe />);
+    expect(screen.getByTestId("probe").textContent).toBe("loading|");
+    expect(renders).toBe(1);
+  });
+});

--- a/packages/ui-next/src/screens/resourceShell.tsx
+++ b/packages/ui-next/src/screens/resourceShell.tsx
@@ -1,6 +1,7 @@
-import { Alert, Button, EmptyState, MultiSelect, Screen, Spinner, type Column, type TableSort } from "@srelens/ui-kit";
+import { Alert, Button, EmptyState, LoadingState, MultiSelect, Screen, Spinner, type Column, type TableSort } from "@srelens/ui-kit";
+import { useContextsError, useContextsStatus } from "../lib/clusters";
 import { toggleColumn } from "../lib/columnPrefs";
-import { FailureAlert } from "../lib/errorCopy";
+import { FailureAlert, FailureState } from "../lib/errorCopy";
 import { setTabView, useTabs, useTabView } from "../lib/tabsStore";
 
 /**
@@ -22,17 +23,55 @@ import { setTabView, useTabs, useTabView } from "../lib/tabsStore";
  * two screens' own module comments.
  */
 
-/** The guard both screens open with: no cluster in focus, so there is no
- *  context name to call core with, and a hook cannot be skipped — this is a
- *  `return` before any hook runs, not a branch inside a hook-calling body. */
+/**
+ * The guard every screen opens with: no cluster context to call core with, so
+ * there is nothing to list. At the call site it is a `return` before any hook
+ * runs, not a branch inside a hook-calling body — the hooks below are this
+ * component's own, which is a different component and so a different list.
+ *
+ * **Why this is three states and not one sentence.** `useActiveContext` is the
+ * intersection of the workspace's active cluster and the *loaded* context
+ * list, and it answers `undefined` when either half is missing. That collapsed
+ * three unrelated situations into "No cluster in focus — pick a cluster in the
+ * rail", including the one where a cluster plainly *is* in focus: every tab
+ * carrying its chip, the title bar carrying its name, and `listContexts`
+ * having refused underneath. The reader was being blamed for a backend
+ * failure srelens had already read and thrown away. It knew "I could not list
+ * the contexts" and said "you have not picked one" — the string asserting more
+ * than srelens knows, on six screens at once, because they all render this.
+ *
+ * So the copy follows the store's own three states and nothing else:
+ *
+ * - **listed, none picked** — the original sentence, which is right here and
+ *   is left exactly as it was.
+ * - **not listed yet** — a spinner. The reader has nothing to do about a
+ *   listing that has not come back, and an instruction they cannot act on is
+ *   worse than no instruction.
+ * - **refused** — the reason, classified by `describeError` like every other
+ *   failure in this app, with the backend's own words a disclosure away.
+ *
+ * There is deliberately no fourth state for "refused, but a cluster is
+ * selected". The failure is the same failure and the remedy is the same
+ * remedy; splitting it would only let the two halves drift.
+ */
 export function NoClusterScreen({ title, noun }: { title: string; noun: string }) {
+  const status = useContextsStatus();
+  const error = useContextsError();
   return (
     <Screen title={title} fill>
-      <EmptyState
-        title="No cluster in focus"
-        hint={`Pick a cluster in the rail to list its ${noun}.`}
-        className="flex-1"
-      />
+      {status === "loading" ? (
+        <LoadingState label="Loading clusters" className="flex-1" />
+      ) : status === "failed" ? (
+        // The contextual half of the message is this component's; the detail
+        // under it is the classification, per `errorCopy`'s rule.
+        <FailureState title="Clusters could not be listed" error={error} className="my-auto" />
+      ) : (
+        <EmptyState
+          title="No cluster in focus"
+          hint={`Pick a cluster in the rail to list its ${noun}.`}
+          className="flex-1"
+        />
+      )}
     </Screen>
   );
 }

--- a/packages/ui-next/src/shell/Status.test.tsx
+++ b/packages/ui-next/src/shell/Status.test.tsx
@@ -176,8 +176,8 @@ describe("Status", () => {
   it("counts the helm operations still changing the cluster", () => {
     setState(defaultState([ctx]));
     helmOps.list = [
-      { id: 1, state: "running" },
-      { id: 2, state: "running" },
+      { id: 1, state: "running", context: ctx.name },
+      { id: 2, state: "running", context: ctx.name },
     ];
     mount(<Status contexts={[ctx]} />);
     expect(screen.getByRole("button", { name: "2 helm operations" })).toBeDefined();
@@ -190,9 +190,9 @@ describe("Status", () => {
     // the singular that one calls for, which a count over all three would get
     // wrong twice.
     helmOps.list = [
-      { id: 1, state: "running" },
-      { id: 2, state: "done" },
-      { id: 3, state: "failed" },
+      { id: 1, state: "running", context: ctx.name },
+      { id: 2, state: "done", context: ctx.name },
+      { id: 3, state: "failed", context: ctx.name },
     ];
     mount(<Status contexts={[ctx]} />);
     expect(screen.getByRole("button", { name: "1 helm operation" })).toBeDefined();
@@ -203,7 +203,7 @@ describe("Status", () => {
 
   it("says nothing about helm when nothing is in flight and nothing failed", () => {
     setState(defaultState([ctx]));
-    helmOps.list = [{ id: 1, state: "done" }];
+    helmOps.list = [{ id: 1, state: "done", context: ctx.name }];
     mount(<Status contexts={[ctx]} />);
     expect(screen.queryByRole("button", { name: /helm/i })).toBeNull();
     // Named as well as counted: `0 helm operations` is the exact readout the
@@ -217,7 +217,7 @@ describe("Status", () => {
     // Nothing else on screen reports that, and the count cannot: an operation
     // that fails leaves nothing in flight, which is what a reader who started
     // no operation at all sees.
-    helmOps.list = [{ id: 1, state: "failed" }];
+    helmOps.list = [{ id: 1, state: "failed", context: ctx.name }];
     mount(<Status contexts={[ctx]} />);
     expect(screen.getByRole("button", { name: "1 helm operation failed" })).toBeDefined();
     expect(screen.queryByRole("button", { name: "0 helm operations" })).toBeNull();
@@ -228,8 +228,8 @@ describe("Status", () => {
     // Both segments at once, and both saying "1": the fixture that catches an
     // assertion which would pass for either one on its own.
     helmOps.list = [
-      { id: 1, state: "running" },
-      { id: 2, state: "failed" },
+      { id: 1, state: "running", context: ctx.name },
+      { id: 2, state: "failed", context: ctx.name },
     ];
     mount(<Status contexts={[ctx]} />);
     expect(screen.getByRole("button", { name: "1 helm operation" })).toBeDefined();
@@ -238,7 +238,7 @@ describe("Status", () => {
 
   it("opens the helm screen from either helm readout", async () => {
     setState(defaultState([ctx]));
-    helmOps.list = [{ id: 1, state: "running" }];
+    helmOps.list = [{ id: 1, state: "running", context: ctx.name }];
     mount(<Status contexts={[ctx]} />);
     await userEvent.click(screen.getByRole("button", { name: "1 helm operation" }));
     expect(activeRoute()).toBe("/helm");
@@ -246,10 +246,63 @@ describe("Status", () => {
 
   it("opens the helm screen from the failed readout", async () => {
     setState(defaultState([ctx]));
-    helmOps.list = [{ id: 1, state: "failed" }];
+    helmOps.list = [{ id: 1, state: "failed", context: ctx.name }];
     mount(<Status contexts={[ctx]} />);
     await userEvent.click(screen.getByRole("button", { name: "1 helm operation failed" }));
     expect(activeRoute()).toBe("/helm");
+  });
+
+  it("counts only the helm operations on the cluster the reader is looking at", () => {
+    setState(defaultState([ctx]));
+    // Two upgrades in flight, one of them on a cluster this window is not
+    // showing. The strip names `prod-eu` and the segment beside it opens the
+    // Helm screen, which lists `prod-eu` and nothing else — so a count of two
+    // would send the reader somewhere the second one cannot be seen.
+    helmOps.list = [
+      { id: 1, state: "running", context: ctx.name },
+      { id: 2, state: "running", context: "staging-us" },
+    ];
+    mount(<Status contexts={[ctx]} />);
+    expect(screen.getByRole("button", { name: "1 helm operation" })).toBeDefined();
+    expect(screen.queryByRole("button", { name: "2 helm operations" })).toBeNull();
+  });
+
+  it("does not report a failure from a cluster this window is not looking at", () => {
+    setState(defaultState([ctx]));
+    // The `sev` tone is a summons, and this one would lead nowhere: the Helm
+    // screen the segment opens lists `prod-eu`, so a `staging-us` failure
+    // shown here is an alarm with no page behind it. It comes back the moment
+    // the reader switches to that cluster; the row stays in the store until
+    // it is dismissed.
+    helmOps.list = [{ id: 1, state: "failed", context: "staging-us" }];
+    mount(<Status contexts={[ctx]} />);
+    expect(screen.queryByRole("button", { name: /helm/i })).toBeNull();
+  });
+
+  it("says nothing about helm when no cluster is active", () => {
+    setState(defaultState([]));
+    // No cluster means no Helm screen to open — the screen asks for a context
+    // before it lists anything — so there is nothing to count towards.
+    helmOps.list = [
+      { id: 1, state: "running", context: ctx.name },
+      { id: 2, state: "failed", context: ctx.name },
+    ];
+    mount(<Status contexts={[]} />);
+    expect(screen.queryByRole("button", { name: /helm/i })).toBeNull();
+  });
+
+  it("still counts forwards and shells from every cluster, the way their screens list them", () => {
+    setState(defaultState([ctx]));
+    // The scoping above is not a rule about the strip, it is a rule about
+    // each segment agreeing with where it sends the reader. `/forwards` and
+    // `/terminals` list every cluster's rows, so these two counts stay whole
+    // — narrowing them to `prod-eu` would hide a tunnel the reader is
+    // depending on from the only surface that reports it.
+    forwards.list = [{ id: 1, status: "active", context: "staging-us" }];
+    sessions.list = [{ id: 1, state: "attached", context: "staging-us" }];
+    mount(<Status contexts={[ctx]} />);
+    expect(screen.getByRole("button", { name: "1 port-forward" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "1 shell" })).toBeDefined();
   });
 
   it("opens the console from Ask", async () => {

--- a/packages/ui-next/src/shell/Status.test.tsx
+++ b/packages/ui-next/src/shell/Status.test.tsx
@@ -4,7 +4,7 @@ import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { Status } from "./Status";
 import { ConsoleProvider, useConsole } from "../console";
-import { setState } from "../lib/tabsStore";
+import { activeRoute, setState } from "../lib/tabsStore";
 import { defaultState } from "../lib/tabs";
 import { probeCluster, resetProbes } from "../lib/probe";
 import { resetView } from "../lib/workspace";
@@ -36,11 +36,26 @@ vi.mock("../lib/sessions", () => ({
   },
 }));
 
+// Helm operations are ui-next's own store too, and read the same way: a
+// module-level snapshot faked at the boundary rather than a real `helm
+// upgrade` stood up through the backend. The getter hands back the same array
+// until it is swapped, which is what `useSyncExternalStore` requires — and
+// what a component that filtered inside its snapshot would break.
+const helmOps = vi.hoisted(() => ({ list: [] as unknown[], notify: new Set<() => void>() }));
+vi.mock("../lib/helmOps", () => ({
+  getHelmOps: () => helmOps.list,
+  subscribeHelmOps: (l: () => void) => {
+    helmOps.notify.add(l);
+    return () => helmOps.notify.delete(l);
+  },
+}));
+
 const ctx = { name: "prod-eu", stableId: "prod", cluster: "c", server: "", isCurrent: false };
 
 beforeEach(() => {
   forwards.list = [];
   sessions.list = [];
+  helmOps.list = [];
   resetView();
   resetProbes();
 });
@@ -156,6 +171,85 @@ describe("Status", () => {
     sessions.list = [{ id: 1, state: "closed" }];
     mount(<Status contexts={[ctx]} />);
     expect(screen.queryByRole("button", { name: /shell/i })).toBeNull();
+  });
+
+  it("counts the helm operations still changing the cluster", () => {
+    setState(defaultState([ctx]));
+    helmOps.list = [
+      { id: 1, state: "running" },
+      { id: 2, state: "running" },
+    ];
+    mount(<Status contexts={[ctx]} />);
+    expect(screen.getByRole("button", { name: "2 helm operations" })).toBeDefined();
+  });
+
+  it("counts only the operations still in flight", () => {
+    setState(defaultState([ctx]));
+    // A `done` upgrade has finished changing the cluster and a `failed` one
+    // has stopped trying; neither is in flight. Three rows, one running — and
+    // the singular that one calls for, which a count over all three would get
+    // wrong twice.
+    helmOps.list = [
+      { id: 1, state: "running" },
+      { id: 2, state: "done" },
+      { id: 3, state: "failed" },
+    ];
+    mount(<Status contexts={[ctx]} />);
+    expect(screen.getByRole("button", { name: "1 helm operation" })).toBeDefined();
+    // And the `done` one is not folded into the failure either: "finished" and
+    // "failed" are two states, and a segment toned `sev` may only count one.
+    expect(screen.getByRole("button", { name: "1 helm operation failed" })).toBeDefined();
+  });
+
+  it("says nothing about helm when nothing is in flight and nothing failed", () => {
+    setState(defaultState([ctx]));
+    helmOps.list = [{ id: 1, state: "done" }];
+    mount(<Status contexts={[ctx]} />);
+    expect(screen.queryByRole("button", { name: /helm/i })).toBeNull();
+    // Named as well as counted: `0 helm operations` is the exact readout the
+    // absent-at-zero rule exists to keep off a strip already carrying five.
+    expect(screen.queryByText(/0 helm operation/i)).toBeNull();
+  });
+
+  it("says so on the strip when a helm operation has failed", () => {
+    setState(defaultState([ctx]));
+    // The reader closed the dialog and the upgrade failed after it had gone.
+    // Nothing else on screen reports that, and the count cannot: an operation
+    // that fails leaves nothing in flight, which is what a reader who started
+    // no operation at all sees.
+    helmOps.list = [{ id: 1, state: "failed" }];
+    mount(<Status contexts={[ctx]} />);
+    expect(screen.getByRole("button", { name: "1 helm operation failed" })).toBeDefined();
+    expect(screen.queryByRole("button", { name: "0 helm operations" })).toBeNull();
+  });
+
+  it("tells a failed operation apart from the ones still running", () => {
+    setState(defaultState([ctx]));
+    // Both segments at once, and both saying "1": the fixture that catches an
+    // assertion which would pass for either one on its own.
+    helmOps.list = [
+      { id: 1, state: "running" },
+      { id: 2, state: "failed" },
+    ];
+    mount(<Status contexts={[ctx]} />);
+    expect(screen.getByRole("button", { name: "1 helm operation" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "1 helm operation failed" })).toBeDefined();
+  });
+
+  it("opens the helm screen from either helm readout", async () => {
+    setState(defaultState([ctx]));
+    helmOps.list = [{ id: 1, state: "running" }];
+    mount(<Status contexts={[ctx]} />);
+    await userEvent.click(screen.getByRole("button", { name: "1 helm operation" }));
+    expect(activeRoute()).toBe("/helm");
+  });
+
+  it("opens the helm screen from the failed readout", async () => {
+    setState(defaultState([ctx]));
+    helmOps.list = [{ id: 1, state: "failed" }];
+    mount(<Status contexts={[ctx]} />);
+    await userEvent.click(screen.getByRole("button", { name: "1 helm operation failed" }));
+    expect(activeRoute()).toBe("/helm");
   });
 
   it("opens the console from Ask", async () => {

--- a/packages/ui-next/src/shell/Status.tsx
+++ b/packages/ui-next/src/shell/Status.tsx
@@ -55,6 +55,13 @@ import { LINK_TONE, LINK_WORD, useWorkspaceView } from "../lib/workspace";
  * streaming helm operation prints often enough to make that a hang rather
  * than a waste. The stores promise a stable reference; the arithmetic below
  * is what keeps that promise useful.
+ *
+ * Each of those counts is scoped to whatever the screen it opens can show,
+ * which is not the same answer for all three: the forwards and terminals
+ * screens list every cluster's rows, and the Helm screen lists one cluster's.
+ * A segment that counted more than its destination could show would be a
+ * readout the reader cannot act on — worst of all in `sev`, where it reads as
+ * a summons.
  */
 export function Status({ contexts }: { contexts: ClusterContext[] }) {
   const activeId = useActiveCluster();
@@ -83,13 +90,30 @@ export function Status({ contexts }: { contexts: ClusterContext[] }) {
   // rail to show what died and why; counting it here would say a shell is
   // alive when it is not, the same lesson the tunnel above already carries.
   const liveSessions = sessions.filter((s) => s.state !== "closed").length;
+  // Scoped to the cluster this strip is naming, which the two counts above are
+  // deliberately not. The rule both follow is the same one: a segment counts
+  // what the screen it opens can show. `/forwards` and `/terminals` list every
+  // cluster's rows, so their counts are whole; `/helm` asks for a context
+  // before it lists anything and then shows that one cluster's releases and
+  // that one cluster's operations, so an operation from elsewhere counted here
+  // would be a `sev` summons to a page that cannot hold it. Nothing is lost by
+  // narrowing: the row stays in the store until it is dismissed, and the
+  // segment comes back the moment the reader switches to its cluster.
+  //
+  // `ctx.name` rather than `activeId`: the store holds the context name helm
+  // was run against, and the id is the workspace's own handle for it. No
+  // active cluster means no Helm screen to open, so nothing is counted at all.
+  //
+  // Derived here, in the component body, and never inside a snapshot getter —
+  // see the note above about identity and "Maximum update depth exceeded".
+  const clusterOps = ctx ? helmOps.filter((o) => o.context === ctx.name) : [];
   // In flight means `running` and nothing else. A `done` operation has stopped
   // changing the cluster and a `failed` one has stopped trying; both stay
   // listed on the helm screen with their output, and counting either here
   // would report a finished mutation as one still under way — the distinction
   // the dead tunnel and the closed shell above are each already drawing.
-  const runningOps = helmOps.filter((o) => o.state === "running").length;
-  const failedOps = helmOps.filter((o) => o.state === "failed").length;
+  const runningOps = clusterOps.filter((o) => o.state === "running").length;
+  const failedOps = clusterOps.filter((o) => o.state === "failed").length;
 
   const segments: StatusSegment[] = [
     {
@@ -152,10 +176,10 @@ export function Status({ contexts }: { contexts: ClusterContext[] }) {
   }
   // The `pf-dead` exception again, and for a bigger stake than a tunnel. A
   // `helm upgrade` that failed is a cluster mutation that half-happened, and
-  // the dialog that would have said so has closed — this is the only surface
-  // left that reports it at all. The count beside it cannot: a failed
-  // operation leaves nothing in flight, which is exactly what a reader who
-  // started no operation sees.
+  // the dialog that would have said so has closed — for the cluster this strip
+  // names, this is the only surface left that reports it at all. The count
+  // beside it cannot: a failed operation leaves nothing in flight, which is
+  // exactly what a reader who started no operation sees.
   //
   // Neither of these labels is a status word, so neither wants one from core:
   // `helmStatus` tones the word Helm puts in a release Secret, and these are

--- a/packages/ui-next/src/shell/Status.tsx
+++ b/packages/ui-next/src/shell/Status.tsx
@@ -8,6 +8,7 @@ import {
 } from "@srelens/core";
 import { StatusBar, type StatusSegment } from "@srelens/ui-kit";
 import { useConsole } from "../console";
+import { getHelmOps, subscribeHelmOps } from "../lib/helmOps";
 import { useInfo } from "../lib/probe";
 import { getSessions, subscribeSessions } from "../lib/sessions";
 import { openTab, useActiveCluster } from "../lib/tabsStore";
@@ -42,6 +43,18 @@ import { LINK_TONE, LINK_WORD, useWorkspaceView } from "../lib/workspace";
  * that one is ui-next's own rather than core's (it holds the xterm instance),
  * but read the same way: `useSyncExternalStore` over a module-level snapshot,
  * so a session outliving the Terminals screen keeps being counted here too.
+ *
+ * The helm readouts are the third of these, and the one with the least excuse
+ * for being anywhere else: a `helm upgrade --wait` runs for minutes and
+ * outlives the dialog that started it, so once that dialog closes this strip
+ * is the only surface reporting a cluster that is still being changed.
+ *
+ * All three snapshots are read raw and counted afterwards. Filtering inside a
+ * `useSyncExternalStore` getter would hand React a fresh array on every read,
+ * which it compares by identity — "Maximum update depth exceeded", and a
+ * streaming helm operation prints often enough to make that a hang rather
+ * than a waste. The stores promise a stable reference; the arithmetic below
+ * is what keeps that promise useful.
  */
 export function Status({ contexts }: { contexts: ClusterContext[] }) {
   const activeId = useActiveCluster();
@@ -50,6 +63,7 @@ export function Status({ contexts }: { contexts: ClusterContext[] }) {
   const { setOpen } = useConsole();
   const forwards = useSyncExternalStore(subscribeForwards, getForwards, getForwards);
   const sessions = useSyncExternalStore(subscribeSessions, getSessions, getSessions);
+  const helmOps = useSyncExternalStore(subscribeHelmOps, getHelmOps, getHelmOps);
 
   // Found rather than assumed: the active id is persisted and the context list
   // is whatever the machine has now, so an id can outlive the context it named.
@@ -69,6 +83,13 @@ export function Status({ contexts }: { contexts: ClusterContext[] }) {
   // rail to show what died and why; counting it here would say a shell is
   // alive when it is not, the same lesson the tunnel above already carries.
   const liveSessions = sessions.filter((s) => s.state !== "closed").length;
+  // In flight means `running` and nothing else. A `done` operation has stopped
+  // changing the cluster and a `failed` one has stopped trying; both stay
+  // listed on the helm screen with their output, and counting either here
+  // would report a finished mutation as one still under way — the distinction
+  // the dead tunnel and the closed shell above are each already drawing.
+  const runningOps = helmOps.filter((o) => o.state === "running").length;
+  const failedOps = helmOps.filter((o) => o.state === "failed").length;
 
   const segments: StatusSegment[] = [
     {
@@ -127,6 +148,39 @@ export function Status({ contexts }: { contexts: ClusterContext[] }) {
       tone: "info",
       dot: true,
       onSelect: () => openTab("/terminals"),
+    });
+  }
+  // The `pf-dead` exception again, and for a bigger stake than a tunnel. A
+  // `helm upgrade` that failed is a cluster mutation that half-happened, and
+  // the dialog that would have said so has closed — this is the only surface
+  // left that reports it at all. The count beside it cannot: a failed
+  // operation leaves nothing in flight, which is exactly what a reader who
+  // started no operation sees.
+  //
+  // Neither of these labels is a status word, so neither wants one from core:
+  // `helmStatus` tones the word Helm puts in a release Secret, and these are
+  // counts of what this window is running. The tones are the strip's own,
+  // shared with the two readouts above — `sev` for news of a failure, `info`
+  // for a count of live work — rather than a helm vocabulary invented here.
+  if (failedOps > 0) {
+    end.push({
+      id: "helm-dead",
+      label: `${plural(failedOps, "helm operation")} failed`,
+      tone: "sev",
+      dot: true,
+      onSelect: () => openTab("/helm"),
+    });
+  }
+  // Absent at zero, following the shells segment rather than the forwards one:
+  // a reader with no helm operation has nothing to be sent to `/helm` for, and
+  // `0 helm operations` is the longest way yet of saying nothing.
+  if (runningOps > 0) {
+    end.push({
+      id: "helm",
+      label: plural(runningOps, "helm operation"),
+      tone: "info",
+      dot: true,
+      onSelect: () => openTab("/helm"),
     });
   }
   end.push({ id: "ask", label: "Ask", tone: "accent", onSelect: () => setOpen(true) });

--- a/packages/ui-next/src/shell/Window.test.tsx
+++ b/packages/ui-next/src/shell/Window.test.tsx
@@ -100,7 +100,7 @@ import { resetProbes } from "../lib/probe";
 import { resetView } from "../lib/workspace";
 import { defaultState, makeTab } from "../lib/tabs";
 import { defaultMark, getMark, setMark, MARKS_KEY } from "../lib/marks";
-import { contextFor, resetContexts } from "../lib/clusters";
+import { contextFor, getContextsError, getContextsStatus, resetContexts } from "../lib/clusters";
 
 const ctx = (stableId: string, name = stableId) => ({ name, stableId, cluster: name, server: "", isCurrent: false });
 
@@ -272,6 +272,33 @@ describe("Window cluster list error", () => {
     listContexts.mockResolvedValue({ error: "kubeconfig unreadable" });
     await booted();
     expect(screen.getByRole("img", { name: "kubeconfig unreadable" })).toBeDefined();
+  });
+
+  it("hands the reason to the store, so the screens can say it too and not blame the reader", async () => {
+    listContexts.mockResolvedValue({ error: "kubeconfig unreadable" });
+    await booted();
+    expect(getContextsStatus()).toBe("failed");
+    expect(getContextsError()).toBe("kubeconfig unreadable");
+  });
+
+  it("treats a listing that rejects as a failed listing, not as a cluster-less kubeconfig", async () => {
+    // The `outcome.error` path was the only one being reported. A rejection
+    // left the store reading "listed, and there are none" — which is the
+    // reader's-fault sentence again, for a failure they cannot act on.
+    listContexts.mockRejectedValue(new Error("kubeconfig unreadable"));
+    await booted();
+    expect(getContextsStatus()).toBe("failed");
+    expect(getContextsError()).toContain("kubeconfig unreadable");
+    expect(screen.getByRole("img", { name: /kubeconfig unreadable/ })).toBeDefined();
+  });
+
+  it("keeps a listing that worked out of the failed state when the workspaces are what fail", async () => {
+    loadTabsState.mockImplementation(() => {
+      throw new Error("storage refuses reads");
+    });
+    await booted();
+    expect(getContextsStatus()).toBe("loaded");
+    expect(getContextsError()).toBe("");
   });
 });
 

--- a/packages/ui-next/src/shell/Window.tsx
+++ b/packages/ui-next/src/shell/Window.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
+  cleanErrorMessage,
   isApplePlatform,
   isTauri,
   listContexts,
@@ -8,7 +9,7 @@ import {
   type ClusterContext,
 } from "@srelens/core";
 import { Button, Checkbox, Drawer, LoadingState, TabStrip, TextInput, type ContextMenuItem, type StripTab } from "@srelens/ui-kit";
-import { setContexts, setKubeconfigFiles, useContexts } from "../lib/clusters";
+import { setContexts, setKubeconfigFiles, useContexts, useContextsError } from "../lib/clusters";
 import { loadColumnPrefs } from "../lib/columnPrefs";
 import { loadRecentLogSubjects } from "../lib/logRecents";
 import { loadMarks } from "../lib/marks";
@@ -95,7 +96,14 @@ export function Window({
   // Kept rather than dropped once read: a failed list still preserves the
   // saved cluster ids (see below), and the rail has to say why it cannot draw
   // them rather than leaving the user to guess.
-  const [contextsError, setContextsError] = useState<string | undefined>(undefined);
+  //
+  // In the store rather than in local state, and for the same reason the list
+  // itself moved there: the rail is not the only surface that has to explain
+  // this. Every screen's no-cluster guard was blaming the reader for it —
+  // "pick a cluster in the rail", for clusters the rail could not draw either
+  // — and a screen receives only `{ route }`, so a copy held here can never
+  // reach one. See `NoClusterScreen`.
+  const contextsError = useContextsError();
   const [creating, setCreating] = useState(false);
   const [name, setName] = useState("");
   const [picked, setPicked] = useState<Set<string>>(new Set());
@@ -161,13 +169,23 @@ export function Window({
       const files = isTauri() ? loadKubeconfigFiles() : [];
       setKubeconfigFiles(files);
       let found: ClusterContext[] = [];
+      // Held next to `found` and installed with it: the list and the reason it
+      // is short are one fact, and the store takes them together so no render
+      // can catch one without the other.
+      let failure = "";
+      // Which half of this `try` a throw came out of. The two are not
+      // interchangeable: `listContexts` rejecting means there are no contexts
+      // and this is why, while anything thrown after it means the workspaces
+      // could not be restored and the contexts are fine.
+      let listed = false;
       try {
         const outcome = await listContexts(files);
         if (cancelled) return;
         found = outcome.contexts ?? [];
-        if (outcome.error) setContextsError(outcome.error);
+        failure = outcome.error ?? "";
+        listed = true;
         const saved = loadTabsState();
-        if (saved && outcome.error) {
+        if (saved && failure !== "") {
           // The list failed, not the clusters: reconciling against nothing would
           // strip every workspace's cluster ids and the next change would persist
           // that. Trust the disk until the backend answers — unless there is
@@ -183,10 +201,11 @@ export function Window({
         }
       } catch (error) {
         if (cancelled) return;
-        console.error("could not restore the workspaces", error);
+        if (!listed) failure = cleanErrorMessage(error);
+        console.error(listed ? "could not restore the workspaces" : "could not list the contexts", error);
         setState(defaultState(found));
       }
-      setContexts(found);
+      setContexts(found, failure);
       setBooted(true);
     })();
     return () => {
@@ -333,7 +352,9 @@ export function Window({
         />
       )}
       <div className="flex min-h-0 flex-1">
-        {active && <Rail contexts={contexts} error={contextsError} onConnect={() => openTab("/connect")} />}
+        {active && (
+          <Rail contexts={contexts} error={contextsError || undefined} onConnect={() => openTab("/connect")} />
+        )}
         {active && <Nav contexts={contexts} />}
         {/* `min-w-0` as well as `min-h-0`. This column holds the tab strip
             and the screen, and a flex item's implicit `min-width: auto`


### PR DESCRIPTION
Ports Helm onto `packages/ui-next` — the last of step 7's three specs, and the last of classic's bottom-dock kinds. Closes the dock: `logs` went in #344, `terminal`/`shell` in #352, `helm` here.

This is the only genuinely destructive surface in the migration, so most of the work below is about not lying to the reader about what is going to happen.

## What ships

- **A status verdict in core** (`helmStatus`) — helm's set is a passthrough string, not a closed enum, so an unrecognised status renders as the word helm gave, toned neutral. Not healthy, not broken.
- **A `revision` parameter** through Rust and core, so a release can be read at an earlier revision. A missing revision errors; there is deliberately no fallback, because falling back to the current one would diff a manifest against itself and report "no changes" about a release that changed.
- **`DiffLines` in the kit** — a presentational diff over `DiffRow[]`. Classic's `DiffView` did **not** move: it takes a `DiffDoc` and renders a manifest dry-run, which is a different component for a different job.
- **A module-level operation store** — `helm upgrade --wait` runs for minutes and outlives the dialog that started it. This is the third such store, after port-forwards and terminal sessions.
- **The four-mode dialog** (install / upgrade / rollback / uninstall) with two gates classic never had: uninstall requires the release name typed exactly, rollback asks once.
- **The operation-or-diff pane**, a failures register, the screen, two status-strip segments, and routing.

## Things worth a reviewer's attention

**Nothing offers to cancel, and the reason is not the obvious one.** The store's own comment used to say that closing a handle "touches the release not at all". That was false: closing aborts the task owning helm's child process, spawned `kill_on_drop(true)`, so it SIGKILLs helm wherever it had reached. No live path reaches it today; the comment now states it as a rule to keep, and a test holds the export list so a new export cannot appear without its author reading that rule.

**A failed operation stays until dismissed, and is readable wherever the strip counts it.** The strip's principle is that a segment counts what the screen it opens can show — so `/helm` grew a failures register scoped exactly as the segment is, and by nothing else.

**Copy that claimed more than srelens knows.** Four instances found and fixed: a rollback hint saying "no history" when history existed; the uninstall alert stating object counts never fetched; a footer naming a revision the dialog could not honour; and an `Equivalent command` omitting the `--values` the backend appends — copy that line into a terminal and you got an upgrade with no values.

**`Upgrade` used to reset a release to chart defaults.** It sent no values, and helm's default for that is to discard the user's. Classic seeded the editor from the release; this now does too.

## Also fixed here, pre-existing and separable

- **"No cluster in focus" shown when a cluster was in focus** — the contexts store had no loaded-or-failed signal, so "still loading" and "the listing failed" both rendered as an accusation. A rejecting `listContexts` was swallowed entirely. Affects every screen, not just this one.
- **Tables wobbled and scrolled unevenly** — `.tbl td` had no tabular figures, so one changed digit in a live CPU or memory cell dragged every digit before it (measured: 2.85px). Separately the virtualizer sized the list from the first rendered row, which sits under a spacer and is 0.375px short — swinging the scroll extent by 545px on 1500 rows. Both arrived with the Table port, not with this branch.

## Verification

`vitest` 4659 passing; coverage 92.18 / 88.35 / 81.65 against floors 85 / 80 / 76; `pnpm -r typecheck`; 568 cargo tests; `cargo build`; `pnpm build`.

Every task ran a mutation pass. Those caught three real bugs rather than only weak tests: a "no changes" state that printed the whole manifest back as context, a re-list that skipped failed operations, and a dismiss that cleared the register while leaving the strip counting.

The status strip was measured at the 960px minimum window rather than estimated — it overflowed at 1036px and clipped `Ask` unreachably, since `body` is `overflow: hidden`. Fixed with the tab strip's own scroll policy.

## Not photographed

The demo cluster has zero Helm releases and nothing was installed to make a screenshot prettier. The populated table and the clipped action column were caught from a real cluster with 383 releases; the diff pane at 11px remains unverified by eye.

## Follow-ups filed, not smuggled in

Dialogs are window-modal and block tab switching — its own PR next, and note it invalidates a wrong-cluster clearance this review relied on. Plus: `sessions.ts` has the handle-after-settle leak this branch fixed in its own copy; the kit's `Field` folds its hint into the label's accessible name; `tokens-only.test.ts` catches hex but not `rgb()` or palette classes; the table's resize observer has never attached, so auto-sized tables never re-fit.
