### PR TITLE
feat(ui-next): the connections and connect screens

### DIFF
--- a/apps/desktop/src/components/AppearanceSettingsSection.test.tsx
+++ b/apps/desktop/src/components/AppearanceSettingsSection.test.tsx
@@ -109,6 +109,19 @@ describe("AppearanceSettingsSection", () => {
     expect(items).toContain("Toolbox");
   });
 
+  it("lists the connections screen and the door a first run comes through", () => {
+    // `/connections` is where a reader sees every cluster srelens can see and
+    // which file each came from; `/connect` is the first-run door, and the only
+    // screen either design shows with no cluster connected at all. A reader
+    // weighing the toggle with nothing connected is weighing that one in
+    // particular, so leaving it unnamed would tell them the new design has no
+    // way in.
+    render(<AppearanceSettingsSection />);
+    const items = screen.getAllByRole("listitem").map((li) => li.textContent);
+    expect(items).toContain("Connections");
+    expect(items).toContain("Connect a cluster");
+  });
+
   it("introduces the list, so the names are not a bare list under the hint", () => {
     render(<AppearanceSettingsSection />);
     expect(screen.getByText(/in the new design so far/i)).toBeDefined();

--- a/apps/desktop/src/design.test.ts
+++ b/apps/desktop/src/design.test.ts
@@ -66,6 +66,8 @@ describe("the list of ported screens", () => {
       "/terminals",
       "/helm",
       "/toolbox",
+      "/connections",
+      "/connect",
     ]);
   });
 
@@ -82,6 +84,8 @@ describe("the list of ported screens", () => {
       "Terminals",
       "Helm",
       "Toolbox",
+      "Connections",
+      "Connect a cluster",
     ]);
   });
 });

--- a/apps/desktop/src/design.ts
+++ b/apps/desktop/src/design.ts
@@ -233,6 +233,15 @@ export const PORTED_SCREENS: ReadonlyArray<{ route: string; name: string }> = [
   // managed kubectl, helm and krew under ~/.srelens/bin, and what the active
   // context's exec-auth needs on PATH.
   { route: "/toolbox", name: "Toolbox" },
+  // Every cluster srelens can see at once, rather than one of them: the file
+  // each context was read from, which credential it uses, and what the last
+  // reachability probe said. Reached from the cluster rail's
+  // `Connection details`.
+  { route: "/connections", name: "Connections" },
+  // The first-run door, and the only screen here a reader can be on with no
+  // cluster connected at all. Listed after connections because that is where
+  // both ways in are — the `Add connection` control and the empty state's own.
+  { route: "/connect", name: "Connect a cluster" },
 ];
 
 /**

--- a/crates/kube/src/context_resolve.rs
+++ b/crates/kube/src/context_resolve.rs
@@ -16,7 +16,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use kube::config::Kubeconfig;
+use kube::config::{AuthInfo, Kubeconfig};
 
 /// One context resolved to a unique, user-facing identity plus everything
 /// needed to enumerate it and to reconnect via its own file.
@@ -37,6 +37,11 @@ pub struct ResolvedContext {
     pub exec_command: Option<String>,
     /// The user's auth-provider name, if any (for classification).
     pub auth_provider: Option<String>,
+    /// The credential MECHANISM this context's `auth-info` uses — never the
+    /// credential itself. See [`auth_kind_of`] for exactly what values this
+    /// takes. Computed once here, while the file is already parsed in memory,
+    /// rather than by re-reading the kubeconfig again per context.
+    pub auth_kind: String,
 }
 
 impl ResolvedContext {
@@ -129,6 +134,9 @@ pub fn resolve_from(configs: &[SourceConfig]) -> Vec<ResolvedContext> {
             let auth_provider = auth
                 .and_then(|info| info.auth_provider.as_ref())
                 .map(|provider| provider.name.clone());
+            let auth_kind = auth
+                .map(auth_kind_of)
+                .unwrap_or_else(|| "none".to_string());
 
             let is_current = !current_taken
                 && global_current.as_deref() == Some(original.as_str());
@@ -147,22 +155,68 @@ pub fn resolve_from(configs: &[SourceConfig]) -> Vec<ResolvedContext> {
                 is_current,
                 exec_command,
                 auth_provider,
+                auth_kind,
             });
         }
     }
     out
 }
 
+/// Map a kubeconfig's `auth-info` to the credential MECHANISM it names —
+/// never the credential. Exec ARGUMENTS are deliberately dropped: they
+/// routinely carry client IDs and, in bad kubeconfigs, secrets, and this
+/// string ends up rendered in a table.
+///
+/// A legacy `auth-provider` block (`gcp`, `azure`, `oidc`, or any other name a
+/// plugin registers) is named as exactly what the kubeconfig calls it —
+/// never generalised to `oidc` for all of them, which would assert something
+/// the source doesn't say. The only extra detail ever appended is a plain-text
+/// `email` already sitting in that provider's config map; nothing else from
+/// that map is ever surfaced, since that's where a refresh token or secret
+/// would live.
+fn auth_kind_of(auth: &AuthInfo) -> String {
+    if let Some(exec) = &auth.exec {
+        let command = exec.command.as_deref().unwrap_or("unknown");
+        return format!("exec plugin · {command}");
+    }
+    if let Some(provider) = &auth.auth_provider {
+        return match provider.config.get("email") {
+            Some(account) => format!("{} · {account}", provider.name),
+            None => provider.name.clone(),
+        };
+    }
+    if auth.client_certificate.is_some() || auth.client_certificate_data.is_some() {
+        return "client certificate".to_string();
+    }
+    if auth.token.is_some() || auth.token_file.is_some() {
+        return "token".to_string();
+    }
+    if auth.username.is_some() || auth.password.is_some() {
+        return "basic".to_string();
+    }
+    if auth.impersonate.is_some() {
+        return "impersonation".to_string();
+    }
+    "none".to_string()
+}
+
 /// Read each path and resolve its contexts. Unreadable files are skipped so one
 /// bad path can't hide every other cluster.
 pub fn resolve_contexts(paths: &[PathBuf]) -> Vec<ResolvedContext> {
+    resolve_contexts_with(paths, |path| Kubeconfig::read_from(path).ok())
+}
+
+/// Same as [`resolve_contexts`], but takes the file reader as a parameter so
+/// a test can count how many times each path is actually read. Kept private:
+/// this seam exists for that one pinning test, not as a public extension
+/// point.
+fn resolve_contexts_with(
+    paths: &[PathBuf],
+    mut read: impl FnMut(&Path) -> Option<Kubeconfig>,
+) -> Vec<ResolvedContext> {
     let configs: Vec<SourceConfig> = paths
         .iter()
-        .filter_map(|path| {
-            Kubeconfig::read_from(path)
-                .ok()
-                .map(|config| SourceConfig { source: path.clone(), config })
-        })
+        .filter_map(|path| read(path).map(|config| SourceConfig { source: path.clone(), config }))
         .collect();
     resolve_from(&configs)
 }
@@ -186,6 +240,106 @@ mod tests {
             source: PathBuf::from(source),
             config: Kubeconfig::from_yaml(yaml).unwrap(),
         }
+    }
+
+    /// An exec-plugin `AuthInfo` naming `command`, with `args` attached the
+    /// way a real exec plugin's arguments would be — so the leak test has
+    /// something to actually catch if `auth_kind_of` ever started including
+    /// them.
+    fn exec_auth(command: &str, args: &[&str]) -> AuthInfo {
+        AuthInfo {
+            exec: Some(kube::config::ExecConfig {
+                command: Some(command.to_string()),
+                args: Some(args.iter().map(|a| a.to_string()).collect()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn token_auth(token: &str) -> AuthInfo {
+        serde_yaml::from_str(&format!("token: \"{token}\"\n")).expect("valid auth-info fixture")
+    }
+
+    fn client_cert_auth() -> AuthInfo {
+        AuthInfo {
+            client_certificate_data: Some("c2VjcmV0LWNlcnQ=".to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn empty_auth() -> AuthInfo {
+        AuthInfo::default()
+    }
+
+    /// A legacy `auth-provider` block naming `provider`, with an arbitrary
+    /// config map — used to pin that the provider's own name is surfaced
+    /// verbatim, and that nothing from `config` leaks except a plain-text
+    /// `email` when present.
+    fn auth_provider(provider: &str, config: &[(&str, &str)]) -> AuthInfo {
+        AuthInfo {
+            auth_provider: Some(kube::config::AuthProviderConfig {
+                name: provider.to_string(),
+                config: config.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect(),
+                other: Default::default(),
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn auth_kind_names_the_mechanism_and_never_the_secret() {
+        assert_eq!(auth_kind_of(&exec_auth("gcloud", &["--client-id", "s3cr3t"])), "exec plugin · gcloud");
+        assert_eq!(auth_kind_of(&token_auth("eyJhbGciOi.very.secret")), "token");
+        assert_eq!(auth_kind_of(&client_cert_auth()), "client certificate");
+        assert_eq!(auth_kind_of(&empty_auth()), "none");
+    }
+
+    #[test]
+    fn auth_kind_leaks_no_credential_material() {
+        let kind = auth_kind_of(&token_auth("eyJhbGciOi.very.secret"));
+        assert!(!kind.contains("eyJ"), "auth kind must not carry the token: {kind}");
+        let exec = auth_kind_of(&exec_auth("gcloud", &["--client-id", "s3cr3t"]));
+        assert!(!exec.contains("s3cr3t"), "auth kind must not carry exec args: {exec}");
+    }
+
+    #[test]
+    fn legacy_auth_provider_is_named_as_what_it_is() {
+        // Each provider is named verbatim — never generalised to `oidc`,
+        // which would assert something the kubeconfig doesn't say.
+        assert_eq!(auth_kind_of(&auth_provider("gcp", &[])), "gcp");
+        assert_eq!(auth_kind_of(&auth_provider("azure", &[])), "azure");
+        assert_eq!(auth_kind_of(&auth_provider("oidc", &[])), "oidc");
+        assert_eq!(auth_kind_of(&auth_provider("my-custom-plugin", &[])), "my-custom-plugin");
+    }
+
+    #[test]
+    fn auth_provider_without_email_yields_the_bare_kind() {
+        // No plain-text account field present — nothing is invented.
+        let kind = auth_kind_of(&auth_provider("oidc", &[("client-id", "abc123")]));
+        assert_eq!(kind, "oidc");
+    }
+
+    #[test]
+    fn auth_provider_with_email_appends_only_the_email() {
+        let kind = auth_kind_of(&auth_provider("oidc", &[("email", "dana@example.com")]));
+        assert_eq!(kind, "oidc · dana@example.com");
+    }
+
+    #[test]
+    fn auth_provider_never_surfaces_any_other_config_key() {
+        // Secrets and refresh material live in this map under other keys —
+        // only `email` is ever allowed through, and only its value.
+        let kind = auth_kind_of(&auth_provider(
+            "oidc",
+            &[
+                ("id-token", "eyJ.super.secret"),
+                ("refresh-token", "another-secret"),
+                ("client-secret", "shh"),
+            ],
+        ));
+        assert_eq!(kind, "oidc", "no email present, so no key from config should leak in");
+        assert!(!kind.contains("secret"));
     }
 
     #[test]
@@ -289,5 +443,27 @@ mod tests {
         let by_display = resolved.iter().find(|c| c.display_name == "kube_stage/default").unwrap();
         assert_eq!(by_display.source, PathBuf::from("/kube/kube_stage.yaml"));
         assert_eq!(by_display.original_name, "default");
+    }
+
+    #[test]
+    fn a_file_with_several_contexts_is_read_once_not_once_per_context() {
+        // auth_kind used to be computed by re-reading each context's owning
+        // kubeconfig separately (once per CONTEXT); it must now come from the
+        // single parse `resolve_contexts` already does (once per FILE).
+        let path = PathBuf::from("/fake/multi.yaml");
+        let yaml = "clusters:\n- name: c\n  cluster: { server: https://c }\ncontexts:\n- name: a\n  context: { cluster: c, user: u }\n- name: b\n  context: { cluster: c, user: u }\n- name: c\n  context: { cluster: c, user: u }\nusers:\n- name: u\n  user: { token: t }\n";
+
+        let reads = std::cell::Cell::new(0usize);
+        let resolved = resolve_contexts_with(&[path.clone()], |p| {
+            assert_eq!(p, path.as_path());
+            reads.set(reads.get() + 1);
+            Kubeconfig::from_yaml(yaml).ok()
+        });
+
+        assert_eq!(resolved.len(), 3, "all three contexts in the file resolve");
+        for context in &resolved {
+            assert_eq!(context.auth_kind, "token", "auth_kind still computed correctly");
+        }
+        assert_eq!(reads.get(), 1, "the file must be read once, not once per context");
     }
 }

--- a/crates/kube/src/context_resolve.rs
+++ b/crates/kube/src/context_resolve.rs
@@ -163,38 +163,62 @@ pub fn resolve_from(configs: &[SourceConfig]) -> Vec<ResolvedContext> {
 }
 
 /// Map a kubeconfig's `auth-info` to the credential MECHANISM it names —
-/// never the credential. Exec ARGUMENTS are deliberately dropped: they
-/// routinely carry client IDs and, in bad kubeconfigs, secrets, and this
-/// string ends up rendered in a table. The exec COMMAND is reduced to its
-/// basename for the same reason — a generated path can itself carry an
-/// identifier or secret (e.g. a per-account credential directory) and the
-/// basename (`gcloud`, `kubelogin`, `aws-iam-authenticator`) is all a reader
-/// needs to know which plugin authenticates the cluster.
+/// never the credential, and never the account either.
+///
+/// **Nothing from an `auth-provider`'s `config` map is emitted, under any
+/// key.** This used to append `· <email>` when that map carried an
+/// `email`-shaped value, gated by a shape check (`@`, no whitespace, ≤254
+/// bytes). Both halves of that were wrong:
+///
+/// - The check was defeatable. `aws@AKIA….wJalrXUtnFEMI…`, a JWT-shaped blob
+///   with an `@` in it, and `a@b\u{200B}SECRET-BLOB` (a zero-width space is not
+///   `char::is_whitespace`) all walked through it. `@` plus no whitespace plus
+///   254 bytes is a wide door, and 254 bytes fits most secret material.
+/// - The account was never load-bearing. This string exists to say WHICH
+///   MECHANISM authenticates a cluster; the account was decoration. And
+///   `k8s.listContexts` is read-only, so it is not consent-gated: every field
+///   on `ContextDto` reaches any connected agent, the reader's own LLM
+///   included. "Already visible in the kubeconfig" is an argument about a
+///   human reading their own screen, not about that audience.
+///
+/// So the door is removed rather than narrowed.
+///
+/// **The two identifiers that ARE emitted are gated by shape.** An exec
+/// command's basename and an `auth-provider`'s own name are both strings a
+/// kubeconfig author chose, and both land in a table cell:
+///
+/// - Exec ARGUMENTS are dropped whole — they routinely carry client IDs and,
+///   in bad kubeconfigs, secrets.
+/// - The exec COMMAND is reduced to its basename, so a generated path
+///   (`/opt/creds/AKIA…/get-token.sh`) cannot bring its directory along. The
+///   basename (`gcloud`, `kubelogin`, `aws-iam-authenticator`) is the reader's
+///   actual question.
+/// - Whatever survives must still look like a plugin identifier — see
+///   [`identifier`]. A name that does not is dropped and only the mechanism is
+///   named: `exec plugin`, or `auth provider`. Honest and short beats echoing
+///   a string nobody checked.
 ///
 /// A legacy `auth-provider` block (`gcp`, `azure`, `oidc`, or any other name a
-/// plugin registers) is named as exactly what the kubeconfig calls it —
-/// never generalised to `oidc` for all of them, which would assert something
-/// the source doesn't say. The only extra detail ever appended is a plain-text
-/// `email` already sitting in that provider's config map, and only when it
-/// actually looks like one (see [`looks_like_an_email`]) — `config` is a
-/// generic `HashMap<String, String>`, so nothing guarantees a provider ever
-/// puts a real address under that key rather than, say, a refresh token.
-/// Nothing else from that map is ever surfaced, since that's where a refresh
-/// token or client secret would live.
+/// plugin registers) is otherwise named as exactly what the kubeconfig calls
+/// it — never generalised to `oidc` for all of them, which would assert
+/// something the source doesn't say.
 fn auth_kind_of(auth: &AuthInfo) -> String {
     if let Some(exec) = &auth.exec {
-        let command = exec.command.as_deref().unwrap_or("unknown");
+        let command = exec.command.as_deref().unwrap_or_default();
         // Basename only, and split on both separators regardless of host OS
         // (matching `local_cluster::is_cloud_auth`'s cross-platform basename
         // handling) — a kubeconfig authored on Windows and read on macOS/
         // Linux still shouldn't leak its directory structure here.
         let basename = command.rsplit(['/', '\\']).next().unwrap_or(command);
-        return format!("exec plugin · {basename}");
+        return match identifier(basename) {
+            Some(name) => format!("exec plugin · {name}"),
+            None => "exec plugin".to_string(),
+        };
     }
     if let Some(provider) = &auth.auth_provider {
-        return match provider.config.get("email").filter(|value| looks_like_an_email(value)) {
-            Some(account) => format!("{} · {account}", provider.name),
-            None => provider.name.clone(),
+        return match identifier(&provider.name) {
+            Some(name) => name.to_string(),
+            None => "auth provider".to_string(),
         };
     }
     if auth.client_certificate.is_some() || auth.client_certificate_data.is_some() {
@@ -212,19 +236,34 @@ fn auth_kind_of(auth: &AuthInfo) -> String {
     "none".to_string()
 }
 
-/// Whether `value` looks enough like an email address to be safely echoed:
-/// contains `@`, carries no whitespace, and is short enough that a smuggled
-/// credential blob (a token, a JWT, a client secret) can't ride along under
-/// this key instead of a real address. This is a shape check, not proof —
-/// `AuthProviderConfig.config` is a generic `HashMap<String, String>`, and
-/// nothing in the kubeconfig format guarantees any particular value under
-/// `"email"` — but it is exactly what stops a construction like
-/// `"refresh-token:abc.def.SECRET"` (no `@`) from being surfaced verbatim.
-fn looks_like_an_email(value: &str) -> bool {
-    // RFC 5321's mailbox length ceiling; generous for a real address and far
-    // too short for most token/JWT/secret material to slip under.
-    const MAX_EMAIL_LEN: usize = 254;
-    value.len() <= MAX_EMAIL_LEN && value.contains('@') && !value.chars().any(char::is_whitespace)
+/// `value` if it is shaped like a plugin identifier, and nothing otherwise.
+///
+/// An ALLOWLIST, not a denylist, and that is the whole point: a bound on
+/// length plus a ban on control/bidi/zero-width characters still passes
+/// `refresh-token:abc.def.SECRET` — 28 printable ASCII bytes carrying a
+/// credential. Naming what a plugin identifier may contain rejects that by
+/// construction rather than by enumerating what it may not.
+///
+/// The set is what real kubeconfigs actually hold: ASCII alphanumerics plus
+/// `-`, `_` and `.` — enough for `gke-gcloud-auth-plugin`,
+/// `kubectl-oidc_login`, `get-token.sh`, `gke-gcloud-auth-plugin.exe`,
+/// `azure-ad`. Anything else — a space, a colon, a slash that survived the
+/// basename split, a control character, a bidi override, a zero-width space,
+/// any non-ASCII — means this is not a name and the caller says so instead of
+/// echoing it.
+///
+/// The length bound is the second half: a 200-character run of `a` passes
+/// every character test and is still not a name.
+fn identifier(value: &str) -> Option<&str> {
+    /// Generous for every plugin and provider name that exists; far too short
+    /// for token, JWT or client-secret material.
+    const MAX_LEN: usize = 40;
+    let ok = !value.is_empty()
+        && value.len() <= MAX_LEN
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.');
+    ok.then_some(value)
 }
 
 /// Read each path and resolve its contexts. Unreadable files are skipped so one
@@ -300,9 +339,9 @@ mod tests {
     }
 
     /// A legacy `auth-provider` block naming `provider`, with an arbitrary
-    /// config map — used to pin that the provider's own name is surfaced
-    /// verbatim, and that nothing from `config` leaks except a plain-text
-    /// `email` when present.
+    /// config map — used to pin that the provider's own name is surfaced when
+    /// it is shaped like one, and that NOTHING from `config` ever leaks,
+    /// under any key.
     fn auth_provider(provider: &str, config: &[(&str, &str)]) -> AuthInfo {
         AuthInfo {
             auth_provider: Some(kube::config::AuthProviderConfig {
@@ -359,61 +398,140 @@ mod tests {
         assert_eq!(auth_kind_of(&auth_provider("my-custom-plugin", &[])), "my-custom-plugin");
     }
 
+    /// **The account is gone, and a real address is the case that proves it.**
+    ///
+    /// `oidc · dana@example.com` used to be emitted whenever a provider's
+    /// config map carried an `email`-shaped value. The auth KIND is the
+    /// load-bearing fact — this screen exists to say which mechanism
+    /// authenticates a cluster — and the account was decoration that cost a
+    /// defeatable shape check plus a PII disclosure on an agent surface
+    /// (`k8s.listContexts` is read-only, so it is not consent-gated and every
+    /// field on the DTO reaches any connected agent, the reader's LLM
+    /// included).
+    ///
+    /// Asserted with a value that WOULD have passed the old check, so this
+    /// test cannot pass by the payload being rejected — only by the account
+    /// never being appended at all.
     #[test]
-    fn auth_provider_without_email_yields_the_bare_kind() {
-        // No plain-text account field present — nothing is invented.
-        let kind = auth_kind_of(&auth_provider("oidc", &[("client-id", "abc123")]));
-        assert_eq!(kind, "oidc");
-    }
-
-    #[test]
-    fn auth_provider_with_email_appends_only_the_email() {
+    fn a_real_address_under_email_is_still_not_named() {
         let kind = auth_kind_of(&auth_provider("oidc", &[("email", "dana@example.com")]));
-        assert_eq!(kind, "oidc · dana@example.com");
-    }
-
-    #[test]
-    fn a_credential_parked_under_the_email_key_fails_the_shape_check() {
-        // The reviewer's construction: a real secret sitting under the one
-        // key meant to carry a plain-text account, with no `@` to give it
-        // away as anything but an address.
-        let kind = auth_kind_of(&auth_provider(
-            "oidc",
-            &[("email", "refresh-token:abc.def.SECRET")],
-        ));
-        assert_eq!(kind, "oidc", "a non-address value under `email` must not be echoed");
-        assert!(!kind.contains("SECRET") && !kind.contains("refresh-token"));
-    }
-
-    #[test]
-    fn an_overlong_value_under_email_fails_the_shape_check() {
-        // Has an `@` and no whitespace, so the naive check alone would pass
-        // it — the length bound is what catches a smuggled blob this shape.
-        let long = format!("{}@example.com", "a".repeat(300));
-        let kind = auth_kind_of(&auth_provider("oidc", &[("email", &long)]));
         assert_eq!(kind, "oidc");
+        assert!(!kind.contains('@'), "no account is ever appended: {kind}");
     }
 
+    /// The payloads that got PAST the old `looks_like_an_email` shape check,
+    /// kept as the record of why it went. Each one has an `@`, no
+    /// `char::is_whitespace`, and fits under 254 bytes — which is most secret
+    /// material. Nothing under any config key is emitted now, so none of them
+    /// has a door to walk through.
     #[test]
-    fn a_value_with_whitespace_under_email_fails_the_shape_check() {
-        let kind = auth_kind_of(&auth_provider("oidc", &[("email", "not an email at all")]));
-        assert_eq!(kind, "oidc");
-    }
+    fn no_value_under_any_config_key_reaches_the_kind() {
+        const AWS_PAIR: &str = "aws@AKIAIOSFODNN7EXAMPLE.wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY";
+        // A JWT-shaped blob with an `@` in it, well under the old 254-byte
+        // ceiling.
+        let jwt = format!("a@{}", "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.".repeat(4));
+        // A zero-width space is not `char::is_whitespace`, so the old check
+        // read this as one unbroken address.
+        const ZERO_WIDTH: &str = "a@b\u{200B}SECRET-BLOB";
 
-    #[test]
-    fn auth_provider_never_surfaces_any_other_config_key() {
-        // Secrets and refresh material live in this map under other keys —
-        // only `email` is ever allowed through, and only its value.
+        for value in [AWS_PAIR, jwt.as_str(), ZERO_WIDTH] {
+            let kind = auth_kind_of(&auth_provider("oidc", &[("email", value)]));
+            assert_eq!(kind, "oidc", "config values are never emitted: {value}");
+        }
+
+        // And the keys that were never allowed through in the first place.
         let kind = auth_kind_of(&auth_provider(
             "oidc",
             &[
                 ("id-token", "eyJ.super.secret"),
                 ("refresh-token", "another-secret"),
                 ("client-secret", "shh"),
+                ("email", "dana@example.com"),
             ],
         ));
-        assert_eq!(kind, "oidc", "no email present, so no key from config should leak in");
-        assert!(!kind.contains("secret"));
+        assert_eq!(kind, "oidc", "no key from config should leak in");
+        assert!(!kind.contains("secret") && !kind.contains('@'));
+    }
+
+    /// **The provider NAME is the other unchecked echo, and for an
+    /// auth-provider the bare kind IS the name** — so "the bare kind is
+    /// returned" is a tautology here and cannot be the assertion. What is
+    /// pinned instead is the SHAPE gate: a name that is not a plugin
+    /// identifier is not named at all.
+    #[test]
+    fn a_provider_name_that_is_not_an_identifier_is_not_named() {
+        // The payload the reviewer put through this door: a credential sitting
+        // where the plugin's name belongs. Short enough for a length bound
+        // alone to pass it, which is why the gate is a character allowlist.
+        let kind = auth_kind_of(&auth_provider("refresh-token:abc.def.SECRET", &[]));
+        assert_eq!(kind, "auth provider");
+        assert!(!kind.contains("SECRET"));
+
+        // Too long to be a name.
+        let long = auth_kind_of(&auth_provider(&"a".repeat(200), &[]));
+        assert_eq!(long, "auth provider");
+
+        // Control, bidi and zero-width characters, which a table renders
+        // invisibly or in reverse.
+        for hostile in ["oi\u{0}dc", "oid\u{202E}c", "oi\u{200B}dc", "oidc\u{FEFF}", "oi dc", "oidc\n"] {
+            let kind = auth_kind_of(&auth_provider(hostile, &[]));
+            assert_eq!(kind, "auth provider", "rejected: {hostile:?}");
+        }
+
+        // And a provider with no name at all is not a blank cell.
+        assert_eq!(auth_kind_of(&auth_provider("", &[])), "auth provider");
+    }
+
+    /// The same gate on the exec basename, the third unchecked echo. A
+    /// basename structurally cannot carry a directory, but it can still carry
+    /// anything a filename can.
+    #[test]
+    fn an_exec_basename_that_is_not_an_identifier_is_not_named() {
+        let kind = auth_kind_of(&exec_auth("/opt/creds/refresh-token:abc.def.SECRET", &[]));
+        assert_eq!(kind, "exec plugin");
+        assert!(!kind.contains("SECRET"));
+
+        let long = auth_kind_of(&exec_auth(&format!("/usr/bin/{}", "a".repeat(200)), &[]));
+        assert_eq!(long, "exec plugin");
+
+        for hostile in ["gcl\u{200B}oud", "gcloud\u{202E}", "gcl\u{0}oud", "get token.sh"] {
+            let kind = auth_kind_of(&exec_auth(hostile, &[]));
+            assert_eq!(kind, "exec plugin", "rejected: {hostile:?}");
+        }
+
+        // An exec block naming no command at all: the mechanism, no invented
+        // plugin name.
+        let nameless = auth_kind_of(&AuthInfo {
+            exec: Some(kube::config::ExecConfig { command: None, ..Default::default() }),
+            ..Default::default()
+        });
+        assert_eq!(nameless, "exec plugin");
+    }
+
+    /// The plugin names a reader actually has, which must all survive the
+    /// gate — a check that rejects real kubeconfigs is worse than none.
+    #[test]
+    fn the_plugin_names_readers_really_have_all_survive_the_gate() {
+        for command in [
+            "gcloud",
+            "gke-gcloud-auth-plugin",
+            "aws-iam-authenticator",
+            "aws",
+            "kubelogin",
+            "kubectl-oidc_login",
+            "get-token.sh",
+            "az",
+            "doctl",
+        ] {
+            assert_eq!(
+                auth_kind_of(&exec_auth(command, &[])),
+                format!("exec plugin · {command}"),
+                "a real plugin name must not be swallowed: {command}"
+            );
+        }
+        for provider in ["gcp", "azure", "oidc", "openstack", "azure-ad", "my-custom-plugin"] {
+            assert_eq!(auth_kind_of(&auth_provider(provider, &[])), provider);
+        }
     }
 
     #[test]

--- a/crates/kube/src/context_resolve.rs
+++ b/crates/kube/src/context_resolve.rs
@@ -165,22 +165,34 @@ pub fn resolve_from(configs: &[SourceConfig]) -> Vec<ResolvedContext> {
 /// Map a kubeconfig's `auth-info` to the credential MECHANISM it names —
 /// never the credential. Exec ARGUMENTS are deliberately dropped: they
 /// routinely carry client IDs and, in bad kubeconfigs, secrets, and this
-/// string ends up rendered in a table.
+/// string ends up rendered in a table. The exec COMMAND is reduced to its
+/// basename for the same reason — a generated path can itself carry an
+/// identifier or secret (e.g. a per-account credential directory) and the
+/// basename (`gcloud`, `kubelogin`, `aws-iam-authenticator`) is all a reader
+/// needs to know which plugin authenticates the cluster.
 ///
 /// A legacy `auth-provider` block (`gcp`, `azure`, `oidc`, or any other name a
 /// plugin registers) is named as exactly what the kubeconfig calls it —
 /// never generalised to `oidc` for all of them, which would assert something
 /// the source doesn't say. The only extra detail ever appended is a plain-text
-/// `email` already sitting in that provider's config map; nothing else from
-/// that map is ever surfaced, since that's where a refresh token or secret
-/// would live.
+/// `email` already sitting in that provider's config map, and only when it
+/// actually looks like one (see [`looks_like_an_email`]) — `config` is a
+/// generic `HashMap<String, String>`, so nothing guarantees a provider ever
+/// puts a real address under that key rather than, say, a refresh token.
+/// Nothing else from that map is ever surfaced, since that's where a refresh
+/// token or client secret would live.
 fn auth_kind_of(auth: &AuthInfo) -> String {
     if let Some(exec) = &auth.exec {
         let command = exec.command.as_deref().unwrap_or("unknown");
-        return format!("exec plugin · {command}");
+        // Basename only, and split on both separators regardless of host OS
+        // (matching `local_cluster::is_cloud_auth`'s cross-platform basename
+        // handling) — a kubeconfig authored on Windows and read on macOS/
+        // Linux still shouldn't leak its directory structure here.
+        let basename = command.rsplit(['/', '\\']).next().unwrap_or(command);
+        return format!("exec plugin · {basename}");
     }
     if let Some(provider) = &auth.auth_provider {
-        return match provider.config.get("email") {
+        return match provider.config.get("email").filter(|value| looks_like_an_email(value)) {
             Some(account) => format!("{} · {account}", provider.name),
             None => provider.name.clone(),
         };
@@ -198,6 +210,21 @@ fn auth_kind_of(auth: &AuthInfo) -> String {
         return "impersonation".to_string();
     }
     "none".to_string()
+}
+
+/// Whether `value` looks enough like an email address to be safely echoed:
+/// contains `@`, carries no whitespace, and is short enough that a smuggled
+/// credential blob (a token, a JWT, a client secret) can't ride along under
+/// this key instead of a real address. This is a shape check, not proof —
+/// `AuthProviderConfig.config` is a generic `HashMap<String, String>`, and
+/// nothing in the kubeconfig format guarantees any particular value under
+/// `"email"` — but it is exactly what stops a construction like
+/// `"refresh-token:abc.def.SECRET"` (no `@`) from being surfaced verbatim.
+fn looks_like_an_email(value: &str) -> bool {
+    // RFC 5321's mailbox length ceiling; generous for a real address and far
+    // too short for most token/JWT/secret material to slip under.
+    const MAX_EMAIL_LEN: usize = 254;
+    value.len() <= MAX_EMAIL_LEN && value.contains('@') && !value.chars().any(char::is_whitespace)
 }
 
 /// Read each path and resolve its contexts. Unreadable files are skipped so one
@@ -304,6 +331,25 @@ mod tests {
     }
 
     #[test]
+    fn exec_command_is_reduced_to_its_basename() {
+        // A generated per-account path can itself carry an identifier or
+        // secret; only the plugin name is ever a reader's actual question.
+        let kind = auth_kind_of(&exec_auth("/opt/creds/AKIASECRETBLOB/get-token.sh", &[]));
+        assert_eq!(kind, "exec plugin · get-token.sh");
+        assert!(!kind.contains("AKIASECRETBLOB"));
+    }
+
+    #[test]
+    fn exec_command_basename_handles_windows_style_paths_too() {
+        let kind = auth_kind_of(&exec_auth(
+            r"C:\Users\dana\SECRET_TOKEN_DIR\gke-gcloud-auth-plugin.exe",
+            &[],
+        ));
+        assert_eq!(kind, "exec plugin · gke-gcloud-auth-plugin.exe");
+        assert!(!kind.contains("SECRET_TOKEN_DIR"));
+    }
+
+    #[test]
     fn legacy_auth_provider_is_named_as_what_it_is() {
         // Each provider is named verbatim — never generalised to `oidc`,
         // which would assert something the kubeconfig doesn't say.
@@ -324,6 +370,34 @@ mod tests {
     fn auth_provider_with_email_appends_only_the_email() {
         let kind = auth_kind_of(&auth_provider("oidc", &[("email", "dana@example.com")]));
         assert_eq!(kind, "oidc · dana@example.com");
+    }
+
+    #[test]
+    fn a_credential_parked_under_the_email_key_fails_the_shape_check() {
+        // The reviewer's construction: a real secret sitting under the one
+        // key meant to carry a plain-text account, with no `@` to give it
+        // away as anything but an address.
+        let kind = auth_kind_of(&auth_provider(
+            "oidc",
+            &[("email", "refresh-token:abc.def.SECRET")],
+        ));
+        assert_eq!(kind, "oidc", "a non-address value under `email` must not be echoed");
+        assert!(!kind.contains("SECRET") && !kind.contains("refresh-token"));
+    }
+
+    #[test]
+    fn an_overlong_value_under_email_fails_the_shape_check() {
+        // Has an `@` and no whitespace, so the naive check alone would pass
+        // it — the length bound is what catches a smuggled blob this shape.
+        let long = format!("{}@example.com", "a".repeat(300));
+        let kind = auth_kind_of(&auth_provider("oidc", &[("email", &long)]));
+        assert_eq!(kind, "oidc");
+    }
+
+    #[test]
+    fn a_value_with_whitespace_under_email_fails_the_shape_check() {
+        let kind = auth_kind_of(&auth_provider("oidc", &[("email", "not an email at all")]));
+        assert_eq!(kind, "oidc");
     }
 
     #[test]
@@ -465,5 +539,35 @@ mod tests {
             assert_eq!(context.auth_kind, "token", "auth_kind still computed correctly");
         }
         assert_eq!(reads.get(), 1, "the file must be read once, not once per context");
+    }
+
+    #[test]
+    fn resolve_from_cannot_be_reading_the_file_itself_for_auth_kind() {
+        // The counting test above only counts calls made through the reader
+        // `resolve_contexts_with` injects — it would not have caught a
+        // regression that added a direct `Kubeconfig::read_from(&sc.source)`
+        // inside `resolve_from`'s own per-context loop, which is structurally
+        // where the original re-read-per-context bug lived. That route
+        // doesn't go through any seam this module controls, so it can't be
+        // closed by counting calls to one.
+        //
+        // Instead this pins the actual property that matters: `resolve_from`
+        // is documented as pure over already-parsed input and must never
+        // touch disk at all. `source` here points at a path that does not
+        // exist. If anything in `resolve_from`'s call graph tried to read it
+        // for real — by any route — that read would fail, and `auth_kind`
+        // could not correctly come out as "token" except by already being in
+        // the in-memory `Kubeconfig` passed in.
+        let ghost = PathBuf::from("/definitely/does/not/exist/srelens-kube-ghost.yaml");
+        let yaml = "clusters:\n- name: c\n  cluster: { server: https://c }\ncontexts:\n- name: a\n  context: { cluster: c, user: u }\n- name: b\n  context: { cluster: c, user: u }\nusers:\n- name: u\n  user: { token: t }\n";
+        let resolved = resolve_from(&[SourceConfig {
+            source: ghost,
+            config: Kubeconfig::from_yaml(yaml).unwrap(),
+        }]);
+
+        assert_eq!(resolved.len(), 2);
+        for context in &resolved {
+            assert_eq!(context.auth_kind, "token");
+        }
     }
 }

--- a/crates/kube/src/contexts.rs
+++ b/crates/kube/src/contexts.rs
@@ -56,14 +56,15 @@ pub struct ContextDto {
     #[serde(rename = "sourceFile")]
     pub source_file: String,
     /// The credential MECHANISM, never the credential. One of `client
-    /// certificate`, `token`, `basic`, `exec plugin · <command>`,
+    /// certificate`, `token`, `basic`, `exec plugin · <command's basename>`,
     /// `impersonation`, `none`, or a legacy auth-provider's own name (`gcp`,
     /// `azure`, `oidc`, …) optionally followed by `· <email>` when the
-    /// kubeconfig already carries that in plain text. See
-    /// `context_resolve::auth_kind_of` for the exact mapping. Exec ARGUMENTS
-    /// and everything else in an auth-provider's config map are deliberately
-    /// excluded: they routinely carry client IDs and sometimes secrets, and
-    /// this string is rendered in a table.
+    /// kubeconfig already carries one in plain text AND it actually looks
+    /// like an address. See `context_resolve::auth_kind_of` for the exact
+    /// mapping. Exec ARGUMENTS, the exec command's directory, and everything
+    /// else in an auth-provider's config map are deliberately excluded: they
+    /// routinely carry client IDs and sometimes secrets, and this string is
+    /// rendered in a table.
     #[serde(rename = "authKind")]
     pub auth_kind: String,
 }

--- a/crates/kube/src/contexts.rs
+++ b/crates/kube/src/contexts.rs
@@ -55,16 +55,20 @@ pub struct ContextDto {
     /// so don't reach for that distinction here either.)
     #[serde(rename = "sourceFile")]
     pub source_file: String,
-    /// The credential MECHANISM, never the credential. One of `client
-    /// certificate`, `token`, `basic`, `exec plugin · <command's basename>`,
-    /// `impersonation`, `none`, or a legacy auth-provider's own name (`gcp`,
-    /// `azure`, `oidc`, …) optionally followed by `· <email>` when the
-    /// kubeconfig already carries one in plain text AND it actually looks
-    /// like an address. See `context_resolve::auth_kind_of` for the exact
-    /// mapping. Exec ARGUMENTS, the exec command's directory, and everything
-    /// else in an auth-provider's config map are deliberately excluded: they
-    /// routinely carry client IDs and sometimes secrets, and this string is
-    /// rendered in a table.
+    /// The credential MECHANISM, never the credential and never the account.
+    /// One of `client certificate`, `token`, `basic`, `impersonation`, `none`,
+    /// `exec plugin · <command's basename>` (or bare `exec plugin`), or a
+    /// legacy auth-provider's own name (`gcp`, `azure`, `oidc`, …) — or bare
+    /// `auth provider` when that name is not shaped like an identifier. See
+    /// `context_resolve::auth_kind_of` for the exact mapping and
+    /// `context_resolve::identifier` for the shape gate.
+    ///
+    /// Deliberately excluded: exec ARGUMENTS, the exec command's directory,
+    /// and every value in an auth-provider's config map INCLUDING `email`.
+    /// The account used to be appended and no longer is — `k8s.listContexts`
+    /// is read-only and so not consent-gated, which makes every field here
+    /// readable by any connected agent, and the account was decoration on a
+    /// string whose job is naming a mechanism.
     #[serde(rename = "authKind")]
     pub auth_kind: String,
 }

--- a/crates/kube/src/contexts.rs
+++ b/crates/kube/src/contexts.rs
@@ -8,8 +8,10 @@ use srelens_capability::{Annotations, Capability, CapabilityError};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use kube::config::{AuthInfo, Kubeconfig};
+
 use crate::client_cache::ClientCache;
-use crate::context_resolve::{resolve_context, resolve_contexts};
+use crate::context_resolve::{resolve_context, resolve_contexts, ResolvedContext};
 use crate::local_cluster::classify;
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
@@ -46,6 +48,19 @@ pub struct ContextDto {
     /// The detected local provider (e.g. `"kind"`, `"vind"`), when `isLocal`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
+    /// The kubeconfig this context was declared in. Taken from the same place
+    /// `stable_id` takes it — NOT parsed back out of `stable_id`, whose
+    /// `file/` prefix appears only on a name collision (#265), so a unique
+    /// name would yield nothing.
+    #[serde(rename = "sourceFile")]
+    pub source_file: String,
+    /// The credential MECHANISM, never the credential. One of `client
+    /// certificate`, `token`, `basic`, `exec plugin · <command>`, `oidc`,
+    /// `impersonation`, `none`. Exec ARGUMENTS are deliberately excluded:
+    /// they routinely carry client IDs and sometimes secrets, and this string
+    /// is rendered in a table.
+    #[serde(rename = "authKind")]
+    pub auth_kind: String,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -129,31 +144,90 @@ pub fn list_contexts_capability(
                         "no kubeconfig contexts could be read".to_string(),
                     ));
                 }
-                let contexts = resolved.into_iter().map(|rc| {
-                    // Classify on the raw in-file name (the disambiguating prefix
-                    // is a file stem, not a signal of local/remote).
-                    let class = classify(
-                        &rc.original_name,
-                        &rc.cluster,
-                        &rc.server,
-                        rc.exec_command.as_deref(),
-                        rc.auth_provider.as_deref(),
-                    );
-                    ContextDto {
-                        is_current: rc.is_current,
-                        stable_id: rc.stable_id(),
-                        name: rc.display_name,
-                        cluster: rc.cluster,
-                        server: rc.server,
-                        namespace: rc.namespace,
-                        is_local: class.is_local,
-                        provider: class.provider.map(|provider| provider.as_str().to_string()),
-                    }
-                }).collect();
+                let contexts = resolved.into_iter().map(build_context_dto).collect();
                 Ok(ListContextsOut { contexts })
             }
         },
     )
+}
+
+/// Build the DTO for one resolved context. Shared by the capability above and
+/// by `dto_for` in tests, so the fixture exercises the exact same mapping
+/// rather than a hand-rolled duplicate of it.
+fn build_context_dto(rc: ResolvedContext) -> ContextDto {
+    // Classify on the raw in-file name (the disambiguating prefix is a file
+    // stem, not a signal of local/remote).
+    let class = classify(
+        &rc.original_name,
+        &rc.cluster,
+        &rc.server,
+        rc.exec_command.as_deref(),
+        rc.auth_provider.as_deref(),
+    );
+    let auth_kind = auth_info_for(&rc)
+        .map(|info| auth_kind_of(&info))
+        .unwrap_or_else(|| "none".to_string());
+    ContextDto {
+        is_current: rc.is_current,
+        stable_id: rc.stable_id(),
+        source_file: rc.source.display().to_string(),
+        name: rc.display_name,
+        cluster: rc.cluster,
+        server: rc.server,
+        namespace: rc.namespace,
+        is_local: class.is_local,
+        provider: class.provider.map(|provider| provider.as_str().to_string()),
+        auth_kind,
+    }
+}
+
+/// Look up the full `AuthInfo` a resolved context uses, by re-reading its
+/// declaring file. `ResolvedContext` only carries the pieces `local_cluster`
+/// classification needs (`exec_command`, `auth_provider` name) — not the full
+/// auth block — so the auth kind is derived here, straight from the
+/// kubeconfig, rather than by widening `ResolvedContext` for this alone.
+fn auth_info_for(rc: &ResolvedContext) -> Option<AuthInfo> {
+    let config = Kubeconfig::read_from(&rc.source).ok()?;
+    config
+        .auth_infos
+        .into_iter()
+        .find(|entry| entry.name == rc.user)
+        .and_then(|entry| entry.auth_info)
+}
+
+/// Map a kubeconfig's `auth-info` to the credential MECHANISM it names —
+/// never the credential. Exec ARGUMENTS are deliberately dropped: they
+/// routinely carry client IDs and, in bad kubeconfigs, secrets, and this
+/// string ends up rendered in a table.
+fn auth_kind_of(auth: &AuthInfo) -> String {
+    if let Some(exec) = &auth.exec {
+        let command = exec.command.as_deref().unwrap_or("unknown");
+        return format!("exec plugin · {command}");
+    }
+    if let Some(provider) = &auth.auth_provider {
+        // The legacy `auth-provider` block (oidc, and the now-deprecated gcp
+        // and azure plugins) is a provider-driven mechanism like exec, not a
+        // bare credential — bucketed here as `oidc`. Only a plain-text field
+        // the kubeconfig already carries (e.g. an email) is ever appended;
+        // nothing from `provider.config` that could be a token or secret is.
+        return match provider.config.get("email") {
+            Some(account) => format!("oidc · {account}"),
+            None => "oidc".to_string(),
+        };
+    }
+    if auth.client_certificate.is_some() || auth.client_certificate_data.is_some() {
+        return "client certificate".to_string();
+    }
+    if auth.token.is_some() || auth.token_file.is_some() {
+        return "token".to_string();
+    }
+    if auth.username.is_some() || auth.password.is_some() {
+        return "basic".to_string();
+    }
+    if auth.impersonate.is_some() {
+        return "impersonation".to_string();
+    }
+    "none".to_string()
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -335,6 +409,92 @@ mod tests {
     use super::*;
     use srelens_capability::Registry;
     use serde_json::json;
+
+    /// Build the DTO for a context declared in `file`, with no cluster/auth
+    /// details — enough to exercise `build_context_dto`'s file/id handling
+    /// without touching disk (`auth_info_for` fails closed to `None` for a
+    /// file that doesn't exist, which is fine: these tests don't assert on
+    /// `auth_kind`).
+    fn dto_for(name: &str, file: &str) -> ContextDto {
+        build_context_dto(ResolvedContext {
+            display_name: name.to_string(),
+            original_name: name.to_string(),
+            source: PathBuf::from(file),
+            cluster: String::new(),
+            server: String::new(),
+            user: String::new(),
+            namespace: String::new(),
+            is_current: false,
+            exec_command: None,
+            auth_provider: None,
+        })
+    }
+
+    /// An exec-plugin `AuthInfo` naming `command`, with `args` attached the
+    /// way a real exec plugin's arguments would be — so the leak test has
+    /// something to actually catch if `auth_kind_of` ever started including
+    /// them.
+    fn exec_auth(command: &str, args: &[&str]) -> AuthInfo {
+        AuthInfo {
+            exec: Some(kube::config::ExecConfig {
+                command: Some(command.to_string()),
+                args: Some(args.iter().map(|a| a.to_string()).collect()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn token_auth(token: &str) -> AuthInfo {
+        serde_yaml::from_str(&format!("token: \"{token}\"\n")).expect("valid auth-info fixture")
+    }
+
+    fn client_cert_auth() -> AuthInfo {
+        AuthInfo {
+            client_certificate_data: Some("c2VjcmV0LWNlcnQ=".to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn empty_auth() -> AuthInfo {
+        AuthInfo::default()
+    }
+
+    #[test]
+    fn context_dto_names_the_file_it_was_declared_in() {
+        let dto = dto_for("prod-eu", "/home/dana/.kube/config");
+        assert_eq!(dto.source_file, "/home/dana/.kube/config");
+    }
+
+    #[test]
+    fn a_unique_context_name_still_carries_its_file() {
+        // `display_name` (the DTO's `name`) gains a `stem/` prefix only on a
+        // cross-file collision (#265); a unique name carries none. `stable_id`
+        // itself is unconditionally `{source}#{original_name}` — it always
+        // embeds the path, collision or not — so it can't be what
+        // distinguishes this case. The point stands regardless: `source_file`
+        // must come from `ResolvedContext.source` directly, the same place
+        // `stable_id` takes it, not by parsing either string back apart.
+        let dto = dto_for("only-one", "/home/dana/.kube/edge.yaml");
+        assert_eq!(dto.name, "only-one", "unique name carries no collision prefix");
+        assert_eq!(dto.source_file, "/home/dana/.kube/edge.yaml");
+    }
+
+    #[test]
+    fn auth_kind_names_the_mechanism_and_never_the_secret() {
+        assert_eq!(auth_kind_of(&exec_auth("gcloud", &["--client-id", "s3cr3t"])), "exec plugin · gcloud");
+        assert_eq!(auth_kind_of(&token_auth("eyJhbGciOi.very.secret")), "token");
+        assert_eq!(auth_kind_of(&client_cert_auth()), "client certificate");
+        assert_eq!(auth_kind_of(&empty_auth()), "none");
+    }
+
+    #[test]
+    fn auth_kind_leaks_no_credential_material() {
+        let kind = auth_kind_of(&token_auth("eyJhbGciOi.very.secret"));
+        assert!(!kind.contains("eyJ"), "auth kind must not carry the token: {kind}");
+        let exec = auth_kind_of(&exec_auth("gcloud", &["--client-id", "s3cr3t"]));
+        assert!(!exec.contains("s3cr3t"), "auth kind must not carry exec args: {exec}");
+    }
 
     #[test]
     fn capability_has_expected_id_and_annotations() {

--- a/crates/kube/src/contexts.rs
+++ b/crates/kube/src/contexts.rs
@@ -8,8 +8,6 @@ use srelens_capability::{Annotations, Capability, CapabilityError};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use kube::config::{AuthInfo, Kubeconfig};
-
 use crate::client_cache::ClientCache;
 use crate::context_resolve::{resolve_context, resolve_contexts, ResolvedContext};
 use crate::local_cluster::classify;
@@ -48,17 +46,24 @@ pub struct ContextDto {
     /// The detected local provider (e.g. `"kind"`, `"vind"`), when `isLocal`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
-    /// The kubeconfig this context was declared in. Taken from the same place
-    /// `stable_id` takes it — NOT parsed back out of `stable_id`, whose
-    /// `file/` prefix appears only on a name collision (#265), so a unique
-    /// name would yield nothing.
+    /// The kubeconfig this context was declared in. Taken from
+    /// `ResolvedContext.source` directly — the same field `stable_id` reads —
+    /// rather than parsed back out of an identity string, which is fragile
+    /// regardless of that string's current format. (`stable_id` itself is
+    /// always `{file}#{name}`, unconditionally; it's `name` — this DTO's
+    /// presentation field, above — that gains a collision-only prefix (#265),
+    /// so don't reach for that distinction here either.)
     #[serde(rename = "sourceFile")]
     pub source_file: String,
     /// The credential MECHANISM, never the credential. One of `client
-    /// certificate`, `token`, `basic`, `exec plugin · <command>`, `oidc`,
-    /// `impersonation`, `none`. Exec ARGUMENTS are deliberately excluded:
-    /// they routinely carry client IDs and sometimes secrets, and this string
-    /// is rendered in a table.
+    /// certificate`, `token`, `basic`, `exec plugin · <command>`,
+    /// `impersonation`, `none`, or a legacy auth-provider's own name (`gcp`,
+    /// `azure`, `oidc`, …) optionally followed by `· <email>` when the
+    /// kubeconfig already carries that in plain text. See
+    /// `context_resolve::auth_kind_of` for the exact mapping. Exec ARGUMENTS
+    /// and everything else in an auth-provider's config map are deliberately
+    /// excluded: they routinely carry client IDs and sometimes secrets, and
+    /// this string is rendered in a table.
     #[serde(rename = "authKind")]
     pub auth_kind: String,
 }
@@ -164,9 +169,6 @@ fn build_context_dto(rc: ResolvedContext) -> ContextDto {
         rc.exec_command.as_deref(),
         rc.auth_provider.as_deref(),
     );
-    let auth_kind = auth_info_for(&rc)
-        .map(|info| auth_kind_of(&info))
-        .unwrap_or_else(|| "none".to_string());
     ContextDto {
         is_current: rc.is_current,
         stable_id: rc.stable_id(),
@@ -177,57 +179,8 @@ fn build_context_dto(rc: ResolvedContext) -> ContextDto {
         namespace: rc.namespace,
         is_local: class.is_local,
         provider: class.provider.map(|provider| provider.as_str().to_string()),
-        auth_kind,
+        auth_kind: rc.auth_kind,
     }
-}
-
-/// Look up the full `AuthInfo` a resolved context uses, by re-reading its
-/// declaring file. `ResolvedContext` only carries the pieces `local_cluster`
-/// classification needs (`exec_command`, `auth_provider` name) — not the full
-/// auth block — so the auth kind is derived here, straight from the
-/// kubeconfig, rather than by widening `ResolvedContext` for this alone.
-fn auth_info_for(rc: &ResolvedContext) -> Option<AuthInfo> {
-    let config = Kubeconfig::read_from(&rc.source).ok()?;
-    config
-        .auth_infos
-        .into_iter()
-        .find(|entry| entry.name == rc.user)
-        .and_then(|entry| entry.auth_info)
-}
-
-/// Map a kubeconfig's `auth-info` to the credential MECHANISM it names —
-/// never the credential. Exec ARGUMENTS are deliberately dropped: they
-/// routinely carry client IDs and, in bad kubeconfigs, secrets, and this
-/// string ends up rendered in a table.
-fn auth_kind_of(auth: &AuthInfo) -> String {
-    if let Some(exec) = &auth.exec {
-        let command = exec.command.as_deref().unwrap_or("unknown");
-        return format!("exec plugin · {command}");
-    }
-    if let Some(provider) = &auth.auth_provider {
-        // The legacy `auth-provider` block (oidc, and the now-deprecated gcp
-        // and azure plugins) is a provider-driven mechanism like exec, not a
-        // bare credential — bucketed here as `oidc`. Only a plain-text field
-        // the kubeconfig already carries (e.g. an email) is ever appended;
-        // nothing from `provider.config` that could be a token or secret is.
-        return match provider.config.get("email") {
-            Some(account) => format!("oidc · {account}"),
-            None => "oidc".to_string(),
-        };
-    }
-    if auth.client_certificate.is_some() || auth.client_certificate_data.is_some() {
-        return "client certificate".to_string();
-    }
-    if auth.token.is_some() || auth.token_file.is_some() {
-        return "token".to_string();
-    }
-    if auth.username.is_some() || auth.password.is_some() {
-        return "basic".to_string();
-    }
-    if auth.impersonate.is_some() {
-        return "impersonation".to_string();
-    }
-    "none".to_string()
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -411,10 +364,10 @@ mod tests {
     use serde_json::json;
 
     /// Build the DTO for a context declared in `file`, with no cluster/auth
-    /// details — enough to exercise `build_context_dto`'s file/id handling
-    /// without touching disk (`auth_info_for` fails closed to `None` for a
-    /// file that doesn't exist, which is fine: these tests don't assert on
-    /// `auth_kind`).
+    /// details — enough to exercise `build_context_dto`'s file/id handling.
+    /// `auth_kind` is set to a fixed placeholder since these tests don't
+    /// assert on it — `auth_kind_of` and its mapping are pinned in
+    /// `context_resolve.rs`, where the credential data actually lives.
     fn dto_for(name: &str, file: &str) -> ContextDto {
         build_context_dto(ResolvedContext {
             display_name: name.to_string(),
@@ -427,37 +380,8 @@ mod tests {
             is_current: false,
             exec_command: None,
             auth_provider: None,
+            auth_kind: "none".to_string(),
         })
-    }
-
-    /// An exec-plugin `AuthInfo` naming `command`, with `args` attached the
-    /// way a real exec plugin's arguments would be — so the leak test has
-    /// something to actually catch if `auth_kind_of` ever started including
-    /// them.
-    fn exec_auth(command: &str, args: &[&str]) -> AuthInfo {
-        AuthInfo {
-            exec: Some(kube::config::ExecConfig {
-                command: Some(command.to_string()),
-                args: Some(args.iter().map(|a| a.to_string()).collect()),
-                ..Default::default()
-            }),
-            ..Default::default()
-        }
-    }
-
-    fn token_auth(token: &str) -> AuthInfo {
-        serde_yaml::from_str(&format!("token: \"{token}\"\n")).expect("valid auth-info fixture")
-    }
-
-    fn client_cert_auth() -> AuthInfo {
-        AuthInfo {
-            client_certificate_data: Some("c2VjcmV0LWNlcnQ=".to_string()),
-            ..Default::default()
-        }
-    }
-
-    fn empty_auth() -> AuthInfo {
-        AuthInfo::default()
     }
 
     #[test]
@@ -478,22 +402,6 @@ mod tests {
         let dto = dto_for("only-one", "/home/dana/.kube/edge.yaml");
         assert_eq!(dto.name, "only-one", "unique name carries no collision prefix");
         assert_eq!(dto.source_file, "/home/dana/.kube/edge.yaml");
-    }
-
-    #[test]
-    fn auth_kind_names_the_mechanism_and_never_the_secret() {
-        assert_eq!(auth_kind_of(&exec_auth("gcloud", &["--client-id", "s3cr3t"])), "exec plugin · gcloud");
-        assert_eq!(auth_kind_of(&token_auth("eyJhbGciOi.very.secret")), "token");
-        assert_eq!(auth_kind_of(&client_cert_auth()), "client certificate");
-        assert_eq!(auth_kind_of(&empty_auth()), "none");
-    }
-
-    #[test]
-    fn auth_kind_leaks_no_credential_material() {
-        let kind = auth_kind_of(&token_auth("eyJhbGciOi.very.secret"));
-        assert!(!kind.contains("eyJ"), "auth kind must not carry the token: {kind}");
-        let exec = auth_kind_of(&exec_auth("gcloud", &["--client-id", "s3cr3t"]));
-        assert!(!exec.contains("s3cr3t"), "auth kind must not carry exec args: {exec}");
     }
 
     #[test]

--- a/crates/kube/src/contexts.rs
+++ b/crates/kube/src/contexts.rs
@@ -364,12 +364,19 @@ mod tests {
     use srelens_capability::Registry;
     use serde_json::json;
 
-    /// Build the DTO for a context declared in `file`, with no cluster/auth
-    /// details — enough to exercise `build_context_dto`'s file/id handling.
-    /// `auth_kind` is set to a fixed placeholder since these tests don't
-    /// assert on it — `auth_kind_of` and its mapping are pinned in
-    /// `context_resolve.rs`, where the credential data actually lives.
-    fn dto_for(name: &str, file: &str) -> ContextDto {
+    /// Build the DTO for a context declared in `file`, carrying `auth_kind`
+    /// through from the resolved context — enough to exercise
+    /// `build_context_dto`'s file/id/auth handling.
+    ///
+    /// **`auth_kind` is a parameter, not a placeholder.** It used to be a fixed
+    /// `"none"` on the reasoning that the MAPPING is pinned in
+    /// `context_resolve.rs`. The mapping is; the JOIN was not — replacing
+    /// `auth_kind: rc.auth_kind` with a literal `"none"` in
+    /// `build_context_dto` passed the whole crate, which on screen is the
+    /// `Auth` column reading `none` for every cluster on every platform with
+    /// nothing noticing. Every caller now names the value it expects out the
+    /// other end.
+    fn dto_for(name: &str, file: &str, auth_kind: &str) -> ContextDto {
         build_context_dto(ResolvedContext {
             display_name: name.to_string(),
             original_name: name.to_string(),
@@ -381,13 +388,13 @@ mod tests {
             is_current: false,
             exec_command: None,
             auth_provider: None,
-            auth_kind: "none".to_string(),
+            auth_kind: auth_kind.to_string(),
         })
     }
 
     #[test]
     fn context_dto_names_the_file_it_was_declared_in() {
-        let dto = dto_for("prod-eu", "/home/dana/.kube/config");
+        let dto = dto_for("prod-eu", "/home/dana/.kube/config", "exec plugin · gcloud");
         assert_eq!(dto.source_file, "/home/dana/.kube/config");
     }
 
@@ -400,9 +407,95 @@ mod tests {
         // distinguishes this case. The point stands regardless: `source_file`
         // must come from `ResolvedContext.source` directly, the same place
         // `stable_id` takes it, not by parsing either string back apart.
-        let dto = dto_for("only-one", "/home/dana/.kube/edge.yaml");
+        let dto = dto_for("only-one", "/home/dana/.kube/edge.yaml", "token");
         assert_eq!(dto.name, "only-one", "unique name carries no collision prefix");
         assert_eq!(dto.source_file, "/home/dana/.kube/edge.yaml");
+    }
+
+    #[test]
+    fn context_dto_carries_the_resolved_credential_kind() {
+        // The JOIN, not the mapping. `auth_kind_of` and every string it can
+        // produce are pinned in `context_resolve.rs`; this pins that
+        // `build_context_dto` hands the resolved value over untouched, which
+        // is the one step between the mapping and the wire. A literal in
+        // `build_context_dto` (`auth_kind: "none".to_string()`) used to pass
+        // the whole crate — a dead `Auth` column nothing noticed.
+        let dto = dto_for("prod-eu", "/home/dana/.kube/config", "exec plugin · gcloud");
+        assert_eq!(dto.auth_kind, "exec plugin · gcloud");
+        assert_ne!(dto.auth_kind, "none", "the placeholder is not an answer");
+    }
+
+    /// **The field NAMES the UI reads, pinned against the JSON rather than
+    /// against the struct.**
+    ///
+    /// Every camelCase name here comes from a `#[serde(rename = …)]`, and a
+    /// rename is invisible to every other test in this crate: renaming
+    /// `authKind` to `auth_kind`, or `sourceFile` to `source_file`, passed the
+    /// whole crate while emptying the column that reads it in
+    /// `packages/ui-next`. `stableId` and `isCurrent` were unpinned the same
+    /// way. Asserting the serialized keys as a SET closes all of them at once
+    /// and fails on a new field arriving unnamed, too.
+    #[test]
+    fn the_wire_names_every_field_the_ui_reads_by() {
+        let dto = dto_for("prod-eu", "/home/dana/.kube/config", "exec plugin · gcloud");
+        let json = serde_json::to_value(&dto).expect("ContextDto serializes");
+        let object = json.as_object().expect("a JSON object");
+
+        let mut keys: Vec<&str> = object.keys().map(String::as_str).collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            vec![
+                "authKind",
+                "cluster",
+                "isCurrent",
+                "isLocal",
+                "name",
+                "namespace",
+                "server",
+                "sourceFile",
+                "stableId",
+            ],
+            "the serialized field names are the UI's contract"
+        );
+
+        // And the values arrive under those names rather than merely the names
+        // existing: a rename plus a re-add elsewhere would satisfy the set.
+        assert_eq!(json["authKind"], "exec plugin · gcloud");
+        assert_eq!(json["sourceFile"], "/home/dana/.kube/config");
+        assert_eq!(json["stableId"], "/home/dana/.kube/config#prod-eu");
+        assert_eq!(json["isCurrent"], false);
+        assert_eq!(json["isLocal"], false);
+        assert_eq!(json["name"], "prod-eu");
+    }
+
+    /// `provider` is the one optional field — `skip_serializing_if` means it is
+    /// ABSENT rather than `null` for a remote cluster, and present under that
+    /// exact name for a local one. Pinned separately so the set above stays a
+    /// set of the fields that are always there.
+    #[test]
+    fn a_local_cluster_names_its_provider_and_a_remote_one_omits_the_key() {
+        let remote = dto_for("prod-eu", "/home/dana/.kube/config", "token");
+        let json = serde_json::to_value(&remote).expect("serializes");
+        assert!(!json.as_object().unwrap().contains_key("provider"));
+
+        let local = build_context_dto(ResolvedContext {
+            display_name: "kind-lab".to_string(),
+            original_name: "kind-lab".to_string(),
+            source: PathBuf::from("/home/dana/.kube/config"),
+            cluster: "kind-kind-lab".to_string(),
+            server: "https://127.0.0.1:6443".to_string(),
+            user: "kind-lab".to_string(),
+            namespace: String::new(),
+            is_current: false,
+            exec_command: None,
+            auth_provider: None,
+            auth_kind: "client certificate".to_string(),
+        });
+        let json = serde_json::to_value(&local).expect("serializes");
+        assert_eq!(json["isLocal"], true);
+        assert_eq!(json["provider"], "kind");
+        assert_eq!(json["authKind"], "client certificate");
     }
 
     #[test]

--- a/packages/core/src/lib/clusters.test.ts
+++ b/packages/core/src/lib/clusters.test.ts
@@ -21,6 +21,19 @@ describe("listContexts", () => {
     expect(outcome.contexts?.[0].namespace).toBe("team-a");
   });
 
+  it("carries the source file and auth kind the backend reported", async () => {
+    const invoke = vi.fn().mockResolvedValue({
+      contexts: [{
+        name: "prod-eu", stableId: "prod-eu", cluster: "prod", server: "https://prod:6443",
+        namespace: "", isCurrent: true, isLocal: false,
+        sourceFile: "/home/dana/.kube/config", authKind: "exec plugin · gcloud",
+      }],
+    });
+    const out = await listContexts([], invoke);
+    expect(out.contexts?.[0].sourceFile).toBe("/home/dana/.kube/config");
+    expect(out.contexts?.[0].authKind).toBe("exec plugin · gcloud");
+  });
+
   it("returns a normalised error on failure", async () => {
     const outcome = await listContexts([], () =>
       Promise.reject(new Error("read kubeconfig: not found")),

--- a/packages/core/src/lib/clusters.ts
+++ b/packages/core/src/lib/clusters.ts
@@ -18,6 +18,10 @@ export interface ClusterContext {
   isLocal?: boolean;
   /** The detected local provider (e.g. "kind", "vind"), when `isLocal`. */
   provider?: string;
+  /** The kubeconfig this context was declared in. */
+  sourceFile: string;
+  /** The credential MECHANISM — never the credential. See the Rust side. */
+  authKind: string;
   /** The context's default namespace from the kubeconfig; empty/absent when unset. */
   namespace?: string;
 }

--- a/packages/ui-kit/src/Table.test.tsx
+++ b/packages/ui-kit/src/Table.test.tsx
@@ -662,6 +662,126 @@ describe("Table", () => {
   });
 });
 
+/**
+ * Group headings inside the body, and the one rule that makes them honest.
+ *
+ * A grouping describes the ORDER the caller handed the table, so the moment a
+ * header sort reorders the list the headings would be labelling rows that no
+ * longer sit under them. They are dropped for as long as a sort is active and
+ * come back when it is cleared — a heading that silently became wrong under
+ * sort is worse than no heading at all.
+ */
+describe("Table row groups", () => {
+  interface Cluster {
+    name: string;
+    source: string;
+    latency: number;
+  }
+
+  const cols: Column<Cluster>[] = [
+    { key: "name", header: "Name" },
+    { key: "source", header: "Source" },
+    { key: "latency", header: "Latency" },
+  ];
+
+  // Two groups, four rows, and the caller's order already groups them: the
+  // table's job here is to draw the boundary, not to find it.
+  const rows: Cluster[] = [
+    { name: "prod-eu", source: "Kubeconfig", latency: 41 },
+    { name: "staging", source: "Kubeconfig", latency: 12 },
+    { name: "kind-dev", source: "Local", latency: 3 },
+    { name: "k3d-lab", source: "Local", latency: 1 },
+  ];
+
+  const group = (row: Cluster) => ({ key: row.source, label: `${row.source} group` });
+
+  function renderGrouped() {
+    return render(
+      <Table columns={cols} data={rows} getRowKey={(r) => r.name} rowGroup={group} />,
+    );
+  }
+
+  const headings = (container: HTMLElement) =>
+    [...container.querySelectorAll('[data-slot="table-group"]')].map((tr) => tr.textContent);
+
+  it("heads each group once, in the caller's own order", () => {
+    const { container } = renderGrouped();
+    expect(headings(container)).toEqual(["Kubeconfig group", "Local group"]);
+  });
+
+  it("puts each heading directly above the first row of its group", () => {
+    const { container } = renderGrouped();
+    const bodyRows = [...container.querySelectorAll("tbody tr")].map((tr) => [
+      tr.getAttribute("data-slot") === "table-group" ? "GROUP" : "row",
+      tr.textContent,
+    ]);
+    expect(bodyRows).toEqual([
+      ["GROUP", "Kubeconfig group"],
+      ["row", "prod-euKubeconfig41"],
+      ["row", "stagingKubeconfig12"],
+      ["GROUP", "Local group"],
+      ["row", "kind-devLocal3"],
+      ["row", "k3d-labLocal1"],
+    ]);
+  });
+
+  it("spans every column, the checkbox one included", () => {
+    const { container } = render(
+      <Table
+        columns={cols}
+        data={rows}
+        getRowKey={(r) => r.name}
+        rowGroup={group}
+        selection={{ selected: new Set<string>(), onChange: vi.fn() }}
+      />,
+    );
+    const heading = container.querySelector('[data-slot="table-group"] th');
+    expect(heading?.getAttribute("colspan")).toBe("4");
+  });
+
+  it("draws no heading at all without a rowGroup", () => {
+    const { container } = render(<Table columns={cols} data={rows} getRowKey={(r) => r.name} />);
+    expect(headings(container)).toEqual([]);
+  });
+
+  it("drops every heading while a sort is active, because the order it described is gone", () => {
+    const { container } = renderGrouped();
+    fireEvent.click(screen.getByRole("button", { name: "Sort by Latency" }));
+
+    // The rows are reordered across the groups — so the headings have to go.
+    expect(
+      [...container.querySelectorAll("tbody tr.tbl-row")].map((tr) => tr.textContent),
+    ).toEqual(["k3d-labLocal1", "kind-devLocal3", "stagingKubeconfig12", "prod-euKubeconfig41"]);
+    expect(headings(container)).toEqual([]);
+  });
+
+  it("brings them back when the reader clears the sort", () => {
+    const { container } = renderGrouped();
+    const sort = screen.getByRole("button", { name: "Sort by Latency" });
+    fireEvent.click(sort); // ascending
+    fireEvent.click(sort); // descending
+    expect(headings(container)).toEqual([]);
+    fireEvent.click(sort); // cleared — the caller's order is back
+    expect(headings(container)).toEqual(["Kubeconfig group", "Local group"]);
+  });
+
+  it("keeps a heading out of the rows a reader can reach", () => {
+    const { container } = render(
+      <Table
+        columns={cols}
+        data={rows}
+        getRowKey={(r) => r.name}
+        rowGroup={group}
+        onRowActivate={vi.fn()}
+      />,
+    );
+    const heading = container.querySelector('[data-slot="table-group"]');
+    // No tab stop, no `tbl-row`: the arrow keys and Enter walk the data rows.
+    expect(heading?.hasAttribute("tabindex")).toBe(false);
+    expect(heading?.className).not.toContain("tbl-row");
+  });
+});
+
 describe("Table multi-selection", () => {
   const cols: Column<{ name: string }>[] = [{ key: "name", header: "Name" }];
   const rows = [{ name: "a" }, { name: "b" }, { name: "c" }, { name: "d" }];

--- a/packages/ui-kit/src/Table.test.tsx
+++ b/packages/ui-kit/src/Table.test.tsx
@@ -671,6 +671,44 @@ describe("Table", () => {
  * come back when it is cleared — a heading that silently became wrong under
  * sort is worse than no heading at all.
  */
+/**
+ * A column pinned to the end of the table.
+ *
+ * **jsdom has no layout, so this is the plumbing and nothing more**: that the
+ * attribute the stylesheet pins on reaches both the header cell and every body
+ * cell of that column, and no other. Whether the cell actually stays on screen
+ * is a browser fact, measured in one (see the task report), and no assertion
+ * here can stand in for it.
+ */
+describe("Table sticky columns", () => {
+  const cols: Column<{ name: string }>[] = [
+    { key: "name", header: "Name" },
+    { key: "actions", header: "", sticky: "end" },
+  ];
+  const rows = [{ name: "a" }, { name: "b" }];
+
+  it("marks the pinned column's header and every one of its cells", () => {
+    const { container } = render(<Table columns={cols} data={rows} getRowKey={(r) => r.name} />);
+    const pinned = container.querySelectorAll('[data-sticky="end"]');
+    // One `th`, one `td` per row — and nothing else in the table.
+    expect([...pinned].map((el) => el.tagName)).toEqual(["TH", "TD", "TD"]);
+  });
+
+  it("leaves every other column unmarked", () => {
+    const { container } = render(<Table columns={cols} data={rows} getRowKey={(r) => r.name} />);
+    const first = container.querySelector("tbody tr td");
+    expect(first?.hasAttribute("data-sticky")).toBe(false);
+    expect(container.querySelector("thead th")?.hasAttribute("data-sticky")).toBe(false);
+  });
+
+  it("marks nothing when no column asks to be pinned", () => {
+    const { container } = render(
+      <Table columns={[{ key: "name", header: "Name" }]} data={rows} getRowKey={(r) => r.name} />,
+    );
+    expect(container.querySelectorAll("[data-sticky]")).toHaveLength(0);
+  });
+});
+
 describe("Table row groups", () => {
   interface Cluster {
     name: string;

--- a/packages/ui-kit/src/Table.tsx
+++ b/packages/ui-kit/src/Table.tsx
@@ -177,6 +177,27 @@ export interface TableProps<T> {
    * That rule lives here rather than in the caller because the sort may be the
    * table's own (uncontrolled), which no caller can see. A heading that
    * silently became wrong under sort is worse than no heading at all.
+   *
+   * **Known limit: headings and virtualization drift, and this comment is the
+   * only guard there is.** Both facts below are invisible to jsdom — every
+   * rect is zeroed there and the table renders every row — so no test in this
+   * kit can hold them.
+   *
+   * 1. `topPad`/`bottomPad` are `count * rowHeight` (see {@link rowPitch}), and
+   *    a rendered heading's height is outside that arithmetic. So the
+   *    scrollTop-to-index mapping drifts by roughly one heading per group above
+   *    the window: two groups is a few pixels and nobody sees it, twenty groups
+   *    over a long list walks the window away from the scrollbar.
+   * 2. `rowPitch` samples the first three `tr.tbl-row`, and a heading row is
+   *    not one — but it still occupies space between them. A first group of one
+   *    or two rows therefore puts a heading inside the measured distance and
+   *    the pitch comes out too large, which scales into `scrollHeight` exactly
+   *    the way the short-first-row bug did.
+   *
+   * Neither bites `/connections`: it has two groups and virtualizes only above
+   * 60 rows. A future consumer with many small groups over a long list should
+   * expect to fix the padding arithmetic to account for headings rather than
+   * assume this works.
    */
   rowGroup?: (row: T) => { key: string; label: ReactNode };
   /**

--- a/packages/ui-kit/src/Table.tsx
+++ b/packages/ui-kit/src/Table.tsx
@@ -104,6 +104,24 @@ export interface Column<T> {
    *  thing and `right` would not. Defaults to `start` — set `end` for numeric
    *  columns (READY, RESTARTS, CPU, MEMORY, AGE) so their digits line up. */
   align?: "start" | "end";
+  /**
+   * Pin this column to the end of the table, so it stays on screen when the
+   * table is wider than the pane it scrolls in.
+   *
+   * For the column holding a row's primary action, and measured before it was
+   * added: the connections table's columns sum to 1082px against a 1014px pane
+   * at a 1600px window, so its `Open` button sat at x=1311 with the pane's
+   * right edge at 1308 — off screen on every row, and the window had to reach
+   * 1668px before it appeared. At the 960px minimum the overflow is 711px,
+   * which no column cap can shave away: shaving fits one window size and fails
+   * the other, and pinning works at both.
+   *
+   * `end`, not `right`: the same logical value `align` takes, for the same
+   * reason. The stylesheet does the pinning (`kit.css`, `[data-sticky="end"]`)
+   * — including painting the cell, which a sticky cell must do or the columns
+   * are visible sliding under it.
+   */
+  sticky?: "end";
   minWidth?: number;
 }
 
@@ -612,7 +630,13 @@ export function Table<T>({
             </th>
           )}
           {columns.map((c) => (
-            <th key={c.key} data-align={c.align === "end" ? "end" : undefined}>
+            <th
+              key={c.key}
+              data-align={c.align === "end" ? "end" : undefined}
+              // Sticky in both axes at once for a pinned column: `top` from
+              // `.tbl thead th`, `right` from `[data-sticky="end"]`.
+              data-sticky={c.sticky}
+            >
               <div className="th-head">
                 <button
                   type="button"
@@ -717,7 +741,11 @@ export function Table<T>({
                 </td>
               )}
               {columns.map((c) => (
-                <td key={c.key} data-align={c.align === "end" ? "end" : undefined}>
+                <td
+                  key={c.key}
+                  data-align={c.align === "end" ? "end" : undefined}
+                  data-sticky={c.sticky}
+                >
                   {c.render ? c.render(row) : String((row as Record<string, unknown>)[c.key])}
                 </td>
               ))}

--- a/packages/ui-kit/src/Table.tsx
+++ b/packages/ui-kit/src/Table.tsx
@@ -1,4 +1,5 @@
 import {
+  Fragment,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -142,6 +143,25 @@ export interface TableProps<T> {
    */
   onRowActivate?: (row: T) => void;
   /**
+   * The heading to draw above the group each row belongs to: `key` is what
+   * marks the boundary (a heading appears wherever it differs from the row
+   * before), `label` is what the reader sees.
+   *
+   * Rows are NOT reordered — the caller hands them over already grouped, and
+   * this draws the line between them. Ordering rows and heading their groups
+   * are separate jobs, and a table that quietly re-sorted its data would be
+   * taking the first one away from the screen that owns it.
+   *
+   * **Drawn only while the table is in the caller's own order.** A grouping
+   * describes THAT order, so the moment a header sort reorders the list a
+   * heading would be labelling rows that no longer sit under it — headings are
+   * dropped for as long as a sort is active and come back when it is cleared.
+   * That rule lives here rather than in the caller because the sort may be the
+   * table's own (uncontrolled), which no caller can see. A heading that
+   * silently became wrong under sort is worse than no heading at all.
+   */
+  rowGroup?: (row: T) => { key: string; label: ReactNode };
+  /**
    * The row's context menu. The kit owns the `<tr>`, so the kit owns the menu
    * wrapped around it; a caller cannot reach between the table and its rows.
    */
@@ -247,6 +267,7 @@ export function Table<T>({
   sort: controlledSort,
   onSortChange,
   onRowActivate,
+  rowGroup,
   rowMenu,
   rowMenuLabel,
 }: TableProps<T>) {
@@ -473,6 +494,20 @@ export function Table<T>({
   // must not strand the table with zero tab stops. Falls back to the first
   // rendered row, so there is always exactly one stop whenever there is a row
   // to hold it.
+  /**
+   * The group heading each row belongs to, over the WHOLE list rather than over
+   * the rendered window.
+   *
+   * Index-based, so virtualization cannot invent a boundary: the window's first
+   * row is usually mid-group, and comparing it against nothing would head it as
+   * if its group started there. A group whose first row is scrolled out of the
+   * window keeps its heading out of view with it, which is what the rows do too.
+   *
+   * `null` while a sort is active — see `rowGroup`. `visibleData` is `data`
+   * itself in that case, so these are the caller's own order.
+   */
+  const groups = rowGroup && !sort ? visibleData.map((row) => rowGroup(row)) : null;
+
   const windowKeys = windowRows.map(getRowKey);
   const preferredKey = focusKey ?? selectedKey ?? null;
   const stopKey =
@@ -642,8 +677,13 @@ export function Table<T>({
             <td colSpan={colCount} style={{ height: topPad, padding: 0, border: 0 }} />
           </tr>
         )}
-        {windowRows.map((row) => {
+        {windowRows.map((row, windowIndex) => {
           const rowKey = getRowKey(row);
+          // The row's place in the whole list, which is what the group
+          // boundaries are indexed by.
+          const index = range.start + windowIndex;
+          const group = groups?.[index];
+          const heads = group !== undefined && (index === 0 || groups?.[index - 1].key !== group.key);
           const selected = selectedKey === rowKey;
           const checked = selection?.selected.has(rowKey) ?? false;
           const body = (
@@ -683,12 +723,32 @@ export function Table<T>({
               ))}
             </tr>
           );
-          return rowMenu ? (
+          const rendered = rowMenu ? (
             <ContextMenu key={rowKey} items={rowMenu(row)} label={rowMenuLabel}>
               {body}
             </ContextMenu>
           ) : (
             body
+          );
+          if (!heads) return rendered;
+          return (
+            <Fragment key={`group-${rowKey}`}>
+              {/* Not a `tbl-row`, and no tab stop: the arrows and Enter walk the
+                  rows a reader can act on, and this is a label over them. `th`
+                  with `scope="rowgroup"` so it is announced as the heading of
+                  the rows it introduces rather than as a cell with one word in
+                  it. */}
+              <tr className="tbl-group" data-slot="table-group">
+                <th colSpan={colCount} scope="rowgroup">
+                  {/* The label is the sticky box, not the cell: the cell spans a
+                      table that may be far wider than its pane, so a heading
+                      left in the cell's own corner scrolls off the moment the
+                      reader pans right. */}
+                  <span>{group.label}</span>
+                </th>
+              </tr>
+              {rendered}
+            </Fragment>
           );
         })}
         {bottomPad > 0 && (

--- a/packages/ui-kit/src/styles/kit.css
+++ b/packages/ui-kit/src/styles/kit.css
@@ -273,6 +273,38 @@
   .tbl-resized { table-layout: fixed; }
   .tbl-check { width: 36px; text-align: center; }
   .tbl-check input { accent-color: var(--accent); vertical-align: middle; }
+  /* A boundary between two groups of rows, from `Table`'s `rowGroup` — the
+     label for the rows under it, in the head's own voice so the eye reads it as
+     structure rather than as data. Ordering rows alone does not group them: the
+     connections table listed its fourteen kubeconfig contexts before its three
+     local clusters with no header, no rule and no change of spacing, and the
+     only cue a reader had was the `Source` cell's text changing at row 15 of 17.
+     Not interactive, so it takes neither the hover wash nor a cursor. */
+  .tbl tbody tr.tbl-group:hover { background: transparent; }
+  .tbl-group th {
+    padding: 0.5rem 0.7rem 0.3rem;
+    border-bottom: 1px solid var(--rule);
+    font-size: 0.625rem;
+    font-weight: 600;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+    text-align: left;
+    white-space: nowrap;
+  }
+  /* Air above every boundary but the first, which is what makes two groups read
+     as two rather than as one list with labels dropped into it. */
+  .tbl-group:not(:first-child) th { padding-top: 0.95rem; }
+  /* The label follows the horizontal scroll. A cell spanning the whole table
+     cannot itself be pinned — its box is as wide as the table — so the inline
+     label inside it is what sticks. MEASURED: the connections table is 1082px
+     against a 374px pane at a 960px window, so without this every group label
+     sits 700px to the left of what the reader is looking at. */
+  .tbl-group th > span {
+    position: sticky;
+    left: 0.7rem;
+    display: inline-block;
+  }
   /* Holds the space the virtualized rows would occupy, so the scrollbar
      describes the whole list rather than the window being rendered. */
   .tbl-spacer { border: 0 !important; }

--- a/packages/ui-kit/src/styles/kit.css
+++ b/packages/ui-kit/src/styles/kit.css
@@ -273,6 +273,47 @@
   .tbl-resized { table-layout: fixed; }
   .tbl-check { width: 36px; text-align: center; }
   .tbl-check input { accent-color: var(--accent); vertical-align: middle; }
+  /* A column pinned to the end of the table, from `Column.sticky` — for the
+     control a reader has to be able to reach when the table is wider than the
+     pane it scrolls in. MEASURED, before and after: the connections table's
+     seven columns sum to 1082px, its pane is 1014px wide at a 1600px window and
+     374px wide at the 960px minimum, so `Open` sat at x=1311 against a right
+     edge of 1308 on every row and the window had to reach 1668px before it
+     appeared. At 960px the overflow is 711px, which is why the columns were
+     pinned rather than capped: a cap can fit one window and cannot fit both. */
+  .tbl th[data-sticky="end"],
+  .tbl td[data-sticky="end"] {
+    position: sticky;
+    right: 0;
+    /* Painted, or the columns are visible sliding under it. `--canvas` is the
+       ground the app's tables sit on — the rows themselves are transparent, so
+       there is nothing to inherit — and `--tbl-sticky-bg` is the way out for a
+       table that sits on another one. */
+    background: var(--tbl-sticky-bg, var(--canvas));
+    /* Says the column is pinned rather than merely last, which is the whole
+       difference between a control at the end of a row and one that follows the
+       reader. */
+    border-left: 1px solid var(--rule);
+  }
+  /* Above the cells it slides over, and the head above the body: `.tbl thead th`
+     already carries `z-index: 1`, so the pinned head takes 2 to sit over its
+     own row's cells. The head keeps the head's own ground — the rule above is
+     the more specific selector, so without this line the pinned header cell
+     paints `--canvas` and sits in the header strip as a patch a shade darker
+     than the six cells beside it. MEASURED as rgb(13,12,18) against the strip's
+     rgb(22,21,29) before this line existed. */
+  .tbl thead th[data-sticky="end"] { z-index: 2; background: var(--surface); }
+  .tbl tbody td[data-sticky="end"] { z-index: 1; }
+  /* The row's own states have to be repeated on the pinned cell: it paints its
+     own background, so the hover wash and the selected wash on the `tr` stop at
+     its edge otherwise — one row in two colours. */
+  .tbl tbody tr:hover td[data-sticky="end"] {
+    background: var(--tbl-sticky-bg-hover, var(--surface-sunk));
+  }
+  .tbl tbody tr[data-selected="true"] td[data-sticky="end"],
+  .tbl tbody tr[data-state="selected"] td[data-sticky="end"] {
+    background: var(--accent-wash);
+  }
   /* A boundary between two groups of rows, from `Table`'s `rowGroup` — the
      label for the rows under it, in the head's own voice so the eye reads it as
      structure rather than as data. Ordering rows alone does not group them: the

--- a/packages/ui-next/src/lib/clusters.test.ts
+++ b/packages/ui-next/src/lib/clusters.test.ts
@@ -11,6 +11,7 @@ import {
 
 const ctx = (stableId: string, name = stableId): ClusterContext => ({
   name, stableId, cluster: name, server: "", isCurrent: false,
+  sourceFile: "/home/dana/.kube/config", authKind: "client certificate",
 });
 
 describe("contexts store", () => {

--- a/packages/ui-next/src/lib/clusters.test.ts
+++ b/packages/ui-next/src/lib/clusters.test.ts
@@ -8,6 +8,8 @@ import {
   resetContexts,
   setContexts,
 } from "./clusters";
+import { defaultState } from "./tabs";
+import * as store from "./tabsStore";
 
 const ctx = (stableId: string, name = stableId): ClusterContext => ({
   name, stableId, cluster: name, server: "", isCurrent: false,
@@ -80,5 +82,86 @@ describe("contexts store — listed, not listed yet, or refused", () => {
     expect(getContextsStatus()).toBe("loading");
     expect(getContextsError()).toBe("");
     expect(getContexts()).toEqual([]);
+  });
+});
+
+/**
+ * **A listing is not only a list — it can invalidate the workspace, and the
+ * store is what has to say so.**
+ *
+ * `Window` already knew this and reconciled its boot listing against the
+ * restored workspaces. Neither connection screen did: a reader who removed or
+ * renamed the ACTIVE context and pressed `Refresh all` got a replaced context
+ * list and a workspace still pointing at the cluster that had gone, so
+ * `useActiveContext()` answered `undefined` and every cluster-scoped screen
+ * fell to its no-cluster state — while other clusters were sitting right there
+ * in the table. `/connect`'s own `reload` had the same gap.
+ *
+ * So it happens HERE, in the one write both screens and `Window` go through,
+ * rather than three times in three callers. Same lesson as this branch's
+ * loaded/failed signal, which exists because an empty list was three facts
+ * being read as one: a store write that invalidates other state has to say so.
+ */
+describe("contexts store — a listing that invalidates the workspace", () => {
+  const PROD = ctx("prod-1", "prod");
+  const DEV = ctx("dev-1", "dev");
+
+  beforeEach(() => {
+    resetContexts();
+    store.setState(defaultState([PROD, DEV]));
+    setContexts([PROD, DEV]);
+  });
+
+  it("moves the focus onto a surviving cluster when a listing drops the active one", () => {
+    expect(store.activeCluster()).toBe("prod-1");
+    setContexts([DEV]);
+    expect(store.activeCluster()).toBe("dev-1");
+    expect(store.currentWorkspace().clusters).toEqual(["dev-1"]);
+  });
+
+  it("leaves the focus where it is when the active cluster survives", () => {
+    setContexts([DEV, PROD]);
+    expect(store.activeCluster()).toBe("prod-1");
+  });
+
+  /**
+   * The workspace is not rewritten when nothing about it changed — identity is
+   * the signal in that store, and one of its subscribers writes a file. A
+   * refresh that answers with the same clusters must not schedule a save.
+   */
+  it("does not touch the workspace when the listing changes nothing about it", () => {
+    const before = store.getState();
+    setContexts([PROD, DEV]);
+    expect(store.getState()).toBe(before);
+  });
+
+  /**
+   * **A listing that REFUSED takes nothing away, and this is the case that
+   * makes the guard load-bearing.**
+   *
+   * `Window` deliberately keeps the restored cluster ids when `listContexts`
+   * refuses — reconciling against nothing would strip every workspace's
+   * clusters and the next change would persist that emptied state. It calls
+   * `setContexts(found, failure)` with `found` empty on that path, so
+   * reconciling on a failed listing here would undo the very thing that branch
+   * exists to protect.
+   */
+  it("strips nothing from the workspace when the listing refused", () => {
+    setContexts([], "kubeconfig unreadable");
+    expect(store.activeCluster()).toBe("prod-1");
+    expect(store.currentWorkspace().clusters).toEqual(["prod-1", "dev-1"]);
+  });
+
+  /**
+   * A PARTIAL listing is a refusal too. `listContexts` can answer with some
+   * contexts and an error — one of several merged kubeconfigs was unreadable —
+   * and a cluster missing for that reason has not gone anywhere. The conservative
+   * read is the same one `Window` takes: trust what is on disk until a listing
+   * answers cleanly.
+   */
+  it("strips nothing when a listing came back short with a reason", () => {
+    setContexts([DEV], "one kubeconfig was unreadable");
+    expect(store.activeCluster()).toBe("prod-1");
+    expect(store.currentWorkspace().clusters).toEqual(["prod-1", "dev-1"]);
   });
 });

--- a/packages/ui-next/src/lib/clusters.ts
+++ b/packages/ui-next/src/lib/clusters.ts
@@ -1,6 +1,6 @@
 import { useSyncExternalStore } from "react";
 import type { ClusterContext } from "@srelens/core";
-import { useActiveCluster } from "./tabsStore";
+import { reconcileClusters, useActiveCluster } from "./tabsStore";
 
 /**
  * The cluster contexts this window knows about.
@@ -74,11 +74,35 @@ export function getContextsError(): string {
  * One call rather than a separate `setContextsError`, so the three states can
  * never be observed half-changed — a list installed before its error, or an
  * error left standing over a list that has since succeeded.
+ *
+ * **A listing that ANSWERED also reconciles the workspaces, and that is part of
+ * this write rather than of its callers.** A replaced context list can invalidate
+ * a workspace's `activeCluster`: remove or rename the active context, press
+ * `Refresh all`, and the workspace went on naming a cluster nobody declares —
+ * `useActiveContext()` answered `undefined` and every cluster-scoped screen fell
+ * to its no-cluster state, telling the reader to pick a cluster while other
+ * clusters sat in the table. `Window` had always reconciled its boot listing;
+ * neither connection screen did. Doing it here is what makes all three callers
+ * consistent at once, rather than leaving the fourth to rediscover it — and it
+ * is the same lesson as {@link ContextsStatus} above: a store write that
+ * invalidates other state has to say so.
+ *
+ * **Only on a clean answer, and the guard is load-bearing.** A listing that
+ * refused — wholly, or partially with some contexts and a reason — has taken
+ * nothing away: the missing clusters may be perfectly present behind an
+ * unreadable file or a dropped VPN. `Window` keeps the restored cluster ids on
+ * exactly that path (see its `saved && failure` branch) precisely so a transient
+ * failure is not persisted as an emptied workspace, and it calls this with an
+ * empty list when it does. Reconciling then would undo it.
  */
 export function setContexts(next: ClusterContext[], error = ""): void {
   contexts = next;
   status = error === "" ? "loaded" : "failed";
   failure = error;
+  // Before this store's own listeners: the tabs store's subscribers read the
+  // active cluster AND this list, and waking them while the two disagree is the
+  // torn render the single-write rule above exists to prevent.
+  if (error === "") reconcileClusters(next);
   for (const listener of listeners) listener();
 }
 

--- a/packages/ui-next/src/lib/clusters.ts
+++ b/packages/ui-next/src/lib/clusters.ts
@@ -12,8 +12,18 @@ import { useActiveCluster } from "./tabsStore";
  * list in `useState` and passed it as props to the two components that needed
  * it.
  *
- * `Window` is still the only writer; it sets this from the same `listContexts`
- * call it already makes, and reads it back rather than keeping a second copy.
+ * **Three writers, not one.** `Window` sets it at boot from the `listContexts`
+ * call it already makes; `Connections.reload()` and `Connect.reload()` both
+ * write their own listing back through {@link setContexts}, which is what makes
+ * `Refresh all` and either door shared rather than private — the rail, the
+ * status bar and every other screen see the list those screens are drawing.
+ *
+ * This comment said "Window is still the only writer" while both screens wrote
+ * to it, and this branch was already bitten once by a screen depending on a
+ * store invariant the store knew nothing about (`/connections` cleared its
+ * in-flight facts only on its OWN reload, latent purely because Window's write
+ * sits behind `if (!booted)`). So: any writer must assume another may write
+ * next, and nothing here promises otherwise.
  */
 let contexts: ClusterContext[] = [];
 const listeners = new Set<() => void>();
@@ -74,8 +84,15 @@ export function setContexts(next: ClusterContext[], error = ""): void {
 
 /**
  * The kubeconfig files the backend must know about before a client can be built
- * for a context that came from one of them. Resolved once at boot and read by
- * every core call that takes them.
+ * for a context that came from one of them. Read by every core call that takes
+ * them.
+ *
+ * **Not resolved once at boot, which this said.** It is seeded at boot and
+ * written again by `Connections.addFile()` and by `Connect.remember()` — a file
+ * the reader has just picked has to be here before the listing that follows,
+ * or the backend cannot build a client for any context in it. Deliberately not
+ * reactive: every writer re-lists in the same breath, and the listing is what
+ * re-renders the screens.
  */
 let files: string[] = [];
 

--- a/packages/ui-next/src/lib/openCluster.ts
+++ b/packages/ui-next/src/lib/openCluster.ts
@@ -30,6 +30,9 @@ export function openCluster(context: ClusterContext): void {
   }
   setActiveCluster(id);
   // By NAME, not by stableId: core's `list*` and `watchResource` all take a
-  // context name, and the tab is what carries it to them (#265).
+  // context name, and the tab is what carries it to them (#265). `openTab`
+  // relabels an `/overview` tab that is already open for a different cluster,
+  // so nothing extra is needed here — see its own note for why that lives
+  // there and not in this function.
   openTab("/overview", { clusterName: context.name });
 }

--- a/packages/ui-next/src/lib/openCluster.ts
+++ b/packages/ui-next/src/lib/openCluster.ts
@@ -1,0 +1,35 @@
+import type { ClusterContext } from "@srelens/core";
+import { currentWorkspace, openTab, setActiveCluster, setWorkspaceClusters } from "./tabsStore";
+
+/**
+ * Open a cluster: put it in this workspace, focus it, and open its overview.
+ *
+ * **The workspace step is not a flourish.** Both connection screens list every
+ * context on the machine, including ones no workspace holds, and
+ * `setActiveCluster` refuses an id the workspace does not have — so without it
+ * `Open` on exactly those rows would do nothing at all, silently. That is the
+ * whole reason this is three calls rather than one.
+ *
+ * **Here rather than on either screen.** `/connections`' row action and
+ * `/connect`'s card row were two copies of this, with the same doc comment
+ * written out twice — the same argument that promoted `STATUS` and `bySource`
+ * into `screens/connections/clusterText`. They had not drifted yet, and two
+ * copies of one gesture is how the two screens start disagreeing about what
+ * opening a cluster means.
+ *
+ * The workspace is read HERE, at the moment of the click, rather than taken
+ * from a `useTabs()` subscription in the calling screen: neither screen renders
+ * anything from the workspace, so a subscription bought them only the risk of
+ * acting on a stale copy of the cluster list.
+ */
+export function openCluster(context: ClusterContext): void {
+  const workspace = currentWorkspace();
+  const id = context.stableId;
+  if (!workspace.clusters.includes(id)) {
+    setWorkspaceClusters(workspace.id, [...workspace.clusters, id]);
+  }
+  setActiveCluster(id);
+  // By NAME, not by stableId: core's `list*` and `watchResource` all take a
+  // context name, and the tab is what carries it to them (#265).
+  openTab("/overview", { clusterName: context.name });
+}

--- a/packages/ui-next/src/lib/probe.test.ts
+++ b/packages/ui-next/src/lib/probe.test.ts
@@ -162,3 +162,60 @@ describe("useProbes", () => {
     expect(result.current).not.toBe(before);
   });
 });
+
+/**
+ * **One cluster, one read in flight — the rule two callers who cannot see each
+ * other both depend on.**
+ *
+ * `shell/Window.tsx` probes the workspace's clusters on every change to its
+ * contexts, skipping any that already has an answer (`if (getInfo(id))
+ * continue`); the connections screen probes every context it lists and re-reads
+ * them all on `Refresh all`. `getInfo` only fills in once the round trip is
+ * over, so for the whole length of a slow cluster both see "no answer yet".
+ * Without the join in `probeCluster` that is two reads whose writes land in
+ * whatever order they finish, and the loser is not recoverable from here.
+ */
+describe("one read per cluster", () => {
+  it("joins the read already out rather than starting a second", async () => {
+    let settle!: (v: unknown) => void;
+    const connect = vi.fn(() => new Promise<never>((r) => { settle = r as never; }));
+    const first = probeCluster(ctx, connect as never, () => 0);
+    // A second caller while the first is still out. The same transport, so the
+    // count is what says only one read was started.
+    const second = probeCluster(ctx, connect as never, () => 0);
+    expect(connect).toHaveBeenCalledTimes(1);
+    // Not merely deduped: the joining caller is handed the SAME read, so its
+    // own `await` resolves when the reading is in — which is what lets it do
+    // more work with the answer.
+    expect(second).toBe(first);
+    settle({ context: "prod-eu", reachable: true, version: "v1.31.2" });
+    await act(async () => {
+      await second;
+    });
+    expect(getProbe("prod").state).toBe("reachable");
+    expect(connect).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads again once the last one has landed", async () => {
+    const connect = vi.fn().mockResolvedValue({ context: "prod-eu", reachable: true });
+    await probeCluster(ctx, connect as never, () => 0);
+    await probeCluster(ctx, connect as never, () => 0);
+    expect(connect).toHaveBeenCalledTimes(2);
+  });
+
+  it("reads two different clusters at once", async () => {
+    const connect = vi.fn(() => new Promise<never>(() => {}));
+    void probeCluster(ctx, connect as never, () => 0);
+    void probeCluster({ ...ctx, stableId: "staging", name: "staging-eu" }, connect as never, () => 0);
+    expect(connect).toHaveBeenCalledTimes(2);
+  });
+
+  /** Or the read left hanging by one test would be joined by the next. */
+  it("forgets a read still out when the store is reset", async () => {
+    const connect = vi.fn(() => new Promise<never>(() => {}));
+    void probeCluster(ctx, connect as never, () => 0);
+    resetProbes();
+    void probeCluster(ctx, connect as never, () => 0);
+    expect(connect).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/ui-next/src/lib/probe.test.ts
+++ b/packages/ui-next/src/lib/probe.test.ts
@@ -218,4 +218,49 @@ describe("one read per cluster", () => {
     void probeCluster(ctx, connect as never, () => 0);
     expect(connect).toHaveBeenCalledTimes(2);
   });
+
+  /**
+   * **A read that lands late clears its OWN entry, not whatever is under its
+   * key.**
+   *
+   * The test above stops at "a second read starts". This is what happens next:
+   * the forgotten first read still lands, and its `.finally` ran
+   * `reading.delete(stableId)` — by KEY, which by then holds the SECOND read.
+   * That silently reopens the guard, and the next caller starts a THIRD
+   * concurrent read of one cluster: exactly the two-unordered-writes case this
+   * map exists to prevent, and the losing write is not recoverable from here.
+   *
+   * `connect` called 3 times where 2 is correct is what that looked like.
+   */
+  it("does not reopen the guard when a forgotten read finally lands", async () => {
+    const settles: ((v: unknown) => void)[] = [];
+    const connect = vi.fn(() => new Promise<never>((r) => { settles.push(r as never); }));
+
+    const first = probeCluster(ctx, connect as never, () => 0);
+    // The read the store no longer knows about.
+    resetProbes();
+    const second = probeCluster(ctx, connect as never, () => 0);
+    expect(connect).toHaveBeenCalledTimes(2);
+    expect(second).not.toBe(first);
+
+    // The forgotten read answers, out of order, after the current one started.
+    settles[0]({ context: "prod-eu", reachable: true, version: "v1.31.2" });
+    await act(async () => {
+      await first;
+    });
+
+    // The current read is still the one in flight, so a third caller joins it.
+    const third = probeCluster(ctx, connect as never, () => 0);
+    expect(third).toBe(second);
+    expect(connect).toHaveBeenCalledTimes(2);
+
+    settles[1]({ context: "prod-eu", reachable: true, version: "v1.31.2" });
+    await act(async () => {
+      await second;
+    });
+    // And once the current read has landed the guard opens again, as it must.
+    settles.length = 0;
+    void probeCluster(ctx, connect as never, () => 0);
+    expect(connect).toHaveBeenCalledTimes(3);
+  });
 });

--- a/packages/ui-next/src/lib/probe.test.ts
+++ b/packages/ui-next/src/lib/probe.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
-import { probeCluster, getInfo, useInfo, useInfos, resetProbes } from "./probe";
+import { probeCluster, getInfo, useInfo, useInfos, getProbe, useProbe, useProbes, resetProbes } from "./probe";
 import { getView, resetView } from "./workspace";
 
 const ctx = {
@@ -59,6 +59,106 @@ describe("useInfos", () => {
     const connect = vi.fn().mockResolvedValue({ context: "prod-eu", reachable: true, version: "v1.31.0" });
     await act(async () => { await probeCluster(ctx, connect as never); });
     expect(result.current.prod?.version).toBe("v1.31.0");
+    expect(result.current).not.toBe(before);
+  });
+});
+
+describe("getProbe", () => {
+  it("is unread before anything has probed", () => {
+    expect(getProbe("prod")).toEqual({ state: "unread" });
+  });
+
+  it("times the round trip and reports it once reachable", async () => {
+    let t = 1000;
+    const now = () => (t += 42);
+    const connect = vi.fn().mockResolvedValue({ context: "prod-eu", reachable: true, version: "v1.29.4" });
+    await probeCluster(ctx, connect as never, now);
+    expect(getProbe("prod")).toEqual({ state: "reachable", latencyMs: 42, version: "v1.29.4" });
+  });
+
+  it("reads the clock exactly twice: once before the call, once after", async () => {
+    const now = vi.fn().mockReturnValueOnce(1000).mockReturnValueOnce(1100);
+    const connect = vi.fn().mockResolvedValue({ context: "prod-eu", reachable: true });
+    await probeCluster(ctx, connect as never, now);
+    expect(now).toHaveBeenCalledTimes(2);
+    expect(getProbe("prod").latencyMs).toBe(100);
+  });
+
+  it("has no latency at all when the cluster does not answer, never zero", async () => {
+    let t = 1000;
+    const connect = vi.fn().mockResolvedValue({ context: "prod-eu", reachable: false, error: "dial tcp: timeout" });
+    await probeCluster(ctx, connect as never, () => (t += 42));
+    const probe = getProbe("prod");
+    expect(probe.state).toBe("unreachable");
+    expect("latencyMs" in probe).toBe(false);
+    expect(probe.error).toBeTruthy();
+    expect(probe.error).not.toContain("dial tcp");
+  });
+
+  it("has no error at all when unreachable without one, matching the disconnected link state", async () => {
+    const connect = vi.fn().mockResolvedValue({ context: "prod-eu", reachable: false });
+    await probeCluster(ctx, connect as never);
+    expect(getProbe("prod")).toEqual({ state: "unreachable" });
+  });
+
+  it("reports a rejected probe as unreachable rather than an unhandled rejection", async () => {
+    const connect = vi.fn().mockRejectedValue(new Error("no route to host"));
+    await probeCluster(ctx, connect as never);
+    const probe = getProbe("prod");
+    expect(probe.state).toBe("unreachable");
+    expect("latencyMs" in probe).toBe(false);
+    // The rejection still reaches the link state, same as a resolved failure.
+    expect(getView().links.prod.state).toBe("error");
+  });
+
+  it("clears a stale latency reading once a later probe comes back unreachable", async () => {
+    let t = 0;
+    const now = () => (t += 10);
+    await probeCluster(ctx, vi.fn().mockResolvedValue({ context: "prod-eu", reachable: true }) as never, now);
+    expect(getProbe("prod").latencyMs).toBe(10);
+    await probeCluster(
+      ctx,
+      vi.fn().mockResolvedValue({ context: "prod-eu", reachable: false, error: "timeout" }) as never,
+      now,
+    );
+    expect("latencyMs" in getProbe("prod")).toBe(false);
+  });
+
+  it("forgets everything on reset", async () => {
+    await probeCluster(ctx, vi.fn().mockResolvedValue({ context: "prod-eu", reachable: true }) as never, () => 5);
+    resetProbes();
+    expect(getProbe("prod")).toEqual({ state: "unread" });
+  });
+});
+
+describe("useProbe", () => {
+  it("re-renders with the probe once it lands, and forgets it on reset", async () => {
+    const { result } = renderHook(() => useProbe("prod"));
+    expect(result.current).toEqual({ state: "unread" });
+    let t = 0;
+    const now = () => (t += 7);
+    await act(async () => {
+      await probeCluster(ctx, vi.fn().mockResolvedValue({ context: "prod-eu", reachable: true }) as never, now);
+    });
+    expect(result.current).toEqual({ state: "reachable", latencyMs: 7 });
+    act(() => resetProbes());
+    expect(result.current).toEqual({ state: "unread" });
+  });
+});
+
+describe("useProbes", () => {
+  it("hands back the whole store, with a new identity only when a probe lands", async () => {
+    const { result, rerender } = renderHook(() => useProbes());
+    expect(result.current).toEqual({});
+    const before = result.current;
+    rerender();
+    expect(result.current).toBe(before);
+
+    let t = 0;
+    await act(async () => {
+      await probeCluster(ctx, vi.fn().mockResolvedValue({ context: "prod-eu", reachable: true }) as never, () => (t += 5));
+    });
+    expect(result.current.prod).toEqual({ state: "reachable", latencyMs: 5 });
     expect(result.current).not.toBe(before);
   });
 });

--- a/packages/ui-next/src/lib/probe.test.ts
+++ b/packages/ui-next/src/lib/probe.test.ts
@@ -3,7 +3,10 @@ import { renderHook, act } from "@testing-library/react";
 import { probeCluster, getInfo, useInfo, useInfos, resetProbes } from "./probe";
 import { getView, resetView } from "./workspace";
 
-const ctx = { name: "prod-eu", stableId: "prod", cluster: "c", server: "", isCurrent: false };
+const ctx = {
+  name: "prod-eu", stableId: "prod", cluster: "c", server: "", isCurrent: false,
+  sourceFile: "/home/dana/.kube/config", authKind: "client certificate",
+};
 
 beforeEach(() => { resetView(); resetProbes(); });
 

--- a/packages/ui-next/src/lib/probe.ts
+++ b/packages/ui-next/src/lib/probe.ts
@@ -140,7 +140,13 @@ export function probeCluster(
   const running = reading.get(ctx.stableId);
   if (running) return running;
   const run = read(ctx, connect, now).finally(() => {
-    reading.delete(ctx.stableId);
+    // **By identity, not by key.** A read that {@link resetProbes} forgot
+    // still lands, and deleting by key alone would clear whatever is under
+    // that key by then — which is the CURRENT read. That silently reopens the
+    // guard and the next caller starts a third concurrent read of one cluster,
+    // the exact case this map exists to prevent. Only the entry this read
+    // installed is its to remove.
+    if (reading.get(ctx.stableId) === run) reading.delete(ctx.stableId);
   });
   reading.set(ctx.stableId, run);
   return run;

--- a/packages/ui-next/src/lib/probe.ts
+++ b/packages/ui-next/src/lib/probe.ts
@@ -47,7 +47,7 @@ const emit = () => { for (const l of listeners) l(); };
 
 export function getInfo(stableId: string): ClusterInfo | undefined { return infos[stableId]; }
 export function getProbe(stableId: string): Probe { return probes[stableId] ?? UNREAD; }
-export function resetProbes(): void { infos = {}; probes = {}; emit(); }
+export function resetProbes(): void { infos = {}; probes = {}; reading.clear(); emit(); }
 function subscribe(l: () => void) { listeners.add(l); return () => listeners.delete(l); }
 export function useProbe(stableId: string | null): Probe {
   return useSyncExternalStore(subscribe, () => (stableId ? (probes[stableId] ?? UNREAD) : UNREAD), () => UNREAD);
@@ -78,6 +78,42 @@ export function useInfos(): Record<string, ClusterInfo> {
 }
 
 /**
+ * The read in flight per cluster — **the one place two callers can both see.**
+ *
+ * Two surfaces ask for a reading of the same cluster and neither can see the
+ * other: `shell/Window.tsx` probes the workspace's clusters whenever its
+ * contexts change, skipping a cluster that already has an answer
+ * (`if (getInfo(id)) continue`), and the connections screen probes every
+ * context it lists and re-reads them all on `Refresh all`. `getInfo` is
+ * populated only AFTER the round trip completes, so for the whole length of a
+ * slow or timing-out cluster both callers see "no answer yet" and both start a
+ * read.
+ *
+ * That is two unordered writes of one cluster's reading, and this store is
+ * exactly where they cannot be undone: whichever finishes last wins, so a
+ * 30-second timeout from the first read lands on top of the second read's
+ * `12 ms` and the row says `unreachable` about a cluster that answered.
+ *
+ * A guard held by either caller could not fix it — a component ref is invisible
+ * to the other, and both call THIS function. So the rule lives here: **one
+ * cluster, one read in flight**, and a second caller joins the first rather
+ * than racing it. Joining also means the second caller's `await` resolves when
+ * the reading is actually in — which is what lets a caller do more work once a
+ * cluster has answered (the connections screen fetches its facts) rather than
+ * walking away from a cluster it declined to re-probe.
+ *
+ * Keyed on `stableId`, and deliberately not on the injected `connect`: two
+ * concurrent reads of one cluster with different transports is not a thing any
+ * caller does, and the tests that inject one await it before the next.
+ * {@link resetProbes} clears this along with the answers, so a test that leaves
+ * a read hanging does not leave the next one joined to it.
+ */
+const reading = new Map<string, Promise<void>>();
+
+/**
+ * Read one cluster: connect to it, time the round trip, and record what came
+ * back — or join the read already out for it (see {@link reading}).
+ *
  * Link state is derived, not invented: `connecting` while the call is out,
  * then `connected` from `reachable`, `error` with the backend's message, or
  * `disconnected` when it is unreachable and says nothing more.
@@ -85,17 +121,36 @@ export function useInfos(): Record<string, ClusterInfo> {
  * `now` times the round trip for {@link Probe.latencyMs} and defaults to
  * `Date.now`; tests inject a fake clock that actually advances, because one
  * that never moves would let a broken timing calculation (e.g. reading the
- * clock once and subtracting it from itself) pass unnoticed.
+ * clock once and subtracting it from itself) pass unnoticed. Both it and
+ * `connect` belong to whichever call STARTED the read — a joining caller gets
+ * the reading the first one is taking, which is the point of joining.
  *
  * `connect` is not expected to reject — `connectCluster` already catches
  * transport failures into `{ reachable: false, error }` — but an injected
  * one in a test might, so a rejection is folded into the same unreachable
- * shape rather than left as an unhandled promise.
+ * shape rather than left as an unhandled promise. Not `async` itself, so a
+ * joining caller is handed the running promise rather than a fresh one wrapped
+ * around it.
  */
-export async function probeCluster(
+export function probeCluster(
   ctx: ClusterContext,
   connect: typeof connectCluster = connectCluster,
   now: () => number = Date.now,
+): Promise<void> {
+  const running = reading.get(ctx.stableId);
+  if (running) return running;
+  const run = read(ctx, connect, now).finally(() => {
+    reading.delete(ctx.stableId);
+  });
+  reading.set(ctx.stableId, run);
+  return run;
+}
+
+/** One reading, start to finish. See {@link probeCluster} for who may start it. */
+async function read(
+  ctx: ClusterContext,
+  connect: typeof connectCluster,
+  now: () => number,
 ): Promise<void> {
   setLink(ctx.stableId, "connecting");
   const started = now();

--- a/packages/ui-next/src/lib/probe.ts
+++ b/packages/ui-next/src/lib/probe.ts
@@ -1,14 +1,63 @@
 import { useSyncExternalStore } from "react";
-import { connectCluster, type ClusterContext, type ClusterInfo } from "@srelens/core";
+import { connectCluster, describeError, type ClusterContext, type ClusterInfo } from "@srelens/core";
 import { setLink } from "./workspace";
 
 let infos: Record<string, ClusterInfo> = {};
+
+/**
+ * A cluster's reachability probe, for readouts (the connections screen) that
+ * want a latency and a tri-state status rather than the raw `ClusterInfo` the
+ * rest of the shell keys off of. Kept as its own store rather than folded into
+ * `infos`, so `getInfo`/`useInfo`/`useInfos` and their callers — the rail, the
+ * status strip, Overview, Toolbox — stay untouched.
+ */
+export type ProbeState = "unread" | "reachable" | "unreachable";
+
+export interface Probe {
+  state: ProbeState;
+  /**
+   * Round trip to the API server, timed around the `connect` call — no
+   * capability returns this, so it is measured here. It is a network
+   * duration, not a cluster health signal. Absent unless `state` is
+   * "reachable": a call that did not complete has no duration to report, and
+   * `0` would read as instant, which is the opposite of the truth.
+   */
+  latencyMs?: number;
+  /** Through `describeError`, never the backend's raw string. Present only
+   *  when `state` is "unreachable" and the backend said something — an
+   *  unreachable cluster that said nothing (the link state's "disconnected")
+   *  gets no invented message either. */
+  error?: string;
+  version?: string;
+}
+
+const UNREAD: Probe = { state: "unread" };
+
+let probes: Record<string, Probe> = {};
+
+function deriveProbe(info: ClusterInfo, latencyMs: number): Probe {
+  if (info.reachable) {
+    return { state: "reachable", latencyMs, ...(info.version ? { version: info.version } : {}) };
+  }
+  return { state: "unreachable", ...(info.error ? { error: describeError(info.error).detail } : {}) };
+}
+
 const listeners = new Set<() => void>();
 const emit = () => { for (const l of listeners) l(); };
 
 export function getInfo(stableId: string): ClusterInfo | undefined { return infos[stableId]; }
-export function resetProbes(): void { infos = {}; emit(); }
+export function getProbe(stableId: string): Probe { return probes[stableId] ?? UNREAD; }
+export function resetProbes(): void { infos = {}; probes = {}; emit(); }
 function subscribe(l: () => void) { listeners.add(l); return () => listeners.delete(l); }
+export function useProbe(stableId: string | null): Probe {
+  return useSyncExternalStore(subscribe, () => (stableId ? (probes[stableId] ?? UNREAD) : UNREAD), () => UNREAD);
+}
+
+/** Every cluster's probe at once, for the connections screen's list — same
+ *  shape and same reasoning as {@link useInfos}. */
+export function useProbes(): Record<string, Probe> {
+  return useSyncExternalStore(subscribe, () => probes, () => probes);
+}
 export function useInfo(stableId: string | null): ClusterInfo | undefined {
   return useSyncExternalStore(subscribe, () => (stableId ? infos[stableId] : undefined), () => undefined);
 }
@@ -32,11 +81,33 @@ export function useInfos(): Record<string, ClusterInfo> {
  * Link state is derived, not invented: `connecting` while the call is out,
  * then `connected` from `reachable`, `error` with the backend's message, or
  * `disconnected` when it is unreachable and says nothing more.
+ *
+ * `now` times the round trip for {@link Probe.latencyMs} and defaults to
+ * `Date.now`; tests inject a fake clock that actually advances, because one
+ * that never moves would let a broken timing calculation (e.g. reading the
+ * clock once and subtracting it from itself) pass unnoticed.
+ *
+ * `connect` is not expected to reject — `connectCluster` already catches
+ * transport failures into `{ reachable: false, error }` — but an injected
+ * one in a test might, so a rejection is folded into the same unreachable
+ * shape rather than left as an unhandled promise.
  */
-export async function probeCluster(ctx: ClusterContext, connect: typeof connectCluster = connectCluster): Promise<void> {
+export async function probeCluster(
+  ctx: ClusterContext,
+  connect: typeof connectCluster = connectCluster,
+  now: () => number = Date.now,
+): Promise<void> {
   setLink(ctx.stableId, "connecting");
-  const info = await connect(ctx.name);
+  const started = now();
+  let info: ClusterInfo;
+  try {
+    info = await connect(ctx.name);
+  } catch (e) {
+    info = { context: ctx.name, reachable: false, error: String(e) };
+  }
+  const elapsedMs = now() - started;
   infos = { ...infos, [ctx.stableId]: info };
+  probes = { ...probes, [ctx.stableId]: deriveProbe(info, elapsedMs) };
   emit();
   if (info.reachable) setLink(ctx.stableId, "connected");
   else if (info.error) setLink(ctx.stableId, "error", info.error);

--- a/packages/ui-next/src/lib/routes.test.ts
+++ b/packages/ui-next/src/lib/routes.test.ts
@@ -5,6 +5,8 @@
 import { describe as suite, it, expect } from "vitest";
 import { describe, isBuiltInKind, screenFor } from "./routes";
 import { AppLog } from "../screens/AppLog";
+import { Connect } from "../screens/Connect";
+import { Connections } from "../screens/Connections";
 import { Events } from "../screens/Events";
 import { ReleaseNotes } from "../screens/ReleaseNotes";
 import { Overview } from "../screens/Overview";
@@ -227,6 +229,23 @@ suite("screenFor", () => {
     // fall to the generic three-column (Name/Namespace/Age) descriptor and
     // silently lose Type, Reason, Object, Message and Count.
     expect(screenFor("/k/events")).toBe(Events);
+  });
+
+  it("resolves the connections screen, which the cluster rail opens", () => {
+    // The rail's `Connection details` has pointed at /connections since the
+    // rail was built, and both panes behind it — the cluster table and the
+    // Sources rail — were finished before this entry existed, so the menu item
+    // opened a correctly titled tab onto the Placeholder.
+    expect(screenFor("/connections")).toBe(Connections);
+  });
+
+  it("resolves the connect screen, the first-run door", () => {
+    // Two controls on /connections open this route — `Add connection` and the
+    // empty state's own — and both were built against a route with no entry
+    // here, which is the seam the note in `Connections.tsx` left for it. It is
+    // also the only screen a reader can be on with no cluster connected, so a
+    // Placeholder here is a first run that never gets past the door.
+    expect(screenFor("/connect")).toBe(Connect);
   });
 
   it("gives a route with no screen a placeholder", () => {

--- a/packages/ui-next/src/lib/routes.ts
+++ b/packages/ui-next/src/lib/routes.ts
@@ -2,6 +2,8 @@ import type { ComponentType } from "react";
 import { K8S_KIND, RESOURCE_LABELS, type ResourceKind } from "@srelens/core";
 import { parseDetailRoute } from "./detailRoute";
 import { AppLog } from "../screens/AppLog";
+import { Connect } from "../screens/Connect";
+import { Connections } from "../screens/Connections";
 import { Events } from "../screens/Events";
 import { Forwards } from "../screens/Forwards";
 import { Helm } from "../screens/Helm";
@@ -166,6 +168,18 @@ const SCREENS: Record<string, ScreenComponent> = Object.assign(Object.create(nul
   // App-scoped: the managed kubectl, helm and krew are the machine's, and the
   // exec-auth rail is the only part of it that looks at a context at all.
   "/toolbox": Toolbox,
+  // App-scoped, and about every cluster at once rather than one: which contexts
+  // srelens can see, the file each was read from, and what the last probe said.
+  // Reached from the cluster rail's `Connection details`, which has pointed
+  // here since the rail was built — without this entry that menu item opened a
+  // correctly titled tab onto the Placeholder.
+  "/connections": Connections,
+  // The first-run door, and the only screen a reader can be on with no cluster
+  // connected at all. Reached from `/connections` twice over — the
+  // `Add connection` control and the empty state's own — and both of those were
+  // built and tested against a route that rendered the Placeholder, which is
+  // the seam the note in `Connections.tsx` left for this entry.
+  "/connect": Connect,
 });
 
 /**

--- a/packages/ui-next/src/lib/tabs.test.ts
+++ b/packages/ui-next/src/lib/tabs.test.ts
@@ -6,6 +6,7 @@ import { CLOSED_CAP, defaultState, makeTab, newId, reconcile, type TabsState, ty
 
 const ctx = (stableId: string, name = stableId): ClusterContext => ({
   name, stableId, cluster: name, server: `https://${name}`, isCurrent: false,
+  sourceFile: "/home/dana/.kube/config", authKind: "client certificate",
 });
 
 const ws = (over: Partial<Workspace> = {}): Workspace => ({

--- a/packages/ui-next/src/lib/tabs.ts
+++ b/packages/ui-next/src/lib/tabs.ts
@@ -70,6 +70,41 @@ export function makeTab(route: string, opts: { preview?: boolean; clusterName?: 
   return tab;
 }
 
+/**
+ * The tab a caller asked for, labelled for the cluster they named.
+ *
+ * **Why this exists at all.** `openTab` dedupes by ROUTE — deliberately, and
+ * right for most of its callers: a detail route, a list route and `/overview`
+ * are each meant to be one tab in the strip. But `makeTab` spends
+ * `clusterName` on the `sub` at CREATION, so a tab reused for a second cluster
+ * kept the first one's label: the overview rendered cluster B while the strip
+ * read cluster A, which is the one place a reader looks to know which cluster
+ * they are in.
+ *
+ * **Through `describe`, never `sub = clusterName`.** `describe` drops `sub`
+ * entirely for an app-scoped route (`{ route, ...app }` spreads no `sub`),
+ * because `/connections` and `/connect` are not about a cluster — assigning the
+ * caller's string straight onto the tab would put a cluster name under the
+ * strip's `Connections` label. The route table stays the one place that decides
+ * whether a route carries a cluster, and the title comes back through the same
+ * call so a route that ever spends `clusterName` on its title follows too.
+ *
+ * No `clusterName` means the caller said nothing about a cluster — a keyboard
+ * shortcut, a reopened tab — and the tab keeps the label it has rather than
+ * being blanked. Returns the input untouched when nothing changed, which is
+ * what lets `openTab` decide by identity whether to emit: one subscriber of
+ * that store writes a file.
+ */
+export function relabel(tab: Tab, clusterName?: string): Tab {
+  if (!clusterName) return tab;
+  const info = describe(tab.route, clusterName);
+  if (info.title === tab.title && info.sub === tab.sub) return tab;
+  const next: Tab = { ...tab, title: info.title };
+  if (info.sub) next.sub = info.sub;
+  else delete next.sub;
+  return next;
+}
+
 function homeTab(): Tab {
   return makeTab("/");
 }

--- a/packages/ui-next/src/lib/tabsPersist.test.ts
+++ b/packages/ui-next/src/lib/tabsPersist.test.ts
@@ -20,6 +20,7 @@ function memory(): Storage & { data: Map<string, string> } {
 
 const ctx = (id: string): ClusterContext => ({
   name: id, stableId: id, cluster: id, server: `https://${id}`, isCurrent: false,
+  sourceFile: "/home/dana/.kube/config", authKind: "client certificate",
 });
 
 const valid = (): TabsState => {

--- a/packages/ui-next/src/lib/tabsStore.test.tsx
+++ b/packages/ui-next/src/lib/tabsStore.test.tsx
@@ -6,6 +6,7 @@ import * as store from "./tabsStore";
 
 const ctx = (id: string): ClusterContext => ({
   name: id, stableId: id, cluster: id, server: `https://${id}`, isCurrent: false,
+  sourceFile: "/home/dana/.kube/config", authKind: "client certificate",
 });
 
 function seed(over: Partial<TabsState> = {}) {

--- a/packages/ui-next/src/lib/tabsStore.test.tsx
+++ b/packages/ui-next/src/lib/tabsStore.test.tsx
@@ -66,6 +66,62 @@ describe("openTab", () => {
     expect(active().sub).toBe("staging");
   });
 
+  /**
+   * **The bug this pins: a second cluster opened onto a tab still labelled with
+   * the first.**
+   *
+   * `openTab` dedupes by ROUTE, which is right for most of its callers — a
+   * detail route, a list route and `/overview` are each meant to be one tab.
+   * But it returned with `activeId: existing.id` and never looked at
+   * `clusterName`, and `makeTab` spends `clusterName` on the `sub`, so the
+   * label was baked in at creation. With an `/overview` tab open for one
+   * cluster, opening a second changed the workspace's active cluster and reused
+   * the first tab: the screen rendered the second cluster while the strip read
+   * the first. Every caller that names a cluster — `Nav`, `Status`,
+   * `openCluster`, and the six screens that open a detail route — had the same
+   * hole.
+   */
+  it("relabels a reused tab for the cluster the caller named", () => {
+    store.openTab("/overview", { clusterName: "prod-eu" });
+    const first = active().id;
+    store.openTab("/overview", { clusterName: "staging-eu" });
+    // One tab, still — the route dedupe is not what was wrong.
+    expect(routes()).toEqual(["/", "/overview"]);
+    expect(active().id).toBe(first);
+    expect(active().sub).toBe("staging-eu");
+  });
+
+  it("leaves a tab's cluster alone when the caller names none", () => {
+    // Cmd-clicking a route from a shortcut says nothing about a cluster, and it
+    // must not blank the label of the tab it lands on.
+    store.openTab("/overview", { clusterName: "prod-eu" });
+    store.openTab("/overview");
+    expect(active().sub).toBe("prod-eu");
+  });
+
+  /**
+   * **Relabelling goes through `describe`, not through `sub = clusterName`.**
+   *
+   * `describe` drops `sub` for an app-scoped route (`{ route, ...app }`, with no
+   * `sub` spread in), because `/connections` and `/connect` are not about a
+   * cluster. Assigning the caller's `clusterName` straight onto the tab would
+   * put a cluster name under the strip's `Connections` label — a tab claiming
+   * to be scoped to a cluster it has nothing to do with. The route table stays
+   * the one place that decides whether a route carries a cluster.
+   */
+  it("puts no cluster on a tab whose route is not about one", () => {
+    store.openTab("/connections");
+    store.openTab("/connections", { clusterName: "staging-eu" });
+    expect(active().sub).toBeUndefined();
+  });
+
+  it("promotes a preview and relabels it in one go", () => {
+    store.openTab("/overview", { preview: true, clusterName: "prod-eu" });
+    store.openTab("/overview", { clusterName: "staging-eu" });
+    expect(active().preview).toBeFalsy();
+    expect(active().sub).toBe("staging-eu");
+  });
+
   it("newTab always appends, even when the route is open", () => {
     store.newTab("/");
     expect(routes()).toEqual(["/", "/"]);
@@ -387,6 +443,15 @@ describe("no-op actions do not notify", () => {
   }
 
   silent("openTab on the active, non-preview route", () => {}, () => store.openTab("/"));
+
+  // The relabel must be a no-op when there is nothing to relabel: one
+  // subscriber writes a file, and re-opening the cluster you are already
+  // looking at must not schedule a save.
+  silent(
+    "openTab naming the cluster the tab already carries",
+    () => store.openTab("/overview", { clusterName: "prod-eu" }),
+    () => store.openTab("/overview", { clusterName: "prod-eu" }),
+  );
 
   silent(
     "closeOthers when every other tab is pinned and this one is active",

--- a/packages/ui-next/src/lib/tabsStore.ts
+++ b/packages/ui-next/src/lib/tabsStore.ts
@@ -1,6 +1,17 @@
 import { useSyncExternalStore } from "react";
+import type { ClusterContext } from "@srelens/core";
 import type { TableSort } from "@srelens/ui-kit";
-import { CLOSED_CAP, defaultState, makeTab, newId, relabel, type Tab, type TabsState, type Workspace } from "./tabs";
+import {
+  CLOSED_CAP,
+  defaultState,
+  makeTab,
+  newId,
+  reconcile,
+  relabel,
+  type Tab,
+  type TabsState,
+  type Workspace,
+} from "./tabs";
 
 /**
  * The tab store: module-level state, one hook, plain functions for actions.
@@ -47,6 +58,29 @@ export function getState(): TabsState {
 /** Replace the whole state — for boot and for tests. */
 export function setState(next: TabsState): void {
   emit(next);
+}
+
+/**
+ * Make every workspace consistent with the clusters that actually exist.
+ *
+ * **Called after a listing that answered, from the contexts store rather than
+ * from a screen.** `Window` does this at boot against the restored state, and
+ * for a while it was the only caller: `/connections`' `Refresh all` and
+ * `/connect`'s `reload` both replaced the context list and left the workspace
+ * pointing at whatever it had, so removing or renaming the ACTIVE context and
+ * refreshing left `activeCluster` naming a context nobody declares —
+ * `useActiveContext()` `undefined`, and every cluster-scoped screen on its
+ * no-cluster state while other clusters sat in the table. `reconcile` is what
+ * picks the first survivor, and it did not run.
+ *
+ * It lives behind the contexts store's own write (see `setContexts`) so that
+ * every listing goes through it, including a fourth caller nobody has written
+ * yet. `reconcile` returns the state untouched when nothing needed changing and
+ * `emit` skips an unchanged state, so a refresh that answers with the same
+ * clusters wakes nobody — one of the subscribers writes a file.
+ */
+export function reconcileClusters(contexts: readonly ClusterContext[]): void {
+  emit(reconcile(cur(), [...contexts]));
 }
 
 export function subscribe(listener: () => void): () => void {

--- a/packages/ui-next/src/lib/tabsStore.ts
+++ b/packages/ui-next/src/lib/tabsStore.ts
@@ -1,6 +1,6 @@
 import { useSyncExternalStore } from "react";
 import type { TableSort } from "@srelens/ui-kit";
-import { CLOSED_CAP, defaultState, makeTab, newId, type Tab, type TabsState, type Workspace } from "./tabs";
+import { CLOSED_CAP, defaultState, makeTab, newId, relabel, type Tab, type TabsState, type Workspace } from "./tabs";
 
 /**
  * The tab store: module-level state, one hook, plain functions for actions.
@@ -111,15 +111,34 @@ export function useTabs() {
   };
 }
 
+/**
+ * The tab for a route: the one already open, or a new one.
+ *
+ * **The dedupe is by route, and a reused tab is relabelled for the cluster the
+ * caller named.** Route-only dedupe is what most callers want — one tab per
+ * detail route, per list route, per `/overview` — and it stays. What did not
+ * hold was returning that tab untouched: `makeTab` fixes the `sub` at creation
+ * from `clusterName`, so opening a second cluster onto an `/overview` tab left
+ * the strip reading the first cluster while the screen rendered the second.
+ *
+ * The relabel lives here rather than in `openCluster` because HERE is where the
+ * reuse decision is made, and every caller that names a cluster had the same
+ * hole: `Nav`, `Status`, `openCluster` and the six screens that open a detail
+ * or logs route from a row. Fixing it in one caller would have left the others
+ * to find it again. See {@link relabel} for why the new label comes back
+ * through the route table rather than from the argument.
+ */
 export function openTab(route: string, opts: { preview?: boolean; clusterName?: string } = {}): void {
   patchCurrent((w) => {
     const existing = w.tabs.find((t) => t.route === route);
     if (existing) {
       // Opening for real promotes a preview; re-previewing leaves it be.
-      const tabs =
-        !opts.preview && existing.preview
-          ? w.tabs.map((t) => (t.id === existing.id ? { ...t, preview: false } : t))
-          : w.tabs;
+      const promoted =
+        !opts.preview && existing.preview ? { ...existing, preview: false } : existing;
+      const next = relabel(promoted, opts.clusterName);
+      // Identity is the signal, as everywhere else in this store: nothing to
+      // promote and nothing to relabel means no new array and no emit.
+      const tabs = next === existing ? w.tabs : w.tabs.map((t) => (t.id === existing.id ? next : t));
       if (tabs === w.tabs && w.activeId === existing.id) return w;
       return { ...w, tabs, activeId: existing.id };
     }

--- a/packages/ui-next/src/screens/Connect.test.tsx
+++ b/packages/ui-next/src/screens/Connect.test.tsx
@@ -89,6 +89,31 @@ const LOCAL: ClusterContext = {
   authKind: "client certificate",
 };
 
+/**
+ * **A context whose `stableId` is not its `name`.**
+ *
+ * Every other fixture in this file has the two strings equal, and that is
+ * exactly the shape that hides a key conflation: handing `openTab` a stableId
+ * where it wants a context name passed all 59 tests across the two connection
+ * screens, because `activeCluster` and `clusters` are both keyed by id and
+ * neither can see the label. A stableId is the declaring file plus the name in
+ * it, which is what every context looks like once two kubeconfigs declare one
+ * name — so the tab-label assertions use this one and can tell a NAME from an
+ * id.
+ *
+ * Used on its own with {@link PROD}, never beside {@link STAGING}, whose name
+ * it deliberately shares.
+ */
+const TWIN: ClusterContext = {
+  name: "staging-eu",
+  stableId: `${EDGE_FILE}#staging-eu`,
+  cluster: "staging",
+  server: "https://staging-eu.example:6443",
+  isCurrent: false,
+  sourceFile: EDGE_FILE,
+  authKind: "token",
+};
+
 /** The three default contexts: two in one file, one in another. */
 const THREE = [PROD, STAGING, EDGE];
 
@@ -430,6 +455,35 @@ describe("Connect", () => {
       }
       // Each row's own reading, not one number copied down the list.
       expect(row("prod-eu").latency?.textContent).not.toBe(row("edge-1").latency?.textContent);
+    });
+
+    /**
+     * **A SECOND cluster opened onto an `/overview` tab the FIRST one made.**
+     *
+     * `openTab` dedupes by route and used to return with `activeId:
+     * existing.id` without looking at `clusterName`, while `makeTab` spends
+     * `clusterName` on the tab's `sub` — so the label was fixed at creation.
+     * The workspace's active cluster moved, the screen rendered the second
+     * cluster, and the strip went on reading the first: the one place a reader
+     * looks to know which cluster they are in.
+     *
+     * The label is asserted to be the NAME and explicitly not the stableId —
+     * see {@link TWIN} for why that second line is not redundant here.
+     */
+    it("relabels the overview tab when a second cluster is opened onto it", async () => {
+      setContexts([PROD, TWIN]);
+      open();
+      await screen.findByText("Contexts found");
+
+      await userEvent.click(screen.getByRole("button", { name: /Open prod-eu/i }));
+      await userEvent.click(screen.getByRole("button", { name: /Open staging-eu/i }));
+
+      const overview = store.currentWorkspace().tabs.filter((t) => t.route === "/overview");
+      // Still one tab: the route dedupe was never the fault.
+      expect(overview).toHaveLength(1);
+      expect(store.activeCluster()).toBe(TWIN.stableId);
+      expect(overview[0]?.sub).toBe(TWIN.name);
+      expect(overview[0]?.sub).not.toBe(TWIN.stableId);
     });
 
     it("opens the cluster the row stands for", async () => {

--- a/packages/ui-next/src/screens/Connect.test.tsx
+++ b/packages/ui-next/src/screens/Connect.test.tsx
@@ -458,6 +458,29 @@ describe("Connect", () => {
     });
 
     /**
+     * **`/connect`'s own listing has the same duty as `/connections`'.**
+     *
+     * Both doors here re-list through `reload`, and a reader who has just
+     * pointed srelens at a different kubeconfig is exactly the reader whose
+     * active context can vanish. The reconciliation lives in the contexts store
+     * rather than in either screen, so this passes for the same reason
+     * `/connections`' does — which is the point of putting it there.
+     */
+    it("moves the focus off a cluster a new listing no longer finds", async () => {
+      core.isTauri.mockReturnValue(true);
+      core.pickKubeconfigFiles.mockResolvedValue([EDGE_FILE]);
+      core.listContexts.mockResolvedValue({ contexts: [EDGE] });
+      open();
+      await screen.findByText("Contexts found");
+      expect(store.activeCluster()).toBe(PROD.stableId);
+
+      await userEvent.click(screen.getByRole("button", { name: /Add a kubeconfig file/i }));
+
+      await waitFor(() => expect(store.activeCluster()).toBe(EDGE.stableId));
+      expect(store.currentWorkspace().clusters).toEqual([EDGE.stableId]);
+    });
+
+    /**
      * **A SECOND cluster opened onto an `/overview` tab the FIRST one made.**
      *
      * `openTab` dedupes by route and used to return with `activeId:

--- a/packages/ui-next/src/screens/Connect.test.tsx
+++ b/packages/ui-next/src/screens/Connect.test.tsx
@@ -25,6 +25,7 @@ vi.mock("@srelens/core", async (orig) => ({
 
 import { describeError, type ClusterContext, type ClusterInfo } from "@srelens/core";
 import { Connect } from "./Connect";
+import { ClusterTable } from "./connections/ClusterTable";
 import { getKubeconfigFiles, resetContexts, setContexts, setKubeconfigFiles } from "../lib/clusters";
 import { getProbe, resetProbes } from "../lib/probe";
 import { defaultState } from "../lib/tabs";
@@ -408,6 +409,62 @@ describe("Connect", () => {
 
       // The badge and the reading keep their own width whatever the name does.
       expect(row("prod-eu").status.parentElement?.className).toContain("shrink-0");
+    });
+  });
+
+  /**
+   * **One set of clusters, one order, across both screens.**
+   *
+   * `/connections` groups its rows by credential source and `/connect` listed
+   * in raw `listContexts` order, so the same seventeen clusters came out in two
+   * different orders on two screens a reader moves between in one click. The
+   * order itself is `bySource`'s, which now lives in `clusterText` beside the
+   * status words — a second sort written here is how the two screens would
+   * start disagreeing again.
+   */
+  describe("the order it lists in", () => {
+    /**
+     * Interleaved ON PURPOSE: the local cluster sits between two kubeconfig
+     * contexts, so the expected order is not the order it was listed in. With
+     * the local cluster last, a screen that applied no grouping at all would
+     * satisfy this on fixture order alone.
+     */
+    const MIXED = [PROD, LOCAL, STAGING];
+
+    it("lists kubeconfig contexts ahead of local clusters, whatever order they were listed in", async () => {
+      setContexts(MIXED);
+      open();
+      await screen.findByText("Contexts found");
+
+      expect(screen.getAllByTestId(/^connect-name-/).map((el) => el.textContent)).toEqual([
+        "prod-eu",
+        "staging-eu",
+        "kind-lab",
+      ]);
+    });
+
+    it("lists them in the same order the connections table does", async () => {
+      setContexts(MIXED);
+      open();
+      await screen.findByText("Contexts found");
+      const here = screen.getAllByTestId(/^connect-name-/).map((el) => el.textContent);
+
+      // The other screen, from the same contexts. Rendered into its own
+      // container so the two lists cannot read each other's rows.
+      const table = render(
+        <ClusterTable
+          rows={MIXED.map((context) => ({ context, probe: { state: "unread" as const } }))}
+          onOpen={() => {}}
+        />,
+      );
+      const there = within(table.container)
+        .getAllByTestId(/^cluster-name-/)
+        .map((el) => el.textContent);
+
+      expect(here).toEqual(there);
+      // And not the raw listing order — which is what makes the line above a
+      // claim about grouping rather than about two screens both doing nothing.
+      expect(here).not.toEqual(MIXED.map((context) => context.name));
     });
   });
 

--- a/packages/ui-next/src/screens/Connect.test.tsx
+++ b/packages/ui-next/src/screens/Connect.test.tsx
@@ -184,9 +184,41 @@ describe("Connect", () => {
       expect(screen.getByText("The room is already reading it.")).toBeTruthy();
       expect(
         screen.getByText(
-          "srelens uses the credentials already in your kubeconfig and talks to the API server directly. Nothing about your clusters leaves this machine.",
+          "srelens uses the credentials already in your kubeconfig and talks to the API server directly. That file stays on this machine, and no srelens service sits between you and your clusters.",
         ),
       ).toBeTruthy();
+    });
+
+    /**
+     * **The absolute promise is gone, and its absence is half the assertion.**
+     *
+     * The lede used to end "Nothing about your clusters leaves this machine",
+     * and srelens cannot keep that. `srelens --mcp-stdio` serves
+     * `k8s.listContexts` as a READ-ONLY capability, and only a mutating one is
+     * confirm-gated — `assert_mutating_capabilities_are_gated`
+     * (`crates/mcp/src/completeness.rs:36-45`) fails the build for a mutating
+     * capability that is not, and says nothing about a read. So a connected
+     * agent, typically a remote model, can read every cluster name, server,
+     * source file and credential kind on this page with no prompt at all. The
+     * reader configured that themselves; the sentence promised it could not
+     * happen.
+     *
+     * What is kept is what holds unconditionally, and it is worth keeping: the
+     * kubeconfig is not uploaded, and there is no srelens service between the
+     * reader and their API servers. Pinned as the ABSENCE of the false
+     * sentence as well as the presence of the true one, because a narrowed
+     * privacy claim is exactly the copy a well-meaning revert restores — and a
+     * presence-only test would pass with both sentences on the page.
+     */
+    it("does not promise a desktop reader that nothing about their clusters leaves the machine", async () => {
+      core.isTauri.mockReturnValue(true);
+      open();
+      await screen.findByText("Contexts found");
+
+      expect(screen.queryByText(/Nothing about your clusters leaves this machine/)).toBeNull();
+      expect(screen.queryByText(/leaves this machine/)).toBeNull();
+      expect(screen.getByText(/That file stays on this machine/)).toBeTruthy();
+      expect(screen.getByText(/no srelens service sits between you and your clusters/)).toBeTruthy();
     });
 
     /**
@@ -689,9 +721,35 @@ describe("Connect", () => {
       expect(strip.querySelector("svg")).toBeTruthy();
       expect(
         within(strip).getByText(
-          "srelens reads each cluster directly, with the credentials already in your kubeconfig, and sends that file nowhere. Asking the console about a cluster in plain language is not in this design yet.",
+          "srelens reads each cluster directly, with the credentials already in your kubeconfig, and never copies or uploads that file. Connect an agent to srelens over MCP and it can read this list, and the clusters on it, without asking first; every change it makes stops at a confirmation prompt. Asking the console about a cluster in plain language is not in this design yet.",
         ),
       ).toBeTruthy();
+    });
+
+    /**
+     * **The agent's READ access gets its own clause, and the old absolute
+     * claim's absence is pinned beside it.**
+     *
+     * The strip used to end "and sends that file nowhere" — a claim about the
+     * kubeconfig, which is true, wrapped around an absolute the neighbouring
+     * lede also made. `SourcesRail`'s own section already tells the reader that
+     * every agent CHANGE stops at a confirmation prompt; nothing anywhere told
+     * them the agent can READ freely, which is the half of the MCP story that
+     * makes "nothing leaves this machine" false. So the true, narrow claim
+     * about the file stays ("never copies or uploads that file"), and the read
+     * is said plainly next to it.
+     *
+     * The confirmation half is worded to agree with the rail rather than to
+     * paraphrase it: two panes one click apart must not describe one gate two
+     * ways.
+     */
+    it("tells the desktop reader the agent may read freely and change nothing unasked", async () => {
+      core.isTauri.mockReturnValue(true);
+      const strip = (open(), await screen.findByTestId("connect-footer"));
+      expect(within(strip).queryByText(/sends that file nowhere/)).toBeNull();
+      expect(within(strip).getByText(/never copies or uploads that file/)).toBeTruthy();
+      expect(within(strip).getByText(/read this list, and the clusters on it, without asking first/)).toBeTruthy();
+      expect(within(strip).getByText(/every change it makes stops at a confirmation prompt/)).toBeTruthy();
     });
 
     /**

--- a/packages/ui-next/src/screens/Connect.test.tsx
+++ b/packages/ui-next/src/screens/Connect.test.tsx
@@ -1,0 +1,576 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+/**
+ * **Only the capability wrappers and the platform read are replaced.**
+ *
+ * `describeError`, `plural` and `contextDisplayName` stay real, so the failure
+ * copy and both halves of the count are core's own arithmetic rather than a
+ * copy of it here. `latencyLabel` and `viaOf` stay real for the same reason —
+ * they are what the connections table and this screen have to agree on.
+ */
+const core = vi.hoisted(() => ({
+  listContexts: vi.fn(),
+  connectCluster: vi.fn(),
+  isTauri: vi.fn(),
+  pickKubeconfigFiles: vi.fn(),
+  saveKubeconfigFiles: vi.fn(),
+  savePastedKubeconfig: vi.fn(),
+}));
+vi.mock("@srelens/core", async (orig) => ({
+  ...(await orig<typeof import("@srelens/core")>()),
+  ...core,
+}));
+
+import { describeError, type ClusterContext, type ClusterInfo } from "@srelens/core";
+import { Connect } from "./Connect";
+import { getKubeconfigFiles, resetContexts, setContexts, setKubeconfigFiles } from "../lib/clusters";
+import { getProbe, resetProbes } from "../lib/probe";
+import { defaultState } from "../lib/tabs";
+import * as store from "../lib/tabsStore";
+import { resetView } from "../lib/workspace";
+import { latencyLabel } from "./connections/clusterText";
+
+const ROUTE = "/connect";
+
+/** The kubeconfig two of the three contexts were declared in. */
+const CONFIG = "/home/dana/.kube/config";
+/** A second file, which is what makes the file half of the count a real count. */
+const EDGE_FILE = "/home/dana/work/edge.yaml";
+
+const PROD: ClusterContext = {
+  name: "prod-eu",
+  stableId: "prod-eu",
+  cluster: "prod",
+  server: "https://prod-eu.example:6443",
+  isCurrent: true,
+  namespace: "platform",
+  sourceFile: CONFIG,
+  authKind: "exec plugin · gcloud",
+};
+
+const STAGING: ClusterContext = {
+  name: "staging-eu",
+  stableId: "staging-eu",
+  cluster: "staging",
+  server: "https://staging-eu.example:6443",
+  isCurrent: false,
+  sourceFile: CONFIG,
+  authKind: "token",
+};
+
+const EDGE: ClusterContext = {
+  name: "edge-1",
+  stableId: "edge-1",
+  cluster: "edge",
+  server: "https://edge-1.example:6443",
+  isCurrent: false,
+  sourceFile: EDGE_FILE,
+  authKind: "client certificate",
+};
+
+/**
+ * A local cluster with **no source file at all** — a synthesized kubeconfig
+ * carries `sourceFile: ""`, which core says is the empty string rather than a
+ * path. It is the row that separates "count the rows' files" from "count the
+ * rows": four contexts here still come from two files.
+ */
+const LOCAL: ClusterContext = {
+  name: "kind-lab",
+  stableId: "kind-lab",
+  cluster: "kind-lab",
+  server: "https://127.0.0.1:52001",
+  isCurrent: false,
+  isLocal: true,
+  provider: "kind",
+  sourceFile: "",
+  authKind: "client certificate",
+};
+
+/** The three default contexts: two in one file, one in another. */
+const THREE = [PROD, STAGING, EDGE];
+
+/**
+ * **No stored kubeconfig files by default**, which is web mode's own shape
+ * (`Window.tsx` hands it `[]`) and the shape that separates a count of the
+ * stored list from a count of what the rows say.
+ */
+const FILES: string[] = [];
+
+/** What each cluster answers, and how long it takes about it. */
+const REACHABLE: Record<string, ClusterInfo> = {
+  "prod-eu": { context: "prod-eu", reachable: true, version: "v1.31.2" },
+  "staging-eu": { context: "staging-eu", reachable: true, version: "v1.30.6" },
+  "edge-1": { context: "edge-1", reachable: true, version: "v1.29.4" },
+  "kind-lab": { context: "kind-lab", reachable: true, version: "v1.31.0" },
+};
+const LATENCY: Record<string, number> = {
+  "prod-eu": 41,
+  "staging-eu": 12,
+  "edge-1": 7,
+  "kind-lab": 3,
+};
+
+/**
+ * A listing failure with a machine string in it, classified by `describeError`
+ * (it matches its connect branch) — the only shape that can tell "reported
+ * through `describeError`" apart from "printed the backend's string".
+ */
+const LIST_FAILURE = "ServiceError: connection refused: ECONNREFUSED 10.0.5.2:6443";
+
+/**
+ * A frozen clock, advanced only by the `connectCluster` double: `probeCluster`
+ * times its own round trip off `Date.now`, so this is the only way a latency
+ * assertion can be an exact number rather than whatever the machine took.
+ */
+let clock = 0;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clock = 1_700_000_000_000;
+  vi.spyOn(Date, "now").mockImplementation(() => clock);
+  core.listContexts.mockResolvedValue({ contexts: THREE });
+  core.connectCluster.mockImplementation(async (name: string) => {
+    clock += LATENCY[name] ?? 0;
+    return REACHABLE[name] ?? { context: name, reachable: false, error: "no route to host" };
+  });
+  // Web by default, so a desktop-only control has to be asked for explicitly.
+  core.isTauri.mockReturnValue(false);
+  core.pickKubeconfigFiles.mockResolvedValue([]);
+  resetProbes();
+  resetContexts();
+  setContexts(THREE);
+  setKubeconfigFiles(FILES);
+  store.setState(defaultState(THREE));
+  resetView();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function open() {
+  store.openTab(ROUTE);
+  return render(<Connect route={ROUTE} />);
+}
+
+/** The count as it is drawn, read from its own node rather than from the page. */
+function countText(): string {
+  return screen.getByTestId("connect-count").textContent ?? "";
+}
+
+/** One row's cells, by test id — never a read of the whole row, which would let
+ *  the mark's initials and the badge's word ride along with the name. */
+function row(stableId: string) {
+  return {
+    name: screen.getByTestId(`connect-name-${stableId}`),
+    detail: screen.queryByTestId(`connect-detail-${stableId}`),
+    status: screen.getByTestId(`connect-status-${stableId}`),
+    latency: screen.queryByTestId(`connect-latency-${stableId}`),
+  };
+}
+
+describe("Connect", () => {
+  describe("what §24 puts on the page", () => {
+    it("draws the eyebrow, both headline lines and the lede", async () => {
+      open();
+      await screen.findByText("Contexts found");
+
+      expect(screen.getByText("srelens · local-first")).toBeTruthy();
+      expect(screen.getByText("Pick a cluster.")).toBeTruthy();
+      expect(screen.getByText("The room is already reading it.")).toBeTruthy();
+      expect(
+        screen.getByText(
+          "srelens uses the credentials already in your kubeconfig and talks to the API server directly. Nothing about your clusters leaves this machine.",
+        ),
+      ).toBeTruthy();
+    });
+
+    it("is full-bleed: no screen toolbar over it", async () => {
+      const { container } = open();
+      await screen.findByText("Contexts found");
+      // `Screen` draws a `.toolbar` with the route's title in it. §24 has none —
+      // the headline IS the head of this page. Asserted on the class the kit's
+      // Toolbar actually carries, so wrapping this in a `Screen` fails here.
+      expect(container.querySelector(".toolbar")).toBeNull();
+    });
+
+    it("rises in, centred at 860px", async () => {
+      open();
+      await screen.findByText("Contexts found");
+      const column = screen.getByTestId("connect-column");
+      expect(column.className).toContain("rise");
+      expect(column.className).toContain("max-w-[860px]");
+      expect(column.className).toContain("mx-auto");
+    });
+  });
+
+  describe("the count", () => {
+    it("counts the contexts it lists, and the files they came from", async () => {
+      open();
+      await screen.findByText("Contexts found");
+
+      // Pinned against the rows that are actually on the page, not against the
+      // fixture's own length: a count read from a different array than the rows
+      // is the defect this screen inherits from §24's own mock (`5 in 2 files`
+      // over eight rows).
+      const rows = screen.getAllByTestId("connect-context");
+      expect(rows).toHaveLength(3);
+      expect(countText()).toBe(`${rows.length} in 2 files`);
+    });
+
+    it("counts only the files the rows name, and says `file` for one of them", async () => {
+      setContexts([PROD, STAGING]);
+      open();
+      await screen.findByText("Contexts found");
+
+      const rows = screen.getAllByTestId("connect-context");
+      expect(rows).toHaveLength(2);
+      expect(countText()).toBe(`${rows.length} in 1 file`);
+    });
+
+    it("does not count a file for a cluster that names none", async () => {
+      setContexts([...THREE, LOCAL]);
+      open();
+      await screen.findByText("Contexts found");
+
+      // Four rows, still two files: the local cluster's `sourceFile` is `""`,
+      // and an empty string counted as a source is a file the reader cannot go
+      // and look at.
+      const rows = screen.getAllByTestId("connect-context");
+      expect(rows).toHaveLength(4);
+      expect(countText()).toBe(`${rows.length} in 2 files`);
+    });
+
+    it("counts the rows it has after a listing changes them", async () => {
+      core.isTauri.mockReturnValue(true);
+      core.pickKubeconfigFiles.mockResolvedValue([EDGE_FILE]);
+      // The second listing answers with one more context, from one more file.
+      core.listContexts.mockResolvedValue({ contexts: [...THREE, LOCAL] });
+      setContexts([PROD, STAGING]);
+      open();
+      await screen.findByText("Contexts found");
+      expect(countText()).toBe("2 in 1 file");
+
+      await userEvent.click(screen.getByRole("button", { name: /Add a kubeconfig file/i }));
+
+      await waitFor(() => expect(screen.getAllByTestId("connect-context")).toHaveLength(4));
+      expect(countText()).toBe(`${screen.getAllByTestId("connect-context").length} in 2 files`);
+    });
+
+    it("puts no count over a card with nothing in it", async () => {
+      setContexts([]);
+      open();
+      await screen.findByText("Contexts found");
+      // A count of nothing asserted as a fact is the same fault as a count that
+      // disagrees with its rows.
+      expect(screen.queryByTestId("connect-count")).toBeNull();
+    });
+  });
+
+  describe("the rows", () => {
+    it("names each context and says which file it came from", async () => {
+      open();
+      await screen.findByText("Contexts found");
+
+      expect(row("prod-eu").name.textContent).toBe("prod-eu");
+      expect(row("prod-eu").detail?.textContent).toBe(CONFIG);
+      expect(row("edge-1").detail?.textContent).toBe(EDGE_FILE);
+    });
+
+    it("says how a local cluster is reached, which is not a file", async () => {
+      setContexts([LOCAL]);
+      open();
+      await screen.findByText("Contexts found");
+      // `viaOf`'s answer for a local cluster: the tool that made it and the
+      // endpoint it listens on. The same helper the connections table uses.
+      expect(row("kind-lab").detail?.textContent).toBe("kind · 127.0.0.1:52001");
+    });
+
+    it("badges each row from its own probe, and never calls one healthy", async () => {
+      core.connectCluster.mockImplementation(async (name: string) => {
+        clock += LATENCY[name] ?? 0;
+        if (name === "edge-1") return { context: name, reachable: false, error: "no route to host" };
+        return REACHABLE[name];
+      });
+      open();
+
+      await waitFor(() => expect(row("prod-eu").status.textContent).toBe("reachable"));
+      await waitFor(() => expect(row("edge-1").status.textContent).toBe("unreachable"));
+
+      // Decision 3: the probe reports whether the API server answered, so no
+      // row may claim a health verdict nothing checked.
+      expect(screen.queryByText(/healthy/i)).toBeNull();
+      expect(screen.queryByText(/degraded/i)).toBeNull();
+    });
+
+    it("says `no reading` for a cluster nothing has answered for yet", async () => {
+      /**
+       * A cluster that never answers: its own row says so and no other row
+       * waits.
+       *
+       * **The cluster that hangs is the FIRST one in the list, deliberately.**
+       * It was `edge-1`, which is last in `THREE` — and with it last, a screen
+       * that read the clusters one after another satisfied this test on fixture
+       * order alone. Verified rather than assumed: a serial probe loop passed
+       * all 26 tests. Hanging the first one is what makes "no other row waits"
+       * the thing being proved, and it is the case that matters — a laptop
+       * kubeconfig whose first context is a VPN-only production cluster would
+       * otherwise spend a full timeout before any other row said anything.
+       */
+      core.connectCluster.mockImplementation(async (name: string) => {
+        if (name === "prod-eu") return new Promise<ClusterInfo>(() => {});
+        clock += LATENCY[name] ?? 0;
+        return REACHABLE[name];
+      });
+      open();
+
+      await waitFor(() => expect(row("edge-1").status.textContent).toBe("reachable"));
+      expect(row("prod-eu").status.textContent).toBe("no reading");
+      // And no invented duration for it — decision 4.
+      expect(row("prod-eu").latency).toBeNull();
+    });
+
+    it("draws the round trip through the one formatter", async () => {
+      open();
+      await waitFor(() => expect(row("prod-eu").latency?.textContent).toBeTruthy());
+
+      /**
+       * **Not a hardcoded `41 ms`.** The clock above is one shared counter that
+       * the `connectCluster` double advances the moment it is CALLED, so a
+       * per-cluster figure only comes out if the screen probes the clusters one
+       * at a time — and it deliberately does not (see the test above: a cluster
+       * that never answers must hold up no other row, which on a real
+       * kubeconfig is the difference between one timeout and one per cluster).
+       * Probed at once, `prod-eu`'s reading is 41 + 12 + 7 = 60 ms: an artifact
+       * of the fake clock, not of the screen.
+       *
+       * What the name of this test is actually about survives, and is what is
+       * pinned: every row draws `latencyLabel`'s own answer for its own probe.
+       * A screen printing `${probe.latencyMs}ms`, one drawing another row's
+       * reading, or a second formatter that rounds a sub-millisecond reading to
+       * `0 ms` all fail here.
+       */
+      for (const id of ["prod-eu", "staging-eu", "edge-1"]) {
+        const label = latencyLabel(getProbe(id));
+        expect(label).toMatch(/^\d+ ms$/);
+        expect(row(id).latency?.textContent).toBe(label);
+      }
+      // Each row's own reading, not one number copied down the list.
+      expect(row("prod-eu").latency?.textContent).not.toBe(row("edge-1").latency?.textContent);
+    });
+
+    it("opens the cluster the row stands for", async () => {
+      open();
+      await screen.findByText("Contexts found");
+
+      await userEvent.click(screen.getByRole("button", { name: /Open edge-1/i }));
+
+      expect(store.activeCluster()).toBe("edge-1");
+      /**
+       * The tab and the cluster, as the store actually models them.
+       *
+       * `getState().tabs` was `undefined` — the state is
+       * `{ workspaces, currentId }` and the tabs hang off the current workspace
+       * — so the original assertion threw instead of checking anything. And a
+       * `Tab` carries no `clusterName`: `makeTab` spends the option on the
+       * tab's `sub` and the cluster in focus is the WORKSPACE's, which is why
+       * the membership line below is the load-bearing one — `setActiveCluster`
+       * refuses an id the workspace does not hold, so a row for a context no
+       * workspace has would otherwise do nothing at all, silently.
+       */
+      expect(store.currentWorkspace().tabs.some((t) => t.route === "/overview")).toBe(true);
+      expect(store.currentWorkspace().clusters).toContain("edge-1");
+    });
+
+    it("caps the strings that have no bound, on the row and inside it", async () => {
+      open();
+      await screen.findByText("Contexts found");
+
+      // `min-width: auto` on a flex child refuses to shrink below its content,
+      // so a 70-character kubeconfig path in an 860px card pushes the badge off
+      // the end. Eight defects on this migration, none of them visible in
+      // jsdom — hence these class assertions.
+      const rows = screen.getAllByTestId("connect-context");
+      for (const drawn of rows) expect(drawn.className).toContain("min-w-0");
+
+      const text = screen.getByTestId("connect-text-prod-eu");
+      expect(text.className).toContain("min-w-0");
+
+      // `block` is what makes `truncate`'s overflow apply at all, and the cap is
+      // what stops the intrinsic width being the whole string.
+      for (const cell of [row("prod-eu").name, row("prod-eu").detail]) {
+        expect(cell?.className).toContain("block");
+        expect(cell?.className).toContain("truncate");
+        expect(cell?.className).toContain("max-w-");
+      }
+
+      // The badge and the reading keep their own width whatever the name does.
+      expect(row("prod-eu").status.parentElement?.className).toContain("shrink-0");
+    });
+  });
+
+  describe("the two doors", () => {
+    it("offers neither door to a build with no filesystem", async () => {
+      open();
+      await screen.findByText("Contexts found");
+
+      expect(screen.queryByText(/add a kubeconfig file/i)).toBeNull();
+      expect(screen.queryByText(/paste a context/i)).toBeNull();
+      // Said once, rather than leaving a reader to wonder at an absent control.
+      expect(screen.getByText(/on the desktop/i)).toBeTruthy();
+    });
+
+    it("offers both on the desktop, and says nothing about the desktop there", async () => {
+      core.isTauri.mockReturnValue(true);
+      open();
+      await screen.findByText("Contexts found");
+
+      expect(screen.getByRole("button", { name: /Add a kubeconfig file/i })).toBeTruthy();
+      expect(screen.getByRole("button", { name: /Paste a context/i })).toBeTruthy();
+      expect(screen.queryByText(/on the desktop/i)).toBeNull();
+    });
+
+    it("remembers a picked kubeconfig file, tells the backend, and lists again", async () => {
+      core.isTauri.mockReturnValue(true);
+      core.pickKubeconfigFiles.mockResolvedValue([EDGE_FILE]);
+      core.listContexts.mockResolvedValue({ contexts: THREE });
+      setContexts([PROD, STAGING]);
+      setKubeconfigFiles([CONFIG]);
+      open();
+      await screen.findByText("Contexts found");
+
+      await userEvent.click(screen.getByRole("button", { name: /Add a kubeconfig file/i }));
+
+      // All three writes: the one that survives a restart, the one every core
+      // call in this window reads, and the listing that puts the file's
+      // contexts on the screen.
+      await waitFor(() => expect(core.saveKubeconfigFiles).toHaveBeenCalledWith([CONFIG, EDGE_FILE]));
+      expect(getKubeconfigFiles()).toEqual([CONFIG, EDGE_FILE]);
+      expect(core.listContexts).toHaveBeenCalledWith([CONFIG, EDGE_FILE]);
+      await waitFor(() => expect(screen.getAllByTestId("connect-context")).toHaveLength(3));
+    });
+
+    it("says why a kubeconfig file could not be added", async () => {
+      core.isTauri.mockReturnValue(true);
+      core.pickKubeconfigFiles.mockRejectedValue(new Error("no such file or directory"));
+      open();
+      await screen.findByText("Contexts found");
+
+      await userEvent.click(screen.getByRole("button", { name: /Add a kubeconfig file/i }));
+
+      await screen.findByText("Could not add that kubeconfig file");
+      // Through `describeError`, never the backend's raw string on its own.
+      expect(screen.getByText(describeError("no such file or directory").detail)).toBeTruthy();
+    });
+
+    it("writes a pasted context to a file, and lists again", async () => {
+      core.isTauri.mockReturnValue(true);
+      core.savePastedKubeconfig.mockResolvedValue("/app/kubeconfigs/pasted.yaml");
+      core.listContexts.mockResolvedValue({ contexts: THREE });
+      setContexts([PROD, STAGING]);
+      setKubeconfigFiles([CONFIG]);
+      open();
+      await screen.findByText("Contexts found");
+
+      await userEvent.click(screen.getByRole("button", { name: /Paste a context/i }));
+      const yaml = "apiVersion: v1\nkind: Config\n";
+      await userEvent.type(screen.getByLabelText("Kubeconfig YAML"), yaml);
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+      await waitFor(() => expect(core.savePastedKubeconfig).toHaveBeenCalledWith(yaml, undefined));
+      expect(core.saveKubeconfigFiles).toHaveBeenCalledWith([
+        CONFIG,
+        "/app/kubeconfigs/pasted.yaml",
+      ]);
+      expect(core.listContexts).toHaveBeenCalledWith([CONFIG, "/app/kubeconfigs/pasted.yaml"]);
+      await waitFor(() => expect(screen.getAllByTestId("connect-context")).toHaveLength(3));
+    });
+
+    it("will not save an empty paste", async () => {
+      core.isTauri.mockReturnValue(true);
+      open();
+      await screen.findByText("Contexts found");
+
+      await userEvent.click(screen.getByRole("button", { name: /Paste a context/i }));
+      const save = screen.getByRole("button", { name: "Save" });
+      expect(save.hasAttribute("disabled")).toBe(true);
+
+      await userEvent.click(save);
+      expect(core.savePastedKubeconfig).not.toHaveBeenCalled();
+    });
+
+    it("says why a pasted context could not be saved, and keeps what was typed", async () => {
+      core.isTauri.mockReturnValue(true);
+      core.savePastedKubeconfig.mockRejectedValue(new Error("permission denied"));
+      open();
+      await screen.findByText("Contexts found");
+
+      await userEvent.click(screen.getByRole("button", { name: /Paste a context/i }));
+      await userEvent.type(screen.getByLabelText("Kubeconfig YAML"), "kind: Config");
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+      await screen.findByText("Could not save that context");
+      // The dialog stays open with the paste still in it: a reader who lost a
+      // pasted kubeconfig to a failed write has to go and find it again.
+      expect((screen.getByLabelText("Kubeconfig YAML") as HTMLTextAreaElement).value).toBe(
+        "kind: Config",
+      );
+    });
+  });
+
+  describe("the states before the rows", () => {
+    it("says what to do when the kubeconfig has nothing in it", async () => {
+      setContexts([]);
+      open();
+      expect(await screen.findByText(/no contexts/i)).toBeTruthy();
+    });
+
+    it("waits rather than claiming the kubeconfig is empty", async () => {
+      // The store's boot state: nothing listed, and no listing finished yet.
+      resetContexts();
+      open();
+      await screen.findByText("Contexts found");
+      expect(screen.queryByText(/no contexts/i)).toBeNull();
+      expect(screen.getByLabelText("Listing your contexts")).toBeTruthy();
+    });
+
+    it("says why the listing refused, and lists again on request", async () => {
+      setContexts([], LIST_FAILURE);
+      core.listContexts.mockResolvedValue({ contexts: THREE });
+      open();
+
+      await screen.findByText("Could not read your kubeconfig");
+      expect(screen.getByText(describeError(LIST_FAILURE).detail)).toBeTruthy();
+      /**
+       * The machine string is folded away, not printed as the sentence.
+       *
+       * Asserted on the two slots rather than with `queryByText(LIST_FAILURE)`:
+       * `RawError` keeps the original in a CLOSED `<details>`, which is exactly
+       * where it belongs, and `queryByText` cannot tell that from a paragraph —
+       * so the original assertion demanded the string be thrown away. (Task 7
+       * settled the same point.) What matters is which slot it is in.
+       */
+      const card = screen.getByRole("alert");
+      expect(card.querySelector('[data-slot="detail"]')?.textContent).not.toContain(LIST_FAILURE);
+      expect(card.querySelector('[data-slot="raw"] pre')?.textContent).toBe(LIST_FAILURE);
+
+      await userEvent.click(screen.getByRole("button", { name: /Try again/i }));
+      await waitFor(() => expect(screen.getAllByTestId("connect-context")).toHaveLength(3));
+    });
+  });
+
+  describe("the footer strip", () => {
+    it("carries the sparkle and its copy", async () => {
+      open();
+      const strip = await screen.findByTestId("connect-footer");
+      expect(strip.querySelector("svg")).toBeTruthy();
+      expect(
+        within(strip).getByText(
+          "Once a cluster is connected, ask the console about it in plain language. srelens reads the cluster to answer and sends your kubeconfig nowhere.",
+        ),
+      ).toBeTruthy();
+    });
+  });
+});

--- a/packages/ui-next/src/screens/Connect.test.tsx
+++ b/packages/ui-next/src/screens/Connect.test.tsx
@@ -175,6 +175,7 @@ function row(stableId: string) {
 describe("Connect", () => {
   describe("what §24 puts on the page", () => {
     it("draws the eyebrow, both headline lines and the lede", async () => {
+      core.isTauri.mockReturnValue(true);
       open();
       await screen.findByText("Contexts found");
 
@@ -186,6 +187,43 @@ describe("Connect", () => {
           "srelens uses the credentials already in your kubeconfig and talks to the API server directly. Nothing about your clusters leaves this machine.",
         ),
       ).toBeTruthy();
+    });
+
+    /**
+     * **The lede is a claim about where the kubeconfig is, so it cannot be one
+     * string.**
+     *
+     * §24's own words are true of the desktop and false of the web build, on
+     * the same page as {@link WEB_ONLY}'s "This build talks to a shared
+     * server": in web mode the kubeconfig is the SERVER's, the clusters are
+     * read on the server's host, and web mode over-listing the server's
+     * contexts is a filed bug (#347). The screen already branched its
+     * empty-state hint for exactly this; the lede did not.
+     *
+     * Asserted as the absence of the specific false sentence rather than as
+     * the presence of the true one alone: a branch that added the web copy and
+     * left the local-first claim standing beside it would satisfy a
+     * presence-only test.
+     */
+    it("does not tell a web reader their clusters never leave this machine", async () => {
+      open();
+      await screen.findByText("Contexts found");
+
+      expect(screen.queryByText(/Nothing about your clusters leaves this machine/)).toBeNull();
+      expect(screen.queryByText(/already in your kubeconfig/)).toBeNull();
+      expect(
+        screen.getByText(
+          "srelens uses the credentials in the kubeconfig this server was started with, and talks to the API server directly from the server's host. The clusters listed below are the ones that server can see, not the ones on the machine you are reading this on.",
+        ),
+      ).toBeTruthy();
+    });
+
+    it("does not call a shared-server build local-first", async () => {
+      open();
+      await screen.findByText("Contexts found");
+
+      expect(screen.queryByText("srelens · local-first")).toBeNull();
+      expect(screen.getByText("srelens · shared server")).toBeTruthy();
     });
 
     it("is full-bleed: no screen toolbar over it", async () => {
@@ -545,6 +583,32 @@ describe("Connect", () => {
       await waitFor(() => expect(screen.getAllByTestId("connect-context")).toHaveLength(3));
     });
 
+    /**
+     * **Where the file actually goes.**
+     *
+     * The hint said "beside your other kubeconfigs". `savePastedKubeconfig`
+     * writes to `app_config_dir()/kubeconfigs/<stem>-<ts>.yaml` — srelens's
+     * own folder — while the reader's kubeconfig is `~/.kube/config`. A reader
+     * who wanted to find, edit or delete that context went to `~/.kube` and
+     * found nothing. The frozen classic app words the same operation
+     * correctly (`SettingsView.tsx`: "Saved securely in the srelens app
+     * configuration directory"); the migration turned a true sentence into a
+     * false one.
+     */
+    it("says where a pasted context is written, which is not beside the reader's kubeconfig", async () => {
+      core.isTauri.mockReturnValue(true);
+      open();
+      await screen.findByText("Contexts found");
+
+      await userEvent.click(screen.getByRole("button", { name: /Paste a context/i }));
+      expect(screen.queryByText(/beside your other kubeconfigs/i)).toBeNull();
+      expect(
+        screen.getByText(
+          "Written to a file of its own in the srelens app configuration folder, not into your own kubeconfig. srelens reads it in place from then on.",
+        ),
+      ).toBeTruthy();
+    });
+
     it("will not save an empty paste", async () => {
       core.isTauri.mockReturnValue(true);
       open();
@@ -620,12 +684,37 @@ describe("Connect", () => {
 
   describe("the footer strip", () => {
     it("carries the sparkle and its copy", async () => {
-      open();
-      const strip = await screen.findByTestId("connect-footer");
+      core.isTauri.mockReturnValue(true);
+      const strip = (open(), await screen.findByTestId("connect-footer"));
       expect(strip.querySelector("svg")).toBeTruthy();
       expect(
         within(strip).getByText(
-          "Once a cluster is connected, ask the console about it in plain language. srelens reads the cluster to answer and sends your kubeconfig nowhere.",
+          "srelens reads each cluster directly, with the credentials already in your kubeconfig, and sends that file nowhere. Asking the console about a cluster in plain language is not in this design yet.",
+        ),
+      ).toBeTruthy();
+    });
+
+    /**
+     * The strip used to promise "ask the console about it in plain language.
+     * srelens reads the cluster to answer" — and the console answers nothing
+     * in this design: `shell/Console.tsx` renders "The agent is not in the new
+     * design yet". Pinned as the absence of the promise, because the honest
+     * replacement is a sentence a future edit could drop while re-adding the
+     * old one.
+     */
+    it("does not promise a console that answers", async () => {
+      core.isTauri.mockReturnValue(true);
+      const strip = (open(), await screen.findByTestId("connect-footer"));
+      expect(within(strip).queryByText(/reads the cluster to answer/)).toBeNull();
+      expect(within(strip).getByText(/not in this design yet/)).toBeTruthy();
+    });
+
+    it("does not call the server's kubeconfig the reader's", async () => {
+      const strip = (open(), await screen.findByTestId("connect-footer"));
+      expect(within(strip).queryByText(/your kubeconfig/)).toBeNull();
+      expect(
+        within(strip).getByText(
+          "srelens reads each cluster directly from this server, with the credentials in the kubeconfig it was started with. Asking the console about a cluster in plain language is not in this design yet.",
         ),
       ).toBeTruthy();
     });

--- a/packages/ui-next/src/screens/Connect.tsx
+++ b/packages/ui-next/src/screens/Connect.tsx
@@ -1,0 +1,654 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  contextDisplayName,
+  isTauri,
+  listContexts,
+  pickKubeconfigFiles,
+  plural,
+  saveKubeconfigFiles,
+  savePastedKubeconfig,
+  type ClusterContext,
+} from "@srelens/core";
+import {
+  Badge,
+  Button,
+  Dialog,
+  EmptyState,
+  Eyebrow,
+  Field,
+  LoadingState,
+  Mark,
+  type BadgeTone,
+  type IconComponent,
+} from "@srelens/ui-kit";
+import {
+  getContexts,
+  getKubeconfigFiles,
+  setContexts,
+  setKubeconfigFiles,
+  useContexts,
+  useContextsError,
+  useContextsStatus,
+} from "../lib/clusters";
+import { FailureAlert, FailureState } from "../lib/errorCopy";
+import { Icons } from "../lib/icons";
+import { useMark } from "../lib/marks";
+import { getProbe, probeCluster, useProbes, type Probe, type ProbeState } from "../lib/probe";
+import { describe } from "../lib/routes";
+import { openTab, setActiveCluster, setWorkspaceClusters, useTabs } from "../lib/tabsStore";
+import { glyph } from "../lib/tree";
+import { latencyLabel, viaOf } from "./connections/clusterText";
+
+/** §24's copy, verbatim, and in one place so the page and the suite quote one string. */
+const HEADLINE_ONE = "Pick a cluster.";
+const HEADLINE_TWO = "The room is already reading it.";
+const LEDE =
+  "srelens uses the credentials already in your kubeconfig and talks to the API server directly. Nothing about your clusters leaves this machine.";
+const FOOTER =
+  "Once a cluster is connected, ask the console about it in plain language. srelens reads the cluster to answer and sends your kubeconfig nowhere.";
+
+/**
+ * Why neither door is drawn in the browser, said once — decision 2.
+ *
+ * A control that is simply absent teaches a reader nothing; this says what is
+ * missing, where it exists, and the reason it cannot exist here. The reason is
+ * not squeamishness: `savePastedKubeconfig` and the file picker both write to
+ * the machine the backend runs on, which in web mode is a shared host, under
+ * the server's own uid rather than the reader's.
+ *
+ * Deliberately worded around the two control labels: the suite proves the
+ * doors are absent by looking for their words, and a sentence that quoted them
+ * would make that proof unable to tell an explanation from a button.
+ */
+const WEB_ONLY =
+  "Adding and pasting kubeconfigs happens on the desktop app. This build talks to a shared server, so a file written from here would land in that server's home directory as its own user rather than yours — it reads the kubeconfigs it was started with instead.";
+
+/**
+ * A cluster nothing has read yet.
+ *
+ * Module-level so the identity is stable: it stands in for every row whose
+ * probe the store has no entry for, and a fresh object per render would make
+ * each of those rows re-render on every notification about any other one.
+ */
+const UNREAD: Probe = { state: "unread" };
+
+/**
+ * The three words a probe can put on a row, and the tone each is worth.
+ *
+ * **No cluster is ever `healthy` or `degraded`** (decision 3). `connectCluster`
+ * reports whether the API server answered; calling that a health verdict claims
+ * a check nothing ran. `unread` is the absence, named as an absence — not
+ * "pending" or "idle", which read as things the cluster is.
+ *
+ * This table is the same three pairs as `ClusterTable`'s own `STATUS`, which is
+ * private to that file. It is duplicated rather than shared because promoting
+ * it means editing a file under review in a parallel task; **it belongs beside
+ * `latencyLabel` in `connections/clusterText.ts`** and should move there the
+ * next time that file is opened. The latency formatter is imported for exactly
+ * this reason — two formatters for one reading is how two surfaces start
+ * disagreeing about the same number.
+ */
+const STATUS: Record<ProbeState, { word: string; tone: BadgeTone }> = {
+  reachable: { word: "reachable", tone: "ok" },
+  unreachable: { word: "unreachable", tone: "sev" },
+  unread: { word: "no reading", tone: "muted" },
+};
+
+/**
+ * How many files the rows came out of.
+ *
+ * **Counted from the rows, never from the stored file list** — §24's own mock
+ * says `5 in 2 files` over eight rows, and the spec resolves that ambiguity in
+ * favour of what is on the page. The stored list is the other candidate and it
+ * is wrong twice over: web mode stores none at all (`Window.tsx` hands it
+ * `[]`), and a stored path that yielded no context is not a file any row came
+ * from.
+ *
+ * The empty string is not a file. A synthesized kubeconfig carries
+ * `sourceFile: ""`, and counting that would offer the reader a file they cannot
+ * go and look at.
+ */
+function fileCount(contexts: readonly ClusterContext[]): number {
+  const paths = new Set<string>();
+  for (const context of contexts) {
+    if (context.sourceFile.trim() !== "") paths.add(context.sourceFile);
+  }
+  return paths.size;
+}
+
+/**
+ * One context, as §24 draws it: the mark, the name, where it is reached
+ * through, its reading and a way in.
+ *
+ * A component per row rather than inline JSX because it reads the cluster's
+ * mark from the marks store and subscribes to it — `ClusterTable`'s
+ * `ClusterCell` makes the same split for the same reason.
+ */
+function ContextRow({
+  context,
+  probe,
+  onOpen,
+}: {
+  context: ClusterContext;
+  probe: Probe;
+  onOpen: (context: ClusterContext) => void;
+}) {
+  const id = context.stableId;
+  const mark = useMark(id, context.name);
+  /**
+   * The name the reader gave this context, or the context's own.
+   *
+   * `contextDisplayName` takes a profile and ui-next has no profiles store yet,
+   * so this resolves to the context name today. It is called anyway: it is the
+   * one place a profile has to be handed over when that store arrives, and
+   * `context.name` inlined here would hide it.
+   */
+  const name = contextDisplayName(context.name);
+  /**
+   * What the cluster is reached THROUGH: the kubeconfig it was declared in, or
+   * — for a local cluster, where the file is beside the point — the tool that
+   * made it and the endpoint it listens on. `viaOf` is the connections table's
+   * own answer to that question, imported rather than restated.
+   */
+  const via = viaOf(context);
+  const status = STATUS[probe.state];
+  const latency = latencyLabel(probe);
+
+  return (
+    // `min-w-0` on the row itself, not only inside it. A flex item's implicit
+    // `min-width: auto` refuses to shrink below its content, so without this
+    // the caps below never engage: a 70-character kubeconfig path inside an
+    // 860px card pushes the badge and the control off the end of the card.
+    // Eight defects on this migration, and jsdom sees none of them — hence the
+    // class assertions in the suite.
+    <div
+      data-testid="connect-context"
+      className="flex min-w-0 items-center gap-3 rounded-tile border border-rule bg-sunk px-3 py-2.5"
+    >
+      <Mark
+        name={mark.name}
+        short={mark.short}
+        color={mark.color}
+        size="lg"
+        // The row names the cluster twice already — the line beside the mark
+        // and the control at the end of the row.
+        decorative
+        withBadge={mark.withText}
+        icon={mark.mark === "icon" && mark.icon ? glyph(mark.icon) : undefined}
+        imageSrc={mark.mark === "image" ? mark.imageSrc : undefined}
+      />
+      <div data-testid={`connect-text-${id}`} className="flex min-w-0 flex-1 flex-col">
+        {/* `block` is what makes `truncate`'s `overflow: hidden` apply at all —
+            it does nothing to an inline box — and `max-w-` is what caps the
+            intrinsic contribution that `white-space: nowrap` would otherwise
+            set to the whole string. */}
+        <span
+          data-testid={`connect-name-${id}`}
+          className="block max-w-[420px] truncate text-[0.9375rem] font-medium"
+        >
+          {name}
+        </span>
+        {via !== "" && (
+          <span
+            data-testid={`connect-detail-${id}`}
+            className="path block max-w-[420px] truncate"
+            // The whole string for the row whose line is clipped. The same
+            // string that is on screen, so the hover hides nothing.
+            title={via}
+          >
+            {via}
+          </span>
+        )}
+      </div>
+      {/* The reading and the control keep their own width whatever the name
+          does: a clipped path is recoverable by widening the window, a clipped
+          badge or a clipped button is not. */}
+      <div className="flex shrink-0 items-center gap-2.5">
+        {latency !== null && (
+          <span data-testid={`connect-latency-${id}`} className="path num">
+            {latency}
+          </span>
+        )}
+        <span data-testid={`connect-status-${id}`}>
+          <Badge tone={status.tone}>{status.word}</Badge>
+        </span>
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          // Named for the cluster, unlike the connections table's `Open` — that
+          // control sits in a row whose first cell a screen reader announces
+          // around it, and this one stands at the end of a card row with three
+          // neighbours that say the same word.
+          aria-label={`Open ${name}`}
+          onClick={() => onOpen(context)}
+        >
+          Open
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/** One of §24's two doors: a full-width tile with a glyph, a label and an arrow. */
+function GhostRow({
+  label,
+  icon: Glyph,
+  busy,
+  onClick,
+}: {
+  label: string;
+  icon: IconComponent;
+  busy?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button type="button" className="ghost" aria-busy={busy || undefined} onClick={onClick}>
+      <span className="flex min-w-0 items-center gap-2">
+        <Glyph size={14} aria-hidden="true" />
+        {label}
+      </span>
+      {/* Decorative: the label already says where the row goes, and the kit's
+          own `.ghost .arrow` rule is what animates it. */}
+      <span className="arrow" aria-hidden="true">
+        →
+      </span>
+    </button>
+  );
+}
+
+/**
+ * §24's second door: a kubeconfig pasted rather than browsed for.
+ *
+ * Its own component so the paste, the write in flight and the reason a write
+ * refused live and die with the dialog rather than lingering in the screen's
+ * state after it closes.
+ */
+function PasteDialog({
+  onClose,
+  onSaved,
+}: {
+  onClose: () => void;
+  onSaved: (path: string) => Promise<void>;
+}) {
+  const [yaml, setYaml] = useState("");
+  const [busy, setBusy] = useState(false);
+  /** Why the paste could not be written, when it could not. */
+  const [failure, setFailure] = useState<unknown>(null);
+
+  const ready = yaml.trim() !== "";
+
+  async function save() {
+    // Guarded here as well as on the control: a disabled button is not a
+    // contract, and an empty file written into the kubeconfig list is a path
+    // every later `listContexts` carries around for nothing.
+    if (!ready || busy) return;
+    setBusy(true);
+    setFailure(null);
+    let path: string;
+    try {
+      // The text exactly as it was pasted — not trimmed. Trailing whitespace is
+      // the pasting reader's business and YAML's, not this dialog's.
+      //
+      // `undefined` for the name, explicitly: core names the file itself, and
+      // §24's door asks for no name. Passing the argument keeps the seam
+      // visible for the day the design wants one.
+      path = await savePastedKubeconfig(yaml, undefined);
+    } catch (error) {
+      // The dialog stays open with the paste still in it. A reader who lost a
+      // pasted kubeconfig to a failed write has to go and find it again.
+      setFailure(error);
+      setBusy(false);
+      return;
+    }
+    await onSaved(path);
+  }
+
+  return (
+    <Dialog
+      title="Paste a context"
+      maxWidth={560}
+      onClose={onClose}
+      footer={
+        <>
+          <Button type="button" variant="secondary" size="sm" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="primary"
+            size="sm"
+            disabled={!ready || busy}
+            onClick={() => void save()}
+          >
+            Save
+          </Button>
+        </>
+      }
+    >
+      <div className="flex flex-col gap-3 p-3">
+        {failure !== null && (
+          <FailureAlert tone="sev" title="Could not save that context" error={failure} />
+        )}
+        {/* The hint is a sibling of the field rather than its `hint` prop.
+            `Field` renders that prop INSIDE the `<label>` it wraps the control
+            in, so a hint there joins the control's accessible name: the
+            textarea would announce as "Kubeconfig YAML Written to a file of its
+            own beside…" — the label plus a paragraph. The label is the name;
+            this is a remark beside it. */}
+        <Field label="Kubeconfig YAML">
+          <textarea
+            value={yaml}
+            onChange={(e) => setYaml(e.target.value)}
+            rows={12}
+            spellCheck={false}
+            className="w-full rounded-md border px-2 py-1 font-mono text-[0.75rem] leading-relaxed outline-none"
+            style={{ background: "var(--surface-sunk)", borderColor: "var(--rule)" }}
+          />
+        </Field>
+        <p className="text-[0.75rem] leading-relaxed text-muted">
+          Written to a file of its own beside your other kubeconfigs. srelens reads it in place from
+          then on.
+        </p>
+      </div>
+    </Dialog>
+  );
+}
+
+/**
+ * `/connect` — §24's screen: the door a reader with no clusters lands on, and
+ * what `Add connection` opens.
+ *
+ * **Full-bleed, with no `Screen` around it.** Every other screen in this
+ * package opens with the kit's toolbar; this one's headline IS its head, and a
+ * 44px "Pick a cluster." under a 32px strip repeating the route's title would
+ * be the page introducing itself twice. The route's title is still what names
+ * the region, so the tab strip and the landmark cannot drift.
+ *
+ * **Nothing is listed on arrival.** `Window` lists the contexts at boot and
+ * every screen reads that one answer, so this draws immediately rather than
+ * re-asking for a list the window already has — and, more to the point, a
+ * listing of its own would paint over the reader's own picked file a moment
+ * after they picked it. The two doors and `Try again` are the only things that
+ * list, and each writes its answer back through `setContexts` so the rail, the
+ * status bar and every other screen see the list this one is drawing.
+ *
+ * **Three properties this screen is careful about**, each of which has shipped
+ * as a defect on some screen in this migration:
+ *
+ * 1. The count is of what is listed — see {@link fileCount}. `5 in 2 files`
+ *    over eight rows is §24's own mock, and both halves here come out of the
+ *    same array the rows do. It is absent whenever there are no rows: a count
+ *    of nothing asserted as a fact is the same fault as a count that disagrees
+ *    with its rows.
+ * 2. A probe never blocks a row. Every cluster is drawn `no reading` on the
+ *    first paint and each reading arrives on its own, so twenty clusters do not
+ *    queue and one that never answers holds up none of the others.
+ * 3. Neither door is drawn where it cannot work, and the reason is said once —
+ *    see {@link WEB_ONLY}. `Toolbox.tsx:188` asks the same platform question
+ *    the same way.
+ */
+export function Connect({ route }: { route: string }) {
+  /** The routes table's own title, so the landmark and the tab strip agree. */
+  const title = describe(route).title;
+
+  const contexts = useContexts();
+  const status = useContextsStatus();
+  const listError = useContextsError();
+  const probes = useProbes();
+  const { workspace } = useTabs();
+
+  /** A listing asked for by the reader, still out. */
+  const [busy, setBusy] = useState(false);
+  /** Why a kubeconfig file could not be added, when one could not. */
+  const [addError, setAddError] = useState<unknown>(null);
+  const [pasteOpen, setPasteOpen] = useState(false);
+
+  /**
+   * Which listing is the current one — `Helm`'s and `Connections`' `listSeq`,
+   * for the same reason. A reader who picks a file and then pastes a context
+   * must be left looking at the second answer whatever order the two come back
+   * in; without this the first listing's late answer paints over the second's.
+   */
+  const listSeq = useRef(0);
+
+  /**
+   * Read every cluster on the list, each on its own.
+   *
+   * **Nothing is awaited in series and nothing gates the render.** The rows are
+   * drawn the moment the contexts exist, every one of them `no reading`, and
+   * each reading arrives as its own store notification. A cluster that never
+   * answers leaves its own row saying so and delays no other row — which is
+   * also why the probes are not started one after another: on a laptop
+   * kubeconfig holding an old kind cluster and a VPN-only production one, a
+   * serial read would spend a timeout per unreachable cluster before the
+   * reachable ones said anything at all.
+   *
+   * Only the unread ones. Arriving here respects what the store already knows —
+   * `Window` probes the workspace's clusters at launch, and re-reading a
+   * cluster whose answer is already in hand is a round trip for nothing.
+   *
+   * **No in-flight guard of this screen's own.** `probeCluster` holds one, and
+   * it has to be the one that does: `Window` probes the same clusters and
+   * cannot see a ref of ours, so a second read started while the first is still
+   * out is two unordered writes to a module store neither caller can un-write.
+   * A second call for a cluster already being read joins that read.
+   */
+  useEffect(() => {
+    for (const context of contexts) {
+      if (getProbe(context.stableId).state !== "unread") continue;
+      // `probeCluster` never rejects — it folds a transport failure into an
+      // unreachable reading — so there is nothing here to catch.
+      void probeCluster(context);
+    }
+  }, [contexts]);
+
+  /**
+   * List the contexts again, and write the answer back to the store.
+   *
+   * A fresh array deliberately, so the effect above re-runs even when the
+   * listing came back with the same contexts. A listing that FAILED keeps the
+   * rows already on screen: a refresh that could not be made took nothing away
+   * from the reader, and the store installs the list and the reason in one
+   * write so no render catches one without the other.
+   */
+  async function reload() {
+    const seq = ++listSeq.current;
+    setBusy(true);
+    const outcome = await listContexts(getKubeconfigFiles());
+    // Superseded. Dropped whole — the list and the reason it is short are one
+    // fact, and installing half of a stale answer is worse than none of it.
+    if (seq !== listSeq.current) return;
+    setBusy(false);
+    setContexts([...(outcome.contexts ?? getContexts())], outcome.error ?? "");
+  }
+
+  /**
+   * Remember a file the backend must know about, and list again.
+   *
+   * Three writes, and all three are needed: `saveKubeconfigFiles` is what makes
+   * the file survive a restart, `setKubeconfigFiles` is what every core call in
+   * this window reads (the backend cannot build a client for a context from a
+   * file it has not been told about), and the listing is what puts that file's
+   * contexts on the screen.
+   */
+  async function remember(paths: readonly string[]) {
+    const next = [...new Set([...getKubeconfigFiles(), ...paths])];
+    saveKubeconfigFiles(next);
+    setKubeconfigFiles(next);
+    await reload();
+  }
+
+  async function addFile() {
+    setAddError(null);
+    let picked: string[];
+    try {
+      picked = await pickKubeconfigFiles();
+    } catch (error) {
+      // Through `describeError` where it is shown, like every other failure
+      // here. Nothing is written when the picker itself refused.
+      setAddError(error);
+      return;
+    }
+    // A cancelled picker is not a failure and has nothing to say.
+    if (picked.length === 0) return;
+    await remember(picked);
+  }
+
+  async function savedPaste(path: string) {
+    // Closed before the listing rather than after it: the dialog has done its
+    // work, and leaving it over the card until a slow listing returns hides the
+    // rows the reader pasted the context to see.
+    setPasteOpen(false);
+    await remember([path]);
+  }
+
+  /**
+   * Open a cluster: put it in this workspace, focus it, and open its overview.
+   *
+   * The workspace step is not a flourish. This screen lists every context on
+   * the machine, including ones no workspace holds, and `setActiveCluster`
+   * refuses an id the workspace does not have — so without it `Open` on exactly
+   * those rows would do nothing at all, silently.
+   */
+  function open(context: ClusterContext) {
+    const id = context.stableId;
+    if (!workspace.clusters.includes(id)) {
+      setWorkspaceClusters(workspace.id, [...workspace.clusters, id]);
+    }
+    setActiveCluster(id);
+    openTab("/overview", { clusterName: context.name });
+  }
+
+  const desktop = isTauri();
+  const count =
+    contexts.length > 0
+      ? `${contexts.length} in ${plural(fileCount(contexts), "file")}`
+      : undefined;
+
+  const Sparkle = Icons.ask;
+
+  return (
+    // A landmark with the route's own name on it: this screen draws no `h1` in
+    // a toolbar, so the region is what a screen reader has to navigate by.
+    <section
+      aria-label={title}
+      className="scroll h-full min-h-0"
+      // §24's decorative background, which is the treatment the classic connect
+      // surface already wears (`styles.css`'s `.fl-landing`): one accent bloom
+      // off the top-left corner over the canvas, in the new design's tokens.
+      style={{
+        background:
+          "radial-gradient(circle at 15% 8%, color-mix(in srgb, var(--accent) 7%, transparent), transparent 30%), var(--canvas)",
+      }}
+    >
+      <div
+        data-testid="connect-column"
+        className="rise mx-auto flex min-w-0 max-w-[860px] flex-col gap-6 px-6 py-12"
+      >
+        <header className="min-w-0">
+          {/* `normal-case`: the label voice is uppercase, and the brand is
+              lowercase everywhere — "SRELENS" is a spelling srelens does not
+              have. The tracking and the mono face are the design's; only the
+              transform gives way. */}
+          <Eyebrow className="normal-case">srelens · local-first</Eyebrow>
+          <h1 className="mt-2.5 flex flex-col text-[2.75rem] font-semibold leading-[1.06] tracking-[-0.02em]">
+            <span>{HEADLINE_ONE}</span>
+            <span className="text-muted">{HEADLINE_TWO}</span>
+          </h1>
+          <p className="mt-4 max-w-[62ch] text-[0.9375rem] leading-relaxed text-muted">{LEDE}</p>
+        </header>
+
+        <div className="card min-w-0">
+          <div className="card-head">
+            <span className="card-title">Contexts found</span>
+            {count !== undefined && (
+              <span data-testid="connect-count" className="eyebrow shrink-0">
+                {count}
+              </span>
+            )}
+          </div>
+
+          <div className="flex min-w-0 flex-col gap-2 p-2.5">
+            {addError !== null && (
+              // `sev`: the reader asked for a file to be added and it was not.
+              // This is not a remark about the rows under it.
+              <FailureAlert
+                tone="sev"
+                title="Could not add that kubeconfig file"
+                error={addError}
+              />
+            )}
+
+            {contexts.length === 0 && status === "loading" && (
+              <LoadingState label="Listing your contexts" />
+            )}
+
+            {contexts.length === 0 && status === "failed" && (
+              <FailureState
+                title="Could not read your kubeconfig"
+                error={listError}
+                retryLabel="Try again"
+                onRetry={() => void reload()}
+              />
+            )}
+
+            {contexts.length === 0 && status === "loaded" && (
+              <EmptyState
+                title="No contexts in your kubeconfig"
+                hint={
+                  desktop
+                    ? "srelens read your kubeconfig and found nothing to connect to. Point it at another file, or paste one below."
+                    : "srelens read the kubeconfig this server was started with and found nothing to connect to."
+                }
+              />
+            )}
+
+            {contexts.map((context) => (
+              <ContextRow
+                key={context.stableId}
+                context={context}
+                // `no reading` until the store has an answer for this cluster,
+                // which is what lets every row paint before any probe lands.
+                probe={probes[context.stableId] ?? UNREAD}
+                onOpen={open}
+              />
+            ))}
+
+            {desktop ? (
+              <>
+                <GhostRow
+                  label="Add a kubeconfig file"
+                  icon={Icons.add}
+                  busy={busy}
+                  onClick={() => void addFile()}
+                />
+                <GhostRow
+                  label="Paste a context"
+                  icon={Icons.copy}
+                  onClick={() => setPasteOpen(true)}
+                />
+              </>
+            ) : (
+              <p className="px-1 py-1 text-[0.8125rem] leading-relaxed text-muted">{WEB_ONLY}</p>
+            )}
+          </div>
+        </div>
+
+        <div
+          data-testid="connect-footer"
+          className="flex min-w-0 items-start gap-2.5 rounded-card border border-accent-line bg-accent-wash px-3.5 py-3"
+        >
+          <span className="mt-px shrink-0 text-accent">
+            <Sparkle size={14} aria-hidden="true" />
+          </span>
+          <p className="text-[0.8125rem] leading-relaxed text-muted">{FOOTER}</p>
+        </div>
+      </div>
+
+      {pasteOpen && (
+        <PasteDialog onClose={() => setPasteOpen(false)} onSaved={savedPaste} />
+      )}
+    </section>
+  );
+}

--- a/packages/ui-next/src/screens/Connect.tsx
+++ b/packages/ui-next/src/screens/Connect.tsx
@@ -18,7 +18,6 @@ import {
   Field,
   LoadingState,
   Mark,
-  type BadgeTone,
   type IconComponent,
 } from "@srelens/ui-kit";
 import {
@@ -33,11 +32,11 @@ import {
 import { FailureAlert, FailureState } from "../lib/errorCopy";
 import { Icons } from "../lib/icons";
 import { useMark } from "../lib/marks";
-import { getProbe, probeCluster, useProbes, type Probe, type ProbeState } from "../lib/probe";
+import { getProbe, probeCluster, useProbes, type Probe } from "../lib/probe";
 import { describe } from "../lib/routes";
 import { openTab, setActiveCluster, setWorkspaceClusters, useTabs } from "../lib/tabsStore";
 import { glyph } from "../lib/tree";
-import { latencyLabel, viaOf } from "./connections/clusterText";
+import { STATUS, latencyLabel, viaOf } from "./connections/clusterText";
 
 /** §24's copy, verbatim, and in one place so the page and the suite quote one string. */
 const HEADLINE_ONE = "Pick a cluster.";
@@ -71,28 +70,6 @@ const WEB_ONLY =
  * each of those rows re-render on every notification about any other one.
  */
 const UNREAD: Probe = { state: "unread" };
-
-/**
- * The three words a probe can put on a row, and the tone each is worth.
- *
- * **No cluster is ever `healthy` or `degraded`** (decision 3). `connectCluster`
- * reports whether the API server answered; calling that a health verdict claims
- * a check nothing ran. `unread` is the absence, named as an absence — not
- * "pending" or "idle", which read as things the cluster is.
- *
- * This table is the same three pairs as `ClusterTable`'s own `STATUS`, which is
- * private to that file. It is duplicated rather than shared because promoting
- * it means editing a file under review in a parallel task; **it belongs beside
- * `latencyLabel` in `connections/clusterText.ts`** and should move there the
- * next time that file is opened. The latency formatter is imported for exactly
- * this reason — two formatters for one reading is how two surfaces start
- * disagreeing about the same number.
- */
-const STATUS: Record<ProbeState, { word: string; tone: BadgeTone }> = {
-  reachable: { word: "reachable", tone: "ok" },
-  unreachable: { word: "unreachable", tone: "sev" },
-  unread: { word: "no reading", tone: "muted" },
-};
 
 /**
  * How many files the rows came out of.

--- a/packages/ui-next/src/screens/Connect.tsx
+++ b/packages/ui-next/src/screens/Connect.tsx
@@ -67,8 +67,30 @@ import { STATUS, bySource, latencyLabel, viaOf } from "./connections/clusterText
  */
 const HEADLINE_ONE = "Pick a cluster.";
 const HEADLINE_TWO = "The room is already reading it.";
+/**
+ * **The desktop lede claims only what holds unconditionally, and that is a
+ * deliberate narrowing of §24 rather than an omission to restore.**
+ *
+ * It used to end "Nothing about your clusters leaves this machine". srelens
+ * cannot keep that promise, and the reader is the one who breaks it: srelens
+ * ships an MCP server (`srelens --mcp-stdio`), `k8s.listContexts` is one of its
+ * READ-ONLY capabilities, and only a MUTATING capability is confirm-gated —
+ * `assert_mutating_capabilities_are_gated`
+ * (`crates/mcp/src/completeness.rs:36-45`) fails the build for a mutating
+ * capability that carries no `requires_confirm` and says nothing about a read.
+ * So once a client is connected, every cluster name, server, source file and
+ * credential kind on this page can be read by it with no prompt, and that
+ * client is usually a remote model.
+ *
+ * The two surrounding facts are true unconditionally and are kept, because a
+ * privacy claim that is specific and true is worth more than none — and the
+ * desktop build really does do something better than a hosted tool: the
+ * kubeconfig is read in place and never uploaded, and there is no srelens
+ * service between the reader and their API servers. What the agent may read is
+ * said in {@link FOOTER_DESKTOP}, where the agent is already the subject.
+ */
 const LEDE_DESKTOP =
-  "srelens uses the credentials already in your kubeconfig and talks to the API server directly. Nothing about your clusters leaves this machine.";
+  "srelens uses the credentials already in your kubeconfig and talks to the API server directly. That file stays on this machine, and no srelens service sits between you and your clusters.";
 const LEDE_WEB =
   "srelens uses the credentials in the kubeconfig this server was started with, and talks to the API server directly from the server's host. The clusters listed below are the ones that server can see, not the ones on the machine you are reading this on.";
 /**
@@ -82,7 +104,30 @@ const EYEBROW_WEB = "srelens · shared server";
 /** Said once, in both footers: the console is not wired up in this design. */
 const CONSOLE_NOT_YET =
   "Asking the console about a cluster in plain language is not in this design yet.";
-const FOOTER_DESKTOP = `srelens reads each cluster directly, with the credentials already in your kubeconfig, and sends that file nowhere. ${CONSOLE_NOT_YET}`;
+/**
+ * **What an agent may do with this list, both halves of it.**
+ *
+ * `SourcesRail`'s own section (one click away, on `/connections`) already tells
+ * the reader that every agent CHANGE stops at a confirmation prompt. Nothing
+ * told them the agent can READ freely, and that is the half which makes an
+ * absolute "nothing leaves this machine" false — see {@link LEDE_DESKTOP} for
+ * why the read is ungated. A reader who has been told only about the gate would
+ * reasonably conclude the reads are gated too.
+ *
+ * Worded to AGREE with the rail rather than to paraphrase it: two panes a click
+ * apart describing one gate in two vocabularies is how a reader starts
+ * believing there are two gates.
+ *
+ * **Desktop only, deliberately.** It is the desktop reader who can start
+ * `srelens --mcp-stdio` on the machine in front of them; the web build's
+ * footer makes no absolute claim to narrow, and telling a browser reader about
+ * a process only whoever runs the server can start would be a fact about
+ * somebody else's machine — the exact fault this file's platform branches
+ * exist to avoid.
+ */
+const AGENT_READS =
+  "Connect an agent to srelens over MCP and it can read this list, and the clusters on it, without asking first; every change it makes stops at a confirmation prompt.";
+const FOOTER_DESKTOP = `srelens reads each cluster directly, with the credentials already in your kubeconfig, and never copies or uploads that file. ${AGENT_READS} ${CONSOLE_NOT_YET}`;
 const FOOTER_WEB = `srelens reads each cluster directly from this server, with the credentials in the kubeconfig it was started with. ${CONSOLE_NOT_YET}`;
 
 /**

--- a/packages/ui-next/src/screens/Connect.tsx
+++ b/packages/ui-next/src/screens/Connect.tsx
@@ -32,9 +32,9 @@ import {
 import { FailureAlert, FailureState } from "../lib/errorCopy";
 import { Icons } from "../lib/icons";
 import { useMark } from "../lib/marks";
+import { openCluster } from "../lib/openCluster";
 import { getProbe, probeCluster, useProbes, type Probe } from "../lib/probe";
 import { describe } from "../lib/routes";
-import { openTab, setActiveCluster, setWorkspaceClusters, useTabs } from "../lib/tabsStore";
 import { glyph } from "../lib/tree";
 import { STATUS, bySource, latencyLabel, viaOf } from "./connections/clusterText";
 
@@ -431,7 +431,6 @@ export function Connect({ route }: { route: string }) {
   const status = useContextsStatus();
   const listError = useContextsError();
   const probes = useProbes();
-  const { workspace } = useTabs();
 
   /** A listing asked for by the reader, still out. */
   const [busy, setBusy] = useState(false);
@@ -536,23 +535,6 @@ export function Connect({ route }: { route: string }) {
     // rows the reader pasted the context to see.
     setPasteOpen(false);
     await remember([path]);
-  }
-
-  /**
-   * Open a cluster: put it in this workspace, focus it, and open its overview.
-   *
-   * The workspace step is not a flourish. This screen lists every context on
-   * the machine, including ones no workspace holds, and `setActiveCluster`
-   * refuses an id the workspace does not have — so without it `Open` on exactly
-   * those rows would do nothing at all, silently.
-   */
-  function open(context: ClusterContext) {
-    const id = context.stableId;
-    if (!workspace.clusters.includes(id)) {
-      setWorkspaceClusters(workspace.id, [...workspace.clusters, id]);
-    }
-    setActiveCluster(id);
-    openTab("/overview", { clusterName: context.name });
   }
 
   const desktop = isTauri();
@@ -667,7 +649,7 @@ export function Connect({ route }: { route: string }) {
                 // `no reading` until the store has an answer for this cluster,
                 // which is what lets every row paint before any probe lands.
                 probe={probes[context.stableId] ?? UNREAD}
-                onOpen={open}
+                onOpen={openCluster}
               />
             ))}
 

--- a/packages/ui-next/src/screens/Connect.tsx
+++ b/packages/ui-next/src/screens/Connect.tsx
@@ -38,13 +38,52 @@ import { openTab, setActiveCluster, setWorkspaceClusters, useTabs } from "../lib
 import { glyph } from "../lib/tree";
 import { STATUS, bySource, latencyLabel, viaOf } from "./connections/clusterText";
 
-/** §24's copy, verbatim, and in one place so the page and the suite quote one string. */
+/**
+ * §24's copy, in one place so the page and the suite quote one string.
+ *
+ * **Two deliberate departures from §24, recorded here because the file used to
+ * claim "verbatim" and a future reviewer would otherwise "restore" the thing
+ * that was wrong.**
+ *
+ * 1. **The lede and the footer branch on the platform.** §24 wrote one string
+ *    each, and both are claims about WHOSE machine the kubeconfig is on —
+ *    true of the desktop and false of the web build, where the kubeconfig is
+ *    the server's, the clusters are read on the server's host, and web mode
+ *    over-listing the server's contexts is a filed bug (#347). §24's own
+ *    words appeared on the same card as {@link WEB_ONLY}'s "This build talks
+ *    to a shared server". The empty-state hint below already branched for
+ *    exactly this reason; these now do too.
+ * 2. **§24's footer is replaced, not quoted.** Its version offered a
+ *    read-only cluster, and there is no such thing in srelens — every write
+ *    the agent can issue stops at a confirmation prompt whatever the cluster
+ *    is, which is what `SourcesRail`'s own section says one click away. The
+ *    verbatim footer would have contradicted its sibling rail.
+ *
+ * The replacement carries no promise of its own either. It used to say "ask
+ * the console about it in plain language. srelens reads the cluster to
+ * answer", and the console answers nothing in this design —
+ * `shell/Console.tsx` renders "The agent is not in the new design yet". So it
+ * says what srelens does do, and says plainly that the asking is not here yet.
+ */
 const HEADLINE_ONE = "Pick a cluster.";
 const HEADLINE_TWO = "The room is already reading it.";
-const LEDE =
+const LEDE_DESKTOP =
   "srelens uses the credentials already in your kubeconfig and talks to the API server directly. Nothing about your clusters leaves this machine.";
-const FOOTER =
-  "Once a cluster is connected, ask the console about it in plain language. srelens reads the cluster to answer and sends your kubeconfig nowhere.";
+const LEDE_WEB =
+  "srelens uses the credentials in the kubeconfig this server was started with, and talks to the API server directly from the server's host. The clusters listed below are the ones that server can see, not the ones on the machine you are reading this on.";
+/**
+ * `local-first` is the desktop's claim and only the desktop's. A build served
+ * from a shared host is not local-first in any sense the word carries, and an
+ * eyebrow is exactly where a reader takes a brand line as a fact about the
+ * software in front of them.
+ */
+const EYEBROW_DESKTOP = "srelens · local-first";
+const EYEBROW_WEB = "srelens · shared server";
+/** Said once, in both footers: the console is not wired up in this design. */
+const CONSOLE_NOT_YET =
+  "Asking the console about a cluster in plain language is not in this design yet.";
+const FOOTER_DESKTOP = `srelens reads each cluster directly, with the credentials already in your kubeconfig, and sends that file nowhere. ${CONSOLE_NOT_YET}`;
+const FOOTER_WEB = `srelens reads each cluster directly from this server, with the credentials in the kubeconfig it was started with. ${CONSOLE_NOT_YET}`;
 
 /**
  * Why neither door is drawn in the browser, said once — decision 2.
@@ -126,6 +165,15 @@ function ContextRow({
    * — for a local cluster, where the file is beside the point — the tool that
    * made it and the endpoint it listens on. `viaOf` is the connections table's
    * own answer to that question, imported rather than restated.
+   *
+   * **A deviation from §24, recorded rather than left for a reviewer to
+   * "restore".** §24's second line is the RAW CONTEXT STRING — the kubeconfig's
+   * own `contexts[].name`, on the reasoning that a reader recognises it. That
+   * needs a profiles store to be worth anything: without one, `name` above is
+   * already the raw context string, so the row would print it twice. `viaOf`
+   * answers the question the second line is actually for — where this cluster
+   * comes from — and when a profiles store arrives the two lines diverge
+   * naturally, the first becoming the reader's own name for the cluster.
    */
   const via = viaOf(context);
   const status = STATUS[probe.state];
@@ -323,9 +371,19 @@ function PasteDialog({
             style={{ background: "var(--surface-sunk)", borderColor: "var(--rule)" }}
           />
         </Field>
+        {/* **Where the file actually goes.** This said "beside your other
+            kubeconfigs" and it does not go there: `savePastedKubeconfig` ->
+            `files.rs`'s `save_pasted_kubeconfig` writes to
+            `app_config_dir()/kubeconfigs/<stem>-<ts>.yaml` — srelens's own
+            folder — while the reader's kubeconfig is `~/.kube/config`. A
+            reader who wanted to find, edit or delete that context went to
+            `~/.kube` and found nothing. The frozen classic app words the same
+            operation correctly (`SettingsView.tsx`: "Saved securely in the
+            srelens app configuration directory"); the migration turned a true
+            sentence into a false one. */}
         <p className="text-[0.75rem] leading-relaxed text-muted">
-          Written to a file of its own beside your other kubeconfigs. srelens reads it in place from
-          then on.
+          Written to a file of its own in the srelens app configuration folder, not into your own
+          kubeconfig. srelens reads it in place from then on.
         </p>
       </div>
     </Dialog>
@@ -547,12 +605,14 @@ export function Connect({ route }: { route: string }) {
               lowercase everywhere — "SRELENS" is a spelling srelens does not
               have. The tracking and the mono face are the design's; only the
               transform gives way. */}
-          <Eyebrow className="normal-case">srelens · local-first</Eyebrow>
+          <Eyebrow className="normal-case">{desktop ? EYEBROW_DESKTOP : EYEBROW_WEB}</Eyebrow>
           <h1 className="mt-2.5 flex flex-col text-[2.75rem] font-semibold leading-[1.06] tracking-[-0.02em]">
             <span>{HEADLINE_ONE}</span>
             <span className="text-muted">{HEADLINE_TWO}</span>
           </h1>
-          <p className="mt-4 max-w-[62ch] text-[0.9375rem] leading-relaxed text-muted">{LEDE}</p>
+          <p className="mt-4 max-w-[62ch] text-[0.9375rem] leading-relaxed text-muted">
+            {desktop ? LEDE_DESKTOP : LEDE_WEB}
+          </p>
         </header>
 
         <div className="card min-w-0">
@@ -638,7 +698,9 @@ export function Connect({ route }: { route: string }) {
           <span className="mt-px shrink-0 text-accent">
             <Sparkle size={14} aria-hidden="true" />
           </span>
-          <p className="text-[0.8125rem] leading-relaxed text-muted">{FOOTER}</p>
+          <p className="text-[0.8125rem] leading-relaxed text-muted">
+            {desktop ? FOOTER_DESKTOP : FOOTER_WEB}
+          </p>
         </div>
       </div>
 

--- a/packages/ui-next/src/screens/Connect.tsx
+++ b/packages/ui-next/src/screens/Connect.tsx
@@ -36,7 +36,7 @@ import { getProbe, probeCluster, useProbes, type Probe } from "../lib/probe";
 import { describe } from "../lib/routes";
 import { openTab, setActiveCluster, setWorkspaceClusters, useTabs } from "../lib/tabsStore";
 import { glyph } from "../lib/tree";
-import { STATUS, latencyLabel, viaOf } from "./connections/clusterText";
+import { STATUS, bySource, latencyLabel, viaOf } from "./connections/clusterText";
 
 /** §24's copy, verbatim, and in one place so the page and the suite quote one string. */
 const HEADLINE_ONE = "Pick a cluster.";
@@ -503,6 +503,25 @@ export function Connect({ route }: { route: string }) {
       ? `${contexts.length} in ${plural(fileCount(contexts), "file")}`
       : undefined;
 
+  /**
+   * The rows, in the order `/connections` puts the same clusters in.
+   *
+   * **Not `listContexts`' own order, and that is the whole change.** This card
+   * listed raw, so a laptop whose kubeconfig declares a kind cluster between two
+   * remote contexts drew them interleaved here and grouped one click away on
+   * §6's table — two orders for one set, on two screens a reader moves between
+   * in a single gesture. `bySource` is the table's own grouping, imported rather
+   * than restated: a second sort written here is exactly how the two screens
+   * would drift apart again.
+   *
+   * No group HEADING goes with it. §6's table draws one per group because it has
+   * a `Source` column to head; this card is one flat list of eight rows at most
+   * in the ordinary case, and a label over each half of it would be chrome the
+   * first screen a reader ever sees does not need. The order is what the two
+   * screens have to agree on.
+   */
+  const listed = bySource(contexts, (context) => context.isLocal);
+
   const Sparkle = Icons.ask;
 
   return (
@@ -581,7 +600,7 @@ export function Connect({ route }: { route: string }) {
               />
             )}
 
-            {contexts.map((context) => (
+            {listed.map((context) => (
               <ContextRow
                 key={context.stableId}
                 context={context}

--- a/packages/ui-next/src/screens/Connections.test.tsx
+++ b/packages/ui-next/src/screens/Connections.test.tsx
@@ -47,9 +47,21 @@ const PROD: ClusterContext = {
   authKind: "exec plugin · gcloud",
 };
 
+/**
+ * **A context whose `stableId` is not its `name`** — the production shape, and
+ * the one thing that keeps the two keys from being conflated in every
+ * assertion below.
+ *
+ * A stableId is the declaring file plus the context's name within it, so this is
+ * what every context looks like once a second kubeconfig declares a name the
+ * first one already had. The screen writes facts under the stableId, reads them
+ * under the stableId, and calls `clusterFacts` with the NAME; with fixtures
+ * where the two strings are equal, keying the answers by name passed all 23
+ * tests and would have emptied the second line of every row in production.
+ */
 const STAGING: ClusterContext = {
   name: "staging-eu",
-  stableId: "staging-eu",
+  stableId: `${CONFIG}#staging-eu`,
   cluster: "staging",
   server: "https://staging-eu.example:6443",
   isCurrent: false,
@@ -67,7 +79,7 @@ const STAGING: ClusterContext = {
  */
 const EDGE: ClusterContext = {
   name: "edge-1",
-  stableId: "edge-1",
+  stableId: "/home/dana/work/edge.yaml#edge-1",
   cluster: "edge",
   server: "https://edge-1.example:6443",
   isCurrent: false,
@@ -184,6 +196,16 @@ const rowFor = (name: string) =>
 const sourceRows = () => Array.from(document.querySelectorAll('[data-testid="source-file"]'));
 
 const refreshAll = () => screen.getByRole("button", { name: "Refresh all" });
+
+/**
+ * The second line of a cluster's row, found by the id the cell is keyed by.
+ *
+ * `ClusterTable` builds that testid out of the `stableId`, so asking for it is
+ * what pins the key the facts were filed under — a text query would find the
+ * line wherever it landed.
+ */
+const detailFor = (context: ClusterContext) =>
+  document.querySelector(`[data-testid="cluster-detail-${context.stableId}"]`)?.textContent ?? null;
 
 describe("Connections", () => {
   it("counts the clusters it is showing, and the files they came from", async () => {
@@ -382,33 +404,107 @@ describe("Connections", () => {
   });
 
   /**
-   * The same guard on the second round trip. Facts are per cluster and land
-   * after their probe, so a slow one can answer under a listing that has since
-   * been replaced.
+   * **A read that spans two listings still gets its facts.**
+   *
+   * This was the defect that took the screen back for review, and it needed one
+   * click to reach. `listContexts` is a local file read and answers in a
+   * millisecond, so `Refresh all` pressed while the clusters are still
+   * connecting starts a round in which every cluster already has a read out.
+   * The old code skipped those clusters ("its own reader will follow through")
+   * and its own round counter then made that reader bail — so nobody asked for
+   * the facts, and twenty rows settled `reachable` with no provider and no
+   * region until a second `Refresh all` after the probes had landed. Nothing on
+   * screen said so: a row with no facts line is the ordinary first paint.
+   *
+   * Now the second round JOINS the read already out (in `probeCluster`, where
+   * both callers can see it) and follows through when it lands.
    */
-  it("a facts answer that arrives after a re-listing cannot paint over it", async () => {
-    const slow = deferred<ClusterFacts>();
-    // Only the FIRST read of staging is slow. A double that stayed slow would
-    // hand the second round the same pending promise, and settling it would
-    // then be a fresh answer arriving — which tests nothing.
-    let staged = 0;
-    core.clusterFacts.mockImplementation(async (context: string) =>
-      context === "staging-eu" && ++staged === 1 ? slow.promise : facts({ context }),
-    );
+  it("fetches the facts of a cluster whose read spanned two listings", async () => {
+    const slow = deferred<ClusterInfo>();
+    core.connectCluster.mockImplementation(async (name: string) => {
+      if (name === "staging-eu") return slow.promise;
+      clock += LATENCY[name] ?? 0;
+      return REACHABLE[name];
+    });
     const user = userEvent.setup();
     open();
     await waitFor(() => expect(drawn().length).toBe(2));
 
-    core.listContexts.mockResolvedValue({ contexts: [PROD, STAGING] });
+    // The new listing lands while staging is still connecting. Waited on prod's
+    // SECOND read rather than on the listing call: that is what proves the new
+    // round actually ran, over a cluster whose read was already out.
     await user.click(refreshAll());
-    await waitFor(() => expect(core.connectCluster).toHaveBeenCalledTimes(4));
+    await waitFor(() =>
+      expect(core.connectCluster.mock.calls.filter((c) => c[0] === "prod-eu").length).toBe(2),
+    );
+    expect(core.clusterFacts).not.toHaveBeenCalledWith("staging-eu");
+    expect(detailFor(STAGING)).toBeNull();
 
     await act(async () => {
-      slow.settle(facts({ context: "staging-eu", provider: "eks", region: "eu-west-1" }));
+      clock += 12;
+      slow.settle(REACHABLE["staging-eu"]);
     });
-    // The round that asked for it has been superseded, so its answer is dropped
-    // rather than drawn under a listing it does not belong to.
-    expect(screen.queryByText(/eks/)).toBeNull();
+
+    expect(within(rowFor("staging-eu")).getByText("reachable")).toBeTruthy();
+    await waitFor(() => expect(detailFor(STAGING)).toBe("gke · v1.30.6 · europe-west4"));
+    // Once, not twice: the two rounds' readers joined one read and then one
+    // facts fetch, rather than each making their own.
+    expect(core.connectCluster.mock.calls.filter((c) => c[0] === "staging-eu").length).toBe(1);
+    expect(core.clusterFacts.mock.calls.filter((c) => c[0] === "staging-eu").length).toBe(1);
+  });
+
+  /**
+   * **A listing this screen did not make.**
+   *
+   * The guards used to be per ROUND, and a round was bumped by any change to
+   * the contexts store while only this screen's own `reload()` set the "re-read
+   * everything" flag. So a write from anywhere else — `Window` re-listing after
+   * a kubeconfig change — dropped whatever was in flight and then refused to
+   * ask again, because the cluster was already marked as asked for. The screen
+   * was depending on an invariant the store knows nothing about: that every
+   * write comes paired with that flag.
+   *
+   * The guards are per cluster now and there is no round, so this is simply a
+   * re-render over work that is still perfectly good.
+   */
+  it("keeps the facts a listing it did not make interrupted", async () => {
+    const slow = deferred<ClusterFacts>();
+    let asked = 0;
+    core.clusterFacts.mockImplementation(async (context: string) =>
+      context === "staging-eu" && ++asked === 1 ? slow.promise : facts({ context }),
+    );
+    open();
+    await waitFor(() => expect(core.clusterFacts).toHaveBeenCalledWith("staging-eu"));
+
+    // Somebody else lists the contexts. No `reload()`, no re-read flag — just a
+    // write to the store this screen reads.
+    await act(async () => {
+      setContexts([PROD, STAGING]);
+    });
+
+    await act(async () => {
+      slow.settle(facts({ context: "staging-eu" }));
+    });
+    await waitFor(() => expect(detailFor(STAGING)).toBe("gke · v1.30.6 · europe-west4"));
+    // And it was not asked for a second time either: the answer already coming
+    // is the answer.
+    expect(core.clusterFacts.mock.calls.filter((c) => c[0] === "staging-eu").length).toBe(1);
+  });
+
+  /**
+   * **The facts are filed under the id the row is keyed by, not the name the
+   * capability is called with.**
+   *
+   * Both strings exist for every cluster and they are equal only in a fixture
+   * that has not thought about it. See {@link STAGING}.
+   */
+  it("files a cluster's facts under its stableId, not its name", async () => {
+    expect(STAGING.stableId).not.toBe(STAGING.name);
+    open();
+    await waitFor(() => expect(detailFor(STAGING)).toBe("gke · v1.30.6 · europe-west4"));
+    // The capability takes a context name, and that is what it was handed.
+    expect(core.clusterFacts).toHaveBeenCalledWith(STAGING.name);
+    expect(core.clusterFacts).not.toHaveBeenCalledWith(STAGING.stableId);
   });
 
   /**
@@ -523,9 +619,10 @@ describe("Connections", () => {
     await waitFor(() => expect(drawn().length).toBe(2));
 
     await user.click(within(rowFor("staging-eu")).getByRole("button", { name: "Open" }));
-    expect(store.activeCluster()).toBe("staging-eu");
+    // The stableId, never the name — the workspace is keyed by id (#265).
+    expect(store.activeCluster()).toBe(STAGING.stableId);
     expect(store.currentWorkspace().tabs.some((t) => t.route === "/overview")).toBe(true);
-    expect(store.currentWorkspace().clusters).toContain("staging-eu");
+    expect(store.currentWorkspace().clusters).toContain(STAGING.stableId);
   });
 
   /**

--- a/packages/ui-next/src/screens/Connections.test.tsx
+++ b/packages/ui-next/src/screens/Connections.test.tsx
@@ -88,6 +88,26 @@ const EDGE: ClusterContext = {
 };
 
 /**
+ * A cluster that runs on whichever host read the kubeconfig.
+ *
+ * The only fixture with `isLocal`, and the one the rail's second section needs
+ * to be drawn at all — the rail skips that section entirely when nothing is
+ * local, so a heading assertion without this passes for the wrong reason (no
+ * heading, and none expected).
+ */
+const LOCAL: ClusterContext = {
+  name: "kind-dev",
+  stableId: "kind-dev",
+  cluster: "kind-dev",
+  server: "https://127.0.0.1:6443",
+  isCurrent: false,
+  isLocal: true,
+  provider: "kind",
+  sourceFile: CONFIG,
+  authKind: "client certificate",
+};
+
+/**
  * **No stored kubeconfig files**, which is web mode's own shape (`Window.tsx`
  * hands it `[]`) and the one that separates "count the stored list" from "count
  * what the rail draws". The desktop tests set their own.
@@ -583,6 +603,37 @@ describe("Connections", () => {
     open();
     expect(await screen.findByRole("button", { name: "Add" })).toBeTruthy();
     expect(screen.queryByText(/added on the desktop/)).toBeNull();
+  });
+
+  /**
+   * **The other fact the rail cannot ask for itself — whose machine it is.**
+   *
+   * The rail's two section headings are claims about a LOCATION ("on this
+   * machine", "runs on this laptop"), and in web mode the location is the
+   * server's host: the kubeconfig is the one that server was started with, and
+   * a kind or minikube cluster it declares runs there, not on the machine the
+   * browser is on. `SourcesRail` takes `desktop` as a prop for the same reason
+   * it takes `onAddFile` — so both wordings are reachable from a fixture — and
+   * a screen that forgets to pass it defaults to the server wording and tells
+   * a desktop reader their own laptop is somebody else's server.
+   *
+   * Both directions asserted, because the fault this replaces was a heading
+   * that was right on one platform and unconditional.
+   */
+  it("tells the rail whose machine it is, on the desktop", async () => {
+    core.isTauri.mockReturnValue(true);
+    setContexts([PROD, LOCAL]);
+    open();
+    expect(await screen.findByText("Kubeconfig · on this machine")).toBeTruthy();
+    expect(screen.getByText("Local · runs on this laptop")).toBeTruthy();
+  });
+
+  it("tells the rail whose machine it is, in the browser", async () => {
+    setContexts([PROD, LOCAL]);
+    open();
+    expect(await screen.findByText("Kubeconfig · on the server's host")).toBeTruthy();
+    expect(screen.getByText("Local · runs on the server's host")).toBeTruthy();
+    expect(screen.queryByText("Local · runs on this laptop")).toBeNull();
   });
 
   it("says why there is no file picker in the browser", async () => {

--- a/packages/ui-next/src/screens/Connections.test.tsx
+++ b/packages/ui-next/src/screens/Connections.test.tsx
@@ -1,0 +1,552 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+/**
+ * **Only the capability wrappers and the two platform reads are replaced.**
+ *
+ * `describeError`, `plural` and `contextDisplayName` stay real, so the failure
+ * copy and both halves of the sub-count are core's own arithmetic rather than a
+ * copy of it. `latencyLabel`, `viaOf` and `joined` stay real for the same
+ * reason — they are what the table and the rail already agree on.
+ */
+const core = vi.hoisted(() => ({
+  listContexts: vi.fn(),
+  connectCluster: vi.fn(),
+  clusterFacts: vi.fn(),
+  isTauri: vi.fn(),
+  pickKubeconfigFiles: vi.fn(),
+  saveKubeconfigFiles: vi.fn(),
+}));
+vi.mock("@srelens/core", async (orig) => ({
+  ...(await orig<typeof import("@srelens/core")>()),
+  ...core,
+}));
+
+import { describeError, plural, type ClusterContext, type ClusterFacts, type ClusterInfo } from "@srelens/core";
+import { Connections } from "./Connections";
+import { getKubeconfigFiles, resetContexts, setContexts, setKubeconfigFiles } from "../lib/clusters";
+import { resetProbes } from "../lib/probe";
+import { defaultState } from "../lib/tabs";
+import * as store from "../lib/tabsStore";
+import { resetView } from "../lib/workspace";
+
+const ROUTE = "/connections";
+
+/** The kubeconfig two of the three contexts were declared in. */
+const CONFIG = "/home/dana/.kube/config";
+
+const PROD: ClusterContext = {
+  name: "prod-eu",
+  stableId: "prod-eu",
+  cluster: "prod",
+  server: "https://prod-eu.example:6443",
+  isCurrent: true,
+  namespace: "platform",
+  sourceFile: CONFIG,
+  authKind: "exec plugin · gcloud",
+};
+
+const STAGING: ClusterContext = {
+  name: "staging-eu",
+  stableId: "staging-eu",
+  cluster: "staging",
+  server: "https://staging-eu.example:6443",
+  isCurrent: false,
+  sourceFile: CONFIG,
+  authKind: "token",
+};
+
+/**
+ * A third context from a SECOND file, used only where a second source matters.
+ *
+ * The default fixture deliberately has two clusters in one file, because that
+ * is the shape the sub-count can get wrong: a count of the stored file list is
+ * `0` here (this window stores none — see {@link FILES}) while the rail draws
+ * one row, and a count of the rows is `2` where the files are `1`.
+ */
+const EDGE: ClusterContext = {
+  name: "edge-1",
+  stableId: "edge-1",
+  cluster: "edge",
+  server: "https://edge-1.example:6443",
+  isCurrent: false,
+  sourceFile: "/home/dana/work/edge.yaml",
+  authKind: "client certificate",
+};
+
+/**
+ * **No stored kubeconfig files**, which is web mode's own shape (`Window.tsx`
+ * hands it `[]`) and the one that separates "count the stored list" from "count
+ * what the rail draws". The desktop tests set their own.
+ */
+const FILES: string[] = [];
+
+const facts = (over: Partial<ClusterFacts> = {}): ClusterFacts => ({
+  context: "prod-eu",
+  provider: "gke",
+  region: "europe-west4",
+  metricsServer: { state: "present", version: "v0.7.1" },
+  ...over,
+});
+
+/** What each cluster answers, and how long it takes about it. */
+const REACHABLE: Record<string, ClusterInfo> = {
+  "prod-eu": { context: "prod-eu", reachable: true, version: "v1.31.2" },
+  "staging-eu": { context: "staging-eu", reachable: true, version: "v1.30.6" },
+  "edge-1": { context: "edge-1", reachable: true, version: "v1.29.4" },
+};
+const LATENCY: Record<string, number> = { "prod-eu": 41, "staging-eu": 12, "edge-1": 7 };
+
+/**
+ * A listing failure with a machine string in it.
+ *
+ * Classified by `describeError` (it matches its connect branch), so the screen
+ * has a sentence to show and an original to fold away — which is the only shape
+ * that can tell "reported through `describeError`" apart from "printed the
+ * backend's string".
+ */
+const LIST_FAILURE = "ServiceError: connection refused: ECONNREFUSED 10.0.5.2:6443";
+
+/**
+ * A frozen clock, advanced only by the `connectCluster` double.
+ *
+ * `probeCluster` times its own round trip off `Date.now` and the screen calls
+ * it with the default, so this is the only way a latency assertion can be an
+ * exact number rather than whatever the machine happened to take.
+ */
+let clock = 0;
+
+function deferred<T>() {
+  let settle: (value: T) => void = () => {};
+  const promise = new Promise<T>((resolve) => {
+    settle = resolve;
+  });
+  return { promise, settle };
+}
+
+/** A promise that never settles — a cluster that does not answer at all. */
+const never = <T,>(): Promise<T> => new Promise<T>(() => {});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clock = 1_700_000_000_000;
+  vi.spyOn(Date, "now").mockImplementation(() => clock);
+  core.listContexts.mockResolvedValue({ contexts: [PROD, STAGING] });
+  core.connectCluster.mockImplementation(async (name: string) => {
+    clock += LATENCY[name] ?? 0;
+    return REACHABLE[name] ?? { context: name, reachable: false, error: "no route to host" };
+  });
+  core.clusterFacts.mockImplementation(async (context: string) => facts({ context }));
+  // Web by default, so a desktop-only control has to be asked for explicitly.
+  core.isTauri.mockReturnValue(false);
+  core.pickKubeconfigFiles.mockResolvedValue([]);
+  resetProbes();
+  resetContexts();
+  setContexts([PROD, STAGING]);
+  setKubeconfigFiles(FILES);
+  store.setState(defaultState([PROD, STAGING]));
+  resetView();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function open() {
+  store.openTab(ROUTE);
+  return render(<Connections route={ROUTE} />);
+}
+
+/** The `Screen`'s sub, exactly as it is drawn. */
+const sub = () => document.querySelector(".crumb")?.textContent ?? null;
+
+/**
+ * Every cluster the table is drawing, in the order it draws them.
+ *
+ * Read from the name element rather than from the cell's `textContent`: the
+ * Cluster cell also carries the mark's initials and the facts line, so the
+ * cell's text is `PEprod-eugke · v1.31.2 · europe-west4` and an equality
+ * against it would pass for reasons that have nothing to do with the row.
+ */
+const drawn = () =>
+  Array.from(document.querySelectorAll("tbody tr.tbl-row")).map(
+    (tr) => tr.querySelector('[data-testid^="cluster-name-"]')?.textContent?.trim() ?? "",
+  );
+
+/** One row, by the cluster its name cell names — exactly, not by inclusion. */
+const rowFor = (name: string) =>
+  Array.from(document.querySelectorAll("tbody tr.tbl-row")).find(
+    (tr) => tr.querySelector('[data-testid^="cluster-name-"]')?.textContent?.trim() === name,
+  ) as HTMLElement;
+
+/** The file rows the Sources rail is drawing. */
+const sourceRows = () => Array.from(document.querySelectorAll('[data-testid="source-file"]'));
+
+const refreshAll = () => screen.getByRole("button", { name: "Refresh all" });
+
+describe("Connections", () => {
+  it("counts the clusters it is showing, and the files they came from", async () => {
+    open();
+    expect(await screen.findByText(/2 clusters · 1 source/)).toBeTruthy();
+  });
+
+  /**
+   * The count and the rows, pinned to each other rather than each to a literal.
+   *
+   * `Releases · 383 in this cluster` over six rows is the defect this guards,
+   * and a pair of hard-coded numbers cannot guard it: they agree with the
+   * fixture, not with the screen. Both halves are read back off the DOM the
+   * reader is looking at — the table's rows and the rail's file rows — so a
+   * count taken from anything else fails here whatever the fixture says.
+   */
+  it("counts what is on the screen, not the lists behind it", async () => {
+    setContexts([PROD, STAGING, EDGE]);
+    open();
+    await waitFor(() => expect(drawn().length).toBe(3));
+    // Two files: the one PROD and STAGING share, and EDGE's own. Neither is in
+    // the stored list, which is empty — so `files.length` is 0 here.
+    expect(getKubeconfigFiles()).toEqual([]);
+    expect(sourceRows().length).toBe(2);
+    expect(sub()).toBe(`${plural(drawn().length, "cluster")} · ${plural(sourceRows().length, "source")}`);
+  });
+
+  it("draws the table before any cluster has answered", async () => {
+    core.connectCluster.mockImplementation(() => never<ClusterInfo>());
+    open();
+    expect(await screen.findByText("prod-eu")).toBeTruthy();
+    expect(screen.getByText("staging-eu")).toBeTruthy();
+    // No reading, and specifically not a reading of zero.
+    expect(screen.queryByText(/\d+\s*ms/)).toBeNull();
+    expect(screen.getAllByText("no reading").length).toBe(2);
+  });
+
+  it("one cluster that does not answer does not hold up the others", async () => {
+    core.connectCluster.mockImplementation(async (name: string) => {
+      if (name === "prod-eu") return never<ClusterInfo>();
+      clock += LATENCY[name] ?? 0;
+      return REACHABLE[name];
+    });
+    open();
+    // The reachable one's own round trip, while the other is still out.
+    expect(await screen.findByText("12 ms")).toBeTruthy();
+    expect(within(rowFor("staging-eu")).getByText("reachable")).toBeTruthy();
+    expect(within(rowFor("prod-eu")).getByText("no reading")).toBeTruthy();
+  });
+
+  /**
+   * The second line of the Cluster cell, which is the whole reason the facts
+   * are fetched at all: provider, server version and region, from the two
+   * different round trips that answer them.
+   */
+  it("fills in the control-plane facts once a cluster has answered", async () => {
+    open();
+    expect(await screen.findByText("gke · v1.30.6 · europe-west4")).toBeTruthy();
+    expect(core.clusterFacts).toHaveBeenCalledWith("staging-eu");
+  });
+
+  it("does not ask a cluster that did not answer for its facts", async () => {
+    core.connectCluster.mockImplementation(async (name: string) => ({
+      context: name,
+      reachable: false,
+      error: "no route to host",
+    }));
+    open();
+    await waitFor(() => expect(screen.getAllByText("unreachable").length).toBe(2));
+    expect(core.clusterFacts).not.toHaveBeenCalled();
+  });
+
+  it("reports a listing that fails, through describeError", async () => {
+    resetContexts();
+    setContexts([], LIST_FAILURE);
+    open();
+    const alert = await screen.findByRole("alert");
+    expect(within(alert).getByText("Could not list your clusters")).toBeTruthy();
+    // The classification, word for word — not a sentence this screen wrote.
+    expect(within(alert).getByText(describeError(LIST_FAILURE).detail)).toBeTruthy();
+    /**
+     * **The backend's own string is never what the reader is shown.**
+     *
+     * Asserted on the detail slot rather than on the whole document: the
+     * original is deliberately offered, folded away inside `RawError`'s
+     * disclosure, and `queryByText` cannot tell a closed `details` from a
+     * paragraph. What must not happen is the machine string standing in for the
+     * sentence — so the element that carries the sentence is the one asked.
+     */
+    const detail = alert.querySelector('[data-slot="detail"]');
+    expect(detail?.textContent ?? "").not.toContain("ECONNREFUSED");
+    expect(alert.querySelector('[data-slot="raw"] pre')?.textContent).toContain("ECONNREFUSED");
+  });
+
+  /**
+   * A count over a screen with no table on it would be a count of nothing,
+   * asserted as a fact. The sub says nothing until there are rows to say it
+   * about.
+   */
+  it("claims no count while the clusters are still being listed", () => {
+    resetContexts();
+    open();
+    expect(sub()).toBeNull();
+    expect(screen.getByRole("status")).toBeTruthy();
+  });
+
+  it("claims no count over a listing that failed", async () => {
+    resetContexts();
+    setContexts([], LIST_FAILURE);
+    open();
+    await screen.findByRole("alert");
+    expect(sub()).toBeNull();
+  });
+
+  it("sends a reader with no clusters to connect rather than an empty table", async () => {
+    resetContexts();
+    setContexts([]);
+    open();
+    expect(await screen.findByRole("button", { name: "Connect a cluster" })).toBeTruthy();
+    expect(screen.getByText("No clusters yet")).toBeTruthy();
+    // Not an empty table with six column headers over it.
+    expect(document.querySelector('[data-testid="cluster-table"]')).toBeNull();
+    expect(sub()).toBeNull();
+  });
+
+  it("opens the connect route from the empty state", async () => {
+    resetContexts();
+    setContexts([]);
+    const user = userEvent.setup();
+    open();
+    await user.click(await screen.findByRole("button", { name: "Connect a cluster" }));
+    expect(store.currentWorkspace().tabs.some((t) => t.route === "/connect")).toBe(true);
+  });
+
+  it("opens the connect route from the header", async () => {
+    const user = userEvent.setup();
+    open();
+    await user.click(screen.getByRole("button", { name: "Add connection" }));
+    expect(store.currentWorkspace().tabs.some((t) => t.route === "/connect")).toBe(true);
+  });
+
+  it("re-lists and re-reads every cluster on Refresh all", async () => {
+    const user = userEvent.setup();
+    open();
+    await waitFor(() => expect(screen.getByText("12 ms")).toBeTruthy());
+    expect(core.connectCluster).toHaveBeenCalledTimes(2);
+
+    core.listContexts.mockResolvedValue({ contexts: [PROD, STAGING, EDGE] });
+    await user.click(refreshAll());
+
+    await waitFor(() => expect(drawn()).toEqual(["prod-eu", "staging-eu", "edge-1"]));
+    /**
+     * **Every cluster read again, not only the one that is new.**
+     *
+     * Counted per cluster rather than asserted as a new latency: the clock is
+     * one number shared by three probes that run at once, so a per-cluster
+     * millisecond figure is only exact when a single cluster answers. The call
+     * count is exact whatever the interleaving, and it is the property — a
+     * `Refresh all` that re-read only the unread clusters would leave twenty
+     * stale readings under a control that says it refreshed them.
+     */
+    await waitFor(() => {
+      for (const name of ["prod-eu", "staging-eu", "edge-1"]) {
+        expect(core.connectCluster.mock.calls.filter((c) => c[0] === name).length).toBe(
+          name === "edge-1" ? 1 : 2,
+        );
+      }
+    });
+    expect(core.connectCluster).toHaveBeenCalledTimes(5);
+    // And their facts with them: the round trip is re-made, not remembered.
+    expect(core.clusterFacts.mock.calls.filter((c) => c[0] === "staging-eu").length).toBe(2);
+  });
+
+  /**
+   * **The sequence guard.** A reader who hits `Refresh all` twice must be left
+   * looking at the second answer, whatever order the two listings come back in.
+   */
+  it("a listing that answers late cannot paint over a fresh one", async () => {
+    const slow = deferred<{ contexts: ClusterContext[] }>();
+    core.listContexts
+      .mockReturnValueOnce(slow.promise)
+      .mockResolvedValueOnce({ contexts: [PROD] });
+    const user = userEvent.setup();
+    open();
+    await waitFor(() => expect(drawn().length).toBe(2));
+
+    await user.click(refreshAll());
+    await user.click(refreshAll());
+    await waitFor(() => expect(drawn()).toEqual(["prod-eu"]));
+
+    // The first listing answers now, with a list the reader has moved on from.
+    await act(async () => {
+      slow.settle({ contexts: [PROD, STAGING, EDGE] });
+    });
+    expect(drawn()).toEqual(["prod-eu"]);
+  });
+
+  /**
+   * The same guard on the second round trip. Facts are per cluster and land
+   * after their probe, so a slow one can answer under a listing that has since
+   * been replaced.
+   */
+  it("a facts answer that arrives after a re-listing cannot paint over it", async () => {
+    const slow = deferred<ClusterFacts>();
+    // Only the FIRST read of staging is slow. A double that stayed slow would
+    // hand the second round the same pending promise, and settling it would
+    // then be a fresh answer arriving — which tests nothing.
+    let staged = 0;
+    core.clusterFacts.mockImplementation(async (context: string) =>
+      context === "staging-eu" && ++staged === 1 ? slow.promise : facts({ context }),
+    );
+    const user = userEvent.setup();
+    open();
+    await waitFor(() => expect(drawn().length).toBe(2));
+
+    core.listContexts.mockResolvedValue({ contexts: [PROD, STAGING] });
+    await user.click(refreshAll());
+    await waitFor(() => expect(core.connectCluster).toHaveBeenCalledTimes(4));
+
+    await act(async () => {
+      slow.settle(facts({ context: "staging-eu", provider: "eks", region: "eu-west-1" }));
+    });
+    // The round that asked for it has been superseded, so its answer is dropped
+    // rather than drawn under a listing it does not belong to.
+    expect(screen.queryByText(/eks/)).toBeNull();
+  });
+
+  /**
+   * Two unordered writes of one cluster's reading, refused at the source.
+   *
+   * `probeCluster` writes to a module store the screen cannot un-write, so the
+   * guard here is not to start a second read of a cluster whose first is still
+   * out: an answer that is already on its way IS the fresh reading.
+   */
+  it("does not start a second read of a cluster that is still answering", async () => {
+    const slow = deferred<ClusterInfo>();
+    core.connectCluster.mockImplementation(async (name: string) => {
+      if (name === "prod-eu") return slow.promise;
+      clock += LATENCY[name] ?? 0;
+      return REACHABLE[name];
+    });
+    const user = userEvent.setup();
+    open();
+    await waitFor(() => expect(screen.getByText("12 ms")).toBeTruthy());
+
+    await user.click(refreshAll());
+    await waitFor(() =>
+      expect(core.connectCluster.mock.calls.filter((c) => c[0] === "staging-eu").length).toBe(2),
+    );
+    expect(core.connectCluster.mock.calls.filter((c) => c[0] === "prod-eu").length).toBe(1);
+
+    await act(async () => {
+      clock += 41;
+      slow.settle(REACHABLE["prod-eu"]);
+    });
+    expect(within(rowFor("prod-eu")).getByText("reachable")).toBeTruthy();
+  });
+
+  /**
+   * **The desktop's file picker, which the rail cannot ask for itself.**
+   *
+   * `SourcesRail` treats an absent `onAddFile` as "there is no filesystem to
+   * browse" and prints that instead of the control, so a screen that forgets to
+   * pass it loses the button on the desktop with nothing saying why.
+   */
+  it("offers the file picker on the desktop", async () => {
+    core.isTauri.mockReturnValue(true);
+    open();
+    expect(await screen.findByRole("button", { name: "Add" })).toBeTruthy();
+    expect(screen.queryByText(/added on the desktop/)).toBeNull();
+  });
+
+  it("says why there is no file picker in the browser", async () => {
+    open();
+    expect(await screen.findByText(/Kubeconfig files are added on the desktop/)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Add" })).toBeNull();
+  });
+
+  it("writes an added file through saveKubeconfigFiles and lists again", async () => {
+    core.isTauri.mockReturnValue(true);
+    core.pickKubeconfigFiles.mockResolvedValue(["/home/dana/work/edge.yaml"]);
+    core.listContexts.mockResolvedValue({ contexts: [PROD, STAGING] });
+    const user = userEvent.setup();
+    open();
+    await waitFor(() => expect(drawn().length).toBe(2));
+
+    core.listContexts.mockResolvedValue({ contexts: [PROD, STAGING, EDGE] });
+    await user.click(await screen.findByRole("button", { name: "Add" }));
+
+    await waitFor(() => expect(drawn().length).toBe(3));
+    expect(core.saveKubeconfigFiles).toHaveBeenCalledWith(["/home/dana/work/edge.yaml"]);
+    // The backend has to be told the path before a client can be built for a
+    // context that came out of it, so the re-listing carries it.
+    expect(core.listContexts).toHaveBeenLastCalledWith(["/home/dana/work/edge.yaml"]);
+    expect(getKubeconfigFiles()).toEqual(["/home/dana/work/edge.yaml"]);
+  });
+
+  it("reports a file picker that fails, through describeError", async () => {
+    core.isTauri.mockReturnValue(true);
+    core.pickKubeconfigFiles.mockRejectedValue(new Error("no route to host"));
+    const user = userEvent.setup();
+    open();
+    await user.click(await screen.findByRole("button", { name: "Add" }));
+    const alert = await screen.findByRole("alert");
+    expect(within(alert).getByText("Could not add that kubeconfig file")).toBeTruthy();
+    expect(within(alert).getByText(describeError("no route to host").detail)).toBeTruthy();
+    // The rows are untouched: this failed before anything was written.
+    expect(drawn().length).toBe(2);
+    expect(core.saveKubeconfigFiles).not.toHaveBeenCalled();
+  });
+
+  it("keeps the clusters it has when a re-listing fails, and says so", async () => {
+    const user = userEvent.setup();
+    open();
+    await waitFor(() => expect(drawn().length).toBe(2));
+
+    core.listContexts.mockResolvedValue({ error: LIST_FAILURE });
+    await user.click(refreshAll());
+
+    // `status`, not `alert`: the rows are still there, so this is a warning
+    // over content rather than a stop — `errorCopy`'s own rule, and the tone is
+    // what decides the role.
+    const alert = await screen.findByRole("status");
+    expect(within(alert).getByText("Could not refresh your clusters")).toBeTruthy();
+    // Still on screen, and still counted: a refresh that failed took nothing
+    // away from the reader.
+    expect(drawn().length).toBe(2);
+    expect(sub()).toBe("2 clusters · 1 source");
+  });
+
+  it("opens a cluster on the cluster the row is about", async () => {
+    // STAGING is listed but not in the workspace, which is the case an `Open`
+    // that only set the focus would silently do nothing for.
+    store.setState(defaultState([PROD]));
+    const user = userEvent.setup();
+    open();
+    await waitFor(() => expect(drawn().length).toBe(2));
+
+    await user.click(within(rowFor("staging-eu")).getByRole("button", { name: "Open" }));
+    expect(store.activeCluster()).toBe("staging-eu");
+    expect(store.currentWorkspace().tabs.some((t) => t.route === "/overview")).toBe(true);
+    expect(store.currentWorkspace().clusters).toContain("staging-eu");
+  });
+
+  /**
+   * **`min-width: auto` is why this is asserted as a class list.**
+   *
+   * A flex item refuses to shrink below its content, so without `min-w-0` on
+   * the table's column a long kubeconfig path pushes the rail's fixed 292px off
+   * the window and the whole screen scrolls sideways. jsdom computes no layout,
+   * so the classes are the only thing a test can hold.
+   */
+  it("lets the table column shrink so the rail keeps its width", async () => {
+    open();
+    await waitFor(() => expect(drawn().length).toBe(2));
+    const main = document.querySelector('[data-slot="connections-main"]') as HTMLElement;
+    expect(main.className.split(/\s+/)).toEqual(
+      expect.arrayContaining(["flex", "min-h-0", "min-w-0", "flex-1", "flex-col"]),
+    );
+    const table = document.querySelector('[data-testid="cluster-table"]') as HTMLElement;
+    expect(table.className.split(/\s+/)).toEqual(
+      expect.arrayContaining(["scroll", "min-h-0", "min-w-0", "flex-1"]),
+    );
+    expect((document.querySelector("aside.side-rail") as HTMLElement).style.width).toBe("292px");
+  });
+});

--- a/packages/ui-next/src/screens/Connections.test.tsx
+++ b/packages/ui-next/src/screens/Connections.test.tsx
@@ -726,6 +726,34 @@ describe("Connections", () => {
   });
 
   /**
+   * **A SECOND cluster opened onto the `/overview` tab the FIRST one made.**
+   *
+   * `openTab` dedupes by route and returned with `activeId: existing.id`
+   * without looking at `clusterName`, while `makeTab` spends `clusterName` on
+   * the tab's `sub` — so the label was fixed at creation. The workspace's
+   * active cluster moved, the overview rendered the second cluster, and the
+   * strip went on reading the first.
+   *
+   * STAGING is the fixture whose stableId differs from its name, so the last
+   * two lines can tell a relabel from a stableId written onto the strip.
+   */
+  it("relabels the overview tab when a second cluster is opened onto it", async () => {
+    const user = userEvent.setup();
+    open();
+    await waitFor(() => expect(drawn().length).toBe(2));
+
+    await user.click(within(rowFor("prod-eu")).getByRole("button", { name: "Open" }));
+    await user.click(within(rowFor("staging-eu")).getByRole("button", { name: "Open" }));
+
+    const overview = store.currentWorkspace().tabs.filter((t) => t.route === "/overview");
+    // Still one tab: the route dedupe was never the fault.
+    expect(overview).toHaveLength(1);
+    expect(store.activeCluster()).toBe(STAGING.stableId);
+    expect(overview[0]?.sub).toBe(STAGING.name);
+    expect(overview[0]?.sub).not.toBe(STAGING.stableId);
+  });
+
+  /**
    * **`min-width: auto` is why this is asserted as a class list.**
    *
    * A flex item refuses to shrink below its content, so without `min-w-0` on

--- a/packages/ui-next/src/screens/Connections.test.tsx
+++ b/packages/ui-next/src/screens/Connections.test.tsx
@@ -321,14 +321,47 @@ describe("Connections", () => {
   });
 
   it("sends a reader with no clusters to connect rather than an empty table", async () => {
+    core.isTauri.mockReturnValue(true);
     resetContexts();
     setContexts([]);
     open();
     expect(await screen.findByRole("button", { name: "Connect a cluster" })).toBeTruthy();
     expect(screen.getByText("No clusters yet")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "srelens reads your kubeconfig files in place. Connect a cluster and it appears here, with the file it came from beside it.",
+      ),
+    ).toBeTruthy();
     // Not an empty table with six column headers over it.
     expect(document.querySelector('[data-testid="cluster-table"]')).toBeNull();
     expect(sub()).toBeNull();
+  });
+
+  /**
+   * **"your kubeconfig files" is a claim about whose machine they are on.**
+   *
+   * In web mode the kubeconfig belongs to the server, the clusters are read on
+   * the server's host, and no file can be added from the browser at all —
+   * `SourcesRail` says so a pane away. The sibling `/connect` screen already
+   * branches its own empty-state hint for exactly this; this one did not, and
+   * said it beside a `Connect a cluster` button.
+   *
+   * Pinned as the absence of the false sentence as well as the presence of the
+   * true one: a branch that appended the web copy and left the possessive
+   * standing would satisfy a presence-only test.
+   */
+  it("does not call the server's kubeconfig files the reader's own", async () => {
+    resetContexts();
+    setContexts([]);
+    open();
+    await screen.findByText("No clusters yet");
+
+    expect(screen.queryByText(/your kubeconfig files/)).toBeNull();
+    expect(
+      screen.getByText(
+        "srelens reads the kubeconfig files this server was started with, in place. A cluster appears here once one of those files declares it, with the file it came from beside it.",
+      ),
+    ).toBeTruthy();
   });
 
   it("opens the connect route from the empty state", async () => {

--- a/packages/ui-next/src/screens/Connections.test.tsx
+++ b/packages/ui-next/src/screens/Connections.test.tsx
@@ -726,6 +726,60 @@ describe("Connections", () => {
   });
 
   /**
+   * **`Refresh all` after the active context was removed from the kubeconfig.**
+   *
+   * The context store was replaced and the workspace was not: it kept an
+   * `activeCluster` naming a context nobody declares any more, so
+   * `useActiveContext()` answered `undefined` and every cluster-scoped screen
+   * fell to its no-cluster state — telling the reader to pick a cluster while
+   * another one sat in the table in front of them. Boot already solved this by
+   * reconciling; a refreshed listing now goes through the same step, inside the
+   * store both screens write to.
+   */
+  it("moves the focus off a cluster Refresh all no longer finds", async () => {
+    const user = userEvent.setup();
+    open();
+    await waitFor(() => expect(drawn().length).toBe(2));
+    expect(store.activeCluster()).toBe(PROD.stableId);
+
+    // PROD has gone from the kubeconfig; STAGING is still there.
+    core.listContexts.mockResolvedValue({ contexts: [STAGING] });
+    await user.click(refreshAll());
+
+    await waitFor(() => expect(drawn().length).toBe(1));
+    expect(store.activeCluster()).toBe(STAGING.stableId);
+    expect(store.currentWorkspace().clusters).toEqual([STAGING.stableId]);
+  });
+
+  /**
+   * **A refresh that came back SHORT WITH A REASON takes nothing away — not the
+   * rows, and not the focus.**
+   *
+   * Partial, deliberately, and this is the only shape of failure that can hold
+   * the property. A WHOLLY failed refresh cannot: `reload` installs
+   * `outcome.contexts ?? getContexts()`, so the list it writes is the one
+   * already on screen and a reconciliation against it would change nothing
+   * whether it ran or not — the test would pass with the guard deleted.
+   * `listContexts` really does answer with some contexts and an error when one
+   * of several merged kubeconfigs is unreadable, and a cluster missing for that
+   * reason has not gone anywhere. `Window` keeps the restored cluster ids on the
+   * same reasoning; a reader whose VPN dropped must not lose the cluster they
+   * were looking at to it.
+   */
+  it("keeps the focus when a refresh comes back short with a reason", async () => {
+    const user = userEvent.setup();
+    open();
+    await waitFor(() => expect(drawn().length).toBe(2));
+
+    core.listContexts.mockResolvedValue({ contexts: [STAGING], error: LIST_FAILURE });
+    await user.click(refreshAll());
+
+    await screen.findByRole("status");
+    expect(store.activeCluster()).toBe(PROD.stableId);
+    expect(store.currentWorkspace().clusters).toEqual([PROD.stableId, STAGING.stableId]);
+  });
+
+  /**
    * **A SECOND cluster opened onto the `/overview` tab the FIRST one made.**
    *
    * `openTab` dedupes by route and returned with `activeId: existing.id`

--- a/packages/ui-next/src/screens/Connections.test.tsx
+++ b/packages/ui-next/src/screens/Connections.test.tsx
@@ -654,8 +654,24 @@ describe("Connections", () => {
     await user.click(within(rowFor("staging-eu")).getByRole("button", { name: "Open" }));
     // The stableId, never the name — the workspace is keyed by id (#265).
     expect(store.activeCluster()).toBe(STAGING.stableId);
-    expect(store.currentWorkspace().tabs.some((t) => t.route === "/overview")).toBe(true);
     expect(store.currentWorkspace().clusters).toContain(STAGING.stableId);
+
+    /**
+     * **And the TAB is opened with the NAME, which is the other half of #265
+     * and the half no test held.**
+     *
+     * `makeTab` spends `clusterName` on the tab's `sub`, and every core call
+     * the overview then makes takes a context NAME. Handing `openTab` the
+     * stableId instead read `/home/dana/.kube/config#staging-eu` on the tab
+     * strip and passed the whole ui-next suite, because `activeCluster` and
+     * `clusters` above are both keyed by id and neither can see it. STAGING is
+     * the fixture whose two keys differ, so asking for the `sub` here IS the
+     * assertion.
+     */
+    const tab = store.currentWorkspace().tabs.find((t) => t.route === "/overview");
+    expect(tab).toBeTruthy();
+    expect(tab?.sub).toBe(STAGING.name);
+    expect(tab?.sub).not.toBe(STAGING.stableId);
   });
 
   /**

--- a/packages/ui-next/src/screens/Connections.tsx
+++ b/packages/ui-next/src/screens/Connections.tsx
@@ -20,9 +20,10 @@ import {
   useContextsStatus,
 } from "../lib/clusters";
 import { FailureAlert, FailureState } from "../lib/errorCopy";
+import { openCluster } from "../lib/openCluster";
 import { getProbe, probeCluster, useProbes, type Probe } from "../lib/probe";
 import { describe } from "../lib/routes";
-import { openTab, setActiveCluster, setWorkspaceClusters, useTabs } from "../lib/tabsStore";
+import { openTab } from "../lib/tabsStore";
 import { ClusterTable, type ClusterRow } from "./connections/ClusterTable";
 import { SourcesRail } from "./connections/SourcesRail";
 
@@ -97,7 +98,6 @@ export function Connections({ route }: { route: string }) {
    * is what re-renders this screen with the new list in hand.
    */
   const files = getKubeconfigFiles();
-  const { workspace } = useTabs();
 
   /**
    * Provider and region per cluster, from the second round trip, **keyed by
@@ -350,21 +350,17 @@ export function Connections({ route }: { route: string }) {
     rows.length > 0 ? `${plural(rows.length, "cluster")} · ${plural(sources, "source")}` : undefined;
 
   /**
-   * Open a cluster: put it in this workspace, focus it, and open its overview.
+   * Open the cluster a row stands for.
    *
-   * The workspace step is not a flourish. This screen lists every context on
-   * the machine, including ones no workspace holds, and `setActiveCluster`
-   * refuses an id the workspace does not have — so without it `Open` on exactly
-   * those rows would do nothing at all, silently.
+   * The row hands over a `stableId` — the table's own key — and the lookup is
+   * what turns it back into the context {@link openCluster} needs. A row for an
+   * id no longer on the list opens nothing rather than opening the wrong
+   * cluster.
    */
   function open(stableId: string) {
     const context = contexts.find((c) => c.stableId === stableId);
     if (!context) return;
-    if (!workspace.clusters.includes(stableId)) {
-      setWorkspaceClusters(workspace.id, [...workspace.clusters, stableId]);
-    }
-    setActiveCluster(stableId);
-    openTab("/overview", { clusterName: context.name });
+    openCluster(context);
   }
 
   /**

--- a/packages/ui-next/src/screens/Connections.tsx
+++ b/packages/ui-next/src/screens/Connections.tsx
@@ -431,6 +431,17 @@ export function Connections({ route }: { route: string }) {
    * The table's own `emptyText` covers the narrow case of a list that came back
    * short; this is the first-run one, where an empty panel with six column
    * headers over it says only that srelens has nothing and not what to do next.
+   *
+   * **The hint branches on the platform, because it is a claim about whose
+   * machine the files are on.** "srelens reads YOUR kubeconfig files in place"
+   * is true of the desktop and false of the web build: there the kubeconfig
+   * belongs to the server, the clusters are read on the server's host, and no
+   * file can be added from the browser at all — which is what `SourcesRail`
+   * says one pane over, and what `/connect`'s own empty-state hint has always
+   * branched for. The `Connect a cluster` control still leads to `/connect` on
+   * web, deliberately: that screen is where §24's own paragraph explains why
+   * neither door is drawn there, which is more use to a web reader than an
+   * absent button.
    */
   if (status === "loaded" && rows.length === 0) {
     return (
@@ -438,7 +449,11 @@ export function Connections({ route }: { route: string }) {
         <EmptyState
           className="flex-1"
           title="No clusters yet"
-          hint="srelens reads your kubeconfig files in place. Connect a cluster and it appears here, with the file it came from beside it."
+          hint={
+            desktop
+              ? "srelens reads your kubeconfig files in place. Connect a cluster and it appears here, with the file it came from beside it."
+              : "srelens reads the kubeconfig files this server was started with, in place. A cluster appears here once one of those files declares it, with the file it came from beside it."
+          }
           action={
             <Button type="button" variant="primary" size="sm" onClick={() => openTab(CONNECT)}>
               Connect a cluster

--- a/packages/ui-next/src/screens/Connections.tsx
+++ b/packages/ui-next/src/screens/Connections.tsx
@@ -1,0 +1,452 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  clusterFacts,
+  isTauri,
+  listContexts,
+  pickKubeconfigFiles,
+  plural,
+  saveKubeconfigFiles,
+  type ClusterContext,
+  type ClusterFacts,
+} from "@srelens/core";
+import { Button, EmptyState, LoadingState, Screen } from "@srelens/ui-kit";
+import {
+  getContexts,
+  getKubeconfigFiles,
+  setContexts,
+  setKubeconfigFiles,
+  useContexts,
+  useContextsError,
+  useContextsStatus,
+} from "../lib/clusters";
+import { FailureAlert, FailureState } from "../lib/errorCopy";
+import { getProbe, probeCluster, useProbes, type Probe } from "../lib/probe";
+import { describe } from "../lib/routes";
+import { openTab, setActiveCluster, setWorkspaceClusters, useTabs } from "../lib/tabsStore";
+import { ClusterTable, type ClusterRow } from "./connections/ClusterTable";
+import { SourcesRail } from "./connections/SourcesRail";
+
+/**
+ * **The route the `Add connection` control opens — and the seam this screen
+ * leaves for it.**
+ *
+ * `/connect` is already in `lib/routes`'s app-scoped table (it has a title and
+ * a tab kind), and it has no entry in that file's `SCREENS` map yet, so opening
+ * it today lands on the `Placeholder`. That is deliberate: the tab, its title
+ * and both ways in exist and are tested from here, and the next task adds one
+ * line — `"/connect": Connect` in `SCREENS` — with nothing on this screen to
+ * change. An import of a component that does not exist would not compile, and
+ * a route invented here would be a second name for the one that table holds.
+ */
+const CONNECT = "/connect";
+
+/**
+ * A cluster nothing has read yet.
+ *
+ * Module-level so the identity is stable: it is spread across every row whose
+ * probe the store has no entry for, and a fresh object per render would defeat
+ * the `useMemo` below on every notification.
+ */
+const UNREAD: Probe = { state: "unread" };
+
+/**
+ * `/connections` — §6's screen: every cluster srelens can see, what the last
+ * reading of it said, and which file each one was read from.
+ *
+ * **The two panes are components, and this composes them.** `ClusterTable` and
+ * `SourcesRail` fetch nothing and hold no state; this screen owns the contexts,
+ * the probes, the facts and the stored file list, which is what lets both panes
+ * be drawn from a fixture. The rail draws its own 292px `aside`, so it is
+ * dropped in beside the table with no wrapper — the `ReleasePane` arrangement
+ * `Helm` uses.
+ *
+ * **The contexts come from the store, not from a listing of this screen's
+ * own.** `Window` lists them at boot and every screen reads that one answer, so
+ * arriving here draws the table immediately rather than re-asking for a list
+ * the window already has. `Refresh all` is the one thing that lists again, and
+ * it writes the answer back through `setContexts` so the rail, the status bar
+ * and every other screen see the same list this one is drawing.
+ *
+ * **Four things this screen is careful about**, each of which has shipped as a
+ * defect on a screen in this migration:
+ *
+ * 1. The sub-count counts what is on the screen — see the `sub` below.
+ *    `Releases · 383 in this cluster` over six rows is the fault, and both
+ *    halves here are read from the same arrays the two panes are given.
+ * 2. A probe never blocks a row. Every cluster is drawn `unread` on the first
+ *    paint and each reading arrives on its own — twenty clusters do not queue,
+ *    and one that never answers holds up none of the others.
+ * 3. A late answer cannot paint over a fresh one, on both round trips. Helm's
+ *    `listSeq` idiom, twice: once on the listing and once on the readings.
+ * 4. `onAddFile` is passed whenever there is a filesystem to browse. The rail
+ *    reads its absence as "there is none" and prints that instead of the
+ *    control, so forgetting it here would lose the button on the desktop with
+ *    nothing on screen saying why.
+ */
+export function Connections({ route }: { route: string }) {
+  // The routes table's own title, so the tab strip and the `h1` cannot drift.
+  const title = describe(route).title;
+
+  const contexts = useContexts();
+  const status = useContextsStatus();
+  const listError = useContextsError();
+  const probes = useProbes();
+  /**
+   * The kubeconfig paths this window was started with, read at render the way
+   * `Helm` reads them.
+   *
+   * Not reactive, and it does not need to be: the only thing that changes it is
+   * {@link addFile} below, which re-lists in the same breath — and the listing
+   * is what re-renders this screen with the new list in hand.
+   */
+  const files = getKubeconfigFiles();
+  const { workspace } = useTabs();
+
+  /** Provider and region per cluster, from the second round trip. */
+  const [facts, setFacts] = useState<Record<string, ClusterFacts>>({});
+  /** A listing asked for by the reader, still out. */
+  const [busy, setBusy] = useState(false);
+  /** Why a kubeconfig file could not be added, when one could not. */
+  const [addError, setAddError] = useState<unknown>(null);
+
+  /**
+   * Which listing is the current one — `Helm`'s `listSeq`, for the same reason.
+   *
+   * A reader who hits `Refresh all` twice must be left looking at the second
+   * answer whatever order the two come back in. Without this, the first
+   * listing's late answer paints over the second's and the table shows a list
+   * the reader has already moved on from.
+   */
+  const listSeq = useRef(0);
+
+  /**
+   * Which round of readings the work in flight belongs to.
+   *
+   * The probes and the facts are per cluster and land one at a time, so a round
+   * that has been superseded — the reader re-listed while it was out — must not
+   * write what it finds. Bumped once per run of the effect below, which is once
+   * per listing.
+   */
+  const readSeq = useRef(0);
+
+  /**
+   * The clusters being read right now.
+   *
+   * **This is what keeps two unordered writes of one cluster's reading from
+   * happening at all.** `probeCluster` writes to a module store this screen
+   * cannot un-write, so a sequence check after the fact could not undo a stale
+   * answer — a 30-second timeout from the first round would land on top of the
+   * second round's `12 ms` and the row would say `unreachable` about a cluster
+   * that had answered. A reading already on its way IS the fresh reading, so a
+   * second one is not started for it.
+   */
+  const reading = useRef<Set<string>>(new Set());
+
+  /** The clusters whose facts have been asked for in this round. */
+  const factsAsked = useRef<Set<string>>(new Set());
+
+  /**
+   * Whether the next round re-reads every cluster or only the unread ones.
+   *
+   * Arriving at this screen respects what the store already knows — `Window`
+   * probes the workspace's clusters at launch, and re-reading twenty clusters
+   * every time the reader flips back to this tab is a round trip per cluster
+   * for an answer already in hand. `Refresh all` sets this, and then every
+   * cluster is read again: that is the whole of what the control promises.
+   */
+  const forceNext = useRef(false);
+
+  /**
+   * List the contexts again, and read every cluster on the new list.
+   *
+   * The answer is written back through `setContexts`, so this screen is not
+   * keeping a second copy of the window's cluster list.
+   */
+  async function reload() {
+    const seq = ++listSeq.current;
+    setBusy(true);
+    const outcome = await listContexts(getKubeconfigFiles());
+    // Superseded. Dropped whole — the list AND the reason it is short are one
+    // fact, and installing half of a stale answer is worse than installing none.
+    if (seq !== listSeq.current) return;
+    setBusy(false);
+    forceNext.current = true;
+    /**
+     * **A fresh array, deliberately.**
+     *
+     * It is what tells the effect below that a listing has happened, and the
+     * two cases that need saying are the ones where the members alone do not
+     * say it: a listing that came back with the same contexts, and a listing
+     * that FAILED — where the rows already on screen are kept rather than
+     * thrown away, because a refresh that could not be made took nothing away
+     * from the reader. The store's own writer installs the list and the reason
+     * together, so both arrive in one write and no render can catch one without
+     * the other.
+     */
+    setContexts([...(outcome.contexts ?? getContexts())], outcome.error ?? "");
+  }
+
+  /**
+   * Read every cluster on the current list, each on its own.
+   *
+   * **Nothing here is awaited in series and nothing gates the render.** The
+   * table is drawn from `contexts` the moment they exist, with every row
+   * `unread`, and each reading arrives as its own store notification. A cluster
+   * that never answers leaves its own row saying `no reading` and delays no
+   * other row.
+   *
+   * The facts are the second round trip, and only for a cluster that answered:
+   * `provider` and `region` come from the API server, so asking an unreachable
+   * cluster for them buys a second timeout for a row that already says why it
+   * is empty.
+   */
+  useEffect(() => {
+    const force = forceNext.current;
+    forceNext.current = false;
+    if (force) factsAsked.current.clear();
+    const seq = ++readSeq.current;
+
+    async function read(context: ClusterContext) {
+      const id = context.stableId;
+      // Its own reader will follow through to the facts — see `reading`.
+      if (reading.current.has(id)) return;
+      if (force || getProbe(id).state === "unread") {
+        reading.current.add(id);
+        try {
+          await probeCluster(context);
+        } finally {
+          reading.current.delete(id);
+        }
+        if (seq !== readSeq.current) return;
+      }
+      if (getProbe(id).state !== "reachable") return;
+      if (factsAsked.current.has(id)) return;
+      factsAsked.current.add(id);
+      // `clusterFacts` never rejects; a failure comes back as empty facts plus
+      // a reason, and the cell simply has nothing to add to the row.
+      const answer = await clusterFacts(context.name);
+      if (seq !== readSeq.current) return;
+      setFacts((current) => ({ ...current, [id]: answer }));
+    }
+
+    for (const context of contexts) void read(context);
+  }, [contexts]);
+
+  /** The rows both panes are drawn from — the one array, so they cannot differ. */
+  const rows = useMemo<ClusterRow[]>(
+    () =>
+      contexts.map((context) => {
+        const probe = probes[context.stableId] ?? UNREAD;
+        const known = facts[context.stableId];
+        return known ? { context, probe, facts: known } : { context, probe };
+      }),
+    [contexts, probes, facts],
+  );
+
+  /**
+   * How many files the rail is listing — **its rule, not the stored list's
+   * length.**
+   *
+   * `files` is not the whole truth about where clusters are read from: web mode
+   * stores none at all (`Window.tsx` hands it `[]`), so counting it would put
+   * `0 sources` over a rail drawing one row for the kubeconfig twelve contexts
+   * came out of. And a stored path that yielded nothing is still a source the
+   * rail lists, so counting only the contexts' files would be short the other
+   * way.
+   *
+   * This mirrors `SourcesRail`'s own `fileRows`: every stored path, plus every
+   * path a context came from, deduped by exact string, ignoring the empty one a
+   * synthesized cluster carries. The suite pins the two together by counting
+   * the rows the rail actually drew rather than by re-deriving the number, so a
+   * drift between here and there fails a test instead of quietly putting a
+   * count over rows that disagree with it.
+   */
+  const sources = useMemo(() => {
+    const paths = new Set<string>();
+    for (const path of files) if (path.trim() !== "") paths.add(path);
+    for (const row of rows) if (row.context.sourceFile.trim() !== "") paths.add(row.context.sourceFile);
+    return paths.size;
+  }, [files, rows]);
+
+  /**
+   * §6's sub: `<n> clusters · <n> sources`.
+   *
+   * **Absent until there is something to count.** A number over a spinner, an
+   * error card or the `/connect` nudge would be a count of nothing asserted as
+   * a fact — the same fault as a count that disagrees with its rows, which is
+   * what `Releases · 383 in this cluster` over six rows was.
+   */
+  const sub =
+    rows.length > 0 ? `${plural(rows.length, "cluster")} · ${plural(sources, "source")}` : undefined;
+
+  /**
+   * Open a cluster: put it in this workspace, focus it, and open its overview.
+   *
+   * The workspace step is not a flourish. This screen lists every context on
+   * the machine, including ones no workspace holds, and `setActiveCluster`
+   * refuses an id the workspace does not have — so without it `Open` on exactly
+   * those rows would do nothing at all, silently.
+   */
+  function open(stableId: string) {
+    const context = contexts.find((c) => c.stableId === stableId);
+    if (!context) return;
+    if (!workspace.clusters.includes(stableId)) {
+      setWorkspaceClusters(workspace.id, [...workspace.clusters, stableId]);
+    }
+    setActiveCluster(stableId);
+    openTab("/overview", { clusterName: context.name });
+  }
+
+  /**
+   * Browse for a kubeconfig file, remember it, and list again.
+   *
+   * Three writes, and all three are needed: `saveKubeconfigFiles` is what makes
+   * the file survive a restart, `setKubeconfigFiles` is what every core call in
+   * this window reads (the backend cannot build a client for a context from a
+   * file it has not been told about), and the listing is what puts that file's
+   * contexts on the screen.
+   */
+  async function addFile() {
+    setAddError(null);
+    let picked: string[];
+    try {
+      picked = await pickKubeconfigFiles();
+    } catch (error) {
+      // Through `describeError` where it is shown, like every other failure on
+      // this screen — nothing is written when the picker itself refused.
+      setAddError(error);
+      return;
+    }
+    if (picked.length === 0) return;
+    const next = [...new Set([...getKubeconfigFiles(), ...picked])];
+    saveKubeconfigFiles(next);
+    setKubeconfigFiles(next);
+    await reload();
+  }
+
+  /**
+   * The desktop's own question, asked once, here.
+   *
+   * The rail takes a callback rather than asking itself, so both of its states
+   * are reachable from a fixture — `Toolbox.tsx:188` makes the same split for
+   * its install column.
+   */
+  const desktop = isTauri();
+
+  const actions = (
+    <>
+      <Button
+        type="button"
+        variant="secondary"
+        size="sm"
+        // Not disabled while a listing is out. A reader who asks twice is
+        // exactly the case `listSeq` exists for, and a control that locks
+        // itself for the length of an unreachable cluster's timeout is a
+        // control the reader cannot use when they most want to.
+        aria-busy={busy || undefined}
+        onClick={() => void reload()}
+      >
+        Refresh all
+      </Button>
+      <Button type="button" variant="primary" size="sm" onClick={() => openTab(CONNECT)}>
+        Add connection
+      </Button>
+    </>
+  );
+
+  /**
+   * A reader with no clusters is sent to `/connect`, not left at an empty
+   * table.
+   *
+   * The table's own `emptyText` covers the narrow case of a list that came back
+   * short; this is the first-run one, where an empty panel with six column
+   * headers over it says only that srelens has nothing and not what to do next.
+   */
+  if (status === "loaded" && rows.length === 0) {
+    return (
+      <Screen title={title} fill actions={actions}>
+        <EmptyState
+          className="flex-1"
+          title="No clusters yet"
+          hint="srelens reads your kubeconfig files in place. Connect a cluster and it appears here, with the file it came from beside it."
+          action={
+            <Button type="button" variant="primary" size="sm" onClick={() => openTab(CONNECT)}>
+              Connect a cluster
+            </Button>
+          }
+        />
+      </Screen>
+    );
+  }
+
+  if (status === "loading" && rows.length === 0) {
+    return (
+      <Screen title={title} fill actions={actions}>
+        <LoadingState label="Loading clusters" className="flex-1" />
+      </Screen>
+    );
+  }
+
+  // Nothing listed and a reason for it. The rows are the only thing this screen
+  // is about, so with none of them the failure takes the whole body.
+  if (rows.length === 0) {
+    return (
+      <Screen title={title} fill actions={actions}>
+        <FailureState
+          className="my-auto"
+          title="Could not list your clusters"
+          error={listError}
+          onRetry={() => void reload()}
+        />
+      </Screen>
+    );
+  }
+
+  return (
+    <Screen title={title} eyebrow={sub} fill actions={actions}>
+      {addError !== null && (
+        // `sev`: the reader asked for a file to be added and it was not. This
+        // is not a remark about the rows below it.
+        <FailureAlert
+          tone="sev"
+          className="mx-3 mt-3"
+          title="Could not add that kubeconfig file"
+          error={addError}
+        />
+      )}
+
+      {/* A refresh that failed over rows that are still there — a warning, not
+          a stop, per `errorCopy`'s rule. The rows are real; what this says is
+          that they may be older than the reader just asked for. */}
+      {status === "failed" && (
+        <FailureAlert className="mx-3 mt-3" title="Could not refresh your clusters" error={listError} />
+      )}
+
+      <div className="flex min-h-0 flex-1">
+        {/* `min-w-0`, and it is load-bearing. A flex item's implicit
+            `min-width: auto` refuses to shrink below its content, so without it
+            a table carrying a 70-character kubeconfig path pushes the rail's
+            fixed 292px off the window and the whole screen scrolls sideways.
+            Eight defects on this migration, and jsdom sees none of them — hence
+            the class assertion in the suite. */}
+        <div data-slot="connections-main" className="flex min-h-0 min-w-0 flex-1 flex-col">
+          {/* The scroll container is the caller's, which is this: `ClusterTable`
+              draws no box of its own, the way `Helm` hands its own table a
+              `scroll min-h-0 flex-1` wrapper. */}
+          <ClusterTable rows={rows} onOpen={open} className="scroll min-h-0 min-w-0 flex-1" />
+        </div>
+
+        {/* No wrapper: the rail is its own `aside.side-rail` at 292px. The same
+            `rows` the table has, so a reading cannot read one way here and
+            another way six inches to the left. */}
+        <SourcesRail
+          rows={rows}
+          files={files}
+          // **Passed whenever there is a filesystem to browse.** Absent, the
+          // rail says why there is no control rather than drawing a dead one.
+          onAddFile={desktop ? () => void addFile() : undefined}
+        />
+      </div>
+    </Screen>
+  );
+}

--- a/packages/ui-next/src/screens/Connections.tsx
+++ b/packages/ui-next/src/screens/Connections.tsx
@@ -76,10 +76,13 @@ const UNREAD: Probe = { state: "unread" };
  *    and one that never answers holds up none of the others.
  * 3. A late answer cannot paint over a fresh one, on both round trips. Helm's
  *    `listSeq` idiom, twice: once on the listing and once on the readings.
- * 4. `onAddFile` is passed whenever there is a filesystem to browse. The rail
- *    reads its absence as "there is none" and prints that instead of the
- *    control, so forgetting it here would lose the button on the desktop with
- *    nothing on screen saying why.
+ * 4. Both of the rail's platform facts are passed down. `onAddFile` is handed
+ *    over whenever there is a filesystem to browse — the rail reads its absence
+ *    as "there is none" and prints that instead of the control, so forgetting it
+ *    here would lose the button on the desktop with nothing on screen saying
+ *    why — and `desktop` is what lets its two headings say WHOSE machine the
+ *    kubeconfigs and the local clusters are on, which in web mode is the
+ *    server's host and not the reader's.
  */
 export function Connections({ route }: { route: string }) {
   // The routes table's own title, so the tab strip and the `h1` cannot drift.
@@ -393,9 +396,11 @@ export function Connections({ route }: { route: string }) {
   /**
    * The desktop's own question, asked once, here.
    *
-   * The rail takes a callback rather than asking itself, so both of its states
-   * are reachable from a fixture — `Toolbox.tsx:188` makes the same split for
-   * its install column.
+   * The rail takes a callback and a `desktop` flag rather than asking itself, so
+   * both of its states are reachable from a fixture — `Toolbox.tsx:188` makes
+   * the same split for its install column. It is asked once here and spent on
+   * two props, which is what keeps the file picker and the rail's "whose
+   * machine" headings from ever disagreeing about which build this is.
    */
   const desktop = isTauri();
 
@@ -526,6 +531,11 @@ export function Connections({ route }: { route: string }) {
           // **Passed whenever there is a filesystem to browse.** Absent, the
           // rail says why there is no control rather than drawing a dead one.
           onAddFile={desktop ? () => void addFile() : undefined}
+          // And whose machine the rail's two headings are about. A second prop
+          // rather than the rail reading `onAddFile`: one says what this caller
+          // can DO, the other where the reader IS, and the rail refuses to
+          // derive a location claim from a button (see its own note).
+          desktop={desktop}
         />
       </div>
     </Screen>

--- a/packages/ui-next/src/screens/Connections.tsx
+++ b/packages/ui-next/src/screens/Connections.tsx
@@ -27,16 +27,13 @@ import { ClusterTable, type ClusterRow } from "./connections/ClusterTable";
 import { SourcesRail } from "./connections/SourcesRail";
 
 /**
- * **The route the `Add connection` control opens — and the seam this screen
- * leaves for it.**
+ * **The route the `Add connection` control opens.**
  *
- * `/connect` is already in `lib/routes`'s app-scoped table (it has a title and
- * a tab kind), and it has no entry in that file's `SCREENS` map yet, so opening
- * it today lands on the `Placeholder`. That is deliberate: the tab, its title
- * and both ways in exist and are tested from here, and the next task adds one
- * line — `"/connect": Connect` in `SCREENS` — with nothing on this screen to
- * change. An import of a component that does not exist would not compile, and
- * a route invented here would be a second name for the one that table holds.
+ * `/connect` is in `lib/routes`'s app-scoped table, which gives it a title and
+ * a tab kind, and in that file's `SCREENS` map, which is what renders the
+ * first-run card rather than the `Placeholder`. Both entries live there and
+ * nothing about them is restated here: a route invented in this file would be a
+ * second name for the one that table holds.
  */
 const CONNECT = "/connect";
 

--- a/packages/ui-next/src/screens/Connections.tsx
+++ b/packages/ui-next/src/screens/Connections.tsx
@@ -102,8 +102,27 @@ export function Connections({ route }: { route: string }) {
   const files = getKubeconfigFiles();
   const { workspace } = useTabs();
 
-  /** Provider and region per cluster, from the second round trip. */
+  /**
+   * Provider and region per cluster, from the second round trip, **keyed by
+   * `stableId`**.
+   *
+   * The same key the probes are under and the same key the rows read. Not the
+   * context NAME, which is what `clusterFacts` is CALLED with: in production a
+   * stableId is the declaring file plus the name (it gains that prefix as soon
+   * as two kubeconfigs declare the same context), so keying the answers by name
+   * would file every cluster's facts under something no row looks up and empty
+   * the second line of every row on every platform. The suite carries a fixture
+   * whose stableId differs from its name so the two cannot be conflated.
+   */
   const [facts, setFacts] = useState<Record<string, ClusterFacts>>({});
+  /**
+   * The same record, readable synchronously.
+   *
+   * The decision "do we already have this cluster's facts" is made inside an
+   * async read, where the `facts` state variable is whatever it was when that
+   * read started. `putFacts` is the only writer of either.
+   */
+  const known = useRef<Record<string, ClusterFacts>>({});
   /** A listing asked for by the reader, still out. */
   const [busy, setBusy] = useState(false);
   /** Why a kubeconfig file could not be added, when one could not. */
@@ -120,30 +139,51 @@ export function Connections({ route }: { route: string }) {
   const listSeq = useRef(0);
 
   /**
-   * Which round of readings the work in flight belongs to.
+   * **Every guard below is per CLUSTER, and that is the whole design.**
    *
-   * The probes and the facts are per cluster and land one at a time, so a round
-   * that has been superseded — the reader re-listed while it was out — must not
-   * write what it finds. Bumped once per run of the effect below, which is once
-   * per listing.
+   * There was a round counter here, bumped once per listing, and it was the
+   * wrong unit for the work: a probe and a facts read belong to one cluster,
+   * and a re-listing says the LIST may have changed — not that a reading of a
+   * cluster still on it is worthless. Judging per-cluster work by a round
+   * number cost the facts outright. `listContexts` is a local file read and
+   * answers in a millisecond, so pressing `Refresh all` while twenty clusters
+   * are still connecting started a round that skipped every one of them (a read
+   * was already out) and abandoned every reader of the round before it (its
+   * round number had moved). Twenty rows settled `reachable` with no provider
+   * and no region, permanently, until a second `Refresh all` after the probes
+   * had landed. Nothing on screen said so — a row with no facts line is the
+   * ordinary first paint.
+   *
+   * It also made the screen depend on an invariant the store knows nothing
+   * about: "every write to the contexts store comes paired with `forceNext`".
+   * Any other writer — `Window` re-listing after a kubeconfig change — re-ran
+   * the effect, dropped whatever was in flight and then refused to ask again.
+   *
+   * So there is no round counter. A read is judged by two questions that are
+   * both about the cluster: is there already a read of THIS cluster out (join
+   * it), and is this the newest read of THIS cluster (only then may it write).
    */
-  const readSeq = useRef(0);
 
   /**
-   * The clusters being read right now.
+   * The facts read in flight per cluster, so every other reader joins it.
    *
-   * **This is what keeps two unordered writes of one cluster's reading from
-   * happening at all.** `probeCluster` writes to a module store this screen
-   * cannot un-write, so a sequence check after the fact could not undo a stale
-   * answer — a 30-second timeout from the first round would land on top of the
-   * second round's `12 ms` and the row would say `unreachable` about a cluster
-   * that had answered. A reading already on its way IS the fresh reading, so a
-   * second one is not started for it.
+   * **This is the whole ordering guard, and it works by there never being two.**
+   * The same shape as `probeCluster`'s own join, for the same reason: two reads
+   * of one cluster answering out of order would draw the older answer over the
+   * newer one, and no check after the fact can put that right. So a second read
+   * of a cluster is not started — a reader that wants the facts joins the read
+   * already out and gets its answer. With at most one read per cluster in
+   * flight, the writes cannot arrive out of order and there is nothing left for
+   * a sequence number to guard. (There was one here. It could not fire, and an
+   * unfireable guard is worse than none: it reads as protection.)
    */
-  const reading = useRef<Set<string>>(new Set());
+  const factsOut = useRef<Map<string, Promise<void>>>(new Map());
 
-  /** The clusters whose facts have been asked for in this round. */
-  const factsAsked = useRef<Set<string>>(new Set());
+  /** The one writer of the facts, state and synchronous mirror together. */
+  function putFacts(id: string, answer: ClusterFacts) {
+    known.current = { ...known.current, [id]: answer };
+    setFacts(known.current);
+  }
 
   /**
    * Whether the next round re-reads every cluster or only the unread ones.
@@ -203,30 +243,56 @@ export function Connections({ route }: { route: string }) {
   useEffect(() => {
     const force = forceNext.current;
     forceNext.current = false;
-    if (force) factsAsked.current.clear();
-    const seq = ++readSeq.current;
 
     async function read(context: ClusterContext) {
       const id = context.stableId;
-      // Its own reader will follow through to the facts — see `reading`.
-      if (reading.current.has(id)) return;
-      if (force || getProbe(id).state === "unread") {
-        reading.current.add(id);
-        try {
-          await probeCluster(context);
-        } finally {
-          reading.current.delete(id);
-        }
-        if (seq !== readSeq.current) return;
-      }
+      /**
+       * **Awaited, never skipped.**
+       *
+       * `probeCluster` joins the read already out for this cluster rather than
+       * starting a second (see its own note — the rule has to live there
+       * because `Window` probes too and neither caller can see the other's
+       * guard). So this `await` resolves when the reading is IN, whether this
+       * call took it or joined it, and the facts below are asked for either
+       * way. Walking away from a cluster whose read was already out is what
+       * left the facts unfetched whenever a read spanned two listings.
+       */
+      if (force || getProbe(id).state === "unread") await probeCluster(context);
+      // Not reachable: `provider` and `region` come from the API server, so
+      // asking buys a second timeout for a row that already says why it is
+      // empty. A later reading that DOES answer comes back through here.
       if (getProbe(id).state !== "reachable") return;
-      if (factsAsked.current.has(id)) return;
-      factsAsked.current.add(id);
-      // `clusterFacts` never rejects; a failure comes back as empty facts plus
-      // a reason, and the cell simply has nothing to add to the row.
-      const answer = await clusterFacts(context.name);
-      if (seq !== readSeq.current) return;
-      setFacts((current) => ({ ...current, [id]: answer }));
+
+      const out = factsOut.current.get(id);
+      /**
+       * A read already out is the answer arriving; joining it is what stops a
+       * second listing asking again for what the first is already fetching.
+       *
+       * **Joined even by a forced read**, which is not obvious. A facts read in
+       * flight was started when this cluster's reading landed, moments ago —
+       * there is no such thing as a stale one, so `Refresh all` has nothing to
+       * gain from a second round trip and the reader would pay for twenty of
+       * them. What `force` overrides is the line below: facts already IN HAND
+       * are re-read, because those can be as old as the window.
+       */
+      if (out) return out;
+      if (!force && known.current[id] !== undefined) return;
+
+      const run = (async () => {
+        // `clusterFacts` never rejects; a failure comes back as empty facts
+        // plus a reason, and the cell simply has nothing to add to the row.
+        const answer = await clusterFacts(context.name);
+        // Keyed by stableId — see `facts`. `clusterFacts` takes the NAME.
+        putFacts(id, answer);
+      })();
+      // Set before this reader yields, which is what makes the join above
+      // reliable rather than a matter of scheduling luck.
+      factsOut.current.set(id, run);
+      try {
+        await run;
+      } finally {
+        factsOut.current.delete(id);
+      }
     }
 
     for (const context of contexts) void read(context);
@@ -271,10 +337,17 @@ export function Connections({ route }: { route: string }) {
   /**
    * §6's sub: `<n> clusters · <n> sources`.
    *
-   * **Absent until there is something to count.** A number over a spinner, an
-   * error card or the `/connect` nudge would be a count of nothing asserted as
-   * a fact — the same fault as a count that disagrees with its rows, which is
-   * what `Releases · 383 in this cluster` over six rows was.
+   * **Absent until there is something to count, and this guard is what makes it
+   * so.** A number over a spinner, an error card or the `/connect` nudge would
+   * be a count of nothing asserted as a fact — the same fault as a count that
+   * disagrees with its rows, which is what `Releases · 383 in this cluster`
+   * over six rows was.
+   *
+   * Every `Screen` below is handed `eyebrow={sub}`, deliberately: the rule
+   * lives here, in one expression, rather than in which of four call sites
+   * remembered to leave the prop off. It was the other way round and the guard
+   * was dead code — the early returns were doing the work, so removing this
+   * `rows.length > 0` cost nothing and no test noticed.
    */
   const sub =
     rows.length > 0 ? `${plural(rows.length, "cluster")} · ${plural(sources, "source")}` : undefined;
@@ -364,7 +437,7 @@ export function Connections({ route }: { route: string }) {
    */
   if (status === "loaded" && rows.length === 0) {
     return (
-      <Screen title={title} fill actions={actions}>
+      <Screen title={title} eyebrow={sub} fill actions={actions}>
         <EmptyState
           className="flex-1"
           title="No clusters yet"
@@ -381,7 +454,7 @@ export function Connections({ route }: { route: string }) {
 
   if (status === "loading" && rows.length === 0) {
     return (
-      <Screen title={title} fill actions={actions}>
+      <Screen title={title} eyebrow={sub} fill actions={actions}>
         <LoadingState label="Loading clusters" className="flex-1" />
       </Screen>
     );
@@ -391,7 +464,7 @@ export function Connections({ route }: { route: string }) {
   // is about, so with none of them the failure takes the whole body.
   if (rows.length === 0) {
     return (
-      <Screen title={title} fill actions={actions}>
+      <Screen title={title} eyebrow={sub} fill actions={actions}>
         <FailureState
           className="my-auto"
           title="Could not list your clusters"

--- a/packages/ui-next/src/screens/Events.test.tsx
+++ b/packages/ui-next/src/screens/Events.test.tsx
@@ -54,6 +54,8 @@ const CTX: ClusterContext = {
   cluster: "prod",
   server: "https://prod",
   isCurrent: true,
+  sourceFile: "/home/dana/.kube/config",
+  authKind: "client certificate",
 };
 
 /**

--- a/packages/ui-next/src/screens/Helm.test.tsx
+++ b/packages/ui-next/src/screens/Helm.test.tsx
@@ -64,6 +64,8 @@ const CTX: ClusterContext = {
   server: "https://prod",
   isCurrent: true,
   namespace: "platform",
+  sourceFile: "/home/u/.config/srelens/imported.yaml",
+  authKind: "client certificate",
 };
 
 const DAY = 86_400_000;
@@ -1476,6 +1478,8 @@ describe("Helm — a dialog open across a cluster switch", () => {
     server: "https://stage",
     isCurrent: false,
     namespace: "default",
+    sourceFile: "/home/u/work/kubeconfig.yaml",
+    authKind: "client certificate",
   };
 
   /** The screen on a window that has both clusters, opened on `prod-eu`. */

--- a/packages/ui-next/src/screens/Logs.test.tsx
+++ b/packages/ui-next/src/screens/Logs.test.tsx
@@ -152,6 +152,8 @@ const CTX: ClusterContext = {
   cluster: "prod",
   server: "https://prod",
   isCurrent: true,
+  sourceFile: "/home/dana/.kube/config",
+  authKind: "client certificate",
 };
 
 /**

--- a/packages/ui-next/src/screens/Overview.test.tsx
+++ b/packages/ui-next/src/screens/Overview.test.tsx
@@ -70,6 +70,8 @@ const CTX: ClusterContext = {
   cluster: "prod",
   server: "https://prod",
   isCurrent: true,
+  sourceFile: "/home/u/.kube/config",
+  authKind: "client certificate",
 };
 
 const ROUTE = "/overview";

--- a/packages/ui-next/src/screens/Resources.test.tsx
+++ b/packages/ui-next/src/screens/Resources.test.tsx
@@ -148,6 +148,8 @@ const CTX: ClusterContext = {
   cluster: "prod",
   server: "https://prod",
   isCurrent: true,
+  sourceFile: "/home/dana/.kube/config",
+  authKind: "client certificate",
 };
 
 const PODS = [

--- a/packages/ui-next/src/screens/Terminals.test.tsx
+++ b/packages/ui-next/src/screens/Terminals.test.tsx
@@ -60,6 +60,8 @@ const CTX: ClusterContext = {
   cluster: "prod",
   server: "https://prod",
   isCurrent: true,
+  sourceFile: "/home/dana/.kube/config",
+  authKind: "client certificate",
 };
 
 /** jsdom has no `matchMedia`; xterm's `CoreBrowserService` reads it on open(). */

--- a/packages/ui-next/src/screens/Toolbox.test.tsx
+++ b/packages/ui-next/src/screens/Toolbox.test.tsx
@@ -42,6 +42,8 @@ const CTX: ClusterContext = {
   cluster: "prod",
   server: "https://prod",
   isCurrent: true,
+  sourceFile: "/home/dana/.kube/config",
+  authKind: "client certificate",
 };
 
 /**

--- a/packages/ui-next/src/screens/Workloads.test.tsx
+++ b/packages/ui-next/src/screens/Workloads.test.tsx
@@ -48,6 +48,8 @@ const CTX: ClusterContext = {
   cluster: "prod",
   server: "https://prod",
   isCurrent: true,
+  sourceFile: "/home/dana/.kube/config",
+  authKind: "client certificate",
 };
 
 // One row per kind, deliberately with ages that interleave across kinds

--- a/packages/ui-next/src/screens/connections/ClusterTable.test.tsx
+++ b/packages/ui-next/src/screens/connections/ClusterTable.test.tsx
@@ -379,4 +379,60 @@ describe("ClusterTable", () => {
     expect(frame.className).toContain("min-w-0");
     expect(frame.className).toContain("flex-1");
   });
+  /**
+   * **Which end a cluster with no reading sorts to, in both directions.**
+   *
+   * There was no test for this column's order at all, and the comment beside
+   * `latencySort` claimed the wrong thing — that an unread cluster "sorts last
+   * however the column is turned". `Table` compares numbers as `left - right`
+   * and multiplies the result by `-1` for a descending column, so a sentinel
+   * above every reading LEADS the list when the reader reverses it. These pin
+   * what actually happens, so the sentence and the behaviour cannot drift apart
+   * again.
+   */
+  describe("the Latency column's order", () => {
+    const mixed: { context: ClusterContext; probe: Probe }[] = [
+      { context: ctx({ stableId: "a#alpha", name: "alpha" }), probe: { state: "reachable", latencyMs: 41 } },
+      { context: ctx({ stableId: "b#bravo", name: "bravo" }), probe: { state: "unread" } },
+      { context: ctx({ stableId: "c#charlie", name: "charlie" }), probe: { state: "reachable", latencyMs: 12 } },
+      // Unreachable, and so also without a reading: `latencyLabel` gates on the
+      // state as well as on the number.
+      { context: ctx({ stableId: "d#delta", name: "delta" }), probe: { state: "unreachable", error: "no route" } },
+    ];
+    const order = () => screen.getAllByTestId(/^cluster-name-/).map((el) => el.textContent);
+    const byLatency = () => screen.getByRole("button", { name: "Sort by Latency" });
+
+    it("puts a cluster with no reading after every reading, ascending", async () => {
+      render(<ClusterTable rows={mixed} onOpen={() => {}} />);
+      await userEvent.click(byLatency());
+      expect(order()).toEqual(["charlie", "alpha", "bravo", "delta"]);
+    });
+
+    it("and before them when the column is reversed", async () => {
+      render(<ClusterTable rows={mixed} onOpen={() => {}} />);
+      await userEvent.click(byLatency());
+      await userEvent.click(byLatency());
+      expect(order()).toEqual(["bravo", "delta", "alpha", "charlie"]);
+    });
+
+    /**
+     * The ordinary first paint is every cluster unread, so this is the case the
+     * column meets most often. `Infinity - Infinity` is `NaN`, which the kit
+     * treats as "equal" only because NaN is falsy; the sentinel is
+     * `Number.MAX_VALUE` so the comparison is `0` and that stable tiebreak is
+     * reached on purpose.
+     */
+    it("keeps clusters with no reading in the order they were given", async () => {
+      const unread: { context: ClusterContext; probe: Probe }[] = [
+        { context: ctx({ stableId: "a#alpha", name: "alpha" }), probe: { state: "unread" } },
+        { context: ctx({ stableId: "b#bravo", name: "bravo" }), probe: { state: "unread" } },
+        { context: ctx({ stableId: "c#charlie", name: "charlie" }), probe: { state: "unread" } },
+      ];
+      render(<ClusterTable rows={unread} onOpen={() => {}} />);
+      await userEvent.click(byLatency());
+      expect(order()).toEqual(["alpha", "bravo", "charlie"]);
+      await userEvent.click(byLatency());
+      expect(order()).toEqual(["alpha", "bravo", "charlie"]);
+    });
+  });
 });

--- a/packages/ui-next/src/screens/connections/ClusterTable.test.tsx
+++ b/packages/ui-next/src/screens/connections/ClusterTable.test.tsx
@@ -474,6 +474,48 @@ describe("ClusterTable", () => {
     expect(cell.firstElementChild?.className).toContain("shrink-0");
   });
 
+  /**
+   * **`Open` stays on screen at the window the app actually opens at.**
+   *
+   * Measured in Chrome against a real kubeconfig: the seven columns sum to
+   * 1082px, the pane is 1014px wide at a 1600px window, and `Open`'s rect was
+   * x=1311…1355 against a visible right edge of 1308 — off screen on every one
+   * of seventeen rows, with the window having to reach 1668px before the button
+   * appeared. Enter and double-click still opened the row, so the ACTION was
+   * reachable and the CONTROL was not. At the 960px minimum the pane is 374px
+   * and the overflow 711px, which is why the column is pinned rather than
+   * capped: a cap fits one window and cannot fit both.
+   *
+   * **jsdom has no layout, so this asserts the plumbing only** — that the
+   * action column asks the kit to pin it, and that the kit's attribute reaches
+   * the header and every row's cell. The rects are browser facts, in the task
+   * report; nothing here can stand in for them.
+   */
+  it("pins the action column to the end of the table, so its control cannot leave the pane", () => {
+    const { container } = render(
+      <ClusterTable
+        rows={[
+          { context: ctx(), probe: { state: "unread" } },
+          { context: ctx({ stableId: "b#staging", name: "staging" }), probe: { state: "unread" } },
+        ]}
+        onOpen={() => {}}
+      />,
+    );
+
+    // The last column, and only it: one header cell and one cell per row.
+    const pinned = [...container.querySelectorAll('[data-sticky="end"]')];
+    expect(pinned.map((el) => el.tagName)).toEqual(["TH", "TD", "TD"]);
+    // Each pinned cell is the one holding that row's `Open`.
+    for (const cell of pinned.slice(1)) {
+      expect(cell.querySelector("button")?.textContent).toBe("Open");
+    }
+    // And it is the LAST cell of its row — a column pinned to the end that is
+    // not at the end would sit over the columns after it.
+    for (const cell of pinned.slice(1)) {
+      expect(cell.nextElementSibling).toBeNull();
+    }
+  });
+
   it("keeps its own frame shrinkable, and takes the caller's classes", () => {
     render(
       <ClusterTable

--- a/packages/ui-next/src/screens/connections/ClusterTable.test.tsx
+++ b/packages/ui-next/src/screens/connections/ClusterTable.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import type { ClusterContext, ClusterFacts } from "@srelens/core";
 import type { Probe } from "../../lib/probe";
 import { ClusterTable } from "./ClusterTable";
+import { STATUS } from "./clusterText";
 
 const ctx = (over: Partial<ClusterContext> = {}): ClusterContext => ({
   name: "prod-eu",
@@ -434,5 +435,34 @@ describe("ClusterTable", () => {
       await userEvent.click(byLatency());
       expect(order()).toEqual(["alpha", "bravo", "charlie"]);
     });
+  });
+});
+
+/**
+ * The vocabulary itself, pinned once at the one place it now lives.
+ *
+ * `ClusterTable` and `Connect` each held a private copy of this table and each
+ * pinned it through what they render, so the words were asserted twice and the
+ * table that produced them not at all. Both render assertions stay — they are
+ * what proves each screen reaches for this and tones a real badge with it — and
+ * this one is what a reader who edits the table has to get past first.
+ */
+describe("the status vocabulary", () => {
+  it("is reachable, unreachable, and the absence named as one", () => {
+    expect(STATUS.reachable).toEqual({ word: "reachable", tone: "ok" });
+    expect(STATUS.unreachable).toEqual({ word: "unreachable", tone: "sev" });
+    // Not "pending" or "idle": those read as things the cluster is, and this is
+    // a thing srelens has not done yet.
+    expect(STATUS.unread).toEqual({ word: "no reading", tone: "muted" });
+  });
+
+  it("never calls a cluster healthy or degraded, whichever screen reads it", () => {
+    // Spec decision 3, and the reason this table exists rather than §6's mock
+    // pairing: the probe reports whether the API server answered, and no word
+    // here may claim a health check that never ran. Asserted over every entry
+    // so a fourth state added later cannot smuggle one in.
+    for (const status of Object.values(STATUS)) {
+      expect(status.word).not.toMatch(/healthy|degraded/i);
+    }
   });
 });

--- a/packages/ui-next/src/screens/connections/ClusterTable.test.tsx
+++ b/packages/ui-next/src/screens/connections/ClusterTable.test.tsx
@@ -301,6 +301,112 @@ describe("ClusterTable", () => {
     expect(names).toEqual(["prod-eu", "staging", "kind-dev", "k3d-lab"]);
   });
 
+  /**
+   * **A boundary a reader can see, and one that cannot come to lie.**
+   *
+   * The rows were correctly ordered — fourteen kubeconfig contexts, then three
+   * local clusters, never interleaved — with no header, no rule and no change of
+   * spacing between the two groups. On a real kubeconfig the only cue was the
+   * `Source` cell's text changing at row 15 of 17, which is invisible in
+   * practice; §6 asks for rows GROUPED by credential source, and ordering alone
+   * does not deliver grouping. The rail beside it heads its own sections, which
+   * made the table's silence read as an oversight.
+   *
+   * The heading holds only while the table is in its grouped order. Sorting by
+   * `Latency` scatters the two sources through one another, so the headings go —
+   * the reader sees the grouping stop, and the `Source` column is what still
+   * says where each row comes from. A heading left in place over a sorted list
+   * would be worse than none, which is why the kit drops them rather than this
+   * screen remembering to.
+   */
+  describe("the group boundary", () => {
+    /** Two of each, interleaved on the way in so the order is the table's doing. */
+    const two = [
+      { context: ctx({ stableId: "a#prod", name: "prod-eu" }), probe: { state: "reachable" as const, latencyMs: 41 } },
+      {
+        context: ctx({ stableId: "b#kind", name: "kind-dev", isLocal: true, provider: "kind" }),
+        probe: { state: "reachable" as const, latencyMs: 3 },
+      },
+      { context: ctx({ stableId: "c#staging", name: "staging" }), probe: { state: "reachable" as const, latencyMs: 12 } },
+      {
+        context: ctx({ stableId: "d#k3d", name: "k3d-lab", isLocal: true, provider: "k3d" }),
+        probe: { state: "reachable" as const, latencyMs: 1 },
+      },
+    ];
+
+    const boundaries = (container: HTMLElement) =>
+      [...container.querySelectorAll('[data-slot="table-group"]')].map((el) => el.textContent);
+    const order = () => screen.getAllByTestId(/^cluster-name-/).map((el) => el.textContent);
+    /** The `Source` cell of one row — the second cell, on its own. */
+    const source = (stableId: string) =>
+      screen.getByTestId(`cluster-name-${stableId}`).closest("tr")?.children[1]?.textContent;
+
+    it("heads each group with the word the Source cells under it use, and how many there are", () => {
+      const { container } = render(<ClusterTable rows={two} onOpen={() => {}} />);
+      // Read from the cells rather than restated, so a heading cannot come to
+      // say something the column under it does not.
+      expect(boundaries(container)).toEqual([
+        `${source("a#prod")} · 2 clusters`,
+        `${source("b#kind")} · 2 clusters`,
+      ]);
+      expect(boundaries(container)).toEqual(["Kubeconfig · 2 clusters", "Local · 2 clusters"]);
+    });
+
+    it("puts each boundary directly above the first row of its group", () => {
+      const { container } = render(<ClusterTable rows={two} onOpen={() => {}} />);
+      const body = [...(container.querySelectorAll("tbody tr") ?? [])].map((tr) =>
+        tr.getAttribute("data-slot") === "table-group"
+          ? `GROUP ${tr.textContent}`
+          : (tr.querySelector('[data-testid^="cluster-name-"]')?.textContent ?? "?"),
+      );
+      expect(body).toEqual([
+        "GROUP Kubeconfig · 2 clusters",
+        "prod-eu",
+        "staging",
+        "GROUP Local · 2 clusters",
+        "kind-dev",
+        "k3d-lab",
+      ]);
+    });
+
+    it("counts the rows in its own group, not the whole list", () => {
+      const { container } = render(
+        <ClusterTable
+          rows={[two[0], two[1], two[2], { context: ctx({ stableId: "e#edge", name: "edge-1" }), probe: { state: "unread" } }]}
+          onOpen={() => {}}
+        />,
+      );
+      // Three kubeconfig contexts and one local cluster — and `1 cluster`
+      // singular, through core's own `plural`.
+      expect(boundaries(container)).toEqual(["Kubeconfig · 3 clusters", "Local · 1 cluster"]);
+    });
+
+    it("stops the grouping visibly when the reader sorts, rather than heading a list that has moved", async () => {
+      const { container } = render(<ClusterTable rows={two} onOpen={() => {}} />);
+      expect(boundaries(container)).toHaveLength(2);
+
+      await userEvent.click(screen.getByRole("button", { name: "Sort by Latency" }));
+
+      // The two sources are now interleaved — which is exactly why no heading
+      // may survive it.
+      expect(order()).toEqual(["k3d-lab", "kind-dev", "staging", "prod-eu"]);
+      expect(source("d#k3d")).toBe("Local");
+      expect(source("c#staging")).toBe("Kubeconfig");
+      expect(boundaries(container)).toEqual([]);
+    });
+
+    it("brings the boundary back when the reader clears the sort", async () => {
+      const { container } = render(<ClusterTable rows={two} onOpen={() => {}} />);
+      const byLatency = screen.getByRole("button", { name: "Sort by Latency" });
+      await userEvent.click(byLatency); // ascending
+      await userEvent.click(byLatency); // descending
+      expect(boundaries(container)).toEqual([]);
+      await userEvent.click(byLatency); // cleared — the grouped order is back
+      expect(boundaries(container)).toEqual(["Kubeconfig · 2 clusters", "Local · 2 clusters"]);
+      expect(order()).toEqual(["prod-eu", "staging", "kind-dev", "k3d-lab"]);
+    });
+  });
+
   it("opens the cluster the row belongs to", async () => {
     const onOpen = vi.fn();
     render(<ClusterTable rows={[{ context: ctx(), probe: { state: "unread" } }]} onOpen={onOpen} />);

--- a/packages/ui-next/src/screens/connections/ClusterTable.test.tsx
+++ b/packages/ui-next/src/screens/connections/ClusterTable.test.tsx
@@ -1,0 +1,382 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ClusterContext, ClusterFacts } from "@srelens/core";
+import type { Probe } from "../../lib/probe";
+import { ClusterTable } from "./ClusterTable";
+
+const ctx = (over: Partial<ClusterContext> = {}): ClusterContext => ({
+  name: "prod-eu",
+  stableId: "prod-eu",
+  cluster: "prod",
+  server: "https://prod:6443",
+  namespace: "",
+  isCurrent: false,
+  isLocal: false,
+  sourceFile: "/home/dana/.kube/config",
+  authKind: "exec plugin · gcloud",
+  ...over,
+});
+
+/** `clusterFacts`'s own shape: provider and region are strings, empty when unread. */
+const facts = (over: Partial<ClusterFacts> = {}): ClusterFacts => ({
+  context: "prod-eu",
+  provider: "gke",
+  region: "europe-west4",
+  metricsServer: { state: "present", version: "v0.7.1" },
+  ...over,
+});
+
+describe("ClusterTable", () => {
+  it("names the file a kubeconfig context came from", () => {
+    render(<ClusterTable rows={[{ context: ctx(), probe: { state: "unread" } }]} onOpen={() => {}} />);
+    expect(screen.getByText("/home/dana/.kube/config")).toBeTruthy();
+  });
+
+  it("shows no latency for a cluster it has not read", () => {
+    render(<ClusterTable rows={[{ context: ctx(), probe: { state: "unread" } }]} onOpen={() => {}} />);
+    expect(screen.queryByText(/0\s*ms/)).toBeNull();
+  });
+
+  it("shows no latency for a cluster that did not answer", () => {
+    render(
+      <ClusterTable
+        rows={[{ context: ctx(), probe: { state: "unreachable", error: "…" } }]}
+        onOpen={() => {}}
+      />,
+    );
+    expect(screen.queryByText(/0\s*ms/)).toBeNull();
+    expect(screen.queryByText(/\d+\s*ms/)).toBeNull();
+  });
+
+  /**
+   * The guard the column needs that the two tests above cannot give it: a
+   * probe carrying `latencyMs: 0` ALONGSIDE a state that is not "reachable".
+   *
+   * `probe.ts` documents latency as absent unless the state is "reachable", so
+   * this shape should not exist — but the table is the thing a reader trusts,
+   * and a drift in the store (or a future prober that reports a timed-out
+   * round trip as its elapsed time) must not become `0 ms` on screen. Gating
+   * on the state as well as the number is what makes it structural.
+   */
+  it("shows no latency for a zero reading on a cluster that did not answer", () => {
+    render(
+      <ClusterTable
+        rows={[{ context: ctx(), probe: { state: "unreachable", latencyMs: 0, error: "…" } }]}
+        onOpen={() => {}}
+      />,
+    );
+    expect(screen.queryByText(/0\s*ms/)).toBeNull();
+    expect(screen.queryByText(/\d+\s*ms/)).toBeNull();
+  });
+
+  it("shows the round trip it timed for a cluster that answered", () => {
+    render(
+      <ClusterTable
+        rows={[{ context: ctx(), probe: { state: "reachable", latencyMs: 12 } }]}
+        onOpen={() => {}}
+      />,
+    );
+    expect(screen.getByText("12 ms")).toBeTruthy();
+  });
+
+  /**
+   * A cluster on this laptop can answer in under half a millisecond. That is a
+   * real reading and is not thrown away — but rounding it would print the one
+   * string this column may never show, so it is drawn as a bound instead.
+   */
+  it("draws a sub-millisecond round trip as a bound rather than as zero", () => {
+    render(
+      <ClusterTable
+        rows={[{ context: ctx(), probe: { state: "reachable", latencyMs: 0.4 } }]}
+        onOpen={() => {}}
+      />,
+    );
+    expect(screen.getByText("<1 ms")).toBeTruthy();
+    expect(screen.queryByText(/\b0\s*ms/)).toBeNull();
+  });
+
+  it("opens a row from the keyboard as well as from its button", async () => {
+    const onOpen = vi.fn();
+    render(<ClusterTable rows={[{ context: ctx(), probe: { state: "unread" } }]} onOpen={onOpen} />);
+    await userEvent.dblClick(screen.getByTestId("cluster-name-prod-eu"));
+    expect(onOpen).toHaveBeenCalledWith("prod-eu");
+  });
+
+  it("never calls a cluster healthy or degraded", () => {
+    render(
+      <ClusterTable
+        rows={[
+          { context: ctx(), probe: { state: "reachable", latencyMs: 12 } },
+          { context: ctx({ stableId: "b", name: "b" }), probe: { state: "unreachable", error: "…" } },
+        ]}
+        onOpen={() => {}}
+      />,
+    );
+    expect(screen.queryByText(/healthy|degraded/i)).toBeNull();
+  });
+
+  it("says what the probe said, and tones it without a health claim", () => {
+    render(
+      <ClusterTable
+        rows={[
+          { context: ctx(), probe: { state: "reachable", latencyMs: 12 } },
+          { context: ctx({ stableId: "b", name: "b" }), probe: { state: "unreachable", error: "…" } },
+          { context: ctx({ stableId: "c", name: "c" }), probe: { state: "unread" } },
+        ]}
+        onOpen={() => {}}
+      />,
+    );
+    expect(screen.getByText("reachable").getAttribute("data-tone")).toBe("ok");
+    expect(screen.getByText("unreachable").getAttribute("data-tone")).toBe("sev");
+    // The absence, named as an absence — not a status word invented for it.
+    expect(screen.getByText("no reading").getAttribute("data-tone")).toBe("muted");
+  });
+
+  it("never labels a source Team server", () => {
+    render(<ClusterTable rows={[{ context: ctx(), probe: { state: "unread" } }]} onOpen={() => {}} />);
+    expect(screen.queryByText(/team server/i)).toBeNull();
+  });
+
+  it("calls a kubeconfig context's source Kubeconfig and a local cluster's Local", () => {
+    render(
+      <ClusterTable
+        rows={[
+          { context: ctx(), probe: { state: "unread" } },
+          {
+            context: ctx({ stableId: "kind-dev", name: "kind-dev", isLocal: true, provider: "kind" }),
+            probe: { state: "unread" },
+          },
+        ]}
+        onOpen={() => {}}
+      />,
+    );
+    expect(screen.getByText("Kubeconfig")).toBeTruthy();
+    expect(screen.getByText("Local")).toBeTruthy();
+  });
+
+  it("assembles the second line from only the parts it has", () => {
+    render(
+      <ClusterTable
+        rows={[{ context: ctx(), probe: { state: "reachable", latencyMs: 5, version: "v1.29.4" } }]}
+        onOpen={() => {}}
+      />,
+    );
+    const line = screen.getByTestId("cluster-detail-prod-eu").textContent ?? "";
+    expect(line).toContain("v1.29.4");
+    expect(line).not.toMatch(/·\s*·/); // no bare separators for absent parts
+  });
+
+  it("joins provider, version and region in that order when it has all three", () => {
+    render(
+      <ClusterTable
+        rows={[
+          {
+            context: ctx(),
+            probe: { state: "reachable", latencyMs: 5, version: "v1.29.4" },
+            facts: facts(),
+          },
+        ]}
+        onOpen={() => {}}
+      />,
+    );
+    expect(screen.getByTestId("cluster-detail-prod-eu").textContent).toBe(
+      "gke · v1.29.4 · europe-west4",
+    );
+  });
+
+  it("drops the separator around a part the facts do not carry", () => {
+    render(
+      <ClusterTable
+        rows={[
+          {
+            context: ctx(),
+            probe: { state: "reachable", latencyMs: 5, version: "v1.29.4" },
+            // `clusterFacts` normalises an unread fact to "", not to absent.
+            facts: facts({ region: "" }),
+          },
+        ]}
+        onOpen={() => {}}
+      />,
+    );
+    expect(screen.getByTestId("cluster-detail-prod-eu").textContent).toBe("gke · v1.29.4");
+  });
+
+  it("renders no second line at all when it has none of the three", () => {
+    render(<ClusterTable rows={[{ context: ctx(), probe: { state: "unread" } }]} onOpen={() => {}} />);
+    // Not an empty line, and not a lone separator: nothing.
+    expect(screen.queryByTestId("cluster-detail-prod-eu")).toBeNull();
+  });
+
+  it("routes a local cluster through its provider and the host it answers on", () => {
+    render(
+      <ClusterTable
+        rows={[
+          {
+            context: ctx({
+              stableId: "kind-dev",
+              name: "kind-dev",
+              isLocal: true,
+              provider: "kind",
+              server: "https://127.0.0.1:6443",
+            }),
+            probe: { state: "unread" },
+          },
+        ]}
+        onOpen={() => {}}
+      />,
+    );
+    expect(screen.getByText("kind · 127.0.0.1:6443")).toBeTruthy();
+    // The kubeconfig path is NOT what a local cluster is reached through.
+    expect(screen.queryByText("/home/dana/.kube/config")).toBeNull();
+  });
+
+  it("names a local cluster by its host alone when no provider was detected", () => {
+    render(
+      <ClusterTable
+        rows={[
+          {
+            context: ctx({
+              stableId: "local",
+              name: "local",
+              isLocal: true,
+              server: "https://127.0.0.1:6443",
+            }),
+            probe: { state: "unread" },
+          },
+        ]}
+        onOpen={() => {}}
+      />,
+    );
+    expect(screen.getByText("127.0.0.1:6443")).toBeTruthy();
+    expect(screen.queryByText(/^·|·$/)).toBeNull();
+  });
+
+  it("falls back to the server as written when it is not a URL", () => {
+    render(
+      <ClusterTable
+        rows={[
+          {
+            context: ctx({ stableId: "odd", name: "odd", isLocal: true, server: "not-a-url" }),
+            probe: { state: "unread" },
+          },
+        ]}
+        onOpen={() => {}}
+      />,
+    );
+    expect(screen.getByText("not-a-url")).toBeTruthy();
+  });
+
+  it("names the credential mechanism the context uses", () => {
+    render(<ClusterTable rows={[{ context: ctx(), probe: { state: "unread" } }]} onOpen={() => {}} />);
+    expect(screen.getByText("exec plugin · gcloud")).toBeTruthy();
+  });
+
+  /**
+   * §6 groups `team` → `file` → `local`, and with the team server out of scope
+   * that is kubeconfig before local — the order Pane 2 lists its sections in
+   * too. The requirement is that the two groups do not interleave; the order
+   * between them follows the design (see `bySource`).
+   */
+  it("groups kubeconfig contexts ahead of local clusters, keeping each group's order", () => {
+    render(
+      <ClusterTable
+        rows={[
+          { context: ctx({ stableId: "prod-eu", name: "prod-eu" }), probe: { state: "unread" } },
+          {
+            context: ctx({ stableId: "kind-dev", name: "kind-dev", isLocal: true, provider: "kind" }),
+            probe: { state: "unread" },
+          },
+          { context: ctx({ stableId: "staging", name: "staging" }), probe: { state: "unread" } },
+          {
+            context: ctx({ stableId: "k3d-lab", name: "k3d-lab", isLocal: true, provider: "k3d" }),
+            probe: { state: "unread" },
+          },
+        ]}
+        onOpen={() => {}}
+      />,
+    );
+    const names = screen.getAllByTestId(/^cluster-name-/).map((el) => el.textContent);
+    expect(names).toEqual(["prod-eu", "staging", "kind-dev", "k3d-lab"]);
+  });
+
+  it("opens the cluster the row belongs to", async () => {
+    const onOpen = vi.fn();
+    render(<ClusterTable rows={[{ context: ctx(), probe: { state: "unread" } }]} onOpen={onOpen} />);
+    await userEvent.click(screen.getByRole("button", { name: "Open" }));
+    expect(onOpen).toHaveBeenCalledWith("prod-eu");
+  });
+
+  it("opens the row that was clicked, not the first one", async () => {
+    const onOpen = vi.fn();
+    render(
+      <ClusterTable
+        rows={[
+          { context: ctx(), probe: { state: "unread" } },
+          { context: ctx({ stableId: "staging#name", name: "staging" }), probe: { state: "unread" } },
+        ]}
+        onOpen={onOpen}
+      />,
+    );
+    await userEvent.click(screen.getAllByRole("button", { name: "Open" })[1]);
+    // The stableId, which is `{file}#{name}` in production — never the name.
+    expect(onOpen).toHaveBeenCalledWith("staging#name");
+  });
+
+  /**
+   * **The `min-width: auto` guard, asserted on the classes because jsdom
+   * cannot see it.** Eight defects on this migration. `Via` holds a full
+   * filesystem path and `Cluster` a display name, both beside §6's fixed 292px
+   * rail: without a cap the cell's intrinsic width is the whole string, and
+   * a flex item's implicit `min-width: auto` refuses to shrink below it, so
+   * the rail is pushed off the window instead. `block` is what makes
+   * `truncate`'s `overflow: hidden` apply at all — it does nothing on an
+   * inline box.
+   */
+  it("caps and truncates the two cells that hold unbounded text", () => {
+    render(
+      <ClusterTable
+        rows={[
+          {
+            context: ctx({
+              sourceFile: "/Users/dana/Library/Application Support/srelens/kubeconfigs/acme-prod.yaml",
+            }),
+            probe: { state: "unread" },
+          },
+        ]}
+        onOpen={() => {}}
+      />,
+    );
+
+    const via = screen.getByTestId("cluster-via-prod-eu");
+    expect(via.className).toContain("block");
+    expect(via.className).toMatch(/max-w-\[\d+px\]/);
+    expect(via.className).toContain("truncate");
+
+    const name = screen.getByTestId("cluster-name-prod-eu");
+    expect(name.className).toContain("block");
+    expect(name.className).toMatch(/max-w-\[\d+px\]/);
+    expect(name.className).toContain("truncate");
+
+    // The flex row that holds the mark beside the name, and the text column
+    // inside it: both need `min-w-0` or the truncation above never engages.
+    const cell = screen.getByTestId("cluster-cell-prod-eu");
+    expect(cell.className).toContain("min-w-0");
+    expect(name.parentElement?.className).toContain("min-w-0");
+    // The mark is the one thing in the row that may not be squeezed away.
+    expect(cell.firstElementChild?.className).toContain("shrink-0");
+  });
+
+  it("keeps its own frame shrinkable, and takes the caller's classes", () => {
+    render(
+      <ClusterTable
+        rows={[{ context: ctx(), probe: { state: "unread" } }]}
+        onOpen={() => {}}
+        className="flex-1"
+      />,
+    );
+    const frame = screen.getByTestId("cluster-table");
+    expect(frame.className).toContain("min-w-0");
+    expect(frame.className).toContain("flex-1");
+  });
+});

--- a/packages/ui-next/src/screens/connections/ClusterTable.test.tsx
+++ b/packages/ui-next/src/screens/connections/ClusterTable.test.tsx
@@ -34,9 +34,26 @@ describe("ClusterTable", () => {
     expect(screen.getByText("/home/dana/.kube/config")).toBeTruthy();
   });
 
+  /**
+   * **The placeholder is asserted as an ELEMENT, not as absent digits.**
+   *
+   * Every "no latency" assertion here used to be `queryByText(/\d+\s*ms/)`
+   * alone, and `return null` in place of the column's whole null branch — the
+   * documented em-dash gone — passed all 82 tests. An absence of digits is
+   * satisfied by an empty cell just as well as by the placeholder, so it
+   * cannot tell "srelens has no reading" apart from "srelens forgot to say
+   * so". {@link noReading} reads the dash's own node, and the exact character
+   * is part of it: this project's absent-not-zero rule is about the reader
+   * seeing that a figure is MISSING rather than seeing nothing at all.
+   */
+  function noReading(): HTMLElement {
+    return screen.getByTitle("no reading");
+  }
+
   it("shows no latency for a cluster it has not read", () => {
     render(<ClusterTable rows={[{ context: ctx(), probe: { state: "unread" } }]} onOpen={() => {}} />);
-    expect(screen.queryByText(/0\s*ms/)).toBeNull();
+    expect(screen.queryByText(/\d+\s*ms/)).toBeNull();
+    expect(noReading().textContent).toBe("—");
   });
 
   it("shows no latency for a cluster that did not answer", () => {
@@ -48,6 +65,7 @@ describe("ClusterTable", () => {
     );
     expect(screen.queryByText(/0\s*ms/)).toBeNull();
     expect(screen.queryByText(/\d+\s*ms/)).toBeNull();
+    expect(noReading().textContent).toBe("—");
   });
 
   /**
@@ -69,6 +87,9 @@ describe("ClusterTable", () => {
     );
     expect(screen.queryByText(/0\s*ms/)).toBeNull();
     expect(screen.queryByText(/\d+\s*ms/)).toBeNull();
+    // And the cell says so rather than standing empty — a blank where a
+    // figure belongs reads as a bug, not as "nothing has read this cluster".
+    expect(noReading().textContent).toBe("—");
   });
 
   it("shows the round trip it timed for a cluster that answered", () => {
@@ -79,6 +100,9 @@ describe("ClusterTable", () => {
       />,
     );
     expect(screen.getByText("12 ms")).toBeTruthy();
+    // The other half of {@link noReading}'s pin: a cell that drew the dash
+    // unconditionally would satisfy every test above.
+    expect(screen.queryByTitle("no reading")).toBeNull();
   });
 
   /**

--- a/packages/ui-next/src/screens/connections/ClusterTable.tsx
+++ b/packages/ui-next/src/screens/connections/ClusterTable.tsx
@@ -76,9 +76,29 @@ function sourceOf(context: ClusterContext): string {
  * The number the `Latency` column SORTS on — never the text beside it.
  */
 function latencySort(probe: Probe): number {
-  // A cluster with no reading sorts last however the column is turned, rather
-  // than ordering as the text "—" happens to collate.
-  return latencyLabel(probe) === null ? Number.POSITIVE_INFINITY : (probe.latencyMs ?? 0);
+  /**
+   * A cluster with no reading sorts **after every reading when the column is
+   * ascending, and before them when it is reversed** — never as the text `—`
+   * happens to collate, which is the thing this exists to prevent.
+   *
+   * It said "sorts last however the column is turned", and that was wrong.
+   * `Table` compares two numbers as `left - right` and then multiplies the
+   * result by `-1` for a descending column, so a sentinel that is larger than
+   * every reading leads the list when the reader reverses it. Nothing here can
+   * change that: a `getSortValue` returns a value, and the direction is applied
+   * to the comparison afterwards. Sorting a column of missing values to one end
+   * in both directions would be the kit's to offer, and it offers no such
+   * thing — so the honest fix is to say what happens. Pinned in both directions
+   * in the suite, so the next reader meets the behaviour rather than the claim.
+   *
+   * `Number.MAX_VALUE` rather than `Number.POSITIVE_INFINITY`, and it matters
+   * for the ordinary first paint where several clusters have no reading yet:
+   * `Infinity - Infinity` is `NaN`, and two unread rows then compared as NaN.
+   * The kit falls through to a stable index compare for any falsy result, so
+   * NaN happened to work — by accident, and invisibly. `MAX_VALUE - MAX_VALUE`
+   * is `0`, which reaches that same branch on purpose.
+   */
+  return latencyLabel(probe) === null ? Number.MAX_VALUE : (probe.latencyMs ?? 0);
 }
 
 /**

--- a/packages/ui-next/src/screens/connections/ClusterTable.tsx
+++ b/packages/ui-next/src/screens/connections/ClusterTable.tsx
@@ -11,6 +11,7 @@ import {
 import { useMark } from "../../lib/marks";
 import { glyph } from "../../lib/tree";
 import type { Probe, ProbeState } from "../../lib/probe";
+import { joined, latencyLabel, viaOf } from "./clusterText";
 
 /**
  * One cluster as §6's table draws it: the context, what the last probe said,
@@ -54,41 +55,6 @@ const STATUS: Record<ProbeState, { word: string; tone: BadgeTone }> = {
 };
 
 /**
- * The one separator on this screen, and the only place parts are joined.
- *
- * Every caller has parts that may be missing — a cluster with no region, a
- * local cluster with no detected provider — so the filter is here rather than
- * at each site. `· ·` and a line that begins or ends with a separator tell a
- * reader nothing and look broken, and both are what an unconditional
- * `parts.join(" · ")` produces.
- *
- * An empty string means there was nothing to say; callers render NOTHING for
- * it rather than an empty line.
- */
-function joined(parts: readonly (string | undefined)[]): string {
-  return parts
-    .map((part) => part?.trim() ?? "")
-    .filter((part) => part.length > 0)
-    .join(" · ");
-}
-
-/**
- * The host a cluster answers on, for a local cluster's `Via`.
- *
- * `new URL` rather than a regexp, and the raw string when it will not parse: a
- * `server` srelens cannot read is still what the kubeconfig says, and printing
- * it verbatim is more use to a reader than an invented "unknown". Unix-socket
- * and non-URL servers arrive here too.
- */
-function hostOf(server: string): string {
-  try {
-    return new URL(server).host || server;
-  } catch {
-    return server;
-  }
-}
-
-/**
  * §6's `Source`, and the whole of its vocabulary.
  *
  * Two values, from `isLocal`. **`Team server` is never one of them** — §6's
@@ -101,39 +67,14 @@ function sourceOf(context: ClusterContext): string {
 }
 
 /**
- * §6's `Via`: what the cluster is actually reached THROUGH.
+ * The three helpers this file used to hold — `joined`, `viaOf` and
+ * `latencyLabel` — now live in `./clusterText`, because the Sources rail
+ * renders the same facts and a second latency formatter is how the
+ * absent-not-zero rule gets lost. `latencySort` below stays here: it is about
+ * how THIS table orders a column, which the rail has no opinion about.
  *
- * For a kubeconfig context that is the file it was declared in — the column's
- * whole reason for existing, and the field decision 1 added. For a local
- * cluster the file is beside the point (kind writes one for you); what
- * identifies it is the tool that made it and the endpoint it listens on.
+ * The number the `Latency` column SORTS on — never the text beside it.
  */
-function viaOf(context: ClusterContext): string {
-  return context.isLocal ? joined([context.provider, hostOf(context.server)]) : context.sourceFile;
-}
-
-/**
- * The round trip, or nothing.
- *
- * **Gated on the STATE as well as on the number.** `probe.ts` documents
- * `latencyMs` as absent unless the state is `reachable`, so the two gates
- * agree today — but the table is what a reader trusts, and `0 ms` on a cluster
- * that never answered reads as "instant", which is the exact opposite of the
- * truth (spec decision 4). One gate would leave that one drift away; two make
- * it structural.
- *
- * A reading under half a millisecond is a real reading of a cluster on this
- * laptop, and it is NOT discarded — it is drawn as `<1 ms`, because rounding it
- * to `0 ms` would put on screen the one string this column may never show.
- */
-function latencyLabel(probe: Probe): string | null {
-  if (probe.state !== "reachable") return null;
-  const ms = probe.latencyMs;
-  if (typeof ms !== "number" || !Number.isFinite(ms) || ms < 0) return null;
-  return ms < 0.5 ? "<1 ms" : `${Math.round(ms)} ms`;
-}
-
-/** The number the `Latency` column SORTS on — never the text beside it. */
 function latencySort(probe: Probe): number {
   // A cluster with no reading sorts last however the column is turned, rather
   // than ordering as the text "—" happens to collate.

--- a/packages/ui-next/src/screens/connections/ClusterTable.tsx
+++ b/packages/ui-next/src/screens/connections/ClusterTable.tsx
@@ -1,0 +1,431 @@
+import { contextDisplayName, type ClusterContext, type ClusterFacts } from "@srelens/core";
+import {
+  Badge,
+  Button,
+  Mark,
+  Table,
+  cx,
+  type BadgeTone,
+  type Column,
+} from "@srelens/ui-kit";
+import { useMark } from "../../lib/marks";
+import { glyph } from "../../lib/tree";
+import type { Probe, ProbeState } from "../../lib/probe";
+
+/**
+ * One cluster as §6's table draws it: the context, what the last probe said,
+ * and the control-plane facts if anything has fetched them yet.
+ *
+ * `facts` is optional because `clusterFacts` is a second round trip the screen
+ * makes per cluster, and the table draws a row before it answers — a cluster
+ * whose provider and region are not known yet is the ordinary first paint, not
+ * a degraded one.
+ */
+export interface ClusterRow {
+  context: ClusterContext;
+  probe: Probe;
+  /** Provider and region; absent until fetched. */
+  facts?: ClusterFacts;
+}
+
+export interface ClusterTableProps {
+  rows: readonly ClusterRow[];
+  onOpen: (stableId: string) => void;
+  className?: string;
+}
+
+/**
+ * What each probe state is called, and how it is toned.
+ *
+ * **No cluster is ever `healthy` or `degraded`.** §6's mock tones
+ * `healthy`→ok and `degraded`→sev, and the spec's decision 3 refuses both:
+ * `connectCluster` reports whether the API server answered, and calling that
+ * answer a health verdict claims a check that never ran. What is drawn is the
+ * reading itself.
+ *
+ * `unread` is the absence, NAMED as an absence. Not a third status word
+ * ("pending", "idle") — those read as things the cluster is, and this is a
+ * thing srelens has not done yet.
+ */
+const STATUS: Record<ProbeState, { word: string; tone: BadgeTone }> = {
+  reachable: { word: "reachable", tone: "ok" },
+  unreachable: { word: "unreachable", tone: "sev" },
+  unread: { word: "no reading", tone: "muted" },
+};
+
+/**
+ * The one separator on this screen, and the only place parts are joined.
+ *
+ * Every caller has parts that may be missing — a cluster with no region, a
+ * local cluster with no detected provider — so the filter is here rather than
+ * at each site. `· ·` and a line that begins or ends with a separator tell a
+ * reader nothing and look broken, and both are what an unconditional
+ * `parts.join(" · ")` produces.
+ *
+ * An empty string means there was nothing to say; callers render NOTHING for
+ * it rather than an empty line.
+ */
+function joined(parts: readonly (string | undefined)[]): string {
+  return parts
+    .map((part) => part?.trim() ?? "")
+    .filter((part) => part.length > 0)
+    .join(" · ");
+}
+
+/**
+ * The host a cluster answers on, for a local cluster's `Via`.
+ *
+ * `new URL` rather than a regexp, and the raw string when it will not parse: a
+ * `server` srelens cannot read is still what the kubeconfig says, and printing
+ * it verbatim is more use to a reader than an invented "unknown". Unix-socket
+ * and non-URL servers arrive here too.
+ */
+function hostOf(server: string): string {
+  try {
+    return new URL(server).host || server;
+  } catch {
+    return server;
+  }
+}
+
+/**
+ * §6's `Source`, and the whole of its vocabulary.
+ *
+ * Two values, from `isLocal`. **`Team server` is never one of them** — §6's
+ * third source signs in to a team server and lists its members with presence,
+ * and no capability in core reports either (spec decision 5). A column that
+ * could say it would be a column asserting a backend srelens does not have.
+ */
+function sourceOf(context: ClusterContext): string {
+  return context.isLocal ? "Local" : "Kubeconfig";
+}
+
+/**
+ * §6's `Via`: what the cluster is actually reached THROUGH.
+ *
+ * For a kubeconfig context that is the file it was declared in — the column's
+ * whole reason for existing, and the field decision 1 added. For a local
+ * cluster the file is beside the point (kind writes one for you); what
+ * identifies it is the tool that made it and the endpoint it listens on.
+ */
+function viaOf(context: ClusterContext): string {
+  return context.isLocal ? joined([context.provider, hostOf(context.server)]) : context.sourceFile;
+}
+
+/**
+ * The round trip, or nothing.
+ *
+ * **Gated on the STATE as well as on the number.** `probe.ts` documents
+ * `latencyMs` as absent unless the state is `reachable`, so the two gates
+ * agree today — but the table is what a reader trusts, and `0 ms` on a cluster
+ * that never answered reads as "instant", which is the exact opposite of the
+ * truth (spec decision 4). One gate would leave that one drift away; two make
+ * it structural.
+ *
+ * A reading under half a millisecond is a real reading of a cluster on this
+ * laptop, and it is NOT discarded — it is drawn as `<1 ms`, because rounding it
+ * to `0 ms` would put on screen the one string this column may never show.
+ */
+function latencyLabel(probe: Probe): string | null {
+  if (probe.state !== "reachable") return null;
+  const ms = probe.latencyMs;
+  if (typeof ms !== "number" || !Number.isFinite(ms) || ms < 0) return null;
+  return ms < 0.5 ? "<1 ms" : `${Math.round(ms)} ms`;
+}
+
+/** The number the `Latency` column SORTS on — never the text beside it. */
+function latencySort(probe: Probe): number {
+  // A cluster with no reading sorts last however the column is turned, rather
+  // than ordering as the text "—" happens to collate.
+  return latencyLabel(probe) === null ? Number.POSITIVE_INFINITY : (probe.latencyMs ?? 0);
+}
+
+/**
+ * Rows grouped by where the cluster comes from, as §6 groups them.
+ *
+ * **Kubeconfig contexts first, then local clusters** — §6's own order is
+ * `team` → `file` → `local`, and with the team server out of scope (spec
+ * decision 5) that leaves file before local. It is also the order Pane 2 lists
+ * its sections in (`Kubeconfig · on this machine`, then
+ * `Local · runs on this laptop`), so a reader's eye maps a group in the table
+ * onto the section beside it.
+ *
+ * (The brief for this task glossed §6 as "local clusters together, then
+ * kubeconfig contexts", which is the reverse of what §6 and Pane 2 both say.
+ * The GROUPING is the requirement — rows must not interleave — and this
+ * follows the design it cites for the order.)
+ *
+ * Stable within each group: whatever order the caller listed its clusters in
+ * survives, because `listContexts` returns them in the kubeconfig's own order
+ * and re-sorting them here would be this file inventing a second opinion about
+ * a list the rail already draws one way.
+ */
+function bySource(rows: readonly ClusterRow[]): ClusterRow[] {
+  return [...rows.filter((r) => !r.context.isLocal), ...rows.filter((r) => r.context.isLocal)];
+}
+
+/**
+ * §6's `Cluster` cell: the mark, the display name, and the second line.
+ *
+ * A component rather than inline JSX because it reads the cluster's mark from
+ * the marks store, and a hook cannot be called inside a column's `render`
+ * callback — `Fleet` makes the same split for the same reason. One component
+ * per row is also what keeps each row's subscription its own.
+ */
+function ClusterCell({ row }: { row: ClusterRow }) {
+  const { context, probe, facts } = row;
+  const mark = useMark(context.stableId, context.name);
+
+  /**
+   * The name the reader gave this context, or the context's own.
+   *
+   * `contextDisplayName` takes a profile, and ui-next has no profiles store
+   * yet — per-cluster appearance here is the marks store, which is a different
+   * record — so this resolves to the context name today. It is called anyway,
+   * and deliberately: it is the one place a profile has to be handed over when
+   * that store arrives, and inlining `context.name` would hide it.
+   */
+  const name = contextDisplayName(context.name);
+
+  /**
+   * §6's second line, from whichever of the three parts exist.
+   *
+   * `facts.provider` and `facts.region` are `""` when the cluster named none
+   * (core says so on `ClusterFacts`), `facts` itself is absent until the fetch
+   * lands, and `probe.version` is absent until the cluster answers. So all
+   * three can be missing, and when they all are there is no line at all —
+   * an empty row of text under a name is a gap a reader tries to read.
+   */
+  const detail = joined([facts?.provider, probe.version, facts?.region]);
+
+  return (
+    // `min-w-0` on the flex row and on the text column inside it. A flex
+    // item's implicit `min-width: auto` refuses to shrink below its content,
+    // so without these the caps below never engage and a long display name
+    // pushes §6's fixed 292px rail off the window. Eight defects on this
+    // migration, none of them visible in jsdom — hence the class assertions in
+    // the suite. The mark carries its own `shrink-0`.
+    <div
+      data-testid={`cluster-cell-${context.stableId}`}
+      className="flex min-w-0 items-center gap-2"
+    >
+      <Mark
+        name={mark.name}
+        short={mark.short}
+        color={mark.color}
+        size="sm"
+        // The row already says which cluster this is, twice — the name beside
+        // it and the `Open` control's own row context.
+        decorative
+        withBadge={mark.withText}
+        icon={mark.mark === "icon" && mark.icon ? glyph(mark.icon) : undefined}
+        imageSrc={mark.mark === "image" ? mark.imageSrc : undefined}
+      />
+      <div className="flex min-w-0 flex-col">
+        {/* `block` is what makes `truncate`'s `overflow: hidden` apply at all
+            — it does nothing on an inline box — and `max-w-` is what caps the
+            cell's intrinsic contribution, which `white-space: nowrap` would
+            otherwise set to the whole string. Helm's chart column carries the
+            same three classes for the same reason. */}
+        <span
+          data-testid={`cluster-name-${context.stableId}`}
+          className="block max-w-[220px] truncate font-medium"
+        >
+          {name}
+        </span>
+        {detail !== "" && (
+          <span
+            data-testid={`cluster-detail-${context.stableId}`}
+            className="path block max-w-[220px] truncate"
+          >
+            {detail}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * §6's cluster table — where each cluster comes from, and which credential it
+ * uses.
+ *
+ * **Driven entirely by props.** It fetches nothing, probes nothing and holds no
+ * state: the screen owns the contexts, the probes and the facts, so the same
+ * rows can be drawn from a fixture. That is also what keeps this out of the
+ * cluster rail's business — the rail selects a cluster, this says where the
+ * cluster came from.
+ *
+ * **Four things it will not say**, each from the spec rather than from taste:
+ * no `Expires` column (decision 2 — srelens does not know an exec plugin's
+ * version requirement, and a wrong expiry claim on a credentials screen
+ * actively misleads); no `healthy`/`degraded` (decision 3, see {@link STATUS});
+ * no `0 ms` for a cluster that did not answer (decision 4, see
+ * {@link latencyLabel}); and no `Team server` (decision 5 — that section of §6
+ * is out of scope and no capability backs it, so `Source` has exactly two
+ * values).
+ *
+ * **`Auth` is a mechanism, never a credential.** `authKind` is rendered
+ * verbatim and nothing here reformats it: the Rust side decides what may
+ * appear in it — `exec plugin · <basename>`, `token`, `client certificate`, a
+ * legacy provider's own name, optionally an account — and a second opinion
+ * about that string in the UI is how a field whose whole purpose is carrying
+ * no secret starts carrying one.
+ */
+export function ClusterTable({ rows, onOpen, className }: ClusterTableProps) {
+  const columns: Column<ClusterRow>[] = [
+    {
+      key: "cluster",
+      header: "Cluster",
+      render: (row) => <ClusterCell row={row} />,
+      // Sorted and searched on the name the reader can see, not on the object.
+      getValue: (row) => contextDisplayName(row.context.name),
+    },
+    {
+      key: "source",
+      header: "Source",
+      // Two values, and there is no third. See the note above about
+      // `Team server`. Rendered rather than left to the table's
+      // `String(row[key])` fallback, which would print `undefined`: the value
+      // is derived from `isLocal`, not a field of the row.
+      render: (row) => <span>{sourceOf(row.context)}</span>,
+      getValue: (row) => sourceOf(row.context),
+    },
+    {
+      key: "via",
+      header: "Via",
+      /**
+       * Mono and capped. This holds a full filesystem path —
+       * `/Users/dana/Library/Application Support/srelens/kubeconfigs/acme-prod.yaml`
+       * is an ordinary one — and an uncapped cell's intrinsic width is that
+       * whole string, which is what pushes the 292px rail off the window.
+       * jsdom sees none of it; the suite asserts the classes.
+       */
+      render: (row) => (
+        <span
+          data-testid={`cluster-via-${row.context.stableId}`}
+          className="path block max-w-[260px] truncate font-mono"
+          // The full path for the row whose cell is clipped. The text is the
+          // same string, so nothing is hidden behind the hover.
+          title={viaOf(row.context)}
+        >
+          {viaOf(row.context)}
+        </span>
+      ),
+      getValue: (row) => viaOf(row.context),
+    },
+    {
+      key: "auth",
+      header: "Auth",
+      /**
+       * Plain, as §6 asks. Capped like `Via` for the same reason: an
+       * `oidc · dana@some-quite-long-domain.example` is as unbounded as a path,
+       * and this column sits between two that are already capped.
+       */
+      render: (row) => (
+        <span
+          data-testid={`cluster-auth-${row.context.stableId}`}
+          className="block max-w-[200px] truncate"
+          title={row.context.authKind}
+        >
+          {row.context.authKind}
+        </span>
+      ),
+      getValue: (row) => row.context.authKind,
+    },
+    {
+      key: "latency",
+      header: "Latency",
+      align: "end",
+      /**
+       * The round trip to the API server — a network duration, and labelled as
+       * one. It is not a health signal and no colour is put on it.
+       *
+       * A cluster with no reading draws an em dash: the same mark every other
+       * screen in this migration uses for a figure it does not have, and
+       * `Status` beside it is where the reader learns why.
+       */
+      render: (row) => {
+        const label = latencyLabel(row.probe);
+        return label === null ? (
+          // The dash plainly, as Helm draws an age it does not have — no
+          // `aria-label` dressing it up as a word, because `Status` in the
+          // next cell is where the reading state is actually said, and two
+          // announcements of one fact is how they start disagreeing.
+          <span className="text-faint" title="no reading">
+            —
+          </span>
+        ) : (
+          <span className="tabular-nums">{label}</span>
+        );
+      },
+      getValue: (row) => latencyLabel(row.probe) ?? "",
+      getSortValue: (row) => latencySort(row.probe),
+    },
+    {
+      key: "status",
+      header: "Status",
+      render: (row) => {
+        const status = STATUS[row.probe.state];
+        return <Badge tone={status.tone}>{status.word}</Badge>;
+      },
+      getValue: (row) => STATUS[row.probe.state].word,
+    },
+    {
+      // §6's unnamed trailing column.
+      key: "actions",
+      header: "",
+      sortable: false,
+      filterable: false,
+      align: "end",
+      minWidth: 80,
+      render: (row) => (
+        // `shrink-0` and `whitespace-nowrap`: flex items shrink by default, and
+        // the capped cells to the left are what absorb a narrow window instead
+        // — a truncated path is recoverable by widening a column, a clipped
+        // control is not.
+        <div className="flex shrink-0 items-center justify-end whitespace-nowrap">
+          <Button
+            size="xs"
+            variant="secondary"
+            // The word is §6's, and it is deliberately NOT
+            // `aria-label="Open prod-eu"`: the accessible name stays `Open`
+            // while the cell that names the cluster is the row's own first
+            // column, which is what a row-reading screen reader announces
+            // around it. `title` carries the cluster for a pointer.
+            title={`Open ${contextDisplayName(row.context.name)}`}
+            onClick={() => onOpen(row.context.stableId)}
+          >
+            Open
+          </Button>
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    // `min-w-0` on the frame, not only inside the cells: this component is
+    // dropped into the screen's flex row beside the 292px rail, and the frame
+    // is the flex item whose `min-width: auto` would refuse to shrink.
+    //
+    // The SCROLL container is the caller's, through `className` — the screen
+    // owns how tall its pane is and whether the table scrolls inside it, the
+    // way `Helm` hands its own table a `scroll min-h-0 flex-1` wrapper. A
+    // second one here would be a box inside a box with its own scrollbar.
+    <div data-testid="cluster-table" className={cx("min-w-0", className)}>
+      <Table
+        columns={columns}
+        data={bySource(rows)}
+        getRowKey={(row) => row.context.stableId}
+        // The keyboard's half of `Open`: Enter on the focused row, or a
+        // double-click. The kit's own rule — a pointer-only route to opening a
+        // row is a fault — and it opens exactly what the button opens.
+        onRowActivate={(row) => onOpen(row.context.stableId)}
+        // A screen with no clusters at all is `/connect`, not this table with
+        // an empty panel (spec: States), so this is the narrow case of a list
+        // that came back short rather than the first-run one.
+        emptyText="No clusters"
+      />
+    </div>
+  );
+}

--- a/packages/ui-next/src/screens/connections/ClusterTable.tsx
+++ b/packages/ui-next/src/screens/connections/ClusterTable.tsx
@@ -167,12 +167,17 @@ function ClusterCell({ row }: { row: ClusterRow }) {
  * is out of scope and no capability backs it, so `Source` has exactly two
  * values).
  *
- * **`Auth` is a mechanism, never a credential.** `authKind` is rendered
- * verbatim and nothing here reformats it: the Rust side decides what may
- * appear in it — `exec plugin · <basename>`, `token`, `client certificate`, a
- * legacy provider's own name, optionally an account — and a second opinion
+ * **`Auth` is a mechanism, never a credential and never an account.**
+ * `authKind` is rendered verbatim and nothing here reformats it: the Rust side
+ * decides what may appear in it — `exec plugin · <basename>` or bare `exec
+ * plugin`, `token`, `client certificate`, `basic`, `impersonation`, `none`, a
+ * legacy provider's own name or bare `auth provider` — and a second opinion
  * about that string in the UI is how a field whose whole purpose is carrying
- * no secret starts carrying one.
+ * no secret starts carrying one. No account rides along: `crates/kube`'s
+ * `auth_kind_of` used to append the kubeconfig's plain-text `email` and no
+ * longer does, because `k8s.listContexts` is read-only and therefore not
+ * consent-gated, so every field on this row is readable by any connected
+ * agent.
  */
 export function ClusterTable({ rows, onOpen, className }: ClusterTableProps) {
   /**

--- a/packages/ui-next/src/screens/connections/ClusterTable.tsx
+++ b/packages/ui-next/src/screens/connections/ClusterTable.tsx
@@ -3,7 +3,7 @@ import { Badge, Button, Mark, Table, cx, type Column } from "@srelens/ui-kit";
 import { useMark } from "../../lib/marks";
 import { glyph } from "../../lib/tree";
 import type { Probe } from "../../lib/probe";
-import { STATUS, joined, latencyLabel, viaOf } from "./clusterText";
+import { STATUS, bySource, joined, latencyLabel, sourceOf, viaOf } from "./clusterText";
 
 /**
  * One cluster as §6's table draws it: the context, what the last probe said,
@@ -28,25 +28,15 @@ export interface ClusterTableProps {
 }
 
 /**
- * §6's `Source`, and the whole of its vocabulary.
- *
- * Two values, from `isLocal`. **`Team server` is never one of them** — §6's
- * third source signs in to a team server and lists its members with presence,
- * and no capability in core reports either (spec decision 5). A column that
- * could say it would be a column asserting a backend srelens does not have.
- */
-function sourceOf(context: ClusterContext): string {
-  return context.isLocal ? "Local" : "Kubeconfig";
-}
-
-/**
- * The four things this file used to hold — `joined`, `viaOf`,
- * `latencyLabel` and the `STATUS` table — now live in `./clusterText`,
+ * The six things this file used to hold — `joined`, `viaOf`, `latencyLabel`,
+ * the `STATUS` table, `sourceOf` and `bySource` — now live in `./clusterText`,
  * because the Sources rail and §24's first-run card render the same facts: a
- * second latency formatter is how the absent-not-zero rule gets lost, and a
- * second status table is how one screen starts calling a cluster something the
- * other never would. `latencySort` below stays here: it is about how THIS
- * table orders a column, which the rail has no opinion about.
+ * second latency formatter is how the absent-not-zero rule gets lost, a second
+ * status table is how one screen starts calling a cluster something the other
+ * never would, and a second sort is how `/connect` came to list one set of
+ * clusters in a different order from this table. `latencySort` below stays
+ * here: it is about how THIS table orders a column, which the rail has no
+ * opinion about.
  *
  * The number the `Latency` column SORTS on — never the text beside it.
  */
@@ -74,30 +64,6 @@ function latencySort(probe: Probe): number {
    * is `0`, which reaches that same branch on purpose.
    */
   return latencyLabel(probe) === null ? Number.MAX_VALUE : (probe.latencyMs ?? 0);
-}
-
-/**
- * Rows grouped by where the cluster comes from, as §6 groups them.
- *
- * **Kubeconfig contexts first, then local clusters** — §6's own order is
- * `team` → `file` → `local`, and with the team server out of scope (spec
- * decision 5) that leaves file before local. It is also the order Pane 2 lists
- * its sections in (`Kubeconfig · on this machine`, then
- * `Local · runs on this laptop`), so a reader's eye maps a group in the table
- * onto the section beside it.
- *
- * (The brief for this task glossed §6 as "local clusters together, then
- * kubeconfig contexts", which is the reverse of what §6 and Pane 2 both say.
- * The GROUPING is the requirement — rows must not interleave — and this
- * follows the design it cites for the order.)
- *
- * Stable within each group: whatever order the caller listed its clusters in
- * survives, because `listContexts` returns them in the kubeconfig's own order
- * and re-sorting them here would be this file inventing a second opinion about
- * a list the rail already draws one way.
- */
-function bySource(rows: readonly ClusterRow[]): ClusterRow[] {
-  return [...rows.filter((r) => !r.context.isLocal), ...rows.filter((r) => r.context.isLocal)];
 }
 
 /**
@@ -351,7 +317,7 @@ export function ClusterTable({ rows, onOpen, className }: ClusterTableProps) {
     <div data-testid="cluster-table" className={cx("min-w-0", className)}>
       <Table
         columns={columns}
-        data={bySource(rows)}
+        data={bySource(rows, (row) => row.context.isLocal)}
         getRowKey={(row) => row.context.stableId}
         // The keyboard's half of `Open`: Enter on the focused row, or a
         // double-click. The kit's own rule — a pointer-only route to opening a

--- a/packages/ui-next/src/screens/connections/ClusterTable.tsx
+++ b/packages/ui-next/src/screens/connections/ClusterTable.tsx
@@ -1,17 +1,9 @@
 import { contextDisplayName, type ClusterContext, type ClusterFacts } from "@srelens/core";
-import {
-  Badge,
-  Button,
-  Mark,
-  Table,
-  cx,
-  type BadgeTone,
-  type Column,
-} from "@srelens/ui-kit";
+import { Badge, Button, Mark, Table, cx, type Column } from "@srelens/ui-kit";
 import { useMark } from "../../lib/marks";
 import { glyph } from "../../lib/tree";
-import type { Probe, ProbeState } from "../../lib/probe";
-import { joined, latencyLabel, viaOf } from "./clusterText";
+import type { Probe } from "../../lib/probe";
+import { STATUS, joined, latencyLabel, viaOf } from "./clusterText";
 
 /**
  * One cluster as §6's table draws it: the context, what the last probe said,
@@ -36,25 +28,6 @@ export interface ClusterTableProps {
 }
 
 /**
- * What each probe state is called, and how it is toned.
- *
- * **No cluster is ever `healthy` or `degraded`.** §6's mock tones
- * `healthy`→ok and `degraded`→sev, and the spec's decision 3 refuses both:
- * `connectCluster` reports whether the API server answered, and calling that
- * answer a health verdict claims a check that never ran. What is drawn is the
- * reading itself.
- *
- * `unread` is the absence, NAMED as an absence. Not a third status word
- * ("pending", "idle") — those read as things the cluster is, and this is a
- * thing srelens has not done yet.
- */
-const STATUS: Record<ProbeState, { word: string; tone: BadgeTone }> = {
-  reachable: { word: "reachable", tone: "ok" },
-  unreachable: { word: "unreachable", tone: "sev" },
-  unread: { word: "no reading", tone: "muted" },
-};
-
-/**
  * §6's `Source`, and the whole of its vocabulary.
  *
  * Two values, from `isLocal`. **`Team server` is never one of them** — §6's
@@ -67,11 +40,13 @@ function sourceOf(context: ClusterContext): string {
 }
 
 /**
- * The three helpers this file used to hold — `joined`, `viaOf` and
- * `latencyLabel` — now live in `./clusterText`, because the Sources rail
- * renders the same facts and a second latency formatter is how the
- * absent-not-zero rule gets lost. `latencySort` below stays here: it is about
- * how THIS table orders a column, which the rail has no opinion about.
+ * The four things this file used to hold — `joined`, `viaOf`,
+ * `latencyLabel` and the `STATUS` table — now live in `./clusterText`,
+ * because the Sources rail and §24's first-run card render the same facts: a
+ * second latency formatter is how the absent-not-zero rule gets lost, and a
+ * second status table is how one screen starts calling a cluster something the
+ * other never would. `latencySort` below stays here: it is about how THIS
+ * table orders a column, which the rail has no opinion about.
  *
  * The number the `Latency` column SORTS on — never the text beside it.
  */

--- a/packages/ui-next/src/screens/connections/ClusterTable.tsx
+++ b/packages/ui-next/src/screens/connections/ClusterTable.tsx
@@ -302,6 +302,24 @@ export function ClusterTable({ rows, onOpen, className }: ClusterTableProps) {
       sortable: false,
       filterable: false,
       align: "end",
+      /**
+       * Pinned to the end of the table, and this is the whole of §6's primary
+       * row action being reachable.
+       *
+       * MEASURED in Chrome, seventeen clusters on a real kubeconfig: the seven
+       * columns sum to 1082px, the pane is 1014px wide at the default 1600px
+       * window, and this button's rect was x=1311…1355 against a visible right
+       * edge of 1308 — off screen on every row, with the window having to reach
+       * 1668px before it appeared. At the 960px minimum the pane is 374px and
+       * the overflow 711px.
+       *
+       * **Pinned rather than capped**, deliberately: shaving the two capped text
+       * columns can fit 1600px and cannot fit 960px, where 711px of overflow
+       * puts the button past the scroll however narrow the text gets. A pinned
+       * column works at every width. Enter and double-click already opened the
+       * row, so what was missing was the CONTROL, not the action.
+       */
+      sticky: "end",
       minWidth: 80,
       render: (row) => (
         // `shrink-0` and `whitespace-nowrap`: flex items shrink by default, and

--- a/packages/ui-next/src/screens/connections/ClusterTable.tsx
+++ b/packages/ui-next/src/screens/connections/ClusterTable.tsx
@@ -1,4 +1,4 @@
-import { contextDisplayName, type ClusterContext, type ClusterFacts } from "@srelens/core";
+import { contextDisplayName, plural, type ClusterContext, type ClusterFacts } from "@srelens/core";
 import { Badge, Button, Mark, Table, cx, type Column } from "@srelens/ui-kit";
 import { useMark } from "../../lib/marks";
 import { glyph } from "../../lib/tree";
@@ -175,6 +175,28 @@ function ClusterCell({ row }: { row: ClusterRow }) {
  * no secret starts carrying one.
  */
 export function ClusterTable({ rows, onOpen, className }: ClusterTableProps) {
+  /**
+   * The rows in the order the table draws them, grouped.
+   *
+   * Taken once and handed to the table, rather than called again for the
+   * headings: the boundary and the rows have to be describing one list.
+   */
+  const ordered = bySource(rows, (row) => row.context.isLocal);
+
+  /**
+   * How many clusters each group holds, for the count in its heading.
+   *
+   * Counted from the rows that are on the screen, which is the rule every count
+   * in this migration now follows — `Releases · 383 in this cluster` over six
+   * rows was the fault, and a heading saying `14 clusters` over a filtered list
+   * would be the same one.
+   */
+  const sizes = new Map<string, number>();
+  for (const row of ordered) {
+    const word = sourceOf(row.context);
+    sizes.set(word, (sizes.get(word) ?? 0) + 1);
+  }
+
   const columns: Column<ClusterRow>[] = [
     {
       key: "cluster",
@@ -317,7 +339,30 @@ export function ClusterTable({ rows, onOpen, className }: ClusterTableProps) {
     <div data-testid="cluster-table" className={cx("min-w-0", className)}>
       <Table
         columns={columns}
-        data={bySource(rows, (row) => row.context.isLocal)}
+        data={ordered}
+        /**
+         * §6's grouping, drawn as a boundary rather than left to the row order.
+         *
+         * The rows were already ordered — kubeconfig contexts, then local
+         * clusters, never interleaved — and on a real kubeconfig the only cue a
+         * reader had was the `Source` cell's text changing at row 15 of 17.
+         * Ordering is not grouping; this is the line between the two groups,
+         * in the same two words the `Source` cells under it use, so the heading
+         * cannot come to say something the column does not.
+         *
+         * **It stops when the reader sorts, and the kit is what stops it** (see
+         * `rowGroup`): a sort by `Latency` scatters the sources through one
+         * another, and a heading left over that list would be labelling rows
+         * that had moved out from under it. The `Source` column is what carries
+         * the fact from then on, and clearing the sort brings the boundary back.
+         */
+        rowGroup={(row) => {
+          const word = sourceOf(row.context);
+          // Through `joined`, the one separator on this screen — the same
+          // ` · ` the rail's own count lines and the second row of every
+          // cluster cell are assembled with.
+          return { key: word, label: joined([word, plural(sizes.get(word) ?? 0, "cluster")]) };
+        }}
         getRowKey={(row) => row.context.stableId}
         // The keyboard's half of `Open`: Enter on the focused row, or a
         // double-click. The kit's own rule — a pointer-only route to opening a

--- a/packages/ui-next/src/screens/connections/SourcesRail.test.tsx
+++ b/packages/ui-next/src/screens/connections/SourcesRail.test.tsx
@@ -82,9 +82,20 @@ describe("SourcesRail", () => {
     render(<SourcesRail files={["/k/gone.yaml"]} rows={[]} />);
     expect(screen.getByText("/k/gone.yaml")).toBeTruthy();
     expect(screen.getByText("0 contexts")).toBeTruthy();
+    /**
+     * **All four causes, and the likeliest one first.**
+     *
+     * This named three — moved, deleted, emptied — and left out the one a
+     * reader hits immediately after `Add a kubeconfig file`: a file srelens
+     * could not parse. `resolve_contexts` skips an unreadable or invalid
+     * kubeconfig silently (`Kubeconfig::read_from(path).ok()`), so the file is
+     * still on the stored list and still yields nothing. Telling someone who
+     * has just picked a file that it may have been deleted sends them looking
+     * for the wrong problem.
+     */
     expect(
       screen.getByText(
-        "No contexts came from this file. It may have been moved, deleted or emptied since it was added.",
+        "No contexts came from this file. srelens may not have been able to read it as a kubeconfig, or it may have been moved, deleted or emptied since it was added.",
       ),
     ).toBeTruthy();
   });

--- a/packages/ui-next/src/screens/connections/SourcesRail.test.tsx
+++ b/packages/ui-next/src/screens/connections/SourcesRail.test.tsx
@@ -1,0 +1,310 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ClusterContext } from "@srelens/core";
+import type { Probe } from "../../lib/probe";
+import type { ClusterRow } from "./ClusterTable";
+import { SourcesRail } from "./SourcesRail";
+
+const ctx = (over: Partial<ClusterContext> = {}): ClusterContext => ({
+  name: "prod-eu",
+  // Unique per name unless a test says otherwise, so a list of rows has a list
+  // of keys.
+  stableId: over.name ?? "prod-eu",
+  cluster: "prod",
+  server: "https://prod:6443",
+  namespace: "",
+  isCurrent: false,
+  isLocal: false,
+  sourceFile: "/home/dana/.kube/config",
+  authKind: "exec plugin · gcloud",
+  ...over,
+});
+
+const row = (over: Partial<ClusterContext> = {}, probe: Probe = { state: "unread" }): ClusterRow => ({
+  context: ctx(over),
+  probe,
+});
+
+/**
+ * The one sentence §6's third section renders, asserted as EXACT TEXT.
+ *
+ * A regexp over a phrase would pass against a section that also drew a badge
+ * per cluster beside it, which is the thing this suite exists to forbid.
+ */
+const GATE =
+  "Every change the agent makes to any cluster on this list stops at a confirmation prompt first — the same gate whether the cluster runs on this laptop or across the internet.";
+
+/** §6's footnote under the kubeconfig section, verbatim. */
+const FOOTNOTE =
+  "srelens reads these files in place and connects to the API server directly. Nothing is copied anywhere.";
+
+describe("SourcesRail", () => {
+  it("is a named region 292px wide", () => {
+    const { container } = render(<SourcesRail files={[]} rows={[]} />);
+    const aside = container.querySelector("aside");
+    expect(aside?.style.width).toBe("292px");
+    expect(screen.getByRole("complementary", { name: "Sources" })).toBeTruthy();
+  });
+
+  it("counts a file's contexts, and how many are in use", () => {
+    render(
+      <SourcesRail
+        files={["/k/config"]}
+        rows={[
+          row({ sourceFile: "/k/config", isCurrent: true }),
+          row({ sourceFile: "/k/config", stableId: "b", name: "b" }),
+        ]}
+      />,
+    );
+    expect(screen.getByText(/2 contexts/)).toBeTruthy();
+    // Exact, not a pattern: the whole line is the claim, and `2 contexts · 2 in
+    // use` would satisfy the regexp above.
+    expect(screen.getByText("2 contexts · 1 in use")).toBeTruthy();
+  });
+
+  it("counts each file's own contexts and nobody else's", () => {
+    render(
+      <SourcesRail
+        files={["/k/one", "/k/two"]}
+        rows={[
+          row({ name: "a", sourceFile: "/k/one", isCurrent: true }),
+          row({ name: "b", sourceFile: "/k/one" }),
+          row({ name: "c", sourceFile: "/k/two" }),
+        ]}
+      />,
+    );
+    expect(screen.getByText("2 contexts · 1 in use")).toBeTruthy();
+    expect(screen.getByText("1 context · 0 in use")).toBeTruthy();
+  });
+
+  it("keeps a stored file that no longer yields any context", () => {
+    render(<SourcesRail files={["/k/gone.yaml"]} rows={[]} />);
+    expect(screen.getByText("/k/gone.yaml")).toBeTruthy();
+    expect(screen.getByText("0 contexts")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "No contexts came from this file. It may have been moved, deleted or emptied since it was added.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("says nothing about a missing file for one that still yields contexts", () => {
+    render(<SourcesRail files={["/k/config"]} rows={[row({ sourceFile: "/k/config" })]} />);
+    expect(screen.queryByText(/no contexts came from this file/i)).toBeNull();
+  });
+
+  it("names a file that supplies contexts even when it was never stored", () => {
+    // Web mode: `loadKubeconfigFiles` is not read, so `files` is empty while
+    // the contexts the server merged still came from somewhere.
+    render(<SourcesRail files={[]} rows={[row({ sourceFile: "/srv/kubeconfig" })]} />);
+    expect(screen.getByText("/srv/kubeconfig")).toBeTruthy();
+    expect(screen.getByText("1 context · 0 in use")).toBeTruthy();
+  });
+
+  it("lists a stored path once when it is stored twice", () => {
+    render(<SourcesRail files={["/k/config", "/k/config"]} rows={[]} />);
+    expect(screen.getAllByText("/k/config")).toHaveLength(1);
+    expect(screen.getAllByTestId("source-file")).toHaveLength(1);
+  });
+
+  it("draws no file row for a context that names no file", () => {
+    render(<SourcesRail files={[]} rows={[row({ sourceFile: "" })]} />);
+    expect(screen.queryAllByTestId("source-file")).toHaveLength(0);
+  });
+
+  it("keeps §6's footnote about reading the files in place", () => {
+    render(<SourcesRail files={["/k/config"]} rows={[row({ sourceFile: "/k/config" })]} />);
+    expect(screen.getByText(FOOTNOTE)).toBeTruthy();
+  });
+
+  it("offers no way to add a file when there is no filesystem to browse", () => {
+    render(<SourcesRail files={["/k/config"]} rows={[row()]} />); // no onAddFile
+    expect(screen.queryByRole("button", { name: /add/i })).toBeNull();
+    expect(screen.getByText(/on the desktop/i)).toBeTruthy(); // the reason, said once
+  });
+
+  it("offers Add, and no explanation, when there is a filesystem to browse", async () => {
+    const onAddFile = vi.fn();
+    render(<SourcesRail files={["/k/config"]} rows={[row()]} onAddFile={onAddFile} />);
+    expect(screen.queryByText(/on the desktop/i)).toBeNull();
+    await userEvent.click(screen.getByRole("button", { name: /add/i }));
+    expect(onAddFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("draws no local section when no cluster runs on this laptop", () => {
+    render(<SourcesRail files={["/k/config"]} rows={[row({ sourceFile: "/k/config" })]} />);
+    expect(screen.queryByTestId("sources-local")).toBeNull();
+  });
+
+  it("says how a local cluster is reached and what it measured", () => {
+    render(
+      <SourcesRail
+        files={[]}
+        rows={[
+          row(
+            { name: "kind-dev", isLocal: true, provider: "kind", server: "https://127.0.0.1:6443" },
+            { state: "reachable", latencyMs: 12 },
+          ),
+        ]}
+      />,
+    );
+    const local = screen.getByTestId("sources-local");
+    expect(local.textContent).toContain("kind-dev");
+    expect(screen.getByText("kind · 127.0.0.1:6443")).toBeTruthy();
+    expect(screen.getByText("12 ms")).toBeTruthy();
+  });
+
+  it("shows no latency for a local cluster it has not read", () => {
+    render(
+      <SourcesRail files={[]} rows={[row({ isLocal: true, provider: "kind" }, { state: "unread" })]} />,
+    );
+    expect(screen.queryByText(/0\s*ms/)).toBeNull();
+    expect(screen.queryByText(/\d+\s*ms/)).toBeNull();
+  });
+
+  it("shows no latency for a local cluster that did not answer", () => {
+    render(
+      <SourcesRail
+        files={[]}
+        rows={[
+          row(
+            { isLocal: true, provider: "kind" },
+            { state: "unreachable", latencyMs: 0, error: "connection refused" },
+          ),
+        ]}
+      />,
+    );
+    expect(screen.queryByText(/0\s*ms/)).toBeNull();
+    expect(screen.queryByText(/\d+\s*ms/)).toBeNull();
+  });
+
+  it("draws a sub-millisecond reading as <1 ms, never as 0 ms", () => {
+    render(
+      <SourcesRail
+        files={[]}
+        rows={[row({ isLocal: true, provider: "kind" }, { state: "reachable", latencyMs: 0.2 })]}
+      />,
+    );
+    expect(screen.getByText("<1 ms")).toBeTruthy();
+    expect(screen.queryByText(/0\s*ms/)).toBeNull();
+  });
+
+  it("names a local cluster's endpoint with no leading separator when no provider was detected", () => {
+    render(
+      <SourcesRail
+        files={[]}
+        rows={[row({ name: "kind-dev", isLocal: true, server: "https://127.0.0.1:6443" })]}
+      />,
+    );
+    // Exact text: a `parts.join(" · ")` over an absent provider produces
+    // ` · 127.0.0.1:6443`, which no "contains" assertion would catch.
+    expect(screen.getByText("127.0.0.1:6443")).toBeTruthy();
+  });
+
+  it("says the confirmation gate once, however many clusters there are", () => {
+    render(
+      <SourcesRail
+        files={["/k/config"]}
+        rows={[
+          row({ name: "prod-eu", sourceFile: "/k/config" }),
+          row({ name: "staging", sourceFile: "/k/config" }),
+          row({ name: "kind-dev", isLocal: true, provider: "kind" }),
+        ]}
+      />,
+    );
+    expect(screen.getAllByText(GATE)).toHaveLength(1);
+  });
+
+  /**
+   * §6's mock draws `read + write` / `read only` per cluster. Task 3
+   * established that no such distinction exists anywhere in srelens: the write
+   * gate is `crates/mcp/src/stdio.rs`'s alone, `isLocal` never enters it, and
+   * no cluster is read-only. Two badges that differ by nothing imply a setting
+   * the reader could change, so the section says one sentence and draws no
+   * badge at all. Restoring the mock's shape has to fail this.
+   */
+  it("draws no per-cluster badge in what the agent may reach", () => {
+    render(
+      <SourcesRail
+        files={["/k/config"]}
+        rows={[
+          row({ name: "prod-eu", sourceFile: "/k/config" }),
+          row({ name: "kind-dev", isLocal: true, provider: "kind" }),
+        ]}
+      />,
+    );
+    const agent = screen.getByTestId("sources-agent");
+    // Element absence, not a text pattern: `Badge` is the only thing in the kit
+    // that renders `.badge`, and any wording of a per-cluster verdict would
+    // have to name the cluster it is about.
+    expect(agent.querySelectorAll(".badge")).toHaveLength(0);
+    expect(agent.querySelectorAll("[data-tone]")).toHaveLength(0);
+    expect(agent.textContent).not.toContain("prod-eu");
+    expect(agent.textContent).not.toContain("kind-dev");
+    expect(screen.queryByText(/read \+ write/i)).toBeNull();
+    expect(screen.queryByText(/read only/i)).toBeNull();
+  });
+
+  /**
+   * `min-width: auto` — eight defects on this migration, none of them visible
+   * in jsdom, which is why the classes themselves are the assertion.
+   */
+  it("keeps the scroll on the body and lets a long path shrink", () => {
+    const long = "/Users/dana/Library/Application Support/srelens/kubeconfigs/acme-prod.yaml";
+    const { container } = render(<SourcesRail files={[long]} rows={[]} />);
+
+    const aside = container.querySelector("aside");
+    expect(aside?.className).toContain("side-rail");
+    // The aside is the fixed frame; the body is what scrolls.
+    expect(aside?.className).not.toContain("scroll");
+    expect(aside?.className).not.toContain("overflow");
+
+    const body = container.querySelector('[data-slot="rail-body"]');
+    expect(body?.className).toContain("side-rail-body");
+    expect(body?.className).toContain("min-w-0");
+
+    const path = screen.getByText(long);
+    expect(path.className).toContain("block");
+    expect(path.className).toContain("truncate");
+    expect(path.className).toMatch(/max-w-\[/);
+    expect(path.title).toBe(long);
+    expect(path.parentElement?.className).toContain("min-w-0");
+  });
+
+  it("lets a local cluster's name and endpoint shrink", () => {
+    render(
+      <SourcesRail
+        files={[]}
+        rows={[
+          row(
+            {
+              name: "kind-a-rather-long-local-cluster-name",
+              isLocal: true,
+              provider: "kind",
+              server: "https://127.0.0.1:6443",
+            },
+            { state: "reachable", latencyMs: 3 },
+          ),
+        ]}
+      />,
+    );
+    const name = screen.getByText("kind-a-rather-long-local-cluster-name");
+    expect(name.className).toContain("block");
+    expect(name.className).toContain("truncate");
+    expect(name.parentElement?.className).toContain("min-w-0");
+
+    const via = screen.getByText("kind · 127.0.0.1:6443");
+    expect(via.className).toContain("truncate");
+
+    // The reading refuses to shrink; the name and the path absorb the width.
+    expect(screen.getByText("3 ms").closest("[data-slot='local-reading']")?.className).toContain(
+      "shrink-0",
+    );
+  });
+
+  it("puts the caller's className on the frame", () => {
+    const { container } = render(<SourcesRail files={[]} rows={[]} className="border-l-0" />);
+    expect(container.querySelector("aside")?.className).toContain("border-l-0");
+  });
+});

--- a/packages/ui-next/src/screens/connections/SourcesRail.test.tsx
+++ b/packages/ui-next/src/screens/connections/SourcesRail.test.tsx
@@ -143,6 +143,55 @@ describe("SourcesRail", () => {
     expect(onAddFile).toHaveBeenCalledTimes(1);
   });
 
+  /**
+   * **"this laptop" is the reader's machine, and in web mode it is not the
+   * machine anything on this rail runs on.**
+   *
+   * The server's kubeconfig can perfectly well declare a kind or minikube
+   * cluster; `isLocal` is then true and the cluster runs on the SERVER's host,
+   * which may be a shared box in another building. Both headings said "this
+   * machine"/"this laptop" unconditionally, one of them directly above the
+   * paragraph that tells a web reader kubeconfig files are added "on the
+   * desktop".
+   *
+   * `desktop` is passed IN rather than read here, exactly as `onAddFile` is:
+   * a component that asks `isTauri()` itself cannot be drawn both ways from a
+   * fixture. It is a second prop rather than `onAddFile !== undefined` on
+   * purpose — this file's own note forbids deriving platform claims from a UI
+   * callback, and a caller may one day pass a picker in web mode or withhold
+   * one on the desktop.
+   *
+   * Asserted as EXACT headings both ways round, so a branch that added the
+   * web wording while leaving the laptop claim standing fails here. The
+   * heading strings are used rather than a `/this laptop/` pattern because the
+   * agent section's own sentence — "whether the cluster runs on this laptop or
+   * across the internet", a claim about the GATE being uniform rather than
+   * about where anything runs — contains the same words.
+   */
+  const LOCAL_DESKTOP = "Local · runs on this laptop";
+  const LOCAL_WEB = "Local · runs on the server's host";
+  const FILES_DESKTOP = "Kubeconfig · on this machine";
+  const FILES_WEB = "Kubeconfig · on the server's host";
+
+  /** One local cluster, so the second section is drawn at all. */
+  const LOCAL_ROW = row({ name: "kind-dev", isLocal: true, provider: "kind" });
+
+  it("heads both sections with the reader's own machine on the desktop", () => {
+    render(<SourcesRail files={["/k/config"]} rows={[LOCAL_ROW]} desktop />);
+    expect(screen.getByText(FILES_DESKTOP)).toBeTruthy();
+    expect(screen.getByText(LOCAL_DESKTOP)).toBeTruthy();
+    expect(screen.queryByText(FILES_WEB)).toBeNull();
+    expect(screen.queryByText(LOCAL_WEB)).toBeNull();
+  });
+
+  it("does not tell a web reader that the server's clusters run on their laptop", () => {
+    render(<SourcesRail files={["/k/config"]} rows={[LOCAL_ROW]} />);
+    expect(screen.queryByText(FILES_DESKTOP)).toBeNull();
+    expect(screen.queryByText(LOCAL_DESKTOP)).toBeNull();
+    expect(screen.getByText(FILES_WEB)).toBeTruthy();
+    expect(screen.getByText(LOCAL_WEB)).toBeTruthy();
+  });
+
   it("draws no local section when no cluster runs on this laptop", () => {
     render(<SourcesRail files={["/k/config"]} rows={[row({ sourceFile: "/k/config" })]} />);
     expect(screen.queryByTestId("sources-local")).toBeNull();

--- a/packages/ui-next/src/screens/connections/SourcesRail.test.tsx
+++ b/packages/ui-next/src/screens/connections/SourcesRail.test.tsx
@@ -138,7 +138,7 @@ describe("SourcesRail", () => {
   });
 
   it("says how a local cluster is reached and what it measured", () => {
-    render(
+    const { container } = render(
       <SourcesRail
         files={[]}
         rows={[
@@ -153,18 +153,38 @@ describe("SourcesRail", () => {
     expect(local.textContent).toContain("kind-dev");
     expect(screen.getByText("kind · 127.0.0.1:6443")).toBeTruthy();
     expect(screen.getByText("12 ms")).toBeTruthy();
+    // The other half of {@link readingPill}'s pin: one pill, and the reading
+    // is inside it rather than merely somewhere on the rail.
+    const pill = readingPill(container);
+    expect(pill?.textContent).toBe("12 ms");
   });
 
+  /**
+   * **The badge is asserted as an ELEMENT, not as absent digits.**
+   *
+   * These two used to assert `queryByText(/\d+\s*ms/)` alone, and replacing
+   * the rail's `{reading !== null && …}` gate with `{true && …}` — an EMPTY
+   * muted pill beside a local cluster nothing has read — passed all 47 tests.
+   * An empty pill is exactly "a placeholder that implies a reading was taken",
+   * which is the shape this project's absent-not-zero rule exists to prevent,
+   * and no assertion about digits can see it. So the pin is on the pill's own
+   * node: for a cluster with no reading there is no pill at all.
+   */
+  function readingPill(container: HTMLElement): Element | null {
+    return container.querySelector('[data-slot="local-reading"]');
+  }
+
   it("shows no latency for a local cluster it has not read", () => {
-    render(
+    const { container } = render(
       <SourcesRail files={[]} rows={[row({ isLocal: true, provider: "kind" }, { state: "unread" })]} />,
     );
     expect(screen.queryByText(/0\s*ms/)).toBeNull();
     expect(screen.queryByText(/\d+\s*ms/)).toBeNull();
+    expect(readingPill(container)).toBeNull();
   });
 
   it("shows no latency for a local cluster that did not answer", () => {
-    render(
+    const { container } = render(
       <SourcesRail
         files={[]}
         rows={[
@@ -177,6 +197,7 @@ describe("SourcesRail", () => {
     );
     expect(screen.queryByText(/0\s*ms/)).toBeNull();
     expect(screen.queryByText(/\d+\s*ms/)).toBeNull();
+    expect(readingPill(container)).toBeNull();
   });
 
   it("draws a sub-millisecond reading as <1 ms, never as 0 ms", () => {

--- a/packages/ui-next/src/screens/connections/SourcesRail.tsx
+++ b/packages/ui-next/src/screens/connections/SourcesRail.tsx
@@ -23,6 +23,24 @@ export interface SourcesRailProps {
    * {@link SourcesRail}.
    */
   onAddFile?: () => void;
+  /**
+   * Whether the reader is looking at the desktop app, so the two section
+   * headings can say WHOSE machine they are about.
+   *
+   * **A fact, passed in like {@link SourcesRailProps.onAddFile} and for the
+   * same reason** — a component that calls `isTauri()` itself cannot be drawn
+   * both ways from a fixture. Deliberately NOT derived from `onAddFile`: this
+   * file's own note refuses to read a platform claim out of a UI callback, and
+   * the two can legitimately diverge (a caller that has a file picker but no
+   * local clusters, or the reverse).
+   *
+   * Absent means the browser, which is the conservative default: the headings
+   * then say "the server's host", which is true of a shared server and merely
+   * pedantic if a reader happens to be running one on their own machine — the
+   * other way round the rail states a falsehood about where somebody's
+   * cluster runs.
+   */
+  desktop?: boolean;
   className?: string;
 }
 
@@ -111,8 +129,10 @@ function countLine({ contexts, inUse }: FileRow): string {
  * §6's right-hand rail: where srelens reads each cluster from.
  *
  * **Driven entirely by props**, like the table beside it — no fetch, no store,
- * no `isTauri()`. The screen owns the contexts, the probes and the stored file
- * list, so every state of this rail is reachable from a fixture.
+ * no `isTauri()`. The screen owns the contexts, the probes, the stored file
+ * list AND the platform, so every state of this rail is reachable from a
+ * fixture; see {@link SourcesRailProps.desktop} for why the platform is a prop
+ * rather than a call.
  *
  * Three sections, and the third is not the one the mock draws.
  *
@@ -142,16 +162,36 @@ function countLine({ contexts, inUse }: FileRow): string {
  * quietly contradicting a comment.
  *
  * The web build's capability denylist IS a real distinction, and it is
- * deliberately not mentioned here: it is a fact about the platform, and this
- * component's only platform signal is whether `onAddFile` was passed. That
- * prop says "this caller can open a file picker" — deriving "and therefore the
- * server refuses nine capabilities" from it would be inventing a platform
- * claim out of a UI callback. The Toolbox says that where it is true.
+ * deliberately not mentioned here even though `desktop` now says which build
+ * this is: the denylist is the SERVER's configuration, not a consequence of
+ * being served over HTTP, and the Toolbox says it where it is checked. What
+ * `desktop` may be spent on is whose machine a thing is on — nothing more. It
+ * is also why the platform is its own prop and not read off `onAddFile`, which
+ * says only "this caller can open a file picker": deriving "and therefore the
+ * server refuses nine capabilities" from a UI callback would be inventing a
+ * platform claim out of a button.
  */
-export function SourcesRail({ rows, files, onAddFile, className }: SourcesRailProps) {
+export function SourcesRail({ rows, files, onAddFile, desktop, className }: SourcesRailProps) {
   const headId = useId();
   const sources = fileRows(files, rows);
   const local = rows.filter((row) => row.context.isLocal);
+  /**
+   * Whose machine the two headings are about.
+   *
+   * Both said "this machine" / "this laptop" unconditionally, and in web mode
+   * neither is the reader's: the kubeconfig is the one the server was started
+   * with, and a kind or minikube cluster it declares runs on the SERVER's host
+   * — possibly a shared box in another building. The `Kubeconfig` heading sat
+   * directly above the paragraph telling that same reader files are added "on
+   * the desktop, where srelens has a filesystem to browse", so the rail
+   * contradicted itself two lines apart.
+   *
+   * The agent section's sentence is left alone: "whether the cluster runs on
+   * this laptop or across the internet" is a claim about the GATE being the
+   * same near and far, not about where any cluster runs.
+   */
+  const filesHead = desktop ? "Kubeconfig · on this machine" : "Kubeconfig · on the server's host";
+  const localHead = desktop ? "Local · runs on this laptop" : "Local · runs on the server's host";
 
   return (
     // The frame is fixed and does not scroll; the body does, exactly as
@@ -172,7 +212,7 @@ export function SourcesRail({ rows, files, onAddFile, className }: SourcesRailPr
           each row inert. Eight defects on this migration, none of them visible
           in jsdom — hence the class assertions in the suite. */}
       <div data-slot="rail-body" className="side-rail-body min-w-0">
-        <Section title="Kubeconfig · on this machine">
+        <Section title={filesHead}>
           <div className="flex min-w-0 flex-col gap-2.5">
             {sources.length === 0 ? (
               <p className="text-[0.8125rem] leading-snug text-muted">No kubeconfig files.</p>
@@ -247,7 +287,7 @@ export function SourcesRail({ rows, files, onAddFile, className }: SourcesRailPr
             box is a thing the reader has to look at and dismiss, and §6's own
             rail has no "you have no local clusters" state. */}
         {local.length > 0 && (
-          <Section title="Local · runs on this laptop">
+          <Section title={localHead}>
             <div data-testid="sources-local" className="flex min-w-0 flex-col gap-2.5">
               {local.map(({ context, probe }) => {
                 const via = viaOf(context);

--- a/packages/ui-next/src/screens/connections/SourcesRail.tsx
+++ b/packages/ui-next/src/screens/connections/SourcesRail.tsx
@@ -1,0 +1,292 @@
+import { useId } from "react";
+import { contextDisplayName, plural } from "@srelens/core";
+import { Badge, Button, Section, cx } from "@srelens/ui-kit";
+import type { ClusterRow } from "./ClusterTable";
+import { joined, latencyLabel, viaOf } from "./clusterText";
+
+/** §6's rail width, in px — see `SideRail`'s note on why a width is a number. */
+const WIDTH = 292;
+
+export interface SourcesRailProps {
+  /** Every cluster the screen is drawing, the same rows the table gets. */
+  rows: readonly ClusterRow[];
+  /** The stored kubeconfig paths, from `loadKubeconfigFiles()`. */
+  files: readonly string[];
+  /**
+   * Browse for a kubeconfig file to add.
+   *
+   * **Absent means there is no filesystem to browse, and the rail says so.**
+   * A callback rather than an `isTauri()` call of its own (which is what
+   * `Toolbox.tsx:188` does): the screen already knows which platform it is on,
+   * and a component that reads the platform itself cannot be rendered both
+   * ways from a fixture. The reason it is absent is printed once — see
+   * {@link SourcesRail}.
+   */
+  onAddFile?: () => void;
+  className?: string;
+}
+
+/** One line of §6's first section: a stored kubeconfig, and what came out of it. */
+interface FileRow {
+  path: string;
+  /** How many contexts in `rows` name this file. */
+  contexts: number;
+  /** How many of them are the kubeconfig's current context. */
+  inUse: number;
+}
+
+/**
+ * The files this rail lists: every stored path, plus every path a context
+ * actually came from.
+ *
+ * **Both directions matter, and each covers a hole the other leaves.**
+ *
+ * A stored path with no contexts is KEPT, because a path can be deleted, moved
+ * or emptied between runs while `saveKubeconfigFiles` still holds it — and a
+ * stored path that silently vanishes from this list is how a reader concludes
+ * they never added it.
+ *
+ * A path that no one stored is ADDED, because `files` is not the whole truth
+ * about where clusters are read from: `Window.tsx` reads
+ * `loadKubeconfigFiles()` only on the desktop and hands web mode `[]`, so
+ * without this the web build would draw an empty "where your clusters come
+ * from" section beside a table listing twelve of them. It exposes nothing new
+ * — the table's own `Via` column already prints the same path for every one of
+ * those rows.
+ *
+ * A context with no `sourceFile` at all (a synthesized cluster) contributes no
+ * row: an empty path drawn as a file is a line the reader cannot act on.
+ *
+ * Order is `files`' own, then first appearance in `rows`, so the list a reader
+ * curated keeps the order they curated it in. Dedupe is by exact path, which
+ * is what both sides are keyed on; two spellings of one file (a symlink, a
+ * trailing slash) are two entries, because this file has no filesystem to ask
+ * and inventing a normalisation would merge two paths that may genuinely
+ * differ.
+ */
+function fileRows(files: readonly string[], rows: readonly ClusterRow[]): FileRow[] {
+  const byPath = new Map<string, FileRow>();
+  const seed = (path: string) => {
+    if (path.trim() === "" || byPath.has(path)) return;
+    byPath.set(path, { path, contexts: 0, inUse: 0 });
+  };
+
+  for (const file of files) seed(file);
+  for (const { context } of rows) seed(context.sourceFile);
+
+  for (const { context } of rows) {
+    const entry = byPath.get(context.sourceFile);
+    if (!entry) continue;
+    entry.contexts += 1;
+    if (context.isCurrent) entry.inUse += 1;
+  }
+
+  return [...byPath.values()];
+}
+
+/**
+ * §6's `<n> contexts · <n> in use`.
+ *
+ * **`in use` is the kubeconfig's `current-context`** — the one context every
+ * other tool on this machine will pick up if nobody says otherwise. Core marks
+ * at most one context current across every merged file
+ * (`crates/kube/src/context_resolve.rs:141-145` takes the first match and
+ * stops), so this number is 0 or 1 per file and that IS the fact, not a
+ * miscount.
+ *
+ * It is deliberately NOT "how many probes came back reachable". That is a
+ * reading, the table already words it (`reachable`), and calling the same fact
+ * "in use" here would be two words for one thing — which is how two panes
+ * start disagreeing.
+ *
+ * `0 in use` is dropped for a file with no contexts: "0 contexts · 0 in use"
+ * says the second half twice, and the sentence under it is what explains the
+ * first.
+ */
+function countLine({ contexts, inUse }: FileRow): string {
+  return joined([plural(contexts, "context"), contexts > 0 ? `${inUse} in use` : undefined]);
+}
+
+/**
+ * §6's right-hand rail: where srelens reads each cluster from.
+ *
+ * **Driven entirely by props**, like the table beside it — no fetch, no store,
+ * no `isTauri()`. The screen owns the contexts, the probes and the stored file
+ * list, so every state of this rail is reachable from a fixture.
+ *
+ * Three sections, and the third is not the one the mock draws.
+ *
+ * **1. The kubeconfig files.** A path, and how many contexts came out of it.
+ * A file that yields none is still listed — see {@link fileRows}.
+ *
+ * **2. The local clusters.** Name, `via` and the round trip, from the same two
+ * helpers the table uses (`./clusterText`), so a reading cannot read one way
+ * here and another way six inches to the left. No reading means no badge; it
+ * never means `0 ms`.
+ *
+ * **3. What the agent may reach — ONE SENTENCE, AND NO BADGE PER CLUSTER.**
+ * §6's mock draws `read + write` / `read only` per cluster. There is no such
+ * distinction anywhere in srelens, and this was established rather than
+ * assumed: every mutating capability carries `requires_confirm`, enforced as a
+ * build-time invariant against the real registry
+ * (`crates/mcp/src/completeness.rs:36-45`), and `tools/call` blocks on that
+ * confirmation before invoking anything (`crates/mcp/src/stdio.rs:156-183`).
+ * `isLocal` appears nowhere in that chain — not in `policy.rs`, not in
+ * `consent_kind`, not in the desktop's `PromptUser::confirm`. No cluster is
+ * read-only in srelens's own logic: the only outright refusals are the
+ * cluster's own RBAC (per verb, not per cluster) and `WEB_DENIED_CAPABILITIES`
+ * (per platform, not per cluster). Two badges that differ by nothing would
+ * imply a setting the reader can change, and there is none — so the section
+ * says the true thing once. The suite asserts the section draws no `.badge`
+ * and names no cluster, so restoring the mock's shape fails a test rather than
+ * quietly contradicting a comment.
+ *
+ * The web build's capability denylist IS a real distinction, and it is
+ * deliberately not mentioned here: it is a fact about the platform, and this
+ * component's only platform signal is whether `onAddFile` was passed. That
+ * prop says "this caller can open a file picker" — deriving "and therefore the
+ * server refuses nine capabilities" from it would be inventing a platform
+ * claim out of a UI callback. The Toolbox says that where it is true.
+ */
+export function SourcesRail({ rows, files, onAddFile, className }: SourcesRailProps) {
+  const headId = useId();
+  const sources = fileRows(files, rows);
+  const local = rows.filter((row) => row.context.isLocal);
+
+  return (
+    // The frame is fixed and does not scroll; the body does, exactly as
+    // `ReleasePane` splits them. A `scroll` on the aside would put the head out
+    // of reach of a reader half way down a long file list.
+    <aside
+      aria-labelledby={headId}
+      className={cx("side-rail", className)}
+      style={{ width: WIDTH }}
+    >
+      <div id={headId} className="pane-head">
+        Sources
+      </div>
+
+      {/* `min-w-0` here as well as on every row below: this body is the flex
+          child that a 70-character filesystem path would otherwise refuse to
+          shrink below, and `min-width: auto` is what makes the truncation in
+          each row inert. Eight defects on this migration, none of them visible
+          in jsdom — hence the class assertions in the suite. */}
+      <div data-slot="rail-body" className="side-rail-body min-w-0">
+        <Section title="Kubeconfig · on this machine">
+          <div className="flex min-w-0 flex-col gap-2.5">
+            {sources.length === 0 ? (
+              <p className="text-[0.8125rem] leading-snug text-muted">No kubeconfig files.</p>
+            ) : (
+              sources.map((source) => (
+                <div
+                  key={source.path}
+                  data-testid="source-file"
+                  className="flex min-w-0 flex-col gap-0.5"
+                >
+                  {/* `block` is what makes `truncate`'s `overflow: hidden`
+                      apply at all, and `max-w-` caps the intrinsic width that
+                      `white-space: nowrap` would otherwise set to the whole
+                      path. 252px is the rail's 292 less the section's inset.
+                      The `title` carries the full path, which is the same
+                      string, so nothing is hidden behind the hover. */}
+                  <span
+                    className="block max-w-[252px] truncate font-mono text-[0.75rem]"
+                    title={source.path}
+                  >
+                    {source.path}
+                  </span>
+                  <span className="path text-faint">{countLine(source)}</span>
+                  {source.contexts === 0 && (
+                    <p className="text-[0.8125rem] leading-snug text-muted">
+                      No contexts came from this file. It may have been moved, deleted or emptied
+                      since it was added.
+                    </p>
+                  )}
+                </div>
+              ))
+            )}
+
+            {onAddFile ? (
+              <div className="flex">
+                <Button size="xs" variant="secondary" onClick={onAddFile}>
+                  Add
+                </Button>
+              </div>
+            ) : (
+              /* Said once, for the section, rather than as a disabled button —
+                 the Toolbox's absent install column is the precedent. A
+                 control that is not there needs its reason on the screen; a
+                 reader who cannot see one concludes srelens lost the feature. */
+              <p className="text-[0.8125rem] leading-snug text-muted">
+                Kubeconfig files are added on the desktop, where srelens has a filesystem to
+                browse.
+              </p>
+            )}
+
+            {/* §6's footnote, verbatim. It is the whole answer to "what does
+                srelens do with my credentials", and it is answered before the
+                reader has to ask. */}
+            <p className="text-[0.8125rem] leading-snug text-muted">
+              srelens reads these files in place and connects to the API server directly. Nothing is
+              copied anywhere.
+            </p>
+          </div>
+        </Section>
+
+        {/* Nothing is drawn when no cluster runs here: a heading over an empty
+            box is a thing the reader has to look at and dismiss, and §6's own
+            rail has no "you have no local clusters" state. */}
+        {local.length > 0 && (
+          <Section title="Local · runs on this laptop">
+            <div data-testid="sources-local" className="flex min-w-0 flex-col gap-2.5">
+              {local.map(({ context, probe }) => {
+                const via = viaOf(context);
+                const reading = latencyLabel(probe);
+                return (
+                  <div key={context.stableId} className="flex min-w-0 items-start gap-2">
+                    {/* No `max-w-` on these two, unlike the path above: this
+                        column is `flex-1 min-w-0` inside a frame of a FIXED
+                        width, so its content is already bounded and a cap
+                        would clip a name early whenever the reading beside it
+                        is absent. The table needed caps because an auto-layout
+                        table cell sizes to its content instead. */}
+                    <div className="flex min-w-0 flex-1 flex-col">
+                      <span className="block truncate font-medium" title={context.name}>
+                        {contextDisplayName(context.name)}
+                      </span>
+                      {via !== "" && (
+                        <span className="path block truncate font-mono" title={via}>
+                          {via}
+                        </span>
+                      )}
+                    </div>
+                    {reading !== null && (
+                      // `shrink-0`: the reading is short and fixed, and the
+                      // name and endpoint are what absorb a long line. Toned
+                      // `muted` deliberately — a round trip is a network
+                      // duration, not a health verdict, and the table puts no
+                      // colour on it either.
+                      <span data-slot="local-reading" className="shrink-0">
+                        <Badge tone="muted">{reading}</Badge>
+                      </span>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </Section>
+        )}
+
+        <Section title="What the agent may reach">
+          <div data-testid="sources-agent">
+            <p className="text-[0.8125rem] leading-snug text-muted">
+              Every change the agent makes to any cluster on this list stops at a confirmation
+              prompt first — the same gate whether the cluster runs on this laptop or across the
+              internet.
+            </p>
+          </div>
+        </Section>
+      </div>
+    </aside>
+  );
+}

--- a/packages/ui-next/src/screens/connections/SourcesRail.tsx
+++ b/packages/ui-next/src/screens/connections/SourcesRail.tsx
@@ -197,9 +197,19 @@ export function SourcesRail({ rows, files, onAddFile, className }: SourcesRailPr
                   </span>
                   <span className="path text-faint">{countLine(source)}</span>
                   {source.contexts === 0 && (
+                    /* **Four causes, and the likeliest one first.** This named
+                       three and left out the one a reader hits right after
+                       `Add a kubeconfig file`: a file srelens could not parse.
+                       `resolve_contexts` skips an unreadable or invalid
+                       kubeconfig silently (`Kubeconfig::read_from(path).ok()`),
+                       so the path stays on the stored list and still yields
+                       nothing. Telling someone who has just picked a file that
+                       it may have been deleted sends them after the wrong
+                       problem. */
                     <p className="text-[0.8125rem] leading-snug text-muted">
-                      No contexts came from this file. It may have been moved, deleted or emptied
-                      since it was added.
+                      No contexts came from this file. srelens may not have been able to read it as
+                      a kubeconfig, or it may have been moved, deleted or emptied since it was
+                      added.
                     </p>
                   )}
                 </div>

--- a/packages/ui-next/src/screens/connections/clusterText.ts
+++ b/packages/ui-next/src/screens/connections/clusterText.ts
@@ -38,6 +38,56 @@ export function joined(parts: readonly (string | undefined)[]): string {
 }
 
 /**
+ * §6's `Source`, and the whole of its vocabulary.
+ *
+ * Two values, from `isLocal`. **`Team server` is never one of them** — §6's
+ * third source signs in to a team server and lists its members with presence,
+ * and no capability in core reports either (spec decision 5). A column that
+ * could say it would be a column asserting a backend srelens does not have.
+ *
+ * Here rather than in `ClusterTable` because the table now heads each group
+ * with this word as well as printing it in the cell — one word for one fact, so
+ * a heading cannot come to say something the cell under it does not.
+ */
+export function sourceOf(context: ClusterContext): string {
+  return context.isLocal ? "Local" : "Kubeconfig";
+}
+
+/**
+ * Clusters grouped by where they come from, as §6 groups them.
+ *
+ * **Kubeconfig contexts first, then local clusters** — §6's own order is
+ * `team` → `file` → `local`, and with the team server out of scope (spec
+ * decision 5) that leaves file before local. It is also the order the Sources
+ * rail lists its sections in (`Kubeconfig · on this machine`, then
+ * `Local · runs on this laptop`), so a reader's eye maps a group in the table
+ * onto the section beside it.
+ *
+ * **Both screens that draw a cluster list call this**, and that is why it is
+ * here rather than in `ClusterTable` where it began. `/connect` listed in raw
+ * `listContexts` order, so a reader moving between the two screens in one click
+ * met the same clusters in two orders — visible immediately, and with two sorts
+ * for one set it is how they would drift apart again.
+ *
+ * Stable within each group: whatever order the caller listed its clusters in
+ * survives, because `listContexts` returns them in the kubeconfig's own order
+ * and re-sorting them here would be this file inventing a second opinion about
+ * a list the rail already draws one way.
+ *
+ * Takes the predicate rather than a `ClusterContext` accessor: the table groups
+ * rows that HOLD a context, `/connect` groups the contexts themselves, and one
+ * implementation serving both is the whole point.
+ *
+ * The predicate may answer `undefined`, because `ClusterContext.isLocal` is
+ * optional in core and a context that says nothing about it is a kubeconfig
+ * one. Absent reads as "not local" here rather than at each call site, where
+ * three spellings of `=== true` would be three chances to get it wrong.
+ */
+export function bySource<T>(items: readonly T[], isLocal: (item: T) => boolean | undefined): T[] {
+  return [...items.filter((item) => !isLocal(item)), ...items.filter((item) => isLocal(item))];
+}
+
+/**
  * The host a cluster answers on, for a local cluster's `Via`.
  *
  * `new URL` rather than a regexp, and the raw string when it will not parse: a

--- a/packages/ui-next/src/screens/connections/clusterText.ts
+++ b/packages/ui-next/src/screens/connections/clusterText.ts
@@ -1,0 +1,83 @@
+import type { ClusterContext } from "@srelens/core";
+import type { Probe } from "../../lib/probe";
+
+/**
+ * The words two surfaces of §6 have to agree on: the table's cells and the
+ * Sources rail's rows.
+ *
+ * These three started private in `ClusterTable.tsx`. They live here because
+ * the rail renders the same facts about the same clusters — a local cluster's
+ * `Via`, its round trip, and a line assembled out of parts that may be missing
+ * — and a second copy of any of them is how two panes six inches apart start
+ * disagreeing about one reading. The latency formatter in particular: its
+ * whole job is to never print `0 ms`, and a second formatter written beside it
+ * is exactly how that rule gets lost.
+ */
+
+/**
+ * The one separator on this screen, and the only place parts are joined.
+ *
+ * Every caller has parts that may be missing — a cluster with no region, a
+ * local cluster with no detected provider, a file with no contexts to count in
+ * use — so the filter is here rather than at each site. `· ·` and a line that
+ * begins or ends with a separator tell a reader nothing and look broken, and
+ * both are what an unconditional `parts.join(" · ")` produces.
+ *
+ * An empty string means there was nothing to say; callers render NOTHING for
+ * it rather than an empty line.
+ */
+export function joined(parts: readonly (string | undefined)[]): string {
+  return parts
+    .map((part) => part?.trim() ?? "")
+    .filter((part) => part.length > 0)
+    .join(" · ");
+}
+
+/**
+ * The host a cluster answers on, for a local cluster's `Via`.
+ *
+ * `new URL` rather than a regexp, and the raw string when it will not parse: a
+ * `server` srelens cannot read is still what the kubeconfig says, and printing
+ * it verbatim is more use to a reader than an invented "unknown". Unix-socket
+ * and non-URL servers arrive here too.
+ */
+function hostOf(server: string): string {
+  try {
+    return new URL(server).host || server;
+  } catch {
+    return server;
+  }
+}
+
+/**
+ * §6's `Via`: what the cluster is actually reached THROUGH.
+ *
+ * For a kubeconfig context that is the file it was declared in — the column's
+ * whole reason for existing, and the field decision 1 added. For a local
+ * cluster the file is beside the point (kind writes one for you); what
+ * identifies it is the tool that made it and the endpoint it listens on.
+ */
+export function viaOf(context: ClusterContext): string {
+  return context.isLocal ? joined([context.provider, hostOf(context.server)]) : context.sourceFile;
+}
+
+/**
+ * The round trip, or nothing.
+ *
+ * **Gated on the STATE as well as on the number.** `probe.ts` documents
+ * `latencyMs` as absent unless the state is `reachable`, so the two gates
+ * agree today — but this is what a reader trusts, and `0 ms` on a cluster
+ * that never answered reads as "instant", which is the exact opposite of the
+ * truth (spec decision 4). One gate would leave that one drift away; two make
+ * it structural.
+ *
+ * A reading under half a millisecond is a real reading of a cluster on this
+ * laptop, and it is NOT discarded — it is drawn as `<1 ms`, because rounding it
+ * to `0 ms` would put on screen the one string this may never show.
+ */
+export function latencyLabel(probe: Probe): string | null {
+  if (probe.state !== "reachable") return null;
+  const ms = probe.latencyMs;
+  if (typeof ms !== "number" || !Number.isFinite(ms) || ms < 0) return null;
+  return ms < 0.5 ? "<1 ms" : `${Math.round(ms)} ms`;
+}

--- a/packages/ui-next/src/screens/connections/clusterText.ts
+++ b/packages/ui-next/src/screens/connections/clusterText.ts
@@ -1,17 +1,21 @@
 import type { ClusterContext } from "@srelens/core";
-import type { Probe } from "../../lib/probe";
+import type { BadgeTone } from "@srelens/ui-kit";
+import type { Probe, ProbeState } from "../../lib/probe";
 
 /**
- * The words two surfaces of §6 have to agree on: the table's cells and the
- * Sources rail's rows.
+ * The words the surfaces that draw a cluster have to agree on: §6's table
+ * cells, the Sources rail's rows, and §24's first-run card.
  *
- * These three started private in `ClusterTable.tsx`. They live here because
- * the rail renders the same facts about the same clusters — a local cluster's
- * `Via`, its round trip, and a line assembled out of parts that may be missing
- * — and a second copy of any of them is how two panes six inches apart start
- * disagreeing about one reading. The latency formatter in particular: its
- * whole job is to never print `0 ms`, and a second formatter written beside it
- * is exactly how that rule gets lost.
+ * All of them started private in a screen. `joined`, `viaOf` and
+ * `latencyLabel` came out of `ClusterTable.tsx`; {@link STATUS} came out of
+ * `ClusterTable.tsx` and `Connect.tsx` at once, where the same three pairs had
+ * been written twice. They live here because those screens render the same
+ * facts about the same clusters — a local cluster's `Via`, its round trip, a
+ * line assembled out of parts that may be missing, and what the last probe
+ * said — and a second copy of any of them is how two panes six inches apart
+ * start disagreeing about one reading. The latency formatter in particular:
+ * its whole job is to never print `0 ms`, and a second formatter written
+ * beside it is exactly how that rule gets lost.
  */
 
 /**
@@ -81,3 +85,30 @@ export function latencyLabel(probe: Probe): string | null {
   if (typeof ms !== "number" || !Number.isFinite(ms) || ms < 0) return null;
   return ms < 0.5 ? "<1 ms" : `${Math.round(ms)} ms`;
 }
+
+/**
+ * The three words a probe can put on a row, and the tone each is worth.
+ *
+ * **No cluster is ever `healthy` or `degraded`** (spec decision 3). §6's mock
+ * tones `healthy`→ok and `degraded`→sev, and the spec refuses both:
+ * `connectCluster` reports whether the API server answered, and calling that
+ * answer a health verdict claims a check that never ran. What is drawn is the
+ * reading itself.
+ *
+ * `unread` is the absence, NAMED as an absence. Not a third status word
+ * ("pending", "idle") — those read as things the cluster is, and this is a
+ * thing srelens has not done yet.
+ *
+ * **One table, and this is the only copy of it.** It was private in
+ * `ClusterTable.tsx` and written again in `Connect.tsx`, because promoting it
+ * would have meant editing a file under review in a parallel task — which is
+ * what the note there said, along with where the table belonged. This project
+ * has already taken ten hand-paired label/tone tables out of the screens that
+ * held them; that pair was the eleventh. It sits beside {@link latencyLabel},
+ * which the first-run card already imported for exactly this reason.
+ */
+export const STATUS: Record<ProbeState, { word: string; tone: BadgeTone }> = {
+  reachable: { word: "reachable", tone: "ok" },
+  unreachable: { word: "unreachable", tone: "sev" },
+  unread: { word: "no reading", tone: "muted" },
+};

--- a/packages/ui-next/src/screens/overview/Fleet.test.tsx
+++ b/packages/ui-next/src/screens/overview/Fleet.test.tsx
@@ -15,7 +15,10 @@ import { statusTone, toneColor } from "@srelens/ui-kit";
 import { Fleet } from "./Fleet";
 
 function aContext(name: string): ClusterContext {
-  return { name, stableId: name, cluster: name, server: `https://${name}`, isCurrent: false };
+  return {
+    name, stableId: name, cluster: name, server: `https://${name}`, isCurrent: false,
+    sourceFile: "/home/dana/.kube/config", authKind: "client certificate",
+  };
 }
 
 /** A 401 as it actually reaches this component, from a real kubeconfig context. */

--- a/packages/ui-next/src/screens/toolbox/ExecAuthRail.test.tsx
+++ b/packages/ui-next/src/screens/toolbox/ExecAuthRail.test.tsx
@@ -421,6 +421,8 @@ describe("Toolbox mounts the rail", () => {
     cluster: "prod",
     server: "https://prod",
     isCurrent: true,
+    sourceFile: "/home/dana/.kube/config",
+    authKind: "exec plugin · gcloud",
   };
 
   it("puts it beside the inventory without losing the pane head", async () => {

--- a/packages/ui-next/src/shell/Chrome.test.tsx
+++ b/packages/ui-next/src/shell/Chrome.test.tsx
@@ -42,7 +42,10 @@ vi.mock("@srelens/core", async (orig) => ({
   isApplePlatform: platform,
 }));
 
-const ctx = (id: string) => ({ name: id, stableId: id, cluster: id, server: "", isCurrent: false });
+const ctx = (id: string) => ({
+  name: id, stableId: id, cluster: id, server: "", isCurrent: false,
+  sourceFile: "/home/dana/.kube/config", authKind: "client certificate",
+});
 
 beforeEach(() => {
   setState(defaultState([ctx("prod")]));

--- a/packages/ui-next/src/shell/Nav.test.tsx
+++ b/packages/ui-next/src/shell/Nav.test.tsx
@@ -22,6 +22,8 @@ const ctx = (name: string): ClusterContext => ({
   cluster: name,
   server: "https://example",
   isCurrent: false,
+  sourceFile: "/home/dana/.kube/config",
+  authKind: "client certificate",
 });
 
 const PROD = ctx("prod-eu");

--- a/packages/ui-next/src/shell/Rail.test.tsx
+++ b/packages/ui-next/src/shell/Rail.test.tsx
@@ -26,6 +26,8 @@ const ctx = (name: string): ClusterContext => ({
   cluster: name,
   server: `https://${name}.example`,
   isCurrent: false,
+  sourceFile: "/home/dana/.kube/config",
+  authKind: "client certificate",
 });
 
 const CONTEXTS = [ctx("prod-eu"), ctx("staging")];

--- a/packages/ui-next/src/shell/Status.test.tsx
+++ b/packages/ui-next/src/shell/Status.test.tsx
@@ -50,7 +50,10 @@ vi.mock("../lib/helmOps", () => ({
   },
 }));
 
-const ctx = { name: "prod-eu", stableId: "prod", cluster: "c", server: "", isCurrent: false };
+const ctx = {
+  name: "prod-eu", stableId: "prod", cluster: "c", server: "", isCurrent: false,
+  sourceFile: "/home/dana/.kube/config", authKind: "client certificate",
+};
 
 beforeEach(() => {
   forwards.list = [];

--- a/packages/ui-next/src/shell/Window.test.tsx
+++ b/packages/ui-next/src/shell/Window.test.tsx
@@ -102,7 +102,10 @@ import { defaultState, makeTab } from "../lib/tabs";
 import { defaultMark, getMark, setMark, MARKS_KEY } from "../lib/marks";
 import { contextFor, getContextsError, getContextsStatus, resetContexts } from "../lib/clusters";
 
-const ctx = (stableId: string, name = stableId) => ({ name, stableId, cluster: name, server: "", isCurrent: false });
+const ctx = (stableId: string, name = stableId) => ({
+  name, stableId, cluster: name, server: "", isCurrent: false,
+  sourceFile: "/home/dana/.kube/config", authKind: "client certificate",
+});
 
 beforeEach(() => {
   listContexts.mockReset().mockResolvedValue({ contexts: [ctx("prod")] });

--- a/scripts/screenshot.mjs
+++ b/scripts/screenshot.mjs
@@ -404,6 +404,10 @@ const TITLES = {
   // screen's own heading is the longer word. `CLUSTER_SCOPED` in routes.ts.
   "/terminals": ["Shell", "terminal"],
   "/toolbox": ["Toolbox", "toolbox"],
+  "/connections": ["Connections", "connections"],
+  // "Connect a cluster", not "Connect": the tab strip carries the whole title
+  // from `APP_SCOPED` in routes.ts, and the screen's own headline is neither.
+  "/connect": ["Connect a cluster", "connect"],
   "/topology": ["Topology", "topology"],
   "/incidents": ["Incidents", "incidents"],
 };
@@ -423,7 +427,12 @@ function tabFor(r, id) {
   // App-scoped routes carry no cluster in their sub — `APP_SCOPED` in
   // packages/ui-next/src/lib/routes.ts is the list, and the toolbox is on it:
   // the managed tools are the machine's, not any one cluster's.
-  if (name && !["/applog", "/notes", "/toolbox"].includes(r)) tab.sub = name;
+  // `/connections` and `/connect` are on it too, and for a sharper reason than
+  // the toolbox: both are about every cluster srelens can see (or none at all),
+  // so a tab naming one of them would be the strip claiming a scope the screen
+  // does not have.
+  if (name && !["/applog", "/notes", "/toolbox", "/connections", "/connect"].includes(r))
+    tab.sub = name;
   return tab;
 }
 


### PR DESCRIPTION
> **Draft:** the final review's fix wave is landing on this branch now — three of its findings block. I will mark this ready when they are in. Details at the bottom.

Step 8, first of two specs: `/connections` says where each cluster comes from and which credential it uses; `/connect` is the first-run door. `Settings` and `LockScreen` follow in their own spec — `SettingsView.tsx` is 1,189 lines with four section components, and `LockScreen` is window chrome rather than a screen.

**Spec:** `docs/superpowers/specs/2026-08-26-new-design-connections-design.md`

## What these screens are for

The cluster rail already lists every cluster and selects one. A second table answering "which cluster am I working in" would put that question in two places. So `/connections` is about **where clusters come from** — which kubeconfig files are in play, what credential each context uses, whether it answers. §6's own structure says so: its second pane is headed `Sources`, and its table is *grouped by credential source* rather than sorted by name.

## What ships

- **A source file and a credential kind on the Rust context DTO.** Both were already in hand where contexts are built — `ContextDto`'s doc comment for `stableId` says as much. Each kubeconfig is parsed once, pinned by a test that hands the resolver a path that **provably does not exist**, so any disk read by any route fails rather than merely being counted.
- **Latency and a three-state reading** on the existing probe store — extended rather than duplicated, because a `probe.ts` already owned that job.
- **The table**, grouped by source with a heading that **drops while a sort is active** and returns when it clears, because a latency sort interleaves the groups. Holding or visibly stopping were the only honest options.
- **A 292px `Sources` rail**, listing each kubeconfig file with the contexts it declares.
- **`/connect`**, listing the same clusters in the same order, via the same promoted grouping.
- **Two kit changes:** a pinned action column, and group heading rows.

## Decisions worth a reviewer's attention

**An auth kind names a mechanism, never a credential.** No token, certificate body, password, exec plugin argument, or path. The exec command is reduced to its basename, so a generated path like `/opt/creds/AKIA…/get-token.sh` cannot reach a table cell. A review got `oidc · refresh-token:abc.def.SECRET` out of an earlier version; the account suffix is now **removed entirely** rather than guarded — the guard was defeatable (a zero-width space is not `char::is_whitespace`), and `k8s.listContexts` is ungated, so every field reaches the reader's agent. The kind is what the column exists for; the account was decoration costing a check plus a disclosure.

**`Expires` is not built.** srelens cannot know an exec plugin's version requirement. On a screen about credentials, a wrong expiry claim actively misleads.

**`Status` is `reachable` / `unreachable` / no reading.** `healthy` and `degraded` are words a reachability probe cannot earn.

**Latency is absent when there is no reading, never `0`.** A zero reads as "instant" — the opposite of the truth.

**The team-server presence section of §6 is out of scope**, in writing. It needs a session model, a presence channel, and a server reporting who is looking at what. Building it inside a migration step would smuggle a feature into a port.

**Adding or pasting a kubeconfig is desktop-only.** Web has no filesystem the reader can browse, and already over-lists the server's own kubeconfig (#347). Neither control is drawn there, and the reason is given once.

**The agent-gate section is one sentence, not per-cluster badges.** An investigation established there is no per-cluster read/write distinction: every agent write is gated — enforced by a build-time invariant that panics if a mutating capability lacks `requires_confirm` — and `isLocal` never enters the gate. Two badges differing by nothing would imply a setting the reader can change.

## Verification

4,188 tests across core/ui-kit/ui-next, 732 in apps/desktop, coverage 92.43 / 88.60 / 82.01 against floors 85 / 80 / 76, `pnpm -r typecheck`, 583 cargo tests, both builds.

Every task ran a mutation pass. **Six tests were found to pass for the wrong reason** and fixed — four by the implementers themselves. Two are worth naming: fixtures where `stableId` equalled `name` hid a key conflation that passed 23 of 23 while it would have emptied the provider column for every cluster on every platform; and a test hanging the *last* context let a serial probe loop pass all 26.

**Measured, not estimated:** `Open` was off-screen at the default 1600px window on every row — its rect `x=1311…1355` against a visible edge of `1308`, needing 1668px to appear. Pinning the column moves it to `x=1253` at 1600px and `x=613` at 960px, verified on all 17 rows of a real cluster. Disclosed cost: while the table overflows, the pinned column covers 59px of the `Status` cell until a 72px pan.

## Known limits, written down

- Layout is browser-verified in **dark theme only**, and in Chromium via web mode — the desktop ships WKWebView.
- `/connections` lists and opens; **it does not remove a source.** Removing a file takes every context it contributed, and after #365 the cluster rail is reachable mid-dialog, so it inherits that PR's captured-context rule. Filed rather than half-built.
- `rowGroup`'s heading height is outside the virtualizer's scroll math — cosmetic here (two groups, virtualization above 60 rows), documented for future consumers.
- No concurrency cap on probing: one request per context, unbounded.

## Landing with this PR

The final review returned **fix first**. Three blocking items, all cheap:

1. `/connect`'s lede told a **web** reader *"Nothing about your clusters leaves this machine"* while the same card said *"This build talks to a shared server."* Fifth instance on this branch of a string claiming more than srelens knows.
2. The paste dialog said the file goes *"beside your other kubeconfigs"*; it goes to the app config directory. Classic worded the same operation correctly — the migration turned a true sentence false.
3. `auth_kind`'s join to the DTO was unpinned: replacing it with `"none"` passed 408/408, which would have left the `Auth` column dead on every platform.

Plus: an empty badge satisfied an assertion written to prove no reading was taken; two doc comments in a shared store went stale as this branch added a second writer; and the in-flight probe guard deleted its entry by key rather than by identity.
