### PR TITLE
fix: download every retained pod log line, and explain every button through a fast tooltip

### DIFF
--- a/apps/desktop/src/components/AppLogView.tsx
+++ b/apps/desktop/src/components/AppLogView.tsx
@@ -3,6 +3,7 @@ import { Check, Copy, FolderOpen, RefreshCw } from "lucide-react";
 import { appLogPath, readAppLog, revealAppLog } from "@srelens/core";
 import { Button, IconButton, Select, Spinner, TextInput } from "../ui";
 import { isTauri } from "@srelens/core/platform";
+import { TitleTooltip } from "@/components/ui/tooltip";
 
 /** Log levels emitted by tauri-plugin-log, most→least severe. */
 const LEVELS = ["ERROR", "WARN", "INFO", "DEBUG", "TRACE"] as const;
@@ -120,15 +121,16 @@ export function AppLogView() {
       </div>
 
       {path && (
-        <button
-          type="button"
-          onClick={() => void copyPath()}
-          title="Copy log file path"
-          className="flex items-center gap-1.5 self-start rounded font-mono text-[11px] text-muted-foreground hover:text-foreground"
-        >
-          {copied ? <Check aria-hidden="true" className="size-3 text-emerald-600 dark:text-emerald-400" /> : <Copy aria-hidden="true" className="size-3" />}
-          <span className="max-w-[52ch] truncate">{path}</span>
-        </button>
+        <TitleTooltip title="Copy log file path">
+          <button
+            type="button"
+            onClick={() => void copyPath()}
+            className="flex items-center gap-1.5 self-start rounded font-mono text-[11px] text-muted-foreground hover:text-foreground"
+          >
+            {copied ? <Check aria-hidden="true" className="size-3 text-emerald-600 dark:text-emerald-400" /> : <Copy aria-hidden="true" className="size-3" />}
+            <span className="max-w-[52ch] truncate">{path}</span>
+          </button>
+        </TitleTooltip>
       )}
 
       <div

--- a/apps/desktop/src/components/AssistantConversation.tsx
+++ b/apps/desktop/src/components/AssistantConversation.tsx
@@ -22,6 +22,7 @@ import {
 import { relativeTime } from "@srelens/core";
 import { settingsStorage } from "@srelens/core";
 import { AssistantMarkdown } from "./AssistantMarkdown";
+import { TitleTooltip } from "@/components/ui/tooltip";
 
 export type AssistantContext = { context: string; namespace?: string; kind?: string; name?: string };
 
@@ -619,18 +620,19 @@ function HistoryPopover({
           <ul className="mt-1 max-h-72 overflow-y-auto">
             {sessions.map((s) => (
               <li key={s.id} className="flex items-center gap-1 rounded px-2 py-1.5 text-xs hover:bg-accent">
-                <button
-                  type="button"
-                  className="min-w-0 flex-1 truncate text-left"
-                  title={s.title}
-                  onClick={() => {
-                    onSelectSession(s.id);
-                    setOpen(false);
-                  }}
-                >
-                  <span className="block truncate">{s.title}</span>
-                  <span className="block text-[10px] text-muted-foreground">{relativeTime(s.updatedAt, now)}</span>
-                </button>
+                <TitleTooltip title={s.title}>
+                  <button
+                    type="button"
+                    className="min-w-0 flex-1 truncate text-left"
+                    onClick={() => {
+                      onSelectSession(s.id);
+                      setOpen(false);
+                    }}
+                  >
+                    <span className="block truncate">{s.title}</span>
+                    <span className="block text-[10px] text-muted-foreground">{relativeTime(s.updatedAt, now)}</span>
+                  </button>
+                </TitleTooltip>
                 <button
                   type="button"
                   aria-label={`Delete ${s.title}`}
@@ -1654,21 +1656,20 @@ export const AssistantConversation = forwardRef<
             />
           </div>
           <div className="flex items-center gap-1">
-            <label
-              title="Attach image"
-              className="flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
-            >
-              <Paperclip aria-hidden="true" className="size-4" />
-              <input
-                type="file"
-                accept="image/*"
-                multiple
-                aria-label="Attach image"
-                onChange={onAttachFiles}
-                disabled={sending}
-                className="hidden"
-              />
-            </label>
+            <TitleTooltip title="Attach image">
+              <label className="flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground">
+                <Paperclip aria-hidden="true" className="size-4" />
+                <input
+                  type="file"
+                  accept="image/*"
+                  multiple
+                  aria-label="Attach image"
+                  onChange={onAttachFiles}
+                  disabled={sending}
+                  className="hidden"
+                />
+              </label>
+            </TitleTooltip>
             {agentPicker}
             {availableContexts !== undefined && (
               <ContextMultiSelect available={availableContexts} selected={selectedContexts} onChange={setSelectedContexts} />

--- a/apps/desktop/src/components/AssistantTab.tsx
+++ b/apps/desktop/src/components/AssistantTab.tsx
@@ -5,6 +5,7 @@ import { relativeTime } from "@srelens/core";
 import type { SessionMeta } from "@srelens/core";
 import { AssistantConversation, type AssistantConversationHandle } from "./AssistantConversation";
 import { SkillsPanel } from "./SkillsPanel";
+import { TitleTooltip } from "@/components/ui/tooltip";
 
 /**
  * Left history rail for the full-tab assistant: New Chat plus the saved
@@ -83,15 +84,16 @@ function HistoryRail({
                 key={s.id}
                 className="group flex items-center gap-1 rounded-lg px-2 py-1.5 text-sm hover:bg-accent"
               >
-                <button
-                  type="button"
-                  className="min-w-0 flex-1 truncate text-left"
-                  title={s.title}
-                  onClick={() => onSelectSession(s.id)}
-                >
-                  <span className="block truncate font-medium">{s.title}</span>
-                  <span className="block text-xs text-muted-foreground">{relativeTime(s.updatedAt, now)}</span>
-                </button>
+                <TitleTooltip title={s.title}>
+                  <button
+                    type="button"
+                    className="min-w-0 flex-1 truncate text-left"
+                    onClick={() => onSelectSession(s.id)}
+                  >
+                    <span className="block truncate font-medium">{s.title}</span>
+                    <span className="block text-xs text-muted-foreground">{relativeTime(s.updatedAt, now)}</span>
+                  </button>
+                </TitleTooltip>
                 <button
                   type="button"
                   aria-label={`Delete ${s.title}`}

--- a/apps/desktop/src/components/ClusterHotbar.tsx
+++ b/apps/desktop/src/components/ClusterHotbar.tsx
@@ -6,6 +6,7 @@ import {
 } from "../ui";
 import { ContextAvatar } from "./ContextAvatar";
 import { contextDisplayName, orderContexts, type ContextProfiles } from "@srelens/core";
+import { TitleTooltip } from "@/components/ui/tooltip";
 
 const EMPTY_LIST: string[] = [];
 
@@ -59,15 +60,15 @@ export function ClusterHotbar({
     const profile = contextProfiles[c.name];
     const displayName = contextDisplayName(c.name, profile);
     return (
-      <button
-        key={c.name}
-        className={`fl-hotbar__item${openContext === c.name ? " fl-hotbar__item--active" : ""}`}
-        title={c.isLocal ? `${displayName} (local)` : displayName}
-        aria-label={c.isLocal ? `${displayName} (local)` : displayName}
-        onClick={() => onOpenContext(c.name)}
-      >
-        <ContextAvatar context={c.name} profile={profile} />
-      </button>
+      <TitleTooltip key={c.name} title={c.isLocal ? `${displayName} (local)` : displayName}>
+        <button
+          className={`fl-hotbar__item${openContext === c.name ? " fl-hotbar__item--active" : ""}`}
+          aria-label={c.isLocal ? `${displayName} (local)` : displayName}
+          onClick={() => onOpenContext(c.name)}
+        >
+          <ContextAvatar context={c.name} profile={profile} />
+        </button>
+      </TitleTooltip>
     );
   };
 
@@ -90,42 +91,34 @@ export function ClusterHotbar({
         )}
         {localContexts.map(renderItem)}
       </div>
-      <button
-        className="fl-hotbar__theme"
-        aria-label={theme.mode === "dark" ? "Switch to light mode" : "Switch to dark mode"}
-        title="Toggle light/dark mode"
-        onClick={onToggleTheme}
-      >
-        {theme.mode === "dark" ? <Sun aria-hidden="true" /> : <Moon aria-hidden="true" />}
-      </button>
-      {onOpenToolbox && (
+      <TitleTooltip title="Toggle light/dark mode">
         <button
           className="fl-hotbar__theme"
-          aria-label="Open toolbox"
-          title="Open toolbox"
-          onClick={onOpenToolbox}
+          aria-label={theme.mode === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+          onClick={onToggleTheme}
         >
-          <Wrench aria-hidden="true" />
+          {theme.mode === "dark" ? <Sun aria-hidden="true" /> : <Moon aria-hidden="true" />}
         </button>
+      </TitleTooltip>
+      {onOpenToolbox && (
+        <TitleTooltip title="Open toolbox">
+          <button className="fl-hotbar__theme" aria-label="Open toolbox" onClick={onOpenToolbox}>
+            <Wrench aria-hidden="true" />
+          </button>
+        </TitleTooltip>
       )}
       {onOpenAssistant && (
-        <button
-          className="fl-hotbar__theme"
-          aria-label="Open assistant"
-          title="Open assistant"
-          onClick={onOpenAssistant}
-        >
-          <Bot aria-hidden="true" />
-        </button>
+        <TitleTooltip title="Open assistant">
+          <button className="fl-hotbar__theme" aria-label="Open assistant" onClick={onOpenAssistant}>
+            <Bot aria-hidden="true" />
+          </button>
+        </TitleTooltip>
       )}
-      <button
-        className="fl-hotbar__theme"
-        aria-label="Open settings"
-        title="Open settings"
-        onClick={onOpenSettings}
-      >
-        <Settings aria-hidden="true" />
-      </button>
+      <TitleTooltip title="Open settings">
+        <button className="fl-hotbar__theme" aria-label="Open settings" onClick={onOpenSettings}>
+          <Settings aria-hidden="true" />
+        </button>
+      </TitleTooltip>
     </nav>
   );
 }

--- a/apps/desktop/src/components/CopyAsKubectlButton.test.tsx
+++ b/apps/desktop/src/components/CopyAsKubectlButton.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 
 const { notifyMock } = vi.hoisted(() => ({
@@ -18,6 +19,14 @@ beforeEach(() => {
 });
 
 describe("CopyAsKubectlButton", () => {
+  it("explains itself with a fast tooltip, not the browser's slow native title (#376)", async () => {
+    render(<CopyAsKubectlButton kind="Pod" name="web-1" namespace="default" context="kind-dev" />);
+    const button = screen.getByRole("button", { name: "Copy as kubectl" });
+    expect(button.hasAttribute("title")).toBe(false);
+    await userEvent.setup({ delay: null }).hover(button);
+    expect((await screen.findByRole("tooltip")).textContent).toBe("Copy as kubectl");
+  });
+
   it("copies the get command (as yaml) from the menu", async () => {
     render(<CopyAsKubectlButton kind="Pod" name="web-1" namespace="default" context="kind-dev" />);
     fireEvent.click(screen.getByRole("button", { name: "Copy as kubectl" }));

--- a/apps/desktop/src/components/DetailActions.test.tsx
+++ b/apps/desktop/src/components/DetailActions.test.tsx
@@ -82,7 +82,17 @@ function titleOf(el: HTMLElement): string | null {
 async function tooltipOf(el: HTMLElement): Promise<string | null> {
   const trigger = el.closest<HTMLElement>('[data-slot="tooltip-trigger"]') ?? el;
   await userEvent.hover(trigger);
-  return (await screen.findByRole("tooltip")).textContent;
+  // Resolved through THIS trigger's `aria-describedby` rather than by asking
+  // for the first thing with the tooltip role. Opening a menu focuses its
+  // first item, and Radix opens a tooltip on focus as well as on hover — so a
+  // bare `findByRole("tooltip")` returns the first item's tooltip however far
+  // down the menu the hover went, and the assertion reads a sibling's text.
+  const id = await waitFor(() => {
+    const described = trigger.getAttribute("aria-describedby");
+    if (!described) throw new Error("no tooltip is open for this trigger");
+    return described;
+  });
+  return document.getElementById(id)?.textContent ?? null;
 }
 
 beforeEach(() => {
@@ -227,7 +237,7 @@ describe("PodActions", () => {
     const items = await screen.findAllByRole("menuitem");
     expect(items.map((i) => i.textContent)).toEqual(["mongodb", "metrics", "generate-tls-certs"]);
     // The finished init container is shown but marked, not silently dropped.
-    expect(titleOf(items[2])).toBe("Shell into generate-tls-certs (not running)");
+    expect(await tooltipOf(items[2])).toBe("Shell into generate-tls-certs (not running)");
   });
 
   it("re-reads the containers when the menu opens", async () => {

--- a/apps/desktop/src/components/DetailActions.test.tsx
+++ b/apps/desktop/src/components/DetailActions.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 
 const {
@@ -74,6 +75,14 @@ function isDisabled(el: HTMLElement): boolean {
 }
 function titleOf(el: HTMLElement): string | null {
   return el.getAttribute("title");
+}
+// IconButton explains itself through a Radix tooltip, not a native title
+// (#376): hover its trigger — the button, or the wrapper around a disabled
+// one, which is what still gets pointer events — and read the tooltip.
+async function tooltipOf(el: HTMLElement): Promise<string | null> {
+  const trigger = el.closest<HTMLElement>('[data-slot="tooltip-trigger"]') ?? el;
+  await userEvent.hover(trigger);
+  return (await screen.findByRole("tooltip")).textContent;
 }
 
 beforeEach(() => {
@@ -868,7 +877,7 @@ describe("ResourceActions", () => {
 describe("PodActions RBAC gating", () => {
   const prodPod = { ...pod, namespace: "prod" };
 
-  it("disables the Delete control and explains why when the user can't delete", () => {
+  it("disables the Delete control and explains why when the user can't delete", async () => {
     vi.mocked(useAccess).mockReturnValue({
       allowed: () => false,
       reason: () => "RBAC: no rule",
@@ -878,7 +887,7 @@ describe("PodActions RBAC gating", () => {
     render(<PodActions context="kind-dev" pod={prodPod} onDeleted={() => {}} />);
     const del = screen.getByRole("button", { name: "Delete" });
     expect(isDisabled(del)).toBe(true);
-    expect(titleOf(del)).toEqual(expect.stringContaining("permission to delete pods in prod"));
+    expect(await tooltipOf(del)).toEqual(expect.stringContaining("permission to delete pods in prod"));
   });
 
   it("enables Delete when allowed", () => {
@@ -892,7 +901,7 @@ describe("PodActions RBAC gating", () => {
     expect(isDisabled(screen.getByRole("button", { name: "Delete" }))).toBe(false);
   });
 
-  it("disables Evict and explains why when the user can't evict", () => {
+  it("disables Evict and explains why when the user can't evict", async () => {
     vi.mocked(useAccess).mockReturnValue({
       allowed: () => false,
       reason: () => "RBAC: no rule",
@@ -902,10 +911,10 @@ describe("PodActions RBAC gating", () => {
     render(<PodActions context="kind-dev" pod={prodPod} onDeleted={() => {}} />);
     const evict = screen.getByRole("button", { name: "Evict" });
     expect(isDisabled(evict)).toBe(true);
-    expect(titleOf(evict)).toEqual(expect.stringContaining("permission to create pods/eviction in prod"));
+    expect(await tooltipOf(evict)).toEqual(expect.stringContaining("permission to create pods/eviction in prod"));
   });
 
-  it("disables the pod Edit control and explains why when the user can't patch pods", () => {
+  it("disables the pod Edit control and explains why when the user can't patch pods", async () => {
     vi.mocked(useAccess).mockReturnValue({
       allowed: () => false,
       reason: () => "RBAC: no rule",
@@ -915,7 +924,7 @@ describe("PodActions RBAC gating", () => {
     render(<PodActions context="kind-dev" pod={prodPod} onDeleted={() => {}} onEdit={() => {}} />);
     const edit = screen.getByRole("button", { name: "Edit" });
     expect(isDisabled(edit)).toBe(true);
-    expect(titleOf(edit)).toEqual(expect.stringContaining("permission to patch pods in prod"));
+    expect(await tooltipOf(edit)).toEqual(expect.stringContaining("permission to patch pods in prod"));
   });
 
   it("enables the pod Edit control when allowed", () => {
@@ -931,7 +940,7 @@ describe("PodActions RBAC gating", () => {
 });
 
 describe("ResourceActions RBAC gating", () => {
-  it("disables the Delete control and explains why when the user can't delete", () => {
+  it("disables the Delete control and explains why when the user can't delete", async () => {
     vi.mocked(useAccess).mockReturnValue({
       allowed: () => false,
       reason: () => "RBAC: no rule",
@@ -949,7 +958,7 @@ describe("ResourceActions RBAC gating", () => {
     );
     const del = screen.getByRole("button", { name: "Delete" });
     expect(isDisabled(del)).toBe(true);
-    expect(titleOf(del)).toEqual(expect.stringContaining("permission to delete deployments in prod"));
+    expect(await tooltipOf(del)).toEqual(expect.stringContaining("permission to delete deployments in prod"));
   });
 
   it("enables Delete when allowed", () => {
@@ -971,7 +980,7 @@ describe("ResourceActions RBAC gating", () => {
     expect(isDisabled(screen.getByRole("button", { name: "Delete" }))).toBe(false);
   });
 
-  it("disables Scale when the user can't patch the scale subresource", () => {
+  it("disables Scale when the user can't patch the scale subresource", async () => {
     vi.mocked(useAccess).mockReturnValue({
       allowed: () => false,
       reason: () => "RBAC: no rule",
@@ -989,7 +998,7 @@ describe("ResourceActions RBAC gating", () => {
     );
     const scale = screen.getByRole("button", { name: "Scale" });
     expect(isDisabled(scale)).toBe(true);
-    expect(titleOf(scale)).toEqual(expect.stringContaining("permission to patch deployments/scale in prod"));
+    expect(await tooltipOf(scale)).toEqual(expect.stringContaining("permission to patch deployments/scale in prod"));
   });
 
   it("disables Restart when the user can't patch the workload", () => {

--- a/apps/desktop/src/components/DetailActions.tsx
+++ b/apps/desktop/src/components/DetailActions.tsx
@@ -42,6 +42,7 @@ import { CopyAsKubectlButton } from "./CopyAsKubectlButton";
 import { toKubectl } from "@srelens/core";
 import { copyKubectlCommand } from "@srelens/core";
 import type { AssistantContext } from "./AssistantDrawer";
+import { TitleTooltip } from "@/components/ui/tooltip";
 
 type Opener = (s: { context: string; namespace: string; pod: string; container?: string }) => void;
 /** Opens the assistant drawer with the current resource attached as context. */
@@ -220,11 +221,10 @@ export function PodActions({
         </PopoverAnchor>
         <PopoverContent align="start" role="menu" className="w-auto min-w-44 gap-0 p-1">
           {containers.map((c) => (
+            <TitleTooltip key={c.name} title={`Shell into ${c.name}${c.running ? "" : " (not running)"}`}>
             <button
-              key={c.name}
               type="button"
               role="menuitem"
-              title={`Shell into ${c.name}${c.running ? "" : " (not running)"}`}
               className={`flex w-full items-center gap-2 rounded px-2 py-1 text-left hover:bg-accent hover:text-accent-foreground ${
                 c.running ? "" : "text-muted-foreground"
               }`}
@@ -239,6 +239,7 @@ export function PodActions({
               />
               <span className="min-w-0 truncate">{c.name}</span>
             </button>
+            </TitleTooltip>
           ))}
         </PopoverContent>
       </Popover>

--- a/apps/desktop/src/components/Dock.tsx
+++ b/apps/desktop/src/components/Dock.tsx
@@ -4,6 +4,7 @@ import { PodTerminal } from "./PodTerminal";
 import { LocalTerminal } from "./LocalTerminal";
 import { LogsView, type LogsSource } from "./LogsView";
 import { HelmOpPane } from "./HelmOpPane";
+import { TitleTooltip } from "@/components/ui/tooltip";
 
 export type DockKind = "terminal" | "logs" | "shell" | "helm";
 
@@ -181,14 +182,11 @@ export function Dock({
           ))}
         </div>
         {onNewTerminal && (
-          <button
-            className="fl-dock__new"
-            aria-label="New terminal"
-            title="New terminal (same context)"
-            onClick={onNewTerminal}
-          >
-            <Plus aria-hidden="true" />
-          </button>
+          <TitleTooltip title="New terminal (same context)">
+            <button className="fl-dock__new" aria-label="New terminal" onClick={onNewTerminal}>
+              <Plus aria-hidden="true" />
+            </button>
+          </TitleTooltip>
         )}
         <button className="fl-dock__close" aria-label="Close dock" onClick={onClose}>
           <X aria-hidden="true" />

--- a/apps/desktop/src/components/ForwardsIndicator.tsx
+++ b/apps/desktop/src/components/ForwardsIndicator.tsx
@@ -9,6 +9,7 @@ import {
   forwardAddress,
   type ActiveForward,
 } from "@srelens/core";
+import { TitleTooltip } from "@/components/ui/tooltip";
 
 /** Subscribe to the active port-forwards store. */
 export function useForwards(): ActiveForward[] {
@@ -72,24 +73,26 @@ export function ForwardsIndicator() {
                 </div>
                 <StatusPill status={forwardStatusLabel(f.status)} kind={forwardStatusKind(f.status)} />
               </div>
-              <button
-                type="button"
-                className="fl-forward-action rounded-sm px-1.5 py-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
-                onClick={() => void navigator.clipboard?.writeText(forwardAddress(f))}
-                title="Copy address"
-              >
-                <Copy aria-hidden="true" />
-                Copy
-              </button>
-              <button
-                type="button"
-                className="fl-forward-action rounded-sm px-1.5 py-0.5 text-destructive hover:bg-destructive/10"
-                onClick={() => void stopPortForward(f.id)}
-                title="Stop forward"
-              >
-                <CircleStop aria-hidden="true" />
-                Stop
-              </button>
+              <TitleTooltip title="Copy address">
+                <button
+                  type="button"
+                  className="fl-forward-action rounded-sm px-1.5 py-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+                  onClick={() => void navigator.clipboard?.writeText(forwardAddress(f))}
+                >
+                  <Copy aria-hidden="true" />
+                  Copy
+                </button>
+              </TitleTooltip>
+              <TitleTooltip title="Stop forward">
+                <button
+                  type="button"
+                  className="fl-forward-action rounded-sm px-1.5 py-0.5 text-destructive hover:bg-destructive/10"
+                  onClick={() => void stopPortForward(f.id)}
+                >
+                  <CircleStop aria-hidden="true" />
+                  Stop
+                </button>
+              </TitleTooltip>
             </li>
           ))}
         </ul>

--- a/apps/desktop/src/components/LogsView.test.tsx
+++ b/apps/desktop/src/components/LogsView.test.tsx
@@ -328,7 +328,7 @@ describe("LogsView", () => {
     render(<LogsView context="kind-dev" namespace="default" source={{ type: "pod", pod: "web-1" }} />);
     await waitFor(() => expect(screen.getByRole("combobox", { name: "Container" })).toBeDefined());
 
-    fireEvent.click(screen.getByRole("button", { name: "Download all containers" }));
+    fireEvent.click(screen.getByRole("button", { name: "Download all container logs" }));
     await waitFor(() =>
       expect(saveTextFileMock).toHaveBeenCalledWith(
         "web-1-all.log",
@@ -337,5 +337,58 @@ describe("LogsView", () => {
     );
     expect(saveTextFileMock.mock.calls[0][1]).toContain("==> web-1/sidecar <==");
     expect(saveTextFileMock.mock.calls[0][1]).toContain("sidecar logs");
+  });
+
+  it("downloads every retained line for all containers, unbounded by the tail/since filters", async () => {
+    // #353: the full dump used to inherit the view's tail (200) and since
+    // window, so "all" was really "the last 200 lines". It must ask for
+    // everything the cluster still holds and leave both bounds out entirely.
+    getObjectMock.mockResolvedValue({
+      object: { spec: { containers: [{ name: "app" }, { name: "sidecar" }] } },
+    });
+    render(<LogsView context="kind-dev" namespace="default" source={{ type: "pod", pod: "web-1" }} />);
+    await waitFor(() => expect(screen.getByRole("combobox", { name: "Container" })).toBeDefined());
+    // Narrow the on-screen view first so the dump's independence is visible.
+    await userEvent.click(screen.getByRole("combobox", { name: "Since" }));
+    await userEvent.click(await screen.findByRole("option", { name: "Last 5m" }));
+    await waitFor(() =>
+      expect(podLogsMock).toHaveBeenCalledWith(
+        "kind-dev",
+        "default",
+        "web-1",
+        undefined,
+        expect.objectContaining({ sinceSeconds: 300, tailLines: 200 }),
+      ),
+    );
+    podLogsMock.mockClear();
+
+    fireEvent.click(screen.getByRole("button", { name: "Download all container logs" }));
+    await waitFor(() => expect(saveTextFileMock).toHaveBeenCalledWith("web-1-all.log", expect.any(String)));
+
+    const dumpCalls = podLogsMock.mock.calls as [string, string, string, unknown, Record<string, unknown>][];
+    expect(dumpCalls.map((c) => c[4].container)).toEqual(["app", "sidecar"]);
+    for (const [, , , , opts] of dumpCalls) {
+      expect(opts.allLines).toBe(true);
+      expect("tailLines" in opts).toBe(false);
+      expect("sinceSeconds" in opts).toBe(false);
+      // Which stream (previous/timestamps) is still the view's choice.
+      expect(opts.previous).toBe(false);
+      expect(opts.timestamps).toBe(false);
+    }
+  });
+
+  it("keeps the plain download bounded to what is on screen", async () => {
+    podLogsMock.mockResolvedValue({ logs: "line one\nline two" });
+    render(<LogsView context="kind-dev" namespace="default" source={{ type: "pod", pod: "web-1" }} />);
+    await waitFor(() => expect(screen.getByText("line two")).toBeDefined());
+    const loadOpts = podLogsMock.mock.calls[0][4] as Record<string, unknown>;
+    expect(loadOpts.tailLines).toBe(200);
+    expect("allLines" in loadOpts).toBe(false);
+    podLogsMock.mockClear();
+
+    fireEvent.click(screen.getByRole("button", { name: "Download" }));
+    await waitFor(() => expect(saveTextFileMock).toHaveBeenCalledWith("web-1.log", "line one\nline two"));
+    // The on-screen download saves the buffer; it never refetches.
+    expect(podLogsMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/components/LogsView.tsx
+++ b/apps/desktop/src/components/LogsView.tsx
@@ -7,6 +7,7 @@ import { saveTextFile } from "@srelens/core";
 import { Spinner, Select, IconButton, TextInput, avatarColor } from "../ui";
 import { computeLogWindow } from "./logWindow";
 import { isTauri } from "@srelens/core/platform";
+import { TitleTooltip } from "@/components/ui/tooltip";
 
 /**
  * Save `content` to `filename`: in the desktop app via the native save
@@ -91,22 +92,23 @@ function ToggleButton({
   title?: string;
 }) {
   return (
-    <button
-      type="button"
-      aria-label={label}
-      aria-pressed={active}
-      title={title ?? label}
-      onClick={onClick}
-      disabled={disabled}
-      className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 transition-colors disabled:opacity-40 ${
-        active
-          ? "bg-primary/15 text-primary"
-          : "text-muted-foreground hover:bg-accent hover:text-foreground"
-      }`}
-    >
-      <Icon className="size-3.5" aria-hidden={true} />
-      {text}
-    </button>
+    <TitleTooltip title={title ?? label} disabled={disabled}>
+      <button
+        type="button"
+        aria-label={label}
+        aria-pressed={active}
+        onClick={onClick}
+        disabled={disabled}
+        className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 transition-colors disabled:opacity-40 ${
+          active
+            ? "bg-primary/15 text-primary"
+            : "text-muted-foreground hover:bg-accent hover:text-foreground"
+        }`}
+      >
+        <Icon className="size-3.5" aria-hidden={true} />
+        {text}
+      </button>
+    </TitleTooltip>
   );
 }
 

--- a/apps/desktop/src/components/LogsView.tsx
+++ b/apps/desktop/src/components/LogsView.tsx
@@ -406,7 +406,10 @@ export function LogsView({
   }
 
   // Full dump: every container of every in-scope pod, ignoring the container
-  // filter, each section headed `==> pod/container <==` (tail-style).
+  // filter, each section headed `==> pod/container <==` (tail-style). Asks
+  // for every retained line and leaves the view's tail/since bounds out:
+  // inheriting them made "all" mean "the last 200 lines" (#353). `previous`
+  // and `timestamps` still apply — they pick which stream, not how much.
   function downloadAll() {
     const base = srcType === "pod" ? srcPod : srcName;
     setSaveError("");
@@ -421,8 +424,7 @@ export function LogsView({
             container: c,
             previous,
             timestamps,
-            tailLines,
-            sinceSeconds,
+            allLines: true,
           });
           parts.push(`==> ${p}${c ? `/${c}` : ""} <==`);
           parts.push(out.error ? `(error: ${out.error})` : out.logs ?? "");
@@ -540,10 +542,10 @@ export function LogsView({
           <IconButton icon={Download} label="Download" onClick={download} disabled={entries.length === 0} />
           <IconButton
             icon={DownloadCloud}
-            label="Download all containers"
+            label="Download all container logs"
             onClick={downloadAll}
             disabled={savingAll || targetPods.length === 0}
-            title="Download every container's logs for the in-scope pods"
+            title="Save everything the cluster still holds for every container of these pods, not just the lines shown here"
           />
           <IconButton icon={RefreshCw} label="Refresh" onClick={() => load()} disabled={follow || loading} />
         </div>

--- a/apps/desktop/src/components/ManifestEditor.test.tsx
+++ b/apps/desktop/src/components/ManifestEditor.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React, { useState } from "react";
 
 const { applyManifestMock, diffManifestMock, notifyMock } = vi.hoisted(() => ({
@@ -32,6 +33,15 @@ import { ManifestEditor } from "./ManifestEditor";
 // DOM properties instead of `toBeDisabled` sugar.
 function isDisabled(el: HTMLElement): boolean {
   return (el as HTMLButtonElement).disabled;
+}
+
+// A disabled control explains itself through a Radix tooltip, not a native
+// title (#376): hover its trigger — the wrapper around a disabled button,
+// which is what still receives pointer events — and read the tooltip.
+async function tooltipOf(el: HTMLElement): Promise<string | null> {
+  const trigger = el.closest<HTMLElement>('[data-slot="tooltip-trigger"]') ?? el;
+  await userEvent.hover(trigger);
+  return (await screen.findByRole("tooltip")).textContent;
 }
 
 function Harness({ mode }: { mode: "create" | "edit" }) {
@@ -334,7 +344,7 @@ describe("ManifestEditor", () => {
     );
     const btn = screen.getByRole("button", { name: /apply/i });
     expect(isDisabled(btn)).toBe(true);
-    expect(btn.getAttribute("title")).toBe("You don't have permission to patch deployments in prod");
+    expect(await tooltipOf(btn)).toBe("You don't have permission to patch deployments in prod");
   });
 
   it("edit mode: disables Apply while the access check is still loading (fail-closed, no title yet)", async () => {
@@ -400,7 +410,7 @@ describe("ManifestEditor", () => {
     );
     const btn = screen.getByRole("button", { name: /apply/i });
     expect(isDisabled(btn)).toBe(true);
-    expect(btn.getAttribute("title")).toBe("You don't have permission to patch deployments in prod");
+    expect(await tooltipOf(btn)).toBe("You don't have permission to patch deployments in prod");
   });
 
   it("edit mode: does NOT gate Apply when the manifest declares no namespace (avoids a wrong-scope false-disable)", async () => {

--- a/apps/desktop/src/components/NodeCordonAction.test.tsx
+++ b/apps/desktop/src/components/NodeCordonAction.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 
 vi.mock("@srelens/core/react", async (importOriginal) => {
@@ -115,7 +116,12 @@ describe("NodeCordonAction RBAC gating", () => {
     render(<NodeCordonAction context="kind-dev" name="node-a" getObjectFn={getObjectFn} />);
     const cordon = await screen.findByRole("button", { name: "Cordon" });
     expect((cordon as HTMLButtonElement).disabled).toBe(true);
-    expect(cordon.getAttribute("title")).toEqual(expect.stringContaining("patch nodes"));
+    // The reason is a Radix tooltip on the wrapper around the disabled button
+    // (#376) — a disabled <button> itself gets no pointer events.
+    const trigger = cordon.closest<HTMLElement>('[data-slot="tooltip-trigger"]');
+    if (!trigger) throw new Error("disabled Cordon has no tooltip trigger");
+    await userEvent.hover(trigger);
+    expect((await screen.findByRole("tooltip")).textContent).toEqual(expect.stringContaining("patch nodes"));
   });
 
   it("enables Cordon when allowed", async () => {

--- a/apps/desktop/src/components/ResourceOverview.test.tsx
+++ b/apps/desktop/src/components/ResourceOverview.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 // Workload relations fetch their own data; stub them so the overview tests
 // stay focused on the Properties rendering (they have their own test file).
@@ -51,6 +52,15 @@ import {
   summarizeAffinity,
 } from "./ResourceOverview";
 import type { K8sObject } from "@srelens/core";
+
+// A disabled control explains itself through a Radix tooltip, not a native
+// title (#376): hover its trigger — the wrapper around a disabled button,
+// which is what still receives pointer events — and read the tooltip.
+async function tooltipOf(el: HTMLElement): Promise<string | null> {
+  const trigger = el.closest<HTMLElement>('[data-slot="tooltip-trigger"]') ?? el;
+  await userEvent.hover(trigger);
+  return (await screen.findByRole("tooltip")).textContent;
+}
 
 const NOW = Date.parse("2026-01-01T00:00:00Z");
 
@@ -535,7 +545,7 @@ describe("ObjectDetail (ConfigMap / Secret)", () => {
     );
   });
 
-  it("disables Save and explains why when the user can't update the ConfigMap", () => {
+  it("disables Save and explains why when the user can't update the ConfigMap", async () => {
     vi.mocked(useAccess).mockReturnValue({
       allowed: () => false,
       reason: () => "RBAC: no rule",
@@ -551,7 +561,7 @@ describe("ObjectDetail (ConfigMap / Secret)", () => {
     fireEvent.change(screen.getByLabelText("Value for app.conf"), { target: { value: "level=debug" } });
     const save = screen.getByRole("button", { name: "Save" });
     expect((save as HTMLButtonElement).disabled).toBe(true);
-    expect(save.getAttribute("title")).toEqual(expect.stringContaining("permission to update configmaps in prod"));
+    expect(await tooltipOf(save)).toEqual(expect.stringContaining("permission to update configmaps in prod"));
   });
 
   it("enables Save when the user can update the ConfigMap", () => {

--- a/apps/desktop/src/components/ResourceOverview.tsx
+++ b/apps/desktop/src/components/ResourceOverview.tsx
@@ -29,6 +29,7 @@ import {
   type OpenResource,
   type ResourceTarget,
 } from "@srelens/core";
+import { TitleTooltip } from "@/components/ui/tooltip";
 
 /* ------------------------------------------------------------------ */
 /* small value helpers                                                 */
@@ -135,15 +136,16 @@ function ResourceLink({
   if (!onOpenResource || !target.name || !isNavigableResourceKind(target.kind))
     return <span className="fl-mono">{content}</span>;
   return (
-    <button
-      type="button"
-      className="fl-link fl-mono"
-      aria-label={`Open ${target.kind} ${target.name}`}
-      title={`Open ${target.kind}`}
-      onClick={() => onOpenResource(target)}
-    >
-      {content}
-    </button>
+    <TitleTooltip title={`Open ${target.kind}`}>
+      <button
+        type="button"
+        className="fl-link fl-mono"
+        aria-label={`Open ${target.kind} ${target.name}`}
+        onClick={() => onOpenResource(target)}
+      >
+        {content}
+      </button>
+    </TitleTooltip>
   );
 }
 

--- a/apps/desktop/src/components/SettingsView.tsx
+++ b/apps/desktop/src/components/SettingsView.tsx
@@ -83,6 +83,7 @@ import { WebKubeconfigSection } from "./WebKubeconfigSection";
 import { WebAddClusterSection } from "./WebAddClusterSection";
 import { WebClusterSignInSection } from "./WebClusterSignInSection";
 import { ReleaseNotes } from "./ReleaseNotes";
+import { TitleTooltip } from "@/components/ui/tooltip";
 
 const MODE_OPTIONS: Array<{ mode: ThemeMode; label: string; description: string; icon: React.ElementType }> = [
   { mode: "dark", label: "Dark", description: "Low-light operational workspace", icon: Moon },
@@ -886,20 +887,22 @@ export function SettingsView({
                         </span>
                         <div className="fl-context-editor__order">
                           {selectedContext.isCurrent && <span className="fl-settings-context-current">Current</span>}
-                          <button
-                            type="button"
-                            onClick={() => moveContext(selectedContext.name, -1)}
-                            disabled={orderedContexts[0]?.name === selectedContext.name}
-                            aria-label={`Move ${selectedContext.name} up`}
-                            title="Move up"
-                          ><ArrowUp aria-hidden="true" /></button>
-                          <button
-                            type="button"
-                            onClick={() => moveContext(selectedContext.name, 1)}
-                            disabled={orderedContexts.at(-1)?.name === selectedContext.name}
-                            aria-label={`Move ${selectedContext.name} down`}
-                            title="Move down"
-                          ><ArrowDown aria-hidden="true" /></button>
+                          <TitleTooltip title="Move up" disabled={orderedContexts[0]?.name === selectedContext.name}>
+                            <button
+                              type="button"
+                              onClick={() => moveContext(selectedContext.name, -1)}
+                              disabled={orderedContexts[0]?.name === selectedContext.name}
+                              aria-label={`Move ${selectedContext.name} up`}
+                            ><ArrowUp aria-hidden="true" /></button>
+                          </TitleTooltip>
+                          <TitleTooltip title="Move down" disabled={orderedContexts.at(-1)?.name === selectedContext.name}>
+                            <button
+                              type="button"
+                              onClick={() => moveContext(selectedContext.name, 1)}
+                              disabled={orderedContexts.at(-1)?.name === selectedContext.name}
+                              aria-label={`Move ${selectedContext.name} down`}
+                            ><ArrowDown aria-hidden="true" /></button>
+                          </TitleTooltip>
                         </div>
                       </header>
 
@@ -1009,14 +1012,16 @@ export function SettingsView({
                               aria-label={`Set ${selectedContext.name} color to ${color}`}
                             />
                           ))}
-                          <label title="Custom color">
-                            <input
-                              type="color"
-                              value={selectedProfile.color ?? "#3b82f6"}
-                              onChange={(event) => updateContext(selectedContext.name, { color: event.target.value })}
-                              aria-label={`Custom color for ${selectedContext.name}`}
-                            />
-                          </label>
+                          <TitleTooltip title="Custom color">
+                            <label>
+                              <input
+                                type="color"
+                                value={selectedProfile.color ?? "#3b82f6"}
+                                onChange={(event) => updateContext(selectedContext.name, { color: event.target.value })}
+                                aria-label={`Custom color for ${selectedContext.name}`}
+                              />
+                            </label>
+                          </TitleTooltip>
                           <code>{selectedProfile.color ?? "Automatic"}</code>
                         </div>
                       </section>

--- a/apps/desktop/src/components/StatusBar.tsx
+++ b/apps/desktop/src/components/StatusBar.tsx
@@ -3,6 +3,7 @@ import { SquareTerminal } from "lucide-react";
 import { ClusterUsage } from "./ClusterUsage";
 import { ForwardsIndicator } from "./ForwardsIndicator";
 import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
+import { TitleTooltip } from "@/components/ui/tooltip";
 
 /** A context a terminal can be opened for. */
 export interface TerminalContext {
@@ -73,22 +74,25 @@ export function StatusBar({
       <span className="fl-statusbar__meta ml-auto flex items-center gap-3">
         {showTerminal && (
           <Popover open={picker} onOpenChange={setPicker}>
-            <PopoverAnchor asChild>
-              <button
-                type="button"
-                className="fl-statusbar__terminal flex items-center gap-1 hover:text-foreground"
-                onClick={launch}
-                title={
-                  terminalContexts.length === 1
-                    ? `Open a kubectl terminal for ${terminalContexts[0].label}`
-                    : "Open a kubectl terminal — choose a context"
-                }
-                aria-label="Open kubectl terminal"
-              >
-                <SquareTerminal className="size-3.5" aria-hidden="true" />
-                Terminal
-              </button>
-            </PopoverAnchor>
+            <TitleTooltip
+              title={
+                terminalContexts.length === 1
+                  ? `Open a kubectl terminal for ${terminalContexts[0].label}`
+                  : "Open a kubectl terminal — choose a context"
+              }
+            >
+              <PopoverAnchor asChild>
+                <button
+                  type="button"
+                  className="fl-statusbar__terminal flex items-center gap-1 hover:text-foreground"
+                  onClick={launch}
+                  aria-label="Open kubectl terminal"
+                >
+                  <SquareTerminal className="size-3.5" aria-hidden="true" />
+                  Terminal
+                </button>
+              </PopoverAnchor>
+            </TitleTooltip>
             {/* Capped and scrollable: a kubeconfig with twenty contexts would
                 otherwise open a menu taller than the window. */}
             <PopoverContent
@@ -98,11 +102,10 @@ export function StatusBar({
               className="max-h-64 w-auto min-w-40 max-w-80 gap-0 overflow-y-auto p-1 text-xs"
             >
               {ordered.map((c) => (
+                <TitleTooltip key={c.name} title={`Open a kubectl terminal for ${c.label}`}>
                 <button
-                  key={c.name}
                   type="button"
                   role="menuitem"
-                  title={`Open a kubectl terminal for ${c.label}`}
                   className="flex w-full items-center gap-2 rounded px-2 py-1 text-left hover:bg-accent hover:text-accent-foreground"
                   onClick={() => {
                     setPicker(false);
@@ -117,6 +120,7 @@ export function StatusBar({
                   />
                   <span className="min-w-0 truncate">{c.label}</span>
                 </button>
+                </TitleTooltip>
               ))}
             </PopoverContent>
           </Popover>

--- a/apps/desktop/src/components/ui/button.test.tsx
+++ b/apps/desktop/src/components/ui/button.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { Button } from "./button";
+import { TOOLTIP_DELAY_MS, TOOLTIP_SKIP_DELAY_MS } from "./tooltip";
+
+const user = userEvent.setup({ delay: null });
+
+// A control explains itself through a Radix tooltip, never a native `title`:
+// the browser's bubble has a fixed ~1 s delay (#376) and the two would double
+// up. `title` is the one prop every button already had, so the switch happens
+// inside `Button` and every caller gets it without changing.
+describe("Button title", () => {
+  it("shows the title as a tooltip on hover and forwards no native title", async () => {
+    render(<Button title="Copy as kubectl">Copy</Button>);
+    const button = screen.getByRole("button", { name: "Copy" });
+    expect(button.hasAttribute("title")).toBe(false);
+    expect(button.getAttribute("data-slot")).toBe("button");
+
+    await user.hover(button);
+    expect((await screen.findByRole("tooltip")).textContent).toBe("Copy as kubectl");
+  });
+
+  it("renders a button without a title exactly as before: no trigger, no tooltip", async () => {
+    const { container } = render(<Button>Plain</Button>);
+    const button = screen.getByRole("button", { name: "Plain" });
+    expect(button.parentElement).toBe(container);
+    // Radix marks its trigger with data-state; a plain button has none.
+    expect(button.hasAttribute("data-state")).toBe(false);
+    expect(document.querySelector('[data-slot="tooltip-trigger"]')).toBeNull();
+  });
+
+  it("treats an empty title like none", () => {
+    render(<Button title="">Plain</Button>);
+    const button = screen.getByRole("button", { name: "Plain" });
+    expect(button.hasAttribute("title")).toBe(false);
+    expect(button.hasAttribute("data-state")).toBe(false);
+  });
+
+  it("keeps asChild rendering the child, and makes that child the trigger", async () => {
+    render(
+      <Button asChild title="Open the docs">
+        <a href="#docs">Docs</a>
+      </Button>,
+    );
+    expect(screen.queryByRole("button")).toBeNull();
+    const link = screen.getByRole("link", { name: "Docs" });
+    expect(link.getAttribute("data-slot")).toBe("button");
+    expect(link.hasAttribute("title")).toBe(false);
+
+    await user.hover(link);
+    expect((await screen.findByRole("tooltip")).textContent).toBe("Open the docs");
+  });
+
+  it("keeps a disabled button's reason reachable through a wrapper trigger", async () => {
+    render(
+      <Button disabled title="You don't have permission to patch deployments in prod">
+        Apply
+      </Button>,
+    );
+    const button = screen.getByRole("button", { name: "Apply" }) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    expect(button.hasAttribute("title")).toBe(false);
+    // A disabled <button> gets no pointer events, so the trigger has to be an
+    // element around it.
+    const trigger = button.parentElement;
+    if (!trigger) throw new Error("disabled Button has no wrapper element");
+    expect(trigger.getAttribute("data-slot")).toBe("tooltip-trigger");
+
+    await user.hover(trigger);
+    expect((await screen.findByRole("tooltip")).textContent).toBe(
+      "You don't have permission to patch deployments in prod",
+    );
+  });
+
+  it("does not wrap a disabled button that has nothing to explain", () => {
+    const { container } = render(<Button disabled>Apply</Button>);
+    expect(screen.getByRole("button", { name: "Apply" }).parentElement).toBe(container);
+  });
+
+  it("still fires onClick through the tooltip trigger", async () => {
+    const onClick = vi.fn();
+    render(
+      <Button title="Refresh the list" onClick={onClick}>
+        Refresh
+      </Button>,
+    );
+    await user.click(screen.getByRole("button", { name: "Refresh" }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("looks like the native title bubble it replaces: popover surface, hairline border, no arrow", async () => {
+    render(<Button title="Refresh the list">Refresh</Button>);
+    await user.hover(screen.getByRole("button", { name: "Refresh" }));
+    await screen.findByRole("tooltip");
+    const content = document.querySelector<HTMLElement>('[data-slot="tooltip-content"]');
+    if (!content) throw new Error("tooltip content not rendered");
+    expect(content.classList.contains("bg-popover")).toBe(true);
+    expect(content.classList.contains("border")).toBe(true);
+    expect(content.classList.contains("text-xs")).toBe(true);
+    expect(content.classList.contains("bg-foreground")).toBe(false);
+    expect(content.querySelector("svg")).toBeNull();
+  });
+});
+
+describe("tooltip delay", () => {
+  it("opens fast — 100 ms, not the browser's second — and sweeps siblings for 300 ms", () => {
+    expect(TOOLTIP_DELAY_MS).toBe(100);
+    expect(TOOLTIP_SKIP_DELAY_MS).toBe(300);
+  });
+});

--- a/apps/desktop/src/components/ui/button.tsx
+++ b/apps/desktop/src/components/ui/button.tsx
@@ -3,6 +3,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { Slot } from "radix-ui"
 
 import { cn } from "@/ui/utils"
+import { TitleTooltip } from "@/components/ui/tooltip"
 
 const buttonVariants = cva(
   "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
@@ -41,11 +42,20 @@ const buttonVariants = cva(
   }
 )
 
+/**
+ * `title` is shown as a Radix tooltip rather than forwarded as the native
+ * attribute: the browser's bubble has a fixed ~1 s delay that made every
+ * toolbar feel unresponsive (#376), and rendering both would show two. With
+ * `asChild` the rendered child is the trigger; a disabled button is wrapped
+ * so its reason stays reachable (see `TitleTooltip`). Without `title` the
+ * button renders exactly as shadcn's.
+ */
 function Button({
   className,
   variant = "default",
   size = "default",
   asChild = false,
+  title,
   ...props
 }: React.ComponentProps<"button"> &
   VariantProps<typeof buttonVariants> & {
@@ -53,7 +63,7 @@ function Button({
   }) {
   const Comp = asChild ? Slot.Root : "button"
 
-  return (
+  const button = (
     <Comp
       data-slot="button"
       data-variant={variant}
@@ -61,6 +71,12 @@ function Button({
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
+  )
+  if (!title) return button
+  return (
+    <TitleTooltip title={title} disabled={props.disabled}>
+      {button}
+    </TitleTooltip>
   )
 }
 

--- a/apps/desktop/src/components/ui/tooltip.tsx
+++ b/apps/desktop/src/components/ui/tooltip.tsx
@@ -3,23 +3,52 @@ import { Tooltip as TooltipPrimitive } from "radix-ui"
 
 import { cn } from "@/ui/utils"
 
+/**
+ * How long a pointer rests on a trigger before its tooltip opens. Not 0: an
+ * instant tooltip flashes on every pointer pass across a toolbar and reads
+ * as noise; 200 ms is below what registers as a wait. Well under the
+ * browser's fixed ~1 s native `title` delay this replaces (#376).
+ */
+export const TOOLTIP_DELAY_MS = 200
+
+/**
+ * After one tooltip has shown, sibling tooltips under the same provider open
+ * with no delay for this long — the "sweep across the toolbar" behaviour.
+ */
+export const TOOLTIP_SKIP_DELAY_MS = 300
+
+// Radix throws for a `Tooltip` rendered outside a `TooltipProvider`. The app
+// mounts one provider at its root so every tooltip shares the skip-delay
+// state; a `Tooltip` mounted anywhere else (a component test, an isolated
+// render) gets a provider of its own instead of a crash.
+const HasTooltipProvider = React.createContext(false)
+
 function TooltipProvider({
-  delayDuration = 0,
+  delayDuration = TOOLTIP_DELAY_MS,
+  skipDelayDuration = TOOLTIP_SKIP_DELAY_MS,
+  children,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
   return (
-    <TooltipPrimitive.Provider
-      data-slot="tooltip-provider"
-      delayDuration={delayDuration}
-      {...props}
-    />
+    <HasTooltipProvider.Provider value={true}>
+      <TooltipPrimitive.Provider
+        data-slot="tooltip-provider"
+        delayDuration={delayDuration}
+        skipDelayDuration={skipDelayDuration}
+        {...props}
+      >
+        {children}
+      </TooltipPrimitive.Provider>
+    </HasTooltipProvider.Provider>
   )
 }
 
 function Tooltip({
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
-  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+  const hasProvider = React.useContext(HasTooltipProvider)
+  const root = <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+  return hasProvider ? root : <TooltipProvider>{root}</TooltipProvider>
 }
 
 function TooltipTrigger({
@@ -28,9 +57,12 @@ function TooltipTrigger({
   return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
 }
 
+// Styled like the native `title` bubble it replaces (light popover surface,
+// hairline border, small dark text, no arrow) so only the delay changes for
+// the reader; shadcn's dark pill with an arrow would read as a new control.
 function TooltipContent({
   className,
-  sideOffset = 0,
+  sideOffset = 4,
   children,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Content>) {
@@ -40,13 +72,12 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "z-50 inline-flex w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "z-50 w-fit max-w-xs rounded-md border border-border bg-popover px-2 py-1 text-xs text-popover-foreground shadow-sm duration-100 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
           className
         )}
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   )

--- a/apps/desktop/src/components/ui/tooltip.tsx
+++ b/apps/desktop/src/components/ui/tooltip.tsx
@@ -6,10 +6,11 @@ import { cn } from "@/ui/utils"
 /**
  * How long a pointer rests on a trigger before its tooltip opens. Not 0: an
  * instant tooltip flashes on every pointer pass across a toolbar and reads
- * as noise; 200 ms is below what registers as a wait. Well under the
- * browser's fixed ~1 s native `title` delay this replaces (#376).
+ * as noise; 100 ms is under what registers as a wait at all — the user's
+ * word for it is "fast". A tenth of the browser's fixed ~1 s native `title`
+ * delay this replaces (#376).
  */
-export const TOOLTIP_DELAY_MS = 200
+export const TOOLTIP_DELAY_MS = 100
 
 /**
  * After one tooltip has shown, sibling tooltips under the same provider open
@@ -83,4 +84,35 @@ function TooltipContent({
   )
 }
 
-export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger }
+/**
+ * Explains a control with `title` in a tooltip, in place of the native `title`
+ * attribute whose ~1 s delay is not configurable (#376). This is the one
+ * implementation behind `Button`'s `title` prop; a control that is not a
+ * `Button` (a hotbar item, a menu row) wraps itself in it directly.
+ *
+ * `disabled` wraps the child in a span that carries the trigger: a disabled
+ * `<button>` receives no pointer events, so without the wrapper the reason
+ * for its being disabled would be unreachable.
+ */
+function TitleTooltip({
+  title,
+  disabled = false,
+  children,
+}: {
+  title: React.ReactNode
+  disabled?: boolean
+  children: React.ReactElement
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        {disabled ? <span className="inline-flex">{children}</span> : children}
+      </TooltipTrigger>
+      <TooltipContent side="bottom" sideOffset={4}>
+        {title}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+export { TitleTooltip, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger }

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -49,11 +49,21 @@ async function bootstrap(root: HTMLElement): Promise<void> {
     );
     return;
   }
-  const [, { default: AppGate }] = await Promise.all([
+  const [, { default: AppGate }, { TooltipProvider }] = await Promise.all([
     import("./styles/globals.css"),
     import("./AppGate"),
+    import("./components/ui/tooltip"),
   ]);
-  createRoot(root).render(<AppGate />);
+  // One tooltip provider for the whole classic window: every tooltip shares
+  // its open delay and, once one has shown, its neighbours open at once for a
+  // moment (the "sweep across the toolbar" the native `title` never allowed,
+  // #376). The delay values are the provider's defaults — see tooltip.tsx for
+  // why. The next design is not wrapped: its kit carries its own tooltip.
+  createRoot(root).render(
+    <TooltipProvider>
+      <AppGate />
+    </TooltipProvider>,
+  );
 }
 
 void bootstrap(container);

--- a/apps/desktop/src/ui/IconButton.test.tsx
+++ b/apps/desktop/src/ui/IconButton.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { Trash2 } from "lucide-react";
+import { IconButton } from "./IconButton";
+
+// No waits between the pointer events, so the hover completes before the
+// tooltip's open delay can elapse and the "not instant" pin is deterministic.
+const user = userEvent.setup({ delay: null });
+
+describe("IconButton", () => {
+  it("names the button by its label and shows the label as the tooltip on hover", async () => {
+    render(<IconButton icon={Trash2} label="Delete" />);
+    const button = screen.getByRole("button", { name: "Delete" });
+    // The browser's own tooltip has a fixed ~1s delay (#376) and would double
+    // up with ours, so the native title must be gone.
+    expect(button.hasAttribute("title")).toBe(false);
+
+    await user.hover(button);
+    expect((await screen.findByRole("tooltip")).textContent).toBe("Delete");
+  });
+
+  it("waits the shared delay rather than opening on the first pointer pass", async () => {
+    render(<IconButton icon={Trash2} label="Delete" />);
+    await user.hover(screen.getByRole("button", { name: "Delete" }));
+    expect(screen.queryByRole("tooltip")).toBeNull();
+    expect((await screen.findByRole("tooltip")).textContent).toBe("Delete");
+  });
+
+  it("shows the title override in place of the label", async () => {
+    render(<IconButton icon={Trash2} label="Shell" title="Shell — 2 containers" />);
+    await user.hover(screen.getByRole("button", { name: "Shell" }));
+    expect((await screen.findByRole("tooltip")).textContent).toBe("Shell — 2 containers");
+  });
+
+  it("keeps a disabled button's reason reachable through a wrapper trigger", async () => {
+    render(<IconButton icon={Trash2} label="Delete" disabled title="You don't have permission to delete pods" />);
+    const button = screen.getByRole("button", { name: "Delete" }) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    expect(button.hasAttribute("title")).toBe(false);
+    // A disabled <button> receives no pointer events, so the tooltip's trigger
+    // has to be an element around it, not the button itself.
+    expect(button.getAttribute("data-slot")).not.toBe("tooltip-trigger");
+    const trigger = button.parentElement;
+    if (!trigger) throw new Error("disabled IconButton has no wrapper element");
+    expect(trigger.getAttribute("data-slot")).toBe("tooltip-trigger");
+
+    await user.hover(trigger);
+    expect((await screen.findByRole("tooltip")).textContent).toBe("You don't have permission to delete pods");
+  });
+
+  it("looks like the native title bubble it replaces: light surface, no arrow", async () => {
+    render(<IconButton icon={Trash2} label="Delete" />);
+    await user.hover(screen.getByRole("button", { name: "Delete" }));
+    await screen.findByRole("tooltip");
+    const content = document.querySelector<HTMLElement>('[data-slot="tooltip-content"]');
+    if (!content) throw new Error("tooltip content not rendered");
+    // Only the delay changes for the reader: the app's popover surface with a
+    // hairline border, not shadcn's dark pill.
+    expect(content.classList.contains("bg-popover")).toBe(true);
+    expect(content.classList.contains("border")).toBe(true);
+    expect(content.classList.contains("bg-primary")).toBe(false);
+    expect(content.classList.contains("bg-foreground")).toBe(false);
+    expect(content.querySelector("svg")).toBeNull();
+    expect(document.querySelector('[data-slot="tooltip-content"] [class*="rotate-45"]')).toBeNull();
+  });
+
+  it("still fires onClick through the tooltip trigger", async () => {
+    const onClick = vi.fn();
+    render(<IconButton icon={Trash2} label="Delete" onClick={onClick} />);
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/ui/IconButton.tsx
+++ b/apps/desktop/src/ui/IconButton.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { LucideIcon } from "lucide-react";
 
 export interface IconButtonProps {
@@ -18,21 +19,42 @@ export interface IconButtonProps {
  * A compact icon-only button (shadcn Button, ghost). The label is both the
  * accessible name and the hover tooltip (unless `title` overrides it), so the
  * icon never stands alone.
+ *
+ * The tooltip is a Radix one, not the native `title`: the browser's tooltip
+ * has a fixed ~1 s delay that made a toolbar feel unresponsive (#376), and
+ * rendering both would show two. The delay lives in the app's root
+ * `TooltipProvider`.
  */
 export function IconButton({ icon, label, onClick, danger, disabled, title }: IconButtonProps) {
   const Icon = icon;
-  return (
+  const button = (
     <Button
       type="button"
       variant="ghost"
       size="icon-sm"
       aria-label={label}
-      title={title ?? label}
       onClick={onClick}
       disabled={disabled}
       className={danger ? "text-destructive hover:text-destructive" : undefined}
     >
       <Icon aria-hidden="true" />
     </Button>
+  );
+  return (
+    <Tooltip>
+      {disabled ? (
+        // A disabled <button> receives no pointer events, so it can't open a
+        // tooltip itself and the disabled reason in `title` would be lost.
+        // Wrap it and let the wrapper be the trigger.
+        <TooltipTrigger asChild>
+          <span className="inline-flex">{button}</span>
+        </TooltipTrigger>
+      ) : (
+        <TooltipTrigger asChild>{button}</TooltipTrigger>
+      )}
+      <TooltipContent side="bottom" sideOffset={4}>
+        {title ?? label}
+      </TooltipContent>
+    </Tooltip>
   );
 }

--- a/apps/desktop/src/ui/IconButton.tsx
+++ b/apps/desktop/src/ui/IconButton.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { LucideIcon } from "lucide-react";
 
 export interface IconButtonProps {
@@ -20,41 +19,24 @@ export interface IconButtonProps {
  * accessible name and the hover tooltip (unless `title` overrides it), so the
  * icon never stands alone.
  *
- * The tooltip is a Radix one, not the native `title`: the browser's tooltip
- * has a fixed ~1 s delay that made a toolbar feel unresponsive (#376), and
- * rendering both would show two. The delay lives in the app's root
- * `TooltipProvider`.
+ * The tooltip is `Button`'s own `title` handling — a Radix tooltip, not the
+ * native attribute with its fixed ~1 s delay (#376) — so a disabled button's
+ * reason stays reachable and there is one mechanism for every button.
  */
 export function IconButton({ icon, label, onClick, danger, disabled, title }: IconButtonProps) {
   const Icon = icon;
-  const button = (
+  return (
     <Button
       type="button"
       variant="ghost"
       size="icon-sm"
       aria-label={label}
+      title={title ?? label}
       onClick={onClick}
       disabled={disabled}
       className={danger ? "text-destructive hover:text-destructive" : undefined}
     >
       <Icon aria-hidden="true" />
     </Button>
-  );
-  return (
-    <Tooltip>
-      {disabled ? (
-        // A disabled <button> receives no pointer events, so it can't open a
-        // tooltip itself and the disabled reason in `title` would be lost.
-        // Wrap it and let the wrapper be the trigger.
-        <TooltipTrigger asChild>
-          <span className="inline-flex">{button}</span>
-        </TooltipTrigger>
-      ) : (
-        <TooltipTrigger asChild>{button}</TooltipTrigger>
-      )}
-      <TooltipContent side="bottom" sideOffset={4}>
-        {title ?? label}
-      </TooltipContent>
-    </Tooltip>
   );
 }

--- a/apps/desktop/src/ui/KubectlPreview.tsx
+++ b/apps/desktop/src/ui/KubectlPreview.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Copy } from "lucide-react";
+import { TitleTooltip } from "@/components/ui/tooltip";
 
 export interface KubectlPreviewProps {
   /** The kubectl-equivalent command. Omit (and pass `note` instead) when there's no faithful one-liner. */
@@ -27,10 +28,10 @@ export function KubectlPreview({ command, note, onCopy }: KubectlPreviewProps) {
       <span>Equivalent kubectl:</span>
       <code>{command}</code>
       {onCopy && (
+        <TitleTooltip title="Copy kubectl command">
         <button
           type="button"
           aria-label="Copy kubectl command"
-          title="Copy kubectl command"
           onClick={onCopy}
           style={{
             display: "inline-flex",
@@ -43,6 +44,7 @@ export function KubectlPreview({ command, note, onCopy }: KubectlPreviewProps) {
         >
           <Copy size={12} aria-hidden="true" />
         </button>
+        </TitleTooltip>
       )}
     </p>
   );

--- a/crates/kube/src/logs.rs
+++ b/crates/kube/src/logs.rs
@@ -31,6 +31,19 @@ impl Default for StreamOpts {
     }
 }
 
+/// How many trailing lines a one-shot `k8s.podLogs` fetch asks for. `None`
+/// means "no bound": the API then returns every line the container runtime
+/// still retains, which is the only way to get a pod's complete history and
+/// is why `all_lines` overrides `tail_lines` rather than combining with it.
+/// Pure, so the precedence is unit-tested.
+pub fn effective_tail_lines(all_lines: bool, tail_lines: Option<i64>) -> Option<i64> {
+    if all_lines {
+        None
+    } else {
+        Some(tail_lines.unwrap_or(DEFAULT_TAIL_LINES))
+    }
+}
+
 /// Build the kube `LogParams` for a target + options. Pure, so the mapping
 /// (follow, tail, since, timestamps, previous) is unit-tested.
 pub fn build_log_params(
@@ -149,9 +162,17 @@ pub struct PodLogsIn {
     /// for any pod with more than one (it does not pick one for you).
     #[serde(default)]
     pub container: Option<String>,
-    /// Number of trailing lines to return (default 200).
+    /// Number of trailing lines to return (default 200). Ignored when
+    /// `all_lines` is set.
     #[serde(default)]
     pub tail_lines: Option<i64>,
+    /// Return every line the container runtime still retains instead of a
+    /// tail. Wins over `tail_lines` when both are given. Kubernetes keeps only
+    /// what log rotation has not yet discarded, and the response can be very
+    /// large — prefer `tail_lines`/`since_seconds` unless the whole history is
+    /// needed (e.g. to save it to a file). Default false.
+    #[serde(default)]
+    pub all_lines: bool,
     /// Logs from the previous, terminated instance (post-crash triage).
     #[serde(default)]
     pub previous: bool,
@@ -168,11 +189,11 @@ pub struct PodLogsOut {
     pub logs: String,
 }
 
-/// `k8s.podLogs` — return the last N lines of a pod's logs.
+/// `k8s.podLogs` — return the last N lines of a pod's logs, or all of them.
 pub fn pod_logs_capability(cache: Arc<ClientCache>) -> Capability {
     Capability::typed::<PodLogsIn, PodLogsOut, _, _>(
         "k8s.podLogs",
-        "fetch recent logs for a pod in a connected kube context",
+        "fetch logs for a pod in a connected kube context: the last 200 lines by default (tail_lines to change), or set all_lines to get everything the runtime still retains (can be large)",
         Annotations::READ_ONLY,
         move |input: PodLogsIn| {
             let cache = cache.clone();
@@ -185,7 +206,7 @@ pub fn pod_logs_capability(cache: Arc<ClientCache>) -> Capability {
                 let params = build_log_params(
                     input.container.clone(),
                     false,
-                    Some(input.tail_lines.unwrap_or(DEFAULT_TAIL_LINES)),
+                    effective_tail_lines(input.all_lines, input.tail_lines),
                     input.since_seconds,
                     input.timestamps,
                     input.previous,
@@ -221,6 +242,35 @@ mod tests {
         assert_eq!(p.since_seconds, Some(300));
         assert!(p.timestamps);
         assert!(p.previous);
+    }
+
+    #[test]
+    fn all_lines_drops_the_tail_bound_and_wins_over_tail_lines() {
+        // `all_lines` is the only way to get `tail_lines: None`, which is what
+        // makes the API return everything the runtime still retains.
+        assert_eq!(effective_tail_lines(true, None), None);
+        assert_eq!(effective_tail_lines(true, Some(50)), None);
+    }
+
+    #[test]
+    fn without_all_lines_the_tail_defaults_to_200_or_the_given_count() {
+        // The default path — every existing caller, MCP agents included — is
+        // unchanged: omit both and you still get the last 200 lines.
+        assert_eq!(effective_tail_lines(false, None), Some(DEFAULT_TAIL_LINES));
+        assert_eq!(effective_tail_lines(false, Some(50)), Some(50));
+    }
+
+    #[test]
+    fn pod_logs_input_defaults_all_lines_to_false() {
+        let input: PodLogsIn =
+            serde_json::from_str(r#"{"context":"c","namespace":"n","pod":"p"}"#).unwrap();
+        assert!(!input.all_lines);
+        assert_eq!(input.tail_lines, None);
+        let input: PodLogsIn = serde_json::from_str(
+            r#"{"context":"c","namespace":"n","pod":"p","all_lines":true,"tail_lines":50}"#,
+        )
+        .unwrap();
+        assert!(input.all_lines);
     }
 
     #[test]

--- a/docs/mcp-catalog.md
+++ b/docs/mcp-catalog.md
@@ -51,7 +51,7 @@ Argument schemas are not reproduced here — call `tools/list` for those, which 
 | `k8s.listStorageClasses` | list StorageClasses of a connected kube context (cluster-scoped) |
 | `k8s.nodeMetrics` | node CPU/memory usage (requires metrics-server) |
 | `k8s.openApiSchema` | fetch the OpenAPI schema for a resource kind (for field autocomplete) |
-| `k8s.podLogs` | fetch recent logs for a pod in a connected kube context |
+| `k8s.podLogs` | fetch logs for a pod in a connected kube context: the last 200 lines by default (tail_lines to change), or set all_lines to get everything the runtime still retains (can be large) |
 | `k8s.podMetrics` | pod CPU/memory usage (requires metrics-server) |
 | `k8s.podsForPvc` | list pods in a namespace that mount a given PersistentVolumeClaim |
 | `k8s.podsForSelector` | list pods matching a label selector (a workload's managed pods) |

--- a/packages/core/src/lib/workloads.test.ts
+++ b/packages/core/src/lib/workloads.test.ts
@@ -87,6 +87,24 @@ describe("podLogs", () => {
     });
   });
 
+  it("asks for every retained line with all_lines, and omits it when false", async () => {
+    const invoke = vi.fn().mockResolvedValue({ logs: "" });
+    await podLogs("kind-dev", "default", "web-1", invoke, { allLines: true });
+    expect(invoke).toHaveBeenCalledWith("k8s.podLogs", {
+      context: "kind-dev",
+      namespace: "default",
+      pod: "web-1",
+      all_lines: true,
+    });
+    await podLogs("kind-dev", "default", "web-1", invoke, { allLines: false, tailLines: 50 });
+    expect(invoke).toHaveBeenLastCalledWith("k8s.podLogs", {
+      context: "kind-dev",
+      namespace: "default",
+      pod: "web-1",
+      tail_lines: 50,
+    });
+  });
+
   it("omits options that are falsy or unset", async () => {
     const invoke = vi.fn().mockResolvedValue({ logs: "" });
     await podLogs("kind-dev", "default", "web-1", invoke, { container: "app", previous: false });

--- a/packages/core/src/lib/workloads.ts
+++ b/packages/core/src/lib/workloads.ts
@@ -215,8 +215,14 @@ export interface PodLogsOptions {
   timestamps?: boolean;
   /** Only lines newer than this many seconds ago. */
   sinceSeconds?: number;
-  /** Number of trailing lines to return. */
+  /** Number of trailing lines to return. Ignored when `allLines` is set. */
   tailLines?: number;
+  /**
+   * Fetch every line the container runtime still retains instead of a tail;
+   * wins over `tailLines`. Only what log rotation has kept is available, and
+   * the response can be very large — for saving a full dump, not for display.
+   */
+  allLines?: boolean;
 }
 
 /** Fetch recent logs for a pod (optionally a specific container) via `k8s.podLogs`. */
@@ -227,7 +233,7 @@ export async function podLogs(
   invoke: Invoker = invokeCapability,
   options: PodLogsOptions = {},
 ): Promise<LogsOutcome> {
-  const { container, previous, timestamps, sinceSeconds, tailLines } = options;
+  const { container, previous, timestamps, sinceSeconds, tailLines, allLines } = options;
   try {
     // `k8s.podLogs` deserialises snake_case field names (no serde rename).
     const out = await invoke<{ logs: string }>("k8s.podLogs", {
@@ -239,6 +245,7 @@ export async function podLogs(
       ...(timestamps ? { timestamps: true } : {}),
       ...(sinceSeconds != null ? { since_seconds: sinceSeconds } : {}),
       ...(tailLines != null ? { tail_lines: tailLines } : {}),
+      ...(allLines ? { all_lines: true } : {}),
     });
     return { logs: out.logs };
   } catch (e) {


### PR DESCRIPTION
Two user-reported fixes, onto `dev`. Merge `dev` → `main` afterwards to ship them; the release computes the number from the commits in range.

Supersedes #377, which carried the same two fixes based on `main` before the tooltip scope widened.

## #353 — Logs: enable download of all pod logs

Two layers, and the first meant no caller could ask for what the reporter wanted:

- `k8s.podLogs` forced `Some(tail_lines.unwrap_or(200))`, so omitting the field meant 200 rather than everything. `PodLogsIn.all_lines` (default false) now yields `tail_lines: None`, which is the only thing that makes Kubernetes return every line the runtime still retains. `all_lines` wins over `tail_lines` when both are given, and the field's doc says so. Every existing caller and MCP agent keeps the 200-line default. `docs/mcp-catalog.md` regenerated — `srelens-registry` asserts it in sync.
- Classic's "Download all containers" passed the view's `tailLines` and `sinceSeconds`, so "all" was bounded by the filter on screen. It now requests `allLines: true` and drops both; `previous` and `timestamps` stay, since they choose *which* stream rather than how much of it.

The button says what it does — *"Download all container logs"* / *"Save everything the cluster still holds for every container of these pods, not just the lines shown here"* — without overclaiming: what log rotation has discarded is gone.

## #376 — tooltip delay is too long

The delay was the browser's, and the first pass fixed too little. `IconButton` was converted, but the buttons in the screenshot are not all `IconButton`s — `Copy as kubectl` is a plain `<Button … title=…>`, and the detail toolbar has ~20 more. Those kept the native tooltip and its fixed ~1 s.

So the fix moved to the seam they already share: **`Button` renders its `title` as a Radix tooltip** instead of forwarding a native attribute, under one root provider at **100 ms** with a 300 ms skip window so sibling controls open instantly while exploring a toolbar. `IconButton` passes `title` down rather than keeping a second mechanism. Raw `<button title=…>` controls were converted; a `title` on a non-interactive element — a truncated span, a table cell — keeps the native one, which is right there.

**The appearance is deliberately unchanged.** The shadcn default (dark pill, arrow) is replaced with classic's own popover surface, hairline border and small dark text, no arrow, so the only observable difference is the delay. A pin fails if the shadcn styling comes back.

A disabled button gets no pointer events from Radix, so its trigger is wrapped in a span — the disabled reason is the only thing several of these titles carry.

## Verification

Tests first for both, then mutation: dropping the `all_lines` branch fails the Rust pin (`Some(200)` vs `None`); passing `tailLines` again fails the TS pin; forwarding `title` natively again fails the button pins; removing the provider fails all of them; restoring the shadcn styling fails the appearance pin.

Six assertions that read `getAttribute("title")` off a button now hover and read the tooltip. `tooltipOf` resolves the trigger's own `aria-describedby` rather than the first node with the tooltip role — opening a menu focuses its first item and Radix opens a tooltip on focus as well as hover, so a bare `findByRole("tooltip")` returned the first item's text however far down the menu the hover went. That one bit during this work and is worth knowing for the next such test.

Gates: 1454 frontend tests across 174 files, `cargo test -p srelens-kube -p srelens-registry` green (326 + 45), typecheck clean across all four packages.

Closes #353. Closes #376.