### PR TITLE
feat(node): show pods scheduled on each node

### DIFF
--- a/apps/desktop/src-tauri/tests/e2e.rs
+++ b/apps/desktop/src-tauri/tests/e2e.rs
@@ -1296,6 +1296,38 @@ async fn run_suite() {
         2,
         "expected the 2 Deployment pods: {out}"
     );
+    let deployment_node = out["pods"][0]["node"]
+        .as_str()
+        .filter(|node| !node.is_empty())
+        .expect("a scheduled Deployment pod must name its node")
+        .to_string();
+
+    let on_node = h
+        .ok(
+            "k8s.podsOnNode",
+            json!({ "context": ctx, "node": deployment_node }),
+        )
+        .await;
+    let scheduled = on_node["pods"].as_array().expect("podsOnNode pods array");
+    assert!(
+        scheduled
+            .iter()
+            .all(|pod| { pod["node"].as_str() == Some(deployment_node.as_str()) }),
+        "podsOnNode returned a pod from another node: {on_node}"
+    );
+    assert_eq!(
+        scheduled
+            .iter()
+            .filter(|pod| {
+                pod["namespace"] == NS
+                    && pod["name"]
+                        .as_str()
+                        .is_some_and(|name| name.starts_with(DEPLOY))
+            })
+            .count(),
+        2,
+        "both Deployment pods should be found on their node: {on_node}"
+    );
 
     let out = h
         .ok(

--- a/crates/kube/src/watch.rs
+++ b/crates/kube/src/watch.rs
@@ -878,6 +878,7 @@ mod tests {
             restarts: 0,
             node: "n".into(),
             age: "1m".into(),
+            created_at: None,
             image: "nginx:1.27".into(),
             waiting_reason: String::new(),
         }

--- a/crates/kube/src/workloads.rs
+++ b/crates/kube/src/workloads.rs
@@ -38,6 +38,10 @@ pub struct PodSummary {
     pub restarts: i32,
     pub node: String,
     pub age: String,
+    /// RFC 3339 creation time, so frontend surfaces can render an age that
+    /// continues to tick instead of freezing this summary's `age` string.
+    #[serde(rename = "createdAt", skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
     /// Container image(s) the pod runs, e.g. `acme/checkout-api:118a7e`.
     /// A pod with several containers joins them as `"img-a, img-b"`; a pod
     /// with no containers (or no status yet) is `""`.
@@ -147,6 +151,11 @@ pub(crate) fn summarise_pod(pod: Pod) -> PodSummary {
         })
         .unwrap_or_default();
 
+    let created_at = pod
+        .metadata
+        .creation_timestamp
+        .as_ref()
+        .map(|created| created.0.to_string());
     PodSummary {
         name,
         namespace,
@@ -155,9 +164,53 @@ pub(crate) fn summarise_pod(pod: Pod) -> PodSummary {
         restarts,
         node,
         age: crate::humanize_age(pod.metadata.creation_timestamp.as_ref()),
+        created_at,
         image,
         waiting_reason,
     }
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct PodsOnNodeIn {
+    pub context: String,
+    pub node: String,
+}
+
+fn pods_on_node_params(node: &str) -> Result<ListParams, CapabilityError> {
+    if node.trim().is_empty() {
+        return Err(CapabilityError::InvalidInput(
+            "node must not be empty".into(),
+        ));
+    }
+    Ok(ListParams::default().fields(&format!("spec.nodeName={node}")))
+}
+
+/// `k8s.podsOnNode` — list pods scheduled on one node, across namespaces.
+pub fn pods_on_node_capability(cache: Arc<ClientCache>) -> Capability {
+    Capability::typed::<PodsOnNodeIn, ListPodsOut, _, _>(
+        "k8s.podsOnNode",
+        "list pods scheduled on a node across all namespaces",
+        Annotations::READ_ONLY,
+        move |input: PodsOnNodeIn| {
+            let cache = cache.clone();
+            async move {
+                let params = pods_on_node_params(&input.node)?;
+                let client = cache
+                    .get(&input.context)
+                    .await
+                    .map_err(CapabilityError::Handler)?;
+                // A node is cluster-scoped and can host pods from every
+                // namespace, so this query must use the all-namespaces API.
+                let api: Api<Pod> = Api::all(client);
+                let list = tokio::time::timeout(request_timeout(), api.list(&params))
+                    .await
+                    .map_err(|_| CapabilityError::Handler("list pods on node timed out".into()))?
+                    .map_err(handler_err)?;
+                let pods = list.items.into_iter().map(summarise_pod).collect();
+                Ok(ListPodsOut { pods })
+            }
+        },
+    )
 }
 
 /// `k8s.listPods` — list pods in a namespace of a connected context.
@@ -405,7 +458,46 @@ mod tests {
             "k8s.listNamespaces"
         );
         assert_eq!(list_pods_capability(cache.clone()).id, "k8s.listPods");
-        assert_eq!(pods_for_selector_capability(cache).id, "k8s.podsForSelector");
+        assert_eq!(
+            pods_for_selector_capability(cache.clone()).id,
+            "k8s.podsForSelector"
+        );
+        assert_eq!(pods_on_node_capability(cache).id, "k8s.podsOnNode");
+    }
+
+    #[test]
+    fn pods_on_node_uses_the_supported_node_field_selector() {
+        let params = pods_on_node_params("worker-2").unwrap();
+        assert_eq!(
+            params.field_selector.as_deref(),
+            Some("spec.nodeName=worker-2")
+        );
+        assert!(pods_on_node_params("").is_err());
+        assert!(pods_on_node_params("   ").is_err());
+    }
+
+    #[test]
+    fn pod_summary_carries_the_creation_timestamp_for_live_ages() {
+        let pod = Pod {
+            metadata: kube::core::ObjectMeta {
+                name: Some("web-1".into()),
+                namespace: Some("default".into()),
+                creation_timestamp: Some(k8s_openapi::apimachinery::pkg::apis::meta::v1::Time(
+                    "2026-08-20T00:00:00Z".parse().unwrap(),
+                )),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let summary = summarise_pod(pod);
+        assert_eq!(summary.created_at.as_deref(), Some("2026-08-20T00:00:00Z"));
+    }
+
+    #[test]
+    fn pod_summary_omits_an_unknown_creation_timestamp() {
+        let summary = summarise_pod(Pod::default());
+        let json = serde_json::to_value(summary).unwrap();
+        assert!(!json.as_object().unwrap().contains_key("createdAt"));
     }
 
     #[test]

--- a/crates/registry/src/lib.rs
+++ b/crates/registry/src/lib.rs
@@ -256,6 +256,9 @@ pub fn build_registry_with_paths_and_settings(
     reg.register(srelens_kube::workloads::pods_for_selector_capability(
         cache.clone(),
     ));
+    reg.register(srelens_kube::workloads::pods_on_node_capability(
+        cache.clone(),
+    ));
     reg.register(srelens_kube::logs::pod_logs_capability(cache.clone()));
     reg.register(srelens_kube::deployments::list_deployments_capability(
         cache.clone(),

--- a/docs/mcp-catalog.md
+++ b/docs/mcp-catalog.md
@@ -5,11 +5,11 @@
 
 Everything this server exposes over MCP, generated from the live registry so it cannot drift. Written for someone wiring an agent to srelens; the narrative reference is [MCP.md](MCP.md).
 
-## Tools (87)
+## Tools (88)
 
 Argument schemas are not reproduced here — call `tools/list` for those, which cannot go stale.
 
-### Kubernetes — read-only (49)
+### Kubernetes — read-only (50)
 
 | Tool | Summary |
 | --- | --- |
@@ -59,6 +59,7 @@ Argument schemas are not reproduced here — call `tools/list` for those, which 
 | `k8s.podsForPvc` | list pods in a namespace that mount a given PersistentVolumeClaim |
 | `k8s.podsForSelector` | list pods matching a label selector (a workload's managed pods) |
 | `k8s.podsForServiceAccount` | list pods in a namespace running as a given ServiceAccount |
+| `k8s.podsOnNode` | list pods scheduled on a node across all namespaces |
 | `k8s.synthesizeClusterKubeconfig` | synthesize a one-context kubeconfig from Add-cluster form fields |
 | `k8s.testClusterConnection` | probe a kubeconfig context's server reachability (no exec plugins run) |
 | `k8s.validateManifest` | validate a resource manifest against the API server (dry-run, strict) |

--- a/packages/core/src/lib/capability-catalog.json
+++ b/packages/core/src/lib/capability-catalog.json
@@ -414,6 +414,12 @@
     "requiresConfirm": false
   },
   {
+    "id": "k8s.podsOnNode",
+    "readOnly": true,
+    "destructive": false,
+    "requiresConfirm": false
+  },
+  {
     "id": "k8s.rolloutRestart",
     "readOnly": false,
     "destructive": false,

--- a/packages/core/src/lib/workloads.test.ts
+++ b/packages/core/src/lib/workloads.test.ts
@@ -7,6 +7,7 @@ import {
   listServices,
   listReplicaSets,
   podsForSelector,
+  podsOnNode,
   podMetrics,
   deletePod,
   evictPod,
@@ -226,6 +227,27 @@ describe("podsForSelector", () => {
 
   it("normalises errors", async () => {
     const outcome = await podsForSelector("x", "default", {}, [], () =>
+      Promise.reject(new Error("forbidden")),
+    );
+    expect(outcome.pods).toBeUndefined();
+    expect(outcome.error).toContain("forbidden");
+  });
+});
+
+describe("podsOnNode", () => {
+  it("passes context and node and returns timestamped pods", async () => {
+    const pods = [{ name: "web-1", namespace: "default", createdAt: "2026-08-20T00:00:00Z" }];
+    const invoke = vi.fn().mockResolvedValue({ pods });
+    const outcome = await podsOnNode("kind-dev", "worker-2", invoke);
+    expect(invoke).toHaveBeenCalledWith("k8s.podsOnNode", {
+      context: "kind-dev",
+      node: "worker-2",
+    });
+    expect(outcome.pods).toEqual(pods);
+  });
+
+  it("normalises errors", async () => {
+    const outcome = await podsOnNode("x", "worker-2", () =>
       Promise.reject(new Error("forbidden")),
     );
     expect(outcome.pods).toBeUndefined();

--- a/packages/core/src/lib/workloads.ts
+++ b/packages/core/src/lib/workloads.ts
@@ -8,6 +8,8 @@ export interface PodSummary {
   restarts: number;
   node: string;
   age: string;
+  /** RFC 3339 creation time for frontend surfaces whose age must keep ticking. */
+  createdAt?: string;
   /** Container image(s) the pod runs; multiple containers are comma-joined,
    *  e.g. "acme/checkout-api:118a7e, envoyproxy/envoy:v1.30". Empty when the
    *  pod has no containers. */
@@ -202,6 +204,20 @@ export async function podsForSelector(
       selector,
       ...(expressions.length === 0 ? {} : { matchExpressions: expressions }),
     });
+    return { pods: out.pods };
+  } catch (e) {
+    return { error: String(e) };
+  }
+}
+
+/** Pods scheduled on one node across all namespaces via `k8s.podsOnNode`. */
+export async function podsOnNode(
+  context: string,
+  node: string,
+  invoke: Invoker = invokeCapability,
+): Promise<PodsOutcome> {
+  try {
+    const out = await invoke<{ pods: PodSummary[] }>("k8s.podsOnNode", { context, node });
     return { pods: out.pods };
   } catch (e) {
     return { error: String(e) };

--- a/packages/ui-next/src/screens/detail/NodePodsSection.test.tsx
+++ b/packages/ui-next/src/screens/detail/NodePodsSection.test.tsx
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import type { ClusterContext, PodSummary } from "@srelens/core";
+
+const { podsOnNode } = vi.hoisted(() => ({
+  podsOnNode: vi.fn(),
+}));
+
+vi.mock("@srelens/core", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@srelens/core")>()),
+  podsOnNode,
+}));
+
+import { defaultState } from "../../lib/tabs";
+import * as store from "../../lib/tabsStore";
+import { NodePodsSection } from "./sections";
+
+const NOW = Date.parse("2026-09-01T12:00:00Z");
+const CTX: ClusterContext = {
+  name: "prod-eu",
+  stableId: "prod",
+  cluster: "prod",
+  server: "https://prod",
+  isCurrent: true,
+  sourceFile: "/home/dana/.kube/config",
+  authKind: "client certificate",
+};
+
+function pod(i: number): PodSummary {
+  return {
+    name: `pod-${String(i).padStart(2, "0")}`,
+    namespace: i % 2 === 0 ? "default" : "kube-system",
+    phase: "Running",
+    ready: "1/1",
+    restarts: 0,
+    node: "worker-2",
+    age: "stale",
+    createdAt: new Date(NOW - 15_000).toISOString(),
+    image: "example.test/app:1",
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+  podsOnNode.mockReset();
+  podsOnNode.mockResolvedValue({ pods: Array.from({ length: 14 }, (_, i) => pod(i)) });
+  store.setState(defaultState([CTX]));
+});
+
+afterEach(() => vi.useRealTimers());
+
+describe("NodePodsSection", () => {
+  it("lists a capped, stable slice with the true total and live ages", async () => {
+    render(<NodePodsSection context="prod-eu" node="worker-2" />);
+    await act(async () => Promise.resolve());
+
+    expect(podsOnNode).toHaveBeenCalledWith("prod-eu", "worker-2");
+    expect(screen.getByRole("heading", { level: 3, name: "Pods (14)" })).toBeDefined();
+    expect(screen.getAllByRole("row")).toHaveLength(13);
+    expect(screen.getByRole("button", { name: "Sort by Pod" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Sort by Namespace" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Sort by Age" })).toBeDefined();
+    expect(screen.getAllByText("15s")).toHaveLength(12);
+
+    act(() => vi.advanceTimersByTime(30_000));
+    expect(screen.getAllByText("45s")).toHaveLength(12);
+  });
+
+  it("opens a pod detail from a row and the node-filtered Pods list from View all", async () => {
+    render(<NodePodsSection context="prod-eu" node="worker-2" />);
+    await act(async () => Promise.resolve());
+
+    fireEvent.click(screen.getByText("pod-00"));
+    expect(store.activeRoute()).toBe("/k/Pod/default/pod-00");
+
+    fireEvent.click(screen.getByRole("button", { name: "View all 14 pods on worker-2" }));
+    expect(store.activeRoute()).toBe("/k/pods");
+    const tab = store.currentWorkspace().tabs.find((candidate) => candidate.route === "/k/pods");
+    expect(tab?.view).toMatchObject({ filter: "worker-2", filterKey: "node" });
+  });
+
+  it("keeps loading, refusal and an empty node distinct", async () => {
+    podsOnNode.mockImplementation(() => new Promise(() => {}));
+    const view = render(<NodePodsSection context="prod-eu" node="worker-2" />);
+    expect(screen.getByText("Loading pods on worker-2")).toBeDefined();
+
+    podsOnNode.mockResolvedValue({ error: "forbidden" });
+    await act(async () => {
+      view.rerender(<NodePodsSection context="prod-eu" node="worker-3" />);
+      await Promise.resolve();
+    });
+    expect(screen.getByText(/doesn't have permission/)).toBeDefined();
+    expect(screen.getByText("forbidden")).toBeDefined();
+
+    podsOnNode.mockResolvedValue({ pods: [] });
+    await act(async () => {
+      view.rerender(<NodePodsSection context="prod-eu" node="worker-4" />);
+      await Promise.resolve();
+    });
+    expect(screen.getByText("No pods on this node")).toBeDefined();
+  });
+});

--- a/packages/ui-next/src/screens/detail/ResourceDetailView.test.tsx
+++ b/packages/ui-next/src/screens/detail/ResourceDetailView.test.tsx
@@ -12,7 +12,7 @@ import type { KindDescriptor, ListRow } from "../../lib/kinds/types";
 // manifest. All four are core's, mocked here so a test controls what "the
 // cluster said" without one — `importOriginal` keeps everything else
 // (K8S_KIND, and the real types) intact.
-const { getObject, getManifest, listEvents, listCrds, deleteResource } = vi.hoisted(() => ({
+const { getObject, getManifest, listEvents, listCrds, deleteResource, podsOnNode } = vi.hoisted(() => ({
   getObject: vi.fn(async (): Promise<{ object?: K8sObject; error?: string }> => ({})),
   getManifest: vi.fn(async (): Promise<{ yaml?: string; error?: string }> => ({ yaml: "" })),
   listEvents: vi.fn(async (): Promise<{ events?: EventSummary[]; error?: string }> => ({ events: [] })),
@@ -20,6 +20,7 @@ const { getObject, getManifest, listEvents, listCrds, deleteResource } = vi.hois
   // The footer's actions are the row menu's, so the one write a test reaches
   // for is mocked here too — a confirm that is never taken must reach nothing.
   deleteResource: vi.fn(async (): Promise<{ error?: string }> => ({})),
+  podsOnNode: vi.fn(async () => ({ pods: [] })),
 }));
 
 vi.mock("@srelens/core", async (importOriginal) => ({
@@ -29,6 +30,7 @@ vi.mock("@srelens/core", async (importOriginal) => ({
   listEvents,
   listCrds,
   deleteResource,
+  podsOnNode,
 }));
 
 // The shell asks the same descriptor the list screen resolves, only to read
@@ -193,6 +195,7 @@ describe("ResourceDetailView", () => {
     getManifest.mockResolvedValue({ yaml: "kind: Pod\n" });
     listEvents.mockResolvedValue({ events: [] });
     listCrds.mockResolvedValue({ crds: [] });
+    podsOnNode.mockResolvedValue({ pods: [] });
     descriptorFor.mockReturnValue(undefined);
     codeEditorProps.length = 0;
     asked.length = 0;
@@ -255,6 +258,24 @@ describe("ResourceDetailView", () => {
     const { getByRole, queryByRole } = render(<ResourceDetailView context="ctx" kind="Node" namespace={null} name="n1" />);
     await waitFor(() => expect(getByRole("tab", { name: "Metrics" })).toBeDefined());
     expect(queryByRole("tab", { name: "Containers" })).toBeNull();
+  });
+
+  it("places a Node's scheduled pods after its annotations", async () => {
+    getObject.mockResolvedValue({
+      object: {
+        kind: "Node",
+        apiVersion: "v1",
+        metadata: { name: "n1", labels: { zone: "east" }, annotations: { owner: "sre" } },
+      },
+    });
+    descriptorFor.mockReturnValue(baseDescriptor({ k8sKind: "Node", scope: "cluster" }));
+    setSectionOpen("Node", "Pods", true);
+    render(<ResourceDetailView context="ctx" kind="Node" namespace={null} name="n1" />);
+
+    const podsHeading = await screen.findByRole("heading", { level: 3, name: "Pods (0)" });
+    const annotations = screen.getByRole("heading", { level: 3, name: "Annotations" }).closest("section")!;
+    const pods = podsHeading.closest("section")!;
+    expect(annotations.compareDocumentPosition(pods) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
   });
 
   it("loads YAML and Events lazily, only once each pane is opened, and never refetches a pane already opened", async () => {

--- a/packages/ui-next/src/screens/detail/ResourceDetailView.tsx
+++ b/packages/ui-next/src/screens/detail/ResourceDetailView.tsx
@@ -237,6 +237,7 @@ export function ResourceDetailView({ context, kind, namespace, name, peek }: Res
         {subject.body}
         {subject.labels}
         {subject.annotations}
+        {subject.afterMetadata}
       </>
     ) : null;
   if (active === PANE_CONTAINERS) pane = subject.containersPane;

--- a/packages/ui-next/src/screens/detail/ResourceTabView.test.tsx
+++ b/packages/ui-next/src/screens/detail/ResourceTabView.test.tsx
@@ -9,13 +9,14 @@ import type { KindDescriptor, ListRow } from "../../lib/kinds/types";
 // The reads behind the tab: the object itself, the pod usage its CPU and
 // Memory tiles show, and the two pane fetches it inherits from the shared
 // pane machinery.
-const { getObject, getManifest, listEvents, listCrds, podMetrics, podsForSelector } = vi.hoisted(() => ({
+const { getObject, getManifest, listEvents, listCrds, podMetrics, podsForSelector, podsOnNode } = vi.hoisted(() => ({
   getObject: vi.fn(async (): Promise<{ object?: K8sObject; error?: string }> => ({})),
   getManifest: vi.fn(async (): Promise<{ yaml?: string; error?: string }> => ({ yaml: "" })),
   listEvents: vi.fn(async () => ({ events: [] })),
   listCrds: vi.fn(async () => ({ crds: [] })),
   podMetrics: vi.fn(async (): Promise<{ metrics?: PodMetric[]; error?: string }> => ({ metrics: [] })),
   podsForSelector: vi.fn(async () => ({ pods: [] })),
+  podsOnNode: vi.fn(async () => ({ pods: [] })),
 }));
 
 vi.mock("@srelens/core", async (importOriginal) => ({
@@ -26,6 +27,7 @@ vi.mock("@srelens/core", async (importOriginal) => ({
   listCrds,
   podMetrics,
   podsForSelector,
+  podsOnNode,
 }));
 
 const { descriptorFor } = vi.hoisted(() => ({
@@ -183,6 +185,24 @@ describe("ResourceTabView — the full tab the design draws", () => {
         "prod-eu",
         "Node",
       ]);
+    });
+
+    it("places a Node's scheduled pods after the Labels/Annotations pair", async () => {
+      getObject.mockResolvedValue({
+        object: {
+          kind: "Node",
+          apiVersion: "v1",
+          metadata: { name: "worker-1", labels: { zone: "east" }, annotations: { owner: "sre" } },
+        },
+      });
+      podsOnNode.mockResolvedValue({ pods: [] });
+      descriptorFor.mockReturnValue(podDescriptor({ k8sKind: "Node", panes: {} }));
+      setSectionOpen("Node", "Pods", true);
+      await openPod({ kind: "Node", namespace: null, name: "worker-1" });
+
+      const pair = document.querySelector<HTMLElement>('[data-slot="metadata-pair"]')!;
+      const pods = (await screen.findByRole("heading", { level: 3, name: "Pods (0)" })).closest("section")!;
+      expect(pair.compareDocumentPosition(pods) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
     });
 
     it("puts the actions in the header row, not in a footer bar", async () => {

--- a/packages/ui-next/src/screens/detail/ResourceTabView.tsx
+++ b/packages/ui-next/src/screens/detail/ResourceTabView.tsx
@@ -249,6 +249,7 @@ export function ResourceTabView({ context, kind, namespace, name }: ResourceTabV
           <div>{subject.labels}</div>
           <div className="rule-l">{subject.annotations}</div>
         </div>
+        {subject.afterMetadata}
       </>
     ) : null;
   if (active === PANE_METRICS) pane = subject.metricsPane;

--- a/packages/ui-next/src/screens/detail/detailData.tsx
+++ b/packages/ui-next/src/screens/detail/detailData.tsx
@@ -31,7 +31,7 @@ import { GenericBody, identityFacts } from "./GenericBody";
 import { JobDetailsBody } from "./JobBody";
 import { NodeDetailsBody } from "./NodeBody";
 import { PodContainersBody, PodContainersTable, PodDetailsBody, podFacts } from "./PodBody";
-import { AnnotationsSection, LabelsSection } from "./sections";
+import { AnnotationsSection, LabelsSection, NodePodsSection } from "./sections";
 import { SecretDetailsBody } from "./SecretBody";
 import { ServiceDetailsBody } from "./ServiceBody";
 import { useDeployRevisions, WorkloadDetailsBody, workloadFacts, type RevisionsState } from "./WorkloadBody";
@@ -371,6 +371,8 @@ export interface DetailSubject {
    *  comment gives: a Secret's annotation can be the secret. */
   labels: ReactNode;
   annotations: ReactNode;
+  /** A kind-specific block that both hosts place after their metadata layout. */
+  afterMetadata: ReactNode;
   /** This kind's manifest goes through `redactSecretManifest`. */
   isSecret: boolean;
 }
@@ -444,6 +446,8 @@ export function useDetailSubject({
     metricsPane: bodyProps && MetricsBody ? createElement(MetricsBody, bodyProps) : null,
     labels: <LabelsSection labels={meta.labels ?? {}} />,
     annotations: <AnnotationsSection kind={kind} annotations={meta.annotations ?? {}} />,
+    afterMetadata:
+      object && kind === "Node" ? <NodePodsSection context={context} node={name} /> : null,
     isSecret: kind === "Secret",
   };
 }

--- a/packages/ui-next/src/screens/detail/sections.test.tsx
+++ b/packages/ui-next/src/screens/detail/sections.test.tsx
@@ -305,6 +305,7 @@ describe("one definition each, across every detail body", () => {
     "AnnotationsToggle",
     "AnnotationLines",
     "RelatedPodsSection",
+    "NodePodsSection",
     "ConditionsSection",
   ];
 

--- a/packages/ui-next/src/screens/detail/sections.tsx
+++ b/packages/ui-next/src/screens/detail/sections.tsx
@@ -5,19 +5,22 @@
  * before it was written once, and every copy had drifted from the others by
  * the time they were compared. (#331)
  *
- * The file was `ConditionsSection.tsx` while it held one block. It holds seven
+ * The file was `ConditionsSection.tsx` while it held one block. It holds eight
  * now — `StringList`, `LabelsSection`, `AnnotationsSection`,
  * `AnnotationsToggle`, `AnnotationLines`, `ConditionsSection` and
- * `RelatedPodsSection`, the same seven `sections.test.tsx` sweeps for exactly
+ * `RelatedPodsSection`, and `NodePodsSection`, the same eight
+ * `sections.test.tsx` sweeps for exactly
  * one definition of — so it is named for what it is: this design's shared
  * detail sections.
  */
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
+  ageFromTimestamp,
   conditionKindWithReason,
   plural,
   podMetrics,
   podsForSelector,
+  podsOnNode,
   podStatus,
   type Condition,
   type PodMetric,
@@ -36,6 +39,8 @@ import { Section } from "./Section";
 import { SectionFailure, useSectionList } from "./sectionList";
 import { formatCpu, formatMemory } from "../../lib/kinds/columns";
 import type { WorkloadSelector } from "../../lib/workloadSelector";
+import { detailRoute } from "../../lib/detailRoute";
+import { currentWorkspace, openTab, setTabView } from "../../lib/tabsStore";
 
 /**
  * A formatted list, one item per line — a pod's IPs, an owner reference, a
@@ -405,6 +410,84 @@ export function RelatedPodsSection({
         <SectionFailure error={state.error} />
       ) : (
         <Table columns={RELATED_POD_COLUMNS} data={state.data ?? []} getRowKey={(p) => p.name} emptyText="No pods" />
+      )}
+    </Section>
+  );
+}
+
+const NODE_POD_LIMIT = 12;
+const NODE_POD_AGE_TICK_MS = 30_000;
+
+interface NodePodRow extends PodSummary {
+  liveAge: string;
+}
+
+const NODE_POD_COLUMNS: Column<NodePodRow>[] = [
+  { key: "name", header: "Pod", render: (pod) => <span className="font-mono">{pod.name}</span> },
+  {
+    key: "namespace",
+    header: "Namespace",
+    render: (pod) => <span className="font-mono">{pod.namespace || "—"}</span>,
+  },
+  { key: "liveAge", header: "Age", align: "end", render: (pod) => pod.liveAge },
+];
+
+/** Pods scheduled on a Node, queried by `spec.nodeName` across namespaces. */
+export function NodePodsSection({ context, node }: { context: string; node: string }) {
+  const state = useSectionList<PodSummary[]>(true, [context, node], async () => {
+    const out = await podsOnNode(context, node);
+    if (out.error) return { error: out.error };
+    const pods = [...(out.pods ?? [])].sort(
+      (a, b) => a.namespace.localeCompare(b.namespace) || a.name.localeCompare(b.name),
+    );
+    return { data: pods };
+  });
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const tick = setInterval(() => setNow(Date.now()), NODE_POD_AGE_TICK_MS);
+    return () => clearInterval(tick);
+  }, []);
+
+  const all = state.data ?? [];
+  const rows: NodePodRow[] = all.slice(0, NODE_POD_LIMIT).map((pod) => ({
+    ...pod,
+    liveAge: ageFromTimestamp(pod.createdAt, now),
+  }));
+  const openPod = (pod: NodePodRow) =>
+    openTab(detailRoute("Pod", pod.namespace, pod.name), { clusterName: context });
+  const viewAll = () => {
+    openTab("/k/pods", { clusterName: context });
+    setTabView(currentWorkspace().activeId, { filter: node, filterKey: "node" });
+  };
+
+  return (
+    <Section title={state.status === "ready" ? `Pods (${all.length})` : "Pods"} id="Pods">
+      {state.status === "loading" ? (
+        <LoadingState label={`Loading pods on ${node}`} />
+      ) : state.status === "error" ? (
+        <SectionFailure error={state.error} />
+      ) : (
+        <>
+          <Table
+            columns={NODE_POD_COLUMNS}
+            data={rows}
+            getRowKey={(pod) => `${pod.namespace}/${pod.name}`}
+            emptyText="No pods on this node"
+            onRowClick={openPod}
+            onRowActivate={openPod}
+          />
+          {all.length > NODE_POD_LIMIT && (
+            <div className="mt-2 flex justify-end">
+              <Button
+                size="xs"
+                onClick={viewAll}
+                aria-label={`View all ${all.length} pods on ${node}`}
+              >
+                View all
+              </Button>
+            </div>
+          )}
+        </>
       )}
     </Section>
   );


### PR DESCRIPTION
## Summary

- adds the read-only `k8s.podsOnNode` capability using Kubernetes' supported `spec.nodeName` field selector across all namespaces
- adds a typed core wrapper and keeps pod age live from the source creation timestamp
- renders a bounded, sortable Node detail section with Pod, Namespace, and Age; rows open the pod and overflow links to the prefiltered Pods list
- updates the capability catalog and both detail hosts

## Verification

- focused Rust selector/summary tests and Node detail integration tests
- complete Rust workspace test suite
- workspace TypeScript typecheck and complete frontend suite with coverage

Closes #409
