### PR TITLE
fix(copy): add shared inline clipboard feedback

### DIFF
--- a/packages/ui-kit/src/ActionBar.test.tsx
+++ b/packages/ui-kit/src/ActionBar.test.tsx
@@ -155,6 +155,16 @@ describe("ActionBar", () => {
       expect(screen.queryByRole("dialog")).toBeNull();
     });
 
+    it("can keep a feedback-bearing action visible after it runs", async () => {
+      setup({
+        max: 1,
+        actions: [action("Logs"), action("Copy", { closeOnSelect: false })],
+      });
+      await openMenu();
+      await userEvent.click(screen.getByRole("button", { name: "Copy" }));
+      expect(screen.getByRole("dialog")).toBeDefined();
+    });
+
     it("offers no menu when everything fits", () => {
       setup({ max: 4 });
       expect(screen.queryByRole("button", { name: "More actions" })).toBeNull();

--- a/packages/ui-kit/src/ActionBar.tsx
+++ b/packages/ui-kit/src/ActionBar.tsx
@@ -19,6 +19,8 @@ export interface ActionBarAction {
    * a blocked action with no explanation is worse than no action at all.
    */
   disabledReason?: string;
+  /** Keep an overflow row open while its transient result replaces the label. */
+  closeOnSelect?: boolean;
   onSelect: () => void;
 }
 
@@ -176,7 +178,7 @@ export function ActionBar({
                       // Left open on purpose: a menu that shuts looks like the
                       // action was taken.
                       if (blocked) return;
-                      close();
+                      if (a.closeOnSelect !== false) close();
                       a.onSelect();
                     }}
                   >

--- a/packages/ui-kit/src/ContextMenu.test.tsx
+++ b/packages/ui-kit/src/ContextMenu.test.tsx
@@ -90,6 +90,14 @@ describe("ContextMenu", () => {
     await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
   });
 
+  it("can keep a feedback-bearing item visible after it is picked", async () => {
+    const onPick = vi.fn();
+    await open({ items: [{ label: "Copy", closeOnPick: false, onPick }] });
+    fireEvent.click(screen.getByRole("menuitem", { name: "Copy" }));
+    expect(onPick).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("menu")).toBeDefined();
+  });
+
   it("draws a separator that is not itself an item", async () => {
     await open();
     const menu = screen.getByRole("menu");

--- a/packages/ui-kit/src/ContextMenu.tsx
+++ b/packages/ui-kit/src/ContextMenu.tsx
@@ -19,6 +19,8 @@ export type ContextMenuItem =
       hint?: string;
       /** Tints the row with the danger colour, over a label that already says so. */
       danger?: boolean;
+      /** Keep the menu open while transient feedback replaces this row's label. */
+      closeOnPick?: boolean;
       onPick: () => void;
     };
 
@@ -118,7 +120,10 @@ export function ContextMenu({ items, children, label, onOpenChange }: ContextMen
                 // what the item does nor what a speech-input user would say to
                 // reach it. (#320)
                 aria-label={item.label}
-                onSelect={item.onPick}
+                onSelect={(event) => {
+                  if (item.closeOnPick === false) event.preventDefault();
+                  item.onPick();
+                }}
               >
                 {/* Always taken, filled or not: the design lines the labels up
                     in a column, and an icon present on only some items shoves

--- a/packages/ui-kit/src/CopyCommand.test.tsx
+++ b/packages/ui-kit/src/CopyCommand.test.tsx
@@ -61,7 +61,7 @@ describe("CopyCommand", () => {
     expect(container.querySelector(".copy-command-check")).not.toBeNull();
   });
 
-  it("leaves the command readable on a machine with no clipboard", async () => {
+  it("keeps the command readable and reports a clipboard failure", async () => {
     // A non-secure origin has no `navigator.clipboard`. The command is still
     // the thing the reader came for: it stays on screen and selectable, and
     // the button does not claim to have copied anything.
@@ -72,7 +72,9 @@ describe("CopyCommand", () => {
       fireEvent.click(copyButton());
     });
 
-    expect(screen.getByRole("button", { name: "Copy" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Copy failed" })).toBeDefined();
+    expect(screen.getByRole("status").textContent).toBe("Could not copy to clipboard");
+    expect(screen.queryByRole("button", { name: "Copied" })).toBeNull();
     expect(container.querySelector("code")?.textContent).toBe(COMMAND);
   });
 

--- a/packages/ui-kit/src/CopyCommand.tsx
+++ b/packages/ui-kit/src/CopyCommand.tsx
@@ -1,38 +1,16 @@
-import { useEffect, useState } from "react";
 import { Button } from "./Button";
+import {
+  ClipboardCopyStatus,
+  CopyFailureGlyph,
+  CopySuccessGlyph,
+  useClipboardCopy,
+} from "./clipboardCopy";
 import { cx } from "./cx";
-
-/** How long the button stays flipped after a copy, from the design's §12. */
-const COPIED_MS = 1400;
 
 export interface CopyCommandProps {
   /** The command, shown in full and copied verbatim. */
   command: string;
   className?: string;
-}
-
-/* Inline rather than an icon-set import: the kit takes no dependency on
-   lucide, and this is the only glyph it needs — the same reason
-   `KubectlPreview` inlines its own. */
-function CheckGlyph() {
-  return (
-    <svg
-      className="copy-command-check"
-      width="12"
-      height="12"
-      viewBox="0 0 24 24"
-      fill="none"
-      aria-hidden="true"
-    >
-      <path
-        d="m5 13 4 4 10-10"
-        stroke="currentColor"
-        strokeWidth="3"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
 }
 
 /**
@@ -79,32 +57,18 @@ function CheckGlyph() {
  * over the top of it, which would be a second string saying the same thing.
  */
 export function CopyCommand({ command, className }: CopyCommandProps) {
-  const [copied, setCopied] = useState(false);
-
-  useEffect(() => {
-    if (!copied) return;
-    const timer = setTimeout(() => setCopied(false), COPIED_MS);
-    return () => clearTimeout(timer);
-  }, [copied]);
-
-  async function copy() {
-    try {
-      await navigator.clipboard.writeText(command);
-      setCopied(true);
-    } catch {
-      // No clipboard on a non-secure origin, and nothing to recover: the
-      // command is rendered in full beside the button and can be selected.
-      // Saying "Copied" when nothing was copied would be the only real harm.
-    }
-  }
+  const copy = useClipboardCopy();
+  const status = copy.statusFor(command);
 
   return (
     <div className={cx("copy-command", className)}>
       <code className="code copy-command-text">{command}</code>
-      <Button variant="ghost" size="xs" onClick={() => void copy()}>
-        {copied && <CheckGlyph />}
-        {copied ? "Copied" : "Copy"}
+      <Button variant="ghost" size="xs" onClick={() => void copy.write(command, command)}>
+        {status === "copied" && <CopySuccessGlyph aria-hidden="true" />}
+        {status === "failed" && <CopyFailureGlyph aria-hidden="true" />}
+        {status === "copied" ? "Copied" : status === "failed" ? "Copy failed" : "Copy"}
       </Button>
+      <ClipboardCopyStatus feedback={copy.feedback} />
     </div>
   );
 }

--- a/packages/ui-kit/src/KubectlPreview.test.tsx
+++ b/packages/ui-kit/src/KubectlPreview.test.tsx
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { act, render, screen, fireEvent } from "@testing-library/react";
 import { KubectlPreview } from "./KubectlPreview";
+
+function stubClipboard(writeText: (text: string) => Promise<void>) {
+  Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+}
 
 /** The classic component's tests, carried over. (#318) */
 describe("KubectlPreview", () => {
@@ -16,20 +20,24 @@ describe("KubectlPreview", () => {
     expect(screen.queryByText("Equivalent kubectl:")).toBeNull();
   });
 
-  it("omits the copy button when no onCopy handler is given", () => {
+  it("offers to copy every command without asking each caller to wire the clipboard", () => {
     render(<KubectlPreview command="kubectl get pods web-0 --context prod" />);
-    expect(screen.queryByRole("button", { name: "Copy kubectl command" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Copy kubectl command" })).toBeDefined();
   });
 
-  it("fires onCopy when the copy button is clicked", () => {
-    const onCopy = vi.fn();
-    render(<KubectlPreview command="kubectl get pods web-0 --context prod" onCopy={onCopy} />);
-    fireEvent.click(screen.getByRole("button", { name: "Copy kubectl command" }));
-    expect(onCopy).toHaveBeenCalledTimes(1);
+  it("copies the command and confirms with a check and a polite announcement", async () => {
+    const writeText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined);
+    stubClipboard(writeText);
+    const { container } = render(<KubectlPreview command="kubectl get pods web-0 --context prod" />);
+    await act(async () => fireEvent.click(screen.getByRole("button", { name: "Copy kubectl command" })));
+    expect(writeText).toHaveBeenCalledWith("kubectl get pods web-0 --context prod");
+    expect(screen.getByRole("button", { name: "Copied" })).toBeDefined();
+    expect(container.querySelector(".copy-command-check")).not.toBeNull();
+    expect(screen.getByRole("status").textContent).toBe("Copied to clipboard");
   });
 
   it("names the copy control for a pointer as well as a screen reader", () => {
-    render(<KubectlPreview command="kubectl delete pod web-0" onCopy={() => {}} />);
+    render(<KubectlPreview command="kubectl delete pod web-0" />);
     const button = screen.getByRole("button", { name: "Copy kubectl command" });
     expect(button.getAttribute("title")).toBe("Copy kubectl command");
   });
@@ -38,7 +46,7 @@ describe("KubectlPreview", () => {
     // The button already carries the name; an unlabelled graphic announced
     // beside it would be read twice.
     const { container } = render(
-      <KubectlPreview command="kubectl delete pod web-0" onCopy={() => {}} />,
+      <KubectlPreview command="kubectl delete pod web-0" />,
     );
     const glyph = container.querySelector("svg");
     expect(glyph).not.toBeNull();
@@ -49,7 +57,7 @@ describe("KubectlPreview", () => {
     // This preview lives inside confirm dialogs, which are forms; a bare
     // button submits the one it is standing in, confirming the action the
     // user was only reading about. (#318)
-    render(<KubectlPreview command="kubectl delete pod web-0" onCopy={() => {}} />);
+    render(<KubectlPreview command="kubectl delete pod web-0" />);
     expect(screen.getByRole("button", { name: "Copy kubectl command" }).getAttribute("type")).toBe(
       "button",
     );

--- a/packages/ui-kit/src/KubectlPreview.tsx
+++ b/packages/ui-kit/src/KubectlPreview.tsx
@@ -1,14 +1,18 @@
 import { cx } from "./cx";
 import { filled } from "./slot";
 import { IconButton, type IconComponent } from "./IconButton";
+import {
+  ClipboardCopyStatus,
+  CopyFailureGlyph,
+  CopySuccessGlyph,
+  useClipboardCopy,
+} from "./clipboardCopy";
 
 export interface KubectlPreviewProps {
   /** The kubectl-equivalent command. Omit (and pass `note` instead) when there's no faithful one-liner. */
   command?: string;
   /** Shown instead of a command when no clean kubectl equivalent exists (e.g. evict). */
   note?: string;
-  /** Copy-to-clipboard handler; renders a copy affordance next to `command` when set. */
-  onCopy?: () => void;
   className?: string;
 }
 
@@ -44,16 +48,26 @@ const CopyGlyph: IconComponent = ({ size = 14, ...rest }) => (
  * top margin. Commands are long and dialogs are narrow, so the line wraps
  * rather than truncating — a preview you cannot finish reading is not one. (#318)
  */
-export function KubectlPreview({ command, note, onCopy, className }: KubectlPreviewProps) {
+export function KubectlPreview({ command, note, className }: KubectlPreviewProps) {
+  const copy = useClipboardCopy();
   if (!filled(command)) {
     if (!filled(note)) return null;
     return <p className={cx("mt-2 text-xs text-muted", className)}>{note}</p>;
   }
+  const copyCommand = command as string;
+  const status = copy.statusFor(copyCommand);
+  const icon = status === "copied" ? CopySuccessGlyph : status === "failed" ? CopyFailureGlyph : CopyGlyph;
+  const label = status === "copied" ? "Copied" : status === "failed" ? "Copy failed" : "Copy kubectl command";
   return (
     <p className={cx("mt-2 flex flex-wrap items-center gap-1 text-xs text-muted", className)}>
       <span>Equivalent kubectl:</span>
       <code className="code min-w-0 break-words">{command}</code>
-      {onCopy && <IconButton icon={CopyGlyph} label="Copy kubectl command" onClick={onCopy} />}
+      <IconButton
+        icon={icon}
+        label={label}
+        onClick={() => void copy.write(copyCommand, copyCommand)}
+      />
+      <ClipboardCopyStatus feedback={copy.feedback} />
     </p>
   );
 }

--- a/packages/ui-kit/src/clipboardCopy.test.tsx
+++ b/packages/ui-kit/src/clipboardCopy.test.tsx
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { ClipboardCopyStatus, useClipboardCopy } from "./clipboardCopy";
+
+function stubClipboard(writeText: (text: string) => Promise<void>) {
+  Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+}
+
+function Harness({ text = "kubectl get pods" }: { text?: string }) {
+  const copy = useClipboardCopy();
+  const status = copy.statusFor("subject");
+  return (
+    <>
+      <button type="button" onClick={() => void copy.write("subject", text)}>
+        {status === "copied" ? "Copied" : status === "failed" ? "Copy failed" : "Copy"}
+      </button>
+      <ClipboardCopyStatus feedback={copy.feedback} />
+    </>
+  );
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useClipboardCopy", () => {
+  it("copies, announces politely, and reverts after the shared 1.4 second window", async () => {
+    const writeText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined);
+    stubClipboard(writeText);
+    vi.useFakeTimers();
+    render(<Harness />);
+
+    await act(async () => fireEvent.click(screen.getByRole("button", { name: "Copy" })));
+
+    expect(writeText).toHaveBeenCalledWith("kubectl get pods");
+    expect(screen.getByRole("button", { name: "Copied" })).toBeDefined();
+    const announcement = screen.getByRole("status");
+    expect(announcement.getAttribute("aria-live")).toBe("polite");
+    expect(announcement.textContent).toBe("Copied to clipboard");
+
+    act(() => vi.advanceTimersByTime(1_400));
+    expect(screen.getByRole("button", { name: "Copy" })).toBeDefined();
+  });
+
+  it("restarts the window on a rapid second copy instead of stacking timers", async () => {
+    stubClipboard(vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined));
+    vi.useFakeTimers();
+    render(<Harness />);
+
+    await act(async () => fireEvent.click(screen.getByRole("button", { name: "Copy" })));
+    act(() => vi.advanceTimersByTime(1_000));
+    await act(async () => fireEvent.click(screen.getByRole("button", { name: "Copied" })));
+    act(() => vi.advanceTimersByTime(1_000));
+    expect(screen.getByRole("button", { name: "Copied" })).toBeDefined();
+    expect(vi.getTimerCount()).toBe(1);
+
+    act(() => vi.advanceTimersByTime(400));
+    expect(screen.getByRole("button", { name: "Copy" })).toBeDefined();
+  });
+
+  it("does not flicker back to Copy while a rapid second write is still pending", async () => {
+    let resolveSecond: (() => void) | undefined;
+    const writeText = vi
+      .fn<(text: string) => Promise<void>>()
+      .mockResolvedValueOnce(undefined)
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveSecond = resolve;
+          }),
+      );
+    stubClipboard(writeText);
+    vi.useFakeTimers();
+    render(<Harness />);
+
+    await act(async () => fireEvent.click(screen.getByRole("button", { name: "Copy" })));
+    act(() => vi.advanceTimersByTime(1_000));
+    act(() => fireEvent.click(screen.getByRole("button", { name: "Copied" })));
+    act(() => vi.advanceTimersByTime(1_000));
+    expect(screen.getByRole("button", { name: "Copied" })).toBeDefined();
+    expect(vi.getTimerCount()).toBe(0);
+
+    await act(async () => resolveSecond?.());
+    act(() => vi.advanceTimersByTime(1_399));
+    expect(screen.getByRole("button", { name: "Copied" })).toBeDefined();
+    act(() => vi.advanceTimersByTime(1));
+    expect(screen.getByRole("button", { name: "Copy" })).toBeDefined();
+  });
+
+  it("reports a rejected or unavailable clipboard without ever claiming success", async () => {
+    stubClipboard(
+      vi.fn<(text: string) => Promise<void>>().mockRejectedValue(new Error("permission denied")),
+    );
+    render(<Harness />);
+
+    await act(async () => fireEvent.click(screen.getByRole("button", { name: "Copy" })));
+
+    expect(screen.queryByRole("button", { name: "Copied" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Copy failed" })).toBeDefined();
+    expect(screen.getByRole("status").textContent).toBe("Could not copy to clipboard");
+  });
+
+  it("reports the same failure when the browser exposes no Clipboard API", async () => {
+    Object.defineProperty(navigator, "clipboard", { value: undefined, configurable: true });
+    render(<Harness />);
+
+    await act(async () => fireEvent.click(screen.getByRole("button", { name: "Copy" })));
+
+    expect(screen.queryByRole("button", { name: "Copied" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Copy failed" })).toBeDefined();
+    expect(screen.getByRole("status").textContent).toBe("Could not copy to clipboard");
+  });
+
+  it("does not let an older, slower attempt overwrite the latest result", async () => {
+    let rejectFirst: ((reason?: unknown) => void) | undefined;
+    const writeText = vi
+      .fn<(text: string) => Promise<void>>()
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((_resolve, reject) => {
+            rejectFirst = reject;
+          }),
+      )
+      .mockResolvedValueOnce(undefined);
+    stubClipboard(writeText);
+    render(<Harness />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+    await act(async () => fireEvent.click(screen.getByRole("button", { name: "Copy" })));
+    expect(screen.getByRole("button", { name: "Copied" })).toBeDefined();
+
+    await act(async () => rejectFirst?.(new Error("late denial")));
+    expect(screen.getByRole("button", { name: "Copied" })).toBeDefined();
+    expect(screen.getByRole("status").textContent).toBe("Copied to clipboard");
+  });
+
+  it("clears the pending revert when its surface unmounts", async () => {
+    stubClipboard(vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined));
+    vi.useFakeTimers();
+    const view = render(<Harness />);
+    await act(async () => fireEvent.click(screen.getByRole("button", { name: "Copy" })));
+    expect(vi.getTimerCount()).toBe(1);
+
+    view.unmount();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/packages/ui-kit/src/clipboardCopy.tsx
+++ b/packages/ui-kit/src/clipboardCopy.tsx
@@ -1,0 +1,142 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { IconComponent } from "./IconButton";
+
+/** One confirmation window for every copy affordance in the design system. */
+export const COPY_FEEDBACK_MS = 1_400;
+
+export type ClipboardCopyStatusKind = "idle" | "copied" | "failed";
+
+export interface ClipboardCopyFeedback {
+  key: string | null;
+  status: ClipboardCopyStatusKind;
+  /** Changes on every attempt, including a repeated copy of the same value. */
+  revision: number;
+}
+
+export interface ClipboardCopyController {
+  feedback: ClipboardCopyFeedback;
+  statusFor: (key: string) => ClipboardCopyStatusKind;
+  write: (key: string, text: string) => Promise<boolean>;
+}
+
+const IDLE: ClipboardCopyFeedback = { key: null, status: "idle", revision: 0 };
+
+/**
+ * Clipboard writing and its short-lived outcome, shared by every copy control.
+ *
+ * A revision, rather than a boolean, makes a second click restart the timer.
+ * The request number makes the latest click authoritative when two browser
+ * writes settle out of order. Neither a missing clipboard nor a rejected write
+ * can ever enter the copied state.
+ */
+export function useClipboardCopy(): ClipboardCopyController {
+  const [feedback, setFeedback] = useState<ClipboardCopyFeedback>(IDLE);
+  const latest = useRef(0);
+  const mounted = useRef(true);
+  const revertTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+      latest.current += 1;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (feedback.status === "idle") return;
+    const revision = feedback.revision;
+    const timer = setTimeout(() => {
+      revertTimer.current = null;
+      setFeedback((current) => (current.revision === revision ? IDLE : current));
+    }, COPY_FEEDBACK_MS);
+    revertTimer.current = timer;
+    return () => {
+      clearTimeout(timer);
+      if (revertTimer.current === timer) revertTimer.current = null;
+    };
+  }, [feedback]);
+
+  const write = useCallback(async (key: string, text: string): Promise<boolean> => {
+    const request = ++latest.current;
+    // A second attempt owns the confirmation window immediately. Without
+    // clearing here, a slow clipboard promise can let the first window expire
+    // and briefly put "Copy" back while the repeat attempt is still pending.
+    if (revertTimer.current !== null) {
+      clearTimeout(revertTimer.current);
+      revertTimer.current = null;
+    }
+    try {
+      const clipboard = typeof navigator === "undefined" ? undefined : navigator.clipboard;
+      if (!clipboard?.writeText) throw new Error("clipboard unavailable");
+      await clipboard.writeText(text);
+      if (mounted.current && latest.current === request) {
+        setFeedback((current) => ({ key, status: "copied", revision: current.revision + 1 }));
+      }
+      return true;
+    } catch {
+      if (mounted.current && latest.current === request) {
+        setFeedback((current) => ({ key, status: "failed", revision: current.revision + 1 }));
+      }
+      return false;
+    }
+  }, []);
+
+  const statusFor = useCallback(
+    (key: string): ClipboardCopyStatusKind =>
+      feedback.key === key ? feedback.status : "idle",
+    [feedback],
+  );
+
+  return { feedback, statusFor, write };
+}
+
+/** A copy result must be spoken independently of a button-name change. */
+export function ClipboardCopyStatus({ feedback }: { feedback: ClipboardCopyFeedback }) {
+  const message =
+    feedback.status === "copied"
+      ? "Copied to clipboard"
+      : feedback.status === "failed"
+        ? "Could not copy to clipboard"
+        : "";
+
+  if (!message) return null;
+
+  return (
+    <span className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+      {message}
+    </span>
+  );
+}
+
+export const CopySuccessGlyph: IconComponent = ({ size = 12, ...rest }) => (
+  <svg
+    className="copy-command-check"
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    {...rest}
+  >
+    <path
+      d="m5 13 4 4 10-10"
+      stroke="currentColor"
+      strokeWidth="3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export const CopyFailureGlyph: IconComponent = ({ size = 12, ...rest }) => (
+  <svg
+    className="copy-command-failure"
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    {...rest}
+  >
+    <path d="M6 6l12 12M18 6 6 18" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
+  </svg>
+);

--- a/packages/ui-kit/src/gallery/Gallery.tsx
+++ b/packages/ui-kit/src/gallery/Gallery.tsx
@@ -19,6 +19,7 @@ import { DiffLines, type DiffRow } from "../DiffLines";
 import { ConsoleDock } from "../ConsoleDock";
 import { ContextMenu } from "../ContextMenu";
 import { CopyCommand } from "../CopyCommand";
+import { ClipboardCopyStatus } from "../clipboardCopy";
 import { CustomizeMark, type MarkAppearance } from "../CustomizeMark";
 import { Drawer } from "../Drawer";
 import { DrillCard } from "../DrillCard";
@@ -771,10 +772,19 @@ export function Gallery() {
       </section>
 
       <section>
+        <h2>ClipboardCopyStatus</h2>
+        {/* This component is intentionally present only in the accessibility
+            tree: these two examples let the gallery audit both polite messages
+            without inventing visible UI that the real component does not own. */}
+        <ClipboardCopyStatus feedback={{ key: "success", status: "copied", revision: 1 }} />
+        <ClipboardCopyStatus feedback={{ key: "failure", status: "failed", revision: 1 }} />
+      </section>
+
+      <section>
         <h2>KubectlPreview</h2>
         {/* Not `CopyCommand`: this sits inside a confirm dialog, beside an
             action the app is about to perform, and says so. */}
-        <KubectlPreview command="kubectl delete pod web-1 -n default" onCopy={() => {}} />
+        <KubectlPreview command="kubectl delete pod web-1 -n default" />
         {/* Not every action has a faithful one-liner; the note says so in the
             same place rather than leaving the dialog silent. */}
         <KubectlPreview note="Eviction is an API call with no kubectl verb of its own." />
@@ -1231,7 +1241,7 @@ export function Gallery() {
             },
           ]}
           menuFooter={
-            <KubectlPreview command="kubectl -n prod-eu get pod checkout-api-7d9f4-x2k9" onCopy={() => {}} />
+            <KubectlPreview command="kubectl -n prod-eu get pod checkout-api-7d9f4-x2k9" />
           }
         />
         {/* An unusable `max` still leaves one action on the bar rather than an
@@ -1767,7 +1777,9 @@ export function Gallery() {
             {
               id: "act",
               label: "Act",
-              content: <KubectlPreview command="kubectl -n prod-eu set resources deploy/checkout-api --limits=memory=1Gi" onCopy={() => {}} />,
+              content: (
+                <KubectlPreview command="kubectl -n prod-eu set resources deploy/checkout-api --limits=memory=1Gi" />
+              ),
             },
           ]}
         />

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -9,6 +9,13 @@ export { Badge, type BadgeTone } from "./Badge";
 export { Breadcrumb, type BreadcrumbProps } from "./Breadcrumb";
 export { Button, type ButtonProps, type ButtonSize, type ButtonVariant } from "./Button";
 export { Checkbox, type CheckboxProps } from "./Checkbox";
+export {
+  ClipboardCopyStatus,
+  useClipboardCopy,
+  type ClipboardCopyController,
+  type ClipboardCopyFeedback,
+  type ClipboardCopyStatusKind,
+} from "./clipboardCopy";
 export { ClusterRail, type ClusterRailItem, type ClusterRailMarker, type ClusterRailProps } from "./ClusterRail";
 export { CodeEditor, documentDiagnostics, yamlDiagnostics, type CodeEditorProps } from "./CodeEditor";
 export { ColumnPicker, type ColumnOption, type ColumnPickerProps } from "./ColumnPicker";

--- a/packages/ui-kit/src/styles/kit.css
+++ b/packages/ui-kit/src/styles/kit.css
@@ -1483,6 +1483,7 @@
     color: var(--ink-muted);
   }
   .copy-command-check { color: var(--ok); flex-shrink: 0; }
+  .copy-command-failure { color: var(--sev); flex-shrink: 0; }
 
   .scroll { overflow: auto; scrollbar-gutter: stable; }
 }

--- a/packages/ui-next/src/lib/icons.ts
+++ b/packages/ui-next/src/lib/icons.ts
@@ -6,6 +6,7 @@ import {
   Box,
   BriefcaseBusiness,
   Circle,
+  Check,
   Clock3,
   Compass,
   Copy,
@@ -192,6 +193,7 @@ export const Icons = {
   // The application log screen's own actions.
   refresh: RefreshCw,
   copy: Copy,
+  check: Check,
   reveal: FolderOpen,
 
   // The row menu's write actions, shared by every kind that offers them.

--- a/packages/ui-next/src/screens/Forwards.test.tsx
+++ b/packages/ui-next/src/screens/Forwards.test.tsx
@@ -197,8 +197,9 @@ const cells = (row: HTMLElement) =>
 const cell = (row: HTMLElement, i: number) => row.querySelectorAll("td")[i] as HTMLElement;
 
 /** jsdom ships no clipboard at all, so there is nothing to spy on. */
-function stubClipboard() {
-  const writeText = vi.fn().mockResolvedValue(undefined);
+function stubClipboard(
+  writeText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined),
+) {
   Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
   return writeText;
 }
@@ -509,6 +510,12 @@ describe("Forwards — the row's actions", () => {
     // And the command really is the port-forward one, so the assertion above
     // is not two identical mistakes agreeing.
     expect(writeText.mock.calls[0][0]).toContain("port-forward svc/checkout-api 8080:8080");
+    expect(
+      await within(rowFor("svc/checkout-api")).findByRole("button", {
+        name: /copied kubectl command/i,
+      }),
+    ).toBeDefined();
+    expect(screen.getByRole("status").textContent).toBe("Copied to clipboard");
   });
 
   it("copies the loopback address on the desktop", async () => {
@@ -547,6 +554,24 @@ describe("Forwards — the row's actions", () => {
       within(rowFor("svc/checkout-api")).getByRole("button", { name: /copy address/i }),
     );
     expect(writeText).toHaveBeenCalledWith(shown);
+  });
+
+  it("shows and announces a rejected address copy without claiming it succeeded", async () => {
+    stubClipboard(
+      vi.fn<(text: string) => Promise<void>>().mockRejectedValue(new Error("permission denied")),
+    );
+    open();
+    await userEvent.click(
+      within(rowFor("svc/checkout-api")).getByRole("button", { name: /copy address/i }),
+    );
+
+    expect(
+      await within(rowFor("svc/checkout-api")).findByRole("button", {
+        name: /copy address failed/i,
+      }),
+    ).toBeDefined();
+    expect(screen.queryByRole("button", { name: /copied address/i })).toBeNull();
+    expect(screen.getByRole("status").textContent).toBe("Could not copy to clipboard");
   });
 
   it("stops the forward the button is standing in, by id", async () => {

--- a/packages/ui-next/src/screens/Forwards.tsx
+++ b/packages/ui-next/src/screens/Forwards.tsx
@@ -2,12 +2,10 @@ import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import {
   ageFromTimestamp,
   browsable,
-  copyKubectlCommand,
   forwardAddress,
   getForwards,
   isForwardEnded,
   kindToForwardTarget,
-  notify,
   openExternal,
   plural,
   rehydrateForwards,
@@ -19,11 +17,13 @@ import {
 import {
   Badge,
   Button,
+  ClipboardCopyStatus,
   EmptyState,
   IconButton,
   Screen,
   StatusPill,
   Table,
+  useClipboardCopy,
   type Column,
   type StatusKind,
 } from "@srelens/ui-kit";
@@ -195,6 +195,7 @@ export function Forwards(_props: { route: string }) {
    * recent, and a second banner over a table is a row of the table gone.
    */
   const [failure, setFailure] = useState<{ title: string; error: unknown } | null>(null);
+  const clipboard = useClipboardCopy();
 
   const rows = useMemo<ForwardRow[]>(
     () =>
@@ -347,17 +348,6 @@ export function Forwards(_props: { route: string }) {
     }
   }
 
-  async function copyAddress(row: ForwardRow) {
-    try {
-      await navigator.clipboard.writeText(row.address);
-      notify.success("Copied the forward's address");
-    } catch {
-      // No clipboard on a non-secure origin, and nothing to recover: the
-      // address is rendered in full in the row's own Local cell and can be
-      // selected. Saying "Copied" when nothing was copied is the only real harm.
-    }
-  }
-
   const columns: Column<ForwardRow>[] = [
     // `void`, the way every other handler on this screen discards its
     // promise: the failure is already the banner's business.
@@ -374,41 +364,71 @@ export function Forwards(_props: { route: string }) {
       filterable: false,
       align: "end",
       minWidth: 128,
-      render: (row) => (
-        <div className="flex items-center justify-end gap-0.5">
-          <IconButton
-            icon={Icons.terminal}
-            // Named per row: four rows all offering "Copy" name nothing at all.
-            // The name carries the TARGET, which the row already shows — never
-            // the command or the address, which it must not hide in a title.
-            label={`Copy kubectl command for ${row.target}`}
-            onClick={() => void copyKubectlCommand(row.command)}
-          />
-          <IconButton
-            icon={Icons.copy}
-            label={`Copy address for ${row.target}`}
-            onClick={() => void copyAddress(row)}
-          />
-          {/* A tunnel that died has nothing left to stop, and a Stop that
-              stops nothing is the kind of control this migration keeps
-              deleting. Not `danger` either: dismissing news is not a
-              destructive act, and the row is already red where it counts. */}
-          {row.dead ? (
+      render: (row) => {
+        const commandKey = `forward-command/${row.id}`;
+        const addressKey = `forward-address/${row.id}`;
+        const commandStatus = clipboard.statusFor(commandKey);
+        const addressStatus = clipboard.statusFor(addressKey);
+        return (
+          <div className="flex items-center justify-end gap-0.5">
             <IconButton
-              icon={Icons.close}
-              label={`Dismiss ${row.target}`}
-              onClick={() => void dismiss(row)}
+              icon={
+                commandStatus === "copied"
+                  ? Icons.check
+                  : commandStatus === "failed"
+                    ? Icons.warn
+                    : Icons.terminal
+              }
+              // Named per row: four rows all offering "Copy" name nothing at all.
+              // The name carries the TARGET, which the row already shows — never
+              // the command or the address, which it must not hide in a title.
+              label={
+                commandStatus === "copied"
+                  ? `Copied kubectl command for ${row.target}`
+                  : commandStatus === "failed"
+                    ? `Copy failed for ${row.target}`
+                    : `Copy kubectl command for ${row.target}`
+              }
+              onClick={() => void clipboard.write(commandKey, row.command)}
             />
-          ) : (
             <IconButton
-              icon={Icons.close}
-              danger
-              label={`Stop forwarding ${row.target}`}
-              onClick={() => void stop(row)}
+              icon={
+                addressStatus === "copied"
+                  ? Icons.check
+                  : addressStatus === "failed"
+                    ? Icons.warn
+                    : Icons.copy
+              }
+              label={
+                addressStatus === "copied"
+                  ? `Copied address for ${row.target}`
+                  : addressStatus === "failed"
+                    ? `Copy address failed for ${row.target}`
+                    : `Copy address for ${row.target}`
+              }
+              onClick={() => void clipboard.write(addressKey, row.address)}
             />
-          )}
-        </div>
-      ),
+            {/* A tunnel that died has nothing left to stop, and a Stop that
+                stops nothing is the kind of control this migration keeps
+                deleting. Not `danger` either: dismissing news is not a
+                destructive act, and the row is already red where it counts. */}
+            {row.dead ? (
+              <IconButton
+                icon={Icons.close}
+                label={`Dismiss ${row.target}`}
+                onClick={() => void dismiss(row)}
+              />
+            ) : (
+              <IconButton
+                icon={Icons.close}
+                danger
+                label={`Stop forwarding ${row.target}`}
+                onClick={() => void stop(row)}
+              />
+            )}
+          </div>
+        );
+      },
     },
   ];
 
@@ -439,6 +459,7 @@ export function Forwards(_props: { route: string }) {
           <FailureAlert tone="sev" title={failure.title} error={failure.error} />
         </div>
       )}
+      <ClipboardCopyStatus feedback={clipboard.feedback} />
       {rows.length === 0 ? (
         <EmptyState
           title="No port forwards"

--- a/packages/ui-next/src/screens/Overview.test.tsx
+++ b/packages/ui-next/src/screens/Overview.test.tsx
@@ -19,7 +19,6 @@ const core = vi.hoisted(() => ({
   podCount: vi.fn(),
   cordonNode: vi.fn(),
   drainNode: vi.fn(),
-  copyKubectlCommand: vi.fn(),
 }));
 vi.mock("@srelens/core", async (orig) => ({
   ...(await orig<typeof import("@srelens/core")>()),
@@ -568,6 +567,24 @@ describe("Overview — the nodes table", () => {
 });
 
 describe("Overview — the node actions", () => {
+  it("keeps the copy action open long enough to confirm it without a toast host", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    open();
+    await waitFor(() => expect(rowFor("n1")).toBeTruthy());
+
+    await userEvent.click(within(rowFor("n1")).getByRole("button", { name: "More actions" }));
+    await userEvent.click(screen.getByRole("button", { name: "Copy as kubectl" }));
+
+    expect(writeText).toHaveBeenCalledWith("kubectl get nodes n1 --context prod-eu -o yaml");
+    expect(await screen.findByRole("button", { name: "Copied" })).toBeDefined();
+    expect(screen.getByRole("dialog")).toBeDefined();
+    expect(screen.getByRole("status").textContent).toBe("Copied to clipboard");
+  });
+
   it("does not drain a node until the drain is confirmed", async () => {
     open();
     await waitFor(() => expect(rowFor("n1")).toBeTruthy());

--- a/packages/ui-next/src/screens/Overview.tsx
+++ b/packages/ui-next/src/screens/Overview.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo, useState, type ReactNode } from "react";
 import {
   K8S_KIND,
-  copyKubectlCommand,
   cordonNode,
   drainNode,
   formatStorageSize,
@@ -21,6 +20,7 @@ import {
   ActionBar,
   Alert,
   Button,
+  ClipboardCopyStatus,
   ConfirmDialog,
   EmptyState,
   ErrorState,
@@ -36,9 +36,11 @@ import {
   StatusPill,
   StatusRow,
   Table,
+  useClipboardCopy,
   loadTone,
   statusTone,
   type ActionBarAction,
+  type ClipboardCopyController,
   type Column,
   type Tone,
 } from "@srelens/ui-kit";
@@ -708,6 +710,7 @@ function Nodes({ context, nodes }: { context: string; nodes: OverviewNodes }) {
   const [pending, setPending] = useState<Pending | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
+  const clipboard = useClipboardCopy();
 
   const all: NodeRow[] = nodes.nodes.map(({ node, usage }) => ({ ...node, usage }));
   // Sorted on a copy: `nodes.nodes` is the loader's array and shared with the
@@ -742,7 +745,10 @@ function Nodes({ context, nodes }: { context: string; nodes: OverviewNodes }) {
     },
     [reset],
   );
-  const columns = useMemo(() => nodeColumns(context, open), [context, open]);
+  const columns = useMemo(
+    () => nodeColumns(context, open, clipboard),
+    [context, open, clipboard.feedback, clipboard.statusFor, clipboard.write],
+  );
 
   function close() {
     setPending(null);
@@ -858,6 +864,7 @@ function Nodes({ context, nodes }: { context: string; nodes: OverviewNodes }) {
           onCancel={close}
         />
       )}
+      <ClipboardCopyStatus feedback={clipboard.feedback} />
     </Section>
   );
 }
@@ -936,7 +943,11 @@ function podsRead(pods: NodeUsage["pods"]): string {
   return `${pods.used}/${pods.allocatable}`;
 }
 
-function nodeColumns(context: string, open: (pending: Pending) => void): Column<NodeRow>[] {
+function nodeColumns(
+  context: string,
+  open: (pending: Pending) => void,
+  clipboard: ClipboardCopyController,
+): Column<NodeRow>[] {
   return [
     {
       key: "name",
@@ -1000,7 +1011,11 @@ function nodeColumns(context: string, open: (pending: Pending) => void): Column<
       sortable: false,
       filterable: false,
       render: (row) => (
-        <ActionBar actions={nodeActions(context, row, open)} label={`Actions for ${row.name}`} max={2} />
+        <ActionBar
+          actions={nodeActions(context, row, open, clipboard)}
+          label={`Actions for ${row.name}`}
+          max={2}
+        />
       ),
     },
   ];
@@ -1016,8 +1031,15 @@ function nodeColumns(context: string, open: (pending: Pending) => void): Column<
  * ephemeral debug-pod flow, which this screen has no path to, and an action
  * that cannot work is worse than one that is absent.
  */
-function nodeActions(context: string, row: NodeRow, open: (pending: Pending) => void): ActionBarAction[] {
+function nodeActions(
+  context: string,
+  row: NodeRow,
+  open: (pending: Pending) => void,
+  clipboard: ClipboardCopyController,
+): ActionBarAction[] {
   const kubectlBase = { kind: "Node", name: row.name, namespace: null, context } as const;
+  const copyKey = `${context}/Node/${row.name}`;
+  const copyStatus = clipboard.statusFor(copyKey);
   return [
     row.unschedulable
       ? {
@@ -1052,8 +1074,19 @@ function nodeActions(context: string, row: NodeRow, open: (pending: Pending) => 
     },
     {
       id: "copy",
-      label: ROW_ACTION_LABEL.copy,
-      onSelect: () => void copyKubectlCommand(toKubectl({ ...kubectlBase, action: "get", output: "yaml" })),
+      label:
+        copyStatus === "copied"
+          ? "Copied"
+          : copyStatus === "failed"
+            ? "Copy failed"
+            : ROW_ACTION_LABEL.copy,
+      icon: copyStatus === "copied" ? Icons.check : copyStatus === "failed" ? Icons.warn : Icons.copy,
+      closeOnSelect: false,
+      onSelect: () =>
+        void clipboard.write(
+          copyKey,
+          toKubectl({ ...kubectlBase, action: "get", output: "yaml" }),
+        ),
     },
   ];
 }
@@ -1365,7 +1398,7 @@ function NodeConfirm({
               </>
             )}
           </p>
-          <KubectlPreview command={command} onCopy={() => void copyKubectlCommand(command)} />
+          <KubectlPreview command={command} />
           {/* The dialog stays open on a refusal, so this is the whole of what
               the reader is told about why the action did not happen. */}
           {error && <FailureLine error={error} className="text-sev" />}

--- a/packages/ui-next/src/screens/ResourceMenu.test.tsx
+++ b/packages/ui-next/src/screens/ResourceMenu.test.tsx
@@ -62,6 +62,7 @@ vi.mock("@srelens/core", async (importOriginal) => ({
 }));
 
 import { useRowMenu, type UseRowMenuArgs } from "./ResourceMenu";
+import { toKubectl } from "@srelens/core";
 import type { ContextMenuItem } from "@srelens/ui-kit";
 import type { ListRow } from "../lib/kinds/types";
 import * as store from "../lib/tabsStore";
@@ -118,6 +119,10 @@ const NODE_ARGS: UseRowMenuArgs = { context: "prod", kind: "Node", actions: {} }
 beforeEach(() => {
   vi.clearAllMocks();
   store.setState(defaultState([]));
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    configurable: true,
+  });
 });
 
 describe("useRowMenu", () => {
@@ -139,6 +144,44 @@ describe("useRowMenu", () => {
     // the one family that needs to: see the `actions.delete === false` test
     // below.
     expect(cmLabels).toEqual(expect.arrayContaining(["Open in new tab", "Edit", "Copy as kubectl", "Delete"]));
+  });
+
+  it("confirms a kubectl copy in place and announces it without a toast host", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    render(<Harness args={POD_ARGS} row={POD_ROW} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Copy as kubectl" }));
+
+    expect(writeText).toHaveBeenCalledWith(
+      toKubectl({
+        action: "get",
+        kind: "Pod",
+        name: "web-0",
+        namespace: "kube-system",
+        context: "prod",
+        output: "yaml",
+      }),
+    );
+    expect(await screen.findByRole("button", { name: "Copied" })).toBeDefined();
+    expect(screen.getByRole("status").textContent).toBe("Copied to clipboard");
+  });
+
+  it("shows and announces a refused kubectl copy without claiming success", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: vi.fn().mockRejectedValue(new Error("denied")) },
+      configurable: true,
+    });
+    render(<Harness args={POD_ARGS} row={POD_ROW} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Copy as kubectl" }));
+
+    expect(await screen.findByRole("button", { name: "Copy failed" })).toBeDefined();
+    expect(screen.queryByRole("button", { name: "Copied" })).toBeNull();
+    expect(screen.getByRole("status").textContent).toBe("Could not copy to clipboard");
   });
 
   // Whole-branch review (FIX 3): a custom resource's `k8sKind` is the CRD's

--- a/packages/ui-next/src/screens/ResourceMenu.tsx
+++ b/packages/ui-next/src/screens/ResourceMenu.tsx
@@ -1,6 +1,5 @@
 import { useState, type ReactNode } from "react";
 import {
-  copyKubectlCommand,
   cronjobSetSuspend,
   cronjobTriggerNow,
   defaultContainer,
@@ -17,7 +16,15 @@ import {
   type ContainerChoice,
   type KubectlInput,
 } from "@srelens/core";
-import { ConfirmDialog, KubectlPreview, Select, TextInput, type ContextMenuItem } from "@srelens/ui-kit";
+import {
+  ClipboardCopyStatus,
+  ConfirmDialog,
+  KubectlPreview,
+  Select,
+  TextInput,
+  useClipboardCopy,
+  type ContextMenuItem,
+} from "@srelens/ui-kit";
 import { ClusterMovedAlert, useClusterGate } from "../lib/clusterMoved";
 import { detailRoute, editRoute } from "../lib/detailRoute";
 import { FailureLine } from "../lib/errorCopy";
@@ -165,6 +172,7 @@ export function useRowMenu({ context, kind, actions }: UseRowMenuArgs): {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
   const [replicas, setReplicas] = useState("");
+  const clipboard = useClipboardCopy();
 
   /**
    * The divergence banner, its acknowledgement and the refusal behind it.
@@ -380,10 +388,19 @@ export function useRowMenu({ context, kind, actions }: UseRowMenuArgs): {
       // and the second pick focused the first resource. See {@link editRoute}.
       onPick: () => openTab(editRoute(kind, row.namespace ?? null, row.name), { clusterName: context }),
     });
+    const copyKey = `${context}/${kind}/${ns}/${row.name}`;
+    const copyStatus = clipboard.statusFor(copyKey);
+    const copyCommand = toKubectl({ ...kubectlBase, action: "get", output: "yaml" });
     list.push({
-      label: ROW_ACTION_LABEL.copy,
-      icon: Icons.copy,
-      onPick: () => void copyKubectlCommand(toKubectl({ ...kubectlBase, action: "get", output: "yaml" })),
+      label:
+        copyStatus === "copied"
+          ? "Copied"
+          : copyStatus === "failed"
+            ? "Copy failed"
+            : ROW_ACTION_LABEL.copy,
+      icon: copyStatus === "copied" ? Icons.check : copyStatus === "failed" ? Icons.warn : Icons.copy,
+      closeOnPick: false,
+      onPick: () => void clipboard.write(copyKey, copyCommand),
     });
 
     if (actions.suspend) {
@@ -489,7 +506,15 @@ export function useRowMenu({ context, kind, actions }: UseRowMenuArgs): {
     />
   ) : null;
 
-  return { items, dialog };
+  return {
+    items,
+    dialog: (
+      <>
+        <ClipboardCopyStatus feedback={clipboard.feedback} />
+        {dialog}
+      </>
+    ),
+  };
 }
 
 // `suspend` isn't here: its title depends on direction (Suspend vs. Resume),
@@ -648,7 +673,7 @@ function PendingDialog({
               autoFocus
             />
           )}
-          <KubectlPreview command={command} note={note} onCopy={command ? () => void copyKubectlCommand(command) : undefined} />
+          <KubectlPreview command={command} note={note} />
           {/* The dialog stays open on a refusal rather than closing as if the
               write had happened, so this line is the whole of what the reader
               is told about why. A validation message this component wrote

--- a/packages/ui-next/src/screens/detail/DetailActions.tsx
+++ b/packages/ui-next/src/screens/detail/DetailActions.tsx
@@ -70,6 +70,7 @@ function toBarActions(items: ContextMenuItem[]): ActionBarAction[] {
       label: BAR_LABEL[item.label] ?? item.label,
       icon: item.icon,
       danger: item.danger,
+      closeOnSelect: item.closeOnPick,
       onSelect: item.onPick,
     });
   }

--- a/packages/ui-next/src/screens/detail/ResourceDetailView.test.tsx
+++ b/packages/ui-next/src/screens/detail/ResourceDetailView.test.tsx
@@ -196,6 +196,10 @@ describe("ResourceDetailView", () => {
     descriptorFor.mockReturnValue(undefined);
     codeEditorProps.length = 0;
     asked.length = 0;
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      configurable: true,
+    });
     // Which blocks are open is a module-level store that outlives a render,
     // exactly as it outlives a launch. Cleared, so no test inherits another's
     // choices — least of all one about a Secret.
@@ -1433,6 +1437,31 @@ describe("ResourceDetailView", () => {
       // Nothing was left over to fold, so there is no overflow to open onto an
       // empty menu.
       expect(queryByRole("button", { name: "More actions" })).toBeNull();
+    });
+
+    it("confirms Copy as kubectl on the footer itself, with no toast host", async () => {
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, "clipboard", {
+        value: { writeText },
+        configurable: true,
+      });
+      getObject.mockResolvedValue({
+        object: { kind: "Widget", metadata: { name: "w-1", namespace: "default" } },
+      });
+      descriptorFor.mockReturnValue(undefined);
+      const { getByRole } = render(
+        <ResourceDetailView context="ctx" kind="Widget" namespace="default" name="w-1" />,
+      );
+      await waitFor(() => expect(getByRole("tab", { name: "Details" })).toBeDefined());
+
+      await userEvent.click(within(footer()!).getByRole("button", { name: "Copy as kubectl" }));
+
+      expect(writeText).toHaveBeenCalledTimes(1);
+      expect(writeText.mock.calls[0][0]).toBe(
+        "kubectl get widget w-1 -n default --context ctx -o yaml",
+      );
+      expect(await within(footer()!).findByRole("button", { name: "Copied" })).toBeDefined();
+      expect(within(footer()!).getByRole("status").textContent).toBe("Copied to clipboard");
     });
 
     it("offers the same actions in the tab's header row, only more of them on the bar", async () => {


### PR DESCRIPTION
## Summary

- introduces one shared clipboard controller with a 1.4-second confirmation window, repeat-click restart, latest-write ordering, and unmount cleanup
- provides visible success/failure states plus a polite assistive-technology announcement; failed writes never claim success
- applies the same behavior to CopyCommand, KubectlPreview, resource row/detail actions, Overview, and forwarded addresses
- preserves reduced-motion behavior and removes reliance on the absent new-design toast host

## Verification

- focused clipboard race/timer/accessibility tests and regression tests for every consuming surface
- workspace TypeScript typecheck
- complete frontend suite: 5,478/5,478 tests passed with coverage

Closes #410
