### PR TITLE
docs(server): say why the per-user paths cannot traverse

### DIFF
--- a/crates/server/src/users.rs
+++ b/crates/server/src/users.rs
@@ -1,6 +1,26 @@
 //! Per-user execution environments: each user's capability calls run against
 //! a registry + client cache built ONLY from their own uploaded kubeconfigs,
 //! materialized as 0600 files under `<data>/runtime/users/<id>/`.
+//!
+//! # Why the paths here are not a traversal risk
+//!
+//! Every path in this module is rooted at `data_dir` and extended only by
+//! literals (`runtime`, `users`, `helm`) and by **integers**: the user's own
+//! `i64` id ([`user_runtime_dir`]) and a kubeconfig row's `i64` id
+//! (`KubeconfigMeta::id`, `stores.rs`). `i64::to_string` can render only
+//! `-?[0-9]+`, so a component built from one cannot contain a path separator,
+//! a `..`, a NUL, or anything else that would leave the directory it is joined
+//! onto. No name, label, or other caller-supplied string is ever a component.
+//!
+//! CodeQL's `rust/path-injection` flags these five joins anyway, and it is
+//! right to follow the taint: the ids do originate in an authenticated HTTP
+//! session. It simply cannot see that the type makes the value inert. **The
+//! type IS the mitigation**, so keep it that way — if a component ever needs
+//! to come from a `String` (a user-chosen kubeconfig name, say), it needs its
+//! own validation and this paragraph stops being true.
+//!
+//! The alerts are dismissed as false positives rather than suppressed in code;
+//! this note exists so the next scan is not re-litigated from scratch.
 
 use std::collections::HashMap;
 use std::io::Write;
@@ -46,6 +66,10 @@ pub struct UserEnvs {
     build_locks: Mutex<HashMap<i64, Arc<tokio::sync::Mutex<()>>>>,
 }
 
+/// This user's private runtime root.
+///
+/// `user_id` is an `i64` and that is load-bearing, not incidental — see the
+/// traversal note at the top of this module before widening it to a string.
 fn user_runtime_dir(data_dir: &Path, user_id: i64) -> PathBuf {
     data_dir
         .join("runtime")
@@ -142,6 +166,9 @@ impl UserEnvs {
                 .get_kubeconfig_yaml(user_id, meta.id, key)
                 .await?
                 .ok_or_else(|| format!("kubeconfig {} disappeared", meta.id))?;
+            // Named from the row's `i64` id, never from `meta.name` — the
+            // filename has to stay inert, and the name is the user's own
+            // string. See the traversal note at the top of this module.
             let path = dir.join(format!("kc-{}.yaml", meta.id));
             write_private_file(&path, yaml.as_bytes())?;
             paths.push(path);


### PR DESCRIPTION
Doc-only — 27 added lines, all comments, no behaviour change.

CodeQL reports five `rust/path-injection` alerts in `crates/server/src/users.rs` at **error** severity. I checked each and they are false positives, but the reasoning was nowhere in the code, so it would have to be rediscovered on every scan.

## Why they are false positives

Every path in that module is rooted at `data_dir` and extended only by literals (`runtime`, `users`, `helm`) and by **integers**: the user's own `i64` id, and a kubeconfig row's `i64` id (`KubeconfigMeta::id`, `stores.rs:25`). `i64::to_string` renders only `-?[0-9]+`, so a component built from one cannot contain a path separator, a `..`, or a NUL. No name, label, or other caller-supplied string is ever a component.

CodeQL is right to follow the taint — those ids do originate in an authenticated HTTP session. It simply cannot see that the type makes the value inert.

## Why write it down rather than just dismiss

**The type is the mitigation, and nothing in the code said so.** The kubeconfig file is named `kc-{meta.id}.yaml` rather than from `meta.name`, which is a deliberate choice that reads like an arbitrary one. The next person who wants a friendlier filename on disk would reach for `meta.name` — a user-chosen string — and turn five false positives into one real traversal. The note says that explicitly at the two integer-derived joins and at the module head.

It also stops the next scan being re-litigated from scratch: the alerts are dismissed in the UI rather than suppressed in code, so there is no in-repo record of the analysis otherwise.

Worth noting the surrounding code is already careful in ways the alert does not credit: `create_private_dir` chmods every component it owns to `0700`, `write_private_file` opens with `create_new` at `0600`, and a per-user build lock stops two racing first-time builds from `remove_dir_all`-ing each other's freshly written files.

Verified: `cargo test -p srelens-server` 137 passed, `cargo build` clean.