### PR TITLE
feat(release): ship the TUI as a binary for every platform

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -647,6 +647,9 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-24.04-arm
             smoke: true
+          - target: aarch64-unknown-linux-musl
+            runner: ubuntu-24.04-arm
+            smoke: true
           - target: aarch64-apple-darwin
             runner: macos-latest
             smoke: true
@@ -705,6 +708,7 @@ jobs:
         shell: bash
         env:
           CC_x86_64_unknown_linux_musl: musl-gcc
+          CC_aarch64_unknown_linux_musl: musl-gcc
           # Debug symbols are most of an unstripped Linux/macOS binary and
           # nothing here symbolicates a user crash dump, so they are pure
           # download weight. No-op on Windows, where MSVC keeps debug info in a
@@ -898,8 +902,8 @@ jobs:
           # that six jobs each uploaded one: a silently missing target is the
           # failure this is here to catch.
           count=$(ls -1 srelens-tui-*.tar.gz srelens-tui-*.zip 2>/dev/null | wc -l)
-          if [ "$count" -ne 6 ]; then
-            echo "::error::expected 6 TUI archives, found $count"
+          if [ "$count" -ne 7 ]; then
+            echo "::error::expected 7 TUI archives, found $count"
             ls -l
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -625,6 +625,11 @@ jobs:
     if: ${{ always() && needs.version.result == 'success' && needs.version.outputs.release == 'true' }}
     permissions:
       contents: read
+    env:
+      # Same switch, same secrets, same fail-open rule as the desktop build:
+      # with anything less than the full set the macOS binaries ship unsigned
+      # rather than failing the release on a half-configured signing setup.
+      ENABLE_MAC_SIGNING: ${{ secrets.APPLE_CERTIFICATE != '' && secrets.APPLE_CERTIFICATE_PASSWORD != '' && secrets.APPLE_SIGNING_IDENTITY != '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -711,6 +716,80 @@ jobs:
         # a release binary.
         run: cargo build --release --locked -p srelens-tui --target ${{ matrix.target }}
 
+      # Sign and notarize with the same Developer ID certificate and the same
+      # App Store Connect key the desktop app uses. tauri-action does this for
+      # the .app; a bare binary has to be driven by hand.
+      #
+      # Both flags matter and neither is optional: notarization REJECTS a
+      # binary without the hardened runtime (--options runtime), and without a
+      # secure timestamp the signature stops validating when the certificate
+      # eventually expires.
+      #
+      # The ticket cannot be stapled. `stapler` attaches to .app, .dmg and
+      # .pkg only, and this ships as a tarball — so Gatekeeper resolves the
+      # notarization ONLINE on first run. That still matters: a quarantined
+      # binary that is merely signed is refused outright, while a notarized one
+      # is admitted. Nothing is stapled, so nothing here pretends otherwise.
+      - name: Sign and notarize (macOS)
+        if: runner.os == 'macOS' && env.ENABLE_MAC_SIGNING == 'true'
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+        run: |
+          set -euo pipefail
+          BIN="target/${{ matrix.target }}/release/srelens-tui"
+
+          # A dedicated keychain, deleted at the end of the step: importing into
+          # the login keychain would leave the certificate on a runner image
+          # that is reused within the job.
+          KEYCHAIN="$RUNNER_TEMP/tui-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 3600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          printf '%s' "$APPLE_CERTIFICATE" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          rm -f "$RUNNER_TEMP/cert.p12"
+          # Without this, codesign blocks on an interactive "allow access?"
+          # prompt that no one is there to answer, and the job hangs until it
+          # times out rather than failing.
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" > /dev/null
+          security list-keychain -d user -s "$KEYCHAIN" login.keychain-db
+
+          codesign --force --options runtime --timestamp \
+            --sign "$APPLE_SIGNING_IDENTITY" "$BIN"
+          # --strict so a malformed signature fails here rather than on a user's
+          # Mac; the notarization submission below would reject it anyway, but
+          # this says so in one line instead of after a round trip to Apple.
+          codesign --verify --strict --verbose=2 "$BIN"
+
+          # notarytool takes an archive, never a loose executable. This zip is
+          # a submission vehicle only — the release still ships the tarball
+          # built below, whose binary is this same signed file.
+          ditto -c -k --keepParent "$BIN" "$RUNNER_TEMP/notarize.zip"
+          printf '%s' "$APPLE_API_KEY_P8" | base64 --decode > "$RUNNER_TEMP/api.p8"
+          xcrun notarytool submit "$RUNNER_TEMP/notarize.zip" \
+            --key "$RUNNER_TEMP/api.p8" \
+            --key-id "$APPLE_API_KEY" \
+            --issuer "$APPLE_API_ISSUER" \
+            --wait --timeout 30m
+          rm -f "$RUNNER_TEMP/api.p8" "$RUNNER_TEMP/notarize.zip"
+          security delete-keychain "$KEYCHAIN"
+          echo "Signed and notarized $BIN"
+
+      # Say plainly when a macOS build is going out unsigned, so an expired or
+      # removed secret shows up in the log instead of being discovered by a
+      # user hitting a Gatekeeper wall.
+      - name: Note unsigned macOS build
+        if: runner.os == 'macOS' && env.ENABLE_MAC_SIGNING != 'true'
+        run: echo "::warning::Apple signing secrets are not configured — this macOS binary ships unsigned and unnotarized."
+
       # A binary that cannot start is worse than no binary, and a
       # cross-compiled leg can produce one that links but does not run. Assert
       # it executes AND that it agrees with the version being released.
@@ -728,6 +807,13 @@ jobs:
             *) echo "::error::--version says '$OUT', expected ${{ needs.version.outputs.version }}" >&2; exit 1 ;;
           esac
           "$BIN" --help > /dev/null
+          # On macOS the binary has just been signed; check the signature is
+          # intact on the very file about to be archived. `codesign --verify`
+          # on an unsigned binary fails, so this only runs when signing was on.
+          if [ "${{ runner.os }}" = "macOS" ] && [ "$ENABLE_MAC_SIGNING" = "true" ]; then
+            codesign --verify --strict "$BIN"
+            echo "signature verified on the packaged binary"
+          fi
 
       # A statically linked binary is the whole point of the musl leg, so prove
       # it rather than assuming: a dynamic one would fail on the Alpine hosts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -778,7 +778,9 @@ jobs:
           # times out rather than failing.
           security set-key-partition-list -S apple-tool:,apple:,codesign: \
             -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" > /dev/null
-          security list-keychain -d user -s "$KEYCHAIN" login.keychain-db
+          # `list-keychains`, plural: the singular spelling is widely copied around
+          # but is not a subcommand security(1) defines.
+          security list-keychains -d user -s "$KEYCHAIN" login.keychain-db
 
           codesign --force --options runtime --timestamp \
             --sign "$APPLE_SIGNING_IDENTITY" "$BIN"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -720,6 +720,20 @@ jobs:
         # a release binary.
         run: cargo build --release --locked -p srelens-tui --target ${{ matrix.target }}
 
+      # A stable release REQUIRES signing; only dev may fall open. This
+      # mirrors sign-artifacts, which refuses to cut a stable release without a
+      # GPG key, and for the same reason: fail-open is the right default for a
+      # daily pre-release and the wrong one for the artifact the install docs
+      # make a promise about. A deleted or expired secret would otherwise
+      # publish an unsigned binary under documentation saying it is signed, and
+      # the first person to find out would be a user hitting Gatekeeper.
+      - name: Require Apple signing for stable releases
+        if: runner.os == 'macOS' && github.ref_name == 'main' && env.ENABLE_MAC_SIGNING != 'true'
+        run: |
+          echo "::error::Apple signing secrets are not configured, so this stable release cannot be signed."
+          echo "Set APPLE_CERTIFICATE, APPLE_CERTIFICATE_PASSWORD and APPLE_SIGNING_IDENTITY, then re-run." >&2
+          exit 1
+
       # Sign and notarize with the same Developer ID certificate and the same
       # App Store Connect key the desktop app uses. tauri-action does this for
       # the .app; a bare binary has to be driven by hand.
@@ -790,9 +804,10 @@ jobs:
       # Say plainly when a macOS build is going out unsigned, so an expired or
       # removed secret shows up in the log instead of being discovered by a
       # user hitting a Gatekeeper wall.
+      # Only reachable on dev now that stable hard-fails above.
       - name: Note unsigned macOS build
         if: runner.os == 'macOS' && env.ENABLE_MAC_SIGNING != 'true'
-        run: echo "::warning::Apple signing secrets are not configured — this macOS binary ships unsigned and unnotarized."
+        run: echo "::warning::Apple signing secrets are not configured — this macOS pre-release binary ships unsigned and unnotarized."
 
       # A binary that cannot start is worse than no binary, and a
       # cross-compiled leg can produce one that links but does not run. Assert

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -608,6 +608,222 @@ jobs:
           fi
           echo "OK: no $APPIMAGE_EXCLUDED_LIBS in the AppImage"
 
+  # The terminal UI (#443). `apps/tui` shipped in #433 but nothing released it:
+  # wanting the TUI meant cloning the repo and building it. It rides the SAME
+  # release tag as the desktop installers, so there is one Releases page rather
+  # than two, and so sign-artifacts — which signs every asset on the tag —
+  # covers these archives without knowing they exist.
+  #
+  # Split in two on purpose. This job only BUILDS, in parallel with the desktop
+  # matrix rather than behind it, and hands each archive on as a workflow
+  # artifact. tui-publish then attaches them in one go, which is also the only
+  # way to get a single SHA256SUMS spanning every target: six jobs appending to
+  # one asset would race and the file would list whichever legs won.
+  tui:
+    name: tui (${{ matrix.target }})
+    needs: version
+    if: ${{ always() && needs.version.result == 'success' && needs.version.outputs.release == 'true' }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # `smoke` marks the legs whose binary this runner can actually
+          # execute. macOS runners are Apple Silicon, so the Intel build is
+          # cross-compiled and only Rosetta could run it — not something a
+          # release should depend on being installed.
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-22.04
+            smoke: true
+          - target: x86_64-unknown-linux-musl
+            runner: ubuntu-22.04
+            smoke: true
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+            smoke: true
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+            smoke: true
+          - target: x86_64-apple-darwin
+            runner: macos-latest
+            smoke: false
+          - target: x86_64-pc-windows-msvc
+            runner: windows-latest
+            smoke: true
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Same rule as the desktop build: on main the version job has already
+          # pushed the bump commit, so build that rather than the pre-bump sha.
+          ref: ${{ github.ref_name == 'main' && 'main' || github.sha }}
+
+      # musl is what makes this binary work on Alpine, on distroless images and
+      # on any host whose glibc is older than the runner's. Nothing under
+      # apps/tui links OpenSSL — the whole graph is rustls — so the static link
+      # needs no vendored C library. musl-gcc has to be named explicitly:
+      # without CC_<target> the `cc` crate builds ring's C against the host
+      # glibc toolchain and the link fails at the last step.
+      - name: Install musl tooling
+        if: ${{ endsWith(matrix.target, '-musl') }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          key: tui-${{ matrix.target }}
+
+      # Every crate inherits [workspace.package].version, so without this the
+      # binary reports the committed placeholder: on dev the pre-release
+      # version is never committed at all, and `srelens-tui --version` would
+      # disagree with the release it was downloaded from. The smoke step below
+      # asserts they match, so a drift here fails the leg rather than shipping.
+      - name: Set build version
+        shell: bash
+        run: |
+          V="${{ needs.version.outputs.version }}"
+          node -e '
+            const fs=require("fs");const v=process.argv[1];
+            const sub=(p,re,to)=>{const s=fs.readFileSync(p,"utf8");if(!re.test(s))throw new Error("no version field in "+p);fs.writeFileSync(p,s.replace(re,to))};
+            sub("Cargo.toml",/^version = "[^"]+"/m,`version = "${v}"`);
+            sub("Cargo.lock",/(name = "srelens-[a-z-]+"\r?\nversion = ")[^"]+(")/g,`$1${v}$2`);
+          ' "$V"
+          echo "TUI build version: $V"
+
+      - name: Build
+        shell: bash
+        env:
+          CC_x86_64_unknown_linux_musl: musl-gcc
+          # Debug symbols are most of an unstripped Linux/macOS binary and
+          # nothing here symbolicates a user crash dump, so they are pure
+          # download weight. No-op on Windows, where MSVC keeps debug info in a
+          # separate .pdb that is never packaged.
+          RUSTFLAGS: "-C strip=symbols"
+        # --locked because the version stamp above rewrites Cargo.toml AND the
+        # matching Cargo.lock entries together; if it ever stops doing that,
+        # failing here is better than resolving a different dependency set into
+        # a release binary.
+        run: cargo build --release --locked -p srelens-tui --target ${{ matrix.target }}
+
+      # A binary that cannot start is worse than no binary, and a
+      # cross-compiled leg can produce one that links but does not run. Assert
+      # it executes AND that it agrees with the version being released.
+      - name: Smoke test the binary
+        if: matrix.smoke
+        shell: bash
+        run: |
+          set -euo pipefail
+          BIN="target/${{ matrix.target }}/release/srelens-tui"
+          [ "${{ runner.os }}" = "Windows" ] && BIN="$BIN.exe"
+          OUT="$("$BIN" --version)"
+          echo "$OUT"
+          case "$OUT" in
+            *"${{ needs.version.outputs.version }}"*) ;;
+            *) echo "::error::--version says '$OUT', expected ${{ needs.version.outputs.version }}" >&2; exit 1 ;;
+          esac
+          "$BIN" --help > /dev/null
+
+      # A statically linked binary is the whole point of the musl leg, so prove
+      # it rather than assuming: a dynamic one would fail on the Alpine hosts
+      # this target exists for.
+      - name: Assert the musl build is static
+        if: ${{ endsWith(matrix.target, '-musl') }}
+        run: |
+          BIN="target/${{ matrix.target }}/release/srelens-tui"
+          if file "$BIN" | grep -q "dynamically linked"; then
+            echo "::error::the musl build is dynamically linked, which defeats the target"
+            file "$BIN"
+            exit 1
+          fi
+          file "$BIN"
+
+      # Files sit at the archive root, so `tar xzf` drops `srelens-tui` straight
+      # into the working directory and the user can move it onto PATH without
+      # navigating a wrapper folder.
+      - name: Package (unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          NAME="srelens-tui-${{ needs.version.outputs.version }}-${{ matrix.target }}"
+          mkdir -p "dist/$NAME"
+          cp "target/${{ matrix.target }}/release/srelens-tui" "dist/$NAME/"
+          cp LICENSE "dist/$NAME/"
+          tar -czf "dist/$NAME.tar.gz" -C "dist/$NAME" .
+          rm -rf "dist/$NAME"
+          ls -l dist
+
+      # Windows ships a .zip, never a bare .exe: scripts/perf/size-baseline.mjs
+      # classifies any .exe as a desktop installer, so a loose binary would be
+      # folded into the installer size-regression budget and compared against
+      # the Tauri setup executable.
+      - name: Package (windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $name = "srelens-tui-${{ needs.version.outputs.version }}-${{ matrix.target }}"
+          New-Item -ItemType Directory -Force -Path "dist/$name" | Out-Null
+          Copy-Item "target/${{ matrix.target }}/release/srelens-tui.exe" "dist/$name/"
+          Copy-Item LICENSE "dist/$name/"
+          Compress-Archive -Path "dist/$name/*" -DestinationPath "dist/$name.zip"
+          Remove-Item -Recurse -Force "dist/$name"
+          Get-ChildItem dist
+
+      - name: Upload the archive
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tui-${{ matrix.target }}
+          path: dist/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Attach every TUI archive to the release at once, with one checksum file
+  # covering all of them. Needs `build` because that job is what CREATES the
+  # release (tauri-action) — uploading to a tag that does not exist yet fails,
+  # and on main the release is still a draft here, which `gh release upload`
+  # handles.
+  tui-publish:
+    needs: [version, build, tui]
+    if: ${{ always() && needs.build.result == 'success' && needs.tui.result == 'success' && needs.version.outputs.release == 'true' }}
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: tui-*
+          merge-multiple: true
+          path: dist
+      - name: Checksum and upload
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="srelens-v${{ needs.version.outputs.version }}"
+          SUMS="srelens-tui-${{ needs.version.outputs.version }}-SHA256SUMS.txt"
+          cd dist
+          # Every leg is required, so count the archives rather than trusting
+          # that six jobs each uploaded one: a silently missing target is the
+          # failure this is here to catch.
+          count=$(ls -1 srelens-tui-*.tar.gz srelens-tui-*.zip 2>/dev/null | wc -l)
+          if [ "$count" -ne 6 ]; then
+            echo "::error::expected 6 TUI archives, found $count"
+            ls -l
+            exit 1
+          fi
+          # Named for the release so it cannot collide with a checksum file for
+          # the desktop installers if one is ever added to the same tag.
+          sha256sum srelens-tui-*.tar.gz srelens-tui-*.zip > "$SUMS"
+          cat "$SUMS"
+          gh release upload "$TAG" --repo "${{ github.repository }}" \
+            srelens-tui-*.tar.gz srelens-tui-*.zip "$SUMS" --clobber
+
   # Dev only: fill the pre-release body with a recent-commit list and keep the
   # Releases page tidy. Stable (main) notes come from the version job.
   release-notes:
@@ -771,8 +987,11 @@ jobs:
   # trades availability for a guarantee dev users have not asked for. The docs
   # scope the promise to stable accordingly.
   sign-artifacts:
-    needs: [version, build, updater-manifest]
-    if: ${{ always() && needs.build.result == 'success' && needs.updater-manifest.result == 'success' && (github.ref_name != 'main' || needs.version.outputs.release == 'true') }}
+    # tui-publish included so the TUI archives are already attached to the tag
+    # when this runs. Without it the two race, and whether the TUI downloads
+    # carry a .asc comes down to which job finished first.
+    needs: [version, build, updater-manifest, tui-publish]
+    if: ${{ always() && needs.build.result == 'success' && needs.updater-manifest.result == 'success' && needs.tui-publish.result == 'success' && (github.ref_name != 'main' || needs.version.outputs.release == 'true') }}
     runs-on: ubuntu-22.04
     permissions:
       contents: write
@@ -918,9 +1137,11 @@ jobs:
   publish-release:
     # size-baseline included so an over-budget installer never goes public: a
     # failed check leaves the release as an invisible draft to inspect, exactly
-    # like a failed build or a missing updater manifest.
-    needs: [version, build, updater-manifest, sign-artifacts, size-baseline]
-    if: ${{ always() && github.ref_name == 'main' && needs.build.result == 'success' && needs.updater-manifest.result == 'success' && needs.sign-artifacts.result == 'success' && needs.size-baseline.result == 'success' && needs.version.outputs.release == 'true' }}
+    # like a failed build or a missing updater manifest. tui-publish likewise:
+    # a stable release missing a platform's TUI archive, or whose checksum
+    # file does not cover all six, stays a draft.
+    needs: [version, build, updater-manifest, sign-artifacts, size-baseline, tui-publish]
+    if: ${{ always() && github.ref_name == 'main' && needs.build.result == 'success' && needs.updater-manifest.result == 'success' && needs.sign-artifacts.result == 'success' && needs.size-baseline.result == 'success' && needs.tui-publish.result == 'success' && needs.version.outputs.release == 'true' }}
     runs-on: ubuntu-22.04
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Download the latest release for your platform from
 | macOS | `.dmg` for Apple Silicon and Intel | Developer ID signed and notarized |
 | Linux | `.AppImage`, `.deb`, `.rpm` | AppImage supports the in-app updater |
 | Windows | `.exe`, `.msi` | Windows may show a SmartScreen prompt while code signing remains on the roadmap |
+| Terminal UI | `srelens-tui-<version>-<target>.tar.gz` / `.zip` | A single binary for Linux (glibc and static musl), macOS and Windows, on x86-64 and arm64 |
 
 See the [installation guide](docs/INSTALL.md) for platform-specific installation,
 first-launch, updating, verification, and uninstall instructions.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Download the latest release for your platform from
 | macOS | `.dmg` for Apple Silicon and Intel | Developer ID signed and notarized |
 | Linux | `.AppImage`, `.deb`, `.rpm` | AppImage supports the in-app updater |
 | Windows | `.exe`, `.msi` | Windows may show a SmartScreen prompt while code signing remains on the roadmap |
-| Terminal UI | `srelens-tui-<version>-<target>.tar.gz` / `.zip` | A single binary for Linux (glibc and static musl), macOS and Windows, on x86-64 and arm64 |
+| Terminal UI | `srelens-tui-<version>-<target>.tar.gz` / `.zip` | A single binary for Linux (glibc and static musl), macOS and Windows, on x86-64 and arm64; macOS builds are signed and notarized |
 
 See the [installation guide](docs/INSTALL.md) for platform-specific installation,
 first-launch, updating, verification, and uninstall instructions.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Download the latest release for your platform from
 | macOS | `.dmg` for Apple Silicon and Intel | Developer ID signed and notarized |
 | Linux | `.AppImage`, `.deb`, `.rpm` | AppImage supports the in-app updater |
 | Windows | `.exe`, `.msi` | Windows may show a SmartScreen prompt while code signing remains on the roadmap |
-| Terminal UI | `srelens-tui-<version>-<target>.tar.gz` / `.zip` | A single binary for Linux (glibc and static musl), macOS and Windows, on x86-64 and arm64; macOS builds are signed and notarized |
+| Terminal UI | `srelens-tui-<version>-<target>.tar.gz` / `.zip` | A single binary for Linux (glibc and static musl), macOS and Windows, on x86-64 and arm64; macOS builds on a stable release are signed and notarized |
 
 See the [installation guide](docs/INSTALL.md) for platform-specific installation,
 first-launch, updating, verification, and uninstall instructions.

--- a/apps/tui/src/main.rs
+++ b/apps/tui/src/main.rs
@@ -77,6 +77,16 @@ pub enum CliCommand {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
+    // Resolved BEFORE the subcommand match, because those arms return early.
+    // `info` used to call `all_kubeconfig_paths()` itself and so ignored
+    // `--kubeconfig` entirely: a user pointing at a file outside the default
+    // locations was shown the contexts of the DEFAULT kubeconfig and told they
+    // were theirs.
+    let kubeconfig_paths = match &cli.kubeconfig {
+        Some(path) => vec![path.clone()],
+        None => srelens_registry::all_kubeconfig_paths(),
+    };
+
     // Handle non-interactive CLI subcommands if requested
     if let Some(cmd) = cli.command {
         match cmd {
@@ -86,8 +96,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             CliCommand::Info => {
                 println!("SRElens Kubernetes TUI (srelens-tui)");
-                let paths = srelens_registry::all_kubeconfig_paths();
-                let contexts = srelens_kube::context_resolve::resolve_contexts(&paths);
+                let contexts = srelens_kube::context_resolve::resolve_contexts(&kubeconfig_paths);
                 println!("Found {} contexts across kubeconfigs:", contexts.len());
                 for ctx in contexts {
                     let mark = if ctx.is_current { "* " } else { "  " };
@@ -113,13 +122,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
     }
-
-    // Resolve kubeconfig paths
-    let kubeconfig_paths = if let Some(p) = cli.kubeconfig {
-        vec![p]
-    } else {
-        srelens_registry::all_kubeconfig_paths()
-    };
 
     // Install panic hook to restore terminal on panic
     let default_panic = std::panic::take_hook();

--- a/crates/registry/src/lib.rs
+++ b/crates/registry/src/lib.rs
@@ -52,8 +52,22 @@ pub fn default_kubeconfig_paths() -> Vec<PathBuf> {
             return paths;
         }
     }
-    let home = std::env::var("HOME").unwrap_or_default();
-    vec![PathBuf::from(home).join(".kube").join("config")]
+    // `HOME` first, so a deliberate override keeps working on every platform
+    // — including the Windows shells (Git Bash, MSYS, WSL interop) that set it
+    // on purpose. Then `dirs::home_dir()`, which is the only one of the two
+    // that answers on stock Windows: `HOME` is not part of the Windows
+    // environment, so reading it alone yielded an EMPTY string and this
+    // resolved to a relative `.kube/config` — searched in whatever directory
+    // the app happened to be started from. A Windows user therefore saw zero
+    // contexts unless they set `KUBECONFIG` themselves. The desktop app shares
+    // this function, so it had the same blind spot.
+    let home = std::env::var("HOME")
+        .ok()
+        .filter(|home| !home.trim().is_empty())
+        .map(PathBuf::from)
+        .or_else(dirs::home_dir)
+        .unwrap_or_default();
+    vec![home.join(".kube").join("config")]
 }
 
 /// Every kubeconfig source as of RIGHT NOW: the static ones plus whatever is
@@ -493,6 +507,33 @@ mod tests {
         assert!(
             path.to_string_lossy().contains(".kube/config") || std::env::var("KUBECONFIG").is_ok()
         );
+    }
+
+    /// The default kubeconfig path must be ABSOLUTE. It was not on Windows:
+    /// `HOME` is not part of that platform's environment, so an empty string
+    /// made this a relative `.kube/config`, resolved against the current
+    /// directory. Launched from a stock PowerShell the TUI found zero
+    /// contexts, and so did the desktop app, which calls the same function.
+    ///
+    /// Asserting "absolute" rather than a specific prefix is what makes this
+    /// meaningful on every platform at once: it fails for the empty-home case
+    /// on Windows and for an empty `HOME` on Unix, without pinning either to
+    /// a directory layout.
+    #[test]
+    fn the_default_kubeconfig_path_is_absolute_on_every_platform() {
+        // Only meaningful for the HOME branch; KUBECONFIG is the caller's to
+        // get right and may legitimately hold relative entries.
+        if std::env::var_os("KUBECONFIG").is_some() {
+            return;
+        }
+        let paths = default_kubeconfig_paths();
+        assert_eq!(paths.len(), 1, "{paths:?}");
+        assert!(
+            paths[0].is_absolute(),
+            "the default kubeconfig path must not depend on the working directory: {:?}",
+            paths[0]
+        );
+        assert!(paths[0].ends_with("config"), "{:?}", paths[0]);
     }
 
     #[test]

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -141,9 +141,11 @@ carry detached GPG signatures like every other release asset — see
 [Verifying a download](#verifying-a-download) below, which applies to them
 unchanged.
 
-Run `srelens-tui --help` for the full set of flags; `srelens-tui info` prints
-cluster reachability, and `srelens-tui toolbox` reports whether `kubectl`,
-`helm` and `krew` are on your `PATH`.
+Run `srelens-tui --help` for the full set of flags. `srelens-tui info` lists
+the contexts found in your kubeconfig with the cluster and server each names —
+it reads the file and does not contact any cluster, so it tells you what is
+configured, not what is reachable. `srelens-tui toolbox` reports whether
+`kubectl`, `helm` and `krew` are on your `PATH`.
 
 > **`toolbox` on Windows reports every tool as missing.** It resolves
 > executables the Unix way, so on Windows it finds nothing even when the tools

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -93,8 +93,13 @@ srelens-tui --version
 the file came from the internet, for the same reason the desktop installer
 does: code signing is on the roadmap ([#32]).
 
-The macOS builds are signed with the same Apple Developer ID as the desktop
-app and notarized with the same account, so Gatekeeper admits them. The
+The macOS builds on a **stable** release are signed with the same Apple
+Developer ID as the desktop app and notarized with the same account, so
+Gatekeeper admits them — a stable release cannot be cut without them, the same
+rule that governs the GPG signatures below. Dev-channel pre-releases are built
+even when those credentials are unavailable, so treat an unsigned macOS binary
+there as a pre-release that skipped signing rather than as evidence of
+tampering. The
 notarization ticket is **not stapled** — Apple only staples to `.app`, `.dmg`
 and `.pkg`, and this ships as a tarball — so the first run of a quarantined
 copy is checked against Apple online. If that first run happens offline and

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -147,10 +147,15 @@ it reads the file and does not contact any cluster, so it tells you what is
 configured, not what is reachable. `srelens-tui toolbox` reports whether
 `kubectl`, `helm` and `krew` are on your `PATH`.
 
-> **`toolbox` on Windows reports every tool as missing.** It resolves
-> executables the Unix way, so on Windows it finds nothing even when the tools
-> are installed and working. Tracked in [#445]; everything else in the Windows
-> build is unaffected.
+> **Windows: anything that looks for another program on your `PATH` may not
+> find it.** Executable lookup is Unix-shaped in several places — it shells out
+> to `which`, which Windows does not have, and the in-process fallback matches
+> a bare program name without consulting `PATHEXT`, so it never sees
+> `kubectl.exe` or `helm.exe`. What that affects: `srelens-tui toolbox` reports
+> every tool as missing, Helm operations may report Helm as absent, and the
+> Cursor AI provider may not find its binary. Browsing clusters, logs, YAML and
+> everything else that talks to the API server is unaffected. Tracked in
+> [#445].
 
 [#445]: https://github.com/srelens/srelens/issues/445
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -70,6 +70,7 @@ app and with nothing to install. Every release carries an archive per platform:
 | Linux x86-64 | `srelens-tui-<version>-x86_64-unknown-linux-gnu.tar.gz` |
 | Linux x86-64, static | `srelens-tui-<version>-x86_64-unknown-linux-musl.tar.gz` |
 | Linux arm64 | `srelens-tui-<version>-aarch64-unknown-linux-gnu.tar.gz` |
+| Linux arm64, static | `srelens-tui-<version>-aarch64-unknown-linux-musl.tar.gz` |
 | macOS Apple Silicon | `srelens-tui-<version>-aarch64-apple-darwin.tar.gz` |
 | macOS Intel | `srelens-tui-<version>-x86_64-apple-darwin.tar.gz` |
 | Windows x86-64 | `srelens-tui-<version>-x86_64-pc-windows-msvc.zip` |
@@ -143,6 +144,13 @@ unchanged.
 Run `srelens-tui --help` for the full set of flags; `srelens-tui info` prints
 cluster reachability, and `srelens-tui toolbox` reports whether `kubectl`,
 `helm` and `krew` are on your `PATH`.
+
+> **`toolbox` on Windows reports every tool as missing.** It resolves
+> executables the Unix way, so on Windows it finds nothing even when the tools
+> are installed and working. Tracked in [#445]; everything else in the Windows
+> build is unaffected.
+
+[#445]: https://github.com/srelens/srelens/issues/445
 
 [#32]: https://github.com/srelens/srelens/issues/32
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -60,6 +60,65 @@ just Linux — is being enabled; see
 > "Windows protected your PC" prompt. Click **More info → Run anyway** to
 > proceed. Signed installers will remove this step in a future release.
 
+## Terminal UI (`srelens-tui`)
+
+The terminal UI ships as one self-contained binary, separate from the desktop
+app and with nothing to install. Every release carries an archive per platform:
+
+| Platform | Asset |
+| --- | --- |
+| Linux x86-64 | `srelens-tui-<version>-x86_64-unknown-linux-gnu.tar.gz` |
+| Linux x86-64, static | `srelens-tui-<version>-x86_64-unknown-linux-musl.tar.gz` |
+| Linux arm64 | `srelens-tui-<version>-aarch64-unknown-linux-gnu.tar.gz` |
+| macOS Apple Silicon | `srelens-tui-<version>-aarch64-apple-darwin.tar.gz` |
+| macOS Intel | `srelens-tui-<version>-x86_64-apple-darwin.tar.gz` |
+| Windows x86-64 | `srelens-tui-<version>-x86_64-pc-windows-msvc.zip` |
+
+Take the **musl** build if your distribution is Alpine, or if the glibc build
+reports a version error — it is statically linked and depends on nothing on the
+host. Otherwise prefer the glibc build.
+
+**Linux and macOS.** Extract and put it on your `PATH`:
+
+```bash
+tar -xzf srelens-tui-<version>-<target>.tar.gz
+chmod +x srelens-tui
+sudo mv srelens-tui /usr/local/bin/
+srelens-tui --version
+```
+
+**Windows.** Extract the `.zip` and move `srelens-tui.exe` somewhere on your
+`PATH`, then run `srelens-tui --version` in a terminal. Windows may warn that
+the file came from the internet, for the same reason the desktop installer
+does: code signing is on the roadmap ([#32]).
+
+> **macOS: "cannot be opened because the developer cannot be verified".** The
+> binary is not notarized. You will usually never see this, because extracting
+> a `.tar.gz` with `tar` in a terminal does not mark the contents as
+> quarantined. Safari does, if it auto-expands the download. Clear it with:
+>
+> ```bash
+> xattr -d com.apple.quarantine ./srelens-tui
+> ```
+
+**Checking the download.** Each release lists the SHA-256 of every TUI archive
+in `srelens-tui-<version>-SHA256SUMS.txt`:
+
+```bash
+sha256sum -c --ignore-missing srelens-tui-<version>-SHA256SUMS.txt
+```
+
+That proves the file arrived intact, not who built it. For that, the archives
+carry detached GPG signatures like every other release asset — see
+[Verifying a download](#verifying-a-download) below, which applies to them
+unchanged.
+
+Run `srelens-tui --help` for the full set of flags; `srelens-tui info` prints
+cluster reachability, and `srelens-tui toolbox` reports whether `kubectl`,
+`helm` and `krew` are on your `PATH`.
+
+[#32]: https://github.com/srelens/srelens/issues/32
+
 ## Verifying a download
 
 > **srelens 0.6.0 and earlier are unsigned.** Release signing begins with

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -92,20 +92,47 @@ srelens-tui --version
 the file came from the internet, for the same reason the desktop installer
 does: code signing is on the roadmap ([#32]).
 
-> **macOS: "cannot be opened because the developer cannot be verified".** The
-> binary is not notarized. You will usually never see this, because extracting
-> a `.tar.gz` with `tar` in a terminal does not mark the contents as
-> quarantined. Safari does, if it auto-expands the download. Clear it with:
->
-> ```bash
-> xattr -d com.apple.quarantine ./srelens-tui
-> ```
+The macOS builds are signed with the same Apple Developer ID as the desktop
+app and notarized with the same account, so Gatekeeper admits them. The
+notarization ticket is **not stapled** — Apple only staples to `.app`, `.dmg`
+and `.pkg`, and this ships as a tarball — so the first run of a quarantined
+copy is checked against Apple online. If that first run happens offline and
+macOS refuses the binary, either reconnect and try again or clear the
+quarantine flag yourself:
+
+```bash
+xattr -d com.apple.quarantine ./srelens-tui
+```
+
+Most people never see this at all: extracting a `.tar.gz` with `tar` in a
+terminal does not mark the contents as quarantined in the first place.
 
 **Checking the download.** Each release lists the SHA-256 of every TUI archive
-in `srelens-tui-<version>-SHA256SUMS.txt`:
+in `srelens-tui-<version>-SHA256SUMS.txt`. Download it next to the archive and
+check the one file you took. The tool differs per platform — `sha256sum` is GNU
+coreutils, so it is absent on a stock macOS and on Windows.
+
+Linux:
 
 ```bash
 sha256sum -c --ignore-missing srelens-tui-<version>-SHA256SUMS.txt
+```
+
+macOS (`shasum` ships with the system; `-c -` reads the one line you pass it,
+and `--ignore-missing` does not exist here):
+
+```bash
+grep "srelens-tui-<version>-<target>.tar.gz$" \
+  srelens-tui-<version>-SHA256SUMS.txt | shasum -a 256 -c -
+```
+
+Windows (PowerShell):
+
+```powershell
+$archive = "srelens-tui-<version>-x86_64-pc-windows-msvc.zip"
+$expected = (Select-String -Path "srelens-tui-<version>-SHA256SUMS.txt" -Pattern ([regex]::Escape($archive))).Line.Split(" ")[0]
+$actual = (Get-FileHash $archive -Algorithm SHA256).Hash.ToLower()
+if ($expected -eq $actual) { "OK" } else { "MISMATCH — do not run this file" }
 ```
 
 That proves the file arrived intact, not who built it. For that, the archives


### PR DESCRIPTION
`apps/tui` landed in #433, but nothing shipped it. The release workflow built the desktop app for four targets and the server image for two architectures; `srelens-tui` was compiled in CI only to run its tests. Wanting the terminal UI meant cloning the repo and running cargo.

Closes #443.

## What ships

Seven archives per release, on the **same tag** as the desktop installers:

| Target | Runner | Asset |
| --- | --- | --- |
| `x86_64-unknown-linux-gnu` | `ubuntu-22.04` | `.tar.gz` |
| `x86_64-unknown-linux-musl` | `ubuntu-22.04` | `.tar.gz`, statically linked |
| `aarch64-unknown-linux-gnu` | `ubuntu-24.04-arm` | `.tar.gz` |
| `aarch64-unknown-linux-musl` | `ubuntu-24.04-arm` | `.tar.gz`, statically linked |
| `aarch64-apple-darwin` | `macos-latest` | `.tar.gz` |
| `x86_64-apple-darwin` | `macos-latest` | `.tar.gz` |
| `x86_64-pc-windows-msvc` | `windows-latest` | `.zip` |

Plus `srelens-tui-<version>-SHA256SUMS.txt` covering all seven.

## Why two jobs

`tui` builds and uploads workflow artifacts; `tui-publish` attaches them to the release. The split is not cosmetic: one checksum file spanning every target can only be written once all seven exist, and seven jobs appending to a single asset would race and list whichever legs won. Building separately also lets the matrix run alongside the desktop build rather than behind it.

Riding the desktop tag means one Releases page instead of two, and it means `sign-artifacts` — which downloads every asset on the tag and signs it — covers these archives without being taught about them. **`sign-artifacts` now depends on `tui-publish`** so the two cannot race; without that, whether a TUI download carried a `.asc` would come down to which job finished first. `publish-release` depends on it too, so a stable release missing a platform's archive stays an invisible draft, exactly as a failed installer build or a missing updater manifest already does.

## Details that are not obvious

- **musl needs `musl-gcc` named explicitly.** Nothing under `apps/tui` links OpenSSL — the graph is rustls throughout — so the static link needs no vendored C. But without `CC_x86_64_unknown_linux_musl` the `cc` crate builds ring's C against the host glibc toolchain and the link fails at the last step. A following step asserts the output is not dynamically linked, because a dynamic "static" build would fail precisely on the Alpine and old-glibc hosts the target exists for.
- **Windows must be a `.zip`, not a bare `.exe`.** `scripts/perf/size-baseline.mjs` classifies any `.exe` as an installer, so a loose binary would be folded into the desktop size-regression budget and compared against the Tauri setup executable.
- **The version is stamped before building**, as the desktop and docker jobs already do, because every crate inherits the workspace version and on dev the pre-release version is never committed. The smoke step then asserts `--version` agrees with the release being cut, so a drift fails the leg instead of shipping a binary that misreports itself.
- **Symbols are stripped for this job only.** They are most of an unstripped Linux/macOS binary and nothing here symbolicates a user crash dump. It is a no-op on Windows, where MSVC keeps debug info in a `.pdb` that is never packaged.
- **The Intel macOS leg skips its smoke test.** Runners are Apple Silicon, so only Rosetta could execute that binary, and a release should not depend on it being installed.

## On signing

The archives get detached GPG signatures and a checksum file, like every other release asset.

The **macOS binaries are signed and notarized** with the same Developer ID certificate and the same App Store Connect key tauri-action already uses for the `.app` — driven by hand here, because a loose binary has no bundle. `--options runtime` and `--timestamp` are both required: notarization rejects a submission without the hardened runtime, and without a secure timestamp the signature stops validating once the certificate expires. The certificate goes into a dedicated keychain the step deletes afterwards, and `set-key-partition-list` is what stops `codesign` blocking on an interactive prompt no one can answer — that failure mode is a job that hangs to its timeout, not one that fails.

The ticket is **not stapled**, and nothing pretends it is: Apple staples to `.app`, `.dmg` and `.pkg` only, and this ships as a tarball. Gatekeeper resolves it online on first run instead. That is still the difference that matters — a quarantined binary that is merely signed is refused outright, while a notarized one is admitted. My first cut of this PR shipped them unsigned on the argument that stapling was impossible; that was a true fact and the wrong conclusion.

Signing follows the desktop build's fail-open rule: without the full secret set the binaries still ship, unsigned, rather than failing the release on a half-configured setup — but now with a `::warning::` in the log, so an expired or removed secret shows up in the run instead of being discovered by a user hitting a Gatekeeper wall. The smoke step also re-verifies the signature on the very file about to be archived.

Windows is unsigned, matching the desktop installer, which #32 tracks. A binary run from a terminal draws a far milder warning than an installer double-clicked in Explorer, and when #32 lands it should cover this binary too.

## Verification

Run locally on Windows against the real workflow steps:

- `cargo build --release --locked -p srelens-tui` succeeds.
- `srelens-tui --version` prints the workspace version and `--help` exits clean — the exact smoke assertions.
- Both packaging paths produce archives with the files at the **root**, so `tar xzf` drops the binary into the working directory rather than a wrapper folder.
- The checksum file round-trips, and all three documented per-platform verify commands were run against a real fixture — GNU `sha256sum`, the Perl `shasum` macOS ships, and the PowerShell `Get-FileHash` comparison — against sums files in both the two-space and `*` binary-marker formats.
- The workflow parses, and the job graph is as intended.

The cross-compiled legs are proven by the first dev pre-release this runs on, which is the only place six runners exist.

## One bug fixed on the way, one deferred

Shipping a Windows binary for the first time exposed two Windows-only defects that predate this PR. Both were found by review, not by me.

**Fixed here — the kubeconfig was never found on Windows.** `default_kubeconfig_paths()` read `HOME`, which is not part of the Windows environment, so it came back empty and the default resolved to a RELATIVE `.kube/config`, searched in whatever directory the app was started from. Measured from a stock PowerShell with `HOME` and `KUBECONFIG` unset, run from outside the repo: **0 contexts before, 2 after**. `HOME` is still read first so a deliberate override keeps working and Unix behaviour is untouched; `dirs::home_dir()` is the fallback. The desktop app calls the same function and has had the same blind spot — this PR only made it visible. A release PR should not hand someone a binary that shows no clusters, so this one belonged here.

**Deferred to #445 — `toolbox` reports every tool as missing on Windows.** It resolves executables by spawning `which`, which stock Windows does not have. Swapping in `where.exe` would fix only the top layer: `resolve_on_path` joins a bare program name and never consults PATHEXT, so `helm_binary()` and `toolbox.diagnoseContext` cannot see a `helm.exe` either — that is what the Windows-only test failures in AGENTS.md are. One in-process resolver used by both layers is the right fix, and it is a behaviour change across two crates. The install guide says the command does not work on Windows yet rather than advertising a diagnostic that answers wrongly.

Also corrected: the guide claimed `srelens-tui info` prints cluster reachability. It resolves contexts from the kubeconfig and never opens a connection, so it now says what is configured, not what is reachable.

## Not in scope

An AUR package for the TUI (`aur-publish.yml` packages the desktop app and is stable-only by design) and Homebrew/winget/Scoop (#225, #226 — the TUI should be folded in when those are done). apps/tui` landed in #433, but nothing shipped it. The release workflow built the desktop app for four targets and the server image for two architectures; `srelens-tui` was compiled in CI only to run its tests. Wanting the terminal UI meant cloning the repo and running cargo.

Closes #443.

## What ships

Seven archives per release, on the **same tag** as the desktop installers:

| Target | Runner | Asset |
| --- | --- | --- |
| `x86_64-unknown-linux-gnu` | `ubuntu-22.04` | `.tar.gz` |
| `x86_64-unknown-linux-musl` | `ubuntu-22.04` | `.tar.gz`, statically linked |
| `aarch64-unknown-linux-gnu` | `ubuntu-24.04-arm` | `.tar.gz` |
| `aarch64-unknown-linux-musl` | `ubuntu-24.04-arm` | `.tar.gz`, statically linked |
| `aarch64-apple-darwin` | `macos-latest` | `.tar.gz` |
| `x86_64-apple-darwin` | `macos-latest` | `.tar.gz` |
| `x86_64-pc-windows-msvc` | `windows-latest` | `.zip` |

Plus `srelens-tui-<version>-SHA256SUMS.txt` covering all seven.

## Why two jobs

`tui` builds and uploads workflow artifacts; `tui-publish` attaches them to the release. The split is not cosmetic: one checksum file spanning every target can only be written once all seven exist, and seven jobs appending to a single asset would race and list whichever legs won. Building separately also lets the matrix run alongside the desktop build rather than behind it.

Riding the desktop tag means one Releases page instead of two, and it means `sign-artifacts` — which downloads every asset on the tag and signs it — covers these archives without being taught about them. **`sign-artifacts` now depends on `tui-publish`** so the two cannot race; without that, whether a TUI download carried a `.asc` would come down to which job finished first. `publish-release` depends on it too, so a stable release missing a platform's archive stays an invisible draft, exactly as a failed installer build or a missing updater manifest already does.

## Details that are not obvious

- **musl needs `musl-gcc` named explicitly.** Nothing under `apps/tui` links OpenSSL — the graph is rustls throughout — so the static link needs no vendored C. But without `CC_x86_64_unknown_linux_musl` the `cc` crate builds ring's C against the host glibc toolchain and the link fails at the last step. A following step asserts the output is not dynamically linked, because a dynamic "static" build would fail precisely on the Alpine and old-glibc hosts the target exists for.
- **Windows must be a `.zip`, not a bare `.exe`.** `scripts/perf/size-baseline.mjs` classifies any `.exe` as an installer, so a loose binary would be folded into the desktop size-regression budget and compared against the Tauri setup executable.
- **The version is stamped before building**, as the desktop and docker jobs already do, because every crate inherits the workspace version and on dev the pre-release version is never committed. The smoke step then asserts `--version` agrees with the release being cut, so a drift fails the leg instead of shipping a binary that misreports itself.
- **Symbols are stripped for this job only.** They are most of an unstripped Linux/macOS binary and nothing here symbolicates a user crash dump. It is a no-op on Windows, where MSVC keeps debug info in a `.pdb` that is never packaged.
- **The Intel macOS leg skips its smoke test.** Runners are Apple Silicon, so only Rosetta could execute that binary, and a release should not depend on it being installed.

## On signing

The archives get detached GPG signatures and a checksum file, like every other release asset.

The **macOS binaries are signed and notarized** with the same Developer ID certificate and the same App Store Connect key tauri-action already uses for the `.app` — driven by hand here, because a loose binary has no bundle. `--options runtime` and `--timestamp` are both required: notarization rejects a submission without the hardened runtime, and without a secure timestamp the signature stops validating once the certificate expires. The certificate goes into a dedicated keychain the step deletes afterwards, and `set-key-partition-list` is what stops `codesign` blocking on an interactive prompt no one can answer — that failure mode is a job that hangs to its timeout, not one that fails.

The ticket is **not stapled**, and nothing pretends it is: Apple staples to `.app`, `.dmg` and `.pkg` only, and this ships as a tarball. Gatekeeper resolves it online on first run instead. That is still the difference that matters — a quarantined binary that is merely signed is refused outright, while a notarized one is admitted. My first cut of this PR shipped them unsigned on the argument that stapling was impossible; that was a true fact and the wrong conclusion.

Signing follows the desktop build's fail-open rule: without the full secret set the binaries still ship, unsigned, rather than failing the release on a half-configured setup — but now with a `::warning::` in the log, so an expired or removed secret shows up in the run instead of being discovered by a user hitting a Gatekeeper wall. The smoke step also re-verifies the signature on the very file about to be archived.

Windows is unsigned, matching the desktop installer, which #32 tracks. A binary run from a terminal draws a far milder warning than an installer double-clicked in Explorer, and when #32 lands it should cover this binary too.

## Verification

Run locally on Windows against the real workflow steps:

- `cargo build --release --locked -p srelens-tui` succeeds.
- `srelens-tui --version` prints the workspace version and `--help` exits clean — the exact smoke assertions.
- Both packaging paths produce archives with the files at the **root**, so `tar xzf` drops the binary into the working directory rather than a wrapper folder.
- The checksum file round-trips, and all three documented per-platform verify commands were run against a real fixture — GNU `sha256sum`, the Perl `shasum` macOS ships, and the PowerShell `Get-FileHash` comparison — against sums files in both the two-space and `*` binary-marker formats.
- The workflow parses, and the job graph is as intended.

The cross-compiled legs are proven by the first dev pre-release this runs on, which is the only place six runners exist.

## One bug fixed on the way, one deferred

Shipping a Windows binary for the first time exposed two Windows-only defects that predate this PR. Both were found by review, not by me.

**Fixed here — the kubeconfig was never found on Windows.** `default_kubeconfig_paths()` read `HOME`, which is not part of the Windows environment, so it came back empty and the default resolved to a RELATIVE `.kube/config`, searched in whatever directory the app was started from. Measured from a stock PowerShell with `HOME` and `KUBECONFIG` unset, run from outside the repo: **0 contexts before, 2 after**. `HOME` is still read first so a deliberate override keeps working and Unix behaviour is untouched; `dirs::home_dir()` is the fallback. The desktop app calls the same function and has had the same blind spot — this PR only made it visible. A release PR should not hand someone a binary that shows no clusters, so this one belonged here.

**Deferred to #445 — `toolbox` reports every tool as missing on Windows.** It resolves executables by spawning `which`, which stock Windows does not have. Swapping in `where.exe` would fix only the top layer: `resolve_on_path` joins a bare program name and never consults PATHEXT, so `helm_binary()` and `toolbox.diagnoseContext` cannot see a `helm.exe` either — that is what the Windows-only test failures in AGENTS.md are. One in-process resolver used by both layers is the right fix, and it is a behaviour change across two crates. The install guide says the command does not work on Windows yet rather than advertising a diagnostic that answers wrongly.

Also corrected: the guide claimed `srelens-tui info` prints cluster reachability. It resolves contexts from the kubeconfig and never opens a connection, so it now says what is configured, not what is reachable.

## Not in scope

An AUR package for the TUI (`aur-publish.yml` packages the desktop app and is stable-only by design) and Homebrew/winget/Scoop (#225, #226 — the TUI should be folded in when those are done). Also deferred: `srelens-tui toolbox` resolves executables by spawning `which`, so it reports every tool as missing on the Windows binary this PR starts shipping. The same blind spot sits a layer down in `resolve_on_path`, which never consults PATHEXT, so `helm_binary()` and `toolbox.diagnoseContext` cannot see a `helm.exe` either — that is what the Windows-only test failures in AGENTS.md are. Fixing it means changing tool resolution across two crates, so it is filed as #445; the install guide says the command does not work on Windows yet rather than advertising a diagnostic that answers wrongly.
