### PR TITLE
build: move the CVE pins to where pnpm 11 reads them, and pin pnpm itself

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # No `version:` — `pnpm/action-setup` reads `packageManager` from
+      # package.json. One source of truth: a second one here is how local
+      # ended up on pnpm 11 while CI ran 9, which silently dropped the CVE
+      # overrides from the lockfile on every local install.
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: 9
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
@@ -81,9 +83,11 @@ jobs:
             libgtk-3-dev \
             libssl-dev \
             build-essential
+      # No `version:` — `pnpm/action-setup` reads `packageManager` from
+      # package.json. One source of truth: a second one here is how local
+      # ended up on pnpm 11 while CI ran 9, which silently dropped the CVE
+      # overrides from the lockfile on every local install.
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: 9
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
@@ -170,9 +174,11 @@ jobs:
             build-essential \
             webkit2gtk-driver \
             xvfb
+      # No `version:` — `pnpm/action-setup` reads `packageManager` from
+      # package.json. One source of truth: a second one here is how local
+      # ended up on pnpm 11 while CI ran 9, which silently dropped the CVE
+      # overrides from the lockfile on every local install.
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: 9
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,9 +217,11 @@ jobs:
             build-essential \
             webkit2gtk-driver \
             xvfb
+      # No `version:` — `pnpm/action-setup` reads `packageManager` from
+      # package.json. One source of truth: a second one here is how local
+      # ended up on pnpm 11 while CI ran 9, which silently dropped the CVE
+      # overrides from the lockfile on every local install.
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: 9
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
@@ -480,9 +482,11 @@ jobs:
           echo "${LINUXDEPLOY_SHA256}  $HOME/.cache/tauri/linuxdeploy-x86_64.AppImage" | sha256sum -c -
           chmod +x ~/.cache/tauri/linuxdeploy-x86_64.AppImage
 
+      # No `version:` — `pnpm/action-setup` reads `packageManager` from
+      # package.json. One source of truth: a second one here is how local
+      # ended up on pnpm 11 while CI ran 9, which silently dropped the CVE
+      # overrides from the lockfile on every local install.
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: 9
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -5,7 +5,7 @@ This guide covers everything you need to build, test, and extend srelens.
 ## Prerequisites
 
 - **Rust** (stable) — install via [rustup](https://rustup.rs). The toolchain is pinned by `rust-toolchain.toml` (stable + `llvm-tools-preview` for coverage).
-- **Node.js 22+** and **pnpm 9+**.
+- **Node.js 22+** and **pnpm 11+**. The exact version is pinned by `packageManager` in `package.json`, and pnpm switches to it on its own — don't install a different one alongside it.
 - **Tauri v2 system dependencies** — see the [official prerequisites](https://v2.tauri.app/start/prerequisites/) (on macOS: Xcode command-line tools; on Linux: webkit2gtk and friends).
 - A kubeconfig with at least one reachable cluster ([kind](https://kind.sigs.k8s.io) or k3d works well for development).
 - **Docker** — only if you want to build or run the [web app](#web-mode) locally.

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "packageManager": "pnpm@11.24.0",
   "name": "srelens-tauri",
   "private": true,
   "scripts": {
@@ -13,16 +14,5 @@
     "@vitest/coverage-v8": "^3.2.7",
     "turbo": "^2.0.0",
     "vitest": "^3.2.7"
-  },
-  "pnpm": {
-    "overrides": {
-      "fast-uri@>=3.0.0 <3.1.4": "^3.1.4",
-      "brace-expansion@>=2.0.0 <2.1.3": "^2.1.3",
-      "brace-expansion@>=4.0.0 <5.0.8": "^5.0.8",
-      "postcss@<8.5.18": "^8.5.18",
-      "@hono/node-server@<2.0.5": "^2.0.5",
-      "nanoid@<3.3.17": "^3.3.17",
-      "js-yaml@>=4.0.0 <4.3.1": "^4.3.1"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,32 @@
 packages:
   - "apps/*"
   - "packages/*"
-onlyBuiltDependencies:
-  - esbuild
+
+# esbuild's postinstall fetches its platform binary, so it has to run.
+#
+# pnpm 11 asks per package rather than taking a bare allow-list, and when it
+# has no answer it WRITES ITS OWN PROMPT INTO THIS FILE — the literal line
+# `esbuild: set this to true or false`, a string where a boolean belongs, which
+# then fails every subsequent install with a YAML or approval error. That is
+# how this file kept getting damaged. An explicit `true` here is what stops it
+# asking, and `pnpm approve-builds` writes the same key.
+allowBuilds:
+  esbuild: true
+
+# CVE pins. These lived under `pnpm.overrides` in package.json until pnpm 11,
+# which stops reading that field entirely: it warns, carries on, re-resolves
+# without them, and rewrites pnpm-lock.yaml with its `overrides:` block gone.
+# That happened twice here before anyone noticed, because the versions it
+# resolved to happened to still be above the advisory floors.
+#
+# Every entry is a floor, not a preference. Raise one only against a published
+# advisory — and afterwards check that pnpm-lock.yaml still carries an
+# `overrides:` block, because losing it is the failure mode and it is silent.
+overrides:
+  "fast-uri@>=3.0.0 <3.1.4": "^3.1.4"
+  "brace-expansion@>=2.0.0 <2.1.3": "^2.1.3"
+  "brace-expansion@>=4.0.0 <5.0.8": "^5.0.8"
+  "postcss@<8.5.18": "^8.5.18"
+  "@hono/node-server@<2.0.5": "^2.0.5"
+  "nanoid@<3.3.17": "^3.3.17"
+  "js-yaml@>=4.0.0 <4.3.1": "^4.3.1"


### PR DESCRIPTION
pnpm 11 stopped reading the `pnpm` field in `package.json`. It warns and carries on — so a local install re-resolved without the seven advisory overrides and rewrote `pnpm-lock.yaml` with its `overrides:` block gone. CI pinned pnpm 9, which still read the field, so nothing failed and the drift was invisible.

It happened **three times** on one machine before it was understood. Each time the versions it landed on were still above the advisory floors, so nothing was exposed — but the enforcement was gone and the next resolution had nothing holding it.

## What moved

| | before | after |
|---|---|---|
| CVE overrides | `pnpm.overrides` in `package.json` — ignored by pnpm 11 | `overrides:` in `pnpm-workspace.yaml` |
| pnpm version | `version: 9` in five workflow steps; whatever is installed locally | `packageManager` in `package.json`; the five steps read it |
| esbuild's build script | `onlyBuiltDependencies` — still `ERR_PNPM_IGNORED_BUILDS` | `allowBuilds: esbuild: true` |

## Verified, not assumed

With the overrides in their new home, pnpm 11 compares them against the lockfile's own `overrides:` block, finds them identical, and **skips resolution entirely** — the lockfile is byte-for-byte unchanged and all seven pins are intact. Before the move, the same command re-resolved and dropped them. Two consecutive installs are clean and idempotent, and `pnpm test` passes with its coverage floors.

The lockfile stays at `lockfileVersion: 9.0`, so no regeneration churn lands in this diff.

## pnpm was damaging the file itself

Worth recording, because it is not obvious. When pnpm 11 has no answer about a build script it **writes its own prompt into `pnpm-workspace.yaml`** — the literal line `esbuild: set this to true or false`, a string where a boolean belongs — which then fails every later install with a YAML or approval error. That is what made `pnpm dev` fail, and it re-appeared during this work minutes after the file was cleaned. An explicit `true` is what stops it asking.

Both files now carry a comment naming the silent failure mode, because losing the `overrides:` block does not announce itself.

## One source of truth for the version

The five `pnpm/action-setup` steps lose their `version:` so the action reads `packageManager`. A second place to state the version is exactly how local and CI came to disagree.

**I could not verify locally that `pnpm/action-setup` v6 reads `packageManager` when `version:` is absent.** It is the documented behaviour and the recommended setup, but the proof is this PR's own CI run. The failure mode is loud — all five jobs fail immediately rather than shipping something wrong.

## Hard cutover

Once this merges, a contributor on pnpm 9 or 10 needs to let pnpm self-switch to the pinned version. `docs/DEVELOPMENT.md` is updated to say so.
