### PR TITLE
test(tui): raise apps/tui from 46% to 87% so #433 clears the coverage floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,8 +135,11 @@ jobs:
           cargo llvm-cov --no-report -p srelens-desktop --test e2e -- --ignored --nocapture --test-threads=1
           cargo llvm-cov --no-report -p srelens-kube --test helm_lifecycle -- --ignored --nocapture --test-threads=1
       - name: Enforce the coverage floor
-        # Only the process entries stay excluded (lib.rs/main.rs and the
-        # server's bin — they execute solely inside a running app/server).
+        # Only the process entries stay excluded (the desktop app's lib.rs and
+        # main.rs, the server's bin, and the TUI's main.rs — they execute solely
+        # inside a running app, server or terminal). Everything else in
+        # apps/tui counts: its views render through ratatui's TestBackend and
+        # its App runs without a cluster, so there is no excuse there.
         # The command shims that used to sit here are unit-tested through
         # tauri::test's MockRuntime and count like everything else. The floor
         # is a ratchet — 55 at first green, 84 when the kind suites started
@@ -144,7 +147,7 @@ jobs:
         # #28's acceptance number) — never lower it.
         run: >-
           cargo llvm-cov report --summary-only --fail-under-lines 85
-          --ignore-filename-regex 'apps/desktop/src-tauri/src/(lib|main)\.rs|crates/server/src/bin/'
+          --ignore-filename-regex 'apps/desktop/src-tauri/src/(lib|main)\.rs|crates/server/src/bin/|apps/tui/src/main[.]rs'
 
   # The WebDriver smoke suite (issue #30): the REAL built app — WebView and
   # all — driven through tauri-driver against a kind cluster. This is the

--- a/apps/tui/tests/agent_bridge_tests.rs
+++ b/apps/tui/tests/agent_bridge_tests.rs
@@ -1,0 +1,307 @@
+//! Behavioural tests for the agent bridge's timeout and process-launch edges.
+//!
+//! `core_logic_tests.rs` already drives `run_native_agent_turn` against a fake
+//! OpenAI-compatible endpoint on loopback; this file covers the two paths it
+//! leaves out: the turn that never gets an answer at all, and the boxed
+//! cursor-agent path's setup when the binary cannot be launched.
+//!
+//! What is deliberately *not* here, because no test can reach it without
+//! breaking determinism:
+//!
+//! * `agent.rs` 469-639 — everything after a successful `cmd.spawn()` of the
+//!   cursor-agent binary (stdout/stderr pumps, exit-status handling, the
+//!   fallback usage estimate). `AgentCommand::program` is the caller-supplied
+//!   binary path with no injection seam, so reaching it means really executing
+//!   an external program.
+//! * `agent.rs` 294-317 — the `bind("127.0.0.1:0")` / `local_addr()` failure
+//!   arms, which cannot be provoked on a working host.
+//! * `agent.rs` 347-418 — the `tempfile::tempdir()` and `std::fs::write`
+//!   failure arms, which need an unwritable temp directory.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use srelens_kube::client_cache::ClientCache;
+use srelens_llm::types::ProviderKind;
+use srelens_llm::ProviderConfig;
+use tokio::net::TcpListener;
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
+
+use srelens_tui::agent::{
+    build_mcp_server, run_boxed_cursor_turn, run_native_agent_turn, McpToolInvoker,
+};
+use srelens_tui::event::AppEvent;
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/// Every `ActionResult` the agent emitted, as `(title, result)`, in order.
+fn action_results(rx: &mut UnboundedReceiver<AppEvent>) -> Vec<(String, Result<String, String>)> {
+    let mut out = Vec::new();
+    while let Ok(ev) = rx.try_recv() {
+        if let AppEvent::ActionResult { title, result } = ev {
+            out.push((title, result));
+        }
+    }
+    out
+}
+
+fn invoker() -> Arc<McpToolInvoker> {
+    let cache = ClientCache::new(PathBuf::from("/nonexistent"));
+    Arc::new(McpToolInvoker::new(build_mcp_server(cache, vec![])))
+}
+
+/// `HttpProvider::new` builds a `reqwest::Client` with `rustls-no-provider`,
+/// which panics ("No rustls crypto provider is configured") unless a process
+/// default was installed earlier. In the running TUI that happens as a side
+/// effect of the first kube `Client` build; a fresh test process has to do the
+/// same, so mirror production by building one (no network involved).
+fn ensure_tls_provider() {
+    let config = srelens_kube::kube::Config::new("https://127.0.0.1:6443".parse().expect("uri"));
+    srelens_kube::kube::Client::try_from(config).expect("kube client builds");
+}
+
+fn provider_config(base_url: &str) -> ProviderConfig {
+    ensure_tls_provider();
+    ProviderConfig {
+        kind: ProviderKind::OpenAiCompatible,
+        api_key: "test-key".into(),
+        base_url: base_url.to_string(),
+        model: "fake-model".into(),
+        max_tokens: 256,
+    }
+}
+
+/// A loopback endpoint that accepts connections and never answers them. Each
+/// socket is kept alive for the life of the task, so the client waits on a
+/// healthy connection rather than seeing a reset — the only way to make the
+/// turn's own `tokio::time::timeout` fire.
+async fn stalled_endpoint() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind loopback");
+    let base_url = format!("http://{}/v1", listener.local_addr().expect("local addr"));
+    tokio::spawn(async move {
+        let mut held = Vec::new();
+        while let Ok((sock, _)) = listener.accept().await {
+            held.push(sock);
+        }
+    });
+    base_url
+}
+
+/// A path inside a fresh temp directory that is guaranteed not to exist, so
+/// `Command::spawn` fails instead of executing anything.
+fn missing_binary(dir: &tempfile::TempDir) -> String {
+    dir.path()
+        .join("no-such-cursor-agent")
+        .to_string_lossy()
+        .to_string()
+}
+
+/// Run one boxed cursor turn against a binary that is not there and return the
+/// action results it emitted.
+async fn boxed_turn_against_missing_binary(
+    bin: String,
+    model: &str,
+    api_key: Option<String>,
+    context: &str,
+) -> Vec<(String, Result<String, String>)> {
+    let (tx, mut rx) = unbounded_channel();
+    run_boxed_cursor_turn(
+        bin,
+        model.to_string(),
+        api_key,
+        "why is the api pod restarting?".into(),
+        context.to_string(),
+        "payments".into(),
+        ClientCache::new(PathBuf::from("/nonexistent")),
+        vec![],
+        tx,
+        30,
+    )
+    .await;
+    action_results(&mut rx)
+}
+
+// ---------------------------------------------------------------------------
+// run_native_agent_turn: the turn that never gets an answer
+// ---------------------------------------------------------------------------
+
+/// The turn clamps its own deadline with `timeout_seconds.max(5)`, so this test
+/// costs about five seconds of wall clock no matter how small a timeout is
+/// asked for. It also pins the mismatch that clamp creates: the message quotes
+/// the *requested* number of seconds, not the number actually waited.
+#[tokio::test]
+async fn a_native_turn_that_never_gets_a_reply_times_out_and_still_reports_usage_and_done() {
+    let base_url = stalled_endpoint().await;
+    let (tx, mut rx) = unbounded_channel();
+    let history = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+
+    let started = std::time::Instant::now();
+    run_native_agent_turn(
+        provider_config(&base_url),
+        invoker(),
+        history.clone(),
+        "how are the pods?".into(),
+        "kind-dev".into(),
+        "payments".into(),
+        tx,
+        1,
+    )
+    .await;
+    let elapsed = started.elapsed();
+
+    let results = action_results(&mut rx);
+    let titles: Vec<&str> = results.iter().map(|(t, _)| t.as_str()).collect();
+    assert_eq!(
+        titles,
+        vec![
+            "ai_chunk:kind-dev",
+            "ai_usage:kind-dev",
+            "ai_chunk:kind-dev",
+            "ai_done:kind-dev"
+        ],
+        "the timeout is announced as a chunk, then usage, then the failure, then done"
+    );
+
+    // 1. The user-visible chunk explains the timeout and points at settings.
+    let announced = results[0]
+        .1
+        .as_ref()
+        .expect("the timeout notice is an Ok chunk");
+    assert_eq!(
+        announced,
+        "\n[Error: AI assistant turn timed out after 1 seconds. You can increase the timeout in settings (<Ctrl+s>).]"
+    );
+
+    // 2. ...but a 1-second timeout is silently raised to the 5-second floor, so
+    //    the number in that message is not the time the user actually waited.
+    assert!(
+        elapsed >= Duration::from_secs(4),
+        "timeout_seconds is clamped by .max(5), so the turn cannot return in ~1s: {elapsed:?}"
+    );
+
+    // 3. Usage is still estimated, with no completion characters to count.
+    let usage: Vec<u64> = results[1]
+        .1
+        .as_ref()
+        .expect("usage payload")
+        .split('|')
+        .map(|f| f.parse().expect("numeric usage field"))
+        .collect();
+    let prompt_est = (("how are the pods?".len() + 200) / 4) as u64;
+    assert_eq!(usage[0], prompt_est);
+    assert_eq!(
+        usage[1], 0,
+        "nothing streamed back, so max(1)/4 rounds to zero"
+    );
+    assert_eq!(usage[2], 0);
+    assert_eq!(usage[3], prompt_est);
+    assert!(
+        usage[4] >= 4000,
+        "the reported duration is the real one: {usage:?}"
+    );
+
+    // 4. The turn is reported as a hard error and then closed out.
+    let err = results[2]
+        .1
+        .as_ref()
+        .expect_err("the failure is an Err chunk");
+    assert_eq!(err, "AI Agent Error: AI assistant turn timed out after 1 seconds. You can increase the timeout in settings (<Ctrl+s>).");
+    assert_eq!(results[3].1, Ok(String::new()));
+
+    // 5. A timed-out turn leaves history untouched, so a retry starts clean.
+    assert!(history.lock().await.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// run_boxed_cursor_turn: the setup that runs before the binary is launched
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_boxed_cursor_turn_that_cannot_launch_skips_the_usage_estimate_a_native_turn_always_sends(
+) {
+    let dir = tempfile::tempdir().expect("temp dir");
+    // No key and the sentinel "default" model: neither `--api-key` nor
+    // `--model` is appended to the argv, and the turn must still fail cleanly.
+    let results =
+        boxed_turn_against_missing_binary(missing_binary(&dir), "default", None, "prod-eu").await;
+
+    let titles: Vec<&str> = results.iter().map(|(t, _)| t.as_str()).collect();
+    assert_eq!(titles, vec!["ai_chunk:prod-eu", "ai_done:prod-eu"]);
+
+    let err = results[0]
+        .1
+        .as_ref()
+        .expect_err("a launch failure is an Err chunk");
+    assert!(err.starts_with("Failed to launch cursor-agent: "), "{err}");
+
+    // The native path emits `ai_usage` on every outcome, success or failure;
+    // the boxed path emits it only once a child process has been started, so a
+    // turn that never launches reports no token estimate at all.
+    assert!(
+        !titles.iter().any(|t| t.starts_with("ai_usage")),
+        "no usage estimate without a child process: {titles:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_boxed_cursor_turn_tags_every_event_with_the_context_it_was_started_for() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let results = boxed_turn_against_missing_binary(
+        missing_binary(&dir),
+        "gpt-5-codex",
+        Some("k-1".into()),
+        "eks-staging",
+    )
+    .await;
+
+    // Both events carry the context so the UI can drop a reply that arrives
+    // after the user switched clusters.
+    assert!(
+        results.iter().all(|(t, _)| t.ends_with(":eks-staging")),
+        "{:?}",
+        results.iter().map(|(t, _)| t.as_str()).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        results.last().map(|(t, _)| t.as_str()),
+        Some("ai_done:eks-staging")
+    );
+}
+
+/// Each turn stands up its own MCP server on an ephemeral loopback port before
+/// launching the agent, so two turns in flight at once must not collide on a
+/// port or cross-talk on each other's channels.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn two_boxed_cursor_turns_at_once_each_get_their_own_port_and_channel() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let bin = missing_binary(&dir);
+
+    let (left, right) = tokio::join!(
+        boxed_turn_against_missing_binary(bin.clone(), "sonnet", None, "cluster-a"),
+        boxed_turn_against_missing_binary(bin, "sonnet", None, "cluster-b"),
+    );
+
+    for (results, ctx) in [(&left, "cluster-a"), (&right, "cluster-b")] {
+        let titles: Vec<&str> = results.iter().map(|(t, _)| t.as_str()).collect();
+        assert_eq!(
+            titles,
+            vec![format!("ai_chunk:{ctx}"), format!("ai_done:{ctx}")]
+        );
+        let err = results[0]
+            .1
+            .as_ref()
+            .expect_err("a launch failure is an Err chunk");
+        assert!(
+            err.starts_with("Failed to launch cursor-agent: "),
+            "neither turn may fail earlier, at the port bind: {err}"
+        );
+    }
+
+    // Let each turn's shutdown signal reach its MCP server task before the
+    // runtime is torn down underneath it.
+    tokio::task::yield_now().await;
+}

--- a/apps/tui/tests/app_extra_tests.rs
+++ b/apps/tui/tests/app_extra_tests.rs
@@ -1,0 +1,2336 @@
+//! Integration tests for the parts of `App` that only run when a cluster
+//! answers: the background refreshes, the CRD discovery pass, the cluster
+//! overview roll-up, the YAML/describe fetchers and the write actions
+//! (delete/restart/scale/cordon).
+//!
+//! None of this needs a real Kubernetes cluster. `fake_cluster` binds a
+//! loopback socket, speaks just enough HTTP/1.1 to satisfy kube-rs, and hands
+//! back a kubeconfig pointing at it; a test then points the app's client cache
+//! at that kubeconfig. Watches are deliberately left pointing at the app's own
+//! (empty) kubeconfig list so no long-poll ever reaches the fake server.
+
+mod common;
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::{json, Value};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::sync::mpsc::UnboundedReceiver;
+
+use srelens_kube::lineage::{LineageNode, LineageRelation};
+use srelens_kube::node_inspector::{NodeInspectorDetails, NodePodItem};
+use srelens_tui::app::{ActiveView, App, SuspendAction};
+use srelens_tui::commands::{CrdMeta, ResourceKind};
+use srelens_tui::event::AppEvent;
+use srelens_tui::ui::Modal;
+use srelens_tui::views::helm_view::{HelmReleaseItem, HelmViewState};
+use srelens_tui::views::node_inspector_view::NodeInspectorState;
+use srelens_tui::views::port_forward_view::{PortForwardEntry, PortForwardViewState};
+use srelens_tui::views::resource_table::ResourceTableState;
+use srelens_tui::views::toolbox_view::{ToolStatusItem, ToolboxViewState};
+use srelens_tui::views::tree_view::TreeViewState;
+
+// ---------------------------------------------------------------------------
+// A loopback apiserver
+// ---------------------------------------------------------------------------
+
+/// The context name every fake cluster answers to. Deliberately unlikely to
+/// exist in a developer's real kubeconfig, so a `kubectl` fallback that does
+/// get spawned can only fail.
+const FAKE_CONTEXT: &str = "srelens-fake-apiserver-ctx";
+
+/// One canned reply: any request whose path starts with `prefix` gets
+/// `status` and `body`. Routes are matched in the order they are given, so a
+/// more specific prefix must come first.
+#[derive(Clone)]
+struct Route {
+    prefix: String,
+    status: u16,
+    body: String,
+}
+
+fn route(prefix: &str, body: Value) -> Route {
+    Route {
+        prefix: prefix.to_string(),
+        status: 200,
+        body: body.to_string(),
+    }
+}
+
+fn failing_route(prefix: &str, status: u16) -> Route {
+    Route {
+        prefix: prefix.to_string(),
+        status,
+        body: json!({
+            "kind": "Status",
+            "apiVersion": "v1",
+            "metadata": {},
+            "status": "Failure",
+            "message": "fake apiserver says no",
+            "reason": "InternalError",
+            "code": status,
+        })
+        .to_string(),
+    }
+}
+
+/// A running fake apiserver plus the kubeconfig that points at it. Dropping it
+/// removes the kubeconfig; the serving task dies with the test's runtime.
+struct FakeCluster {
+    _dir: tempfile::TempDir,
+    kubeconfig: PathBuf,
+}
+
+fn find_head_end(buf: &[u8]) -> Option<usize> {
+    buf.windows(4).position(|w| w == b"\r\n\r\n").map(|p| p + 4)
+}
+
+fn status_text(status: u16) -> &'static str {
+    match status {
+        200 => "OK",
+        404 => "Not Found",
+        409 => "Conflict",
+        500 => "Internal Server Error",
+        _ => "Unknown",
+    }
+}
+
+/// Serve exactly one request on `sock` and close. Closing after every reply
+/// keeps the server single-threaded-simple; hyper just opens a new connection.
+async fn serve_one(mut sock: tokio::net::TcpStream, routes: Arc<Vec<Route>>) {
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 4096];
+    let head_end = loop {
+        if let Some(end) = find_head_end(&buf) {
+            break end;
+        }
+        match sock.read(&mut chunk).await {
+            Ok(0) | Err(_) => return,
+            Ok(n) => buf.extend_from_slice(&chunk[..n]),
+        }
+    };
+
+    let head = String::from_utf8_lossy(&buf[..head_end]).to_string();
+    let mut lines = head.lines();
+    let path = lines
+        .next()
+        .and_then(|l| l.split_whitespace().nth(1))
+        .unwrap_or("/")
+        .split('?')
+        .next()
+        .unwrap_or("/")
+        .to_string();
+    let content_length: usize = head
+        .lines()
+        .filter_map(|l| l.split_once(':'))
+        .find(|(k, _)| k.trim().eq_ignore_ascii_case("content-length"))
+        .and_then(|(_, v)| v.trim().parse().ok())
+        .unwrap_or(0);
+
+    // Drain the request body so the client never sees a reset mid-write.
+    while buf.len() < head_end + content_length {
+        match sock.read(&mut chunk).await {
+            Ok(0) | Err(_) => break,
+            Ok(n) => buf.extend_from_slice(&chunk[..n]),
+        }
+    }
+
+    let (status, body) = routes
+        .iter()
+        .find(|r| path.starts_with(&r.prefix))
+        .map(|r| (r.status, r.body.clone()))
+        .unwrap_or_else(|| {
+            let miss = failing_route("", 404);
+            (404, miss.body)
+        });
+
+    let response = format!(
+        "HTTP/1.1 {} {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        status,
+        status_text(status),
+        body.len(),
+        body
+    );
+    let _ = sock.write_all(response.as_bytes()).await;
+    let _ = sock.flush().await;
+    let _ = sock.shutdown().await;
+}
+
+/// Start a loopback apiserver serving `routes` and write a kubeconfig whose
+/// `test-cluster` context points at it.
+async fn fake_cluster(routes: Vec<Route>) -> FakeCluster {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("a loopback port");
+    let port = listener.local_addr().expect("bound address").port();
+    let routes = Arc::new(routes);
+    tokio::spawn(async move {
+        loop {
+            match listener.accept().await {
+                Ok((sock, _)) => {
+                    let routes = routes.clone();
+                    tokio::spawn(serve_one(sock, routes));
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let kubeconfig = dir.path().join("config");
+    std::fs::write(
+        &kubeconfig,
+        format!(
+            "apiVersion: v1\nkind: Config\ncurrent-context: {FAKE_CONTEXT}\n\
+             clusters:\n- name: fake\n  cluster:\n    server: http://127.0.0.1:{port}\n\
+             contexts:\n- name: {FAKE_CONTEXT}\n  context:\n    cluster: fake\n    user: fake-user\n    namespace: default\n\
+             users:\n- name: fake-user\n  user: {{}}\n"
+        ),
+    )
+    .expect("write kubeconfig");
+
+    FakeCluster {
+        _dir: dir,
+        kubeconfig,
+    }
+}
+
+/// An app whose *client cache* talks to `cluster`. `app.kubeconfig_paths` is
+/// left empty on purpose: watches and the kubectl fallbacks resolve nothing,
+/// so only the code paths under test reach the fake server.
+async fn app_on(cluster: &FakeCluster) -> (App, UnboundedReceiver<AppEvent>) {
+    let (mut app, rx) = common::app_with(FAKE_CONTEXT, "default").await;
+    app.client_cache
+        .set_paths(vec![cluster.kubeconfig.clone()])
+        .await;
+    // `kubectl` fallbacks must never resolve: point KUBECONFIG at a file that
+    // does not exist so any spawned kubectl fails immediately, on every OS and
+    // whether or not kubectl is installed.
+    app.kubeconfig_paths = vec![cluster.kubeconfig.with_file_name("no-such-kubeconfig")];
+    (app, rx)
+}
+
+/// Wait (bounded) for the `ActionResult` carrying `title`.
+async fn action_result(
+    rx: &mut UnboundedReceiver<AppEvent>,
+    title: &str,
+) -> Result<String, String> {
+    tokio::time::timeout(Duration::from_secs(20), async {
+        loop {
+            match rx.recv().await {
+                Some(AppEvent::ActionResult { title: t, result }) if t == title => return result,
+                Some(_) => continue,
+                None => panic!("event channel closed before '{}'", title),
+            }
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("no '{}' event within 20s", title))
+}
+
+fn toast(app: &App) -> String {
+    app.toast
+        .as_ref()
+        .map(|(m, _, _)| m.clone())
+        .unwrap_or_default()
+}
+
+// ---------------------------------------------------------------------------
+// Canned cluster payloads
+// ---------------------------------------------------------------------------
+
+fn version_body() -> Value {
+    json!({
+        "major": "1",
+        "minor": "31",
+        "gitVersion": "v1.31.7",
+        "gitCommit": "deadbeef",
+        "gitTreeState": "clean",
+        "buildDate": "2026-01-01T00:00:00Z",
+        "goVersion": "go1.23",
+        "compiler": "gc",
+        "platform": "linux/amd64",
+    })
+}
+
+fn node(name: &str, ready: bool, extra_allocatable: Value) -> Value {
+    let mut allocatable = json!({ "cpu": "4", "memory": "8Gi", "pods": "110" });
+    if let (Some(dst), Some(src)) = (allocatable.as_object_mut(), extra_allocatable.as_object()) {
+        for (k, v) in src {
+            dst.insert(k.clone(), v.clone());
+        }
+    }
+    json!({
+        "apiVersion": "v1",
+        "kind": "Node",
+        "metadata": { "name": name, "creationTimestamp": "2026-01-01T00:00:00Z" },
+        "spec": {},
+        "status": {
+            "capacity": { "cpu": "4", "memory": "8Gi", "pods": "110" },
+            "allocatable": allocatable,
+            "conditions": [{
+                "type": "Ready",
+                "status": if ready { "True" } else { "False" },
+                "lastHeartbeatTime": "2026-01-01T00:00:00Z",
+                "lastTransitionTime": "2026-01-01T00:00:00Z",
+            }],
+            "nodeInfo": {
+                "architecture": "amd64",
+                "bootID": "b",
+                "containerRuntimeVersion": "containerd://1.7",
+                "kernelVersion": "6.1",
+                "kubeProxyVersion": "v1.31.7",
+                "kubeletVersion": "v1.31.7",
+                "machineID": "m",
+                "operatingSystem": "linux",
+                "osImage": "Ubuntu",
+                "systemUUID": "u",
+            },
+        },
+    })
+}
+
+fn node_list(items: Vec<Value>) -> Value {
+    json!({
+        "apiVersion": "v1",
+        "kind": "NodeList",
+        "metadata": { "resourceVersion": "1" },
+        "items": items,
+    })
+}
+
+/// A pod whose single container requests `requests`, in `phase`, optionally
+/// with a container status that makes it unhealthy.
+fn pod(name: &str, phase: &str, requests: Value, container_state: Option<Value>) -> Value {
+    let mut status = json!({ "phase": phase });
+    if let Some(state) = container_state {
+        status["containerStatuses"] = json!([{
+            "name": "app",
+            "ready": false,
+            "restartCount": 0,
+            "image": "busybox",
+            "imageID": "busybox@sha256:0",
+            "state": state,
+        }]);
+    }
+    json!({
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+            "name": name,
+            "namespace": "default",
+            "creationTimestamp": "2026-01-01T00:00:00Z",
+        },
+        "spec": {
+            "containers": [{
+                "name": "app",
+                "image": "busybox",
+                "resources": { "requests": requests },
+            }],
+            "initContainers": [{
+                "name": "init",
+                "image": "busybox",
+                "resources": { "requests": { "cpu": "10m", "memory": "16Mi" } },
+            }],
+        },
+        "status": status,
+    })
+}
+
+fn pod_list(items: Vec<Value>) -> Value {
+    json!({
+        "apiVersion": "v1",
+        "kind": "PodList",
+        "metadata": { "resourceVersion": "1" },
+        "items": items,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// refresh_cluster_info
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_reachable_apiserver_reports_its_version_and_node_and_pod_counts() {
+    let cluster = fake_cluster(vec![
+        route("/version", version_body()),
+        route(
+            "/api/v1/nodes",
+            node_list(vec![node("a", true, json!({})), node("b", true, json!({}))]),
+        ),
+        route(
+            "/api/v1/pods",
+            pod_list(vec![
+                pod("p1", "Running", json!({}), None),
+                pod("p2", "Running", json!({}), None),
+                pod("p3", "Running", json!({}), None),
+            ]),
+        ),
+    ])
+    .await;
+    let (mut app, mut rx) = app_on(&cluster).await;
+
+    app.refresh_cluster_info();
+    let payload = action_result(&mut rx, "cluster_info_updated")
+        .await
+        .expect("a reachable apiserver reports Ok");
+    assert_eq!(payload, "v1.31.7|2|3");
+
+    app.handle_cluster_info_update(&payload);
+    assert!(app.is_connected);
+    assert_eq!(app.cluster_version, "v1.31.7");
+    assert_eq!((app.node_count, app.pod_count), (2, 3));
+}
+
+#[tokio::test]
+async fn a_version_call_that_fails_reports_the_apiserver_error_not_a_count() {
+    let cluster = fake_cluster(vec![failing_route("/version", 500)]).await;
+    let (app, mut rx) = app_on(&cluster).await;
+
+    app.refresh_cluster_info();
+    let err = action_result(&mut rx, "cluster_info_failed")
+        .await
+        .expect_err("a 500 from /version is a failure");
+    assert!(
+        err.contains("500") || err.to_lowercase().contains("internal"),
+        "the apiserver's own error is surfaced: {err}"
+    );
+}
+
+#[tokio::test]
+async fn unlistable_nodes_and_pods_still_report_a_version_with_zero_counts() {
+    // Only /version answers; the two metadata lists 404, and each falls back
+    // to zero rather than failing the whole refresh.
+    let cluster = fake_cluster(vec![route("/version", version_body())]).await;
+    let (app, mut rx) = app_on(&cluster).await;
+
+    app.refresh_cluster_info();
+    let payload = action_result(&mut rx, "cluster_info_updated")
+        .await
+        .expect("version alone is enough");
+    assert_eq!(payload, "v1.31.7|0|0");
+}
+
+// ---------------------------------------------------------------------------
+// refresh_crds
+// ---------------------------------------------------------------------------
+
+fn crd_object(name: &str, spec: Value) -> Value {
+    json!({
+        "apiVersion": "apiextensions.k8s.io/v1",
+        "kind": "CustomResourceDefinition",
+        "metadata": { "name": name },
+        "spec": spec,
+    })
+}
+
+#[tokio::test]
+async fn crd_discovery_picks_the_storage_version_its_columns_and_skips_groupless_definitions() {
+    let cluster = fake_cluster(vec![route(
+        "/apis/apiextensions.k8s.io/v1/customresourcedefinitions",
+        json!({
+            "apiVersion": "apiextensions.k8s.io/v1",
+            "kind": "CustomResourceDefinitionList",
+            "metadata": { "resourceVersion": "1" },
+            "items": [
+                // Storage version wins over the older served one, and brings
+                // its own printer columns.
+                crd_object("widgets.example.com", json!({
+                    "group": "example.com",
+                    "scope": "Namespaced",
+                    "names": { "kind": "Widget", "plural": "widgets", "singular": "widget", "shortNames": ["wd"] },
+                    "versions": [
+                        { "name": "v1beta1", "served": true, "storage": false },
+                        { "name": "v1", "served": true, "storage": true, "additionalPrinterColumns": [
+                            { "name": "Size", "jsonPath": ".spec.size", "type": "integer", "priority": 1, "description": "how big" }
+                        ] }
+                    ],
+                })),
+                // No storage version at all: the first served one is used, and
+                // the columns come from the spec-level fallback.
+                crd_object("gadgets.example.com", json!({
+                    "group": "example.com",
+                    "scope": "Cluster",
+                    "names": { "kind": "Gadget", "plural": "gadgets", "singular": "gadget" },
+                    "additionalPrinterColumns": [
+                        { "name": "Phase", "jsonPath": ".status.phase", "type": "string" }
+                    ],
+                    "versions": [ { "name": "v2", "served": true, "storage": false } ],
+                })),
+                // No versions block: falls back to v1 with no columns.
+                crd_object("sprockets.example.com", json!({
+                    "group": "example.com",
+                    "scope": "Namespaced",
+                    "names": { "kind": "Sprocket", "plural": "sprockets", "singular": "sprocket" },
+                })),
+                // No group: not a usable CRD, so it is dropped.
+                crd_object("broken", json!({
+                    "scope": "Namespaced",
+                    "names": { "kind": "Broken", "plural": "brokens", "singular": "broken" },
+                })),
+            ],
+        }),
+    )])
+    .await;
+    let (mut app, mut rx) = app_on(&cluster).await;
+
+    app.refresh_crds();
+    let payload = action_result(&mut rx, "crds_updated")
+        .await
+        .expect("discovery serialises its findings");
+    app.handle_crds_update(&payload);
+
+    let names: Vec<&str> = app.crds.iter().map(|c| c.kind.as_str()).collect();
+    assert_eq!(names, vec!["Widget", "Gadget", "Sprocket"]);
+
+    let widget = &app.crds[0];
+    assert_eq!(widget.crd_name, "widgets.example.com");
+    assert_eq!(widget.version, "v1", "the storage version wins");
+    assert!(widget.namespaced);
+    assert_eq!(widget.short_names, vec!["wd".to_string()]);
+    assert_eq!(widget.printer_columns.len(), 1);
+    assert_eq!(widget.printer_columns[0].name, "Size");
+    assert_eq!(widget.printer_columns[0].json_path, ".spec.size");
+    assert_eq!(widget.printer_columns[0].priority, 1);
+    assert_eq!(
+        widget.printer_columns[0].description.as_deref(),
+        Some("how big")
+    );
+
+    let gadget = &app.crds[1];
+    assert_eq!(
+        gadget.version, "v2",
+        "no storage version, so the served one"
+    );
+    assert!(!gadget.namespaced);
+    assert_eq!(
+        gadget.printer_columns[0].name, "Phase",
+        "columns fall back to the spec-level list"
+    );
+
+    let sprocket = &app.crds[2];
+    assert_eq!(sprocket.version, "v1", "no versions block means v1");
+    assert!(sprocket.printer_columns.is_empty());
+}
+
+#[tokio::test]
+async fn crd_discovery_stays_silent_when_the_definitions_cannot_be_listed() {
+    let cluster = fake_cluster(vec![failing_route("/apis/apiextensions.k8s.io", 404)]).await;
+    let (mut app, mut rx) = app_on(&cluster).await;
+
+    app.refresh_crds();
+    tokio::task::yield_now().await;
+    app.handle_crds_update(&json!([]).to_string());
+    assert!(app.crds.is_empty());
+    assert!(
+        common::drain(&mut rx).iter().all(
+            |ev| !matches!(ev, AppEvent::ActionResult { title, .. } if title == "crds_updated")
+        ),
+        "a failed list publishes no CRD update"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// refresh_cluster_overview
+// ---------------------------------------------------------------------------
+
+/// Two nodes whose allocatable maps exercise every GPU key shape and every
+/// suffix `parse_gpu_mem_mib` understands.
+fn gpu_nodes() -> Value {
+    node_list(vec![
+        node(
+            "gpu-a",
+            true,
+            json!({
+                "nvidia.com/gpu": "2",
+                "example.com/gpu-mem-ki": "2048Ki",
+                "example.com/gpu-mem-mi": "512Mi",
+            }),
+        ),
+        node(
+            "gpu-b",
+            false,
+            json!({
+                "amd.com/gpu": "1",
+                "example.com/gpu-mem-gi": "2Gi",
+                "example.com/gpu-vram-ti": "1Ti",
+                "example.com/gpu-mem-bytes": "34359738368",
+                "example.com/gpu-mem-plain": "512",
+                "example.com/gpu-mem-nonsense": "abc",
+                "example.com/vgpu": "4",
+                "nvidia.com/gpu-cores": "8",
+            }),
+        ),
+    ])
+}
+
+/// 2Ki + 512Mi + 2Gi + 1Ti + 32GiB-as-bytes + a bare 512, all in MiB. The
+/// unparseable value contributes nothing.
+const EXPECTED_GPU_MEM_MIB: i64 = 2 + 512 + 2048 + 1_048_576 + 32_768 + 512;
+
+fn overview_pods() -> Value {
+    pod_list(vec![
+        pod(
+            "p-running",
+            "Running",
+            json!({
+                "cpu": "250m",
+                "memory": "512Mi",
+                "nvidia.com/gpu": "1",
+                "example.com/gpu-mem": "256Mi",
+            }),
+            None,
+        ),
+        pod("p-pending", "Pending", json!({}), None),
+        pod("p-failed", "Failed", json!({}), None),
+        pod(
+            "p-crashing",
+            "Running",
+            json!({}),
+            Some(json!({ "waiting": { "reason": "CrashLoopBackOff" } })),
+        ),
+        pod(
+            "p-oomkilled",
+            "Running",
+            json!({}),
+            Some(json!({ "terminated": { "exitCode": 137, "reason": "OOMKilled" } })),
+        ),
+    ])
+}
+
+#[tokio::test]
+async fn the_cluster_overview_rolls_up_nodes_pods_gpus_and_metrics_server_usage() {
+    let cluster = fake_cluster(vec![
+        route("/version", version_body()),
+        route("/api/v1/nodes", gpu_nodes()),
+        route(
+            "/apis/metrics.k8s.io/v1beta1/",
+            json!({
+                "apiVersion": "metrics.k8s.io/v1beta1",
+                "kind": "NodeMetricsList",
+                "metadata": { "resourceVersion": "1" },
+                "items": [
+                    { "metadata": { "name": "gpu-a" }, "usage": { "cpu": "1500m", "memory": "2048Mi" } },
+                    { "metadata": { "name": "gpu-b" }, "usage": { "cpu": "1500m", "memory": "2048Mi" } },
+                ],
+            }),
+        ),
+        route("/api/v1/pods", overview_pods()),
+    ])
+    .await;
+    let (mut app, mut rx) = app_on(&cluster).await;
+
+    app.refresh_cluster_overview();
+    let payload = action_result(&mut rx, "cluster_overview_updated")
+        .await
+        .expect("the roll-up serialises");
+    app.handle_cluster_overview_update(&payload);
+    let data = app
+        .cluster_overview_data
+        .as_ref()
+        .expect("the overview is stored");
+
+    assert!(data.is_reachable);
+    assert_eq!(data.k8s_version, "v1.31.7");
+    assert_eq!(data.node_count, 2);
+    assert_eq!(data.ready_nodes, 1, "only one node reports Ready=True");
+    assert_eq!(data.total_cpu_millicores, 8_000);
+    assert_eq!(data.total_mem_mib, 16_384);
+    assert_eq!(data.total_gpus, 3, "nvidia + amd, ignoring vgpu and cores");
+    assert_eq!(data.total_gpu_mem_mib, EXPECTED_GPU_MEM_MIB);
+
+    assert_eq!(data.total_pods, 5);
+    assert_eq!(data.running_pods, 1);
+    assert_eq!(data.pending_pods, 1);
+    assert_eq!(
+        data.failed_pods, 3,
+        "phase Failed plus the crash-looping and OOMKilled pods"
+    );
+    assert_eq!(data.allocated_gpus, 1);
+    assert_eq!(data.used_gpu_mem_mib, 256);
+
+    assert_eq!(
+        data.used_cpu_millicores, 3_000,
+        "metrics-server usage wins over pod requests"
+    );
+    assert_eq!(data.used_mem_mib, 4_096);
+}
+
+#[tokio::test]
+async fn the_cluster_overview_falls_back_to_pod_requests_without_a_metrics_server() {
+    let cluster = fake_cluster(vec![
+        route("/version", version_body()),
+        route("/api/v1/nodes", gpu_nodes()),
+        failing_route("/apis/metrics.k8s.io", 404),
+        route("/api/v1/pods", overview_pods()),
+    ])
+    .await;
+    let (mut app, mut rx) = app_on(&cluster).await;
+
+    app.refresh_cluster_overview();
+    let payload = action_result(&mut rx, "cluster_overview_updated")
+        .await
+        .expect("the roll-up serialises");
+    app.handle_cluster_overview_update(&payload);
+    let data = app.cluster_overview_data.as_ref().expect("overview");
+
+    // Every pod carries a 10m/16Mi init container; only p-running asks for more.
+    assert_eq!(data.used_cpu_millicores, 5 * 10 + 250);
+    assert_eq!(data.used_mem_mib, 5 * 16 + 512);
+}
+
+#[tokio::test]
+async fn an_unreachable_apiserver_still_publishes_an_overview_marked_unreachable() {
+    // No /version route: the apiserver answers 404 and the roll-up records an
+    // unknown version rather than giving up.
+    let cluster = fake_cluster(vec![
+        route("/api/v1/nodes", node_list(vec![node("n", true, json!({}))])),
+        route("/api/v1/pods", pod_list(vec![])),
+    ])
+    .await;
+    let (mut app, mut rx) = app_on(&cluster).await;
+
+    app.refresh_cluster_overview();
+    let payload = action_result(&mut rx, "cluster_overview_updated")
+        .await
+        .expect("the roll-up still publishes");
+    app.handle_cluster_overview_update(&payload);
+    let data = app.cluster_overview_data.as_ref().expect("overview");
+    assert!(!data.is_reachable);
+    assert_eq!(data.k8s_version, "unknown");
+    assert_eq!(data.node_count, 1);
+    assert!(!app.is_connected);
+}
+
+// ---------------------------------------------------------------------------
+// Custom resource instances
+// ---------------------------------------------------------------------------
+
+fn widget_crd() -> CrdMeta {
+    CrdMeta {
+        crd_name: "widgets.example.com".to_string(),
+        group: "example.com".to_string(),
+        version: "v1".to_string(),
+        kind: "Widget".to_string(),
+        plural: "widgets".to_string(),
+        singular: "widget".to_string(),
+        namespaced: true,
+        short_names: vec![],
+        printer_columns: vec![],
+    }
+}
+
+fn gadget_crd() -> CrdMeta {
+    CrdMeta {
+        namespaced: false,
+        crd_name: "gadgets.example.com".to_string(),
+        kind: "Gadget".to_string(),
+        plural: "gadgets".to_string(),
+        singular: "gadget".to_string(),
+        ..widget_crd()
+    }
+}
+
+#[tokio::test]
+async fn custom_resource_instances_are_published_with_name_namespace_and_age() {
+    let cluster = fake_cluster(vec![
+        route(
+            "/apis/example.com/v1/namespaces/default/widgets",
+            json!({
+                "apiVersion": "example.com/v1",
+                "kind": "WidgetList",
+                "metadata": { "resourceVersion": "1" },
+                "items": [{
+                    "apiVersion": "example.com/v1",
+                    "kind": "Widget",
+                    "metadata": {
+                        "name": "w-1",
+                        "namespace": "default",
+                        "creationTimestamp": "2026-01-01T00:00:00Z",
+                    },
+                    "spec": { "size": 3 },
+                }],
+            }),
+        ),
+        route(
+            "/apis/example.com/v1/gadgets",
+            json!({
+                "apiVersion": "example.com/v1",
+                "kind": "GadgetList",
+                "metadata": { "resourceVersion": "1" },
+                "items": [{
+                    "metadata": { "name": "g-1" },
+                    "spec": { "size": 9 },
+                }],
+            }),
+        ),
+    ])
+    .await;
+    let (mut app, mut rx) = app_on(&cluster).await;
+
+    app.fetch_crd_instances(widget_crd());
+    let payload = action_result(&mut rx, "crd_instances:Widget")
+        .await
+        .expect("the namespaced list is published");
+    let items: Vec<Value> = serde_json::from_str(&payload).expect("a JSON array");
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["name"], "w-1");
+    assert_eq!(items[0]["namespace"], "default");
+    assert_eq!(items[0]["spec"]["size"], 3);
+    assert_eq!(
+        items[0]["metadata"]["name"], "w-1",
+        "the object metadata is folded back in"
+    );
+    assert!(
+        items[0]["age"].is_string() && items[0]["createdAt"].is_string(),
+        "creation time becomes an age and an ISO stamp: {}",
+        items[0]
+    );
+
+    app.fetch_crd_instances(gadget_crd());
+    let payload = action_result(&mut rx, "crd_instances:Gadget")
+        .await
+        .expect("the cluster-scoped list is published");
+    let items: Vec<Value> = serde_json::from_str(&payload).expect("a JSON array");
+    assert_eq!(items[0]["name"], "g-1");
+    assert!(
+        items[0].get("namespace").is_none(),
+        "a cluster-scoped object gets no namespace"
+    );
+    assert!(
+        items[0].get("age").is_none(),
+        "no creation timestamp means no age"
+    );
+
+    // Feeding a payload back through the handler fills the CRD table.
+    app.switch_view_to_crd(widget_crd()).await;
+    app.handle_crd_instances_update(
+        "crd_instances:Widget",
+        &json!([{ "name": "w-1", "namespace": "default" }]).to_string(),
+    );
+    match &app.active_view {
+        ActiveView::Table(t) => assert_eq!(t.raw_items.len(), 1),
+        _ => panic!("expected the widget table"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pod containers from the API
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn pod_containers_come_from_the_api_when_the_informer_cache_has_nothing() {
+    let cluster = fake_cluster(vec![route(
+        "/api/v1/namespaces/default/pods/web-0",
+        json!({
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": { "name": "web-0", "namespace": "default" },
+            "spec": {
+                "containers": [
+                    { "name": "app", "image": "busybox" },
+                    { "name": "sidecar", "image": "busybox" }
+                ],
+                "initContainers": [{ "name": "init", "image": "busybox" }],
+                "ephemeralContainers": [{ "name": "debugger", "image": "busybox" }],
+            },
+        }),
+    )])
+    .await;
+    let (app, _rx) = app_on(&cluster).await;
+
+    let containers = app.get_pod_containers("web-0", Some("default")).await;
+    assert_eq!(containers, vec!["app", "sidecar", "init", "debugger"]);
+
+    assert!(
+        app.get_pod_containers("missing", Some("default"))
+            .await
+            .is_empty(),
+        "a pod the apiserver does not know has no containers"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Live YAML
+// ---------------------------------------------------------------------------
+
+fn yaml_text(app: &App) -> String {
+    match &app.active_view {
+        ActiveView::Yaml(y) => y.yaml_content.clone(),
+        other => panic!(
+            "expected the YAML view, got {:?}",
+            std::mem::discriminant(other)
+        ),
+    }
+}
+
+fn describe_text(app: &App) -> String {
+    match &app.active_view {
+        ActiveView::Describe(d) => d.content.clone(),
+        other => panic!(
+            "expected the describe view, got {:?}",
+            std::mem::discriminant(other)
+        ),
+    }
+}
+
+#[tokio::test]
+async fn the_yaml_view_serialises_the_live_object_for_builtin_and_custom_kinds() {
+    let cluster = fake_cluster(vec![
+        route(
+            "/api/v1/namespaces/default/pods/web-0",
+            json!({
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "metadata": {
+                    "name": "web-0",
+                    "namespace": "default",
+                    "managedFields": [{ "manager": "kubectl", "operation": "Apply" }],
+                },
+                "spec": { "containers": [{ "name": "app", "image": "busybox" }] },
+            }),
+        ),
+        route(
+            "/api/v1/nodes/node-a",
+            json!({
+                "apiVersion": "v1",
+                "kind": "Node",
+                "metadata": { "name": "node-a" },
+                "spec": {},
+            }),
+        ),
+        route(
+            "/apis/example.com/v1/namespaces/default/widgets/w-1",
+            json!({
+                "apiVersion": "example.com/v1",
+                "kind": "Widget",
+                "metadata": { "name": "w-1", "namespace": "default" },
+                "spec": { "size": 3 },
+            }),
+        ),
+        route(
+            "/apis/example.com/v1/gadgets/g-1",
+            json!({
+                "apiVersion": "example.com/v1",
+                "kind": "Gadget",
+                "metadata": { "name": "g-1" },
+                "spec": { "size": 9 },
+            }),
+        ),
+    ])
+    .await;
+    let (mut app, _rx) = app_on(&cluster).await;
+    app.crds = vec![widget_crd(), gadget_crd()];
+
+    app.open_yaml_view("web-0".into(), "Pod".into(), Some("default".into()))
+        .await;
+    let text = yaml_text(&app);
+    assert!(text.contains("name: web-0"), "{text}");
+    assert!(
+        !text.contains("managedFields"),
+        "server-side apply bookkeeping is stripped:\n{text}"
+    );
+    assert_eq!(app.nav_stack.len(), 1);
+
+    app.open_yaml_view("node-a".into(), "Node".into(), None)
+        .await;
+    assert!(
+        yaml_text(&app).contains("name: node-a"),
+        "a cluster-scoped builtin is fetched without a namespace"
+    );
+
+    app.open_yaml_view("w-1".into(), "Widget".into(), Some("default".into()))
+        .await;
+    let text = yaml_text(&app);
+    assert!(text.contains("name: w-1"), "{text}");
+    assert!(text.contains("size: 3"), "{text}");
+
+    app.open_yaml_view("g-1".into(), "gadgets".into(), None)
+        .await;
+    assert!(
+        yaml_text(&app).contains("name: g-1"),
+        "a CRD is matched by its plural too"
+    );
+    assert_eq!(app.nav_stack.len(), 4, "each view stacks on the last");
+}
+
+#[tokio::test]
+async fn the_yaml_view_reports_the_kubectl_fallback_failing_when_nothing_can_serve_the_manifest() {
+    // No cluster and a KUBECONFIG that does not exist: the API path fails,
+    // the kubectl fallback fails, and the view shows the error manifest.
+    let (mut app, _rx) = common::app_with(FAKE_CONTEXT, "default").await;
+    app.kubeconfig_paths = vec![PathBuf::from("no-such-kubeconfig-a"), PathBuf::from("b")];
+
+    app.open_yaml_view("web-0".into(), "Pod".into(), Some("default".into()))
+        .await;
+    assert_eq!(
+        yaml_text(&app),
+        "# Error: Unable to fetch live manifest for Pod/web-0 in namespace default\n"
+    );
+
+    // An explicitly empty namespace is not passed to kubectl as `-n`, and it
+    // is reported verbatim rather than as "default".
+    app.open_yaml_view("cm-1".into(), "ConfigMap".into(), Some(String::new()))
+        .await;
+    assert_eq!(
+        yaml_text(&app),
+        "# Error: Unable to fetch live manifest for ConfigMap/cm-1 in namespace \n"
+    );
+
+    // No namespace and no context at all still produces the error manifest.
+    app.active_context = String::new();
+    app.kubeconfig_paths.clear();
+    app.open_yaml_view("node-a".into(), "Node".into(), None)
+        .await;
+    assert_eq!(
+        yaml_text(&app),
+        "# Error: Unable to fetch live manifest for Node/node-a in namespace default\n"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Describe
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn describing_a_service_renders_its_metadata_spec_and_events() {
+    let cluster = fake_cluster(vec![
+        route(
+            "/api/v1/namespaces/default/services/web",
+            json!({
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "name": "web",
+                    "namespace": "default",
+                    "labels": { "app": "web", "tier": "front" },
+                    "annotations": {
+                        "owner": "team-a",
+                        "note": "second",
+                        "example.com/managed-fields-hint": "skipped",
+                    },
+                },
+                "spec": {
+                    "selector": { "app": "web" },
+                    "type": "ClusterIP",
+                    "clusterIP": "10.0.0.9",
+                    "ports": [
+                        { "name": "http", "port": 80, "protocol": "TCP", "targetPort": 8080 },
+                        { "port": 443 },
+                    ],
+                },
+            }),
+        ),
+        route(
+            "/api/v1/namespaces/default/events",
+            json!({
+                "apiVersion": "v1",
+                "kind": "EventList",
+                "metadata": { "resourceVersion": "1" },
+                "items": [{
+                    "metadata": { "name": "e1", "namespace": "default" },
+                    "involvedObject": { "kind": "Service", "name": "web" },
+                    "type": "Warning",
+                    "reason": "NoEndpoints",
+                    "message": "no backends",
+                    "source": { "component": "endpoint-controller" },
+                    "lastTimestamp": "2026-01-01T00:00:00Z",
+                }],
+            }),
+        ),
+    ])
+    .await;
+    let (mut app, _rx) = app_on(&cluster).await;
+
+    app.open_describe_view("web".into(), "Service".into(), Some("default".into()))
+        .await;
+    let text = describe_text(&app);
+    assert!(text.contains("Name:                     web"), "{text}");
+    assert!(text.contains("Namespace:                default"), "{text}");
+    assert!(text.contains("app=web"), "{text}");
+    assert!(text.contains("tier=front"), "labels are listed:\n{text}");
+    assert!(text.contains("owner: team-a"), "{text}");
+    assert!(
+        !text.contains("skipped"),
+        "managed-fields annotations are dropped:\n{text}"
+    );
+    assert!(text.contains("Selector:"), "{text}");
+    assert!(text.contains("ClusterIP"), "{text}");
+    assert!(text.contains("10.0.0.9"), "{text}");
+    assert!(text.contains("http  80/TCP"), "{text}");
+    assert!(text.contains("TargetPort:"), "{text}");
+    assert!(
+        text.contains("443/TCP"),
+        "a port without a name still shows"
+    );
+    assert!(text.contains("NoEndpoints"), "{text}");
+    assert!(text.contains("endpoint-controller"), "{text}");
+    assert_eq!(app.nav_stack.len(), 1);
+}
+
+#[tokio::test]
+async fn describing_a_cluster_scoped_object_without_events_says_none() {
+    let cluster = fake_cluster(vec![
+        route(
+            "/api/v1/nodes/node-a",
+            json!({
+                "apiVersion": "v1",
+                "kind": "Node",
+                "metadata": { "name": "node-a" },
+                "spec": {},
+            }),
+        ),
+        route(
+            "/api/v1/events",
+            json!({
+                "apiVersion": "v1",
+                "kind": "EventList",
+                "metadata": { "resourceVersion": "1" },
+                "items": [],
+            }),
+        ),
+    ])
+    .await;
+    let (mut app, _rx) = app_on(&cluster).await;
+
+    app.open_describe_view("node-a".into(), "Node".into(), None)
+        .await;
+    let text = describe_text(&app);
+    assert!(text.contains("Name:                     node-a"), "{text}");
+    assert!(
+        !text.contains("Namespace:"),
+        "a cluster-scoped object has no namespace line:\n{text}"
+    );
+    assert!(text.contains("Events:"), "{text}");
+    assert!(text.contains("<none>"), "{text}");
+}
+
+#[tokio::test]
+async fn describing_a_resource_whose_events_cannot_be_listed_still_renders_the_object() {
+    let cluster = fake_cluster(vec![
+        route(
+            "/api/v1/namespaces/default/configmaps/settings",
+            json!({
+                "apiVersion": "v1",
+                "kind": "ConfigMap",
+                "metadata": { "name": "settings", "namespace": "default" },
+                "data": { "key": "value" },
+            }),
+        ),
+        failing_route("/api/v1/namespaces/default/events", 500),
+    ])
+    .await;
+    let (mut app, _rx) = app_on(&cluster).await;
+
+    app.open_describe_view(
+        "settings".into(),
+        "ConfigMap".into(),
+        Some("default".into()),
+    )
+    .await;
+    let text = describe_text(&app);
+    assert!(
+        text.contains("Name:                     settings"),
+        "{text}"
+    );
+    assert!(
+        text.contains("Events:") && text.contains("<none>"),
+        "an unlistable event feed reads as none:\n{text}"
+    );
+}
+
+#[tokio::test]
+async fn describing_something_no_backend_can_reach_reports_the_failure() {
+    let (mut app, _rx) = common::app_with(FAKE_CONTEXT, "default").await;
+    app.kubeconfig_paths = vec![PathBuf::from("no-such-kubeconfig")];
+
+    app.open_describe_view("web-0".into(), "Pod".into(), Some("default".into()))
+        .await;
+    assert_eq!(
+        describe_text(&app),
+        "Error: Unable to describe Pod/web-0 in namespace default\n"
+    );
+
+    app.active_context = String::new();
+    app.kubeconfig_paths.clear();
+    app.open_describe_view("web-0".into(), "Pod".into(), Some(String::new()))
+        .await;
+    assert_eq!(
+        describe_text(&app),
+        "Error: Unable to describe Pod/web-0 in namespace \n",
+        "an explicitly empty namespace stays empty in the message"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Destructive confirmations: delete, restart, scale
+// ---------------------------------------------------------------------------
+
+fn pods_table(app: &mut App, names: &[&str]) {
+    let mut table = ResourceTableState::new(ResourceKind::Pods);
+    table.set_items(
+        names
+            .iter()
+            .map(|n| json!({ "name": n, "namespace": "default", "status": "Running" }))
+            .collect(),
+        "",
+    );
+    table.is_loading = false;
+    app.active_view = ActiveView::Table(table);
+}
+
+fn table_names(app: &App) -> Vec<String> {
+    match &app.active_view {
+        ActiveView::Table(t) => t
+            .raw_items
+            .iter()
+            .filter_map(|i| i.get("name").and_then(|v| v.as_str()).map(String::from))
+            .collect(),
+        _ => panic!("expected a table"),
+    }
+}
+
+#[tokio::test]
+async fn confirming_a_delete_drops_the_row_and_a_rejected_delete_toasts_the_error() {
+    let cluster = fake_cluster(vec![
+        route(
+            "/api/v1/namespaces/default/pods/web-0",
+            json!({ "apiVersion": "v1", "kind": "Pod", "metadata": { "name": "web-0" } }),
+        ),
+        failing_route("/api/v1/namespaces/default/pods/web-1", 409),
+    ])
+    .await;
+    let (mut app, _rx) = app_on(&cluster).await;
+    pods_table(&mut app, &["web-0", "web-1"]);
+
+    app.execute_modal_confirm("delete:Pod:default:web-0".into())
+        .await;
+    assert_eq!(toast(&app), "✓ Deleted Pod 'web-0' in 'default'");
+    assert_eq!(
+        table_names(&app),
+        vec!["web-1".to_string()],
+        "the deleted row leaves the table immediately"
+    );
+
+    app.execute_modal_confirm("delete:Pod:default:web-1".into())
+        .await;
+    assert!(
+        toast(&app).starts_with("Delete failed:"),
+        "toast: {}",
+        toast(&app)
+    );
+    assert_eq!(
+        table_names(&app),
+        vec!["web-1".to_string()],
+        "a rejected delete leaves the row alone"
+    );
+}
+
+#[tokio::test]
+async fn a_delete_resolves_custom_kinds_and_refuses_ones_it_cannot_place() {
+    let cluster = fake_cluster(vec![
+        route(
+            "/apis/example.com/v1/namespaces/default/widgets/w-1",
+            json!({ "apiVersion": "example.com/v1", "kind": "Widget", "metadata": { "name": "w-1" } }),
+        ),
+        route(
+            "/apis/example.com/v1/gadgets/g-1",
+            json!({ "apiVersion": "example.com/v1", "kind": "Gadget", "metadata": { "name": "g-1" } }),
+        ),
+    ])
+    .await;
+    let (mut app, _rx) = app_on(&cluster).await;
+    app.crds = vec![widget_crd(), gadget_crd()];
+
+    app.execute_modal_confirm("delete:Widget:default:w-1".into())
+        .await;
+    assert_eq!(toast(&app), "✓ Deleted Widget 'w-1' in 'default'");
+
+    app.execute_modal_confirm("delete:gadgets::g-1".into())
+        .await;
+    assert_eq!(
+        toast(&app),
+        "✓ Deleted gadgets 'g-1' in ''",
+        "a cluster-scoped custom resource needs no namespace"
+    );
+
+    app.execute_modal_confirm("delete:Nonesuch:default:x".into())
+        .await;
+    assert_eq!(toast(&app), "Cannot resolve resource kind 'Nonesuch'");
+
+    app.execute_modal_confirm("delete:malformed".into()).await;
+    assert_eq!(
+        toast(&app),
+        "Resource deleted successfully",
+        "a malformed action name is treated as already done"
+    );
+}
+
+#[tokio::test]
+async fn a_restart_patches_the_workload_and_reports_what_it_could_not_restart() {
+    let cluster = fake_cluster(vec![
+        route(
+            "/apis/apps/v1/namespaces/default/deployments/web",
+            json!({ "apiVersion": "apps/v1", "kind": "Deployment", "metadata": { "name": "web" } }),
+        ),
+        failing_route("/apis/apps/v1/namespaces/default/statefulsets/db", 404),
+    ])
+    .await;
+    let (mut app, _rx) = app_on(&cluster).await;
+
+    app.execute_modal_confirm("restart:Deployment:default:web".into())
+        .await;
+    assert_eq!(
+        toast(&app),
+        "✓ Rollout restart triggered for Deployment 'web'"
+    );
+
+    app.execute_modal_confirm("restart:StatefulSet:default:db".into())
+        .await;
+    assert!(
+        toast(&app).starts_with("Restart failed:"),
+        "toast: {}",
+        toast(&app)
+    );
+
+    app.execute_modal_confirm("restart:Nonesuch:default:x".into())
+        .await;
+    assert_eq!(toast(&app), "Cannot restart resource kind 'Nonesuch'");
+
+    app.execute_modal_confirm("restart:malformed".into()).await;
+    assert_eq!(toast(&app), "Rollout restart triggered");
+
+    app.execute_modal_confirm("stop-pf:pf-1".into()).await;
+    assert_eq!(toast(&app), "Port forward stopped");
+}
+
+#[tokio::test]
+async fn a_confirmation_without_a_reachable_cluster_toasts_a_connection_error() {
+    let (mut app, _rx) = common::app_with(FAKE_CONTEXT, "default").await;
+
+    app.execute_modal_confirm("delete:Pod:default:web-0".into())
+        .await;
+    assert!(
+        toast(&app).starts_with("Connection error:"),
+        "toast: {}",
+        toast(&app)
+    );
+
+    app.execute_modal_confirm("restart:Deployment:default:web".into())
+        .await;
+    assert!(
+        toast(&app).starts_with("Connection error:"),
+        "toast: {}",
+        toast(&app)
+    );
+
+    app.execute_scale_workload("web".into(), 3).await;
+    assert!(
+        toast(&app).starts_with("Connection error:"),
+        "toast: {}",
+        toast(&app)
+    );
+}
+
+#[tokio::test]
+async fn scaling_patches_the_selected_workload_and_surfaces_a_rejection() {
+    let cluster = fake_cluster(vec![
+        route(
+            "/apis/apps/v1/namespaces/prod/deployments/web",
+            json!({ "apiVersion": "apps/v1", "kind": "Deployment", "metadata": { "name": "web" } }),
+        ),
+        failing_route("/apis/apps/v1/namespaces/default/deployments/ghost", 404),
+    ])
+    .await;
+    let (mut app, _rx) = app_on(&cluster).await;
+
+    // The namespace comes from the selected row, not the active namespace.
+    let mut table = ResourceTableState::new(ResourceKind::Deployments);
+    table.set_items(
+        vec![json!({ "name": "web", "namespace": "prod", "ready": "1/1" })],
+        "",
+    );
+    table.is_loading = false;
+    app.active_view = ActiveView::Table(table);
+
+    app.execute_scale_workload("web".into(), 5).await;
+    assert_eq!(toast(&app), "✓ Scaled Deployments 'web' to 5 replicas");
+
+    // Off a table the kind defaults to Deployment in the active namespace.
+    app.active_view = ActiveView::Assistant;
+    app.execute_scale_workload("ghost".into(), 2).await;
+    assert!(
+        toast(&app).starts_with("Scale failed:"),
+        "toast: {}",
+        toast(&app)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Node inspector keys
+// ---------------------------------------------------------------------------
+
+fn node_pod(name: &str, ns: &str) -> NodePodItem {
+    NodePodItem {
+        name: name.into(),
+        namespace: ns.into(),
+        phase: "Running".into(),
+        ready_containers: "1/1".into(),
+        restarts: 0,
+        age: "1d".into(),
+        cpu_requests_millicores: 100,
+        mem_requests_mib: 128,
+        gpu_requests: 0,
+        gpu_mem_requests_mib: 0,
+        pod_ip: "10.0.0.2".into(),
+    }
+}
+
+fn inspector(name: &str, unschedulable: bool, with_pods: bool) -> NodeInspectorState {
+    let mut state = NodeInspectorState::new(name.into());
+    state.set_details(NodeInspectorDetails {
+        name: name.into(),
+        status: "Ready".into(),
+        unschedulable,
+        roles: "worker".into(),
+        instance_type: "m5.large".into(),
+        zone: None,
+        region: None,
+        nodepool: None,
+        internal_ip: None,
+        external_ip: None,
+        os_image: "Ubuntu".into(),
+        kernel_version: "6.1".into(),
+        container_runtime: "containerd".into(),
+        kubelet_version: "v1.31.7".into(),
+        architecture: "amd64".into(),
+        created_at: "2026-01-01T00:00:00Z".into(),
+        cpu_capacity_millicores: 4000,
+        cpu_allocatable_millicores: 3800,
+        cpu_requests_millicores: 100,
+        mem_capacity_mib: 8192,
+        mem_allocatable_mib: 7800,
+        mem_requests_mib: 128,
+        pods_capacity: 110,
+        pods_allocatable: 110,
+        pods_count: if with_pods { 1 } else { 0 },
+        has_gpu: false,
+        gpu_model: None,
+        gpu_driver_version: None,
+        gpu_cuda_version: None,
+        gpu_capacity_count: 0,
+        gpu_allocatable_count: 0,
+        gpu_requests_count: 0,
+        gpu_memory_total_mib: None,
+        gpu_memory_requests_mib: 0,
+        conditions: vec![],
+        taints: vec![],
+        pods: if with_pods {
+            vec![node_pod("api-0", "default")]
+        } else {
+            vec![]
+        },
+    });
+    state
+}
+
+#[tokio::test]
+async fn cordoning_and_uncordoning_a_node_patches_it_and_reports_which_way_it_went() {
+    let cluster = fake_cluster(vec![route(
+        "/api/v1/nodes/gpu-1",
+        json!({ "apiVersion": "v1", "kind": "Node", "metadata": { "name": "gpu-1" } }),
+    )])
+    .await;
+    let (mut app, mut rx) = app_on(&cluster).await;
+
+    app.active_view = ActiveView::NodeInspector(inspector("gpu-1", false, false));
+    app.handle_key_event(common::ch('c')).await;
+    assert_eq!(toast(&app), "Cordoning node 'gpu-1'...");
+    assert_eq!(
+        action_result(&mut rx, "cordon_node:gpu-1").await,
+        Ok("Cordoned node 'gpu-1'".to_string())
+    );
+
+    app.active_view = ActiveView::NodeInspector(inspector("gpu-1", true, false));
+    app.handle_key_event(common::ch('c')).await;
+    assert_eq!(toast(&app), "Uncordoning node 'gpu-1'...");
+    assert_eq!(
+        action_result(&mut rx, "cordon_node:gpu-1").await,
+        Ok("Uncordoned node 'gpu-1'".to_string())
+    );
+}
+
+#[tokio::test]
+async fn a_cordon_the_apiserver_rejects_is_reported_as_an_error() {
+    let cluster = fake_cluster(vec![failing_route("/api/v1/nodes/gpu-1", 409)]).await;
+    let (mut app, mut rx) = app_on(&cluster).await;
+
+    app.active_view = ActiveView::NodeInspector(inspector("gpu-1", false, false));
+    app.handle_key_event(common::ch('c')).await;
+    let err = action_result(&mut rx, "cordon_node:gpu-1")
+        .await
+        .expect_err("a 409 fails the patch");
+    assert!(!err.is_empty(), "the apiserver error is carried back");
+}
+
+#[tokio::test]
+async fn the_node_inspector_describes_and_shows_yaml_for_the_node_or_the_highlighted_pod() {
+    let (mut app, _rx) = common::app_with(FAKE_CONTEXT, "default").await;
+    app.kubeconfig_paths = vec![PathBuf::from("no-such-kubeconfig")];
+
+    // With pods listed, the pod-scoped keys act on the highlighted pod.
+    app.active_view = ActiveView::NodeInspector(inspector("gpu-1", false, true));
+    app.handle_key_event(common::ch('d')).await;
+    match &app.active_view {
+        ActiveView::Describe(d) => {
+            assert_eq!(d.resource_name, "api-0");
+            assert_eq!(d.resource_kind, "Pod");
+        }
+        _ => panic!("expected a describe view for the highlighted pod"),
+    }
+
+    app.active_view = ActiveView::NodeInspector(inspector("gpu-1", false, true));
+    app.handle_key_event(common::ch('y')).await;
+    match &app.active_view {
+        ActiveView::Yaml(y) => assert_eq!(y.resource_name, "api-0"),
+        _ => panic!("expected the pod's YAML"),
+    }
+
+    // The upper-case variants always target the node itself.
+    app.active_view = ActiveView::NodeInspector(inspector("gpu-1", false, true));
+    app.handle_key_event(common::ch('D')).await;
+    match &app.active_view {
+        ActiveView::Describe(d) => assert_eq!(d.resource_kind, "Node"),
+        _ => panic!("expected the node's describe"),
+    }
+
+    app.active_view = ActiveView::NodeInspector(inspector("gpu-1", false, true));
+    app.handle_key_event(common::ch('Y')).await;
+    match &app.active_view {
+        ActiveView::Yaml(y) => {
+            assert_eq!(y.resource_name, "gpu-1");
+            assert_eq!(y.resource_kind, "Node");
+        }
+        _ => panic!("expected the node's YAML"),
+    }
+
+    // With no pods at all the lower-case keys fall back to the node.
+    app.active_view = ActiveView::NodeInspector(inspector("gpu-1", false, false));
+    app.handle_key_event(common::ch('d')).await;
+    match &app.active_view {
+        ActiveView::Describe(d) => assert_eq!(d.resource_name, "gpu-1"),
+        _ => panic!("expected the node's describe"),
+    }
+
+    app.active_view = ActiveView::NodeInspector(inspector("gpu-1", false, false));
+    app.handle_key_event(common::ch('y')).await;
+    match &app.active_view {
+        ActiveView::Yaml(y) => assert_eq!(y.resource_name, "gpu-1"),
+        _ => panic!("expected the node's YAML"),
+    }
+}
+
+#[tokio::test]
+async fn the_node_inspector_offers_a_debug_shell_command_and_an_action_palette() {
+    let (mut app, _rx) = common::app_with(FAKE_CONTEXT, "default").await;
+
+    app.active_view = ActiveView::NodeInspector(inspector("gpu-1", false, true));
+    app.handle_key_event(common::ch('s')).await;
+    assert_eq!(
+        toast(&app),
+        "Node debug command: kubectl debug node/gpu-1 -it --image=busybox"
+    );
+
+    app.handle_key_event(common::ch('x')).await;
+    match &app.modal {
+        Some(Modal::ActionPalette {
+            resource_kind,
+            resource_name,
+            ..
+        }) => {
+            assert_eq!(resource_kind, "Pod");
+            assert_eq!(resource_name, "api-0", "the palette targets the pod");
+        }
+        other => panic!("expected the action palette, got {:?}", other),
+    }
+    app.modal = None;
+
+    app.active_view = ActiveView::NodeInspector(inspector("gpu-1", false, false));
+    app.handle_key_event(common::ch('x')).await;
+    match &app.modal {
+        Some(Modal::ActionPalette {
+            resource_kind,
+            resource_name,
+            ..
+        }) => {
+            assert_eq!(resource_kind, "Node");
+            assert_eq!(resource_name, "gpu-1");
+        }
+        other => panic!("expected the action palette, got {:?}", other),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Table keys that open a resource
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn table_keys_open_yaml_describe_and_the_editor_for_the_selected_row() {
+    let (mut app, _rx) = common::app_with(FAKE_CONTEXT, "default").await;
+    app.kubeconfig_paths = vec![PathBuf::from("no-such-kubeconfig")];
+
+    pods_table(&mut app, &["web-0"]);
+    app.handle_key_event(common::ch('y')).await;
+    match &app.active_view {
+        ActiveView::Yaml(y) => {
+            assert_eq!(y.resource_name, "web-0");
+            assert_eq!(y.resource_kind, "Pod");
+        }
+        _ => panic!("expected the YAML view"),
+    }
+
+    pods_table(&mut app, &["web-0"]);
+    app.handle_key_event(common::ch('d')).await;
+    match &app.active_view {
+        ActiveView::Describe(d) => assert_eq!(d.resource_name, "web-0"),
+        _ => panic!("expected the describe view"),
+    }
+
+    pods_table(&mut app, &["web-0"]);
+    app.handle_key_event(common::ch('e')).await;
+    assert!(matches!(app.active_view, ActiveView::Yaml(_)));
+    assert!(
+        matches!(app.requires_terminal_suspend, Some(SuspendAction::EditYaml)),
+        "'e' opens the manifest and asks the shell to hand over the terminal"
+    );
+}
+
+#[tokio::test]
+async fn on_an_events_table_yaml_and_describe_follow_the_involved_object() {
+    let (mut app, _rx) = common::app_with(FAKE_CONTEXT, "default").await;
+    app.kubeconfig_paths = vec![PathBuf::from("no-such-kubeconfig")];
+
+    let events = vec![json!({
+        "name": "e1",
+        "namespace": "default",
+        "reason": "BackOff",
+        "type": "Warning",
+        "object": "Pod/web-1",
+        "age": "2m",
+        "message": "restarting",
+    })];
+    let events_table = |app: &mut App| {
+        let mut table = ResourceTableState::new(ResourceKind::Events);
+        table.set_items(events.clone(), "");
+        table.is_loading = false;
+        app.active_view = ActiveView::Table(table);
+    };
+
+    events_table(&mut app);
+    app.handle_key_event(common::ch('y')).await;
+    match &app.active_view {
+        ActiveView::Yaml(y) => {
+            assert_eq!(y.resource_name, "web-1");
+            assert_eq!(y.resource_kind, "Pod");
+        }
+        _ => panic!("expected the involved object's YAML"),
+    }
+
+    events_table(&mut app);
+    app.handle_key_event(common::ch('d')).await;
+    match &app.active_view {
+        ActiveView::Describe(d) => {
+            assert_eq!(d.resource_name, "web-1");
+            assert_eq!(d.resource_kind, "Pod");
+        }
+        _ => panic!("expected the involved object's describe"),
+    }
+
+    events_table(&mut app);
+    app.handle_key_event(common::ch('c')).await;
+    assert_eq!(toast(&app), "✓ Copied event message to clipboard");
+}
+
+// ---------------------------------------------------------------------------
+// Tree, port-forward, Helm and toolbox keys
+// ---------------------------------------------------------------------------
+
+fn tree_view() -> TreeViewState {
+    let mut root = LineageNode::new(
+        "Deployment",
+        "web",
+        Some("default".to_string()),
+        LineageRelation::Target,
+    );
+    root.children.push(LineageNode::new(
+        "Pod",
+        "web-1",
+        Some("default".to_string()),
+        LineageRelation::Child,
+    ));
+    let mut tree = TreeViewState::new("Deployment".into(), "web".into(), Some("default".into()));
+    tree.set_tree(root);
+    tree
+}
+
+#[tokio::test]
+async fn tree_keys_copy_a_node_the_whole_tree_and_open_the_selection() {
+    let (mut app, _rx) = common::app_with(FAKE_CONTEXT, "default").await;
+    app.kubeconfig_paths = vec![PathBuf::from("no-such-kubeconfig")];
+
+    app.active_view = ActiveView::Tree(tree_view());
+    app.handle_key_event(common::ch('c')).await;
+    assert_eq!(toast(&app), "✓ Copied 'web' to clipboard");
+
+    app.handle_key_event(common::shift(crossterm::event::KeyCode::Char('C')))
+        .await;
+    assert_eq!(
+        toast(&app),
+        "✓ Copied resource relationship tree to clipboard"
+    );
+
+    app.handle_key_event(common::ch('y')).await;
+    match &app.active_view {
+        ActiveView::Yaml(y) => {
+            assert_eq!(y.resource_name, "web");
+            assert_eq!(y.resource_kind, "Deployment");
+        }
+        _ => panic!("expected the selected node's YAML"),
+    }
+
+    app.active_view = ActiveView::Tree(tree_view());
+    app.handle_key_event(common::ch('d')).await;
+    match &app.active_view {
+        ActiveView::Describe(d) => assert_eq!(d.resource_name, "web"),
+        _ => panic!("expected the selected node's describe"),
+    }
+
+    app.active_view = ActiveView::Tree(tree_view());
+    app.handle_key_event(common::key(crossterm::event::KeyCode::Enter))
+        .await;
+    match &app.active_view {
+        ActiveView::Describe(d) => assert_eq!(d.resource_kind, "Deployment"),
+        _ => panic!("enter describes the selection"),
+    }
+
+    // Logs are only offered for pods.
+    app.active_view = ActiveView::Tree(tree_view());
+    app.handle_key_event(common::ch('l')).await;
+    assert_eq!(
+        toast(&app),
+        "Logs only available for Pods (selected Deployment)"
+    );
+
+    app.active_view = ActiveView::Tree(tree_view());
+    app.handle_key_event(common::ch('x')).await;
+    match &app.modal {
+        Some(Modal::ActionPalette { resource_name, .. }) => assert_eq!(resource_name, "web"),
+        other => panic!("expected the action palette, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn port_forward_keys_copy_the_local_url_a_deep_link_and_confirm_a_stop() {
+    let (mut app, _rx) = common::app_with(FAKE_CONTEXT, "default").await;
+    let mut pf = PortForwardViewState::new();
+    pf.set_forwards(vec![PortForwardEntry {
+        id: "pf-1".into(),
+        context: FAKE_CONTEXT.into(),
+        namespace: "default".into(),
+        target_type: "Pod".into(),
+        target_name: "web-0".into(),
+        local_port: 8080,
+        container_port: 80,
+        active_connections: 0,
+        bytes_rx: 0,
+        bytes_tx: 0,
+        status: "Active".into(),
+    }]);
+    app.active_view = ActiveView::PortForwards(pf);
+
+    app.handle_key_event(common::ch('c')).await;
+    assert_eq!(toast(&app), "Copied forward URL: http://127.0.0.1:8080");
+
+    app.handle_key_event(common::ctrl('y')).await;
+    assert!(
+        toast(&app).starts_with("Copied deep link:") && toast(&app).contains("web-0"),
+        "toast: {}",
+        toast(&app)
+    );
+
+    app.handle_key_event(common::ch('d')).await;
+    match &app.modal {
+        Some(Modal::Confirm {
+            title, action_name, ..
+        }) => {
+            assert_eq!(title, "Stop Port Forward [127.0.0.1:8080]");
+            assert_eq!(action_name, "stop-pf:pf-1");
+        }
+        other => panic!("expected the stop confirmation, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn helm_keys_copy_a_deep_link_and_open_the_values_and_manifest() {
+    let (mut app, _rx) = common::app_with(FAKE_CONTEXT, "default").await;
+    app.kubeconfig_paths = vec![PathBuf::from("no-such-kubeconfig")];
+    let helm = || {
+        let mut helm = HelmViewState::new();
+        helm.set_releases(vec![HelmReleaseItem {
+            name: "nginx".into(),
+            namespace: "default".into(),
+            revision: 3,
+            status: "deployed".into(),
+            chart: "nginx-15.0.0".into(),
+            app_version: "1.25".into(),
+            updated: "2026-01-01".into(),
+        }]);
+        helm
+    };
+
+    app.active_view = ActiveView::Helm(helm());
+    app.handle_key_event(common::ch('c')).await;
+    assert!(
+        toast(&app).starts_with("Copied deep link:") && toast(&app).contains("nginx"),
+        "toast: {}",
+        toast(&app)
+    );
+
+    app.handle_key_event(common::ctrl('y')).await;
+    assert!(
+        toast(&app).contains("HelmRelease"),
+        "toast: {}",
+        toast(&app)
+    );
+
+    app.active_view = ActiveView::Helm(helm());
+    app.handle_key_event(common::ch('v')).await;
+    match &app.active_view {
+        ActiveView::Yaml(y) => {
+            assert_eq!(y.resource_kind, "HelmValues");
+            assert_eq!(y.resource_name, "nginx");
+        }
+        _ => panic!("expected the Helm values view"),
+    }
+
+    app.active_view = ActiveView::Helm(helm());
+    app.handle_key_event(common::ch('y')).await;
+    match &app.active_view {
+        ActiveView::Yaml(y) => assert_eq!(y.resource_kind, "HelmManifest"),
+        _ => panic!("expected the Helm manifest view"),
+    }
+}
+
+#[tokio::test]
+async fn toolbox_keys_move_the_cursor_and_copy_the_tool_path_or_name() {
+    let (mut app, _rx) = common::app_with(FAKE_CONTEXT, "default").await;
+    app.active_view = ActiveView::Toolbox(ToolboxViewState {
+        tools: vec![
+            ToolStatusItem {
+                name: "kubectl".into(),
+                installed: true,
+                version: Some("v1.31.7".into()),
+                path: Some("/usr/local/bin/kubectl".into()),
+                required: true,
+            },
+            ToolStatusItem {
+                name: "helm".into(),
+                installed: false,
+                version: None,
+                path: None,
+                required: false,
+            },
+        ],
+        selected_idx: 0,
+    });
+
+    app.handle_key_event(common::ch('c')).await;
+    assert_eq!(toast(&app), "Copied tool info: /usr/local/bin/kubectl");
+
+    app.handle_key_event(common::ch('j')).await;
+    app.handle_key_event(common::ch('y')).await;
+    assert_eq!(
+        toast(&app),
+        "Copied tool info: helm",
+        "a tool with no path falls back to its name"
+    );
+
+    app.handle_key_event(common::ch('k')).await;
+    app.handle_key_event(common::ch('c')).await;
+    assert_eq!(toast(&app), "Copied tool info: /usr/local/bin/kubectl");
+}
+
+// ---------------------------------------------------------------------------
+// Assistant chords
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn assistant_chords_clear_the_conversation_and_toggle_tool_chips() {
+    let (mut app, _rx) = common::app_with(FAKE_CONTEXT, "default").await;
+    app.active_view = ActiveView::Assistant;
+    app.assistant_state
+        .add_assistant_message("the cluster is fine".into());
+
+    let expanded = app.assistant_state.expand_tools;
+    app.handle_key_event(common::ctrl('t')).await;
+    assert_ne!(
+        app.assistant_state.expand_tools, expanded,
+        "ctrl+t toggles tool-chip expansion"
+    );
+
+    app.handle_key_event(common::ctrl('l')).await;
+    assert_eq!(toast(&app), "✓ Conversation cleared");
+    assert_eq!(
+        app.assistant_state.messages.len(),
+        1,
+        "clearing leaves only the seeded greeting"
+    );
+    assert!(app.assistant_state.messages[0]
+        .content
+        .starts_with("Hello!"));
+}
+
+#[tokio::test]
+async fn ctrl_c_in_the_assistant_quits_instead_of_copying_the_last_answer() {
+    // `handle_key_event` treats Ctrl+C as the global quit before the assistant
+    // ever sees it, so the assistant's own Ctrl+C copy chord cannot fire.
+    let (mut app, _rx) = common::app_with(FAKE_CONTEXT, "default").await;
+    app.active_view = ActiveView::Assistant;
+    app.assistant_state
+        .add_assistant_message("the cluster is fine".into());
+
+    app.handle_key_event(common::ctrl('c')).await;
+    assert!(!app.is_running, "Ctrl+C exits the TUI");
+    assert_eq!(toast(&app), "", "nothing is copied on the way out");
+}
+
+// ---------------------------------------------------------------------------
+// Watch pool
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_full_watch_pool_evicts_its_oldest_channel_when_a_workloads_view_opens() {
+    let (mut app, _rx) = common::app_with(FAKE_CONTEXT, "default").await;
+    for i in 0..20 {
+        let channel = format!("watch:filler:{}", i);
+        app.active_watch_pool.push(channel.clone());
+        app.active_watch_channels.insert(channel);
+    }
+
+    app.switch_view_to_kind(ResourceKind::Workloads).await;
+
+    assert!(
+        !app.active_watch_channels.contains("watch:filler:0"),
+        "the oldest channel is evicted to make room"
+    );
+    assert!(
+        app.active_watch_channels
+            .contains(&format!("watch:{}:default:deployments", FAKE_CONTEXT)),
+        "the workloads view registers its constituent watches: {:?}",
+        app.active_watch_channels
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Live metrics refreshes
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_metrics_server_feeds_the_pod_table_and_the_node_history() {
+    let cluster = fake_cluster(vec![
+        route(
+            "/apis/metrics.k8s.io/v1beta1/namespaces/default/pods",
+            json!({
+                "apiVersion": "metrics.k8s.io/v1beta1",
+                "kind": "PodMetricsList",
+                "metadata": { "resourceVersion": "1" },
+                "items": [{
+                    "metadata": { "name": "web-0", "namespace": "default" },
+                    "containers": [
+                        { "name": "app", "usage": { "cpu": "200m", "memory": "1024Mi" } },
+                        { "name": "sidecar", "usage": { "cpu": "50m", "memory": "512Mi" } },
+                    ],
+                }],
+            }),
+        ),
+        route(
+            "/apis/metrics.k8s.io/v1beta1/nodes",
+            json!({
+                "apiVersion": "metrics.k8s.io/v1beta1",
+                "kind": "NodeMetricsList",
+                "metadata": { "resourceVersion": "1" },
+                "items": [{
+                    "metadata": { "name": "node-a" },
+                    "usage": { "cpu": "750m", "memory": "3072Mi" },
+                }],
+            }),
+        ),
+    ])
+    .await;
+    let (mut app, mut rx) = app_on(&cluster).await;
+    pods_table(&mut app, &["web-0"]);
+
+    app.refresh_pod_metrics();
+    let payload = action_result(&mut rx, "pod_metrics_updated")
+        .await
+        .expect("pod metrics are published");
+    app.handle_pod_metrics_update(&payload);
+    match &app.active_view {
+        ActiveView::Table(t) => {
+            assert_eq!(
+                t.raw_items[0]["cpu"], "250m",
+                "both containers count towards the pod's usage"
+            );
+            assert_eq!(t.raw_items[0]["memory"], "1.5Gi");
+        }
+        _ => panic!("expected the pods table"),
+    }
+    assert_eq!(app.pod_metrics_history["web-0"].len(), 1);
+
+    app.active_view = ActiveView::NodeInspector(inspector("node-a", false, false));
+    app.refresh_node_metrics();
+    let payload = action_result(&mut rx, "node_metrics_updated")
+        .await
+        .expect("node metrics are published");
+    app.handle_node_metrics_update(&payload);
+    match &app.active_view {
+        ActiveView::NodeInspector(ni) => {
+            assert_eq!(ni.cpu_history, vec![750]);
+            assert_eq!(ni.mem_history, vec![3072]);
+        }
+        _ => panic!("expected the node inspector"),
+    }
+}
+
+#[tokio::test]
+async fn a_cluster_without_a_metrics_server_publishes_no_metrics_at_all() {
+    let cluster = fake_cluster(vec![failing_route("/apis/metrics.k8s.io", 404)]).await;
+    let (app, mut rx) = app_on(&cluster).await;
+
+    app.refresh_pod_metrics();
+    app.refresh_node_metrics();
+    tokio::task::yield_now().await;
+    let titles: Vec<String> = common::drain(&mut rx)
+        .into_iter()
+        .filter_map(|ev| match ev {
+            AppEvent::ActionResult { title, .. } => Some(title),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        !titles.iter().any(|t| t.ends_with("metrics_updated")),
+        "a 404 from metrics.k8s.io publishes nothing: {titles:?}"
+    );
+    assert!(app.pod_metrics_history.is_empty());
+    assert!(app.node_metrics_history.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Command resolution
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_command_nothing_can_explain_toasts_that_it_is_unknown() {
+    let (mut app, _rx) = common::app_with(FAKE_CONTEXT, "default").await;
+
+    app.execute_colon_command("qqqqqqqqqq").await;
+    assert_eq!(
+        toast(&app),
+        "Unknown command: 'qqqqqqqqqq' (type :help or ?)"
+    );
+}
+
+#[tokio::test]
+async fn enter_on_a_plain_table_row_describes_it() {
+    let (mut app, _rx) = common::app_with(FAKE_CONTEXT, "default").await;
+    app.kubeconfig_paths = vec![PathBuf::from("no-such-kubeconfig")];
+
+    let mut table = ResourceTableState::new(ResourceKind::ConfigMaps);
+    table.set_items(
+        vec![json!({ "name": "settings", "namespace": "default" })],
+        "",
+    );
+    table.is_loading = false;
+    app.active_view = ActiveView::Table(table);
+
+    app.handle_key_event(common::key(crossterm::event::KeyCode::Enter))
+        .await;
+    match &app.active_view {
+        ActiveView::Describe(d) => {
+            assert_eq!(d.resource_name, "settings");
+            assert_eq!(d.resource_kind, "ConfigMap");
+        }
+        _ => panic!("enter describes the selected row"),
+    }
+}
+
+#[tokio::test]
+async fn a_command_only_a_crd_short_name_can_explain_still_opens_that_crd() {
+    // Resolution never looks at CRD short names for a two-letter prefix, but
+    // the suggestion list does and scores it well above the confidence bar, so
+    // the app runs the top suggestion instead of complaining.
+    let (mut app, _rx) = common::app_with(FAKE_CONTEXT, "default").await;
+    let mut crd = widget_crd();
+    crd.plural = "zzthings".into();
+    crd.singular = "zzthing".into();
+    crd.short_names = vec!["wdgt".into()];
+    app.crds = vec![crd];
+
+    assert!(
+        srelens_tui::commands::resolve_command_with_crds("wd", &app.crds).is_none(),
+        "'wd' resolves to nothing on its own"
+    );
+
+    app.execute_colon_command("wd").await;
+    match &app.active_view {
+        ActiveView::Table(t) => match &t.kind {
+            ResourceKind::CustomResource(found) => assert_eq!(found.kind, "Widget"),
+            other => panic!("expected the custom resource table, got {}", other),
+        },
+        _ => panic!("expected a table"),
+    }
+    assert_eq!(toast(&app), "", "no complaint for a confident correction");
+}
+
+// ---------------------------------------------------------------------------
+// Clipboard copies that happen on a spawned task
+// ---------------------------------------------------------------------------
+
+/// Let the tasks the app just spawned (the clipboard writes) run to completion.
+async fn settle() {
+    for _ in 0..8 {
+        tokio::task::yield_now().await;
+    }
+}
+
+#[tokio::test]
+async fn copying_from_a_table_covers_one_row_a_marked_set_and_a_whole_manifest() {
+    let (mut app, _rx) = common::app_with(FAKE_CONTEXT, "default").await;
+    pods_table(&mut app, &["web-0", "web-1", "web-2"]);
+
+    app.handle_key_event(common::ch('c')).await;
+    settle().await;
+    assert_eq!(toast(&app), "✓ Copied 'web-0' to clipboard");
+
+    // Space marks a row; two marks make the copy a name list.
+    app.handle_key_event(common::ch(' ')).await;
+    app.handle_key_event(common::ch('j')).await;
+    app.handle_key_event(common::ch(' ')).await;
+    app.handle_key_event(common::ch('c')).await;
+    settle().await;
+    assert_eq!(toast(&app), "✓ Copied 2 resource names to clipboard");
+
+    app.handle_key_event(common::shift(crossterm::event::KeyCode::Char('C')))
+        .await;
+    settle().await;
+    assert!(
+        toast(&app).contains("Copied"),
+        "shift+C copies the row's manifest: {}",
+        toast(&app)
+    );
+}
+
+#[tokio::test]
+async fn copying_an_event_summary_a_tree_a_forward_link_and_a_tool_path_reaches_the_clipboard() {
+    let (mut app, _rx) = common::app_with(FAKE_CONTEXT, "default").await;
+
+    let mut table = ResourceTableState::new(ResourceKind::Events);
+    table.set_items(
+        vec![json!({
+            "name": "e1", "namespace": "default", "reason": "BackOff",
+            "type": "Warning", "object": "Pod/web-1", "age": "2m", "message": "restarting",
+        })],
+        "",
+    );
+    table.is_loading = false;
+    app.active_view = ActiveView::Table(table);
+    app.handle_key_event(common::ch('c')).await;
+    settle().await;
+    assert_eq!(toast(&app), "✓ Copied event message to clipboard");
+
+    app.active_view = ActiveView::Tree(tree_view());
+    app.handle_key_event(common::ch('c')).await;
+    settle().await;
+    assert_eq!(toast(&app), "✓ Copied 'web' to clipboard");
+    app.handle_key_event(common::shift(crossterm::event::KeyCode::Char('C')))
+        .await;
+    settle().await;
+    assert_eq!(
+        toast(&app),
+        "✓ Copied resource relationship tree to clipboard"
+    );
+
+    let mut pf = PortForwardViewState::new();
+    pf.set_forwards(vec![PortForwardEntry {
+        id: "pf-1".into(),
+        context: FAKE_CONTEXT.into(),
+        namespace: "default".into(),
+        target_type: "Pod".into(),
+        target_name: "web-0".into(),
+        local_port: 9090,
+        container_port: 90,
+        active_connections: 0,
+        bytes_rx: 0,
+        bytes_tx: 0,
+        status: "Active".into(),
+    }]);
+    app.active_view = ActiveView::PortForwards(pf);
+    app.handle_key_event(common::ch('c')).await;
+    settle().await;
+    assert_eq!(toast(&app), "Copied forward URL: http://127.0.0.1:9090");
+    app.handle_key_event(common::ctrl('y')).await;
+    settle().await;
+    assert!(toast(&app).starts_with("Copied deep link:"));
+
+    app.active_view = ActiveView::Toolbox(ToolboxViewState {
+        tools: vec![ToolStatusItem {
+            name: "kubectl".into(),
+            installed: true,
+            version: None,
+            path: Some("/usr/local/bin/kubectl".into()),
+            required: true,
+        }],
+        selected_idx: 0,
+    });
+    app.handle_key_event(common::ch('c')).await;
+    settle().await;
+    assert_eq!(toast(&app), "Copied tool info: /usr/local/bin/kubectl");
+}
+
+#[tokio::test]
+async fn releasing_a_drag_in_the_yaml_view_copies_the_dragged_lines() {
+    use crossterm::event::{MouseButton, MouseEventKind};
+
+    let (mut app, _rx) = common::app_with(FAKE_CONTEXT, "default").await;
+    let content: String = (0..12).map(|i| format!("line-{i}\n")).collect();
+    app.active_view = ActiveView::Yaml(srelens_tui::views::yaml_view::YamlViewState::new(
+        "web-0".into(),
+        "Pod".into(),
+        None,
+        content,
+    ));
+    common::render_app(&mut app, 120, 40);
+    let viewport = match &app.active_view {
+        ActiveView::Yaml(y) => y.last_viewport_rect.get(),
+        _ => unreachable!(),
+    };
+
+    app.handle_mouse(common::click(viewport.x + 1, viewport.y))
+        .await;
+    app.handle_mouse(common::mouse(
+        MouseEventKind::Drag(MouseButton::Left),
+        viewport.x + 1,
+        viewport.y + 2,
+    ))
+    .await;
+    app.handle_mouse(common::mouse(
+        MouseEventKind::Up(MouseButton::Left),
+        viewport.x + 1,
+        viewport.y + 2,
+    ))
+    .await;
+    settle().await;
+    assert_eq!(toast(&app), "✓ Copied selection to clipboard");
+    match &app.active_view {
+        ActiveView::Yaml(y) => {
+            assert_eq!(y.selected_text().as_deref(), Some("line-0\nline-1\nline-2"))
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[tokio::test]
+async fn a_mouse_event_the_node_inspector_has_no_use_for_leaves_it_alone() {
+    use crossterm::event::MouseEventKind;
+
+    let (mut app, _rx) = common::app_with(FAKE_CONTEXT, "default").await;
+    app.active_view = ActiveView::NodeInspector(inspector("gpu-1", false, true));
+    common::render_app(&mut app, 160, 45);
+    let rect = match &app.active_view {
+        ActiveView::NodeInspector(ni) => ni.last_pods_table_rect.get(),
+        _ => unreachable!(),
+    };
+
+    app.handle_mouse(common::mouse(MouseEventKind::Moved, rect.x + 1, rect.y + 1))
+        .await;
+    match &app.active_view {
+        ActiveView::NodeInspector(ni) => assert_eq!(ni.selected_pod_idx, 0),
+        _ => panic!("still the node inspector"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Action palettes
+// ---------------------------------------------------------------------------
+
+fn palette_titles(app: &App) -> Vec<String> {
+    match &app.modal {
+        Some(Modal::ActionPalette { actions, .. }) => {
+            actions.iter().map(|a| a.title.clone()).collect()
+        }
+        other => panic!("expected the action palette, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn the_ingress_action_palette_offers_the_tree_describe_yaml_and_delete() {
+    let (mut app, _rx) = common::app_with(FAKE_CONTEXT, "default").await;
+
+    app.open_action_palette("ingresses".into(), "web".into(), Some("default".into()));
+    let titles = palette_titles(&app);
+    assert_eq!(titles.len(), 4);
+    assert!(
+        titles[0].contains("Resource Relationship Tree"),
+        "titles: {titles:?}"
+    );
+    assert!(titles[1].contains("Describe Ingress"), "titles: {titles:?}");
+    assert!(titles[2].contains("View YAML"), "titles: {titles:?}");
+    assert!(titles[3].contains("Delete Ingress"), "titles: {titles:?}");
+
+    let screen = common::render_app(&mut app, 140, 40);
+    assert!(
+        screen.contains("Actions: ingresses/web (default)"),
+        "{screen}"
+    );
+
+    // The singular spelling reaches the same list.
+    app.open_action_palette("ingress".into(), "web".into(), None);
+    assert_eq!(palette_titles(&app).len(), 4);
+}
+
+// ---------------------------------------------------------------------------
+// Assistant composer
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn tab_in_the_assistant_completes_the_highlighted_slash_command() {
+    let (mut app, _rx) = common::app_with(FAKE_CONTEXT, "default").await;
+    app.active_view = ActiveView::Assistant;
+
+    common::type_str(&mut app, "/cav").await;
+    assert!(
+        !app.assistant_state.slash_suggestions.is_empty(),
+        "'/cav' offers at least one slash command"
+    );
+    let first = app.assistant_state.slash_suggestions[0].name;
+
+    app.handle_key_event(common::key(crossterm::event::KeyCode::Tab))
+        .await;
+    assert!(
+        app.assistant_state
+            .input
+            .starts_with(&format!("/{}", first)),
+        "tab completes to the highlighted suggestion: {:?}",
+        app.assistant_state.input
+    );
+
+    // With nothing to complete, Tab is not swallowed as a completion.
+    app.assistant_state.input.clear();
+    app.assistant_state.slash_suggestions.clear();
+    app.handle_key_event(common::key(crossterm::event::KeyCode::Tab))
+        .await;
+    assert_eq!(app.assistant_state.input, "");
+}

--- a/apps/tui/tests/app_input_tests.rs
+++ b/apps/tui/tests/app_input_tests.rs
@@ -1,0 +1,2918 @@
+//! Integration tests for `App`'s input handling: construction, key handling,
+//! command and filter modes, modals, navigation and the background-update
+//! handlers that feed state back into the app. Nothing here talks to a
+//! cluster; every cluster-bound path ends in the error/toast state the app
+//! shows when the context cannot be resolved.
+
+mod common;
+
+use std::time::{Duration, Instant};
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::style::Style;
+use serde_json::{json, Value};
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
+
+use srelens_kube::contexts::ContextDto;
+use srelens_tui::app::{ActiveView, App, SuspendAction};
+use srelens_tui::commands::{command_suggestions_with_crds, CrdMeta, PrinterColumn, ResourceKind};
+use srelens_tui::event::AppEvent;
+use srelens_tui::ui::{ContainerAction, InputMode, Modal};
+use srelens_tui::views::metrics_panel_view::MetricsTimeRange;
+use srelens_tui::views::overview_view::ClusterOverviewData;
+use srelens_tui::views::resource_table::WorkloadSegment;
+use srelens_tui::views::{
+    DescribeViewState, LogsViewState, NodeInspectorState, ResourceTableState, YamlViewState,
+};
+
+use common::{ch, ctrl, key, shift, type_str};
+
+// ---------------------------------------------------------------------------
+// Local helpers
+// ---------------------------------------------------------------------------
+
+async fn press(app: &mut App, k: KeyEvent) {
+    app.handle_key_event(k).await;
+}
+
+fn table(app: &App) -> &ResourceTableState {
+    match &app.active_view {
+        ActiveView::Table(t) => t,
+        _ => panic!("expected a table view"),
+    }
+}
+
+fn table_mut(app: &mut App) -> &mut ResourceTableState {
+    match &mut app.active_view {
+        ActiveView::Table(t) => t,
+        _ => panic!("expected a table view"),
+    }
+}
+
+fn set_table(app: &mut App, kind: ResourceKind, items: Vec<Value>) {
+    let mut t = ResourceTableState::new(kind);
+    t.set_items(items, "");
+    app.active_view = ActiveView::Table(t);
+}
+
+/// Set the active table *and* prime the informer cache for its kind. Popping
+/// back to a table re-runs `restart_active_watch`, which clears the rows
+/// unless the cache can re-prime them, so any test that navigates away and
+/// comes back needs the cache seeded too.
+fn seed_table(app: &mut App, kind: ResourceKind, items: Vec<Value>) {
+    if let Some(watch_kind) = kind.watch_kind() {
+        app.resource_cache.insert(
+            (
+                app.active_context.clone(),
+                app.active_namespace.clone(),
+                watch_kind.to_string(),
+            ),
+            items.clone(),
+        );
+    }
+    set_table(app, kind, items);
+}
+
+fn toast(app: &App) -> String {
+    app.toast
+        .as_ref()
+        .map(|(m, _, _)| m.clone())
+        .unwrap_or_default()
+}
+
+fn ago(secs: u64) -> Instant {
+    Instant::now()
+        .checked_sub(Duration::from_secs(secs))
+        .expect("monotonic clock older than a few seconds")
+}
+
+fn ctx(name: &str, cluster: &str, namespace: &str) -> ContextDto {
+    ContextDto {
+        name: name.to_string(),
+        stable_id: format!("file/{}", name),
+        cluster: cluster.to_string(),
+        server: format!("https://{}.example.invalid", cluster),
+        namespace: namespace.to_string(),
+        is_current: false,
+        is_local: false,
+        provider: None,
+        // Deliberately free of the substrings the picker tests filter on:
+        // the picker matches the source file too, so "kubeconfig" (which
+        // contains "be") would match every context.
+        source_file: "cluster-config.yaml".to_string(),
+        auth_kind: "token".to_string(),
+    }
+}
+
+fn pods(names: &[&str]) -> Vec<Value> {
+    names
+        .iter()
+        .map(|n| json!({ "name": n, "namespace": "default", "status": "Running" }))
+        .collect()
+}
+
+fn widget_crd() -> CrdMeta {
+    CrdMeta {
+        crd_name: "widgets.example.com".to_string(),
+        group: "example.com".to_string(),
+        version: "v1".to_string(),
+        kind: "Widget".to_string(),
+        plural: "widgets".to_string(),
+        singular: "widget".to_string(),
+        namespaced: true,
+        short_names: vec!["wd".to_string()],
+        printer_columns: vec![PrinterColumn {
+            name: "Size".to_string(),
+            json_path: ".spec.size".to_string(),
+            col_type: "integer".to_string(),
+            priority: 0,
+            description: None,
+        }],
+    }
+}
+
+/// Wait (bounded) for the background task that emits `title` to report in.
+async fn await_action_result(
+    rx: &mut UnboundedReceiver<AppEvent>,
+    title: &str,
+) -> Result<String, String> {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            match rx.recv().await {
+                Some(AppEvent::ActionResult { title: t, result }) if t == title => return result,
+                Some(_) => continue,
+                None => panic!("event channel closed"),
+            }
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("no '{}' event within 10s", title))
+}
+
+// ---------------------------------------------------------------------------
+// App::new
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn new_with_an_explicit_namespace_opens_the_pods_table_and_starts_its_watch() {
+    let (app, _rx) = common::app().await;
+    assert_eq!(app.active_context, "test-cluster");
+    assert_eq!(app.active_namespace, "default");
+    assert_eq!(app.last_active_namespace, "default");
+    assert_eq!(table(&app).kind, ResourceKind::Pods);
+    assert!(
+        table(&app).is_loading,
+        "no cache yet, so the table is loading"
+    );
+    assert!(app.nav_stack.is_empty());
+    assert!(app.is_running);
+    assert_eq!(app.input_mode, InputMode::Normal);
+    assert_eq!(app.cluster_version, "Connecting...");
+    assert_eq!(
+        app.cluster_name, "kubernetes",
+        "unknown context falls back to a generic cluster name"
+    );
+    assert_eq!(
+        app.current_watch_channel.as_deref(),
+        Some("watch:test-cluster:default:pods")
+    );
+    assert!(app
+        .active_watch_channels
+        .contains("watch:test-cluster:default:pods"));
+    assert_eq!(
+        app.active_watch_pool,
+        vec!["watch:test-cluster:default:pods".to_string()]
+    );
+}
+
+#[tokio::test]
+async fn new_without_a_namespace_opens_namespaces_and_all_namespaces_clears_the_namespace() {
+    let (tx, _rx) = unbounded_channel();
+    let app = App::new(None, None, true, None, vec![], tx)
+        .await
+        .expect("app");
+    assert_eq!(
+        app.active_context, "default",
+        "no kubeconfig means the fallback context"
+    );
+    assert_eq!(app.active_namespace, "");
+    assert_eq!(app.last_active_namespace, "default");
+    assert_eq!(table(&app).kind, ResourceKind::Namespaces);
+    assert_eq!(
+        app.current_watch_channel.as_deref(),
+        Some("watch:default::namespaces")
+    );
+
+    let (tx, _rx) = unbounded_channel();
+    let app = App::new(
+        Some("c".into()),
+        None,
+        false,
+        Some(ResourceKind::Nodes),
+        vec![],
+        tx,
+    )
+    .await
+    .expect("app");
+    assert_eq!(app.active_namespace, "");
+    assert_eq!(
+        table(&app).kind,
+        ResourceKind::Nodes,
+        "an explicit initial resource wins"
+    );
+}
+
+#[tokio::test]
+async fn new_reads_contexts_from_kubeconfig_and_prefers_the_current_one() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config");
+    std::fs::write(
+        &path,
+        r#"apiVersion: v1
+kind: Config
+current-context: staging
+clusters:
+- name: staging-cluster
+  cluster: {server: "https://127.0.0.1:1"}
+- name: prod-cluster
+  cluster: {server: "https://127.0.0.1:2"}
+contexts:
+- name: staging
+  context: {cluster: staging-cluster, user: u, namespace: team-a}
+- name: prod
+  context: {cluster: prod-cluster, user: u}
+users:
+- name: u
+  user: {token: abc}
+"#,
+    )
+    .expect("write kubeconfig");
+
+    let (tx, _rx) = unbounded_channel();
+    let app = App::new(None, None, false, None, vec![path.clone()], tx)
+        .await
+        .expect("app");
+    assert_eq!(app.contexts.len(), 2);
+    assert_eq!(app.active_context, "staging");
+    assert_eq!(app.cluster_name, "staging-cluster");
+    assert_eq!(app.server_url, "https://127.0.0.1:1");
+    let staging = app
+        .contexts
+        .iter()
+        .find(|c| c.name == "staging")
+        .expect("staging");
+    assert!(staging.is_current);
+    assert_eq!(staging.namespace, "team-a");
+    assert_eq!(staging.source_file, path.to_string_lossy());
+    assert_eq!(staging.auth_kind, "token");
+    assert_eq!(app.kubeconfig_paths, vec![path]);
+
+    let (tx, _rx) = unbounded_channel();
+    let app = App::new(
+        Some("prod".into()),
+        None,
+        false,
+        None,
+        vec![dir.path().join("config")],
+        tx,
+    )
+    .await
+    .expect("app");
+    assert_eq!(app.cluster_name, "prod-cluster");
+    assert_eq!(app.server_url, "https://127.0.0.1:2");
+}
+
+#[tokio::test]
+async fn startup_background_fetches_report_failures_that_the_handlers_apply() {
+    let (mut app, mut rx) = common::app().await;
+
+    let info = await_action_result(&mut rx, "cluster_info_failed").await;
+    let err = info.expect_err("no cluster means the info fetch fails");
+    assert!(!err.is_empty());
+    app.handle_cluster_info_failure(&err);
+    assert!(!app.is_connected);
+    assert!(
+        !app.cluster_unreachable,
+        "still inside the connection grace period"
+    );
+
+    let overview = await_action_result(&mut rx, "cluster_overview_updated")
+        .await
+        .expect("overview payload");
+    app.handle_cluster_overview_update(&overview);
+    let data = app
+        .cluster_overview_data
+        .as_ref()
+        .expect("overview data stored");
+    assert_eq!(data.context_name, "test-cluster");
+    assert_eq!(data.cluster_name, "kubernetes");
+    assert!(!data.is_reachable);
+    assert_eq!(data.node_count, 0);
+    assert!(!app.is_connected);
+}
+
+#[tokio::test]
+async fn any_keypress_dismisses_the_drag_to_copy_selection() {
+    let (mut app, _rx) = common::app().await;
+    app.screen_selection = Some(((0, 0), (5, 5)));
+    app.screen_selecting = true;
+    press(&mut app, key(KeyCode::Null)).await;
+    assert!(app.screen_selection.is_none());
+    assert!(!app.screen_selecting);
+}
+
+// ---------------------------------------------------------------------------
+// Tick and metric updates
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn tick_expires_toasts_and_marks_the_cluster_unreachable_after_the_grace_period() {
+    let (mut app, _rx) = common::app().await;
+    app.toast = Some(("old".to_string(), ago(4), Style::default()));
+    app.handle_tick();
+    assert!(app.toast.is_none(), "toasts older than 3s are dropped");
+    assert!(!app.cluster_unreachable);
+    assert!(table(&app).is_loading);
+
+    app.connection_attempt_start = ago(9);
+    app.handle_tick();
+    assert!(app.cluster_unreachable);
+    assert!(!app.is_connected);
+    assert!(
+        !table(&app).is_loading,
+        "an empty table stops spinning once the cluster is unreachable"
+    );
+
+    let screen = common::render_app(&mut app, 100, 30);
+    assert!(screen.contains("test-cluster"), "screen: {}", screen);
+}
+
+#[tokio::test]
+async fn tick_schedules_metric_refreshes_for_pod_and_node_views_and_modals() {
+    let (mut app, _rx) = common::app().await;
+    app.handle_tick();
+    assert_eq!(
+        app.pod_metrics_tick_counter, 1,
+        "pods table wants pod metrics"
+    );
+    assert_eq!(app.node_metrics_tick_counter, 0);
+
+    set_table(&mut app, ResourceKind::Nodes, vec![]);
+    app.handle_tick();
+    assert_eq!(app.pod_metrics_tick_counter, 1);
+    assert_eq!(
+        app.node_metrics_tick_counter, 1,
+        "nodes table wants node metrics"
+    );
+
+    app.active_view = ActiveView::NodeInspector(NodeInspectorState::new("node-1".into()));
+    app.handle_tick();
+    assert_eq!(app.node_metrics_tick_counter, 2);
+
+    app.active_view = ActiveView::Assistant;
+    app.modal = Some(Modal::MetricsTimeline(
+        srelens_tui::views::MetricsPanelState::new(
+            "Pod".into(),
+            "pod-a".into(),
+            Some("default".into()),
+            vec![],
+        ),
+    ));
+    app.handle_tick();
+    assert_eq!(
+        app.pod_metrics_tick_counter, 2,
+        "a pod timeline modal wants pod metrics"
+    );
+
+    app.modal = Some(Modal::MetricsTimeline(
+        srelens_tui::views::MetricsPanelState::new("Node".into(), "node-1".into(), None, vec![]),
+    ));
+    app.handle_tick();
+    assert_eq!(app.node_metrics_tick_counter, 3);
+
+    app.modal = None;
+    app.handle_tick();
+    assert_eq!(
+        app.pod_metrics_tick_counter, 2,
+        "the assistant view needs neither"
+    );
+    assert_eq!(app.node_metrics_tick_counter, 3);
+}
+
+#[tokio::test]
+async fn pod_metrics_update_fills_the_table_the_cache_and_an_open_timeline() {
+    let (mut app, _rx) = common::app().await;
+    set_table(&mut app, ResourceKind::Pods, pods(&["pod-a", "pod-b"]));
+    app.resource_cache.insert(
+        ("test-cluster".into(), "default".into(), "pods".into()),
+        pods(&["pod-a"]),
+    );
+    app.modal = Some(Modal::MetricsTimeline(
+        srelens_tui::views::MetricsPanelState::new(
+            "Pod".into(),
+            "pod-a".into(),
+            Some("default".into()),
+            vec![],
+        ),
+    ));
+
+    app.handle_pod_metrics_update("not json");
+    app.handle_pod_metrics_update("[]");
+    assert!(
+        app.pod_metrics_history.is_empty(),
+        "bad and empty payloads are ignored"
+    );
+
+    let payload = json!([
+        { "name": "pod-a", "namespace": "default", "cpuMillicores": 250, "memoryMiB": 2048 },
+        { "name": "pod-b", "namespace": "default", "cpuMillicores": 5, "memoryMiB": 64 },
+    ])
+    .to_string();
+    app.handle_pod_metrics_update(&payload);
+
+    let t = table(&app);
+    assert_eq!(t.raw_items[0]["cpu"], "250m");
+    assert_eq!(t.raw_items[0]["memory"], "2.0Gi");
+    assert_eq!(t.raw_items[1]["cpu"], "5m");
+    assert_eq!(t.raw_items[1]["memory"], "64Mi");
+    let cached = &app.resource_cache[&("test-cluster".into(), "default".into(), "pods".into())];
+    assert_eq!(
+        cached[0]["memory"], "2.0Gi",
+        "the informer cache keeps the metrics too"
+    );
+    assert_eq!(app.pod_metrics_history["pod-a"].len(), 1);
+    match &app.modal {
+        Some(Modal::MetricsTimeline(panel)) => assert_eq!(panel.samples.len(), 1),
+        _ => panic!("timeline modal should still be open"),
+    }
+}
+
+#[tokio::test]
+async fn pod_metrics_update_only_touches_pod_rows_of_the_workloads_table() {
+    let (mut app, _rx) = common::app().await;
+    set_table(
+        &mut app,
+        ResourceKind::Workloads,
+        vec![
+            json!({ "name": "web", "namespace": "default", "kind": "Deployment" }),
+            json!({ "name": "web-1", "namespace": "default", "kind": "Pod" }),
+        ],
+    );
+    let payload = json!([
+        { "name": "web", "namespace": "default", "cpuMillicores": 1, "memoryMiB": 1 },
+        { "name": "web-1", "namespace": "default", "cpuMillicores": 100, "memoryMiB": 1536 },
+    ])
+    .to_string();
+    app.handle_pod_metrics_update(&payload);
+    let t = table(&app);
+    assert!(
+        t.raw_items[0].get("cpu").is_none(),
+        "controller rows carry no usage"
+    );
+    assert_eq!(t.raw_items[1]["cpu"], "100m");
+    assert_eq!(t.raw_items[1]["memory"], "1.5Gi");
+}
+
+#[tokio::test]
+async fn pod_metrics_history_is_capped_at_720_samples() {
+    let (mut app, _rx) = common::app().await;
+    app.active_view = ActiveView::Assistant;
+    let payload =
+        json!([{ "name": "p", "namespace": "default", "cpuMillicores": 1, "memoryMiB": 1 }])
+            .to_string();
+    for _ in 0..725 {
+        app.handle_pod_metrics_update(&payload);
+    }
+    assert_eq!(app.pod_metrics_history["p"].len(), 720);
+}
+
+#[tokio::test]
+async fn node_metrics_update_feeds_the_node_inspector_and_an_open_timeline() {
+    let (mut app, _rx) = common::app().await;
+    app.active_view = ActiveView::NodeInspector(NodeInspectorState::new("node-1".into()));
+
+    app.handle_node_metrics_update("nope");
+    app.handle_node_metrics_update("[]");
+    assert!(app.node_metrics_history.is_empty());
+
+    let payload = json!([
+        { "name": "node-1", "cpuMillicores": 1500, "memoryMiB": 4096 },
+        { "name": "node-2", "cpuMillicores": -5, "memoryMiB": -1 },
+    ])
+    .to_string();
+    app.handle_node_metrics_update(&payload);
+    assert_eq!(app.node_metrics_history["node-1"].len(), 1);
+    assert_eq!(
+        app.node_metrics_history["node-2"][0].cpu_millicores, 0,
+        "negative usage clamps to zero"
+    );
+    match &app.active_view {
+        ActiveView::NodeInspector(ni) => {
+            assert_eq!(ni.cpu_history, vec![1500]);
+            assert_eq!(ni.mem_history, vec![4096]);
+        }
+        _ => panic!("expected the node inspector"),
+    }
+
+    app.active_view = ActiveView::Assistant;
+    app.modal = Some(Modal::MetricsTimeline(
+        srelens_tui::views::MetricsPanelState::new("Node".into(), "node-1".into(), None, vec![]),
+    ));
+    app.handle_node_metrics_update(&payload);
+    match &app.modal {
+        Some(Modal::MetricsTimeline(panel)) => assert_eq!(panel.samples.len(), 2),
+        _ => panic!("timeline modal should still be open"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Cluster info, overview and CRD handlers
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn cluster_info_update_marks_the_cluster_connected_and_fills_the_overview() {
+    let (mut app, _rx) = common::app().await;
+    app.handle_cluster_info_update("garbage");
+    assert!(!app.is_connected);
+    app.handle_cluster_info_update("unknown|0|0");
+    assert!(!app.is_connected, "an unknown version is not a connection");
+
+    app.switch_view_to_kind(ResourceKind::Overview).await;
+    app.handle_cluster_info_update("v1.30.2|3|42");
+    assert!(app.is_connected);
+    assert_eq!(app.cluster_version, "v1.30.2");
+    assert_eq!((app.node_count, app.pod_count), (3, 42));
+    match &app.active_view {
+        ActiveView::Overview(ov) => {
+            assert_eq!(ov.data.k8s_version, "v1.30.2");
+            assert_eq!(ov.data.node_count, 3);
+            assert_eq!(ov.data.total_pods, 42);
+            assert!(ov.data.is_reachable);
+            assert_eq!(ov.data.context_name, "test-cluster");
+        }
+        _ => panic!("expected the overview"),
+    }
+    let screen = common::render_app(&mut app, 120, 40);
+    assert!(screen.contains("v1.30.2"), "screen: {}", screen);
+}
+
+#[tokio::test]
+async fn cluster_info_failure_only_marks_unreachable_after_the_grace_period() {
+    let (mut app, _rx) = common::app().await;
+    app.is_connected = true;
+    app.handle_cluster_info_failure("boom");
+    assert!(!app.is_connected);
+    assert!(!app.cluster_unreachable);
+    assert!(table(&app).is_loading);
+
+    app.connection_attempt_start = ago(9);
+    app.handle_cluster_info_failure("boom");
+    assert!(app.cluster_unreachable);
+    assert!(!table(&app).is_loading);
+}
+
+#[tokio::test]
+async fn cluster_overview_update_ignores_other_contexts_and_applies_its_own() {
+    let (mut app, _rx) = common::app().await;
+    let mut other = ClusterOverviewData::default();
+    other.context_name = "somewhere-else".into();
+    other.k8s_version = "v9".into();
+    other.is_reachable = true;
+    app.handle_cluster_overview_update(&serde_json::to_string(&other).unwrap());
+    assert!(app.cluster_overview_data.is_none());
+    assert_eq!(app.cluster_version, "Connecting...");
+
+    app.switch_view_to_kind(ResourceKind::Overview).await;
+    app.cluster_unreachable = true;
+    let mut mine = ClusterOverviewData::default();
+    mine.context_name = "test-cluster".into();
+    mine.k8s_version = "v1.31.0".into();
+    mine.is_reachable = true;
+    mine.node_count = 2;
+    mine.total_pods = 7;
+    app.handle_cluster_overview_update(&serde_json::to_string(&mine).unwrap());
+    assert_eq!(app.cluster_version, "v1.31.0");
+    assert_eq!((app.node_count, app.pod_count), (2, 7));
+    assert!(app.is_connected);
+    assert!(!app.cluster_unreachable);
+    match &app.active_view {
+        ActiveView::Overview(ov) => assert_eq!(ov.data.total_pods, 7),
+        _ => panic!("expected the overview"),
+    }
+    app.handle_cluster_overview_update("{ not json");
+    assert_eq!(app.cluster_version, "v1.31.0", "bad payloads are ignored");
+}
+
+#[tokio::test]
+async fn crd_updates_populate_the_registry_and_instances_fill_the_crd_table() {
+    let (mut app, _rx) = common::app().await;
+    app.handle_crds_update("[nonsense");
+    assert!(app.crds.is_empty());
+    app.handle_crds_update(&serde_json::to_string(&vec![widget_crd()]).unwrap());
+    assert_eq!(app.crds.len(), 1);
+
+    let mut bare = widget_crd();
+    bare.printer_columns.clear();
+    app.switch_view_to_crd(bare).await;
+    assert_eq!(app.nav_stack.len(), 1);
+    assert!(table(&app).is_loading);
+    match &table(&app).kind {
+        ResourceKind::CustomResource(crd) => {
+            assert_eq!(crd.printer_columns.len(), 1, "columns come from discovery")
+        }
+        other => panic!("expected a CRD table, got {}", other),
+    }
+
+    app.handle_crd_instances_update("crd_instances:Widget", "oops");
+    assert!(table(&app).raw_items.is_empty());
+    app.handle_crd_instances_update(
+        "crd_instances:Widget",
+        &json!([{ "name": "w-1", "namespace": "default", "spec": { "size": 3 } }]).to_string(),
+    );
+    assert_eq!(table(&app).raw_items.len(), 1);
+    assert!(!table(&app).is_loading);
+    assert!(app.resource_cache.contains_key(&(
+        "test-cluster".into(),
+        "default".into(),
+        "Widget".into()
+    )));
+
+    // A table whose CRD was built without columns picks them up from the registry on first data.
+    if let ActiveView::Table(t) = &mut app.active_view {
+        if let ResourceKind::CustomResource(crd) = &mut t.kind {
+            crd.printer_columns.clear();
+        }
+    }
+    app.handle_crd_instances_update(
+        "crd_instances:widgets",
+        &json!([{ "name": "w-2" }]).to_string(),
+    );
+    match &table(&app).kind {
+        ResourceKind::CustomResource(crd) => assert_eq!(crd.printer_columns[0].name, "Size"),
+        other => panic!("expected a CRD table, got {}", other),
+    }
+    assert_eq!(table(&app).raw_items.len(), 1);
+    let screen = common::render_app(&mut app, 120, 30);
+    assert!(screen.contains("w-2"), "screen: {}", screen);
+}
+
+// ---------------------------------------------------------------------------
+// Context and namespace switching
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn switch_namespace_updates_state_toast_and_watch_channel() {
+    let (mut app, _rx) = common::app().await;
+    app.switch_namespace("kube-system".into()).await;
+    assert_eq!(app.active_namespace, "kube-system");
+    assert_eq!(app.last_active_namespace, "kube-system");
+    assert_eq!(toast(&app), "Switched to namespace [kube-system]");
+    assert_eq!(
+        app.current_watch_channel.as_deref(),
+        Some("watch:test-cluster:kube-system:pods")
+    );
+    let screen = common::render_app(&mut app, 120, 30);
+    assert!(
+        screen.contains("Switched to namespace [kube-system]"),
+        "screen: {}",
+        screen
+    );
+
+    app.switch_namespace(String::new()).await;
+    assert_eq!(app.active_namespace, "");
+    assert_eq!(
+        app.last_active_namespace, "kube-system",
+        "'all' does not overwrite the remembered namespace"
+    );
+    assert_eq!(toast(&app), "Switched to namespace [all]");
+}
+
+#[tokio::test]
+async fn switch_context_swaps_assistant_state_and_resets_cluster_info() {
+    let (mut app, _rx) = common::app().await;
+    app.contexts = vec![
+        ctx("test-cluster", "c-test", ""),
+        ctx("staging", "c-staging", "team-a"),
+    ];
+    app.assistant_state.input = "draft question".into();
+    app.cluster_version = "v1.29.0".into();
+    app.is_connected = true;
+    app.resource_cache.insert(
+        ("test-cluster".into(), "default".into(), "pods".into()),
+        pods(&["p"]),
+    );
+
+    app.switch_context("test-cluster".into()).await;
+    assert!(
+        app.toast.is_none(),
+        "switching to the current context is a no-op"
+    );
+
+    app.switch_context("staging".into()).await;
+    assert_eq!(app.active_context, "staging");
+    assert_eq!(app.cluster_name, "c-staging");
+    assert_eq!(app.server_url, "https://c-staging.example.invalid");
+    assert_eq!(
+        app.active_namespace, "team-a",
+        "the context's default namespace applies"
+    );
+    assert_eq!(
+        app.assistant_state.input, "",
+        "a fresh assistant for the new context"
+    );
+    assert_eq!(app.assistant_state.context_name, "staging");
+    assert_eq!(app.assistant_states["test-cluster"].input, "draft question");
+    assert_eq!(app.cluster_version, "Connecting...");
+    assert!(!app.is_connected);
+    assert!(app.resource_cache.is_empty());
+    assert_eq!(toast(&app), "Switched to context 'staging'");
+    assert_eq!(
+        app.current_watch_channel.as_deref(),
+        Some("watch:staging:team-a:pods")
+    );
+
+    app.switch_context("test-cluster".into()).await;
+    assert_eq!(
+        app.assistant_state.input, "draft question",
+        "the saved assistant comes back"
+    );
+    assert!(!app.assistant_states.contains_key("test-cluster"));
+    assert_eq!(
+        app.active_namespace, "",
+        "a context without a default namespace shows all"
+    );
+}
+
+#[tokio::test]
+async fn switch_context_while_on_the_overview_resets_the_panel() {
+    let (mut app, _rx) = common::app().await;
+    app.contexts = vec![ctx("prod", "c-prod", "")];
+    app.switch_view_to_kind(ResourceKind::Overview).await;
+    app.switch_context("prod".into()).await;
+    match &app.active_view {
+        ActiveView::Overview(ov) => {
+            assert_eq!(ov.data.context_name, "prod");
+            assert_eq!(ov.data.cluster_name, "c-prod");
+            assert_eq!(ov.data.k8s_version, "Connecting...");
+            assert!(ov.data.is_reachable);
+        }
+        _ => panic!("expected the overview"),
+    }
+}
+
+#[tokio::test]
+async fn function_keys_switch_to_the_nth_context() {
+    let (mut app, _rx) = common::app().await;
+    app.contexts = vec![ctx("test-cluster", "a", ""), ctx("second", "b", "")];
+    press(&mut app, key(KeyCode::F(2))).await;
+    assert_eq!(app.active_context, "second");
+    press(&mut app, key(KeyCode::F(9))).await;
+    assert_eq!(
+        app.active_context, "second",
+        "a hotkey without a context does nothing"
+    );
+    press(&mut app, key(KeyCode::F(1))).await;
+    assert_eq!(app.active_context, "test-cluster");
+}
+
+#[tokio::test]
+async fn ctrl_a_toggles_between_all_namespaces_and_the_last_one() {
+    let (mut app, _rx) = common::app().await;
+    press(&mut app, ctrl('a')).await;
+    assert_eq!(app.active_namespace, "");
+    assert_eq!(app.last_active_namespace, "default");
+    press(&mut app, ctrl('a')).await;
+    assert_eq!(app.active_namespace, "default");
+
+    app.active_namespace.clear();
+    app.last_active_namespace.clear();
+    press(&mut app, ctrl('a')).await;
+    assert_eq!(
+        app.active_namespace, "default",
+        "nothing remembered falls back to default"
+    );
+}
+
+#[tokio::test]
+async fn ctrl_x_opens_the_context_picker_whose_keys_navigate_filter_and_select() {
+    let (mut app, _rx) = common::app().await;
+    app.contexts = vec![
+        ctx("alpha", "c-alpha", ""),
+        ctx("beta", "c-beta", ""),
+        ctx("gamma", "c-gamma", ""),
+    ];
+
+    press(&mut app, ctrl('x')).await;
+    let sel = |app: &App| match &app.modal {
+        Some(Modal::ContextPicker {
+            selected_idx,
+            filter,
+            ..
+        }) => (*selected_idx, filter.clone()),
+        other => panic!("expected the context picker, got {:?}", other),
+    };
+    assert_eq!(sel(&app), (0, String::new()));
+    press(&mut app, key(KeyCode::Down)).await;
+    assert_eq!(sel(&app).0, 1);
+    press(&mut app, key(KeyCode::Down)).await;
+    press(&mut app, key(KeyCode::Down)).await;
+    assert_eq!(sel(&app).0, 0, "down wraps");
+    press(&mut app, key(KeyCode::Up)).await;
+    assert_eq!(sel(&app).0, 2, "up wraps");
+    press(&mut app, ctrl('j')).await;
+    assert_eq!(sel(&app).0, 0);
+    press(&mut app, ctrl('k')).await;
+    assert_eq!(sel(&app).0, 2);
+    let screen = common::render_app(&mut app, 120, 40);
+    assert!(screen.contains("gamma"), "screen: {}", screen);
+
+    type_str(&mut app, "bet").await;
+    assert_eq!(sel(&app), (0, "bet".to_string()));
+    press(&mut app, key(KeyCode::Backspace)).await;
+    assert_eq!(sel(&app).1, "be");
+    press(&mut app, key(KeyCode::Down)).await;
+    assert_eq!(sel(&app).0, 0, "only one match, so it wraps to itself");
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert!(app.modal.is_none());
+    assert_eq!(app.active_context, "beta");
+
+    press(&mut app, ctrl('x')).await;
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert!(app.modal.is_none());
+
+    press(&mut app, ctrl('x')).await;
+    type_str(&mut app, "zzz").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert_eq!(
+        app.active_context, "beta",
+        "enter with no match keeps the context"
+    );
+
+    press(&mut app, ch(':')).await;
+    type_str(&mut app, "ctx").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert!(
+        matches!(app.modal, Some(Modal::ContextPicker { .. })),
+        ":ctx opens the same picker"
+    );
+}
+
+#[tokio::test]
+async fn namespace_picker_filters_navigates_and_switches() {
+    let (mut app, _rx) = common::app().await;
+    app.namespaces = vec!["default".into(), "kube-system".into(), "monitoring".into()];
+    let sel = |app: &App| match &app.modal {
+        Some(Modal::NamespacePicker {
+            selected_idx,
+            filter,
+            ..
+        }) => (*selected_idx, filter.clone()),
+        other => panic!("expected the namespace picker, got {:?}", other),
+    };
+
+    press(&mut app, ch(':')).await;
+    type_str(&mut app, "ns").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert_eq!(sel(&app), (0, String::new()));
+    press(&mut app, key(KeyCode::Down)).await;
+    assert_eq!(sel(&app).0, 1);
+    press(&mut app, key(KeyCode::Down)).await;
+    press(&mut app, key(KeyCode::Down)).await;
+    assert_eq!(sel(&app).0, 0);
+    press(&mut app, key(KeyCode::Up)).await;
+    assert_eq!(sel(&app).0, 2);
+    press(&mut app, ctrl('j')).await;
+    assert_eq!(sel(&app).0, 0);
+    press(&mut app, ctrl('k')).await;
+    assert_eq!(sel(&app).0, 2);
+    press(&mut app, key(KeyCode::Null)).await;
+    assert_eq!(sel(&app).0, 2, "unknown keys leave the picker alone");
+
+    type_str(&mut app, "kube sys").await;
+    assert_eq!(sel(&app), (0, "kube sys".to_string()));
+    press(&mut app, ctrl('w')).await;
+    assert_eq!(sel(&app).1, "kube ");
+    press(&mut app, ctrl('u')).await;
+    assert_eq!(sel(&app).1, "");
+    type_str(&mut app, "monx").await;
+    press(&mut app, key(KeyCode::Backspace)).await;
+    assert_eq!(sel(&app).1, "mon");
+    let screen = common::render_app(&mut app, 120, 40);
+    assert!(screen.contains("monitoring"), "screen: {}", screen);
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert!(app.modal.is_none());
+    assert_eq!(app.active_namespace, "monitoring");
+
+    press(&mut app, ch(':')).await;
+    type_str(&mut app, "namespaces").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert_eq!(sel(&app).0, 2, "the picker starts on the active namespace");
+    press(&mut app, ch('0')).await;
+    assert!(app.modal.is_none());
+    assert_eq!(app.active_namespace, "", "'0' means all namespaces");
+
+    press(&mut app, ch(':')).await;
+    type_str(&mut app, "ns").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    type_str(&mut app, "nothing-here").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert_eq!(app.active_namespace, "", "no match keeps the namespace");
+
+    press(&mut app, ch(':')).await;
+    type_str(&mut app, "ns").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert!(app.modal.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Command mode
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn pressing_colon_enters_command_mode_and_esc_leaves_it() {
+    let (mut app, _rx) = common::app().await;
+    press(&mut app, ch(':')).await;
+    assert_eq!(app.input_mode, InputMode::Command);
+    type_str(&mut app, "pods").await;
+    assert_eq!(app.command_buffer, "pods");
+    let screen = common::render_app(&mut app, 120, 30);
+    assert!(screen.contains(":pods"), "screen: {}", screen);
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert_eq!(app.input_mode, InputMode::Normal);
+    assert_eq!(app.command_buffer, "");
+    assert_eq!(app.command_suggestion_idx, 0);
+}
+
+#[tokio::test]
+async fn command_mode_tab_and_arrow_keys_cycle_the_suggestions() {
+    let (mut app, _rx) = common::app().await;
+    press(&mut app, ch(':')).await;
+    let suggestions = command_suggestions_with_crds("s", &app.crds);
+    let len = suggestions.len();
+    assert!(len > 1, "':s' should offer several commands");
+
+    // Each key completes to a suggestion; the buffer is reset between keys
+    // because completing changes the buffer and therefore the candidate list.
+    for k in [key(KeyCode::Tab), key(KeyCode::Down), ctrl('n')] {
+        app.command_buffer = "s".to_string();
+        app.command_suggestion_idx = 0;
+        press(&mut app, k).await;
+        assert_eq!(app.command_buffer, suggestions[0].0.name);
+        assert_eq!(
+            app.command_suggestion_idx, 1,
+            "the cursor advances to the next candidate"
+        );
+    }
+    for k in [key(KeyCode::BackTab), key(KeyCode::Up), ctrl('p')] {
+        app.command_buffer = "s".to_string();
+        app.command_suggestion_idx = 0;
+        press(&mut app, k).await;
+        assert_eq!(
+            app.command_buffer,
+            suggestions[len - 1].0.name,
+            "stepping back from the first wraps to the last"
+        );
+        assert_eq!(app.command_suggestion_idx, len - 1);
+    }
+
+    app.command_buffer = "qqqqqq".into();
+    app.command_suggestion_idx = 3;
+    press(&mut app, key(KeyCode::Tab)).await;
+    assert_eq!(
+        app.command_buffer, "qqqqqq",
+        "no suggestions, nothing changes"
+    );
+    assert_eq!(app.command_suggestion_idx, 3);
+}
+
+#[tokio::test]
+async fn command_mode_editing_keys_delete_words_clear_and_backspace_out() {
+    let (mut app, _rx) = common::app().await;
+    press(&mut app, ch(':')).await;
+    type_str(&mut app, "get pods").await;
+    press(&mut app, ctrl('w')).await;
+    assert_eq!(app.command_buffer, "get ");
+    type_str(&mut app, "svc").await;
+    press(
+        &mut app,
+        KeyEvent::new(KeyCode::Backspace, KeyModifiers::ALT),
+    )
+    .await;
+    assert_eq!(app.command_buffer, "get ");
+    press(
+        &mut app,
+        KeyEvent::new(KeyCode::Backspace, KeyModifiers::CONTROL),
+    )
+    .await;
+    assert_eq!(app.command_buffer, "");
+    assert_eq!(
+        app.input_mode,
+        InputMode::Command,
+        "deleting the last word keeps the prompt open"
+    );
+    press(&mut app, ctrl('w')).await;
+    assert_eq!(
+        app.input_mode,
+        InputMode::Normal,
+        "a word delete on an empty prompt closes it"
+    );
+
+    press(&mut app, ch(':')).await;
+    type_str(&mut app, "deploy").await;
+    press(&mut app, ctrl('u')).await;
+    assert_eq!(app.command_buffer, "");
+    assert_eq!(app.input_mode, InputMode::Command);
+    type_str(&mut app, "po").await;
+    press(&mut app, key(KeyCode::Backspace)).await;
+    assert_eq!(app.command_buffer, "p");
+    press(&mut app, key(KeyCode::Backspace)).await;
+    assert_eq!(
+        app.input_mode,
+        InputMode::Normal,
+        "backspacing the last character leaves command mode"
+    );
+
+    press(&mut app, ch(':')).await;
+    type_str(&mut app, "po").await;
+    press(
+        &mut app,
+        KeyEvent::new(KeyCode::Char('z'), KeyModifiers::ALT),
+    )
+    .await;
+    assert_eq!(app.command_buffer, "po", "alt-chords are not typed");
+    press(&mut app, ctrl('v')).await;
+    assert!(
+        app.command_buffer.starts_with("po"),
+        "paste appends (or is a no-op headless)"
+    );
+    assert!(!app.command_buffer.contains('\n'));
+    press(&mut app, key(KeyCode::Null)).await;
+    assert_eq!(
+        app.input_mode,
+        InputMode::Command,
+        "unknown keys are ignored"
+    );
+}
+
+#[tokio::test]
+async fn command_enter_runs_the_command_and_unknown_commands_toast() {
+    let (mut app, _rx) = common::app().await;
+    press(&mut app, ch(':')).await;
+    type_str(&mut app, "zzzz").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert_eq!(app.input_mode, InputMode::Normal);
+    assert_eq!(app.command_buffer, "");
+    assert!(
+        toast(&app).starts_with("Unknown command: 'zzzz'"),
+        "toast: {}",
+        toast(&app)
+    );
+
+    press(&mut app, ch(':')).await;
+    type_str(&mut app, "help").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert!(app.show_help);
+    press(&mut app, ch('?')).await;
+    assert!(!app.show_help);
+
+    press(&mut app, ch(':')).await;
+    type_str(&mut app, "nodes").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert_eq!(table(&app).kind, ResourceKind::Nodes);
+    assert_eq!(app.nav_stack.len(), 1);
+    assert_eq!(
+        app.current_watch_channel.as_deref(),
+        Some("watch:test-cluster:default:nodes")
+    );
+
+    press(&mut app, ch(':')).await;
+    type_str(&mut app, "deplo").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert_eq!(
+        table(&app).kind,
+        ResourceKind::Deployments,
+        "prefixes resolve"
+    );
+
+    press(&mut app, ch(':')).await;
+    type_str(&mut app, "q").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert!(!app.is_running);
+}
+
+#[tokio::test]
+async fn colon_commands_that_need_a_selection_warn_when_the_table_is_empty() {
+    let (mut app, _rx) = common::app().await;
+    for (cmd, expected) in [
+        (
+            "tree",
+            "Select a resource in table to view its relationship tree",
+        ),
+        (
+            "actions",
+            "Select a resource in table to open its actions palette",
+        ),
+        (
+            "metrics",
+            "Select a Pod or Node to view its live metrics timeline",
+        ),
+        (
+            "reasons",
+            ":reasons is only available when viewing Events (:events)",
+        ),
+    ] {
+        press(&mut app, ch(':')).await;
+        type_str(&mut app, cmd).await;
+        press(&mut app, key(KeyCode::Enter)).await;
+        assert_eq!(toast(&app), expected, "for :{}", cmd);
+        assert!(app.modal.is_none());
+    }
+}
+
+#[tokio::test]
+async fn colon_commands_open_tree_palette_metrics_and_reasons_for_the_selection() {
+    let (mut app, _rx) = common::app().await;
+    set_table(&mut app, ResourceKind::Pods, pods(&["pod-a"]));
+
+    press(&mut app, ch(':')).await;
+    type_str(&mut app, "act").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    match &app.modal {
+        Some(Modal::ActionPalette {
+            resource_kind,
+            resource_name,
+            ..
+        }) => {
+            assert_eq!(resource_kind, "Pods");
+            assert_eq!(resource_name, "pod-a");
+        }
+        other => panic!("expected the action palette, got {:?}", other),
+    }
+    press(&mut app, key(KeyCode::Esc)).await;
+
+    press(&mut app, ch(':')).await;
+    type_str(&mut app, "metrics").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    match &app.modal {
+        Some(Modal::MetricsTimeline(panel)) => {
+            assert_eq!(panel.target_name, "pod-a");
+            assert_eq!(panel.namespace.as_deref(), Some("default"));
+        }
+        other => panic!("expected the metrics timeline, got {:?}", other),
+    }
+    press(&mut app, key(KeyCode::Esc)).await;
+
+    press(&mut app, ch(':')).await;
+    type_str(&mut app, "tree").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    match &app.active_view {
+        ActiveView::Tree(t) => {
+            assert_eq!(t.root_kind, "Pods");
+            assert_eq!(t.root_name, "pod-a");
+            assert_eq!(t.namespace.as_deref(), Some("default"));
+        }
+        _ => panic!("expected the tree view"),
+    }
+    assert_eq!(app.nav_stack.len(), 1);
+
+    set_table(
+        &mut app,
+        ResourceKind::Events,
+        vec![
+            json!({ "name": "e1", "reason": "BackOff", "type": "Warning", "object": "Pod/web-1" }),
+        ],
+    );
+    press(&mut app, ch(':')).await;
+    type_str(&mut app, "reasons").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    match &app.modal {
+        Some(Modal::ReasonRail { tallies, .. }) => assert_eq!(tallies[0].reason, "BackOff"),
+        other => panic!("expected the reason rail, got {:?}", other),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Filter mode
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn slash_filter_narrows_the_table_and_esc_clears_it() {
+    let (mut app, _rx) = common::app().await;
+    set_table(
+        &mut app,
+        ResourceKind::Pods,
+        pods(&["api-1", "api-2", "db-1"]),
+    );
+    press(&mut app, ch('/')).await;
+    assert_eq!(app.input_mode, InputMode::Filter);
+    type_str(&mut app, "api").await;
+    assert_eq!(table(&app).filtered_indices.len(), 2);
+    let screen = common::render_app(&mut app, 120, 30);
+    assert!(screen.contains("api"), "screen: {}", screen);
+    assert!(
+        !screen.contains("db-1"),
+        "filtered rows disappear: {}",
+        screen
+    );
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert_eq!(app.input_mode, InputMode::Normal);
+    assert_eq!(app.filter_buffer, "api", "enter keeps the filter applied");
+    assert_eq!(table(&app).filtered_indices.len(), 2);
+
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert_eq!(
+        app.filter_buffer, "",
+        "esc in normal mode clears an active filter first"
+    );
+    assert_eq!(table(&app).filtered_indices.len(), 3);
+
+    press(&mut app, ch('/')).await;
+    type_str(&mut app, "db").await;
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert_eq!(app.input_mode, InputMode::Normal);
+    assert_eq!(app.filter_buffer, "");
+    assert_eq!(table(&app).filtered_indices.len(), 3);
+}
+
+#[tokio::test]
+async fn filter_editing_keys_delete_words_clear_backspace_and_paste() {
+    let (mut app, _rx) = common::app().await;
+    set_table(
+        &mut app,
+        ResourceKind::Pods,
+        pods(&["foo bar", "foo", "baz"]),
+    );
+    press(&mut app, ch('/')).await;
+    type_str(&mut app, "foo bar").await;
+    assert_eq!(table(&app).filtered_indices.len(), 1);
+    press(&mut app, ctrl('w')).await;
+    assert_eq!(app.filter_buffer, "foo ");
+    assert_eq!(
+        table(&app).filtered_indices.len(),
+        2,
+        "the filter is trimmed before matching"
+    );
+    press(&mut app, key(KeyCode::Backspace)).await;
+    assert_eq!(app.filter_buffer, "foo");
+    press(&mut app, ctrl('u')).await;
+    assert_eq!(app.filter_buffer, "");
+    assert_eq!(table(&app).filtered_indices.len(), 3);
+    press(&mut app, ctrl('v')).await;
+    assert!(!app.filter_buffer.contains('\n'));
+    press(
+        &mut app,
+        KeyEvent::new(KeyCode::Char('x'), KeyModifiers::ALT),
+    )
+    .await;
+    press(&mut app, key(KeyCode::Null)).await;
+    assert_eq!(
+        app.input_mode,
+        InputMode::Filter,
+        "chords and unknown keys are ignored"
+    );
+}
+
+#[tokio::test]
+async fn slash_in_text_views_seeds_the_filter_with_the_current_search() {
+    let (mut app, _rx) = common::app().await;
+
+    let mut yaml = YamlViewState::new(
+        "p".into(),
+        "Pod".into(),
+        None,
+        "kind: Pod\nname: x\n".into(),
+    );
+    yaml.set_search_query("kind");
+    app.active_view = ActiveView::Yaml(yaml);
+    press(&mut app, ch('/')).await;
+    assert_eq!(app.filter_buffer, "kind");
+    type_str(&mut app, "s").await;
+    match &app.active_view {
+        ActiveView::Yaml(y) => assert_eq!(y.search_query, "kinds"),
+        _ => panic!("expected yaml"),
+    }
+    press(&mut app, key(KeyCode::Esc)).await;
+    match &app.active_view {
+        ActiveView::Yaml(y) => assert_eq!(y.search_query, ""),
+        _ => panic!("expected yaml"),
+    }
+
+    let mut desc = DescribeViewState::new(
+        "p".into(),
+        "Pod".into(),
+        None,
+        "Name: p\nStatus: Running\n".into(),
+    );
+    desc.set_search_query("status");
+    app.active_view = ActiveView::Describe(desc);
+    press(&mut app, ch('/')).await;
+    assert_eq!(app.filter_buffer, "status");
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert_eq!(app.input_mode, InputMode::Normal);
+    match &app.active_view {
+        ActiveView::Describe(d) => assert_eq!(d.search_matches.len(), 1),
+        _ => panic!("expected describe"),
+    }
+
+    let mut logs = LogsViewState::new("p".into(), "default".into(), None, "logs:x".into());
+    logs.push_line("error one".into());
+    logs.set_search_query("error");
+    app.active_view = ActiveView::Logs(logs);
+    press(&mut app, ch('/')).await;
+    assert_eq!(app.filter_buffer, "error");
+    press(&mut app, ctrl('u')).await;
+    match &app.active_view {
+        ActiveView::Logs(l) => assert!(l.search_matches.is_empty()),
+        _ => panic!("expected logs"),
+    }
+}
+
+#[tokio::test]
+async fn n_and_shift_n_step_through_search_matches_in_text_views() {
+    let (mut app, _rx) = common::app().await;
+    let text = "x1\ny\nx2\nx3\n";
+    let idx = |app: &App| match &app.active_view {
+        ActiveView::Yaml(v) => v.current_match_idx,
+        ActiveView::Describe(v) => v.current_match_idx,
+        ActiveView::Logs(v) => v.current_match_idx,
+        _ => panic!("expected a text view"),
+    };
+
+    let mut yaml = YamlViewState::new("p".into(), "Pod".into(), None, text.into());
+    yaml.set_search_query("x");
+    app.active_view = ActiveView::Yaml(yaml);
+    assert_eq!(idx(&app), Some(0));
+    press(&mut app, ch('n')).await;
+    assert_eq!(idx(&app), Some(1));
+    press(&mut app, ch('N')).await;
+    assert_eq!(idx(&app), Some(0));
+    press(&mut app, ch('N')).await;
+    assert_eq!(idx(&app), Some(2), "previous wraps to the last match");
+
+    let mut desc = DescribeViewState::new("p".into(), "Pod".into(), None, text.into());
+    desc.set_search_query("x");
+    app.active_view = ActiveView::Describe(desc);
+    press(&mut app, ch('n')).await;
+    assert_eq!(idx(&app), Some(1));
+    press(&mut app, ch('N')).await;
+    assert_eq!(idx(&app), Some(0));
+
+    let mut logs = LogsViewState::new("p".into(), "default".into(), None, "logs:x".into());
+    for l in text.lines() {
+        logs.push_line(l.into());
+    }
+    logs.set_search_query("x");
+    app.active_view = ActiveView::Logs(logs);
+    press(&mut app, ch('n')).await;
+    assert_eq!(idx(&app), Some(1));
+    press(&mut app, ch('N')).await;
+    assert_eq!(idx(&app), Some(0));
+}
+
+#[tokio::test]
+async fn esc_in_text_views_clears_selection_and_search_before_popping_the_view() {
+    let (mut app, _rx) = common::app().await;
+    app.switch_view_to_kind(ResourceKind::Nodes).await;
+    let base_depth = app.nav_stack.len();
+
+    let mut yaml = YamlViewState::new("p".into(), "Pod".into(), None, "a\nb\nc\n".into());
+    yaml.start_selection(0);
+    yaml.update_selection(1);
+    yaml.set_search_query("b");
+    let prev = std::mem::replace(&mut app.active_view, ActiveView::Yaml(yaml));
+    app.nav_stack.push(prev);
+    app.filter_buffer = "b".into();
+
+    press(&mut app, key(KeyCode::Esc)).await;
+    match &app.active_view {
+        ActiveView::Yaml(y) => {
+            assert!(y.selection.is_none(), "first esc drops the selection");
+            assert_eq!(y.search_query, "b");
+        }
+        _ => panic!("expected yaml"),
+    }
+    press(&mut app, key(KeyCode::Esc)).await;
+    match &app.active_view {
+        ActiveView::Yaml(y) => assert_eq!(y.search_query, "", "second esc drops the search"),
+        _ => panic!("expected yaml"),
+    }
+    assert_eq!(app.filter_buffer, "");
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert!(
+        matches!(app.active_view, ActiveView::Table(_)),
+        "third esc pops the view"
+    );
+    assert_eq!(app.nav_stack.len(), base_depth);
+
+    let mut desc = DescribeViewState::new("p".into(), "Pod".into(), None, "Name: p\n".into());
+    desc.set_search_query("name");
+    let prev = std::mem::replace(&mut app.active_view, ActiveView::Describe(desc));
+    app.nav_stack.push(prev);
+    press(&mut app, key(KeyCode::Esc)).await;
+    match &app.active_view {
+        ActiveView::Describe(d) => assert_eq!(d.search_query, ""),
+        _ => panic!("expected describe"),
+    }
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert!(matches!(app.active_view, ActiveView::Table(_)));
+
+    let mut logs = LogsViewState::new("p".into(), "default".into(), None, "logs:x".into());
+    logs.push_line("hello".into());
+    logs.set_search_query("hello");
+    let prev = std::mem::replace(&mut app.active_view, ActiveView::Logs(logs));
+    app.nav_stack.push(prev);
+    app.active_log_channel = Some("logs:x".into());
+    press(&mut app, key(KeyCode::Esc)).await;
+    match &app.active_view {
+        ActiveView::Logs(l) => assert_eq!(l.search_query, ""),
+        _ => panic!("expected logs"),
+    }
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert!(matches!(app.active_view, ActiveView::Table(_)));
+    assert!(
+        app.active_log_channel.is_none(),
+        "leaving the logs view stops the stream"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Help, quit, toasts, assistant drawer, settings
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn question_mark_opens_help_and_esc_q_or_question_mark_close_it() {
+    let (mut app, _rx) = common::app().await;
+    press(&mut app, ch('?')).await;
+    assert!(app.show_help);
+    let screen = common::render_app(&mut app, 120, 40);
+    assert!(screen.contains("Cheat Sheet"), "screen: {}", screen);
+    press(&mut app, ch('j')).await;
+    assert!(app.show_help, "other keys are swallowed while help is open");
+    press(&mut app, ch('q')).await;
+    assert!(!app.show_help);
+    press(&mut app, ch('?')).await;
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert!(!app.show_help);
+    press(&mut app, ch('?')).await;
+    press(&mut app, ch('?')).await;
+    assert!(!app.show_help);
+}
+
+#[tokio::test]
+async fn ctrl_c_stops_the_app_even_inside_a_modal_or_help() {
+    let (mut app, _rx) = common::app().await;
+    app.show_help = true;
+    app.modal = Some(Modal::Confirm {
+        title: "t".into(),
+        message: "m".into(),
+        action_name: "noop".into(),
+        is_destructive: false,
+    });
+    press(&mut app, ctrl('c')).await;
+    assert!(!app.is_running);
+    assert!(app.show_help, "nothing else is touched");
+}
+
+#[tokio::test]
+async fn a_toast_older_than_four_seconds_is_dropped_on_the_next_keypress() {
+    let (mut app, _rx) = common::app().await;
+    app.toast = Some(("stale".into(), ago(5), Style::default()));
+    press(&mut app, ch('?')).await;
+    assert!(app.toast.is_none());
+    app.toast = Some(("fresh".into(), Instant::now(), Style::default()));
+    press(&mut app, ch('?')).await;
+    assert_eq!(toast(&app), "fresh");
+}
+
+#[tokio::test]
+async fn tab_toggles_the_assistant_drawer_and_its_esc_clears_suggestions_and_selection() {
+    let (mut app, _rx) = common::app().await;
+    press(&mut app, key(KeyCode::Tab)).await;
+    assert!(matches!(app.active_view, ActiveView::Assistant));
+    assert_eq!(app.nav_stack.len(), 1);
+    let screen = common::render_app(&mut app, 120, 40);
+    assert!(screen.contains("AI Assistant"), "screen: {}", screen);
+    press(&mut app, key(KeyCode::Tab)).await;
+    assert!(matches!(app.active_view, ActiveView::Table(_)));
+    assert!(app.nav_stack.is_empty());
+
+    press(&mut app, key(KeyCode::Tab)).await;
+    app.assistant_state.input = "/cr".into();
+    app.assistant_state.update_slash_suggestions();
+    assert!(!app.assistant_state.slash_suggestions.is_empty());
+    press(&mut app, ch(':')).await;
+    assert_eq!(
+        app.input_mode,
+        InputMode::Normal,
+        "':' with a draft goes to the composer, not the prompt"
+    );
+    assert_eq!(
+        app.assistant_state.input, "/cr:",
+        "the character lands in the composer"
+    );
+    press(&mut app, ch('?')).await;
+    assert!(
+        !app.show_help,
+        "'?' with a draft goes to the composer, not help"
+    );
+    assert_eq!(app.assistant_state.input, "/cr:?");
+
+    app.assistant_state.input = "/cr".into();
+    app.assistant_state.update_slash_suggestions();
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert!(
+        app.assistant_state.slash_suggestions.is_empty(),
+        "esc first drops the suggestions"
+    );
+    assert!(matches!(app.active_view, ActiveView::Assistant));
+
+    app.assistant_state.update_slash_suggestions();
+    press(&mut app, key(KeyCode::Tab)).await;
+    assert!(app.assistant_state.input.starts_with('/'));
+    assert!(
+        app.assistant_state.input.ends_with(' '),
+        "tab completes the slash command"
+    );
+    assert!(matches!(app.active_view, ActiveView::Assistant));
+
+    app.assistant_state.start_selection(0, 0);
+    app.assistant_state.update_selection(0, 4);
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert!(
+        app.assistant_state.selection.is_none(),
+        "esc drops the selection"
+    );
+    assert!(matches!(app.active_view, ActiveView::Assistant));
+
+    app.assistant_state.input.clear();
+    press(&mut app, ch('/')).await;
+    assert_eq!(
+        app.input_mode,
+        InputMode::Normal,
+        "'/' in the assistant is a slash command, not a filter"
+    );
+    assert_eq!(app.assistant_state.input, "/");
+    app.assistant_state.input.clear();
+    app.assistant_state.update_slash_suggestions();
+    press(&mut app, ch(':')).await;
+    assert_eq!(
+        app.input_mode,
+        InputMode::Command,
+        "an empty composer lets ':' open the prompt"
+    );
+}
+
+#[tokio::test]
+async fn tab_on_workloads_cycles_segments_and_on_wide_events_focuses_the_reason_rail() {
+    let (mut app, _rx) = common::app().await;
+    set_table(
+        &mut app,
+        ResourceKind::Workloads,
+        vec![
+            json!({ "name": "web", "namespace": "default", "kind": "Deployment" }),
+            json!({ "name": "web-1", "namespace": "default", "kind": "Pod" }),
+        ],
+    );
+    press(&mut app, key(KeyCode::Tab)).await;
+    assert_eq!(table(&app).workload_segment, WorkloadSegment::Deployment);
+    assert_eq!(table(&app).filtered_indices.len(), 1);
+    assert_eq!(toast(&app), "Segment: Deployment");
+    assert!(matches!(app.active_view, ActiveView::Table(_)));
+
+    set_table(
+        &mut app,
+        ResourceKind::Events,
+        vec![json!({ "name": "e", "reason": "Pulled", "object": "Pod/p" })],
+    );
+    table_mut(&mut app).last_area_width.set(120);
+    press(&mut app, key(KeyCode::Tab)).await;
+    assert!(table(&app).reason_rail_focused);
+    press(&mut app, key(KeyCode::Tab)).await;
+    assert!(
+        !table(&app).reason_rail_focused,
+        "tab in the rail hands focus back"
+    );
+
+    table_mut(&mut app).last_area_width.set(80);
+    press(&mut app, key(KeyCode::Tab)).await;
+    assert!(
+        matches!(app.active_view, ActiveView::Assistant),
+        "a narrow events table opens the assistant"
+    );
+}
+
+#[tokio::test]
+async fn settings_view_lets_colon_open_the_prompt_unless_a_field_is_being_edited() {
+    let (mut app, _rx) = common::app().await;
+    app.switch_view_to_kind(ResourceKind::Settings).await;
+    press(&mut app, ch(':')).await;
+    assert_eq!(app.input_mode, InputMode::Command);
+    press(&mut app, key(KeyCode::Esc)).await;
+
+    if let ActiveView::Settings(s) = &mut app.active_view {
+        s.is_editing = true;
+    }
+    press(&mut app, ch(':')).await;
+    assert_eq!(
+        app.input_mode,
+        InputMode::Normal,
+        "while editing, ':' is text"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Table keys that open modals
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn ctrl_d_asks_to_confirm_deletion_and_n_cancels_while_y_runs_it() {
+    let (mut app, _rx) = common::app().await;
+    press(&mut app, ctrl('d')).await;
+    assert!(app.modal.is_none(), "nothing selected, nothing to delete");
+
+    set_table(&mut app, ResourceKind::Pods, pods(&["pod-a"]));
+    press(&mut app, ctrl('d')).await;
+    match &app.modal {
+        Some(Modal::Confirm {
+            title,
+            action_name,
+            is_destructive,
+            ..
+        }) => {
+            assert_eq!(title, "Delete Pod [pod-a]");
+            assert_eq!(action_name, "delete:Pod:default:pod-a");
+            assert!(is_destructive);
+        }
+        other => panic!("expected a confirm dialog, got {:?}", other),
+    }
+    let screen = common::render_app(&mut app, 120, 40);
+    assert!(screen.contains("Delete Pod [pod-a]"), "screen: {}", screen);
+    press(&mut app, ch('x')).await;
+    assert!(app.modal.is_some(), "unrelated keys keep the dialog");
+    press(&mut app, ch('n')).await;
+    assert!(app.modal.is_none());
+    assert!(app.toast.is_none());
+
+    press(&mut app, ctrl('d')).await;
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert!(app.modal.is_none());
+
+    press(&mut app, ctrl('d')).await;
+    press(&mut app, ch('y')).await;
+    assert!(app.modal.is_none());
+    assert!(
+        toast(&app).starts_with("Connection error"),
+        "toast: {}",
+        toast(&app)
+    );
+
+    app.active_namespace.clear();
+    set_table(
+        &mut app,
+        ResourceKind::Nodes,
+        vec![json!({ "name": "node-1" })],
+    );
+    press(&mut app, ctrl('d')).await;
+    match &app.modal {
+        Some(Modal::Confirm { action_name, .. }) => {
+            assert_eq!(action_name, "delete:Node:default:node-1")
+        }
+        other => panic!("expected a confirm dialog, got {:?}", other),
+    }
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert!(toast(&app).starts_with("Connection error"));
+}
+
+#[tokio::test]
+async fn r_on_a_workload_asks_to_confirm_a_rollout_restart() {
+    let (mut app, _rx) = common::app().await;
+    set_table(
+        &mut app,
+        ResourceKind::Deployments,
+        vec![json!({ "name": "web", "namespace": "shop" })],
+    );
+    press(&mut app, ch('r')).await;
+    match &app.modal {
+        Some(Modal::Confirm {
+            title,
+            action_name,
+            is_destructive,
+            ..
+        }) => {
+            assert_eq!(title, "Restart Workload [web]");
+            assert_eq!(action_name, "restart:Deployment:shop:web");
+            assert!(!is_destructive);
+        }
+        other => panic!("expected a confirm dialog, got {:?}", other),
+    }
+    press(&mut app, ch('Y')).await;
+    assert!(
+        toast(&app).starts_with("Connection error"),
+        "toast: {}",
+        toast(&app)
+    );
+
+    set_table(
+        &mut app,
+        ResourceKind::Workloads,
+        vec![json!({ "name": "web-1", "namespace": "shop", "kind": "Pod" })],
+    );
+    press(&mut app, ch('r')).await;
+    assert!(app.modal.is_none());
+    assert!(
+        toast(&app).starts_with("Rollout restart is only available"),
+        "toast: {}",
+        toast(&app)
+    );
+
+    set_table(
+        &mut app,
+        ResourceKind::Workloads,
+        vec![json!({ "name": "agent", "namespace": "shop", "kind": "DaemonSet" })],
+    );
+    press(&mut app, ch('r')).await;
+    match &app.modal {
+        Some(Modal::Confirm { action_name, .. }) => {
+            assert_eq!(action_name, "restart:DaemonSet:shop:agent")
+        }
+        other => panic!("expected a confirm dialog, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn r_on_an_empty_or_unreachable_table_retries_the_connection() {
+    let (mut app, _rx) = common::app().await;
+    app.cluster_unreachable = true;
+    app.connection_attempt_start = ago(30);
+    table_mut(&mut app).is_loading = false;
+    press(&mut app, ch('r')).await;
+    assert!(app.modal.is_none());
+    assert!(!app.cluster_unreachable);
+    assert!(table(&app).is_loading);
+    assert!(app.connection_attempt_start.elapsed() < Duration::from_secs(5));
+    assert_eq!(toast(&app), "Retrying cluster connection...");
+}
+
+#[tokio::test]
+async fn ctrl_s_opens_the_scale_dialog_which_digits_backspace_and_enter_drive() {
+    let (mut app, _rx) = common::app().await;
+    set_table(
+        &mut app,
+        ResourceKind::Deployments,
+        vec![json!({ "name": "web", "namespace": "default" })],
+    );
+    let input = |app: &App| match &app.modal {
+        Some(Modal::Scale {
+            input,
+            workload_name,
+            ..
+        }) => {
+            assert_eq!(workload_name, "web");
+            input.clone()
+        }
+        other => panic!("expected the scale dialog, got {:?}", other),
+    };
+    press(&mut app, ctrl('s')).await;
+    assert_eq!(input(&app), "1");
+    press(&mut app, ch('5')).await;
+    assert_eq!(input(&app), "15");
+    press(&mut app, ch('x')).await;
+    assert_eq!(input(&app), "15", "letters are not replicas");
+    let screen = common::render_app(&mut app, 120, 40);
+    assert!(screen.contains("15"), "screen: {}", screen);
+    press(&mut app, key(KeyCode::Backspace)).await;
+    press(&mut app, key(KeyCode::Backspace)).await;
+    assert_eq!(input(&app), "");
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert!(app.modal.is_none());
+    assert!(app.toast.is_none(), "an empty count is silently dropped");
+
+    press(&mut app, ctrl('s')).await;
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert!(app.modal.is_none());
+
+    press(&mut app, ctrl('s')).await;
+    press(&mut app, ch('3')).await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert!(
+        toast(&app).starts_with("Connection error"),
+        "toast: {}",
+        toast(&app)
+    );
+
+    set_table(
+        &mut app,
+        ResourceKind::Workloads,
+        vec![json!({ "name": "web-1", "namespace": "default", "kind": "Pod" })],
+    );
+    press(&mut app, ctrl('s')).await;
+    assert!(app.modal.is_none());
+    assert!(
+        toast(&app).starts_with("Scale is only available"),
+        "toast: {}",
+        toast(&app)
+    );
+}
+
+#[tokio::test]
+async fn f_opens_port_forward_with_the_detected_port_and_enter_starts_it() {
+    let (mut app, _rx) = common::app().await;
+    set_table(
+        &mut app,
+        ResourceKind::Services,
+        vec![
+            json!({ "name": "web-svc", "namespace": "shop", "spec": { "ports": [{ "port": 443 }] } }),
+        ],
+    );
+    let input = |app: &App| match &app.modal {
+        Some(Modal::PortForward {
+            local_port_input,
+            container_port,
+            ..
+        }) => (*container_port, local_port_input.clone()),
+        other => panic!("expected the port-forward dialog, got {:?}", other),
+    };
+    let target = |app: &App| match &app.modal {
+        Some(Modal::PortForward {
+            pod_name,
+            namespace,
+            ..
+        }) => (pod_name.clone(), namespace.clone()),
+        other => panic!("expected the port-forward dialog, got {:?}", other),
+    };
+    press(&mut app, ch('F')).await;
+    assert_eq!(target(&app), ("web-svc".to_string(), "shop".to_string()));
+    assert_eq!(input(&app), (443, "443".to_string()));
+    press(&mut app, ch('1')).await;
+    press(&mut app, ch('a')).await;
+    assert_eq!(input(&app).1, "4431");
+    press(&mut app, key(KeyCode::Backspace)).await;
+    assert_eq!(input(&app).1, "443");
+    let screen = common::render_app(&mut app, 120, 40);
+    assert!(screen.contains("443"), "screen: {}", screen);
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert!(app.modal.is_none());
+    assert_eq!(
+        toast(&app),
+        "Port forward started on 127.0.0.1:443 -> web-svc:443"
+    );
+
+    press(&mut app, ch('f')).await;
+    press(&mut app, key(KeyCode::Backspace)).await;
+    press(&mut app, key(KeyCode::Backspace)).await;
+    press(&mut app, key(KeyCode::Backspace)).await;
+    app.toast = None;
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert!(app.toast.is_none(), "an unparsable port does nothing");
+
+    press(&mut app, ch('f')).await;
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert!(app.modal.is_none());
+
+    set_table(&mut app, ResourceKind::Pods, pods(&["plain"]));
+    press(&mut app, ch('f')).await;
+    assert_eq!(input(&app).0, 8080, "no declared port falls back to 8080");
+    press(&mut app, key(KeyCode::Esc)).await;
+
+    set_table(
+        &mut app,
+        ResourceKind::Workloads,
+        vec![json!({ "name": "web", "namespace": "default", "kind": "Deployment" })],
+    );
+    press(&mut app, ch('f')).await;
+    assert!(app.modal.is_none());
+    assert!(
+        toast(&app).starts_with("Port forward is only available for Pods"),
+        "toast: {}",
+        toast(&app)
+    );
+}
+
+#[tokio::test]
+async fn container_picker_cycles_and_enter_opens_logs_or_a_shell() {
+    let (mut app, _rx) = common::app().await;
+    let multi = vec![json!({
+        "name": "multi",
+        "namespace": "default",
+        "spec": { "containers": [{ "name": "app" }, { "name": "sidecar" }], "initContainers": [{ "name": "init" }] }
+    })];
+    // `get_pod_containers` looks the pod up under a "Pods" cache key; the
+    // informer cache the table is re-primed from uses the watch kind "pods".
+    app.resource_cache.insert(
+        ("test-cluster".into(), "default".into(), "Pods".into()),
+        multi.clone(),
+    );
+    seed_table(&mut app, ResourceKind::Pods, multi);
+
+    let picker = |app: &App| match &app.modal {
+        Some(Modal::ContainerPicker {
+            containers,
+            selected_idx,
+            action,
+            ..
+        }) => {
+            assert_eq!(containers, &["app", "sidecar", "init"]);
+            (*selected_idx, *action)
+        }
+        other => panic!("expected the container picker, got {:?}", other),
+    };
+    press(&mut app, ch('l')).await;
+    assert_eq!(picker(&app), (0, ContainerAction::Logs));
+    press(&mut app, ch('j')).await;
+    assert_eq!(picker(&app).0, 1);
+    press(&mut app, key(KeyCode::Down)).await;
+    press(&mut app, key(KeyCode::Down)).await;
+    assert_eq!(picker(&app).0, 0, "down wraps");
+    press(&mut app, ch('k')).await;
+    assert_eq!(picker(&app).0, 2, "up wraps");
+    press(&mut app, key(KeyCode::Up)).await;
+    assert_eq!(picker(&app).0, 1);
+    press(&mut app, ch('z')).await;
+    assert_eq!(picker(&app).0, 1);
+    let screen = common::render_app(&mut app, 120, 40);
+    assert!(screen.contains("sidecar"), "screen: {}", screen);
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert!(app.modal.is_none());
+    match &app.active_view {
+        ActiveView::Logs(l) => {
+            assert_eq!(l.pod_name, "multi");
+            assert_eq!(l.container.as_deref(), Some("sidecar"));
+            assert_eq!(l.namespace, "default");
+        }
+        _ => panic!("expected the logs view"),
+    }
+    assert!(app
+        .active_log_channel
+        .as_deref()
+        .unwrap()
+        .starts_with("logs:multi:"));
+    assert_eq!(app.nav_stack.len(), 1);
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert!(matches!(app.active_view, ActiveView::Table(_)));
+    assert!(app.active_log_channel.is_none());
+
+    press(&mut app, ch('s')).await;
+    assert_eq!(picker(&app), (0, ContainerAction::Shell));
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert!(app.modal.is_none());
+    press(&mut app, ch('s')).await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    match &app.requires_terminal_suspend {
+        Some(SuspendAction::PodShell { pod, container }) => {
+            assert_eq!(pod, "multi");
+            assert_eq!(container.as_deref(), Some("app"));
+        }
+        _ => panic!("expected a pending pod shell"),
+    }
+}
+
+#[tokio::test]
+async fn l_and_s_on_a_single_container_pod_go_straight_to_logs_and_shell() {
+    let (mut app, _rx) = common::app().await;
+    seed_table(&mut app, ResourceKind::Pods, pods(&["pod-a"]));
+    press(&mut app, ch('l')).await;
+    assert!(app.modal.is_none());
+    match &app.active_view {
+        ActiveView::Logs(l) => {
+            assert_eq!(l.pod_name, "pod-a");
+            assert!(l.container.is_none());
+            assert!(
+                l.lines[0].contains("Streaming logs for pod default/pod-a"),
+                "line: {}",
+                l.lines[0]
+            );
+        }
+        _ => panic!("expected the logs view"),
+    }
+    let channel = app.active_log_channel.clone().expect("log channel");
+    app.handle_stream_event(channel, json!({ "line": "hello from the pod" }));
+    let screen = common::render_app(&mut app, 120, 30);
+    assert!(screen.contains("hello from the pod"), "screen: {}", screen);
+    press(&mut app, key(KeyCode::Esc)).await;
+
+    press(&mut app, ch('s')).await;
+    match &app.requires_terminal_suspend {
+        Some(SuspendAction::PodShell { pod, container }) => {
+            assert_eq!(pod, "pod-a");
+            assert!(container.is_none());
+        }
+        _ => panic!("expected a pending pod shell"),
+    }
+    app.requires_terminal_suspend = None;
+
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert!(
+        matches!(app.active_view, ActiveView::Logs(_)),
+        "enter on a pod opens its logs"
+    );
+    press(&mut app, key(KeyCode::Esc)).await;
+
+    set_table(
+        &mut app,
+        ResourceKind::Workloads,
+        vec![json!({ "name": "web", "namespace": "default", "kind": "Deployment" })],
+    );
+    press(&mut app, ch('l')).await;
+    assert!(matches!(app.active_view, ActiveView::Table(_)));
+    assert!(
+        toast(&app).starts_with("Logs only available for Pods"),
+        "toast: {}",
+        toast(&app)
+    );
+    press(&mut app, ch('s')).await;
+    assert!(app.requires_terminal_suspend.is_none());
+    assert!(
+        toast(&app).starts_with("Shell only available for Pods"),
+        "toast: {}",
+        toast(&app)
+    );
+
+    set_table(
+        &mut app,
+        ResourceKind::Workloads,
+        vec![json!({ "name": "web-1", "namespace": "default", "kind": "Pod" })],
+    );
+    press(&mut app, ch('l')).await;
+    assert!(matches!(app.active_view, ActiveView::Logs(_)));
+}
+
+#[tokio::test]
+async fn action_palette_opens_with_x_filters_navigates_and_runs_the_chosen_action() {
+    let (mut app, _rx) = common::app().await;
+    seed_table(&mut app, ResourceKind::Pods, pods(&["pod-a"]));
+    let palette = |app: &App| match &app.modal {
+        Some(Modal::ActionPalette {
+            actions,
+            selected_idx,
+            filter,
+            resource_kind,
+            ..
+        }) => {
+            assert_eq!(resource_kind, "Pod");
+            (actions.len(), *selected_idx, filter.clone())
+        }
+        other => panic!("expected the action palette, got {:?}", other),
+    };
+
+    press(&mut app, ch('x')).await;
+    let (count, _, _) = palette(&app);
+    assert_eq!(count, 12);
+    press(&mut app, key(KeyCode::Down)).await;
+    assert_eq!(palette(&app).1, 1);
+    press(&mut app, key(KeyCode::Up)).await;
+    assert_eq!(palette(&app).1, 0);
+    press(&mut app, key(KeyCode::Up)).await;
+    assert_eq!(palette(&app).1, count - 1, "up wraps");
+    press(&mut app, ctrl('j')).await;
+    assert_eq!(palette(&app).1, 0, "down wraps");
+    press(&mut app, ctrl('k')).await;
+    assert_eq!(palette(&app).1, count - 1);
+    press(&mut app, key(KeyCode::Null)).await;
+    assert_eq!(palette(&app).1, count - 1);
+    let screen = common::render_app(&mut app, 120, 40);
+    assert!(screen.contains("pod-a"), "screen: {}", screen);
+
+    type_str(&mut app, "shells").await;
+    assert_eq!(palette(&app).1, 0, "typing resets the selection");
+    press(&mut app, key(KeyCode::Backspace)).await;
+    assert_eq!(palette(&app).2, "shell");
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert!(app.modal.is_none());
+    assert!(matches!(
+        app.requires_terminal_suspend,
+        Some(SuspendAction::PodShell { .. })
+    ));
+    app.requires_terminal_suspend = None;
+
+    press(&mut app, ch('x')).await;
+    type_str(&mut app, "port").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert!(matches!(
+        app.modal,
+        Some(Modal::PortForward {
+            container_port: 8080,
+            ..
+        })
+    ));
+    press(&mut app, key(KeyCode::Esc)).await;
+
+    press(&mut app, ch('x')).await;
+    type_str(&mut app, "del").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    match &app.modal {
+        Some(Modal::Confirm {
+            action_name,
+            is_destructive,
+            ..
+        }) => {
+            assert_eq!(action_name, "delete:Pod:default:pod-a");
+            assert!(is_destructive);
+        }
+        other => panic!("expected a confirm dialog, got {:?}", other),
+    }
+    press(&mut app, key(KeyCode::Esc)).await;
+
+    press(&mut app, ch('x')).await;
+    type_str(&mut app, "no such action").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert!(app.modal.is_none(), "enter on an empty list just closes");
+
+    press(&mut app, ch('x')).await;
+    type_str(&mut app, "/crashloop").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert!(matches!(app.active_view, ActiveView::Assistant));
+    assert_eq!(app.assistant_state.input, "/crashloop pod-a");
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert_eq!(
+        table(&app).kind,
+        ResourceKind::Pods,
+        "esc pops back to the table it was opened from"
+    );
+    assert_eq!(
+        table(&app).raw_items.len(),
+        1,
+        "the informer cache re-primes the restored table"
+    );
+
+    press(&mut app, ch('x')).await;
+    // "logs" alone would hit the CrashLoop playbook, whose description
+    // mentions container logs and which sorts first.
+    type_str(&mut app, "view live logs").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert!(matches!(app.active_view, ActiveView::Logs(_)));
+    press(&mut app, key(KeyCode::Esc)).await;
+
+    press(&mut app, ch('x')).await;
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert!(app.modal.is_none());
+}
+
+#[tokio::test]
+async fn action_palette_offers_kind_specific_actions_for_workloads_and_nodes() {
+    let (mut app, _rx) = common::app().await;
+    seed_table(
+        &mut app,
+        ResourceKind::Deployments,
+        vec![json!({ "name": "web", "namespace": "default" })],
+    );
+    press(&mut app, ch('x')).await;
+    type_str(&mut app, "scale").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert!(matches!(app.modal, Some(Modal::Scale { .. })));
+    press(&mut app, key(KeyCode::Esc)).await;
+
+    press(&mut app, ch('x')).await;
+    type_str(&mut app, "restart").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    match &app.modal {
+        Some(Modal::Confirm { action_name, .. }) => {
+            assert_eq!(action_name, "restart:Deployment:default:web")
+        }
+        other => panic!("expected a confirm dialog, got {:?}", other),
+    }
+    press(&mut app, key(KeyCode::Esc)).await;
+
+    press(&mut app, ch('x')).await;
+    type_str(&mut app, "/rollout").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert!(matches!(app.active_view, ActiveView::Assistant));
+    assert_eq!(app.assistant_state.input, "/rollout web");
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert_eq!(table(&app).kind, ResourceKind::Deployments);
+
+    press(&mut app, ch('x')).await;
+    // Plain "pods" would hit the relationship tree, whose description maps
+    // "Workload -> ReplicaSets -> Pods -> Services" and which sorts first.
+    type_str(&mut app, "view pods").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert_eq!(table(&app).kind, ResourceKind::Pods);
+    assert_eq!(app.filter_buffer, "web");
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert_eq!(
+        app.filter_buffer, "",
+        "esc clears the filter the jump left behind"
+    );
+
+    seed_table(
+        &mut app,
+        ResourceKind::Nodes,
+        vec![json!({ "name": "node-1" })],
+    );
+    press(&mut app, ch('x')).await;
+    type_str(&mut app, "inspect").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    match &app.active_view {
+        ActiveView::NodeInspector(ni) => assert_eq!(ni.node_name, "node-1"),
+        _ => panic!("expected the node inspector"),
+    }
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert_eq!(table(&app).kind, ResourceKind::Nodes);
+
+    press(&mut app, ch('x')).await;
+    type_str(&mut app, "tree").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    match &app.active_view {
+        ActiveView::Tree(t) => assert_eq!(
+            (t.root_kind.as_str(), t.root_name.as_str()),
+            ("Node", "node-1")
+        ),
+        _ => panic!("expected the tree view"),
+    }
+    press(&mut app, key(KeyCode::Esc)).await;
+
+    set_table(
+        &mut app,
+        ResourceKind::ConfigMaps,
+        vec![json!({ "name": "cfg", "namespace": "default" })],
+    );
+    press(&mut app, ch('x')).await;
+    type_str(&mut app, "ask ai").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert!(matches!(app.active_view, ActiveView::Assistant));
+    assert!(
+        app.assistant_state.input.contains("ConfigMap 'cfg'"),
+        "input: {}",
+        app.assistant_state.input
+    );
+}
+
+#[tokio::test]
+async fn m_opens_the_metrics_timeline_and_keys_change_its_range() {
+    let (mut app, _rx) = common::app().await;
+    set_table(&mut app, ResourceKind::Pods, pods(&["pod-a"]));
+    let panel = |app: &App| match &app.modal {
+        Some(Modal::MetricsTimeline(p)) => (p.target_kind.clone(), p.namespace.clone(), p.range),
+        other => panic!("expected the metrics timeline, got {:?}", other),
+    };
+    press(&mut app, ch('m')).await;
+    assert_eq!(
+        panel(&app),
+        (
+            "Pod".to_string(),
+            Some("default".to_string()),
+            MetricsTimeRange::FiveMin
+        )
+    );
+    press(&mut app, key(KeyCode::Tab)).await;
+    assert_eq!(panel(&app).2, MetricsTimeRange::TenMin);
+    press(&mut app, ch('3')).await;
+    assert_eq!(panel(&app).2, MetricsTimeRange::ThirtyMin);
+    press(&mut app, ch('4')).await;
+    assert_eq!(panel(&app).2, MetricsTimeRange::OneHour);
+    press(&mut app, ch('1')).await;
+    assert_eq!(panel(&app).2, MetricsTimeRange::FiveMin);
+    press(&mut app, ch('2')).await;
+    assert_eq!(panel(&app).2, MetricsTimeRange::TenMin);
+    press(&mut app, ch('r')).await;
+    assert_eq!(toast(&app), "Refreshing metrics...");
+    press(&mut app, ch('z')).await;
+    assert!(app.modal.is_some());
+    let screen = common::render_app(&mut app, 120, 40);
+    assert!(screen.contains("pod-a"), "screen: {}", screen);
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert!(app.modal.is_none());
+
+    set_table(
+        &mut app,
+        ResourceKind::Nodes,
+        vec![json!({ "name": "node-1" })],
+    );
+    press(&mut app, ch('m')).await;
+    assert_eq!(panel(&app).0, "Node");
+    assert!(panel(&app).1.is_none());
+    press(&mut app, ch('r')).await;
+    assert_eq!(toast(&app), "Refreshing metrics...");
+    press(&mut app, key(KeyCode::Esc)).await;
+
+    set_table(
+        &mut app,
+        ResourceKind::Workloads,
+        vec![json!({ "name": "web", "namespace": "default", "kind": "Deployment" })],
+    );
+    press(&mut app, ch('m')).await;
+    assert!(app.modal.is_none());
+    assert!(
+        toast(&app).starts_with("Metrics timeline is only available for Pods"),
+        "toast: {}",
+        toast(&app)
+    );
+
+    set_table(
+        &mut app,
+        ResourceKind::Workloads,
+        vec![json!({ "name": "web-1", "namespace": "default", "kind": "Pod" })],
+    );
+    press(&mut app, ch('m')).await;
+    assert_eq!(panel(&app).0, "Pod");
+}
+
+fn events() -> Vec<Value> {
+    vec![
+        json!({ "name": "e1", "namespace": "default", "reason": "BackOff", "type": "Warning", "object": "Pod/web-1", "message": "restarting", "age": "1m" }),
+        json!({ "name": "e2", "namespace": "default", "reason": "BackOff", "type": "Warning", "object": "Pod/web-2", "message": "restarting", "age": "2m" }),
+        json!({ "name": "e3", "namespace": "default", "reason": "Pulled", "type": "Normal", "object": "Pod/web-1", "message": "pulled", "age": "3m" }),
+    ]
+}
+
+#[tokio::test]
+async fn shift_r_on_a_narrow_events_table_opens_the_reason_rail_modal() {
+    let (mut app, _rx) = common::app().await;
+    set_table(&mut app, ResourceKind::Events, events());
+    let rail = |app: &App| match &app.modal {
+        Some(Modal::ReasonRail {
+            tallies,
+            selected_idx,
+            ..
+        }) => (tallies.len(), *selected_idx),
+        other => panic!("expected the reason rail, got {:?}", other),
+    };
+    press(&mut app, ch('R')).await;
+    assert_eq!(rail(&app), (2, 0));
+    press(&mut app, ch('j')).await;
+    assert_eq!(rail(&app).1, 1);
+    press(&mut app, key(KeyCode::Down)).await;
+    assert_eq!(rail(&app).1, 1, "no wrap past the end");
+    press(&mut app, ch('z')).await;
+    assert_eq!(rail(&app).1, 1);
+    press(&mut app, ch('k')).await;
+    assert_eq!(rail(&app).1, 0);
+    press(&mut app, key(KeyCode::Up)).await;
+    assert_eq!(rail(&app).1, 0);
+    let screen = common::render_app(&mut app, 100, 40);
+    assert!(screen.contains("BackOff"), "screen: {}", screen);
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert!(app.modal.is_none());
+    assert_eq!(table(&app).active_reason_filter.as_deref(), Some("BackOff"));
+    assert_eq!(table(&app).filtered_indices.len(), 2);
+    assert_eq!(toast(&app), "Filtered events by reason: BackOff");
+
+    press(&mut app, ch('R')).await;
+    press(&mut app, ch('c')).await;
+    assert!(table(&app).active_reason_filter.is_none());
+    assert_eq!(table(&app).filtered_indices.len(), 3);
+    assert_eq!(toast(&app), "Cleared event reason filter");
+
+    press(&mut app, ch('R')).await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    press(&mut app, ch('R')).await;
+    press(&mut app, key(KeyCode::Backspace)).await;
+    assert!(table(&app).active_reason_filter.is_none());
+
+    press(&mut app, ch('R')).await;
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert!(app.modal.is_none());
+}
+
+#[tokio::test]
+async fn shift_r_on_a_wide_events_table_focuses_the_rail_whose_keys_pick_a_reason() {
+    let (mut app, _rx) = common::app().await;
+    set_table(&mut app, ResourceKind::Events, events());
+    table_mut(&mut app).last_area_width.set(120);
+    press(&mut app, ch('R')).await;
+    assert!(table(&app).reason_rail_focused);
+    assert!(app.modal.is_none());
+    press(&mut app, ch('j')).await;
+    assert_eq!(table(&app).selected_reason_idx, 1);
+    press(&mut app, key(KeyCode::Down)).await;
+    assert_eq!(table(&app).selected_reason_idx, 1);
+    press(&mut app, ch('k')).await;
+    assert_eq!(table(&app).selected_reason_idx, 0);
+    press(&mut app, key(KeyCode::Up)).await;
+    assert_eq!(table(&app).selected_reason_idx, 0);
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert!(!table(&app).reason_rail_focused);
+    assert_eq!(table(&app).active_reason_filter.as_deref(), Some("BackOff"));
+    assert_eq!(toast(&app), "Filtered events by reason: BackOff");
+
+    press(&mut app, ch('R')).await;
+    press(&mut app, ch('c')).await;
+    assert!(!table(&app).reason_rail_focused);
+    assert!(table(&app).active_reason_filter.is_none());
+    assert_eq!(toast(&app), "Cleared event reason filter");
+
+    press(&mut app, ch('R')).await;
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert!(
+        table(&app).reason_rail_focused,
+        "Esc never reaches the rail: the global back/clear handler claims it first, \
+         so the rail's own Esc arm (app.rs:2145) is dead"
+    );
+    press(&mut app, ch('R')).await;
+    assert!(!table(&app).reason_rail_focused, "'R' does leave the rail");
+
+    press(&mut app, ch('R')).await;
+    press(&mut app, ch('w')).await;
+    assert!(
+        table(&app).reason_rail_focused,
+        "unhandled keys fall through without leaving the rail"
+    );
+    assert!(
+        toast(&app).starts_with("Warning Triage"),
+        "toast: {}",
+        toast(&app)
+    );
+    press(&mut app, ch('R')).await;
+
+    set_table(&mut app, ResourceKind::Events, vec![]);
+    table_mut(&mut app).last_area_width.set(120);
+    press(&mut app, ch('R')).await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert!(
+        !table(&app).reason_rail_focused,
+        "enter with no reasons just unfocuses"
+    );
+    assert!(table(&app).active_reason_filter.is_none());
+}
+
+#[tokio::test]
+async fn w_toggles_warning_triage_on_the_events_table() {
+    let (mut app, _rx) = common::app().await;
+    set_table(&mut app, ResourceKind::Events, events());
+    press(&mut app, ch('w')).await;
+    assert!(table(&app).warning_triage);
+    assert_eq!(table(&app).filtered_indices.len(), 2);
+    assert_eq!(toast(&app), "Warning Triage: ON (2 warnings)");
+    press(&mut app, ch('w')).await;
+    assert!(!table(&app).warning_triage);
+    assert_eq!(toast(&app), "Warning Triage: OFF (all 3 events)");
+
+    set_table(&mut app, ResourceKind::Pods, pods(&["p"]));
+    press(&mut app, ch('w')).await;
+    assert!(
+        !table(&app).warning_triage,
+        "'w' means nothing outside events"
+    );
+}
+
+#[tokio::test]
+async fn events_table_keys_act_on_the_involved_object() {
+    let (mut app, _rx) = common::app().await;
+    seed_table(&mut app, ResourceKind::Events, events());
+
+    press(&mut app, ch('c')).await;
+    assert_eq!(toast(&app), "✓ Copied event message to clipboard");
+    press(&mut app, ctrl('y')).await;
+    assert!(
+        toast(&app).starts_with("✓ Copied deep link: "),
+        "toast: {}",
+        toast(&app)
+    );
+    assert!(toast(&app).contains("web-1"));
+
+    press(&mut app, ch('l')).await;
+    match &app.active_view {
+        ActiveView::Logs(l) => assert_eq!(l.pod_name, "web-1"),
+        _ => panic!("expected the logs view"),
+    }
+    press(&mut app, key(KeyCode::Esc)).await;
+
+    press(&mut app, ch('x')).await;
+    match &app.modal {
+        Some(Modal::ActionPalette {
+            resource_kind,
+            resource_name,
+            ..
+        }) => {
+            assert_eq!(
+                (resource_kind.as_str(), resource_name.as_str()),
+                ("Pod", "web-1")
+            );
+        }
+        other => panic!("expected the action palette, got {:?}", other),
+    }
+    press(&mut app, key(KeyCode::Esc)).await;
+
+    press(&mut app, ch('t')).await;
+    match &app.active_view {
+        ActiveView::Tree(t) => assert_eq!(
+            (t.root_kind.as_str(), t.root_name.as_str()),
+            ("Pod", "web-1")
+        ),
+        _ => panic!("expected the tree view"),
+    }
+    press(&mut app, key(KeyCode::Esc)).await;
+
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert_eq!(table(&app).kind, ResourceKind::Pods);
+    assert_eq!(app.filter_buffer, "web-1");
+    assert_eq!(toast(&app), "Jumped to Pod 'web-1'");
+    press(&mut app, key(KeyCode::Esc)).await;
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert_eq!(table(&app).kind, ResourceKind::Events);
+
+    seed_table(
+        &mut app,
+        ResourceKind::Events,
+        vec![
+            json!({ "name": "e", "namespace": "default", "reason": "ScalingReplicaSet", "type": "Normal", "involvedObject": { "kind": "Deployment", "name": "api" } }),
+            json!({ "name": "e2", "namespace": "default", "reason": "Odd", "type": "Normal", "message": "no object" }),
+        ],
+    );
+    press(&mut app, ch('l')).await;
+    assert!(matches!(app.active_view, ActiveView::Table(_)));
+    assert_eq!(
+        toast(&app),
+        "Logs only available for Pods (event target is Deployment)"
+    );
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert_eq!(table(&app).kind, ResourceKind::Deployments);
+    assert_eq!(app.filter_buffer, "api");
+    assert_eq!(toast(&app), "Jumped to Deployment 'api'");
+    press(&mut app, key(KeyCode::Esc)).await;
+    press(&mut app, key(KeyCode::Esc)).await;
+
+    press(&mut app, ch('j')).await;
+    app.toast = None;
+    for k in [ch('x'), ch('t'), ctrl('y'), key(KeyCode::Enter)] {
+        press(&mut app, k).await;
+        assert!(app.modal.is_none());
+        assert!(matches!(app.active_view, ActiveView::Table(_)));
+        assert!(
+            app.toast.is_none(),
+            "an event without an object has nothing to act on"
+        );
+    }
+}
+
+#[tokio::test]
+async fn table_navigation_keys_move_page_and_mark_rows() {
+    let (mut app, _rx) = common::app().await;
+    set_table(
+        &mut app,
+        ResourceKind::Pods,
+        pods(&["a", "b", "c", "d", "e"]),
+    );
+    app.set_toast("hello".into(), Style::default());
+    press(&mut app, ch('j')).await;
+    assert_eq!(table(&app).selected_idx, 1);
+    assert!(app.toast.is_none(), "moving dismisses the toast");
+    press(&mut app, key(KeyCode::Down)).await;
+    assert_eq!(table(&app).selected_idx, 2);
+    press(&mut app, ch('k')).await;
+    press(&mut app, key(KeyCode::Up)).await;
+    assert_eq!(table(&app).selected_idx, 0);
+    press(&mut app, ch('k')).await;
+    assert_eq!(table(&app).selected_idx, 0, "no wrap at the top");
+    press(&mut app, ch('G')).await;
+    assert_eq!(table(&app).selected_idx, 4);
+    press(&mut app, ch('g')).await;
+    assert_eq!(table(&app).selected_idx, 0);
+    press(&mut app, key(KeyCode::End)).await;
+    assert_eq!(table(&app).selected_idx, 4);
+    press(&mut app, key(KeyCode::Home)).await;
+    assert_eq!(table(&app).selected_idx, 0);
+    press(&mut app, key(KeyCode::PageDown)).await;
+    assert_eq!(table(&app).selected_idx, 4);
+    press(&mut app, key(KeyCode::PageUp)).await;
+    assert_eq!(table(&app).selected_idx, 0);
+    press(&mut app, key(KeyCode::PageDown)).await;
+    press(&mut app, ctrl('u')).await;
+    assert_eq!(table(&app).selected_idx, 0);
+
+    press(&mut app, ch(' ')).await;
+    assert!(table(&app).marked_indices.contains(&0));
+    press(&mut app, ch(' ')).await;
+    assert!(table(&app).marked_indices.is_empty());
+    press(&mut app, key(KeyCode::Null)).await;
+    assert_eq!(table(&app).selected_idx, 0);
+    let screen = common::render_app(&mut app, 120, 30);
+    assert!(screen.contains("e"), "screen: {}", screen);
+}
+
+#[tokio::test]
+async fn c_copies_the_selection_or_marked_names_and_shift_c_copies_yaml() {
+    let (mut app, _rx) = common::app().await;
+    press(&mut app, ch('c')).await;
+    assert!(app.toast.is_none(), "nothing to copy on an empty table");
+    press(&mut app, ch('C')).await;
+    assert!(app.toast.is_none());
+    press(&mut app, ctrl('y')).await;
+    assert!(app.toast.is_none());
+
+    set_table(
+        &mut app,
+        ResourceKind::Pods,
+        pods(&["pod-a", "pod-b", "pod-c"]),
+    );
+    press(&mut app, ch('c')).await;
+    assert_eq!(toast(&app), "✓ Copied 'pod-a' to clipboard");
+    press(&mut app, ch(' ')).await;
+    press(&mut app, ch('j')).await;
+    press(&mut app, ch(' ')).await;
+    press(&mut app, ch('c')).await;
+    assert_eq!(toast(&app), "✓ Copied 2 resource names to clipboard");
+    press(&mut app, shift(KeyCode::Char('C'))).await;
+    assert_eq!(toast(&app), "✓ Copied resource YAML to clipboard");
+    press(&mut app, ctrl('y')).await;
+    assert!(
+        toast(&app).starts_with("✓ Copied deep link: "),
+        "toast: {}",
+        toast(&app)
+    );
+    assert!(toast(&app).contains("pod-b"));
+    assert!(toast(&app).contains("test-cluster"));
+}
+
+#[tokio::test]
+async fn enter_drills_into_namespaces_crds_controllers_and_nodes() {
+    let (mut app, _rx) = common::app().await;
+    set_table(
+        &mut app,
+        ResourceKind::Namespaces,
+        vec![json!({ "name": "team-a" })],
+    );
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert_eq!(app.active_namespace, "team-a");
+    assert_eq!(table(&app).kind, ResourceKind::Pods);
+    assert_eq!(app.nav_stack.len(), 1);
+
+    app.crds = vec![widget_crd()];
+    set_table(
+        &mut app,
+        ResourceKind::CustomResourceDefinitions,
+        vec![json!({ "name": "widgets.example.com" })],
+    );
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert!(matches!(&table(&app).kind, ResourceKind::CustomResource(c) if c.kind == "Widget"));
+
+    set_table(
+        &mut app,
+        ResourceKind::CustomResourceDefinitions,
+        vec![json!({ "name": "unknown.example.com" })],
+    );
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert_eq!(
+        table(&app).kind,
+        ResourceKind::CustomResourceDefinitions,
+        "an undiscovered CRD stays put"
+    );
+
+    set_table(
+        &mut app,
+        ResourceKind::StatefulSets,
+        vec![json!({ "name": "db", "namespace": "team-a" })],
+    );
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert_eq!(table(&app).kind, ResourceKind::Pods);
+    assert_eq!(app.filter_buffer, "db");
+
+    set_table(
+        &mut app,
+        ResourceKind::Nodes,
+        vec![json!({ "name": "node-1" })],
+    );
+    app.node_metrics_history.insert(
+        "node-1".into(),
+        std::iter::once(srelens_kube::metrics::MetricSample {
+            timestamp_epoch_ms: 1,
+            cpu_millicores: 7,
+            memory_mib: 9,
+        })
+        .collect(),
+    );
+    press(&mut app, key(KeyCode::Enter)).await;
+    match &app.active_view {
+        ActiveView::NodeInspector(ni) => {
+            assert_eq!(ni.node_name, "node-1");
+            assert_eq!(
+                ni.cpu_history,
+                vec![7],
+                "existing history seeds the inspector"
+            );
+        }
+        _ => panic!("expected the node inspector"),
+    }
+    let screen = common::render_app(&mut app, 120, 40);
+    assert!(screen.contains("node-1"), "screen: {}", screen);
+
+    set_table(
+        &mut app,
+        ResourceKind::Workloads,
+        vec![json!({ "name": "web", "namespace": "team-a", "kind": "Deployment" })],
+    );
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert_eq!(table(&app).kind, ResourceKind::Pods);
+    assert_eq!(app.filter_buffer, "web");
+
+    set_table(
+        &mut app,
+        ResourceKind::Workloads,
+        vec![json!({ "name": "web-1", "namespace": "team-a", "kind": "Pod" })],
+    );
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert!(matches!(app.active_view, ActiveView::Logs(_)));
+
+    set_table(&mut app, ResourceKind::Pods, vec![]);
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert!(
+        matches!(app.active_view, ActiveView::Table(_)),
+        "enter on an empty table does nothing"
+    );
+}
+
+#[tokio::test]
+async fn esc_pops_the_navigation_stack_after_clearing_filters() {
+    let (mut app, _rx) = common::app().await;
+    set_table(&mut app, ResourceKind::Pods, pods(&["a", "b"]));
+    app.switch_view_to_kind(ResourceKind::Nodes).await;
+    assert_eq!(app.nav_stack.len(), 1);
+    table_mut(&mut app).set_items(
+        vec![
+            json!({ "name": "beta-1" }),
+            json!({ "name": "beta-2" }),
+            json!({ "name": "gamma" }),
+        ],
+        "",
+    );
+
+    press(&mut app, ch('/')).await;
+    // Two matches, not one: a single match makes Enter drill into the row.
+    type_str(&mut app, "beta").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert_eq!(table(&app).filtered_indices.len(), 2);
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert_eq!(
+        table(&app).kind,
+        ResourceKind::Nodes,
+        "the first esc only clears the filter"
+    );
+    assert_eq!(table(&app).filtered_indices.len(), 3);
+
+    table_mut(&mut app).active_reason_filter = Some("x".into());
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert!(table(&app).active_reason_filter.is_none());
+    assert_eq!(table(&app).kind, ResourceKind::Nodes);
+
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert_eq!(table(&app).kind, ResourceKind::Pods);
+    assert!(app.nav_stack.is_empty());
+    assert_eq!(
+        app.current_watch_channel.as_deref(),
+        Some("watch:test-cluster:default:pods")
+    );
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert_eq!(
+        table(&app).kind,
+        ResourceKind::Pods,
+        "esc on the root view is a no-op"
+    );
+}
+
+#[tokio::test]
+async fn yaml_view_keys_scroll_copy_and_flag_an_edit() {
+    let (mut app, _rx) = common::app().await;
+    let content: String = (0..40).map(|i| format!("line-{}\n", i)).collect();
+    app.active_view = ActiveView::Yaml(YamlViewState::new(
+        "p".into(),
+        "Pod".into(),
+        Some("default".into()),
+        content,
+    ));
+    let offset = |app: &App| match &app.active_view {
+        ActiveView::Yaml(y) => y.scroll_offset,
+        _ => panic!("expected yaml"),
+    };
+    press(&mut app, ch('j')).await;
+    press(&mut app, key(KeyCode::Down)).await;
+    assert_eq!(offset(&app), 2);
+    press(&mut app, ch('k')).await;
+    assert_eq!(offset(&app), 1);
+    press(&mut app, ctrl('d')).await;
+    assert_eq!(offset(&app), 11);
+    press(&mut app, ctrl('u')).await;
+    assert_eq!(offset(&app), 1);
+    press(&mut app, ch('G')).await;
+    assert!(offset(&app) > 1);
+    press(&mut app, ch('g')).await;
+    assert_eq!(offset(&app), 0);
+    press(&mut app, ch('c')).await;
+    assert_eq!(toast(&app), "✓ Copied YAML to clipboard");
+    press(&mut app, ch('e')).await;
+    assert!(matches!(
+        app.requires_terminal_suspend,
+        Some(SuspendAction::EditYaml)
+    ));
+    let screen = common::render_app(&mut app, 120, 30);
+    assert!(screen.contains("line-0"), "screen: {}", screen);
+}
+
+// ---------------------------------------------------------------------------
+// Watch pool bookkeeping
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn restart_active_watch_primes_from_the_cache_and_keeps_channels_pooled() {
+    let (mut app, _rx) = common::app().await;
+    app.resource_cache.insert(
+        ("test-cluster".into(), "default".into(), "pods".into()),
+        pods(&["cached"]),
+    );
+    app.restart_active_watch().await;
+    assert!(!table(&app).is_loading);
+    assert_eq!(
+        table(&app).selected_resource_name().as_deref(),
+        Some("cached")
+    );
+
+    app.switch_view_to_kind(ResourceKind::Nodes).await;
+    assert!(table(&app).is_loading, "no cache for nodes");
+    assert_eq!(app.active_watch_pool.len(), 2);
+    assert_eq!(app.active_watch_pool[1], "watch:test-cluster:default:nodes");
+    app.switch_view_to_kind(ResourceKind::Pods).await;
+    assert_eq!(
+        app.active_watch_pool.len(),
+        2,
+        "revisiting a kind does not duplicate its channel"
+    );
+    assert_eq!(
+        app.active_watch_pool[1], "watch:test-cluster:default:pods",
+        "most recently used goes last"
+    );
+
+    app.switch_view_to_kind(ResourceKind::Overview).await;
+    let before = app.active_watch_pool.clone();
+    app.restart_active_watch().await;
+    assert_eq!(
+        app.active_watch_pool, before,
+        "non-table views start no watch"
+    );
+}
+
+#[tokio::test]
+async fn the_watch_pool_evicts_its_oldest_channel_past_twenty() {
+    let (mut app, _rx) = common::app().await;
+    app.active_watch_pool = (0..20)
+        .map(|i| format!("watch:test-cluster:default:fake{}", i))
+        .collect();
+    app.active_watch_channels = app.active_watch_pool.iter().cloned().collect();
+    app.switch_view_to_kind(ResourceKind::Services).await;
+    assert_eq!(app.active_watch_pool.len(), 20);
+    assert!(!app
+        .active_watch_pool
+        .contains(&"watch:test-cluster:default:fake0".to_string()));
+    assert!(!app
+        .active_watch_channels
+        .contains("watch:test-cluster:default:fake0"));
+    assert_eq!(
+        app.active_watch_pool[19],
+        "watch:test-cluster:default:services"
+    );
+}
+
+#[tokio::test]
+async fn the_workloads_view_watches_every_constituent_kind_and_rebuilds_from_the_cache() {
+    let (mut app, _rx) = common::app().await;
+    press(&mut app, ch(':')).await;
+    type_str(&mut app, "wl").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert_eq!(table(&app).kind, ResourceKind::Workloads);
+    assert_eq!(
+        app.current_watch_channel.as_deref(),
+        Some("workloads:test-cluster:default")
+    );
+    assert!(table(&app).is_loading);
+    for kind in [
+        "deployments",
+        "statefulsets",
+        "daemonsets",
+        "pods",
+        "cronjobs",
+    ] {
+        let ch = format!("watch:test-cluster:default:{}", kind);
+        assert!(app.active_watch_pool.contains(&ch), "missing {}", ch);
+    }
+
+    app.handle_stream_event(
+        "watch:test-cluster:default:deployments".into(),
+        json!([{ "name": "web", "namespace": "default", "ready": "1/2", "age": "5m" }]),
+    );
+    app.handle_stream_event(
+        "watch:test-cluster:default:pods".into(),
+        json!([{ "name": "web-1", "namespace": "default", "phase": "Running", "ready": "0/1", "restarts": 3 }]),
+    );
+    assert!(!table(&app).is_loading);
+    assert_eq!(table(&app).raw_items.len(), 2);
+    assert_eq!(table(&app).raw_items[0]["status"], "Degraded");
+    assert_eq!(table(&app).raw_items[1]["status"], "NotReady");
+
+    app.restart_active_watch().await;
+    assert_eq!(
+        table(&app).raw_items.len(),
+        2,
+        "restarting rebuilds from the cache"
+    );
+    let mut channels: Vec<String> = app.active_watch_channels.iter().cloned().collect();
+    channels.sort();
+    assert_eq!(
+        channels,
+        vec![
+            "watch:test-cluster:default:cronjobs".to_string(),
+            "watch:test-cluster:default:daemonsets".to_string(),
+            "watch:test-cluster:default:deployments".to_string(),
+            "watch:test-cluster:default:pods".to_string(),
+            "watch:test-cluster:default:statefulsets".to_string(),
+        ],
+        "the workloads view watches exactly its five constituent kinds"
+    );
+}

--- a/apps/tui/tests/app_state_tests.rs
+++ b/apps/tui/tests/app_state_tests.rs
@@ -46,12 +46,50 @@ use tokio::sync::mpsc::UnboundedReceiver;
 const WIDE: (u16, u16) = (200, 50);
 const NARROW: (u16, u16) = (80, 24);
 
-/// Point AI settings persistence at a scratch file so no test touches the
-/// user's real configuration.
-fn isolate_ai_settings() {
-    let dir = std::env::temp_dir().join("srelens-app-state-tests");
-    let _ = std::fs::create_dir_all(&dir);
-    std::env::set_var("SRELENS_AI_SETTINGS_PATH", dir.join("ai_settings.json"));
+/// Point AI settings persistence at a scratch file that belongs to this test
+/// alone, and hold a lock for as long as it is pointed there. Bind the guard
+/// (`let _settings = isolate_ai_settings();`) — dropping it immediately
+/// releases the lock and deletes the directory.
+///
+/// `AiSettings::config_path()` reads a process-global environment variable,
+/// which is the only seam the type offers. So two settings tests running at
+/// once would fight over it, and — the reason this is not merely theoretical —
+/// a FIXED scratch path carries one run's saved state into the next run of the
+/// binary: a saved `"openai": "value"` seeds the next run's edit buffer and
+/// the assertion reads `valuesk-test` instead of `sk-test`. A fresh directory
+/// per test cannot do that.
+fn isolate_ai_settings() -> SettingsGuard {
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    // A test that panics while holding the lock poisons it; the next test
+    // still wants the lock, not the panic.
+    let lock = LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    let dir = tempfile::tempdir().expect("a scratch directory for AI settings");
+    let previous = std::env::var("SRELENS_AI_SETTINGS_PATH").ok();
+    std::env::set_var(
+        "SRELENS_AI_SETTINGS_PATH",
+        dir.path().join("ai_settings.json"),
+    );
+    SettingsGuard {
+        _lock: lock,
+        _dir: dir,
+        previous,
+    }
+}
+
+struct SettingsGuard {
+    _lock: std::sync::MutexGuard<'static, ()>,
+    /// Held, not used: dropping it deletes the scratch directory.
+    _dir: tempfile::TempDir,
+    previous: Option<String>,
+}
+
+impl Drop for SettingsGuard {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(value) => std::env::set_var("SRELENS_AI_SETTINGS_PATH", value),
+            None => std::env::remove_var("SRELENS_AI_SETTINGS_PATH"),
+        }
+    }
 }
 
 /// An assistant configuration that can never reach a provider: Gemini with no
@@ -869,7 +907,7 @@ async fn the_overview_renders_cluster_health_with_gauges_and_hints() {
 
 #[tokio::test]
 async fn the_assistant_settings_and_tree_views_render_with_their_hints() {
-    isolate_ai_settings();
+    let _settings = isolate_ai_settings();
     let (mut app, _rx) = common::app().await;
 
     app.assistant_state
@@ -1938,7 +1976,7 @@ async fn a_configured_provider_starts_a_native_agent_turn() {
 
 #[tokio::test]
 async fn caveman_phrases_and_slash_commands_switch_the_terse_mode() {
-    isolate_ai_settings();
+    let _settings = isolate_ai_settings();
     let (mut app, _rx) = common::app().await;
     keyless_assistant(&mut app);
     app.active_view = ActiveView::Assistant;
@@ -1985,7 +2023,7 @@ async fn caveman_phrases_and_slash_commands_switch_the_terse_mode() {
 
 #[tokio::test]
 async fn utility_slash_commands_clear_open_settings_and_expand_playbooks() {
-    isolate_ai_settings();
+    let _settings = isolate_ai_settings();
     let (mut app, _rx) = common::app().await;
     keyless_assistant(&mut app);
     app.active_view = ActiveView::Assistant;
@@ -2015,7 +2053,7 @@ async fn utility_slash_commands_clear_open_settings_and_expand_playbooks() {
 
 #[tokio::test]
 async fn settings_keys_navigate_toggle_edit_and_save() {
-    isolate_ai_settings();
+    let _settings = isolate_ai_settings();
     let (mut app, _rx) = common::app().await;
     app.switch_view_to_kind(ResourceKind::Settings).await;
     // The view opens on whichever provider the stored settings name; start

--- a/apps/tui/tests/app_state_tests.rs
+++ b/apps/tui/tests/app_state_tests.rs
@@ -17,9 +17,8 @@ use srelens_kube::node_inspector::{
 };
 use srelens_tui::ai_skills::CavemanLevel;
 use srelens_tui::app::{
-    copy_to_clipboard, copy_via_osc52, extract_tool_call_completed_info,
-    extract_tool_call_start_info, format_event_summary, get_clipboard_text, parse_involved_object,
-    parse_ready_ratio, ActiveView, App, SuspendAction,
+    extract_tool_call_completed_info, extract_tool_call_start_info, format_event_summary,
+    get_clipboard_text, parse_involved_object, parse_ready_ratio, ActiveView, App, SuspendAction,
 };
 use srelens_tui::commands::{CommandTarget, CrdMeta, PrinterColumn, ResourceKind};
 use srelens_tui::event::AppEvent;
@@ -418,18 +417,16 @@ fn assert_only_greeting(app: &App) {
 // Free helper functions
 // ---------------------------------------------------------------------------
 
-#[test]
-fn copying_to_the_clipboard_reports_a_result_even_without_a_display() {
-    // OSC 52 + native command fallbacks: the call must not panic and must
-    // return the io::Result shape regardless of what the runner has installed.
-    copy_via_osc52("selected text");
-    let result = copy_to_clipboard("line one\nline two");
-    assert!(result.is_ok() || result.is_err());
-    // Base64 boundary cases (1, 2 and 3 byte tails) all go through the encoder.
-    copy_via_osc52("a");
-    copy_via_osc52("ab");
-    copy_via_osc52("");
-}
+// Nothing here calls `copy_via_osc52` or `copy_to_clipboard` directly. They
+// write to the host: OSC 52 hands the text to the terminal emulator and the
+// fallbacks shell out to wl-copy/xclip, so a direct call from a test
+// overwrites whatever the developer had on their clipboard. There is nothing
+// to assert about them either — they return `()` and `io::Result`, so the
+// only available assertion is that a result is a result. The copy paths that
+// carry real signal are the key handlers in `app_extra_tests.rs`, which press
+// the key and assert the toast that names what was copied.
+//
+// Reading is a different matter: it takes nothing away from the developer.
 
 #[test]
 fn reading_the_clipboard_never_yields_an_empty_string() {

--- a/apps/tui/tests/app_state_tests.rs
+++ b/apps/tui/tests/app_state_tests.rs
@@ -1,0 +1,3285 @@
+//! Integration tests for `App` state handling: incoming events, rendering
+//! across every view and modal, mouse handling, per-view key handling, and
+//! the free helpers at the bottom of `app.rs`.
+
+mod common;
+
+use std::collections::VecDeque;
+use std::time::Duration;
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEventKind};
+use ratatui::layout::Rect;
+use serde_json::{json, Value};
+use srelens_kube::lineage::{LineageNode, LineageRelation};
+use srelens_kube::metrics::MetricSample;
+use srelens_kube::node_inspector::{
+    NodeConditionInfo, NodeInspectorDetails, NodePodItem, NodeTaintInfo,
+};
+use srelens_tui::ai_skills::CavemanLevel;
+use srelens_tui::app::{
+    copy_to_clipboard, copy_via_osc52, extract_tool_call_completed_info,
+    extract_tool_call_start_info, format_event_summary, get_clipboard_text, parse_involved_object,
+    parse_ready_ratio, ActiveView, App, SuspendAction,
+};
+use srelens_tui::commands::{CommandTarget, CrdMeta, PrinterColumn, ResourceKind};
+use srelens_tui::event::AppEvent;
+use srelens_tui::ui::dialogs::{QuickActionId, QuickActionItem};
+use srelens_tui::ui::{ContainerAction, InputMode, Modal};
+use srelens_tui::views::describe_view::DescribeViewState;
+use srelens_tui::views::helm_view::{HelmReleaseItem, HelmViewState};
+use srelens_tui::views::logs_view::LogsViewState;
+use srelens_tui::views::metrics_panel_view::MetricsPanelState;
+use srelens_tui::views::node_inspector_view::NodeInspectorState;
+use srelens_tui::views::overview_view::{ClusterOverviewData, OverviewViewState};
+use srelens_tui::views::port_forward_view::{PortForwardEntry, PortForwardViewState};
+use srelens_tui::views::resource_table::ResourceTableState;
+use srelens_tui::views::toolbox_view::{ToolStatusItem, ToolboxViewState};
+use srelens_tui::views::tree_view::TreeViewState;
+use srelens_tui::views::yaml_view::YamlViewState;
+use srelens_tui::{AiProvider, AiSettings, DeepLink};
+use tokio::sync::mpsc::UnboundedReceiver;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const WIDE: (u16, u16) = (200, 50);
+const NARROW: (u16, u16) = (80, 24);
+
+/// Point AI settings persistence at a scratch file so no test touches the
+/// user's real configuration.
+fn isolate_ai_settings() {
+    let dir = std::env::temp_dir().join("srelens-app-state-tests");
+    let _ = std::fs::create_dir_all(&dir);
+    std::env::set_var("SRELENS_AI_SETTINGS_PATH", dir.join("ai_settings.json"));
+}
+
+/// An assistant configuration that can never reach a provider: Gemini with no
+/// key anywhere, so a submitted query is answered by the "No API key" reply.
+fn keyless_assistant(app: &mut App) {
+    std::env::remove_var("GEMINI_API_KEY");
+    let mut settings = AiSettings::default();
+    settings.default_provider = AiProvider::Gemini;
+    settings.api_keys.clear();
+    app.ai_settings = settings;
+    app.assistant_state.caveman_level = None;
+}
+
+fn toast(app: &App) -> String {
+    app.toast
+        .as_ref()
+        .map(|(m, _, _)| m.clone())
+        .unwrap_or_default()
+}
+
+fn wide(app: &mut App) -> String {
+    common::render_app(app, WIDE.0, WIDE.1)
+}
+
+fn narrow(app: &mut App) -> String {
+    common::render_app(app, NARROW.0, NARROW.1)
+}
+
+fn pod(name: &str, ns: &str) -> Value {
+    json!({
+        "name": name,
+        "namespace": ns,
+        "status": "Running",
+        "ready": "1/1",
+        "restarts": 0,
+        "age": "5m",
+        "node": "node-1",
+    })
+}
+
+fn table_with(kind: ResourceKind, items: Vec<Value>) -> ResourceTableState {
+    let mut table = ResourceTableState::new(kind);
+    table.set_items(items, "");
+    table.is_loading = false;
+    table
+}
+
+fn sample(ts: u64, cpu: u64, mem: u64) -> MetricSample {
+    MetricSample {
+        timestamp_epoch_ms: ts,
+        cpu_millicores: cpu,
+        memory_mib: mem,
+    }
+}
+
+fn overview_data() -> ClusterOverviewData {
+    ClusterOverviewData {
+        context_name: "test-cluster".into(),
+        cluster_name: "kubernetes".into(),
+        server_url: "https://10.0.0.1:6443".into(),
+        k8s_version: "v1.31.0".into(),
+        is_reachable: true,
+        node_count: 3,
+        ready_nodes: 3,
+        total_pods: 40,
+        running_pods: 38,
+        pending_pods: 1,
+        failed_pods: 1,
+        total_cpu_millicores: 12_000,
+        used_cpu_millicores: 4_000,
+        total_mem_mib: 32 * 1024,
+        used_mem_mib: 8 * 1024,
+        total_gpus: 2,
+        allocated_gpus: 1,
+        total_gpu_mem_mib: 32 * 1024,
+        used_gpu_mem_mib: 4 * 1024,
+    }
+}
+
+/// A toolbox built by hand: `ToolboxViewState::new()` shells out to `which`.
+fn toolbox() -> ToolboxViewState {
+    ToolboxViewState {
+        tools: vec![
+            ToolStatusItem {
+                name: "kubectl".into(),
+                installed: true,
+                version: Some("v1.31.0".into()),
+                path: Some("/usr/local/bin/kubectl".into()),
+                required: true,
+            },
+            ToolStatusItem {
+                name: "helm".into(),
+                installed: false,
+                version: None,
+                path: None,
+                required: false,
+            },
+        ],
+        selected_idx: 0,
+    }
+}
+
+fn port_forwards() -> PortForwardViewState {
+    let mut pf = PortForwardViewState::new();
+    pf.set_forwards(vec![PortForwardEntry {
+        id: "pf-1".into(),
+        context: "test-cluster".into(),
+        namespace: "default".into(),
+        target_type: "Pod".into(),
+        target_name: "web-0".into(),
+        local_port: 8080,
+        container_port: 80,
+        active_connections: 1,
+        bytes_rx: 10,
+        bytes_tx: 20,
+        status: "Active".into(),
+    }]);
+    pf
+}
+
+fn helm_releases() -> HelmViewState {
+    let mut helm = HelmViewState::new();
+    helm.set_releases(vec![HelmReleaseItem {
+        name: "nginx".into(),
+        namespace: "default".into(),
+        revision: 3,
+        status: "deployed".into(),
+        chart: "nginx-15.0.0".into(),
+        app_version: "1.25".into(),
+        updated: "2026-01-01".into(),
+    }]);
+    helm
+}
+
+fn lineage_tree() -> LineageNode {
+    let mut root = LineageNode::new(
+        "Deployment",
+        "web",
+        Some("default".to_string()),
+        LineageRelation::Target,
+    );
+    let mut rs = LineageNode::new(
+        "ReplicaSet",
+        "web-abc",
+        Some("default".to_string()),
+        LineageRelation::Child,
+    );
+    rs.children.push(LineageNode::new(
+        "Pod",
+        "web-abc-1",
+        Some("default".to_string()),
+        LineageRelation::Child,
+    ));
+    root.children.push(rs);
+    root
+}
+
+fn tree_view() -> TreeViewState {
+    let mut tree = TreeViewState::new("Deployment".into(), "web".into(), Some("default".into()));
+    tree.set_tree(lineage_tree());
+    tree
+}
+
+fn node_pod(name: &str, ns: &str) -> NodePodItem {
+    NodePodItem {
+        name: name.into(),
+        namespace: ns.into(),
+        phase: "Running".into(),
+        ready_containers: "1/1".into(),
+        restarts: 0,
+        age: "1d".into(),
+        cpu_requests_millicores: 100,
+        mem_requests_mib: 128,
+        gpu_requests: 0,
+        gpu_mem_requests_mib: 0,
+        pod_ip: "10.0.0.2".into(),
+    }
+}
+
+fn node_details(name: &str, unschedulable: bool) -> NodeInspectorDetails {
+    NodeInspectorDetails {
+        name: name.into(),
+        status: "Ready".into(),
+        unschedulable,
+        roles: "worker".into(),
+        instance_type: "m5.large".into(),
+        zone: Some("eu-west-1a".into()),
+        region: Some("eu-west-1".into()),
+        nodepool: None,
+        internal_ip: Some("10.0.0.1".into()),
+        external_ip: None,
+        os_image: "Ubuntu".into(),
+        kernel_version: "6.1".into(),
+        container_runtime: "containerd".into(),
+        kubelet_version: "v1.31.0".into(),
+        architecture: "amd64".into(),
+        created_at: "2026-01-01T00:00:00Z".into(),
+        cpu_capacity_millicores: 4000,
+        cpu_allocatable_millicores: 3800,
+        cpu_requests_millicores: 1000,
+        mem_capacity_mib: 8192,
+        mem_allocatable_mib: 7800,
+        mem_requests_mib: 2048,
+        pods_capacity: 110,
+        pods_allocatable: 110,
+        pods_count: 2,
+        has_gpu: true,
+        gpu_model: Some("A10".into()),
+        gpu_driver_version: Some("550".into()),
+        gpu_cuda_version: Some("12.4".into()),
+        gpu_capacity_count: 1,
+        gpu_allocatable_count: 1,
+        gpu_requests_count: 0,
+        gpu_memory_total_mib: Some(24_576),
+        gpu_memory_requests_mib: 0,
+        conditions: vec![NodeConditionInfo {
+            type_: "Ready".into(),
+            status: "True".into(),
+            reason: None,
+            message: None,
+        }],
+        taints: vec![NodeTaintInfo {
+            key: "dedicated".into(),
+            value: Some("gpu".into()),
+            effect: "NoSchedule".into(),
+        }],
+        pods: vec![
+            node_pod("api-0", "default"),
+            node_pod("exporter", "monitoring"),
+        ],
+    }
+}
+
+fn inspector_with_details(name: &str, unschedulable: bool) -> NodeInspectorState {
+    let mut ni = NodeInspectorState::new(name.into());
+    ni.set_details(node_details(name, unschedulable));
+    ni
+}
+
+fn action(id: QuickActionId, title: &str) -> QuickActionItem {
+    QuickActionItem {
+        id,
+        key_hint: "k".into(),
+        title: title.into(),
+        description: "desc".into(),
+    }
+}
+
+fn palette(kind: &str, name: &str, ns: Option<&str>, id: QuickActionId) -> Modal {
+    Modal::ActionPalette {
+        resource_kind: kind.into(),
+        resource_name: name.into(),
+        namespace: ns.map(String::from),
+        actions: vec![action(id, "Chosen action")],
+        selected_idx: 0,
+        filter: String::new(),
+    }
+}
+
+/// Wait for the first emitted event matching `pred`; spawned cluster calls
+/// fail fast, so this never waits on a network round trip.
+async fn wait_for<F>(rx: &mut UnboundedReceiver<AppEvent>, mut pred: F) -> AppEvent
+where
+    F: FnMut(&AppEvent) -> bool,
+{
+    tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            let ev = rx.recv().await.expect("event channel stays open");
+            if pred(&ev) {
+                return ev;
+            }
+        }
+    })
+    .await
+    .expect("expected event was emitted")
+}
+
+fn last_message(app: &App) -> String {
+    app.assistant_state
+        .messages
+        .last()
+        .map(|m| m.content.clone())
+        .unwrap_or_default()
+}
+
+/// A key press with Alt held.
+fn alt(c: char) -> KeyEvent {
+    KeyEvent::new(KeyCode::Char(c), KeyModifiers::ALT)
+}
+
+/// Type into the assistant composer. A leading `c` on an empty input is the
+/// "copy the last answer" shortcut rather than a character, so the first
+/// character is seeded directly when it would be swallowed.
+async fn compose(app: &mut App, text: &str) {
+    for (i, c) in text.chars().enumerate() {
+        if i == 0 && c == 'c' && app.assistant_state.input.is_empty() {
+            app.assistant_state.input.push('c');
+            continue;
+        }
+        app.handle_key_event(common::ch(c)).await;
+    }
+}
+
+/// The cell column of `needle` within a rendered row. `str::find` returns a
+/// byte offset and the frame is full of multi-byte box-drawing characters, so
+/// the count has to be in characters.
+fn cell_col(line: &str, needle: &str) -> u16 {
+    let byte = line.find(needle).expect("text is on this row");
+    line[..byte].chars().count() as u16
+}
+
+/// A conversation always opens with one seeded assistant greeting.
+fn assert_only_greeting(app: &App) {
+    assert_eq!(app.assistant_state.messages.len(), 1);
+    assert_eq!(app.assistant_state.messages[0].role, "assistant");
+    assert!(
+        app.assistant_state.messages[0]
+            .content
+            .starts_with("Hello!"),
+        "{}",
+        app.assistant_state.messages[0].content
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Free helper functions
+// ---------------------------------------------------------------------------
+
+#[test]
+fn copying_to_the_clipboard_reports_a_result_even_without_a_display() {
+    // OSC 52 + native command fallbacks: the call must not panic and must
+    // return the io::Result shape regardless of what the runner has installed.
+    copy_via_osc52("selected text");
+    let result = copy_to_clipboard("line one\nline two");
+    assert!(result.is_ok() || result.is_err());
+    // Base64 boundary cases (1, 2 and 3 byte tails) all go through the encoder.
+    copy_via_osc52("a");
+    copy_via_osc52("ab");
+    copy_via_osc52("");
+}
+
+#[test]
+fn reading_the_clipboard_never_yields_an_empty_string() {
+    match get_clipboard_text() {
+        Some(text) => assert!(!text.is_empty(), "Some(...) must carry text"),
+        None => {}
+    }
+}
+
+#[test]
+fn a_tool_call_start_summarises_the_arguments_by_kind() {
+    let bash = json!({
+        "call_id": "c1",
+        "tool_call": { "bashToolCall": { "args": { "command": "kubectl get pods" } } }
+    });
+    assert_eq!(
+        extract_tool_call_start_info(&bash),
+        Some(("c1".into(), "bash".into(), "kubectl get pods".into()))
+    );
+
+    let read = json!({
+        "callId": "c2",
+        "toolCall": { "readToolCall": { "args": { "path": "/etc/hosts" } } }
+    });
+    assert_eq!(
+        extract_tool_call_start_info(&read),
+        Some(("c2".into(), "read".into(), "path: /etc/hosts".into()))
+    );
+
+    let grep = json!({ "toolCall": { "grepToolCall": { "args": { "pattern": "ERROR" } } } });
+    assert_eq!(
+        extract_tool_call_start_info(&grep).unwrap().2,
+        "pattern: ERROR"
+    );
+
+    let search = json!({ "toolCall": { "webSearchToolCall": { "args": { "query": "k8s" } } } });
+    assert_eq!(
+        extract_tool_call_start_info(&search).unwrap().2,
+        "query: k8s"
+    );
+
+    let named = json!({ "toolCall": { "skillToolCall": { "args": { "name": "triage" } } } });
+    assert_eq!(
+        extract_tool_call_start_info(&named).unwrap().2,
+        "name: triage"
+    );
+
+    let str_args = json!({ "toolCall": { "echoToolCall": { "args": "raw" } } });
+    assert_eq!(extract_tool_call_start_info(&str_args).unwrap().2, "raw");
+
+    let empty_obj = json!({ "toolCall": { "listToolCall": { "args": {} } } });
+    assert_eq!(extract_tool_call_start_info(&empty_obj).unwrap().2, "");
+
+    let other_obj = json!({ "toolCall": { "xToolCall": { "args": { "k": 1 } } } });
+    assert_eq!(
+        extract_tool_call_start_info(&other_obj).unwrap().2,
+        "{\"k\":1}"
+    );
+
+    let num_args = json!({ "toolCall": { "xToolCall": { "args": 42 } } });
+    assert_eq!(extract_tool_call_start_info(&num_args).unwrap().2, "42");
+
+    let no_args = json!({ "toolCall": { "xToolCall": {} } });
+    assert_eq!(extract_tool_call_start_info(&no_args).unwrap().2, "");
+}
+
+#[test]
+fn an_mcp_tool_call_start_uses_the_nested_tool_name_and_arguments() {
+    // The nested name is only unwrapped once the key strips down to exactly
+    // "callMcpTool" or "mcp".
+    let mcp = json!({
+        "call_id": "m1",
+        "tool_call": { "callMcpToolToolCall": {
+            "args": { "tool": "list_pods", "arguments": { "namespace": "default" } }
+        } }
+    });
+    assert_eq!(
+        extract_tool_call_start_info(&mcp),
+        Some((
+            "m1".into(),
+            "list_pods".into(),
+            "{\"namespace\":\"default\"}".into()
+        ))
+    );
+
+    let scalar_args = json!({
+        "tool_call": { "mcpToolCall": { "args": { "name": "get_logs", "arguments": "web-0" } } }
+    });
+    assert_eq!(
+        extract_tool_call_start_info(&scalar_args),
+        Some(("".into(), "get_logs".into(), "\"web-0\"".into()))
+    );
+
+    // Any other key keeps the stripped key as the tool name.
+    let plain = json!({
+        "tool_call": { "callMcpToolCall": { "args": { "tool": "list_pods", "arguments": {} } } }
+    });
+    assert_eq!(extract_tool_call_start_info(&plain).unwrap().1, "callMcp");
+}
+
+#[test]
+fn a_tool_call_start_without_a_tool_call_payload_is_ignored() {
+    assert_eq!(
+        extract_tool_call_start_info(&json!({ "call_id": "x" })),
+        None
+    );
+    assert_eq!(
+        extract_tool_call_start_info(&json!({ "tool_call": "not-an-object" })),
+        None
+    );
+    // Only metadata siblings, no *ToolCall key.
+    let meta_only = json!({ "tool_call": { "hookAdditionalContexts": {}, "startedAtMs": 1 } });
+    assert_eq!(extract_tool_call_start_info(&meta_only), None);
+}
+
+#[test]
+fn a_tool_call_completion_carries_its_id_and_error_flag() {
+    assert_eq!(
+        extract_tool_call_completed_info(&json!({ "call_id": "c1", "is_error": true })),
+        Some(("c1".into(), true))
+    );
+    assert_eq!(
+        extract_tool_call_completed_info(&json!({ "callId": "c2", "isError": false })),
+        Some(("c2".into(), false))
+    );
+    assert_eq!(
+        extract_tool_call_completed_info(&json!({})),
+        Some(("".into(), false))
+    );
+    let with_tool = json!({ "call_id": "c3", "toolCall": { "bashToolCall": {} } });
+    assert_eq!(
+        extract_tool_call_completed_info(&with_tool),
+        Some(("c3".into(), false))
+    );
+    let meta_only = json!({ "call_id": "c4", "tool_call": { "hookAdditionalContexts": {} } });
+    assert_eq!(extract_tool_call_completed_info(&meta_only), None);
+}
+
+#[test]
+fn an_events_involved_object_is_read_from_either_shape() {
+    assert_eq!(
+        parse_involved_object(&json!({ "object": "Pod/web-0" })),
+        ("Pod".into(), "web-0".into())
+    );
+    assert_eq!(
+        parse_involved_object(&json!({ "involvedObject": { "kind": "Node", "name": "n1" } })),
+        ("Node".into(), "n1".into())
+    );
+    assert_eq!(
+        parse_involved_object(&json!({ "involvedObject": { "name": "orphan" } })),
+        ("".into(), "orphan".into())
+    );
+    assert_eq!(
+        parse_involved_object(&json!({ "object": "noslash" })),
+        ("".into(), "".into())
+    );
+    assert_eq!(parse_involved_object(&json!({})), ("".into(), "".into()));
+}
+
+#[test]
+fn an_event_summary_lists_age_type_reason_object_namespace_and_message() {
+    let ev = json!({
+        "age": "3m", "type": "Warning", "reason": "BackOff",
+        "object": "Pod/web-0", "namespace": "prod", "message": "restarting"
+    });
+    assert_eq!(
+        format_event_summary(&ev),
+        "[3m] [Warning] BackOff Pod/web-0 (prod): restarting"
+    );
+    let typed = json!({ "type_": "Normal", "reason": "Pulled" });
+    assert_eq!(format_event_summary(&typed), "[] [Normal] Pulled  (): ");
+}
+
+#[test]
+fn a_ready_ratio_parses_leniently() {
+    assert_eq!(parse_ready_ratio("2/3"), (2, 3));
+    assert_eq!(parse_ready_ratio(" 1 / 1 "), (1, 1));
+    assert_eq!(parse_ready_ratio("4"), (4, 0));
+    assert_eq!(parse_ready_ratio("garbage"), (0, 0));
+}
+
+// ---------------------------------------------------------------------------
+// Stream events
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_pods_watch_for_the_current_channel_keeps_previous_metrics_and_fills_the_cache() {
+    let (mut app, _rx) = common::app().await;
+    let mut table = table_with(ResourceKind::Pods, vec![pod("web-0", "default")]);
+    table.raw_items[0]["cpu"] = json!("5m");
+    table.raw_items[0]["memory"] = json!("64Mi");
+    app.active_view = ActiveView::Table(table);
+    let channel = "watch:test-cluster:default:pods".to_string();
+    app.current_watch_channel = Some(channel.clone());
+    app.is_connected = false;
+    app.cluster_unreachable = true;
+
+    app.handle_stream_event(
+        channel,
+        json!([pod("web-0", "default"), pod("web-1", "default")]),
+    );
+
+    assert!(app.is_connected);
+    assert!(!app.cluster_unreachable);
+    let cached = app
+        .resource_cache
+        .get(&("test-cluster".into(), "default".into(), "pods".into()))
+        .expect("watch payload is cached");
+    assert_eq!(cached.len(), 2);
+    let ActiveView::Table(t) = &app.active_view else {
+        panic!("still a table")
+    };
+    assert_eq!(t.raw_items.len(), 2);
+    assert_eq!(t.raw_items[0]["cpu"], json!("5m"));
+    assert_eq!(t.raw_items[0]["memory"], json!("64Mi"));
+    assert!(t.raw_items[1].get("cpu").is_none());
+}
+
+#[tokio::test]
+async fn a_watch_for_another_channel_only_updates_the_cache() {
+    let (mut app, _rx) = common::app().await;
+    app.active_view = ActiveView::Table(table_with(ResourceKind::Deployments, vec![]));
+    app.current_watch_channel = Some("watch:test-cluster:default:deployments".into());
+
+    app.handle_stream_event(
+        "watch:test-cluster:default:services".into(),
+        json!([{ "name": "svc-a" }]),
+    );
+
+    let ActiveView::Table(t) = &app.active_view else {
+        panic!("table")
+    };
+    assert!(t.raw_items.is_empty());
+    assert!(app.resource_cache.contains_key(&(
+        "test-cluster".into(),
+        "default".into(),
+        "services".into()
+    )));
+}
+
+#[tokio::test]
+async fn a_non_pod_watch_for_the_current_channel_replaces_the_rows() {
+    let (mut app, _rx) = common::app().await;
+    app.active_view = ActiveView::Table(table_with(ResourceKind::Services, vec![]));
+    let channel = "watch:test-cluster:default:services".to_string();
+    app.current_watch_channel = Some(channel.clone());
+
+    app.handle_stream_event(channel, json!([{ "name": "svc-a" }, { "name": "svc-b" }]));
+
+    let ActiveView::Table(t) = &app.active_view else {
+        panic!("table")
+    };
+    assert_eq!(t.raw_items.len(), 2);
+    assert_eq!(t.filtered_indices.len(), 2);
+}
+
+#[tokio::test]
+async fn a_workloads_table_is_rebuilt_when_a_constituent_kind_arrives() {
+    let (mut app, _rx) = common::app().await;
+    app.active_view = ActiveView::Table(table_with(ResourceKind::Workloads, vec![]));
+
+    app.handle_stream_event(
+        "watch:test-cluster:default:deployments".into(),
+        json!([{ "name": "web", "namespace": "default", "ready": "1/1" }]),
+    );
+
+    let ActiveView::Table(t) = &app.active_view else {
+        panic!("table")
+    };
+    assert_eq!(t.kind, ResourceKind::Workloads);
+    assert!(
+        t.raw_items.iter().any(|i| i["name"] == "web"),
+        "workloads table picks up the deployment: {:?}",
+        t.raw_items
+    );
+}
+
+#[tokio::test]
+async fn a_namespaces_watch_replaces_the_sorted_namespace_list() {
+    let (mut app, _rx) = common::app().await;
+    app.handle_stream_event(
+        "watch:test-cluster::namespaces".into(),
+        json!([{ "name": "zeta" }, { "name": "alpha" }, { "other": 1 }]),
+    );
+    assert_eq!(
+        app.namespaces,
+        vec!["alpha".to_string(), "zeta".to_string()]
+    );
+
+    // An empty list keeps the previous namespaces.
+    app.handle_stream_event("watch:test-cluster::namespaces".into(), json!([]));
+    assert_eq!(app.namespaces.len(), 2);
+}
+
+#[tokio::test]
+async fn log_lines_and_status_markers_for_the_open_log_stream_are_appended() {
+    let (mut app, _rx) = common::app().await;
+    let logs = LogsViewState::new(
+        "web-0".into(),
+        "default".into(),
+        None,
+        "logs:web-0:1".into(),
+    );
+    app.active_view = ActiveView::Logs(logs);
+
+    app.handle_stream_event("logs:web-0:1".into(), json!({ "line": "hello world" }));
+    app.handle_stream_event("logs:web-0:1".into(), json!({ "status": "closed" }));
+    app.handle_stream_event("logs:other:2".into(), json!({ "line": "ignored" }));
+
+    let ActiveView::Logs(l) = &app.active_view else {
+        panic!("logs")
+    };
+    assert_eq!(l.lines, vec!["hello world", "--- log status: closed ---"]);
+}
+
+// ---------------------------------------------------------------------------
+// Rendering: every view, wide and narrow
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn every_table_kind_renders_its_own_key_hints() {
+    let (mut app, _rx) = common::app().await;
+    app.pod_count = 7;
+    let cases: Vec<(ResourceKind, &str)> = vec![
+        (ResourceKind::Workloads, "Segment"),
+        (ResourceKind::Pods, "PortForward"),
+        (ResourceKind::Deployments, "Restart"),
+        (ResourceKind::StatefulSets, "Scale"),
+        (ResourceKind::DaemonSets, "Scale"),
+        (ResourceKind::Services, "Endpoints"),
+        (ResourceKind::Ingresses, "Edit"),
+        (ResourceKind::Namespaces, "Pods"),
+        (ResourceKind::Events, "Triage"),
+        (ResourceKind::Nodes, "Inspect"),
+        (ResourceKind::ConfigMaps, "Help"),
+    ];
+    for (kind, hint) in cases {
+        let title = kind.display_name().to_string();
+        app.active_view = ActiveView::Table(table_with(kind, vec![pod("web-0", "default")]));
+        let screen = wide(&mut app);
+        assert!(
+            screen.contains(&title),
+            "{title} title on wide screen:\n{screen}"
+        );
+        assert!(
+            screen.contains(hint),
+            "{title} shows hint {hint}:\n{screen}"
+        );
+        let screen = narrow(&mut app);
+        assert!(
+            screen.contains(&title),
+            "{title} title on narrow screen:\n{screen}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn an_unreachable_cluster_with_no_rows_renders_the_cracked_lens() {
+    let (mut app, _rx) = common::app().await;
+    app.cluster_unreachable = true;
+    app.active_view = ActiveView::Table(table_with(ResourceKind::Pods, vec![]));
+
+    let screen = wide(&mut app);
+    assert!(screen.contains("Cluster Unreachable"), "{screen}");
+    assert!(screen.contains("Retry"), "{screen}");
+    assert!(screen.contains("SwitchCtx"), "{screen}");
+
+    // Rows in hand win over the unreachable flag.
+    app.active_view = ActiveView::Table(table_with(ResourceKind::Pods, vec![pod("a", "b")]));
+    let screen = wide(&mut app);
+    assert!(!screen.contains("Cluster Unreachable"), "{screen}");
+    assert!(screen.contains("Shell"), "{screen}");
+}
+
+#[tokio::test]
+async fn text_views_render_their_titles_search_counts_and_hints() {
+    let (mut app, _rx) = common::app().await;
+
+    let mut yaml = YamlViewState::new(
+        "web-0".into(),
+        "Pod".into(),
+        Some("default".into()),
+        "apiVersion: v1\nkind: Pod\nmetadata:\n  name: web-0\n".into(),
+    );
+    yaml.set_search_query("Pod");
+    app.active_view = ActiveView::Yaml(yaml);
+    let screen = wide(&mut app);
+    assert!(screen.contains("YAML Manifest"), "{screen}");
+    assert!(screen.contains("Next/Prev"), "{screen}");
+    assert!(screen.contains("Edit"), "{screen}");
+    // A narrow terminal truncates the header's view name, but the body keeps
+    // its own title.
+    let screen = narrow(&mut app);
+    assert!(screen.contains("YAML: Pod/web-0"), "{screen}");
+
+    let mut desc = DescribeViewState::new(
+        "web-0".into(),
+        "Pod".into(),
+        Some("default".into()),
+        "Name: web-0\nNamespace: default\nStatus: Running\n".into(),
+    );
+    desc.set_search_query("Running");
+    app.active_view = ActiveView::Describe(desc);
+    let screen = wide(&mut app);
+    assert!(screen.contains("Describe: Pod/web-0"), "{screen}");
+    assert!(screen.contains("Next/Prev"), "{screen}");
+    assert!(narrow(&mut app).contains("Describe: Pod/web-0"));
+
+    let mut logs = LogsViewState::new(
+        "web-0".into(),
+        "default".into(),
+        Some("app".into()),
+        "ch".into(),
+    );
+    logs.push_line("first line".into());
+    logs.push_line("second ERROR line".into());
+    logs.set_search_query("ERROR");
+    app.active_view = ActiveView::Logs(logs);
+    // An active search narrows the body to the matching lines.
+    let screen = wide(&mut app);
+    assert!(screen.contains("Logs: web-0 (default/app)"), "{screen}");
+    assert!(screen.contains("[2/2 lines]"), "{screen}");
+    assert!(screen.contains("1/1 matches"), "{screen}");
+    assert!(screen.contains("second ERROR line"), "{screen}");
+    assert!(!screen.contains("first line"), "{screen}");
+    assert!(screen.contains("Timestamps"), "{screen}");
+    assert!(screen.contains("Follow"), "{screen}");
+    assert!(narrow(&mut app).contains("second ERROR line"));
+}
+
+#[tokio::test]
+async fn list_views_render_their_rows_and_hints() {
+    let (mut app, _rx) = common::app().await;
+
+    app.active_view = ActiveView::PortForwards(port_forwards());
+    let screen = wide(&mut app);
+    assert!(screen.contains("Active Port Forwards [1]"), "{screen}");
+    assert!(screen.contains("web-0"), "{screen}");
+    assert!(screen.contains("CopyURL"), "{screen}");
+    assert!(screen.contains("Stop"), "{screen}");
+    assert!(narrow(&mut app).contains("Active Port Forwards [1]"));
+
+    app.active_view = ActiveView::Helm(helm_releases());
+    let screen = wide(&mut app);
+    assert!(screen.contains("Helm 3 Releases [1]"), "{screen}");
+    assert!(screen.contains("nginx"), "{screen}");
+    assert!(screen.contains("Values"), "{screen}");
+    assert!(screen.contains("Manifest"), "{screen}");
+    assert!(narrow(&mut app).contains("Helm 3 Releases [1]"));
+
+    app.active_view = ActiveView::Toolbox(toolbox());
+    let screen = wide(&mut app);
+    assert!(screen.contains("SRElens Toolbox"), "{screen}");
+    assert!(screen.contains("kubectl"), "{screen}");
+    assert!(screen.contains("CopyPath"), "{screen}");
+    assert!(narrow(&mut app).contains("Toolbox"));
+}
+
+#[tokio::test]
+async fn the_overview_renders_cluster_health_with_gauges_and_hints() {
+    let (mut app, _rx) = common::app().await;
+    app.active_view = ActiveView::Overview(OverviewViewState::with_data(overview_data()));
+
+    let screen = wide(&mut app);
+    assert!(
+        screen.contains("Cluster Health & Resource Overview"),
+        "{screen}"
+    );
+    assert!(screen.contains("Workload Health Distribution"), "{screen}");
+    assert!(screen.contains("Summarise"), "{screen}");
+    assert!(screen.contains("Refresh"), "{screen}");
+    let screen = narrow(&mut app);
+    assert!(screen.contains("Overview"), "{screen}");
+}
+
+#[tokio::test]
+async fn the_assistant_settings_and_tree_views_render_with_their_hints() {
+    isolate_ai_settings();
+    let (mut app, _rx) = common::app().await;
+
+    app.assistant_state
+        .add_assistant_message("Cluster looks healthy.".into());
+    app.active_view = ActiveView::Assistant;
+    let screen = wide(&mut app);
+    assert!(screen.contains("AI Assistant"), "{screen}");
+    assert!(screen.contains("Cluster looks healthy."), "{screen}");
+    assert!(screen.contains("Cmd"), "{screen}");
+    assert!(
+        !screen.contains("Filter"),
+        "assistant hides the filter hint:\n{screen}"
+    );
+    assert!(narrow(&mut app).contains("Cluster looks healthy."));
+
+    app.switch_view_to_kind(ResourceKind::Settings).await;
+    let screen = wide(&mut app);
+    assert!(screen.contains("AI Settings"), "{screen}");
+    assert!(screen.contains("Anthropic"), "{screen}");
+    assert!(narrow(&mut app).contains("SRElens AI & Assistant Settings"));
+
+    app.active_view = ActiveView::Tree(tree_view());
+    let screen = wide(&mut app);
+    assert!(
+        screen.contains("Resource Relationship Tree: Deployment/web"),
+        "{screen}"
+    );
+    assert!(screen.contains("web-abc-1"), "{screen}");
+    assert!(screen.contains("Jump"), "{screen}");
+    assert!(screen.contains("Actions"), "{screen}");
+    assert!(narrow(&mut app).contains("Relationship Tree"));
+
+    let mut failed = TreeViewState::new("Pod".into(), "gone".into(), None);
+    failed.set_error("not found".into());
+    app.active_view = ActiveView::Tree(failed);
+    let screen = wide(&mut app);
+    assert!(screen.contains("not found"), "{screen}");
+}
+
+#[tokio::test]
+async fn the_node_inspector_renders_loading_error_and_detail_states() {
+    let (mut app, _rx) = common::app().await;
+
+    app.active_view = ActiveView::NodeInspector(NodeInspectorState::new("gpu-1".into()));
+    let screen = wide(&mut app);
+    assert!(screen.contains("Node Inspector: gpu-1"), "{screen}");
+    assert!(screen.contains("Cordon"), "{screen}");
+    assert!(screen.contains("PodDesc"), "{screen}");
+
+    let mut failed = NodeInspectorState::new("gpu-1".into());
+    failed.set_error("node not found".into());
+    app.active_view = ActiveView::NodeInspector(failed);
+    let screen = wide(&mut app);
+    assert!(screen.contains("Node Inspector Error: gpu-1"), "{screen}");
+
+    app.active_view = ActiveView::NodeInspector(inspector_with_details("gpu-1", true));
+    let screen = wide(&mut app);
+    assert!(
+        screen.contains("Uncordon"),
+        "cordoned node offers uncordon:\n{screen}"
+    );
+    assert!(screen.contains("api-0"), "{screen}");
+    assert!(screen.contains("Health Conditions & Taints"), "{screen}");
+    // The detail layout titles the panel with the node name, not "Inspector".
+    let screen = narrow(&mut app);
+    assert!(screen.contains("Node: gpu-1"), "{screen}");
+    assert!(screen.contains("CORDONED"), "{screen}");
+    assert!(screen.contains("Scheduled Pods (2 Total)"), "{screen}");
+}
+
+#[tokio::test]
+async fn every_modal_variant_renders_over_the_view() {
+    let (mut app, _rx) = common::app().await;
+    app.active_view = ActiveView::Table(table_with(
+        ResourceKind::Pods,
+        vec![pod("web-0", "default")],
+    ));
+
+    app.modal = Some(Modal::Confirm {
+        title: "Delete Pod".into(),
+        message: "Really delete web-0?".into(),
+        action_name: "delete:Pod:default:web-0".into(),
+        is_destructive: true,
+    });
+    let screen = wide(&mut app);
+    assert!(screen.contains("Delete Pod"), "{screen}");
+    assert!(screen.contains("Really delete web-0?"), "{screen}");
+
+    app.modal = Some(Modal::Scale {
+        workload_name: "web".into(),
+        current_replicas: 2,
+        input: "5".into(),
+    });
+    assert!(wide(&mut app).contains("Scale Workload: web"));
+
+    app.modal = Some(Modal::PortForward {
+        pod_name: "web-0".into(),
+        namespace: "default".into(),
+        container_port: 80,
+        local_port_input: "8080".into(),
+    });
+    assert!(wide(&mut app).contains("Start Port Forward: web-0 (default)"));
+
+    app.modal = Some(Modal::ContainerPicker {
+        pod_name: "web-0".into(),
+        namespace: Some("default".into()),
+        containers: vec!["app".into(), "sidecar".into()],
+        selected_idx: 1,
+        action: ContainerAction::Shell,
+    });
+    let screen = wide(&mut app);
+    assert!(screen.contains("sidecar"), "{screen}");
+
+    app.open_context_picker();
+    assert!(wide(&mut app).contains("Switch Kubernetes Context"));
+
+    app.modal = Some(Modal::NamespacePicker {
+        namespaces: vec!["default".into(), "kube-system".into()],
+        current_namespace: "default".into(),
+        selected_idx: 0,
+        filter: "kube".into(),
+    });
+    let screen = wide(&mut app);
+    assert!(screen.contains("Switch Namespace"), "{screen}");
+    assert!(screen.contains("kube-system"), "{screen}");
+
+    app.open_action_palette("Pod".into(), "web-0".into(), Some("default".into()));
+    let screen = wide(&mut app);
+    assert!(screen.contains("Actions: Pod/web-0 (default)"), "{screen}");
+    assert!(screen.contains("View Live Logs"), "{screen}");
+
+    let samples = vec![sample(1_000, 100, 200), sample(2_000, 150, 250)];
+    app.modal = Some(Modal::MetricsTimeline(MetricsPanelState::new(
+        "Pod".into(),
+        "web-0".into(),
+        Some("default".into()),
+        samples,
+    )));
+    assert!(wide(&mut app).contains("Live Metrics Timeline"));
+
+    let events = vec![
+        json!({ "reason": "BackOff", "type": "Warning" }),
+        json!({ "reason": "Pulled", "type": "Normal" }),
+    ];
+    app.modal = Some(Modal::ReasonRail {
+        tallies: srelens_tui::views::reason_rail::tally_event_reasons(&events),
+        selected_idx: 0,
+        active_filter: Some("BackOff".into()),
+    });
+    let screen = wide(&mut app);
+    assert!(screen.contains("BackOff"), "{screen}");
+
+    app.modal = None;
+    app.show_help = true;
+    assert!(wide(&mut app).contains("Keybindings Cheat Sheet"));
+}
+
+#[tokio::test]
+async fn the_status_bar_reflects_input_mode_toast_and_filter() {
+    let (mut app, _rx) = common::app().await;
+    app.active_view = ActiveView::Table(table_with(
+        ResourceKind::Pods,
+        vec![pod("web-0", "default"), pod("db-0", "default")],
+    ));
+
+    app.input_mode = InputMode::Command;
+    app.command_buffer = "dep".into();
+    let screen = wide(&mut app);
+    assert!(
+        screen.contains("deployments"),
+        "command suggestions are rendered:\n{screen}"
+    );
+
+    app.input_mode = InputMode::Filter;
+    app.filter_buffer = "web".into();
+    app.apply_current_filter();
+    let screen = wide(&mut app);
+    assert!(screen.contains("web"), "{screen}");
+
+    app.input_mode = InputMode::Normal;
+    app.set_toast("Copied something".into(), ratatui::style::Style::default());
+    let screen = wide(&mut app);
+    assert!(screen.contains("Copied something"), "{screen}");
+    assert!(
+        screen.contains("[1/2]"),
+        "filter match count is shown:\n{screen}"
+    );
+}
+
+#[tokio::test]
+async fn rendering_with_a_screen_selection_captures_the_highlighted_text() {
+    let (mut app, _rx) = common::app().await;
+    app.active_view = ActiveView::Table(table_with(
+        ResourceKind::Pods,
+        vec![pod("web-0", "default")],
+    ));
+
+    let screen = wide(&mut app);
+    let row = screen
+        .lines()
+        .position(|l| l.contains("web-0"))
+        .expect("pod row is rendered") as u16;
+    let col = cell_col(screen.lines().nth(row as usize).unwrap(), "web-0");
+
+    app.screen_selection = Some(((col, row), (col + 4, row)));
+    wide(&mut app);
+    assert_eq!(app.screen_selection_text.borrow().as_str(), "web-0");
+}
+
+// ---------------------------------------------------------------------------
+// Mouse handling
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn clicking_and_scrolling_a_table_moves_the_selection() {
+    let (mut app, _rx) = common::app().await;
+    let items: Vec<Value> = (0..6)
+        .map(|i| pod(&format!("pod-{i}"), "default"))
+        .collect();
+    app.active_view = ActiveView::Table(table_with(ResourceKind::Pods, items));
+    wide(&mut app);
+    let vp = match &app.active_view {
+        ActiveView::Table(t) => t.last_viewport_rect.get(),
+        _ => unreachable!(),
+    };
+
+    app.handle_mouse(common::click(vp.x + 2, vp.y + 2 + 1))
+        .await;
+    let ActiveView::Table(t) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(t.selected_idx, 1);
+
+    app.handle_mouse(common::mouse(
+        MouseEventKind::ScrollDown,
+        vp.x + 2,
+        vp.y + 3,
+    ))
+    .await;
+    let ActiveView::Table(t) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(t.selected_idx, 4);
+
+    app.handle_mouse(common::mouse(MouseEventKind::ScrollUp, vp.x + 2, vp.y + 3))
+        .await;
+    let ActiveView::Table(t) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(t.selected_idx, 1);
+
+    // Clicking the header rows leaves the selection alone.
+    app.handle_mouse(common::click(vp.x + 2, vp.y)).await;
+    let ActiveView::Table(t) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(t.selected_idx, 1);
+}
+
+#[tokio::test]
+async fn dragging_in_the_yaml_view_copies_the_selected_lines() {
+    let (mut app, _rx) = common::app().await;
+    let content: String = (0..12).map(|i| format!("line-{i}\n")).collect();
+    app.active_view = ActiveView::Yaml(YamlViewState::new(
+        "web-0".into(),
+        "Pod".into(),
+        None,
+        content,
+    ));
+    wide(&mut app);
+    let vp = match &app.active_view {
+        ActiveView::Yaml(y) => y.last_viewport_rect.get(),
+        _ => unreachable!(),
+    };
+
+    app.handle_mouse(common::click(vp.x + 1, vp.y)).await;
+    app.handle_mouse(common::mouse(
+        MouseEventKind::Drag(MouseButton::Left),
+        vp.x + 1,
+        vp.y + 1,
+    ))
+    .await;
+    app.handle_mouse(common::mouse(
+        MouseEventKind::Up(MouseButton::Left),
+        vp.x + 1,
+        vp.y + 1,
+    ))
+    .await;
+    assert_eq!(toast(&app), "✓ Copied selection to clipboard");
+    let ActiveView::Yaml(y) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(y.selected_text().as_deref(), Some("line-0\nline-1"));
+    assert!(
+        app.screen_selection.is_none(),
+        "yaml keeps its own selection"
+    );
+
+    app.handle_mouse(common::mouse(MouseEventKind::ScrollDown, vp.x + 1, vp.y))
+        .await;
+    let ActiveView::Yaml(y) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(y.scroll_offset, 3);
+    app.handle_mouse(common::mouse(MouseEventKind::ScrollUp, vp.x + 1, vp.y))
+        .await;
+    let ActiveView::Yaml(y) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(y.scroll_offset, 0);
+
+    // A click outside the viewport clears the selection.
+    app.handle_mouse(common::click(0, 0)).await;
+    let ActiveView::Yaml(y) = &app.active_view else {
+        panic!()
+    };
+    assert!(y.selection.is_none());
+}
+
+#[tokio::test]
+async fn mouse_in_the_assistant_toggles_tool_chips_and_selects_text() {
+    let (mut app, _rx) = common::app().await;
+    app.assistant_state
+        .add_assistant_message("alpha beta gamma".into());
+    app.active_view = ActiveView::Assistant;
+    wide(&mut app);
+    let vp = app.assistant_state.last_viewport_rect.get();
+    let line = app
+        .assistant_state
+        .plain_lines
+        .borrow()
+        .iter()
+        .position(|l| l.contains("alpha beta gamma"))
+        .expect("message line is rendered") as u16;
+
+    // A click on a tool-chip line toggles expansion instead of selecting.
+    app.assistant_state
+        .tool_chip_lines
+        .borrow_mut()
+        .push(line as usize);
+    let before = app.assistant_state.expand_tools;
+    app.handle_mouse(common::click(vp.x + 1, vp.y + line)).await;
+    assert_ne!(app.assistant_state.expand_tools, before);
+    app.assistant_state.tool_chip_lines.borrow_mut().clear();
+
+    app.handle_mouse(common::click(vp.x + 1, vp.y + line)).await;
+    app.handle_mouse(common::mouse(
+        MouseEventKind::Drag(MouseButton::Left),
+        vp.x + 6,
+        vp.y + line,
+    ))
+    .await;
+    app.handle_mouse(common::mouse(
+        MouseEventKind::Up(MouseButton::Left),
+        vp.x + 6,
+        vp.y + line,
+    ))
+    .await;
+    assert_eq!(
+        app.assistant_state.get_selected_text().as_deref(),
+        Some("alpha")
+    );
+    assert!(
+        app.screen_selection.is_none(),
+        "assistant keeps its own selection"
+    );
+
+    app.handle_key_event(common::ch('c')).await;
+    assert_eq!(toast(&app), "✓ Copied selection to clipboard");
+
+    // Re-select, then click outside the viewport to clear.
+    app.handle_mouse(common::click(vp.x + 1, vp.y + line)).await;
+    app.handle_mouse(common::mouse(
+        MouseEventKind::Up(MouseButton::Left),
+        vp.x + 4,
+        vp.y + line,
+    ))
+    .await;
+    assert!(app.assistant_state.selection.is_some());
+    app.handle_mouse(common::click(0, 0)).await;
+    assert!(app.assistant_state.selection.is_none());
+}
+
+#[tokio::test]
+async fn mouse_in_the_node_inspector_pod_table_selects_and_scrolls_pods() {
+    let (mut app, _rx) = common::app().await;
+    app.active_view = ActiveView::NodeInspector(inspector_with_details("gpu-1", false));
+    wide(&mut app);
+    let vp = match &app.active_view {
+        ActiveView::NodeInspector(ni) => ni.last_pods_table_rect.get(),
+        _ => unreachable!(),
+    };
+    assert!(vp.height > 0, "pods table was laid out");
+
+    app.handle_mouse(common::click(vp.x + 1, vp.y + 1 + 1))
+        .await;
+    let ActiveView::NodeInspector(ni) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(ni.selected_pod_idx, 1);
+
+    app.handle_mouse(common::mouse(MouseEventKind::ScrollUp, vp.x + 1, vp.y + 1))
+        .await;
+    let ActiveView::NodeInspector(ni) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(ni.selected_pod_idx, 0);
+
+    app.handle_mouse(common::mouse(
+        MouseEventKind::ScrollDown,
+        vp.x + 1,
+        vp.y + 1,
+    ))
+    .await;
+    let ActiveView::NodeInspector(ni) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(ni.selected_pod_idx, 1);
+}
+
+#[tokio::test]
+async fn scroll_wheel_moves_tree_logs_and_describe_views() {
+    let (mut app, _rx) = common::app().await;
+
+    app.active_view = ActiveView::Tree(tree_view());
+    app.handle_mouse(common::mouse(MouseEventKind::ScrollDown, 10, 10))
+        .await;
+    let ActiveView::Tree(t) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(t.selected_idx, 1);
+    app.handle_mouse(common::mouse(MouseEventKind::ScrollUp, 10, 10))
+        .await;
+    let ActiveView::Tree(t) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(t.selected_idx, 0);
+
+    let mut logs = LogsViewState::new("web".into(), "default".into(), None, "ch".into());
+    for i in 0..20 {
+        logs.push_line(format!("l{i}"));
+    }
+    logs.follow = false;
+    logs.scroll_offset = 0;
+    app.active_view = ActiveView::Logs(logs);
+    app.handle_mouse(common::mouse(MouseEventKind::ScrollDown, 10, 10))
+        .await;
+    let ActiveView::Logs(l) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(l.scroll_offset, 3);
+    app.handle_mouse(common::mouse(MouseEventKind::ScrollUp, 10, 10))
+        .await;
+    let ActiveView::Logs(l) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(l.scroll_offset, 0);
+
+    let content: String = (0..20).map(|i| format!("d{i}\n")).collect();
+    app.active_view = ActiveView::Describe(DescribeViewState::new(
+        "web".into(),
+        "Pod".into(),
+        None,
+        content,
+    ));
+    app.handle_mouse(common::mouse(MouseEventKind::ScrollDown, 10, 10))
+        .await;
+    let ActiveView::Describe(d) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(d.scroll_offset, 3);
+    app.handle_mouse(common::mouse(MouseEventKind::ScrollUp, 10, 10))
+        .await;
+    let ActiveView::Describe(d) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(d.scroll_offset, 0);
+}
+
+#[tokio::test]
+async fn a_drag_over_visible_text_copies_it_and_an_empty_drag_is_dropped() {
+    let (mut app, _rx) = common::app().await;
+    app.active_view = ActiveView::Table(table_with(
+        ResourceKind::Pods,
+        vec![pod("web-0", "default")],
+    ));
+    let screen = wide(&mut app);
+    let row = screen.lines().position(|l| l.contains("web-0")).unwrap() as u16;
+    let col = cell_col(screen.lines().nth(row as usize).unwrap(), "web-0");
+
+    app.handle_mouse(common::click(col, row)).await;
+    assert!(app.screen_selecting);
+    app.handle_mouse(common::mouse(
+        MouseEventKind::Drag(MouseButton::Left),
+        col + 4,
+        row,
+    ))
+    .await;
+    wide(&mut app);
+    app.handle_mouse(common::mouse(
+        MouseEventKind::Up(MouseButton::Left),
+        col + 4,
+        row,
+    ))
+    .await;
+    assert!(!app.screen_selecting);
+    assert_eq!(toast(&app), "✓ Copied selection to clipboard");
+    assert!(
+        app.screen_selection.is_some(),
+        "highlight stays until the next key"
+    );
+    assert_eq!(app.screen_selection_text.borrow().as_str(), "web-0");
+
+    // A key press dismisses the highlight.
+    app.handle_key_event(common::ch('j')).await;
+    assert!(app.screen_selection.is_none());
+
+    // Press and release on the same cell selects nothing.
+    app.toast = None;
+    app.handle_mouse(common::click(col, row)).await;
+    app.handle_mouse(common::mouse(
+        MouseEventKind::Up(MouseButton::Left),
+        col,
+        row,
+    ))
+    .await;
+    assert!(app.screen_selection.is_none());
+    assert!(app.toast.is_none());
+
+    // A drag over blank cells is discarded without a toast.
+    app.handle_mouse(common::click(5, 40)).await;
+    app.handle_mouse(common::mouse(
+        MouseEventKind::Drag(MouseButton::Left),
+        30,
+        40,
+    ))
+    .await;
+    wide(&mut app);
+    app.handle_mouse(common::mouse(MouseEventKind::Up(MouseButton::Left), 30, 40))
+        .await;
+    assert!(app.screen_selection.is_none());
+    assert!(app.toast.is_none());
+
+    // A drag without a prior press is ignored.
+    app.handle_mouse(common::mouse(
+        MouseEventKind::Drag(MouseButton::Left),
+        30,
+        41,
+    ))
+    .await;
+    assert!(app.screen_selection.is_none());
+}
+
+#[tokio::test]
+async fn clicking_a_context_chip_opens_the_picker_or_switches_context() {
+    let (mut app, _rx) = common::app().await;
+    *app.context_chip_rects.borrow_mut() = vec![
+        (Rect::new(0, 1, 10, 1), ":ctx".into()),
+        (Rect::new(12, 1, 10, 1), "staging".into()),
+        (Rect::new(24, 1, 10, 1), "test-cluster".into()),
+    ];
+
+    app.handle_mouse(common::click(2, 1)).await;
+    assert!(matches!(app.modal, Some(Modal::ContextPicker { .. })));
+    app.modal = None;
+
+    app.handle_mouse(common::click(26, 1)).await;
+    assert_eq!(
+        app.active_context, "test-cluster",
+        "clicking the current chip is a no-op"
+    );
+    assert!(app.toast.is_none());
+
+    app.handle_mouse(common::click(14, 1)).await;
+    assert_eq!(app.active_context, "staging");
+    assert_eq!(toast(&app), "Switched to context 'staging'");
+}
+
+// ---------------------------------------------------------------------------
+// Per-view key handling
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn yaml_view_keys_scroll_copy_edit_and_share() {
+    let (mut app, _rx) = common::app().await;
+    let content: String = (0..40).map(|i| format!("k{i}: v\n")).collect();
+    app.active_view = ActiveView::Yaml(YamlViewState::new(
+        "web-0".into(),
+        "Pod".into(),
+        Some("default".into()),
+        content,
+    ));
+
+    app.handle_key_event(common::ch('j')).await;
+    app.handle_key_event(common::key(KeyCode::Down)).await;
+    app.handle_key_event(common::ctrl('d')).await;
+    let ActiveView::Yaml(y) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(y.scroll_offset, 12);
+    app.handle_key_event(common::ctrl('u')).await;
+    app.handle_key_event(common::ch('k')).await;
+    let ActiveView::Yaml(y) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(y.scroll_offset, 1);
+    app.handle_key_event(common::ch('G')).await;
+    let ActiveView::Yaml(y) = &app.active_view else {
+        panic!()
+    };
+    assert!(y.scroll_offset > 1);
+    app.handle_key_event(common::ch('g')).await;
+    let ActiveView::Yaml(y) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(y.scroll_offset, 0);
+
+    app.handle_key_event(common::ch('c')).await;
+    assert_eq!(toast(&app), "✓ Copied YAML to clipboard");
+
+    if let ActiveView::Yaml(y) = &mut app.active_view {
+        y.start_selection(0);
+        y.update_selection(2);
+    }
+    app.handle_key_event(common::ch('y')).await;
+    assert_eq!(toast(&app), "✓ Copied selection to clipboard");
+
+    app.handle_key_event(common::ctrl('y')).await;
+    assert_eq!(
+        toast(&app),
+        "Copied deep link: srelens://resource/test-cluster/default/Pod/web-0"
+    );
+
+    app.handle_key_event(common::ch('e')).await;
+    assert!(matches!(
+        app.requires_terminal_suspend,
+        Some(SuspendAction::EditYaml)
+    ));
+}
+
+#[tokio::test]
+async fn describe_view_keys_scroll_copy_and_share() {
+    let (mut app, _rx) = common::app().await;
+    let content: String = (0..40).map(|i| format!("Line {i}\n")).collect();
+    app.active_view = ActiveView::Describe(DescribeViewState::new(
+        "web".into(),
+        "Deployment".into(),
+        Some("prod".into()),
+        content,
+    ));
+
+    app.handle_key_event(common::ch('j')).await;
+    app.handle_key_event(common::ctrl('d')).await;
+    let ActiveView::Describe(d) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(d.scroll_offset, 11);
+    app.handle_key_event(common::ctrl('u')).await;
+    app.handle_key_event(common::key(KeyCode::Up)).await;
+    let ActiveView::Describe(d) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(d.scroll_offset, 0);
+    app.handle_key_event(common::key(KeyCode::End)).await;
+    let ActiveView::Describe(d) = &app.active_view else {
+        panic!()
+    };
+    assert!(d.scroll_offset > 0);
+    app.handle_key_event(common::key(KeyCode::Home)).await;
+    let ActiveView::Describe(d) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(d.scroll_offset, 0);
+
+    app.handle_key_event(common::ch('c')).await;
+    assert_eq!(toast(&app), "Copied describe output to clipboard");
+    app.handle_key_event(common::ctrl('y')).await;
+    assert_eq!(
+        toast(&app),
+        "Copied deep link: srelens://resource/test-cluster/prod/Deployment/web"
+    );
+}
+
+#[tokio::test]
+async fn logs_view_keys_toggle_flags_scroll_save_copy_and_share() {
+    let (mut app, _rx) = common::app().await;
+    let mut logs = LogsViewState::new(
+        "web-0".into(),
+        "default".into(),
+        Some("app".into()),
+        "ch".into(),
+    );
+    for i in 0..30 {
+        logs.push_line(format!("log {i}"));
+    }
+    app.active_view = ActiveView::Logs(logs);
+
+    let flags = |app: &App| match &app.active_view {
+        ActiveView::Logs(l) => (l.follow, l.timestamps, l.previous, l.wrap),
+        _ => unreachable!(),
+    };
+    let initial = flags(&app);
+    app.handle_key_event(common::ch('f')).await;
+    app.handle_key_event(common::ch('t')).await;
+    app.handle_key_event(common::ch('p')).await;
+    app.handle_key_event(common::ch('w')).await;
+    let toggled = flags(&app);
+    assert_eq!(toggled.0, !initial.0);
+    assert_eq!(toggled.1, !initial.1);
+    assert_eq!(toggled.2, !initial.2);
+    assert_eq!(toggled.3, !initial.3);
+
+    app.handle_key_event(common::ch('g')).await;
+    app.handle_key_event(common::ch('j')).await;
+    app.handle_key_event(common::key(KeyCode::Down)).await;
+    app.handle_key_event(common::ch('k')).await;
+    let ActiveView::Logs(l) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(l.scroll_offset, 1);
+    // `G` jumps to the last line; it scrolls, it does not re-arm following.
+    app.handle_key_event(common::ch('G')).await;
+    let ActiveView::Logs(l) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(l.scroll_offset, l.lines.len() - 1);
+    assert!(!l.follow);
+
+    app.handle_key_event(common::ch('s')).await;
+    assert!(toast(&app).starts_with("Logs saved to "), "{}", toast(&app));
+
+    app.handle_key_event(common::ch('c')).await;
+    assert_eq!(toast(&app), "Copied 30 log lines to clipboard");
+    app.handle_key_event(common::ctrl('y')).await;
+    assert_eq!(
+        toast(&app),
+        "Copied deep link: srelens://resource/test-cluster/default/Pod/web-0"
+    );
+}
+
+#[tokio::test]
+async fn port_forward_view_keys_copy_share_and_stop_a_forward() {
+    let (mut app, _rx) = common::app().await;
+    app.active_view = ActiveView::PortForwards(port_forwards());
+
+    app.handle_key_event(common::ch('j')).await;
+    app.handle_key_event(common::ch('k')).await;
+    let ActiveView::PortForwards(pf) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(pf.selected_idx, 0);
+
+    app.handle_key_event(common::ch('c')).await;
+    assert_eq!(toast(&app), "Copied forward URL: http://127.0.0.1:8080");
+    app.handle_key_event(common::ctrl('y')).await;
+    assert_eq!(
+        toast(&app),
+        "Copied deep link: srelens://resource/test-cluster/default/Pod/web-0"
+    );
+
+    app.handle_key_event(common::ch('d')).await;
+    match &app.modal {
+        Some(Modal::Confirm {
+            title,
+            action_name,
+            is_destructive,
+            ..
+        }) => {
+            assert_eq!(title, "Stop Port Forward [127.0.0.1:8080]");
+            assert_eq!(action_name, "stop-pf:pf-1");
+            assert!(!is_destructive);
+        }
+        other => panic!("expected confirm modal, got {:?}", other.is_some()),
+    }
+    app.handle_key_event(common::ch('y')).await;
+    assert!(app.modal.is_none());
+    assert_eq!(toast(&app), "Port forward stopped");
+
+    // With nothing selected the copy keys do nothing.
+    app.active_view = ActiveView::PortForwards(PortForwardViewState::new());
+    app.toast = None;
+    app.handle_key_event(common::ch('c')).await;
+    app.handle_key_event(common::ch('d')).await;
+    assert!(app.toast.is_none());
+    assert!(app.modal.is_none());
+}
+
+#[tokio::test]
+async fn helm_view_keys_navigate_and_copy_release_links() {
+    let (mut app, _rx) = common::app().await;
+    app.active_view = ActiveView::Helm(helm_releases());
+
+    app.handle_key_event(common::key(KeyCode::Down)).await;
+    app.handle_key_event(common::key(KeyCode::Up)).await;
+    let ActiveView::Helm(h) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(h.selected_idx, 0);
+
+    app.handle_key_event(common::ch('c')).await;
+    assert_eq!(
+        toast(&app),
+        "Copied deep link: srelens://resource/test-cluster/default/HelmRelease/nginx"
+    );
+    app.toast = None;
+    app.handle_key_event(common::ctrl('y')).await;
+    assert_eq!(
+        toast(&app),
+        "Copied deep link: srelens://resource/test-cluster/default/HelmRelease/nginx"
+    );
+
+    app.active_view = ActiveView::Helm(HelmViewState::new());
+    app.toast = None;
+    app.handle_key_event(common::ch('c')).await;
+    assert!(app.toast.is_none());
+}
+
+#[tokio::test]
+async fn toolbox_keys_copy_the_tool_path_or_name() {
+    let (mut app, _rx) = common::app().await;
+    app.active_view = ActiveView::Toolbox(toolbox());
+
+    app.handle_key_event(common::ch('c')).await;
+    assert_eq!(toast(&app), "Copied tool info: /usr/local/bin/kubectl");
+
+    app.handle_key_event(common::ch('j')).await;
+    app.handle_key_event(common::ch('y')).await;
+    assert_eq!(toast(&app), "Copied tool info: helm");
+
+    app.handle_key_event(common::ch('k')).await;
+    let ActiveView::Toolbox(tb) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(tb.selected_idx, 0);
+}
+
+#[tokio::test]
+async fn overview_keys_refresh_copy_share_and_summarise() {
+    let (mut app, _rx) = common::app().await;
+    keyless_assistant(&mut app);
+    app.active_view = ActiveView::Overview(OverviewViewState::with_data(overview_data()));
+
+    app.handle_key_event(common::ch('r')).await;
+    assert_eq!(toast(&app), "Refreshing cluster overview...");
+    app.handle_key_event(common::ch('c')).await;
+    assert_eq!(toast(&app), "Copied cluster overview summary to clipboard");
+    app.handle_key_event(common::ctrl('y')).await;
+    assert_eq!(
+        toast(&app),
+        "Copied deep link: srelens://cluster/test-cluster"
+    );
+
+    app.handle_key_event(common::ch('s')).await;
+    assert!(matches!(app.active_view, ActiveView::Assistant));
+    assert!(matches!(
+        app.nav_stack.last(),
+        Some(ActiveView::Overview(_))
+    ));
+    assert_eq!(toast(&app), "Generating AI cluster health summary...");
+    assert!(app
+        .assistant_state
+        .messages
+        .iter()
+        .any(|m| m.role == "user" && m.content == "Summarise the health of this cluster"));
+    assert!(last_message(&app).contains("No API key configured for Google Gemini"));
+
+    // A busy assistant refuses a second summary.
+    app.active_view = ActiveView::Overview(OverviewViewState::with_data(overview_data()));
+    app.assistant_state.is_busy = true;
+    app.handle_key_event(common::ctrl('a')).await;
+    assert!(matches!(app.active_view, ActiveView::Overview(_)));
+    assert!(toast(&app).contains("Assistant is busy"));
+}
+
+#[tokio::test]
+async fn assistant_editing_keys_shape_the_input_buffer() {
+    let (mut app, _rx) = common::app().await;
+    app.active_view = ActiveView::Assistant;
+
+    common::type_str(&mut app, "hello world").await;
+    assert_eq!(app.assistant_state.input, "hello world");
+    app.handle_key_event(common::key(KeyCode::Backspace)).await;
+    assert_eq!(app.assistant_state.input, "hello worl");
+    app.handle_key_event(common::ctrl('w')).await;
+    assert_eq!(app.assistant_state.input, "hello ");
+    // Ctrl+u is bound to scrolling here; Alt+u is what clears the composer.
+    app.handle_key_event(common::ctrl('u')).await;
+    assert_eq!(app.assistant_state.input, "hello ");
+    app.handle_key_event(alt('u')).await;
+    assert_eq!(app.assistant_state.input, "");
+
+    // Ctrl+v appends the clipboard when there is one; either way the buffer
+    // stays a single line.
+    app.handle_key_event(common::ctrl('v')).await;
+    assert!(!app.assistant_state.input.contains('\n'));
+    app.assistant_state.input.clear();
+
+    // 'c' with no assistant answer at all is plain typing.
+    app.assistant_state.messages.clear();
+    app.handle_key_event(common::ch('c')).await;
+    assert_eq!(app.assistant_state.input, "c");
+    app.handle_key_event(common::ch('c')).await;
+    assert_eq!(app.assistant_state.input, "cc");
+
+    // 'c' on an empty input copies the last assistant answer.
+    app.assistant_state.input.clear();
+    app.assistant_state
+        .add_assistant_message("the answer".into());
+    app.handle_key_event(common::ch('c')).await;
+    assert_eq!(toast(&app), "✓ Copied assistant answer to clipboard");
+    assert_eq!(app.assistant_state.input, "");
+
+    // ... but with text in the buffer it is still typing.
+    common::type_str(&mut app, "ab").await;
+    app.handle_key_event(common::ch('c')).await;
+    assert_eq!(app.assistant_state.input, "abc");
+
+    // Ctrl+t toggles the tool chip expansion, Ctrl+l clears the conversation.
+    let expanded = app.assistant_state.expand_tools;
+    app.handle_key_event(common::ctrl('t')).await;
+    assert_ne!(app.assistant_state.expand_tools, expanded);
+    app.handle_key_event(common::ctrl('l')).await;
+    assert_only_greeting(&app);
+    assert_eq!(toast(&app), "✓ Conversation cleared");
+}
+
+#[tokio::test]
+async fn assistant_history_and_slash_suggestions_drive_the_arrow_keys() {
+    let (mut app, _rx) = common::app().await;
+    app.active_view = ActiveView::Assistant;
+    app.assistant_state.prompt_history = vec!["first".into(), "second".into()];
+    app.assistant_state.input = "draft".into();
+
+    app.handle_key_event(common::key(KeyCode::Up)).await;
+    assert_eq!(app.assistant_state.input, "second");
+    app.handle_key_event(common::key(KeyCode::Up)).await;
+    assert_eq!(app.assistant_state.input, "first");
+    app.handle_key_event(common::key(KeyCode::Down)).await;
+    assert_eq!(app.assistant_state.input, "second");
+    app.handle_key_event(common::key(KeyCode::Down)).await;
+    assert_eq!(app.assistant_state.input, "draft");
+
+    app.assistant_state.input.clear();
+    common::type_str(&mut app, "/").await;
+    let n = app.assistant_state.slash_suggestions.len();
+    assert!(n > 1, "slash prefix lists suggestions");
+    app.handle_key_event(common::key(KeyCode::Down)).await;
+    assert_eq!(app.assistant_state.slash_suggestion_idx, 1);
+    app.handle_key_event(common::key(KeyCode::Up)).await;
+    assert_eq!(app.assistant_state.slash_suggestion_idx, 0);
+    app.handle_key_event(common::key(KeyCode::Up)).await;
+    assert_eq!(app.assistant_state.slash_suggestion_idx, n - 1);
+
+    // Tab applies the highlighted suggestion.
+    app.handle_key_event(common::key(KeyCode::Tab)).await;
+    assert!(app.assistant_state.input.starts_with('/'));
+    assert!(app.assistant_state.input.ends_with(' '));
+    assert!(app.assistant_state.slash_suggestions.is_empty());
+
+    // Enter on a bare prefix with suggestions completes instead of submitting.
+    app.assistant_state.input.clear();
+    let before = app.assistant_state.messages.len();
+    common::type_str(&mut app, "/cra").await;
+    assert!(!app.assistant_state.slash_suggestions.is_empty());
+    app.handle_key_event(common::key(KeyCode::Enter)).await;
+    assert_eq!(app.assistant_state.input, "/crashloop ");
+    assert_eq!(
+        app.assistant_state.messages.len(),
+        before,
+        "nothing was submitted"
+    );
+}
+
+#[tokio::test]
+async fn assistant_scroll_keys_move_the_viewport() {
+    let (mut app, _rx) = common::app().await;
+    app.active_view = ActiveView::Assistant;
+    for i in 0..80 {
+        app.assistant_state
+            .add_assistant_message(format!("message number {i}"));
+    }
+    narrow(&mut app);
+    let max = app.assistant_state.last_max_scroll.get();
+    assert!(max > 20, "enough content to scroll: {max}");
+
+    app.handle_key_event(common::key(KeyCode::PageUp)).await;
+    assert!(!app.assistant_state.auto_scroll);
+    assert_eq!(app.assistant_state.scroll_offset, max - 10);
+    app.handle_key_event(common::ctrl('k')).await;
+    assert_eq!(app.assistant_state.scroll_offset, max - 12);
+    app.handle_key_event(common::ctrl('u')).await;
+    assert_eq!(app.assistant_state.scroll_offset, max - 22);
+    app.handle_key_event(common::ctrl('j')).await;
+    assert_eq!(app.assistant_state.scroll_offset, max - 20);
+    app.handle_key_event(common::ctrl('d')).await;
+    assert_eq!(app.assistant_state.scroll_offset, max - 10);
+    app.handle_key_event(common::key(KeyCode::PageDown)).await;
+    assert!(app.assistant_state.auto_scroll);
+    app.handle_key_event(common::key(KeyCode::Home)).await;
+    assert_eq!(app.assistant_state.scroll_offset, 0);
+    app.handle_key_event(common::key(KeyCode::End)).await;
+    assert!(app.assistant_state.auto_scroll);
+}
+
+#[tokio::test]
+async fn submitting_a_query_without_an_api_key_answers_with_setup_guidance() {
+    let (mut app, _rx) = common::app().await;
+    keyless_assistant(&mut app);
+    app.active_view = ActiveView::Assistant;
+
+    // Empty input submits nothing: the seeded greeting is all there is.
+    app.handle_key_event(common::key(KeyCode::Enter)).await;
+    assert_only_greeting(&app);
+
+    compose(&mut app, "why is web-0 crashing?").await;
+    app.handle_key_event(common::key(KeyCode::Enter)).await;
+    assert_eq!(app.assistant_state.input, "");
+    assert_eq!(app.assistant_state.messages[1].role, "user");
+    assert_eq!(
+        app.assistant_state.messages[1].content,
+        "why is web-0 crashing?"
+    );
+    assert!(last_message(&app).contains("No API key configured for Google Gemini"));
+    assert!(last_message(&app).contains("GEMINI_API_KEY"));
+    assert!(!app.assistant_state.is_busy);
+
+    // A busy assistant rejects a second query with a toast.
+    app.assistant_state.is_busy = true;
+    compose(&mut app, "again").await;
+    app.handle_key_event(common::key(KeyCode::Enter)).await;
+    assert!(toast(&app).contains("Assistant is busy"));
+    assert_eq!(app.assistant_state.input, "again");
+}
+
+#[tokio::test]
+async fn a_configured_provider_starts_a_native_agent_turn() {
+    let (mut app, _rx) = common::app().await;
+    let mut settings = AiSettings::default();
+    settings.default_provider = AiProvider::OpenAiCompatible;
+    // A closed loopback port: the spawned turn fails to connect instead of
+    // talking to anything real.
+    settings
+        .base_urls
+        .insert("openai-compatible".into(), "http://127.0.0.1:9/v1".into());
+    app.ai_settings = settings;
+    app.assistant_state.caveman_level = None;
+    app.active_view = ActiveView::Assistant;
+
+    compose(&mut app, "list pods").await;
+    app.handle_key_event(common::key(KeyCode::Enter)).await;
+
+    assert!(app.assistant_state.is_busy, "a turn is in flight");
+    assert_eq!(
+        app.assistant_state.messages.len(),
+        2,
+        "greeting plus the query"
+    );
+    let last = app.assistant_state.messages.last().unwrap();
+    assert_eq!(last.role, "user");
+    assert_eq!(last.content, "list pods");
+    assert_eq!(
+        app.assistant_state.prompt_history,
+        vec!["list pods".to_string()]
+    );
+}
+
+#[tokio::test]
+async fn caveman_phrases_and_slash_commands_switch_the_terse_mode() {
+    isolate_ai_settings();
+    let (mut app, _rx) = common::app().await;
+    keyless_assistant(&mut app);
+    app.active_view = ActiveView::Assistant;
+
+    compose(&mut app, "caveman mode").await;
+    app.handle_key_event(common::key(KeyCode::Enter)).await;
+    assert_eq!(app.assistant_state.caveman_level, Some(CavemanLevel::Full));
+    assert_eq!(toast(&app), "🦖 Caveman mode: full");
+    assert!(last_message(&app).contains("Caveman mode active"));
+
+    compose(&mut app, "stop caveman").await;
+    app.handle_key_event(common::key(KeyCode::Enter)).await;
+    assert_eq!(app.assistant_state.caveman_level, None);
+    assert_eq!(toast(&app), "Caveman mode disabled");
+
+    // "/caveman" with no level reports status when active, activates otherwise.
+    compose(&mut app, "/caveman").await;
+    app.handle_key_event(common::key(KeyCode::Enter)).await;
+    assert_eq!(app.assistant_state.caveman_level, Some(CavemanLevel::Full));
+    assert!(last_message(&app).contains("activated"));
+    compose(&mut app, "/caveman").await;
+    app.handle_key_event(common::key(KeyCode::Enter)).await;
+    assert!(last_message(&app).contains("currently active"));
+
+    compose(&mut app, "/caveman ultra").await;
+    app.handle_key_event(common::key(KeyCode::Enter)).await;
+    assert_eq!(app.assistant_state.caveman_level, Some(CavemanLevel::Ultra));
+    assert_eq!(toast(&app), "🦖 Caveman mode: ultra");
+
+    compose(&mut app, "/caveman off").await;
+    app.handle_key_event(common::key(KeyCode::Enter)).await;
+    assert_eq!(app.assistant_state.caveman_level, None);
+
+    // A level followed by a question sets the level and submits the question.
+    let before = app.assistant_state.messages.len();
+    compose(&mut app, "/caveman lite why is web-0 pending").await;
+    app.handle_key_event(common::key(KeyCode::Enter)).await;
+    assert_eq!(app.assistant_state.caveman_level, Some(CavemanLevel::Lite));
+    let user = &app.assistant_state.messages[before];
+    assert_eq!(user.role, "user");
+    assert_eq!(user.content, "why is web-0 pending");
+    assert!(last_message(&app).contains("No API key"));
+}
+
+#[tokio::test]
+async fn utility_slash_commands_clear_open_settings_and_expand_playbooks() {
+    isolate_ai_settings();
+    let (mut app, _rx) = common::app().await;
+    keyless_assistant(&mut app);
+    app.active_view = ActiveView::Assistant;
+    app.assistant_state.add_assistant_message("old".into());
+
+    compose(&mut app, "/clear").await;
+    app.handle_key_event(common::key(KeyCode::Enter)).await;
+    assert_only_greeting(&app);
+    assert_eq!(toast(&app), "✓ Conversation cleared");
+
+    compose(&mut app, "/crashloop web-0").await;
+    app.handle_key_event(common::key(KeyCode::Enter)).await;
+    assert_eq!(app.assistant_state.messages[1].role, "user");
+    assert_eq!(app.assistant_state.messages[1].content, "/crashloop web-0");
+    assert!(last_message(&app).contains("No API key"));
+
+    compose(&mut app, "/settings").await;
+    app.handle_key_event(common::key(KeyCode::Enter)).await;
+    assert!(matches!(app.active_view, ActiveView::Settings(_)));
+    assert!(matches!(app.nav_stack.last(), Some(ActiveView::Assistant)));
+
+    // Ctrl+s from the assistant also opens settings.
+    app.active_view = ActiveView::Assistant;
+    app.handle_key_event(common::ctrl('s')).await;
+    assert!(matches!(app.active_view, ActiveView::Settings(_)));
+}
+
+#[tokio::test]
+async fn settings_keys_navigate_toggle_edit_and_save() {
+    isolate_ai_settings();
+    let (mut app, _rx) = common::app().await;
+    app.switch_view_to_kind(ResourceKind::Settings).await;
+    // The view opens on whichever provider the stored settings name; start
+    // from a known row so the moves below are checkable.
+    if let ActiveView::Settings(s) = &mut app.active_view {
+        s.selected_provider_idx = 0;
+    }
+
+    app.handle_key_event(common::ch('j')).await;
+    app.handle_key_event(common::key(KeyCode::Down)).await;
+    app.handle_key_event(common::ch('k')).await;
+    let ActiveView::Settings(s) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(s.selected_provider_idx, 1);
+
+    app.handle_key_event(common::ch('l')).await;
+    let ActiveView::Settings(s) = &app.active_view else {
+        panic!()
+    };
+    let field_after_next = s.selected_field;
+    app.handle_key_event(common::ch('h')).await;
+    let ActiveView::Settings(s) = &app.active_view else {
+        panic!()
+    };
+    assert_ne!(s.selected_field, field_after_next);
+    app.handle_key_event(common::key(KeyCode::Tab)).await;
+    app.handle_key_event(common::key(KeyCode::BackTab)).await;
+
+    app.handle_key_event(common::ch(' ')).await;
+    assert!(
+        toast(&app).starts_with("✓ Active provider set to "),
+        "{}",
+        toast(&app)
+    );
+    assert_eq!(app.ai_settings.default_provider, AiProvider::OpenAi);
+
+    app.handle_key_event(common::ch('s')).await;
+    assert!(
+        toast(&app).starts_with("Saved AI settings to "),
+        "{}",
+        toast(&app)
+    );
+
+    // Editing a field: the provider toggle row has nothing to edit, so move
+    // onto the API key first, then type, word-delete, backspace, cancel and
+    // commit.
+    app.handle_key_event(common::ch('e')).await;
+    let ActiveView::Settings(s) = &app.active_view else {
+        panic!()
+    };
+    assert!(!s.is_editing, "the provider toggle row is not editable");
+    app.handle_key_event(common::key(KeyCode::Tab)).await;
+    app.handle_key_event(common::ch('e')).await;
+    let ActiveView::Settings(s) = &app.active_view else {
+        panic!()
+    };
+    assert!(s.is_editing);
+    common::type_str(&mut app, "sk-test key").await;
+    app.handle_key_event(common::ctrl('w')).await;
+    let ActiveView::Settings(s) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(s.edit_buffer, "sk-test ");
+    app.handle_key_event(common::key(KeyCode::Backspace)).await;
+    let ActiveView::Settings(s) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(s.edit_buffer, "sk-test");
+    app.handle_key_event(common::ctrl('v')).await;
+    let ActiveView::Settings(s) = &app.active_view else {
+        panic!()
+    };
+    assert!(!s.edit_buffer.contains('\n'));
+    app.handle_key_event(common::key(KeyCode::Esc)).await;
+    let ActiveView::Settings(s) = &app.active_view else {
+        panic!()
+    };
+    assert!(!s.is_editing);
+
+    app.handle_key_event(common::key(KeyCode::Enter)).await;
+    common::type_str(&mut app, "value").await;
+    app.handle_key_event(common::key(KeyCode::Enter)).await;
+    let ActiveView::Settings(s) = &app.active_view else {
+        panic!()
+    };
+    assert!(!s.is_editing);
+    assert_eq!(toast(&app), "✓ Setting updated and saved");
+
+    // 'q' returns to the previous view; with no history it opens Pods.
+    app.handle_key_event(common::ch('q')).await;
+    assert!(matches!(app.active_view, ActiveView::Table(_)));
+    app.active_view =
+        ActiveView::Settings(srelens_tui::views::settings_view::SettingsViewState::new());
+    app.nav_stack.clear();
+    app.handle_key_event(common::key(KeyCode::Esc)).await;
+    assert!(matches!(&app.active_view, ActiveView::Table(t) if t.kind == ResourceKind::Pods));
+}
+
+#[tokio::test]
+async fn tree_keys_move_copy_and_open_logs_or_actions() {
+    let (mut app, _rx) = common::app().await;
+    app.active_view = ActiveView::Tree(tree_view());
+
+    app.handle_key_event(common::ch('G')).await;
+    let ActiveView::Tree(t) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(t.selected_idx, 2);
+    app.handle_key_event(common::ch('k')).await;
+    app.handle_key_event(common::ch('g')).await;
+    app.handle_key_event(common::ch('j')).await;
+    let ActiveView::Tree(t) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(t.selected_idx, 1);
+    assert_eq!(t.selected_node().unwrap().name, "web-abc");
+
+    app.handle_key_event(common::ch('c')).await;
+    assert_eq!(toast(&app), "✓ Copied 'web-abc' to clipboard");
+    app.handle_key_event(common::shift(KeyCode::Char('C')))
+        .await;
+    assert_eq!(
+        toast(&app),
+        "✓ Copied resource relationship tree to clipboard"
+    );
+
+    app.handle_key_event(common::ch('l')).await;
+    assert_eq!(
+        toast(&app),
+        "Logs only available for Pods (selected ReplicaSet)"
+    );
+
+    app.handle_key_event(common::ch('x')).await;
+    match &app.modal {
+        Some(Modal::ActionPalette {
+            resource_kind,
+            resource_name,
+            namespace,
+            ..
+        }) => {
+            assert_eq!(resource_kind, "ReplicaSet");
+            assert_eq!(resource_name, "web-abc");
+            assert_eq!(namespace.as_deref(), Some("default"));
+        }
+        _ => panic!("expected action palette"),
+    }
+    app.modal = None;
+
+    app.handle_key_event(common::ch('j')).await;
+    app.handle_key_event(common::ch('l')).await;
+    match &app.active_view {
+        ActiveView::Logs(l) => {
+            assert_eq!(l.pod_name, "web-abc-1");
+            assert_eq!(l.namespace, "default");
+        }
+        _ => panic!("pod logs open from the tree"),
+    }
+}
+
+#[tokio::test]
+async fn node_inspector_keys_navigate_pods_and_offer_node_actions() {
+    let (mut app, _rx) = common::app().await;
+    app.nav_stack
+        .push(ActiveView::Table(table_with(ResourceKind::Nodes, vec![])));
+    app.active_view = ActiveView::NodeInspector(inspector_with_details("gpu-1", false));
+
+    app.handle_key_event(common::ch('j')).await;
+    app.handle_key_event(common::ch('k')).await;
+    app.handle_key_event(common::ch('G')).await;
+    let ActiveView::NodeInspector(ni) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(ni.selected_pod_idx, 1);
+    app.handle_key_event(common::ch('g')).await;
+    app.handle_key_event(common::ctrl('d')).await;
+    let ActiveView::NodeInspector(ni) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(ni.selected_pod_idx, 1);
+    app.handle_key_event(common::ctrl('u')).await;
+    let ActiveView::NodeInspector(ni) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(ni.selected_pod_idx, 0);
+
+    app.handle_key_event(common::ch('s')).await;
+    assert_eq!(
+        toast(&app),
+        "Node debug command: kubectl debug node/gpu-1 -it --image=busybox"
+    );
+
+    app.handle_key_event(common::ch('c')).await;
+    assert_eq!(toast(&app), "Cordoning node 'gpu-1'...");
+
+    app.handle_key_event(common::ch('x')).await;
+    match &app.modal {
+        Some(Modal::ActionPalette {
+            resource_kind,
+            resource_name,
+            namespace,
+            ..
+        }) => {
+            assert_eq!(resource_kind, "Pod");
+            assert_eq!(resource_name, "api-0");
+            assert_eq!(namespace.as_deref(), Some("default"));
+        }
+        _ => panic!("expected pod action palette"),
+    }
+    app.modal = None;
+
+    // Refreshing re-opens the inspector for the same node.
+    app.handle_key_event(common::ch('r')).await;
+    match &app.active_view {
+        ActiveView::NodeInspector(ni) => {
+            assert_eq!(ni.node_name, "gpu-1");
+            assert!(ni.is_loading);
+        }
+        _ => panic!("still the inspector"),
+    }
+
+    // Escape pops back to the previous view.
+    app.handle_key_event(common::key(KeyCode::Esc)).await;
+    assert!(matches!(app.active_view, ActiveView::NodeInspector(_)));
+    app.handle_key_event(common::ch('q')).await;
+    assert!(matches!(&app.active_view, ActiveView::Table(t) if t.kind == ResourceKind::Nodes));
+
+    // With no history, leaving opens the Nodes table.
+    app.nav_stack.clear();
+    app.active_view = ActiveView::NodeInspector(NodeInspectorState::new("gpu-1".into()));
+    app.handle_key_event(common::ch('q')).await;
+    assert!(matches!(&app.active_view, ActiveView::Table(t) if t.kind == ResourceKind::Nodes));
+}
+
+#[tokio::test]
+async fn node_inspector_without_pods_targets_the_node_and_toggles_uncordon() {
+    let (mut app, _rx) = common::app().await;
+    let mut details = node_details("gpu-1", true);
+    details.pods.clear();
+    let mut ni = NodeInspectorState::new("gpu-1".into());
+    ni.set_details(details);
+    app.active_view = ActiveView::NodeInspector(ni);
+
+    app.handle_key_event(common::ch('c')).await;
+    assert_eq!(toast(&app), "Uncordoning node 'gpu-1'...");
+
+    app.handle_key_event(common::ch('x')).await;
+    match &app.modal {
+        Some(Modal::ActionPalette {
+            resource_kind,
+            resource_name,
+            namespace,
+            ..
+        }) => {
+            assert_eq!(resource_kind, "Node");
+            assert_eq!(resource_name, "gpu-1");
+            assert!(namespace.is_none());
+        }
+        _ => panic!("expected node action palette"),
+    }
+    app.modal = None;
+
+    // Enter and 'l' need a highlighted pod; without one they are no-ops.
+    app.handle_key_event(common::key(KeyCode::Enter)).await;
+    app.handle_key_event(common::ch('l')).await;
+    assert!(matches!(app.active_view, ActiveView::NodeInspector(_)));
+}
+
+#[tokio::test]
+async fn node_inspector_enter_and_l_jump_to_the_highlighted_pod() {
+    let (mut app, _rx) = common::app().await;
+    app.active_view = ActiveView::NodeInspector(inspector_with_details("gpu-1", false));
+    app.handle_key_event(common::ch('j')).await;
+
+    app.handle_key_event(common::ch('l')).await;
+    match &app.active_view {
+        ActiveView::Logs(l) => {
+            assert_eq!(l.pod_name, "exporter");
+            assert_eq!(l.namespace, "monitoring");
+        }
+        _ => panic!("logs open for the highlighted pod"),
+    }
+    app.handle_key_event(common::key(KeyCode::Esc)).await;
+    assert!(matches!(app.active_view, ActiveView::NodeInspector(_)));
+
+    app.handle_key_event(common::key(KeyCode::Enter)).await;
+    assert_eq!(app.active_namespace, "monitoring");
+    assert_eq!(app.filter_buffer, "exporter");
+    assert!(matches!(&app.active_view, ActiveView::Table(t) if t.kind == ResourceKind::Pods));
+    assert_eq!(toast(&app), "Jumped to Pod 'exporter'");
+}
+
+// ---------------------------------------------------------------------------
+// Filters, paste and colon commands
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn filters_apply_and_clear_in_every_text_view() {
+    let (mut app, _rx) = common::app().await;
+
+    app.active_view = ActiveView::Describe(DescribeViewState::new(
+        "w".into(),
+        "Pod".into(),
+        None,
+        "alpha\nbeta\nalpha again\n".into(),
+    ));
+    app.filter_buffer = "alpha".into();
+    app.apply_current_filter();
+    let ActiveView::Describe(d) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(d.search_matches.len(), 2);
+    app.clear_current_filter();
+    let ActiveView::Describe(d) = &app.active_view else {
+        panic!()
+    };
+    assert!(d.search_matches.is_empty());
+    assert!(app.filter_buffer.is_empty());
+
+    app.active_view = ActiveView::Yaml(YamlViewState::new(
+        "w".into(),
+        "Pod".into(),
+        None,
+        "a: 1\nb: 2\na: 3\n".into(),
+    ));
+    app.filter_buffer = "a:".into();
+    app.apply_current_filter();
+    let ActiveView::Yaml(y) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(y.search_matches.len(), 2);
+    app.clear_current_filter();
+    let ActiveView::Yaml(y) = &app.active_view else {
+        panic!()
+    };
+    assert!(y.search_query.is_empty());
+
+    let mut logs = LogsViewState::new("w".into(), "default".into(), None, "ch".into());
+    logs.push_line("ERROR one".into());
+    logs.push_line("info".into());
+    app.active_view = ActiveView::Logs(logs);
+    app.filter_buffer = "ERROR".into();
+    app.apply_current_filter();
+    let ActiveView::Logs(l) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(l.search_matches.len(), 1);
+    app.clear_current_filter();
+    let ActiveView::Logs(l) = &app.active_view else {
+        panic!()
+    };
+    assert!(l.search_matches.is_empty());
+
+    // Views without a filter are untouched.
+    app.active_view = ActiveView::Assistant;
+    app.filter_buffer = "x".into();
+    app.apply_current_filter();
+    app.clear_current_filter();
+    assert!(app.filter_buffer.is_empty());
+}
+
+#[tokio::test]
+async fn pasted_text_lands_in_the_active_input() {
+    let (mut app, _rx) = common::app().await;
+
+    app.input_mode = InputMode::Command;
+    app.handle_paste("po\r\nds".into());
+    assert_eq!(app.command_buffer, "po ds");
+
+    app.input_mode = InputMode::Filter;
+    app.active_view = ActiveView::Yaml(YamlViewState::new(
+        "w".into(),
+        "Pod".into(),
+        None,
+        "web\nx\n".into(),
+    ));
+    app.handle_paste("we\nb".into());
+    assert_eq!(app.filter_buffer, "web");
+    let ActiveView::Yaml(y) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(y.search_matches.len(), 1);
+
+    app.input_mode = InputMode::Normal;
+    app.active_view = ActiveView::Assistant;
+    app.handle_paste("multi\nline".into());
+    assert_eq!(app.assistant_state.input, "multi line");
+
+    let mut settings = srelens_tui::views::settings_view::SettingsViewState::new();
+    settings.is_editing = true;
+    app.active_view = ActiveView::Settings(settings);
+    app.handle_paste("sk-\nabc".into());
+    let ActiveView::Settings(s) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(s.edit_buffer, "sk-abc");
+
+    app.active_view = ActiveView::Table(ResourceTableState::new(ResourceKind::Pods));
+    app.modal = Some(Modal::Scale {
+        workload_name: "web".into(),
+        current_replicas: 1,
+        input: String::new(),
+    });
+    app.handle_paste("1\n2".into());
+    assert!(matches!(&app.modal, Some(Modal::Scale { input, .. }) if input == "12"));
+
+    app.modal = Some(Modal::PortForward {
+        pod_name: "web".into(),
+        namespace: "default".into(),
+        container_port: 80,
+        local_port_input: String::new(),
+    });
+    app.handle_paste("90\r\n90".into());
+    assert!(
+        matches!(&app.modal, Some(Modal::PortForward { local_port_input, .. }) if local_port_input == "9090")
+    );
+
+    // Other modals ignore pastes.
+    app.modal = Some(Modal::Confirm {
+        title: "t".into(),
+        message: "m".into(),
+        action_name: "a".into(),
+        is_destructive: false,
+    });
+    app.handle_paste("ignored".into());
+    assert!(matches!(&app.modal, Some(Modal::Confirm { message, .. }) if message == "m"));
+}
+
+#[tokio::test]
+async fn colon_commands_open_tree_actions_and_metrics_for_the_selected_row() {
+    let (mut app, _rx) = common::app().await;
+
+    app.active_view = ActiveView::Table(table_with(
+        ResourceKind::Nodes,
+        vec![json!({ "name": "gpu-1", "status": "Ready" })],
+    ));
+    app.node_metrics_history.insert(
+        "gpu-1".into(),
+        VecDeque::from(vec![sample(1, 100, 512), sample(2, 200, 600)]),
+    );
+    app.execute_colon_command("metrics").await;
+    match &app.modal {
+        Some(Modal::MetricsTimeline(panel)) => {
+            assert_eq!(panel.target_name, "gpu-1");
+            assert_eq!(panel.target_kind, "Nodes");
+            assert!(panel.namespace.is_none());
+            assert_eq!(panel.samples.len(), 2);
+        }
+        _ => panic!("expected metrics timeline"),
+    }
+    app.modal = None;
+
+    app.execute_colon_command("tree").await;
+    match &app.active_view {
+        ActiveView::Tree(t) => {
+            assert_eq!(t.root_kind, "Nodes");
+            assert_eq!(t.root_name, "gpu-1");
+            assert!(t.is_loading);
+        }
+        _ => panic!("expected tree view"),
+    }
+    app.active_view = app.nav_stack.pop().unwrap();
+
+    app.execute_colon_command("actions").await;
+    assert!(
+        matches!(&app.modal, Some(Modal::ActionPalette { resource_name, .. }) if resource_name == "gpu-1")
+    );
+    app.modal = None;
+
+    app.active_view = ActiveView::Table(table_with(ResourceKind::Pods, vec![pod("web-0", "prod")]));
+    app.pod_metrics_history
+        .insert("web-0".into(), VecDeque::from(vec![sample(1, 5, 64)]));
+    app.execute_colon_command("metric").await;
+    match &app.modal {
+        Some(Modal::MetricsTimeline(panel)) => {
+            assert_eq!(panel.namespace.as_deref(), Some("prod"));
+            assert_eq!(panel.samples.len(), 1);
+        }
+        _ => panic!("expected metrics timeline"),
+    }
+    app.modal = None;
+
+    // Metrics only exist for pods and nodes; other tables get a hint.
+    app.active_view = ActiveView::Table(table_with(
+        ResourceKind::Services,
+        vec![json!({ "name": "svc" })],
+    ));
+    app.execute_colon_command("metrics").await;
+    assert_eq!(
+        toast(&app),
+        "Select a Pod or Node to view its live metrics timeline"
+    );
+
+    // Without a selected row the tree and actions commands explain themselves.
+    app.active_view = ActiveView::Table(table_with(ResourceKind::Pods, vec![]));
+    app.execute_colon_command("lineage").await;
+    assert_eq!(
+        toast(&app),
+        "Select a resource in table to view its relationship tree"
+    );
+    app.execute_colon_command("act").await;
+    assert_eq!(
+        toast(&app),
+        "Select a resource in table to open its actions palette"
+    );
+}
+
+#[tokio::test]
+async fn colon_commands_open_the_reason_rail_clear_ai_and_fall_back_to_fuzzy_matches() {
+    let (mut app, _rx) = common::app().await;
+
+    app.active_view = ActiveView::Table(table_with(
+        ResourceKind::Events,
+        vec![json!({ "name": "e1", "reason": "BackOff", "type": "Warning" })],
+    ));
+    app.execute_colon_command("reasons").await;
+    match &app.modal {
+        Some(Modal::ReasonRail { tallies, .. }) => assert_eq!(tallies[0].reason, "BackOff"),
+        _ => panic!("expected reason rail"),
+    }
+    app.modal = None;
+
+    app.active_view = ActiveView::Table(table_with(ResourceKind::Pods, vec![]));
+    app.execute_colon_command("reason").await;
+    assert!(toast(&app).starts_with(":reasons is only available"));
+
+    app.assistant_state.add_assistant_message("x".into());
+    app.execute_colon_command("clear-ai").await;
+    assert_only_greeting(&app);
+    assert_eq!(toast(&app), "✓ Conversation cleared");
+
+    // "clear" only means the conversation while the assistant is showing.
+    app.active_view = ActiveView::Assistant;
+    app.assistant_state.add_assistant_message("y".into());
+    assert_eq!(app.assistant_state.messages.len(), 2);
+    app.execute_colon_command("clear").await;
+    assert_only_greeting(&app);
+
+    // An alias prefix scores high enough to run without an exact match.
+    app.execute_colon_command("sv").await;
+    assert!(matches!(&app.active_view, ActiveView::Table(t) if t.kind == ResourceKind::Services));
+
+    app.execute_colon_command("zzzz-nothing").await;
+    assert_eq!(
+        toast(&app),
+        "Unknown command: 'zzzz-nothing' (type :help or ?)"
+    );
+}
+
+#[tokio::test]
+async fn view_targets_open_pickers_help_quit_and_deep_links() {
+    let (mut app, _rx) = common::app().await;
+    app.namespaces = vec!["default".into(), "kube-system".into()];
+    app.active_namespace = "kube-system".into();
+
+    app.execute_view_target(CommandTarget::Namespaces).await;
+    match &app.modal {
+        Some(Modal::NamespacePicker {
+            selected_idx,
+            current_namespace,
+            ..
+        }) => {
+            assert_eq!(*selected_idx, 1);
+            assert_eq!(current_namespace, "kube-system");
+        }
+        _ => panic!("expected namespace picker"),
+    }
+    app.modal = None;
+
+    app.execute_view_target(CommandTarget::Contexts).await;
+    assert!(matches!(app.modal, Some(Modal::ContextPicker { .. })));
+    app.modal = None;
+
+    app.execute_view_target(CommandTarget::Help).await;
+    assert!(app.show_help);
+    app.execute_view_target(CommandTarget::OpenUrl("x".into()))
+        .await;
+    app.execute_view_target(CommandTarget::Quit).await;
+    assert!(!app.is_running);
+    app.is_running = true;
+
+    app.execute_command_target(CommandTarget::OpenUrl(String::new()))
+        .await;
+    assert_eq!(toast(&app), "Usage: :open <srelens://... or kind/name>");
+    app.execute_command_target(CommandTarget::OpenUrl("srelens://nope/x".into()))
+        .await;
+    assert!(toast(&app).starts_with("Invalid URL: "), "{}", toast(&app));
+    app.execute_command_target(CommandTarget::OpenUrl(
+        "srelens://resource/test-cluster/default/widget/w1".into(),
+    ))
+    .await;
+    assert_eq!(
+        toast(&app),
+        "Navigation error: Unknown resource kind 'widget'"
+    );
+
+    app.execute_command_target(CommandTarget::OpenUrl(
+        "srelens://view/_/kube-system/nodes".into(),
+    ))
+    .await;
+    assert!(matches!(&app.active_view, ActiveView::Table(t) if t.kind == ResourceKind::Nodes));
+}
+
+#[tokio::test]
+async fn deep_links_switch_namespace_select_rows_or_filter_for_missing_rows() {
+    let (mut app, _rx) = common::app().await;
+    app.resource_cache.insert(
+        ("test-cluster".into(), "prod".into(), "pods".into()),
+        vec![pod("web-0", "prod"), pod("web-1", "prod")],
+    );
+
+    let link = DeepLink::Resource {
+        context: "test-cluster".into(),
+        namespace: Some("prod".into()),
+        kind: "pods".into(),
+        name: "web-1".into(),
+    };
+    app.navigate_deep_link(&link).await.unwrap();
+    assert_eq!(app.active_namespace, "prod");
+    let ActiveView::Table(t) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(t.kind, ResourceKind::Pods);
+    assert_eq!(t.selected_idx, 1);
+    assert_eq!(toast(&app), "Navigated to pods 'web-1'");
+
+    let missing = DeepLink::Resource {
+        context: String::new(),
+        namespace: Some("prod".into()),
+        kind: "pod".into(),
+        name: "ghost".into(),
+    };
+    app.navigate_deep_link(&missing).await.unwrap();
+    let ActiveView::Table(t) = &app.active_view else {
+        panic!()
+    };
+    assert!(
+        t.filtered_indices.is_empty(),
+        "filtered to the missing name"
+    );
+
+    let view = DeepLink::View {
+        context: Some("test-cluster".into()),
+        namespace: Some("default".into()),
+        target: CommandTarget::Resource(ResourceKind::Deployments),
+    };
+    app.navigate_deep_link(&view).await.unwrap();
+    assert_eq!(app.active_namespace, "default");
+    assert!(
+        matches!(&app.active_view, ActiveView::Table(t) if t.kind == ResourceKind::Deployments)
+    );
+
+    let cluster = DeepLink::Cluster {
+        context: "test-cluster".into(),
+    };
+    app.navigate_deep_link(&cluster).await.unwrap();
+    assert_eq!(toast(&app), "Switched to cluster 'test-cluster'");
+
+    let unknown = DeepLink::Resource {
+        context: String::new(),
+        namespace: None,
+        kind: "widget".into(),
+        name: "w".into(),
+    };
+    assert_eq!(
+        app.navigate_deep_link(&unknown).await,
+        Err("Unknown resource kind 'widget'".to_string())
+    );
+}
+
+#[tokio::test]
+async fn switching_to_a_crd_uses_cached_instances_and_discovered_columns() {
+    let (mut app, _rx) = common::app().await;
+    let mut discovered = CrdMeta {
+        crd_name: "widgets.example.io".into(),
+        group: "example.io".into(),
+        version: "v1".into(),
+        kind: "Widget".into(),
+        plural: "widgets".into(),
+        singular: "widget".into(),
+        namespaced: true,
+        short_names: vec!["wd".into()],
+        printer_columns: vec![PrinterColumn {
+            name: "Size".into(),
+            json_path: ".spec.size".into(),
+            col_type: "integer".into(),
+            priority: 0,
+            description: None,
+        }],
+    };
+    app.crds.push(discovered.clone());
+    app.resource_cache.insert(
+        ("test-cluster".into(), "default".into(), "Widget".into()),
+        vec![json!({ "name": "w1", "spec": { "size": 3 } })],
+    );
+
+    discovered.printer_columns.clear();
+    app.switch_view_to_crd(discovered.clone()).await;
+    match &app.active_view {
+        ActiveView::Table(t) => {
+            assert!(!t.is_loading);
+            assert_eq!(t.raw_items.len(), 1);
+            match &t.kind {
+                ResourceKind::CustomResource(crd) => assert_eq!(crd.printer_columns.len(), 1),
+                other => panic!("expected custom resource kind, got {other:?}"),
+            }
+        }
+        _ => panic!("expected table"),
+    }
+
+    // Without a cache entry the table starts loading.
+    app.resource_cache.clear();
+    app.switch_view_to_crd(discovered).await;
+    let ActiveView::Table(t) = &app.active_view else {
+        panic!()
+    };
+    assert!(t.is_loading);
+    assert!(t.raw_items.is_empty());
+
+    // The colon command resolves the short name to the same view.
+    app.execute_colon_command("wd").await;
+    assert!(
+        matches!(&app.active_view, ActiveView::Table(t) if matches!(&t.kind, ResourceKind::CustomResource(c) if c.kind == "Widget"))
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Containers, logs, shells
+// ---------------------------------------------------------------------------
+
+fn cached_pod_spec(name: &str) -> Value {
+    json!({
+        "name": name,
+        "namespace": "default",
+        "spec": {
+            "containers": [{ "name": "app" }, { "name": "sidecar" }],
+            "initContainers": [{ "name": "init-db" }],
+            "ephemeralContainers": [{ "name": "debugger" }]
+        }
+    })
+}
+
+#[tokio::test]
+async fn a_multi_container_pod_prompts_for_the_container_before_logs_or_shell() {
+    let (mut app, _rx) = common::app().await;
+    app.resource_cache.insert(
+        ("test-cluster".into(), "default".into(), "Pods".into()),
+        vec![cached_pod_spec("web-0")],
+    );
+
+    let containers = app.get_pod_containers("web-0", None).await;
+    assert_eq!(containers, vec!["app", "sidecar", "init-db", "debugger"]);
+
+    app.prompt_pod_logs("web-0".into(), None).await;
+    match &app.modal {
+        Some(Modal::ContainerPicker {
+            containers,
+            action,
+            pod_name,
+            ..
+        }) => {
+            assert_eq!(containers.len(), 4);
+            assert_eq!(*action, ContainerAction::Logs);
+            assert_eq!(pod_name, "web-0");
+        }
+        _ => panic!("expected container picker"),
+    }
+    app.modal = None;
+
+    app.prompt_pod_shell("web-0".into(), Some("default".into()))
+        .await;
+    assert!(matches!(
+        &app.modal,
+        Some(Modal::ContainerPicker {
+            action: ContainerAction::Shell,
+            ..
+        })
+    ));
+    assert!(app.requires_terminal_suspend.is_none());
+}
+
+#[tokio::test]
+async fn a_single_or_unknown_container_pod_goes_straight_to_logs_or_shell() {
+    let (mut app, _rx) = common::app().await;
+    app.resource_cache.insert(
+        ("test-cluster".into(), "default".into(), "Pods".into()),
+        vec![json!({ "metadata": { "name": "solo" }, "spec": { "containers": [{ "name": "only" }] } })],
+    );
+
+    app.prompt_pod_shell("solo".into(), None).await;
+    match &app.requires_terminal_suspend {
+        Some(SuspendAction::PodShell { pod, container }) => {
+            assert_eq!(pod, "solo");
+            assert_eq!(container.as_deref(), Some("only"));
+        }
+        _ => panic!("expected pod shell suspend"),
+    }
+    app.requires_terminal_suspend = None;
+
+    // A pod the cache does not know falls back to the (failing) API and opens
+    // with no container.
+    app.prompt_pod_shell("ghost".into(), None).await;
+    assert!(matches!(
+        &app.requires_terminal_suspend,
+        Some(SuspendAction::PodShell {
+            container: None,
+            ..
+        })
+    ));
+
+    app.prompt_pod_logs("solo".into(), None).await;
+    match &app.active_view {
+        ActiveView::Logs(l) => {
+            assert_eq!(l.pod_name, "solo");
+            assert_eq!(l.container.as_deref(), Some("only"));
+            assert_eq!(
+                l.lines[0],
+                "Streaming logs for pod default/solo (container: only)..."
+            );
+        }
+        _ => panic!("expected logs view"),
+    }
+    assert!(app
+        .active_log_channel
+        .as_deref()
+        .unwrap()
+        .starts_with("logs:solo:"));
+
+    // Opening another stream replaces the active log channel.
+    let previous = app.active_log_channel.clone();
+    app.open_logs_view("other".into(), Some("kube-system".into()), None)
+        .await;
+    assert_ne!(app.active_log_channel, previous);
+    let ActiveView::Logs(l) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(l.namespace, "kube-system");
+    assert_eq!(
+        l.lines[0],
+        "Streaming logs for pod kube-system/other (container: default)..."
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Lineage and node inspector round trips
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn opening_a_resource_tree_without_a_cluster_reports_the_error_through_the_event_loop() {
+    let (mut app, mut rx) = common::app().await;
+    app.open_resource_tree("Deployment".into(), "web".into(), Some("default".into()));
+    assert!(matches!(&app.active_view, ActiveView::Tree(t) if t.is_loading));
+
+    let ev = wait_for(&mut rx, |e| matches!(e, AppEvent::LineageResult { .. })).await;
+    let AppEvent::LineageResult { kind, name, result } = ev else {
+        unreachable!()
+    };
+    assert_eq!((kind.as_str(), name.as_str()), ("Deployment", "web"));
+    let err = result.expect_err("no cluster behind the test");
+    assert!(err.starts_with("Failed to connect to cluster: "), "{err}");
+
+    // A result for a different resource is ignored.
+    app.handle_lineage_result("Pod", "other", Err("nope".into()));
+    assert!(matches!(&app.active_view, ActiveView::Tree(t) if t.is_loading && t.error.is_none()));
+
+    app.handle_lineage_result("deployment", "web", Err(err.clone()));
+    let ActiveView::Tree(t) = &app.active_view else {
+        panic!()
+    };
+    assert!(!t.is_loading);
+    assert_eq!(t.error.as_deref(), Some(err.as_str()));
+
+    app.handle_lineage_result("Deployment", "web", Ok(lineage_tree()));
+    let ActiveView::Tree(t) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(t.nodes.len(), 3);
+    assert!(t.error.is_none());
+}
+
+#[tokio::test]
+async fn opening_the_node_inspector_seeds_history_and_reports_the_connection_error() {
+    let (mut app, mut rx) = common::app().await;
+    app.node_metrics_history.insert(
+        "gpu-1".into(),
+        VecDeque::from(vec![sample(1, 100, 512), sample(2, 300, 700)]),
+    );
+    app.open_node_inspector("gpu-1".into());
+    match &app.active_view {
+        ActiveView::NodeInspector(ni) => {
+            assert_eq!(ni.cpu_history, vec![100, 300]);
+            assert_eq!(ni.mem_history, vec![512, 700]);
+            assert!(ni.is_loading);
+        }
+        _ => panic!("expected inspector"),
+    }
+
+    let ev = wait_for(&mut rx, |e| {
+        matches!(e, AppEvent::NodeInspectorResult { .. })
+    })
+    .await;
+    let AppEvent::NodeInspectorResult { node_name, result } = ev else {
+        unreachable!()
+    };
+    assert_eq!(node_name, "gpu-1");
+    let err = result.expect_err("no cluster behind the test");
+
+    app.handle_node_inspector_result("other-node", Err("ignored".into()));
+    assert!(matches!(&app.active_view, ActiveView::NodeInspector(ni) if ni.error.is_none()));
+    app.handle_node_inspector_result("gpu-1", Err(err.clone()));
+    let ActiveView::NodeInspector(ni) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(ni.error.as_deref(), Some(err.as_str()));
+    assert!(!ni.is_loading);
+
+    app.handle_node_inspector_result("gpu-1", Ok(node_details("gpu-1", false)));
+    let ActiveView::NodeInspector(ni) = &app.active_view else {
+        panic!()
+    };
+    assert!(ni.error.is_none());
+    assert_eq!(ni.details.as_ref().unwrap().pods.len(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// Action palette execution and confirmations
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn ai_palette_actions_prefill_the_assistant_prompt() {
+    let (mut app, _rx) = common::app().await;
+    let cases = [
+        (
+            QuickActionId::AskAi,
+            "Investigate Pod 'web-0' in namespace 'default'",
+        ),
+        (QuickActionId::PlaybookCrashLoop, "/crashloop web-0"),
+        (QuickActionId::PlaybookPending, "/pending web-0"),
+        (QuickActionId::PlaybookOom, "/oom web-0"),
+        (QuickActionId::PlaybookRollout, "/rollout web-0"),
+        (QuickActionId::PlaybookEndpoints, "/endpoints web-0"),
+        (QuickActionId::PlaybookNodePressure, "/nodepressure web-0"),
+    ];
+    for (id, expected) in cases {
+        app.active_view = ActiveView::Table(ResourceTableState::new(ResourceKind::Pods));
+        app.modal = Some(palette("Pod", "web-0", Some("default"), id));
+        app.execute_action_palette().await;
+        assert!(app.modal.is_none());
+        assert!(matches!(app.active_view, ActiveView::Assistant), "{id:?}");
+        assert!(matches!(app.nav_stack.last(), Some(ActiveView::Table(_))));
+        assert!(
+            app.assistant_state.input.starts_with(expected),
+            "{id:?}: {}",
+            app.assistant_state.input
+        );
+    }
+}
+
+#[tokio::test]
+async fn navigation_palette_actions_open_the_matching_view_or_modal() {
+    let (mut app, _rx) = common::app().await;
+
+    app.modal = Some(palette(
+        "Deployment",
+        "web",
+        Some("default"),
+        QuickActionId::RelationshipTree,
+    ));
+    app.execute_action_palette().await;
+    assert!(matches!(&app.active_view, ActiveView::Tree(t) if t.root_name == "web"));
+
+    app.modal = Some(palette(
+        "Pod",
+        "web-0",
+        Some("default"),
+        QuickActionId::ViewLogs,
+    ));
+    app.execute_action_palette().await;
+    assert!(matches!(&app.active_view, ActiveView::Logs(l) if l.pod_name == "web-0"));
+
+    app.modal = Some(palette("Pod", "web-0", None, QuickActionId::OpenShell));
+    app.execute_action_palette().await;
+    assert!(
+        matches!(&app.requires_terminal_suspend, Some(SuspendAction::PodShell { pod, .. }) if pod == "web-0")
+    );
+
+    app.modal = Some(palette("Pod", "web-0", None, QuickActionId::PortForward));
+    app.execute_action_palette().await;
+    match &app.modal {
+        Some(Modal::PortForward {
+            pod_name,
+            namespace,
+            container_port,
+            local_port_input,
+        }) => {
+            assert_eq!(pod_name, "web-0");
+            assert_eq!(namespace, "default");
+            assert_eq!(*container_port, 8080);
+            assert_eq!(local_port_input, "8080");
+        }
+        _ => panic!("expected port forward modal"),
+    }
+
+    app.modal = Some(palette(
+        "Deployment",
+        "web",
+        Some("prod"),
+        QuickActionId::RolloutRestart,
+    ));
+    app.execute_action_palette().await;
+    match &app.modal {
+        Some(Modal::Confirm {
+            action_name,
+            is_destructive,
+            ..
+        }) => {
+            assert_eq!(action_name, "restart:Deployment:prod:web");
+            assert!(!is_destructive);
+        }
+        _ => panic!("expected confirm modal"),
+    }
+
+    app.modal = Some(palette("Deployment", "web", None, QuickActionId::Scale));
+    app.execute_action_palette().await;
+    assert!(
+        matches!(&app.modal, Some(Modal::Scale { workload_name, input, .. }) if workload_name == "web" && input == "1")
+    );
+
+    app.modal = Some(palette(
+        "Deployment",
+        "web",
+        None,
+        QuickActionId::JumpToPods,
+    ));
+    app.execute_action_palette().await;
+    assert_eq!(app.filter_buffer, "web");
+    assert!(matches!(&app.active_view, ActiveView::Table(t) if t.kind == ResourceKind::Pods));
+
+    app.modal = Some(palette("Node", "gpu-1", None, QuickActionId::InspectNode));
+    app.execute_action_palette().await;
+    assert!(matches!(&app.active_view, ActiveView::NodeInspector(ni) if ni.node_name == "gpu-1"));
+
+    app.modal = Some(palette("Node", "gpu-1", None, QuickActionId::CordonNode));
+    app.execute_action_palette().await;
+    assert_eq!(toast(&app), "Cordoned node gpu-1");
+    app.modal = Some(palette("Node", "gpu-1", None, QuickActionId::DrainNode));
+    app.execute_action_palette().await;
+    assert_eq!(toast(&app), "Draining node gpu-1");
+
+    app.modal = Some(palette("Service", "api", None, QuickActionId::Delete));
+    app.execute_action_palette().await;
+    match &app.modal {
+        Some(Modal::Confirm {
+            title,
+            action_name,
+            is_destructive,
+            ..
+        }) => {
+            assert_eq!(title, "Delete Service");
+            assert_eq!(action_name, "delete:Service:default:api");
+            assert!(is_destructive);
+        }
+        _ => panic!("expected destructive confirm"),
+    }
+}
+
+#[tokio::test]
+async fn the_palette_filter_narrows_what_enter_runs() {
+    let (mut app, _rx) = common::app().await;
+    app.active_view = ActiveView::Table(ResourceTableState::new(ResourceKind::Nodes));
+    let make = |filter: &str, selected_idx: usize| Modal::ActionPalette {
+        resource_kind: "Node".into(),
+        resource_name: "gpu-1".into(),
+        namespace: None,
+        actions: vec![
+            action(QuickActionId::CordonNode, "Cordon node"),
+            action(QuickActionId::DrainNode, "Drain node"),
+        ],
+        selected_idx,
+        filter: filter.into(),
+    };
+
+    app.modal = Some(make("drain", 0));
+    app.execute_action_palette().await;
+    assert_eq!(toast(&app), "Draining node gpu-1");
+
+    app.toast = None;
+    app.modal = Some(make("nothing-matches", 0));
+    app.execute_action_palette().await;
+    assert!(app.toast.is_none());
+    assert!(app.modal.is_none());
+
+    app.modal = Some(make("", 5));
+    app.execute_action_palette().await;
+    assert!(app.toast.is_none());
+
+    // A non-palette modal is left alone.
+    app.show_help = true;
+    app.modal = None;
+    app.execute_action_palette().await;
+    assert!(app.show_help);
+}
+
+#[tokio::test]
+async fn confirmed_actions_without_a_cluster_report_a_connection_error() {
+    let (mut app, _rx) = common::app().await;
+    app.active_view = ActiveView::Table(table_with(
+        ResourceKind::Pods,
+        vec![pod("web-0", "default")],
+    ));
+
+    let confirm = |name: &str| Modal::Confirm {
+        title: "t".into(),
+        message: "m".into(),
+        action_name: name.into(),
+        is_destructive: true,
+    };
+
+    app.modal = Some(confirm("delete:Pod:default:web-0"));
+    app.handle_key_event(common::key(KeyCode::Enter)).await;
+    assert!(app.modal.is_none());
+    assert!(
+        toast(&app).starts_with("Connection error: "),
+        "{}",
+        toast(&app)
+    );
+    let ActiveView::Table(t) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(t.raw_items.len(), 1, "nothing was removed locally");
+
+    app.modal = Some(confirm("delete:legacy"));
+    app.handle_key_event(common::ch('Y')).await;
+    assert_eq!(toast(&app), "Resource deleted successfully");
+
+    app.modal = Some(confirm("restart:Deployment:default:web"));
+    app.handle_key_event(common::ch('y')).await;
+    assert!(
+        toast(&app).starts_with("Connection error: "),
+        "{}",
+        toast(&app)
+    );
+
+    app.modal = Some(confirm("restart:legacy"));
+    app.handle_key_event(common::key(KeyCode::Enter)).await;
+    assert_eq!(toast(&app), "Rollout restart triggered");
+
+    app.modal = Some(confirm("stop-pf:abc"));
+    app.handle_key_event(common::key(KeyCode::Enter)).await;
+    assert_eq!(toast(&app), "Port forward stopped");
+
+    // Unknown actions and cancellations do nothing.
+    app.toast = None;
+    app.modal = Some(confirm("noop:x"));
+    app.handle_key_event(common::key(KeyCode::Enter)).await;
+    assert!(app.toast.is_none());
+    app.modal = Some(confirm("delete:Pod:default:web-0"));
+    app.handle_key_event(common::ch('n')).await;
+    assert!(app.modal.is_none());
+    assert!(app.toast.is_none());
+}
+
+#[tokio::test]
+async fn scale_and_port_forward_modals_run_on_enter() {
+    let (mut app, _rx) = common::app().await;
+    app.active_view = ActiveView::Table(table_with(
+        ResourceKind::Deployments,
+        vec![json!({ "name": "web", "namespace": "prod" })],
+    ));
+
+    app.modal = Some(Modal::Scale {
+        workload_name: "web".into(),
+        current_replicas: 1,
+        input: String::new(),
+    });
+    app.handle_key_event(common::ch('3')).await;
+    app.handle_key_event(common::ch('x')).await;
+    app.handle_key_event(common::key(KeyCode::Enter)).await;
+    assert!(app.modal.is_none());
+    assert!(
+        toast(&app).starts_with("Connection error: "),
+        "{}",
+        toast(&app)
+    );
+
+    // Outside a table the scale command still resolves to a deployment.
+    app.active_view = ActiveView::Assistant;
+    app.toast = None;
+    app.execute_scale_workload("web".into(), 2).await;
+    assert!(
+        toast(&app).starts_with("Connection error: "),
+        "{}",
+        toast(&app)
+    );
+
+    app.modal = Some(Modal::PortForward {
+        pod_name: "web-0".into(),
+        namespace: "default".into(),
+        container_port: 8080,
+        local_port_input: "90".into(),
+    });
+    app.handle_key_event(common::ch('9')).await;
+    app.handle_key_event(common::ch('0')).await;
+    app.handle_key_event(common::key(KeyCode::Backspace)).await;
+    app.handle_key_event(common::key(KeyCode::Enter)).await;
+    assert!(app.modal.is_none());
+    assert_eq!(
+        toast(&app),
+        "Port forward started on 127.0.0.1:909 -> web-0:8080"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Overview data plumbing
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn the_overview_starts_from_cached_data_and_live_updates_replace_it() {
+    let (mut app, _rx) = common::app().await;
+    app.cluster_overview_data = Some(overview_data());
+    app.cluster_version = "v1.31.0".into();
+    app.is_connected = true;
+    app.node_count = 9;
+    app.pod_count = 99;
+
+    app.switch_view_to_kind(ResourceKind::Overview).await;
+    let ActiveView::Overview(ov) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(
+        ov.data.node_count, 3,
+        "cached counts win over header counts"
+    );
+    assert_eq!(ov.data.total_pods, 40);
+    assert_eq!(ov.data.k8s_version, "v1.31.0");
+    assert!(ov.data.is_reachable);
+
+    let mut live = overview_data();
+    live.ready_nodes = 2;
+    live.failed_pods = 5;
+    app.handle_cluster_overview_update(&serde_json::to_string(&live).unwrap());
+    let ActiveView::Overview(ov) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(ov.data.ready_nodes, 2);
+    assert_eq!(ov.data.failed_pods, 5);
+    assert_eq!(app.cluster_overview_data.as_ref().unwrap().failed_pods, 5);
+
+    let screen = wide(&mut app);
+    assert!(screen.contains("2/3"), "ready ratio is drawn:\n{screen}");
+}
+
+#[tokio::test]
+async fn the_overview_falls_back_to_header_counts_without_cached_data() {
+    let (mut app, _rx) = common::app().await;
+    app.cluster_overview_data = None;
+    app.node_count = 4;
+    app.pod_count = 12;
+    app.switch_view_to_kind(ResourceKind::Overview).await;
+    let ActiveView::Overview(ov) = &app.active_view else {
+        panic!()
+    };
+    assert_eq!(ov.data.node_count, 4);
+    assert_eq!(ov.data.total_pods, 12);
+    assert_eq!(ov.data.context_name, "test-cluster");
+    assert!(!ov.data.is_reachable);
+}

--- a/apps/tui/tests/chrome_tests.rs
+++ b/apps/tui/tests/chrome_tests.rs
@@ -1,0 +1,2016 @@
+//! Rendering tests for the TUI's chrome: modals, the help overlay, the header,
+//! the status bar, and the AI assistant view.
+//!
+//! Every test renders through ratatui's `TestBackend` (see `common`) and
+//! asserts on the screen text, or drives `AssistantViewState` directly and
+//! asserts on the resulting state.
+
+mod common;
+
+use std::cell::RefCell;
+
+use crossterm::event::KeyCode;
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+use ratatui::text::Line;
+use srelens_tui::ai_skills::CavemanLevel;
+use srelens_tui::app::ActiveView;
+use srelens_tui::commands::command_suggestions;
+use srelens_tui::ui::dialogs::{
+    render_modal, ContainerAction, ContextPickerItem, Modal, QuickActionId, QuickActionItem,
+};
+use srelens_tui::ui::header::{render_header, ContextChipInfo, HeaderProps};
+use srelens_tui::ui::help::{centered_rect, render_help_modal};
+use srelens_tui::ui::statusbar::{render_statusbar, InputMode, StatusBarProps};
+use srelens_tui::views::assistant_view::{
+    format_message_content, format_message_content_with_width, parse_inline_markdown,
+    render_assistant_view, render_markdown_table, wrap_line, AssistantViewState, ChatMessage,
+    TokenUsage, ToolCallRecord, ToolCallStatus,
+};
+use srelens_tui::views::metrics_panel_view::MetricsPanelState;
+use srelens_tui::views::reason_rail::ReasonTally;
+use srelens_tui::AiSettings;
+
+// ───────────────────────── helpers ─────────────────────────
+
+fn modal_text(width: u16, height: u16, modal: &Modal) -> String {
+    common::render_text(width, height, |f| render_modal(f, f.area(), modal))
+}
+
+fn line_text(line: &Line) -> String {
+    line.spans.iter().map(|s| s.content.as_ref()).collect()
+}
+
+/// Run the markdown formatter over `content` and return one plain string per
+/// produced line.
+fn md(content: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    format_message_content(&mut out, content);
+    out.iter().map(line_text).collect()
+}
+
+fn assistant_text(width: u16, height: u16, state: &AssistantViewState) -> String {
+    let settings = AiSettings::default();
+    common::render_text(width, height, |f| {
+        render_assistant_view(f, f.area(), state, &settings)
+    })
+}
+
+fn msg(role: &str, content: &str) -> ChatMessage {
+    ChatMessage {
+        role: role.to_string(),
+        content: content.to_string(),
+        timestamp: "10:00:00".to_string(),
+        tool_calls: Vec::new(),
+        token_usage: None,
+    }
+}
+
+fn tool(id: &str, name: &str, args: &str, status: ToolCallStatus) -> ToolCallRecord {
+    ToolCallRecord {
+        id: id.to_string(),
+        tool: name.to_string(),
+        args_summary: args.to_string(),
+        status,
+    }
+}
+
+/// A fresh assistant state whose greeting has a fixed timestamp so rendered
+/// rows are deterministic.
+fn fresh_state() -> AssistantViewState {
+    let mut state = AssistantViewState::new();
+    state.messages[0].timestamp = "10:00:00".to_string();
+    state
+}
+
+fn status_props(mode: &InputMode) -> StatusBarProps<'_> {
+    StatusBarProps {
+        mode,
+        command_input: "",
+        filter_input: "",
+        matched_count: 0,
+        total_count: 0,
+        is_text_search: false,
+        toast: None,
+        custom_hints: None,
+        suggestions: None,
+    }
+}
+
+fn statusbar_text(props: StatusBarProps) -> String {
+    let lines = common::render_lines(200, 24, |f| {
+        render_statusbar(f, Rect::new(0, 22, 200, 2), props)
+    });
+    lines[22..].join(
+        "
+",
+    )
+}
+
+fn header_props<'a>(contexts: &'a [ContextChipInfo]) -> HeaderProps<'a> {
+    HeaderProps {
+        context: "prod-east",
+        cluster: "prod-east-cluster",
+        server: "https://10.0.0.1:6443",
+        namespace: "default",
+        version: "v1.29.2",
+        node_count: 3,
+        pod_count: 42,
+        is_connected: true,
+        active_view_name: "Pods",
+        contexts,
+        context_chip_rects: None,
+    }
+}
+
+fn header_text(width: u16, height: u16, props: HeaderProps) -> String {
+    common::render_text(width, height, |f| {
+        render_header(f, Rect::new(0, 0, width, height), props)
+    })
+}
+
+fn chip(index: usize, name: &str, is_current: bool, is_local: bool) -> ContextChipInfo {
+    ContextChipInfo {
+        name: name.to_string(),
+        is_current,
+        is_local,
+        index,
+    }
+}
+
+fn ctx_item(
+    name: &str,
+    cluster: &str,
+    ns: &str,
+    is_local: bool,
+    provider: Option<&str>,
+    file: &str,
+) -> ContextPickerItem {
+    ContextPickerItem {
+        name: name.to_string(),
+        cluster: cluster.to_string(),
+        server: format!("https://{}.example:6443", cluster),
+        namespace: ns.to_string(),
+        is_local,
+        provider: provider.map(str::to_string),
+        source_file: file.to_string(),
+    }
+}
+
+fn sample_contexts() -> Vec<ContextPickerItem> {
+    vec![
+        ctx_item(
+            "prod-east",
+            "prod-east-cluster",
+            "payments",
+            false,
+            Some("gke"),
+            "/home/sre/.kube/config",
+        ),
+        ctx_item(
+            "dev-local",
+            "kind-dev",
+            "",
+            true,
+            None,
+            "/home/sre/.kube/kind.yaml",
+        ),
+        ctx_item("staging", "stg", "web", false, None, "/etc/kube/staging"),
+    ]
+}
+
+fn action(id: QuickActionId, key: &str, title: &str, desc: &str) -> QuickActionItem {
+    QuickActionItem {
+        id,
+        key_hint: key.to_string(),
+        title: title.to_string(),
+        description: desc.to_string(),
+    }
+}
+
+fn sample_actions() -> Vec<QuickActionItem> {
+    vec![
+        action(
+            QuickActionId::AskAi,
+            "a",
+            "Ask AI",
+            "Investigate this resource with the assistant",
+        ),
+        action(
+            QuickActionId::ViewLogs,
+            "l",
+            "View Logs",
+            "Stream container logs",
+        ),
+        action(
+            QuickActionId::Delete,
+            "^d",
+            "Delete",
+            "Remove the resource (confirmation required)",
+        ),
+    ]
+}
+
+fn confirm(destructive: bool) -> Modal {
+    Modal::Confirm {
+        title: if destructive {
+            "Delete Pod".into()
+        } else {
+            "Restart Deployment".into()
+        },
+        message: if destructive {
+            "Delete pod web-0 in namespace default?".into()
+        } else {
+            "Rollout restart deployment web?".into()
+        },
+        action_name: if destructive {
+            "Delete".into()
+        } else {
+            "Restart".into()
+        },
+        is_destructive: destructive,
+    }
+}
+
+fn every_modal() -> Vec<Modal> {
+    vec![
+        confirm(true),
+        Modal::Scale {
+            workload_name: "web".into(),
+            current_replicas: 3,
+            input: "5".into(),
+        },
+        Modal::PortForward {
+            pod_name: "web-0".into(),
+            namespace: "default".into(),
+            container_port: 8080,
+            local_port_input: "8080".into(),
+        },
+        Modal::ContainerPicker {
+            pod_name: "web-0".into(),
+            namespace: Some("default".into()),
+            containers: vec!["app".into(), "sidecar".into()],
+            selected_idx: 0,
+            action: ContainerAction::Logs,
+        },
+        Modal::ContextPicker {
+            contexts: sample_contexts(),
+            current_context: "prod-east".into(),
+            selected_idx: 0,
+            filter: String::new(),
+        },
+        Modal::NamespacePicker {
+            namespaces: vec!["default".into(), "kube-system".into()],
+            current_namespace: "default".into(),
+            selected_idx: 0,
+            filter: String::new(),
+        },
+        Modal::ActionPalette {
+            resource_kind: "Pod".into(),
+            resource_name: "web-0".into(),
+            namespace: None,
+            actions: sample_actions(),
+            selected_idx: 0,
+            filter: String::new(),
+        },
+        Modal::MetricsTimeline(MetricsPanelState::new(
+            "Pod".into(),
+            "web-0".into(),
+            Some("default".into()),
+            vec![],
+        )),
+        Modal::ReasonRail {
+            tallies: vec![ReasonTally {
+                reason: "BackOff".into(),
+                count: 3,
+                event_type: "Warning".into(),
+            }],
+            selected_idx: 0,
+            active_filter: None,
+        },
+    ]
+}
+
+// ───────────────────────── dialogs: Confirm ─────────────────────────
+
+#[test]
+fn the_delete_confirmation_modal_names_the_resource_and_both_choices() {
+    let text = modal_text(120, 40, &confirm(true));
+    assert!(text.contains(" Delete Pod "), "{text}");
+    assert!(
+        text.contains("Delete pod web-0 in namespace default?"),
+        "{text}"
+    );
+    assert!(
+        text.contains("Press [Enter/y] to Delete  |  [Esc/n] to Cancel"),
+        "{text}"
+    );
+}
+
+#[test]
+fn a_non_destructive_confirmation_uses_its_own_action_verb() {
+    let text = modal_text(120, 40, &confirm(false));
+    assert!(text.contains(" Restart Deployment "), "{text}");
+    assert!(text.contains("Rollout restart deployment web?"), "{text}");
+    assert!(text.contains("[Enter/y] to Restart"), "{text}");
+}
+
+#[test]
+fn a_long_confirmation_message_wraps_inside_the_modal() {
+    let modal = Modal::Confirm {
+        title: "Drain Node".into(),
+        message: "Drain node worker-1? Every pod on it will be evicted and rescheduled elsewhere in the cluster.".into(),
+        action_name: "Drain".into(),
+        is_destructive: true,
+    };
+    let lines = common::render_lines(100, 40, |f| render_modal(f, f.area(), &modal));
+    let body: Vec<&String> = lines
+        .iter()
+        .filter(|l| l.contains("Drain node") || l.contains("evicted") || l.contains("cluster."))
+        .collect();
+    assert!(
+        body.len() >= 2,
+        "message should span several rows: {lines:?}"
+    );
+    assert!(
+        lines.iter().any(|l| l.contains("[Enter/y] to Drain")),
+        "{lines:?}"
+    );
+}
+
+// ───────────────────────── dialogs: Scale / PortForward ─────────────────────────
+
+#[test]
+fn the_scale_modal_shows_current_replicas_and_the_typed_target() {
+    let modal = Modal::Scale {
+        workload_name: "web".into(),
+        current_replicas: 3,
+        input: "5".into(),
+    };
+    let text = modal_text(120, 40, &modal);
+    assert!(text.contains(" Scale Workload: web "), "{text}");
+    assert!(text.contains("Current replicas: 3"), "{text}");
+    assert!(text.contains(" Desired Replicas "), "{text}");
+    assert!(text.contains("5█"), "{text}");
+    assert!(text.contains("[Enter] Apply  [Esc] Cancel"), "{text}");
+}
+
+#[test]
+fn an_empty_scale_input_shows_only_the_cursor() {
+    let modal = Modal::Scale {
+        workload_name: "api".into(),
+        current_replicas: 0,
+        input: String::new(),
+    };
+    let lines = common::render_lines(120, 40, |f| render_modal(f, f.area(), &modal));
+    let cursor_row = lines.iter().find(|l| l.contains('█')).expect("cursor row");
+    assert!(
+        cursor_row.trim_matches(|c| c == '│' || c == ' ') == "█",
+        "{cursor_row:?}"
+    );
+    assert!(
+        lines.iter().any(|l| l.contains("Current replicas: 0")),
+        "{lines:?}"
+    );
+}
+
+#[test]
+fn the_port_forward_modal_shows_the_target_port_and_the_local_port_being_typed() {
+    let modal = Modal::PortForward {
+        pod_name: "web-0".into(),
+        namespace: "default".into(),
+        container_port: 8080,
+        local_port_input: "80".into(),
+    };
+    let text = modal_text(120, 40, &modal);
+    assert!(
+        text.contains(" Start Port Forward: web-0 (default) "),
+        "{text}"
+    );
+    assert!(text.contains("Target container port: 8080"), "{text}");
+    assert!(text.contains(" Local Port (127.0.0.1) "), "{text}");
+    assert!(text.contains("80█"), "{text}");
+    assert!(text.contains("[Enter] Forward  [Esc] Cancel"), "{text}");
+}
+
+// ───────────────────────── dialogs: ContainerPicker ─────────────────────────
+
+#[test]
+fn the_container_picker_titles_itself_after_the_action_and_marks_the_selection() {
+    let mut modal = Modal::ContainerPicker {
+        pod_name: "web-0".into(),
+        namespace: Some("default".into()),
+        containers: vec!["app".into(), "sidecar".into(), "init-db".into()],
+        selected_idx: 1,
+        action: ContainerAction::Logs,
+    };
+    let text = modal_text(120, 40, &modal);
+    assert!(text.contains(" View Logs for Container (web-0) "), "{text}");
+    assert!(text.contains("  app"), "{text}");
+    assert!(text.contains("▶ sidecar"), "{text}");
+    assert!(text.contains("  init-db"), "{text}");
+
+    if let Modal::ContainerPicker {
+        action,
+        selected_idx,
+        ..
+    } = &mut modal
+    {
+        *action = ContainerAction::Shell;
+        *selected_idx = 2;
+    }
+    let text = modal_text(120, 40, &modal);
+    assert!(
+        text.contains(" Exec Shell into Container (web-0) "),
+        "{text}"
+    );
+    assert!(text.contains("▶ init-db"), "{text}");
+    assert!(!text.contains("▶ sidecar"), "{text}");
+}
+
+// ───────────────────────── dialogs: ContextPicker ─────────────────────────
+
+#[test]
+fn the_context_picker_lists_every_context_with_badges_and_marks_the_active_one() {
+    let modal = Modal::ContextPicker {
+        contexts: sample_contexts(),
+        current_context: "prod-east".into(),
+        selected_idx: 1,
+        filter: String::new(),
+    };
+    let text = modal_text(140, 40, &modal);
+    assert!(
+        text.contains(
+            " Switch Kubernetes Context (Type to filter, ↑/↓ Navigate, Enter Switch, Esc Close) "
+        ),
+        "{text}"
+    );
+    assert!(text.contains(" Filter Contexts "), "{text}");
+    assert!(
+        text.contains(" / █"),
+        "empty filter renders just the cursor: {text}"
+    );
+    assert!(
+        text.contains("★ [gke] prod-east (active) ns:[payments]"),
+        "{text}"
+    );
+    assert!(
+        text.contains("cluster: prod-east-cluster  •  file: config"),
+        "{text}"
+    );
+    assert!(text.contains("▶ [local] dev-local"), "{text}");
+    assert!(!text.contains("dev-local (active)"), "{text}");
+    assert!(
+        text.contains("cluster: kind-dev  •  file: kind.yaml"),
+        "{text}"
+    );
+    assert!(text.contains("  [remote] staging ns:[web]"), "{text}");
+    assert!(
+        text.contains("Showing 3/3 contexts  •  Enter: Switch  Esc: Cancel"),
+        "{text}"
+    );
+}
+
+#[test]
+fn the_context_picker_filter_matches_name_cluster_provider_and_file_case_insensitively() {
+    let mut modal = Modal::ContextPicker {
+        contexts: sample_contexts(),
+        current_context: "prod-east".into(),
+        selected_idx: 0,
+        filter: "GKE".into(),
+    };
+    let text = modal_text(140, 40, &modal);
+    assert!(text.contains(" / GKE█"), "{text}");
+    assert!(text.contains("prod-east"), "{text}");
+    assert!(!text.contains("dev-local"), "{text}");
+    assert!(text.contains("Showing 1/3 contexts"), "{text}");
+
+    for (filter, expected) in [
+        ("stg", "staging"),
+        ("kind.yaml", "dev-local"),
+        ("dev-lo", "dev-local"),
+    ] {
+        if let Modal::ContextPicker { filter: f, .. } = &mut modal {
+            *f = filter.to_string();
+        }
+        let text = modal_text(140, 40, &modal);
+        assert!(
+            text.contains(expected),
+            "filter {filter:?} should keep {expected}: {text}"
+        );
+        assert!(
+            text.contains("Showing 1/3 contexts"),
+            "filter {filter:?}: {text}"
+        );
+    }
+
+    if let Modal::ContextPicker { filter: f, .. } = &mut modal {
+        *f = "nothing-matches".to_string();
+    }
+    let text = modal_text(140, 40, &modal);
+    assert!(text.contains("Showing 0/3 contexts"), "{text}");
+}
+
+// ───────────────────────── dialogs: NamespacePicker ─────────────────────────
+
+#[test]
+fn the_namespace_picker_stars_the_active_namespace_and_arrows_the_selection() {
+    let modal = Modal::NamespacePicker {
+        namespaces: vec![
+            "default".into(),
+            "kube-system".into(),
+            "kube-public".into(),
+            "payments".into(),
+        ],
+        current_namespace: "default".into(),
+        selected_idx: 1,
+        filter: String::new(),
+    };
+    let text = modal_text(140, 40, &modal);
+    assert!(
+        text.contains(" Switch Namespace (0: All Namespaces, ↑/↓ Navigate, Enter Select) "),
+        "{text}"
+    );
+    assert!(text.contains(" Filter "), "{text}");
+    assert!(text.contains("★ default"), "{text}");
+    assert!(text.contains("▶ kube-system"), "{text}");
+    assert!(text.contains("  kube-public"), "{text}");
+    assert!(text.contains("  payments"), "{text}");
+}
+
+#[test]
+fn the_namespace_picker_filter_narrows_the_list_and_reindexes_the_selection() {
+    let modal = Modal::NamespacePicker {
+        namespaces: vec![
+            "default".into(),
+            "kube-system".into(),
+            "kube-public".into(),
+            "payments".into(),
+        ],
+        current_namespace: "default".into(),
+        selected_idx: 0,
+        filter: "kube".into(),
+    };
+    let text = modal_text(140, 40, &modal);
+    assert!(text.contains("kube█"), "{text}");
+    assert!(text.contains("▶ kube-system"), "{text}");
+    assert!(text.contains("  kube-public"), "{text}");
+    assert!(!text.contains("default"), "{text}");
+    assert!(!text.contains("payments"), "{text}");
+}
+
+// ───────────────────────── dialogs: ActionPalette ─────────────────────────
+
+#[test]
+fn the_action_palette_shows_every_action_with_its_key_and_description() {
+    let modal = Modal::ActionPalette {
+        resource_kind: "Pod".into(),
+        resource_name: "web-0".into(),
+        namespace: Some("default".into()),
+        actions: sample_actions(),
+        selected_idx: 0,
+        filter: String::new(),
+    };
+    let text = modal_text(140, 40, &modal);
+    assert!(text.contains(" ⚡  Actions: Pod/web-0 (default) [Type to filter, ↑/↓ Navigate, Enter Run, Esc Close] "), "{text}");
+    assert!(text.contains(" Filter Actions "), "{text}");
+    assert!(text.contains("▶ [a] Ask AI"), "{text}");
+    assert!(
+        text.contains("Investigate this resource with the assistant"),
+        "{text}"
+    );
+    assert!(text.contains("  [l] View Logs"), "{text}");
+    assert!(text.contains("  [^d] Delete"), "{text}");
+    assert!(
+        text.contains("Showing 3/3 actions  •  Enter: Run Action  Esc: Cancel"),
+        "{text}"
+    );
+}
+
+#[test]
+fn the_action_palette_drops_the_namespace_suffix_for_cluster_scoped_resources_and_filters_by_description(
+) {
+    let mut modal = Modal::ActionPalette {
+        resource_kind: "Node".into(),
+        resource_name: "worker-1".into(),
+        namespace: None,
+        actions: sample_actions(),
+        selected_idx: 0,
+        filter: "stream".into(),
+    };
+    let text = modal_text(140, 40, &modal);
+    assert!(
+        text.contains(" ⚡  Actions: Node/worker-1 [Type to filter"),
+        "{text}"
+    );
+    assert!(text.contains(" / stream█"), "{text}");
+    assert!(text.contains("▶ [l] View Logs"), "{text}");
+    assert!(!text.contains("Ask AI"), "{text}");
+    assert!(text.contains("Showing 1/3 actions"), "{text}");
+
+    if let Modal::ActionPalette { filter, .. } = &mut modal {
+        *filter = "^D".to_string();
+    }
+    let text = modal_text(140, 40, &modal);
+    assert!(
+        text.contains("▶ [^d] Delete"),
+        "key hints match case-insensitively: {text}"
+    );
+    assert!(text.contains("Showing 1/3 actions"), "{text}");
+}
+
+// ───────────────────────── dialogs: delegated modals ─────────────────────────
+
+#[test]
+fn the_metrics_timeline_modal_is_delegated_to_the_metrics_panel() {
+    let modal = Modal::MetricsTimeline(MetricsPanelState::new(
+        "Pod".into(),
+        "web-0".into(),
+        Some("default".into()),
+        vec![],
+    ));
+    let text = modal_text(120, 40, &modal);
+    assert!(text.contains("Live Metrics Timeline"), "{text}");
+    assert!(text.contains("Collecting metrics-server data"), "{text}");
+}
+
+#[test]
+fn the_reason_rail_modal_is_delegated_to_the_reason_rail_widget() {
+    let modal = Modal::ReasonRail {
+        tallies: vec![
+            ReasonTally {
+                reason: "BackOff".into(),
+                count: 3,
+                event_type: "Warning".into(),
+            },
+            ReasonTally {
+                reason: "Scheduled".into(),
+                count: 1,
+                event_type: "Normal".into(),
+            },
+        ],
+        selected_idx: 0,
+        active_filter: Some("BackOff".into()),
+    };
+    let text = modal_text(120, 40, &modal);
+    assert!(text.contains("Event Reasons"), "{text}");
+    assert!(text.contains("BackOff"), "{text}");
+    assert!(text.contains("Scheduled"), "{text}");
+}
+
+#[test]
+fn every_modal_still_draws_its_frame_on_a_cramped_terminal() {
+    for modal in every_modal() {
+        for (w, h) in [(30u16, 8u16), (24, 6)] {
+            let text = modal_text(w, h, &modal);
+            assert!(
+                text.contains('┌') || text.contains('─'),
+                "{w}x{h} {modal:?}: {text:?}"
+            );
+        }
+        // Too small for any frame at all: must simply not panic.
+        modal_text(12, 4, &modal);
+    }
+}
+
+// ───────────────────────── help ─────────────────────────
+
+#[test]
+fn centered_rect_carves_a_proportional_rectangle_out_of_the_middle() {
+    let r = centered_rect(50, 50, Rect::new(0, 0, 100, 40));
+    assert_eq!(r, Rect::new(25, 10, 50, 20));
+    let tiny = centered_rect(50, 50, Rect::new(0, 0, 1, 1));
+    assert!(tiny.width <= 1 && tiny.height <= 1);
+}
+
+#[test]
+fn the_help_modal_lists_every_section_and_its_key_bindings() {
+    let text = common::render_text(160, 60, |f| render_help_modal(f, f.area()));
+    assert!(
+        text.contains(" SRElens & k9s Keybindings Cheat Sheet (Press Esc to close) "),
+        "{text}"
+    );
+    for section in [
+        "Navigation & Views",
+        "Resource Actions",
+        "SRElens Superpowers",
+    ] {
+        assert!(text.contains(section), "missing section {section}: {text}");
+    }
+    for (key, desc) in [
+        (": <command>", "Open command prompt"),
+        ("Ctrl+c", "Exit / kill srelens-tui immediately"),
+        ("/ <filter>", "Filter table rows by substring or regex"),
+        ("j / k / ↑ / ↓", "Navigate up / down"),
+        ("g / G", "Jump to top / bottom"),
+        ("Ctrl+u / Ctrl+d", "Half-page scroll"),
+        ("Enter", "Drill down"),
+        ("Esc", "Pop view back"),
+        (
+            "Ctrl+a",
+            "Toggle between active namespace and all namespaces",
+        ),
+        ("Space", "Mark / select item"),
+        ("x", "Quick Actions & Incident Palette"),
+        ("t", "Resource Relationship Tree"),
+        ("l", "View Logs"),
+        ("s", "Interactive Shell"),
+        ("y / v", "View YAML manifest"),
+        ("d", "Describe resource"),
+        ("e", "Edit resource YAML in $EDITOR"),
+        ("Ctrl+d", "Delete selected resource"),
+        ("Ctrl+r", "Rollout restart workload"),
+        ("Ctrl+s", "Scale workload replica count"),
+        ("Shift+f / Ctrl+f", "Start Port Forwarding"),
+        ("c", "Copy resource name"),
+        ("C / Shift+c", "Copy resource full YAML"),
+        ("Ctrl+y", "Copy resource srelens:// deep link URL"),
+        ("Mouse drag", "Select text in any view"),
+        ("c / u (Nodes)", "Cordon / Drain Node"),
+        ("Tab / :ai", "Open SRElens AI Assistant"),
+        (":helm", "Helm 3 release management"),
+        (":tb", "Toolbox diagnostics"),
+        (":pf", "Port Forwards manager"),
+        (
+            "F1 - F10 / :ctx",
+            "Quick-switch Kubernetes cluster contexts",
+        ),
+    ] {
+        let row = text
+            .lines()
+            .find(|l| l.contains(key) && l.contains(desc))
+            .unwrap_or_else(|| panic!("no row pairs {key:?} with {desc:?}:\n{text}"));
+        assert!(
+            row.find(key).unwrap() < row.find(desc).unwrap(),
+            "key column precedes description: {row}"
+        );
+    }
+}
+
+#[test]
+fn the_help_modal_truncates_from_the_bottom_when_the_terminal_is_short() {
+    let text = common::render_text(120, 24, |f| render_help_modal(f, f.area()));
+    assert!(text.contains("Cheat Sheet"), "{text}");
+    assert!(text.contains("Navigation & Views"), "{text}");
+    assert!(text.contains(": <command>"), "{text}");
+    assert!(
+        !text.contains("SRElens Superpowers"),
+        "later sections fall off a 24-row terminal: {text}"
+    );
+    assert!(!text.contains("F1 - F10"), "{text}");
+}
+
+#[test]
+fn the_help_modal_degrades_to_a_border_on_a_tiny_terminal() {
+    let text = common::render_text(20, 6, |f| render_help_modal(f, f.area()));
+    assert!(text.contains('┌') && text.contains('┘'), "{text:?}");
+}
+
+// ───────────────────────── statusbar ─────────────────────────
+
+#[test]
+fn command_mode_echoes_the_prompt_with_a_cursor_and_no_popup_without_suggestions() {
+    let mode = InputMode::Command;
+    let mut props = status_props(&mode);
+    props.command_input = "po";
+    let text = statusbar_text(props);
+    assert!(text.contains(":po█"), "{text}");
+    assert!(!text.contains("Commands (Tab to complete"), "{text}");
+
+    let mode = InputMode::Command;
+    let mut props = status_props(&mode);
+    props.command_input = "zzz";
+    let empty: Vec<(srelens_tui::commands::DynamicCommandDef, usize)> = Vec::new();
+    props.suggestions = Some((&empty, 0));
+    let text = statusbar_text(props);
+    assert!(text.contains(":zzz█"), "{text}");
+    assert!(
+        !text.contains("Commands (Tab to complete"),
+        "an empty suggestion list draws no popup: {text}"
+    );
+}
+
+#[test]
+fn command_mode_pops_up_the_matching_commands_above_the_bar_and_arrows_the_selection() {
+    let suggs = command_suggestions("po");
+    assert!(
+        suggs.len() >= 2,
+        "the registry should offer several matches for 'po'"
+    );
+    let selected = 1;
+    let mode = InputMode::Command;
+    let mut props = status_props(&mode);
+    props.command_input = "po";
+    props.suggestions = Some((&suggs, selected));
+    let lines = common::render_lines(80, 24, |f| {
+        render_statusbar(f, Rect::new(0, 22, 80, 2), props)
+    });
+    let text = lines.join("\n");
+    assert!(
+        text.contains(" Commands (Tab to complete, Enter to run) "),
+        "{text}"
+    );
+
+    let sel_name = &suggs[selected].0.name;
+    let sel_row = lines
+        .iter()
+        .find(|l| l.contains("▶ "))
+        .expect("a selected row");
+    assert!(
+        sel_row.contains(sel_name.as_str()),
+        "selected row {sel_row:?} names {sel_name}"
+    );
+    assert!(
+        sel_row.contains(&suggs[selected].0.description),
+        "{sel_row}"
+    );
+    let first = &suggs[0].0;
+    let first_row = lines
+        .iter()
+        .find(|l| l.contains(first.name.as_str()) && !l.contains("▶ "))
+        .expect("unselected first row");
+    if !first.aliases.is_empty() {
+        assert!(
+            first_row.contains(&format!("({})", first.aliases.join(", "))),
+            "{first_row}"
+        );
+    }
+    let popup_row = lines
+        .iter()
+        .position(|l| l.contains("Commands (Tab"))
+        .unwrap();
+    assert!(popup_row < 22, "popup opens above the bar");
+    assert!(lines[23].starts_with(":po█"), "{:?}", lines[23]);
+}
+
+#[test]
+fn regex_filter_mode_shows_the_match_ratio_and_apply_hint() {
+    let mode = InputMode::Filter;
+    let mut props = status_props(&mode);
+    props.filter_input = "web-.*";
+    props.matched_count = 3;
+    props.total_count = 10;
+    let text = statusbar_text(props);
+    assert!(
+        text.contains("Filter (regex): /web-.*█  [3/10]  (Enter to apply, Esc to clear)"),
+        "{text}"
+    );
+}
+
+#[test]
+fn text_search_mode_shows_a_match_count_and_next_prev_hint() {
+    let mode = InputMode::Filter;
+    let mut props = status_props(&mode);
+    props.filter_input = "OOM";
+    props.matched_count = 4;
+    props.total_count = 900;
+    props.is_text_search = true;
+    let text = statusbar_text(props);
+    assert!(
+        text.contains("Search: /OOM█  [4 matches]  (Enter to finish, n/N next/prev, Esc to clear)"),
+        "{text}"
+    );
+    assert!(!text.contains("900"), "{text}");
+}
+
+#[test]
+fn normal_mode_shows_the_default_key_palette() {
+    let mode = InputMode::Normal;
+    let text = statusbar_text(status_props(&mode));
+    for hint in [
+        "<:> Cmd",
+        "</> Filter",
+        "<c> CopyURL",
+        "<l> Logs",
+        "<s> Shell",
+        "<f>/<F> PortForward",
+        "<d> Describe",
+    ] {
+        assert!(text.contains(hint), "missing {hint}: {text}");
+    }
+    assert!(!text.contains("Filter:"), "{text}");
+    assert!(!text.contains('➜'), "{text}");
+}
+
+#[test]
+fn normal_mode_prefixes_a_toast_and_appends_the_active_filter() {
+    let mode = InputMode::Normal;
+    let mut props = status_props(&mode);
+    props.toast = Some(("Copied web-0", Style::default()));
+    props.filter_input = "web";
+    props.matched_count = 2;
+    props.total_count = 9;
+    let text = statusbar_text(props);
+    assert!(text.starts_with("─"), "{text}");
+    assert!(text.contains("➜ Copied web-0 │ <:> Cmd"), "{text}");
+    assert!(text.contains(" | Filter: \"web\" [2/9]"), "{text}");
+}
+
+#[test]
+fn normal_mode_uses_custom_hints_when_a_view_supplies_them() {
+    let mode = InputMode::Normal;
+    let mut props = status_props(&mode);
+    let hints: &[(&str, &str)] = &[("<Esc>", "Back"), ("<w>", "Wrap")];
+    props.custom_hints = Some(hints);
+    let text = statusbar_text(props);
+    assert!(text.contains("<Esc> Back <w> Wrap"), "{text}");
+    assert!(!text.contains("<:> Cmd"), "{text}");
+}
+
+// ───────────────────────── header ─────────────────────────
+
+#[test]
+fn a_two_row_header_shows_brand_chips_stats_and_the_active_context_line() {
+    let contexts = vec![
+        chip(1, "prod-east", true, false),
+        chip(2, "dev-local", false, true),
+    ];
+    let props = header_props(&contexts);
+    let lines = common::render_lines(120, 3, |f| render_header(f, Rect::new(0, 0, 120, 3), props));
+    assert!(lines[0].starts_with("⚡  SRELENS"), "{:?}", lines[0]);
+    assert!(
+        lines[0].contains("[● 1: prod-east] [2: dev-local]"),
+        "{:?}",
+        lines[0]
+    );
+    assert!(
+        lines[0].ends_with("● v1.29.2 Nodes: 3 Pods: 42"),
+        "{:?}",
+        lines[0]
+    );
+    assert!(
+        lines[1].starts_with("Ctx: prod-east  NS: [default]  View: Pods"),
+        "{:?}",
+        lines[1]
+    );
+    assert!(
+        lines[1].contains("<:ctx> All Ctx  <F1-F10> Hotkeys"),
+        "{:?}",
+        lines[1]
+    );
+    assert!(lines[2].starts_with("───"), "bottom border: {:?}", lines[2]);
+}
+
+#[test]
+fn an_empty_namespace_reads_as_all_and_a_bare_version_gains_a_v_prefix() {
+    let mut props = header_props(&[]);
+    props.namespace = "";
+    props.version = "1.30.1";
+    props.is_connected = false;
+    let text = header_text(120, 3, props);
+    assert!(text.contains("NS: [all]"), "{text}");
+    assert!(text.contains("● v1.30.1 Nodes: 3 Pods: 42"), "{text}");
+
+    let mut props = header_props(&[]);
+    props.version = "unknown";
+    let text = header_text(120, 3, props);
+    assert!(
+        text.contains("● unknown Nodes: 3"),
+        "a version with no dots is left alone: {text}"
+    );
+}
+
+#[test]
+fn context_chips_record_their_click_rects_and_collapse_into_an_overflow_chip() {
+    let contexts = vec![
+        chip(1, "alpha-cluster-01", true, false),
+        chip(2, "bravo-cluster-02", false, false),
+        chip(3, "charlie-cluster-03", false, false),
+    ];
+    let rects = RefCell::new(Vec::new());
+    let mut props = header_props(&contexts);
+    props.context = "alpha-cluster-01";
+    props.context_chip_rects = Some(&rects);
+    // The chip column runs from x=11 (after the brand) to width-34 (before
+    // the stats). At width 106 that is x=11..72: the 23-wide current chip and
+    // the 21-wide second chip fit, the 23-wide third does not, and the
+    // 11-wide overflow marker takes its place.
+    let lines = common::render_lines(106, 3, |f| render_header(f, Rect::new(0, 0, 106, 3), props));
+    assert!(
+        lines[0].contains("[● 1: alpha-cluster-01] [2: bravo-cluster-02] [+1 (:ctx)]"),
+        "{:?}",
+        lines[0]
+    );
+    assert!(!lines[0].contains("charlie"), "{:?}", lines[0]);
+
+    let recorded = rects.borrow();
+    let names: Vec<&str> = recorded.iter().map(|(_, n)| n.as_str()).collect();
+    assert_eq!(names, vec!["alpha-cluster-01", "bravo-cluster-02", ":ctx"]);
+    assert_eq!(recorded[0].0, Rect::new(11, 0, 23, 1));
+    assert_eq!(recorded[1].0, Rect::new(35, 0, 21, 1));
+    assert_eq!(recorded[2].0, Rect::new(57, 0, 11, 1));
+}
+
+#[test]
+fn a_chip_that_does_not_fit_takes_the_overflow_marker_with_it() {
+    let contexts = vec![
+        chip(1, "alpha-cluster-01", true, false),
+        chip(2, "bravo-cluster-02", false, false),
+        chip(3, "charlie-cluster-03", false, false),
+    ];
+    let props = header_props(&contexts);
+    // Four columns narrower and the overflow marker no longer fits either, so
+    // the row stops after the two chips that do.
+    let lines = common::render_lines(100, 3, |f| render_header(f, Rect::new(0, 0, 100, 3), props));
+    assert!(
+        lines[0].contains("[● 1: alpha-cluster-01] [2: bravo-cluster-02]"),
+        "{:?}",
+        lines[0]
+    );
+    assert!(
+        !lines[0].contains("charlie") && !lines[0].contains("(:ctx)"),
+        "{:?}",
+        lines[0]
+    );
+}
+
+#[test]
+fn the_overflow_chip_is_dropped_when_even_it_would_not_fit() {
+    let contexts = vec![
+        chip(1, "production-cluster-eu-west", true, false),
+        chip(2, "staging", false, false),
+    ];
+    let rects = RefCell::new(vec![(Rect::default(), "stale".to_string())]);
+    let mut props = header_props(&contexts);
+    props.context_chip_rects = Some(&rects);
+    // Width 80 leaves 35 columns: the 31-wide first chip fits, then only 4
+    // columns remain, too few for "[+1 (:ctx)]".
+    let lines = common::render_lines(80, 3, |f| render_header(f, Rect::new(0, 0, 80, 3), props));
+    assert!(
+        lines[0].contains("[● 1: production-cluster-eu-west]"),
+        "{:?}",
+        lines[0]
+    );
+    assert!(!lines[0].contains("staging"), "{:?}", lines[0]);
+    assert!(!lines[0].contains("(:ctx)"), "{:?}", lines[0]);
+    let recorded = rects.borrow();
+    assert_eq!(
+        recorded.len(),
+        1,
+        "stale rects are cleared before drawing: {recorded:?}"
+    );
+    assert_eq!(recorded[0].1, "production-cluster-eu-west");
+}
+
+#[test]
+fn chips_are_skipped_entirely_when_there_are_none_or_no_room_for_them() {
+    // No contexts to draw: the rest of the header still renders.
+    let rects = RefCell::new(Vec::new());
+    let mut props = header_props(&[]);
+    props.context_chip_rects = Some(&rects);
+    let text = header_text(120, 3, props);
+    assert!(text.starts_with("⚡  SRELENS"), "{text}");
+    assert!(text.contains("Ctx: prod-east"), "{text}");
+    assert!(!text.contains(" (:ctx)]"), "{text}");
+    assert!(rects.borrow().is_empty());
+
+    // A header only a few columns wide: the chip strip is under five cells, so
+    // nothing is drawn there and no click target is recorded.
+    let contexts = vec![chip(1, "prod", true, false)];
+    let rects = RefCell::new(Vec::new());
+    let mut props = header_props(&contexts);
+    props.context_chip_rects = Some(&rects);
+    let text = header_text(4, 3, props);
+    assert!(!text.contains("prod"), "{text}");
+    assert!(rects.borrow().is_empty());
+}
+
+#[test]
+fn a_single_row_header_collapses_everything_onto_one_line() {
+    let contexts = vec![chip(1, "prod-east", true, false)];
+    let mut props = header_props(&contexts);
+    props.namespace = "";
+    props.version = "1.28.0";
+    let lines = common::render_lines(120, 2, |f| render_header(f, Rect::new(0, 0, 120, 2), props));
+    assert!(lines[0].starts_with("⚡  SRELENS"), "{:?}", lines[0]);
+    assert!(
+        lines[0].contains("Ctx: prod-east NS: [all] View: Pods"),
+        "{:?}",
+        lines[0]
+    );
+    assert!(
+        lines[0].ends_with("● v1.28.0 Nodes: 3 Pods: 42"),
+        "{:?}",
+        lines[0]
+    );
+    assert!(
+        !lines[0].contains("[● 1: prod-east]"),
+        "no chip row in compact mode: {:?}",
+        lines[0]
+    );
+    assert!(lines[1].starts_with("───"), "{:?}", lines[1]);
+}
+
+// ───────────────────────── assistant: title bar ─────────────────────────
+
+#[test]
+fn the_assistant_title_names_the_provider_model_and_key_hints() {
+    let state = fresh_state();
+    let text = assistant_text(200, 30, &state);
+    let settings = AiSettings::default();
+    let model = settings.get_model(settings.default_provider);
+    assert!(text.contains(&format!(" SRElens AI Assistant[Anthropic (Claude) - {model}] [<c> Copy, <Ctrl+t> Tools, <Ctrl+e> Save, <Ctrl+l> Clear, <Ctrl+s> Settings, <Esc> Back] ")), "{text}");
+    assert!(text.contains("SRElens [10:00:00]:"), "{text}");
+    assert!(
+        text.contains("Hello! I am your SRElens AI Assistant."),
+        "{text}"
+    );
+    assert!(text.contains(" Ask Assistant (Type '/' for SRE Playbooks, ↑/↓ History, <c> Copy, <Ctrl+s> Settings) "), "{text}");
+}
+
+#[test]
+fn the_assistant_title_reflects_context_caveman_tokens_selection_and_folded_tools() {
+    let mut state = AssistantViewState::for_context("prod-east");
+    state.messages[0].timestamp = "10:00:00".into();
+    assert!(state.messages[0]
+        .content
+        .contains("for context 'prod-east'"));
+    state.caveman_level = Some(CavemanLevel::WenyanUltra);
+    state.expand_tools = true;
+    state.start_selection(0, 0);
+    state.update_selection(0, 3);
+    state.finish_selection(0, 3);
+    let mut usage_msg = msg("assistant", "done");
+    usage_msg.token_usage = Some(TokenUsage {
+        total_tokens: 1234,
+        ..Default::default()
+    });
+    state.messages.push(usage_msg);
+
+    let text = assistant_text(220, 30, &state);
+    assert!(
+        text.contains(
+            " SRElens AI Assistant @prod-east  [🦖  CAVEMAN: WENYAN-ULTRA][Anthropic (Claude) - "
+        ),
+        "{text}"
+    );
+    assert!(
+        text.contains("[⚡  1,234 tokens, <c> Copy Selection, <Ctrl+t> Fold Tools, <Ctrl+e> Save"),
+        "{text}"
+    );
+}
+
+// ───────────────────────── assistant: tool chips ─────────────────────────
+
+fn state_with_tools(expand: bool) -> AssistantViewState {
+    let mut state = fresh_state();
+    let mut m = msg("assistant", "Found it.");
+    m.tool_calls = vec![
+        tool(
+            "1",
+            "srelens-k8s.getObject",
+            "pod/web-0",
+            ToolCallStatus::Success,
+        ),
+        tool(
+            "2",
+            "srelens-k8s.getObject",
+            "pod/web-1",
+            ToolCallStatus::Success,
+        ),
+        tool(
+            "3",
+            "srelens-k8s.getObject",
+            "pod/web-2",
+            ToolCallStatus::Success,
+        ),
+        tool("4", "k8s_listPods", "", ToolCallStatus::Success),
+        tool("5", "hookAdditionalContexts", "", ToolCallStatus::Success),
+        tool("6", "bash", &"k".repeat(70), ToolCallStatus::Success),
+    ];
+    state.messages.push(m);
+    state.expand_tools = expand;
+    state
+}
+
+#[test]
+fn a_collapsed_tool_chip_groups_repeated_tools_and_hides_internal_ones() {
+    let state = state_with_tools(false);
+    let text = assistant_text(160, 30, &state);
+    assert!(text.contains("▶ ⚙ 5 tools queried: getObject (×3), listPods, bash [✓ ok]  (click or <Ctrl+t> to expand)"), "{text}");
+    assert!(!text.contains("hookAdditionalContexts"), "{text}");
+    assert!(
+        !text.contains("pod/web-0"),
+        "collapsed chips hide per-tool args: {text}"
+    );
+    let chip_lines = state.tool_chip_lines.borrow();
+    assert_eq!(
+        chip_lines.as_slice(),
+        &[4],
+        "the chip sits right under the second message header: {chip_lines:?}"
+    );
+}
+
+#[test]
+fn an_expanded_tool_chip_lists_each_call_and_truncates_long_arguments() {
+    let state = state_with_tools(true);
+    let text = assistant_text(160, 30, &state);
+    assert!(
+        text.contains("▼ ⚙ 5 tools queried (click or <Ctrl+t> to collapse): [✓ ok]"),
+        "{text}"
+    );
+    assert!(text.contains("⚙ getObject pod/web-0 [✓ ok]"), "{text}");
+    assert!(text.contains("⚙ getObject pod/web-2 [✓ ok]"), "{text}");
+    assert!(
+        text.contains("⚙ listPods [✓ ok]"),
+        "empty args add no preview: {text}"
+    );
+    assert!(
+        text.contains(&format!("⚙ bash {}... [✓ ok]", "k".repeat(62))),
+        "{text}"
+    );
+    assert!(!text.contains(&"k".repeat(63)), "{text}");
+}
+
+#[test]
+fn the_overall_tool_badge_prefers_running_over_error_over_ok() {
+    let mut state = fresh_state();
+    let mut m = msg("assistant", "");
+    m.tool_calls = vec![
+        tool("1", "bash", "ls", ToolCallStatus::Error("boom".into())),
+        tool("2", "read", "f", ToolCallStatus::Running),
+    ];
+    state.messages.push(m);
+    state.expand_tools = true;
+    let text = assistant_text(160, 30, &state);
+    assert!(
+        text.contains("2 tools queried (click or <Ctrl+t> to collapse): [⠋ running]"),
+        "{text}"
+    );
+    assert!(text.contains("⚙ bash ls [✗ error]"), "{text}");
+    assert!(text.contains("⚙ read f [⠋ running]"), "{text}");
+
+    state.finish_tool_call("2", ToolCallStatus::Success);
+    state.expand_tools = false;
+    let text = assistant_text(160, 30, &state);
+    assert!(
+        text.contains("2 tools queried: bash, read [✗ error]"),
+        "{text}"
+    );
+}
+
+// ───────────────────────── assistant: usage footer, busy line ─────────────────────────
+
+#[test]
+fn the_token_footer_formats_thousands_cache_and_duration() {
+    let mut state = fresh_state();
+    let mut m = msg("assistant", "ok");
+    m.token_usage = Some(TokenUsage {
+        prompt_tokens: 1000,
+        completion_tokens: 500,
+        cached_tokens: 200,
+        total_tokens: 1500,
+        duration_ms: Some(1234),
+    });
+    state.messages.push(m);
+    let text = assistant_text(160, 30, &state);
+    assert!(
+        text.contains("⚡  1,500 tokens (1,000 prompt, 500 completion • 200 cached) • 1.2s"),
+        "{text}"
+    );
+
+    state.set_token_usage(TokenUsage {
+        prompt_tokens: 10,
+        completion_tokens: 5,
+        cached_tokens: 0,
+        total_tokens: 15,
+        duration_ms: Some(850),
+    });
+    let text = assistant_text(160, 30, &state);
+    assert!(
+        text.contains("⚡  15 tokens (10 prompt, 5 completion) • 850ms"),
+        "{text}"
+    );
+
+    state.set_token_usage(TokenUsage {
+        prompt_tokens: 1,
+        completion_tokens: 1,
+        total_tokens: 2,
+        ..Default::default()
+    });
+    let lines = common::render_lines(160, 30, |f| {
+        render_assistant_view(f, f.area(), &state, &AiSettings::default())
+    });
+    // The title bar carries a token hint too, so match the footer's own shape.
+    let footer = lines
+        .iter()
+        .find(|l| l.contains("2 tokens (1 prompt"))
+        .expect("footer");
+    assert!(
+        footer
+            .trim_end_matches(['│', ' '])
+            .ends_with("(1 prompt, 1 completion)"),
+        "no cache and no duration means no badges: {footer:?}"
+    );
+}
+
+#[test]
+fn a_busy_assistant_shows_a_spinner_status_and_elapsed_seconds() {
+    let mut state = fresh_state();
+    state.is_busy = true;
+    state.spinner_frame = 3;
+    let text = assistant_text(160, 30, &state);
+    assert!(
+        text.contains("⠸ Consulting AI provider & cluster state... (0s elapsed)"),
+        "{text}"
+    );
+
+    state.set_status("Running kubectl get pods".into());
+    state.busy_start = Some(std::time::Instant::now());
+    state.tick();
+    let text = assistant_text(160, 30, &state);
+    assert!(
+        text.contains("⠼ Running kubectl get pods (0s elapsed)"),
+        "{text}"
+    );
+
+    state.finish_turn();
+    assert!(!state.is_busy && state.busy_start.is_none());
+    state.tick();
+    assert_eq!(
+        state.spinner_frame, 4,
+        "the spinner only advances while busy"
+    );
+}
+
+// ───────────────────────── assistant: scrolling ─────────────────────────
+
+/// True when some row of the frame carries exactly `body` between the
+/// assistant block's side borders. Rows are border-terminated, so a plain
+/// `contains("question 1\n")` never matches.
+fn has_body_row(lines: &[String], body: &str) -> bool {
+    lines.iter().any(|l| l.trim_matches('│').trim() == body)
+}
+
+fn long_conversation() -> AssistantViewState {
+    let mut state = fresh_state();
+    for i in 1..=40 {
+        state.messages.push(msg("user", &format!("question {i}")));
+    }
+    state
+}
+
+#[test]
+fn following_the_bottom_shows_the_newest_message_and_the_default_input_title() {
+    let state = long_conversation();
+    let lines = common::render_lines(120, 24, |f| {
+        render_assistant_view(f, f.area(), &state, &AiSettings::default())
+    });
+    let text = lines.join("\n");
+    assert!(has_body_row(&lines, "question 40"), "{text}");
+    assert!(!has_body_row(&lines, "question 1"), "{text}");
+    assert!(
+        text.contains("Ask Assistant (Type '/' for SRE Playbooks"),
+        "{text}"
+    );
+    assert!(state.last_max_scroll.get() > 0);
+    assert_eq!(state.last_total_lines.get(), 1 + 2 + 1 + 40 * 3 + 2, "greeting (header, 2 wrapped content rows at this width, blank) + 40 × (header, content, blank) + 2 breathing rows");
+}
+
+#[test]
+fn scrolling_up_shows_the_oldest_lines_and_a_line_counter_in_the_input_title() {
+    let mut state = long_conversation();
+    state.last_max_scroll.set(999);
+    state.scroll_to_top();
+    let lines = common::render_lines(120, 24, |f| {
+        render_assistant_view(f, f.area(), &state, &AiSettings::default())
+    });
+    let text = lines.join("\n");
+    assert!(has_body_row(&lines, "question 1"), "{text}");
+    assert!(!text.contains("question 40"), "{text}");
+    let total = state.last_total_lines.get();
+    assert!(
+        text.contains(&format!(
+            "Ask Assistant (<End> Follow bottom, <PageUp>/<PageDown> Scroll) [Line 1/{total}]"
+        )),
+        "{text}"
+    );
+
+    state.scroll_down(5);
+    assert!(!state.auto_scroll);
+    let text = assistant_text(120, 24, &state);
+    assert!(text.contains(&format!("[Line 6/{total}]")), "{text}");
+
+    state.scroll_down(10_000);
+    assert!(
+        state.auto_scroll,
+        "scrolling past the end re-engages follow mode"
+    );
+    let text = assistant_text(120, 24, &state);
+    assert!(text.contains("question 40"), "{text}");
+    assert!(!text.contains("Follow bottom"), "{text}");
+}
+
+#[test]
+fn an_explicit_offset_at_or_past_the_end_drops_the_line_counter() {
+    let mut state = long_conversation();
+    assistant_text(120, 24, &state);
+    state.auto_scroll = false;
+    state.scroll_offset = state.last_max_scroll.get() + 50;
+    let text = assistant_text(120, 24, &state);
+    assert!(text.contains("question 40"), "{text}");
+    assert!(
+        text.contains("Ask Assistant (Type '/' for SRE Playbooks"),
+        "{text}"
+    );
+}
+
+// ───────────────────────── assistant: input box ─────────────────────────
+
+#[test]
+fn a_multi_line_prompt_grows_the_input_box_and_keeps_the_cursor_line_visible() {
+    let mut state = fresh_state();
+    state.input = (1..=8)
+        .map(|i| format!("line{i}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let lines = common::render_lines(120, 30, |f| {
+        render_assistant_view(f, f.area(), &state, &AiSettings::default())
+    });
+    let text = lines.join("\n");
+    assert!(text.contains("line8█"), "{text}");
+    assert!(text.contains("line3"), "{text}");
+    assert!(
+        !text.contains("line1\n") && !text.contains("line2"),
+        "the first rows scroll out of an 8-row box: {text}"
+    );
+    let title_row = lines
+        .iter()
+        .position(|l| l.contains("Ask Assistant"))
+        .unwrap();
+    assert_eq!(
+        lines.len() - 1 - title_row,
+        8,
+        "input box is capped at 8 rows (title, 6 text rows, bottom border) inside the outer border"
+    );
+}
+
+#[test]
+fn a_long_single_line_prompt_wraps_inside_the_input_box() {
+    let mut state = fresh_state();
+    state.input = "a".repeat(150);
+    let text = assistant_text(60, 24, &state);
+    assert!(text.contains(&"a".repeat(56)), "{text}");
+    assert!(text.contains(&format!("{}█", "a".repeat(38))), "{text}");
+}
+
+// ───────────────────────── assistant: slash suggestions ─────────────────────────
+
+#[test]
+fn typing_a_slash_pops_up_every_playbook_with_the_first_selected() {
+    let mut state = fresh_state();
+    state.input = "/".into();
+    state.update_slash_suggestions();
+    let n = state.slash_suggestions.len();
+    assert!(n > 7, "enough playbooks to need windowing");
+    let text = assistant_text(140, 40, &state);
+    assert!(
+        text.contains(&format!(
+            " ⚡  SRE Playbooks & Slash Commands (1/{n}) [<Tab>/<Enter>: Apply, ↑/↓: Select] "
+        )),
+        "{text}"
+    );
+    assert!(
+        text.contains(" ▶ /crashloop [Pod] - Triage pod stuck in CrashLoopBackOff"),
+        "{text}"
+    );
+    assert!(text.contains("   /pending"), "{text}");
+    assert!(
+        text.contains(
+            " Ask Assistant (⚡  SRE Playbooks: <Tab>/<Enter> Apply, ↑/↓ Select, <Esc> Dismiss) "
+        ),
+        "{text}"
+    );
+    assert!(
+        text.contains("   /summarise - "),
+        "the seventh row still fits: {text}"
+    );
+    // The greeting itself names /caveman, so look for its popup row instead.
+    assert!(
+        !text.contains("/caveman ["),
+        "only the first seven playbooks fit the popup: {text}"
+    );
+    assert!(!text.contains("/clear - "), "{text}");
+}
+
+#[test]
+fn the_suggestion_popup_windows_around_a_selection_past_the_seventh_row() {
+    let mut state = fresh_state();
+    state.input = "/".into();
+    state.update_slash_suggestions();
+    let n = state.slash_suggestions.len();
+    // Stepping up from the first row wraps around to the last one.
+    state.slash_suggestion_up();
+    assert_eq!(state.slash_suggestion_idx, n - 1);
+    let text = assistant_text(140, 40, &state);
+    assert!(
+        text.contains(&format!("Slash Commands ({n}/{n})")),
+        "{text}"
+    );
+    assert!(
+        text.contains(" ▶ /caveman [lite|full|ultra|wenyan|off] - "),
+        "{text}"
+    );
+    assert!(text.contains("   /settings - "), "{text}");
+    assert!(
+        !text.contains("/crashloop"),
+        "the window slid past the first rows: {text}"
+    );
+
+    // And stepping down from the last row wraps back to the first.
+    state.slash_suggestion_down();
+    assert_eq!(state.slash_suggestion_idx, 0);
+    let text = assistant_text(140, 40, &state);
+    assert!(text.contains(&format!("Slash Commands (1/{n})")), "{text}");
+    assert!(text.contains(" ▶ /crashloop [Pod] - "), "{text}");
+
+    // A prefix narrows the popup, and it matches a playbook's name as well as
+    // its command: "cl" reaches /summarise through its name "cluster-summary".
+    state.input = "/cl".into();
+    state.update_slash_suggestions();
+    let text = assistant_text(140, 40, &state);
+    assert!(text.contains("Slash Commands (1/2)"), "{text}");
+    assert!(text.contains(" ▶ /summarise - "), "{text}");
+    assert!(
+        text.contains("   /clear - Clear conversation history"),
+        "a utility without a target has no bracket: {text}"
+    );
+    assert!(!text.contains("/clear ["), "{text}");
+    assert!(!text.contains("/crashloop"), "{text}");
+
+    state.slash_suggestion_down();
+    assert!(state.apply_selected_slash_suggestion());
+    assert_eq!(state.input, "/clear ");
+    assert!(state.slash_suggestions.is_empty());
+    state.update_slash_suggestions();
+    assert!(
+        state.slash_suggestions.is_empty(),
+        "a completed command with a space offers no suggestions"
+    );
+    assert!(!state.apply_selected_slash_suggestion());
+}
+
+// ───────────────────────── assistant: selection ─────────────────────────
+
+#[test]
+fn a_selection_spanning_rows_is_highlighted_and_extracted_from_the_rendered_rows() {
+    let mut state = fresh_state();
+    state.messages.push(msg("user", "hello world"));
+    assistant_text(160, 30, &state);
+    {
+        let plain = state.plain_lines.borrow();
+        assert_eq!(plain[0], "SRElens [10:00:00]:");
+        assert_eq!(plain[3], "You [10:00:00]:");
+        assert_eq!(plain[4], "hello world");
+    }
+    state.start_selection(3, 4);
+    state.update_selection(4, 5);
+    state.finish_selection(4, 5);
+    assert_eq!(
+        state.get_selected_text().as_deref(),
+        Some("[10:00:00]:\nhello")
+    );
+    let text = assistant_text(160, 30, &state);
+    assert!(text.contains("<c> Copy Selection"), "{text}");
+    assert!(
+        text.contains("hello world"),
+        "highlighting keeps the text intact: {text}"
+    );
+
+    // Dragging backwards is normalised, so the same text comes out.
+    state.start_selection(4, 5);
+    state.finish_selection(3, 4);
+    assert_eq!(
+        state.get_selected_text().as_deref(),
+        Some("[10:00:00]:\nhello")
+    );
+    assistant_text(160, 30, &state);
+
+    // Selecting the whole of a middle row exercises the open-ended column range.
+    state.start_selection(0, 2);
+    state.finish_selection(4, 3);
+    assert_eq!(state.get_selected_text().as_deref(), Some("Elens [10:00:00]:\nHello! I am your SRElens AI Assistant. Type '/' for SRE playbooks or '/caveman' for token compression, or ask any question:\n\nYou [10:00:00]:\nhel"));
+    assistant_text(160, 30, &state);
+
+    state.clear_selection();
+    assert!(state.selection.is_none() && !state.is_selecting);
+}
+
+#[test]
+fn a_click_without_a_drag_leaves_no_selection() {
+    let mut state = fresh_state();
+    state.start_selection(2, 7);
+    assert!(state.is_selecting);
+    state.finish_selection(2, 7);
+    assert!(!state.is_selecting);
+    assert!(state.selection.is_none());
+    assert!(state.get_selected_text().is_none());
+
+    state.update_selection(5, 5);
+    assert!(
+        state.selection.is_none(),
+        "moving without a press does nothing"
+    );
+}
+
+// ───────────────────────── assistant: conversation state ─────────────────────────
+
+#[test]
+fn clearing_a_conversation_resets_everything_and_keeps_the_context_in_the_greeting() {
+    let mut state = AssistantViewState::for_context("stage");
+    state.start_turn("why is web-0 crashing?".into());
+    state.append_stream_chunk("Because");
+    state.scroll_up(3);
+    state.set_status("thinking".into());
+    state.input = "draft".into();
+    state.clear_conversation();
+    assert_eq!(state.messages.len(), 1);
+    assert!(state.messages[0].content.starts_with(
+        "Hello! I am your SRElens AI Assistant for context 'stage'. I can analyze pod crashes"
+    ));
+    assert!(state.input.is_empty() && !state.is_busy && state.busy_status.is_empty());
+    assert!(state.auto_scroll && state.scroll_offset == 0);
+
+    let mut plain = AssistantViewState::new();
+    plain.clear_conversation();
+    assert!(plain.messages[0]
+        .content
+        .starts_with("Hello! I am your SRElens AI Assistant. I can analyze pod crashes"));
+}
+
+#[test]
+fn exporting_to_markdown_records_roles_tools_statuses_and_usage() {
+    let mut state = fresh_state();
+    state.messages.push(msg("user", "why?"));
+    let mut reply = msg("assistant", "Because of OOM.");
+    reply.timestamp = String::new();
+    reply.tool_calls = vec![
+        tool("1", "bash", "kubectl top", ToolCallStatus::Running),
+        tool("2", "read", "pod.yaml", ToolCallStatus::Success),
+        tool("3", "exec", "sh", ToolCallStatus::Error("exit 1".into())),
+        tool("4", "getMcpTools", "", ToolCallStatus::Success),
+    ];
+    reply.token_usage = Some(TokenUsage {
+        prompt_tokens: 2000,
+        completion_tokens: 100,
+        cached_tokens: 1500,
+        total_tokens: 2100,
+        duration_ms: Some(4200),
+    });
+    state.messages.push(reply);
+    let mut note = msg("system", "   ");
+    note.token_usage = Some(TokenUsage {
+        total_tokens: 7,
+        duration_ms: Some(12),
+        ..Default::default()
+    });
+    state.messages.push(note);
+
+    let md = state.export_to_markdown("Anthropic", "claude-x");
+    assert!(
+        md.starts_with("# SRElens AI Assistant Conversation Export\n\n- **Exported At**: "),
+        "{md}"
+    );
+    assert!(
+        md.contains("- **Provider**: Anthropic\n- **Model**: claude-x\n\n---\n\n"),
+        "{md}"
+    );
+    assert!(
+        md.contains("### 🤖 SRElens Assistant [10:00:00]\n\nHello!"),
+        "{md}"
+    );
+    assert!(md.contains("### 👤 You [10:00:00]\n\nwhy?\n\n---"), "{md}");
+    assert!(md.contains("### 🤖 SRElens Assistant\n\n#### Executed Tools:\n- `bash`: `kubectl top` [running]\n- `read`: `pod.yaml` [ok]\n- `exec`: `sh` [exit 1]\n\nBecause of OOM.\n\n*⚡ 2,100 tokens (2,000 prompt, 100 completion • 1,500 cached) • 4.2s*\n\n---"), "{md}");
+    assert!(!md.contains("getMcpTools"), "{md}");
+    assert!(
+        md.contains(
+            "### ℹ️ System [10:00:00]\n\n*⚡ 7 tokens (0 prompt, 0 completion) • 12ms*\n\n---"
+        ),
+        "blank content is skipped: {md}"
+    );
+}
+
+#[test]
+fn saving_a_conversation_to_an_explicit_path_writes_the_markdown_there() {
+    let state = fresh_state();
+    let dir = std::path::Path::new(env!("CARGO_TARGET_TMPDIR")).join("chrome_tests");
+    std::fs::create_dir_all(&dir).expect("tmp dir");
+    let path = dir.join("export.md");
+    let written = state
+        .save_conversation_to_file("Anthropic", "claude-x", Some(path.to_str().unwrap()))
+        .expect("save");
+    assert_eq!(written, path);
+    let body = std::fs::read_to_string(&path).expect("read back");
+    assert!(body.contains("- **Model**: claude-x"), "{body}");
+    assert!(
+        body.contains("Hello! I am your SRElens AI Assistant."),
+        "{body}"
+    );
+    let _ = std::fs::remove_file(&path);
+
+    let missing = dir.join("no-such-dir").join("export.md");
+    let err = state
+        .save_conversation_to_file("p", "m", Some(missing.to_str().unwrap()))
+        .unwrap_err();
+    assert!(err.starts_with("Failed to save conversation: "), "{err}");
+}
+
+// ───────────────────────── assistant: markdown blocks ─────────────────────────
+
+#[test]
+fn headings_of_every_depth_get_their_own_marker() {
+    let lines = md("# Title\n## Section\n### Point\n#### Detail\nplain");
+    assert_eq!(
+        lines,
+        vec![
+            "",
+            "  ▌ Title",
+            "",
+            "  ▌ Section",
+            "  ● Point",
+            "    Detail",
+            "plain"
+        ]
+    );
+}
+
+#[test]
+fn horizontal_rules_blockquotes_and_lists_are_rendered_with_glyphs() {
+    let lines = md("---\n***\n> quoted **loud**\n- top\n  - nested\n* star\n+ plus\n1. first\n12. twelfth\nv1. not a list\nend.");
+    assert!(lines[0].starts_with("  ──────"), "{lines:?}");
+    assert!(lines[1].starts_with("  ──────"), "{lines:?}");
+    assert_eq!(lines[2], "  ▎ quoted loud");
+    assert_eq!(lines[3], "  • top");
+    assert_eq!(lines[4], "    ◦ nested");
+    assert_eq!(lines[5], "  • star");
+    assert_eq!(lines[6], "  • plus");
+    assert_eq!(lines[7], "  1. first");
+    assert_eq!(lines[8], "  12. twelfth");
+    assert_eq!(lines[9], "v1. not a list");
+    assert_eq!(lines[10], "end.");
+}
+
+#[test]
+fn a_dash_line_with_other_characters_is_not_a_rule() {
+    let lines = md("--- not a rule\n---");
+    assert_eq!(lines[0], "--- not a rule");
+    assert!(lines[1].starts_with("  ─────"), "{lines:?}");
+}
+
+#[test]
+fn fenced_code_blocks_are_framed_with_the_language_and_colour_comments_and_keys() {
+    let lines = md("```yaml\n# a comment\nreplicas: 3\n  // c-style\nhttp://example.com:8080/x\nplain text\n```\nafter");
+    assert_eq!(
+        lines[0],
+        format!("  ┌── yaml {}", "─".repeat(65 - "── yaml ".len()))
+    );
+    assert_eq!(lines[1], "  │ # a comment");
+    assert_eq!(lines[2], "  │ replicas: 3");
+    assert_eq!(lines[3], "  │   // c-style");
+    assert_eq!(lines[4], "  │ http://example.com:8080/x");
+    assert_eq!(lines[5], "  │ plain text");
+    assert_eq!(lines[6], format!("  └{}", "─".repeat(66)));
+    assert_eq!(lines[7], "after");
+
+    let mut out = Vec::new();
+    format_message_content(&mut out, "```yaml\nkey: value\n```");
+    let key_line = &out[1];
+    let contents: Vec<&str> = key_line.spans.iter().map(|s| s.content.as_ref()).collect();
+    assert_eq!(
+        contents,
+        vec!["  ", "│ ", "key:", " value"],
+        "key and value are separate spans"
+    );
+}
+
+#[test]
+fn an_unterminated_or_language_less_fence_still_closes_its_frame() {
+    let lines = md("```\necho hi");
+    assert!(lines[0].starts_with("  ┌── code ─"), "{lines:?}");
+    assert_eq!(lines[1], "  │ echo hi");
+    assert!(lines[2].starts_with("  └──"), "{lines:?}");
+    assert_eq!(lines.len(), 3);
+}
+
+// ───────────────────────── assistant: markdown tables ─────────────────────────
+
+fn table_lines(header: &str, rows: &[&str], width: Option<usize>) -> Vec<String> {
+    let mut out = Vec::new();
+    render_markdown_table(&mut out, header, rows, width);
+    out.iter().map(line_text).collect()
+}
+
+#[test]
+fn a_markdown_table_is_boxed_with_cleaned_cells() {
+    let lines = table_lines(
+        "| `Name` | 'Status' | \"Mem\" |",
+        &["| web-0 | Ready | 512MiB |", "| data-1 | 3.5 |"],
+        None,
+    );
+    assert_eq!(lines[0], "  ┌────────┬────────┬────────┐");
+    assert_eq!(lines[1], "  │ Name   │ Status │ Mem    │");
+    assert_eq!(lines[2], "  ├────────┼────────┼────────┤");
+    assert_eq!(lines[3], "  │ web-0  │ Ready  │ 512MiB │");
+    assert_eq!(
+        lines[4], "  │ data-1 │ 3.5    │        │",
+        "a short row is padded with empty cells"
+    );
+    assert_eq!(lines[5], "  └────────┴────────┴────────┘");
+}
+
+#[test]
+fn a_narrow_width_shrinks_the_widest_column_and_wraps_its_cells() {
+    let header = "| Pod | Message |";
+    let rows = ["| api-0 | container restarted, exit code 137/OOM-killed by kernel |"];
+    let wide = table_lines(header, &rows, None);
+    assert!(
+        wide[3].contains("container restarted, exit code 137/OOM-killed by kernel"),
+        "{wide:?}"
+    );
+    assert_eq!(wide.len(), 5);
+
+    let narrow = table_lines(header, &rows, Some(40));
+    assert!(
+        narrow.len() > 5,
+        "the message cell wraps across rows: {narrow:?}"
+    );
+    let widest = narrow.iter().map(|l| l.chars().count()).max().unwrap();
+    assert!(widest <= 40, "{narrow:?}");
+    assert!(narrow[3].starts_with("  │ api-0 │ container"), "{narrow:?}");
+    assert!(
+        narrow[4].starts_with("  │       │ "),
+        "continuation rows leave the first cell blank: {narrow:?}"
+    );
+    let joined: String = narrow[3..narrow.len() - 1]
+        .iter()
+        .map(|l| l.split('│').nth(2).unwrap().trim().to_string())
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert_eq!(
+        joined,
+        "container restarted, exit code 137/OOM-killed by kernel"
+    );
+}
+
+#[test]
+fn a_hopelessly_narrow_width_leaves_the_columns_at_their_minimum() {
+    let lines = table_lines("| a | b | c |", &["| x | y | z |"], Some(5));
+    assert_eq!(
+        lines[1], "  │ a   │ b   │ c   │",
+        "columns keep their 3-cell floor when the budget is below 4 per column"
+    );
+}
+
+#[test]
+fn an_unbreakable_cell_is_split_at_the_column_width() {
+    let lines = table_lines("| Id |", &["| abcdefghijklmnopqrstuvwxyz |"], Some(20));
+    let cells: Vec<String> = lines[3..lines.len() - 1]
+        .iter()
+        .map(|l| l.split('│').nth(1).unwrap().trim().to_string())
+        .collect();
+    assert!(cells.len() >= 2, "{lines:?}");
+    assert_eq!(cells.concat(), "abcdefghijklmnopqrstuvwxyz");
+
+    let with_blank = table_lines("| Note |", &["| first\n\nsecond |"], None);
+    assert!(with_blank.len() >= 5, "{with_blank:?}");
+}
+
+#[test]
+fn a_table_inside_a_message_is_detected_and_a_lone_pipe_row_is_not() {
+    let lines = md("Summary:\n| Pod | Ready |\n|-----|:-----:|\n| web-0 | True |\n| web-1 | False |\ndone\n| orphan |");
+    assert_eq!(lines[0], "Summary:");
+    assert!(lines[1].starts_with("  ┌"), "{lines:?}");
+    assert!(lines[2].contains("│ Pod   │ Ready │"), "{lines:?}");
+    assert!(lines[4].contains("│ web-0 │ True  │"), "{lines:?}");
+    assert!(lines[5].contains("│ web-1 │ False │"), "{lines:?}");
+    assert!(lines[6].starts_with("  └"), "{lines:?}");
+    assert_eq!(lines[7], "done");
+    assert_eq!(
+        lines[8], "| orphan |",
+        "a pipe row with no separator beneath it is plain text"
+    );
+
+    let mut out = Vec::new();
+    format_message_content_with_width(&mut out, "| A | B |\n|---|---|\n| 1 | 2 |", Some(200));
+    assert!(line_text(&out[0]).starts_with("  ┌"));
+}
+
+#[test]
+fn table_rows_are_never_wrapped_but_long_words_are_split_at_the_width() {
+    let boxed = Line::from("  │ a very long table row that would otherwise wrap around │");
+    assert_eq!(wrap_line(boxed, 10).len(), 1);
+
+    let word = Line::from("x".repeat(45));
+    let wrapped: Vec<String> = wrap_line(word, 20).iter().map(line_text).collect();
+    assert_eq!(wrapped, vec!["x".repeat(20), "x".repeat(20), "x".repeat(5)]);
+
+    let mixed: Vec<String> = wrap_line(Line::from(format!("short {} tail", "y".repeat(30))), 12)
+        .iter()
+        .map(line_text)
+        .collect();
+    assert_eq!(
+        mixed,
+        vec!["short ", "yyyyyyyyyyyy", "yyyyyyyyyyyy", "yyyyyy tail"]
+    );
+
+    assert_eq!(wrap_line(Line::from("untouched"), 0).len(), 1);
+    assert_eq!(line_text(&wrap_line(Line::from(""), 5)[0]), "");
+}
+
+// ───────────────────────── assistant: inline markdown ─────────────────────────
+
+fn span_texts(input: &str) -> Vec<String> {
+    parse_inline_markdown(input)
+        .iter()
+        .map(|s| s.content.to_string())
+        .collect()
+}
+
+#[test]
+fn inline_markdown_splits_bold_italic_links_strikethrough_and_code_into_spans() {
+    assert_eq!(
+        span_texts("see ***both*** and **bold** and *it* and [docs](https://k8s.io) and ~~gone~~ and `code` end"),
+        vec![
+            "see ", "both", " and ", "bold", " and ", "it", " and ", "docs", " (https://k8s.io)", " and ", "gone", " and ", "code", " end",
+        ]
+    );
+}
+
+#[test]
+fn unterminated_inline_markers_consume_to_the_end_of_the_line() {
+    assert_eq!(
+        span_texts("***open"),
+        vec!["op", "en"],
+        "the bold-italic scanner stops two chars early when unterminated"
+    );
+    assert_eq!(
+        span_texts("**open"),
+        vec!["ope", "n"],
+        "the bold scanner stops one char early"
+    );
+    assert_eq!(span_texts("*open"), vec!["open"]);
+    assert_eq!(span_texts("~~open"), vec!["ope", "n"]);
+    assert_eq!(span_texts("`open"), vec!["open"]);
+}
+
+#[test]
+fn brackets_without_a_url_and_escaped_asterisks_stay_literal() {
+    assert_eq!(span_texts("[not a link] here"), vec!["[not a link] here"]);
+    assert_eq!(span_texts("[label](no close"), vec!["[label](no close"]);
+    assert_eq!(span_texts("[label] (spaced)"), vec!["[label] (spaced)"]);
+    assert_eq!(span_texts("2 \\* 3 = 6"), vec!["2 \\* 3 = 6"]);
+    assert_eq!(span_texts("a~b"), vec!["a~b"]);
+}
+
+// ───────────────────────── through the App ─────────────────────────
+
+#[tokio::test]
+async fn the_app_draws_the_help_overlay_and_closes_it_on_escape() {
+    let (mut app, _rx) = common::app().await;
+    app.show_help = true;
+    let text = common::render_app(&mut app, 160, 60);
+    assert!(text.contains("Keybindings Cheat Sheet"), "{text}");
+    assert!(text.contains("SRElens Superpowers"), "{text}");
+    app.handle_key_event(common::key(KeyCode::Esc)).await;
+    assert!(!app.show_help);
+    let text = common::render_app(&mut app, 160, 60);
+    assert!(!text.contains("Keybindings Cheat Sheet"), "{text}");
+}
+
+#[tokio::test]
+async fn the_app_draws_whatever_modal_is_open_over_the_current_view() {
+    let (mut app, _rx) = common::app().await;
+    app.modal = Some(confirm(true));
+    let text = common::render_app(&mut app, 120, 40);
+    assert!(text.contains(" Delete Pod "), "{text}");
+    assert!(text.contains("[Enter/y] to Delete"), "{text}");
+
+    app.modal = Some(Modal::Scale {
+        workload_name: "web".into(),
+        current_replicas: 2,
+        input: "4".into(),
+    });
+    let text = common::render_app(&mut app, 120, 40);
+    assert!(text.contains(" Scale Workload: web "), "{text}");
+    assert!(text.contains("4█"), "{text}");
+}
+
+#[tokio::test]
+async fn the_app_renders_the_assistant_view_with_the_active_context_in_its_title() {
+    let (mut app, _rx) = common::app().await;
+    app.active_view = ActiveView::Assistant;
+    app.assistant_state.caveman_level = Some(CavemanLevel::Lite);
+    let text = common::render_app(&mut app, 200, 40);
+    assert!(
+        text.contains(" SRElens AI Assistant @test-cluster  [🦖  CAVEMAN: LITE]["),
+        "{text}"
+    );
+    assert!(text.contains("for context 'test-cluster'"), "{text}");
+    common::type_str(&mut app, "/oo").await;
+    let text = common::render_app(&mut app, 200, 40);
+    assert!(
+        text.contains("/oom"),
+        "typing a slash prefix opens the playbook popup: {text}"
+    );
+    assert!(text.contains("/oo█"), "{text}");
+}

--- a/apps/tui/tests/chrome_tests.rs
+++ b/apps/tui/tests/chrome_tests.rs
@@ -8,6 +8,7 @@
 mod common;
 
 use std::cell::RefCell;
+use std::time::Duration;
 
 use crossterm::event::KeyCode;
 use ratatui::layout::Rect;
@@ -81,6 +82,25 @@ fn fresh_state() -> AssistantViewState {
     let mut state = AssistantViewState::new();
     state.messages[0].timestamp = "10:00:00".to_string();
     state
+}
+
+/// The `(Ns elapsed)` count from the busy line that starts with `prefix`.
+/// Panics with the frame if the line or the count is not there, so a renderer
+/// that stops showing elapsed time fails loudly rather than silently.
+fn elapsed_seconds(text: &str, prefix: &str) -> u64 {
+    let line = text
+        .lines()
+        .find(|l| l.contains(prefix))
+        .unwrap_or_else(|| panic!("no busy line starting {prefix:?}: {text}"));
+    let (_, after) = line
+        .split_once(&format!("{prefix} ("))
+        .unwrap_or_else(|| panic!("no elapsed badge on {line:?}"));
+    let (count, _) = after
+        .split_once("s elapsed)")
+        .unwrap_or_else(|| panic!("no elapsed badge on {line:?}"));
+    count
+        .parse()
+        .unwrap_or_else(|e| panic!("elapsed count {count:?} is not a number: {e}"))
 }
 
 fn status_props(mode: &InputMode) -> StatusBarProps<'_> {
@@ -1315,14 +1335,21 @@ fn a_busy_assistant_shows_a_spinner_status_and_elapsed_seconds() {
         "{text}"
     );
 
+    // Seed a known age instead of reading the clock and asserting an exact
+    // count: on a loaded runner a second can pass between `Instant::now()`
+    // and the render, and a CORRECT renderer would then print 8s and fail an
+    // equality check. Assert the floor instead — that the elapsed seconds are
+    // the seeded age or more, which a renderer stuck at 0 still fails.
     state.set_status("Running kubectl get pods".into());
-    state.busy_start = Some(std::time::Instant::now());
+    state.busy_start = std::time::Instant::now().checked_sub(Duration::from_secs(7));
+    assert!(
+        state.busy_start.is_some(),
+        "the clock must support a 7s offset"
+    );
     state.tick();
     let text = assistant_text(160, 30, &state);
-    assert!(
-        text.contains("⠼ Running kubectl get pods (0s elapsed)"),
-        "{text}"
-    );
+    let seconds = elapsed_seconds(&text, "⠼ Running kubectl get pods");
+    assert!(seconds >= 7, "expected at least the seeded 7s: {text}");
 
     state.finish_turn();
     assert!(!state.is_busy && state.busy_start.is_none());

--- a/apps/tui/tests/common/mod.rs
+++ b/apps/tui/tests/common/mod.rs
@@ -1,0 +1,123 @@
+//! Shared helpers for the TUI's integration tests.
+//!
+//! Every test file under `tests/` is its own crate; `mod common;` pulls this
+//! in. Nothing here touches a cluster: `App::new` with no kubeconfig paths
+//! resolves zero contexts, falls back to a `default` context, and every
+//! capability call fails fast with "context not found" instead of hanging.
+
+#![allow(dead_code)]
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+use ratatui::backend::TestBackend;
+use ratatui::{Frame, Terminal};
+use srelens_tui::app::App;
+use srelens_tui::event::AppEvent;
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
+
+/// An `App` with no kubeconfig, no cluster, and the given context/namespace,
+/// plus the receiving end of its event channel so a test can observe what the
+/// app emitted.
+pub async fn app_with(context: &str, namespace: &str) -> (App, UnboundedReceiver<AppEvent>) {
+    let (tx, rx) = unbounded_channel();
+    let app = App::new(
+        Some(context.to_string()),
+        Some(namespace.to_string()),
+        false,
+        None,
+        vec![],
+        tx,
+    )
+    .await
+    .expect("App::new never needs a cluster");
+    (app, rx)
+}
+
+/// `app_with("test-cluster", "default")`.
+pub async fn app() -> (App, UnboundedReceiver<AppEvent>) {
+    app_with("test-cluster", "default").await
+}
+
+/// A plain key press.
+pub fn key(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::NONE)
+}
+
+/// A character key press.
+pub fn ch(c: char) -> KeyEvent {
+    key(KeyCode::Char(c))
+}
+
+/// A key press with Ctrl held.
+pub fn ctrl(c: char) -> KeyEvent {
+    KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL)
+}
+
+/// A key press with Shift held.
+pub fn shift(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::SHIFT)
+}
+
+/// Type a string one character at a time through `App::handle_key_event`.
+pub async fn type_str(app: &mut App, s: &str) {
+    for c in s.chars() {
+        app.handle_key_event(ch(c)).await;
+    }
+}
+
+/// A left-button mouse event of the given kind at a cell.
+pub fn mouse(kind: MouseEventKind, column: u16, row: u16) -> MouseEvent {
+    MouseEvent {
+        kind,
+        column,
+        row,
+        modifiers: KeyModifiers::NONE,
+    }
+}
+
+/// A left click at a cell.
+pub fn click(column: u16, row: u16) -> MouseEvent {
+    mouse(MouseEventKind::Down(MouseButton::Left), column, row)
+}
+
+/// Render one frame at the given size through any drawing closure and return
+/// the screen as text, one `String` per row, trailing spaces trimmed.
+pub fn render_lines<F>(width: u16, height: u16, draw: F) -> Vec<String>
+where
+    F: FnOnce(&mut Frame),
+{
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    terminal.draw(draw).expect("draw");
+    let buffer = terminal.backend().buffer();
+    (0..buffer.area.height)
+        .map(|y| {
+            let mut line = String::new();
+            for x in 0..buffer.area.width {
+                line.push_str(buffer[(x, y)].symbol());
+            }
+            line.trim_end().to_string()
+        })
+        .collect()
+}
+
+/// `render_lines` joined with newlines, for `contains` assertions.
+pub fn render_text<F>(width: u16, height: u16, draw: F) -> String
+where
+    F: FnOnce(&mut Frame),
+{
+    render_lines(width, height, draw).join("\n")
+}
+
+/// Render the whole app at the given size and return the screen text.
+pub fn render_app(app: &mut App, width: u16, height: u16) -> String {
+    render_text(width, height, |f| app.render(f))
+}
+
+/// Drain every event the app has emitted so far.
+pub fn drain(rx: &mut UnboundedReceiver<AppEvent>) -> Vec<AppEvent> {
+    let mut out = Vec::new();
+    while let Ok(ev) = rx.try_recv() {
+        out.push(ev);
+    }
+    out
+}

--- a/apps/tui/tests/core_logic_tests.rs
+++ b/apps/tui/tests/core_logic_tests.rs
@@ -1,0 +1,1385 @@
+//! Behavioural tests for the TUI's pure core: command resolution, deep links,
+//! AI settings, skills, theme, the event/sink plumbing, and the native agent
+//! bridge driven against an in-process fake OpenAI-compatible endpoint on
+//! loopback (no real provider, no agent subprocess).
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use ratatui::style::{Color, Modifier, Style};
+use serde_json::{json, Value};
+use srelens_kube::client_cache::ClientCache;
+use srelens_llm::types::{ProviderKind, Turn};
+use srelens_llm::{ProviderConfig, ToolInvoker};
+use srelens_streams::EventSink;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
+
+use srelens_tui::agent::{build_mcp_server, run_boxed_cursor_turn, run_native_agent_turn, McpToolInvoker};
+use srelens_tui::ai_config::{
+    default_base_url_for_provider, default_model_for_provider, env_var_for_provider, provider_display_name,
+    provider_slug, AiProvider, AiSettings, ALL_PROVIDERS,
+};
+use srelens_tui::ai_skills::{
+    expand_slash_command, load_user_skills_dir, match_slash_commands, parse_caveman_command, CavemanCommandAction,
+    CavemanLevel, BUILTIN_PLAYBOOKS,
+};
+use srelens_tui::commands::{
+    command_suggestions, command_suggestions_with_crds, resolve_command, resolve_command_with_crds, CommandTarget,
+    CrdMeta, DynamicCommandDef, ResourceKind, COMMAND_REGISTRY,
+};
+use srelens_tui::deep_link::DeepLink;
+use srelens_tui::event::{AppEvent, EventHandler};
+use srelens_tui::sink::TuiSink;
+use srelens_tui::theme::{status_style, Theme};
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/// Every `ActionResult` the agent emitted, as `(title, result)`, in order.
+fn action_results(rx: &mut UnboundedReceiver<AppEvent>) -> Vec<(String, Result<String, String>)> {
+    let mut out = Vec::new();
+    while let Ok(ev) = rx.try_recv() {
+        if let AppEvent::ActionResult { title, result } = ev {
+            out.push((title, result));
+        }
+    }
+    out
+}
+
+fn invoker() -> Arc<McpToolInvoker> {
+    let cache = ClientCache::new(PathBuf::from("/nonexistent"));
+    Arc::new(McpToolInvoker::new(build_mcp_server(cache, vec![])))
+}
+
+fn crd(plural: &str, singular: &str, kind: &str, group: &str, short_names: &[&str]) -> CrdMeta {
+    CrdMeta {
+        crd_name: format!("{}.{}", plural, group),
+        group: group.to_string(),
+        version: "v1".to_string(),
+        kind: kind.to_string(),
+        plural: plural.to_string(),
+        singular: singular.to_string(),
+        namespaced: true,
+        short_names: short_names.iter().map(|s| s.to_string()).collect(),
+        printer_columns: vec![],
+    }
+}
+
+fn cilium_pool() -> CrdMeta {
+    crd(
+        "ciliumloadbalancerippools",
+        "ciliumloadbalancerippool",
+        "CiliumLoadBalancerIPPool",
+        "cilium.io",
+        &["ippool"],
+    )
+}
+
+// ---------------------------------------------------------------------------
+// A fake OpenAI-compatible endpoint on loopback
+// ---------------------------------------------------------------------------
+
+/// One scripted HTTP reply: status code and raw body (SSE `data:` lines).
+struct Reply {
+    status: u16,
+    body: String,
+}
+
+fn sse(events: &[&str]) -> String {
+    let mut s = String::new();
+    for e in events {
+        s.push_str("data: ");
+        s.push_str(e);
+        s.push_str("\n\n");
+    }
+    s.push_str("data: [DONE]\n\n");
+    s
+}
+
+fn text_reply(chunks: &[&str]) -> Reply {
+    let mut events: Vec<String> =
+        chunks.iter().map(|c| json!({"choices":[{"delta":{"content":c}}]}).to_string()).collect();
+    events.push(json!({"choices":[{"delta":{},"finish_reason":"stop"}]}).to_string());
+    let refs: Vec<&str> = events.iter().map(String::as_str).collect();
+    Reply { status: 200, body: sse(&refs) }
+}
+
+/// A reply that requests the given tool calls: `(id, name, raw arguments string)`.
+fn tool_call_reply(calls: &[(&str, &str, &str)]) -> Reply {
+    let deltas: Vec<Value> = calls
+        .iter()
+        .enumerate()
+        .map(|(i, (id, name, args))| {
+            json!({"index": i, "id": id, "function": {"name": name, "arguments": args}})
+        })
+        .collect();
+    let events = vec![
+        json!({"choices":[{"delta":{"tool_calls": deltas}}]}).to_string(),
+        json!({"choices":[{"delta":{},"finish_reason":"tool_calls"}]}).to_string(),
+    ];
+    let refs: Vec<&str> = events.iter().map(String::as_str).collect();
+    Reply { status: 200, body: sse(&refs) }
+}
+
+struct FakeLlm {
+    base_url: String,
+    /// Every request body the provider sent, parsed, in order.
+    requests: Arc<Mutex<Vec<Value>>>,
+}
+
+/// Read one HTTP request off the socket and return its parsed JSON body.
+async fn read_request(sock: &mut tokio::net::TcpStream) -> Value {
+    let mut buf = Vec::new();
+    let header_end = loop {
+        let mut chunk = [0u8; 4096];
+        let n = sock.read(&mut chunk).await.expect("read request");
+        if n == 0 {
+            break None;
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+            break Some(pos + 4);
+        }
+    };
+    let Some(header_end) = header_end else {
+        return Value::Null;
+    };
+    let headers = String::from_utf8_lossy(&buf[..header_end]).to_string();
+    let content_length: usize = headers
+        .lines()
+        .find_map(|l| {
+            let (k, v) = l.split_once(':')?;
+            k.trim().eq_ignore_ascii_case("content-length").then(|| v.trim().parse().ok())?
+        })
+        .unwrap_or(0);
+    while buf.len() < header_end + content_length {
+        let mut chunk = [0u8; 4096];
+        let n = sock.read(&mut chunk).await.expect("read body");
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&chunk[..n]);
+    }
+    serde_json::from_slice(&buf[header_end..header_end + content_length]).unwrap_or(Value::Null)
+}
+
+/// Serve the scripted replies, one per connection, in order. A request past
+/// the end of the script gets a 500 so a runaway loop fails loudly.
+async fn fake_llm(replies: Vec<Reply>) -> FakeLlm {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind loopback");
+    let base_url = format!("http://{}/v1", listener.local_addr().expect("local addr"));
+    let requests = Arc::new(Mutex::new(Vec::new()));
+    let seen = requests.clone();
+    tokio::spawn(async move {
+        let mut replies = replies.into_iter();
+        loop {
+            let Ok((mut sock, _)) = listener.accept().await else { break };
+            let body = read_request(&mut sock).await;
+            seen.lock().unwrap().push(body);
+            let reply = replies.next().unwrap_or(Reply { status: 500, body: "script exhausted".into() });
+            let response = format!(
+                "HTTP/1.1 {} X\r\nContent-Type: text/event-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                reply.status,
+                reply.body.len(),
+                reply.body
+            );
+            let _ = sock.write_all(response.as_bytes()).await;
+            let _ = sock.shutdown().await;
+        }
+    });
+    FakeLlm { base_url, requests }
+}
+
+/// `HttpProvider::new` builds a `reqwest::Client` with `rustls-no-provider`,
+/// which panics ("No rustls crypto provider is configured") unless a process
+/// default was installed earlier. In the running TUI that happens as a side
+/// effect of the first kube `Client` build; a fresh test process has to do the
+/// same, so mirror production by building one (no network involved).
+fn ensure_tls_provider() {
+    let config = srelens_kube::kube::Config::new("https://127.0.0.1:6443".parse().expect("uri"));
+    srelens_kube::kube::Client::try_from(config).expect("kube client builds");
+}
+
+fn provider_config(base_url: &str) -> ProviderConfig {
+    ensure_tls_provider();
+    ProviderConfig {
+        kind: ProviderKind::OpenAiCompatible,
+        api_key: "test-key".into(),
+        base_url: base_url.to_string(),
+        model: "fake-model".into(),
+        max_tokens: 256,
+    }
+}
+
+/// Run one native turn against `llm` and return the emitted action results
+/// plus the history the turn left behind.
+async fn native_turn(
+    llm: &FakeLlm,
+    prior: Vec<Turn>,
+    prompt: &str,
+) -> (Vec<(String, Result<String, String>)>, Vec<Turn>) {
+    let (tx, mut rx) = unbounded_channel();
+    let history = Arc::new(tokio::sync::Mutex::new(prior));
+    run_native_agent_turn(
+        provider_config(&llm.base_url),
+        invoker(),
+        history.clone(),
+        prompt.to_string(),
+        "kind-dev".into(),
+        "payments".into(),
+        tx,
+        30,
+    )
+    .await;
+    let events = action_results(&mut rx);
+    let turns = history.lock().await.clone();
+    (events, turns)
+}
+
+fn usage_fields(payload: &str) -> Vec<u64> {
+    payload.split('|').map(|f| f.parse().expect("numeric usage field")).collect()
+}
+
+// ---------------------------------------------------------------------------
+// agent.rs: McpToolInvoker
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn tool_aliases_are_provider_safe_and_stable_across_repeated_listings() {
+    let inv = invoker();
+    let first: Vec<String> = inv.list_tools().await.unwrap().into_iter().map(|t| t.name).collect();
+    let second: Vec<String> = inv.list_tools().await.unwrap().into_iter().map(|t| t.name).collect();
+
+    assert!(first.iter().all(|n| !n.contains('.')), "dots must be rewritten: {:?}", first);
+    assert!(first.contains(&"k8s_listPods".to_string()));
+    assert!(first.contains(&"ping".to_string()));
+    // Re-listing maps each id to the alias it already owns instead of
+    // growing a trailing underscore.
+    assert_eq!(first, second);
+}
+
+#[tokio::test]
+async fn list_tools_carries_description_schema_and_read_only_hint() {
+    let inv = invoker();
+    let tools = inv.list_tools().await.unwrap();
+    let ping = tools.iter().find(|t| t.name == "ping").expect("ping tool");
+    assert!(ping.read_only);
+    assert!(ping.description.contains("health check"));
+    assert!(ping.input_schema.is_object());
+    let delete = tools.iter().find(|t| t.name == "k8s_deleteContext").expect("deleteContext tool");
+    assert!(!delete.read_only);
+}
+
+#[tokio::test]
+async fn calling_a_read_only_tool_returns_its_output_as_a_clean_result() {
+    let inv = invoker();
+    let res = inv.call_tool("ping", &json!({"hello": "world"})).await.unwrap();
+    assert!(!res.is_error);
+    assert!(!res.denied);
+    let body: Value = serde_json::from_str(&res.content).expect("ping echoes JSON");
+    assert_eq!(body["pong"]["hello"], "world");
+}
+
+#[tokio::test]
+async fn a_destructive_tool_called_by_alias_is_denied_by_the_policy() {
+    let inv = invoker();
+    inv.list_tools().await.unwrap();
+    let res = inv.call_tool("k8s_deleteContext", &json!({"context": "prod"})).await.unwrap();
+    assert!(res.denied, "FlagGated(false, ..) must refuse destructive calls: {:?}", res);
+    assert!(res.is_error);
+    assert!(res.content.contains("k8s.deleteContext"), "reason names the real tool: {}", res.content);
+}
+
+#[tokio::test]
+async fn an_unknown_tool_name_is_a_tool_error_not_a_transport_failure() {
+    let inv = invoker();
+    let res = inv.call_tool("definitely_not_a_tool", &json!({})).await.unwrap();
+    assert!(res.is_error);
+    assert!(!res.denied);
+    assert!(!res.content.is_empty());
+}
+
+#[tokio::test]
+async fn a_tool_that_needs_a_missing_cluster_reports_an_error_result() {
+    let inv = invoker();
+    inv.list_tools().await.unwrap();
+    let res = inv.call_tool("k8s_listPods", &json!({"context": "nowhere", "namespace": "default"})).await.unwrap();
+    assert!(res.is_error);
+    assert!(!res.denied);
+    assert!(!res.content.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// agent.rs: run_native_agent_turn against the fake endpoint
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_native_turn_streams_text_thinking_usage_and_done_in_order() {
+    let events = vec![
+        json!({"choices":[{"delta":{"reasoning_content":"let me think"}}]}).to_string(),
+        json!({"choices":[{"delta":{"content":"Hel"}}]}).to_string(),
+        json!({"choices":[{"delta":{"content":"lo"}}]}).to_string(),
+        json!({"choices":[{"delta":{},"finish_reason":"stop"}]}).to_string(),
+    ];
+    let refs: Vec<&str> = events.iter().map(String::as_str).collect();
+    let llm = fake_llm(vec![Reply { status: 200, body: sse(&refs) }]).await;
+
+    let (results, turns) = native_turn(&llm, vec![], "how are the pods?").await;
+
+    assert_eq!(results[0], ("ai_status:kind-dev".into(), Ok("let me think".into())));
+    assert_eq!(results[1], ("ai_chunk:kind-dev".into(), Ok("Hel".into())));
+    assert_eq!(results[2], ("ai_chunk:kind-dev".into(), Ok("lo".into())));
+    assert_eq!(results[3].0, "ai_usage:kind-dev");
+    let usage = usage_fields(results[3].1.as_ref().unwrap());
+    let prompt_est = ("how are the pods?".len() + 200) / 4;
+    assert_eq!(usage[0], prompt_est as u64);
+    assert_eq!(usage[1], 1, "5 output chars / 4");
+    assert_eq!(usage[2], 0);
+    assert_eq!(usage[3], prompt_est as u64 + 1);
+    assert_eq!(results[4], ("ai_done:kind-dev".into(), Ok(String::new())));
+    assert_eq!(results.len(), 5);
+
+    // The reply is recorded so a follow-up sees it, behind the enriched prompt.
+    assert_eq!(turns.len(), 2);
+    assert_eq!(
+        turns[0],
+        Turn::User("[Active Kubernetes Context: \"kind-dev\", Namespace: \"payments\"]\n\nhow are the pods?".into())
+    );
+    assert_eq!(turns[1], Turn::Assistant { text: "Hello".into(), tool_calls: vec![] });
+
+    // The provider saw the enriched prompt and the tool catalogue.
+    let requests = llm.requests.lock().unwrap();
+    assert_eq!(requests.len(), 1);
+    let messages = requests[0]["messages"].as_array().unwrap();
+    let user = messages.iter().find(|m| m["role"] == "user").expect("user message");
+    assert!(user["content"].as_str().unwrap().starts_with("[Active Kubernetes Context: \"kind-dev\""));
+    assert!(requests[0]["tools"].as_array().unwrap().iter().any(|t| t["function"]["name"] == "ping"));
+}
+
+#[tokio::test]
+async fn a_native_turn_runs_a_tool_call_and_reports_start_and_completion() {
+    let llm = fake_llm(vec![tool_call_reply(&[("call_1", "ping", "{\"x\":1}")]), text_reply(&["pong ok"])]).await;
+
+    let (results, turns) = native_turn(&llm, vec![], "ping it").await;
+
+    let titles: Vec<&str> = results.iter().map(|(t, _)| t.as_str()).collect();
+    assert_eq!(
+        titles,
+        vec![
+            "ai_status:kind-dev",
+            "ai_tool_start:kind-dev",
+            "ai_tool_done:kind-dev",
+            "ai_chunk:kind-dev",
+            "ai_usage:kind-dev",
+            "ai_done:kind-dev",
+        ]
+    );
+    assert_eq!(results[0].1, Ok("Executing ping...".into()));
+    assert_eq!(results[1].1, Ok("call_1|ping|{\"x\":1}".into()));
+    assert_eq!(results[2].1, Ok("call_1|ok".into()));
+    assert_eq!(results[3].1, Ok("pong ok".into()));
+
+    // User, assistant(tool call), tool results, assistant(final).
+    assert_eq!(turns.len(), 4);
+    assert!(matches!(&turns[1], Turn::Assistant { tool_calls, .. } if tool_calls.len() == 1));
+    assert!(matches!(&turns[2], Turn::ToolResults(r) if r.len() == 1 && !r[0].is_error));
+    assert_eq!(turns[3], Turn::Assistant { text: "pong ok".into(), tool_calls: vec![] });
+
+    // The second request fed the tool output back to the model.
+    let requests = llm.requests.lock().unwrap();
+    assert_eq!(requests.len(), 2);
+    let tool_msg = requests[1]["messages"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|m| m["role"] == "tool")
+        .expect("tool result message");
+    assert!(tool_msg["content"].as_str().unwrap().contains("pong"));
+}
+
+#[tokio::test]
+async fn tool_call_previews_cover_object_string_and_null_arguments_and_every_status() {
+    let llm = fake_llm(vec![
+        tool_call_reply(&[
+            ("c_obj", "no_such_tool", "{\"a\":1}"),
+            ("c_str", "k8s_deleteContext", "\"just text\""),
+            ("c_null", "ping", "null"),
+        ]),
+        text_reply(&["done"]),
+    ])
+    .await;
+
+    let (results, _) = native_turn(&llm, vec![], "mixed").await;
+    let starts: Vec<&str> = results
+        .iter()
+        .filter(|(t, _)| t == "ai_tool_start:kind-dev")
+        .map(|(_, r)| r.as_ref().unwrap().as_str())
+        .collect();
+    assert_eq!(starts, vec!["c_obj|no_such_tool|{\"a\":1}", "c_str|k8s_deleteContext|just text", "c_null|ping|"]);
+
+    let dones: Vec<&str> = results
+        .iter()
+        .filter(|(t, _)| t == "ai_tool_done:kind-dev")
+        .map(|(_, r)| r.as_ref().unwrap().as_str())
+        .collect();
+    assert_eq!(dones, vec!["c_obj|error", "c_str|denied", "c_null|ok"]);
+
+    let statuses: Vec<&str> = results
+        .iter()
+        .filter(|(t, _)| t == "ai_status:kind-dev")
+        .map(|(_, r)| r.as_ref().unwrap().as_str())
+        .collect();
+    assert_eq!(statuses, vec!["Executing no_such_tool...", "Executing k8s_deleteContext...", "Executing ping..."]);
+}
+
+#[tokio::test]
+async fn a_provider_error_item_is_shown_as_an_error_chunk_and_history_is_kept() {
+    let err = json!({"error": {"message": "quota exceeded"}}).to_string();
+    let llm = fake_llm(vec![Reply { status: 200, body: sse(&[err.as_str()]) }]).await;
+    let prior = vec![Turn::User("earlier".into()), Turn::Assistant { text: "ok".into(), tool_calls: vec![] }];
+
+    let (results, turns) = native_turn(&llm, prior.clone(), "again").await;
+
+    assert_eq!(results[0], ("ai_chunk:kind-dev".into(), Ok("\n[Error: quota exceeded]".into())));
+    assert_eq!(results[1].0, "ai_usage:kind-dev");
+    assert_eq!(results[2], ("ai_done:kind-dev".into(), Ok(String::new())));
+    assert_eq!(results.len(), 3);
+    // The failed turn is discarded: the next message continues from `prior`.
+    assert_eq!(turns, prior);
+}
+
+#[tokio::test]
+async fn an_http_failure_from_the_provider_is_reported_as_an_agent_error() {
+    let llm = fake_llm(vec![Reply { status: 401, body: json!({"error": {"message": "bad key"}}).to_string() }]).await;
+
+    let (results, turns) = native_turn(&llm, vec![], "hi").await;
+
+    assert_eq!(results[0].0, "ai_usage:kind-dev");
+    assert_eq!(results[1].0, "ai_chunk:kind-dev");
+    let err = results[1].1.as_ref().unwrap_err();
+    assert!(err.starts_with("AI Agent Error: "), "{err}");
+    assert!(err.contains("bad key"), "{err}");
+    assert_eq!(results[2], ("ai_done:kind-dev".into(), Ok(String::new())));
+    assert!(turns.is_empty(), "a failed turn leaves history untouched");
+}
+
+#[tokio::test]
+async fn a_stream_that_ends_without_a_terminal_marker_is_an_agent_error() {
+    let body = format!("data: {}\n\n", json!({"choices":[{"delta":{"content":"partial"}}]}));
+    let llm = fake_llm(vec![Reply { status: 200, body }]).await;
+
+    let (results, turns) = native_turn(&llm, vec![], "hi").await;
+
+    assert_eq!(results[0], ("ai_chunk:kind-dev".into(), Ok("partial".into())));
+    let err = results[2].1.as_ref().unwrap_err();
+    assert!(err.contains("ended before signaling completion"), "{err}");
+    assert!(turns.is_empty());
+}
+
+#[tokio::test]
+async fn history_is_capped_at_forty_turns_after_a_successful_turn() {
+    let llm = fake_llm(vec![text_reply(&["fresh reply"])]).await;
+    let prior: Vec<Turn> = (0..44)
+        .map(|i| {
+            if i % 2 == 0 {
+                Turn::User(format!("u{i}"))
+            } else {
+                Turn::Assistant { text: format!("a{i}"), tool_calls: vec![] }
+            }
+        })
+        .collect();
+
+    let (_, turns) = native_turn(&llm, prior, "latest").await;
+
+    assert_eq!(turns.len(), 40);
+    // 44 + 2 new = 46; the oldest six were dropped, so the window starts at u6.
+    assert_eq!(turns[0], Turn::User("u6".into()));
+    assert_eq!(turns[39], Turn::Assistant { text: "fresh reply".into(), tool_calls: vec![] });
+}
+
+#[tokio::test]
+async fn a_native_turn_that_cannot_reach_the_provider_still_finishes_cleanly() {
+    // Bind then drop, so the port is closed and the connection is refused.
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base_url = format!("http://{}/v1", listener.local_addr().unwrap());
+    drop(listener);
+    let llm = FakeLlm { base_url, requests: Arc::new(Mutex::new(Vec::new())) };
+
+    let (results, _) = native_turn(&llm, vec![], "hi").await;
+
+    let titles: Vec<&str> = results.iter().map(|(t, _)| t.as_str()).collect();
+    assert_eq!(titles, vec!["ai_usage:kind-dev", "ai_chunk:kind-dev", "ai_done:kind-dev"]);
+    assert!(results[1].1.as_ref().unwrap_err().starts_with("AI Agent Error: network error"));
+}
+
+// ---------------------------------------------------------------------------
+// agent.rs: run_boxed_cursor_turn without a cursor-agent binary
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_boxed_cursor_turn_reports_a_missing_binary_and_finishes() {
+    let dir = tempfile::tempdir().unwrap();
+    let missing = dir.path().join("no-such-cursor-agent").to_string_lossy().to_string();
+    let (tx, mut rx) = unbounded_channel();
+    let cache = ClientCache::new(PathBuf::from("/nonexistent"));
+
+    run_boxed_cursor_turn(
+        missing,
+        "gpt-x".into(),
+        Some("cursor-test-key".into()),
+        "what is wrong?".into(),
+        "kind-dev".into(),
+        "default".into(),
+        cache,
+        vec![],
+        tx,
+        30,
+    )
+    .await;
+
+    let results = action_results(&mut rx);
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0].0, "ai_chunk:kind-dev");
+    let err = results[0].1.as_ref().unwrap_err();
+    assert!(err.starts_with("Failed to launch cursor-agent: "), "{err}");
+    assert_eq!(results[1], ("ai_done:kind-dev".into(), Ok(String::new())));
+}
+
+// ---------------------------------------------------------------------------
+// event.rs
+// ---------------------------------------------------------------------------
+
+async fn next_non_tick(handler: &mut EventHandler) -> AppEvent {
+    loop {
+        match handler.recv().await.expect("channel open") {
+            AppEvent::Tick => continue,
+            other => return other,
+        }
+    }
+}
+
+#[tokio::test]
+async fn events_sent_on_the_handler_channel_arrive_in_order() {
+    let mut handler = EventHandler::new(Duration::from_secs(3600));
+    handler.tx.send(AppEvent::Paste("pasted".into())).unwrap();
+    handler.tx.send(AppEvent::Resize(80, 24)).unwrap();
+
+    assert!(matches!(next_non_tick(&mut handler).await, AppEvent::Paste(s) if s == "pasted"));
+    assert!(matches!(next_non_tick(&mut handler).await, AppEvent::Resize(80, 24)));
+}
+
+#[tokio::test]
+async fn try_recv_hands_back_a_queued_event_and_pausing_does_not_close_the_channel() {
+    let mut handler = EventHandler::new(Duration::from_secs(3600));
+    handler.pause();
+    handler.tx.send(AppEvent::StreamEvent { channel: "pods".into(), payload: json!({"n": 1}) }).unwrap();
+
+    let mut found = None;
+    while let Ok(ev) = handler.try_recv() {
+        if let AppEvent::StreamEvent { channel, payload } = ev {
+            found = Some((channel, payload));
+        }
+    }
+    assert_eq!(found, Some(("pods".to_string(), json!({"n": 1}))));
+
+    handler.resume();
+    handler.tx.send(AppEvent::Paste("after resume".into())).unwrap();
+    assert!(matches!(next_non_tick(&mut handler).await, AppEvent::Paste(s) if s == "after resume"));
+}
+
+#[test]
+fn app_events_debug_render_their_variant_and_payload() {
+    let ev = AppEvent::ActionResult { title: "ai_done:ctx".into(), result: Err("boom".into()) };
+    let dbg = format!("{ev:?}");
+    assert!(dbg.contains("ActionResult"));
+    assert!(dbg.contains("ai_done:ctx"));
+    assert!(dbg.contains("boom"));
+}
+
+// ---------------------------------------------------------------------------
+// sink.rs
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn the_tui_sink_forwards_stream_events_onto_the_app_channel() {
+    let (tx, mut rx) = unbounded_channel();
+    let sink = TuiSink::arc(tx);
+    sink.emit("pods", json!({"name": "api-1"}));
+    sink.emit("events", json!([1, 2]));
+
+    let first = rx.try_recv().unwrap();
+    assert!(matches!(first, AppEvent::StreamEvent { ref channel, ref payload } if channel == "pods" && payload["name"] == "api-1"));
+    let second = rx.try_recv().unwrap();
+    assert!(matches!(second, AppEvent::StreamEvent { ref channel, ref payload } if channel == "events" && payload == &json!([1, 2])));
+    assert!(rx.try_recv().is_err());
+}
+
+#[tokio::test]
+async fn the_tui_sink_ignores_a_closed_receiver() {
+    let (tx, rx) = unbounded_channel::<AppEvent>();
+    drop(rx);
+    let sink = TuiSink::new(tx);
+    // Must not panic: the app may be shutting down while a watch still emits.
+    sink.emit("pods", json!({}));
+}
+
+// ---------------------------------------------------------------------------
+// theme.rs
+// ---------------------------------------------------------------------------
+
+fn bold(style: Style) -> bool {
+    style.add_modifier.contains(Modifier::BOLD)
+}
+
+#[test]
+fn every_theme_style_uses_its_palette_colour() {
+    assert_eq!(Theme::header().fg, Some(Theme::CYAN));
+    assert!(bold(Theme::header()));
+    assert_eq!(Theme::header_label().fg, Some(Theme::DIM));
+    assert!(!bold(Theme::header_label()));
+    assert_eq!(Theme::header_val().fg, Some(Theme::FG));
+    assert_eq!(Theme::title().fg, Some(Theme::ACCENT));
+    assert_eq!(Theme::table_header().fg, Some(Theme::CYAN));
+    assert_eq!(Theme::selected_row().bg, Some(Theme::SEL_BG));
+    assert_eq!(Theme::selected_row().fg, Some(Theme::SEL_FG));
+    assert_eq!(Theme::marked_row().bg, Some(Color::Rgb(60, 40, 90)));
+    assert_eq!(Theme::marked_row().fg, Some(Color::Yellow));
+    assert_eq!(Theme::status_ok().fg, Some(Theme::GREEN));
+    assert_eq!(Theme::status_warn().fg, Some(Theme::YELLOW));
+    assert_eq!(Theme::status_error().fg, Some(Theme::RED));
+    assert_eq!(Theme::status_dim().fg, Some(Theme::DIM));
+    assert_eq!(Theme::key_hint_key().fg, Some(Theme::CYAN));
+    assert_eq!(Theme::key_hint_desc().fg, Some(Theme::DIM));
+    assert_eq!(Theme::prompt().fg, Some(Theme::ACCENT));
+    assert!(bold(Theme::prompt()));
+    let badge = Theme::badge(Theme::RED, Theme::SEL_FG);
+    assert_eq!(badge.bg, Some(Theme::RED));
+    assert_eq!(badge.fg, Some(Theme::SEL_FG));
+    assert!(bold(badge));
+    assert_eq!(Theme::BORDER_FOCUS, Theme::ACCENT);
+    assert_eq!(Theme::BG, Color::Reset);
+}
+
+#[test]
+fn context_colour_reflects_the_environment_named_in_the_context() {
+    let prod = Color::Rgb(255, 110, 110);
+    let staging = Color::Rgb(255, 200, 80);
+    let local = Color::Rgb(80, 220, 140);
+    let other = Color::Rgb(100, 200, 255);
+
+    assert_eq!(Theme::context_color("eu-PROD-1", false), prod);
+    assert_eq!(Theme::context_color("prd-us", false), prod);
+    assert_eq!(Theme::context_color("live-cluster", true), prod, "prod outranks the local flag");
+    assert_eq!(Theme::context_color("stage-eu", false), staging);
+    assert_eq!(Theme::context_color("stg", false), staging);
+    assert_eq!(Theme::context_color("UAT", false), staging);
+    assert_eq!(Theme::context_color("qa-2", false), staging);
+    assert_eq!(Theme::context_color("kind-dev", false), local);
+    assert_eq!(Theme::context_color("minikube", false), local);
+    assert_eq!(Theme::context_color("k3d-x", false), local);
+    assert_eq!(Theme::context_color("something", true), local, "local flag alone is enough");
+    assert_eq!(Theme::context_color("harvester-amd", false), other);
+}
+
+#[test]
+fn status_style_maps_every_status_family_to_its_colour() {
+    for s in ["CrashLoopBackOff", "Error", "Failed", "NotReady", "Unknown", "ImagePullBackOff", "Degraded", "false"] {
+        assert_eq!(status_style(s), Theme::status_error(), "{s}");
+    }
+    for s in ["Scaled down", "Not scheduled", "Suspended"] {
+        assert_eq!(status_style(s), Style::default().fg(Theme::DIM), "{s}");
+    }
+    for s in ["Pending", "ContainerCreating", "Terminating", "Warning"] {
+        assert_eq!(status_style(s), Theme::status_warn(), "{s}");
+    }
+    for s in ["Running", "Active", "Ready", "Completed", "Succeeded", "Scheduled", "true", "SecretSynced"] {
+        assert_eq!(status_style(s), Theme::status_ok(), "{s}");
+    }
+    assert_eq!(status_style("Bound"), Style::default().fg(Theme::FG));
+    assert_eq!(status_style(""), Style::default().fg(Theme::FG));
+}
+
+// ---------------------------------------------------------------------------
+// ai_skills.rs
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_skill_placeholder_is_its_target_kind_or_blank() {
+    let crash = BUILTIN_PLAYBOOKS.iter().find(|s| s.command == "crashloop").unwrap();
+    assert_eq!(crash.target_placeholder(), "Pod");
+    let clear = BUILTIN_PLAYBOOKS.iter().find(|s| s.command == "clear").unwrap();
+    assert_eq!(clear.target_placeholder(), "");
+}
+
+#[test]
+fn caveman_levels_round_trip_through_their_display_names() {
+    for level in [
+        CavemanLevel::Lite,
+        CavemanLevel::Full,
+        CavemanLevel::Ultra,
+        CavemanLevel::WenyanLite,
+        CavemanLevel::WenyanFull,
+        CavemanLevel::WenyanUltra,
+    ] {
+        assert_eq!(CavemanLevel::parse(level.display_name()), Some(level));
+    }
+    assert_eq!(CavemanLevel::WenyanLite.display_name(), "wenyan-lite");
+    assert_eq!(CavemanLevel::WenyanUltra.display_name(), "wenyan-ultra");
+    assert_eq!(CavemanLevel::parse("  WENYAN_ULTRA "), Some(CavemanLevel::WenyanUltra));
+    assert_eq!(CavemanLevel::parse("wenyanlite"), Some(CavemanLevel::WenyanLite));
+    assert_eq!(CavemanLevel::parse("wenyanfull"), Some(CavemanLevel::WenyanFull));
+}
+
+#[test]
+fn caveman_command_keywords_set_each_level_and_keep_the_trailing_question() {
+    let cases = [
+        ("full", CavemanLevel::Full),
+        ("wenyan-lite", CavemanLevel::WenyanLite),
+        ("wenyan_lite", CavemanLevel::WenyanLite),
+        ("wenyanlite", CavemanLevel::WenyanLite),
+        ("wenyan", CavemanLevel::WenyanFull),
+        ("wenyan_full", CavemanLevel::WenyanFull),
+        ("wenyanfull", CavemanLevel::WenyanFull),
+        ("wenyan-ultra", CavemanLevel::WenyanUltra),
+        ("wenyan_ultra", CavemanLevel::WenyanUltra),
+        ("wenyanultra", CavemanLevel::WenyanUltra),
+        ("ULTRA", CavemanLevel::Ultra),
+    ];
+    for (word, level) in cases {
+        assert_eq!(
+            parse_caveman_command(word),
+            CavemanCommandAction::SetLevel { level, remainder_query: None },
+            "{word}"
+        );
+        assert_eq!(
+            parse_caveman_command(&format!("{word}   why  is it slow?  ")),
+            CavemanCommandAction::SetLevel { level, remainder_query: Some("why is it slow?".into()) },
+            "{word} with question"
+        );
+    }
+    for word in ["disable", "none", "OFF"] {
+        assert_eq!(parse_caveman_command(word), CavemanCommandAction::Disable, "{word}");
+    }
+}
+
+#[test]
+fn the_user_skills_dir_lives_under_an_assistant_skills_folder() {
+    let dir = load_user_skills_dir();
+    assert!(dir.ends_with("skills"), "{}", dir.display());
+    assert!(dir.to_string_lossy().contains("srelens"), "{}", dir.display());
+}
+
+#[test]
+fn slash_command_matching_uses_only_the_first_word() {
+    let hits = match_slash_commands("/crash my-pod-123");
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].command, "crashloop");
+    assert!(match_slash_commands("/zzz").is_empty());
+    assert_eq!(match_slash_commands("").len(), BUILTIN_PLAYBOOKS.len());
+    // Alias and name prefixes both match: "node" is an alias of nodepressure.
+    assert!(match_slash_commands("/node").iter().any(|s| s.command == "nodepressure"));
+}
+
+#[test]
+fn slash_commands_expand_discovery_prompts_per_target_kind() {
+    let node = expand_slash_command("node-pressure", None, "prod", "kube-system").unwrap();
+    assert!(node.contains("Scan the cluster for any nodes experiencing pressure"));
+
+    let deploy = expand_slash_command("rollout", None, "prod", "").unwrap();
+    assert!(deploy.contains("Scan all namespaces for any stalled or degraded rollouts"));
+    assert!(deploy.contains("Context: Cluster 'prod', all namespaces"));
+
+    let svc = expand_slash_command("svc", None, "prod", "web").unwrap();
+    assert!(svc.contains("Scan namespace 'web' for any services with zero endpoints"));
+
+    let summary = expand_slash_command("health", None, "prod", "web").unwrap();
+    assert!(summary.contains("Investigate cluster 'prod' in namespace 'web'."));
+
+    let targeted = expand_slash_command("summary", Some("thing"), "prod", "").unwrap();
+    assert!(targeted.contains("Focus on resource 'thing' in all namespaces."));
+
+    assert!(expand_slash_command("not-a-skill", None, "prod", "web").is_none());
+}
+
+// ---------------------------------------------------------------------------
+// ai_config.rs
+// ---------------------------------------------------------------------------
+
+#[test]
+fn every_provider_maps_to_its_slug_label_defaults_and_env_var() {
+    let table = [
+        (AiProvider::Anthropic, "anthropic", "ANTHROPIC_API_KEY", Some(ProviderKind::Anthropic)),
+        (AiProvider::OpenAi, "openai", "OPENAI_API_KEY", Some(ProviderKind::OpenAi)),
+        (AiProvider::Gemini, "gemini", "GEMINI_API_KEY", Some(ProviderKind::Gemini)),
+        (
+            AiProvider::OpenAiCompatible,
+            "openai-compatible",
+            "OPENAI_COMPATIBLE_API_KEY",
+            Some(ProviderKind::OpenAiCompatible),
+        ),
+        (AiProvider::Cursor, "cursor", "CURSOR_API_KEY", None),
+    ];
+    for (provider, slug, env, kind) in table {
+        assert_eq!(provider_slug(provider), slug);
+        assert_eq!(env_var_for_provider(provider), env);
+        assert_eq!(provider.to_llm_kind(), kind);
+        assert!(!provider_display_name(provider).is_empty());
+        assert!(!default_model_for_provider(provider).is_empty());
+    }
+    assert_eq!(ALL_PROVIDERS.len(), 5);
+    assert_eq!(default_base_url_for_provider(AiProvider::Cursor), "");
+    assert_eq!(default_base_url_for_provider(AiProvider::OpenAi), "https://api.openai.com/v1");
+    assert_eq!(default_base_url_for_provider(AiProvider::Gemini), "https://generativelanguage.googleapis.com");
+    assert!(provider_display_name(AiProvider::Cursor).contains("cursor-agent"));
+}
+
+#[test]
+fn settings_missing_optional_fields_deserialize_with_defaults() {
+    let s: AiSettings = serde_json::from_str(r#"{"defaultProvider":"gemini"}"#).unwrap();
+    assert_eq!(s.default_provider, AiProvider::Gemini);
+    assert_eq!(s.max_tokens, 4096);
+    assert_eq!(s.timeout_seconds, 120);
+    assert!(s.models.is_empty());
+    assert!(s.base_urls.is_empty());
+    assert_eq!(s.caveman_level, None);
+    // Blank maps fall back to the provider defaults.
+    assert_eq!(s.get_model(AiProvider::Gemini), "gemini-2.5-flash");
+    assert_eq!(s.get_base_url(AiProvider::Anthropic), "https://api.anthropic.com");
+    assert_eq!(s.get_timeout_seconds(AiProvider::Gemini), 120);
+}
+
+#[test]
+fn blank_model_url_and_zero_timeout_fall_back_to_defaults() {
+    let mut s = AiSettings::default();
+    s.models.insert("openai".into(), "   ".into());
+    s.base_urls.insert("openai".into(), "".into());
+    s.timeouts.clear();
+    s.timeout_seconds = 0;
+    assert_eq!(s.get_model(AiProvider::OpenAi), "gpt-4o");
+    assert_eq!(s.get_base_url(AiProvider::OpenAi), "https://api.openai.com/v1");
+    assert_eq!(s.get_timeout_seconds(AiProvider::OpenAi), 120);
+
+    s.timeout_seconds = 45;
+    assert_eq!(s.get_timeout_seconds(AiProvider::OpenAi), 45, "global timeout when no per-provider entry");
+    s.set_timeout_seconds(AiProvider::OpenAi, 300);
+    assert_eq!(s.get_timeout_seconds(AiProvider::OpenAi), 300);
+    assert_eq!(s.timeout_seconds, 300);
+}
+
+#[test]
+fn caveman_level_setting_round_trips_and_clears() {
+    let mut s = AiSettings::default();
+    s.set_caveman_level(Some(CavemanLevel::WenyanFull));
+    assert_eq!(s.caveman_level.as_deref(), Some("wenyan-full"));
+    assert_eq!(s.get_caveman_level(), Some(CavemanLevel::WenyanFull));
+    s.set_caveman_level(None);
+    assert_eq!(s.caveman_level, None);
+    s.caveman_level = Some("garbage".into());
+    assert_eq!(s.get_caveman_level(), None);
+}
+
+#[test]
+fn an_explicit_api_key_produces_a_provider_config_and_cursor_never_does() {
+    let mut s = AiSettings::default();
+    s.api_keys.insert("anthropic".into(), "sk-ant-test".into());
+    s.models.insert("anthropic".into(), "claude-x".into());
+    s.max_tokens = 999;
+    let cfg = s.resolve_provider_config(AiProvider::Anthropic).expect("config");
+    assert_eq!(cfg.kind, ProviderKind::Anthropic);
+    assert_eq!(cfg.api_key, "sk-ant-test");
+    assert_eq!(cfg.model, "claude-x");
+    assert_eq!(cfg.base_url, "https://api.anthropic.com");
+    assert_eq!(cfg.max_tokens, 999);
+
+    s.api_keys.insert("cursor".into(), "cur-key".into());
+    assert_eq!(s.get_api_key(AiProvider::Cursor).as_deref(), Some("cur-key"));
+    assert!(s.resolve_provider_config(AiProvider::Cursor).is_none(), "cursor is not a native provider");
+
+    s.api_keys.insert("openai".into(), "   ".into());
+    assert!(s.api_keys.contains_key("openai"));
+    // A blank stored key is treated as absent (the env fallback is exercised below).
+    assert_ne!(s.get_api_key(AiProvider::OpenAi).as_deref(), Some("   "));
+}
+
+/// The only test in this binary that touches process environment variables, so
+/// it cannot race with a sibling test. Each variable is restored afterwards.
+#[test]
+fn settings_paths_and_key_lookups_follow_the_environment() {
+    struct Restore(Vec<(&'static str, Option<String>)>);
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            for (k, v) in &self.0 {
+                match v {
+                    Some(v) => std::env::set_var(k, v),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+    }
+    let vars = ["SRELENS_AI_SETTINGS_PATH", "SRELENS_CONFIG_DIR", "GEMINI_API_KEY", "OPENAI_COMPATIBLE_API_KEY"];
+    let _restore = Restore(vars.iter().map(|k| (*k, std::env::var(k).ok())).collect());
+
+    // 1. Explicit settings file: save then load round-trips.
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("nested").join("ai.json");
+    std::env::set_var("SRELENS_AI_SETTINGS_PATH", &file);
+    std::env::remove_var("SRELENS_CONFIG_DIR");
+    assert_eq!(AiSettings::config_path(), file);
+
+    let mut s = AiSettings::default();
+    s.default_provider = AiProvider::OpenAiCompatible;
+    s.api_keys.insert("gemini".into(), "g-stored".into());
+    s.set_timeout_seconds(AiProvider::Gemini, 33);
+    let written = s.save().expect("save creates the parent directory");
+    assert_eq!(written, file);
+    assert!(file.is_file());
+    assert_eq!(AiSettings::load(), s);
+
+    // 2. A config dir puts the file at <dir>/ai_settings.json; the explicit path wins over it.
+    std::env::set_var("SRELENS_CONFIG_DIR", dir.path());
+    assert_eq!(AiSettings::config_path(), file);
+    std::env::set_var("SRELENS_AI_SETTINGS_PATH", "   ");
+    assert_eq!(AiSettings::config_path(), dir.path().join("ai_settings.json"));
+    std::env::remove_var("SRELENS_AI_SETTINGS_PATH");
+    assert_eq!(AiSettings::config_path(), dir.path().join("ai_settings.json"));
+
+    // 3. Key lookup: stored key first, then the provider's env var, else none.
+    let mut s = AiSettings::default();
+    std::env::remove_var("GEMINI_API_KEY");
+    assert_eq!(s.get_api_key(AiProvider::Gemini), None);
+    assert!(s.resolve_provider_config(AiProvider::Gemini).is_none(), "no key, no config");
+    std::env::set_var("GEMINI_API_KEY", "g-env");
+    assert_eq!(s.get_api_key(AiProvider::Gemini).as_deref(), Some("g-env"));
+    assert_eq!(s.resolve_provider_config(AiProvider::Gemini).unwrap().api_key, "g-env");
+    s.api_keys.insert("gemini".into(), "g-stored".into());
+    assert_eq!(s.get_api_key(AiProvider::Gemini).as_deref(), Some("g-stored"));
+    std::env::set_var("GEMINI_API_KEY", "   ");
+    s.api_keys.remove("gemini");
+    assert_eq!(s.get_api_key(AiProvider::Gemini), None, "blank env value is ignored");
+
+    // 4. OpenAI-compatible endpoints need no key: "ollama" is substituted.
+    std::env::remove_var("OPENAI_COMPATIBLE_API_KEY");
+    let cfg = s.resolve_provider_config(AiProvider::OpenAiCompatible).expect("keyless config");
+    assert_eq!(cfg.api_key, "ollama");
+    assert_eq!(cfg.base_url, "http://localhost:11434/v1");
+}
+
+// ---------------------------------------------------------------------------
+// deep_link.rs
+// ---------------------------------------------------------------------------
+
+#[test]
+fn view_links_format_every_target_kind() {
+    let view = |target: CommandTarget| DeepLink::View { context: Some("prod".into()), namespace: None, target }.to_url();
+    assert_eq!(view(CommandTarget::Resource(ResourceKind::Assistant)), "srelens://view/prod/_/ai");
+    assert_eq!(view(CommandTarget::Resource(ResourceKind::Overview)), "srelens://view/prod/_/overview");
+    assert_eq!(view(CommandTarget::Resource(ResourceKind::Toolbox)), "srelens://view/prod/_/toolbox");
+    assert_eq!(view(CommandTarget::Resource(ResourceKind::Settings)), "srelens://view/prod/_/settings");
+    assert_eq!(view(CommandTarget::Resource(ResourceKind::Deployments)), "srelens://view/prod/_/deployments");
+    assert_eq!(view(CommandTarget::CustomResource(cilium_pool())), "srelens://view/prod/_/ciliumloadbalancerippools");
+    assert_eq!(view(CommandTarget::Help), "srelens://view/prod/_/help");
+    assert_eq!(view(CommandTarget::Contexts), "srelens://view/prod/_/contexts");
+    assert_eq!(view(CommandTarget::Namespaces), "srelens://view/prod/_/namespaces");
+    assert_eq!(view(CommandTarget::Quit), "srelens://view/prod/_/quit");
+    assert_eq!(view(CommandTarget::OpenUrl("x".into())), "srelens://view/prod/_/open/x");
+
+    let no_ctx = DeepLink::View { context: None, namespace: Some("web".into()), target: CommandTarget::Help };
+    assert_eq!(no_ctx.to_url(), "srelens://view/_/web/help");
+}
+
+#[test]
+fn resource_links_with_blank_context_or_namespace_format_placeholders() {
+    let link = DeepLink::Resource { context: String::new(), namespace: Some(String::new()), kind: "Pod".into(), name: "p".into() };
+    assert_eq!(link.to_url(), "srelens://resource/_/_/Pod/p");
+}
+
+#[test]
+fn view_links_parse_with_placeholder_context_and_namespace() {
+    let link = DeepLink::parse("srelens://view/_/_all/pods").unwrap();
+    assert_eq!(
+        link,
+        DeepLink::View { context: None, namespace: None, target: CommandTarget::Resource(ResourceKind::Pods) }
+    );
+    assert_eq!(link.to_url(), "srelens://view/_/_/pods");
+
+    let link = DeepLink::parse("srelens://view/prod/web/deploy").unwrap();
+    assert_eq!(
+        link,
+        DeepLink::View {
+            context: Some("prod".into()),
+            namespace: Some("web".into()),
+            target: CommandTarget::Resource(ResourceKind::Deployments)
+        }
+    );
+    assert_eq!(link.to_url(), "srelens://view/prod/web/deployments");
+
+    let dash = DeepLink::parse("srelens://view/prod/-/ai").unwrap();
+    assert!(matches!(dash, DeepLink::View { namespace: None, target: CommandTarget::Resource(ResourceKind::Assistant), .. }));
+}
+
+#[test]
+fn malformed_srelens_urls_explain_what_is_missing() {
+    let err = |s: &str| DeepLink::parse(s).unwrap_err();
+    assert_eq!(err(""), "Empty deep link URL");
+    assert_eq!(err("srelens://"), "Missing target in srelens:// URL");
+    assert!(err("srelens://resource/prod/ns/Pod").contains("Expected format: srelens://resource/"));
+    assert!(err("srelens://cluster").contains("Expected format: srelens://cluster/<context>"));
+    assert!(err("srelens://view/prod/ns").contains("Expected format: srelens://view/"));
+    assert_eq!(err("srelens://view/prod/ns/nosuchview"), "Unknown view target: 'nosuchview'");
+    assert!(err("srelens://bogus/x").starts_with("Unknown srelens URL route 'bogus'"));
+}
+
+#[test]
+fn the_context_route_is_an_alias_for_cluster() {
+    let link = DeepLink::parse("srelens://context/prod-eu").unwrap();
+    assert_eq!(link, DeepLink::Cluster { context: "prod-eu".into() });
+    assert_eq!(link.to_url(), "srelens://cluster/prod-eu");
+}
+
+#[test]
+fn shorthand_targets_parse_by_segment_count() {
+    assert_eq!(
+        DeepLink::parse("web/Deployment/api").unwrap(),
+        DeepLink::Resource { context: String::new(), namespace: Some("web".into()), kind: "Deployment".into(), name: "api".into() }
+    );
+    for placeholder in ["_", "_all", "-"] {
+        let link = DeepLink::parse(&format!("{placeholder}/Node/worker-1")).unwrap();
+        assert!(matches!(link, DeepLink::Resource { namespace: None, .. }), "{placeholder}");
+        let link = DeepLink::parse(&format!("prod/{placeholder}/Node/worker-1")).unwrap();
+        assert!(matches!(&link, DeepLink::Resource { context, namespace: None, .. } if context == "prod"), "{placeholder}");
+    }
+    assert_eq!(
+        DeepLink::parse("prod/web/Pod/api-1").unwrap(),
+        DeepLink::Resource { context: "prod".into(), namespace: Some("web".into()), kind: "Pod".into(), name: "api-1".into() }
+    );
+    assert_eq!(
+        DeepLink::parse("prod/web/Pod/api-1").unwrap().to_url(),
+        "srelens://resource/prod/web/Pod/api-1"
+    );
+    let err = DeepLink::parse("a/b/c/d/e").unwrap_err();
+    assert!(err.starts_with("Unrecognized shorthand format 'a/b/c/d/e'"), "{err}");
+    let err = DeepLink::parse("solo/").unwrap_err();
+    assert!(err.contains("Unrecognized shorthand format"), "{err}");
+}
+
+#[test]
+fn a_bare_command_word_becomes_a_view_link_and_nonsense_is_rejected() {
+    let link = DeepLink::parse("  nodes ").unwrap();
+    assert_eq!(
+        link,
+        DeepLink::View { context: None, namespace: None, target: CommandTarget::Resource(ResourceKind::Nodes) }
+    );
+    assert_eq!(DeepLink::parse("nosuchthing").unwrap_err(), "Unrecognized target or URL: 'nosuchthing'");
+}
+
+#[test]
+fn a_percent_encoded_namespace_is_kept_verbatim_and_round_trips() {
+    let url = "srelens://resource/prod/team%2Fweb/Pod/api-1";
+    let link = DeepLink::parse(url).unwrap();
+    assert!(matches!(&link, DeepLink::Resource { namespace: Some(ns), .. } if ns == "team%2Fweb"));
+    assert_eq!(link.to_url(), url);
+}
+
+// ---------------------------------------------------------------------------
+// commands.rs: ResourceKind tables
+// ---------------------------------------------------------------------------
+
+fn all_static_kinds() -> Vec<ResourceKind> {
+    vec![
+        ResourceKind::Pods,
+        ResourceKind::Deployments,
+        ResourceKind::StatefulSets,
+        ResourceKind::DaemonSets,
+        ResourceKind::Jobs,
+        ResourceKind::CronJobs,
+        ResourceKind::ConfigMaps,
+        ResourceKind::Secrets,
+        ResourceKind::ResourceQuotas,
+        ResourceKind::LimitRanges,
+        ResourceKind::Services,
+        ResourceKind::Endpoints,
+        ResourceKind::EndpointSlices,
+        ResourceKind::Ingresses,
+        ResourceKind::NetworkPolicies,
+        ResourceKind::PersistentVolumeClaims,
+        ResourceKind::PersistentVolumes,
+        ResourceKind::StorageClasses,
+        ResourceKind::ServiceAccounts,
+        ResourceKind::Roles,
+        ResourceKind::ClusterRoles,
+        ResourceKind::RoleBindings,
+        ResourceKind::ClusterRoleBindings,
+        ResourceKind::Nodes,
+        ResourceKind::Namespaces,
+        ResourceKind::Events,
+        ResourceKind::CustomResourceDefinitions,
+        ResourceKind::HelmReleases,
+        ResourceKind::PortForwards,
+        ResourceKind::Overview,
+        ResourceKind::Toolbox,
+        ResourceKind::Assistant,
+        ResourceKind::Settings,
+        ResourceKind::Workloads,
+    ]
+}
+
+#[test]
+fn display_names_are_unique_and_match_the_display_impl() {
+    let mut seen = std::collections::HashSet::new();
+    for kind in all_static_kinds() {
+        let name = kind.display_name().to_string();
+        assert!(!name.is_empty(), "{kind:?}");
+        assert_eq!(kind.to_string(), name, "Display delegates to display_name");
+        assert!(seen.insert(name.clone()), "duplicate display name {name}");
+    }
+    assert_eq!(ResourceKind::HelmReleases.display_name(), "Helm Releases");
+    assert_eq!(ResourceKind::Overview.display_name(), "Cluster Overview");
+    assert_eq!(ResourceKind::Settings.display_name(), "AI & Assistant Settings");
+    let custom = ResourceKind::CustomResource(cilium_pool());
+    assert_eq!(custom.display_name(), "CiliumLoadBalancerIPPool");
+    assert_eq!(custom.to_string(), "CiliumLoadBalancerIPPool");
+}
+
+#[test]
+fn watch_kinds_are_lowercase_plurals_for_watchable_kinds_only() {
+    let mut watchable = 0;
+    for kind in all_static_kinds() {
+        match kind.watch_kind() {
+            Some(w) => {
+                watchable += 1;
+                assert_eq!(w, w.to_lowercase(), "{kind:?}");
+                assert_eq!(w, kind.display_name().to_lowercase(), "{kind:?}");
+            }
+            None => assert!(
+                matches!(
+                    kind,
+                    ResourceKind::Endpoints
+                        | ResourceKind::CustomResourceDefinitions
+                        | ResourceKind::HelmReleases
+                        | ResourceKind::PortForwards
+                        | ResourceKind::Overview
+                        | ResourceKind::Toolbox
+                        | ResourceKind::Assistant
+                        | ResourceKind::Settings
+                        | ResourceKind::Workloads
+                ),
+                "{kind:?} unexpectedly has no watch kind"
+            ),
+        }
+    }
+    assert_eq!(watchable, 25);
+    assert_eq!(ResourceKind::CustomResource(cilium_pool()).watch_kind(), None);
+}
+
+#[test]
+fn k8s_kinds_are_singular_pascal_case_and_crds_use_their_own_kind() {
+    for kind in all_static_kinds() {
+        match kind.k8s_kind() {
+            Some(k) => {
+                assert!(k.chars().next().unwrap().is_ascii_uppercase(), "{kind:?}");
+                // Every k8s kind is a singular of its display name (Endpoints stays plural).
+                if kind != ResourceKind::Endpoints {
+                    assert!(kind.display_name().starts_with(&k[..k.len() - 1]), "{kind:?}: {k}");
+                }
+            }
+            None => assert!(
+                matches!(
+                    kind,
+                    ResourceKind::HelmReleases
+                        | ResourceKind::PortForwards
+                        | ResourceKind::Overview
+                        | ResourceKind::Toolbox
+                        | ResourceKind::Assistant
+                        | ResourceKind::Settings
+                        | ResourceKind::Workloads
+                ),
+                "{kind:?} unexpectedly has no k8s kind"
+            ),
+        }
+    }
+    assert_eq!(ResourceKind::Ingresses.k8s_kind(), Some("Ingress"));
+    assert_eq!(ResourceKind::NetworkPolicies.k8s_kind(), Some("NetworkPolicy"));
+    assert_eq!(ResourceKind::CustomResourceDefinitions.k8s_kind(), Some("CustomResourceDefinition"));
+    assert_eq!(ResourceKind::CustomResource(cilium_pool()).k8s_kind(), Some("CiliumLoadBalancerIPPool"));
+}
+
+#[test]
+fn cluster_scoped_kinds_are_not_namespaced() {
+    let cluster_scoped = [
+        ResourceKind::Nodes,
+        ResourceKind::Namespaces,
+        ResourceKind::PersistentVolumes,
+        ResourceKind::StorageClasses,
+        ResourceKind::ClusterRoles,
+        ResourceKind::ClusterRoleBindings,
+        ResourceKind::CustomResourceDefinitions,
+        ResourceKind::Overview,
+        ResourceKind::Toolbox,
+        ResourceKind::Assistant,
+    ];
+    for kind in all_static_kinds() {
+        assert_eq!(kind.is_namespaced(), !cluster_scoped.contains(&kind), "{kind:?}");
+    }
+    assert!(ResourceKind::CustomResource(cilium_pool()).is_namespaced());
+}
+
+// ---------------------------------------------------------------------------
+// commands.rs: dynamic definitions, resolution, suggestions
+// ---------------------------------------------------------------------------
+
+#[test]
+fn static_commands_convert_to_dynamic_definitions_verbatim() {
+    let pods = COMMAND_REGISTRY.iter().find(|c| c.name == "pods").unwrap();
+    let dynamic = DynamicCommandDef::from(pods);
+    assert_eq!(dynamic.name, "pods");
+    assert_eq!(dynamic.aliases, vec!["po".to_string(), "pod".to_string()]);
+    assert_eq!(dynamic.description, "Pods view");
+    assert_eq!(dynamic.target, CommandTarget::Resource(ResourceKind::Pods));
+}
+
+#[test]
+fn a_crd_definition_collects_singular_short_names_and_lb_shorthands_without_duplicates() {
+    let def = DynamicCommandDef::from(&cilium_pool());
+    assert_eq!(def.name, "ciliumloadbalancerippools");
+    assert_eq!(
+        def.aliases,
+        vec!["ciliumloadbalancerippool", "ippool", "ciliumlbippools", "ciliumlbippool"]
+    );
+    assert_eq!(def.description, "CRD: CiliumLoadBalancerIPPool (cilium.io)");
+    assert_eq!(def.target, CommandTarget::CustomResource(cilium_pool()));
+
+    // Same singular as plural, a short name equal to the singular, no "loadbalancer".
+    let plain = crd("widgets", "widgets", "Widget", "example.io", &["widgets", "wd"]);
+    let def = DynamicCommandDef::from(&plain);
+    assert_eq!(def.aliases, vec!["widgets", "wd"]);
+}
+
+#[test]
+fn resolve_recognises_direct_urls_and_open_prefixes() {
+    assert_eq!(
+        resolve_command(":srelens://cluster/prod"),
+        Some(CommandTarget::OpenUrl("srelens://cluster/prod".into()))
+    );
+    assert_eq!(resolve_command("open  pods/api "), Some(CommandTarget::OpenUrl("pods/api".into())));
+    assert_eq!(resolve_command(":open:srelens://x"), Some(CommandTarget::OpenUrl("srelens://x".into())));
+    assert_eq!(resolve_command("goto nodes"), Some(CommandTarget::OpenUrl("nodes".into())));
+    assert_eq!(resolve_command("goto:nodes"), Some(CommandTarget::OpenUrl("nodes".into())));
+    // Bare "open" is the registry entry with an empty URL.
+    assert_eq!(resolve_command(":open"), Some(CommandTarget::OpenUrl(String::new())));
+    assert_eq!(resolve_command(""), None);
+    assert_eq!(resolve_command("  :  "), None);
+}
+
+#[test]
+fn resolve_matches_static_commands_case_insensitively_then_by_prefix() {
+    assert_eq!(resolve_command(":PODS"), Some(CommandTarget::Resource(ResourceKind::Pods)));
+    assert_eq!(resolve_command(":Deploy"), Some(CommandTarget::Resource(ResourceKind::Deployments)));
+    assert_eq!(resolve_command(":statef"), Some(CommandTarget::Resource(ResourceKind::StatefulSets)));
+    assert_eq!(resolve_command(":netpo"), Some(CommandTarget::Resource(ResourceKind::NetworkPolicies)));
+    assert_eq!(resolve_command(":?"), Some(CommandTarget::Help));
+    assert_eq!(resolve_command(":exit"), Some(CommandTarget::Quit));
+    assert_eq!(resolve_command(":zzzz"), None);
+}
+
+#[test]
+fn resolve_matches_crds_by_every_name_and_by_prefix_only_from_three_characters() {
+    let crds = vec![cilium_pool(), crd("widgets", "widget", "Widget", "example.io", &["wg"])];
+    let pool = CommandTarget::CustomResource(cilium_pool());
+    let widget = CommandTarget::CustomResource(crds[1].clone());
+
+    assert_eq!(resolve_command_with_crds(":CiliumLoadBalancerIPPool", &crds), Some(pool.clone()), "kind");
+    assert_eq!(resolve_command_with_crds("ciliumloadbalancerippools.cilium.io", &crds), Some(pool.clone()), "crd name");
+    assert_eq!(resolve_command_with_crds(":ippool", &crds), Some(pool.clone()), "short name");
+    assert_eq!(resolve_command_with_crds(":ciliumlbippools", &crds), Some(pool.clone()), "lb plural");
+    assert_eq!(resolve_command_with_crds(":widget", &crds), Some(widget.clone()), "singular");
+    assert_eq!(resolve_command_with_crds(":wg", &crds), Some(widget.clone()), "two-char short name is exact");
+    assert_eq!(resolve_command_with_crds(":ciliumlb", &crds), Some(pool.clone()), "prefix of lb shorthand");
+    assert_eq!(resolve_command_with_crds(":widg", &crds), Some(widget), "prefix of plural");
+    // Two characters never prefix-match a CRD; the static registry wins instead.
+    assert_eq!(resolve_command_with_crds(":wi", &crds), None);
+    assert_eq!(resolve_command_with_crds(":po", &crds), Some(CommandTarget::Resource(ResourceKind::Pods)));
+    // CRD prefix beats static prefix.
+    let cr_like = vec![crd("crontabs", "crontab", "CronTab", "stable.example.com", &[])];
+    assert_eq!(
+        resolve_command_with_crds(":cront", &cr_like),
+        Some(CommandTarget::CustomResource(cr_like[0].clone()))
+    );
+}
+
+#[test]
+fn namespace_and_context_switch_forms_resolve_to_their_switchers() {
+    assert_eq!(resolve_command(":ns kube-system"), Some(CommandTarget::Namespaces));
+    assert_eq!(resolve_command("ctx prod-eu"), Some(CommandTarget::Contexts));
+    assert_eq!(resolve_command("ns   "), Some(CommandTarget::Namespaces), "bare alias after trim");
+}
+
+#[test]
+fn an_empty_query_suggests_the_whole_registry_and_at_most_thirty_crds() {
+    let crds: Vec<CrdMeta> =
+        (0..35).map(|i| crd(&format!("things{i}"), &format!("thing{i}"), &format!("Thing{i}"), "x.io", &[])).collect();
+    let all = command_suggestions_with_crds(" : ", &crds);
+    assert_eq!(all.len(), COMMAND_REGISTRY.len() + 30);
+    assert!(all.iter().all(|(_, score)| *score == 0));
+    assert_eq!(all[0].0.name, COMMAND_REGISTRY[0].name, "registry order is preserved");
+    assert_eq!(all[COMMAND_REGISTRY.len()].0.name, "things0");
+    assert_eq!(command_suggestions("").len(), COMMAND_REGISTRY.len());
+}
+
+#[test]
+fn static_suggestions_are_scored_by_match_quality_and_sorted() {
+    let po = command_suggestions("po");
+    assert_eq!(po[0].0.name, "pods");
+    assert_eq!(po[0].1, 120, "exact alias");
+    assert_eq!(po[1].0.name, "portforwards");
+    assert_eq!(po[1].1, 100, "name prefix");
+
+    let sv = command_suggestions(":sv");
+    assert_eq!(sv.len(), 1);
+    assert_eq!((sv[0].0.name.as_str(), sv[0].1), ("services", 80), "alias prefix");
+
+    let health = command_suggestions("health");
+    assert_eq!(health.len(), 1);
+    assert_eq!((health[0].0.name.as_str(), health[0].1), ("overview", 50), "description contains");
+
+    let ole = command_suggestions("ole");
+    assert!(ole.iter().any(|(d, s)| d.name == "roles" && *s == 50), "name contains: {:?}", ole);
+
+    let ties = command_suggestions("c");
+    let scores: Vec<usize> = ties.iter().map(|(_, s)| *s).collect();
+    let mut sorted = scores.clone();
+    sorted.sort_unstable_by(|a, b| b.cmp(a));
+    assert_eq!(scores, sorted, "descending by score");
+    let hundreds: Vec<&str> = ties.iter().filter(|(_, s)| *s == 100).map(|(d, _)| d.name.as_str()).collect();
+    let mut alpha = hundreds.clone();
+    alpha.sort_unstable();
+    assert_eq!(hundreds, alpha, "ties break alphabetically");
+}
+
+#[test]
+fn crd_suggestions_are_scored_by_exact_prefix_alias_and_group() {
+    let crds = vec![cilium_pool()];
+    let score = |q: &str| {
+        command_suggestions_with_crds(q, &crds)
+            .into_iter()
+            .find(|(d, _)| d.name == "ciliumloadbalancerippools")
+            .map(|(_, s)| s)
+    };
+    assert_eq!(score("ippool"), Some(120), "short-name alias exact");
+    assert_eq!(score("CiliumLoadBalancerIPPool"), Some(120), "kind exact");
+    assert_eq!(score("ciliumlbippools"), Some(120), "lb plural exact");
+    assert_eq!(score("ciliumlb"), Some(105), "lb prefix");
+    assert_eq!(score("ciliumload"), Some(105), "plural prefix");
+    assert_eq!(score("ipp"), Some(95), "alias prefix only");
+    assert_eq!(score("cilium.io"), Some(55), "group contains");
+    assert_eq!(score("balancer"), Some(55), "plural contains");
+    assert_eq!(score("unrelated"), None);
+
+    // A CRD prefix (105) outranks a static name prefix (100) for the same query.
+    let both = command_suggestions_with_crds("cilium", &crds);
+    assert_eq!(both[0].0.name, "ciliumloadbalancerippools");
+}

--- a/apps/tui/tests/core_logic_tests.rs
+++ b/apps/tui/tests/core_logic_tests.rs
@@ -18,18 +18,20 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
 
-use srelens_tui::agent::{build_mcp_server, run_boxed_cursor_turn, run_native_agent_turn, McpToolInvoker};
+use srelens_tui::agent::{
+    build_mcp_server, run_boxed_cursor_turn, run_native_agent_turn, McpToolInvoker,
+};
 use srelens_tui::ai_config::{
-    default_base_url_for_provider, default_model_for_provider, env_var_for_provider, provider_display_name,
-    provider_slug, AiProvider, AiSettings, ALL_PROVIDERS,
+    default_base_url_for_provider, default_model_for_provider, env_var_for_provider,
+    provider_display_name, provider_slug, AiProvider, AiSettings, ALL_PROVIDERS,
 };
 use srelens_tui::ai_skills::{
-    expand_slash_command, load_user_skills_dir, match_slash_commands, parse_caveman_command, CavemanCommandAction,
-    CavemanLevel, BUILTIN_PLAYBOOKS,
+    expand_slash_command, load_user_skills_dir, match_slash_commands, parse_caveman_command,
+    CavemanCommandAction, CavemanLevel, BUILTIN_PLAYBOOKS,
 };
 use srelens_tui::commands::{
-    command_suggestions, command_suggestions_with_crds, resolve_command, resolve_command_with_crds, CommandTarget,
-    CrdMeta, DynamicCommandDef, ResourceKind, COMMAND_REGISTRY,
+    command_suggestions, command_suggestions_with_crds, resolve_command, resolve_command_with_crds,
+    CommandTarget, CrdMeta, DynamicCommandDef, ResourceKind, COMMAND_REGISTRY,
 };
 use srelens_tui::deep_link::DeepLink;
 use srelens_tui::event::{AppEvent, EventHandler};
@@ -102,11 +104,16 @@ fn sse(events: &[&str]) -> String {
 }
 
 fn text_reply(chunks: &[&str]) -> Reply {
-    let mut events: Vec<String> =
-        chunks.iter().map(|c| json!({"choices":[{"delta":{"content":c}}]}).to_string()).collect();
+    let mut events: Vec<String> = chunks
+        .iter()
+        .map(|c| json!({"choices":[{"delta":{"content":c}}]}).to_string())
+        .collect();
     events.push(json!({"choices":[{"delta":{},"finish_reason":"stop"}]}).to_string());
     let refs: Vec<&str> = events.iter().map(String::as_str).collect();
-    Reply { status: 200, body: sse(&refs) }
+    Reply {
+        status: 200,
+        body: sse(&refs),
+    }
 }
 
 /// A reply that requests the given tool calls: `(id, name, raw arguments string)`.
@@ -123,7 +130,10 @@ fn tool_call_reply(calls: &[(&str, &str, &str)]) -> Reply {
         json!({"choices":[{"delta":{},"finish_reason":"tool_calls"}]}).to_string(),
     ];
     let refs: Vec<&str> = events.iter().map(String::as_str).collect();
-    Reply { status: 200, body: sse(&refs) }
+    Reply {
+        status: 200,
+        body: sse(&refs),
+    }
 }
 
 struct FakeLlm {
@@ -154,7 +164,9 @@ async fn read_request(sock: &mut tokio::net::TcpStream) -> Value {
         .lines()
         .find_map(|l| {
             let (k, v) = l.split_once(':')?;
-            k.trim().eq_ignore_ascii_case("content-length").then(|| v.trim().parse().ok())?
+            k.trim()
+                .eq_ignore_ascii_case("content-length")
+                .then(|| v.trim().parse().ok())?
         })
         .unwrap_or(0);
     while buf.len() < header_end + content_length {
@@ -171,17 +183,24 @@ async fn read_request(sock: &mut tokio::net::TcpStream) -> Value {
 /// Serve the scripted replies, one per connection, in order. A request past
 /// the end of the script gets a 500 so a runaway loop fails loudly.
 async fn fake_llm(replies: Vec<Reply>) -> FakeLlm {
-    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind loopback");
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind loopback");
     let base_url = format!("http://{}/v1", listener.local_addr().expect("local addr"));
     let requests = Arc::new(Mutex::new(Vec::new()));
     let seen = requests.clone();
     tokio::spawn(async move {
         let mut replies = replies.into_iter();
         loop {
-            let Ok((mut sock, _)) = listener.accept().await else { break };
+            let Ok((mut sock, _)) = listener.accept().await else {
+                break;
+            };
             let body = read_request(&mut sock).await;
             seen.lock().unwrap().push(body);
-            let reply = replies.next().unwrap_or(Reply { status: 500, body: "script exhausted".into() });
+            let reply = replies.next().unwrap_or(Reply {
+                status: 500,
+                body: "script exhausted".into(),
+            });
             let response = format!(
                 "HTTP/1.1 {} X\r\nContent-Type: text/event-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
                 reply.status,
@@ -242,7 +261,10 @@ async fn native_turn(
 }
 
 fn usage_fields(payload: &str) -> Vec<u64> {
-    payload.split('|').map(|f| f.parse().expect("numeric usage field")).collect()
+    payload
+        .split('|')
+        .map(|f| f.parse().expect("numeric usage field"))
+        .collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -252,10 +274,26 @@ fn usage_fields(payload: &str) -> Vec<u64> {
 #[tokio::test]
 async fn tool_aliases_are_provider_safe_and_stable_across_repeated_listings() {
     let inv = invoker();
-    let first: Vec<String> = inv.list_tools().await.unwrap().into_iter().map(|t| t.name).collect();
-    let second: Vec<String> = inv.list_tools().await.unwrap().into_iter().map(|t| t.name).collect();
+    let first: Vec<String> = inv
+        .list_tools()
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|t| t.name)
+        .collect();
+    let second: Vec<String> = inv
+        .list_tools()
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|t| t.name)
+        .collect();
 
-    assert!(first.iter().all(|n| !n.contains('.')), "dots must be rewritten: {:?}", first);
+    assert!(
+        first.iter().all(|n| !n.contains('.')),
+        "dots must be rewritten: {:?}",
+        first
+    );
     assert!(first.contains(&"k8s_listPods".to_string()));
     assert!(first.contains(&"ping".to_string()));
     // Re-listing maps each id to the alias it already owns instead of
@@ -271,14 +309,20 @@ async fn list_tools_carries_description_schema_and_read_only_hint() {
     assert!(ping.read_only);
     assert!(ping.description.contains("health check"));
     assert!(ping.input_schema.is_object());
-    let delete = tools.iter().find(|t| t.name == "k8s_deleteContext").expect("deleteContext tool");
+    let delete = tools
+        .iter()
+        .find(|t| t.name == "k8s_deleteContext")
+        .expect("deleteContext tool");
     assert!(!delete.read_only);
 }
 
 #[tokio::test]
 async fn calling_a_read_only_tool_returns_its_output_as_a_clean_result() {
     let inv = invoker();
-    let res = inv.call_tool("ping", &json!({"hello": "world"})).await.unwrap();
+    let res = inv
+        .call_tool("ping", &json!({"hello": "world"}))
+        .await
+        .unwrap();
     assert!(!res.is_error);
     assert!(!res.denied);
     let body: Value = serde_json::from_str(&res.content).expect("ping echoes JSON");
@@ -289,16 +333,30 @@ async fn calling_a_read_only_tool_returns_its_output_as_a_clean_result() {
 async fn a_destructive_tool_called_by_alias_is_denied_by_the_policy() {
     let inv = invoker();
     inv.list_tools().await.unwrap();
-    let res = inv.call_tool("k8s_deleteContext", &json!({"context": "prod"})).await.unwrap();
-    assert!(res.denied, "FlagGated(false, ..) must refuse destructive calls: {:?}", res);
+    let res = inv
+        .call_tool("k8s_deleteContext", &json!({"context": "prod"}))
+        .await
+        .unwrap();
+    assert!(
+        res.denied,
+        "FlagGated(false, ..) must refuse destructive calls: {:?}",
+        res
+    );
     assert!(res.is_error);
-    assert!(res.content.contains("k8s.deleteContext"), "reason names the real tool: {}", res.content);
+    assert!(
+        res.content.contains("k8s.deleteContext"),
+        "reason names the real tool: {}",
+        res.content
+    );
 }
 
 #[tokio::test]
 async fn an_unknown_tool_name_is_a_tool_error_not_a_transport_failure() {
     let inv = invoker();
-    let res = inv.call_tool("definitely_not_a_tool", &json!({})).await.unwrap();
+    let res = inv
+        .call_tool("definitely_not_a_tool", &json!({}))
+        .await
+        .unwrap();
     assert!(res.is_error);
     assert!(!res.denied);
     assert!(!res.content.is_empty());
@@ -308,7 +366,13 @@ async fn an_unknown_tool_name_is_a_tool_error_not_a_transport_failure() {
 async fn a_tool_that_needs_a_missing_cluster_reports_an_error_result() {
     let inv = invoker();
     inv.list_tools().await.unwrap();
-    let res = inv.call_tool("k8s_listPods", &json!({"context": "nowhere", "namespace": "default"})).await.unwrap();
+    let res = inv
+        .call_tool(
+            "k8s_listPods",
+            &json!({"context": "nowhere", "namespace": "default"}),
+        )
+        .await
+        .unwrap();
     assert!(res.is_error);
     assert!(!res.denied);
     assert!(!res.content.is_empty());
@@ -327,11 +391,18 @@ async fn a_native_turn_streams_text_thinking_usage_and_done_in_order() {
         json!({"choices":[{"delta":{},"finish_reason":"stop"}]}).to_string(),
     ];
     let refs: Vec<&str> = events.iter().map(String::as_str).collect();
-    let llm = fake_llm(vec![Reply { status: 200, body: sse(&refs) }]).await;
+    let llm = fake_llm(vec![Reply {
+        status: 200,
+        body: sse(&refs),
+    }])
+    .await;
 
     let (results, turns) = native_turn(&llm, vec![], "how are the pods?").await;
 
-    assert_eq!(results[0], ("ai_status:kind-dev".into(), Ok("let me think".into())));
+    assert_eq!(
+        results[0],
+        ("ai_status:kind-dev".into(), Ok("let me think".into()))
+    );
     assert_eq!(results[1], ("ai_chunk:kind-dev".into(), Ok("Hel".into())));
     assert_eq!(results[2], ("ai_chunk:kind-dev".into(), Ok("lo".into())));
     assert_eq!(results[3].0, "ai_usage:kind-dev");
@@ -350,20 +421,40 @@ async fn a_native_turn_streams_text_thinking_usage_and_done_in_order() {
         turns[0],
         Turn::User("[Active Kubernetes Context: \"kind-dev\", Namespace: \"payments\"]\n\nhow are the pods?".into())
     );
-    assert_eq!(turns[1], Turn::Assistant { text: "Hello".into(), tool_calls: vec![] });
+    assert_eq!(
+        turns[1],
+        Turn::Assistant {
+            text: "Hello".into(),
+            tool_calls: vec![]
+        }
+    );
 
     // The provider saw the enriched prompt and the tool catalogue.
     let requests = llm.requests.lock().unwrap();
     assert_eq!(requests.len(), 1);
     let messages = requests[0]["messages"].as_array().unwrap();
-    let user = messages.iter().find(|m| m["role"] == "user").expect("user message");
-    assert!(user["content"].as_str().unwrap().starts_with("[Active Kubernetes Context: \"kind-dev\""));
-    assert!(requests[0]["tools"].as_array().unwrap().iter().any(|t| t["function"]["name"] == "ping"));
+    let user = messages
+        .iter()
+        .find(|m| m["role"] == "user")
+        .expect("user message");
+    assert!(user["content"]
+        .as_str()
+        .unwrap()
+        .starts_with("[Active Kubernetes Context: \"kind-dev\""));
+    assert!(requests[0]["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|t| t["function"]["name"] == "ping"));
 }
 
 #[tokio::test]
 async fn a_native_turn_runs_a_tool_call_and_reports_start_and_completion() {
-    let llm = fake_llm(vec![tool_call_reply(&[("call_1", "ping", "{\"x\":1}")]), text_reply(&["pong ok"])]).await;
+    let llm = fake_llm(vec![
+        tool_call_reply(&[("call_1", "ping", "{\"x\":1}")]),
+        text_reply(&["pong ok"]),
+    ])
+    .await;
 
     let (results, turns) = native_turn(&llm, vec![], "ping it").await;
 
@@ -388,7 +479,13 @@ async fn a_native_turn_runs_a_tool_call_and_reports_start_and_completion() {
     assert_eq!(turns.len(), 4);
     assert!(matches!(&turns[1], Turn::Assistant { tool_calls, .. } if tool_calls.len() == 1));
     assert!(matches!(&turns[2], Turn::ToolResults(r) if r.len() == 1 && !r[0].is_error));
-    assert_eq!(turns[3], Turn::Assistant { text: "pong ok".into(), tool_calls: vec![] });
+    assert_eq!(
+        turns[3],
+        Turn::Assistant {
+            text: "pong ok".into(),
+            tool_calls: vec![]
+        }
+    );
 
     // The second request fed the tool output back to the model.
     let requests = llm.requests.lock().unwrap();
@@ -420,7 +517,14 @@ async fn tool_call_previews_cover_object_string_and_null_arguments_and_every_sta
         .filter(|(t, _)| t == "ai_tool_start:kind-dev")
         .map(|(_, r)| r.as_ref().unwrap().as_str())
         .collect();
-    assert_eq!(starts, vec!["c_obj|no_such_tool|{\"a\":1}", "c_str|k8s_deleteContext|just text", "c_null|ping|"]);
+    assert_eq!(
+        starts,
+        vec![
+            "c_obj|no_such_tool|{\"a\":1}",
+            "c_str|k8s_deleteContext|just text",
+            "c_null|ping|"
+        ]
+    );
 
     let dones: Vec<&str> = results
         .iter()
@@ -434,18 +538,41 @@ async fn tool_call_previews_cover_object_string_and_null_arguments_and_every_sta
         .filter(|(t, _)| t == "ai_status:kind-dev")
         .map(|(_, r)| r.as_ref().unwrap().as_str())
         .collect();
-    assert_eq!(statuses, vec!["Executing no_such_tool...", "Executing k8s_deleteContext...", "Executing ping..."]);
+    assert_eq!(
+        statuses,
+        vec![
+            "Executing no_such_tool...",
+            "Executing k8s_deleteContext...",
+            "Executing ping..."
+        ]
+    );
 }
 
 #[tokio::test]
 async fn a_provider_error_item_is_shown_as_an_error_chunk_and_history_is_kept() {
     let err = json!({"error": {"message": "quota exceeded"}}).to_string();
-    let llm = fake_llm(vec![Reply { status: 200, body: sse(&[err.as_str()]) }]).await;
-    let prior = vec![Turn::User("earlier".into()), Turn::Assistant { text: "ok".into(), tool_calls: vec![] }];
+    let llm = fake_llm(vec![Reply {
+        status: 200,
+        body: sse(&[err.as_str()]),
+    }])
+    .await;
+    let prior = vec![
+        Turn::User("earlier".into()),
+        Turn::Assistant {
+            text: "ok".into(),
+            tool_calls: vec![],
+        },
+    ];
 
     let (results, turns) = native_turn(&llm, prior.clone(), "again").await;
 
-    assert_eq!(results[0], ("ai_chunk:kind-dev".into(), Ok("\n[Error: quota exceeded]".into())));
+    assert_eq!(
+        results[0],
+        (
+            "ai_chunk:kind-dev".into(),
+            Ok("\n[Error: quota exceeded]".into())
+        )
+    );
     assert_eq!(results[1].0, "ai_usage:kind-dev");
     assert_eq!(results[2], ("ai_done:kind-dev".into(), Ok(String::new())));
     assert_eq!(results.len(), 3);
@@ -455,7 +582,11 @@ async fn a_provider_error_item_is_shown_as_an_error_chunk_and_history_is_kept() 
 
 #[tokio::test]
 async fn an_http_failure_from_the_provider_is_reported_as_an_agent_error() {
-    let llm = fake_llm(vec![Reply { status: 401, body: json!({"error": {"message": "bad key"}}).to_string() }]).await;
+    let llm = fake_llm(vec![Reply {
+        status: 401,
+        body: json!({"error": {"message": "bad key"}}).to_string(),
+    }])
+    .await;
 
     let (results, turns) = native_turn(&llm, vec![], "hi").await;
 
@@ -470,12 +601,18 @@ async fn an_http_failure_from_the_provider_is_reported_as_an_agent_error() {
 
 #[tokio::test]
 async fn a_stream_that_ends_without_a_terminal_marker_is_an_agent_error() {
-    let body = format!("data: {}\n\n", json!({"choices":[{"delta":{"content":"partial"}}]}));
+    let body = format!(
+        "data: {}\n\n",
+        json!({"choices":[{"delta":{"content":"partial"}}]})
+    );
     let llm = fake_llm(vec![Reply { status: 200, body }]).await;
 
     let (results, turns) = native_turn(&llm, vec![], "hi").await;
 
-    assert_eq!(results[0], ("ai_chunk:kind-dev".into(), Ok("partial".into())));
+    assert_eq!(
+        results[0],
+        ("ai_chunk:kind-dev".into(), Ok("partial".into()))
+    );
     let err = results[2].1.as_ref().unwrap_err();
     assert!(err.contains("ended before signaling completion"), "{err}");
     assert!(turns.is_empty());
@@ -489,7 +626,10 @@ async fn history_is_capped_at_forty_turns_after_a_successful_turn() {
             if i % 2 == 0 {
                 Turn::User(format!("u{i}"))
             } else {
-                Turn::Assistant { text: format!("a{i}"), tool_calls: vec![] }
+                Turn::Assistant {
+                    text: format!("a{i}"),
+                    tool_calls: vec![],
+                }
             }
         })
         .collect();
@@ -499,7 +639,13 @@ async fn history_is_capped_at_forty_turns_after_a_successful_turn() {
     assert_eq!(turns.len(), 40);
     // 44 + 2 new = 46; the oldest six were dropped, so the window starts at u6.
     assert_eq!(turns[0], Turn::User("u6".into()));
-    assert_eq!(turns[39], Turn::Assistant { text: "fresh reply".into(), tool_calls: vec![] });
+    assert_eq!(
+        turns[39],
+        Turn::Assistant {
+            text: "fresh reply".into(),
+            tool_calls: vec![]
+        }
+    );
 }
 
 #[tokio::test]
@@ -508,13 +654,23 @@ async fn a_native_turn_that_cannot_reach_the_provider_still_finishes_cleanly() {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let base_url = format!("http://{}/v1", listener.local_addr().unwrap());
     drop(listener);
-    let llm = FakeLlm { base_url, requests: Arc::new(Mutex::new(Vec::new())) };
+    let llm = FakeLlm {
+        base_url,
+        requests: Arc::new(Mutex::new(Vec::new())),
+    };
 
     let (results, _) = native_turn(&llm, vec![], "hi").await;
 
     let titles: Vec<&str> = results.iter().map(|(t, _)| t.as_str()).collect();
-    assert_eq!(titles, vec!["ai_usage:kind-dev", "ai_chunk:kind-dev", "ai_done:kind-dev"]);
-    assert!(results[1].1.as_ref().unwrap_err().starts_with("AI Agent Error: network error"));
+    assert_eq!(
+        titles,
+        vec!["ai_usage:kind-dev", "ai_chunk:kind-dev", "ai_done:kind-dev"]
+    );
+    assert!(results[1]
+        .1
+        .as_ref()
+        .unwrap_err()
+        .starts_with("AI Agent Error: network error"));
 }
 
 // ---------------------------------------------------------------------------
@@ -524,14 +680,23 @@ async fn a_native_turn_that_cannot_reach_the_provider_still_finishes_cleanly() {
 #[tokio::test]
 async fn a_boxed_cursor_turn_reports_a_missing_binary_and_finishes() {
     let dir = tempfile::tempdir().unwrap();
-    let missing = dir.path().join("no-such-cursor-agent").to_string_lossy().to_string();
+    let missing = dir
+        .path()
+        .join("no-such-cursor-agent")
+        .to_string_lossy()
+        .to_string();
     let (tx, mut rx) = unbounded_channel();
     let cache = ClientCache::new(PathBuf::from("/nonexistent"));
 
     run_boxed_cursor_turn(
         missing,
         "gpt-x".into(),
-        Some("cursor-test-key".into()),
+        // Deliberately None. `run_boxed_cursor_turn` calls
+        // `std::env::set_var("CURSOR_API_KEY", key)` (apps/tui/src/agent.rs:444)
+        // as well as putting the key on the child, so passing a key here would
+        // leak it into the environment of every sibling test in this binary.
+        // The key is not what this test is about.
+        None,
         "what is wrong?".into(),
         "kind-dev".into(),
         "default".into(),
@@ -570,14 +735,23 @@ async fn events_sent_on_the_handler_channel_arrive_in_order() {
     handler.tx.send(AppEvent::Resize(80, 24)).unwrap();
 
     assert!(matches!(next_non_tick(&mut handler).await, AppEvent::Paste(s) if s == "pasted"));
-    assert!(matches!(next_non_tick(&mut handler).await, AppEvent::Resize(80, 24)));
+    assert!(matches!(
+        next_non_tick(&mut handler).await,
+        AppEvent::Resize(80, 24)
+    ));
 }
 
 #[tokio::test]
 async fn try_recv_hands_back_a_queued_event_and_pausing_does_not_close_the_channel() {
     let mut handler = EventHandler::new(Duration::from_secs(3600));
     handler.pause();
-    handler.tx.send(AppEvent::StreamEvent { channel: "pods".into(), payload: json!({"n": 1}) }).unwrap();
+    handler
+        .tx
+        .send(AppEvent::StreamEvent {
+            channel: "pods".into(),
+            payload: json!({"n": 1}),
+        })
+        .unwrap();
 
     let mut found = None;
     while let Ok(ev) = handler.try_recv() {
@@ -588,13 +762,19 @@ async fn try_recv_hands_back_a_queued_event_and_pausing_does_not_close_the_chann
     assert_eq!(found, Some(("pods".to_string(), json!({"n": 1}))));
 
     handler.resume();
-    handler.tx.send(AppEvent::Paste("after resume".into())).unwrap();
+    handler
+        .tx
+        .send(AppEvent::Paste("after resume".into()))
+        .unwrap();
     assert!(matches!(next_non_tick(&mut handler).await, AppEvent::Paste(s) if s == "after resume"));
 }
 
 #[test]
 fn app_events_debug_render_their_variant_and_payload() {
-    let ev = AppEvent::ActionResult { title: "ai_done:ctx".into(), result: Err("boom".into()) };
+    let ev = AppEvent::ActionResult {
+        title: "ai_done:ctx".into(),
+        result: Err("boom".into()),
+    };
     let dbg = format!("{ev:?}");
     assert!(dbg.contains("ActionResult"));
     assert!(dbg.contains("ai_done:ctx"));
@@ -613,9 +793,13 @@ async fn the_tui_sink_forwards_stream_events_onto_the_app_channel() {
     sink.emit("events", json!([1, 2]));
 
     let first = rx.try_recv().unwrap();
-    assert!(matches!(first, AppEvent::StreamEvent { ref channel, ref payload } if channel == "pods" && payload["name"] == "api-1"));
+    assert!(
+        matches!(first, AppEvent::StreamEvent { ref channel, ref payload } if channel == "pods" && payload["name"] == "api-1")
+    );
     let second = rx.try_recv().unwrap();
-    assert!(matches!(second, AppEvent::StreamEvent { ref channel, ref payload } if channel == "events" && payload == &json!([1, 2])));
+    assert!(
+        matches!(second, AppEvent::StreamEvent { ref channel, ref payload } if channel == "events" && payload == &json!([1, 2]))
+    );
     assert!(rx.try_recv().is_err());
 }
 
@@ -674,7 +858,11 @@ fn context_colour_reflects_the_environment_named_in_the_context() {
 
     assert_eq!(Theme::context_color("eu-PROD-1", false), prod);
     assert_eq!(Theme::context_color("prd-us", false), prod);
-    assert_eq!(Theme::context_color("live-cluster", true), prod, "prod outranks the local flag");
+    assert_eq!(
+        Theme::context_color("live-cluster", true),
+        prod,
+        "prod outranks the local flag"
+    );
     assert_eq!(Theme::context_color("stage-eu", false), staging);
     assert_eq!(Theme::context_color("stg", false), staging);
     assert_eq!(Theme::context_color("UAT", false), staging);
@@ -682,13 +870,26 @@ fn context_colour_reflects_the_environment_named_in_the_context() {
     assert_eq!(Theme::context_color("kind-dev", false), local);
     assert_eq!(Theme::context_color("minikube", false), local);
     assert_eq!(Theme::context_color("k3d-x", false), local);
-    assert_eq!(Theme::context_color("something", true), local, "local flag alone is enough");
+    assert_eq!(
+        Theme::context_color("something", true),
+        local,
+        "local flag alone is enough"
+    );
     assert_eq!(Theme::context_color("harvester-amd", false), other);
 }
 
 #[test]
 fn status_style_maps_every_status_family_to_its_colour() {
-    for s in ["CrashLoopBackOff", "Error", "Failed", "NotReady", "Unknown", "ImagePullBackOff", "Degraded", "false"] {
+    for s in [
+        "CrashLoopBackOff",
+        "Error",
+        "Failed",
+        "NotReady",
+        "Unknown",
+        "ImagePullBackOff",
+        "Degraded",
+        "false",
+    ] {
         assert_eq!(status_style(s), Theme::status_error(), "{s}");
     }
     for s in ["Scaled down", "Not scheduled", "Suspended"] {
@@ -697,7 +898,16 @@ fn status_style_maps_every_status_family_to_its_colour() {
     for s in ["Pending", "ContainerCreating", "Terminating", "Warning"] {
         assert_eq!(status_style(s), Theme::status_warn(), "{s}");
     }
-    for s in ["Running", "Active", "Ready", "Completed", "Succeeded", "Scheduled", "true", "SecretSynced"] {
+    for s in [
+        "Running",
+        "Active",
+        "Ready",
+        "Completed",
+        "Succeeded",
+        "Scheduled",
+        "true",
+        "SecretSynced",
+    ] {
         assert_eq!(status_style(s), Theme::status_ok(), "{s}");
     }
     assert_eq!(status_style("Bound"), Style::default().fg(Theme::FG));
@@ -710,9 +920,15 @@ fn status_style_maps_every_status_family_to_its_colour() {
 
 #[test]
 fn a_skill_placeholder_is_its_target_kind_or_blank() {
-    let crash = BUILTIN_PLAYBOOKS.iter().find(|s| s.command == "crashloop").unwrap();
+    let crash = BUILTIN_PLAYBOOKS
+        .iter()
+        .find(|s| s.command == "crashloop")
+        .unwrap();
     assert_eq!(crash.target_placeholder(), "Pod");
-    let clear = BUILTIN_PLAYBOOKS.iter().find(|s| s.command == "clear").unwrap();
+    let clear = BUILTIN_PLAYBOOKS
+        .iter()
+        .find(|s| s.command == "clear")
+        .unwrap();
     assert_eq!(clear.target_placeholder(), "");
 }
 
@@ -730,9 +946,18 @@ fn caveman_levels_round_trip_through_their_display_names() {
     }
     assert_eq!(CavemanLevel::WenyanLite.display_name(), "wenyan-lite");
     assert_eq!(CavemanLevel::WenyanUltra.display_name(), "wenyan-ultra");
-    assert_eq!(CavemanLevel::parse("  WENYAN_ULTRA "), Some(CavemanLevel::WenyanUltra));
-    assert_eq!(CavemanLevel::parse("wenyanlite"), Some(CavemanLevel::WenyanLite));
-    assert_eq!(CavemanLevel::parse("wenyanfull"), Some(CavemanLevel::WenyanFull));
+    assert_eq!(
+        CavemanLevel::parse("  WENYAN_ULTRA "),
+        Some(CavemanLevel::WenyanUltra)
+    );
+    assert_eq!(
+        CavemanLevel::parse("wenyanlite"),
+        Some(CavemanLevel::WenyanLite)
+    );
+    assert_eq!(
+        CavemanLevel::parse("wenyanfull"),
+        Some(CavemanLevel::WenyanFull)
+    );
 }
 
 #[test]
@@ -753,17 +978,27 @@ fn caveman_command_keywords_set_each_level_and_keep_the_trailing_question() {
     for (word, level) in cases {
         assert_eq!(
             parse_caveman_command(word),
-            CavemanCommandAction::SetLevel { level, remainder_query: None },
+            CavemanCommandAction::SetLevel {
+                level,
+                remainder_query: None
+            },
             "{word}"
         );
         assert_eq!(
             parse_caveman_command(&format!("{word}   why  is it slow?  ")),
-            CavemanCommandAction::SetLevel { level, remainder_query: Some("why is it slow?".into()) },
+            CavemanCommandAction::SetLevel {
+                level,
+                remainder_query: Some("why is it slow?".into())
+            },
             "{word} with question"
         );
     }
     for word in ["disable", "none", "OFF"] {
-        assert_eq!(parse_caveman_command(word), CavemanCommandAction::Disable, "{word}");
+        assert_eq!(
+            parse_caveman_command(word),
+            CavemanCommandAction::Disable,
+            "{word}"
+        );
     }
 }
 
@@ -771,7 +1006,11 @@ fn caveman_command_keywords_set_each_level_and_keep_the_trailing_question() {
 fn the_user_skills_dir_lives_under_an_assistant_skills_folder() {
     let dir = load_user_skills_dir();
     assert!(dir.ends_with("skills"), "{}", dir.display());
-    assert!(dir.to_string_lossy().contains("srelens"), "{}", dir.display());
+    assert!(
+        dir.to_string_lossy().contains("srelens"),
+        "{}",
+        dir.display()
+    );
 }
 
 #[test]
@@ -782,7 +1021,9 @@ fn slash_command_matching_uses_only_the_first_word() {
     assert!(match_slash_commands("/zzz").is_empty());
     assert_eq!(match_slash_commands("").len(), BUILTIN_PLAYBOOKS.len());
     // Alias and name prefixes both match: "node" is an alias of nodepressure.
-    assert!(match_slash_commands("/node").iter().any(|s| s.command == "nodepressure"));
+    assert!(match_slash_commands("/node")
+        .iter()
+        .any(|s| s.command == "nodepressure"));
 }
 
 #[test]
@@ -813,9 +1054,24 @@ fn slash_commands_expand_discovery_prompts_per_target_kind() {
 #[test]
 fn every_provider_maps_to_its_slug_label_defaults_and_env_var() {
     let table = [
-        (AiProvider::Anthropic, "anthropic", "ANTHROPIC_API_KEY", Some(ProviderKind::Anthropic)),
-        (AiProvider::OpenAi, "openai", "OPENAI_API_KEY", Some(ProviderKind::OpenAi)),
-        (AiProvider::Gemini, "gemini", "GEMINI_API_KEY", Some(ProviderKind::Gemini)),
+        (
+            AiProvider::Anthropic,
+            "anthropic",
+            "ANTHROPIC_API_KEY",
+            Some(ProviderKind::Anthropic),
+        ),
+        (
+            AiProvider::OpenAi,
+            "openai",
+            "OPENAI_API_KEY",
+            Some(ProviderKind::OpenAi),
+        ),
+        (
+            AiProvider::Gemini,
+            "gemini",
+            "GEMINI_API_KEY",
+            Some(ProviderKind::Gemini),
+        ),
         (
             AiProvider::OpenAiCompatible,
             "openai-compatible",
@@ -833,8 +1089,14 @@ fn every_provider_maps_to_its_slug_label_defaults_and_env_var() {
     }
     assert_eq!(ALL_PROVIDERS.len(), 5);
     assert_eq!(default_base_url_for_provider(AiProvider::Cursor), "");
-    assert_eq!(default_base_url_for_provider(AiProvider::OpenAi), "https://api.openai.com/v1");
-    assert_eq!(default_base_url_for_provider(AiProvider::Gemini), "https://generativelanguage.googleapis.com");
+    assert_eq!(
+        default_base_url_for_provider(AiProvider::OpenAi),
+        "https://api.openai.com/v1"
+    );
+    assert_eq!(
+        default_base_url_for_provider(AiProvider::Gemini),
+        "https://generativelanguage.googleapis.com"
+    );
     assert!(provider_display_name(AiProvider::Cursor).contains("cursor-agent"));
 }
 
@@ -849,7 +1111,10 @@ fn settings_missing_optional_fields_deserialize_with_defaults() {
     assert_eq!(s.caveman_level, None);
     // Blank maps fall back to the provider defaults.
     assert_eq!(s.get_model(AiProvider::Gemini), "gemini-2.5-flash");
-    assert_eq!(s.get_base_url(AiProvider::Anthropic), "https://api.anthropic.com");
+    assert_eq!(
+        s.get_base_url(AiProvider::Anthropic),
+        "https://api.anthropic.com"
+    );
     assert_eq!(s.get_timeout_seconds(AiProvider::Gemini), 120);
 }
 
@@ -861,11 +1126,18 @@ fn blank_model_url_and_zero_timeout_fall_back_to_defaults() {
     s.timeouts.clear();
     s.timeout_seconds = 0;
     assert_eq!(s.get_model(AiProvider::OpenAi), "gpt-4o");
-    assert_eq!(s.get_base_url(AiProvider::OpenAi), "https://api.openai.com/v1");
+    assert_eq!(
+        s.get_base_url(AiProvider::OpenAi),
+        "https://api.openai.com/v1"
+    );
     assert_eq!(s.get_timeout_seconds(AiProvider::OpenAi), 120);
 
     s.timeout_seconds = 45;
-    assert_eq!(s.get_timeout_seconds(AiProvider::OpenAi), 45, "global timeout when no per-provider entry");
+    assert_eq!(
+        s.get_timeout_seconds(AiProvider::OpenAi),
+        45,
+        "global timeout when no per-provider entry"
+    );
     s.set_timeout_seconds(AiProvider::OpenAi, 300);
     assert_eq!(s.get_timeout_seconds(AiProvider::OpenAi), 300);
     assert_eq!(s.timeout_seconds, 300);
@@ -889,7 +1161,9 @@ fn an_explicit_api_key_produces_a_provider_config_and_cursor_never_does() {
     s.api_keys.insert("anthropic".into(), "sk-ant-test".into());
     s.models.insert("anthropic".into(), "claude-x".into());
     s.max_tokens = 999;
-    let cfg = s.resolve_provider_config(AiProvider::Anthropic).expect("config");
+    let cfg = s
+        .resolve_provider_config(AiProvider::Anthropic)
+        .expect("config");
     assert_eq!(cfg.kind, ProviderKind::Anthropic);
     assert_eq!(cfg.api_key, "sk-ant-test");
     assert_eq!(cfg.model, "claude-x");
@@ -897,8 +1171,14 @@ fn an_explicit_api_key_produces_a_provider_config_and_cursor_never_does() {
     assert_eq!(cfg.max_tokens, 999);
 
     s.api_keys.insert("cursor".into(), "cur-key".into());
-    assert_eq!(s.get_api_key(AiProvider::Cursor).as_deref(), Some("cur-key"));
-    assert!(s.resolve_provider_config(AiProvider::Cursor).is_none(), "cursor is not a native provider");
+    assert_eq!(
+        s.get_api_key(AiProvider::Cursor).as_deref(),
+        Some("cur-key")
+    );
+    assert!(
+        s.resolve_provider_config(AiProvider::Cursor).is_none(),
+        "cursor is not a native provider"
+    );
 
     s.api_keys.insert("openai".into(), "   ".into());
     assert!(s.api_keys.contains_key("openai"));
@@ -921,7 +1201,12 @@ fn settings_paths_and_key_lookups_follow_the_environment() {
             }
         }
     }
-    let vars = ["SRELENS_AI_SETTINGS_PATH", "SRELENS_CONFIG_DIR", "GEMINI_API_KEY", "OPENAI_COMPATIBLE_API_KEY"];
+    let vars = [
+        "SRELENS_AI_SETTINGS_PATH",
+        "SRELENS_CONFIG_DIR",
+        "GEMINI_API_KEY",
+        "OPENAI_COMPATIBLE_API_KEY",
+    ];
     let _restore = Restore(vars.iter().map(|k| (*k, std::env::var(k).ok())).collect());
 
     // 1. Explicit settings file: save then load round-trips.
@@ -944,27 +1229,50 @@ fn settings_paths_and_key_lookups_follow_the_environment() {
     std::env::set_var("SRELENS_CONFIG_DIR", dir.path());
     assert_eq!(AiSettings::config_path(), file);
     std::env::set_var("SRELENS_AI_SETTINGS_PATH", "   ");
-    assert_eq!(AiSettings::config_path(), dir.path().join("ai_settings.json"));
+    assert_eq!(
+        AiSettings::config_path(),
+        dir.path().join("ai_settings.json")
+    );
     std::env::remove_var("SRELENS_AI_SETTINGS_PATH");
-    assert_eq!(AiSettings::config_path(), dir.path().join("ai_settings.json"));
+    assert_eq!(
+        AiSettings::config_path(),
+        dir.path().join("ai_settings.json")
+    );
 
     // 3. Key lookup: stored key first, then the provider's env var, else none.
     let mut s = AiSettings::default();
     std::env::remove_var("GEMINI_API_KEY");
     assert_eq!(s.get_api_key(AiProvider::Gemini), None);
-    assert!(s.resolve_provider_config(AiProvider::Gemini).is_none(), "no key, no config");
+    assert!(
+        s.resolve_provider_config(AiProvider::Gemini).is_none(),
+        "no key, no config"
+    );
     std::env::set_var("GEMINI_API_KEY", "g-env");
     assert_eq!(s.get_api_key(AiProvider::Gemini).as_deref(), Some("g-env"));
-    assert_eq!(s.resolve_provider_config(AiProvider::Gemini).unwrap().api_key, "g-env");
+    assert_eq!(
+        s.resolve_provider_config(AiProvider::Gemini)
+            .unwrap()
+            .api_key,
+        "g-env"
+    );
     s.api_keys.insert("gemini".into(), "g-stored".into());
-    assert_eq!(s.get_api_key(AiProvider::Gemini).as_deref(), Some("g-stored"));
+    assert_eq!(
+        s.get_api_key(AiProvider::Gemini).as_deref(),
+        Some("g-stored")
+    );
     std::env::set_var("GEMINI_API_KEY", "   ");
     s.api_keys.remove("gemini");
-    assert_eq!(s.get_api_key(AiProvider::Gemini), None, "blank env value is ignored");
+    assert_eq!(
+        s.get_api_key(AiProvider::Gemini),
+        None,
+        "blank env value is ignored"
+    );
 
     // 4. OpenAI-compatible endpoints need no key: "ollama" is substituted.
     std::env::remove_var("OPENAI_COMPATIBLE_API_KEY");
-    let cfg = s.resolve_provider_config(AiProvider::OpenAiCompatible).expect("keyless config");
+    let cfg = s
+        .resolve_provider_config(AiProvider::OpenAiCompatible)
+        .expect("keyless config");
     assert_eq!(cfg.api_key, "ollama");
     assert_eq!(cfg.base_url, "http://localhost:11434/v1");
 }
@@ -975,26 +1283,69 @@ fn settings_paths_and_key_lookups_follow_the_environment() {
 
 #[test]
 fn view_links_format_every_target_kind() {
-    let view = |target: CommandTarget| DeepLink::View { context: Some("prod".into()), namespace: None, target }.to_url();
-    assert_eq!(view(CommandTarget::Resource(ResourceKind::Assistant)), "srelens://view/prod/_/ai");
-    assert_eq!(view(CommandTarget::Resource(ResourceKind::Overview)), "srelens://view/prod/_/overview");
-    assert_eq!(view(CommandTarget::Resource(ResourceKind::Toolbox)), "srelens://view/prod/_/toolbox");
-    assert_eq!(view(CommandTarget::Resource(ResourceKind::Settings)), "srelens://view/prod/_/settings");
-    assert_eq!(view(CommandTarget::Resource(ResourceKind::Deployments)), "srelens://view/prod/_/deployments");
-    assert_eq!(view(CommandTarget::CustomResource(cilium_pool())), "srelens://view/prod/_/ciliumloadbalancerippools");
+    let view = |target: CommandTarget| {
+        DeepLink::View {
+            context: Some("prod".into()),
+            namespace: None,
+            target,
+        }
+        .to_url()
+    };
+    assert_eq!(
+        view(CommandTarget::Resource(ResourceKind::Assistant)),
+        "srelens://view/prod/_/ai"
+    );
+    assert_eq!(
+        view(CommandTarget::Resource(ResourceKind::Overview)),
+        "srelens://view/prod/_/overview"
+    );
+    assert_eq!(
+        view(CommandTarget::Resource(ResourceKind::Toolbox)),
+        "srelens://view/prod/_/toolbox"
+    );
+    assert_eq!(
+        view(CommandTarget::Resource(ResourceKind::Settings)),
+        "srelens://view/prod/_/settings"
+    );
+    assert_eq!(
+        view(CommandTarget::Resource(ResourceKind::Deployments)),
+        "srelens://view/prod/_/deployments"
+    );
+    assert_eq!(
+        view(CommandTarget::CustomResource(cilium_pool())),
+        "srelens://view/prod/_/ciliumloadbalancerippools"
+    );
     assert_eq!(view(CommandTarget::Help), "srelens://view/prod/_/help");
-    assert_eq!(view(CommandTarget::Contexts), "srelens://view/prod/_/contexts");
-    assert_eq!(view(CommandTarget::Namespaces), "srelens://view/prod/_/namespaces");
+    assert_eq!(
+        view(CommandTarget::Contexts),
+        "srelens://view/prod/_/contexts"
+    );
+    assert_eq!(
+        view(CommandTarget::Namespaces),
+        "srelens://view/prod/_/namespaces"
+    );
     assert_eq!(view(CommandTarget::Quit), "srelens://view/prod/_/quit");
-    assert_eq!(view(CommandTarget::OpenUrl("x".into())), "srelens://view/prod/_/open/x");
+    assert_eq!(
+        view(CommandTarget::OpenUrl("x".into())),
+        "srelens://view/prod/_/open/x"
+    );
 
-    let no_ctx = DeepLink::View { context: None, namespace: Some("web".into()), target: CommandTarget::Help };
+    let no_ctx = DeepLink::View {
+        context: None,
+        namespace: Some("web".into()),
+        target: CommandTarget::Help,
+    };
     assert_eq!(no_ctx.to_url(), "srelens://view/_/web/help");
 }
 
 #[test]
 fn resource_links_with_blank_context_or_namespace_format_placeholders() {
-    let link = DeepLink::Resource { context: String::new(), namespace: Some(String::new()), kind: "Pod".into(), name: "p".into() };
+    let link = DeepLink::Resource {
+        context: String::new(),
+        namespace: Some(String::new()),
+        kind: "Pod".into(),
+        name: "p".into(),
+    };
     assert_eq!(link.to_url(), "srelens://resource/_/_/Pod/p");
 }
 
@@ -1003,7 +1354,11 @@ fn view_links_parse_with_placeholder_context_and_namespace() {
     let link = DeepLink::parse("srelens://view/_/_all/pods").unwrap();
     assert_eq!(
         link,
-        DeepLink::View { context: None, namespace: None, target: CommandTarget::Resource(ResourceKind::Pods) }
+        DeepLink::View {
+            context: None,
+            namespace: None,
+            target: CommandTarget::Resource(ResourceKind::Pods)
+        }
     );
     assert_eq!(link.to_url(), "srelens://view/_/_/pods");
 
@@ -1019,7 +1374,14 @@ fn view_links_parse_with_placeholder_context_and_namespace() {
     assert_eq!(link.to_url(), "srelens://view/prod/web/deployments");
 
     let dash = DeepLink::parse("srelens://view/prod/-/ai").unwrap();
-    assert!(matches!(dash, DeepLink::View { namespace: None, target: CommandTarget::Resource(ResourceKind::Assistant), .. }));
+    assert!(matches!(
+        dash,
+        DeepLink::View {
+            namespace: None,
+            target: CommandTarget::Resource(ResourceKind::Assistant),
+            ..
+        }
+    ));
 }
 
 #[test]
@@ -1030,14 +1392,22 @@ fn malformed_srelens_urls_explain_what_is_missing() {
     assert!(err("srelens://resource/prod/ns/Pod").contains("Expected format: srelens://resource/"));
     assert!(err("srelens://cluster").contains("Expected format: srelens://cluster/<context>"));
     assert!(err("srelens://view/prod/ns").contains("Expected format: srelens://view/"));
-    assert_eq!(err("srelens://view/prod/ns/nosuchview"), "Unknown view target: 'nosuchview'");
+    assert_eq!(
+        err("srelens://view/prod/ns/nosuchview"),
+        "Unknown view target: 'nosuchview'"
+    );
     assert!(err("srelens://bogus/x").starts_with("Unknown srelens URL route 'bogus'"));
 }
 
 #[test]
 fn the_context_route_is_an_alias_for_cluster() {
     let link = DeepLink::parse("srelens://context/prod-eu").unwrap();
-    assert_eq!(link, DeepLink::Cluster { context: "prod-eu".into() });
+    assert_eq!(
+        link,
+        DeepLink::Cluster {
+            context: "prod-eu".into()
+        }
+    );
     assert_eq!(link.to_url(), "srelens://cluster/prod-eu");
 }
 
@@ -1045,24 +1415,49 @@ fn the_context_route_is_an_alias_for_cluster() {
 fn shorthand_targets_parse_by_segment_count() {
     assert_eq!(
         DeepLink::parse("web/Deployment/api").unwrap(),
-        DeepLink::Resource { context: String::new(), namespace: Some("web".into()), kind: "Deployment".into(), name: "api".into() }
+        DeepLink::Resource {
+            context: String::new(),
+            namespace: Some("web".into()),
+            kind: "Deployment".into(),
+            name: "api".into()
+        }
     );
     for placeholder in ["_", "_all", "-"] {
         let link = DeepLink::parse(&format!("{placeholder}/Node/worker-1")).unwrap();
-        assert!(matches!(link, DeepLink::Resource { namespace: None, .. }), "{placeholder}");
+        assert!(
+            matches!(
+                link,
+                DeepLink::Resource {
+                    namespace: None,
+                    ..
+                }
+            ),
+            "{placeholder}"
+        );
         let link = DeepLink::parse(&format!("prod/{placeholder}/Node/worker-1")).unwrap();
-        assert!(matches!(&link, DeepLink::Resource { context, namespace: None, .. } if context == "prod"), "{placeholder}");
+        assert!(
+            matches!(&link, DeepLink::Resource { context, namespace: None, .. } if context == "prod"),
+            "{placeholder}"
+        );
     }
     assert_eq!(
         DeepLink::parse("prod/web/Pod/api-1").unwrap(),
-        DeepLink::Resource { context: "prod".into(), namespace: Some("web".into()), kind: "Pod".into(), name: "api-1".into() }
+        DeepLink::Resource {
+            context: "prod".into(),
+            namespace: Some("web".into()),
+            kind: "Pod".into(),
+            name: "api-1".into()
+        }
     );
     assert_eq!(
         DeepLink::parse("prod/web/Pod/api-1").unwrap().to_url(),
         "srelens://resource/prod/web/Pod/api-1"
     );
     let err = DeepLink::parse("a/b/c/d/e").unwrap_err();
-    assert!(err.starts_with("Unrecognized shorthand format 'a/b/c/d/e'"), "{err}");
+    assert!(
+        err.starts_with("Unrecognized shorthand format 'a/b/c/d/e'"),
+        "{err}"
+    );
     let err = DeepLink::parse("solo/").unwrap_err();
     assert!(err.contains("Unrecognized shorthand format"), "{err}");
 }
@@ -1072,9 +1467,16 @@ fn a_bare_command_word_becomes_a_view_link_and_nonsense_is_rejected() {
     let link = DeepLink::parse("  nodes ").unwrap();
     assert_eq!(
         link,
-        DeepLink::View { context: None, namespace: None, target: CommandTarget::Resource(ResourceKind::Nodes) }
+        DeepLink::View {
+            context: None,
+            namespace: None,
+            target: CommandTarget::Resource(ResourceKind::Nodes)
+        }
     );
-    assert_eq!(DeepLink::parse("nosuchthing").unwrap_err(), "Unrecognized target or URL: 'nosuchthing'");
+    assert_eq!(
+        DeepLink::parse("nosuchthing").unwrap_err(),
+        "Unrecognized target or URL: 'nosuchthing'"
+    );
 }
 
 #[test]
@@ -1139,7 +1541,10 @@ fn display_names_are_unique_and_match_the_display_impl() {
     }
     assert_eq!(ResourceKind::HelmReleases.display_name(), "Helm Releases");
     assert_eq!(ResourceKind::Overview.display_name(), "Cluster Overview");
-    assert_eq!(ResourceKind::Settings.display_name(), "AI & Assistant Settings");
+    assert_eq!(
+        ResourceKind::Settings.display_name(),
+        "AI & Assistant Settings"
+    );
     let custom = ResourceKind::CustomResource(cilium_pool());
     assert_eq!(custom.display_name(), "CiliumLoadBalancerIPPool");
     assert_eq!(custom.to_string(), "CiliumLoadBalancerIPPool");
@@ -1173,7 +1578,10 @@ fn watch_kinds_are_lowercase_plurals_for_watchable_kinds_only() {
         }
     }
     assert_eq!(watchable, 25);
-    assert_eq!(ResourceKind::CustomResource(cilium_pool()).watch_kind(), None);
+    assert_eq!(
+        ResourceKind::CustomResource(cilium_pool()).watch_kind(),
+        None
+    );
 }
 
 #[test]
@@ -1184,7 +1592,10 @@ fn k8s_kinds_are_singular_pascal_case_and_crds_use_their_own_kind() {
                 assert!(k.chars().next().unwrap().is_ascii_uppercase(), "{kind:?}");
                 // Every k8s kind is a singular of its display name (Endpoints stays plural).
                 if kind != ResourceKind::Endpoints {
-                    assert!(kind.display_name().starts_with(&k[..k.len() - 1]), "{kind:?}: {k}");
+                    assert!(
+                        kind.display_name().starts_with(&k[..k.len() - 1]),
+                        "{kind:?}: {k}"
+                    );
                 }
             }
             None => assert!(
@@ -1203,9 +1614,18 @@ fn k8s_kinds_are_singular_pascal_case_and_crds_use_their_own_kind() {
         }
     }
     assert_eq!(ResourceKind::Ingresses.k8s_kind(), Some("Ingress"));
-    assert_eq!(ResourceKind::NetworkPolicies.k8s_kind(), Some("NetworkPolicy"));
-    assert_eq!(ResourceKind::CustomResourceDefinitions.k8s_kind(), Some("CustomResourceDefinition"));
-    assert_eq!(ResourceKind::CustomResource(cilium_pool()).k8s_kind(), Some("CiliumLoadBalancerIPPool"));
+    assert_eq!(
+        ResourceKind::NetworkPolicies.k8s_kind(),
+        Some("NetworkPolicy")
+    );
+    assert_eq!(
+        ResourceKind::CustomResourceDefinitions.k8s_kind(),
+        Some("CustomResourceDefinition")
+    );
+    assert_eq!(
+        ResourceKind::CustomResource(cilium_pool()).k8s_kind(),
+        Some("CiliumLoadBalancerIPPool")
+    );
 }
 
 #[test]
@@ -1223,7 +1643,11 @@ fn cluster_scoped_kinds_are_not_namespaced() {
         ResourceKind::Assistant,
     ];
     for kind in all_static_kinds() {
-        assert_eq!(kind.is_namespaced(), !cluster_scoped.contains(&kind), "{kind:?}");
+        assert_eq!(
+            kind.is_namespaced(),
+            !cluster_scoped.contains(&kind),
+            "{kind:?}"
+        );
     }
     assert!(ResourceKind::CustomResource(cilium_pool()).is_namespaced());
 }
@@ -1248,13 +1672,24 @@ fn a_crd_definition_collects_singular_short_names_and_lb_shorthands_without_dupl
     assert_eq!(def.name, "ciliumloadbalancerippools");
     assert_eq!(
         def.aliases,
-        vec!["ciliumloadbalancerippool", "ippool", "ciliumlbippools", "ciliumlbippool"]
+        vec![
+            "ciliumloadbalancerippool",
+            "ippool",
+            "ciliumlbippools",
+            "ciliumlbippool"
+        ]
     );
     assert_eq!(def.description, "CRD: CiliumLoadBalancerIPPool (cilium.io)");
     assert_eq!(def.target, CommandTarget::CustomResource(cilium_pool()));
 
     // Same singular as plural, a short name equal to the singular, no "loadbalancer".
-    let plain = crd("widgets", "widgets", "Widget", "example.io", &["widgets", "wd"]);
+    let plain = crd(
+        "widgets",
+        "widgets",
+        "Widget",
+        "example.io",
+        &["widgets", "wd"],
+    );
     let def = DynamicCommandDef::from(&plain);
     assert_eq!(def.aliases, vec!["widgets", "wd"]);
 }
@@ -1265,22 +1700,49 @@ fn resolve_recognises_direct_urls_and_open_prefixes() {
         resolve_command(":srelens://cluster/prod"),
         Some(CommandTarget::OpenUrl("srelens://cluster/prod".into()))
     );
-    assert_eq!(resolve_command("open  pods/api "), Some(CommandTarget::OpenUrl("pods/api".into())));
-    assert_eq!(resolve_command(":open:srelens://x"), Some(CommandTarget::OpenUrl("srelens://x".into())));
-    assert_eq!(resolve_command("goto nodes"), Some(CommandTarget::OpenUrl("nodes".into())));
-    assert_eq!(resolve_command("goto:nodes"), Some(CommandTarget::OpenUrl("nodes".into())));
+    assert_eq!(
+        resolve_command("open  pods/api "),
+        Some(CommandTarget::OpenUrl("pods/api".into()))
+    );
+    assert_eq!(
+        resolve_command(":open:srelens://x"),
+        Some(CommandTarget::OpenUrl("srelens://x".into()))
+    );
+    assert_eq!(
+        resolve_command("goto nodes"),
+        Some(CommandTarget::OpenUrl("nodes".into()))
+    );
+    assert_eq!(
+        resolve_command("goto:nodes"),
+        Some(CommandTarget::OpenUrl("nodes".into()))
+    );
     // Bare "open" is the registry entry with an empty URL.
-    assert_eq!(resolve_command(":open"), Some(CommandTarget::OpenUrl(String::new())));
+    assert_eq!(
+        resolve_command(":open"),
+        Some(CommandTarget::OpenUrl(String::new()))
+    );
     assert_eq!(resolve_command(""), None);
     assert_eq!(resolve_command("  :  "), None);
 }
 
 #[test]
 fn resolve_matches_static_commands_case_insensitively_then_by_prefix() {
-    assert_eq!(resolve_command(":PODS"), Some(CommandTarget::Resource(ResourceKind::Pods)));
-    assert_eq!(resolve_command(":Deploy"), Some(CommandTarget::Resource(ResourceKind::Deployments)));
-    assert_eq!(resolve_command(":statef"), Some(CommandTarget::Resource(ResourceKind::StatefulSets)));
-    assert_eq!(resolve_command(":netpo"), Some(CommandTarget::Resource(ResourceKind::NetworkPolicies)));
+    assert_eq!(
+        resolve_command(":PODS"),
+        Some(CommandTarget::Resource(ResourceKind::Pods))
+    );
+    assert_eq!(
+        resolve_command(":Deploy"),
+        Some(CommandTarget::Resource(ResourceKind::Deployments))
+    );
+    assert_eq!(
+        resolve_command(":statef"),
+        Some(CommandTarget::Resource(ResourceKind::StatefulSets))
+    );
+    assert_eq!(
+        resolve_command(":netpo"),
+        Some(CommandTarget::Resource(ResourceKind::NetworkPolicies))
+    );
     assert_eq!(resolve_command(":?"), Some(CommandTarget::Help));
     assert_eq!(resolve_command(":exit"), Some(CommandTarget::Quit));
     assert_eq!(resolve_command(":zzzz"), None);
@@ -1288,23 +1750,67 @@ fn resolve_matches_static_commands_case_insensitively_then_by_prefix() {
 
 #[test]
 fn resolve_matches_crds_by_every_name_and_by_prefix_only_from_three_characters() {
-    let crds = vec![cilium_pool(), crd("widgets", "widget", "Widget", "example.io", &["wg"])];
+    let crds = vec![
+        cilium_pool(),
+        crd("widgets", "widget", "Widget", "example.io", &["wg"]),
+    ];
     let pool = CommandTarget::CustomResource(cilium_pool());
     let widget = CommandTarget::CustomResource(crds[1].clone());
 
-    assert_eq!(resolve_command_with_crds(":CiliumLoadBalancerIPPool", &crds), Some(pool.clone()), "kind");
-    assert_eq!(resolve_command_with_crds("ciliumloadbalancerippools.cilium.io", &crds), Some(pool.clone()), "crd name");
-    assert_eq!(resolve_command_with_crds(":ippool", &crds), Some(pool.clone()), "short name");
-    assert_eq!(resolve_command_with_crds(":ciliumlbippools", &crds), Some(pool.clone()), "lb plural");
-    assert_eq!(resolve_command_with_crds(":widget", &crds), Some(widget.clone()), "singular");
-    assert_eq!(resolve_command_with_crds(":wg", &crds), Some(widget.clone()), "two-char short name is exact");
-    assert_eq!(resolve_command_with_crds(":ciliumlb", &crds), Some(pool.clone()), "prefix of lb shorthand");
-    assert_eq!(resolve_command_with_crds(":widg", &crds), Some(widget), "prefix of plural");
+    assert_eq!(
+        resolve_command_with_crds(":CiliumLoadBalancerIPPool", &crds),
+        Some(pool.clone()),
+        "kind"
+    );
+    assert_eq!(
+        resolve_command_with_crds("ciliumloadbalancerippools.cilium.io", &crds),
+        Some(pool.clone()),
+        "crd name"
+    );
+    assert_eq!(
+        resolve_command_with_crds(":ippool", &crds),
+        Some(pool.clone()),
+        "short name"
+    );
+    assert_eq!(
+        resolve_command_with_crds(":ciliumlbippools", &crds),
+        Some(pool.clone()),
+        "lb plural"
+    );
+    assert_eq!(
+        resolve_command_with_crds(":widget", &crds),
+        Some(widget.clone()),
+        "singular"
+    );
+    assert_eq!(
+        resolve_command_with_crds(":wg", &crds),
+        Some(widget.clone()),
+        "two-char short name is exact"
+    );
+    assert_eq!(
+        resolve_command_with_crds(":ciliumlb", &crds),
+        Some(pool.clone()),
+        "prefix of lb shorthand"
+    );
+    assert_eq!(
+        resolve_command_with_crds(":widg", &crds),
+        Some(widget),
+        "prefix of plural"
+    );
     // Two characters never prefix-match a CRD; the static registry wins instead.
     assert_eq!(resolve_command_with_crds(":wi", &crds), None);
-    assert_eq!(resolve_command_with_crds(":po", &crds), Some(CommandTarget::Resource(ResourceKind::Pods)));
+    assert_eq!(
+        resolve_command_with_crds(":po", &crds),
+        Some(CommandTarget::Resource(ResourceKind::Pods))
+    );
     // CRD prefix beats static prefix.
-    let cr_like = vec![crd("crontabs", "crontab", "CronTab", "stable.example.com", &[])];
+    let cr_like = vec![crd(
+        "crontabs",
+        "crontab",
+        "CronTab",
+        "stable.example.com",
+        &[],
+    )];
     assert_eq!(
         resolve_command_with_crds(":cront", &cr_like),
         Some(CommandTarget::CustomResource(cr_like[0].clone()))
@@ -1313,19 +1819,41 @@ fn resolve_matches_crds_by_every_name_and_by_prefix_only_from_three_characters()
 
 #[test]
 fn namespace_and_context_switch_forms_resolve_to_their_switchers() {
-    assert_eq!(resolve_command(":ns kube-system"), Some(CommandTarget::Namespaces));
-    assert_eq!(resolve_command("ctx prod-eu"), Some(CommandTarget::Contexts));
-    assert_eq!(resolve_command("ns   "), Some(CommandTarget::Namespaces), "bare alias after trim");
+    assert_eq!(
+        resolve_command(":ns kube-system"),
+        Some(CommandTarget::Namespaces)
+    );
+    assert_eq!(
+        resolve_command("ctx prod-eu"),
+        Some(CommandTarget::Contexts)
+    );
+    assert_eq!(
+        resolve_command("ns   "),
+        Some(CommandTarget::Namespaces),
+        "bare alias after trim"
+    );
 }
 
 #[test]
 fn an_empty_query_suggests_the_whole_registry_and_at_most_thirty_crds() {
-    let crds: Vec<CrdMeta> =
-        (0..35).map(|i| crd(&format!("things{i}"), &format!("thing{i}"), &format!("Thing{i}"), "x.io", &[])).collect();
+    let crds: Vec<CrdMeta> = (0..35)
+        .map(|i| {
+            crd(
+                &format!("things{i}"),
+                &format!("thing{i}"),
+                &format!("Thing{i}"),
+                "x.io",
+                &[],
+            )
+        })
+        .collect();
     let all = command_suggestions_with_crds(" : ", &crds);
     assert_eq!(all.len(), COMMAND_REGISTRY.len() + 30);
     assert!(all.iter().all(|(_, score)| *score == 0));
-    assert_eq!(all[0].0.name, COMMAND_REGISTRY[0].name, "registry order is preserved");
+    assert_eq!(
+        all[0].0.name, COMMAND_REGISTRY[0].name,
+        "registry order is preserved"
+    );
     assert_eq!(all[COMMAND_REGISTRY.len()].0.name, "things0");
     assert_eq!(command_suggestions("").len(), COMMAND_REGISTRY.len());
 }
@@ -1340,21 +1868,37 @@ fn static_suggestions_are_scored_by_match_quality_and_sorted() {
 
     let sv = command_suggestions(":sv");
     assert_eq!(sv.len(), 1);
-    assert_eq!((sv[0].0.name.as_str(), sv[0].1), ("services", 80), "alias prefix");
+    assert_eq!(
+        (sv[0].0.name.as_str(), sv[0].1),
+        ("services", 80),
+        "alias prefix"
+    );
 
     let health = command_suggestions("health");
     assert_eq!(health.len(), 1);
-    assert_eq!((health[0].0.name.as_str(), health[0].1), ("overview", 50), "description contains");
+    assert_eq!(
+        (health[0].0.name.as_str(), health[0].1),
+        ("overview", 50),
+        "description contains"
+    );
 
     let ole = command_suggestions("ole");
-    assert!(ole.iter().any(|(d, s)| d.name == "roles" && *s == 50), "name contains: {:?}", ole);
+    assert!(
+        ole.iter().any(|(d, s)| d.name == "roles" && *s == 50),
+        "name contains: {:?}",
+        ole
+    );
 
     let ties = command_suggestions("c");
     let scores: Vec<usize> = ties.iter().map(|(_, s)| *s).collect();
     let mut sorted = scores.clone();
     sorted.sort_unstable_by(|a, b| b.cmp(a));
     assert_eq!(scores, sorted, "descending by score");
-    let hundreds: Vec<&str> = ties.iter().filter(|(_, s)| *s == 100).map(|(d, _)| d.name.as_str()).collect();
+    let hundreds: Vec<&str> = ties
+        .iter()
+        .filter(|(_, s)| *s == 100)
+        .map(|(d, _)| d.name.as_str())
+        .collect();
     let mut alpha = hundreds.clone();
     alpha.sort_unstable();
     assert_eq!(hundreds, alpha, "ties break alphabetically");

--- a/apps/tui/tests/views_inspect_tests.rs
+++ b/apps/tui/tests/views_inspect_tests.rs
@@ -1,0 +1,2018 @@
+//! Integration tests for the four "inspect something" views: the node
+//! inspector, the settings screen, the cluster overview and the YAML viewer.
+//!
+//! Every test builds a state through its public constructors and mutators,
+//! asserts the state, then renders it through ratatui's `TestBackend` at a
+//! wide and a narrow size and asserts on text that only the intended branch
+//! could have drawn. Nothing here touches a cluster, the network, the user's
+//! config file or an editor.
+
+mod common;
+
+use ratatui::backend::TestBackend;
+use ratatui::buffer::Buffer;
+use ratatui::style::Color;
+use ratatui::{Frame, Terminal};
+
+use srelens_kube::node_inspector::{
+    NodeConditionInfo, NodeInspectorDetails, NodePodItem, NodeTaintInfo,
+};
+use srelens_tui::ai_config::{AiProvider, AiSettings};
+use srelens_tui::theme::Theme;
+use srelens_tui::views::node_inspector_view::{render_node_inspector_view, NodeInspectorState};
+use srelens_tui::views::overview_view::{
+    render_overview_view, ClusterOverviewData, OverviewViewState,
+};
+use srelens_tui::views::settings_view::{render_settings_view, SettingField, SettingsViewState};
+use srelens_tui::views::yaml_view::{render_yaml_view, YamlViewState};
+
+/// Render one frame and hand back the raw buffer, for the few assertions that
+/// need a cell's style rather than its text.
+fn render_buffer<F>(width: u16, height: u16, draw: F) -> Buffer
+where
+    F: FnOnce(&mut Frame),
+{
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    terminal.draw(draw).expect("draw");
+    terminal.backend().buffer().clone()
+}
+
+/// The screen column at which `needle` starts in a rendered row. `str::find`
+/// gives a byte offset, which drifts from the column as soon as a row holds
+/// a box-drawing or bullet character.
+fn col(line: &str, needle: &str) -> u16 {
+    let byte = line
+        .find(needle)
+        .unwrap_or_else(|| panic!("no {needle:?} in {line:?}"));
+    line[..byte].chars().count() as u16
+}
+
+/// The row index of the first rendered line containing `needle`.
+fn row_of(lines: &[String], needle: &str) -> usize {
+    lines
+        .iter()
+        .position(|l| l.contains(needle))
+        .unwrap_or_else(|| panic!("no row contains {needle:?}:\n{}", lines.join("\n")))
+}
+
+// ───────────────────────────── node inspector ─────────────────────────────
+
+fn pod(namespace: &str, name: &str, phase: &str) -> NodePodItem {
+    NodePodItem {
+        name: name.to_string(),
+        namespace: namespace.to_string(),
+        phase: phase.to_string(),
+        ready_containers: "1/1".to_string(),
+        restarts: 0,
+        age: "3d".to_string(),
+        cpu_requests_millicores: 100,
+        mem_requests_mib: 128,
+        gpu_requests: 0,
+        gpu_mem_requests_mib: 0,
+        pod_ip: "10.244.1.5".to_string(),
+    }
+}
+
+fn node_details(name: &str) -> NodeInspectorDetails {
+    NodeInspectorDetails {
+        name: name.to_string(),
+        status: "Ready".to_string(),
+        unschedulable: false,
+        roles: "worker".to_string(),
+        instance_type: "m5.xlarge".to_string(),
+        zone: None,
+        region: None,
+        nodepool: None,
+        internal_ip: None,
+        external_ip: None,
+        os_image: "Ubuntu 22.04".to_string(),
+        kernel_version: "5.15.0".to_string(),
+        container_runtime: "containerd://1.7".to_string(),
+        kubelet_version: "v1.30.2".to_string(),
+        architecture: "amd64".to_string(),
+        created_at: "2026-01-01T00:00:00Z".to_string(),
+        cpu_capacity_millicores: 8000,
+        cpu_allocatable_millicores: 7800,
+        cpu_requests_millicores: 2500,
+        mem_capacity_mib: 32768,
+        mem_allocatable_mib: 31000,
+        mem_requests_mib: 14000,
+        pods_capacity: 110,
+        pods_allocatable: 110,
+        pods_count: 2,
+        has_gpu: false,
+        gpu_model: None,
+        gpu_driver_version: None,
+        gpu_cuda_version: None,
+        gpu_capacity_count: 0,
+        gpu_allocatable_count: 0,
+        gpu_requests_count: 0,
+        gpu_memory_total_mib: None,
+        gpu_memory_requests_mib: 0,
+        conditions: vec![NodeConditionInfo {
+            type_: "Ready".to_string(),
+            status: "True".to_string(),
+            reason: None,
+            message: None,
+        }],
+        taints: vec![],
+        pods: vec![
+            pod("kube-system", "coredns-abc", "Running"),
+            pod("monitoring", "node-exporter", "Running"),
+        ],
+    }
+}
+
+fn node_state(details: NodeInspectorDetails) -> NodeInspectorState {
+    let mut state = NodeInspectorState::new(details.name.clone());
+    state.set_details(details);
+    state
+}
+
+fn render_node(width: u16, height: u16, state: &NodeInspectorState) -> String {
+    common::render_text(width, height, |f| {
+        render_node_inspector_view(f, f.area(), state)
+    })
+}
+
+#[test]
+fn node_inspector_starts_loading_and_draws_the_loading_placeholder() {
+    let state = NodeInspectorState::new("node-1".to_string());
+    assert!(state.is_loading);
+    assert!(state.details.is_none());
+    assert_eq!(state.pods_len(), 0);
+    assert!(state.selected_pod().is_none());
+
+    let wide = render_node(120, 40, &state);
+    assert!(wide.contains("Node Inspector: node-1"), "{wide}");
+    assert!(wide.contains("Inspecting node 'node-1'..."), "{wide}");
+    assert!(wide.contains("Fetching hardware capacity"), "{wide}");
+    assert!(!wide.contains("Scheduled Pods"), "{wide}");
+
+    let narrow = render_node(60, 20, &state);
+    assert!(narrow.contains("Node Inspector: node-1"), "{narrow}");
+    assert!(narrow.contains("Inspecting node 'node-1'"), "{narrow}");
+}
+
+#[test]
+fn node_inspector_error_without_details_draws_the_error_panel_with_retry_hint() {
+    let mut state = NodeInspectorState::new("node-1".to_string());
+    state.set_error("nodes \"node-1\" not found".to_string());
+    assert!(!state.is_loading);
+    assert_eq!(state.error.as_deref(), Some("nodes \"node-1\" not found"));
+
+    let text = render_node(120, 40, &state);
+    assert!(text.contains("Node Inspector Error: node-1"), "{text}");
+    assert!(text.contains("Failed to inspect node 'node-1':"), "{text}");
+    assert!(text.contains("nodes \"node-1\" not found"), "{text}");
+    assert!(
+        text.contains("Press <Esc> or <q> to return, or <r> to retry."),
+        "{text}"
+    );
+    assert!(!text.contains("Scheduled Pods"), "{text}");
+}
+
+#[test]
+fn node_inspector_error_after_details_keeps_showing_the_dashboard() {
+    let mut state = node_state(node_details("node-1"));
+    state.set_error("refresh failed".to_string());
+    assert!(state.details.is_some());
+
+    let text = render_node(120, 40, &state);
+    assert!(!text.contains("Node Inspector Error"), "{text}");
+    assert!(text.contains("Scheduled Pods (2 Total)"), "{text}");
+}
+
+#[test]
+fn node_inspector_not_loading_with_no_details_and_no_error_draws_nothing() {
+    let mut state = NodeInspectorState::new("node-1".to_string());
+    state.is_loading = false;
+    let lines = common::render_lines(60, 20, |f| render_node_inspector_view(f, f.area(), &state));
+    assert!(lines.iter().all(|l| l.is_empty()), "{lines:?}");
+}
+
+#[test]
+fn node_inspector_set_details_clears_error_and_clamps_the_selection() {
+    let mut state = NodeInspectorState::new("node-1".to_string());
+    state.set_error("boom".to_string());
+    state.selected_pod_idx = 7;
+    state.set_details(node_details("node-1"));
+    assert!(state.error.is_none());
+    assert!(!state.is_loading);
+    assert_eq!(state.pods_len(), 2);
+    assert_eq!(state.selected_pod_idx, 1);
+    assert_eq!(state.selected_pod().unwrap().name, "node-exporter");
+
+    // With no pods the selection clamps to zero rather than underflowing.
+    let mut empty = node_details("node-1");
+    empty.pods.clear();
+    state.selected_pod_idx = 3;
+    state.set_details(empty);
+    assert_eq!(state.selected_pod_idx, 0);
+    assert!(state.selected_pod().is_none());
+}
+
+#[test]
+fn node_inspector_selection_moves_within_bounds_and_pages() {
+    let mut details = node_details("node-1");
+    details.pods = (0..10)
+        .map(|i| pod("default", &format!("pod-{i}"), "Running"))
+        .collect();
+    let mut state = node_state(details);
+
+    state.select_prev();
+    assert_eq!(state.selected_pod_idx, 0);
+    state.select_next();
+    state.select_next();
+    assert_eq!(state.selected_pod_idx, 2);
+    state.page_down(5);
+    assert_eq!(state.selected_pod_idx, 7);
+    state.page_down(50);
+    assert_eq!(state.selected_pod_idx, 9);
+    state.select_next();
+    assert_eq!(
+        state.selected_pod_idx, 9,
+        "select_next stops at the last pod"
+    );
+    state.page_up(4);
+    assert_eq!(state.selected_pod_idx, 5);
+    state.page_up(100);
+    assert_eq!(state.selected_pod_idx, 0);
+    state.select_last();
+    assert_eq!(state.selected_pod_idx, 9);
+    state.scroll_offset = 4;
+    state.select_first();
+    assert_eq!(state.selected_pod_idx, 0);
+    assert_eq!(state.scroll_offset, 0);
+
+    // Empty pod lists never move the selection.
+    let mut empty = NodeInspectorState::new("n".to_string());
+    empty.select_next();
+    empty.select_last();
+    empty.page_down(3);
+    assert_eq!(empty.selected_pod_idx, 0);
+}
+
+#[test]
+fn node_inspector_metrics_history_is_replaced_wholesale() {
+    let mut state = NodeInspectorState::new("node-1".to_string());
+    state.update_metrics_history(&[1, 2, 3], &[10, 20]);
+    assert_eq!(state.cpu_history, vec![1, 2, 3]);
+    assert_eq!(state.mem_history, vec![10, 20]);
+    state.update_metrics_history(&[9], &[]);
+    assert_eq!(state.cpu_history, vec![9]);
+    assert!(state.mem_history.is_empty());
+}
+
+#[test]
+fn node_inspector_header_shows_status_role_type_kubelet_os_kernel_and_runtime() {
+    let state = node_state(node_details("node-1"));
+    let text = render_node(160, 40, &state);
+    assert!(text.contains("Node: node-1"), "{text}");
+    assert!(text.contains("● Ready"), "{text}");
+    assert!(!text.contains("CORDONED"), "{text}");
+    assert!(text.contains("Role: worker"), "{text}");
+    assert!(text.contains("Type: m5.xlarge"), "{text}");
+    assert!(!text.contains("Zone:"), "{text}");
+    assert!(!text.contains("Pool:"), "{text}");
+    assert!(text.contains("Kubelet: v1.30.2"), "{text}");
+    assert!(text.contains("OS: Ubuntu 22.04 (amd64)"), "{text}");
+    assert!(text.contains("Kernel: 5.15.0"), "{text}");
+    assert!(text.contains("Runtime: containerd://1.7"), "{text}");
+    assert!(!text.contains("IP:"), "{text}");
+}
+
+#[test]
+fn node_inspector_header_shows_cordon_badge_gpu_model_zone_pool_and_ip() {
+    let mut details = node_details("gpu-node");
+    details.status = "NotReady".to_string();
+    details.unschedulable = true;
+    details.has_gpu = true;
+    details.gpu_model = Some("Tesla T4".to_string());
+    details.zone = Some("eu-west-1b".to_string());
+    details.nodepool = Some("gpu-pool".to_string());
+    details.internal_ip = Some("10.0.1.50".to_string());
+    let state = node_state(details);
+
+    let text = render_node(180, 40, &state);
+    assert!(text.contains("● NotReady"), "{text}");
+    assert!(text.contains("[CORDONED / UNSCHEDULABLE]"), "{text}");
+    assert!(text.contains("Tesla T4]"), "{text}");
+    assert!(text.contains("Zone: eu-west-1b"), "{text}");
+    assert!(text.contains("Pool: gpu-pool"), "{text}");
+    assert!(text.contains("IP: 10.0.1.50"), "{text}");
+    // The footer flips its cordon hint when the node is already cordoned.
+    assert!(text.contains("<c>:Uncordon"), "{text}");
+    assert!(!text.contains(":Cordon "), "{text}");
+
+    let buf = render_buffer(180, 40, |f| render_node_inspector_view(f, f.area(), &state));
+    let lines = common::render_lines(180, 40, |f| render_node_inspector_view(f, f.area(), &state));
+    let y = row_of(&lines, "● NotReady") as u16;
+    let x = col(&lines[y as usize], "● NotReady");
+    assert_eq!(
+        buf[(x, y)].fg,
+        Theme::RED,
+        "a non-Ready status is drawn red"
+    );
+}
+
+#[test]
+fn node_inspector_gpu_model_falls_back_to_a_generic_label() {
+    let mut details = node_details("gpu-node");
+    details.has_gpu = true;
+    details.gpu_model = None;
+    details.gpu_capacity_count = 1;
+    details.gpu_allocatable_count = 1;
+    let state = node_state(details);
+    let text = render_node(160, 40, &state);
+    assert!(text.contains("GPU Accelerator]"), "{text}");
+    assert!(text.contains("GPU: 0/1 (0%)"), "{text}");
+}
+
+#[test]
+fn node_inspector_footer_lists_every_shortcut_with_the_cordon_hint() {
+    let state = node_state(node_details("node-1"));
+    let lines = common::render_lines(180, 40, |f| render_node_inspector_view(f, f.area(), &state));
+    let footer = lines.last().unwrap();
+    for hint in [
+        "<↑/↓>:Select Pod",
+        "<Enter>:Jump",
+        "<l>:Logs",
+        "<d>:Pod Describe",
+        "<D>:Node Describe",
+        "<y>:Pod YAML",
+        "<Y>:Node YAML",
+        "<x>:Actions",
+        "<c>:Cordon",
+        "<s>:Shell",
+        "<r>:Refresh",
+        "<Esc>:Back",
+    ] {
+        assert!(footer.contains(hint), "missing {hint} in {footer}");
+    }
+}
+
+#[test]
+fn node_inspector_gauges_show_cpu_memory_and_pod_percentages_without_a_gpu() {
+    let state = node_state(node_details("node-1"));
+    let text = render_node(120, 40, &state);
+    assert!(text.contains("CPU: 2.5/7.8 Cores (32%)"), "{text}");
+    assert!(text.contains("Memory: 13.7/30.3 GiB (45%)"), "{text}");
+    assert!(text.contains("Pods: 2/110 (2%)"), "{text}");
+    assert!(!text.contains("VRAM"), "{text}");
+    assert!(!text.contains("Slices"), "{text}");
+}
+
+#[test]
+fn node_inspector_gauges_report_zero_when_allocatable_is_zero() {
+    let mut details = node_details("node-1");
+    details.cpu_allocatable_millicores = 0;
+    details.mem_allocatable_mib = 0;
+    details.pods_allocatable = 0;
+    details.pods_count = 3;
+    let state = node_state(details);
+    let text = render_node(120, 40, &state);
+    assert!(text.contains("CPU: 2.5/0.0 Cores (0%)"), "{text}");
+    assert!(text.contains("Memory: 13.7/0.0 GiB (0%)"), "{text}");
+    // pods_allocatable is floored to 1 so the ratio does not divide by zero.
+    assert!(text.contains("Pods: 3/0 (300%)"), "{text}");
+}
+
+#[test]
+fn node_inspector_gauges_go_yellow_then_red_as_pressure_rises() {
+    let mut details = node_details("node-1");
+    details.cpu_requests_millicores = 6000; // 77%
+    details.mem_requests_mib = 30000; // 97%
+    details.pods_count = 80; // 73%
+    let state = node_state(details);
+    let lines = common::render_lines(160, 40, |f| render_node_inspector_view(f, f.area(), &state));
+    let buf = render_buffer(160, 40, |f| render_node_inspector_view(f, f.area(), &state));
+    let title_row = row_of(&lines, "CPU: 6.0/7.8 Cores (77%)");
+    let cpu_x = col(&lines[title_row], "CPU: 6.0");
+    let mem_x = col(&lines[title_row], "Memory: 29.3/30.3 GiB (97%)");
+    let pods_x = col(&lines[title_row], "Pods: 80/110 (73%)");
+    // The gauge body sits one row under its title; the filled part carries the fg colour.
+    let body = title_row as u16 + 1;
+    assert_eq!(buf[(cpu_x, body)].fg, Theme::YELLOW);
+    assert_eq!(buf[(mem_x, body)].fg, Theme::RED);
+    assert_eq!(buf[(pods_x, body)].fg, Theme::YELLOW);
+}
+
+#[test]
+fn node_inspector_gpu_gauge_prefers_vram_when_memory_requests_are_known() {
+    let mut details = node_details("gpu-node");
+    details.has_gpu = true;
+    details.gpu_model = Some("Tesla T4".to_string());
+    details.gpu_capacity_count = 1;
+    details.gpu_allocatable_count = 1;
+    details.gpu_requests_count = 1;
+    details.gpu_memory_total_mib = Some(15360);
+    details.gpu_memory_requests_mib = 7168;
+    let state = node_state(details);
+    let text = render_node(200, 40, &state);
+    assert!(text.contains("Tesla T4: 7.0/15.0 GiB VRAM (47%)"), "{text}");
+}
+
+#[test]
+fn node_inspector_gpu_gauge_counts_slices_when_more_than_one_gpu_is_allocatable() {
+    let mut details = node_details("gpu-node");
+    details.has_gpu = true;
+    details.gpu_model = Some("A100".to_string());
+    details.gpu_capacity_count = 8;
+    details.gpu_allocatable_count = 8;
+    details.gpu_requests_count = 3;
+    let state = node_state(details);
+    let text = render_node(160, 40, &state);
+    assert!(text.contains("A100: 3/8 Slices (38%)"), "{text}");
+
+    // Over-commit beyond 90% turns the gauge red.
+    let mut hot = node_details("gpu-node");
+    hot.has_gpu = true;
+    hot.gpu_model = Some("A100".to_string());
+    hot.gpu_capacity_count = 4;
+    hot.gpu_allocatable_count = 4;
+    hot.gpu_requests_count = 4;
+    let hot_state = node_state(hot);
+    let lines = common::render_lines(160, 40, |f| {
+        render_node_inspector_view(f, f.area(), &hot_state)
+    });
+    let buf = render_buffer(160, 40, |f| {
+        render_node_inspector_view(f, f.area(), &hot_state)
+    });
+    let row = row_of(&lines, "A100: 4/4 Slices (100%)");
+    let x = col(&lines[row], "A100: 4/4");
+    assert_eq!(buf[(x, row as u16 + 1)].fg, Theme::RED);
+}
+
+#[test]
+fn node_inspector_sparklines_only_appear_when_the_terminal_is_tall_enough() {
+    let mut state = node_state(node_details("node-1"));
+
+    // No samples yet: both cards explain they are waiting on metrics-server.
+    let tall = render_node(160, 40, &state);
+    assert!(
+        tall.contains("CPU Usage Trend [cur: 2500m | peak: 2500m | alloc: 7800m]"),
+        "{tall}"
+    );
+    assert!(
+        tall.contains("Memory Usage Trend [cur: 14000MiB | peak: 14000MiB | alloc: 31000MiB]"),
+        "{tall}"
+    );
+    assert_eq!(
+        tall.matches("Awaiting metrics-server samples...").count(),
+        2,
+        "{tall}"
+    );
+
+    // With samples the sparkline replaces the placeholder and the title tracks cur/peak.
+    state.update_metrics_history(&[100, 900, 400], &[2048, 4096]);
+    let with_data = render_node(160, 40, &state);
+    assert!(
+        with_data.contains("CPU Usage Trend [cur: 400m | peak: 900m | alloc: 7800m]"),
+        "{with_data}"
+    );
+    assert!(
+        with_data.contains("Memory Usage Trend [cur: 4096MiB | peak: 4096MiB"),
+        "{with_data}"
+    );
+    assert!(
+        !with_data.contains("Awaiting metrics-server samples"),
+        "{with_data}"
+    );
+
+    // Under 26 rows the timeline is dropped entirely.
+    let short = render_node(160, 25, &state);
+    assert!(!short.contains("Usage Trend"), "{short}");
+    assert!(short.contains("Scheduled Pods"), "{short}");
+}
+
+#[test]
+fn node_inspector_conditions_and_taints_render_or_say_none() {
+    let mut state = node_state(node_details("node-1"));
+    let text = render_node(160, 40, &state);
+    assert!(text.contains("Health Conditions & Taints"), "{text}");
+    assert!(text.contains("Conditions: Ready:True"), "{text}");
+    assert!(text.contains("Taints: None"), "{text}");
+
+    let mut details = node_details("node-1");
+    details.conditions = vec![
+        NodeConditionInfo {
+            type_: "Ready".to_string(),
+            status: "False".to_string(),
+            reason: None,
+            message: None,
+        },
+        NodeConditionInfo {
+            type_: "MemoryPressure".to_string(),
+            status: "True".to_string(),
+            reason: None,
+            message: None,
+        },
+        NodeConditionInfo {
+            type_: "DiskPressure".to_string(),
+            status: "False".to_string(),
+            reason: None,
+            message: None,
+        },
+    ];
+    details.taints = vec![
+        NodeTaintInfo {
+            key: "nvidia.com/gpu".to_string(),
+            value: Some("present".to_string()),
+            effect: "NoSchedule".to_string(),
+        },
+        NodeTaintInfo {
+            key: "dedicated".to_string(),
+            value: None,
+            effect: "NoExecute".to_string(),
+        },
+    ];
+    state.set_details(details);
+    let lines = common::render_lines(160, 40, |f| render_node_inspector_view(f, f.area(), &state));
+    let buf = render_buffer(160, 40, |f| render_node_inspector_view(f, f.area(), &state));
+    let row = row_of(&lines, "Conditions:");
+    let line = &lines[row];
+    assert!(
+        line.contains("Ready:False MemoryPressure:True DiskPressure:False"),
+        "{line}"
+    );
+    assert!(
+        line.contains("Taints: nvidia.com/gpu=present:NoSchedule dedicated:NoExecute"),
+        "{line}"
+    );
+    let bad = col(&line, "Ready:False");
+    let good = col(&line, "DiskPressure:False");
+    assert_eq!(buf[(bad, row as u16)].fg, Theme::RED);
+    assert_eq!(buf[(good, row as u16)].fg, Theme::GREEN);
+
+    let mut none = node_details("node-1");
+    none.conditions.clear();
+    state.set_details(none);
+    let text = render_node(160, 40, &state);
+    assert!(text.contains("Conditions: None"), "{text}");
+}
+
+#[test]
+fn node_inspector_pods_table_lists_pods_and_marks_the_selected_one() {
+    let mut details = node_details("node-1");
+    details.pods = vec![
+        {
+            let mut p = pod("ai-prod", "vllm-serve-7b", "Running");
+            p.cpu_requests_millicores = 2000;
+            p.mem_requests_mib = 12000;
+            p.gpu_requests = 1;
+            p.gpu_mem_requests_mib = 7168;
+            p.restarts = 3;
+            p
+        },
+        {
+            let mut p = pod("batch", "trainer", "Pending");
+            p.cpu_requests_millicores = 0;
+            p.mem_requests_mib = 0;
+            p.gpu_requests = 2;
+            p.pod_ip = String::new();
+            p
+        },
+        {
+            let mut p = pod("batch", "small-vram", "Failed");
+            p.gpu_mem_requests_mib = 512;
+            p
+        },
+        pod(
+            "kube-system",
+            "a-very-long-pod-name-that-will-be-truncated",
+            "Succeeded",
+        ),
+    ];
+    let mut state = node_state(details);
+    state.select_next();
+
+    let lines = common::render_lines(160, 40, |f| render_node_inspector_view(f, f.area(), &state));
+    let text = lines.join("\n");
+    // Emoji take two cells, so assert on the text either side of them.
+    assert!(text.contains("Scheduled Pods (4 Total |"), "{text}");
+    assert!(text.contains("3 GPU Workloads)"), "{text}");
+    let header = &lines[row_of(&lines, "NAMESPACE")];
+    for col in [
+        "NAME", "IP", "STATUS", "READY", "REST", "CPU REQ", "MEM REQ", "GPU REQ", "AGE",
+    ] {
+        assert!(header.contains(col), "missing {col} in {header}");
+    }
+
+    // Rows sit inside the table's block, so each one opens with its border.
+    let vllm = &lines[row_of(&lines, "vllm-serve-7b")];
+    assert!(
+        vllm.starts_with("│  ai-prod"),
+        "unselected rows have a blank marker: {vllm}"
+    );
+    assert!(vllm.contains("2.0c"), "{vllm}");
+    assert!(vllm.contains("11.7 GiB"), "{vllm}");
+    assert!(vllm.contains("7.0 GiB"), "{vllm}");
+    assert!(vllm.contains("10.244.1.5"), "{vllm}");
+
+    let trainer = &lines[row_of(&lines, "trainer")];
+    assert!(
+        trainer.starts_with("│▶ batch"),
+        "selected row carries the marker: {trainer}"
+    );
+    assert!(
+        trainer.contains(" -  "),
+        "missing ip/cpu/mem show as dashes: {trainer}"
+    );
+    assert!(trainer.contains("2 GPU"), "{trainer}");
+    assert!(trainer.contains("Pending"), "{trainer}");
+
+    let small = &lines[row_of(&lines, "small-vram")];
+    assert!(small.contains("512 MiB"), "{small}");
+    assert!(small.contains("100m"), "{small}");
+    assert!(small.contains("128 MiB"), "{small}");
+
+    let long = &lines[row_of(&lines, "a-very-long-pod-name")];
+    assert!(long.contains("a-very-long-pod-name-that-…"), "{long}");
+    assert!(!long.contains("truncated"), "{long}");
+
+    let buf = render_buffer(160, 40, |f| render_node_inspector_view(f, f.area(), &state));
+    let sel_row = row_of(&lines, "trainer") as u16;
+    assert_eq!(
+        buf[(4, sel_row)].bg,
+        Theme::SEL_BG,
+        "selected row is highlighted"
+    );
+    let other_row = row_of(&lines, "vllm-serve-7b") as u16;
+    assert_eq!(buf[(4, other_row)].bg, Color::Reset);
+    let status_x = col(&vllm, "Running");
+    assert_eq!(buf[(status_x, other_row)].fg, Theme::GREEN);
+    let pending_x = col(&trainer, "Pending");
+    assert_eq!(buf[(pending_x, sel_row)].fg, Theme::YELLOW);
+    let failed_row = row_of(&lines, "small-vram") as u16;
+    let failed_x = col(&small, "Failed");
+    assert_eq!(buf[(failed_x, failed_row)].fg, Theme::RED);
+    let succeeded_row = row_of(&lines, "a-very-long-pod-name") as u16;
+    let succeeded_x = col(&long, "Succeeded");
+    assert_eq!(buf[(succeeded_x, succeeded_row)].fg, Theme::CYAN);
+}
+
+#[test]
+fn node_inspector_pods_table_says_so_when_the_node_is_empty() {
+    let mut details = node_details("node-1");
+    details.pods.clear();
+    let state = node_state(details);
+    let text = render_node(120, 40, &state);
+    assert!(text.contains("Scheduled Pods (0 Total)"), "{text}");
+    assert!(
+        text.contains("No pods currently scheduled on this node."),
+        "{text}"
+    );
+    assert!(!text.contains("NAMESPACE"), "{text}");
+}
+
+#[test]
+fn node_inspector_pods_table_scrolls_to_keep_the_selection_visible() {
+    let mut details = node_details("node-1");
+    details.pods = (0..30)
+        .map(|i| pod("default", &format!("pod-{i:02}"), "Running"))
+        .collect();
+    let mut state = node_state(details);
+
+    // Wide/tall: 21 visible rows. Selecting the last pod scrolls down.
+    state.select_last();
+    let text = render_node(120, 40, &state);
+    assert!(text.contains("▶ default"), "{text}");
+    assert!(text.contains("pod-29"), "{text}");
+    assert!(!text.contains("pod-00"), "{text}");
+    assert_eq!(state.last_scroll_offset.get(), 9);
+    assert!(state.last_pods_table_rect.get().height > 0);
+
+    // A stale scroll offset below the selection snaps back up to it.
+    state.select_first();
+    state.scroll_offset = 5;
+    let text = render_node(120, 40, &state);
+    assert!(text.contains("pod-00"), "{text}");
+    assert_eq!(state.last_scroll_offset.get(), 0);
+
+    // Narrow terminal: only a handful of rows fit, the selection still shows.
+    state.scroll_offset = 0;
+    state.page_down(12);
+    let narrow = render_node(60, 20, &state);
+    assert!(narrow.contains("pod-12"), "{narrow}");
+    assert!(!narrow.contains("pod-00"), "{narrow}");
+    assert!(narrow.contains("Scheduled Pods (30 Total)"), "{narrow}");
+    assert!(state.last_scroll_offset.get() > 0);
+}
+
+#[test]
+fn node_inspector_pods_table_skips_rows_when_there_is_no_room_for_them() {
+    let state = node_state(node_details("node-1"));
+    // At three rows the layout squeezes the table down to its borders, so
+    // the renderer bails before recording where the rows would have gone.
+    let sentinel = ratatui::layout::Rect::new(7, 7, 7, 7);
+    state.last_pods_table_rect.set(sentinel);
+    let text = render_node(80, 3, &state);
+    assert!(!text.contains("NAMESPACE"), "{text}");
+    assert!(!text.contains("coredns"), "{text}");
+    assert_eq!(
+        state.last_pods_table_rect.get(),
+        sentinel,
+        "no table rect is recorded"
+    );
+}
+
+// ─────────────────────────────── settings ───────────────────────────────
+
+fn settings_state() -> SettingsViewState {
+    SettingsViewState {
+        settings: AiSettings::default(),
+        selected_provider_idx: 0,
+        selected_field: SettingField::ProviderToggle,
+        is_editing: false,
+        edit_buffer: String::new(),
+        toast: None,
+    }
+}
+
+fn render_settings(width: u16, height: u16, state: &SettingsViewState) -> String {
+    common::render_text(width, height, |f| render_settings_view(f, f.area(), state))
+}
+
+#[test]
+fn settings_view_new_selects_the_configured_default_provider() {
+    // `new` loads whatever the machine has on disk; the invariant that holds
+    // regardless is that the cursor starts on the default provider.
+    let state = SettingsViewState::new();
+    assert_eq!(state.current_provider(), state.settings.default_provider);
+    assert_eq!(state.selected_field, SettingField::ProviderToggle);
+    assert!(!state.is_editing);
+    assert!(state.edit_buffer.is_empty());
+    assert!(state.toast.is_none());
+}
+
+#[test]
+fn settings_view_provider_selection_wraps_both_ways_and_freezes_while_editing() {
+    let mut state = settings_state();
+    assert_eq!(state.current_provider(), AiProvider::Anthropic);
+    state.select_prev_provider();
+    assert_eq!(state.current_provider(), AiProvider::Cursor);
+    state.select_next_provider();
+    assert_eq!(state.current_provider(), AiProvider::Anthropic);
+    state.select_next_provider();
+    assert_eq!(state.current_provider(), AiProvider::OpenAi);
+    state.select_prev_provider();
+    assert_eq!(state.current_provider(), AiProvider::Anthropic);
+
+    state.is_editing = true;
+    state.select_next_provider();
+    state.select_prev_provider();
+    assert_eq!(state.current_provider(), AiProvider::Anthropic);
+
+    // An out-of-range index is folded back into the provider list.
+    state.selected_provider_idx = 7;
+    assert_eq!(state.current_provider(), AiProvider::Gemini);
+}
+
+#[test]
+fn settings_view_field_cycle_skips_base_url_unless_the_provider_is_custom() {
+    let mut state = settings_state();
+    let mut seen = vec![state.selected_field];
+    for _ in 0..4 {
+        state.select_next_field();
+        seen.push(state.selected_field);
+    }
+    assert_eq!(
+        seen,
+        vec![
+            SettingField::ProviderToggle,
+            SettingField::ApiKey,
+            SettingField::Model,
+            SettingField::Timeout,
+            SettingField::ProviderToggle,
+        ]
+    );
+
+    let mut back = vec![state.selected_field];
+    for _ in 0..4 {
+        state.select_prev_field();
+        back.push(state.selected_field);
+    }
+    assert_eq!(
+        back,
+        vec![
+            SettingField::ProviderToggle,
+            SettingField::Timeout,
+            SettingField::Model,
+            SettingField::ApiKey,
+            SettingField::ProviderToggle,
+        ]
+    );
+
+    // The OpenAI-compatible provider adds Base URL between Model and Timeout.
+    state.selected_provider_idx = 3;
+    assert_eq!(state.current_provider(), AiProvider::OpenAiCompatible);
+    let mut custom = vec![state.selected_field];
+    for _ in 0..5 {
+        state.select_next_field();
+        custom.push(state.selected_field);
+    }
+    assert_eq!(
+        custom,
+        vec![
+            SettingField::ProviderToggle,
+            SettingField::ApiKey,
+            SettingField::Model,
+            SettingField::BaseUrl,
+            SettingField::Timeout,
+            SettingField::ProviderToggle,
+        ]
+    );
+    state.select_prev_field();
+    assert_eq!(state.selected_field, SettingField::Timeout);
+    state.select_prev_field();
+    assert_eq!(state.selected_field, SettingField::BaseUrl);
+    state.select_prev_field();
+    assert_eq!(state.selected_field, SettingField::Model);
+
+    // Field navigation is frozen while an edit is open.
+    state.is_editing = true;
+    state.select_next_field();
+    state.select_prev_field();
+    assert_eq!(state.selected_field, SettingField::Model);
+}
+
+#[test]
+fn settings_view_enter_on_the_provider_row_activates_it_instead_of_editing() {
+    let mut state = settings_state();
+    state.selected_provider_idx = 2;
+    state.start_editing();
+    assert!(!state.is_editing);
+    assert_eq!(state.settings.default_provider, AiProvider::Gemini);
+    assert!(state.edit_buffer.is_empty());
+
+    state.selected_provider_idx = 4;
+    state.set_active_provider();
+    assert_eq!(state.settings.default_provider, AiProvider::Cursor);
+}
+
+#[test]
+fn settings_view_start_editing_prefills_the_buffer_from_the_current_value() {
+    let mut state = settings_state();
+    state
+        .settings
+        .api_keys
+        .insert("anthropic".to_string(), "sk-ant-secret".to_string());
+
+    state.selected_field = SettingField::ApiKey;
+    state.start_editing();
+    assert!(state.is_editing);
+    assert_eq!(state.edit_buffer, "sk-ant-secret");
+    state.cancel_editing();
+    assert!(!state.is_editing);
+    assert!(state.edit_buffer.is_empty());
+
+    state.selected_field = SettingField::Model;
+    state.start_editing();
+    assert_eq!(state.edit_buffer, "claude-3-7-sonnet-20250219");
+    state.cancel_editing();
+
+    state.selected_field = SettingField::Timeout;
+    state.start_editing();
+    assert_eq!(state.edit_buffer, "120");
+    state.cancel_editing();
+
+    state.selected_provider_idx = 3;
+    state.selected_field = SettingField::BaseUrl;
+    state.start_editing();
+    assert_eq!(state.edit_buffer, "http://localhost:11434/v1");
+    state.cancel_editing();
+
+    // A provider with no stored key starts from an empty buffer.
+    state.selected_provider_idx = 1;
+    state.selected_field = SettingField::ApiKey;
+    state.start_editing();
+    assert_eq!(state.edit_buffer, "");
+}
+
+#[test]
+fn settings_view_finish_editing_stores_trimmed_values_and_removes_blanks() {
+    let mut state = settings_state();
+    state.selected_provider_idx = 1; // OpenAI
+
+    state.selected_field = SettingField::ApiKey;
+    state.start_editing();
+    state.edit_buffer = "  sk-openai-1234  ".to_string();
+    state.finish_editing();
+    assert!(!state.is_editing);
+    assert!(state.edit_buffer.is_empty());
+    assert_eq!(
+        state.settings.api_keys.get("openai").map(String::as_str),
+        Some("sk-openai-1234")
+    );
+
+    state.start_editing();
+    state.edit_buffer = "   ".to_string();
+    state.finish_editing();
+    assert!(!state.settings.api_keys.contains_key("openai"));
+
+    state.selected_field = SettingField::Model;
+    state.start_editing();
+    state.edit_buffer = "gpt-4.1-mini".to_string();
+    state.finish_editing();
+    assert_eq!(state.settings.get_model(AiProvider::OpenAi), "gpt-4.1-mini");
+    state.start_editing();
+    state.edit_buffer.clear();
+    state.finish_editing();
+    assert!(!state.settings.models.contains_key("openai"));
+    assert_eq!(
+        state.settings.get_model(AiProvider::OpenAi),
+        "gpt-4o",
+        "falls back to the default"
+    );
+
+    state.selected_provider_idx = 3; // OpenAI-compatible
+    state.selected_field = SettingField::BaseUrl;
+    state.start_editing();
+    state.edit_buffer = "http://ollama.internal:11434/v1".to_string();
+    state.finish_editing();
+    assert_eq!(
+        state.settings.get_base_url(AiProvider::OpenAiCompatible),
+        "http://ollama.internal:11434/v1"
+    );
+    state.start_editing();
+    state.edit_buffer.clear();
+    state.finish_editing();
+    assert!(!state.settings.base_urls.contains_key("openai-compatible"));
+    assert_eq!(
+        state.settings.get_base_url(AiProvider::OpenAiCompatible),
+        "http://localhost:11434/v1"
+    );
+}
+
+#[test]
+fn settings_view_timeout_edits_are_parsed_and_clamped() {
+    let mut state = settings_state();
+    state.selected_field = SettingField::Timeout;
+
+    state.start_editing();
+    state.edit_buffer = "300".to_string();
+    state.finish_editing();
+    assert_eq!(
+        state.settings.get_timeout_seconds(AiProvider::Anthropic),
+        300
+    );
+
+    state.start_editing();
+    state.edit_buffer = "1".to_string();
+    state.finish_editing();
+    assert_eq!(state.settings.get_timeout_seconds(AiProvider::Anthropic), 5);
+
+    state.start_editing();
+    state.edit_buffer = "99999".to_string();
+    state.finish_editing();
+    assert_eq!(
+        state.settings.get_timeout_seconds(AiProvider::Anthropic),
+        3600
+    );
+
+    state.start_editing();
+    state.edit_buffer = "soon".to_string();
+    state.finish_editing();
+    assert_eq!(
+        state.settings.get_timeout_seconds(AiProvider::Anthropic),
+        3600,
+        "garbage is ignored"
+    );
+    assert!(!state.is_editing);
+
+    // Finishing on the provider row changes nothing.
+    state.selected_field = SettingField::ProviderToggle;
+    state.is_editing = true;
+    state.edit_buffer = "ignored".to_string();
+    let before = state.settings.clone();
+    state.finish_editing();
+    assert_eq!(state.settings, before);
+    assert!(!state.is_editing);
+}
+
+#[test]
+fn settings_view_renders_the_active_provider_summary_and_every_provider_card() {
+    let mut state = settings_state();
+    state.settings.default_provider = AiProvider::Gemini;
+    state.selected_provider_idx = 2;
+    let text = render_settings(120, 40, &state);
+
+    assert!(text.contains("SRElens AI & Assistant Settings"), "{text}");
+    assert!(
+        text.contains("Active AI Provider: ● Google Gemini (model: gemini-2.5-flash)"),
+        "{text}"
+    );
+    assert!(
+        text.contains("Configure default provider, API keys, models"),
+        "{text}"
+    );
+    assert!(text.contains("○ 1. Anthropic (Claude)"), "{text}");
+    assert!(text.contains("○ 2. OpenAI (GPT-4o)"), "{text}");
+    assert!(
+        text.contains("● 3. Google Gemini  [ACTIVE DEFAULT]"),
+        "{text}"
+    );
+    assert!(
+        text.contains("○ 4. OpenAI-Compatible / Ollama (Local)"),
+        "{text}"
+    );
+    assert!(text.contains("○ 5. Cursor Agent (cursor-agent)"), "{text}");
+    assert_eq!(text.matches("[ACTIVE DEFAULT]").count(), 1, "{text}");
+    assert!(
+        text.contains("Model:   claude-3-7-sonnet-20250219   │   Timeout: 120s"),
+        "{text}"
+    );
+    assert!(text.contains("Model:   llama3.2"), "{text}");
+    assert!(
+        text.contains("Auth:    auto (uses logged-in cursor auth or CURSOR_API_KEY)"),
+        "{text}"
+    );
+    assert!(
+        text.contains("[installed: ") || text.contains("[not found on PATH]"),
+        "the cursor card reports whether the binary was found: {text}"
+    );
+    assert!(
+        text.contains("[↑/↓/j/k] Provider  [Tab/←/→] Field  [Space] Set Active"),
+        "{text}"
+    );
+    assert!(
+        text.contains("[e/Enter] Edit  [s] Save to Disk  [Esc/q] Back"),
+        "{text}"
+    );
+    assert!(
+        !text.contains("Enter new value"),
+        "no modal unless editing: {text}"
+    );
+}
+
+#[test]
+fn settings_view_masks_stored_api_keys_and_flags_missing_ones() {
+    let mut state = settings_state();
+    state.settings.api_keys.insert(
+        "anthropic".to_string(),
+        "sk-ant-api03-verylongkey-wxyz".to_string(),
+    );
+    state
+        .settings
+        .api_keys
+        .insert("gemini".to_string(), "short".to_string());
+    state
+        .settings
+        .api_keys
+        .insert("openai".to_string(), "   ".to_string());
+    let text = render_settings(120, 40, &state);
+
+    assert!(
+        text.contains("API Key: sk-a••••••••wxyz [stored in config]"),
+        "{text}"
+    );
+    assert!(
+        !text.contains("verylongkey"),
+        "the middle of the key never reaches the screen"
+    );
+    assert!(
+        text.contains("API Key: •••••••• [stored in config]"),
+        "{text}"
+    );
+    assert!(!text.contains("short"), "{text}");
+    // A blank stored key counts as unset. (Guarded: a developer's shell may
+    // export the key, which legitimately takes the env branch instead.)
+    if std::env::var("OPENAI_API_KEY").is_err() {
+        assert!(
+            text.contains("API Key: no key set (press 'e' to set or export OPENAI_API_KEY)"),
+            "{text}"
+        );
+    }
+    if std::env::var("OPENAI_COMPATIBLE_API_KEY").is_err() {
+        assert!(text.contains("API Key: optional (local Ollama)"), "{text}");
+    }
+}
+
+#[test]
+fn settings_view_reports_an_api_key_that_comes_from_the_environment() {
+    // Only this test touches GEMINI_API_KEY, and no other test in this file
+    // asserts on Gemini's key line, so the parallel runner cannot race it.
+    std::env::set_var("GEMINI_API_KEY", "from-env");
+    let state = settings_state();
+    let text = render_settings(120, 40, &state);
+    std::env::remove_var("GEMINI_API_KEY");
+    assert!(
+        text.contains("API Key: [env: GEMINI_API_KEY set]"),
+        "{text}"
+    );
+    assert!(
+        !text.contains("from-env"),
+        "the value itself is never shown: {text}"
+    );
+}
+
+#[test]
+fn settings_view_highlights_the_focused_field_on_the_selected_card() {
+    let mut state = settings_state();
+    state.selected_provider_idx = 1;
+    state.selected_field = SettingField::Model;
+    let lines = common::render_lines(120, 40, |f| render_settings_view(f, f.area(), &state));
+    let buf = render_buffer(120, 40, |f| render_settings_view(f, f.area(), &state));
+
+    let openai_row = row_of(&lines, "2. OpenAI (GPT-4o)");
+    let model_row = openai_row + 2;
+    assert!(
+        lines[model_row].contains("Model:   gpt-4o"),
+        "{}",
+        lines[model_row]
+    );
+    let model_x = col(&lines[model_row], "Model:");
+    assert_eq!(
+        buf[(model_x, model_row as u16)].fg,
+        Theme::YELLOW,
+        "focused label is yellow"
+    );
+    let value_x = col(&lines[model_row], "gpt-4o");
+    assert_eq!(
+        buf[(value_x, model_row as u16)].fg,
+        Theme::YELLOW,
+        "focused value is yellow"
+    );
+    let timeout_x = col(&lines[model_row], "Timeout:");
+    assert_eq!(
+        buf[(timeout_x, model_row as u16)].fg,
+        Theme::DIM,
+        "unfocused label stays dim"
+    );
+
+    // The selected card's border is cyan, the others' are the plain border colour.
+    let card_top = openai_row as u16 - 1;
+    assert_eq!(buf[(1, card_top)].fg, Theme::CYAN);
+    let anthropic_top = row_of(&lines, "1. Anthropic (Claude)") as u16 - 1;
+    assert_eq!(buf[(1, anthropic_top)].fg, Theme::BORDER);
+
+    // Timeout, API key and Base URL focus each light up their own label.
+    let mut s = settings_state();
+    s.selected_field = SettingField::Timeout;
+    let b = render_buffer(120, 40, |f| render_settings_view(f, f.area(), &s));
+    let l = common::render_lines(120, 40, |f| render_settings_view(f, f.area(), &s));
+    let r = row_of(&l, "1. Anthropic (Claude)") + 2;
+    let tx = col(&l[r], "Timeout:");
+    assert_eq!(b[(tx, r as u16)].fg, Theme::YELLOW);
+
+    s.selected_field = SettingField::ApiKey;
+    let b = render_buffer(120, 40, |f| render_settings_view(f, f.area(), &s));
+    let r = row_of(&l, "1. Anthropic (Claude)") + 1;
+    let kx = col(&l[r], "API Key:");
+    assert_eq!(b[(kx, r as u16)].fg, Theme::YELLOW);
+}
+
+#[test]
+fn settings_view_edit_modal_names_the_field_and_shows_the_buffer() {
+    let mut state = settings_state();
+    state.selected_provider_idx = 1;
+    state.selected_field = SettingField::Model;
+    state.start_editing();
+    state.edit_buffer.push_str("-mini");
+    let text = render_settings(160, 40, &state);
+    assert!(text.contains("Edit Model ID for OpenAI (GPT-4o)"), "{text}");
+    assert!(text.contains("Enter new value for Model ID:"), "{text}");
+    assert!(text.contains("gpt-4o-mini█"), "{text}");
+    assert!(
+        text.contains("<Enter> Confirm  |  <Ctrl+v> Paste  |  <Ctrl+w> Rubout  |  <Esc> Cancel"),
+        "{text}"
+    );
+    // The modal is drawn over the cards, which stay visible around it.
+    assert!(text.contains("5. Cursor Agent (cursor-agent)"), "{text}");
+
+    state.cancel_editing();
+    state.selected_field = SettingField::Timeout;
+    state.start_editing();
+    let text = render_settings(160, 40, &state);
+    assert!(
+        text.contains("Edit Turn Timeout (seconds, e.g. 120) for OpenAI (GPT-4o)"),
+        "{text}"
+    );
+    assert!(text.contains("120█"), "{text}");
+
+    state.cancel_editing();
+    state.selected_field = SettingField::ApiKey;
+    state.start_editing();
+    let text = render_settings(160, 40, &state);
+    assert!(text.contains("Edit API Key for OpenAI (GPT-4o)"), "{text}");
+    assert!(text.contains("Enter new value for API Key:"), "{text}");
+
+    state.cancel_editing();
+    state.selected_provider_idx = 4;
+    state.start_editing();
+    let text = render_settings(160, 40, &state);
+    assert!(
+        text.contains("Edit API Key (or leave blank for cursor login) for Cursor Agent"),
+        "{text}"
+    );
+
+    state.cancel_editing();
+    state.selected_provider_idx = 3;
+    state.selected_field = SettingField::BaseUrl;
+    state.start_editing();
+    let text = render_settings(160, 40, &state);
+    assert!(
+        text.contains("Edit Base URL (e.g. http://localhost:11434/v1) for OpenAI-Compatible"),
+        "{text}"
+    );
+    assert!(text.contains("http://localhost:11434/v1█"), "{text}");
+
+    // A forced edit on the provider row still labels itself sensibly.
+    state.cancel_editing();
+    state.selected_field = SettingField::ProviderToggle;
+    state.is_editing = true;
+    let text = render_settings(160, 40, &state);
+    assert!(
+        text.contains("Edit Provider for OpenAI-Compatible"),
+        "{text}"
+    );
+}
+
+#[test]
+fn settings_view_narrow_terminal_still_shows_the_header_and_first_cards() {
+    let state = settings_state();
+    let text = render_settings(60, 20, &state);
+    assert!(text.contains("SRElens AI & Assistant Settings"), "{text}");
+    assert!(
+        text.contains("Active AI Provider: ● Anthropic (Claude)"),
+        "{text}"
+    );
+    assert!(
+        text.contains("● 1. Anthropic (Claude)  [ACTIVE DEFAULT]"),
+        "{text}"
+    );
+    // The cards shrink to their borders and header line: no field rows fit.
+    assert!(!text.contains("API Key:"), "{text}");
+    assert!(!text.contains("Model:"), "{text}");
+}
+
+// ─────────────────────────────── overview ───────────────────────────────
+
+fn overview_data() -> ClusterOverviewData {
+    ClusterOverviewData {
+        context_name: "prod-eu".to_string(),
+        cluster_name: "eks-prod".to_string(),
+        server_url: "https://k8s.example.com:6443".to_string(),
+        k8s_version: "v1.30.2".to_string(),
+        is_reachable: true,
+        node_count: 3,
+        ready_nodes: 3,
+        total_pods: 42,
+        running_pods: 40,
+        pending_pods: 0,
+        failed_pods: 0,
+        total_cpu_millicores: 8000,
+        used_cpu_millicores: 2500,
+        total_mem_mib: 32768,
+        used_mem_mib: 14000,
+        total_gpus: 0,
+        allocated_gpus: 0,
+        total_gpu_mem_mib: 0,
+        used_gpu_mem_mib: 0,
+    }
+}
+
+fn render_overview(width: u16, height: u16, state: &OverviewViewState) -> String {
+    common::render_text(width, height, |f| render_overview_view(f, f.area(), state))
+}
+
+#[test]
+fn overview_summary_text_covers_every_optional_line() {
+    let empty = ClusterOverviewData::default();
+    let text = empty.to_summary_text();
+    assert!(text.contains("Cluster:  ()"), "{text}");
+    assert!(text.contains("Status: Unreachable"), "{text}");
+    assert!(!text.contains("Server:"), "{text}");
+    assert!(!text.contains("Kubernetes Version:"), "{text}");
+    assert!(text.contains("Nodes: 0/0 Ready"), "{text}");
+    assert!(
+        text.contains("CPU Allocation: 0.0 / 0.0 Cores (0%)"),
+        "{text}"
+    );
+    assert!(
+        text.contains("Memory Allocation: 0.0 / 0.0 GiB (0%)"),
+        "{text}"
+    );
+    assert!(!text.contains("GPU Allocation"), "{text}");
+    assert!(
+        text.contains("Workloads: 0 Total (0 Running, 0 Pending, 0 Failed/Crash)"),
+        "{text}"
+    );
+
+    let mut full = overview_data();
+    full.pending_pods = 1;
+    full.failed_pods = 1;
+    full.total_gpus = 4;
+    full.allocated_gpus = 3;
+    full.used_gpu_mem_mib = 20480;
+    let text = full.to_summary_text();
+    assert!(text.contains("Cluster: eks-prod (prod-eu)"), "{text}");
+    assert!(text.contains("Status: Reachable / Healthy"), "{text}");
+    assert!(
+        text.contains("Server: https://k8s.example.com:6443"),
+        "{text}"
+    );
+    assert!(text.contains("Kubernetes Version: v1.30.2"), "{text}");
+    assert!(text.contains("Nodes: 3/3 Ready"), "{text}");
+    assert!(
+        text.contains("CPU Allocation: 2.5 / 8.0 Cores (31%)"),
+        "{text}"
+    );
+    assert!(
+        text.contains("Memory Allocation: 13.7 / 32.0 GiB (43%)"),
+        "{text}"
+    );
+    assert!(
+        text.contains("GPU Allocation: 3 / 4 GPUs (75%), VRAM Allocated: 20.0 GiB"),
+        "{text}"
+    );
+    assert!(
+        text.contains("Workloads: 42 Total (40 Running, 1 Pending, 1 Failed/Crash)"),
+        "{text}"
+    );
+
+    // VRAM without any counted GPUs still earns a GPU line, at 0%.
+    let mut vram_only = overview_data();
+    vram_only.used_gpu_mem_mib = 1024;
+    let text = vram_only.to_summary_text();
+    assert!(
+        text.contains("GPU Allocation: 0 / 0 GPUs (0%), VRAM Allocated: 1.0 GiB"),
+        "{text}"
+    );
+
+    // GPUs without VRAM accounting omit the VRAM suffix.
+    let mut gpus_only = overview_data();
+    gpus_only.total_gpus = 2;
+    let text = gpus_only.to_summary_text();
+    assert!(text.contains("GPU Allocation: 0 / 2 GPUs (0%)\n"), "{text}");
+}
+
+#[test]
+fn overview_state_constructors_and_set_data_replace_the_snapshot() {
+    let state = OverviewViewState::new();
+    assert!(state.data.context_name.is_empty());
+    assert!(!state.data.is_reachable);
+
+    let mut state = OverviewViewState::with_data(overview_data());
+    assert_eq!(state.data.cluster_name, "eks-prod");
+
+    let mut next = overview_data();
+    next.cluster_name = "eks-staging".to_string();
+    next.is_reachable = false;
+    state.set_data(next);
+    assert_eq!(state.data.cluster_name, "eks-staging");
+    assert!(!state.data.is_reachable);
+}
+
+#[test]
+fn overview_view_before_any_data_shows_placeholders_and_zeroed_gauges() {
+    let state = OverviewViewState::new();
+    let text = render_overview(120, 40, &state);
+    assert!(
+        text.contains(
+            "Cluster Health & Resource Overview [<s> Summarise, <c> Copy, <r> Refresh, <Esc> Back]"
+        ),
+        "{text}"
+    );
+    assert!(text.contains("● UNREACHABLE"), "{text}");
+    assert!(text.contains("K8s Version:   Connecting..."), "{text}");
+    assert!(text.contains("Nodes:         Fetching..."), "{text}");
+    assert!(text.contains("CPU Allocation: 0m / 0m (0%)"), "{text}");
+    assert!(
+        text.contains("Memory Allocation: 0MiB / 0MiB (0%)"),
+        "{text}"
+    );
+    assert!(!text.contains("GPU"), "{text}");
+    assert!(text.contains("Workload Health Distribution"), "{text}");
+    assert!(text.contains("Total Pods:     0"), "{text}");
+    assert!(text.contains("● Running:      0"), "{text}");
+    assert!(text.contains("● Pending:      0"), "{text}");
+    assert!(!text.contains("Unschedulable"), "{text}");
+    assert!(text.contains("● Failed/Crash: 0"), "{text}");
+    assert!(!text.contains("OOMKilled"), "{text}");
+}
+
+#[test]
+fn overview_view_populated_cluster_shows_health_version_nodes_and_gauges() {
+    let state = OverviewViewState::with_data(overview_data());
+    let lines = common::render_lines(120, 40, |f| render_overview_view(f, f.area(), &state));
+    let text = lines.join("\n");
+    assert!(text.contains("Context:     prod-eu"), "{text}");
+    assert!(text.contains("● REACHABLE / HEALTHY"), "{text}");
+    assert!(text.contains("Cluster:     eks-prod"), "{text}");
+    assert!(text.contains("K8s Version:   v1.30.2"), "{text}");
+    assert!(
+        text.contains("Server:      https://k8s.example.com:6443"),
+        "{text}"
+    );
+    assert!(text.contains("Nodes:         3/3 Ready"), "{text}");
+    assert!(
+        text.contains("CPU Allocation: 2.5 / 8.0 Cores (31%)"),
+        "{text}"
+    );
+    assert!(
+        text.contains("Memory Allocation: 13.7 / 32.0 GiB (42%)"),
+        "{text}"
+    );
+    assert!(text.contains("Total Pods:     42"), "{text}");
+    assert!(text.contains("● Running:      40"), "{text}");
+    assert!(!text.contains("GPU Slices"), "{text}");
+
+    let buf = render_buffer(120, 40, |f| render_overview_view(f, f.area(), &state));
+    let cpu_row = row_of(&lines, "CPU Allocation") as u16 + 1;
+    assert_eq!(
+        buf[(2, cpu_row)].fg,
+        Theme::CYAN,
+        "a cool CPU gauge is cyan"
+    );
+    let mem_row = row_of(&lines, "Memory Allocation") as u16 + 1;
+    assert_eq!(
+        buf[(2, mem_row)].fg,
+        Theme::ACCENT,
+        "a cool memory gauge uses the accent"
+    );
+}
+
+#[test]
+fn overview_view_prefixes_a_bare_version_with_v_and_uses_small_units_for_small_totals() {
+    let mut data = overview_data();
+    data.k8s_version = "1.29.0".to_string();
+    data.total_cpu_millicores = 900;
+    data.used_cpu_millicores = 800;
+    data.total_mem_mib = 1000;
+    data.used_mem_mib = 900;
+    let state = OverviewViewState::with_data(data);
+    let lines = common::render_lines(120, 40, |f| render_overview_view(f, f.area(), &state));
+    let text = lines.join("\n");
+    assert!(text.contains("K8s Version:   v1.29.0"), "{text}");
+    assert!(text.contains("CPU Allocation: 800m / 900m (88%)"), "{text}");
+    assert!(
+        text.contains("Memory Allocation: 900MiB / 1000MiB (90%)"),
+        "{text}"
+    );
+
+    let buf = render_buffer(120, 40, |f| render_overview_view(f, f.area(), &state));
+    let cpu_row = row_of(&lines, "CPU Allocation") as u16 + 1;
+    assert_eq!(buf[(2, cpu_row)].fg, Theme::RED, "over 85% turns red");
+    let mem_row = row_of(&lines, "Memory Allocation") as u16 + 1;
+    assert_eq!(buf[(2, mem_row)].fg, Theme::RED);
+
+    // 70-85% is the yellow band.
+    let mut warm = overview_data();
+    warm.used_cpu_millicores = 6000; // 75%
+    warm.used_mem_mib = 26000; // 79%
+    let warm_state = OverviewViewState::with_data(warm);
+    let lines = common::render_lines(120, 40, |f| render_overview_view(f, f.area(), &warm_state));
+    let buf = render_buffer(120, 40, |f| render_overview_view(f, f.area(), &warm_state));
+    let cpu_row = row_of(&lines, "CPU Allocation: 6.0 / 8.0 Cores (75%)") as u16 + 1;
+    assert_eq!(buf[(2, cpu_row)].fg, Theme::YELLOW);
+    let mem_row = row_of(&lines, "Memory Allocation: 25.4 / 32.0 GiB (79%)") as u16 + 1;
+    assert_eq!(buf[(2, mem_row)].fg, Theme::YELLOW);
+}
+
+#[test]
+fn overview_view_explains_pending_and_failed_pods_when_there_are_any() {
+    let mut data = overview_data();
+    data.pending_pods = 2;
+    data.failed_pods = 1;
+    data.ready_nodes = 2;
+    data.is_reachable = false;
+    let state = OverviewViewState::with_data(data);
+    let text = render_overview(120, 40, &state);
+    assert!(
+        text.contains("● Pending:      2  (Unschedulable or waiting for resources/PVC)"),
+        "{text}"
+    );
+    assert!(
+        text.contains("● Failed/Crash: 1  (OOMKilled, CrashLoopBackOff, or Error)"),
+        "{text}"
+    );
+    assert!(text.contains("Nodes:         2/3 Ready"), "{text}");
+    assert!(text.contains("● UNREACHABLE"), "{text}");
+}
+
+#[test]
+fn overview_view_adds_a_gpu_gauge_and_slice_line_when_the_cluster_has_gpus() {
+    let mut data = overview_data();
+    data.total_gpus = 4;
+    data.allocated_gpus = 3;
+    let state = OverviewViewState::with_data(data.clone());
+    let text = render_overview(120, 40, &state);
+    assert!(text.contains("GPU Allocation: 3 / 4 GPUs (75%)"), "{text}");
+    assert!(!text.contains("VRAM"), "{text}");
+    assert!(text.contains("GPU Slices:     3/4 Physical GPUs"), "{text}");
+
+    // VRAM used but no total: allocated GiB only.
+    data.used_gpu_mem_mib = 20480;
+    let state = OverviewViewState::with_data(data.clone());
+    let text = render_overview(120, 40, &state);
+    assert!(
+        text.contains("GPU Allocation: 3 / 4 GPUs (75%)  •  VRAM Allocated: 20.0 GiB"),
+        "{text}"
+    );
+    assert!(
+        text.contains("GPU Slices:     3/4 Physical GPUs  [VRAM: 20.0 GiB allocated]"),
+        "{text}"
+    );
+
+    // VRAM used and total known: a ratio and a percentage.
+    data.total_gpu_mem_mib = 65536;
+    let state = OverviewViewState::with_data(data);
+    let text = render_overview(120, 40, &state);
+    assert!(
+        text.contains("GPU Allocation: 3 / 4 GPUs (75%)  •  VRAM: 20.0 / 64.0 GiB (31%)"),
+        "{text}"
+    );
+    assert!(
+        text.contains("GPU Slices:     3/4 Physical GPUs  [VRAM: 20.0 / 64.0 GiB allocated]"),
+        "{text}"
+    );
+}
+
+#[test]
+fn overview_view_vram_without_counted_gpus_lists_slices_but_draws_no_gauge() {
+    let mut data = overview_data();
+    data.used_gpu_mem_mib = 2048;
+    let state = OverviewViewState::with_data(data);
+    let text = render_overview(120, 40, &state);
+    assert!(
+        !text.contains("GPU Allocation"),
+        "no gauge without physical GPUs: {text}"
+    );
+    assert!(
+        text.contains("GPU Slices:     0/0 Physical GPUs  [VRAM: 2.0 GiB allocated]"),
+        "{text}"
+    );
+}
+
+#[test]
+fn overview_view_narrow_terminal_keeps_the_key_facts_visible() {
+    let state = OverviewViewState::with_data(overview_data());
+    let text = render_overview(60, 20, &state);
+    assert!(
+        text.contains("Cluster Health & Resource Overview"),
+        "{text}"
+    );
+    assert!(text.contains("prod-eu"), "{text}");
+    assert!(
+        text.contains("CPU Allocation: 2.5 / 8.0 Cores (31%)"),
+        "{text}"
+    );
+    assert!(text.contains("Total Pods:     42"), "{text}");
+}
+
+// ───────────────────────────────── yaml ─────────────────────────────────
+
+const POD_YAML: &str = "\
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: default
+  labels:
+    app: \"web\"
+spec:
+  containers:
+    - name: nginx
+      image: nginx:1.25
+      ports:
+        - containerPort: 80
+      readinessProbe:
+        enabled: true
+# trailing comment
+---
+status:
+  phase: Running";
+
+fn yaml_state(yaml: &str) -> YamlViewState {
+    YamlViewState::new(
+        "test-pod".to_string(),
+        "Pod".to_string(),
+        Some("default".to_string()),
+        yaml.to_string(),
+    )
+}
+
+fn render_yaml(width: u16, height: u16, state: &YamlViewState) -> String {
+    common::render_text(width, height, |f| render_yaml_view(f, f.area(), state))
+}
+
+#[test]
+fn yaml_view_new_splits_lines_and_neutralises_tabs_escapes_and_control_characters() {
+    let raw = "kind: Pod\nmessage: a\tb\n\u{1b}[31mred\u{1b}[0m: value\nbell:\u{07} x\r\nplain: ok";
+    let state = yaml_state(raw);
+    assert_eq!(state.resource_name, "test-pod");
+    assert_eq!(state.resource_kind, "Pod");
+    assert_eq!(state.namespace.as_deref(), Some("default"));
+    assert_eq!(
+        state.yaml_content, raw,
+        "the raw content is kept for editing"
+    );
+    assert_eq!(state.scroll_offset, 0);
+    assert!(state.search_matches.is_empty());
+    assert!(state.selection.is_none());
+    assert!(!state.is_diff);
+
+    assert_eq!(state.lines.len(), 5);
+    assert_eq!(state.lines[0], "kind: Pod");
+    assert_eq!(
+        state.lines[1], "message: a      b",
+        "tab expands to the next 8-column stop"
+    );
+    assert_eq!(
+        state.lines[2], "red: value",
+        "ANSI colour sequences are dropped"
+    );
+    assert_eq!(state.lines[3], "bell: x", "BEL and CR are removed");
+    assert_eq!(state.lines[4], "plain: ok");
+    for line in &state.lines {
+        assert!(!line.chars().any(char::is_control), "{line:?}");
+    }
+
+    // What reaches the screen is the sanitised text.
+    let text = render_yaml(80, 12, &state);
+    assert!(text.contains("2 │ message: a      b"), "{text}");
+    assert!(text.contains("3 │ red: value"), "{text}");
+    assert!(!text.contains('\u{1b}'), "{text}");
+}
+
+#[test]
+fn yaml_view_update_content_resanitises_and_resets_navigation_state() {
+    let mut state = yaml_state(POD_YAML);
+    state.set_search_query("name");
+    state.scroll_down(3);
+    state.start_selection(1);
+    state.update_selection(2);
+    assert!(state.selection.is_some());
+    assert!(!state.search_matches.is_empty());
+
+    state.update_content("a: 1\nb:\tc\n\u{1b}[1mbold\u{1b}[0m: yes".to_string());
+    assert_eq!(state.lines, vec!["a: 1", "b:      c", "bold: yes"]);
+    assert_eq!(
+        state.yaml_content,
+        "a: 1\nb:\tc\n\u{1b}[1mbold\u{1b}[0m: yes"
+    );
+    assert_eq!(state.scroll_offset, 0);
+    assert!(state.search_matches.is_empty());
+    assert!(state.current_match_idx.is_none());
+    assert!(state.selection.is_none());
+    assert!(!state.is_selecting);
+    // The query string itself survives, so the badge still reports zero matches.
+    assert_eq!(state.search_query, "name");
+    // Wide enough that the block title is not truncated to fit the border.
+    let text = render_yaml(160, 10, &state);
+    assert!(text.contains("[Search: \"name\" (0 matches)]"), "{text}");
+}
+
+#[test]
+fn yaml_view_search_is_case_insensitive_jumps_to_the_first_match_and_cycles() {
+    let mut state = yaml_state(POD_YAML);
+    state.set_search_query("NGINX");
+    assert_eq!(state.search_query, "NGINX");
+    assert_eq!(state.search_matches, vec![9, 10]);
+    assert_eq!(state.current_match_idx, Some(0));
+    assert_eq!(state.scroll_offset, 9);
+
+    state.next_match();
+    assert_eq!(state.current_match_idx, Some(1));
+    assert_eq!(state.scroll_offset, 10);
+    state.next_match();
+    assert_eq!(state.current_match_idx, Some(0), "wraps to the first match");
+    assert_eq!(state.scroll_offset, 9);
+    state.prev_match();
+    assert_eq!(state.current_match_idx, Some(1), "wraps to the last match");
+    assert_eq!(state.scroll_offset, 10);
+    state.prev_match();
+    assert_eq!(state.current_match_idx, Some(0));
+
+    // With the index cleared, next goes to the first and prev to the last.
+    state.current_match_idx = None;
+    state.next_match();
+    assert_eq!(state.current_match_idx, Some(0));
+    state.current_match_idx = None;
+    state.prev_match();
+    assert_eq!(state.current_match_idx, Some(1));
+
+    // No matches: nothing to cycle, index stays empty.
+    state.set_search_query("zzz-not-here");
+    assert!(state.search_matches.is_empty());
+    assert!(state.current_match_idx.is_none());
+    let before = state.scroll_offset;
+    state.next_match();
+    state.prev_match();
+    assert_eq!(state.scroll_offset, before);
+
+    // An empty query clears the match list.
+    state.set_search_query("name");
+    state.set_search_query("");
+    assert!(state.search_matches.is_empty());
+    assert!(state.current_match_idx.is_none());
+    assert!(state.search_query.is_empty());
+
+    // "name" also lives inside "namespace", so substring matching finds three.
+    state.set_search_query("name");
+    assert_eq!(state.search_matches, vec![3, 4, 9]);
+    state.clear_search();
+    assert!(state.search_query.is_empty());
+    assert!(state.search_matches.is_empty());
+    assert!(state.current_match_idx.is_none());
+}
+
+#[test]
+fn yaml_view_selection_tracks_a_drag_and_yields_the_covered_lines() {
+    let mut state = yaml_state(POD_YAML);
+    assert!(state.selected_text().is_none());
+    assert!(
+        state.finish_selection(2).is_none(),
+        "no selection to finish"
+    );
+
+    state.start_selection(1);
+    assert!(state.is_selecting);
+    assert_eq!(state.selection, Some((1, 1)));
+    state.update_selection(3);
+    assert_eq!(state.selection, Some((1, 3)));
+    assert_eq!(
+        state.selected_text().as_deref(),
+        Some("kind: Pod\nmetadata:\n  name: test-pod")
+    );
+
+    // Dragging upwards past the anchor still yields the lines in order.
+    let text = state.finish_selection(0).unwrap();
+    assert_eq!(text, "apiVersion: v1\nkind: Pod");
+    assert!(!state.is_selecting);
+    assert_eq!(state.selection, Some((1, 0)));
+
+    // Updates after the drag ended are ignored.
+    state.update_selection(5);
+    assert_eq!(state.selection, Some((1, 0)));
+
+    // Indices past the end clamp to the last line.
+    state.start_selection(999);
+    let last = state.lines.len() - 1;
+    assert_eq!(state.selection, Some((last, last)));
+    assert_eq!(state.selected_text().as_deref(), Some("  phase: Running"));
+
+    state.clear_selection();
+    assert!(state.selection.is_none());
+    assert!(!state.is_selecting);
+
+    // An empty document never selects anything.
+    let mut empty = yaml_state("");
+    empty.start_selection(0);
+    empty.update_selection(0);
+    assert!(empty.selection.is_none());
+    assert!(!empty.is_selecting);
+    assert!(empty.finish_selection(0).is_none());
+    assert!(empty.selected_text().is_none());
+}
+
+#[test]
+fn yaml_view_scrolling_stays_within_the_document() {
+    let mut state = yaml_state(POD_YAML);
+    let last = state.lines.len() - 1;
+    state.scroll_down(5);
+    assert_eq!(state.scroll_offset, 5);
+    state.scroll_down(1000);
+    assert_eq!(state.scroll_offset, 5, "a jump past the end is refused");
+    state.scroll_up(2);
+    assert_eq!(state.scroll_offset, 3);
+    state.scroll_up(100);
+    assert_eq!(state.scroll_offset, 0);
+    state.scroll_bottom();
+    assert_eq!(state.scroll_offset, last);
+    state.scroll_down(1);
+    assert_eq!(state.scroll_offset, last);
+    state.scroll_top();
+    assert_eq!(state.scroll_offset, 0);
+
+    let mut empty = yaml_state("");
+    empty.scroll_bottom();
+    empty.scroll_down(1);
+    assert_eq!(empty.scroll_offset, 0);
+}
+
+#[test]
+fn yaml_view_spawn_editor_reports_a_missing_editor_without_running_anything() {
+    // Point $EDITOR at a binary that cannot exist so the spawn fails fast.
+    // The quoted form also exercises the shlex split.
+    std::env::set_var("EDITOR", "\"srelens-no-such-editor-0x5b\" --wait");
+    let state = yaml_state(POD_YAML);
+    let result = state.spawn_editor();
+    std::env::remove_var("EDITOR");
+    let err = result.expect_err("a nonexistent editor cannot be spawned");
+    assert!(
+        err.starts_with("Failed to spawn editor '\"srelens-no-such-editor-0x5b\" --wait':"),
+        "{err}"
+    );
+}
+
+#[test]
+fn yaml_view_title_reports_kind_name_namespace_position_and_hints() {
+    let state = yaml_state(POD_YAML);
+    let lines = common::render_lines(120, 40, |f| render_yaml_view(f, f.area(), &state));
+    let title = &lines[0];
+    assert!(
+        title.contains(
+            "YAML: Pod/test-pod (default) (Line 1/19) [e: Edit, c: Copy, /: Search, Esc: Back]"
+        ),
+        "{title}"
+    );
+    assert!(!title.contains("Search:"), "{title}");
+    assert_eq!(state.last_viewport_rect.get().height, 38);
+    assert_eq!(state.last_viewport_rect.get().width, 118);
+
+    let text = lines.join("\n");
+    assert!(text.contains("   1 │ apiVersion: v1"), "{text}");
+    assert!(text.contains("  19 │   phase: Running"), "{text}");
+
+    // Cluster-scoped resources have no namespace.
+    let node = YamlViewState::new(
+        "worker-1".to_string(),
+        "Node".to_string(),
+        None,
+        "kind: Node".to_string(),
+    );
+    let text = render_yaml(100, 5, &node);
+    assert!(text.contains("YAML: Node/worker-1  (Line 1/1)"), "{text}");
+}
+
+#[test]
+fn yaml_view_renders_only_the_visible_window_from_the_scroll_offset() {
+    let mut state = yaml_state(POD_YAML);
+    state.scroll_down(4);
+    let lines = common::render_lines(60, 8, |f| render_yaml_view(f, f.area(), &state));
+    assert!(lines[0].contains("(Line 5/19)"), "{}", lines[0]);
+    assert!(
+        lines[1].contains("   5 │   namespace: default"),
+        "{}",
+        lines[1]
+    );
+    assert!(
+        lines[6].contains("  10 │     - name: nginx"),
+        "{}",
+        lines[6]
+    );
+    assert!(lines.iter().all(|l| !l.contains("apiVersion")), "{lines:?}");
+    assert!(lines.iter().all(|l| !l.contains("image:")), "{lines:?}");
+
+    // Narrow terminal: long lines are cut, not wrapped onto extra rows.
+    let long = yaml_state(
+        "key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\nnext: 1",
+    );
+    let lines = common::render_lines(40, 6, |f| render_yaml_view(f, f.area(), &long));
+    assert!(lines[1].contains("   1 │ key: aaaa"), "{}", lines[1]);
+    assert!(lines[2].contains("   2 │ next: 1"), "{}", lines[2]);
+}
+
+#[test]
+fn yaml_view_search_badge_counts_matches_and_highlights_them_in_yellow() {
+    let mut state = yaml_state(POD_YAML);
+    state.set_search_query("Nginx");
+    // 160 columns keep the whole title, badge included, off the border.
+    let lines = common::render_lines(160, 40, |f| render_yaml_view(f, f.area(), &state));
+    assert!(
+        lines[0].contains("[Search: \"Nginx\" (1/2 matches, n/N)]"),
+        "{}",
+        lines[0]
+    );
+    // The first match is scrolled to the top of the viewport.
+    assert!(
+        lines[1].contains("  10 │     - name: nginx"),
+        "{}",
+        lines[1]
+    );
+
+    let buf = render_buffer(160, 40, |f| render_yaml_view(f, f.area(), &state));
+    let x = col(&lines[1], "nginx");
+    assert_eq!(
+        buf[(x, 1)].bg,
+        Theme::YELLOW,
+        "the matched text gets the match background"
+    );
+    let before = col(&lines[1], "name:");
+    assert_ne!(
+        buf[(before, 1)].bg,
+        Theme::YELLOW,
+        "the rest of the line is not highlighted"
+    );
+
+    state.next_match();
+    let lines = common::render_lines(160, 40, |f| render_yaml_view(f, f.area(), &state));
+    assert!(lines[0].contains("(2/2 matches, n/N)"), "{}", lines[0]);
+    assert!(
+        lines[1].contains("  11 │       image: nginx:1.25"),
+        "{}",
+        lines[1]
+    );
+
+    state.set_search_query("nowhere");
+    let text = render_yaml(160, 40, &state);
+    assert!(text.contains("[Search: \"nowhere\" (0 matches)]"), "{text}");
+}
+
+#[test]
+fn yaml_view_selection_changes_the_hint_and_shades_the_selected_rows() {
+    let mut state = yaml_state(POD_YAML);
+    state.start_selection(2);
+    state.update_selection(0);
+    let lines = common::render_lines(120, 40, |f| render_yaml_view(f, f.area(), &state));
+    assert!(
+        lines[0].contains("[c: Copy Selection, Esc: Clear Selection]"),
+        "{}",
+        lines[0]
+    );
+    assert!(!lines[0].contains("e: Edit"), "{}", lines[0]);
+
+    let buf = render_buffer(120, 40, |f| render_yaml_view(f, f.area(), &state));
+    let shaded = Color::Rgb(35, 55, 95);
+    for row in 1..=3u16 {
+        assert_eq!(
+            buf[(10, row)].bg,
+            shaded,
+            "row {row} is inside the selection"
+        );
+        assert_eq!(
+            buf[(1, row)].fg,
+            Theme::CYAN,
+            "selected line numbers turn cyan"
+        );
+    }
+    assert_ne!(buf[(10, 4)].bg, shaded, "row 4 is outside the selection");
+    assert_eq!(buf[(1, 4)].fg, Theme::DIM);
+}
+
+#[test]
+fn yaml_view_colours_comments_separators_keys_and_scalar_values() {
+    let state = yaml_state(POD_YAML);
+    let lines = common::render_lines(120, 40, |f| render_yaml_view(f, f.area(), &state));
+    let buf = render_buffer(120, 40, |f| render_yaml_view(f, f.area(), &state));
+    let style_at = |needle: &str, offset: usize| {
+        let row = row_of(&lines, needle);
+        let x = col(&lines[row], needle) + offset as u16;
+        buf[(x, row as u16)].fg
+    };
+
+    assert_eq!(style_at("# trailing comment", 0), Theme::DIM);
+    assert_eq!(style_at("---", 0), Theme::YELLOW);
+    assert_eq!(style_at("apiVersion:", 0), Theme::CYAN, "keys are cyan");
+    assert_eq!(
+        style_at("apiVersion: v1", 12),
+        Theme::FG,
+        "bare scalars use the foreground"
+    );
+    assert_eq!(
+        style_at("app: \"web\"", 5),
+        Theme::GREEN,
+        "quoted strings are green"
+    );
+    assert_eq!(
+        style_at("containerPort: 80", 15),
+        Theme::YELLOW,
+        "numbers are yellow"
+    );
+    assert_eq!(
+        style_at("enabled: true", 9),
+        Theme::YELLOW,
+        "booleans are yellow"
+    );
+    assert_eq!(
+        style_at("- name: nginx", 0),
+        Theme::YELLOW,
+        "list dashes are yellow"
+    );
+    assert_eq!(
+        style_at("- name: nginx", 2),
+        Theme::CYAN,
+        "the key after the dash is cyan"
+    );
+
+    // A line with no colon at all is plain foreground, and single-quoted
+    // scalars count as strings too.
+    let plain = yaml_state("just words here\nq: 'single'\nempty:");
+    let lines = common::render_lines(60, 6, |f| render_yaml_view(f, f.area(), &plain));
+    let buf = render_buffer(60, 6, |f| render_yaml_view(f, f.area(), &plain));
+    let x = col(&lines[1], "just");
+    assert_eq!(buf[(x, 1)].fg, Theme::FG);
+    let x = col(&lines[2], "'single'");
+    assert_eq!(buf[(x, 2)].fg, Theme::GREEN);
+    assert!(lines[3].contains("   3 │ empty:"), "{}", lines[3]);
+}
+
+#[test]
+fn yaml_view_empty_document_renders_a_bare_frame() {
+    let state = yaml_state("");
+    assert!(state.lines.is_empty());
+    let lines = common::render_lines(60, 20, |f| render_yaml_view(f, f.area(), &state));
+    assert!(
+        lines[0].contains("YAML: Pod/test-pod (default) (Line 1/0)"),
+        "{}",
+        lines[0]
+    );
+    assert!(
+        lines[1..19].iter().all(|l| !l.contains(" │ ")),
+        "no numbered rows: {lines:?}"
+    );
+}

--- a/apps/tui/tests/views_panels_tests.rs
+++ b/apps/tui/tests/views_panels_tests.rs
@@ -1,0 +1,2443 @@
+//! Integration tests for the smaller panel views under `src/views/`: their
+//! `*State` constructors and mutators, and what `render_*` draws for each
+//! branch (loading, error, empty, populated, wide, narrow).
+//!
+//! Nothing here touches a cluster, spawns a process, or depends on what is
+//! installed on the machine. States are built through the public API and
+//! rendered through ratatui's `TestBackend`.
+
+mod common;
+
+use ratatui::backend::TestBackend;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Position;
+use ratatui::style::{Color, Style};
+use ratatui::{Frame, Terminal};
+use serde_json::{json, Value};
+use srelens_kube::lineage::{LineageNode, LineageRelation};
+use srelens_kube::metrics::MetricSample;
+use srelens_tui::commands::{CrdMeta, PrinterColumn, ResourceKind};
+use srelens_tui::theme::Theme;
+use srelens_tui::views::cracked_lens::render_cracked_lens;
+use srelens_tui::views::describe_view::{render_describe_view, DescribeViewState};
+use srelens_tui::views::helm_view::{render_helm_view, HelmReleaseItem, HelmViewState};
+use srelens_tui::views::logs_view::{render_logs_view, LogsViewState};
+use srelens_tui::views::metrics_panel_view::{
+    render_metrics_panel_modal, MetricsPanelState, MetricsTimeRange,
+};
+use srelens_tui::views::port_forward_view::{
+    render_port_forward_view, PortForwardEntry, PortForwardViewState,
+};
+use srelens_tui::views::reason_rail::{
+    render_reason_rail_modal, render_reason_rail_widget, tally_event_reasons, ReasonTally,
+};
+use srelens_tui::views::resource_table::{
+    default_columns_for_kind, eval_crd_json_path, extract_field_str, is_event_warning_or_failure,
+    render_resource_table, ResourceTableState, WorkloadSegment,
+};
+use srelens_tui::views::toolbox_view::{render_toolbox_view, ToolStatusItem, ToolboxViewState};
+use srelens_tui::views::tree_view::{render_tree_view, TreeViewState};
+use srelens_tui::views::{highlight_text_matches, sanitize_span_text};
+
+/// Render one frame and hand back the raw buffer so a test can inspect cell
+/// styles (the colour a status cell was drawn in), not only the text.
+fn render_buffer<F>(width: u16, height: u16, draw: F) -> Buffer
+where
+    F: FnOnce(&mut Frame),
+{
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    terminal.draw(draw).expect("draw");
+    terminal.backend().buffer().clone()
+}
+
+/// The row text of a buffer, trailing spaces trimmed.
+fn buffer_row(buf: &Buffer, y: u16) -> String {
+    let mut line = String::new();
+    for x in 0..buf.area.width {
+        line.push_str(buf[(x, y)].symbol());
+    }
+    line.trim_end().to_string()
+}
+
+/// Foreground colour of the first cell on row `y` whose text starts `needle`.
+fn fg_of(buf: &Buffer, y: u16, needle: &str) -> Option<Color> {
+    let row = buffer_row(buf, y);
+    let col = row.find(needle)?;
+    // `find` returns a byte offset; rows here are ASCII up to the needle
+    // except for box-drawing borders, so count chars instead.
+    let x = row[..col].chars().count() as u16;
+    buf.cell(Position::new(x, y)).and_then(|c| c.style().fg)
+}
+
+/// Screen column (not byte offset) at which `needle` starts in `row`.
+fn col_of(row: &str, needle: &str) -> u16 {
+    let byte = row
+        .find(needle)
+        .unwrap_or_else(|| panic!("{needle:?} not in {row:?}"));
+    row[..byte].chars().count() as u16
+}
+
+fn row_containing<'a>(lines: &'a [String], needle: &str) -> Option<(usize, &'a String)> {
+    lines.iter().enumerate().find(|(_, l)| l.contains(needle))
+}
+
+// ---------------------------------------------------------------------------
+// views/mod.rs: sanitize_span_text and highlight_text_matches
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sanitize_span_text_passes_plain_text_through_unchanged() {
+    assert_eq!(sanitize_span_text("plain text 123"), "plain text 123");
+    assert_eq!(sanitize_span_text(""), "");
+}
+
+#[test]
+fn sanitize_span_text_expands_tabs_to_eight_column_stops() {
+    assert_eq!(sanitize_span_text("\tx"), "        x");
+    assert_eq!(sanitize_span_text("abc\tx"), "abc     x");
+    assert_eq!(sanitize_span_text("12345678\tx"), "12345678        x");
+}
+
+#[test]
+fn sanitize_span_text_drops_csi_and_two_byte_escape_sequences() {
+    // CSI: ESC [ params final-byte.
+    assert_eq!(sanitize_span_text("\u{1b}[1;32mok\u{1b}[0m"), "ok");
+    // A non-CSI escape is ESC plus exactly one byte.
+    assert_eq!(sanitize_span_text("a\u{1b}Mb"), "ab");
+    // A trailing bare ESC has nothing to swallow and simply disappears.
+    assert_eq!(sanitize_span_text("tail\u{1b}"), "tail");
+}
+
+#[test]
+fn sanitize_span_text_flattens_newlines_and_removes_other_controls() {
+    assert_eq!(sanitize_span_text("a\nb"), "a b");
+    assert_eq!(sanitize_span_text("a\r\nb\u{7}\u{0}c"), "a bc");
+    // A newline counts as one column for the following tab stop.
+    assert_eq!(sanitize_span_text("\n\tx"), "        x");
+}
+
+#[test]
+fn highlight_text_matches_returns_one_base_span_for_an_empty_query() {
+    let spans = highlight_text_matches("hello", "", Style::default(), Style::default());
+    assert_eq!(spans.len(), 1);
+    assert_eq!(spans[0].content, "hello");
+}
+
+#[test]
+fn highlight_text_matches_splits_around_every_case_insensitive_hit() {
+    let base = Style::default().fg(Color::White);
+    let hit = Style::default().fg(Color::Yellow);
+    let spans = highlight_text_matches("Error: an ERROR again", "error", base, hit);
+    let parts: Vec<(&str, Option<Color>)> = spans
+        .iter()
+        .map(|s| (s.content.as_ref(), s.style.fg))
+        .collect();
+    assert_eq!(
+        parts,
+        vec![
+            ("Error", Some(Color::Yellow)),
+            (": an ", Some(Color::White)),
+            ("ERROR", Some(Color::Yellow)),
+            (" again", Some(Color::White)),
+        ]
+    );
+}
+
+#[test]
+fn highlight_text_matches_falls_back_to_the_whole_text_when_nothing_matches() {
+    let base = Style::default().fg(Color::White);
+    let hit = Style::default().fg(Color::Yellow);
+    let spans = highlight_text_matches("nothing here", "zzz", base, hit);
+    assert_eq!(spans.len(), 1);
+    assert_eq!(spans[0].content, "nothing here");
+    assert_eq!(spans[0].style.fg, Some(Color::White));
+}
+
+#[test]
+fn highlight_text_matches_handles_a_match_that_ends_the_text() {
+    let spans = highlight_text_matches("abcXYZ", "xyz", Style::default(), Style::default());
+    let parts: Vec<&str> = spans.iter().map(|s| s.content.as_ref()).collect();
+    assert_eq!(parts, vec!["abc", "XYZ"]);
+}
+
+// ---------------------------------------------------------------------------
+// logs_view
+// ---------------------------------------------------------------------------
+
+fn logs() -> LogsViewState {
+    LogsViewState::new(
+        "web-0".to_string(),
+        "default".to_string(),
+        Some("app".to_string()),
+        "chan-1".to_string(),
+    )
+}
+
+#[test]
+fn logs_view_starts_empty_and_following() {
+    let state = logs();
+    assert!(state.lines.is_empty());
+    assert!(state.follow);
+    assert!(!state.timestamps);
+    assert!(!state.previous);
+    assert!(!state.wrap);
+    assert_eq!(state.scroll_offset, 0);
+    assert!(state.search_query.is_empty());
+    assert!(state.current_match_idx.is_none());
+}
+
+#[test]
+fn logs_view_push_line_keeps_the_bottom_in_view_while_following() {
+    let mut state = logs();
+    for i in 0..5 {
+        state.push_line(format!("line {i}"));
+    }
+    assert_eq!(state.lines.len(), 5);
+    assert_eq!(state.scroll_offset, 4);
+}
+
+#[test]
+fn logs_view_stops_following_when_the_user_scrolls_up() {
+    let mut state = logs();
+    for i in 0..10 {
+        state.push_line(format!("line {i}"));
+    }
+    state.scroll_up(3);
+    assert!(!state.follow);
+    assert_eq!(state.scroll_offset, 6);
+    // New lines no longer drag the viewport down.
+    state.push_line("line 10".to_string());
+    assert_eq!(state.scroll_offset, 6);
+    // Scrolling up past the top clamps at zero.
+    state.scroll_up(100);
+    assert_eq!(state.scroll_offset, 0);
+}
+
+#[test]
+fn logs_view_scroll_down_is_bounded_by_the_last_line() {
+    let mut state = logs();
+    for i in 0..4 {
+        state.push_line(format!("line {i}"));
+    }
+    state.scroll_top();
+    assert_eq!(state.scroll_offset, 0);
+    assert!(!state.follow);
+    state.scroll_down(2);
+    assert_eq!(state.scroll_offset, 2);
+    // A step that would run past the end is ignored entirely.
+    state.scroll_down(5);
+    assert_eq!(state.scroll_offset, 2);
+}
+
+#[test]
+fn logs_view_toggle_follow_jumps_back_to_the_bottom() {
+    let mut state = logs();
+    for i in 0..6 {
+        state.push_line(format!("line {i}"));
+    }
+    state.scroll_top();
+    state.toggle_follow();
+    assert!(state.follow);
+    assert_eq!(state.scroll_offset, 5);
+    state.toggle_follow();
+    assert!(!state.follow);
+}
+
+#[test]
+fn logs_view_flag_toggles_flip_each_flag_independently() {
+    let mut state = logs();
+    state.toggle_timestamps();
+    state.toggle_previous();
+    state.toggle_wrap();
+    assert!(state.timestamps && state.previous && state.wrap);
+    state.toggle_timestamps();
+    assert!(!state.timestamps && state.previous && state.wrap);
+}
+
+#[test]
+fn logs_view_search_finds_matches_and_cycles_through_them() {
+    let mut state = logs();
+    state.push_line("boot ok".to_string());
+    state.push_line("ERROR one".to_string());
+    state.push_line("fine".to_string());
+    state.push_line("error two".to_string());
+
+    state.set_search_query("error");
+    assert_eq!(state.search_matches, vec![1, 3]);
+    assert_eq!(state.current_match_idx, Some(0));
+    assert_eq!(state.scroll_offset, 1);
+    assert!(!state.follow);
+
+    state.next_match();
+    assert_eq!(state.current_match_idx, Some(1));
+    assert_eq!(state.scroll_offset, 3);
+    state.next_match();
+    assert_eq!(state.current_match_idx, Some(0), "next wraps around");
+
+    state.prev_match();
+    assert_eq!(
+        state.current_match_idx,
+        Some(1),
+        "prev from first wraps to last"
+    );
+    state.prev_match();
+    assert_eq!(state.current_match_idx, Some(0));
+
+    state.clear_search();
+    assert!(state.search_query.is_empty());
+    assert!(state.search_matches.is_empty());
+    assert!(state.current_match_idx.is_none());
+}
+
+#[test]
+fn logs_view_search_with_no_hits_or_empty_query_clears_the_cursor() {
+    let mut state = logs();
+    state.push_line("only line".to_string());
+    state.set_search_query("nomatch");
+    assert!(state.search_matches.is_empty());
+    assert!(state.current_match_idx.is_none());
+    // next/prev on no matches are no-ops.
+    state.next_match();
+    state.prev_match();
+    assert!(state.current_match_idx.is_none());
+
+    state.set_search_query("line");
+    assert_eq!(state.current_match_idx, Some(0));
+    state.set_search_query("");
+    assert!(state.search_matches.is_empty());
+    assert!(state.current_match_idx.is_none());
+
+    // With no current index, next/prev start from the ends.
+    state.set_search_query("line");
+    state.current_match_idx = None;
+    state.next_match();
+    assert_eq!(state.current_match_idx, Some(0));
+    state.current_match_idx = None;
+    state.prev_match();
+    assert_eq!(state.current_match_idx, Some(0));
+}
+
+#[test]
+fn logs_view_save_to_file_writes_every_line_to_the_temp_dir() {
+    let mut state = logs();
+    state.push_line("first".to_string());
+    state.push_line("second".to_string());
+    let path = state.save_to_file().expect("saved");
+    let contents = std::fs::read_to_string(&path).expect("readable");
+    assert_eq!(contents, "first\nsecond");
+    assert!(path.contains("web-0-"));
+    assert!(path.ends_with("-logs.txt"));
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn logs_view_renders_a_waiting_placeholder_when_there_are_no_lines() {
+    let state = logs();
+    let text = common::render_text(120, 40, |f| render_logs_view(f, f.area(), &state));
+    assert!(
+        text.contains("Logs: web-0 (default/app) [Ftpw] [1/0 lines]"),
+        "{text}"
+    );
+    assert!(text.contains("Waiting for logs..."));
+}
+
+#[test]
+fn logs_view_renders_numbered_lines_and_the_flag_letters_when_following() {
+    let mut state =
+        LogsViewState::new("api".to_string(), "prod".to_string(), None, "c".to_string());
+    for i in 1..=3 {
+        state.push_line(format!("message {i}"));
+    }
+    state.toggle_timestamps();
+    state.toggle_previous();
+    state.toggle_wrap();
+    let text = common::render_text(120, 40, |f| render_logs_view(f, f.area(), &state));
+    assert!(
+        text.contains("Logs: api (prod/all) [FTPW] [3/3 lines]"),
+        "{text}"
+    );
+    assert!(text.contains("    1 │ message 1"));
+    assert!(text.contains("    3 │ message 3"));
+}
+
+#[test]
+fn logs_view_shows_the_tail_while_following_and_the_offset_when_not() {
+    let mut state = logs();
+    for i in 1..=50 {
+        state.push_line(format!("line {i}"));
+    }
+    // 10 rows tall: 8 inner rows -> the last 8 lines while following.
+    let text = common::render_text(60, 10, |f| render_logs_view(f, f.area(), &state));
+    assert!(text.contains("   50 │ line 50"), "{text}");
+    assert!(!text.contains("   42 │ line 42"), "{text}");
+    assert!(text.contains("   43 │ line 43"), "{text}");
+
+    state.scroll_top();
+    state.scroll_down(4);
+    let text = common::render_text(60, 10, |f| render_logs_view(f, f.area(), &state));
+    assert!(text.contains("[5/50 lines]"), "{text}");
+    assert!(text.contains("    5 │ line 5"), "{text}");
+    assert!(!text.contains("    4 │ line 4"), "{text}");
+}
+
+#[test]
+fn logs_view_colours_lines_by_severity_and_highlights_search_hits() {
+    let mut state = logs();
+    state.push_line("something FATAL happened".to_string());
+    state.push_line("a warning here".to_string());
+    state.push_line("info: started".to_string());
+    state.push_line("debug: details".to_string());
+    state.push_line("plain".to_string());
+    state.scroll_top();
+
+    let buf = render_buffer(80, 12, |f| render_logs_view(f, f.area(), &state));
+    let red = Theme::RED;
+    let yellow = Theme::YELLOW;
+    let dim = Theme::DIM;
+    assert_eq!(fg_of(&buf, 1, "something"), Some(red));
+    assert_eq!(fg_of(&buf, 2, "a warning"), Some(yellow));
+    assert_eq!(fg_of(&buf, 3, "info:"), Some(Theme::FG));
+    assert_eq!(fg_of(&buf, 4, "debug:"), Some(dim));
+    assert_eq!(fg_of(&buf, 5, "plain"), Some(Theme::FG));
+
+    state.set_search_query("WARN");
+    let buf = render_buffer(140, 12, |f| render_logs_view(f, f.area(), &state));
+    let title = buffer_row(&buf, 0);
+    assert!(
+        title.contains("[Search: \"WARN\" (1/1 matches, n/N)]"),
+        "{title}"
+    );
+    // The viewport now starts at the match; the hit itself is drawn on the
+    // yellow match background, the rest of the line in the base colour.
+    let row = buffer_row(&buf, 1);
+    assert!(row.contains("a warning here"), "{row}");
+    let x = col_of(&row, "warn");
+    assert_eq!(
+        buf.cell(Position::new(x, 1)).unwrap().style().bg,
+        Some(yellow)
+    );
+    let x_a = col_of(&row, "a warning");
+    assert_ne!(
+        buf.cell(Position::new(x_a, 1)).unwrap().style().bg,
+        Some(yellow)
+    );
+}
+
+#[test]
+fn logs_view_title_reports_zero_matches_and_wraps_long_lines_when_asked() {
+    let mut state = logs();
+    state.push_line("x".repeat(100));
+    state.set_search_query("nothing");
+    let lines = common::render_lines(60, 20, |f| render_logs_view(f, f.area(), &state));
+    // The title is clipped to the width; the badge is still part of it.
+    let title_text = common::render_text(200, 20, |f| render_logs_view(f, f.area(), &state));
+    assert!(
+        title_text.contains("[Search: \"nothing\" (0 matches)]"),
+        "{title_text}"
+    );
+    // Without wrap the 100-char line is cut at the border.
+    assert!(lines[1].starts_with("│    1 │ xxxx"), "{}", lines[1]);
+    assert!(
+        lines[2].trim_matches(|c| c == '│' || c == ' ').is_empty(),
+        "{}",
+        lines[2]
+    );
+
+    state.toggle_wrap();
+    let wrapped = common::render_lines(60, 20, |f| render_logs_view(f, f.area(), &state));
+    assert!(
+        wrapped[2].contains("xxxx"),
+        "wrapped continuation: {}",
+        wrapped[2]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// describe_view
+// ---------------------------------------------------------------------------
+
+const DESCRIBE: &str = "Name:         web-0\nNamespace:    default\nLabels:       app=web\n\nContainers:\n  app:\n    Image:  nginx\nplain trailing line\nEvents:       <none>";
+
+fn describe() -> DescribeViewState {
+    DescribeViewState::new(
+        "web-0".to_string(),
+        "Pod".to_string(),
+        Some("default".to_string()),
+        DESCRIBE.to_string(),
+    )
+}
+
+#[test]
+fn describe_view_splits_content_into_lines_at_construction() {
+    let state = describe();
+    assert_eq!(state.lines.len(), 9);
+    assert_eq!(state.lines[0], "Name:         web-0");
+    assert_eq!(state.content, DESCRIBE);
+    assert_eq!(state.scroll_offset, 0);
+}
+
+#[test]
+fn describe_view_search_cycles_and_clears() {
+    let mut state = describe();
+    state.set_search_query("APP");
+    assert_eq!(state.search_matches, vec![2, 5]);
+    assert_eq!(state.current_match_idx, Some(0));
+    assert_eq!(state.scroll_offset, 2);
+
+    state.next_match();
+    assert_eq!(state.scroll_offset, 5);
+    state.next_match();
+    assert_eq!(state.current_match_idx, Some(0));
+    state.prev_match();
+    assert_eq!(state.current_match_idx, Some(1));
+    state.prev_match();
+    assert_eq!(state.current_match_idx, Some(0));
+
+    state.set_search_query("zzz");
+    assert!(state.search_matches.is_empty());
+    assert!(state.current_match_idx.is_none());
+    state.next_match();
+    state.prev_match();
+    assert!(state.current_match_idx.is_none());
+
+    state.set_search_query("");
+    assert!(state.search_matches.is_empty());
+
+    state.set_search_query("name");
+    state.clear_search();
+    assert!(state.search_query.is_empty() && state.search_matches.is_empty());
+    assert!(state.current_match_idx.is_none());
+}
+
+#[test]
+fn describe_view_scrolling_is_clamped_to_the_content() {
+    let mut state = describe();
+    state.scroll_down(3);
+    assert_eq!(state.scroll_offset, 3);
+    state.scroll_down(100);
+    assert_eq!(state.scroll_offset, 3, "overshoot is ignored");
+    state.scroll_up(1);
+    assert_eq!(state.scroll_offset, 2);
+    state.scroll_up(50);
+    assert_eq!(state.scroll_offset, 0);
+    state.scroll_bottom();
+    assert_eq!(state.scroll_offset, 8);
+    state.scroll_top();
+    assert_eq!(state.scroll_offset, 0);
+
+    let mut empty = DescribeViewState::new("x".into(), "Pod".into(), None, String::new());
+    empty.scroll_bottom();
+    assert_eq!(empty.scroll_offset, 0);
+}
+
+#[test]
+fn describe_view_renders_title_with_namespace_and_styled_key_value_lines() {
+    let state = describe();
+    let buf = render_buffer(120, 40, |f| render_describe_view(f, f.area(), &state));
+    let title = buffer_row(&buf, 0);
+    assert!(
+        title
+            .contains("Describe: Pod/web-0 (default) (Line 1/9) [c: Copy] [/: Search] [Esc: Back]"),
+        "{title}"
+    );
+    // "Name:" is the cyan key, the value is the base colour.
+    assert_eq!(fg_of(&buf, 1, "Name:"), Some(Theme::CYAN));
+    assert_eq!(fg_of(&buf, 1, "web-0"), Some(Theme::FG));
+    // A line without a colon is drawn plain.
+    assert_eq!(fg_of(&buf, 8, "plain trailing"), Some(Theme::FG));
+    assert!(buffer_row(&buf, 9).contains("Events:       <none>"));
+}
+
+#[test]
+fn describe_view_renders_without_namespace_and_from_the_scroll_offset() {
+    let mut state = DescribeViewState::new(
+        "node-a".into(),
+        "Node".into(),
+        None,
+        (1..=30)
+            .map(|i| format!("k{i}: v{i}"))
+            .collect::<Vec<_>>()
+            .join("\n"),
+    );
+    state.scroll_down(10);
+    let lines = common::render_lines(60, 20, |f| render_describe_view(f, f.area(), &state));
+    assert!(
+        lines[0].contains("Describe: Node/node-a  (Line 11/30)"),
+        "{}",
+        lines[0]
+    );
+    assert!(lines[1].contains("k11: v11"), "{}", lines[1]);
+    assert!(!lines.iter().any(|l| l.contains("k10: v10")));
+}
+
+#[test]
+fn describe_view_shows_the_search_badge_and_highlights_the_hit() {
+    let mut state = describe();
+    state.set_search_query("nginx");
+    let buf = render_buffer(120, 40, |f| render_describe_view(f, f.area(), &state));
+    let title = buffer_row(&buf, 0);
+    assert!(
+        title.contains("[Search: \"nginx\" (1/1 matches, n/N)]"),
+        "{title}"
+    );
+    // Scrolled to the match: first body row is the Image line.
+    let row = buffer_row(&buf, 1);
+    assert!(row.contains("Image:  nginx"), "{row}");
+    let x = col_of(&row, "nginx");
+    assert_eq!(
+        buf.cell(Position::new(x, 1)).unwrap().style().bg,
+        Some(Theme::YELLOW)
+    );
+    assert_ne!(
+        buf.cell(Position::new(x - 1, 1)).unwrap().style().bg,
+        Some(Theme::YELLOW)
+    );
+
+    state.set_search_query("absent");
+    let text = common::render_text(120, 40, |f| render_describe_view(f, f.area(), &state));
+    assert!(text.contains("[Search: \"absent\" (0 matches)]"), "{text}");
+}
+
+// ---------------------------------------------------------------------------
+// tree_view
+// ---------------------------------------------------------------------------
+
+fn lineage() -> LineageNode {
+    let mut deploy = LineageNode::new(
+        "Deployment",
+        "web",
+        Some("prod".into()),
+        LineageRelation::Owner,
+    );
+    deploy.status = Some("3/3 ready".into());
+    let mut rs = LineageNode::new(
+        "ReplicaSet",
+        "web-abc",
+        Some("prod".into()),
+        LineageRelation::Owner,
+    );
+    let mut pod = LineageNode::new(
+        "Pod",
+        "web-abc-1",
+        Some("prod".into()),
+        LineageRelation::Target,
+    );
+    pod.status = Some("Running".into());
+    pod.details = Some("node-1".into());
+    let mut ctr = LineageNode::new("Container", "app", None, LineageRelation::Child);
+    ctr.status = Some("CrashLoopBackOff".into());
+    let mut cm = LineageNode::new(
+        "ConfigMap",
+        "web-cfg",
+        Some("prod".into()),
+        LineageRelation::Config,
+    );
+    cm.status = Some("Pending".into());
+    let svc = LineageNode::new(
+        "Service",
+        "web-svc",
+        Some("prod".into()),
+        LineageRelation::Service,
+    );
+    let ing = LineageNode::new(
+        "Ingress",
+        "web-ing",
+        Some("prod".into()),
+        LineageRelation::Ingress,
+    );
+    let sec = LineageNode::new(
+        "Secret",
+        "web-tls",
+        Some("prod".into()),
+        LineageRelation::Secret,
+    );
+    let pvc = LineageNode::new(
+        "PersistentVolumeClaim",
+        "data",
+        Some("prod".into()),
+        LineageRelation::Storage,
+    );
+    let node = LineageNode::new("Node", "node-1", None, LineageRelation::Node);
+    let other = LineageNode::new("Widget", "w", None, LineageRelation::Child);
+    pod.children = vec![ctr, cm, sec, pvc, node, other];
+    rs.children.push(pod);
+    deploy.children = vec![rs, svc, ing];
+    deploy
+}
+
+#[test]
+fn tree_view_flattens_with_branch_glyphs_and_selects_the_target() {
+    let mut state = TreeViewState::new("Pod".into(), "web-abc-1".into(), Some("prod".into()));
+    assert!(state.is_loading);
+    state.set_tree(lineage());
+    assert!(!state.is_loading);
+    assert!(state.error.is_none());
+    assert_eq!(state.nodes.len(), 11);
+    assert_eq!(state.nodes[0].prefix, "");
+    assert_eq!(state.nodes[1].prefix, "├── ");
+    assert_eq!(state.nodes[2].prefix, "│   └── ");
+    assert_eq!(state.nodes[3].prefix, "│       ├── ");
+    assert_eq!(state.nodes[8].prefix, "│       └── ");
+    assert_eq!(state.nodes[9].prefix, "├── ");
+    assert_eq!(state.nodes[10].prefix, "└── ");
+    assert_eq!(state.selected_idx, 2);
+    assert_eq!(state.selected_node().unwrap().name, "web-abc-1");
+    assert_eq!(state.nodes[2].depth, 2);
+    assert!(state.nodes[2].is_last_child);
+}
+
+#[test]
+fn tree_view_navigation_clamps_at_both_ends() {
+    let mut state = TreeViewState::new("Pod".into(), "web-abc-1".into(), None);
+    state.set_tree(lineage());
+    state.select_first();
+    assert_eq!(state.selected_idx, 0);
+    state.select_prev();
+    assert_eq!(state.selected_idx, 0);
+    state.select_last();
+    assert_eq!(state.selected_idx, 10);
+    state.select_next();
+    assert_eq!(state.selected_idx, 10);
+    state.select_prev();
+    state.select_next();
+    assert_eq!(state.selected_idx, 10);
+
+    let mut empty = TreeViewState::new("Pod".into(), "x".into(), None);
+    empty.select_last();
+    empty.select_next();
+    assert_eq!(empty.selected_idx, 0);
+    assert!(empty.selected_node().is_none());
+}
+
+#[test]
+fn tree_view_tree_as_text_lists_every_node_with_badge_and_status() {
+    let mut state = TreeViewState::new("Pod".into(), "web-abc-1".into(), None);
+    state.set_tree(lineage());
+    let text = state.tree_as_text();
+    assert!(text.starts_with("Resource Relationship Tree for Pod/web-abc-1\n"));
+    assert!(text.contains(&"=".repeat(50)));
+    assert!(text.contains("Deployment/web [OWNER] [status: 3/3 ready] \n"));
+    assert!(text.contains("│   └── Pod/web-abc-1 [TARGET] [status: Running] node-1\n"));
+    assert!(text.contains("├── Service/web-svc [SERVICE] [status: -] \n"));
+}
+
+#[test]
+fn tree_view_renders_loading_error_and_empty_branches() {
+    let mut state = TreeViewState::new("Pod".into(), "web-0".into(), Some("ns".into()));
+    let text = common::render_text(120, 40, |f| render_tree_view(f, f.area(), &state));
+    assert!(
+        text.contains("Resource Relationship Tree: Pod/web-0 ns"),
+        "{text}"
+    );
+    assert!(text.contains("Resolving resource lineage..."));
+    assert!(text.contains("linked resources for Pod/web-0..."));
+
+    state.set_error("forbidden: pods is forbidden".into());
+    assert!(!state.is_loading);
+    let text = common::render_text(120, 40, |f| render_tree_view(f, f.area(), &state));
+    assert!(
+        text.contains("Failed to resolve lineage: forbidden: pods is forbidden"),
+        "{text}"
+    );
+
+    state.error = None;
+    let text = common::render_text(120, 40, |f| render_tree_view(f, f.area(), &state));
+    assert!(
+        text.contains("No relationships or lineage found for this resource."),
+        "{text}"
+    );
+}
+
+#[test]
+fn tree_view_renders_every_node_kind_with_its_badges_and_status_colour() {
+    let mut state = TreeViewState::new("Pod".into(), "web-abc-1".into(), Some("prod".into()));
+    state.set_tree(lineage());
+    let buf = render_buffer(120, 40, |f| render_tree_view(f, f.area(), &state));
+    let rows: Vec<String> = (0..buf.area.height).map(|y| buffer_row(&buf, y)).collect();
+
+    let (y, deploy) = row_containing(&rows, "Deployment/web [OWNER]").unwrap();
+    assert!(deploy.contains("[● 3/3 ready]"), "{deploy}");
+    assert_eq!(fg_of(&buf, y as u16, "[● 3/3"), Theme::status_ok().fg);
+
+    let (y, pod) = row_containing(&rows, "Pod/web-abc-1 [TARGET]").unwrap();
+    assert!(pod.contains("[● Running] (node-1)"), "{pod}");
+    // Selected row: the name is drawn in the selection foreground.
+    assert_eq!(fg_of(&buf, y as u16, "web-abc-1"), Some(Theme::SEL_FG));
+
+    let (y, ctr) = row_containing(&rows, "Container/app [CHILD]").unwrap();
+    assert!(ctr.contains("[● CrashLoopBackOff]"), "{ctr}");
+    assert_eq!(fg_of(&buf, y as u16, "[● Crash"), Theme::status_error().fg);
+
+    let (y, cm) = row_containing(&rows, "ConfigMap/web-cfg [CONFIG]").unwrap();
+    assert!(cm.contains("[● Pending]"), "{cm}");
+    assert_eq!(fg_of(&buf, y as u16, "[● Pending"), Theme::status_warn().fg);
+
+    assert!(row_containing(&rows, "Secret/web-tls [SECRET]").is_some());
+    assert!(row_containing(&rows, "PersistentVolumeClaim/data [STORAGE]").is_some());
+    assert!(row_containing(&rows, "Node/node-1 [NODE]").is_some());
+    assert!(row_containing(&rows, "Widget/w [CHILD]").is_some());
+    assert!(row_containing(&rows, "Service/web-svc [SERVICE]").is_some());
+    assert!(row_containing(&rows, "Ingress/web-ing [INGRESS]").is_some());
+}
+
+#[test]
+fn tree_view_scrolls_so_a_far_selection_stays_visible_on_a_short_screen() {
+    let mut root = LineageNode::new("Deployment", "big", None, LineageRelation::Owner);
+    for i in 0..40 {
+        root.children.push(LineageNode::new(
+            "Pod",
+            format!("pod-{i:02}"),
+            None,
+            LineageRelation::Child,
+        ));
+    }
+    let mut state = TreeViewState::new("Deployment".into(), "big".into(), None);
+    state.set_tree(root);
+    state.select_last();
+    // 20 rows -> 18 inner rows; selection 40 -> start at 40 - 9 = 31.
+    let lines = common::render_lines(60, 20, |f| render_tree_view(f, f.area(), &state));
+    assert!(lines.iter().any(|l| l.contains("Pod/pod-39")), "{lines:?}");
+    assert!(lines.iter().any(|l| l.contains("Pod/pod-30")), "{lines:?}");
+    assert!(!lines.iter().any(|l| l.contains("Pod/pod-29")), "{lines:?}");
+    // The root is scrolled out of the body (it still appears in the title).
+    assert!(
+        !lines[1..].iter().any(|l| l.contains("Deployment/big")),
+        "{lines:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// toolbox_view (hand-built state: the constructor probes the machine)
+// ---------------------------------------------------------------------------
+
+fn tool(
+    name: &str,
+    installed: bool,
+    required: bool,
+    version: Option<&str>,
+    path: Option<&str>,
+) -> ToolStatusItem {
+    ToolStatusItem {
+        name: name.to_string(),
+        installed,
+        version: version.map(str::to_string),
+        path: path.map(str::to_string),
+        required,
+    }
+}
+
+fn toolbox() -> ToolboxViewState {
+    ToolboxViewState {
+        tools: vec![
+            tool(
+                "kubectl",
+                true,
+                true,
+                Some("v1.30.2"),
+                Some("/usr/local/bin/kubectl"),
+            ),
+            tool("helm", false, true, None, None),
+            tool("krew", false, false, None, None),
+        ],
+        selected_idx: 0,
+    }
+}
+
+#[test]
+fn toolbox_view_selection_moves_within_the_tool_list() {
+    let mut state = toolbox();
+    state.select_prev();
+    assert_eq!(state.selected_idx, 0);
+    state.select_next();
+    state.select_next();
+    assert_eq!(state.selected_idx, 2);
+    state.select_next();
+    assert_eq!(state.selected_idx, 2);
+    state.select_prev();
+    assert_eq!(state.selected_idx, 1);
+
+    let mut empty = ToolboxViewState {
+        tools: vec![],
+        selected_idx: 0,
+    };
+    empty.select_next();
+    assert_eq!(empty.selected_idx, 0);
+}
+
+#[test]
+fn toolbox_view_renders_one_status_per_tool_with_the_right_colour() {
+    let state = toolbox();
+    let buf = render_buffer(120, 20, |f| render_toolbox_view(f, f.area(), &state));
+    let rows: Vec<String> = (0..buf.area.height).map(|y| buffer_row(&buf, y)).collect();
+    assert!(
+        rows[0].contains("SRElens Toolbox & CLI Environment Diagnostics (<Esc> Back)"),
+        "{}",
+        rows[0]
+    );
+    assert!(
+        rows[1].contains("TOOL")
+            && rows[1].contains("STATUS")
+            && rows[1].contains("VERSION")
+            && rows[1].contains("PATH")
+    );
+
+    let (y, kubectl) = row_containing(&rows, "kubectl").unwrap();
+    assert!(kubectl.contains("● INSTALLED"), "{kubectl}");
+    assert!(
+        kubectl.contains("v1.30.2") && kubectl.contains("/usr/local/bin/kubectl"),
+        "{kubectl}"
+    );
+    assert_eq!(fg_of(&buf, y as u16, "● INSTALLED"), Theme::status_ok().fg);
+
+    let (y, helm) = row_containing(&rows, "helm").unwrap();
+    assert!(helm.contains("● MISSING (REQUIRED)"), "{helm}");
+    assert_eq!(fg_of(&buf, y as u16, "● MISSING"), Theme::status_error().fg);
+
+    let (y, krew) = row_containing(&rows, "krew").unwrap();
+    assert!(krew.contains("○ NOT INSTALLED"), "{krew}");
+    assert_eq!(fg_of(&buf, y as u16, "○ NOT"), Theme::status_warn().fg);
+    // Missing version and path render as a dash.
+    assert!(
+        krew.matches(" - ").count() >= 1 || krew.ends_with('-') || krew.contains("-  "),
+        "{krew}"
+    );
+}
+
+#[test]
+fn toolbox_view_highlights_the_selected_row_even_on_a_narrow_screen() {
+    let mut state = toolbox();
+    state.select_next();
+    let buf = render_buffer(60, 20, |f| render_toolbox_view(f, f.area(), &state));
+    let rows: Vec<String> = (0..buf.area.height).map(|y| buffer_row(&buf, y)).collect();
+    let (y, _) = row_containing(&rows, "helm").unwrap();
+    assert_eq!(
+        buf.cell(Position::new(2, y as u16)).unwrap().style().bg,
+        Theme::selected_row().bg
+    );
+    let (y0, _) = row_containing(&rows, "kubectl").unwrap();
+    assert_ne!(
+        buf.cell(Position::new(2, y0 as u16)).unwrap().style().bg,
+        Theme::selected_row().bg
+    );
+}
+
+// ---------------------------------------------------------------------------
+// port_forward_view
+// ---------------------------------------------------------------------------
+
+fn forward(id: &str, status: &str, local: u16, rx: u64, tx: u64) -> PortForwardEntry {
+    PortForwardEntry {
+        id: id.to_string(),
+        context: "prod".to_string(),
+        namespace: "default".to_string(),
+        target_type: "pod".to_string(),
+        target_name: format!("web-{id}"),
+        local_port: local,
+        container_port: 8080,
+        active_connections: 2,
+        bytes_rx: rx,
+        bytes_tx: tx,
+        status: status.to_string(),
+    }
+}
+
+#[test]
+fn port_forward_view_set_forwards_clamps_the_selection() {
+    let mut state = PortForwardViewState::new();
+    assert!(state.forwards.is_empty());
+    assert!(state.selected_forward().is_none());
+
+    state.set_forwards(vec![
+        forward("a", "active", 8080, 0, 0),
+        forward("b", "active", 8081, 0, 0),
+        forward("c", "error", 8082, 0, 0),
+    ]);
+    state.select_next();
+    state.select_next();
+    state.select_next();
+    assert_eq!(state.selected_idx, 2);
+    assert_eq!(state.selected_forward().unwrap().id, "c");
+
+    state.set_forwards(vec![forward("a", "active", 8080, 0, 0)]);
+    assert_eq!(state.selected_idx, 0);
+    state.select_prev();
+    assert_eq!(state.selected_idx, 0);
+
+    state.set_forwards(vec![]);
+    assert_eq!(state.selected_idx, 0);
+    state.select_next();
+    assert_eq!(state.selected_idx, 0);
+}
+
+#[test]
+fn port_forward_view_renders_the_empty_placeholder() {
+    let state = PortForwardViewState::new();
+    let text = common::render_text(120, 20, |f| render_port_forward_view(f, f.area(), &state));
+    assert!(
+        text.contains(
+            "Active Port Forwards [0] (<d> Stop Forward <shift-f> New Forward <Esc> Back)"
+        ),
+        "{text}"
+    );
+    assert!(
+        text.contains("No active port forwards. Select a Pod or Service and press <shift-f>"),
+        "{text}"
+    );
+}
+
+#[test]
+fn port_forward_view_renders_rows_with_human_byte_counts_and_status_colours() {
+    let mut state = PortForwardViewState::new();
+    state.set_forwards(vec![
+        forward("a", "active", 8080, 512, 1536),
+        forward("b", "running", 9090, 3 * 1024 * 1024, 0),
+        forward("c", "error", 7070, 1024, 2048),
+    ]);
+    state.select_next();
+    let buf = render_buffer(140, 20, |f| render_port_forward_view(f, f.area(), &state));
+    let rows: Vec<String> = (0..buf.area.height).map(|y| buffer_row(&buf, y)).collect();
+    assert!(rows[0].contains("Active Port Forwards [3]"), "{}", rows[0]);
+    assert!(
+        rows[1].contains("STATUS") && rows[1].contains("LOCAL PORT") && rows[1].contains("RX / TX"),
+        "{}",
+        rows[1]
+    );
+
+    let (y, a) = row_containing(&rows, "127.0.0.1:8080").unwrap();
+    assert!(
+        a.contains("● active")
+            && a.contains("pod/web-a")
+            && a.contains("8080")
+            && a.contains("512B / 1.5KB"),
+        "{a}"
+    );
+    assert_eq!(fg_of(&buf, y as u16, "● active"), Theme::status_ok().fg);
+
+    let (y, b) = row_containing(&rows, "127.0.0.1:9090").unwrap();
+    assert!(b.contains("3.0MB / 0B"), "{b}");
+    assert_eq!(fg_of(&buf, y as u16, "● running"), Theme::status_ok().fg);
+    assert_eq!(
+        buf.cell(Position::new(2, y as u16)).unwrap().style().bg,
+        Theme::selected_row().bg
+    );
+
+    let (y, c) = row_containing(&rows, "127.0.0.1:7070").unwrap();
+    assert!(c.contains("1.0KB / 2.0KB"), "{c}");
+    assert_eq!(fg_of(&buf, y as u16, "● error"), Theme::status_warn().fg);
+}
+
+/// At a narrow width this table is over-constrained — its seven columns ask
+/// for 115 cells and cannot all fit — and WHICH columns survive is not
+/// stable between runs (see the note in the PR: cassowary resolves a
+/// degenerate system by an order that Rust's per-process hash seed varies).
+/// So this asserts only what a narrow render is actually guaranteed to
+/// produce: the block, its count, and the flexible TARGET column, which is
+/// the one `Constraint::Min` and therefore always allotted. Anything about
+/// STATUS or the local address at this width would be a coin flip.
+#[test]
+fn port_forward_view_at_a_narrow_width_keeps_its_block_and_flexible_column() {
+    let mut state = PortForwardViewState::new();
+    state.set_forwards(vec![forward("a", "active", 8080, 0, 0)]);
+    let text = common::render_text(60, 20, |f| render_port_forward_view(f, f.area(), &state));
+    assert!(text.contains("Active Port Forwards [1]"), "{text}");
+    assert!(text.contains("TARGET"), "{text}");
+    assert!(text.contains("pod/web-a"), "{text}");
+}
+
+/// The same view given room for every column: here the layout is determinate,
+/// so the status and the local address can be asserted.
+#[test]
+fn port_forward_view_shows_status_and_local_port_once_every_column_fits() {
+    let mut state = PortForwardViewState::new();
+    state.set_forwards(vec![forward("a", "active", 8080, 0, 0)]);
+    let text = common::render_text(130, 20, |f| render_port_forward_view(f, f.area(), &state));
+    assert!(text.contains("● active"), "{text}");
+    assert!(text.contains("127.0.0.1:8080"), "{text}");
+    assert!(text.contains("pod/web-a"), "{text}");
+}
+
+// ---------------------------------------------------------------------------
+// helm_view
+// ---------------------------------------------------------------------------
+
+fn release(name: &str, status: &str, revision: i64) -> HelmReleaseItem {
+    HelmReleaseItem {
+        name: name.to_string(),
+        namespace: "platform".to_string(),
+        revision,
+        status: status.to_string(),
+        chart: format!("{name}-1.2.3"),
+        app_version: "2.0".to_string(),
+        updated: "2026-09-01 10:00".to_string(),
+    }
+}
+
+#[test]
+fn helm_view_set_releases_clamps_the_selection() {
+    let mut state = HelmViewState::new();
+    assert!(state.selected_release().is_none());
+    state.set_releases(vec![
+        release("a", "deployed", 1),
+        release("b", "failed", 2),
+        release("c", "pending-install", 3),
+    ]);
+    state.select_next();
+    state.select_next();
+    state.select_next();
+    assert_eq!(state.selected_release().unwrap().name, "c");
+    state.set_releases(vec![release("a", "deployed", 1)]);
+    assert_eq!(state.selected_idx, 0);
+    state.select_prev();
+    assert_eq!(state.selected_idx, 0);
+    state.set_releases(vec![]);
+    state.select_next();
+    assert_eq!(state.selected_idx, 0);
+}
+
+#[test]
+fn helm_view_renders_the_empty_placeholder() {
+    let state = HelmViewState::new();
+    let text = common::render_text(120, 20, |f| render_helm_view(f, f.area(), &state));
+    assert!(text.contains("Helm 3 Releases [0] (<v> Values <y> Manifest <d> History <ctrl-d> Uninstall <Esc> Back)"), "{text}");
+    assert!(
+        text.contains("No Helm releases found in current namespace."),
+        "{text}"
+    );
+}
+
+#[test]
+fn helm_view_renders_rows_and_colours_status_by_outcome() {
+    let mut state = HelmViewState::new();
+    state.set_releases(vec![
+        release("ingress", "deployed", 4),
+        release("db", "failed", 2),
+        release("cache", "superseded", 7),
+    ]);
+    state.select_next();
+    let buf = render_buffer(140, 20, |f| render_helm_view(f, f.area(), &state));
+    let rows: Vec<String> = (0..buf.area.height).map(|y| buffer_row(&buf, y)).collect();
+    assert!(rows[0].contains("Helm 3 Releases [3]"), "{}", rows[0]);
+    assert!(
+        rows[1].contains("NAMESPACE")
+            && rows[1].contains("REVISION")
+            && rows[1].contains("APP VERSION")
+            && rows[1].contains("UPDATED")
+    );
+
+    let (y, ingress) = row_containing(&rows, "ingress-1.2.3").unwrap();
+    assert!(
+        ingress.contains("platform")
+            && ingress.contains("deployed")
+            && ingress.contains("2026-09-01 10:00"),
+        "{ingress}"
+    );
+    assert_eq!(fg_of(&buf, y as u16, "deployed"), Theme::status_ok().fg);
+
+    let (y, db) = row_containing(&rows, "db-1.2.3").unwrap();
+    assert!(db.contains("failed") && db.contains(" 2 "), "{db}");
+    assert_eq!(fg_of(&buf, y as u16, "failed"), Theme::status_error().fg);
+    assert_eq!(
+        buf.cell(Position::new(2, y as u16)).unwrap().style().bg,
+        Theme::selected_row().bg
+    );
+
+    let (y, cache) = row_containing(&rows, "cache-1.2.3").unwrap();
+    assert!(cache.contains("superseded"), "{cache}");
+    assert_eq!(fg_of(&buf, y as u16, "superseded"), Theme::status_warn().fg);
+}
+
+#[test]
+fn helm_view_narrow_screen_keeps_namespace_and_name() {
+    let mut state = HelmViewState::new();
+    state.set_releases(vec![release("ingress", "deployed", 4)]);
+    let text = common::render_text(60, 20, |f| render_helm_view(f, f.area(), &state));
+    assert!(text.contains("platform"), "{text}");
+    assert!(text.contains("ingress"), "{text}");
+}
+
+// ---------------------------------------------------------------------------
+// reason_rail
+// ---------------------------------------------------------------------------
+
+fn tallies() -> Vec<ReasonTally> {
+    vec![
+        ReasonTally {
+            reason: "BackOff".into(),
+            count: 5,
+            event_type: "Warning".into(),
+        },
+        ReasonTally {
+            reason: "Scheduled".into(),
+            count: 3,
+            event_type: "Normal".into(),
+        },
+        ReasonTally {
+            reason: "Pulled".into(),
+            count: 1,
+            event_type: "Normal".into(),
+        },
+    ]
+}
+
+#[test]
+fn tally_event_reasons_defaults_missing_fields_and_skips_blank_reasons() {
+    let events = vec![
+        json!({ "type": "Warning" }),
+        json!({ "reason": "   " }),
+        json!({ "reason": " Pulled " }),
+        json!({ "reason": "Pulled", "type": "Normal" }),
+        json!({ "reason": "Killing", "type": "Warning" }),
+    ];
+    let t = tally_event_reasons(&events);
+    assert_eq!(t.len(), 3);
+    assert_eq!(t[0].reason, "Pulled");
+    assert_eq!(t[0].count, 2);
+    assert_eq!(
+        t[0].event_type, "Normal",
+        "type comes from the first sighting"
+    );
+    assert_eq!(t[1].reason, "Unknown");
+    assert_eq!(t[1].event_type, "Warning");
+    assert_eq!(t[2].reason, "Killing");
+}
+
+#[test]
+fn reason_rail_widget_shows_the_empty_placeholder_and_the_focus_dependent_title() {
+    let text = common::render_text(40, 8, |f| {
+        render_reason_rail_widget(f, f.area(), &[], 0, false, None)
+    });
+    assert!(text.contains("Event Reasons [Tab/<R> Focus]"), "{text}");
+    assert!(text.contains("No events in scope"), "{text}");
+
+    let text = common::render_text(60, 8, |f| {
+        render_reason_rail_widget(f, f.area(), &[], 0, true, None)
+    });
+    assert!(
+        text.contains("Event Reasons [↑/↓ Navigate, Enter Pick, Esc Back]"),
+        "{text}"
+    );
+}
+
+#[test]
+fn reason_rail_widget_marks_the_cursor_the_active_filter_and_warning_dots() {
+    let t = tallies();
+    let buf = render_buffer(40, 8, |f| {
+        render_reason_rail_widget(f, f.area(), &t, 1, true, Some("Pulled"))
+    });
+    let rows: Vec<String> = (0..buf.area.height).map(|y| buffer_row(&buf, y)).collect();
+    assert!(rows[1].contains("  ● BackOff (5)"), "{}", rows[1]);
+    assert_eq!(fg_of(&buf, 1, "BackOff"), Some(Theme::YELLOW));
+    assert!(rows[2].contains("▸ ○ Scheduled (3)"), "{}", rows[2]);
+    assert_eq!(fg_of(&buf, 2, "Scheduled"), Some(Theme::SEL_FG));
+    assert_eq!(
+        buf.cell(Position::new(1, 2)).unwrap().style().bg,
+        Theme::selected_row().bg
+    );
+    assert!(rows[3].contains("  ○ Pulled (1) ✔"), "{}", rows[3]);
+    assert_eq!(fg_of(&buf, 3, "Pulled"), Some(Theme::CYAN));
+
+    // Unfocused: no cursor is drawn even for the selected index.
+    let text = common::render_text(40, 8, |f| {
+        render_reason_rail_widget(f, f.area(), &t, 1, false, None)
+    });
+    assert!(!text.contains("▸"), "{text}");
+    assert!(text.contains("○ Scheduled (3)"), "{text}");
+}
+
+#[test]
+fn reason_rail_widget_scrolls_to_keep_a_far_selection_visible() {
+    let many: Vec<ReasonTally> = (0..30)
+        .map(|i| ReasonTally {
+            reason: format!("Reason{i:02}"),
+            count: 30 - i,
+            event_type: "Normal".into(),
+        })
+        .collect();
+    // 8 rows -> 6 visible; selection 20 -> offset 17.
+    let lines = common::render_lines(40, 8, |f| {
+        render_reason_rail_widget(f, f.area(), &many, 20, true, None)
+    });
+    assert!(lines.iter().any(|l| l.contains("Reason17")), "{lines:?}");
+    assert!(
+        lines.iter().any(|l| l.contains("▸ ○ Reason20")),
+        "{lines:?}"
+    );
+    assert!(lines.iter().any(|l| l.contains("Reason22")), "{lines:?}");
+    assert!(!lines.iter().any(|l| l.contains("Reason16")), "{lines:?}");
+    assert!(!lines.iter().any(|l| l.contains("Reason23")), "{lines:?}");
+}
+
+#[test]
+fn reason_rail_modal_centres_a_focused_rail_and_shrinks_on_small_screens() {
+    let t = tallies();
+    let lines = common::render_lines(120, 40, |f| {
+        render_reason_rail_modal(f, f.area(), &t, 0, None)
+    });
+    // 60 wide, 20 tall, centred: rows 10..30, columns 30..90.
+    assert!(lines[10].starts_with(&" ".repeat(30)), "{}", lines[10]);
+    assert!(
+        lines[10].contains("Event Reasons [↑/↓ Navigate"),
+        "{}",
+        lines[10]
+    );
+    assert!(lines[11].contains("▸ ● BackOff (5)"), "{}", lines[11]);
+    assert!(lines[29].trim_start().starts_with('└'), "{}", lines[29]);
+    assert!(lines[9].is_empty() && lines[30].is_empty());
+
+    let lines = common::render_lines(30, 10, |f| {
+        render_reason_rail_modal(f, f.area(), &t, 2, Some("Pulled"))
+    });
+    assert!(lines[2].starts_with("  ┌"), "{}", lines[2]);
+    assert!(
+        lines.iter().any(|l| l.contains("▸ ○ Pulled (1) ✔")),
+        "{lines:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// cracked_lens
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cracked_lens_uses_the_compact_message_when_there_is_no_room_for_art() {
+    let text = common::render_text(50, 8, |f| {
+        render_cracked_lens(f, f.area(), "prod", "", "", 30)
+    });
+    assert!(text.contains("Cluster Unreachable"), "{text}");
+    assert!(text.contains("(timed out after 30s)"), "{text}");
+    assert!(text.contains("Context: prod"), "{text}");
+    assert!(
+        text.contains("Press <r> to retry or <Ctrl+x> to switch context"),
+        "{text}"
+    );
+    assert!(!text.contains("Quick Actions"), "{text}");
+
+    // Tall enough but too narrow is also compact: the art and diagnostics
+    // are skipped. (The centred, unwrapped compact lines are wider than 26
+    // columns, so ratatui draws none of them here; only the block title
+    // survives. See the report on cracked_lens.rs.)
+    let text = common::render_text(28, 30, |f| {
+        render_cracked_lens(f, f.area(), "prod", "", "", 5)
+    });
+    assert!(text.contains("Cluster Unreachable"), "{text}");
+    assert!(!text.contains("Quick Actions"), "{text}");
+    assert!(!text.contains(".----"), "{text}");
+}
+
+#[test]
+fn cracked_lens_draws_art_beside_diagnostics_on_a_wide_screen() {
+    let lines = common::render_lines(140, 40, |f| {
+        render_cracked_lens(
+            f,
+            f.area(),
+            "prod-eu",
+            "eu-cluster",
+            "https://10.0.0.1:6443",
+            45,
+        )
+    });
+    let text = lines.join("\n");
+    assert!(
+        text.contains("Context:  prod-eu") || text.contains("prod-eu"),
+        "{text}"
+    );
+    assert!(text.contains("Cluster:  eu-cluster"), "{text}");
+    assert!(text.contains("Server:   https://10.0.0.1:6443"), "{text}");
+    assert!(text.contains("Quick Actions:"), "{text}");
+    assert!(text.contains("Retry connection"), "{text}");
+    assert!(text.contains("Switch context (:ctx)"), "{text}");
+    // Side by side: the art's top rim and the diagnostics share rows.
+    let (art_row, _) = row_containing(&lines, ".--------------------.").unwrap();
+    let (cluster_row, _) = row_containing(&lines, "Cluster:  eu-cluster").unwrap();
+    assert!(
+        (art_row as i32 - cluster_row as i32).abs() < 12,
+        "{art_row} vs {cluster_row}"
+    );
+    let (_, side) = row_containing(&lines, "Cluster:  eu-cluster").unwrap();
+    assert!(
+        side.find("Cluster:").unwrap() > 44,
+        "diagnostics are right of the art: {side}"
+    );
+}
+
+#[test]
+fn cracked_lens_stacks_art_above_diagnostics_on_a_narrow_screen_and_omits_blank_fields() {
+    let lines = common::render_lines(60, 40, |f| {
+        render_cracked_lens(f, f.area(), "dev", "", "", 12)
+    });
+    let text = lines.join("\n");
+    assert!(text.contains("Quick Actions:"), "{text}");
+    assert!(!text.contains("Cluster:"), "{text}");
+    assert!(!text.contains("Server:"), "{text}");
+    let (art_row, _) = row_containing(&lines, ".--------------------.").unwrap();
+    let (qa_row, _) = row_containing(&lines, "Quick Actions:").unwrap();
+    assert!(
+        qa_row > art_row + 10,
+        "diagnostics come after the art: {art_row} < {qa_row}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// metrics_panel_view
+// ---------------------------------------------------------------------------
+
+fn sample(ts_ms: u64, cpu: u64, mem: u64) -> MetricSample {
+    MetricSample {
+        timestamp_epoch_ms: ts_ms,
+        cpu_millicores: cpu,
+        memory_mib: mem,
+    }
+}
+
+#[test]
+fn metrics_panel_state_cycles_ranges_and_replaces_samples() {
+    let mut state =
+        MetricsPanelState::new("Pod".into(), "web-0".into(), Some("default".into()), vec![]);
+    assert_eq!(state.range, MetricsTimeRange::FiveMin);
+    state.cycle_time_range();
+    assert_eq!(state.range, MetricsTimeRange::TenMin);
+    state.cycle_time_range();
+    state.cycle_time_range();
+    assert_eq!(state.range, MetricsTimeRange::OneHour);
+    state.cycle_time_range();
+    assert_eq!(state.range, MetricsTimeRange::FiveMin);
+    assert_eq!(MetricsTimeRange::ThirtyMin.label(), "30m");
+    assert_eq!(MetricsTimeRange::OneHour.window_ms(), 3_600_000);
+
+    state.update_samples(&[sample(1_000, 10, 20)]);
+    assert_eq!(state.samples.len(), 1);
+    assert_eq!(state.samples[0].cpu_millicores, 10);
+}
+
+#[test]
+fn metrics_panel_modal_shows_the_collecting_placeholder_without_samples() {
+    let state = MetricsPanelState::new("Node".into(), "node-1".into(), None, vec![]);
+    let text = common::render_text(120, 40, |f| render_metrics_panel_modal(f, f.area(), &state));
+    assert!(
+        text.contains("Live Metrics Timeline — Node: node-1"),
+        "{text}"
+    );
+    assert!(text.contains("Time Range:"), "{text}");
+    assert!(text.contains("[1: 5m]"), "{text}");
+    assert!(text.contains("(0 samples in buffer)"), "{text}");
+    assert!(text.contains("Collecting metrics-server data..."), "{text}");
+    assert!(!text.contains("CPU Usage:"), "{text}");
+}
+
+#[test]
+fn metrics_panel_modal_summarises_only_the_samples_inside_the_window() {
+    let now = 10_000_000u64;
+    let samples = vec![
+        // 20 minutes old: outside a 5m window, inside a 30m window.
+        sample(now - 20 * 60 * 1000, 900, 900),
+        sample(now - 60 * 1000, 100, 200),
+        sample(now, 300, 400),
+    ];
+    let mut state = MetricsPanelState::new(
+        "Pod".into(),
+        "web-0".into(),
+        Some("default".into()),
+        samples,
+    );
+    let text = common::render_text(120, 40, |f| render_metrics_panel_modal(f, f.area(), &state));
+    assert!(
+        text.contains("Live Metrics Timeline — Pod: default/web-0"),
+        "{text}"
+    );
+    assert!(text.contains("(3 samples in buffer)"), "{text}");
+    assert!(
+        text.contains("CPU Usage: 300m  (min: 100m, avg: 200m, peak: 300m)"),
+        "{text}"
+    );
+    assert!(
+        text.contains("Memory Usage: 400 MiB  (min: 200 MiB, avg: 300 MiB, peak: 400 MiB)"),
+        "{text}"
+    );
+
+    state.cycle_time_range();
+    state.cycle_time_range();
+    assert_eq!(state.range, MetricsTimeRange::ThirtyMin);
+    let text = common::render_text(120, 40, |f| render_metrics_panel_modal(f, f.area(), &state));
+    assert!(
+        text.contains("CPU Usage: 300m  (min: 100m, avg: 433m, peak: 900m)"),
+        "{text}"
+    );
+    assert!(text.contains("[3: 30m]"), "{text}");
+}
+
+// ---------------------------------------------------------------------------
+// resource_table: columns, segments, state mutators
+// ---------------------------------------------------------------------------
+
+fn names(kind: &ResourceKind) -> Vec<&'static str> {
+    default_columns_for_kind(kind)
+        .iter()
+        .map(|c| c.name)
+        .collect()
+}
+
+#[test]
+fn default_columns_match_each_resource_kind() {
+    assert_eq!(
+        names(&ResourceKind::Workloads),
+        [
+            "NAMESPACE",
+            "KIND",
+            "NAME",
+            "READY",
+            "STATUS",
+            "RESTARTS",
+            "CPU",
+            "MEM",
+            "AGE",
+            "IMAGE"
+        ]
+    );
+    assert_eq!(
+        names(&ResourceKind::Pods),
+        [
+            "NAMESPACE",
+            "NAME",
+            "READY",
+            "STATUS",
+            "RESTARTS",
+            "CPU",
+            "MEM",
+            "IP",
+            "NODE",
+            "AGE"
+        ]
+    );
+    assert_eq!(
+        names(&ResourceKind::Deployments),
+        [
+            "NAMESPACE",
+            "NAME",
+            "READY",
+            "UP-TO-DATE",
+            "AVAILABLE",
+            "AGE"
+        ]
+    );
+    assert_eq!(
+        names(&ResourceKind::StatefulSets),
+        ["NAMESPACE", "NAME", "READY", "AGE"]
+    );
+    assert_eq!(
+        names(&ResourceKind::DaemonSets),
+        [
+            "NAMESPACE",
+            "NAME",
+            "DESIRED",
+            "CURRENT",
+            "READY",
+            "UP-TO-DATE",
+            "AVAILABLE",
+            "AGE"
+        ]
+    );
+    assert_eq!(
+        names(&ResourceKind::Jobs),
+        ["NAMESPACE", "NAME", "COMPLETIONS", "DURATION", "AGE"]
+    );
+    assert_eq!(
+        names(&ResourceKind::CronJobs),
+        [
+            "NAMESPACE",
+            "NAME",
+            "SCHEDULE",
+            "SUSPEND",
+            "ACTIVE",
+            "LAST SCHEDULE",
+            "AGE"
+        ]
+    );
+    assert_eq!(
+        names(&ResourceKind::Services),
+        [
+            "NAMESPACE",
+            "NAME",
+            "TYPE",
+            "CLUSTER-IP",
+            "EXTERNAL-IP",
+            "PORTS",
+            "AGE"
+        ]
+    );
+    assert_eq!(
+        names(&ResourceKind::Ingresses),
+        [
+            "NAMESPACE",
+            "NAME",
+            "CLASS",
+            "HOSTS",
+            "ADDRESS",
+            "PORTS",
+            "AGE"
+        ]
+    );
+    assert_eq!(
+        names(&ResourceKind::EndpointSlices),
+        [
+            "NAMESPACE",
+            "NAME",
+            "ADDRESS-TYPE",
+            "PORTS",
+            "ENDPOINTS",
+            "AGE"
+        ]
+    );
+    assert_eq!(
+        names(&ResourceKind::ConfigMaps),
+        ["NAMESPACE", "NAME", "DATA", "AGE"]
+    );
+    assert_eq!(
+        names(&ResourceKind::Secrets),
+        ["NAMESPACE", "NAME", "TYPE", "DATA", "AGE"]
+    );
+    assert_eq!(
+        names(&ResourceKind::PersistentVolumeClaims),
+        [
+            "NAMESPACE",
+            "NAME",
+            "STATUS",
+            "VOLUME",
+            "CAPACITY",
+            "ACCESS MODES",
+            "STORAGECLASS",
+            "AGE"
+        ]
+    );
+    assert_eq!(
+        names(&ResourceKind::PersistentVolumes),
+        [
+            "NAME",
+            "CAPACITY",
+            "ACCESS MODES",
+            "RECLAIM POLICY",
+            "STATUS",
+            "CLAIM",
+            "STORAGECLASS",
+            "AGE"
+        ]
+    );
+    assert_eq!(
+        names(&ResourceKind::StorageClasses),
+        [
+            "NAME",
+            "PROVISIONER",
+            "RECLAIMPOLICY",
+            "VOLUMEBINDINGMODE",
+            "ALLOWEXPANSION",
+            "AGE"
+        ]
+    );
+    assert_eq!(
+        names(&ResourceKind::Nodes),
+        ["NAME", "STATUS", "ROLES", "VERSION", "CPU", "MEMORY", "PODS", "AGE"]
+    );
+    assert_eq!(names(&ResourceKind::Namespaces), ["NAME", "STATUS", "AGE"]);
+    assert_eq!(
+        names(&ResourceKind::Events),
+        [
+            "NAMESPACE",
+            "LAST SEEN",
+            "TYPE",
+            "REASON",
+            "OBJECT",
+            "MESSAGE"
+        ]
+    );
+    assert_eq!(
+        names(&ResourceKind::CustomResourceDefinitions),
+        ["NAME", "GROUP", "VERSION", "SCOPE", "AGE"]
+    );
+    // Kinds without a bespoke layout share the generic three-column one.
+    assert_eq!(
+        names(&ResourceKind::ServiceAccounts),
+        ["NAMESPACE", "NAME", "AGE"]
+    );
+    assert_eq!(
+        names(&ResourceKind::ResourceQuotas),
+        ["NAMESPACE", "NAME", "AGE"]
+    );
+}
+
+fn crd(namespaced: bool, columns: &[(&str, &str, i32)]) -> ResourceKind {
+    ResourceKind::CustomResource(CrdMeta {
+        crd_name: "widgets.example.io".into(),
+        group: "example.io".into(),
+        version: "v1".into(),
+        kind: "Widget".into(),
+        plural: "widgets".into(),
+        singular: "widget".into(),
+        namespaced,
+        short_names: vec![],
+        printer_columns: columns
+            .iter()
+            .map(|(name, path, priority)| PrinterColumn {
+                name: name.to_string(),
+                json_path: path.to_string(),
+                col_type: "string".into(),
+                priority: *priority,
+                description: None,
+            })
+            .collect(),
+    })
+}
+
+#[test]
+fn custom_resource_columns_follow_the_crd_printer_columns() {
+    // No printer columns: NAMESPACE (namespaced), NAME, AGE.
+    assert_eq!(names(&crd(true, &[])), ["NAMESPACE", "NAME", "AGE"]);
+    assert_eq!(names(&crd(false, &[])), ["NAME", "AGE"]);
+
+    // Printer columns: priority > 0 is skipped, AGE is appended only when the
+    // CRD does not declare one, and every known heading gets its width.
+    let kind = crd(
+        false,
+        &[
+            ("Ready", ".status.ready", 0),
+            ("Status", ".status.phase", 0),
+            ("StoreType", ".spec.store.type", 0),
+            ("Store", ".spec.store.name", 0),
+            ("Refresh Interval", ".spec.refresh", 0),
+            ("Last Sync", ".status.lastSync", 0),
+            ("Hidden", ".spec.hidden", 1),
+            ("Custom", ".spec.custom", 0),
+        ],
+    );
+    assert_eq!(
+        names(&kind),
+        [
+            "NAME",
+            "READY",
+            "STATUS",
+            "STORETYPE",
+            "STORE",
+            "REFRESH INTERVAL",
+            "LAST SYNC",
+            "CUSTOM",
+            "AGE"
+        ]
+    );
+    let cols = default_columns_for_kind(&kind);
+    assert_eq!(cols[1].key, "printer:.status.ready");
+    assert_eq!(cols[1].width, ratatui::layout::Constraint::Length(8));
+    assert_eq!(cols[4].width, ratatui::layout::Constraint::Min(22));
+    assert_eq!(cols[7].width, ratatui::layout::Constraint::Length(16));
+
+    let with_age = crd(true, &[("Age", ".metadata.creationTimestamp", 0)]);
+    assert_eq!(names(&with_age), ["NAMESPACE", "NAME", "AGE"]);
+    assert_eq!(
+        default_columns_for_kind(&with_age)[2].key,
+        "printer:.metadata.creationTimestamp"
+    );
+}
+
+#[test]
+fn workload_segments_cycle_in_order_and_name_themselves() {
+    let all = WorkloadSegment::all();
+    assert_eq!(all.len(), 6);
+    assert_eq!(all[0], WorkloadSegment::All);
+    let mut seg = WorkloadSegment::default();
+    let mut seen = Vec::new();
+    for _ in 0..6 {
+        seen.push(seg.display_name());
+        seg = seg.next();
+    }
+    assert_eq!(
+        seen,
+        [
+            "All",
+            "Deployment",
+            "StatefulSet",
+            "DaemonSet",
+            "Pod",
+            "CronJob"
+        ]
+    );
+    assert_eq!(seg, WorkloadSegment::All, "cycles back to All");
+}
+
+fn pods(n: usize) -> Vec<Value> {
+    (0..n)
+        .map(|i| json!({ "name": format!("pod-{i:02}"), "namespace": if i % 2 == 0 { "a" } else { "b" }, "kind": "Pod", "status": "Running" }))
+        .collect()
+}
+
+#[test]
+fn table_selection_jumps_and_pages_within_the_filtered_rows() {
+    let mut t = ResourceTableState::new(ResourceKind::Pods);
+    assert!(t.is_loading);
+    // Empty table: everything is a no-op.
+    t.select_bottom();
+    t.page_down(5);
+    t.page_up(5);
+    t.select_next();
+    assert_eq!(t.selected_idx, 0);
+    assert!(t.selected_item().is_none());
+
+    t.set_items(pods(10), "");
+    assert!(!t.is_loading);
+    t.select_bottom();
+    assert_eq!(t.selected_idx, 9);
+    t.select_top();
+    assert_eq!(t.selected_idx, 0);
+    t.page_down(4);
+    assert_eq!(t.selected_idx, 4);
+    t.page_down(100);
+    assert_eq!(t.selected_idx, 9);
+    t.page_up(3);
+    assert_eq!(t.selected_idx, 6);
+    t.page_up(100);
+    assert_eq!(t.selected_idx, 0);
+    t.select_prev();
+    assert_eq!(t.selected_idx, 0);
+    assert_eq!(t.selected_resource_name().as_deref(), Some("pod-00"));
+    assert_eq!(t.selected_namespace().as_deref(), Some("a"));
+    assert_eq!(t.selected_resource_kind().as_deref(), Some("Pod"));
+}
+
+#[test]
+fn table_marks_toggle_per_raw_item_and_survive_refiltering() {
+    let mut t = ResourceTableState::new(ResourceKind::Pods);
+    t.set_items(pods(4), "");
+    t.select_next();
+    t.toggle_mark_selected();
+    assert!(t.marked_indices.contains(&1));
+    t.toggle_mark_selected();
+    assert!(!t.marked_indices.contains(&1));
+    t.toggle_mark_selected();
+    // Filter down to namespace b: pod-01 and pod-03.
+    t.apply_filter("^b$");
+    assert_eq!(t.filtered_indices, vec![1, 3]);
+    assert!(t.marked_indices.contains(&1));
+    // Marking on an empty filter result is a no-op.
+    t.apply_filter("nothing-matches");
+    assert!(t.filtered_indices.is_empty());
+    t.toggle_mark_selected();
+    assert_eq!(t.marked_indices.len(), 1);
+}
+
+#[test]
+fn table_filter_falls_back_to_substring_when_the_regex_is_invalid() {
+    let mut t = ResourceTableState::new(ResourceKind::Pods);
+    t.set_items(
+        vec![
+            json!({ "name": "svc(1)", "namespace": "x" }),
+            json!({ "name": "other", "namespace": "y" }),
+        ],
+        "",
+    );
+    t.apply_filter("svc(");
+    assert_eq!(t.filtered_indices, vec![0]);
+    // Namespace is searched too, and the selection is clamped when it falls
+    // outside the new result set.
+    t.apply_filter("");
+    t.select_bottom();
+    t.apply_filter("^x$");
+    assert_eq!(t.filtered_indices, vec![0]);
+    assert_eq!(t.selected_idx, 0);
+    // Metadata-shaped items are searched by metadata.name/namespace.
+    t.set_items(
+        vec![json!({ "metadata": { "name": "meta-pod", "namespace": "kube-system" } })],
+        "meta",
+    );
+    assert_eq!(t.filtered_indices, vec![0]);
+    t.apply_filter("KUBE-SYS");
+    assert_eq!(t.filtered_indices, vec![0]);
+}
+
+fn events() -> Vec<Value> {
+    vec![
+        json!({ "namespace": "a", "type": "Normal", "reason": "Scheduled", "object": "Pod/web-0", "message": "ok" }),
+        json!({ "namespace": "a", "type": "Warning", "reason": "BackOff", "object": "Pod/web-1", "message": "Back-off restarting" }),
+        json!({ "namespace": "b", "type": "Normal", "reason": "Pulled", "involvedObject": { "kind": "Pod", "name": "web-2" }, "message": "image pulled" }),
+        json!({ "namespace": "b", "type": "Normal", "reason": "BackOff", "object": "Pod/web-3", "message": "again" }),
+    ]
+}
+
+#[test]
+fn table_event_triage_and_reason_filters_narrow_the_rows() {
+    let mut t = ResourceTableState::new(ResourceKind::Events);
+    t.set_items(events(), "");
+    assert_eq!(t.filtered_indices.len(), 4);
+
+    assert!(t.toggle_warning_triage(""));
+    assert_eq!(
+        t.filtered_indices,
+        vec![1, 3],
+        "warning type or critical reason"
+    );
+    assert!(!t.toggle_warning_triage(""));
+    assert_eq!(t.filtered_indices.len(), 4);
+
+    t.select_bottom();
+    t.set_reason_filter(Some("backoff".into()), "");
+    assert_eq!(
+        t.filtered_indices,
+        vec![1, 3],
+        "reason match is case-insensitive"
+    );
+    assert_eq!(t.selected_idx, 0);
+    t.set_reason_filter(None, "");
+    assert_eq!(t.filtered_indices.len(), 4);
+
+    assert!(!t.reason_rail_focused);
+    t.toggle_reason_rail_focus();
+    assert!(t.reason_rail_focused);
+    t.select_next_reason(2);
+    t.select_next_reason(2);
+    assert_eq!(t.selected_reason_idx, 1);
+    t.select_next_reason(0);
+    assert_eq!(t.selected_reason_idx, 1);
+    t.select_prev_reason();
+    t.select_prev_reason();
+    assert_eq!(t.selected_reason_idx, 0);
+}
+
+#[test]
+fn table_reason_and_triage_filters_only_apply_to_events() {
+    let mut t = ResourceTableState::new(ResourceKind::Pods);
+    t.set_items(pods(3), "");
+    t.toggle_warning_triage("");
+    t.set_reason_filter(Some("BackOff".into()), "");
+    assert_eq!(t.filtered_indices.len(), 3);
+}
+
+#[test]
+fn table_workload_segment_filters_by_kind() {
+    let mut t = ResourceTableState::new(ResourceKind::Workloads);
+    t.set_items(
+        vec![
+            json!({ "name": "d", "kind": "Deployment", "namespace": "x" }),
+            json!({ "name": "s", "kind": "StatefulSet", "namespace": "x" }),
+            json!({ "name": "p", "kind": "Pod", "namespace": "x" }),
+        ],
+        "",
+    );
+    t.workload_segment = WorkloadSegment::StatefulSet;
+    t.apply_filter("");
+    assert_eq!(t.filtered_indices, vec![1]);
+    t.workload_segment = WorkloadSegment::CronJob;
+    t.apply_filter("");
+    assert!(t.filtered_indices.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// resource_table: field extraction
+// ---------------------------------------------------------------------------
+
+#[test]
+fn extract_field_str_handles_bools_arrays_and_nested_containers() {
+    let item = json!({
+        "suspend": true,
+        "hosts": ["a.example", "b.example"],
+        "emptyArr": [1, 2],
+        "spec": { "schedule": "*/5 * * * *", "StorageClass": "fast" },
+        "status": { "Phase": "Bound" },
+        "metadata": { "uid": "abc" },
+        "count": 7,
+    });
+    assert_eq!(extract_field_str(&item, "suspend"), "true");
+    assert_eq!(extract_field_str(&item, "hosts"), "a.example, b.example");
+    assert_eq!(
+        extract_field_str(&item, "emptyArr"),
+        "-",
+        "non-string arrays are not rendered"
+    );
+    assert_eq!(extract_field_str(&item, "count"), "7");
+    assert_eq!(extract_field_str(&item, "schedule"), "*/5 * * * *");
+    assert_eq!(
+        extract_field_str(&item, "storageClass"),
+        "fast",
+        "case-insensitive inside spec"
+    );
+    assert_eq!(extract_field_str(&item, "phase"), "Bound");
+    assert_eq!(extract_field_str(&item, "uid"), "abc");
+    assert_eq!(extract_field_str(&item, "missing"), "-");
+    assert_eq!(
+        extract_field_str(&item, "SUSPEND"),
+        "true",
+        "case-insensitive top level"
+    );
+}
+
+#[test]
+fn extract_field_str_resolves_service_addresses_from_spec_and_status() {
+    let lb = json!({
+        "spec": { "type": "LoadBalancer", "clusterIP": "10.0.0.1" },
+        "status": { "loadBalancer": { "ingress": [{ "ip": "1.2.3.4" }, { "hostname": "lb.example" }] } },
+    });
+    assert_eq!(extract_field_str(&lb, "clusterIP"), "10.0.0.1");
+    assert_eq!(extract_field_str(&lb, "externalIP"), "1.2.3.4, lb.example");
+
+    let ext = json!({ "spec": { "type": "ClusterIP", "externalIPs": ["9.9.9.9"] } });
+    assert_eq!(extract_field_str(&ext, "externalIP"), "9.9.9.9");
+
+    let pending = json!({ "type": "LoadBalancer" });
+    assert_eq!(extract_field_str(&pending, "externalIP"), "<pending>");
+    let none = json!({ "type": "NodePort" });
+    assert_eq!(extract_field_str(&none, "externalIP"), "<none>");
+    let untyped = json!({ "name": "x" });
+    assert_eq!(extract_field_str(&untyped, "externalIP"), "-");
+}
+
+#[test]
+fn extract_field_str_resolves_pod_fields_from_raw_manifests() {
+    let raw = json!({
+        "kind": "Pod",
+        "spec": {
+            "nodeName": "node-7",
+            "containers": [{ "image": "nginx:1.27", "resources": { "requests": { "cpu": "250m", "memory": "128Mi" } } }],
+        },
+        "status": { "phase": "Pending", "podIP": "10.1.1.1" },
+    });
+    assert_eq!(extract_field_str(&raw, "status"), "Pending");
+    assert_eq!(extract_field_str(&raw, "nodeName"), "node-7");
+    assert_eq!(extract_field_str(&raw, "podIp"), "10.1.1.1");
+    assert_eq!(extract_field_str(&raw, "cpu"), "250m");
+    assert_eq!(extract_field_str(&raw, "memory"), "128Mi");
+    assert_eq!(
+        extract_field_str(&raw, "restarts"),
+        "—",
+        "a typed item with no restarts shows an em dash"
+    );
+    assert_eq!(extract_field_str(&raw, "ready"), "—");
+    assert_eq!(
+        extract_field_str(&raw, "image"),
+        "—",
+        "pod images live at spec.containers, not the template path"
+    );
+
+    let summary = json!({ "kind": "Pod", "node": "n1", "podIP": "10.2.2.2", "cpuUsage": "5m", "memUsage": "9Mi", "restarts": 3, "ready": "1/1", "image": "busybox" });
+    assert_eq!(extract_field_str(&summary, "node"), "n1");
+    assert_eq!(extract_field_str(&summary, "ip"), "10.2.2.2");
+    assert_eq!(extract_field_str(&summary, "cpu"), "5m");
+    assert_eq!(extract_field_str(&summary, "mem"), "9Mi");
+    assert_eq!(extract_field_str(&summary, "restarts"), "3");
+    assert_eq!(extract_field_str(&summary, "ready"), "1/1");
+    assert_eq!(extract_field_str(&summary, "image"), "busybox");
+
+    let deploy = json!({ "kind": "Deployment", "spec": { "template": { "spec": { "containers": [{ "image": "api:2" }] } } } });
+    assert_eq!(extract_field_str(&deploy, "image"), "api:2");
+    assert_eq!(extract_field_str(&deploy, "cpu"), "—");
+    assert_eq!(extract_field_str(&deploy, "memory"), "—");
+
+    let untyped = json!({ "name": "x" });
+    for key in [
+        "restarts", "cpu", "memory", "image", "ready", "status", "nodeName", "podIp",
+    ] {
+        assert_eq!(extract_field_str(&untyped, key), "-", "{key}");
+    }
+}
+
+#[test]
+fn extract_field_str_formats_event_objects_and_type_aliases() {
+    let with_obj = json!({ "object": "Pod/web-0", "type_": "Warning" });
+    assert_eq!(extract_field_str(&with_obj, "involvedObject"), "Pod/web-0");
+    assert_eq!(extract_field_str(&with_obj, "type"), "Warning");
+    assert_eq!(extract_field_str(&with_obj, "type_"), "Warning");
+
+    let inv = json!({ "involvedObject": { "kind": "Node", "name": "n1" } });
+    assert_eq!(extract_field_str(&inv, "object"), "Node/n1");
+    let empty_inv = json!({ "involvedObject": {} });
+    assert_eq!(extract_field_str(&empty_inv, "object"), "-");
+}
+
+#[test]
+fn is_event_warning_or_failure_checks_type_reason_and_message() {
+    assert!(is_event_warning_or_failure(&json!({ "type_": "warning" })));
+    assert!(is_event_warning_or_failure(
+        &json!({ "type": "Normal", "reason": "BackOff" })
+    ));
+    assert!(is_event_warning_or_failure(
+        &json!({ "type": "Normal", "reason": "Pulled", "message": "container was OOMKilled" })
+    ));
+    assert!(is_event_warning_or_failure(&json!({ "reason": "Killing" })));
+    assert!(!is_event_warning_or_failure(
+        &json!({ "type": "Normal", "reason": "Scheduled", "message": "all good" })
+    ));
+    assert!(!is_event_warning_or_failure(&json!({})));
+}
+
+#[test]
+fn eval_crd_json_path_walks_fields_indexes_and_filters() {
+    let obj = json!({
+        "status": {
+            "phase": "Ready",
+            "ready": true,
+            "count": 3,
+            "conditions": [
+                { "type": "Ready", "status": "True" },
+                { "type": "Synced", "status": "False" },
+            ],
+            "tags": ["a", "", "b"],
+            "nested": { "x": 1 },
+            "nothing": null,
+            "empty": "",
+            "created": "2020-01-01T00:00:00Z",
+        },
+        "spec": { "items": [{ "name": "first" }, { "name": "second" }], "odd.key": "v" },
+    });
+    assert_eq!(eval_crd_json_path(&obj, ""), "-");
+    assert_eq!(eval_crd_json_path(&obj, ".status.phase"), "Ready");
+    assert_eq!(eval_crd_json_path(&obj, "status.ready"), "True");
+    assert_eq!(eval_crd_json_path(&obj, ".status.count"), "3");
+    assert_eq!(eval_crd_json_path(&obj, ".spec.items[1].name"), "second");
+    assert_eq!(eval_crd_json_path(&obj, ".spec.items[5].name"), "-");
+    assert_eq!(eval_crd_json_path(&obj, ".spec[\"odd.key\"]"), "v");
+    assert_eq!(
+        eval_crd_json_path(&obj, ".status.conditions[?(@.type==\"Ready\")].status"),
+        "True"
+    );
+    assert_eq!(
+        eval_crd_json_path(&obj, ".status.conditions[?(@.type=='Synced')].status"),
+        "False"
+    );
+    assert_eq!(
+        eval_crd_json_path(&obj, ".status.conditions.[?(@.type==\"Ready\")].status"),
+        "True",
+        "filter with no leading field"
+    );
+    assert_eq!(
+        eval_crd_json_path(&obj, ".status.conditions[?(@.type==\"Missing\")].status"),
+        "-"
+    );
+    assert_eq!(
+        eval_crd_json_path(&obj, ".status.phase[?(@.type==\"Ready\")]"),
+        "-",
+        "filter on a non-array"
+    );
+    assert_eq!(eval_crd_json_path(&obj, ".status.tags"), "a, b");
+    assert_eq!(eval_crd_json_path(&obj, ".status.nested"), "-");
+    assert_eq!(eval_crd_json_path(&obj, ".status.nothing"), "-");
+    assert_eq!(eval_crd_json_path(&obj, ".status.empty"), "-");
+    assert_eq!(eval_crd_json_path(&obj, ".status.missing.deeper"), "-");
+    assert_eq!(
+        eval_crd_json_path(&obj, ".status.ready[0]"),
+        "-",
+        "index into a non-array"
+    );
+    let age = eval_crd_json_path(&obj, ".status.created");
+    assert_ne!(
+        age, "2020-01-01T00:00:00Z",
+        "RFC3339 timestamps become an age"
+    );
+    assert_ne!(age, "-");
+    // A printer key routes through the same evaluator.
+    assert_eq!(extract_field_str(&obj, "printer:.status.phase"), "Ready");
+}
+
+// ---------------------------------------------------------------------------
+// resource_table: rendering
+// ---------------------------------------------------------------------------
+
+#[test]
+fn table_renders_loading_and_empty_states() {
+    let mut t = ResourceTableState::new(ResourceKind::Pods);
+    let text = common::render_text(120, 40, |f| render_resource_table(f, f.area(), &t));
+    assert!(text.contains(" Pods [Loading...] "), "{text}");
+    assert!(text.contains("Loading Pods from cluster API..."), "{text}");
+    assert_eq!(t.last_area_width.get(), 120);
+
+    t.set_items(vec![], "");
+    let text = common::render_text(60, 20, |f| render_resource_table(f, f.area(), &t));
+    assert!(text.contains(" Pods [0] "), "{text}");
+    assert!(text.contains("No Pods found in this scope."), "{text}");
+    assert_eq!(t.last_area_width.get(), 60);
+}
+
+#[test]
+fn table_renders_headers_rows_marks_and_the_filtered_count_badge() {
+    let mut t = ResourceTableState::new(ResourceKind::Pods);
+    t.set_items(
+        vec![
+            json!({ "name": "web-0", "namespace": "prod", "ready": "1/1", "status": "Running", "restarts": 0, "podIp": "10.0.0.1", "nodeName": "n1", "age": "2d" }),
+            json!({ "name": "web-1", "namespace": "prod", "ready": "0/1", "status": "CrashLoopBackOff", "restarts": 12, "age": "1h" }),
+            json!({ "name": "job-x", "namespace": "batch", "status": "Pending" }),
+        ],
+        "",
+    );
+    t.select_next();
+    t.toggle_mark_selected();
+    t.apply_filter("web");
+    let buf = render_buffer(160, 40, |f| render_resource_table(f, f.area(), &t));
+    let rows: Vec<String> = (0..buf.area.height).map(|y| buffer_row(&buf, y)).collect();
+    assert!(rows[0].contains(" Pods [2/3] "), "{}", rows[0]);
+    for h in [
+        "NAMESPACE",
+        "NAME",
+        "READY",
+        "STATUS",
+        "RESTARTS",
+        "CPU",
+        "MEM",
+        "IP",
+        "NODE",
+        "AGE",
+    ] {
+        assert!(rows[1].contains(h), "header {h} in {}", rows[1]);
+    }
+    let (y0, r0) = row_containing(&rows, "web-0").unwrap();
+    assert!(
+        r0.contains("prod")
+            && r0.contains("1/1")
+            && r0.contains("Running")
+            && r0.contains("10.0.0.1")
+            && r0.contains("n1")
+            && r0.contains("2d"),
+        "{r0}"
+    );
+    assert_eq!(fg_of(&buf, y0 as u16, "Running"), Theme::status_ok().fg);
+    let (y1, r1) = row_containing(&rows, "✔ web-1").unwrap();
+    // STATUS is a fixed 14-column cell, so the 16-char phase is clipped.
+    assert!(
+        r1.contains("CrashLoopBackO") && r1.contains("12") && r1.contains("0/1"),
+        "{r1}"
+    );
+    assert_eq!(
+        fg_of(&buf, y1 as u16, "CrashLoop"),
+        Theme::status_error().fg
+    );
+    // The marked row is also the selected one, so it takes the selection bg.
+    assert_eq!(
+        buf.cell(Position::new(2, y1 as u16)).unwrap().style().bg,
+        Theme::selected_row().bg
+    );
+    assert!(!rows.iter().any(|l| l.contains("job-x")));
+    assert_eq!(t.last_start_idx.get(), 0);
+    assert_eq!(t.last_viewport_rect.get().width, 158);
+}
+
+#[test]
+fn table_marked_but_unselected_row_uses_the_marked_background() {
+    let mut t = ResourceTableState::new(ResourceKind::Namespaces);
+    t.set_items(
+        vec![
+            json!({ "name": "default", "status": "Active" }),
+            json!({ "name": "kube-system", "status": "Terminating" }),
+        ],
+        "",
+    );
+    t.toggle_mark_selected();
+    t.select_next();
+    let buf = render_buffer(80, 10, |f| render_resource_table(f, f.area(), &t));
+    let rows: Vec<String> = (0..buf.area.height).map(|y| buffer_row(&buf, y)).collect();
+    let (y0, r0) = row_containing(&rows, "✔ default").unwrap();
+    assert!(r0.contains("Active"), "{r0}");
+    assert_eq!(
+        buf.cell(Position::new(2, y0 as u16)).unwrap().style().bg,
+        Theme::marked_row().bg
+    );
+    let (y1, _) = row_containing(&rows, "kube-system").unwrap();
+    assert_eq!(
+        buf.cell(Position::new(2, y1 as u16)).unwrap().style().bg,
+        Theme::selected_row().bg
+    );
+    assert_eq!(
+        fg_of(&buf, y1 as u16, "Terminating"),
+        Theme::status_warn().fg
+    );
+}
+
+#[test]
+fn table_scrolls_to_keep_a_far_selection_in_a_short_viewport() {
+    let mut t = ResourceTableState::new(ResourceKind::Pods);
+    t.set_items(pods(40), "");
+    t.select_bottom();
+    // 12 rows: inner 10, minus header+margin -> 8 visible; start = 39 - 4 = 35.
+    let lines = common::render_lines(120, 12, |f| render_resource_table(f, f.area(), &t));
+    assert!(lines.iter().any(|l| l.contains("pod-39")), "{lines:?}");
+    assert!(lines.iter().any(|l| l.contains("pod-35")), "{lines:?}");
+    assert!(!lines.iter().any(|l| l.contains("pod-34")), "{lines:?}");
+    assert_eq!(t.last_start_idx.get(), 35);
+    // Alternating stripes: the even display row gets the stripe background.
+    let buf = render_buffer(120, 12, |f| render_resource_table(f, f.area(), &t));
+    let rows: Vec<String> = (0..buf.area.height).map(|y| buffer_row(&buf, y)).collect();
+    let (y36, _) = row_containing(&rows, "pod-36").unwrap();
+    let (y37, _) = row_containing(&rows, "pod-37").unwrap();
+    assert_eq!(
+        buf.cell(Position::new(2, y36 as u16)).unwrap().style().bg,
+        Some(Color::Rgb(22, 24, 30))
+    );
+    assert_ne!(
+        buf.cell(Position::new(2, y37 as u16)).unwrap().style().bg,
+        Some(Color::Rgb(22, 24, 30))
+    );
+}
+
+#[test]
+fn events_table_shows_the_reason_rail_only_when_wide_enough() {
+    let mut t = ResourceTableState::new(ResourceKind::Events);
+    t.set_items(events(), "");
+    // Exactly at the 110-column threshold the rail appears (32 columns wide,
+    // so its title is clipped) and the table columns are squeezed.
+    let wide = common::render_lines(110, 30, |f| render_resource_table(f, f.area(), &t));
+    let text = wide.join("\n");
+    assert!(text.contains("Event Reasons [Tab/<R>"), "{text}");
+    assert!(text.contains("● BackOff (2)"), "{text}");
+    assert!(text.contains("○ Scheduled (1)"), "{text}");
+    assert!(text.contains("○ Pulled (1)"), "{text}");
+    assert!(
+        wide[1].contains("TYPE")
+            && wide[1].contains("REASON")
+            && wide[1].contains("OBJECT")
+            && wide[1].contains("MESSAGE"),
+        "{}",
+        wide[1]
+    );
+
+    let roomy = common::render_lines(180, 30, |f| render_resource_table(f, f.area(), &t));
+    assert!(
+        roomy[1].contains("NAMESPACE") && roomy[1].contains("LAST SEEN"),
+        "{}",
+        roomy[1]
+    );
+    let text = roomy.join("\n");
+    assert!(
+        text.contains("Pod/web-2"),
+        "involvedObject is formatted: {text}"
+    );
+    assert!(
+        text.contains("Pod/web-0"),
+        "object string is used verbatim: {text}"
+    );
+
+    let narrow = common::render_text(109, 30, |f| render_resource_table(f, f.area(), &t));
+    assert!(!narrow.contains("Event Reasons"), "{narrow}");
+    assert!(narrow.contains(" Events [4] "), "{narrow}");
+}
+
+#[test]
+fn events_table_title_carries_triage_and_reason_badges_and_colours_the_type() {
+    let mut t = ResourceTableState::new(ResourceKind::Events);
+    t.set_items(events(), "");
+    t.toggle_warning_triage("");
+    t.set_reason_filter(Some("BackOff".into()), "");
+    let buf = render_buffer(160, 30, |f| render_resource_table(f, f.area(), &t));
+    let rows: Vec<String> = (0..buf.area.height).map(|y| buffer_row(&buf, y)).collect();
+    // Both BackOff events survive triage (the reason itself is critical).
+    assert!(
+        rows[0].contains(" Events [2/4] [TRIAGE: ON] [Reason: BackOff] "),
+        "{}",
+        rows[0]
+    );
+    assert_eq!(
+        fg_of(&buf, 0, "Events ["),
+        Some(Color::Yellow),
+        "triage title is yellow"
+    );
+    assert_eq!(
+        buf.cell(Position::new(0, 0)).unwrap().style().fg,
+        Some(Color::Yellow),
+        "triage border is yellow"
+    );
+    let (y, row) = row_containing(&rows, "Back-off restarting").unwrap();
+    assert!(row.contains("Warning") && row.contains("BackOff"), "{row}");
+    assert_eq!(fg_of(&buf, y as u16, "Warning"), Theme::status_warn().fg);
+    assert_eq!(fg_of(&buf, y as u16, "BackOff"), Theme::status_error().fg);
+    // The rail shows the active filter tick and the focused title when focused.
+    assert!(rows.iter().any(|l| l.contains("BackOff (2) ✔")), "{rows:?}");
+    t.toggle_reason_rail_focus();
+    let buf = render_buffer(160, 30, |f| render_resource_table(f, f.area(), &t));
+    assert_eq!(
+        buf.cell(Position::new(0, 0)).unwrap().style().fg,
+        Some(Theme::BORDER),
+        "border returns to normal while the rail is focused"
+    );
+    // The 32-column rail clips its title, but the focused variant starts
+    // with the navigation hint where the unfocused one says "Tab/<R>".
+    assert!(
+        buffer_row(&buf, 0).contains("Event Reasons [↑/↓"),
+        "{}",
+        buffer_row(&buf, 0)
+    );
+    assert!(
+        !buffer_row(&buf, 0).contains("Tab/<R>"),
+        "{}",
+        buffer_row(&buf, 0)
+    );
+}
+
+#[test]
+fn workloads_table_title_shows_the_segment_and_kind_column() {
+    let mut t = ResourceTableState::new(ResourceKind::Workloads);
+    t.set_items(
+        vec![
+            json!({ "name": "api", "kind": "Deployment", "namespace": "prod", "ready": "2/2", "status": "Available", "image": "api:1" }),
+            json!({ "name": "api-0", "kind": "Pod", "namespace": "prod", "ready": "1/1", "status": "Running" }),
+        ],
+        "",
+    );
+    let text = common::render_text(160, 20, |f| render_resource_table(f, f.area(), &t));
+    assert!(
+        text.contains(" Workloads [Segment: All (Tab to cycle)] [2] "),
+        "{text}"
+    );
+    assert!(text.contains("KIND") && text.contains("IMAGE"), "{text}");
+    assert!(
+        text.contains("Deployment") && text.contains("api:1"),
+        "{text}"
+    );
+    t.workload_segment = WorkloadSegment::Pod;
+    t.apply_filter("");
+    let text = common::render_text(160, 20, |f| render_resource_table(f, f.area(), &t));
+    assert!(
+        text.contains(" Workloads [Segment: Pod (Tab to cycle)] [1/2] "),
+        "{text}"
+    );
+    assert!(!text.contains("api:1"), "{text}");
+}
+
+#[test]
+fn custom_resource_table_colours_printer_status_columns() {
+    let kind = crd(
+        true,
+        &[
+            ("Ready", ".status.ready", 0),
+            ("Health", ".status.health", 0),
+            ("Sync", ".status.sync", 0),
+        ],
+    );
+    let mut t = ResourceTableState::new(kind);
+    t.set_items(
+        vec![
+            json!({ "metadata": { "name": "w1", "namespace": "ns" }, "status": { "ready": "True", "health": "Healthy", "sync": "Synced" } }),
+            json!({ "metadata": { "name": "w2", "namespace": "ns" }, "status": { "ready": "False", "health": "Degraded", "sync": "OutOfSync" } }),
+        ],
+        "",
+    );
+    let buf = render_buffer(120, 20, |f| render_resource_table(f, f.area(), &t));
+    let rows: Vec<String> = (0..buf.area.height).map(|y| buffer_row(&buf, y)).collect();
+    assert!(rows[0].contains(" Widget [2] "), "{}", rows[0]);
+    assert!(
+        rows[1].contains("READY")
+            && rows[1].contains("HEALTH")
+            && rows[1].contains("SYNC")
+            && rows[1].contains("AGE"),
+        "{}",
+        rows[1]
+    );
+    let (y1, r1) = row_containing(&rows, "w1").unwrap();
+    assert!(
+        r1.contains("True") && r1.contains("Healthy") && r1.contains("Synced"),
+        "{r1}"
+    );
+    assert_eq!(fg_of(&buf, y1 as u16, "True"), Theme::status_ok().fg);
+    // "Healthy" is not a status word the theme knows, so it falls back to the
+    // plain foreground rather than the selected-row foreground: proof the
+    // HEALTH column went through status_style even on the selected row.
+    assert_eq!(fg_of(&buf, y1 as u16, "Healthy"), Some(Theme::FG));
+    assert_ne!(
+        fg_of(&buf, y1 as u16, "w1"),
+        Some(Theme::FG),
+        "the name cell is selection-styled"
+    );
+    let (y2, r2) = row_containing(&rows, "w2").unwrap();
+    assert!(r2.contains("Degraded"), "{r2}");
+    assert_eq!(fg_of(&buf, y2 as u16, "False"), Theme::status_error().fg);
+    assert_eq!(fg_of(&buf, y2 as u16, "Degraded"), Theme::status_error().fg);
+}


### PR DESCRIPTION
#433's backend job fails the coverage floor:

```
TOTAL … 76.52%
cargo llvm-cov report --fail-under-lines 85   →   exit 1
```

The cause is `apps/tui`: 13,750 lines at **46%** covered, against 86.9% for the rest of the workspace. The TUI is a quarter of the tree's lines and arrived with almost none of its own tests, so it pulled the whole number down.

## Result

| | before | after |
|---|---|---|
| `apps/tui` | 46.0% | **87.5%** |
| workspace total | 76.52% | **~87.1%** |

**592 tests, green over repeated full runs.** The workspace figure is projected: `apps/tui` is measured here, and every other file's number is taken from #433's own last CI run, which the TUI's tests do not touch. The kind-bound suites only ever add covered lines, so the real CI number should land at or above this.

## What this adds

Tests, not an exemption. Eight files under `apps/tui/tests/`, sharing one harness (`tests/common/mod.rs`):

| File | Covers |
| --- | --- |
| `app_input_tests.rs` | keys, command and filter modes, modals, navigation, view switching |
| `app_state_tests.rs` | app events, the render pass across every view and modal, screen selection, the free helpers |
| `app_extra_tests.rs` | everything that only runs once a cluster answers |
| `views_inspect_tests.rs` | node inspector, settings, overview, YAML |
| `views_panels_tests.rs` | logs, describe, toolbox, port-forward, helm, exec, tree, resource table, reason rail |
| `chrome_tests.rs` | dialogs, help, header, status bar, assistant |
| `core_logic_tests.rs` | commands, AI config, deep links, events, theme, skills |
| `agent_bridge_tests.rs` | the agent bridge, as far as a test can reach |

Two things make it work without a cluster. `App::new` with no kubeconfig resolves zero contexts and falls back to a `default` context, so capability calls fail fast instead of hanging and the failure states are themselves worth asserting. And for the paths that need an answer rather than a failure, `app_extra_tests.rs` stands up a **loopback fake apiserver**: bind `127.0.0.1:0`, speak just enough HTTP/1.1 for kube-rs, point a temp kubeconfig at it, and point only the app's `client_cache` there — `kubeconfig_paths` still names a file that does not exist, so watches and kubectl fallbacks still fail fast and nothing long-polls. That reaches the cluster refreshes, CRD discovery, the overview roll-up, YAML and describe for builtin and custom kinds, scale, cordon, delete and restart.

## Discipline

- Every test asserts behaviour — a state field, an emitted event, or rendered text proving the branch drew. None assert merely that a frame is non-empty.
- No sleeps, no network beyond loopback servers on ephemeral ports, no dependence on installed tools or the developer's home directory. Nothing spawns an editor or a shell.
- At most one env-touching test per binary, restoring in a `Drop` guard.
- **No file under `apps/tui/src/` changed.** Where a test disagreed with the source, the source won — unless the source was demonstrably wrong, in which case the test documents today's behaviour and the finding is written down below.

One real flake surfaced and is fixed: the port-forward table asks for 115 columns of fixed width, so at a narrow terminal the layout is over-constrained and **which columns survive varies from process to process**. That test now asserts only what is stable there, with a second test at a width where the layout is determinate.

## The one exclusion

`apps/tui/src/main.rs` joins the desktop app's `lib.rs`/`main.rs` and the server's bin in the ignore regex. It builds a terminal, installs panic hooks and runs the event loop; it executes only inside a running terminal. That is the rule the workflow comment already states, applied consistently — and the comment now also says that nothing else in `apps/tui` is exempt.

## Findings, recorded not fixed

Writing tests for code that had almost none turned up eight things. **None is
fixed here** — this branch is about coverage, and a behaviour change belongs
in its own PR against `add-tui`. Each is pinned by a test that documents what
the code does today, so a later fix will show up as a test that has to change.

### Worth fixing

1. **`apps/tui/src/agent.rs:444` — `std::env::set_var` on a live async task.**
   `run_boxed_cursor_turn` sets `CURSOR_API_KEY` process-wide from a task that
   may be on any worker thread while other threads call `getenv`. That is a
   data race, and a hard error under edition 2024. It is also redundant: the
   line above already puts the key on the child with `cmd.env(...)`, which is
   the correct scope. Side effect: the key leaks into the environment of every
   later child process. It leaked into this test suite too, which is why
   `core_logic_tests.rs` passes `None` there with a comment.

2. **`apps/tui/src/app.rs:4168` — a cache key that can never match, so every
   container lookup hits the API.** The fast path tests `kind == "Pods"`, but
   the informer cache is keyed by the lowercase watch kind (`"pods"`, inserted
   at `apps/tui/src/app.rs:5268`). The capitalised key is never produced, so
   the container picker makes a live call every time. Found because the picker
   only opened once a capital-`"Pods"` entry was inserted by hand.

3. **`apps/tui/src/agent.rs:223` vs `:227` — the timeout message reports a
   number the code did not use.** The deadline is `timeout_seconds.max(5)` but
   the message interpolates the unclamped value, so asking for 1 second waits
   5 and then says "timed out after 1 seconds". Both halves are now asserted,
   so fixing one without the other fails.

4. **`apps/tui/src/views/overview_view.rs:267-282` is unreachable.**
   `has_gpus` is `d.total_gpus > 0` and guards the block, so the inner
   `if d.total_gpus > 0` is always true and the two `else` arms — the VRAM
   allocation lines — can never render. The guard most likely wants to be
   `total_gpus > 0 || total_gpu_mem_mib > 0 || used_gpu_mem_mib > 0`. No input
   reaches those 16 lines.

9. **`apps/tui/src/app.rs:5773` — the clipboard write has no off switch, so
   running the test suite clobbers the developer's clipboard.**
   `copy_via_osc52` opens `/dev/tty` and writes the escape there, falling back
   to stdout only if that fails, so cargo's output capture does not contain
   it; `copy_to_clipboard` then also spawns `wl-copy`/`xclip`/`pbcopy`. Any
   test that presses a copy key therefore overwrites the real clipboard on a
   machine with a terminal. **CI is unaffected** — the runner has no
   controlling terminal and neither helper is installed, so every branch is
   inert there — and the wart predates this PR, since `tui_tests.rs` exercises
   copy handlers too. But this PR adds more of them. Codex asked for the
   boundary to be stubbed; there is no seam to stub, and adding one means
   editing production code, which this PR does not do. Suggested fix for a
   follow-up: a process-level switch (an `AtomicBool` behind
   `pub fn set_clipboard_enabled`, or an env guard) that a test harness turns
   off once, so the handlers still run end to end and only the final write is
   suppressed. That thread is left open on this PR on purpose.

### Dead code, harmless today

5. **`apps/tui/src/app.rs:2145` — the focused reason rail's `Esc` arm never
   runs.** The global `Esc` handler at `apps/tui/src/app.rs:2040` acts first
   and clears a filter or pops the view stack. Only `R` and `Tab` leave the
   rail.

6. **`apps/tui/src/app.rs:2959` — one assistant binding is shadowed.** The
   "clear input" arm matches `Char('u')` with ALT *or* CONTROL, but
   `apps/tui/src/app.rs:2951` already matches CONTROL for `scroll_up(10)`.
   Only Alt+u clears the composer.

### Decisions for the author, not defects

7. **`apps/tui/src/app.rs:5883` — MCP tool names unwrap for only one spelling.**
   The nested name is unwrapped when the stripped key is `callMcpTool` or
   `mcp`, i.e. a payload key of `callMcpToolToolCall`. The equally natural
   `callMcpToolCall` strips to `callMcp` and falls through, labelling the call
   `callMcp` instead of the real tool. Which is right depends on the agent wire
   format, which is not in this repo, so the test documents both paths.

8. **Per-turn token accounting has a hole.** `run_boxed_cursor_turn` emits no
   `ai_usage` event when the binary fails to launch, because the estimate sits
   inside the spawn-Ok arm, while `run_native_agent_turn` emits one on every
   outcome. Any UI reconciling per-turn tokens will see a gap for failed
   launches.

## Why some lines stay uncovered

The floor is met, but four areas resist tests on purpose rather than for lack
of effort, and it is worth saying which so nobody re-litigates them:

- **`apps/tui/src/main.rs`** builds a terminal, installs panic hooks and runs
  the event loop. It is the process entry point and is excluded, exactly as
  the desktop app's entry points and the server's bin already are.
- **`apps/tui/src/views/exec_view.rs`** is three methods that build an argv and
  call `Command::status()` on `kubectl`. There is no pure helper and no return
  value but the spawn result, so covering it means really running
  `kubectl exec -i -t`.
- **`apps/tui/src/agent.rs` after a successful spawn** (~157 lines) needs a
  real child process: `AgentCommand::program` is the caller's binary path
  verbatim, with no injection seam.
- **`apps/tui/src/event.rs`'s select loop** is driven by crossterm's
  `EventStream`. With no controlling terminal the stream errors on first poll
  and the loop breaks, racing the first interval tick; the handler holds its
  own sender, so a lost race hangs rather than fails. Any assertion there is a
  coin flip with a hang on the losing side.
