### PR TITLE
fix(errors): scope timeout and TLS guidance to callers

### DIFF
--- a/packages/core/src/lib/errors.test.ts
+++ b/packages/core/src/lib/errors.test.ts
@@ -95,6 +95,27 @@ describe("describeError", () => {
     delete (window as unknown as { __TAURI_INTERNALS__?: object }).__TAURI_INTERNALS__;
   });
 
+  it("does not send an HTTP timeout to Kubernetes settings (#383)", () => {
+    const result = describeError("the update download timed out", { domain: "http" });
+    expect(result.title).toBe("Request timed out");
+    expect(result.detail).toMatch(/network connection/i);
+    expect(result.detail).not.toMatch(/Kubernetes|cluster|kubeconfig|SRELENS_TIMEOUT_SECS/);
+  });
+
+  it("does not blame kubeconfig for another server's TLS certificate (#383)", () => {
+    const result = describeError("x509: certificate signed by unknown authority", {
+      domain: "http",
+    });
+    expect(result.title).toBe("Couldn't verify the connection");
+    expect(result.detail).toMatch(/server's TLS certificate/i);
+    expect(result.detail).not.toMatch(/cluster|kubeconfig|certificate-authority/);
+  });
+
+  it("keeps cluster timeout and TLS guidance as the default", () => {
+    expect(describeError("list pods timed out").detail).toMatch(/Kubernetes API server/);
+    expect(describeError("x509: unknown authority").detail).toMatch(/kubeconfig/);
+  });
+
   it("classifies a refused connection", () => {
     expect(describeError("tcp connect error: connection refused").title).toBe(
       "Can't reach the cluster",

--- a/packages/core/src/lib/errors.ts
+++ b/packages/core/src/lib/errors.ts
@@ -24,6 +24,14 @@ export interface FriendlyError {
   raw: string;
 }
 
+/** The system a caller actually contacted when it received the error. */
+export type ErrorDomain = "cluster" | "http" | "local";
+
+export interface DescribeErrorOptions {
+  /** Cluster calls remain the default so existing callers keep their guidance. */
+  domain?: ErrorDomain;
+}
+
 /**
  * The two wrappers that get printed in front of a message on the way here,
  * neither of which is news to anyone:
@@ -107,7 +115,10 @@ export function isExecAuthError(input: unknown): boolean {
 }
 
 /** Classify a raw error into a friendly, actionable message. */
-export function describeError(input: unknown): FriendlyError {
+export function describeError(
+  input: unknown,
+  { domain = "cluster" }: DescribeErrorOptions = {},
+): FriendlyError {
   const raw = cleanErrorMessage(input);
   const lower = raw.toLowerCase();
 
@@ -133,6 +144,22 @@ export function describeError(input: unknown): FriendlyError {
   }
 
   if (/timed out|timeout|deadline exceeded/.test(lower)) {
+    if (domain === "http") {
+      return {
+        title: "Request timed out",
+        detail:
+          "The request didn't finish in time. Check your network connection and try again.",
+        raw,
+      };
+    }
+    if (domain === "local") {
+      return {
+        title: "Operation timed out",
+        detail:
+          "The local operation didn't finish in time. Try again; if it keeps happening, check that the file or device is still available.",
+        raw,
+      };
+    }
     // The remedy is platform-specific: the Settings slider only exists on the
     // desktop, so pointing a web user at it would be an impossible
     // instruction. The server honours SRELENS_TIMEOUT_SECS instead.
@@ -193,6 +220,16 @@ export function describeError(input: unknown): FriendlyError {
     };
   }
   if (/certificate|x509|\btls\b|self.signed|unknown authority/.test(lower)) {
+    if (domain !== "cluster") {
+      return {
+        title: "Couldn't verify the connection",
+        detail:
+          domain === "http"
+            ? "The server's TLS certificate couldn't be verified. It may be self-signed or expired, or this machine may not trust its issuer."
+            : "A TLS certificate couldn't be verified. It may be self-signed or expired, or this machine may not trust its issuer.",
+        raw,
+      };
+    }
     return {
       title: "Couldn't verify the cluster",
       detail:

--- a/packages/ui-next/src/lib/errorCopy.test.tsx
+++ b/packages/ui-next/src/lib/errorCopy.test.tsx
@@ -107,6 +107,18 @@ describe("FailureState", () => {
     expect(screen.getByText(REDACTION_REFUSED)).toBeDefined();
     expect(screen.queryByText("Something went wrong")).toBeNull();
   });
+
+  it("passes the caller's domain to the classifier", () => {
+    render(
+      <FailureState
+        title="Could not check for updates"
+        error="request timed out"
+        domain="http"
+      />,
+    );
+    expect(screen.getByText(/network connection/i)).toBeDefined();
+    expect(screen.queryByText(/Kubernetes API server/i)).toBeNull();
+  });
 });
 
 describe("FailureAlert", () => {

--- a/packages/ui-next/src/lib/errorCopy.tsx
+++ b/packages/ui-next/src/lib/errorCopy.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { describeError } from "@srelens/core";
+import { describeError, type ErrorDomain } from "@srelens/core";
 import { Alert, ErrorState, RawError, type Tone } from "@srelens/ui-kit";
 
 /**
@@ -56,8 +56,8 @@ export interface FriendlyCopy {
 }
 
 /** {@link describeError}, with the "is the original worth offering" rule applied. */
-export function friendly(error: unknown): FriendlyCopy {
-  const { title, detail, raw } = describeError(error);
+export function friendly(error: unknown, domain: ErrorDomain = "cluster"): FriendlyCopy {
+  const { title, detail, raw } = describeError(error, { domain });
   return { title, detail, raw: raw === detail ? undefined : raw };
 }
 
@@ -71,7 +71,9 @@ export function friendly(error: unknown): FriendlyCopy {
  * is not six problems.
  */
 export function summarise(errors: string[]): { detail: string; raw: string | undefined } {
-  const copies = errors.filter((e) => e !== "").map(friendly);
+  // Do not hand `friendly` straight to map: its second parameter is a domain,
+  // while Array.map's second callback argument is the numeric index.
+  const copies = errors.filter((e) => e !== "").map((error) => friendly(error));
   const details = [...new Set(copies.map((c) => c.detail))];
   // The originals are kept apart by a blank line rather than the separator the
   // sentences use: each one is a struct that already contains punctuation, and
@@ -90,6 +92,8 @@ export interface FailureStateProps {
    */
   title?: ReactNode;
   error: unknown;
+  /** What the failing operation contacted; cluster preserves the default copy. */
+  domain?: ErrorDomain;
   onRetry?: () => void;
   retryLabel?: string;
   action?: { label: string; onClick: () => void };
@@ -97,8 +101,8 @@ export interface FailureStateProps {
 }
 
 /** A content area whose load failed, said in words the reader can act on. */
-export function FailureState({ title, error, ...rest }: FailureStateProps) {
-  const copy = friendly(error);
+export function FailureState({ title, error, domain, ...rest }: FailureStateProps) {
+  const copy = friendly(error, domain);
   return <ErrorState title={title ?? copy.title} detail={copy.detail} raw={copy.raw} {...rest} />;
 }
 
@@ -111,6 +115,8 @@ export interface FailureAlertProps {
    */
   title: ReactNode;
   error: unknown;
+  /** What the failing operation contacted; cluster preserves the default copy. */
+  domain?: ErrorDomain;
   /** `warn` by default: a banner over surviving rows is a warning, not a stop. */
   tone?: Tone;
   className?: string;
@@ -125,8 +131,14 @@ export interface FailureAlertProps {
  * has. The title is the caller's for the same reason — those sentences were
  * written on purpose and this only changes what sits under them.
  */
-export function FailureAlert({ title, error, tone = "warn", className }: FailureAlertProps) {
-  const copy = friendly(error);
+export function FailureAlert({
+  title,
+  error,
+  domain,
+  tone = "warn",
+  className,
+}: FailureAlertProps) {
+  const copy = friendly(error, domain);
   return (
     <Alert tone={tone} title={title} className={className}>
       {copy.detail}

--- a/packages/ui-next/src/screens/AppLog.test.tsx
+++ b/packages/ui-next/src/screens/AppLog.test.tsx
@@ -78,6 +78,15 @@ describe("AppLog", () => {
     expect(core.readAppLog).toHaveBeenCalledTimes(2);
   });
 
+  it("does not describe a local-file timeout as a Kubernetes timeout", async () => {
+    core.readAppLog.mockRejectedValueOnce(new Error("read operation timed out"));
+    render(<AppLog route="/logs" />);
+
+    const alert = await screen.findByRole("alert");
+    expect(within(alert).getByText(/local operation/i)).toBeTruthy();
+    expect(alert.textContent).not.toMatch(/Kubernetes|cluster|kubeconfig/);
+  });
+
   it("does not read anything in the browser, and says where the log lives", async () => {
     core.isTauri.mockReturnValue(false);
     render(<AppLog route="/logs" />);

--- a/packages/ui-next/src/screens/AppLog.tsx
+++ b/packages/ui-next/src/screens/AppLog.tsx
@@ -75,7 +75,10 @@ export function AppLog(_props: { route: string }) {
     try {
       await revealAppLog();
     } catch (e) {
-      notify.error("Couldn't reveal the application log", describeError(e).detail);
+      notify.error(
+        "Couldn't reveal the application log",
+        describeError(e, { domain: "local" }).detail,
+      );
     }
   }
 
@@ -157,6 +160,7 @@ export function AppLog(_props: { route: string }) {
         <FailureState
           title="Could not read the application log"
           error={log.error}
+          domain="local"
           onRetry={log.reload}
         />
       )}

--- a/packages/ui-next/src/screens/ReleaseNotes.test.tsx
+++ b/packages/ui-next/src/screens/ReleaseNotes.test.tsx
@@ -183,6 +183,26 @@ describe("ReleaseNotes", () => {
     expect(within(alert).getByText("Could not check for updates")).toBeTruthy();
   });
 
+  it("describes updater timeouts as HTTP failures, not cluster failures", async () => {
+    checkForUpdate.mockRejectedValueOnce(new Error("request timed out"));
+    render(<ReleaseNotes route="/release-notes" />);
+
+    const alert = await screen.findByRole("alert");
+    expect(within(alert).getByText(/network connection/i)).toBeTruthy();
+    expect(alert.textContent).not.toMatch(/Kubernetes|cluster|kubeconfig/);
+  });
+
+  it("does not blame kubeconfig when the update server's TLS check fails", async () => {
+    checkForUpdate.mockResolvedValue(update());
+    installUpdate.mockRejectedValue(new Error("x509: certificate signed by unknown authority"));
+    render(<ReleaseNotes route="/release-notes" />);
+
+    await userEvent.click(await screen.findByRole("button", { name: /install/i }));
+    const alert = await screen.findByRole("alert");
+    expect(within(alert).getByText(/server's TLS certificate/i)).toBeTruthy();
+    expect(alert.textContent).not.toMatch(/cluster|kubeconfig|certificate-authority/);
+  });
+
   it("leaves updates to the server in web mode", async () => {
     isTauri.mockReturnValue(false);
     render(<ReleaseNotes route="/release-notes" />);

--- a/packages/ui-next/src/screens/ReleaseNotes.tsx
+++ b/packages/ui-next/src/screens/ReleaseNotes.tsx
@@ -97,6 +97,7 @@ export function ReleaseNotes(_props: { route: string }) {
         <FailureState
           title="Could not check for updates"
           error={found.error}
+          domain="http"
           onRetry={found.reload}
         />
       ) : !update ? (
@@ -146,7 +147,12 @@ export function ReleaseNotes(_props: { route: string }) {
             // region the hand-written paragraph had, kept, because this arrives
             // while the reader is looking at the notes. The notes stay on screen
             // under it: a failed install has not taken them away.
-            <FailureAlert tone="sev" title="Could not install the update" error={install.cause} />
+            <FailureAlert
+              tone="sev"
+              title="Could not install the update"
+              error={install.cause}
+              domain="http"
+            />
           )}
         </div>
       )}


### PR DESCRIPTION
## Summary

- gives `describeError` an explicit caller domain while preserving the cluster default
- keeps useful shared classifications such as authentication failures, but makes timeout and TLS guidance truthful for HTTP and local-file callers
- wires Release Notes as HTTP and App Log as local, leaving Kubernetes call sites unchanged

## Verification

- focused core error-copy, Release Notes, and App Log regression tests
- workspace TypeScript typecheck
- complete frontend test suite with coverage

Closes #383
