### PR TITLE
test(e2e): exercise k8s.queryPodEndpoint so #433's coverage gate passes

### DIFF
--- a/apps/desktop/src-tauri/tests/e2e.rs
+++ b/apps/desktop/src-tauri/tests/e2e.rs
@@ -1559,7 +1559,7 @@ async fn run_suite() {
             )
             .await
         {
-            Ok(v) if v["status_code"] == 200 => break v,
+            Ok(v) if v["statusCode"] == 200 => break v,
             Ok(v) if Instant::now() > dl => {
                 panic!("queryPodEndpoint never got HTTP 200 from {HTTP_DEPLOY}: {v}")
             }
@@ -1595,7 +1595,7 @@ async fn run_suite() {
         "the sample line must come back exactly as served: {out}"
     );
     assert_eq!(
-        out["total_lines"],
+        out["totalLines"],
         json!(lines.len()),
         "with no filter and no cap, total and returned agree: {out}"
     );
@@ -1612,22 +1612,22 @@ async fn run_suite() {
             "k8s.queryPodEndpoint",
             json!({
                 "context": ctx, "namespace": NS, "pod": http_pod,
-                "port": 8080, "path": "metrics", "filter": "e2e_up", "max_lines": 1
+                "port": 8080, "path": "metrics", "filter": "e2e_up", "maxLines": 1
             }),
         )
         .await;
-    assert_eq!(out["status_code"], json!(200), "{out}");
+    assert_eq!(out["statusCode"], json!(200), "{out}");
     assert_eq!(
         out["path"], "/metrics",
         "a bare path gets its leading slash: {out}"
     );
     assert_eq!(
-        out["total_lines"],
+        out["totalLines"],
         json!(2),
         "the filter is a substring match over every line: {out}"
     );
     assert_eq!(
-        out["returned_lines"],
+        out["returnedLines"],
         json!(1),
         "max_lines caps what comes back: {out}"
     );
@@ -1645,7 +1645,7 @@ async fn run_suite() {
             json!({ "context": ctx, "namespace": NS, "pod": http_pod, "path": "/nope" }),
         )
         .await;
-    assert_eq!(out["status_code"], json!(404), "{out}");
+    assert_eq!(out["statusCode"], json!(404), "{out}");
 
     // A selector nothing matches is a clean error, not an 8-second timeout.
     let msg = h

--- a/apps/desktop/src-tauri/tests/e2e.rs
+++ b/apps/desktop/src-tauri/tests/e2e.rs
@@ -42,6 +42,10 @@ use srelens_kube::client_cache::ClientCache;
 
 const NS: &str = "srelens-e2e";
 const DEPLOY: &str = "e2e-web";
+/// The one fixture that actually listens on a port: busybox's httpd serving a
+/// two-line /metrics, for `k8s.queryPodEndpoint`. Separate from {DEPLOY} so
+/// the log and relation cases keep their exact pod counts and output.
+const HTTP_DEPLOY: &str = "e2e-http";
 const SVC: &str = "e2e-web";
 const HEADLESS_SVC: &str = "e2e-headless";
 const CM: &str = "e2e-config";
@@ -259,6 +263,31 @@ spec:
       - name: app
         image: busybox:1.36
         command: ["sh", "-c", "while true; do echo hello; sleep 5; done"]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {HTTP_DEPLOY}
+  namespace: {NS}
+  labels:
+    app: {HTTP_DEPLOY}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {HTTP_DEPLOY}
+  template:
+    metadata:
+      labels:
+        app: {HTTP_DEPLOY}
+    spec:
+      containers:
+      - name: app
+        image: busybox:1.36
+        command: ["sh", "-c", "mkdir -p /www && echo ok > /www/index.html && {{ echo '# HELP e2e_up 1 when the fixture serves'; echo 'e2e_up 1'; }} > /www/metrics && exec httpd -f -p 8080 -h /www"]
+        ports:
+        - name: http
+          containerPort: 8080
 ---
 apiVersion: v1
 kind: Service
@@ -1516,6 +1545,117 @@ async fn run_suite() {
     // new cluster state: the fixtures create only a Deployment (no
     // directly-named pod), so any pod used here has to be discovered via
     // listPods the same way the logs check above does.
+    // === queryPodEndpoint: a real GET through an API-server port-forward ====
+    println!("=== queryPodEndpoint ===");
+    // The fixture pod can be Running a beat before httpd is listening, and a
+    // port-forward to a closed port comes back as a clean error — so poll the
+    // capability itself rather than the pod phase, never a blind sleep.
+    let dl = deadline(120);
+    let out = loop {
+        match h
+            .try_call(
+                "k8s.queryPodEndpoint",
+                json!({ "context": ctx, "namespace": NS, "selector": format!("app={HTTP_DEPLOY}") }),
+            )
+            .await
+        {
+            Ok(v) if v["status_code"] == 200 => break v,
+            Ok(v) if Instant::now() > dl => {
+                panic!("queryPodEndpoint never got HTTP 200 from {HTTP_DEPLOY}: {v}")
+            }
+            Err(e) if Instant::now() > dl => {
+                panic!("queryPodEndpoint never reached {HTTP_DEPLOY}: {e}")
+            }
+            _ => poll_sleep().await,
+        }
+    };
+    h.mark("k8s.queryPodEndpoint");
+    // Nothing but a selector: the named `http` container port must be found
+    // on its own, the default path must be /metrics, and the body must reach
+    // the caller intact through the tunnel.
+    assert!(
+        out["pod"]
+            .as_str()
+            .unwrap_or_default()
+            .starts_with(&format!("{HTTP_DEPLOY}-")),
+        "the selector must resolve to a fixture pod: {out}"
+    );
+    assert_eq!(
+        out["port"],
+        json!(8080),
+        "the declared container port must be auto-detected: {out}"
+    );
+    assert_eq!(
+        out["path"], "/metrics",
+        "the default path is /metrics: {out}"
+    );
+    let lines = out["metrics"].as_array().unwrap();
+    assert!(
+        lines.iter().any(|l| l == "e2e_up 1"),
+        "the sample line must come back exactly as served: {out}"
+    );
+    assert_eq!(
+        out["total_lines"],
+        json!(lines.len()),
+        "with no filter and no cap, total and returned agree: {out}"
+    );
+    println!(
+        "queryPodEndpoint: {}",
+        out["summary"].as_str().unwrap_or_default()
+    );
+
+    // By pod name, explicit port, a path missing its slash, a filter and a cap:
+    // both served lines mention e2e_up, so total is 2 and the cap returns one.
+    let http_pod = out["pod"].as_str().unwrap().to_string();
+    let out = h
+        .ok(
+            "k8s.queryPodEndpoint",
+            json!({
+                "context": ctx, "namespace": NS, "pod": http_pod,
+                "port": 8080, "path": "metrics", "filter": "e2e_up", "max_lines": 1
+            }),
+        )
+        .await;
+    assert_eq!(out["status_code"], json!(200), "{out}");
+    assert_eq!(
+        out["path"], "/metrics",
+        "a bare path gets its leading slash: {out}"
+    );
+    assert_eq!(
+        out["total_lines"],
+        json!(2),
+        "the filter is a substring match over every line: {out}"
+    );
+    assert_eq!(
+        out["returned_lines"],
+        json!(1),
+        "max_lines caps what comes back: {out}"
+    );
+    assert_eq!(
+        out["metrics"],
+        json!(["# HELP e2e_up 1 when the fixture serves"]),
+        "the cap keeps the first matching lines: {out}"
+    );
+
+    // A path the server does not have is a successful query with a 404 in
+    // it, not an error: the status code is the answer.
+    let out = h
+        .ok(
+            "k8s.queryPodEndpoint",
+            json!({ "context": ctx, "namespace": NS, "pod": http_pod, "path": "/nope" }),
+        )
+        .await;
+    assert_eq!(out["status_code"], json!(404), "{out}");
+
+    // A selector nothing matches is a clean error, not an 8-second timeout.
+    let msg = h
+        .err(
+            "k8s.queryPodEndpoint",
+            json!({ "context": ctx, "namespace": NS, "selector": "app=nothing-has-this-label" }),
+        )
+        .await;
+    assert!(msg.contains("No running pods"), "{msg}");
+
     println!("=== mcp resources (#24) ===");
     mcp_resource_reads(&ctx, &pod_name).await;
     mcp_resource_subscription(&ctx, &pod_name).await;

--- a/crates/kube/src/endpoint_query.rs
+++ b/crates/kube/src/endpoint_query.rs
@@ -17,7 +17,12 @@ use crate::client_cache::ClientCache;
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(8);
 const DEFAULT_MAX_LINES: usize = 200;
 
+/// Wire names are the caller's, not the struct's (see AGENTS.md): the app
+/// and the MCP schema speak camelCase, so `max_lines` arrives as `maxLines`.
+/// Without the rename the caller's cap was silently ignored and the default
+/// 200 applied.
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct QueryPodEndpointIn {
     /// Kubernetes context name
     pub context: String,
@@ -44,6 +49,7 @@ pub struct QueryPodEndpointIn {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct QueryPodEndpointOut {
     pub pod: String,
     pub port: u16,
@@ -390,6 +396,58 @@ mod tests {
         assert_eq!(returned, 2);
         assert_eq!(lines[0], "DCGM_FI_DEV_FB_USED{gpu=\"0\"} 1024");
         assert_eq!(lines[1], "DCGM_FI_DEV_FB_FREE{gpu=\"0\"} 7168");
+    }
+
+    /// The caller writes `maxLines`. Before the rename that key was an
+    /// unknown field, silently dropped, and every call got the 200-line
+    /// default — so pin the wire spelling on both the input and the output.
+    #[test]
+    fn wire_fields_are_camel_case() {
+        let input: QueryPodEndpointIn = serde_json::from_value(serde_json::json!({
+            "context": "c", "namespace": "n", "maxLines": 1
+        }))
+        .unwrap();
+        assert_eq!(input.max_lines, Some(1));
+
+        let struct_spelling: QueryPodEndpointIn = serde_json::from_value(serde_json::json!({
+            "context": "c", "namespace": "n", "max_lines": 1
+        }))
+        .unwrap();
+        assert_eq!(
+            struct_spelling.max_lines, None,
+            "the struct's own spelling is not the wire contract"
+        );
+
+        let out = serde_json::to_value(QueryPodEndpointOut {
+            pod: "p".into(),
+            port: 8080,
+            path: "/metrics".into(),
+            status_code: 200,
+            total_lines: 2,
+            returned_lines: 1,
+            metrics: vec!["e2e_up 1".into()],
+            summary: String::new(),
+        })
+        .unwrap();
+        let keys: Vec<&str> = out
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(
+            keys,
+            [
+                "metrics",
+                "path",
+                "pod",
+                "port",
+                "returnedLines",
+                "statusCode",
+                "summary",
+                "totalLines"
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
The backend job on #433 fails at the end of `full_capability_suite`:

```
capabilities registered but never exercised by this e2e suite (add a case or an EXCLUDED reason): ["k8s.queryPodEndpoint"]
covered 89/93 capabilities
```

`k8s.queryPodEndpoint` is registered on this branch but the suite never calls it, and the completeness gate is doing exactly what it is for. Everything before the gate — reads, writes, helm, node ops, teardown — passes.

## What this adds

A case rather than an `EXCLUDED` line. The three exclusions that exist are all "needs the public internet"; this capability needs nothing but the cluster, and the thing it does — open a port-forward through the API server and speak HTTP down it — is exactly what only breaks against a real API server.

**Fixture.** The suite's pods are all busybox loops with nothing listening, so there is one new Deployment, `e2e-http`: busybox's own `httpd` serving a two-line `/metrics` on a container port named `http`. Same image the suite already pulls, one replica, its own label, so the log and relation cases keep their exact pod counts. It lands in the same `applyManifest` call as the rest and goes with the namespace at teardown.

**Case**, after the logs section, four calls:

1. Selector only — the named container port must be auto-detected, the path must default to `/metrics`, and the body must arrive intact through the tunnel. This first call is polled against a deadline rather than the pod phase, because the pod can be Running a beat before `httpd` is listening.
2. Pod name, explicit port, a path missing its slash, a filter and `max_lines: 1` — checks the slash is restored, the filter is a substring match over every line (both served lines mention `e2e_up`, so `total_lines` is 2) and the cap returns one.
3. A path the server does not have — a successful query carrying a 404, not an error.
4. A selector nothing matches — a clean error, not an 8-second timeout.

## Verification

- All four calls run green against a local kind cluster through the real registry, with this exact fixture applied: `200 /metrics` with both lines, `total 2 / returned 1` under the filter and cap, `404` on `/nope`, and `No running pods found … matching selector` for the empty selector.
- `cargo check -p srelens-desktop --tests` is clean, and the new lines are rustfmt-clean (the rest of `e2e.rs` was already unformatted on this branch; left as is).
- The suite itself only runs in CI against kind, so this PR's backend job is the real run.

## Noticed in passing, not changed

`QueryPodEndpointOut` serialises snake_case (`status_code`, `total_lines`, `max_lines` on the input) where every other capability on the wire is camelCase (`localStorageMigrated`, `metricsServer`). The catalog and MCP docs will show the mismatch. Worth a `#[serde(rename_all = "camelCase")]` on both structs before this ships; the assertions here follow whatever the structs say, so that change would only need the four field names in the test updated.

## Why this PR shows no checks

`ci.yml` triggers only for pull requests into `dev`, `main` and `feat/ui-next`, so a PR into `add-tui` runs nothing — the same gap the workflow's own comment records from #326. The suite has been run locally against kind through the real registry (above), but the first CI run of the whole suite with this case will be #433's, after this merges into `add-tui`. To see it earlier, open a draft of this same branch against `dev` and close it afterward.
