### PR TITLE
feat(ui-next): the resource editor — edit, create and delete a manifest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,13 @@ over the values.
   `NamespaceChoice` in `screens/resourceShell.tsx` are the shared pair —
   reach for them rather than writing the loading state again, because that is
   the part that drifts (an empty dropdown reads as "this cluster has none").
+- **Edge to edge.** The desktop layout is flush regions divided by
+  hairlines, each scrolling on its own — no gutters, no floating cards, no
+  page scroll. The rule is in `kit.css` under "panes" and it is easy to
+  break by habit: the editor sat in `p-4` inside a rounded, bordered frame,
+  which is a card in a design that has none. A component that IS a region
+  fills it; a control inside one keeps its frame (that is what `CodeEditor`'s
+  `flush` distinguishes). Prose still gets a gutter — a document does not.
 - **Machine text does not wrap.** A `last-applied-configuration` annotation is
   one line of a thousand characters; `break-all` turns it into a
   paragraph-shaped block that hides the short lines around it. Let it run and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,124 @@
+# Working in this repo
+
+Read [`CONTRIBUTING.md`](CONTRIBUTING.md) and [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md)
+first. They are the guide: setup, architecture, the capability registry, the
+test-driven rule, the coverage floors. This file does not repeat them.
+
+What is here is the short list of traps this codebase has actually sprung —
+each one a bug that shipped, passed CI, and was found by a person looking at
+the screen. If a rule below reads as obvious, it is only obvious in hindsight.
+
+## Capabilities: the wire name is the caller's, not the struct's
+
+A capability's `*In` struct is deserialized from the JSON that
+`@srelens/core`'s wrapper sends. The wrapper writes `camelCase`. Rust writes
+`snake_case`. **Any multi-word field must carry `#[serde(rename = "…")]`**
+naming it exactly as the wrapper sends it — `ListEventsIn`,
+`ListReplicaSetsIn` and `PodsForSelectorIn` each do.
+
+`OpenApiSchemaIn` did not. Its field was `api_version`; every caller sends
+`apiVersion`; so every call failed to deserialize and editor field
+autocomplete never worked in either design, in any release. Nothing caught it
+for two reasons, and both are rules:
+
+- **Test with the caller's payload, not the struct's field names.** The e2e
+  case sent `{"api_version": …}` — the struct's own spelling — so it agreed
+  with the bug instead of catching it. An e2e case that hand-writes JSON is
+  asserting a contract; write the contract the app actually speaks. Better
+  still, add a unit test that deserializes the wrapper's payload and asserts
+  the wrong spelling is rejected, so nothing drifts back.
+- **Never collapse a failed call into a fact about the cluster.** See below.
+
+Adding a capability? Follow the walkthrough in `docs/DEVELOPMENT.md`, and
+before you finish, read your `*In` struct beside the `core` wrapper that calls
+it, field by field.
+
+## Say what you know, not what you guess
+
+Two different facts must not render as one sentence:
+
+- the call failed (refused, timed out, unreachable), and
+- the cluster answered, and the thing genuinely is not there.
+
+The schema pane rendered both as "The cluster has no schema for Secret" — a
+confident, wrong claim about a built-in kind that certainly has one, and it
+hid the bug above for as long as it stood. A failed call says what failed,
+gives the reason through `describeError`, and offers a retry. An absence says
+the cluster serves none.
+
+The same rule caught an apply that came back with no documents and was toasted
+as a success, and a dry-run diff whose failure was rendered as "No changes." —
+false reassurance one click before Apply.
+
+## The route is the identity
+
+`openTab` dedupes by route **string**. Whatever distinguishes two things a
+reader can have open at once has to be *in* the route, or the second one
+silently focuses the first:
+
+- `/edit/<cluster>/<kind>/<namespace>/<name>` — the cluster is in it because
+  the editor pins the cluster it opened on. Without it, Edit on staging's
+  `default/web` focused prod's draft and staging's could not be opened at all.
+- A custom kind carries its group (`acme.io%2FDeployment`), because a CRD may
+  legally reuse a built-in kind's name and resolving by name alone lands on
+  the built-in — including for delete.
+- Screens are keyed by route, **not** by the rail's cluster. Keying by
+  `stableId` remounts the screen on a rail switch, which re-pins it, throws
+  the draft away, and makes `useClusterGate` see `pinned === live` — so the
+  write goes to the new cluster with no warning.
+
+And: **a route with no screen registered in `lib/routes.ts` renders the
+Placeholder.** That is the whole of "clicking Edit does nothing". A new screen
+is not done until `SCREENS` (or a parse-based match in `screenFor`) names it,
+and something in the app opens it — `/new` had a route, a screen, and no
+button anywhere for weeks.
+
+## Secrets
+
+`k8s.getManifest` returns a Secret's values in the clear. Redact on arrival
+with `redactSecretManifest`, fail closed, and keep the editor read-only until
+the reader reveals — through `k8s.getSecret`, the consent-gated read. Apply
+stays off while placeholders are shown, or applying writes the placeholders
+over the values.
+
+## UI
+
+- **Don't mix a native `<select>` with the app's picker in one control
+  cluster.** The kit's `Select` is a real native `<select>` and the new design
+  uses it deliberately for short, fixed, app-defined option sets. But the
+  browser draws its own dropdown for it, so beside a `Combobox` it reads as
+  another application's control.
+- **Any list of cluster-supplied values gets `Combobox` or `MultiSelect`.**
+  Namespaces, contexts, containers, kinds: you do not know at design time
+  whether it is four entries or four hundred, and a native dropdown over
+  sixty namespaces is a wall with no search. `NamespacePicker` and
+  `NamespaceChoice` in `screens/resourceShell.tsx` are the shared pair —
+  reach for them rather than writing the loading state again, because that is
+  the part that drifts (an empty dropdown reads as "this cluster has none").
+- **Machine text does not wrap.** A `last-applied-configuration` annotation is
+  one line of a thousand characters; `break-all` turns it into a
+  paragraph-shaped block that hides the short lines around it. Let it run and
+  scroll the block.
+- **Do not render walls.** A manifest diff is almost entirely unchanged lines.
+  Collapse long unchanged runs behind a counted, expandable gap and keep a few
+  lines of context — but leave a run shorter than the marker that would
+  replace it, and leave a no-change diff whole, because "unchanged" is an
+  answer and an empty panel is not.
+- Colour is never the only signal. A dot carries a word beside it.
+
+## Verify by running it
+
+Tests are the floor, not the ceiling. Every UI change in this repo that broke
+in front of a user passed its suite first. Drive the screen — a Vite harness
+with the `@srelens/core` wrappers stubbed is enough — and look at it.
+
+Two examples from one branch: the Changes toggle stayed on "Hide changes"
+after an apply, and the diff panel was unreadable at its column width. Both
+had green tests. Neither was findable without looking.
+
+## Windows
+
+Three suites fail on Windows only and are unrelated to your change:
+`SmallPanes.test.tsx` (ShortcutsPane) and `tailwind-sources.test.ts` (two
+cases). `crates/kube/src/toolbox.rs` has a Unix-symlink test that will not
+compile there. Do not "fix" them by changing what they assert; CI runs Linux.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# CLAUDE.md
+
+See [`AGENTS.md`](AGENTS.md).
+
+One file, not two. The guidance for a coding agent working here does not
+differ by which agent it is, and a second copy is a second thing to forget to
+update — which is the failure mode half of `AGENTS.md` is about.

--- a/apps/desktop/src-tauri/tests/e2e.rs
+++ b/apps/desktop/src-tauri/tests/e2e.rs
@@ -1271,7 +1271,10 @@ async fn run_suite() {
     let out = h
         .ok(
             "k8s.openApiSchema",
-            json!({ "context": ctx, "api_version": "apps/v1", "kind": "Deployment" }),
+            // `apiVersion`, the spelling `core`'s wrapper sends. This case
+            // used to send `api_version` — the struct's own field name — and
+            // so passed while every real call failed to deserialize.
+            json!({ "context": ctx, "apiVersion": "apps/v1", "kind": "Deployment" }),
         )
         .await;
     assert!(out["key"]

--- a/crates/kube/src/schema.rs
+++ b/crates/kube/src/schema.rs
@@ -20,6 +20,17 @@ use crate::manifest::parse_api_version;
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct OpenApiSchemaIn {
     pub context: String,
+    /// `apiVersion` on the wire, as every caller has always sent it.
+    ///
+    /// Without this rename the field was `api_version`, which nothing sends:
+    /// `core`'s `openApiSchema` wrapper passes `apiVersion`, so every call
+    /// failed to deserialize and the editor's field autocomplete was dead —
+    /// silently, because the caller turns any failure into "no schema". Its
+    /// neighbours (`ListEventsIn`, `ListReplicaSetsIn`, `PodsForSelectorIn`)
+    /// each rename their own multi-word fields the same way; this one did not.
+    /// The e2e case did not catch it because it spoke the STRUCT's spelling
+    /// rather than the app's — it sends `apiVersion` now.
+    #[serde(rename = "apiVersion")]
     pub api_version: String,
     pub kind: String,
 }
@@ -168,6 +179,32 @@ mod tests {
             Some("io.k8s.api.apps.v1.Deployment")
         );
         assert!(find_schema_key(&sample(), "apps", "v1", "Missing").is_none());
+    }
+
+    /// The wire shape, which is not the struct's field spelling.
+    ///
+    /// `core`'s `openApiSchema` wrapper sends `apiVersion`; the field is
+    /// `api_version`. Without the rename every call failed to deserialize and
+    /// the editor's field autocomplete was dead — silently, because the caller
+    /// reads any failure as "this kind has no schema". The e2e case sent the
+    /// struct's own spelling and so agreed with the bug.
+    #[test]
+    fn deserializes_the_payload_callers_actually_send() {
+        let input: OpenApiSchemaIn = serde_json::from_value(serde_json::json!({
+            "context": "prod-eu",
+            "apiVersion": "v1",
+            "kind": "Secret",
+        }))
+        .expect("the wrapper's own payload must deserialize");
+        assert_eq!(input.api_version, "v1");
+        assert_eq!(input.kind, "Secret");
+        // And the struct spelling is NOT also accepted, so nothing drifts back.
+        assert!(serde_json::from_value::<OpenApiSchemaIn>(serde_json::json!({
+            "context": "prod-eu",
+            "api_version": "v1",
+            "kind": "Secret",
+        }))
+        .is_err());
     }
 
     #[test]

--- a/packages/ui-kit/src/CodeEditor.test.tsx
+++ b/packages/ui-kit/src/CodeEditor.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import { CodeEditor } from "./CodeEditor";
 
 describe("CodeEditor", () => {
@@ -72,5 +72,36 @@ describe("CodeEditor", () => {
 
     rerender(<CodeEditor value="a: 1" schemaValidate={second} />);
     await vi.waitFor(() => expect(second).toHaveBeenCalled(), { timeout: 3000 });
+  });
+});
+
+describe("CodeEditor — what it tells the caller", () => {
+  it("reports the cursor on mount, and again when the document is replaced under it", () => {
+    // A sidebar that says what is valid at the cursor needs the position; the
+    // editor is mounted imperatively, so this is the one way it gets out.
+    const onCursorChange = vi.fn();
+    const { rerender } = render(<CodeEditor value="a: 1" onCursorChange={onCursorChange} />);
+    expect(onCursorChange).toHaveBeenCalledWith(0);
+    rerender(<CodeEditor value="b: 22" onCursorChange={onCursorChange} />);
+    expect(onCursorChange).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports each lint pass's findings, with the line each is on", async () => {
+    // The gutter shows a marker; a list beside the editor has to say "line 2"
+    // and what is wrong there. A duplicate key is a syntax-level error the
+    // yaml package places at the second key.
+    const onDiagnostics = vi.fn();
+    render(<CodeEditor value={"a: 1\na: 2\n"} onDiagnostics={onDiagnostics} />);
+    await waitFor(() => expect(onDiagnostics).toHaveBeenCalled(), { timeout: 3000 });
+    const last = onDiagnostics.mock.calls.at(-1)![0] as Array<{ line: number; severity: string; message: string }>;
+    expect(last.length).toBeGreaterThan(0);
+    expect(last[0].line).toBe(2);
+    expect(last[0].severity).toBe("error");
+  });
+
+  it("reports an empty pass too, so the caller can say the document is clean", async () => {
+    const onDiagnostics = vi.fn();
+    render(<CodeEditor value={"a: 1\n"} onDiagnostics={onDiagnostics} />);
+    await waitFor(() => expect(onDiagnostics).toHaveBeenCalledWith([]), { timeout: 3000 });
   });
 });

--- a/packages/ui-kit/src/CodeEditor.tsx
+++ b/packages/ui-kit/src/CodeEditor.tsx
@@ -238,6 +238,16 @@ function editorTheme(minHeight: number, maxHeight: number, fill: boolean) {
   });
 }
 
+/** One finding of a lint pass, as the caller sees it: where, how bad, what. */
+export interface EditorDiagnostic {
+  from: number;
+  to: number;
+  /** 1-based, for a list beside the editor to say "line 12". */
+  line: number;
+  severity: "error" | "warning" | "info" | "hint";
+  message: string;
+}
+
 export interface CodeEditorProps {
   value: string;
   onChange?: (value: string) => void;
@@ -269,6 +279,20 @@ export interface CodeEditorProps {
    * (#318)
    */
   completions?: CompletionSource;
+  /**
+   * Where the cursor is, as an offset into the document — once on mount and
+   * whenever it moves or the document changes under it. What is valid THERE
+   * is the caller's to say (a schema sidebar, say); the editor only knows the
+   * position.
+   */
+  onCursorChange?: (pos: number) => void;
+  /**
+   * Every lint pass's findings — syntax first, then whatever `schemaValidate`
+   * answered — so a caller can list them beside the editor and not only in
+   * the gutter. An empty list is a pass that found nothing, which is worth
+   * knowing too.
+   */
+  onDiagnostics?: (diagnostics: EditorDiagnostic[]) => void;
 }
 
 /**
@@ -287,6 +311,8 @@ export function CodeEditor({
   fill = false,
   schemaValidate,
   completions,
+  onCursorChange,
+  onDiagnostics,
 }: CodeEditorProps) {
   const parentRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
@@ -297,6 +323,10 @@ export function CodeEditor({
   validateRef.current = schemaValidate;
   const completionsRef = useRef(completions);
   completionsRef.current = completions;
+  const onCursorRef = useRef(onCursorChange);
+  onCursorRef.current = onCursorChange;
+  const onDiagnosticsRef = useRef(onDiagnostics);
+  onDiagnosticsRef.current = onDiagnostics;
 
   useEffect(() => {
     const parent = parentRef.current;
@@ -319,6 +349,9 @@ export function CodeEditor({
       EditorView.editable.of(!readOnly),
       EditorState.readOnly.of(readOnly),
       EditorView.updateListener.of((u) => {
+        // The cursor is a fact about the view, not an edit: reported whether
+        // the reader moved it or a reload moved the text under it.
+        if (u.selectionSet || u.docChanged) onCursorRef.current?.(u.state.selection.main.head);
         if (!u.docChanged) return;
         // A reset or a reload replaces the document from outside. That is the
         // caller telling us, not the user typing, and reporting it back as an
@@ -330,17 +363,30 @@ export function CodeEditor({
     if (language === "yaml") {
       // Lint YAML syntax first (local, instant); if it parses, validate against
       // the caller's validator (debounced via the linter delay) for deeper errors.
+      // Every pass's findings go to the caller as well as to the gutter.
+      const report = (view: EditorView, diagnostics: Diagnostic[]) => {
+        onDiagnosticsRef.current?.(
+          diagnostics.map((d) => ({
+            from: d.from,
+            to: d.to,
+            line: view.state.doc.lineAt(Math.min(d.from, view.state.doc.length)).number,
+            severity: d.severity,
+            message: d.message,
+          })),
+        );
+        return diagnostics;
+      };
       const yamlLinter = linter(
         async (view) => {
           const text = view.state.doc.toString();
           const syntax = yamlDiagnostics(text);
-          if (syntax.length) return syntax;
+          if (syntax.length) return report(view, syntax);
           const validate = validateRef.current;
-          if (!validate || !text.trim()) return [];
+          if (!validate || !text.trim()) return report(view, []);
           try {
-            return documentDiagnostics(text, await validate(text));
+            return report(view, documentDiagnostics(text, await validate(text)));
           } catch {
-            return [];
+            return report(view, []);
           }
         },
         {
@@ -371,6 +417,7 @@ export function CodeEditor({
       parent,
     });
     viewRef.current = view;
+    onCursorRef.current?.(view.state.selection.main.head);
     return () => {
       view.destroy();
       viewRef.current = null;

--- a/packages/ui-kit/src/CodeEditor.tsx
+++ b/packages/ui-kit/src/CodeEditor.tsx
@@ -160,19 +160,26 @@ const highlightStyle = HighlightStyle.define([
 ]);
 
 /** Editor chrome, themed from CSS tokens (so light/dark just works). */
-function editorTheme(minHeight: number, maxHeight: number, fill: boolean) {
+function editorTheme(minHeight: number, maxHeight: number, fill: boolean, flush: boolean) {
   return EditorView.theme({
     "&": {
       color: "var(--ink)",
       backgroundColor: "var(--surface)",
       fontSize: "12px",
-      border: "1px solid var(--rule)",
-      borderRadius: "var(--radius-tile)",
+      // A framed editor sits inside a form or a dialog and needs an edge of
+      // its own. One that IS a region does not: the desktop layout is flush
+      // regions divided by hairlines (see `kit.css`, "panes"), and a border
+      // and radius inside one draw a floating card in a design that has none.
+      ...(flush
+        ? { border: "none", borderRadius: "0" }
+        : { border: "1px solid var(--rule)", borderRadius: "var(--radius-tile)" }),
       // `fill` makes the editor take its container's full height (scrolling
       // internally); otherwise it grows with content up to `maxHeight`.
       ...(fill ? { height: "100%" } : { maxHeight: `${maxHeight}px` }),
     },
-    "&.cm-focused": { outline: "none", borderColor: "var(--accent)" },
+    // A focus ring is an edge too; a flush editor fills its region and has
+    // nothing to ring, and the caret already says where typing goes.
+    "&.cm-focused": flush ? { outline: "none" } : { outline: "none", borderColor: "var(--accent)" },
     ".cm-scroller": { fontFamily: "var(--font-mono)", lineHeight: "1.55", overflow: "auto" },
     ".cm-content": { minHeight: fill ? "0" : `${minHeight}px`, caretColor: "var(--accent)" },
     ".cm-cursor, .cm-dropCursor": { borderLeftColor: "var(--accent)" },
@@ -280,6 +287,15 @@ export interface CodeEditorProps {
    */
   completions?: CompletionSource;
   /**
+   * Fill the region edge to edge: no border, no corner radius, no focus ring.
+   *
+   * For an editor that IS a pane rather than a control inside one. The
+   * desktop layout draws region boundaries with hairlines and gives them no
+   * gutters, so an editor set in from the edge with a rounded frame reads as
+   * a card floating in a design that has no cards.
+   */
+  flush?: boolean;
+  /**
    * Where the cursor is, as an offset into the document — once on mount and
    * whenever it moves or the document changes under it. What is valid THERE
    * is the caller's to say (a schema sidebar, say); the editor only knows the
@@ -311,6 +327,7 @@ export function CodeEditor({
   fill = false,
   schemaValidate,
   completions,
+  flush = false,
   onCursorChange,
   onDiagnostics,
 }: CodeEditorProps) {
@@ -344,7 +361,7 @@ export function CodeEditor({
       bracketMatching(),
       highlightSelectionMatches(),
       keymap.of([...completionKeymap, ...defaultKeymap, ...historyKeymap, ...searchKeymap, ...foldKeymap, indentWithTab]),
-      editorTheme(minHeight, maxHeight, fill),
+      editorTheme(minHeight, maxHeight, fill, flush),
       syntaxHighlighting(highlightStyle),
       EditorView.editable.of(!readOnly),
       EditorState.readOnly.of(readOnly),
@@ -424,7 +441,7 @@ export function CodeEditor({
     };
     // Re-create only when structural options change, not on every value/onChange.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [readOnly, language, ariaLabel, minHeight, maxHeight, fill]);
+  }, [readOnly, language, ariaLabel, minHeight, maxHeight, fill, flush]);
 
   // A new validator has to be asked about the document already on screen.
   // Swapping it changes what is true — a different cluster, a different set of

--- a/packages/ui-kit/src/DiffLines.tsx
+++ b/packages/ui-kit/src/DiffLines.tsx
@@ -18,6 +18,16 @@ export interface DiffRow {
 export interface DiffLinesProps {
   rows: DiffRow[];
   className?: string;
+  /**
+   * Wrap a line too long for the column (the default), or let it run and
+   * scroll the block sideways.
+   *
+   * Wrapping is right for prose-width text and wrong for a manifest: a
+   * `last-applied-configuration` annotation is one line of a thousand
+   * characters, and `break-all` turns it into a paragraph-shaped block that
+   * hides the short lines around it — the ones that actually changed.
+   */
+  wrap?: boolean;
 }
 
 interface Line {
@@ -74,18 +84,27 @@ const MARK: Record<Line["tag"], string> = { same: " ", delete: "-", insert: "+" 
  * `RawError` and `PairList` follow: a diff pane with nothing to say should
  * not leave a blank box behind for its caller to notice and hide.
  */
-export function DiffLines({ rows, className }: DiffLinesProps) {
+export function DiffLines({ rows, className, wrap = true }: DiffLinesProps) {
   const lines = toLines(rows);
   if (lines.length === 0) return null;
 
   return (
-    <div className={cx("flex flex-col font-mono text-[0.6875rem] leading-relaxed", className)}>
+    <div
+      className={cx(
+        "flex flex-col font-mono text-[0.6875rem] leading-relaxed",
+        // The block scrolls, not the page: `w-max` lets the widest line set
+        // the width so every row's wash runs the full length of the longest
+        // one, rather than stopping at the column edge.
+        !wrap && "w-max min-w-full",
+        className,
+      )}
+    >
       {lines.map((l) => (
         <div
           key={l.key}
           data-slot="line"
           data-tag={l.tag}
-          className="flex gap-2 whitespace-pre-wrap break-all px-2 py-px"
+          className={cx("flex gap-2 px-2 py-px", wrap ? "whitespace-pre-wrap break-all" : "whitespace-pre")}
           style={
             l.tag === "same"
               ? { color: "var(--ink-soft)" }

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -10,7 +10,13 @@ export { Breadcrumb, type BreadcrumbProps } from "./Breadcrumb";
 export { Button, type ButtonProps, type ButtonSize, type ButtonVariant } from "./Button";
 export { Checkbox, type CheckboxProps } from "./Checkbox";
 export { ClusterRail, type ClusterRailItem, type ClusterRailMarker, type ClusterRailProps } from "./ClusterRail";
-export { CodeEditor, documentDiagnostics, yamlDiagnostics, type CodeEditorProps } from "./CodeEditor";
+export {
+  CodeEditor,
+  documentDiagnostics,
+  yamlDiagnostics,
+  type CodeEditorProps,
+  type EditorDiagnostic,
+} from "./CodeEditor";
 export { ColumnPicker, type ColumnOption, type ColumnPickerProps } from "./ColumnPicker";
 export { Combobox, type ComboboxOption, type ComboboxProps } from "./Combobox";
 export { ConfirmDialog, type ConfirmDialogProps } from "./ConfirmDialog";

--- a/packages/ui-next/src/lib/crdGvk.ts
+++ b/packages/ui-next/src/lib/crdGvk.ts
@@ -33,15 +33,20 @@ export function isBuiltInKind(kind: string): boolean {
 export async function resolveCrdGvk(
   context: string,
   kind: string,
+  /** The API group, when the caller knows it — the only thing that tells a
+   *  CRD reusing a built-in kind's name apart from the built-in. */
+  group?: string,
 ): Promise<{ crd?: DynamicGvk; error?: string }> {
   const result = await listCrds(context);
   if (result.error) {
     return { error: `Could not look up ${kind}'s CustomResourceDefinition: ${result.error}` };
   }
-  const matches = result.crds?.filter((c) => c.kind === kind) ?? [];
+  const named = group === undefined ? kind : `${kind} in ${group}`;
+  const matches =
+    result.crds?.filter((c) => c.kind === kind && (group === undefined || c.group === group)) ?? [];
   if (matches.length === 0) {
     return {
-      error: `${kind} has no matching CustomResourceDefinition on this cluster, so its manifest cannot be resolved.`,
+      error: `${named} has no matching CustomResourceDefinition on this cluster, so its manifest cannot be resolved.`,
     };
   }
   if (matches.length > 1) {

--- a/packages/ui-next/src/lib/crdGvk.ts
+++ b/packages/ui-next/src/lib/crdGvk.ts
@@ -1,0 +1,57 @@
+import { K8S_KIND, listCrds, type DynamicGvk } from "@srelens/core";
+
+/** The list slug for each built-in Kubernetes kind — `Deployment` to
+ *  `deployments` — which is also the set of kinds the backend resolves on its
+ *  own. */
+export const SLUG_BY_K8S_KIND: Record<string, string> = Object.fromEntries(
+  Object.entries(K8S_KIND)
+    .filter(([, k8sKind]) => k8sKind !== "")
+    .map(([slug, k8sKind]) => [k8sKind, slug]),
+);
+
+/** Whether `k8s.getManifest` can find this kind without being told its group. */
+export function isBuiltInKind(kind: string): boolean {
+  return SLUG_BY_K8S_KIND[kind] !== undefined;
+}
+
+/**
+ * The group, version and plural behind a custom kind, from the cluster's
+ * CustomResourceDefinitions.
+ *
+ * `k8s.getManifest` resolves the built-in kinds itself and needs to be TOLD
+ * about any other, so a screen that reads a custom resource's manifest has to
+ * look this up first — the detail pane's YAML view did, and the editor opened
+ * every custom resource to an error until it did the same. Shared here so the
+ * two cannot drift.
+ *
+ * Refuses rather than guesses. A kind claimed by two CRDs in different
+ * groups is real — two operators, one noun — and picking either would fetch
+ * a manifest from possibly the wrong group and render it as though it were
+ * the right one: a possibly-wrong success, which is worse than a failure,
+ * because nothing on screen would say anything was ambiguous.
+ */
+export async function resolveCrdGvk(
+  context: string,
+  kind: string,
+): Promise<{ crd?: DynamicGvk; error?: string }> {
+  const result = await listCrds(context);
+  if (result.error) {
+    return { error: `Could not look up ${kind}'s CustomResourceDefinition: ${result.error}` };
+  }
+  const matches = result.crds?.filter((c) => c.kind === kind) ?? [];
+  if (matches.length === 0) {
+    return {
+      error: `${kind} has no matching CustomResourceDefinition on this cluster, so its manifest cannot be resolved.`,
+    };
+  }
+  if (matches.length > 1) {
+    // Sorted and de-duplicated so the message reads the same whichever order
+    // `listCrds` happened to return them in.
+    const groups = [...new Set(matches.map((c) => c.group))].sort().join(", ");
+    return {
+      error: `${kind} is claimed by more than one CustomResourceDefinition on this cluster (${groups}), so its manifest cannot be resolved unambiguously.`,
+    };
+  }
+  const match = matches[0];
+  return { crd: { group: match.group, version: match.version, plural: match.plural } };
+}

--- a/packages/ui-next/src/lib/detailRoute.test.ts
+++ b/packages/ui-next/src/lib/detailRoute.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
-import { detailRoute, editRoute, parseDetailRoute, parseEditRoute } from "./detailRoute";
+import { detailRoute, editRoute, newRoute, parseDetailRoute, parseEditRoute, parseNewRoute } from "./detailRoute";
 
 describe("detailRoute", () => {
   it("carries the kind, the namespace and the name", () => {
@@ -139,5 +139,29 @@ describe("editRoute", () => {
     // And it does not answer for another prefix's route of the right arity.
     expect(parseEditRoute("/k/Pod/default/web-0")).toBeNull();
     expect(parseDetailRoute("/edit/Pod/default/web-0")).toBeNull();
+  });
+});
+
+describe("newRoute", () => {
+  it("names the cluster, so New on two clusters is two tabs", () => {
+    expect(newRoute("prod")).toBe("/new/prod");
+    expect(newRoute("prod")).not.toBe(newRoute("staging"));
+    expect(parseNewRoute(newRoute("staging"))).toEqual({ cluster: "staging" });
+  });
+
+  it("encodes the cluster, and refuses one that will not decode", () => {
+    expect(parseNewRoute(newRoute("kind/local"))!.cluster).toBe("kind/local");
+    expect(parseNewRoute("/new/%zz")).toBeNull();
+  });
+
+  it("still answers for the bare /new an earlier build named, with no cluster", () => {
+    expect(parseNewRoute("/new")).toEqual({});
+  });
+
+  it("refuses anything else", () => {
+    expect(parseNewRoute("/new/")).toBeNull();
+    expect(parseNewRoute("/new/prod/extra")).toBeNull();
+    expect(parseNewRoute("/news")).toBeNull();
+    expect(parseNewRoute("/edit/prod/Pod/default/web")).toBeNull();
   });
 });

--- a/packages/ui-next/src/lib/detailRoute.test.ts
+++ b/packages/ui-next/src/lib/detailRoute.test.ts
@@ -54,33 +54,71 @@ describe("detailRoute", () => {
 // route string, so `Edit` on `default/api` and on `staging/api` collapsed into
 // ONE tab, and the second click focused the first resource's editor. So did a
 // Pod `api` and a Deployment `api`.
+const ON = { cluster: "prod" };
+
 describe("editRoute", () => {
-  it("carries the kind, the namespace and the name, like every other resource route", () => {
-    expect(editRoute("Pod", "kube-system", "web-0")).toBe("/edit/Pod/kube-system/web-0");
+  it("carries the cluster, the kind, the namespace and the name", () => {
+    expect(editRoute("Pod", "kube-system", "web-0", ON)).toBe("/edit/prod/Pod/kube-system/web-0");
   });
 
   it("stands the same placeholder in for a cluster-scoped kind, so the arity never varies", () => {
-    expect(editRoute("Node", null, "worker-1")).toBe("/edit/Node/-/worker-1");
+    expect(editRoute("Node", null, "worker-1", ON)).toBe("/edit/prod/Node/-/worker-1");
   });
 
   it("gives two namespaces' same-named resources two different routes", () => {
-    expect(editRoute("Deployment", "default", "api")).not.toBe(editRoute("Deployment", "staging", "api"));
+    expect(editRoute("Deployment", "default", "api", ON)).not.toBe(editRoute("Deployment", "staging", "api", ON));
   });
 
   it("gives two kinds' same-named resources two different routes", () => {
-    expect(editRoute("Pod", "default", "api")).not.toBe(editRoute("Deployment", "default", "api"));
+    expect(editRoute("Pod", "default", "api", ON)).not.toBe(editRoute("Deployment", "default", "api", ON));
+  });
+
+  it("gives two clusters' same-named resources two different routes", () => {
+    // The editor pins the cluster it was opened on, and `openTab` dedupes by
+    // route: without the cluster in it, Edit on staging's resource focused
+    // prod's pinned editor for the same name, and staging's could not be
+    // opened at all until that tab was closed.
+    expect(editRoute("ConfigMap", "default", "web", { cluster: "prod" })).not.toBe(
+      editRoute("ConfigMap", "default", "web", { cluster: "staging" }),
+    );
+    expect(parseEditRoute(editRoute("ConfigMap", "default", "web", { cluster: "staging" }))!.cluster).toBe(
+      "staging",
+    );
+  });
+
+  it("carries a custom kind's group in the kind segment, and tells it from the built-in of the same name", () => {
+    // A CRD may legally reuse a built-in kind's name in its own group; by kind
+    // alone the two are one route, and the editor would open the built-in.
+    const custom = editRoute("Deployment", "default", "api", { cluster: "prod", group: "acme.io" });
+    expect(custom).toBe("/edit/prod/acme.io%2FDeployment/default/api");
+    expect(custom.split("/")).toHaveLength(6);
+    expect(parseEditRoute(custom)).toEqual({
+      cluster: "prod",
+      group: "acme.io",
+      kind: "Deployment",
+      namespace: "default",
+      name: "api",
+    });
+    expect(custom).not.toBe(editRoute("Deployment", "default", "api", ON));
+    expect(parseEditRoute(editRoute("Deployment", "default", "api", ON))!.group).toBeUndefined();
   });
 
   it("encodes every segment, so a name cannot change the route's shape", () => {
-    const route = editRoute("Widget", "default", "a/b");
-    expect(route.split("/")).toHaveLength(5);
+    const route = editRoute("Widget", "default", "a/b", ON);
+    expect(route.split("/")).toHaveLength(6);
     expect(parseEditRoute(route)!.name).toBe("a/b");
   });
 
   it("round-trips", () => {
     for (const [k, ns, n] of [["Pod", "default", "web"], ["Node", null, "n1"]] as const) {
-      expect(parseEditRoute(editRoute(k, ns, n))).toEqual({ kind: k, namespace: ns, name: n });
+      expect(parseEditRoute(editRoute(k, ns, n, ON))).toEqual({ cluster: "prod", kind: k, namespace: ns, name: n });
     }
+  });
+
+  it("still parses the five-segment shape an earlier build persisted, with no cluster", () => {
+    // Such a tab opens an editor pinned to whatever the rail is on, rather
+    // than the Placeholder.
+    expect(parseEditRoute("/edit/Pod/default/web")).toEqual({ kind: "Pod", namespace: "default", name: "web" });
   });
 
   it("refuses a segment that cannot be decoded, rather than throwing", () => {
@@ -89,13 +127,15 @@ describe("editRoute", () => {
     expect(parseEditRoute("/edit/Pod/default/%zz")).toBeNull();
     expect(parseEditRoute("/edit/%e0%a4%a/default/web-1")).toBeNull();
     expect(parseEditRoute("/edit/Pod/%/web-1")).toBeNull();
+    expect(parseEditRoute("/edit/%zz/Pod/default/web-1")).toBeNull();
+    expect(parseEditRoute("/edit/prod/Pod/default/%zz")).toBeNull();
   });
 
   it("refuses the wrong arity, so the legacy one-segment shape is not mistaken for a subject", () => {
     expect(parseEditRoute("/edit/web-1")).toBeNull();
     expect(parseEditRoute("/edit")).toBeNull();
     expect(parseEditRoute("/edit/Pod/default")).toBeNull();
-    expect(parseEditRoute("/edit/Pod/default/web-0/extra")).toBeNull();
+    expect(parseEditRoute("/edit/prod/Pod/default/web-0/extra")).toBeNull();
     // And it does not answer for another prefix's route of the right arity.
     expect(parseEditRoute("/k/Pod/default/web-0")).toBeNull();
     expect(parseDetailRoute("/edit/Pod/default/web-0")).toBeNull();

--- a/packages/ui-next/src/lib/detailRoute.ts
+++ b/packages/ui-next/src/lib/detailRoute.ts
@@ -154,6 +154,31 @@ export function parseEditRoute(route: string): EditRouteParts | null {
   return qualified ? { ...qualified, cluster } : null;
 }
 
+/**
+ * `/new/<cluster>` — the editor's CREATE half, on a named cluster.
+ *
+ * The cluster is in it for the reason it is in the edit route: the editor
+ * pins the cluster it was opened on and `openTab` dedupes by route, so a bare
+ * `/new` opened from staging while prod's new-resource tab was open would
+ * have focused prod's draft. The bare `/new` is still parsed — an earlier
+ * build's table named it — and pins whatever the rail is on.
+ */
+export function newRoute(cluster: string): string {
+  return `/new/${encodeURIComponent(cluster)}`;
+}
+
+/** The inverse of {@link newRoute}; `{}` for the bare `/new`; `null` for anything else. */
+export function parseNewRoute(route: string): { cluster?: string } | null {
+  if (route === "/new") return {};
+  const segments = route.split("/");
+  if (segments.length !== 3 || segments[0] !== "" || segments[1] !== "new" || !segments[2]) return null;
+  try {
+    return { cluster: decodeURIComponent(segments[2]) };
+  } catch {
+    return null;
+  }
+}
+
 /** `<group>/<kind>` in the kind segment becomes `group` and `kind`; a bare kind is left alone. */
 function splitGroup(parts: DetailRouteParts): EditRouteParts | null {
   const at = parts.kind.lastIndexOf("/");

--- a/packages/ui-next/src/lib/detailRoute.ts
+++ b/packages/ui-next/src/lib/detailRoute.ts
@@ -48,9 +48,47 @@ export interface DetailRouteParts {
  * does for a DETAIL route today. Reported rather than changed: that file is
  * outside this task's reach.
  */
-export function editRoute(kind: string, namespace: string | null, name: string): string {
+export function editRoute(
+  kind: string,
+  namespace: string | null,
+  name: string,
+  on: {
+    /** The cluster the resource is on — part of the editor's identity, see {@link EditRouteParts}. */
+    cluster: string;
+    /** The API group, for a custom kind only — see {@link EditRouteParts.group}. */
+    group?: string;
+  },
+): string {
   const ns = namespace === null ? CLUSTER_SCOPED_SEGMENT : encodeURIComponent(namespace);
-  return `/edit/${encodeURIComponent(kind)}/${ns}/${encodeURIComponent(name)}`;
+  const qualified = on.group ? `${on.group}/${kind}` : kind;
+  return `/edit/${encodeURIComponent(on.cluster)}/${encodeURIComponent(qualified)}/${ns}/${encodeURIComponent(name)}`;
+}
+
+/**
+ * What an edit route names, over and above a detail route.
+ *
+ * **The cluster is in the route** because the editor PINS the cluster it was
+ * opened on — every read and write goes there, whatever the rail does later —
+ * and `openTab` dedupes by route string. With the cluster left out, Edit on
+ * staging's `default/web` while prod's editor for `default/web` was open
+ * focused prod's draft, and staging's resource could not be opened at all
+ * without closing that tab first. The detail route has no cluster in it
+ * because the detail pane follows the rail; the editor deliberately does not.
+ *
+ * **The group is in the route for a custom kind** because a kind NAME alone
+ * does not identify one: a CRD may legally reuse a built-in kind's name in its
+ * own group — `Deployment` in `acme.io` — and an editor that inferred
+ * "built-in" from the name would read, and offer to delete, the built-in
+ * object of the same name instead. It rides in the kind segment as
+ * `<group>/<kind>`, kubectl's own qualified spelling; the segment is
+ * percent-encoded, so the `/` never changes the route's arity.
+ */
+export interface EditRouteParts extends DetailRouteParts {
+  /** Absent only on the five-segment shape an earlier build persisted, which
+   *  had no cluster in it; the editor then pins whatever the rail is on. */
+  cluster?: string;
+  /** Set only for a custom kind. A built-in kind's group is known to the backend. */
+  group?: string;
 }
 
 /**
@@ -87,10 +125,43 @@ function parseResourceRoute(route: string, prefix: string): DetailRouteParts | n
   }
 }
 
-/** The inverse of {@link editRoute}, or `null` for anything it cannot make a
- *  subject of — including the legacy one-segment `/edit/<name>`. */
-export function parseEditRoute(route: string): DetailRouteParts | null {
-  return parseResourceRoute(route, "edit");
+/**
+ * The inverse of {@link editRoute}, or `null` for anything it cannot make a
+ * subject of — including the legacy one-segment `/edit/<name>`.
+ *
+ * Six segments is the shape `editRoute` mints; five is the shape before the
+ * cluster joined it, still parsed so a tab an earlier build persisted opens
+ * an editor rather than the Placeholder.
+ */
+export function parseEditRoute(route: string): EditRouteParts | null {
+  const segments = route.split("/");
+  if (segments.length === 5) {
+    const parts = parseResourceRoute(route, "edit");
+    return parts ? splitGroup(parts) : null;
+  }
+  if (segments.length !== 6) return null;
+  const [empty, head, rawCluster, ...rest] = segments;
+  if (empty !== "" || head !== "edit" || !rawCluster) return null;
+  const parts = parseResourceRoute(`/edit/${rest.join("/")}`, "edit");
+  if (!parts) return null;
+  let cluster: string;
+  try {
+    cluster = decodeURIComponent(rawCluster);
+  } catch {
+    return null;
+  }
+  const qualified = splitGroup(parts);
+  return qualified ? { ...qualified, cluster } : null;
+}
+
+/** `<group>/<kind>` in the kind segment becomes `group` and `kind`; a bare kind is left alone. */
+function splitGroup(parts: DetailRouteParts): EditRouteParts | null {
+  const at = parts.kind.lastIndexOf("/");
+  if (at < 0) return parts;
+  const group = parts.kind.slice(0, at);
+  const kind = parts.kind.slice(at + 1);
+  if (!group || !kind) return null;
+  return { ...parts, group, kind };
 }
 
 /**

--- a/packages/ui-next/src/lib/diffCollapse.test.ts
+++ b/packages/ui-next/src/lib/diffCollapse.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import type { DiffRow } from "@srelens/core";
+import { collapseDiff, diffCounts } from "./diffCollapse";
+
+const same = (text: string): DiffRow => ({ tag: "same", left: text, right: text });
+const insert = (text: string): DiffRow => ({ tag: "insert", left: null, right: text });
+const remove = (text: string): DiffRow => ({ tag: "delete", left: text, right: null });
+const replace = (left: string, right: string): DiffRow => ({ tag: "replace", left, right });
+
+/** N unchanged lines, numbered so a slice can be checked for which ones. */
+const filler = (n: number, from = 0) => Array.from({ length: n }, (_, i) => same(`line ${from + i}`));
+
+describe("diffCounts", () => {
+  it("counts a replace as both an addition and a deletion", () => {
+    expect(diffCounts([same("a"), insert("b"), remove("c"), replace("d", "e")])).toEqual({
+      added: 2,
+      removed: 2,
+    });
+  });
+
+  it("counts nothing in a diff with no changes", () => {
+    expect(diffCounts(filler(5))).toEqual({ added: 0, removed: 0 });
+  });
+});
+
+describe("collapseDiff", () => {
+  it("hides a long unchanged run and keeps context either side of the change", () => {
+    // The shape that made this necessary: one changed label inside a
+    // Deployment whose last-applied-configuration annotation is 30 lines.
+    const rows = [...filler(30), insert("  tier: web"), ...filler(30, 30)];
+    const segments = collapseDiff(rows, 3);
+    expect(segments.map((s) => s.kind)).toEqual(["gap", "rows", "gap"]);
+    expect(segments[0].rows).toHaveLength(27);
+    // Three lines before, the change, three after.
+    expect(segments[1].rows).toHaveLength(7);
+    expect(segments[1].rows[3]).toEqual(insert("  tier: web"));
+    expect(segments[2].rows).toHaveLength(27);
+  });
+
+  it("carries the hidden rows in the gap, so opening one needs nothing else", () => {
+    const rows = [...filler(20), insert("x")];
+    const [gap] = collapseDiff(rows, 3);
+    expect(gap.kind).toBe("gap");
+    expect(gap.rows[0]).toEqual(same("line 0"));
+    expect(gap.rows.at(-1)).toEqual(same("line 16"));
+    expect(gap.from).toBe(0);
+  });
+
+  it("keeps a short unchanged run rather than making a gap that saves nothing", () => {
+    // Two changes with two unchanged lines between them: a gap here would be
+    // a click to hide less than the gap marker itself takes up.
+    const rows = [insert("a"), same("1"), same("2"), insert("b"), ...filler(30, 10)];
+    const segments = collapseDiff(rows, 1, 4);
+    expect(segments[0].kind).toBe("rows");
+    expect(segments[0].rows.slice(0, 4)).toEqual([insert("a"), same("1"), same("2"), insert("b")]);
+  });
+
+  it("leaves a diff with no changes whole, rather than hiding all of it", () => {
+    // "Unchanged" is an answer; an empty panel is not.
+    const rows = filler(40);
+    expect(collapseDiff(rows)).toEqual([{ kind: "rows", rows, from: 0 }]);
+  });
+
+  it("gives an empty diff no segments at all", () => {
+    expect(collapseDiff([])).toEqual([]);
+  });
+
+  it("shows every line of a diff that is all changes", () => {
+    const rows = [insert("a"), remove("b"), replace("c", "d")];
+    expect(collapseDiff(rows)).toEqual([{ kind: "rows", rows, from: 0 }]);
+  });
+
+  it("keeps the run between two changes when it is short, and hides it when it is long", () => {
+    const near = [insert("a"), ...filler(5), insert("b")];
+    expect(collapseDiff(near, 3).map((s) => s.kind)).toEqual(["rows"]);
+    const far = [insert("a"), ...filler(40), insert("b")];
+    expect(collapseDiff(far, 3).map((s) => s.kind)).toEqual(["rows", "gap", "rows"]);
+  });
+});

--- a/packages/ui-next/src/lib/diffCollapse.ts
+++ b/packages/ui-next/src/lib/diffCollapse.ts
@@ -1,0 +1,77 @@
+import type { DiffRow } from "@srelens/core";
+
+/**
+ * A diff, cut down to the parts that changed and a little of what surrounds
+ * them.
+ *
+ * A manifest's diff is almost entirely unchanged lines. One
+ * `kubectl.kubernetes.io/last-applied-configuration` annotation is a
+ * thousand-character line on its own, and printing every line of a Deployment
+ * to show that one label moved buries the answer in the question. So: keep
+ * `context` lines either side of every change, and stand a counted gap in for
+ * each run of unchanged lines longer than that.
+ *
+ * The gap carries the rows it hid rather than only their count, so opening it
+ * is a local decision — no second pass over the original list, and no index
+ * arithmetic in the component to get wrong.
+ */
+
+export type DiffSegment =
+  | { kind: "rows"; rows: DiffRow[]; from: number }
+  /** A run of unchanged rows worth hiding; `rows` is what opening it shows. */
+  | { kind: "gap"; rows: DiffRow[]; from: number };
+
+/** How many additions and deletions a diff carries, counting a `replace` as both. */
+export function diffCounts(rows: DiffRow[]): { added: number; removed: number } {
+  let added = 0;
+  let removed = 0;
+  for (const row of rows) {
+    if (row.tag === "insert" || row.tag === "replace") added += 1;
+    if (row.tag === "delete" || row.tag === "replace") removed += 1;
+  }
+  return { added, removed };
+}
+
+/**
+ * Split rows into shown runs and hidden gaps.
+ *
+ * A gap is only made where hiding actually pays: a run has to be longer than
+ * `2 * context + minGap` before any of it is hidden, or a two-line gap
+ * standing in for two lines would be a click to see less than it replaced.
+ * A diff with no changes at all is left whole — that is the "unchanged"
+ * case, and hiding all of it would leave an empty panel.
+ */
+export function collapseDiff(rows: DiffRow[], context = 3, minGap = 4): DiffSegment[] {
+  const changed = rows.some((r) => r.tag !== "same");
+  if (!changed) return rows.length > 0 ? [{ kind: "rows", rows, from: 0 }] : [];
+
+  // Which rows survive: every change, plus `context` either side of one.
+  const keep = new Array<boolean>(rows.length).fill(false);
+  rows.forEach((row, i) => {
+    if (row.tag === "same") return;
+    for (let j = Math.max(0, i - context); j <= Math.min(rows.length - 1, i + context); j++) {
+      keep[j] = true;
+    }
+  });
+
+  // A short hidden run costs the reader a click and saves them nothing; keep it.
+  let runStart = 0;
+  for (let i = 0; i <= rows.length; i++) {
+    if (i < rows.length && !keep[i]) continue;
+    if (i - runStart > 0 && i - runStart < minGap) {
+      for (let j = runStart; j < i; j++) keep[j] = true;
+    }
+    runStart = i + 1;
+  }
+
+  const segments: DiffSegment[] = [];
+  let start = 0;
+  while (start < rows.length) {
+    const shown = keep[start];
+    let end = start;
+    while (end < rows.length && keep[end] === shown) end += 1;
+    segments.push({ kind: shown ? "rows" : "gap", rows: rows.slice(start, end), from: start });
+    start = end;
+  }
+  return segments;
+}

--- a/packages/ui-next/src/lib/kinds/custom.ts
+++ b/packages/ui-next/src/lib/kinds/custom.ts
@@ -59,6 +59,7 @@ export const CUSTOM_RESOURCE_ACTIONS: KindActions = { delete: false };
 export function customDescriptor(crd: CrdRef): KindDescriptor<CustomRow> {
   return {
     k8sKind: crd.kind,
+    group: crd.group,
     columns: customColumns(crd),
     source: "poll",
     scope: crd.namespaced ? "namespaced" : "cluster",

--- a/packages/ui-next/src/lib/kinds/types.ts
+++ b/packages/ui-next/src/lib/kinds/types.ts
@@ -64,6 +64,13 @@ export interface KindActions {
 export interface KindDescriptor<Row extends ListRow = ListRow> {
   /** The Kubernetes kind, for actions and for the detail route. */
   k8sKind: string;
+  /**
+   * The API group — set only for a custom kind, whose kind NAME alone does
+   * not identify it: a CRD may legally reuse a built-in kind's name in its
+   * own group (`Deployment` in `acme.io`), and anything that resolves by
+   * kind alone then lands on the built-in. Carried into the edit route.
+   */
+  group?: string;
   columns: Column<Row>[];
   /** `watch` streams snapshots; `poll` re-lists on an interval. */
   source: "watch" | "poll";

--- a/packages/ui-next/src/lib/manifestSchema.test.ts
+++ b/packages/ui-next/src/lib/manifestSchema.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import type { SchemaBundle } from "@srelens/core";
+import { keysAt, schemaCompletions } from "./manifestSchema";
+
+// A ConfigMap's schema, cut down: an object ref wrapped in `allOf` the way
+// the real document wraps every one, a plain object, a boolean.
+const BUNDLE: SchemaBundle = {
+  key: "io.k8s.api.core.v1.ConfigMap",
+  schemas: {
+    "io.k8s.api.core.v1.ConfigMap": {
+      type: "object",
+      properties: {
+        apiVersion: { type: "string", description: "APIVersion defines the versioned schema." },
+        kind: { type: "string", description: "Kind is a string value." },
+        metadata: {
+          description: "Standard object's metadata.",
+          allOf: [{ $ref: "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta" }],
+        },
+        data: { type: "object", description: "Data contains the configuration data." },
+        immutable: { type: "boolean", description: "Immutable, if set to true, ensures that data cannot be updated." },
+      },
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Name must be unique within a namespace." },
+        namespace: { type: "string", description: "Namespace defines the space within which each name must be unique." },
+      },
+    },
+  },
+};
+
+const DOC = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: web
+  na
+immutable: 
+`;
+
+describe("keysAt", () => {
+  it("lists the keys of the mapping the cursor is in, with their types and descriptions", () => {
+    const here = keysAt(BUNDLE, DOC, DOC.indexOf("  na") + 4);
+    expect(here.path).toEqual(["metadata"]);
+    expect(here.onValue).toBe(false);
+    expect(here.entries.map((e) => e.label)).toEqual(["name", "namespace"]);
+    expect(here.entries[0].detail).toBe("string");
+    expect(here.entries[0].info).toContain("unique within a namespace");
+  });
+
+  it("lists the top-level keys at the top level", () => {
+    const here = keysAt(BUNDLE, DOC, 0);
+    expect(here.path).toEqual([]);
+    expect(here.entries.map((e) => e.label)).toEqual(["apiVersion", "kind", "metadata", "data", "immutable"]);
+  });
+
+  it("switches to a key's values after `key: `, when the key has a fixed set", () => {
+    const here = keysAt(BUNDLE, DOC, DOC.indexOf("immutable: ") + "immutable: ".length);
+    expect(here.onValue).toBe(true);
+    expect(here.valueKey).toBe("immutable");
+    expect(here.entries.map((e) => e.label)).toEqual(["true", "false"]);
+  });
+
+  it("falls back to the keys beside a key whose values are free text", () => {
+    // `name: ` takes any string; an empty "values" section would say less
+    // than the keys that belong next to it.
+    const doc = "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: ";
+    const here = keysAt(BUNDLE, doc, doc.length);
+    expect(here.onValue).toBe(false);
+    expect(here.path).toEqual(["metadata"]);
+    expect(here.entries.map((e) => e.label)).toEqual(["name", "namespace"]);
+  });
+
+  it("clamps a cursor past the end rather than throwing", () => {
+    expect(() => keysAt(BUNDLE, DOC, DOC.length + 50)).not.toThrow();
+  });
+});
+
+/** A CodeMirror completion context, reduced to what the source reads. */
+function context(doc: string, pos: number, explicit = false) {
+  const before = doc.slice(0, pos);
+  const m = before.match(/[\w.-]*$/)!;
+  return {
+    pos,
+    explicit,
+    state: { doc: { toString: () => doc } },
+    matchBefore: () => ({ from: pos - m[0].length, to: pos, text: m[0] }),
+  } as unknown as Parameters<ReturnType<typeof schemaCompletions>>[0];
+}
+
+describe("schemaCompletions", () => {
+  it("offers the mapping's field names for the word being typed", () => {
+    const source = schemaCompletions(() => BUNDLE);
+    const pos = DOC.indexOf("  na") + 4;
+    const result = source(context(DOC, pos)) as unknown as { from: number; options: { label: string; detail?: string }[] };
+    expect(result.from).toBe(pos - 2);
+    expect(result.options.map((o) => o.label)).toEqual(["name", "namespace"]);
+    expect(result.options[0].detail).toBe("string");
+  });
+
+  it("offers a key's values after `key: `", () => {
+    const source = schemaCompletions(() => BUNDLE);
+    const pos = DOC.indexOf("immutable: ") + "immutable: ".length;
+    const result = source(context(DOC, pos, true)) as unknown as { options: { label: string }[] };
+    expect(result.options.map((o) => o.label)).toEqual(["true", "false"]);
+  });
+
+  it("stays quiet with nothing typed unless asked, and with no schema at all", () => {
+    const source = schemaCompletions(() => BUNDLE);
+    const pos = DOC.indexOf("  na") + 2;
+    expect(source(context(DOC, pos))).toBeNull();
+    expect(source(context(DOC, pos, true))).not.toBeNull();
+    expect(schemaCompletions(() => null)(context(DOC, pos, true))).toBeNull();
+  });
+
+  it("reads the schema through the getter, so one that arrives later is offered", () => {
+    let bundle: SchemaBundle | null = null;
+    const source = schemaCompletions(() => bundle);
+    const pos = DOC.indexOf("  na") + 4;
+    expect(source(context(DOC, pos))).toBeNull();
+    bundle = BUNDLE;
+    expect(source(context(DOC, pos))).not.toBeNull();
+  });
+});

--- a/packages/ui-next/src/lib/manifestSchema.ts
+++ b/packages/ui-next/src/lib/manifestSchema.ts
@@ -1,5 +1,6 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
+  describeError,
   extractApiVersionKind,
   fieldCompletions,
   openApiSchema,
@@ -27,41 +28,62 @@ export type SchemaStatus =
   | "none"
   | "loading"
   | "ready"
-  /** The cluster has no schema for this kind — a CRD without one, or a typo. */
-  | "unavailable";
+  /** The cluster answered, and publishes no schema for this kind. */
+  | "absent"
+  /** The lookup itself failed. Kept apart from `absent`: they are different
+   *  facts, and saying "the cluster has no schema for Secret" when the request
+   *  was refused or timed out is a confident wrong answer about a built-in
+   *  kind that certainly has one. */
+  | "failed";
 
 /** The schema for the kind the draft names, loaded once per cluster, apiVersion and kind. */
 export function useManifestSchema(
   context: string,
   yaml: string,
-): { bundle: SchemaBundle | null; status: SchemaStatus; kind: string | null } {
+): {
+  bundle: SchemaBundle | null;
+  status: SchemaStatus;
+  kind: string | null;
+  /** Why the lookup failed, when it did. */
+  error: string;
+  /** Ask again — the failure may have been the cluster, not the kind. */
+  retry: () => void;
+} {
   const ident = extractApiVersionKind(yaml);
   const apiVersion = ident?.apiVersion ?? null;
   const kind = ident?.kind ?? null;
-  const [state, setState] = useState<{ bundle: SchemaBundle | null; status: SchemaStatus }>({
+  const [state, setState] = useState<{ bundle: SchemaBundle | null; status: SchemaStatus; error: string }>({
     bundle: null,
     status: "none",
+    error: "",
   });
+  const [attempt, setAttempt] = useState(0);
+  const retry = useCallback(() => setAttempt((n) => n + 1), []);
 
   useEffect(() => {
     if (!apiVersion || !kind) {
-      setState({ bundle: null, status: "none" });
+      setState({ bundle: null, status: "none", error: "" });
       return;
     }
     let active = true;
-    setState({ bundle: null, status: "loading" });
+    setState({ bundle: null, status: "loading", error: "" });
     void openApiSchema(context, apiVersion, kind).then((out) => {
       if (!active) return;
-      // `key: null` is the backend saying the kind is not in the document.
-      if ("error" in out || !out.key) setState({ bundle: null, status: "unavailable" });
-      else setState({ bundle: out, status: "ready" });
+      if ("error" in out) {
+        setState({ bundle: null, status: "failed", error: describeError(out.error).detail });
+      } else if (!out.key) {
+        // The document came back and nothing in it declares this kind.
+        setState({ bundle: null, status: "absent", error: "" });
+      } else {
+        setState({ bundle: out, status: "ready", error: "" });
+      }
     });
     return () => {
       active = false;
     };
-  }, [context, apiVersion, kind]);
+  }, [context, apiVersion, kind, attempt]);
 
-  return { bundle: state.bundle, status: state.status, kind };
+  return { bundle: state.bundle, status: state.status, error: state.error, kind, retry };
 }
 
 /** What the schema allows at one position: the keys of the mapping the cursor

--- a/packages/ui-next/src/lib/manifestSchema.ts
+++ b/packages/ui-next/src/lib/manifestSchema.ts
@@ -1,0 +1,112 @@
+import { useEffect, useState } from "react";
+import {
+  extractApiVersionKind,
+  fieldCompletions,
+  openApiSchema,
+  pathAtCursor,
+  valueCompletions,
+  type FieldCompletion,
+  type SchemaBundle,
+} from "@srelens/core";
+import type { CodeEditorProps } from "@srelens/ui-kit";
+
+/**
+ * The OpenAPI schema behind a manifest, and what it says about the cursor.
+ *
+ * Core has the pieces — `openApiSchema` fetches a kind's schema from the
+ * cluster, `pathAtCursor` reads the mapping path out of block YAML, and the
+ * two completion helpers walk the schema — and the kit's editor takes a
+ * completion source but resolves nothing itself. This is the join: one hook
+ * that owns the schema for whatever kind the draft names, one function that
+ * says what goes at a position, and one completion source built on the same
+ * schema, so the sidebar and the popup can never disagree.
+ */
+
+export type SchemaStatus =
+  /** The draft names no apiVersion and kind yet, so there is nothing to ask for. */
+  | "none"
+  | "loading"
+  | "ready"
+  /** The cluster has no schema for this kind — a CRD without one, or a typo. */
+  | "unavailable";
+
+/** The schema for the kind the draft names, loaded once per cluster, apiVersion and kind. */
+export function useManifestSchema(
+  context: string,
+  yaml: string,
+): { bundle: SchemaBundle | null; status: SchemaStatus; kind: string | null } {
+  const ident = extractApiVersionKind(yaml);
+  const apiVersion = ident?.apiVersion ?? null;
+  const kind = ident?.kind ?? null;
+  const [state, setState] = useState<{ bundle: SchemaBundle | null; status: SchemaStatus }>({
+    bundle: null,
+    status: "none",
+  });
+
+  useEffect(() => {
+    if (!apiVersion || !kind) {
+      setState({ bundle: null, status: "none" });
+      return;
+    }
+    let active = true;
+    setState({ bundle: null, status: "loading" });
+    void openApiSchema(context, apiVersion, kind).then((out) => {
+      if (!active) return;
+      // `key: null` is the backend saying the kind is not in the document.
+      if ("error" in out || !out.key) setState({ bundle: null, status: "unavailable" });
+      else setState({ bundle: out, status: "ready" });
+    });
+    return () => {
+      active = false;
+    };
+  }, [context, apiVersion, kind]);
+
+  return { bundle: state.bundle, status: state.status, kind };
+}
+
+/** What the schema allows at one position: the keys of the mapping the cursor
+ *  is in, or — on a `key: ` line — the values that key takes. */
+export interface KeysHere {
+  /** The mapping path down to the cursor, outermost first; empty at the top level. */
+  path: string[];
+  /** True when the cursor sits after `key:` and `entries` are that key's values. */
+  onValue: boolean;
+  valueKey?: string;
+  entries: FieldCompletion[];
+}
+
+export function keysAt(bundle: SchemaBundle, yaml: string, pos: number): KeysHere {
+  const at = pathAtCursor(yaml, Math.max(0, Math.min(pos, yaml.length)));
+  if (at.onValue && at.valueKey) {
+    const values = valueCompletions(bundle, at.path, at.valueKey);
+    // A key with no fixed set of values (a name, a number) has nothing to
+    // list; the keys beside it are more use than an empty section.
+    if (values.length > 0) return { path: at.path, onValue: true, valueKey: at.valueKey, entries: values };
+  }
+  return { path: at.path, onValue: false, entries: fieldCompletions(bundle, at.path) };
+}
+
+type Completions = NonNullable<CodeEditorProps["completions"]>;
+
+/**
+ * The editor's completion source: field names for the mapping at the cursor,
+ * enum members and booleans after `key: `. Reads the bundle through a getter
+ * so one source serves the editor's whole life while the schema arrives, or
+ * changes with the kind, underneath it.
+ */
+export function schemaCompletions(bundle: () => SchemaBundle | null): Completions {
+  return (ctx) => {
+    const current = bundle();
+    if (!current) return null;
+    const word = ctx.matchBefore(/[\w.-]*/);
+    if (!word || (word.from === word.to && !ctx.explicit)) return null;
+    const { path, onValue, valueKey } = pathAtCursor(ctx.state.doc.toString(), ctx.pos);
+    const found =
+      onValue && valueKey ? valueCompletions(current, path, valueKey) : fieldCompletions(current, path);
+    if (found.length === 0) return null;
+    return {
+      from: word.from,
+      options: found.map((f) => ({ label: f.label, detail: f.detail, info: f.info })),
+    };
+  };
+}

--- a/packages/ui-next/src/lib/routes.test.ts
+++ b/packages/ui-next/src/lib/routes.test.ts
@@ -154,6 +154,8 @@ suite("describe", () => {
       sub: "c",
     });
     expect(describe("/edit/prod/acme.io%2FDeployment/staging/api", "c").title).toBe("Edit staging/api");
+    // The create half on a named cluster, beside the bare `/new` in the table.
+    expect(describe("/new/prod", "c")).toMatchObject({ title: "New resource", kind: "edit", sub: "c" });
     // Cluster-scoped: there is no namespace to name.
     expect(describe("/edit/Node/-/worker-1", "c")).toMatchObject({ title: "Edit worker-1", kind: "edit" });
     // Percent-encoded on the way in, so the title is the decoded name.

--- a/packages/ui-next/src/lib/routes.test.ts
+++ b/packages/ui-next/src/lib/routes.test.ts
@@ -146,6 +146,14 @@ suite("describe", () => {
       sub: "c",
     });
     expect(describe("/edit/Deployment/staging/api", "c").title).toBe("Edit staging/api");
+    // The shape `editRoute` mints now, with the cluster in front; the title
+    // does not repeat the cluster, which is the tab's own label.
+    expect(describe("/edit/prod/Deployment/staging/api", "c")).toMatchObject({
+      title: "Edit staging/api",
+      kind: "edit",
+      sub: "c",
+    });
+    expect(describe("/edit/prod/acme.io%2FDeployment/staging/api", "c").title).toBe("Edit staging/api");
     // Cluster-scoped: there is no namespace to name.
     expect(describe("/edit/Node/-/worker-1", "c")).toMatchObject({ title: "Edit worker-1", kind: "edit" });
     // Percent-encoded on the way in, so the title is the decoded name.

--- a/packages/ui-next/src/lib/routes.ts
+++ b/packages/ui-next/src/lib/routes.ts
@@ -1,6 +1,6 @@
 import type { ComponentType } from "react";
 import { K8S_KIND, RESOURCE_LABELS, type ResourceKind } from "@srelens/core";
-import { parseDetailRoute, parseEditRoute } from "./detailRoute";
+import { parseDetailRoute, parseEditRoute, parseNewRoute } from "./detailRoute";
 import { Agent } from "../screens/Agent";
 import { AppLog } from "../screens/AppLog";
 import { Connect } from "../screens/Connect";
@@ -150,6 +150,9 @@ export function describe(route: string, clusterName?: string): RouteInfo {
     const where = edit.namespace === null ? edit.name : `${edit.namespace}/${edit.name}`;
     return { route, title: `Edit ${where}`, sub, kind: "edit" };
   }
+  // `/new/<cluster>` — the create half, on a named cluster. The cluster is
+  // not in the title: it is the tab's own label, as on every other tab.
+  if (parseNewRoute(route)) return { route, title: "New resource", sub, kind: "edit" };
   // The legacy one-segment `/edit/<name>`. Nothing mints it any more; the shape
   // survives here only so a tab a previous session persisted can still name
   // itself in the strip, exactly as `/resources/<name>/logs|shell|forward` does
@@ -344,6 +347,9 @@ export function screenFor(route: string): ScreenComponent | null {
   // one-segment `/edit/<name>` stay a Placeholder rather than an editor with
   // no resource in it.
   if (parseEditRoute(route)) return EditResource;
+  // And its create half on a named cluster, `/new/<cluster>`; the bare
+  // `/new` is in `SCREENS`.
+  if (parseNewRoute(route)) return EditResource;
   // A logs subject route, for the same reason and by the same means: matched
   // by parse rather than by a `/logs/` prefix entry, so `/logs/` on its own —
   // and anything else under the prefix that is not a whole subject — stays a

--- a/packages/ui-next/src/lib/routes.ts
+++ b/packages/ui-next/src/lib/routes.ts
@@ -12,6 +12,7 @@ import { Logs, parseLogsRoute } from "../screens/Logs";
 import { Overview } from "../screens/Overview";
 import { ReleaseNotes } from "../screens/ReleaseNotes";
 import { ResourceDetailScreen, Resources } from "../screens/Resources";
+import { EditResource } from "../screens/Edit";
 import { Settings } from "../screens/Settings";
 import { Terminals } from "../screens/Terminals";
 import { Toolbox } from "../screens/Toolbox";
@@ -264,6 +265,11 @@ const SCREENS: Record<string, ScreenComponent> = Object.assign(Object.create(nul
   // never a second conversation.
   "/agent": Agent,
   "/resources": Workloads,
+  // The editor's create half. The row menu's `Edit` reaches the same screen
+  // through `parseEditRoute` in `screenFor` — one screen, two shapes, as
+  // `/logs` is. Without these two the menu opened a correctly titled tab
+  // onto the Placeholder, which is what "Edit does nothing" was.
+  "/new": EditResource,
   "/events": Events,
   "/overview": Overview,
   // The bare route. Its deeper `/logs/<kind>/<namespace>/<name>` shape reaches
@@ -333,6 +339,11 @@ export function screenFor(route: string): ScreenComponent | null {
   // were just another kind slug. Matched by parse rather than by adding a
   // second `/k/` entry to `PREFIXED`, which cannot tell the two apart at all.
   if (parseDetailRoute(route)) return ResourceDetailScreen;
+  // The editor's edit half, by the same means and for the same reason: a
+  // whole subject or nothing, so `/edit/` on its own and the legacy
+  // one-segment `/edit/<name>` stay a Placeholder rather than an editor with
+  // no resource in it.
+  if (parseEditRoute(route)) return EditResource;
   // A logs subject route, for the same reason and by the same means: matched
   // by parse rather than by a `/logs/` prefix entry, so `/logs/` on its own —
   // and anything else under the prefix that is not a whole subject — stays a

--- a/packages/ui-next/src/screens/Edit.test.tsx
+++ b/packages/ui-next/src/screens/Edit.test.tsx
@@ -1,0 +1,206 @@
+import { createElement } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+/**
+ * The manifest, the apply, the diff and the delete are all supplied at core's
+ * boundary — the only thing this screen reads or writes. Everything in the
+ * kit stays real except that `CodeEditor` is wrapped to record what it was
+ * handed: CodeMirror compiles its state into a generated stylesheet jsdom
+ * cannot see, so what the editor was ASKED to show, and what it says back
+ * through `onChange`, are the two observable things.
+ */
+const core = vi.hoisted(() => ({
+  getManifest: vi.fn(),
+  applyManifest: vi.fn(),
+  diffManifest: vi.fn(),
+  validateManifest: vi.fn(),
+  deleteResource: vi.fn(),
+}));
+vi.mock("@srelens/core", async (orig) => ({
+  ...(await orig<typeof import("@srelens/core")>()),
+  ...core,
+}));
+vi.mock("@srelens/core/react", async (orig) => ({
+  ...(await orig<typeof import("@srelens/core/react")>()),
+  useNamespaceOptions: () => ({ namespaces: ["default", "payments"], scope: "", error: "" }),
+}));
+vi.mock("../lib/clusters", async (orig) => ({
+  ...(await orig<typeof import("../lib/clusters")>()),
+  useActiveContext: () => ({ name: "prod-eu", stableId: "prod-eu" }),
+  getKubeconfigFiles: () => [],
+}));
+
+const { editors } = vi.hoisted(() => ({ editors: [] as Record<string, unknown>[] }));
+vi.mock("@srelens/ui-kit", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@srelens/ui-kit")>();
+  return {
+    ...actual,
+    CodeEditor: (props: Record<string, unknown>) => {
+      editors.push({ ...props });
+      return createElement(actual.CodeEditor, props as never);
+    },
+  };
+});
+
+import { EditResource, TEMPLATES } from "./Edit";
+
+// The same jsdom gaps every screen with a Radix dialog or picker stubs.
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+const proto = window.HTMLElement.prototype as unknown as Record<string, unknown>;
+proto.scrollIntoView ??= () => {};
+proto.hasPointerCapture ??= () => false;
+proto.setPointerCapture ??= () => {};
+proto.releasePointerCapture ??= () => {};
+
+const LIVE = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: web
+  namespace: checkout
+  resourceVersion: "100"
+data:
+  key: value
+`;
+const EDITED = LIVE.replace("key: value", "key: changed");
+const ROUTE = "/edit/ConfigMap/checkout/web";
+
+/** The editor's last mount, and a way to type into it. */
+function latestEditor() {
+  const props = editors.at(-1) as { value: string; onChange: (v: string) => void; ariaLabel: string };
+  return props;
+}
+
+beforeEach(() => {
+  editors.length = 0;
+  core.getManifest.mockReset().mockResolvedValue({ yaml: LIVE });
+  core.applyManifest.mockReset().mockResolvedValue({
+    documents: [{ kind: "ConfigMap", name: "web", applied: true }],
+    applied: true,
+  });
+  core.diffManifest.mockReset().mockResolvedValue({ documents: [] });
+  core.validateManifest.mockReset().mockResolvedValue({ valid: true, errors: [] });
+  core.deleteResource.mockReset().mockResolvedValue({ ok: true });
+});
+
+describe("EditResource", () => {
+  it("opens on the live manifest, read from the cluster the tab is on", async () => {
+    render(<EditResource route={ROUTE} />);
+    await waitFor(() => expect(latestEditor()?.value).toBe(LIVE));
+    expect(core.getManifest).toHaveBeenCalledWith("prod-eu", "ConfigMap", "checkout", "web");
+    expect(latestEditor().ariaLabel).toBe("web manifest");
+    // Nothing typed yet, so there is nothing to apply.
+    expect(screen.getByRole("button", { name: "Apply" })).toHaveProperty("disabled", true);
+  });
+
+  it("applies an edited draft only after the reader confirms, and reloads on success", async () => {
+    render(<EditResource route={ROUTE} />);
+    await waitFor(() => expect(latestEditor()?.value).toBe(LIVE));
+
+    act(() => latestEditor().onChange(EDITED));
+    const apply = screen.getByRole("button", { name: "Apply" });
+    expect(apply).toHaveProperty("disabled", false);
+    await userEvent.click(apply);
+    // Nothing has been written yet — the dialog names what will be.
+    expect(core.applyManifest).not.toHaveBeenCalled();
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog.textContent).toContain("ConfigMap");
+    expect(dialog.textContent).toContain("prod-eu");
+
+    core.getManifest.mockResolvedValue({ yaml: EDITED });
+    await userEvent.click(within(dialog).getByRole("button", { name: "Apply" }));
+    await waitFor(() => expect(core.applyManifest).toHaveBeenCalledWith("prod-eu", EDITED, false));
+    // Applied, and the manifest re-read so the editor shows what is live now.
+    expect((await screen.findByRole("status")).textContent).toContain("Applied ConfigMap web");
+    await waitFor(() => expect(core.getManifest).toHaveBeenCalledTimes(2));
+  });
+
+  it("offers to force an apply another manager's field blocks", async () => {
+    // Server-side apply refuses a field someone else owns rather than
+    // overwriting it. The screen says whose, and the one way past it.
+    core.applyManifest.mockResolvedValueOnce({
+      documents: [
+        {
+          kind: "ConfigMap",
+          name: "web",
+          applied: false,
+          conflict: { managers: ["helm"], fields: [".data.key"], message: "conflict" },
+        },
+      ],
+      applied: false,
+    });
+    render(<EditResource route={ROUTE} />);
+    await waitFor(() => expect(latestEditor()?.value).toBe(LIVE));
+    act(() => latestEditor().onChange(EDITED));
+    await userEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await userEvent.click(within(await screen.findByRole("dialog")).getByRole("button", { name: "Apply" }));
+
+    const banner = await screen.findByRole("alert");
+    expect(banner.textContent).toContain("helm");
+    expect(banner.textContent).toContain(".data.key");
+    await userEvent.click(within(banner).getByRole("button", { name: "Force apply" }));
+    await waitFor(() => expect(core.applyManifest).toHaveBeenLastCalledWith("prod-eu", EDITED, true));
+  });
+
+  it("deletes only after a confirmation that names the resource and the cluster", async () => {
+    render(<EditResource route={ROUTE} />);
+    await waitFor(() => expect(latestEditor()?.value).toBe(LIVE));
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog.textContent).toContain("web");
+    expect(dialog.textContent).toContain("prod-eu");
+    expect(core.deleteResource).not.toHaveBeenCalled();
+
+    await userEvent.click(within(dialog).getByRole("button", { name: "Delete" }));
+    await waitFor(() =>
+      expect(core.deleteResource).toHaveBeenCalledWith("prod-eu", "ConfigMap", "checkout", "web"),
+    );
+    // The tab says what happened rather than showing an editor over nothing.
+    expect(await screen.findByText(/ConfigMap web was deleted/)).toBeDefined();
+  });
+
+  it("says when the manifest could not be read, instead of an empty editor", async () => {
+    core.getManifest.mockResolvedValue({ error: 'configmaps "web" is forbidden' });
+    render(<EditResource route={ROUTE} />);
+    expect(await screen.findByText(/Could not load ConfigMap web/)).toBeDefined();
+    expect(editors).toHaveLength(0);
+  });
+
+  it("refuses a route that does not name a resource", () => {
+    render(<EditResource route="/edit/web" />);
+    expect(screen.getByText(/does not name a resource/)).toBeDefined();
+  });
+});
+
+describe("EditResource on /new", () => {
+  it("starts from a template in the picked namespace, and creates with one click", async () => {
+    render(<EditResource route="/new" />);
+    await waitFor(() => expect(latestEditor()?.value).toBe(TEMPLATES.Deployment("default")));
+    expect(screen.getByRole("heading", { name: "New resource" })).toBeDefined();
+
+    await userEvent.click(screen.getByRole("button", { name: "Create" }));
+    await waitFor(() =>
+      expect(core.applyManifest).toHaveBeenCalledWith("prod-eu", TEMPLATES.Deployment("default"), false),
+    );
+    expect((await screen.findByRole("status")).textContent).toContain("Created ConfigMap web");
+  });
+
+  it("swaps the draft when a different template is picked", async () => {
+    render(<EditResource route="/new" />);
+    await waitFor(() => expect(latestEditor()?.value).toBe(TEMPLATES.Deployment("default")));
+    // A native select, so picked with `selectOptions` rather than two clicks.
+    await userEvent.selectOptions(screen.getByRole("combobox", { name: "Template" }), "ConfigMap");
+    await waitFor(() => expect(latestEditor()?.value).toBe(TEMPLATES.ConfigMap("default")));
+    // And the namespace follows the picker while the draft is still the
+    // template's.
+    await userEvent.selectOptions(screen.getByRole("combobox", { name: "Namespace" }), "payments");
+    await waitFor(() => expect(latestEditor()?.value).toBe(TEMPLATES.ConfigMap("payments")));
+  });
+});

--- a/packages/ui-next/src/screens/Edit.test.tsx
+++ b/packages/ui-next/src/screens/Edit.test.tsx
@@ -119,6 +119,12 @@ const SCHEMA = {
   },
 };
 
+/** Open one of the toolbar's pickers and choose a row. */
+async function pick(label: string, option: string) {
+  await userEvent.click(screen.getByRole("combobox", { name: label }));
+  await userEvent.click(await screen.findByRole("option", { name: option }));
+}
+
 beforeEach(() => {
   editors.length = 0;
   active.name = "prod-eu";
@@ -584,12 +590,12 @@ describe("EditResource on /new", () => {
   it("swaps the draft when a different template is picked", async () => {
     render(<EditResource route="/new" />);
     await waitFor(() => expect(latestEditor()?.value).toBe(TEMPLATES.Deployment("default")));
-    // A native select, so picked with `selectOptions` rather than two clicks.
-    await userEvent.selectOptions(screen.getByRole("combobox", { name: "Template" }), "ConfigMap");
+    // The design's picker, not a native select: open the trigger, choose a row.
+    await pick("Template", "ConfigMap");
     await waitFor(() => expect(latestEditor()?.value).toBe(TEMPLATES.ConfigMap("default")));
     // And the namespace follows the picker while the draft is still the
     // template's.
-    await userEvent.selectOptions(screen.getByRole("combobox", { name: "Namespace" }), "payments");
+    await pick("Namespace", "payments");
     await waitFor(() => expect(latestEditor()?.value).toBe(TEMPLATES.ConfigMap("payments")));
   });
 });

--- a/packages/ui-next/src/screens/Edit.test.tsx
+++ b/packages/ui-next/src/screens/Edit.test.tsx
@@ -75,7 +75,7 @@ data:
   key: value
 `;
 const EDITED = LIVE.replace("key: value", "key: changed");
-const ROUTE = "/edit/ConfigMap/checkout/web";
+const ROUTE = "/edit/prod-eu/ConfigMap/checkout/web";
 
 /** The editor's last mount, and a way to type into it. */
 function latestEditor() {
@@ -215,7 +215,7 @@ describe("EditResource", () => {
     // `k8s.getManifest` returns a Secret in the clear; the detail pane
     // redacts it and the editor has to, or one tab over undoes the gate.
     core.getManifest.mockResolvedValue({ yaml: SECRET });
-    render(<EditResource route="/edit/Secret/checkout/db" />);
+    render(<EditResource route="/edit/prod-eu/Secret/checkout/db" />);
     await waitFor(() => expect(latestEditor()?.value).toBeDefined());
     const shown = latestEditor().value as string;
     expect(shown).not.toContain("czNjcmV0");
@@ -238,7 +238,7 @@ describe("EditResource", () => {
       crds: [{ name: "widgets.acme.io", group: "acme.io", version: "v1", kind: "Widget", plural: "widgets", namespaced: true }],
     });
     core.getManifest.mockResolvedValue({ yaml: "apiVersion: acme.io/v1\nkind: Widget\nmetadata:\n  name: w1\n" });
-    render(<EditResource route="/edit/Widget/checkout/w1" />);
+    render(<EditResource route="/edit/prod-eu/Widget/checkout/w1" />);
     await waitFor(() => expect(latestEditor()?.value).toContain("kind: Widget"));
     expect(core.getManifest).toHaveBeenCalledWith("prod-eu", "Widget", "checkout", "w1", undefined, {
       group: "acme.io",
@@ -275,6 +275,68 @@ describe("EditResource", () => {
     await userEvent.click(within(dialog).getByRole("checkbox"));
     await userEvent.click(within(dialog).getByRole("button", { name: "Apply" }));
     await waitFor(() => expect(core.applyManifest).toHaveBeenCalledWith("prod-eu", EDITED, false));
+  });
+
+  it("edits the cluster named in the route, not the one the rail is on", async () => {
+    // Edit picked on staging while the rail — and perhaps another editor tab
+    // for the same-named resource — is on prod-eu. The route carries the
+    // cluster, so this is its own tab, pinned to staging from the first read.
+    render(<EditResource route="/edit/staging/ConfigMap/checkout/web" />);
+    await waitFor(() => expect(latestEditor()?.value).toBe(LIVE));
+    expect(core.getManifest).toHaveBeenCalledWith("staging", "ConfigMap", "checkout", "web", undefined, undefined);
+    act(() => latestEditor().onChange(EDITED));
+    await userEvent.click(screen.getByRole("button", { name: "Apply" }));
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog.textContent).toContain("still runs against staging, not prod-eu");
+  });
+
+  it("takes a conflict down once the draft that caused it changes", async () => {
+    core.applyManifest.mockResolvedValueOnce({
+      documents: [
+        {
+          kind: "ConfigMap",
+          name: "web",
+          applied: false,
+          conflict: { managers: ["helm"], fields: [".data.key"], message: "conflict" },
+        },
+      ],
+      applied: false,
+    });
+    render(<EditResource route={ROUTE} />);
+    await waitFor(() => expect(latestEditor()?.value).toBe(LIVE));
+    act(() => latestEditor().onChange(EDITED));
+    await userEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await userEvent.click(within(await screen.findByRole("dialog")).getByRole("button", { name: "Apply" }));
+    await screen.findByRole("alert");
+
+    // Force applies what is in the editor, so a banner left over an edited
+    // draft would force text no plain apply had described. Typing takes it
+    // down, Force with it.
+    act(() => latestEditor().onChange(EDITED.replace("changed", "changed-again")));
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Force apply" })).toBeNull();
+    // Back to the conflicted text, and the banner is back: it is that text's.
+    act(() => latestEditor().onChange(EDITED));
+    expect(screen.getByRole("alert").textContent).toContain("helm");
+  });
+
+  it("opens a custom kind that shares a built-in's name under its own group, not as the built-in", async () => {
+    core.listCrds.mockResolvedValue({
+      crds: [
+        { name: "deployments.acme.io", group: "acme.io", version: "v1", kind: "Deployment", plural: "deployments", namespaced: true },
+      ],
+    });
+    core.getManifest.mockResolvedValue({ yaml: "apiVersion: acme.io/v1\nkind: Deployment\nmetadata:\n  name: api\n" });
+    render(<EditResource route="/edit/prod-eu/acme.io%2FDeployment/checkout/api" />);
+    await waitFor(() => expect(latestEditor()?.value).toContain("acme.io/v1"));
+    expect(core.getManifest).toHaveBeenCalledWith("prod-eu", "Deployment", "checkout", "api", undefined, {
+      group: "acme.io",
+      version: "v1",
+      plural: "deployments",
+    });
+    // And no Delete: `k8s.deleteResource` resolves by kind alone, which here
+    // would be the built-in Deployment of the same name.
+    expect(screen.queryByRole("button", { name: "Delete" })).toBeNull();
   });
 
   it("says when the manifest could not be read, instead of an empty editor", async () => {

--- a/packages/ui-next/src/screens/Edit.test.tsx
+++ b/packages/ui-next/src/screens/Edit.test.tsx
@@ -17,6 +17,8 @@ const core = vi.hoisted(() => ({
   diffManifest: vi.fn(),
   validateManifest: vi.fn(),
   deleteResource: vi.fn(),
+  getSecret: vi.fn(),
+  listCrds: vi.fn(),
 }));
 vi.mock("@srelens/core", async (orig) => ({
   ...(await orig<typeof import("@srelens/core")>()),
@@ -74,7 +76,12 @@ const ROUTE = "/edit/ConfigMap/checkout/web";
 
 /** The editor's last mount, and a way to type into it. */
 function latestEditor() {
-  const props = editors.at(-1) as { value: string; onChange: (v: string) => void; ariaLabel: string };
+  const props = editors.at(-1) as {
+    value: string;
+    onChange: (v: string) => void;
+    ariaLabel: string;
+    readOnly?: boolean;
+  };
   return props;
 }
 
@@ -88,13 +95,27 @@ beforeEach(() => {
   core.diffManifest.mockReset().mockResolvedValue({ documents: [] });
   core.validateManifest.mockReset().mockResolvedValue({ valid: true, errors: [] });
   core.deleteResource.mockReset().mockResolvedValue({ ok: true });
+  core.getSecret.mockReset().mockResolvedValue({ data: { password: "s3cret" } });
+  core.listCrds.mockReset().mockResolvedValue({ crds: [] });
 });
+
+const SECRET = `apiVersion: v1
+kind: Secret
+metadata:
+  name: db
+  namespace: checkout
+type: Opaque
+data:
+  password: czNjcmV0
+`;
 
 describe("EditResource", () => {
   it("opens on the live manifest, read from the cluster the tab is on", async () => {
     render(<EditResource route={ROUTE} />);
     await waitFor(() => expect(latestEditor()?.value).toBe(LIVE));
-    expect(core.getManifest).toHaveBeenCalledWith("prod-eu", "ConfigMap", "checkout", "web");
+    // A built-in kind needs no CRD lookup, so none is passed.
+    expect(core.getManifest).toHaveBeenCalledWith("prod-eu", "ConfigMap", "checkout", "web", undefined, undefined);
+    expect(core.listCrds).not.toHaveBeenCalled();
     expect(latestEditor().ariaLabel).toBe("web manifest");
     // Nothing typed yet, so there is nothing to apply.
     expect(screen.getByRole("button", { name: "Apply" })).toHaveProperty("disabled", true);
@@ -164,6 +185,61 @@ describe("EditResource", () => {
     );
     // The tab says what happened rather than showing an editor over nothing.
     expect(await screen.findByText(/ConfigMap web was deleted/)).toBeDefined();
+  });
+
+  it("does not call an emptied manifest applied", async () => {
+    // Blank YAML applies nothing; the API answers with no documents, which is
+    // neither a conflict nor a failure and used to be toasted as a success.
+    core.applyManifest.mockResolvedValueOnce({ documents: [], applied: false });
+    render(<EditResource route={ROUTE} />);
+    await waitFor(() => expect(latestEditor()?.value).toBe(LIVE));
+    act(() => latestEditor().onChange("   \n"));
+    // Whitespace alone is not a draft worth applying.
+    expect(screen.getByRole("button", { name: "Apply" })).toHaveProperty("disabled", true);
+    // A comment-only document reaches the server and comes back empty.
+    act(() => latestEditor().onChange("# nothing here\n"));
+    await userEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await userEvent.click(within(await screen.findByRole("dialog")).getByRole("button", { name: "Apply" }));
+    expect(await screen.findByText(/Nothing to apply/)).toBeDefined();
+    expect(screen.queryByText(/^Applied /)).toBeNull();
+    // The draft is kept, not cleared as an applied one would be.
+    expect(core.getManifest).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a Secret's values out of the editor until they are revealed through the gated read", async () => {
+    // `k8s.getManifest` returns a Secret in the clear; the detail pane
+    // redacts it and the editor has to, or one tab over undoes the gate.
+    core.getManifest.mockResolvedValue({ yaml: SECRET });
+    render(<EditResource route="/edit/Secret/checkout/db" />);
+    await waitFor(() => expect(latestEditor()?.value).toBeDefined());
+    const shown = latestEditor().value as string;
+    expect(shown).not.toContain("czNjcmV0");
+    expect(shown).toContain("REDACTED");
+    expect(latestEditor().readOnly).toBe(true);
+    expect(screen.getByTestId("secret-redacted")).toBeDefined();
+    expect(core.getSecret).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole("button", { name: "Reveal values" }));
+    await waitFor(() => expect(core.getSecret).toHaveBeenCalledWith("prod-eu", "checkout", "db"));
+    await waitFor(() => expect(latestEditor().value).toBe(SECRET));
+    expect(latestEditor().readOnly).toBe(false);
+    expect(screen.queryByTestId("secret-redacted")).toBeNull();
+  });
+
+  it("resolves a custom kind's group before reading its manifest", async () => {
+    // `k8s.getManifest` knows the built-in kinds and has to be told about any
+    // other; every custom resource opened to an error until the editor asked.
+    core.listCrds.mockResolvedValue({
+      crds: [{ name: "widgets.acme.io", group: "acme.io", version: "v1", kind: "Widget", plural: "widgets", namespaced: true }],
+    });
+    core.getManifest.mockResolvedValue({ yaml: "apiVersion: acme.io/v1\nkind: Widget\nmetadata:\n  name: w1\n" });
+    render(<EditResource route="/edit/Widget/checkout/w1" />);
+    await waitFor(() => expect(latestEditor()?.value).toContain("kind: Widget"));
+    expect(core.getManifest).toHaveBeenCalledWith("prod-eu", "Widget", "checkout", "w1", undefined, {
+      group: "acme.io",
+      version: "v1",
+      plural: "widgets",
+    });
   });
 
   it("says when the manifest could not be read, instead of an empty editor", async () => {

--- a/packages/ui-next/src/screens/Edit.test.tsx
+++ b/packages/ui-next/src/screens/Edit.test.tsx
@@ -323,6 +323,45 @@ describe("EditResource", () => {
     expect(dialog.textContent).toContain("still runs against staging, not prod-eu");
   });
 
+  it("shows the diff in its own column, with long unchanged runs behind a counted gap", async () => {
+    // A manifest diff is almost all unchanged lines — one
+    // last-applied-configuration annotation is a thousand characters on one
+    // line — so the panel used to bury the one changed line in the document
+    // around it, wrapped, in a 360px rail.
+    const same = (text: string) => ({ tag: "same", left: text, right: text });
+    const rows = [
+      ...Array.from({ length: 30 }, (_, i) => same(`  line ${i}`)),
+      { tag: "replace", left: "  key: value", right: "  key: changed" },
+      ...Array.from({ length: 30 }, (_, i) => same(`  tail ${i}`)),
+    ];
+    core.diffManifest.mockResolvedValue({
+      documents: [{ kind: "ConfigMap", name: "web", exists: true, changed: true, currentResourceVersion: "100", rows }],
+    });
+    render(<EditResource route={ROUTE} />);
+    await waitFor(() => expect(latestEditor()?.value).toBe(LIVE));
+    act(() => latestEditor().onChange(EDITED));
+    await userEvent.click(screen.getByRole("button", { name: "Diff" }));
+
+    // Its own column, not a section of the analysis rail.
+    const panel = await screen.findByRole("complementary", { name: "Diff" });
+    expect(within(screen.getByRole("complementary", { name: "Analysis" })).queryByText(/unchanged/)).toBeNull();
+    // The change and its context are shown; the rest is a counted gap.
+    const gaps = await within(panel).findAllByRole(
+      "button",
+      { name: /unchanged lines/ },
+      { timeout: 3000 },
+    );
+    expect(gaps).toHaveLength(2);
+    expect(gaps[0].textContent).toContain("27");
+    expect(panel.textContent).toContain("key: changed");
+    expect(panel.textContent).not.toContain("line 0");
+    // And what the whole document costs, counted.
+    expect(panel.textContent).toContain("+1");
+
+    // A gap opens where it stands.
+    await userEvent.click(gaps[0]);
+    expect(panel.textContent).toContain("line 0");
+  });
   it("says when the comparison failed, rather than showing no changes", async () => {
     // A dry run that is forbidden, or times out, used to come back as an
     // empty diff — "No changes." one click before Apply, and no "changed

--- a/packages/ui-next/src/screens/Edit.test.tsx
+++ b/packages/ui-next/src/screens/Edit.test.tsx
@@ -416,6 +416,37 @@ describe("EditResource", () => {
     expect(typeof latestEditor().completions).toBe("function");
   });
 
+  it("tells a schema the cluster would not hand over apart from one it does not have", async () => {
+    // Secret is a built-in kind; the cluster certainly has a schema for it.
+    // Saying "this cluster publishes no schema for Secret" when the lookup
+    // itself failed is a confident wrong answer, and it hid a backend bug
+    // that made every lookup fail.
+    core.openApiSchema.mockResolvedValue({ error: "the openapi document could not be read" });
+    render(<EditResource route={ROUTE} />);
+    await waitFor(() => expect(latestEditor()?.value).toBe(LIVE));
+    const sidebar = screen.getByRole("complementary", { name: "Analysis" });
+    expect(await within(sidebar).findByText(/Could not read ConfigMap's schema/)).toBeDefined();
+    // The reason travels with it, through the same friendly-error copy every
+    // other failure on this screen uses.
+    expect(within(sidebar).getByText(/openapi document could not be read/)).toBeDefined();
+    expect(within(sidebar).queryByText(/publishes no schema/)).toBeNull();
+
+    // And it can be asked again: the failure may have been the cluster.
+    core.openApiSchema.mockResolvedValue({ key: "cm", schemas: { cm: { type: "object", properties: { data: { type: "object", description: "Data." } } } } });
+    await userEvent.click(within(sidebar).getByRole("button", { name: "Try again" }));
+    expect(await within(sidebar).findByText("data")).toBeDefined();
+  });
+
+  it("says a kind the cluster serves no schema for is exactly that", async () => {
+    // The other fact: the document came back and declares nothing of this
+    // kind — a CRD that ships no schema of its own.
+    core.openApiSchema.mockResolvedValue({ key: null, schemas: {} });
+    render(<EditResource route={ROUTE} />);
+    await waitFor(() => expect(latestEditor()?.value).toBe(LIVE));
+    const sidebar = screen.getByRole("complementary", { name: "Analysis" });
+    expect(await within(sidebar).findByText(/publishes no schema for ConfigMap/)).toBeDefined();
+    expect(within(sidebar).queryByRole("button", { name: "Try again" })).toBeNull();
+  });
   it("runs a dry run on demand, shows the verdict, and retires it when the draft changes", async () => {
     core.validateManifest.mockResolvedValue({
       valid: false,

--- a/packages/ui-next/src/screens/Edit.test.tsx
+++ b/packages/ui-next/src/screens/Edit.test.tsx
@@ -28,9 +28,12 @@ vi.mock("@srelens/core/react", async (orig) => ({
   ...(await orig<typeof import("@srelens/core/react")>()),
   useNamespaceOptions: () => ({ namespaces: ["default", "payments"], scope: "", error: "" }),
 }));
+// The rail's cluster, mutable so a test can move it out from under an open
+// editor the way a reader would.
+const { active } = vi.hoisted(() => ({ active: { name: "prod-eu", stableId: "prod-eu" } }));
 vi.mock("../lib/clusters", async (orig) => ({
   ...(await orig<typeof import("../lib/clusters")>()),
-  useActiveContext: () => ({ name: "prod-eu", stableId: "prod-eu" }),
+  useActiveContext: () => ({ ...active }),
   getKubeconfigFiles: () => [],
 }));
 
@@ -87,6 +90,8 @@ function latestEditor() {
 
 beforeEach(() => {
   editors.length = 0;
+  active.name = "prod-eu";
+  active.stableId = "prod-eu";
   core.getManifest.mockReset().mockResolvedValue({ yaml: LIVE });
   core.applyManifest.mockReset().mockResolvedValue({
     documents: [{ kind: "ConfigMap", name: "web", applied: true }],
@@ -240,6 +245,36 @@ describe("EditResource", () => {
       version: "v1",
       plural: "widgets",
     });
+    // `k8s.deleteResource` has no CRD path, so Delete on a custom resource
+    // would fail every time; it is withheld, as the list menu withholds it.
+    expect(screen.queryByRole("button", { name: "Delete" })).toBeNull();
+  });
+
+  it("keeps the cluster it opened on when the rail moves, and asks before writing there", async () => {
+    const { rerender } = render(<EditResource route={ROUTE} />);
+    await waitFor(() => expect(latestEditor()?.value).toBe(LIVE));
+    act(() => latestEditor().onChange(EDITED));
+
+    // The rail moves on to another cluster. The tab is not re-pointed: the
+    // draft stays, nothing is re-read, and the write is still aimed at the
+    // cluster the tab opened on.
+    active.name = "staging";
+    active.stableId = "staging";
+    rerender(<EditResource route={ROUTE} />);
+    expect(latestEditor().value).toBe(EDITED);
+    expect(core.getManifest).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(screen.getByRole("button", { name: "Apply" }));
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog.textContent).toContain("still runs against prod-eu, not staging");
+    // Unacknowledged, the apply is refused and the dialog stays on the question.
+    await userEvent.click(within(dialog).getByRole("button", { name: "Apply" }));
+    expect(core.applyManifest).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog").textContent).toContain("This runs on prod-eu, not staging");
+
+    await userEvent.click(within(dialog).getByRole("checkbox"));
+    await userEvent.click(within(dialog).getByRole("button", { name: "Apply" }));
+    await waitFor(() => expect(core.applyManifest).toHaveBeenCalledWith("prod-eu", EDITED, false));
   });
 
   it("says when the manifest could not be read, instead of an empty editor", async () => {

--- a/packages/ui-next/src/screens/Edit.test.tsx
+++ b/packages/ui-next/src/screens/Edit.test.tsx
@@ -19,6 +19,7 @@ const core = vi.hoisted(() => ({
   deleteResource: vi.fn(),
   getSecret: vi.fn(),
   listCrds: vi.fn(),
+  openApiSchema: vi.fn(),
 }));
 vi.mock("@srelens/core", async (orig) => ({
   ...(await orig<typeof import("@srelens/core")>()),
@@ -31,6 +32,9 @@ vi.mock("@srelens/core/react", async (orig) => ({
 // The rail's cluster, mutable so a test can move it out from under an open
 // editor the way a reader would.
 const { active } = vi.hoisted(() => ({ active: { name: "prod-eu", stableId: "prod-eu" } }));
+// The console the Review button hands the draft to.
+const { ask } = vi.hoisted(() => ({ ask: vi.fn() }));
+vi.mock("../console", () => ({ useConsole: () => ({ ask }) }));
 vi.mock("../lib/clusters", async (orig) => ({
   ...(await orig<typeof import("../lib/clusters")>()),
   useActiveContext: () => ({ ...active }),
@@ -84,9 +88,36 @@ function latestEditor() {
     onChange: (v: string) => void;
     ariaLabel: string;
     readOnly?: boolean;
+    completions?: unknown;
+    onCursorChange?: (pos: number) => void;
+    onDiagnostics?: (diagnostics: unknown[]) => void;
   };
   return props;
 }
+
+/** A schema bundle for the fixture's ConfigMap: enough to say what goes where. */
+const SCHEMA = {
+  key: "io.k8s.api.core.v1.ConfigMap",
+  schemas: {
+    "io.k8s.api.core.v1.ConfigMap": {
+      type: "object",
+      properties: {
+        apiVersion: { type: "string", description: "APIVersion defines the versioned schema." },
+        kind: { type: "string" },
+        metadata: { allOf: [{ $ref: "#/components/schemas/ObjectMeta" }], description: "Standard object's metadata." },
+        data: { type: "object", description: "Data contains the configuration data." },
+        immutable: { type: "boolean", description: "Immutable, if set to true, ensures that data cannot be updated." },
+      },
+    },
+    ObjectMeta: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Name must be unique within a namespace." },
+        namespace: { type: "string", description: "Namespace defines the space within which each name must be unique." },
+      },
+    },
+  },
+};
 
 beforeEach(() => {
   editors.length = 0;
@@ -102,6 +133,8 @@ beforeEach(() => {
   core.deleteResource.mockReset().mockResolvedValue({ ok: true });
   core.getSecret.mockReset().mockResolvedValue({ data: { password: "s3cret" } });
   core.listCrds.mockReset().mockResolvedValue({ crds: [] });
+  core.openApiSchema.mockReset().mockResolvedValue(SCHEMA);
+  ask.mockReset();
 });
 
 const SECRET = `apiVersion: v1
@@ -290,6 +323,104 @@ describe("EditResource", () => {
     expect(dialog.textContent).toContain("still runs against staging, not prod-eu");
   });
 
+  it("says when the comparison failed, rather than showing no changes", async () => {
+    // A dry run that is forbidden, or times out, used to come back as an
+    // empty diff — "No changes." one click before Apply, and no "changed
+    // elsewhere" check either.
+    core.diffManifest.mockResolvedValue({ error: 'configmaps "web" is forbidden: cannot dry-run' });
+    render(<EditResource route={ROUTE} />);
+    await waitFor(() => expect(latestEditor()?.value).toBe(LIVE));
+    act(() => latestEditor().onChange(EDITED));
+    await userEvent.click(screen.getByRole("button", { name: "Diff" }));
+    expect(await screen.findByText("Could not compare with the cluster", {}, { timeout: 3000 })).toBeDefined();
+    expect(screen.queryByText("No changes.")).toBeNull();
+    // And the header says so, whether or not the panel is open.
+    expect(screen.getByText("Not compared")).toBeDefined();
+  });
+
+  it("lists the lint pass's findings beside the editor, and calls the draft valid when there are none", async () => {
+    render(<EditResource route={ROUTE} />);
+    await waitFor(() => expect(latestEditor()?.value).toBe(LIVE));
+    const sidebar = screen.getByRole("complementary", { name: "Analysis" });
+    // What the editor's linter found — syntax, then the server-side dry run
+    // — arrives through one callback and is listed with its line.
+    act(() =>
+      latestEditor().onDiagnostics!([
+        { from: 60, to: 70, line: 7, severity: "error", message: 'unknown field "immutble"' },
+      ]),
+    );
+    expect(within(sidebar).getByText('unknown field "immutble"')).toBeDefined();
+    expect(within(sidebar).getByText("L7")).toBeDefined();
+    expect(screen.getByTestId("manifest-status").textContent).toContain("1 problem");
+
+    act(() => latestEditor().onDiagnostics!([]));
+    expect(screen.getByTestId("manifest-status").textContent).toContain("valid");
+    expect(within(sidebar).getByText(/No problems/).textContent).toContain("dry run");
+  });
+
+  it("says what the schema allows where the cursor is, and completes from the same schema", async () => {
+    render(<EditResource route={ROUTE} />);
+    await waitFor(() => expect(latestEditor()?.value).toBe(LIVE));
+    expect(core.openApiSchema).toHaveBeenCalledWith("prod-eu", "v1", "ConfigMap");
+    const sidebar = screen.getByRole("complementary", { name: "Analysis" });
+    // Cursor at the top: the top-level keys, with type and description.
+    expect(await within(sidebar).findByText("immutable")).toBeDefined();
+    expect(within(sidebar).getByText("Data contains the configuration data")).toBeDefined();
+
+    // Cursor inside metadata: its keys, and the path in the heading.
+    act(() => latestEditor().onCursorChange!(LIVE.indexOf("  name: web") + 4));
+    expect(await within(sidebar).findByText("namespace")).toBeDefined();
+    expect(within(sidebar).getByText("metadata")).toBeDefined();
+    expect(within(sidebar).queryByText("immutable")).toBeNull();
+
+    // The editor's completion popup is fed from the same schema.
+    expect(typeof latestEditor().completions).toBe("function");
+  });
+
+  it("runs a dry run on demand, shows the verdict, and retires it when the draft changes", async () => {
+    core.validateManifest.mockResolvedValue({
+      valid: false,
+      errors: [{ docIndex: 0, message: "metadata.name: Invalid value: too long" }],
+    });
+    render(<EditResource route={ROUTE} />);
+    await waitFor(() => expect(latestEditor()?.value).toBe(LIVE));
+    await userEvent.click(screen.getByRole("button", { name: "Dry run" }));
+    const verdict = await screen.findByTestId("dry-run-verdict");
+    expect(verdict.textContent).toContain("Dry run failed");
+    expect(verdict.textContent).toContain("Invalid value: too long");
+    expect(core.validateManifest).toHaveBeenCalledWith("prod-eu", LIVE);
+
+    // The verdict was about that text; typing makes it stale, so it goes.
+    act(() => latestEditor().onChange(EDITED));
+    expect(screen.queryByTestId("dry-run-verdict")).toBeNull();
+
+    core.validateManifest.mockResolvedValue({ valid: true, errors: [] });
+    await userEvent.click(screen.getByRole("button", { name: "Dry run" }));
+    expect((await screen.findByTestId("dry-run-verdict")).textContent).toContain("Dry run passed");
+  });
+
+  it("hands the draft to the assistant for review, naming the cluster it is bound for", async () => {
+    render(<EditResource route={ROUTE} />);
+    await waitFor(() => expect(latestEditor()?.value).toBe(LIVE));
+    act(() => latestEditor().onChange(EDITED));
+    await userEvent.click(screen.getByRole("button", { name: "Review" }));
+    expect(ask).toHaveBeenCalledTimes(1);
+    const question = ask.mock.calls[0][0] as string;
+    expect(question).toContain("ConfigMap web");
+    expect(question).toContain("prod-eu");
+    expect(question).toContain("key: changed");
+  });
+
+  it("reverts the draft to the live manifest", async () => {
+    render(<EditResource route={ROUTE} />);
+    await waitFor(() => expect(latestEditor()?.value).toBe(LIVE));
+    act(() => latestEditor().onChange(EDITED));
+    expect(latestEditor().value).toBe(EDITED);
+    await userEvent.click(screen.getByRole("button", { name: "Revert" }));
+    await waitFor(() => expect(latestEditor().value).toBe(LIVE));
+    expect(core.getManifest).toHaveBeenCalledTimes(2);
+  });
+
   it("takes a conflict down once the draft that caused it changes", async () => {
     core.applyManifest.mockResolvedValueOnce({
       documents: [
@@ -353,6 +484,21 @@ describe("EditResource", () => {
 });
 
 describe("EditResource on /new", () => {
+  it("creates on the cluster named in the route, and asks first when the rail is elsewhere", async () => {
+    // New pressed on staging's list opens /new/staging; the rail is on
+    // prod-eu. The draft is staging's, and the gate says so before Create.
+    render(<EditResource route="/new/staging" />);
+    await waitFor(() => expect(latestEditor()?.value).toBe(TEMPLATES.Deployment("default")));
+    await userEvent.click(screen.getByRole("button", { name: "Create" }));
+    expect(core.applyManifest).not.toHaveBeenCalled();
+    expect(screen.getByText(/still runs against staging, not prod-eu/)).toBeDefined();
+    await userEvent.click(screen.getByRole("checkbox"));
+    await userEvent.click(screen.getByRole("button", { name: "Create" }));
+    await waitFor(() =>
+      expect(core.applyManifest).toHaveBeenCalledWith("staging", TEMPLATES.Deployment("default"), false),
+    );
+  });
+
   it("starts from a template in the picked namespace, and creates with one click", async () => {
     render(<EditResource route="/new" />);
     await waitFor(() => expect(latestEditor()?.value).toBe(TEMPLATES.Deployment("default")));

--- a/packages/ui-next/src/screens/Edit.tsx
+++ b/packages/ui-next/src/screens/Edit.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   applyManifest,
   deleteResource,
@@ -24,15 +24,19 @@ import {
   EmptyState,
   Screen,
   Select,
+  type EditorDiagnostic,
 } from "@srelens/ui-kit";
+import { useConsole } from "../console";
 import { getKubeconfigFiles, useActiveContext } from "../lib/clusters";
 import { useClusterGate } from "../lib/clusterMoved";
 import { SLUG_BY_K8S_KIND, isBuiltInKind, resolveCrdGvk } from "../lib/crdGvk";
-import { parseEditRoute, type EditRouteParts } from "../lib/detailRoute";
+import { parseEditRoute, parseNewRoute, type EditRouteParts } from "../lib/detailRoute";
 import { FailureAlert } from "../lib/errorCopy";
+import { keysAt, schemaCompletions, useManifestSchema } from "../lib/manifestSchema";
 import { CUSTOM_RESOURCE_ACTIONS } from "../lib/kinds/custom";
 import { descriptorFor } from "../lib/kinds/descriptors";
 import { useResource } from "../lib/useResource";
+import { EditAnalysis, ProblemsDot, type DryRunState } from "./EditAnalysis";
 import { NoClusterScreen } from "./resourceShell";
 
 /**
@@ -53,21 +57,22 @@ import { NoClusterScreen } from "./resourceShell";
  * a field another manager owns comes back as a conflict rather than an
  * overwrite — the reader chooses to force it, and is told whose field it was.
  *
- * What is NOT here yet: schema-driven completion in the editor. The kit takes
- * a completion source and core has the schema helpers, but wiring the two
- * needs CodeMirror's autocomplete types in this package, which it does not
- * yet depend on. Validation — a strict dry run against the API server — is
- * wired, and is the half that catches a wrong manifest before it is applied.
+ * **Beside the editor, an analysis of the draft**: the lint pass's findings
+ * listed with their lines, an on-demand dry run's verdict, and what the
+ * kind's OpenAPI schema allows where the cursor is — the same schema that
+ * feeds the editor's completion popup, through `lib/manifestSchema`. The
+ * toolbar carries the one-word verdict ("valid", "2 problems"), Revert, Diff,
+ * Review — which hands the draft to the assistant — Dry run, and Apply.
  */
 export function EditResource({ route }: { route: string }) {
   const context = useActiveContext();
-  const creating = route === "/new";
-  const parts = creating ? null : parseEditRoute(route);
+  const created = parseNewRoute(route);
+  const parts = created ? null : parseEditRoute(route);
   const title = parts ? `Edit ${parts.name}` : "New resource";
 
   if (!context) return <NoClusterScreen title={title} noun="resources" />;
 
-  if (!creating && !parts) {
+  if (!created && !parts) {
     // Unreachable through `screenFor`, which sends a route here only once
     // `parseEditRoute` has accepted it — but a route string can arrive from a
     // persisted session, and a tab that says what is wrong with it is worth
@@ -94,7 +99,7 @@ export function EditResource({ route }: { route: string }) {
   return parts ? (
     <EditExisting key={route} context={context} parts={parts} />
   ) : (
-    <NewResource context={context} />
+    <NewResource key={route} context={context} cluster={created?.cluster} />
   );
 }
 
@@ -203,6 +208,64 @@ function validator(context: string) {
     validateManifest(context, yaml).then((r) => (r.valid === false ? (r.errors ?? []) : []));
 }
 
+/**
+ * Everything the analysis sidebar knows about the draft, shared by edit and
+ * create: the last lint pass's findings, the schema for the kind the draft
+ * names and what it allows at the cursor, an on-demand dry run, the
+ * completion source built on that same schema, and the hand-off to the
+ * assistant for a review.
+ */
+function useAnalysis(pinned: string, yaml: string) {
+  // `null` until the first pass: "no problems" before anything has looked
+  // would be a guess, and the toolbar says "unchecked" instead.
+  const [problems, setProblems] = useState<EditorDiagnostic[] | null>(null);
+  const [cursor, setCursor] = useState(0);
+  const schema = useManifestSchema(pinned, yaml);
+  const bundleRef = useRef(schema.bundle);
+  bundleRef.current = schema.bundle;
+  // One source for the editor's life. It reads the bundle through the ref, so
+  // a schema that arrives after mount — or changes with the kind — is offered
+  // without rebuilding the editor.
+  const completions = useMemo(() => schemaCompletions(() => bundleRef.current), []);
+  const keys = useMemo(
+    () => (schema.bundle ? keysAt(schema.bundle, yaml, cursor) : null),
+    [schema.bundle, yaml, cursor],
+  );
+
+  const [dryRun, setDryRun] = useState<DryRunState>({ status: "idle", errors: [] });
+  // A dry run's verdict is about the text it ran on; typing retires it.
+  useEffect(() => {
+    setDryRun({ status: "idle", errors: [] });
+  }, [yaml]);
+  async function runDryRun() {
+    setDryRun({ status: "running", errors: [] });
+    const r = await validateManifest(pinned, yaml);
+    if (r.error) setDryRun({ status: "error", errors: [], error: describeError(r.error).detail });
+    else if (r.valid === false) setDryRun({ status: "failed", errors: r.errors ?? [] });
+    else setDryRun({ status: "passed", errors: [] });
+  }
+
+  const { ask } = useConsole();
+  function review(what: string) {
+    ask(
+      `Review this ${what} before I apply it to ${pinned}. Say what is risky, wrong, or missing, and why.\n\n\`\`\`yaml\n${yaml}\n\`\`\``,
+    );
+  }
+
+  return {
+    problems: problems ?? [],
+    checked: problems !== null,
+    setProblems,
+    setCursor,
+    schema,
+    keys,
+    completions,
+    dryRun,
+    runDryRun,
+    review,
+  };
+}
+
 /** The conflict banner: who owns the field, and the one way past it. */
 function Conflicts({
   conflicts,
@@ -245,7 +308,21 @@ function Conflicts({
  * dry run — and the one line that matters most, whether the live object has
  * moved since the manifest was loaded.
  */
-function Changes({ docs, computing }: { docs: DiffDoc[] | null; computing: boolean }) {
+function Changes({ docs, computing, error }: { docs: DiffDoc[] | null; computing: boolean; error: string }) {
+  // A comparison that failed is not "no changes": the reader is one click
+  // from Apply, and the dry run that would have told them what it does — and
+  // whether the object moved under them — never answered.
+  if (error) {
+    return (
+      <div className="flex flex-col gap-2 p-3">
+        <FailureAlert title="Could not compare with the cluster" error={error} />
+        <p className="text-xs text-muted">
+          Nothing here can say what applying would change, or whether the live object has changed
+          since you opened it. Applying takes your version.
+        </p>
+      </div>
+    );
+  }
   if (computing && !docs) return <p className="p-3 text-sm text-muted">Comparing with the cluster…</p>;
   if (!docs || docs.length === 0) return <p className="p-3 text-sm text-muted">No changes.</p>;
   return (
@@ -347,6 +424,7 @@ function EditExisting({ context, parts }: { context: ClusterContext; parts: Edit
   const [draft, setDraft] = useState<string | null>(null);
   const yaml = draft ?? live ?? "";
   const dirty = draft !== null && draft !== live;
+  const analysis = useAnalysis(pinned, yaml);
   const loadedRv = useMemo(() => parseResourceVersion(manifest.data?.raw ?? ""), [manifest.data]);
 
   const [confirming, setConfirming] = useState(false);
@@ -381,9 +459,15 @@ function EditExisting({ context, parts }: { context: ClusterContext; parts: Edit
    */
   const [diff, setDiff] = useState<DiffDoc[] | null>(null);
   const [diffing, setDiffing] = useState(false);
+  // Kept apart from `diff` rather than folded into an empty list: an empty
+  // list is a real answer ("nothing would change"), and a failed comparison
+  // shown as that answer was false reassurance right before Apply — and
+  // silently switched off the "changed elsewhere" check with it.
+  const [diffError, setDiffError] = useState("");
   useEffect(() => {
     if (!dirty) {
       setDiff(null);
+      setDiffError("");
       return;
     }
     let active = true;
@@ -391,7 +475,8 @@ function EditExisting({ context, parts }: { context: ClusterContext; parts: Edit
     const t = setTimeout(() => {
       void diffManifest(pinned, yaml).then((out) => {
         if (!active) return;
-        setDiff(out.error ? [] : (out.documents ?? []));
+        setDiff(out.error ? null : (out.documents ?? []));
+        setDiffError(out.error ? describeError(out.error).detail : "");
         setDiffing(false);
       });
     }, 600);
@@ -447,10 +532,19 @@ function EditExisting({ context, parts }: { context: ClusterContext; parts: Edit
       eyebrow={`${where} · ${pinned}`}
       actions={
         <>
+          <ProblemsDot problems={analysis.problems} checked={analysis.checked} />
+          {diffError && (
+            <span
+              className="text-xs text-sev"
+              title={`The dry run that compares the draft with the cluster failed, so whether the live object has changed is unknown. ${diffError}`}
+            >
+              Not compared
+            </span>
+          )}
           {stale && (
             <span
               className="text-xs text-warn"
-              title="The live object has a newer resourceVersion than the one loaded here. Reload to see it; applying over it takes your version."
+              title="The live object has a newer resourceVersion than the one loaded here. Revert to see it; applying over it takes your version."
             >
               Changed elsewhere
             </span>
@@ -465,9 +559,6 @@ function EditExisting({ context, parts }: { context: ClusterContext; parts: Edit
               {revealBusy ? "Revealing…" : "Reveal values"}
             </Button>
           )}
-          <Button variant="ghost" onClick={() => setShowChanges((v) => !v)} disabled={!dirty}>
-            {showChanges ? "Hide changes" : "Changes"}
-          </Button>
           <Button
             variant="ghost"
             onClick={() => {
@@ -476,7 +567,26 @@ function EditExisting({ context, parts }: { context: ClusterContext; parts: Edit
             }}
             title="Throw the draft away and load the manifest again from the cluster"
           >
-            Reload
+            Revert
+          </Button>
+          <Button variant="ghost" onClick={() => setShowChanges((v) => !v)} disabled={!dirty}>
+            {showChanges ? "Hide diff" : "Diff"}
+          </Button>
+          <Button
+            variant="ghost"
+            onClick={() => analysis.review(`${kind} ${name}`)}
+            disabled={!revealed || !yaml.trim() || manifest.status !== "ready"}
+            title="Hand the manifest to the assistant to look over before you apply it"
+          >
+            Review
+          </Button>
+          <Button
+            variant="ghost"
+            onClick={() => void analysis.runDryRun()}
+            disabled={!revealed || !yaml.trim() || analysis.dryRun.status === "running" || manifest.status !== "ready"}
+            title="Send the manifest to the API server as a dry run — admission included, nothing written"
+          >
+            {analysis.dryRun.status === "running" ? "Dry run…" : "Dry run"}
           </Button>
           {canDelete && (
             <Button
@@ -546,14 +656,23 @@ function EditExisting({ context, parts }: { context: ClusterContext; parts: Edit
                   readOnly={!revealed}
                   ariaLabel={`${name} manifest`}
                   schemaValidate={validator(pinned)}
+                  completions={analysis.completions}
+                  onCursorChange={analysis.setCursor}
+                  onDiagnostics={analysis.setProblems}
                 />
               </div>
             )}
           </div>
-          {showChanges && dirty && (
-            <aside className="rule-l scroll w-[440px] shrink-0" aria-label="Changes">
-              <Changes docs={diff} computing={diffing} />
-            </aside>
+          {manifest.status === "ready" && (
+            <EditAnalysis
+              problems={analysis.problems}
+              checked={analysis.checked}
+              keys={analysis.keys}
+              schema={analysis.schema.status}
+              kind={analysis.schema.kind}
+              dryRun={analysis.dryRun}
+              diff={showChanges && dirty ? <Changes docs={diff} computing={diffing} error={diffError} /> : null}
+            />
           )}
         </div>
       </div>
@@ -709,8 +828,10 @@ metadata:
 
 export const TEMPLATE_ORDER = ["Deployment", "Service", "ConfigMap", "Secret", "Ingress", "Namespace", "Blank"];
 
-function NewResource({ context }: { context: ClusterContext }) {
-  const [pinned] = useState(context.name);
+function NewResource({ context, cluster }: { context: ClusterContext; cluster?: string }) {
+  // The cluster in the route — the one the reader pressed New on — or, on the
+  // bare `/new`, whatever the rail is on now. See `newRoute`.
+  const [pinned] = useState(cluster ?? context.name);
   const { namespaces } = useNamespaceOptions(pinned, getKubeconfigFiles());
   const options = namespaces ?? [];
 
@@ -728,6 +849,7 @@ function NewResource({ context }: { context: ClusterContext }) {
   }, [options, namespace, template]);
 
   const editor = useApply({ pinned, live: context.name, verb: "create", yaml, onApplied: () => {} });
+  const analysis = useAnalysis(pinned, yaml);
   const untouched = yaml === TEMPLATES[template](namespace);
 
   const pickTemplate = (next: string) => {
@@ -765,6 +887,23 @@ function NewResource({ context }: { context: ClusterContext }) {
               className="min-w-36"
             />
           </label>
+          <ProblemsDot problems={analysis.problems} checked={analysis.checked} />
+          <Button
+            variant="ghost"
+            onClick={() => analysis.review("new manifest")}
+            disabled={!yaml.trim()}
+            title="Hand the manifest to the assistant to look over before you create it"
+          >
+            Review
+          </Button>
+          <Button
+            variant="ghost"
+            onClick={() => void analysis.runDryRun()}
+            disabled={!yaml.trim() || analysis.dryRun.status === "running"}
+            title="Send the manifest to the API server as a dry run — admission included, nothing written"
+          >
+            {analysis.dryRun.status === "running" ? "Dry run…" : "Dry run"}
+          </Button>
           <Button
             variant="primary"
             disabled={!yaml.trim() || editor.busy}
@@ -795,17 +934,30 @@ function NewResource({ context }: { context: ClusterContext }) {
             </p>
           )}
         </div>
-        <div className="relative min-h-0 flex-1 p-4">
-          <div className="absolute inset-4">
-            <CodeEditor
-              value={yaml}
-              onChange={setYaml}
-              language="yaml"
-              fill
-              ariaLabel="New resource manifest"
-              schemaValidate={validator(pinned)}
-            />
+        <div className="flex min-h-0 flex-1">
+          <div className="relative min-h-0 min-w-0 flex-1 p-4">
+            <div className="absolute inset-4">
+              <CodeEditor
+                value={yaml}
+                onChange={setYaml}
+                language="yaml"
+                fill
+                ariaLabel="New resource manifest"
+                schemaValidate={validator(pinned)}
+                completions={analysis.completions}
+                onCursorChange={analysis.setCursor}
+                onDiagnostics={analysis.setProblems}
+              />
+            </div>
           </div>
+          <EditAnalysis
+            problems={analysis.problems}
+            checked={analysis.checked}
+            keys={analysis.keys}
+            schema={analysis.schema.status}
+            kind={analysis.schema.kind}
+            dryRun={analysis.dryRun}
+          />
         </div>
       </div>
     </Screen>

--- a/packages/ui-next/src/screens/Edit.tsx
+++ b/packages/ui-next/src/screens/Edit.tsx
@@ -28,7 +28,7 @@ import {
 import { getKubeconfigFiles, useActiveContext } from "../lib/clusters";
 import { useClusterGate } from "../lib/clusterMoved";
 import { SLUG_BY_K8S_KIND, isBuiltInKind, resolveCrdGvk } from "../lib/crdGvk";
-import { parseEditRoute, type DetailRouteParts } from "../lib/detailRoute";
+import { parseEditRoute, type EditRouteParts } from "../lib/detailRoute";
 import { FailureAlert } from "../lib/errorCopy";
 import { CUSTOM_RESOURCE_ACTIONS } from "../lib/kinds/custom";
 import { descriptorFor } from "../lib/kinds/descriptors";
@@ -77,20 +77,20 @@ export function EditResource({ route }: { route: string }) {
         <div className="p-4">
           <FailureAlert
             title={`${route} does not name a resource`}
-            error="An editor tab's route is /edit/<kind>/<namespace>/<name>. Close this tab and open the resource from its list."
+            error="An editor tab's route is /edit/<cluster>/<kind>/<namespace>/<name>. Close this tab and open the resource from its list."
           />
         </div>
       </Screen>
     );
   }
 
-  // Keyed by route alone, NOT by cluster. A tab that is re-pointed at another
-  // resource starts its draft over; a rail that moves to another cluster must
-  // not. Each editor pins the cluster it was opened on, and that pin has to
-  // outlive the rail: keyed by `stableId` too, a rail switch remounted the
-  // editor, re-pinned it to the new cluster, threw the draft away, and made
-  // the gate see pinned === live — so Apply and Delete went to the new
-  // cluster without the moved-cluster warning this screen promises.
+  // Keyed by route alone, NOT by the rail's cluster. The route names the
+  // cluster the editor is FOR (see `EditRouteParts`), so a tab re-pointed at
+  // another resource, or at another cluster's resource, starts over — while a
+  // rail that merely moves must not: keyed by `stableId` too, a rail switch
+  // remounted the editor, re-pinned it to the new cluster, threw the draft
+  // away, and made the gate see pinned === live — so Apply and Delete went to
+  // the new cluster without the moved-cluster warning this screen promises.
   return parts ? (
     <EditExisting key={route} context={context} parts={parts} />
   ) : (
@@ -127,17 +127,27 @@ function useApply({
   pinned,
   live,
   verb,
+  yaml,
   onApplied,
 }: {
   pinned: string;
   live: string;
   verb: string;
+  /** What the editor holds NOW — what a remembered conflict is checked against. */
+  yaml: string;
   onApplied: (docs: ApplyDoc[]) => void;
 }) {
   const gate = useClusterGate({ pinned, live, verb });
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
-  const [conflicts, setConflicts] = useState<ApplyDoc[]>([]);
+  // A conflict is remembered WITH the text that produced it, and shown only
+  // while the editor still holds that text. The banner's Force applies what
+  // is in the editor, so a banner left standing over an edited draft would
+  // have forced text no non-forcing attempt had described — new documents,
+  // retargeted ones — and taken ownership the banner never named. Typing
+  // takes the banner down; the next Apply is a plain one.
+  const [conflict, setConflict] = useState<{ docs: ApplyDoc[]; yaml: string } | null>(null);
+  const conflicts = conflict !== null && conflict.yaml === yaml ? conflict.docs : [];
   const [applied, setApplied] = useState<{ kind: string; name: string } | null>(null);
 
   async function apply(yaml: string, force: boolean) {
@@ -154,7 +164,7 @@ function useApply({
     setBusy(false);
     if (out.error) {
       setError(describeError(out.error).detail);
-      setConflicts([]);
+      setConflict(null);
       return false;
     }
     const docs = out.documents ?? [];
@@ -163,11 +173,11 @@ function useApply({
     // success, toast one, and reload the unchanged object.
     if (docs.length === 0) {
       setError("Nothing to apply: the manifest has no documents in it.");
-      setConflicts([]);
+      setConflict(null);
       return false;
     }
     const { conflicts: conflicted, failures } = outcome(docs);
-    setConflicts(conflicted);
+    setConflict(conflicted.length > 0 ? { docs: conflicted, yaml } : null);
     // A conflict and a hard failure can arrive together; the failure is shown
     // now rather than after the reader has forced the conflict.
     if (failures.length > 0) setError(failureLine(failures));
@@ -254,19 +264,28 @@ function Changes({ docs, computing }: { docs: DiffDoc[] | null; computing: boole
   );
 }
 
-function EditExisting({ context, parts }: { context: ClusterContext; parts: DetailRouteParts }) {
-  // The cluster this tab was opened on. Reads and writes go here, whatever the
-  // rail does later.
-  const [pinned] = useState(context.name);
+function EditExisting({ context, parts }: { context: ClusterContext; parts: EditRouteParts }) {
+  // The cluster this tab is FOR: the one in the route, which is the one the
+  // resource was picked on. Reads and writes go here, whatever the rail does
+  // later. Only a route an earlier build persisted has no cluster in it, and
+  // that one pins whatever the rail was on when the tab came back.
+  const [pinned] = useState(parts.cluster ?? context.name);
   const { kind, namespace, name } = parts;
+
+  // Custom when the route says so — a group is carried only for a custom
+  // kind, and it is what tells `Deployment` in `acme.io` from the built-in
+  // — or, on a route with no group, when the kind is outside the built-in
+  // table.
+  const custom = parts.group !== undefined || !isBuiltInKind(kind);
 
   // Whether Delete is offered at all: the same verdict the list menu and the
   // detail footer reach from the kind's descriptor. `k8s.deleteResource`
   // resolves kinds from a closed table with no CRD path — the manifest read
   // below is told a custom kind's group, delete cannot be — so for a custom
-  // resource it fails every time, after a confirm that read as real. See
-  // `KindActions.delete`.
-  const actions = isBuiltInKind(kind) ? descriptorFor(SLUG_BY_K8S_KIND[kind])?.actions : CUSTOM_RESOURCE_ACTIONS;
+  // resource it fails every time, after a confirm that read as real; and for
+  // a custom kind that shares a built-in's name it would delete the built-in.
+  // See `KindActions.delete`.
+  const actions = custom ? CUSTOM_RESOURCE_ACTIONS : descriptorFor(SLUG_BY_K8S_KIND[kind])?.actions;
   const canDelete = actions?.delete !== false;
 
   /**
@@ -292,8 +311,8 @@ function EditExisting({ context, parts }: { context: ClusterContext; parts: Deta
       // A kind outside the built-in table has to be resolved to its group
       // first, or the read fails for every custom resource.
       let crd: DynamicGvk | undefined;
-      if (!isBuiltInKind(kind)) {
-        const resolved = await resolveCrdGvk(pinned, kind);
+      if (custom) {
+        const resolved = await resolveCrdGvk(pinned, kind, parts.group);
         if (resolved.error) throw new Error(resolved.error);
         crd = resolved.crd;
       }
@@ -340,6 +359,7 @@ function EditExisting({ context, parts }: { context: ClusterContext; parts: Deta
   const editor = useApply({
     pinned,
     live: context.name,
+    yaml,
     verb: "apply",
     onApplied: () => {
       // The live object is now what was typed; the draft has nothing left to
@@ -707,7 +727,7 @@ function NewResource({ context }: { context: ClusterContext }) {
     setYaml((current) => (current === TEMPLATES[template](namespace) ? TEMPLATES[template](first) : current));
   }, [options, namespace, template]);
 
-  const editor = useApply({ pinned, live: context.name, verb: "create", onApplied: () => {} });
+  const editor = useApply({ pinned, live: context.name, verb: "create", yaml, onApplied: () => {} });
   const untouched = yaml === TEMPLATES[template](namespace);
 
   const pickTemplate = (next: string) => {

--- a/packages/ui-next/src/screens/Edit.tsx
+++ b/packages/ui-next/src/screens/Edit.tsx
@@ -32,6 +32,7 @@ import { useClusterGate } from "../lib/clusterMoved";
 import { SLUG_BY_K8S_KIND, isBuiltInKind, resolveCrdGvk } from "../lib/crdGvk";
 import { parseEditRoute, parseNewRoute, type EditRouteParts } from "../lib/detailRoute";
 import { FailureAlert } from "../lib/errorCopy";
+import { collapseDiff, diffCounts } from "../lib/diffCollapse";
 import { keysAt, schemaCompletions, useManifestSchema } from "../lib/manifestSchema";
 import { CUSTOM_RESOURCE_ACTIONS } from "../lib/kinds/custom";
 import { descriptorFor } from "../lib/kinds/descriptors";
@@ -304,6 +305,62 @@ function Conflicts({
 }
 
 /**
+ * One document's diff: the changed lines, a few either side, and a counted
+ * gap standing in for every long unchanged run.
+ *
+ * A manifest diff is almost all unchanged lines — a Deployment's
+ * `last-applied-configuration` annotation alone runs to a thousand
+ * characters on one line — so printing the whole document to show that one
+ * label moved buried the answer. Each gap opens where it stands, and lines
+ * run rather than wrap, because a wrapped annotation is a block of text with
+ * the short changed lines lost inside it.
+ */
+function DocDiff({ doc }: { doc: DiffDoc }) {
+  const rows = doc.rows ?? [];
+  const { added, removed } = diffCounts(rows);
+  const segments = useMemo(() => collapseDiff(rows), [rows]);
+  const [opened, setOpened] = useState<Set<number>>(new Set());
+
+  return (
+    <section>
+      <h3 className="mb-1 flex items-baseline gap-2 text-[10px] uppercase tracking-wide text-faint">
+        <span className="truncate">
+          {doc.kind} {doc.name}
+        </span>
+        {!doc.exists ? (
+          <span className="normal-case tracking-normal text-ok">will be created</span>
+        ) : added === 0 && removed === 0 ? (
+          <span className="normal-case tracking-normal text-muted">unchanged</span>
+        ) : (
+          <span className="tabular-nums normal-case tracking-normal">
+            <span className="text-ok">+{added}</span> <span className="text-sev">−{removed}</span>
+          </span>
+        )}
+      </h3>
+      {rows.length > 0 && (
+        <div className="overflow-x-auto rounded-md border border-rule">
+          {segments.map((segment) =>
+            segment.kind === "rows" || opened.has(segment.from) ? (
+              <DiffLines key={segment.from} rows={segment.rows} wrap={false} />
+            ) : (
+              <button
+                key={segment.from}
+                type="button"
+                onClick={() => setOpened((prev) => new Set(prev).add(segment.from))}
+                className="sticky left-0 flex w-full items-center gap-2 bg-sunk px-2 py-1 text-left text-[10px] text-muted hover:text-ink"
+              >
+                <span aria-hidden>⋯</span>
+                Show {segment.rows.length} unchanged {segment.rows.length === 1 ? "line" : "lines"}
+              </button>
+            ),
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+/**
  * The Changes panel: what applying the draft would do, per document, from a
  * dry run — and the one line that matters most, whether the live object has
  * moved since the manifest was loaded.
@@ -328,14 +385,7 @@ function Changes({ docs, computing, error }: { docs: DiffDoc[] | null; computing
   return (
     <div className="flex flex-col gap-4 p-3">
       {docs.map((d, i) => (
-        <section key={`${d.kind}/${d.name}/${i}`}>
-          <h3 className="mb-1 text-[10px] uppercase text-faint">
-            {d.kind} {d.name}
-            {!d.exists && " · will be created"}
-            {d.exists && !d.changed && " · unchanged"}
-          </h3>
-          {d.changed && <DiffLines rows={d.rows} />}
-        </section>
+        <DocDiff key={`${d.kind}/${d.name}/${i}`} doc={d} />
       ))}
     </div>
   );
@@ -663,6 +713,13 @@ function EditExisting({ context, parts }: { context: ClusterContext; parts: Edit
               </div>
             )}
           </div>
+          {/* The diff is its own column, not a section of the analysis rail:
+              a manifest diff is wide, and 360px of it was unreadable. */}
+          {showChanges && dirty && (
+            <aside className="rule-l scroll w-[30rem] shrink-0" aria-label="Diff">
+              <Changes docs={diff} computing={diffing} error={diffError} />
+            </aside>
+          )}
           {manifest.status === "ready" && (
             <EditAnalysis
               problems={analysis.problems}
@@ -671,7 +728,6 @@ function EditExisting({ context, parts }: { context: ClusterContext; parts: Edit
               schema={analysis.schema.status}
               kind={analysis.schema.kind}
               dryRun={analysis.dryRun}
-              diff={showChanges && dirty ? <Changes docs={diff} computing={diffing} error={diffError} /> : null}
             />
           )}
         </div>

--- a/packages/ui-next/src/screens/Edit.tsx
+++ b/packages/ui-next/src/screens/Edit.tsx
@@ -1,0 +1,691 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  applyManifest,
+  deleteResource,
+  describeError,
+  diffManifest,
+  getManifest,
+  notify,
+  parseResourceVersion,
+  validateManifest,
+  type ApplyDoc,
+  type ClusterContext,
+  type DiffDoc,
+} from "@srelens/core";
+import { useNamespaceOptions } from "@srelens/core/react";
+import {
+  Button,
+  CodeEditor,
+  ConfirmDialog,
+  DiffLines,
+  EmptyState,
+  Screen,
+  Select,
+} from "@srelens/ui-kit";
+import { getKubeconfigFiles, useActiveContext } from "../lib/clusters";
+import { useClusterGate } from "../lib/clusterMoved";
+import { parseEditRoute, type DetailRouteParts } from "../lib/detailRoute";
+import { FailureAlert } from "../lib/errorCopy";
+import { useResource } from "../lib/useResource";
+import { NoClusterScreen } from "./resourceShell";
+
+/**
+ * The resource editor: one YAML manifest, applied server-side.
+ *
+ * Two routes land here. `/edit/<kind>/<namespace>/<name>` — what the row
+ * menu's `Edit` and the detail pane's footer mint — loads the live manifest
+ * and edits it in place; `/new` starts from a template and creates. Both were
+ * routes before this screen existed: the menu opened a correctly titled tab
+ * onto the Placeholder, which is what "clicking Edit does nothing" was.
+ *
+ * **Every write goes to the cluster the tab was opened on**, not to whatever
+ * the rail points at now. The route names a resource, and a resource belongs
+ * to one cluster; a reader who moved the rail mid-edit is told, and asked to
+ * confirm, exactly as the row menu's dialogs do. See `lib/clusterMoved`.
+ *
+ * **Apply is server-side apply**, so the same button creates and updates, and
+ * a field another manager owns comes back as a conflict rather than an
+ * overwrite — the reader chooses to force it, and is told whose field it was.
+ *
+ * What is NOT here yet: schema-driven completion in the editor. The kit takes
+ * a completion source and core has the schema helpers, but wiring the two
+ * needs CodeMirror's autocomplete types in this package, which it does not
+ * yet depend on. Validation — a strict dry run against the API server — is
+ * wired, and is the half that catches a wrong manifest before it is applied.
+ */
+export function EditResource({ route }: { route: string }) {
+  const context = useActiveContext();
+  const creating = route === "/new";
+  const parts = creating ? null : parseEditRoute(route);
+  const title = parts ? `Edit ${parts.name}` : "New resource";
+
+  if (!context) return <NoClusterScreen title={title} noun="resources" />;
+
+  if (!creating && !parts) {
+    // Unreachable through `screenFor`, which sends a route here only once
+    // `parseEditRoute` has accepted it — but a route string can arrive from a
+    // persisted session, and a tab that says what is wrong with it is worth
+    // more than a blank one.
+    return (
+      <Screen title="Edit" eyebrow={context.name} fill>
+        <div className="p-4">
+          <FailureAlert
+            title={`${route} does not name a resource`}
+            error="An editor tab's route is /edit/<kind>/<namespace>/<name>. Close this tab and open the resource from its list."
+          />
+        </div>
+      </Screen>
+    );
+  }
+
+  // Keyed by cluster and route, so a tab that is re-pointed starts its draft
+  // over rather than carrying one resource's edits onto another.
+  return parts ? (
+    <EditExisting key={`${context.stableId}:${route}`} context={context} parts={parts} />
+  ) : (
+    <NewResource key={context.stableId} context={context} />
+  );
+}
+
+/**
+ * What the API server answers about an apply, reduced to what the screen has
+ * to say next: nothing, a conflict to force, or a failure to show.
+ */
+function outcome(docs: ApplyDoc[]): { conflicts: ApplyDoc[]; failures: ApplyDoc[] } {
+  return {
+    conflicts: docs.filter((d) => d.conflict),
+    failures: docs.filter((d) => d.error),
+  };
+}
+
+function failureLine(failures: ApplyDoc[]): string {
+  const names = failures.map((d) => `${d.kind}/${d.name}`).join(", ");
+  const detail = failures.map((d) => d.error).filter(Boolean).join("; ");
+  return `${failures.length > 1 ? `Failed to apply ${failures.length} documents: ${names}` : `Failed to apply ${names}`}${
+    detail ? ` — ${detail}` : ""
+  }`;
+}
+
+/**
+ * The parts of applying a manifest that edit and create share: the call, the
+ * conflict, the failure, the success — and the cluster gate in front of all of
+ * them. The two screens differ only in where the YAML came from and in what
+ * the button is called.
+ */
+function useApply({
+  pinned,
+  live,
+  verb,
+  onApplied,
+}: {
+  pinned: string;
+  live: string;
+  verb: string;
+  onApplied: (docs: ApplyDoc[]) => void;
+}) {
+  const gate = useClusterGate({ pinned, live, verb });
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [conflicts, setConflicts] = useState<ApplyDoc[]>([]);
+  const [applied, setApplied] = useState<{ kind: string; name: string } | null>(null);
+
+  async function apply(yaml: string, force: boolean) {
+    // Asked before anything else: it is the only question whose answer changes
+    // what every other name on the screen refers to.
+    if (gate.refusal) {
+      setError(gate.refusal);
+      return false;
+    }
+    setBusy(true);
+    setError("");
+    setApplied(null);
+    const out = await applyManifest(pinned, yaml, force);
+    setBusy(false);
+    if (out.error) {
+      setError(describeError(out.error).detail);
+      setConflicts([]);
+      return false;
+    }
+    const docs = out.documents ?? [];
+    const { conflicts: conflicted, failures } = outcome(docs);
+    setConflicts(conflicted);
+    // A conflict and a hard failure can arrive together; the failure is shown
+    // now rather than after the reader has forced the conflict.
+    if (failures.length > 0) setError(failureLine(failures));
+    if (conflicted.length > 0 || failures.length > 0) return false;
+    const first = docs[0];
+    const result = { kind: first?.kind ?? "", name: first?.name ?? "" };
+    setApplied(result);
+    notify.success(
+      docs.length > 1
+        ? `Applied ${docs.length} resources`
+        : `Applied ${result.kind || "resource"} ${result.name}`.trim(),
+    );
+    onApplied(docs);
+    return true;
+  }
+
+  return { gate, busy, error, setError, conflicts, applied, apply };
+}
+
+/** The dry-run validation the editor lints with: strict, against the API server. */
+function validator(context: string) {
+  return (yaml: string) =>
+    validateManifest(context, yaml).then((r) => (r.valid === false ? (r.errors ?? []) : []));
+}
+
+/** The conflict banner: who owns the field, and the one way past it. */
+function Conflicts({
+  conflicts,
+  busy,
+  onForce,
+}: {
+  conflicts: ApplyDoc[];
+  busy: boolean;
+  onForce: () => void;
+}) {
+  if (conflicts.length === 0) return null;
+  return (
+    <div
+      role="alert"
+      className="flex flex-wrap items-center gap-3 rounded-md border border-warn/40 bg-warn-wash px-3 py-2 text-sm"
+    >
+      <div className="min-w-0 flex-1">
+        {conflicts.map((d, i) => (
+          <p key={`${d.kind}/${d.name}/${i}`} className="break-words" title={d.conflict?.message}>
+            <strong>
+              {d.kind}/{d.name}
+            </strong>{" "}
+            conflicts with <strong>{d.conflict?.managers.join(", ") || "another manager"}</strong>
+            {d.conflict && d.conflict.fields.length > 0 && <> on {d.conflict.fields.join(", ")}</>}.
+          </p>
+        ))}
+        <p className="text-xs text-muted">
+          Forcing takes those fields over; the other manager will see its next write conflict.
+        </p>
+      </div>
+      <Button variant="danger" onClick={onForce} disabled={busy}>
+        {busy ? "Forcing…" : "Force apply"}
+      </Button>
+    </div>
+  );
+}
+
+/**
+ * The Changes panel: what applying the draft would do, per document, from a
+ * dry run — and the one line that matters most, whether the live object has
+ * moved since the manifest was loaded.
+ */
+function Changes({ docs, computing }: { docs: DiffDoc[] | null; computing: boolean }) {
+  if (computing && !docs) return <p className="p-3 text-sm text-muted">Comparing with the cluster…</p>;
+  if (!docs || docs.length === 0) return <p className="p-3 text-sm text-muted">No changes.</p>;
+  return (
+    <div className="flex flex-col gap-4 p-3">
+      {docs.map((d, i) => (
+        <section key={`${d.kind}/${d.name}/${i}`}>
+          <h3 className="mb-1 text-[10px] uppercase text-faint">
+            {d.kind} {d.name}
+            {!d.exists && " · will be created"}
+            {d.exists && !d.changed && " · unchanged"}
+          </h3>
+          {d.changed && <DiffLines rows={d.rows} />}
+        </section>
+      ))}
+    </div>
+  );
+}
+
+function EditExisting({ context, parts }: { context: ClusterContext; parts: DetailRouteParts }) {
+  // The cluster this tab was opened on. Reads and writes go here, whatever the
+  // rail does later.
+  const [pinned] = useState(context.name);
+  const { kind, namespace, name } = parts;
+
+  const manifest = useResource(
+    async () => {
+      const out = await getManifest(pinned, kind, namespace, name);
+      if (out.error) throw new Error(out.error);
+      return out.yaml ?? "";
+    },
+    [pinned, kind, namespace, name],
+    // An empty manifest is still a manifest that loaded.
+    () => false,
+  );
+
+  // `null` is "the reader has not typed": the editor shows the live manifest,
+  // Apply is off, and a reload from the cluster is not a lost draft.
+  const [draft, setDraft] = useState<string | null>(null);
+  const yaml = draft ?? manifest.data ?? "";
+  const dirty = draft !== null && draft !== manifest.data;
+  const loadedRv = useMemo(() => parseResourceVersion(manifest.data ?? ""), [manifest.data]);
+
+  const [confirming, setConfirming] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [deleted, setDeleted] = useState(false);
+  const [deleteBusy, setDeleteBusy] = useState(false);
+  const [deleteError, setDeleteError] = useState("");
+  const [showChanges, setShowChanges] = useState(false);
+
+  const editor = useApply({
+    pinned,
+    live: context.name,
+    verb: "apply",
+    onApplied: () => {
+      // The live object is now what was typed; the draft has nothing left to
+      // say and the next load is the new baseline for "changed elsewhere".
+      setDraft(null);
+      setConfirming(false);
+      manifest.reload();
+    },
+  });
+
+  /**
+   * A dry-run diff of the draft, debounced. Runs whether or not the panel is
+   * open, because its side product — the live resourceVersion — is what says
+   * the object changed under the reader, and that is worth knowing before
+   * they open anything.
+   */
+  const [diff, setDiff] = useState<DiffDoc[] | null>(null);
+  const [diffing, setDiffing] = useState(false);
+  useEffect(() => {
+    if (!dirty) {
+      setDiff(null);
+      return;
+    }
+    let active = true;
+    setDiffing(true);
+    const t = setTimeout(() => {
+      void diffManifest(pinned, yaml).then((out) => {
+        if (!active) return;
+        setDiff(out.error ? [] : (out.documents ?? []));
+        setDiffing(false);
+      });
+    }, 600);
+    return () => {
+      active = false;
+      clearTimeout(t);
+    };
+  }, [pinned, yaml, dirty]);
+  const stale = useMemo(
+    () =>
+      diff?.some(
+        (d) => d.currentResourceVersion && loadedRv && d.currentResourceVersion !== loadedRv,
+      ) ?? false,
+    [diff, loadedRv],
+  );
+
+  async function remove() {
+    if (editor.gate.refusal) {
+      setDeleteError(editor.gate.refusal);
+      return;
+    }
+    setDeleteBusy(true);
+    setDeleteError("");
+    const out = await deleteResource(pinned, kind, namespace, name);
+    setDeleteBusy(false);
+    if (out.error) {
+      setDeleteError(describeError(out.error).detail);
+      return;
+    }
+    setDeleting(false);
+    setDeleted(true);
+    notify.success(`Deleted ${kind} ${name}`);
+  }
+
+  const where = namespace === null ? kind : `${kind} · ${namespace}`;
+
+  if (deleted) {
+    return (
+      <Screen title={`Edit ${name}`} eyebrow={`${where} · ${pinned}`} fill>
+        <div className="grid h-full place-items-center">
+          <EmptyState
+            title={`${kind} ${name} was deleted`}
+            hint="This tab has nothing left to edit. Close it, or reopen the resource from its list if it is recreated."
+          />
+        </div>
+      </Screen>
+    );
+  }
+
+  return (
+    <Screen
+      title={`Edit ${name}`}
+      eyebrow={`${where} · ${pinned}`}
+      actions={
+        <>
+          {stale && (
+            <span
+              className="text-xs text-warn"
+              title="The live object has a newer resourceVersion than the one loaded here. Reload to see it; applying over it takes your version."
+            >
+              Changed elsewhere
+            </span>
+          )}
+          <Button variant="ghost" onClick={() => setShowChanges((v) => !v)} disabled={!dirty}>
+            {showChanges ? "Hide changes" : "Changes"}
+          </Button>
+          <Button
+            variant="ghost"
+            onClick={() => {
+              setDraft(null);
+              manifest.reload();
+            }}
+            title="Throw the draft away and load the manifest again from the cluster"
+          >
+            Reload
+          </Button>
+          <Button
+            variant="danger"
+            onClick={() => {
+              setDeleteError("");
+              editor.gate.reset();
+              setDeleting(true);
+            }}
+          >
+            Delete
+          </Button>
+          <Button
+            variant="primary"
+            disabled={!dirty || editor.busy || manifest.status !== "ready"}
+            onClick={() => {
+              editor.setError("");
+              editor.gate.reset();
+              setConfirming(true);
+            }}
+          >
+            {editor.busy ? "Applying…" : "Apply"}
+          </Button>
+        </>
+      }
+      fill
+    >
+      <div className="flex h-full min-h-0 flex-col">
+        <div className="flex flex-col gap-2 px-4 pt-3 empty:hidden">
+          {manifest.status === "error" && (
+            <FailureAlert title={`Could not load ${kind} ${name}`} error={manifest.error} />
+          )}
+          <Conflicts
+            conflicts={editor.conflicts}
+            busy={editor.busy}
+            onForce={() => void editor.apply(yaml, true)}
+          />
+          {editor.error && !confirming && (
+            <FailureAlert title={`Could not apply ${name}`} error={editor.error} />
+          )}
+          {editor.applied && !dirty && (
+            <p className="text-sm text-ok" role="status">
+              Applied {editor.applied.kind} {editor.applied.name}.
+            </p>
+          )}
+        </div>
+        <div className="flex min-h-0 flex-1">
+          <div className="relative min-h-0 min-w-0 flex-1 p-4">
+            {manifest.status === "loading" ? (
+              <p className="text-sm text-muted">Loading the manifest…</p>
+            ) : manifest.status === "error" ? null : (
+              <div className="absolute inset-4">
+                <CodeEditor
+                  value={yaml}
+                  onChange={setDraft}
+                  language="yaml"
+                  fill
+                  ariaLabel={`${name} manifest`}
+                  schemaValidate={validator(pinned)}
+                />
+              </div>
+            )}
+          </div>
+          {showChanges && dirty && (
+            <aside className="rule-l scroll w-[440px] shrink-0" aria-label="Changes">
+              <Changes docs={diff} computing={diffing} />
+            </aside>
+          )}
+        </div>
+      </div>
+      {confirming && (
+        <ConfirmDialog
+          title="Apply changes?"
+          confirmLabel="Apply"
+          busy={editor.busy}
+          // Closed on any answer, not only success: a conflict and a failure
+          // are shown on the page behind the dialog, and a modal left open
+          // would hide the one thing the reader now has to act on.
+          onConfirm={() => void editor.apply(yaml, false).finally(() => setConfirming(false))}
+          onCancel={() => setConfirming(false)}
+          message={
+            <>
+              <p>
+                Server-side apply the edited <code>{kind}</code> <code>{name}</code> on{" "}
+                <code>{pinned}</code>
+                {namespace ? (
+                  <>
+                    {" "}
+                    in <code>{namespace}</code>
+                  </>
+                ) : null}
+                .
+              </p>
+              {stale && (
+                <p className="mt-2 text-warn">
+                  The live object changed since you opened it; applying takes your version of every
+                  field you edited.
+                </p>
+              )}
+              {editor.gate.alert}
+              {editor.error && <p className="mt-2 text-sev">{editor.error}</p>}
+            </>
+          }
+        />
+      )}
+      {deleting && (
+        <ConfirmDialog
+          title={`Delete ${kind} ${name}?`}
+          confirmLabel="Delete"
+          danger
+          busy={deleteBusy}
+          onConfirm={() => void remove()}
+          onCancel={() => setDeleting(false)}
+          message={
+            <>
+              <p>
+                This deletes <code>{name}</code> from <code>{pinned}</code>
+                {namespace ? (
+                  <>
+                    {" "}
+                    in <code>{namespace}</code>
+                  </>
+                ) : null}
+                . Anything it owns goes with it.
+              </p>
+              {editor.gate.alert}
+              {deleteError && <p className="mt-2 text-sev">{deleteError}</p>}
+            </>
+          }
+        />
+      )}
+    </Screen>
+  );
+}
+
+/** Starter manifests for the kinds people most often create by hand. */
+export const TEMPLATES: Record<string, (ns: string) => string> = {
+  Blank: () => "",
+  Deployment: (ns) => `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+  namespace: ${ns}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-app
+  template:
+    metadata:
+      labels:
+        app: my-app
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.27
+          ports:
+            - containerPort: 80
+`,
+  Service: (ns) => `apiVersion: v1
+kind: Service
+metadata:
+  name: my-app
+  namespace: ${ns}
+spec:
+  selector:
+    app: my-app
+  ports:
+    - port: 80
+      targetPort: 80
+`,
+  ConfigMap: (ns) => `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-config
+  namespace: ${ns}
+data:
+  key: value
+`,
+  Secret: (ns) => `apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+  namespace: ${ns}
+type: Opaque
+stringData:
+  key: value
+`,
+  Ingress: (ns) => `apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: my-ingress
+  namespace: ${ns}
+spec:
+  rules:
+    - host: example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: my-app
+                port:
+                  number: 80
+`,
+  Namespace: () => `apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-namespace
+`,
+};
+
+export const TEMPLATE_ORDER = ["Deployment", "Service", "ConfigMap", "Secret", "Ingress", "Namespace", "Blank"];
+
+function NewResource({ context }: { context: ClusterContext }) {
+  const [pinned] = useState(context.name);
+  const { namespaces } = useNamespaceOptions(pinned, getKubeconfigFiles());
+  const options = namespaces ?? [];
+
+  const [namespace, setNamespace] = useState("default");
+  const [template, setTemplate] = useState(TEMPLATE_ORDER[0]);
+  const [yaml, setYaml] = useState(() => TEMPLATES[TEMPLATE_ORDER[0]](namespace));
+  // Once the cluster's namespaces are known, a `default` that does not exist
+  // there is swapped for one that does — but only while the draft is still
+  // the untouched template, so a reader who has typed keeps what they typed.
+  useEffect(() => {
+    if (options.length === 0 || options.includes(namespace)) return;
+    const first = options[0];
+    setNamespace(first);
+    setYaml((current) => (current === TEMPLATES[template](namespace) ? TEMPLATES[template](first) : current));
+  }, [options, namespace, template]);
+
+  const editor = useApply({ pinned, live: context.name, verb: "create", onApplied: () => {} });
+  const untouched = yaml === TEMPLATES[template](namespace);
+
+  const pickTemplate = (next: string) => {
+    setTemplate(next);
+    setYaml(TEMPLATES[next](namespace));
+  };
+  const pickNamespace = (next: string) => {
+    // The template's namespace follows the picker only while the draft is
+    // still the template; a typed manifest is the reader's.
+    setYaml((current) => (current === TEMPLATES[template](namespace) ? TEMPLATES[template](next) : current));
+    setNamespace(next);
+  };
+
+  return (
+    <Screen
+      title="New resource"
+      eyebrow={pinned}
+      actions={
+        <>
+          <label className="flex items-center gap-2 text-xs text-muted">
+            Template
+            <Select
+              value={template}
+              onValueChange={pickTemplate}
+              options={TEMPLATE_ORDER.map((t) => ({ value: t }))}
+              className="min-w-36"
+            />
+          </label>
+          <label className="flex items-center gap-2 text-xs text-muted">
+            Namespace
+            <Select
+              value={namespace}
+              onValueChange={pickNamespace}
+              options={(options.length > 0 ? options : [namespace]).map((n) => ({ value: n }))}
+              className="min-w-36"
+            />
+          </label>
+          <Button
+            variant="primary"
+            disabled={!yaml.trim() || editor.busy}
+            onClick={() => {
+              editor.setError("");
+              void editor.apply(yaml, false);
+            }}
+          >
+            {editor.busy ? "Creating…" : "Create"}
+          </Button>
+        </>
+      }
+      fill
+    >
+      <div className="flex h-full min-h-0 flex-col">
+        <div className="flex flex-col gap-2 px-4 pt-3 empty:hidden">
+          {editor.gate.alert}
+          <Conflicts
+            conflicts={editor.conflicts}
+            busy={editor.busy}
+            onForce={() => void editor.apply(yaml, true)}
+          />
+          {editor.error && <FailureAlert title="Could not create the resource" error={editor.error} />}
+          {editor.applied && (
+            <p className="text-sm text-ok" role="status">
+              Created {editor.applied.kind} {editor.applied.name}.{" "}
+              {untouched ? "" : "The editor keeps your manifest, so a second one is a name away."}
+            </p>
+          )}
+        </div>
+        <div className="relative min-h-0 flex-1 p-4">
+          <div className="absolute inset-4">
+            <CodeEditor
+              value={yaml}
+              onChange={setYaml}
+              language="yaml"
+              fill
+              ariaLabel="New resource manifest"
+              schemaValidate={validator(pinned)}
+            />
+          </div>
+        </div>
+      </div>
+    </Screen>
+  );
+}

--- a/packages/ui-next/src/screens/Edit.tsx
+++ b/packages/ui-next/src/screens/Edit.tsx
@@ -727,6 +727,8 @@ function EditExisting({ context, parts }: { context: ClusterContext; parts: Edit
               keys={analysis.keys}
               schema={analysis.schema.status}
               kind={analysis.schema.kind}
+              schemaError={analysis.schema.error}
+              onRetrySchema={analysis.schema.retry}
               dryRun={analysis.dryRun}
             />
           )}
@@ -1012,6 +1014,8 @@ function NewResource({ context, cluster }: { context: ClusterContext; cluster?: 
             keys={analysis.keys}
             schema={analysis.schema.status}
             kind={analysis.schema.kind}
+            schemaError={analysis.schema.error}
+            onRetrySchema={analysis.schema.retry}
             dryRun={analysis.dryRun}
           />
         </div>

--- a/packages/ui-next/src/screens/Edit.tsx
+++ b/packages/ui-next/src/screens/Edit.tsx
@@ -19,11 +19,11 @@ import { useNamespaceOptions } from "@srelens/core/react";
 import {
   Button,
   CodeEditor,
+  Combobox,
   ConfirmDialog,
   DiffLines,
   EmptyState,
   Screen,
-  Select,
   type EditorDiagnostic,
 } from "@srelens/ui-kit";
 import { useConsole } from "../console";
@@ -38,7 +38,7 @@ import { CUSTOM_RESOURCE_ACTIONS } from "../lib/kinds/custom";
 import { descriptorFor } from "../lib/kinds/descriptors";
 import { useResource } from "../lib/useResource";
 import { EditAnalysis, ProblemsDot, type DryRunState } from "./EditAnalysis";
-import { NoClusterScreen } from "./resourceShell";
+import { NamespaceChoice, NoClusterScreen } from "./resourceShell";
 
 /**
  * The resource editor: one YAML manifest, applied server-side.
@@ -927,24 +927,25 @@ function NewResource({ context, cluster }: { context: ClusterContext; cluster?: 
       eyebrow={pinned}
       actions={
         <>
-          <label className="flex items-center gap-2 text-xs text-muted">
+          {/* The design's own picker, not a native `<select>`: the browser
+              draws its own dropdown for those, which reads as another app's
+              control beside this toolbar — and a cluster with sixty
+              namespaces needs the search this one has. */}
+          <span className="flex items-center gap-2 text-xs text-muted">
             Template
-            <Select
+            <Combobox
               value={template}
               onValueChange={pickTemplate}
               options={TEMPLATE_ORDER.map((t) => ({ value: t }))}
-              className="min-w-36"
+              ariaLabel="Template"
+              searchPlaceholder="Find a template…"
+              className="min-w-40"
             />
-          </label>
-          <label className="flex items-center gap-2 text-xs text-muted">
+          </span>
+          <span className="flex items-center gap-2 text-xs text-muted">
             Namespace
-            <Select
-              value={namespace}
-              onValueChange={pickNamespace}
-              options={(options.length > 0 ? options : [namespace]).map((n) => ({ value: n }))}
-              className="min-w-36"
-            />
-          </label>
+            <NamespaceChoice namespaces={namespaces} value={namespace} onChange={pickNamespace} />
+          </span>
           <ProblemsDot problems={analysis.problems} checked={analysis.checked} />
           <Button
             variant="ghost"

--- a/packages/ui-next/src/screens/Edit.tsx
+++ b/packages/ui-next/src/screens/Edit.tsx
@@ -27,9 +27,11 @@ import {
 } from "@srelens/ui-kit";
 import { getKubeconfigFiles, useActiveContext } from "../lib/clusters";
 import { useClusterGate } from "../lib/clusterMoved";
-import { isBuiltInKind, resolveCrdGvk } from "../lib/crdGvk";
+import { SLUG_BY_K8S_KIND, isBuiltInKind, resolveCrdGvk } from "../lib/crdGvk";
 import { parseEditRoute, type DetailRouteParts } from "../lib/detailRoute";
 import { FailureAlert } from "../lib/errorCopy";
+import { CUSTOM_RESOURCE_ACTIONS } from "../lib/kinds/custom";
+import { descriptorFor } from "../lib/kinds/descriptors";
 import { useResource } from "../lib/useResource";
 import { NoClusterScreen } from "./resourceShell";
 
@@ -82,12 +84,17 @@ export function EditResource({ route }: { route: string }) {
     );
   }
 
-  // Keyed by cluster and route, so a tab that is re-pointed starts its draft
-  // over rather than carrying one resource's edits onto another.
+  // Keyed by route alone, NOT by cluster. A tab that is re-pointed at another
+  // resource starts its draft over; a rail that moves to another cluster must
+  // not. Each editor pins the cluster it was opened on, and that pin has to
+  // outlive the rail: keyed by `stableId` too, a rail switch remounted the
+  // editor, re-pinned it to the new cluster, threw the draft away, and made
+  // the gate see pinned === live — so Apply and Delete went to the new
+  // cluster without the moved-cluster warning this screen promises.
   return parts ? (
-    <EditExisting key={`${context.stableId}:${route}`} context={context} parts={parts} />
+    <EditExisting key={route} context={context} parts={parts} />
   ) : (
-    <NewResource key={context.stableId} context={context} />
+    <NewResource context={context} />
   );
 }
 
@@ -252,6 +259,15 @@ function EditExisting({ context, parts }: { context: ClusterContext; parts: Deta
   // rail does later.
   const [pinned] = useState(context.name);
   const { kind, namespace, name } = parts;
+
+  // Whether Delete is offered at all: the same verdict the list menu and the
+  // detail footer reach from the kind's descriptor. `k8s.deleteResource`
+  // resolves kinds from a closed table with no CRD path — the manifest read
+  // below is told a custom kind's group, delete cannot be — so for a custom
+  // resource it fails every time, after a confirm that read as real. See
+  // `KindActions.delete`.
+  const actions = isBuiltInKind(kind) ? descriptorFor(SLUG_BY_K8S_KIND[kind])?.actions : CUSTOM_RESOURCE_ACTIONS;
+  const canDelete = actions?.delete !== false;
 
   /**
    * A Secret's values stay out of the DOM until the reader reveals them.
@@ -442,16 +458,18 @@ function EditExisting({ context, parts }: { context: ClusterContext; parts: Deta
           >
             Reload
           </Button>
-          <Button
-            variant="danger"
-            onClick={() => {
-              setDeleteError("");
-              editor.gate.reset();
-              setDeleting(true);
-            }}
-          >
-            Delete
-          </Button>
+          {canDelete && (
+            <Button
+              variant="danger"
+              onClick={() => {
+                setDeleteError("");
+                editor.gate.reset();
+                setDeleting(true);
+              }}
+            >
+              Delete
+            </Button>
+          )}
           <Button
             variant="primary"
             disabled={
@@ -524,10 +542,17 @@ function EditExisting({ context, parts }: { context: ClusterContext; parts: Deta
           title="Apply changes?"
           confirmLabel="Apply"
           busy={editor.busy}
-          // Closed on any answer, not only success: a conflict and a failure
-          // are shown on the page behind the dialog, and a modal left open
-          // would hide the one thing the reader now has to act on.
-          onConfirm={() => void editor.apply(yaml, false).finally(() => setConfirming(false))}
+          // Closed on any answer the server gave, not only success: a conflict
+          // and a failure are shown on the page behind the dialog, and a modal
+          // left open would hide the one thing the reader now has to act on.
+          // A refusal from the cluster gate is different — it is the dialog's
+          // own question, still unanswered, and closing would hide the box
+          // the refusal points at.
+          onConfirm={() =>
+            void editor.apply(yaml, false).then((ok) => {
+              if (ok || !editor.gate.refusal) setConfirming(false);
+            })
+          }
           onCancel={() => setConfirming(false)}
           message={
             <>

--- a/packages/ui-next/src/screens/Edit.tsx
+++ b/packages/ui-next/src/screens/Edit.tsx
@@ -275,6 +275,9 @@ function EditExisting({ context, parts }: { context: ClusterContext; parts: Deta
       // say and the next load is the new baseline for "changed elsewhere".
       setDraft(null);
       setConfirming(false);
+      // The panel closes with the draft it was comparing; left open, the
+      // button read "Hide changes" over no panel at all.
+      setShowChanges(false);
       manifest.reload();
     },
   });

--- a/packages/ui-next/src/screens/Edit.tsx
+++ b/packages/ui-next/src/screens/Edit.tsx
@@ -5,12 +5,15 @@ import {
   describeError,
   diffManifest,
   getManifest,
+  getSecret,
   notify,
   parseResourceVersion,
+  redactSecretManifest,
   validateManifest,
   type ApplyDoc,
   type ClusterContext,
   type DiffDoc,
+  type DynamicGvk,
 } from "@srelens/core";
 import { useNamespaceOptions } from "@srelens/core/react";
 import {
@@ -24,6 +27,7 @@ import {
 } from "@srelens/ui-kit";
 import { getKubeconfigFiles, useActiveContext } from "../lib/clusters";
 import { useClusterGate } from "../lib/clusterMoved";
+import { isBuiltInKind, resolveCrdGvk } from "../lib/crdGvk";
 import { parseEditRoute, type DetailRouteParts } from "../lib/detailRoute";
 import { FailureAlert } from "../lib/errorCopy";
 import { useResource } from "../lib/useResource";
@@ -147,6 +151,14 @@ function useApply({
       return false;
     }
     const docs = out.documents ?? [];
+    // An emptied editor applies nothing, and the API answers with no
+    // documents — neither a conflict nor a failure, so it used to read as a
+    // success, toast one, and reload the unchanged object.
+    if (docs.length === 0) {
+      setError("Nothing to apply: the manifest has no documents in it.");
+      setConflicts([]);
+      return false;
+    }
     const { conflicts: conflicted, failures } = outcome(docs);
     setConflicts(conflicted);
     // A conflict and a hard failure can arrive together; the failure is shown
@@ -241,23 +253,66 @@ function EditExisting({ context, parts }: { context: ClusterContext; parts: Deta
   const [pinned] = useState(context.name);
   const { kind, namespace, name } = parts;
 
+  /**
+   * A Secret's values stay out of the DOM until the reader reveals them.
+   *
+   * `k8s.getManifest` returns them in the clear, so the manifest is redacted
+   * on arrival — the same redactor the detail pane's YAML view uses, failing
+   * closed on any shape it does not understand — and the editor shows that,
+   * read-only, until Reveal. Reveal goes through `k8s.getSecret`, the
+   * consent-gated read, and only after it answers is the real manifest put
+   * in the editor. The real text is held here in the meantime, in state, and
+   * never rendered; and Apply is off while the editor shows placeholders,
+   * because applying a redacted manifest would write the placeholders over
+   * the values.
+   */
+  const isSecret = kind === "Secret";
+  const [revealed, setRevealed] = useState(!isSecret);
+  const [revealBusy, setRevealBusy] = useState(false);
+  const [revealError, setRevealError] = useState("");
+
   const manifest = useResource(
     async () => {
-      const out = await getManifest(pinned, kind, namespace, name);
+      // A kind outside the built-in table has to be resolved to its group
+      // first, or the read fails for every custom resource.
+      let crd: DynamicGvk | undefined;
+      if (!isBuiltInKind(kind)) {
+        const resolved = await resolveCrdGvk(pinned, kind);
+        if (resolved.error) throw new Error(resolved.error);
+        crd = resolved.crd;
+      }
+      const out = await getManifest(pinned, kind, namespace, name, undefined, crd);
       if (out.error) throw new Error(out.error);
-      return out.yaml ?? "";
+      const raw = out.yaml ?? "";
+      if (!isSecret) return { raw, shown: raw };
+      const redacted = redactSecretManifest(raw);
+      if (redacted.error !== undefined) throw new Error(redacted.error);
+      return { raw, shown: redacted.yaml ?? "" };
     },
     [pinned, kind, namespace, name],
     // An empty manifest is still a manifest that loaded.
     () => false,
   );
+  const live = revealed ? manifest.data?.raw : manifest.data?.shown;
+
+  async function reveal() {
+    setRevealBusy(true);
+    setRevealError("");
+    const out = await getSecret(pinned, namespace ?? "", name);
+    setRevealBusy(false);
+    if (out.error) {
+      setRevealError(describeError(out.error).detail);
+      return;
+    }
+    setRevealed(true);
+  }
 
   // `null` is "the reader has not typed": the editor shows the live manifest,
   // Apply is off, and a reload from the cluster is not a lost draft.
   const [draft, setDraft] = useState<string | null>(null);
-  const yaml = draft ?? manifest.data ?? "";
-  const dirty = draft !== null && draft !== manifest.data;
-  const loadedRv = useMemo(() => parseResourceVersion(manifest.data ?? ""), [manifest.data]);
+  const yaml = draft ?? live ?? "";
+  const dirty = draft !== null && draft !== live;
+  const loadedRv = useMemo(() => parseResourceVersion(manifest.data?.raw ?? ""), [manifest.data]);
 
   const [confirming, setConfirming] = useState(false);
   const [deleting, setDeleting] = useState(false);
@@ -364,6 +419,16 @@ function EditExisting({ context, parts }: { context: ClusterContext; parts: Deta
               Changed elsewhere
             </span>
           )}
+          {isSecret && !revealed && (
+            <Button
+              variant="secondary"
+              onClick={() => void reveal()}
+              disabled={revealBusy || manifest.status !== "ready"}
+              title="Reads the Secret's values through the consent-gated read, then shows the real manifest"
+            >
+              {revealBusy ? "Revealing…" : "Reveal values"}
+            </Button>
+          )}
           <Button variant="ghost" onClick={() => setShowChanges((v) => !v)} disabled={!dirty}>
             {showChanges ? "Hide changes" : "Changes"}
           </Button>
@@ -389,7 +454,9 @@ function EditExisting({ context, parts }: { context: ClusterContext; parts: Deta
           </Button>
           <Button
             variant="primary"
-            disabled={!dirty || editor.busy || manifest.status !== "ready"}
+            disabled={
+              !revealed || !dirty || !yaml.trim() || editor.busy || manifest.status !== "ready"
+            }
             onClick={() => {
               editor.setError("");
               editor.gate.reset();
@@ -407,6 +474,12 @@ function EditExisting({ context, parts }: { context: ClusterContext; parts: Deta
           {manifest.status === "error" && (
             <FailureAlert title={`Could not load ${kind} ${name}`} error={manifest.error} />
           )}
+          {isSecret && !revealed && manifest.status === "ready" && (
+            <p className="text-sm text-muted" data-testid="secret-redacted">
+              Values are redacted. Reveal them to edit this Secret; applying is off until then.
+            </p>
+          )}
+          {revealError && <FailureAlert title={`Could not reveal ${name}`} error={revealError} />}
           <Conflicts
             conflicts={editor.conflicts}
             busy={editor.busy}
@@ -432,6 +505,7 @@ function EditExisting({ context, parts }: { context: ClusterContext; parts: Deta
                   onChange={setDraft}
                   language="yaml"
                   fill
+                  readOnly={!revealed}
                   ariaLabel={`${name} manifest`}
                   schemaValidate={validator(pinned)}
                 />

--- a/packages/ui-next/src/screens/Edit.tsx
+++ b/packages/ui-next/src/screens/Edit.tsx
@@ -693,24 +693,28 @@ function EditExisting({ context, parts }: { context: ClusterContext; parts: Edit
           )}
         </div>
         <div className="flex min-h-0 flex-1">
-          <div className="relative min-h-0 min-w-0 flex-1 p-4">
+          {/* Edge to edge. The design is flush regions divided by hairlines
+              with no gutters (`kit.css`, "panes"), and the editor is a
+              region — inset by a gutter with a rounded frame it read as a
+              card floating in a design that has none. Prose still gets a
+              gutter; a document does not. */}
+          <div className="min-h-0 min-w-0 flex-1">
             {manifest.status === "loading" ? (
-              <p className="text-sm text-muted">Loading the manifest…</p>
+              <p className="p-3 text-sm text-muted">Loading the manifest…</p>
             ) : manifest.status === "error" ? null : (
-              <div className="absolute inset-4">
-                <CodeEditor
-                  value={yaml}
-                  onChange={setDraft}
-                  language="yaml"
-                  fill
-                  readOnly={!revealed}
-                  ariaLabel={`${name} manifest`}
-                  schemaValidate={validator(pinned)}
-                  completions={analysis.completions}
-                  onCursorChange={analysis.setCursor}
-                  onDiagnostics={analysis.setProblems}
-                />
-              </div>
+              <CodeEditor
+                value={yaml}
+                onChange={setDraft}
+                language="yaml"
+                fill
+                flush
+                readOnly={!revealed}
+                ariaLabel={`${name} manifest`}
+                schemaValidate={validator(pinned)}
+                completions={analysis.completions}
+                onCursorChange={analysis.setCursor}
+                onDiagnostics={analysis.setProblems}
+              />
             )}
           </div>
           {/* The diff is its own column, not a section of the analysis rail:
@@ -994,20 +998,20 @@ function NewResource({ context, cluster }: { context: ClusterContext; cluster?: 
           )}
         </div>
         <div className="flex min-h-0 flex-1">
-          <div className="relative min-h-0 min-w-0 flex-1 p-4">
-            <div className="absolute inset-4">
-              <CodeEditor
-                value={yaml}
-                onChange={setYaml}
-                language="yaml"
-                fill
-                ariaLabel="New resource manifest"
-                schemaValidate={validator(pinned)}
-                completions={analysis.completions}
-                onCursorChange={analysis.setCursor}
-                onDiagnostics={analysis.setProblems}
-              />
-            </div>
+          {/* Edge to edge, as above. */}
+          <div className="min-h-0 min-w-0 flex-1">
+            <CodeEditor
+              value={yaml}
+              onChange={setYaml}
+              language="yaml"
+              fill
+              flush
+              ariaLabel="New resource manifest"
+              schemaValidate={validator(pinned)}
+              completions={analysis.completions}
+              onCursorChange={analysis.setCursor}
+              onDiagnostics={analysis.setProblems}
+            />
           </div>
           <EditAnalysis
             problems={analysis.problems}

--- a/packages/ui-next/src/screens/EditAnalysis.tsx
+++ b/packages/ui-next/src/screens/EditAnalysis.tsx
@@ -1,0 +1,180 @@
+import type { ReactNode } from "react";
+import type { EditorDiagnostic } from "@srelens/ui-kit";
+import { FailureAlert } from "../lib/errorCopy";
+import type { KeysHere, SchemaStatus } from "../lib/manifestSchema";
+
+/**
+ * The editor's sidebar: what is wrong with the draft, what a dry run said,
+ * and what the schema allows where the cursor is.
+ *
+ * Every line here is derived from something the editor or the cluster
+ * already told the screen — the lint pass's findings, the on-demand dry run,
+ * the kind's OpenAPI schema — laid out where a reader can see all of it at
+ * once instead of hovering gutter markers one at a time. The diff, when it is
+ * open, sits at the top: it is the one section that is a choice.
+ */
+
+/** What an on-demand dry run came back with. */
+export interface DryRunState {
+  status: "idle" | "running" | "passed" | "failed" | "error";
+  /** The API server's objections, per document, when `failed`. */
+  errors: { docIndex: number; message: string }[];
+  /** Why the run itself could not be made, when `error`. */
+  error?: string;
+}
+
+/**
+ * The one-word verdict in the toolbar — "valid", "2 problems", "unchecked" —
+ * with a dot in the tone the word already carries. Never the dot alone.
+ */
+export function ProblemsDot({ problems, checked }: { problems: EditorDiagnostic[]; checked: boolean }) {
+  const n = problems.length;
+  const label = !checked ? "unchecked" : n === 0 ? "valid" : `${n} problem${n === 1 ? "" : "s"}`;
+  const tone = !checked ? "text-faint" : n === 0 ? "text-ok" : "text-sev";
+  return (
+    <span
+      className="flex items-center gap-1.5 text-xs text-muted"
+      data-testid="manifest-status"
+      title={
+        !checked
+          ? "Nothing has checked the manifest yet"
+          : n === 0
+            ? "The last check found nothing wrong"
+            : "See Problems in the sidebar"
+      }
+    >
+      <span aria-hidden className={tone}>
+        ●
+      </span>
+      {label}
+    </span>
+  );
+}
+
+function Section({
+  title,
+  count,
+  detail,
+  children,
+}: {
+  title: string;
+  count?: number;
+  detail?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-2 border-b border-rule px-3 py-3 last:border-b-0">
+      <h3 className="flex items-baseline justify-between gap-2 text-[10px] uppercase tracking-wide text-faint">
+        <span>
+          {title}
+          {detail && <span className="ml-2 normal-case tracking-normal text-muted">{detail}</span>}
+        </span>
+        {count !== undefined && <span className="tabular-nums">{count}</span>}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
+/** The first sentence of a schema description, which is the part that fits on a line. */
+function lead(text: string | undefined): string {
+  if (!text) return "";
+  const end = text.search(/\.\s|\.$/);
+  return end === -1 ? text : text.slice(0, end);
+}
+
+export function EditAnalysis({
+  problems,
+  checked,
+  keys,
+  schema,
+  kind,
+  dryRun,
+  diff,
+}: {
+  problems: EditorDiagnostic[];
+  /** Whether any lint pass has run at all — before one has, "no problems" would be a guess. */
+  checked: boolean;
+  keys: KeysHere | null;
+  schema: SchemaStatus;
+  kind: string | null;
+  dryRun: DryRunState;
+  /** The diff panel, when the reader has it open. */
+  diff?: ReactNode;
+}) {
+  return (
+    <aside className="rule-l scroll flex w-[360px] shrink-0 flex-col text-sm" aria-label="Analysis">
+      {diff && <Section title="Diff">{diff}</Section>}
+
+      <Section title="Problems" count={problems.length}>
+        {problems.length === 0 ? (
+          <p className="text-xs text-muted">
+            {checked
+              ? "No problems. The check is the API server's own dry run, admission included; a webhook that does not support dry run answers only on Apply."
+              : "Nothing has checked the manifest yet."}
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-1.5">
+            {problems.map((p, i) => (
+              <li key={`${p.line}:${i}`} className="grid grid-cols-[auto_1fr] gap-2 text-xs">
+                <span className="tabular-nums text-faint">L{p.line}</span>
+                <span className={p.severity === "error" ? "text-sev" : "text-warn"}>{p.message}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+        {dryRun.status === "running" && <p className="text-xs text-muted">Dry run against the API server…</p>}
+        {dryRun.status === "passed" && (
+          <p className="text-xs text-ok" data-testid="dry-run-verdict">
+            Dry run passed. The API server accepted the manifest as it is now.
+          </p>
+        )}
+        {dryRun.status === "failed" && (
+          <div className="flex flex-col gap-1" data-testid="dry-run-verdict">
+            <p className="text-xs text-sev">Dry run failed.</p>
+            <ul className="flex flex-col gap-1">
+              {dryRun.errors.map((e, i) => (
+                <li key={i} className="grid grid-cols-[auto_1fr] gap-2 text-xs">
+                  <span className="tabular-nums text-faint">doc {e.docIndex + 1}</span>
+                  <span className="text-sev">{e.message}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {dryRun.status === "error" && <FailureAlert title="Could not dry-run the manifest" error={dryRun.error} />}
+      </Section>
+
+      <Section
+        title={keys?.onValue ? "Values valid here" : "Keys valid here"}
+        detail={
+          keys ? (keys.onValue ? keys.valueKey : keys.path.length > 0 ? keys.path.join(" › ") : "top level") : undefined
+        }
+      >
+        {schema === "none" ? (
+          <p className="text-xs text-muted">Name an apiVersion and a kind to see what goes here.</p>
+        ) : schema === "loading" ? (
+          <p className="text-xs text-muted">Loading the schema…</p>
+        ) : schema === "unavailable" ? (
+          <p className="text-xs text-muted">
+            The cluster has no schema for {kind ?? "this kind"}, so nothing can say what goes here.
+          </p>
+        ) : !keys || keys.entries.length === 0 ? (
+          <p className="text-xs text-muted">Nothing more goes here.</p>
+        ) : (
+          <ul className="flex flex-col gap-1">
+            {keys.entries.map((e) => (
+              <li key={e.label} className="grid grid-cols-[auto_1fr_auto] items-baseline gap-2 text-xs">
+                <code className="text-accent">{e.label}</code>
+                <span className="truncate text-muted" title={e.info}>
+                  {lead(e.info)}
+                </span>
+                <span className="text-faint">{e.detail}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Section>
+    </aside>
+  );
+}

--- a/packages/ui-next/src/screens/EditAnalysis.tsx
+++ b/packages/ui-next/src/screens/EditAnalysis.tsx
@@ -10,8 +10,10 @@ import type { KeysHere, SchemaStatus } from "../lib/manifestSchema";
  * Every line here is derived from something the editor or the cluster
  * already told the screen — the lint pass's findings, the on-demand dry run,
  * the kind's OpenAPI schema — laid out where a reader can see all of it at
- * once instead of hovering gutter markers one at a time. The diff, when it is
- * open, sits at the top: it is the one section that is a choice.
+ * once instead of hovering gutter markers one at a time.
+ *
+ * The diff is NOT here. It was, and 360px of manifest diff was unreadable:
+ * it has its own wider column beside this one, opened from the toolbar.
  */
 
 /** What an on-demand dry run came back with. */
@@ -90,7 +92,6 @@ export function EditAnalysis({
   schema,
   kind,
   dryRun,
-  diff,
 }: {
   problems: EditorDiagnostic[];
   /** Whether any lint pass has run at all — before one has, "no problems" would be a guess. */
@@ -99,13 +100,9 @@ export function EditAnalysis({
   schema: SchemaStatus;
   kind: string | null;
   dryRun: DryRunState;
-  /** The diff panel, when the reader has it open. */
-  diff?: ReactNode;
 }) {
   return (
-    <aside className="rule-l scroll flex w-[360px] shrink-0 flex-col text-sm" aria-label="Analysis">
-      {diff && <Section title="Diff">{diff}</Section>}
-
+    <aside className="rule-l scroll flex w-[22rem] shrink-0 flex-col text-sm" aria-label="Analysis">
       <Section title="Problems" count={problems.length}>
         {problems.length === 0 ? (
           <p className="text-xs text-muted">

--- a/packages/ui-next/src/screens/EditAnalysis.tsx
+++ b/packages/ui-next/src/screens/EditAnalysis.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import type { EditorDiagnostic } from "@srelens/ui-kit";
+import { Button, type EditorDiagnostic } from "@srelens/ui-kit";
 import { FailureAlert } from "../lib/errorCopy";
 import type { KeysHere, SchemaStatus } from "../lib/manifestSchema";
 
@@ -91,6 +91,8 @@ export function EditAnalysis({
   keys,
   schema,
   kind,
+  schemaError,
+  onRetrySchema,
   dryRun,
 }: {
   problems: EditorDiagnostic[];
@@ -99,6 +101,9 @@ export function EditAnalysis({
   keys: KeysHere | null;
   schema: SchemaStatus;
   kind: string | null;
+  /** Why the schema lookup failed, when `schema` is `failed`. */
+  schemaError?: string;
+  onRetrySchema?: () => void;
   dryRun: DryRunState;
 }) {
   return (
@@ -152,9 +157,25 @@ export function EditAnalysis({
           <p className="text-xs text-muted">Name an apiVersion and a kind to see what goes here.</p>
         ) : schema === "loading" ? (
           <p className="text-xs text-muted">Loading the schema…</p>
-        ) : schema === "unavailable" ? (
+        ) : schema === "failed" ? (
+          // Not "the cluster has no schema for Secret": the cluster was not
+          // heard from. Which it is changes what the reader does next.
+          <div className="flex flex-col items-start gap-2">
+            <p className="text-xs text-muted">
+              Could not read {kind ?? "this kind"}&apos;s schema from the cluster, so nothing here can
+              say what goes where the cursor is.
+            </p>
+            {schemaError && <p className="text-xs text-sev">{schemaError}</p>}
+            {onRetrySchema && (
+              <Button variant="ghost" onClick={onRetrySchema}>
+                Try again
+              </Button>
+            )}
+          </div>
+        ) : schema === "absent" ? (
           <p className="text-xs text-muted">
-            The cluster has no schema for {kind ?? "this kind"}, so nothing can say what goes here.
+            This cluster publishes no schema for {kind ?? "this kind"} — a CustomResourceDefinition
+            with none of its own, or a kind spelled differently from any it serves.
           </p>
         ) : !keys || keys.entries.length === 0 ? (
           <p className="text-xs text-muted">Nothing more goes here.</p>

--- a/packages/ui-next/src/screens/ResourceMenu.test.tsx
+++ b/packages/ui-next/src/screens/ResourceMenu.test.tsx
@@ -170,10 +170,37 @@ describe("useRowMenu", () => {
    * click focused the FIRST resource's editor. A Pod `api` and a Deployment
    * `api` collapsed the same way.
    */
-  it("opens Edit at a route carrying the kind, the namespace and the name", async () => {
+  it("opens Edit at a route carrying the cluster, the kind, the namespace and the name", async () => {
     render(<Harness args={POD_ARGS} row={POD_ROW} />);
     await userEvent.click(screen.getByRole("button", { name: "Edit" }));
-    expect(store.currentWorkspace().tabs.some((t) => t.route === "/edit/Pod/kube-system/web-0")).toBe(true);
+    expect(
+      store.currentWorkspace().tabs.some((t) => t.route === `/edit/${POD_ARGS.context}/Pod/kube-system/web-0`),
+    ).toBe(true);
+  });
+
+  it("gives Edit on two clusters' same-named resources two tabs, not one", async () => {
+    // The editor pins the cluster it was opened on, so a second cluster's
+    // same-named resource must not land on the first cluster's pinned draft.
+    const row = { name: "web", namespace: "default" };
+    const { unmount } = render(<Harness args={{ context: "prod", kind: "ConfigMap", actions: {} }} row={row} />);
+    await userEvent.click(screen.getByRole("button", { name: "Edit" }));
+    unmount();
+    render(<Harness args={{ context: "staging", kind: "ConfigMap", actions: {} }} row={row} />);
+    await userEvent.click(screen.getByRole("button", { name: "Edit" }));
+    const edits = store.currentWorkspace().tabs.filter((t) => t.route.startsWith("/edit/"));
+    expect(edits.map((t) => t.route)).toEqual([
+      "/edit/prod/ConfigMap/default/web",
+      "/edit/staging/ConfigMap/default/web",
+    ]);
+  });
+
+  it("carries a custom kind's group into Edit's route, so a CRD reusing a built-in's name opens its own object", async () => {
+    const args: UseRowMenuArgs = { context: "prod", kind: "Deployment", actions: { delete: false }, group: "acme.io" };
+    render(<Harness args={args} row={{ name: "api", namespace: "default" }} />);
+    await userEvent.click(screen.getByRole("button", { name: "Edit" }));
+    expect(
+      store.currentWorkspace().tabs.some((t) => t.route === "/edit/prod/acme.io%2FDeployment/default/api"),
+    ).toBe(true);
   });
 
   it("gives Edit on two namespaces' same-named resources two tabs, not one", async () => {
@@ -185,15 +212,17 @@ describe("useRowMenu", () => {
     await userEvent.click(screen.getByRole("button", { name: "Edit" }));
     const edits = store.currentWorkspace().tabs.filter((t) => t.route.startsWith("/edit/"));
     expect(edits.map((t) => t.route)).toEqual([
-      "/edit/Deployment/default/api",
-      "/edit/Deployment/staging/api",
+      "/edit/prod/Deployment/default/api",
+      "/edit/prod/Deployment/staging/api",
     ]);
   });
 
   it("gives Edit on a cluster-scoped kind the same arity, with the placeholder segment", async () => {
     render(<Harness args={NODE_ARGS} row={NODE_ROW} />);
     await userEvent.click(screen.getByRole("button", { name: "Edit" }));
-    expect(store.currentWorkspace().tabs.some((t) => t.route === "/edit/Node/-/worker-1")).toBe(true);
+    expect(
+      store.currentWorkspace().tabs.some((t) => t.route === `/edit/${NODE_ARGS.context}/Node/-/worker-1`),
+    ).toBe(true);
   });
 
   it("opens Follow logs at the Logs screen's route, not the placeholder one", async () => {

--- a/packages/ui-next/src/screens/ResourceMenu.tsx
+++ b/packages/ui-next/src/screens/ResourceMenu.tsx
@@ -35,6 +35,9 @@ export interface UseRowMenuArgs {
   /** The Kubernetes kind this list is showing, e.g. "Pod", "CronJob". */
   kind: string;
   actions: KindActions;
+  /** The API group, for a custom kind only — see `KindDescriptor.group`. Edit
+   *  carries it, so a CRD that reuses a built-in kind's name opens ITS object. */
+  group?: string;
 }
 
 /** What a picked entry is waiting to do, once the confirm is taken. */
@@ -139,7 +142,7 @@ interface ShellPick {
  * `danger`, and Run now skips `pending` entirely — it is a call, not a
  * mutation of anything already running.
  */
-export function useRowMenu({ context, kind, actions }: UseRowMenuArgs): {
+export function useRowMenu({ context, kind, actions, group }: UseRowMenuArgs): {
   items: (row: ListRow) => ContextMenuItem[];
   dialog: ReactNode;
 } {
@@ -378,7 +381,13 @@ export function useRowMenu({ context, kind, actions }: UseRowMenuArgs): {
       // under `openTab`'s dedupe, so a name alone collapsed `default/api` and
       // `staging/api` — and a Pod `api` and a Deployment `api` — onto one tab,
       // and the second pick focused the first resource. See {@link editRoute}.
-      onPick: () => openTab(editRoute(kind, row.namespace ?? null, row.name), { clusterName: context }),
+      // The CLUSTER is in it too, because the editor pins the cluster it was
+      // opened on, and a pinned editor for another cluster's same-named
+      // resource must not be the tab this pick lands on.
+      onPick: () =>
+        openTab(editRoute(kind, row.namespace ?? null, row.name, { cluster: context, group }), {
+          clusterName: context,
+        }),
     });
     list.push({
       label: ROW_ACTION_LABEL.copy,

--- a/packages/ui-next/src/screens/Resources.test.tsx
+++ b/packages/ui-next/src/screens/Resources.test.tsx
@@ -397,6 +397,19 @@ describe("Resources", () => {
 
   // Correction 1: the design mock titles every kind's identifier column
   // "Name" — never "Pod", "Deployment", "Secret". Classic named it by kind.
+  it("offers New, which opens the create editor on this cluster", async () => {
+    // The create half of the editor had a route and a screen and no door:
+    // nothing in the app opened /new. This is the door.
+    open("/k/pods");
+    await screen.findByRole("heading", { level: 1, name: "Pods" });
+    await userEvent.click(screen.getByRole("button", { name: "New" }));
+    const created = store.currentWorkspace().tabs.filter((t) => t.route.startsWith("/new/"));
+    expect(created).toHaveLength(1);
+    // The cluster is in the route: the editor pins it, and New on a second
+    // cluster must not land on this one's draft.
+    expect(created[0].route).toBe("/new/prod-eu");
+  });
+
   it("titles the identifier column Name, not the kind", async () => {
     open("/k/pods");
 

--- a/packages/ui-next/src/screens/Resources.tsx
+++ b/packages/ui-next/src/screens/Resources.tsx
@@ -216,6 +216,7 @@ function KindList({
     context: name,
     kind: descriptor?.k8sKind ?? "",
     actions: descriptor?.actions ?? {},
+    group: descriptor?.group,
   });
 
   // The checkbox column's selection. Table owns the interaction (toggle,

--- a/packages/ui-next/src/screens/Resources.tsx
+++ b/packages/ui-next/src/screens/Resources.tsx
@@ -8,6 +8,7 @@ import {
 } from "@srelens/core";
 import { useNamespaceOptions } from "@srelens/core/react";
 import {
+  Button,
   ColumnPicker,
   ErrorState,
   FilterBar,
@@ -23,7 +24,7 @@ import {
 import { useConsole } from "../console";
 import { getKubeconfigFiles, useActiveContext } from "../lib/clusters";
 import { useHiddenColumns } from "../lib/columnPrefs";
-import { detailRoute, parseDetailRoute } from "../lib/detailRoute";
+import { detailRoute, newRoute, parseDetailRoute } from "../lib/detailRoute";
 import { customDescriptor } from "../lib/kinds/custom";
 import { descriptorFor } from "../lib/kinds/descriptors";
 import { withRowAffordances } from "../lib/kinds/rowAffordances";
@@ -483,6 +484,13 @@ function KindList({
             onToggle={onToggleColumn}
             pinnedKey={NAME_KEY}
           />
+          <Button
+            variant="secondary"
+            title={`Create a resource on ${name} from a template`}
+            onClick={() => openTab(newRoute(name), { clusterName: name })}
+          >
+            New
+          </Button>
         </>
       }
     >

--- a/packages/ui-next/src/screens/Workloads.tsx
+++ b/packages/ui-next/src/screens/Workloads.tsx
@@ -13,6 +13,7 @@ import {
 } from "@srelens/core";
 import { useNamespaceOptions } from "@srelens/core/react";
 import {
+  Button,
   ColumnPicker,
   FilterBar,
   LiveSignal,
@@ -30,7 +31,7 @@ import {
 import { useConsole } from "../console";
 import { getKubeconfigFiles, useActiveContext } from "../lib/clusters";
 import { useHiddenColumns } from "../lib/columnPrefs";
-import { detailRoute } from "../lib/detailRoute";
+import { detailRoute, newRoute } from "../lib/detailRoute";
 import { FailureAlert } from "../lib/errorCopy";
 import {
   cronJobVerdict,
@@ -436,6 +437,13 @@ function WorkloadList({
             onToggle={onToggleColumn}
             pinnedKey={NAME_KEY}
           />
+          <Button
+            variant="secondary"
+            title={`Create a resource on ${name} from a template`}
+            onClick={() => openTab(newRoute(name), { clusterName: name })}
+          >
+            New
+          </Button>
         </>
       }
     >

--- a/packages/ui-next/src/screens/detail/detailData.tsx
+++ b/packages/ui-next/src/screens/detail/detailData.tsx
@@ -1,9 +1,7 @@
 import { createElement, useEffect, useRef, useState, type ReactNode } from "react";
 import {
-  K8S_KIND,
   eventVerdict,
   getManifest,
-  listCrds,
   listEvents,
   redactSecretManifest,
   resourceStatusLine,
@@ -24,6 +22,7 @@ import {
 } from "@srelens/ui-kit";
 import { FailureState } from "../../lib/errorCopy";
 import { descriptorFor } from "../../lib/kinds/descriptors";
+import { SLUG_BY_K8S_KIND, isBuiltInKind, resolveCrdGvk } from "../../lib/crdGvk";
 import { useObject } from "../../lib/useObject";
 import { ConfigDetailsBody } from "./ConfigBody";
 import { CronJobDetailsBody } from "./CronJobBody";
@@ -65,77 +64,12 @@ import type { DetailFact, FactsFor } from "./facts";
  *  `KindDescriptor` the list already resolves what extra panes a kind offers.
  *  Built from core's own table rather than hand-duplicated, so a kind added
  *  there is never silently unresolvable here. */
-const SLUG_BY_K8S_KIND: Record<string, string> = Object.fromEntries(
-  Object.entries(K8S_KIND)
-    .filter(([, k8sKind]) => k8sKind !== "")
-    .map(([slug, k8sKind]) => [k8sKind, slug]),
-);
 
 /** How a subject is named in a loading or error line, in either screen. */
 export function describeTarget(kind: string, namespace: string | null, name: string): string {
   return `${kind} ${namespace ? `${namespace}/` : ""}${name}`;
 }
 
-/**
- * Resolves a custom resource's `{group, version, plural}` from the cluster's
- * own CRD list, for `getManifest`'s optional fifth argument.
- *
- * `getManifest(context, kind, namespace, name, invoke, crd?)` needs that GVK
- * to resolve a CRD-backed kind — kind alone is ambiguous to the backend's
- * kind→GVR match, which has no CRD path at all (the same reason
- * `KindActions.delete` is withheld for custom resources in `lib/kinds/
- * custom.ts`). This layer only ever receives a bare `kind` string (not a
- * slug, not a `CrdRef`), and there is nowhere upstream to source one from
- * yet — no descriptor represents a CRD kind today, and threading a `CrdRef`
- * through `KindDescriptor`/props would only work once every future caller
- * remembers to supply it, which is exactly the kind of coordination gap that
- * has already bitten this screen once (see Task 9's own "must remember to
- * set panes.containers" concern). Resolving it here instead means the YAML
- * pane works correctly for a custom resource the moment ANY caller passes
- * its kind — self-contained, not dependent on another task's discipline —
- * at the cost of one extra `listCrds` round trip per custom-resource YAML
- * open (skipped entirely for a built-in kind, and only paid once the reader
- * actually opens the YAML tab, matching this module's existing laziness).
- *
- * A `kind` with no CRD on the cluster (the CRD was deleted, or the caller
- * mis-typed it) is reported as an error, not silently passed through
- * unresolved: an unresolved `crd` would make `getManifest` guess via the
- * same ambiguous kind→GVR match this function exists to avoid, which can
- * fail confusingly or, worse, resolve to the wrong resource entirely.
- *
- * A `kind` claimed by MORE than one CRD is reported the same way, for the
- * same reason. Two groups can legitimately define the same `.kind`
- * (`widgets.example.com` and `widgets.other.io`), and this layer is handed a
- * bare kind string with no group to disambiguate it. Taking the first match
- * would fetch a manifest from possibly the wrong group and render it as
- * though it were the right one — a possibly-wrong success, which is worse
- * than a failure, because nothing on screen would say anything was ambiguous.
- */
-async function resolveCrdGvk(
-  context: string,
-  kind: string,
-): Promise<{ crd?: DynamicGvk; error?: string }> {
-  const result = await listCrds(context);
-  if (result.error) {
-    return { error: `Could not look up ${kind}'s CustomResourceDefinition: ${result.error}` };
-  }
-  const matches = result.crds?.filter((c) => c.kind === kind) ?? [];
-  if (matches.length === 0) {
-    return {
-      error: `${kind} has no matching CustomResourceDefinition on this cluster, so its manifest cannot be resolved.`,
-    };
-  }
-  if (matches.length > 1) {
-    // Sorted and de-duplicated so the message reads the same whichever order
-    // `listCrds` happened to return them in.
-    const groups = [...new Set(matches.map((c) => c.group))].sort().join(", ");
-    return {
-      error: `${kind} is claimed by more than one CustomResourceDefinition on this cluster (${groups}), so its manifest cannot be resolved unambiguously.`,
-    };
-  }
-  const match = matches[0];
-  return { crd: { group: match.group, version: match.version, plural: match.plural } };
-}
 
 /**
  * `kind` is the route's, not `object.kind`. A body dispatched on one kind and
@@ -528,7 +462,7 @@ export function useDetailPaneState({
   // `getManifest` needs a CRD's group/version/plural to resolve a
   // custom-resource manifest — see `resolveCrdGvk`'s own doc comment for why
   // this is looked up here rather than threaded in from a descriptor.
-  const isBuiltInKind = SLUG_BY_K8S_KIND[kind] !== undefined;
+  const builtIn = isBuiltInKind(kind);
   // The Details pane keeps a Secret's values out of the DOM until the reader
   // reveals them; `k8s.getManifest` returns them in the clear (only
   // `k8s.getObject` redacts — see `crates/kube/src/manifest.rs`), so without
@@ -540,7 +474,7 @@ export function useDetailPaneState({
   const isSecret = kind === "Secret";
   const yamlState = useLoad<string>(openedPanes.has(PANE_YAML), target, async () => {
     let crd: DynamicGvk | undefined;
-    if (!isBuiltInKind) {
+    if (!builtIn) {
       const resolved = await resolveCrdGvk(context, kind);
       if (resolved.error) return { error: resolved.error };
       crd = resolved.crd;

--- a/packages/ui-next/src/screens/resourceShell.tsx
+++ b/packages/ui-next/src/screens/resourceShell.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, EmptyState, LoadingState, MultiSelect, Screen, Spinner, type Column, type TableSort } from "@srelens/ui-kit";
+import { Alert, Button, Combobox, EmptyState, LoadingState, MultiSelect, Screen, Spinner, type Column, type TableSort } from "@srelens/ui-kit";
 import { useContextsError, useContextsStatus } from "../lib/clusters";
 import { toggleColumn } from "../lib/columnPrefs";
 import { FailureAlert, FailureState } from "../lib/errorCopy";
@@ -108,6 +108,51 @@ export function NamespacePicker({
       onChange={onChange}
       allLabel="All namespaces"
       ariaLabel="Namespaces"
+    />
+  );
+}
+
+/**
+ * The same picker, for a screen that needs exactly ONE namespace rather than a
+ * set — the editor's create half writes into one.
+ *
+ * Beside `NamespacePicker` and not written at the call site, for that
+ * component's own reason: the loading state is the part that drifts. A bare
+ * `Combobox options={(namespaces ?? []).map(...)}` is an empty dropdown that
+ * reads as "this cluster has no namespaces" for as long as the listing takes.
+ *
+ * `Combobox`, not `Select`: a cluster with sixty namespaces is a wall in a
+ * native dropdown, and this is the control the rest of the app already opens
+ * for the same list — searchable, height-capped, one look.
+ */
+export function NamespaceChoice({
+  namespaces,
+  value,
+  onChange,
+}: {
+  namespaces: string[] | null;
+  value: string;
+  onChange: (next: string) => void;
+}) {
+  if (namespaces === null) {
+    return (
+      <Button variant="secondary" className="justify-between gap-1.5" disabled aria-label="Namespace">
+        <Spinner label="Loading namespaces" />
+        Loading namespaces…
+      </Button>
+    );
+  }
+  return (
+    <Combobox
+      // A namespace typed into the draft before the listing arrived, or one
+      // that has since gone, is still what the manifest says — so it gets a
+      // row rather than falling back to the placeholder.
+      options={(namespaces.includes(value) ? namespaces : [value, ...namespaces]).map((ns) => ({ value: ns }))}
+      value={value}
+      onValueChange={onChange}
+      ariaLabel="Namespace"
+      searchPlaceholder="Find a namespace…"
+      className="min-w-44"
     />
   );
 }


### PR DESCRIPTION
Clicking **Edit** on any resource in the next design opened a correctly titled tab onto the Placeholder. The row menu and the detail footer mint `/edit/<kind>/<namespace>/<name>`, the routes table names `/new`, and no screen was registered for either. This adds that screen.

## What it does

- **Edit** loads the live manifest into the kit's `CodeEditor`, lints it with a strict server-side dry run, and applies server-side after a confirmation naming the resource and the cluster. A **Changes** panel shows a dry-run diff of the draft; **Changed elsewhere** appears when the live `resourceVersion` has moved since the manifest was loaded.
- A field another manager owns comes back as a **conflict** naming the manager and the field, with **Force apply** as the one way past it.
- **Delete** has its own confirmation in the danger tone; the tab then says the resource is gone rather than editing over nothing.
- **New** (`/new`) starts from a template — Deployment, Service, ConfigMap, Secret, Ingress, Namespace, or blank — in a picked namespace, and creates with the same apply.
- Every read and write goes to the **cluster the tab was opened on**, not wherever the rail points now; a reader who moved the rail is told and asked to confirm, as the row menu's dialogs already do (`useClusterGate`).

## Verification

- 8 screen tests (load, confirm-then-apply with reload, conflict → force, delete, load failure, bad route, template create, template/namespace swap); full frontend suite and typecheck clean apart from the three pre-existing Windows-only failures.
- Driven in a real browser against stubbed capabilities: typed into CodeMirror, watched the diff panel, confirmed, hit the conflict banner, forced, saw the manifest reload; deleted; created from a swapped template. That run found one thing the tests had not (the Changes toggle stayed on "Hide changes" after an apply), fixed in the second commit.

## Not in this PR

Schema-driven completion in the editor. The kit takes a completion source and core has the schema helpers, but joining them needs CodeMirror's autocomplete types in `ui-next`, which it does not yet depend on. Validation — the half that catches a wrong manifest before it is applied — is wired.
