### PR TITLE
fix(ui-next): keep a dialog in the tab it belongs to

### DIFF
--- a/packages/ui-kit/src/ColumnPicker.test.tsx
+++ b/packages/ui-kit/src/ColumnPicker.test.tsx
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
 import { ColumnPicker, type ColumnOption } from "./ColumnPicker";
+import { PortalScopeProvider, usePortalHost } from "./portal";
 
 // jsdom has no ResizeObserver, and Radix's popper watches the trigger and the
 // content with one. The kit's shared setup does not stub it — nothing in the
@@ -243,5 +245,84 @@ describe("ColumnPicker's appearance", () => {
     await open();
     const panel = screen.getByRole("group").parentElement as HTMLElement;
     expect(panel.style.position).toBe("relative");
+  });
+});
+
+/** A tab-sized surface that owns the layers opened inside it, as `TabSurface` does. */
+function Surface({ children }: { children: ReactNode }) {
+  const { ref, scope } = usePortalHost();
+  return (
+    <div data-testid="surface">
+      <PortalScopeProvider scope={scope}>
+        <div data-testid="content">{children}</div>
+        <div data-testid="host" ref={ref} />
+      </PortalScopeProvider>
+    </div>
+  );
+}
+
+/**
+ * The node the layer was portalled into.
+ *
+ * Radix's `Portal` renders a div of its own as a direct child of the container
+ * and the popper adds another inside that, so the container is never the
+ * content's parent. Matching the outermost portalled element and taking *its*
+ * parent names the container exactly, where "somewhere in the document" would
+ * also pass for a container that was wrong but still attached.
+ */
+function mountedIn(node: Element): Element | null {
+  return node.closest("body > *, [data-testid='host'] > *")?.parentElement ?? null;
+}
+
+async function openInSurface() {
+  const onToggle = vi.fn();
+  const view = render(
+    <Surface>
+      <ColumnPicker columns={COLUMNS} hidden={new Set<string>()} onToggle={onToggle} pinnedKey="name" />
+    </Surface>,
+  );
+  await userEvent.click(trigger());
+  await screen.findByRole("group");
+  return { onToggle, ...view };
+}
+
+const columnPanel = () => screen.getByRole("dialog");
+
+/**
+ * A panel anchored to a toolbar button belongs to the tab that toolbar is in.
+ *
+ * The window is a strip of tabs over one screen each, all of them mounted at
+ * once with the inactive ones hidden by the `hidden` attribute — which a portal
+ * to `document.body` escapes. So the column list opened over one table stayed
+ * on screen over whatever tab the reader moved to, with its trigger and its
+ * table already gone. (#357)
+ *
+ * The container is the whole change. Radix's Popover is already non-modal and
+ * already dismisses on an outside interaction, which is the right answer for a
+ * panel and is why none of the dialog's other treatment applies here.
+ */
+describe("ColumnPicker inside a surface", () => {
+  it("mounts into the surface's own node, so hiding the tab hides it too", async () => {
+    await openInSurface();
+    expect(mountedIn(columnPanel())).toBe(screen.getByTestId("host"));
+  });
+
+  it("mounts into the document body when there is no surface", async () => {
+    // The fallback the gallery, the frozen classic app and most of this kit's
+    // own tests rely on, and it must stay exactly as it was.
+    await open();
+    expect(mountedIn(columnPanel())).toBe(document.body);
+  });
+
+  it("still toggles a column from inside the surface", async () => {
+    const { onToggle } = await openInSurface();
+    await userEvent.click(screen.getByRole("checkbox", { name: "Status" }));
+    expect(onToggle).toHaveBeenCalledWith("status");
+  });
+
+  it("still closes on Escape", async () => {
+    await openInSurface();
+    fireEvent.keyDown(document.activeElement ?? document.body, { key: "Escape" });
+    await waitFor(() => expect(screen.queryByRole("group")).toBeNull());
   });
 });

--- a/packages/ui-kit/src/ColumnPicker.tsx
+++ b/packages/ui-kit/src/ColumnPicker.tsx
@@ -1,6 +1,7 @@
 import { Popover } from "radix-ui";
 import { Button } from "./Button";
 import { cx } from "./cx";
+import { usePortalContainer } from "./portal";
 import { filled } from "./slot";
 
 export interface ColumnOption {
@@ -38,6 +39,14 @@ export interface ColumnPickerProps {
  * hidden set through the pin, because that set outlives the layout it was
  * written for — a persisted set can still name a column that has since become
  * the identifier, and neither the checkbox nor the count may believe it.
+ *
+ * Inside a portal scope — one tab of a window that holds several — the panel
+ * mounts into the tab's own node rather than the document body, so it is hidden
+ * with the tab. A portal escapes the `hidden` attribute an inactive tab wears,
+ * so the column list opened over one table used to stay on screen over the next
+ * tab, with the toolbar it belonged to already gone. Nothing else changes: this
+ * popover is already non-modal and already dismisses on an outside interaction,
+ * which is right for a panel. Outside a scope nothing changes at all. (#357)
  */
 export function ColumnPicker({
   columns,
@@ -53,6 +62,7 @@ export function ColumnPicker({
   // matching what is on screen is what lets a speech-input user say it, and the
   // fallback appears only when nothing is on screen to say. (#318 review)
   const named = filled(label);
+  const container = usePortalContainer();
   return (
     <Popover.Root>
       <Popover.Trigger asChild>
@@ -88,7 +98,7 @@ export function ColumnPicker({
           )}
         </Button>
       </Popover.Trigger>
-      <Popover.Portal>
+      <Popover.Portal container={container}>
         <Popover.Content
           align="end"
           sideOffset={6}

--- a/packages/ui-kit/src/ConfirmDialog.test.tsx
+++ b/packages/ui-kit/src/ConfirmDialog.test.tsx
@@ -305,7 +305,7 @@ describe("ConfirmDialog inside a surface", () => {
     expect(screen.getByRole("dialog").parentElement).toBe(document.body);
   });
 
-  it("covers only its surface: the overlay is positioned against the tab, not the window", () => {
+  it("positions its overlay against the tab, not the window", () => {
     openInSurface();
     expect(overlay().className).toContain("absolute");
     expect(overlay().className).not.toContain("fixed");
@@ -317,7 +317,7 @@ describe("ConfirmDialog inside a surface", () => {
     expect(screen.getByRole("dialog").className).not.toContain("fixed");
   });
 
-  it("still covers the whole window when there is no surface", () => {
+  it("positions its overlay against the window when there is no surface", () => {
     open();
     expect(overlay().className).toContain("fixed");
     expect(overlay().className).not.toContain("absolute");
@@ -341,12 +341,12 @@ describe("ConfirmDialog inside a surface", () => {
     }
   });
 
-  it("makes its own tab's content unreachable while it is open", () => {
+  it("marks its own tab's content inert while it is open", () => {
     openInSurface();
     expect(screen.getByTestId("content").hasAttribute("inert")).toBe(true);
   });
 
-  it("gives the tab's content back when it is answered", () => {
+  it("clears its own tab's inert mark when it is answered", () => {
     // Rerendered rather than remounted: a fresh surface would start clear
     // whatever the dialog had done to the old one, so it would pass even if
     // the hold were never released.
@@ -437,5 +437,196 @@ describe("ConfirmDialog inside a surface", () => {
 
     unmount();
     await waitFor(() => expect(document.activeElement).toBe(opener));
+  });
+});
+
+function setupTabbing(inSurface: boolean, props: Partial<Parameters<typeof ConfirmDialog>[0]> = {}) {
+  const onCancel = vi.fn();
+  const dialog = (
+    <ConfirmDialog
+      title="Delete pod?"
+      message="This cannot be undone."
+      confirmLabel="Delete"
+      danger
+      onConfirm={() => {}}
+      onCancel={onCancel}
+      {...props}
+    />
+  );
+  const view = render(
+    <>
+      <button type="button">the tab strip</button>
+      {inSurface ? <Surface>{dialog}</Surface> : dialog}
+      <button type="button">the status bar</button>
+    </>,
+  );
+  return { onCancel, ...view };
+}
+
+const named = (name: string) => screen.getByRole("button", { name });
+
+async function pressTabFrom(from: HTMLElement, shift = false) {
+  await waitFor(() => expect(screen.getByRole("dialog").contains(document.activeElement)).toBe(true));
+  from.focus();
+  fireEvent.keyDown(from, { key: "Tab", shiftKey: shift });
+}
+
+/**
+ * Tab is how a keyboard user leaves, and this is the dialog they most need to
+ * leave: every destructive confirmation in the app is this component.
+ *
+ * Scoping it to its tab gave the tab strip back to the pointer only. Radix
+ * hands its focus scope `loop: true` and hardcodes it — the scope loops whether
+ * or not it is trapping — so Tab off the last control came back round to Cancel
+ * and the reader was still shut inside a dialog that no longer had any right to
+ * hold them. The loop cannot be turned off, so it is out-run: the card answers
+ * Tab at its own edge first and moves focus out, and Radix's handler then finds
+ * focus on neither edge and does nothing. (#357 review)
+ *
+ * Outside a surface the loop is still right and is left alone.
+ */
+describe("ConfirmDialog and the Tab key", () => {
+  it("lets Tab off the last control reach the window past the tab", async () => {
+    setupTabbing(true);
+    await pressTabFrom(named("Delete"));
+    expect(document.activeElement).toBe(named("the status bar"));
+  });
+
+  it("lets Shift+Tab off the first control reach the window before the tab", async () => {
+    setupTabbing(true);
+    await pressTabFrom(named("Cancel"), true);
+    expect(document.activeElement).toBe(named("the tab strip"));
+  });
+
+  it("leaves Tab inside the card alone", async () => {
+    // Not an edge, so nothing here should touch it: the browser moves focus,
+    // and jsdom's does not, which is exactly what makes this assertable.
+    setupTabbing(true);
+    await pressTabFrom(named("Cancel"));
+    expect(document.activeElement).toBe(named("Cancel"));
+  });
+
+  it("does not cancel itself when the reader tabs out of it", async () => {
+    // Leaving is the thing that was asked for. It is not an answer to the
+    // question, the same way clicking the tab strip is not.
+    const { onCancel } = setupTabbing(true);
+    await pressTabFrom(named("Delete"));
+    await waitFor(() => expect(document.activeElement).toBe(named("the status bar")));
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("keeps looping when there is nothing outside the tab to reach", async () => {
+    // The fallback: with no neighbour, out-running the loop would strand focus
+    // on nothing, so the loop is left to do its job.
+    render(
+      <Surface>
+        <ConfirmDialog
+          title="Delete pod?"
+          message="m"
+          confirmLabel="Delete"
+          onConfirm={() => {}}
+          onCancel={() => {}}
+        />
+      </Surface>,
+    );
+    await pressTabFrom(named("Delete"));
+    expect(document.activeElement).toBe(named("Cancel"));
+  });
+
+  it("still loops inside itself when there is no surface", async () => {
+    // A confirmation with no tab around it is modal over the whole document,
+    // and being the only reachable thing is what that means.
+    setupTabbing(false);
+    await pressTabFrom(named("Delete"));
+    expect(document.activeElement).toBe(named("Cancel"));
+  });
+
+  it("lets the reader leave the tab while the action is in flight", async () => {
+    // `busy` closes every way out of the question, and Tab is not one of them:
+    // it answers nothing. It is also the moment the card holds no tab stop at
+    // all — both controls are disabled — so Radix stops Tab dead on the card
+    // itself, and a reader who cannot leave has nothing left to do but watch a
+    // request they can no longer cancel. (#357 review)
+    setupTabbing(true, { busy: true });
+    await pressTabFrom(screen.getByRole("dialog"));
+    expect(document.activeElement).toBe(named("the status bar"));
+  });
+
+  it("still holds the reader while an unscoped action is in flight", async () => {
+    // No tab to go back to: the document-wide modal is the whole window's
+    // question and the loop is right.
+    setupTabbing(false, { busy: true });
+    await pressTabFrom(screen.getByRole("dialog"));
+    expect(document.activeElement).toBe(screen.getByRole("dialog"));
+  });
+});
+
+/** The answer is deferred to the end of the dispatch; this is the end of it. */
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function openTwoTabs() {
+  const onVisible = vi.fn();
+  const onHidden = vi.fn();
+  render(
+    <>
+      <Surface>
+        <ConfirmDialog title="Delete pod?" message="m" onConfirm={() => {}} onCancel={onVisible} />
+      </Surface>
+      <Surface visible={false}>
+        <ConfirmDialog title="Uninstall ingress-nginx?" message="m" onConfirm={() => {}} onCancel={onHidden} />
+      </Surface>
+    </>,
+  );
+  return { onVisible, onHidden };
+}
+
+/**
+ * Escape belongs to the tab the reader is looking at.
+ *
+ * Radix routes it to the highest layer and orders layers by mount, so a
+ * confirmation left open on a tab the reader switched away from swallows the
+ * key from the one they opened afterwards on the tab they are looking at — and
+ * with the first tab's dialog refusing to answer, as it must, nothing at all
+ * happens. Two clicks and a keypress away: the Helm uninstall gate, Workloads,
+ * a delete confirm, back. (#357 review)
+ */
+describe("ConfirmDialog and Escape across tabs", () => {
+  it("answers Escape on the tab on screen, though a hidden tab's dialog opened later", async () => {
+    const { onVisible } = openTwoTabs();
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => expect(onVisible).toHaveBeenCalledTimes(1));
+  });
+
+  it("leaves the hidden tab's own question unanswered", async () => {
+    const { onHidden } = openTwoTabs();
+    fireEvent.keyDown(document, { key: "Escape" });
+    await settle();
+    expect(onHidden).not.toHaveBeenCalled();
+  });
+
+  it("answers once when its tab is the only one with a dialog open", async () => {
+    const onCancel = vi.fn();
+    openInSurface({ onCancel });
+    fireEvent.keyDown(document, { key: "Escape" });
+    await settle();
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("still refuses while its own action is in flight", async () => {
+    // The deferred answer is a second way in, and `busy` has to close it too.
+    const onVisible = vi.fn();
+    render(
+      <>
+        <Surface>
+          <ConfirmDialog title="Delete pod?" message="m" busy onConfirm={() => {}} onCancel={onVisible} />
+        </Surface>
+        <Surface visible={false}>
+          <ConfirmDialog title="Uninstall ingress-nginx?" message="m" onConfirm={() => {}} onCancel={() => {}} />
+        </Surface>
+      </>,
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    await settle();
+    expect(onVisible).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui-kit/src/ConfirmDialog.test.tsx
+++ b/packages/ui-kit/src/ConfirmDialog.test.tsx
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
 import { ConfirmDialog } from "./ConfirmDialog";
+import { PortalScopeProvider, usePortalHost } from "./portal";
 
 function open(props: Partial<Parameters<typeof ConfirmDialog>[0]> = {}) {
   return render(
@@ -241,5 +243,199 @@ describe("ConfirmDialog focus", () => {
     );
     const dialog = screen.getByRole("dialog");
     expect(dialog.contains(document.activeElement), "focus must stay in the modal").toBe(true);
+  });
+});
+
+/** A tab-sized surface that owns the layers opened inside it, as TabSurface does. */
+function Surface({ visible = true, children }: { visible?: boolean; children: ReactNode }) {
+  const { ref, layered, scope } = usePortalHost(visible);
+  return (
+    <div data-testid="surface" hidden={!visible}>
+      <PortalScopeProvider scope={scope}>
+        <div data-testid="content" inert={layered}>
+          {children}
+        </div>
+        <div data-testid="host" ref={ref} />
+      </PortalScopeProvider>
+    </div>
+  );
+}
+
+function openInSurface(props: Partial<Parameters<typeof ConfirmDialog>[0]> = {}, visible = true) {
+  return render(
+    <Surface visible={visible}>
+      <ConfirmDialog
+        title="Delete pod?"
+        message="This cannot be undone."
+        onConfirm={() => {}}
+        onCancel={() => {}}
+        {...props}
+      />
+    </Surface>,
+  );
+}
+
+/**
+ * The same question asked inside one tab of a window that holds several.
+ *
+ * A confirmation portalled to `document.body` covered the tab strip, the
+ * cluster rail and the status bar, and Radix's focus trap and `aria-hidden`
+ * isolation made every other tab unreachable until it was answered — and,
+ * because a portal escapes the `hidden` attribute an inactive tab is hidden
+ * with, it would have followed the reader to whatever tab they moved to. So it
+ * belongs to its tab: mounted in it, covering it and no more, and marking that
+ * tab's own content unreachable rather than the document's. (#357)
+ *
+ * `busy` is untouched by any of it. The action is in flight; every way out of
+ * *this* dialog is still closed. What is now open is the way out of the tab,
+ * which was never what `busy` was protecting.
+ */
+describe("ConfirmDialog inside a surface", () => {
+  it("mounts into the surface's own node, so hiding the tab hides it too", () => {
+    openInSurface();
+    expect(screen.getByRole("dialog").parentElement).toBe(screen.getByTestId("host"));
+  });
+
+  it("mounts into the document body when there is no surface", () => {
+    // The fallback the gallery, the window chrome and most of this kit's tests
+    // rely on. Asserted as the literal parent rather than "somewhere in the
+    // document": a container that was wrong but still attached would pass the
+    // looser check.
+    open();
+    expect(screen.getByRole("dialog").parentElement).toBe(document.body);
+  });
+
+  it("covers only its surface: the overlay is positioned against the tab, not the window", () => {
+    openInSurface();
+    expect(overlay().className).toContain("absolute");
+    expect(overlay().className).not.toContain("fixed");
+  });
+
+  it("centres itself in its surface rather than in the window", () => {
+    openInSurface();
+    expect(screen.getByRole("dialog").className).toContain("absolute");
+    expect(screen.getByRole("dialog").className).not.toContain("fixed");
+  });
+
+  it("still covers the whole window when there is no surface", () => {
+    open();
+    expect(overlay().className).toContain("fixed");
+    expect(overlay().className).not.toContain("absolute");
+    expect(screen.getByRole("dialog").className).toContain("fixed");
+  });
+
+  it("leaves the page outside its tab in the accessibility tree", () => {
+    // The inverse of the unscoped case above. Radix's `aria-hidden` isolation
+    // takes the *whole document* out of the accessibility tree, which is what
+    // made every other tab unreachable. Scoped, the isolation is the surface's
+    // own `inert` instead, and it stops at the tab.
+    const behind = document.createElement("div");
+    behind.innerHTML = "<button>the tab strip</button>";
+    document.body.appendChild(behind);
+    try {
+      openInSurface();
+      expect(behind.getAttribute("aria-hidden")).toBeNull();
+      expect(screen.getByRole("dialog").getAttribute("aria-modal")).toBeNull();
+    } finally {
+      behind.remove();
+    }
+  });
+
+  it("makes its own tab's content unreachable while it is open", () => {
+    openInSurface();
+    expect(screen.getByTestId("content").hasAttribute("inert")).toBe(true);
+  });
+
+  it("gives the tab's content back when it is answered", () => {
+    // Rerendered rather than remounted: a fresh surface would start clear
+    // whatever the dialog had done to the old one, so it would pass even if
+    // the hold were never released.
+    const { rerender } = render(
+      <Surface>
+        <ConfirmDialog title="Delete pod?" message="m" onConfirm={() => {}} onCancel={() => {}} />
+      </Surface>,
+    );
+    expect(screen.getByTestId("content").hasAttribute("inert")).toBe(true);
+    rerender(<Surface><p>the table</p></Surface>);
+    expect(screen.getByTestId("content").hasAttribute("inert")).toBe(false);
+  });
+
+  it("keeps the marker Drawer looks for", () => {
+    openInSurface();
+    expect(document.querySelector('[role="dialog"][data-state="open"]')).not.toBeNull();
+  });
+
+  it("cancels on Escape", () => {
+    const onCancel = vi.fn();
+    openInSurface({ onCancel });
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels on a click on the overlay", async () => {
+    const onCancel = vi.fn();
+    openInSurface({ onCancel });
+    await userEvent.click(overlay());
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cancel when the click lands on the shell outside its tab", async () => {
+    // With the overlay no longer covering the tab strip, switching tabs became
+    // an outside pointer-down, and a non-modal Radix layer dismisses on any of
+    // those. Cancelling a destructive confirmation because the reader looked at
+    // another tab is the wrong answer to a question they never answered. (#357)
+    const strip = document.createElement("button");
+    strip.textContent = "another tab";
+    document.body.appendChild(strip);
+    try {
+      const onCancel = vi.fn();
+      openInSurface({ onCancel });
+      await userEvent.click(strip);
+      expect(onCancel).not.toHaveBeenCalled();
+    } finally {
+      strip.remove();
+    }
+  });
+
+  it("ignores Escape while its tab is hidden", () => {
+    // Radix routes Escape to the layer opened last, not to the one the reader
+    // can see. A hidden tab's question must not answer itself.
+    const onCancel = vi.fn();
+    openInSurface({ onCancel }, false);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("does not cancel on a click inside the dialog", async () => {
+    const onCancel = vi.fn();
+    openInSurface({ onCancel });
+    await userEvent.click(screen.getByRole("dialog"));
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("still ignores Escape while the action is in flight", () => {
+    const onCancel = vi.fn();
+    openInSurface({ busy: true, onCancel });
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("still ignores the overlay while the action is in flight", async () => {
+    const onCancel = vi.fn();
+    openInSurface({ busy: true, onCancel });
+    await userEvent.click(overlay());
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("still moves focus into itself, and back to the opener on close", async () => {
+    render(<button>Delete pod</button>);
+    const opener = screen.getByRole("button", { name: "Delete pod" });
+    opener.focus();
+
+    const { unmount } = openInSurface();
+    expect(screen.getByRole("dialog").contains(document.activeElement)).toBe(true);
+
+    unmount();
+    await waitFor(() => expect(document.activeElement).toBe(opener));
   });
 });

--- a/packages/ui-kit/src/ConfirmDialog.tsx
+++ b/packages/ui-kit/src/ConfirmDialog.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, type ReactNode } from "react";
 import { Dialog } from "radix-ui";
 import { Button } from "./Button";
+import { declineEscape, useScopedEscape, useTabOut } from "./layerKeys";
 import { useOpenLayer } from "./portal";
 import { Spinner } from "./Spinner";
 
@@ -49,7 +50,17 @@ export interface ConfirmDialogProps {
  * part-of-the-page, so it is composed out of three. `busy` is untouched by any
  * of it: the action is in flight and every way out of *this* dialog is still
  * closed. What is now open is the way out of the tab, which is not what `busy`
- * was ever protecting. Outside a scope nothing changes at all. (#357)
+ * was ever protecting — Tab answers nothing, and while the action is in flight
+ * it is the only thing left to press, because both controls are disabled and
+ * Radix stops Tab dead on a card that holds no tab stop at all. Outside a scope
+ * nothing changes at all. (#357)
+ *
+ * Two of Radix's answers do not survive the move and are replaced rather than
+ * turned off, because neither can be: its focus scope loops Tab whether or not
+ * it is trapping, and it routes Escape to the layer that mounted last rather
+ * than to the one the reader can see. Both live in `layerKeys`, shared with
+ * {@link Dialog} — every destructive confirmation in the app is this component,
+ * and a second copy of either is the one that would not get fixed. (#357)
  */
 export function ConfirmDialog({
   title,
@@ -67,6 +78,13 @@ export function ConfirmDialog({
   // question is on screen: it is what puts `inert` on the surface's content.
   const { container, scoped, showing } = useOpenLayer();
   const overlayRef = useRef<HTMLDivElement>(null);
+  const onTabOut = useTabOut(scoped);
+  // Escape, when this tab is the one on screen. `busy` decides the answer is
+  // no, which is not the same as the question having gone to the wrong tab:
+  // this dialog is still the one being asked, and it still refuses.
+  useScopedEscape(scoped, showing, () => {
+    if (!busy) onCancel();
+  });
   const wash = { background: "color-mix(in srgb, var(--canvas-deep) 72%, transparent)" };
 
   // Whether an interaction outside the card was an interaction with this tab.
@@ -157,8 +175,15 @@ export function ConfirmDialog({
           // see: a dialog left open on a tab they switched away from is still
           // mounted and still stacked. A hidden tab's dialog answering that key
           // press is the same bug as a portal escaping `hidden`. (#357)
+          //
+          // The order of these two matters. A hidden tab's question is not the
+          // one being asked, whether or not its own action is in flight, and
+          // saying so is what lets the dialog on screen answer instead; a
+          // silent refusal would leave the reader pressing Escape at a dialog
+          // they can see and getting nothing. (#357 review)
           onEscapeKeyDown={(event) => {
-            if (busy || !showing) event.preventDefault();
+            if (!showing) declineEscape(event);
+            else if (busy) event.preventDefault();
           }}
           onPointerDownOutside={(event) => {
             if (busy) event.preventDefault();
@@ -183,6 +208,7 @@ export function ConfirmDialog({
           onInteractOutside={(event) => {
             if (busy || (scoped && !onOverlay(event.target))) event.preventDefault();
           }}
+          onKeyDown={onTabOut}
         >
           <div className="card-head shrink-0">
             <Dialog.Title className="card-title">{title}</Dialog.Title>

--- a/packages/ui-kit/src/ConfirmDialog.tsx
+++ b/packages/ui-kit/src/ConfirmDialog.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef, type ReactNode } from "react";
+import { useCallback, useEffect, useRef, type ReactNode } from "react";
 import { Dialog } from "radix-ui";
 import { Button } from "./Button";
+import { useOpenLayer } from "./portal";
 import { Spinner } from "./Spinner";
 
 export interface ConfirmDialogProps {
@@ -40,6 +41,15 @@ export interface ConfirmDialogProps {
  * is mounted only while open — the opener is a button elsewhere in the app, so
  * there is no `Dialog.Trigger` to render. They are handled at the two hooks
  * below, `onOpenAutoFocus`/`onCloseAutoFocus` and the `busy` effect. (#324)
+ *
+ * Inside a portal scope — one tab of a window that holds several — the question
+ * belongs to its tab: it mounts in that tab, covers that tab and no more, and
+ * marks that tab's own content `inert` rather than taking the whole document
+ * out of the accessibility tree. Radix has no single flag for modal-within-one-
+ * part-of-the-page, so it is composed out of three. `busy` is untouched by any
+ * of it: the action is in flight and every way out of *this* dialog is still
+ * closed. What is now open is the way out of the tab, which is not what `busy`
+ * was ever protecting. Outside a scope nothing changes at all. (#357)
  */
 export function ConfirmDialog({
   title,
@@ -53,6 +63,16 @@ export function ConfirmDialog({
 }: ConfirmDialogProps) {
   const contentRef = useRef<HTMLDivElement>(null);
   const openerRef = useRef<HTMLElement | null>(null);
+  // Held for as long as this component is mounted, which is as long as the
+  // question is on screen: it is what puts `inert` on the surface's content.
+  const { container, scoped, showing } = useOpenLayer();
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const wash = { background: "color-mix(in srgb, var(--canvas-deep) 72%, transparent)" };
+
+  // Whether an interaction outside the card was an interaction with this tab.
+  const onOverlay = useCallback((target: EventTarget | null) => {
+    return target instanceof Node && overlayRef.current?.contains(target) === true;
+  }, []);
 
   // Confirming disables the button that was just pressed, and the browser then
   // blurs it — with both controls disabled there is no tab stop left, so focus
@@ -70,35 +90,56 @@ export function ConfirmDialog({
   return (
     <Dialog.Root
       open
+      modal={!scoped}
       onOpenChange={(open) => {
         if (!open && !busy) onCancel();
       }}
     >
-      <Dialog.Portal>
-        <Dialog.Overlay
-          data-slot="dialog-overlay"
-          className="fixed inset-0 z-50"
-          style={{ background: "color-mix(in srgb, var(--canvas-deep) 72%, transparent)" }}
-        />
+      <Dialog.Portal container={container}>
+        {scoped ? (
+          // Radix's own Overlay renders nothing at all when `modal` is false,
+          // so a scoped dialog draws its own. Nothing is lost with it: what
+          // that component adds is the body scroll lock and the pointer-events
+          // shield, and both are document-wide answers to a question that now
+          // stops at the tab.
+          <div ref={overlayRef} data-slot="dialog-overlay" className="absolute inset-0 z-50" style={wash} />
+        ) : (
+          <Dialog.Overlay data-slot="dialog-overlay" className="fixed inset-0 z-50" style={wash} />
+        )}
         <Dialog.Content
           ref={contentRef}
           data-slot="dialog-content"
-          // Radix isolates the background with aria-hidden on the surrounding
-          // content, which is stronger than aria-modal — it removes the page
-          // from the accessibility tree rather than asking for it to be
-          // ignored. aria-modal is set anyway: it costs nothing and is what
+          // Unscoped, Radix isolates the background with aria-hidden on the
+          // surrounding content, which is stronger than aria-modal — it removes
+          // the page from the accessibility tree rather than asking for it to
+          // be ignored. aria-modal is set anyway: it costs nothing and is what
           // older assistive technology looks for.
-          aria-modal="true"
-          className="card rise fixed left-1/2 top-1/2 z-50 flex max-h-[calc(100%-3rem)] w-[calc(100%-3rem)] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden outline-none"
+          //
+          // Scoped, it is wrong in the same breath: aria-modal asks assistive
+          // technology to ignore everything outside the dialog, and everything
+          // outside includes the tab strip and the cluster rail, which are the
+          // exact surfaces the reader is meant to keep. The isolation there is
+          // the surface's own `inert`, which stops at the tab.
+          aria-modal={scoped ? undefined : "true"}
+          // The card centres on whatever the overlay covers, so it follows the
+          // overlay: on the tab when there is one, on the window when there is
+          // not. `fixed` inside a tab would centre the card on the window while
+          // the wash behind it covered only the tab.
+          className={`card rise ${scoped ? "absolute" : "fixed"} left-1/2 top-1/2 z-50 flex max-h-[calc(100%-3rem)] w-[calc(100%-3rem)] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden outline-none`}
           style={{ maxWidth: 448 }}
           // Radix returns focus to `Dialog.Trigger` on close, and there is none
           // here: the dialog is mounted by whatever code decided to open it. Its
           // own fallback — the element focused before the dialog mounted — is
-          // the right one, but the modal content cancels that fallback in favour
-          // of the trigger it expects, so with no trigger to focus the opener
+          // the right one, but the content cancels that fallback in favour of
+          // the trigger it expects, so with no trigger to focus the opener
           // never gets focus back. Capture it and restore it. This hook fires
           // before focus moves in, so the opener is still the active element.
           // (#324 review)
+          //
+          // True in both modes, by two different routes: the modal content
+          // cancels the fallback outright, and the non-modal one cancels it
+          // unless this handler has already prevented the event — which it
+          // does, because it has an opener of its own to restore. (#357)
           onOpenAutoFocus={() => {
             const active = document.activeElement;
             openerRef.current = active instanceof HTMLElement ? active : null;
@@ -111,14 +152,36 @@ export function ConfirmDialog({
             if (opener?.isConnected) opener.focus();
           }}
           // Both dismissal paths are blocked while the action is in flight.
+          // Radix listens for Escape on the document and routes it to the
+          // layer opened last, which is not necessarily the one the reader can
+          // see: a dialog left open on a tab they switched away from is still
+          // mounted and still stacked. A hidden tab's dialog answering that key
+          // press is the same bug as a portal escaping `hidden`. (#357)
           onEscapeKeyDown={(event) => {
-            if (busy) event.preventDefault();
+            if (busy || !showing) event.preventDefault();
           }}
           onPointerDownOutside={(event) => {
             if (busy) event.preventDefault();
           }}
+          // What counts as dismissing this dialog, now that the window around
+          // it is live again. A non-modal Radix layer dismisses on *any*
+          // outside pointer-down, and with the overlay no longer covering the
+          // tab strip, switching tabs is one — so the dialog closed the moment
+          // the reader clicked away, losing whatever they had typed on a
+          // surface that is hidden rather than unmounted precisely so it would
+          // survive. The overlay is this tab's own dismiss affordance; the
+          // shell around it — the strip, the cluster rail, the status bar — is
+          // not, so only the overlay answers. Unscoped there is no live chrome
+          // outside the modal at all, and the old behaviour is right.
+          //
+          // This hook and not `onPointerDownOutside`, which would look like the
+          // obvious place: Radix calls this one after it on the pointer path
+          // *and* on its own when focus leaves for a control outside, so it is
+          // the only one of the two that sees every way out. Mutation testing
+          // is what showed the pair was one hook doing the work and one
+          // watching. (#357)
           onInteractOutside={(event) => {
-            if (busy) event.preventDefault();
+            if (busy || (scoped && !onOverlay(event.target))) event.preventDefault();
           }}
         >
           <div className="card-head shrink-0">

--- a/packages/ui-kit/src/ContextMenu.test.tsx
+++ b/packages/ui-kit/src/ContextMenu.test.tsx
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
+import { PortalScopeProvider, usePortalHost } from "./portal";
 
 // jsdom has no ResizeObserver, and Radix's popper watches the trigger and the
 // content with one. The kit's shared setup does not stub it, and that setup is
@@ -197,5 +200,133 @@ describe("ContextMenu is wired to Radix correctly", () => {
     // applies.
     await open();
     expect(screen.getByRole("menu").style.position).toBe("relative");
+  });
+});
+
+/** A tab-sized surface that owns the layers opened inside it, as `TabSurface` does. */
+function Surface({ children }: { children: ReactNode }) {
+  const { ref, scope } = usePortalHost();
+  return (
+    <div data-testid="surface">
+      <PortalScopeProvider scope={scope}>
+        <div data-testid="content">{children}</div>
+        <div data-testid="host" ref={ref} />
+      </PortalScopeProvider>
+    </div>
+  );
+}
+
+/**
+ * The node the layer was portalled into.
+ *
+ * Radix's `Portal` renders a div of its own as a direct child of the container
+ * and the popper adds another inside that, so the container is never the
+ * content's parent. Matching the outermost portalled element and taking *its*
+ * parent names the container exactly, where "somewhere in the document" would
+ * also pass for a container that was wrong but still attached.
+ */
+function mountedIn(node: Element): Element | null {
+  return node.closest("body > *, [data-testid='host'] > *")?.parentElement ?? null;
+}
+
+async function openInSurface() {
+  const view = render(
+    <Surface>
+      <ContextMenu items={ITEMS} label="Tab actions">
+        <button type="button">checkout-api</button>
+      </ContextMenu>
+    </Surface>,
+  );
+  fireEvent.contextMenu(screen.getByText("checkout-api"));
+  await screen.findByRole("menu");
+  return view;
+}
+
+/**
+ * A menu opened in one tab belongs to that tab.
+ *
+ * The window is a strip of tabs over one screen each, all of them mounted at
+ * once with the inactive ones hidden by the `hidden` attribute — which a portal
+ * to `document.body` escapes. So a right-click menu opened in one tab stayed on
+ * screen over whatever tab the reader moved to. (#357)
+ *
+ * A menu is not a dialog and does not get a dialog's treatment: it already
+ * dismisses on an outside interaction, which is right for it, and it holds
+ * nothing the reader typed that leaving the tab would lose. What it does share
+ * with the dialog is Radix's modality — `ContextMenu.Root` defaults to `modal`,
+ * which takes the whole document out of the accessibility tree and switches the
+ * document's pointer events off, so the tab strip and the cluster rail were
+ * unreachable behind a right-click menu for exactly the reason they were
+ * unreachable behind a dialog. Worse once the menu mounts inside the tab: a
+ * menu left open on a tab the reader has switched away from is invisible and
+ * still holding the window hostage.
+ */
+describe("ContextMenu inside a surface", () => {
+  it("mounts into the surface's own node, so hiding the tab hides it too", async () => {
+    await openInSurface();
+    expect(mountedIn(screen.getByRole("menu"))).toBe(screen.getByTestId("host"));
+  });
+
+  it("mounts into the document body when there is no surface", async () => {
+    // The fallback the gallery, the frozen classic app and most of this kit's
+    // own tests rely on, and it must stay exactly as it was.
+    await open();
+    expect(mountedIn(screen.getByRole("menu"))).toBe(document.body);
+  });
+
+  it("leaves the rest of the window in the accessibility tree", async () => {
+    const chrome = document.createElement("div");
+    chrome.innerHTML = "<button>the tab strip</button>";
+    document.body.appendChild(chrome);
+    try {
+      await openInSurface();
+      expect(chrome.getAttribute("aria-hidden")).toBeNull();
+    } finally {
+      chrome.remove();
+    }
+  });
+
+  it("still takes the whole document out of it when there is no surface", async () => {
+    const chrome = document.createElement("div");
+    chrome.innerHTML = "<button>the window chrome</button>";
+    document.body.appendChild(chrome);
+    try {
+      await open();
+      expect(chrome.getAttribute("aria-hidden")).toBe("true");
+    } finally {
+      chrome.remove();
+    }
+  });
+
+  it("leaves the window outside the tab clickable", async () => {
+    // Radix's modal menu switches the document's own pointer events off, so the
+    // first click anywhere outside the menu does nothing but dismiss it. Inside
+    // a tab that costs the reader a click to reach a strip they can see.
+    await openInSurface();
+    expect(document.body.style.pointerEvents).toBe("");
+  });
+
+  it("still blocks the window outside it when there is no surface", async () => {
+    await open();
+    expect(document.body.style.pointerEvents).toBe("none");
+  });
+
+  it("still closes on Escape", async () => {
+    await openInSurface();
+    fireEvent.keyDown(document.activeElement ?? document.body, { key: "Escape" });
+    await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
+  });
+
+  it("still closes on an interaction outside it", async () => {
+    const elsewhere = document.createElement("button");
+    elsewhere.textContent = "the tab strip";
+    document.body.appendChild(elsewhere);
+    try {
+      await openInSurface();
+      await userEvent.click(elsewhere);
+      await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
+    } finally {
+      elsewhere.remove();
+    }
   });
 });

--- a/packages/ui-kit/src/ContextMenu.test.tsx
+++ b/packages/ui-kit/src/ContextMenu.test.tsx
@@ -330,3 +330,48 @@ describe("ContextMenu inside a surface", () => {
     }
   });
 });
+
+/**
+ * A surface whose node has not arrived yet.
+ *
+ * Real for exactly one render: `usePortalHost` holds the node in state, filled
+ * by a ref callback that fires after the render that declared it, so a layer
+ * mounting in the same commit as its surface sees a scope with no container.
+ * Standing it up by hand is the only way to hold that render still. (#357
+ * review)
+ */
+const arriving = { container: undefined, visible: true, hold: () => () => {} };
+
+async function openInArrivingSurface() {
+  const view = render(
+    <PortalScopeProvider scope={arriving}>
+      <ContextMenu items={ITEMS} label="Tab actions">
+        <button type="button">checkout-api</button>
+      </ContextMenu>
+    </PortalScopeProvider>,
+  );
+  fireEvent.contextMenu(screen.getByText("checkout-api"));
+  await screen.findByRole("menu");
+  return view;
+}
+
+describe("ContextMenu before its surface's node arrives", () => {
+  it("is still the tab's menu, not the window's", async () => {
+    // Where to mount and whether there is a surface to be modal within are two
+    // questions, and the container answers only the first: `undefined` means
+    // "document.body" outside a tab and "not yet" inside one. Read as the
+    // second, this render is a window-wide modal — the tab strip and the
+    // cluster rail out of the accessibility tree and the document's pointer
+    // events off — inside a tab that has one.
+    const chrome = document.createElement("div");
+    chrome.innerHTML = "<button>the tab strip</button>";
+    document.body.appendChild(chrome);
+    try {
+      await openInArrivingSurface();
+      expect(chrome.getAttribute("aria-hidden")).toBeNull();
+      expect(document.body.style.pointerEvents).toBe("");
+    } finally {
+      chrome.remove();
+    }
+  });
+});

--- a/packages/ui-kit/src/ContextMenu.tsx
+++ b/packages/ui-kit/src/ContextMenu.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { ContextMenu as Menu } from "radix-ui";
 import type { IconComponent } from "./IconButton";
+import { usePortalContainer } from "./portal";
 
 export type ContextMenuItem =
   | { kind: "sep" }
@@ -68,12 +69,23 @@ export interface ContextMenuProps {
  * and Radix does the rest. What stays ours is the item vocabulary, the icon
  * column that holds its width so the labels line up, and keeping the shortcut
  * hint out of each item's accessible name. (#320)
+ *
+ * Inside a portal scope — one tab of a window that holds several — the menu
+ * belongs to that tab twice over. It mounts into the tab's own node, so it is
+ * hidden with the tab instead of following the reader to the next one, and it
+ * stops being modal, because Radix's menu is modal by default and that took the
+ * whole document out of the accessibility tree and switched the document's
+ * pointer events off — the tab strip and the cluster rail with them. Both
+ * matter, and the second matters more once the first lands: a menu left open on
+ * a tab the reader has switched away from is invisible and would otherwise
+ * still be holding the window. Outside a scope nothing changes. (#357)
  */
 export function ContextMenu({ items, children, label, onOpenChange }: ContextMenuProps) {
+  const container = usePortalContainer();
   return (
-    <Menu.Root onOpenChange={onOpenChange}>
+    <Menu.Root onOpenChange={onOpenChange} modal={container === undefined}>
       <Menu.Trigger asChild>{children}</Menu.Trigger>
-      <Menu.Portal>
+      <Menu.Portal container={container}>
         <Menu.Content
           aria-label={label}
           className="ctx-menu"

--- a/packages/ui-kit/src/ContextMenu.tsx
+++ b/packages/ui-kit/src/ContextMenu.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { ContextMenu as Menu } from "radix-ui";
 import type { IconComponent } from "./IconButton";
-import { usePortalContainer } from "./portal";
+import { usePortalContainer, usePortalScoped } from "./portal";
 
 export type ContextMenuItem =
   | { kind: "sep" }
@@ -82,8 +82,15 @@ export interface ContextMenuProps {
  */
 export function ContextMenu({ items, children, label, onOpenChange }: ContextMenuProps) {
   const container = usePortalContainer();
+  // Not `container === undefined`, which is the same answer for all but one
+  // render and the wrong question in every one of them: undefined means
+  // "document.body" outside a surface and "the node has not arrived yet"
+  // inside one, and the render between a surface mounting and its ref firing
+  // is the second. Read as the first, that render is a window-wide modal
+  // inside a tab that has one. (#357 review)
+  const scoped = usePortalScoped();
   return (
-    <Menu.Root onOpenChange={onOpenChange} modal={container === undefined}>
+    <Menu.Root onOpenChange={onOpenChange} modal={!scoped}>
       <Menu.Trigger asChild>{children}</Menu.Trigger>
       <Menu.Portal container={container}>
         <Menu.Content

--- a/packages/ui-kit/src/Dialog.test.tsx
+++ b/packages/ui-kit/src/Dialog.test.tsx
@@ -263,3 +263,103 @@ describe("Dialog inside a surface", () => {
     opener.remove();
   });
 });
+
+function setupTabbing(inSurface: boolean) {
+  const onClose = vi.fn();
+  const dialog = (
+    <Dialog title="Customise kind-local" onClose={onClose} footer={<button type="button">Done</button>}>
+      <label>
+        Display name
+        <input />
+      </label>
+    </Dialog>
+  );
+  const view = render(
+    <>
+      <button type="button">the tab strip</button>
+      {inSurface ? <Surface>{dialog}</Surface> : dialog}
+      <button type="button">the status bar</button>
+    </>,
+  );
+  return { onClose, ...view };
+}
+
+const named = (name: string) => screen.getByRole("button", { name });
+
+async function pressTabFrom(from: HTMLElement, shift = false) {
+  await waitFor(() => expect(screen.getByRole("dialog").contains(document.activeElement)).toBe(true));
+  from.focus();
+  fireEvent.keyDown(from, { key: "Tab", shiftKey: shift });
+}
+
+/**
+ * Tab is how a keyboard user leaves.
+ *
+ * The rest of the fix gave the reader the tab strip back, and gave it back to
+ * the pointer only: Radix hands its focus scope `loop: true` unconditionally,
+ * so Tab off the last control in the card came back round to the first one and
+ * a keyboard user was still shut in — the one thing the scoping was for. The
+ * flag is hardcoded and there is no prop for it, so the loop is not turned off
+ * but out-run: this component answers Tab at the card's edge first, moves focus
+ * to the neighbour outside, and Radix's own handler then finds focus somewhere
+ * that is neither edge and does nothing. (#357)
+ *
+ * Outside a surface the loop is still right and is left alone — a document-wide
+ * modal is meant to be the only thing you can reach.
+ */
+describe("Dialog and the Tab key", () => {
+  it("lets Tab off the last control reach the window past the tab", async () => {
+    setupTabbing(true);
+    await pressTabFrom(named("Done"));
+    expect(document.activeElement).toBe(named("the status bar"));
+  });
+
+  it("lets Shift+Tab off the first control reach the window before the tab", async () => {
+    setupTabbing(true);
+    await pressTabFrom(named("Close"), true);
+    expect(document.activeElement).toBe(named("the tab strip"));
+  });
+
+  it("leaves Tab inside the card alone", async () => {
+    setupTabbing(true);
+    // Not an edge, so nothing here should touch it: the browser moves focus,
+    // and jsdom's does not, which is exactly what makes this assertable.
+    await pressTabFrom(screen.getByLabelText(/Display name/));
+    expect(document.activeElement).toBe(screen.getByLabelText(/Display name/));
+  });
+
+  it("does not dismiss itself when the reader tabs out of it", async () => {
+    // Leaving is the thing that was asked for. It is not an answer to the
+    // question the dialog is asking, the same way clicking the strip is not.
+    const { onClose } = setupTabbing(true);
+    await pressTabFrom(named("Done"));
+    await waitFor(() => expect(document.activeElement).toBe(named("the status bar")));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("keeps looping when there is nothing outside the tab to reach", async () => {
+    // The fallback: with no neighbour, out-running the loop would strand focus
+    // on nothing, so the loop is left to do its job.
+    const onClose = vi.fn();
+    render(
+      <Surface>
+        <Dialog title="Customise kind-local" onClose={onClose} footer={<button type="button">Done</button>}>
+          <label>
+            Display name
+            <input />
+          </label>
+        </Dialog>
+      </Surface>,
+    );
+    await pressTabFrom(named("Done"));
+    expect(document.activeElement).toBe(named("Close"));
+  });
+
+  it("still loops inside itself when there is no surface", async () => {
+    // A dialog with no tab around it is modal over the whole document, and
+    // being the only reachable thing is what that means.
+    setupTabbing(false);
+    await pressTabFrom(named("Done"));
+    expect(document.activeElement).toBe(named("Close"));
+  });
+});

--- a/packages/ui-kit/src/Dialog.test.tsx
+++ b/packages/ui-kit/src/Dialog.test.tsx
@@ -140,7 +140,7 @@ describe("Dialog inside a surface", () => {
     expect(screen.getByRole("dialog").parentElement).toBe(document.body);
   });
 
-  it("covers only its surface: the overlay is positioned against the tab, not the window", () => {
+  it("positions its overlay against the tab, not the window", () => {
     setupInSurface();
     expect(overlay().className).toContain("absolute");
     expect(overlay().className).not.toContain("fixed");
@@ -152,7 +152,7 @@ describe("Dialog inside a surface", () => {
     expect(screen.getByRole("dialog").className).not.toContain("fixed");
   });
 
-  it("still covers the whole window when there is no surface", () => {
+  it("positions its overlay against the window when there is no surface", () => {
     setup();
     expect(overlay().className).toContain("fixed");
     expect(overlay().className).not.toContain("absolute");
@@ -190,13 +190,13 @@ describe("Dialog inside a surface", () => {
     }
   });
 
-  it("makes the tab's own content unreachable while it is open, and reachable again after", () => {
+  it("marks the tab's own content inert while it is open", () => {
     const { unmount } = setupInSurface();
     expect(screen.getByTestId("content").hasAttribute("inert")).toBe(true);
     unmount();
   });
 
-  it("leaves the tab's content reachable when no dialog is open", () => {
+  it("leaves the tab's content unmarked when no dialog is open", () => {
     render(<Surface><p>the table</p></Surface>);
     expect(screen.getByTestId("content").hasAttribute("inert")).toBe(false);
   });
@@ -361,5 +361,196 @@ describe("Dialog and the Tab key", () => {
     setupTabbing(false);
     await pressTabFrom(named("Done"));
     expect(document.activeElement).toBe(named("Close"));
+  });
+});
+
+/**
+ * Escape belongs to the tab the reader is looking at.
+ *
+ * Radix routes it to the highest layer and orders layers by mount, which is the
+ * right answer for a window that holds one dialog at a time and the wrong one
+ * here: a dialog left open on a tab the reader switched away from is still
+ * mounted, so a dialog opened *after* it — on the tab they are looking at now —
+ * sits below it and never hears the key. Declining is not something a layer can
+ * say from `onEscapeKeyDown`; all it can do is refuse to close, and Radix stops
+ * at the first layer either way. So the refusal is marked as a refusal, and the
+ * visible tab's dialog answers once the key has finished propagating and every
+ * layer has had its say. (#357 review)
+ */
+function setupTwoTabs() {
+  const onVisible = vi.fn();
+  const onHidden = vi.fn();
+  render(
+    <>
+      <Surface>
+        <Dialog title="Customise kind-local" onClose={onVisible}>
+          <input />
+        </Dialog>
+      </Surface>
+      <Surface visible={false}>
+        <Dialog title="Uninstall ingress-nginx" onClose={onHidden}>
+          <input />
+        </Dialog>
+      </Surface>
+    </>,
+  );
+  return { onVisible, onHidden };
+}
+
+/** The answer is deferred to the end of the dispatch; this is the end of it. */
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("Dialog and Escape across tabs", () => {
+  it("answers Escape on the tab on screen, though a hidden tab's dialog opened later", async () => {
+    const { onVisible } = setupTwoTabs();
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => expect(onVisible).toHaveBeenCalledTimes(1));
+  });
+
+  it("leaves the hidden tab's own dialog open", async () => {
+    // It is still that tab's question, and the reader is not looking at it.
+    const { onHidden } = setupTwoTabs();
+    fireEvent.keyDown(document, { key: "Escape" });
+    await settle();
+    expect(onHidden).not.toHaveBeenCalled();
+  });
+
+  it("answers once when its tab is the only one with a dialog open", async () => {
+    // Radix's own routing already closes this case, and the deferred answer
+    // must not close it a second time.
+    const { onClose } = setupInSurface();
+    fireEvent.keyDown(document, { key: "Escape" });
+    await settle();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves the key alone when a layer above it has already answered", async () => {
+    // A select or a popover open inside the card is a Radix layer above this
+    // one, and it takes Escape from its own capture listener on the document.
+    // jsdom can host the mechanism but not the widget, so this stands in for
+    // one: a capture listener registered before either dialog mounts, which is
+    // where such a layer's listener sits.
+    const taken = (event: KeyboardEvent) => {
+      if (event.key === "Escape") event.preventDefault();
+    };
+    document.addEventListener("keydown", taken, true);
+    try {
+      const { onVisible, onHidden } = setupTwoTabs();
+      fireEvent.keyDown(document, { key: "Escape" });
+      await settle();
+      expect(onVisible).not.toHaveBeenCalled();
+      expect(onHidden).not.toHaveBeenCalled();
+    } finally {
+      document.removeEventListener("keydown", taken, true);
+    }
+  });
+
+  it("answers on the dialog opened last inside the tab on screen", async () => {
+    // A dialog that opened a second dialog. The tab on screen owns the key, and
+    // inside that tab the last one opened is still the one on top of it.
+    const first = vi.fn();
+    const second = vi.fn();
+    render(
+      <>
+        <Surface>
+          <Dialog title="Customise kind-local" onClose={first}>
+            <input />
+          </Dialog>
+          <Dialog title="Rename kind-local" onClose={second}>
+            <input />
+          </Dialog>
+        </Surface>
+        <Surface visible={false}>
+          <Dialog title="Uninstall ingress-nginx" onClose={vi.fn()}>
+            <input />
+          </Dialog>
+        </Surface>
+      </>,
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => expect(second).toHaveBeenCalledTimes(1));
+    expect(first).not.toHaveBeenCalled();
+  });
+
+  it("leaves a dialog with no surface of its own to Radix, even when nobody then answers", async () => {
+    // The one pairing this does not compose for, written down rather than
+    // fixed. A dialog with no surface is modal over the whole document, so it
+    // is the one that should answer — and it is deliberately not in this
+    // routing, because putting it there would run this on a path that has no
+    // tabs in it at all: the gallery, the frozen classic app, every test in
+    // this file above the surfaces. So the hidden tab's layer declines, and
+    // there is nobody registered to hand the key on to.
+    //
+    // Reaching it needs the reader to switch tabs and open a second dialog
+    // while a document-wide modal holds the window, which is the one thing such
+    // a modal does not let them do. (#357 review)
+    const unscoped = vi.fn();
+    const hidden = vi.fn();
+    render(
+      <>
+        <Dialog title="Customise kind-local" onClose={unscoped}>
+          <input />
+        </Dialog>
+        <Surface visible={false}>
+          <Dialog title="Uninstall ingress-nginx" onClose={hidden}>
+            <input />
+          </Dialog>
+        </Surface>
+      </>,
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    await settle();
+    expect(unscoped).not.toHaveBeenCalled();
+    expect(hidden).not.toHaveBeenCalled();
+  });
+
+  it("answers nothing when every dialog in the window is on a hidden tab", async () => {
+    const { onClose } = setupInSurface({}, false);
+    fireEvent.keyDown(document, { key: "Escape" });
+    await settle();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});
+
+describe("Dialog's tab order", () => {
+  it("counts a contenteditable body as a control of its own", async () => {
+    // The values editor inside the Helm dialog is CodeMirror, whose content DOM
+    // is `contenteditable` with no tabindex of its own. Missed, the card's last
+    // control is the one before it, and Tab off the real last one falls through
+    // to Radix's loop — back to the top of a dialog the reader is entitled to
+    // leave. (#357 review)
+    const onClose = vi.fn();
+    render(
+      <>
+        <button type="button">the tab strip</button>
+        <Surface>
+          <Dialog title="Uninstall ingress-nginx" onClose={onClose}>
+            <div contentEditable suppressContentEditableWarning data-testid="values" />
+          </Dialog>
+        </Surface>
+        <button type="button">the status bar</button>
+      </>,
+    );
+    await pressTabFrom(screen.getByTestId("values"));
+    expect(document.activeElement).toBe(named("the status bar"));
+  });
+
+  it("ignores a contenteditable that opts out", async () => {
+    // `contenteditable="false"` is not a control, and counting it would make
+    // the card's last control something the browser never stops at.
+    const onClose = vi.fn();
+    render(
+      <>
+        <button type="button">the tab strip</button>
+        <Surface>
+          <Dialog title="Uninstall ingress-nginx" onClose={onClose} footer={<button type="button">Done</button>}>
+            <div contentEditable={false} data-testid="values" />
+          </Dialog>
+        </Surface>
+        <button type="button">the status bar</button>
+      </>,
+    );
+    await pressTabFrom(named("Done"));
+    expect(document.activeElement).toBe(named("the status bar"));
   });
 });

--- a/packages/ui-kit/src/Dialog.test.tsx
+++ b/packages/ui-kit/src/Dialog.test.tsx
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { cleanup, render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
 import { Dialog } from "./Dialog";
+import { PortalScopeProvider, usePortalHost } from "./portal";
 
 function setup(props: Partial<Parameters<typeof Dialog>[0]> = {}) {
   const onClose = vi.fn();
@@ -72,5 +75,191 @@ describe("Dialog", () => {
   it("draws no footer rule when the caller offers no controls", () => {
     setup({ footer: undefined });
     expect(screen.getByRole("dialog").querySelector("[data-slot='dialog-footer']")).toBeNull();
+  });
+});
+
+/** A tab-sized surface that owns the layers opened inside it, as TabSurface does. */
+function Surface({ visible = true, children }: { visible?: boolean; children: ReactNode }) {
+  const { ref, layered, scope } = usePortalHost(visible);
+  return (
+    <div data-testid="surface" hidden={!visible}>
+      <PortalScopeProvider scope={scope}>
+        <div data-testid="content" inert={layered}>
+          {children}
+        </div>
+        <div data-testid="host" ref={ref} />
+      </PortalScopeProvider>
+    </div>
+  );
+}
+
+function setupInSurface(props: Partial<Parameters<typeof Dialog>[0]> = {}, visible = true) {
+  const onClose = vi.fn();
+  const view = render(
+    <Surface visible={visible}>
+      <Dialog title="Customise kind-local" onClose={onClose} {...props}>
+        <label>
+          Display name
+          <input />
+        </label>
+      </Dialog>
+    </Surface>,
+  );
+  return { onClose, ...view };
+}
+
+const overlay = () => document.querySelector('[data-slot="dialog-overlay"]') as HTMLElement;
+
+/**
+ * A dialog opened inside a tab belongs to that tab and to nothing else.
+ *
+ * The window is a strip of tabs over one screen each, all of them mounted at
+ * once. A dialog portalled to `document.body` covered the strip, the cluster
+ * rail and the status bar, and Radix's focus trap and `aria-hidden` isolation
+ * made every other tab unreachable until it was dismissed — and, because a
+ * portal escapes the `hidden` attribute that hides an inactive tab, it would
+ * have followed the reader to whatever tab they moved to. (#357)
+ *
+ * What replaces the trap is not a weaker trap: the reader is *meant* to be able
+ * to leave. The dialog is modal within its tab — an overlay that covers only
+ * the tab, and `inert` on the tab's own content — and non-modal outside it.
+ */
+describe("Dialog inside a surface", () => {
+  it("mounts into the surface's own node, so hiding the tab hides it too", () => {
+    setupInSurface();
+    expect(screen.getByRole("dialog").parentElement).toBe(screen.getByTestId("host"));
+    expect(screen.getByTestId("surface").contains(screen.getByRole("dialog"))).toBe(true);
+  });
+
+  it("mounts into the document body when there is no surface", () => {
+    // The fallback the gallery, the frozen classic app and most of this kit's
+    // tests rely on. Asserted as the literal parent rather than "somewhere in
+    // the document": a container that was wrong but still attached would pass
+    // the looser check.
+    setup();
+    expect(screen.getByRole("dialog").parentElement).toBe(document.body);
+  });
+
+  it("covers only its surface: the overlay is positioned against the tab, not the window", () => {
+    setupInSurface();
+    expect(overlay().className).toContain("absolute");
+    expect(overlay().className).not.toContain("fixed");
+  });
+
+  it("centres itself in its surface rather than in the window", () => {
+    setupInSurface();
+    expect(screen.getByRole("dialog").className).toContain("absolute");
+    expect(screen.getByRole("dialog").className).not.toContain("fixed");
+  });
+
+  it("still covers the whole window when there is no surface", () => {
+    setup();
+    expect(overlay().className).toContain("fixed");
+    expect(overlay().className).not.toContain("absolute");
+    expect(screen.getByRole("dialog").className).toContain("fixed");
+  });
+
+  it("does not claim the whole document as its modal", () => {
+    // `aria-modal` tells assistive technology to ignore everything outside the
+    // dialog — the tab strip and the cluster rail included, which is the exact
+    // thing this change exists to keep reachable. Inside a surface the
+    // isolation is `inert` on that surface's content instead, which stops at
+    // the tab. Outside one there is nothing narrower to scope to, so the
+    // document-wide modal is still right.
+    setupInSurface();
+    expect(screen.getByRole("dialog").getAttribute("aria-modal")).toBeNull();
+    cleanup();
+    setup();
+    expect(screen.getByRole("dialog").getAttribute("aria-modal")).toBe("true");
+  });
+
+  it("leaves the rest of the window in the accessibility tree", () => {
+    // The defect itself. Radix's `aria-hidden` isolation takes the *whole
+    // document* out of the accessibility tree, which is what made the tab
+    // strip, the cluster rail and every other tab unreachable until the dialog
+    // was dismissed. Scoped, the isolation is the surface's own `inert`, and
+    // it stops at the tab.
+    const behind = document.createElement("div");
+    behind.innerHTML = "<button>the tab strip</button>";
+    document.body.appendChild(behind);
+    try {
+      setupInSurface();
+      expect(behind.getAttribute("aria-hidden")).toBeNull();
+    } finally {
+      behind.remove();
+    }
+  });
+
+  it("makes the tab's own content unreachable while it is open, and reachable again after", () => {
+    const { unmount } = setupInSurface();
+    expect(screen.getByTestId("content").hasAttribute("inert")).toBe(true);
+    unmount();
+  });
+
+  it("leaves the tab's content reachable when no dialog is open", () => {
+    render(<Surface><p>the table</p></Surface>);
+    expect(screen.getByTestId("content").hasAttribute("inert")).toBe(false);
+  });
+
+  it("closes on Escape", async () => {
+    const { onClose } = setupInSurface();
+    fireEvent.keyDown(document.activeElement ?? document.body, { key: "Escape" });
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+  });
+
+  it("closes on a click on the overlay", async () => {
+    const { onClose } = setupInSurface();
+    await userEvent.click(overlay());
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not close when the click lands on the shell outside its tab", async () => {
+    // The half of the fix that only appears once the other half works: with
+    // the overlay no longer covering the tab strip, switching tabs became an
+    // outside pointer-down, and a non-modal Radix layer dismisses on any of
+    // those. So a dialog would close the moment the reader clicked away to
+    // another tab — losing whatever they had typed in it, on a surface that is
+    // hidden rather than unmounted precisely so it would survive. The strip,
+    // the cluster rail and the status bar are not this tab's, so an
+    // interaction with them is not an answer to this tab's dialog. (#357)
+    const strip = document.createElement("button");
+    strip.textContent = "another tab";
+    document.body.appendChild(strip);
+    try {
+      const { onClose } = setupInSurface();
+      await userEvent.click(strip);
+      expect(onClose).not.toHaveBeenCalled();
+    } finally {
+      strip.remove();
+    }
+  });
+
+  it("ignores Escape while its tab is hidden", async () => {
+    // Radix listens for Escape on the document and routes it to the top layer,
+    // which is whichever dialog was opened last — not whichever one the reader
+    // can see. A hidden tab's dialog answering a key press meant for the tab on
+    // screen is the same bug as a portal escaping `hidden`, in the keyboard.
+    const { onClose } = setupInSurface({}, false);
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => expect(onClose).not.toHaveBeenCalled());
+  });
+
+  it("does not close on a click inside itself", async () => {
+    const { onClose } = setupInSurface();
+    await userEvent.click(screen.getByRole("dialog"));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("still hands focus back to whatever opened it", async () => {
+    const opener = document.createElement("button");
+    document.body.appendChild(opener);
+    opener.focus();
+
+    const { unmount } = setupInSurface();
+    await waitFor(() => expect(screen.getByRole("dialog").contains(document.activeElement)).toBe(true));
+
+    unmount();
+    await waitFor(() => expect(document.activeElement).toBe(opener));
+    opener.remove();
   });
 });

--- a/packages/ui-kit/src/Dialog.tsx
+++ b/packages/ui-kit/src/Dialog.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useRef, type KeyboardEvent, type ReactNode } from "react";
+import { useCallback, useRef, type ReactNode } from "react";
 import { Dialog as Modal } from "radix-ui";
 import { cx } from "./cx";
+import { declineEscape, useScopedEscape, useTabOut } from "./layerKeys";
 import { useOpenLayer } from "./portal";
 
 export interface DialogProps {
@@ -50,40 +51,11 @@ export interface DialogProps {
  * Composed in one more place than it first looked. Giving the reader the tab
  * strip back gave it back to the pointer only, because Radix's focus scope
  * loops Tab whether or not it is trapping — so a keyboard user was still shut
- * in a dialog that no longer had any right to hold them. See `onTabOut`. (#357)
+ * in a dialog that no longer had any right to hold them. Escape needed the same
+ * kind of composition for the same kind of reason: Radix routes it to the layer
+ * that mounted last, which is not necessarily the one the reader can see. Both
+ * are in `layerKeys`, shared with ConfirmDialog. (#357)
  */
-
-/**
- * Everything the browser would stop at on Tab, in document order.
- *
- * Narrower than a general tab-order model on purpose. This design writes no
- * positive `tabindex`, so document order *is* the order; and the only things
- * that take a control out of the sequence in this window are the three checked
- * here — `disabled`, the `hidden` attribute an inactive tab wears, and the
- * `inert` a surface puts on its own content while a layer covers it. A control
- * hidden by CSS alone would be missed, which is a real limit and a quiet one:
- * it is why the caller below leaves the loop in place rather than moving focus
- * when it is not sure, so the worst case is the behaviour we already had.
- *
- * Radix's own focus guards are the one thing removed rather than counted. It
- * plants a tabbable span at each end of the body to catch focus on its way out
- * to the browser's chrome; they show nothing and do nothing, and landing on one
- * is indistinguishable from focus having vanished. They are also, when the tab
- * holds nothing but the dialog, exactly what sits next to it.
- */
-function tabOrder(): HTMLElement[] {
-  const candidates = document.body.querySelectorAll<HTMLElement>(
-    "a[href],button,input,select,textarea,[tabindex]",
-  );
-  return Array.from(candidates).filter(
-    (el) =>
-      el.tabIndex >= 0 &&
-      !el.hasAttribute("disabled") &&
-      !el.hasAttribute("data-radix-focus-guard") &&
-      el.closest("[inert],[hidden]") === null,
-  );
-}
-
 export function Dialog({ title, children, onClose, footer, maxWidth = 420, closeLabel = "Close", className }: DialogProps) {
   const openerRef = useRef<HTMLElement | null>(null);
   // Held for as long as this component is mounted, which is as long as the
@@ -97,38 +69,11 @@ export function Dialog({ title, children, onClose, footer, maxWidth = 420, close
     return target instanceof Node && overlayRef.current?.contains(target) === true;
   }, []);
 
-  // Tab off either edge of the card, when the card is only as modal as its tab.
-  //
-  // Radix hands its focus scope `loop: true` and hardcodes it — there is no
-  // prop, and its handler does not check `defaultPrevented`, so the loop cannot
-  // be turned off from out here. It can be out-run. Radix's handler acts only
-  // when the *live* focus is on the first or last control in the card, and it
-  // reads that at the moment it runs; this one runs first, because Radix's
-  // `Slot` composes a child's handler ahead of its own. So moving focus out
-  // here leaves Radix's handler looking at a focus that is on neither edge, and
-  // it does nothing.
-  //
-  // Only inside a surface. A dialog with no tab around it is modal over the
-  // whole document, and being the only thing you can reach is what that means.
-  const onTabOut = useCallback(
-    (event: KeyboardEvent<HTMLDivElement>) => {
-      if (!scoped || event.key !== "Tab" || event.altKey || event.ctrlKey || event.metaKey) return;
-      const card = event.currentTarget;
-      const order = tabOrder();
-      const inside = order.filter((el) => card.contains(el));
-      const edge = event.shiftKey ? inside[0] : inside[inside.length - 1];
-      if (edge === undefined || document.activeElement !== edge) return;
-      const at = order.indexOf(edge);
-      const next = order[(at + (event.shiftKey ? -1 : 1) + order.length) % order.length];
-      // Nothing outside the card to go to — the tab is all there is, or the
-      // window's own chrome is not in the list. Leave the loop to it rather
-      // than strand focus.
-      if (next === undefined || card.contains(next)) return;
-      event.preventDefault();
-      next.focus();
-    },
-    [scoped],
-  );
+  // Tab and Escape, both of which Radix answers for the whole window and
+  // neither of which is the whole window's to answer once the dialog belongs to
+  // one tab of it. See `layerKeys`.
+  const onTabOut = useTabOut(scoped);
+  useScopedEscape(scoped, showing, onClose);
 
   return (
     <Modal.Root open modal={!scoped} onOpenChange={(open) => !open && onClose()}>
@@ -217,9 +162,12 @@ export function Dialog({ title, children, onClose, footer, maxWidth = 420, close
           // layer opened last, which is not necessarily the one the reader can
           // see: a dialog left open on a tab they switched away from is still
           // mounted and still stacked. A hidden tab's dialog answering that key
-          // press is the same bug as a portal escaping `hidden`. (#357)
+          // press is the same bug as a portal escaping `hidden`. Refusing is
+          // not enough on its own — Radix stops at the layer it routed to
+          // either way, so the refusal has to be legible to the dialog the
+          // reader can actually see. (#357)
           onEscapeKeyDown={(event) => {
-            if (!showing) event.preventDefault();
+            if (!showing) declineEscape(event);
           }}
           onKeyDown={onTabOut}
         >

--- a/packages/ui-kit/src/Dialog.tsx
+++ b/packages/ui-kit/src/Dialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, type ReactNode } from "react";
+import { useCallback, useRef, type KeyboardEvent, type ReactNode } from "react";
 import { Dialog as Modal } from "radix-ui";
 import { cx } from "./cx";
 import { useOpenLayer } from "./portal";
@@ -45,8 +45,45 @@ export interface DialogProps {
  * content `inert` while the layer is held open. Outside a scope nothing
  * changes at all: the plain document-wide modal is still the right shape for a
  * dialog with no surface to belong to, and every existing call site — the
- * gallery, the window chrome, this kit's own tests — is one of those. (#357)
+ * gallery, the window chrome, this kit's own tests — is one of those.
+ *
+ * Composed in one more place than it first looked. Giving the reader the tab
+ * strip back gave it back to the pointer only, because Radix's focus scope
+ * loops Tab whether or not it is trapping — so a keyboard user was still shut
+ * in a dialog that no longer had any right to hold them. See `onTabOut`. (#357)
  */
+
+/**
+ * Everything the browser would stop at on Tab, in document order.
+ *
+ * Narrower than a general tab-order model on purpose. This design writes no
+ * positive `tabindex`, so document order *is* the order; and the only things
+ * that take a control out of the sequence in this window are the three checked
+ * here — `disabled`, the `hidden` attribute an inactive tab wears, and the
+ * `inert` a surface puts on its own content while a layer covers it. A control
+ * hidden by CSS alone would be missed, which is a real limit and a quiet one:
+ * it is why the caller below leaves the loop in place rather than moving focus
+ * when it is not sure, so the worst case is the behaviour we already had.
+ *
+ * Radix's own focus guards are the one thing removed rather than counted. It
+ * plants a tabbable span at each end of the body to catch focus on its way out
+ * to the browser's chrome; they show nothing and do nothing, and landing on one
+ * is indistinguishable from focus having vanished. They are also, when the tab
+ * holds nothing but the dialog, exactly what sits next to it.
+ */
+function tabOrder(): HTMLElement[] {
+  const candidates = document.body.querySelectorAll<HTMLElement>(
+    "a[href],button,input,select,textarea,[tabindex]",
+  );
+  return Array.from(candidates).filter(
+    (el) =>
+      el.tabIndex >= 0 &&
+      !el.hasAttribute("disabled") &&
+      !el.hasAttribute("data-radix-focus-guard") &&
+      el.closest("[inert],[hidden]") === null,
+  );
+}
+
 export function Dialog({ title, children, onClose, footer, maxWidth = 420, closeLabel = "Close", className }: DialogProps) {
   const openerRef = useRef<HTMLElement | null>(null);
   // Held for as long as this component is mounted, which is as long as the
@@ -59,6 +96,39 @@ export function Dialog({ title, children, onClose, footer, maxWidth = 420, close
   const onOverlay = useCallback((target: EventTarget | null) => {
     return target instanceof Node && overlayRef.current?.contains(target) === true;
   }, []);
+
+  // Tab off either edge of the card, when the card is only as modal as its tab.
+  //
+  // Radix hands its focus scope `loop: true` and hardcodes it — there is no
+  // prop, and its handler does not check `defaultPrevented`, so the loop cannot
+  // be turned off from out here. It can be out-run. Radix's handler acts only
+  // when the *live* focus is on the first or last control in the card, and it
+  // reads that at the moment it runs; this one runs first, because Radix's
+  // `Slot` composes a child's handler ahead of its own. So moving focus out
+  // here leaves Radix's handler looking at a focus that is on neither edge, and
+  // it does nothing.
+  //
+  // Only inside a surface. A dialog with no tab around it is modal over the
+  // whole document, and being the only thing you can reach is what that means.
+  const onTabOut = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (!scoped || event.key !== "Tab" || event.altKey || event.ctrlKey || event.metaKey) return;
+      const card = event.currentTarget;
+      const order = tabOrder();
+      const inside = order.filter((el) => card.contains(el));
+      const edge = event.shiftKey ? inside[0] : inside[inside.length - 1];
+      if (edge === undefined || document.activeElement !== edge) return;
+      const at = order.indexOf(edge);
+      const next = order[(at + (event.shiftKey ? -1 : 1) + order.length) % order.length];
+      // Nothing outside the card to go to — the tab is all there is, or the
+      // window's own chrome is not in the list. Leave the loop to it rather
+      // than strand focus.
+      if (next === undefined || card.contains(next)) return;
+      event.preventDefault();
+      next.focus();
+    },
+    [scoped],
+  );
 
   return (
     <Modal.Root open modal={!scoped} onOpenChange={(open) => !open && onClose()}>
@@ -151,6 +221,7 @@ export function Dialog({ title, children, onClose, footer, maxWidth = 420, close
           onEscapeKeyDown={(event) => {
             if (!showing) event.preventDefault();
           }}
+          onKeyDown={onTabOut}
         >
           <div className="card-head shrink-0">
             <Modal.Title className="card-title min-w-0 truncate">{title}</Modal.Title>

--- a/packages/ui-kit/src/Dialog.tsx
+++ b/packages/ui-kit/src/Dialog.tsx
@@ -1,6 +1,7 @@
-import { useRef, type ReactNode } from "react";
+import { useCallback, useRef, type ReactNode } from "react";
 import { Dialog as Modal } from "radix-ui";
 import { cx } from "./cx";
+import { useOpenLayer } from "./portal";
 
 export interface DialogProps {
   /** Names the dialog, and is drawn as its heading. */
@@ -36,40 +37,81 @@ export interface DialogProps {
  * no `Dialog.Trigger` to render, because whoever decided to open this is
  * somewhere else in the app, so the opener is captured on the way in and
  * focused again on the way out. (#325)
+ *
+ * Inside a portal scope — one tab of a window that holds several — this is
+ * modal within that tab and non-modal outside it, which Radix has no single
+ * flag for, so it is composed: the layer mounts into the tab's own node, the
+ * overlay is `absolute` and covers only the tab, and the tab marks its own
+ * content `inert` while the layer is held open. Outside a scope nothing
+ * changes at all: the plain document-wide modal is still the right shape for a
+ * dialog with no surface to belong to, and every existing call site — the
+ * gallery, the window chrome, this kit's own tests — is one of those. (#357)
  */
 export function Dialog({ title, children, onClose, footer, maxWidth = 420, closeLabel = "Close", className }: DialogProps) {
   const openerRef = useRef<HTMLElement | null>(null);
+  // Held for as long as this component is mounted, which is as long as the
+  // dialog is open: it is what puts `inert` on the surface's own content.
+  const { container, scoped, showing } = useOpenLayer();
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const wash = { background: "color-mix(in srgb, var(--canvas-deep) 72%, transparent)" };
+
+  // Whether an interaction outside the card was an interaction with this tab.
+  const onOverlay = useCallback((target: EventTarget | null) => {
+    return target instanceof Node && overlayRef.current?.contains(target) === true;
+  }, []);
 
   return (
-    <Modal.Root open onOpenChange={(open) => !open && onClose()}>
-      <Modal.Portal>
-        <Modal.Overlay
-          data-slot="dialog-overlay"
-          className="fixed inset-0 z-50"
-          style={{ background: "color-mix(in srgb, var(--canvas-deep) 72%, transparent)" }}
-        />
+    <Modal.Root open modal={!scoped} onOpenChange={(open) => !open && onClose()}>
+      <Modal.Portal container={container}>
+        {scoped ? (
+          // Radix's own Overlay renders nothing at all when `modal` is false,
+          // so a scoped dialog draws its own. Nothing is lost with it: what
+          // that component adds is the body scroll lock and the pointer-events
+          // shield, and both are document-wide answers to a question that now
+          // stops at the tab.
+          <div ref={overlayRef} data-slot="dialog-overlay" className="absolute inset-0 z-50" style={wash} />
+        ) : (
+          <Modal.Overlay data-slot="dialog-overlay" className="fixed inset-0 z-50" style={wash} />
+        )}
         <Modal.Content
           data-slot="dialog-content"
-          // Radix isolates the background with aria-hidden, which is stronger
-          // than aria-modal — it removes the page from the accessibility tree
-          // rather than asking for it to be ignored. aria-modal is set anyway:
-          // it costs nothing and is what older assistive technology looks for.
-          aria-modal="true"
+          // Unscoped, Radix isolates the background with aria-hidden, which is
+          // stronger than aria-modal — it removes the page from the
+          // accessibility tree rather than asking for it to be ignored.
+          // aria-modal is set anyway: it costs nothing and is what older
+          // assistive technology looks for.
+          //
+          // Scoped, it is wrong in the same breath: aria-modal asks assistive
+          // technology to ignore everything outside the dialog, and everything
+          // outside includes the tab strip and the cluster rail, which are the
+          // exact surfaces the reader is meant to keep. The isolation there is
+          // the surface's own `inert`, which stops at the tab.
+          aria-modal={scoped ? undefined : "true"}
           // The body is the caller's, so there is nothing here that reliably
           // describes the dialog. Left undefined rather than pointed at the
           // whole body, which Radix would otherwise read out entire.
           aria-describedby={undefined}
           className={cx(
-            "card rise fixed left-1/2 top-1/2 z-50 flex max-h-[calc(100%-3rem)] w-[calc(100%-3rem)] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden outline-none",
+            "card rise left-1/2 top-1/2 z-50 flex max-h-[calc(100%-3rem)] w-[calc(100%-3rem)] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden outline-none",
+            // The card centres on whatever the overlay covers, so it follows
+            // the overlay: on the tab when there is one, on the window when
+            // there is not. `fixed` inside a tab would centre the card on the
+            // window while the wash behind it covered only the tab.
+            scoped ? "absolute" : "fixed",
             className,
           )}
           style={{ maxWidth }}
           // Radix returns focus to `Dialog.Trigger` on close and there is none
           // here. Its own fallback — whatever was focused before the dialog
-          // mounted — is the right one, but the modal content cancels that
-          // fallback in favour of the trigger it expects, so with no trigger
-          // the opener never gets focus back. This hook fires before focus
-          // moves in, so the opener is still the active element.
+          // mounted — is the right one, but the content cancels that fallback
+          // in favour of the trigger it expects, so with no trigger the opener
+          // never gets focus back. This hook fires before focus moves in, so
+          // the opener is still the active element.
+          //
+          // True in both modes, by two different routes: the modal content
+          // cancels the fallback outright, and the non-modal one cancels it
+          // unless this handler has already prevented the event — which it
+          // does, because it has an opener of its own to restore.
           onOpenAutoFocus={() => {
             const active = document.activeElement;
             openerRef.current = active instanceof HTMLElement ? active : null;
@@ -80,6 +122,34 @@ export function Dialog({ title, children, onClose, footer, maxWidth = 420, close
             // A dialog can outlive the control that opened it. Focusing a
             // detached node does nothing, so leave focus where it falls.
             if (opener?.isConnected) opener.focus();
+          }}
+          // What counts as dismissing this dialog, now that the window around
+          // it is live again. A non-modal Radix layer dismisses on *any*
+          // outside pointer-down, and with the overlay no longer covering the
+          // tab strip, switching tabs is one — so the dialog closed the moment
+          // the reader clicked away, losing whatever they had typed on a
+          // surface that is hidden rather than unmounted precisely so it would
+          // survive. The overlay is this tab's own dismiss affordance; the
+          // shell around it — the strip, the cluster rail, the status bar — is
+          // not, so only the overlay answers. Unscoped there is no live chrome
+          // outside the modal at all, and the old behaviour is right.
+          //
+          // This hook and not `onPointerDownOutside`, which would look like the
+          // obvious place: Radix calls this one after it on the pointer path
+          // *and* on its own when focus leaves for a control outside, so it is
+          // the only one of the two that sees every way out. Mutation testing
+          // is what showed the pair was one hook doing the work and one
+          // watching. (#357)
+          onInteractOutside={(event) => {
+            if (scoped && !onOverlay(event.target)) event.preventDefault();
+          }}
+          // Radix listens for Escape on the document and routes it to the
+          // layer opened last, which is not necessarily the one the reader can
+          // see: a dialog left open on a tab they switched away from is still
+          // mounted and still stacked. A hidden tab's dialog answering that key
+          // press is the same bug as a portal escaping `hidden`. (#357)
+          onEscapeKeyDown={(event) => {
+            if (!showing) event.preventDefault();
           }}
         >
           <div className="card-head shrink-0">

--- a/packages/ui-kit/src/Popover.test.tsx
+++ b/packages/ui-kit/src/Popover.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { FormEvent } from "react";
+import type { FormEvent, ReactNode } from "react";
 import { Popover } from "./Popover";
+import { PortalScopeProvider, usePortalHost } from "./portal";
 
 // jsdom has no ResizeObserver, and Radix's popper watches the trigger and the
 // content with one. The kit's shared setup does not stub it, and that setup is
@@ -207,5 +208,107 @@ describe("Popover's panel", () => {
     // read back through the variable it publishes.
     await open();
     expect(panel().style.maxHeight).toBe("var(--radix-popover-content-available-height)");
+  });
+});
+
+/** A tab-sized surface that owns the layers opened inside it, as `TabSurface` does. */
+function Surface({ children }: { children: ReactNode }) {
+  const { ref, scope } = usePortalHost();
+  return (
+    <div data-testid="surface">
+      <PortalScopeProvider scope={scope}>
+        <div data-testid="content">{children}</div>
+        <div data-testid="host" ref={ref} />
+      </PortalScopeProvider>
+    </div>
+  );
+}
+
+/**
+ * The node the layer was portalled into.
+ *
+ * Radix's `Portal` renders a div of its own as a direct child of the container
+ * and the popper adds another inside that, so the container is never the
+ * content's parent. Matching the outermost portalled element and taking *its*
+ * parent names the container exactly, where "somewhere in the document" would
+ * also pass for a container that was wrong but still attached.
+ */
+function mountedIn(node: Element): Element | null {
+  return node.closest("body > *, [data-testid='host'] > *")?.parentElement ?? null;
+}
+
+async function openInSurface() {
+  const view = render(
+    <Surface>
+      <Popover label="Filters" trigger="Open filters">
+        <p>Only failing pods</p>
+      </Popover>
+    </Surface>,
+  );
+  await userEvent.click(trigger());
+  await screen.findByRole("dialog");
+  return view;
+}
+
+/**
+ * A panel opened in one tab belongs to that tab.
+ *
+ * The window is a strip of tabs over one screen each, all of them mounted at
+ * once with the inactive ones hidden by the `hidden` attribute — which a portal
+ * to `document.body` escapes. So a filter panel opened in one tab stayed on
+ * screen over whatever tab the reader moved to. Its anchor went with the tab
+ * and it did not. (#357)
+ *
+ * Nothing else about it changes, deliberately. Radix's Popover is already
+ * non-modal, already leaves the window outside it live, and already dismisses
+ * on an outside interaction — which is the right answer for a panel, and is why
+ * this gets the container and none of the rest of the dialog's treatment.
+ */
+describe("Popover inside a surface", () => {
+  it("mounts into the surface's own node, so hiding the tab hides it too", async () => {
+    await openInSurface();
+    expect(mountedIn(panel())).toBe(screen.getByTestId("host"));
+  });
+
+  it("mounts into the document body when there is no surface", async () => {
+    // The fallback the gallery, the frozen classic app and most of this kit's
+    // own tests rely on, and it must stay exactly as it was.
+    await open();
+    expect(mountedIn(panel())).toBe(document.body);
+  });
+
+  it("leaves the window outside the tab live, as it always did", async () => {
+    // A panel is not a dialog: it takes nothing away from the window around it,
+    // so there is nothing here to scope. Pinned so that giving it the container
+    // is not mistaken for a licence to give it the rest.
+    const chrome = document.createElement("div");
+    chrome.innerHTML = "<button>the tab strip</button>";
+    document.body.appendChild(chrome);
+    try {
+      await openInSurface();
+      expect(chrome.getAttribute("aria-hidden")).toBeNull();
+      expect(document.body.style.pointerEvents).toBe("");
+    } finally {
+      chrome.remove();
+    }
+  });
+
+  it("still closes on Escape", async () => {
+    await openInSurface();
+    fireEvent.keyDown(document.activeElement ?? document.body, { key: "Escape" });
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+  });
+
+  it("still closes on an interaction outside it", async () => {
+    const elsewhere = document.createElement("button");
+    elsewhere.textContent = "the tab strip";
+    document.body.appendChild(elsewhere);
+    try {
+      await openInSurface();
+      await userEvent.click(elsewhere);
+      await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+    } finally {
+      elsewhere.remove();
+    }
   });
 });

--- a/packages/ui-kit/src/Popover.tsx
+++ b/packages/ui-kit/src/Popover.tsx
@@ -1,6 +1,7 @@
 import { useState, type ReactNode } from "react";
 import { Popover as RadixPopover } from "radix-ui";
 import { cx } from "./cx";
+import { usePortalContainer } from "./portal";
 
 export interface PopoverProps {
   /** What the trigger shows. It is the button's content, and so its name. */
@@ -54,6 +55,15 @@ export interface PopoverProps {
  * has to be able to dismiss itself and nothing else can tell it how; a plain
  * node is accepted too, since most panels are content rather than a form.
  * (#320)
+ *
+ * Inside a portal scope — one tab of a window that holds several — the panel
+ * mounts into the tab's own node rather than the document body, so it is hidden
+ * with the tab. A portal escapes the `hidden` attribute an inactive tab wears,
+ * so a panel opened in one tab used to stay on screen over the next one, still
+ * anchored to a trigger that had gone with the tab. That is the whole change: a
+ * popover is already non-modal and already dismisses on an outside interaction,
+ * which is the right behaviour for it and none of the dialog's business.
+ * Outside a scope nothing changes. (#357)
  */
 export function Popover({
   trigger,
@@ -66,6 +76,7 @@ export function Popover({
   // Held here rather than left to Radix, because `close` is the whole point of
   // the render prop and an uncontrolled root has nothing to hand out.
   const [open, setOpen] = useState(false);
+  const container = usePortalContainer();
 
   return (
     <RadixPopover.Root open={open} onOpenChange={setOpen}>
@@ -77,7 +88,7 @@ export function Popover({
       <RadixPopover.Trigger type="button" className="inline-flex">
         {trigger}
       </RadixPopover.Trigger>
-      <RadixPopover.Portal>
+      <RadixPopover.Portal container={container}>
         <RadixPopover.Content
           // The panel is a dialog by Radix's reckoning; `label` is what it is
           // called. Not repeated on the trigger — see the note above.

--- a/packages/ui-kit/src/Tooltip.test.tsx
+++ b/packages/ui-kit/src/Tooltip.test.tsx
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
 import { Tooltip } from "./Tooltip";
+import { PortalScopeProvider, usePortalHost } from "./portal";
 
 // jsdom has no ResizeObserver, and Radix's popper watches the trigger and the
 // content with one. The kit's shared setup does not stub it, and that setup is
@@ -150,5 +152,82 @@ describe("Tooltip", () => {
     await userEvent.hover(target());
     expect(screen.queryByRole("tooltip")).toBeNull();
     expect(target()).toBeDefined();
+  });
+});
+
+/** A tab-sized surface that owns the layers opened inside it, as `TabSurface` does. */
+function Surface({ children }: { children: ReactNode }) {
+  const { ref, scope } = usePortalHost();
+  return (
+    <div data-testid="surface">
+      <PortalScopeProvider scope={scope}>
+        <div data-testid="content">{children}</div>
+        <div data-testid="host" ref={ref} />
+      </PortalScopeProvider>
+    </div>
+  );
+}
+
+/**
+ * The node the layer was portalled into.
+ *
+ * Radix's `Portal` renders a div of its own as a direct child of the container
+ * and the popper adds another inside that, so the container is never the
+ * content's parent. Matching the outermost portalled element and taking *its*
+ * parent names the container exactly, where "somewhere in the document" would
+ * also pass for a container that was wrong but still attached.
+ */
+function mountedIn(node: Element): Element | null {
+  return node.closest("body > *, [data-testid='host'] > *")?.parentElement ?? null;
+}
+
+async function showInSurface() {
+  const view = render(
+    <Surface>
+      <Tooltip label="Delete this pod">
+        <button type="button">Delete</button>
+      </Tooltip>
+    </Surface>,
+  );
+  await userEvent.tab();
+  await screen.findByRole("tooltip");
+  return view;
+}
+
+/**
+ * A hint belongs to the tab the thing it is about is in.
+ *
+ * The window is a strip of tabs over one screen each, all of them mounted at
+ * once with the inactive ones hidden by the `hidden` attribute — which a portal
+ * to `document.body` escapes. A tooltip is the weakest case for this of the
+ * five layers: it is tied to hover and focus, both of which the browser
+ * normally takes away when the tab it is in is hidden, so most of the time it
+ * closes itself. But "most of the time" is the whole gap — a hint drawn beside
+ * a button that is no longer on screen is a caption on the wrong picture, and
+ * the container costs one line and removes the question. (#357)
+ */
+describe("Tooltip inside a surface", () => {
+  it("mounts into the surface's own node, so hiding the tab hides it too", async () => {
+    await showInSurface();
+    expect(mountedIn(screen.getByRole("tooltip"))).toBe(screen.getByTestId("host"));
+  });
+
+  it("mounts into the document body when there is no surface", async () => {
+    // The fallback the gallery, the frozen classic app and most of this kit's
+    // own tests rely on, and it must stay exactly as it was.
+    setup();
+    await userEvent.tab();
+    await screen.findByRole("tooltip");
+    expect(mountedIn(screen.getByRole("tooltip"))).toBe(document.body);
+  });
+
+  it("still describes its target from inside the surface", async () => {
+    // The portal moved; the wiring that makes the hint reachable at all did
+    // not. `aria-describedby` crosses the portal either way, and this is the
+    // one property of this component that a wrong container could quietly
+    // break.
+    await showInSurface();
+    const tip = screen.getByRole("tooltip");
+    expect(screen.getByRole("button", { name: "Delete" }).getAttribute("aria-describedby")).toBe(tip.id);
   });
 });

--- a/packages/ui-kit/src/Tooltip.tsx
+++ b/packages/ui-kit/src/Tooltip.tsx
@@ -1,5 +1,6 @@
 import { isValidElement, type ReactNode } from "react";
 import { Tooltip as RadixTooltip } from "radix-ui";
+import { usePortalContainer } from "./portal";
 import { filled } from "./slot";
 
 export interface TooltipProps {
@@ -52,8 +53,18 @@ export interface TooltipProps {
  * focusable — around a badge or a truncated string the hint was pointer-only.
  * A single element is used as the target as it stands, and anything else is
  * wrapped in a span that can take focus. (#320)
+ *
+ * Inside a portal scope — one tab of a window that holds several — the bubble
+ * mounts into the tab's own node rather than the document body, so it is hidden
+ * with the tab. This is the weakest of the kit's five portalled layers' cases
+ * for that, and it is taken anyway: a hint lives and dies with hover and focus,
+ * and hiding the tab it is in normally takes both away, so most of the time it
+ * closes itself. Most of the time is the gap. A hint drawn beside a control
+ * that is no longer on screen is a caption on the wrong picture, and one line
+ * makes the question not arise. Outside a scope nothing changes. (#357)
  */
 export function Tooltip({ label, children, side = "top" }: TooltipProps) {
+  const container = usePortalContainer();
   return (
     <RadixTooltip.Provider delayDuration={200}>
       <RadixTooltip.Root>
@@ -75,7 +86,7 @@ export function Tooltip({ label, children, side = "top" }: TooltipProps) {
             unmounting the tree instead would remount the caller's control —
             taking focus off it — every time the label went from empty to not. */}
         {filled(label) && (
-          <RadixTooltip.Portal>
+          <RadixTooltip.Portal container={container}>
             <RadixTooltip.Content
               side={side}
               // `.tip::after` sat at `calc(100% + 5px)`.

--- a/packages/ui-kit/src/gallery/Gallery.test.tsx
+++ b/packages/ui-kit/src/gallery/Gallery.test.tsx
@@ -8,7 +8,14 @@ describe("Gallery", () => {
     // Derived from the barrel rather than a hand-written list, which would
     // drift the first time someone was in a hurry. The catalogue is the only
     // visual review surface this design has.
-    const components = Object.keys(kit).filter((name) => /^[A-Z]/.test(name));
+    //
+    // One name is excused, and it is named rather than pattern-matched so that
+    // the next component someone finds inconvenient to draw cannot excuse
+    // itself: `PortalScopeProvider` renders no DOM at all. It is a context
+    // around a part of the window that owns the layers opened inside it, and a
+    // catalogue entry for it would be an empty heading. (#357)
+    const invisible = new Set(["PortalScopeProvider"]);
+    const components = Object.keys(kit).filter((name) => /^[A-Z]/.test(name) && !invisible.has(name));
     expect(components.length).toBeGreaterThan(0);
     render(<Gallery />);
     for (const name of components) {

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -43,7 +43,14 @@ export { NavIcon, type NavIconProps } from "./NavIcon";
 export { PairList, type PairListProps } from "./PairList";
 export { Panel, type PanelProps } from "./Panel";
 export { Popover, type PopoverProps } from "./Popover";
-export { PortalScopeProvider, useOpenLayer, usePortalContainer, usePortalHost, type PortalScope } from "./portal";
+export {
+  PortalScopeProvider,
+  useOpenLayer,
+  usePortalContainer,
+  usePortalHost,
+  usePortalScoped,
+  type PortalScope,
+} from "./portal";
 export { Progress, type ProgressProps } from "./Progress";
 export { Radio, type RadioProps } from "./Radio";
 export { RawError, type RawErrorProps } from "./RawError";

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -43,6 +43,7 @@ export { NavIcon, type NavIconProps } from "./NavIcon";
 export { PairList, type PairListProps } from "./PairList";
 export { Panel, type PanelProps } from "./Panel";
 export { Popover, type PopoverProps } from "./Popover";
+export { PortalScopeProvider, useOpenLayer, usePortalContainer, usePortalHost, type PortalScope } from "./portal";
 export { Progress, type ProgressProps } from "./Progress";
 export { Radio, type RadioProps } from "./Radio";
 export { RawError, type RawErrorProps } from "./RawError";

--- a/packages/ui-kit/src/layerKeys.ts
+++ b/packages/ui-kit/src/layerKeys.ts
@@ -1,0 +1,237 @@
+import { useCallback, useEffect, useRef, type KeyboardEvent as ReactKeyboardEvent } from "react";
+
+/**
+ * The two keys a dialog scoped to one tab has to answer for itself.
+ *
+ * Radix owns Tab and Escape for a dialog, and both of its answers are right for
+ * a dialog that owns the window: loop focus inside the card, and hand Escape to
+ * whichever layer was opened last. Neither is right for a dialog that owns one
+ * tab of a window that holds several, neither can be turned off from a prop,
+ * and both replacements are small enough to get subtly wrong. {@link Dialog}
+ * and {@link ConfirmDialog} need the same two, so they are here rather than
+ * copied: the second copy is the one that does not get fixed. (#357)
+ *
+ * Nothing here is reachable without a portal scope. A dialog with no surface
+ * around it — the gallery, the frozen classic app, most of this kit's tests —
+ * registers nothing, listens to nothing, and is left entirely to Radix.
+ */
+
+/**
+ * Everything the browser would stop at on Tab, in document order.
+ *
+ * Narrower than a general tab-order model on purpose. This design writes no
+ * positive `tabindex`, so document order *is* the order; and the only things
+ * that take a control out of the sequence in this window are the three checked
+ * here — `disabled`, the `hidden` attribute an inactive tab wears, and the
+ * `inert` a surface puts on its own content while a layer covers it.
+ *
+ * The limit that remains is a control hidden by CSS alone: `display: none`,
+ * `visibility: hidden`, a zero-sized ancestor. Reading that back needs layout,
+ * which is why it is not attempted rather than attempted badly. It is why the
+ * caller below leaves the loop in place when it is unsure, so the worst case is
+ * the behaviour we already had.
+ *
+ * `contenteditable` earns its place in the selector rather than in the list of
+ * things a general model would want: the values editor in the Helm dialog is
+ * CodeMirror, whose content DOM is a `contenteditable` with no tabindex, and it
+ * sits inside a dialog this scoping applies to. The rest — a frame, a summary,
+ * a media control — are here for completeness and cost one selector each.
+ *
+ * Radix's own focus guards are the one thing removed rather than counted. It
+ * plants a tabbable span at each end of the body to catch focus on its way out
+ * to the browser's chrome; they show nothing and do nothing, and landing on one
+ * is indistinguishable from focus having vanished. They are also, when the tab
+ * holds nothing but the dialog, exactly what sits next to it.
+ */
+const TABBABLE = [
+  "a[href]",
+  "area[href]",
+  "button",
+  "input",
+  "select",
+  "textarea",
+  "iframe",
+  "details > summary",
+  "audio[controls]",
+  "video[controls]",
+  "[tabindex]",
+  '[contenteditable]:not([contenteditable="false"])',
+].join(",");
+
+const EDITABLE = '[contenteditable]:not([contenteditable="false"])';
+
+/**
+ * Whether the browser stops at this element, for an element the selector above
+ * already matched.
+ *
+ * `tabIndex` answers it for everything with a `tabindex` attribute, and for
+ * everything the DOM has always agreed is focusable. It is not agreed on for a
+ * `contenteditable` with no `tabindex` of its own — a browser reports 0, jsdom
+ * reports -1 while still letting `focus()` land on it — so that one case is
+ * read off the attribute, which everything agrees about.
+ */
+function tabbable(el: HTMLElement): boolean {
+  if (el.hasAttribute("tabindex")) return el.tabIndex >= 0;
+  return el.tabIndex >= 0 || el.matches(EDITABLE);
+}
+
+export function tabOrder(): HTMLElement[] {
+  const candidates = document.body.querySelectorAll<HTMLElement>(TABBABLE);
+  return Array.from(candidates).filter(
+    (el) =>
+      tabbable(el) &&
+      !el.hasAttribute("disabled") &&
+      !el.hasAttribute("data-radix-focus-guard") &&
+      el.closest("[inert],[hidden]") === null,
+  );
+}
+
+/**
+ * Tab off either edge of a card that is only as modal as its tab.
+ *
+ * Radix hands its focus scope `loop: true` and hardcodes it — there is no prop,
+ * the scope loops whether or not it is trapping, and its handler does not check
+ * `defaultPrevented`, so the loop cannot be turned off from out here. It can be
+ * out-run. Radix's handler acts only when the *live* focus is on the first or
+ * last control in the card, and it reads that at the moment it runs; this one
+ * runs first, because Radix's `Slot` composes a child's handler ahead of its
+ * own. So moving focus out here leaves Radix's handler looking at a focus that
+ * is on neither edge, and it does nothing.
+ *
+ * Returns a handler for the card's own `onKeyDown`. Inert outside a surface: a
+ * dialog with no tab around it is modal over the whole document, and being the
+ * only thing you can reach is what that means. Radix would enforce that anyway
+ * — the focus scope is *trapping* there, and pulls focus straight back out of
+ * anything this moved it to — so the check is what stops the two from fighting
+ * over every Tab rather than what produces the behaviour. It is the one line
+ * here a mutation cannot be made to show. (#357 review)
+ */
+export function useTabOut(scoped: boolean) {
+  return useCallback(
+    (event: ReactKeyboardEvent<HTMLElement>) => {
+      if (!scoped || event.key !== "Tab" || event.altKey || event.ctrlKey || event.metaKey) return;
+      const card = event.currentTarget;
+      const order = tabOrder();
+      const inside = order.filter((el) => card.contains(el));
+      const edge = event.shiftKey ? inside[0] : inside[inside.length - 1];
+      const step = event.shiftKey ? -1 : 1;
+      let from: number;
+      if (edge === undefined) {
+        // No tab stop inside the card at all — every control in it disabled
+        // while an action is in flight. Radix stops Tab dead there, so it is
+        // the case where leaving matters most: there is nothing left in the
+        // card to move to and nothing left in it to do. The card holds focus
+        // itself then, on the `tabindex="-1"` Radix gives it, and it has no
+        // slot in the order of its own, so it borrows the one it is travelling
+        // away from.
+        if (document.activeElement !== card) return;
+        from =
+          order.filter((el) => (card.compareDocumentPosition(el) & Node.DOCUMENT_POSITION_PRECEDING) !== 0).length -
+          (event.shiftKey ? 0 : 1);
+      } else {
+        if (document.activeElement !== edge) return;
+        from = order.indexOf(edge);
+      }
+      const next = order[(from + step + order.length) % order.length];
+      // Nothing outside the card to go to — the tab is all there is, or the
+      // window's own chrome is not in the list. Leave the loop to it rather
+      // than strand focus.
+      if (next === undefined || card.contains(next)) return;
+      event.preventDefault();
+      next.focus();
+    },
+    [scoped],
+  );
+}
+
+interface ScopedLayer {
+  /** Whether this layer's surface is the one on screen. */
+  showing: boolean;
+  /** What answering Escape means for it, including deciding not to. */
+  escape: () => void;
+}
+
+/** Every open scoped layer, in the order they mounted. */
+const layers: ScopedLayer[] = [];
+
+/** Escape key presses a hidden surface's layer refused without claiming. */
+const declined = new WeakSet<Event>();
+
+/**
+ * What a layer on a hidden surface does with an Escape meant for another tab.
+ *
+ * Refusing to close is all Radix lets a layer say, and it is not enough: it
+ * routes the key to the layer that mounted last and stops there, so a dialog
+ * left open on a tab the reader switched away from silently swallows the key
+ * from the dialog they opened afterwards on the tab they are looking at. What
+ * that layer needs to say is that it is not the one being asked, which is not
+ * expressible from `onEscapeKeyDown` — so it is said out here instead, and
+ * {@link useScopedEscape} listens for it. (#357 review)
+ */
+export function declineEscape(event: KeyboardEvent): void {
+  // Only when nothing above has already answered. `defaultPrevented` here means
+  // a real handler — a select open inside the card, a window-wide modal over
+  // it — took the key first, and declining after that would hand a key that is
+  // already spent to a second dialog.
+  if (!event.defaultPrevented) declined.add(event);
+  event.preventDefault();
+}
+
+function answer(event: KeyboardEvent): void {
+  // Answered for real by some layer of Radix's own, this dialog included when
+  // it happened to be the one Radix routed to. Only a decline leaves the key
+  // going spare.
+  if (event.defaultPrevented && !declined.has(event)) return;
+  const top = layers.filter((layer) => layer.showing).at(-1);
+  top?.escape();
+}
+
+function onKeyDown(event: KeyboardEvent): void {
+  if (event.key !== "Escape") return;
+  // Deliberately after the dispatch rather than during it. Every layer decides
+  // in this one dispatch, each from its own capture listener on the document,
+  // in the order they mounted — so during it there is no way to know whether a
+  // layer that has not run yet is about to take the key. Deferring to the end
+  // of it is what makes this independent of that order.
+  queueMicrotask(() => answer(event));
+}
+
+/** One listener for the whole window, for as long as any scoped layer is open. */
+let listening = 0;
+
+/**
+ * Escape for a dialog that belongs to one tab.
+ *
+ * `showing` is what orders the answer: the last-mounted layer whose surface is
+ * on screen is the one the reader is looking at. `onEscape` is called for that
+ * layer alone, and is the caller's chance to decide the answer is no — a
+ * confirmation with its action already in flight closes nothing.
+ *
+ * The one pairing this does not compose for: a dialog with no surface at all,
+ * open at the same time as one inside a tab that has since been hidden. The
+ * unscoped dialog is modal over the whole document, so it is the one that
+ * should answer, and it is not in this list. Reaching it needs the reader to
+ * switch tabs and open a second dialog while a document-wide modal holds the
+ * window, which is the one thing such a modal does not let them do.
+ */
+export function useScopedEscape(scoped: boolean, showing: boolean, onEscape: () => void): void {
+  const layer = useRef<ScopedLayer>({ showing, escape: onEscape }).current;
+
+  // Every commit, because both change with a render rather than with the
+  // registration: the surface is hidden and shown again while the layer stays
+  // mounted, which is the whole point of it.
+  useEffect(() => {
+    layer.showing = showing;
+    layer.escape = onEscape;
+  });
+
+  useEffect(() => {
+    if (!scoped) return;
+    layers.push(layer);
+    if (listening++ === 0) document.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      layers.splice(layers.indexOf(layer), 1);
+      if (--listening === 0) document.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [scoped, layer]);
+}

--- a/packages/ui-kit/src/picker.test.tsx
+++ b/packages/ui-kit/src/picker.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { Picker, PickerRow } from "./picker";
+import { PortalScopeProvider, usePortalHost } from "./portal";
+
+/**
+ * jsdom does not implement the two browser APIs a floating, scrolling list is
+ * built on: Radix positions the popover with a ResizeObserver watching the
+ * trigger, and cmdk scrolls the highlighted row into view. Stubbed here rather
+ * than in `test-setup.ts` for the reason `Combobox.test.tsx` gives — a global
+ * stub hides from the next component that it needs one.
+ */
+if (!("ResizeObserver" in window)) {
+  (window as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+const proto = window.HTMLElement.prototype as unknown as Record<string, unknown>;
+proto.scrollIntoView ??= () => {};
+proto.hasPointerCapture ??= () => false;
+proto.setPointerCapture ??= () => {};
+proto.releasePointerCapture ??= () => {};
+
+/** A tab-sized surface that owns the layers opened inside it, as `TabSurface` does. */
+function Surface({ children }: { children: ReactNode }) {
+  const { ref, scope } = usePortalHost();
+  return (
+    <div data-testid="surface">
+      <PortalScopeProvider scope={scope}>
+        <div data-testid="content">{children}</div>
+        <div data-testid="host" ref={ref} />
+      </PortalScopeProvider>
+    </div>
+  );
+}
+
+/**
+ * The node the layer was portalled into.
+ *
+ * Radix's `Portal` renders a div of its own as a direct child of the container
+ * and the popper adds another inside that, so the container is never the
+ * content's parent. Matching the outermost portalled element and taking *its*
+ * parent names the container exactly, where "somewhere in the document" would
+ * also pass for a container that was wrong but still attached.
+ */
+function mountedIn(node: Element): Element | null {
+  return node.closest("body > *, [data-testid='host'] > *")?.parentElement ?? null;
+}
+
+function subject() {
+  return (
+    <Picker summary="Everything" ariaLabel="Namespace">
+      {(close) => <PickerRow value="alpha" label="alpha" checked={false} onSelect={close} />}
+    </Picker>
+  );
+}
+
+const trigger = () => screen.getByRole("combobox", { name: "Namespace" });
+const panel = () => screen.getByRole("dialog");
+
+async function open() {
+  const view = render(subject());
+  await userEvent.click(trigger());
+  await screen.findByRole("dialog");
+  return view;
+}
+
+async function openInSurface() {
+  const view = render(<Surface>{subject()}</Surface>);
+  await userEvent.click(trigger());
+  await screen.findByRole("dialog");
+  return view;
+}
+
+/**
+ * The shell `Combobox` and `MultiSelect` are both built out of. What those two
+ * suites cover is what a row click does; what this one covers is the seam they
+ * share with the window around them.
+ *
+ * A searchable list opened in one tab belongs to that tab. The window is a
+ * strip of tabs over one screen each, all of them mounted at once with the
+ * inactive ones hidden by the `hidden` attribute — which a portal to
+ * `document.body` escapes. So the list stayed on screen over whatever tab the
+ * reader moved to, anchored to a trigger that had gone with the tab. (#357)
+ *
+ * The container is the whole change. Radix's Popover is already non-modal and
+ * already dismisses on an outside interaction, and the search box's contents
+ * are a filter rather than something the reader would mind losing, so none of
+ * the dialog's other treatment applies.
+ */
+describe("Picker inside a surface", () => {
+  it("mounts into the surface's own node, so hiding the tab hides it too", async () => {
+    await openInSurface();
+    expect(mountedIn(panel())).toBe(screen.getByTestId("host"));
+  });
+
+  it("mounts into the document body when there is no surface", async () => {
+    // The fallback the gallery, the frozen classic app and most of this kit's
+    // own tests rely on, and it must stay exactly as it was.
+    await open();
+    expect(mountedIn(panel())).toBe(document.body);
+  });
+
+  it("still filters and picks from inside the surface", async () => {
+    await openInSurface();
+    await userEvent.type(screen.getByPlaceholderText("Search…"), "alp");
+    await userEvent.click(screen.getByRole("option", { name: "alpha" }));
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+  });
+
+  it("still closes on Escape", async () => {
+    await openInSurface();
+    fireEvent.keyDown(document.activeElement ?? document.body, { key: "Escape" });
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+  });
+});

--- a/packages/ui-kit/src/picker.tsx
+++ b/packages/ui-kit/src/picker.tsx
@@ -2,6 +2,7 @@ import { useState, type ReactNode } from "react";
 import { Popover } from "radix-ui";
 import { Command } from "cmdk";
 import { cx } from "./cx";
+import { usePortalContainer } from "./portal";
 import { filled } from "./slot";
 
 export interface ComboboxOption {
@@ -46,9 +47,19 @@ export interface PickerProps {
  * filtered list are each a library-sized problem, and all four are already
  * solved. What is ours is the seam: which classes it wears, and the render prop
  * below. (#318)
+ *
+ * Inside a portal scope — one tab of a window that holds several — the popover
+ * mounts into the tab's own node rather than the document body, so it is hidden
+ * with the tab. A portal escapes the `hidden` attribute an inactive tab wears,
+ * so a list opened in one tab used to stay on screen over the next one,
+ * anchored to a trigger that had gone with the tab. Nothing else changes: it is
+ * already non-modal, already dismisses on an outside interaction, and the
+ * search box holds a filter rather than anything the reader would mind losing.
+ * Outside a scope nothing changes at all. (#357)
  */
 export function Picker({ summary, ariaLabel, searchPlaceholder = "Search…", className, footer, children }: PickerProps) {
   const [open, setOpen] = useState(false);
+  const container = usePortalContainer();
 
   return (
     <Popover.Root open={open} onOpenChange={setOpen}>
@@ -67,7 +78,7 @@ export function Picker({ summary, ariaLabel, searchPlaceholder = "Search…", cl
           </svg>
         </button>
       </Popover.Trigger>
-      <Popover.Portal>
+      <Popover.Portal container={container}>
         <Popover.Content
           align="start"
           sideOffset={4}

--- a/packages/ui-kit/src/portal.test.tsx
+++ b/packages/ui-kit/src/portal.test.tsx
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { useRef, useState, type ReactNode } from "react";
+import { PortalScopeProvider, useOpenLayer, usePortalContainer, usePortalHost } from "./portal";
+
+/** Reports what a portalled component would be told to mount into. */
+function Probe() {
+  const container = usePortalContainer();
+  return <span data-testid="probe">{container?.dataset.name ?? "none"}</span>;
+}
+
+/** Stands in for a dialog: holds the scope open for as long as it is mounted. */
+function Layer({ id = "layer" }: { id?: string }) {
+  const { container, scoped, showing } = useOpenLayer();
+  const where = `${scoped ? "scoped" : "loose"}:${container?.dataset.name ?? "none"}`;
+  return <span data-testid={id}>{`${where}:${showing ? "showing" : "hidden"}`}</span>;
+}
+
+/** A surface that hosts its own layers, the way TabSurface does. */
+function Host({ name, visible = true, children }: { name: string; visible?: boolean; children: ReactNode }) {
+  const { ref, layered, scope } = usePortalHost(visible);
+  return (
+    <PortalScopeProvider scope={scope}>
+      <div data-testid={`content-${name}`} inert={layered}>
+        {children}
+      </div>
+      <div data-name={name} ref={ref} />
+    </PortalScopeProvider>
+  );
+}
+
+/** Opens and closes layers inside one host, from outside it. */
+function Stage({ name = "a" }: { name?: string }) {
+  const [open, setOpen] = useState(0);
+  return (
+    <>
+      <button type="button" onClick={() => setOpen((n) => n + 1)}>open</button>
+      <button type="button" onClick={() => setOpen((n) => Math.max(0, n - 1))}>close</button>
+      <Host name={name}>
+        {Array.from({ length: open }, (_, i) => <Layer key={i} id={`layer-${i}`} />)}
+      </Host>
+    </>
+  );
+}
+
+/** Drives the registration by hand, to reach the cases a component cannot. */
+function Rig() {
+  const { ref, layered, scope } = usePortalHost();
+  const first = useRef<(() => void) | null>(null);
+  return (
+    <PortalScopeProvider scope={scope}>
+      <div data-testid="content-r" inert={layered} />
+      <div data-name="r" ref={ref} />
+      <button type="button" onClick={() => { first.current = scope.hold(); }}>hold one</button>
+      <button type="button" onClick={() => { scope.hold(); }}>hold two</button>
+      <button type="button" onClick={() => first.current?.()}>release one</button>
+    </PortalScopeProvider>
+  );
+}
+
+const content = (name = "a") => screen.getByTestId(`content-${name}`);
+
+/**
+ * The seam that lets a portalled layer belong to one part of the window rather
+ * than to the whole document.
+ *
+ * Optional on purpose, and that is the load-bearing part: the gallery, the
+ * frozen classic app and most tests render a dialog with no surface around it
+ * at all, and every one of them has to keep working. No scope means no
+ * container, which is exactly what Radix's `container` prop wants in order to
+ * fall back to `document.body`. (#357)
+ */
+describe("a portal scope", () => {
+  it("names no container outside a scope, so Radix falls back to document.body", () => {
+    render(<Probe />);
+    expect(screen.getByTestId("probe").textContent).toBe("none");
+  });
+
+  it("names the surface's own node inside one", () => {
+    render(<Host name="a"><Probe /></Host>);
+    expect(screen.getByTestId("probe").textContent).toBe("a");
+  });
+
+  it("tells a layer whether it is scoped, which is not the same question as where to mount", () => {
+    // A layer needs both: the container says where to render, and `scoped`
+    // says whether there is a surface to be modal *within*. They differ during
+    // the render before the host's node exists, and a layer that read only the
+    // container could not tell that case from having no surface at all.
+    render(<Layer />);
+    expect(screen.getByTestId("layer").textContent).toBe("loose:none:showing");
+  });
+
+  it("tells a layer when its surface is off screen", () => {
+    // A tab that is hidden rather than unmounted keeps its layers mounted with
+    // it, and a layer that cannot tell it is off screen will answer key
+    // presses meant for the tab the reader is actually looking at.
+    render(<Host name="a" visible={false}><Layer /></Host>);
+    expect(screen.getByTestId("layer").textContent).toBe("scoped:a:hidden");
+  });
+
+  it("keeps each surface's layers to itself", () => {
+    render(
+      <>
+        <Host name="a"><Layer id="in-a" /></Host>
+        <Host name="b"><Layer id="in-b" /></Host>
+      </>,
+    );
+    expect(screen.getByTestId("in-a").textContent).toBe("scoped:a:showing");
+    expect(screen.getByTestId("in-b").textContent).toBe("scoped:b:showing");
+  });
+});
+
+/**
+ * The count exists so the surface can make its own content unreachable while a
+ * layer covers it. The overlay stops the pointer; nothing else stops Tab or an
+ * assistive technology's own cursor, and `inert` is the one attribute that
+ * means all three.
+ */
+describe("a portal scope's open-layer count", () => {
+  it("starts clear", () => {
+    render(<Stage />);
+    expect(content().hasAttribute("inert")).toBe(false);
+  });
+
+  it("marks the surface while a layer is open", () => {
+    render(<Stage />);
+    fireEvent.click(screen.getByRole("button", { name: "open" }));
+    expect(content().hasAttribute("inert")).toBe(true);
+  });
+
+  it("clears the surface when the layer closes", () => {
+    render(<Stage />);
+    fireEvent.click(screen.getByRole("button", { name: "open" }));
+    fireEvent.click(screen.getByRole("button", { name: "close" }));
+    expect(content().hasAttribute("inert")).toBe(false);
+  });
+
+  it("holds until the last of several layers closes", () => {
+    // A dialog that opens a second dialog: releasing on the first close would
+    // hand the covered screen back while it is still covered.
+    render(<Stage />);
+    fireEvent.click(screen.getByRole("button", { name: "open" }));
+    fireEvent.click(screen.getByRole("button", { name: "open" }));
+    fireEvent.click(screen.getByRole("button", { name: "close" }));
+    expect(content().hasAttribute("inert")).toBe(true);
+    fireEvent.click(screen.getByRole("button", { name: "close" }));
+    expect(content().hasAttribute("inert")).toBe(false);
+  });
+
+  it("ignores a release called twice, so another layer still holds the surface", () => {
+    // The count is shared and the release is handed out, so a caller that
+    // releases twice — a cleanup run again, an effect double-invoked — would
+    // hand the covered screen back while a second dialog was still covering
+    // it. jsdom cannot show that as a reachable button; the count is the thing
+    // that can be pinned.
+    render(<Rig />);
+    fireEvent.click(screen.getByRole("button", { name: "hold one" }));
+    fireEvent.click(screen.getByRole("button", { name: "hold two" }));
+    fireEvent.click(screen.getByRole("button", { name: "release one" }));
+    fireEvent.click(screen.getByRole("button", { name: "release one" }));
+    expect(screen.getByTestId("content-r").hasAttribute("inert")).toBe(true);
+  });
+
+  it("counts only its own surface's layers", () => {
+    render(
+      <>
+        <Stage name="a" />
+        <Host name="b"><span /></Host>
+      </>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "open" }));
+    expect(content("a").hasAttribute("inert")).toBe(true);
+    expect(content("b").hasAttribute("inert")).toBe(false);
+  });
+});

--- a/packages/ui-kit/src/portal.tsx
+++ b/packages/ui-kit/src/portal.tsx
@@ -53,6 +53,20 @@ export function usePortalContainer(): HTMLElement | undefined {
 }
 
 /**
+ * Whether there is a surface around this component at all.
+ *
+ * The other half of what {@link usePortalContainer} answers, for the component
+ * that needs both: `container` says where to render, and this says whether
+ * there is a surface to be modal *within*. They are not the same question and
+ * they differ for one render — see {@link useOpenLayer}, which hands a layer
+ * both — so a component that has a use for the second must ask for it rather
+ * than infer it from the first.
+ */
+export function usePortalScoped(): boolean {
+  return useContext(ScopeContext) !== undefined;
+}
+
+/**
  * For a layer that covers the surface it belongs to, and must be counted while
  * it does: a dialog, not a tooltip.
  *

--- a/packages/ui-kit/src/portal.tsx
+++ b/packages/ui-kit/src/portal.tsx
@@ -1,0 +1,129 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
+
+/**
+ * A part of the window that owns the layers opened inside it.
+ *
+ * `container` is the node those layers mount into, and `hold` is how a layer
+ * says it is open — the surface needs the count to make its own content
+ * unreachable while a layer covers it.
+ */
+export interface PortalScope {
+  /** Where layers in this scope mount. Undefined until the node exists. */
+  container: HTMLElement | undefined;
+  /**
+   * Whether this surface is the one on screen. A surface that hides rather
+   * than unmounts keeps its layers mounted with it, and a layer that cannot
+   * tell it is off screen will answer key presses meant for the surface the
+   * reader is actually looking at.
+   */
+  visible: boolean;
+  /** Registers one open layer. Call the returned function to release it. */
+  hold: () => () => void;
+}
+
+/**
+ * Undefined by default, and that default is load-bearing rather than an
+ * oversight: a dialog rendered with no surface around it — the gallery, the
+ * frozen classic app, most of this kit's own tests — must behave exactly as it
+ * did before this existed. `undefined` is what Radix's `container` prop wants
+ * in order to fall back to `document.body`.
+ */
+const ScopeContext = createContext<PortalScope | undefined>(undefined);
+
+/**
+ * Puts everything below it inside one surface's scope.
+ *
+ * Wraps both the surface's content and the node its layers mount into, so
+ * `usePortalHost` can hand one `scope` to one provider — see that hook for why
+ * the two have to be siblings.
+ */
+export function PortalScopeProvider({ scope, children }: { scope: PortalScope; children: ReactNode }) {
+  return <ScopeContext.Provider value={scope}>{children}</ScopeContext.Provider>;
+}
+
+/**
+ * Where a portalled component should mount: the surrounding surface's node, or
+ * `undefined` when there is no surface, which sends it to `document.body`.
+ *
+ * This is the whole API a menu, a popover or a tooltip needs. A layer that also
+ * covers the surface wants {@link useOpenLayer} instead.
+ */
+export function usePortalContainer(): HTMLElement | undefined {
+  return useContext(ScopeContext)?.container;
+}
+
+/**
+ * For a layer that covers the surface it belongs to, and must be counted while
+ * it does: a dialog, not a tooltip.
+ *
+ * The registration lasts as long as the caller is mounted, which is the right
+ * lifetime for the two dialogs in this kit — both are mounted only while open.
+ * A component that stays mounted across open and closed would hold the surface
+ * covered the whole time and must not use this hook.
+ *
+ * `scoped` is a separate answer from `container`, deliberately. A layer needs
+ * to know whether there is a surface to be modal *within*, and that is not the
+ * same as whether the node exists yet: they differ for the render between a
+ * surface mounting and its ref firing, and a layer reading only the container
+ * would treat that render as "no surface at all" and set up as a document-wide
+ * modal for it.
+ *
+ * `showing` is true outside any surface, because a layer with no surface around
+ * it is never the one hidden behind another.
+ */
+export function useOpenLayer(): { container: HTMLElement | undefined; scoped: boolean; showing: boolean } {
+  const scope = useContext(ScopeContext);
+  // The hold, not the scope: the scope's identity changes when its node
+  // arrives, and depending on it would release and re-take the registration
+  // for nothing. `hold` is stable for the surface's lifetime.
+  const hold = scope?.hold;
+  useEffect(() => hold?.(), [hold]);
+  return { container: scope?.container, scoped: scope !== undefined, showing: scope?.visible ?? true };
+}
+
+/**
+ * The state a surface needs to host its own layers.
+ *
+ * `ref` goes on the node the layers mount into, and `layered` is true while at
+ * least one of them is open — which is the surface's cue to mark its content
+ * `inert`. That is why the two must be *siblings*: an element cannot be marked
+ * inert and also be the ancestor of the thing that is meant to stay reachable.
+ *
+ * The node is held in state rather than a ref because the container has to
+ * reach the layers through a render; a ref would be filled after the render
+ * that needed it and nothing would re-read it.
+ *
+ * `visible` is what the surface would put on its own `hidden` attribute,
+ * inverted. It defaults to true for a surface that is always on screen.
+ */
+export function usePortalHost(visible = true): {
+  /** Attach to the node layers mount into. It must be a sibling of the content. */
+  ref: (node: HTMLElement | null) => void;
+  /** True while a layer is open: mark the content `inert`. */
+  layered: boolean;
+  /** Hand to {@link PortalScopeProvider}, around both the content and the node. */
+  scope: PortalScope;
+} {
+  const [container, setContainer] = useState<HTMLElement | undefined>(undefined);
+  const [layers, setLayers] = useState(0);
+
+  const hold = useCallback(() => {
+    setLayers((n) => n + 1);
+    // Guarded because a release called twice would uncover the surface while a
+    // second layer is still open. React's own effect cleanup does not do that,
+    // but this function is handed out and the count is shared.
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      setLayers((n) => n - 1);
+    };
+  }, []);
+
+  const ref = useCallback((node: HTMLElement | null) => {
+    setContainer(node ?? undefined);
+  }, []);
+
+  const scope = useMemo(() => ({ container, visible, hold }), [container, visible, hold]);
+  return { ref, layered: layers > 0, scope };
+}

--- a/packages/ui-next/src/lib/clusterMoved.tsx
+++ b/packages/ui-next/src/lib/clusterMoved.tsx
@@ -1,0 +1,144 @@
+import { useCallback, useState, type ReactNode } from "react";
+import { Alert, Checkbox } from "@srelens/ui-kit";
+
+/**
+ * What a dialog says, and asks again, when the cluster rail moves out from
+ * under it.
+ *
+ * **Why this exists at all.** Until #357 a dialog was window-modal: its
+ * overlay covered the cluster rail, so the reader could not switch clusters
+ * while one was open, and every screen that read the live context inside a
+ * confirm was accidentally right. b6dd228 scopes a dialog to its own tab, so
+ * the rail, the tab strip and the status bar are all live behind one — and
+ * `setActiveCluster` switches the active cluster in place, globally. No screen
+ * carries `key={name}`, so nothing remounts: a dialog opened on one cluster
+ * stays open, still naming that cluster's object, while every prop under it
+ * quietly becomes another cluster's.
+ *
+ * `Helm.tsx` solved this first (7e50ea0) for the four helm operations. This is
+ * the same shape, factored out because three more screens need it and three
+ * hand-written copies of a sentence about a destructive write is how two of
+ * them end up saying different things about the same event.
+ *
+ * **The rule, in three parts.**
+ *
+ * 1. The cluster is captured when the reader OPENS the dialog — not when the
+ *    dialog mounts. Helm's case proved mount-time is too late: a dialog that
+ *    opens after an async round trip mounts under whatever cluster is in focus
+ *    by the time the answer lands.
+ * 2. The pinned cluster is what the action runs against. Following the rail is
+ *    the one outcome that must never happen — an operation that retargets
+ *    itself silently is the worst thing on offer here.
+ * 3. The divergence is STATED. Nothing is closed and nothing the reader typed
+ *    is thrown away, which is `StaleSelectionAlert`'s documented rule and
+ *    `Overview`'s own stale-reading banner.
+ *
+ * Where this parts company with Helm is the fourth part: {@link useClusterGate}
+ * also RE-ARMS the confirmation. Helm justified leaving its gate armed by
+ * saying that closing would discard a typed values body — an upgrade's
+ * argument, applied to an uninstall's decision. The dialogs this module serves
+ * are confirms whose whole input is a click (or, for Scale, one number that is
+ * kept), so asking again costs the reader one tick and nothing else. A reader
+ * who moved the rail BECAUSE they realised they were on the wrong cluster, and
+ * then reached for the button they already meant to press, is the case a
+ * banner alone does not catch.
+ */
+export function ClusterMovedAlert({
+  pinned,
+  live,
+  children,
+}: {
+  /** The cluster the action was opened against, and will run against. */
+  pinned: string;
+  /** The cluster the reader has in FOCUS now — the only thing that moved. */
+  live: string;
+  /** The acknowledgement control, or a closing sentence, under the words. */
+  children?: ReactNode;
+}) {
+  return (
+    // Toned `warn`, so the kit gives it `role="status"` — a polite live region,
+    // which is what announces a fact that appears while the dialog is already
+    // open. A dialog's own destructive alert stays the assertive one, and this
+    // goes above it: it changes what every name below it refers to.
+    <Alert tone="warn" title={`This still runs against ${pinned}, not ${live}`}>
+      {/* Deliberately number-neutral: one row, one node and forty rows all
+          reach this sentence, and a singular one would have to be written
+          three times to stay true. */}
+      The cluster in focus changed while this was open. srelens is still
+      talking to {pinned}, and what is named here belongs to that cluster — the
+      same names on {live} are different objects.
+      {children}
+    </Alert>
+  );
+}
+
+/** Why the write did not go ahead. One sentence, shared by every caller. */
+export function clusterMovedRefusal(pinned: string, live: string): string {
+  return `This runs on ${pinned}, not ${live}. Confirm the cluster above, or cancel.`;
+}
+
+export interface ClusterGate {
+  /** Has the rail moved out from under the open dialog? */
+  moved: boolean;
+  /** What the dialog renders about it, or `null` when there is nothing to say. */
+  alert: ReactNode;
+  /**
+   * Why the action must not run yet, or `null` when it may.
+   *
+   * Checked by the confirm handler and shown as the dialog's own error line —
+   * the same path a validation message this side wrote takes today. It is
+   * `null` in the ordinary case, so a dialog nobody moved the rail under
+   * behaves exactly as it did before.
+   */
+  refusal: string | null;
+  /** Forget any acknowledgement. Called when a dialog opens and when it closes. */
+  reset: () => void;
+}
+
+/**
+ * The divergence banner, its acknowledgement, and the refusal that keeps the
+ * two honest — see this module's note.
+ *
+ * `pinned` is `null` while nothing is open, which is also how a caller says
+ * "there is nothing to compare": `moved` is false, the alert is nothing, and
+ * the refusal is nothing.
+ *
+ * The acknowledgement is stored as the cluster it was given AGAINST, not as a
+ * boolean. A reader who ticks the box on `stage-eu` and then moves the rail
+ * on to `dev` has confirmed a divergence that no longer exists, and the gate
+ * re-arms itself rather than carrying their answer over to a question they
+ * were never asked.
+ */
+export function useClusterGate({
+  pinned,
+  live,
+  verb,
+}: {
+  pinned: string | null;
+  live: string;
+  /** What the button does, for the acknowledgement's own words: "delete", "drain". */
+  verb: string;
+}): ClusterGate {
+  const [acknowledgedFor, setAcknowledgedFor] = useState<string | null>(null);
+  const reset = useCallback(() => setAcknowledgedFor(null), []);
+
+  const moved = pinned !== null && pinned !== live;
+  const acknowledged = moved && acknowledgedFor === live;
+
+  return {
+    moved,
+    alert:
+      pinned !== null && moved ? (
+        <ClusterMovedAlert pinned={pinned} live={live}>
+          <Checkbox
+            className="mt-2"
+            checked={acknowledged}
+            onChange={(next) => setAcknowledgedFor(next ? live : null)}
+            label={`Yes, still ${verb} on ${pinned}.`}
+          />
+        </ClusterMovedAlert>
+      ) : null,
+    refusal: moved && !acknowledged ? clusterMovedRefusal(pinned, live) : null,
+    reset,
+  };
+}

--- a/packages/ui-next/src/screens/Helm.test.tsx
+++ b/packages/ui-next/src/screens/Helm.test.tsx
@@ -1440,3 +1440,181 @@ describe("Helm — failures the table cannot show", () => {
     expect(document.querySelector('[data-slot="helm-failures"]')).toBeNull();
   });
 });
+
+/**
+ * **The cluster rail is reachable while a dialog is open, and the dialog is
+ * the one irreversible surface in the app.**
+ *
+ * PR #354's whole-branch review asked whether a destructive operation could
+ * run against a different cluster than the one named on screen and cleared it,
+ * partly because Radix's modal overlay covered the rail: with a dialog open the
+ * reader simply could not switch clusters underneath it. `b6dd228` scopes a
+ * dialog to its own tab (#357), so the rail, the tab strip and the status bar
+ * are all live behind one — and that clearance no longer holds on its own.
+ *
+ * The rule these pin: **an operation runs against the cluster it was opened
+ * against, and says so whenever that is no longer the cluster in focus.**
+ * Following the rail silently is the one outcome that must never happen here;
+ * `helm uninstall checkout` on the wrong cluster is not recoverable, and a
+ * release of the SAME NAME on the cluster the reader moved to is the ordinary
+ * shape of a staging cluster beside a production one.
+ */
+describe("Helm — a dialog open across a cluster switch", () => {
+  /**
+   * The second cluster, carrying a release with production's name.
+   *
+   * `stage-eu` is what `staging/checkout` would look like if it lived on its
+   * own cluster rather than in its own namespace, which is the case that makes
+   * a silent retarget destroy something: an uninstall gate typed out for
+   * `checkout` on `prod-eu` is a gate already passed for `checkout` on
+   * `stage-eu`.
+   */
+  const STAGE: ClusterContext = {
+    name: "stage-eu",
+    stableId: "stage",
+    cluster: "stage",
+    server: "https://stage",
+    isCurrent: false,
+    namespace: "default",
+  };
+
+  /** The screen on a window that has both clusters, opened on `prod-eu`. */
+  function openBoth() {
+    resetContexts();
+    setContexts([CTX, STAGE]);
+    setKubeconfigFiles(FILES);
+    // `defaultState` focuses the first, so this opens on `prod-eu`.
+    store.setState(defaultState([CTX, STAGE]));
+    return open();
+  }
+
+  /** What the rail does: put another cluster in focus, with the dialog open. */
+  const switchTo = (stableId: string) =>
+    act(() => {
+      store.setActiveCluster(stableId);
+    });
+
+  /** The context every `startHelmOp` was told to run against. */
+  const targets = () => core.startHelmOp.mock.calls.map((c) => c[0] as string);
+
+  async function openUninstall() {
+    await userEvent.click(
+      within(rowFor("checkout", "checkout")).getByRole("button", { name: "Uninstall checkout" }),
+    );
+    return screen.findByRole("dialog");
+  }
+
+  it("uninstalls on the cluster the dialog was opened against, not the one the rail moved to", async () => {
+    openBoth();
+    await ready();
+    const dialog = await openUninstall();
+    await userEvent.type(within(dialog).getByLabelText("Type checkout to confirm"), "checkout");
+
+    switchTo("stage");
+    await userEvent.click(within(dialog).getByRole("button", { name: "Uninstall" }));
+    await waitFor(() => expect(core.startHelmOp).toHaveBeenCalled());
+
+    // The release this gate was typed out for lives on `prod-eu`. `stage-eu`
+    // has one with the same name and it is not this one.
+    expect(targets()).toEqual(["prod-eu"]);
+  });
+
+  it("says which cluster it runs against once that is no longer the one in focus", async () => {
+    openBoth();
+    await ready();
+    const dialog = await openUninstall();
+    expect(within(dialog).getByText("srelens runs this against prod-eu.")).toBeTruthy();
+
+    switchTo("stage");
+
+    // Still prod-eu, because that is still what it will do — and now said
+    // twice, because the screen behind the dialog is a different cluster's.
+    expect(within(dialog).getByText("srelens runs this against prod-eu.")).toBeTruthy();
+    expect(
+      within(dialog).getByText("This still runs against prod-eu, not stage-eu"),
+    ).toBeTruthy();
+  });
+
+  it("keeps quiet about the cluster while the rail has not moved", async () => {
+    openBoth();
+    await ready();
+    const dialog = await openUninstall();
+    expect(within(dialog).queryByText(/This still runs against/)).toBeNull();
+  });
+
+  /**
+   * The gate is the release name typed out, matched exactly against the
+   * release the dialog was OPENED for. A switch must not turn that into a
+   * gate for some other cluster's release of the same name — and it must not
+   * quietly re-arm either: the operation has not changed, so neither has what
+   * was confirmed.
+   */
+  it("holds the typed gate to the release it was opened for", async () => {
+    openBoth();
+    await ready();
+    const dialog = await openUninstall();
+    switchTo("stage");
+
+    const gate = within(dialog).getByLabelText("Type checkout to confirm");
+    expect((within(dialog).getByRole("button", { name: "Uninstall" }) as HTMLButtonElement).disabled).toBe(true);
+    await userEvent.type(gate, "checkou");
+    expect((within(dialog).getByRole("button", { name: "Uninstall" }) as HTMLButtonElement).disabled).toBe(true);
+    await userEvent.type(gate, "t");
+    expect((within(dialog).getByRole("button", { name: "Uninstall" }) as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  /**
+   * **The in-flight read is the sharp one.** A rollback dialog opens on an
+   * answer, not before it — `getHelmRelease` is asked for the release's
+   * revisions and the dialog is opened once they arrive. Move the rail during
+   * that round trip and the dialog mounts under a cluster that is not the one
+   * the revisions came from; anything that reads the cluster at MOUNT rather
+   * than at the click has already lost the answer's own cluster by then.
+   */
+  it("opens a rollback against the cluster its revisions came from", async () => {
+    let deliver!: () => void;
+    const held = new Promise<void>((resolve) => {
+      deliver = resolve;
+    });
+    core.getHelmRelease.mockImplementationOnce(async (_c: string, ns: string, n: string) => {
+      await held;
+      return { release: { name: n, manifest: "", history: HISTORIES[`${ns}/${n}`] ?? [] } };
+    });
+
+    openBoth();
+    await ready();
+    await userEvent.click(
+      within(rowFor("checkout", "checkout")).getByRole("button", { name: "Roll back checkout" }),
+    );
+
+    // The rail moves while the read is still out.
+    switchTo("stage");
+    await act(async () => {
+      deliver();
+      await held;
+    });
+
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("srelens runs this against prod-eu.")).toBeTruthy();
+    await userEvent.click(within(dialog).getByRole("checkbox"));
+    await userEvent.click(within(dialog).getByRole("button", { name: /^Roll back to / }));
+    await waitFor(() => expect(core.startHelmOp).toHaveBeenCalled());
+    expect(targets()).toEqual(["prod-eu"]);
+  });
+
+  /**
+   * The read itself, not just the dialog it opens: `getHelmRelease` is asked
+   * of the cluster the row was clicked on. A screen that read the context
+   * afresh inside the async body would ask `stage-eu` for a release it does
+   * not have.
+   */
+  it("reads the release from the cluster the row was clicked on", async () => {
+    openBoth();
+    await ready();
+    await userEvent.click(
+      within(rowFor("checkout", "checkout")).getByRole("button", { name: "Roll back checkout" }),
+    );
+    await screen.findByRole("dialog");
+    expect(core.getHelmRelease.mock.calls.map((c) => c[0] as string)).toContain("prod-eu");
+  });
+});

--- a/packages/ui-next/src/screens/Helm.tsx
+++ b/packages/ui-next/src/screens/Helm.tsx
@@ -89,6 +89,24 @@ interface ReleaseRow {
 /** What the dialog is about, decided when it is opened and not before. */
 interface Pending {
   kind: HelmOpKind;
+  /**
+   * The cluster the operation will run against, captured when the dialog was
+   * asked for and never re-read.
+   *
+   * **Not the cluster in focus.** Since #357 a dialog covers only its own tab,
+   * so the cluster rail stays live behind it and the focus can move while the
+   * dialog is open — or, for upgrade and rollback, during the `getHelmRelease`
+   * round trip that has to answer before the dialog can open at all. Reading
+   * the focus at render time meant an operation opened on one cluster's
+   * release ran against whichever cluster the reader had wandered to, with the
+   * dialog quietly renaming its own target to match. `helm uninstall checkout`
+   * is not recoverable, and a staging cluster with a release of the same name
+   * is the ordinary shape rather than the exotic one.
+   *
+   * The release, namespace, values and history beside it are all that
+   * cluster's; this is the field that keeps them together.
+   */
+  context: string;
   release: string;
   namespace: string;
   chart: string;
@@ -499,6 +517,10 @@ function HelmReleases({ title, context }: { title: string; context: ClusterConte
     setSelectedKey(row.key);
     const base: Pending = {
       kind,
+      // The cluster this row is a row OF, read once, here. Everything below —
+      // including the read that has to come back before an upgrade or a
+      // rollback dialog can open — belongs to it.
+      context: name,
       release: row.name,
       namespace: row.namespace,
       // The chart and version the release is ON. §16's own upgrade path is the
@@ -797,6 +819,10 @@ function HelmReleases({ title, context }: { title: string; context: ClusterConte
             onClick={() =>
               setPending({
                 kind: "install",
+                // The cluster in focus when the reader asked for the dialog.
+                // See `Pending.context`: an install started here creates a
+                // release on THIS cluster, whatever the rail does next.
+                context: name,
                 // **Empty, and the dialog asks.** This opened on
                 // `new-release` — §A.5's own fixture — over a dialog with no
                 // field to change it with, so every install srelens could
@@ -826,7 +852,13 @@ function HelmReleases({ title, context }: { title: string; context: ClusterConte
       {pending && (
         <HelmOpDialog
           kind={pending.kind}
-          context={name}
+          // Captured, not current — see `Pending.context`. `name` goes in
+          // beside it as what the reader has in FOCUS, which is the only thing
+          // a cluster switch is allowed to change about an open dialog: the
+          // dialog says the two have parted, and keeps running against the
+          // first.
+          context={pending.context}
+          activeContext={name}
           namespace={pending.namespace}
           release={pending.release}
           chart={pending.chart}

--- a/packages/ui-next/src/screens/Overview.test.tsx
+++ b/packages/ui-next/src/screens/Overview.test.tsx
@@ -1655,3 +1655,122 @@ describe("Overview — coming back to the tab", () => {
     expect(screen.queryByText("prod-eu-1")).toBeNull();
   });
 });
+
+/**
+ * **A node action runs on the cluster it was picked on.**
+ *
+ * Until #357 a dialog was window-modal: its overlay covered the cluster rail,
+ * so the reader could not switch clusters while one was open, and reading the
+ * live `context` prop inside `confirm` was accidentally right. It is not any
+ * more. `setActiveCluster` switches the active cluster in place, globally;
+ * `Nodes` is mounted unconditionally and `{pending && <NodeConfirm/>}` sits
+ * outside the loading and error branches, so nothing here remounts and nothing
+ * resets `pending`.
+ *
+ * Reproduced by execution against this screen before this suite existed: Drain
+ * opened on `prod-eu`'s `n1`, `setActiveCluster("stage")`, the dialog still on
+ * screen, Drain confirmed — and `drainNode` was called with `[ 'stage-eu',
+ * 'n1' ]`. Every pod on staging's node of that name, evicted from a dialog
+ * that named production's.
+ *
+ * The rule is `lib/clusterMoved`'s: pin at pick, run against the pinned
+ * cluster, state the divergence, and re-arm the confirmation — this confirm's
+ * whole input is one click, so asking again costs the reader a tick.
+ */
+describe("Overview — the cluster a node action was picked on", () => {
+  const MOVED = "stage-eu";
+  const STAGE: ClusterContext = { ...CTX, name: MOVED, stableId: "stage", isCurrent: false };
+
+  const box = () => dialog() as HTMLElement;
+  const tick = (verb: string) =>
+    screen.getByRole("checkbox", { name: `Yes, still ${verb} on prod-eu.` }) as HTMLInputElement;
+  const REFUSAL = `This runs on prod-eu, not ${MOVED}. Confirm the cluster above, or cancel.`;
+
+  beforeEach(() => {
+    setContexts([CTX, STAGE]);
+    store.setState(defaultState([CTX, STAGE]));
+    store.setActiveCluster(CTX.stableId);
+  });
+
+  /** Pick a node action on `prod-eu`, then move the rail to `stage-eu`. */
+  async function pickThenMove(label: string, node = "n1") {
+    open();
+    await waitFor(() => expect(rowFor(node)).toBeTruthy());
+    await userEvent.click(within(rowFor(node)).getByRole("button", { name: label }));
+    expect(box()).toBeTruthy();
+
+    store.setActiveCluster(STAGE.stableId);
+    await waitFor(() => expect(store.currentWorkspace().activeCluster).toBe(STAGE.stableId));
+    // The rail is reachable behind a scoped dialog now, so the question is
+    // still on screen — which is the whole premise this fix answers.
+    expect(box()).toBeTruthy();
+  }
+
+  it("drains the node on the cluster it was picked on, not the one the rail moved to", async () => {
+    await pickThenMove("Drain");
+    await userEvent.click(tick("drain"));
+    await userEvent.click(within(box()).getByRole("button", { name: "Drain" }));
+
+    await waitFor(() => expect(core.drainNode).toHaveBeenCalledTimes(1));
+    expect(core.drainNode).toHaveBeenCalledWith("prod-eu", "n1");
+  });
+
+  it("refuses the drain until the reader confirms which cluster, and says why", async () => {
+    await pickThenMove("Drain");
+    await userEvent.click(within(box()).getByRole("button", { name: "Drain" }));
+
+    expect(core.drainNode).not.toHaveBeenCalled();
+    expect(within(box()).getByText(REFUSAL)).toBeTruthy();
+    expect(box()).toBeTruthy();
+
+    await userEvent.click(tick("drain"));
+    await userEvent.click(within(box()).getByRole("button", { name: "Drain" }));
+    await waitFor(() => expect(core.drainNode).toHaveBeenCalledWith("prod-eu", "n1"));
+  });
+
+  it("cordons the node on the cluster it was picked on", async () => {
+    // The other half of the same `confirm`: a fix applied to the drain branch
+    // alone would still retarget this one.
+    await pickThenMove("Cordon");
+    await userEvent.click(tick("cordon"));
+    await userEvent.click(within(box()).getByRole("button", { name: "Cordon" }));
+    await waitFor(() => expect(core.cordonNode).toHaveBeenCalledTimes(1));
+    expect(core.cordonNode).toHaveBeenCalledWith("prod-eu", "n1", true);
+  });
+
+  it("says the rail moved, first, above the node's own name, and keeps the kubectl honest", async () => {
+    await pickThenMove("Drain");
+    const alert = screen.getByText(`This still runs against prod-eu, not ${MOVED}`).closest("[data-tone]");
+    expect(alert).toBeTruthy();
+    expect(alert?.getAttribute("data-tone")).toBe("warn");
+    expect(alert?.getAttribute("role")).toBe("status");
+    expect(alert?.textContent?.replace(/\s+/g, " ")).toContain(
+      `the same names on ${MOVED} are different objects`,
+    );
+
+    const message = alert?.parentElement;
+    expect(message?.firstElementChild).toBe(alert);
+    expect(message?.textContent).toContain("evicts every pod");
+
+    // The command names the cluster the write will actually reach, so the
+    // dialog and the operation cannot agree on the wrong one.
+    expect(
+      within(box()).getByText(
+        "kubectl drain n1 --ignore-daemonsets --delete-emptydir-data --force --context prod-eu",
+      ),
+    ).toBeTruthy();
+    expect(within(box()).queryByText(new RegExp(`--context ${MOVED}`))).toBeNull();
+  });
+
+  it("says nothing, and asks nothing, while the rail has not moved", async () => {
+    open();
+    await waitFor(() => expect(rowFor("n1")).toBeTruthy());
+    await userEvent.click(within(rowFor("n1")).getByRole("button", { name: "Drain" }));
+
+    expect(within(box()).queryByText(/This still runs against/)).toBeNull();
+    expect(screen.queryByRole("checkbox")).toBeNull();
+    // One click, exactly as before this fix existed.
+    await userEvent.click(within(box()).getByRole("button", { name: "Drain" }));
+    await waitFor(() => expect(core.drainNode).toHaveBeenCalledWith("prod-eu", "n1"));
+  });
+});

--- a/packages/ui-next/src/screens/Overview.tsx
+++ b/packages/ui-next/src/screens/Overview.tsx
@@ -43,6 +43,7 @@ import {
   type Tone,
 } from "@srelens/ui-kit";
 import { useConsole } from "../console";
+import { useClusterGate } from "../lib/clusterMoved";
 import { useActiveContext, useContexts } from "../lib/clusters";
 import { detailRoute } from "../lib/detailRoute";
 import { FailureLine, FailureState, FailureWord, summarise } from "../lib/errorCopy";
@@ -713,17 +714,40 @@ function Nodes({ context, nodes }: { context: string; nodes: OverviewNodes }) {
   // capacity tiles, which count off it.
   const rows = [...all].sort(worstFirst).slice(0, NODE_ROWS);
 
+  /**
+   * The divergence banner, its acknowledgement and the refusal behind it.
+   *
+   * `pending.context` is the cluster the action runs against; `context` is
+   * what the reader has in FOCUS, which is the only thing a rail switch may
+   * change. See `lib/clusterMoved` for why the gate re-arms here rather than
+   * only stating the divergence: a drain confirm's whole input is one click,
+   * so asking again costs nothing.
+   */
+  const gate = useClusterGate({
+    pinned: pending?.context ?? null,
+    live: context,
+    verb: pending ? (pending.type === "drain" ? "drain" : pending.unschedulable ? "cordon" : "uncordon") : "act",
+  });
+  const reset = gate.reset;
+
   // Stable, so the column set below is built once per context rather than per
-  // render — `Table` re-sorts whenever its `columns` identity changes.
-  const open = useCallback((next: Pending) => {
-    setError("");
-    setPending(next);
-  }, []);
+  // render — `Table` re-sorts whenever its `columns` identity changes. The
+  // cluster each action was picked on rides IN the pending record (see
+  // `Pending`), captured by the row's own action rather than read here.
+  const open = useCallback(
+    (next: Pending) => {
+      setError("");
+      reset();
+      setPending(next);
+    },
+    [reset],
+  );
   const columns = useMemo(() => nodeColumns(context, open), [context, open]);
 
   function close() {
     setPending(null);
     setError("");
+    gate.reset();
   }
 
   /**
@@ -738,11 +762,21 @@ function Nodes({ context, nodes }: { context: string; nodes: OverviewNodes }) {
    */
   async function confirm() {
     if (!pending) return;
+    // Asked before anything else: it is the only question on screen whose
+    // answer changes which machine the name below refers to. The write still
+    // goes to `pending.context` either way — this re-arms the confirmation, it
+    // does not retarget it.
+    if (gate.refusal) {
+      setError(gate.refusal);
+      return;
+    }
+
     setBusy(true);
     setError("");
 
     if (pending.type === "drain") {
-      const out = await drainNode(context, pending.name);
+      // `pending.context`, never the live prop. See {@link Pending}.
+      const out = await drainNode(pending.context, pending.name);
       setBusy(false);
       // A refused write leaves the dialog up with the reason in it, rather
       // than closing as if the node had been drained.
@@ -752,7 +786,7 @@ function Nodes({ context, nodes }: { context: string; nodes: OverviewNodes }) {
       }
       notify.success(`Drained ${pending.name}`, `${out.evicted ?? 0} evicted, ${out.skipped ?? 0} skipped`);
     } else {
-      const out = await cordonNode(context, pending.name, pending.unschedulable);
+      const out = await cordonNode(pending.context, pending.name, pending.unschedulable);
       setBusy(false);
       if (out.error) {
         setError(out.error);
@@ -814,7 +848,10 @@ function Nodes({ context, nodes }: { context: string; nodes: OverviewNodes }) {
       {pending && (
         <NodeConfirm
           pending={pending}
-          context={context}
+          // Captured, not current: the kubectl line under the message names
+          // the cluster the write will actually reach.
+          context={pending.context}
+          moved={gate.alert}
           busy={busy}
           error={error}
           onConfirm={() => void confirm()}
@@ -990,14 +1027,14 @@ function nodeActions(context: string, row: NodeRow, open: (pending: Pending) => 
           // label is what says which way it is being thrown, and a second
           // picture for the reverse of one action is a second thing to read.
           icon: Icons.cordon,
-          onSelect: () => open({ type: "cordon", name: row.name, unschedulable: false }),
+          onSelect: () => open({ type: "cordon", name: row.name, unschedulable: false, context }),
         }
       : {
           id: "cordon",
           // The design's crossed circle — nothing new gets scheduled here.
           label: NODE_ACTION_LABEL.cordon,
           icon: Icons.cordon,
-          onSelect: () => open({ type: "cordon", name: row.name, unschedulable: true }),
+          onSelect: () => open({ type: "cordon", name: row.name, unschedulable: true, context }),
         },
     {
       id: "drain",
@@ -1006,7 +1043,7 @@ function nodeActions(context: string, row: NodeRow, open: (pending: Pending) => 
       icon: Icons.drain,
       // Danger-toned because it is: every pod on the node is evicted.
       danger: true,
-      onSelect: () => open({ type: "drain", name: row.name }),
+      onSelect: () => open({ type: "drain", name: row.name, context }),
     },
     {
       id: "open",
@@ -1245,21 +1282,37 @@ function NotReady({ context, overview }: { context: string; overview: OverviewDa
 
 /* ---------------------------------------------------------------- confirms */
 
-/** What a picked action is waiting to do, once the confirm is taken. */
-type Pending =
+/**
+ * What a picked action is waiting to do, once the confirm is taken — and the
+ * cluster it was picked ON.
+ *
+ * **`context` is captured when the reader picks the action, not when the
+ * dialog renders.** Since #357 a dialog covers only its own tab, so the
+ * cluster rail is live behind this one; `setActiveCluster` switches the active
+ * cluster in place and nothing on this screen remounts, so `pending` survives
+ * the switch while every prop around it becomes another cluster's. A drain
+ * opened on production, confirmed after a rail click, would otherwise evict
+ * every pod on staging's node of the same name. See `lib/clusterMoved`.
+ */
+type Pending = { context: string } & (
   | { type: "cordon"; name: string; unschedulable: boolean }
-  | { type: "drain"; name: string };
+  | { type: "drain"; name: string }
+);
 
 function NodeConfirm({
   pending,
   context,
+  moved,
   busy,
   error,
   onConfirm,
   onCancel,
 }: {
   pending: Pending;
+  /** The cluster this runs against — `pending.context`, never the live prop. */
   context: string;
+  /** The cluster-moved banner and its tick, or `null` when the rail has not moved. */
+  moved: ReactNode;
   busy: boolean;
   error: string;
   onConfirm: () => void;
@@ -1292,6 +1345,9 @@ function NodeConfirm({
       onCancel={onCancel}
       message={
         <>
+          {/* First, above the node's own name: it changes which machine that
+              name refers to. */}
+          {moved}
           <p style={{ marginTop: 0 }}>
             {drain ? (
               <>

--- a/packages/ui-next/src/screens/ResourceBulk.test.tsx
+++ b/packages/ui-next/src/screens/ResourceBulk.test.tsx
@@ -333,3 +333,163 @@ describe("ResourceBulk", () => {
     expect(rolloutRestart).toHaveBeenCalledWith("prod", "Deployment", "prod", "api-1");
   });
 });
+
+/**
+ * **A batch runs on the cluster it was opened on.**
+ *
+ * `Pending` was always a snapshot of the ROWS, so a selection change under an
+ * open dialog could not retarget it. It was never a snapshot of the CLUSTER,
+ * and since #357 the cluster rail is live behind a dialog: `setActiveCluster`
+ * switches the active cluster in place, nothing here remounts, and
+ * `Resources.tsx` keeps this bar mounted across the switch whenever the
+ * cluster being moved TO already has that kind in the row cache — which is the
+ * ordinary case for a reader moving between two clusters they have both looked
+ * at.
+ *
+ * Established by execution against the real `Resources` screen before this
+ * suite existed: the dialog stayed open across `setActiveCluster`, and the
+ * confirmed delete went out as `[ 'stage-eu', 'Pod', 'default', 'web-1' ]` —
+ * production's row name, staging's cluster. The `showRows` flip that was
+ * assumed to save this saves nothing once the target view is cached, and it
+ * was never designed to save it.
+ *
+ * The rule is `lib/clusterMoved`'s: pin at open, run against the pinned
+ * cluster, state the divergence, and re-arm the confirmation. This dialog has
+ * no typed input at all, so the tick costs nothing — and it is the one confirm
+ * here where a silent retarget takes out forty objects rather than one.
+ */
+describe("ResourceBulk — the cluster the batch was opened on", () => {
+  const PINNED = "prod-eu";
+  const MOVED = "stage-eu";
+  const ROWS: ListRow[] = [
+    { name: "web-0", namespace: "kube-system" },
+    { name: "api-1", namespace: "prod" },
+  ];
+  const SELECTED = new Set(ROWS.map(keyOf));
+
+  const bar = (context: string) => (
+    <ResourceBulk
+      selected={SELECTED}
+      kind="pods"
+      descriptor={POD_DESCRIPTOR}
+      context={context}
+      rows={ROWS}
+      onDone={() => {}}
+    />
+  );
+
+  const box = () => within(screen.getByRole("dialog"));
+  const tick = (verb: string) =>
+    screen.getByRole("checkbox", { name: `Yes, still ${verb} on ${PINNED}.` }) as HTMLInputElement;
+  const REFUSAL = `This runs on ${PINNED}, not ${MOVED}. Confirm the cluster above, or cancel.`;
+
+  /** The cluster every call in a batch went to. The mocks above declare no
+   *  parameters, so the argument list is read structurally. */
+  const targetsOf = (calls: unknown[][]) => calls.map((call) => call[0]);
+
+  /** Open a batch on `prod-eu`, then move the rail to `stage-eu` under it. */
+  async function openThenMove(label: string) {
+    const view = render(bar(PINNED));
+    await userEvent.click(screen.getByRole("button", { name: label }));
+    await screen.findByRole("dialog");
+    view.rerender(bar(MOVED));
+    return view;
+  }
+
+  it("deletes on the cluster the batch was opened on, not the one the rail moved to", async () => {
+    await openThenMove("Delete");
+    await userEvent.click(tick("delete"));
+    await userEvent.click(box().getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => expect(deleteResource).toHaveBeenCalledTimes(2));
+    for (const row of ROWS) {
+      expect(deleteResource).toHaveBeenCalledWith(PINNED, "Pod", row.namespace, row.name);
+    }
+    expect(targetsOf(deleteResource.mock.calls)).toEqual([PINNED, PINNED]);
+  });
+
+  it("refuses the run until the reader confirms which cluster, and says why", async () => {
+    await openThenMove("Delete");
+    await userEvent.click(box().getByRole("button", { name: "Delete" }));
+
+    // Not one row went out, and the dialog is still up with the reason in it.
+    expect(deleteResource).not.toHaveBeenCalled();
+    expect(box().getByText(REFUSAL)).toBeTruthy();
+    expect(screen.getByRole("dialog")).toBeTruthy();
+
+    await userEvent.click(tick("delete"));
+    await userEvent.click(box().getByRole("button", { name: "Delete" }));
+    await waitFor(() => expect(deleteResource).toHaveBeenCalledTimes(2));
+  });
+
+  it("evicts on the cluster the batch was opened on", async () => {
+    // A second core call behind the same confirm: a fix applied to Delete
+    // alone would still retarget this one.
+    await openThenMove("Evict");
+    await userEvent.click(tick("evict"));
+    await userEvent.click(box().getByRole("button", { name: "Evict" }));
+    await waitFor(() => expect(evictPod).toHaveBeenCalledTimes(2));
+    expect(targetsOf(evictPod.mock.calls)).toEqual([PINNED, PINNED]);
+  });
+
+  it("says the rail moved, first, above the list of rows", async () => {
+    await openThenMove("Delete");
+    const alert = screen.getByText(`This still runs against ${PINNED}, not ${MOVED}`).closest("[data-tone]");
+    expect(alert).toBeTruthy();
+    expect(alert?.getAttribute("data-tone")).toBe("warn");
+    expect(alert?.getAttribute("role")).toBe("status");
+    expect(alert?.textContent?.replace(/\s+/g, " ")).toContain(
+      `the same names on ${MOVED} are different objects`,
+    );
+
+    // Above `This will delete 2 pods`: the alert changes what every name in
+    // the list under it refers to.
+    const message = alert?.parentElement;
+    expect(message?.firstElementChild).toBe(alert);
+    expect(message?.textContent).toContain("This will delete 2 pods");
+  });
+
+  it("says nothing, and asks nothing, while the rail has not moved", async () => {
+    render(bar(PINNED));
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+    await screen.findByRole("dialog");
+
+    expect(document.querySelector('[role="dialog"] [data-tone]')).toBeNull();
+    expect(screen.queryByRole("checkbox")).toBeNull();
+    await userEvent.click(box().getByRole("button", { name: "Delete" }));
+    await waitFor(() => expect(deleteResource).toHaveBeenCalledTimes(2));
+    expect(targetsOf(deleteResource.mock.calls)).toEqual([PINNED, PINNED]);
+  });
+
+  /**
+   * Caught by mutation testing: making the gate's `reset` a no-op left every
+   * assertion above green. An acknowledgement is about ONE open question.
+   */
+  it("forgets an acknowledgement when the dialog it was given for closes", async () => {
+    const view = await openThenMove("Delete");
+    await userEvent.click(tick("delete"));
+    await userEvent.click(box().getByRole("button", { name: "Cancel" }));
+    expect(screen.queryByRole("dialog")).toBeNull();
+
+    view.rerender(bar(PINNED));
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+    await screen.findByRole("dialog");
+    view.rerender(bar(MOVED));
+
+    expect(tick("delete").checked).toBe(false);
+    await userEvent.click(box().getByRole("button", { name: "Delete" }));
+    expect(deleteResource).not.toHaveBeenCalled();
+    expect(box().getByText(REFUSAL)).toBeTruthy();
+  });
+
+  it("re-arms when the rail moves on again, rather than carrying the tick over", async () => {
+    const view = await openThenMove("Delete");
+    await userEvent.click(tick("delete"));
+    expect(tick("delete").checked).toBe(true);
+
+    view.rerender(bar("dev-eu"));
+    expect(tick("delete").checked).toBe(false);
+    await userEvent.click(box().getByRole("button", { name: "Delete" }));
+    expect(deleteResource).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui-next/src/screens/ResourceBulk.tsx
+++ b/packages/ui-next/src/screens/ResourceBulk.tsx
@@ -8,7 +8,8 @@ import {
   type BulkOutcome,
 } from "@srelens/core";
 import { ActionBar, ConfirmDialog, type ActionBarAction } from "@srelens/ui-kit";
-import { FailureWord } from "../lib/errorCopy";
+import { useClusterGate } from "../lib/clusterMoved";
+import { FailureLine, FailureWord } from "../lib/errorCopy";
 import type { KindDescriptor, ListRow } from "../lib/kinds/types";
 
 export interface ResourceBulkProps {
@@ -51,6 +52,21 @@ const PAST: Record<ActionType, string> = { delete: "deleted", evict: "evicted", 
 interface Pending {
   type: ActionType;
   rows: ListRow[];
+  /**
+   * The cluster the batch was opened on, captured with the rows rather than
+   * read live at confirm time.
+   *
+   * **The snapshot above was only half a snapshot.** Since #357 a dialog covers
+   * only its own tab, so the cluster rail is live behind it;
+   * `setActiveCluster` switches the active cluster in place and nothing
+   * remounts. `Resources.tsx` keeps this bar mounted across the switch
+   * whenever the cluster being moved TO already has that kind in the row cache
+   * — which is the ordinary case for a reader moving between two clusters —
+   * so `pending` survived with one cluster's rows in it while `context`
+   * became another's. A confirmed bulk delete then ran production's row names
+   * against staging. Executed, not theorised: see this task's report.
+   */
+  context: string;
 }
 
 /** The finished run's per-row detail, once at least one row failed. A full
@@ -90,6 +106,28 @@ export function ResourceBulk({ selected, kind, descriptor, context, rows, onDone
   const [pending, setPending] = useState<Pending | null>(null);
   const [report, setReport] = useState<Report | null>(null);
   const [busy, setBusy] = useState(false);
+  /**
+   * Why the run did not start. The only thing that reaches it today is the
+   * cluster gate below — a partial failure is the report dialog's job, and a
+   * refused row carries its own words there.
+   */
+  const [refused, setRefused] = useState("");
+
+  /**
+   * The divergence banner, its acknowledgement and the refusal behind it.
+   *
+   * `pending.context` is the cluster the batch runs against; `context` is what
+   * the reader has in FOCUS, which is the only thing a rail switch may change.
+   * The gate re-arms rather than only stating the divergence: this confirm's
+   * whole input is one click, so asking again costs the reader a tick — and a
+   * batch is the one dialog here where a silent retarget takes out forty
+   * objects rather than one.
+   */
+  const gate = useClusterGate({
+    pinned: pending?.context ?? null,
+    live: context,
+    verb: pending ? VERB[pending.type].toLowerCase() : "act",
+  });
 
   // Resolved against `rows` first, and counted from the result — `Table`
   // never prunes `selection.selected` when its data changes, so a key that
@@ -103,18 +141,34 @@ export function ResourceBulk({ selected, kind, descriptor, context, rows, onDone
 
   function open(type: ActionType) {
     setReport(null);
-    setPending({ type, rows: selectedRows });
+    setRefused("");
+    gate.reset();
+    // The cluster these rows are rows OF, read once, here — with them, not
+    // after them. See {@link Pending.context}.
+    setPending({ type, rows: selectedRows, context });
   }
 
   function close() {
     setPending(null);
     setReport(null);
+    setRefused("");
+    gate.reset();
   }
 
   async function confirm() {
     if (!pending) return;
+    // Asked before the run starts: it is the only question on screen whose
+    // answer changes what every name in the list below refers to. The run
+    // still goes to `pending.context` either way — this re-arms the
+    // confirmation, it does not retarget it.
+    if (gate.refusal) {
+      setRefused(gate.refusal);
+      return;
+    }
+    setRefused("");
     setBusy(true);
-    const outcomes = await runBulk(pending.rows, opFor(pending.type, context, descriptor.k8sKind));
+    // `pending.context`, never the live prop. See {@link Pending.context}.
+    const outcomes = await runBulk(pending.rows, opFor(pending.type, pending.context, descriptor.k8sKind));
     setBusy(false);
     const { failed } = summarize(outcomes);
     const { type } = pending;
@@ -159,6 +213,10 @@ export function ResourceBulk({ selected, kind, descriptor, context, rows, onDone
           onCancel={close}
           message={
             <>
+              {/* First, above the list: it changes what every name in it
+                  refers to, and it is the only thing here the reader does not
+                  already know. */}
+              {gate.alert}
               <p style={{ marginTop: 0 }}>
                 This will {VERB[pending.type].toLowerCase()} {pending.rows.length} {kind}
                 {pending.type === "delete" ? " — this cannot be undone" : ""}:
@@ -170,6 +228,10 @@ export function ResourceBulk({ selected, kind, descriptor, context, rows, onDone
                   </li>
                 ))}
               </ul>
+              {/* The dialog stays open on a refusal rather than closing as if
+                  the run had happened, so this line is the whole of what the
+                  reader is told about why. */}
+              {refused && <FailureLine error={refused} className="text-sev" />}
             </>
           }
         />

--- a/packages/ui-next/src/screens/ResourceMenu.test.tsx
+++ b/packages/ui-next/src/screens/ResourceMenu.test.tsx
@@ -412,3 +412,230 @@ describe("useRowMenu", () => {
     expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
   });
 });
+
+/**
+ * **Every write here runs on the cluster the row was picked on.**
+ *
+ * Until #357 a dialog was window-modal: its overlay covered the cluster rail,
+ * so the reader could not switch clusters while one was open, and reading the
+ * live `context` prop inside `confirm` was accidentally right. It is not any
+ * more — `setActiveCluster` switches the active cluster in place, globally,
+ * and no screen carries `key={name}`, so nothing here remounts and `pending`
+ * survives the switch with the other cluster's row still in it.
+ *
+ * Reproduced by execution before this suite existed: Delete opened on
+ * `prod-eu`'s `checkout`, the rail moved to `stage-eu`, Delete confirmed, and
+ * `deleteResource` was called with `[ 'stage-eu', 'Deployment', 'default',
+ * 'checkout' ]`. Two clicks and staging's Deployment is gone, with the dialog
+ * still naming production's row.
+ *
+ * The rule, from `lib/clusterMoved`: the cluster is pinned when the entry is
+ * picked, the write runs against the pinned one, the divergence is stated —
+ * and, unlike Helm's dialog, the confirmation is re-armed. These confirms take
+ * one click (Scale takes one number, and it is kept), so asking again costs
+ * the reader a tick.
+ */
+describe("useRowMenu — the cluster the row was picked on", () => {
+  const PINNED = "prod-eu";
+  const MOVED = "stage-eu";
+  const ROW: ListRow = { name: "checkout", namespace: "default" };
+
+  const argsOn = (context: string): UseRowMenuArgs => ({
+    context,
+    kind: "Deployment",
+    actions: { scale: true, restart: true },
+  });
+
+  const box = () => within(screen.getByRole("dialog"));
+  const tickFor = (verb: string) => screen.getByRole("checkbox", { name: `Yes, still ${verb} on ${PINNED}.` });
+  const REFUSAL = `This runs on ${PINNED}, not ${MOVED}. Confirm the cluster above, or cancel.`;
+
+  /** Pick an entry on `prod-eu`, then move the rail to `stage-eu` under it. */
+  async function pickThenMove(label: string, args: (context: string) => UseRowMenuArgs = argsOn) {
+    const view = render(<Harness args={args(PINNED)} row={ROW} />);
+    await userEvent.click(screen.getByRole("button", { name: label }));
+    await screen.findByRole("dialog");
+    view.rerender(<Harness args={args(MOVED)} row={ROW} />);
+    return view;
+  }
+
+  it("deletes on the cluster the row was picked on, not the one the rail moved to", async () => {
+    await pickThenMove("Delete");
+    await userEvent.click(tickFor("delete"));
+    await userEvent.click(box().getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => expect(deleteResource).toHaveBeenCalledTimes(1));
+    expect(deleteResource).toHaveBeenCalledWith(PINNED, "Deployment", "default", "checkout");
+  });
+
+  it("refuses the write until the reader confirms which cluster, and says why", async () => {
+    await pickThenMove("Delete");
+    await userEvent.click(box().getByRole("button", { name: "Delete" }));
+
+    // Nothing went out, and the dialog is still up with the reason in it —
+    // the same path a validation message this hook wrote itself takes.
+    expect(deleteResource).not.toHaveBeenCalled();
+    expect(box().getByText(REFUSAL)).toBeTruthy();
+    expect(screen.getByRole("dialog")).toBeTruthy();
+
+    // And the tick is all it takes: the question is which cluster, not
+    // whether to ask the whole confirm again.
+    await userEvent.click(tickFor("delete"));
+    await userEvent.click(box().getByRole("button", { name: "Delete" }));
+    await waitFor(() => expect(deleteResource).toHaveBeenCalledTimes(1));
+    expect(deleteResource).toHaveBeenCalledWith(PINNED, "Deployment", "default", "checkout");
+  });
+
+  it("says the rail moved, first, above the row's own name", async () => {
+    await pickThenMove("Delete");
+    const alert = screen.getByText(`This still runs against ${PINNED}, not ${MOVED}`).closest("[data-tone]");
+    expect(alert).toBeTruthy();
+    expect(alert?.getAttribute("data-tone")).toBe("warn");
+    // Toned `warn`, so the kit gives it `role="status"` — a polite live
+    // region, which is what announces a fact that appears while the dialog is
+    // already open.
+    expect(alert?.getAttribute("role")).toBe("status");
+    expect(alert?.textContent?.replace(/\s+/g, " ")).toContain(
+      `the same names on ${MOVED} are different objects`,
+    );
+
+    // First in the message, above `Delete checkout in default?`: it changes
+    // what that name refers to.
+    const message = alert?.parentElement;
+    expect(message?.firstElementChild).toBe(alert);
+    expect(message?.textContent).toContain("This cannot be undone.");
+  });
+
+  it("keeps naming the cluster the write will reach in the kubectl preview", async () => {
+    await pickThenMove("Delete");
+    expect(box().getByText(new RegExp(`^kubectl delete .* --context ${PINNED}$`))).toBeTruthy();
+    expect(box().queryByText(new RegExp(`--context ${MOVED}`))).toBeNull();
+  });
+
+  it("says nothing, and asks nothing, while the rail has not moved", async () => {
+    render(<Harness args={argsOn(PINNED)} row={ROW} />);
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+    await screen.findByRole("dialog");
+
+    expect(document.querySelector('[role="dialog"] [data-tone]')).toBeNull();
+    expect(screen.queryByRole("checkbox")).toBeNull();
+    // One click, exactly as before this fix existed.
+    await userEvent.click(box().getByRole("button", { name: "Delete" }));
+    await waitFor(() => expect(deleteResource).toHaveBeenCalledTimes(1));
+    expect(deleteResource).toHaveBeenCalledWith(PINNED, "Deployment", "default", "checkout");
+  });
+
+  it("re-arms when the rail moves on again, rather than carrying the tick over", async () => {
+    const view = await pickThenMove("Delete");
+    await userEvent.click(tickFor("delete"));
+    expect((tickFor("delete") as HTMLInputElement).checked).toBe(true);
+
+    // A third cluster. The reader confirmed a divergence that no longer
+    // exists, and was never asked about this one.
+    view.rerender(<Harness args={argsOn("dev-eu")} row={ROW} />);
+    const again = screen.getByRole("checkbox", { name: `Yes, still delete on ${PINNED}.` }) as HTMLInputElement;
+    expect(again.checked).toBe(false);
+    await userEvent.click(box().getByRole("button", { name: "Delete" }));
+    expect(deleteResource).not.toHaveBeenCalled();
+    expect(box().getByText(`This runs on ${PINNED}, not dev-eu. Confirm the cluster above, or cancel.`)).toBeTruthy();
+  });
+
+  /**
+   * Caught by mutation testing: making the gate's `reset` a no-op left every
+   * assertion above green. An acknowledgement is about ONE open question, and
+   * a dialog that cancelled and a dialog that opened next are two.
+   */
+  it("forgets an acknowledgement when the dialog it was given for closes", async () => {
+    const view = await pickThenMove("Delete");
+    await userEvent.click(tickFor("delete"));
+    await userEvent.click(box().getByRole("button", { name: "Cancel" }));
+    expect(screen.queryByRole("dialog")).toBeNull();
+
+    // Back on the cluster the row belongs to, and a fresh Delete on it.
+    view.rerender(<Harness args={argsOn(PINNED)} row={ROW} />);
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+    await screen.findByRole("dialog");
+    view.rerender(<Harness args={argsOn(MOVED)} row={ROW} />);
+
+    expect((tickFor("delete") as HTMLInputElement).checked).toBe(false);
+    await userEvent.click(box().getByRole("button", { name: "Delete" }));
+    expect(deleteResource).not.toHaveBeenCalled();
+    expect(box().getByText(REFUSAL)).toBeTruthy();
+  });
+
+  it("scales the cluster it was picked on, and keeps the replica count typed for it", async () => {
+    const view = render(<Harness args={argsOn(PINNED)} row={ROW} />);
+    await userEvent.click(screen.getByRole("button", { name: "Scale" }));
+    await screen.findByRole("dialog");
+    await userEvent.type(box().getByLabelText("Replica count"), "3");
+    view.rerender(<Harness args={argsOn(MOVED)} row={ROW} />);
+
+    // The number survives the switch — the gate re-arms the confirmation, it
+    // does not reset the dialog.
+    expect((box().getByLabelText("Replica count") as HTMLInputElement).value).toBe("3");
+    await userEvent.click(tickFor("scale"));
+    await userEvent.click(box().getByRole("button", { name: "Scale" }));
+    await waitFor(() => expect(scaleResource).toHaveBeenCalledTimes(1));
+    expect(scaleResource).toHaveBeenCalledWith(PINNED, "Deployment", "default", "checkout", 3);
+  });
+
+  it("restarts the cluster it was picked on", async () => {
+    // The other destructive entries share one `confirm`, but each names its
+    // own core call: a fix applied to Delete alone would still retarget these.
+    await pickThenMove("Restart rollout");
+    await userEvent.click(tickFor("restart"));
+    await userEvent.click(box().getByRole("button", { name: "Restart" }));
+    await waitFor(() => expect(rolloutRestart).toHaveBeenCalledTimes(1));
+    expect(rolloutRestart).toHaveBeenCalledWith(PINNED, "Deployment", "default", "checkout");
+  });
+
+  it("evicts on the cluster the pod was picked on", async () => {
+    const podArgs = (context: string): UseRowMenuArgs => ({ context, kind: "Pod", actions: { evict: true } });
+    await pickThenMove("Evict", podArgs);
+    await userEvent.click(tickFor("evict"));
+    await userEvent.click(box().getByRole("button", { name: "Evict" }));
+    await waitFor(() => expect(evictPod).toHaveBeenCalledTimes(1));
+    expect(evictPod).toHaveBeenCalledWith(PINNED, "default", "checkout");
+  });
+
+  it("suspends on the cluster the CronJob was picked on, and says which way in the tick", async () => {
+    const cronArgs = (context: string): UseRowMenuArgs => ({ context, kind: "CronJob", actions: { suspend: true } });
+    await pickThenMove("Suspend", cronArgs);
+    // The acknowledgement carries the button's own word, so a Resume can
+    // never be confirmed with a sentence that says "suspend".
+    await userEvent.click(tickFor("suspend"));
+    await userEvent.click(box().getByRole("button", { name: "Suspend" }));
+    await waitFor(() => expect(cronjobSetSuspend).toHaveBeenCalledTimes(1));
+    expect(cronjobSetSuspend).toHaveBeenCalledWith(PINNED, "default", "checkout", true);
+  });
+
+  /**
+   * `Open shell` is the one entry with a round trip between the click and the
+   * dialog — the exact case Helm's own fix singles out. It writes nothing, so
+   * it states the divergence and asks for no tick; what was wrong before is
+   * which cluster's pod the terminal attached to.
+   */
+  it("attaches a shell to the pod on the cluster it was picked on", async () => {
+    getObject.mockResolvedValue({ object: { spec: { containers: [{ name: "app" }, { name: "sidecar" }] } } });
+    const podArgs = (context: string): UseRowMenuArgs => ({ context, kind: "Pod", actions: { shell: true } });
+    await pickThenMove("Open shell", podArgs);
+
+    // Stated, with no acknowledgement to give: nothing is written by opening
+    // a terminal, and the terminal itself is labelled with its cluster.
+    expect(screen.getByText(`This still runs against ${PINNED}, not ${MOVED}`)).toBeTruthy();
+    expect(screen.queryByRole("checkbox")).toBeNull();
+
+    await userEvent.click(box().getByRole("button", { name: "Open" }));
+    await waitFor(() => expect(startPodSession).toHaveBeenCalledTimes(1));
+    expect(startPodSession).toHaveBeenCalledWith({
+      context: PINNED,
+      namespace: "default",
+      pod: "checkout",
+      container: "app",
+    });
+    // The tab the session opens is labelled with the same cluster: a
+    // terminal captioned `stage-eu` over a `prod-eu` pod is the same lie one
+    // layer up.
+    expect(store.currentWorkspace().tabs.some((t) => t.route === "/terminals" && t.sub === PINNED)).toBe(true);
+  });
+});

--- a/packages/ui-next/src/screens/ResourceMenu.tsx
+++ b/packages/ui-next/src/screens/ResourceMenu.tsx
@@ -18,6 +18,7 @@ import {
   type KubectlInput,
 } from "@srelens/core";
 import { ConfirmDialog, KubectlPreview, Select, TextInput, type ContextMenuItem } from "@srelens/ui-kit";
+import { ClusterMovedAlert, useClusterGate } from "../lib/clusterMoved";
 import { detailRoute } from "../lib/detailRoute";
 import { FailureLine } from "../lib/errorCopy";
 import { Icons } from "../lib/icons";
@@ -37,13 +38,42 @@ export interface UseRowMenuArgs {
 }
 
 /** What a picked entry is waiting to do, once the confirm is taken. */
-type Pending =
+type Ask =
   | { type: "delete"; row: ListRow }
   | { type: "scale"; row: ListRow }
   | { type: "restart"; row: ListRow }
   | { type: "evict"; row: ListRow }
   /** `suspend: true` sets the CronJob suspended; `false` resumes it. */
   | { type: "suspend"; row: ListRow; suspend: boolean };
+
+/**
+ * An {@link Ask}, plus the cluster it was asked ON.
+ *
+ * **The context is captured when the entry is picked and never re-read.**
+ * Since #357 a dialog covers only its own tab, so the cluster rail is live
+ * behind this one and `setActiveCluster` switches the active cluster in place,
+ * globally — no screen carries `key={name}`, so nothing here remounts and
+ * `pending` survives the switch intact. Reading the `context` prop inside
+ * `confirm` therefore meant a Delete opened on production's `checkout` ran
+ * against whichever cluster the reader had moved to, while the dialog on
+ * screen still named production's row. Two clicks, and staging's Deployment
+ * is gone.
+ *
+ * The row, its namespace and the kubectl line beside it are all that cluster's;
+ * this is the field that keeps them together. See `lib/clusterMoved`.
+ */
+type Pending = Ask & { context: string };
+
+/**
+ * The word on the confirm's own button, for the acknowledgement the cluster
+ * gate asks for. Taken from the pick rather than restated, so "Yes, still
+ * resume on prod-eu." can never read as "suspend".
+ */
+function verbOf(pending: Pending | null): string {
+  if (!pending) return "act";
+  if (pending.type === "suspend") return pending.suspend ? "suspend" : "resume";
+  return pending.type;
+}
 
 /** `CronJobSummary` carries `suspended`; a bare `ListRow` doesn't promise it. */
 function isSuspended(row: ListRow): boolean {
@@ -58,6 +88,14 @@ interface ShellPick {
   namespace: string;
   choices: ContainerChoice[];
   container: string;
+  /**
+   * The cluster the pod was picked on, captured BEFORE the read that opens
+   * this — the exact case Helm's own fix (7e50ea0) singles out. `getObject` is
+   * a round trip, and the rail can move while it is in flight, so a dialog
+   * that pinned the context at mount would already be showing one cluster's
+   * container names over another cluster's pod.
+   */
+  context: string;
 }
 
 /**
@@ -112,15 +150,35 @@ export function useRowMenu({ context, kind, actions }: UseRowMenuArgs): {
   const [error, setError] = useState("");
   const [replicas, setReplicas] = useState("");
 
-  function open(next: Pending) {
+  /**
+   * The divergence banner, its acknowledgement and the refusal behind it.
+   *
+   * `pending.context` is what this dialog runs against; `context` is what the
+   * reader has in FOCUS, which is the only thing a rail switch may change.
+   * The verb is the button's own word, so the tick reads as the thing that is
+   * about to happen rather than as a generic assent.
+   */
+  const gate = useClusterGate({
+    pinned: pending?.context ?? null,
+    live: context,
+    verb: verbOf(pending),
+  });
+  /** The same, for the container picker — see {@link ShellPick.context}. */
+  const shellMoved = shellPick !== null && shellPick.context !== context;
+
+  function open(next: Ask) {
     setError("");
+    gate.reset();
     if (next.type === "scale") setReplicas("");
-    setPending(next);
+    // The cluster the reader picked this ON, read once, here. Everything the
+    // confirm does below belongs to it.
+    setPending({ ...next, context });
   }
 
   function close() {
     setPending(null);
     setError("");
+    gate.reset();
   }
 
   async function runNow(row: ListRow) {
@@ -153,7 +211,11 @@ export function useRowMenu({ context, kind, actions }: UseRowMenuArgs): {
    */
   async function startShell(row: ListRow) {
     const namespace = row.namespace ?? "";
-    const result = await getObject(context, kind, namespace || null, row.name);
+    // Pinned before the read, not after it: the rail can move while
+    // `getObject` is in flight, and a shell opened on one cluster's container
+    // list must not attach to another cluster's pod of the same name.
+    const target = context;
+    const result = await getObject(target, kind, namespace || null, row.name);
     if (result.error || !result.object) {
       notify.error(`Couldn't open a shell in ${row.name}`, describeError(result.error ?? "Pod not found").detail);
       return;
@@ -169,33 +231,43 @@ export function useRowMenu({ context, kind, actions }: UseRowMenuArgs): {
         namespace,
         choices,
         container: defaultContainer(result.object, choices) ?? choices[0].name,
+        context: target,
       });
       return;
     }
-    await launchShell(row, namespace, choices[0].name);
+    await launchShell(row, namespace, choices[0].name, target);
   }
 
   /** Starts the session and opens the screen that shows it. Two separate
    *  effects — a session that failed to open is still a `closed` row on
    *  `/terminals`, worth showing rather than hiding behind a tab that never
    *  opens. */
-  async function launchShell(row: ListRow, namespace: string, container: string) {
-    await startPodSession({ context, namespace, pod: row.name, container });
-    openTab("/terminals", { clusterName: context });
+  async function launchShell(row: ListRow, namespace: string, container: string, target: string) {
+    await startPodSession({ context: target, namespace, pod: row.name, container });
+    openTab("/terminals", { clusterName: target });
   }
 
   async function confirmShell() {
     if (!shellPick) return;
     setShellBusy(true);
-    await launchShell(shellPick.row, shellPick.namespace, shellPick.container);
+    await launchShell(shellPick.row, shellPick.namespace, shellPick.container, shellPick.context);
     setShellBusy(false);
     setShellPick(null);
   }
 
   async function confirm() {
     if (!pending) return;
-    const { row } = pending;
+    const { row, context: target } = pending;
     const ns = row.namespace ?? "";
+
+    // Asked before anything else: it is the only question on screen whose
+    // answer changes what every other name in the dialog refers to. The write
+    // still goes to `target` either way — this re-arms the confirmation, it
+    // does not retarget it.
+    if (gate.refusal) {
+      setError(gate.refusal);
+      return;
+    }
 
     if (pending.type === "scale") {
       const n = Number(replicas);
@@ -209,16 +281,18 @@ export function useRowMenu({ context, kind, actions }: UseRowMenuArgs): {
     setError("");
     const result = await (async () => {
       switch (pending.type) {
+        // Every one of these takes `target` — the cluster the entry was picked
+        // on — and never the live `context` prop. See {@link Pending}.
         case "delete":
-          return deleteResource(context, kind, row.namespace ?? null, row.name);
+          return deleteResource(target, kind, row.namespace ?? null, row.name);
         case "scale":
-          return scaleResource(context, kind, ns, row.name, Number(replicas));
+          return scaleResource(target, kind, ns, row.name, Number(replicas));
         case "restart":
-          return rolloutRestart(context, kind, ns, row.name);
+          return rolloutRestart(target, kind, ns, row.name);
         case "evict":
-          return evictPod(context, ns, row.name);
+          return evictPod(target, ns, row.name);
         case "suspend":
-          return cronjobSetSuspend(context, ns, row.name, pending.suspend);
+          return cronjobSetSuspend(target, ns, row.name, pending.suspend);
       }
     })();
     setBusy(false);
@@ -313,7 +387,21 @@ export function useRowMenu({ context, kind, actions }: UseRowMenuArgs): {
   }
 
   const dialog = pending ? (
-    <PendingDialog pending={pending} kind={kind} context={context} busy={busy} error={error} replicas={replicas} onReplicasChange={setReplicas} onConfirm={() => void confirm()} onCancel={close} />
+    <PendingDialog
+      pending={pending}
+      kind={kind}
+      // Captured, not current. The kubectl line under the message names the
+      // cluster the write will actually reach, which is the same one the alert
+      // above it names.
+      context={pending.context}
+      moved={gate.alert}
+      busy={busy}
+      error={error}
+      replicas={replicas}
+      onReplicasChange={setReplicas}
+      onConfirm={() => void confirm()}
+      onCancel={close}
+    />
   ) : forwarding ? (
     // The row's own kind and identity, prefilled. A list row knows no ports,
     // so the remote one is the reader's to name — and the dialog stays fully
@@ -333,6 +421,15 @@ export function useRowMenu({ context, kind, actions }: UseRowMenuArgs): {
       onCancel={() => setShellPick(null)}
       message={
         <>
+          {/* Stated, and nothing more: opening a shell writes nothing, and the
+              terminal it opens is labelled with the cluster it is on. What was
+              silently wrong before is which cluster's pod it attached to, and
+              pinning `shellPick.context` is what fixes that. */}
+          {shellMoved && (
+            <ClusterMovedAlert pinned={shellPick.context} live={context}>
+              {` Cancel and open a shell again from ${context} to attach there.`}
+            </ClusterMovedAlert>
+          )}
           <p style={{ marginTop: 0 }}>
             <code>{shellPick.row.name}</code> runs more than one container — which one?
           </p>
@@ -443,6 +540,7 @@ function PendingDialog({
   pending,
   kind,
   context,
+  moved,
   busy,
   error,
   replicas,
@@ -452,7 +550,10 @@ function PendingDialog({
 }: {
   pending: Pending;
   kind: string;
+  /** The cluster this runs against — `pending.context`, never the live prop. */
   context: string;
+  /** The cluster-moved banner and its tick, or `null` when the rail has not moved. */
+  moved: ReactNode;
   busy: boolean;
   error: string;
   replicas: string;
@@ -487,6 +588,10 @@ function PendingDialog({
       onCancel={onCancel}
       message={
         <>
+          {/* First, above the row's own name: it changes what that name refers
+              to, and it is the only thing here the reader does not already
+              know. */}
+          {moved}
           <p style={{ marginTop: 0 }}>{messageFor(pending)}</p>
           {pending.type === "scale" && (
             <TextInput

--- a/packages/ui-next/src/screens/helm/HelmOpDialog.test.tsx
+++ b/packages/ui-next/src/screens/helm/HelmOpDialog.test.tsx
@@ -666,3 +666,100 @@ describe("HelmOpDialog — submitting", () => {
     expect(screen.getByText(/image: nginx:1\.27/)).toBeTruthy();
   });
 });
+
+/**
+ * **The cluster this operation targets is the one it was opened against.**
+ *
+ * The rail is reachable behind a dialog since #357, so the cluster in focus
+ * can change while this is open. `context` is what the operation runs against
+ * and it must not move; `activeContext` is what the reader has in focus now,
+ * and the only thing it may change is what the dialog SAYS.
+ *
+ * A silent retarget is the failure worth all of this: `helm uninstall` on the
+ * cluster the reader wandered to, behind a gate they typed out for a different
+ * cluster's release, is not recoverable.
+ */
+describe("HelmOpDialog — the cluster it was opened against", () => {
+  const ELSEWHERE = "stage-eu";
+
+  /** What the store was told to run the operation against. */
+  const target = () => store.startHelmOperation.mock.calls[0]?.[0]?.context;
+
+  /** The divergence alert, by its title, or null when it is not there. */
+  const moved = () => screen.queryByText(`This still runs against ${CONTEXT}, not ${ELSEWHERE}`);
+
+  it("submits the context it was opened against, not the one in focus", async () => {
+    open({ kind: "uninstall", activeContext: ELSEWHERE });
+    await screen.findByRole("dialog");
+    await userEvent.type(field(`Type ${RELEASE} to confirm`), RELEASE);
+    await userEvent.click(button("Uninstall"));
+
+    expect(store.startHelmOperation).toHaveBeenCalledTimes(1);
+    expect(target()).toBe(CONTEXT);
+  });
+
+  it("keeps naming the cluster it was opened against in the command block", async () => {
+    open({ kind: "upgrade", activeContext: ELSEWHERE });
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText(`srelens runs this against ${CONTEXT}.`)).toBeTruthy();
+    expect(within(dialog).queryByText(new RegExp(ELSEWHERE + "\\."))).toBeNull();
+  });
+
+  it("says the rail has moved, and what that does not change", async () => {
+    open({ kind: "uninstall", activeContext: ELSEWHERE });
+    await screen.findByRole("dialog");
+    // Toned `warn`, so the kit gives it `role="status"` — a polite live region,
+    // which is what announces a fact that appears while the dialog is already
+    // open. Uninstall's own `sev` alert stays the assertive one.
+    const alert = moved()?.closest('[data-tone="warn"]');
+    expect(alert).toBeTruthy();
+    expect(alert?.getAttribute("role")).toBe("status");
+    expect(alert?.textContent?.replace(/\s+/g, " ")).toContain(
+      `a release of the same name on ${ELSEWHERE} is a different release`,
+    );
+
+    // And it is first, above even "This removes every object in the release":
+    // it changes what every name under it refers to.
+    const alerts = Array.from(document.querySelectorAll("[data-tone]"));
+    expect(alerts[0]).toBe(alert);
+  });
+
+  it("says nothing when the rail has not moved, or when there is nothing in focus", async () => {
+    const { unmount } = render(
+      <HelmOpDialog
+        kind="uninstall"
+        context={CONTEXT}
+        activeContext={CONTEXT}
+        namespace={NAMESPACE}
+        release={RELEASE}
+        onClose={vi.fn()}
+      />,
+    );
+    await screen.findByRole("dialog");
+    // Uninstall's own alert, and only it.
+    expect(document.querySelectorAll("[data-tone]")).toHaveLength(1);
+    expect(screen.queryByText(new RegExp("This still runs against"))).toBeNull();
+    unmount();
+
+    open({ kind: "uninstall" });
+    await screen.findByRole("dialog");
+    expect(document.querySelectorAll("[data-tone]")).toHaveLength(1);
+    expect(screen.queryByText(new RegExp("This still runs against"))).toBeNull();
+  });
+
+  /**
+   * The gate is unchanged by any of this: it is the release the dialog was
+   * opened for, typed exactly. A switch neither passes it nor re-arms it — the
+   * operation has not changed, so neither has what was confirmed about it.
+   */
+  it("leaves the typed gate exactly as it was", async () => {
+    open({ kind: "uninstall", activeContext: ELSEWHERE });
+    await screen.findByRole("dialog");
+    expect(button("Uninstall").disabled).toBe(true);
+    await userEvent.type(field(`Type ${RELEASE} to confirm`), RELEASE.toUpperCase());
+    expect(button("Uninstall").disabled).toBe(true);
+    await userEvent.clear(field(`Type ${RELEASE} to confirm`));
+    await userEvent.type(field(`Type ${RELEASE} to confirm`), RELEASE);
+    expect(button("Uninstall").disabled).toBe(false);
+  });
+});

--- a/packages/ui-next/src/screens/helm/HelmOpDialog.tsx
+++ b/packages/ui-next/src/screens/helm/HelmOpDialog.tsx
@@ -197,8 +197,27 @@ export function lastGoodRevision(
 export interface HelmOpDialogProps {
   /** Which of the four this is. */
   kind: HelmOpKind;
-  /** The cluster it runs in — a kubeconfig context NAME. */
+  /**
+   * The cluster it runs in — a kubeconfig context NAME.
+   *
+   * **Fixed when the dialog is opened, and never afterwards.** The caller
+   * captures it and hands the same value for this dialog's whole life; see
+   * {@link activeContext} for why that is now a rule rather than an accident.
+   */
   context: string;
+  /**
+   * The cluster the reader has in FOCUS, which is not always {@link context}.
+   *
+   * Since #357 a dialog covers only its own tab, so the cluster rail is live
+   * behind this one and the reader can move it while the dialog is open. The
+   * operation does not move with it: it runs against the cluster it was opened
+   * against, because the release named in this dialog is that cluster's and a
+   * release of the same name elsewhere is a different release. What changes is
+   * only what the dialog SAYS — a divergence is stated rather than acted on.
+   *
+   * Omitted means "nothing to compare against", and the dialog says nothing.
+   */
+  activeContext?: string;
   /** Where the release lives — and, for install, where its own field starts. */
   namespace: string;
   /**
@@ -283,6 +302,7 @@ const TITLE: Record<HelmOpKind, string> = {
 export function HelmOpDialog({
   kind,
   context,
+  activeContext,
   namespace,
   release,
   chart: initialChart = "",
@@ -297,6 +317,19 @@ export function HelmOpDialog({
   onStarted,
 }: HelmOpDialogProps) {
   const takesChart = kind === "install" || kind === "upgrade";
+  /**
+   * Has the reader moved the cluster rail out from under this dialog?
+   *
+   * Nothing is done about it beyond saying so. Retargeting the operation to
+   * follow the rail is the one outcome that must never happen here — an
+   * uninstall whose gate was typed out for one cluster's release, submitted
+   * against another cluster's release of the same name, is not recoverable —
+   * and closing the dialog would throw away a values body the reader typed for
+   * a mistake they may be about to undo. The screen's own habit is the one
+   * followed: keep what is there, state what changed, reset nothing the reader
+   * did not ask to have reset.
+   */
+  const moved = activeContext !== undefined && activeContext !== context;
   /**
    * **Install names its own release, which §A.5 does not draw.**
    *
@@ -473,6 +506,19 @@ export function HelmOpDialog({
       }
     >
       <div className="flex min-w-0 flex-col gap-3 p-3">
+        {moved && (
+          /* First, above even uninstall's own alert: it is the only thing on
+             screen the reader does not already know, and it changes what every
+             name below it refers to. */
+          <Alert tone="warn" title={`This still runs against ${context}, not ${activeContext}`}>
+            The cluster in focus changed while this was open. srelens is still
+            talking to {context}, and the release named here is that cluster's
+            — a release of the same name on {activeContext} is a different
+            release. Cancel and open this again from {activeContext} to operate
+            there.
+          </Alert>
+        )}
+
         {kind === "uninstall" && (
           <Alert tone="sev" title="This removes every object in the release">
             {/* No counts. See this component's note: srelens has not asked the

--- a/packages/ui-next/src/shell/TabSurface.test.tsx
+++ b/packages/ui-next/src/shell/TabSurface.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
+import { Dialog } from "@srelens/ui-kit";
 import { TabSurface } from "./TabSurface";
 
 /** Holds a count so a remount would be visible: it would reset to 0. */
@@ -14,11 +15,15 @@ function Counter() {
   );
 }
 
+const surfaces = () => Array.from(document.querySelectorAll("[data-slot='tab-surface']")) as HTMLElement[];
+const surface = () => surfaces()[0];
+const content = () => document.querySelector("[data-slot='tab-content']") as HTMLElement;
+
 describe("TabSurface", () => {
   it("shows its child when visible", () => {
     render(<TabSurface visible><p>the table</p></TabSurface>);
-    const surface = screen.getByText("the table").parentElement!;
-    expect(surface.hidden).toBe(false);
+    expect(screen.getByText("the table")).toBeDefined();
+    expect(surface().hidden).toBe(false);
   });
 
   it("hides rather than unmounts when not visible, so state survives", async () => {
@@ -27,8 +32,8 @@ describe("TabSurface", () => {
     expect(screen.getByRole("button").textContent).toBe("count 1");
 
     rerender(<TabSurface visible={false}><Counter /></TabSurface>);
-    const surface = screen.getByRole("button", { hidden: true }).parentElement!;
-    expect(surface.hidden).toBe(true);
+    expect(surface().hidden).toBe(true);
+    expect(screen.getByRole("button", { hidden: true }).textContent).toBe("count 1");
 
     rerender(<TabSurface visible><Counter /></TabSurface>);
     expect(screen.getByRole("button").textContent).toBe("count 1");
@@ -43,8 +48,175 @@ describe("TabSurface", () => {
 
   it("fills its container", () => {
     render(<TabSurface visible><p>x</p></TabSurface>);
-    const surface = screen.getByText("x").parentElement!;
-    expect(surface.className).toContain("absolute");
-    expect(surface.className).toContain("inset-0");
+    expect(surface().className).toContain("absolute");
+    expect(surface().className).toContain("inset-0");
+  });
+
+  it("passes the tab's column layout through the content wrapper", () => {
+    // The wrapper is new: it exists so the portal target can be a sibling
+    // rather than a descendant. A screen inside a tab is written against a
+    // full-height flex column, so the wrapper has to be one too, or every
+    // ported screen loses its height the day this lands.
+    render(<TabSurface visible><p>x</p></TabSurface>);
+    expect(content().className).toContain("flex");
+    expect(content().className).toContain("flex-col");
+    expect(content().className).toContain("flex-1");
+    expect(content().className).toContain("min-h-0");
+  });
+});
+
+/**
+ * A dialog opened in a tab belongs to that tab.
+ *
+ * Two halves of one bug, which have to land together. A dialog portalled to
+ * `document.body` covered the tab strip, the cluster rail and the status bar,
+ * so no other tab could be reached until it was dismissed — and a portal
+ * escapes `hidden`, so the moment that blocking was lifted the first tab's
+ * dialog would have sat on top of whatever tab the reader moved to. Mounting it
+ * inside the tab's own subtree answers both at once. (#357)
+ */
+describe("TabSurface as a portal scope", () => {
+  it("keeps a dialog opened inside it inside it", () => {
+    render(
+      <TabSurface visible>
+        <Dialog title="Customise" onClose={() => {}}>body</Dialog>
+      </TabSurface>,
+    );
+    expect(surface().contains(screen.getByRole("dialog"))).toBe(true);
+    expect(screen.getByRole("dialog").parentElement).not.toBe(document.body);
+  });
+
+  it("hides the dialog when the tab is hidden, which a portal to the body would not", () => {
+    const { rerender } = render(
+      <TabSurface visible>
+        <Dialog title="Customise" onClose={() => {}}>body</Dialog>
+      </TabSurface>,
+    );
+    expect(screen.getByRole("dialog")).toBeDefined();
+
+    rerender(
+      <TabSurface visible={false}>
+        <Dialog title="Customise" onClose={() => {}}>body</Dialog>
+      </TabSurface>,
+    );
+    expect(screen.queryByRole("dialog")).toBeNull();
+    // Still mounted, and still this tab's: hidden, not moved and not unmounted.
+    expect(surface().contains(screen.getByRole("dialog", { hidden: true }))).toBe(true);
+  });
+
+  it("gives two tabs a dialog each, in their own tabs", () => {
+    render(
+      <>
+        <TabSurface visible={false}>
+          <Dialog title="Rename workload" onClose={() => {}}>a</Dialog>
+        </TabSurface>
+        <TabSurface visible>
+          <Dialog title="Uninstall release" onClose={() => {}}>b</Dialog>
+        </TabSurface>
+      </>,
+    );
+    const [first, second] = surfaces();
+    expect(first.contains(screen.getByRole("dialog", { hidden: true, name: "Rename workload" }))).toBe(true);
+    expect(second.contains(screen.getByRole("dialog", { name: "Uninstall release" }))).toBe(true);
+  });
+
+  it("makes the tab's content unreachable while a dialog covers it", () => {
+    // The overlay stops the pointer, and that is all it stops. Without this the
+    // covered screen is still a tab stop and still on an assistive
+    // technology's own cursor, because a non-modal Radix dialog no longer
+    // applies `aria-hidden` to anything.
+    const { rerender } = render(
+      <TabSurface visible>
+        <Dialog title="Customise" onClose={() => {}}>body</Dialog>
+      </TabSurface>,
+    );
+    expect(content().hasAttribute("inert")).toBe(true);
+
+    rerender(<TabSurface visible><p>the table</p></TabSurface>);
+    expect(content().hasAttribute("inert")).toBe(false);
+  });
+
+  it("leaves the dialog itself reachable", () => {
+    // Which is why the portal target is a sibling of the content and not
+    // inside it: an inert subtree takes its own descendants with it.
+    render(
+      <TabSurface visible>
+        <Dialog title="Customise" onClose={() => {}}>body</Dialog>
+      </TabSurface>,
+    );
+    expect(content().contains(screen.getByRole("dialog"))).toBe(false);
+    expect(surface().contains(screen.getByRole("dialog"))).toBe(true);
+  });
+
+  it("keeps a dialog, and what was typed in it, across a switch away and back", () => {
+    // The reason the surface is hidden rather than unmounted, now that a dialog
+    // lives inside it. A reader who leaves a half-filled dialog to check
+    // another tab — the release name in Helm's uninstall gate is the case that
+    // reported this — must find it exactly as they left it. (#357)
+    const dialog = (
+      <Dialog title="Uninstall release" onClose={() => {}}>
+        <input aria-label="Release name" defaultValue="" />
+      </Dialog>
+    );
+    const { rerender } = render(<TabSurface visible>{dialog}</TabSurface>);
+    const field = screen.getByLabelText("Release name") as HTMLInputElement;
+    fireEvent.change(field, { target: { value: "kube-prometheus" } });
+
+    rerender(<TabSurface visible={false}>{dialog}</TabSurface>);
+    expect(screen.queryByRole("dialog")).toBeNull();
+
+    rerender(<TabSurface visible>{dialog}</TabSurface>);
+    expect(screen.getByRole("dialog", { name: "Uninstall release" })).toBeDefined();
+    expect((screen.getByLabelText("Release name") as HTMLInputElement).value).toBe("kube-prometheus");
+  });
+
+  it("does not close a dialog when the reader clicks the shell around the tab", async () => {
+    // Switching tabs is a click outside the dialog, and the overlay no longer
+    // covers the strip that click lands on. Standing in for the strip here,
+    // because TabSurface's siblings in the window are exactly that.
+    const onClose = vi.fn();
+    render(
+      <>
+        <button type="button">another tab</button>
+        <TabSurface visible>
+          <Dialog title="Customise" onClose={onClose}>body</Dialog>
+        </TabSurface>
+      </>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "another tab" }));
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog")).toBeDefined();
+  });
+
+  it("still closes a dialog on a click on its own overlay", async () => {
+    // The other half of the same rule, kept apart from it on purpose: one loose
+    // assertion about "clicks outside" would pass for both while only one of
+    // them was true.
+    const onClose = vi.fn();
+    render(
+      <TabSurface visible>
+        <Dialog title="Customise" onClose={onClose}>body</Dialog>
+      </TabSurface>,
+    );
+    await userEvent.click(document.querySelector("[data-slot='dialog-overlay']") as HTMLElement);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("makes a hidden tab's dialog ignore Escape", () => {
+    // Radix routes Escape to whichever layer was opened last, which is not
+    // necessarily the tab the reader is looking at.
+    const onClose = vi.fn();
+    render(
+      <TabSurface visible={false}>
+        <Dialog title="Customise" onClose={onClose}>body</Dialog>
+      </TabSurface>,
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("marks nothing inert with no dialog open", () => {
+    render(<TabSurface visible><p>the table</p></TabSurface>);
+    expect(content().hasAttribute("inert")).toBe(false);
   });
 });

--- a/packages/ui-next/src/shell/TabSurface.tsx
+++ b/packages/ui-next/src/shell/TabSurface.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { PortalScopeProvider, usePortalHost } from "@srelens/ui-kit";
 
 /**
  * One tab's view, kept mounted whether or not it is the one on screen.
@@ -14,11 +15,47 @@ import type { ReactNode } from "react";
  * tree and the tab order as well as from view, which `display: none` also
  * does, but the attribute says what is meant. Every surface is absolutely
  * positioned over the same box, so the visible one is the only one laid out.
+ *
+ * It is also a portal scope, which is what keeps a dialog opened in this tab
+ * inside this tab. Two halves of one bug (#357). A dialog portalled to
+ * `document.body` covered the tab strip, the cluster rail and the status bar,
+ * and Radix's focus trap and `aria-hidden` isolation made every other tab
+ * unreachable until it was dismissed — and a portal escapes `hidden`, so
+ * lifting that blocking on its own would have left the first tab's dialog
+ * sitting on top of whatever tab the reader moved to. Mounting the dialog in
+ * this subtree answers both: it is hidden with the tab, and it covers only the
+ * tab, so the strip and the rail stay live behind it.
+ *
+ * Hence the two children rather than one. The content goes in its own wrapper
+ * so it can be marked `inert` while a dialog covers it — the overlay stops the
+ * pointer and nothing else, and a non-modal Radix dialog applies `aria-hidden`
+ * to nothing, so without this the covered screen is still a tab stop and still
+ * on a screen reader's cursor. The portal target has to be that wrapper's
+ * *sibling*: an inert subtree takes its own descendants with it, so a dialog
+ * mounted inside the content it is meant to be covering would be inert too.
+ *
+ * The scope is told whether this tab is the one on screen, because a hidden
+ * tab keeps its dialogs mounted: without it, a dialog left open on a tab the
+ * reader has switched away from would still answer their Escape. (#357)
+ *
+ * The target carries no layout of its own. This surface is `absolute`, so it
+ * is already the containing block a dialog's `absolute inset-0` overlay
+ * resolves against; an empty static div is a zero-sized flex item and changes
+ * nothing about how the tab is laid out.
  */
 export function TabSurface({ visible, children }: { visible: boolean; children: ReactNode }) {
+  const { ref, layered, scope } = usePortalHost(visible);
+
   return (
-    <div hidden={!visible} className="absolute inset-0 flex min-h-0 flex-col">
-      {children}
+    <div data-slot="tab-surface" hidden={!visible} className="absolute inset-0 flex min-h-0 flex-col">
+      <PortalScopeProvider scope={scope}>
+        {/* The column the screens are written against, unchanged: it was this
+            element's parent that held it before the wrapper existed. */}
+        <div data-slot="tab-content" inert={layered} className="flex min-h-0 flex-1 flex-col">
+          {children}
+        </div>
+        <div data-slot="tab-layers" ref={ref} />
+      </PortalScopeProvider>
     </div>
   );
 }


### PR DESCRIPTION
Closes #357.

A dialog opened in one tab blocked every other tab: the kit's dialogs portalled to `document.body` with a `fixed inset-0` overlay plus Radix's focus trap and `aria-hidden` isolation, so the overlay covered the tab strip and the cluster rail.

The blocking was hiding a second bug. **A portal escapes `hidden`**, which is how `TabSurface` hides an inactive tab — so lifting the blocking alone would have left one tab's dialog sitting on top of whatever tab the reader moved to. Both halves land together.

## What ships

- **A portal scope.** `TabSurface` hosts its tab's layers; a dialog mounts inside its own tab and is hidden with it. The overlay is `absolute`, covering only the tab, so the strip, rail and status bar stay live. Optional by design: with no provider the value is `undefined` and Radix falls back to `document.body` — the gallery, the frozen classic app and bare tests are all on that path, unchanged.
- **All seven portalled components**, not just `Dialog` — `ConfirmDialog`, `ContextMenu`, `Popover`, `Tooltip`, `ColumnPicker`, `picker`. A context menu surviving a tab switch is the same bug in miniature.
- **Dismissal that matches the new shape.** An outside interaction dismisses only when it lands on the tab's own overlay. Clicking the strip switches tabs and leaves the dialog untouched, with typed values intact — which matters when the input is an uninstall gate's release name.
- **Tab can leave a dialog.** Radix hardcodes `loop: true`, exposes no prop and ignores `defaultPrevented`, so the loop cannot be turned off — but it can be out-run, because `Slot` composes a child's handler first and Radix reads live focus when it runs. Shared between both dialogs in `layerKeys.ts`.
- **Escape reaches the tab you can see.** Radix routes Escape to the highest layer by mount order, so a hidden tab's later-mounted dialog swallowed the key and the visible one never heard it. A hidden layer now marks its refusal and the last-mounted *showing* layer answers.

## The safety half

PR #354's review cleared *"can a destructive operation run against the wrong cluster?"* **partly because the modal overlay blocked the cluster rail.** This branch removes that premise, so the clearance was re-established by investigation — and the behaviour underneath turned out to be worse than #357 recorded.

`setActiveCluster` switches the active cluster **in place, globally**; no screen carries a `key`, so nothing remounts. Dialogs read the live cluster and **followed the rail**. Reproduced by execution:

```
deleteResource called with: [ 'stage-eu', 'Deployment', 'default', 'checkout' ]
```

Open Delete on a production row, click the rail, click Delete — staging's Deployment is gone, with the dialog still naming production's. Same for Helm's uninstall gate (typed out for one cluster, submitted against another), node drain, cordon, bulk delete, and `Open shell`, which read one cluster's containers and attached to another.

**Not reachable on `feat/ui-next` as it stands** — the overlay blocks the rail there. It becomes reachable only with this change, which is why the fix ships in the same PR and must never be split from it.

Fixed by capturing the cluster at the **click**, ahead of any round trip — not at the dialog's mount, which the in-flight rollback case proves is too late. Divergence is stated in a `warn` alert above even the destructive one, and confirms **re-arm**: the case a banner alone misses is the reader who moved the rail *because* they were on the wrong cluster, then pressed the button they already meant to press. Helm states without re-arming, since its input is a typed values body worth more than the tick.

**Left deliberately:** `Port forward` has the same latent shape, but it is a form whose effect visibly re-lists on a cluster change, so the switch is seen rather than silent. Fixing it honestly needs two more files; filed rather than half-done.

## Verification

4069 tests across core/ui-kit/ui-next, 731 in apps/desktop, `pnpm -r typecheck` clean.

Every task ran a mutation pass; they found four real defects rather than only weak tests — a redundant pair of dismissal handlers where removing either changed nothing, a stale cluster acknowledgement satisfying a question never asked, a stacked-dialog ordering bug, and an unscoped-dialog gap in the Escape routing.

Where jsdom cannot reach — layout, focus, `inert` — properties were verified in real Chrome over CDP, and the tests that can only check an attribute now say so in their names.

## Known limits, written down

- An unscoped dialog is deliberately outside the Escape routing, so a document-wide modal under a later-mounted hidden layer gets no answer. Reaching it needs a tab switch while such a modal holds the window.
- `tabOrder()` misses controls hidden by CSS alone; a wrong edge degrades to Radix's loop rather than stranding focus.
- Nested dialogs are counted but not isolated — every dialog site in ui-next is mutually exclusive today.
