### PR TITLE
fix(ui-next): let a screen's Ask keep its hands off the composer

### DIFF
--- a/packages/ui-next/src/console.tsx
+++ b/packages/ui-next/src/console.tsx
@@ -80,6 +80,16 @@ export interface ConsoleValue {
    */
   attachError: unknown;
   setAttachError: (e: unknown) => void;
+  /**
+   * Puts a consumed attachment failure back, but only if nothing has happened
+   * since.
+   *
+   * A method rather than an updater on `setAttachError`, because the state is
+   * `unknown` and `unknown | ((held: unknown) => unknown)` collapses back to
+   * `unknown` — there is no way to type the updater form. The rule lives here
+   * instead, where it can read the current value.
+   */
+  restoreAttachError: (e: unknown) => void;
   noCluster: boolean;
   setNoCluster: (v: boolean) => void;
 }
@@ -122,6 +132,9 @@ export function ConsoleProvider({
   const [images, setImages] = useState<string[]>([]);
   const [reading, setReading] = useState(0);
   const [attachError, setAttachError] = useState<unknown>(null);
+  const restoreAttachError = useCallback((e: unknown) => {
+    setAttachError((held: unknown) => (held === null ? e : held));
+  }, []);
   const [noCluster, setNoCluster] = useState(false);
   const [scope, setScope] = useState(initialScope);
   const submit = useRef<Submit | null>(null);
@@ -166,10 +179,11 @@ export function ConsoleProvider({
       setReading,
       attachError,
       setAttachError,
+      restoreAttachError,
       noCluster,
       setNoCluster,
     }),
-    [open, ask, scope, registerSubmit, apple, onToggleTheme, draft, images, reading, attachError, noCluster],
+    [open, ask, scope, registerSubmit, apple, onToggleTheme, draft, images, reading, attachError, restoreAttachError, noCluster],
   );
 
   return <ConsoleContext.Provider value={value}>{children}</ConsoleContext.Provider>;

--- a/packages/ui-next/src/shell/Console.test.tsx
+++ b/packages/ui-next/src/shell/Console.test.tsx
@@ -802,6 +802,104 @@ describe("Console", () => {
     expect(await screen.findByText(/could not be read/i)).toBeTruthy();
   });
 
+  /**
+   * Codex P1 on #392, merged unfixed: a screen's Ask control reaches `ask()`,
+   * which reached the COMPOSER's submit path — so a canned question carried
+   * whatever the reader had attached and wiped what they had typed.
+   */
+  it("does not consume the composer when a screen asks its own question", async () => {
+    const user = userEvent.setup();
+    const shot = () => new File([new Uint8Array([1, 2, 3])], "shot.png", { type: "image/png" });
+    setup();
+    // Open the dock and get a draft and an attachment into it.
+    await user.click(screen.getByRole("button", { name: "Ask from elsewhere" }));
+    const box = screen.getByRole("textbox", { name: "Console prompt" });
+    fireEvent.paste(box, { clipboardData: { files: [shot()], types: ["Files"] } });
+    await screen.findByAltText("Attachment 1");
+    await user.type(box, "half a question");
+    askAgent.mockClear();
+
+    // A screen's own Ask control fires its canned question.
+    await user.click(screen.getByRole("button", { name: "Ask from elsewhere" }));
+
+    await vi.waitFor(() => {
+      expect(askAgent).toHaveBeenCalled();
+    });
+    // It went WITHOUT the reader's screenshot.
+    expect(askAgent).toHaveBeenCalledWith("x", expect.objectContaining({ images: undefined }));
+    // And their draft and attachment are untouched.
+    expect((box as HTMLTextAreaElement).value).toBe("half a question");
+    expect(screen.getByAltText("Attachment 1")).toBeTruthy();
+  });
+
+  it("does not drop a screen's question while the composer is reading an image", async () => {
+    const user = userEvent.setup();
+    const shot = () => new File([new Uint8Array([1, 2, 3])], "shot.png", { type: "image/png" });
+    let release: ((uri: string) => void) | undefined;
+    readImageFile.mockImplementationOnce(() => new Promise<string>((res) => (release = res)));
+    setup();
+    await user.click(screen.getByRole("button", { name: "Ask from elsewhere" }));
+    fireEvent.paste(screen.getByRole("textbox", { name: "Console prompt" }), {
+      clipboardData: { files: [shot()], types: ["Files"] },
+    });
+    await vi.waitFor(() => {
+      expect(release).toBeDefined();
+    });
+    askAgent.mockClear();
+
+    // The composer's `reading` gate is about the composer's own question.
+    await user.click(screen.getByRole("button", { name: "Ask from elsewhere" }));
+    await vi.waitFor(() => {
+      expect(askAgent).toHaveBeenCalledWith("x", expect.objectContaining({ images: undefined }));
+    });
+    release?.("data:image/png;base64,AAA");
+  });
+
+  /**
+   * Codex P2 on #392, merged unfixed: the chip belonged to the composition, and
+   * a successful submission cleared only the text and the images — so it sat
+   * over every later blank question with no way to dismiss it.
+   */
+  it("clears an attachment failure with the question it belonged to", async () => {
+    const user = userEvent.setup();
+    const shot = () => new File([new Uint8Array([1, 2, 3])], "shot.png", { type: "image/png" });
+    readImageFile.mockRejectedValueOnce(new Error("not an image"));
+    setup();
+    await user.click(screen.getByRole("button", { name: "Ask from elsewhere" }));
+    const box = screen.getByRole("textbox", { name: "Console prompt" });
+    fireEvent.paste(box, { clipboardData: { files: [shot()], types: ["Files"] } });
+    expect(await screen.findByText(/could not be read/i)).toBeTruthy();
+
+    await user.type(box, "ask it anyway");
+    fireEvent.keyDown(box, { key: "Enter" });
+
+    await vi.waitFor(() => {
+      expect(screen.queryByText(/could not be read/i)).toBeNull();
+    });
+  });
+
+  it("keeps the attachment failure when the store refuses the question", async () => {
+    const user = userEvent.setup();
+    const shot = () => new File([new Uint8Array([1, 2, 3])], "shot.png", { type: "image/png" });
+    readImageFile.mockRejectedValueOnce(new Error("not an image"));
+    askAgent.mockResolvedValueOnce(true).mockResolvedValue(false);
+    setup();
+    await user.click(screen.getByRole("button", { name: "Ask from elsewhere" }));
+    const box = screen.getByRole("textbox", { name: "Console prompt" });
+    fireEvent.paste(box, { clipboardData: { files: [shot()], types: ["Files"] } });
+    await screen.findByText(/could not be read/i);
+
+    await user.type(box, "ask it anyway");
+    fireEvent.keyDown(box, { key: "Enter" });
+
+    // Refused: the question comes back, and so does the reason it had no
+    // screenshot on it.
+    await vi.waitFor(() => {
+      expect((box as HTMLTextAreaElement).value).toBe("ask it anyway");
+    });
+    expect(screen.getByText(/could not be read/i)).toBeTruthy();
+  });
+
   it("prints the console accelerator for the platform", () => {
     setup();
     expect(screen.getByText("⌘K")).toBeDefined();

--- a/packages/ui-next/src/shell/Console.tsx
+++ b/packages/ui-next/src/shell/Console.tsx
@@ -130,6 +130,7 @@ export function Console({ fullView }: { fullView?: boolean }) {
     setReading,
     attachError,
     setAttachError,
+    restoreAttachError,
     noCluster,
     setNoCluster,
   } = useConsole();
@@ -332,6 +333,56 @@ export function Console({ fullView }: { fullView?: boolean }) {
 
   const commands = useMemo(() => commandsFor(deps), [deps]);
 
+  /**
+   * Whether a question can be sent at all, and the reason drawn where the
+   * reader is if it cannot. Shared by both paths below, because neither a
+   * browser nor a missing cluster cares who asked.
+   */
+  function sendable(raw: string): boolean {
+    /*
+      In a browser this component renders `null` further down — nothing served
+      by `srelens server` can answer a question, since `api_command.rs` has no
+      `chat_*` arm. That guard is BELOW the effect that registers the handler,
+      so a screen-level Ask button (`Overview.tsx`'s, for one) still reached
+      `askAgent`, whose `chat_start` came back unsupported, and the dock that
+      would have shown the failure was not on screen to show it.
+
+      So a question asked in web mode does the one useful thing available: it
+      opens `/agent`, which carries the explanation of why the agent needs the
+      desktop app.
+    */
+    if (!isTauri()) {
+      openTab("/agent", { clusterName: context || undefined });
+      return false;
+    }
+    // Every MCP tool call takes an explicit context, so a question sent with no
+    // cluster lets the agent pick one — and the run is keyed under an empty
+    // cluster, so it vanishes from the dock the moment a context resolves.
+    if (askCluster === "") {
+      setNoCluster(true);
+      return false;
+    }
+    setNoCluster(false);
+    return true;
+  }
+
+  /**
+   * A canned question from a screen's own Ask control, arriving through
+   * `ask()`.
+   *
+   * It does NOT touch the composer. Routing these through `onSubmit` meant a
+   * screen action snapshotted whatever the reader had attached and cleared
+   * whatever they had typed: press Overview's Summarise with a screenshot
+   * pasted and a half-written question, and the screenshot went with the canned
+   * question while the half-written one was wiped. Worse, an image still being
+   * read dropped the screen action entirely, because the composer's own
+   * `reading` gate applied to a question that had nothing to do with it.
+   */
+  function askFromScreen(question: string) {
+    if (!sendable(question)) return;
+    void send(question, "screen");
+  }
+
   function onSubmit(raw: string) {
     if (raw.startsWith("/")) {
       const matched = matchCommands(commands, raw.slice(1));
@@ -343,36 +394,10 @@ export function Console({ fullView }: { fullView?: boolean }) {
       // §F's own words for this: no command matched, so what was typed is
       // asked as a question instead of being discarded.
     }
-    /*
-      In a browser this component renders `null` further down — nothing served
-      by `srelens server` can answer a question, since `api_command.rs` has no
-      `chat_*` arm. That guard is BELOW the effect that registers this handler,
-      so a screen-level Ask button (`Overview.tsx`'s, for one) still reached
-      `askAgent`, whose `chat_start` came back unsupported, and the dock that
-      would have shown the failure was not on screen to show it.
-
-      So a question asked in web mode does the one useful thing available: it
-      opens `/agent`, which carries the explanation of why the agent needs the
-      desktop app. Handled here rather than by skipping the registration — an
-      Ask button that silently does nothing is the same dead end by a quieter
-      route.
-    */
-    if (!isTauri()) {
-      openTab("/agent", { clusterName: context || undefined });
-      return;
-    }
-    // #7: every MCP tool call takes an explicit context, so a question sent
-    // with no cluster lets the agent pick one — and the run is keyed under an
-    // empty cluster, so it vanishes from the dock the moment a context does
-    // resolve. Refused where the reader can see it, rather than sent and left
-    // to fail somewhere they cannot.
-    if (askCluster === "") {
-      setNoCluster(true);
-      return;
-    }
-    setNoCluster(false);
+    if (!sendable(raw)) return;
     // An image still being read belongs to THIS question. Sending now would
-    // send the question without it and attach it to the next one.
+    // send the question without it and attach it to the next one. Only the
+    // composer waits: a screen's canned question owns none of this.
     if (reading > 0) return;
     /*
       In the full view the dock shows whichever conversation is SELECTED, and
@@ -385,11 +410,16 @@ export function Console({ fullView }: { fullView?: boolean }) {
       follow-up goes back to it. A run restored from a file written before that
       was recorded has none, and falls back to this route — the old behaviour.
     */
-    void submit(raw);
+    void send(raw, "composer");
   }
 
   /**
-   * Sends, and puts the draft back if the store REFUSES the question.
+   * Sends a question, and puts the composition back if the store REFUSES it.
+   *
+   * `from` says whether this question owns the composition. The composer's own
+   * submission does: it carries the draft's attachments and clears them. A
+   * screen's Ask control does not, so a canned question neither takes the
+   * reader's screenshot nor wipes their half-written question.
    *
    * Cleared first, restored on refusal — rather than cleared after `askAgent`
    * resolves. That promise settles when the ANSWER settles, which can be
@@ -398,13 +428,27 @@ export function Console({ fullView }: { fullView?: boolean }) {
    * contrast, happens before `askAgent` awaits anything at all, so the restore
    * lands in the same microtask and is never seen.
    *
-   * The restore is conditional both ways: if the reader has typed since, their
-   * text stands. Nothing here overwrites something newer.
+   * The restore is conditional every way: if the reader has typed, attached or
+   * failed to attach something since, theirs stands. Nothing here overwrites
+   * something newer.
    */
-  async function submit(raw: string) {
-    const sent = images;
-    setValue("");
-    setImages([]);
+  async function send(raw: string, from: "composer" | "screen") {
+    // WHO asked, not what state happens to hold. Inferring it from the draft
+    // read the reader's half-written question as evidence that the canned one
+    // owned it, and cleared it anyway.
+    const consumes = from === "composer";
+    const sent = consumes ? images : [];
+    const sentError = consumes ? attachError : null;
+    if (consumes) {
+      setValue("");
+      setImages([]);
+      // WITH the draft. An attachment failure explains why this question has no
+      // screenshot on it, so it belongs to the question being sent — left
+      // behind, the chip sat over every later blank question and over the dock
+      // in whichever tab it was next mounted in, with no way to dismiss it but
+      // attempting another attachment.
+      setAttachError(null);
+    }
     setOpen(true);
     const accepted = await askAgent(raw, {
       // The KEY, not a route to re-derive one from. `runKey` is what this dock
@@ -419,7 +463,7 @@ export function Console({ fullView }: { fullView?: boolean }) {
       route: shown?.route ?? route,
       images: sent.length > 0 ? sent : undefined,
     });
-    if (accepted) return;
+    if (accepted || !consumes) return;
     // Refused — `askAgent` turns a question away while ANOTHER run's turn is in
     // flight, and this dock is not busy, so the reader can submit and be
     // refused. Discarding the question then left them retyping something they
@@ -430,6 +474,7 @@ export function Console({ fullView }: { fullView?: boolean }) {
     // have typed or attached since is newer than this and stands.
     setValue((v) => (v === "" ? raw : v));
     setImages((held) => (held.length === 0 ? sent : held));
+    restoreAttachError(sentError);
   }
 
   // A ref, not `[registerSubmit]` alone closing over a stale `onSubmit`: a
@@ -437,9 +482,12 @@ export function Console({ fullView }: { fullView?: boolean }) {
   // effect last ran, and it must reach the CURRENT `commands`/`route`, not
   // whichever ones were in scope when the dock first mounted. The same
   // pattern `Window.tsx`'s own `runRef` uses for its accelerator handler.
-  const onSubmitRef = useRef(onSubmit);
-  onSubmitRef.current = onSubmit;
-  useEffect(() => registerSubmit((q) => onSubmitRef.current(q)), [registerSubmit]);
+  // The SCREEN path, not the composer's. `ask()` delivers a canned question
+  // from a screen's own control, which must not consume what the reader is
+  // composing here.
+  const askRef = useRef(askFromScreen);
+  askRef.current = askFromScreen;
+  useEffect(() => registerSubmit((q) => askRef.current(q)), [registerSubmit]);
 
 
   // After every hook above, never before: the guard decides what renders,


### PR DESCRIPTION
Follow-up to #392. Two findings were raised on that PR in its last review round, resolved without a fix, and merged. Both are real, both were mine, and both are consequences of routing every submission through one path.

## A screen's Ask control consumed the reader's composition

`useConsole().ask()` reached the composer's own submit handler, so a canned question from a screen took whatever the composer held.

Press Overview's Summarise with a screenshot pasted and a half-written question in the dock, and the screenshot went with the canned question while the half-written one was wiped. Worse, an image still being read dropped the screen action entirely — the composer's `reading` gate was being applied to a question that had nothing to do with it.

There are two paths now:

- `onSubmit` is the composer's. It owns the draft, carries its attachments, and waits for a read that belongs to it.
- `askFromScreen` is what `ask()` reaches. It touches none of that.

What they genuinely share moved into `sendable`: the web-mode redirect to `/agent`, and the refusal when no cluster is active. Neither of those cares who asked, and a screen question must not be sent with `cluster: ""` either.

`send` now takes **who is asking** rather than inferring it. My first attempt derived "does this consume the composition" from the state, which read the reader's half-written question as evidence that the canned one owned it and cleared it anyway. The test below caught that.

## An attachment failure goes with the question it belonged to

"That image could not be read" explains why a question has no screenshot on it, so it is part of that composition. It was cleared by nothing, so it sat over every later blank question — and, since it lives in the provider, over the dock in whichever tab it was next mounted in, with no way to dismiss it but attempting another attachment.

It is now consumed with the draft, and restored with the draft if the store refuses the question — and only if nothing newer has happened since.

That restore is a provider method (`restoreAttachError`) rather than an updater on `setAttachError`. The state is `unknown`, and `unknown | ((held: unknown) => unknown)` collapses back to `unknown`, so the updater form cannot be typed at all; the rule lives where it can read the current value.

## Tests

Four new, in `Console.test.tsx`, each verified to fail against the specific change it guards:

| Test | Mutation it fails on |
| --- | --- |
| does not consume the composer when a screen asks its own question | screen asks routed as `"composer"` |
| does not drop a screen's question while the composer is reading an image | the `reading` gate applied to screen asks |
| clears an attachment failure with the question it belonged to | `setAttachError(null)` removed from the consume path |
| keeps the attachment failure when the store refuses the question | `restoreAttachError` removed |

## Verification

- `pnpm -r typecheck` clean.
- `pnpm test` — 5794 passing.

No behaviour change to the composer's own submit path beyond clearing the attachment chip with it.