### PR TITLE
feat(gpui): the resource list on GPUI Kit, as its own binary against the crates

### DIFF
--- a/.claude/skills/gpui-kit-design-guides/SKILL.md
+++ b/.claude/skills/gpui-kit-design-guides/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: gpui-kit-design-guides
+description: The normative Design Guides for GPUI Kit desktop applications. Read in full before designing or changing any screen, layout, spacing, visual hierarchy, color, density, component choice, interaction state, overlay, motion, data-heavy view, or interface copy in a GPUI Kit (gpui-kit / gpui-component) application, and before reviewing UI work for design quality. Also use when asked what the design rules are, or whether a UI decision follows them.
+---
+
+# GPUI Kit Design Guides
+
+The guide is [references/design-guides.md](references/design-guides.md). It is
+a requirement, not inspiration. Read the guide file itself before doing UI
+work. Do not answer from this page, from an existing screen in the codebase, or
+from training data.
+
+If the file is missing, fetch `https://gpui-kit.com/docs/design-guides.md`.
+The guide is a verbatim copy of that page, so its link to `./coding-guides.md`
+means the Coding Guides in the `gpui-kit` skill (or `https://gpui-kit.com/docs/coding-guides.md`).
+
+## How to read it
+
+Read the whole guide for a new screen or a redesign. For a narrow change, read
+"Design thesis" and "Start from the task" first, then the section for the
+change. Sections, in order (`grep -n '^## ' references/design-guides.md`):
+
+| Section                              | Read when                                                              |
+| ------------------------------------ | ---------------------------------------------------------------------- |
+| Design thesis                        | Always                                                                 |
+| Learning from Shadcn                 | Choosing what to borrow from web component libraries                   |
+| Start from the task                  | Always; task hierarchy, interaction promise, what to leave out         |
+| Visual language                      | Color, typography, spacing, radius, borders, elevation, density, icons |
+| Layout patterns                      | Window structure, sidebars, toolbars, panels, forms, resizable regions |
+| Components and composition           | Picking a component, composing parts, when to build a new one          |
+| Interaction states                   | Hover, focus, pressed, selected, disabled, loading, validation, danger |
+| Feedback and overlays                | Dialog, sheet, popover, menu, notification, tooltip, dismissal, focus  |
+| Motion                               | Any animation or transition                                            |
+| Designing data-heavy interfaces      | Tables, lists, trees, dashboards, dense inspectors                     |
+| Interface language                   | Any user-facing text: labels, buttons, titles, errors, empty states    |
+| Internationalization and platform fit | Multi-locale copy, Chinese terminology, macOS/Windows conventions     |
+| Guidance for AI-generated interfaces | Always when an agent produces UI                                       |
+| Accessibility checklist              | Before finishing                                                       |
+| Design review checklist              | Before finishing; run every item against the work                     |
+
+## Non-negotiables
+
+A floor, not a substitute for the guide.
+
+- **Desktop before web convention.** Keyboard access, window chrome, menus,
+  dense data views, resizable regions, persistent navigation.
+- **`Button` vs `Link`.** `Button` for every in-app command, `ghost` or
+  `outline` when it should read quietly. `Link` only for external URLs and
+  email addresses.
+- **Tokens before values.** No raw hex or `rgb(...)`; use `cx.theme()`
+  semantic tokens and rem-based helpers. Any spacing number quoted in the guide
+  is the current default scale, not a literal to repeat.
+- **State must be visible.** Hover, focus, selection, disabled, loading,
+  validation, and destructive states each need distinct, consistent treatment.
+- **Overlays.** Escape dismisses the topmost surface and returns focus to its
+  trigger.
+- **Copy.** Name the object and the verb: `Delete "Roadmap"?` with a `Delete`
+  button, not `Are you sure?` with `OK`.
+
+Finish by running the Design review checklist against the work.

--- a/.claude/skills/gpui-kit-design-guides/references/design-guides.md
+++ b/.claude/skills/gpui-kit-design-guides/references/design-guides.md
@@ -1,0 +1,890 @@
+---
+title: Design Guides
+description: Product and interaction design guidance for GPUI Kit applications
+order: -2.1
+---
+
+# Design Guides
+
+Use this guide before choosing components or writing layout code. It records
+the product judgment accumulated through years of GPUI Kit desktop work:
+an interface should feel native, restrained, precise, and understandable
+without guesswork.
+
+This is a normative guide. **Must** identifies a correctness or ecosystem
+constraint, **should** is the default that needs a concrete reason to override,
+and **may** is an optional technique. Component API documentation remains the
+authority for individual methods.
+
+The rules build on behavior in `gpui-base`, the GPUI Component theme and
+component system, and familiar desktop interaction. Shadcn contributes useful
+methods—open code, composition, and dependable defaults—but does not determine
+how a GPUI application should look. When influences conflict, preserve GPUI's
+lifecycle constraints and the interaction people already understand.
+
+## Design thesis
+
+Build interfaces that feel native, quiet, and precise. Let content, hierarchy,
+and interaction carry the experience; decoration should support them rather
+than compete with them.
+
+1. **Clarity before personality.** Make the primary task and next action clear
+   before adding brand expression.
+2. **Composition before invention.** Start with established components and
+   compose them into product-specific workflows. Create a new primitive only
+   when its behavior is genuinely new.
+3. **Tokens before values.** Colors, radii, typography, and spacing should form
+   a system. Avoid isolated literals that cannot respond to themes.
+4. **Desktop before web convention.** Preserve keyboard access, window chrome,
+   menus, dense data views, resizable regions, and persistent navigation where
+   the task benefits from them.
+5. **State must be visible.** Hover, focus, selection, disabled, loading,
+   validation, and destructive states need distinct and consistent treatment.
+
+## Learning from Shadcn
+
+Shadcn's most useful contribution is not a particular border color. It is a
+way of building a system:
+
+- own the top layer of the interface instead of fighting a sealed abstraction;
+- compose small, predictable parts into product-specific components;
+- provide defaults that already form one visual language;
+- keep the code and composition legible to both people and AI;
+- separate behavior primitives from the styled layer.
+
+GPUI Kit applies those ideas through a Rust library and the split between
+`gpui-base` and `gpui-component`. Applications normally compose or wrap the
+published components; contributors move genuinely reusable behavior into Base
+and keep visual policy above it.
+
+Do not copy these web assumptions blindly:
+
+| Web habit | Native GPUI default |
+| --- | --- |
+| Pointing-hand cursor on every button | Default arrow cursor; pointing hand for links |
+| Page navigation as the main structure | Persistent windows, panes, sidebars, tabs, and menus |
+| Browser focus and scrolling as a fallback | Explicit focus ownership and region-owned scrolling |
+| Mobile-first single column | Resizable desktop shell with a defined minimum window size |
+| Hover-revealed critical actions | Keyboard- and pointer-reachable actions that do not depend on hover |
+| A row of hover-only icon buttons | A visible primary action plus `DropdownMenu` or `ContextMenu` for secondary commands |
+| Link-styled text for application commands | `Button`, `outline`, or `ghost`; Link only for URLs, web resources, or email addresses |
+| Large touch density everywhere | Medium density by default; compact only where information work benefits |
+| CSS overrides across descendants | Typed builders, semantic parts, and application composition |
+
+## Start from the task
+
+Before drawing a screen, write down:
+
+- the user's primary task;
+- the object being viewed or changed;
+- the actions that must remain immediately available;
+- the information required to make a decision;
+- empty, loading, error, offline, read-only, and permission-denied states;
+- the keyboard path through the workflow.
+
+Organize the window around those answers. Do not begin with a dashboard grid or
+a component catalogue. A good desktop interface exposes the user's mental
+model: documents, accounts, projects, messages, settings, or another stable
+object—not the internal service architecture.
+
+Design the primary task before distributing controls. Its visual weight,
+location, and information depth should match its importance to the product. A
+core result must not be reduced to a small count, an icon in a corner, or a
+weak footer action while secondary content consumes the page. When a result set
+is the product's main value, consider a summary region or card that exposes the
+count, representative results, meaningful state, and a clear next action.
+
+For every proposed action, name its visible object, current state, scope, and
+result. If the interface does not show or clearly imply those things, the
+action is premature. Do not expose a capability merely because the backend has
+it; first design how the object enters the user's mental model.
+
+## Visual language
+
+### Hierarchy
+
+Prefer a small number of clear levels:
+
+- **window or page title** identifies the current object or workspace;
+- **section title** separates meaningful regions;
+- **body text** carries the work;
+- **muted text** provides secondary metadata and help;
+- **labels** identify controls and values.
+
+Use size, weight, spacing, and separators before adding color or containers.
+Avoid nesting cards inside cards: most desktop regions need only a background,
+a hairline boundary, and intentional spacing.
+
+Evaluate hierarchy across the whole feature, not component by component. Hide
+accent color and decoration during review: the primary task, current selection,
+result summary, and next action should still be obvious from structure. A
+screen that contains individually plausible controls can still fail when they
+do not form one reading order and one decision path.
+
+Treat emphasis as a limited budget. A local surface needs one clear focal point,
+not a field of competing highlights. If everything is colored, badged, bold,
+boxed, or promoted to an alert, nothing reads as important. Establish priority
+with structure and proximity first; spend stronger color and components only
+where a distinction changes what the user notices or does.
+
+### Color and themes
+
+Read colors from `cx.theme()` and use them by semantic role:
+
+- `background` and `foreground` for the main surface and text;
+- `group_box`, `popover`, `sidebar`, and their foreground tokens for their
+  named surfaces;
+- `muted` and `muted_foreground` for supporting information;
+- `primary` for the principal action or selection emphasis;
+- `danger`, `warning`, `success`, and `info` only for their meanings;
+- `border`, `input`, and focus-ring tokens for structure and interaction.
+
+Do not use a semantic status color as decoration. Do not encode meaning by
+color alone. Verify every custom surface in light and dark themes and with
+custom theme values; never assume that foreground is black or background is
+white.
+
+Use Badge for a short state, count, or classification that benefits from rapid
+scanning—not for every label, metadata value, filter, or section title. Keep
+most badges neutral; reserve semantic variants for states that truly carry
+success, warning, danger, or informational meaning. A row of multicolored
+badges is usually a missing hierarchy or grouping decision.
+
+Application UI should not contain raw hex, `rgb`/`rgba`, or `hsla` colors.
+Resolve colors from `cx.theme()` by semantic role. If the required role does
+not exist, define it in the product's theme/token layer rather than embedding a
+palette value at the call site. Raw colors belong only inside theme definitions
+or in audited data/raster content whose color is itself the data.
+
+### Radius, spacing, and density
+
+Derive corner radii from the active theme. This preserves a product's ability
+to become square or more rounded as one coherent system. Use `radius_full()`
+for circles and pills rather than a literal maximum radius.
+
+Use a compact spacing scale and repeat it. Related label/control pairs should
+be closer than separate groups; separate groups should be closer than separate
+sections. Prefer component sizes (`xsmall`, `small`, default medium, `large`)
+over one-off heights. Use compact variants for toolbars and data-dense screens,
+not to squeeze an unclear layout into less space.
+
+The shared semantic scale is intentionally small: spacing progresses through
+roughly 2, 4, 8, 12, 16, 24, and 32 pixels, while typography stays near 12,
+14, 16, 18, and 20 pixels. Treat these as relationships rather than permission
+to scatter their current values through feature code. GPUI Component currently
+projects a fixed default `SpacingTokens` scale from its global `Theme`; unlike
+colors and radii, `Theme::apply_semantic_tokens` does not persist a custom
+spacing scale. An application that needs different spacing must own that full
+token snapshot and use it consistently in its application components.
+
+### Spatial grammar
+
+Spacing expresses relationship. Choose a gap from the semantic scale by asking
+what the two things mean to each other:
+
+| Relationship | Typical token | Current scale | Examples |
+| --- | --- | --- | --- |
+| Optical correction | `xxs` | 2 px | icon baseline, compact separator |
+| Parts of one control | `xs` | 4 px | menu icon/label, title/description |
+| Closely related controls | `sm` | 8 px | button icon/label, dialog actions |
+| One content group | `md` | 12 px | notification columns, compact form rows |
+| Separate groups in one section | `lg` | 16 px | panel padding, form groups |
+| Separate sections | `xl` | 24 px | major blocks in a page or inspector |
+| Major region boundary | `xxl` | 32 px | empty-state breathing room, page bands |
+
+These values describe the current default scale, not literals to repeat. Use
+`cx.theme().spacing_tokens()` or the corresponding GPUI scale helpers for the
+ecosystem default. A product-owned scale should preserve the ordering and
+relationships and must be passed through the application's own design-system
+context rather than assumed to persist in the global GPUI Component theme.
+
+Use these rules when resolving horizontal and vertical space:
+
+1. **Inside before outside.** A component's padding belongs to the component;
+   the gap between components belongs to their parent.
+2. **Vertical rhythm shows grouping.** The gap between a title and its
+   description is smaller than the gap from that description to the next
+   section. Equal gaps imply equal relationships.
+3. **Horizontal space supports scanning.** Repeated rows keep icons, labels,
+   values, badges, and trailing actions on stable columns.
+4. **Leading and trailing are semantic.** Think in reading-order edges even
+   when the current API uses left/right; this keeps future RTL adaptation
+   possible.
+5. **Do not double padding.** A card placed in an already padded panel should
+   not automatically add another full panel inset.
+6. **Use optical alignment sparingly.** A one- or two-pixel correction is valid
+   for icon or glyph geometry, but document why it differs from the scale.
+
+Common compositions in the current system illustrate the relationships:
+
+- button contents use 4 px at small sizes and 8 px at normal sizes;
+- dialog headers and footers use an 8 px internal gap;
+- compact list and menu rows use 4 px vertical and 8–12 px horizontal padding;
+- sheet headers use about 16 px leading and 12 px trailing space, leaving room
+  for a close affordance, while footers use 16 px horizontal and 12 px vertical
+  space;
+- notifications use 16 px horizontal padding and a 12 px column gap because
+  icon, message, and action are distinct groups.
+
+Do not treat these as copy-and-paste recipes for every surface. They reveal the
+system: controls are tighter internally, rows optimize scanning, and
+containers spend more space at their boundary than between their contents.
+
+### Proportion and layer hierarchy
+
+Start with content requirements, then set proportions. Avoid arbitrary halves
+when one pane has a clearly different role.
+
+- A navigation sidebar should be wide enough for stable labels but visibly
+  subordinate to the work area. Give it a minimum, preferred, and maximum
+  width rather than a percentage alone.
+- In master–detail layouts, let the collection remain scannable and give the
+  detail pane the surplus. A roughly one-third/two-thirds starting point is
+  often useful, but content constraints are authoritative.
+- Inspectors and auxiliary sheets should not cover the primary object by
+  default. They should be resizable or dismissible when their content grows.
+- Dialog width comes from the decision: short confirmation, medium form, or a
+  dedicated window/page for complex work. Do not enlarge a dialog simply to
+  create whitespace.
+- Reserve the strongest elevation for the topmost decision layer. Within a
+  layer, use background and hairlines—not successively larger shadows—to show
+  hierarchy.
+
+Define three size constraints for every major region: the minimum at which its
+task still works, a comfortable default, and how it consumes surplus. Persist
+user-controlled splits when they represent workflow preference, and clamp
+restored values against the current window.
+
+### Alignment details
+
+Alignment is a structural system, not a final polish pass. Establish a small
+set of alignment spines for each surface: shared leading and trailing edges,
+text baselines, center lines, and fixed functional lanes. Elements at the same
+level should attach to the same spine from top to bottom or leading to trailing,
+even when they are different component types.
+
+<img class="alignment-light" src="/alignment-spines.svg?v=20260822-4" alt="Alignment spines across a desktop surface">
+<img class="alignment-dark" src="/alignment-spines-dark.svg?v=20260822-4" alt="Alignment spines across a desktop surface">
+
+Vertical red lines sit beside shared edges or control centers for content,
+status, time, and trailing actions. Horizontal lines sit beneath text baselines
+or pass through a row center to show bottom and vertical-center alignment. The
+compact comparison isolates a one-rendered-pixel drift that must be corrected
+at its structural owner.
+
+- Give sibling regions a shared content inset. A heading, toolbar, list row,
+  empty state, and footer that describe the same level should not each invent a
+  slightly different leading edge.
+- Repeat column geometry through the whole region. Headers, rows, summaries,
+  loading states, and inline editors should reserve the same lanes for identity,
+  metadata, status, numbers, and actions.
+- Align related controls across rows and sections. Form labels, fields,
+  descriptions, and validation messages should reveal a stable vertical grid
+  when the page is scanned from top to bottom.
+- Keep horizontal bands coherent. Items sharing a toolbar, title bar, status
+  bar, or row should use one baseline or center line instead of individually
+  tuned offsets.
+- Introduce indentation only for real hierarchy, containment, or disclosure.
+  Decorative indentation makes siblings look subordinate and breaks the
+  surface's reading line.
+- When a nested level ends, return exactly to the parent spine. Do not let
+  accumulated padding drift across nested containers.
+- Preserve the spine through optional content. Missing icons, badges,
+  descriptions, or trailing actions must not move the remaining labels; use
+  intentional slots or lanes when cross-row comparison matters.
+- Align major regions with one another where their hierarchy matches. Sidebar
+  headers, content titles, split panes, toolbars, and bottom bars need not share
+  every coordinate, but coincident levels should form visible continuous lines.
+
+Not every edge should align. A child can indent, a primary value can lead its
+supporting metadata, and a destructive decision can gain separation. Such
+exceptions must communicate hierarchy or meaning; they must not result from
+uncoordinated component padding. Start with the shared spine, then make the
+exception explicit.
+
+Treat exact alignment and repeated gaps as quality invariants. When two edges
+or spaces are intended to be equal, a one-rendered-pixel difference is a defect,
+not an acceptable optical approximation. Inspect resolved bounds with a
+measurement tool at representative window sizes, zoom levels, and display scale
+factors. Compare coordinates and distances; do not approve alignment only from
+a casual screenshot.
+
+The rendered-pixel tolerance is a verification rule, not permission to patch
+the code with raw pixel offsets. Equal relationships should resolve from the
+same `rem` helper, spacing token, grid definition, or shared component inset.
+Fix the common owner when they differ. Account for fractional layout and device
+rounding so intended spines land on the same physical pixel instead of drifting
+at particular zoom levels.
+
+- Align text by baselines, not by bounding-box centers, when mixed sizes share
+  a row.
+- Center icons in a fixed slot so labels do not move when icons differ in
+  intrinsic width.
+- Right-align comparable numbers; left-align prose and identifiers unless the
+  locale requires otherwise.
+- Keep trailing row actions and disclosure indicators in fixed-width lanes.
+- Align form controls by their interactive frame, not by help text below them.
+- Use `justify_between` only when the two sides truly own opposite edges; it
+  should not disguise missing structure in the middle.
+- Hairlines belong on the boundary owner. Two adjacent regions must not each
+  draw the same separator.
+- A scrollbar belongs to the region that scrolls and sits against that panel,
+  editor, or window's trailing edge. Content padding may inset text and rows;
+  it must not pull the scrollbar into the middle of the surface. Reserve a
+  deliberate scrollbar gutter when content needs clearance.
+
+### Density tiers
+
+Medium is the ecosystem default. Change density for the whole local context,
+not one isolated control:
+
+- **comfortable / large:** onboarding, sparse forms, prominent decisions;
+- **standard / medium:** most application chrome and workflows;
+- **compact / small:** toolbars, menus, tables, and repeated professional data;
+- **extra compact / xsmall:** exceptional high-density utilities, never the
+  automatic choice for an entire application.
+
+The current controls demonstrate a bounded scale rather than arbitrary sizing:
+buttons commonly move through approximately 20, 24, and 32 px frames; input
+and data controls may extend to about 44 px at large size; table rows use about
+26, 30, 32, and 40 px. Use the component's `Size` API so typography, icon,
+padding, and hit target change together. A custom height that changes only the
+outer box is usually incomplete.
+
+### Zoom, base font, and `rem`
+
+A well-designed `rem` system preserves hierarchy while the interface zooms.
+Zoom is successful when the relationship between title and body, control and
+icon, inner and outer spacing, primary and secondary regions still feels the
+same at every scale—not merely when every object becomes larger.
+
+GPUI Component adopts the relative-scale idea familiar from Tailwind. The
+theme's base `font_size` becomes the window's `rem` through `Root`, and GPUI
+scale helpers such as `text_sm()`, `gap_2()`, `p_4()`, `h_8()`, and `size_4()`
+resolve against it. This gives typography, spacing, controls, and icons one
+shared zoom axis.
+
+Design in ratios:
+
+- type steps keep the same hierarchy around the base body size;
+- spacing steps keep the same grouping relationships around the type;
+- control frames, icons, and hit targets scale with their labels;
+- pane minima and comfortable widths account for the scaled content;
+- corner radii and focus treatment remain optically consistent with the
+  control frame.
+
+Do not implement zoom by changing text size alone. A larger label inside a
+fixed-height button, a larger document inside fixed pane minima, or larger rows
+inside a stale virtual-list measurement destroys the original rhythm and can
+clip content. Conversely, multiplying every physical pixel—including
+hairlines—can make the interface visually heavy.
+
+As a rule, application layout should not call `px(...)` directly. Use GPUI's
+rem-based scale helpers (`p_2`, `gap_3`, `w_64`, `text_sm`, and related
+builders) or semantic component sizes. Use fixed pixels only when the value
+represents a physical or raster boundary:
+a one-device-pixel hairline, platform window inset, bitmap dimension, minimum
+hit-test tolerance, or geometry that must match an external surface. These are
+audited, documented exceptions. Product spacing, typography, icon size, and
+ordinary control geometry stay on the relative scale.
+
+Test interface zoom at several base-font values, not just the default. Verify
+hierarchy, wrapping, truncation, minimum window size, pane resizing, focus-ring
+clearance, popup placement, and virtualized row measurement. Also distinguish
+interface zoom from Dock's panel zoom: Dock zoom makes one container fill its
+area while retaining its chrome; it does not change `rem` or application scale.
+
+### Surfaces and elevation
+
+Use elevation to explain stacking, not importance. The base window surface is
+flat; separators and background contrast define its regions. Popovers, menus,
+dialogs, and notifications may use progressively stronger shadows because they
+sit above other content. Do not put a shadow on every card.
+
+All surfaces of the same kind should share one treatment. GPUI Component, for
+example, deliberately gives popup families one themed popover surface so
+Popover, Select, Combobox, DatePicker, and menus do not drift apart. When an
+application invents another anchored surface, reuse that semantic treatment
+instead of approximating it with unrelated border and shadow literals.
+
+### Typography and icons
+
+Use the platform UI font for interface text and monospace only for code,
+identifiers, shortcuts, and aligned numeric data. Keep body text readable and
+avoid excessive uppercase or letter spacing, especially for CJK text.
+
+Use one icon family in a product. Icons supplement labels; they should not
+replace unfamiliar actions with guesswork. Icon-only buttons require a tooltip
+and an accessible name. Use filled or colored icons to communicate a state,
+not merely to make a toolbar lively.
+
+## Layout patterns
+
+### Choose a stable shell
+
+Most applications should use one of these shells:
+
+- **single workspace:** toolbar or title bar above one primary view;
+- **sidebar workspace:** persistent navigation beside a changing detail view;
+- **master–detail:** resizable collection and detail panes;
+- **document workspace:** tabs or a dock area for multiple long-lived objects;
+- **utility window:** one focused task with a short, fixed action path.
+
+Keep global navigation stable while content changes. Give the primary work area
+the remaining space with `flex_1()` and `min_w_0()` / `min_h_0()` where
+overflowing children must shrink. Use `Scrollable`, `VirtualList`, `Table`, or
+`DockArea` for their intended behavior instead of rebuilding scrolling or pane
+management from nested `div`s.
+
+### Responsive desktop windows
+
+Desktop does not mean fixed-size. Decide what happens as a window narrows:
+
+1. preserve the primary task;
+2. allow resizable regions to reach a documented minimum;
+3. collapse secondary labels or inspectors;
+4. move low-frequency actions into a menu;
+5. scroll only the region whose content actually overflows.
+
+Do not hide an action without providing another path to it. Avoid making the
+entire window scroll when only a list or document body should scroll.
+
+GPUI flex layouts have the same intrinsic-size pressure found in other layout
+systems: a `flex_1()` child may still refuse to shrink around long content.
+Design and implementation must agree on which panes may shrink, truncate, wrap,
+or scroll. A clipped region also clips an outward focus ring; never trade away
+keyboard visibility merely to simplify overflow.
+
+### Forms and settings
+
+Use a visible label for each field and place help or validation next to the
+field it describes. Align related fields, but do not force long labels into a
+narrow fixed column. Use the appropriate control: `Checkbox` for independent
+choices, `RadioGroup` for a small visible set, `Select` for a longer set, and
+`Switch` for a setting that takes effect immediately.
+
+Disable submission while an operation is in flight, keep the user's input, and
+show the result near the action. Reserve dialogs for short, focused decisions;
+use a full page or sheet for workflows that need exploration or many fields.
+
+## Components and composition
+
+Follow the Shadcn principle that components are building material rather than a
+sealed design system. GPUI Component supplies coherent defaults, while the
+application owns composition and product semantics.
+
+- Use component variants by meaning. Primary is reserved for the explicit
+  default commit in a decision area—normally the action invoked by Enter. A
+  lone, frequent, or desirable action is not automatically primary. An `Add`
+  command in a management toolbar normally uses a default Button; a form's
+  default `Create` commit may use primary. Use `danger` for destructive
+  commitment and `ghost` for quiet toolbar actions.
+- Prefer explicit compound parts and render callbacks over styling arbitrary
+  descendants.
+- Keep a repeated pattern consistent across the product. Wrap it in an
+  application component when it carries domain language or policy.
+- Use the standard component for its semantic role. A menu, dropdown menu,
+  popover, select, and command palette are not interchangeable boxes; each owns
+  different selection, focus, keyboard, dismissal, and layout contracts.
+- Preserve the component family's geometry. Menu rows share vertical and
+  horizontal padding, height, icon and checkmark slots, separators, radius, and
+  state treatment. Do not imitate one menu with a custom popup whose spacing
+  only approximates the system.
+- Do not wrap a library component merely to rename every method or freeze all
+  of its capabilities.
+- Move reusable behavior without product styling to `gpui-base`; keep themed,
+  opinionated presentation in GPUI Component or the application.
+
+## Interaction states
+
+### Make the result understandable before the click
+
+A control should predict its result. Use familiar desktop controls and
+placement so people can act without learning the interface first. Its label
+names the action and object, its state shows availability, and its feedback
+confirms the same outcome.
+
+Do not label a Button `Save` if it opens a configuration flow, or `Delete` if
+it only removes an item from a group. Name the scope when context does not make
+it clear. Respond immediately to activation, prevent duplicate submission
+during longer work, and show the result near the object that changed. Add a
+success message only when the result itself is not visible.
+
+Every interactive control should be designed for:
+
+| State | Design requirement |
+| --- | --- |
+| Rest | Clear affordance without visual noise |
+| Hover | Subtle pointer feedback, never the only cue |
+| Pressed | Immediate press feedback |
+| Open / pressed | Persistent feedback while an attached popup is open |
+| Focus visible | High-contrast keyboard focus ring |
+| Selected / checked | Persistent state distinct from hover |
+| Disabled | Lower emphasis and no misleading hover/pressed response |
+| Loading | Preserve context, prevent duplicate action, explain long waits |
+| Error | State what happened and how to recover |
+
+Use GPUI's focus system and Actions for commands that should work from the
+keyboard. Match familiar desktop shortcuts, expose shortcuts in menus or
+tooltips, and keep focus in a logical place after opening or dismissing an
+overlay.
+
+Selection is part of the information model, not optional polish. Tabs,
+segmented choices, selectable rows, filters, and navigation destinations must
+show a persistent selected state. A Button that owns a dropdown must remain
+visibly pressed or open until the popup closes; hover alone cannot explain the
+relationship between trigger and surface.
+
+For destructive actions, distinguish between reversible and irreversible work.
+Prefer undo or a temporary notification for reversible changes. Use an
+`AlertDialog` when the consequence is serious and cannot be undone; name the
+specific object and consequence in the confirmation copy.
+
+### Pointer conventions
+
+Use the default arrow cursor for buttons, checkboxes, menu items, tabs, and
+other native controls. Use a pointing hand for links and content that behaves
+as a link. Use text, resize, grab, and prohibited cursors only when they
+describe the active manipulation. A cursor reinforces an affordance; it does
+not replace the control's visible state or accessible role.
+
+Keep hover effects modest because keyboard and accessibility interaction has no
+hover. Do not reveal the only copy of a destructive or essential action on
+hover. Contextual row actions may become quieter at rest if the same commands
+remain available through selection, keyboard, or a context menu.
+
+### Prefer desktop command surfaces over hover toolbars
+
+Use command frequency and scope to choose where an action lives:
+
+- keep the primary or frequent action visible as a labeled Button or familiar
+  toolbar control;
+- put secondary actions for the current region behind a visible
+  `DropdownMenu` trigger;
+- put commands that act on the object under the pointer in a `ContextMenu`;
+- expose the same important command through an Action/key binding when it has a
+  natural keyboard form;
+- use a hover-revealed icon only as a shortcut to a command that remains
+  reachable elsewhere.
+
+This is more than a visual preference. GPUI Component's menu system already
+owns directional keyboard navigation, confirmation and cancellation, disabled
+items, separators, submenus, shortcut presentation, focus transfer and
+restoration, and nested-menu dismissal. A custom strip of hover buttons must
+rebuild those behaviors and is invisible to keyboard-only and many assistive
+technology workflows.
+
+Choose `DropdownMenu` when users need a visible indication that more commands
+exist—for example a toolbar overflow, document actions, or account menu. Choose
+`ContextMenu` for selection- or object-scoped commands such as rename,
+duplicate, reveal, or remove. The context menu must not be the only way to
+perform an essential command; provide a menu-bar, toolbar, keyboard, or detail
+view path as appropriate.
+
+Do not put every action into a menu to make a screen look minimal. Discovery
+and speed matter: the main action stays visible, dangerous items remain clearly
+labeled and separated, and a menu item should use the same verb, icon, shortcut,
+enabled state, and result everywhere it appears.
+
+### Button means application action; Link means external resource
+
+Use a Button when activation changes application state, confirms a decision,
+opens a tool, submits data, or runs a command. Choose its treatment by local
+hierarchy:
+
+- primary Button for the one emphasized commitment in a decision area;
+- default Button for ordinary visible actions;
+- outline Button when an action needs a clear boundary with less emphasis;
+- ghost Button for familiar, low-emphasis toolbar and inline actions;
+- icon Button only for a well-known symbol, with an accessible name and tooltip.
+
+Do not assign primary because a Button is the only action on screen, because it
+is placed at the top right, or because the team wants more clicks. Primary
+communicates default commitment and keyboard behavior. If activation is merely
+an ordinary command such as adding an item, opening a tool, or refreshing a
+view, use a default, outline, or ghost Button according to its local hierarchy.
+
+Use an underlined Link only for an external resource target: a URL, web page,
+online documentation, or email address. It uses the pointing-hand cursor
+because its contract is leaving the current application context for that
+resource. Do not use Link styling to make a functional command look quiet. A
+link-shaped Delete, Save, Refresh, Add, Open-menu, or in-app navigation action
+hides the control's affordance and exposes the wrong accessibility role.
+
+“View” does not make an in-app destination a Link. A full report, analysis,
+details panel, or local record still opens through a Button, row, card, tab, or
+disclosure control. Use concise context-aware labels such as `Full analysis`
+when the containing card already establishes what opens; reserve underlining
+for a resource that actually opens in a browser or mail client.
+
+All internal navigation—sidebar rows, tabs, breadcrumbs, list items, opening a
+local view, or switching workspaces—must use the corresponding native component
+or a Button/Action. Visual emphasis is chosen through Button variant or the
+navigation component's selected state, never by lying about semantics.
+
+## Feedback and overlays
+
+Choose the smallest surface that fits the decision:
+
+- tooltip: a short explanation or shortcut;
+- popover: contextual controls that do not interrupt the task;
+- menu: a compact list of actions;
+- notification: asynchronous status that does not require a decision;
+- dialog: a focused decision or short form;
+- alert dialog: explicit confirmation of a consequential action;
+- sheet: supplementary work that benefits from more persistent space.
+
+An Alert interrupts the visual hierarchy even when it does not open a modal.
+Use it for important, exceptional information that needs attention in the
+current task, not as a decorated container for ordinary descriptions, tips, or
+empty space. Prefer inline help, muted text, or a normal section when the
+content does not require immediate notice or action.
+
+Avoid stacking overlays. Escape should dismiss the topmost dismissible layer,
+and focus should return to the trigger or the next logical target.
+
+An overlay action must refer to an object or state the overlay actually shows.
+For example, expose `Clear history` only when a distinct recent-history section
+is visible and contains entries. Search results, recent items, and favorites
+are different collections; label and separate them instead of merging them
+into one unexplained list. Hide an inapplicable action or disable it with a
+useful reason—do not park an ambiguous trash icon in a footer.
+
+Footer space is not a catch-all for capabilities that lacked a place in the
+design. A footer may present shortcuts, status, or actions that apply to the
+whole surface, but each item must answer: what is its object, why is it
+available now, what scope does it affect, and what visible state changes after
+activation?
+
+## Motion
+
+Motion explains change; it is not ambient decoration. Use short transitions for
+appearance, dismissal, expansion, and spatial continuity. Avoid animating large
+layout changes when opacity or transform communicates the same relationship.
+Honor reduced-motion preferences, never require animation to understand state,
+and do not add a default animation to every component.
+
+Motion policy belongs to the styled or application layer. Base may own the
+lifecycle mechanism or geometry needed for a transition, but it should not
+decide that every product fades or slides. Give independently animated values
+stable identity, and make interruption reverse smoothly from the currently
+sampled value rather than restarting from an old endpoint.
+
+## Designing data-heavy interfaces
+
+Dense does not mean cramped. In tables, trees, command palettes, editors, and
+docks:
+
+- keep headers and primary row identity visually stable;
+- align comparable values and use tabular numerals where appropriate;
+- distinguish focus, hover, active row, and multi-selection;
+- keep sorting and filtering visible and reversible;
+- preserve selection by domain identity across filtering and reordering;
+- virtualize large collections without changing keyboard semantics;
+- use progressive disclosure for secondary columns and inspectors;
+- provide a useful empty state that explains the next action.
+
+Choose a table for comparison across consistent fields, a list for scanning
+heterogeneous items, a tree for real hierarchy, and a dock only when users need
+to arrange long-lived tools or documents. Do not use a complex data component
+as a visual style.
+
+## Interface language
+
+Words are part of the interface architecture. Write the vocabulary for a
+feature as a system—destinations, objects, commands, states, and outcomes—not as
+isolated translations of implementation features. Prefer the shortest wording
+that remains accurate in its actual context.
+
+### Let context carry context
+
+Do not repeat information that the surrounding surface already establishes. A
+sidebar destination is usually the object or domain itself: use `Users`, not
+`User Management`; `Shortcuts`, not `Shortcut Configuration Management`. A
+column whose rows already contain actions can omit a generic `Operation`
+heading. A dialog titled `Delete “Roadmap”?` does not need body text that asks
+the same question again.
+
+This is context economy, not deletion for its own sake. Add text when it changes
+the decision: identify the affected scope, an irreversible consequence, an
+unusual prerequisite, or a way to recover. Every extra word should answer a
+question the current layout does not already answer.
+
+Use nouns for destinations and objects (`Users`, `Appearance`, `Orders`), verbs
+for commands (`Save`, `Duplicate`, `Export`), and adjectives or short phrases
+for states (`Offline`, `Up to date`, `Pending review`). Avoid wrappers such as
+`Management`, `Module`, `Page`, `Function`, `Operation`, and `System` unless the
+word distinguishes a real domain concept.
+
+### Write each language, do not translate its shape
+
+Start from shared intent, hierarchy, and terminology, then compose each locale
+as natural interface language. Do not preserve the source language's word
+order, number of words, politeness filler, or grammatical category. English
+`Users` can express a Chinese feature concept that would literally expand to
+“user management”; fidelity means preserving purpose, not preserving tokens.
+
+Remove words supplied by the enclosing information architecture. Inside a
+`Settings` surface, a destination is often simply `Account`, not `Account
+Settings` and never the unnatural singular `Account Setting`. The correct
+English label is chosen from its role and neighbors, not from the standalone
+source phrase.
+
+Maintain a small product lexicon for recurring objects, commands, and states.
+Use the same term in the toolbar, menu, context menu, dialog, shortcut search,
+and documentation unless the context genuinely changes its meaning. Review
+copy in the rendered surface: neighboring labels often reveal repetition or
+inconsistent scope that a locale file cannot.
+
+In localized technical writing, preserve an established framework term when a
+translation would be less precise. Keep API identifiers in their original form
+and format them as code. Do not retain ordinary foreign words merely to sound
+technical. Explain a retained term on first use when needed, then use the same
+form throughout the interface, documentation, and API examples.
+
+### Buttons and confirmation dialogs
+
+Button labels are short by default—usually one or two words—and describe the
+result, not the gesture or the component. Prefer `Save`, `Move`, or `Delete` to
+`Click to save`, `Perform move`, or `Confirm deletion`. Use `Cancel` consistently
+for the action that leaves without committing. Reserve `OK` for acknowledging
+purely informational content.
+
+Short is a default, not a character limit. A deliberately longer label is
+better when its words expose a consequence or distinguish choices that users
+could otherwise confuse, for example `Delete from this group` versus `Delete
+everywhere`, or `Restart without saving`. Length must buy decision-critical
+information; it must not restate the dialog title or body.
+
+Use the most specific concise result as the confirmation label when possible:
+
+| Context | Weak | Prefer |
+| --- | --- | --- |
+| Delete dialog | `Yes`, `Sure`, `Confirm deletion` | `Delete` |
+| Unsaved changes | `Confirm`, `Yes` | `Discard changes` |
+| Pure acknowledgement | `Confirm operation` | `OK` or `Done` |
+| Complex consent whose result has no clear verb | `Yes` | `Confirm` |
+
+`Confirm` is a useful fallback when the surrounding dialog fully names a
+complex commitment and no shorter result verb is accurate. It should not
+replace a clear command. `Sure` is conversational rather than a stable English
+command and is too ambiguous for the standard vocabulary.
+
+A confirmation dialog should form one compact decision:
+
+- title: the decision or condition, such as `Delete “Roadmap”?`;
+- body: only new scope, consequence, or recovery information;
+- actions: `Cancel` and the result, such as `Delete`;
+- destructive styling: applied to the destructive result, not substituted for
+  precise wording.
+
+Avoid generic titles such as `Notice`, `Warning`, `Error`, and `Confirmation`
+when the actual condition can be named. Avoid ritual phrases such as “Are you
+sure you want to…”, “Would you like to…”, “Please note that…”, and “successfully”
+when the structure or state already communicates them. Courtesy should come
+from a calm, respectful tone, not repeated `please`.
+
+### Capitalization, punctuation, and symbols
+
+Use sentence case for English UI by default: `Reset layout`, not `Reset Layout`
+or `RESET LAYOUT`. Preserve proper nouns and established acronyms. Follow a
+platform convention such as title case for native menu commands only when the
+platform integration benefits from it, and apply that convention consistently
+within the component class.
+
+ALL CAPS can provide restrained typographic emphasis for very short section
+labels, eyebrows, statuses, established acronyms, and code-like identifiers.
+Its compact shape and measured tracking can form a level similar to bold type,
+but it does not belong on Buttons, long headings, sentences, or dense lists. Do
+not combine uppercase, strong color, and bold weight in the same region, and do
+not transform every string automatically: product names, acronyms, and localized
+content must preserve their intended casing.
+
+Labels, buttons, menu items, tabs, headings, placeholders, and short states do
+not take a final period. Complete explanatory, warning, and error sentences do.
+Avoid exclamation marks in routine success and failure messages. In Chinese,
+use full-width punctuation in sentences and omit terminal punctuation from
+short control labels by the same semantic rule.
+
+Use the single ellipsis character (`…`), not three periods. Append it to every
+Button or MenuItem that opens a dialog, sheet, or separate window, and to a
+command that requires more input or choices before it can complete, such as
+`Settings…` or `Export…`. An immediately executed command does not take an
+ellipsis. Use an indeterminate progress indicator, not decorative dots, to
+communicate ongoing work.
+
+Errors should say what happened and, when useful, the next recovery action.
+Success feedback should name the resulting state only when that state is not
+already visible. Prefer `Couldn’t save. Check your connection and try again.`
+to a technical code or a long apology; omit a `Saved successfully` toast when
+the document visibly becomes saved.
+
+## Internationalization and platform fit
+
+Copy must survive expansion, CJK typography, and different shortcut notation.
+Do not size a control from one English label. Keep text out of raster assets,
+avoid concatenating translated fragments, and let labels wrap or truncate only
+where the product defines a recovery path such as a tooltip.
+
+Respect platform differences that carry meaning: Command versus Control,
+native window decorations, system appearance, scrollbar behavior, menus, and
+notification capabilities. Keep the product's information architecture stable
+across platforms, but do not erase familiar platform behavior for superficial
+pixel equality.
+
+## Guidance for AI-generated interfaces
+
+An AI changing a GPUI interface should first inspect the nearest feature,
+theme tokens, and component documentation. It should state the primary task,
+state owner, component composition, and keyboard path before generating code.
+It must not infer an API from React/Shadcn examples or invent a GPUI method
+because the name seems plausible.
+
+AI output is incomplete until a human can explain why the hierarchy, density,
+component choice, and exceptional literal values belong in this product. A
+visually plausible screenshot is not proof: keyboard behavior, focus, dynamic
+content, themes, resizing, and failure states are part of the design.
+
+## Accessibility checklist
+
+Before considering a screen complete, verify that:
+
+- every action is reachable and operable by keyboard;
+- focus order follows visual and task order;
+- focus remains visible and is restored after overlays;
+- controls have names, and icon-only controls have tooltips;
+- text and meaningful boundaries have sufficient contrast;
+- status is not communicated by color alone;
+- disabled and read-only states are distinguishable;
+- labels, errors, and descriptions remain near their controls;
+- content remains usable with longer translations and larger text;
+- pointer targets are comfortably sized even in a dense layout.
+
+## Design review checklist
+
+A review does not inventory components; it judges whether the interface made
+the right decisions. Ask, in order:
+
+1. **Is the task clear?** Can a new user recognize the purpose, primary action,
+   and next step without learning, guessing, or experimenting?
+2. **Does every action keep its promise?** Do the label, control, state, scope,
+   feedback, and result describe one consistent outcome?
+3. **Is hierarchy decisive and restrained?** Does the core feature receive the
+   space it deserves while strong color, bold type, badges, alerts, and primary
+   Buttons remain scarce?
+4. **Could the interface do less, better?** Can an entry point, option, or state
+   be removed, combined, or deferred without weakening the complete task?
+5. **Is the structure exact?** Do peers share alignment spines, equal gaps stay
+   equal to the rendered pixel, and scrollbars sit at the edge of their actual
+   scrolling region?
+6. **Does it follow the component system?** Do standard controls retain their
+   geometry, states, keyboard behavior, and dismissal model, with appearance
+   supplied by theme and scale tokens?
+7. **Does it remain usable in every state and constraint?** Verify keyboard and
+   focus behavior, empty/loading/failure/permission states, longer translations,
+   zoom, minimum window size, and reduced motion.
+8. **Has it been tested in a real window?** Complete the task with real
+   components, copy, and representative content—not only an ideal screenshot.
+
+Continue with [Coding Guides](./coding-guides.md) to translate these design
+decisions into GPUI architecture and code.

--- a/.claude/skills/gpui-kit/SKILL.md
+++ b/.claude/skills/gpui-kit/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: gpui-kit
+description: 'How to build desktop applications with GPUI Kit, the Rust framework published as the gpui-kit crate (GPUI plus gpui_kit::component, gpui_kit::base, gpui_kit::assets). Use when setting up a gpui-kit app, choosing or using a component (Button, Input, Select, Dialog, Sheet, Tabs, Sidebar, List, DataTable, Tree, Chart, etc.), handling component state, theming, or window overlays, and for GPUI mechanics: actions and keybindings, async tasks, contexts, custom elements, entities, events, focus, global state, layout and styling, ElementId, and tests. Holds the normative Coding Guides: read them before any architecture, state-ownership, public API, naming, or testing decision. Pairs with the gpui-kit-design-guides skill for the Design Guides.'
+---
+
+# GPUI Kit
+
+Applications depend on one crate, `gpui-kit`. GPUI is `use gpui_kit::*;`, and
+each layer is reachable by name: `gpui_kit::component` (styled components),
+`gpui_kit::base` (unstyled behavior), `gpui_kit::assets` (default icons),
+`gpui_kit::platform`.
+
+## Read the Guides First
+
+Two guides hold the rules this skill assumes. They are requirements, not
+inspiration. Read the guide file itself; do not answer from this page, from a
+similar file in the codebase, or from training data.
+
+| Guide                                                  | Read before                                                                                                                   |
+| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| Design Guides, skill `gpui-kit-design-guides`          | Choosing components, layout, spacing, hierarchy, color, density, interaction states, overlays, motion, interface copy          |
+| [Coding Guides](references/coding-guides.md)           | Crate layering, `RenderOnce` vs `Entity<T>`, state ownership, `ElementId`, events, focus, async, public API, naming, testing |
+
+Read the Design Guides first when the change has a visible surface: code
+structure preserves product intent, it does not replace it. If the design
+skill is not installed, fetch `https://gpui-kit.com/docs/design-guides.md`.
+The coding guide is a verbatim copy of `https://gpui-kit.com/docs/coding-guides.md`,
+so its links to `./design-guides.md` and `./getting-started.md` mean the design
+skill and `https://gpui-kit.com/docs/getting-started.md`.
+
+### Coding Guides section map
+
+Read the whole guide for a new crate, module, or feature. For a narrow change,
+read "Architecture at a glance" and "Rules for coding agents" first, then the
+section for the change (`grep -n '^## ' references/coding-guides.md`).
+
+| Section                              | Read when                                                              |
+| ------------------------------------ | ---------------------------------------------------------------------- |
+| Architecture at a glance             | Always; crate layering, ownership boundary                             |
+| Bootstrap and root ownership         | `main`, `init`, `Root`, window creation, app-level state               |
+| Understand GPUI's phases and contexts | Anything touching `App`, `Window`, `Context<T>`, render vs update      |
+| Choose the right unit                | Deciding `RenderOnce` vs `Entity<T>` vs custom `Element`               |
+| State ownership                      | Where a piece of state lives, who mutates it, `Entity<State>` handles  |
+| Stable identity                      | `ElementId`, lists, repeated elements, keyed state                     |
+| Rendering and composition            | `render`, builder chains, `when`/`map`, child composition              |
+| Behavior and presentation boundary   | `gpui-base` vs `gpui-component` vs application code                    |
+| Theme and styling                    | `cx.theme()`, tokens, `Styled`, sizes, variants                        |
+| Events, actions, and focus           | `cx.emit`, `subscribe`, `actions!`, keybindings, `FocusHandle`         |
+| Async work and side effects          | `cx.spawn`, `background_spawn`, `Task`, I/O, timers                    |
+| Layout, measurement, and scrolling   | Flex layout, sizing, `overflow`, scroll handles, measuring             |
+| Lists, tables, and large data        | `VirtualList`, `List`, `DataTable`, delegates, large collections       |
+| Public API design                    | Anything `pub`: builders, private fields, setter and reader naming     |
+| Platform and capability boundaries   | macOS/Windows/Linux/wasm differences, feature gates                    |
+| File and naming conventions          | New files, modules, type and method names, `Kind` suffix, `Context`    |
+| Testing strategy                     | What to test, `#[gpui_kit::test]`, `TestAppContext`                    |
+| Performance rules                    | Render cost, allocation, re-render triggers                            |
+| Common failure modes                 | Before finishing; invented APIs, state in render, index ids            |
+| Rules for coding agents              | Always when an agent writes code                                       |
+| Implementation checklist             | Before finishing; run every item against the work                     |
+
+### Non-negotiables
+
+A floor, not a substitute for the guides.
+
+- **Never invent an API.** Search the current source for the real signature.
+  Do not translate a React, CSS, or older-GPUI example by analogy; a
+  plausible-looking method that does not exist is the most common failure.
+- **One dependency.** Applications depend on `gpui-kit` alone. GPUI is
+  `use gpui_kit::*;`; the layers are `gpui_kit::component`, `gpui_kit::base`,
+  `gpui_kit::assets`, `gpui_kit::platform`.
+- **Framework owns behavior, application owns presentation.** Do not put
+  colors, sizing, or layout in `gpui-base`; do not put interaction behavior in
+  application styling code.
+- **Stable identity.** Repeated elements need domain-derived `ElementId`s, not
+  list indexes.
+- **No `pub` fields across the seam.** Public data types use builders and
+  reader methods.
+- **Spell `Context` out.** `cx` is GPUI's; name anything else after what it
+  holds.
+
+## Documentation
+
+- **Full reference**: fetch `https://gpui-kit.com/llms-full.txt`
+- **Per-component API**: fetch `https://gpui-kit.com/docs/components/{name}.md`,
+  e.g. `button.md`, `input.md`, `select.md`, `dialog.md`, `data-table.md`
+- **Any site page** can be fetched as Markdown by appending `.md` to the URL
+
+## Quick Reference
+
+Setup and examples: [references/usage.md](references/usage.md).
+
+```rust
+use gpui_kit::*;
+use gpui_kit::component::Root;
+
+gpui_kit::application()
+    .with_assets(gpui_kit::assets::Assets)
+    .run(|cx| {
+        gpui_kit::init(cx);                       // first, before anything else
+        // ... open_window(..., |window, cx| cx.new(|cx| Root::new(view, window, cx)))
+    });
+```
+
+- **Stateless** (`RenderOnce`): build in `render`:
+  `Button::new("save").primary().label("Save").on_click(|_, _, _| {})`
+- **Stateful**: hold `Entity<State>` in the view, pass a reference in `render`:
+  `let input = cx.new(|cx| InputState::new(window, cx));` then `Input::new(&self.input)`
+- **Sizes**: `.xsmall()` `.small()` `.medium()` (default) `.large()`
+- **Theme**: `cx.theme().primary` · `.background` · `.foreground` · `.border` · `.muted`
+- **Overlays**: `window.open_dialog(...)`, `open_sheet(...)`, `push_notification(...)`
+  via `gpui_kit::component::WindowExt`
+
+## Component Catalog
+
+Import paths are relative to `gpui_kit::component::`, so `input::{Input, InputState}`
+means `use gpui_kit::component::input::{Input, InputState};`. For the full API
+fetch the component's `.md` doc.
+
+### Input & Form
+
+| Component     | Import                                          | Notes                                        |
+| ------------- | ----------------------------------------------- | -------------------------------------------- |
+| `Input`       | `input::{Input, InputState}`                    | Stateful. Text, password, mask, validation   |
+| `Textarea`    | `input::{Textarea, TextareaState}`              | Stateful. Multi-line text                    |
+| `Editor`      | `input::{Editor, EditorState}`                  | Stateful. Code editor, `tree-sitter` feature |
+| `NumberInput` | `input::{NumberInput, NumberInputEvent}`        | Stateful. Numeric with step                  |
+| `OtpInput`    | `input::OtpInput`                               | Stateful. One-time password                  |
+| `Select`      | `select::{Select, SelectState}`                 | Stateful. Dropdown picker                    |
+| `Combobox`    | `combobox::{Combobox, ComboboxState}`           | Stateful. Searchable select                  |
+| `Checkbox`    | `checkbox::Checkbox`                            | Stateless. `on_click` receives `&bool`       |
+| `Switch`      | `switch::Switch`                                | Stateless. Toggle                            |
+| `Radio`       | `radio::{Radio, RadioGroup}`                    | Stateless.                                   |
+| `Slider`      | `slider::{Slider, SliderState}`                 | Stateful.                                    |
+| `Toggle`      | `button::Toggle`                                | Stateless.                                   |
+| `Rating`      | `rating::Rating`                                | Stateless.                                   |
+| `Stepper`     | `stepper::Stepper`                              | Stateless. Multi-step progress               |
+| `ColorPicker` | `color_picker::{ColorPicker, ColorPickerState}` | Stateful.                                    |
+| `DatePicker`  | `date_picker::{DatePicker, DatePickerState}`    | Stateful.                                    |
+| `Calendar`    | `calendar::{Calendar, CalendarState}`           | Stateful. Inline month view                  |
+| `Form`        | `form::{v_form, h_form, field}`                 | Layout container for form fields             |
+
+### Display & Feedback
+
+| Component   | Import                                    | Notes                                 |
+| ----------- | ----------------------------------------- | ------------------------------------- |
+| `Button`    | `button::{Button, ButtonGroup}`           | Stateless. Primary UI action          |
+| `Icon`      | `{Icon, IconName}`                        | Stateless. Lucide icons               |
+| `Badge`     | `badge::Badge`                            | Stateless.                            |
+| `Tag`       | `tag::Tag`                                | Stateless. Closable tags              |
+| `Avatar`    | `avatar::Avatar`                          | Stateless.                            |
+| `Label`     | `label::Label`                            | Stateless. Form label                 |
+| `Kbd`       | `kbd::Kbd`                                | Stateless. Keyboard key display       |
+| `Alert`     | `alert::Alert`                            | Stateless. Info/success/warning/error |
+| `Spinner`   | `spinner::Spinner`                        | Stateless. Loading indicator          |
+| `Skeleton`  | `skeleton::Skeleton`                      | Stateless. Loading placeholder        |
+| `Shimmer`   | `shimmer::{ShimmerText, ShimmerStyle}`    | Stateless. Streaming-text shimmer     |
+| `Marker`    | `marker::{Marker, MarkerVariant}`         | Stateless. Inline status marker       |
+| `Progress`  | `progress::{Progress, ProgressCircle}`    | Stateless.                            |
+| `Tooltip`   | `tooltip::Tooltip`                        | Via `.tooltip()` on elements          |
+| `HoverCard` | `hover_card::{HoverCard, HoverCardState}` | Stateful.                             |
+| `Clipboard` | `clipboard::Clipboard`                    | Stateless. Copy button                |
+| `TextView`  | `text::TextView`                          | `TextView::markdown(id, text)`, HTML too |
+| Image       | `gpui_kit::{img, ImageSource, ObjectFit}` | GPUI's `img()` element                |
+
+### Overlay & Popups
+
+| Component        | Import                                            | Notes                                    |
+| ---------------- | ------------------------------------------------- | ---------------------------------------- |
+| `Dialog`         | `dialog::Dialog` + `WindowExt`                    | Via `window.open_dialog(...)`            |
+| `AlertDialog`    | `WindowExt`                                       | Via `window.open_alert_dialog(...)`      |
+| `Sheet`          | `sheet::Sheet` + `WindowExt`                      | Side panel, via `window.open_sheet(...)` |
+| `Notification`   | `notification::Notification` + `WindowExt`        | Via `window.push_notification(...)`      |
+| `Popover`        | `popover::Popover`                                | Floating overlay                         |
+| `Menu`           | `menu::{PopupMenu, DropdownMenu}`                 | Context menus                            |
+| `DropdownButton` | `button::DropdownButton`                          | Button with dropdown menu                |
+| `Command`        | `command::{Command, CommandState, CommandGroup}`  | Stateful. Command palette                |
+| Focus trap       | `FocusTrapElement`                                | `.focus_trap(id, &handle)` on a container; `Dialog` and `Sheet` have it built in |
+
+### Navigation & Layout
+
+| Component         | Import                                                                   | Notes                     |
+| ----------------- | ------------------------------------------------------------------------ | ------------------------- |
+| `Tabs` / `TabBar` | `tab::{Tab, TabBar}`                                                     | Tabbed interface          |
+| `Sidebar`         | `sidebar::{Sidebar, SidebarMenu, ...}`                                   | App navigation panel      |
+| `TitleBar`        | `TitleBar`                                                               | Window title bar          |
+| `StatusBar`       | `status_bar::StatusBar`                                                  | Window status bar         |
+| `Breadcrumb`      | `breadcrumb::Breadcrumb`                                                 | Navigation breadcrumb     |
+| `Pagination`      | `pagination::Pagination`                                                 | Page navigation           |
+| `Accordion`       | `accordion::Accordion`                                                   | Collapsible sections      |
+| `Collapsible`     | `collapsible::Collapsible`                                               | Single collapsible        |
+| `GroupBox`        | `group_box::GroupBox`                                                    | Labeled container         |
+| `Resizable`       | `resizable::{h_resizable, v_resizable, resizable_panel, ResizableState}` | Draggable split panes     |
+| `Scrollbar`       | `scroll::Scrollbar`                                                      | Custom scrollbar          |
+
+### Data Display
+
+| Component         | Import                                          | Notes                         |
+| ----------------- | ----------------------------------------------- | ----------------------------- |
+| `DataTable`       | `table::{DataTable, TableState, TableDelegate}` | Stateful. Full-featured table |
+| `Table`           | `table::{Table, ...}`                           | Simpler table                 |
+| `VirtualList`     | `{v_virtual_list, h_virtual_list}`              | High-perf large lists         |
+| `List`            | `list::{List, ListState, ListDelegate}`         | Stateful. Searchable list     |
+| `Tree`            | `tree::{Tree, TreeState, TreeItem, TreeEntry}`  | Stateful. Hierarchy           |
+| `DescriptionList` | `description_list::DescriptionList`             | Key-value pairs               |
+| `Settings`        | `setting::Settings`                             | Settings panel                |
+
+### Chat & Messaging
+
+| Component         | Import                                                   | Notes                                 |
+| ----------------- | -------------------------------------------------------- | ------------------------------------- |
+| `Message`         | `message::{Message, MessageContent, MessageAlignment}`   | Stateless. Chat message row           |
+| `Bubble`          | `bubble::{Bubble, BubbleContent, BubbleVariant}`         | Stateless. Message bubble             |
+| `Attachment`      | `attachment::{Attachment, AttachmentContent, ...}`       | Stateless. File/media attachment card |
+| `MessageScroller` | `message_scroller::{MessageScroller, MessageScrollerState}` | Stateful. Auto-scrolling message list |
+
+### Charts
+
+| Component | Import                                                          | Notes                          |
+| --------- | --------------------------------------------------------------- | ------------------------------ |
+| `Chart`   | `chart::{AreaChart, BarChart, LineChart, PieChart, RadarChart}` | Bar, line, area, pie charts    |
+| `Plot`    | `plot::Plot`                                                    | `#[derive(IntoPlot)]` for data |
+
+## GPUI References
+
+Load the file for the mechanism the task touches. Each file starts with a
+contents line.
+
+| Topic                       | File                                                   | Load when                                                       |
+| --------------------------- | ------------------------------------------------------ | --------------------------------------------------------------- |
+| Actions & keybindings       | [action.md](references/gpui/action.md)                 | `actions!`, `bind_keys`, `on_action`, `key_context`             |
+| Async & background tasks    | [async.md](references/gpui/async.md)                   | `cx.spawn`, `background_spawn`, `Task`, async I/O               |
+| Context management          | [context.md](references/gpui/context.md)               | `App`, `Window`, `Context<T>`, `AsyncApp`                       |
+| Custom elements (low-level) | [element.md](references/gpui/element.md)               | `Element` trait, `request_layout`, `prepaint`, `paint`          |
+| Entity state                | [entity.md](references/gpui/entity.md)                 | `Entity<T>`, `WeakEntity`, state management                     |
+| Events & subscriptions      | [event.md](references/gpui/event.md)                   | `cx.emit`, `cx.subscribe`, `cx.observe`                         |
+| Focus & keyboard nav        | [focus-handle.md](references/gpui/focus-handle.md)     | `FocusHandle`, `track_focus`, Tab navigation                    |
+| Global state                | [global.md](references/gpui/global.md)                 | `Global` trait, `cx.set_global`, app-wide config                |
+| Layout & styling            | [layout-style.md](references/gpui/layout-style.md)     | `div()`, `h_flex()`, `v_flex()`, flexbox, overflow, positioning |
+| ElementId                   | [element-id.md](references/gpui/element-id.md)         | `ElementId`, `.id()`, uniqueness rules, stateful elements       |
+| Testing                     | [test.md](references/gpui/test.md)                     | `#[gpui_kit::test]`, `TestAppContext`, `VisualTestContext`      |
+
+Deep dives, for when the topic file is not enough:
+
+- **Element trait**: [element-api.md](references/gpui/element-api.md) (complete API, hitbox, events) ·
+  [element-patterns.md](references/gpui/element-patterns.md) (text, interactive, container, composite) ·
+  [element-examples.md](references/gpui/element-examples.md) (full examples) ·
+  [element-best-practices.md](references/gpui/element-best-practices.md) (performance, state, pitfalls) ·
+  [element-advanced.md](references/gpui/element-advanced.md) (custom layouts, async updates, virtual lists)
+- **Entities**: [entity-api.md](references/gpui/entity-api.md) (complete API, lifecycle) ·
+  [entity-patterns.md](references/gpui/entity-patterns.md) (model-view, cross-entity, observer) ·
+  [entity-best-practices.md](references/gpui/entity-best-practices.md) (memory, performance) ·
+  [entity-advanced.md](references/gpui/entity-advanced.md) (collections, registry, debounce, state machines)
+- **Testing**: [test-examples.md](references/gpui/test-examples.md) (organization, setup, assertions, running tests) ·
+  [test-reference.md](references/gpui/test-reference.md) (re-entrancy, property tests, mocking)

--- a/.claude/skills/gpui-kit/references/coding-guides.md
+++ b/.claude/skills/gpui-kit/references/coding-guides.md
@@ -1,0 +1,891 @@
+---
+title: Coding Guides
+description: Architecture and coding conventions for maintainable GPUI Kit applications
+order: -2.2
+---
+
+# Coding Guides
+
+This guide describes the application architecture and code patterns that have
+proved durable in GPUI Kit. It is written for both engineers and coding
+agents. Read [Design Guides](./design-guides.md) first: code structure should
+preserve product intent, not replace it.
+
+This is a normative guide. **Must** marks lifecycle, correctness, or ecosystem
+constraints; **should** is the default architecture and requires a concrete
+reason to depart from it. Current source and API docs remain authoritative for
+exact signatures.
+
+## Architecture at a glance
+
+<img class="architecture-light" src="/application-layers-light.svg?v=20260822-16" alt="GPUI application architecture layers">
+<img class="architecture-dark" src="/application-layers-dark.svg?v=20260822-16" alt="GPUI application architecture layers">
+
+Dependencies point downward. Higher layers own domain meaning and orchestration;
+lower layers own reusable presentation or behavior. Do not make a reusable
+component depend on an application screen, or make `gpui-base` depend on a
+theme from GPUI Component.
+
+Use these boundaries:
+
+- **app shell:** compose windows and feature crates while keeping feature logic out;
+- **feature crate:** keep one capability's model, services, views, commands, dialogs,
+  and workflow behind one public boundary;
+- **app component:** a repeated domain-aware pattern;
+- **gpui-component:** themed, general-purpose UI;
+- **gpui-base:** reusable behavior and geometry without product presentation.
+
+### Organize large applications by capability
+
+In a large Rust application, a feature should usually be a crate, not another
+file in a global `views`, `models`, or `modals` directory. Keep the model,
+views, commands, dialogs, and workflow for one capability together. A dialog
+that edits a workspace belongs to the workspace feature; only the reusable
+dialog primitive belongs to the UI library.
+
+```text
+crates/
+├── app/
+│   └── src/main.rs             # Compose windows and features
+├── workspace/
+│   └── src/
+│       ├── lib.rs              # The feature's public boundary
+│       ├── model.rs
+│       ├── commands.rs
+│       ├── workspace_view.rs
+│       └── rename_dialog.rs
+├── search/
+│   └── src/
+│       ├── lib.rs
+│       ├── model.rs
+│       ├── commands.rs
+│       ├── search_view.rs
+│       └── filters.rs
+├── settings/
+│   └── src/
+│       ├── lib.rs
+│       ├── model.rs
+│       ├── settings_view.rs
+│       └── account_dialog.rs
+└── shared/
+    └── src/
+        ├── lib.rs
+        └── recent_items.rs     # A stable capability with multiple owners
+```
+
+Do not invert this into global `models/`, `views/`, `modals/`, and `commands/`
+directories. Those folders classify files by implementation role while
+scattering every feature across the application.
+
+The application shell composes feature crates but contains little feature
+logic. A feature may depend on stable shared capabilities and UI foundations;
+it must not depend on the shell or reach into a sibling feature's internals.
+When two features need to communicate, prefer an explicit command, event, data
+type, or small shared service over a dependency between their views. Extract a
+shared crate only after the capability has a coherent name and more than one
+real owner.
+
+Crate boundaries are engineering boundaries. They let Cargo rebuild and test a
+smaller dependency subgraph, make ownership visible in `Cargo.toml`, and limit
+the review and regression surface of a change. They also make removal honest:
+a feature that cannot be detached without searching through global view and
+modal directories was never isolated.
+
+Do not create a crate for every screen or helper. Split where a capability has
+its own state and lifecycle, a stable public seam, or enough implementation to
+benefit from independent compilation and tests. Keep dependencies acyclic and
+pointing toward smaller, more stable crates.
+
+## Bootstrap and root ownership
+
+Initialize GPUI Component once, before creating component-backed views, and put
+`Root` at the first level of each window:
+
+```rust
+app.run(move |cx| {
+    gpui_kit::init(cx);
+
+    cx.spawn(async move |cx| {
+        cx.open_window(WindowOptions::default(), |window, cx| {
+            let workspace = cx.new(|cx| Workspace::new(window, cx));
+            cx.new(|cx| Root::new(workspace, window, cx))
+        })
+        .expect("failed to open window");
+    })
+    .detach();
+});
+```
+
+`Root` coordinates window-level component facilities such as overlays and
+notifications. Do not create a separate root for each page inside one window.
+It also coordinates modal focus restoration, focus traps, tooltip/menu layers,
+and window-scoped text selection. Bypassing it can produce behavior that looks
+correct at rest but fails when overlays nest or focus changes quickly.
+
+## Understand GPUI's phases and contexts
+
+GPUI is retained state with declarative rendering. An entity survives across
+frames; the element tree returned by `render` is a fresh description of the
+current frame. Keep that distinction explicit.
+
+- `Context<Self>` mutates the current entity, creates listeners tied to it,
+  emits its events, and notifies its observers.
+- `App` gives access to application globals and entity reads/updates without
+  implying ownership by the rendered element.
+- `Window` owns focus, actions, input dispatch, element-keyed state,
+  measurement, and animation-frame requests for that window.
+- layout, prepaint, and paint are later phases; use their hooks only when
+  resolved geometry is genuinely required.
+
+Never retain `&mut Window`, `&mut App`, or `&mut Context<_>` beyond the call in
+which it is provided. Retain typed handles—`Entity`, `WeakEntity`,
+`FocusHandle`, scroll handles, or domain IDs—instead.
+
+## Choose the right unit
+
+### Use `RenderOnce` for value-like elements
+
+Use a `RenderOnce`/`IntoElement` component when all inputs can be supplied by
+the caller and the element does not need to retain application state between
+frames. This is the normal choice for presentational wrappers and small
+controls.
+
+```rust
+#[derive(IntoElement)]
+struct EmptyState {
+    title: SharedString,
+}
+
+impl RenderOnce for EmptyState {
+    fn render(self, _: &mut Window, cx: &mut App) -> impl IntoElement {
+        div()
+            .v_flex()
+            .gap_2()
+            .items_center()
+            .text_color(cx.theme().muted_foreground)
+            .child(self.title)
+    }
+}
+```
+
+### Use `Entity<T>` for retained behavior
+
+Use an entity-backed `Render` view when behavior spans frames or needs
+observation, subscriptions, focus, async work, history, measurement, or
+incremental updates. Store entities in an owning view rather than recreating
+them in `render`.
+
+```rust
+struct SearchView {
+    query: Entity<InputState>,
+}
+
+impl SearchView {
+    fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
+        let query = cx.new(|cx| InputState::new(window, cx).placeholder("Search…"));
+        Self { query }
+    }
+}
+```
+
+Do not turn every visual fragment into an entity. Entity boundaries have
+lifecycle and coordination costs; use them where retained identity matters.
+
+### Elements, views, and behavior systems are different
+
+Do not force every component into one template. The ecosystem contains:
+
+- semantic elements such as Button, Checkbox, Link, and Tabs;
+- compound behavior roots such as Dialog, Popover, Select, and Combobox;
+- entity-backed systems such as Input, Table, Tree, Dock, and notifications;
+- infrastructure such as positioning, virtualization, scrolling, focus traps,
+  motion, history, and measurement.
+
+An element may be internally complex and still be value-like to its caller. A
+stateful system may expose render callbacks so applications own presentation
+without reimplementing behavior. Choose the public seam from the behavior,
+not from how many `div`s appear in its renderer.
+
+## State ownership
+
+Put each state in the narrowest owner that can keep it correct:
+
+- domain state belongs to a model or feature view;
+- transient view state belongs to the view that renders it;
+- reusable behavioral state belongs to the component state designed for it;
+- tiny element-local state may use GPUI keyed element state;
+- shared application services may be stored as GPUI globals.
+
+Prefer controlled values for ordinary selection and toggles: pass the current
+value into the component, receive a requested change, update the owner, and
+render again. A callback reports intent; it should not create a second hidden
+source of truth.
+
+```rust
+Checkbox::new("show-hidden")
+    .checked(self.show_hidden)
+    .label("Show hidden files")
+    .on_click(cx.listener(|this, checked, _, cx| {
+        this.show_hidden = *checked;
+        cx.notify();
+    }))
+```
+
+Call `cx.notify()` after a mutation that changes rendering. Use `cx.emit(...)`
+for a semantic event that an owner should handle, and `cx.subscribe(...)` or
+`cx.observe(...)` when the lifetime should follow an entity. Keep returned
+subscriptions alive when the API requires it.
+
+Do not notify merely because a value was read or derived. Avoid unconditional
+notification from `render`; it schedules another render and can create a
+permanent redraw loop. When several fields form one invariant, update them
+together and notify once. A reusable state type that cannot receive a context
+should make that limitation explicit and require its owner to emit/notify.
+
+### Avoid state feedback loops
+
+Text input, selection, filters, and controlled popups commonly have two paths:
+an external owner updates the value, and user interaction requests a new value.
+Do not send an owner-supplied value back through the user callback during sync.
+Track the origin or compare coherent snapshots so each logical change is
+reported once. Make callbacks re-entrancy-safe when a callback can synchronously
+close, replace, or update the component that invoked it.
+
+## Stable identity
+
+An `ElementId` is part of behavior. It gives an element stable identity and keys
+element-local or component state. A component may also use it as one input to
+its own focus, measurement, or animation identity; focus and scrolling are
+otherwise owned by their dedicated handles.
+
+- Use stable domain IDs for rows, tabs, tree nodes, and repeated controls.
+- Namespace child IDs with their owning object when the same control repeats.
+- Never derive identity from a translated label or a mutable list index when
+  items can be inserted or reordered.
+- Do not generate a fresh random ID during `render`.
+
+```rust
+Button::new(("delete-project", project.id))
+    .danger()
+    .label("Delete")
+```
+
+A changed ID means a changed UI identity. Treat that reset as deliberate.
+
+The same rule applies to transition channels, overlay tokens, scroll handles,
+and persistence IDs. If two independently retained behaviors share a key, they
+can overwrite each other's state; if one behavior changes keys every frame, it
+never accumulates state.
+
+## Rendering and composition
+
+Keep `render` declarative: read current state, derive presentation values, and
+compose elements. Move domain operations, parsing, and non-trivial mutation to
+named methods or services.
+
+```rust
+impl Render for ProjectView {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .v_flex()
+            .size_full()
+            .child(self.render_toolbar(cx))
+            .child(self.render_content(cx))
+    }
+}
+```
+
+Extract a render helper when it names a meaningful region and reduces the
+amount of state a reader must hold at once. Extract a new component when the
+region has its own reusable contract or retained lifecycle—not merely because
+a builder chain is long.
+
+Use GPUI Component's fluent traits consistently (`Sizable`, `Disableable`,
+`Selectable`, and component-specific builders). Prefer `.when(...)` and
+`.when_some(...)` for small conditional refinements; use ordinary Rust control
+flow when branches represent substantially different interfaces.
+
+Compose from the standard semantic component before building a custom surface.
+Do not reproduce a menu, select, dropdown, or command palette from generic
+`div`s merely to match one screenshot. Reusing the component preserves its
+item geometry, focus transfer, keyboard navigation, selection, disabled state,
+dismissal, and accessibility contract. If the standard component cannot
+express a recurring valid pattern, improve its explicit API instead of styling
+arbitrary descendants at each call site.
+
+Render callbacks supplied by application code should be side-effect-free. A
+list item renderer, menu builder, or dock panel renderer may run whenever its
+owner needs to measure or redraw. It must not perform a business operation,
+append data, or register an unbounded subscription.
+
+## Behavior and presentation boundary
+
+The durable Base rule is:
+
+> Base owns reusable behavior and the geometry required to implement it. The
+> presentation layer owns the product's visual language.
+
+“Headless” does not mean “one empty `div`.” Popup collision, keyboard
+navigation, editing, virtualization, resize arithmetic, focus trapping, and
+dock reconciliation require internal structure and state. Moving that work to
+every caller would not create flexibility; it would duplicate fragile
+behavior.
+
+Conversely, Base must not choose brand colors, typography, density, final
+icons, component variants, or application composition. Expose presentation
+through `Styled`, typed semantic-state styles, explicit parts, child slots, and
+item renderers. Do not inspect arbitrary descendants to discover titles,
+descriptions, or close buttons—make semantic parts explicit.
+
+## Theme and styling
+
+Read semantic values from the active theme and apply layout with GPUI's
+`Styled` methods:
+
+```rust
+div()
+    .bg(cx.theme().background)
+    .text_color(cx.theme().foreground)
+    .border_1()
+    .border_color(cx.theme().border)
+    .rounded(cx.theme().radius)
+```
+
+Rules:
+
+- do not hard-code product colors, corner radii, spacing, or control geometry;
+- application code must not introduce raw hex, `rgb`/`rgba`, or `hsla`; read a
+  semantic color from `cx.theme()` or add the missing role to the product theme;
+- application layout should use GPUI's rem-based scale helpers (`p_2()`,
+  `gap_3()`, `w_64()`, `text_sm()`) instead of direct `px(...)` values;
+- use semantic tokens for meaning, not palette position;
+- keep state-independent geometry in the ordinary builder chain;
+- use GPUI `hover`, `active`, `focus`, and `focus_visible` modifiers for
+  runtime interaction states;
+- use a component's semantic state styles for checked, selected, pressed, or
+  disabled appearance;
+- keep popup ownership in explicit state so its trigger can render the open or
+  pressed appearance until dismissal;
+- guard hover/active refinements when a disabled control must not react;
+- keep component variants few and meaningful rather than adding a variant for
+  every call site.
+- bind primary styling to the decision area's real default commit and Enter
+  action; do not derive it from action count, frequency, or toolbar position.
+- keep Badge and Alert variants semantic and scarce. Ordinary metadata stays
+  neutral; do not map every enum case or section to a different color merely
+  because a variant exists.
+
+The effective precedence is instance style, active semantic value states,
+disabled state, then GPUI runtime interaction refinements. Later layers only
+replace fields they set.
+
+Prefer `Theme::semantic_tokens()` for new application-owned presentation. The
+semantic token surface contains generic color roles plus radius, spacing,
+typography, and shadow scales; it deliberately avoids component names. Legacy
+component-specific theme values still exist for compatibility but should not
+become the extension point for every application widget.
+
+There is one current ownership caveat: `Theme::spacing_tokens()` projects the
+default scale, and `Theme::apply_semantic_tokens(...)` does not store custom
+spacing or elevation scales. An application that customizes those scales must
+retain its own `SemanticThemeTokens` (or narrower design-system state) and make
+that state available to its components. Do not write a custom spacing snapshot
+into the global theme and expect a later `cx.theme().semantic_tokens()` call to
+return it.
+
+If code mutates the global GPUI Component theme directly, call
+`Theme::sync_base(cx)` afterward so Base-owned scrollbars and resize handles
+receive the new projection. `Theme::change(...)` performs this projection as
+part of a complete theme change.
+
+An outward focus ring needs physical room. An ancestor with
+`overflow_hidden()` clips it. Prefer layouts that leave room; if a product must
+clip heavily, use the theme's focus-ring policy and retain the focused border
+instead of silently hiding all keyboard focus.
+
+### Base font is the application zoom control
+
+`Root::render` calls `window.set_rem_size(cx.theme().font_size)`. Therefore the
+theme's base font is not only body typography; it is the reference length for
+the application's rem-based design scale. This deliberately follows the useful
+part of Tailwind's model: named type, spacing, and size steps share one relative
+base instead of becoming unrelated pixel constants.
+
+Change zoom by updating the base font and refreshing the window:
+
+```rust
+Theme::global_mut(cx).font_size = px(18.);
+Theme::sync_base(cx);
+window.refresh();
+```
+
+The base font itself is a pixel value because it anchors the scale. Descendant
+application UI should normally use relative helpers—`text_sm()`, `gap_2()`,
+`px_3()`, `h_8()`, `size_4()`—so type, whitespace, controls, and icons respond
+together. A custom component that combines rem-based text with fixed-pixel
+padding or icon geometry must document why that part should not zoom.
+
+Treat every direct `px(...)` and raw color constructor in application UI as a
+review finding. Accept it only for a documented physical/platform boundary,
+measured runtime geometry, raster/data color, or the theme/token definition
+itself. Convenience and matching a screenshot are not valid exceptions.
+
+Anything cached from resolved layout must include `window.rem_size()` in its
+invalidation key, directly or through a revision that changes with it. This
+includes wrapped row heights, text shaping/layout, virtual-list measurement,
+popup and dialog geometry, icon sizing derived from text, and custom canvas
+metrics. The Command component's variable-height rows are an ecosystem example:
+they remeasure when rem changes because the same fixed width wraps differently
+at a larger base font.
+
+Do not confuse this application zoom with Dock panel zoom. Dock zoom is a
+stateful layout operation that makes one tab group or tile fill the DockArea
+while keeping the container chrome and the way back out. It must not modify the
+window rem size.
+
+## Events, actions, and focus
+
+Use pointer callbacks for pointer-specific behavior. Use GPUI Actions for
+commands that should support key bindings, menus, or dispatch from multiple
+inputs. Keep action handlers close to the view that owns the command.
+
+Model one logical desktop command once. A toolbar Button, `DropdownMenu` item,
+`ContextMenu` item, menu-bar item, and key binding should dispatch the same
+Action or call the same owner method instead of copying five mutations. Derive
+their label, icon, shortcut, and enabled state from one command policy where
+practical, so the entry points cannot disagree. The menu owns navigation and
+dismissal; the feature owner still owns whether the command is allowed and
+what it does.
+
+Preserve semantic roles in the element choice. Use `Button` for commands even
+when the desired treatment is quiet—select `outline`, `ghost`, or an icon
+presentation instead of replacing it with `Link`. GPUI Kit applications
+reserve `Link` for targets opened by a browser or mail client, such as a URL,
+web document, or email address. Use the relevant navigation component for an
+in-app destination and `Button`/`Action` for a command. This is a product
+convention, not a limitation of `gpui_kit::base::Link`, whose `open_with` seam can
+route a destination elsewhere.
+
+Only stop propagation when a nested interaction must prevent its parent from
+handling the same event. Blanket propagation stops break menus, selection,
+dragging, and window-level commands in ways that are difficult to diagnose.
+
+Make focus ownership explicit:
+
+- retain a `FocusHandle` in the entity that owns keyboard interaction;
+- register key contexts and actions on the appropriate focused region;
+- transfer focus when opening an overlay and restore it on dismissal;
+- render a visible `focus_visible` state;
+- do not request focus unconditionally from `render`.
+
+Attach a `key_context` and its `on_action` handlers to the same focused region.
+Bindings are contextual: a registered Action without the intended focus path
+is not a working keyboard interaction. Composite widgets should implement the
+complete navigation model—arrow movement, Home/End or page movement where
+appropriate, confirmation, cancellation, and Tab behavior—rather than a few
+isolated shortcuts.
+
+Modal surfaces must trap focus and restore the previous valid focus target on
+dismissal. Nested overlays dismiss from the top. Handle rapid close/open
+sequences without restoring focus through an intermediate, already-closing
+surface.
+
+## Async work and side effects
+
+Start async work from an event, lifecycle hook, or named method—not as an
+unconditional side effect of `render`. Capture weak entities when work should
+not keep a closed view alive. When the task completes, update state through the
+GPUI context, handle the case where the entity or window no longer exists, and
+notify once after the coherent state change.
+
+Represent async operations with explicit states such as idle, loading, loaded,
+and failed. Preserve usable previous data during refresh when possible. Prevent
+duplicate destructive submissions and surface recoverable errors in the UI;
+do not rely on logs as user feedback.
+
+Use background executors for expensive parsing or computation, but keep GPUI
+entity mutation on the appropriate application context. Results can arrive
+after the request, document, view, or selection has changed; attach a revision
+or identity and reject stale work rather than applying it to new state.
+
+## Layout, measurement, and scrolling
+
+`h_flex` centres its children on the cross axis; `v_flex` leaves flexbox's
+default, `stretch`. This matches Zed's `h_flex`, and it is what a row of
+controls wants, so a row of icon and label says nothing. It is not what a row
+of full-height columns wants: a column placed in a bare `h_flex` does not fill
+the row's height, so a column taller than the row is centred and its top —
+commonly a header — is clipped off the top of the window, with nothing near the
+column to say why. A row whose children are columns says `items_stretch()`:
+
+```rust
+h_flex()
+    .items_stretch()
+    .size_full()
+    .child(sidebar)
+    .child(content)
+```
+
+Most UI should use GPUI layout rather than measuring itself. Measurement is a
+deep behavior tool for popups, virtualization, editors, resize handles, charts,
+and similar components whose correctness depends on resolved geometry.
+
+- Put measurement and geometry in the layer that owns the behavior.
+- Observe bounds in prepaint only when ordinary layout cannot express the
+  relationship.
+- Never mutate unrelated application state every prepaint.
+- Treat measured data as frame- or revision-scoped; it can become stale after
+  typography, rem size, width, theme, or content changes.
+- Centralize shared geometry such as popup flipping and viewport clamping so
+  every overlay follows the same edge policy.
+
+For alignment invariants, prefer construction over correction: sibling regions
+should consume the same spacing token or shared inset instead of repeating
+equivalent literals. Add geometry assertions or visual regression coverage for
+critical repeated edges, columns, and gaps. Exercise more than the default
+window: rem zoom and display scaling can turn fractional coordinates into a
+one-physical-pixel drift even when the default screenshot looks aligned.
+
+Measure the resolved result when reviewing precision, but do not encode a
+measured correction as a raw `px(...)` nudge. Trace the mismatch to duplicated
+padding, nested insets, border ownership, font metrics, or rounding, then fix
+the structural owner.
+
+`h_flex()` and `v_flex()` are not mirror images: `h_flex()` centers its
+children on the cross axis, `v_flex()` leaves them stretching. A column placed
+in a row therefore takes its content's height, not the row's, and a column
+taller than the row is centered — its header is pushed off the top edge and
+clipped. Give a full-height column `h_full()`, or give the row `items_start()`
+or `items_stretch()`, whenever the child owns a header, a footer, or a scroll
+region that must resolve against the row's height.
+
+Every scrollable region must have one owner. In flex layouts, apply
+`min_w_0()` or `min_h_0()` to the flexible child that is allowed to shrink.
+A flex item only drops its content-based automatic minimum size when its own
+overflow is not visible, so an ordinary flexible child refuses to shrink around
+long content until you say so. `Scrollable` handles this for its own wrapper,
+but a plain `div` between it and the flex container still needs the minimum
+released. Avoid accidental nested scrolling; route wheel input to the intended
+axis and preserve platform/wasm differences when an API is not portable.
+
+Attach `Scrollable` to the element that owns the full panel, editor, or window
+viewport so its scrollbar resolves against the region edge. Put content inset
+inside that scroll owner rather than wrapping the scroll owner in a padded
+container. A scrollbar floating between content and the panel boundary usually
+reveals the wrong scroll owner or padding on the wrong layer.
+
+## Lists, tables, and large data
+
+Use virtualization when data can grow beyond a small, bounded collection. Keep
+row identity separate from visible position and avoid cloning the full data set
+on every render. Let a stateful list or table own navigation, selection, scroll
+coordination, and visible-range calculation while item renderers own row
+presentation.
+
+Separate:
+
+- source data and domain IDs;
+- filtering/sorting state;
+- selection state;
+- viewport/scroll state;
+- row rendering.
+
+This keeps updates local and prevents the view tree from becoming the data
+model.
+
+Virtualization is a behavioral contract, not just a performance switch. Item
+measurement must be invalidated when width, typography, rem size, or row
+content changes. Keyboard selection and scroll-to-item must operate in model
+coordinates even when most elements do not exist in the current frame.
+
+## Public API design
+
+For reusable components:
+
+- constructors should establish valid defaults;
+- builders take and return `Self` and use domain language;
+- callbacks describe requested changes and include pointer events only when
+  modifiers or pointer details are meaningful;
+- evolvable behavioral seams use private fields, builders for construction,
+  and readers for inspection;
+- boolean readers use `is_` or `has_` where a same-named builder exists;
+- non-boolean setters use `with_` when readers need the plain field name;
+- explicit compound parts are preferable to inspecting arbitrary descendants;
+- adding reusable behavior must not force a product-level visual choice.
+
+Private fields are the default for behavioral state that must evolve without
+breaking callers. Public fields are appropriate for deliberately record-like
+configuration, theme tokens, geometry, and serialized schemas when direct
+construction is part of the contract and the compatibility cost is accepted.
+Use `#[non_exhaustive]` when callers may inspect a record but should not depend
+on exhaustive construction or matching.
+
+Keep public module paths stable while reorganizing internals: use a module seam
+with deliberate re-exports so folders can change without forcing downstream
+imports to change. Prefer platform control terminology and established project
+naming over web-framework vocabulary.
+
+## Platform and capability boundaries
+
+Do not assume every native or web target supports the same facility. Window
+decorations, accessibility bridges, system notifications, clipboard behavior,
+scroll gestures, fonts, and timing can differ. Put platform-specific code
+behind a narrow capability seam and define the fallback behavior.
+
+A platform branch must preserve the semantic contract even if presentation
+differs. For example, a system notification may have different retraction
+support, but the application still needs a coherent delivery state. Test both
+the shared state machine and the platform adapter where possible.
+
+## File and naming conventions
+
+- Name views and entities after product concepts: `ProjectList`,
+  `ProjectEditor`, `SettingsState`.
+- Name event handlers after intent: `confirm_delete`, `open_project`,
+  `on_query_changed`.
+- Keep one main responsibility per module; split a file when state ownership or
+  lifecycle can no longer be understood without reading unrelated behavior.
+- Keep component module, state, events, and focused tests together when they
+  change together.
+- Document invariants and surprising lifecycle constraints; do not narrate
+  obvious builder calls.
+- Use `rustfmt` and satisfy the workspace's Clippy rules. Avoid broad `allow`
+  attributes that conceal unrelated warnings.
+
+### Vocabulary is part of the API
+
+Use the same word for the same concept across components. Before naming a new
+method, search GPUI, `gpui-base`, and GPUI Component for the established term;
+prefer macOS/Windows control terminology where the ecosystem has no precedent.
+Localized documentation preserves exact API identifiers and established UI
+framework terms when translation would reduce precision. Format identifiers as
+code, explain retained terms when needed, and do not mix languages merely to
+make ordinary prose sound technical.
+
+| Concept | Naming pattern | Example |
+| --- | --- | --- |
+| Value-like rendered control | noun | `Button`, `Checkbox`, `Tab` |
+| Retained behavioral model | `<Control>State` | `InputState`, `TableState` |
+| Imperative shared reference | `<Control>Handle` | `DialogHandle`, scroll handle |
+| Semantic notification | `<Control>Event` | `TableEvent`, `SelectEvent` |
+| Keyboard command | verb or intent noun | `Confirm`, `Cancel`, `SelectNext` |
+| Pluggable data/behavior owner | `<Role>Delegate` / `<Role>Provider` | `TableDelegate`, `CompletionProvider` |
+| Application-supplied presentation | `render_<part>` or `<part>_renderer` | `render_item` |
+| Construction | `new`, or a semantic constructor | `new`, `horizontal`, `vertical` |
+| Fluent property | noun/adjective | `label`, `disabled`, `selected`, `placement` |
+| General non-boolean replacement builder | `with_<field>` | `with_size`, `with_mode` |
+| In-place mutation | `set_<field>` | `set_items`, `set_selected_index` |
+| Boolean reader | `is_<adjective>` / `has_<noun>` | `is_open`, `is_closable`, `has_selection` |
+| Plain value reader | field noun | `placement`, `selected_value` |
+| Callback registration | `on_<event or intent>` | `on_click`, `on_open_change` |
+| Rendering a named region | `render_<region>` | `render_toolbar`, `render_content` |
+
+For new APIs, fluent builders omit `set_` because they consume and return
+`Self`; mutation through `&mut self` uses `set_`. Preserve established public
+names when changing them would cause needless churn. Existing builder names
+such as `set_position` are compatibility exceptions, not patterns for new APIs.
+
+A boolean reader is either `has_<noun>`, when the value holds something, or
+`is_<adjective>`, when it describes a state or a permission. Reach for the
+adjective whenever the action has one: `is_closable` over `can_close`,
+`is_zoomable` over `can_zoom`, `is_copyable` over `can_copy`. When the action
+is a verb phrase with no adjective form, name the thing it needs instead:
+`has_definition`, not `can_go_to_definition`. Do not add new `can_` readers.
+
+Boolean builders may use the field name (`disabled(bool)`) while their readers
+use `is_disabled()`. For a public seam struct containing non-boolean fields,
+use `with_item_ix(...)` for construction and `item_ix()` for reading so setter
+and getter names never collide. Prefer `_ix` for new local or internal
+zero-based indices, preserve established public terms such as `selected_index`,
+and do not introduce `_idx`. If callers never construct the seam value, do not
+publish a builder merely for symmetry.
+
+### Let the enclosing name carry the context
+
+A name is read inside something. A field is read inside its type and a parameter
+inside its method, so neither repeats what encloses it: `with_item_ix(ix)`, not
+`with_item_ix(item_ix)`.
+
+Keep one type's fields at the same level of abbreviation. A single field spelled
+out in full becomes the odd one out, and a reader goes looking for the
+distinction that made it different. Because a builder is named `with_<field>`,
+shortening a field shortens its builder with it and the pair stays matched.
+
+Shorten only where the enclosing name really does disambiguate. When a short
+form is also the established term for a *different* quantity elsewhere in the
+ecosystem, say which one you mean in the doc comment rather than lengthening the
+identifier — the doc is read at the call, and it can explain what a longer name
+could only hint at.
+
+### Use precise domain words
+
+- **selected** is persistent membership or the active item; **focused** is the
+  current keyboard target; **hovered** is pointer presence; **confirmed** is an
+  activation result. Never use them interchangeably.
+- **open/close** describes an overlay or disclosure state; **show/hide** is for
+  transient presentation requests; **expand/collapse** describes structure.
+- **disabled** prevents interaction; **read-only** permits navigation and
+  selection but prevents editing; **loading** prevents duplicate work while an
+  operation is pending.
+- **index** is a current positional coordinate; **id** is stable identity;
+  `IndexPath` represents hierarchical position. Do not persist or key
+  reorderable data by index.
+- **value** is controlled domain data; **presentation** is a read-only snapshot
+  prepared for rendering; **state** is retained behavior.
+- **placement** is a side or anchor policy; **position** is resolved geometry.
+- **size** is a semantic control tier; **width/height/bounds** are geometry.
+- **child/children** follows GPUI composition; named slots such as `header`,
+  `footer`, `trigger`, and `content` carry additional semantics.
+
+Avoid vague public names such as `data`, `item2`, `handle_action`, `update_ui`,
+`process`, `manager`, or `config` when a narrower domain term exists. `Manager`
+is appropriate only when a type truly coordinates a collection or lifecycle,
+as `ToastManager` does.
+
+### Type and module style
+
+- Rust types and Actions use `UpperCamelCase`; modules, functions, methods,
+  fields, and local variables use `snake_case`; constants use
+  `SCREAMING_SNAKE_CASE`.
+- A module named after a component owns its public seam. Internal folders may
+  split state, element, geometry, platform adapter, and tests without leaking
+  those folder names into imports.
+- Use singular module names for one component concept and established
+  ecosystem names for families (`input`, `table`, `dock`).
+- Suffix type-erased wrappers with `Any` only when they erase a real type
+  boundary, such as `AnyInputState` or `AnyElement`.
+- Suffix identifiers with `Id`, zero-based indices with `ix`, and collections
+  with meaningful plurals. Do not alternate `idx`, `index`, and `ix` in one
+  subsystem.
+- Name predicates positively when possible. A positive `enabled`/`visible`
+  contract is easier to compose than multiple negatives, but preserve
+  established API terms such as `disabled` where they match control semantics.
+
+### Callback and event wording
+
+Use `on_click` only for a genuine click-level contract. A controlled semantic
+primitive in Base should prefer `on_change(next_value, ...)`; a styled
+compatibility component may retain `on_click` when pointer details or existing
+API expectations matter. Do not invent a `ClickEvent` for a model-driven
+change.
+
+Name before/after lifecycle hooks precisely. `on_will_change` can veto or
+prepare; `on_change` observes a requested/current value contract; `on_confirm`
+commits a choice; `on_dismiss` closes a transient surface. Document whether a
+callback runs before internal state changes, after them, or instead of them,
+and whether it may synchronously re-enter the component.
+
+### Documentation and copy style
+
+Public docs should begin with what a type does and who owns its state. Examples
+must use current, compilable APIs and show stable IDs. Document defaults,
+platform limitations, focus behavior, callback ordering, and any requirement
+to call `notify`, `emit`, or a theme synchronization method.
+
+Follow the [interface-language rules](./design-guides.md#interface-language) for
+labels, commands, confirmation dialogs, capitalization, and ellipses. Keep one
+canonical term for each domain object, command, and state.
+
+Translation keys describe stable intent (`dialog.delete_project.title`), not a
+source-language sentence or a screen coordinate. Never assemble a sentence
+from translated fragments or reuse one key for meanings that happen to share
+the same English text.
+
+Localize intent, not syntax. Give every locale control over word order,
+pluralization, punctuation, and the amount of context it needs. Review strings
+inside the component and with realistic data. Tests or linting should catch
+missing keys, unintended CJK text in English resources, three-dot ellipses,
+unreviewed ALL CAPS, and inconsistent fixed terms; human review still decides
+whether repetition is justified by context. Verify every string inside its
+component with realistic content, text expansion, and application zoom.
+
+## Testing strategy
+
+Test at the lowest layer that can prove the behavior:
+
+1. pure tests for state transitions, geometry, parsing, and ordering;
+2. GPUI context tests for entities, events, and subscriptions;
+3. `VisualTestContext` interaction tests for focus, keyboard, pointer, layout,
+   and rendered state;
+4. example or application smoke tests for complete workflows.
+
+For an interactive component, cover the semantic contract rather than its
+implementation details: pointer and keyboard activation, controlled value
+changes, disabled behavior, focus movement, event count/order, stable identity,
+and important empty or failure states. Add a regression test before fixing a
+bug whenever the failure can be reproduced deterministically.
+
+For UI behavior that depends on the real window system, test through the
+accessibility tree by role, label, value, enabled state, focus, and selection.
+Re-read the tree after every state-changing action because element indexes are
+snapshots. Use screenshots for visual facts the semantic tree cannot express;
+use coordinate input only as a fallback. Report automated and manual evidence
+separately.
+
+## Performance rules
+
+- Do not mutate state or notify unconditionally in `render`.
+- Avoid rebuilding entities, subscriptions, focus handles, and expensive data
+  structures per frame.
+- Notify the narrowest owning entity after a coherent state change.
+- Virtualize long collections and render only the visible range.
+- Avoid cloning large strings or collections solely to satisfy a closure;
+  capture stable handles or shared data.
+- Measure before adding caches. A cache must have a clear invalidation owner.
+- Keep animation work bounded and honor reduced motion.
+
+## Common failure modes
+
+Avoid these patterns:
+
+- one entity containing the entire application's unrelated state;
+- business logic and network requests embedded in a long `render` method;
+- random or index-based `ElementId` values for reorderable content;
+- literal colors and radii that break custom themes;
+- custom clickable `div`s where a semantic component already supplies focus,
+  keyboard, disabled, and accessibility behavior;
+- duplicated local state that drifts from a controlled model value;
+- `cx.notify()` loops caused by mutation during every render;
+- nested scroll containers without explicit ownership;
+- a new component variant for a one-off screen;
+- confirmation dialogs for reversible, low-risk actions;
+- tests that call internal methods but never exercise keyboard or pointer
+  behavior.
+
+## Rules for coding agents
+
+Before editing, an agent must read the nearest implementation, its tests, the
+re-export seam, and the relevant component documentation. It must search the
+current source for signatures instead of translating a React, CSS, or old GPUI
+example by analogy.
+
+For each change, the agent should be able to name:
+
+1. the behavior owner and presentation owner;
+2. the retained identity and state lifecycle;
+3. the pointer, keyboard, focus, and accessibility contract;
+4. the layout and overflow owner;
+5. the theme tokens and intentional exceptions;
+6. the test that would fail if the behavior regressed.
+
+Generated code must be reviewed and tested by a person. “Compiles” is not a UI
+quality bar, and a broad refactor that merely makes generated code look tidy is
+not a substitute for matching the repository's architecture.
+
+## Implementation checklist
+
+Before opening a change for review, confirm that:
+
+- state and side-effect ownership are explicit;
+- `RenderOnce` versus `Entity<T>` is chosen deliberately;
+- repeated elements have stable domain-based IDs;
+- theme tokens and component sizes replace isolated visual literals;
+- keyboard actions, focus, disabled state, and overlays work together;
+- loading, empty, error, and cancellation paths are represented;
+- long data sets use an appropriate virtualized component;
+- public API additions preserve dependency direction and encapsulation;
+- tests prove behavior at the appropriate layer;
+- formatting, Clippy, targeted tests, and relevant examples pass.
+
+See [Getting Started](./getting-started.md) for application setup and the
+component pages for current API details.

--- a/.claude/skills/gpui-kit/references/gpui/action.md
+++ b/.claude/skills/gpui-kit/references/gpui/action.md
@@ -1,0 +1,173 @@
+# Actions & Keybindings
+
+**Contents:** [Overview](#overview) · [Quick Start](#quick-start) · [Key Formats](#key-formats) · [Action Naming](#action-naming) · [Context-Aware Bindings](#context-aware-bindings) · [Best Practices](#best-practices)
+
+## Overview
+
+Actions provide declarative keyboard-driven UI interactions in GPUI.
+
+**Key Concepts:**
+- Define actions with `actions!` macro or `#[derive(Action)]`
+- Bind keys with `cx.bind_keys()`
+- Handle with `.on_action()` on elements
+- Context-aware via `key_context()`
+
+## Quick Start
+
+### Simple Actions
+
+```rust
+use gpui_kit::actions;
+
+actions!(editor, [MoveUp, MoveDown, Save, Quit]);
+
+const CONTEXT: &str = "Editor";
+
+pub fn init(cx: &mut App) {
+    cx.bind_keys([
+        KeyBinding::new("up", MoveUp, Some(CONTEXT)),
+        KeyBinding::new("down", MoveDown, Some(CONTEXT)),
+        KeyBinding::new("cmd-s", Save, Some(CONTEXT)),
+        KeyBinding::new("cmd-q", Quit, Some(CONTEXT)),
+    ]);
+}
+
+impl Render for Editor {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .key_context(CONTEXT)
+            .on_action(cx.listener(Self::move_up))
+            .on_action(cx.listener(Self::move_down))
+            .on_action(cx.listener(Self::save))
+    }
+}
+
+impl Editor {
+    fn move_up(&mut self, _: &MoveUp, cx: &mut Context<Self>) {
+        // Handle move up
+        cx.notify();
+    }
+
+    fn move_down(&mut self, _: &MoveDown, cx: &mut Context<Self>) {
+        cx.notify();
+    }
+
+    fn save(&mut self, _: &Save, cx: &mut Context<Self>) {
+        // Save logic
+        cx.notify();
+    }
+}
+```
+
+### Actions with Parameters
+
+```rust
+#[derive(Clone, PartialEq, Action, Deserialize)]
+#[action(namespace = editor)]
+pub struct InsertText {
+    pub text: String,
+}
+
+#[derive(Action, Clone, PartialEq, Eq, Deserialize)]
+#[action(namespace = editor, no_json)]
+pub struct Digit(pub u8);
+
+cx.bind_keys([
+    KeyBinding::new("0", Digit(0), Some(CONTEXT)),
+    KeyBinding::new("1", Digit(1), Some(CONTEXT)),
+    // ...
+]);
+
+impl Editor {
+    fn on_digit(&mut self, action: &Digit, cx: &mut Context<Self>) {
+        self.insert_digit(action.0, cx);
+    }
+}
+```
+
+## Key Formats
+
+```rust
+// Modifiers
+"cmd-s"         // Command (macOS) / Ctrl (Windows/Linux)
+"ctrl-c"        // Control
+"alt-f"         // Alt
+"shift-tab"     // Shift
+"cmd-ctrl-f"    // Multiple modifiers
+
+// Keys
+"a-z", "0-9"    // Letters and numbers
+"f1-f12"        // Function keys
+"up", "down", "left", "right"
+"enter", "escape", "space", "tab"
+"backspace", "delete"
+"-", "=", "[", "]", etc.  // Special characters
+```
+
+## Action Naming
+
+Prefer verb-noun pattern:
+
+```rust
+actions!([
+    OpenFile,      // ✅ Good
+    CloseWindow,   // ✅ Good
+    ToggleSidebar, // ✅ Good
+    Save,          // ✅ Good (common exception)
+]);
+```
+
+## Context-Aware Bindings
+
+```rust
+const EDITOR_CONTEXT: &str = "Editor";
+const MODAL_CONTEXT: &str = "Modal";
+
+// Same key, different contexts
+cx.bind_keys([
+    KeyBinding::new("escape", CloseModal, Some(MODAL_CONTEXT)),
+    KeyBinding::new("escape", ClearSelection, Some(EDITOR_CONTEXT)),
+]);
+
+// Set context on element
+div()
+    .key_context(EDITOR_CONTEXT)
+    .child(editor_content)
+```
+
+## Best Practices
+
+### ✅ Use Contexts
+
+```rust
+// ✅ Good: Context-aware
+div()
+    .key_context("MyComponent")
+    .on_action(cx.listener(Self::handle))
+```
+
+### ✅ Name Actions Clearly
+
+```rust
+// ✅ Good: Clear intent
+actions!([
+    SaveDocument,
+    CloseTab,
+    TogglePreview,
+]);
+```
+
+### ✅ Handle with Listeners
+
+```rust
+// ✅ Good: Proper handler naming
+impl MyComponent {
+    fn on_action_save(&mut self, _: &Save, cx: &mut Context<Self>) {
+        // Handle save
+        cx.notify();
+    }
+}
+
+div().on_action(cx.listener(Self::on_action_save))
+```
+

--- a/.claude/skills/gpui-kit/references/gpui/async.md
+++ b/.claude/skills/gpui-kit/references/gpui/async.md
@@ -1,0 +1,226 @@
+# Async & Background Tasks
+
+**Contents:** [Overview](#overview) · [Quick Start](#quick-start) · [Core Patterns](#core-patterns) · [Common Pitfalls](#common-pitfalls)
+
+## Overview
+
+GPUI provides integrated async runtime for foreground UI updates and background computation.
+
+**Key Concepts:**
+
+- **Foreground tasks**: UI thread, can update entities (`cx.spawn`)
+- **Background tasks**: Worker threads, CPU-intensive work (`cx.background_spawn`)
+- All entity updates happen on foreground thread
+
+## Quick Start
+
+### Foreground Tasks (UI Updates)
+
+When spawned from `Context<Self>`, the closure receives `(WeakEntity<Self>, &mut AsyncApp)`:
+
+```rust
+impl MyComponent {
+    fn fetch_data(&mut self, cx: &mut Context<Self>) {
+        cx.spawn(async move |this, cx: &mut AsyncApp| {
+            // Runs on UI thread, can await and update entities
+            let data = fetch_from_api().await;
+
+            this.update(cx, |state, cx| {
+                state.data = Some(data);
+                cx.notify();
+            }).ok();
+        }).detach();
+    }
+}
+```
+
+When spawned from `&mut App` (not inside an entity), the closure receives only `(cx: &mut AsyncApp)`:
+
+```rust
+cx.spawn(async move |cx: &mut AsyncApp| {
+    // No entity reference
+}).detach();
+```
+
+### Spawn with Window Context (spawn_in)
+
+Use `spawn_in` when the task also needs window access (`update_in`):
+
+```rust
+impl MyComponent {
+    fn animate(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        cx.spawn_in(window, async move |this, cx| {
+            // cx here is AsyncWindowContext
+            this.update_in(cx, |state, window, cx| {
+                // Can access window here
+                state.frame += 1;
+                cx.notify();
+            }).ok();
+        }).detach();
+    }
+}
+```
+
+### Background Tasks (Heavy Work)
+
+```rust
+impl MyComponent {
+    fn process_file(&mut self, cx: &mut Context<Self>) {
+        let entity = cx.entity().downgrade();
+
+        cx.background_spawn(async move {
+            // Runs on background thread, CPU-intensive
+            let result = heavy_computation().await;
+            result
+        })
+        .then(cx.spawn(move |result, cx| {
+            // Back to foreground to update UI
+            entity.update(cx, |state, cx| {
+                state.result = result;
+                cx.notify();
+            }).ok();
+        }))
+        .detach();
+    }
+}
+```
+
+### Task Management
+
+```rust
+struct MyView {
+    _task: Task<()>,  // Prefix with _ if stored but not accessed
+}
+
+impl MyView {
+    fn new(cx: &mut Context<Self>) -> Self {
+        let _task = cx.spawn(async move |this, cx: &mut AsyncApp| {
+            // Task automatically cancelled when dropped
+            loop {
+                cx.background_executor().timer(Duration::from_secs(1)).await;
+
+                this.update(cx, |state, cx| {
+                    state.tick();
+                    cx.notify();
+                }).ok();
+            }
+        });
+
+        Self { _task }
+    }
+}
+```
+
+## Core Patterns
+
+### 1. Async Data Fetching (from Context<Self>)
+
+```rust
+cx.spawn(async move |this, cx: &mut AsyncApp| {
+    let data = fetch_data().await?;
+    this.update(cx, |state, cx| {
+        state.data = Some(data);
+        cx.notify();
+    })?;
+    Ok::<_, anyhow::Error>(())
+}).detach();
+```
+
+### 2. Background Computation + UI Update
+
+```rust
+cx.background_spawn(async move {
+    heavy_work()
+})
+.then(cx.spawn(move |this, cx: &mut AsyncApp| {
+    this.update(cx, |state, cx| {
+        state.result = result;
+        cx.notify();
+    }).ok();
+}))
+.detach();
+```
+
+### 3. Periodic Tasks
+
+```rust
+cx.spawn(async move |this, cx: &mut AsyncApp| {
+    loop {
+        cx.background_executor().timer(Duration::from_secs(5)).await;
+
+        this.update(cx, |state, cx| {
+            state.tick();
+            cx.notify();
+        }).ok();
+    }
+}).detach();
+```
+
+### 4. Task Cancellation
+
+Tasks are automatically cancelled when dropped. Store in struct to keep alive.
+
+## Common Pitfalls
+
+### ❌ Don't: Use `defer_in` and then update the same entity through its handle
+
+`cx.defer_in(window, callback)` schedules `callback` to run **on the current entity** — GPUI re-acquires that entity's lock to execute it. Calling `entity.update(cx, …)` on the *same* entity from within the deferred callback re-enters the lock and panics:
+
+```
+cannot update … while it is already being updated
+```
+
+```rust
+// ❌ Panic: list entity is locked for the defer_in; calling list.update re-enters
+fn confirm(&mut self, _: bool, window: &mut Window, cx: &mut Context<ListState<Self>>) {
+    cx.defer_in(window, |list_state, window, cx| {
+        parent.update(cx, |this, cx| {
+            this.inner_list.update(cx, |_, _| {}); // PANIC if inner_list == the deferred entity
+        });
+    });
+}
+```
+
+```rust
+// ✅ Correct: use the direct &mut reference — no lock needed
+fn confirm(&mut self, _: bool, window: &mut Window, cx: &mut Context<ListState<Self>>) {
+    cx.defer_in(window, |list_state, window, cx| {
+        // Access list data directly through the &mut reference
+        list_state.delegate_mut().some_method();
+
+        // Update a *different* entity — fine, different lock
+        parent.update(cx, |this, cx| { /* … */ });
+
+        // Sync list state directly after parent update — no lock needed
+        list_state.delegate_mut().update_snapshot(new_val);
+    });
+}
+```
+
+The rule: inside a `defer_in` callback, **never call `entity.update(cx, …)` or `entity.read(cx)` on the entity the `defer_in` was scheduled on**. Use the `&mut Entity` direct reference the callback provides instead.
+
+### ❌ Don't: Update entities from background tasks
+
+```rust
+// ❌ Wrong: Can't update entities from background thread
+cx.background_spawn(async move {
+    entity.update(cx, |state, cx| { // Compile error!
+        state.data = data;
+    });
+});
+```
+
+### ✅ Do: Use foreground task or chain
+
+```rust
+// ✅ Correct: Chain with foreground task
+cx.background_spawn(async move { data })
+    .then(cx.spawn(move |data, cx| {
+        entity.update(cx, |state, cx| {
+            state.data = data;
+            cx.notify();
+        }).ok();
+    }))
+    .detach();
+```
+

--- a/.claude/skills/gpui-kit/references/gpui/context.md
+++ b/.claude/skills/gpui-kit/references/gpui/context.md
@@ -1,0 +1,258 @@
+# Context Management
+
+**Contents:** [Overview](#overview) · [Quick Start](#quick-start) · [Common Operations](#common-operations) · [Context Hierarchy](#context-hierarchy) · [cx.listener](#cxlistener--binding-callbacks-to-self) · [subscribe_in](#subscribe_in--subscribe-with-window-access) · [observe_window_activation](#observe_window_activation) · [observe_global](#observe_global) · [defer / defer_in](#defer-and-defer_in) · [Naming Convention](#context-naming-convention)
+
+## Overview
+
+GPUI uses different context types for different scenarios:
+
+**Context Types:**
+- **`App`**: Global app state, entity creation
+- **`Window`**: Window-specific operations, painting, layout
+- **`Context<T>`**: Entity-specific context for component `T`
+- **`AsyncApp`**: Async context for foreground tasks
+- **`AsyncWindowContext`**: Async context with window access
+
+## Quick Start
+
+### Context<T> - Component Context
+
+```rust
+impl MyComponent {
+    fn update_state(&mut self, cx: &mut Context<Self>) {
+        self.value = 42;
+        cx.notify(); // Trigger re-render
+
+        // Spawn async task
+        cx.spawn(async move |cx| {
+            // Async work
+        }).detach();
+
+        // Get current entity
+        let entity = cx.entity();
+    }
+}
+```
+
+### App - Global Context
+
+```rust
+fn main() {
+    let app = Application::new();
+    app.run(|cx: &mut App| {
+        // Create entities
+        let entity = cx.new(|cx| MyState::default());
+
+        // Open windows
+        cx.open_window(WindowOptions::default(), |window, cx| {
+            cx.new(|cx| Root::new(view, window, cx))
+        });
+    });
+}
+```
+
+### Window - Window Context
+
+```rust
+impl Render for MyView {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        // Window operations
+        let is_focused = window.is_window_focused();
+        let bounds = window.bounds();
+
+        div().child("Content")
+    }
+}
+```
+
+### AsyncApp - Async Context
+
+```rust
+cx.spawn(async move |cx: &mut AsyncApp| {
+    let data = fetch_data().await;
+
+    entity.update(cx, |state, inner_cx| {
+        state.data = data;
+        inner_cx.notify();
+    }).ok();
+}).detach();
+```
+
+## Common Operations
+
+### Entity Operations
+
+```rust
+// Create entity
+let entity = cx.new(|cx| MyState::default());
+
+// Update entity
+entity.update(cx, |state, cx| {
+    state.value = 42;
+    cx.notify();
+});
+
+// Read entity
+let value = entity.read(cx).value;
+```
+
+### Notifications and Events
+
+```rust
+// Trigger re-render
+cx.notify();
+
+// Emit event
+cx.emit(MyEvent::Updated);
+
+// Observe entity
+cx.observe(&entity, |this, observed, cx| {
+    // React to changes
+}).detach();
+
+// Subscribe to events
+cx.subscribe(&entity, |this, source, event, cx| {
+    // Handle event
+}).detach();
+```
+
+### Window Operations
+
+```rust
+// Window state
+let focused = window.is_window_focused();
+let bounds = window.bounds();
+let scale = window.scale_factor();
+
+// Close window
+window.remove_window();
+```
+
+### Async Operations
+
+```rust
+// Spawn foreground task
+cx.spawn(async move |cx| {
+    // Async work with entity access
+}).detach();
+
+// Spawn background task
+cx.background_spawn(async move {
+    // Heavy computation
+}).detach();
+```
+
+## Context Hierarchy
+
+```
+App (Global)
+  └─ Window (Per-window)
+       └─ Context<T> (Per-component)
+            └─ AsyncApp (In async tasks)
+                 └─ AsyncWindowContext (Async + Window)
+```
+
+## cx.listener — Binding Callbacks to Self
+
+`cx.listener` creates a callback that borrows `&mut self` (the current entity). Use it for `on_click`, `on_action`, and other element event handlers:
+
+```rust
+impl Render for MyView {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .on_action(cx.listener(Self::on_save))
+            .child(
+                Button::new("btn")
+                    .on_click(cx.listener(|this, _event, _window, cx| {
+                        this.count += 1;
+                        cx.notify();
+                    }))
+            )
+    }
+}
+
+impl MyView {
+    fn on_save(&mut self, _: &Save, _window: &mut Window, cx: &mut Context<Self>) {
+        cx.notify();
+    }
+}
+```
+
+`cx.listener(Self::method)` is equivalent to creating a closure that calls `self.method(...)`.
+
+## subscribe_in — Subscribe with Window Access
+
+Use `subscribe_in` (instead of `subscribe`) when the callback needs `&mut Window`:
+
+```rust
+let _subscription = cx.subscribe_in(&input, window, |this, state, event, window, cx| {
+    match event {
+        InputEvent::Change => {
+            let val = state.read(cx).value();
+            this.on_input_change(val, window, cx);
+        }
+        _ => {}
+    }
+});
+// Store _subscription in struct to keep it alive
+```
+
+`subscribe` vs `subscribe_in`:
+- `subscribe(&entity, |this, source, event, cx|)` — no window access
+- `subscribe_in(&entity, window, |this, source, event, window, cx|)` — has window access
+
+## observe_window_activation
+
+React when the window gains or loses focus:
+
+```rust
+let _sub = cx.observe_window_activation(window, |this, window, cx| {
+    if window.is_window_active() {
+        this.resume(cx);
+    } else {
+        this.pause(cx);
+    }
+});
+```
+
+## observe_global
+
+React when a global value changes:
+
+```rust
+cx.observe_global::<Theme>(|cx| {
+    // Theme changed — react
+    cx.notify();
+});
+```
+
+## defer and defer_in
+
+Schedule work after the current update completes:
+
+```rust
+// defer: runs after current App update, no window access
+cx.defer(|cx| {
+    // Runs after current entity update is done
+});
+
+// defer_in: runs after update, with window access
+cx.defer_in(window, |this, window, cx| {
+    // Can access window here
+    // CAUTION: never call entity.update(cx) on *this same entity* inside defer_in
+    // — it re-enters the lock and panics. Use the &mut self reference directly.
+    this.some_method(window, cx);
+});
+```
+
+## Context Naming Convention
+
+Always name contexts `cx` regardless of type:
+
+```rust
+fn new(window: &mut Window, cx: &mut App) {}             // cx = App
+impl Render for View {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) {}  // cx = Context<Self>
+}
+cx.spawn(async move |this, cx: &mut AsyncApp| {})         // cx = AsyncApp
+```

--- a/.claude/skills/gpui-kit/references/gpui/element-advanced.md
+++ b/.claude/skills/gpui-kit/references/gpui/element-advanced.md
@@ -1,0 +1,705 @@
+# Advanced Element Patterns
+
+**Contents:** [Custom Layout Algorithms](#custom-layout-algorithms) · [Element Composition with Traits](#element-composition-with-traits) · [Async Element Updates](#async-element-updates) · [Element Memoization](#element-memoization) · [Virtual List Pattern](#virtual-list-pattern)
+
+## Custom Layout Algorithms
+
+Implementing custom layout algorithms not supported by GPUI's built-in layouts.
+
+### Masonry Layout (Pinterest-Style)
+
+```rust
+pub struct MasonryLayout {
+    id: ElementId,
+    columns: usize,
+    gap: Pixels,
+    children: Vec<AnyElement>,
+}
+
+struct MasonryLayoutState {
+    column_layouts: Vec<Vec<LayoutId>>,
+    column_heights: Vec<Pixels>,
+}
+
+struct MasonryPaintState {
+    child_bounds: Vec<Bounds<Pixels>>,
+}
+
+impl Element for MasonryLayout {
+    type RequestLayoutState = MasonryLayoutState;
+    type PrepaintState = MasonryPaintState;
+
+    fn id(&self) -> Option<ElementId> {
+        Some(self.id.clone())
+    }
+
+    fn source_location(&self) -> Option<&'static std::panic::Location<'static>> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        global_id: Option<&GlobalElementId>,
+        inspector_id: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App
+    ) -> (LayoutId, MasonryLayoutState) {
+        // Initialize columns
+        let mut columns: Vec<Vec<LayoutId>> = vec![Vec::new(); self.columns];
+        let mut column_heights = vec![px(0.); self.columns];
+
+        // Distribute children across columns
+        for child in &mut self.children {
+            let (child_layout_id, _) = child.request_layout(
+                global_id,
+                inspector_id,
+                window,
+                cx
+            );
+
+            let child_size = window.layout_bounds(child_layout_id).size;
+
+            // Find shortest column
+            let min_column_idx = column_heights
+                .iter()
+                .enumerate()
+                .min_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+                .unwrap()
+                .0;
+
+            // Add child to shortest column
+            columns[min_column_idx].push(child_layout_id);
+            column_heights[min_column_idx] += child_size.height + self.gap;
+        }
+
+        // Calculate total layout size
+        let column_width = px(200.); // Fixed column width
+        let total_width = column_width * self.columns as f32
+            + self.gap * (self.columns - 1) as f32;
+        let total_height = column_heights.iter()
+            .max_by(|a, b| a.partial_cmp(b).unwrap())
+            .copied()
+            .unwrap_or(px(0.));
+
+        let layout_id = window.request_layout(
+            Style {
+                size: size(total_width, total_height),
+                ..default()
+            },
+            columns.iter().flatten().copied().collect(),
+            cx
+        );
+
+        (layout_id, MasonryLayoutState {
+            column_layouts: columns,
+            column_heights,
+        })
+    }
+
+    fn prepaint(
+        &mut self,
+        global_id: Option<&GlobalElementId>,
+        inspector_id: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        layout_state: &mut MasonryLayoutState,
+        window: &mut Window,
+        cx: &mut App
+    ) -> MasonryPaintState {
+        let column_width = px(200.);
+        let mut child_bounds = Vec::new();
+
+        // Position children in columns
+        for (col_idx, column) in layout_state.column_layouts.iter().enumerate() {
+            let x_offset = bounds.left()
+                + (column_width + self.gap) * col_idx as f32;
+            let mut y_offset = bounds.top();
+
+            for (child_idx, layout_id) in column.iter().enumerate() {
+                let child_size = window.layout_bounds(*layout_id).size;
+                let child_bound = Bounds::new(
+                    point(x_offset, y_offset),
+                    size(column_width, child_size.height)
+                );
+
+                self.children[child_idx].prepaint(
+                    global_id,
+                    inspector_id,
+                    child_bound,
+                    window,
+                    cx
+                );
+
+                child_bounds.push(child_bound);
+                y_offset += child_size.height + self.gap;
+            }
+        }
+
+        MasonryPaintState { child_bounds }
+    }
+
+    fn paint(
+        &mut self,
+        global_id: Option<&GlobalElementId>,
+        inspector_id: Option<&InspectorElementId>,
+        _bounds: Bounds<Pixels>,
+        _layout_state: &mut MasonryLayoutState,
+        paint_state: &mut MasonryPaintState,
+        window: &mut Window,
+        cx: &mut App
+    ) {
+        for (child, bounds) in self.children.iter_mut().zip(&paint_state.child_bounds) {
+            child.paint(global_id, inspector_id, *bounds, window, cx);
+        }
+    }
+}
+```
+
+### Circular Layout
+
+```rust
+pub struct CircularLayout {
+    id: ElementId,
+    radius: Pixels,
+    children: Vec<AnyElement>,
+}
+
+impl Element for CircularLayout {
+    type RequestLayoutState = Vec<LayoutId>;
+    type PrepaintState = Vec<Bounds<Pixels>>;
+
+    fn request_layout(
+        &mut self,
+        global_id: Option<&GlobalElementId>,
+        inspector_id: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App
+    ) -> (LayoutId, Vec<LayoutId>) {
+        let child_layouts: Vec<_> = self.children
+            .iter_mut()
+            .map(|child| child.request_layout(global_id, inspector_id, window, cx).0)
+            .collect();
+
+        let diameter = self.radius * 2.;
+        let layout_id = window.request_layout(
+            Style {
+                size: size(diameter, diameter),
+                ..default()
+            },
+            child_layouts.clone(),
+            cx
+        );
+
+        (layout_id, child_layouts)
+    }
+
+    fn prepaint(
+        &mut self,
+        global_id: Option<&GlobalElementId>,
+        inspector_id: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        layout_ids: &mut Vec<LayoutId>,
+        window: &mut Window,
+        cx: &mut App
+    ) -> Vec<Bounds<Pixels>> {
+        let center = bounds.center();
+        let angle_step = 2.0 * std::f32::consts::PI / self.children.len() as f32;
+
+        let mut child_bounds = Vec::new();
+
+        for (i, (child, layout_id)) in self.children.iter_mut()
+            .zip(layout_ids.iter())
+            .enumerate()
+        {
+            let angle = angle_step * i as f32;
+            let child_size = window.layout_bounds(*layout_id).size;
+
+            // Position child on circle
+            let x = center.x + self.radius * angle.cos() - child_size.width / 2.;
+            let y = center.y + self.radius * angle.sin() - child_size.height / 2.;
+
+            let child_bound = Bounds::new(point(x, y), child_size);
+
+            child.prepaint(global_id, inspector_id, child_bound, window, cx);
+            child_bounds.push(child_bound);
+        }
+
+        child_bounds
+    }
+
+    fn paint(
+        &mut self,
+        global_id: Option<&GlobalElementId>,
+        inspector_id: Option<&InspectorElementId>,
+        _bounds: Bounds<Pixels>,
+        _layout_ids: &mut Vec<LayoutId>,
+        child_bounds: &mut Vec<Bounds<Pixels>>,
+        window: &mut Window,
+        cx: &mut App
+    ) {
+        for (child, bounds) in self.children.iter_mut().zip(child_bounds) {
+            child.paint(global_id, inspector_id, *bounds, window, cx);
+        }
+    }
+}
+```
+
+## Element Composition with Traits
+
+Create reusable behaviors via traits for element composition.
+
+### Hoverable Trait
+
+```rust
+pub trait Hoverable: Element {
+    fn on_hover<F>(&mut self, f: F) -> &mut Self
+    where
+        F: Fn(&mut Window, &mut App) + 'static;
+
+    fn on_hover_end<F>(&mut self, f: F) -> &mut Self
+    where
+        F: Fn(&mut Window, &mut App) + 'static;
+}
+
+// Implementation for custom element
+pub struct HoverableElement {
+    id: ElementId,
+    content: AnyElement,
+    hover_handlers: Vec<Box<dyn Fn(&mut Window, &mut App)>>,
+    hover_end_handlers: Vec<Box<dyn Fn(&mut Window, &mut App)>>,
+    was_hovered: bool,
+}
+
+impl Hoverable for HoverableElement {
+    fn on_hover<F>(&mut self, f: F) -> &mut Self
+    where
+        F: Fn(&mut Window, &mut App) + 'static
+    {
+        self.hover_handlers.push(Box::new(f));
+        self
+    }
+
+    fn on_hover_end<F>(&mut self, f: F) -> &mut Self
+    where
+        F: Fn(&mut Window, &mut App) + 'static
+    {
+        self.hover_end_handlers.push(Box::new(f));
+        self
+    }
+}
+
+impl Element for HoverableElement {
+    type RequestLayoutState = LayoutId;
+    type PrepaintState = Hitbox;
+
+    fn paint(
+        &mut self,
+        _global_id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        _layout: &mut LayoutId,
+        hitbox: &mut Hitbox,
+        window: &mut Window,
+        cx: &mut App
+    ) {
+        let is_hovered = hitbox.is_hovered(window);
+
+        // Trigger hover events
+        if is_hovered && !self.was_hovered {
+            for handler in &self.hover_handlers {
+                handler(window, cx);
+            }
+        } else if !is_hovered && self.was_hovered {
+            for handler in &self.hover_end_handlers {
+                handler(window, cx);
+            }
+        }
+
+        self.was_hovered = is_hovered;
+
+        // Paint content
+        self.content.paint(bounds, window, cx);
+    }
+
+    // ... other methods
+}
+```
+
+### Clickable Trait
+
+```rust
+pub trait Clickable: Element {
+    fn on_click<F>(&mut self, f: F) -> &mut Self
+    where
+        F: Fn(&MouseUpEvent, &mut Window, &mut App) + 'static;
+
+    fn on_double_click<F>(&mut self, f: F) -> &mut Self
+    where
+        F: Fn(&MouseUpEvent, &mut Window, &mut App) + 'static;
+}
+
+pub struct ClickableElement {
+    id: ElementId,
+    content: AnyElement,
+    click_handlers: Vec<Box<dyn Fn(&MouseUpEvent, &mut Window, &mut App)>>,
+    double_click_handlers: Vec<Box<dyn Fn(&MouseUpEvent, &mut Window, &mut App)>>,
+    last_click_time: Option<Instant>,
+}
+
+impl Clickable for ClickableElement {
+    fn on_click<F>(&mut self, f: F) -> &mut Self
+    where
+        F: Fn(&MouseUpEvent, &mut Window, &mut App) + 'static
+    {
+        self.click_handlers.push(Box::new(f));
+        self
+    }
+
+    fn on_double_click<F>(&mut self, f: F) -> &mut Self
+    where
+        F: Fn(&MouseUpEvent, &mut Window, &mut App) + 'static
+    {
+        self.double_click_handlers.push(Box::new(f));
+        self
+    }
+}
+```
+
+## Async Element Updates
+
+Elements that update based on async operations.
+
+```rust
+pub struct AsyncElement {
+    id: ElementId,
+    state: Entity<AsyncState>,
+    loading: bool,
+    data: Option<String>,
+}
+
+pub struct AsyncState {
+    loading: bool,
+    data: Option<String>,
+}
+
+impl Element for AsyncElement {
+    type RequestLayoutState = ();
+    type PrepaintState = Hitbox;
+
+    fn paint(
+        &mut self,
+        _global_id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        _layout: &mut (),
+        hitbox: &mut Hitbox,
+        window: &mut Window,
+        cx: &mut App
+    ) {
+        // Display loading or data
+        if self.loading {
+            // Paint loading indicator
+            self.paint_loading(bounds, window, cx);
+        } else if let Some(data) = &self.data {
+            // Paint data
+            self.paint_data(data, bounds, window, cx);
+        }
+
+        // Trigger async update on click
+        window.on_mouse_event({
+            let state = self.state.clone();
+            let hitbox = hitbox.clone();
+
+            move |event: &MouseUpEvent, phase, window, cx| {
+                if hitbox.is_hovered(window) && phase.bubble() {
+                    // Spawn async task
+                    cx.spawn({
+                        let state = state.clone();
+                        async move {
+                            // Perform async operation
+                            let result = fetch_data_async().await;
+
+                            // Update state on completion
+                            state.update(cx, |state, cx| {
+                                state.loading = false;
+                                state.data = Some(result);
+                                cx.notify();
+                            });
+                        }
+                    }).detach();
+
+                    // Set loading state immediately
+                    state.update(cx, |state, cx| {
+                        state.loading = true;
+                        cx.notify();
+                    });
+
+                    cx.stop_propagation();
+                }
+            }
+        });
+    }
+
+    // ... other methods
+}
+
+async fn fetch_data_async() -> String {
+    // Simulate async operation
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    "Data loaded!".to_string()
+}
+```
+
+## Element Memoization
+
+Optimize performance by memoizing expensive element computations.
+
+```rust
+pub struct MemoizedElement<T: PartialEq + Clone + 'static> {
+    id: ElementId,
+    value: T,
+    render_fn: Box<dyn Fn(&T) -> AnyElement>,
+    cached_element: Option<AnyElement>,
+    last_value: Option<T>,
+}
+
+impl<T: PartialEq + Clone + 'static> MemoizedElement<T> {
+    pub fn new<F>(id: ElementId, value: T, render_fn: F) -> Self
+    where
+        F: Fn(&T) -> AnyElement + 'static,
+    {
+        Self {
+            id,
+            value,
+            render_fn: Box::new(render_fn),
+            cached_element: None,
+            last_value: None,
+        }
+    }
+}
+
+impl<T: PartialEq + Clone + 'static> Element for MemoizedElement<T> {
+    type RequestLayoutState = LayoutId;
+    type PrepaintState = ();
+
+    fn id(&self) -> Option<ElementId> {
+        Some(self.id.clone())
+    }
+
+    fn source_location(&self) -> Option<&'static std::panic::Location<'static>> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        global_id: Option<&GlobalElementId>,
+        inspector_id: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App
+    ) -> (LayoutId, LayoutId) {
+        // Check if value changed
+        if self.last_value.as_ref() != Some(&self.value) || self.cached_element.is_none() {
+            // Recompute element
+            self.cached_element = Some((self.render_fn)(&self.value));
+            self.last_value = Some(self.value.clone());
+        }
+
+        // Request layout for cached element
+        let (layout_id, _) = self.cached_element
+            .as_mut()
+            .unwrap()
+            .request_layout(global_id, inspector_id, window, cx);
+
+        (layout_id, layout_id)
+    }
+
+    fn prepaint(
+        &mut self,
+        global_id: Option<&GlobalElementId>,
+        inspector_id: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        _layout_id: &mut LayoutId,
+        window: &mut Window,
+        cx: &mut App
+    ) -> () {
+        self.cached_element
+            .as_mut()
+            .unwrap()
+            .prepaint(global_id, inspector_id, bounds, window, cx);
+    }
+
+    fn paint(
+        &mut self,
+        global_id: Option<&GlobalElementId>,
+        inspector_id: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        _layout_id: &mut LayoutId,
+        _: &mut (),
+        window: &mut Window,
+        cx: &mut App
+    ) {
+        self.cached_element
+            .as_mut()
+            .unwrap()
+            .paint(global_id, inspector_id, bounds, window, cx);
+    }
+}
+
+// Usage
+fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    MemoizedElement::new(
+        ElementId::Name("memoized".into()),
+        self.expensive_value.clone(),
+        |value| {
+            // Expensive rendering function only called when value changes
+            div().child(format!("Computed: {}", value))
+        }
+    )
+}
+```
+
+## Virtual List Pattern
+
+Efficiently render large lists by only rendering visible items.
+
+```rust
+pub struct VirtualList {
+    id: ElementId,
+    item_count: usize,
+    item_height: Pixels,
+    viewport_height: Pixels,
+    scroll_offset: Pixels,
+    render_item: Box<dyn Fn(usize) -> AnyElement>,
+}
+
+struct VirtualListState {
+    visible_range: Range<usize>,
+    visible_item_layouts: Vec<LayoutId>,
+}
+
+impl Element for VirtualList {
+    type RequestLayoutState = VirtualListState;
+    type PrepaintState = Hitbox;
+
+    fn request_layout(
+        &mut self,
+        global_id: Option<&GlobalElementId>,
+        inspector_id: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App
+    ) -> (LayoutId, VirtualListState) {
+        // Calculate visible range
+        let start_idx = (self.scroll_offset / self.item_height).floor() as usize;
+        let end_idx = ((self.scroll_offset + self.viewport_height) / self.item_height)
+            .ceil() as usize;
+        let visible_range = start_idx..end_idx.min(self.item_count);
+
+        // Request layout only for visible items
+        let visible_item_layouts: Vec<_> = visible_range.clone()
+            .map(|i| {
+                let mut item = (self.render_item)(i);
+                item.request_layout(global_id, inspector_id, window, cx).0
+            })
+            .collect();
+
+        let total_height = self.item_height * self.item_count as f32;
+        let layout_id = window.request_layout(
+            Style {
+                size: size(relative(1.0), self.viewport_height),
+                overflow: Overflow::Hidden,
+                ..default()
+            },
+            visible_item_layouts.clone(),
+            cx
+        );
+
+        (layout_id, VirtualListState {
+            visible_range,
+            visible_item_layouts,
+        })
+    }
+
+    fn prepaint(
+        &mut self,
+        _global_id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        state: &mut VirtualListState,
+        window: &mut Window,
+        _cx: &mut App
+    ) -> Hitbox {
+        // Prepaint visible items at correct positions
+        for (i, layout_id) in state.visible_item_layouts.iter().enumerate() {
+            let item_idx = state.visible_range.start + i;
+            let y = item_idx as f32 * self.item_height - self.scroll_offset;
+            let item_bounds = Bounds::new(
+                point(bounds.left(), bounds.top() + y),
+                size(bounds.width(), self.item_height)
+            );
+
+            // Prepaint if visible
+            if item_bounds.intersects(&bounds) {
+                // Prepaint item...
+            }
+        }
+
+        window.insert_hitbox(bounds, HitboxBehavior::Normal)
+    }
+
+    fn paint(
+        &mut self,
+        _global_id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        state: &mut VirtualListState,
+        hitbox: &mut Hitbox,
+        window: &mut Window,
+        cx: &mut App
+    ) {
+        // Paint visible items
+        for (i, _layout_id) in state.visible_item_layouts.iter().enumerate() {
+            let item_idx = state.visible_range.start + i;
+            let y = item_idx as f32 * self.item_height - self.scroll_offset;
+            let item_bounds = Bounds::new(
+                point(bounds.left(), bounds.top() + y),
+                size(bounds.width(), self.item_height)
+            );
+
+            if item_bounds.intersects(&bounds) {
+                let mut item = (self.render_item)(item_idx);
+                item.paint(item_bounds, window, cx);
+            }
+        }
+
+        // Handle scroll
+        window.on_mouse_event({
+            let hitbox = hitbox.clone();
+            let total_height = self.item_height * self.item_count as f32;
+
+            move |event: &ScrollWheelEvent, phase, window, cx| {
+                if hitbox.is_hovered(window) && phase.bubble() {
+                    self.scroll_offset -= event.delta.y;
+                    self.scroll_offset = self.scroll_offset
+                        .max(px(0.))
+                        .min(total_height - self.viewport_height);
+                    cx.notify();
+                    cx.stop_propagation();
+                }
+            }
+        });
+    }
+}
+
+// Usage: Efficiently render 10,000 items
+let virtual_list = VirtualList {
+    id: ElementId::Name("large-list".into()),
+    item_count: 10_000,
+    item_height: px(40.),
+    viewport_height: px(400.),
+    scroll_offset: px(0.),
+    render_item: Box::new(|index| {
+        div().child(format!("Item {}", index))
+    }),
+};
+```
+
+These advanced patterns enable sophisticated element implementations while maintaining performance and code quality.

--- a/.claude/skills/gpui-kit/references/gpui/element-api.md
+++ b/.claude/skills/gpui-kit/references/gpui/element-api.md
@@ -1,0 +1,477 @@
+# Element API Reference
+
+**Contents:** [Element Trait Structure](#element-trait-structure) · [Associated Types](#associated-types) · [Methods](#methods) · [IntoElement Integration](#intoelement-integration) · [Layout System Integration](#layout-system-integration) · [Hitbox System](#hitbox-system) · [Event Handling](#event-handling) · [Cursor Styles](#cursor-styles)
+
+## Element Trait Structure
+
+The `Element` trait requires implementing three associated types and five methods:
+
+```rust
+pub trait Element: 'static + IntoElement {
+    type RequestLayoutState: 'static;
+    type PrepaintState: 'static;
+
+    fn id(&self) -> Option<ElementId>;
+    fn source_location(&self) -> Option<&'static std::panic::Location<'static>>;
+    fn request_layout(
+        &mut self,
+        global_id: Option<&GlobalElementId>,
+        inspector_id: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> (LayoutId, Self::RequestLayoutState);
+    fn prepaint(
+        &mut self,
+        global_id: Option<&GlobalElementId>,
+        inspector_id: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        request_layout: &mut Self::RequestLayoutState,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Self::PrepaintState;
+    fn paint(
+        &mut self,
+        global_id: Option<&GlobalElementId>,
+        inspector_id: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        request_layout: &mut Self::RequestLayoutState,
+        prepaint: &mut Self::PrepaintState,
+        window: &mut Window,
+        cx: &mut App,
+    );
+}
+```
+
+## Associated Types
+
+### RequestLayoutState
+
+Data passed from `request_layout` to `prepaint` and `paint` phases.
+
+**Usage:**
+- Store layout calculations (styled text, child layout IDs)
+- Cache expensive computations
+- Pass child state between phases
+
+**Examples:**
+```rust
+// Simple: no state needed
+type RequestLayoutState = ();
+
+// Single value
+type RequestLayoutState = StyledText;
+
+// Multiple values
+type RequestLayoutState = (StyledText, Vec<ChildLayout>);
+
+// Complex struct
+pub struct MyLayoutState {
+    pub styled_text: StyledText,
+    pub child_layouts: Vec<(LayoutId, ChildState)>,
+    pub computed_bounds: Bounds<Pixels>,
+}
+type RequestLayoutState = MyLayoutState;
+```
+
+### PrepaintState
+
+Data passed from `prepaint` to `paint` phase.
+
+**Usage:**
+- Store hitboxes for interaction
+- Cache visual bounds
+- Store prepaint results
+
+**Examples:**
+```rust
+// Simple: just a hitbox
+type PrepaintState = Hitbox;
+
+// Optional hitbox
+type PrepaintState = Option<Hitbox>;
+
+// Multiple values
+type PrepaintState = (Hitbox, Vec<Bounds<Pixels>>);
+
+// Complex struct
+pub struct MyPaintState {
+    pub hitbox: Hitbox,
+    pub child_bounds: Vec<Bounds<Pixels>>,
+    pub visible_range: Range<usize>,
+}
+type PrepaintState = MyPaintState;
+```
+
+## Methods
+
+### id()
+
+Returns optional unique identifier for debugging and inspection.
+
+```rust
+fn id(&self) -> Option<ElementId> {
+    Some(self.id.clone())
+}
+
+// Or if no ID needed
+fn id(&self) -> Option<ElementId> {
+    None
+}
+```
+
+### source_location()
+
+Returns source location for debugging. Usually returns `None` unless debugging is needed.
+
+```rust
+fn source_location(&self) -> Option<&'static std::panic::Location<'static>> {
+    None
+}
+```
+
+### request_layout()
+
+Calculates sizes and positions for the element tree.
+
+**Parameters:**
+- `global_id`: Global element identifier (optional)
+- `inspector_id`: Inspector element identifier (optional)
+- `window`: Mutable window reference
+- `cx`: Mutable app context
+
+**Returns:**
+- `(LayoutId, Self::RequestLayoutState)`: Layout ID and state for next phases
+
+**Responsibilities:**
+1. Calculate child layouts by calling `child.request_layout()`
+2. Create own layout using `window.request_layout()`
+3. Return layout ID and state to pass to next phases
+
+**Example:**
+```rust
+fn request_layout(
+    &mut self,
+    global_id: Option<&GlobalElementId>,
+    inspector_id: Option<&InspectorElementId>,
+    window: &mut Window,
+    cx: &mut App,
+) -> (LayoutId, Self::RequestLayoutState) {
+    // 1. Calculate child layouts
+    let child_layout_id = self.child.request_layout(
+        global_id,
+        inspector_id,
+        window,
+        cx
+    ).0;
+
+    // 2. Create own layout
+    let layout_id = window.request_layout(
+        Style {
+            size: size(px(200.), px(100.)),
+            ..default()
+        },
+        vec![child_layout_id],
+        cx
+    );
+
+    // 3. Return layout ID and state
+    (layout_id, MyLayoutState { child_layout_id })
+}
+```
+
+### prepaint()
+
+Prepares for painting by creating hitboxes and computing final bounds.
+
+**Parameters:**
+- `global_id`: Global element identifier (optional)
+- `inspector_id`: Inspector element identifier (optional)
+- `bounds`: Final bounds calculated by layout engine
+- `request_layout`: Mutable reference to layout state
+- `window`: Mutable window reference
+- `cx`: Mutable app context
+
+**Returns:**
+- `Self::PrepaintState`: State for paint phase
+
+**Responsibilities:**
+1. Compute final child bounds based on layout bounds
+2. Call `child.prepaint()` for all children
+3. Create hitboxes using `window.insert_hitbox()`
+4. Return state for paint phase
+
+**Example:**
+```rust
+fn prepaint(
+    &mut self,
+    global_id: Option<&GlobalElementId>,
+    inspector_id: Option<&InspectorElementId>,
+    bounds: Bounds<Pixels>,
+    request_layout: &mut Self::RequestLayoutState,
+    window: &mut Window,
+    cx: &mut App,
+) -> Self::PrepaintState {
+    // 1. Compute child bounds
+    let child_bounds = bounds; // or calculated subset
+
+    // 2. Prepaint children
+    self.child.prepaint(
+        global_id,
+        inspector_id,
+        child_bounds,
+        &mut request_layout.child_state,
+        window,
+        cx
+    );
+
+    // 3. Create hitboxes
+    let hitbox = window.insert_hitbox(bounds, HitboxBehavior::Normal);
+
+    // 4. Return paint state
+    MyPaintState { hitbox }
+}
+```
+
+### paint()
+
+Renders the element and handles interactions.
+
+**Parameters:**
+- `global_id`: Global element identifier (optional)
+- `inspector_id`: Inspector element identifier (optional)
+- `bounds`: Final bounds for rendering
+- `request_layout`: Mutable reference to layout state
+- `prepaint`: Mutable reference to prepaint state
+- `window`: Mutable window reference
+- `cx`: Mutable app context
+
+**Responsibilities:**
+1. Paint children first (bottom to top)
+2. Paint own content (backgrounds, borders, etc.)
+3. Set up interactions (mouse events, cursor styles)
+
+**Example:**
+```rust
+fn paint(
+    &mut self,
+    global_id: Option<&GlobalElementId>,
+    inspector_id: Option<&InspectorElementId>,
+    bounds: Bounds<Pixels>,
+    request_layout: &mut Self::RequestLayoutState,
+    prepaint: &mut Self::PrepaintState,
+    window: &mut Window,
+    cx: &mut App,
+) {
+    // 1. Paint children first
+    self.child.paint(
+        global_id,
+        inspector_id,
+        child_bounds,
+        &mut request_layout.child_state,
+        &mut prepaint.child_paint_state,
+        window,
+        cx
+    );
+
+    // 2. Paint own content
+    window.paint_quad(paint_quad(
+        bounds,
+        Anchor::all(px(4.)),
+        cx.theme().background,
+    ));
+
+    // 3. Set up interactions
+    window.on_mouse_event({
+        let hitbox = prepaint.hitbox.clone();
+        move |event: &MouseDownEvent, phase, window, cx| {
+            if hitbox.is_hovered(window) && phase.bubble() {
+                // Handle click
+                cx.stop_propagation();
+            }
+        }
+    });
+
+    window.set_cursor_style(CursorStyle::PointingHand, &prepaint.hitbox);
+}
+```
+
+## IntoElement Integration
+
+Elements must also implement `IntoElement` to be used as children:
+
+```rust
+impl IntoElement for MyElement {
+    type Element = Self;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+```
+
+This allows your custom element to be used directly in the element tree:
+
+```rust
+div()
+    .child(MyElement::new()) // Works because of IntoElement
+```
+
+## Common Parameters
+
+### Global and Inspector IDs
+
+Both are optional identifiers used for debugging and inspection:
+- `global_id`: Unique identifier across entire app
+- `inspector_id`: Identifier for dev tools/inspector
+
+Usually passed through to children without modification.
+
+### Window and Context
+
+- `window: &mut Window`: Window-specific operations (painting, hitboxes, events)
+- `cx: &mut App`: App-wide operations (spawning tasks, accessing globals)
+
+## Layout System Integration
+
+### window.request_layout()
+
+Creates a layout node with specified style and children:
+
+```rust
+let layout_id = window.request_layout(
+    Style {
+        size: size(px(200.), px(100.)),
+        flex: Flex::Column,
+        gap: px(8.),
+        ..default()
+    },
+    vec![child1_layout_id, child2_layout_id],
+    cx
+);
+```
+
+### Bounds<Pixels>
+
+Represents rectangular region:
+
+```rust
+pub struct Bounds<T> {
+    pub origin: Point<T>,
+    pub size: Size<T>,
+}
+
+// Create bounds
+let bounds = Bounds::new(
+    point(px(10.), px(20.)),
+    size(px(100.), px(50.))
+);
+
+// Access properties
+bounds.left()    // origin.x
+bounds.top()     // origin.y
+bounds.right()   // origin.x + size.width
+bounds.bottom()  // origin.y + size.height
+bounds.center()  // center point
+```
+
+## Hitbox System
+
+### Creating Hitboxes
+
+```rust
+// Normal hitbox (blocks events)
+let hitbox = window.insert_hitbox(bounds, HitboxBehavior::Normal);
+
+// Transparent hitbox (passes events through)
+let hitbox = window.insert_hitbox(bounds, HitboxBehavior::Transparent);
+```
+
+### Using Hitboxes
+
+```rust
+// Check if hovered
+if hitbox.is_hovered(window) {
+    // ...
+}
+
+// Set cursor style
+window.set_cursor_style(CursorStyle::PointingHand, &hitbox);
+
+// Use in event handlers
+window.on_mouse_event(move |event, phase, window, cx| {
+    if hitbox.is_hovered(window) && phase.bubble() {
+        // Handle event
+    }
+});
+```
+
+## Event Handling
+
+### Mouse Events
+
+```rust
+// Mouse down
+window.on_mouse_event(move |event: &MouseDownEvent, phase, window, cx| {
+    if phase.bubble() && bounds.contains(&event.position) {
+        // Handle mouse down
+        cx.stop_propagation(); // Prevent bubbling
+    }
+});
+
+// Mouse up
+window.on_mouse_event(move |event: &MouseUpEvent, phase, window, cx| {
+    // Handle mouse up
+});
+
+// Mouse move
+window.on_mouse_event(move |event: &MouseMoveEvent, phase, window, cx| {
+    // Handle mouse move
+});
+
+// Scroll
+window.on_mouse_event(move |event: &ScrollWheelEvent, phase, window, cx| {
+    // Handle scroll
+});
+```
+
+### Event Phase
+
+Events go through two phases:
+- **Capture**: Top-down (parent → child)
+- **Bubble**: Bottom-up (child → parent)
+
+```rust
+move |event, phase, window, cx| {
+    if phase.capture() {
+        // Handle in capture phase
+    } else if phase.bubble() {
+        // Handle in bubble phase
+    }
+
+    cx.stop_propagation(); // Stop event from continuing
+}
+```
+
+## Cursor Styles
+
+Available cursor styles:
+
+```rust
+CursorStyle::Arrow
+CursorStyle::IBeam           // Text selection
+CursorStyle::PointingHand    // Clickable
+CursorStyle::ResizeLeft
+CursorStyle::ResizeRight
+CursorStyle::ResizeUp
+CursorStyle::ResizeDown
+CursorStyle::ResizeLeftRight
+CursorStyle::ResizeUpDown
+CursorStyle::Crosshair
+CursorStyle::OperationNotAllowed
+```
+
+Usage:
+
+```rust
+window.set_cursor_style(CursorStyle::PointingHand, &hitbox);
+```

--- a/.claude/skills/gpui-kit/references/gpui/element-best-practices.md
+++ b/.claude/skills/gpui-kit/references/gpui/element-best-practices.md
@@ -1,0 +1,546 @@
+# Element Best Practices
+
+**Contents:** [State Management](#state-management) · [Performance Considerations](#performance-considerations) · [Interaction Handling](#interaction-handling) · [Layout Strategies](#layout-strategies) · [Error Handling](#error-handling) · [Testing Element Implementations](#testing-element-implementations) · [Common Pitfalls](#common-pitfalls) · [Performance Checklist](#performance-checklist)
+
+## State Management
+
+### Using Associated Types Effectively
+
+**Good:** Use associated types to pass meaningful data between phases
+
+```rust
+// Good: Structured state with type safety
+type RequestLayoutState = (StyledText, Vec<ChildLayout>);
+type PrepaintState = (Hitbox, Vec<ChildBounds>);
+```
+
+**Bad:** Using empty state when you need data
+
+```rust
+// Bad: No state when you need to pass data
+type RequestLayoutState = ();
+type PrepaintState = ();
+// Now you can't pass layout info to paint phase!
+```
+
+### Managing Complex State
+
+For elements with complex state, create dedicated structs:
+
+```rust
+// Good: Dedicated struct for complex state
+pub struct TextElementState {
+    pub styled_text: StyledText,
+    pub text_layout: TextLayout,
+    pub child_states: Vec<ChildState>,
+}
+
+type RequestLayoutState = TextElementState;
+```
+
+**Benefits:**
+- Clear documentation of state structure
+- Easy to extend
+- Type-safe access
+
+### State Lifecycle
+
+**Golden Rule:** State flows in one direction through the phases
+
+```
+request_layout → RequestLayoutState →
+prepaint → PrepaintState →
+paint
+```
+
+**Don't:**
+- Store state in the element struct that should be in associated types
+- Try to mutate element state in paint phase (use `cx.notify()` to schedule re-render)
+- Pass mutable references across phase boundaries
+
+## Performance Considerations
+
+### Minimize Allocations in Paint Phase
+
+**Critical:** Paint phase is called every frame during animations. Minimize allocations.
+
+**Good:** Pre-allocate in `request_layout` or `prepaint`
+
+```rust
+impl Element for MyElement {
+    fn request_layout(&mut self, .., window: &mut Window, cx: &mut App)
+        -> (LayoutId, Vec<StyledText>)
+    {
+        // Allocate once during layout
+        let styled_texts = self.children
+            .iter()
+            .map(|child| StyledText::new(child.text.clone()))
+            .collect();
+
+        (layout_id, styled_texts)
+    }
+
+    fn paint(&mut self, .., styled_texts: &mut Vec<StyledText>, ..) {
+        // Just use pre-allocated styled_texts
+        for text in styled_texts {
+            text.paint(..);
+        }
+    }
+}
+```
+
+**Bad:** Allocate in `paint` phase
+
+```rust
+fn paint(&mut self, ..) {
+    // Bad: Allocation in paint phase!
+    let styled_texts: Vec<_> = self.children
+        .iter()
+        .map(|child| StyledText::new(child.text.clone()))
+        .collect();
+}
+```
+
+### Cache Expensive Computations
+
+Use memoization for expensive operations:
+
+```rust
+pub struct CachedElement {
+    // Cache key
+    last_text: Option<SharedString>,
+    last_width: Option<Pixels>,
+
+    // Cached result
+    cached_layout: Option<TextLayout>,
+}
+
+impl Element for CachedElement {
+    fn request_layout(&mut self, .., window: &mut Window, cx: &mut App)
+        -> (LayoutId, TextLayout)
+    {
+        let current_width = window.bounds().width();
+
+        // Check if cache is valid
+        if self.last_text.as_ref() != Some(&self.text)
+            || self.last_width != Some(current_width)
+            || self.cached_layout.is_none()
+        {
+            // Recompute expensive layout
+            self.cached_layout = Some(self.compute_text_layout(current_width));
+            self.last_text = Some(self.text.clone());
+            self.last_width = Some(current_width);
+        }
+
+        // Use cached layout
+        let layout = self.cached_layout.as_ref().unwrap();
+        (layout_id, layout.clone())
+    }
+}
+```
+
+### Lazy Child Rendering
+
+Only render visible children in scrollable containers:
+
+```rust
+fn paint(&mut self, .., bounds: Bounds<Pixels>, paint_state: &mut Self::PrepaintState, ..) {
+    for (i, child) in self.children.iter_mut().enumerate() {
+        let child_bounds = paint_state.child_bounds[i];
+
+        // Only paint visible children
+        if self.is_visible(&child_bounds, &bounds) {
+            child.paint(..);
+        }
+    }
+}
+
+fn is_visible(&self, child_bounds: &Bounds<Pixels>, container_bounds: &Bounds<Pixels>) -> bool {
+    child_bounds.bottom() >= container_bounds.top() &&
+    child_bounds.top() <= container_bounds.bottom()
+}
+```
+
+## Interaction Handling
+
+### Proper Event Bubbling
+
+Always check phase and bounds before handling events:
+
+```rust
+fn paint(&mut self, .., window: &mut Window, cx: &mut App) {
+    window.on_mouse_event({
+        let hitbox = self.hitbox.clone();
+        move |event: &MouseDownEvent, phase, window, cx| {
+            // Check phase first
+            if !phase.bubble() {
+                return;
+            }
+
+            // Check if event is within bounds
+            if !hitbox.is_hovered(window) {
+                return;
+            }
+
+            // Handle event
+            self.handle_click(event);
+
+            // Stop propagation if handled
+            cx.stop_propagation();
+        }
+    });
+}
+```
+
+**Don't forget:**
+- Check `phase.bubble()` or `phase.capture()` as appropriate
+- Check hitbox hover state or bounds
+- Call `cx.stop_propagation()` if you handle the event
+
+### Hitbox Management
+
+Create hitboxes in `prepaint` phase, not `paint`:
+
+**Good:**
+
+```rust
+fn prepaint(&mut self, .., bounds: Bounds<Pixels>, window: &mut Window, ..) -> Hitbox {
+    // Create hitbox in prepaint
+    window.insert_hitbox(bounds, HitboxBehavior::Normal)
+}
+
+fn paint(&mut self, .., hitbox: &mut Hitbox, window: &mut Window, ..) {
+    // Use hitbox in paint
+    window.set_cursor_style(CursorStyle::PointingHand, hitbox);
+}
+```
+
+**Hitbox Behaviors:**
+
+```rust
+// Normal: Blocks events from passing through
+HitboxBehavior::Normal
+
+// Transparent: Allows events to pass through to elements below
+HitboxBehavior::Transparent
+```
+
+### Cursor Style Guidelines
+
+Set appropriate cursor styles for interactivity cues:
+
+```rust
+// Text selection
+window.set_cursor_style(CursorStyle::IBeam, &hitbox);
+
+// Clickable elements (desktop convention: use default, not pointing hand)
+window.set_cursor_style(CursorStyle::Arrow, &hitbox);
+
+// Links (web convention: use pointing hand)
+window.set_cursor_style(CursorStyle::PointingHand, &hitbox);
+
+// Resizable edges
+window.set_cursor_style(CursorStyle::ResizeLeftRight, &hitbox);
+```
+
+**Desktop vs Web Convention:**
+- Desktop apps: Use `Arrow` for buttons
+- Web apps: Use `PointingHand` for links only
+
+## Layout Strategies
+
+### Fixed Size Elements
+
+For elements with known, unchanging size:
+
+```rust
+fn request_layout(&mut self, .., window: &mut Window, cx: &mut App) -> (LayoutId, ()) {
+    let layout_id = window.request_layout(
+        Style {
+            size: size(px(200.), px(100.)),
+            ..default()
+        },
+        vec![], // No children
+        cx
+    );
+    (layout_id, ())
+}
+```
+
+### Content-Based Sizing
+
+For elements sized by their content:
+
+```rust
+fn request_layout(&mut self, .., window: &mut Window, cx: &mut App)
+    -> (LayoutId, Size<Pixels>)
+{
+    // Measure content
+    let text_bounds = self.measure_text(window);
+    let padding = px(16.);
+
+    let layout_id = window.request_layout(
+        Style {
+            size: size(
+                text_bounds.width() + padding * 2.,
+                text_bounds.height() + padding * 2.,
+            ),
+            ..default()
+        },
+        vec![],
+        cx
+    );
+
+    (layout_id, text_bounds)
+}
+```
+
+### Flexible Layouts
+
+For elements that adapt to available space:
+
+```rust
+fn request_layout(&mut self, .., window: &mut Window, cx: &mut App)
+    -> (LayoutId, Vec<LayoutId>)
+{
+    let mut child_layout_ids = Vec::new();
+
+    for child in &mut self.children {
+        let (layout_id, _) = child.request_layout(window, cx);
+        child_layout_ids.push(layout_id);
+    }
+
+    let layout_id = window.request_layout(
+        Style {
+            flex_direction: FlexDirection::Row,
+            gap: px(8.),
+            size: Size {
+                width: relative(1.0),  // Fill parent width
+                height: auto(),        // Auto height
+            },
+            ..default()
+        },
+        child_layout_ids.clone(),
+        cx
+    );
+
+    (layout_id, child_layout_ids)
+}
+```
+
+## Error Handling
+
+### Graceful Degradation
+
+Handle errors gracefully, don't panic:
+
+```rust
+fn request_layout(&mut self, .., window: &mut Window, cx: &mut App)
+    -> (LayoutId, Option<TextLayout>)
+{
+    // Try to create styled text
+    match StyledText::new(self.text.clone()).request_layout(None, None, window, cx) {
+        Ok((layout_id, text_layout)) => {
+            (layout_id, Some(text_layout))
+        }
+        Err(e) => {
+            // Log error
+            eprintln!("Failed to layout text: {}", e);
+
+            // Fallback to simple text
+            let fallback_text = StyledText::new("(Error loading text)".into());
+            let (layout_id, _) = fallback_text.request_layout(None, None, window, cx);
+            (layout_id, None)
+        }
+    }
+}
+```
+
+### Defensive Bounds Checking
+
+Always validate bounds and indices:
+
+```rust
+fn paint_selection(&self, selection: &Selection, text_layout: &TextLayout, ..) {
+    // Validate selection bounds
+    let start = selection.start.min(self.text.len());
+    let end = selection.end.min(self.text.len());
+
+    if start >= end {
+        return; // Invalid selection
+    }
+
+    let rects = text_layout.rects_for_range(start..end);
+    // Paint selection...
+}
+```
+
+## Testing Element Implementations
+
+### Layout Tests
+
+Test that layout calculations are correct:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui_kit::TestAppContext;
+
+    #[gpui_kit::test]
+    fn test_element_layout(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let mut window = cx.open_window(Default::default(), |_, _| ()).unwrap();
+
+            window.update(cx, |window, cx| {
+                let mut element = MyElement::new();
+                let (layout_id, layout_state) = element.request_layout(
+                    None,
+                    None,
+                    window,
+                    cx
+                );
+
+                // Assert layout properties
+                let bounds = window.layout_bounds(layout_id);
+                assert_eq!(bounds.size.width, px(200.));
+                assert_eq!(bounds.size.height, px(100.));
+            });
+        });
+    }
+}
+```
+
+### Interaction Tests
+
+Test that interactions work correctly:
+
+```rust
+#[gpui_kit::test]
+fn test_element_click(cx: &mut TestAppContext) {
+    cx.update(|cx| {
+        let mut window = cx.open_window(Default::default(), |_, cx| {
+            cx.new(|_| MyElement::new())
+        }).unwrap();
+
+        window.update(cx, |window, cx| {
+            let view = window.root_view().unwrap();
+
+            // Simulate click
+            let position = point(px(10.), px(10.));
+            window.dispatch_event(MouseDownEvent {
+                position,
+                button: MouseButton::Left,
+                modifiers: Modifiers::default(),
+            });
+
+            // Assert element responded
+            view.read(cx).assert_clicked();
+        });
+    });
+}
+```
+
+## Common Pitfalls
+
+### ❌ Storing Layout State in Element Struct
+
+**Bad:**
+
+```rust
+pub struct MyElement {
+    id: ElementId,
+    // Bad: This should be in RequestLayoutState
+    cached_layout: Option<TextLayout>,
+}
+```
+
+**Good:**
+
+```rust
+pub struct MyElement {
+    id: ElementId,
+    text: SharedString,
+}
+
+type RequestLayoutState = TextLayout; // Good: State in associated type
+```
+
+### ❌ Mutating Element in Paint Phase
+
+**Bad:**
+
+```rust
+fn paint(&mut self, ..) {
+    self.counter += 1; // Bad: Mutating element in paint
+}
+```
+
+**Good:**
+
+```rust
+fn paint(&mut self, .., window: &mut Window, cx: &mut App) {
+    window.on_mouse_event(move |event, phase, window, cx| {
+        if phase.bubble() {
+            self.counter += 1;
+            cx.notify(); // Schedule re-render
+        }
+    });
+}
+```
+
+### ❌ Creating Hitboxes in Paint Phase
+
+**Bad:**
+
+```rust
+fn paint(&mut self, .., bounds: Bounds<Pixels>, window: &mut Window, ..) {
+    // Bad: Creating hitbox in paint
+    let hitbox = window.insert_hitbox(bounds, HitboxBehavior::Normal);
+}
+```
+
+**Good:**
+
+```rust
+fn prepaint(&mut self, .., bounds: Bounds<Pixels>, window: &mut Window, ..) -> Hitbox {
+    // Good: Creating hitbox in prepaint
+    window.insert_hitbox(bounds, HitboxBehavior::Normal)
+}
+```
+
+### ❌ Ignoring Event Phase
+
+**Bad:**
+
+```rust
+window.on_mouse_event(move |event, phase, window, cx| {
+    // Bad: Not checking phase
+    self.handle_click(event);
+});
+```
+
+**Good:**
+
+```rust
+window.on_mouse_event(move |event, phase, window, cx| {
+    // Good: Checking phase
+    if !phase.bubble() {
+        return;
+    }
+    self.handle_click(event);
+});
+```
+
+## Performance Checklist
+
+Before shipping an element implementation, verify:
+
+- [ ] No allocations in `paint` phase (except event handlers)
+- [ ] Expensive computations are cached/memoized
+- [ ] Only visible children are rendered in scrollable containers
+- [ ] Hitboxes created in `prepaint`, not `paint`
+- [ ] Event handlers check phase and bounds
+- [ ] Layout state is passed through associated types, not stored in element
+- [ ] Element implements proper error handling with fallbacks
+- [ ] Tests cover layout calculations and interactions

--- a/.claude/skills/gpui-kit/references/gpui/element-examples.md
+++ b/.claude/skills/gpui-kit/references/gpui/element-examples.md
@@ -1,0 +1,632 @@
+# Element Implementation Examples
+
+Complete examples of implementing custom elements for various scenarios.
+
+## Table of Contents
+
+1. [Simple Text Element](#simple-text-element)
+2. [Interactive Element with Selection](#interactive-element-with-selection)
+3. [Complex Element with Child Management](#complex-element-with-child-management)
+
+## Simple Text Element
+
+A basic text element with syntax highlighting support.
+
+```rust
+pub struct SimpleText {
+    id: ElementId,
+    text: SharedString,
+    highlights: Vec<(Range<usize>, HighlightStyle)>,
+}
+
+impl IntoElement for SimpleText {
+    type Element = Self;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+
+impl Element for SimpleText {
+    type RequestLayoutState = StyledText;
+    type PrepaintState = Hitbox;
+
+    fn id(&self) -> Option<ElementId> {
+        Some(self.id.clone())
+    }
+
+    fn source_location(&self) -> Option<&'static std::panic::Location<'static>> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        global_id: Option<&GlobalElementId>,
+        inspector_id: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App
+    ) -> (LayoutId, Self::RequestLayoutState) {
+        // Create styled text with highlights
+        let mut runs = Vec::new();
+        let mut ix = 0;
+
+        for (range, highlight) in &self.highlights {
+            // Add unstyled text before highlight
+            if ix < range.start {
+                runs.push(window.text_style().to_run(range.start - ix));
+            }
+
+            // Add highlighted text
+            runs.push(
+                window.text_style()
+                    .highlight(*highlight)
+                    .to_run(range.len())
+            );
+            ix = range.end;
+        }
+
+        // Add remaining unstyled text
+        if ix < self.text.len() {
+            runs.push(window.text_style().to_run(self.text.len() - ix));
+        }
+
+        let styled_text = StyledText::new(self.text.clone()).with_runs(runs);
+        let (layout_id, _) = styled_text.request_layout(
+            global_id,
+            inspector_id,
+            window,
+            cx
+        );
+
+        (layout_id, styled_text)
+    }
+
+    fn prepaint(
+        &mut self,
+        global_id: Option<&GlobalElementId>,
+        inspector_id: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        styled_text: &mut Self::RequestLayoutState,
+        window: &mut Window,
+        cx: &mut App
+    ) -> Self::PrepaintState {
+        // Prepaint the styled text
+        styled_text.prepaint(
+            global_id,
+            inspector_id,
+            bounds,
+            &mut (),
+            window,
+            cx
+        );
+
+        // Create hitbox for interaction
+        let hitbox = window.insert_hitbox(bounds, HitboxBehavior::Normal);
+        hitbox
+    }
+
+    fn paint(
+        &mut self,
+        global_id: Option<&GlobalElementId>,
+        inspector_id: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        styled_text: &mut Self::RequestLayoutState,
+        hitbox: &mut Self::PrepaintState,
+        window: &mut Window,
+        cx: &mut App
+    ) {
+        // Paint the styled text
+        styled_text.paint(
+            global_id,
+            inspector_id,
+            bounds,
+            &mut (),
+            &mut (),
+            window,
+            cx
+        );
+
+        // Set cursor style for text
+        window.set_cursor_style(CursorStyle::IBeam, hitbox);
+    }
+}
+```
+
+## Interactive Element with Selection
+
+A text element that supports text selection via mouse interaction.
+
+```rust
+#[derive(Clone)]
+pub struct Selection {
+    pub start: usize,
+    pub end: usize,
+}
+
+pub struct SelectableText {
+    id: ElementId,
+    text: SharedString,
+    selectable: bool,
+    selection: Option<Selection>,
+}
+
+impl IntoElement for SelectableText {
+    type Element = Self;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+
+impl Element for SelectableText {
+    type RequestLayoutState = TextLayout;
+    type PrepaintState = Option<Hitbox>;
+
+    fn id(&self) -> Option<ElementId> {
+        Some(self.id.clone())
+    }
+
+    fn source_location(&self) -> Option<&'static std::panic::Location<'static>> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        global_id: Option<&GlobalElementId>,
+        inspector_id: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App
+    ) -> (LayoutId, Self::RequestLayoutState) {
+        let styled_text = StyledText::new(self.text.clone());
+        let (layout_id, _) = styled_text.request_layout(
+            global_id,
+            inspector_id,
+            window,
+            cx
+        );
+
+        // Extract text layout for selection painting
+        let text_layout = styled_text.layout().clone();
+
+        (layout_id, text_layout)
+    }
+
+    fn prepaint(
+        &mut self,
+        _global_id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        _text_layout: &mut Self::RequestLayoutState,
+        window: &mut Window,
+        _cx: &mut App
+    ) -> Self::PrepaintState {
+        // Only create hitbox if selectable
+        if self.selectable {
+            Some(window.insert_hitbox(bounds, HitboxBehavior::Normal))
+        } else {
+            None
+        }
+    }
+
+    fn paint(
+        &mut self,
+        global_id: Option<&GlobalElementId>,
+        inspector_id: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        text_layout: &mut Self::RequestLayoutState,
+        hitbox: &mut Self::PrepaintState,
+        window: &mut Window,
+        cx: &mut App
+    ) {
+        // Paint text
+        let styled_text = StyledText::new(self.text.clone());
+        styled_text.paint(
+            global_id,
+            inspector_id,
+            bounds,
+            &mut (),
+            &mut (),
+            window,
+            cx
+        );
+
+        // Paint selection if any
+        if let Some(selection) = &self.selection {
+            Self::paint_selection(selection, text_layout, &bounds, window, cx);
+        }
+
+        // Handle mouse events for selection
+        if let Some(hitbox) = hitbox {
+            window.set_cursor_style(CursorStyle::IBeam, hitbox);
+
+            // Mouse down to start selection
+            window.on_mouse_event({
+                let bounds = bounds.clone();
+                move |event: &MouseDownEvent, phase, window, cx| {
+                    if bounds.contains(&event.position) && phase.bubble() {
+                        // Start selection at mouse position
+                        let char_index = Self::position_to_index(
+                            event.position,
+                            &bounds,
+                            text_layout
+                        );
+                        self.selection = Some(Selection {
+                            start: char_index,
+                            end: char_index,
+                        });
+                        cx.notify();
+                        cx.stop_propagation();
+                    }
+                }
+            });
+
+            // Mouse drag to extend selection
+            window.on_mouse_event({
+                let bounds = bounds.clone();
+                move |event: &MouseMoveEvent, phase, window, cx| {
+                    if let Some(selection) = &mut self.selection {
+                        if phase.bubble() {
+                            let char_index = Self::position_to_index(
+                                event.position,
+                                &bounds,
+                                text_layout
+                            );
+                            selection.end = char_index;
+                            cx.notify();
+                        }
+                    }
+                }
+            });
+        }
+    }
+}
+
+impl SelectableText {
+    fn paint_selection(
+        selection: &Selection,
+        text_layout: &TextLayout,
+        bounds: &Bounds<Pixels>,
+        window: &mut Window,
+        cx: &mut App
+    ) {
+        // Calculate selection bounds from text layout
+        let selection_rects = text_layout.rects_for_range(
+            selection.start..selection.end
+        );
+
+        // Paint selection background
+        for rect in selection_rects {
+            window.paint_quad(paint_quad(
+                Bounds::new(
+                    point(bounds.left() + rect.origin.x, bounds.top() + rect.origin.y),
+                    rect.size
+                ),
+                Anchor::default(),
+                cx.theme().selection_background,
+            ));
+        }
+    }
+
+    fn position_to_index(
+        position: Point<Pixels>,
+        bounds: &Bounds<Pixels>,
+        text_layout: &TextLayout
+    ) -> usize {
+        // Convert screen position to character index
+        let relative_pos = point(
+            position.x - bounds.left(),
+            position.y - bounds.top()
+        );
+        text_layout.index_for_position(relative_pos)
+    }
+}
+```
+
+## Complex Element with Child Management
+
+A container element that manages multiple children with scrolling support.
+
+```rust
+pub struct ComplexElement {
+    id: ElementId,
+    children: Vec<Box<dyn Element<RequestLayoutState = (), PrepaintState = ()>>>,
+    scrollable: bool,
+    scroll_offset: Point<Pixels>,
+}
+
+struct ComplexLayoutState {
+    child_layouts: Vec<LayoutId>,
+    total_height: Pixels,
+}
+
+struct ComplexPaintState {
+    child_bounds: Vec<Bounds<Pixels>>,
+    hitbox: Hitbox,
+}
+
+impl IntoElement for ComplexElement {
+    type Element = Self;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+
+impl Element for ComplexElement {
+    type RequestLayoutState = ComplexLayoutState;
+    type PrepaintState = ComplexPaintState;
+
+    fn id(&self) -> Option<ElementId> {
+        Some(self.id.clone())
+    }
+
+    fn source_location(&self) -> Option<&'static std::panic::Location<'static>> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        global_id: Option<&GlobalElementId>,
+        inspector_id: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App
+    ) -> (LayoutId, Self::RequestLayoutState) {
+        let mut child_layouts = Vec::new();
+        let mut total_height = px(0.);
+
+        // Request layout for all children
+        for child in &mut self.children {
+            let (child_layout_id, _) = child.request_layout(
+                global_id,
+                inspector_id,
+                window,
+                cx
+            );
+            child_layouts.push(child_layout_id);
+
+            // Get child size from layout
+            let child_size = window.layout_bounds(child_layout_id).size();
+            total_height += child_size.height;
+        }
+
+        // Create container layout
+        let layout_id = window.request_layout(
+            Style {
+                flex_direction: FlexDirection::Column,
+                gap: px(8.),
+                size: Size {
+                    width: relative(1.0),
+                    height: if self.scrollable {
+                        // Fixed height for scrollable
+                        px(400.)
+                    } else {
+                        // Auto height for non-scrollable
+                        total_height
+                    },
+                },
+                ..default()
+            },
+            child_layouts.clone(),
+            cx
+        );
+
+        (layout_id, ComplexLayoutState {
+            child_layouts,
+            total_height,
+        })
+    }
+
+    fn prepaint(
+        &mut self,
+        global_id: Option<&GlobalElementId>,
+        inspector_id: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        layout_state: &mut Self::RequestLayoutState,
+        window: &mut Window,
+        cx: &mut App
+    ) -> Self::PrepaintState {
+        let mut child_bounds = Vec::new();
+        let mut y_offset = self.scroll_offset.y;
+
+        // Calculate child bounds and prepaint children
+        for (child, layout_id) in self.children.iter_mut()
+            .zip(&layout_state.child_layouts)
+        {
+            let child_size = window.layout_bounds(*layout_id).size();
+            let child_bound = Bounds::new(
+                point(bounds.left(), bounds.top() + y_offset),
+                child_size
+            );
+
+            // Only prepaint visible children
+            if self.is_visible(&child_bound, &bounds) {
+                child.prepaint(
+                    global_id,
+                    inspector_id,
+                    child_bound,
+                    &mut (),
+                    window,
+                    cx
+                );
+            }
+
+            child_bounds.push(child_bound);
+            y_offset += child_size.height + px(8.); // gap
+        }
+
+        let hitbox = window.insert_hitbox(bounds, HitboxBehavior::Normal);
+
+        ComplexPaintState {
+            child_bounds,
+            hitbox,
+        }
+    }
+
+    fn paint(
+        &mut self,
+        global_id: Option<&GlobalElementId>,
+        inspector_id: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        layout_state: &mut Self::RequestLayoutState,
+        paint_state: &mut Self::PrepaintState,
+        window: &mut Window,
+        cx: &mut App
+    ) {
+        // Paint background
+        window.paint_quad(paint_quad(
+            bounds,
+            Anchor::all(px(4.)),
+            cx.theme().background,
+        ));
+
+        // Paint visible children only
+        for (i, child) in self.children.iter_mut().enumerate() {
+            let child_bounds = paint_state.child_bounds[i];
+
+            if self.is_visible(&child_bounds, &bounds) {
+                child.paint(
+                    global_id,
+                    inspector_id,
+                    child_bounds,
+                    &mut (),
+                    &mut (),
+                    window,
+                    cx
+                );
+            }
+        }
+
+        // Paint scrollbar if scrollable
+        if self.scrollable {
+            self.paint_scrollbar(bounds, layout_state, window, cx);
+        }
+
+        // Handle scroll events
+        if self.scrollable {
+            window.on_mouse_event({
+                let hitbox = paint_state.hitbox.clone();
+                let total_height = layout_state.total_height;
+                let visible_height = bounds.size.height;
+
+                move |event: &ScrollWheelEvent, phase, window, cx| {
+                    if hitbox.is_hovered(window) && phase.bubble() {
+                        // Update scroll offset
+                        self.scroll_offset.y -= event.delta.y;
+
+                        // Clamp scroll offset
+                        let max_scroll = (total_height - visible_height).max(px(0.));
+                        self.scroll_offset.y = self.scroll_offset.y
+                            .max(px(0.))
+                            .min(max_scroll);
+
+                        cx.notify();
+                        cx.stop_propagation();
+                    }
+                }
+            });
+        }
+    }
+}
+
+impl ComplexElement {
+    fn is_visible(&self, child_bounds: &Bounds<Pixels>, container_bounds: &Bounds<Pixels>) -> bool {
+        // Check if child is within visible area
+        child_bounds.bottom() >= container_bounds.top() &&
+        child_bounds.top() <= container_bounds.bottom()
+    }
+
+    fn paint_scrollbar(
+        &self,
+        bounds: Bounds<Pixels>,
+        layout_state: &ComplexLayoutState,
+        window: &mut Window,
+        cx: &mut App
+    ) {
+        let scrollbar_width = px(8.);
+        let visible_height = bounds.size.height;
+        let total_height = layout_state.total_height;
+
+        if total_height <= visible_height {
+            return; // No need for scrollbar
+        }
+
+        // Calculate scrollbar position and size
+        let scroll_ratio = self.scroll_offset.y / (total_height - visible_height);
+        let thumb_height = (visible_height / total_height) * visible_height;
+        let thumb_y = scroll_ratio * (visible_height - thumb_height);
+
+        // Paint scrollbar track
+        let track_bounds = Bounds::new(
+            point(bounds.right() - scrollbar_width, bounds.top()),
+            size(scrollbar_width, visible_height)
+        );
+        window.paint_quad(paint_quad(
+            track_bounds,
+            Anchor::default(),
+            cx.theme().scrollbar_track,
+        ));
+
+        // Paint scrollbar thumb
+        let thumb_bounds = Bounds::new(
+            point(bounds.right() - scrollbar_width, bounds.top() + thumb_y),
+            size(scrollbar_width, thumb_height)
+        );
+        window.paint_quad(paint_quad(
+            thumb_bounds,
+            Anchor::all(px(4.)),
+            cx.theme().scrollbar_thumb,
+        ));
+    }
+}
+```
+
+## Usage Examples
+
+### Using SimpleText
+
+```rust
+fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    div()
+        .child(SimpleText {
+            id: ElementId::Name("code-text".into()),
+            text: "fn main() { println!(\"Hello\"); }".into(),
+            highlights: vec![
+                (0..2, HighlightStyle::keyword()),
+                (3..7, HighlightStyle::function()),
+            ],
+        })
+}
+```
+
+### Using SelectableText
+
+```rust
+fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    div()
+        .child(SelectableText {
+            id: ElementId::Name("selectable-text".into()),
+            text: "Select this text with your mouse".into(),
+            selectable: true,
+            selection: self.current_selection.clone(),
+        })
+}
+```
+
+### Using ComplexElement
+
+```rust
+fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    let children: Vec<Box<dyn Element<_, _>>> = self.items
+        .iter()
+        .map(|item| Box::new(div().child(item.name.clone())) as Box<_>)
+        .collect();
+
+    div()
+        .child(ComplexElement {
+            id: ElementId::Name("scrollable-list".into()),
+            children,
+            scrollable: true,
+            scroll_offset: self.scroll_offset,
+        })
+}
+```

--- a/.claude/skills/gpui-kit/references/gpui/element-id.md
+++ b/.claude/skills/gpui-kit/references/gpui/element-id.md
@@ -1,0 +1,95 @@
+# ElementId
+
+`ElementId` is a unique identifier for a GPUI element. It is required for elements that need:
+- Mouse event handling (`on_click`, `on_hover`, etc.)
+- State storage via `window.use_keyed_state`
+- Interaction tracking
+
+## Making an Element Stateful
+
+Call `.id()` on a `div()` to create a `Stateful<Div>`:
+
+```rust
+div().id("my-element")          // ElementId from &str
+div().id(42usize)               // ElementId from usize
+div().id(ElementId::from(idx))  // Explicit
+```
+
+Without `.id()`, a div cannot receive mouse events or store state.
+
+## Accepted Types
+
+```rust
+impl Into<ElementId> for &str      // "my-id"
+impl Into<ElementId> for String    // String::from("my-id")
+impl Into<ElementId> for usize     // 0, 1, 2, ...
+impl Into<ElementId> for u64
+impl Into<ElementId> for SharedString
+```
+
+## Uniqueness Rules
+
+IDs must be unique within the same **stateful parent's scope** — not globally. GPUI builds a `GlobalElementId` by chaining parent IDs:
+
+```rust
+div().id("app").child(
+    div().id("list1").children(vec![
+        div().id(1usize).child("Item 1"),  // GlobalId: ["app", "list1", 1]
+        div().id(2usize).child("Item 2"),  // GlobalId: ["app", "list1", 2]
+    ])
+).child(
+    div().id("list2").children(vec![
+        div().id(1usize).child("Item 1"),  // GlobalId: ["app", "list2", 1] — no conflict
+    ])
+)
+```
+
+Items in different parent scopes can reuse simple IDs (integers, short strings).
+
+## In Component Structs
+
+Components always store `id: ElementId` and pass it in `new()`:
+
+```rust
+#[derive(IntoElement)]
+pub struct Button {
+    id: ElementId,
+    base: Stateful<Div>,
+    // ...
+}
+
+impl Button {
+    pub fn new(id: impl Into<ElementId>) -> Self {
+        let id = id.into();
+        Self {
+            id: id.clone(),
+            base: div().id(id),  // id applied to base
+            // ...
+        }
+    }
+}
+
+impl RenderOnce for Button {
+    fn render(self, _: &mut Window, _: &mut App) -> impl IntoElement {
+        self.base  // already has .id() applied
+            .on_click(/* ... */)
+    }
+}
+```
+
+## Usage at Call Sites
+
+```rust
+// Use unique string IDs for named components
+Button::new("save-btn").label("Save")
+Button::new("cancel-btn").label("Cancel")
+
+// Use index-based IDs in lists
+for (i, item) in items.iter().enumerate() {
+    div().id(i)  // unique within this parent
+}
+
+// Use descriptive IDs for debugging
+Input::new("search-input")
+Select::new("country-select")
+```

--- a/.claude/skills/gpui-kit/references/gpui/element-patterns.md
+++ b/.claude/skills/gpui-kit/references/gpui/element-patterns.md
@@ -1,0 +1,509 @@
+# Common Element Patterns
+
+**Contents:** [Text Rendering Elements](#text-rendering-elements) · [Container Elements](#container-elements) · [Interactive Elements](#interactive-elements) · [Composite Elements](#composite-elements) · [Scrollable Elements](#scrollable-elements) · [Pattern Selection Guide](#pattern-selection-guide)
+
+## Text Rendering Elements
+
+Elements that display and manipulate text content.
+
+### Pattern Characteristics
+
+- Use `StyledText` for text layout and rendering
+- Handle text selection in `paint` phase with hitbox interaction
+- Create hitboxes for text interaction in `prepaint`
+- Support text highlighting and custom styling via runs
+
+### Implementation Template
+
+```rust
+pub struct TextElement {
+    id: ElementId,
+    text: SharedString,
+    style: TextStyle,
+}
+
+impl Element for TextElement {
+    type RequestLayoutState = StyledText;
+    type PrepaintState = Hitbox;
+
+    fn request_layout(&mut self, .., window: &mut Window, cx: &mut App)
+        -> (LayoutId, StyledText)
+    {
+        let styled_text = StyledText::new(self.text.clone())
+            .with_style(self.style);
+        let (layout_id, _) = styled_text.request_layout(None, None, window, cx);
+        (layout_id, styled_text)
+    }
+
+    fn prepaint(&mut self, .., bounds: Bounds<Pixels>, styled_text: &mut StyledText,
+                window: &mut Window, cx: &mut App) -> Hitbox
+    {
+        styled_text.prepaint(None, None, bounds, &mut (), window, cx);
+        window.insert_hitbox(bounds, HitboxBehavior::Normal)
+    }
+
+    fn paint(&mut self, .., bounds: Bounds<Pixels>, styled_text: &mut StyledText,
+             hitbox: &mut Hitbox, window: &mut Window, cx: &mut App)
+    {
+        styled_text.paint(None, None, bounds, &mut (), &mut (), window, cx);
+        window.set_cursor_style(CursorStyle::IBeam, hitbox);
+    }
+}
+```
+
+### Use Cases
+
+- Code editors with syntax highlighting
+- Rich text displays
+- Labels with custom formatting
+- Selectable text areas
+
+## Container Elements
+
+Elements that manage and layout child elements.
+
+### Pattern Characteristics
+
+- Manage child element layouts and positions
+- Handle scrolling and clipping when needed
+- Implement flex/grid-like layouts
+- Coordinate child interactions and event delegation
+
+### Implementation Template
+
+```rust
+pub struct ContainerElement {
+    id: ElementId,
+    children: Vec<AnyElement>,
+    direction: FlexDirection,
+    gap: Pixels,
+}
+
+impl Element for ContainerElement {
+    type RequestLayoutState = Vec<LayoutId>;
+    type PrepaintState = Vec<Bounds<Pixels>>;
+
+    fn request_layout(&mut self, .., window: &mut Window, cx: &mut App)
+        -> (LayoutId, Vec<LayoutId>)
+    {
+        let child_layout_ids: Vec<_> = self.children
+            .iter_mut()
+            .map(|child| child.request_layout(window, cx).0)
+            .collect();
+
+        let layout_id = window.request_layout(
+            Style {
+                flex_direction: self.direction,
+                gap: self.gap,
+                ..default()
+            },
+            child_layout_ids.clone(),
+            cx
+        );
+
+        (layout_id, child_layout_ids)
+    }
+
+    fn prepaint(&mut self, .., bounds: Bounds<Pixels>, layout_ids: &mut Vec<LayoutId>,
+                window: &mut Window, cx: &mut App) -> Vec<Bounds<Pixels>>
+    {
+        let mut child_bounds = Vec::new();
+
+        for (child, layout_id) in self.children.iter_mut().zip(layout_ids.iter()) {
+            let child_bound = window.layout_bounds(*layout_id);
+            child.prepaint(child_bound, window, cx);
+            child_bounds.push(child_bound);
+        }
+
+        child_bounds
+    }
+
+    fn paint(&mut self, .., child_bounds: &mut Vec<Bounds<Pixels>>,
+             window: &mut Window, cx: &mut App)
+    {
+        for (child, bounds) in self.children.iter_mut().zip(child_bounds.iter()) {
+            child.paint(*bounds, window, cx);
+        }
+    }
+}
+```
+
+### Use Cases
+
+- Panels and split views
+- List containers
+- Grid layouts
+- Tab containers
+
+## Interactive Elements
+
+Elements that respond to user input (mouse, keyboard, touch).
+
+### Pattern Characteristics
+
+- Create appropriate hitboxes for interaction areas
+- Handle mouse/keyboard/touch events properly
+- Manage focus and cursor styles
+- Support hover, active, and disabled states
+
+### Implementation Template
+
+```rust
+pub struct InteractiveElement {
+    id: ElementId,
+    content: AnyElement,
+    on_click: Option<Box<dyn Fn(&MouseUpEvent, &mut Window, &mut App)>>,
+    hover_style: Option<Style>,
+}
+
+impl Element for InteractiveElement {
+    type RequestLayoutState = LayoutId;
+    type PrepaintState = (Hitbox, bool); // hitbox and is_hovered
+
+    fn request_layout(&mut self, .., window: &mut Window, cx: &mut App)
+        -> (LayoutId, LayoutId)
+    {
+        let (content_layout, _) = self.content.request_layout(window, cx);
+        (content_layout, content_layout)
+    }
+
+    fn prepaint(&mut self, .., bounds: Bounds<Pixels>, content_layout: &mut LayoutId,
+                window: &mut Window, cx: &mut App) -> (Hitbox, bool)
+    {
+        let hitbox = window.insert_hitbox(bounds, HitboxBehavior::Normal);
+        let is_hovered = hitbox.is_hovered(window);
+
+        self.content.prepaint(bounds, window, cx);
+
+        (hitbox, is_hovered)
+    }
+
+    fn paint(&mut self, .., bounds: Bounds<Pixels>, content_layout: &mut LayoutId,
+             prepaint: &mut (Hitbox, bool), window: &mut Window, cx: &mut App)
+    {
+        let (hitbox, is_hovered) = prepaint;
+
+        // Paint hover background if hovered
+        if *is_hovered {
+            if let Some(hover_style) = &self.hover_style {
+                window.paint_quad(paint_quad(
+                    bounds,
+                    Anchor::all(px(4.)),
+                    hover_style.background_color.unwrap_or(cx.theme().hover),
+                ));
+            }
+        }
+
+        // Paint content
+        self.content.paint(bounds, window, cx);
+
+        // Handle click
+        if let Some(on_click) = self.on_click.as_ref() {
+            window.on_mouse_event({
+                let on_click = on_click.clone();
+                let hitbox = hitbox.clone();
+                move |event: &MouseUpEvent, phase, window, cx| {
+                    if hitbox.is_hovered(window) && phase.bubble() {
+                        on_click(event, window, cx);
+                        cx.stop_propagation();
+                    }
+                }
+            });
+        }
+
+        // Set cursor style
+        window.set_cursor_style(CursorStyle::PointingHand, hitbox);
+    }
+}
+```
+
+### Use Cases
+
+- Buttons
+- Links
+- Clickable cards
+- Drag handles
+- Menu items
+
+## Composite Elements
+
+Elements that combine multiple child elements with complex coordination.
+
+### Pattern Characteristics
+
+- Combine multiple child elements with different types
+- Manage complex state across children
+- Coordinate animations and transitions
+- Handle focus delegation between children
+
+### Implementation Template
+
+```rust
+pub struct CompositeElement {
+    id: ElementId,
+    header: AnyElement,
+    content: AnyElement,
+    footer: Option<AnyElement>,
+}
+
+struct CompositeLayoutState {
+    header_layout: LayoutId,
+    content_layout: LayoutId,
+    footer_layout: Option<LayoutId>,
+}
+
+struct CompositePaintState {
+    header_bounds: Bounds<Pixels>,
+    content_bounds: Bounds<Pixels>,
+    footer_bounds: Option<Bounds<Pixels>>,
+}
+
+impl Element for CompositeElement {
+    type RequestLayoutState = CompositeLayoutState;
+    type PrepaintState = CompositePaintState;
+
+    fn request_layout(&mut self, .., window: &mut Window, cx: &mut App)
+        -> (LayoutId, CompositeLayoutState)
+    {
+        let (header_layout, _) = self.header.request_layout(window, cx);
+        let (content_layout, _) = self.content.request_layout(window, cx);
+        let footer_layout = self.footer.as_mut()
+            .map(|f| f.request_layout(window, cx).0);
+
+        let mut children = vec![header_layout, content_layout];
+        if let Some(footer) = footer_layout {
+            children.push(footer);
+        }
+
+        let layout_id = window.request_layout(
+            Style {
+                flex_direction: FlexDirection::Column,
+                size: Size {
+                    width: relative(1.0),
+                    height: auto(),
+                },
+                ..default()
+            },
+            children,
+            cx
+        );
+
+        (layout_id, CompositeLayoutState {
+            header_layout,
+            content_layout,
+            footer_layout,
+        })
+    }
+
+    fn prepaint(&mut self, .., bounds: Bounds<Pixels>, layout: &mut CompositeLayoutState,
+                window: &mut Window, cx: &mut App) -> CompositePaintState
+    {
+        let header_bounds = window.layout_bounds(layout.header_layout);
+        let content_bounds = window.layout_bounds(layout.content_layout);
+        let footer_bounds = layout.footer_layout
+            .map(|id| window.layout_bounds(id));
+
+        self.header.prepaint(header_bounds, window, cx);
+        self.content.prepaint(content_bounds, window, cx);
+        if let (Some(footer), Some(bounds)) = (&mut self.footer, footer_bounds) {
+            footer.prepaint(bounds, window, cx);
+        }
+
+        CompositePaintState {
+            header_bounds,
+            content_bounds,
+            footer_bounds,
+        }
+    }
+
+    fn paint(&mut self, .., paint_state: &mut CompositePaintState,
+             window: &mut Window, cx: &mut App)
+    {
+        self.header.paint(paint_state.header_bounds, window, cx);
+        self.content.paint(paint_state.content_bounds, window, cx);
+        if let (Some(footer), Some(bounds)) = (&mut self.footer, paint_state.footer_bounds) {
+            footer.paint(bounds, window, cx);
+        }
+    }
+}
+```
+
+### Use Cases
+
+- Dialog boxes (header + content + footer)
+- Cards with multiple sections
+- Form layouts
+- Panels with toolbars
+
+## Scrollable Elements
+
+Elements with scrollable content areas.
+
+### Pattern Characteristics
+
+- Manage scroll state (offset, velocity)
+- Handle scroll events (wheel, drag, touch)
+- Paint scrollbars (track and thumb)
+- Clip content to visible area
+
+### Implementation Template
+
+```rust
+pub struct ScrollableElement {
+    id: ElementId,
+    content: AnyElement,
+    scroll_offset: Point<Pixels>,
+    content_size: Size<Pixels>,
+}
+
+struct ScrollPaintState {
+    hitbox: Hitbox,
+    visible_bounds: Bounds<Pixels>,
+}
+
+impl Element for ScrollableElement {
+    type RequestLayoutState = (LayoutId, Size<Pixels>);
+    type PrepaintState = ScrollPaintState;
+
+    fn request_layout(&mut self, .., window: &mut Window, cx: &mut App)
+        -> (LayoutId, (LayoutId, Size<Pixels>))
+    {
+        let (content_layout, _) = self.content.request_layout(window, cx);
+        let content_size = window.layout_bounds(content_layout).size;
+
+        let layout_id = window.request_layout(
+            Style {
+                size: Size {
+                    width: relative(1.0),
+                    height: px(400.), // Fixed viewport height
+                },
+                overflow: Overflow::Hidden,
+                ..default()
+            },
+            vec![content_layout],
+            cx
+        );
+
+        (layout_id, (content_layout, content_size))
+    }
+
+    fn prepaint(&mut self, .., bounds: Bounds<Pixels>, layout: &mut (LayoutId, Size<Pixels>),
+                window: &mut Window, cx: &mut App) -> ScrollPaintState
+    {
+        let (content_layout, content_size) = layout;
+
+        // Calculate content bounds with scroll offset
+        let content_bounds = Bounds::new(
+            point(bounds.left(), bounds.top() - self.scroll_offset.y),
+            *content_size
+        );
+
+        self.content.prepaint(content_bounds, window, cx);
+
+        let hitbox = window.insert_hitbox(bounds, HitboxBehavior::Normal);
+
+        ScrollPaintState {
+            hitbox,
+            visible_bounds: bounds,
+        }
+    }
+
+    fn paint(&mut self, .., layout: &mut (LayoutId, Size<Pixels>),
+             paint_state: &mut ScrollPaintState, window: &mut Window, cx: &mut App)
+    {
+        let (_, content_size) = layout;
+
+        // Paint content
+        self.content.paint(paint_state.visible_bounds, window, cx);
+
+        // Paint scrollbar
+        self.paint_scrollbar(paint_state.visible_bounds, *content_size, window, cx);
+
+        // Handle scroll events
+        window.on_mouse_event({
+            let hitbox = paint_state.hitbox.clone();
+            let content_height = content_size.height;
+            let visible_height = paint_state.visible_bounds.size.height;
+
+            move |event: &ScrollWheelEvent, phase, window, cx| {
+                if hitbox.is_hovered(window) && phase.bubble() {
+                    // Update scroll offset
+                    self.scroll_offset.y -= event.delta.y;
+
+                    // Clamp to valid range
+                    let max_scroll = (content_height - visible_height).max(px(0.));
+                    self.scroll_offset.y = self.scroll_offset.y
+                        .max(px(0.))
+                        .min(max_scroll);
+
+                    cx.notify();
+                    cx.stop_propagation();
+                }
+            }
+        });
+    }
+}
+
+impl ScrollableElement {
+    fn paint_scrollbar(
+        &self,
+        bounds: Bounds<Pixels>,
+        content_size: Size<Pixels>,
+        window: &mut Window,
+        cx: &mut App
+    ) {
+        let visible_height = bounds.size.height;
+        let content_height = content_size.height;
+
+        if content_height <= visible_height {
+            return; // No scrollbar needed
+        }
+
+        let scrollbar_width = px(8.);
+
+        // Calculate thumb position and size
+        let scroll_ratio = self.scroll_offset.y / (content_height - visible_height);
+        let thumb_height = (visible_height / content_height) * visible_height;
+        let thumb_y = scroll_ratio * (visible_height - thumb_height);
+
+        // Paint track
+        window.paint_quad(paint_quad(
+            Bounds::new(
+                point(bounds.right() - scrollbar_width, bounds.top()),
+                size(scrollbar_width, visible_height)
+            ),
+            Anchor::default(),
+            cx.theme().scrollbar_track,
+        ));
+
+        // Paint thumb
+        window.paint_quad(paint_quad(
+            Bounds::new(
+                point(bounds.right() - scrollbar_width, bounds.top() + thumb_y),
+                size(scrollbar_width, thumb_height)
+            ),
+            Anchor::all(px(4.)),
+            cx.theme().scrollbar_thumb,
+        ));
+    }
+}
+```
+
+### Use Cases
+
+- Scrollable lists
+- Code editors with large files
+- Long-form text content
+- Image galleries
+
+## Pattern Selection Guide
+
+| Need | Pattern | Complexity |
+|------|---------|------------|
+| Display styled text | Text Rendering | Low |
+| Layout multiple children | Container | Low-Medium |
+| Handle clicks/hovers | Interactive | Medium |
+| Complex multi-part UI | Composite | Medium-High |
+| Large content with scrolling | Scrollable | High |
+
+Choose the simplest pattern that meets your requirements, then extend as needed.

--- a/.claude/skills/gpui-kit/references/gpui/element.md
+++ b/.claude/skills/gpui-kit/references/gpui/element.md
@@ -1,0 +1,107 @@
+# Custom Elements
+
+**Contents:** [When to Use](#when-to-use) · [Quick Start](#quick-start) · [Core Concepts](#core-concepts) · [Reference Documentation](#reference-documentation)
+
+## When to Use
+
+Use the low-level `Element` trait when:
+- Need fine-grained control over layout calculation
+- Building complex, performance-critical components
+- Implementing custom layout algorithms (masonry, circular, etc.)
+- High-level `Render`/`RenderOnce` APIs are insufficient
+
+**Prefer `Render`/`RenderOnce` for:** Simple components, standard layouts, declarative UI
+
+## Quick Start
+
+The `Element` trait provides direct control over three rendering phases:
+
+```rust
+impl Element for MyElement {
+    type RequestLayoutState = MyLayoutState;  // Data passed to later phases
+    type PrepaintState = MyPaintState;        // Data for painting
+
+    fn id(&self) -> Option<ElementId> {
+        Some(self.id.clone())
+    }
+
+    fn source_location(&self) -> Option<&'static std::panic::Location<'static>> {
+        None
+    }
+
+    // Phase 1: Calculate sizes and positions
+    fn request_layout(&mut self, .., window: &mut Window, cx: &mut App)
+        -> (LayoutId, Self::RequestLayoutState)
+    {
+        let layout_id = window.request_layout(
+            Style { size: size(px(200.), px(100.)), ..default() },
+            vec![],
+            cx
+        );
+        (layout_id, MyLayoutState { /* ... */ })
+    }
+
+    // Phase 2: Create hitboxes, prepare for painting
+    fn prepaint(&mut self, .., bounds: Bounds<Pixels>, layout: &mut Self::RequestLayoutState,
+                window: &mut Window, cx: &mut App) -> Self::PrepaintState
+    {
+        let hitbox = window.insert_hitbox(bounds, HitboxBehavior::Normal);
+        MyPaintState { hitbox }
+    }
+
+    // Phase 3: Render and handle interactions
+    fn paint(&mut self, .., bounds: Bounds<Pixels>, layout: &mut Self::RequestLayoutState,
+             paint_state: &mut Self::PrepaintState, window: &mut Window, cx: &mut App)
+    {
+        window.paint_quad(paint_quad(bounds, Anchor::all(px(4.)), cx.theme().background));
+
+        window.on_mouse_event({
+            let hitbox = paint_state.hitbox.clone();
+            move |event: &MouseDownEvent, phase, window, cx| {
+                if hitbox.is_hovered(window) && phase.bubble() {
+                    // Handle interaction
+                    cx.stop_propagation();
+                }
+            }
+        });
+    }
+}
+
+// Enable element to be used as child
+impl IntoElement for MyElement {
+    type Element = Self;
+    fn into_element(self) -> Self::Element { self }
+}
+```
+
+## Core Concepts
+
+### Three-Phase Rendering
+
+1. **request_layout**: Calculate sizes and positions, return layout ID and state
+2. **prepaint**: Create hitboxes, compute final bounds, prepare for painting
+3. **paint**: Render element, set up interactions (mouse events, cursor styles)
+
+### State Flow
+
+```
+RequestLayoutState → PrepaintState → paint
+```
+
+State flows in one direction through associated types, passed as mutable references between phases.
+
+### Key Operations
+
+- **Layout**: `window.request_layout(style, children, cx)` - Create layout node
+- **Hitboxes**: `window.insert_hitbox(bounds, behavior)` - Create interaction area
+- **Painting**: `window.paint_quad(...)` - Render visual content
+- **Events**: `window.on_mouse_event(handler)` - Handle user input
+
+## Reference Documentation
+
+### Complete API Documentation
+- **API**: See [element-api.md](element-api.md) — associated types, hitbox system, event handling, cursor styles
+- **Examples**: See [element-examples.md](element-examples.md) — text, interactive, complex elements
+- **Patterns**: See [element-patterns.md](element-patterns.md) — text, container, interactive, composite, scrollable
+- **Best Practices**: See [element-best-practices.md](element-best-practices.md) — performance, state, common pitfalls
+- **Advanced**: See [element-advanced.md](element-advanced.md) — masonry/circular layouts, memoization, virtual lists

--- a/.claude/skills/gpui-kit/references/gpui/entity-advanced.md
+++ b/.claude/skills/gpui-kit/references/gpui/entity-advanced.md
@@ -1,0 +1,528 @@
+# Advanced Entity Patterns
+
+**Contents:** [Entity Collections Management](#entity-collections-management) · [Conditional Update Patterns](#conditional-update-patterns) · [Entity State Machine Pattern](#entity-state-machine-pattern) · [Entity Proxy Pattern](#entity-proxy-pattern) · [Cascading Updates Pattern](#cascading-updates-pattern) · [Entity Snapshot Pattern](#entity-snapshot-pattern) · [Entity Transaction Pattern](#entity-transaction-pattern) · [Entity Pool Pattern](#entity-pool-pattern)
+
+## Entity Collections Management
+
+### Dynamic Collection with Cleanup
+
+```rust
+struct EntityCollection<T> {
+    strong_refs: Vec<Entity<T>>,
+    weak_refs: Vec<WeakEntity<T>>,
+}
+
+impl<T> EntityCollection<T> {
+    fn new() -> Self {
+        Self {
+            strong_refs: Vec::new(),
+            weak_refs: Vec::new(),
+        }
+    }
+
+    fn add(&mut self, entity: Entity<T>, cx: &mut App) {
+        self.strong_refs.push(entity.clone());
+        self.weak_refs.push(entity.downgrade());
+    }
+
+    fn remove(&mut self, entity_id: EntityId, cx: &mut App) {
+        self.strong_refs.retain(|e| e.entity_id() != entity_id);
+        self.weak_refs.retain(|w| {
+            w.upgrade()
+                .map(|e| e.entity_id() != entity_id)
+                .unwrap_or(false)
+        });
+    }
+
+    fn cleanup_invalid(&mut self, cx: &mut App) {
+        self.weak_refs.retain(|weak| weak.upgrade().is_some());
+    }
+
+    fn for_each<F>(&self, cx: &mut App, mut f: F)
+    where
+        F: FnMut(&Entity<T>, &mut App),
+    {
+        for entity in &self.strong_refs {
+            f(entity, cx);
+        }
+    }
+
+    fn for_each_weak<F>(&mut self, cx: &mut App, mut f: F)
+    where
+        F: FnMut(Entity<T>, &mut App),
+    {
+        self.weak_refs.retain(|weak| {
+            if let Some(entity) = weak.upgrade() {
+                f(entity, cx);
+                true
+            } else {
+                false // Remove invalid weak references
+            }
+        });
+    }
+}
+```
+
+### Entity Registry Pattern
+
+```rust
+use std::collections::HashMap;
+
+struct EntityRegistry<T> {
+    entities: HashMap<EntityId, WeakEntity<T>>,
+}
+
+impl<T> EntityRegistry<T> {
+    fn new() -> Self {
+        Self {
+            entities: HashMap::new(),
+        }
+    }
+
+    fn register(&mut self, entity: &Entity<T>) {
+        self.entities.insert(entity.entity_id(), entity.downgrade());
+    }
+
+    fn unregister(&mut self, entity_id: EntityId) {
+        self.entities.remove(&entity_id);
+    }
+
+    fn get(&self, entity_id: EntityId) -> Option<Entity<T>> {
+        self.entities.get(&entity_id)?.upgrade()
+    }
+
+    fn cleanup(&mut self) {
+        self.entities.retain(|_, weak| weak.upgrade().is_some());
+    }
+
+    fn count(&self) -> usize {
+        self.entities.len()
+    }
+
+    fn all_entities(&self) -> Vec<Entity<T>> {
+        self.entities
+            .values()
+            .filter_map(|weak| weak.upgrade())
+            .collect()
+    }
+}
+```
+
+## Conditional Update Patterns
+
+### Debounced Updates
+
+```rust
+use std::time::{Duration, Instant};
+
+struct DebouncedEntity<T> {
+    entity: Entity<T>,
+    last_update: Instant,
+    debounce_duration: Duration,
+    pending_update: Option<Box<dyn FnOnce(&mut T, &mut Context<T>)>>,
+}
+
+impl<T: 'static> DebouncedEntity<T> {
+    fn new(entity: Entity<T>, debounce_ms: u64) -> Self {
+        Self {
+            entity,
+            last_update: Instant::now(),
+            debounce_duration: Duration::from_millis(debounce_ms),
+            pending_update: None,
+        }
+    }
+
+    fn update<F>(&mut self, cx: &mut App, update_fn: F)
+    where
+        F: FnOnce(&mut T, &mut Context<T>) + 'static,
+    {
+        let now = Instant::now();
+        let elapsed = now.duration_since(self.last_update);
+
+        if elapsed >= self.debounce_duration {
+            // Execute immediately
+            self.entity.update(cx, update_fn);
+            self.last_update = now;
+            self.pending_update = None;
+        } else {
+            // Store for later
+            self.pending_update = Some(Box::new(update_fn));
+
+            // Schedule execution
+            let entity = self.entity.clone();
+            let delay = self.debounce_duration - elapsed;
+
+            cx.spawn(async move |cx| {
+                tokio::time::sleep(delay).await;
+
+                if let Some(update) = self.pending_update.take() {
+                    entity.update(cx, |state, inner_cx| {
+                        update(state, inner_cx);
+                    });
+                }
+            }).detach();
+        }
+    }
+}
+```
+
+### Throttled Updates
+
+```rust
+struct ThrottledEntity<T> {
+    entity: Entity<T>,
+    last_update: Instant,
+    throttle_duration: Duration,
+}
+
+impl<T: 'static> ThrottledEntity<T> {
+    fn new(entity: Entity<T>, throttle_ms: u64) -> Self {
+        Self {
+            entity,
+            last_update: Instant::now(),
+            throttle_duration: Duration::from_millis(throttle_ms),
+        }
+    }
+
+    fn try_update<F>(&mut self, cx: &mut App, update_fn: F) -> bool
+    where
+        F: FnOnce(&mut T, &mut Context<T>),
+    {
+        let now = Instant::now();
+        let elapsed = now.duration_since(self.last_update);
+
+        if elapsed >= self.throttle_duration {
+            self.entity.update(cx, update_fn);
+            self.last_update = now;
+            true
+        } else {
+            false // Update throttled
+        }
+    }
+}
+```
+
+## Entity State Machine Pattern
+
+```rust
+enum AppState {
+    Idle,
+    Loading,
+    Loaded(String),
+    Error(String),
+}
+
+struct StateMachine {
+    state: AppState,
+}
+
+impl StateMachine {
+    fn new() -> Self {
+        Self {
+            state: AppState::Idle,
+        }
+    }
+
+    fn start_loading(&mut self, cx: &mut Context<Self>) {
+        if matches!(self.state, AppState::Idle | AppState::Error(_)) {
+            self.state = AppState::Loading;
+            cx.notify();
+
+            let weak_entity = cx.entity().downgrade();
+
+            cx.spawn(async move |cx| {
+                let result = perform_load().await;
+
+                let _ = weak_entity.update(cx, |state, cx| {
+                    match result {
+                        Ok(data) => state.on_load_success(data, cx),
+                        Err(e) => state.on_load_error(e.to_string(), cx),
+                    }
+                });
+            }).detach();
+        }
+    }
+
+    fn on_load_success(&mut self, data: String, cx: &mut Context<Self>) {
+        if matches!(self.state, AppState::Loading) {
+            self.state = AppState::Loaded(data);
+            cx.notify();
+        }
+    }
+
+    fn on_load_error(&mut self, error: String, cx: &mut Context<Self>) {
+        if matches!(self.state, AppState::Loading) {
+            self.state = AppState::Error(error);
+            cx.notify();
+        }
+    }
+
+    fn reset(&mut self, cx: &mut Context<Self>) {
+        self.state = AppState::Idle;
+        cx.notify();
+    }
+}
+
+async fn perform_load() -> Result<String, anyhow::Error> {
+    // Actual load implementation
+    Ok("Data".to_string())
+}
+```
+
+## Entity Proxy Pattern
+
+```rust
+struct EntityProxy<T> {
+    entity: WeakEntity<T>,
+}
+
+impl<T> EntityProxy<T> {
+    fn new(entity: &Entity<T>) -> Self {
+        Self {
+            entity: entity.downgrade(),
+        }
+    }
+
+    fn with<F, R>(&self, cx: &mut App, f: F) -> Result<R, anyhow::Error>
+    where
+        F: FnOnce(&T, &App) -> R,
+    {
+        self.entity.read_with(cx, f)
+    }
+
+    fn update<F, R>(&self, cx: &mut App, f: F) -> Result<R, anyhow::Error>
+    where
+        F: FnOnce(&mut T, &mut Context<T>) -> R,
+    {
+        self.entity.update(cx, f)
+    }
+
+    fn is_valid(&self, cx: &App) -> bool {
+        self.entity.upgrade().is_some()
+    }
+}
+```
+
+## Cascading Updates Pattern
+
+```rust
+struct CascadingUpdater {
+    entities: Vec<WeakEntity<UpdateTarget>>,
+}
+
+impl CascadingUpdater {
+    fn new() -> Self {
+        Self {
+            entities: Vec::new(),
+        }
+    }
+
+    fn add_target(&mut self, entity: &Entity<UpdateTarget>) {
+        self.entities.push(entity.downgrade());
+    }
+
+    fn cascade_update<F>(&mut self, cx: &mut App, update_fn: F)
+    where
+        F: Fn(&mut UpdateTarget, &mut Context<UpdateTarget>) + Clone,
+    {
+        // Update all entities in sequence
+        self.entities.retain(|weak| {
+            if let Ok(_) = weak.update(cx, |state, inner_cx| {
+                update_fn.clone()(state, inner_cx);
+            }) {
+                true // Keep valid entity
+            } else {
+                false // Remove invalid entity
+            }
+        });
+    }
+}
+
+struct UpdateTarget {
+    value: i32,
+}
+```
+
+## Entity Snapshot Pattern
+
+```rust
+use serde::{Serialize, Deserialize};
+
+#[derive(Clone, Serialize, Deserialize)]
+struct EntitySnapshot {
+    data: String,
+    timestamp: u64,
+}
+
+struct SnapshotableEntity {
+    data: String,
+    snapshots: Vec<EntitySnapshot>,
+}
+
+impl SnapshotableEntity {
+    fn new(data: String) -> Self {
+        Self {
+            data,
+            snapshots: Vec::new(),
+        }
+    }
+
+    fn take_snapshot(&mut self, cx: &mut Context<Self>) {
+        let snapshot = EntitySnapshot {
+            data: self.data.clone(),
+            timestamp: current_timestamp(),
+        };
+        self.snapshots.push(snapshot);
+        cx.notify();
+    }
+
+    fn restore_snapshot(&mut self, index: usize, cx: &mut Context<Self>) -> Result<(), String> {
+        if let Some(snapshot) = self.snapshots.get(index) {
+            self.data = snapshot.data.clone();
+            cx.notify();
+            Ok(())
+        } else {
+            Err("Invalid snapshot index".to_string())
+        }
+    }
+
+    fn clear_old_snapshots(&mut self, keep_last: usize, cx: &mut Context<Self>) {
+        if self.snapshots.len() > keep_last {
+            self.snapshots.drain(0..self.snapshots.len() - keep_last);
+            cx.notify();
+        }
+    }
+}
+
+fn current_timestamp() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+```
+
+## Entity Transaction Pattern
+
+```rust
+struct Transaction<T> {
+    entity: Entity<T>,
+    original_state: Option<T>,
+}
+
+impl<T: Clone> Transaction<T> {
+    fn begin(entity: Entity<T>, cx: &mut App) -> Self {
+        let original_state = entity.read(cx).clone();
+
+        Self {
+            entity,
+            original_state: Some(original_state),
+        }
+    }
+
+    fn update<F>(&mut self, cx: &mut App, update_fn: F)
+    where
+        F: FnOnce(&mut T, &mut Context<T>),
+    {
+        self.entity.update(cx, update_fn);
+    }
+
+    fn commit(mut self, cx: &mut App) {
+        self.original_state = None; // Don't rollback
+        self.entity.update(cx, |_, cx| {
+            cx.notify();
+        });
+    }
+
+    fn rollback(mut self, cx: &mut App) {
+        if let Some(original) = self.original_state.take() {
+            self.entity.update(cx, |state, cx| {
+                *state = original;
+                cx.notify();
+            });
+        }
+    }
+}
+
+impl<T> Drop for Transaction<T> {
+    fn drop(&mut self) {
+        // Auto-rollback if not committed
+        if self.original_state.is_some() {
+            eprintln!("Warning: Transaction dropped without commit");
+        }
+    }
+}
+
+// Usage
+fn perform_transaction(entity: Entity<MyState>, cx: &mut App) -> Result<(), String> {
+    let mut tx = Transaction::begin(entity, cx);
+
+    tx.update(cx, |state, cx| {
+        state.value = 42;
+    });
+
+    if validate_state(&tx.entity, cx)? {
+        tx.commit(cx);
+        Ok(())
+    } else {
+        tx.rollback(cx);
+        Err("Validation failed".to_string())
+    }
+}
+```
+
+## Entity Pool Pattern
+
+```rust
+struct EntityPool<T> {
+    available: Vec<Entity<T>>,
+    in_use: Vec<WeakEntity<T>>,
+    factory: Box<dyn Fn(&mut App) -> Entity<T>>,
+}
+
+impl<T: 'static> EntityPool<T> {
+    fn new<F>(factory: F) -> Self
+    where
+        F: Fn(&mut App) -> Entity<T> + 'static,
+    {
+        Self {
+            available: Vec::new(),
+            in_use: Vec::new(),
+            factory: Box::new(factory),
+        }
+    }
+
+    fn acquire(&mut self, cx: &mut App) -> Entity<T> {
+        let entity = if let Some(entity) = self.available.pop() {
+            entity
+        } else {
+            (self.factory)(cx)
+        };
+
+        self.in_use.push(entity.downgrade());
+        entity
+    }
+
+    fn release(&mut self, entity: Entity<T>, cx: &mut App) {
+        // Reset entity state if needed
+        entity.update(cx, |state, cx| {
+            // Reset logic here
+            cx.notify();
+        });
+
+        self.available.push(entity);
+        self.cleanup_in_use();
+    }
+
+    fn cleanup_in_use(&mut self) {
+        self.in_use.retain(|weak| weak.upgrade().is_some());
+    }
+
+    fn pool_size(&self) -> (usize, usize) {
+        (self.available.len(), self.in_use.len())
+    }
+}
+```
+
+These advanced patterns provide powerful abstractions for managing complex entity scenarios while maintaining code quality and performance.

--- a/.claude/skills/gpui-kit/references/gpui/entity-api.md
+++ b/.claude/skills/gpui-kit/references/gpui/entity-api.md
@@ -1,0 +1,382 @@
+# Entity API Reference
+
+**Contents:** [Entity Types](#entity-types) · [Entity Creation](#entity-creation) · [Entity Operations](#entity-operations) · [Context Methods](#context-methods-for-entities) · [Async Operations](#async-operations) · [Entity Lifecycle](#entity-lifecycle) · [EntityId](#entityid) · [Error Handling](#error-handling) · [Type Conversions](#type-conversions)
+
+## Entity Types
+
+### Entity<T>
+
+A strong reference to state of type `T`.
+
+**Methods:**
+- `entity_id()` → `EntityId` - Returns unique identifier
+- `downgrade()` → `WeakEntity<T>` - Creates weak reference
+- `read(cx)` → `&T` - Immutable access to state
+- `read_with(cx, |state, cx| ...)` → `R` - Read with closure, returns closure result
+- `update(cx, |state, cx| ...)` → `R` - Mutable update with `Context<T>`, returns closure result
+- `update_in(cx, |state, window, cx| ...)` → `R` - Update with `Window` access (requires `AsyncWindowContext` or `VisualTestContext`)
+
+**Important Notes:**
+- Trying to update an entity while it's already being updated will panic
+- Within closures, use the inner `cx` provided to avoid multiple borrow issues
+- With async contexts, return values are wrapped in `anyhow::Result`
+
+### WeakEntity<T>
+
+A weak reference to state of type `T`.
+
+**Methods:**
+- `upgrade()` → `Option<Entity<T>>` - Convert to strong reference if still alive
+- `read_with(cx, |state, cx| ...)` → `Result<R>` - Read if entity exists
+- `update(cx, |state, cx| ...)` → `Result<R>` - Update if entity exists
+- `update_in(cx, |state, window, cx| ...)` → `Result<R>` - Update with window if entity exists
+
+**Use Cases:**
+- Avoid circular dependencies between entities
+- Store references in closures/callbacks without preventing cleanup
+- Optional relationships between components
+
+**Important:** All operations return `Result` since the entity may no longer exist.
+
+### AnyEntity
+
+Dynamically-typed entity handle for storing entities of different types.
+
+### AnyWeakEntity
+
+Dynamically-typed weak entity handle.
+
+## Entity Creation
+
+### cx.new()
+
+Create new entity with initial state.
+
+```rust
+let entity = cx.new(|cx| MyState {
+    count: 0,
+    name: "Default".to_string(),
+});
+```
+
+**Parameters:**
+- `cx: &mut App` or other context type
+- Closure receiving `&mut Context<T>` returning initial state `T`
+
+**Returns:** `Entity<T>`
+
+## Entity Operations
+
+### Reading State
+
+#### read()
+
+Direct read-only access to state.
+
+```rust
+let count = my_entity.read(cx).count;
+```
+
+**Use when:** Simple field access, no context operations needed.
+
+#### read_with()
+
+Read with context access in closure.
+
+```rust
+let count = my_entity.read_with(cx, |state, cx| {
+    // Can access both state and context
+    state.count
+});
+
+// Return multiple values
+let (count, theme) = my_entity.read_with(cx, |state, cx| {
+    (state.count, cx.theme().clone())
+});
+```
+
+**Use when:** Need context operations, multiple return values, complex logic.
+
+### Updating State
+
+#### update()
+
+Mutable update with `Context<T>`.
+
+```rust
+my_entity.update(cx, |state, cx| {
+    state.count += 1;
+    cx.notify(); // Trigger re-render
+});
+```
+
+**Available Operations:**
+- `cx.notify()` - Trigger re-render
+- `cx.entity()` - Get current entity
+- `cx.emit(event)` - Emit event
+- `cx.spawn(task)` - Spawn async task
+- Other `Context<T>` methods
+
+#### update_in()
+
+Update with both `Window` and `Context<T>` access.
+
+```rust
+my_entity.update_in(cx, |state, window, cx| {
+    state.focused = window.is_window_focused();
+    cx.notify();
+});
+```
+
+**Requires:** `AsyncWindowContext` or `VisualTestContext`
+
+**Use when:** Need window-specific operations like focus state, window bounds, etc.
+
+## Context Methods for Entities
+
+### cx.entity()
+
+Get current entity being updated.
+
+```rust
+impl MyComponent {
+    fn some_method(&mut self, cx: &mut Context<Self>) {
+        let current_entity = cx.entity();  // Entity<MyComponent>
+        let weak = current_entity.downgrade();
+    }
+}
+```
+
+### cx.observe()
+
+Observe entity for changes.
+
+```rust
+cx.observe(&entity, |this, observed_entity, cx| {
+    // Called when observed_entity.update() calls cx.notify()
+    println!("Entity changed");
+}).detach();
+```
+
+**Returns:** `Subscription` - Call `.detach()` to make permanent
+
+### cx.subscribe()
+
+Subscribe to events from entity.
+
+```rust
+cx.subscribe(&entity, |this, emitter, event: &SomeEvent, cx| {
+    // Called when emitter emits SomeEvent
+    match event {
+        SomeEvent::DataChanged => {
+            cx.notify();
+        }
+    }
+}).detach();
+```
+
+**Returns:** `Subscription` - Call `.detach()` to make permanent
+
+### cx.observe_new_entities()
+
+Register callback for new entities of a type.
+
+```rust
+cx.observe_new_entities::<MyState>(|entity, cx| {
+    println!("New entity created: {:?}", entity.entity_id());
+}).detach();
+```
+
+## Async Operations
+
+### cx.spawn()
+
+Spawn foreground task (UI thread).
+
+```rust
+cx.spawn(async move |this, cx| {
+    // `this`: WeakEntity<T>
+    // `cx`: &mut AsyncApp
+
+    let result = some_async_work().await;
+
+    // Update entity safely
+    let _ = this.update(cx, |state, cx| {
+        state.data = result;
+        cx.notify();
+    });
+}).detach();
+```
+
+**Note:** Always use weak entity reference in spawned tasks to prevent retain cycles.
+
+### cx.background_spawn()
+
+Spawn background task (background thread).
+
+```rust
+cx.background_spawn(async move {
+    // Long-running computation
+    let result = heavy_computation().await;
+    // Cannot directly update entities here
+    // Use channels or spawn foreground task to update
+}).detach();
+```
+
+## Entity Lifecycle
+
+### Creation
+
+Entities are created via `cx.new()` and immediately registered in the app.
+
+### Reference Counting
+
+- `Entity<T>` is a strong reference (increases reference count)
+- `WeakEntity<T>` is a weak reference (does not increase reference count)
+- Cloning `Entity<T>` increases reference count
+
+### Disposal
+
+Entities are automatically disposed when all strong references are dropped.
+
+```rust
+{
+    let entity = cx.new(|cx| MyState::default());
+    // entity exists
+} // entity dropped here if no other strong references exist
+```
+
+**Memory Leak Prevention:**
+- Use `WeakEntity` in closures/callbacks
+- Use `WeakEntity` for parent-child relationships
+- Avoid circular strong references
+
+## EntityId
+
+Every entity has a unique identifier.
+
+```rust
+let id: EntityId = entity.entity_id();
+
+// EntityIds can be compared
+if entity1.entity_id() == entity2.entity_id() {
+    // Same entity
+}
+```
+
+**Use Cases:**
+- Debugging and logging
+- Entity comparison without borrowing
+- Hash maps keyed by entity
+
+## Error Handling
+
+### WeakEntity Operations
+
+All `WeakEntity` operations return `Result`:
+
+```rust
+let weak = entity.downgrade();
+
+// Handle potential failure
+match weak.read_with(cx, |state, cx| state.count) {
+    Ok(count) => println!("Count: {}", count),
+    Err(e) => eprintln!("Entity no longer exists: {}", e),
+}
+
+// Or use Result combinators
+let _ = weak.update(cx, |state, cx| {
+    state.count += 1;
+    cx.notify();
+}).ok(); // Ignore errors
+```
+
+### Update Panics
+
+Nested updates on the same entity will panic:
+
+```rust
+// ❌ Will panic
+entity.update(cx, |state1, cx| {
+    entity.update(cx, |state2, cx| {
+        // Panic: entity already borrowed
+    });
+});
+```
+
+**Solution:** Perform updates sequentially or use different entities.
+
+## Type Conversions
+
+### Entity → WeakEntity
+
+```rust
+let entity: Entity<T> = cx.new(|cx| T::default());
+let weak: WeakEntity<T> = entity.downgrade();
+```
+
+### WeakEntity → Entity
+
+```rust
+let weak: WeakEntity<T> = entity.downgrade();
+let strong: Option<Entity<T>> = weak.upgrade();
+```
+
+### AnyEntity
+
+```rust
+let any: AnyEntity = entity.into();
+let typed: Option<Entity<T>> = any.downcast::<T>();
+```
+
+## Best Practice Guidelines
+
+### Always Use Inner cx
+
+```rust
+// ✅ Good: Use inner cx
+entity.update(cx, |state, inner_cx| {
+    inner_cx.notify(); // Use inner_cx, not outer cx
+});
+
+// ❌ Bad: Use outer cx
+entity.update(cx, |state, inner_cx| {
+    cx.notify(); // Wrong! Multiple borrow error
+});
+```
+
+### Weak References in Closures
+
+```rust
+// ✅ Good: Weak reference
+let weak = cx.entity().downgrade();
+callback(move || {
+    let _ = weak.update(cx, |state, cx| {
+        cx.notify();
+    });
+});
+
+// ❌ Bad: Strong reference (retain cycle)
+let strong = cx.entity();
+callback(move || {
+    strong.update(cx, |state, cx| {
+        // May never be dropped
+        cx.notify();
+    });
+});
+```
+
+### Sequential Updates
+
+```rust
+// ✅ Good: Sequential updates
+entity1.update(cx, |state, cx| { /* ... */ });
+entity2.update(cx, |state, cx| { /* ... */ });
+
+// ❌ Bad: Nested updates
+entity1.update(cx, |_, cx| {
+    entity2.update(cx, |_, cx| {
+        // May panic if entities are related
+    });
+});
+```

--- a/.claude/skills/gpui-kit/references/gpui/entity-best-practices.md
+++ b/.claude/skills/gpui-kit/references/gpui/entity-best-practices.md
@@ -1,0 +1,537 @@
+# Entity Best Practices
+
+**Contents:** [Avoiding Common Pitfalls](#avoiding-common-pitfalls) · [Performance Optimization](#performance-optimization) · [Entity Lifecycle Management](#entity-lifecycle-management) · [Entity Observation Best Practices](#entity-observation-best-practices) · [Async Best Practices](#async-best-practices) · [Testing Best Practices](#testing-best-practices) · [Performance Checklist](#performance-checklist)
+
+## Avoiding Common Pitfalls
+
+### Avoid Re-entrant Entity Access (Same Entity)
+
+**Problem:** GPUI locks an entity for the entire duration of its render or update pass. Any attempt to `read` or `update` that *same* entity while the lock is held panics:
+
+```
+cannot update … while it is already being updated
+```
+
+```rust
+// ❌ Panic: entity_a updated from within entity_a's own update
+entity_a.update(cx, |_, cx| {
+    entity_a.update(cx, |_, _| {}); // PANIC
+});
+
+// ✅ Fine: updating a *different* entity from within an update
+entity_a.update(cx, |_, cx| {
+    entity_b.update(cx, |_, _| {}); // OK — different lock
+});
+```
+
+**Note:** Updating two *different* entities in a nested fashion is safe. The restriction is strictly about re-entering the *same* entity's lock.
+
+### `defer_in` Re-locks the Entity — Same Rules Apply
+
+`cx.defer_in(window, callback)` schedules `callback` to run *on the entity the context refers to*. GPUI re-acquires that entity's lock to execute the deferred callback, so the re-entrancy rules apply equally inside it:
+
+```rust
+// ❌ Panic: defer_in runs with ListState locked; calling list.update re-enters
+fn confirm(&mut self, _: bool, window: &mut Window, cx: &mut Context<ListState<Self>>) {
+    cx.defer_in(window, |list_state, window, cx| {
+        // list_state IS locked for this entire callback!
+        parent.update(cx, |this, cx| {
+            this.list.update(cx, |_, _| {}); // PANIC — re-enters ListState lock
+        });
+    });
+}
+```
+
+**Fix:** Use the direct `&mut` reference the callback provides instead of going through the entity handle:
+
+```rust
+// ✅ Correct: direct mutable access — no lock needed
+fn confirm(&mut self, _: bool, window: &mut Window, cx: &mut Context<ListState<Self>>) {
+    cx.defer_in(window, |list_state, window, cx| {
+        // Step 1: call hooks directly through list_state (no entity lock)
+        list_state.delegate_mut().on_will_change(&mut op, &snapshot);
+
+        // Step 2: update the parent entity — different lock, safe
+        let new_sel = parent.update(cx, |this, cx| {
+            this.state.apply_change(op);
+            cx.notify();
+            this.state.selection.clone() // return data needed for step 3
+        });
+
+        // Step 3: sync list state directly — no entity lock
+        if let Ok(sel) = new_sel {
+            list_state.delegate_mut().update_snapshot(sel.clone());
+            list_state.delegate_mut().on_confirm(&sel);
+        }
+    });
+}
+```
+
+### Render Callbacks Must Not Access External Entities
+
+`render_item` and any other rendering hook runs inside the entity's render pass. Calling `entity.read(cx)` or `entity.update(cx, …)` on an external entity (which may itself be in a render/update pass) panics with the same re-entrancy error.
+
+**Fix:** Keep a plain `snapshot` field updated eagerly from outside render after every mutation:
+
+```rust
+// ❌ Panic — called during ListState render; external entity access re-enters
+fn render_item(&mut self, ix: IndexPath, …) -> … {
+    let checked = parent.read(cx).selection.contains(&ix); // PANIC
+}
+
+// ✅ Read from snapshot field — no entity access at all
+fn render_item(&mut self, ix: IndexPath, …) -> … {
+    let checked = self.selection_snapshot.iter().any(|(sel_ix, _)| sel_ix == &ix);
+}
+// After every mutation from outside render:
+list.update(cx, |l, _| l.delegate_mut().update_snapshot(new_snapshot));
+```
+
+### Use Weak References in Closures
+
+**Problem:** Strong references in closures can create retain cycles and memory leaks.
+
+```rust
+// ❌ Bad: Strong reference creates retain cycle
+impl MyComponent {
+    fn setup_callback(&mut self, cx: &mut Context<Self>) {
+        let entity = cx.entity(); // Strong reference
+
+        some_callback(move || {
+            entity.update(cx, |state, cx| {
+                // This closure holds a strong reference
+                // If the closure itself is retained by the entity, memory leak!
+                cx.notify();
+            });
+        });
+    }
+}
+```
+
+**Solution:** Use weak references in closures.
+
+```rust
+// ✅ Good: Weak reference prevents retain cycle
+impl MyComponent {
+    fn setup_callback(&mut self, cx: &mut Context<Self>) {
+        let weak_entity = cx.entity().downgrade(); // Weak reference
+
+        some_callback(move || {
+            // Safe: weak reference doesn't prevent cleanup
+            let _ = weak_entity.update(cx, |state, cx| {
+                cx.notify();
+            });
+        });
+    }
+}
+```
+
+### Use Inner Context in Closures
+
+**Problem:** Using outer context causes multiple borrow errors.
+
+```rust
+// ❌ Bad: Using outer cx causes borrow issues
+entity.update(cx, |state, inner_cx| {
+    cx.notify(); // Wrong! Using outer cx
+    cx.spawn(...); // Multiple borrow error
+});
+```
+
+**Solution:** Always use the inner context provided to the closure.
+
+```rust
+// ✅ Good: Use inner cx
+entity.update(cx, |state, inner_cx| {
+    inner_cx.notify(); // Correct
+    inner_cx.spawn(...); // Works fine
+});
+```
+
+### Entity as Props - Use Weak References
+
+**Problem:** Strong entity references in props can create ownership issues.
+
+```rust
+// ❌ Questionable: Strong reference in child
+struct ChildComponent {
+    parent: Entity<ParentComponent>, // Strong reference
+}
+```
+
+**Better:** Use weak references for parent relationships.
+
+```rust
+// ✅ Good: Weak reference prevents issues
+struct ChildComponent {
+    parent: WeakEntity<ParentComponent>, // Weak reference
+}
+
+impl ChildComponent {
+    fn notify_parent(&mut self, cx: &mut Context<Self>) {
+        // Check if parent still exists
+        if let Ok(_) = self.parent.update(cx, |parent_state, cx| {
+            // Update parent
+            cx.notify();
+        }) {
+            // Parent successfully updated
+        }
+    }
+}
+```
+
+## Performance Optimization
+
+### Minimize cx.notify() Calls
+
+Each `cx.notify()` triggers a re-render. Batch updates when possible.
+
+```rust
+// ❌ Bad: Multiple notifications
+impl MyComponent {
+    fn update_multiple_fields(&mut self, cx: &mut Context<Self>) {
+        self.field1 = new_value1;
+        cx.notify(); // Unnecessary intermediate notification
+
+        self.field2 = new_value2;
+        cx.notify(); // Unnecessary intermediate notification
+
+        self.field3 = new_value3;
+        cx.notify();
+    }
+}
+```
+
+```rust
+// ✅ Good: Single notification after all updates
+impl MyComponent {
+    fn update_multiple_fields(&mut self, cx: &mut Context<Self>) {
+        self.field1 = new_value1;
+        self.field2 = new_value2;
+        self.field3 = new_value3;
+        cx.notify(); // Single notification
+    }
+}
+```
+
+### Conditional Updates
+
+Only notify when state actually changes.
+
+```rust
+impl MyComponent {
+    fn set_value(&mut self, new_value: i32, cx: &mut Context<Self>) {
+        if self.value != new_value {
+            self.value = new_value;
+            cx.notify(); // Only notify if changed
+        }
+    }
+}
+```
+
+### Use read_with for Complex Operations
+
+Prefer `read_with` over separate `read` calls.
+
+```rust
+// ❌ Less efficient: Multiple borrows
+let state_ref = entity.read(cx);
+let value1 = state_ref.field1;
+let value2 = state_ref.field2;
+// state_ref borrowed for entire scope
+
+// ✅ More efficient: Single borrow with closure
+let (value1, value2) = entity.read_with(cx, |state, cx| {
+    (state.field1, state.field2)
+});
+```
+
+### Avoid Excessive Entity Creation
+
+Creating entities has overhead. Reuse when appropriate.
+
+```rust
+// ❌ Bad: Creating entity per item in render
+impl Render for MyList {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        div().children(
+            self.items.iter().map(|item| {
+                // Don't create entities in render!
+                let entity = cx.new(|_| item.clone());
+                ItemView { entity }
+            })
+        )
+    }
+}
+```
+
+```rust
+// ✅ Good: Create entities once, reuse
+struct MyList {
+    item_entities: Vec<Entity<Item>>,
+}
+
+impl MyList {
+    fn add_item(&mut self, item: Item, cx: &mut Context<Self>) {
+        let entity = cx.new(|_| item);
+        self.item_entities.push(entity);
+        cx.notify();
+    }
+}
+```
+
+## Entity Lifecycle Management
+
+### Clean Up Weak References
+
+Periodically clean up invalid weak references from collections.
+
+```rust
+struct Container {
+    weak_children: Vec<WeakEntity<Child>>,
+}
+
+impl Container {
+    fn cleanup_invalid_children(&mut self, cx: &mut Context<Self>) {
+        // Remove weak references that are no longer valid
+        let before_count = self.weak_children.len();
+        self.weak_children.retain(|weak| weak.upgrade().is_some());
+        let after_count = self.weak_children.len();
+
+        if before_count != after_count {
+            cx.notify(); // Notify if list changed
+        }
+    }
+}
+```
+
+### Entity Cloning and Sharing
+
+Understand that cloning `Entity<T>` increases reference count.
+
+```rust
+// Each clone increases the reference count
+let entity1: Entity<MyState> = cx.new(|_| MyState::default());
+let entity2 = entity1.clone(); // Reference count: 2
+let entity3 = entity1.clone(); // Reference count: 3
+
+// Entity is dropped only when all references are dropped
+drop(entity1); // Reference count: 2
+drop(entity2); // Reference count: 1
+drop(entity3); // Reference count: 0, entity is deallocated
+```
+
+### Proper Resource Cleanup
+
+Implement cleanup in `Drop` or explicit cleanup methods.
+
+```rust
+struct ManagedResource {
+    handle: Option<FileHandle>,
+}
+
+impl ManagedResource {
+    fn close(&mut self, cx: &mut Context<Self>) {
+        if let Some(handle) = self.handle.take() {
+            // Explicit cleanup
+            handle.close();
+            cx.notify();
+        }
+    }
+}
+
+impl Drop for ManagedResource {
+    fn drop(&mut self) {
+        // Automatic cleanup when entity is dropped
+        if let Some(handle) = self.handle.take() {
+            handle.close();
+        }
+    }
+}
+```
+
+## Entity Observation Best Practices
+
+### Detach Subscriptions Appropriately
+
+Call `.detach()` on subscriptions you want to keep alive.
+
+```rust
+impl MyComponent {
+    fn new(other_entity: Entity<OtherComponent>, cx: &mut App) -> Entity<Self> {
+        cx.new(|cx| {
+            // Observer will live as long as both entities exist
+            cx.observe(&other_entity, |this, observed, cx| {
+                // Handle changes
+                cx.notify();
+            }).detach(); // Important: detach to make permanent
+
+            Self { /* fields */ }
+        })
+    }
+}
+```
+
+### Avoid Observation Cycles
+
+Don't create mutual observation between entities.
+
+```rust
+// ❌ Bad: Mutual observation can cause infinite loops
+entity1.update(cx, |_, cx| {
+    cx.observe(&entity2, |_, _, cx| {
+        cx.notify(); // May trigger entity2's observer
+    }).detach();
+});
+
+entity2.update(cx, |_, cx| {
+    cx.observe(&entity1, |_, _, cx| {
+        cx.notify(); // May trigger entity1's observer → infinite loop
+    }).detach();
+});
+```
+
+## Async Best Practices
+
+### Always Use Weak References in Async Tasks
+
+```rust
+// ✅ Good: Weak reference in spawned task
+impl MyComponent {
+    fn fetch_data(&mut self, cx: &mut Context<Self>) {
+        let weak_entity = cx.entity().downgrade();
+
+        cx.spawn(async move |cx| {
+            let data = fetch_from_api().await;
+
+            // Entity may have been dropped during fetch
+            let _ = weak_entity.update(cx, |state, cx| {
+                state.data = Some(data);
+                cx.notify();
+            });
+        }).detach();
+    }
+}
+```
+
+### Handle Async Errors Gracefully
+
+```rust
+impl MyComponent {
+    fn fetch_data(&mut self, cx: &mut Context<Self>) {
+        let weak_entity = cx.entity().downgrade();
+
+        cx.spawn(async move |cx| {
+            match fetch_from_api().await {
+                Ok(data) => {
+                    let _ = weak_entity.update(cx, |state, cx| {
+                        state.data = Some(data);
+                        state.error = None;
+                        cx.notify();
+                    });
+                }
+                Err(e) => {
+                    let _ = weak_entity.update(cx, |state, cx| {
+                        state.error = Some(e.to_string());
+                        cx.notify();
+                    });
+                }
+            }
+        }).detach();
+    }
+}
+```
+
+### Cancellation Patterns
+
+Implement cancellation for long-running tasks.
+
+```rust
+struct DataFetcher {
+    current_task: Option<Task<()>>,
+    data: Option<String>,
+}
+
+impl DataFetcher {
+    fn fetch_data(&mut self, url: String, cx: &mut Context<Self>) {
+        // Cancel previous task
+        self.current_task = None; // Dropping task cancels it
+
+        let weak_entity = cx.entity().downgrade();
+
+        let task = cx.spawn(async move |cx| {
+            let data = fetch_from_url(&url).await?;
+
+            let _ = weak_entity.update(cx, |state, cx| {
+                state.data = Some(data);
+                cx.notify();
+            });
+
+            Ok::<(), anyhow::Error>(())
+        });
+
+        self.current_task = Some(task);
+    }
+}
+```
+
+## Testing Best Practices
+
+### Use TestAppContext for Entity Tests
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui_kit::TestAppContext;
+
+    #[gpui_kit::test]
+    fn test_entity_update(cx: &mut TestAppContext) {
+        let entity = cx.new(|_| MyState { count: 0 });
+
+        entity.update(cx, |state, cx| {
+            state.count += 1;
+            assert_eq!(state.count, 1);
+        });
+
+        let count = entity.read(cx).count;
+        assert_eq!(count, 1);
+    }
+}
+```
+
+### Test Entity Observation
+
+```rust
+#[gpui_kit::test]
+fn test_entity_observation(cx: &mut TestAppContext) {
+    let observed = cx.new(|_| MyState { value: 0 });
+    let observer = cx.new(|cx| Observer::new(observed.clone(), cx));
+
+    // Update observed entity
+    observed.update(cx, |state, cx| {
+        state.value = 42;
+        cx.notify();
+    });
+
+    // Verify observer was notified
+    observer.read(cx).assert_observed();
+}
+```
+
+## Performance Checklist
+
+Before shipping entity-based code, verify:
+
+- [ ] No strong references in closures/callbacks (use `WeakEntity`)
+- [ ] No nested entity updates (use sequential updates)
+- [ ] Using inner `cx` in update closures
+- [ ] Batching updates before calling `cx.notify()`
+- [ ] Cleaning up invalid weak references periodically
+- [ ] Using `read_with` for complex read operations
+- [ ] Properly detaching subscriptions and observers
+- [ ] Using weak references in async tasks
+- [ ] No observation cycles between entities
+- [ ] Proper error handling in async operations
+- [ ] Resource cleanup in `Drop` or explicit methods
+- [ ] Tests cover entity lifecycle and interactions

--- a/.claude/skills/gpui-kit/references/gpui/entity-patterns.md
+++ b/.claude/skills/gpui-kit/references/gpui/entity-patterns.md
@@ -1,0 +1,579 @@
+# Entity Patterns
+
+**Contents:** [Application Scenarios](#application-scenarios) · [Common Patterns](#common-patterns) · [Pattern Selection Guide](#pattern-selection-guide)
+
+## Application Scenarios
+
+### Model-View Separation
+
+Separate business logic (model) from UI (view) using entities.
+
+```rust
+struct CounterModel {
+    count: usize,
+    listeners: Vec<Box<dyn Fn(usize)>>,
+}
+
+struct CounterView {
+    model: Entity<CounterModel>,
+}
+
+impl CounterModel {
+    fn increment(&mut self, cx: &mut Context<Self>) {
+        self.count += 1;
+
+        // Notify listeners
+        for listener in &self.listeners {
+            listener(self.count);
+        }
+
+        cx.notify();
+    }
+
+    fn decrement(&mut self, cx: &mut Context<Self>) {
+        if self.count > 0 {
+            self.count -= 1;
+            cx.notify();
+        }
+    }
+}
+
+impl CounterView {
+    fn new(cx: &mut App) -> Entity<Self> {
+        let model = cx.new(|_cx| CounterModel {
+            count: 0,
+            listeners: Vec::new(),
+        });
+
+        cx.new(|cx| Self { model })
+    }
+
+    fn increment_count(&mut self, cx: &mut Context<Self>) {
+        self.model.update(cx, |model, cx| {
+            model.increment(cx);
+        });
+    }
+}
+
+impl Render for CounterView {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let count = self.model.read(cx).count;
+
+        div()
+            .child(format!("Count: {}", count))
+            .child(
+                Button::new("increment")
+                    .label("Increment")
+                    .on_click(cx.listener(|this, _, cx| {
+                        this.increment_count(cx);
+                    }))
+            )
+    }
+}
+```
+
+### Component State Management
+
+Managing complex component state with entities.
+
+```rust
+struct TodoList {
+    todos: Vec<Todo>,
+    filter: TodoFilter,
+    next_id: usize,
+}
+
+struct Todo {
+    id: usize,
+    text: String,
+    completed: bool,
+}
+
+enum TodoFilter {
+    All,
+    Active,
+    Completed,
+}
+
+impl TodoList {
+    fn new() -> Self {
+        Self {
+            todos: Vec::new(),
+            filter: TodoFilter::All,
+            next_id: 0,
+        }
+    }
+
+    fn add_todo(&mut self, text: String, cx: &mut Context<Self>) {
+        self.todos.push(Todo {
+            id: self.next_id,
+            text,
+            completed: false,
+        });
+        self.next_id += 1;
+        cx.notify();
+    }
+
+    fn toggle_todo(&mut self, id: usize, cx: &mut Context<Self>) {
+        if let Some(todo) = self.todos.iter_mut().find(|t| t.id == id) {
+            todo.completed = !todo.completed;
+            cx.notify();
+        }
+    }
+
+    fn remove_todo(&mut self, id: usize, cx: &mut Context<Self>) {
+        self.todos.retain(|t| t.id != id);
+        cx.notify();
+    }
+
+    fn set_filter(&mut self, filter: TodoFilter, cx: &mut Context<Self>) {
+        self.filter = filter;
+        cx.notify();
+    }
+
+    fn visible_todos(&self) -> impl Iterator<Item = &Todo> {
+        self.todos.iter().filter(move |todo| match self.filter {
+            TodoFilter::All => true,
+            TodoFilter::Active => !todo.completed,
+            TodoFilter::Completed => todo.completed,
+        })
+    }
+}
+```
+
+### Cross-Entity Communication
+
+Coordinating state between parent and child entities.
+
+```rust
+struct ParentComponent {
+    child_entities: Vec<Entity<ChildComponent>>,
+    global_message: String,
+}
+
+struct ChildComponent {
+    id: usize,
+    message: String,
+    parent: WeakEntity<ParentComponent>,
+}
+
+impl ParentComponent {
+    fn new(cx: &mut App) -> Entity<Self> {
+        cx.new(|cx| Self {
+            child_entities: Vec::new(),
+            global_message: String::new(),
+        })
+    }
+
+    fn add_child(&mut self, cx: &mut Context<Self>) {
+        let parent_weak = cx.entity().downgrade();
+        let child_id = self.child_entities.len();
+
+        let child = cx.new(|cx| ChildComponent {
+            id: child_id,
+            message: String::new(),
+            parent: parent_weak,
+        });
+
+        self.child_entities.push(child);
+        cx.notify();
+    }
+
+    fn broadcast_message(&mut self, message: String, cx: &mut Context<Self>) {
+        self.global_message = message.clone();
+
+        // Update all children
+        for child in &self.child_entities {
+            child.update(cx, |child_state, cx| {
+                child_state.message = message.clone();
+                cx.notify();
+            });
+        }
+
+        cx.notify();
+    }
+}
+
+impl ChildComponent {
+    fn notify_parent(&mut self, message: String, cx: &mut Context<Self>) {
+        if let Ok(_) = self.parent.update(cx, |parent_state, cx| {
+            parent_state.global_message = format!("Child {}: {}", self.id, message);
+            cx.notify();
+        }) {
+            // Parent successfully notified
+        }
+    }
+}
+```
+
+### Async Operations with Entities
+
+Managing async state updates.
+
+```rust
+struct DataLoader {
+    loading: bool,
+    data: Option<String>,
+    error: Option<String>,
+}
+
+impl DataLoader {
+    fn new() -> Self {
+        Self {
+            loading: false,
+            data: None,
+            error: None,
+        }
+    }
+
+    fn load_data(&mut self, cx: &mut Context<Self>) {
+        // Set loading state
+        self.loading = true;
+        self.error = None;
+        cx.notify();
+
+        // Get weak reference for async task
+        let entity = cx.entity().downgrade();
+
+        cx.spawn(async move |cx| {
+            // Simulate async operation
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            let result = fetch_data().await;
+
+            // Update entity with result
+            let _ = entity.update(cx, |state, cx| {
+                state.loading = false;
+                match result {
+                    Ok(data) => state.data = Some(data),
+                    Err(e) => state.error = Some(e.to_string()),
+                }
+                cx.notify();
+            });
+        }).detach();
+    }
+}
+
+async fn fetch_data() -> Result<String, anyhow::Error> {
+    // Actual fetch implementation
+    Ok("Fetched data".to_string())
+}
+```
+
+### Background Task Coordination
+
+Using background tasks with entity updates.
+
+```rust
+struct ImageProcessor {
+    images: Vec<ProcessedImage>,
+    processing: bool,
+}
+
+struct ProcessedImage {
+    path: PathBuf,
+    thumbnail: Option<Vec<u8>>,
+}
+
+impl ImageProcessor {
+    fn process_images(&mut self, paths: Vec<PathBuf>, cx: &mut Context<Self>) {
+        self.processing = true;
+        cx.notify();
+
+        let entity = cx.entity().downgrade();
+
+        cx.background_spawn({
+            let paths = paths.clone();
+            async move {
+                let mut processed = Vec::new();
+
+                for path in paths {
+                    // Process image on background thread
+                    let thumbnail = generate_thumbnail(&path).await;
+                    processed.push((path, thumbnail));
+                }
+
+                // Send results back to foreground
+                processed
+            }
+        })
+        .then(cx.spawn(move |processed, cx| {
+            // Update entity on foreground thread
+            let _ = entity.update(cx, |state, cx| {
+                for (path, thumbnail) in processed {
+                    state.images.push(ProcessedImage {
+                        path,
+                        thumbnail: Some(thumbnail),
+                    });
+                }
+                state.processing = false;
+                cx.notify();
+            });
+        }))
+        .detach();
+    }
+}
+```
+
+## Common Patterns
+
+### 1. Stateful Components
+
+Use entities for components that maintain internal state.
+
+```rust
+struct StatefulComponent {
+    value: i32,
+    history: Vec<i32>,
+}
+
+impl StatefulComponent {
+    fn update_value(&mut self, new_value: i32, cx: &mut Context<Self>) {
+        self.history.push(self.value);
+        self.value = new_value;
+        cx.notify();
+    }
+
+    fn undo(&mut self, cx: &mut Context<Self>) {
+        if let Some(prev_value) = self.history.pop() {
+            self.value = prev_value;
+            cx.notify();
+        }
+    }
+}
+```
+
+### 2. Shared State
+
+Share state between multiple components using entities.
+
+```rust
+struct SharedState {
+    theme: Theme,
+    user: Option<User>,
+}
+
+struct ComponentA {
+    shared: Entity<SharedState>,
+}
+
+struct ComponentB {
+    shared: Entity<SharedState>,
+}
+
+// Both components can read/update the same shared state
+impl ComponentA {
+    fn update_theme(&mut self, theme: Theme, cx: &mut Context<Self>) {
+        self.shared.update(cx, |state, cx| {
+            state.theme = theme;
+            cx.notify();
+        });
+    }
+}
+```
+
+### 3. Event Coordination
+
+Use entities to coordinate events between components.
+
+```rust
+struct EventCoordinator {
+    listeners: Vec<WeakEntity<dyn EventListener>>,
+}
+
+trait EventListener {
+    fn on_event(&mut self, event: &AppEvent, cx: &mut App);
+}
+
+impl EventCoordinator {
+    fn emit_event(&mut self, event: AppEvent, cx: &mut Context<Self>) {
+        // Notify all listeners
+        self.listeners.retain(|weak_listener| {
+            weak_listener.update(cx, |listener, cx| {
+                listener.on_event(&event, cx);
+            }).is_ok()
+        });
+        cx.notify();
+    }
+}
+```
+
+### 4. Async State Management
+
+Manage state that changes based on async operations.
+
+```rust
+struct AsyncState<T> {
+    state: AsyncValue<T>,
+}
+
+enum AsyncValue<T> {
+    Loading,
+    Loaded(T),
+    Error(String),
+}
+
+impl<T> AsyncState<T> {
+    fn is_loading(&self) -> bool {
+        matches!(self.state, AsyncValue::Loading)
+    }
+
+    fn value(&self) -> Option<&T> {
+        match &self.state {
+            AsyncValue::Loaded(v) => Some(v),
+            _ => None,
+        }
+    }
+}
+```
+
+### 5. Parent-Child Relationships
+
+Manage hierarchical relationships with weak references.
+
+```rust
+struct Parent {
+    children: Vec<Entity<Child>>,
+}
+
+struct Child {
+    parent: WeakEntity<Parent>,
+    data: String,
+}
+
+impl Child {
+    fn notify_parent_of_change(&mut self, cx: &mut Context<Self>) {
+        if let Ok(_) = self.parent.update(cx, |parent, cx| {
+            // Parent can react to child change
+            cx.notify();
+        }) {
+            // Successfully notified
+        }
+    }
+}
+```
+
+### 6. Observer Pattern
+
+React to entity state changes using observers.
+
+```rust
+struct Observable {
+    value: i32,
+}
+
+struct Observer {
+    observed: Entity<Observable>,
+}
+
+impl Observer {
+    fn new(observed: Entity<Observable>, cx: &mut App) -> Entity<Self> {
+        cx.new(|cx| {
+            // Observe the entity
+            cx.observe(&observed, |this, observed_entity, cx| {
+                // React to changes
+                let value = observed_entity.read(cx).value;
+                println!("Value changed to: {}", value);
+            }).detach();
+
+            Self { observed }
+        })
+    }
+}
+```
+
+### 7. Event Subscription
+
+Handle events emitted by other entities.
+
+```rust
+#[derive(Clone)]
+enum DataEvent {
+    Updated,
+    Deleted,
+}
+
+struct DataSource {
+    data: Vec<String>,
+}
+
+impl DataSource {
+    fn update_data(&mut self, cx: &mut Context<Self>) {
+        // Update data
+        cx.emit(DataEvent::Updated);
+        cx.notify();
+    }
+}
+
+struct DataConsumer {
+    source: Entity<DataSource>,
+}
+
+impl DataConsumer {
+    fn new(source: Entity<DataSource>, cx: &mut App) -> Entity<Self> {
+        cx.new(|cx| {
+            // Subscribe to events
+            cx.subscribe(&source, |this, source, event: &DataEvent, cx| {
+                match event {
+                    DataEvent::Updated => {
+                        // Handle update
+                        cx.notify();
+                    }
+                    DataEvent::Deleted => {
+                        // Handle deletion
+                    }
+                }
+            }).detach();
+
+            Self { source }
+        })
+    }
+}
+```
+
+### 8. Resource Management
+
+Manage external resources with proper cleanup.
+
+```rust
+struct FileHandle {
+    path: PathBuf,
+    file: Option<File>,
+}
+
+impl FileHandle {
+    fn open(&mut self, cx: &mut Context<Self>) -> Result<()> {
+        self.file = Some(File::open(&self.path)?);
+        cx.notify();
+        Ok(())
+    }
+
+    fn close(&mut self, cx: &mut Context<Self>) {
+        self.file = None;
+        cx.notify();
+    }
+}
+
+impl Drop for FileHandle {
+    fn drop(&mut self) {
+        // Cleanup when entity is dropped
+        if let Some(file) = self.file.take() {
+            drop(file);
+        }
+    }
+}
+```
+
+## Pattern Selection Guide
+
+| Need | Pattern | Complexity |
+|------|---------|------------|
+| Component with internal state | Stateful Components | Low |
+| State shared by multiple components | Shared State | Low |
+| Coordinate events between components | Event Coordination | Medium |
+| Handle async data fetching | Async State Management | Medium |
+| Parent-child component hierarchy | Parent-Child Relationships | Medium |
+| React to state changes | Observer Pattern | Medium |
+| Handle custom events | Event Subscription | Medium-High |
+| Manage external resources | Resource Management | High |
+
+Choose the simplest pattern that meets your requirements. Combine patterns as needed for complex scenarios.

--- a/.claude/skills/gpui-kit/references/gpui/entity.md
+++ b/.claude/skills/gpui-kit/references/gpui/entity.md
@@ -1,0 +1,218 @@
+# Entity State Management
+
+**Contents:** [Overview](#overview) · [Quick Start](#quick-start) · [Core Principles](#core-principles) · [Common Use Cases](#common-use-cases) · [Extended References](#reference-documentation)
+
+## Overview
+
+An `Entity<T>` is a handle to state of type `T`, providing safe access and updates.
+
+**Key Methods:**
+- `entity.read(cx)` → `&T` - Read-only access
+- `entity.read_with(cx, |state, cx| ...)` → `R` - Read with closure
+- `entity.update(cx, |state, cx| ...)` → `R` - Mutable update
+- `entity.downgrade()` → `WeakEntity<T>` - Create weak reference
+- `entity.entity_id()` → `EntityId` - Unique identifier
+
+**Entity Types:**
+- **`Entity<T>`**: Strong reference (increases ref count)
+- **`WeakEntity<T>`**: Weak reference (doesn't prevent cleanup, returns `Result`)
+
+## Quick Start
+
+### Creating and Using Entities
+
+```rust
+// Create entity
+let counter = cx.new(|cx| Counter { count: 0 });
+
+// Read state
+let count = counter.read(cx).count;
+
+// Update state
+counter.update(cx, |state, cx| {
+    state.count += 1;
+    cx.notify(); // Trigger re-render
+});
+
+// Weak reference (for closures/callbacks)
+let weak = counter.downgrade();
+let _ = weak.update(cx, |state, cx| {
+    state.count += 1;
+    cx.notify();
+});
+```
+
+### In Components
+
+```rust
+struct MyComponent {
+    shared_state: Entity<SharedData>,
+}
+
+impl MyComponent {
+    fn new(cx: &mut App) -> Entity<Self> {
+        let shared = cx.new(|_| SharedData::default());
+
+        cx.new(|cx| Self {
+            shared_state: shared,
+        })
+    }
+
+    fn update_shared(&mut self, cx: &mut Context<Self>) {
+        self.shared_state.update(cx, |state, cx| {
+            state.value = 42;
+            cx.notify();
+        });
+    }
+}
+```
+
+### Async Operations
+
+When calling `cx.spawn` from `Context<Self>`, the closure receives `(WeakEntity<Self>, &mut AsyncApp)`:
+
+```rust
+impl MyComponent {
+    fn fetch_data(&mut self, cx: &mut Context<Self>) {
+        cx.spawn(async move |this, cx: &mut AsyncApp| {
+            let data = fetch_from_api().await;
+
+            // Update entity safely via the weak reference
+            let _ = this.update(cx, |state, cx| {
+                state.data = Some(data);
+                cx.notify();
+            });
+        }).detach();
+    }
+}
+```
+
+## Core Principles
+
+### Always Use Weak References in Closures
+
+```rust
+// ✅ Good: Weak reference prevents retain cycles
+let weak = cx.entity().downgrade();
+callback(move || {
+    let _ = weak.update(cx, |state, cx| cx.notify());
+});
+
+// ❌ Bad: Strong reference may cause memory leak
+let strong = cx.entity();
+callback(move || {
+    strong.update(cx, |state, cx| cx.notify());
+});
+```
+
+### Use Inner Context
+
+```rust
+// ✅ Good: Use inner cx from closure
+entity.update(cx, |state, inner_cx| {
+    inner_cx.notify(); // Correct
+});
+
+// ❌ Bad: Use outer cx (multiple borrow error)
+entity.update(cx, |state, inner_cx| {
+    cx.notify(); // Wrong!
+});
+```
+
+### Avoid Nested Entity Updates
+
+Nested `entity.update(cx, …)` calls are dangerous. The default posture is: **do not nest them**. The sub-cases below clarify when a panic is guaranteed vs. merely possible.
+
+**Same entity → always panics.**  
+GPUI locks an entity for the entire duration of its update or render pass. Re-entering that same lock panics immediately:
+
+```
+cannot update … while it is already being updated
+```
+
+```rust
+// ❌ Panic: updating entity_a from inside entity_a's own update
+entity_a.update(cx, |state, cx| {
+    entity_a.update(cx, |_, _| {}); // PANIC — same lock
+});
+```
+
+**Different entity → generally safe, but indirect cycles still panic.**  
+Each entity has its own lock, so updating `entity_b` from within `entity_a`'s update normally succeeds. However, if `entity_b`'s callback reaches back into `entity_a` — directly or through a chain — GPUI will attempt to re-acquire `entity_a`'s lock and panic.
+
+```rust
+// ✅ Usually fine: different entities, no cycle
+entity_a.update(cx, |_, cx| {
+    entity_b.update(cx, |_, _| {}); // OK — different lock
+});
+
+// ❌ Panic: indirect cycle back to entity_a
+entity_a.update(cx, |_, cx| {
+    entity_b.update(cx, |_, cx| {
+        entity_a.update(cx, |_, _| {}); // PANIC — entity_a is still locked
+    });
+});
+```
+
+When in doubt, flatten the call sequence rather than nesting: finish the outer update, then update the second entity from outside.
+
+**`defer_in` does not bypass the lock.** `cx.defer_in(window, callback)` schedules `callback` to run on the current entity — meaning GPUI re-acquires the entity's lock to execute it. The re-entrancy rules apply equally inside the deferred callback:
+
+```rust
+// ❌ Panic: defer_in re-locks entity_a; calling entity_a.update inside re-enters
+impl SomeDelegate for MyAdapter {
+    fn confirm(&mut self, _: bool, window: &mut Window, cx: &mut Context<ListState<Self>>) {
+        cx.defer_in(window, |list_state, window, cx| {
+            // list_state is locked for this callback!
+            parent.update(cx, |this, cx| {
+                this.list.update(cx, |_, _| {}); // PANIC — list is already locked above
+            });
+        });
+    }
+}
+
+// ✅ Fix: use the direct &mut reference the callback provides
+impl SomeDelegate for MyAdapter {
+    fn confirm(&mut self, _: bool, window: &mut Window, cx: &mut Context<ListState<Self>>) {
+        cx.defer_in(window, |list_state, window, cx| {
+            // Access list data directly — no entity lock needed
+            list_state.delegate_mut().some_hook();
+
+            // Update the *parent* entity — different lock, safe
+            parent.update(cx, |this, cx| { /* … */ });
+
+            // Sync list state directly after parent update
+            list_state.delegate_mut().update_snapshot(new_val);
+        });
+    }
+}
+```
+
+**Snapshot pattern for render callbacks.** `render_item` (and any other rendering hook) runs inside the entity's render pass. It must never call `entity.read(cx)` or `entity.update(cx, …)` on any external entity. Instead, keep a plain `snapshot` field updated eagerly from *outside* render after every mutation:
+
+```rust
+// ❌ Panic in render_item — ListState is already locked
+fn render_item(&mut self, ix: IndexPath, window: &mut Window, cx: &mut Context<ListState<Self>>) -> … {
+    let checked = parent_entity.read(cx).selection.contains(&ix); // PANIC
+}
+
+// ✅ Read from a plain snapshot field — no entity access
+fn render_item(&mut self, ix: IndexPath, window: &mut Window, cx: &mut Context<ListState<Self>>) -> … {
+    let checked = self.selection_snapshot.iter().any(|(sel_ix, _)| sel_ix == &ix);
+}
+```
+
+## Common Use Cases
+
+1. **Component State**: Internal state that needs reactivity
+2. **Shared State**: State shared between multiple components
+3. **Parent-Child**: Coordinating between related components (use weak refs)
+4. **Async State**: Managing state that changes from async operations
+5. **Observations**: Reacting to changes in other entities
+
+## Reference Documentation
+
+- **API**: See [entity-api.md](entity-api.md) — entity types, methods, lifecycle, error handling
+- **Patterns**: See [entity-patterns.md](entity-patterns.md) — model-view, cross-entity communication, observer
+- **Best Practices**: See [entity-best-practices.md](entity-best-practices.md) — pitfalls, memory, performance, async
+- **Advanced**: See [entity-advanced.md](entity-advanced.md) — collections, registry, debounce, state machines

--- a/.claude/skills/gpui-kit/references/gpui/event.md
+++ b/.claude/skills/gpui-kit/references/gpui/event.md
@@ -1,0 +1,238 @@
+# Events & Subscriptions
+
+**Contents:** [Overview](#overview) · [Quick Start](#quick-start) · [Common Patterns](#common-patterns) · [subscribe_in](#subscribe_in--subscription-with-window-access) · [observe_window_activation](#observe_window_activation) · [observe_global](#observe_global) · [Subscription Lifetime](#subscription-lifetime) · [Best Practices](#best-practices)
+
+## Overview
+
+GPUI provides event system for component coordination:
+
+**Event Mechanisms:**
+- **Custom Events**: Define and emit type-safe events
+- **Observations**: React to entity state changes
+- **Subscriptions**: Listen to events from other entities
+- **Global Events**: App-wide event handling
+
+## Quick Start
+
+### Define and Emit Events
+
+```rust
+#[derive(Clone)]
+enum MyEvent {
+    DataUpdated(String),
+    ActionTriggered,
+}
+
+impl MyComponent {
+    fn update_data(&mut self, data: String, cx: &mut Context<Self>) {
+        self.data = data.clone();
+
+        // Emit event
+        cx.emit(MyEvent::DataUpdated(data));
+        cx.notify();
+    }
+}
+```
+
+### Subscribe to Events
+
+```rust
+impl Listener {
+    fn new(source: Entity<MyComponent>, cx: &mut App) -> Entity<Self> {
+        cx.new(|cx| {
+            // Subscribe to events
+            cx.subscribe(&source, |this, emitter, event: &MyEvent, cx| {
+                match event {
+                    MyEvent::DataUpdated(data) => {
+                        this.handle_update(data.clone(), cx);
+                    }
+                    MyEvent::ActionTriggered => {
+                        this.handle_action(cx);
+                    }
+                }
+            }).detach();
+
+            Self { source }
+        })
+    }
+}
+```
+
+### Observe Entity Changes
+
+```rust
+impl Observer {
+    fn new(target: Entity<Target>, cx: &mut App) -> Entity<Self> {
+        cx.new(|cx| {
+            // Observe entity for any changes
+            cx.observe(&target, |this, observed, cx| {
+                // Called when observed.update() calls cx.notify()
+                println!("Target changed");
+                cx.notify();
+            }).detach();
+
+            Self { target }
+        })
+    }
+}
+```
+
+## Common Patterns
+
+### 1. Parent-Child Communication
+
+```rust
+// Parent emits events
+impl Parent {
+    fn notify_children(&mut self, cx: &mut Context<Self>) {
+        cx.emit(ParentEvent::Updated);
+        cx.notify();
+    }
+}
+
+// Children subscribe
+impl Child {
+    fn new(parent: Entity<Parent>, cx: &mut App) -> Entity<Self> {
+        cx.new(|cx| {
+            cx.subscribe(&parent, |this, parent, event, cx| {
+                this.handle_parent_event(event, cx);
+            }).detach();
+
+            Self { parent }
+        })
+    }
+}
+```
+
+### 2. Global Event Broadcasting
+
+```rust
+struct EventBus {
+    listeners: Vec<WeakEntity<dyn Listener>>,
+}
+
+impl EventBus {
+    fn broadcast(&mut self, event: GlobalEvent, cx: &mut Context<Self>) {
+        self.listeners.retain(|weak| {
+            weak.update(cx, |listener, cx| {
+                listener.on_event(&event, cx);
+            }).is_ok()
+        });
+    }
+}
+```
+
+### 3. Observer Pattern
+
+```rust
+cx.observe(&entity, |this, observed, cx| {
+    // React to any state change
+    let state = observed.read(cx);
+    this.sync_with_state(state, cx);
+}).detach();
+```
+
+## subscribe_in — Subscription with Window Access
+
+Use when the subscription callback needs `&mut Window`:
+
+```rust
+// Store subscriptions to keep them alive
+struct MyComponent {
+    _subscriptions: Vec<Subscription>,
+}
+
+impl MyComponent {
+    fn new(input: &Entity<InputState>, window: &mut Window, cx: &mut Context<Self>) -> Self {
+        let _subscriptions = vec![
+            cx.subscribe_in(input, window, |this, state, event, window, cx| {
+                match event {
+                    InputEvent::PressEnter { .. } => this.on_submit(window, cx),
+                    InputEvent::Change => {
+                        let val = state.read(cx).value();
+                        this.on_change(val, cx);
+                    }
+                    _ => {}
+                }
+            }),
+        ];
+        Self { _subscriptions }
+    }
+}
+```
+
+`subscribe` vs `subscribe_in`:
+- `cx.subscribe(&entity, |this, source, event, cx|)` — no window
+- `cx.subscribe_in(&entity, window, |this, source, event, window, cx|)` — window access
+
+## observe_window_activation
+
+```rust
+let _sub = cx.observe_window_activation(window, |this, window, cx| {
+    if window.is_window_active() {
+        this.start_polling(cx);
+    } else {
+        this.stop_polling(cx);
+    }
+});
+```
+
+## observe_global
+
+```rust
+cx.observe_global::<Theme>(|cx| {
+    cx.notify(); // Re-render when theme changes
+});
+```
+
+## Subscription Lifetime
+
+Subscriptions are cancelled when dropped. Two ways to keep alive:
+
+```rust
+// 1. .detach() — lives until entity is dropped
+cx.subscribe(&entity, |this, _, event, cx| {
+    // ...
+}).detach();
+
+// 2. Store in struct — cancelled when struct drops
+struct MyView {
+    _subscriptions: Vec<Subscription>,
+}
+// _subscriptions.push(cx.subscribe(...));
+```
+
+Use `.detach()` for permanent subscriptions; store in struct for subscriptions that should stop when the component unmounts.
+
+## Best Practices
+
+### ✅ Detach Subscriptions
+
+```rust
+// ✅ Detach to keep alive
+cx.subscribe(&entity, |this, source, event, cx| {
+    // Handle event
+}).detach();
+```
+
+### ✅ Clean Event Types
+
+```rust
+#[derive(Clone)]
+enum AppEvent {
+    DataChanged { id: usize, value: String },
+    ActionPerformed(ActionType),
+    Error(String),
+}
+```
+
+### ❌ Avoid Event Loops
+
+```rust
+// ❌ Don't create mutual subscriptions
+entity1.subscribe(entity2) → emits event
+entity2.subscribe(entity1) → emits event → infinite loop!
+```
+
+## Reference Documentation
+

--- a/.claude/skills/gpui-kit/references/gpui/focus-handle.md
+++ b/.claude/skills/gpui-kit/references/gpui/focus-handle.md
@@ -1,0 +1,225 @@
+# Focus & Keyboard Navigation
+
+**Contents:** [Overview](#overview) · [Quick Start](#quick-start) · [Focus Events](#focus-events) · [Keyboard Navigation](#keyboard-navigation) · [Common Patterns](#common-patterns) · [Best Practices](#best-practices)
+
+## Overview
+
+GPUI's focus system enables keyboard navigation and focus management.
+
+**Key Concepts:**
+- **FocusHandle**: Reference to focusable element
+- **Focus tracking**: Current focused element
+- **Keyboard navigation**: Tab/Shift-Tab between elements
+- **Focus events**: on_focus, on_blur
+
+## Quick Start
+
+### Creating Focus Handles
+
+```rust
+struct FocusableComponent {
+    focus_handle: FocusHandle,
+}
+
+impl FocusableComponent {
+    fn new(cx: &mut Context<Self>) -> Self {
+        Self {
+            focus_handle: cx.focus_handle(),
+        }
+    }
+}
+```
+
+### Making Elements Focusable
+
+```rust
+impl Render for FocusableComponent {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .track_focus(&self.focus_handle)
+            .on_action(cx.listener(Self::on_enter))
+            .child("Focusable content")
+    }
+
+    fn on_enter(&mut self, _: &Enter, cx: &mut Context<Self>) {
+        // Handle Enter key when focused
+        cx.notify();
+    }
+}
+```
+
+### Focus Management
+
+```rust
+impl MyComponent {
+    fn focus(&mut self, cx: &mut Context<Self>) {
+        self.focus_handle.focus(cx);
+    }
+
+    fn is_focused(&self, cx: &App) -> bool {
+        self.focus_handle.is_focused(cx)
+    }
+
+    fn blur(&mut self, cx: &mut Context<Self>) {
+        cx.blur();
+    }
+}
+```
+
+## Focus Events
+
+### Handling Focus Changes
+
+```rust
+impl Render for MyInput {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let is_focused = self.focus_handle.is_focused(cx);
+
+        div()
+            .track_focus(&self.focus_handle)
+            .on_focus(cx.listener(|this, _event, cx| {
+                this.on_focus(cx);
+            }))
+            .on_blur(cx.listener(|this, _event, cx| {
+                this.on_blur(cx);
+            }))
+            .when(is_focused, |el| {
+                el.bg(cx.theme().focused_background)
+            })
+            .child(self.render_content())
+    }
+}
+
+impl MyInput {
+    fn on_focus(&mut self, cx: &mut Context<Self>) {
+        // Handle focus gained
+        cx.notify();
+    }
+
+    fn on_blur(&mut self, cx: &mut Context<Self>) {
+        // Handle focus lost
+        cx.notify();
+    }
+}
+```
+
+## Keyboard Navigation
+
+### Tab Order
+
+Elements with `track_focus()` automatically participate in Tab navigation.
+
+```rust
+div()
+    .child(
+        input1.track_focus(&focus1)  // Tab order: 1
+    )
+    .child(
+        input2.track_focus(&focus2)  // Tab order: 2
+    )
+    .child(
+        input3.track_focus(&focus3)  // Tab order: 3
+    )
+```
+
+### Focus Within Containers
+
+```rust
+impl Container {
+    fn focus_first(&mut self, cx: &mut Context<Self>) {
+        if let Some(first) = self.children.first() {
+            first.update(cx, |child, cx| {
+                child.focus_handle.focus(cx);
+            });
+        }
+    }
+
+    fn focus_next(&mut self, cx: &mut Context<Self>) {
+        // Custom focus navigation logic
+    }
+}
+```
+
+## Common Patterns
+
+### 1. Auto-focus on Mount
+
+```rust
+impl MyDialog {
+    fn new(cx: &mut Context<Self>) -> Self {
+        let focus_handle = cx.focus_handle();
+
+        // Focus when created
+        focus_handle.focus(cx);
+
+        Self { focus_handle }
+    }
+}
+```
+
+### 2. Focus Trap (Modal)
+
+```rust
+impl Modal {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .track_focus(&self.focus_handle)
+            .on_key_down(cx.listener(|this, event: &KeyDownEvent, cx| {
+                if event.key == Key::Tab {
+                    // Keep focus within modal
+                    this.focus_next_in_modal(cx);
+                    cx.stop_propagation();
+                }
+            }))
+            .child(self.render_content())
+    }
+}
+```
+
+### 3. Conditional Focus
+
+```rust
+impl Searchable {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .track_focus(&self.focus_handle)
+            .when(self.search_active, |el| {
+                el.on_mount(cx.listener(|this, _, cx| {
+                    this.focus_handle.focus(cx);
+                }))
+            })
+            .child(self.search_input())
+    }
+}
+```
+
+## Best Practices
+
+### ✅ Track Focus on Interactive Elements
+
+```rust
+// ✅ Good: Track focus for keyboard interaction
+input()
+    .track_focus(&self.focus_handle)
+    .on_action(cx.listener(Self::on_enter))
+```
+
+### ✅ Provide Visual Focus Indicators
+
+```rust
+let is_focused = self.focus_handle.is_focused(cx);
+
+div()
+    .when(is_focused, |el| {
+        el.border_color(cx.theme().focused_border)
+    })
+```
+
+### ❌ Don't: Forget to Track Focus
+
+```rust
+// ❌ Bad: No track_focus, keyboard navigation won't work
+div()
+    .on_action(cx.listener(Self::on_enter))
+```
+

--- a/.claude/skills/gpui-kit/references/gpui/global.md
+++ b/.claude/skills/gpui-kit/references/gpui/global.md
@@ -1,0 +1,197 @@
+# Global State
+
+**Contents:** [Overview](#overview) · [Quick Start](#quick-start) · [Common Use Cases](#common-use-cases) · [Best Practices](#best-practices) · [When to Use](#when-to-use)
+
+## Overview
+
+Global state in GPUI provides app-wide shared data accessible from any context.
+
+**Key Trait**: `Global` - Implement on types to make them globally accessible
+
+## Quick Start
+
+### Define Global State
+
+```rust
+use gpui_kit::Global;
+
+#[derive(Clone)]
+struct AppSettings {
+    theme: Theme,
+    language: String,
+}
+
+impl Global for AppSettings {}
+```
+
+### Set and Access Globals
+
+```rust
+fn main() {
+    let app = Application::new();
+    app.run(|cx: &mut App| {
+        // Set global
+        cx.set_global(AppSettings {
+            theme: Theme::Dark,
+            language: "en".to_string(),
+        });
+
+        // Access global (read-only)
+        let settings = cx.global::<AppSettings>();
+        println!("Theme: {:?}", settings.theme);
+    });
+}
+```
+
+### Update Globals
+
+```rust
+impl MyComponent {
+    fn change_theme(&mut self, new_theme: Theme, cx: &mut Context<Self>) {
+        cx.update_global::<AppSettings, _>(|settings, cx| {
+            settings.theme = new_theme;
+            // Global updates don't trigger automatic notifications
+            // Manually notify components that care
+        });
+
+        cx.notify(); // Re-render this component
+    }
+}
+```
+
+## Common Use Cases
+
+### 1. App Configuration
+
+```rust
+#[derive(Clone)]
+struct AppConfig {
+    api_endpoint: String,
+    max_retries: u32,
+    timeout: Duration,
+}
+
+impl Global for AppConfig {}
+
+// Set once at startup
+cx.set_global(AppConfig {
+    api_endpoint: "https://api.example.com".to_string(),
+    max_retries: 3,
+    timeout: Duration::from_secs(30),
+});
+
+// Access anywhere
+let config = cx.global::<AppConfig>();
+```
+
+### 2. Feature Flags
+
+```rust
+#[derive(Clone)]
+struct FeatureFlags {
+    enable_beta_features: bool,
+    enable_analytics: bool,
+}
+
+impl Global for FeatureFlags {}
+
+impl MyComponent {
+    fn render_beta_feature(&self, cx: &App) -> Option<impl IntoElement> {
+        let flags = cx.global::<FeatureFlags>();
+
+        if flags.enable_beta_features {
+            Some(div().child("Beta feature"))
+        } else {
+            None
+        }
+    }
+}
+```
+
+### 3. Shared Services
+
+```rust
+#[derive(Clone)]
+struct ServiceRegistry {
+    http_client: Arc<HttpClient>,
+    logger: Arc<Logger>,
+}
+
+impl Global for ServiceRegistry {}
+
+impl MyComponent {
+    fn fetch_data(&mut self, cx: &mut Context<Self>) {
+        let registry = cx.global::<ServiceRegistry>();
+        let client = registry.http_client.clone();
+
+        cx.spawn(async move |cx| {
+            let data = client.get("api/data").await?;
+            // Process data...
+            Ok::<_, anyhow::Error>(())
+        }).detach();
+    }
+}
+```
+
+## Best Practices
+
+### ✅ Use Arc for Shared Resources
+
+```rust
+#[derive(Clone)]
+struct GlobalState {
+    database: Arc<Database>,  // Cheap to clone
+    cache: Arc<RwLock<Cache>>,
+}
+
+impl Global for GlobalState {}
+```
+
+### ✅ Immutable by Default
+
+Globals are read-only by default. Use interior mutability when needed:
+
+```rust
+#[derive(Clone)]
+struct Counter {
+    count: Arc<AtomicUsize>,
+}
+
+impl Global for Counter {}
+
+impl Counter {
+    fn increment(&self) {
+        self.count.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn get(&self) -> usize {
+        self.count.load(Ordering::SeqCst)
+    }
+}
+```
+
+### ❌ Don't: Overuse Globals
+
+```rust
+// ❌ Bad: Too many globals
+cx.set_global(UserState { ... });
+cx.set_global(CartState { ... });
+cx.set_global(CheckoutState { ... });
+
+// ✅ Good: Use entities for component state
+let user_entity = cx.new(|_| UserState { ... });
+```
+
+## When to Use
+
+**Use Globals for:**
+- App-wide configuration
+- Feature flags
+- Shared services (HTTP client, logger)
+- Read-only reference data
+
+**Use Entities for:**
+- Component-specific state
+- State that changes frequently
+- State that needs notifications
+

--- a/.claude/skills/gpui-kit/references/gpui/layout-style.md
+++ b/.claude/skills/gpui-kit/references/gpui/layout-style.md
@@ -1,0 +1,280 @@
+# Layout & Styling
+
+**Contents:** [Overview](#overview) · [Quick Start](#quick-start) · [Common Patterns](#common-patterns) · [Styling Methods](#styling-methods) · [h_flex / v_flex](#h_flex--v_flex-helpers) · [Tailwind Shorthands](#tailwind-style-shorthand) · [Overflow & Scroll](#overflow-and-scroll) · [Absolute Positioning](#absolute-positioning) · [Stacking Order](#stacking-order) · [Theme Integration](#theme-integration) · [Conditional Styling](#conditional-styling) · [Text Styling](#text-styling)
+
+## Overview
+
+GPUI provides CSS-like styling with Rust type safety.
+
+**Key Concepts:**
+
+- Flexbox layout system
+- Styled trait for chaining styles
+- Size units: `px()`, `rems()`, `relative()`
+- Colors, borders, shadows
+
+## Quick Start
+
+### Basic Styling
+
+```rust
+use gpui_kit::*;
+
+div()
+    .w(px(200.))
+    .h(px(100.))
+    .bg(rgb(0x2196F3))
+    .text_color(rgb(0xFFFFFF))
+    .rounded(px(8.))
+    .p(px(16.))
+    .child("Styled content")
+```
+
+### Flexbox Layout
+
+```rust
+div()
+    .flex()
+    .flex_row()  // or flex_col() for column
+    .gap(px(8.))
+    .items_center()
+    .justify_between()
+    .children([
+        div().child("Item 1"),
+        div().child("Item 2"),
+        div().child("Item 3"),
+    ])
+```
+
+### Size Units
+
+```rust
+div()
+    .w(px(200.))           // Pixels
+    .h(rems(10.))          // Relative to font size
+    .w(relative(0.5))      // 50% of parent
+    .min_w(px(100.))
+    .max_w(px(400.))
+```
+
+## Common Patterns
+
+### Centered Content
+
+```rust
+div()
+    .flex()
+    .items_center()
+    .justify_center()
+    .size_full()
+    .child("Centered")
+```
+
+### Card Layout
+
+```rust
+div()
+    .w(px(300.))
+    .bg(cx.theme().surface)
+    .rounded(px(8.))
+    .shadow_md()
+    .p(px(16.))
+    .gap(px(12.))
+    .flex()
+    .flex_col()
+    .child(heading())
+    .child(content())
+```
+
+### Responsive Spacing
+
+```rust
+div()
+    .p(px(16.))           // Padding all sides
+    .px(px(20.))          // Padding horizontal
+    .py(px(12.))          // Padding vertical
+    .pt(px(8.))           // Padding top
+    .gap(px(8.))          // Gap between children
+```
+
+## Styling Methods
+
+### Dimensions
+
+```rust
+.w(px(200.))              // Width
+.h(px(100.))              // Height
+.size(px(200.))           // Width and height
+.min_w(px(100.))          // Min width
+.max_w(px(400.))          // Max width
+```
+
+### Colors
+
+```rust
+.bg(rgb(0x2196F3))        // Background
+.text_color(rgb(0xFFFFFF)) // Text color
+.border_color(rgb(0x000000)) // Border color
+```
+
+### Borders
+
+```rust
+.border(px(1.))           // Border width
+.rounded(px(8.))          // Border radius
+.rounded_t(px(8.))        // Top corners
+.border_color(rgb(0x000000))
+```
+
+### Spacing
+
+```rust
+.p(px(16.))               // Padding
+.m(px(8.))                // Margin
+.gap(px(8.))              // Gap between flex children
+```
+
+### Flexbox
+
+```rust
+.flex()                   // Enable flexbox
+.flex_row()               // Row direction
+.flex_col()               // Column direction
+.items_center()           // Align items center
+.justify_between()        // Space between items
+.flex_grow_1()              // Grow to fill space
+```
+
+## h_flex / v_flex Helpers
+
+`gpui_kit::component` provides shorthand helpers (import from `gpui_kit::component`):
+
+```rust
+use gpui_kit::component::{h_flex, v_flex};
+
+// h_flex() = div().flex().flex_row().items_center()
+h_flex()
+    .gap_2()
+    .child(icon)
+    .child(label)
+
+// v_flex() = div().flex().flex_col()
+v_flex()
+    .gap_4()
+    .p_4()
+    .child(input1)
+    .child(input2)
+    .child(submit_btn)
+```
+
+These are the standard layout primitives in `gpui_kit::component`. Prefer them over raw `div().flex()`.
+
+## Tailwind-style Shorthand
+
+GPUI provides Tailwind-style spacing/sizing shorthands:
+
+```rust
+// Spacing (0=0, 1=4px, 2=8px, 3=12px, 4=16px, ...)
+.p_2()    // padding: 8px
+.px_4()   // padding x: 16px
+.py_3()   // padding y: 12px
+.m_2()    // margin: 8px
+.gap_3()  // gap: 12px
+
+// Size
+.size_full()   // width: 100%, height: 100%
+.size_4()      // width: 16px, height: 16px
+.w_full()      // width: 100%
+.h_full()      // height: 100%
+.flex_1()      // flex: 1 1 0 (fill remaining space)
+.flex_shrink_0() // prevent shrinking
+```
+
+## Overflow and Scroll
+
+```rust
+div()
+    .overflow_hidden()          // clip content
+    .overflow_x_hidden()        // clip horizontal
+    .overflow_y_scrollbar()     // show scrollbar on y axis
+    .overflow_scroll()          // scroll both axes
+```
+
+## Absolute Positioning
+
+```rust
+div()
+    .relative()                 // position: relative (container)
+    .child(
+        div()
+            .absolute()         // position: absolute
+            .top_0()
+            .right_0()
+            .child("badge")
+    )
+
+// Inset helpers
+div().absolute().inset_0()      // top/right/bottom/left: 0 (fill parent)
+div().absolute().top(px(8.)).left(px(8.))
+```
+
+## Stacking Order
+
+```rust
+div()
+    .relative()
+    .child(content)
+    .child(
+        div()
+            .absolute()
+            .top_0()
+            .right_0()
+            .child("badge")
+    ) // later children are typically painted above earlier siblings
+```
+
+GPUI's general `Styled` API does **not** provide a `z_index(...)` method.
+
+For normal elements, stacking is usually controlled by:
+
+- Parent/child composition
+- Absolute positioning
+- Render order of siblings (later siblings paint above earlier ones)
+
+If you see a `z_index(...)` method in this repository, make sure it belongs to the specific component you are using. For example, `TileItem::z_index(...)` in the dock tiles system is a custom component API, not a general GPUI `Div` styling method.
+
+## Theme Integration
+
+```rust
+div()
+    .bg(cx.theme().surface)
+    .text_color(cx.theme().foreground)
+    .border_color(cx.theme().border)
+    .when(is_hovered, |el| {
+        el.bg(cx.theme().hover)
+    })
+```
+
+## Conditional Styling
+
+```rust
+use gpui_kit::prelude::FluentBuilder as _;
+
+div()
+    .when(is_active, |el| el.bg(cx.theme().primary))
+    .when(!is_active, |el| el.opacity(0.5))
+    .when_some(optional_color.as_ref(), |el, color| el.bg(*color))
+```
+
+## Text Styling
+
+```rust
+div()
+    .text_sm()          // font-size: small
+    .text_base()        // font-size: base
+    .text_lg()          // font-size: large
+    .font_bold()        // font-weight: bold
+    .line_height_snug() // tighter line height
+    .truncate()         // overflow: ellipsis, single line
+    .whitespace_nowrap()
+```

--- a/.claude/skills/gpui-kit/references/gpui/test-examples.md
+++ b/.claude/skills/gpui-kit/references/gpui/test-examples.md
@@ -1,0 +1,176 @@
+# Test Examples
+
+**Contents:** [Testing Best Practices](#testing-best-practices) · [Test Organization](#test-organization) · [Setup and Teardown](#setup-and-teardown) · [Assertions](#assertions) · [Performance Testing](#performance-testing) · [Running Tests](#running-tests) · [Basic Test Execution](#basic-test-execution) · [Test Configuration](#test-configuration) · [Advanced Test Execution](#advanced-test-execution) · [CI/CD Integration](#cicd-integration)
+
+## Testing Best Practices
+
+### Test Organization
+
+Group related tests in modules:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod entity_tests {
+        use super::*;
+
+        #[gpui_kit::test]
+        fn test_creation() { /* ... */ }
+
+        #[gpui_kit::test]
+        fn test_updates() { /* ... */ }
+    }
+
+    mod async_tests {
+        use super::*;
+
+        #[gpui_kit::test]
+        async fn test_async_ops() { /* ... */ }
+    }
+
+    mod distributed_tests {
+        use super::*;
+
+        #[gpui_kit::test]
+        fn test_multi_app() { /* ... */ }
+    }
+}
+```
+
+### Setup and Teardown
+
+Use helper functions for common setup:
+
+```rust
+fn create_test_counter(cx: &mut TestAppContext) -> Entity<Counter> {
+    cx.new(|cx| Counter::new(cx))
+}
+
+#[gpui_kit::test]
+fn test_counter_operations(cx: &mut TestAppContext) {
+    let counter = create_test_counter(cx);
+
+    // Test operations
+}
+```
+
+### Assertions
+
+Use descriptive assertions:
+
+```rust
+#[gpui_kit::test]
+fn test_counter_bounds(cx: &mut TestAppContext) {
+    let counter = create_test_counter(cx);
+
+    // Test upper bound
+    for _ in 0..100 {
+        counter.update(cx, |counter, cx| {
+            counter.increment(cx);
+        });
+    }
+
+    let count = counter.read_with(cx, |counter, _| counter.count);
+    assert!(count <= 100, "Counter should not exceed maximum");
+
+    // Test lower bound
+    for _ in 0..200 {
+        counter.update(cx, |counter, cx| {
+            counter.decrement(cx);
+        });
+    }
+
+    let count = counter.read_with(cx, |counter, _| counter.count);
+    assert!(count >= 0, "Counter should not go below minimum");
+}
+```
+
+### Performance Testing
+
+Test performance characteristics:
+
+```rust
+#[gpui_kit::test]
+fn test_operation_performance(cx: &mut TestAppContext) {
+    let component = cx.new(|cx| MyComponent::new(cx));
+
+    let start = std::time::Instant::now();
+
+    // Perform many operations
+    for i in 0..1000 {
+        component.update(cx, |comp, cx| {
+            comp.perform_operation(i, cx);
+        });
+    }
+
+    let elapsed = start.elapsed();
+    assert!(elapsed < Duration::from_millis(100), "Operations should complete quickly");
+}
+```
+
+## Running Tests
+
+### Basic Test Execution
+
+```bash
+# Run all tests
+cargo test
+
+# Run specific test
+cargo test test_counter_operations
+
+# Run tests in a specific module
+cargo test entity_tests::
+
+# Run with output
+cargo test -- --nocapture
+```
+
+### Test Configuration
+
+Enable test-support feature for GPUI tests:
+
+```toml
+[features]
+test-support = ["gpui/test-support"]
+```
+
+```bash
+cargo test --features test-support
+```
+
+### Advanced Test Execution
+
+```bash
+# Run tests with iterations for property testing
+cargo test -- --test-threads=1
+
+# Run tests matching a pattern
+cargo test test_async
+
+# Run tests with backtrace on failure
+RUST_BACKTRACE=1 cargo test
+```
+
+### CI/CD Integration
+
+For continuous integration:
+
+```yaml
+# .github/workflows/test.yml
+name: Tests
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Run tests
+        run: cargo test --features test-support
+```
+
+GPUI's testing framework provides deterministic, fast, and comprehensive testing capabilities that mirror real application behavior while providing the control needed for thorough testing of complex UI and async scenarios.

--- a/.claude/skills/gpui-kit/references/gpui/test-reference.md
+++ b/.claude/skills/gpui-kit/references/gpui/test-reference.md
@@ -1,0 +1,473 @@
+# Test Reference
+
+**Contents:** [Testing Patterns](#testing-patterns) · [Testing Crash-Free State Management (Re-entrancy)](#testing-crash-free-state-management-re-entrancy) · [Property Testing](#property-testing) · [Distributed Systems Testing](#distributed-systems-testing) · [Mocking and Isolation](#mocking-and-isolation)
+
+## Testing Patterns
+
+### Basic Entity Testing
+
+Test entity creation, updates, and reads:
+
+```rust
+#[gpui_kit::test]
+fn test_counter_entity(cx: &mut TestAppContext) {
+    let counter = cx.new(|cx| Counter::new(cx));
+
+    // Test initial state
+    let initial_count = counter.read_with(cx, |counter, _| counter.count);
+    assert_eq!(initial_count, 0);
+
+    // Test updates
+    counter.update(cx, |counter, cx| {
+        counter.count = 42;
+        cx.notify();
+    });
+
+    let updated_count = counter.read_with(cx, |counter, _| counter.count);
+    assert_eq!(updated_count, 42);
+}
+```
+
+### Event Testing
+
+Test event emission and handling:
+
+```rust
+#[derive(Clone)]
+struct ValueChanged {
+    new_value: i32,
+}
+
+impl EventEmitter<ValueChanged> for MyComponent {}
+
+#[gpui_kit::test]
+fn test_event_emission(cx: &mut TestAppContext) {
+    let component = cx.new(|cx| {
+        let mut comp = MyComponent::default();
+
+        // Subscribe to self
+        cx.subscribe_self(|this, event: &ValueChanged, cx| {
+            this.received_value = event.new_value;
+            cx.notify();
+        });
+
+        comp
+    });
+
+    // Emit event
+    component.update(cx, |_, cx| {
+        cx.emit(ValueChanged { new_value: 123 });
+    });
+
+    // Verify event was handled
+    let received = component.read_with(cx, |comp, _| comp.received_value);
+    assert_eq!(received, 123);
+}
+```
+
+### Action Testing
+
+Test action dispatching and handling:
+
+```rust
+actions!(my_app, [Increment, Decrement]);
+
+#[gpui_kit::test]
+fn test_action_dispatch(cx: &mut TestAppContext) {
+    let window = cx.update(|cx| {
+        cx.open_window(Default::default(), |_, cx| {
+            cx.new(|cx| MyComponent::new(cx))
+        }).unwrap()
+    });
+
+    let mut cx = VisualTestContext::from_window(window.into(), cx);
+    let counter = window.root(&mut cx).unwrap();
+
+    // Dispatch action via focus handle
+    let focus_handle = counter.read_with(&cx, |counter, _| counter.focus_handle.clone());
+    cx.update(|window, cx| {
+        focus_handle.dispatch_action(&Increment, window, cx);
+    });
+
+    let count = counter.read_with(&cx, |counter, _| counter.count);
+    assert_eq!(count, 1);
+}
+```
+
+### Async Testing
+
+Test async operations and background tasks:
+
+```rust
+impl MyComponent {
+    fn load_data(&self, cx: &mut Context<Self>) -> Task<i32> {
+        cx.spawn(async move |this, cx| {
+            // Simulate async work
+            this.update(cx, |comp, _| comp.loading = true).await;
+            // Return result
+            42
+        })
+    }
+
+    fn background_update(&self, cx: &mut Context<Self>) {
+        cx.spawn(async move |this, cx| {
+            // Background work
+            this.update(cx, |comp, _| {
+                comp.value += 10;
+            }).await;
+        }).detach();
+    }
+}
+
+#[gpui_kit::test]
+async fn test_async_operations(cx: &mut TestAppContext) {
+    let component = cx.new(|cx| MyComponent::new(cx));
+
+    // Test awaited task
+    let result = component.update(cx, |comp, cx| comp.load_data(cx)).await;
+    assert_eq!(result, 42);
+
+    // Test detached task
+    component.update(cx, |comp, cx| comp.background_update(cx));
+
+    // Detached tasks don't run until you yield
+    let value_before = component.read_with(cx, |comp, _| comp.value);
+    assert_eq!(value_before, 0);
+
+    // Run pending tasks
+    cx.run_until_parked();
+
+    let value_after = component.read_with(cx, |comp, _| comp.value);
+    assert_eq!(value_after, 10);
+}
+```
+
+### Timer Testing
+
+Test timer-based operations:
+
+```rust
+impl MyComponent {
+    fn delayed_action(&self, cx: &mut Context<Self>) {
+        cx.spawn(async move |this, cx| {
+            cx.background_executor()
+                .timer(Duration::from_millis(100))
+                .await;
+
+            this.update(cx, |comp, cx| {
+                comp.action_performed = true;
+                cx.notify();
+            }).await;
+        }).detach();
+    }
+}
+
+#[gpui_kit::test]
+async fn test_timers(cx: &mut TestAppContext) {
+    let component = cx.new(|cx| MyComponent::new(cx));
+
+    component.update(cx, |comp, cx| comp.delayed_action(cx));
+
+    // Action shouldn't have completed yet
+    let performed = component.read_with(cx, |comp, _| comp.action_performed);
+    assert!(!performed);
+
+    // Run until parked (timers complete)
+    cx.run_until_parked();
+
+    let performed = component.read_with(cx, |comp, _| comp.action_performed);
+    assert!(performed);
+}
+```
+
+### External I/O Testing
+
+For tests involving external systems, use `allow_parking()`:
+
+```rust
+#[gpui_kit::test]
+async fn test_external_io(cx: &mut TestAppContext) {
+    // Allow parking for external I/O
+    cx.executor().allow_parking();
+
+    // Simulate external operation
+    let (tx, rx) = futures::channel::oneshot::channel();
+    std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(10));
+        tx.send(42).ok();
+    });
+
+    let result = rx.await.unwrap();
+    assert_eq!(result, 42);
+}
+```
+
+## Testing Crash-Free State Management (Re-entrancy)
+
+The most dangerous class of GPUI bugs is **entity re-entrancy**: code that tries to update or read an entity while it is already locked in a render/update pass. These bugs are invisible at compile time — they only panic at runtime, typically when the user clicks something in a list or dropdown.
+
+**Key properties of re-entrancy panics:**
+- Triggered by user interaction (click, key press), not during static rendering.
+- `#[should_panic]` only confirms the bug exists — tests must pass *without* panicking.
+- `cx.run_until_parked()` is required after the triggering action to let deferred callbacks (`defer_in`) execute.
+
+### Pattern: Drive `confirm` / `cancel` through the real delegate
+
+```rust
+#[gpui_kit::test]
+fn test_confirm_does_not_panic(cx: &mut TestAppContext) {
+    // Build the component state the same way the real app does.
+    let state = cx.new(|cx| {
+        SelectState::new(MyDelegate::default(), None, &mut cx.window_handle(), cx)
+    });
+
+    // Simulate the user clicking the first item — this exercises on_confirm
+    // and its deferred callback, which is where re-entrancy bugs hide.
+    state.update(cx, |this, cx| {
+        this.state.list.update(cx, |list, cx| {
+            list.delegate_mut().set_selected_index(Some(IndexPath::new(0)), window, cx);
+            list.delegate_mut().confirm(false, window, cx);
+        });
+    });
+
+    // Let defer_in callbacks execute — required to trigger the crash.
+    cx.run_until_parked();
+
+    // If we reach here without panicking, the re-entrancy is fixed.
+    let selected = state.read_with(cx, |s, _| s.selected_value().cloned());
+    assert!(selected.is_some());
+}
+```
+
+### Pattern: Verify `on_will_change` and `on_confirm` hooks are called correctly
+
+Use a recording delegate to assert that hooks fire with the right arguments and in the right order:
+
+```rust
+#[derive(Default)]
+struct RecordingDelegate {
+    items: Vec<MyItem>,
+    will_change_calls: Vec<Vec<IndexPath>>,
+    confirm_calls: Vec<Vec<IndexPath>>,
+}
+
+impl SearchableListDelegate for RecordingDelegate {
+    // … required impls …
+
+    fn on_will_change(
+        &mut self,
+        change: &mut SearchableListChange<Self>,
+        _current: &[(IndexPath, Self::Item)],
+    ) {
+        self.will_change_calls.push(
+            change.select_queue.iter().map(|(ix, _)| *ix).collect()
+        );
+    }
+
+    fn on_confirm(&mut self, final_selection: &[(IndexPath, Self::Item)]) {
+        self.confirm_calls.push(
+            final_selection.iter().map(|(ix, _)| *ix).collect()
+        );
+    }
+}
+
+#[gpui_kit::test]
+fn test_hooks_fire_in_correct_order(cx: &mut TestAppContext) {
+    let state = cx.new(|cx| SelectState::new(RecordingDelegate::with_items(3), None, window, cx));
+
+    // Simulate confirm on item 0
+    state.update(cx, |this, cx| {
+        // … trigger confirm …
+    });
+    cx.run_until_parked();
+
+    state.read_with(cx, |s, cx| {
+        let delegate = s.state.list.read(cx).delegate().delegate;
+        assert_eq!(delegate.will_change_calls.len(), 1);
+        assert_eq!(delegate.confirm_calls.len(), 1);
+        assert_eq!(delegate.confirm_calls[0], vec![IndexPath::new(0)]);
+    });
+}
+```
+
+### Pattern: Rapid multiple confirms (snapshot consistency)
+
+```rust
+#[gpui_kit::test]
+fn test_rapid_confirms_keep_consistent_snapshot(cx: &mut TestAppContext) {
+    let state = cx.new(|cx| SelectState::new(MyDelegate::with_items(5), None, window, cx));
+
+    for i in 0..5 {
+        state.update(cx, |this, cx| {
+            // trigger confirm on item i
+        });
+        cx.run_until_parked();
+
+        state.read_with(cx, |s, cx| {
+            let snapshot = s.state.list.read(cx).delegate().selection_snapshot.clone();
+            let selection = s.state.selection.clone();
+            assert_eq!(snapshot, selection, "snapshot out of sync after confirm {i}");
+        });
+    }
+}
+```
+
+### Checklist: What to test for each component that uses `defer_in`
+
+- [ ] `confirm` path: no panic, correct final selection, snapshot matches selection
+- [ ] `cancel` path: no panic, selection unchanged, popover closed
+- [ ] `on_will_change` veto: selection not changed, `on_confirm` not called
+- [ ] `on_will_change` mutating the change: final selection reflects delegate's modification
+- [ ] Rapid consecutive confirms: each one leaves snapshot consistent with selection
+- [ ] `render_item` never panics even when called immediately after a mutation
+
+## Property Testing
+
+Use random data to test edge cases:
+
+```rust
+#[gpui_kit::test(iterations = 10)]
+fn test_counter_random_operations(cx: &mut TestAppContext, mut rng: StdRng) {
+    let counter = cx.new(|cx| Counter::new(cx));
+
+    let mut expected = 0i32;
+    for _ in 0..100 {
+        let delta = rng.random_range(-10..=10);
+        expected += delta;
+
+        counter.update(cx, |counter, cx| {
+            counter.count += delta;
+            cx.notify();
+        });
+    }
+
+    let actual = counter.read_with(cx, |counter, _| counter.count);
+    assert_eq!(actual, expected);
+}
+```
+
+## Distributed Systems Testing
+
+Test multiple app contexts communicating:
+
+```rust
+#[derive(Clone)]
+struct NetworkMessage {
+    from: String,
+    to: String,
+    data: i32,
+}
+
+#[gpui_kit::test]
+fn test_distributed_apps(cx_a: &mut TestAppContext, cx_b: &mut TestAppContext) {
+    // Create components in different app contexts
+    let comp_a = cx_a.new(|_| MyComponent::new("A".to_string()));
+    let comp_b = cx_b.new(|_| MyComponent::new("B".to_string()));
+
+    // Simulate message passing
+    comp_a.update(cx_a, |comp, cx| {
+        comp.send_message("B", 42, cx);
+    });
+
+    // Run async operations
+    cx_a.run_until_parked();
+
+    // Verify message received in other context
+    comp_b.update(cx_b, |comp, _| {
+        comp.receive_messages();
+    });
+
+    let messages = comp_b.read_with(cx_b, |comp, _| comp.messages.clone());
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].data, 42);
+}
+```
+
+### Interleaving Testing
+
+Test concurrent operations with random execution order:
+
+```rust
+#[gpui_kit::test(iterations = 10)]
+fn test_concurrent_operations(
+    cx_a: &mut TestAppContext,
+    cx_b: &mut TestAppContext,
+    mut rng: StdRng,
+) {
+    let comp_a = cx_a.new(|_| MyComponent::new());
+    let comp_b = cx_b.new(|_| MyComponent::new());
+
+    // Perform random operations across contexts
+    for i in 0..20 {
+        if rng.random_bool(0.5) {
+            comp_a.update(cx_a, |comp, cx| {
+                comp.perform_operation(i, cx);
+            });
+        } else {
+            comp_b.update(cx_b, |comp, cx| {
+                comp.perform_operation(i, cx);
+            });
+        }
+    }
+
+    // Run all pending operations
+    cx_a.run_until_parked();
+
+    // Verify final state
+    let state_a = comp_a.read_with(cx_a, |comp, _| comp.state);
+    let state_b = comp_b.read_with(cx_b, |comp, _| comp.state);
+
+    // Assert invariants hold despite execution order
+    assert!(state_a.is_consistent());
+    assert!(state_b.is_consistent());
+}
+```
+
+## Mocking and Isolation
+
+### Network Mocking
+
+Create mock networks for testing distributed features:
+
+```rust
+struct MockNetwork {
+    messages: Arc<Mutex<Vec<NetworkMessage>>>,
+}
+
+impl MockNetwork {
+    fn new() -> Self {
+        Self {
+            messages: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn send(&self, message: NetworkMessage) {
+        self.messages.lock().unwrap().push(message);
+    }
+
+    fn receive_all(&self) -> Vec<NetworkMessage> {
+        self.messages.lock().unwrap().drain(..).collect()
+    }
+}
+
+#[gpui_kit::test]
+fn test_networked_components(cx: &mut TestAppContext) {
+    let network = Arc::new(MockNetwork::new());
+
+    let sender = cx.new(|_| MessageSender::new(network.clone()));
+    let receiver = cx.new(|_| MessageReceiver::new(network));
+
+    // Send message
+    sender.update(cx, |sender, _| {
+        sender.send("Hello");
+    });
+
+    // Receive message
+    receiver.update(cx, |receiver, _| {
+        receiver.receive_all();
+    });
+
+    let received = receiver.read_with(cx, |receiver, _| receiver.messages.clone());
+    assert_eq!(received, vec!["Hello"]);
+}
+```

--- a/.claude/skills/gpui-kit/references/gpui/test.md
+++ b/.claude/skills/gpui-kit/references/gpui/test.md
@@ -1,0 +1,94 @@
+# Testing
+
+**Contents:** [Overview](#overview) · [Core Testing Infrastructure](#core-testing-infrastructure) · [Additional Resources](#additional-resources)
+
+## Overview
+
+GPUI provides a comprehensive testing framework that allows you to test UI components, async operations, and distributed systems. Tests run on a single-threaded executor that provides deterministic execution and the ability to test complex async scenarios. GPUI tests use the `#[gpui_kit::test]` attribute and work with `TestAppContext` for basic testing and `VisualTestContext` for window-dependent tests.
+
+### Rules
+
+- `#[gpui_kit::test]` is GPUI's test attribute reached through the umbrella crate. It needs the `test-support` feature: add `gpui-kit = { version = "...", features = ["test-support"] }` under `[dev-dependencies]`.
+- If the test does not need windows or rendering, skip `#[gpui_kit::test]` and `TestAppContext` and write a plain `#[test]`.
+
+## Core Testing Infrastructure
+
+### Test Attributes
+
+#### Basic Test
+
+```rust
+#[gpui_kit::test]
+fn my_test(cx: &mut TestAppContext) {
+    // Test implementation
+}
+```
+
+#### Async Test
+
+```rust
+#[gpui_kit::test]
+async fn my_async_test(cx: &mut TestAppContext) {
+    // Async test implementation
+}
+```
+
+#### Property Test with Iterations
+
+```rust
+#[gpui_kit::test(iterations = 10)]
+fn my_property_test(cx: &mut TestAppContext, mut rng: StdRng) {
+    // Property testing with random data
+}
+```
+
+### Test Contexts
+
+#### TestAppContext
+
+`TestAppContext` provides access to GPUI's core functionality without windows:
+
+```rust
+#[gpui_kit::test]
+fn test_entity_operations(cx: &mut TestAppContext) {
+    // Create entities
+    let entity = cx.new(|cx| MyComponent::new(cx));
+
+    // Update entities
+    entity.update(cx, |component, cx| {
+        component.value = 42;
+        cx.notify();
+    });
+
+    // Read entities
+    let value = entity.read_with(cx, |component, _| component.value);
+    assert_eq!(value, 42);
+}
+```
+
+#### VisualTestContext
+
+`VisualTestContext` extends `TestAppContext` with window support:
+
+```rust
+#[gpui_kit::test]
+fn test_with_window(cx: &mut TestAppContext) {
+    // Create window with component
+    let window = cx.update(|cx| {
+        cx.open_window(Default::default(), |_, cx| {
+            cx.new(|cx| MyComponent::new(cx))
+        }).unwrap()
+    });
+
+    // Convert to visual context
+    let mut cx = VisualTestContext::from_window(window.into(), cx);
+
+    // Access window and component
+    let component = window.root(&mut cx).unwrap();
+}
+```
+
+## Additional Resources
+
+- For detailed patterns (including re-entrancy crash-free testing), see [test-reference.md](test-reference.md)
+- For examples and best practices, see [test-examples.md](test-examples.md)

--- a/.claude/skills/gpui-kit/references/usage.md
+++ b/.claude/skills/gpui-kit/references/usage.md
@@ -1,0 +1,400 @@
+# gpui-kit Usage Guide
+
+**Contents:** [Setup](#setup) · [Component Types](#component-types) · [Common Components](#common-components) (Button, Input, Select, Checkbox, Icon, Dialog, Notification, Tabs, Tooltip, Form, List) · [Theming](#theming) · [Layout Helpers](#layout-helpers) · [Overlay Layers](#overlay-layers-dialogs-sheets-notifications) · [Shared Traits](#shared-traits)
+
+## Setup
+
+### 1. Cargo.toml
+
+```toml
+[dependencies]
+gpui-kit = "0.6" # re-exports gpui, gpui_platform, gpui-base, gpui-component, gpui-shell and the default icons
+```
+
+### 2. Initialization
+
+```rust
+fn main() {
+    gpui_kit::application()
+        .with_assets(gpui_kit::assets::Assets)
+        .run(move |cx| {
+            gpui_kit::init(cx); // MUST be first
+
+            cx.spawn(async move |cx| {
+                cx.open_window(WindowOptions::default(), |window, cx| {
+                    let view = cx.new(|_| MyApp);
+                    cx.new(|cx| Root::new(view, window, cx)) // Root wraps first view
+                }).expect("Failed to open window");
+            }).detach();
+        });
+}
+```
+
+**`Root` is required** as the first-level child of every window — it enables dialogs, sheets, and notifications.
+
+---
+
+## Component Types
+
+### Stateless (most components)
+
+Used directly in `render`, no stored state:
+
+```rust
+use gpui_kit::component::button::Button;
+
+impl Render for MyView {
+    fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+        Button::new("btn").primary().label("Submit")
+            .on_click(|_, _, _| println!("clicked"))
+    }
+}
+```
+
+### Stateful (Input, Select, Combobox, etc.)
+
+Require an `Entity<State>` stored in your view:
+
+```rust
+use gpui_kit::component::input::{Input, InputState};
+
+struct MyView {
+    name: Entity<InputState>,
+}
+
+impl MyView {
+    fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
+        Self {
+            name: cx.new(|cx| InputState::new(window, cx).placeholder("Your name")),
+        }
+    }
+}
+
+impl Render for MyView {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        Input::new(&self.name)
+    }
+}
+```
+
+---
+
+## Common Components
+
+### Button
+
+```rust
+use gpui_kit::component::button::{Button, ButtonGroup};
+
+// Variants
+Button::new("btn").label("Default")
+Button::new("btn").primary().label("Primary")
+Button::new("btn").danger().label("Delete")
+Button::new("btn").warning().label("Warning")
+Button::new("btn").success().label("Success")
+Button::new("btn").ghost().label("Ghost")
+Button::new("btn").link().label("Link")
+
+// States
+Button::new("btn").label("Text").disabled(true)
+Button::new("btn").label("Text").loading(true)
+Button::new("btn").label("Text").selected(true)
+
+// With icon
+Button::new("btn").icon(IconName::Plus).label("Add")
+
+// Sizes
+Button::new("btn").xsmall().label("XS")
+Button::new("btn").small().label("S")
+Button::new("btn").large().label("L")
+
+// Group
+ButtonGroup::new("group")
+    .child(Button::new("a").label("A"))
+    .child(Button::new("b").label("B"))
+    .on_click(|indices, _, _| { /* selected indices */ })
+```
+
+### Input
+
+```rust
+use gpui_kit::component::input::{Input, InputState};
+
+// State setup (in new/init)
+let input = cx.new(|cx| InputState::new(window, cx)
+    .placeholder("Enter text...")
+    .default_value("Hello")
+);
+
+// Render
+Input::new(&input)
+Input::new(&input).cleanable(true)           // clear button
+Input::new(&input).disabled(true)
+Input::new(&input).prefix(Icon::new(IconName::Search).small())
+Input::new(&input).suffix(Button::new("b").ghost().icon(IconName::X).xsmall())
+Input::new(&input).content_type(InputContentType::Password)
+Input::new(&input).mask_toggle()             // password reveal toggle
+Input::new(&input).appearance(false)         // remove default border/bg
+
+// Reading value
+let value = input.read(cx).value();
+
+// Events
+cx.subscribe_in(&input, window, |view, state, event, window, cx| {
+    match event {
+        InputEvent::Change => { let v = state.read(cx).value(); }
+        InputEvent::PressEnter { .. } => { /* submit */ }
+        InputEvent::Focus | InputEvent::Blur => {}
+    }
+});
+```
+
+### Select
+
+```rust
+use gpui_kit::component::select::{Select, SelectState};
+
+// Simple string list
+let state = cx.new(|cx| {
+    SelectState::new(vec!["Apple", "Orange", "Banana"], Some(IndexPath::default()), window, cx)
+});
+
+// Render
+Select::new(&state)
+Select::new(&state).placeholder("Pick one")
+
+// Reading selection
+let selected = state.read(cx).selected_item();
+```
+
+### Checkbox / Switch / Radio
+
+```rust
+use gpui_kit::component::{Checkbox, Switch};
+
+// Stateless (controlled)
+Checkbox::new("cb").checked(self.checked)
+    .on_click(|checked, _, cx| { /* &bool */ })
+
+Switch::new("sw").checked(self.enabled)
+    .on_click(|checked, _, cx| {})
+```
+
+### Icon
+
+```rust
+use gpui_kit::component::{Icon, IconName};
+
+Icon::new(IconName::Check)
+Icon::new(IconName::Search).small()
+Icon::new(IconName::Plus).large().text_color(cx.theme().primary)
+```
+
+### Dialog
+
+```rust
+use gpui_kit::component::dialog::{Dialog, DialogAction, DialogClose, DialogFooter};
+
+// Open from window context. `footer` takes an element, not a closure.
+// DialogClose dismisses the dialog, so no manual close call is needed.
+window.open_dialog(cx, |dialog, _, _| {
+    dialog
+        .title("Export Report")
+        .child("Choose a destination for the exported file.")
+        .footer(
+            DialogFooter::new()
+                .gap_2()
+                .child(DialogClose::new().child(
+                    Button::new("cancel").label("Cancel").outline(),
+                ))
+                .child(DialogAction::new().child(
+                    Button::new("export").label("Export").primary(),
+                )),
+        )
+});
+```
+
+### AlertDialog
+
+Use `AlertDialog` — not `Dialog` — to confirm a consequential action. It is not
+overlay-closable and has no close button, so the choice must be made. Name the
+object in the title and the result on the confirming button; see the Design
+Guides for the copy rules.
+
+```rust
+use gpui_kit::component::{button::ButtonVariant, dialog::DialogButtonProps};
+
+window.open_alert_dialog(cx, |alert, _, _| {
+    alert
+        .title("Remove “Roadmap”?")
+        .description("Files on disk aren’t deleted.")
+        .button_props(
+            DialogButtonProps::default()
+                .ok_text("Remove")
+                .ok_variant(ButtonVariant::Danger)
+                .on_ok(|_, _, _| true),
+        )
+});
+```
+
+### Notification
+
+```rust
+// Simple string message
+window.push_notification("Saved successfully!", cx);
+
+// With type variant
+window.push_notification(
+    Notification::new("Upload complete").info().message("File uploaded"),
+    cx,
+);
+```
+
+### Tabs
+
+```rust
+use gpui_kit::component::tab::{Tab, TabBar};
+
+TabBar::new("tabs")
+    .child(Tab::new("tab1").child("Overview"))
+    .child(Tab::new("tab2").child("Settings"))
+    .child(Tab::new("tab3").child("Logs"))
+```
+
+### Tooltip
+
+```rust
+// On any element with .id(), add .tooltip():
+div()
+    .id("my-btn")
+    .tooltip(|window, cx| Tooltip::new("Delete item").build(window, cx))
+    .child("Delete")
+
+// Or on a Button directly:
+Button::new("btn").icon(IconName::Trash).tooltip("Delete")
+```
+
+### Form
+
+```rust
+use gpui_kit::component::form::{v_form, h_form, field};
+
+// Vertical form
+v_form()
+    .child(field().label("Name").child(Input::new(&self.name)))
+    .child(field().label("Email").child(Input::new(&self.email)))
+    .child(Button::new("submit").primary().label("Submit"))
+
+// Horizontal label alignment
+h_form()
+    .child(field().label("Username").child(Input::new(&self.username)))
+```
+
+### List (searchable, virtualized)
+
+```rust
+use gpui_kit::component::list::{List, ListState, ListDelegate, ListItem, ListEvent};
+
+// Implement ListDelegate for your data type, then:
+let list_state = cx.new(|cx| ListState::new(MyDelegate::new(), window, cx));
+
+// Render
+List::new(&list_state)
+// Events
+cx.subscribe(&list_state, |this, _, event, cx| {
+    if let ListEvent::Select(index_path) = event {
+        // handle selection
+    }
+});
+```
+
+---
+
+## Theming
+
+```rust
+use gpui_kit::component::ActiveTheme as _;
+
+// Access colors
+cx.theme().primary
+cx.theme().background
+cx.theme().foreground
+cx.theme().border
+cx.theme().surface
+cx.theme().muted
+cx.theme().destructive
+
+// Use in styles
+div()
+    .bg(cx.theme().surface)
+    .text_color(cx.theme().foreground)
+    .border_color(cx.theme().border)
+```
+
+### Switch Theme
+
+```rust
+use gpui_kit::component::Theme;
+
+// Toggle light/dark
+cx.update_global::<Theme, _>(|theme, cx| {
+    theme.toggle_mode(cx);
+});
+
+// Load a named theme
+Theme::global_mut(cx).apply_config(&theme_config);
+```
+
+---
+
+## Layout Helpers
+
+`gpui_kit::component` extends GPUI with convenient layout methods:
+
+```rust
+h_flex()    // div().flex().flex_row().items_center()
+v_flex()    // div().flex().flex_col()
+
+// Common patterns
+h_flex().gap_2().items_center()
+    .child(Icon::new(IconName::User))
+    .child(label("Username"))
+
+v_flex().gap_4().p_4()
+    .child(Input::new(&self.name))
+    .child(Input::new(&self.email))
+    .child(Button::new("submit").primary().label("Submit"))
+```
+
+---
+
+## Overlay Layers (Dialogs, Sheets, Notifications)
+
+To render overlays, add these to your first-level view's render:
+
+```rust
+impl Render for MyApp {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .size_full()
+            .child(self.main_content(window, cx))
+            .children(Root::render_dialog_layer(cx))
+            .children(Root::render_sheet_layer(cx))
+            .children(Root::render_notification_layer(cx))
+    }
+}
+```
+
+---
+
+## Shared Traits
+
+All components follow the builder pattern `Component::new("id").method().method()`:
+
+- `Sizable`: `.xsmall()` / `.small()` / `.medium()` (default) / `.large()`
+- `Disableable`: `.disabled(bool)`
+- `Selectable`: `.selected(bool)`
+- `Styled`: any GPUI style methods (`.w()`, `.bg()`, `.p_2()`, etc.)
+
+For any component not covered here, fetch its doc from:
+`https://gpui-kit.com/docs/components/{name}.md`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # Tauri v2 system libraries needed to compile the desktop crate.
+      # Tauri v2 system libraries needed to compile the desktop crate, plus the
+      # one library the GPUI shell (apps/gpui) links that the runner image
+      # lacks. GPUI's Linux backend wants xcb, fontconfig, freetype, xkbcommon
+      # and xkbcommon-x11; the runner has all but the last, and the workspace
+      # test build failed at link time on exactly `-lxkbcommon-x11`.
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
@@ -82,6 +86,7 @@ jobs:
             patchelf \
             libgtk-3-dev \
             libssl-dev \
+            libxkbcommon-x11-dev \
             build-essential
       # No `version:` — `pnpm/action-setup` reads `packageManager` from
       # package.json. One source of truth: a second one here is how local
@@ -136,8 +141,10 @@ jobs:
           cargo llvm-cov --no-report -p srelens-kube --test helm_lifecycle -- --ignored --nocapture --test-threads=1
       - name: Enforce the coverage floor
         # Only the process entries stay excluded (lib.rs/main.rs, the
-        # server's bin, and the GPUI shell's main.rs — they execute solely
-        # inside a running app, server or window).
+        # server's bin, and the GPUI shell's main.rs, workspace.rs and
+        # kube_bridge.rs — they execute solely inside a running app, server or
+        # window, or against a live cluster). The shell's pods_table.rs is
+        # pure and tested, so it counts like everything else.
         # The command shims that used to sit here are unit-tested through
         # tauri::test's MockRuntime and count like everything else. The floor
         # is a ratchet — 55 at first green, 84 when the kind suites started
@@ -145,7 +152,7 @@ jobs:
         # #28's acceptance number) — never lower it.
         run: >-
           cargo llvm-cov report --summary-only --fail-under-lines 85
-          --ignore-filename-regex 'apps/desktop/src-tauri/src/(lib|main)\.rs|crates/server/src/bin/|apps/gpui/src/main\.rs'
+          --ignore-filename-regex 'apps/desktop/src-tauri/src/(lib|main)\.rs|crates/server/src/bin/|apps/gpui/src/(main|workspace|kube_bridge)\.rs'
 
   # The WebDriver smoke suite (issue #30): the REAL built app — WebView and
   # all — driven through tauri-driver against a kind cluster. This is the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,8 +135,9 @@ jobs:
           cargo llvm-cov --no-report -p srelens-desktop --test e2e -- --ignored --nocapture --test-threads=1
           cargo llvm-cov --no-report -p srelens-kube --test helm_lifecycle -- --ignored --nocapture --test-threads=1
       - name: Enforce the coverage floor
-        # Only the process entries stay excluded (lib.rs/main.rs and the
-        # server's bin — they execute solely inside a running app/server).
+        # Only the process entries stay excluded (lib.rs/main.rs, the
+        # server's bin, and the GPUI shell's main.rs — they execute solely
+        # inside a running app, server or window).
         # The command shims that used to sit here are unit-tested through
         # tauri::test's MockRuntime and count like everything else. The floor
         # is a ratchet — 55 at first green, 84 when the kind suites started
@@ -144,7 +145,7 @@ jobs:
         # #28's acceptance number) — never lower it.
         run: >-
           cargo llvm-cov report --summary-only --fail-under-lines 85
-          --ignore-filename-regex 'apps/desktop/src-tauri/src/(lib|main)\.rs|crates/server/src/bin/'
+          --ignore-filename-regex 'apps/desktop/src-tauri/src/(lib|main)\.rs|crates/server/src/bin/|apps/gpui/src/main\.rs'
 
   # The WebDriver smoke suite (issue #30): the REAL built app — WebView and
   # all — driven through tauri-driver against a kind cluster. This is the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,31 @@ Two examples from one branch: the Changes toggle stayed on "Hide changes"
 after an apply, and the diff panel was unreadable at its column width. Both
 had green tests. Neither was findable without looking.
 
+## The GPUI shell (`apps/gpui`)
+
+An experiment, not the product: one screen against the existing crates, to
+cost a migration (`docs/design/gpui-kit-feasibility.md`). Three things it
+already taught, each of which cost a build to learn:
+
+- **Two rustls providers end up in one process.** kube-rs brings `ring`,
+  GPUI's HTTP client brings `aws-lc-rs`, and rustls panics on the first
+  handshake — on the kube thread, silently, with an empty window. `main`
+  installs `ring` explicitly before anything touches the network. Any binary
+  that links both ecosystems needs that line.
+- **`use super::*` in a test module under `use gpui_kit::*` breaks `#[test]`.**
+  The glob carries a `test` attribute macro, and a bare `#[test]` then
+  expands into itself until the recursion limit. Name the imports.
+- **The accessibility tree is measurable, so measure it.** On Windows the
+  window is exposed through AccessKit to UI Automation; a PowerShell walker
+  over `RawViewWalker` lists what a screen reader gets. Pickers need
+  `accessibility_label` or they arrive nameless; the `DataTable` does not
+  arrive at all, and the pickers' `ExpandCollapse` pattern is declared but
+  does nothing. Check the tree before calling a GPUI screen done.
+
+Read the two installed skills (`.claude/skills/gpui-kit*`) before touching it;
+their coding and design guides are normative, and every API in that crate was
+taken from the toolkit's source, not guessed.
+
 ## Windows
 
 Three suites fail on Windows only and are unrelated to your change:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9609,7 +9609,6 @@ name = "srelens-gpui"
 version = "0.8.0"
 dependencies = [
  "gpui-kit",
- "rustls",
  "srelens-capability",
  "srelens-kube",
  "srelens-registry",
@@ -9629,6 +9628,7 @@ dependencies = [
  "http",
  "k8s-openapi",
  "kube",
+ "rustls",
  "schemars 0.8.22",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,95 @@
 version = 4
 
 [[package]]
+name = "accesskit"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3b7f7f85a7e5f68090000ed7622545829afd484d210358702ae4cb97dd0c320"
+dependencies = [
+ "enumn",
+ "uuid",
+]
+
+[[package]]
+name = "accesskit_atspi_common"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "023da0e5097f46df7092d5280b02efb9bbf8d93298daeced42652463e357d636"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "atspi-common",
+ "phf 0.13.1",
+ "serde",
+ "zvariant 5.13.1",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d10a236f96f87d70732e44520046785431ef01d5bcd6b041317bfadd2f88245"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "accesskit_macos"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce02dc63b43f0c9296af9ac946312a2dc8814427d7a64d2d600971dac55b6076"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "hashbrown 0.16.1",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "accesskit_unix"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e156ed3802e35eefe894ef2671bc6c889303d8a7e110b5e1b48f504b91362f"
+dependencies = [
+ "accesskit",
+ "accesskit_atspi_common",
+ "async-channel",
+ "async-executor",
+ "async-task",
+ "atspi",
+ "futures-lite",
+ "futures-util",
+ "serde",
+ "zbus 5.18.0",
+]
+
+[[package]]
+name = "accesskit_windows"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106c2b961215864d1c2e703ee63269c25c4e80a577ffb2c1017b9c17dcdf83a1"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "hashbrown 0.16.1",
+ "static_assertions",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,6 +116,7 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures 0.2.17",
+ "zeroize",
 ]
 
 [[package]]
@@ -61,6 +151,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "const-random",
  "getrandom 0.3.4",
  "once_cell",
  "version_check",
@@ -74,6 +165,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
 ]
 
 [[package]]
@@ -156,6 +265,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,10 +303,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+
+[[package]]
+name = "as-raw-xcb-connection"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
+dependencies = [
+ "libloading 0.8.9",
+]
+
+[[package]]
+name = "ashpd"
+version = "0.13.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb8421aaa9644a5faf26735f258b669b15f063313ef8f8e2bdb28912a1a6f111"
+dependencies = [
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "getrandom 0.4.3",
+ "serde",
+ "serde_repr",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "zbus 5.18.0",
+]
 
 [[package]]
 name = "async-broadcast"
@@ -211,6 +388,7 @@ checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
 dependencies = [
  "compression-codecs",
  "compression-core",
+ "futures-io",
  "pin-project-lite",
  "tokio",
 ]
@@ -227,6 +405,17 @@ dependencies = [
  "futures-lite",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
 ]
 
 [[package]]
@@ -256,6 +445,17 @@ dependencies = [
  "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
 ]
 
 [[package]]
@@ -377,16 +577,125 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "atspi"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77886257be21c9cd89a4ae7e64860c6f0eefca799bb79127913052bd0eefb3d"
+dependencies = [
+ "atspi-common",
+ "atspi-proxies",
+]
+
+[[package]]
+name = "atspi-common"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c5617155740c98003016429ad13fe43ce7a77b007479350a9f8bf95a29f63d"
+dependencies = [
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zbus 5.18.0",
+ "zbus-lockstep",
+ "zbus-lockstep-macros",
+ "zbus_names 4.3.4",
+ "zvariant 5.13.1",
+]
+
+[[package]]
+name = "atspi-proxies"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2230e48787ed3eb4088996eab66a32ca20c0b67bbd4fd6cdfe79f04f1f04c9fc"
+dependencies = [
+ "atspi-common",
+ "serde",
+ "zbus 5.18.0",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.18",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom 8.0.0",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
 
 [[package]]
 name = "axum"
@@ -458,10 +767,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base62"
+version = "2.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd637ac531c60eb7fbc4684dc061c2d7d90d73d758181aa02eeff0464b9eee4b"
 
 [[package]]
 name = "base64"
@@ -482,12 +812,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.13.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.10.5",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.2",
+ "shlex 1.3.0",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
+dependencies = [
+ "bit-vec 0.9.1",
 ]
 
 [[package]]
@@ -495,6 +863,18 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+
+[[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
 name = "bitflags"
@@ -509,6 +889,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "bitstream-io"
+version = "4.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
+dependencies = [
+ "no_std_io2",
 ]
 
 [[package]]
@@ -531,6 +920,12 @@ checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
  "digest 0.10.7",
 ]
+
+[[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-buffer"
@@ -561,11 +956,20 @@ dependencies = [
 
 [[package]]
 name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
- "objc2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -636,6 +1040,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
+name = "built"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,6 +1100,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+]
 
 [[package]]
 name = "byteorder"
@@ -688,12 +1122,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bzip2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
+dependencies = [
+ "libbz2-rs-sys",
 ]
 
 [[package]]
@@ -719,6 +1168,31 @@ dependencies = [
  "glib-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "calloop"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7"
+dependencies = [
+ "bitflags 2.13.0",
+ "polling",
+ "rustix",
+ "slab",
+ "tracing",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138efcf0940a02ebf0cc8d1eff41a1682a46b431630f4c52450d6265876021fa"
+dependencies = [
+ "calloop",
+ "rustix",
+ "wayland-backend",
+ "wayland-client",
 ]
 
 [[package]]
@@ -773,13 +1247,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbindgen"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadd868a2ce9ca38de7eeafdcec9c7065ef89b42b32f0839278d55f35c54d1ff"
+dependencies = [
+ "heck 0.4.1",
+ "indexmap 2.14.0",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.118",
+ "tempfile",
+ "toml 0.8.23",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
- "shlex",
+ "jobserver",
+ "libc",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -787,6 +1281,15 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
 
 [[package]]
 name = "cfb"
@@ -826,6 +1329,15 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "cgl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "chacha20"
@@ -888,6 +1400,102 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "cocoa"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6140449f97a6e97f9511815c5632d84c8aacf8ac271ad77c559218161a1373c"
+dependencies = [
+ "bitflags 1.3.2",
+ "block",
+ "cocoa-foundation 0.1.2",
+ "core-foundation 0.9.4",
+ "core-graphics 0.23.2",
+ "foreign-types",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79398230a6e2c08f5c9760610eb6924b52aa9e7950a619602baba59dcbbdbb2"
+dependencies = [
+ "bitflags 2.13.0",
+ "block",
+ "cocoa-foundation 0.2.1",
+ "core-foundation 0.10.1",
+ "core-graphics 0.24.0",
+ "foreign-types",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa-foundation"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c6234cbb2e4c785b456c0644748b1ac416dd045799740356f8363dfe00c93f7"
+dependencies = [
+ "bitflags 1.3.2",
+ "block",
+ "core-foundation 0.9.4",
+ "core-graphics-types 0.1.3",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa-foundation"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81411967c50ee9a1fc11365f8c585f863a22a9697c89239c452292c40ba79b0d"
+dependencies = [
+ "bitflags 2.13.0",
+ "block",
+ "core-foundation 0.10.1",
+ "core-graphics-types 0.2.0",
+ "objc",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,6 +1511,7 @@ version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
+ "bzip2",
  "compression-core",
  "flate2",
  "memchr",
@@ -921,6 +1530,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -953,6 +1572,24 @@ dependencies = [
  "getrandom 0.2.17",
  "once_cell",
  "tiny-keccak",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -993,14 +1630,64 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "core-graphics-types 0.1.3",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.10.1",
+ "core-graphics-types 0.2.0",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.13.0",
  "core-foundation 0.10.1",
- "core-graphics-types",
+ "core-graphics-types 0.2.0",
  "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-helmer-fork"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32eb7c354ae9f6d437a6039099ce7ecd049337a8109b23d73e48e8ffba8e9cd5"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.9.4",
+ "core-graphics-types 0.1.3",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
  "libc",
 ]
 
@@ -1013,6 +1700,78 @@ dependencies = [
  "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "libc",
+]
+
+[[package]]
+name = "core-graphics2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4416167a69126e617f8d0a214af0e3c1dbdeffcb100ddf72dcd1a1ac9893c146"
+dependencies = [
+ "bitflags 2.13.0",
+ "block",
+ "cfg-if",
+ "core-foundation 0.10.1",
+ "libc",
+]
+
+[[package]]
+name = "core-text"
+version = "21.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a593227b66cbd4007b2a050dfdd9e1d1318311409c8d600dc82ba1b15ca9c130"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-graphics 0.24.0",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-video"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139679cc63eb9504bdbe37e37874b0247136177655f0008588781e90863afa62"
+dependencies = [
+ "block",
+ "core-foundation 0.10.1",
+ "core-graphics2",
+ "io-surface",
+ "libc",
+ "metal",
+]
+
+[[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "cosmic-text"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be17b688510d934ce13f48a2beba700e11583e281e0fda99c22bb256a14eda73"
+dependencies = [
+ "bitflags 2.13.0",
+ "fontdb",
+ "harfrust",
+ "linebender_resource_handle",
+ "log",
+ "rangemap",
+ "rustc-hash 2.1.2",
+ "self_cell",
+ "skrifa 0.40.0",
+ "smol_str",
+ "swash",
+ "sys-locale",
+ "unicode-bidi",
+ "unicode-linebreak",
+ "unicode-script",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1062,6 +1821,25 @@ name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622f3fc73690be383c7214310406f28a90e6edeadc3cea882f9d71e495b9711a"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc74980687109a3b14c72fd458107bf0baa1da1a1a805e178d15501ba9b86d9d"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1128,7 +1906,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf",
+ "phf 0.13.1",
  "smallvec",
 ]
 
@@ -1150,6 +1928,16 @@ checksum = "352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98"
 dependencies = [
  "ctor-proc-macro",
  "dtor",
+]
+
+[[package]]
+name = "ctor"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a755b7c2d4af2bdcff7ce1739e2db9a1b81a9b07123d8015786ae03c0980d"
+dependencies = [
+ "link-section",
+ "linktime-proc-macro",
 ]
 
 [[package]]
@@ -1233,6 +2021,12 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "dbus"
@@ -1340,10 +2134,12 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
  "syn 2.0.118",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1371,11 +2167,32 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1386,9 +2203,15 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "dispatch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
 name = "dispatch2"
@@ -1397,9 +2220,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -1411,6 +2234,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -1446,18 +2278,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "dom_query"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
- "bit-set",
+ "bit-set 0.8.0",
  "cssparser",
  "foldhash 0.2.0",
- "html5ever",
+ "html5ever 0.38.0",
  "precomputed-hash",
  "selectors",
- "tendril",
+ "tendril 0.5.0",
 ]
 
 [[package]]
@@ -1516,6 +2357,18 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dwrote"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b35532432acc8b19ceed096e35dfa088d3ea037fe4f3c085f1f97f33b4d02"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "winapi",
+ "wio",
+]
 
 [[package]]
 name = "dyn-clone"
@@ -1648,6 +2501,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
+name = "enum-iterator"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4549325971814bda7a44061bf3fe7e487d447cba01e4220a4b454d630d7a016"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "enum-ordinalize"
 version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1689,6 +2562,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumn"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1696,6 +2580,26 @@ checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
 dependencies = [
  "log",
  "regex",
+]
+
+[[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1726,6 +2630,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "etagere"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc89bf99e5dc15954a60f707c1e09d7540e5cd9af85fa75caa0b510bc08c5342"
+dependencies = [
+ "euclid",
+ "svg_fmt",
+]
+
+[[package]]
 name = "etcetera"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1734,6 +2648,15 @@ dependencies = [
  "cfg-if",
  "home",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1757,10 +2680,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "exr"
+version = "1.74.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711fe42c9964295e01ee3fba3f9fe0e1d24b98886950d68efe81b1c76e21adf3"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "num-complex",
+ "pulp",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1844,6 +2804,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1854,6 +2820,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
+name = "float-ord"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
+
+[[package]]
+name = "float_next_after"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
+
+[[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1861,7 +2854,19 @@ checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin",
+ "spin 0.9.9",
+]
+
+[[package]]
+name = "flume"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-sink",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -1881,6 +2886,47 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "font-types"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "font-types"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64eb721ca85a34323425f4041adc5d82704d3782d5f8f03793bc012419dce23"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree 0.20.0",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
 
 [[package]]
 name = "foreign-types"
@@ -1919,10 +2965,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "freetype-sys"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7edc5b9669349acfda99533e9e0bcf26a51862ab43b08ee7745c55d28eb134"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
 
 [[package]]
 name = "futures"
@@ -1947,6 +3029,19 @@ checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
+]
+
+[[package]]
+name = "futures-concurrency"
+version = "7.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
+dependencies = [
+ "fixedbitset",
+ "futures-core",
+ "futures-lite",
+ "pin-project",
+ "smallvec",
 ]
 
 [[package]]
@@ -2147,6 +3242,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2198,6 +3303,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2230,6 +3361,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
+]
+
+[[package]]
 name = "glib"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2259,7 +3401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bb0228f477c0900c880fd78c8759b95c7636dbd7842707f49e132378aa2acdc"
 dependencies = [
  "heck 0.4.1",
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 2.0.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -2283,6 +3425,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "globset"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
+dependencies = [
+ "bitflags 1.3.2",
+ "ignore",
+ "walkdir",
+]
+
+[[package]]
 name = "gloo-timers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2295,6 +3461,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "glow"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
 name = "gobject-sys"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2304,6 +3491,711 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
+dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
+ "log",
+ "presser",
+ "thiserror 2.0.18",
+ "windows 0.61.3",
+]
+
+[[package]]
+name = "gpu-descriptor"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
+dependencies = [
+ "bitflags 2.13.0",
+ "gpu-descriptor-types",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "gpu-descriptor-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
+name = "gpui-base"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2caaf00ebe0482774dd370a82a936edf4bf19a18a0d1a39353d20ecf61f70330"
+dependencies = [
+ "aho-corasick",
+ "anyhow",
+ "async-channel",
+ "chrono",
+ "futures",
+ "gpui-pre",
+ "gpui-pre-macros",
+ "gpui-pre-platform",
+ "gpui-pre-sum-tree",
+ "html5ever 0.27.0",
+ "instant",
+ "lsp-types",
+ "markdown",
+ "markup5ever_rcdom",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+ "raw-window-handle",
+ "regex",
+ "ropey",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "smol",
+ "syntect",
+ "tracing",
+ "unicode-segmentation",
+ "web-time",
+]
+
+[[package]]
+name = "gpui-component"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd7938c395be32cea6127b92f7206501ad1fe7e121a609de1aafdedcb4d98be"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "core-text",
+ "enum-iterator",
+ "gpui-base",
+ "gpui-component-macros",
+ "gpui-kit-assets",
+ "gpui-pre",
+ "gpui-pre-macros",
+ "gpui-pre-sum-tree",
+ "instant",
+ "itertools 0.13.0",
+ "log",
+ "lsp-types",
+ "markdown",
+ "notify",
+ "num-traits",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+ "once_cell",
+ "paste",
+ "raw-window-handle",
+ "resvg 0.45.1",
+ "ropey",
+ "rust-i18n",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "smallvec",
+ "smol",
+ "tracing",
+ "uuid",
+ "windows 0.58.0",
+]
+
+[[package]]
+name = "gpui-component-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dacef57cadf1ce9b05b1f1ba6b3f3fed2521fd814f548eea0e4d8e43c5857795"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "gpui-kit"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3279d239b0b9228e04511ada0131120f1d7983147586e28a69820630755569f"
+dependencies = [
+ "gpui-base",
+ "gpui-component",
+ "gpui-kit-assets",
+ "gpui-pre",
+ "gpui-pre-platform",
+ "gpui-pre-reqwest-client",
+ "gpui-pre-web",
+]
+
+[[package]]
+name = "gpui-kit-assets"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb6fed67d6488fa9333b6534d17f5eaef32b83e3d7148b83a3d444a1884bd1c"
+dependencies = [
+ "anyhow",
+ "gpui-pre",
+ "gpui-pre-reqwest",
+ "log",
+ "rust-embed",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "gpui-pre"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8b0f6f593153b6eb84c336ea7ccf12a1fca186f0db99af628e72f85048c1d7b"
+dependencies = [
+ "accesskit",
+ "anyhow",
+ "async-channel",
+ "async-task",
+ "backtrace",
+ "bindgen",
+ "bitflags 2.13.0",
+ "chrono",
+ "core-video",
+ "ctor 1.0.13",
+ "derive_more",
+ "embed-resource",
+ "etagere",
+ "futures",
+ "futures-concurrency",
+ "getrandom 0.3.4",
+ "gpui-pre-collections",
+ "gpui-pre-http-client",
+ "gpui-pre-macros",
+ "gpui-pre-refineable",
+ "gpui-pre-scheduler",
+ "gpui-pre-shared-string",
+ "gpui-pre-sum-tree",
+ "gpui-pre-util",
+ "gpui-pre-util-macros",
+ "gpui-pre-ztracing",
+ "heapless",
+ "image",
+ "inventory",
+ "itertools 0.14.0",
+ "log",
+ "lyon",
+ "num_cpus",
+ "parking",
+ "parking_lot",
+ "pin-project",
+ "pollster 0.4.0",
+ "postage",
+ "profiling",
+ "proptest",
+ "rand 0.9.5",
+ "raw-window-handle",
+ "regex",
+ "resvg 0.46.0",
+ "schemars 1.2.1",
+ "seahash",
+ "serde",
+ "serde_json",
+ "slotmap",
+ "smallvec",
+ "spin 0.10.1",
+ "strum 0.28.0",
+ "taffy",
+ "thiserror 2.0.18",
+ "tracing",
+ "ttf-parser",
+ "url",
+ "usvg 0.46.0",
+ "uuid",
+ "waker-fn",
+ "web-time",
+ "windows 0.62.2",
+ "zed-font-kit",
+ "zed-scap",
+]
+
+[[package]]
+name = "gpui-pre-apple"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e027ea436bb876a8da6962862ffdbf9708c6b8352415325647c4fc2a48467d"
+dependencies = [
+ "anyhow",
+ "block",
+ "cbindgen",
+ "cocoa 0.26.0",
+ "core-foundation 0.10.1",
+ "core-video",
+ "derive_more",
+ "etagere",
+ "foreign-types",
+ "gpui-pre",
+ "gpui-pre-collections",
+ "image",
+ "log",
+ "metal",
+ "objc",
+ "parking_lot",
+]
+
+[[package]]
+name = "gpui-pre-collections"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89c8efa2e51e368c8538a7be1ea9a12127ca03abe6cc01d9d3474e9ac4f53016"
+dependencies = [
+ "gpui-pre-util",
+ "indexmap 2.14.0",
+ "rustc-hash 2.1.2",
+]
+
+[[package]]
+name = "gpui-pre-derive-refineable"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a098d319acc9f84bf159944f96c5ea43a4f4cd7ed759f984acbd15719495aa0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "gpui-pre-http-client"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3495a45a28cb800c8626d2053406114bcaca26d390a4d4b183365b5bb8fdaf02"
+dependencies = [
+ "anyhow",
+ "async-compression",
+ "bytes",
+ "derive_more",
+ "futures",
+ "http",
+ "http-body",
+ "log",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "url",
+]
+
+[[package]]
+name = "gpui-pre-http-client-tls"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10157341e736f024112d995fb89750aa8b4e80c9157b3dc22200127a64b27dc1"
+dependencies = [
+ "log",
+ "rustls",
+ "rustls-platform-verifier",
+ "webpki-roots",
+]
+
+[[package]]
+name = "gpui-pre-linux"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9025a2a9f7e9241651bb5f9df6b69233ca4111b233e1fb3a4544d69ecc52bc3"
+dependencies = [
+ "accesskit",
+ "accesskit_unix",
+ "anyhow",
+ "as-raw-xcb-connection",
+ "ashpd",
+ "bitflags 2.13.0",
+ "bytemuck",
+ "calloop",
+ "calloop-wayland-source",
+ "filedescriptor",
+ "futures",
+ "gpui-pre",
+ "gpui-pre-collections",
+ "gpui-pre-http-client",
+ "gpui-pre-util",
+ "gpui-pre-wgpu",
+ "libc",
+ "log",
+ "notify-rust",
+ "oo7",
+ "open",
+ "parking_lot",
+ "raw-window-handle",
+ "smallvec",
+ "smol",
+ "strum 0.28.0",
+ "url",
+ "uuid",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-plasma",
+ "wayland-protocols-wlr",
+ "x11-clipboard",
+ "x11rb",
+ "xkbcommon",
+ "zed-scap",
+ "zed-xim",
+]
+
+[[package]]
+name = "gpui-pre-macos"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54678bfe6be71aa8e3fd31c3ae51af5d81e367344762540fd7cfdb778621abb1"
+dependencies = [
+ "accesskit",
+ "accesskit_macos",
+ "anyhow",
+ "async-task",
+ "block",
+ "block2 0.6.2",
+ "cocoa 0.26.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "core-graphics 0.24.0",
+ "core-text",
+ "ctor 1.0.13",
+ "dispatch2",
+ "foreign-types",
+ "futures",
+ "gpui-pre",
+ "gpui-pre-apple",
+ "gpui-pre-collections",
+ "gpui-pre-media",
+ "gpui-pre-util",
+ "image",
+ "itertools 0.14.0",
+ "libc",
+ "log",
+ "mach2",
+ "metal",
+ "objc",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+ "objc2-user-notifications",
+ "parking_lot",
+ "pathfinder_geometry",
+ "raw-window-handle",
+ "semver",
+ "smallvec",
+ "strum 0.28.0",
+ "uuid",
+ "zed-font-kit",
+]
+
+[[package]]
+name = "gpui-pre-macros"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be2db7b5097b4d523b2bce933604bcc5acdaf679bb9a150e8299e6c07efc29c"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "gpui-pre-media"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a35102d2a165f2fbf21521d56e37d6f0ab906372d13b3e1fa94d68b299b22b74"
+dependencies = [
+ "anyhow",
+ "bindgen",
+ "core-foundation 0.10.1",
+ "core-video",
+ "foreign-types",
+ "metal",
+ "objc",
+]
+
+[[package]]
+name = "gpui-pre-perf"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1db0c046b93c2a29120f8ee4c04bc80a4d7d6117d1164ef349faface8943491"
+dependencies = [
+ "gpui-pre-collections",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "gpui-pre-platform"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35131851444188e573d21d3e8020a51af16bf08b177e25b1120815edbd448c80"
+dependencies = [
+ "console_error_panic_hook",
+ "gpui-pre",
+ "gpui-pre-linux",
+ "gpui-pre-macos",
+ "gpui-pre-web",
+ "gpui-pre-windows",
+]
+
+[[package]]
+name = "gpui-pre-refineable"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "864e2e54a3029481dae5b6aae3ba2905f2fb1dfe66ced913b68c9ff527f8e327"
+dependencies = [
+ "gpui-pre-derive-refineable",
+]
+
+[[package]]
+name = "gpui-pre-reqwest"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05be23908e707966824f8c51a609904b7f30739e8d915e120a53c1b995ba964c"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "mime_guess",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-rustls",
+ "tokio-socks",
+ "tokio-util",
+ "tower",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
+ "web-sys",
+ "windows-registry 0.4.0",
+]
+
+[[package]]
+name = "gpui-pre-reqwest-client"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfa3df55759b31177cc5c4abb302921844a89698cc91783685a2002200a6257d"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "futures",
+ "gpui-pre-http-client",
+ "gpui-pre-http-client-tls",
+ "gpui-pre-reqwest",
+ "gpui-pre-util",
+ "log",
+ "regex",
+ "tokio",
+]
+
+[[package]]
+name = "gpui-pre-scheduler"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b58a78c4e0c032900704ea49922641c534cf8bbf1bf22eda6ba00a76e88c6c3"
+dependencies = [
+ "async-task",
+ "backtrace",
+ "chrono",
+ "flume 0.12.0",
+ "futures",
+ "parking_lot",
+ "rand 0.9.5",
+ "wasm_thread",
+ "web-time",
+]
+
+[[package]]
+name = "gpui-pre-shared-string"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82fc99fe88e44173758a500522d3f4059a6541da4b471af720e3f60cf34a2bc3"
+dependencies = [
+ "schemars 1.2.1",
+ "serde",
+ "smol_str",
+]
+
+[[package]]
+name = "gpui-pre-sum-tree"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "002baed852f20cef1188d3d5e0f749025fc718e4d6cea026b9077a9a6c10d042"
+dependencies = [
+ "gpui-pre-ztracing",
+ "heapless",
+ "log",
+ "rayon",
+ "tracing",
+]
+
+[[package]]
+name = "gpui-pre-util"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fe779c4cb00929aafcb2b307cd1240588aebb5d1eb328c59b80f77c05a41fad"
+dependencies = [
+ "anyhow",
+ "log",
+ "which",
+]
+
+[[package]]
+name = "gpui-pre-util-macros"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f0ccc4bccb6a31786095d15fc9f40d6a4c6a295522e3460331dd7e929ff2f79"
+dependencies = [
+ "gpui-pre-perf",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "gpui-pre-web"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27728bd9180d1a10516d719fed446adf85872cedf0e262ad0738f4edc9deaf33"
+dependencies = [
+ "anyhow",
+ "console_error_panic_hook",
+ "futures",
+ "gpui-pre",
+ "gpui-pre-http-client",
+ "gpui-pre-scheduler",
+ "gpui-pre-wgpu",
+ "js-sys",
+ "log",
+ "parking_lot",
+ "raw-window-handle",
+ "uuid",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm_thread",
+ "web-sys",
+ "web-time",
+]
+
+[[package]]
+name = "gpui-pre-wgpu"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695c613099863bbf434ff896d196e3f55d4d5f59769dac99596e79dbb18a8aff"
+dependencies = [
+ "anyhow",
+ "bytemuck",
+ "cosmic-text",
+ "etagere",
+ "gpui-pre",
+ "gpui-pre-collections",
+ "gpui-pre-util",
+ "itertools 0.14.0",
+ "log",
+ "parking_lot",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "swash",
+ "unicode-bidi",
+ "unicode-segmentation",
+ "web-sys",
+ "wgpu",
+ "zed-font-kit",
+]
+
+[[package]]
+name = "gpui-pre-windows"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a4b60579aa2cb4ef7b6f22133a7b9fe12458062961343bdcf36e259047bc7ad"
+dependencies = [
+ "accesskit",
+ "accesskit_windows",
+ "anyhow",
+ "dunce",
+ "etagere",
+ "futures",
+ "gpui-pre",
+ "gpui-pre-collections",
+ "gpui-pre-util",
+ "image",
+ "itertools 0.14.0",
+ "log",
+ "parking_lot",
+ "rand 0.9.5",
+ "raw-window-handle",
+ "smallvec",
+ "uuid",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+ "windows-numerics 0.3.1",
+ "windows-registry 0.6.1",
+]
+
+[[package]]
+name = "gpui-pre-zlog"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1416ea5f018e3a8a1c8be266332c443583f28f8f87379a84ab1e77622173ac0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "gpui-pre-collections",
+ "log",
+]
+
+[[package]]
+name = "gpui-pre-ztracing"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cc64a25a3cc4e4f1d8acb00074d3925339dae657c020083735738ba8af96bf7"
+dependencies = [
+ "gpui-pre-zlog",
+ "gpui-pre-ztracing-macro",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "gpui-pre-ztracing-macro"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f3ea75672348f37d94472e579f5979ee19b744d0fa5aaadc2fe129ccafa80b"
 
 [[package]]
 name = "granit-parser"
@@ -2379,6 +4271,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
+]
+
+[[package]]
+name = "harfrust"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9da2e5ae821f6e96664977bf974d6d6a2d6682f9ccee23e62ec1d134246845f9"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytemuck",
+ "core_maths",
+ "read-fonts 0.37.0",
+ "smallvec",
+]
+
+[[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2431,6 +4376,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "heapless"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2453,6 +4408,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hexf-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "hkdf"
@@ -2494,12 +4455,26 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13771afe0e6e846f1e67d038d4cb29998a6779f93c809212e4e9c32efd244d4"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "html5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
 dependencies = [
  "log",
- "markup5ever",
+ "markup5ever 0.38.0",
 ]
 
 [[package]]
@@ -2566,6 +4541,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -2775,6 +4751,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b17771570a2b94107741a7b033f19132c2eee21d59d21b24d2ced26500bd66e"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif 0.14.2",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "qoi",
+ "ravif",
+ "rayon",
+ "tiff",
+ "zune-core 0.5.3",
+ "zune-jpeg 0.5.15",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error 2.0.1",
+]
+
+[[package]]
+name = "imagesize"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
+
+[[package]]
+name = "imagesize"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
+
+[[package]]
+name = "imgref"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e44b0a4eaa4c82f441d50a963f2d5f05a787240aeee097597033e72accfd22f"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2807,6 +4850,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2814,6 +4877,50 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "io-surface"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "554b8c5d64ec09a3a520fe58e4d48a73e00ff32899cdcbe32a4877afd4968b8e"
+dependencies = [
+ "cgl",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "leaky-cow",
 ]
 
 [[package]]
@@ -2846,6 +4953,33 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -2990,6 +5124,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3097,6 +5241,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "khronos-egl"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "libloading 0.8.9",
+ "pkg-config",
+]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "kqueue"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.13.0",
+ "libc",
+]
+
+[[package]]
 name = "kube"
 version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3191,13 +5372,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "kurbo"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "polycool",
+ "smallvec",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.9",
 ]
+
+[[package]]
+name = "leak"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd100e01f1154f2908dfa7d02219aeab25d0b9c7fa955164192e3245255a0c73"
+
+[[package]]
+name = "leaky-cow"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40a8225d44241fd324a8af2806ba635fc7c8a7e9a7de4d5cf3ef54e71f5926fc"
+dependencies = [
+ "leak",
+]
+
+[[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libappindicator"
@@ -3219,9 +5444,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
 dependencies = [
  "gtk-sys",
- "libloading",
+ "libloading 0.7.4",
  "once_cell",
 ]
+
+[[package]]
+name = "libbz2-rs-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
@@ -3239,6 +5470,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libfuzzer-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3246,6 +5487,16 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3278,6 +5529,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "linebender_resource_handle"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
+
+[[package]]
+name = "link-section"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39c29a617ce3df32c08497bdc1ab6e2376e0b17948ac166a2fbe5977c5954cd9"
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e57c38c1e860fd37c604281cdfb1dd2216977fd76a50f85ba2f388ef3219616"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3288,6 +5557,12 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -3304,7 +5579,17 @@ version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 dependencies = [
+ "serde_core",
  "value-bag",
+]
+
+[[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
 ]
 
 [[package]]
@@ -3314,14 +5599,153 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lsp-types"
+version = "0.97.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
+dependencies = [
+ "bitflags 1.3.2",
+ "fluent-uri",
+ "serde",
+ "serde_json",
+ "serde_repr",
+]
+
+[[package]]
+name = "lyon"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0578bdecb7d6d88987b8b2b1e3a4e2f81df9d0ece1078623324a567904e7b7"
+dependencies = [
+ "lyon_algorithms",
+ "lyon_tessellation",
+]
+
+[[package]]
+name = "lyon_algorithms"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdfa8785f95e57914ddb35e3b59994aeba6f5e79e9cfd03da1c269f010f36009"
+dependencies = [
+ "lyon_path",
+ "num-traits",
+]
+
+[[package]]
+name = "lyon_geom"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4336502e29e32af93cf2dad2214ed6003c17ceb5bd499df77b1de663b9042b92"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "num-traits",
+]
+
+[[package]]
+name = "lyon_path"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c463f9c428b7fc5ec885dcd39ce4aa61e29111d0e33483f6f98c74e89d8621e"
+dependencies = [
+ "lyon_geom",
+ "num-traits",
+]
+
+[[package]]
+name = "lyon_tessellation"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dabea159dc6eea9171a541b458134b70ca95e3162d068132b2b3b9bc01aad06e"
+dependencies = [
+ "float_next_after",
+ "lyon_path",
+ "num-traits",
+]
+
+[[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "mac-notification-sys"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
+dependencies = [
+ "cc",
+ "log",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "time",
+ "uuid",
+]
+
+[[package]]
+name = "mach2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "markdown"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5cab8f2cadc416a82d2e783a1946388b31654d391d1c7d92cc1f03e295b1deb"
+dependencies = [
+ "serde",
+ "unicode-id",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ce3abbeba692c8b8441d036ef91aea6df8da2c6b6e21c7e14d3c18e526be45"
+dependencies = [
+ "log",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+ "string_cache 0.8.9",
+ "string_cache_codegen 0.5.4",
+ "tendril 0.4.3",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
 dependencies = [
  "log",
- "tendril",
+ "tendril 0.5.0",
  "web_atoms",
+]
+
+[[package]]
+name = "markup5ever_rcdom"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edaa21ab3701bfee5099ade5f7e1f84553fd19228cf332f13cd6e964bf59be18"
+dependencies = [
+ "html5ever 0.27.0",
+ "markup5ever 0.12.1",
+ "tendril 0.4.3",
+ "xml5ever",
 ]
 
 [[package]]
@@ -3329,6 +5753,16 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
 
 [[package]]
 name = "md-5"
@@ -3347,12 +5781,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "metal"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7047791b5bc903b8cd963014b355f71dc9864a9a0b727057676c1dcae5cbc15"
+dependencies = [
+ "bitflags 2.13.0",
+ "block",
+ "core-graphics-types 0.2.0",
+ "foreign-types",
+ "log",
+ "objc",
+ "paste",
 ]
 
 [[package]]
@@ -3370,6 +5828,12 @@ dependencies = [
  "mime",
  "unicase",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "minisign-verify"
@@ -3394,8 +5858,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -3408,15 +5883,41 @@ dependencies = [
  "dpi",
  "gtk",
  "keyboard-types",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "naga"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2bf919621e7975acb27d881bae2fb993e0d45c8e0446e85e6272971e00dc8df"
+dependencies = [
+ "arrayvec",
+ "bit-set 0.9.1",
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "codespan-reporting",
+ "half",
+ "hashbrown 0.16.1",
+ "hexf-parse",
+ "indexmap 2.14.0",
+ "libm",
+ "log",
+ "num-traits",
+ "once_cell",
+ "rustc-hash 1.1.0",
+ "spirv",
+ "thiserror 2.0.18",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -3475,10 +5976,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
+name = "normpath"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9985ef7269fa99f3b12437bb698381da2428743ab90f20393f399fa14cab21a"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "notify"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+dependencies = [
+ "bitflags 2.13.0",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "notify-rust"
+version = "4.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus 5.18.0",
+]
+
+[[package]]
+name = "notify-types"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num"
@@ -3521,11 +6125,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f9a86e097b0d187ad0e65667c2f58b9254671e86e7dbb78036b16692eae099"
+dependencies = [
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "once_cell",
+ "rand 0.9.5",
+ "serde",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
+ "bytemuck",
  "num-traits",
 ]
 
@@ -3534,6 +6156,17 @@ name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "num-integer"
@@ -3573,6 +6206,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -3627,6 +6270,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+ "objc_exception",
+]
+
+[[package]]
+name = "objc-foundation"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
+dependencies = [
+ "block",
+ "objc",
+ "objc_id",
+]
+
+[[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3638,15 +6318,39 @@ dependencies = [
 
 [[package]]
 name = "objc2-app-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+ "objc2-core-data 0.2.2",
+ "objc2-core-image 0.2.2",
+ "objc2-foundation 0.2.2",
+ "objc2-quartz-core 0.2.2",
+]
+
+[[package]]
+name = "objc2-app-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
- "objc2",
+ "block2 0.6.2",
+ "libc",
+ "objc2 0.6.4",
+ "objc2-cloud-kit",
+ "objc2-core-data 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image 0.3.2",
+ "objc2-core-text",
+ "objc2-core-video",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
 ]
 
 [[package]]
@@ -3656,8 +6360,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
  "bitflags 2.13.0",
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3666,8 +6382,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "bitflags 2.13.0",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3677,10 +6394,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.6.2",
  "dispatch2",
  "libc",
- "objc2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -3691,9 +6408,21 @@ checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.13.0",
  "dispatch2",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal 0.2.2",
 ]
 
 [[package]]
@@ -3702,8 +6431,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3712,8 +6441,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3723,9 +6452,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
  "bitflags 2.13.0",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -3745,14 +6487,26 @@ dependencies = [
 
 [[package]]
 name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
@@ -3763,7 +6517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
  "bitflags 2.13.0",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
@@ -3773,10 +6527,34 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48e0b8b339e0d9d2ed4416b7f93f9d4daadff7d4dd797f89867cde11aeac607"
 dependencies = [
- "block2",
- "objc2",
- "objc2-foundation",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
  "objc2-security",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3786,9 +6564,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
 dependencies = [
  "bitflags 2.13.0",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal 0.2.2",
 ]
 
 [[package]]
@@ -3798,9 +6589,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
  "bitflags 2.13.0",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
 ]
 
 [[package]]
@@ -3810,9 +6602,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
@@ -3823,17 +6615,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
- "objc2",
+ "block2 0.6.2",
+ "objc2 0.6.4",
  "objc2-cloud-kit",
- "objc2-core-data",
+ "objc2-core-data 0.3.2",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-core-image",
+ "objc2-core-image 0.3.2",
  "objc2-core-location",
  "objc2-core-text",
- "objc2-foundation",
- "objc2-quartz-core",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
  "objc2-user-notifications",
 ]
 
@@ -3843,8 +6635,11 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "bitflags 2.13.0",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-core-location",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3854,11 +6649,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
- "objc2",
- "objc2-app-kit",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc_exception"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "objc_id"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
+dependencies = [
+ "objc",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3866,6 +6688,41 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oo7"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78f2bfed90f1618b4b48dcad9307f25e14ae894e2949642c87c351601d62cebd"
+dependencies = [
+ "aes",
+ "ashpd",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "cbc",
+ "cipher",
+ "digest 0.10.7",
+ "endi",
+ "futures-lite",
+ "futures-util",
+ "getrandom 0.4.3",
+ "hkdf",
+ "hmac",
+ "md-5",
+ "num",
+ "num-bigint-dig 0.9.1",
+ "pbkdf2",
+ "serde",
+ "serde_bytes",
+ "sha2 0.10.9",
+ "subtle",
+ "zbus 5.18.0",
+ "zbus_macros 5.18.0",
+ "zeroize",
+ "zvariant 5.13.1",
+]
 
 [[package]]
 name = "opaque-debug"
@@ -3896,7 +6753,7 @@ dependencies = [
  "ed25519-dalek",
  "hmac",
  "http",
- "itertools",
+ "itertools 0.10.5",
  "log",
  "oauth2",
  "p256",
@@ -3937,6 +6794,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7c9e0d9b23589f26070720bac724174bfec1083e82f7854cdd0267518343c0"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ordered-multimap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3962,8 +6828,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
  "objc2-osa-kit",
  "serde",
  "serde_json",
@@ -4066,6 +6932,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "pathfinder_geometry"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b7e7b4ea703700ce73ebf128e1450eb69c3a8329199ffbfb9b2a0418e5ad3"
+dependencies = [
+ "log",
+ "pathfinder_simd",
+]
+
+[[package]]
+name = "pathfinder_simd"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4500030c302e4af1d423f36f3b958d1aecb6c04184356ed5a833bf6b60435777"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4135,13 +7036,32 @@ dependencies = [
 
 [[package]]
 name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.13.1",
  "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -4150,8 +7070,18 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared 0.11.3",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -4161,7 +7091,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -4170,11 +7100,20 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -4185,6 +7124,12 @@ checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
@@ -4310,6 +7255,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pollster"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da3b0203fd7ee5720aa0b5e790b591aa5d3f41c3ed2c34a3a393382198af2f7"
+
+[[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
 name = "poly1305"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4318,6 +7275,15 @@ dependencies = [
  "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
+]
+
+[[package]]
+name = "polycool"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
+dependencies = [
+ "arrayvec",
 ]
 
 [[package]]
@@ -4369,6 +7335,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "postage"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af3fb618632874fb76937c2361a7f22afd393c982a2165595407edc75b06d3c1"
+dependencies = [
+ "atomic",
+ "crossbeam-queue",
+ "futures",
+ "log",
+ "parking_lot",
+ "pin-project",
+ "pollster 0.2.5",
+ "static_assertions",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4399,6 +7382,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4419,11 +7418,10 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "2.0.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
+checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
- "toml_datetime 0.6.3",
  "toml_edit 0.20.2",
 ]
 
@@ -4470,6 +7468,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "profiling"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
+ "bitflags 2.13.0",
+ "num-traits",
+ "proptest-macro",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "proptest-macro"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efaa288b896cb2b345da7b7f2110ab19e51565b83495b56fcec98a62f8b1f33e"
+dependencies = [
+ "convert_case 0.11.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4488,6 +7537,56 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "pulp"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "paste",
+ "pulp-wasm-simd-flag",
+ "raw-cpuid",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
+name = "pulp-wasm-simd-flag"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -4509,7 +7608,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -4530,7 +7629,7 @@ dependencies = [
  "rand 0.10.2",
  "rand_pcg",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -4667,10 +7766,150 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "range-alloc"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
+
+[[package]]
+name = "rangemap"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a611d15b50743feb4c76b7d03edcb0e64f399c26961e4efe6975bc398be6aa3d"
+
+[[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools 0.14.0",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "simd_helpers",
+ "thiserror 2.0.18",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error 2.0.1",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "raw-window-metal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
+dependencies = [
+ "bytemuck",
+ "core_maths",
+ "font-types 0.11.3",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046a7d674daf459825b32f5062056d6882db0d2f5a479fbd76ccfc870ac18709"
+dependencies = [
+ "bytemuck",
+ "font-types 0.12.4",
+ "once_cell",
+]
+
+[[package]]
+name = "reborrow"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "redox_syscall"
@@ -4688,6 +7927,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
 dependencies = [
  "bitflags 2.13.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4758,6 +8008,12 @@ checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
 dependencies = [
  "bytecheck",
 ]
+
+[[package]]
+name = "renderdoc-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "reqwest"
@@ -4833,8 +8089,42 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
+]
+
+[[package]]
+name = "resvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8928798c0a55e03c9ca6c4c6846f76377427d2c1e1f7e6de3c06ae57942df43"
+dependencies = [
+ "gif 0.13.3",
+ "image-webp",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes 0.15.3",
+ "tiny-skia",
+ "usvg 0.45.1",
+ "zune-jpeg 0.4.21",
+]
+
+[[package]]
+name = "resvg"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b563218631706d614e23059436526d005b50ab5f2d506b55a17eb65c5eb83419"
+dependencies = [
+ "gif 0.14.2",
+ "image-webp",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes 0.16.1",
+ "tiny-skia",
+ "usvg 0.46.0",
+ "zune-jpeg 0.5.15",
 ]
 
 [[package]]
@@ -4853,22 +8143,31 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
 dependencies = [
- "block2",
+ "block2 0.6.2",
  "dispatch2",
  "glib-sys",
  "gobject-sys",
  "gtk-sys",
  "js-sys",
  "log",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "raw-window-handle",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -4915,6 +8214,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ropey"
+version = "2.0.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4045a00dc327d084a2bbf126976e14125b54f23bd30511d45b842eba76c52d74"
+dependencies = [
+ "str_indices",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "roxmltree"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4922,7 +8245,7 @@ checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
  "const-oid 0.9.6",
  "digest 0.10.7",
- "num-bigint-dig",
+ "num-bigint-dig 0.8.6",
  "num-integer",
  "num-traits",
  "pkcs1",
@@ -4955,6 +8278,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
+ "shellexpand",
  "syn 2.0.118",
  "walkdir",
 ]
@@ -4965,8 +8289,56 @@ version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
 dependencies = [
+ "globset",
  "sha2 0.11.0",
  "walkdir",
+]
+
+[[package]]
+name = "rust-i18n"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f10cee36dd3b1f7929ea12b759de9eea9eff83bfccbc71f387ef4d41a57c64a4"
+dependencies = [
+ "globwalk",
+ "regex",
+ "rust-i18n-macro",
+ "rust-i18n-support",
+ "smallvec",
+]
+
+[[package]]
+name = "rust-i18n-macro"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0bb1ed4e04fe26c2a2652cad1c6595efaf7196f4445c0d6e13c67154347fb7e"
+dependencies = [
+ "glob",
+ "proc-macro2",
+ "quote",
+ "rust-i18n-support",
+ "serde",
+ "serde_json",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "rust-i18n-support"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1c083408a2733180ae0acf2897612f8ceec7b0c0dcd065a0a87103bfb3b1d9"
+dependencies = [
+ "arc-swap",
+ "base62",
+ "globwalk",
+ "itertools 0.11.0",
+ "normpath",
+ "serde",
+ "serde-saphyr",
+ "serde_json",
+ "siphasher",
+ "toml 0.8.23",
+ "triomphe",
 ]
 
 [[package]]
@@ -4995,6 +8367,18 @@ dependencies = [
  "serde_json",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -5030,6 +8414,7 @@ version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -5049,6 +8434,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework 3.7.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5094,6 +8488,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -5104,6 +8499,36 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
+name = "rustybuzz"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytemuck",
+ "core_maths",
+ "log",
+ "smallvec",
+ "ttf-parser",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
 
 [[package]]
 name = "ryu"
@@ -5137,7 +8562,7 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
  "url",
@@ -5163,7 +8588,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
+ "indexmap 2.14.0",
  "ref-cast",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
 ]
@@ -5181,10 +8608,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "screencapturekit"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5eeeb57ac94960cfe5ff4c402be6585ae4c8d29a2cf41b276048c2e849d64e"
+dependencies = [
+ "screencapturekit-sys",
+]
+
+[[package]]
+name = "screencapturekit-sys"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22411b57f7d49e7fe08025198813ee6fd65e1ee5eff4ebc7880c12c82bde4c60"
+dependencies = [
+ "block",
+ "dispatch",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "once_cell",
+]
 
 [[package]]
 name = "seahash"
@@ -5281,13 +8749,19 @@ dependencies = [
  "derive_more",
  "log",
  "new_debug_unreachable",
- "phf",
- "phf_codegen",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
  "precomputed-hash",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "servo_arc",
  "smallvec",
 ]
+
+[[package]]
+name = "self_cell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
 
 [[package]]
 name = "semver"
@@ -5346,8 +8820,18 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
- "ordered-float",
+ "ordered-float 2.10.1",
  "serde",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -5379,6 +8863,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "serde_fmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e497af288b3b95d067a23a4f749f2861121ffcb2f6d8379310dcda040c345ed"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -5555,6 +9048,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5577,6 +9076,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shared_library"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5591,6 +9099,21 @@ name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
+name = "shellexpand"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
+dependencies = [
+ "dirs 6.0.0",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shlex"
@@ -5635,6 +9158,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5647,10 +9179,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "skrifa"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
+dependencies = [
+ "bytemuck",
+ "read-fonts 0.37.0",
+]
+
+[[package]]
+name = "skrifa"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819ab7d62b1d3e72d9d9dea5650bac30424f9111364bb94928dbf5ecad1baa68"
+dependencies = [
+ "bytemuck",
+ "read-fonts 0.41.0",
+]
 
 [[package]]
 name = "slab"
@@ -5659,12 +9220,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "smol"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-net",
+ "async-process",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "smol_str"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
+dependencies = [
+ "borsh",
+ "serde_core",
 ]
 
 [[package]]
@@ -5686,11 +9283,11 @@ dependencies = [
  "bytemuck",
  "js-sys",
  "ndk",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation",
- "objc2-quartz-core",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
  "raw-window-handle",
  "redox_syscall 0.5.18",
  "tracing",
@@ -5732,6 +9329,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spin"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spirv"
+version = "0.4.0+sdk-1.4.341.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
+dependencies = [
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -5912,7 +9527,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
 dependencies = [
  "atoi",
- "flume",
+ "flume 0.11.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -5956,7 +9571,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "chacha20poly1305",
- "dirs",
+ "dirs 6.0.0",
  "fix-path-env",
  "futures",
  "getrandom 0.2.17",
@@ -5990,12 +9605,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "srelens-gpui"
+version = "0.8.0"
+dependencies = [
+ "gpui-kit",
+ "rustls",
+ "srelens-capability",
+ "srelens-kube",
+ "srelens-registry",
+ "tokio",
+]
+
+[[package]]
 name = "srelens-kube"
 version = "0.8.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
- "dirs",
+ "dirs 6.0.0",
  "flate2",
  "futures",
  "hex",
@@ -6052,7 +9679,7 @@ dependencies = [
 name = "srelens-registry"
 version = "0.8.0"
 dependencies = [
- "dirs",
+ "dirs 6.0.0",
  "reqwest 0.13.4",
  "schemars 0.8.22",
  "serde",
@@ -6121,6 +9748,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "str_indices"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08889ec5408683408db66ad89e0e1f93dff55c73a4ccc71c427d5b277ee47e6"
+
+[[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
+
+[[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.11.3",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
 name = "string_cache"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6128,8 +9783,20 @@ checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared",
+ "phf_shared 0.13.1",
  "precomputed-hash",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -6138,8 +9805,8 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
 ]
@@ -6185,7 +9852,16 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -6202,10 +9878,138 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "sval"
+version = "2.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b81b254da21fe1fcc4e3a74fe39b46e25e3a863078f8b71c954d47f84889dbc6"
+
+[[package]]
+name = "sval_buffer"
+version = "2.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50be352d2822ffafb59e3e2ddac9d5ee60f2eeadbb7b5a2a951b9f3651e87a6f"
+dependencies = [
+ "sval",
+ "sval_ref",
+ "zerocopy",
+]
+
+[[package]]
+name = "sval_dynamic"
+version = "2.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048ca293b998d9a45659159f94a64063791e74cdc670164943dbb434405573d"
+dependencies = [
+ "sval",
+]
+
+[[package]]
+name = "sval_fmt"
+version = "2.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6b5888e40f80568733217f27b7317b845f463400ced36c424b1a804730e53b2"
+dependencies = [
+ "itoa",
+ "ryu",
+ "sval",
+]
+
+[[package]]
+name = "sval_json"
+version = "2.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17664d6bb6b74947afaab9d7c991caa9bf5638d4dee16fcbef637f440796049"
+dependencies = [
+ "itoa",
+ "ryu",
+ "sval",
+]
+
+[[package]]
+name = "sval_nested"
+version = "2.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07c059969ca5ca163ea7fef6c9661758973d17691aba92abdcf5c428f4ec122c"
+dependencies = [
+ "sval",
+ "sval_buffer",
+ "sval_ref",
+]
+
+[[package]]
+name = "sval_ref"
+version = "2.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d6b29ff568c85c87561807f51d2adfff4b6016c6363133f7cd1652a12548f3"
+dependencies = [
+ "sval",
+]
+
+[[package]]
+name = "sval_serde"
+version = "2.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f33ec9edc42b12764d5c90ca0a1d84189c6bde81ed27507f1e661c6e4e05853"
+dependencies = [
+ "serde_core",
+ "sval",
+ "sval_nested",
+]
+
+[[package]]
+name = "svg_fmt"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0193cc4331cfd2f3d2011ef287590868599a2f33c3e69bc22c1a3d3acf9e02fb"
+
+[[package]]
+name = "svgtypes"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
+dependencies = [
+ "kurbo 0.11.3",
+ "siphasher",
+]
+
+[[package]]
+name = "svgtypes"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695b5790b3131dafa99b3bbfd25a216edb3d216dad9ca208d4657bfb8f2abc3d"
+dependencies = [
+ "kurbo 0.13.1",
+ "siphasher",
+]
+
+[[package]]
+name = "swash"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2499c2d826531388872b2268718aed907a39bd785ab0dcfe57fab26283f92e"
+dependencies = [
+ "skrifa 0.44.0",
+ "yazi",
+ "zeno",
+]
 
 [[package]]
 name = "swift-rs"
@@ -6241,6 +10045,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6261,6 +10076,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "fancy-regex",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "thiserror 2.0.18",
+ "walkdir",
+]
+
+[[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.31.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "355dbe4f8799b304b05e1b0f05fc59b2a18d36645cf169607da45bde2f69a1be"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows 0.57.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6269,8 +10146,20 @@ dependencies = [
  "cfg-expr",
  "heck 0.5.0",
  "pkg-config",
- "toml 0.8.2",
+ "toml 0.8.23",
  "version-compare",
+]
+
+[[package]]
+name = "taffy"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c034e05f6ee85a12daa63863c2245797715075c70649947aa0da54f3f2ab1d0f"
+dependencies = [
+ "arrayvec",
+ "serde",
+ "slotmap",
+ "smallvec",
 ]
 
 [[package]]
@@ -6280,9 +10169,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.6.2",
  "core-foundation 0.10.1",
- "core-graphics",
+ "core-graphics 0.25.0",
  "crossbeam-channel",
  "dbus",
  "dispatch2",
@@ -6296,9 +10185,9 @@ dependencies = [
  "log",
  "ndk",
  "ndk-sys",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "objc2-ui-kit",
  "once_cell",
  "parking_lot",
@@ -6307,10 +10196,22 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
+]
+
+[[package]]
+name = "tao-core-video-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271450eb289cb4d8d0720c6ce70c72c8c858c93dd61fc625881616752e6b98f6"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "objc",
 ]
 
 [[package]]
@@ -6356,7 +10257,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -6369,9 +10270,9 @@ dependencies = [
  "log",
  "mime",
  "muda",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "objc2-ui-kit",
  "objc2-web-kit",
  "percent-encoding",
@@ -6395,7 +10296,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -6406,7 +10307,7 @@ checksum = "bc9ce40b16101cb6ea63d3e221567affd1c3a9205f95d7bc574941a10636b632"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch 3.0.1",
@@ -6482,11 +10383,11 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1d70628154316603585a1e82e41edac5f8a3946c045fb365c38c9ccc2255122"
 dependencies = [
- "block2",
+ "block2 0.6.2",
  "log",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "objc2-local-authentication",
  "objc2-security",
  "serde",
@@ -6495,7 +10396,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -6515,7 +10416,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "url",
- "windows-registry",
+ "windows-registry 0.5.3",
  "windows-result 0.3.4",
 ]
 
@@ -6547,7 +10448,7 @@ dependencies = [
  "dunce",
  "glob",
  "log",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "percent-encoding",
  "schemars 0.8.22",
  "serde",
@@ -6571,8 +10472,8 @@ dependencies = [
  "byte-unit",
  "fern",
  "log",
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -6591,8 +10492,8 @@ checksum = "17e1bea14edce6b793a04e2417e3fd924b9bc4faae83cdee7d714156cceeed29"
 dependencies = [
  "dunce",
  "glob",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "open",
  "schemars 0.8.22",
  "serde",
@@ -6601,7 +10502,7 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "url",
- "windows",
+ "windows 0.61.3",
  "zbus 5.18.0",
 ]
 
@@ -6639,7 +10540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
 dependencies = [
  "base64 0.22.1",
- "dirs",
+ "dirs 6.0.0",
  "flate2",
  "futures-util",
  "http",
@@ -6691,7 +10592,7 @@ dependencies = [
  "gtk",
  "http",
  "jni 0.21.1",
- "objc2",
+ "objc2 0.6.4",
  "objc2-ui-kit",
  "objc2-web-kit",
  "raw-window-handle",
@@ -6702,7 +10603,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -6715,8 +10616,8 @@ dependencies = [
  "http",
  "jni 0.21.1",
  "log",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
@@ -6727,7 +10628,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -6740,7 +10641,7 @@ dependencies = [
  "anyhow",
  "brotli",
  "cargo_metadata",
- "ctor",
+ "ctor 0.8.0",
  "dom_query",
  "dunce",
  "glob",
@@ -6749,7 +10650,7 @@ dependencies = [
  "json-patch 3.0.1",
  "log",
  "memchr",
- "phf",
+ "phf 0.13.1",
  "plist",
  "proc-macro2",
  "quote",
@@ -6781,6 +10682,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-winrt-notification"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
+dependencies = [
+ "thiserror 2.0.18",
+ "windows 0.61.3",
+ "windows-version",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6795,12 +10707,32 @@ dependencies = [
 
 [[package]]
 name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
+]
+
+[[package]]
+name = "tendril"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
 dependencies = [
  "new_debug_unreachable",
  "utf-8",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -6821,7 +10753,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "stringmatch",
- "strum",
+ "strum 0.26.3",
  "thirtyfour-macros",
  "thiserror 1.0.69",
  "tokio",
@@ -6878,6 +10810,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error 2.0.1",
+ "weezl",
+ "zune-jpeg 0.5.15",
 ]
 
 [[package]]
@@ -6939,6 +10894,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png 0.17.16",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
 ]
 
 [[package]]
@@ -7004,6 +10985,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-socks"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7e2948f60dbe26b35f2c7fb74ac2854c1fddded0fe9d7548fcc674a246f7615"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7054,14 +11047,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.2"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned 0.6.9",
- "toml_datetime 0.6.3",
- "toml_edit 0.20.2",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -7096,9 +11089,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
@@ -7128,7 +11121,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.14.0",
- "toml_datetime 0.6.3",
+ "toml_datetime 0.6.11",
  "winnow 0.5.40",
 ]
 
@@ -7139,10 +11132,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
  "indexmap 2.14.0",
+ "toml_datetime 0.6.11",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
- "toml_datetime 0.6.3",
- "winnow 0.5.40",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -7165,6 +11170,12 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.3",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -7257,6 +11268,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -7266,14 +11303,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65ba1e5f6b9ef9fd87e21b9c6f351554dbd717960089168fcfdef854686961dc"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "png 0.18.1",
  "serde",
@@ -7282,10 +11319,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "triomphe"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b40688ea6389c8171614b25491f71d4a27946e0c7ce2da1c6de27e25abf1a0ae"
+dependencies = [
+ "arc-swap",
+ "serde",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
 
 [[package]]
 name = "tungstenite"
@@ -7351,6 +11408,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unic-char-property"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7404,10 +11467,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
+name = "unicode-bidi-mirroring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
+
+[[package]]
+name = "unicode-id"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ba288e709927c043cbe476718d37be306be53fb1fafecd0dbe36d072be2580"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization"
@@ -7425,16 +11512,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
+
+[[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
@@ -7484,6 +11589,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "usvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80be9b06fbae3b8b303400ab20778c80bbaf338f563afe567cf3c9eea17b47ef"
+dependencies = [
+ "base64 0.22.1",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize 0.13.0",
+ "kurbo 0.11.3",
+ "log",
+ "pico-args",
+ "roxmltree 0.20.0",
+ "rustybuzz",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes 0.15.3",
+ "tiny-skia-path",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
+]
+
+[[package]]
+name = "usvg"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e419dff010bb12512b0ae9e3d2f318dfbdf0167fde7eb05465134d4e8756076f"
+dependencies = [
+ "base64 0.22.1",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize 0.14.0",
+ "kurbo 0.13.1",
+ "log",
+ "pico-args",
+ "roxmltree 0.21.1",
+ "rustybuzz",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes 0.16.1",
+ "tiny-skia-path",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
+]
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7510,14 +11669,62 @@ dependencies = [
  "getrandom 0.4.3",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-bag"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
+dependencies = [
+ "value-bag-serde1",
+ "value-bag-sval2",
+]
+
+[[package]]
+name = "value-bag-serde1"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0941feceafbe7a8f59ea1096d45b97002884a41306315ad797b3684b63a81d8c"
+dependencies = [
+ "erased-serde",
+ "serde_core",
+ "serde_fmt",
+]
+
+[[package]]
+name = "value-bag-sval2"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "839752af8179287d27eb2b94164641b1ede9e60ab7424163388dc21ebd0508cd"
+dependencies = [
+ "sval",
+ "sval_buffer",
+ "sval_dynamic",
+ "sval_fmt",
+ "sval_json",
+ "sval_ref",
+ "sval_serde",
+]
 
 [[package]]
 name = "vcpkg"
@@ -7565,6 +11772,21 @@ checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "waker-fn"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
 name = "walkdir"
@@ -7663,6 +11885,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
@@ -7672,6 +11907,117 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasm_thread"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7516db7f32decdadb1c3b8deb1b7d78b9df7606c5cc2f6241737c2ab3a0258e"
+dependencies = [
+ "futures",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a91b4eaddff87b1cd1074985e3713da4af2c49742d1b356b2c01670a67a078"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "log",
+ "rustix",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
+dependencies = [
+ "bitflags 2.13.0",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-cursor"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a52d18780be9b1314328a3de5f930b73d2200112e3849ca6cb11822793fb34d"
+dependencies = [
+ "rustix",
+ "wayland-client",
+ "xcursor",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-plasma"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
+ "pkg-config",
 ]
 
 [[package]]
@@ -7700,10 +12046,10 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
 dependencies = [
- "phf",
- "phf_codegen",
- "string_cache",
- "string_cache_codegen",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "string_cache 0.9.0",
+ "string_cache_codegen 0.6.1",
 ]
 
 [[package]]
@@ -7776,10 +12122,10 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
 ]
 
 [[package]]
@@ -7800,8 +12146,201 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "wgpu"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76e8840e1ba2881d4cbb18d2147627a56af426ff064c0401eb0c8410c6325d07"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.13.0",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "document-features",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "log",
+ "naga",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f519832254e56965a9940c4af57dcb75f702b6f6fa4a0b172f685395843a4d7"
+dependencies = [
+ "arrayvec",
+ "bit-set 0.9.1",
+ "bit-vec 0.9.1",
+ "bitflags 2.13.0",
+ "bytemuck",
+ "cfg_aliases 0.2.1",
+ "document-features",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
+ "log",
+ "naga",
+ "once_cell",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash 1.1.0",
+ "smallvec",
+ "thiserror 2.0.18",
+ "wgpu-core-deps-apple",
+ "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-wasm",
+ "wgpu-core-deps-windows-linux-android",
+ "wgpu-hal",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core-deps-apple"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e39e26c4c0e07589e67d18546cf79ff45383659fc72fca4dd293358a0347f3"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-emscripten"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01e09be551dc939498bdd5f6b2c66e55ab275dad25825267a08605a80fc9f0af"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-wasm"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1fb1798be2a912497d4c224f72d39bb0cb34af50e8bcc29865bc339c943059"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e592c1bbef6ad047647ae6e666ebd8cee7a32bb4544d9700ec96cbf73230257"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ace1c17727311c22a46e4e3faf56ea6de81af99dcc839bdfb54857b94d448d"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set 0.9.1",
+ "bitflags 2.13.0",
+ "block2 0.6.2",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "glow",
+ "glutin_wgl_sys",
+ "gpu-allocator",
+ "gpu-descriptor",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading 0.8.9",
+ "log",
+ "naga",
+ "ndk-sys",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "once_cell",
+ "ordered-float 5.5.0",
+ "parking_lot",
+ "portable-atomic",
+ "portable-atomic-util",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle",
+ "raw-window-metal",
+ "renderdoc-sys",
+ "smallvec",
+ "thiserror 2.0.18",
+ "wasm-bindgen",
+ "wayland-sys",
+ "web-sys",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+ "windows-result 0.4.1",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95226013f547544b223281cd16a4fb549aa9dcb562adbda0faae4c73ffbbc161"
+dependencies = [
+ "naga",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84bf84cd9ca8ca45e2b223a3868f1adf9bfc0c66aeac212e76ee7e40fdadf8f5"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytemuck",
+ "js-sys",
+ "log",
+ "raw-window-handle",
+ "web-sys",
+]
+
+[[package]]
+name = "which"
+version = "8.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bae2f2b2b816647a1cab1acc91f5bd20812d53cb344382635ec2181940c8034f"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -7851,13 +12390,33 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9bec5a31f3f9362f2258fd0e9c9dd61a9ca432e7306cc78c444258f0dce9a9c"
 dependencies = [
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "raw-window-handle",
  "windows-sys 0.59.0",
  "windows-version",
+]
+
+[[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7866,11 +12425,36 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
+]
+
+[[package]]
+name = "windows-capture"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a4df73e95feddb9ec1a7e9c2ca6323b8c97d5eeeff78d28f1eccdf19c882b24"
+dependencies = [
+ "parking_lot",
+ "rayon",
+ "thiserror 2.0.18",
+ "windows 0.61.3",
+ "windows-future 0.2.1",
 ]
 
 [[package]]
@@ -7883,13 +12467,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -7901,8 +12519,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -7916,7 +12534,40 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7924,6 +12575,28 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7964,6 +12637,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
+dependencies = [
+ "windows-result 0.3.4",
+ "windows-strings 0.3.1",
+ "windows-targets 0.53.5",
+]
+
+[[package]]
 name = "windows-registry"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7972,6 +12666,35 @@ dependencies = [
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7990,6 +12713,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -8134,6 +12876,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -8339,6 +13090,9 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"
@@ -8369,6 +13123,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wio"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8387,10 +13150,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "186f9871daa55fd9c016578b810d149de58367113db7fb72b462d2323ce19514"
 dependencies = [
  "base64 0.22.1",
- "block2",
+ "block2 0.6.2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dom_query",
  "dpi",
  "dunce",
@@ -8401,10 +13164,10 @@ dependencies = [
  "jni 0.21.1",
  "libc",
  "ndk",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "objc2-ui-kit",
  "objc2-web-kit",
  "once_cell",
@@ -8418,7 +13181,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -8444,6 +13207,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11-clipboard"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "662d74b3d77e396b8e5beb00b9cad6a9eccf40b2ef68cc858784b14c41d535a3"
+dependencies = [
+ "libc",
+ "x11rb",
+]
+
+[[package]]
 name = "x11-dl"
 version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8453,6 +13226,26 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "as-raw-xcb-connection",
+ "gethostname",
+ "libc",
+ "rustix",
+ "x11rb-protocol",
+ "xcursor",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xattr"
@@ -8465,6 +13258,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "xcb"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6c2ad15e0e922856ee89afe862b8992334bbe7953adad56cd1199358cb30566"
+dependencies = [
+ "bitflags 2.13.0",
+ "libc",
+ "quick-xml",
+ "x11",
+]
+
+[[package]]
+name = "xcursor"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "163b33ed8786455e2fa5d72f554057ce3f3182425434f756cd39c99839d88e23"
+
+[[package]]
 name = "xdg-home"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8472,6 +13283,88 @@ checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "xim-ctext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac61a7062c40f3c37b6e82eeeef835d5cc7824b632a72784a89b3963c33284c"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
+name = "xim-parser"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dcee45f89572d5a65180af3a84e7ddb24f5ea690a6d3aa9de231281544dd7b7"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
+name = "xkbcommon"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d66ca9352cbd4eecbbc40871d8a11b4ac8107cfc528a6e14d7c19c69d0e1ac9"
+dependencies = [
+ "as-raw-xcb-connection",
+ "libc",
+ "memmap2",
+ "xkeysym",
+]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+
+[[package]]
+name = "xml-rs"
+version = "0.8.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e450f9b2ed1dff33c94c12589a87338689467b9c4f5d8a5710bd09a847d2c8a7"
+
+[[package]]
+name = "xml5ever"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bbb26405d8e919bc1547a5aa9abc95cbfa438f04844f5fdd9dc7596b748bf69"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever 0.12.1",
+]
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+
+[[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
+name = "yazi"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01738255b5a16e78bbb83e7fbba0a1e7dd506905cfc53f4622d89015a03fbb5"
+
+[[package]]
+name = "yeslogic-fontconfig-sys"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8b8abf912b9a29ff112e1671c97c33636903d13a69712037190e6805af4f76"
+dependencies = [
+ "dlib",
+ "once_cell",
+ "pkg-config",
 ]
 
 [[package]]
@@ -8565,6 +13458,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus-lockstep"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6998de05217a084b7578728a9443d04ea4cd80f2a0839b8d78770b76ccd45863"
+dependencies = [
+ "zbus_xml",
+ "zvariant 5.13.1",
+]
+
+[[package]]
+name = "zbus-lockstep-macros"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10da05367f3a7b7553c8cdf8fa91aee6b64afebe32b51c95177957efc47ca3a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "zbus-lockstep",
+ "zbus_xml",
+ "zvariant 5.13.1",
+]
+
+[[package]]
 name = "zbus_macros"
 version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8613,6 +13530,85 @@ dependencies = [
  "winnow 1.0.3",
  "zvariant 5.13.1",
 ]
+
+[[package]]
+name = "zbus_xml"
+version = "5.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1586c021a01ca0a9216dcd874e546382e156a5cbab5fab6cb5f10087e22682a"
+dependencies = [
+ "serde",
+ "winnow 1.0.3",
+ "zbus_names 4.3.4",
+ "zvariant 5.13.1",
+]
+
+[[package]]
+name = "zed-font-kit"
+version = "0.14.1-zed"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3898e450f36f852edda72e3f985c34426042c4951790b23b107f93394f9bff5"
+dependencies = [
+ "bitflags 2.13.0",
+ "byteorder",
+ "core-foundation 0.10.1",
+ "core-graphics 0.24.0",
+ "core-text",
+ "dirs 5.0.1",
+ "dwrote",
+ "float-ord",
+ "freetype-sys",
+ "lazy_static",
+ "libc",
+ "log",
+ "pathfinder_geometry",
+ "pathfinder_simd",
+ "walkdir",
+ "winapi",
+ "yeslogic-fontconfig-sys",
+]
+
+[[package]]
+name = "zed-scap"
+version = "0.0.8-zed"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b338d705ae33a43ca00287c11129303a7a0aa57b101b72a1c08c863f698ac8"
+dependencies = [
+ "anyhow",
+ "cocoa 0.25.0",
+ "core-graphics-helmer-fork",
+ "log",
+ "objc",
+ "rand 0.8.6",
+ "screencapturekit",
+ "screencapturekit-sys",
+ "sysinfo",
+ "tao-core-video-sys",
+ "windows 0.61.3",
+ "windows-capture",
+ "x11",
+ "xcb",
+]
+
+[[package]]
+name = "zed-xim"
+version = "0.4.0-zed"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0b46ed118eba34d9ba53d94ddc0b665e0e06a2cf874cfa2dd5dec278148642"
+dependencies = [
+ "ahash 0.8.12",
+ "hashbrown 0.14.5",
+ "log",
+ "x11rb",
+ "xim-ctext",
+ "xim-parser",
+]
+
+[[package]]
+name = "zeno"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"
@@ -8727,6 +13723,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-core"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
+dependencies = [
+ "zune-core 0.4.12",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core 0.5.3",
+]
+
+[[package]]
 name = "zvariant"
 version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8748,6 +13783,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
+ "serde_bytes",
  "winnow 1.0.3",
  "zvariant_derive 5.13.1",
  "zvariant_utils 3.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/agent", "crates/capability", "crates/mcp", "crates/kube", "crates/streams", "crates/server", "crates/registry", "crates/llm", "apps/desktop/src-tauri"]
+members = ["crates/agent", "crates/capability", "crates/mcp", "crates/kube", "crates/streams", "crates/server", "crates/registry", "crates/llm", "apps/desktop/src-tauri", "apps/gpui"]
 
 [workspace.package]
 edition = "2021"

--- a/apps/gpui/Cargo.toml
+++ b/apps/gpui/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "srelens-gpui"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+description = "srelens on GPUI Kit: the resource list, as its own binary, to find out"
+
+[[bin]]
+name = "srelens-gpui"
+path = "src/main.rs"
+
+[dependencies]
+gpui-kit = "0.6"
+# The service layer, called directly. No IPC, no JSON: see `kube_bridge`.
+srelens-capability = { path = "../../crates/capability" }
+srelens-kube = { path = "../../crates/kube" }
+srelens-registry = { path = "../../crates/registry" }
+# kube-rs needs a tokio reactor; GPUI has its own executor. One runtime is
+# built at startup and every kube future runs on it — see `kube_bridge`.
+tokio = { version = "1", features = ["rt-multi-thread"] }
+# Two rustls crypto providers end up in this one process: kube-rs brings
+# `ring`, GPUI's HTTP client brings `aws-lc-rs`. rustls then refuses to pick
+# one at runtime and panics on the first TLS handshake — on the kube thread,
+# where it took the pod list down without a word in the window. `main`
+# installs `ring` explicitly before anything touches the network. Default
+# features off so this line does not become a third vote.
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
+
+[dev-dependencies]
+gpui-kit = { version = "0.6", features = ["test-support"] }

--- a/apps/gpui/Cargo.toml
+++ b/apps/gpui/Cargo.toml
@@ -19,13 +19,6 @@ srelens-registry = { path = "../../crates/registry" }
 # kube-rs needs a tokio reactor; GPUI has its own executor. One runtime is
 # built at startup and every kube future runs on it — see `kube_bridge`.
 tokio = { version = "1", features = ["rt-multi-thread"] }
-# Two rustls crypto providers end up in this one process: kube-rs brings
-# `ring`, GPUI's HTTP client brings `aws-lc-rs`. rustls then refuses to pick
-# one at runtime and panics on the first TLS handshake — on the kube thread,
-# where it took the pod list down without a word in the window. `main`
-# installs `ring` explicitly before anything touches the network. Default
-# features off so this line does not become a third vote.
-rustls = { version = "0.23", default-features = false, features = ["ring"] }
 
 [dev-dependencies]
 gpui-kit = { version = "0.6", features = ["test-support"] }

--- a/apps/gpui/src/kube_bridge.rs
+++ b/apps/gpui/src/kube_bridge.rs
@@ -1,0 +1,121 @@
+//! The one place this binary touches the cluster.
+//!
+//! Two facts shape it. **The service layer is already Rust**: `crates/kube`
+//! owns the kube client, kubeconfig discovery and every summary type, and it
+//! now exposes typed doors — `list_contexts`, `list_namespaces`, `list_pods`
+//! — beside the JSON capabilities the registry serves. This shell calls the
+//! doors. There is no `packages/core` here and no `Value` in the middle,
+//! which is the claim the feasibility made and the thing this file exists to
+//! test.
+//!
+//! **kube-rs needs a tokio reactor and GPUI has its own executor.** The two
+//! do not share a runtime. So one tokio runtime is built at startup and every
+//! kube future is spawned onto it; what comes back to GPUI is the
+//! `JoinHandle`, which is an ordinary `Future` that any executor can await.
+//! State is then mutated on GPUI's foreground through the normal `cx.spawn` /
+//! `this.update` path — never from a tokio thread.
+//!
+//! Held as a GPUI global because it is an application service with one owner
+//! and one lifetime, which is what the coding guide reserves globals for.
+
+use std::future::Future;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use gpui_kit::Global;
+use srelens_capability::CapabilityError;
+use srelens_kube::client_cache::ClientCache;
+use srelens_kube::contexts::{self, ContextDto};
+use srelens_kube::workloads::{self, PodSummary};
+
+pub struct KubeBridge {
+    runtime: tokio::runtime::Runtime,
+    cache: Arc<ClientCache>,
+    default_paths: Vec<PathBuf>,
+}
+
+impl Global for KubeBridge {}
+
+impl KubeBridge {
+    /// Build the runtime and the client cache over the host's default
+    /// kubeconfig paths — the same discovery the desktop and MCP surfaces use.
+    pub fn new() -> std::io::Result<Self> {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .worker_threads(2)
+            .thread_name("srelens-kube")
+            .build()?;
+        let default_paths = srelens_registry::default_kubeconfig_paths();
+        let cache = ClientCache::new_many(default_paths.clone());
+        Ok(Self {
+            runtime,
+            cache,
+            default_paths,
+        })
+    }
+
+    /// Every context across the active kubeconfig files.
+    pub fn contexts(&self) -> impl Future<Output = Result<Vec<ContextDto>, String>> + Send {
+        let cache = self.cache.clone();
+        let paths = self.default_paths.clone();
+        self.run(async move {
+            contexts::list_contexts(&cache, paths, None, None)
+                .await
+                .map(|out| out.contexts)
+        })
+    }
+
+    /// Namespace names in one context.
+    pub fn namespaces(
+        &self,
+        context: String,
+    ) -> impl Future<Output = Result<Vec<String>, String>> + Send {
+        let cache = self.cache.clone();
+        self.run(async move {
+            workloads::list_namespaces(&cache, &context)
+                .await
+                .map(|out| out.namespaces)
+        })
+    }
+
+    /// Pods in one namespace of one context; `""` for every namespace.
+    pub fn pods(
+        &self,
+        context: String,
+        namespace: String,
+    ) -> impl Future<Output = Result<Vec<PodSummary>, String>> + Send {
+        let cache = self.cache.clone();
+        self.run(async move {
+            workloads::list_pods(&cache, &context, &namespace)
+                .await
+                .map(|out| out.pods)
+        })
+    }
+
+    /// Run a kube future on the tokio runtime and hand its result back as a
+    /// future any executor can await. Both failures — the call's own, and the
+    /// task being cancelled or panicking — arrive as one string the screen can
+    /// show; a screen has nothing different to do about the two.
+    fn run<T>(
+        &self,
+        work: impl Future<Output = Result<T, CapabilityError>> + Send + 'static,
+    ) -> impl Future<Output = Result<T, String>> + Send
+    where
+        T: Send + 'static,
+    {
+        let join = self.runtime.spawn(work);
+        async move {
+            match join.await {
+                Ok(Ok(value)) => Ok(value),
+                Ok(Err(error)) => Err(describe(error)),
+                Err(join_error) => Err(format!("the request was interrupted: {join_error}")),
+            }
+        }
+    }
+}
+
+/// The message a reader sees for a capability failure: the error's own
+/// `Display`, which `crates/capability` writes to carry the backend's words.
+fn describe(error: CapabilityError) -> String {
+    error.to_string()
+}

--- a/apps/gpui/src/main.rs
+++ b/apps/gpui/src/main.rs
@@ -1,0 +1,64 @@
+//! srelens on GPUI Kit — the resource list, as its own binary.
+//!
+//! This is the experiment `docs/design/gpui-kit-feasibility.md` asked for: one
+//! screen, built against the existing Rust crates rather than through the
+//! Tauri boundary, to find out what a migration would actually cost. It is
+//! not wired into the shipping app and nothing in the shipping app depends on
+//! it.
+//!
+//! Bootstrap follows the toolkit's own rules: `gpui_kit::init` before anything
+//! else, one `Root` at the first level of the window, the application service
+//! (`KubeBridge`) set as a global before the first view is created.
+
+mod kube_bridge;
+mod pods_table;
+mod workspace;
+
+use gpui_kit::component::Root;
+use gpui_kit::*;
+
+use kube_bridge::KubeBridge;
+use workspace::Workspace;
+
+fn main() {
+    // Before any TLS: see the note on `rustls` in Cargo.toml. Two providers
+    // are linked and rustls will not choose between them; this chooses the
+    // one kube-rs was built against. A second install (a test harness that
+    // already did it) is not an error worth stopping for.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let bridge = match KubeBridge::new() {
+        Ok(bridge) => bridge,
+        Err(error) => {
+            eprintln!("srelens-gpui: could not start the kube runtime: {error}");
+            std::process::exit(1);
+        }
+    };
+
+    gpui_kit::application()
+        .with_assets(gpui_kit::assets::Assets)
+        .run(move |cx| {
+            gpui_kit::init(cx);
+            cx.set_global(bridge);
+
+            let bounds = Bounds::centered(None, size(px(1280.), px(820.)), cx);
+            let options = WindowOptions {
+                titlebar: Some(TitlebarOptions {
+                    title: Some("srelens".into()),
+                    ..Default::default()
+                }),
+                window_bounds: Some(WindowBounds::Windowed(bounds)),
+                window_min_size: Some(size(px(720.), px(480.))),
+                ..Default::default()
+            };
+
+            cx.spawn(async move |cx| {
+                cx.open_window(options, |window, cx| {
+                    let workspace = cx.new(|cx| Workspace::new(window, cx));
+                    cx.new(|cx| Root::new(workspace, window, cx))
+                })
+                .expect("failed to open the window");
+            })
+            .detach();
+        });
+}

--- a/apps/gpui/src/main.rs
+++ b/apps/gpui/src/main.rs
@@ -21,11 +21,14 @@ use kube_bridge::KubeBridge;
 use workspace::Workspace;
 
 fn main() {
-    // Before any TLS: see the note on `rustls` in Cargo.toml. Two providers
-    // are linked and rustls will not choose between them; this chooses the
-    // one kube-rs was built against. A second install (a test harness that
-    // already did it) is not an error worth stopping for.
-    let _ = rustls::crypto::ring::default_provider().install_default();
+    // Two rustls crypto providers end up in this process — kube-rs brings
+    // `ring`, GPUI's HTTP client brings `aws-lc-rs` — and rustls will not
+    // choose between them: it panics on the first TLS handshake, which was on
+    // the kube thread, and took the pod list down without a word in the
+    // window. `crates/kube` owns the choice and makes it before every client
+    // it builds; this call just makes it before anything else in this binary
+    // could touch TLS first.
+    srelens_kube::connect::ensure_crypto_provider();
 
     let bridge = match KubeBridge::new() {
         Ok(bridge) => bridge,

--- a/apps/gpui/src/pods_table.rs
+++ b/apps/gpui/src/pods_table.rs
@@ -1,0 +1,445 @@
+//! The pod list's data: rows, their health, sorting, and the table delegate.
+//!
+//! Kept apart from the view so the parts that can be wrong in a testable way
+//! — how a summary becomes a row, what counts as unhealthy, what a sort does
+//! — are plain functions with plain tests, and the delegate is a thin owner
+//! of them. The coding guide's separation: source data and IDs, sort state,
+//! selection (the table's), viewport (the table's), and row rendering.
+
+use gpui_kit::base::h_flex;
+use gpui_kit::component::table::{Column, ColumnSort, TableDelegate, TableState};
+use gpui_kit::component::ActiveTheme as _;
+use gpui_kit::*;
+use srelens_kube::workloads::PodSummary;
+
+/// What a pod's status means, decided once here for this shell.
+///
+/// This duplicates a decision `@srelens/core`'s `podStatus` makes for the web
+/// frontends — which waiting reasons are a failure and which are a pod on its
+/// way up. `crates/kube` deliberately does not decide it (see `PodSummary::
+/// waiting_reason`), so a second frontend has to, and this is the second copy.
+/// That is exactly the drift the feasibility asked about; the fix is to move
+/// the rule down into `crates/kube` so every shell reads one verdict. Until
+/// then the rule is kept minimal and the copy is named.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Health {
+    /// Running with nothing waiting.
+    Running,
+    /// A container is in a back-off or a config failure; the phase hides it.
+    Failing(String),
+    /// A container is waiting for an ordinary reason — pulling, creating.
+    Starting(String),
+    /// The pod itself failed.
+    Failed,
+    /// Pending, Succeeded, Unknown, anything else — shown as the phase says.
+    Other(String),
+}
+
+impl Health {
+    pub fn from_summary(phase: &str, waiting_reason: &str) -> Self {
+        if phase == "Failed" {
+            return Health::Failed;
+        }
+        if !waiting_reason.is_empty() {
+            return match waiting_reason {
+                "CrashLoopBackOff"
+                | "ImagePullBackOff"
+                | "ErrImagePull"
+                | "CreateContainerConfigError"
+                | "CreateContainerError"
+                | "InvalidImageName"
+                | "RunContainerError" => Health::Failing(waiting_reason.to_string()),
+                other => Health::Starting(other.to_string()),
+            };
+        }
+        match phase {
+            "Running" => Health::Running,
+            other => Health::Other(other.to_string()),
+        }
+    }
+
+    /// The word shown in the Status column.
+    pub fn label(&self) -> &str {
+        match self {
+            Health::Running => "Running",
+            Health::Failing(reason) | Health::Starting(reason) | Health::Other(reason) => reason,
+            Health::Failed => "Failed",
+        }
+    }
+}
+
+/// One row: a pod summary with its health decided and a stable key.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PodRow {
+    /// `namespace/name`: the row's identity for element IDs and selection,
+    /// stable across sorting and refreshes. Never the row's index.
+    pub key: SharedString,
+    pub name: SharedString,
+    pub namespace: SharedString,
+    pub ready: SharedString,
+    pub health: Health,
+    pub restarts: i32,
+    pub node: SharedString,
+    pub age: SharedString,
+    pub image: SharedString,
+}
+
+impl From<PodSummary> for PodRow {
+    fn from(pod: PodSummary) -> Self {
+        let health = Health::from_summary(&pod.phase, &pod.waiting_reason);
+        Self {
+            key: SharedString::from(format!("{}/{}", pod.namespace, pod.name)),
+            name: pod.name.into(),
+            namespace: pod.namespace.into(),
+            ready: pod.ready.into(),
+            health,
+            restarts: pod.restarts,
+            node: pod.node.into(),
+            age: pod.age.into(),
+            image: pod.image.into(),
+        }
+    }
+}
+
+/// Column keys, in display order. The delegate matches on these.
+const NAME: &str = "name";
+const NAMESPACE: &str = "namespace";
+const READY: &str = "ready";
+const STATUS: &str = "status";
+const RESTARTS: &str = "restarts";
+const NODE: &str = "node";
+const AGE: &str = "age";
+const IMAGE: &str = "image";
+
+fn columns() -> Vec<Column> {
+    vec![
+        Column::new(NAME, "Name")
+            .width(px(300.))
+            .min_width(px(160.))
+            .sortable(),
+        Column::new(NAMESPACE, "Namespace").width(px(180.)),
+        Column::new(READY, "Ready").width(px(72.)),
+        Column::new(STATUS, "Status").width(px(180.)).sortable(),
+        Column::new(RESTARTS, "Restarts")
+            .width(px(88.))
+            .text_right()
+            .sortable(),
+        Column::new(NODE, "Node").width(px(200.)),
+        Column::new(AGE, "Age").width(px(72.)),
+        Column::new(IMAGE, "Image").width(px(360.)),
+    ]
+}
+
+/// Sort `rows` by one column. `ColumnSort::Default` is the caller's job — it
+/// means "the order they arrived in", which this function no longer has.
+pub fn sort_rows(rows: &mut [PodRow], key: &str, sort: ColumnSort) {
+    let descending = match sort {
+        ColumnSort::Ascending => false,
+        ColumnSort::Descending => true,
+        ColumnSort::Default => return,
+    };
+    match key {
+        NAME => rows.sort_by(|a, b| a.name.cmp(&b.name)),
+        STATUS => rows.sort_by(|a, b| a.health.label().cmp(b.health.label())),
+        RESTARTS => rows.sort_by_key(|row| row.restarts),
+        _ => return,
+    }
+    if descending {
+        rows.reverse();
+    }
+}
+
+/// The table's data owner. Holds the rows as they arrived and the rows as
+/// they are shown, so a sort can be undone without a reload.
+pub struct PodsDelegate {
+    arrived: Vec<PodRow>,
+    shown: Vec<PodRow>,
+    columns: Vec<Column>,
+    sort: Option<(usize, ColumnSort)>,
+}
+
+impl Default for PodsDelegate {
+    fn default() -> Self {
+        Self {
+            arrived: Vec::new(),
+            shown: Vec::new(),
+            columns: columns(),
+            sort: None,
+        }
+    }
+}
+
+impl PodsDelegate {
+    /// Replace every row. The current sort, if any, is applied to the new
+    /// rows, so a refresh does not silently unsort the table.
+    pub fn set_rows(&mut self, rows: Vec<PodRow>) {
+        self.arrived = rows;
+        self.apply_sort();
+    }
+
+    pub fn len(&self) -> usize {
+        self.shown.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.shown.is_empty()
+    }
+
+    fn apply_sort(&mut self) {
+        self.shown = self.arrived.clone();
+        if let Some((col_ix, sort)) = self.sort {
+            if let Some(column) = self.columns.get(col_ix) {
+                sort_rows(&mut self.shown, column.key.as_ref(), sort);
+            }
+        }
+    }
+}
+
+impl TableDelegate for PodsDelegate {
+    fn columns_count(&self, _: &App) -> usize {
+        self.columns.len()
+    }
+
+    fn rows_count(&self, _: &App) -> usize {
+        self.shown.len()
+    }
+
+    fn column(&self, col_ix: usize, _: &App) -> Column {
+        self.columns[col_ix].clone()
+    }
+
+    fn perform_sort(
+        &mut self,
+        col_ix: usize,
+        sort: ColumnSort,
+        _: &mut Window,
+        _: &mut Context<TableState<Self>>,
+    ) {
+        self.sort = match sort {
+            ColumnSort::Default => None,
+            other => Some((col_ix, other)),
+        };
+        self.apply_sort();
+    }
+
+    fn render_tr(
+        &mut self,
+        row_ix: usize,
+        _: &mut Window,
+        _: &mut Context<TableState<Self>>,
+    ) -> Stateful<Div> {
+        // Identity is the pod, not its position: the default `("row", ix)` would
+        // hand one row's element state to another the moment the sort changed.
+        let key = self
+            .shown
+            .get(row_ix)
+            .map(|row| row.key.clone())
+            .unwrap_or_else(|| SharedString::from(format!("missing-{row_ix}")));
+        div().id(ElementId::Name(key))
+    }
+
+    fn render_td(
+        &mut self,
+        row_ix: usize,
+        col_ix: usize,
+        _: &mut Window,
+        cx: &mut Context<TableState<Self>>,
+    ) -> impl IntoElement {
+        let Some(row) = self.shown.get(row_ix) else {
+            return div().into_any_element();
+        };
+        let key = self.columns[col_ix].key.as_ref();
+        match key {
+            NAME => div().child(row.name.clone()).into_any_element(),
+            NAMESPACE => div()
+                .text_color(cx.theme().muted_foreground)
+                .child(row.namespace.clone())
+                .into_any_element(),
+            READY => div().child(row.ready.clone()).into_any_element(),
+            STATUS => {
+                // A word and a dot in the same tone: the colour is never the
+                // only signal, and the word is what a screen reader gets.
+                let tone = match &row.health {
+                    Health::Running => cx.theme().success,
+                    Health::Failing(_) | Health::Failed => cx.theme().danger,
+                    Health::Starting(_) => cx.theme().warning,
+                    Health::Other(_) => cx.theme().muted_foreground,
+                };
+                h_flex()
+                    .gap_2()
+                    .text_color(tone)
+                    .child("●")
+                    .child(SharedString::from(row.health.label().to_string()))
+                    .into_any_element()
+            }
+            RESTARTS => div()
+                .child(SharedString::from(row.restarts.to_string()))
+                .into_any_element(),
+            NODE => div()
+                .text_color(cx.theme().muted_foreground)
+                .child(row.node.clone())
+                .into_any_element(),
+            AGE => div()
+                .text_color(cx.theme().muted_foreground)
+                .child(row.age.clone())
+                .into_any_element(),
+            IMAGE => div()
+                .text_color(cx.theme().muted_foreground)
+                .child(row.image.clone())
+                .into_any_element(),
+            _ => div().into_any_element(),
+        }
+    }
+
+    fn render_empty(
+        &mut self,
+        _: &mut Window,
+        cx: &mut Context<TableState<Self>>,
+    ) -> impl IntoElement {
+        h_flex()
+            .size_full()
+            .justify_center()
+            .text_color(cx.theme().muted_foreground)
+            .child("No pods in this namespace")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Named imports, not `use super::*`: the parent globs `gpui_kit::*`, which
+    // carries a `test` attribute macro of its own, and inside this module a
+    // bare `#[test]` then resolves to it and expands into itself until the
+    // recursion limit. Std's `#[test]` and `#[gpui_kit::test]` both need
+    // `test` to mean only one thing here.
+    use super::{sort_rows, Health, PodRow, PodsDelegate, NAME, RESTARTS};
+    use gpui_kit::component::table::{ColumnSort, TableDelegate};
+    use gpui_kit::TestAppContext;
+    use srelens_kube::workloads::PodSummary;
+
+    fn pod(name: &str, phase: &str, waiting: &str, restarts: i32) -> PodSummary {
+        PodSummary {
+            name: name.into(),
+            namespace: "checkout".into(),
+            phase: phase.into(),
+            ready: "1/1".into(),
+            restarts,
+            node: "n1".into(),
+            created: None,
+            age: "2d".into(),
+            image: "acme/api:1".into(),
+            waiting_reason: waiting.into(),
+        }
+    }
+
+    #[test]
+    fn a_running_pod_in_a_back_off_loop_is_failing_not_running() {
+        // The phase says Running; the waiting reason says otherwise. The
+        // reason wins, which is the whole point of carrying it.
+        assert_eq!(
+            Health::from_summary("Running", "CrashLoopBackOff"),
+            Health::Failing("CrashLoopBackOff".into())
+        );
+        assert_eq!(Health::from_summary("Running", ""), Health::Running);
+        assert_eq!(
+            Health::from_summary("Pending", "ContainerCreating"),
+            Health::Starting("ContainerCreating".into())
+        );
+        assert_eq!(Health::from_summary("Failed", ""), Health::Failed);
+        assert_eq!(
+            Health::from_summary("Succeeded", ""),
+            Health::Other("Succeeded".into())
+        );
+    }
+
+    #[test]
+    fn a_row_keys_itself_by_namespace_and_name() {
+        let row = PodRow::from(pod("api-1", "Running", "", 0));
+        assert_eq!(row.key.as_ref(), "checkout/api-1");
+        assert_eq!(row.health, Health::Running);
+    }
+
+    #[test]
+    fn sorting_by_restarts_orders_numerically_and_reverses_for_descending() {
+        let mut rows: Vec<PodRow> = [("a", 2), ("b", 10), ("c", 1)]
+            .into_iter()
+            .map(|(name, restarts)| PodRow::from(pod(name, "Running", "", restarts)))
+            .collect();
+        sort_rows(&mut rows, RESTARTS, ColumnSort::Ascending);
+        assert_eq!(
+            rows.iter().map(|r| r.restarts).collect::<Vec<_>>(),
+            vec![1, 2, 10]
+        );
+        sort_rows(&mut rows, RESTARTS, ColumnSort::Descending);
+        assert_eq!(
+            rows.iter().map(|r| r.restarts).collect::<Vec<_>>(),
+            vec![10, 2, 1]
+        );
+    }
+
+    #[test]
+    fn clearing_the_sort_restores_arrival_order_and_a_refresh_keeps_the_sort() {
+        let mut delegate = PodsDelegate::default();
+        let arrivals = |names: &[&str]| -> Vec<PodRow> {
+            names
+                .iter()
+                .enumerate()
+                .map(|(ix, name)| PodRow::from(pod(name, "Running", "", ix as i32)))
+                .collect()
+        };
+        delegate.set_rows(arrivals(&["c", "a", "b"]));
+        assert_eq!(
+            delegate
+                .shown
+                .iter()
+                .map(|r| r.name.as_ref())
+                .collect::<Vec<_>>(),
+            ["c", "a", "b"]
+        );
+
+        // Column 0 is Name.
+        delegate.sort = Some((0, ColumnSort::Ascending));
+        delegate.apply_sort();
+        assert_eq!(
+            delegate
+                .shown
+                .iter()
+                .map(|r| r.name.as_ref())
+                .collect::<Vec<_>>(),
+            ["a", "b", "c"]
+        );
+
+        // New rows arrive; the sort holds.
+        delegate.set_rows(arrivals(&["z", "y"]));
+        assert_eq!(
+            delegate
+                .shown
+                .iter()
+                .map(|r| r.name.as_ref())
+                .collect::<Vec<_>>(),
+            ["y", "z"]
+        );
+
+        // Back to Default: the order they arrived in.
+        delegate.sort = None;
+        delegate.apply_sort();
+        assert_eq!(
+            delegate
+                .shown
+                .iter()
+                .map(|r| r.name.as_ref())
+                .collect::<Vec<_>>(),
+            ["z", "y"]
+        );
+    }
+
+    #[gpui_kit::test]
+    fn the_delegate_reports_its_shape_to_the_table(cx: &mut TestAppContext) {
+        let mut delegate = PodsDelegate::default();
+        delegate.set_rows(vec![PodRow::from(pod("api-1", "Running", "", 0))]);
+        cx.update(|cx| {
+            assert_eq!(delegate.columns_count(cx), 8);
+            assert_eq!(delegate.rows_count(cx), 1);
+            assert_eq!(delegate.column(0, cx).key.as_ref(), NAME);
+        });
+    }
+}

--- a/apps/gpui/src/workspace.rs
+++ b/apps/gpui/src/workspace.rs
@@ -1,0 +1,340 @@
+//! The pod list: one context, one namespace, the pods in it.
+//!
+//! Written down before the screen, as the design guide asks:
+//!
+//! - **Primary task.** See the pods of one namespace on one cluster and tell
+//!   the unhealthy ones from the rest without reading every row.
+//! - **Object.** Pods. The context and namespace are the scope, not the
+//!   object, so they sit in the toolbar and the table gets the window.
+//! - **Actions that stay available.** Change the context, change the
+//!   namespace, refresh. Nothing per row yet: this increment is about whether
+//!   the list itself is right, and a row action with no place to land would be
+//!   a capability exposed because the backend has it.
+//! - **Information for a decision.** Name, namespace, ready count, status
+//!   with the waiting reason the phase hides, restarts, node, age, image.
+//! - **States.** No kubeconfig contexts at all; loading contexts, namespaces
+//!   or pods; a load that failed, with the backend's words and a way to retry;
+//!   an empty namespace.
+//! - **Keyboard path.** Tab reaches the two pickers and Refresh in order; the
+//!   table owns arrow navigation and row selection through `TableState`.
+//!
+//! State lives in the narrowest owner that keeps it correct: the pickers own
+//! their open/close and search, the table owns selection, scroll and sort
+//! coordination, and this view owns what is being looked at and whether it
+//! has arrived. Every load is stamped with a revision; a result for an older
+//! revision is dropped, so switching context twice quickly never paints the
+//! first cluster's pods under the second cluster's name.
+
+use gpui_kit::base::{h_flex, v_flex, IndexPath};
+use gpui_kit::component::alert::Alert;
+use gpui_kit::component::button::Button;
+use gpui_kit::component::label::Label;
+use gpui_kit::component::select::{Select, SelectEvent, SelectState};
+use gpui_kit::component::table::{DataTable, TableState};
+use gpui_kit::component::{ActiveTheme as _, Root, Sizable as _};
+use gpui_kit::prelude::*;
+use gpui_kit::*;
+
+use crate::kube_bridge::KubeBridge;
+use crate::pods_table::{PodRow, PodsDelegate};
+
+type NamesSelect = SelectState<Vec<String>>;
+
+/// Which namespace to open on, out of the ones the cluster has.
+///
+/// `SRELENS_GPUI_NAMESPACE` wins when it names one of them: a development
+/// override so a screenshot or a check can land on a namespace with something
+/// in it without driving the picker first. Then `default`, then the first.
+/// A context's own declared namespace is the rule this should learn next;
+/// it needs the chosen `ContextDto` kept around, which the first increment
+/// does not yet do.
+fn initial_namespace(names: &[String]) -> usize {
+    if let Ok(wanted) = std::env::var("SRELENS_GPUI_NAMESPACE") {
+        if let Some(ix) = names.iter().position(|n| *n == wanted) {
+            return ix;
+        }
+    }
+    names.iter().position(|n| n == "default").unwrap_or(0)
+}
+
+pub struct Workspace {
+    contexts: Entity<NamesSelect>,
+    namespaces: Entity<NamesSelect>,
+    table: Entity<TableState<PodsDelegate>>,
+    /// What is being looked at. `None` until the pickers have something.
+    context: Option<String>,
+    namespace: Option<String>,
+    /// Whether any load is in flight; drives the Refresh button's state.
+    busy: bool,
+    /// The last failure, in the backend's words, until the next load starts.
+    error: Option<String>,
+    /// Stamped onto every load; a result carrying an older stamp is dropped.
+    revision: u64,
+    _subscriptions: Vec<Subscription>,
+}
+
+impl Workspace {
+    pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
+        let contexts = cx.new(|cx| SelectState::new(Vec::<String>::new(), None, window, cx));
+        let namespaces = cx.new(|cx| SelectState::new(Vec::<String>::new(), None, window, cx));
+        let table = cx.new(|cx| {
+            TableState::new(PodsDelegate::default(), window, cx)
+                .row_selectable(true)
+                .col_resizable(true)
+                .sortable(true)
+        });
+
+        let subscriptions = vec![
+            cx.subscribe_in(&contexts, window, |this, _, event, window, cx| {
+                if let SelectEvent::Confirm(Some(name)) = event {
+                    this.choose_context(name.clone(), window, cx);
+                }
+            }),
+            cx.subscribe_in(&namespaces, window, |this, _, event, window, cx| {
+                if let SelectEvent::Confirm(Some(name)) = event {
+                    this.choose_namespace(name.clone(), window, cx);
+                }
+            }),
+        ];
+
+        let mut this = Self {
+            contexts,
+            namespaces,
+            table,
+            context: None,
+            namespace: None,
+            busy: false,
+            error: None,
+            revision: 0,
+            _subscriptions: subscriptions,
+        };
+        this.load_contexts(window, cx);
+        this
+    }
+
+    /// A new load begins: everything older is now stale.
+    fn begin(&mut self, cx: &mut Context<Self>) -> u64 {
+        self.revision += 1;
+        self.busy = true;
+        self.error = None;
+        cx.notify();
+        self.revision
+    }
+
+    fn fail(&mut self, message: String, cx: &mut Context<Self>) {
+        self.busy = false;
+        self.error = Some(message);
+        cx.notify();
+    }
+
+    fn load_contexts(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let revision = self.begin(cx);
+        let work = cx.global::<KubeBridge>().contexts();
+        cx.spawn_in(window, async move |this, cx| {
+            let result = work.await;
+            this.update_in(cx, |this, window, cx| {
+                if revision != this.revision {
+                    return;
+                }
+                match result {
+                    Ok(list) => {
+                        let names: Vec<String> = list.iter().map(|c| c.name.clone()).collect();
+                        // The kubeconfig's current context first, else the first listed.
+                        let pick = list.iter().position(|c| c.is_current).unwrap_or(0);
+                        let chosen = names.get(pick).cloned();
+                        this.contexts.update(cx, |select, cx| {
+                            select.set_items(names, window, cx);
+                            select.set_selected_index(
+                                chosen.as_ref().map(|_| IndexPath::new(pick)),
+                                window,
+                                cx,
+                            );
+                        });
+                        match chosen {
+                            Some(name) => this.choose_context(name, window, cx),
+                            None => this
+                                .fail("No contexts in any kubeconfig on this machine".into(), cx),
+                        }
+                    }
+                    Err(message) => this.fail(message, cx),
+                }
+            })
+            .ok();
+        })
+        .detach();
+    }
+
+    fn choose_context(&mut self, name: String, window: &mut Window, cx: &mut Context<Self>) {
+        // Setting the picker's index from a load reports back as a choice, and
+        // `load_contexts` also calls this directly, so the same name arrives
+        // twice. Choosing what is already chosen is not a change — unless the
+        // last load of it failed, in which case choosing it again is the retry.
+        if self.context.as_deref() == Some(name.as_str()) && self.error.is_none() {
+            return;
+        }
+        self.context = Some(name);
+        self.namespace = None;
+        self.load_namespaces(window, cx);
+    }
+
+    fn load_namespaces(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(context) = self.context.clone() else {
+            return;
+        };
+        let revision = self.begin(cx);
+        let work = cx.global::<KubeBridge>().namespaces(context);
+        cx.spawn_in(window, async move |this, cx| {
+            let result = work.await;
+            this.update_in(cx, |this, window, cx| {
+                if revision != this.revision {
+                    return;
+                }
+                match result {
+                    Ok(names) => {
+                        let pick = initial_namespace(&names);
+                        let chosen = names.get(pick).cloned();
+                        this.namespaces.update(cx, |select, cx| {
+                            select.set_items(names, window, cx);
+                            select.set_selected_index(
+                                chosen.as_ref().map(|_| IndexPath::new(pick)),
+                                window,
+                                cx,
+                            );
+                        });
+                        match chosen {
+                            Some(name) => this.choose_namespace(name, window, cx),
+                            None => this.fail("This cluster has no namespaces".into(), cx),
+                        }
+                    }
+                    Err(message) => this.fail(message, cx),
+                }
+            })
+            .ok();
+        })
+        .detach();
+    }
+
+    fn choose_namespace(&mut self, name: String, window: &mut Window, cx: &mut Context<Self>) {
+        if self.namespace.as_deref() == Some(name.as_str()) && self.error.is_none() {
+            return;
+        }
+        self.namespace = Some(name);
+        self.load_pods(window, cx);
+    }
+
+    fn load_pods(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let (Some(context), Some(namespace)) = (self.context.clone(), self.namespace.clone())
+        else {
+            return;
+        };
+        let revision = self.begin(cx);
+        let work = cx.global::<KubeBridge>().pods(context, namespace);
+        cx.spawn_in(window, async move |this, cx| {
+            let result = work.await;
+            this.update_in(cx, |this, _, cx| {
+                if revision != this.revision {
+                    return;
+                }
+                match result {
+                    Ok(pods) => {
+                        let rows: Vec<PodRow> = pods.into_iter().map(PodRow::from).collect();
+                        this.table.update(cx, |table, cx| {
+                            table.delegate_mut().set_rows(rows);
+                            table.refresh(cx);
+                        });
+                        this.busy = false;
+                        cx.notify();
+                    }
+                    Err(message) => this.fail(message, cx),
+                }
+            })
+            .ok();
+        })
+        .detach();
+    }
+
+    /// Refresh re-reads the pods of the current scope. It does not re-read
+    /// the pickers: a context that vanished mid-session is a rarer event than
+    /// a pod that did, and it has its own remedy (restart) for now.
+    fn refresh(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.load_pods(window, cx);
+    }
+
+    fn render_toolbar(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let delegate = self.table.read(cx).delegate();
+        let summary: SharedString = match (&self.namespace, self.busy) {
+            (_, true) => "Loading…".into(),
+            (Some(_), false) if delegate.is_empty() => "No pods".into(),
+            (Some(_), false) if delegate.len() == 1 => "1 pod".into(),
+            (Some(_), false) => format!("{} pods", delegate.len()).into(),
+            (None, false) => "".into(),
+        };
+        h_flex()
+            .gap_2()
+            .px_3()
+            .py_2()
+            .border_b_1()
+            .border_color(cx.theme().border)
+            .child(Label::new("Pods").text_sm())
+            // Named for assistive technology as well as for the eye. Without
+            // `accessibility_label` these reached Windows UI Automation as two
+            // ComboBoxes with empty names — measured with AccessKit's bridge,
+            // which is what GPUI exposes on Windows.
+            .child(
+                Select::new(&self.contexts)
+                    .placeholder("Context")
+                    .accessibility_label("Context")
+                    .small()
+                    .w_64(),
+            )
+            .child(
+                Select::new(&self.namespaces)
+                    .placeholder("Namespace")
+                    .accessibility_label("Namespace")
+                    .small()
+                    .w_56(),
+            )
+            .child(div().flex_1())
+            .child(
+                div()
+                    .text_sm()
+                    .text_color(cx.theme().muted_foreground)
+                    .child(summary),
+            )
+            .child(
+                Button::new("refresh")
+                    .outline()
+                    .small()
+                    .label("Refresh")
+                    .loading(self.busy)
+                    .on_click(cx.listener(|this, _, window, cx| this.refresh(window, cx))),
+            )
+    }
+}
+
+impl Render for Workspace {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        v_flex()
+            .size_full()
+            .bg(cx.theme().background)
+            .text_color(cx.theme().foreground)
+            .child(self.render_toolbar(cx))
+            .when_some(self.error.clone(), |this, message| {
+                this.child(
+                    div()
+                        .px_3()
+                        .py_2()
+                        .child(Alert::error("load-error", message)),
+                )
+            })
+            .child(
+                div()
+                    .flex_1()
+                    .min_h_0()
+                    .child(DataTable::new(&self.table).stripe(true).small()),
+            )
+            .children(Root::render_dialog_layer(window, cx))
+            .children(Root::render_sheet_layer(window, cx))
+            .children(Root::render_notification_layer(window, cx))
+    }
+}

--- a/crates/kube/Cargo.toml
+++ b/crates/kube/Cargo.toml
@@ -24,6 +24,13 @@ tokio = { version = "1", features = ["fs", "time", "net", "io-util", "process"] 
 # cluster over loopback the payload is small enough that gzip is a wash
 # either way. Without this feature, kube-rs never sends `Accept-Encoding`.
 kube = { version = "4", default-features = false, features = ["client", "config", "rustls-tls", "ring", "runtime", "ws", "gzip"] }
+# Direct, for `connect::ensure_crypto_provider`: rustls picks a process-wide
+# provider on its own only while exactly ONE is compiled in. A binary that
+# also links something built against `aws-lc-rs` — the GPUI shell does,
+# through its HTTP client — has two, and rustls then panics on the first TLS
+# handshake instead of choosing. This crate names `ring` before it builds a
+# client, so it is correct whatever else the process links.
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 k8s-openapi = { version = "0.28", features = ["v1_34"] }
 futures = "0.3"
 base64 = "0.22"

--- a/crates/kube/src/connect.rs
+++ b/crates/kube/src/connect.rs
@@ -20,6 +20,24 @@ use srelens_capability::{Annotations, Capability, CapabilityError};
 use crate::client_cache::ClientCache;
 use crate::context_resolve::resolve_context;
 
+/// Name `ring` as the process-wide rustls provider, once.
+///
+/// rustls resolves a default provider on its own only while exactly one is
+/// compiled into the process. This crate brings `ring` through kube-rs; a
+/// host that also links a crate built against `aws-lc-rs` — the GPUI shell
+/// does, through GPUI's HTTP client — has two, and `Client::try_from` then
+/// panics on the first TLS config it builds, on whatever thread happened to
+/// build it. Choosing explicitly makes this crate correct regardless of the
+/// binary around it. Idempotent: a second call, or a host that installed one
+/// first, is not an error.
+pub fn ensure_crypto_provider() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        // `Err` means a provider is already installed, which is the state we want.
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
+
 /// Default per-request timeout budget (connect + list/get/apply), in seconds.
 pub const DEFAULT_TIMEOUT_SECS: u64 = 8;
 /// Smallest timeout a user may configure, in seconds.
@@ -276,6 +294,7 @@ pub(crate) async fn config_for_context(paths: &[PathBuf], context: &str) -> Resu
 
 pub(crate) async fn build_client(paths: &[PathBuf], context: &str) -> Result<Client, String> {
     let config = config_for_context(paths, context).await?;
+    ensure_crypto_provider();
     Client::try_from(config).map_err(|e| e.to_string())
 }
 
@@ -346,6 +365,7 @@ pub async fn build_client_with_bearer(
     bearer: &str,
 ) -> Result<Client, String> {
     let config = config_for_context_with_bearer(paths, context, bearer).await?;
+    ensure_crypto_provider();
     Client::try_from(config).map_err(|e| e.to_string())
 }
 
@@ -466,6 +486,7 @@ async fn probe_cluster_from_yaml(yaml: &str, context: &str) -> ClusterInfoOut {
         Ok(c) => c,
         Err(e) => return fail(e.to_string()),
     };
+    ensure_crypto_provider();
     let client = match Client::try_from(config) {
         Ok(c) => c,
         Err(e) => return fail(e.to_string()),
@@ -698,15 +719,19 @@ mod tests {
     use super::*;
 
     /// kube's `rustls-tls` feature no longer selects a crypto provider on its
-    /// own -- kube 4 split `ring` and `aws-lc-rs` out into separate features.
-    /// Without one of them rustls cannot resolve a process-level provider and
-    /// `Client::try_from` panics the first time it builds a TLS config.
-    ///
-    /// This only bites when the crate is built on its own: a workspace build
-    /// unifies `ring` in from a sibling crate and hides it. CI runs the
-    /// kind-bound suites as `cargo test -p srelens-kube`, so guard that.
+    /// own -- kube 4 split `ring` and `aws-lc-rs` out into separate features,
+    /// and rustls resolves one automatically only while exactly ONE is
+    /// compiled in. That held until `apps/gpui` joined the workspace: its
+    /// HTTP client is built against `aws-lc-rs`, a workspace test build then
+    /// links both, and twenty-five of this crate's own tests panicked in
+    /// `Client::try_from` — in CI, not locally, because `-p srelens-kube`
+    /// alone still had one provider. `ensure_crypto_provider` names `ring`
+    /// before every client this crate builds, so the crate is correct in any
+    /// process. This test builds a client the way production does and is
+    /// what fails if that call ever goes missing.
     #[tokio::test]
     async fn building_a_client_selects_a_rustls_crypto_provider() {
+        ensure_crypto_provider();
         let config = kube::Config::new("https://127.0.0.1:6443".parse().expect("uri"));
         Client::try_from(config).expect("client builds without a rustls provider panic");
     }

--- a/crates/kube/src/contexts.rs
+++ b/crates/kube/src/contexts.rs
@@ -1,7 +1,7 @@
 //! The `k8s.listContexts` capability — reads the kubeconfig and returns its
 //! contexts. Surfaced to both the UI and MCP via the shared registry.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use srelens_capability::{Annotations, Capability, CapabilityError};
@@ -86,6 +86,75 @@ pub struct ListContextsOut {
 /// the developer's real config directory. The DIRECTORY is fixed but its
 /// CONTENTS are read on each call, which is what lets a config pasted or
 /// dropped in while the app runs resolve without a restart (#256).
+/// List the contexts across the active kubeconfig files.
+///
+/// The typed door; `list_contexts_capability` is this behind JSON. `additional`
+/// is the capability's optional `paths`: `Some` rebuilds the active set from
+/// `default_paths` plus these; `None` keeps whatever is already active.
+pub async fn list_contexts(
+    cache: &ClientCache,
+    default_paths: Vec<PathBuf>,
+    managed_dir: Option<&Path>,
+    additional: Option<Vec<String>>,
+) -> Result<ListContextsOut, CapabilityError> {
+    // A caller that names its own files rebuilds from the static
+    // defaults; one that doesn't keeps whatever is already active,
+    // so an MCP `{}` call never discards paths the desktop set.
+    let mut paths = match additional {
+        Some(additional) => {
+            let mut paths = default_paths;
+            for path in additional.into_iter().map(PathBuf::from) {
+                if !paths.contains(&path) {
+                    paths.push(path);
+                }
+            }
+            paths
+        }
+        None => cache.paths().await,
+    };
+    // Both branches then reconcile with the disk, so discovery
+    // behaves the same however the capability is invoked.
+    //
+    // Read HERE, not captured at registry-build time: the folder's
+    // contents change while the app runs, and a startup snapshot
+    // would miss anything pasted or dropped in afterwards (#256).
+    if let Some(dir) = managed_dir {
+        for managed in crate::connect::kubeconfig_files_in(dir) {
+            if !paths.contains(&managed) {
+                paths.push(managed);
+            }
+        }
+    }
+    // `default_paths` and the cache seed are both snapshots, so a
+    // kubeconfig deleted while the app runs would otherwise be
+    // reintroduced on every call and sit in the cache forever —
+    // where `load_kubeconfigs` is strict and fails the
+    // merged-resolution fallback on the missing file. Only ABSENT
+    // files are dropped: one that exists but is malformed still
+    // reaches the reader and surfaces its parse error, which the
+    // caller needs to see.
+    paths.retain(|path| path.exists());
+    cache.set_paths(paths).await;
+    // Enumerate every context across all files with duplicate-name
+    // disambiguation, so contexts that share a name (e.g. `default`
+    // across per-cluster kubeconfigs) are all visible and each
+    // resolves to its own file — kube-rs merge would drop them.
+    let paths = cache.paths().await;
+    let resolved = resolve_contexts(&paths);
+    // Resilient to a bad additional file. An empty result is only an
+    // error when *no* kubeconfig could be read at all; a readable file
+    // with zero contexts (e.g. after deleting the last one) is fine.
+    if resolved.is_empty()
+        && !paths.iter().any(|path| kube::config::Kubeconfig::read_from(path).is_ok())
+    {
+        return Err(CapabilityError::Handler(
+            "no kubeconfig contexts could be read".to_string(),
+        ));
+    }
+    let contexts = resolved.into_iter().map(build_context_dto).collect();
+    Ok(ListContextsOut { contexts })
+}
+
 pub fn list_contexts_capability(
     cache: Arc<ClientCache>,
     default_paths: Vec<PathBuf>,
@@ -100,62 +169,7 @@ pub fn list_contexts_capability(
             let default_paths = default_paths.clone();
             let managed_dir = managed_dir.clone();
             async move {
-                // A caller that names its own files rebuilds from the static
-                // defaults; one that doesn't keeps whatever is already active,
-                // so an MCP `{}` call never discards paths the desktop set.
-                let mut paths = match input.paths {
-                    Some(additional) => {
-                        let mut paths = default_paths;
-                        for path in additional.into_iter().map(PathBuf::from) {
-                            if !paths.contains(&path) {
-                                paths.push(path);
-                            }
-                        }
-                        paths
-                    }
-                    None => cache.paths().await,
-                };
-                // Both branches then reconcile with the disk, so discovery
-                // behaves the same however the capability is invoked.
-                //
-                // Read HERE, not captured at registry-build time: the folder's
-                // contents change while the app runs, and a startup snapshot
-                // would miss anything pasted or dropped in afterwards (#256).
-                if let Some(dir) = &managed_dir {
-                    for managed in crate::connect::kubeconfig_files_in(dir) {
-                        if !paths.contains(&managed) {
-                            paths.push(managed);
-                        }
-                    }
-                }
-                // `default_paths` and the cache seed are both snapshots, so a
-                // kubeconfig deleted while the app runs would otherwise be
-                // reintroduced on every call and sit in the cache forever —
-                // where `load_kubeconfigs` is strict and fails the
-                // merged-resolution fallback on the missing file. Only ABSENT
-                // files are dropped: one that exists but is malformed still
-                // reaches the reader and surfaces its parse error, which the
-                // caller needs to see.
-                paths.retain(|path| path.exists());
-                cache.set_paths(paths).await;
-                // Enumerate every context across all files with duplicate-name
-                // disambiguation, so contexts that share a name (e.g. `default`
-                // across per-cluster kubeconfigs) are all visible and each
-                // resolves to its own file — kube-rs merge would drop them.
-                let paths = cache.paths().await;
-                let resolved = resolve_contexts(&paths);
-                // Resilient to a bad additional file. An empty result is only an
-                // error when *no* kubeconfig could be read at all; a readable file
-                // with zero contexts (e.g. after deleting the last one) is fine.
-                if resolved.is_empty()
-                    && !paths.iter().any(|path| kube::config::Kubeconfig::read_from(path).is_ok())
-                {
-                    return Err(CapabilityError::Handler(
-                        "no kubeconfig contexts could be read".to_string(),
-                    ));
-                }
-                let contexts = resolved.into_iter().map(build_context_dto).collect();
-                Ok(ListContextsOut { contexts })
+                list_contexts(&cache, default_paths, managed_dir.as_deref(), input.paths).await
             }
         },
     )

--- a/crates/kube/src/manifest.rs
+++ b/crates/kube/src/manifest.rs
@@ -1008,6 +1008,7 @@ mod tests {
             }
         });
         let config = kube::Config::new(format!("http://{addr}").parse().unwrap());
+        crate::connect::ensure_crypto_provider();
         (kube::Client::try_from(config).unwrap(), seen)
     }
 

--- a/crates/kube/src/pod_count.rs
+++ b/crates/kube/src/pod_count.rs
@@ -214,6 +214,7 @@ mod pod_count_tests {
             }
         });
         let config = Config::new(format!("http://{addr}").parse().unwrap());
+        crate::connect::ensure_crypto_provider();
         (Client::try_from(config).unwrap(), handle, seen)
     }
 
@@ -346,6 +347,7 @@ mod pod_count_tests {
             }
         });
         let config = Config::new(format!("http://{addr}").parse().unwrap());
+        crate::connect::ensure_crypto_provider();
         let client = Client::try_from(config).unwrap();
 
         let err = count_pods(client, Duration::from_millis(50)).await.unwrap_err();

--- a/crates/kube/src/pod_overview.rs
+++ b/crates/kube/src/pod_overview.rs
@@ -567,7 +567,10 @@ mod pod_overview_tests {
         });
         let config = Config::new(format!("http://{addr}").parse().unwrap());
         Server {
-            client: Client::try_from(config).unwrap(),
+            client: {
+                crate::connect::ensure_crypto_provider();
+                Client::try_from(config).unwrap()
+            },
             handle,
             seen,
         }
@@ -877,6 +880,7 @@ mod pod_overview_tests {
             }
         });
         let config = Config::new(format!("http://{addr}").parse().unwrap());
+        crate::connect::ensure_crypto_provider();
         let client = Client::try_from(config).unwrap();
 
         let out = overview(client, Duration::from_secs(5)).await.unwrap();
@@ -920,6 +924,7 @@ mod pod_overview_tests {
             }
         });
         let config = Config::new(format!("http://{addr}").parse().unwrap());
+        crate::connect::ensure_crypto_provider();
         let client = Client::try_from(config).unwrap();
 
         let err = overview(client, Duration::from_millis(50)).await.unwrap_err();

--- a/crates/kube/src/workloads.rs
+++ b/crates/kube/src/workloads.rs
@@ -72,6 +72,31 @@ fn handler_err(e: impl ToString) -> CapabilityError {
     CapabilityError::Handler(e.to_string())
 }
 
+/// List namespace names in a connected context.
+///
+/// The typed door. `list_namespaces_capability` is this behind JSON for the
+/// registry; a Rust caller in the same process — the GPUI shell — calls this
+/// and never sees a `Value`. One body, so the two cannot drift, and no field
+/// name to misspell between them (which is how `k8s.openApiSchema` was dead
+/// for every release: its struct and its callers disagreed on one key).
+pub async fn list_namespaces(
+    cache: &ClientCache,
+    context: &str,
+) -> Result<ListNamespacesOut, CapabilityError> {
+    let client = cache.get(context).await.map_err(CapabilityError::Handler)?;
+    let api: Api<Namespace> = Api::all(client);
+    let list = tokio::time::timeout(request_timeout(), api.list(&ListParams::default()))
+        .await
+        .map_err(|_| CapabilityError::Handler("list namespaces timed out".into()))?
+        .map_err(handler_err)?;
+    let namespaces = list
+        .items
+        .into_iter()
+        .filter_map(|ns| ns.metadata.name)
+        .collect();
+    Ok(ListNamespacesOut { namespaces })
+}
+
 /// `k8s.listNamespaces` — list namespace names in a connected context.
 pub fn list_namespaces_capability(cache: Arc<ClientCache>) -> Capability {
     Capability::typed::<ListNamespacesIn, ListNamespacesOut, _, _>(
@@ -80,23 +105,7 @@ pub fn list_namespaces_capability(cache: Arc<ClientCache>) -> Capability {
         Annotations::READ_ONLY,
         move |input: ListNamespacesIn| {
             let cache = cache.clone();
-            async move {
-                let client = cache
-                    .get(&input.context)
-                    .await
-                    .map_err(CapabilityError::Handler)?;
-                let api: Api<Namespace> = Api::all(client);
-                let list = tokio::time::timeout(request_timeout(), api.list(&ListParams::default()))
-                    .await
-                    .map_err(|_| CapabilityError::Handler("list namespaces timed out".into()))?
-                    .map_err(handler_err)?;
-                let namespaces = list
-                    .items
-                    .into_iter()
-                    .filter_map(|ns| ns.metadata.name)
-                    .collect();
-                Ok(ListNamespacesOut { namespaces })
-            }
+            async move { list_namespaces(&cache, &input.context).await }
         },
     )
 }
@@ -167,6 +176,25 @@ pub(crate) fn summarise_pod(pod: Pod) -> PodSummary {
 }
 
 /// `k8s.listPods` — list pods in a namespace of a connected context.
+/// List the pods of one namespace (`""` for all) in a connected context.
+///
+/// The typed door; see `list_namespaces` for why it exists beside the
+/// capability rather than inside it.
+pub async fn list_pods(
+    cache: &ClientCache,
+    context: &str,
+    namespace: &str,
+) -> Result<ListPodsOut, CapabilityError> {
+    let client = cache.get(context).await.map_err(CapabilityError::Handler)?;
+    let api: Api<Pod> = crate::scoped_api(client, namespace);
+    let list = tokio::time::timeout(request_timeout(), api.list(&ListParams::default()))
+        .await
+        .map_err(|_| CapabilityError::Handler("list pods timed out".into()))?
+        .map_err(handler_err)?;
+    let pods = list.items.into_iter().map(summarise_pod).collect();
+    Ok(ListPodsOut { pods })
+}
+
 pub fn list_pods_capability(cache: Arc<ClientCache>) -> Capability {
     Capability::typed::<ListPodsIn, ListPodsOut, _, _>(
         "k8s.listPods",
@@ -174,19 +202,7 @@ pub fn list_pods_capability(cache: Arc<ClientCache>) -> Capability {
         Annotations::READ_ONLY,
         move |input: ListPodsIn| {
             let cache = cache.clone();
-            async move {
-                let client = cache
-                    .get(&input.context)
-                    .await
-                    .map_err(CapabilityError::Handler)?;
-                let api: Api<Pod> = crate::scoped_api(client, &input.namespace);
-                let list = tokio::time::timeout(request_timeout(), api.list(&ListParams::default()))
-                    .await
-                    .map_err(|_| CapabilityError::Handler("list pods timed out".into()))?
-                    .map_err(handler_err)?;
-                let pods = list.items.into_iter().map(summarise_pod).collect();
-                Ok(ListPodsOut { pods })
-            }
+            async move { list_pods(&cache, &input.context, &input.namespace).await }
         },
     )
 }

--- a/docs/design/gpui-kit-feasibility.md
+++ b/docs/design/gpui-kit-feasibility.md
@@ -133,9 +133,10 @@ arguing about:
   says "one Rust codebase to macOS, Windows, and Linux" and never mentions the
   browser, and why the skills treat wasm as a set of differences to work
   around rather than a headline. It also means the browser path depends on
-  one company keeping a divergence from upstream alive. The one concrete rough edge I found — `std::time::Instant` is
-  unimplemented on `wasm32`, so scroll axis-locking had to be disabled in the
-  browser to stop a panic — is the kind of thing a quiet target has more of.
+  one company keeping a divergence from upstream alive. The one concrete
+  rough edge I found — `std::time::Instant` is unimplemented on `wasm32`, so
+  scroll axis-locking had to be disabled in the browser to stop a panic — is
+  the kind of thing a quiet target has more of.
 - *WebGPU narrows reach.* Today's web mode is a React app: it opens in
   anything. A WebGPU build needs a browser that has WebGPU on, which is not a
   given in locked-down enterprise fleets or older Safari. For a tool aimed at

--- a/docs/design/gpui-kit-feasibility.md
+++ b/docs/design/gpui-kit-feasibility.md
@@ -3,7 +3,8 @@
 **Verdict: not as a migration, yes as a bounded experiment.** The technical
 fit is better than it looks from the outside, and the project cost is worse.
 The blocker is not GPUI Kit; it is that srelens would be carrying three user
-interfaces instead of two, and would lose the browser.
+interfaces instead of two, and that the browser build gives back the one
+boundary whose removal is the whole financial case.
 
 What follows is measured rather than estimated. Every number in it came from
 this repository or from the GPUI Kit skills, both read on 2026-09-06.
@@ -55,12 +56,22 @@ IPC boundary into `crates/kube` and back, plus the types to describe what
 crosses. In a GPUI application that boundary does not exist: a screen calls
 the capability directly.
 
-So `packages/core` is not ported. It is **deleted**. That is the one place in
-this exercise where the work goes down rather than up, and it is a real 11k
-lines. It also removes a whole class of bug this codebase has actually had —
-the `api_version` / `apiVersion` mismatch that killed schema autocomplete in
-both designs for every release was a defect that can only exist because there
-is a JSON boundary in the middle. Direct calls are typed end to end.
+So `packages/core` is not ported. It is **deleted** — on the desktop. That
+is the one place in this exercise where the work goes down rather than up, and
+it is a real 11k lines. It also removes a whole class of bug this codebase has
+actually had — the `api_version` / `apiVersion` mismatch that killed schema
+autocomplete in both designs for every release was a defect that can only
+exist because there is a JSON boundary in the middle. Direct calls are typed
+end to end.
+
+**The browser build does not get this.** See §4: a GPUI app compiled to
+WebAssembly runs in the browser, but `crates/kube` does not — the kube
+client, kubeconfigs, exec plugins and TLS all stay on the server. So the
+browser build needs an RPC client to `crates/server`, which is `core`
+again, in Rust. It would be smaller than 11k lines and it could share types
+with the server crate rather than hand-mirroring them, which is a genuine
+improvement over today. But the boundary is back, and with it the class of
+bug. The deletion is a desktop win only.
 
 The second argument is performance, and it is not theoretical here. The
 topology screen was reworked twice for lag, and the resource lists are
@@ -102,12 +113,40 @@ because they would have changed the verdict in the wrong direction:
 about punctuation. Zed has an alacritty-backed terminal, but it is not part of
 `gpui-kit`. This is build-it-or-vendor-it, and it is not small.
 
-**Web mode dies.** `crates/server` is 7,784 lines that exist to serve this
-frontend into a browser, with a Docker image and `docs/WEB.md` behind it. GPUI
-is native only — macOS, Windows, Linux. Moving ui-next to GPUI means either
-dropping browser access as a product capability, or keeping the React frontend
-alive forever to serve it. That is a product decision, not an engineering one,
-and it should be made before any code is written.
+**Web mode is possible, and it is the least proven path.** An earlier draft
+of this document called GPUI native-only. That was wrong, and the correction
+was sitting in the installed skills: the coding guides list "macOS / Windows /
+Linux / wasm" as the platform axis and say to "preserve platform/wasm
+differences when an API is not portable". GPUI compiles to `wasm32` and
+renders through WebGPU in the browser, and gpui-component's own gallery ships
+that way.
+
+Three things temper it, all worth carrying into the experiment rather than
+arguing about:
+
+- *It is the quiet target, and it is a fork's.* Upstream GPUI — the one Zed
+  ships — does not run in a browser. Zed's own discussion of it has "no work
+  on wasm support" in mid-2024, lists "Zed on the web" as a milestone beyond
+  1.0, and by February 2026 the maintainers were redirecting the question to
+  Discord. The browser target that gpui-kit exercises therefore lives in
+  Longbridge's line of GPUI, not Zed's. That is why the gpui-component README
+  says "one Rust codebase to macOS, Windows, and Linux" and never mentions the
+  browser, and why the skills treat wasm as a set of differences to work
+  around rather than a headline. It also means the browser path depends on
+  one company keeping a divergence from upstream alive. The one concrete rough edge I found — `std::time::Instant` is
+  unimplemented on `wasm32`, so scroll axis-locking had to be disabled in the
+  browser to stop a panic — is the kind of thing a quiet target has more of.
+- *WebGPU narrows reach.* Today's web mode is a React app: it opens in
+  anything. A WebGPU build needs a browser that has WebGPU on, which is not a
+  given in locked-down enterprise fleets or older Safari. For a tool aimed at
+  operators on whatever machine is in front of them, that is a real regression
+  to weigh against the rendering speed.
+- *The RPC boundary returns* (§2). `crates/server` at 7,784 lines stays,
+  and the browser build needs a typed client for it. The desktop's strongest
+  argument does not carry across.
+
+So browser access is not the blocker it looked like. It is the part of the
+experiment most likely to surprise, and it has to be in the experiment.
 
 **A third interface.** The classic-to-ui-next migration is *not finished*:
 `design.ts` lists 19 ported routes and `apps/desktop/src` is still 23,871
@@ -144,9 +183,12 @@ scrolling, the namespace picker, the row menu, and it calls `crates/kube`
 directly — so it also proves or disproves the "delete `packages/core`" claim,
 which is the whole financial case.
 
-Build it as its own binary against the existing crates. Do not wire it into
-the Tauri app, do not put it behind a feature flag in the shipping product,
-and do not port a second screen until the first has answered:
+Build it as its own binary against the existing crates, **and build the
+same screen for `wasm32` against `crates/server`**, because the browser
+build is where this toolkit is least proven and where the desktop's best
+argument stops applying. Do not wire either into the Tauri app, do not put
+them behind a feature flag in the shipping product, and do not port a second
+screen until the first has answered:
 
 1. How many lines is the list screen in GPUI versus its 43k-line neighbourhood
    in ui-next?
@@ -156,15 +198,19 @@ and do not port a second screen until the first has answered:
 4. What does the accessibility tree expose, checked with a real screen reader
    on Windows and macOS?
 5. How much of `ui-kit`'s token system survives GPUI Kit's own design guides?
+6. Does the `wasm32` build open, scroll and render the list in the browsers
+   the web mode is actually used from — measured on WebGPU availability,
+   bundle size and first paint against today's React build?
+7. How big is the Rust RPC client the browser build needs, and can it share
+   types with `crates/server` instead of mirroring them?
 
 If the answers are good, the migration is a real option and there is a number
-to put on it. If they are not, the cost of finding out was one screen.
+to put on it. If they are not, the cost of finding out was one screen, twice.
 
-**Two things to settle first, because they are not engineering questions:**
-whether browser access is expendable, and whether the classic design gets
-retired before another interface starts. If browser access stays, this is a
-second frontend forever, and the answer is no regardless of how good the
-prototype looks.
+**One thing to settle first, because it is not an engineering question:**
+whether the classic design gets retired before another interface starts.
+Three shipping UIs is the failure mode this repository has already met at a
+smaller scale.
 
 ---
 

--- a/docs/design/gpui-kit-feasibility.md
+++ b/docs/design/gpui-kit-feasibility.md
@@ -102,9 +102,20 @@ because they would have changed the verdict in the wrong direction:
   single-threaded deterministic executor. Not Testing Library, but not a gap.
 - *Accessibility.* The coding guides direct you to test "through the
   accessibility tree by role, label, value, enabled state, focus, and
-  selection". There is a semantic tree. Given how much this codebase has
-  invested in aria roles, live regions and a 7:1 contrast promise, an absent
-  one would have been disqualifying on its own.
+  selection". There is a tree, and it reaches the OS: on Windows the window
+  reports itself to UI Automation as framework `AccessKit`, and the first
+  screen (§7) exposed its two pickers as ComboBoxes and its Refresh as a
+  Button. Two things measured against it, both worth knowing: the pickers
+  arrived with **empty names** until the app set `accessibility_label` —
+  names are the application's job, as they are in HTML — and the
+  `DataTable` **did not appear in the tree at all**. The pickers also
+  advertise UI Automation's `ExpandCollapse` pattern, and calling it left
+  them collapsed with no option ever entering the tree — declared, not
+  honoured. A list screen whose list is invisible to a screen reader, behind
+  a picker a screen reader cannot open, is not shippable to the readers this
+  codebase's 7:1 promise was made for. Whether those are gaps in this
+  toolkit version or in AccessKit's Windows adapter is the first thing the
+  experiment should run down, before any second screen.
 
 ## 4. What has no answer
 

--- a/docs/design/gpui-kit-feasibility.md
+++ b/docs/design/gpui-kit-feasibility.md
@@ -1,0 +1,182 @@
+# Moving ui-next to GPUI Kit — a feasibility
+
+**Verdict: not as a migration, yes as a bounded experiment.** The technical
+fit is better than it looks from the outside, and the project cost is worse.
+The blocker is not GPUI Kit; it is that srelens would be carrying three user
+interfaces instead of two, and would lose the browser.
+
+What follows is measured rather than estimated. Every number in it came from
+this repository or from the GPUI Kit skills, both read on 2026-09-06.
+
+---
+
+## 1. What we would be moving
+
+| | files | lines (no tests) |
+| --- | ---: | ---: |
+| `packages/ui-next` | 131 | 43,197 |
+| `packages/ui-kit` | 89 | 13,786 |
+| `packages/core` (TypeScript service layer) | 95 | 11,375 |
+| `apps/desktop/src` (classic, frozen but shipping) | — | 23,871 |
+| **frontend total** | | **92,229** |
+
+And the part that is easy to forget:
+
+| | files | lines |
+| --- | ---: | ---: |
+| `packages/ui-next` tests | 111 | 49,074 |
+
+Those tests are not filler. Nearly every one of them names the defect it
+exists to prevent — a stale namespace picker, a dialog that followed the
+cluster rail, a diff that printed a whole document to show one line. They are
+the project's memory. They do not port; they would be rewritten, and the
+reasoning in them is what would be at risk.
+
+Against that, the Rust already in the tree:
+
+| crate | lines |
+| --- | ---: |
+| `kube` | 25,902 |
+| `mcp` | 8,348 |
+| `server` | 7,784 |
+| `registry` | 2,317 |
+| `streams` | 2,697 |
+| `llm` | 2,129 |
+| `agent` | 1,845 |
+| `capability` | 244 |
+| `apps/desktop/src-tauri` | 10,514 |
+| **total** | **61,780** |
+
+## 2. The strongest argument for it
+
+**The service layer is already Rust, and `packages/core` exists only to reach
+it.** All 11,375 lines of it are wrappers that marshal a call across the Tauri
+IPC boundary into `crates/kube` and back, plus the types to describe what
+crosses. In a GPUI application that boundary does not exist: a screen calls
+the capability directly.
+
+So `packages/core` is not ported. It is **deleted**. That is the one place in
+this exercise where the work goes down rather than up, and it is a real 11k
+lines. It also removes a whole class of bug this codebase has actually had —
+the `api_version` / `apiVersion` mismatch that killed schema autocomplete in
+both designs for every release was a defect that can only exist because there
+is a JSON boundary in the middle. Direct calls are typed end to end.
+
+The second argument is performance, and it is not theoretical here. The
+topology screen was reworked twice for lag, and the resource lists are
+virtualized by hand. GPUI Kit ships `DataTable` and `VirtualList` built for
+"hundreds of thousands of rows", GPU-composited. That is squarely the shape of
+this app.
+
+## 3. What GPUI Kit actually covers
+
+Read from the installed skills rather than the marketing page.
+
+**Covered, and well:** Button, Input, Select, Combobox, Checkbox, Switch,
+Radio, Icon, Dialog, AlertDialog, Notification, Tabs, Tooltip, Form, a
+searchable virtualized List, DataTable with resizable and sortable columns,
+DockArea with draggable tabs, charts, Markdown rendering, and a rope-backed
+code editor with Tree-sitter highlighting and LSP diagnostics.
+
+That last one matters more than it sounds. The manifest editor is one of the
+larger things in ui-next and it is CodeMirror plus our own lint, completion
+and diff plumbing. GPUI Kit's editor arrives with the highlighting and
+diagnostics already attached.
+
+**Two assumptions I had going in were wrong**, and both are worth correcting
+because they would have changed the verdict in the wrong direction:
+
+- *Testing.* GPUI has a real framework, documented across 741 lines:
+  `#[gpui_kit::test]`, `TestAppContext`, `VisualTestContext`, and a
+  single-threaded deterministic executor. Not Testing Library, but not a gap.
+- *Accessibility.* The coding guides direct you to test "through the
+  accessibility tree by role, label, value, enabled state, focus, and
+  selection". There is a semantic tree. Given how much this codebase has
+  invested in aria roles, live regions and a 7:1 contrast promise, an absent
+  one would have been disqualifying on its own.
+
+## 4. What has no answer
+
+**No terminal.** `Terminals.tsx` and the pod shell are xterm. The word
+"terminal" appears exactly once across all 27 installed skill files, and it is
+about punctuation. Zed has an alacritty-backed terminal, but it is not part of
+`gpui-kit`. This is build-it-or-vendor-it, and it is not small.
+
+**Web mode dies.** `crates/server` is 7,784 lines that exist to serve this
+frontend into a browser, with a Docker image and `docs/WEB.md` behind it. GPUI
+is native only — macOS, Windows, Linux. Moving ui-next to GPUI means either
+dropping browser access as a product capability, or keeping the React frontend
+alive forever to serve it. That is a product decision, not an engineering one,
+and it should be made before any code is written.
+
+**A third interface.** The classic-to-ui-next migration is *not finished*:
+`design.ts` lists 19 ported routes and `apps/desktop/src` is still 23,871
+lines of shipping React. Adding GPUI now means three UIs in one repository,
+each needing the same bug fixed three times. This project already has a
+written scar from exactly that failure mode at a smaller scale — the shell
+pieces `Resources` and `Workloads` duplicated, where "a batch of fixes landed
+on one that never reached the other".
+
+**The design system is ours.** `ui-kit` is 13,786 lines built on Radix and
+cmdk with a token system of five themes, five accents and three densities,
+pinned by contrast tests. GPUI Kit brings its own components *and its own
+normative design guides*, which are a requirement rather than inspiration.
+Adopting it is adopting somebody else's design language, or fighting it.
+
+## 5. Cost
+
+Roughly 57,000 lines of UI to re-express (`ui-next` plus `ui-kit`), minus what
+GPUI Kit's components absorb, plus a terminal, plus rewriting 49,000 lines of
+tests into a different framework, plus running two or three frontends during
+the transition. Rust UI code is not more compact than JSX.
+
+There is no honest version of this that is a quarter of work. It is the
+largest thing this repository would have ever done, larger than the
+classic-to-ui-next migration currently in flight and unfinished.
+
+## 6. Recommendation
+
+**Do not start a migration. Do one screen, on purpose, to get real numbers.**
+
+The resource list is the right subject. It is the spine of the app, it is
+where the performance complaints live, it exercises `DataTable`, virtual
+scrolling, the namespace picker, the row menu, and it calls `crates/kube`
+directly — so it also proves or disproves the "delete `packages/core`" claim,
+which is the whole financial case.
+
+Build it as its own binary against the existing crates. Do not wire it into
+the Tauri app, do not put it behind a feature flag in the shipping product,
+and do not port a second screen until the first has answered:
+
+1. How many lines is the list screen in GPUI versus its 43k-line neighbourhood
+   in ui-next?
+2. Does calling `crates/kube` directly actually delete the `core` wrapper, or
+   does an equivalent adapter grow back?
+3. Do 5,000 pods scroll better than they do today, measured, not felt?
+4. What does the accessibility tree expose, checked with a real screen reader
+   on Windows and macOS?
+5. How much of `ui-kit`'s token system survives GPUI Kit's own design guides?
+
+If the answers are good, the migration is a real option and there is a number
+to put on it. If they are not, the cost of finding out was one screen.
+
+**Two things to settle first, because they are not engineering questions:**
+whether browser access is expendable, and whether the classic design gets
+retired before another interface starts. If browser access stays, this is a
+second frontend forever, and the answer is no regardless of how good the
+prototype looks.
+
+---
+
+## Appendix: the skills
+
+Installed at `.claude/skills/`, from
+`longbridge/gpui-component` on GitHub:
+
+- `gpui-kit/` — SKILL.md plus 24 references covering components, GPUI
+  mechanics (actions, async, contexts, elements, entities, events, focus,
+  globals, layout) and testing.
+- `gpui-kit-design-guides/` — SKILL.md plus the normative design guide.
+
+27 files, 376 KB. GPUI Kit is Apache-2.0, by Longbridge, built on Zed's GPUI;
+version 0.6.0 at the time of writing.


### PR DESCRIPTION
> **Draft.** The first increment of the GPUI Kit migration, built the way `docs/design/gpui-kit-feasibility.md` asked: one screen, its own binary, against the existing crates, to find out what the rest would cost. Not wired into the shipping app.

## What it is

`apps/gpui` — a GPUI Kit window that lists the pods of one namespace on one context. Context picker, namespace picker, a `DataTable` with sortable Name / Status / Restarts, a status cell that says `CrashLoopBackOff` in the danger tone where the phase alone would say `Running`, Refresh, and the empty / loading / failed states.

Verified against a live kind cluster on the author's machine: an empty namespace shows its empty state; the `broken` namespace shows ImagePullBackOff and CrashLoopBackOff (3258 restarts) in red and a Pending pod muted.

## What it needed from the tree

`crates/kube` gains typed doors — `list_contexts`, `list_namespaces`, `list_pods` — and the JSON capabilities now call them. One body, two callers. **The shell calls the crates directly; there is no `packages/core` counterpart and no `Value` between the window and the cluster.** That is the claim the feasibility rested on, and it holds on the desktop.

## What it cost to learn

Each is written where the next person will look (module docs, `AGENTS.md`, the feasibility). Two of them only surfaced in CI, which is the point of having it.

- **Two rustls crypto providers in one process — and the fix belongs in `crates/kube`, not the binary.** kube-rs brings `ring`, GPUI's HTTP client brings `aws-lc-rs`; rustls picks a provider by itself only while exactly one is compiled in. The first version installed `ring` in the GPUI binary's `main`. CI then failed 25 of *kube's own* tests, because a workspace test build links both providers into kube's test process too, and `cargo test -p srelens-kube` alone could never see it. `connect::ensure_crypto_provider` now names `ring` before every client the crate builds; the GPUI binary calls that. One owner, correct in any process.
- **The runner lacked one library.** GPUI's Linux backend links xcb, fontconfig, freetype, xkbcommon and xkbcommon-x11; ubuntu-22.04 had all but the last. One apt package.
- **`use super::*` in a test module under `use gpui_kit::*` breaks `#[test]`** — the glob carries a `test` macro that expands into itself. Imports are named.
- **Accessibility, measured rather than assumed.** The window reaches Windows UI Automation through AccessKit. The pickers arrived nameless until given `accessibility_label`; the `DataTable` does not appear in the tree at all; the pickers' `ExpandCollapse` pattern is declared and does nothing. This is the first thing to run down before a second screen, and the feasibility says so.

## Verification

- CI green on `a3eb5d4`: frontend, backend, smoke. Coverage **88.33 %** lines against the 85 % floor, with the shell's window-bound files (`main.rs`, `workspace.rs`, `kube_bridge.rs`) excluded on the same grounds as the Tauri entry point and the server binary; `pods_table.rs` counts and is tested.
- `cargo test -p srelens-gpui`: 5 passing. `cargo test -p srelens-kube` with gpui in the same feature resolution — the exact CI condition — 509 passing; the eight left are PATH-resolution tests that fail on Windows on `dev` too.
- One frontend run failed on `Topology › pans and zooms by moving one composited layer`, a test that has flaked locally too and passed on the run before and after with no frontend change between. Flagged separately.

## Not in this increment

Per-row actions, live watch, the filter box, and the context's own declared namespace as the starting namespace (a `SRELENS_GPUI_NAMESPACE` override stands in for verification). Each is a deliberate stop: the increment is about whether the list is right and what the toolkit costs, not about breadth.
