### PR TITLE
feat(node): surface the number of taints on the Nodes list (#426)

### DIFF
--- a/apps/desktop/src/components/ResourceBrowser.test.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.test.tsx
@@ -705,7 +705,14 @@ describe("ResourceBrowser", () => {
     listNamespacesMock.mockResolvedValue({ namespaces: ["default"] });
     listNodesMock.mockResolvedValue({
       nodes: [
-        { name: "worker-1", status: "Ready", unschedulable: true, taints: 2, version: "v1.35.0", roles: "<none>" },
+        {
+          name: "worker-1", status: "Ready", unschedulable: true, version: "v1.35.0", roles: "<none>",
+          taints: 2,
+          taintDetails: [
+            { key: "node.kubernetes.io/memory-pressure", value: "", effect: "NoSchedule" },
+            { key: "team", value: "payments", effect: "NoExecute" },
+          ],
+        },
       ],
     });
     render(<ResourceBrowser context="kind-dev" kind="nodes" />);
@@ -713,7 +720,14 @@ describe("ResourceBrowser", () => {
     await waitFor(() => expect(screen.getByText("worker-1")).toBeDefined());
     expect(screen.getByText("Ready")).toBeDefined();
     expect(screen.getByText("SchedulingDisabled")).toBeDefined();
-    expect(screen.getByText("Tainted (2)")).toBeDefined();
+    // "(2)" until #426 put the count on every tainted node's badge, singular
+    // included, with the taints themselves on hover and the number spelled out
+    // for a screen reader.
+    expect(screen.getByText("Tainted \u00b7 2")).toBeDefined();
+    const badge = screen.getByLabelText("2 taints");
+    expect(badge.getAttribute("title")).toBe(
+      "team=payments:NoExecute\nnode.kubernetes.io/memory-pressure=:NoSchedule",
+    );
   });
 
   it("hides a node column via the column picker and remembers it", async () => {
@@ -737,7 +751,12 @@ describe("ResourceBrowser", () => {
       expect(screen.queryByRole("columnheader", { name: /Version/ })).toBeNull(),
     );
     // …and the choice is persisted.
-    expect(JSON.parse(localStorage.getItem("srelens.hiddenColumns")!)).toEqual({ nodes: ["version"] });
+    // "taints" rides along: since #426 the Taints column starts hidden, and the
+    // first toggle of ANY column on this view is what turns "no choice yet"
+    // into a stored choice — so the default it was showing is written down.
+    expect(JSON.parse(localStorage.getItem("srelens.hiddenColumns")!)).toEqual({
+      nodes: ["taints", "version"],
+    });
 
     // Remounting the nodes view keeps the column hidden.
     view.unmount();

--- a/apps/desktop/src/components/ResourceBrowser.tsx
+++ b/apps/desktop/src/components/ResourceBrowser.tsx
@@ -2,6 +2,12 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Plus, RefreshCw } from "lucide-react";
 import {
   podMetrics,
+  TAINT_COLUMN_HINT,
+  taintBadgeLabel,
+  taintBadgeText,
+  taintSortValue,
+  taintTallyText,
+  taintTooltip,
   type PodSummary,
   type DeploymentSummary,
   type ServiceSummary,
@@ -362,6 +368,21 @@ const clusterRoleBindingColumns: Column<ClusterRoleBindingSummary>[] = [
   { key: "age", header: "Age", getSortValue: ageSortValue, render: (b) => <Muted>{b.age}</Muted> },
 ];
 
+/**
+ * The Tainted badge with its count, its hover list and its accessible name —
+ * the classic half of the pair in `ui-next`'s `columns.tsx`. Both render their
+ * own design's Badge and take every word, every ordering and the sort value
+ * from `@srelens/core`'s `taints`, so the two lists cannot drift. (#426)
+ */
+function TaintBadge({ row }: { row: NodeRow }) {
+  const taints = row.taintDetails ?? [];
+  return (
+    <span tabIndex={0} title={taintTooltip(taints)} aria-label={taintBadgeLabel(row.taints)}>
+      <Badge variant="neutral">{taintBadgeText(row.taints)}</Badge>
+    </span>
+  );
+}
+
 const nodeColumns: Column<NodeRow>[] = [
   { key: "name", header: "Node", render: (n) => <strong>{n.name}</strong> },
   {
@@ -371,9 +392,7 @@ const nodeColumns: Column<NodeRow>[] = [
       <span className="inline-flex items-center gap-1.5">
         <StatusPill status={n.status} kind={phaseKind(n.status)} />
         {n.unschedulable && <Badge variant="warning">SchedulingDisabled</Badge>}
-        {n.taints > 0 && (
-          <Badge variant="neutral">{n.taints > 1 ? `Tainted (${n.taints})` : "Tainted"}</Badge>
-        )}
+        {n.taints > 0 && <TaintBadge row={n} />}
       </span>
     ),
   },
@@ -381,6 +400,20 @@ const nodeColumns: Column<NodeRow>[] = [
   { key: "cpu", header: "CPU", render: (n) => <Muted>{n.cpu != null ? `${n.cpu}m` : "—"}</Muted> },
   { key: "memory", header: "Memory", render: (n) => <Muted>{n.memory != null ? `${n.memory}Mi` : "—"}</Muted> },
   { key: "version", header: "Version", render: (n) => <Muted>{n.version}</Muted> },
+  {
+    key: "taints",
+    header: "Taints",
+    // Off until asked for — the same bargain the new design's column makes.
+    defaultHidden: true,
+    getSortValue: (n) => taintSortValue(n.taintDetails),
+    render: (n) => (
+      <Muted>
+        <span title={(n.taintDetails ?? []).length > 0 ? taintTooltip(n.taintDetails ?? []) : TAINT_COLUMN_HINT}>
+          {taintTallyText(n.taintDetails ?? [])}
+        </span>
+      </Muted>
+    ),
+  },
   { key: "age", header: "Age", getSortValue: ageSortValue, render: (n) => <Muted>{n.age}</Muted> },
 ];
 

--- a/apps/desktop/src/components/ResourceOverview.test.tsx
+++ b/apps/desktop/src/components/ResourceOverview.test.tsx
@@ -158,6 +158,69 @@ describe("ObjectDetail (Pod)", () => {
     expect(screen.getByText("beta.kubernetes.io/arch")).toBeDefined();
   });
 
+  /**
+   * #426 — the classic half of the Node detail page's Taints section. The
+   * ui-next half is `screens/detail/NodeBody.test.tsx`; both read the same
+   * `@srelens/core` formatting and ordering, which is what keeps the two
+   * designs from drifting.
+   */
+  describe("a Node's taints", () => {
+    const nodeWith = (spec: Record<string, unknown>): K8sObject => ({
+      metadata: { name: "worker-1", creationTimestamp: "2026-01-01T00:00:00Z" },
+      spec,
+      status: {},
+    });
+
+    it("says the count is 0 rather than leaving the block out", () => {
+      render(<ObjectDetail kind="Node" obj={nodeWith({})} now={NOW} />);
+      expect(screen.getByText("Taints")).toBeDefined();
+      expect(screen.getByText("Count")).toBeDefined();
+    });
+
+    it("lists one taint as key=value:effect", () => {
+      render(
+        <ObjectDetail
+          kind="Node"
+          obj={nodeWith({ taints: [{ key: "node-role.kubernetes.io/control-plane", effect: "NoSchedule" }] })}
+          now={NOW}
+        />,
+      );
+      expect(screen.getByText("node-role.kubernetes.io/control-plane=:NoSchedule")).toBeDefined();
+    });
+
+    it("lists N taints worst-effect first, with timeAdded where Kubernetes set one", () => {
+      render(
+        <ObjectDetail
+          kind="Node"
+          obj={nodeWith({
+            taints: [
+              { key: "spot", value: "true", effect: "PreferNoSchedule" },
+              { key: "team", value: "payments", effect: "NoExecute", timeAdded: "2026-09-02T08:15:00Z" },
+            ],
+          })}
+          now={NOW}
+        />,
+      );
+      const listed = screen.getAllByText(/:(No|Prefer)/).map((el) => el.textContent);
+      expect(listed).toEqual(["team=payments:NoExecute", "spot=true:PreferNoSchedule"]);
+      expect(screen.getByText("added 2026-09-02T08:15:00Z")).toBeDefined();
+    });
+
+    it("keeps the cordon taint the list leaves to its SchedulingDisabled badge", () => {
+      render(
+        <ObjectDetail
+          kind="Node"
+          obj={nodeWith({
+            unschedulable: true,
+            taints: [{ key: "node.kubernetes.io/unschedulable", effect: "NoSchedule" }],
+          })}
+          now={NOW}
+        />,
+      );
+      expect(screen.getByText("node.kubernetes.io/unschedulable=:NoSchedule")).toBeDefined();
+    });
+  });
+
   it("shows real volume sources and opens linked resources", () => {
     const onOpenResource = vi.fn();
     const pod: K8sObject = {

--- a/apps/desktop/src/components/ResourceOverview.tsx
+++ b/apps/desktop/src/components/ResourceOverview.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { ArrowLeftRight, ChevronDown, ChevronUp, ScrollText, SquareTerminal } from "lucide-react";
+import { formatTaint, orderTaints, parseTaints, taintTimeAddedText } from "@srelens/core";
 import { getObject, getSecret, type K8sObject } from "@srelens/core";
 import { certificateRows, type CertificateRow } from "@srelens/core";
 import { listEndpointSlices } from "@srelens/core";
@@ -1172,6 +1173,7 @@ function NodeBody({ obj }: { obj: K8sObject }) {
   const cap = asRecord(status.capacity);
   const alloc = asRecord(status.allocatable);
   const cordoned = spec.unschedulable === true;
+  const taints = orderTaints(parseTaints(obj.spec));
   return (
     <>
       <Section title="Info">
@@ -1200,6 +1202,21 @@ function NodeBody({ obj }: { obj: K8sObject }) {
             ["Memory", `${str(alloc.memory)} / ${str(cap.memory)}`],
             ["Pods", `${str(alloc.pods)} / ${str(cap.pods)}`],
           ]}
+        />
+      </Section>
+      {/* Every taint, cordon one included — see `NodeBody` in ui-next's
+          `screens/detail` for why this differs from the list's count, and
+          `@srelens/core`'s `taints` for the ordering both designs share. */}
+      <Section title="Taints">
+        <KV
+          pairs={
+            taints.length === 0
+              ? [["Count", "0"]]
+              : taints.map(
+                  (taint) =>
+                    [formatTaint(taint), taintTimeAddedText(taint)] as [string, React.ReactNode],
+                )
+          }
         />
       </Section>
     </>

--- a/apps/desktop/src/ui/Table.tsx
+++ b/apps/desktop/src/ui/Table.tsx
@@ -25,6 +25,9 @@ export interface Column<T> {
    *  visible text. */
   getSortValue?: (row: T) => unknown;
   sortable?: boolean;
+  /** Start hidden, offered by the ColumnPicker — see ui-kit's `Column`. Only
+   *  the default: a reader's own toggle for this view wins from then on. */
+  defaultHidden?: boolean;
   filterable?: boolean;
   minWidth?: number;
 }

--- a/apps/desktop/src/ui/useColumnVisibility.test.ts
+++ b/apps/desktop/src/ui/useColumnVisibility.test.ts
@@ -46,3 +46,58 @@ describe("useColumnVisibility", () => {
     expect(pods.result.current.visibleColumns.map((c) => c.key)).toEqual(["name", "age", "actions"]);
   });
 });
+
+/**
+ * #426 — the classic half of "a column that starts hidden". Same trap as the
+ * new design's store: the record holds hidden keys, so an absent entry has to
+ * mean "no choice yet, use the default" while a stored entry — an empty one
+ * included — is the reader's own answer and outranks it.
+ */
+describe("a column that starts hidden", () => {
+  const withTaints: Column<Row>[] = [
+    { key: "name", header: "Name" },
+    { key: "status", header: "Status" },
+    { key: "taints", header: "Taints", defaultHidden: true },
+    { key: "age", header: "Age" },
+  ];
+  const keys = (result: { visibleColumns: Column<Row>[] }) => result.visibleColumns.map((c) => c.key);
+
+  it("is out of the table before the reader has said anything", () => {
+    const { result } = renderHook(() => useColumnVisibility("nodes", withTaints));
+    expect(keys(result.current)).toEqual(["name", "status", "age"]);
+    expect(result.current.hidden.has("taints")).toBe(true);
+  });
+
+  it("is still offered by the picker, so there is a way to turn it on", () => {
+    const { result } = renderHook(() => useColumnVisibility("nodes", withTaints));
+    expect(result.current.columnOptions.map((o) => o.key)).toContain("taints");
+  });
+
+  it("stays on once turned on, and survives a remount", () => {
+    const first = renderHook(() => useColumnVisibility("nodes", withTaints));
+    act(() => first.result.current.toggle("taints"));
+    expect(keys(first.result.current)).toEqual(["name", "status", "taints", "age"]);
+
+    const second = renderHook(() => useColumnVisibility("nodes", withTaints));
+    expect(keys(second.result.current)).toEqual(["name", "status", "taints", "age"]);
+  });
+
+  it("goes back off when turned off again", () => {
+    const { result } = renderHook(() => useColumnVisibility("nodes", withTaints));
+    act(() => result.current.toggle("taints"));
+    act(() => result.current.toggle("taints"));
+    expect(keys(result.current)).toEqual(["name", "status", "age"]);
+  });
+
+  it("hides only itself — turning it on does not disturb another column", () => {
+    const { result } = renderHook(() => useColumnVisibility("nodes", withTaints));
+    act(() => result.current.toggle("taints"));
+    act(() => result.current.toggle("status"));
+    expect(keys(result.current)).toEqual(["name", "taints", "age"]);
+  });
+
+  it("leaves a view whose columns declare no default exactly as it was", () => {
+    const { result } = renderHook(() => useColumnVisibility("pods", columns));
+    expect(result.current.hidden.size).toBe(0);
+  });
+});

--- a/apps/desktop/src/ui/useColumnVisibility.ts
+++ b/apps/desktop/src/ui/useColumnVisibility.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { loadHiddenColumns, saveHiddenColumns } from "@srelens/core";
+import { loadHiddenColumnsEntry, saveHiddenColumns } from "@srelens/core";
 import type { Column } from "./Table";
 import type { ColumnOption } from "./ColumnPicker";
 
@@ -28,12 +28,25 @@ function columnLabel<T>(column: Column<T>): string {
 
 export function useColumnVisibility<T>(viewKey: string, columns: Column<T>[]): ColumnVisibility<T> {
   const pinnedKey = columns[0]?.key;
-  const [hidden, setHidden] = useState<Set<string>>(() => new Set(loadHiddenColumns(viewKey)));
+  // A column marked `defaultHidden` starts off — but only until the reader has
+  // made a choice for this view. The stored record holds hidden keys, so an
+  // absent entry and "the reader turned this column on" would otherwise be the
+  // same thing and the column would come back hidden next launch; a stored
+  // entry, empty included, is a choice and outranks the defaults. Compared as
+  // a joined string so a fresh `columns` array each render is not a new
+  // dependency. (#426)
+  const defaultHidden = columns
+    .filter((column) => column.defaultHidden)
+    .map((column) => column.key)
+    .join(",");
+  const [hidden, setHidden] = useState<Set<string>>(
+    () => new Set(loadHiddenColumnsEntry(viewKey) ?? (defaultHidden ? defaultHidden.split(",") : [])),
+  );
 
   // Reload when the view changes (e.g. switching resource kind in one browser).
   useEffect(() => {
-    setHidden(new Set(loadHiddenColumns(viewKey)));
-  }, [viewKey]);
+    setHidden(new Set(loadHiddenColumnsEntry(viewKey) ?? (defaultHidden ? defaultHidden.split(",") : [])));
+  }, [viewKey, defaultHidden]);
 
   // Only labelled, non-identifier columns can be hidden. The pinned first column
   // and headerless columns (e.g. a row-actions cell) are always shown.

--- a/crates/kube/src/nodes.rs
+++ b/crates/kube/src/nodes.rs
@@ -17,6 +17,21 @@ pub struct ListNodesIn {
     pub context: String,
 }
 
+/// One entry of `spec.taints` — the shape the Nodes list's badge tooltip and
+/// the optional Taints column read. `value` is empty for the common valueless
+/// taint (`node-role.kubernetes.io/control-plane:NoSchedule`), which is a real
+/// value and not a missing one, so it is a `String` and not an `Option`.
+#[derive(Debug, Clone, PartialEq, Serialize, JsonSchema)]
+pub struct NodeTaint {
+    pub key: String,
+    pub value: String,
+    /// `NoSchedule`, `PreferNoSchedule` or `NoExecute`.
+    pub effect: String,
+    /// Set by Kubernetes only for `NoExecute` taints.
+    #[serde(rename = "timeAdded", skip_serializing_if = "Option::is_none")]
+    pub time_added: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, JsonSchema)]
 pub struct NodeSummary {
     pub name: String,
@@ -26,6 +41,15 @@ pub struct NodeSummary {
     pub unschedulable: bool,
     /// Number of taints on the node, excluding the auto-added unschedulable taint.
     pub taints: u32,
+    /// The taints `taints` counts, in the order the API server reports them.
+    /// Deliberately the *same* filtered set as the count rather than the whole
+    /// of `spec.taints`: the list's badge shows the count and its tooltip shows
+    /// this, and a badge reading "2" over a tooltip listing three lines is a
+    /// worse answer than leaving the cordon taint — already spelled out by the
+    /// SchedulingDisabled badge beside it — to the detail page, which reads the
+    /// live object and lists every taint.
+    #[serde(rename = "taintDetails")]
+    pub taint_details: Vec<NodeTaint>,
     pub version: String,
     pub roles: String,
     pub age: String,
@@ -90,15 +114,22 @@ fn summarise(node: Node) -> NodeSummary {
     let unschedulable = spec.and_then(|s| s.unschedulable).unwrap_or(false);
     // Count taints, ignoring the taint Kubernetes adds automatically when a node
     // is cordoned — that state is already conveyed by `unschedulable`.
-    let taints = spec
+    let taint_details: Vec<NodeTaint> = spec
         .and_then(|s| s.taints.as_ref())
         .map(|taints| {
             taints
                 .iter()
                 .filter(|taint| taint.key != "node.kubernetes.io/unschedulable")
-                .count() as u32
+                .map(|taint| NodeTaint {
+                    key: taint.key.clone(),
+                    value: taint.value.clone().unwrap_or_default(),
+                    effect: taint.effect.clone(),
+                    time_added: taint.time_added.as_ref().map(|t| t.0.to_string()),
+                })
+                .collect()
         })
-        .unwrap_or(0);
+        .unwrap_or_default();
+    let taints = taint_details.len() as u32;
     // A node that reports no allocatable at all reports zero, not a guess —
     // the consumer downstream (packages/core/src/lib/k8sCapacity.ts) is what
     // turns a zero denominator into "no reading".
@@ -134,6 +165,7 @@ fn summarise(node: Node) -> NodeSummary {
         status,
         unschedulable,
         taints,
+        taint_details,
         version,
         roles,
         age: crate::humanize_age(node.metadata.creation_timestamp.as_ref()),
@@ -361,5 +393,118 @@ mod tests {
         assert_eq!(s.status, "Ready");
         assert!(s.unschedulable);
         assert_eq!(s.taints, 1);
+        // The detail list is the same filtered set the count reports, so the
+        // badge's number and its tooltip can never disagree.
+        assert_eq!(s.taint_details.len(), 1);
+        assert_eq!(s.taint_details[0].key, "dedicated");
+    }
+
+    /// A node with an empty `spec.taints` and a node with no `spec` at all are
+    /// the same answer — zero, and an empty list rather than a null the
+    /// frontend would have to guard.
+    #[test]
+    fn a_node_with_no_taints_reports_zero_and_an_empty_list() {
+        let no_spec = Node {
+            metadata: kube::core::ObjectMeta {
+                name: Some("clean-1".into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let s = summarise(no_spec);
+        assert_eq!(s.taints, 0);
+        assert!(s.taint_details.is_empty());
+
+        let empty_taints = Node {
+            metadata: kube::core::ObjectMeta {
+                name: Some("clean-2".into()),
+                ..Default::default()
+            },
+            spec: Some(k8s_openapi::api::core::v1::NodeSpec {
+                taints: Some(vec![]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let s = summarise(empty_taints);
+        assert_eq!(s.taints, 0);
+        assert!(s.taint_details.is_empty());
+    }
+
+    /// The single-taint case the issue calls out as the benign one: a fresh
+    /// control-plane node. Its taint carries no value, which is a real value
+    /// (the empty string) and not a missing one.
+    #[test]
+    fn a_control_plane_nodes_one_taint_is_carried_whole() {
+        use k8s_openapi::api::core::v1::{NodeSpec, Taint};
+        let node = Node {
+            metadata: kube::core::ObjectMeta {
+                name: Some("cp-1".into()),
+                ..Default::default()
+            },
+            spec: Some(NodeSpec {
+                taints: Some(vec![Taint {
+                    key: "node-role.kubernetes.io/control-plane".into(),
+                    effect: "NoSchedule".into(),
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let s = summarise(node);
+        assert_eq!(s.taints, 1);
+        assert_eq!(s.taint_details.len(), 1);
+        assert_eq!(s.taint_details[0].value, "");
+        assert_eq!(s.taint_details[0].effect, "NoSchedule");
+        assert_eq!(s.taint_details[0].time_added, None);
+    }
+
+    /// N taints across all three effects, with `timeAdded` — which Kubernetes
+    /// sets only for `NoExecute` — carried through as RFC 3339 for the detail
+    /// page. Order is the API server's, unchanged.
+    #[test]
+    fn carries_every_effect_and_the_time_a_no_execute_taint_was_added() {
+        use k8s_openapi::api::core::v1::{NodeSpec, Taint};
+        use k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;
+        let added: Time = serde_json::from_str("\"2026-09-02T08:15:00Z\"").unwrap();
+        let node = Node {
+            metadata: kube::core::ObjectMeta {
+                name: Some("worker-9".into()),
+                ..Default::default()
+            },
+            spec: Some(NodeSpec {
+                taints: Some(vec![
+                    Taint {
+                        key: "node.kubernetes.io/memory-pressure".into(),
+                        effect: "NoSchedule".into(),
+                        ..Default::default()
+                    },
+                    Taint {
+                        key: "spot".into(),
+                        value: Some("true".into()),
+                        effect: "PreferNoSchedule".into(),
+                        ..Default::default()
+                    },
+                    Taint {
+                        key: "team".into(),
+                        value: Some("payments".into()),
+                        effect: "NoExecute".into(),
+                        time_added: Some(added),
+                    },
+                ]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let s = summarise(node);
+        assert_eq!(s.taints, 3);
+        let effects: Vec<&str> = s.taint_details.iter().map(|t| t.effect.as_str()).collect();
+        assert_eq!(effects, ["NoSchedule", "PreferNoSchedule", "NoExecute"]);
+        assert_eq!(s.taint_details[1].value, "true");
+        assert_eq!(
+            s.taint_details[2].time_added.as_deref(),
+            Some("2026-09-02T08:15:00Z")
+        );
     }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -84,6 +84,7 @@ export * from "./lib/skills";
 export * from "./lib/storage";
 export * from "./lib/tabs";
 export * from "./lib/tabView";
+export * from "./lib/taints";
 export * from "./lib/terminal";
 export * from "./lib/terminalDriver";
 export * from "./lib/terminalReconnect";

--- a/packages/core/src/lib/k8sCapacity.test.ts
+++ b/packages/core/src/lib/k8sCapacity.test.ts
@@ -8,6 +8,7 @@ function node(overrides: Partial<NodeSummary> = {}): NodeSummary {
     status: "Ready",
     unschedulable: false,
     taints: 0,
+    taintDetails: [],
     version: "v1.30.0",
     roles: "worker",
     age: "10d",

--- a/packages/core/src/lib/manifest.ts
+++ b/packages/core/src/lib/manifest.ts
@@ -1,5 +1,6 @@
 import { isMap, isScalar, parse, parseDocument, visit } from "yaml";
 import { invokeCapability, type Invoker } from "../transport/transport";
+import type { NodeTaint } from "./taints";
 
 export interface NodeSummary {
   name: string;
@@ -9,6 +10,12 @@ export interface NodeSummary {
   unschedulable: boolean;
   /** Number of taints, excluding the auto-added unschedulable taint. */
   taints: number;
+  /**
+   * The taints `taints` counts — the same filtered set, so the list badge's
+   * number and its tooltip can never disagree. The Node detail page reads the
+   * live object instead and lists every taint, cordon one included.
+   */
+  taintDetails: NodeTaint[];
   version: string;
   roles: string;
   age: string;

--- a/packages/core/src/lib/settings.ts
+++ b/packages/core/src/lib/settings.ts
@@ -179,15 +179,25 @@ export function saveKubeconfigFiles(paths: string[]): void {
 const HIDDEN_COLUMNS_KEY = "srelens.hiddenColumns";
 
 /** Column keys the user has hidden for a given table view (keyed by view id). */
-export function loadHiddenColumns(view: string): string[] {
+/**
+ * The stored hidden-column keys for a view, or `null` when the view has never
+ * been touched. The distinction is what makes a default-hidden column
+ * possible: an absent entry means "no choice made, use the column's default",
+ * while a stored empty array means "the reader turned everything on".
+ */
+export function loadHiddenColumnsEntry(view: string): string[] | null {
   try {
     const parsed = JSON.parse(stored(HIDDEN_COLUMNS_KEY) ?? "{}") as unknown;
     const map = parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
     const keys = map[view];
-    return Array.isArray(keys) ? keys.filter((k): k is string => typeof k === "string") : [];
+    return Array.isArray(keys) ? keys.filter((k): k is string => typeof k === "string") : null;
   } catch {
-    return [];
+    return null;
   }
+}
+
+export function loadHiddenColumns(view: string): string[] {
+  return loadHiddenColumnsEntry(view) ?? [];
 }
 
 /** Persist the hidden column keys for a view, merging into the per-view map. */

--- a/packages/core/src/lib/taints.test.ts
+++ b/packages/core/src/lib/taints.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import {
+  TAINT_COLUMN_HINT,
+  formatTaint,
+  orderTaints,
+  parseTaints,
+  taintBadgeLabel,
+  taintBadgeText,
+  taintSortValue,
+  taintTally,
+  taintTallyText,
+  taintTimeAddedText,
+  taintTooltip,
+  type NodeTaint,
+} from "./taints";
+
+const taint = (key: string, effect: string, value = "", timeAdded?: string): NodeTaint => ({
+  key,
+  value,
+  effect,
+  ...(timeAdded ? { timeAdded } : {}),
+});
+
+const CONTROL_PLANE = taint("node-role.kubernetes.io/control-plane", "NoSchedule");
+const MEMORY_PRESSURE = taint("node.kubernetes.io/memory-pressure", "NoSchedule");
+const SPOT = taint("spot", "PreferNoSchedule", "true");
+const PAYMENTS = taint("team", "NoExecute", "payments", "2026-09-02T08:15:00Z");
+
+describe("formatTaint", () => {
+  it("writes kubectl's own key=value:effect", () => {
+    expect(formatTaint(PAYMENTS)).toBe("team=payments:NoExecute");
+  });
+
+  it("keeps the empty value visible, because a valueless taint is written that way", () => {
+    expect(formatTaint(CONTROL_PLANE)).toBe("node-role.kubernetes.io/control-plane=:NoSchedule");
+  });
+});
+
+describe("orderTaints", () => {
+  it("reads worst-first: NoExecute, then NoSchedule, then PreferNoSchedule", () => {
+    const ordered = orderTaints([SPOT, CONTROL_PLANE, PAYMENTS]);
+    expect(ordered.map((t) => t.effect)).toEqual(["NoExecute", "NoSchedule", "PreferNoSchedule"]);
+  });
+
+  it("holds the API server's order within one effect, so a node always reads the same way", () => {
+    const ordered = orderTaints([CONTROL_PLANE, MEMORY_PRESSURE]);
+    expect(ordered.map((t) => t.key)).toEqual([CONTROL_PLANE.key, MEMORY_PRESSURE.key]);
+  });
+
+  it("does not drop an effect it has never heard of — it sorts it last", () => {
+    const future = taint("future", "NoExecuteSoon");
+    expect(orderTaints([future, PAYMENTS]).map((t) => t.key)).toEqual(["team", "future"]);
+  });
+
+  it("leaves its argument alone", () => {
+    const input = [SPOT, PAYMENTS];
+    orderTaints(input);
+    expect(input.map((t) => t.effect)).toEqual(["PreferNoSchedule", "NoExecute"]);
+  });
+});
+
+describe("taintTooltip", () => {
+  it("is empty for a node with none, so a badge that isn't drawn has nothing to say", () => {
+    expect(taintTooltip([])).toBe("");
+  });
+
+  it("is one line for one taint", () => {
+    expect(taintTooltip([CONTROL_PLANE])).toBe("node-role.kubernetes.io/control-plane=:NoSchedule");
+  });
+
+  it("is one line per taint, worst effect first", () => {
+    expect(taintTooltip([CONTROL_PLANE, SPOT, PAYMENTS]).split("\n")).toEqual([
+      "team=payments:NoExecute",
+      "node-role.kubernetes.io/control-plane=:NoSchedule",
+      "spot=true:PreferNoSchedule",
+    ]);
+  });
+});
+
+describe("taintTally", () => {
+  it("counts zero of everything for a node with no taints", () => {
+    expect(taintTally([])).toEqual({ noSchedule: 0, preferNoSchedule: 0, noExecute: 0 });
+    expect(taintTallyText([])).toBe("0 / 0 / 0");
+  });
+
+  it("counts each effect into its own bucket", () => {
+    expect(taintTally([CONTROL_PLANE, MEMORY_PRESSURE, SPOT, PAYMENTS])).toEqual({
+      noSchedule: 2,
+      preferNoSchedule: 1,
+      noExecute: 1,
+    });
+  });
+
+  it("reads NoSchedule / PreferNoSchedule / NoExecute, the order the header hint names", () => {
+    expect(taintTallyText([CONTROL_PLANE, MEMORY_PRESSURE, SPOT, PAYMENTS])).toBe("2 / 1 / 1");
+    expect(TAINT_COLUMN_HINT).toBe("NoSchedule / PreferNoSchedule / NoExecute");
+  });
+
+  it("ignores an effect it does not know rather than miscounting it as one it does", () => {
+    expect(taintTally([taint("future", "Unknown")])).toEqual({
+      noSchedule: 0,
+      preferNoSchedule: 0,
+      noExecute: 0,
+    });
+  });
+});
+
+describe("taintTimeAddedText", () => {
+  it("gives the time Kubernetes stamped on a NoExecute taint", () => {
+    expect(taintTimeAddedText(PAYMENTS)).toBe("added 2026-09-02T08:15:00Z");
+  });
+
+  it("says there is no time in words, never as an em dash", () => {
+    // The classic design's `KV` drops any row whose value is "—", so an em
+    // dash here would delete the taint from that page rather than style it.
+    expect(taintTimeAddedText(CONTROL_PLANE)).toBe("time not recorded");
+    expect(taintTimeAddedText(CONTROL_PLANE)).not.toBe("—");
+  });
+});
+
+describe("taintBadgeLabel", () => {
+  it("spells the count out, because a screen reader reads '· 2' as punctuation", () => {
+    expect(taintBadgeLabel(2)).toBe("2 taints");
+  });
+
+  it("is singular for one", () => {
+    expect(taintBadgeLabel(1)).toBe("1 taint");
+  });
+
+  it("puts the count on the badge's own text too", () => {
+    expect(taintBadgeText(3)).toBe("Tainted · 3");
+  });
+});
+
+describe("taintSortValue", () => {
+  it("sorts a node with no taints as 0, not out of the order", () => {
+    expect(taintSortValue([])).toBe(0);
+    expect(taintSortValue(undefined)).toBe(0);
+  });
+
+  it("orders by count, most-constrained first when sorted descending", () => {
+    const nodes = [
+      { name: "three", taints: [CONTROL_PLANE, SPOT, PAYMENTS] },
+      { name: "none", taints: [] as NodeTaint[] },
+      { name: "one", taints: [CONTROL_PLANE] },
+    ];
+    const byTaints = [...nodes].sort((a, b) => taintSortValue(b.taints) - taintSortValue(a.taints));
+    expect(byTaints.map((n) => n.name)).toEqual(["three", "one", "none"]);
+  });
+
+  it("never lets the effect mix outrank the count", () => {
+    // One NoExecute taint is more disruptive than two PreferNoSchedule ones,
+    // and still sorts below them: the column's promise is the count.
+    expect(taintSortValue([PAYMENTS])).toBeLessThan(taintSortValue([SPOT, SPOT]));
+  });
+
+  it("breaks a tie on the more disruptive effect", () => {
+    expect(taintSortValue([PAYMENTS, PAYMENTS])).toBeGreaterThan(taintSortValue([SPOT, SPOT]));
+  });
+});
+
+describe("parseTaints", () => {
+  it("reads spec.taints off a live object", () => {
+    expect(
+      parseTaints({
+        taints: [{ key: "team", value: "payments", effect: "NoExecute", timeAdded: "2026-09-02T08:15:00Z" }],
+      }),
+    ).toEqual([PAYMENTS]);
+  });
+
+  it("keeps the cordon taint the list leaves out — this is the drill-down", () => {
+    const parsed = parseTaints({
+      taints: [
+        { key: "node.kubernetes.io/unschedulable", effect: "NoSchedule" },
+        { key: "dedicated", effect: "NoSchedule" },
+      ],
+    });
+    expect(parsed.map((t) => t.key)).toEqual(["node.kubernetes.io/unschedulable", "dedicated"]);
+  });
+
+  it("reports none for a spec that is not there, or carries no taints", () => {
+    expect(parseTaints(undefined)).toEqual([]);
+    expect(parseTaints({})).toEqual([]);
+    expect(parseTaints({ taints: "several" })).toEqual([]);
+    expect(parseTaints("nonsense")).toEqual([]);
+  });
+
+  it("drops an entry with nothing to identify it, and keeps the rest", () => {
+    const parsed = parseTaints({ taints: [null, { effect: "NoSchedule" }, { key: "real", effect: "NoExecute" }] });
+    expect(parsed).toEqual([{ key: "real", value: "", effect: "NoExecute" }]);
+  });
+
+  it("omits timeAdded rather than carrying an empty string for it", () => {
+    expect(parseTaints({ taints: [{ key: "k", effect: "NoSchedule" }] })[0]).not.toHaveProperty("timeAdded");
+  });
+});

--- a/packages/core/src/lib/taints.ts
+++ b/packages/core/src/lib/taints.ts
@@ -1,0 +1,154 @@
+/**
+ * Node taints, as the Nodes list and the Node detail page read them.
+ *
+ * The renderers live in two designs — `apps/desktop` (classic) and
+ * `packages/ui-next` — so every decision that could drift between them is
+ * made once here: the order the taints read in, the text of a taint, the
+ * per-effect tally, the badge's accessible name, and the number a Taints
+ * column sorts on. Each design supplies only its own Badge and its own
+ * tooltip host. (#426)
+ */
+
+/** One entry of a Node's `spec.taints`, mirroring `crates/kube`'s `NodeTaint`. */
+export interface NodeTaint {
+  key: string;
+  /** Empty for a valueless taint — a real value, not a missing one. */
+  value: string;
+  /** `NoSchedule`, `PreferNoSchedule` or `NoExecute`. */
+  effect: string;
+  /** RFC 3339; Kubernetes sets it only for `NoExecute` taints. */
+  timeAdded?: string;
+}
+
+/**
+ * Most disruptive first. `NoExecute` evicts pods that are already running,
+ * `NoSchedule` only turns new ones away, and `PreferNoSchedule` is a hint —
+ * so a tooltip that reads top-down reads worst-first, which is the order an
+ * operator triaging "why won't this pod land" needs. An unrecognised effect
+ * (a future one, or a malformed object) sorts last rather than being dropped:
+ * a taint nobody can see is worse than a taint in the wrong place.
+ */
+const EFFECT_RANK: Record<string, number> = {
+  NoExecute: 0,
+  NoSchedule: 1,
+  PreferNoSchedule: 2,
+};
+
+const rank = (effect: string): number => EFFECT_RANK[effect] ?? 3;
+
+/** `key=value:effect` — `kubectl`'s own notation, valueless taints included. */
+export function formatTaint(taint: NodeTaint): string {
+  return `${taint.key}=${taint.value}:${taint.effect}`;
+}
+
+/**
+ * The taints in tooltip order: severity first, then the API server's order
+ * within an effect (a stable sort), so two nodes with the same taints always
+ * read the same way.
+ */
+export function orderTaints(taints: readonly NodeTaint[]): NodeTaint[] {
+  return [...taints].sort((a, b) => rank(a.effect) - rank(b.effect));
+}
+
+/** One `key=value:effect` per line, worst effect first. */
+export function taintTooltip(taints: readonly NodeTaint[]): string {
+  return orderTaints(taints).map(formatTaint).join("\n");
+}
+
+/**
+ * What to show beside a taint on a detail page. Kubernetes stamps `timeAdded`
+ * only on `NoExecute` taints, so most rows genuinely have no time — and the
+ * text has to be a real one rather than an em dash, because the classic
+ * design's `KV` drops a row whose value is "—" and the taint would disappear
+ * from the page entirely. Shared so both designs say the same words.
+ */
+export function taintTimeAddedText(taint: NodeTaint): string {
+  return taint.timeAdded ? `added ${taint.timeAdded}` : "time not recorded";
+}
+
+export interface TaintTally {
+  noSchedule: number;
+  preferNoSchedule: number;
+  noExecute: number;
+}
+
+export function taintTally(taints: readonly NodeTaint[]): TaintTally {
+  const tally: TaintTally = { noSchedule: 0, preferNoSchedule: 0, noExecute: 0 };
+  for (const taint of taints) {
+    if (taint.effect === "NoSchedule") tally.noSchedule += 1;
+    else if (taint.effect === "PreferNoSchedule") tally.preferNoSchedule += 1;
+    else if (taint.effect === "NoExecute") tally.noExecute += 1;
+  }
+  return tally;
+}
+
+/** The Taints column's cell: `NoSchedule / PreferNoSchedule / NoExecute`. */
+export function taintTallyText(taints: readonly NodeTaint[]): string {
+  const { noSchedule, preferNoSchedule, noExecute } = taintTally(taints);
+  return `${noSchedule} / ${preferNoSchedule} / ${noExecute}`;
+}
+
+/** The header hint that says what the three numbers in a cell mean. */
+export const TAINT_COLUMN_HINT = "NoSchedule / PreferNoSchedule / NoExecute";
+
+/**
+ * The badge's accessible name. "· 2" is a visual shorthand a screen reader
+ * would read as punctuation, so the count is spelled out — and singular for
+ * one, because "1 taints" is the kind of detail that makes a reader distrust
+ * the rest of the screen.
+ */
+export function taintBadgeLabel(count: number): string {
+  return count === 1 ? "1 taint" : `${count} taints`;
+}
+
+/** The badge's visible text: the count rides on the existing word. */
+export function taintBadgeText(count: number): string {
+  return `Tainted · ${count}`;
+}
+
+/**
+ * What a Taints column sorts on: the count, so the most-constrained nodes come
+ * to the top, and a node with no taints sorts as 0 rather than falling out of
+ * the order. Ties break on the more disruptive effect, so among nodes with two
+ * taints each the one that is evicting pods sorts above the one that is not.
+ */
+export function taintSortValue(taints: readonly NodeTaint[] | undefined): number {
+  if (!taints || taints.length === 0) return 0;
+  const { preferNoSchedule, noSchedule, noExecute } = taintTally(taints);
+  // The count dominates; the effect mix is a fraction below 1, so it can only
+  // ever order nodes that already have the same number of taints.
+  const severity = (noExecute * 4 + noSchedule * 2 + preferNoSchedule) / (taints.length * 5);
+  return taints.length + severity;
+}
+
+const isRecord = (v: unknown): v is Record<string, unknown> =>
+  typeof v === "object" && v !== null && !Array.isArray(v);
+
+const text = (v: unknown): string => (typeof v === "string" ? v : "");
+
+/**
+ * Read `spec.taints` off a live object for the detail page. Unlike the list,
+ * this keeps *every* taint — including the one Kubernetes adds when a node is
+ * cordoned, which the list leaves to its SchedulingDisabled badge. The detail
+ * page is the drill-down, and `kubectl describe node` shows it there too.
+ *
+ * An entry that is not an object, or carries no `key`, is dropped: a row with
+ * nothing to identify it is noise, not a taint.
+ */
+export function parseTaints(spec: unknown): NodeTaint[] {
+  if (!isRecord(spec) || !Array.isArray(spec.taints)) return [];
+  const taints: NodeTaint[] = [];
+  for (const entry of spec.taints) {
+    if (!isRecord(entry)) continue;
+    const key = text(entry.key);
+    if (!key) continue;
+    const timeAdded = text(entry.timeAdded);
+    taints.push({
+      key,
+      value: text(entry.value),
+      effect: text(entry.effect),
+      ...(timeAdded ? { timeAdded } : {}),
+    });
+  }
+  return taints;
+}

--- a/packages/ui-kit/src/Table.tsx
+++ b/packages/ui-kit/src/Table.tsx
@@ -90,6 +90,14 @@ export interface Column<T> {
    *  sortable column stays clickable regardless of which one is the active
    *  sort — this only gates the header button existing at all. */
   sortable?: boolean;
+  /**
+   * Start this column hidden, so the ColumnPicker offers it rather than the
+   * default view carrying it. For a column that is useful when you go looking
+   * for it and clutter when you are not — a Nodes list's taint tally. Only the
+   * *default* is affected: once a reader has toggled the column either way for
+   * a kind, their choice is what is stored and this is not consulted again.
+   */
+  defaultHidden?: boolean;
   /** Dual role with opposite defaults:
    *  (1) Opt-in for the header filter funnel button: `filterable === true` shows
    *      a funnel that scopes the toolbar search to this column alone.

--- a/packages/ui-next/src/lib/columnPrefs.test.ts
+++ b/packages/ui-next/src/lib/columnPrefs.test.ts
@@ -71,3 +71,64 @@ describe("column preferences", () => {
     expect([...result.current]).toEqual([]);
   });
 });
+
+/**
+ * #426 needed a column that starts hidden — a Nodes list's taint tally, useful
+ * when you go looking for it and clutter when you are not. The record holds
+ * HIDDEN keys, so the whole difficulty is that "the reader turned the
+ * default-off column on" and "the reader has said nothing" are both an absent
+ * key, and the naive version springs the column back to hidden on relaunch.
+ */
+describe("a column that starts hidden", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    loadColumnPrefs();
+  });
+
+  it("is hidden before the reader has said anything", () => {
+    expect(hiddenColumns("nodes", ["taints"]).has("taints")).toBe(true);
+  });
+
+  it("leaves every other column of that kind alone", () => {
+    expect(hiddenColumns("nodes", ["taints"]).has("age")).toBe(false);
+  });
+
+  it("stays on once turned on — including across a reload", () => {
+    toggleColumn("nodes", "taints", undefined, ["taints"]);
+    expect(hiddenColumns("nodes", ["taints"]).has("taints")).toBe(false);
+    loadColumnPrefs();
+    expect(hiddenColumns("nodes", ["taints"]).has("taints")).toBe(false);
+  });
+
+  it("goes back off when turned off again", () => {
+    toggleColumn("nodes", "taints", undefined, ["taints"]);
+    toggleColumn("nodes", "taints", undefined, ["taints"]);
+    expect(hiddenColumns("nodes", ["taints"]).has("taints")).toBe(true);
+  });
+
+  it("does not drag another column down with it on that first toggle", () => {
+    toggleColumn("nodes", "taints", undefined, ["taints"]);
+    toggleColumn("nodes", "version", undefined, ["taints"]);
+    const hidden = hiddenColumns("nodes", ["taints"]);
+    expect(hidden.has("taints")).toBe(false);
+    expect(hidden.has("version")).toBe(true);
+  });
+
+  it("comes back to its default once the kind is reset", () => {
+    toggleColumn("nodes", "taints", undefined, ["taints"]);
+    resetColumns("nodes");
+    expect(hiddenColumns("nodes", ["taints"]).has("taints")).toBe(true);
+  });
+
+  it("is still stable per set of defaults, so a subscriber cannot tear", () => {
+    expect(hiddenColumns("nodes", ["taints"])).toBe(hiddenColumns("nodes", ["taints"]));
+    // …and asking with different defaults is a different question, not the
+    // memoised answer to the first one.
+    expect(hiddenColumns("nodes", ["taints"])).not.toBe(hiddenColumns("nodes", []));
+  });
+
+  it("changes nothing for a kind that declares no defaults", () => {
+    toggleColumn("pods", "node");
+    expect([...hiddenColumns("pods")]).toEqual(["node"]);
+  });
+});

--- a/packages/ui-next/src/lib/columnPrefs.ts
+++ b/packages/ui-next/src/lib/columnPrefs.ts
@@ -100,18 +100,44 @@ function save(storage: Storage) {
   }
 }
 
-/** The columns hidden for a kind, as a stable set until it next changes. */
-export function hiddenColumns(kind: string): ReadonlySet<string> {
-  const cached = snapshots.get(kind);
+/**
+ * The columns hidden for a kind, as a stable set until it next changes.
+ *
+ * `defaultHidden` is consulted only while the kind has **no stored entry at
+ * all**. That is the whole of what makes a default-off column work here: the
+ * record holds hidden keys, so "the reader turned the default-off column on"
+ * and "the reader has expressed nothing" would otherwise both be an absent
+ * key, and the column would spring back to hidden on the next launch. A
+ * stored empty array is a choice — everything shown — and outranks the
+ * defaults. (#426)
+ */
+export function hiddenColumns(kind: string, defaultHidden: readonly string[] = []): ReadonlySet<string> {
+  // The cache is keyed by both, because one kind can be asked with different
+  // defaults (a screen before and after its descriptor loads) and the memo
+  // must not answer the first question with the second one's set.
+  const cacheKey = `${kind}\u0000${defaultHidden.join(",")}`;
+  const cached = snapshots.get(cacheKey);
   if (cached) return cached;
-  const set = new Set(prefs[kind] ?? []);
-  snapshots.set(kind, set);
+  const set = new Set(prefs[kind] ?? defaultHidden);
+  snapshots.set(cacheKey, set);
   return set;
 }
 
-/** Hide a shown column, or show a hidden one, for one kind. */
-export function toggleColumn(kind: string, key: string, storage: Storage = settingsStorage): void {
-  const next = new Set(prefs[kind] ?? []);
+/**
+ * Hide a shown column, or show a hidden one, for one kind.
+ *
+ * Starts from the *effective* set, not the raw record, so the first toggle of
+ * a default-hidden column turns it on rather than hiding it a second time.
+ * Always writes an entry — an empty one included — which is what turns "no
+ * choice" into "chose everything".
+ */
+export function toggleColumn(
+  kind: string,
+  key: string,
+  storage: Storage = settingsStorage,
+  defaultHidden: readonly string[] = [],
+): void {
+  const next = new Set(prefs[kind] ?? defaultHidden);
   if (next.has(key)) next.delete(key);
   else next.add(key);
   prefs = { ...prefs, [kind]: [...next] };
@@ -119,7 +145,7 @@ export function toggleColumn(kind: string, key: string, storage: Storage = setti
   save(storage);
 }
 
-/** Forget a kind's hidden columns, putting it back to showing all of them. */
+/** Forget a kind's hidden columns, putting it back to its default columns. */
 export function resetColumns(kind: string, storage: Storage = settingsStorage): void {
   if (!(kind in prefs)) return;
   const { [kind]: _dropped, ...rest } = prefs;
@@ -128,11 +154,16 @@ export function resetColumns(kind: string, storage: Storage = settingsStorage): 
   save(storage);
 }
 
-/** The columns hidden for a kind, re-rendering whoever reads it when they change. */
-export function useHiddenColumns(kind: string): ReadonlySet<string> {
+/**
+ * The columns hidden for a kind, re-rendering whoever reads it when they
+ * change. `defaultHidden` is compared by value, not identity, so a caller may
+ * hand it a fresh array every render without tearing the store.
+ */
+export function useHiddenColumns(kind: string, defaultHidden: readonly string[] = []): ReadonlySet<string> {
+  const defaults = defaultHidden.join(",");
   return useSyncExternalStore(
     subscribe,
-    () => hiddenColumns(kind),
-    () => hiddenColumns(kind),
+    () => hiddenColumns(kind, defaults ? defaults.split(",") : []),
+    () => hiddenColumns(kind, defaults ? defaults.split(",") : []),
   );
 }

--- a/packages/ui-next/src/lib/kinds/columns.test.ts
+++ b/packages/ui-next/src/lib/kinds/columns.test.ts
@@ -43,7 +43,7 @@ import {
 } from "./columns";
 import { customColumns } from "./custom";
 import { genericClusterColumns, genericColumns } from "./generic";
-import type { CrdRef } from "@srelens/core";
+import type { CrdRef, NodeTaint } from "@srelens/core";
 
 /** Every typed column set columns.tsx exports — the design mock titles every
  *  one of these "Name", never the kind, and none of them may ask for a
@@ -256,7 +256,7 @@ describe("node columns", () => {
     const cpu = nodeColumns.find((c) => c.key === "cpu")!;
     const memory = nodeColumns.find((c) => c.key === "memory")!;
     const node = {
-      name: "n1", status: "Ready", roles: "worker", version: "1.30", age: "9d", taints: 0, unschedulable: false,
+      name: "n1", status: "Ready", roles: "worker", version: "1.30", age: "9d", taints: 0, taintDetails: [], unschedulable: false,
       allocatableCpuMillicores: 4000, allocatableMemoryMiB: 8192, allocatablePods: 110, instanceType: "",
     };
     const withCpu = { ...node, cpu: 2410 };
@@ -278,7 +278,7 @@ describe("node columns", () => {
 describe("a node's pill and its unhealthy dot are one verdict", () => {
   const node = (over: Partial<NodeRow>): NodeRow => ({
     name: "n1", status: "Ready", roles: "worker", version: "1.30", age: "9d",
-    taints: 0, unschedulable: false,
+    taints: 0, taintDetails: [], unschedulable: false,
     allocatableCpuMillicores: 4000, allocatableMemoryMiB: 8192, allocatablePods: 110, instanceType: "",
     ...over,
   });
@@ -304,7 +304,9 @@ describe("a node's pill and its unhealthy dot are one verdict", () => {
     // and both badges the mock draws are still there.
     expect(view.container.querySelector(".status")?.textContent).toBe("Ready");
     expect(view.container.textContent).toContain("SchedulingDisabled");
-    expect(view.container.textContent).toContain("Tainted (2)");
+    // "(2)" until #426 put the count on every tainted node's badge, singular
+    // included, and gave it an accessible name that spells the number out.
+    expect(view.container.textContent).toContain("Tainted \u00b7 2");
   });
 
   it("never pairs a healthy-toned pill with the dot, nor a danger-toned one without it", () => {
@@ -379,7 +381,7 @@ describe("flagged rows — the design's unhealthy dot, per kind", () => {
   // from its own pane. Both now read core's `nodeStatus`.
   it("flags a Node that is NotReady or cordoned, and neither when it is healthy and schedulable", () => {
     const base = {
-      name: "n1", roles: "worker", version: "1.30", age: "9d", taints: 0,
+      name: "n1", roles: "worker", version: "1.30", age: "9d", taints: 0, taintDetails: [],
       allocatableCpuMillicores: 4000, allocatableMemoryMiB: 8192, allocatablePods: 110, instanceType: "",
     };
     expect(nodeFlagged({ ...base, status: "Ready", unschedulable: false })).toBe(false);
@@ -453,7 +455,7 @@ describe("column alignment — a count or a measurement is end-aligned, everythi
     [daemonSetColumns, ["desired", "current", "ready", "upToDate", "available", "age"]],
     [jobColumns, ["completions", "duration", "age"]],
     [cronJobColumns, ["active", "age"]],
-    [nodeColumns, ["cpu", "memory", "age"]],
+    [nodeColumns, ["cpu", "memory", "taints", "age"]],
     [configMapColumns, ["keys", "age"]],
     [secretColumns, ["keys", "age"]],
     [resourceQuotaColumns, ["resources", "age"]],
@@ -515,5 +517,107 @@ describe("the generic and custom families follow the same two rules as the 23 ty
     expect(genericColumns.find((c) => c.key === "age")!.align).toBe("end");
     expect(genericClusterColumns.find((c) => c.key === "age")!.align).toBe("end");
     expect(customColumns(crd()).find((c) => c.key === "age")!.align).toBe("end");
+  });
+});
+
+/**
+ * #426 — the Nodes list answered "is this node tainted?" and not "how many?".
+ * One taint and five drew the identical pill, so the normal control-plane
+ * taint and a node with three pressure taints read the same.
+ */
+describe("a node's taint count", () => {
+  const taint = (key: string, effect: string, value = ""): NodeTaint => ({ key, value, effect });
+  const node = (over: Partial<NodeRow>): NodeRow => ({
+    name: "n1", status: "Ready", roles: "worker", version: "1.30", age: "9d",
+    taints: 0, taintDetails: [], unschedulable: false,
+    allocatableCpuMillicores: 4000, allocatableMemoryMiB: 8192, allocatablePods: 110, instanceType: "",
+    ...over,
+  });
+  const statusColumn = nodeColumns.find((c) => c.key === "status")!;
+  const taintsColumn = nodeColumns.find((c) => c.key === "taints")!;
+  const status = (n: NodeRow) => render(statusColumn.render!(n) as ReactElement);
+
+  it("draws no badge at all for a node with none — unchanged", () => {
+    expect(status(node({})).container.textContent).not.toContain("Tainted");
+  });
+
+  it("counts the one taint a fresh control-plane node carries", () => {
+    const view = status(node({ taints: 1, taintDetails: [taint("node-role.kubernetes.io/control-plane", "NoSchedule")] }));
+    expect(view.container.textContent).toContain("Tainted · 1");
+  });
+
+  it("counts N, so three pressure taints cannot read as the normal one", () => {
+    const view = status(
+      node({
+        taints: 3,
+        taintDetails: [
+          taint("node.kubernetes.io/memory-pressure", "NoSchedule"),
+          taint("node.kubernetes.io/disk-pressure", "NoSchedule"),
+          taint("team", "NoExecute", "payments"),
+        ],
+      }),
+    );
+    expect(view.container.textContent).toContain("Tainted · 3");
+  });
+
+  it("names the count for a screen reader rather than leaving it as '· 3'", () => {
+    const view = status(node({ taints: 3, taintDetails: [taint("a", "NoSchedule"), taint("b", "NoSchedule"), taint("c", "NoExecute")] }));
+    expect(view.container.querySelector("[aria-label]")?.getAttribute("aria-label")).toBe("3 taints");
+  });
+
+  it("says '1 taint', not '1 taints'", () => {
+    const view = status(node({ taints: 1, taintDetails: [taint("a", "NoSchedule")] }));
+    expect(view.container.querySelector("[aria-label]")?.getAttribute("aria-label")).toBe("1 taint");
+  });
+
+  it("lists every taint on hover, NoExecute first, and stays reachable by keyboard", () => {
+    const view = status(
+      node({
+        taints: 2,
+        taintDetails: [taint("node-role.kubernetes.io/control-plane", "NoSchedule"), taint("team", "NoExecute", "payments")],
+      }),
+    );
+    const host = view.container.querySelector("[title]")!;
+    expect(host.getAttribute("title")).toBe(
+      "team=payments:NoExecute\nnode-role.kubernetes.io/control-plane=:NoSchedule",
+    );
+    expect(host.getAttribute("tabindex")).toBe("0");
+  });
+
+  it("offers a Taints column that starts hidden, so the default view is unchanged", () => {
+    expect(taintsColumn.defaultHidden).toBe(true);
+    expect(taintsColumn.sortable).toBe(true);
+  });
+
+  it("renders the per-effect tally, and a real 0 / 0 / 0 for a node with none", () => {
+    expect(render(taintsColumn.render!(node({})) as ReactElement).container.textContent).toBe("0 / 0 / 0");
+    const busy = node({
+      taints: 3,
+      taintDetails: [taint("a", "NoSchedule"), taint("b", "NoSchedule"), taint("c", "NoExecute")],
+    });
+    expect(render(taintsColumn.render!(busy) as ReactElement).container.textContent).toBe("2 / 0 / 1");
+  });
+
+  it("explains the three numbers on a node that has none, and lists them on one that does", () => {
+    const empty = render(taintsColumn.render!(node({})) as ReactElement);
+    expect(empty.container.querySelector("[title]")?.getAttribute("title")).toBe(
+      "NoSchedule / PreferNoSchedule / NoExecute",
+    );
+    const one = render(
+      taintsColumn.render!(node({ taints: 1, taintDetails: [taint("dedicated", "NoSchedule")] })) as ReactElement,
+    );
+    expect(one.container.querySelector("[title]")?.getAttribute("title")).toBe("dedicated=:NoSchedule");
+  });
+
+  it("sorts on the count, bringing the most-constrained nodes to the top", () => {
+    const rows = [
+      node({ name: "one", taints: 1, taintDetails: [taint("a", "NoSchedule")] }),
+      node({ name: "none" }),
+      node({ name: "three", taints: 3, taintDetails: [taint("a", "NoSchedule"), taint("b", "NoSchedule"), taint("c", "NoExecute")] }),
+    ];
+    const sorted = [...rows].sort(
+      (a, b) => (taintsColumn.getSortValue!(b) as number) - (taintsColumn.getSortValue!(a) as number),
+    );
+    expect(sorted.map((n) => n.name)).toEqual(["three", "one", "none"]);
   });
 });

--- a/packages/ui-next/src/lib/kinds/columns.tsx
+++ b/packages/ui-next/src/lib/kinds/columns.tsx
@@ -31,6 +31,12 @@ import {
   type StatefulSetSummary,
   type StatusVerdict,
   type StorageClassSummary,
+  TAINT_COLUMN_HINT,
+  taintBadgeLabel,
+  taintBadgeText,
+  taintSortValue,
+  taintTallyText,
+  taintTooltip,
 } from "@srelens/core";
 import { Badge, StatusPill, type Column, type Tone } from "@srelens/ui-kit";
 
@@ -248,6 +254,37 @@ export const nodeVerdict = (row: NodeRow): StatusVerdict => nodeStatus(row.statu
 
 export const nodeFlagged = (row: NodeRow): boolean => nodeVerdict(row).flagged;
 
+/**
+ * The Tainted badge, carrying the count. A node with no taints renders no
+ * badge at all, exactly as before — the caller guards on that.
+ *
+ * The wrapper, not the Badge, holds the hint and the accessible name: `Badge`
+ * is a presentational span shared with five other callers, and widening its
+ * props for one of them is how a kit component turns into a grab bag. `title`
+ * is the tooltip host here rather than the kit's `Tooltip` because the content
+ * is several lines and `Tooltip` renders a single nowrap line; `tabIndex`
+ * keeps it reachable by keyboard rather than hover alone. (#426)
+ */
+function TaintBadge({ row }: { row: NodeRow }) {
+  const taints = row.taintDetails ?? [];
+  return (
+    <span tabIndex={0} title={taintTooltip(taints)} aria-label={taintBadgeLabel(row.taints)}>
+      <Badge tone={BADGE_TONE.neutral}>{taintBadgeText(row.taints)}</Badge>
+    </span>
+  );
+}
+
+/** The optional Taints column's cell: the per-effect tally, `0 / 0 / 0` for a
+ *  node with none — a number, not a blank, so the column reads as a column. */
+function TaintTally({ row }: { row: NodeRow }) {
+  const taints = row.taintDetails ?? [];
+  return (
+    <span title={taints.length > 0 ? taintTooltip(taints) : TAINT_COLUMN_HINT}>
+      {taintTallyText(taints)}
+    </span>
+  );
+}
+
 export const nodeColumns: Column<NodeRow>[] = [
   { key: "name", header: "Name", sortable: true },
   {
@@ -265,9 +302,7 @@ export const nodeColumns: Column<NodeRow>[] = [
       <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
         <StatusPill status={n.status} kind={nodeVerdict(n).health} />
         {n.unschedulable && <Badge tone={BADGE_TONE.warning}>SchedulingDisabled</Badge>}
-        {n.taints > 0 && (
-          <Badge tone={BADGE_TONE.neutral}>{n.taints > 1 ? `Tainted (${n.taints})` : "Tainted"}</Badge>
-        )}
+        {n.taints > 0 && <TaintBadge row={n} />}
       </span>
     ),
   },
@@ -275,6 +310,18 @@ export const nodeColumns: Column<NodeRow>[] = [
   { key: "cpu", header: "CPU", sortable: true, align: "end", render: (n) => metric(n.cpu, formatCpu), getSortValue: (n) => metricSort(n.cpu) },
   { key: "memory", header: "Memory", sortable: true, align: "end", render: (n) => metric(n.memory, formatMemory), getSortValue: (n) => metricSort(n.memory) },
   { key: "version", header: "Version" },
+  {
+    key: "taints",
+    header: "Taints",
+    sortable: true,
+    align: "end",
+    // Off until asked for: a tally is what you go looking for when a pod will
+    // not schedule, and noise on every other day. #411's Namespace columns are
+    // the same bargain.
+    defaultHidden: true,
+    render: (n) => <TaintTally row={n} />,
+    getSortValue: (n) => taintSortValue(n.taintDetails),
+  },
   { key: "age", header: "Age", sortable: true, align: "end", getSortValue: ageSortValue },
 ];
 

--- a/packages/ui-next/src/lib/overview.test.tsx
+++ b/packages/ui-next/src/lib/overview.test.tsx
@@ -47,6 +47,7 @@ function aNode(name: string, over: Partial<NodeSummary> = {}): NodeSummary {
     status: "Ready",
     unschedulable: false,
     taints: 0,
+    taintDetails: [],
     version: "v1.31.4",
     roles: "worker",
     age: "10d",

--- a/packages/ui-next/src/screens/Overview.test.tsx
+++ b/packages/ui-next/src/screens/Overview.test.tsx
@@ -88,6 +88,7 @@ function aNode(name: string, over: Partial<NodeSummary> = {}): NodeSummary {
     status: "Ready",
     unschedulable: false,
     taints: 0,
+    taintDetails: [],
     version: "v1.31.4",
     roles: "worker",
     age: "10d",

--- a/packages/ui-next/src/screens/Resources.tsx
+++ b/packages/ui-next/src/screens/Resources.tsx
@@ -46,6 +46,7 @@ import {
   NoClusterScreen,
   StaleSelectionAlert,
   columnOptionsFor,
+  defaultHiddenKeys,
   emptyTableCopy,
   toggleColumnVisibility,
   useResourceTabView,
@@ -167,8 +168,9 @@ function KindList({
   const namespace = clusterScoped ? "" : watchNamespaceForSelection(selection);
   const list = useResourceList<ListRow>(name, slug, descriptor, namespace, files);
 
-  const hidden = useHiddenColumns(slug);
   const allColumns = descriptor?.columns ?? NO_COLUMNS;
+  const defaultHidden = useMemo(() => defaultHiddenKeys(allColumns), [allColumns]);
+  const hidden = useHiddenColumns(slug, defaultHidden);
   const columns = useMemo(
     // The identifier is never hidden: a table whose rows lost their name is
     // not a table any more. `ColumnPicker` pins the same key.
@@ -312,7 +314,7 @@ function KindList({
   const lower = title.toLocaleLowerCase();
 
   function onToggleColumn(key: string) {
-    toggleColumnVisibility({ key, storageKey: slug, hidden, filterKey, tabId });
+    toggleColumnVisibility({ key, storageKey: slug, hidden, filterKey, tabId, defaultHidden });
   }
 
   if (!descriptor) {

--- a/packages/ui-next/src/screens/detail/NodeBody.test.tsx
+++ b/packages/ui-next/src/screens/detail/NodeBody.test.tsx
@@ -77,7 +77,8 @@ describe("NodeDetailsBody", () => {
   it("is a run of flat blocks, not a stack of cards", () => {
     const { container } = render(<NodeDetailsBody object={node({})} />);
     const blocks = [...container.children];
-    expect(blocks).toHaveLength(2);
+    // Info, Capacity, and Taints since #426.
+    expect(blocks).toHaveLength(3);
     for (const block of blocks) expect(block.matches("section.section")).toBe(true);
     expect(container.querySelector(".card")).toBeNull();
   });
@@ -103,5 +104,81 @@ describe("NodeDetailsBody", () => {
       // Node has no `relatedPodSelector` case, so GenericBody fetches nothing.
       expect(screen.queryByRole("heading", { name: "Pods" })).toBeNull();
     });
+  });
+});
+
+/**
+ * #426 — the drill-down the Nodes list's taint count sends a reader to. Unlike
+ * the list, this keeps every taint, cordon one included: there is no
+ * SchedulingDisabled badge here to say it, and `kubectl describe node` shows
+ * it, so dropping it would be the pane disagreeing with kubectl.
+ */
+describe("NodeDetailsBody — Taints", () => {
+  it("says so plainly on a node with none, rather than leaving the block out", () => {
+    render(<NodeDetailsBody object={node({})} />);
+    expect(screen.getByText("Taints")).toBeTruthy();
+    expect(screen.getByText("Count")).toBeTruthy();
+    expect(screen.getByText("0")).toBeTruthy();
+  });
+
+  it("lists one taint as key=value:effect", () => {
+    render(
+      <NodeDetailsBody
+        object={node({ taints: [{ key: "node-role.kubernetes.io/control-plane", effect: "NoSchedule" }] })}
+      />,
+    );
+    expect(screen.getByText("node-role.kubernetes.io/control-plane=:NoSchedule")).toBeTruthy();
+  });
+
+  it("lists N taints worst-effect first", () => {
+    render(
+      <NodeDetailsBody
+        object={node({
+          taints: [
+            { key: "spot", value: "true", effect: "PreferNoSchedule" },
+            { key: "node.kubernetes.io/memory-pressure", effect: "NoSchedule" },
+            { key: "team", value: "payments", effect: "NoExecute" },
+          ],
+        })}
+      />,
+    );
+    const rows = screen.getAllByText(/:(No|Prefer)/).map((el) => el.textContent);
+    expect(rows).toEqual([
+      "team=payments:NoExecute",
+      "node.kubernetes.io/memory-pressure=:NoSchedule",
+      "spot=true:PreferNoSchedule",
+    ]);
+  });
+
+  it("shows timeAdded for the NoExecute taint that has one, and an em dash for the rest", () => {
+    render(
+      <NodeDetailsBody
+        object={node({
+          taints: [
+            { key: "team", value: "payments", effect: "NoExecute", timeAdded: "2026-09-02T08:15:00Z" },
+            { key: "dedicated", effect: "NoSchedule" },
+          ],
+        })}
+      />,
+    );
+    expect(screen.getByText("added 2026-09-02T08:15:00Z")).toBeTruthy();
+    // Not an em dash: classic's KV drops a row whose value is "—", so the
+    // taint would have vanished from that design's page altogether.
+    expect(screen.getByText("time not recorded")).toBeTruthy();
+  });
+
+  it("keeps the cordon taint the list leaves to its SchedulingDisabled badge", () => {
+    render(
+      <NodeDetailsBody
+        object={node({
+          unschedulable: true,
+          taints: [
+            { key: "node.kubernetes.io/unschedulable", effect: "NoSchedule" },
+            { key: "dedicated", effect: "NoSchedule" },
+          ],
+        })}
+      />,
+    );
+    expect(screen.getByText("node.kubernetes.io/unschedulable=:NoSchedule")).toBeTruthy();
   });
 });

--- a/packages/ui-next/src/screens/detail/NodeBody.tsx
+++ b/packages/ui-next/src/screens/detail/NodeBody.tsx
@@ -1,4 +1,12 @@
-import { asRecord, str, type K8sObject } from "@srelens/core";
+import {
+  asRecord,
+  formatTaint,
+  orderTaints,
+  parseTaints,
+  str,
+  taintTimeAddedText,
+  type K8sObject,
+} from "@srelens/core";
 import { KV, StatusPill } from "@srelens/ui-kit";
 import { Section } from "./Section";
 
@@ -53,6 +61,45 @@ function CapacitySection({ object }: { object: K8sObject }) {
 }
 
 /**
+ * A Node's taints, in full — the drill-down the list's count sends a reader to.
+ *
+ * Unlike the list, this reads the live object and keeps EVERY taint, including
+ * the one Kubernetes adds when a node is cordoned. The list leaves that one out
+ * because the SchedulingDisabled badge beside its count already says it; here
+ * there is no such badge, and `kubectl describe node` shows it too, so leaving
+ * it out would be the pane quietly disagreeing with kubectl.
+ *
+ * The section stays on a node with none and says so: an absent block cannot be
+ * told apart from a block that failed to render, and "no taints" is a fact an
+ * operator asking why a pod will not schedule specifically wants confirmed.
+ *
+ * `timeAdded` is set by Kubernetes only for `NoExecute` taints; the rest say
+ * so in words, which `taintTimeAddedText` explains is not merely a wording
+ * choice. (#426)
+ */
+function TaintsSection({ object }: { object: K8sObject }) {
+  const taints = orderTaints(parseTaints(object.spec));
+  return (
+    <Section title="Taints">
+      {taints.length === 0 ? (
+        // "Taints" as the key under a section already headed Taints is the
+        // word twice; the count is the fact, and it is the list's zero-state.
+        <KV k="Count" v="0" />
+      ) : (
+        taints.map((taint) => (
+          <KV
+            key={`${taint.key}:${taint.effect}`}
+            k={formatTaint(taint)}
+            v={taintTimeAddedText(taint)}
+            mono
+          />
+        ))
+      )}
+    </Section>
+  );
+}
+
+/**
  * A Node's Details pane: Info and Capacity, in classic's own order
  * (`NodeBody`). `relatedPodSelector` has no case for "Node", so `GenericBody`
  * fetches no related pods for one; its unheaded identity block and its
@@ -68,6 +115,7 @@ export function NodeDetailsBody({ object }: { object: K8sObject }) {
     <>
       <InfoSection object={object} />
       <CapacitySection object={object} />
+      <TaintsSection object={object} />
     </>
   );
 }

--- a/packages/ui-next/src/screens/resourceShell.tsx
+++ b/packages/ui-next/src/screens/resourceShell.tsx
@@ -244,10 +244,18 @@ export function toggleColumnVisibility(params: {
   hidden: ReadonlySet<string>;
   filterKey: string | null;
   tabId: string;
+  /** Keys of the kind's `defaultHidden` columns, so the first toggle of one
+   *  starts from what the reader is actually looking at. (#426) */
+  defaultHidden?: readonly string[];
 }): void {
-  const { key, storageKey, hidden, filterKey, tabId } = params;
+  const { key, storageKey, hidden, filterKey, tabId, defaultHidden } = params;
   if (!hidden.has(key) && filterKey === key) setTabView(tabId, { filterKey: null });
-  toggleColumn(storageKey, key);
+  toggleColumn(storageKey, key, undefined, defaultHidden);
+}
+
+/** The keys a kind starts with hidden — `ColumnPicker`'s "off by default". */
+export function defaultHiddenKeys<T>(columns: readonly Column<T>[]): string[] {
+  return columns.filter((column) => column.defaultHidden).map((column) => column.key);
 }
 
 /** "This kind has none" and "the filter matched none" are different facts,


### PR DESCRIPTION
Closes #426.

Surfaces the **number of taints** on a node, so the Nodes list distinguishes "just the normal control-plane taint" from "several pressure/custom taints" at a glance — instead of the binary `Tainted` badge it showed before.

## What ships — all four parts, in both the classic and `ui-next` designs

1. **Count on the badge** — `Tainted · 2` for every tainted node, singular included (`Tainted · 1` for the lone control-plane taint, which is the screenshot case). A node with 0 taints still draws no badge.
2. **Hover tooltip** — every taint as `key=value:effect`, one per line, `NoExecute` first (it evicts running pods; `NoSchedule` only turns new ones away). The host is tabbable, so it isn't hover-only.
3. **Optional Taints column** — a per-effect tally `2 / 0 / 1` (NoSchedule / PreferNoSchedule / NoExecute), **sortable on count**, **default off** via a new `Column.defaultHidden` in both designs.
4. **Node-detail Taints section** — `key=value:effect` + `timeAdded`, in both designs.

## Judgment calls (all deliberate)

- **Count semantics.** The existing list count excludes the auto-added `node.kubernetes.io/unschedulable` taint. Reading `spec.taints.length` literally would make a cordoned-but-otherwise-clean node newly show `Tainted · 1` — a behaviour change beyond the ticket. So the **list** (badge, tooltip, column all read one filtered set, so the number and the tooltip can never disagree) keeps the exclusion, while the **detail page** lists every taint including the cordon one, as `kubectl describe` does. The list already shows a `SchedulingDisabled` badge beside the count to convey that state.
- **Shared logic, not a shared component.** Classic renders shadcn's `Badge`, `ui-next` renders ui-kit's — no common render path. So every word, ordering, tally, `aria-label` and sort value lives once in `@srelens/core`'s `taints`, and each design supplies only its own `Badge`. This mirrors the repo's existing cross-design pattern (`ageSortValue`, `nodeStatus`).
- **`defaultHidden` needed a store change.** Both designs persist only *hidden* keys, so "reader turned the default-off column on" and "reader has said nothing" were the same absent key — the column would spring back to hidden on next launch. Fixed by making a stored entry (empty included) outrank the defaults, with the toggle starting from the effective set. Tested both directions, plus reset and remount, in both designs.

## A real bug the tests caught

Classic's KV renderer drops any row whose value is `—`. The first version used an em dash for taints with no `timeAdded` (Kubernetes stamps it only on `NoExecute`), which **silently deleted those taints** from the classic detail page. Fixed at the source with a shared `taintTimeAddedText()` returning `time not recorded`, so both designs say the same words and neither can regress — with a test asserting it is not an em dash and a comment saying why.

## Verification

- Root `pnpm test` (with coverage, the real gate): **5524/5524 tests pass, 92.9% lines** (new `core/taints.ts` at 100%).
- `cargo test --workspace`: green. `pnpm typecheck`: clean across all 4 projects.
- 4 existing tests updated as genuine consequences (each with a comment): the two `Tainted (2)` badge-format assertions; the end-aligned-columns invariant gained `taints`; `NodeBody`'s flat-blocks count 2 → 3; and one classic persistence assertion now stores `['taints','version']` because the first toggle on that view writes the default down.

Read-only throughout: nothing adds, edits, or removes a taint.

## Diff

25 files, +1149 / −44. New: `packages/core/src/lib/taints.ts` and its test. Touched `crates/kube/src/nodes.rs`, core manifest/settings/index, ui-kit `Table`, `ui-next` columns/columnPrefs/resourceShell/Resources/NodeBody, classic ResourceBrowser/ResourceOverview/Table/useColumnVisibility.
