### PR TITLE
feat(filters): add persistent regex mode

### DIFF
--- a/packages/ui-kit/src/FilterBar.test.tsx
+++ b/packages/ui-kit/src/FilterBar.test.tsx
@@ -138,9 +138,41 @@ describe("FilterBar", () => {
   });
 
   it("can be disabled while the list behind it is loading", () => {
-    setup({ value: "nginx", disabled: true });
+    setup({ value: "nginx", disabled: true, regex: true, onRegexChange: vi.fn() });
     expect((field() as HTMLInputElement).disabled).toBe(true);
     expect((clear() as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole("button", { name: "Use regular expression" }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("offers an accessible pressed toggle only when regex mode is supported", async () => {
+    expect(setup().queryByRole("button", { name: "Use regular expression" })).toBeNull();
+
+    const onRegexChange = vi.fn();
+    const view = setup({ regex: false, onRegexChange });
+    const toggle = screen.getByRole("button", { name: "Use regular expression" });
+    expect(toggle.getAttribute("aria-pressed")).toBe("false");
+    await userEvent.click(toggle);
+    expect(onRegexChange).toHaveBeenCalledWith(true);
+
+    view.rerender(
+      <FilterBar
+        label="Filter pods"
+        value="^web"
+        onValueChange={() => {}}
+        regex
+        onRegexChange={onRegexChange}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Use regular expression" }).getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("names an invalid regular expression without hiding the current text", () => {
+    setup({ value: "^web-(", regex: true, onRegexChange: vi.fn(), invalid: true });
+    expect(field().getAttribute("aria-invalid")).toBe("true");
+    const descriptionId = field().getAttribute("aria-describedby");
+    expect(descriptionId).not.toBeNull();
+    expect(document.getElementById(descriptionId!)?.textContent).toBe("Invalid regular expression");
+    expect((field() as HTMLInputElement).value).toBe("^web-(");
   });
 
   it("forwards className onto the bar", () => {

--- a/packages/ui-kit/src/FilterBar.test.tsx
+++ b/packages/ui-kit/src/FilterBar.test.tsx
@@ -166,6 +166,12 @@ describe("FilterBar", () => {
     expect(screen.getByRole("button", { name: "Use regular expression" }).getAttribute("aria-pressed")).toBe("true");
   });
 
+  it("keeps the regex toggle immediately left of the rightmost clear control", () => {
+    setup({ value: "^web", regex: true, onRegexChange: vi.fn() });
+    const toggle = screen.getByRole("button", { name: "Use regular expression" });
+    expect(toggle.nextElementSibling).toBe(clear());
+  });
+
   it("names an invalid regular expression without hiding the current text", () => {
     setup({ value: "^web-(", regex: true, onRegexChange: vi.fn(), invalid: true });
     expect(field().getAttribute("aria-invalid")).toBe("true");

--- a/packages/ui-kit/src/FilterBar.tsx
+++ b/packages/ui-kit/src/FilterBar.tsx
@@ -1,4 +1,4 @@
-import { useRef, type ReactNode } from "react";
+import { useId, useRef, type ReactNode } from "react";
 import { cx } from "./cx";
 import { filled } from "./slot";
 
@@ -14,6 +14,12 @@ export interface FilterBarProps {
   /** Shown while the field is empty. Not a substitute for `label`. */
   placeholder?: string;
   disabled?: boolean;
+  /** Whether the field currently interprets its value as a regular expression. */
+  regex?: boolean;
+  /** Supplying this enables the in-field regular-expression toggle. */
+  onRegexChange?: (on: boolean) => void;
+  /** Marks the current regular expression as incomplete or invalid. */
+  invalid?: boolean;
   /** Controls that filter alongside the text — a namespace picker, a toggle. */
   children?: ReactNode;
   className?: string;
@@ -56,10 +62,14 @@ export function FilterBar({
   label,
   placeholder,
   disabled,
+  regex = false,
+  onRegexChange,
+  invalid = false,
   children,
   className,
 }: FilterBarProps) {
   const fieldRef = useRef<HTMLInputElement>(null);
+  const invalidId = useId();
 
   return (
     <div
@@ -68,7 +78,11 @@ export function FilterBar({
       className={cx("rule-b flex shrink-0 flex-wrap items-center gap-3 px-2.5 py-1.5", className)}
       style={{ background: "var(--surface-sunk)" }}
     >
-      <div className="flex min-w-[200px] flex-1 items-center gap-1.5">
+      <div
+        className="flex min-w-[200px] flex-1 items-center gap-1.5 rounded border border-transparent px-1"
+        data-invalid={invalid ? "true" : undefined}
+        style={{ borderColor: invalid ? "var(--sev)" : "transparent" }}
+      >
         {/* Inline rather than an icon-set import: the kit takes no dependency
             on lucide, and this is the only glyph it needs. */}
         <svg
@@ -98,6 +112,9 @@ export function FilterBar({
           placeholder={placeholder}
           disabled={disabled}
           aria-label={label}
+          aria-invalid={invalid ? true : undefined}
+          aria-describedby={invalid ? invalidId : undefined}
+          title={invalid ? "Invalid regular expression" : undefined}
           className="w-full bg-transparent text-[0.8125rem] outline-none placeholder:text-faint"
         />
         {value !== "" && (
@@ -118,6 +135,34 @@ export function FilterBar({
               <path d="M18 6 6 18M6 6l12 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
             </svg>
           </button>
+        )}
+        {onRegexChange && (
+          <button
+            type="button"
+            className="icon-btn shrink-0 text-[0.6875rem] font-semibold"
+            aria-label="Use regular expression"
+            aria-pressed={regex}
+            data-on={regex}
+            title="Use regular expression"
+            disabled={disabled}
+            onClick={() => onRegexChange(!regex)}
+            style={
+              regex
+                ? {
+                    background: "var(--field)",
+                    color: "var(--accent)",
+                    boxShadow: "inset 0 0 0 1px var(--accent)",
+                  }
+                : undefined
+            }
+          >
+            .*
+          </button>
+        )}
+        {invalid && (
+          <span id={invalidId} className="sr-only">
+            Invalid regular expression
+          </span>
         )}
       </div>
       {filled(children) && (

--- a/packages/ui-kit/src/FilterBar.tsx
+++ b/packages/ui-kit/src/FilterBar.tsx
@@ -117,25 +117,6 @@ export function FilterBar({
           title={invalid ? "Invalid regular expression" : undefined}
           className="w-full bg-transparent text-[0.8125rem] outline-none placeholder:text-faint"
         />
-        {value !== "" && (
-          <button
-            type="button"
-            className="icon-btn shrink-0"
-            aria-label="Clear filter"
-            title="Clear filter"
-            disabled={disabled}
-            onClick={() => {
-              onValueChange("");
-              // The button is about to vanish with the value that summoned it,
-              // and focus would land on the body.
-              fieldRef.current?.focus();
-            }}
-          >
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-              <path d="M18 6 6 18M6 6l12 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-            </svg>
-          </button>
-        )}
         {onRegexChange && (
           <button
             type="button"
@@ -157,6 +138,25 @@ export function FilterBar({
             }
           >
             .*
+          </button>
+        )}
+        {value !== "" && (
+          <button
+            type="button"
+            className="icon-btn shrink-0"
+            aria-label="Clear filter"
+            title="Clear filter"
+            disabled={disabled}
+            onClick={() => {
+              onValueChange("");
+              // The button is about to vanish with the value that summoned it,
+              // and focus would land on the body.
+              fieldRef.current?.focus();
+            }}
+          >
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <path d="M18 6 6 18M6 6l12 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+            </svg>
           </button>
         )}
         {invalid && (

--- a/packages/ui-kit/src/Table.test.tsx
+++ b/packages/ui-kit/src/Table.test.tsx
@@ -3,7 +3,14 @@ import { join } from "node:path";
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { act, render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { Table, filterTableData, computeVisibleRange, rowPitch, type Column } from "./Table";
+import {
+  Table,
+  filterTableData,
+  tableFilterError,
+  computeVisibleRange,
+  rowPitch,
+  type Column,
+} from "./Table";
 
 /**
  * Compact ages as seconds, standing in for core's `ageSeconds`, which the kit
@@ -601,6 +608,21 @@ describe("Table", () => {
     expect(filterTableData(data, columns, "running", null)).toEqual([data[0]]);
     expect(filterTableData(data, columns, "web", "phase")).toEqual([]);
     expect(filterTableData(data, columns, "web-2", "name")).toEqual([data[1]]);
+  });
+
+  it("filters raw cell values with case-insensitive regular expressions", () => {
+    expect(filterTableData(data, columns, "^WEB-1$", null, true)).toEqual([data[0]]);
+    expect(filterTableData(data, columns, "(running|pending)", "phase", true)).toEqual(data);
+    expect(filterTableData(data, columns, "-\\d+$", "name", true)).toEqual(data);
+    expect(filterTableData(data, columns, "^(?!.*web-2)", "name", true)).toEqual([data[0]]);
+  });
+
+  it("treats an invalid or empty regular expression as no filter", () => {
+    expect(filterTableData(data, columns, "^web-(", null, true)).toBe(data);
+    expect(filterTableData(data, columns, "  ", null, true)).toBe(data);
+    expect(tableFilterError("^web-(", true)).toBe("Invalid regular expression");
+    expect(tableFilterError("^web-(a|b)", true)).toBeNull();
+    expect(tableFilterError("[", false)).toBeNull();
   });
 
   it("resizes a column with the keyboard and resets it on double click", () => {

--- a/packages/ui-kit/src/Table.tsx
+++ b/packages/ui-kit/src/Table.tsx
@@ -300,23 +300,50 @@ export function rowPitch(tops: readonly number[], fallbackHeight: number): numbe
   return Number.isFinite(pitch) && pitch > 0 ? pitch : fallbackHeight;
 }
 
+/** The stable message FilterBar exposes when a regex is still being typed. */
+export function tableFilterError(query: string, regex = false): string | null {
+  const pattern = query.trim();
+  if (!regex || pattern === "") return null;
+  try {
+    new RegExp(pattern, "i");
+    return null;
+  } catch {
+    return "Invalid regular expression";
+  }
+}
+
 /** Apply the toolbar query to one selected column, or all searchable columns. */
 export function filterTableData<T>(
   data: T[],
   columns: Column<T>[],
   query: string,
   activeFilterKey: string | null,
+  regex = false,
 ): T[] {
-  const normalized = query.trim().toLocaleLowerCase();
-  if (!normalized) return data;
+  const pattern = query.trim();
+  if (!pattern) return data;
   const searchable = activeFilterKey
     ? columns.filter((column) => column.key === activeFilterKey)
     : columns.filter((column) => column.filterable !== false);
   if (searchable.length === 0) return data;
+  let matcher: RegExp | null = null;
+  if (regex) {
+    try {
+      // No global flag: `test` stays stateless while the same compiled pattern
+      // is reused for every cell in this pass.
+      matcher = new RegExp(pattern, "i");
+    } catch {
+      // An incomplete expression is normal while someone types. Keep the
+      // current list available; FilterBar names the invalid state beside it.
+      return data;
+    }
+  }
+  const normalized = pattern.toLocaleLowerCase();
   return data.filter((row) =>
-    searchable.some((column) =>
-      String(getColumnValue(row, column) ?? "").toLocaleLowerCase().includes(normalized),
-    ),
+    searchable.some((column) => {
+      const value = String(getColumnValue(row, column) ?? "");
+      return matcher ? matcher.test(value) : value.toLocaleLowerCase().includes(normalized);
+    }),
   );
 }
 

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -71,7 +71,7 @@ export { StatusRow, type StatusRowProps } from "./StatusRow";
 export { SubHead, type SubHeadProps, type SubHeadVariant } from "./SubHead";
 export { SurfaceToast, type SurfaceToastProps } from "./SurfaceToast";
 export { Switch, type SwitchProps } from "./Switch";
-export { Table, computeVisibleRange, filterTableData, nextSort, type Column, type TableProps, type TableSelection, type TableSort } from "./Table";
+export { Table, computeVisibleRange, filterTableData, tableFilterError, nextSort, type Column, type TableProps, type TableSelection, type TableSort } from "./Table";
 export { Tabs, type TabItem, type TabsProps, type TabsVariant } from "./Tabs";
 export { TabStrip, type StripTab, type TabStripProps } from "./TabStrip";
 export { TextInput, type TextInputProps } from "./TextInput";

--- a/packages/ui-next/src/lib/tabs.ts
+++ b/packages/ui-next/src/lib/tabs.ts
@@ -17,7 +17,7 @@ export interface Tab {
    * to the tab, not the screen, so it survives a restart the way the rest of
    * the tab does. Absent until the user sorts or filters — see `setTabView`.
    */
-  view?: { sort?: TableSort | null; filter?: string; filterKey?: string | null };
+  view?: { sort?: TableSort | null; filter?: string; filterKey?: string | null; regex?: boolean };
 }
 
 export interface Workspace {

--- a/packages/ui-next/src/lib/tabsPersist.test.ts
+++ b/packages/ui-next/src/lib/tabsPersist.test.ts
@@ -119,7 +119,12 @@ describe("parseStoredState", () => {
 
   it("keeps a tab's sort through a save and a load", () => {
     const s = valid();
-    s.workspaces[0].tabs[1].view = { sort: { key: "restarts", direction: "desc" }, filter: "crash", filterKey: "status" };
+    s.workspaces[0].tabs[1].view = {
+      sort: { key: "restarts", direction: "desc" },
+      filter: "crash",
+      filterKey: "status",
+      regex: true,
+    };
     const storage = memory();
     saveTabsState(s, storage);
     const parsed = parseStoredState(storage.getItem(STORAGE_KEY));
@@ -127,6 +132,17 @@ describe("parseStoredState", () => {
       sort: { key: "restarts", direction: "desc" },
       filter: "crash",
       filterKey: "status",
+      regex: true,
+    });
+  });
+
+  it("drops a non-boolean regex mode without losing the rest of the view", () => {
+    const s = valid();
+    s.workspaces[0].tabs[1].view = { filter: "crash" };
+    const doc = JSON.parse(JSON.stringify({ version: 1, ...s }));
+    doc.workspaces[0].tabs[1].view.regex = "yes";
+    expect(parseStoredState(JSON.stringify(doc))!.workspaces[0].tabs[1].view).toEqual({
+      filter: "crash",
     });
   });
 

--- a/packages/ui-next/src/lib/tabsPersist.ts
+++ b/packages/ui-next/src/lib/tabsPersist.ts
@@ -42,6 +42,7 @@ function parseView(v: unknown): Tab["view"] | undefined {
   if (isString(v.filter)) view.filter = v.filter;
   if (v.filterKey === null) view.filterKey = null;
   else if (isString(v.filterKey)) view.filterKey = v.filterKey;
+  if (typeof v.regex === "boolean") view.regex = v.regex;
   return view;
 }
 

--- a/packages/ui-next/src/lib/tabsStore.test.tsx
+++ b/packages/ui-next/src/lib/tabsStore.test.tsx
@@ -481,9 +481,11 @@ describe("setTabView / useTabView", () => {
     const id = active().id;
     store.setTabView(id, { filter: "abc" });
     store.setTabView(id, { sort: { key: "name", direction: "asc" } });
+    store.setTabView(id, { regex: true });
     expect(store.currentWorkspace().tabs.find((t) => t.id === id)?.view).toEqual({
       filter: "abc",
       sort: { key: "name", direction: "asc" },
+      regex: true,
     });
   });
 
@@ -492,6 +494,12 @@ describe("setTabView / useTabView", () => {
     const { result } = renderHook(() => store.useTabView(id));
     act(() => store.setTabView(id, { filter: "x" }));
     expect(result.current.filter).toBe("x");
+  });
+
+  it("does not discard a regex-only view change", () => {
+    const id = active().id;
+    store.setTabView(id, { regex: true });
+    expect(store.currentWorkspace().tabs.find((t) => t.id === id)?.view?.regex).toBe(true);
   });
 
   it("ignores an id that is not there", () => {

--- a/packages/ui-next/src/lib/tabsStore.ts
+++ b/packages/ui-next/src/lib/tabsStore.ts
@@ -367,7 +367,7 @@ function sortEqual(a: TableSort | null | undefined, b: TableSort | null | undefi
 }
 
 /**
- * A resource list's sort, filter string and active filter column, merged
+ * A resource list's sort, filter string, mode and active filter column, merged
  * into whatever the tab already has. Guarded like every other action here:
  * one subscriber writes a file, so patching a view with values it already
  * holds must not emit.
@@ -378,7 +378,12 @@ export function setTabView(tabId: string, patch: Partial<NonNullable<Tab["view"]
     if (at < 0) return w;
     const current = w.tabs[at].view ?? EMPTY_VIEW;
     const next: NonNullable<Tab["view"]> = { ...current, ...patch };
-    if (sortEqual(current.sort, next.sort) && current.filter === next.filter && current.filterKey === next.filterKey) {
+    if (
+      sortEqual(current.sort, next.sort) &&
+      current.filter === next.filter &&
+      current.filterKey === next.filterKey &&
+      current.regex === next.regex
+    ) {
       return w;
     }
     const tabs = w.tabs.map((t, i) => (i === at ? { ...t, view: next } : t));

--- a/packages/ui-next/src/screens/Events.test.tsx
+++ b/packages/ui-next/src/screens/Events.test.tsx
@@ -229,6 +229,16 @@ const eyebrowText = () =>
   );
 
 describe("Events", () => {
+  it("applies regex mode to the same event fields as plain filtering", async () => {
+    open();
+    await waitFor(() => expect(reasons()).toHaveLength(4));
+
+    await userEvent.type(search(), "^(BackOff|Unhealthy)$");
+    await waitFor(() => expect(reasons()).toEqual([]));
+    await userEvent.click(screen.getByRole("button", { name: "Use regular expression" }));
+    await waitFor(() => expect(reasons()).toEqual(["BackOff", "Unhealthy"]));
+  });
+
   it("renders the design's eight columns, in its order", async () => {
     open();
     await waitFor(() => expect(cells().length).toBe(4));

--- a/packages/ui-next/src/screens/Events.tsx
+++ b/packages/ui-next/src/screens/Events.tsx
@@ -19,6 +19,7 @@ import {
   Table,
   Tabs,
   filterTableData,
+  tableFilterError,
   type TabItem,
 } from "@srelens/ui-kit";
 import { useConsole } from "../console";
@@ -173,10 +174,17 @@ function EventList({
 
   // Sort, filter text and filter column live on this route's own tab, so they
   // survive a restart with it — see `useResourceTabView`'s own comment.
-  const { tabId, sort, filter, filterKey, setFilter, setSort, setFilterKey } = useResourceTabView(
-    route,
-    columns,
-  );
+  const {
+    tabId,
+    sort,
+    filter,
+    filterKey,
+    regex,
+    setFilter,
+    setSort,
+    setFilterKey,
+    setRegex,
+  } = useResourceTabView(route, columns);
 
   // The segment narrows the rows on screen and nothing else: it never touches
   // the watch above, so switching segments cannot re-list. Component state
@@ -205,9 +213,10 @@ function EventList({
     [columns, filterKey],
   );
   const filtered = useMemo(
-    () => filterTableData(segmented, searchColumns, filter, filterKey),
-    [segmented, searchColumns, filter, filterKey],
+    () => filterTableData(segmented, searchColumns, filter, filterKey, regex),
+    [segmented, searchColumns, filter, filterKey, regex],
   );
+  const invalidFilter = tableFilterError(filter, regex) !== null;
 
   // Both counts are of what is ON SCREEN, per §8 — a header that counted the
   // loaded set would disagree with the rows under it the moment anyone typed.
@@ -318,6 +327,9 @@ function EventList({
         <FilterBar
           value={filter}
           onValueChange={setFilter}
+          regex={regex}
+          onRegexChange={setRegex}
+          invalid={invalidFilter}
           label={`Filter ${lower}`}
           // Verbatim from §8. The label above is what NAMES the field; this only
           // says what it matches.

--- a/packages/ui-next/src/screens/Helm.test.tsx
+++ b/packages/ui-next/src/screens/Helm.test.tsx
@@ -1192,6 +1192,20 @@ describe("Helm — the namespace selector", () => {
     expect(screen.getByText("Clear the filter to see all 5.")).toBeTruthy();
   });
 
+  it("applies regex mode to Helm releases and stores the mode on its tab", async () => {
+    open();
+    await ready();
+    const input = screen.getByRole("searchbox", { name: "Filter releases" });
+
+    await userEvent.type(input, "^(redis-session|payments)$");
+    await waitFor(() => expect(drawn()).toEqual([]));
+    await userEvent.click(screen.getByRole("button", { name: "Use regular expression" }));
+    await waitFor(() =>
+      expect(drawn()).toEqual(["payments/payments", "checkout/redis-session"]),
+    );
+    expect(store.currentWorkspace().tabs.find((tab) => tab.route === ROUTE)?.view?.regex).toBe(true);
+  });
+
   it("follows the namespace a restricted credential is scoped to", async () => {
     useNamespaceOptions.mockReturnValue({ namespaces: ["payments"], scope: "payments", error: "" });
 

--- a/packages/ui-next/src/screens/Helm.tsx
+++ b/packages/ui-next/src/screens/Helm.tsx
@@ -30,6 +30,7 @@ import {
   StatusPill,
   Table,
   filterTableData,
+  tableFilterError,
   type Column,
 } from "@srelens/ui-kit";
 import { useConsole } from "../console";
@@ -53,6 +54,7 @@ import {
   NoClusterScreen,
   StaleSelectionAlert,
   emptyTableCopy,
+  useResourceTabView,
 } from "./resourceShell";
 
 /**
@@ -250,7 +252,7 @@ export function Helm({ route }: { route: string }) {
     return <NoClusterScreen title={title} noun="Helm releases" />;
   }
 
-  return <HelmReleases title={title} context={context} />;
+  return <HelmReleases route={route} title={title} context={context} />;
 }
 
 /**
@@ -271,7 +273,15 @@ export function Helm({ route }: { route: string }) {
  * owns its own 420px frame — `aside.side-rail`, head, body and footer — so a
  * `SideRail` around it would be a second rail around the first.
  */
-function HelmReleases({ title, context }: { title: string; context: ClusterContext }) {
+function HelmReleases({
+  route,
+  title,
+  context,
+}: {
+  route: string;
+  title: string;
+  context: ClusterContext;
+}) {
   // Core takes a context *name*; the workspace holds a `stableId`. The two are
   // never interchangeable — see `lib/clusters`.
   const name = context.name;
@@ -283,7 +293,7 @@ function HelmReleases({ title, context }: { title: string; context: ClusterConte
   const [list, setList] = useState<ListLoad>({ status: "loading" });
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const [pending, setPending] = useState<Pending | null>(null);
-  const [filter, setFilter] = useState("");
+  const { filter, regex, setFilter, setRegex } = useResourceTabView<ReleaseRow>(route, []);
 
   /**
    * **The namespace selection is the cluster's, not this screen's.**
@@ -769,7 +779,8 @@ function HelmReleases({ title, context }: { title: string; context: ClusterConte
    * `useMemo` keyed on it would recompute every time regardless — an honest
    * call is cheaper than a cache that never hits.
    */
-  const visible = filterTableData(rows, columns, filter, null);
+  const visible = filterTableData(rows, columns, filter, null, regex);
+  const invalidFilter = tableFilterError(filter, regex) !== null;
 
   /**
    * §16's pane head, made to describe what the reader is looking at.
@@ -878,6 +889,9 @@ function HelmReleases({ title, context }: { title: string; context: ClusterConte
       <FilterBar
         value={filter}
         onValueChange={setFilter}
+        regex={regex}
+        onRegexChange={setRegex}
+        invalid={invalidFilter}
         label="Filter releases"
         placeholder="Filter releases…"
       >

--- a/packages/ui-next/src/screens/Resources.test.tsx
+++ b/packages/ui-next/src/screens/Resources.test.tsx
@@ -534,6 +534,23 @@ describe("Resources", () => {
     await waitFor(() => expect(rowNames()).toEqual(["web-1"]));
   });
 
+  it("switches the tab to regex filtering and keeps invalid patterns non-destructive", async () => {
+    open("/k/pods");
+    await waitFor(() => expect(rowNames()).toHaveLength(2));
+    const input = screen.getByRole("searchbox", { name: "Filter pods" });
+
+    await userEvent.type(input, "^web-1$");
+    await waitFor(() => expect(rowNames()).toEqual([]));
+    await userEvent.click(screen.getByRole("button", { name: "Use regular expression" }));
+    await waitFor(() => expect(rowNames()).toEqual(["web-1"]));
+    expect(tabFor("/k/pods").view?.regex).toBe(true);
+
+    await userEvent.clear(input);
+    await userEvent.type(input, "(");
+    await waitFor(() => expect(rowNames()).toEqual(["web-1", "api-7"]));
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+  });
+
   it("reorders by a sortable column when its header is activated", async () => {
     open("/k/pods");
     await waitFor(() => expect(rowNames()).toEqual(["web-1", "api-7"]));
@@ -630,8 +647,13 @@ describe("Resources", () => {
     await screen.findByRole("searchbox", { name: "Filter pods" });
 
     await userEvent.type(screen.getByRole("searchbox", { name: "Filter pods" }), "web");
+    await userEvent.click(
+      within(screen.getByRole("search", { name: "Filter pods" })).getByRole("button", {
+        name: "Use regular expression",
+      }),
+    );
 
-    expect(tabFor("/k/pods").view).toMatchObject({ filter: "web" });
+    expect(tabFor("/k/pods").view).toMatchObject({ filter: "web", regex: true });
     // Reading the *active* tab would have written the filter here instead, and
     // re-filtered a list the user is not even looking at on every keystroke.
     expect(tabFor("/k/nodes").view).toBeUndefined();

--- a/packages/ui-next/src/screens/Resources.tsx
+++ b/packages/ui-next/src/screens/Resources.tsx
@@ -18,6 +18,7 @@ import {
   SideRail,
   Table,
   filterTableData,
+  tableFilterError,
   type Column,
 } from "@srelens/ui-kit";
 import { useConsole } from "../console";
@@ -191,7 +192,17 @@ function KindList({
   // Sort, filter text and filter column live on the tab — see
   // `useResourceTabView`'s own comment for why, and why `filterKey` is
   // derived rather than merely cleared when this screen hides a column.
-  const { tabId, sort, filter, filterKey, setFilter, setSort, setFilterKey } = useResourceTabView(route, columns);
+  const {
+    tabId,
+    sort,
+    filter,
+    filterKey,
+    regex,
+    setFilter,
+    setSort,
+    setFilterKey,
+    setRegex,
+  } = useResourceTabView(route, columns);
 
   const rows = useMemo(
     () =>
@@ -201,9 +212,10 @@ function KindList({
     [list.rows, clusterScoped, selection],
   );
   const filtered = useMemo(
-    () => filterTableData(rows, columns, filter, filterKey),
-    [rows, columns, filter, filterKey],
+    () => filterTableData(rows, columns, filter, filterKey, regex),
+    [rows, columns, filter, filterKey, regex],
   );
+  const invalidFilter = tableFilterError(filter, regex) !== null;
 
   // Called unconditionally — same reason every hook above it is: the guard
   // for "no descriptor yet" is a `return` below, not a skip, and a hook
@@ -486,6 +498,9 @@ function KindList({
       <FilterBar
         value={filter}
         onValueChange={setFilter}
+        regex={regex}
+        onRegexChange={setRegex}
+        invalid={invalidFilter}
         label={`Filter ${lower}`}
         placeholder={`Filter ${lower}…`}
       >

--- a/packages/ui-next/src/screens/Workloads.test.tsx
+++ b/packages/ui-next/src/screens/Workloads.test.tsx
@@ -141,6 +141,18 @@ describe("Workloads", () => {
     expect(watchResource).toHaveBeenCalledTimes(5);
   });
 
+  it("applies regex mode across the combined workload list", async () => {
+    open();
+    await waitFor(() => expect(rowNames()).toHaveLength(5));
+    const input = screen.getByRole("searchbox", { name: "Filter workloads" });
+
+    await userEvent.type(input, "^web-\\d+$");
+    await waitFor(() => expect(rowNames()).toEqual([]));
+    await userEvent.click(screen.getByRole("button", { name: "Use regular expression" }));
+    await waitFor(() => expect(rowNames()).toEqual(["web-1"]));
+    expect(tabFor("/resources").view?.regex).toBe(true);
+  });
+
   it("reads a crash-looping pod's waiting reason in the row, not the phase that hides it", async () => {
     // The row already got its unhealthy dot from `podFlagged`, which asks
     // core. The label asked `row.phase` instead — and a pod whose container

--- a/packages/ui-next/src/screens/Workloads.tsx
+++ b/packages/ui-next/src/screens/Workloads.tsx
@@ -22,6 +22,7 @@ import {
   Table,
   Tabs,
   filterTableData,
+  tableFilterError,
   type Column,
   type ContextMenuItem,
   type StatusKind,
@@ -395,12 +396,23 @@ function WorkloadList({
     [columns, ask],
   );
 
-  const { tabId, sort, filter, filterKey, setFilter, setSort, setFilterKey } = useResourceTabView(route, columns);
+  const {
+    tabId,
+    sort,
+    filter,
+    filterKey,
+    regex,
+    setFilter,
+    setSort,
+    setFilterKey,
+    setRegex,
+  } = useResourceTabView(route, columns);
 
   const filtered = useMemo(
-    () => filterTableData(segmented, columns, filter, filterKey),
-    [segmented, columns, filter, filterKey],
+    () => filterTableData(segmented, columns, filter, filterKey, regex),
+    [segmented, columns, filter, filterKey, regex],
   );
+  const invalidFilter = tableFilterError(filter, regex) !== null;
 
   function onToggleColumn(key: string) {
     toggleColumnVisibility({ key, storageKey: "workloads", hidden, filterKey, tabId });
@@ -442,6 +454,9 @@ function WorkloadList({
       <FilterBar
         value={filter}
         onValueChange={setFilter}
+        regex={regex}
+        onRegexChange={setRegex}
+        invalid={invalidFilter}
         label={`Filter ${lower}`}
         placeholder={`Filter ${lower}…`}
       >

--- a/packages/ui-next/src/screens/resourceShell.tsx
+++ b/packages/ui-next/src/screens/resourceShell.tsx
@@ -189,9 +189,11 @@ export interface ResourceListTabView {
   sort: TableSort | null;
   filter: string;
   filterKey: string | null;
+  regex: boolean;
   setFilter: (value: string) => void;
   setSort: (next: TableSort | null) => void;
   setFilterKey: (key: string | null) => void;
+  setRegex: (on: boolean) => void;
 }
 
 /**
@@ -216,14 +218,17 @@ export function useResourceTabView<T>(route: string, columns: readonly Column<T>
   const sort = view.sort ?? null;
   const filter = view.filter ?? "";
   const filterKey = view.filterKey && columns.some((column) => column.key === view.filterKey) ? view.filterKey : null;
+  const regex = view.regex ?? false;
   return {
     tabId,
     sort,
     filter,
     filterKey,
+    regex,
     setFilter: (value) => setTabView(tabId, { filter: value }),
     setSort: (next) => setTabView(tabId, { sort: next }),
     setFilterKey: (key) => setTabView(tabId, { filterKey: key }),
+    setRegex: (on) => setTabView(tabId, { regex: on }),
   };
 }
 


### PR DESCRIPTION
## Summary

- adds an accessible literal/regex toggle inside the shared filter field
- centralizes regex compilation and invalid-pattern handling in `Table`, preserving rows while the expression is incomplete or invalid
- persists the selected mode per tab and wires it through Resources, Workloads, Events, and Helm lists

## Verification

- focused `FilterBar`, `Table`, tab persistence, and consuming-screen tests
- workspace TypeScript typecheck
- complete frontend test suite with coverage

Closes #406
