### PR TITLE
feat(tui): add an update command so the binary can update itself

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2029,6 +2029,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -6415,14 +6416,19 @@ dependencies = [
  "clap",
  "crossterm",
  "dirs",
+ "flate2",
  "futures",
  "libc",
  "log",
  "ratatui",
  "regex",
+ "reqwest 0.13.4",
+ "rustls",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2 0.10.9",
  "shlex 1.3.0",
  "similar",
  "srelens-agent",
@@ -6432,10 +6438,12 @@ dependencies = [
  "srelens-mcp",
  "srelens-registry",
  "srelens-streams",
+ "tar",
  "tempfile",
  "tokio",
  "unicode-width 0.2.0",
  "uuid",
+ "zip",
 ]
 
 [[package]]
@@ -9081,15 +9089,35 @@ checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
 dependencies = [
  "arbitrary",
  "crc32fast",
+ "flate2",
  "indexmap 2.14.0",
  "memchr",
+ "zopfli",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zvariant"

--- a/apps/tui/Cargo.toml
+++ b/apps/tui/Cargo.toml
@@ -25,6 +25,20 @@ serde_yaml = "0.9"
 unicode-width = "0.2"
 similar = "2"
 dirs = "6"
+# `update` (#446): fetch the release, verify its checksum, unpack it. Blocking
+# reqwest because the command is a short synchronous script, not part of the
+# event loop; `rustls-no-provider` matches the rest of the workspace, and the
+# provider is installed by `srelens_kube::connect`.
+reqwest = { version = "0.13", default-features = false, features = ["blocking", "rustls-no-provider"] }
+flate2 = "1"
+tar = "0.4"
+zip = { version = "4", default-features = false, features = ["deflate"] }
+sha2 = "0.10"
+semver = "1"
+# Named explicitly because reqwest is built with `rustls-no-provider`, which
+# does NOT resolve one on its own: the first client panics without an installed
+# provider. `ring` to match kube-rs, so the binary links one provider, not two.
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 srelens-capability = { path = "../../crates/capability" }
 srelens-kube = { path = "../../crates/kube" }
 srelens-streams = { path = "../../crates/streams" }

--- a/apps/tui/src/lib.rs
+++ b/apps/tui/src/lib.rs
@@ -7,6 +7,7 @@ pub mod app;
 pub mod commands;
 pub mod deep_link;
 pub mod event;
+pub mod self_update;
 pub mod sink;
 pub mod theme;
 pub mod ui;

--- a/apps/tui/src/main.rs
+++ b/apps/tui/src/main.rs
@@ -554,7 +554,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// Written as a plain synchronous function: it runs before the terminal is
 /// touched and exits, so there is nothing to interleave with.
 fn run_update(check_only: bool) -> Result<(), Box<dyn std::error::Error>> {
-    use srelens_tui::self_update::{self, UpdateError};
+    // `#[tokio::main]` means this function is called ON a runtime worker
+    // thread. `reqwest::blocking` drives its own runtime on a private thread
+    // and parks the caller on a channel until it answers; doing that from a
+    // worker ties up a thread the runtime owns, and reqwest documents using it
+    // from inside a runtime as unsupported. It does not in fact panic here —
+    // the command was run end to end against the real API before this was
+    // written — but there is no reason to depend on that. Nothing in the update
+    // path is async, so it runs on a thread of its own and the question does
+    // not arise.
+    // `String` rather than `Box<dyn Error>`: the boxed trait object is not
+    // `Send`, so it cannot come back across a thread boundary.
+    std::thread::spawn(move || update_off_the_runtime(check_only))
+        .join()
+        .map_err(|_| "the update thread panicked")??;
+    Ok(())
+}
+
+fn update_off_the_runtime(check_only: bool) -> Result<(), String> {
+    use srelens_tui::self_update::{self, Check, UpdateError};
 
     // reqwest is built with `rustls-no-provider`, which does NOT pick a
     // provider on its own: building a client without one panics inside
@@ -604,9 +622,18 @@ fn run_update(check_only: bool) -> Result<(), Box<dyn std::error::Error>> {
     // the quotes and the variant name are noise, and the message is the part
     // that tells the user what to do.
     let plan = match self_update::plan(current, exe.clone(), &fetch) {
-        Ok(Some(plan)) => plan,
-        Ok(None) => {
+        Ok(Check::Available(plan)) => *plan,
+        Ok(Check::UpToDate { .. }) => {
             println!("srelens-tui {current} is the latest release.");
+            return Ok(());
+        }
+        Ok(Check::AheadOfStable { latest }) => {
+            // Only the stable channel was consulted, so all that is known is
+            // that nothing stable is newer. Saying "you are on the latest"
+            // would be a claim about pre-releases that were never checked.
+            println!(
+                "srelens-tui {current} is ahead of the latest stable release ({latest}); there is no stable update to install."
+            );
             return Ok(());
         }
         Err(error) => fail(error),

--- a/apps/tui/src/main.rs
+++ b/apps/tui/src/main.rs
@@ -604,9 +604,6 @@ fn update_off_the_runtime(check_only: bool, channel: Option<String>) -> Result<(
     };
     let exe = std::env::current_exe()
         .map_err(|e| format!("could not find this binary on disk: {e}"))?;
-    // A Windows update leaves the displaced binary behind because the running
-    // process still holds it open. This is the next run.
-    self_update::clear_displaced_binary(&exe);
 
     let fetch = |url: &str| -> Result<Vec<u8>, UpdateError> {
         let client = reqwest::blocking::Client::builder()

--- a/apps/tui/src/main.rs
+++ b/apps/tui/src/main.rs
@@ -71,6 +71,12 @@ pub enum CliCommand {
     Toolbox,
     /// Print version information
     Version,
+    /// Update srelens-tui to the latest release
+    Update {
+        /// Report what an update would do, without changing anything
+        #[arg(long)]
+        check: bool,
+    },
 }
 
 #[tokio::main]
@@ -103,6 +109,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     println!("{}{} -> cluster: {}, server: {}", mark, ctx.display_name, ctx.cluster, ctx.server);
                 }
                 return Ok(());
+            }
+            CliCommand::Update { check } => {
+                return run_update(check);
             }
             CliCommand::Toolbox => {
                 let state = views::ToolboxViewState::new();
@@ -538,4 +547,91 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     terminal.show_cursor()?;
 
     Ok(())
+}
+
+/// `srelens-tui update` — see `self_update` for why each step is where it is.
+///
+/// Written as a plain synchronous function: it runs before the terminal is
+/// touched and exits, so there is nothing to interleave with.
+fn run_update(check_only: bool) -> Result<(), Box<dyn std::error::Error>> {
+    use srelens_tui::self_update::{self, UpdateError};
+
+    // reqwest is built with `rustls-no-provider`, which does NOT pick a
+    // provider on its own: building a client without one panics inside
+    // reqwest's runtime thread, which surfaces as "event loop thread panicked"
+    // and tells the user nothing. Elsewhere in the app a kube client is built
+    // first and leaves a provider installed as a side effect; `update` runs
+    // before anything touches a cluster, so it has to say so itself.
+    //
+    // `ring` to match kube-rs. Installing a SECOND provider would be worse than
+    // installing none: rustls refuses to choose between two and panics on the
+    // first handshake. `Err` here means one is already installed, which is the
+    // state we want.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let current = env!("CARGO_PKG_VERSION");
+    let exe = std::env::current_exe()
+        .map_err(|e| format!("could not find this binary on disk: {e}"))?;
+    // A Windows update leaves the displaced binary behind because the running
+    // process still holds it open. This is the next run.
+    self_update::clear_displaced_binary(&exe);
+
+    let fetch = |url: &str| -> Result<Vec<u8>, UpdateError> {
+        let client = reqwest::blocking::Client::builder()
+            .user_agent(concat!("srelens-tui/", env!("CARGO_PKG_VERSION")))
+            .timeout(std::time::Duration::from_secs(120))
+            .build()
+            .map_err(|e| UpdateError::Download(e.to_string()))?;
+        let response = client
+            .get(url)
+            .send()
+            .map_err(|e| UpdateError::Download(e.to_string()))?;
+        if !response.status().is_success() {
+            return Err(UpdateError::Download(format!(
+                "{} for {url}",
+                response.status()
+            )));
+        }
+        response
+            .bytes()
+            .map(|b| b.to_vec())
+            .map_err(|e| UpdateError::Download(e.to_string()))
+    };
+
+    // Errors are printed here rather than returned. `main` reports a
+    // `Box<dyn Error>` with its DEBUG formatting, so returning one turns a
+    // written-out sentence into `Download("404 Not Found for https://…")` —
+    // the quotes and the variant name are noise, and the message is the part
+    // that tells the user what to do.
+    let plan = match self_update::plan(current, exe.clone(), &fetch) {
+        Ok(Some(plan)) => plan,
+        Ok(None) => {
+            println!("srelens-tui {current} is the latest release.");
+            return Ok(());
+        }
+        Err(error) => fail(error),
+    };
+
+    if check_only {
+        println!(
+            "srelens-tui {} is available (you have {}).\n  {}\nRun `srelens-tui update` to install it.",
+            plan.latest, plan.current, plan.archive_url
+        );
+        return Ok(());
+    }
+
+    println!("Updating srelens-tui {} -> {}…", plan.current, plan.latest);
+    if let Err(error) = self_update::apply(&plan, &fetch) {
+        fail(error);
+    }
+    println!("Installed {} to {}", plan.latest, exe.display());
+    Ok(())
+}
+
+/// Report an update failure the way a command-line tool should: the sentence
+/// the error carries, on stderr, and a non-zero status so a script wrapping
+/// this can tell.
+fn fail(error: srelens_tui::self_update::UpdateError) -> ! {
+    eprintln!("srelens-tui: {error}");
+    std::process::exit(1);
 }

--- a/apps/tui/src/main.rs
+++ b/apps/tui/src/main.rs
@@ -94,11 +94,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // this process IS that displaced file, put it back. A no-op anywhere
     // else, and off Windows entirely.
     if let Ok(exe) = std::env::current_exe() {
-        if let Some(restored) = srelens_tui::self_update::recover_interrupted_update(&exe) {
-            eprintln!(
+        match srelens_tui::self_update::recover_interrupted_update(&exe) {
+            Ok(Some(restored)) => eprintln!(
                 "srelens-tui: an interrupted update left this binary beside its own name; restored it to {}",
                 restored.display()
-            );
+            ),
+            Ok(None) => {}
+            // Needed and failed, which is not the same as nothing to do.
+            // The command path is still missing, so say so rather than
+            // letting someone rediscover it later.
+            Err(why) => eprintln!(
+                "srelens-tui: an interrupted update left this binary at {}, and it could not be moved back: {why}. Rename it yourself to restore the command.",
+                exe.display()
+            ),
         }
     }
 
@@ -621,6 +629,9 @@ fn update_off_the_runtime(check_only: bool, channel: Option<String>) -> Result<(
     };
     let exe = std::env::current_exe()
         .map_err(|e| format!("could not find this binary on disk: {e}"))?;
+    // After a recovery this process is still reported as running from the
+    // displaced name; updating that path would leave the real one alone.
+    let exe = self_update::installed_path(&exe);
 
     let fetch = |url: &str| -> Result<Vec<u8>, UpdateError> {
         let client = reqwest::blocking::Client::builder()

--- a/apps/tui/src/main.rs
+++ b/apps/tui/src/main.rs
@@ -622,6 +622,7 @@ fn update_off_the_runtime(check_only: bool, channel: Option<String>) -> Result<(
     let current = env!("CARGO_PKG_VERSION");
     // Default to the channel this binary came from, so `update` keeps someone
     // where they are instead of quietly moving a dev user onto stable.
+    let requested = channel.is_some();
     let channel = match channel {
         Some(name) => Channel::parse(&name)
             .ok_or_else(|| format!("unknown channel {name:?} — use \"stable\" or \"dev\""))?,
@@ -660,7 +661,7 @@ fn update_off_the_runtime(check_only: bool, channel: Option<String>) -> Result<(
     // written-out sentence into `Download("404 Not Found for https://…")` —
     // the quotes and the variant name are noise, and the message is the part
     // that tells the user what to do.
-    let plan = match self_update::plan(current, channel, exe.clone(), &fetch) {
+    let plan = match self_update::plan(current, channel, requested, exe.clone(), &fetch) {
         Ok(Check::Available(plan)) => *plan,
         Ok(Check::UpToDate { channel, .. }) => {
             println!(
@@ -702,8 +703,13 @@ fn update_off_the_runtime(check_only: bool, channel: Option<String>) -> Result<(
         return Ok(());
     }
 
+    let verb = if self_update::is_newer(&plan.current, &plan.latest) {
+        "Updating"
+    } else {
+        "Switching"
+    };
     println!(
-        "Updating srelens-tui {} -> {} ({} channel)…",
+        "{verb} srelens-tui {} -> {} ({} channel)…",
         plan.current,
         plan.latest,
         channel.as_str()

--- a/apps/tui/src/main.rs
+++ b/apps/tui/src/main.rs
@@ -76,6 +76,10 @@ pub enum CliCommand {
         /// Report what an update would do, without changing anything
         #[arg(long)]
         check: bool,
+        /// Which releases to consider: stable, or the rolling dev
+        /// pre-releases. Defaults to the channel this binary came from.
+        #[arg(long, value_parser = ["stable", "dev"])]
+        channel: Option<String>,
     },
 }
 
@@ -110,8 +114,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
                 return Ok(());
             }
-            CliCommand::Update { check } => {
-                return run_update(check);
+            CliCommand::Update { check, channel } => {
+                return run_update(check, channel);
             }
             CliCommand::Toolbox => {
                 let state = views::ToolboxViewState::new();
@@ -553,7 +557,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///
 /// Written as a plain synchronous function: it runs before the terminal is
 /// touched and exits, so there is nothing to interleave with.
-fn run_update(check_only: bool) -> Result<(), Box<dyn std::error::Error>> {
+fn run_update(
+    check_only: bool,
+    channel: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
     // `#[tokio::main]` means this function is called ON a runtime worker
     // thread. `reqwest::blocking` drives its own runtime on a private thread
     // and parks the caller on a channel until it answers; doing that from a
@@ -565,14 +572,14 @@ fn run_update(check_only: bool) -> Result<(), Box<dyn std::error::Error>> {
     // not arise.
     // `String` rather than `Box<dyn Error>`: the boxed trait object is not
     // `Send`, so it cannot come back across a thread boundary.
-    std::thread::spawn(move || update_off_the_runtime(check_only))
+    std::thread::spawn(move || update_off_the_runtime(check_only, channel))
         .join()
         .map_err(|_| "the update thread panicked")??;
     Ok(())
 }
 
-fn update_off_the_runtime(check_only: bool) -> Result<(), String> {
-    use srelens_tui::self_update::{self, Check, UpdateError};
+fn update_off_the_runtime(check_only: bool, channel: Option<String>) -> Result<(), String> {
+    use srelens_tui::self_update::{self, Channel, Check, UpdateError};
 
     // reqwest is built with `rustls-no-provider`, which does NOT pick a
     // provider on its own: building a client without one panics inside
@@ -588,6 +595,13 @@ fn update_off_the_runtime(check_only: bool) -> Result<(), String> {
     let _ = rustls::crypto::ring::default_provider().install_default();
 
     let current = env!("CARGO_PKG_VERSION");
+    // Default to the channel this binary came from, so `update` keeps someone
+    // where they are instead of quietly moving a dev user onto stable.
+    let channel = match channel {
+        Some(name) => Channel::parse(&name)
+            .ok_or_else(|| format!("unknown channel {name:?} — use \"stable\" or \"dev\""))?,
+        None => Channel::of_version(current),
+    };
     let exe = std::env::current_exe()
         .map_err(|e| format!("could not find this binary on disk: {e}"))?;
     // A Windows update leaves the displaced binary behind because the running
@@ -621,33 +635,54 @@ fn update_off_the_runtime(check_only: bool) -> Result<(), String> {
     // written-out sentence into `Download("404 Not Found for https://…")` —
     // the quotes and the variant name are noise, and the message is the part
     // that tells the user what to do.
-    let plan = match self_update::plan(current, exe.clone(), &fetch) {
+    let plan = match self_update::plan(current, channel, exe.clone(), &fetch) {
         Ok(Check::Available(plan)) => *plan,
-        Ok(Check::UpToDate { .. }) => {
-            println!("srelens-tui {current} is the latest release.");
+        Ok(Check::UpToDate { channel, .. }) => {
+            println!(
+                "srelens-tui {current} is the latest {} release.",
+                channel.as_str()
+            );
             return Ok(());
         }
-        Ok(Check::AheadOfStable { latest }) => {
-            // Only the stable channel was consulted, so all that is known is
-            // that nothing stable is newer. Saying "you are on the latest"
-            // would be a claim about pre-releases that were never checked.
-            println!(
-                "srelens-tui {current} is ahead of the latest stable release ({latest}); there is no stable update to install."
+        Ok(Check::AheadOfChannel { channel, latest }) => {
+            // Only this channel was consulted, so that is all that can be
+            // claimed. Naming the other one turns a dead end into a next step.
+            print!(
+                "srelens-tui {current} is ahead of the latest {} release ({latest}); there is no {} update to install.",
+                channel.as_str(),
+                channel.as_str()
             );
+            match channel {
+                Channel::Stable => println!(" Try `srelens-tui update --channel dev`."),
+                Channel::Dev => println!(),
+            }
             return Ok(());
         }
         Err(error) => fail(error),
     };
 
     if check_only {
+        // The hint has to carry the channel when it is not the default one, or
+        // copying the line installs from a channel the user did not ask about —
+        // which for a stable binary checking dev is the whole point of asking.
+        let flag = if channel == Channel::of_version(current) {
+            String::new()
+        } else {
+            format!(" --channel {}", channel.as_str())
+        };
         println!(
-            "srelens-tui {} is available (you have {}).\n  {}\nRun `srelens-tui update` to install it.",
-            plan.latest, plan.current, plan.archive_url
+            "srelens-tui {} is available (you have {}).\n  {}\nRun `srelens-tui update{}` to install it.",
+            plan.latest, plan.current, plan.archive_url, flag
         );
         return Ok(());
     }
 
-    println!("Updating srelens-tui {} -> {}…", plan.current, plan.latest);
+    println!(
+        "Updating srelens-tui {} -> {} ({} channel)…",
+        plan.current,
+        plan.latest,
+        channel.as_str()
+    );
     if let Err(error) = self_update::apply(&plan, &fetch) {
         fail(error);
     }

--- a/apps/tui/src/main.rs
+++ b/apps/tui/src/main.rs
@@ -85,6 +85,23 @@ pub enum CliCommand {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // BEFORE parsing: clap exits during `--version` and `--help`, which is
+    // exactly what someone whose binary vanished is likely to type first.
+    //
+    // An update interrupted between its two renames leaves this binary at
+    // `.srelens-tui.exe.old` with nothing at the real name — and no way to
+    // run `update` to repair it, since there is nothing left to run. If
+    // this process IS that displaced file, put it back. A no-op anywhere
+    // else, and off Windows entirely.
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(restored) = srelens_tui::self_update::recover_interrupted_update(&exe) {
+            eprintln!(
+                "srelens-tui: an interrupted update left this binary beside its own name; restored it to {}",
+                restored.display()
+            );
+        }
+    }
+
     let cli = Cli::parse();
 
     // Resolved BEFORE the subcommand match, because those arms return early.

--- a/apps/tui/src/self_update.rs
+++ b/apps/tui/src/self_update.rs
@@ -732,10 +732,27 @@ fn world_writable_without_sticky(_dir: &Path) -> bool {
 /// nothing left to run. What they CAN run is the displaced file itself, so
 /// every start checks whether that is what is happening and repairs it.
 ///
-/// Returns where it restored the binary to, so the caller can say so.
+/// `Ok(None)` means there was nothing to recover, which is the ordinary
+/// case. An `Err` means recovery was NEEDED and failed — a different thing
+/// entirely, and one the caller has to say out loud: the command path is
+/// still missing, so staying quiet would leave someone with a broken
+/// install and no clue why.
+///
 /// Deliberately narrow: it acts only when this process IS the displaced
 /// file and the real name is free, which cannot be true in ordinary use.
-pub fn recover_interrupted_update(exe: &Path) -> Option<PathBuf> {
+pub fn recover_interrupted_update(exe: &Path) -> Result<Option<PathBuf>, UpdateError> {
+    let Some(target) = displaced_original(exe) else {
+        return Ok(None);
+    };
+    // Windows allows renaming a running image, which is the same property
+    // the update itself relies on.
+    std::fs::rename(exe, &target).map_err(io)?;
+    Ok(Some(target))
+}
+
+/// The name this binary should have, if it is sitting under the displaced
+/// one with the real name free.
+fn displaced_original(exe: &Path) -> Option<PathBuf> {
     if !cfg!(windows) {
         return None;
     }
@@ -745,12 +762,27 @@ pub fn recover_interrupted_update(exe: &Path) -> Option<PathBuf> {
         return None;
     }
     let target = exe.with_file_name(restored);
-    if target.exists() {
-        return None;
-    }
-    // Windows allows renaming a running image, which is the same property
-    // the update itself relies on.
-    std::fs::rename(exe, &target).ok().map(|()| target)
+    (!target.exists()).then_some(target)
+}
+
+/// Where the installed binary lives, given the path this process started
+/// from.
+///
+/// After a recovery renames us back, `current_exe` still reports the path
+/// the image was loaded from — the displaced one. An update that trusted
+/// that would stage beside `.<binary>.old` and rename onto it, leaving the
+/// command path untouched and the mess intact.
+pub fn installed_path(exe: &Path) -> PathBuf {
+    let displaced = || -> Option<PathBuf> {
+        let name = exe.file_name()?.to_str()?;
+        let restored = name.strip_prefix(".")?.strip_suffix(".old")?;
+        if restored != BIN {
+            return None;
+        }
+        let target = exe.with_file_name(restored);
+        target.exists().then_some(target)
+    };
+    displaced().unwrap_or_else(|| exe.to_path_buf())
 }
 
 /// Confirm the file at `path` still holds exactly `bytes`.
@@ -878,6 +910,21 @@ fn set_executable(_path: &Path) -> Result<(), UpdateError> {
 mod tests {
     use super::create_new_file;
 
+    /// `umask` is process-global, and unit tests share a process. Every
+    /// test in this module that creates a file takes this first, so the one
+    /// that changes the mask cannot hand a permissive default to another
+    /// test's file — which would make the suite depend on thread timing
+    /// rather than on the code.
+    static FILE_TESTS: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn file_test_lock() -> std::sync::MutexGuard<'static, ()> {
+        // A panicking test poisons the mutex; the next one wants the lock,
+        // not the panic.
+        FILE_TESTS
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
     /// The staged file must be private to its owner from the instant it
     /// exists, not from the moment its mode is corrected.
     ///
@@ -893,6 +940,7 @@ mod tests {
     fn a_staged_file_is_created_private_to_its_owner() {
         use std::os::unix::fs::PermissionsExt;
 
+        let _guard = file_test_lock();
         let dir = tempfile::tempdir().expect("temp dir");
         let previous = unsafe { libc::umask(0) };
         let created = create_new_file(dir.path(), ".probe-");
@@ -913,6 +961,7 @@ mod tests {
     fn a_staged_file_that_changed_underneath_us_is_refused() {
         use super::{assert_staged_is_unchanged, UpdateError};
 
+        let _guard = file_test_lock();
         let dir = tempfile::tempdir().expect("temp dir");
         let path = dir.path().join("staged");
 
@@ -952,6 +1001,7 @@ mod tests {
         use super::world_writable_without_sticky;
         use std::os::unix::fs::PermissionsExt;
 
+        let _guard = file_test_lock();
         let dir = tempfile::tempdir().expect("temp dir");
         let set = |mode: u32| {
             std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(mode))
@@ -989,6 +1039,7 @@ mod tests {
     /// rather than derived from the process id.
     #[test]
     fn staged_files_do_not_reuse_a_name() {
+        let _guard = file_test_lock();
         let dir = tempfile::tempdir().expect("temp dir");
         let (first, _a) = create_new_file(dir.path(), ".probe-").expect("first");
         let (second, _b) = create_new_file(dir.path(), ".probe-").expect("second");

--- a/apps/tui/src/self_update.rs
+++ b/apps/tui/src/self_update.rs
@@ -643,37 +643,49 @@ pub fn replace_running_binary(target: &Path, bytes: &[u8]) -> Result<(), UpdateE
     // see `create_new_file`. Writing through a planted symlink here would
     // put a downloaded executable wherever the link pointed.
     let (staged, mut file) = create_new_file(dir, &format!(".{BIN}.new-"))?;
-    let written = file
-        .write_all(bytes)
+    // From here every exit removes the staged file, including the ones added
+    // later by someone who did not read this far. It used to be a cleanup line
+    // per early return, and the one that got missed leaked a whole downloaded
+    // binary on each attempt — with random names now, those accumulate rather
+    // than overwrite. After a successful rename the path is gone and the
+    // removal is a no-op, so the success path needs no special case either.
+    let staged = Staged(staged);
+
+    file.write_all(bytes)
         .and_then(|()| file.sync_all())
-        .map_err(io);
+        .map_err(io)?;
     drop(file);
-    if let Err(e) = written {
-        let _ = std::fs::remove_file(&staged);
-        return Err(e);
-    }
-    set_executable(&staged)?;
+    set_executable(&staged.0)?;
 
     if cfg!(windows) {
         let displaced = dir.join(format!("{BIN}.old"));
         let _ = std::fs::remove_file(&displaced);
-        if let Err(e) = std::fs::rename(target, &displaced) {
-            let _ = std::fs::remove_file(&staged);
-            return Err(io(e));
-        }
-        if let Err(e) = std::fs::rename(&staged, target) {
+        std::fs::rename(target, &displaced).map_err(io)?;
+        if let Err(e) = std::fs::rename(&staged.0, target) {
             // Put the original back rather than leaving the user with nothing.
             let _ = std::fs::rename(&displaced, target);
-            let _ = std::fs::remove_file(&staged);
             return Err(io(e));
         }
         // Fails while this process holds the image open; the next run clears it.
         let _ = std::fs::remove_file(&displaced);
-    } else if let Err(e) = std::fs::rename(&staged, target) {
-        let _ = std::fs::remove_file(&staged);
-        return Err(io(e));
+    } else {
+        std::fs::rename(&staged.0, target).map_err(io)?;
     }
     Ok(())
+}
+
+/// A staged download that deletes itself unless it was renamed into place.
+///
+/// The point is that no future early return can forget: a half-finished
+/// update leaves nothing behind whichever way it failed.
+struct Staged(PathBuf);
+
+impl Drop for Staged {
+    fn drop(&mut self) {
+        // A no-op once the file has been renamed away, which is the
+        // successful case.
+        let _ = std::fs::remove_file(&self.0);
+    }
 }
 
 #[cfg(unix)]

--- a/apps/tui/src/self_update.rs
+++ b/apps/tui/src/self_update.rs
@@ -106,6 +106,9 @@ pub enum UpdateError {
     },
     /// The binary's directory cannot be written to by this user.
     NotWritable { path: PathBuf },
+    /// The binary lives somewhere anyone on the machine can write, which no
+    /// amount of care during the update can compensate for.
+    UnsafeDirectory { path: PathBuf },
     /// The staged download changed between being written and being
     /// installed — someone else can write to the directory.
     StagedChanged,
@@ -153,6 +156,11 @@ impl fmt::Display for UpdateError {
             Self::NotWritable { path } => write!(
                 f,
                 "cannot write to {} — re-run with the rights to change it, or install srelens-tui somewhere you own",
+                path.display()
+            ),
+            Self::UnsafeDirectory { path } => write!(
+                f,
+                "anyone on this machine can create files in {}, so an update there cannot be made safe — move srelens-tui somewhere only you can write, then update",
                 path.display()
             ),
             Self::StagedChanged => write!(
@@ -589,6 +597,11 @@ pub fn apply(
         });
     }
     let dir = plan.target.parent().unwrap_or_else(|| Path::new("."));
+    if world_writable_without_sticky(dir) {
+        return Err(UpdateError::UnsafeDirectory {
+            path: dir.to_path_buf(),
+        });
+    }
     if !writable_dir(dir) {
         return Err(UpdateError::NotWritable {
             path: dir.to_path_buf(),
@@ -669,6 +682,44 @@ fn writable_dir(dir: &Path) -> bool {
     }
 }
 
+/// Whether anyone on the machine can create and replace entries in `dir`.
+///
+/// Where that is true, no amount of care with temporary files makes an
+/// update safe: writing and renaming are separate operations on a NAME, and
+/// on Unix there is no way to rename by file descriptor, so the path can
+/// always be swapped between the last check and the rename. The read-back
+/// before replacement narrows that to a race an attacker must win, but a
+/// race is not a guarantee. Refusing is the only honest answer.
+///
+/// The test is deliberately WORLD-writable and not sticky, not merely
+/// group-writable. A group-writable install directory is an ordinary
+/// configuration — `/usr/local/bin` belongs to `admin` on macOS — and group
+/// membership is a trust decision someone already made. World-writable
+/// without the sticky bit is not a place to keep an executable, and saying
+/// so beats pretending the update was safe. The sticky bit is what makes
+/// `/tmp` acceptable: entries there can only be removed by their owner.
+#[cfg(unix)]
+fn world_writable_without_sticky(dir: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    match std::fs::metadata(dir) {
+        Ok(meta) => {
+            let mode = meta.permissions().mode();
+            mode & 0o002 != 0 && mode & 0o1000 == 0
+        }
+        // Unreadable metadata is not evidence of a problem; the write probe
+        // below will fail on its own if the directory is unusable.
+        Err(_) => false,
+    }
+}
+
+/// Windows has no equivalent this cheap. Its ACLs would need a real query,
+/// and the common failure there — a directory a package manager owns — is
+/// already caught by `package_manager_for`.
+#[cfg(not(unix))]
+fn world_writable_without_sticky(_dir: &Path) -> bool {
+    false
+}
+
 /// Confirm the file at `path` still holds exactly `bytes`.
 ///
 /// Split out so it can be tested directly: the race it defends against
@@ -732,7 +783,14 @@ pub fn replace_running_binary(target: &Path, bytes: &[u8]) -> Result<(), UpdateE
     assert_staged_is_unchanged(&staged.0, bytes)?;
 
     if cfg!(windows) {
-        let displaced = dir.join(format!("{BIN}.old"));
+        // Dot-prefixed, matching the staging files, so this is plainly the
+        // updater's and not something a person put here. The previous name
+        // was `<binary>.old`, which is exactly what someone would call a
+        // backup they made themselves — and it was removed unconditionally,
+        // so a real update destroyed it. `fs::rename` overwrites on Windows
+        // too, so choosing a name nobody else would pick is the fix, not the
+        // explicit removal.
+        let displaced = dir.join(format!(".{BIN}.old"));
         let _ = std::fs::remove_file(&displaced);
         std::fs::rename(target, &displaced).map_err(io)?;
         if let Err(e) = std::fs::rename(&staged.0, target) {
@@ -848,6 +906,50 @@ mod tests {
             assert_staged_is_unchanged(&path, b"the verified bytes"),
             Err(UpdateError::Io(_))
         ));
+    }
+
+    /// A directory anyone can write to is refused; the ordinary ones are not.
+    ///
+    /// The group-writable case is the one worth pinning: `/usr/local/bin` is
+    /// group-writable on macOS, so refusing it would break a normal install
+    /// rather than protect anyone.
+    #[cfg(unix)]
+    #[test]
+    fn only_a_directory_anyone_can_write_to_is_refused() {
+        use super::world_writable_without_sticky;
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let set = |mode: u32| {
+            std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(mode))
+                .expect("set mode");
+        };
+
+        set(0o755);
+        assert!(!world_writable_without_sticky(dir.path()), "0755 is fine");
+
+        set(0o775);
+        assert!(
+            !world_writable_without_sticky(dir.path()),
+            "group-writable is an ordinary configuration, not a refusal"
+        );
+
+        set(0o777);
+        assert!(
+            world_writable_without_sticky(dir.path()),
+            "world-writable without the sticky bit must be refused"
+        );
+
+        // The sticky bit is what makes /tmp acceptable: only an entry's
+        // owner may remove it, so the swap this guards against cannot
+        // happen.
+        set(0o1777);
+        assert!(
+            !world_writable_without_sticky(dir.path()),
+            "sticky world-writable is how /tmp is set up"
+        );
+
+        set(0o755);
     }
 
     /// Two calls never collide, which is what lets the name be unpredictable

--- a/apps/tui/src/self_update.rs
+++ b/apps/tui/src/self_update.rs
@@ -483,32 +483,41 @@ pub fn is_newer(current: &str, latest: &str) -> bool {
 /// database would still name the old version, and the next upgrade would put
 /// it back. The desktop app already declines for AUR on the same grounds.
 pub fn package_manager_for(path: &Path) -> Option<&'static str> {
-    // Lower-cased because Windows paths are case-insensitive and the real
-    // Chocolatey root is `C:\\ProgramData\\chocolatey` — a case-sensitive
-    // match against `Chocolatey` never fired, so a Chocolatey-managed copy
-    // sailed past this guard and would have been overwritten. Unix paths are
-    // case-sensitive, so this can in principle over-match there; refusing to
-    // update with a named manager is the safe direction to be wrong in.
-    let text = path.to_string_lossy().replace('\\', "/").to_lowercase();
-    // Ordered longest-prefix-first where they nest, so a Cellar path is not
-    // reported as the more general /usr/local.
-    let owners: &[(&str, &str)] = &[
-        // Lower-case, to match the normalisation above.
+    let text = path.to_string_lossy().replace('\\', "/");
+
+    // Roots a package manager owns, matched as PREFIXES. Matching them
+    // anywhere was wrong: `/home/me/rootfs/usr/bin/srelens-tui` is a file its
+    // owner controls, and calling it distribution-managed refused to update
+    // it. Compared case-sensitively, because `/usr/bin` and `/USR/BIN` are
+    // different directories on Unix.
+    const ROOTS: &[(&str, &str)] = &[
         ("/opt/homebrew/", "Homebrew"),
         ("/home/linuxbrew/.linuxbrew/", "Homebrew"),
-        ("/usr/local/cellar/", "Homebrew"),
+        ("/usr/local/Cellar/", "Homebrew"),
         ("/usr/bin/", "your distribution's package manager"),
         ("/snap/", "snap"),
         ("/var/lib/flatpak/", "Flatpak"),
         ("/nix/store/", "Nix"),
+    ];
+    if let Some((_, manager)) = ROOTS.iter().find(|(root, _)| text.starts_with(root)) {
+        return Some(manager);
+    }
+
+    // Windows package roots sit at varying depths — under a user profile, or
+    // ProgramData — so they are matched anywhere rather than anchored, and
+    // folded to one case because Windows paths are case-insensitive. The real
+    // Chocolatey root is `C:\\ProgramData\\chocolatey`, lower case, which a
+    // case-sensitive match missed entirely.
+    const WINDOWS_MARKERS: &[(&str, &str)] = &[
         ("/scoop/apps/", "Scoop"),
         ("/scoop/shims/", "Scoop"),
         ("/winget/packages/", "winget"),
         ("/chocolatey/", "Chocolatey"),
     ];
-    owners
+    let folded = text.to_lowercase();
+    WINDOWS_MARKERS
         .iter()
-        .find(|(prefix, _)| text.contains(prefix))
+        .find(|(marker, _)| folded.contains(marker))
         .map(|(_, manager)| *manager)
 }
 

--- a/apps/tui/src/self_update.rs
+++ b/apps/tui/src/self_update.rs
@@ -514,6 +514,13 @@ pub fn package_manager_for(path: &Path) -> Option<&'static str> {
         ("/winget/packages/", "winget"),
         ("/chocolatey/", "Chocolatey"),
     ];
+    // Only on Windows. Applied everywhere, `/home/me/scoop/apps/demo/...`
+    // on Linux read as Scoop-owned and the update was refused before
+    // anything was downloaded — these names mean a package manager on one
+    // platform and nothing in particular on the others.
+    if !cfg!(windows) {
+        return None;
+    }
     let folded = text.to_lowercase();
     WINDOWS_MARKERS
         .iter()
@@ -554,9 +561,15 @@ pub enum Check {
 
 /// Resolve the latest stable release and decide whether it is worth
 /// downloading. Not finding an update is a normal outcome, not a failure.
+/// `requested` is whether the caller NAMED this channel rather than
+/// falling into it. It is the difference between "nothing newer here" and
+/// "put me on this channel": a dev build sorts above the stable release, so
+/// without it `--channel stable` could never do the switch the install
+/// guide promises.
 pub fn plan(
     current: &str,
     channel: Channel,
+    requested: bool,
     target: PathBuf,
     fetch: &impl Fn(&str) -> Result<Vec<u8>, UpdateError>,
 ) -> Result<Check, UpdateError> {
@@ -566,7 +579,10 @@ pub fn plan(
         Channel::Stable => parse_latest_version(&body, triple)?,
         Channel::Dev => parse_newest_version(&body, triple)?,
     };
-    if !is_newer(current, &latest) {
+    // Asking for a channel by name means asking to be ON it, even where
+    // that means going backwards — the usual case, since any dev build
+    // sorts above the stable release it was cut after.
+    if !is_newer(current, &latest) && !(requested && current != latest) {
         // An unparseable current version lands here too, and is reported as
         // up to date rather than ahead: claiming to be ahead of a release we
         // could not compare against would be the same overclaim in reverse.
@@ -782,6 +798,14 @@ fn displaced_original(exe: &Path) -> Option<PathBuf> {
 /// that would stage beside `.<binary>.old` and rename onto it, leaving the
 /// command path untouched and the mess intact.
 pub fn installed_path(exe: &Path) -> PathBuf {
+    // Windows only, matching the recovery it exists to follow. Applied on
+    // Unix it would take someone running a backup they named
+    // `.srelens-tui.old` and update the sibling instead — replacing a
+    // binary they did not invoke, which is the one promise this command
+    // makes about what it touches.
+    if !cfg!(windows) {
+        return exe.to_path_buf();
+    }
     let displaced = || -> Option<PathBuf> {
         let name = exe.file_name()?.to_str()?;
         let restored = name.strip_prefix(".")?.strip_suffix(".old")?;

--- a/apps/tui/src/self_update.rs
+++ b/apps/tui/src/self_update.rs
@@ -115,7 +115,10 @@ impl fmt::Display for UpdateError {
                 f,
                 "no srelens-tui release is built for {os}/{arch} — build from source with `cargo build --release -p srelens-tui`"
             ),
-            Self::BadRelease(why) => write!(f, "could not read the latest release: {why}"),
+            // No prefix: these messages are whole sentences, and a "could not
+            // read" preamble was actively wrong for the common case, where the
+            // release reads fine and simply carries no build for this platform.
+            Self::BadRelease(why) => write!(f, "{why}"),
             Self::ChecksumMissing { asset } => write!(
                 f,
                 "the release's checksum file does not list {asset}, so the download cannot be verified"
@@ -206,39 +209,74 @@ pub fn asset_url(version: &str, file: &str) -> String {
     format!("{DOWNLOAD_BASE}/srelens-v{version}/{file}")
 }
 
-/// The version of the latest release, from the API's JSON.
+/// The version a release tag names, or nothing if the tag is not one of ours
+/// or does not carry a version.
+///
+/// Parsed, not merely non-empty. A tag like `srelens-vnightly` would
+/// otherwise pass, fail to compare later, and be reported as "you are on the
+/// latest" — turning broken release metadata into a confident answer about
+/// the user's version, which is the one thing this command must not do.
+fn version_from_tag(tag: &str) -> Option<String> {
+    let version = tag.strip_prefix("srelens-v")?;
+    semver::Version::parse(version).ok()?;
+    Some(version.to_string())
+}
+
+/// Whether a release actually carries the two files an update needs for this
+/// platform: the archive and the checksum file listing it.
+///
+/// A dev pre-release is published the moment it builds (`releaseDraft: false`
+/// in the release workflow), so if the TUI matrix or `tui-publish` fails
+/// afterwards the tag is public with no archives on it. Resolving to it would
+/// promise an update and then 404 on the download. Every release cut before
+/// the TUI shipped at all looks the same from here.
+fn release_carries_this_platform(release: &serde_json::Value, version: &str, triple: &str) -> bool {
+    let Some(assets) = release.get("assets").and_then(|a| a.as_array()) else {
+        return false;
+    };
+    let names: Vec<&str> = assets
+        .iter()
+        .filter_map(|a| a.get("name").and_then(|n| n.as_str()))
+        .collect();
+    let archive = asset_name(version, triple);
+    let sums = sums_name(version);
+    names.contains(&archive.as_str()) && names.contains(&sums.as_str())
+}
+
+/// The version of the latest stable release, from the API's JSON.
 ///
 /// Tags are `srelens-v<version>`; the prefix is stripped so the rest of the
 /// module deals in versions only.
-pub fn parse_latest_version(body: &[u8]) -> Result<String, UpdateError> {
+pub fn parse_latest_version(body: &[u8], triple: &str) -> Result<String, UpdateError> {
     let value: serde_json::Value = serde_json::from_slice(body)
         .map_err(|e| UpdateError::BadRelease(format!("the API did not return JSON: {e}")))?;
     let tag = value
         .get("tag_name")
         .and_then(|t| t.as_str())
         .ok_or_else(|| UpdateError::BadRelease("no tag_name in the response".into()))?;
-    let version = tag
-        .strip_prefix("srelens-v")
+    let version = version_from_tag(tag)
         .ok_or_else(|| UpdateError::BadRelease(format!("unexpected tag {tag}")))?;
-    // Parsed, not merely non-empty. A tag like `srelens-vnightly` would
-    // otherwise pass here, fail to compare later, and be reported as
-    // "you are on the latest" — turning broken release metadata into a
-    // confident answer about the user's version, which is the one thing
-    // this command must not do.
-    semver::Version::parse(version)
-        .map_err(|e| UpdateError::BadRelease(format!("tag {tag} is not a version: {e}")))?;
-    Ok(version.to_string())
+    // Unlike the dev list there is nothing else to fall back to here, so a
+    // release without the archives is reported rather than skipped. Saying so
+    // now beats promising an update and 404ing on the download.
+    if !release_carries_this_platform(&value, &version, triple) {
+        return Err(UpdateError::BadRelease(format!(
+            "release {tag} carries no srelens-tui build for {triple}"
+        )));
+    }
+    Ok(version)
 }
 
 /// The newest version in a releases LIST, which is how the dev channel is
 /// resolved: pre-releases are what it is made of, so the stable endpoint
 /// cannot see them.
 ///
-/// GitHub returns the list newest first. Three kinds of entry are skipped:
+/// GitHub returns the list newest first. Four kinds of entry are skipped:
 /// anything not tagged `srelens-v…`; `dev-channel`, a permanent rolling
 /// pre-release carrying only the desktop updater's manifest and none of the
-/// TUI archives; and stable releases, which belong to the other channel.
-pub fn parse_newest_version(body: &[u8]) -> Result<String, UpdateError> {
+/// TUI archives; stable releases, which belong to the other channel; and any
+/// release that does not actually carry a build for this platform.
+pub fn parse_newest_version(body: &[u8], triple: &str) -> Result<String, UpdateError> {
     let releases: Vec<serde_json::Value> = serde_json::from_slice(body)
         .map_err(|e| UpdateError::BadRelease(format!("the API did not return a list: {e}")))?;
     for release in releases {
@@ -261,20 +299,25 @@ pub fn parse_newest_version(body: &[u8]) -> Result<String, UpdateError> {
         {
             continue;
         }
-        // Unlike the single-release endpoint, a tag that is not a version is
-        // SKIPPED here rather than failing the command: this is a list, so
-        // there is a next entry to try, and one odd tag should not stop a
-        // dev user updating. Failing is right only where there is no
-        // alternative to fall back to.
-        if let Some(version) = tag.strip_prefix("srelens-v") {
-            if semver::Version::parse(version).is_ok() {
-                return Ok(version.to_string());
-            }
+        // Unlike the single-release endpoint, anything unusable is SKIPPED
+        // here rather than failing the command: this is a list, so there is a
+        // next entry to try, and one bad release should not stop a dev user
+        // updating. Failing is right only where there is no alternative.
+        let Some(version) = version_from_tag(tag) else {
+            continue;
+        };
+        if !release_carries_this_platform(&release, &version, triple) {
+            continue;
         }
+        return Ok(version);
     }
-    Err(UpdateError::BadRelease(
-        "no srelens release found in the list".into(),
-    ))
+    // Accurate about which step came up empty: the list was read fine, it just
+    // holds nothing installable here. Naming the platform matters because the
+    // usual cause is a release whose build for THIS target failed while the
+    // others published.
+    Err(UpdateError::BadRelease(format!(
+        "no dev release carries a srelens-tui build for {triple}"
+    )))
 }
 
 /// Look one archive up in a `sha256sum`-format file.
@@ -478,8 +521,8 @@ pub fn plan(
     let triple = current_triple()?;
     let body = fetch(channel.url())?;
     let latest = match channel {
-        Channel::Stable => parse_latest_version(&body)?,
-        Channel::Dev => parse_newest_version(&body)?,
+        Channel::Stable => parse_latest_version(&body, triple)?,
+        Channel::Dev => parse_newest_version(&body, triple)?,
     };
     if !is_newer(current, &latest) {
         // An unparseable current version lands here too, and is reported as

--- a/apps/tui/src/self_update.rs
+++ b/apps/tui/src/self_update.rs
@@ -1,0 +1,474 @@
+//! `srelens-tui update` — move this binary to the latest stable release.
+//!
+//! The desktop app updates itself from Settings; the TUI is a loose binary on
+//! someone's `PATH`, so it has to do the same job by hand. The shape here is
+//! the one `crates/kube/src/toolbox_install.rs` already uses for kubectl and
+//! helm: every decision is a pure function over strings, and the one step that
+//! touches the network takes an injected `fetch`, so the whole path is tested
+//! without a request.
+//!
+//! Two rules the code is built around, both of them about not leaving someone
+//! worse off than before they ran it:
+//!
+//! - Nothing is written until the download's SHA-256 matches the checksum the
+//!   release publishes. A corrupt or substituted archive never reaches the
+//!   path the user runs.
+//! - The final step is always a rename, never a copy into place, so an
+//!   interrupted update cannot produce a half-written binary.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+/// Where the release metadata and assets live. `releases/latest` is the
+/// GitHub endpoint that skips pre-releases, which is what makes this the
+/// stable channel without any filtering of our own.
+pub const LATEST_RELEASE_URL: &str = "https://api.github.com/repos/srelens/srelens/releases/latest";
+const DOWNLOAD_BASE: &str = "https://github.com/srelens/srelens/releases/download";
+
+/// The name of the binary inside every archive, and on disk.
+const BIN: &str = if cfg!(windows) {
+    "srelens-tui.exe"
+} else {
+    "srelens-tui"
+};
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum UpdateError {
+    /// No release archive is built for this OS/architecture.
+    UnsupportedPlatform { os: String, arch: String },
+    /// The release API answered with something unparseable.
+    BadRelease(String),
+    /// The checksum file did not list the archive we downloaded.
+    ChecksumMissing { asset: String },
+    /// The archive's hash is not the published one.
+    ChecksumMismatch { expected: String, actual: String },
+    /// The archive did not contain the binary.
+    BinaryMissing { asset: String },
+    /// A download failed; retrying may work.
+    Download(String),
+    /// The archive could not be opened.
+    Archive(String),
+    /// Something on disk refused.
+    Io(String),
+    /// The binary belongs to a package manager, which should do the updating.
+    PackageManaged {
+        manager: &'static str,
+        path: PathBuf,
+    },
+    /// The binary's directory cannot be written to by this user.
+    NotWritable { path: PathBuf },
+}
+
+impl fmt::Display for UpdateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedPlatform { os, arch } => write!(
+                f,
+                "no srelens-tui release is built for {os}/{arch} — build from source with `cargo build --release -p srelens-tui`"
+            ),
+            Self::BadRelease(why) => write!(f, "could not read the latest release: {why}"),
+            Self::ChecksumMissing { asset } => write!(
+                f,
+                "the release's checksum file does not list {asset}, so the download cannot be verified"
+            ),
+            Self::ChecksumMismatch { expected, actual } => write!(
+                f,
+                "the download does not match its published checksum (expected {expected}, got {actual}) — nothing was changed"
+            ),
+            Self::BinaryMissing { asset } => {
+                write!(f, "{asset} does not contain {BIN}")
+            }
+            Self::Download(why) => write!(f, "download failed: {why}"),
+            Self::Archive(why) => write!(f, "could not read the downloaded archive: {why}"),
+            Self::Io(why) => write!(f, "{why}"),
+            Self::PackageManaged { manager, path } => write!(
+                f,
+                "{} installed this copy ({}), so let it do the upgrade — srelens will not write over a file a package manager owns",
+                manager,
+                path.display()
+            ),
+            Self::NotWritable { path } => write!(
+                f,
+                "cannot write to {} — re-run with the rights to change it, or install srelens-tui somewhere you own",
+                path.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for UpdateError {}
+
+fn io(e: std::io::Error) -> UpdateError {
+    UpdateError::Io(e.to_string())
+}
+
+/// The release-asset triple for an OS/arch, and whether the binary is linked
+/// against musl.
+///
+/// `musl` is the running binary's own libc, not a preference: a musl build
+/// exists because the host cannot run the glibc one, so updating it to a glibc
+/// archive would hand the user a binary that no longer starts. The caller
+/// passes `cfg!(target_env = "musl")`, which is decided when THIS binary was
+/// compiled.
+pub fn triple_for(os: &str, arch: &str, musl: bool) -> Result<&'static str, UpdateError> {
+    let unsupported = || UpdateError::UnsupportedPlatform {
+        os: os.to_string(),
+        arch: arch.to_string(),
+    };
+    match (os, arch, musl) {
+        ("linux", "x86_64", false) => Ok("x86_64-unknown-linux-gnu"),
+        ("linux", "x86_64", true) => Ok("x86_64-unknown-linux-musl"),
+        ("linux", "aarch64", false) => Ok("aarch64-unknown-linux-gnu"),
+        ("linux", "aarch64", true) => Ok("aarch64-unknown-linux-musl"),
+        ("macos", "x86_64", _) => Ok("x86_64-apple-darwin"),
+        ("macos", "aarch64", _) => Ok("aarch64-apple-darwin"),
+        ("windows", "x86_64", _) => Ok("x86_64-pc-windows-msvc"),
+        _ => Err(unsupported()),
+    }
+}
+
+/// The triple for the binary that is running.
+pub fn current_triple() -> Result<&'static str, UpdateError> {
+    triple_for(
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+        cfg!(target_env = "musl"),
+    )
+}
+
+/// The asset filename for a version and triple. Windows ships a `.zip`;
+/// everything else a `.tar.gz`.
+pub fn asset_name(version: &str, triple: &str) -> String {
+    let ext = if triple.contains("windows") {
+        "zip"
+    } else {
+        "tar.gz"
+    };
+    format!("srelens-tui-{version}-{triple}.{ext}")
+}
+
+/// The checksum file published beside the archives.
+pub fn sums_name(version: &str) -> String {
+    format!("srelens-tui-{version}-SHA256SUMS.txt")
+}
+
+/// A release asset's download URL.
+pub fn asset_url(version: &str, file: &str) -> String {
+    format!("{DOWNLOAD_BASE}/srelens-v{version}/{file}")
+}
+
+/// The version of the latest release, from the API's JSON.
+///
+/// Tags are `srelens-v<version>`; the prefix is stripped so the rest of the
+/// module deals in versions only.
+pub fn parse_latest_version(body: &[u8]) -> Result<String, UpdateError> {
+    let value: serde_json::Value = serde_json::from_slice(body)
+        .map_err(|e| UpdateError::BadRelease(format!("the API did not return JSON: {e}")))?;
+    let tag = value
+        .get("tag_name")
+        .and_then(|t| t.as_str())
+        .ok_or_else(|| UpdateError::BadRelease("no tag_name in the response".into()))?;
+    let version = tag
+        .strip_prefix("srelens-v")
+        .ok_or_else(|| UpdateError::BadRelease(format!("unexpected tag {tag}")))?;
+    if version.is_empty() {
+        return Err(UpdateError::BadRelease(format!(
+            "empty version in tag {tag}"
+        )));
+    }
+    Ok(version.to_string())
+}
+
+/// Look one archive up in a `sha256sum`-format file.
+///
+/// Both spellings appear in the wild and the release has shipped each: GNU
+/// writes `<hash>  <name>` and binary mode writes `<hash> *<name>`. Matching
+/// the trailing name rather than splitting on a fixed column handles both.
+pub fn checksum_for(sums: &str, asset: &str) -> Result<String, UpdateError> {
+    for line in sums.lines() {
+        let mut parts = line.split_whitespace();
+        let (Some(hash), Some(name)) = (parts.next(), parts.next()) else {
+            continue;
+        };
+        let name = name.strip_prefix('*').unwrap_or(name);
+        if name == asset {
+            if hash.len() == 64 && hash.bytes().all(|b| b.is_ascii_hexdigit()) {
+                return Ok(hash.to_ascii_lowercase());
+            }
+            return Err(UpdateError::ChecksumMissing {
+                asset: asset.to_string(),
+            });
+        }
+    }
+    Err(UpdateError::ChecksumMissing {
+        asset: asset.to_string(),
+    })
+}
+
+/// Verify `bytes` against an expected hex SHA-256.
+pub fn verify_sha256(bytes: &[u8], expected_hex: &str) -> Result<(), UpdateError> {
+    use sha2::{Digest, Sha256};
+    let actual = format!("{:x}", Sha256::digest(bytes));
+    if actual.eq_ignore_ascii_case(expected_hex) {
+        Ok(())
+    } else {
+        Err(UpdateError::ChecksumMismatch {
+            expected: expected_hex.to_ascii_lowercase(),
+            actual,
+        })
+    }
+}
+
+/// Pull the binary out of a downloaded archive, choosing the reader by the
+/// asset's extension rather than by the host, so a test can exercise both.
+pub fn extract_binary(archive: &[u8], asset: &str) -> Result<Vec<u8>, UpdateError> {
+    if asset.ends_with(".zip") {
+        extract_from_zip(archive, asset)
+    } else {
+        extract_from_targz(archive, asset)
+    }
+}
+
+fn extract_from_targz(archive: &[u8], asset: &str) -> Result<Vec<u8>, UpdateError> {
+    use std::io::Read;
+    let decoder = flate2::read::GzDecoder::new(archive);
+    let mut tar = tar::Archive::new(decoder);
+    for entry in tar
+        .entries()
+        .map_err(|e| UpdateError::Archive(e.to_string()))?
+    {
+        let mut entry = entry.map_err(|e| UpdateError::Archive(e.to_string()))?;
+        let path = entry
+            .path()
+            .map_err(|e| UpdateError::Archive(e.to_string()))?
+            .into_owned();
+        // The archive stores files at its root, so entries arrive as `./name`
+        // or `name` depending on how they were added.
+        if path
+            .file_name()
+            .map(|n| n == "srelens-tui")
+            .unwrap_or(false)
+        {
+            let mut bytes = Vec::new();
+            entry
+                .read_to_end(&mut bytes)
+                .map_err(|e| UpdateError::Archive(e.to_string()))?;
+            return Ok(bytes);
+        }
+    }
+    Err(UpdateError::BinaryMissing {
+        asset: asset.to_string(),
+    })
+}
+
+fn extract_from_zip(archive: &[u8], asset: &str) -> Result<Vec<u8>, UpdateError> {
+    use std::io::Read;
+    let reader = std::io::Cursor::new(archive);
+    let mut zip = zip::ZipArchive::new(reader).map_err(|e| UpdateError::Archive(e.to_string()))?;
+    for i in 0..zip.len() {
+        let mut file = zip
+            .by_index(i)
+            .map_err(|e| UpdateError::Archive(e.to_string()))?;
+        let name = file
+            .name()
+            .rsplit('/')
+            .next()
+            .unwrap_or_default()
+            .to_string();
+        if name == "srelens-tui.exe" {
+            let mut bytes = Vec::new();
+            file.read_to_end(&mut bytes)
+                .map_err(|e| UpdateError::Archive(e.to_string()))?;
+            return Ok(bytes);
+        }
+    }
+    Err(UpdateError::BinaryMissing {
+        asset: asset.to_string(),
+    })
+}
+
+/// Whether `latest` is a higher version than `current`.
+///
+/// Both are parsed as semver so `0.10.0` sorts above `0.9.0`, which a string
+/// comparison gets backwards. Anything unparseable is treated as "no update",
+/// because refusing to act on a version we do not understand is safer than
+/// overwriting a binary on a guess.
+pub fn is_newer(current: &str, latest: &str) -> bool {
+    match (
+        semver::Version::parse(current),
+        semver::Version::parse(latest),
+    ) {
+        (Ok(current), Ok(latest)) => latest > current,
+        _ => false,
+    }
+}
+
+/// The package manager that owns `path`, if one does.
+///
+/// srelens will not write over a file a package manager tracks: the manager's
+/// database would still name the old version, and the next upgrade would put
+/// it back. The desktop app already declines for AUR on the same grounds.
+pub fn package_manager_for(path: &Path) -> Option<&'static str> {
+    let text = path.to_string_lossy().replace('\\', "/");
+    // Ordered longest-prefix-first where they nest, so a Cellar path is not
+    // reported as the more general /usr/local.
+    let owners: &[(&str, &str)] = &[
+        ("/opt/homebrew/", "Homebrew"),
+        ("/home/linuxbrew/.linuxbrew/", "Homebrew"),
+        ("/usr/local/Cellar/", "Homebrew"),
+        ("/usr/bin/", "your distribution's package manager"),
+        ("/snap/", "snap"),
+        ("/var/lib/flatpak/", "Flatpak"),
+        ("/nix/store/", "Nix"),
+        ("scoop/apps/", "Scoop"),
+        ("scoop/shims/", "Scoop"),
+        ("WinGet/Packages/", "winget"),
+        ("Chocolatey/", "Chocolatey"),
+    ];
+    owners
+        .iter()
+        .find(|(prefix, _)| text.contains(prefix))
+        .map(|(_, manager)| *manager)
+}
+
+/// What an update would do, resolved before anything is downloaded.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Plan {
+    pub current: String,
+    pub latest: String,
+    pub asset: String,
+    pub archive_url: String,
+    pub sums_url: String,
+    pub target: PathBuf,
+}
+
+/// Resolve the latest release and decide whether it is worth downloading.
+///
+/// `Ok(None)` means already current — a normal outcome, not a failure.
+pub fn plan(
+    current: &str,
+    target: PathBuf,
+    fetch: &impl Fn(&str) -> Result<Vec<u8>, UpdateError>,
+) -> Result<Option<Plan>, UpdateError> {
+    let triple = current_triple()?;
+    let body = fetch(LATEST_RELEASE_URL)?;
+    let latest = parse_latest_version(&body)?;
+    if !is_newer(current, &latest) {
+        return Ok(None);
+    }
+    let asset = asset_name(&latest, triple);
+    Ok(Some(Plan {
+        current: current.to_string(),
+        archive_url: asset_url(&latest, &asset),
+        sums_url: asset_url(&latest, &sums_name(&latest)),
+        asset,
+        latest,
+        target,
+    }))
+}
+
+/// Download, verify, and install the binary a [`Plan`] names.
+///
+/// Verification happens before anything is written, so a mismatched download
+/// leaves the installed binary untouched.
+pub fn apply(
+    plan: &Plan,
+    fetch: &impl Fn(&str) -> Result<Vec<u8>, UpdateError>,
+) -> Result<(), UpdateError> {
+    if let Some(manager) = package_manager_for(&plan.target) {
+        return Err(UpdateError::PackageManaged {
+            manager,
+            path: plan.target.clone(),
+        });
+    }
+    let dir = plan.target.parent().unwrap_or_else(|| Path::new("."));
+    if !writable_dir(dir) {
+        return Err(UpdateError::NotWritable {
+            path: dir.to_path_buf(),
+        });
+    }
+
+    let sums = fetch(&plan.sums_url)?;
+    let sums = String::from_utf8(sums)
+        .map_err(|_| UpdateError::BadRelease("the checksum file is not text".into()))?;
+    let expected = checksum_for(&sums, &plan.asset)?;
+
+    let archive = fetch(&plan.archive_url)?;
+    verify_sha256(&archive, &expected)?;
+
+    let binary = extract_binary(&archive, &plan.asset)?;
+    replace_running_binary(&plan.target, &binary)
+}
+
+/// Can this process create files in `dir`? Asked by trying, because the
+/// permission bits do not account for ownership, ACLs or a read-only mount,
+/// and a wrong guess here turns into a confusing failure halfway through.
+fn writable_dir(dir: &Path) -> bool {
+    let probe = dir.join(format!(".srelens-tui-write-test-{}", std::process::id()));
+    match std::fs::File::create(&probe) {
+        Ok(_) => {
+            let _ = std::fs::remove_file(&probe);
+            true
+        }
+        Err(_) => false,
+    }
+}
+
+/// Put `bytes` at `target`, replacing the binary that is currently running.
+///
+/// The new file is written beside the target and renamed in, so the last step
+/// is atomic and an interrupted update cannot leave a truncated binary on the
+/// user's `PATH`.
+///
+/// Windows cannot unlink a running image, which is what makes this more than a
+/// rename: it CAN rename one, so the running binary is moved aside first and
+/// the new one takes its place. The displaced file cannot be deleted until the
+/// process exits, so it is left for the next run to clear.
+pub fn replace_running_binary(target: &Path, bytes: &[u8]) -> Result<(), UpdateError> {
+    let dir = target.parent().unwrap_or_else(|| Path::new("."));
+    let staged = dir.join(format!(".{}.new-{}", BIN, std::process::id()));
+    std::fs::write(&staged, bytes).map_err(io)?;
+    set_executable(&staged)?;
+
+    if cfg!(windows) {
+        let displaced = dir.join(format!("{BIN}.old"));
+        let _ = std::fs::remove_file(&displaced);
+        if let Err(e) = std::fs::rename(target, &displaced) {
+            let _ = std::fs::remove_file(&staged);
+            return Err(io(e));
+        }
+        if let Err(e) = std::fs::rename(&staged, target) {
+            // Put the original back rather than leaving the user with nothing.
+            let _ = std::fs::rename(&displaced, target);
+            let _ = std::fs::remove_file(&staged);
+            return Err(io(e));
+        }
+        // Fails while this process holds the image open; the next run clears it.
+        let _ = std::fs::remove_file(&displaced);
+    } else if let Err(e) = std::fs::rename(&staged, target) {
+        let _ = std::fs::remove_file(&staged);
+        return Err(io(e));
+    }
+    Ok(())
+}
+
+/// Remove the file a previous Windows update left behind. A no-op everywhere
+/// else, and best-effort: a leftover is untidy, never harmful.
+pub fn clear_displaced_binary(target: &Path) {
+    if cfg!(windows) {
+        if let Some(dir) = target.parent() {
+            let _ = std::fs::remove_file(dir.join(format!("{BIN}.old")));
+        }
+    }
+}
+
+#[cfg(unix)]
+fn set_executable(path: &Path) -> Result<(), UpdateError> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).map_err(io)
+}
+
+#[cfg(not(unix))]
+fn set_executable(_path: &Path) -> Result<(), UpdateError> {
+    Ok(())
+}

--- a/apps/tui/src/self_update.rs
+++ b/apps/tui/src/self_update.rs
@@ -220,11 +220,13 @@ pub fn parse_latest_version(body: &[u8]) -> Result<String, UpdateError> {
     let version = tag
         .strip_prefix("srelens-v")
         .ok_or_else(|| UpdateError::BadRelease(format!("unexpected tag {tag}")))?;
-    if version.is_empty() {
-        return Err(UpdateError::BadRelease(format!(
-            "empty version in tag {tag}"
-        )));
-    }
+    // Parsed, not merely non-empty. A tag like `srelens-vnightly` would
+    // otherwise pass here, fail to compare later, and be reported as
+    // "you are on the latest" — turning broken release metadata into a
+    // confident answer about the user's version, which is the one thing
+    // this command must not do.
+    semver::Version::parse(version)
+        .map_err(|e| UpdateError::BadRelease(format!("tag {tag} is not a version: {e}")))?;
     Ok(version.to_string())
 }
 
@@ -247,8 +249,13 @@ pub fn parse_newest_version(body: &[u8]) -> Result<String, UpdateError> {
         if tag == "dev-channel" {
             continue;
         }
+        // Unlike the single-release endpoint, a tag that is not a version is
+        // SKIPPED here rather than failing the command: this is a list, so
+        // there is a next entry to try, and one odd tag should not stop a
+        // dev user updating. Failing is right only where there is no
+        // alternative to fall back to.
         if let Some(version) = tag.strip_prefix("srelens-v") {
-            if !version.is_empty() {
+            if semver::Version::parse(version).is_ok() {
                 return Ok(version.to_string());
             }
         }
@@ -513,13 +520,43 @@ pub fn apply(
     replace_running_binary(&plan.target, &binary)
 }
 
+/// Create a file in `dir` that did not exist a moment ago, and hand back
+/// both it and its path.
+///
+/// `create_new` is the point: it fails if anything is already at the path,
+/// INCLUDING a symlink, so it cannot be tricked into writing through one.
+/// A predictable name plus a following open is a real hazard here — the
+/// install guide has people extract and run from a working directory, and a
+/// directory another user can write to lets them pre-create the path as a
+/// link to a file the victim owns, which the update would then truncate.
+/// The name is random as well, so the attempt cannot be aimed.
+fn create_new_file(dir: &Path, prefix: &str) -> Result<(PathBuf, std::fs::File), UpdateError> {
+    let mut last = None;
+    for _ in 0..8 {
+        let path = dir.join(format!("{prefix}{}", uuid::Uuid::new_v4()));
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+        {
+            Ok(file) => return Ok((path, file)),
+            // Lost a race, or someone is planting names. Try another.
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => last = Some(e),
+            Err(e) => return Err(io(e)),
+        }
+    }
+    Err(io(last.unwrap_or_else(|| {
+        std::io::Error::other("could not create a temporary file")
+    })))
+}
+
 /// Can this process create files in `dir`? Asked by trying, because the
 /// permission bits do not account for ownership, ACLs or a read-only mount,
 /// and a wrong guess here turns into a confusing failure halfway through.
 fn writable_dir(dir: &Path) -> bool {
-    let probe = dir.join(format!(".srelens-tui-write-test-{}", std::process::id()));
-    match std::fs::File::create(&probe) {
-        Ok(_) => {
+    match create_new_file(dir, ".srelens-tui-write-test-") {
+        Ok((probe, file)) => {
+            drop(file);
             let _ = std::fs::remove_file(&probe);
             true
         }
@@ -538,9 +575,21 @@ fn writable_dir(dir: &Path) -> bool {
 /// the new one takes its place. The displaced file cannot be deleted until the
 /// process exits, so it is left for the next run to clear.
 pub fn replace_running_binary(target: &Path, bytes: &[u8]) -> Result<(), UpdateError> {
+    use std::io::Write;
     let dir = target.parent().unwrap_or_else(|| Path::new("."));
-    let staged = dir.join(format!(".{}.new-{}", BIN, std::process::id()));
-    std::fs::write(&staged, bytes).map_err(io)?;
+    // Created with `create_new` rather than written to a predictable path:
+    // see `create_new_file`. Writing through a planted symlink here would
+    // put a downloaded executable wherever the link pointed.
+    let (staged, mut file) = create_new_file(dir, &format!(".{BIN}.new-"))?;
+    let written = file
+        .write_all(bytes)
+        .and_then(|()| file.sync_all())
+        .map_err(io);
+    drop(file);
+    if let Err(e) = written {
+        let _ = std::fs::remove_file(&staged);
+        return Err(e);
+    }
     set_executable(&staged)?;
 
     if cfg!(windows) {

--- a/apps/tui/src/self_update.rs
+++ b/apps/tui/src/self_update.rs
@@ -342,29 +342,58 @@ pub struct Plan {
     pub target: PathBuf,
 }
 
-/// Resolve the latest release and decide whether it is worth downloading.
+/// What checking for an update found.
 ///
-/// `Ok(None)` means already current — a normal outcome, not a failure.
+/// `UpToDate` and `AheadOfStable` are deliberately not the same answer. The
+/// endpoint consulted describes the STABLE channel, so a dev build that sorts
+/// above the newest stable release has not been told it is the latest of
+/// anything — only that no newer stable applies to it. Collapsing the two would
+/// have `update` report a pre-release as "the latest release" while newer
+/// pre-releases exist, which is the difference AGENTS.md is about: say what you
+/// know, not what you guess.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Check {
+    /// Running exactly the latest stable release.
+    UpToDate { latest: String },
+    /// Running something that sorts above it — a dev or locally built binary.
+    AheadOfStable { latest: String },
+    /// A newer stable release is available.
+    Available(Box<Plan>),
+}
+
+/// Resolve the latest stable release and decide whether it is worth
+/// downloading. Not finding an update is a normal outcome, not a failure.
 pub fn plan(
     current: &str,
     target: PathBuf,
     fetch: &impl Fn(&str) -> Result<Vec<u8>, UpdateError>,
-) -> Result<Option<Plan>, UpdateError> {
+) -> Result<Check, UpdateError> {
     let triple = current_triple()?;
     let body = fetch(LATEST_RELEASE_URL)?;
     let latest = parse_latest_version(&body)?;
     if !is_newer(current, &latest) {
-        return Ok(None);
+        // An unparseable current version lands here too, and is reported as
+        // up to date rather than ahead: claiming to be ahead of a release we
+        // could not compare against would be the same overclaim in reverse.
+        let ahead = matches!(
+            (semver::Version::parse(current), semver::Version::parse(&latest)),
+            (Ok(current), Ok(latest)) if current > latest
+        );
+        return Ok(if ahead {
+            Check::AheadOfStable { latest }
+        } else {
+            Check::UpToDate { latest }
+        });
     }
     let asset = asset_name(&latest, triple);
-    Ok(Some(Plan {
+    Ok(Check::Available(Box::new(Plan {
         current: current.to_string(),
         archive_url: asset_url(&latest, &asset),
         sums_url: asset_url(&latest, &sums_name(&latest)),
         asset,
         latest,
         target,
-    }))
+    })))
 }
 
 /// Download, verify, and install the binary a [`Plan`] names.

--- a/apps/tui/src/self_update.rs
+++ b/apps/tui/src/self_update.rs
@@ -19,11 +19,60 @@
 use std::fmt;
 use std::path::{Path, PathBuf};
 
-/// Where the release metadata and assets live. `releases/latest` is the
-/// GitHub endpoint that skips pre-releases, which is what makes this the
-/// stable channel without any filtering of our own.
+/// The stable channel. `releases/latest` is the GitHub endpoint that skips
+/// pre-releases, so this needs no filtering of our own.
 pub const LATEST_RELEASE_URL: &str = "https://api.github.com/repos/srelens/srelens/releases/latest";
+/// The dev channel. The full list, newest first, because dev builds ARE
+/// pre-releases and the endpoint above hides them by definition.
+pub const RELEASES_URL: &str = "https://api.github.com/repos/srelens/srelens/releases?per_page=20";
 const DOWNLOAD_BASE: &str = "https://github.com/srelens/srelens/releases/download";
+
+/// Which releases to consider, matching the two the desktop app offers under
+/// Settings → Updates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Channel {
+    /// Released versions.
+    Stable,
+    /// Rolling pre-releases, cut from `dev` once a day.
+    Dev,
+}
+
+impl Channel {
+    /// The channel a binary reporting `version` came from.
+    ///
+    /// Used as the default so `update` keeps you where you are: a dev build
+    /// carries a pre-release version (`0.8.1-152`), and offering it only
+    /// stable would strand it — the stable release it sits above is not an
+    /// update, so there would be nothing to install and no way to say so.
+    pub fn of_version(version: &str) -> Channel {
+        match semver::Version::parse(version) {
+            Ok(parsed) if !parsed.pre.is_empty() => Channel::Dev,
+            _ => Channel::Stable,
+        }
+    }
+
+    pub fn parse(name: &str) -> Option<Channel> {
+        match name.trim().to_ascii_lowercase().as_str() {
+            "stable" => Some(Channel::Stable),
+            "dev" => Some(Channel::Dev),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Channel::Stable => "stable",
+            Channel::Dev => "dev",
+        }
+    }
+
+    fn url(self) -> &'static str {
+        match self {
+            Channel::Stable => LATEST_RELEASE_URL,
+            Channel::Dev => RELEASES_URL,
+        }
+    }
+}
 
 /// The name of the binary inside every archive, and on disk.
 const BIN: &str = if cfg!(windows) {
@@ -177,6 +226,36 @@ pub fn parse_latest_version(body: &[u8]) -> Result<String, UpdateError> {
         )));
     }
     Ok(version.to_string())
+}
+
+/// The newest version in a releases LIST, which is how the dev channel is
+/// resolved: pre-releases are what it is made of, so the stable endpoint
+/// cannot see them.
+///
+/// GitHub returns the list newest first. Two entries are skipped: anything
+/// not tagged `srelens-v…`, and `dev-channel` — a permanent rolling
+/// pre-release that carries only the desktop updater's manifest and none of
+/// the TUI archives, so resolving to it would produce URLs for assets that
+/// are not there.
+pub fn parse_newest_version(body: &[u8]) -> Result<String, UpdateError> {
+    let releases: Vec<serde_json::Value> = serde_json::from_slice(body)
+        .map_err(|e| UpdateError::BadRelease(format!("the API did not return a list: {e}")))?;
+    for release in releases {
+        let Some(tag) = release.get("tag_name").and_then(|t| t.as_str()) else {
+            continue;
+        };
+        if tag == "dev-channel" {
+            continue;
+        }
+        if let Some(version) = tag.strip_prefix("srelens-v") {
+            if !version.is_empty() {
+                return Ok(version.to_string());
+            }
+        }
+    }
+    Err(UpdateError::BadRelease(
+        "no srelens release found in the list".into(),
+    ))
 }
 
 /// Look one archive up in a `sha256sum`-format file.
@@ -344,19 +423,20 @@ pub struct Plan {
 
 /// What checking for an update found.
 ///
-/// `UpToDate` and `AheadOfStable` are deliberately not the same answer. The
-/// endpoint consulted describes the STABLE channel, so a dev build that sorts
-/// above the newest stable release has not been told it is the latest of
-/// anything — only that no newer stable applies to it. Collapsing the two would
-/// have `update` report a pre-release as "the latest release" while newer
-/// pre-releases exist, which is the difference AGENTS.md is about: say what you
-/// know, not what you guess.
+/// `UpToDate` and `AheadOfChannel` are deliberately not the same answer, and
+/// both name the channel they are about. Only one channel is ever consulted,
+/// so a dev build checked against stable has not been told it is the latest of
+/// anything — only that no newer STABLE release applies to it. Collapsing the
+/// two would have `update` report a pre-release as "the latest release" while
+/// newer pre-releases exist, which is the difference AGENTS.md is about: say
+/// what you know, not what you guess.
 #[derive(Debug, PartialEq, Eq)]
 pub enum Check {
-    /// Running exactly the latest stable release.
-    UpToDate { latest: String },
-    /// Running something that sorts above it — a dev or locally built binary.
-    AheadOfStable { latest: String },
+    /// Running the newest release this channel offers.
+    UpToDate { channel: Channel, latest: String },
+    /// Running something that sorts above it — typically a dev build checked
+    /// against stable, or a locally built one.
+    AheadOfChannel { channel: Channel, latest: String },
     /// A newer stable release is available.
     Available(Box<Plan>),
 }
@@ -365,12 +445,16 @@ pub enum Check {
 /// downloading. Not finding an update is a normal outcome, not a failure.
 pub fn plan(
     current: &str,
+    channel: Channel,
     target: PathBuf,
     fetch: &impl Fn(&str) -> Result<Vec<u8>, UpdateError>,
 ) -> Result<Check, UpdateError> {
     let triple = current_triple()?;
-    let body = fetch(LATEST_RELEASE_URL)?;
-    let latest = parse_latest_version(&body)?;
+    let body = fetch(channel.url())?;
+    let latest = match channel {
+        Channel::Stable => parse_latest_version(&body)?,
+        Channel::Dev => parse_newest_version(&body)?,
+    };
     if !is_newer(current, &latest) {
         // An unparseable current version lands here too, and is reported as
         // up to date rather than ahead: claiming to be ahead of a release we
@@ -380,9 +464,9 @@ pub fn plan(
             (Ok(current), Ok(latest)) if current > latest
         );
         return Ok(if ahead {
-            Check::AheadOfStable { latest }
+            Check::AheadOfChannel { channel, latest }
         } else {
-            Check::UpToDate { latest }
+            Check::UpToDate { channel, latest }
         });
     }
     let asset = asset_name(&latest, triple);

--- a/apps/tui/src/self_update.rs
+++ b/apps/tui/src/self_update.rs
@@ -106,6 +106,9 @@ pub enum UpdateError {
     },
     /// The binary's directory cannot be written to by this user.
     NotWritable { path: PathBuf },
+    /// The staged download changed between being written and being
+    /// installed — someone else can write to the directory.
+    StagedChanged,
     /// The update failed AND the original could not be put back. The user
     /// has no working binary until they move it themselves, so this says
     /// exactly where it is rather than only why the update failed.
@@ -151,6 +154,10 @@ impl fmt::Display for UpdateError {
                 f,
                 "cannot write to {} — re-run with the rights to change it, or install srelens-tui somewhere you own",
                 path.display()
+            ),
+            Self::StagedChanged => write!(
+                f,
+                "the downloaded file changed on disk before it could be installed, so nothing was replaced — someone else can write to that directory"
             ),
             Self::LeftDisplaced {
                 displaced,
@@ -662,6 +669,20 @@ fn writable_dir(dir: &Path) -> bool {
     }
 }
 
+/// Confirm the file at `path` still holds exactly `bytes`.
+///
+/// Split out so it can be tested directly: the race it defends against
+/// cannot be staged from a test without becoming the very timing problem it
+/// is about.
+fn assert_staged_is_unchanged(path: &Path, bytes: &[u8]) -> Result<(), UpdateError> {
+    let on_disk = std::fs::read(path).map_err(io)?;
+    if on_disk == bytes {
+        Ok(())
+    } else {
+        Err(UpdateError::StagedChanged)
+    }
+}
+
 /// Put `bytes` at `target`, replacing the binary that is currently running.
 ///
 /// The new file is written beside the target and renamed in, so the last step
@@ -692,6 +713,23 @@ pub fn replace_running_binary(target: &Path, bytes: &[u8]) -> Result<(), UpdateE
         .map_err(io)?;
     drop(file);
     set_executable(&staged.0)?;
+
+    // Read back what is actually at that path before installing it.
+    //
+    // Closing the handle gives up the only hold on the NAME. On Windows
+    // that ends the share-mode protection; on Unix a handle never protected
+    // the name anyway — anyone who can write to a non-sticky directory may
+    // unlink a 0600 file they cannot read and put their own there. Either
+    // way the rename below could pick up a file nobody verified. Comparing
+    // against the bytes in hand costs one read and makes the guarantee
+    // whole: what gets installed is what came out of the archive whose
+    // checksum matched, or nothing does.
+    //
+    // This does NOT make a directory other people can write to safe. They
+    // can overwrite the installed binary a moment later, with or without
+    // this command. It means only that THIS command never installs bytes it
+    // did not verify.
+    assert_staged_is_unchanged(&staged.0, bytes)?;
 
     if cfg!(windows) {
         let displaced = dir.join(format!("{BIN}.old"));
@@ -776,6 +814,40 @@ mod tests {
             .mode()
             & 0o777;
         assert_eq!(mode, 0o600, "created as {mode:o}, not 0600");
+    }
+
+    /// Nothing is installed unless the file on disk is still the file that
+    /// came out of the verified archive.
+    #[test]
+    fn a_staged_file_that_changed_underneath_us_is_refused() {
+        use super::{assert_staged_is_unchanged, UpdateError};
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("staged");
+
+        std::fs::write(&path, b"the verified bytes").unwrap();
+        assert!(assert_staged_is_unchanged(&path, b"the verified bytes").is_ok());
+
+        // What an attacker who can write to the directory would leave.
+        std::fs::write(&path, b"something else entirely").unwrap();
+        assert!(matches!(
+            assert_staged_is_unchanged(&path, b"the verified bytes"),
+            Err(UpdateError::StagedChanged)
+        ));
+
+        // Same length, one byte different — a truncation check would miss it.
+        std::fs::write(&path, b"the verified byteS").unwrap();
+        assert!(matches!(
+            assert_staged_is_unchanged(&path, b"the verified bytes"),
+            Err(UpdateError::StagedChanged)
+        ));
+
+        // Gone entirely is an IO error, not a silent pass.
+        std::fs::remove_file(&path).unwrap();
+        assert!(matches!(
+            assert_staged_is_unchanged(&path, b"the verified bytes"),
+            Err(UpdateError::Io(_))
+        ));
     }
 
     /// Two calls never collide, which is what lets the name be unpredictable

--- a/apps/tui/src/self_update.rs
+++ b/apps/tui/src/self_update.rs
@@ -106,6 +106,14 @@ pub enum UpdateError {
     },
     /// The binary's directory cannot be written to by this user.
     NotWritable { path: PathBuf },
+    /// The update failed AND the original could not be put back. The user
+    /// has no working binary until they move it themselves, so this says
+    /// exactly where it is rather than only why the update failed.
+    LeftDisplaced {
+        displaced: PathBuf,
+        target: PathBuf,
+        why: String,
+    },
 }
 
 impl fmt::Display for UpdateError {
@@ -143,6 +151,16 @@ impl fmt::Display for UpdateError {
                 f,
                 "cannot write to {} — re-run with the rights to change it, or install srelens-tui somewhere you own",
                 path.display()
+            ),
+            Self::LeftDisplaced {
+                displaced,
+                target,
+                why,
+            } => write!(
+                f,
+                "the update failed and your previous binary could not be put back: it is at {}. Move it to {} to restore it. ({why})",
+                displaced.display(),
+                target.display()
             ),
         }
     }
@@ -596,11 +614,29 @@ fn create_new_file(dir: &Path, prefix: &str) -> Result<(PathBuf, std::fs::File),
     let mut last = None;
     for _ in 0..8 {
         let path = dir.join(format!("{prefix}{}", uuid::Uuid::new_v4()));
-        match std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&path)
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
         {
+            use std::os::unix::fs::OpenOptionsExt;
+            // 0600 AT CREATION, not afterwards. The default is 0666 masked
+            // by the umask, so a umask of 0002 — normal on systems with
+            // per-group directories — would publish the file group-writable
+            // for the window before the mode is corrected. Someone watching
+            // the directory could open it in that window, hold the
+            // descriptor, and change the contents after the archive was
+            // verified. Opening restrictively closes the window instead of
+            // narrowing it.
+            options.mode(0o600);
+        }
+        #[cfg(windows)]
+        {
+            use std::os::windows::fs::OpenOptionsExt;
+            // FILE_SHARE_READ only: while this handle is open nobody else
+            // may open the file for writing or delete it.
+            options.share_mode(0x0000_0001);
+        }
+        match options.open(&path) {
             Ok(file) => return Ok((path, file)),
             // Lost a race, or someone is planting names. Try another.
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => last = Some(e),
@@ -662,8 +698,18 @@ pub fn replace_running_binary(target: &Path, bytes: &[u8]) -> Result<(), UpdateE
         let _ = std::fs::remove_file(&displaced);
         std::fs::rename(target, &displaced).map_err(io)?;
         if let Err(e) = std::fs::rename(&staged.0, target) {
-            // Put the original back rather than leaving the user with nothing.
-            let _ = std::fs::rename(&displaced, target);
+            // Put the original back rather than leaving the user with
+            // nothing — and if even that fails, say so. Reporting only the
+            // first error would tell the user the update failed while
+            // leaving them with no binary on their PATH and no idea their
+            // old one is sitting next to it under another name.
+            if let Err(rollback) = std::fs::rename(&displaced, target) {
+                return Err(UpdateError::LeftDisplaced {
+                    displaced: displaced.clone(),
+                    target: target.to_path_buf(),
+                    why: format!("{e}; restoring it also failed: {rollback}"),
+                });
+            }
             return Err(io(e));
         }
         // Fails while this process holds the image open; the next run clears it.
@@ -697,4 +743,48 @@ fn set_executable(path: &Path) -> Result<(), UpdateError> {
 #[cfg(not(unix))]
 fn set_executable(_path: &Path) -> Result<(), UpdateError> {
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::create_new_file;
+
+    /// The staged file must be private to its owner from the instant it
+    /// exists, not from the moment its mode is corrected.
+    ///
+    /// The umask is set to 0 for the check, which is the point: a default
+    /// creation would then be 0666, so seeing 0600 proves the mode comes from
+    /// the open call rather than from whatever the machine's umask happens to
+    /// be. Under a real umask of 0002 — normal where users share a group —
+    /// the default would have been group-writable, and someone watching the
+    /// directory could have opened the file, held the descriptor, and changed
+    /// the contents after the archive's checksum was verified.
+    #[cfg(unix)]
+    #[test]
+    fn a_staged_file_is_created_private_to_its_owner() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let previous = unsafe { libc::umask(0) };
+        let created = create_new_file(dir.path(), ".probe-");
+        unsafe { libc::umask(previous) };
+
+        let (path, _file) = created.expect("the file is created");
+        let mode = std::fs::metadata(&path)
+            .expect("metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600, "created as {mode:o}, not 0600");
+    }
+
+    /// Two calls never collide, which is what lets the name be unpredictable
+    /// rather than derived from the process id.
+    #[test]
+    fn staged_files_do_not_reuse_a_name() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let (first, _a) = create_new_file(dir.path(), ".probe-").expect("first");
+        let (second, _b) = create_new_file(dir.path(), ".probe-").expect("second");
+        assert_ne!(first, second);
+    }
 }

--- a/apps/tui/src/self_update.rs
+++ b/apps/tui/src/self_update.rs
@@ -234,11 +234,10 @@ pub fn parse_latest_version(body: &[u8]) -> Result<String, UpdateError> {
 /// resolved: pre-releases are what it is made of, so the stable endpoint
 /// cannot see them.
 ///
-/// GitHub returns the list newest first. Two entries are skipped: anything
-/// not tagged `srelens-v…`, and `dev-channel` — a permanent rolling
-/// pre-release that carries only the desktop updater's manifest and none of
-/// the TUI archives, so resolving to it would produce URLs for assets that
-/// are not there.
+/// GitHub returns the list newest first. Three kinds of entry are skipped:
+/// anything not tagged `srelens-v…`; `dev-channel`, a permanent rolling
+/// pre-release carrying only the desktop updater's manifest and none of the
+/// TUI archives; and stable releases, which belong to the other channel.
 pub fn parse_newest_version(body: &[u8]) -> Result<String, UpdateError> {
     let releases: Vec<serde_json::Value> = serde_json::from_slice(body)
         .map_err(|e| UpdateError::BadRelease(format!("the API did not return a list: {e}")))?;
@@ -247,6 +246,19 @@ pub fn parse_newest_version(body: &[u8]) -> Result<String, UpdateError> {
             continue;
         };
         if tag == "dev-channel" {
+            continue;
+        }
+        // Pre-releases only. When main cuts a stable release, it is the
+        // newest entry in this list — and taking it would move a dev user
+        // onto stable without saying so. Worse, it would stick: the
+        // installed version would no longer carry a pre-release, so the
+        // next plain `update` would default to the stable channel. A
+        // channel switch has to be something the user asked for.
+        if !release
+            .get("prerelease")
+            .and_then(|p| p.as_bool())
+            .unwrap_or(false)
+        {
             continue;
         }
         // Unlike the single-release endpoint, a tag that is not a version is
@@ -395,21 +407,28 @@ pub fn is_newer(current: &str, latest: &str) -> bool {
 /// database would still name the old version, and the next upgrade would put
 /// it back. The desktop app already declines for AUR on the same grounds.
 pub fn package_manager_for(path: &Path) -> Option<&'static str> {
-    let text = path.to_string_lossy().replace('\\', "/");
+    // Lower-cased because Windows paths are case-insensitive and the real
+    // Chocolatey root is `C:\\ProgramData\\chocolatey` — a case-sensitive
+    // match against `Chocolatey` never fired, so a Chocolatey-managed copy
+    // sailed past this guard and would have been overwritten. Unix paths are
+    // case-sensitive, so this can in principle over-match there; refusing to
+    // update with a named manager is the safe direction to be wrong in.
+    let text = path.to_string_lossy().replace('\\', "/").to_lowercase();
     // Ordered longest-prefix-first where they nest, so a Cellar path is not
     // reported as the more general /usr/local.
     let owners: &[(&str, &str)] = &[
+        // Lower-case, to match the normalisation above.
         ("/opt/homebrew/", "Homebrew"),
         ("/home/linuxbrew/.linuxbrew/", "Homebrew"),
-        ("/usr/local/Cellar/", "Homebrew"),
+        ("/usr/local/cellar/", "Homebrew"),
         ("/usr/bin/", "your distribution's package manager"),
         ("/snap/", "snap"),
         ("/var/lib/flatpak/", "Flatpak"),
         ("/nix/store/", "Nix"),
-        ("scoop/apps/", "Scoop"),
-        ("scoop/shims/", "Scoop"),
-        ("WinGet/Packages/", "winget"),
-        ("Chocolatey/", "Chocolatey"),
+        ("/scoop/apps/", "Scoop"),
+        ("/scoop/shims/", "Scoop"),
+        ("/winget/packages/", "winget"),
+        ("/chocolatey/", "Chocolatey"),
     ];
     owners
         .iter()
@@ -612,16 +631,6 @@ pub fn replace_running_binary(target: &Path, bytes: &[u8]) -> Result<(), UpdateE
         return Err(io(e));
     }
     Ok(())
-}
-
-/// Remove the file a previous Windows update left behind. A no-op everywhere
-/// else, and best-effort: a leftover is untidy, never harmful.
-pub fn clear_displaced_binary(target: &Path) {
-    if cfg!(windows) {
-        if let Some(dir) = target.parent() {
-            let _ = std::fs::remove_file(dir.join(format!("{BIN}.old")));
-        }
-    }
 }
 
 #[cfg(unix)]

--- a/apps/tui/src/self_update.rs
+++ b/apps/tui/src/self_update.rs
@@ -712,12 +712,45 @@ fn world_writable_without_sticky(dir: &Path) -> bool {
     }
 }
 
-/// Windows has no equivalent this cheap. Its ACLs would need a real query,
-/// and the common failure there — a directory a package manager owns — is
-/// already caught by `package_manager_for`.
+/// Windows has no equivalent this cheap: its ACLs need the security
+/// descriptor read and every ACE walked, which is a new dependency and a
+/// judgement about which principals count as trusted — and getting that wrong
+/// fails in the direction that stops people updating. Tracked in #450. The
+/// staged handle's share mode and the read-back before the rename narrow the
+/// window there; they do not close it.
 #[cfg(not(unix))]
 fn world_writable_without_sticky(_dir: &Path) -> bool {
     false
+}
+
+/// Put a binary back after an update was interrupted between the two
+/// Windows renames.
+///
+/// That gap is two adjacent syscalls, but a kill or a power cut inside it
+/// leaves the executable only at `.<name>.old` with nothing at the command
+/// path — and the user cannot run `update` to fix it, because there is
+/// nothing left to run. What they CAN run is the displaced file itself, so
+/// every start checks whether that is what is happening and repairs it.
+///
+/// Returns where it restored the binary to, so the caller can say so.
+/// Deliberately narrow: it acts only when this process IS the displaced
+/// file and the real name is free, which cannot be true in ordinary use.
+pub fn recover_interrupted_update(exe: &Path) -> Option<PathBuf> {
+    if !cfg!(windows) {
+        return None;
+    }
+    let name = exe.file_name()?.to_str()?;
+    let restored = name.strip_prefix(".")?.strip_suffix(".old")?;
+    if restored != BIN {
+        return None;
+    }
+    let target = exe.with_file_name(restored);
+    if target.exists() {
+        return None;
+    }
+    // Windows allows renaming a running image, which is the same property
+    // the update itself relies on.
+    std::fs::rename(exe, &target).ok().map(|()| target)
 }
 
 /// Confirm the file at `path` still holds exactly `bytes`.

--- a/apps/tui/tests/self_update_tests.rs
+++ b/apps/tui/tests/self_update_tests.rs
@@ -10,8 +10,8 @@ use std::path::{Path, PathBuf};
 
 use srelens_tui::self_update::{
     apply, asset_name, asset_url, checksum_for, extract_binary, is_newer, package_manager_for,
-    parse_latest_version, plan, replace_running_binary, sums_name, triple_for, verify_sha256, Plan,
-    UpdateError, LATEST_RELEASE_URL,
+    parse_latest_version, plan, replace_running_binary, sums_name, triple_for, verify_sha256,
+    Check, Plan, UpdateError, LATEST_RELEASE_URL,
 };
 
 // ---------------------------------------------------------------------------
@@ -362,21 +362,56 @@ fn being_up_to_date_is_a_quiet_success_not_an_error() {
     };
     assert_eq!(
         plan("1.0.0", PathBuf::from("/tmp/srelens-tui"), &fetch).unwrap(),
-        None
+        Check::UpToDate {
+            latest: "1.0.0".into()
+        }
     );
-    // A build ahead of the latest release (a local one) is also "nothing to do".
+}
+
+/// Only the STABLE endpoint is consulted, so a dev build sorting above the
+/// newest stable has not been told it is the latest of anything. Reporting it
+/// as up to date would be a claim about pre-releases nobody checked.
+#[test]
+fn a_build_ahead_of_stable_is_not_reported_as_up_to_date() {
+    let fetch = |_: &str| -> Result<Vec<u8>, UpdateError> { Ok(release_json("srelens-v0.8.0")) };
+    // Exactly the shape the dev channel produces: 0.8.1-152 sorts above 0.8.0.
     assert_eq!(
-        plan("1.1.0", PathBuf::from("/tmp/srelens-tui"), &fetch).unwrap(),
-        None
+        plan("0.8.1-152", PathBuf::from("/tmp/srelens-tui"), &fetch).unwrap(),
+        Check::AheadOfStable {
+            latest: "0.8.0".into()
+        }
+    );
+
+    // A pre-release of the version that IS the latest stable sorts BELOW it,
+    // so that one is a real update rather than being ahead.
+    let fetch = |_: &str| -> Result<Vec<u8>, UpdateError> { Ok(release_json("srelens-v0.8.0")) };
+    assert!(matches!(
+        plan("0.8.0-7", PathBuf::from("/tmp/srelens-tui"), &fetch).unwrap(),
+        Check::Available(_)
+    ));
+}
+
+/// A version that cannot be parsed is reported as up to date, never as ahead:
+/// claiming to be ahead of a release we could not compare against is the same
+/// overclaim in the other direction.
+#[test]
+fn an_unparseable_current_version_is_not_claimed_to_be_ahead() {
+    let fetch = |_: &str| -> Result<Vec<u8>, UpdateError> { Ok(release_json("srelens-v1.0.0")) };
+    assert_eq!(
+        plan("nightly", PathBuf::from("/tmp/srelens-tui"), &fetch).unwrap(),
+        Check::UpToDate {
+            latest: "1.0.0".into()
+        }
     );
 }
 
 #[test]
 fn a_newer_release_plans_urls_under_its_own_tag() {
     let fetch = |_: &str| -> Result<Vec<u8>, UpdateError> { Ok(release_json("srelens-v2.0.0")) };
-    let plan = plan("1.0.0", PathBuf::from("/tmp/srelens-tui"), &fetch)
-        .unwrap()
-        .expect("an update is available");
+    let plan = match plan("1.0.0", PathBuf::from("/tmp/srelens-tui"), &fetch).unwrap() {
+        Check::Available(plan) => *plan,
+        other => panic!("expected an update, got {other:?}"),
+    };
 
     assert_eq!(plan.current, "1.0.0");
     assert_eq!(plan.latest, "2.0.0");

--- a/apps/tui/tests/self_update_tests.rs
+++ b/apps/tui/tests/self_update_tests.rs
@@ -215,6 +215,26 @@ fn the_dev_channel_skips_the_rolling_manifest_release() {
     assert_eq!(parse_newest_version(body).unwrap(), "0.8.1-152");
 }
 
+/// When main cuts a stable release it becomes the newest entry in this
+/// list. Taking it would move a dev user onto stable without saying so —
+/// and it would stick, because the installed version would no longer carry
+/// a pre-release, so the next plain `update` would default to stable.
+#[test]
+fn the_dev_channel_does_not_offer_a_stable_release() {
+    let body = br#"[
+        {"tag_name":"srelens-v0.9.0","prerelease":false},
+        {"tag_name":"srelens-v0.8.1-152","prerelease":true}
+    ]"#;
+    assert_eq!(parse_newest_version(body).unwrap(), "0.8.1-152");
+
+    // And a list of nothing but stable releases has no dev build to offer.
+    let stable_only = br#"[{"tag_name":"srelens-v0.9.0","prerelease":false}]"#;
+    assert!(matches!(
+        parse_newest_version(stable_only),
+        Err(UpdateError::BadRelease(_))
+    ));
+}
+
 #[test]
 fn a_list_with_no_srelens_release_is_an_error_not_a_guess() {
     assert!(matches!(
@@ -244,7 +264,7 @@ fn each_channel_asks_its_own_endpoint() {
 
     let dev = |url: &str| -> Result<Vec<u8>, UpdateError> {
         assert_eq!(url, RELEASES_URL);
-        Ok(br#"[{"tag_name":"srelens-v0.8.1-152"}]"#.to_vec())
+        Ok(br#"[{"tag_name":"srelens-v0.8.1-152","prerelease":true}]"#.to_vec())
     };
     match plan("0.8.1-150", Channel::Dev, PathBuf::from("/tmp/x"), &dev).unwrap() {
         Check::Available(plan) => {
@@ -267,7 +287,7 @@ fn each_channel_asks_its_own_endpoint() {
 #[test]
 fn a_dev_build_is_up_to_date_on_dev_and_ahead_on_stable() {
     let dev = |_: &str| -> Result<Vec<u8>, UpdateError> {
-        Ok(br#"[{"tag_name":"srelens-v0.8.1-152"}]"#.to_vec())
+        Ok(br#"[{"tag_name":"srelens-v0.8.1-152","prerelease":true}]"#.to_vec())
     };
     assert_eq!(
         plan("0.8.1-152", Channel::Dev, PathBuf::from("/tmp/x"), &dev).unwrap(),
@@ -352,8 +372,8 @@ fn a_release_tag_that_is_not_a_version_is_rejected() {
 #[test]
 fn the_dev_channel_skips_a_tag_it_cannot_read_and_takes_the_next() {
     let body = br#"[
-        {"tag_name":"srelens-vnightly"},
-        {"tag_name":"srelens-v0.8.1-152"}
+        {"tag_name":"srelens-vnightly","prerelease":true},
+        {"tag_name":"srelens-v0.8.1-152","prerelease":true}
     ]"#;
     assert_eq!(parse_newest_version(body).unwrap(), "0.8.1-152");
 }
@@ -526,6 +546,21 @@ fn a_binary_a_package_manager_owns_is_recognised() {
         ),
         ("/snap/srelens/current/bin/srelens-tui", "snap"),
         ("/nix/store/abc-srelens/bin/srelens-tui", "Nix"),
+        // Windows paths are case-insensitive, and the real Chocolatey root
+        // is `C:\\ProgramData\\chocolatey` — lower case. A case-sensitive
+        // match let a Chocolatey-managed copy through this guard entirely.
+        (
+            r"C:\ProgramData\chocolatey\bin\srelens-tui.exe",
+            "Chocolatey",
+        ),
+        (
+            r"C:\Users\me\Scoop\Apps\srelens-tui\current\srelens-tui.exe",
+            "Scoop",
+        ),
+        (
+            r"C:\PROGRAMDATA\CHOCOLATEY\bin\srelens-tui.exe",
+            "Chocolatey",
+        ),
         (r"C:\Users\me\scoop\shims\srelens-tui.exe", "Scoop"),
         (
             r"C:\Users\me\AppData\Local\Microsoft\WinGet\Packages\x\srelens-tui.exe",

--- a/apps/tui/tests/self_update_tests.rs
+++ b/apps/tui/tests/self_update_tests.rs
@@ -51,8 +51,52 @@ fn sha256_hex(bytes: &[u8]) -> String {
     format!("{:x}", Sha256::digest(bytes))
 }
 
+/// The triple under test, so fixtures name assets this platform would want.
+fn here() -> &'static str {
+    triple_for(
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+        cfg!(target_env = "musl"),
+    )
+    .expect("this platform has a release target")
+}
+
+/// The two asset names a release must carry for `version` to be installable
+/// here, as the GitHub API would list them.
+fn assets_for(version: &str) -> String {
+    format!(
+        r#"[{{"name":"{}"}},{{"name":"{}"}}]"#,
+        asset_name(version, here()),
+        sums_name(version)
+    )
+}
+
+/// A releases-list response. Each entry is (tag, is_prerelease, carries the
+/// archives) — the three things the dev channel filters on.
+fn releases_json(entries: &[(&str, bool, bool)]) -> Vec<u8> {
+    let items: Vec<String> = entries
+        .iter()
+        .map(|(tag, prerelease, complete)| {
+            let version = tag.strip_prefix("srelens-v").unwrap_or("0.0.0");
+            let assets = if *complete {
+                assets_for(version)
+            } else {
+                "[]".to_string()
+            };
+            format!(r#"{{"tag_name":"{tag}","prerelease":{prerelease},"assets":{assets}}}"#)
+        })
+        .collect();
+    format!("[{}]", items.join(",")).into_bytes()
+}
+
+/// A single-release response carrying the assets an update needs.
 fn release_json(tag: &str) -> Vec<u8> {
-    format!(r#"{{"tag_name":"{tag}","prerelease":false}}"#).into_bytes()
+    let version = tag.strip_prefix("srelens-v").unwrap_or("0.0.0");
+    format!(
+        r#"{{"tag_name":"{tag}","prerelease":false,"assets":{}}}"#,
+        assets_for(version)
+    )
+    .into_bytes()
 }
 
 /// The binary name inside an archive for the platform under test.
@@ -71,6 +115,11 @@ fn archive_for(asset: &str, body: &[u8]) -> Vec<u8> {
     } else {
         targz(bin_name(), body)
     }
+}
+
+/// `parse_latest_version` for this platform.
+fn parse_latest_version_here(body: &[u8]) -> Result<String, UpdateError> {
+    parse_latest_version(body, here())
 }
 
 // ---------------------------------------------------------------------------
@@ -194,12 +243,12 @@ fn a_channel_can_be_named_on_the_command_line() {
 /// is made of and the stable endpoint hides them by definition.
 #[test]
 fn the_dev_channel_takes_the_newest_release_of_any_kind() {
-    let body = br#"[
-        {"tag_name":"srelens-v0.8.1-152","prerelease":true},
-        {"tag_name":"srelens-v0.8.1-150","prerelease":true},
-        {"tag_name":"srelens-v0.8.0","prerelease":false}
-    ]"#;
-    assert_eq!(parse_newest_version(body).unwrap(), "0.8.1-152");
+    let body = releases_json(&[
+        ("srelens-v0.8.1-152", true, true),
+        ("srelens-v0.8.1-150", true, true),
+        ("srelens-v0.8.0", false, false),
+    ]);
+    assert_eq!(parse_newest_version(&body, here()).unwrap(), "0.8.1-152");
 }
 
 /// The rolling `dev-channel` release is a permanent pre-release carrying only
@@ -207,12 +256,12 @@ fn the_dev_channel_takes_the_newest_release_of_any_kind() {
 /// build URLs for assets that are not there.
 #[test]
 fn the_dev_channel_skips_the_rolling_manifest_release() {
-    let body = br#"[
-        {"tag_name":"dev-channel","prerelease":true},
-        {"tag_name":"some-other-tag","prerelease":true},
-        {"tag_name":"srelens-v0.8.1-152","prerelease":true}
-    ]"#;
-    assert_eq!(parse_newest_version(body).unwrap(), "0.8.1-152");
+    let body = releases_json(&[
+        ("dev-channel", true, false),
+        ("some-other-tag", true, false),
+        ("srelens-v0.8.1-152", true, true),
+    ]);
+    assert_eq!(parse_newest_version(&body, here()).unwrap(), "0.8.1-152");
 }
 
 /// When main cuts a stable release it becomes the newest entry in this
@@ -221,16 +270,16 @@ fn the_dev_channel_skips_the_rolling_manifest_release() {
 /// a pre-release, so the next plain `update` would default to stable.
 #[test]
 fn the_dev_channel_does_not_offer_a_stable_release() {
-    let body = br#"[
-        {"tag_name":"srelens-v0.9.0","prerelease":false},
-        {"tag_name":"srelens-v0.8.1-152","prerelease":true}
-    ]"#;
-    assert_eq!(parse_newest_version(body).unwrap(), "0.8.1-152");
+    let body = releases_json(&[
+        ("srelens-v0.9.0", false, false),
+        ("srelens-v0.8.1-152", true, true),
+    ]);
+    assert_eq!(parse_newest_version(&body, here()).unwrap(), "0.8.1-152");
 
     // And a list of nothing but stable releases has no dev build to offer.
-    let stable_only = br#"[{"tag_name":"srelens-v0.9.0","prerelease":false}]"#;
+    let stable_only = releases_json(&[("srelens-v0.9.0", false, true)]);
     assert!(matches!(
-        parse_newest_version(stable_only),
+        parse_newest_version(&stable_only, here()),
         Err(UpdateError::BadRelease(_))
     ));
 }
@@ -238,15 +287,15 @@ fn the_dev_channel_does_not_offer_a_stable_release() {
 #[test]
 fn a_list_with_no_srelens_release_is_an_error_not_a_guess() {
     assert!(matches!(
-        parse_newest_version(br#"[{"tag_name":"dev-channel"}]"#),
+        parse_newest_version(br#"[{"tag_name":"dev-channel"}]"#, here()),
         Err(UpdateError::BadRelease(_))
     ));
     assert!(matches!(
-        parse_newest_version(b"[]"),
+        parse_newest_version(b"[]", here()),
         Err(UpdateError::BadRelease(_))
     ));
     assert!(matches!(
-        parse_newest_version(b"not a list"),
+        parse_newest_version(b"not a list", here()),
         Err(UpdateError::BadRelease(_))
     ));
 }
@@ -264,7 +313,7 @@ fn each_channel_asks_its_own_endpoint() {
 
     let dev = |url: &str| -> Result<Vec<u8>, UpdateError> {
         assert_eq!(url, RELEASES_URL);
-        Ok(br#"[{"tag_name":"srelens-v0.8.1-152","prerelease":true}]"#.to_vec())
+        Ok(releases_json(&[("srelens-v0.8.1-152", true, true)]))
     };
     match plan("0.8.1-150", Channel::Dev, PathBuf::from("/tmp/x"), &dev).unwrap() {
         Check::Available(plan) => {
@@ -287,7 +336,7 @@ fn each_channel_asks_its_own_endpoint() {
 #[test]
 fn a_dev_build_is_up_to_date_on_dev_and_ahead_on_stable() {
     let dev = |_: &str| -> Result<Vec<u8>, UpdateError> {
-        Ok(br#"[{"tag_name":"srelens-v0.8.1-152","prerelease":true}]"#.to_vec())
+        Ok(releases_json(&[("srelens-v0.8.1-152", true, true)]))
     };
     assert_eq!(
         plan("0.8.1-152", Channel::Dev, PathBuf::from("/tmp/x"), &dev).unwrap(),
@@ -320,7 +369,7 @@ fn a_dev_build_is_up_to_date_on_dev_and_ahead_on_stable() {
 #[test]
 fn the_release_tag_is_read_without_its_prefix() {
     assert_eq!(
-        parse_latest_version(&release_json("srelens-v0.9.1")).unwrap(),
+        parse_latest_version_here(&release_json("srelens-v0.9.1")).unwrap(),
         "0.9.1"
     );
 }
@@ -334,7 +383,10 @@ fn an_unreadable_release_response_is_an_error_not_a_guess() {
         br#"{"tag_name":"srelens-v"}"#,
     ] {
         assert!(
-            matches!(parse_latest_version(body), Err(UpdateError::BadRelease(_))),
+            matches!(
+                parse_latest_version(body, here()),
+                Err(UpdateError::BadRelease(_))
+            ),
             "{:?} should not parse",
             String::from_utf8_lossy(body)
         );
@@ -354,7 +406,7 @@ fn a_release_tag_that_is_not_a_version_is_rejected() {
     ] {
         assert!(
             matches!(
-                parse_latest_version(&release_json(tag)),
+                parse_latest_version_here(&release_json(tag)),
                 Err(UpdateError::BadRelease(_))
             ),
             "{tag} should be refused"
@@ -362,7 +414,7 @@ fn a_release_tag_that_is_not_a_version_is_rejected() {
     }
     // A pre-release version is still a version.
     assert_eq!(
-        parse_latest_version(&release_json("srelens-v0.8.1-152")).unwrap(),
+        parse_latest_version_here(&release_json("srelens-v0.8.1-152")).unwrap(),
         "0.8.1-152"
     );
 }
@@ -371,11 +423,11 @@ fn a_release_tag_that_is_not_a_version_is_rejected() {
 /// one unreadable tag should not stop a dev user updating.
 #[test]
 fn the_dev_channel_skips_a_tag_it_cannot_read_and_takes_the_next() {
-    let body = br#"[
-        {"tag_name":"srelens-vnightly","prerelease":true},
-        {"tag_name":"srelens-v0.8.1-152","prerelease":true}
-    ]"#;
-    assert_eq!(parse_newest_version(body).unwrap(), "0.8.1-152");
+    let body = releases_json(&[
+        ("srelens-vnightly", true, false),
+        ("srelens-v0.8.1-152", true, true),
+    ]);
+    assert_eq!(parse_newest_version(&body, here()).unwrap(), "0.8.1-152");
 }
 
 // ---------------------------------------------------------------------------
@@ -410,6 +462,54 @@ fn a_planted_symlink_beside_the_binary_is_not_written_through() {
         "the linked file must be untouched"
     );
     assert_eq!(std::fs::read(&target).unwrap(), b"new");
+}
+
+/// A dev pre-release goes public the moment it builds, so if the TUI matrix
+/// or `tui-publish` fails afterwards the tag is out there with no archives on
+/// it. Offering it would promise an update and then 404 on the download.
+/// This is not hypothetical: every release cut before the TUI shipped looks
+/// exactly like that, and the dev check offered one.
+#[test]
+fn a_release_without_the_archives_is_passed_over_for_the_last_complete_one() {
+    let body = format!(
+        r#"[
+        {{"tag_name":"srelens-v0.8.1-152","prerelease":true,"assets":[]}},
+        {{"tag_name":"srelens-v0.8.1-150","prerelease":true,"assets":{}}}
+    ]"#,
+        assets_for("0.8.1-150")
+    );
+    assert_eq!(
+        parse_newest_version(body.as_bytes(), here()).unwrap(),
+        "0.8.1-150"
+    );
+}
+
+/// Half a release is no better than none: the archive without the checksum
+/// file cannot be verified, so it is not installable either.
+#[test]
+fn a_release_missing_only_the_checksum_file_is_also_passed_over() {
+    let body = format!(
+        r#"[{{"tag_name":"srelens-v0.8.1-152","prerelease":true,"assets":[{{"name":"{}"}}]}}]"#,
+        asset_name("0.8.1-152", here())
+    );
+    assert!(matches!(
+        parse_newest_version(body.as_bytes(), here()),
+        Err(UpdateError::BadRelease(_))
+    ));
+}
+
+/// On stable there is nothing to fall back to, so the same situation is
+/// reported instead of skipped — a named reason now beats a 404 later.
+#[test]
+fn a_stable_release_without_a_build_for_this_platform_says_so() {
+    let body = br#"{"tag_name":"srelens-v0.9.0","prerelease":false,"assets":[]}"#;
+    match parse_latest_version(body, here()) {
+        Err(UpdateError::BadRelease(why)) => {
+            assert!(why.contains("srelens-v0.9.0"), "{why}");
+            assert!(why.contains(here()), "{why}");
+        }
+        other => panic!("expected BadRelease, got {other:?}"),
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/tui/tests/self_update_tests.rs
+++ b/apps/tui/tests/self_update_tests.rs
@@ -307,7 +307,14 @@ fn each_channel_asks_its_own_endpoint() {
         Ok(release_json("srelens-v0.8.0"))
     };
     assert!(matches!(
-        plan("0.7.0", Channel::Stable, PathBuf::from("/tmp/x"), &stable).unwrap(),
+        plan(
+            "0.7.0",
+            Channel::Stable,
+            false,
+            PathBuf::from("/tmp/x"),
+            &stable
+        )
+        .unwrap(),
         Check::Available(_)
     ));
 
@@ -315,7 +322,15 @@ fn each_channel_asks_its_own_endpoint() {
         assert_eq!(url, RELEASES_URL);
         Ok(releases_json(&[("srelens-v0.8.1-152", true, true)]))
     };
-    match plan("0.8.1-150", Channel::Dev, PathBuf::from("/tmp/x"), &dev).unwrap() {
+    match plan(
+        "0.8.1-150",
+        Channel::Dev,
+        false,
+        PathBuf::from("/tmp/x"),
+        &dev,
+    )
+    .unwrap()
+    {
         Check::Available(plan) => {
             assert_eq!(plan.latest, "0.8.1-152");
             // Pre-release versions order by their numeric identifier, so 152
@@ -331,6 +346,64 @@ fn each_channel_asks_its_own_endpoint() {
     }
 }
 
+/// Naming a channel means asking to be ON it, even when that goes backwards.
+///
+/// The usual case rather than a corner: any dev build sorts above the
+/// stable release it was cut after, so without this `--channel stable`
+/// could never perform the switch the install guide promises.
+#[test]
+fn naming_the_stable_channel_from_a_dev_build_installs_stable() {
+    let fetch = |_: &str| -> Result<Vec<u8>, UpdateError> { Ok(release_json("srelens-v0.8.0")) };
+
+    // Asked for: the downgrade is the point.
+    match plan(
+        "0.8.1-152",
+        Channel::Stable,
+        true,
+        PathBuf::from("/tmp/x"),
+        &fetch,
+    )
+    .unwrap()
+    {
+        Check::Available(plan) => assert_eq!(plan.latest, "0.8.0"),
+        other => panic!("expected the switch to be planned, got {other:?}"),
+    }
+
+    // Not asked for: falling into stable by default is no reason to move
+    // someone backwards.
+    assert_eq!(
+        plan(
+            "0.8.1-152",
+            Channel::Stable,
+            false,
+            PathBuf::from("/tmp/x"),
+            &fetch
+        )
+        .unwrap(),
+        Check::AheadOfChannel {
+            channel: Channel::Stable,
+            latest: "0.8.0".into()
+        }
+    );
+
+    // Already on it, asked for or not: nothing to do.
+    let fetch = |_: &str| -> Result<Vec<u8>, UpdateError> { Ok(release_json("srelens-v1.0.0")) };
+    assert_eq!(
+        plan(
+            "1.0.0",
+            Channel::Stable,
+            true,
+            PathBuf::from("/tmp/x"),
+            &fetch
+        )
+        .unwrap(),
+        Check::UpToDate {
+            channel: Channel::Stable,
+            latest: "1.0.0".into()
+        }
+    );
+}
+
 /// A dev build checked against dev is up to date; the same build checked
 /// against stable is ahead of it. Two different facts, two different answers.
 #[test]
@@ -339,7 +412,14 @@ fn a_dev_build_is_up_to_date_on_dev_and_ahead_on_stable() {
         Ok(releases_json(&[("srelens-v0.8.1-152", true, true)]))
     };
     assert_eq!(
-        plan("0.8.1-152", Channel::Dev, PathBuf::from("/tmp/x"), &dev).unwrap(),
+        plan(
+            "0.8.1-152",
+            Channel::Dev,
+            false,
+            PathBuf::from("/tmp/x"),
+            &dev
+        )
+        .unwrap(),
         Check::UpToDate {
             channel: Channel::Dev,
             latest: "0.8.1-152".into()
@@ -351,6 +431,7 @@ fn a_dev_build_is_up_to_date_on_dev_and_ahead_on_stable() {
         plan(
             "0.8.1-152",
             Channel::Stable,
+            false,
             PathBuf::from("/tmp/x"),
             &stable
         )
@@ -673,20 +754,34 @@ fn a_binary_a_package_manager_owns_is_recognised() {
         ),
         ("/snap/srelens/current/bin/srelens-tui", "snap"),
         ("/nix/store/abc-srelens/bin/srelens-tui", "Nix"),
-        // Windows paths are case-insensitive, and the real Chocolatey root
-        // is `C:\\ProgramData\\chocolatey` — lower case. A case-sensitive
-        // match let a Chocolatey-managed copy through this guard entirely.
+    ] {
+        assert_eq!(
+            package_manager_for(Path::new(path)),
+            Some(manager),
+            "{path}"
+        );
+    }
+}
+
+/// The Windows markers are Windows-only. Applied everywhere,
+/// `/home/me/scoop/apps/…` on Linux read as Scoop-owned and the update was
+/// refused before anything was downloaded — these names mean a package
+/// manager on one platform and nothing in particular on the others.
+#[cfg(windows)]
+#[test]
+fn a_windows_package_manager_is_recognised_at_any_depth_and_any_case() {
+    for (path, manager) in [
         (
             r"C:\ProgramData\chocolatey\bin\srelens-tui.exe",
             "Chocolatey",
         ),
         (
-            r"C:\Users\me\Scoop\Apps\srelens-tui\current\srelens-tui.exe",
-            "Scoop",
-        ),
-        (
             r"C:\PROGRAMDATA\CHOCOLATEY\bin\srelens-tui.exe",
             "Chocolatey",
+        ),
+        (
+            r"C:\Users\me\Scoop\Apps\srelens-tui\current\srelens-tui.exe",
+            "Scoop",
         ),
         (r"C:\Users\me\scoop\shims\srelens-tui.exe", "Scoop"),
         (
@@ -699,6 +794,20 @@ fn a_binary_a_package_manager_owns_is_recognised() {
             Some(manager),
             "{path}"
         );
+    }
+}
+
+/// The same names on Unix mean nothing in particular, and refusing there
+/// would block an update to a file its owner controls.
+#[cfg(unix)]
+#[test]
+fn windows_package_markers_do_not_apply_on_unix() {
+    for path in [
+        "/home/me/scoop/apps/demo/srelens-tui",
+        "/home/me/scoop/shims/srelens-tui",
+        "/opt/chocolatey/srelens-tui",
+    ] {
+        assert_eq!(package_manager_for(Path::new(path)), None, "{path}");
     }
 }
 
@@ -762,6 +871,7 @@ fn being_up_to_date_is_a_quiet_success_not_an_error() {
         plan(
             "1.0.0",
             Channel::Stable,
+            false,
             PathBuf::from("/tmp/srelens-tui"),
             &fetch
         )
@@ -784,6 +894,7 @@ fn a_build_ahead_of_stable_is_not_reported_as_up_to_date() {
         plan(
             "0.8.1-152",
             Channel::Stable,
+            false,
             PathBuf::from("/tmp/srelens-tui"),
             &fetch
         )
@@ -801,6 +912,7 @@ fn a_build_ahead_of_stable_is_not_reported_as_up_to_date() {
         plan(
             "0.8.0-7",
             Channel::Stable,
+            false,
             PathBuf::from("/tmp/srelens-tui"),
             &fetch
         )
@@ -819,6 +931,7 @@ fn an_unparseable_current_version_is_not_claimed_to_be_ahead() {
         plan(
             "nightly",
             Channel::Stable,
+            false,
             PathBuf::from("/tmp/srelens-tui"),
             &fetch
         )
@@ -836,6 +949,7 @@ fn a_newer_release_plans_urls_under_its_own_tag() {
     let plan = match plan(
         "1.0.0",
         Channel::Stable,
+        false,
         PathBuf::from("/tmp/srelens-tui"),
         &fetch,
     )
@@ -868,6 +982,7 @@ fn a_failed_release_lookup_is_reported_rather_than_swallowed() {
         plan(
             "1.0.0",
             Channel::Stable,
+            false,
             PathBuf::from("/tmp/srelens-tui"),
             &fetch
         ),

--- a/apps/tui/tests/self_update_tests.rs
+++ b/apps/tui/tests/self_update_tests.rs
@@ -10,8 +10,8 @@ use std::path::{Path, PathBuf};
 
 use srelens_tui::self_update::{
     apply, asset_name, asset_url, checksum_for, extract_binary, is_newer, package_manager_for,
-    parse_latest_version, plan, replace_running_binary, sums_name, triple_for, verify_sha256,
-    Check, Plan, UpdateError, LATEST_RELEASE_URL,
+    parse_latest_version, parse_newest_version, plan, replace_running_binary, sums_name,
+    triple_for, verify_sha256, Channel, Check, Plan, UpdateError, LATEST_RELEASE_URL, RELEASES_URL,
 };
 
 // ---------------------------------------------------------------------------
@@ -157,6 +157,139 @@ fn asset_names_match_what_the_release_workflow_publishes() {
     assert_eq!(
         asset_url("1.2.3", "srelens-tui-1.2.3-SHA256SUMS.txt"),
         "https://github.com/srelens/srelens/releases/download/srelens-v1.2.3/srelens-tui-1.2.3-SHA256SUMS.txt"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Channels
+// ---------------------------------------------------------------------------
+
+/// The default has to keep a dev user on dev. Offering a pre-release only the
+/// stable channel would strand it: the stable release it already sits above is
+/// not an update, so there would be nothing to install.
+#[test]
+fn the_default_channel_is_the_one_the_binary_came_from() {
+    // Exactly the shape .github/workflows/release.yml gives a dev build.
+    assert_eq!(Channel::of_version("0.8.1-152"), Channel::Dev);
+    assert_eq!(Channel::of_version("1.0.0-1"), Channel::Dev);
+
+    assert_eq!(Channel::of_version("0.8.0"), Channel::Stable);
+    assert_eq!(Channel::of_version("1.2.3"), Channel::Stable);
+    // Unparseable falls to stable rather than assuming someone is on dev.
+    assert_eq!(Channel::of_version("nightly"), Channel::Stable);
+}
+
+#[test]
+fn a_channel_can_be_named_on_the_command_line() {
+    assert_eq!(Channel::parse("stable"), Some(Channel::Stable));
+    assert_eq!(Channel::parse("dev"), Some(Channel::Dev));
+    assert_eq!(Channel::parse("  DEV  "), Some(Channel::Dev));
+    assert_eq!(Channel::parse("nightly"), None);
+    assert_eq!(Channel::parse(""), None);
+    assert_eq!(Channel::Stable.as_str(), "stable");
+    assert_eq!(Channel::Dev.as_str(), "dev");
+}
+
+/// The dev channel reads the releases LIST, because pre-releases are what it
+/// is made of and the stable endpoint hides them by definition.
+#[test]
+fn the_dev_channel_takes_the_newest_release_of_any_kind() {
+    let body = br#"[
+        {"tag_name":"srelens-v0.8.1-152","prerelease":true},
+        {"tag_name":"srelens-v0.8.1-150","prerelease":true},
+        {"tag_name":"srelens-v0.8.0","prerelease":false}
+    ]"#;
+    assert_eq!(parse_newest_version(body).unwrap(), "0.8.1-152");
+}
+
+/// The rolling `dev-channel` release is a permanent pre-release carrying only
+/// the desktop updater's manifest — no TUI archives — so resolving to it would
+/// build URLs for assets that are not there.
+#[test]
+fn the_dev_channel_skips_the_rolling_manifest_release() {
+    let body = br#"[
+        {"tag_name":"dev-channel","prerelease":true},
+        {"tag_name":"some-other-tag","prerelease":true},
+        {"tag_name":"srelens-v0.8.1-152","prerelease":true}
+    ]"#;
+    assert_eq!(parse_newest_version(body).unwrap(), "0.8.1-152");
+}
+
+#[test]
+fn a_list_with_no_srelens_release_is_an_error_not_a_guess() {
+    assert!(matches!(
+        parse_newest_version(br#"[{"tag_name":"dev-channel"}]"#),
+        Err(UpdateError::BadRelease(_))
+    ));
+    assert!(matches!(
+        parse_newest_version(b"[]"),
+        Err(UpdateError::BadRelease(_))
+    ));
+    assert!(matches!(
+        parse_newest_version(b"not a list"),
+        Err(UpdateError::BadRelease(_))
+    ));
+}
+
+#[test]
+fn each_channel_asks_its_own_endpoint() {
+    let stable = |url: &str| -> Result<Vec<u8>, UpdateError> {
+        assert_eq!(url, LATEST_RELEASE_URL);
+        Ok(release_json("srelens-v0.8.0"))
+    };
+    assert!(matches!(
+        plan("0.7.0", Channel::Stable, PathBuf::from("/tmp/x"), &stable).unwrap(),
+        Check::Available(_)
+    ));
+
+    let dev = |url: &str| -> Result<Vec<u8>, UpdateError> {
+        assert_eq!(url, RELEASES_URL);
+        Ok(br#"[{"tag_name":"srelens-v0.8.1-152"}]"#.to_vec())
+    };
+    match plan("0.8.1-150", Channel::Dev, PathBuf::from("/tmp/x"), &dev).unwrap() {
+        Check::Available(plan) => {
+            assert_eq!(plan.latest, "0.8.1-152");
+            // Pre-release versions order by their numeric identifier, so 152
+            // is an update over 150 — a string comparison would agree here by
+            // luck and disagree at 99 against 100.
+            assert!(
+                plan.archive_url.contains("/srelens-v0.8.1-152/"),
+                "{}",
+                plan.archive_url
+            );
+        }
+        other => panic!("expected an update on the dev channel, got {other:?}"),
+    }
+}
+
+/// A dev build checked against dev is up to date; the same build checked
+/// against stable is ahead of it. Two different facts, two different answers.
+#[test]
+fn a_dev_build_is_up_to_date_on_dev_and_ahead_on_stable() {
+    let dev = |_: &str| -> Result<Vec<u8>, UpdateError> {
+        Ok(br#"[{"tag_name":"srelens-v0.8.1-152"}]"#.to_vec())
+    };
+    assert_eq!(
+        plan("0.8.1-152", Channel::Dev, PathBuf::from("/tmp/x"), &dev).unwrap(),
+        Check::UpToDate {
+            channel: Channel::Dev,
+            latest: "0.8.1-152".into()
+        }
+    );
+
+    let stable = |_: &str| -> Result<Vec<u8>, UpdateError> { Ok(release_json("srelens-v0.8.0")) };
+    assert_eq!(
+        plan(
+            "0.8.1-152",
+            Channel::Stable,
+            PathBuf::from("/tmp/x"),
+            &stable
+        )
+        .unwrap(),
+        Check::AheadOfChannel {
+            channel: Channel::Stable,
+            latest: "0.8.0".into()
+        }
     );
 }
 
@@ -361,8 +494,15 @@ fn being_up_to_date_is_a_quiet_success_not_an_error() {
         Ok(release_json("srelens-v1.0.0"))
     };
     assert_eq!(
-        plan("1.0.0", PathBuf::from("/tmp/srelens-tui"), &fetch).unwrap(),
+        plan(
+            "1.0.0",
+            Channel::Stable,
+            PathBuf::from("/tmp/srelens-tui"),
+            &fetch
+        )
+        .unwrap(),
         Check::UpToDate {
+            channel: Channel::Stable,
             latest: "1.0.0".into()
         }
     );
@@ -376,8 +516,15 @@ fn a_build_ahead_of_stable_is_not_reported_as_up_to_date() {
     let fetch = |_: &str| -> Result<Vec<u8>, UpdateError> { Ok(release_json("srelens-v0.8.0")) };
     // Exactly the shape the dev channel produces: 0.8.1-152 sorts above 0.8.0.
     assert_eq!(
-        plan("0.8.1-152", PathBuf::from("/tmp/srelens-tui"), &fetch).unwrap(),
-        Check::AheadOfStable {
+        plan(
+            "0.8.1-152",
+            Channel::Stable,
+            PathBuf::from("/tmp/srelens-tui"),
+            &fetch
+        )
+        .unwrap(),
+        Check::AheadOfChannel {
+            channel: Channel::Stable,
             latest: "0.8.0".into()
         }
     );
@@ -386,7 +533,13 @@ fn a_build_ahead_of_stable_is_not_reported_as_up_to_date() {
     // so that one is a real update rather than being ahead.
     let fetch = |_: &str| -> Result<Vec<u8>, UpdateError> { Ok(release_json("srelens-v0.8.0")) };
     assert!(matches!(
-        plan("0.8.0-7", PathBuf::from("/tmp/srelens-tui"), &fetch).unwrap(),
+        plan(
+            "0.8.0-7",
+            Channel::Stable,
+            PathBuf::from("/tmp/srelens-tui"),
+            &fetch
+        )
+        .unwrap(),
         Check::Available(_)
     ));
 }
@@ -398,8 +551,15 @@ fn a_build_ahead_of_stable_is_not_reported_as_up_to_date() {
 fn an_unparseable_current_version_is_not_claimed_to_be_ahead() {
     let fetch = |_: &str| -> Result<Vec<u8>, UpdateError> { Ok(release_json("srelens-v1.0.0")) };
     assert_eq!(
-        plan("nightly", PathBuf::from("/tmp/srelens-tui"), &fetch).unwrap(),
+        plan(
+            "nightly",
+            Channel::Stable,
+            PathBuf::from("/tmp/srelens-tui"),
+            &fetch
+        )
+        .unwrap(),
         Check::UpToDate {
+            channel: Channel::Stable,
             latest: "1.0.0".into()
         }
     );
@@ -408,7 +568,14 @@ fn an_unparseable_current_version_is_not_claimed_to_be_ahead() {
 #[test]
 fn a_newer_release_plans_urls_under_its_own_tag() {
     let fetch = |_: &str| -> Result<Vec<u8>, UpdateError> { Ok(release_json("srelens-v2.0.0")) };
-    let plan = match plan("1.0.0", PathBuf::from("/tmp/srelens-tui"), &fetch).unwrap() {
+    let plan = match plan(
+        "1.0.0",
+        Channel::Stable,
+        PathBuf::from("/tmp/srelens-tui"),
+        &fetch,
+    )
+    .unwrap()
+    {
         Check::Available(plan) => *plan,
         other => panic!("expected an update, got {other:?}"),
     };
@@ -433,7 +600,12 @@ fn a_failed_release_lookup_is_reported_rather_than_swallowed() {
         Err(UpdateError::Download("503 Service Unavailable".into()))
     };
     assert!(matches!(
-        plan("1.0.0", PathBuf::from("/tmp/srelens-tui"), &fetch),
+        plan(
+            "1.0.0",
+            Channel::Stable,
+            PathBuf::from("/tmp/srelens-tui"),
+            &fetch
+        ),
         Err(UpdateError::Download(_))
     ));
 }

--- a/apps/tui/tests/self_update_tests.rs
+++ b/apps/tui/tests/self_update_tests.rs
@@ -1,0 +1,539 @@
+//! Tests for `srelens-tui update`.
+//!
+//! No stable release carries the TUI archives yet — #444 only just landed — so
+//! the download-verify-replace path cannot be proven against a real release.
+//! It is proven here instead: the archives are built in the test, hashed with
+//! the same function the code uses, and served through the injected `fetch`.
+//! Nothing reaches the network.
+
+use std::path::{Path, PathBuf};
+
+use srelens_tui::self_update::{
+    apply, asset_name, asset_url, checksum_for, extract_binary, is_newer, package_manager_for,
+    parse_latest_version, plan, replace_running_binary, sums_name, triple_for, verify_sha256, Plan,
+    UpdateError, LATEST_RELEASE_URL,
+};
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/// A gzipped tar holding one file at the archive root, the way the release
+/// workflow builds it (`tar -czf … -C dir .`, so members arrive as `./name`).
+fn targz(name: &str, contents: &[u8]) -> Vec<u8> {
+    let mut tar = tar::Builder::new(Vec::new());
+    let mut header = tar::Header::new_gnu();
+    header.set_size(contents.len() as u64);
+    header.set_mode(0o755);
+    header.set_cksum();
+    tar.append_data(&mut header, format!("./{name}"), contents)
+        .expect("append");
+    let tar = tar.into_inner().expect("finish tar");
+
+    use std::io::Write;
+    let mut gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+    gz.write_all(&tar).expect("gzip");
+    gz.finish().expect("finish gzip")
+}
+
+/// A zip holding one file at the root, as the Windows leg builds it.
+fn zip_with(name: &str, contents: &[u8]) -> Vec<u8> {
+    use std::io::Write;
+    let mut zip = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+    zip.start_file::<_, ()>(name, zip::write::SimpleFileOptions::default())
+        .expect("start");
+    zip.write_all(contents).expect("write");
+    zip.finish().expect("finish").into_inner()
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+fn release_json(tag: &str) -> Vec<u8> {
+    format!(r#"{{"tag_name":"{tag}","prerelease":false}}"#).into_bytes()
+}
+
+/// The binary name inside an archive for the platform under test.
+fn bin_name() -> &'static str {
+    if cfg!(windows) {
+        "srelens-tui.exe"
+    } else {
+        "srelens-tui"
+    }
+}
+
+/// An archive of the right kind for the platform under test, carrying `body`.
+fn archive_for(asset: &str, body: &[u8]) -> Vec<u8> {
+    if asset.ends_with(".zip") {
+        zip_with(bin_name(), body)
+    } else {
+        targz(bin_name(), body)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Platform → asset
+// ---------------------------------------------------------------------------
+
+#[test]
+fn every_target_the_release_builds_has_a_triple_and_nothing_else_does() {
+    // The seven legs in .github/workflows/release.yml, exactly.
+    assert_eq!(
+        triple_for("linux", "x86_64", false).unwrap(),
+        "x86_64-unknown-linux-gnu"
+    );
+    assert_eq!(
+        triple_for("linux", "x86_64", true).unwrap(),
+        "x86_64-unknown-linux-musl"
+    );
+    assert_eq!(
+        triple_for("linux", "aarch64", false).unwrap(),
+        "aarch64-unknown-linux-gnu"
+    );
+    assert_eq!(
+        triple_for("linux", "aarch64", true).unwrap(),
+        "aarch64-unknown-linux-musl"
+    );
+    assert_eq!(
+        triple_for("macos", "x86_64", false).unwrap(),
+        "x86_64-apple-darwin"
+    );
+    assert_eq!(
+        triple_for("macos", "aarch64", false).unwrap(),
+        "aarch64-apple-darwin"
+    );
+    assert_eq!(
+        triple_for("windows", "x86_64", false).unwrap(),
+        "x86_64-pc-windows-msvc"
+    );
+
+    // No 32-bit and no arm64 Windows leg is built, so there is nothing to
+    // point those at; saying so beats downloading the wrong architecture.
+    for (os, arch) in [
+        ("windows", "aarch64"),
+        ("linux", "i686"),
+        ("freebsd", "x86_64"),
+    ] {
+        assert!(
+            matches!(
+                triple_for(os, arch, false),
+                Err(UpdateError::UnsupportedPlatform { .. })
+            ),
+            "{os}/{arch} should be unsupported"
+        );
+    }
+}
+
+/// A musl binary exists because the host cannot run the glibc one. Updating it
+/// across flavours would hand the user something that no longer starts.
+#[test]
+fn a_musl_binary_updates_to_a_musl_archive() {
+    assert!(triple_for("linux", "x86_64", true)
+        .unwrap()
+        .ends_with("musl"));
+    assert!(triple_for("linux", "aarch64", true)
+        .unwrap()
+        .ends_with("musl"));
+    assert!(triple_for("linux", "x86_64", false)
+        .unwrap()
+        .ends_with("gnu"));
+}
+
+#[test]
+fn asset_names_match_what_the_release_workflow_publishes() {
+    assert_eq!(
+        asset_name("1.2.3", "x86_64-unknown-linux-gnu"),
+        "srelens-tui-1.2.3-x86_64-unknown-linux-gnu.tar.gz"
+    );
+    // Windows is a zip, never a bare exe — size-baseline.mjs treats any .exe
+    // as a desktop installer.
+    assert_eq!(
+        asset_name("1.2.3", "x86_64-pc-windows-msvc"),
+        "srelens-tui-1.2.3-x86_64-pc-windows-msvc.zip"
+    );
+    assert_eq!(sums_name("1.2.3"), "srelens-tui-1.2.3-SHA256SUMS.txt");
+    assert_eq!(
+        asset_url("1.2.3", "srelens-tui-1.2.3-SHA256SUMS.txt"),
+        "https://github.com/srelens/srelens/releases/download/srelens-v1.2.3/srelens-tui-1.2.3-SHA256SUMS.txt"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Release metadata
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_release_tag_is_read_without_its_prefix() {
+    assert_eq!(
+        parse_latest_version(&release_json("srelens-v0.9.1")).unwrap(),
+        "0.9.1"
+    );
+}
+
+#[test]
+fn an_unreadable_release_response_is_an_error_not_a_guess() {
+    for body in [
+        &b"not json"[..],
+        br#"{"prerelease":false}"#,
+        br#"{"tag_name":"v1.0.0"}"#,
+        br#"{"tag_name":"srelens-v"}"#,
+    ] {
+        assert!(
+            matches!(parse_latest_version(body), Err(UpdateError::BadRelease(_))),
+            "{:?} should not parse",
+            String::from_utf8_lossy(body)
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Checksums
+// ---------------------------------------------------------------------------
+
+/// The release writes sums on Linux (two spaces); a developer regenerating
+/// them on a system defaulting to binary mode writes `*name`. Both must read.
+#[test]
+fn a_checksum_is_found_in_either_sha256sum_format() {
+    let hash = "a".repeat(64);
+    let asset = "srelens-tui-1.2.3-x86_64-unknown-linux-gnu.tar.gz";
+    let gnu = format!("{hash}  {asset}\n{}  other.tar.gz\n", "b".repeat(64));
+    let binary_mode = format!("{hash} *{asset}\n");
+
+    assert_eq!(checksum_for(&gnu, asset).unwrap(), hash);
+    assert_eq!(checksum_for(&binary_mode, asset).unwrap(), hash);
+}
+
+#[test]
+fn a_checksum_file_that_does_not_list_the_asset_is_refused() {
+    let sums = format!("{}  some-other-file.tar.gz\n", "a".repeat(64));
+    assert!(matches!(
+        checksum_for(&sums, "srelens-tui-1.2.3-x86_64-apple-darwin.tar.gz"),
+        Err(UpdateError::ChecksumMissing { .. })
+    ));
+    // A line for the right asset carrying something that is not a hash is the
+    // same failure: there is nothing to verify against.
+    let malformed = "not-a-hash  wanted.tar.gz\n";
+    assert!(matches!(
+        checksum_for(malformed, "wanted.tar.gz"),
+        Err(UpdateError::ChecksumMissing { .. })
+    ));
+}
+
+#[test]
+fn verification_accepts_the_published_hash_and_rejects_any_other() {
+    let bytes = b"payload";
+    let hash = sha256_hex(bytes);
+    assert!(verify_sha256(bytes, &hash).is_ok());
+    assert!(
+        verify_sha256(bytes, &hash.to_uppercase()).is_ok(),
+        "case-insensitive"
+    );
+    assert!(matches!(
+        verify_sha256(b"different", &hash),
+        Err(UpdateError::ChecksumMismatch { .. })
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// Archives
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_binary_is_pulled_out_of_a_tarball_stored_at_the_root() {
+    let archive = targz("srelens-tui", b"ELF-ish");
+    let got = extract_binary(
+        &archive,
+        "srelens-tui-1.2.3-x86_64-unknown-linux-gnu.tar.gz",
+    );
+    assert_eq!(got.unwrap(), b"ELF-ish");
+}
+
+#[test]
+fn the_binary_is_pulled_out_of_a_zip() {
+    let archive = zip_with("srelens-tui.exe", b"MZ-ish");
+    let got = extract_binary(&archive, "srelens-tui-1.2.3-x86_64-pc-windows-msvc.zip");
+    assert_eq!(got.unwrap(), b"MZ-ish");
+}
+
+#[test]
+fn an_archive_without_the_binary_is_an_error_naming_the_asset() {
+    let archive = targz("README", b"nope");
+    let asset = "srelens-tui-1.2.3-x86_64-unknown-linux-gnu.tar.gz";
+    match extract_binary(&archive, asset) {
+        Err(UpdateError::BinaryMissing { asset: named }) => assert_eq!(named, asset),
+        other => panic!("expected BinaryMissing, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_corrupt_archive_reports_the_archive_not_a_panic() {
+    assert!(matches!(
+        extract_binary(b"not a tarball at all", "x-1.0.0-linux.tar.gz"),
+        Err(UpdateError::Archive(_)) | Err(UpdateError::BinaryMissing { .. })
+    ));
+    assert!(matches!(
+        extract_binary(b"not a zip at all", "x-1.0.0-windows.zip"),
+        Err(UpdateError::Archive(_))
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// Version comparison
+// ---------------------------------------------------------------------------
+
+#[test]
+fn versions_compare_as_semver_not_as_text() {
+    // The case a string comparison gets backwards, and the reason semver is
+    // parsed at all.
+    assert!(is_newer("0.9.0", "0.10.0"));
+    assert!(!is_newer("0.10.0", "0.9.0"));
+
+    assert!(is_newer("1.2.3", "1.2.4"));
+    assert!(!is_newer("1.2.3", "1.2.3"), "equal is not newer");
+    assert!(!is_newer("1.2.4", "1.2.3"));
+    // A pre-release sorts below its release, so a dev build is not offered an
+    // "update" to the stable it already contains.
+    assert!(is_newer("1.2.3-99", "1.2.3"));
+}
+
+#[test]
+fn an_unparseable_version_never_triggers_an_update() {
+    assert!(!is_newer("not-a-version", "1.0.0"));
+    assert!(!is_newer("1.0.0", "not-a-version"));
+}
+
+// ---------------------------------------------------------------------------
+// Package-manager ownership
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_binary_a_package_manager_owns_is_recognised() {
+    for (path, manager) in [
+        ("/opt/homebrew/bin/srelens-tui", "Homebrew"),
+        (
+            "/usr/local/Cellar/srelens-tui/1.0.0/bin/srelens-tui",
+            "Homebrew",
+        ),
+        (
+            "/usr/bin/srelens-tui",
+            "your distribution's package manager",
+        ),
+        ("/snap/srelens/current/bin/srelens-tui", "snap"),
+        ("/nix/store/abc-srelens/bin/srelens-tui", "Nix"),
+        (r"C:\Users\me\scoop\shims\srelens-tui.exe", "Scoop"),
+        (
+            r"C:\Users\me\AppData\Local\Microsoft\WinGet\Packages\x\srelens-tui.exe",
+            "winget",
+        ),
+    ] {
+        assert_eq!(
+            package_manager_for(Path::new(path)),
+            Some(manager),
+            "{path}"
+        );
+    }
+}
+
+/// The locations the install guide tells people to use by hand. Reporting one
+/// of these as package-managed would refuse to update the ordinary install.
+#[test]
+fn a_hand_installed_binary_is_not_mistaken_for_a_managed_one() {
+    for path in [
+        "/usr/local/bin/srelens-tui",
+        "/home/me/.local/bin/srelens-tui",
+        "/home/me/bin/srelens-tui",
+        r"C:\Users\me\bin\srelens-tui.exe",
+    ] {
+        assert_eq!(package_manager_for(Path::new(path)), None, "{path}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Planning
+// ---------------------------------------------------------------------------
+
+#[test]
+fn being_up_to_date_is_a_quiet_success_not_an_error() {
+    let fetch = |url: &str| -> Result<Vec<u8>, UpdateError> {
+        assert_eq!(url, LATEST_RELEASE_URL);
+        Ok(release_json("srelens-v1.0.0"))
+    };
+    assert_eq!(
+        plan("1.0.0", PathBuf::from("/tmp/srelens-tui"), &fetch).unwrap(),
+        None
+    );
+    // A build ahead of the latest release (a local one) is also "nothing to do".
+    assert_eq!(
+        plan("1.1.0", PathBuf::from("/tmp/srelens-tui"), &fetch).unwrap(),
+        None
+    );
+}
+
+#[test]
+fn a_newer_release_plans_urls_under_its_own_tag() {
+    let fetch = |_: &str| -> Result<Vec<u8>, UpdateError> { Ok(release_json("srelens-v2.0.0")) };
+    let plan = plan("1.0.0", PathBuf::from("/tmp/srelens-tui"), &fetch)
+        .unwrap()
+        .expect("an update is available");
+
+    assert_eq!(plan.current, "1.0.0");
+    assert_eq!(plan.latest, "2.0.0");
+    assert!(
+        plan.archive_url.contains("/srelens-v2.0.0/") && plan.archive_url.ends_with(&plan.asset),
+        "{}",
+        plan.archive_url
+    );
+    assert!(
+        plan.sums_url.ends_with("srelens-tui-2.0.0-SHA256SUMS.txt"),
+        "{}",
+        plan.sums_url
+    );
+}
+
+#[test]
+fn a_failed_release_lookup_is_reported_rather_than_swallowed() {
+    let fetch = |_: &str| -> Result<Vec<u8>, UpdateError> {
+        Err(UpdateError::Download("503 Service Unavailable".into()))
+    };
+    assert!(matches!(
+        plan("1.0.0", PathBuf::from("/tmp/srelens-tui"), &fetch),
+        Err(UpdateError::Download(_))
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// Applying — the part no release can exercise yet
+// ---------------------------------------------------------------------------
+
+/// Build a plan whose target is a real file in `dir`, plus a fetch that serves
+/// a matching archive and checksum file.
+fn staged(
+    dir: &Path,
+    body: &'static [u8],
+) -> (Plan, impl Fn(&str) -> Result<Vec<u8>, UpdateError>) {
+    let triple = triple_for(
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+        cfg!(target_env = "musl"),
+    )
+    .expect("this platform has a release target");
+    let asset = asset_name("2.0.0", triple);
+    let target = dir.join(bin_name());
+    std::fs::write(&target, b"the old binary").expect("seed the installed binary");
+
+    let archive = archive_for(&asset, body);
+    let sums = format!("{}  {}\n", sha256_hex(&archive), asset);
+    let plan = Plan {
+        current: "1.0.0".into(),
+        latest: "2.0.0".into(),
+        archive_url: asset_url("2.0.0", &asset),
+        sums_url: asset_url("2.0.0", &sums_name("2.0.0")),
+        asset,
+        target,
+    };
+    let sums_url = plan.sums_url.clone();
+    let fetch = move |url: &str| -> Result<Vec<u8>, UpdateError> {
+        if url == sums_url {
+            Ok(sums.clone().into_bytes())
+        } else {
+            Ok(archive.clone())
+        }
+    };
+    (plan, fetch)
+}
+
+#[test]
+fn a_verified_download_replaces_the_installed_binary() {
+    let dir = tempfile::tempdir().unwrap();
+    let (plan, fetch) = staged(dir.path(), b"the new binary");
+
+    apply(&plan, &fetch).expect("the update applies");
+
+    assert_eq!(
+        std::fs::read(&plan.target).unwrap(),
+        b"the new binary",
+        "the installed binary is the one from the archive"
+    );
+    // Nothing staged is left lying around next to it.
+    let strays: Vec<_> = std::fs::read_dir(dir.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| n != bin_name())
+        .collect();
+    assert!(strays.is_empty(), "left behind: {strays:?}");
+}
+
+/// The property the whole design exists for: a download that does not match
+/// its published checksum must not reach the path the user runs.
+#[test]
+fn a_download_that_fails_verification_leaves_the_old_binary_in_place() {
+    let dir = tempfile::tempdir().unwrap();
+    let (plan, _) = staged(dir.path(), b"unused");
+    let asset = plan.asset.clone();
+    let sums_url = plan.sums_url.clone();
+    // The checksum file names a hash the archive does not have — what a
+    // substituted or truncated download looks like.
+    let fetch = move |url: &str| -> Result<Vec<u8>, UpdateError> {
+        if url == sums_url {
+            Ok(format!("{}  {}\n", "a".repeat(64), asset).into_bytes())
+        } else {
+            Ok(archive_for(&asset, b"tampered"))
+        }
+    };
+
+    match apply(&plan, &fetch) {
+        Err(UpdateError::ChecksumMismatch { .. }) => {}
+        other => panic!("expected a checksum mismatch, got {other:?}"),
+    }
+    assert_eq!(
+        std::fs::read(&plan.target).unwrap(),
+        b"the old binary",
+        "the installed binary must be untouched"
+    );
+}
+
+#[test]
+fn a_binary_a_package_manager_owns_is_refused_before_anything_is_downloaded() {
+    let dir = tempfile::tempdir().unwrap();
+    let (mut plan, _) = staged(dir.path(), b"unused");
+    plan.target = PathBuf::from("/opt/homebrew/bin").join(bin_name());
+    let fetch = |_: &str| -> Result<Vec<u8>, UpdateError> {
+        panic!("nothing should be downloaded for a package-managed binary")
+    };
+
+    match apply(&plan, &fetch) {
+        Err(UpdateError::PackageManaged { manager, .. }) => assert_eq!(manager, "Homebrew"),
+        other => panic!("expected PackageManaged, got {other:?}"),
+    }
+}
+
+#[test]
+fn replacing_the_binary_is_atomic_from_the_readers_point_of_view() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join(bin_name());
+    std::fs::write(&target, b"old").unwrap();
+
+    replace_running_binary(&target, b"new").expect("replace");
+    assert_eq!(std::fs::read(&target).unwrap(), b"new");
+
+    // Twice in a row: on Windows the second call has to cope with the `.old`
+    // file the first one could not delete while the image was open.
+    replace_running_binary(&target, b"newer").expect("replace again");
+    assert_eq!(std::fs::read(&target).unwrap(), b"newer");
+}
+
+#[cfg(unix)]
+#[test]
+fn the_installed_binary_is_executable() {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join(bin_name());
+    std::fs::write(&target, b"old").unwrap();
+
+    replace_running_binary(&target, b"new").expect("replace");
+    let mode = std::fs::metadata(&target).unwrap().permissions().mode();
+    assert_eq!(mode & 0o111, 0o111, "mode was {mode:o} — not executable");
+}

--- a/apps/tui/tests/self_update_tests.rs
+++ b/apps/tui/tests/self_update_tests.rs
@@ -438,6 +438,33 @@ fn the_dev_channel_skips_a_tag_it_cannot_read_and_takes_the_next() {
 /// advance cannot be written through. On Unix that is the difference between
 /// truncating a symlink's target and refusing; the same guard is what stops
 /// a stale leftover being reused on any platform.
+/// A staged download must not survive a failure. Unix only because the
+/// failure has to be forced, and a directory where the binary belongs makes
+/// the final rename fail there; on Windows the same setup renames the
+/// directory aside instead and succeeds.
+///
+/// This matters more than it reads: the staged names are random, so a leak
+/// accumulates a full copy of the binary per attempt rather than reusing one
+/// path.
+#[cfg(unix)]
+#[test]
+fn a_failed_replacement_leaves_nothing_staged_behind() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join(bin_name());
+    std::fs::create_dir(&target).expect("a directory where the binary should be");
+
+    let result = replace_running_binary(&target, b"new");
+    assert!(result.is_err(), "renaming onto a directory must fail");
+
+    let strays: Vec<String> = std::fs::read_dir(dir.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|name| name != bin_name())
+        .collect();
+    assert!(strays.is_empty(), "left behind: {strays:?}");
+}
+
 #[cfg(unix)]
 #[test]
 fn a_planted_symlink_beside_the_binary_is_not_written_through() {

--- a/apps/tui/tests/self_update_tests.rs
+++ b/apps/tui/tests/self_update_tests.rs
@@ -321,6 +321,77 @@ fn an_unreadable_release_response_is_an_error_not_a_guess() {
     }
 }
 
+/// A tag that is not a version must be reported as bad metadata. Accepting
+/// it would fail the later comparison, and that failure reads as "nothing
+/// newer" — so a broken release would tell the user they are up to date.
+#[test]
+fn a_release_tag_that_is_not_a_version_is_rejected() {
+    for tag in [
+        "srelens-vnightly",
+        "srelens-vlatest",
+        "srelens-v1.2",
+        "srelens-v",
+    ] {
+        assert!(
+            matches!(
+                parse_latest_version(&release_json(tag)),
+                Err(UpdateError::BadRelease(_))
+            ),
+            "{tag} should be refused"
+        );
+    }
+    // A pre-release version is still a version.
+    assert_eq!(
+        parse_latest_version(&release_json("srelens-v0.8.1-152")).unwrap(),
+        "0.8.1-152"
+    );
+}
+
+/// The list endpoint is the other way round: there is a next entry to try, so
+/// one unreadable tag should not stop a dev user updating.
+#[test]
+fn the_dev_channel_skips_a_tag_it_cannot_read_and_takes_the_next() {
+    let body = br#"[
+        {"tag_name":"srelens-vnightly"},
+        {"tag_name":"srelens-v0.8.1-152"}
+    ]"#;
+    assert_eq!(parse_newest_version(body).unwrap(), "0.8.1-152");
+}
+
+// ---------------------------------------------------------------------------
+// Temporary files
+// ---------------------------------------------------------------------------
+
+/// The staged file is created with `create_new`, so a path planted in
+/// advance cannot be written through. On Unix that is the difference between
+/// truncating a symlink's target and refusing; the same guard is what stops
+/// a stale leftover being reused on any platform.
+#[cfg(unix)]
+#[test]
+fn a_planted_symlink_beside_the_binary_is_not_written_through() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join(bin_name());
+    std::fs::write(&target, b"old").unwrap();
+
+    // What an attacker with write access to the directory would leave: a
+    // link named the way the updater's staging file used to be named.
+    let victim = dir.path().join("private-file");
+    std::fs::write(&victim, b"do not truncate me").unwrap();
+    let planted = dir
+        .path()
+        .join(format!(".{}.new-{}", bin_name(), std::process::id()));
+    std::os::unix::fs::symlink(&victim, &planted).unwrap();
+
+    replace_running_binary(&target, b"new").expect("the update still succeeds");
+
+    assert_eq!(
+        std::fs::read(&victim).unwrap(),
+        b"do not truncate me",
+        "the linked file must be untouched"
+    );
+    assert_eq!(std::fs::read(&target).unwrap(), b"new");
+}
+
 // ---------------------------------------------------------------------------
 // Checksums
 // ---------------------------------------------------------------------------

--- a/apps/tui/tests/self_update_tests.rs
+++ b/apps/tui/tests/self_update_tests.rs
@@ -702,6 +702,38 @@ fn a_binary_a_package_manager_owns_is_recognised() {
     }
 }
 
+/// A package-manager root only counts at the START of the path.
+///
+/// An unpacked root filesystem, a container image being edited, a chroot
+/// staging directory — all contain `/usr/bin/` partway through, and all
+/// belong to whoever unpacked them. Matching the marker anywhere refused to
+/// update a file its owner controls.
+#[test]
+fn a_package_root_buried_inside_another_path_is_not_its_owner() {
+    for path in [
+        "/home/me/rootfs/usr/bin/srelens-tui",
+        "/home/me/containers/alpine/usr/bin/srelens-tui",
+        "/tmp/extract/snap/srelens-tui",
+        "/home/me/backup/nix/store/srelens-tui",
+    ] {
+        assert_eq!(package_manager_for(Path::new(path)), None, "{path}");
+    }
+
+    // The same markers at the front still count.
+    assert_eq!(
+        package_manager_for(Path::new("/usr/bin/srelens-tui")),
+        Some("your distribution's package manager")
+    );
+}
+
+/// Unix paths are case-sensitive, so a differently-cased lookalike is a
+/// different directory and not the package manager's.
+#[test]
+fn a_unix_root_is_matched_case_sensitively() {
+    assert_eq!(package_manager_for(Path::new("/USR/BIN/srelens-tui")), None);
+    assert_eq!(package_manager_for(Path::new("/Snap/srelens-tui")), None);
+}
+
 /// The locations the install guide tells people to use by hand. Reporting one
 /// of these as package-managed would refuse to update the ordinary install.
 #[test]

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -154,10 +154,20 @@ srelens-tui update           # download it and replace this binary
 ```
 
 It only ever replaces the binary you ran it from. Before writing anything it
-checks the download against the published SHA-256, so a corrupted or
-substituted archive is refused and the copy you already have is left alone.
+checks the download against the SHA-256 the release published, so a corrupted
+or truncated archive is refused and the copy you already have is left alone.
 The last step is a rename, so an interrupted update cannot leave a
 half-written binary on your `PATH`.
+
+> **What that check does and does not prove.** It proves the file arrived
+> intact. It does not prove who built it: the checksum file lives on the same
+> release as the archive, so anyone able to replace one could replace both.
+> Verifying the GPG signature against a pinned key would close that, and is
+> tracked in [#448]. If that distinction matters to you, install by hand and
+> check the signature as described under
+> [Verifying a download](#verifying-a-download).
+
+[#448]: https://github.com/srelens/srelens/issues/448
 
 **Channels.** The same two the desktop app offers under Settings → Updates:
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -146,6 +146,32 @@ carry detached GPG signatures like every other release asset — see
 [Verifying a download](#verifying-a-download) below, which applies to them
 unchanged.
 
+**Keeping it current.** The binary updates itself:
+
+```bash
+srelens-tui update --check   # what is available, without changing anything
+srelens-tui update           # download it and replace this binary
+```
+
+It follows the **stable** channel, and only ever replaces the binary you ran
+it from. Before writing anything it checks the download against the published
+SHA-256, so a corrupted or substituted archive is refused and the copy you
+already have is left alone. The last step is a rename, so an interrupted
+update cannot leave a half-written binary on your `PATH`.
+
+Two cases where it declines rather than acting, both on purpose:
+
+- **A package manager owns the binary.** If it lives somewhere Homebrew, your
+  distribution, Scoop, winget or Nix put it, srelens says so and names the
+  tool to use instead — writing over those files would leave the manager's
+  database describing a version that is no longer there.
+- **You cannot write to the directory.** A copy in `/usr/local/bin` usually
+  needs elevation. It says which directory refused rather than failing with a
+  bare permission error.
+
+A musl build updates to a musl build, since that binary exists precisely
+because the host cannot run the glibc one.
+
 Run `srelens-tui --help` for the full set of flags. `srelens-tui info` lists
 the contexts found in your kubeconfig with the cluster and server each names —
 it reads the file and does not contact any cluster, so it tells you what is

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -153,11 +153,24 @@ srelens-tui update --check   # what is available, without changing anything
 srelens-tui update           # download it and replace this binary
 ```
 
-It follows the **stable** channel, and only ever replaces the binary you ran
-it from. Before writing anything it checks the download against the published
-SHA-256, so a corrupted or substituted archive is refused and the copy you
-already have is left alone. The last step is a rename, so an interrupted
-update cannot leave a half-written binary on your `PATH`.
+It only ever replaces the binary you ran it from. Before writing anything it
+checks the download against the published SHA-256, so a corrupted or
+substituted archive is refused and the copy you already have is left alone.
+The last step is a rename, so an interrupted update cannot leave a
+half-written binary on your `PATH`.
+
+**Channels.** The same two the desktop app offers under Settings → Updates:
+
+```bash
+srelens-tui update --channel stable   # released versions
+srelens-tui update --channel dev      # rolling pre-releases, cut daily
+```
+
+Without the flag it stays on the channel your binary came from — a
+pre-release version means a dev build, anything else means stable — so
+updating never moves you between channels by accident. Pass the flag to
+switch; the choice is not remembered, so the next plain `update` goes back to
+following the binary you are then running.
 
 Two cases where it declines rather than acting, both on purpose:
 


### PR DESCRIPTION
#444 put a copy of `srelens-tui` on people's `PATH` with no way to move it forward. The desktop app updates itself from Settings; the TUI had `info`, `toolbox` and `version`, so the only upgrade path was to notice a release had happened, work out which of the seven archives was yours, download it, extract it and replace the file by hand.

Closes #446.

```console
$ srelens-tui update --check
srelens-tui 0.8.0 is available (you have 0.7.0).
  https://github.com/srelens/srelens/releases/download/srelens-v0.8.0/srelens-tui-0.8.0-x86_64-pc-windows-msvc.zip
Run `srelens-tui update` to install it.
```

It follows the **stable** channel — `releases/latest` is the endpoint that skips pre-releases, so that needs no filtering of our own — picks the asset for the running platform, verifies it, and replaces the binary it was run from.

## How it is built

The shape is the one `crates/kube/src/toolbox_install.rs` already uses for kubectl and helm: every decision is a pure function over strings, and the single networked step takes an injected `fetch`. That matters more than usual here, because **no release carries the TUI archives yet** — #444 only just merged — so the download-verify-replace path cannot be exercised against a real release. The tests build real tarballs and zips, hash them with the same function the code uses, and serve them through the seam.

## The parts that would hurt someone if they were wrong

- **Nothing is written until the SHA-256 matches** the checksum the release publishes. A test substitutes the archive and asserts the installed binary is untouched.
- **The last step is always a rename**, never a copy into place, so an interrupted update cannot leave a truncated binary on someone's `PATH`.
- **Windows cannot unlink a running image, but it can rename one.** The current binary is moved aside, the new one takes its place, and the leftover is cleared on the next run. If the second rename fails, the original is put back rather than leaving the user with no binary at all.
- **A package manager's file is refused before anything is downloaded** — Homebrew, distro packages, snap, Nix, Scoop, winget, Chocolatey. Writing over those would leave the manager's database describing a version that is no longer there, which is the line the desktop app already takes for AUR. `/usr/local/bin` is deliberately **not** treated as managed: that is where the install guide tells people to put it by hand, and refusing there would break the ordinary install.
- **A musl binary updates to a musl archive.** It exists precisely because the host cannot run the glibc one, so crossing flavours would hand someone a binary that no longer starts.
- **Versions compare as semver**, so `0.10.0` is newer than `0.9.0` — a string comparison gets that backwards. An unparseable version never triggers an update.

## Two bugs found by running it, not by reading it

- **reqwest's `rustls-no-provider` does not resolve a provider by itself.** The first request panicked inside reqwest's runtime thread, surfacing as `event loop thread panicked`, which tells a user nothing. Everywhere else in the app a kube client is built first and leaves a provider installed as a side effect; `update` runs before anything touches a cluster, so it installs `ring` itself — matching kube-rs, because linking a *second* provider is worse than none: rustls refuses to choose and panics on the first handshake.
- **The error messages never reached the user.** Returning the error from `main` prints its Debug form, so a carefully written sentence came out as `Download("404 Not Found for …")`. Failures now print the sentence to stderr and exit non-zero.

## Verification

Live, against the real GitHub API:

- `update --check` on the current build resolves `srelens-v0.8.0` and reports it is already the latest.
- A build stamped `0.7.0` sees 0.8.0 as newer, prints the correct per-platform asset URL, and on `update` fails with `download failed: 404 Not Found for …SHA256SUMS.txt` — correct, because 0.8.0 predates #444 and carries no TUI assets. Exit status 1.

By test, with real archives: extraction from both a tar.gz and a zip, checksum lookup in both `sha256sum` output formats, replacement, the executable bit, the mismatch case leaving the old binary in place, and the package-manager refusal happening before any download.

23 new tests. The crate is at 615, green.

## Known limits

The full loop against a real release can only be proven once a release carries the archives — the next dev pre-release will. And while the Windows rename-aside path is exercised (including a second run clearing the previous leftover), no test holds the target open as a running image; that is the documented Windows behaviour the design rests on.
