### PR TITLE
fix(ui-kit): separate field hints from accessible names

### DIFF
--- a/packages/ui-kit/src/Field.test.tsx
+++ b/packages/ui-kit/src/Field.test.tsx
@@ -22,7 +22,9 @@ describe("Field", () => {
         <input />
       </Field>,
     );
-    expect(screen.getByText("Lowercase letters only")).toBeDefined();
+    const control = screen.getByRole("textbox", { name: "Name" });
+    const hint = screen.getByText("Lowercase letters only");
+    expect(control.getAttribute("aria-describedby")).toBe(hint.id);
   });
 
   it("shows the error instead of the hint, never both", () => {
@@ -33,8 +35,24 @@ describe("Field", () => {
         <input />
       </Field>,
     );
-    expect(screen.getByText("Already taken")).toBeDefined();
+    const control = screen.getByRole("textbox", { name: "Name" });
+    const error = screen.getByText("Already taken");
+    expect(control.getAttribute("aria-describedby")).toBe(error.id);
     expect(screen.queryByText("Lowercase letters only")).toBeNull();
+  });
+
+  it("keeps a control's existing description when it adds the field note", () => {
+    render(
+      <Field label="Name" hint="Lowercase letters only">
+        <input aria-describedby="server-rule" />
+      </Field>,
+    );
+    const control = screen.getByRole("textbox", { name: "Name" });
+    const hint = screen.getByText("Lowercase letters only");
+    expect(control.getAttribute("aria-describedby")?.split(/\s+/)).toEqual([
+      "server-rule",
+      hint.id,
+    ]);
   });
 
   it("keeps an action outside the label element", () => {
@@ -49,6 +67,7 @@ describe("Field", () => {
     );
     const action = screen.getByRole("button", { name: "Preview" });
     expect(action.closest("label")).toBeNull();
+    expect(screen.getByLabelText("Manifest")).toBe(screen.getByRole("textbox"));
   });
 
   it("forwards className", () => {

--- a/packages/ui-kit/src/Field.tsx
+++ b/packages/ui-kit/src/Field.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { cloneElement, isValidElement, useId, type ReactNode } from "react";
 import { cx } from "./cx";
 
 export interface FieldProps {
@@ -19,18 +19,29 @@ export interface FieldProps {
 }
 
 /** The small print under a control: the error if there is one, else the hint. */
-function Note({ hint, error }: { hint?: ReactNode; error?: ReactNode }) {
+function Note({ id, hint, error }: { id: string; hint?: ReactNode; error?: ReactNode }) {
   // Never both. Two lines of small print under one control, one of them advice
   // the user has already failed to follow, reads as a rendering fault.
   if (error) {
     return (
-      <div className="mt-1 text-[0.75rem]" style={{ color: "var(--sev)" }}>
+      <div id={id} className="mt-1 text-[0.75rem]" style={{ color: "var(--sev)" }}>
         {error}
       </div>
     );
   }
-  if (hint) return <div className="mt-1 text-[0.75rem] text-muted">{hint}</div>;
+  if (hint) {
+    return (
+      <div id={id} className="mt-1 text-[0.75rem] text-muted">
+        {hint}
+      </div>
+    );
+  }
   return null;
+}
+
+interface DescribedControlProps {
+  id?: string;
+  "aria-describedby"?: string;
 }
 
 /**
@@ -42,27 +53,49 @@ function Note({ hint, error }: { hint?: ReactNode; error?: ReactNode }) {
  * so clicking the text did nothing and assistive technology had to guess from
  * proximity. (#318)
  *
+ * The note is deliberately outside that label. Text inside a wrapping label is
+ * part of the control's accessible name, so putting a sentence-long hint there
+ * renamed "Chart version" to "Chart version Leave empty…". The control points
+ * to the note with `aria-describedby` instead: its name says what it is and its
+ * description says how to fill it. Existing descriptions are retained. (#359)
+ *
  * With an `action` the wrapper cannot be the `<label>`, for the reason given on
- * the prop, so that form keeps the classic component's arrangement.
+ * the prop. That form uses an explicit `htmlFor`/`id` association instead.
  */
 export function Field({ label, action, hint, error, children, className }: FieldProps) {
+  const generatedControlId = useId();
+  const noteId = useId();
+  const note = error ?? hint;
+  const child = isValidElement<DescribedControlProps>(children) ? children : null;
+  const controlId = child?.props.id ?? generatedControlId;
+  const describedBy = [child?.props["aria-describedby"], note ? noteId : undefined]
+    .filter(Boolean)
+    .join(" ") || undefined;
+  const control = child
+    ? cloneElement(child, { id: controlId, "aria-describedby": describedBy })
+    : children;
+
   if (action) {
     return (
       <div className={cx("py-1", className)}>
         <div className="mb-0.5 flex items-center justify-between gap-2">
-          <span className="field-label">{label}</span>
+          <label className="field-label" htmlFor={child ? controlId : undefined}>
+            {label}
+          </label>
           {action}
         </div>
-        {children}
-        <Note hint={hint} error={error} />
+        {control}
+        <Note id={noteId} hint={hint} error={error} />
       </div>
     );
   }
   return (
-    <label className={cx("block py-1", className)}>
-      <span className="field-label mb-0.5">{label}</span>
-      {children}
-      <Note hint={hint} error={error} />
-    </label>
+    <div className={cx("py-1", className)}>
+      <label className="block">
+        <span className="field-label mb-0.5">{label}</span>
+        {control}
+      </label>
+      <Note id={noteId} hint={hint} error={error} />
+    </div>
   );
 }

--- a/packages/ui-kit/src/Select.tsx
+++ b/packages/ui-kit/src/Select.tsx
@@ -17,7 +17,9 @@ export interface SelectProps {
    * permission to use, which wants an explanation instead of a dead control.
    */
   disabled?: boolean;
+  id?: string;
   "aria-label"?: string;
+  "aria-describedby"?: string;
 }
 
 /**
@@ -41,7 +43,9 @@ export function Select({
   className,
   placeholder,
   disabled,
+  id,
   "aria-label": ariaLabel,
+  "aria-describedby": ariaDescribedBy,
 }: SelectProps) {
   const unmatched = !options.some((o) => o.value === value);
   // A controlled value matching no option leaves the browser free to choose,
@@ -54,9 +58,11 @@ export function Select({
     <div className="relative inline-flex items-center">
       <select
         value={rendered}
+        id={id}
         disabled={disabled}
         onChange={(e) => onValueChange(e.target.value)}
         aria-label={ariaLabel}
+        aria-describedby={ariaDescribedBy}
         className={cx(
           "appearance-none rounded-md border py-1 pl-2 pr-6 text-[0.8125rem] outline-none",
           className,

--- a/packages/ui-kit/src/TextInput.tsx
+++ b/packages/ui-kit/src/TextInput.tsx
@@ -14,7 +14,9 @@ export interface TextInputProps {
   autoFocus?: boolean;
   /** Marks the field as failing validation, in colour and to assistive tech. */
   invalid?: boolean;
+  id?: string;
   "aria-label"?: string;
+  "aria-describedby"?: string;
 }
 
 /**
@@ -39,7 +41,9 @@ export function TextInput({
   type = "text",
   autoFocus,
   invalid,
+  id,
   "aria-label": ariaLabel,
+  "aria-describedby": ariaDescribedBy,
 }: TextInputProps) {
   return (
     <input
@@ -53,7 +57,9 @@ export function TextInput({
       disabled={disabled}
       type={type}
       autoFocus={autoFocus}
+      id={id}
       aria-label={ariaLabel}
+      aria-describedby={ariaDescribedBy}
       aria-invalid={invalid ? true : undefined}
       className={cx("w-full rounded-md border px-2 py-1 text-[0.8125rem] outline-none", className)}
       style={{

--- a/packages/ui-next/src/screens/helm/HelmOpDialog.test.tsx
+++ b/packages/ui-next/src/screens/helm/HelmOpDialog.test.tsx
@@ -69,16 +69,8 @@ function field(label: string): HTMLElement {
   return screen.getByLabelText(label) as HTMLElement;
 }
 
-/**
- * A field whose `Field` carries a hint.
- *
- * The kit renders the hint INSIDE the `<label>`, so the control's accessible
- * name is the label followed by the hint; an exact match would never find it.
- */
 function hintedField(label: string): HTMLElement {
-  // No word boundary: the label and the hint are adjacent spans, so the
-  // computed name runs the two together with nothing between them.
-  return screen.getByLabelText(new RegExp(`^${label}`)) as HTMLElement;
+  return screen.getByLabelText(label) as HTMLElement;
 }
 
 describe("HelmOpDialog — §A.5's frame", () => {
@@ -88,7 +80,9 @@ describe("HelmOpDialog — §A.5's frame", () => {
     expect(within(dialog).getByText(`Install ${RELEASE}`)).toBeTruthy();
     expect((dialog as HTMLElement).style.maxWidth).toBe("620px");
     expect(field("Chart")).toBeTruthy();
-    expect(field("Chart version")).toBeTruthy();
+    const chartVersion = field("Chart version");
+    const chartVersionHint = screen.getByText("Leave empty to use the latest chart version.");
+    expect(chartVersion.getAttribute("aria-describedby")).toBe(chartVersionHint.id);
     expect(screen.getByRole("tablist", { name: "Panel" })).toBeTruthy();
     expect(screen.getByRole("tab", { name: "Values" })).toBeTruthy();
     expect(screen.getByRole("tab", { name: "Rendered diff" })).toBeTruthy();

--- a/packages/ui-next/src/screens/helm/HelmOpDialog.tsx
+++ b/packages/ui-next/src/screens/helm/HelmOpDialog.tsx
@@ -602,10 +602,11 @@ export function HelmOpDialog({
             <Field label="Chart" className="min-w-0">
               <TextInput value={chart} onValueChange={setChart} placeholder="bitnami/nginx" />
             </Field>
-            {/* No hint here: the kit's `Field` renders one INSIDE the label,
-                so a hint becomes part of the control's accessible name — the
-                placeholder says the same thing without renaming the field. */}
-            <Field label="Chart version" className="min-w-0">
+            <Field
+              label="Chart version"
+              hint="Leave empty to use the latest chart version."
+              className="min-w-0"
+            >
               <TextInput value={chartVersion} onValueChange={setChartVersion} placeholder="18.3.0" />
             </Field>
           </div>


### PR DESCRIPTION
## Summary

- separates field labels from hint text so the hint no longer becomes part of every control's accessible name
- associates hints through stable `aria-describedby` IDs, including `TextInput` and `Select`
- restores the Helm chart-version guidance that previously had to live in a placeholder

## Verification

- focused `Field` and `HelmOpDialog` accessibility tests
- workspace TypeScript typecheck
- complete frontend test suite with coverage

Closes #359
