### PR TITLE
fix(desktop): grant the window commands every close goes through (#425)

### DIFF
--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -7,6 +7,8 @@
   ],
   "permissions": [
     "core:default",
+    "core:window:allow-close",
+    "core:window:allow-destroy",
     "core:webview:allow-set-webview-zoom",
     "core:window:allow-set-decorations",
     "core:window:allow-set-title-bar-style",

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -6,8 +6,10 @@ import React from "react";
 // and a stub window so we can assert tab-close vs. window-close behavior.
 const tauri = vi.hoisted(() => {
   const handlers = new Map<string, (e: { payload: unknown }) => void>();
-  const windowClose = vi.fn();
-  const windowDestroy = vi.fn();
+  // Promise-returning, like the real commands: the close path chains a
+  // `.catch()` onto destroy(), which a bare vi.fn() would make explode.
+  const windowClose = vi.fn(() => Promise.resolve());
+  const windowDestroy = vi.fn(() => Promise.resolve());
   return {
     handlers,
     windowClose,
@@ -348,6 +350,30 @@ describe("App", () => {
     // write has drained — close() would re-enter this handler and loop.
     expect(preventDefault).toHaveBeenCalled();
     expect(tauri.windowDestroy).toHaveBeenCalled();
+    delete (window as unknown as { __TAURI_INTERNALS__?: object }).__TAURI_INTERNALS__;
+  });
+
+  it("still closes when destroy() is refused, rather than wedging the window (#425)", async () => {
+    // `core:window:allow-destroy` was never granted, so the destroy that
+    // re-issues the cancelled close was rejected by the ACL and nothing closed
+    // the window: the macOS red traffic light did nothing, and only Cmd+Q —
+    // which quits without reaching this handler — could shut the app down.
+    // The grant is the fix; this is the belt, because any rejection here has
+    // the same cost, and losing a flush is cheaper than losing the quit.
+    (window as unknown as { __TAURI_INTERNALS__?: object }).__TAURI_INTERNALS__ = {};
+    tauri.windowDestroy.mockClear().mockRejectedValueOnce(new Error("window.destroy not allowed"));
+    tauri.windowClose.mockClear();
+    render(<App />);
+
+    expect(tauri.closeRequestedHandler).toBeTypeOf("function");
+    await tauri.closeRequestedHandler!({ preventDefault: vi.fn() });
+    expect(tauri.windowClose).toHaveBeenCalled();
+
+    // close() re-emits this event, so the second pass has to let it through —
+    // cancelling the close it just asked for is how a fallback becomes a loop.
+    const second = vi.fn();
+    await tauri.closeRequestedHandler!({ preventDefault: second });
+    expect(second).not.toHaveBeenCalled();
     delete (window as unknown as { __TAURI_INTERNALS__?: object }).__TAURI_INTERNALS__;
   });
 

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -473,18 +473,34 @@ export function App() {
     if (typeof win?.onCloseRequested !== "function") return;
     let unlisten: (() => void) | undefined;
     let disposed = false;
+    // Set once we have taken over a close, so the close() below — which
+    // re-emits this event — is let through instead of cancelled a second time.
+    let closing = false;
     void win
       .onCloseRequested(async (event) => {
+        if (closing) return;
         event.preventDefault();
-        flushSaveOpenTabs();
-        // Bounded: a stuck or slow write must never leave the user unable to
-        // quit, so the close proceeds either way.
-        await Promise.race([
-          flushSettingsWrites(),
-          new Promise((resolve) => setTimeout(resolve, CLOSE_WRITE_TIMEOUT_MS)),
-        ]);
-        // destroy(), not close() — close() re-emits this event and would loop.
-        await win.destroy();
+        closing = true;
+        try {
+          flushSaveOpenTabs();
+          // Bounded: a stuck or slow write must never leave the user unable to
+          // quit, so the close proceeds either way.
+          await Promise.race([
+            flushSettingsWrites(),
+            new Promise((resolve) => setTimeout(resolve, CLOSE_WRITE_TIMEOUT_MS)),
+          ]);
+        } finally {
+          // Whatever the drain did, the close it cancelled has to be re-issued:
+          // a best-effort flush must never cost the user the ability to quit.
+          // Anything thrown above escaped here and left the window stuck open
+          // with the red light dead — which is exactly what an ungranted
+          // `core:window:allow-destroy` did to every close but Cmd+Q. (#425)
+          //
+          // destroy(), not close() — close() re-emits this event, so it is the
+          // last resort rather than the path, and the guard above stops it
+          // looping.
+          await win.destroy().catch(() => win.close());
+        }
       })
       .then((fn) => {
         if (disposed) fn();

--- a/apps/desktop/src/tauri-capabilities.test.ts
+++ b/apps/desktop/src/tauri-capabilities.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment node
+// (reads files from disk; jsdom buys nothing here)
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+
+/**
+ * Tauri v2 gates every window command behind an ACL entry in
+ * `capabilities/default.json`. Nothing checks the two against each other:
+ * `getCurrentWindow().destroy()` type-checks, ships, and then rejects at
+ * runtime on a build that never granted `core:window:allow-destroy`.
+ *
+ * That is #425. `core:default` brings in `core:window:default`, which is the
+ * READ-ONLY half of the window API — every getter, no mutator. So the close
+ * this app intercepts and re-issues was refused by the ACL, nothing ever closed
+ * the window, and the macOS red traffic light did nothing; only Cmd+Q, which
+ * quits the process without reaching the webview's close-requested handler,
+ * could shut the app down. Cmd+W on the last tab was refused the same way.
+ *
+ * A rejected promise was the only symptom and both call sites swallowed it, so
+ * the app failed silently and identically on every platform. Pinned here
+ * because the mismatch is invisible to the compiler and to every test that
+ * mocks the window away — which is all of them.
+ */
+const root = join(__dirname, "..");
+const capabilities = JSON.parse(
+  readFileSync(join(root, "src-tauri/capabilities/default.json"), "utf8"),
+) as { permissions: string[] };
+
+/**
+ * Methods on the window handle that are not commands: they subscribe through
+ * the event system, which `core:default` already covers, so they need no
+ * `core:window:allow-*` of their own.
+ */
+const NOT_COMMANDS = new Set(["onCloseRequested", "onResized", "onMoved", "onFocusChanged", "listen", "once"]);
+
+/** `setTitleBarStyle` -> `set-title-bar-style`, the shape ACL keys take. */
+function kebab(method: string): string {
+  return method.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
+}
+
+/** Every `.ts`/`.tsx` under `dir`, minus tests and type declarations. */
+function sources(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name !== "node_modules") out.push(...sources(path));
+    } else if (/[.]tsx?$/.test(entry.name) && !/[.]test[.]|[.]d[.]ts$/.test(entry.name)) {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+/**
+ * The window commands the frontend actually calls, keyed by file.
+ *
+ * Deliberately a scan for the two shapes this repo uses —
+ * `getCurrentWindow().m()`, and `const win = getCurrentWindow()` followed by
+ * `win.m()` — rather than a parse. A third shape would go unseen here instead
+ * of failing, which is the safe direction for a test whose job is to cover the
+ * shapes that exist.
+ */
+function windowCalls(): Map<string, Set<string>> {
+  const HANDLE = "getCurrentWindow[(][)]";
+  const found = new Map<string, Set<string>>();
+  for (const file of sources(join(root, "src"))) {
+    const text = readFileSync(file, "utf8");
+    if (!text.includes("getCurrentWindow()")) continue;
+    const handles = [HANDLE];
+    const bound = new RegExp("(?:const|let) +([A-Za-z_][A-Za-z0-9_]*) *= *" + HANDLE, "g");
+    for (const [, name] of text.matchAll(bound)) handles.push(name);
+
+    const calls = new RegExp("(?:" + handles.join("|") + ")[.]([A-Za-z]+) *[(]", "g");
+    for (const [, method] of text.matchAll(calls)) {
+      if (NOT_COMMANDS.has(method)) continue;
+      const key = relative(root, file).split(sep).join("/");
+      if (!found.has(key)) found.set(key, new Set());
+      found.get(key)!.add(method);
+    }
+  }
+  return found;
+}
+
+describe("Tauri window capabilities", () => {
+  it("grants close and destroy, which every window close goes through (#425)", () => {
+    // Named outright rather than only derived below: these two are what the
+    // bug was, so a refactor that stops calling them should have to delete
+    // this on purpose.
+    expect(capabilities.permissions).toContain("core:window:allow-close");
+    expect(capabilities.permissions).toContain("core:window:allow-destroy");
+  });
+
+  it("grants every window command the frontend calls", () => {
+    const calls = windowCalls();
+    expect(calls.size, "no getCurrentWindow() call found at all — has this scan gone stale?").toBeGreaterThan(0);
+
+    const missing: string[] = [];
+    for (const [file, methods] of calls) {
+      for (const method of methods) {
+        const permission = "core:window:allow-" + kebab(method);
+        if (!capabilities.permissions.includes(permission)) {
+          missing.push(file + " calls " + method + "(), which needs " + permission);
+        }
+      }
+    }
+    expect(missing, "capabilities/default.json is missing window grants: " + missing.join("; ")).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #425.

## What was wrong

Not the traffic lights, and not macOS-specific.

`App.tsx` intercepts `CloseRequested` to drain pending settings writes, then re-issues the close as `win.destroy()`. But `capabilities/default.json` granted only `core:default` — whose `core:window:default` set is the **read-only** half of the window API: every getter, no mutator. The ACL refused the destroy, the rejection landed in a swallowed `.catch`, and nothing ever closed the window.

Cmd+Q kept working because macOS quits the process without routing through the webview's close-requested handler. That asymmetry is what made the bug look like a dead red light rather than a missing permission. `getCurrentWindow().close()` — Cmd+W on the last tab — was refused the same way, and on Windows Alt+F4 goes through `WM_CLOSE` too, so there was no escape hatch at all short of Task Manager.

Only the **classic** design is affected. The new design mounts `NextApp`, which registers no close handler, so its close was never intercepted.

## The change

- **`capabilities/default.json`** — grant `core:window:allow-close` and `core:window:allow-destroy`. This is the fix.
- **`App.tsx`** — the drain now sits in `try`/`finally` with the close re-issued from the `finally`, falling back to `close()` behind a re-entry guard. The old shape was the real hazard: *any* rejection between `preventDefault()` and `destroy()` left the window permanently unclosable. Losing a best-effort flush is far cheaper than losing the ability to quit.
- **`tauri-capabilities.test.ts`** (new) — scans the frontend for `getCurrentWindow()` commands and fails on any that is not granted. Nothing else checks the two against each other: the call type-checks, ships, and only then rejects at runtime. Reverting the grant makes it name both missing permissions.
- **`App.test.tsx`** — regression test for a refused `destroy()`. The window stubs now return promises, like the real commands do.

## Verification

Built and ran the real Tauri app, posting `WM_CLOSE` to the window — the message the close button sends, on the same `CloseRequested` path the macOS red light takes.

A first attempt was invalid and worth recording: the dev profile was on the new design, and stale workspace deps meant the frontend never mounted, so the window closed natively and everything looked fine. After `pnpm install` and forcing the classic design, a probe handler that only cancels confirmed the harness was actually live. Then, same build, one variable:

| `App.tsx` | grant | result |
| --- | --- | --- |
| original | absent | **still running** — bug reproduced |
| original | present | closed |
| fixed | present | closed |

Desktop suite: 777 passing. Two pre-existing failures in `tailwind-sources.test.ts` are unrelated — they fail identically on a clean tree (Windows backslash paths not matching the scan globs).

Verified on Windows, not macOS. The ACL is cross-platform and the handler is the same code, but a macOS-only contribution to the reported symptom can't be ruled out from here — worth a second pair of eyes on a Mac before release.
