### PR TITLE
fix(editor): preserve unsaved resource drafts per tab

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -94,8 +94,18 @@ vi.mock("@srelens/core/lib/kinds", () => ({
     services: "Services",
     settings: "Settings",
     assistant: "Assistant",
+    newresource: "New Resource",
+    editresource: "Edit Resource",
   },
-  K8S_KIND: { overview: "", pods: "Pod", services: "Service", settings: "", assistant: "" },
+  K8S_KIND: {
+    overview: "",
+    pods: "Pod",
+    services: "Service",
+    settings: "",
+    assistant: "",
+    newresource: "",
+    editresource: "",
+  },
 }));
 vi.mock("./components/ResourceBrowser", () => ({
   ResourceBrowser: ({
@@ -105,6 +115,7 @@ vi.mock("./components/ResourceBrowser", () => ({
     onViewChange,
     onOpenResource,
     onOpenEdit,
+    onOpenNew,
   }: {
     context: string;
     kind: string;
@@ -112,6 +123,7 @@ vi.mock("./components/ResourceBrowser", () => ({
     onViewChange?: (patch: { query?: string }) => void;
     onOpenResource?: (target: { kind: string; namespace: string | null; name: string }) => void;
     onOpenEdit?: (kind: string, namespace: string | null, name: string) => void;
+    onOpenNew?: (initialKind?: string) => void;
   }) => (
     <div data-testid="browser">
       {context}:{kind}
@@ -123,6 +135,7 @@ vi.mock("./components/ResourceBrowser", () => ({
         linked-pod
       </button>
       <button onClick={() => onOpenEdit?.("Deployment", "default", "web")}>edit-web</button>
+      <button onClick={() => onOpenNew?.("Secret")}>new-secret</button>
     </div>
   ),
 }));
@@ -149,11 +162,58 @@ vi.mock("@srelens/core/lib/clusters", async (importOriginal) => ({
   listContexts: listContextsMock,
 }));
 vi.mock("./components/EditResourceTab", () => ({
-  EditResourceTab: ({ kind, name }: { kind: string; name: string }) => (
+  EditResourceTab: ({
+    kind,
+    name,
+    draft,
+    onDraftChange,
+    onEdited,
+  }: {
+    kind: string;
+    name: string;
+    draft: string | null;
+    onDraftChange: (yaml: string) => void;
+    onEdited?: () => void;
+  }) => (
     <div data-testid="edit-tab">
       {kind}/{name}
+      <textarea
+        aria-label="mock edit draft"
+        value={draft ?? "kind: Deployment\nmetadata:\n  name: web\n"}
+        onChange={(event) => onDraftChange(event.target.value)}
+      />
+      <button onClick={onEdited}>mock apply succeeds</button>
     </div>
   ),
+}));
+vi.mock("./components/NewResourceEditor", () => ({
+  NewResourceEditor: ({
+    initialKind,
+    draft,
+    onDraftChange,
+    onCreated,
+  }: {
+    initialKind?: string;
+    draft?: { template: string; yaml: string };
+    onDraftChange: (draft: { template: string; yaml: string }) => void;
+    onCreated?: () => void;
+  }) => {
+    const current = draft ?? {
+      template: initialKind ?? "Deployment",
+      yaml: `kind: ${initialKind ?? "Deployment"}\nmetadata:\n  name: stock\n`,
+    };
+    return (
+      <div data-testid="new-resource-tab">
+        <span>{current.template}</span>
+        <textarea
+          aria-label="mock new draft"
+          value={current.yaml}
+          onChange={(event) => onDraftChange({ ...current, yaml: event.target.value })}
+        />
+        <button onClick={onCreated}>mock create succeeds</button>
+      </div>
+    );
+  },
 }));
 
 import { App } from "./App";
@@ -265,13 +325,68 @@ describe("App", () => {
     fireEvent.click(screen.getByText("open-kind-dev"));
     fireEvent.click(screen.getByText("nav-services"));
     fireEvent.click(screen.getByText("edit-web"));
-    expect(screen.getByTestId("edit-tab").textContent).toBe("Deployment/web");
+    expect(screen.getByTestId("edit-tab").textContent).toContain("Deployment/web");
     expect(screen.getByRole("tab", { name: /edit: Deployment\/web/ })).toBeDefined();
 
     // Re-edit the same resource from the services tab → focuses, doesn't duplicate.
     fireEvent.click(screen.getByRole("tab", { name: /Services/ }));
     fireEvent.click(screen.getByText("edit-web"));
     expect(screen.getAllByRole("tab", { name: /edit: Deployment\/web/ })).toHaveLength(1);
+  });
+
+  it("keeps new-resource YAML in its tab while another tab is active (#403)", () => {
+    render(<App />);
+    fireEvent.click(screen.getByText("open-kind-dev"));
+    fireEvent.click(screen.getByText("nav-services"));
+    fireEvent.click(screen.getByText("new-secret"));
+
+    const editor = screen.getByLabelText("mock new draft") as HTMLTextAreaElement;
+    fireEvent.change(editor, { target: { value: "kind: Secret\nmetadata:\n  name: unsaved\n" } });
+    fireEvent.click(screen.getByRole("tab", { name: /Services · kind-dev/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /New Resource · kind-dev/ }));
+    expect((screen.getByLabelText("mock new draft") as HTMLTextAreaElement).value).toContain(
+      "name: unsaved",
+    );
+  });
+
+  it("keeps edit-resource YAML in its tab and does not replace it on return (#403)", () => {
+    render(<App />);
+    fireEvent.click(screen.getByText("open-kind-dev"));
+    fireEvent.click(screen.getByText("nav-services"));
+    fireEvent.click(screen.getByText("edit-web"));
+
+    const editor = screen.getByLabelText("mock edit draft") as HTMLTextAreaElement;
+    fireEvent.change(editor, { target: { value: "kind: Deployment\nmetadata:\n  name: unsaved\n" } });
+    fireEvent.click(screen.getByRole("tab", { name: /Services · kind-dev/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /edit: Deployment\/web/ }));
+    expect((screen.getByLabelText("mock edit draft") as HTMLTextAreaElement).value).toContain(
+      "name: unsaved",
+    );
+  });
+
+  it("clears each in-memory draft after its apply succeeds", () => {
+    render(<App />);
+    fireEvent.click(screen.getByText("open-kind-dev"));
+    fireEvent.click(screen.getByText("nav-services"));
+
+    fireEvent.click(screen.getByText("new-secret"));
+    fireEvent.change(screen.getByLabelText("mock new draft"), {
+      target: { value: "kind: Secret\nmetadata:\n  name: created\n" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "mock create succeeds" }));
+    expect((screen.getByLabelText("mock new draft") as HTMLTextAreaElement).value).toContain(
+      "name: stock",
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: /Services · kind-dev/ }));
+    fireEvent.click(screen.getByText("edit-web"));
+    fireEvent.change(screen.getByLabelText("mock edit draft"), {
+      target: { value: "kind: Deployment\nmetadata:\n  name: edited\n" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "mock apply succeeds" }));
+    expect((screen.getByLabelText("mock edit draft") as HTMLTextAreaElement).value).toContain(
+      "name: web",
+    );
   });
 
   it("opens views across multiple clusters and closes tabs", () => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -84,7 +84,7 @@ import type { SettingsSection } from "./components/SettingsView";
 import { listContexts, deleteContext, type ClusterContext } from "@srelens/core";
 import { deletePod } from "@srelens/core";
 import { clearAccessCache } from "@srelens/core/react";
-import type { ViewTab } from "@srelens/core";
+import type { NewResourceDraft, ViewTab } from "@srelens/core";
 
 /** How long a closing window waits for the settings write to land. */
 const CLOSE_WRITE_TIMEOUT_MS = 2000;
@@ -835,6 +835,25 @@ export function App() {
     setActiveTabId(id);
   }
 
+  /** Keep an editor's working copy on its tab so unmounting it is harmless. */
+  function setNewResourceDraft(tabId: number, draft: NewResourceDraft | undefined) {
+    setTabs((current) =>
+      current.map((tab) =>
+        tab.id === tabId && tab.create
+          ? { ...tab, create: { ...tab.create, draft } }
+          : tab,
+      ),
+    );
+  }
+
+  function setEditResourceDraft(tabId: number, draft: string | undefined) {
+    setTabs((current) =>
+      current.map((tab) =>
+        tab.id === tabId && tab.edit ? { ...tab, edit: { ...tab.edit, draft } } : tab,
+      ),
+    );
+  }
+
   /** Open (or focus) a full-tab editor preloaded with a resource's manifest. */
   function openEditResource(kind: string, namespace: string | null, name: string) {
     if (!activeCluster) return;
@@ -1081,6 +1100,9 @@ export function App() {
                       key={activeTab.id}
                       context={activeCluster}
                       initialKind={activeTab.create?.initialKind}
+                      draft={activeTab.create?.draft}
+                      onDraftChange={(draft) => setNewResourceDraft(activeTab.id, draft)}
+                      onCreated={() => setNewResourceDraft(activeTab.id, undefined)}
                     />
                   ) : activeCluster && activeKind === "editresource" && activeTab.edit ? (
                     <EditResourceTab
@@ -1089,6 +1111,9 @@ export function App() {
                       kind={activeTab.edit.kind}
                       namespace={activeTab.edit.namespace}
                       name={activeTab.edit.name}
+                      draft={activeTab.edit.draft ?? null}
+                      onDraftChange={(draft) => setEditResourceDraft(activeTab.id, draft)}
+                      onEdited={() => setEditResourceDraft(activeTab.id, undefined)}
                     />
                   ) : activeCluster ? (
                     <ResourceBrowser

--- a/apps/desktop/src/components/EditResourceTab.test.tsx
+++ b/apps/desktop/src/components/EditResourceTab.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 
 const { loadEditableManifestMock } = vi.hoisted(() => ({ loadEditableManifestMock: vi.fn() }));
@@ -11,17 +11,31 @@ vi.mock("@srelens/core/lib/manifest", async (importOriginal) => ({
 }));
 vi.mock("@srelens/core/lib/schema", () => ({ openApiSchema: vi.fn().mockResolvedValue({ error: "n/a" }) }));
 vi.mock("../ui/CodeEditor", () => ({
-  CodeEditor: ({ value, ariaLabel }: { value: string; ariaLabel?: string }) => (
-    <textarea aria-label={ariaLabel} value={value} readOnly />
+  CodeEditor: ({ value, onChange, ariaLabel }: { value: string; onChange?: (v: string) => void; ariaLabel?: string }) => (
+    <textarea aria-label={ariaLabel} value={value} onChange={(e) => onChange?.(e.target.value)} />
   ),
 }));
 
 import { EditResourceTab } from "./EditResourceTab";
 
+function StatefulEditResourceTab(
+  props: Omit<React.ComponentProps<typeof EditResourceTab>, "draft" | "onDraftChange">,
+) {
+  const [draft, setDraft] = React.useState<string | null>(null);
+  return <EditResourceTab {...props} draft={draft} onDraftChange={setDraft} />;
+}
+
 describe("EditResourceTab", () => {
   it("preloads the resource's manifest into the editor with an Apply action", async () => {
     loadEditableManifestMock.mockResolvedValue({ yaml: "kind: ConfigMap\nmetadata:\n  name: web\n" });
-    render(<EditResourceTab context="kind-dev" kind="ConfigMap" namespace="default" name="web" />);
+    render(
+      <StatefulEditResourceTab
+        context="kind-dev"
+        kind="ConfigMap"
+        namespace="default"
+        name="web"
+      />,
+    );
     await waitFor(() =>
       expect(loadEditableManifestMock).toHaveBeenCalledWith("kind-dev", "ConfigMap", "default", "web"),
     );
@@ -33,7 +47,36 @@ describe("EditResourceTab", () => {
 
   it("shows an error when the manifest can't be loaded", async () => {
     loadEditableManifestMock.mockResolvedValue({ error: "not found" });
-    render(<EditResourceTab context="kind-dev" kind="Pod" namespace="default" name="ghost" />);
+    render(
+      <StatefulEditResourceTab
+        context="kind-dev"
+        kind="Pod"
+        namespace="default"
+        name="ghost"
+      />,
+    );
     expect(await screen.findByText(/not found/)).toBeDefined();
+  });
+
+  it("uses the tab's existing draft without fetching over it", () => {
+    loadEditableManifestMock.mockClear();
+    const onDraftChange = vi.fn();
+    const draft = "kind: ConfigMap\nmetadata:\n  name: unsaved\n";
+    render(
+      <EditResourceTab
+        context="kind-dev"
+        kind="ConfigMap"
+        namespace="default"
+        name="web"
+        draft={draft}
+        onDraftChange={onDraftChange}
+      />,
+    );
+
+    const editor = screen.getByLabelText("Edit resource YAML") as HTMLTextAreaElement;
+    expect(editor.value).toBe(draft);
+    fireEvent.change(editor, { target: { value: `${draft}data:\n  key: changed\n` } });
+    expect(onDraftChange).toHaveBeenCalledWith(`${draft}data:\n  key: changed\n`);
+    expect(loadEditableManifestMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/components/EditResourceTab.tsx
+++ b/apps/desktop/src/components/EditResourceTab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Spinner } from "../ui";
 import { loadEditableManifest } from "@srelens/core";
 import { ManifestEditor } from "./ManifestEditor";
@@ -14,40 +14,48 @@ export function EditResourceTab({
   kind,
   namespace,
   name,
+  draft,
+  onDraftChange,
   onEdited,
 }: {
   context: string;
   kind: string;
   namespace: string | null;
   name: string;
+  /** The loaded/edited working copy owned by this tab; null means load it. */
+  draft: string | null;
+  onDraftChange: (yaml: string) => void;
   /** Called after a successful apply (so the parent can refresh views). */
   onEdited?: () => void;
 }) {
-  const [yaml, setYaml] = useState<string | null>(null);
   const [error, setError] = useState("");
+  const onDraftChangeRef = useRef(onDraftChange);
+  onDraftChangeRef.current = onDraftChange;
 
   useEffect(() => {
+    // Returning to a tab with a working copy must neither show a loading flash
+    // nor fetch the cluster's current manifest over unsaved edits.
+    if (draft !== null) return;
     let active = true;
-    setYaml(null);
     setError("");
     void loadEditableManifest(context, kind, namespace, name).then((out) => {
       if (!active) return;
       if (out.error) setError(out.error);
-      else setYaml(out.yaml ?? "");
+      else onDraftChangeRef.current(out.yaml ?? "");
     });
     return () => {
       active = false;
     };
-  }, [context, kind, namespace, name]);
+  }, [context, kind, namespace, name, draft]);
 
   if (error) return <p style={{ color: "var(--fl-color-danger)", padding: 12 }}>Error: {error}</p>;
-  if (yaml === null) return <Spinner label="Loading manifest" />;
+  if (draft === null) return <Spinner label="Loading manifest" />;
 
   return (
     <ManifestEditor
       context={context}
-      yaml={yaml}
-      onYamlChange={setYaml}
+      yaml={draft}
+      onYamlChange={onDraftChange}
       ariaLabel="Edit resource YAML"
       fill
       headerLabel={`Edit ${kind}/${name}`}

--- a/apps/desktop/src/components/NewResourceEditor.test.tsx
+++ b/apps/desktop/src/components/NewResourceEditor.test.tsx
@@ -17,6 +17,13 @@ import { NewResourceEditor } from "./NewResourceEditor";
 
 beforeEach(() => applyManifestMock.mockReset());
 
+function StatefulNewResourceEditor(
+  props: Omit<React.ComponentProps<typeof NewResourceEditor>, "draft" | "onDraftChange">,
+) {
+  const [draft, setDraft] = React.useState<React.ComponentProps<typeof NewResourceEditor>["draft"]>();
+  return <NewResourceEditor {...props} draft={draft} onDraftChange={setDraft} />;
+}
+
 describe("NewResourceEditor", () => {
   it("prefills a template and applies it, staying open on success", async () => {
     applyManifestMock.mockResolvedValue({
@@ -24,7 +31,14 @@ describe("NewResourceEditor", () => {
       documents: [{ kind: "Service", name: "my-app", applied: true }],
     });
     const onCreated = vi.fn();
-    render(<NewResourceEditor context="kind-dev" namespace="prod" initialKind="Service" onCreated={onCreated} />);
+    render(
+      <StatefulNewResourceEditor
+        context="kind-dev"
+        namespace="prod"
+        initialKind="Service"
+        onCreated={onCreated}
+      />,
+    );
 
     const editor = (await screen.findByLabelText("New resource YAML")) as HTMLTextAreaElement;
     expect(editor.value).toContain("kind: Service");
@@ -41,8 +55,32 @@ describe("NewResourceEditor", () => {
 
   it("surfaces an apply error", async () => {
     applyManifestMock.mockResolvedValue({ error: "invalid manifest" });
-    render(<NewResourceEditor context="kind-dev" />);
+    render(<StatefulNewResourceEditor context="kind-dev" />);
     fireEvent.click(screen.getByRole("button", { name: "Create" }));
     expect(await screen.findByText(/invalid manifest/)).toBeDefined();
+  });
+
+  it("renders and updates the draft owned by its tab", () => {
+    const onDraftChange = vi.fn();
+    const draft = {
+      template: "Secret",
+      yaml: "apiVersion: v1\nkind: Secret\nmetadata:\n  name: hand-written\n",
+    };
+    render(
+      <NewResourceEditor
+        context="kind-dev"
+        initialKind="Deployment"
+        draft={draft}
+        onDraftChange={onDraftChange}
+      />,
+    );
+
+    const editor = screen.getByLabelText("New resource YAML") as HTMLTextAreaElement;
+    expect(editor.value).toBe(draft.yaml);
+    fireEvent.change(editor, { target: { value: `${draft.yaml}stringData:\n  token: changed\n` } });
+    expect(onDraftChange).toHaveBeenCalledWith({
+      template: "Secret",
+      yaml: `${draft.yaml}stringData:\n  token: changed\n`,
+    });
   });
 });

--- a/apps/desktop/src/components/NewResourceEditor.tsx
+++ b/apps/desktop/src/components/NewResourceEditor.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from "react";
+import React from "react";
 import { FilePlus2 } from "lucide-react";
+import type { NewResourceDraft } from "@srelens/core";
 import { Combobox } from "../ui";
 import { ManifestEditor } from "./ManifestEditor";
 
@@ -98,29 +99,35 @@ export function NewResourceEditor({
   context,
   namespace = "default",
   initialKind,
+  draft,
+  onDraftChange,
   onCreated,
 }: {
   context: string;
   namespace?: string;
   /** k8s Kind (e.g. "Deployment") to preselect a template. */
   initialKind?: string;
+  /** The working copy owned by this tab; absent until the first change. */
+  draft?: NewResourceDraft;
+  onDraftChange: (draft: NewResourceDraft) => void;
   onCreated?: () => void;
 }) {
   const ns = namespace || "default";
   const startTemplate = initialKind && TEMPLATES[initialKind] ? initialKind : "Deployment";
-  const [template, setTemplate] = useState(startTemplate);
-  const [yaml, setYaml] = useState(() => TEMPLATES[startTemplate](ns));
+  const current = draft ?? {
+    template: startTemplate,
+    yaml: TEMPLATES[startTemplate](ns),
+  };
 
   function pickTemplate(t: string) {
-    setTemplate(t);
-    setYaml(TEMPLATES[t](ns));
+    onDraftChange({ template: t, yaml: TEMPLATES[t](ns) });
   }
 
   return (
     <ManifestEditor
       context={context}
-      yaml={yaml}
-      onYamlChange={setYaml}
+      yaml={current.yaml}
+      onYamlChange={(yaml) => onDraftChange({ ...current, yaml })}
       ariaLabel="New resource YAML"
       fill
       headerLabel="New resource"
@@ -132,7 +139,7 @@ export function NewResourceEditor({
         <>
           <span className="mx-1 text-xs text-muted-foreground">Template</span>
           <Combobox
-            value={template}
+            value={current.template}
             onValueChange={pickTemplate}
             options={TEMPLATE_ORDER.map((t) => ({ value: t }))}
             ariaLabel="Template"

--- a/packages/core/src/lib/openTabs.test.ts
+++ b/packages/core/src/lib/openTabs.test.ts
@@ -70,6 +70,27 @@ describe("openTabs persistence (web mode)", () => {
     expect(restored!.activeTabId).toBe(1);
   });
 
+  it("never writes transient editor YAML to session storage", () => {
+    const sensitive = "stringData:\n  token: do-not-persist";
+    saveOpenTabs(
+      [
+        tab({ id: 1, kind: "pods" }),
+        tab({
+          id: 2,
+          kind: "newresource",
+          create: { initialKind: "Secret", draft: { template: "Secret", yaml: sensitive } },
+        }),
+        tab({
+          id: 3,
+          kind: "editresource",
+          edit: { kind: "Secret", namespace: "default", name: "api", draft: sensitive },
+        }),
+      ],
+      2,
+    );
+    expect(localStorage.getItem(KEY)).not.toContain("do-not-persist");
+  });
+
   it("falls back to the first tab when the stored active id is gone", () => {
     saveOpenTabs([tab({ id: 5 }), tab({ id: 6 })], 999);
     expect(loadOpenTabs()!.activeTabId).toBe(5);

--- a/packages/core/src/lib/openTabs.ts
+++ b/packages/core/src/lib/openTabs.ts
@@ -18,8 +18,8 @@ export interface PersistedWorkspace {
   activeTabId: number | null;
 }
 
-/** Transient editor tabs carry unsaved content that lives outside App state,
- * so restoring them would show a blank editor — drop them from persistence. */
+/** Transient editor tabs can carry Secret YAML in their in-memory tab state.
+ * Never serialize those drafts into settings.json or localStorage. */
 function isRestorable(t: ViewTab): boolean {
   return !t.create && !t.edit;
 }

--- a/packages/core/src/lib/tabs.ts
+++ b/packages/core/src/lib/tabs.ts
@@ -2,6 +2,12 @@ import type { CrdRef } from "./crds";
 import type { ResourceKind } from "./kinds";
 import type { TabViewState } from "./tabView";
 
+/** Unsaved state for one New Resource tab. Kept in memory, never persisted. */
+export interface NewResourceDraft {
+  template: string;
+  yaml: string;
+}
+
 /**
  * One open tab in the workspace. It lives here rather than beside the
  * component that renders it because `openTabs` persists it, and a persistence
@@ -15,10 +21,10 @@ export interface ViewTab {
   crd?: CrdRef;
   /** Deep-link target from global search (opens the resource's detail). */
   focus?: { name: string; namespace: string | null; nonce: number };
-  /** For a "new resource" tab: the template kind to start from. */
-  create?: { initialKind?: string };
-  /** For an "edit resource" tab: the resource to preload and apply back. */
-  edit?: { kind: string; namespace: string | null; name: string };
+  /** For a "new resource" tab: its starting kind and in-memory working copy. */
+  create?: { initialKind?: string; draft?: NewResourceDraft };
+  /** For an "edit resource" tab: its target and loaded/in-memory working copy. */
+  edit?: { kind: string; namespace: string | null; name: string; draft?: string };
   /** Identity of `cluster` (#265). The display name changes when another
    *  kubeconfig declares the same context name; this does not, so a rename
    *  never reads as a deleted context and never closes the tab. */


### PR DESCRIPTION
## Summary

- moves create/edit YAML drafts into their owning tab records so switching tabs cannot discard unsaved work
- makes both resource editors controlled and prevents an edit tab from refetching over an in-memory draft
- keeps transient editor content out of persisted tab storage and clears it through the existing close/success lifecycle

## Verification

- focused `App`, `NewResourceEditor`, `EditResourceTab`, and tab-persistence tests
- workspace TypeScript typecheck
- complete frontend test suite with coverage

Closes #403
