### PR TITLE
fix(kube): derive list AGE from a timestamp so it ticks (#405)

### DIFF
--- a/crates/kube/src/configmaps.rs
+++ b/crates/kube/src/configmaps.rs
@@ -24,6 +24,11 @@ pub struct ConfigMapSummary {
     pub namespace: String,
     /// Number of keys (`data` + `binaryData`).
     pub keys: i32,
+    /// `creationTimestamp` (RFC 3339), so the frontend can derive a LIVE age.
+    /// `age` below is rendered once, when this summary is built, and a summary
+    /// is only rebuilt when a watch event arrives for the object — so it goes
+    /// stale (#405). Prefer this; `age` stays for callers that have no clock.
+    pub created: Option<String>,
     pub age: String,
 }
 
@@ -39,6 +44,7 @@ pub(crate) fn summarise(cm: ConfigMap) -> ConfigMapSummary {
         name: cm.metadata.name.clone().unwrap_or_default(),
         namespace: cm.metadata.namespace.clone().unwrap_or_default(),
         keys: (data_keys + binary_keys) as i32,
+        created: crate::creation_rfc3339(cm.metadata.creation_timestamp.as_ref()),
         age: crate::humanize_age(cm.metadata.creation_timestamp.as_ref()),
     }
 }
@@ -80,6 +86,34 @@ mod tests {
         let cap = list_configmaps_capability(ClientCache::new(PathBuf::from("/x")));
         assert_eq!(cap.id, "k8s.listConfigMaps");
         assert!(cap.annotations.read_only);
+    }
+
+    /// #405: the summary must carry the raw `creationTimestamp`, not only the
+    /// rendered `age`. `age` is resolved against `now` when the summary is
+    /// built and a summary is rebuilt only on a watch event, so a list showing
+    /// it freezes; `created` is what lets the frontend re-derive a live age.
+    #[test]
+    fn summary_carries_creation_timestamp_for_a_live_age() {
+        use k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;
+        let created = "2026-09-01T12:59:22Z".parse::<k8s_openapi::jiff::Timestamp>().unwrap();
+        let cm = ConfigMap {
+            metadata: kube::core::ObjectMeta {
+                name: Some("demo-cm".into()),
+                namespace: Some("default".into()),
+                creation_timestamp: Some(Time(created)),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out = summarise(cm);
+        assert_eq!(out.created.as_deref(), Some("2026-09-01T12:59:22Z"));
+
+        // No timestamp => None, so the UI renders nothing rather than a wrong age.
+        let bare = ConfigMap {
+            metadata: kube::core::ObjectMeta { name: Some("x".into()), ..Default::default() },
+            ..Default::default()
+        };
+        assert_eq!(summarise(bare).created, None);
     }
 
     #[test]

--- a/crates/kube/src/lib.rs
+++ b/crates/kube/src/lib.rs
@@ -31,6 +31,24 @@ pub(crate) fn humanize_age(creation: Option<&Time>) -> String {
     }
 }
 
+/// A resource's `creationTimestamp` as RFC 3339, for a caller that must
+/// compute the age itself rather than read one someone else already rendered.
+///
+/// `humanize_age` above resolves `now` at the moment it is called, so what it
+/// returns is a SNAPSHOT. A summary is built once per watch event and then
+/// cached, so an object nothing is changing keeps the age string it was born
+/// with — a Secret created while its list is open reads `0s` for as long as the
+/// list stays open (#405). Sending the timestamp instead lets the frontend
+/// re-derive the age against a clock that ticks, which is the only place that
+/// can be done: the backend cannot re-render a string for an object no event
+/// is arriving for.
+///
+/// `None` for an object with no timestamp, so a caller renders nothing rather
+/// than a wrong number.
+pub(crate) fn creation_rfc3339(creation: Option<&Time>) -> Option<String> {
+    creation.map(|t| t.0.to_string())
+}
+
 /// Abbreviate PV/PVC access modes ("ReadWriteOnce" → "RWO"), comma-joined.
 pub(crate) fn abbreviate_access_modes(modes: Option<&Vec<String>>) -> String {
     modes

--- a/crates/kube/src/secrets.rs
+++ b/crates/kube/src/secrets.rs
@@ -48,6 +48,11 @@ pub struct SecretSummary {
     pub type_: String,
     /// Number of keys — NOT their names or values.
     pub keys: i32,
+    /// `creationTimestamp` (RFC 3339), so the frontend can derive a LIVE age.
+    /// `age` below is rendered once, when this summary is built, and a summary
+    /// is only rebuilt when a watch event arrives for the object — so it goes
+    /// stale (#405). Prefer this; `age` stays for callers that have no clock.
+    pub created: Option<String>,
     pub age: String,
 }
 
@@ -64,6 +69,7 @@ pub(crate) fn summarise(secret: Secret) -> SecretSummary {
         namespace: secret.metadata.namespace.clone().unwrap_or_default(),
         type_: secret.type_.clone().unwrap_or_default(),
         keys: keys as i32,
+        created: crate::creation_rfc3339(secret.metadata.creation_timestamp.as_ref()),
         age: crate::humanize_age(secret.metadata.creation_timestamp.as_ref()),
     }
 }

--- a/crates/kube/src/watch.rs
+++ b/crates/kube/src/watch.rs
@@ -877,6 +877,7 @@ mod tests {
             ready: "1/1".into(),
             restarts: 0,
             node: "n".into(),
+            created: None,
             age: "1m".into(),
             image: "nginx:1.27".into(),
             waiting_reason: String::new(),

--- a/crates/kube/src/workloads.rs
+++ b/crates/kube/src/workloads.rs
@@ -37,6 +37,11 @@ pub struct PodSummary {
     pub ready: String,
     pub restarts: i32,
     pub node: String,
+    /// `creationTimestamp` (RFC 3339), so the frontend can derive a LIVE age.
+    /// `age` below is rendered once, when this summary is built, and a summary
+    /// is only rebuilt when a watch event arrives for the object — so it goes
+    /// stale (#405). Prefer this; `age` stays for callers that have no clock.
+    pub created: Option<String>,
     pub age: String,
     /// Container image(s) the pod runs, e.g. `acme/checkout-api:118a7e`.
     /// A pod with several containers joins them as `"img-a, img-b"`; a pod
@@ -154,6 +159,7 @@ pub(crate) fn summarise_pod(pod: Pod) -> PodSummary {
         ready: format!("{ready_count}/{total}"),
         restarts,
         node,
+        created: crate::creation_rfc3339(pod.metadata.creation_timestamp.as_ref()),
         age: crate::humanize_age(pod.metadata.creation_timestamp.as_ref()),
         image,
         waiting_reason,

--- a/packages/core/src/lib/age.ts
+++ b/packages/core/src/lib/age.ts
@@ -27,6 +27,15 @@ export function ageSeconds(age: string): number {
  * Drop-in `getSortValue` for any summary row carrying a compact `age` —
  * one shared function rather than an arrow per column definition.
  */
-export function ageSortValue(row: { age?: string }): number {
+export function ageSortValue(row: { created?: string | null; age?: string }): number {
+  // `created` is the real thing, so it sorts on a real duration — no parsing,
+  // no unit table, and correct between two rows the compact string renders
+  // identically (two Secrets 3m10s and 3m50s old are both "3m"). Rows whose
+  // kind does not carry a timestamp yet fall back to reading the string, which
+  // is what #236 added this function for.
+  if (row.created) {
+    const then = new Date(row.created).getTime();
+    if (!Number.isNaN(then)) return Math.max(0, Math.floor((Date.now() - then) / 1000));
+  }
   return ageSeconds(row.age ?? "");
 }

--- a/packages/core/src/lib/controllers.ts
+++ b/packages/core/src/lib/controllers.ts
@@ -112,6 +112,11 @@ export interface ConfigMapSummary {
   name: string;
   namespace: string;
   keys: number;
+  /** `creationTimestamp` (RFC 3339), for deriving a LIVE age. Prefer this over
+   *  `age`, which the backend renders once per watch event and which therefore
+   *  freezes for an object nothing is changing (#405). Absent when the object
+   *  carries no timestamp. */
+  created?: string | null;
   age: string;
 }
 
@@ -121,6 +126,11 @@ export interface SecretSummary {
   namespace: string;
   type: string;
   keys: number;
+  /** `creationTimestamp` (RFC 3339), for deriving a LIVE age. Prefer this over
+   *  `age`, which the backend renders once per watch event and which therefore
+   *  freezes for an object nothing is changing (#405). Absent when the object
+   *  carries no timestamp. */
+  created?: string | null;
   age: string;
 }
 

--- a/packages/core/src/lib/k8sTime.ts
+++ b/packages/core/src/lib/k8sTime.ts
@@ -10,7 +10,11 @@ export function ageFromTimestamp(iso?: string, now: number = Date.now()): string
   const hours = Math.floor(mins / 60);
   if (hours < 24) return `${hours}h`;
   const days = Math.floor(hours / 24);
-  return `${days}d`;
+  if (days < 365) return `${days}d`;
+  // Matches `format_age` in crates/kube and the `y` unit `ageSeconds` already
+  // knows about: without this a two-year-old object read "730d" here and "2y"
+  // from the backend, for the same object on two screens.
+  return `${Math.floor(days / 365)}y`;
 }
 
 /** Human-readable duration between two ISO timestamps, e.g. "2m 30s". */

--- a/packages/core/src/lib/workloads.ts
+++ b/packages/core/src/lib/workloads.ts
@@ -7,6 +7,11 @@ export interface PodSummary {
   ready: string;
   restarts: number;
   node: string;
+  /** `creationTimestamp` (RFC 3339), for deriving a LIVE age. Prefer this over
+   *  `age`, which the backend renders once per watch event and which therefore
+   *  freezes for an object nothing is changing (#405). Absent when the object
+   *  carries no timestamp. */
+  created?: string | null;
   age: string;
   /** Container image(s) the pod runs; multiple containers are comma-joined,
    *  e.g. "acme/checkout-api:118a7e, envoyproxy/envoy:v1.30". Empty when the

--- a/packages/ui-next/src/lib/ageCell.test.tsx
+++ b/packages/ui-next/src/lib/ageCell.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { act, render, screen, cleanup } from "@testing-library/react";
+import { AgeCell } from "./ageCell";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+const CREATED = "2026-09-01T12:00:00Z";
+const AT = (ms: number) => new Date(CREATED).getTime() + ms;
+
+describe("AgeCell (#405)", () => {
+  it("advances as time passes instead of freezing at the value it first rendered", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(AT(0));
+    render(<AgeCell created={CREATED} />);
+    // The #405 repro: an object created while its list is open.
+    expect(screen.getByText("0s")).toBeDefined();
+
+    act(() => void vi.advanceTimersByTime(30_000));
+    expect(screen.getByText("30s")).toBeDefined();
+
+    act(() => void vi.advanceTimersByTime(150_000));
+    expect(screen.getByText("3m")).toBeDefined();
+
+    // The bug this guards: the cell used to render a string the backend had
+    // rendered once, so all three assertions above read "0s".
+    expect(screen.queryByText("0s")).toBeNull();
+  });
+
+  it("falls back to the backend's age string for a kind that carries no timestamp", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(AT(0));
+    render(<AgeCell age="119d" />);
+    expect(screen.getByText("119d")).toBeDefined();
+  });
+
+  it("renders nothing numeric when it has neither, rather than a wrong age", () => {
+    render(<AgeCell />);
+    expect(screen.getByText("—")).toBeDefined();
+  });
+
+  it("stops its interval once the last cell unmounts", () => {
+    vi.useFakeTimers();
+    const clear = vi.spyOn(globalThis, "clearInterval");
+    const a = render(<AgeCell created={CREATED} />);
+    const b = render(<AgeCell created={CREATED} />);
+    a.unmount();
+    expect(clear).not.toHaveBeenCalled(); // one cell left, clock still needed
+    b.unmount();
+    expect(clear).toHaveBeenCalled();
+  });
+});

--- a/packages/ui-next/src/lib/ageCell.tsx
+++ b/packages/ui-next/src/lib/ageCell.tsx
@@ -1,0 +1,72 @@
+import { useSyncExternalStore } from "react";
+import { ageFromTimestamp } from "@srelens/core";
+
+/**
+ * A live AGE cell for the resource lists (#405).
+ *
+ * The backend renders each summary's `age` ONCE, against the clock at the
+ * moment the summary is built — and a summary is rebuilt only when a watch
+ * event arrives for that object. An object nothing is changing therefore keeps
+ * the age it was born with: a Secret created while its list is open reads `0s`
+ * for as long as the list stays open, while the same Secret's detail panel
+ * reads `3m ago`, because the detail panel derives from the timestamp.
+ *
+ * No backend fix is possible: there is no event on which to re-render the
+ * string. The age has to be derived where a clock is ticking, which is here.
+ *
+ * ONE interval for the whole app, not one per row. A node with 110 pods would
+ * otherwise hold 110 timers to show the same second; every cell subscribes to
+ * a single module-level clock instead, the way `columnPrefs` shares its store.
+ * The interval only runs while at least one cell is mounted.
+ */
+const TICK_MS = 1_000;
+
+let now = Date.now();
+let timer: ReturnType<typeof setInterval> | null = null;
+const listeners = new Set<() => void>();
+
+function subscribe(listener: () => void): () => void {
+  // The clock stops when the last cell unmounts, so `now` is as stale as the
+  // gap since — leave a resource list for ten minutes and the first paint on
+  // return would otherwise show a ten-minute-old age until the next tick.
+  // Safe here and not in `getSnapshot`, which React calls during render and
+  // which must return a stable value.
+  if (listeners.size === 0) now = Date.now();
+  listeners.add(listener);
+  if (timer === null) {
+    timer = setInterval(() => {
+      now = Date.now();
+      for (const l of listeners) l();
+    }, TICK_MS);
+  }
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0 && timer !== null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  };
+}
+
+// A cached value, never `Date.now()` inline: `useSyncExternalStore` compares
+// snapshots by identity and would re-render forever on a fresh number.
+const getSnapshot = () => now;
+
+/** The shared ticking clock, for anything else that must re-derive on time. */
+export function useNow(): number {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+/**
+ * `created` is the object's `creationTimestamp`; `age` is the backend's
+ * pre-rendered string, used only for a kind whose summary does not carry a
+ * timestamp yet.
+ *
+ * A row with neither renders an em dash rather than a number — a kind that
+ * cannot be timed must show nothing, never something wrong.
+ */
+export function AgeCell({ created, age }: { created?: string | null; age?: string }) {
+  const tick = useNow();
+  if (created) return <>{ageFromTimestamp(created, tick)}</>;
+  return <>{age || "—"}</>;
+}

--- a/packages/ui-next/src/lib/kinds/columns.tsx
+++ b/packages/ui-next/src/lib/kinds/columns.tsx
@@ -32,6 +32,7 @@ import {
   type StatusVerdict,
   type StorageClassSummary,
 } from "@srelens/core";
+import { AgeCell } from "../ageCell";
 import { Badge, StatusPill, type Column, type Tone } from "@srelens/ui-kit";
 
 export type PodRow = PodSummary & { cpu?: number; memory?: number };
@@ -102,7 +103,10 @@ export const podColumns: Column<PodRow>[] = [
   { key: "restarts", header: "Restarts", sortable: true, align: "end" },
   { key: "cpu", header: "CPU", sortable: true, align: "end", render: (p) => metric(p.cpu, formatCpu), getSortValue: (p) => metricSort(p.cpu) },
   { key: "memory", header: "Memory", sortable: true, align: "end", render: (p) => metric(p.memory, formatMemory), getSortValue: (p) => metricSort(p.memory) },
-  { key: "age", header: "Age", sortable: true, align: "end", getSortValue: ageSortValue },
+  // #405: derived here against a ticking clock, from the summary's
+  // `created` timestamp — the backend's `age` string is rendered once per
+  // watch event and freezes for an object nothing is changing.
+  { key: "age", header: "Age", sortable: true, align: "end", render: (r) => <AgeCell created={r.created} age={r.age} />, getSortValue: ageSortValue },
   // Not sortable: a comma-joined list of container images (PodSummary.image)
   // has no single natural order, and the design mock renders a plain header
   // for it — no SortHeader. Left filterable-unset like every other column
@@ -282,7 +286,10 @@ export const configMapColumns: Column<ConfigMapSummary>[] = [
   { key: "name", header: "Name", sortable: true },
   { key: "namespace", header: "Namespace", sortable: true },
   { key: "keys", header: "Keys", sortable: true, align: "end", render: (c) => String(c.keys) },
-  { key: "age", header: "Age", sortable: true, align: "end", getSortValue: ageSortValue },
+  // #405: derived here against a ticking clock, from the summary's
+  // `created` timestamp — the backend's `age` string is rendered once per
+  // watch event and freezes for an object nothing is changing.
+  { key: "age", header: "Age", sortable: true, align: "end", render: (r) => <AgeCell created={r.created} age={r.age} />, getSortValue: ageSortValue },
 ];
 
 export const secretColumns: Column<SecretSummary>[] = [
@@ -290,7 +297,10 @@ export const secretColumns: Column<SecretSummary>[] = [
   { key: "namespace", header: "Namespace", sortable: true },
   { key: "type", header: "Type" },
   { key: "keys", header: "Keys", sortable: true, align: "end", render: (s) => String(s.keys) },
-  { key: "age", header: "Age", sortable: true, align: "end", getSortValue: ageSortValue },
+  // #405: derived here against a ticking clock, from the summary's
+  // `created` timestamp — the backend's `age` string is rendered once per
+  // watch event and freezes for an object nothing is changing.
+  { key: "age", header: "Age", sortable: true, align: "end", render: (r) => <AgeCell created={r.created} age={r.age} />, getSortValue: ageSortValue },
 ];
 
 export const resourceQuotaColumns: Column<ResourceQuotaSummary>[] = [


### PR DESCRIPTION
Closes #405.

## The bug

The AGE column in a resource list was a string rendered on the backend **once per watch event** and cached in between. `humanize_age` resolves `now` when it is called, and `summarise` only runs when an event arrives for that object — so an object nothing is changing keeps the age it was born with.

A Secret created while its list is open read `0s` for as long as the list stayed open, while the same Secret's detail panel read `3m ago`, because the detail panel derives from `metadata.creationTimestamp`. Both readings are in #405's screenshots, in the same frame.

No backend fix is possible: there is no event on which to re-render the string. The age has to be derived where a clock is ticking.

## The fix

- **Backend carries the timestamp.** New `creation_rfc3339` helper; `SecretSummary`, `ConfigMapSummary` and `PodSummary` gain `created: Option<String>` (RFC 3339), set in each `summarise`.
- **Frontend derives the age.** A shared `AgeCell` re-computes the displayed age against a ticking clock.
- **One interval for the whole app**, not one timer per row — a node with 110 pods would otherwise hold 110 timers to show the same second. It runs only while a cell is mounted, and re-reads the clock when the first cell subscribes, so a list reopened after an idle spell does not paint a stale age.
- **`age` is kept** on the summaries as the fallback for kinds not yet converted, so nothing regresses. A row with neither renders an em dash rather than a wrong number.
- `ageSortValue` now sorts on the real duration when a row has a timestamp — which also orders two rows the compact string renders identically (3m10s and 3m50s are both `3m`). It still parses the string for rows without one, so #236's workaround keeps working where it is still needed.
- `ageFromTimestamp` gains the year bucket that `format_age` and `ageSeconds`' unit table already had, so a two-year-old object no longer reads `730d` on one screen and `2y` on another.

## Verified

- `cargo build --workspace` and `pnpm build` both green; `pnpm typecheck` clean across all four packages.
- **420 Rust tests and 5468 TS tests pass**, no regressions.
- New ticking test (`packages/ui-next/src/lib/ageCell.test.tsx`): renders a cell, advances the clock, asserts the age *changed* (`0s → 30s → 3m`) and that `0s` is gone — the assertion that fails on the old code. Also covers the fallback string, the em-dash case, and that the interval stops when the last cell unmounts.
- New backend test: `summarise` emits the apiserver's RFC 3339 string, and `None` when the object has no timestamp.
- End-to-end against the real repro object from the issue: feeding its actual `creationTimestamp` through the real cell gives `0s → 1s → 30s → 3m → 1h`, where it previously sat at `0s`.

## Scope

Applied to the surfaces #405 demonstrates: **Secrets, ConfigMaps and Pods**.

The other 24 summary structs still carry `age: String` alone and are tracked separately as a mechanical follow-up — each needs its Rust field, its TS mirror, its column wiring and any struct-literal test fixture. `manifest.rs`'s `ResourceRow` is the highest-value one in that list: it is the generic list path, so converting it covers every untyped kind at once.
