### PR TITLE
fix: 0.7.3 — download every retained pod log line, and icon-button tooltips after 200 ms

### DIFF
--- a/apps/desktop/src/components/DetailActions.test.tsx
+++ b/apps/desktop/src/components/DetailActions.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 
 const {
@@ -74,6 +75,14 @@ function isDisabled(el: HTMLElement): boolean {
 }
 function titleOf(el: HTMLElement): string | null {
   return el.getAttribute("title");
+}
+// IconButton explains itself through a Radix tooltip, not a native title
+// (#376): hover its trigger — the button, or the wrapper around a disabled
+// one, which is what still gets pointer events — and read the tooltip.
+async function tooltipOf(el: HTMLElement): Promise<string | null> {
+  const trigger = el.closest<HTMLElement>('[data-slot="tooltip-trigger"]') ?? el;
+  await userEvent.hover(trigger);
+  return (await screen.findByRole("tooltip")).textContent;
 }
 
 beforeEach(() => {
@@ -868,7 +877,7 @@ describe("ResourceActions", () => {
 describe("PodActions RBAC gating", () => {
   const prodPod = { ...pod, namespace: "prod" };
 
-  it("disables the Delete control and explains why when the user can't delete", () => {
+  it("disables the Delete control and explains why when the user can't delete", async () => {
     vi.mocked(useAccess).mockReturnValue({
       allowed: () => false,
       reason: () => "RBAC: no rule",
@@ -878,7 +887,7 @@ describe("PodActions RBAC gating", () => {
     render(<PodActions context="kind-dev" pod={prodPod} onDeleted={() => {}} />);
     const del = screen.getByRole("button", { name: "Delete" });
     expect(isDisabled(del)).toBe(true);
-    expect(titleOf(del)).toEqual(expect.stringContaining("permission to delete pods in prod"));
+    expect(await tooltipOf(del)).toEqual(expect.stringContaining("permission to delete pods in prod"));
   });
 
   it("enables Delete when allowed", () => {
@@ -892,7 +901,7 @@ describe("PodActions RBAC gating", () => {
     expect(isDisabled(screen.getByRole("button", { name: "Delete" }))).toBe(false);
   });
 
-  it("disables Evict and explains why when the user can't evict", () => {
+  it("disables Evict and explains why when the user can't evict", async () => {
     vi.mocked(useAccess).mockReturnValue({
       allowed: () => false,
       reason: () => "RBAC: no rule",
@@ -902,10 +911,10 @@ describe("PodActions RBAC gating", () => {
     render(<PodActions context="kind-dev" pod={prodPod} onDeleted={() => {}} />);
     const evict = screen.getByRole("button", { name: "Evict" });
     expect(isDisabled(evict)).toBe(true);
-    expect(titleOf(evict)).toEqual(expect.stringContaining("permission to create pods/eviction in prod"));
+    expect(await tooltipOf(evict)).toEqual(expect.stringContaining("permission to create pods/eviction in prod"));
   });
 
-  it("disables the pod Edit control and explains why when the user can't patch pods", () => {
+  it("disables the pod Edit control and explains why when the user can't patch pods", async () => {
     vi.mocked(useAccess).mockReturnValue({
       allowed: () => false,
       reason: () => "RBAC: no rule",
@@ -915,7 +924,7 @@ describe("PodActions RBAC gating", () => {
     render(<PodActions context="kind-dev" pod={prodPod} onDeleted={() => {}} onEdit={() => {}} />);
     const edit = screen.getByRole("button", { name: "Edit" });
     expect(isDisabled(edit)).toBe(true);
-    expect(titleOf(edit)).toEqual(expect.stringContaining("permission to patch pods in prod"));
+    expect(await tooltipOf(edit)).toEqual(expect.stringContaining("permission to patch pods in prod"));
   });
 
   it("enables the pod Edit control when allowed", () => {
@@ -931,7 +940,7 @@ describe("PodActions RBAC gating", () => {
 });
 
 describe("ResourceActions RBAC gating", () => {
-  it("disables the Delete control and explains why when the user can't delete", () => {
+  it("disables the Delete control and explains why when the user can't delete", async () => {
     vi.mocked(useAccess).mockReturnValue({
       allowed: () => false,
       reason: () => "RBAC: no rule",
@@ -949,7 +958,7 @@ describe("ResourceActions RBAC gating", () => {
     );
     const del = screen.getByRole("button", { name: "Delete" });
     expect(isDisabled(del)).toBe(true);
-    expect(titleOf(del)).toEqual(expect.stringContaining("permission to delete deployments in prod"));
+    expect(await tooltipOf(del)).toEqual(expect.stringContaining("permission to delete deployments in prod"));
   });
 
   it("enables Delete when allowed", () => {
@@ -971,7 +980,7 @@ describe("ResourceActions RBAC gating", () => {
     expect(isDisabled(screen.getByRole("button", { name: "Delete" }))).toBe(false);
   });
 
-  it("disables Scale when the user can't patch the scale subresource", () => {
+  it("disables Scale when the user can't patch the scale subresource", async () => {
     vi.mocked(useAccess).mockReturnValue({
       allowed: () => false,
       reason: () => "RBAC: no rule",
@@ -989,7 +998,7 @@ describe("ResourceActions RBAC gating", () => {
     );
     const scale = screen.getByRole("button", { name: "Scale" });
     expect(isDisabled(scale)).toBe(true);
-    expect(titleOf(scale)).toEqual(expect.stringContaining("permission to patch deployments/scale in prod"));
+    expect(await tooltipOf(scale)).toEqual(expect.stringContaining("permission to patch deployments/scale in prod"));
   });
 
   it("disables Restart when the user can't patch the workload", () => {

--- a/apps/desktop/src/components/LogsView.test.tsx
+++ b/apps/desktop/src/components/LogsView.test.tsx
@@ -328,7 +328,7 @@ describe("LogsView", () => {
     render(<LogsView context="kind-dev" namespace="default" source={{ type: "pod", pod: "web-1" }} />);
     await waitFor(() => expect(screen.getByRole("combobox", { name: "Container" })).toBeDefined());
 
-    fireEvent.click(screen.getByRole("button", { name: "Download all containers" }));
+    fireEvent.click(screen.getByRole("button", { name: "Download all container logs" }));
     await waitFor(() =>
       expect(saveTextFileMock).toHaveBeenCalledWith(
         "web-1-all.log",
@@ -337,5 +337,58 @@ describe("LogsView", () => {
     );
     expect(saveTextFileMock.mock.calls[0][1]).toContain("==> web-1/sidecar <==");
     expect(saveTextFileMock.mock.calls[0][1]).toContain("sidecar logs");
+  });
+
+  it("downloads every retained line for all containers, unbounded by the tail/since filters", async () => {
+    // #353: the full dump used to inherit the view's tail (200) and since
+    // window, so "all" was really "the last 200 lines". It must ask for
+    // everything the cluster still holds and leave both bounds out entirely.
+    getObjectMock.mockResolvedValue({
+      object: { spec: { containers: [{ name: "app" }, { name: "sidecar" }] } },
+    });
+    render(<LogsView context="kind-dev" namespace="default" source={{ type: "pod", pod: "web-1" }} />);
+    await waitFor(() => expect(screen.getByRole("combobox", { name: "Container" })).toBeDefined());
+    // Narrow the on-screen view first so the dump's independence is visible.
+    await userEvent.click(screen.getByRole("combobox", { name: "Since" }));
+    await userEvent.click(await screen.findByRole("option", { name: "Last 5m" }));
+    await waitFor(() =>
+      expect(podLogsMock).toHaveBeenCalledWith(
+        "kind-dev",
+        "default",
+        "web-1",
+        undefined,
+        expect.objectContaining({ sinceSeconds: 300, tailLines: 200 }),
+      ),
+    );
+    podLogsMock.mockClear();
+
+    fireEvent.click(screen.getByRole("button", { name: "Download all container logs" }));
+    await waitFor(() => expect(saveTextFileMock).toHaveBeenCalledWith("web-1-all.log", expect.any(String)));
+
+    const dumpCalls = podLogsMock.mock.calls as [string, string, string, unknown, Record<string, unknown>][];
+    expect(dumpCalls.map((c) => c[4].container)).toEqual(["app", "sidecar"]);
+    for (const [, , , , opts] of dumpCalls) {
+      expect(opts.allLines).toBe(true);
+      expect("tailLines" in opts).toBe(false);
+      expect("sinceSeconds" in opts).toBe(false);
+      // Which stream (previous/timestamps) is still the view's choice.
+      expect(opts.previous).toBe(false);
+      expect(opts.timestamps).toBe(false);
+    }
+  });
+
+  it("keeps the plain download bounded to what is on screen", async () => {
+    podLogsMock.mockResolvedValue({ logs: "line one\nline two" });
+    render(<LogsView context="kind-dev" namespace="default" source={{ type: "pod", pod: "web-1" }} />);
+    await waitFor(() => expect(screen.getByText("line two")).toBeDefined());
+    const loadOpts = podLogsMock.mock.calls[0][4] as Record<string, unknown>;
+    expect(loadOpts.tailLines).toBe(200);
+    expect("allLines" in loadOpts).toBe(false);
+    podLogsMock.mockClear();
+
+    fireEvent.click(screen.getByRole("button", { name: "Download" }));
+    await waitFor(() => expect(saveTextFileMock).toHaveBeenCalledWith("web-1.log", "line one\nline two"));
+    // The on-screen download saves the buffer; it never refetches.
+    expect(podLogsMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/components/LogsView.tsx
+++ b/apps/desktop/src/components/LogsView.tsx
@@ -406,7 +406,10 @@ export function LogsView({
   }
 
   // Full dump: every container of every in-scope pod, ignoring the container
-  // filter, each section headed `==> pod/container <==` (tail-style).
+  // filter, each section headed `==> pod/container <==` (tail-style). Asks
+  // for every retained line and leaves the view's tail/since bounds out:
+  // inheriting them made "all" mean "the last 200 lines" (#353). `previous`
+  // and `timestamps` still apply — they pick which stream, not how much.
   function downloadAll() {
     const base = srcType === "pod" ? srcPod : srcName;
     setSaveError("");
@@ -421,8 +424,7 @@ export function LogsView({
             container: c,
             previous,
             timestamps,
-            tailLines,
-            sinceSeconds,
+            allLines: true,
           });
           parts.push(`==> ${p}${c ? `/${c}` : ""} <==`);
           parts.push(out.error ? `(error: ${out.error})` : out.logs ?? "");
@@ -540,10 +542,10 @@ export function LogsView({
           <IconButton icon={Download} label="Download" onClick={download} disabled={entries.length === 0} />
           <IconButton
             icon={DownloadCloud}
-            label="Download all containers"
+            label="Download all container logs"
             onClick={downloadAll}
             disabled={savingAll || targetPods.length === 0}
-            title="Download every container's logs for the in-scope pods"
+            title="Save everything the cluster still holds for every container of these pods, not just the lines shown here"
           />
           <IconButton icon={RefreshCw} label="Refresh" onClick={() => load()} disabled={follow || loading} />
         </div>

--- a/apps/desktop/src/components/NodeCordonAction.test.tsx
+++ b/apps/desktop/src/components/NodeCordonAction.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 
 vi.mock("../lib/access", async (importOriginal) => {
@@ -115,7 +116,12 @@ describe("NodeCordonAction RBAC gating", () => {
     render(<NodeCordonAction context="kind-dev" name="node-a" getObjectFn={getObjectFn} />);
     const cordon = await screen.findByRole("button", { name: "Cordon" });
     expect((cordon as HTMLButtonElement).disabled).toBe(true);
-    expect(cordon.getAttribute("title")).toEqual(expect.stringContaining("patch nodes"));
+    // The reason is a Radix tooltip on the wrapper around the disabled button
+    // (#376) — a disabled <button> itself gets no pointer events.
+    const trigger = cordon.closest<HTMLElement>('[data-slot="tooltip-trigger"]');
+    if (!trigger) throw new Error("disabled Cordon has no tooltip trigger");
+    await userEvent.hover(trigger);
+    expect((await screen.findByRole("tooltip")).textContent).toEqual(expect.stringContaining("patch nodes"));
   });
 
   it("enables Cordon when allowed", async () => {

--- a/apps/desktop/src/components/ui/tooltip.tsx
+++ b/apps/desktop/src/components/ui/tooltip.tsx
@@ -3,23 +3,52 @@ import { Tooltip as TooltipPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 
+/**
+ * How long a pointer rests on a trigger before its tooltip opens. Not 0: an
+ * instant tooltip flashes on every pointer pass across a toolbar and reads
+ * as noise; 200 ms is below what registers as a wait. Well under the
+ * browser's fixed ~1 s native `title` delay this replaces (#376).
+ */
+export const TOOLTIP_DELAY_MS = 200
+
+/**
+ * After one tooltip has shown, sibling tooltips under the same provider open
+ * with no delay for this long — the "sweep across the toolbar" behaviour.
+ */
+export const TOOLTIP_SKIP_DELAY_MS = 300
+
+// Radix throws for a `Tooltip` rendered outside a `TooltipProvider`. The app
+// mounts one provider at its root so every tooltip shares the skip-delay
+// state; a `Tooltip` mounted anywhere else (a component test, an isolated
+// render) gets a provider of its own instead of a crash.
+const HasTooltipProvider = React.createContext(false)
+
 function TooltipProvider({
-  delayDuration = 0,
+  delayDuration = TOOLTIP_DELAY_MS,
+  skipDelayDuration = TOOLTIP_SKIP_DELAY_MS,
+  children,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
   return (
-    <TooltipPrimitive.Provider
-      data-slot="tooltip-provider"
-      delayDuration={delayDuration}
-      {...props}
-    />
+    <HasTooltipProvider.Provider value={true}>
+      <TooltipPrimitive.Provider
+        data-slot="tooltip-provider"
+        delayDuration={delayDuration}
+        skipDelayDuration={skipDelayDuration}
+        {...props}
+      >
+        {children}
+      </TooltipPrimitive.Provider>
+    </HasTooltipProvider.Provider>
   )
 }
 
 function Tooltip({
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
-  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+  const hasProvider = React.useContext(HasTooltipProvider)
+  const root = <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+  return hasProvider ? root : <TooltipProvider>{root}</TooltipProvider>
 }
 
 function TooltipTrigger({
@@ -28,9 +57,12 @@ function TooltipTrigger({
   return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
 }
 
+// Styled like the native `title` bubble it replaces (light popover surface,
+// hairline border, small dark text, no arrow) so only the delay changes for
+// the reader; shadcn's dark pill with an arrow would read as a new control.
 function TooltipContent({
   className,
-  sideOffset = 0,
+  sideOffset = 4,
   children,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Content>) {
@@ -40,13 +72,12 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "z-50 inline-flex w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "z-50 w-fit max-w-xs rounded-md border border-border bg-popover px-2 py-1 text-xs text-popover-foreground shadow-sm duration-100 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
           className
         )}
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   )

--- a/apps/desktop/src/lib/workloads.test.ts
+++ b/apps/desktop/src/lib/workloads.test.ts
@@ -87,6 +87,24 @@ describe("podLogs", () => {
     });
   });
 
+  it("asks for every retained line with all_lines, and omits it when false", async () => {
+    const invoke = vi.fn().mockResolvedValue({ logs: "" });
+    await podLogs("kind-dev", "default", "web-1", invoke, { allLines: true });
+    expect(invoke).toHaveBeenCalledWith("k8s.podLogs", {
+      context: "kind-dev",
+      namespace: "default",
+      pod: "web-1",
+      all_lines: true,
+    });
+    await podLogs("kind-dev", "default", "web-1", invoke, { allLines: false, tailLines: 50 });
+    expect(invoke).toHaveBeenLastCalledWith("k8s.podLogs", {
+      context: "kind-dev",
+      namespace: "default",
+      pod: "web-1",
+      tail_lines: 50,
+    });
+  });
+
   it("omits options that are falsy or unset", async () => {
     const invoke = vi.fn().mockResolvedValue({ logs: "" });
     await podLogs("kind-dev", "default", "web-1", invoke, { container: "app", previous: false });

--- a/apps/desktop/src/lib/workloads.ts
+++ b/apps/desktop/src/lib/workloads.ts
@@ -215,8 +215,14 @@ export interface PodLogsOptions {
   timestamps?: boolean;
   /** Only lines newer than this many seconds ago. */
   sinceSeconds?: number;
-  /** Number of trailing lines to return. */
+  /** Number of trailing lines to return. Ignored when `allLines` is set. */
   tailLines?: number;
+  /**
+   * Fetch every line the container runtime still retains instead of a tail;
+   * wins over `tailLines`. Only what log rotation has kept is available, and
+   * the response can be very large — for saving a full dump, not for display.
+   */
+  allLines?: boolean;
 }
 
 /** Fetch recent logs for a pod (optionally a specific container) via `k8s.podLogs`. */
@@ -227,7 +233,7 @@ export async function podLogs(
   invoke: Invoker = invokeCapability,
   options: PodLogsOptions = {},
 ): Promise<LogsOutcome> {
-  const { container, previous, timestamps, sinceSeconds, tailLines } = options;
+  const { container, previous, timestamps, sinceSeconds, tailLines, allLines } = options;
   try {
     // `k8s.podLogs` deserialises snake_case field names (no serde rename).
     const out = await invoke<{ logs: string }>("k8s.podLogs", {
@@ -239,6 +245,7 @@ export async function podLogs(
       ...(timestamps ? { timestamps: true } : {}),
       ...(sinceSeconds != null ? { since_seconds: sinceSeconds } : {}),
       ...(tailLines != null ? { tail_lines: tailLines } : {}),
+      ...(allLines ? { all_lines: true } : {}),
     });
     return { logs: out.logs };
   } catch (e) {

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -2,6 +2,7 @@ import "./styles/globals.css"; // Tailwind + shadcn tokens — must load first.
 import React from "react";
 import { createRoot } from "react-dom/client";
 import AppGate from "./AppGate";
+import { TooltipProvider } from "./components/ui/tooltip";
 import { applyPersistedTimeout } from "./lib/requestTimeout";
 import { isTauri } from "./transport/platform";
 import { initializeSettingsStorage } from "./lib/settingsStorage";
@@ -19,7 +20,15 @@ if (!container) throw new Error("Root element #root not found");
 async function bootstrap(root: HTMLElement): Promise<void> {
   await initializeSettingsStorage();
   if (isTauri()) void applyPersistedTimeout();
-  createRoot(root).render(<AppGate />);
+  // One tooltip provider for the whole window: every tooltip shares its open
+  // delay and, once one has shown, its neighbours open at once for a moment
+  // (the "sweep across the toolbar" the native `title` never allowed, #376).
+  // The delay values are the provider's defaults — see tooltip.tsx for why.
+  createRoot(root).render(
+    <TooltipProvider>
+      <AppGate />
+    </TooltipProvider>,
+  );
 }
 
 void bootstrap(container);

--- a/apps/desktop/src/ui/IconButton.test.tsx
+++ b/apps/desktop/src/ui/IconButton.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { Trash2 } from "lucide-react";
+import { IconButton } from "./IconButton";
+
+// No waits between the pointer events, so the hover completes before the
+// tooltip's open delay can elapse and the "not instant" pin is deterministic.
+const user = userEvent.setup({ delay: null });
+
+describe("IconButton", () => {
+  it("names the button by its label and shows the label as the tooltip on hover", async () => {
+    render(<IconButton icon={Trash2} label="Delete" />);
+    const button = screen.getByRole("button", { name: "Delete" });
+    // The browser's own tooltip has a fixed ~1s delay (#376) and would double
+    // up with ours, so the native title must be gone.
+    expect(button.hasAttribute("title")).toBe(false);
+
+    await user.hover(button);
+    expect((await screen.findByRole("tooltip")).textContent).toBe("Delete");
+  });
+
+  it("waits the shared delay rather than opening on the first pointer pass", async () => {
+    render(<IconButton icon={Trash2} label="Delete" />);
+    await user.hover(screen.getByRole("button", { name: "Delete" }));
+    expect(screen.queryByRole("tooltip")).toBeNull();
+    expect((await screen.findByRole("tooltip")).textContent).toBe("Delete");
+  });
+
+  it("shows the title override in place of the label", async () => {
+    render(<IconButton icon={Trash2} label="Shell" title="Shell — 2 containers" />);
+    await user.hover(screen.getByRole("button", { name: "Shell" }));
+    expect((await screen.findByRole("tooltip")).textContent).toBe("Shell — 2 containers");
+  });
+
+  it("keeps a disabled button's reason reachable through a wrapper trigger", async () => {
+    render(<IconButton icon={Trash2} label="Delete" disabled title="You don't have permission to delete pods" />);
+    const button = screen.getByRole("button", { name: "Delete" }) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    expect(button.hasAttribute("title")).toBe(false);
+    // A disabled <button> receives no pointer events, so the tooltip's trigger
+    // has to be an element around it, not the button itself.
+    expect(button.getAttribute("data-slot")).not.toBe("tooltip-trigger");
+    const trigger = button.parentElement;
+    if (!trigger) throw new Error("disabled IconButton has no wrapper element");
+    expect(trigger.getAttribute("data-slot")).toBe("tooltip-trigger");
+
+    await user.hover(trigger);
+    expect((await screen.findByRole("tooltip")).textContent).toBe("You don't have permission to delete pods");
+  });
+
+  it("looks like the native title bubble it replaces: light surface, no arrow", async () => {
+    render(<IconButton icon={Trash2} label="Delete" />);
+    await user.hover(screen.getByRole("button", { name: "Delete" }));
+    await screen.findByRole("tooltip");
+    const content = document.querySelector<HTMLElement>('[data-slot="tooltip-content"]');
+    if (!content) throw new Error("tooltip content not rendered");
+    // Only the delay changes for the reader: the app's popover surface with a
+    // hairline border, not shadcn's dark pill.
+    expect(content.classList.contains("bg-popover")).toBe(true);
+    expect(content.classList.contains("border")).toBe(true);
+    expect(content.classList.contains("bg-primary")).toBe(false);
+    expect(content.classList.contains("bg-foreground")).toBe(false);
+    expect(content.querySelector("svg")).toBeNull();
+    expect(document.querySelector('[data-slot="tooltip-content"] [class*="rotate-45"]')).toBeNull();
+  });
+
+  it("still fires onClick through the tooltip trigger", async () => {
+    const onClick = vi.fn();
+    render(<IconButton icon={Trash2} label="Delete" onClick={onClick} />);
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/ui/IconButton.tsx
+++ b/apps/desktop/src/ui/IconButton.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { LucideIcon } from "lucide-react";
 
 export interface IconButtonProps {
@@ -18,21 +19,42 @@ export interface IconButtonProps {
  * A compact icon-only button (shadcn Button, ghost). The label is both the
  * accessible name and the hover tooltip (unless `title` overrides it), so the
  * icon never stands alone.
+ *
+ * The tooltip is a Radix one, not the native `title`: the browser's tooltip
+ * has a fixed ~1 s delay that made a toolbar feel unresponsive (#376), and
+ * rendering both would show two. The delay lives in the app's root
+ * `TooltipProvider`.
  */
 export function IconButton({ icon, label, onClick, danger, disabled, title }: IconButtonProps) {
   const Icon = icon;
-  return (
+  const button = (
     <Button
       type="button"
       variant="ghost"
       size="icon-sm"
       aria-label={label}
-      title={title ?? label}
       onClick={onClick}
       disabled={disabled}
       className={danger ? "text-destructive hover:text-destructive" : undefined}
     >
       <Icon aria-hidden="true" />
     </Button>
+  );
+  return (
+    <Tooltip>
+      {disabled ? (
+        // A disabled <button> receives no pointer events, so it can't open a
+        // tooltip itself and the disabled reason in `title` would be lost.
+        // Wrap it and let the wrapper be the trigger.
+        <TooltipTrigger asChild>
+          <span className="inline-flex">{button}</span>
+        </TooltipTrigger>
+      ) : (
+        <TooltipTrigger asChild>{button}</TooltipTrigger>
+      )}
+      <TooltipContent side="bottom" sideOffset={4}>
+        {title ?? label}
+      </TooltipContent>
+    </Tooltip>
   );
 }

--- a/crates/kube/src/logs.rs
+++ b/crates/kube/src/logs.rs
@@ -31,6 +31,19 @@ impl Default for StreamOpts {
     }
 }
 
+/// How many trailing lines a one-shot `k8s.podLogs` fetch asks for. `None`
+/// means "no bound": the API then returns every line the container runtime
+/// still retains, which is the only way to get a pod's complete history and
+/// is why `all_lines` overrides `tail_lines` rather than combining with it.
+/// Pure, so the precedence is unit-tested.
+pub fn effective_tail_lines(all_lines: bool, tail_lines: Option<i64>) -> Option<i64> {
+    if all_lines {
+        None
+    } else {
+        Some(tail_lines.unwrap_or(DEFAULT_TAIL_LINES))
+    }
+}
+
 /// Build the kube `LogParams` for a target + options. Pure, so the mapping
 /// (follow, tail, since, timestamps, previous) is unit-tested.
 pub fn build_log_params(
@@ -149,9 +162,17 @@ pub struct PodLogsIn {
     /// for any pod with more than one (it does not pick one for you).
     #[serde(default)]
     pub container: Option<String>,
-    /// Number of trailing lines to return (default 200).
+    /// Number of trailing lines to return (default 200). Ignored when
+    /// `all_lines` is set.
     #[serde(default)]
     pub tail_lines: Option<i64>,
+    /// Return every line the container runtime still retains instead of a
+    /// tail. Wins over `tail_lines` when both are given. Kubernetes keeps only
+    /// what log rotation has not yet discarded, and the response can be very
+    /// large — prefer `tail_lines`/`since_seconds` unless the whole history is
+    /// needed (e.g. to save it to a file). Default false.
+    #[serde(default)]
+    pub all_lines: bool,
     /// Logs from the previous, terminated instance (post-crash triage).
     #[serde(default)]
     pub previous: bool,
@@ -168,11 +189,11 @@ pub struct PodLogsOut {
     pub logs: String,
 }
 
-/// `k8s.podLogs` — return the last N lines of a pod's logs.
+/// `k8s.podLogs` — return the last N lines of a pod's logs, or all of them.
 pub fn pod_logs_capability(cache: Arc<ClientCache>) -> Capability {
     Capability::typed::<PodLogsIn, PodLogsOut, _, _>(
         "k8s.podLogs",
-        "fetch recent logs for a pod in a connected kube context",
+        "fetch logs for a pod in a connected kube context: the last 200 lines by default (tail_lines to change), or set all_lines to get everything the runtime still retains (can be large)",
         Annotations::READ_ONLY,
         move |input: PodLogsIn| {
             let cache = cache.clone();
@@ -185,7 +206,7 @@ pub fn pod_logs_capability(cache: Arc<ClientCache>) -> Capability {
                 let params = build_log_params(
                     input.container.clone(),
                     false,
-                    Some(input.tail_lines.unwrap_or(DEFAULT_TAIL_LINES)),
+                    effective_tail_lines(input.all_lines, input.tail_lines),
                     input.since_seconds,
                     input.timestamps,
                     input.previous,
@@ -221,6 +242,35 @@ mod tests {
         assert_eq!(p.since_seconds, Some(300));
         assert!(p.timestamps);
         assert!(p.previous);
+    }
+
+    #[test]
+    fn all_lines_drops_the_tail_bound_and_wins_over_tail_lines() {
+        // `all_lines` is the only way to get `tail_lines: None`, which is what
+        // makes the API return everything the runtime still retains.
+        assert_eq!(effective_tail_lines(true, None), None);
+        assert_eq!(effective_tail_lines(true, Some(50)), None);
+    }
+
+    #[test]
+    fn without_all_lines_the_tail_defaults_to_200_or_the_given_count() {
+        // The default path — every existing caller, MCP agents included — is
+        // unchanged: omit both and you still get the last 200 lines.
+        assert_eq!(effective_tail_lines(false, None), Some(DEFAULT_TAIL_LINES));
+        assert_eq!(effective_tail_lines(false, Some(50)), Some(50));
+    }
+
+    #[test]
+    fn pod_logs_input_defaults_all_lines_to_false() {
+        let input: PodLogsIn =
+            serde_json::from_str(r#"{"context":"c","namespace":"n","pod":"p"}"#).unwrap();
+        assert!(!input.all_lines);
+        assert_eq!(input.tail_lines, None);
+        let input: PodLogsIn = serde_json::from_str(
+            r#"{"context":"c","namespace":"n","pod":"p","all_lines":true,"tail_lines":50}"#,
+        )
+        .unwrap();
+        assert!(input.all_lines);
     }
 
     #[test]

--- a/docs/mcp-catalog.md
+++ b/docs/mcp-catalog.md
@@ -51,7 +51,7 @@ Argument schemas are not reproduced here — call `tools/list` for those, which 
 | `k8s.listStorageClasses` | list StorageClasses of a connected kube context (cluster-scoped) |
 | `k8s.nodeMetrics` | node CPU/memory usage (requires metrics-server) |
 | `k8s.openApiSchema` | fetch the OpenAPI schema for a resource kind (for field autocomplete) |
-| `k8s.podLogs` | fetch recent logs for a pod in a connected kube context |
+| `k8s.podLogs` | fetch logs for a pod in a connected kube context: the last 200 lines by default (tail_lines to change), or set all_lines to get everything the runtime still retains (can be large) |
 | `k8s.podMetrics` | pod CPU/memory usage (requires metrics-server) |
 | `k8s.podsForPvc` | list pods in a namespace that mount a given PersistentVolumeClaim |
 | `k8s.podsForSelector` | list pods matching a label selector (a workload's managed pods) |


### PR DESCRIPTION
Two user-reported fixes, cut from `main` so the release computes to **0.7.3** — `dev` carries `feat:` commits that would bump it to 0.8.0, which stays deferred until the new-design migration lands. Merge with a **plain merge** (not squash), then merge `main` back into `dev`.

## #353 — Logs: enable download of all pod logs

Two layers. `k8s.podLogs` forced `Some(tail_lines.unwrap_or(200))`, so no caller could ask the server for everything — omitting the field meant 200. And classic's "Download all containers" passed the view's `tailLines` and `sinceSeconds`, so "all" was capped by the filter the reporter was looking at.

- `PodLogsIn.all_lines` (default false): when set, `tail_lines: None`, which is the only thing that makes Kubernetes return every line the runtime still retains. `all_lines` wins over `tail_lines` if both are given; the field's doc says so. Every existing caller and MCP agent keeps the 200-line default. `docs/mcp-catalog.md` regenerated (asserted in sync by `srelens-registry`).
- `downloadAll()` requests `allLines: true` and drops the view's tail and since; `previous` and `timestamps` stay, since they choose *which* stream rather than how much of it.
- The button now says what it does — *"Download all container logs"*, title *"Save everything the cluster still holds for every container of these pods, not just the lines shown here"* — and does not overclaim: what log rotation has already discarded is gone.

## #376 — tooltip delay is too long

The delay was the browser's: `IconButton` rendered a native `title=`, whose ~1 s cannot be configured, and no `TooltipProvider` was mounted anywhere. `IconButton` now uses the Radix tooltip under one root provider — 200 ms, with a 300 ms skip window so sibling buttons open instantly while exploring a toolbar. **The look is unchanged by design:** the shadcn dark pill and arrow are replaced with classic's own popover surface, hairline border and small text, so the only observable difference is the delay. A disabled button wraps its trigger in a span, so a disabled reason still shows. `aria-label` is kept.

Scope held to the toolbar controls the reporter was hovering; the ~170 native `title=` attributes on other elements are a separate sweep.

## Verification

Tests first for both, then mutation: dropping the `all_lines` branch fails the Rust pin (`Some(200)` vs `None`); passing `tailLines` again fails the TS pin; restoring `title=` fails two `IconButton` pins; removing the provider fails all five; restoring the shadcn styling fails the appearance pin. Six existing assertions that read `getAttribute("title")` off icon buttons now hover and read the tooltip.

Gates: `pnpm -r test` 1254 tests, coverage 86.1% lines; `cargo test -p srelens-kube -p srelens-desktop -p srelens-registry` green; typecheck and `cargo build` clean.

Closes #353. Closes #376.