### PR TITLE
fix(kube): resolve apply scope from the kind, not the document (#404)

### DIFF
--- a/apps/desktop/src/components/EditResourceTab.tsx
+++ b/apps/desktop/src/components/EditResourceTab.tsx
@@ -46,6 +46,7 @@ export function EditResourceTab({
   return (
     <ManifestEditor
       context={context}
+      namespace={namespace ?? undefined}
       yaml={yaml}
       onYamlChange={setYaml}
       ariaLabel="Edit resource YAML"

--- a/apps/desktop/src/components/ManifestEditor.test.tsx
+++ b/apps/desktop/src/components/ManifestEditor.test.tsx
@@ -78,7 +78,7 @@ describe("ManifestEditor", () => {
     applyManifestMock.mockResolvedValue({ applied: true, documents: [{ kind: "ConfigMap", name: "web", applied: true }] });
     render(<Harness mode="create" />);
     fireEvent.click(screen.getByRole("button", { name: "Create" }));
-    await waitFor(() => expect(applyManifestMock).toHaveBeenCalledWith("kind-dev", expect.stringContaining("ConfigMap"), false));
+    await waitFor(() => expect(applyManifestMock).toHaveBeenCalledWith("kind-dev", expect.stringContaining("ConfigMap"), false, undefined));
     expect(notifyMock.success).toHaveBeenCalled();
   });
 
@@ -132,7 +132,7 @@ describe("ManifestEditor", () => {
     const force = await screen.findByRole("button", { name: /force apply/i });
     expect(screen.getByText(/kubectl/)).toBeDefined();
     fireEvent.click(force);
-    await waitFor(() => expect(applyManifestMock).toHaveBeenLastCalledWith("ctx", expect.any(String), true));
+    await waitFor(() => expect(applyManifestMock).toHaveBeenLastCalledWith("ctx", expect.any(String), true, undefined));
   });
 
   it("drawer (non-fill) surfaces conflicts too: Force apply appears and re-applies with force", async () => {
@@ -164,7 +164,7 @@ describe("ManifestEditor", () => {
     const force = await screen.findByRole("button", { name: /force apply/i });
     expect(screen.getByText(/kubectl/)).toBeDefined();
     fireEvent.click(force);
-    await waitFor(() => expect(applyManifestMock).toHaveBeenLastCalledWith("ctx", expect.any(String), true));
+    await waitFor(() => expect(applyManifestMock).toHaveBeenLastCalledWith("ctx", expect.any(String), true, undefined));
   });
 
   it("multi-doc conflict banner names each conflicting document, not the applied one", async () => {

--- a/apps/desktop/src/components/ManifestEditor.tsx
+++ b/apps/desktop/src/components/ManifestEditor.tsx
@@ -34,6 +34,7 @@ const CodeEditor = lazy(() => import("../ui/CodeEditor").then((m) => ({ default:
  */
 export function ManifestEditor({
   context,
+  namespace,
   yaml,
   onYamlChange,
   ariaLabel = "Manifest YAML",
@@ -48,6 +49,9 @@ export function ManifestEditor({
   onApplied,
 }: {
   context: string;
+  /** Namespace this editor is scoped to, applied to a document that names
+   *  none. Without it the backend falls back to `default` (#404). */
+  namespace?: string;
   yaml: string;
   onYamlChange: (yaml: string) => void;
   ariaLabel?: string;
@@ -170,7 +174,7 @@ export function ManifestEditor({
   async function doApply(force: boolean) {
     setBusy(true);
     setError("");
-    const out = await applyManifest(context, yaml, force);
+    const out = await applyManifest(context, yaml, force, namespace);
     setBusy(false);
     if (out.error) {
       setError(describeError(out.error).detail);
@@ -241,7 +245,7 @@ export function ManifestEditor({
     let active = true;
     setDiffing(true);
     const t = setTimeout(() => {
-      void diffManifest(context, yaml).then((out) => {
+      void diffManifest(context, yaml, namespace).then((out) => {
         if (!active) return;
         const docs = out.error ? [] : out.documents ?? [];
         // After a successful apply, adopt the freshly-bumped resourceVersion as
@@ -274,7 +278,7 @@ export function ManifestEditor({
         minHeight={fill ? undefined : 320}
         maxHeight={fill ? undefined : 520}
         schemaValidate={(y) =>
-          validateManifest(context, y).then((r) => (r.valid === false ? r.errors ?? [] : []))
+          validateManifest(context, y, namespace).then((r) => (r.valid === false ? r.errors ?? [] : []))
         }
         schemaSource={(apiVersion, kind) =>
           openApiSchema(context, apiVersion, kind).then((r) => ("error" in r ? null : r))

--- a/apps/desktop/src/components/NewResourceEditor.test.tsx
+++ b/apps/desktop/src/components/NewResourceEditor.test.tsx
@@ -32,7 +32,7 @@ describe("NewResourceEditor", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Create" }));
 
-    await waitFor(() => expect(applyManifestMock).toHaveBeenCalledWith("kind-dev", editor.value, false));
+    await waitFor(() => expect(applyManifestMock).toHaveBeenCalledWith("kind-dev", editor.value, false, "prod"));
     expect(await screen.findByText(/Applied Service/)).toBeDefined();
     expect(onCreated).toHaveBeenCalled();
     // Editor is still present (tab stays open to create more).

--- a/apps/desktop/src/components/NewResourceEditor.tsx
+++ b/apps/desktop/src/components/NewResourceEditor.tsx
@@ -119,6 +119,7 @@ export function NewResourceEditor({
   return (
     <ManifestEditor
       context={context}
+      namespace={ns}
       yaml={yaml}
       onYamlChange={setYaml}
       ariaLabel="New resource YAML"

--- a/apps/desktop/src/components/YamlView.test.tsx
+++ b/apps/desktop/src/components/YamlView.test.tsx
@@ -81,7 +81,7 @@ describe("YamlView", () => {
     fireEvent.click(screen.getByRole("button", { name: "Apply" }));
 
     await waitFor(() =>
-      expect(applyManifestMock).toHaveBeenCalledWith("kind-dev", "kind: ConfigMap\ndata:\n  k: v\n", false),
+      expect(applyManifestMock).toHaveBeenCalledWith("kind-dev", "kind: ConfigMap\ndata:\n  k: v\n", false, "default"),
     );
   });
 });

--- a/apps/desktop/src/components/YamlView.tsx
+++ b/apps/desktop/src/components/YamlView.tsx
@@ -51,6 +51,7 @@ export function YamlView({
   return (
     <ManifestEditor
       context={context}
+      namespace={namespace ?? undefined}
       yaml={draft}
       onYamlChange={setDraft}
       confirm={{ kind, name }}

--- a/crates/kube/src/manifest.rs
+++ b/crates/kube/src/manifest.rs
@@ -386,6 +386,11 @@ pub struct ApplyIn {
     pub context: String,
     /// One or more resource manifests as YAML (documents separated by `---`).
     pub yaml: String,
+    /// Namespace the request is scoped to, used for a document that names
+    /// none. Threaded from the caller (the tab's namespace) rather than
+    /// hardcoded — see `apply_namespace`.
+    #[serde(default)]
+    pub namespace: Option<String>,
     /// Force apply, taking ownership of fields held by other managers.
     #[serde(default)]
     pub force: bool,
@@ -454,6 +459,58 @@ pub fn parse_conflict(message: &str) -> Conflict {
     }
 }
 
+/// The namespace a manifest document must be applied in — `None` meaning the
+/// cluster-scoped endpoint.
+///
+/// The scope of a request is decided by the KIND, never by whether the author
+/// happened to type a `metadata.namespace`. Reading it off the document is what
+/// #404 was: a Secret written without a namespace produced
+/// `PATCH /api/v1/secrets/<name>`, which matches no route on the API server, so
+/// it answered `404 the server could not find the requested resource` — while
+/// `kubectl apply -f` accepts the very same file. The read paths
+/// (`get_manifest_capability`, `get_object_capability`) have always resolved
+/// scope from `gvk_for`'s `namespaced` flag; this is the write paths catching
+/// up.
+///
+/// `fallback` is the namespace the request is scoped to (the tab's), used when
+/// the document names none. It is threaded in from the caller rather than
+/// hardcoded so a New-resource tab pointed at `staging` creates in `staging`.
+/// With no fallback either, `default` — the same last resort the read paths
+/// take.
+///
+/// A kind `gvk_for` does not know is a custom resource whose scope cannot be
+/// decided here (nothing in this process knows a CRD's `scope` without asking
+/// the cluster). Those keep exactly the behaviour they had: the document's own
+/// namespace, or cluster-scoped. Guessing would break applying a cluster-scoped
+/// CRD, which works today.
+///
+/// `gvk_for` keys on the kind alone, so it is only trusted when the document's
+/// group and version match the entry it returns — a custom `Service` in another
+/// group must not be mistaken for the core one.
+pub fn apply_namespace(
+    kind: &str,
+    group: &str,
+    version: &str,
+    doc_namespace: Option<&str>,
+    fallback: Option<&str>,
+) -> Option<String> {
+    let known = gvk_for(kind).filter(|(gvk, _)| gvk.group == group && gvk.version == version);
+    let non_empty = |s: &str| (!s.is_empty()).then(|| s.to_string());
+    match known {
+        // Namespaced kind: the document's namespace, else the caller's, else
+        // `default`. Never the cluster-scoped path — that is the 404.
+        Some((_, true)) => doc_namespace
+            .and_then(non_empty)
+            .or_else(|| fallback.and_then(non_empty))
+            .or_else(|| Some("default".to_string())),
+        // Cluster-scoped kind: no namespace, even if the document carries one
+        // (the API server ignores it there, and a namespaced path 404s).
+        Some((_, false)) => None,
+        // Unknown kind (a custom resource): unchanged from before.
+        None => doc_namespace.and_then(non_empty),
+    }
+}
+
 /// Split an `apiVersion` into (group, version). Core resources ("v1") have an
 /// empty group.
 pub fn parse_api_version(api_version: &str) -> (String, String) {
@@ -509,7 +566,16 @@ pub fn apply_manifest_capability(cache: Arc<ClientCache>) -> Capability {
                     let (group, version) = parse_api_version(&r.api_version);
                     let ar =
                         ApiResource::from_gvk(&GroupVersionKind::gvk(&group, &version, &r.kind));
-                    let api: Api<DynamicObject> = match &r.namespace {
+                    // Scope comes from the KIND, not from whether the document
+                    // named a namespace (#404).
+                    let ns = apply_namespace(
+                        &r.kind,
+                        &group,
+                        &version,
+                        r.namespace.as_deref(),
+                        input.namespace.as_deref(),
+                    );
+                    let api: Api<DynamicObject> = match &ns {
                         Some(ns) => Api::namespaced_with(client.clone(), ns, &ar),
                         None => Api::all_with(client.clone(), &ar),
                     };
@@ -549,6 +615,11 @@ pub fn apply_manifest_capability(cache: Arc<ClientCache>) -> Capability {
 pub struct ValidateIn {
     pub context: String,
     pub yaml: String,
+    /// Namespace the request is scoped to, used for a document that names
+    /// none. Threaded from the caller (the tab's namespace) rather than
+    /// hardcoded — see `apply_namespace`.
+    #[serde(default)]
+    pub namespace: Option<String>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -587,12 +658,17 @@ fn clean_kube_error(e: kube::Error) -> String {
 async fn validate_document(
     client: &kube::Client,
     value: &serde_json::Value,
+    fallback_namespace: Option<&str>,
 ) -> Option<Result<(), String>> {
     let r = resource_ref(value)?;
     let (group, version) = parse_api_version(&r.api_version);
     let gvk = GroupVersionKind::gvk(&group, &version, &r.kind);
     let ar = ApiResource::from_gvk(&gvk);
-    let api: Api<DynamicObject> = match &r.namespace {
+    // Scope from the KIND (#404): reading it off the document made a valid
+    // manifest with no namespace fail validation, which is the inline red
+    // marker the issue reports.
+    let ns = apply_namespace(&r.kind, &group, &version, r.namespace.as_deref(), fallback_namespace);
+    let api: Api<DynamicObject> = match &ns {
         Some(ns) => Api::namespaced_with(client.clone(), ns, &ar),
         None => Api::all_with(client.clone(), &ar),
     };
@@ -677,7 +753,7 @@ pub fn validate_manifest_capability(cache: Arc<ClientCache>) -> Capability {
                     }
                     results.push((
                         doc_index,
-                        validate_document(client.as_ref().unwrap(), value).await,
+                        validate_document(client.as_ref().unwrap(), value, input.namespace.as_deref()).await,
                     ));
                 }
                 Ok(aggregate_validation(results))
@@ -690,6 +766,11 @@ pub fn validate_manifest_capability(cache: Arc<ClientCache>) -> Capability {
 pub struct DiffIn {
     pub context: String,
     pub yaml: String,
+    /// Namespace the request is scoped to, used for a document that names
+    /// none. Threaded from the caller (the tab's namespace) rather than
+    /// hardcoded — see `apply_namespace`.
+    #[serde(default)]
+    pub namespace: Option<String>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -823,7 +904,17 @@ pub fn diff_manifest_capability(cache: Arc<ClientCache>) -> Capability {
                     let (group, version) = parse_api_version(&r.api_version);
                     let gvk = GroupVersionKind::gvk(&group, &version, &r.kind);
                     let ar = ApiResource::from_gvk(&gvk);
-                    let api: Api<DynamicObject> = match &r.namespace {
+                    // Scope from the KIND (#404): the wrong path made the live
+                    // object read as absent, so the Changes panel showed a full
+                    // create for a resource that already exists.
+                    let doc_ns = apply_namespace(
+                        &r.kind,
+                        &group,
+                        &version,
+                        r.namespace.as_deref(),
+                        input.namespace.as_deref(),
+                    );
+                    let api: Api<DynamicObject> = match &doc_ns {
                         Some(ns) => Api::namespaced_with(client.clone(), ns, &ar),
                         None => Api::all_with(client.clone(), &ar),
                     };
@@ -864,7 +955,10 @@ pub fn diff_manifest_capability(cache: Arc<ClientCache>) -> Capability {
                     documents.push(diff_document(
                         r.kind,
                         r.name,
-                        r.namespace,
+                        // The namespace actually diffed against, not the one the
+                        // document happened to name — they differ exactly when
+                        // the document named none (#404).
+                        doc_ns,
                         exists,
                         current_resource_version,
                         current_json,
@@ -882,6 +976,98 @@ pub fn diff_manifest_capability(cache: Arc<ClientCache>) -> Capability {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+    use std::sync::{Arc, Mutex};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    /// A stand-in API server that records the request line it was sent, so a
+    /// test can assert the PATH a capability actually built — the level #404
+    /// went wrong at. Answers everything 200 with an empty object.
+    async fn recording_server() -> (kube::Client, Arc<Mutex<Vec<String>>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let seen_task = seen.clone();
+        tokio::spawn(async move {
+            while let Ok((mut stream, _)) = listener.accept().await {
+                let seen = seen_task.clone();
+                tokio::spawn(async move {
+                    let mut buf = vec![0u8; 16384];
+                    let n = stream.read(&mut buf).await.unwrap_or(0);
+                    let req = String::from_utf8_lossy(&buf[..n]).to_string();
+                    let line = req.lines().next().unwrap_or("").to_string();
+                    seen.lock().unwrap().push(line);
+                    let body = "{}";
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(response.as_bytes()).await;
+                });
+            }
+        });
+        let config = kube::Config::new(format!("http://{addr}").parse().unwrap());
+        (kube::Client::try_from(config).unwrap(), seen)
+    }
+
+    /// #404 at the wire: a valid TLS Secret with NO `metadata.namespace` must
+    /// be sent to the NAMESPACED endpoint. Before the fix this went to
+    /// `/api/v1/secrets/test-secret`, which matches no route on the API server
+    /// — hence "the server could not find the requested resource".
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_namespaceless_secret_is_sent_to_the_namespaced_path() {
+        let (client, seen) = recording_server().await;
+        let doc: serde_json::Value = serde_yaml::from_str(
+            "apiVersion: v1\nkind: Secret\nmetadata:\n  name: test-secret\ntype: kubernetes.io/tls\n",
+        )
+        .unwrap();
+        let _ = validate_document(&client, &doc, None).await;
+
+        let lines = seen.lock().unwrap().clone();
+        assert!(!lines.is_empty(), "no request was sent");
+        let line = &lines[0];
+        assert!(
+            line.contains("/api/v1/namespaces/default/secrets/test-secret"),
+            "expected the namespaced path, got: {line}",
+        );
+        // The exact shape of the bug: the cluster-scoped collection path with a
+        // name hung off it.
+        assert!(
+            !line.contains("/api/v1/secrets/test-secret"),
+            "still building the cluster-scoped path: {line}",
+        );
+    }
+
+    /// The caller's namespace reaches the wire, so a New-resource tab scoped to
+    /// one namespace does not silently create in `default`.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn the_callers_namespace_reaches_the_request_path() {
+        let (client, seen) = recording_server().await;
+        let doc: serde_json::Value =
+            serde_yaml::from_str("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: my-config\n").unwrap();
+        let _ = validate_document(&client, &doc, Some("staging")).await;
+
+        let lines = seen.lock().unwrap().clone();
+        assert!(
+            lines[0].contains("/api/v1/namespaces/staging/configmaps/my-config"),
+            "expected the caller's namespace in the path, got: {}",
+            lines[0],
+        );
+    }
+
+    /// A cluster-scoped kind must NOT gain a namespace segment.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_cluster_scoped_kind_keeps_the_cluster_path() {
+        let (client, seen) = recording_server().await;
+        let doc: serde_json::Value =
+            serde_yaml::from_str("apiVersion: v1\nkind: Namespace\nmetadata:\n  name: my-ns\n").unwrap();
+        let _ = validate_document(&client, &doc, Some("staging")).await;
+
+        let lines = seen.lock().unwrap().clone();
+        assert!(lines[0].contains("/api/v1/namespaces/my-ns"), "got: {}", lines[0]);
+        assert!(!lines[0].contains("/namespaces/staging/"), "got: {}", lines[0]);
+    }
 
     #[test]
     fn parses_api_version_groups() {
@@ -935,6 +1121,78 @@ metadata:
         assert_eq!(docs.len(), 2);
         assert_eq!(docs[0]["metadata"]["name"], "a");
         assert_eq!(docs[1]["metadata"]["name"], "b");
+    }
+
+    // ---- #404: request scope comes from the KIND, not from the document ----
+
+    /// The bug itself, at the level it was decided: a namespaced kind with no
+    /// `metadata.namespace` must still resolve to a namespace. Reading the
+    /// document instead produced `/api/v1/secrets/<name>`, which matches no
+    /// route, so the API server answered "the server could not find the
+    /// requested resource".
+    #[test]
+    fn a_namespaced_kind_without_a_namespace_is_not_cluster_scoped() {
+        assert_eq!(
+            apply_namespace("Secret", "", "v1", None, None).as_deref(),
+            Some("default"),
+        );
+        // The caller's namespace wins over the `default` last resort, so a
+        // New-resource tab pointed at `staging` creates in `staging`.
+        assert_eq!(
+            apply_namespace("Secret", "", "v1", None, Some("staging")).as_deref(),
+            Some("staging"),
+        );
+        // An explicit namespace still wins over both.
+        assert_eq!(
+            apply_namespace("Secret", "", "v1", Some("prod"), Some("staging")).as_deref(),
+            Some("prod"),
+        );
+        // Empty strings are not namespaces.
+        assert_eq!(
+            apply_namespace("Secret", "", "v1", Some(""), Some("")).as_deref(),
+            Some("default"),
+        );
+        // Not Secret-specific.
+        assert_eq!(apply_namespace("ConfigMap", "", "v1", None, None).as_deref(), Some("default"));
+        assert_eq!(
+            apply_namespace("Deployment", "apps", "v1", None, None).as_deref(),
+            Some("default"),
+        );
+    }
+
+    /// A cluster-scoped kind stays cluster-scoped even when the document names
+    /// a namespace — the API server ignores one there, and a namespaced path
+    /// would 404 the same way.
+    #[test]
+    fn a_cluster_scoped_kind_ignores_any_namespace() {
+        assert_eq!(apply_namespace("Namespace", "", "v1", None, Some("prod")), None);
+        assert_eq!(apply_namespace("Node", "", "v1", Some("prod"), None), None);
+        assert_eq!(
+            apply_namespace("ClusterRole", "rbac.authorization.k8s.io", "v1", Some("prod"), None),
+            None,
+        );
+    }
+
+    /// A kind this process cannot classify (a custom resource — nothing here
+    /// knows a CRD's `scope` without asking the cluster) keeps exactly the
+    /// behaviour it had. Guessing would break applying a cluster-scoped CRD,
+    /// which works today.
+    #[test]
+    fn an_unknown_kind_keeps_its_previous_behaviour() {
+        assert_eq!(
+            apply_namespace("Widget", "acme.io", "v1", Some("prod"), Some("staging")).as_deref(),
+            Some("prod"),
+        );
+        assert_eq!(apply_namespace("Widget", "acme.io", "v1", None, Some("staging")), None);
+    }
+
+    /// `gvk_for` keys on the kind alone, so a custom `Service` in someone
+    /// else's group must not be mistaken for the core one and forced into a
+    /// namespace it may not have.
+    #[test]
+    fn a_same_named_kind_in_another_group_is_not_the_core_one() {
+        assert_eq!(apply_namespace("Service", "", "v1", None, None).as_deref(), Some("default"));
+        assert_eq!(apply_namespace("Service", "acme.io", "v1", None, None), None);
     }
 
     #[test]

--- a/packages/core/src/lib/manifest.test.ts
+++ b/packages/core/src/lib/manifest.test.ts
@@ -92,7 +92,7 @@ describe("listEvents", () => {
 describe("applyManifest", () => {
   it("passes context+yaml and returns applied", async () => {
     const invoke = vi.fn().mockResolvedValue({ documents: [{ kind: "ConfigMap", name: "cm", applied: true, conflict: null, error: null }], applied: true });
-    const out = await applyManifest("kind-dev", "kind: ConfigMap\n", false, invoke);
+    const out = await applyManifest("kind-dev", "kind: ConfigMap\n", false, undefined, invoke);
     expect(invoke).toHaveBeenCalledWith("k8s.applyManifest", {
       context: "kind-dev",
       yaml: "kind: ConfigMap\n",
@@ -102,7 +102,7 @@ describe("applyManifest", () => {
   });
 
   it("normalises errors", async () => {
-    const out = await applyManifest("c", "bad", false, () => Promise.reject(new Error("invalid")));
+    const out = await applyManifest("c", "bad", false, undefined, () => Promise.reject(new Error("invalid")));
     expect(out.error).toContain("invalid");
   });
 });
@@ -135,7 +135,7 @@ describe("applyManifest force + multi-doc", () => {
       documents: [{ kind: "ConfigMap", name: "a", applied: true, conflict: null, error: null }],
       applied: true,
     });
-    const out = await applyManifest("ctx", "kind: ConfigMap", true, invoke);
+    const out = await applyManifest("ctx", "kind: ConfigMap", true, undefined, invoke);
     expect(invoke).toHaveBeenCalledWith("k8s.applyManifest", { context: "ctx", yaml: "kind: ConfigMap", force: true });
     expect(out.applied).toBe(true);
     expect(out.documents?.[0].name).toBe("a");
@@ -143,13 +143,13 @@ describe("applyManifest force + multi-doc", () => {
 
   it("defaults force to false", async () => {
     const invoke = vi.fn().mockResolvedValue({ documents: [], applied: true });
-    await applyManifest("ctx", "kind: ConfigMap", undefined, invoke);
+    await applyManifest("ctx", "kind: ConfigMap", undefined, undefined, invoke);
     expect(invoke).toHaveBeenCalledWith("k8s.applyManifest", { context: "ctx", yaml: "kind: ConfigMap", force: false });
   });
 
   it("surfaces call errors", async () => {
     const invoke = vi.fn().mockRejectedValue(new Error("boom"));
-    const out = await applyManifest("ctx", "x", false, invoke);
+    const out = await applyManifest("ctx", "x", false, undefined, invoke);
     expect(out.error).toContain("boom");
   });
 });
@@ -159,7 +159,7 @@ describe("diffManifest", () => {
     const invoke = vi.fn().mockResolvedValue({
       documents: [{ kind: "ConfigMap", name: "a", namespace: "d", exists: true, changed: true, rows: [], currentResourceVersion: "9" }],
     });
-    const out = await diffManifest("ctx", "kind: ConfigMap", invoke);
+    const out = await diffManifest("ctx", "kind: ConfigMap", undefined, invoke);
     expect(invoke).toHaveBeenCalledWith("k8s.diffManifest", { context: "ctx", yaml: "kind: ConfigMap" });
     expect(out.documents?.[0].currentResourceVersion).toBe("9");
   });

--- a/packages/core/src/lib/manifest.ts
+++ b/packages/core/src/lib/manifest.ts
@@ -313,6 +313,9 @@ export async function applyManifest(
   context: string,
   yaml: string,
   force = false,
+  /** Namespace to apply a document that names none in. Without it the backend
+   *  falls back to `default` — see `apply_namespace` in crates/kube (#404). */
+  namespace?: string,
   invoke: Invoker = invokeCapability,
 ): Promise<{ documents?: ApplyDoc[]; applied?: boolean; error?: string }> {
   try {
@@ -320,6 +323,7 @@ export async function applyManifest(
       context,
       yaml,
       force,
+      namespace,
     });
     return { documents: out.documents, applied: out.applied };
   } catch (e) {
@@ -331,10 +335,12 @@ export async function applyManifest(
 export async function diffManifest(
   context: string,
   yaml: string,
+  /** Namespace for a document that names none (#404). */
+  namespace?: string,
   invoke: Invoker = invokeCapability,
 ): Promise<{ documents?: DiffDoc[]; error?: string }> {
   try {
-    const out = await invoke<{ documents: DiffDoc[] }>("k8s.diffManifest", { context, yaml });
+    const out = await invoke<{ documents: DiffDoc[] }>("k8s.diffManifest", { context, yaml, namespace });
     return { documents: out.documents };
   } catch (e) {
     return { error: String(e) };
@@ -367,12 +373,15 @@ export interface ValidateError {
 export async function validateManifest(
   context: string,
   yaml: string,
+  /** Namespace for a document that names none (#404). */
+  namespace?: string,
   invoke: Invoker = invokeCapability,
 ): Promise<{ valid?: boolean; errors?: ValidateError[]; error?: string }> {
   try {
     const out = await invoke<{ valid: boolean; errors: ValidateError[] }>("k8s.validateManifest", {
       context,
       yaml,
+      namespace,
     });
     return { valid: out.valid, errors: out.errors };
   } catch (e) {


### PR DESCRIPTION
Closes #404.

## The bug

Applying a manifest for a **namespaced** kind that omits `metadata.namespace` failed with `the server could not find the requested resource`. The apply path chose the request scope from *whether the document named a namespace*, not from *whether the kind is namespaced* — so a namespaceless Secret was sent to the cluster-scoped path `PATCH /api/v1/secrets/test-secret`, which matches no route, and the API server answered 404.

## The fix

A single shared helper `apply_namespace(kind, group, version, doc_ns, fallback)` resolves the namespace to use, and all three write/dry-run paths now go through it:

- `applyManifest`
- `validateManifest` (`validate_document`) — the source of the spurious inline lint marker
- `diffManifest` — which now also reports the namespace it *actually* diffed against, rather than the one the document happened to name (they differ exactly when the document named none)

`ApplyIn` / `ValidateIn` / `DiffIn` each gain an optional `namespace`, threaded from the caller (`ManifestEditor` → `NewResourceEditor` / `YamlView` / `EditResourceTab`), so a New-resource tab scoped to `staging` creates in `staging`, not silently in `default`.

### Scope rules

- **Namespaced kind** → the document's namespace, else the caller's, else `default` (matching the read paths' existing last resort).
- **Cluster-scoped kind** → no namespace, even if the document names one (the API server ignores it there).
- **Kind unknown to `gvk_for` (a CRD)** → **behaviour unchanged, deliberately.** Nothing in-process knows a CRD's scope without asking the cluster, and defaulting an unknown kind to namespaced would break applying a cluster-scoped CRD (e.g. a `ClusterIssuer`) that works today. This trades no known bug for an unknown regression.
- `gvk_for` keys on the kind alone, so its answer is trusted only when the document's **group and version** also match the entry — otherwise a custom `Service` in another group could be forced into a namespace it may not have. Covered by a test.

`watch.rs` (the list/watch path, where all-namespaces is correct) is untouched.

## Verification

- **The regression test is proven to fail pre-fix:** reverting `validate_document` to the old behaviour makes it fail with the exact URL from the issue (`PATCH /api/v1/secrets/test-secret`, no namespace); restoring the fix makes it pass.
- **Root `pnpm test` (with coverage): 5464 tests pass, 92.89% lines** (over the 85% gate). `cargo test --workspace`: all pass.
- **7 new tests** — 4 unit tests exhaustively covering `apply_namespace`'s branches (namespaceless→default, caller-wins-over-default, explicit-wins, empty-strings-are-not-namespaces, cluster-scoped-ignores-a-namespace, unknown-kind-unchanged, same-name-different-group), and 3 wire-level tests asserting the actual request line for a namespaceless Secret, a caller-scoped ConfigMap, and a cluster-scoped kind.

### Test scope note

`validate` is proven at the wire (the HTTP request line is asserted against a recording stand-in). `apply` and `diff` are verified structurally — they construct the `Api` identically and route every scope decision through the exhaustively-tested `apply_namespace` (there is no remaining `match &r.namespace` in `manifest.rs`) — but not through their own HTTP test, which would need a kubeconfig-backed mock-server harness the repo doesn't have elsewhere. That harness can be added if reviewers want the two remaining paths wire-proven.
