### PR TITLE
test(kube): compare queryPodEndpoint's wire keys as a set so #433's backend job passes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,28 @@ Two examples from one branch: the Changes toggle stayed on "Hide changes"
 after an apply, and the diff panel was unreadable at its column width. Both
 had green tests. Neither was findable without looking.
 
+## `-p <crate>` and `--workspace` are two different builds
+
+CI runs `cargo test --workspace`. Cargo unifies features across everything
+in that build, so your crate's tests run inside whatever the rest of the
+workspace turned on — and `cargo test -p <crate>` on your machine did not.
+
+Two bugs from one branch, both invisible under `-p`, both red in CI:
+
+- `serde_json` sorts map keys until any crate enables `preserve_order`;
+  `thirtyfour` (the desktop smoke driver) does. A test that asserted key
+  order passed alone and failed in the workspace. Never assert map order.
+- kube-rs brings the `ring` rustls provider; GPUI's HTTP client brings
+  `aws-lc-rs`. With both linked, rustls will not pick, and twenty-five of
+  `crates/kube`'s own tests panicked in `Client::try_from` — only in the
+  workspace build. The fix names a provider in the crate that builds the
+  client, not in the binary that happened to notice.
+
+Before you push, run the failing crate the way CI does — at minimum
+`cargo test -p <crate> -p <the heaviest sibling>`, or the whole workspace —
+and check `cargo tree -e features -i <dep>` when a test depends on a
+dependency's behaviour.
+
 ## Windows
 
 Three suites fail on Windows only and are unrelated to your change:

--- a/crates/kube/src/endpoint_query.rs
+++ b/crates/kube/src/endpoint_query.rs
@@ -429,12 +429,17 @@ mod tests {
             summary: String::new(),
         })
         .unwrap();
-        let keys: Vec<&str> = out
+        // Sorted before comparing: serde_json's map keeps declaration order
+        // when any crate in the build turns on its `preserve_order` feature
+        // and sorts otherwise, and a workspace test build is not the same
+        // build as `-p srelens-kube`. The contract is the set of names.
+        let mut keys: Vec<&str> = out
             .as_object()
             .unwrap()
             .keys()
             .map(String::as_str)
             .collect();
+        keys.sort_unstable();
         assert_eq!(
             keys,
             [


### PR DESCRIPTION
#433's backend job now fails before the e2e suite even starts, in the unit test #440 added:

```
---- endpoint_query::tests::wire_fields_are_camel_case stdout ----
assertion `left == right` failed
  left:  ["pod", "port", "path", "statusCode", "totalLines", "returnedLines", "metrics", "summary"]
  right: ["metrics", "path", "pod", "port", "returnedLines", "statusCode", "summary", "totalLines"]
```

## Why

The test asserted the output keys in sorted order — which is what serde_json produces when its `Map` is a `BTreeMap`, and what `cargo test -p srelens-kube` gives you locally. CI runs `--workspace`, and in that build `thirtyfour` (the desktop smoke-test driver, a dev-dependency) turns on serde_json's `preserve_order` feature. Cargo unifies features across the whole build, so every crate's `Map` becomes an `IndexMap` and keys come out in declaration order. Same class of trap as the rustls-provider one in #439: `-p <crate>` and `--workspace` are two different builds, and only the second is the one CI runs.

## Fix

Sort the keys before comparing. The contract is the set of names, never their order. One hunk in `crates/kube/src/endpoint_query.rs`, with the reason written beside it.

## Verification

- `cargo test -p srelens-kube --lib endpoint_query::tests::wire_fields` passes with default features **and** with `--features serde_json/preserve_order` forced on, which reproduces CI's unified build.
- `cargo tree --workspace -e features -i serde_json` confirms `thirtyfour` is the crate that enables `preserve_order`, and that `-p srelens-kube` alone does not.

## What happens next on #433

With this unit test green the backend job reaches the e2e suite, which is where the `k8s.queryPodEndpoint` case from #440 gets its first CI run against kind. The suite ran clean locally against kind through the real registry with the exact fixture, so I expect it to pass, but that run is the proof. As before, CI does not trigger for PRs into `add-tui`, so this PR will show no checks; #433's next run is the one to watch.
