### PR TITLE
feat(tui): deep helm inspector, values diff & settings CRD disambiguation

### DIFF
--- a/apps/tui/src/ai_config.rs
+++ b/apps/tui/src/ai_config.rs
@@ -126,6 +126,8 @@ pub struct AiSettings {
     pub timeout_seconds: u32,
     #[serde(default)]
     pub caveman_level: Option<String>,
+    #[serde(default)]
+    pub theme: Option<String>,
 }
 
 fn default_max_tokens() -> u32 {
@@ -157,6 +159,7 @@ impl Default for AiSettings {
             max_tokens: 4096,
             timeout_seconds: 120,
             caveman_level: None,
+            theme: None,
         }
     }
 }

--- a/apps/tui/src/app.rs
+++ b/apps/tui/src/app.rs
@@ -15,6 +15,7 @@ use srelens_capability::Registry;
 use srelens_kube::client_cache::ClientCache;
 use srelens_kube::contexts::ContextDto;
 use srelens_kube::{k8s_openapi, kube};
+use srelens_streams::forward::ForwardManager;
 use srelens_streams::logs::LogStreamManager;
 use srelens_streams::watch::WatchManager;
 
@@ -38,12 +39,16 @@ pub enum ActiveView {
     Logs(LogsViewState),
     PortForwards(PortForwardViewState),
     Helm(HelmViewState),
+    HelmDetail(HelmDetailViewState),
     Overview(OverviewViewState),
     Toolbox(ToolboxViewState),
     Assistant,
     Settings(SettingsViewState),
     Tree(tree_view::TreeViewState),
     NodeInspector(node_inspector_view::NodeInspectorState),
+    Topology(topology_view::TopologyViewState),
+    GpuInfo(gpu_view::GpuViewState),
+    Top(top_view::TopViewState),
 }
 
 pub struct App {
@@ -64,6 +69,7 @@ pub struct App {
     pub client_cache: Arc<ClientCache>,
     pub watch_manager: Arc<WatchManager>,
     pub logs_manager: Arc<LogStreamManager>,
+    pub forward_manager: Arc<ForwardManager>,
     pub event_tx: UnboundedSender<AppEvent>,
     pub current_watch_channel: Option<String>,
     pub active_watch_channels: HashSet<String>,
@@ -75,6 +81,7 @@ pub struct App {
     pub is_running: bool,
     pub requires_terminal_suspend: Option<SuspendAction>,
     pub context_chip_rects: std::cell::RefCell<Vec<(ratatui::layout::Rect, String)>>,
+    pub close_pf_button_rect: std::cell::RefCell<Option<ratatui::layout::Rect>>,
     // Dynamic Cluster Metrics & Information
     pub cluster_version: String,
     pub cluster_name: String,
@@ -152,6 +159,7 @@ impl App {
         let client_cache = ClientCache::new_many(kubeconfig_paths.clone());
         let watch_manager = Arc::new(WatchManager::new(client_cache.clone()));
         let logs_manager = Arc::new(LogStreamManager::new(client_cache.clone()));
+        let forward_manager = Arc::new(ForwardManager::new(client_cache.clone()));
 
         // Resolve contexts
         let resolved = srelens_kube::context_resolve::resolve_contexts(&kubeconfig_paths);
@@ -224,6 +232,7 @@ impl App {
             client_cache,
             watch_manager,
             logs_manager,
+            forward_manager,
             event_tx,
             current_watch_channel: None,
             active_watch_channels: HashSet::new(),
@@ -235,6 +244,7 @@ impl App {
             is_running: true,
             requires_terminal_suspend: None,
             context_chip_rects: std::cell::RefCell::new(Vec::new()),
+            close_pf_button_rect: std::cell::RefCell::new(None),
             cluster_version: "Connecting...".to_string(),
             cluster_name,
             server_url,
@@ -258,6 +268,10 @@ impl App {
 
         if let Some(lvl) = app.ai_settings.get_caveman_level() {
             app.assistant_state.caveman_level = Some(lvl);
+        }
+
+        if let Some(theme_name) = &app.ai_settings.theme {
+            Theme::set_theme_by_name(theme_name);
         }
 
         app.refresh_cluster_info();
@@ -298,6 +312,8 @@ impl App {
         // Periodically refresh pod metrics (CPU/MEM) every ~4 seconds (40 ticks at 100ms)
         let need_pod_metrics = if let ActiveView::Table(table) = &self.active_view {
             table.kind == ResourceKind::Pods || table.kind == ResourceKind::Workloads
+        } else if matches!(self.active_view, ActiveView::Top(_)) {
+            true
         } else if let Some(Modal::MetricsTimeline(ref panel)) = self.modal {
             panel.target_kind == "Pod"
         } else {
@@ -313,7 +329,7 @@ impl App {
         // Periodically refresh node metrics every ~4 seconds
         let need_node_metrics = if let ActiveView::Table(table) = &self.active_view {
             table.kind == ResourceKind::Nodes
-        } else if matches!(self.active_view, ActiveView::NodeInspector(_)) {
+        } else if matches!(self.active_view, ActiveView::NodeInspector(_) | ActiveView::Top(_)) {
             true
         } else if let Some(Modal::MetricsTimeline(ref panel)) = self.modal {
             panel.target_kind == "Node"
@@ -325,6 +341,10 @@ impl App {
             if self.node_metrics_tick_counter % 40 == 1 {
                 self.refresh_node_metrics();
             }
+        }
+
+        if matches!(self.active_view, ActiveView::PortForwards(_)) {
+            self.sync_port_forwards();
         }
     }
 
@@ -446,6 +466,7 @@ impl App {
                 }
             }
         }
+        self.refresh_top_view_data();
     }
 
     pub fn rebuild_workloads_table(&mut self) {
@@ -729,6 +750,8 @@ impl App {
                 }
             }
         }
+
+        self.refresh_top_view_data();
     }
 
     pub fn refresh_cluster_info(&self) {
@@ -1243,6 +1266,64 @@ impl App {
     }
 
     pub async fn restart_active_watch(&mut self) {
+        if matches!(self.active_view, ActiveView::Top(_)) {
+            let ctx = self.active_context.clone();
+            let ns = self.active_namespace.clone();
+
+            // Ensure "nodes" watch is running so node allocatable CPU & Memory are populated
+            let node_ch = format!("watch:{}:{}:nodes", ctx, "");
+            if !self.watch_manager.has_channel(&node_ch) {
+                if self.active_watch_pool.len() >= 20 {
+                    let evicted = self.active_watch_pool.remove(0);
+                    self.watch_manager.stop(&evicted);
+                    self.active_watch_channels.remove(&evicted);
+                }
+                let sink = TuiSink::arc(self.event_tx.clone());
+                let paths = self.kubeconfig_paths.clone();
+                self.active_watch_channels.insert(node_ch.clone());
+                self.active_watch_pool.push(node_ch.clone());
+                let _ = self.watch_manager.start(sink, ctx.clone(), "".to_string(), "nodes".to_string(), node_ch, paths).await;
+            } else if let Some(pos) = self.active_watch_pool.iter().position(|c| c == &node_ch) {
+                let c = self.active_watch_pool.remove(pos);
+                self.active_watch_pool.push(c);
+            }
+
+            // Ensure "pods" watch is running so pod requests & limits are populated
+            let pod_ch = format!("watch:{}:{}:pods", ctx, ns);
+            if !self.watch_manager.has_channel(&pod_ch) {
+                if self.active_watch_pool.len() >= 20 {
+                    let evicted = self.active_watch_pool.remove(0);
+                    self.watch_manager.stop(&evicted);
+                    self.active_watch_channels.remove(&evicted);
+                }
+                let sink = TuiSink::arc(self.event_tx.clone());
+                let paths = self.kubeconfig_paths.clone();
+                self.active_watch_channels.insert(pod_ch.clone());
+                self.active_watch_pool.push(pod_ch.clone());
+                let _ = self.watch_manager.start(sink, ctx.clone(), ns.clone(), "pods".to_string(), pod_ch, paths).await;
+            } else if let Some(pos) = self.active_watch_pool.iter().position(|c| c == &pod_ch) {
+                let c = self.active_watch_pool.remove(pos);
+                self.active_watch_pool.push(c);
+            }
+
+            self.refresh_pod_metrics();
+            self.refresh_node_metrics();
+            self.refresh_top_view_data();
+            return;
+        }
+
+        if matches!(self.active_view, ActiveView::Helm(_)) {
+            self.refresh_helm_releases();
+            return;
+        }
+
+        if let ActiveView::HelmDetail(detail) = &self.active_view {
+            let name = detail.release_name.clone();
+            let ns = detail.namespace.clone();
+            self.reload_helm_detail(&name, &ns);
+            return;
+        }
+
         if let ActiveView::Table(table) = &mut self.active_view {
             if table.kind == ResourceKind::Workloads {
                 let ctx = self.active_context.clone();
@@ -1365,6 +1446,49 @@ impl App {
                         _ => {}
                     }
                 }
+                Modal::InputConfirm {
+                    title,
+                    message,
+                    action_name,
+                    required_input,
+                    mut current_input,
+                    is_destructive,
+                } => {
+                    match key.code {
+                        KeyCode::Enter => {
+                            if current_input.trim().eq_ignore_ascii_case(&required_input) {
+                                self.modal = None;
+                                self.execute_modal_confirm(action_name).await;
+                            }
+                        }
+                        KeyCode::Esc => {
+                            self.modal = None;
+                        }
+                        KeyCode::Backspace => {
+                            current_input.pop();
+                            self.modal = Some(Modal::InputConfirm {
+                                title,
+                                message,
+                                action_name,
+                                required_input,
+                                current_input,
+                                is_destructive,
+                            });
+                        }
+                        KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) && !key.modifiers.contains(KeyModifiers::ALT) => {
+                            current_input.push(c);
+                            self.modal = Some(Modal::InputConfirm {
+                                title,
+                                message,
+                                action_name,
+                                required_input,
+                                current_input,
+                                is_destructive,
+                            });
+                        }
+                        _ => {}
+                    }
+                }
                 Modal::Scale { workload_name, mut input, current_replicas } => {
                     match key.code {
                         KeyCode::Char(c) if c.is_ascii_digit() => {
@@ -1387,21 +1511,22 @@ impl App {
                         _ => {}
                     }
                 }
-                Modal::PortForward { pod_name, namespace, container_port, mut local_port_input } => {
+                Modal::PortForward { pod_name, namespace, container_port, mut local_port_input, kind } => {
                     match key.code {
                         KeyCode::Char(c) if c.is_ascii_digit() => {
                             local_port_input.push(c);
-                            self.modal = Some(Modal::PortForward { pod_name, namespace, container_port, local_port_input });
+                            self.modal = Some(Modal::PortForward { pod_name, namespace, container_port, local_port_input, kind });
                         }
                         KeyCode::Backspace => {
                             local_port_input.pop();
-                            self.modal = Some(Modal::PortForward { pod_name, namespace, container_port, local_port_input });
+                            self.modal = Some(Modal::PortForward { pod_name, namespace, container_port, local_port_input, kind });
                         }
                         KeyCode::Enter => {
                             self.modal = None;
                             if let Ok(local_port) = local_port_input.parse::<u16>() {
                                 self.execute_start_port_forward(
                                     pod_name,
+                                    kind,
                                     namespace,
                                     local_port,
                                     container_port,
@@ -1728,11 +1853,15 @@ impl App {
                 }
                 Modal::MetricsTimeline(mut state) => {
                     match key.code {
-                        KeyCode::Esc => {
+                        KeyCode::Esc | KeyCode::Char('q') => {
                             self.modal = None;
                         }
-                        KeyCode::Tab => {
+                        KeyCode::Tab | KeyCode::Right | KeyCode::Char('l') => {
                             state.cycle_time_range();
+                            self.modal = Some(Modal::MetricsTimeline(state));
+                        }
+                        KeyCode::BackTab | KeyCode::Left | KeyCode::Char('h') => {
+                            state.cycle_time_range_prev();
                             self.modal = Some(Modal::MetricsTimeline(state));
                         }
                         KeyCode::Char('1') => {
@@ -1803,6 +1932,44 @@ impl App {
                         }
                     }
                 }
+                Modal::ThemePicker { mut selected_idx, initial_theme_idx } => {
+                    let total = Theme::all_themes().len();
+                    match key.code {
+                        KeyCode::Esc => {
+                            Theme::set_theme_by_index(initial_theme_idx);
+                            self.modal = None;
+                        }
+                        KeyCode::Char('k') | KeyCode::Up => {
+                            if selected_idx > 0 {
+                                selected_idx -= 1;
+                            } else {
+                                selected_idx = total.saturating_sub(1);
+                            }
+                            Theme::set_theme_by_index(selected_idx);
+                            self.modal = Some(Modal::ThemePicker { selected_idx, initial_theme_idx });
+                        }
+                        KeyCode::Char('j') | KeyCode::Down => {
+                            if selected_idx + 1 < total {
+                                selected_idx += 1;
+                            } else {
+                                selected_idx = 0;
+                            }
+                            Theme::set_theme_by_index(selected_idx);
+                            self.modal = Some(Modal::ThemePicker { selected_idx, initial_theme_idx });
+                        }
+                        KeyCode::Enter => {
+                            Theme::set_theme_by_index(selected_idx);
+                            let palette = Theme::active_palette();
+                            self.ai_settings.theme = Some(palette.name.to_string());
+                            let _ = self.ai_settings.save();
+                            self.set_toast(format!("Theme set to {}", palette.display_name), Theme::status_ok());
+                            self.modal = None;
+                        }
+                        _ => {
+                            self.modal = Some(Modal::ThemePicker { selected_idx, initial_theme_idx });
+                        }
+                    }
+                }
             }
             return;
         }
@@ -1816,11 +1983,47 @@ impl App {
                     self.command_suggestion_idx = 0;
                 }
                 KeyCode::Enter => {
-                    let cmd_str = self.command_buffer.clone();
+                    let trimmed = self.command_buffer.trim().trim_start_matches(':').trim();
+                    if trimmed.is_empty() {
+                        self.input_mode = InputMode::Normal;
+                        self.command_buffer.clear();
+                        self.command_suggestion_idx = 0;
+                        return;
+                    }
+
+                    // Special contextual colon commands handled directly by execute_colon_command
+                    if trimmed == "save-ai" || trimmed == "export-ai"
+                        || (trimmed == "save" && matches!(self.active_view, ActiveView::Assistant))
+                        || trimmed == "clear-ai"
+                        || (trimmed == "clear" && matches!(self.active_view, ActiveView::Assistant))
+                        || trimmed == "tree" || trimmed == "lineage" || trimmed == "related"
+                        || trimmed == "actions" || trimmed == "act"
+                        || trimmed == "metrics" || trimmed == "metric"
+                        || trimmed == "reasons" || trimmed == "reason"
+                    {
+                        let cmd = self.command_buffer.clone();
+                        self.input_mode = InputMode::Normal;
+                        self.command_buffer.clear();
+                        self.command_suggestion_idx = 0;
+                        self.execute_colon_command(&cmd).await;
+                        return;
+                    }
+
+                    let suggestions = command_suggestions_with_crds(&self.command_buffer, &self.crds);
+                    let target = if !suggestions.is_empty() && self.command_suggestion_idx < suggestions.len() {
+                        Some(suggestions[self.command_suggestion_idx].0.target.clone())
+                    } else {
+                        None
+                    };
+                    let fallback_cmd = self.command_buffer.clone();
                     self.input_mode = InputMode::Normal;
                     self.command_buffer.clear();
                     self.command_suggestion_idx = 0;
-                    self.execute_colon_command(&cmd_str).await;
+                    if let Some(target) = target {
+                        self.execute_command_target(target).await;
+                    } else {
+                        self.execute_colon_command(&fallback_cmd).await;
+                    }
                 }
                 KeyCode::Tab => {
                     let suggestions = command_suggestions_with_crds(&self.command_buffer, &self.crds);
@@ -1835,42 +2038,20 @@ impl App {
                     if !suggestions.is_empty() {
                         let len = suggestions.len();
                         let idx = (self.command_suggestion_idx + len - 1) % len;
-                        self.command_buffer = suggestions[idx].0.name.clone();
                         self.command_suggestion_idx = idx;
                     }
                 }
-                KeyCode::Down => {
+                KeyCode::Down | KeyCode::Char('n') | KeyCode::Char('N') if key.code == KeyCode::Down || key.modifiers.contains(KeyModifiers::CONTROL) => {
                     let suggestions = command_suggestions_with_crds(&self.command_buffer, &self.crds);
                     if !suggestions.is_empty() {
-                        let idx = self.command_suggestion_idx % suggestions.len();
-                        self.command_buffer = suggestions[idx].0.name.clone();
-                        self.command_suggestion_idx = (idx + 1) % suggestions.len();
+                        self.command_suggestion_idx = (self.command_suggestion_idx + 1) % suggestions.len();
                     }
                 }
-                KeyCode::Up => {
+                KeyCode::Up | KeyCode::Char('p') | KeyCode::Char('P') if key.code == KeyCode::Up || key.modifiers.contains(KeyModifiers::CONTROL) => {
                     let suggestions = command_suggestions_with_crds(&self.command_buffer, &self.crds);
                     if !suggestions.is_empty() {
                         let len = suggestions.len();
-                        let idx = (self.command_suggestion_idx + len - 1) % len;
-                        self.command_buffer = suggestions[idx].0.name.clone();
-                        self.command_suggestion_idx = idx;
-                    }
-                }
-                KeyCode::Char('n') | KeyCode::Char('N') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                    let suggestions = command_suggestions_with_crds(&self.command_buffer, &self.crds);
-                    if !suggestions.is_empty() {
-                        let idx = self.command_suggestion_idx % suggestions.len();
-                        self.command_buffer = suggestions[idx].0.name.clone();
-                        self.command_suggestion_idx = (idx + 1) % suggestions.len();
-                    }
-                }
-                KeyCode::Char('p') | KeyCode::Char('P') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                    let suggestions = command_suggestions_with_crds(&self.command_buffer, &self.crds);
-                    if !suggestions.is_empty() {
-                        let len = suggestions.len();
-                        let idx = (self.command_suggestion_idx + len - 1) % len;
-                        self.command_buffer = suggestions[idx].0.name.clone();
-                        self.command_suggestion_idx = idx;
+                        self.command_suggestion_idx = (self.command_suggestion_idx + len - 1) % len;
                     }
                 }
                 _ if is_word_delete_key(&key) => {
@@ -1982,6 +2163,9 @@ impl App {
                     ActiveView::Describe(desc) => self.filter_buffer = desc.search_query.clone(),
                     ActiveView::Yaml(yaml) => self.filter_buffer = yaml.search_query.clone(),
                     ActiveView::Logs(logs) => self.filter_buffer = logs.search_query.clone(),
+                    ActiveView::Top(top) => self.filter_buffer = top.filter.clone(),
+                    ActiveView::Helm(helm) => self.filter_buffer = helm.filter_query.clone(),
+                    ActiveView::HelmDetail(detail) => self.filter_buffer = detail.filter_query.clone(),
                     _ => {}
                 }
             }
@@ -2086,6 +2270,8 @@ impl App {
                     }
                     self.active_view = prev_view;
                     self.restart_active_watch().await;
+                } else if matches!(self.active_view, ActiveView::Top(_)) {
+                    self.switch_view_to_kind(ResourceKind::Pods).await;
                 }
             }
             // Toggle AI Assistant Drawer (or Reason Rail on wide Events table, or cycle segment on Workloads)
@@ -2113,6 +2299,22 @@ impl App {
                             return;
                         }
                     }
+                }
+                if let ActiveView::GpuInfo(ref mut gpu) = self.active_view {
+                    gpu.toggle_pane();
+                    return;
+                }
+                if let ActiveView::Topology(ref mut topo) = self.active_view {
+                    topo.select_next_lane();
+                    return;
+                }
+                if let ActiveView::Top(ref mut top) = self.active_view {
+                    top.toggle_tab();
+                    return;
+                }
+                if let ActiveView::HelmDetail(ref mut detail) = self.active_view {
+                    detail.next_tab();
+                    return;
                 }
                 if let Some(seg_name) = cycled_segment {
                     self.set_toast(format!("Segment: {}", seg_name), Theme::status_ok());
@@ -2262,14 +2464,30 @@ impl App {
                         }
                     }
                     KeyCode::Char('f') | KeyCode::Char('F') => {
-                        // Port forward (f, Shift+f, or Ctrl+f)
+                        // Port forward (f, Shift+f)
                         if table_kind == ResourceKind::Workloads && row_kind != "Pod" {
                             self.set_toast(format!("Port forward is only available for Pods (selected is {})", row_kind), Theme::status_warn());
                             return;
                         }
-                        if let Some(pod_name) = sel_name {
-                            let ns = sel_ns.unwrap_or_else(|| self.active_namespace.clone());
-                            let detected_port = table.selected_item().and_then(|item| {
+
+                        let target_kind = if table_kind == ResourceKind::Services { "Service" } else { "Pod" }.to_string();
+                        let ns = sel_ns.clone().unwrap_or_else(|| self.active_namespace.clone());
+
+                        if key.code == KeyCode::Char('F') {
+                            let has_active = if let Some(target_name) = &sel_name {
+                                table.active_port_forwards.contains_key(&(ns.clone(), target_name.clone()))
+                                    || table.active_port_forwards.contains_key(&(String::new(), target_name.clone()))
+                            } else {
+                                false
+                            };
+                            if has_active {
+                                self.close_selected_port_forward().await;
+                                return;
+                            }
+                        }
+
+                        if let Some(target_name) = sel_name {
+                            let mut detected_port = table.selected_item().and_then(|item| {
                                 item.pointer("/spec/containers/0/ports/0/containerPort")
                                     .and_then(|v| v.as_u64())
                                     .map(|p| p as u16)
@@ -2278,12 +2496,46 @@ impl App {
                                             .and_then(|v| v.as_u64())
                                             .map(|p| p as u16)
                                     })
-                            }).unwrap_or(8080);
+                            });
+
+                            if detected_port.is_none() {
+                                if let Ok(client) = self.client_cache.get(&self.active_context).await {
+                                    if target_kind == "Service" {
+                                        let api: kube::Api<k8s_openapi::api::core::v1::Service> = kube::Api::namespaced(client, &ns);
+                                        if let Ok(svc) = api.get(&target_name).await {
+                                            if let Some(spec) = svc.spec {
+                                                if let Some(ports) = spec.ports {
+                                                    if let Some(p) = ports.first() {
+                                                        detected_port = Some(p.port as u16);
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    } else {
+                                        let api: kube::Api<k8s_openapi::api::core::v1::Pod> = kube::Api::namespaced(client, &ns);
+                                        if let Ok(pod) = api.get(&target_name).await {
+                                            if let Some(spec) = pod.spec {
+                                                for container in spec.containers {
+                                                    if let Some(ports) = container.ports {
+                                                        if let Some(p) = ports.first() {
+                                                            detected_port = Some(p.container_port as u16);
+                                                            break;
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            let target_port = detected_port.unwrap_or(8080);
                             self.modal = Some(Modal::PortForward {
-                                pod_name,
+                                pod_name: target_name,
                                 namespace: ns,
-                                container_port: detected_port,
-                                local_port_input: detected_port.to_string(),
+                                container_port: target_port,
+                                local_port_input: target_port.to_string(),
+                                kind: target_kind,
                             });
                         }
                     }
@@ -2333,7 +2585,59 @@ impl App {
                         }
                     }
                     KeyCode::Char('l') => {
-                        // Logs
+                        // 1. Multi-pod logs from marked items
+                        if table.marked_indices.len() > 1 {
+                            let mut marked_pods: Vec<String> = Vec::new();
+                            let mut common_ns: Option<String> = None;
+                            for &idx in &table.marked_indices {
+                                if let Some(item) = table.raw_items.get(idx) {
+                                    let kind = item.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+                                    let is_pod = table_kind == ResourceKind::Pods || kind.eq_ignore_ascii_case("Pod");
+                                    if is_pod {
+                                        if let Some(pname) = item.get("name").and_then(|v| v.as_str()) {
+                                            marked_pods.push(pname.to_string());
+                                            if common_ns.is_none() {
+                                                common_ns = item.get("namespace").and_then(|v| v.as_str()).map(String::from);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            if marked_pods.len() > 1 {
+                                let label = format!("{} pods", marked_pods.len());
+                                self.open_multi_pod_logs_view(label, common_ns, marked_pods).await;
+                                return;
+                            }
+                        }
+
+                        // 2. Workload multi-pod logs (Deployment, StatefulSet, DaemonSet, Job)
+                        let is_workload = matches!(
+                            table_kind,
+                            ResourceKind::Deployments | ResourceKind::StatefulSets | ResourceKind::DaemonSets | ResourceKind::Jobs
+                        ) || (table_kind == ResourceKind::Workloads && matches!(row_kind.as_str(), "Deployment" | "StatefulSet" | "DaemonSet" | "Job"));
+
+                        if is_workload {
+                            if let Some(wname) = sel_name {
+                                let ns = sel_ns.clone()
+                                    .or_else(|| if self.active_namespace.is_empty() { None } else { Some(self.active_namespace.clone()) })
+                                    .unwrap_or_else(|| "default".to_string());
+                                let target_kind = if table_kind == ResourceKind::Workloads {
+                                    row_kind.clone()
+                                } else {
+                                    table_kind.k8s_kind().unwrap_or("Deployment").to_string()
+                                };
+                                let pods = self.get_workload_pods(&target_kind, &wname, &ns).await;
+                                if !pods.is_empty() {
+                                    self.open_multi_pod_logs_view(wname, Some(ns), pods).await;
+                                    return;
+                                } else {
+                                    self.set_toast(format!("No running pods found for {}/{}", target_kind, wname), Theme::status_warn());
+                                    return;
+                                }
+                            }
+                        }
+
+                        // 3. Single pod logs
                         let (pod_name, target_ns) = if table_kind == ResourceKind::Events {
                             if let Some(item) = table.selected_item() {
                                 let (obj_kind, obj_name) = parse_involved_object(item);
@@ -2350,7 +2654,7 @@ impl App {
                             if row_kind == "Pod" {
                                 (sel_name.clone(), sel_ns.clone().or_else(|| if self.active_namespace.is_empty() { None } else { Some(self.active_namespace.clone()) }))
                             } else {
-                                self.set_toast(format!("Logs only available for Pods (selected is {})", row_kind), Theme::status_warn());
+                                self.set_toast(format!("Logs only available for Pods or Workloads (selected is {})", row_kind), Theme::status_warn());
                                 (None, None)
                             }
                         } else {
@@ -2759,6 +3063,11 @@ impl App {
                 match key.code {
                     KeyCode::Char('j') | KeyCode::Down => helm.select_next(),
                     KeyCode::Char('k') | KeyCode::Up => helm.select_prev(),
+                    KeyCode::Enter => {
+                        if let Some(rel) = sel_rel {
+                            self.open_helm_detail(rel.name, rel.namespace, HelmDetailTab::Overview);
+                        }
+                    }
                     KeyCode::Char('c') => {
                         if let Some(rel) = sel_rel {
                             let link = crate::deep_link::DeepLink::Resource {
@@ -2792,15 +3101,43 @@ impl App {
                         }
                     }
                     KeyCode::Char('v') => {
-                        // Inspect Helm values
                         if let Some(rel) = sel_rel {
-                            self.open_yaml_view(rel.name, "HelmValues".to_string(), Some(rel.namespace)).await;
+                            self.open_helm_detail(rel.name, rel.namespace, HelmDetailTab::ValuesDiff);
                         }
                     }
                     KeyCode::Char('y') => {
-                        // Inspect Helm manifest
                         if let Some(rel) = sel_rel {
-                            self.open_yaml_view(rel.name, "HelmManifest".to_string(), Some(rel.namespace)).await;
+                            self.open_helm_detail(rel.name, rel.namespace, HelmDetailTab::Manifest);
+                        }
+                    }
+                    KeyCode::Char('d') if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        if let Some(rel) = sel_rel {
+                            self.open_helm_detail(rel.name, rel.namespace, HelmDetailTab::Revisions);
+                        }
+                    }
+                    KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        if let Some(rel) = sel_rel {
+                            self.modal = Some(Modal::Confirm {
+                                title: format!("Uninstall Helm Release [{}]", rel.name),
+                                message: format!("Uninstall release '{}' from namespace '{}'?", rel.name, rel.namespace),
+                                action_name: format!("helm-uninstall:{}:{}", rel.name, rel.namespace),
+                                is_destructive: true,
+                            });
+                        }
+                    }
+                    KeyCode::Char('r') => {
+                        if let Some(rel) = sel_rel {
+                            if rel.revision > 1 {
+                                let target_rev = rel.revision - 1;
+                                self.modal = Some(Modal::Confirm {
+                                    title: format!("Rollback Helm Release [{}]", rel.name),
+                                    message: format!("Rollback '{}' in namespace '{}' to previous revision {}?", rel.name, rel.namespace, target_rev),
+                                    action_name: format!("helm-rollback:{}:{}:{}", rel.name, rel.namespace, target_rev),
+                                    is_destructive: true,
+                                });
+                            } else {
+                                self.set_toast(format!("Release '{}' is at revision 1 (no previous revision)", rel.name), Theme::status_warn());
+                            }
                         }
                     }
                     _ => {}
@@ -3361,32 +3698,450 @@ impl App {
                         self.set_toast(format!("Node debug command: {}", cmd_str), Theme::status_ok());
                     }
                     KeyCode::Char('c') => {
-                        // Toggle Cordon / Uncordon
                         let target_unsched = !is_unsched;
-                        let n_name = node_name.clone();
-                        let ctx = self.active_context.clone();
-                        let cache = self.client_cache.clone();
-                        let event_tx = self.event_tx.clone();
-                        tokio::spawn(async move {
-                            if let Ok(client) = cache.get(&ctx).await {
-                                let api: kube::Api<k8s_openapi::api::core::v1::Node> = kube::Api::all(client);
-                                let patch = serde_json::json!({ "spec": { "unschedulable": target_unsched } });
-                                let res = api.patch(&n_name, &kube::api::PatchParams::default(), &kube::api::Patch::Merge(&patch)).await;
-                                let msg = if target_unsched {
-                                    format!("Cordoned node '{}'", n_name)
-                                } else {
-                                    format!("Uncordoned node '{}'", n_name)
-                                };
-                                let _ = event_tx.send(crate::event::AppEvent::ActionResult {
-                                    title: format!("cordon_node:{}", n_name),
-                                    result: res.map(|_| msg).map_err(|e| e.to_string()),
+                        let action_type = if target_unsched { "cordon" } else { "uncordon" };
+                        let action_title = if target_unsched {
+                            format!("Cordon Node [{}]", node_name)
+                        } else {
+                            format!("Uncordon Node [{}]", node_name)
+                        };
+                        let action_desc = if target_unsched {
+                            format!(
+                                "Mark node '{}' as unschedulable (cordon)? New pods will not be scheduled onto this node.",
+                                node_name
+                            )
+                        } else {
+                            format!(
+                                "Mark node '{}' as schedulable (uncordon)? New workloads can resume scheduling.",
+                                node_name
+                            )
+                        };
+                        self.modal = Some(Modal::InputConfirm {
+                            title: action_title,
+                            message: action_desc,
+                            action_name: format!("{}:{}", action_type, node_name),
+                            required_input: "confirm".to_string(),
+                            current_input: String::new(),
+                            is_destructive: target_unsched,
+                        });
+                    }
+                    _ => {}
+                }
+            }
+            ActiveView::Topology(topo) => {
+                match key.code {
+                    KeyCode::Esc | KeyCode::Char('q') => {
+                        if let Some(prev) = self.nav_stack.pop() {
+                            self.active_view = prev;
+                        } else {
+                            self.switch_view_to_kind(ResourceKind::Workloads).await;
+                        }
+                    }
+                    KeyCode::Left | KeyCode::Char('h') => topo.select_prev_lane(),
+                    KeyCode::Right => topo.select_next_lane(),
+                    KeyCode::Up | KeyCode::Char('k') => topo.select_prev_node(),
+                    KeyCode::Down | KeyCode::Char('j') => topo.select_next_node(),
+                    KeyCode::Tab => topo.select_next_lane(),
+                    KeyCode::BackTab => topo.select_prev_lane(),
+                    KeyCode::Char('g') | KeyCode::Home => topo.select_first_node(),
+                    KeyCode::Char('G') | KeyCode::End => topo.select_last_node(),
+                    KeyCode::Char('r') => {
+                        self.reload_topology_view();
+                    }
+                    KeyCode::Enter => {
+                        if let Some(node) = topo.selected_node() {
+                            let name = node.name.clone();
+                            let kind = node.kind.clone();
+                            let ns = node.namespace.clone();
+                            let is_workload = matches!(
+                                kind.to_lowercase().as_str(),
+                                "deployment" | "statefulset" | "daemonset" | "job" | "cronjob"
+                            );
+                            if is_workload {
+                                self.nav_stack.push(ActiveView::Topology(topo.clone()));
+                                if !ns.is_empty() && ns != self.active_namespace {
+                                    self.switch_namespace(ns.clone()).await;
+                                }
+                                self.switch_view_to_kind(ResourceKind::Pods).await;
+                                if let ActiveView::Table(t) = &mut self.active_view {
+                                    t.apply_filter(&name);
+                                }
+                                self.filter_buffer = name.clone();
+                                self.set_toast(format!("Jumped to Pods for {}", name), Theme::status_ok());
+                            } else if !kind.eq_ignore_ascii_case("External") {
+                                self.open_describe_view(name, kind, if ns.is_empty() { None } else { Some(ns.clone()) }).await;
+                            }
+                        }
+                    }
+                    KeyCode::Char('d') => {
+                        if let Some(node) = topo.selected_node() {
+                            let name = node.name.clone();
+                            let kind = node.kind.clone();
+                            let ns = node.namespace.clone();
+                            if !kind.eq_ignore_ascii_case("External") {
+                                self.open_describe_view(name, kind, if ns.is_empty() { None } else { Some(ns) }).await;
+                            }
+                        }
+                    }
+                    KeyCode::Char('y') => {
+                        if let Some(node) = topo.selected_node() {
+                            let name = node.name.clone();
+                            let kind = node.kind.clone();
+                            let ns = node.namespace.clone();
+                            if !kind.eq_ignore_ascii_case("External") {
+                                self.open_yaml_view(name, kind, if ns.is_empty() { None } else { Some(ns) }).await;
+                            }
+                        }
+                    }
+                    KeyCode::Char('l') => {
+                        if let Some(node) = topo.selected_node() {
+                            let name = node.name.clone();
+                            let kind = node.kind.clone();
+                            let ns = node.namespace.clone();
+                            let is_workload = matches!(
+                                kind.to_lowercase().as_str(),
+                                "deployment" | "statefulset" | "daemonset" | "job" | "cronjob" | "pod"
+                            );
+                            if is_workload {
+                                self.prompt_pod_logs(name, if ns.is_empty() { None } else { Some(ns) }).await;
+                            } else {
+                                self.set_toast(format!("Logs only available for workloads/pods (selected {})", kind), Theme::status_warn());
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            ActiveView::GpuInfo(gpu) => {
+                match key.code {
+                    KeyCode::Esc | KeyCode::Char('q') => {
+                        if let Some(prev) = self.nav_stack.pop() {
+                            self.active_view = prev;
+                        } else {
+                            self.switch_view_to_kind(ResourceKind::Nodes).await;
+                        }
+                    }
+                    KeyCode::Tab | KeyCode::BackTab | KeyCode::Left | KeyCode::Right => {
+                        gpu.toggle_pane();
+                    }
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        match gpu.focused_pane {
+                            gpu_view::GpuPane::Nodes => gpu.select_prev_node(),
+                            gpu_view::GpuPane::Pods => gpu.select_prev_pod(),
+                        }
+                    }
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        match gpu.focused_pane {
+                            gpu_view::GpuPane::Nodes => gpu.select_next_node(),
+                            gpu_view::GpuPane::Pods => gpu.select_next_pod(),
+                        }
+                    }
+                    KeyCode::Char('g') | KeyCode::Home => {
+                        match gpu.focused_pane {
+                            gpu_view::GpuPane::Nodes => gpu.select_first_node(),
+                            gpu_view::GpuPane::Pods => gpu.select_first_pod(),
+                        }
+                    }
+                    KeyCode::Char('G') | KeyCode::End => {
+                        match gpu.focused_pane {
+                            gpu_view::GpuPane::Nodes => gpu.select_last_node(),
+                            gpu_view::GpuPane::Pods => gpu.select_last_pod(),
+                        }
+                    }
+                    KeyCode::Char('r') => {
+                        self.reload_gpu_info_view();
+                    }
+                    KeyCode::Enter => {
+                        if gpu.focused_pane == gpu_view::GpuPane::Pods {
+                            if let Some(pod) = gpu.selected_pod() {
+                                let p_name = pod.name.clone();
+                                let p_ns = pod.namespace.clone();
+                                self.open_describe_view(p_name, "Pod".to_string(), Some(p_ns)).await;
+                            }
+                        } else if let Some(node) = gpu.selected_node() {
+                            let n_name = node.name.clone();
+                            self.open_node_inspector(n_name);
+                        }
+                    }
+                    KeyCode::Char('l') => {
+                        if let Some(pod) = gpu.selected_pod() {
+                            let p_name = pod.name.clone();
+                            let p_ns = pod.namespace.clone();
+                            self.prompt_pod_logs(p_name, Some(p_ns)).await;
+                        } else {
+                            self.set_toast("Select a pod to stream logs".to_string(), Theme::status_warn());
+                        }
+                    }
+                    KeyCode::Char('d') => {
+                        if gpu.focused_pane == gpu_view::GpuPane::Pods {
+                            if let Some(pod) = gpu.selected_pod() {
+                                let p_name = pod.name.clone();
+                                let p_ns = pod.namespace.clone();
+                                self.open_describe_view(p_name, "Pod".to_string(), Some(p_ns)).await;
+                            }
+                        } else if let Some(node) = gpu.selected_node() {
+                            let n_name = node.name.clone();
+                            self.open_describe_view(n_name, "Node".to_string(), None).await;
+                        }
+                    }
+                    KeyCode::Char('y') => {
+                        if gpu.focused_pane == gpu_view::GpuPane::Pods {
+                            if let Some(pod) = gpu.selected_pod() {
+                                let p_name = pod.name.clone();
+                                let p_ns = pod.namespace.clone();
+                                self.open_yaml_view(p_name, "Pod".to_string(), Some(p_ns)).await;
+                            }
+                        } else if let Some(node) = gpu.selected_node() {
+                            let n_name = node.name.clone();
+                            self.open_yaml_view(n_name, "Node".to_string(), None).await;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            ActiveView::Top(top) => {
+                match key.code {
+                    KeyCode::Esc | KeyCode::Char('q') => {
+                        if let Some(prev) = self.nav_stack.pop() {
+                            self.active_view = prev;
+                        } else {
+                            self.switch_view_to_kind(ResourceKind::Pods).await;
+                        }
+                    }
+                    KeyCode::Tab | KeyCode::BackTab => {
+                        top.toggle_tab();
+                    }
+                    KeyCode::Char('1') => {
+                        top.set_tab(top_view::TopTab::Pods);
+                    }
+                    KeyCode::Char('2') => {
+                        top.set_tab(top_view::TopTab::Nodes);
+                    }
+                    KeyCode::Char('c') => {
+                        top.set_sort_by(top_view::TopSortBy::Cpu);
+                    }
+                    KeyCode::Char('m') => {
+                        top.set_sort_by(top_view::TopSortBy::Memory);
+                    }
+                    KeyCode::Char('S') => {
+                        top.toggle_sort_direction();
+                    }
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        top.select_prev();
+                    }
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        top.select_next();
+                    }
+                    KeyCode::PageUp => {
+                        top.scroll_page_up(10);
+                    }
+                    KeyCode::PageDown => {
+                        top.scroll_page_down(10);
+                    }
+                    KeyCode::Char('g') | KeyCode::Home => {
+                        top.select_first();
+                    }
+                    KeyCode::Char('G') | KeyCode::End => {
+                        top.select_last();
+                    }
+                    KeyCode::Char('/') => {
+                        self.input_mode = InputMode::Filter;
+                        self.filter_buffer = top.filter.clone();
+                    }
+                    KeyCode::Char('r') => {
+                        self.refresh_pod_metrics();
+                        self.refresh_node_metrics();
+                        self.refresh_top_view_data();
+                        self.set_toast("Refreshed metrics".to_string(), Theme::status_ok());
+                    }
+                    KeyCode::Enter | KeyCode::Char('d') => {
+                        match top.active_tab {
+                            top_view::TopTab::Pods => {
+                                if let Some(pod) = top.selected_pod() {
+                                    let p_name = pod.name.clone();
+                                    let p_ns = pod.namespace.clone();
+                                    self.open_describe_view(p_name, "Pod".to_string(), Some(p_ns)).await;
+                                }
+                            }
+                            top_view::TopTab::Nodes => {
+                                if let Some(node) = top.selected_node() {
+                                    let n_name = node.name.clone();
+                                    self.open_describe_view(n_name, "Node".to_string(), None).await;
+                                }
+                            }
+                        }
+                    }
+                    KeyCode::Char('l') => {
+                        if top.active_tab == top_view::TopTab::Pods {
+                            if let Some(pod) = top.selected_pod() {
+                                let p_name = pod.name.clone();
+                                let p_ns = pod.namespace.clone();
+                                self.prompt_pod_logs(p_name, Some(p_ns)).await;
+                            }
+                        } else {
+                            self.set_toast("Logs only available for Pods".to_string(), Theme::status_warn());
+                        }
+                    }
+                    KeyCode::Char('f') | KeyCode::Char('F') => {
+                        if top.active_tab == top_view::TopTab::Pods {
+                            if let Some(pod) = top.selected_pod() {
+                                let p_name = pod.name.clone();
+                                let p_ns = pod.namespace.clone();
+
+                                if key.code == KeyCode::Char('F') && !self.active_forwards_for("Pod", &p_ns, &p_name).is_empty() {
+                                    self.close_selected_port_forward().await;
+                                    return;
+                                }
+
+                                let mut detected_port = None;
+                                if let Ok(client) = self.client_cache.get(&self.active_context).await {
+                                    let api: kube::Api<k8s_openapi::api::core::v1::Pod> = kube::Api::namespaced(client, &p_ns);
+                                    if let Ok(p) = api.get(&p_name).await {
+                                        if let Some(spec) = p.spec {
+                                            for container in spec.containers {
+                                                if let Some(ports) = container.ports {
+                                                    if let Some(port) = ports.first() {
+                                                        detected_port = Some(port.container_port as u16);
+                                                        break;
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                                let target_port = detected_port.unwrap_or(8080);
+                                self.modal = Some(Modal::PortForward {
+                                    pod_name: p_name,
+                                    namespace: p_ns,
+                                    container_port: target_port,
+                                    local_port_input: target_port.to_string(),
+                                    kind: "Pod".to_string(),
                                 });
                             }
+                        } else {
+                            self.set_toast("Port forward only available for Pods".to_string(), Theme::status_warn());
+                        }
+                    }
+                    KeyCode::Char('y') => {
+                        match top.active_tab {
+                            top_view::TopTab::Pods => {
+                                if let Some(pod) = top.selected_pod() {
+                                    let p_name = pod.name.clone();
+                                    let p_ns = pod.namespace.clone();
+                                    self.open_yaml_view(p_name, "Pod".to_string(), Some(p_ns)).await;
+                                }
+                            }
+                            top_view::TopTab::Nodes => {
+                                if let Some(node) = top.selected_node() {
+                                    let n_name = node.name.clone();
+                                    self.open_yaml_view(n_name, "Node".to_string(), None).await;
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            ActiveView::HelmDetail(detail) => {
+                match key.code {
+                    KeyCode::Esc | KeyCode::Char('q') => {
+                        if let Some(prev) = self.nav_stack.pop() {
+                            self.active_view = prev;
+                        } else {
+                            self.switch_view_to_kind(ResourceKind::HelmReleases).await;
+                        }
+                    }
+                    KeyCode::Tab => detail.next_tab(),
+                    KeyCode::BackTab => detail.prev_tab(),
+                    KeyCode::Right | KeyCode::Char('l') if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        detail.next_tab();
+                    }
+                    KeyCode::Left | KeyCode::Char('h') if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        detail.prev_tab();
+                    }
+                    KeyCode::Char('1') => detail.set_tab(HelmDetailTab::Overview),
+                    KeyCode::Char('2') => detail.set_tab(HelmDetailTab::ValuesDiff),
+                    KeyCode::Char('3') => detail.set_tab(HelmDetailTab::Revisions),
+                    KeyCode::Char('4') => detail.set_tab(HelmDetailTab::Manifest),
+                    KeyCode::Char('5') => detail.set_tab(HelmDetailTab::Notes),
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        if detail.active_tab == HelmDetailTab::Revisions {
+                            detail.select_prev_revision();
+                        } else {
+                            detail.scroll_up(1);
+                        }
+                    }
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        if detail.active_tab == HelmDetailTab::Revisions {
+                            detail.select_next_revision();
+                        } else {
+                            detail.scroll_down(1);
+                        }
+                    }
+                    KeyCode::PageUp => detail.scroll_up(15),
+                    KeyCode::PageDown => detail.scroll_down(15),
+                    KeyCode::Char('g') => detail.scroll_to_top(),
+                    KeyCode::Char('m') => {
+                        if detail.active_tab == HelmDetailTab::ValuesDiff {
+                            detail.toggle_diff_mode();
+                        }
+                    }
+                    KeyCode::Char('r') => {
+                        let rev_opt = if detail.active_tab == HelmDetailTab::Revisions {
+                            detail.selected_revision().map(|r| r.revision)
+                        } else if let Some(d) = &detail.detail {
+                            if d.revision > 1 {
+                                Some(d.revision - 1)
+                            } else {
+                                None
+                            }
+                        } else {
+                            None
+                        };
+                        if let Some(rev) = rev_opt {
+                            self.modal = Some(Modal::Confirm {
+                                title: format!("Rollback Helm Release [{}]", detail.release_name),
+                                message: format!(
+                                    "Rollback '{}' in namespace '{}' to revision {}?",
+                                    detail.release_name, detail.namespace, rev
+                                ),
+                                action_name: format!(
+                                    "helm-rollback:{}:{}:{}",
+                                    detail.release_name, detail.namespace, rev
+                                ),
+                                is_destructive: true,
+                            });
+                        } else {
+                            self.set_toast("No previous revision available to rollback to".to_string(), Theme::status_warn());
+                        }
+                    }
+                    KeyCode::Char('c') => {
+                        let link = crate::deep_link::DeepLink::Resource {
+                            context: self.active_context.clone(),
+                            namespace: Some(detail.namespace.clone()),
+                            kind: "HelmRelease".to_string(),
+                            name: detail.release_name.clone(),
+                        };
+                        let url = link.to_url();
+                        let url_clone = url.clone();
+                        tokio::spawn(async move {
+                            let _ = copy_to_clipboard(&url_clone);
                         });
-                        self.set_toast(
-                            if target_unsched { format!("Cordoning node '{}'...", node_name) } else { format!("Uncordoning node '{}'...", node_name) },
-                            Theme::status_warn(),
-                        );
+                        self.set_toast(format!("Copied deep link: {}", url), Theme::status_ok());
+                    }
+                    KeyCode::Char('y') => {
+                        let text_to_copy: Option<String> = match detail.active_tab {
+                            HelmDetailTab::Manifest => detail.detail.as_ref().map(|d| d.manifest.clone()),
+                            HelmDetailTab::ValuesDiff => detail.detail.as_ref().map(|d| d.values_yaml.clone()),
+                            HelmDetailTab::Notes => detail.detail.as_ref().map(|d| d.notes.clone()),
+                            _ => None,
+                        };
+                        if let Some(txt) = text_to_copy {
+                            tokio::spawn(async move {
+                                let _ = copy_to_clipboard(&txt);
+                            });
+                            self.set_toast("Copied tab content to clipboard".to_string(), Theme::status_ok());
+                        }
                     }
                     _ => {}
                 }
@@ -3482,6 +4237,25 @@ impl App {
     pub async fn handle_mouse(&mut self, mouse: crossterm::event::MouseEvent) {
         use crossterm::event::{MouseButton, MouseEventKind};
 
+        // 0. Check if clicking on Close Port Forward button in status bar
+        if mouse.kind == MouseEventKind::Down(MouseButton::Left) {
+            let clicked_close_pf = {
+                if let Some(rect) = *self.close_pf_button_rect.borrow() {
+                    mouse.column >= rect.x
+                        && mouse.column < rect.x + rect.width
+                        && mouse.row >= rect.y
+                        && mouse.row < rect.y + rect.height
+                } else {
+                    false
+                }
+            };
+
+            if clicked_close_pf {
+                self.close_selected_port_forward().await;
+                return;
+            }
+        }
+
         // 1. Check if clicking on header context chips
         if mouse.kind == MouseEventKind::Down(MouseButton::Left) {
             let clicked_ctx = self.context_chip_rects.borrow().iter().find_map(|(rect, name)| {
@@ -3501,6 +4275,31 @@ impl App {
                     self.switch_context(target).await;
                 }
                 return;
+            }
+        }
+
+        // Check if clicking inside MetricsTimeline modal range buttons
+        if let Some(Modal::MetricsTimeline(ref mut panel)) = self.modal {
+            if mouse.kind == MouseEventKind::Down(MouseButton::Left) {
+                let clicked_range = {
+                    if let Ok(lock) = panel.range_button_rects.lock() {
+                        lock.iter().find_map(|(rect, r)| {
+                            if mouse.column >= rect.x && mouse.column < rect.x + rect.width
+                                && mouse.row >= rect.y && mouse.row < rect.y + rect.height
+                            {
+                                Some(*r)
+                            } else {
+                                None
+                            }
+                        })
+                    } else {
+                        None
+                    }
+                };
+                if let Some(r) = clicked_range {
+                    panel.range = r;
+                    return;
+                }
             }
         }
 
@@ -3648,6 +4447,19 @@ impl App {
             }
         }
 
+        // Top view scrolling
+        if let ActiveView::Top(top) = &mut self.active_view {
+            match mouse.kind {
+                MouseEventKind::ScrollDown => {
+                    top.select_next();
+                }
+                MouseEventKind::ScrollUp => {
+                    top.select_prev();
+                }
+                _ => {}
+            }
+        }
+
         // Logs view scrolling
         if let ActiveView::Logs(logs) = &mut self.active_view {
             match mouse.kind {
@@ -3671,6 +4483,54 @@ impl App {
                     desc.scroll_up(3);
                 }
                 _ => {}
+            }
+        }
+
+        // GPU View mouse selection, hover & scrolling
+        if let ActiveView::GpuInfo(gpu) = &mut self.active_view {
+            let left_vp = gpu.last_left_pane_rect.get();
+            if mouse.column >= left_vp.x && mouse.column < left_vp.x + left_vp.width
+                && mouse.row >= left_vp.y && mouse.row < left_vp.y + left_vp.height
+            {
+                let data_start_y = left_vp.y + 3;
+                if mouse.row >= data_start_y {
+                    let screen_row = (mouse.row - data_start_y) as usize;
+                    let target_idx = gpu.last_nodes_start_idx.get() + screen_row;
+                    if let Some(ci) = &gpu.cluster_info {
+                        if target_idx < ci.nodes.len() {
+                            gpu.selected_node_idx = target_idx;
+                            gpu.selected_pod_idx = 0;
+                            gpu.focused_pane = gpu_view::GpuPane::Nodes;
+                        }
+                    }
+                }
+                match mouse.kind {
+                    MouseEventKind::ScrollDown => gpu.select_next_node(),
+                    MouseEventKind::ScrollUp => gpu.select_prev_node(),
+                    _ => {}
+                }
+            }
+
+            let pods_vp = gpu.last_pods_pane_rect.get();
+            if mouse.column >= pods_vp.x && mouse.column < pods_vp.x + pods_vp.width
+                && mouse.row >= pods_vp.y && mouse.row < pods_vp.y + pods_vp.height
+            {
+                let data_start_y = pods_vp.y + 2;
+                if mouse.row >= data_start_y {
+                    let screen_row = (mouse.row - data_start_y) as usize;
+                    let target_idx = gpu.last_pods_start_idx.get() + screen_row;
+                    if let Some(node) = gpu.selected_node() {
+                        if target_idx < node.pods.len() {
+                            gpu.selected_pod_idx = target_idx;
+                            gpu.focused_pane = gpu_view::GpuPane::Pods;
+                        }
+                    }
+                }
+                match mouse.kind {
+                    MouseEventKind::ScrollDown => gpu.select_next_pod(),
+                    MouseEventKind::ScrollUp => gpu.select_prev_pod(),
+                    _ => {}
+                }
             }
         }
 
@@ -3735,6 +4595,20 @@ impl App {
             ActiveView::Logs(logs) => {
                 logs.set_search_query(&filter);
             }
+            ActiveView::Top(top) => {
+                top.filter = filter;
+                top.clamp_selection();
+            }
+            ActiveView::Helm(helm) => {
+                helm.filter_query = filter;
+                let count = helm.filtered_indices().len();
+                if helm.selected_idx >= count {
+                    helm.selected_idx = count.saturating_sub(1);
+                }
+            }
+            ActiveView::HelmDetail(detail) => {
+                detail.filter_query = filter;
+            }
             _ => {}
         }
     }
@@ -3754,6 +4628,16 @@ impl App {
             }
             ActiveView::Logs(logs) => {
                 logs.clear_search();
+            }
+            ActiveView::Top(top) => {
+                top.filter.clear();
+                top.clamp_selection();
+            }
+            ActiveView::Helm(helm) => {
+                helm.filter_query.clear();
+            }
+            ActiveView::HelmDetail(detail) => {
+                detail.filter_query.clear();
             }
             _ => {}
         }
@@ -3941,6 +4825,22 @@ impl App {
             CommandTarget::Quit => {
                 self.is_running = false;
             }
+            CommandTarget::ThemePicker => {
+                let current_idx = Theme::active_index();
+                self.modal = Some(Modal::ThemePicker {
+                    selected_idx: current_idx,
+                    initial_theme_idx: current_idx,
+                });
+            }
+            CommandTarget::SetTheme(theme_name) => {
+                if let Some(p) = Theme::set_theme_by_name(&theme_name) {
+                    self.ai_settings.theme = Some(p.name.to_string());
+                    let _ = self.ai_settings.save();
+                    self.set_toast(format!("Theme switched to {}", p.display_name), Theme::status_ok());
+                } else {
+                    self.set_toast(format!("Unknown theme '{}'. Try :themes to pick.", theme_name), Theme::status_warn());
+                }
+            }
             CommandTarget::OpenUrl(_) => {}
         }
     }
@@ -3998,6 +4898,13 @@ impl App {
                     if ns != &self.active_namespace {
                         self.switch_namespace(ns.clone()).await;
                     }
+                }
+
+                if kind.eq_ignore_ascii_case("helmrelease") || kind.eq_ignore_ascii_case("helm") {
+                    let ns = namespace.clone().unwrap_or_else(|| self.active_namespace.clone());
+                    self.open_helm_detail(name.clone(), ns, HelmDetailTab::Overview);
+                    self.set_toast(format!("Navigated to Helm release '{}'", name), Theme::status_ok());
+                    return Ok(());
                 }
 
                 // Resolve kind
@@ -4118,7 +5025,10 @@ impl App {
     pub async fn switch_view_to_kind(&mut self, kind: ResourceKind) {
         let new_view = match kind {
             ResourceKind::PortForwards => ActiveView::PortForwards(PortForwardViewState::new()),
-            ResourceKind::HelmReleases => ActiveView::Helm(HelmViewState::new()),
+            ResourceKind::HelmReleases => {
+                self.refresh_helm_releases();
+                ActiveView::Helm(HelmViewState::new())
+            }
             ResourceKind::Overview => {
                 let mut initial_data = self.cluster_overview_data.clone().unwrap_or_default();
                 initial_data.context_name = self.active_context.clone();
@@ -4138,6 +5048,72 @@ impl App {
             ResourceKind::Toolbox => ActiveView::Toolbox(ToolboxViewState::new()),
             ResourceKind::Assistant => ActiveView::Assistant,
             ResourceKind::Settings => ActiveView::Settings(SettingsViewState::new()),
+            ResourceKind::Topology => {
+                let namespaces = if self.active_namespace.is_empty() {
+                    vec![]
+                } else {
+                    vec![self.active_namespace.clone()]
+                };
+                let topo_state = topology_view::TopologyViewState::new(namespaces.clone());
+                let ctx = self.active_context.clone();
+                let cache = self.client_cache.clone();
+                let event_tx = self.event_tx.clone();
+                let ns_list = namespaces.clone();
+
+                tokio::spawn(async move {
+                    let input = srelens_kube::topology::TopologyGraphIn {
+                        context: ctx.clone(),
+                        namespaces: ns_list.clone(),
+                        prometheus: vec![],
+                    };
+                    let res = match srelens_kube::topology::build_topology(cache, input, false).await {
+                        Ok(graph) => Ok(graph),
+                        Err(e) => Err(format!("Failed to build topology: {}", e)),
+                    };
+                    let _ = event_tx.send(crate::event::AppEvent::TopologyResult {
+                        context: ctx,
+                        namespaces: ns_list,
+                        result: res,
+                    });
+                });
+
+                ActiveView::Topology(topo_state)
+            }
+            ResourceKind::GpuInfo => {
+                let gpu_state = gpu_view::GpuViewState::new();
+                let ctx = self.active_context.clone();
+                let cache = self.client_cache.clone();
+                let event_tx = self.event_tx.clone();
+
+                tokio::spawn(async move {
+                    let res = match cache.get(&ctx).await {
+                        Ok(client) => srelens_kube::gpu_info::fetch_gpu_info(client).await,
+                        Err(e) => Err(format!("Failed to connect to cluster: {}", e)),
+                    };
+                    let _ = event_tx.send(crate::event::AppEvent::GpuInfoResult {
+                        context: ctx,
+                        result: res,
+                    });
+                });
+
+                ActiveView::GpuInfo(gpu_state)
+            }
+            ResourceKind::TopPods => {
+                self.refresh_pod_metrics();
+                self.refresh_node_metrics();
+                let mut top_state = top_view::TopViewState::new(top_view::TopTab::Pods);
+                let (pods, nodes) = self.build_top_rows();
+                top_state.set_data(pods, nodes);
+                ActiveView::Top(top_state)
+            }
+            ResourceKind::TopNodes => {
+                self.refresh_pod_metrics();
+                self.refresh_node_metrics();
+                let mut top_state = top_view::TopViewState::new(top_view::TopTab::Nodes);
+                let (pods, nodes) = self.build_top_rows();
+                top_state.set_data(pods, nodes);
+                ActiveView::Top(top_state)
+            }
             _ => {
                 let mut table = ResourceTableState::new(kind.clone());
                 if let Some(watch_kind) = table.kind.watch_kind() {
@@ -4156,6 +5132,9 @@ impl App {
         self.nav_stack.push(old_view);
         self.filter_buffer.clear();
         self.restart_active_watch().await;
+        if matches!(self.active_view, ActiveView::PortForwards(_)) {
+            self.sync_port_forwards();
+        }
     }
 
     pub async fn get_pod_containers(&self, pod_name: &str, namespace: Option<&str>) -> Vec<String> {
@@ -4296,6 +5275,286 @@ impl App {
 
         let old_view = std::mem::replace(&mut self.active_view, ActiveView::Logs(logs_state));
         self.nav_stack.push(old_view);
+    }
+
+    pub async fn open_multi_pod_logs_view(
+        &mut self,
+        target_name: String,
+        namespace: Option<String>,
+        pod_names: Vec<String>,
+    ) {
+        if let Some(prev_ch) = self.active_log_channel.take() {
+            self.logs_manager.stop(&prev_ch);
+        }
+
+        let channel = format!("logs:multi:{}:{}", target_name, uuid::Uuid::new_v4());
+        self.active_log_channel = Some(channel.clone());
+
+        let target_ns = namespace
+            .or_else(|| if self.active_namespace.is_empty() { None } else { Some(self.active_namespace.clone()) })
+            .unwrap_or_else(|| "default".to_string());
+
+        let mut logs_state = LogsViewState::new_multi_pod(
+            target_name.clone(),
+            target_ns.clone(),
+            pod_names.clone(),
+            channel.clone(),
+        );
+        logs_state.push_line(format!(
+            "Streaming logs for {} ({} pods in {})...",
+            target_name,
+            pod_names.len(),
+            target_ns
+        ));
+
+        let sink = TuiSink::arc(self.event_tx.clone());
+        let ctx = self.active_context.clone();
+        let targets = pod_names
+            .iter()
+            .map(|p| srelens_streams::logs::LogTarget {
+                pod: p.clone(),
+                container: None,
+                label: p.clone(),
+            })
+            .collect();
+
+        let _ = self.logs_manager.start(
+            sink,
+            ctx,
+            target_ns,
+            targets,
+            channel,
+            Some(logs_state.timestamps),
+            None,
+            Some(200),
+        ).await;
+
+        let old_view = std::mem::replace(&mut self.active_view, ActiveView::Logs(logs_state));
+        self.nav_stack.push(old_view);
+    }
+
+    pub async fn get_workload_pods(&self, workload_kind: &str, workload_name: &str, namespace: &str) -> Vec<String> {
+        let mut matching_pods = Vec::new();
+
+        // 1. Check in-memory resource_cache
+        for ((_, ns, kind), items) in &self.resource_cache {
+            if kind.eq_ignore_ascii_case("pods") && (ns == namespace || ns.is_empty()) {
+                for item in items {
+                    let pod_name = item.get("name").and_then(|v| v.as_str())
+                        .or_else(|| item.pointer("/metadata/name").and_then(|v| v.as_str()));
+                    if let Some(pname) = pod_name {
+                        let owner_match = item.pointer("/metadata/ownerReferences")
+                            .and_then(|v| v.as_array())
+                            .map(|owners| {
+                                owners.iter().any(|o| {
+                                    let oname = o.get("name").and_then(|v| v.as_str()).unwrap_or("");
+                                    let okind = o.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+                                    if okind.eq_ignore_ascii_case(workload_kind) && oname == workload_name {
+                                        return true;
+                                    }
+                                    if workload_kind.eq_ignore_ascii_case("Deployment")
+                                        && okind.eq_ignore_ascii_case("ReplicaSet")
+                                        && oname.starts_with(workload_name)
+                                    {
+                                        return true;
+                                    }
+                                    false
+                                })
+                            })
+                            .unwrap_or(false);
+
+                        let prefix_match = pname.starts_with(workload_name);
+                        if owner_match || prefix_match {
+                            if !matching_pods.contains(&pname.to_string()) {
+                                matching_pods.push(pname.to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if !matching_pods.is_empty() {
+            return matching_pods;
+        }
+
+        // 2. Query Kubernetes API
+        let ctx = self.active_context.clone();
+        if let Ok(client) = self.client_cache.get(&ctx).await {
+            let api: kube::Api<k8s_openapi::api::core::v1::Pod> = kube::Api::namespaced(client, namespace);
+            if let Ok(pod_list) = api.list(&kube::api::ListParams::default()).await {
+                for pod in pod_list {
+                    let pname = pod.metadata.name.unwrap_or_default();
+                    let owner_match = pod.metadata.owner_references.as_deref().unwrap_or(&[]).iter().any(|o| {
+                        if o.kind.eq_ignore_ascii_case(workload_kind) && o.name == workload_name {
+                            return true;
+                        }
+                        if workload_kind.eq_ignore_ascii_case("Deployment")
+                            && o.kind.eq_ignore_ascii_case("ReplicaSet")
+                            && o.name.starts_with(workload_name)
+                        {
+                            return true;
+                        }
+                        false
+                    });
+                    if owner_match || pname.starts_with(workload_name) {
+                        if !matching_pods.contains(&pname) {
+                            matching_pods.push(pname);
+                        }
+                    }
+                }
+            }
+        }
+
+        matching_pods
+    }
+
+    fn find_cached_node_allocatable(&self, node_name: &str) -> (i64, i64) {
+        for ((_, _, kind), items) in &self.resource_cache {
+            if kind.eq_ignore_ascii_case("nodes") {
+                for item in items {
+                    let name = item.get("name").and_then(|v| v.as_str())
+                        .or_else(|| item.pointer("/metadata/name").and_then(|v| v.as_str()))
+                        .unwrap_or("");
+                    if name == node_name {
+                        let alloc_cpu = item.get("allocatableCpuMillicores").and_then(|v| v.as_i64())
+                            .or_else(|| item.pointer("/status/allocatable/cpu").and_then(|v| v.as_str()).map(srelens_kube::metrics::cpu_millicores))
+                            .unwrap_or(0);
+                        let alloc_mem = item.get("allocatableMemoryMiB").and_then(|v| v.as_i64())
+                            .or_else(|| item.pointer("/status/allocatable/memory").and_then(|v| v.as_str()).map(srelens_kube::metrics::mem_mib))
+                            .unwrap_or(0);
+                        return (alloc_cpu, alloc_mem);
+                    }
+                }
+            }
+        }
+        (0, 0)
+    }
+
+    pub fn build_top_rows(&self) -> (Vec<crate::views::top_view::TopPodRow>, Vec<crate::views::top_view::TopNodeRow>) {
+        let mut pod_rows = Vec::new();
+
+        for ((_, ns, kind), items) in &self.resource_cache {
+            if kind.eq_ignore_ascii_case("pods") {
+                for item in items {
+                    let name = item.get("name").and_then(|v| v.as_str())
+                        .or_else(|| item.pointer("/metadata/name").and_then(|v| v.as_str()))
+                        .unwrap_or("").to_string();
+                    if name.is_empty() { continue; }
+                    let namespace = item.get("namespace").and_then(|v| v.as_str())
+                        .or_else(|| item.pointer("/metadata/namespace").and_then(|v| v.as_str()))
+                        .unwrap_or(ns).to_string();
+
+                    if !self.active_namespace.is_empty() && namespace != self.active_namespace {
+                        continue;
+                    }
+                    if pod_rows.iter().any(|r: &crate::views::top_view::TopPodRow| r.name == name && r.namespace == namespace) {
+                        continue;
+                    }
+
+                    let (req_cpu, lim_cpu, req_mem, lim_mem) = crate::views::top_view::TopViewState::extract_pod_resources(item);
+
+                    let (cur_cpu, cur_mem) = self.pod_metrics_history.get(&name)
+                        .and_then(|h| h.back())
+                        .map(|s| (s.cpu_millicores as i64, s.memory_mib as i64))
+                        .unwrap_or((0, 0));
+
+                    pod_rows.push(crate::views::top_view::TopPodRow {
+                        namespace,
+                        name,
+                        cpu_millicores: cur_cpu,
+                        cpu_req_millicores: req_cpu,
+                        cpu_lim_millicores: lim_cpu,
+                        mem_mib: cur_mem,
+                        mem_req_mib: req_mem,
+                        mem_lim_mib: lim_mem,
+                    });
+                }
+            }
+        }
+
+        for (pname, history) in &self.pod_metrics_history {
+            if !pod_rows.iter().any(|r| &r.name == pname) {
+                if let Some(latest) = history.back() {
+                    pod_rows.push(crate::views::top_view::TopPodRow {
+                        namespace: self.active_namespace.clone(),
+                        name: pname.clone(),
+                        cpu_millicores: latest.cpu_millicores as i64,
+                        cpu_req_millicores: 0,
+                        cpu_lim_millicores: 0,
+                        mem_mib: latest.memory_mib as i64,
+                        mem_req_mib: 0,
+                        mem_lim_mib: 0,
+                    });
+                }
+            }
+        }
+
+        let mut node_rows = Vec::new();
+        for ((_, _, kind), items) in &self.resource_cache {
+            if kind.eq_ignore_ascii_case("nodes") {
+                for item in items {
+                    let name = item.get("name").and_then(|v| v.as_str())
+                        .or_else(|| item.pointer("/metadata/name").and_then(|v| v.as_str()))
+                        .unwrap_or("").to_string();
+                    if name.is_empty() { continue; }
+                    if node_rows.iter().any(|r: &crate::views::top_view::TopNodeRow| r.name == name) {
+                        continue;
+                    }
+                    let status = item.get("status").and_then(|v| v.as_str())
+                        .unwrap_or("Ready").to_string();
+
+                    let alloc_cpu = item.get("allocatableCpuMillicores").and_then(|v| v.as_i64())
+                        .or_else(|| item.pointer("/status/allocatable/cpu").and_then(|v| v.as_str()).map(srelens_kube::metrics::cpu_millicores))
+                        .unwrap_or(0);
+
+                    let alloc_mem = item.get("allocatableMemoryMiB").and_then(|v| v.as_i64())
+                        .or_else(|| item.pointer("/status/allocatable/memory").and_then(|v| v.as_str()).map(srelens_kube::metrics::mem_mib))
+                        .unwrap_or(0);
+
+                    let (cur_cpu, cur_mem) = self.node_metrics_history.get(&name)
+                        .and_then(|h| h.back())
+                        .map(|s| (s.cpu_millicores as i64, s.memory_mib as i64))
+                        .unwrap_or((0, 0));
+
+                    node_rows.push(crate::views::top_view::TopNodeRow {
+                        name,
+                        status,
+                        cpu_millicores: cur_cpu,
+                        cpu_alloc_millicores: alloc_cpu,
+                        mem_mib: cur_mem,
+                        mem_alloc_mib: alloc_mem,
+                    });
+                }
+            }
+        }
+
+        for (nname, history) in &self.node_metrics_history {
+            if !node_rows.iter().any(|r| &r.name == nname) {
+                if let Some(latest) = history.back() {
+                    let (alloc_cpu, alloc_mem) = self.find_cached_node_allocatable(nname);
+                    node_rows.push(crate::views::top_view::TopNodeRow {
+                        name: nname.clone(),
+                        status: "Ready".to_string(),
+                        cpu_millicores: latest.cpu_millicores as i64,
+                        cpu_alloc_millicores: alloc_cpu,
+                        mem_mib: latest.memory_mib as i64,
+                        mem_alloc_mib: alloc_mem,
+                    });
+                }
+            }
+        }
+
+        (pod_rows, node_rows)
+    }
+
+    pub fn refresh_top_view_data(&mut self) {
+        if matches!(self.active_view, ActiveView::Top(_)) {
+            let (pods, nodes) = self.build_top_rows();
+            if let ActiveView::Top(ref mut top) = self.active_view {
+                top.set_data(pods, nodes);
+            }
+        }
     }
 
     pub async fn open_yaml_view(&mut self, name: String, kind: String, namespace: Option<String>) {
@@ -4626,85 +5885,330 @@ impl App {
         }
     }
 
+    pub fn reload_topology_view(&mut self) {
+        if let ActiveView::Topology(topo) = &mut self.active_view {
+            topo.is_loading = true;
+            topo.error = None;
+            let namespaces = topo.namespaces.clone();
+            let ctx = self.active_context.clone();
+            let cache = self.client_cache.clone();
+            let event_tx = self.event_tx.clone();
+            let ns_list = namespaces.clone();
+
+            tokio::spawn(async move {
+                let input = srelens_kube::topology::TopologyGraphIn {
+                    context: ctx.clone(),
+                    namespaces: ns_list.clone(),
+                    prometheus: vec![],
+                };
+                let res = match srelens_kube::topology::build_topology(cache, input, false).await {
+                    Ok(graph) => Ok(graph),
+                    Err(e) => Err(format!("Failed to build topology: {}", e)),
+                };
+                let _ = event_tx.send(crate::event::AppEvent::TopologyResult {
+                    context: ctx,
+                    namespaces: ns_list,
+                    result: res,
+                });
+            });
+        }
+    }
+
+    pub fn handle_topology_result(
+        &mut self,
+        context: &str,
+        _namespaces: Vec<String>,
+        result: Result<srelens_kube::topology::TopologyGraphOut, String>,
+    ) {
+        if let ActiveView::Topology(topo) = &mut self.active_view {
+            if self.active_context == context {
+                match result {
+                    Ok(graph) => topo.set_graph(graph),
+                    Err(err) => topo.set_error(err),
+                }
+            }
+        }
+    }
+
+    pub fn reload_gpu_info_view(&mut self) {
+        if let ActiveView::GpuInfo(gpu) = &mut self.active_view {
+            gpu.is_loading = true;
+            gpu.error = None;
+            let ctx = self.active_context.clone();
+            let cache = self.client_cache.clone();
+            let event_tx = self.event_tx.clone();
+
+            tokio::spawn(async move {
+                let res = match cache.get(&ctx).await {
+                    Ok(client) => srelens_kube::gpu_info::fetch_gpu_info(client).await,
+                    Err(e) => Err(format!("Failed to connect to cluster: {}", e)),
+                };
+                let _ = event_tx.send(crate::event::AppEvent::GpuInfoResult {
+                    context: ctx,
+                    result: res,
+                });
+            });
+        }
+    }
+
+    pub fn handle_gpu_info_result(
+        &mut self,
+        context: &str,
+        result: Result<srelens_kube::gpu_info::GpuClusterInfo, String>,
+    ) {
+        if let ActiveView::GpuInfo(gpu) = &mut self.active_view {
+            if self.active_context == context {
+                match result {
+                    Ok(info) => gpu.set_info(info),
+                    Err(err) => gpu.set_error(err),
+                }
+            }
+        }
+    }
+
+    pub fn refresh_helm_releases(&mut self) {
+        if let ActiveView::Helm(helm) = &mut self.active_view {
+            helm.is_loading = true;
+            helm.error = None;
+        }
+        let ctx = self.active_context.clone();
+        let ns = if self.active_namespace.is_empty() {
+            None
+        } else {
+            Some(self.active_namespace.clone())
+        };
+        let ns_str = self.active_namespace.clone();
+        let cache = self.client_cache.clone();
+        let event_tx = self.event_tx.clone();
+
+        tokio::spawn(async move {
+            let res = srelens_kube::helm::fetch_helm_releases(&cache, &ctx, ns.as_deref()).await;
+            let _ = event_tx.send(crate::event::AppEvent::HelmReleasesResult {
+                context: ctx,
+                namespace: ns_str,
+                result: res,
+            });
+        });
+    }
+
+    pub fn handle_helm_releases_result(
+        &mut self,
+        context: &str,
+        _namespace: &str,
+        result: Result<Vec<srelens_kube::helm::HelmReleaseSummary>, String>,
+    ) {
+        if let ActiveView::Helm(helm) = &mut self.active_view {
+            if self.active_context == context {
+                match result {
+                    Ok(summaries) => {
+                        let items: Vec<HelmReleaseItem> = summaries.into_iter().map(Into::into).collect();
+                        helm.set_releases(items);
+                    }
+                    Err(err) => {
+                        helm.set_error(err);
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn open_helm_detail(&mut self, name: String, namespace: String, initial_tab: HelmDetailTab) {
+        let mut detail_state = HelmDetailViewState::new(name.clone(), namespace.clone());
+        detail_state.set_tab(initial_tab);
+        let ctx = self.active_context.clone();
+        let cache = self.client_cache.clone();
+        let event_tx = self.event_tx.clone();
+        let name_c = name.clone();
+        let ns_c = namespace.clone();
+
+        tokio::spawn(async move {
+            let res = srelens_kube::helm::fetch_helm_release_detail(&cache, &ctx, &ns_c, &name_c, None).await;
+            let _ = event_tx.send(crate::event::AppEvent::HelmDetailResult {
+                context: ctx,
+                namespace: ns_c,
+                name: name_c,
+                revision: None,
+                result: res,
+            });
+        });
+
+        let old_view = std::mem::replace(&mut self.active_view, ActiveView::HelmDetail(detail_state));
+        self.nav_stack.push(old_view);
+    }
+
+    pub fn reload_helm_detail(&mut self, name: &str, namespace: &str) {
+        if let ActiveView::HelmDetail(detail) = &mut self.active_view {
+            detail.is_loading = true;
+            detail.error = None;
+        }
+        let ctx = self.active_context.clone();
+        let cache = self.client_cache.clone();
+        let event_tx = self.event_tx.clone();
+        let name_c = name.to_string();
+        let ns_c = namespace.to_string();
+
+        tokio::spawn(async move {
+            let res = srelens_kube::helm::fetch_helm_release_detail(&cache, &ctx, &ns_c, &name_c, None).await;
+            let _ = event_tx.send(crate::event::AppEvent::HelmDetailResult {
+                context: ctx,
+                namespace: ns_c,
+                name: name_c,
+                revision: None,
+                result: res,
+            });
+        });
+    }
+
+    pub fn handle_helm_detail_result(
+        &mut self,
+        context: &str,
+        namespace: &str,
+        name: &str,
+        revision: Option<i64>,
+        result: Result<srelens_kube::helm::HelmReleaseDetail, String>,
+    ) {
+        if let ActiveView::HelmDetail(detail) = &mut self.active_view {
+            if self.active_context == context && detail.namespace == namespace && detail.release_name == name {
+                match result {
+                    Ok(rel_detail) => {
+                        if let Some(rev) = revision {
+                            if let Some(curr) = &detail.detail {
+                                if curr.revision.saturating_sub(1) == rev {
+                                    detail.set_previous_detail(rel_detail);
+                                    return;
+                                }
+                            }
+                        }
+                        let curr_rev = rel_detail.revision;
+                        detail.set_detail(rel_detail);
+
+                        if curr_rev > 1 && detail.previous_detail.is_none() {
+                            let prev_rev = curr_rev - 1;
+                            let ctx = self.active_context.clone();
+                            let cache = self.client_cache.clone();
+                            let event_tx = self.event_tx.clone();
+                            let name_c = name.to_string();
+                            let ns_c = namespace.to_string();
+                            tokio::spawn(async move {
+                                let res = srelens_kube::helm::fetch_helm_release_detail(&cache, &ctx, &ns_c, &name_c, Some(prev_rev)).await;
+                                let _ = event_tx.send(crate::event::AppEvent::HelmDetailResult {
+                                    context: ctx,
+                                    namespace: ns_c,
+                                    name: name_c,
+                                    revision: Some(prev_rev),
+                                    result: res,
+                                });
+                            });
+                        }
+                    }
+                    Err(err) => {
+                        if revision.is_none() {
+                            detail.set_error(err);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     pub fn open_action_palette(&mut self, kind: String, name: String, namespace: Option<String>) {
         use crate::ui::dialogs::{QuickActionId, QuickActionItem};
 
         let kind_lower = kind.to_lowercase();
         let actions = match kind_lower.as_str() {
-            "pod" | "pods" => vec![
-                QuickActionItem {
-                    id: QuickActionId::AskAi,
-                    key_hint: "ai".to_string(),
-                    title: "🤖 Ask AI Assistant about this Pod".to_string(),
-                    description: "Inspect pod status, errors, exit codes & recent events".to_string(),
-                },
-                QuickActionItem {
-                    id: QuickActionId::PlaybookCrashLoop,
-                    key_hint: "/crashloop".to_string(),
-                    title: "⚡ AI Triage CrashLoopBackOff".to_string(),
-                    description: "Fetch previous container logs, termination exit codes & recent events".to_string(),
-                },
-                QuickActionItem {
-                    id: QuickActionId::PlaybookPending,
-                    key_hint: "/pending".to_string(),
-                    title: "⚡ AI Diagnose Pending / Unschedulable".to_string(),
-                    description: "Analyze scheduling taints, node affinities, and PVC constraints".to_string(),
-                },
-                QuickActionItem {
-                    id: QuickActionId::PlaybookOom,
-                    key_hint: "/oom".to_string(),
-                    title: "⚡ AI Diagnose OOMKilled".to_string(),
-                    description: "Inspect memory limits, usage peaks, and OOM terminations".to_string(),
-                },
-                QuickActionItem {
-                    id: QuickActionId::RelationshipTree,
-                    key_hint: "t".to_string(),
-                    title: "🌳 Resource Relationship Tree".to_string(),
-                    description: "Trace owner Deployment/ReplicaSet, Service, ConfigMaps & PVCs".to_string(),
-                },
-                QuickActionItem {
-                    id: QuickActionId::ViewLogs,
-                    key_hint: "l".to_string(),
-                    title: "📋 View Live Logs".to_string(),
-                    description: "Stream logs from pod containers with tailing".to_string(),
-                },
-                QuickActionItem {
-                    id: QuickActionId::OpenShell,
-                    key_hint: "s".to_string(),
-                    title: "🐚 Open Shell".to_string(),
-                    description: "Attach interactive terminal session inside container".to_string(),
-                },
-                QuickActionItem {
-                    id: QuickActionId::PortForward,
-                    key_hint: "f".to_string(),
-                    title: "🔌 Port Forward".to_string(),
-                    description: "Forward local port to pod container".to_string(),
-                },
-                QuickActionItem {
-                    id: QuickActionId::Describe,
-                    key_hint: "d".to_string(),
-                    title: "📄 Describe Pod".to_string(),
-                    description: "Formatted Kubernetes describe output & events".to_string(),
-                },
-                QuickActionItem {
-                    id: QuickActionId::ViewYaml,
-                    key_hint: "y".to_string(),
-                    title: "📝 View YAML".to_string(),
-                    description: "Inspect live Kubernetes YAML manifest".to_string(),
-                },
-                QuickActionItem {
-                    id: QuickActionId::EditYaml,
-                    key_hint: "e".to_string(),
-                    title: "✏️  Edit YAML".to_string(),
-                    description: "Open in external editor with server-side apply".to_string(),
-                },
-                QuickActionItem {
-                    id: QuickActionId::Delete,
-                    key_hint: "del".to_string(),
-                    title: "🗑️  Delete Pod".to_string(),
-                    description: "Gracefully delete pod from the cluster".to_string(),
-                },
-            ],
+            "pod" | "pods" => {
+                let mut acts = vec![
+                    QuickActionItem {
+                        id: QuickActionId::AskAi,
+                        key_hint: "ai".to_string(),
+                        title: "🤖 Ask AI Assistant about this Pod".to_string(),
+                        description: "Inspect pod status, errors, exit codes & recent events".to_string(),
+                    },
+                    QuickActionItem {
+                        id: QuickActionId::PlaybookCrashLoop,
+                        key_hint: "/crashloop".to_string(),
+                        title: "⚡ AI Triage CrashLoopBackOff".to_string(),
+                        description: "Fetch previous container logs, termination exit codes & recent events".to_string(),
+                    },
+                    QuickActionItem {
+                        id: QuickActionId::PlaybookPending,
+                        key_hint: "/pending".to_string(),
+                        title: "⚡ AI Diagnose Pending / Unschedulable".to_string(),
+                        description: "Analyze scheduling taints, node affinities, and PVC constraints".to_string(),
+                    },
+                    QuickActionItem {
+                        id: QuickActionId::PlaybookOom,
+                        key_hint: "/oom".to_string(),
+                        title: "⚡ AI Diagnose OOMKilled".to_string(),
+                        description: "Inspect memory limits, usage peaks, and OOM terminations".to_string(),
+                    },
+                    QuickActionItem {
+                        id: QuickActionId::RelationshipTree,
+                        key_hint: "t".to_string(),
+                        title: "🌳 Resource Relationship Tree".to_string(),
+                        description: "Trace owner Deployment/ReplicaSet, Service, ConfigMaps & PVCs".to_string(),
+                    },
+                    QuickActionItem {
+                        id: QuickActionId::ViewLogs,
+                        key_hint: "l".to_string(),
+                        title: "📋 View Live Logs".to_string(),
+                        description: "Stream logs from pod containers with tailing".to_string(),
+                    },
+                    QuickActionItem {
+                        id: QuickActionId::OpenShell,
+                        key_hint: "s".to_string(),
+                        title: "🐚 Open Shell".to_string(),
+                        description: "Attach interactive terminal session inside container".to_string(),
+                    },
+                    QuickActionItem {
+                        id: QuickActionId::PortForward,
+                        key_hint: "f".to_string(),
+                        title: "🔌 Port Forward".to_string(),
+                        description: "Forward local port to pod container".to_string(),
+                    },
+                    QuickActionItem {
+                        id: QuickActionId::Describe,
+                        key_hint: "d".to_string(),
+                        title: "📄 Describe Pod".to_string(),
+                        description: "Formatted Kubernetes describe output & events".to_string(),
+                    },
+                    QuickActionItem {
+                        id: QuickActionId::ViewYaml,
+                        key_hint: "y".to_string(),
+                        title: "📝 View YAML".to_string(),
+                        description: "Inspect live Kubernetes YAML manifest".to_string(),
+                    },
+                    QuickActionItem {
+                        id: QuickActionId::EditYaml,
+                        key_hint: "e".to_string(),
+                        title: "✏️  Edit YAML".to_string(),
+                        description: "Open in external editor with server-side apply".to_string(),
+                    },
+                    QuickActionItem {
+                        id: QuickActionId::Delete,
+                        key_hint: "del".to_string(),
+                        title: "🗑️  Delete Pod".to_string(),
+                        description: "Gracefully delete pod from the cluster".to_string(),
+                    },
+                ];
+
+                let has_active_pf = !self.active_forwards_for("Pod", namespace.as_deref().unwrap_or(""), &name).is_empty();
+                if has_active_pf {
+                    if let Some(pos) = acts.iter().position(|a| a.id == QuickActionId::PortForward) {
+                        acts.insert(
+                            pos + 1,
+                            QuickActionItem {
+                                id: QuickActionId::StopPortForward,
+                                key_hint: "F".to_string(),
+                                title: "⏹ Close Active Port Forward".to_string(),
+                                description: "Terminate running port forward tunnel for this pod".to_string(),
+                            },
+                        );
+                    }
+                }
+
+                acts
+            },
             "deployment" | "deployments" | "statefulset" | "statefulsets" | "daemonset" | "daemonsets" => vec![
                 QuickActionItem {
                     id: QuickActionId::AskAi,
@@ -4773,50 +6277,69 @@ impl App {
                     description: "Delete workload resource from the cluster".to_string(),
                 },
             ],
-            "service" | "services" => vec![
-                QuickActionItem {
-                    id: QuickActionId::RelationshipTree,
-                    key_hint: "t".to_string(),
-                    title: "🌳 Resource Relationship Tree".to_string(),
-                    description: "View Service -> Ingress -> Endpoints -> Pods".to_string(),
-                },
-                QuickActionItem {
-                    id: QuickActionId::PlaybookEndpoints,
-                    key_hint: "/endpoints".to_string(),
-                    title: "⚡ AI Triage Missing Endpoints".to_string(),
-                    description: "Check selector matching, readiness probes, and backend pods".to_string(),
-                },
-                QuickActionItem {
-                    id: QuickActionId::JumpToPods,
-                    key_hint: "pods".to_string(),
-                    title: "🎯 Jump to Backend Pods".to_string(),
-                    description: "Navigate to pods matching this service's selector".to_string(),
-                },
-                QuickActionItem {
-                    id: QuickActionId::PortForward,
-                    key_hint: "f".to_string(),
-                    title: "🔌 Port Forward".to_string(),
-                    description: "Forward local port to service".to_string(),
-                },
-                QuickActionItem {
-                    id: QuickActionId::Describe,
-                    key_hint: "d".to_string(),
-                    title: "📄 Describe Service".to_string(),
-                    description: "Inspect service ports, endpoints & selectors".to_string(),
-                },
-                QuickActionItem {
-                    id: QuickActionId::ViewYaml,
-                    key_hint: "y".to_string(),
-                    title: "📝 View YAML".to_string(),
-                    description: "Inspect live Kubernetes YAML manifest".to_string(),
-                },
-                QuickActionItem {
-                    id: QuickActionId::Delete,
-                    key_hint: "del".to_string(),
-                    title: "🗑️  Delete Service".to_string(),
-                    description: "Delete service from the cluster".to_string(),
-                },
-            ],
+            "service" | "services" => {
+                let mut acts = vec![
+                    QuickActionItem {
+                        id: QuickActionId::RelationshipTree,
+                        key_hint: "t".to_string(),
+                        title: "🌳 Resource Relationship Tree".to_string(),
+                        description: "View Service -> Ingress -> Endpoints -> Pods".to_string(),
+                    },
+                    QuickActionItem {
+                        id: QuickActionId::PlaybookEndpoints,
+                        key_hint: "/endpoints".to_string(),
+                        title: "⚡ AI Triage Missing Endpoints".to_string(),
+                        description: "Check selector matching, readiness probes, and backend pods".to_string(),
+                    },
+                    QuickActionItem {
+                        id: QuickActionId::JumpToPods,
+                        key_hint: "pods".to_string(),
+                        title: "🎯 Jump to Backend Pods".to_string(),
+                        description: "Navigate to pods matching this service's selector".to_string(),
+                    },
+                    QuickActionItem {
+                        id: QuickActionId::PortForward,
+                        key_hint: "f".to_string(),
+                        title: "🔌 Port Forward".to_string(),
+                        description: "Forward local port to service".to_string(),
+                    },
+                    QuickActionItem {
+                        id: QuickActionId::Describe,
+                        key_hint: "d".to_string(),
+                        title: "📄 Describe Service".to_string(),
+                        description: "Inspect service ports, endpoints & selectors".to_string(),
+                    },
+                    QuickActionItem {
+                        id: QuickActionId::ViewYaml,
+                        key_hint: "y".to_string(),
+                        title: "📝 View YAML".to_string(),
+                        description: "Inspect live Kubernetes YAML manifest".to_string(),
+                    },
+                    QuickActionItem {
+                        id: QuickActionId::Delete,
+                        key_hint: "del".to_string(),
+                        title: "🗑️  Delete Service".to_string(),
+                        description: "Delete service from the cluster".to_string(),
+                    },
+                ];
+
+                let has_active_pf = !self.active_forwards_for("Service", namespace.as_deref().unwrap_or(""), &name).is_empty();
+                if has_active_pf {
+                    if let Some(pos) = acts.iter().position(|a| a.id == QuickActionId::PortForward) {
+                        acts.insert(
+                            pos + 1,
+                            QuickActionItem {
+                                id: QuickActionId::StopPortForward,
+                                key_hint: "F".to_string(),
+                                title: "⏹ Close Active Port Forward".to_string(),
+                                description: "Terminate running port forward tunnel for this service".to_string(),
+                            },
+                        );
+                    }
+                }
+
+                acts
+            },
             "ingress" | "ingresses" => vec![
                 QuickActionItem {
                     id: QuickActionId::RelationshipTree,
@@ -5017,12 +6540,58 @@ impl App {
                     }
                     QuickActionId::PortForward => {
                         let ns = namespace.unwrap_or_else(|| self.active_namespace.clone());
+                        let mut detected_port = None;
+                        let target_kind = if resource_kind.eq_ignore_ascii_case("service") { "Service" } else { "Pod" }.to_string();
+                        if let Ok(client) = self.client_cache.get(&self.active_context).await {
+                            if target_kind == "Service" {
+                                let api: kube::Api<k8s_openapi::api::core::v1::Service> = kube::Api::namespaced(client, &ns);
+                                if let Ok(svc) = api.get(&resource_name).await {
+                                    if let Some(spec) = svc.spec {
+                                        if let Some(ports) = spec.ports {
+                                            if let Some(p) = ports.first() {
+                                                detected_port = Some(p.port as u16);
+                                            }
+                                        }
+                                    }
+                                }
+                            } else {
+                                let api: kube::Api<k8s_openapi::api::core::v1::Pod> = kube::Api::namespaced(client, &ns);
+                                if let Ok(pod) = api.get(&resource_name).await {
+                                    if let Some(spec) = pod.spec {
+                                        for container in spec.containers {
+                                            if let Some(ports) = container.ports {
+                                                if let Some(p) = ports.first() {
+                                                    detected_port = Some(p.container_port as u16);
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        let target_port = detected_port.unwrap_or(8080);
                         self.modal = Some(Modal::PortForward {
                             pod_name: resource_name,
                             namespace: ns,
-                            container_port: 8080,
-                            local_port_input: "8080".to_string(),
+                            container_port: target_port,
+                            local_port_input: target_port.to_string(),
+                            kind: target_kind,
                         });
+                    }
+                    QuickActionId::StopPortForward => {
+                        let ns = namespace.unwrap_or_else(|| self.active_namespace.clone());
+                        let forwards = self.active_forwards_for(&resource_kind, &ns, &resource_name);
+                        let count = forwards.len();
+                        for f in forwards {
+                            self.forward_manager.stop(f.id);
+                        }
+                        self.sync_port_forwards();
+                        if count > 0 {
+                            self.set_toast(format!("✓ Closed {} active port forward(s) for {}", count, resource_name), Theme::status_ok());
+                        } else {
+                            self.set_toast("No active port forward to close".to_string(), Theme::status_warn());
+                        }
                     }
                     QuickActionId::Describe => {
                         self.open_describe_view(resource_name, resource_kind, namespace).await;
@@ -5206,7 +6775,133 @@ impl App {
                 self.set_toast("Rollout restart triggered".to_string(), Theme::status_ok());
             }
         } else if action_name.starts_with("stop-pf:") {
-            self.set_toast("Port forward stopped".to_string(), Theme::status_ok());
+            let id_str = action_name.strip_prefix("stop-pf:").unwrap_or("");
+            if let Ok(id) = id_str.parse::<u64>() {
+                self.forward_manager.stop(id);
+                self.sync_port_forwards();
+                self.set_toast(format!("Stopped port forward #{}", id), Theme::status_ok());
+            } else {
+                self.set_toast("Port forward stopped".to_string(), Theme::status_ok());
+            }
+        } else if action_name.starts_with("cordon:") {
+            let node_name = action_name.strip_prefix("cordon:").unwrap_or("").to_string();
+            let ctx = self.active_context.clone();
+            let cache = self.client_cache.clone();
+            let event_tx = self.event_tx.clone();
+            let n_name = node_name.clone();
+
+            tokio::spawn(async move {
+                if let Ok(client) = cache.get(&ctx).await {
+                    let api: kube::Api<k8s_openapi::api::core::v1::Node> = kube::Api::all(client);
+                    let patch = serde_json::json!({ "spec": { "unschedulable": true } });
+                    let res = api.patch(&n_name, &kube::api::PatchParams::default(), &kube::api::Patch::Merge(&patch)).await;
+                    let msg = format!("✓ Cordoned node '{}'", n_name);
+                    let _ = event_tx.send(crate::event::AppEvent::ActionResult {
+                        title: format!("cordon_node:{}", n_name),
+                        result: res.map(|_| msg).map_err(|e| e.to_string()),
+                    });
+                }
+            });
+            self.set_toast(format!("Cordoning node '{}'...", node_name), Theme::status_warn());
+        } else if action_name.starts_with("uncordon:") {
+            let node_name = action_name.strip_prefix("uncordon:").unwrap_or("").to_string();
+            let ctx = self.active_context.clone();
+            let cache = self.client_cache.clone();
+            let event_tx = self.event_tx.clone();
+            let n_name = node_name.clone();
+
+            tokio::spawn(async move {
+                if let Ok(client) = cache.get(&ctx).await {
+                    let api: kube::Api<k8s_openapi::api::core::v1::Node> = kube::Api::all(client);
+                    let patch = serde_json::json!({ "spec": { "unschedulable": false } });
+                    let res = api.patch(&n_name, &kube::api::PatchParams::default(), &kube::api::Patch::Merge(&patch)).await;
+                    let msg = format!("✓ Uncordoned node '{}'", n_name);
+                    let _ = event_tx.send(crate::event::AppEvent::ActionResult {
+                        title: format!("cordon_node:{}", n_name),
+                        result: res.map(|_| msg).map_err(|e| e.to_string()),
+                    });
+                }
+            });
+            self.set_toast(format!("Uncordoning node '{}'...", node_name), Theme::status_warn());
+        } else if action_name.starts_with("helm-rollback:") {
+            let parts: Vec<&str> = action_name.splitn(4, ':').collect();
+            if parts.len() == 4 {
+                let name = parts[1].to_string();
+                let ns = parts[2].to_string();
+                let rev_str = parts[3];
+                let rev: Option<i64> = rev_str.parse().ok();
+
+                let ctx = self.active_context.clone();
+                let cache = self.client_cache.clone();
+                let event_tx = self.event_tx.clone();
+                let name_c = name.clone();
+                let ns_c = ns.clone();
+                let rev_val = rev_str.to_string();
+
+                tokio::spawn(async move {
+                    let args = srelens_kube::helm_cli::rollback_args(&name_c, rev.unwrap_or(1), Some(&ns_c));
+                    let res = srelens_kube::helm_cli::run_helm(&cache, &ctx, &args).await;
+                    let title = format!("helm_rollback:{}:{}", ns_c, name_c);
+                    match res {
+                        Ok(output) => {
+                            let msg = if output.trim().is_empty() {
+                                format!("✓ Rolled back '{}' to revision {}", name_c, rev_val)
+                            } else {
+                                format!("✓ Rolled back '{}' to revision {}: {}", name_c, rev_val, output.trim())
+                            };
+                            let _ = event_tx.send(crate::event::AppEvent::ActionResult {
+                                title,
+                                result: Ok(msg),
+                            });
+                        }
+                        Err(e) => {
+                            let _ = event_tx.send(crate::event::AppEvent::ActionResult {
+                                title,
+                                result: Err(format!("Rollback failed: {}", e)),
+                            });
+                        }
+                    }
+                });
+                self.set_toast(format!("Rolling back '{}' to revision {}...", name, rev_str), Theme::status_warn());
+            }
+        } else if action_name.starts_with("helm-uninstall:") {
+            let parts: Vec<&str> = action_name.splitn(3, ':').collect();
+            if parts.len() == 3 {
+                let name = parts[1].to_string();
+                let ns = parts[2].to_string();
+
+                let ctx = self.active_context.clone();
+                let cache = self.client_cache.clone();
+                let event_tx = self.event_tx.clone();
+                let name_c = name.clone();
+                let ns_c = ns.clone();
+
+                tokio::spawn(async move {
+                    let args = srelens_kube::helm_cli::uninstall_args(&name_c, Some(&ns_c));
+                    let res = srelens_kube::helm_cli::run_helm(&cache, &ctx, &args).await;
+                    let title = format!("helm_uninstall:{}:{}", ns_c, name_c);
+                    match res {
+                        Ok(output) => {
+                            let msg = if output.trim().is_empty() {
+                                format!("✓ Uninstalled release '{}'", name_c)
+                            } else {
+                                format!("✓ Uninstalled release '{}': {}", name_c, output.trim())
+                            };
+                            let _ = event_tx.send(crate::event::AppEvent::ActionResult {
+                                title,
+                                result: Ok(msg),
+                            });
+                        }
+                        Err(e) => {
+                            let _ = event_tx.send(crate::event::AppEvent::ActionResult {
+                                title,
+                                result: Err(format!("Uninstall failed: {}", e)),
+                            });
+                        }
+                    }
+                });
+                self.set_toast(format!("Uninstalling release '{}'...", name), Theme::status_warn());
+            }
         }
     }
 
@@ -5251,11 +6946,173 @@ impl App {
         }
     }
 
-    pub async fn execute_start_port_forward(&mut self, pod: String, _ns: String, local_port: u16, target_port: u16) {
-        self.set_toast(format!("Port forward started on 127.0.0.1:{} -> {}:{}", local_port, pod, target_port), Theme::status_ok());
+    pub async fn execute_start_port_forward(
+        &mut self,
+        target_name: String,
+        target_kind: String,
+        ns: String,
+        local_port: u16,
+        target_port: u16,
+    ) {
+        let sink = TuiSink::arc(self.event_tx.clone());
+        let ctx = self.active_context.clone();
+        match self.forward_manager.start(
+            sink,
+            ctx,
+            ns.clone(),
+            target_kind.clone(),
+            target_name.clone(),
+            target_port,
+            Some(local_port),
+        ).await {
+            Ok(info) => {
+                self.set_toast(
+                    format!("Port forward active: 127.0.0.1:{} -> {} {}:{}", info.local_port, target_kind, target_name, target_port),
+                    Theme::status_ok(),
+                );
+                self.sync_port_forwards();
+            }
+            Err(err) => {
+                self.set_toast(
+                    format!("Failed to port forward: {}", err),
+                    Theme::status_error(),
+                );
+            }
+        }
+    }
+
+    pub fn active_forwards_for(&self, kind: &str, namespace: &str, name: &str) -> Vec<srelens_streams::forward::ForwardEntry> {
+        self.forward_manager
+            .list()
+            .into_iter()
+            .filter(|f| {
+                !f.ended
+                    && f.context == self.active_context
+                    && (f.namespace.is_empty() || namespace.is_empty() || f.namespace == namespace)
+                    && f.kind.eq_ignore_ascii_case(kind)
+                    && f.name == name
+            })
+            .collect()
+    }
+
+    pub async fn close_selected_port_forward(&mut self) {
+        let selected_info = match &self.active_view {
+            ActiveView::Table(table) => {
+                if let Some(item) = table.selected_item() {
+                    let name = item.get("name").or_else(|| item.pointer("/metadata/name")).and_then(|v| v.as_str()).unwrap_or("").to_string();
+                    let ns = item.get("namespace").or_else(|| item.pointer("/metadata/namespace")).and_then(|v| v.as_str()).unwrap_or("").to_string();
+                    let kind = if table.kind == ResourceKind::Services { "Service" } else { "Pod" }.to_string();
+                    Some((kind, ns, name))
+                } else {
+                    None
+                }
+            }
+            ActiveView::Top(top) => {
+                if top.active_tab == top_view::TopTab::Pods {
+                    let pods = top.filtered_pods();
+                    if let Some(pod) = pods.get(top.selected_idx) {
+                        Some(("Pod".to_string(), pod.namespace.clone(), pod.name.clone()))
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        };
+
+        if let Some((kind, ns, name)) = selected_info {
+            let forwards = self.active_forwards_for(&kind, &ns, &name);
+            if forwards.is_empty() {
+                self.set_toast(format!("No active port forward for {}/{}", kind, name), Theme::status_warn());
+                return;
+            }
+
+            let count = forwards.len();
+            let first_loc = forwards[0].local_port;
+            let first_rem = forwards[0].remote_port;
+
+            for f in forwards {
+                self.forward_manager.stop(f.id);
+            }
+            self.sync_port_forwards();
+
+            if count == 1 {
+                self.set_toast(
+                    format!("✓ Closed port forward: 127.0.0.1:{} -> {}:{}", first_loc, name, first_rem),
+                    Theme::status_ok(),
+                );
+            } else {
+                self.set_toast(
+                    format!("✓ Closed {} active port forwards for {}/{}", count, kind, name),
+                    Theme::status_ok(),
+                );
+            }
+        }
+    }
+
+    pub fn sync_port_forwards(&mut self) {
+        let entries = self.forward_manager.list();
+        let mut active_map: std::collections::HashMap<(String, String), Vec<(u16, u16, String)>> = std::collections::HashMap::new();
+        for f in &entries {
+            if !f.ended && f.context == self.active_context {
+                active_map
+                    .entry((f.namespace.clone(), f.name.clone()))
+                    .or_default()
+                    .push((f.local_port, f.remote_port, f.id.to_string()));
+            }
+        }
+
+        if let ActiveView::Table(ref mut table) = self.active_view {
+            table.active_port_forwards = active_map.clone();
+        }
+        if let ActiveView::Top(ref mut top) = self.active_view {
+            top.active_port_forwards = active_map;
+        }
+
+        let view_entries: Vec<crate::views::port_forward_view::PortForwardEntry> = entries
+            .into_iter()
+            .map(|f| {
+                let status = if let Some(err) = &f.error {
+                    format!("Error: {}", err)
+                } else if f.ended {
+                    "Stopped".to_string()
+                } else {
+                    "Active".to_string()
+                };
+                crate::views::port_forward_view::PortForwardEntry {
+                    id: f.id.to_string(),
+                    context: f.context,
+                    namespace: f.namespace,
+                    target_type: f.kind,
+                    target_name: f.name,
+                    local_port: f.local_port,
+                    container_port: f.remote_port,
+                    active_connections: 0,
+                    bytes_rx: f.bytes,
+                    bytes_tx: 0,
+                    status,
+                }
+            })
+            .collect();
+
+        if let ActiveView::PortForwards(ref mut state) = self.active_view {
+            state.set_forwards(view_entries);
+        }
     }
 
     pub fn handle_stream_event(&mut self, channel: String, payload: serde_json::Value) {
+        if channel.starts_with("forward:") {
+            self.sync_port_forwards();
+            if channel.starts_with("forward:closed:") {
+                if let Some(err_str) = payload.as_str() {
+                    self.set_toast(format!("Port forward closed: {}", err_str), Theme::status_error());
+                }
+            }
+            return;
+        }
+
         if let Some(items) = payload.as_array() {
             if !items.is_empty() {
                 self.is_connected = true;
@@ -5277,6 +7134,9 @@ impl App {
                     };
                     if is_wl_table && matches!(kind.as_str(), "deployments" | "statefulsets" | "daemonsets" | "pods" | "cronjobs") {
                         self.rebuild_workloads_table();
+                    }
+                    if matches!(self.active_view, ActiveView::Top(_)) && matches!(kind.as_str(), "nodes" | "pods") {
+                        self.refresh_top_view_data();
                     }
                 }
             }
@@ -5331,10 +7191,11 @@ impl App {
 
         if let ActiveView::Logs(logs) = &mut self.active_view {
             if logs.channel == channel {
+                let source = payload.get("source").and_then(|v| v.as_str()).map(String::from);
                 if let Some(line) = payload.get("line").and_then(|v| v.as_str()) {
-                    logs.push_line(line.to_string());
+                    logs.push_entry(source, line.to_string());
                 } else if let Some(status) = payload.get("status").and_then(|v| v.as_str()) {
-                    logs.push_line(format!("--- log status: {} ---", status));
+                    logs.push_entry(source, format!("--- log status: {} ---", status));
                 }
             }
         }
@@ -5360,12 +7221,25 @@ impl App {
             ActiveView::Logs(_) => "Logs",
             ActiveView::PortForwards(_) => "Port Forwards",
             ActiveView::Helm(_) => "Helm Releases",
+            ActiveView::HelmDetail(detail) => match detail.active_tab {
+                HelmDetailTab::Overview => "Helm: Overview",
+                HelmDetailTab::ValuesDiff => "Helm: Values Diff",
+                HelmDetailTab::Revisions => "Helm: Revisions History",
+                HelmDetailTab::Manifest => "Helm: Rendered Manifest",
+                HelmDetailTab::Notes => "Helm: Release Notes",
+            },
             ActiveView::Overview(_) => "Overview",
             ActiveView::Toolbox(_) => "Toolbox",
             ActiveView::Assistant => "AI Assistant",
             ActiveView::Settings(_) => "AI Settings",
             ActiveView::Tree(_) => "Resource Relationship Tree",
             ActiveView::NodeInspector(_) => "Node & GPU Hardware Inspector",
+            ActiveView::Topology(_) => "Workload & Traffic Topology Flow",
+            ActiveView::GpuInfo(_) => "GPU Info & VRAM Allocation",
+            ActiveView::Top(top) => match top.active_tab {
+                top_view::TopTab::Pods => "Top Pods Hotspots",
+                top_view::TopTab::Nodes => "Top Nodes Hotspots",
+            },
         };
 
         let active_pods_count = if let ActiveView::Table(t) = &self.active_view {
@@ -5433,12 +7307,16 @@ impl App {
             ActiveView::Logs(logs) => render_logs_view(f, chunks[1], logs),
             ActiveView::PortForwards(pf) => render_port_forward_view(f, chunks[1], pf),
             ActiveView::Helm(helm) => render_helm_view(f, chunks[1], helm),
+            ActiveView::HelmDetail(detail) => render_helm_detail_view(f, chunks[1], detail),
             ActiveView::Overview(ov) => render_overview_view(f, chunks[1], ov),
             ActiveView::Toolbox(tb) => render_toolbox_view(f, chunks[1], tb),
             ActiveView::Assistant => render_assistant_view(f, chunks[1], &self.assistant_state, &self.ai_settings),
             ActiveView::Settings(s) => render_settings_view(f, chunks[1], s),
             ActiveView::Tree(tree) => render_tree_view(f, chunks[1], tree),
             ActiveView::NodeInspector(ni) => render_node_inspector_view(f, chunks[1], ni),
+            ActiveView::Topology(topo) => topology_view::render_topology_view(f, chunks[1], topo),
+            ActiveView::GpuInfo(gpu) => gpu_view::render(f, chunks[1], gpu),
+            ActiveView::Top(top) => top_view::render_top_view(f, chunks[1], top),
         }
 
         // 3. Render Status Bar
@@ -5447,6 +7325,8 @@ impl App {
             ActiveView::Describe(desc) => (desc.search_matches.len(), desc.lines.len(), true),
             ActiveView::Yaml(yaml) => (yaml.search_matches.len(), yaml.lines.len(), true),
             ActiveView::Logs(logs) => (logs.search_matches.len(), logs.lines.len(), true),
+            ActiveView::Helm(helm) => (helm.filtered_indices().len(), helm.releases.len(), false),
+            ActiveView::Top(top) => (top.visible_count(), if top.active_tab == top_view::TopTab::Pods { top.pods.len() } else { top.nodes.len() }, false),
             _ => (0, 0, false),
         };
 
@@ -5459,7 +7339,107 @@ impl App {
         };
         let suggestions_prop = suggestions.as_ref().map(|s| (s.as_slice(), self.command_suggestion_idx));
 
+        let selected_active_forwards: Vec<srelens_streams::forward::ForwardEntry> = match &self.active_view {
+            ActiveView::Table(table) => {
+                if let Some(item) = table.selected_item() {
+                    let name = item.get("name").or_else(|| item.pointer("/metadata/name")).and_then(|v| v.as_str()).unwrap_or("");
+                    let ns = item.get("namespace").or_else(|| item.pointer("/metadata/namespace")).and_then(|v| v.as_str()).unwrap_or("");
+                    let kind = if table.kind == ResourceKind::Services { "Service" } else { "Pod" };
+                    if !name.is_empty() {
+                        self.active_forwards_for(kind, ns, name)
+                    } else {
+                        Vec::new()
+                    }
+                } else {
+                    Vec::new()
+                }
+            }
+            ActiveView::Top(top) => {
+                if top.active_tab == top_view::TopTab::Pods {
+                    let pods = top.filtered_pods();
+                    if let Some(pod) = pods.get(top.selected_idx) {
+                        self.active_forwards_for("Pod", &pod.namespace, &pod.name)
+                    } else {
+                        Vec::new()
+                    }
+                } else {
+                    Vec::new()
+                }
+            }
+            _ => Vec::new(),
+        };
+
+        let has_selected_pf = !selected_active_forwards.is_empty();
+        let close_pf_button_data = if has_selected_pf {
+            let label = if selected_active_forwards.len() == 1 {
+                format!("✕ Close PF: {}", selected_active_forwards[0].local_port)
+            } else {
+                format!("✕ Close All PF ({})", selected_active_forwards.len())
+            };
+            let style = Style::default()
+                .bg(Theme::red())
+                .fg(ratatui::style::Color::White)
+                .add_modifier(Modifier::BOLD);
+            Some((label, style))
+        } else {
+            None
+        };
+
         let custom_hints: Option<&[(&str, &str)]> = match &self.active_view {
+            ActiveView::Top(_) => if has_selected_pf {
+                Some(&[
+                    ("<:>", "Cmd"),
+                    ("<Tab>", "Pods/Nodes"),
+                    ("<c>", "Sort CPU"),
+                    ("<m>", "Sort MEM"),
+                    ("<f>", "New PF"),
+                    ("<F>", "Close PF"),
+                    ("<l>", "Logs"),
+                    ("<d>", "Describe"),
+                    ("<y>", "YAML"),
+                    ("<r>", "Refresh"),
+                    ("<Esc>", "Back"),
+                    ("<?>", "Help"),
+                ][..])
+            } else {
+                Some(&[
+                    ("<:>", "Cmd"),
+                    ("<Tab>", "Pods/Nodes"),
+                    ("<c>", "Sort CPU"),
+                    ("<m>", "Sort MEM"),
+                    ("<S>", "Rev"),
+                    ("<l>", "Logs"),
+                    ("<d>", "Describe"),
+                    ("<y>", "YAML"),
+                    ("<r>", "Refresh"),
+                    ("<Esc>", "Back"),
+                    ("<?>", "Help"),
+                ][..])
+            },
+            ActiveView::GpuInfo(_) => Some(&[
+                ("<:>", "Cmd"),
+                ("<↑/↓>", "Select"),
+                ("<Tab>", "Pane"),
+                ("<Enter>", "Inspect"),
+                ("<l>", "Logs"),
+                ("<d>", "Describe"),
+                ("<y>", "YAML"),
+                ("<r>", "Refresh"),
+                ("<Esc>", "Back"),
+                ("<?>", "Help"),
+            ][..]),
+            ActiveView::Topology(_) => Some(&[
+                ("<:>", "Cmd"),
+                ("<←/→>", "Lane"),
+                ("<↑/↓>", "Node"),
+                ("<Enter>", "Inspect"),
+                ("<d>", "Describe"),
+                ("<y>", "YAML"),
+                ("<l>", "Logs"),
+                ("<r>", "Refresh"),
+                ("<Esc>", "Back"),
+                ("<?>", "Help"),
+            ][..]),
             ActiveView::NodeInspector(ni) => {
                 let cordon_act = if ni.details.as_ref().map(|d| d.unschedulable).unwrap_or(false) {
                     "Uncordon"
@@ -5538,19 +7518,36 @@ impl App {
                             ("<^d>", "Delete"),
                             ("<?>", "Help"),
                         ][..]),
-                        ResourceKind::Pods => Some(&[
-                            ("<:>", "Cmd"),
-                            ("</>", "Filter"),
-                            ("<l>", "Logs"),
-                            ("<s>", "Shell"),
-                            ("<m>", "Metrics"),
-                            ("<f>/<F>", "PortForward"),
-                            ("<d>", "Describe"),
-                            ("<y>", "YAML"),
-                            ("<e>", "Edit"),
-                            ("<^d>", "Delete"),
-                            ("<?>", "Help"),
-                        ][..]),
+                        ResourceKind::Pods => if has_selected_pf {
+                            Some(&[
+                                ("<:>", "Cmd"),
+                                ("</>", "Filter"),
+                                ("<l>", "Logs"),
+                                ("<s>", "Shell"),
+                                ("<m>", "Metrics"),
+                                ("<f>", "New PF"),
+                                ("<F>", "Close PF"),
+                                ("<d>", "Describe"),
+                                ("<y>", "YAML"),
+                                ("<e>", "Edit"),
+                                ("<^d>", "Delete"),
+                                ("<?>", "Help"),
+                            ][..])
+                        } else {
+                            Some(&[
+                                ("<:>", "Cmd"),
+                                ("</>", "Filter"),
+                                ("<l>", "Logs"),
+                                ("<s>", "Shell"),
+                                ("<m>", "Metrics"),
+                                ("<f>/<F>", "PortForward"),
+                                ("<d>", "Describe"),
+                                ("<y>", "YAML"),
+                                ("<e>", "Edit"),
+                                ("<^d>", "Delete"),
+                                ("<?>", "Help"),
+                            ][..])
+                        },
                 ResourceKind::Deployments | ResourceKind::DaemonSets | ResourceKind::StatefulSets => Some(&[
                     ("<:>", "Cmd"),
                     ("</>", "Filter"),
@@ -5563,17 +7560,32 @@ impl App {
                     ("<^d>", "Delete"),
                     ("<?>", "Help"),
                 ][..]),
-                ResourceKind::Services => Some(&[
-                    ("<:>", "Cmd"),
-                    ("</>", "Filter"),
-                    ("<Enter>", "Endpoints"),
-                    ("<f>/<F>", "PortForward"),
-                    ("<d>", "Describe"),
-                    ("<y>", "YAML"),
-                    ("<e>", "Edit"),
-                    ("<^d>", "Delete"),
-                    ("<?>", "Help"),
-                ][..]),
+                ResourceKind::Services => if has_selected_pf {
+                    Some(&[
+                        ("<:>", "Cmd"),
+                        ("</>", "Filter"),
+                        ("<Enter>", "Endpoints"),
+                        ("<f>", "New PF"),
+                        ("<F>", "Close PF"),
+                        ("<d>", "Describe"),
+                        ("<y>", "YAML"),
+                        ("<e>", "Edit"),
+                        ("<^d>", "Delete"),
+                        ("<?>", "Help"),
+                    ][..])
+                } else {
+                    Some(&[
+                        ("<:>", "Cmd"),
+                        ("</>", "Filter"),
+                        ("<Enter>", "Endpoints"),
+                        ("<f>/<F>", "PortForward"),
+                        ("<d>", "Describe"),
+                        ("<y>", "YAML"),
+                        ("<e>", "Edit"),
+                        ("<^d>", "Delete"),
+                        ("<?>", "Help"),
+                    ][..])
+                },
                 ResourceKind::Ingresses => Some(&[
                     ("<:>", "Cmd"),
                     ("</>", "Filter"),
@@ -5647,12 +7659,66 @@ impl App {
             ][..]),
             ActiveView::Helm(_) => Some(&[
                 ("<:>", "Cmd"),
-                ("<c>", "CopyURL"),
+                ("</>", "Filter"),
+                ("<Enter>", "Inspect"),
                 ("<v>", "Values"),
                 ("<y>", "Manifest"),
+                ("<d>", "History"),
+                ("<r>", "Rollback"),
+                ("<^d>", "Uninstall"),
+                ("<c>", "CopyURL"),
                 ("<Esc>", "Back"),
                 ("<?>", "Help"),
             ][..]),
+            ActiveView::HelmDetail(detail) => match detail.active_tab {
+                HelmDetailTab::Overview => Some(&[
+                    ("<:>", "Cmd"),
+                    ("<Tab>", "NextTab"),
+                    ("<1..5>", "Tab"),
+                    ("<j/k>", "Scroll"),
+                    ("<c>", "CopyURL"),
+                    ("<r>", "Rollback"),
+                    ("<Esc>", "Back"),
+                    ("<?>", "Help"),
+                ][..]),
+                HelmDetailTab::ValuesDiff => Some(&[
+                    ("<:>", "Cmd"),
+                    ("<Tab>", "NextTab"),
+                    ("<1..5>", "Tab"),
+                    ("<m>", "ToggleDiffMode"),
+                    ("<j/k>", "Scroll"),
+                    ("<y>", "Copy"),
+                    ("<Esc>", "Back"),
+                    ("<?>", "Help"),
+                ][..]),
+                HelmDetailTab::Revisions => Some(&[
+                    ("<:>", "Cmd"),
+                    ("<Tab>", "NextTab"),
+                    ("<1..5>", "Tab"),
+                    ("<j/k>", "SelectRev"),
+                    ("<r>", "Rollback"),
+                    ("<Esc>", "Back"),
+                    ("<?>", "Help"),
+                ][..]),
+                HelmDetailTab::Manifest => Some(&[
+                    ("<:>", "Cmd"),
+                    ("<Tab>", "NextTab"),
+                    ("<1..5>", "Tab"),
+                    ("<j/k>", "Scroll"),
+                    ("<y>", "Copy"),
+                    ("<Esc>", "Back"),
+                    ("<?>", "Help"),
+                ][..]),
+                HelmDetailTab::Notes => Some(&[
+                    ("<:>", "Cmd"),
+                    ("<Tab>", "NextTab"),
+                    ("<1..5>", "Tab"),
+                    ("<j/k>", "Scroll"),
+                    ("<y>", "Copy"),
+                    ("<Esc>", "Back"),
+                    ("<?>", "Help"),
+                ][..]),
+            },
             ActiveView::Toolbox(_) => Some(&[
                 ("<:>", "Cmd"),
                 ("<c>", "CopyPath"),
@@ -5675,6 +7741,8 @@ impl App {
                 toast: toast_prop,
                 custom_hints,
                 suggestions: suggestions_prop,
+                close_pf_button: close_pf_button_data.as_ref().map(|(l, s)| (l.as_str(), *s)),
+                close_pf_rect: Some(&self.close_pf_button_rect),
             },
         );
 

--- a/apps/tui/src/commands.rs
+++ b/apps/tui/src/commands.rs
@@ -40,6 +40,10 @@ pub enum ResourceKind {
     Assistant,
     Settings,
     Workloads,
+    Topology,
+    GpuInfo,
+    TopPods,
+    TopNodes,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
@@ -103,6 +107,10 @@ impl ResourceKind {
             Self::Assistant => "SRElens Assistant",
             Self::Settings => "AI & Assistant Settings",
             Self::Workloads => "Workloads",
+            Self::Topology => "Workload & Traffic Topology",
+            Self::GpuInfo => "GPU Info & VRAM Allocation",
+            Self::TopPods => "Top Pods",
+            Self::TopNodes => "Top Nodes",
         }
     }
 
@@ -210,14 +218,52 @@ pub enum CommandTarget {
     Help,
     Quit,
     OpenUrl(String),
+    ThemePicker,
+    SetTheme(String),
 }
 
 pub const COMMAND_REGISTRY: &[CommandDef] = &[
+    CommandDef {
+        name: "themes",
+        aliases: &["theme", "colors"],
+        description: "Interactive theme selector (Catppuccin, Tokyo Night, Dracula, Nord, Gruvbox, etc.)",
+        target: CommandTarget::ThemePicker,
+    },
     CommandDef {
         name: "workloads",
         aliases: &["wl", "workload"],
         description: "Unified Workloads view (Deployments, StatefulSets, DaemonSets, Pods, CronJobs)",
         target: CommandTarget::Resource(ResourceKind::Workloads),
+    },
+    CommandDef {
+        name: "topology",
+        aliases: &["topo", "flow"],
+        description: "Workload and traffic topology flow map (:topology, :topo, :flow)",
+        target: CommandTarget::Resource(ResourceKind::Topology),
+    },
+    CommandDef {
+        name: "gpuinfo",
+        aliases: &["gpu", "gpus"],
+        description: "GPU nodes, VRAM allocation & GPU workloads (:gpuinfo, :gpu, :gpus)",
+        target: CommandTarget::Resource(ResourceKind::GpuInfo),
+    },
+    CommandDef {
+        name: "top",
+        aliases: &["hotspots", "ranking"],
+        description: "Top Hotspots ranking (Pods & Nodes) (:top, :toppods, :topnodes)",
+        target: CommandTarget::Resource(ResourceKind::TopPods),
+    },
+    CommandDef {
+        name: "toppods",
+        aliases: &["top pods", "top-pods", "tp"],
+        description: "Top Pods ranking by CPU & Memory (:toppods, :top pods)",
+        target: CommandTarget::Resource(ResourceKind::TopPods),
+    },
+    CommandDef {
+        name: "topnodes",
+        aliases: &["top nodes", "top-nodes", "tn"],
+        description: "Top Nodes ranking by CPU & Memory (:topnodes, :top nodes)",
+        target: CommandTarget::Resource(ResourceKind::TopNodes),
     },
     CommandDef {
         name: "pods",
@@ -400,8 +446,8 @@ pub const COMMAND_REGISTRY: &[CommandDef] = &[
         target: CommandTarget::Resource(ResourceKind::Assistant),
     },
     CommandDef {
-        name: "settings",
-        aliases: &["config", "ai-config", "ai-settings"],
+        name: "ai-settings",
+        aliases: &["settings", "config", "ai-config"],
         description: "AI & Assistant Settings",
         target: CommandTarget::Resource(ResourceKind::Settings),
     },
@@ -495,19 +541,24 @@ pub fn resolve_command_with_crds(input: &str, crds: &[CrdMeta]) -> Option<Comman
         }
     }
 
-    // 1. Exact match on static commands & aliases
-    for cmd in COMMAND_REGISTRY {
-        if cmd.name.eq_ignore_ascii_case(trimmed) {
-            return Some(cmd.target.clone());
-        }
-        for alias in cmd.aliases {
-            if alias.eq_ignore_ascii_case(trimmed) {
-                return Some(cmd.target.clone());
+    // Direct theme setter command (e.g. ":theme tokyo-night" or ":colors nord")
+    for prefix in &["theme ", "theme:", "colors ", "colors:"] {
+        if let Some(rest) = trimmed.strip_prefix(prefix) {
+            let name = rest.trim();
+            if !name.is_empty() {
+                return Some(CommandTarget::SetTheme(name.to_string()));
             }
         }
     }
 
-    // 2. Exact match on CRDs & aliases
+    // 1. Exact match on static command primary name
+    for cmd in COMMAND_REGISTRY {
+        if cmd.name.eq_ignore_ascii_case(trimmed) {
+            return Some(cmd.target.clone());
+        }
+    }
+
+    // 2. Exact match on CRDs & aliases (cluster CRDs take precedence over static command aliases)
     let q = trimmed.to_lowercase();
     for crd in crds {
         if crd.plural.eq_ignore_ascii_case(&q)
@@ -529,7 +580,16 @@ pub fn resolve_command_with_crds(input: &str, crds: &[CrdMeta]) -> Option<Comman
         }
     }
 
-    // 3. Prefix match on CRDs (e.g. if q is at least 3 chars)
+    // 3. Exact match on static command aliases (e.g. ":po" -> pods, ":settings" -> ai-settings if no CRD exists)
+    for cmd in COMMAND_REGISTRY {
+        for alias in cmd.aliases {
+            if alias.eq_ignore_ascii_case(trimmed) {
+                return Some(cmd.target.clone());
+            }
+        }
+    }
+
+    // 4. Prefix match on CRDs (e.g. if q is at least 3 chars)
     if q.len() >= 3 {
         for crd in crds {
             let norm_plural = crd.plural.to_lowercase().replace("loadbalancer", "lb");
@@ -544,7 +604,7 @@ pub fn resolve_command_with_crds(input: &str, crds: &[CrdMeta]) -> Option<Comman
         }
     }
 
-    // 4. Prefix match on static commands (e.g. ":deplo" -> deployments)
+    // 5. Prefix match on static commands & aliases (e.g. ":deplo" -> deployments)
     for cmd in COMMAND_REGISTRY {
         if cmd.name.starts_with(&q) {
             return Some(cmd.target.clone());
@@ -591,6 +651,29 @@ pub fn command_suggestions_with_crds(query: &str, crds: &[CrdMeta]) -> Vec<(Dyna
         return matches;
     }
 
+    // Direct theme name suggestions when typing ":theme <subquery>" or ":colors <subquery>"
+    if q.starts_with("theme ") || q.starts_with("colors ") {
+        let prefix = if q.starts_with("theme ") { "theme " } else { "colors " };
+        let sub = q.strip_prefix(prefix).unwrap().trim();
+        for p in crate::theme::ALL_THEMES {
+            if sub.is_empty() || p.name.starts_with(sub) || p.display_name.to_lowercase().starts_with(sub) {
+                matches.push((
+                    DynamicCommandDef {
+                        name: format!("theme {}", p.name),
+                        aliases: vec![],
+                        description: format!("Theme: {} ({})", p.display_name, p.description),
+                        target: CommandTarget::SetTheme(p.name.to_string()),
+                    },
+                    150,
+                ));
+            }
+        }
+        if !matches.is_empty() {
+            matches.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.name.cmp(&b.0.name)));
+            return matches;
+        }
+    }
+
     // Match static registry
     for cmd in COMMAND_REGISTRY {
         if cmd.name == q || cmd.aliases.iter().any(|a| *a == q) {
@@ -620,6 +703,7 @@ pub fn command_suggestions_with_crds(query: &str, crds: &[CrdMeta]) -> Vec<(Dyna
             matches.push((crd_def, 120));
         } else if crd.plural.to_lowercase().starts_with(&q)
             || crd.singular.to_lowercase().starts_with(&q)
+            || crd.kind.to_lowercase().starts_with(&q)
             || norm_plural.starts_with(&q)
             || norm_singular.starts_with(&q)
         {
@@ -629,6 +713,7 @@ pub fn command_suggestions_with_crds(query: &str, crds: &[CrdMeta]) -> Vec<(Dyna
         } else if crd.plural.to_lowercase().contains(&q)
             || crd.kind.to_lowercase().contains(&q)
             || crd.group.to_lowercase().contains(&q)
+            || crd.crd_name.to_lowercase().contains(&q)
         {
             matches.push((crd_def, 55));
         }

--- a/apps/tui/src/deep_link.rs
+++ b/apps/tui/src/deep_link.rs
@@ -55,6 +55,8 @@ impl DeepLink {
                     CommandTarget::Contexts => "contexts".to_string(),
                     CommandTarget::Namespaces => "namespaces".to_string(),
                     CommandTarget::Quit => "quit".to_string(),
+                    CommandTarget::ThemePicker => "themes".to_string(),
+                    CommandTarget::SetTheme(t) => format!("theme/{}", t),
                     CommandTarget::OpenUrl(u) => format!("open/{}", u),
                 };
                 format!("srelens://view/{}/{}/{}", ctx, ns, target_name)

--- a/apps/tui/src/event.rs
+++ b/apps/tui/src/event.rs
@@ -29,6 +29,27 @@ pub enum AppEvent {
         node_name: String,
         result: Result<srelens_kube::node_inspector::NodeInspectorDetails, String>,
     },
+    TopologyResult {
+        context: String,
+        namespaces: Vec<String>,
+        result: Result<srelens_kube::topology::TopologyGraphOut, String>,
+    },
+    GpuInfoResult {
+        context: String,
+        result: Result<srelens_kube::gpu_info::GpuClusterInfo, String>,
+    },
+    HelmReleasesResult {
+        context: String,
+        namespace: String,
+        result: Result<Vec<srelens_kube::helm::HelmReleaseSummary>, String>,
+    },
+    HelmDetailResult {
+        context: String,
+        namespace: String,
+        name: String,
+        revision: Option<i64>,
+        result: Result<srelens_kube::helm::HelmReleaseDetail, String>,
+    },
 }
 
 pub struct EventHandler {

--- a/apps/tui/src/main.rs
+++ b/apps/tui/src/main.rs
@@ -214,6 +214,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 app::ActiveView::Describe(desc) => desc.scroll_up(3),
                                 app::ActiveView::Yaml(yaml) => yaml.scroll_up(3),
                                 app::ActiveView::Table(table) => table.select_prev(),
+                                app::ActiveView::Helm(helm) => helm.select_prev(),
+                                app::ActiveView::HelmDetail(detail) => {
+                                    if detail.active_tab == views::HelmDetailTab::Revisions {
+                                        detail.select_prev_revision();
+                                    } else {
+                                        detail.scroll_up(3);
+                                    }
+                                }
                                 _ => {}
                             }
                         }
@@ -225,6 +233,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 app::ActiveView::Describe(desc) => desc.scroll_down(3),
                                 app::ActiveView::Yaml(yaml) => yaml.scroll_down(3),
                                 app::ActiveView::Table(table) => table.select_next(),
+                                app::ActiveView::Helm(helm) => helm.select_next(),
+                                app::ActiveView::HelmDetail(detail) => {
+                                    if detail.active_tab == views::HelmDetailTab::Revisions {
+                                        detail.select_next_revision();
+                                    } else {
+                                        detail.scroll_down(3);
+                                    }
+                                }
                                 _ => {}
                             }
                         }
@@ -317,6 +333,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             } else if title == "node_metrics_updated" {
                                 app.handle_node_metrics_update(&msg);
                             } else {
+                                if title.starts_with("helm_rollback:") || title.starts_with("helm_uninstall:") {
+                                    app.refresh_helm_releases();
+                                    if let app::ActiveView::HelmDetail(detail) = &app.active_view {
+                                        let name = detail.release_name.clone();
+                                        let ns = detail.namespace.clone();
+                                        app.reload_helm_detail(&name, &ns);
+                                    }
+                                }
                                 app.set_toast(msg, theme::Theme::status_ok());
                             }
                         }
@@ -347,6 +371,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
                 AppEvent::NodeInspectorResult { node_name, result } => {
                     app.handle_node_inspector_result(&node_name, result);
+                }
+                AppEvent::TopologyResult { context, namespaces, result } => {
+                    app.handle_topology_result(&context, namespaces, result);
+                }
+                AppEvent::GpuInfoResult { context, result } => {
+                    app.handle_gpu_info_result(&context, result);
+                }
+                AppEvent::HelmReleasesResult { context, namespace, result } => {
+                    app.handle_helm_releases_result(&context, &namespace, result);
+                }
+                AppEvent::HelmDetailResult { context, namespace, name, revision, result } => {
+                    app.handle_helm_detail_result(&context, &namespace, &name, revision, result);
                 }
             }
         }

--- a/apps/tui/src/theme.rs
+++ b/apps/tui/src/theme.rs
@@ -1,9 +1,407 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
 use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::BorderType;
+use serde::{Deserialize, Serialize};
 
-/// SRElens TUI Theme palette
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum HeaderStyle {
+    Standard,
+    FinoTime,
+    Minimal,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ThemeId {
+    CatppuccinMocha,
+    TokyoNight,
+    Dracula,
+    Nord,
+    GruvboxDark,
+    SolarizedDark,
+    MonokaiPro,
+    CatppuccinLatte,
+    FinoTime,
+    RosePine,
+    Cyberpunk,
+    OneDark,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ThemePalette {
+    pub id: ThemeId,
+    pub name: &'static str,
+    pub display_name: &'static str,
+    pub description: &'static str,
+    pub is_light: bool,
+    pub bg: Color,
+    pub fg: Color,
+    pub dim: Color,
+    pub accent: Color,
+    pub cyan: Color,
+    pub green: Color,
+    pub yellow: Color,
+    pub red: Color,
+    pub orange: Color,
+    pub border: Color,
+    pub border_focus: Color,
+    pub sel_bg: Color,
+    pub sel_fg: Color,
+    pub marked_bg: Color,
+    pub marked_fg: Color,
+    pub header_style: HeaderStyle,
+    pub border_type: BorderType,
+    pub prompt_glyph: &'static str,
+    pub bullet_glyph: &'static str,
+    pub brand_icon: &'static str,
+    pub show_live_clock: bool,
+}
+
+pub static ALL_THEMES: &[ThemePalette] = &[
+    ThemePalette {
+        id: ThemeId::CatppuccinMocha,
+        name: "catppuccin-mocha",
+        display_name: "Catppuccin Mocha",
+        description: "Brand lavender & violet on deep charcoal — SRElens original",
+        is_light: false,
+        bg: Color::Reset,
+        fg: Color::Rgb(220, 224, 232),
+        dim: Color::Rgb(110, 115, 135),
+        accent: Color::Rgb(139, 92, 246),
+        cyan: Color::Rgb(56, 189, 248),
+        green: Color::Rgb(34, 197, 94),
+        yellow: Color::Rgb(234, 179, 8),
+        red: Color::Rgb(239, 68, 68),
+        orange: Color::Rgb(249, 115, 22),
+        border: Color::Rgb(75, 85, 99),
+        border_focus: Color::Rgb(139, 92, 246),
+        sel_bg: Color::Rgb(45, 55, 72),
+        sel_fg: Color::Rgb(255, 255, 255),
+        marked_bg: Color::Rgb(60, 40, 90),
+        marked_fg: Color::Yellow,
+        header_style: HeaderStyle::Standard,
+        border_type: BorderType::Rounded,
+        prompt_glyph: ":",
+        bullet_glyph: "●",
+        brand_icon: "⚡ ",
+        show_live_clock: false,
+    },
+    ThemePalette {
+        id: ThemeId::TokyoNight,
+        name: "tokyo-night",
+        display_name: "Tokyo Night",
+        description: "Neon cyan and soft blue on dark midnight indigo",
+        is_light: false,
+        bg: Color::Reset,
+        fg: Color::Rgb(192, 202, 245),
+        dim: Color::Rgb(86, 95, 137),
+        accent: Color::Rgb(122, 162, 247),
+        cyan: Color::Rgb(125, 207, 255),
+        green: Color::Rgb(158, 206, 106),
+        yellow: Color::Rgb(224, 175, 104),
+        red: Color::Rgb(247, 118, 142),
+        orange: Color::Rgb(255, 158, 100),
+        border: Color::Rgb(59, 66, 97),
+        border_focus: Color::Rgb(122, 162, 247),
+        sel_bg: Color::Rgb(40, 52, 87),
+        sel_fg: Color::Rgb(255, 255, 255),
+        marked_bg: Color::Rgb(65, 45, 80),
+        marked_fg: Color::Rgb(224, 175, 104),
+        header_style: HeaderStyle::Standard,
+        border_type: BorderType::Rounded,
+        prompt_glyph: ":",
+        bullet_glyph: "●",
+        brand_icon: "⚡ ",
+        show_live_clock: false,
+    },
+    ThemePalette {
+        id: ThemeId::Dracula,
+        name: "dracula",
+        display_name: "Dracula",
+        description: "High contrast purple, pink, and luminous neon",
+        is_light: false,
+        bg: Color::Reset,
+        fg: Color::Rgb(248, 248, 242),
+        dim: Color::Rgb(98, 114, 164),
+        accent: Color::Rgb(189, 147, 249),
+        cyan: Color::Rgb(139, 233, 253),
+        green: Color::Rgb(80, 250, 123),
+        yellow: Color::Rgb(241, 250, 140),
+        red: Color::Rgb(255, 85, 85),
+        orange: Color::Rgb(255, 184, 108),
+        border: Color::Rgb(68, 71, 90),
+        border_focus: Color::Rgb(189, 147, 249),
+        sel_bg: Color::Rgb(68, 71, 90),
+        sel_fg: Color::Rgb(255, 255, 255),
+        marked_bg: Color::Rgb(70, 45, 85),
+        marked_fg: Color::Rgb(241, 250, 140),
+        header_style: HeaderStyle::Standard,
+        border_type: BorderType::Rounded,
+        prompt_glyph: ":",
+        bullet_glyph: "●",
+        brand_icon: "⚡ ",
+        show_live_clock: false,
+    },
+    ThemePalette {
+        id: ThemeId::Nord,
+        name: "nord",
+        display_name: "Nord",
+        description: "Arctic frost cyan, snow white, and aurora colors",
+        is_light: false,
+        bg: Color::Reset,
+        fg: Color::Rgb(236, 239, 244),
+        dim: Color::Rgb(76, 86, 106),
+        accent: Color::Rgb(136, 192, 208),
+        cyan: Color::Rgb(129, 161, 193),
+        green: Color::Rgb(163, 190, 140),
+        yellow: Color::Rgb(235, 203, 139),
+        red: Color::Rgb(191, 97, 106),
+        orange: Color::Rgb(208, 135, 112),
+        border: Color::Rgb(59, 66, 82),
+        border_focus: Color::Rgb(136, 192, 208),
+        sel_bg: Color::Rgb(67, 76, 94),
+        sel_fg: Color::Rgb(236, 239, 244),
+        marked_bg: Color::Rgb(60, 50, 75),
+        marked_fg: Color::Rgb(235, 203, 139),
+        header_style: HeaderStyle::Minimal,
+        border_type: BorderType::Plain,
+        prompt_glyph: "❯ ",
+        bullet_glyph: "◆",
+        brand_icon: "❄ ",
+        show_live_clock: false,
+    },
+    ThemePalette {
+        id: ThemeId::GruvboxDark,
+        name: "gruvbox-dark",
+        display_name: "Gruvbox Dark",
+        description: "Warm retro amber, olive green, and earthy tones",
+        is_light: false,
+        bg: Color::Reset,
+        fg: Color::Rgb(235, 219, 178),
+        dim: Color::Rgb(146, 131, 116),
+        accent: Color::Rgb(254, 128, 25),
+        cyan: Color::Rgb(131, 165, 152),
+        green: Color::Rgb(184, 187, 38),
+        yellow: Color::Rgb(250, 189, 47),
+        red: Color::Rgb(251, 73, 52),
+        orange: Color::Rgb(254, 128, 25),
+        border: Color::Rgb(80, 73, 69),
+        border_focus: Color::Rgb(254, 128, 25),
+        sel_bg: Color::Rgb(60, 56, 54),
+        sel_fg: Color::Rgb(251, 241, 199),
+        marked_bg: Color::Rgb(80, 50, 40),
+        marked_fg: Color::Rgb(250, 189, 47),
+        header_style: HeaderStyle::Standard,
+        border_type: BorderType::Plain,
+        prompt_glyph: ":",
+        bullet_glyph: "●",
+        brand_icon: "⚡ ",
+        show_live_clock: false,
+    },
+    ThemePalette {
+        id: ThemeId::SolarizedDark,
+        name: "solarized-dark",
+        display_name: "Solarized Dark",
+        description: "Engineered low-contrast teal, cyan, and blue",
+        is_light: false,
+        bg: Color::Reset,
+        fg: Color::Rgb(131, 148, 150),
+        dim: Color::Rgb(88, 110, 117),
+        accent: Color::Rgb(38, 139, 210),
+        cyan: Color::Rgb(42, 161, 152),
+        green: Color::Rgb(133, 153, 0),
+        yellow: Color::Rgb(181, 137, 0),
+        red: Color::Rgb(220, 50, 47),
+        orange: Color::Rgb(203, 75, 22),
+        border: Color::Rgb(7, 54, 66),
+        border_focus: Color::Rgb(42, 161, 152),
+        sel_bg: Color::Rgb(7, 54, 66),
+        sel_fg: Color::Rgb(147, 161, 161),
+        marked_bg: Color::Rgb(20, 45, 60),
+        marked_fg: Color::Rgb(181, 137, 0),
+        header_style: HeaderStyle::Minimal,
+        border_type: BorderType::Plain,
+        prompt_glyph: ":",
+        bullet_glyph: "●",
+        brand_icon: "⚡ ",
+        show_live_clock: false,
+    },
+    ThemePalette {
+        id: ThemeId::MonokaiPro,
+        name: "monokai-pro",
+        display_name: "Monokai Pro",
+        description: "Vibrant yellow, electric cyan, and magenta",
+        is_light: false,
+        bg: Color::Reset,
+        fg: Color::Rgb(252, 252, 250),
+        dim: Color::Rgb(114, 112, 114),
+        accent: Color::Rgb(255, 216, 102),
+        cyan: Color::Rgb(120, 220, 232),
+        green: Color::Rgb(169, 220, 118),
+        yellow: Color::Rgb(255, 216, 102),
+        red: Color::Rgb(255, 97, 136),
+        orange: Color::Rgb(252, 152, 103),
+        border: Color::Rgb(64, 62, 65),
+        border_focus: Color::Rgb(255, 216, 102),
+        sel_bg: Color::Rgb(64, 62, 65),
+        sel_fg: Color::Rgb(255, 255, 255),
+        marked_bg: Color::Rgb(70, 50, 55),
+        marked_fg: Color::Rgb(255, 216, 102),
+        header_style: HeaderStyle::Standard,
+        border_type: BorderType::Rounded,
+        prompt_glyph: "▶ ",
+        bullet_glyph: "▪",
+        brand_icon: "⚡ ",
+        show_live_clock: false,
+    },
+    ThemePalette {
+        id: ThemeId::CatppuccinLatte,
+        name: "catppuccin-latte",
+        display_name: "Catppuccin Latte (Light)",
+        description: "Clean daytime light mode with dark text and crisp contrast",
+        is_light: true,
+        bg: Color::Reset,
+        fg: Color::Rgb(76, 79, 105),
+        dim: Color::Rgb(156, 160, 176),
+        accent: Color::Rgb(136, 57, 239),
+        cyan: Color::Rgb(30, 102, 245),
+        green: Color::Rgb(64, 160, 43),
+        yellow: Color::Rgb(223, 142, 29),
+        red: Color::Rgb(210, 15, 57),
+        orange: Color::Rgb(254, 100, 11),
+        border: Color::Rgb(188, 192, 204),
+        border_focus: Color::Rgb(136, 57, 239),
+        sel_bg: Color::Rgb(204, 208, 218),
+        sel_fg: Color::Rgb(76, 79, 105),
+        marked_bg: Color::Rgb(220, 210, 230),
+        marked_fg: Color::Rgb(136, 57, 239),
+        header_style: HeaderStyle::Standard,
+        border_type: BorderType::Rounded,
+        prompt_glyph: ":",
+        bullet_glyph: "●",
+        brand_icon: "⚡ ",
+        show_live_clock: false,
+    },
+    ThemePalette {
+        id: ThemeId::FinoTime,
+        name: "fino-time",
+        display_name: "Fino Time (Zsh)",
+        description: "Oh-My-Zsh fino-time tree-connected header, live clock & hollow circle prompt",
+        is_light: false,
+        bg: Color::Reset,
+        fg: Color::Rgb(225, 230, 235),
+        dim: Color::Rgb(105, 115, 125),
+        accent: Color::Rgb(250, 204, 21),
+        cyan: Color::Rgb(56, 189, 248),
+        green: Color::Rgb(52, 211, 153),
+        yellow: Color::Rgb(251, 191, 36),
+        red: Color::Rgb(248, 113, 113),
+        orange: Color::Rgb(251, 146, 60),
+        border: Color::Rgb(70, 80, 90),
+        border_focus: Color::Rgb(250, 204, 21),
+        sel_bg: Color::Rgb(40, 50, 62),
+        sel_fg: Color::Rgb(255, 255, 255),
+        marked_bg: Color::Rgb(55, 55, 75),
+        marked_fg: Color::Rgb(250, 204, 21),
+        header_style: HeaderStyle::FinoTime,
+        border_type: BorderType::Rounded,
+        prompt_glyph: "╰─○ ",
+        bullet_glyph: "○",
+        brand_icon: "╭─",
+        show_live_clock: true,
+    },
+    ThemePalette {
+        id: ThemeId::RosePine,
+        name: "rose-pine",
+        display_name: "Rosé Pine",
+        description: "All natural pine, foam, iris, and love pastels on warm dark velvet",
+        is_light: false,
+        bg: Color::Reset,
+        fg: Color::Rgb(224, 222, 244),
+        dim: Color::Rgb(110, 106, 134),
+        accent: Color::Rgb(235, 188, 186),
+        cyan: Color::Rgb(156, 207, 216),
+        green: Color::Rgb(196, 167, 231),
+        yellow: Color::Rgb(246, 193, 119),
+        red: Color::Rgb(235, 111, 146),
+        orange: Color::Rgb(235, 188, 186),
+        border: Color::Rgb(68, 65, 90),
+        border_focus: Color::Rgb(235, 188, 186),
+        sel_bg: Color::Rgb(50, 47, 70),
+        sel_fg: Color::Rgb(240, 240, 255),
+        marked_bg: Color::Rgb(65, 45, 75),
+        marked_fg: Color::Rgb(246, 193, 119),
+        header_style: HeaderStyle::Standard,
+        border_type: BorderType::Rounded,
+        prompt_glyph: "❯ ",
+        bullet_glyph: "◆",
+        brand_icon: "✦ ",
+        show_live_clock: false,
+    },
+    ThemePalette {
+        id: ThemeId::Cyberpunk,
+        name: "cyberpunk",
+        display_name: "Cyberpunk / Synth",
+        description: "High-voltage neon cyan, hot magenta, electric amber & thick cyber borders",
+        is_light: false,
+        bg: Color::Reset,
+        fg: Color::Rgb(240, 245, 255),
+        dim: Color::Rgb(100, 90, 130),
+        accent: Color::Rgb(255, 0, 127),
+        cyan: Color::Rgb(0, 240, 255),
+        green: Color::Rgb(0, 255, 159),
+        yellow: Color::Rgb(255, 222, 0),
+        red: Color::Rgb(255, 42, 109),
+        orange: Color::Rgb(255, 140, 0),
+        border: Color::Rgb(110, 40, 140),
+        border_focus: Color::Rgb(0, 240, 255),
+        sel_bg: Color::Rgb(60, 20, 75),
+        sel_fg: Color::Rgb(0, 240, 255),
+        marked_bg: Color::Rgb(70, 15, 60),
+        marked_fg: Color::Rgb(255, 222, 0),
+        header_style: HeaderStyle::Standard,
+        border_type: BorderType::Thick,
+        prompt_glyph: "▶ ",
+        bullet_glyph: "▪",
+        brand_icon: "⚡ ",
+        show_live_clock: true,
+    },
+    ThemePalette {
+        id: ThemeId::OneDark,
+        name: "one-dark",
+        display_name: "One Dark",
+        description: "Iconic Atom & Neovim syntax theme with balanced chalky pastels",
+        is_light: false,
+        bg: Color::Reset,
+        fg: Color::Rgb(171, 178, 191),
+        dim: Color::Rgb(92, 99, 112),
+        accent: Color::Rgb(97, 175, 239),
+        cyan: Color::Rgb(86, 182, 194),
+        green: Color::Rgb(152, 195, 121),
+        yellow: Color::Rgb(229, 192, 123),
+        red: Color::Rgb(224, 108, 117),
+        orange: Color::Rgb(209, 154, 102),
+        border: Color::Rgb(75, 82, 99),
+        border_focus: Color::Rgb(97, 175, 239),
+        sel_bg: Color::Rgb(44, 50, 60),
+        sel_fg: Color::Rgb(255, 255, 255),
+        marked_bg: Color::Rgb(55, 55, 75),
+        marked_fg: Color::Rgb(229, 192, 123),
+        header_style: HeaderStyle::Standard,
+        border_type: BorderType::Plain,
+        prompt_glyph: ":",
+        bullet_glyph: "●",
+        brand_icon: "⚡ ",
+        show_live_clock: false,
+    },
+];
+
+static ACTIVE_THEME_IDX: AtomicUsize = AtomicUsize::new(0);
+
+/// SRElens TUI Theme palette and dynamic styling engine
 pub struct Theme;
 
 impl Theme {
+    // Compile-time default constant fallbacks for tests and constant evaluation
     pub const BG: Color = Color::Reset;
     pub const FG: Color = Color::Rgb(220, 224, 232);
     pub const DIM: Color = Color::Rgb(110, 115, 135);
@@ -18,44 +416,127 @@ impl Theme {
     pub const SEL_BG: Color = Color::Rgb(45, 55, 72);        // Selected row background
     pub const SEL_FG: Color = Color::Rgb(255, 255, 255);     // Selected row foreground
 
+    /// Active theme palette reference
+    pub fn active_palette() -> &'static ThemePalette {
+        let idx = ACTIVE_THEME_IDX.load(Ordering::Relaxed);
+        &ALL_THEMES[idx.min(ALL_THEMES.len() - 1)]
+    }
+
+    /// Current active theme index
+    pub fn active_index() -> usize {
+        ACTIVE_THEME_IDX.load(Ordering::Relaxed).min(ALL_THEMES.len() - 1)
+    }
+
+    /// Set theme by index (0-based)
+    pub fn set_theme_by_index(idx: usize) -> bool {
+        if idx < ALL_THEMES.len() {
+            ACTIVE_THEME_IDX.store(idx, Ordering::Relaxed);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Set theme by case-insensitive name or alias
+    pub fn set_theme_by_name(name: &str) -> Option<&'static ThemePalette> {
+        let lower = name.trim().to_lowercase();
+        for (i, p) in ALL_THEMES.iter().enumerate() {
+            if p.name == lower
+                || p.name.replace('-', "") == lower.replace(['-', '_', ' '], "")
+                || (lower == "default" && p.id == ThemeId::CatppuccinMocha)
+                || (lower == "light" && p.id == ThemeId::CatppuccinLatte)
+                || (lower == "latte" && p.id == ThemeId::CatppuccinLatte)
+                || (lower == "mocha" && p.id == ThemeId::CatppuccinMocha)
+                || (lower == "gruvbox" && p.id == ThemeId::GruvboxDark)
+                || (lower == "solarized" && p.id == ThemeId::SolarizedDark)
+                || (lower == "monokai" && p.id == ThemeId::MonokaiPro)
+                || (lower == "tokyo" && p.id == ThemeId::TokyoNight)
+                || (lower == "fino" && p.id == ThemeId::FinoTime)
+                || (lower == "finotime" && p.id == ThemeId::FinoTime)
+                || (lower == "fino-time" && p.id == ThemeId::FinoTime)
+                || (lower == "rosepine" && p.id == ThemeId::RosePine)
+                || (lower == "rose-pine" && p.id == ThemeId::RosePine)
+                || (lower == "cyberpunk" && p.id == ThemeId::Cyberpunk)
+                || (lower == "synth" && p.id == ThemeId::Cyberpunk)
+                || (lower == "synthwave" && p.id == ThemeId::Cyberpunk)
+                || (lower == "onedark" && p.id == ThemeId::OneDark)
+                || (lower == "one-dark" && p.id == ThemeId::OneDark)
+                || (lower == "atom" && p.id == ThemeId::OneDark)
+            {
+                ACTIVE_THEME_IDX.store(i, Ordering::Relaxed);
+                return Some(p);
+            }
+        }
+        None
+    }
+
+    pub fn all_themes() -> &'static [ThemePalette] {
+        ALL_THEMES
+    }
+
+    // Visual chrome and layout accessors
+    pub fn header_style() -> HeaderStyle { Self::active_palette().header_style }
+    pub fn border_type() -> BorderType { Self::active_palette().border_type }
+    pub fn prompt_glyph() -> &'static str { Self::active_palette().prompt_glyph }
+    pub fn bullet_glyph() -> &'static str { Self::active_palette().bullet_glyph }
+    pub fn brand_icon() -> &'static str { Self::active_palette().brand_icon }
+    pub fn show_live_clock() -> bool { Self::active_palette().show_live_clock }
+
+    // Dynamic color accessors reading live from the active theme
+    pub fn bg() -> Color { Self::active_palette().bg }
+    pub fn fg() -> Color { Self::active_palette().fg }
+    pub fn dim() -> Color { Self::active_palette().dim }
+    pub fn accent() -> Color { Self::active_palette().accent }
+    pub fn cyan() -> Color { Self::active_palette().cyan }
+    pub fn green() -> Color { Self::active_palette().green }
+    pub fn yellow() -> Color { Self::active_palette().yellow }
+    pub fn red() -> Color { Self::active_palette().red }
+    pub fn orange() -> Color { Self::active_palette().orange }
+    pub fn border() -> Color { Self::active_palette().border }
+    pub fn border_focus() -> Color { Self::active_palette().border_focus }
+    pub fn sel_bg() -> Color { Self::active_palette().sel_bg }
+    pub fn sel_fg() -> Color { Self::active_palette().sel_fg }
+    pub fn marked_bg() -> Color { Self::active_palette().marked_bg }
+    pub fn marked_fg() -> Color { Self::active_palette().marked_fg }
+
     pub fn header() -> Style {
-        Style::default().fg(Self::CYAN).add_modifier(Modifier::BOLD)
+        Style::default().fg(Self::cyan()).add_modifier(Modifier::BOLD)
     }
 
     pub fn header_label() -> Style {
-        Style::default().fg(Self::DIM)
+        Style::default().fg(Self::dim())
     }
 
     pub fn header_val() -> Style {
-        Style::default().fg(Self::FG).add_modifier(Modifier::BOLD)
+        Style::default().fg(Self::fg()).add_modifier(Modifier::BOLD)
     }
 
     pub fn title() -> Style {
-        Style::default().fg(Self::ACCENT).add_modifier(Modifier::BOLD)
+        Style::default().fg(Self::accent()).add_modifier(Modifier::BOLD)
     }
 
     pub fn table_header() -> Style {
-        Style::default().fg(Self::CYAN).add_modifier(Modifier::BOLD)
+        Style::default().fg(Self::cyan()).add_modifier(Modifier::BOLD)
     }
 
     pub fn selected_row() -> Style {
-        Style::default().bg(Self::SEL_BG).fg(Self::SEL_FG).add_modifier(Modifier::BOLD)
+        Style::default().bg(Self::sel_bg()).fg(Self::sel_fg()).add_modifier(Modifier::BOLD)
     }
 
     pub fn marked_row() -> Style {
-        Style::default().bg(Color::Rgb(60, 40, 90)).fg(Color::Yellow).add_modifier(Modifier::BOLD)
+        Style::default().bg(Self::marked_bg()).fg(Self::marked_fg()).add_modifier(Modifier::BOLD)
     }
 
     pub fn status_ok() -> Style {
-        Style::default().fg(Self::GREEN).add_modifier(Modifier::BOLD)
+        Style::default().fg(Self::green()).add_modifier(Modifier::BOLD)
     }
 
     pub fn status_warn() -> Style {
-        Style::default().fg(Self::YELLOW).add_modifier(Modifier::BOLD)
+        Style::default().fg(Self::yellow()).add_modifier(Modifier::BOLD)
     }
 
     pub fn status_error() -> Style {
-        Style::default().fg(Self::RED).add_modifier(Modifier::BOLD)
+        Style::default().fg(Self::red()).add_modifier(Modifier::BOLD)
     }
 
     pub fn context_color(ctx_name: &str, is_local: bool) -> Color {
@@ -72,19 +553,19 @@ impl Theme {
     }
 
     pub fn status_dim() -> Style {
-        Style::default().fg(Self::DIM)
+        Style::default().fg(Self::dim())
     }
 
     pub fn key_hint_key() -> Style {
-        Style::default().fg(Self::CYAN).add_modifier(Modifier::BOLD)
+        Style::default().fg(Self::cyan()).add_modifier(Modifier::BOLD)
     }
 
     pub fn key_hint_desc() -> Style {
-        Style::default().fg(Self::DIM)
+        Style::default().fg(Self::dim())
     }
 
     pub fn prompt() -> Style {
-        Style::default().fg(Self::ACCENT).add_modifier(Modifier::BOLD)
+        Style::default().fg(Self::accent()).add_modifier(Modifier::BOLD)
     }
 
     pub fn badge(bg: Color, fg: Color) -> Style {
@@ -109,11 +590,13 @@ pub fn status_style(status: &str) -> Style {
         || lower.contains("not scheduled")
         || lower.contains("suspended")
     {
-        Style::default().fg(Theme::DIM)
+        Style::default().fg(Theme::dim())
     } else if lower.contains("pending")
         || lower.contains("containercreating")
         || lower.contains("terminating")
         || lower.contains("warning")
+        || lower.contains("schedulingdisabled")
+        || lower.contains("cordon")
     {
         Theme::status_warn()
     } else if lower.contains("running")
@@ -127,6 +610,7 @@ pub fn status_style(status: &str) -> Style {
     {
         Theme::status_ok()
     } else {
-        Style::default().fg(Theme::FG)
+        Style::default().fg(Theme::fg())
     }
 }
+

--- a/apps/tui/src/ui/dialogs.rs
+++ b/apps/tui/src/ui/dialogs.rs
@@ -17,6 +17,14 @@ pub enum Modal {
         action_name: String,
         is_destructive: bool,
     },
+    InputConfirm {
+        title: String,
+        message: String,
+        action_name: String,
+        required_input: String,
+        current_input: String,
+        is_destructive: bool,
+    },
     Scale {
         workload_name: String,
         current_replicas: i32,
@@ -27,6 +35,7 @@ pub enum Modal {
         namespace: String,
         container_port: u16,
         local_port_input: String,
+        kind: String,
     },
     ContainerPicker {
         pod_name: String,
@@ -61,6 +70,10 @@ pub enum Modal {
         selected_idx: usize,
         active_filter: Option<String>,
     },
+    ThemePicker {
+        selected_idx: usize,
+        initial_theme_idx: usize,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -76,6 +89,7 @@ pub enum QuickActionId {
     ViewLogs,
     OpenShell,
     PortForward,
+    StopPortForward,
     Describe,
     ViewYaml,
     EditYaml,
@@ -122,6 +136,7 @@ pub fn render_modal(f: &mut Frame, area: Rect, modal: &Modal) {
             let border_color = if *is_destructive { Theme::RED } else { Theme::ACCENT };
             let block = Block::default()
                 .borders(Borders::ALL)
+                .border_type(Theme::border_type())
                 .border_style(Style::default().fg(border_color))
                 .title(format!(" {} ", title));
 
@@ -152,12 +167,65 @@ pub fn render_modal(f: &mut Frame, area: Rect, modal: &Modal) {
             let prompt_widget = Paragraph::new(prompt_line).alignment(Alignment::Center);
             f.render_widget(prompt_widget, chunks[1]);
         }
+        Modal::InputConfirm { title, message, action_name: _, required_input, current_input, is_destructive } => {
+            let modal_area = centered_rect(55, 34, area);
+            f.render_widget(Clear, modal_area);
+
+            let border_color = if *is_destructive { Theme::red() } else { Theme::accent() };
+            let block = Block::default()
+                .borders(Borders::ALL)
+                .border_type(Theme::border_type())
+                .border_style(Style::default().fg(border_color))
+                .title(Span::styled(format!(" {} ", title), Style::default().fg(border_color).add_modifier(Modifier::BOLD)));
+
+            let inner = block.inner(modal_area);
+            f.render_widget(block, modal_area);
+
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([
+                    Constraint::Min(3),
+                    Constraint::Length(3),
+                    Constraint::Length(2),
+                ])
+                .split(inner);
+
+            let msg_widget = Paragraph::new(message.as_str())
+                .wrap(Wrap { trim: true })
+                .alignment(Alignment::Center);
+            f.render_widget(msg_widget, chunks[0]);
+
+            let is_matched = current_input == required_input;
+            let input_block = Block::default()
+                .borders(Borders::ALL)
+                .border_type(Theme::border_type())
+                .border_style(Style::default().fg(if is_matched { Theme::green() } else { Theme::yellow() }))
+                .title(format!(" Type \"{}\" to confirm ", required_input));
+
+            let input_widget = Paragraph::new(format!("{}█", current_input))
+                .style(Style::default().fg(if is_matched { Theme::green() } else { Theme::fg() }).add_modifier(Modifier::BOLD))
+                .alignment(Alignment::Center)
+                .block(input_block);
+            f.render_widget(input_widget, chunks[1]);
+
+            let prompt_line = Line::from(vec![
+                Span::styled("Press ", Style::default().fg(Theme::dim())),
+                Span::styled("[Enter]", Style::default().fg(if is_matched { Theme::green() } else { Theme::dim() }).add_modifier(if is_matched { Modifier::BOLD } else { Modifier::empty() })),
+                Span::styled(if is_matched { " Confirm" } else { " (type word to enable)" }, Style::default().fg(if is_matched { Theme::fg() } else { Theme::dim() })),
+                Span::styled("  |  ", Style::default().fg(Theme::dim())),
+                Span::styled("[Esc]", Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD)),
+                Span::styled(" Cancel", Style::default().fg(Theme::dim())),
+            ]);
+            let prompt_widget = Paragraph::new(prompt_line).alignment(Alignment::Center);
+            f.render_widget(prompt_widget, chunks[2]);
+        }
         Modal::Scale { workload_name, current_replicas, input } => {
             let modal_area = centered_rect(45, 25, area);
             f.render_widget(Clear, modal_area);
 
             let block = Block::default()
                 .borders(Borders::ALL)
+                .border_type(Theme::border_type())
                 .border_style(Style::default().fg(Theme::ACCENT))
                 .title(format!(" Scale Workload: {} ", workload_name));
 
@@ -179,6 +247,7 @@ pub fn render_modal(f: &mut Frame, area: Rect, modal: &Modal) {
 
             let input_block = Block::default()
                 .borders(Borders::ALL)
+                .border_type(Theme::border_type())
                 .border_style(Style::default().fg(Theme::CYAN))
                 .title(" Desired Replicas ");
             let input_widget = Paragraph::new(format!("{}█", input))
@@ -195,14 +264,20 @@ pub fn render_modal(f: &mut Frame, area: Rect, modal: &Modal) {
             ])).alignment(Alignment::Center);
             f.render_widget(hints, chunks[2]);
         }
-        Modal::PortForward { pod_name, namespace, container_port, local_port_input } => {
+        Modal::PortForward { pod_name, namespace, container_port, local_port_input, kind } => {
             let modal_area = centered_rect(50, 30, area);
             f.render_widget(Clear, modal_area);
 
+            let title_str = if kind.is_empty() || kind == "Pod" {
+                format!(" Start Port Forward: {} ({}) ", pod_name, namespace)
+            } else {
+                format!(" Start Port Forward: {}/{} ({}) ", kind, pod_name, namespace)
+            };
             let block = Block::default()
                 .borders(Borders::ALL)
+                .border_type(Theme::border_type())
                 .border_style(Style::default().fg(Theme::ACCENT))
-                .title(format!(" Start Port Forward: {} ({}) ", pod_name, namespace));
+                .title(title_str);
 
             let inner = block.inner(modal_area);
             f.render_widget(block, modal_area);
@@ -222,6 +297,7 @@ pub fn render_modal(f: &mut Frame, area: Rect, modal: &Modal) {
 
             let input_block = Block::default()
                 .borders(Borders::ALL)
+                .border_type(Theme::border_type())
                 .border_style(Style::default().fg(Theme::CYAN))
                 .title(" Local Port (127.0.0.1) ");
             let input_widget = Paragraph::new(format!("{}█", local_port_input))
@@ -249,6 +325,7 @@ pub fn render_modal(f: &mut Frame, area: Rect, modal: &Modal) {
 
             let block = Block::default()
                 .borders(Borders::ALL)
+                .border_type(Theme::border_type())
                 .border_style(Style::default().fg(Theme::ACCENT))
                 .title(format!(" {} ({}) ", action_title, pod_name));
 
@@ -279,6 +356,7 @@ pub fn render_modal(f: &mut Frame, area: Rect, modal: &Modal) {
 
             let block = Block::default()
                 .borders(Borders::ALL)
+                .border_type(Theme::border_type())
                 .border_style(Style::default().fg(Theme::ACCENT))
                 .title(" Switch Kubernetes Context (Type to filter, ↑/↓ Navigate, Enter Switch, Esc Close) ");
 
@@ -297,6 +375,7 @@ pub fn render_modal(f: &mut Frame, area: Rect, modal: &Modal) {
             // 1. Search input box
             let search_block = Block::default()
                 .borders(Borders::ALL)
+                .border_type(Theme::border_type())
                 .border_style(Style::default().fg(Theme::CYAN))
                 .title(" Filter Contexts ");
             let search_para = Paragraph::new(Line::from(vec![
@@ -395,6 +474,7 @@ pub fn render_modal(f: &mut Frame, area: Rect, modal: &Modal) {
 
             let block = Block::default()
                 .borders(Borders::ALL)
+                .border_type(Theme::border_type())
                 .border_style(Style::default().fg(Theme::ACCENT))
                 .title(" Switch Namespace (0: All Namespaces, ↑/↓ Navigate, Enter Select) ");
 
@@ -411,6 +491,7 @@ pub fn render_modal(f: &mut Frame, area: Rect, modal: &Modal) {
 
             let filter_block = Block::default()
                 .borders(Borders::ALL)
+                .border_type(Theme::border_type())
                 .border_style(Style::default().fg(Theme::CYAN))
                 .title(" Filter ");
             let filter_widget = Paragraph::new(format!("{}█", filter))
@@ -458,6 +539,7 @@ pub fn render_modal(f: &mut Frame, area: Rect, modal: &Modal) {
             let ns_str = namespace.as_deref().map(|n| format!(" ({})", n)).unwrap_or_default();
             let block = Block::default()
                 .borders(Borders::ALL)
+                .border_type(Theme::border_type())
                 .border_style(Style::default().fg(Theme::ACCENT))
                 .title(Span::styled(
                     format!(" ⚡ Actions: {}/{}{} [Type to filter, ↑/↓ Navigate, Enter Run, Esc Close] ", resource_kind, resource_name, ns_str),
@@ -479,6 +561,7 @@ pub fn render_modal(f: &mut Frame, area: Rect, modal: &Modal) {
             // 1. Search box
             let search_block = Block::default()
                 .borders(Borders::ALL)
+                .border_type(Theme::border_type())
                 .border_style(Style::default().fg(Theme::CYAN))
                 .title(" Filter Actions ");
             let search_para = Paragraph::new(Line::from(vec![
@@ -549,6 +632,91 @@ pub fn render_modal(f: &mut Frame, area: Rect, modal: &Modal) {
         }
         Modal::ReasonRail { tallies, selected_idx, active_filter } => {
             crate::views::reason_rail::render_reason_rail_modal(f, area, tallies, *selected_idx, active_filter.as_deref());
+        }
+        Modal::ThemePicker { selected_idx, initial_theme_idx: _ } => {
+            let modal_area = centered_rect(75, 75, area);
+            f.render_widget(Clear, modal_area);
+
+            let block = Block::default()
+                .borders(Borders::ALL)
+                .border_type(Theme::border_type())
+                .border_style(Style::default().fg(Theme::accent()))
+                .title(Span::styled(" Themes & Visual Styles (↑/↓ or j/k Preview • Enter Select • Esc Cancel) ", Style::default().fg(Theme::accent()).add_modifier(Modifier::BOLD)));
+
+            let inner = block.inner(modal_area);
+            f.render_widget(block, modal_area);
+
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([
+                    Constraint::Min(6),
+                    Constraint::Length(1),
+                ])
+                .split(inner);
+
+            let active_idx = Theme::active_index();
+            let items: Vec<ListItem> = Theme::all_themes()
+                .iter()
+                .enumerate()
+                .map(|(i, p)| {
+                    let is_sel = i == *selected_idx;
+                    let is_current = i == active_idx;
+                    let cursor = if is_sel { "▶ " } else { "  " };
+
+                    let visual_badge = match p.header_style {
+                        crate::theme::HeaderStyle::FinoTime => "[Fino • Live Clock • Tree] ",
+                        crate::theme::HeaderStyle::Minimal => "[Minimalist Chrome] ",
+                        crate::theme::HeaderStyle::Standard => {
+                            if p.border_type == ratatui::widgets::BorderType::Thick {
+                                "[Thick Neon Borders] "
+                            } else {
+                                ""
+                            }
+                        }
+                    };
+
+                    let mut spans = vec![
+                        Span::styled(cursor, if is_sel { Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD) } else { Style::default().fg(Theme::dim()) }),
+                        Span::styled(format!("{:<20}", p.display_name), if is_sel { Style::default().fg(Theme::fg()).add_modifier(Modifier::BOLD) } else { Style::default().fg(Theme::fg()) }),
+                        Span::raw(" "),
+                        Span::styled("■ ", Style::default().fg(p.accent)),
+                        Span::styled("■ ", Style::default().fg(p.cyan)),
+                        Span::styled("■ ", Style::default().fg(p.green)),
+                        Span::styled("■ ", Style::default().fg(p.yellow)),
+                        Span::styled("■ ", Style::default().fg(p.red)),
+                        Span::raw(" "),
+                    ];
+
+                    if !visual_badge.is_empty() {
+                        spans.push(Span::styled(visual_badge, Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)));
+                    }
+
+                    if is_current {
+                        spans.push(Span::styled("✔ ACTIVE ", Style::default().fg(p.green).add_modifier(Modifier::BOLD)));
+                    }
+
+                    spans.push(Span::styled(format!("— {}", p.description), Style::default().fg(Theme::dim())));
+
+                    let row_style = if is_sel {
+                        Theme::selected_row()
+                    } else {
+                        Style::default()
+                    };
+
+                    ListItem::new(Line::from(spans)).style(row_style)
+                })
+                .collect();
+
+            let list = List::new(items);
+            f.render_widget(list, chunks[0]);
+
+            let active_name = Theme::active_palette().display_name;
+            let footer = Paragraph::new(Line::from(vec![
+                Span::styled("Live Previewing: ", Style::default().fg(Theme::dim())),
+                Span::styled(active_name, Style::default().fg(Theme::accent()).add_modifier(Modifier::BOLD)),
+                Span::styled("  •  [Enter] Save  [Esc] Cancel", Style::default().fg(Theme::dim())),
+            ])).alignment(Alignment::Center);
+            f.render_widget(footer, chunks[1]);
         }
     }
 }

--- a/apps/tui/src/ui/header.rs
+++ b/apps/tui/src/ui/header.rs
@@ -33,7 +33,7 @@ pub struct HeaderProps<'a> {
 pub fn render_header(f: &mut Frame, area: Rect, props: HeaderProps) {
     let block = Block::default()
         .borders(Borders::BOTTOM)
-        .border_style(Style::default().fg(Theme::BORDER));
+        .border_style(Style::default().fg(Theme::border()));
 
     let inner = block.inner(area);
     f.render_widget(block, area);
@@ -41,6 +41,8 @@ pub fn render_header(f: &mut Frame, area: Rect, props: HeaderProps) {
     if let Some(rects) = props.context_chip_rects {
         rects.borrow_mut().clear();
     }
+
+    let header_style = Theme::header_style();
 
     if inner.height >= 2 {
         let v_rows = Layout::default()
@@ -51,22 +53,46 @@ pub fn render_header(f: &mut Frame, area: Rect, props: HeaderProps) {
             ])
             .split(inner);
 
+        // Prepare Brand spans based on HeaderStyle
+        let brand_spans = match header_style {
+            crate::theme::HeaderStyle::FinoTime => {
+                let mut s = vec![
+                    Span::styled("╭─[ ", Style::default().fg(Theme::dim())),
+                    Span::styled("SRELENS", Style::default().fg(Theme::accent()).add_modifier(Modifier::BOLD)),
+                    Span::styled(" ]", Style::default().fg(Theme::dim())),
+                ];
+                if Theme::show_live_clock() {
+                    let time_str = chrono::Local::now().format("%H:%M:%S").to_string();
+                    s.push(Span::styled("──[ ", Style::default().fg(Theme::dim())));
+                    s.push(Span::styled(time_str, Style::default().fg(Theme::cyan())));
+                    s.push(Span::styled(" ]", Style::default().fg(Theme::dim())));
+                }
+                s
+            }
+            crate::theme::HeaderStyle::Minimal => vec![
+                Span::styled("SRELENS", Style::default().fg(Theme::accent()).add_modifier(Modifier::BOLD)),
+            ],
+            crate::theme::HeaderStyle::Standard => vec![
+                Span::styled(Theme::brand_icon(), Style::default().fg(Theme::yellow())),
+                Span::styled("SRELENS", Style::default().fg(Theme::accent()).add_modifier(Modifier::BOLD)),
+            ],
+        };
+
+        let brand_line = Line::from(brand_spans);
+        let brand_w = (unicode_width::UnicodeWidthStr::width(brand_line.to_string().as_str()) as u16).max(9);
+        let stats_w = if header_style == crate::theme::HeaderStyle::FinoTime { 44 } else { 34 };
+
         // Row 0:
         let r0_chunks = Layout::default()
             .direction(Direction::Horizontal)
             .constraints([
-                Constraint::Length(11), // Brand "⚡ SRELENS"
-                Constraint::Min(20),    // Context Hotbar Chips
-                Constraint::Length(34), // Stats
+                Constraint::Length(brand_w + 1), // Brand
+                Constraint::Min(20),             // Context Hotbar Chips
+                Constraint::Length(stats_w),     // Stats
             ])
             .split(v_rows[0]);
 
-        // Brand
-        let brand = Paragraph::new(Line::from(vec![
-            Span::styled("⚡ ", Style::default().fg(Theme::YELLOW)),
-            Span::styled("SRELENS", Style::default().fg(Theme::ACCENT).add_modifier(Modifier::BOLD)),
-        ]));
-        f.render_widget(brand, r0_chunks[0]);
+        f.render_widget(Paragraph::new(brand_line), r0_chunks[0]);
 
         // Contexts Hotbar
         render_context_chips(f, r0_chunks[1], props.contexts, props.context_chip_rects);
@@ -91,24 +117,48 @@ pub fn render_header(f: &mut Frame, area: Rect, props: HeaderProps) {
 
         let active_ctx_color = Theme::context_color(props.context, props.contexts.iter().find(|c| c.name == props.context).map(|c| c.is_local).unwrap_or(false));
 
-        let active_line = Line::from(vec![
-            Span::styled("Ctx: ", Theme::header_label()),
-            Span::styled(props.context, Style::default().fg(active_ctx_color).add_modifier(Modifier::BOLD)),
-            Span::raw("  "),
-            Span::styled("NS: ", Theme::header_label()),
-            Span::styled(format!("[{}]", ns_display), Style::default().fg(Theme::CYAN).add_modifier(Modifier::BOLD)),
-            Span::raw("  "),
-            Span::styled("View: ", Theme::header_label()),
-            Span::styled(props.active_view_name, Style::default().fg(Theme::YELLOW).add_modifier(Modifier::BOLD)),
-        ]);
+        let active_line = match header_style {
+            crate::theme::HeaderStyle::FinoTime => Line::from(vec![
+                Span::styled("╰─[ ", Style::default().fg(Theme::dim())),
+                Span::styled("ctx: ", Theme::header_label()),
+                Span::styled(props.context, Style::default().fg(active_ctx_color).add_modifier(Modifier::BOLD)),
+                Span::styled(" ]──[ ", Style::default().fg(Theme::dim())),
+                Span::styled("ns: ", Theme::header_label()),
+                Span::styled(ns_display, Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)),
+                Span::styled(" ]──[ ", Style::default().fg(Theme::dim())),
+                Span::styled("view: ", Theme::header_label()),
+                Span::styled(props.active_view_name, Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD)),
+                Span::styled(" ]", Style::default().fg(Theme::dim())),
+            ]),
+            crate::theme::HeaderStyle::Minimal => Line::from(vec![
+                Span::styled("ctx: ", Theme::header_label()),
+                Span::styled(props.context, Style::default().fg(active_ctx_color).add_modifier(Modifier::BOLD)),
+                Span::raw("  "),
+                Span::styled("ns: ", Theme::header_label()),
+                Span::styled(format!("[{}]", ns_display), Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)),
+                Span::raw("  "),
+                Span::styled("view: ", Theme::header_label()),
+                Span::styled(props.active_view_name, Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD)),
+            ]),
+            crate::theme::HeaderStyle::Standard => Line::from(vec![
+                Span::styled("Ctx: ", Theme::header_label()),
+                Span::styled(props.context, Style::default().fg(active_ctx_color).add_modifier(Modifier::BOLD)),
+                Span::raw("  "),
+                Span::styled("NS: ", Theme::header_label()),
+                Span::styled(format!("[{}]", ns_display), Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)),
+                Span::raw("  "),
+                Span::styled("View: ", Theme::header_label()),
+                Span::styled(props.active_view_name, Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD)),
+            ]),
+        };
         f.render_widget(Paragraph::new(active_line), r1_chunks[0]);
 
         let hints_line = Line::from(vec![
-            Span::styled("<:ctx>", Style::default().fg(Theme::CYAN).add_modifier(Modifier::BOLD)),
+            Span::styled("<:ctx>", Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)),
             Span::styled(" All Ctx  ", Theme::header_label()),
-            Span::styled("<F1-F10>", Style::default().fg(Theme::CYAN).add_modifier(Modifier::BOLD)),
+            Span::styled("<F1-F10>", Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)),
             Span::styled(" Hotkeys  ", Theme::header_label()),
-            Span::styled("<?>", Style::default().fg(Theme::CYAN).add_modifier(Modifier::BOLD)),
+            Span::styled("<?>", Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)),
             Span::styled(" Help", Theme::header_label()),
         ]);
         f.render_widget(Paragraph::new(hints_line).alignment(ratatui::layout::Alignment::Right), r1_chunks[1]);
@@ -124,8 +174,8 @@ pub fn render_header(f: &mut Frame, area: Rect, props: HeaderProps) {
             .split(inner);
 
         let brand = Paragraph::new(Line::from(vec![
-            Span::styled("⚡ ", Style::default().fg(Theme::YELLOW)),
-            Span::styled("SRELENS", Style::default().fg(Theme::ACCENT).add_modifier(Modifier::BOLD)),
+            Span::styled(Theme::brand_icon(), Style::default().fg(Theme::yellow())),
+            Span::styled("SRELENS", Style::default().fg(Theme::accent()).add_modifier(Modifier::BOLD)),
         ]));
         f.render_widget(brand, chunks[0]);
 
@@ -136,10 +186,10 @@ pub fn render_header(f: &mut Frame, area: Rect, props: HeaderProps) {
             Span::styled(props.context, Style::default().fg(active_ctx_color).add_modifier(Modifier::BOLD)),
             Span::raw(" "),
             Span::styled("NS: ", Theme::header_label()),
-            Span::styled(format!("[{}]", ns_display), Style::default().fg(Theme::CYAN).add_modifier(Modifier::BOLD)),
+            Span::styled(format!("[{}]", ns_display), Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)),
             Span::raw(" "),
             Span::styled("View: ", Theme::header_label()),
-            Span::styled(props.active_view_name, Style::default().fg(Theme::YELLOW).add_modifier(Modifier::BOLD)),
+            Span::styled(props.active_view_name, Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD)),
         ]);
         f.render_widget(Paragraph::new(cluster_line), chunks[1]);
         render_stats(f, chunks[2], &props);
@@ -147,10 +197,12 @@ pub fn render_header(f: &mut Frame, area: Rect, props: HeaderProps) {
 }
 
 fn render_stats(f: &mut Frame, area: Rect, props: &HeaderProps) {
-    let status_dot = if props.is_connected {
-        Span::styled("● ", Style::default().fg(Theme::GREEN))
+    let header_style = Theme::header_style();
+    let bullet = Theme::bullet_glyph();
+    let status_color = if props.is_connected {
+        Theme::green()
     } else {
-        Span::styled("● ", Style::default().fg(Theme::RED))
+        Theme::red()
     };
 
     let version_clean = if props.version.starts_with('v') {
@@ -161,14 +213,34 @@ fn render_stats(f: &mut Frame, area: Rect, props: &HeaderProps) {
         props.version.to_string()
     };
 
-    let stats_line = Line::from(vec![
-        status_dot,
-        Span::styled(format!("{} ", version_clean), Theme::header_label()),
-        Span::styled("Nodes: ", Theme::header_label()),
-        Span::styled(format!("{} ", props.node_count), Theme::header_val()),
-        Span::styled("Pods: ", Theme::header_label()),
-        Span::styled(format!("{}", props.pod_count), Theme::header_val()),
-    ]);
+    let stats_line = match header_style {
+        crate::theme::HeaderStyle::FinoTime => Line::from(vec![
+            Span::styled("[ ", Style::default().fg(Theme::dim())),
+            Span::styled(format!("{} ", bullet), Style::default().fg(status_color)),
+            Span::styled(version_clean, Theme::header_label()),
+            Span::styled(" ]──[ ", Style::default().fg(Theme::dim())),
+            Span::styled("nodes: ", Theme::header_label()),
+            Span::styled(format!("{}", props.node_count), Theme::header_val()),
+            Span::styled(" ]──[ ", Style::default().fg(Theme::dim())),
+            Span::styled("pods: ", Theme::header_label()),
+            Span::styled(format!("{}", props.pod_count), Theme::header_val()),
+            Span::styled(" ]", Style::default().fg(Theme::dim())),
+        ]),
+        crate::theme::HeaderStyle::Minimal => Line::from(vec![
+            Span::styled(format!("{} ", bullet), Style::default().fg(status_color)),
+            Span::styled(format!("{} ", version_clean), Theme::header_label()),
+            Span::styled(format!("{} nodes  ", props.node_count), Theme::header_val()),
+            Span::styled(format!("{} pods", props.pod_count), Theme::header_val()),
+        ]),
+        crate::theme::HeaderStyle::Standard => Line::from(vec![
+            Span::styled(format!("{} ", bullet), Style::default().fg(status_color)),
+            Span::styled(format!("{} ", version_clean), Theme::header_label()),
+            Span::styled("Nodes: ", Theme::header_label()),
+            Span::styled(format!("{} ", props.node_count), Theme::header_val()),
+            Span::styled("Pods: ", Theme::header_label()),
+            Span::styled(format!("{}", props.pod_count), Theme::header_val()),
+        ]),
+    };
     f.render_widget(Paragraph::new(stats_line).alignment(ratatui::layout::Alignment::Right), area);
 }
 

--- a/apps/tui/src/ui/help.rs
+++ b/apps/tui/src/ui/help.rs
@@ -35,7 +35,8 @@ pub fn render_help_modal(f: &mut Frame, area: Rect) {
 
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Theme::ACCENT))
+        .border_type(Theme::border_type())
+        .border_style(Style::default().fg(Theme::accent()))
         .title(" SRElens & k9s Keybindings Cheat Sheet (Press Esc to close) ");
 
     let inner = block.inner(modal_area);
@@ -52,12 +53,20 @@ pub fn render_help_modal(f: &mut Frame, area: Rect) {
 
     let rows = vec![
         Row::new(vec![
-            Cell::from(Span::styled("Navigation & Views", Style::default().fg(Theme::CYAN).add_modifier(Modifier::BOLD))),
+            Cell::from(Span::styled("Navigation & Views", Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD))),
             Cell::from(""),
         ]),
         Row::new(vec![
             Cell::from(Span::styled("  : <command>", Theme::key_hint_key())),
-            Cell::from("Open command prompt (:pod, :deploy, :svc, :no, :ns, :helm, :pf, :ai, :ctx, :q)"),
+            Cell::from("Open command prompt (:pod, :deploy, :top, :toppods, :topnodes, :gpuinfo, :svc, :topo, :no, :ns, :helm, :pf, :ai, :ctx, :q)"),
+        ]),
+        Row::new(vec![
+            Cell::from(Span::styled("  :top / :toppods / :topnodes", Theme::key_hint_key())),
+            Cell::from("Top Hotspots ranking (Pods & Nodes) sorted by CPU / MEM with % Req & % Limit"),
+        ]),
+        Row::new(vec![
+            Cell::from(Span::styled("  :gpuinfo / :gpu", Theme::key_hint_key())),
+            Cell::from("GPU nodes list, VRAM allocation & GPU pod workloads inspector"),
         ]),
         Row::new(vec![
             Cell::from(Span::styled("  Ctrl+c", Theme::key_hint_key())),
@@ -96,7 +105,7 @@ pub fn render_help_modal(f: &mut Frame, area: Rect) {
             Cell::from("Mark / select item for bulk operations"),
         ]),
         Row::new(vec![
-            Cell::from(Span::styled("Resource Actions", Style::default().fg(Theme::CYAN).add_modifier(Modifier::BOLD))),
+            Cell::from(Span::styled("Resource Actions", Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD))),
             Cell::from(""),
         ]),
         Row::new(vec![
@@ -109,7 +118,7 @@ pub fn render_help_modal(f: &mut Frame, area: Rect) {
         ]),
         Row::new(vec![
             Cell::from(Span::styled("  l", Theme::key_hint_key())),
-            Cell::from("View Logs (options: p previous, t timestamps, w wrap, f follow, s save)"),
+            Cell::from("View Logs (single pod, multi-pod on marked items, or workload replica streams)"),
         ]),
         Row::new(vec![
             Cell::from(Span::styled("  s", Theme::key_hint_key())),
@@ -168,7 +177,7 @@ pub fn render_help_modal(f: &mut Frame, area: Rect) {
             Cell::from("Trigger CronJob / Job manual run"),
         ]),
         Row::new(vec![
-            Cell::from(Span::styled("SRElens Superpowers", Style::default().fg(Theme::CYAN).add_modifier(Modifier::BOLD))),
+            Cell::from(Span::styled("SRElens Superpowers", Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD))),
             Cell::from(""),
         ]),
         Row::new(vec![

--- a/apps/tui/src/ui/statusbar.rs
+++ b/apps/tui/src/ui/statusbar.rs
@@ -26,12 +26,14 @@ pub struct StatusBarProps<'a> {
     pub toast: Option<(&'a str, Style)>,
     pub custom_hints: Option<&'a [(&'a str, &'a str)]>,
     pub suggestions: Option<(&'a [(crate::commands::DynamicCommandDef, usize)], usize)>,
+    pub close_pf_button: Option<(&'a str, Style)>,
+    pub close_pf_rect: Option<&'a std::cell::RefCell<Option<Rect>>>,
 }
 
 pub fn render_statusbar(f: &mut Frame, area: Rect, props: StatusBarProps) {
     let block = Block::default()
         .borders(Borders::TOP)
-        .border_style(Style::default().fg(Theme::BORDER));
+        .border_style(Style::default().fg(Theme::border()));
 
     let inner = block.inner(area);
     f.render_widget(block, area);
@@ -39,17 +41,25 @@ pub fn render_statusbar(f: &mut Frame, area: Rect, props: StatusBarProps) {
     match props.mode {
         InputMode::Command => {
             // Render command bar with autocomplete popup
+            let prompt_prefix = Theme::prompt_glyph();
+            let prompt_str = if prompt_prefix == ":" {
+                ":".to_string()
+            } else {
+                format!("{}:", prompt_prefix)
+            };
             let cmd_text = Line::from(vec![
-                Span::styled(":", Theme::prompt()),
-                Span::styled(props.command_input, Style::default().fg(Theme::FG)),
-                Span::styled("█", Style::default().fg(Theme::CYAN)), // Cursor
+                Span::styled(prompt_str, Theme::prompt()),
+                Span::styled(props.command_input, Style::default().fg(Theme::fg())),
+                Span::styled("█", Style::default().fg(Theme::cyan())), // Cursor
             ]);
             f.render_widget(Paragraph::new(cmd_text), inner);
 
             // Render autocomplete suggestions if typing
             if let Some((suggs, selected_idx)) = props.suggestions {
                 if !suggs.is_empty() {
-                    let popup_height = (suggs.len() as u16 + 2).min(8);
+                    let max_visible = 6usize;
+                    let visible_count = suggs.len().min(max_visible);
+                    let popup_height = (visible_count as u16 + 2).min(8);
                     let popup_area = Rect {
                         x: area.x + 2,
                         y: area.y.saturating_sub(popup_height),
@@ -58,11 +68,21 @@ pub fn render_statusbar(f: &mut Frame, area: Rect, props: StatusBarProps) {
                     };
                     f.render_widget(Clear, popup_area);
 
-                    let items: Vec<ListItem> = suggs
+                    // Compute window offset to keep selected_idx visible
+                    let scroll_offset = if selected_idx >= max_visible {
+                        selected_idx + 1 - max_visible
+                    } else {
+                        0
+                    };
+
+                    let visible_slice = &suggs[scroll_offset..(scroll_offset + visible_count).min(suggs.len())];
+
+                    let items: Vec<ListItem> = visible_slice
                         .iter()
                         .enumerate()
-                        .map(|(i, (cmd, _score))| {
-                            let is_selected = i == selected_idx;
+                        .map(|(rel_i, (cmd, _score))| {
+                            let abs_i = scroll_offset + rel_i;
+                            let is_selected = abs_i == selected_idx;
                             let prefix = if is_selected { "▶ " } else { "  " };
                             let alias_str = if !cmd.aliases.is_empty() {
                                 format!(" ({})", cmd.aliases.join(", "))
@@ -73,14 +93,14 @@ pub fn render_statusbar(f: &mut Frame, area: Rect, props: StatusBarProps) {
                                 Span::styled(
                                     format!("{}{}{:<20}", prefix, cmd.name, alias_str),
                                     if is_selected {
-                                        Style::default().fg(Theme::CYAN).add_modifier(Modifier::BOLD)
+                                        Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)
                                     } else {
-                                        Style::default().fg(Theme::FG)
+                                        Style::default().fg(Theme::fg())
                                     },
                                 ),
                                 Span::styled(
                                     format!("  {}", cmd.description),
-                                    Style::default().fg(Theme::DIM),
+                                    Style::default().fg(Theme::dim()),
                                 ),
                             ]);
                             ListItem::new(line).style(if is_selected {
@@ -91,37 +111,53 @@ pub fn render_statusbar(f: &mut Frame, area: Rect, props: StatusBarProps) {
                         })
                         .collect();
 
+                    let title = if suggs.len() > max_visible {
+                        format!(" Commands [{}/{}] (Tab: complete, Enter: run) ", selected_idx + 1, suggs.len())
+                    } else {
+                        " Commands (Tab to complete, Enter to run) ".to_string()
+                    };
+
                     let list = List::new(items).block(
                         Block::default()
                             .borders(Borders::ALL)
-                            .border_style(Style::default().fg(Theme::ACCENT))
-                            .title(" Commands (Tab to complete, Enter to run) "),
+                            .border_type(Theme::border_type())
+                            .border_style(Style::default().fg(Theme::accent()))
+                            .title(title),
                     );
                     f.render_widget(list, popup_area);
                 }
             }
         }
         InputMode::Filter => {
-            let (label, stats, hint) = if props.is_text_search {
+            let prompt_prefix = Theme::prompt_glyph();
+            let base_label = if props.is_text_search {
+                "Search: /"
+            } else {
+                "Filter (regex): /"
+            };
+            let label = if prompt_prefix != ":" {
+                format!("{}{}", prompt_prefix, base_label)
+            } else {
+                base_label.to_string()
+            };
+            let (stats, hint) = if props.is_text_search {
                 (
-                    "Search: /",
                     format!("[{} matches]", props.matched_count),
                     "  (Enter to finish, n/N next/prev, Esc to clear)",
                 )
             } else {
                 (
-                    "Filter (regex): /",
                     format!("[{}/{}]", props.matched_count, props.total_count),
                     "  (Enter to apply, Esc to clear)",
                 )
             };
             let filter_text = Line::from(vec![
                 Span::styled(label, Theme::prompt()),
-                Span::styled(props.filter_input, Style::default().fg(Theme::FG)),
-                Span::styled("█", Style::default().fg(Theme::YELLOW)), // Cursor
+                Span::styled(props.filter_input, Style::default().fg(Theme::fg())),
+                Span::styled("█", Style::default().fg(Theme::yellow())), // Cursor
                 Span::raw("  "),
-                Span::styled(stats, Style::default().fg(Theme::DIM)),
-                Span::styled(hint, Style::default().fg(Theme::DIM)),
+                Span::styled(stats, Style::default().fg(Theme::dim())),
+                Span::styled(hint, Style::default().fg(Theme::dim())),
             ]);
             f.render_widget(Paragraph::new(filter_text), inner);
         }
@@ -147,9 +183,9 @@ pub fn render_statusbar(f: &mut Frame, area: Rect, props: StatusBarProps) {
 
             // Render notification toast without hiding keystroke palette
             if let Some((msg, style)) = props.toast {
-                spans.push(Span::styled("➜ ", style));
+                spans.push(Span::styled(format!("{} ", Theme::bullet_glyph()), style));
                 spans.push(Span::styled(format!("{} ", msg), style));
-                spans.push(Span::styled("│ ", Style::default().fg(Theme::BORDER)));
+                spans.push(Span::styled("│ ", Style::default().fg(Theme::border())));
             }
 
             for (key, desc) in hints {
@@ -162,11 +198,46 @@ pub fn render_statusbar(f: &mut Frame, area: Rect, props: StatusBarProps) {
                 spans.push(Span::styled("Filter: ", Theme::header_label()));
                 spans.push(Span::styled(
                     format!("\"{}\" [{}/{}]", props.filter_input, props.matched_count, props.total_count),
-                    Style::default().fg(Theme::YELLOW),
+                    Style::default().fg(Theme::yellow()),
                 ));
             }
 
-            f.render_widget(Paragraph::new(Line::from(spans)), inner);
+            if let Some((btn_label, btn_style)) = props.close_pf_button {
+                let btn_text = format!(" [ {} ] ", btn_label);
+                let btn_width = (btn_text.len() as u16).min(inner.width);
+                let btn_x = inner.x + inner.width.saturating_sub(btn_width);
+                let btn_area = Rect {
+                    x: btn_x,
+                    y: inner.y,
+                    width: btn_width,
+                    height: inner.height.min(1),
+                };
+                if let Some(rect_cell) = props.close_pf_rect {
+                    *rect_cell.borrow_mut() = Some(btn_area);
+                }
+
+                let hints_area = Rect {
+                    x: inner.x,
+                    y: inner.y,
+                    width: inner.width.saturating_sub(btn_width),
+                    height: inner.height,
+                };
+                f.render_widget(Paragraph::new(Line::from(spans)), hints_area);
+                f.render_widget(Paragraph::new(Line::from(vec![
+                    Span::styled(btn_text, btn_style),
+                ])), btn_area);
+            } else {
+                if let Some(rect_cell) = props.close_pf_rect {
+                    *rect_cell.borrow_mut() = None;
+                }
+                f.render_widget(Paragraph::new(Line::from(spans)), inner);
+            }
+        }
+    }
+
+    if props.mode != &InputMode::Normal {
+        if let Some(rect_cell) = props.close_pf_rect {
+            *rect_cell.borrow_mut() = None;
         }
     }
 }

--- a/apps/tui/src/views/gpu_view.rs
+++ b/apps/tui/src/views/gpu_view.rs
@@ -1,0 +1,763 @@
+use std::cell::Cell;
+use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Gauge, Paragraph};
+use ratatui::Frame;
+
+use srelens_kube::gpu_info::{format_vram_mib, GpuClusterInfo, GpuNodeInfo, GpuPodItem};
+use crate::theme::Theme;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuPane {
+    Nodes,
+    Pods,
+}
+
+#[derive(Debug, Clone)]
+pub struct GpuViewState {
+    pub cluster_info: Option<GpuClusterInfo>,
+    pub selected_node_idx: usize,
+    pub selected_pod_idx: usize,
+    pub focused_pane: GpuPane,
+    pub is_loading: bool,
+    pub error: Option<String>,
+    pub last_left_pane_rect: Cell<Rect>,
+    pub last_pods_pane_rect: Cell<Rect>,
+    pub last_nodes_start_idx: Cell<usize>,
+    pub last_pods_start_idx: Cell<usize>,
+}
+
+impl Default for GpuViewState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GpuViewState {
+    pub fn new() -> Self {
+        Self {
+            cluster_info: None,
+            selected_node_idx: 0,
+            selected_pod_idx: 0,
+            focused_pane: GpuPane::Nodes,
+            is_loading: true,
+            error: None,
+            last_left_pane_rect: Cell::new(Rect::default()),
+            last_pods_pane_rect: Cell::new(Rect::default()),
+            last_nodes_start_idx: Cell::new(0),
+            last_pods_start_idx: Cell::new(0),
+        }
+    }
+
+    pub fn set_info(&mut self, info: GpuClusterInfo) {
+        self.is_loading = false;
+        self.error = None;
+        if self.selected_node_idx >= info.nodes.len() && !info.nodes.is_empty() {
+            self.selected_node_idx = info.nodes.len() - 1;
+        }
+        self.clamp_pod_selection(&info);
+        self.cluster_info = Some(info);
+    }
+
+    pub fn set_error(&mut self, err: String) {
+        self.is_loading = false;
+        self.error = Some(err);
+    }
+
+    fn clamp_pod_selection(&mut self, info: &GpuClusterInfo) {
+        if let Some(node) = info.nodes.get(self.selected_node_idx) {
+            if self.selected_pod_idx >= node.pods.len() && !node.pods.is_empty() {
+                self.selected_pod_idx = node.pods.len() - 1;
+            } else if node.pods.is_empty() {
+                self.selected_pod_idx = 0;
+            }
+        } else {
+            self.selected_pod_idx = 0;
+        }
+    }
+
+    pub fn selected_node(&self) -> Option<&GpuNodeInfo> {
+        self.cluster_info
+            .as_ref()
+            .and_then(|ci| ci.nodes.get(self.selected_node_idx))
+    }
+
+    pub fn selected_pod(&self) -> Option<&GpuPodItem> {
+        self.selected_node().and_then(|n| n.pods.get(self.selected_pod_idx))
+    }
+
+    pub fn select_next_node(&mut self) {
+        if let Some(ci) = &self.cluster_info {
+            if !ci.nodes.is_empty() && self.selected_node_idx + 1 < ci.nodes.len() {
+                self.selected_node_idx += 1;
+                self.selected_pod_idx = 0;
+            }
+        }
+    }
+
+    pub fn select_prev_node(&mut self) {
+        if self.selected_node_idx > 0 {
+            self.selected_node_idx -= 1;
+            self.selected_pod_idx = 0;
+        }
+    }
+
+    pub fn select_first_node(&mut self) {
+        self.selected_node_idx = 0;
+        self.selected_pod_idx = 0;
+    }
+
+    pub fn select_last_node(&mut self) {
+        if let Some(ci) = &self.cluster_info {
+            if !ci.nodes.is_empty() {
+                self.selected_node_idx = ci.nodes.len() - 1;
+                self.selected_pod_idx = 0;
+            }
+        }
+    }
+
+    pub fn select_next_pod(&mut self) {
+        if let Some(node) = self.selected_node() {
+            if !node.pods.is_empty() && self.selected_pod_idx + 1 < node.pods.len() {
+                self.selected_pod_idx += 1;
+            }
+        }
+    }
+
+    pub fn select_prev_pod(&mut self) {
+        if self.selected_pod_idx > 0 {
+            self.selected_pod_idx -= 1;
+        }
+    }
+
+    pub fn select_first_pod(&mut self) {
+        self.selected_pod_idx = 0;
+    }
+
+    pub fn select_last_pod(&mut self) {
+        if let Some(node) = self.selected_node() {
+            if !node.pods.is_empty() {
+                self.selected_pod_idx = node.pods.len() - 1;
+            }
+        }
+    }
+
+    pub fn toggle_pane(&mut self) {
+        self.focused_pane = match self.focused_pane {
+            GpuPane::Nodes => GpuPane::Pods,
+            GpuPane::Pods => GpuPane::Nodes,
+        };
+    }
+
+    pub fn set_node_by_index(&mut self, idx: usize) {
+        if let Some(ci) = &self.cluster_info {
+            if idx < ci.nodes.len() {
+                self.selected_node_idx = idx;
+                self.selected_pod_idx = 0;
+            }
+        }
+    }
+
+    pub fn set_pod_by_index(&mut self, idx: usize) {
+        if let Some(node) = self.selected_node() {
+            if idx < node.pods.len() {
+                self.selected_pod_idx = idx;
+            }
+        }
+    }
+}
+
+pub fn render(f: &mut Frame, area: Rect, state: &GpuViewState) {
+    // Dynamic width for left pane based on the longest node name
+    let max_node_name_len = state
+        .cluster_info
+        .as_ref()
+        .map(|ci| {
+            ci.nodes
+                .iter()
+                .map(|n| n.name.len())
+                .max()
+                .unwrap_or(18)
+        })
+        .unwrap_or(18)
+        .max("NODE".len());
+
+    // Left pane needs:
+    // border (2) + prefix (1) + node_name (max_node_name_len) + space (1) +
+    // status (10) + gpus (8) + vram (8) = max_node_name_len + 30
+    let needed_left_width = (max_node_name_len + 30) as u16;
+    let left_width = if area.width > 90 {
+        // Reserve at least 48 cols for right details pane if space allows
+        needed_left_width.min(area.width.saturating_sub(48)).max(44)
+    } else {
+        needed_left_width.min(area.width.saturating_sub(30)).max(36)
+    };
+
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Length(left_width), // Left pane: GPU nodes list (dynamically sized)
+            Constraint::Min(40),            // Right pane: Node metrics & GPU Pods
+        ])
+        .split(area);
+
+    state.last_left_pane_rect.set(chunks[0]);
+
+    render_nodes_list(f, chunks[0], state, max_node_name_len);
+    render_details_pane(f, chunks[1], state);
+}
+
+fn render_nodes_list(f: &mut Frame, area: Rect, state: &GpuViewState, max_node_name_len: usize) {
+    let is_focused = state.focused_pane == GpuPane::Nodes;
+    let node_count = state.cluster_info.as_ref().map(|ci| ci.nodes.len()).unwrap_or(0);
+
+    let border_color = if is_focused {
+        Theme::ACCENT
+    } else {
+        Theme::BORDER
+    };
+
+    let title_style = if is_focused {
+        Style::default().fg(Theme::ACCENT).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Theme::fg()).add_modifier(Modifier::BOLD)
+    };
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(border_color))
+        .title(Span::styled(format!(" ⚡ GPU NODES ({}) ", node_count), title_style));
+
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    if state.is_loading {
+        let p = Paragraph::new(vec![
+            Line::from(""),
+            Line::from(Span::styled("  ⚡ Querying cluster GPU nodes...", Style::default().fg(Theme::CYAN))),
+        ]);
+        f.render_widget(p, inner);
+        return;
+    }
+
+    if let Some(err) = &state.error {
+        let p = Paragraph::new(vec![
+            Line::from(""),
+            Line::from(Span::styled(format!("  ✖ Error: {}", err), Style::default().fg(Theme::RED))),
+            Line::from(Span::styled("  Press 'r' to retry.", Style::default().fg(Theme::DIM))),
+        ]);
+        f.render_widget(p, inner);
+        return;
+    }
+
+    let nodes = state.cluster_info.as_ref().map(|ci| &ci.nodes[..]).unwrap_or(&[]);
+    if nodes.is_empty() {
+        let p = Paragraph::new(vec![
+            Line::from(""),
+            Line::from(Span::styled("  ⊘ No GPU nodes detected.", Style::default().fg(Theme::YELLOW))),
+            Line::from(""),
+            Line::from(Span::styled("  No nodes in this cluster report", Style::default().fg(Theme::DIM))),
+            Line::from(Span::styled("  nvidia.com/gpu, amd.com/gpu, or", Style::default().fg(Theme::DIM))),
+            Line::from(Span::styled("  accelerator device labels.", Style::default().fg(Theme::DIM))),
+        ]);
+        f.render_widget(p, inner);
+        return;
+    }
+
+    // Available rows for list items
+    let visible_rows = inner.height.saturating_sub(2) as usize;
+    if visible_rows == 0 {
+        return;
+    }
+
+    let selected = state.selected_node_idx;
+    let mut start_idx = state.last_nodes_start_idx.get();
+    if selected < start_idx {
+        start_idx = selected;
+    } else if selected >= start_idx + visible_rows {
+        start_idx = selected + 1 - visible_rows;
+    }
+    state.last_nodes_start_idx.set(start_idx);
+
+    let mut lines = Vec::new();
+
+    let available_node_col = (inner.width as usize).saturating_sub(28);
+    let node_col_width = max_node_name_len.min(available_node_col).max(12);
+
+    // Header row
+    lines.push(Line::from(vec![
+        Span::styled(format!(" {:<width$} ", "NODE", width = node_col_width), Theme::table_header()),
+        Span::styled(format!("{:<9} ", "STATUS"), Theme::table_header()),
+        Span::styled(format!("{:<7} ", "GPUS"), Theme::table_header()),
+        Span::styled(format!("{:<8}", "VRAM"), Theme::table_header()),
+    ]));
+    lines.push(Line::from(Span::styled("─".repeat(inner.width as usize), Style::default().fg(Theme::BORDER))));
+
+    let end_idx = (start_idx + visible_rows).min(nodes.len());
+    for i in start_idx..end_idx {
+        let node = &nodes[i];
+        let is_sel = i == selected;
+
+        let status_span = if node.unschedulable {
+            Span::styled("⊘ Cordon ", Style::default().fg(Theme::YELLOW))
+        } else if node.status == "Ready" {
+            Span::styled("● Ready  ", Style::default().fg(Theme::GREEN))
+        } else {
+            Span::styled("✖ NotRdy ", Style::default().fg(Theme::RED))
+        };
+
+        let gpus_str = format!("{}/{}", node.gpu_requests, node.gpu_capacity);
+        let vram_str = if let Some(tot) = node.vram_capacity_total_mib {
+            format!("{}/{}G", node.vram_requests_total_mib / 1024, tot / 1024)
+        } else {
+            "-".to_string()
+        };
+
+        let row_style = if is_sel {
+            if is_focused {
+                Style::default().bg(Theme::SEL_BG).fg(Theme::SEL_FG).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().bg(Color::Rgb(30, 41, 59)).fg(Theme::SEL_FG).add_modifier(Modifier::BOLD)
+            }
+        } else {
+            Style::default().fg(Theme::fg())
+        };
+
+        let prefix = if is_sel { ">" } else { " " };
+        let trunc_name = if node.name.len() > node_col_width {
+            format!("{}…", &node.name[..node_col_width.saturating_sub(1)])
+        } else {
+            node.name.clone()
+        };
+
+        lines.push(Line::from(vec![
+            Span::styled(format!("{}{:<width$} ", prefix, trunc_name, width = node_col_width), row_style),
+            status_span,
+            Span::styled(format!(" {:<6} ", gpus_str), row_style),
+            Span::styled(format!("{:<8}", vram_str), row_style),
+        ]));
+    }
+
+    let p = Paragraph::new(lines);
+    f.render_widget(p, inner);
+}
+
+fn render_details_pane(f: &mut Frame, area: Rect, state: &GpuViewState) {
+    let node_opt = state.selected_node();
+    if node_opt.is_none() {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Theme::BORDER))
+            .title(Span::styled(" GPU CONSUMPTION & WORKLOADS ", Style::default().fg(Theme::BORDER)));
+        let inner = block.inner(area);
+        f.render_widget(block, area);
+
+        let p = Paragraph::new(vec![
+            Line::from(""),
+            Line::from(Span::styled("  Select a GPU node on the left to inspect its GPU & VRAM allocation.", Style::default().fg(Theme::DIM))),
+        ]);
+        f.render_widget(p, inner);
+        return;
+    }
+
+    let node = node_opt.unwrap();
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(8), // Top: Node GPU metrics & allocation gauges
+            Constraint::Min(6),    // Bottom: Pods requesting GPU table
+        ])
+        .split(area);
+
+    render_node_gpu_summary(f, chunks[0], node);
+    render_node_pods_table(f, chunks[1], state, node);
+}
+
+fn render_node_gpu_summary(f: &mut Frame, area: Rect, node: &GpuNodeInfo) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Theme::BORDER))
+        .title(Span::styled(
+            format!(" 🖥️  NODE GPU CONSUMPTION: {} ", node.name),
+            Style::default().fg(Theme::ACCENT).add_modifier(Modifier::BOLD),
+        ));
+
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    // Inner layout: Line 1 info, Row 2/3 Gauges, Row 4 summary
+    let inner_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1), // Hardware details
+            Constraint::Length(1), // Spacing
+            Constraint::Length(1), // GPU count gauge
+            Constraint::Length(1), // VRAM gauge
+            Constraint::Length(1), // Summary footer
+            Constraint::Min(0),
+        ])
+        .split(inner);
+
+    // 1. Hardware details line
+    let model = node.gpu_model.as_deref().unwrap_or("Unknown GPU");
+    let driver = node.gpu_driver_version.as_deref().unwrap_or("-");
+    let cuda = node.gpu_cuda_version.as_deref().unwrap_or("-");
+    let itype = &node.instance_type;
+
+    let info_line = Line::from(vec![
+        Span::styled("Model: ", Theme::header_label()),
+        Span::styled(format!("{}  ", model), Theme::header_val()),
+        Span::styled("Driver: ", Theme::header_label()),
+        Span::styled(format!("{}  ", driver), Theme::header_val()),
+        Span::styled("CUDA: ", Theme::header_label()),
+        Span::styled(format!("{}  ", cuda), Theme::header_val()),
+        Span::styled("Instance: ", Theme::header_label()),
+        Span::styled(itype, Theme::header_val()),
+    ]);
+    f.render_widget(Paragraph::new(info_line), inner_chunks[0]);
+
+    // 2. GPU Count Allocation Gauge
+    let gpu_cap = node.gpu_capacity.max(1);
+    let gpu_pct = ((node.gpu_requests as f64 / gpu_cap as f64) * 100.0).round() as u16;
+    let gpu_color = if gpu_pct >= 90 {
+        Theme::RED
+    } else if gpu_pct >= 70 {
+        Theme::YELLOW
+    } else {
+        Theme::GREEN
+    };
+
+    let gpu_gauge_label = format!("GPUs Allocated: {} / {} ({:.0}%)", node.gpu_requests, node.gpu_capacity, gpu_pct);
+    let gpu_gauge = Gauge::default()
+        .gauge_style(Style::default().fg(gpu_color))
+        .label(Span::styled(gpu_gauge_label, Style::default().fg(Theme::SEL_FG).add_modifier(Modifier::BOLD)))
+        .percent(gpu_pct.min(100));
+    f.render_widget(gpu_gauge, inner_chunks[2]);
+
+    // 3. VRAM Allocation Gauge
+    if let Some(tot_vram) = node.vram_capacity_total_mib {
+        let vram_cap = tot_vram.max(1);
+        let vram_pct = ((node.vram_requests_total_mib as f64 / vram_cap as f64) * 100.0).round() as u16;
+        let vram_color = if vram_pct >= 90 {
+            Theme::RED
+        } else if vram_pct >= 70 {
+            Theme::YELLOW
+        } else {
+            Theme::CYAN
+        };
+
+        let vram_gauge_label = format!(
+            "VRAM Allocated: {} / {} ({:.1}%)",
+            format_vram_mib(node.vram_requests_total_mib),
+            format_vram_mib(tot_vram),
+            (node.vram_requests_total_mib as f64 / vram_cap as f64) * 100.0
+        );
+
+        let vram_gauge = Gauge::default()
+            .gauge_style(Style::default().fg(vram_color))
+            .label(Span::styled(vram_gauge_label, Style::default().fg(Theme::SEL_FG).add_modifier(Modifier::BOLD)))
+            .percent(vram_pct.min(100));
+        f.render_widget(vram_gauge, inner_chunks[3]);
+    } else {
+        let vram_label = Line::from(Span::styled(
+            format!("VRAM Requested: {} (Total capacity not reported by node labels)", format_vram_mib(node.vram_requests_total_mib)),
+            Style::default().fg(Theme::YELLOW),
+        ));
+        f.render_widget(Paragraph::new(vram_label), inner_chunks[3]);
+    }
+
+    // 4. Summary footer stats
+    let free_gpus = node.gpu_capacity.saturating_sub(node.gpu_requests);
+    let free_vram_str = if let Some(tot) = node.vram_capacity_total_mib {
+        format_vram_mib(tot.saturating_sub(node.vram_requests_total_mib))
+    } else {
+        "-".to_string()
+    };
+
+    let summary_line = Line::from(vec![
+        Span::styled("Pods on GPU: ", Theme::header_label()),
+        Span::styled(format!("{}   ", node.pods.len()), Theme::header_val()),
+        Span::styled("Available GPUs: ", Theme::header_label()),
+        Span::styled(format!("{}   ", free_gpus), Style::default().fg(Theme::GREEN).add_modifier(Modifier::BOLD)),
+        Span::styled("Available VRAM: ", Theme::header_label()),
+        Span::styled(free_vram_str, Style::default().fg(Theme::CYAN).add_modifier(Modifier::BOLD)),
+    ]);
+    f.render_widget(Paragraph::new(summary_line), inner_chunks[4]);
+}
+
+fn render_node_pods_table(f: &mut Frame, area: Rect, state: &GpuViewState, node: &GpuNodeInfo) {
+    let is_focused = state.focused_pane == GpuPane::Pods;
+    let border_color = if is_focused {
+        Theme::ACCENT
+    } else {
+        Theme::BORDER
+    };
+
+    let title_style = if is_focused {
+        Style::default().fg(Theme::ACCENT).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Theme::fg()).add_modifier(Modifier::BOLD)
+    };
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(border_color))
+        .title(Span::styled(
+            format!(" 📦 PODS ASKING FOR GPU / VRAM ({}) ", node.pods.len()),
+            title_style,
+        ));
+
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    state.last_pods_pane_rect.set(inner);
+
+    if node.pods.is_empty() {
+        let p = Paragraph::new(vec![
+            Line::from(""),
+            Line::from(Span::styled("  ✓ No pods currently requesting GPU on this node.", Style::default().fg(Theme::GREEN))),
+            Line::from(""),
+            Line::from(Span::styled(
+                format!("  All {} GPUs ({}) are free and ready to accept workloads.",
+                    node.gpu_capacity,
+                    node.vram_capacity_total_mib.map(format_vram_mib).unwrap_or_else(|| "-".to_string())
+                ),
+                Style::default().fg(Theme::DIM)
+            )),
+        ]);
+        f.render_widget(p, inner);
+        return;
+    }
+
+    let visible_rows = inner.height.saturating_sub(2) as usize;
+    if visible_rows == 0 {
+        return;
+    }
+
+    let selected = state.selected_pod_idx;
+    let mut start_idx = state.last_pods_start_idx.get();
+    if selected < start_idx {
+        start_idx = selected;
+    } else if selected >= start_idx + visible_rows {
+        start_idx = selected + 1 - visible_rows;
+    }
+    state.last_pods_start_idx.set(start_idx);
+
+    let mut lines = Vec::new();
+
+    let pod_col_width = (inner.width as usize).saturating_sub(74).max(28);
+
+    // Table Header
+    lines.push(Line::from(vec![
+        Span::styled(format!(" {:<15} ", "NAMESPACE"), Theme::table_header()),
+        Span::styled(format!("{:<width$} ", "POD NAME", width = pod_col_width), Theme::table_header()),
+        Span::styled(format!("{:<11} ", "STATUS"), Theme::table_header()),
+        Span::styled(format!("{:<7} ", "GPUS"), Theme::table_header()),
+        Span::styled(format!("{:<12} ", "VRAM REQ"), Theme::table_header()),
+        Span::styled(format!("{:<7} ", "READY"), Theme::table_header()),
+        Span::styled(format!("{:<9} ", "RESTARTS"), Theme::table_header()),
+        Span::styled(format!("{:<6}", "AGE"), Theme::table_header()),
+    ]));
+    lines.push(Line::from(Span::styled("─".repeat(inner.width as usize), Style::default().fg(Theme::BORDER))));
+
+    let end_idx = (start_idx + visible_rows).min(node.pods.len());
+    for i in start_idx..end_idx {
+        let pod = &node.pods[i];
+        let is_sel = i == selected;
+
+        let row_style = if is_sel {
+            if is_focused {
+                Style::default().bg(Theme::SEL_BG).fg(Theme::SEL_FG).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().bg(Color::Rgb(30, 41, 59)).fg(Theme::SEL_FG).add_modifier(Modifier::BOLD)
+            }
+        } else {
+            Style::default().fg(Theme::fg())
+        };
+
+        let status_color = if pod.phase == "Running" {
+            Theme::GREEN
+        } else if pod.phase == "Completed" || pod.phase == "Succeeded" {
+            Theme::CYAN
+        } else {
+            Theme::RED
+        };
+
+        let prefix = if is_sel { ">" } else { " " };
+        let trunc_ns = if pod.namespace.len() > 15 {
+            format!("{}…", &pod.namespace[..14])
+        } else {
+            pod.namespace.clone()
+        };
+
+        let trunc_name = if pod.name.len() > pod_col_width {
+            format!("{}…", &pod.name[..pod_col_width.saturating_sub(1)])
+        } else {
+            pod.name.clone()
+        };
+
+        let vram_str = format_vram_mib(pod.vram_requests_mib);
+
+        lines.push(Line::from(vec![
+            Span::styled(format!("{}{:<15} ", prefix, trunc_ns), row_style),
+            Span::styled(format!("{:<width$} ", trunc_name, width = pod_col_width), row_style),
+            Span::styled(format!("{:<11} ", pod.phase), Style::default().fg(status_color)),
+            Span::styled(format!("{:<7} ", pod.gpu_requests), row_style),
+            Span::styled(format!("{:<12} ", vram_str), Style::default().fg(Theme::CYAN).add_modifier(Modifier::BOLD)),
+            Span::styled(format!("{:<7} ", pod.ready_containers), row_style),
+            Span::styled(format!("{:<9} ", pod.restarts), row_style),
+            Span::styled(format!("{:<6}", pod.age), Style::default().fg(Theme::DIM)),
+        ]));
+    }
+
+    let p = Paragraph::new(lines);
+    f.render_widget(p, inner);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_gpu_view_state_navigation_and_selection() {
+        let mut state = GpuViewState::new();
+        assert!(state.is_loading);
+
+        let pod = GpuPodItem {
+            name: "llama3-70b-0".to_string(),
+            namespace: "ai-gen".to_string(),
+            phase: "Running".to_string(),
+            gpu_requests: 4,
+            vram_requests_mib: 327680,
+            ready_containers: "1/1".to_string(),
+            restarts: 0,
+            age: "5d".to_string(),
+            containers: vec!["engine".to_string()],
+        };
+
+        let node1 = GpuNodeInfo {
+            name: "gpu-node-alpha".to_string(),
+            status: "Ready".to_string(),
+            unschedulable: false,
+            roles: "worker".to_string(),
+            instance_type: "p4de.24xlarge".to_string(),
+            gpu_model: Some("NVIDIA A100 SXM4 80GB".to_string()),
+            gpu_driver_version: Some("535.129.03".to_string()),
+            gpu_cuda_version: Some("12.2".to_string()),
+            gpu_capacity: 8,
+            gpu_allocatable: 8,
+            gpu_requests: 4,
+            vram_per_gpu_mib: Some(81920),
+            vram_capacity_total_mib: Some(655360),
+            vram_requests_total_mib: 327680,
+            pods: vec![pod.clone()],
+        };
+
+        let node2 = GpuNodeInfo {
+            name: "gpu-node-beta".to_string(),
+            status: "Ready".to_string(),
+            unschedulable: false,
+            roles: "worker".to_string(),
+            instance_type: "g4dn.xlarge".to_string(),
+            gpu_model: Some("Tesla T4".to_string()),
+            gpu_driver_version: Some("535.129.03".to_string()),
+            gpu_cuda_version: Some("12.2".to_string()),
+            gpu_capacity: 1,
+            gpu_allocatable: 1,
+            gpu_requests: 0,
+            vram_per_gpu_mib: Some(15360),
+            vram_capacity_total_mib: Some(15360),
+            vram_requests_total_mib: 0,
+            pods: vec![],
+        };
+
+        let info = GpuClusterInfo {
+            nodes: vec![node1, node2],
+            total_gpu_nodes: 2,
+            total_gpus: 9,
+            total_allocated_gpus: 4,
+            total_vram_mib: 670720,
+            total_allocated_vram_mib: 327680,
+            total_gpu_pods: 1,
+        };
+
+        state.set_info(info);
+        assert!(!state.is_loading);
+        assert_eq!(state.selected_node().unwrap().name, "gpu-node-alpha");
+        assert_eq!(state.selected_pod().unwrap().name, "llama3-70b-0");
+
+        // Navigate to next node
+        state.select_next_node();
+        assert_eq!(state.selected_node().unwrap().name, "gpu-node-beta");
+        assert!(state.selected_pod().is_none()); // node2 has 0 pods
+
+        // Navigate back to prev node
+        state.select_prev_node();
+        assert_eq!(state.selected_node().unwrap().name, "gpu-node-alpha");
+        assert_eq!(state.selected_pod().unwrap().name, "llama3-70b-0");
+
+        // Toggle pane focus
+        assert_eq!(state.focused_pane, GpuPane::Nodes);
+        state.toggle_pane();
+        assert_eq!(state.focused_pane, GpuPane::Pods);
+    }
+
+    #[test]
+    fn test_gpu_view_render_dynamic_node_col_width() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let mut state = GpuViewState::new();
+        let long_node_name = "data-processing-stage-gpu-s79cj".to_string();
+        let node = GpuNodeInfo {
+            name: long_node_name.clone(),
+            status: "Ready".to_string(),
+            unschedulable: false,
+            roles: "worker".to_string(),
+            instance_type: "p4de.24xlarge".to_string(),
+            gpu_model: Some("NVIDIA A100 SXM4 80GB".to_string()),
+            gpu_driver_version: Some("535.129.03".to_string()),
+            gpu_cuda_version: Some("12.2".to_string()),
+            gpu_capacity: 8,
+            gpu_allocatable: 8,
+            gpu_requests: 0,
+            vram_per_gpu_mib: Some(81920),
+            vram_capacity_total_mib: Some(655360),
+            vram_requests_total_mib: 0,
+            pods: vec![],
+        };
+
+        let info = GpuClusterInfo {
+            nodes: vec![node],
+            total_gpu_nodes: 1,
+            total_gpus: 8,
+            total_allocated_gpus: 0,
+            total_vram_mib: 655360,
+            total_allocated_vram_mib: 0,
+            total_gpu_pods: 0,
+        };
+        state.set_info(info);
+
+        let backend = TestBackend::new(140, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| render(f, f.area(), &state)).unwrap();
+
+        let buffer = terminal.backend().buffer();
+        let content: String = (0..buffer.area.height)
+            .map(|y| {
+                let mut line = String::new();
+                for x in 0..buffer.area.width {
+                    line.push_str(buffer[(x, y)].symbol());
+                }
+                line
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        // The full long node name must be rendered without being cut/truncated with '…'
+        assert!(content.contains("data-processing-stage-gpu-s79cj"), "Rendered output should contain full node name without truncation");
+        assert!(!content.contains("data-processing-st…"));
+    }
+}

--- a/apps/tui/src/views/gpu_view.rs
+++ b/apps/tui/src/views/gpu_view.rs
@@ -760,4 +760,137 @@ mod tests {
         assert!(content.contains("data-processing-stage-gpu-s79cj"), "Rendered output should contain full node name without truncation");
         assert!(!content.contains("data-processing-st…"));
     }
+
+    #[test]
+    fn test_gpu_view_all_branches_and_pod_navigation() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let mut state = GpuViewState::new();
+        let backend = TestBackend::new(120, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        // 1. Loading state
+        assert!(state.is_loading);
+        terminal.draw(|f| render(f, f.area(), &state)).unwrap();
+
+        // 2. Error state
+        state.set_error("Cannot connect to Kubelet".to_string());
+        assert_eq!(state.error.as_deref(), Some("Cannot connect to Kubelet"));
+        terminal.draw(|f| render(f, f.area(), &state)).unwrap();
+
+        // 3. Empty nodes state
+        let empty_info = GpuClusterInfo {
+            nodes: vec![],
+            total_gpu_nodes: 0,
+            total_gpus: 0,
+            total_allocated_gpus: 0,
+            total_vram_mib: 0,
+            total_allocated_vram_mib: 0,
+            total_gpu_pods: 0,
+        };
+        state.set_info(empty_info);
+        terminal.draw(|f| render(f, f.area(), &state)).unwrap();
+
+        // 4. Populated with diverse node states: Cordoned, NotReady, High GPU/VRAM %, No VRAM info
+        let pod1 = GpuPodItem {
+            name: "vllm-mistral-0".to_string(),
+            namespace: "prod".to_string(),
+            phase: "Running".to_string(),
+            gpu_requests: 4,
+            vram_requests_mib: 32768,
+            ready_containers: "1/1".to_string(),
+            restarts: 0,
+            age: "2d".to_string(),
+            containers: vec!["mistral".to_string()],
+        };
+        let pod2 = GpuPodItem {
+            name: "vllm-mistral-1".to_string(),
+            namespace: "prod".to_string(),
+            phase: "Pending".to_string(),
+            gpu_requests: 4,
+            vram_requests_mib: 0,
+            ready_containers: "0/1".to_string(),
+            restarts: 0,
+            age: "5m".to_string(),
+            containers: vec![],
+        };
+
+        let node_cordon = GpuNodeInfo {
+            name: "gpu-cordon-node".to_string(),
+            status: "Ready".to_string(),
+            unschedulable: true,
+            roles: "worker".to_string(),
+            instance_type: "p3.8xlarge".to_string(),
+            gpu_model: Some("Tesla V100".to_string()),
+            gpu_driver_version: None,
+            gpu_cuda_version: None,
+            gpu_capacity: 4,
+            gpu_allocatable: 4,
+            gpu_requests: 4,
+            vram_per_gpu_mib: Some(16384),
+            vram_capacity_total_mib: Some(65536),
+            vram_requests_total_mib: 60000, // > 90% -> Red
+            pods: vec![pod1.clone(), pod2.clone()],
+        };
+
+        let node_notready = GpuNodeInfo {
+            name: "gpu-notready-node".to_string(),
+            status: "NotReady".to_string(),
+            unschedulable: false,
+            roles: "worker".to_string(),
+            instance_type: "custom".to_string(),
+            gpu_model: None,
+            gpu_driver_version: None,
+            gpu_cuda_version: None,
+            gpu_capacity: 2,
+            gpu_allocatable: 2,
+            gpu_requests: 1,
+            vram_per_gpu_mib: None,
+            vram_capacity_total_mib: None,
+            vram_requests_total_mib: 0,
+            pods: vec![],
+        };
+
+        let populated_info = GpuClusterInfo {
+            nodes: vec![node_cordon, node_notready],
+            total_gpu_nodes: 2,
+            total_gpus: 6,
+            total_allocated_gpus: 5,
+            total_vram_mib: 65536,
+            total_allocated_vram_mib: 60000,
+            total_gpu_pods: 2,
+        };
+
+        state.set_info(populated_info);
+
+        // Test pod selection and navigation
+        assert_eq!(state.selected_pod().unwrap().name, "vllm-mistral-0");
+        state.select_next_pod();
+        assert_eq!(state.selected_pod().unwrap().name, "vllm-mistral-1");
+        state.select_prev_pod();
+        assert_eq!(state.selected_pod().unwrap().name, "vllm-mistral-0");
+        state.select_last_pod();
+        assert_eq!(state.selected_pod().unwrap().name, "vllm-mistral-1");
+        state.select_first_pod();
+        assert_eq!(state.selected_pod().unwrap().name, "vllm-mistral-0");
+        state.set_pod_by_index(1);
+        assert_eq!(state.selected_pod().unwrap().name, "vllm-mistral-1");
+
+        // Test node navigation
+        state.select_first_node();
+        state.select_last_node();
+        assert_eq!(state.selected_node().unwrap().name, "gpu-notready-node");
+        state.set_node_by_index(0);
+        assert_eq!(state.selected_node().unwrap().name, "gpu-cordon-node");
+
+        // Focus Pods pane and render
+        state.focused_pane = GpuPane::Pods;
+        terminal.draw(|f| render(f, f.area(), &state)).unwrap();
+
+        // Render with narrow width to exercise responsive sizing (< 90 width)
+        let narrow_backend = TestBackend::new(80, 25);
+        let mut narrow_terminal = Terminal::new(narrow_backend).unwrap();
+        narrow_terminal.draw(|f| render(f, f.area(), &state)).unwrap();
+    }
 }

--- a/apps/tui/src/views/helm_detail_view.rs
+++ b/apps/tui/src/views/helm_detail_view.rs
@@ -1,0 +1,640 @@
+use ratatui::{
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table, Tabs, Wrap},
+    Frame,
+};
+use srelens_kube::helm::{HelmReleaseDetail, HelmRevision};
+
+use crate::theme::Theme;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HelmDetailTab {
+    Overview = 0,
+    ValuesDiff = 1,
+    Revisions = 2,
+    Manifest = 3,
+    Notes = 4,
+}
+
+impl HelmDetailTab {
+    pub fn title(&self) -> &'static str {
+        match self {
+            Self::Overview => "1: Overview",
+            Self::ValuesDiff => "2: Values Diff",
+            Self::Revisions => "3: Revisions",
+            Self::Manifest => "4: Manifest",
+            Self::Notes => "5: Notes",
+        }
+    }
+
+    pub fn from_index(idx: usize) -> Self {
+        match idx {
+            0 => Self::Overview,
+            1 => Self::ValuesDiff,
+            2 => Self::Revisions,
+            3 => Self::Manifest,
+            4 => Self::Notes,
+            _ => Self::Overview,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValuesDiffMode {
+    CustomVsDefault,
+    RevisionVsPrevious,
+}
+
+#[derive(Debug, Clone)]
+pub enum DiffKind {
+    Same,
+    Add,
+    Remove,
+}
+
+#[derive(Debug, Clone)]
+pub struct DiffLine {
+    pub kind: DiffKind,
+    pub text: String,
+    pub line_num_left: Option<usize>,
+    pub line_num_right: Option<usize>,
+}
+
+pub struct HelmDetailViewState {
+    pub release_name: String,
+    pub namespace: String,
+    pub active_tab: HelmDetailTab,
+    pub is_loading: bool,
+    pub error: Option<String>,
+    pub detail: Option<HelmReleaseDetail>,
+    pub previous_detail: Option<HelmReleaseDetail>,
+    pub selected_revision_idx: usize,
+    pub scroll_offset: usize,
+    pub values_diff_mode: ValuesDiffMode,
+    pub filter_query: String,
+}
+
+impl HelmDetailViewState {
+    pub fn new(name: String, namespace: String) -> Self {
+        Self {
+            release_name: name,
+            namespace,
+            active_tab: HelmDetailTab::Overview,
+            is_loading: true,
+            error: None,
+            detail: None,
+            previous_detail: None,
+            selected_revision_idx: 0,
+            scroll_offset: 0,
+            values_diff_mode: ValuesDiffMode::CustomVsDefault,
+            filter_query: String::new(),
+        }
+    }
+
+    pub fn set_detail(&mut self, detail: HelmReleaseDetail) {
+        self.detail = Some(detail);
+        self.is_loading = false;
+        self.error = None;
+    }
+
+    pub fn set_previous_detail(&mut self, detail: HelmReleaseDetail) {
+        self.previous_detail = Some(detail);
+    }
+
+    pub fn set_error(&mut self, err: String) {
+        self.error = Some(err);
+        self.is_loading = false;
+    }
+
+    pub fn next_tab(&mut self) {
+        let curr = self.active_tab as usize;
+        self.active_tab = HelmDetailTab::from_index((curr + 1) % 5);
+        self.scroll_offset = 0;
+    }
+
+    pub fn prev_tab(&mut self) {
+        let curr = self.active_tab as usize;
+        self.active_tab = HelmDetailTab::from_index(if curr == 0 { 4 } else { curr - 1 });
+        self.scroll_offset = 0;
+    }
+
+    pub fn set_tab(&mut self, tab: HelmDetailTab) {
+        self.active_tab = tab;
+        self.scroll_offset = 0;
+    }
+
+    pub fn toggle_diff_mode(&mut self) {
+        self.values_diff_mode = match self.values_diff_mode {
+            ValuesDiffMode::CustomVsDefault => ValuesDiffMode::RevisionVsPrevious,
+            ValuesDiffMode::RevisionVsPrevious => ValuesDiffMode::CustomVsDefault,
+        };
+        self.scroll_offset = 0;
+    }
+
+    pub fn scroll_down(&mut self, n: usize) {
+        self.scroll_offset += n;
+    }
+
+    pub fn scroll_up(&mut self, n: usize) {
+        self.scroll_offset = self.scroll_offset.saturating_sub(n);
+    }
+
+    pub fn scroll_to_top(&mut self) {
+        self.scroll_offset = 0;
+    }
+
+    pub fn select_next_revision(&mut self) {
+        if let Some(ref d) = self.detail {
+            if !d.history.is_empty() && self.selected_revision_idx + 1 < d.history.len() {
+                self.selected_revision_idx += 1;
+            }
+        }
+    }
+
+    pub fn select_prev_revision(&mut self) {
+        if self.selected_revision_idx > 0 {
+            self.selected_revision_idx -= 1;
+        }
+    }
+
+    pub fn selected_revision(&self) -> Option<&HelmRevision> {
+        let d = self.detail.as_ref()?;
+        d.history.get(self.selected_revision_idx)
+    }
+
+    pub fn compute_values_diff(&self) -> Vec<DiffLine> {
+        let (left, right) = match self.values_diff_mode {
+            ValuesDiffMode::CustomVsDefault => {
+                let default_values = self.detail.as_ref().map(|d| d.chart_values_yaml.as_str()).unwrap_or("");
+                let custom_values = self.detail.as_ref().map(|d| d.values_yaml.as_str()).unwrap_or("");
+                (default_values, custom_values)
+            }
+            ValuesDiffMode::RevisionVsPrevious => {
+                let prev = self.previous_detail.as_ref().map(|d| d.values_yaml.as_str()).unwrap_or("");
+                let curr = self.detail.as_ref().map(|d| d.values_yaml.as_str()).unwrap_or("");
+                (prev, curr)
+            }
+        };
+
+        let diff = similar::TextDiff::from_lines(left, right);
+        let mut lines = Vec::new();
+        let mut left_line = 1;
+        let mut right_line = 1;
+
+        for change in diff.iter_all_changes() {
+            let text = change.value().trim_end_matches('\n').to_string();
+            match change.tag() {
+                similar::ChangeTag::Equal => {
+                    lines.push(DiffLine {
+                        kind: DiffKind::Same,
+                        text,
+                        line_num_left: Some(left_line),
+                        line_num_right: Some(right_line),
+                    });
+                    left_line += 1;
+                    right_line += 1;
+                }
+                similar::ChangeTag::Delete => {
+                    lines.push(DiffLine {
+                        kind: DiffKind::Remove,
+                        text,
+                        line_num_left: Some(left_line),
+                        line_num_right: None,
+                    });
+                    left_line += 1;
+                }
+                similar::ChangeTag::Insert => {
+                    lines.push(DiffLine {
+                        kind: DiffKind::Add,
+                        text,
+                        line_num_left: None,
+                        line_num_right: Some(right_line),
+                    });
+                    right_line += 1;
+                }
+            }
+        }
+        lines
+    }
+
+    pub fn parse_manifest_resource_counts(&self) -> Vec<(String, usize)> {
+        let Some(ref d) = self.detail else { return Vec::new() };
+        let mut map: std::collections::BTreeMap<String, usize> = std::collections::BTreeMap::new();
+        for doc in d.manifest.split("---") {
+            for line in doc.lines() {
+                let trimmed = line.trim();
+                if let Some(rest) = trimmed.strip_prefix("kind:") {
+                    let k = rest.trim().to_string();
+                    if !k.is_empty() {
+                        *map.entry(k).or_insert(0) += 1;
+                    }
+                    break;
+                }
+            }
+        }
+        map.into_iter().collect()
+    }
+}
+
+pub fn render_helm_detail_view(f: &mut Frame, area: Rect, state: &HelmDetailViewState) {
+    let main_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // Tab navigation bar
+            Constraint::Min(10),   // Active tab contents
+            Constraint::Length(1), // Bottom hints
+        ])
+        .split(area);
+
+    render_tab_strip(f, main_chunks[0], state);
+
+    if state.is_loading {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(Theme::border_type())
+            .border_style(Style::default().fg(Theme::border()));
+        let inner = block.inner(main_chunks[1]);
+        f.render_widget(block, main_chunks[1]);
+        let msg = Paragraph::new(format!("⟳ Loading Helm release details for '{}/{}'...", state.namespace, state.release_name))
+            .style(Style::default().fg(Theme::cyan()));
+        f.render_widget(msg, inner);
+        return;
+    }
+
+    if let Some(ref err) = state.error {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(Theme::border_type())
+            .border_style(Style::default().fg(Theme::border()));
+        let inner = block.inner(main_chunks[1]);
+        f.render_widget(block, main_chunks[1]);
+        let msg = Paragraph::new(format!("⚠ Failed to load release: {}", err))
+            .style(Style::default().fg(Theme::red()));
+        f.render_widget(msg, inner);
+        return;
+    }
+
+    match state.active_tab {
+        HelmDetailTab::Overview => render_overview_tab(f, main_chunks[1], state),
+        HelmDetailTab::ValuesDiff => render_values_diff_tab(f, main_chunks[1], state),
+        HelmDetailTab::Revisions => render_revisions_tab(f, main_chunks[1], state),
+        HelmDetailTab::Manifest => render_manifest_tab(f, main_chunks[1], state),
+        HelmDetailTab::Notes => render_notes_tab(f, main_chunks[1], state),
+    }
+
+    render_bottom_hints(f, main_chunks[2], state);
+}
+
+fn render_tab_strip(f: &mut Frame, area: Rect, state: &HelmDetailViewState) {
+    let rev_str = state.detail.as_ref().map(|d| format!("v{}", d.revision)).unwrap_or_default();
+    let status_str = state.detail.as_ref().map(|d| d.status.as_str()).unwrap_or("loading");
+    let title = format!(" ⎈ Helm Release: {}/{} [{}] ({}) ", state.namespace, state.release_name, rev_str, status_str);
+
+    let titles: Vec<Line> = [
+        HelmDetailTab::Overview,
+        HelmDetailTab::ValuesDiff,
+        HelmDetailTab::Revisions,
+        HelmDetailTab::Manifest,
+        HelmDetailTab::Notes,
+    ]
+    .iter()
+    .map(|tab| {
+        let is_selected = *tab == state.active_tab;
+        let style = if is_selected {
+            Style::default().fg(Theme::accent()).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(Theme::dim())
+        };
+        Line::from(vec![Span::styled(format!(" {} ", tab.title()), style)])
+    })
+    .collect();
+
+    let tabs = Tabs::new(titles)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_type(Theme::border_type())
+                .border_style(Style::default().fg(Theme::border()))
+                .title(Span::styled(title, Theme::title())),
+        )
+        .highlight_style(
+            Style::default()
+                .fg(Theme::sel_fg())
+                .bg(Theme::sel_bg())
+                .add_modifier(Modifier::BOLD),
+        )
+        .select(state.active_tab as usize);
+
+    f.render_widget(tabs, area);
+}
+
+fn render_overview_tab(f: &mut Frame, area: Rect, state: &HelmDetailViewState) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(Theme::border_type())
+        .border_style(Style::default().fg(Theme::border()))
+        .title(Span::styled(" Release Overview & Topology Breakdown ", Theme::title()));
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let Some(ref d) = state.detail else { return };
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(8), // Release details table/cards
+            Constraint::Length(1), // Separator
+            Constraint::Min(6),   // Rendered Kubernetes resources
+        ])
+        .split(inner);
+
+    let status_style = if d.status == "deployed" {
+        Theme::status_ok()
+    } else if d.status.contains("fail") {
+        Theme::status_error()
+    } else {
+        Theme::status_warn()
+    };
+
+    let meta_lines = vec![
+        Line::from(vec![
+            Span::styled("  Release Name  : ", Style::default().fg(Theme::dim())),
+            Span::styled(&d.name, Style::default().fg(Theme::fg()).add_modifier(Modifier::BOLD)),
+            Span::raw("    "),
+            Span::styled("Namespace     : ", Style::default().fg(Theme::dim())),
+            Span::styled(&d.namespace, Style::default().fg(Theme::cyan())),
+        ]),
+        Line::from(vec![
+            Span::styled("  Status        : ", Style::default().fg(Theme::dim())),
+            Span::styled(&d.status, status_style.add_modifier(Modifier::BOLD)),
+            Span::raw("        "),
+            Span::styled("Revision      : ", Style::default().fg(Theme::dim())),
+            Span::styled(format!("{} (latest)", d.revision), Style::default().fg(Theme::fg())),
+        ]),
+        Line::from(vec![
+            Span::styled("  Chart         : ", Style::default().fg(Theme::dim())),
+            Span::styled(format!("{}-{}", d.chart, d.chart_version), Style::default().fg(Theme::accent())),
+            Span::raw("    "),
+            Span::styled("App Version   : ", Style::default().fg(Theme::dim())),
+            Span::styled(&d.app_version, Style::default().fg(Theme::fg())),
+        ]),
+        Line::from(vec![
+            Span::styled("  Last Updated  : ", Style::default().fg(Theme::dim())),
+            Span::styled(&d.updated, Style::default().fg(Theme::dim())),
+        ]),
+        Line::from(vec![
+            Span::styled("  Revisions     : ", Style::default().fg(Theme::dim())),
+            Span::styled(format!("{} revisions recorded in history", d.history.len()), Style::default().fg(Theme::dim())),
+        ]),
+    ];
+
+    let meta_para = Paragraph::new(meta_lines);
+    f.render_widget(meta_para, chunks[0]);
+
+    // Resource breakdown from manifest
+    let res_counts = state.parse_manifest_resource_counts();
+    let mut count_lines = Vec::new();
+    count_lines.push(Line::from(vec![
+        Span::styled("  Kubernetes Resources in Manifest:", Style::default().fg(Theme::accent()).add_modifier(Modifier::BOLD)),
+    ]));
+    count_lines.push(Line::from(""));
+
+    if res_counts.is_empty() {
+        count_lines.push(Line::from(vec![
+            Span::styled("    (No resources detected in rendered manifest)", Style::default().fg(Theme::dim())),
+        ]));
+    } else {
+        for (kind, count) in res_counts {
+            count_lines.push(Line::from(vec![
+                Span::styled(format!("    • {:<20} : ", kind), Style::default().fg(Theme::fg())),
+                Span::styled(format!("{}", count), Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)),
+            ]));
+        }
+    }
+
+    let res_para = Paragraph::new(count_lines);
+    f.render_widget(res_para, chunks[2]);
+}
+
+fn render_values_diff_tab(f: &mut Frame, area: Rect, state: &HelmDetailViewState) {
+    let mode_desc = match state.values_diff_mode {
+        ValuesDiffMode::CustomVsDefault => "[Mode: Custom Overrides (helm get values) vs Chart Defaults]",
+        ValuesDiffMode::RevisionVsPrevious => "[Mode: Current Revision vs Previous Revision Values]",
+    };
+
+    let title = format!(" Values Diff {} (Press <m> to toggle mode) ", mode_desc);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(Theme::border_type())
+        .border_style(Style::default().fg(Theme::border()))
+        .title(Span::styled(title, Theme::title()));
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let diff_lines = state.compute_values_diff();
+    if diff_lines.is_empty() {
+        let msg = Paragraph::new("No values diff detected (values identical or empty).")
+            .style(Style::default().fg(Theme::dim()));
+        f.render_widget(msg, inner);
+        return;
+    }
+
+    let viewport_height = inner.height as usize;
+    let visible_lines: Vec<Line> = diff_lines
+        .iter()
+        .skip(state.scroll_offset)
+        .take(viewport_height)
+        .map(|dl| {
+            let (prefix, style) = match dl.kind {
+                DiffKind::Same => ("   ", Style::default().fg(Theme::dim())),
+                DiffKind::Add => (" + ", Style::default().fg(Theme::green())),
+                DiffKind::Remove => (" - ", Style::default().fg(Theme::red())),
+            };
+
+            let left_str = dl.line_num_left.map(|n| format!("{:>4}", n)).unwrap_or_else(|| "    ".to_string());
+            let right_str = dl.line_num_right.map(|n| format!("{:>4}", n)).unwrap_or_else(|| "    ".to_string());
+
+            Line::from(vec![
+                Span::styled(format!("{} {} ", left_str, right_str), Style::default().fg(Theme::dim())),
+                Span::styled(prefix, style.add_modifier(Modifier::BOLD)),
+                Span::styled(&dl.text, style),
+            ])
+        })
+        .collect();
+
+    let para = Paragraph::new(visible_lines);
+    f.render_widget(para, inner);
+}
+
+fn render_revisions_tab(f: &mut Frame, area: Rect, state: &HelmDetailViewState) {
+    let title = " Revision History (<j/k> Select  <r> Rollback to Revision N  <v>/<Enter> Inspect Revision) ";
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(Theme::border_type())
+        .border_style(Style::default().fg(Theme::border()))
+        .title(Span::styled(title, Theme::title()));
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let Some(ref d) = state.detail else { return };
+    if d.history.is_empty() {
+        let msg = Paragraph::new("No revision history available.").style(Style::default().fg(Theme::dim()));
+        f.render_widget(msg, inner);
+        return;
+    }
+
+    let headers = Row::new(vec![
+        Cell::from("REV").style(Theme::table_header()),
+        Cell::from("STATUS").style(Theme::table_header()),
+        Cell::from("UPDATED").style(Theme::table_header()),
+        Cell::from("CHART VERSION").style(Theme::table_header()),
+        Cell::from("DESCRIPTION").style(Theme::table_header()),
+    ])
+    .height(1)
+    .bottom_margin(1);
+
+    let rows: Vec<Row> = d
+        .history
+        .iter()
+        .enumerate()
+        .map(|(i, rev)| {
+            let is_selected = i == state.selected_revision_idx;
+            let status_style = if rev.status == "deployed" {
+                Theme::status_ok()
+            } else if rev.status.contains("fail") {
+                Theme::status_error()
+            } else {
+                Theme::status_warn()
+            };
+
+            let row_style = if is_selected {
+                Theme::selected_row()
+            } else {
+                Style::default()
+            };
+
+            let is_current = rev.revision == d.revision;
+            let rev_display = if is_current {
+                format!("{} (current)", rev.revision)
+            } else {
+                rev.revision.to_string()
+            };
+
+            Row::new(vec![
+                Cell::from(rev_display),
+                Cell::from(rev.status.as_str()).style(status_style),
+                Cell::from(rev.updated.as_str()),
+                Cell::from(rev.chart_version.as_str()),
+                Cell::from(rev.description.as_str()),
+            ])
+            .style(row_style)
+        })
+        .collect();
+
+    let widths = [
+        Constraint::Length(16),
+        Constraint::Length(14),
+        Constraint::Length(25),
+        Constraint::Length(20),
+        Constraint::Min(30),
+    ];
+
+    let table = Table::new(rows, widths).header(headers);
+    f.render_widget(table, inner);
+}
+
+fn render_manifest_tab(f: &mut Frame, area: Rect, state: &HelmDetailViewState) {
+    let title = " Rendered Kubernetes Manifests (YAML) (<c> Copy  </> Search) ";
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(Theme::border_type())
+        .border_style(Style::default().fg(Theme::border()))
+        .title(Span::styled(title, Theme::title()));
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let Some(ref d) = state.detail else { return };
+    if d.manifest.is_empty() {
+        let msg = Paragraph::new("Manifest is empty.").style(Style::default().fg(Theme::dim()));
+        f.render_widget(msg, inner);
+        return;
+    }
+
+    let viewport_height = inner.height as usize;
+    let lines: Vec<Line> = d
+        .manifest
+        .lines()
+        .skip(state.scroll_offset)
+        .take(viewport_height)
+        .enumerate()
+        .map(|(i, l)| {
+            let line_idx = state.scroll_offset + i + 1;
+            let style = if l.starts_with("kind:") || l.starts_with("apiVersion:") {
+                Style::default().fg(Theme::accent()).add_modifier(Modifier::BOLD)
+            } else if l.starts_with("---") {
+                Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)
+            } else if l.trim_start().starts_with('#') {
+                Style::default().fg(Theme::dim())
+            } else if l.contains(':') {
+                Style::default().fg(Theme::fg())
+            } else {
+                Style::default().fg(Theme::dim())
+            };
+
+            Line::from(vec![
+                Span::styled(format!("{:>5} │ ", line_idx), Style::default().fg(Theme::dim())),
+                Span::styled(l, style),
+            ])
+        })
+        .collect();
+
+    let para = Paragraph::new(lines);
+    f.render_widget(para, inner);
+}
+
+fn render_notes_tab(f: &mut Frame, area: Rect, state: &HelmDetailViewState) {
+    let title = " Chart Release Notes (NOTES.txt) ";
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(Theme::border_type())
+        .border_style(Style::default().fg(Theme::border()))
+        .title(Span::styled(title, Theme::title()));
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let Some(ref d) = state.detail else { return };
+    if d.notes.is_empty() {
+        let msg = Paragraph::new("No release notes (NOTES.txt) provided by chart.")
+            .style(Style::default().fg(Theme::dim()));
+        f.render_widget(msg, inner);
+        return;
+    }
+
+    let viewport_height = inner.height as usize;
+    let lines: Vec<Line> = d
+        .notes
+        .lines()
+        .skip(state.scroll_offset)
+        .take(viewport_height)
+        .map(|l| Line::from(Span::styled(l, Style::default().fg(Theme::fg()))))
+        .collect();
+
+    let para = Paragraph::new(lines);
+    f.render_widget(para, inner);
+}
+
+fn render_bottom_hints(f: &mut Frame, area: Rect, state: &HelmDetailViewState) {
+    let hints = match state.active_tab {
+        HelmDetailTab::Overview => "<Tab> Switch Tab  <1-5> Jump Tab  <Esc> Back to Releases",
+        HelmDetailTab::ValuesDiff => "<Tab> Switch Tab  <m> Toggle Diff Mode  <j/k> Scroll  <g/G> Top/Bottom  <Esc> Back",
+        HelmDetailTab::Revisions => "<Tab> Switch Tab  <j/k> Select Rev  <r> Rollback to Selected  <Enter>/<v> View  <Esc> Back",
+        HelmDetailTab::Manifest => "<Tab> Switch Tab  <j/k> Scroll  <c> Copy  </> Search  <Esc> Back",
+        HelmDetailTab::Notes => "<Tab> Switch Tab  <j/k> Scroll  <c> Copy  <Esc> Back",
+    };
+
+    let p = Paragraph::new(format!(" {}", hints))
+        .style(Style::default().fg(Theme::dim()));
+    f.render_widget(p, area);
+}

--- a/apps/tui/src/views/helm_detail_view.rs
+++ b/apps/tui/src/views/helm_detail_view.rs
@@ -43,6 +43,7 @@ impl HelmDetailTab {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ValuesDiffMode {
+    CustomVsComputed,
     CustomVsDefault,
     RevisionVsPrevious,
 }
@@ -88,7 +89,7 @@ impl HelmDetailViewState {
             previous_detail: None,
             selected_revision_idx: 0,
             scroll_offset: 0,
-            values_diff_mode: ValuesDiffMode::CustomVsDefault,
+            values_diff_mode: ValuesDiffMode::CustomVsComputed,
             filter_query: String::new(),
         }
     }
@@ -127,8 +128,9 @@ impl HelmDetailViewState {
 
     pub fn toggle_diff_mode(&mut self) {
         self.values_diff_mode = match self.values_diff_mode {
+            ValuesDiffMode::CustomVsComputed => ValuesDiffMode::CustomVsDefault,
             ValuesDiffMode::CustomVsDefault => ValuesDiffMode::RevisionVsPrevious,
-            ValuesDiffMode::RevisionVsPrevious => ValuesDiffMode::CustomVsDefault,
+            ValuesDiffMode::RevisionVsPrevious => ValuesDiffMode::CustomVsComputed,
         };
         self.scroll_offset = 0;
     }
@@ -166,6 +168,11 @@ impl HelmDetailViewState {
 
     pub fn compute_values_diff(&self) -> Vec<DiffLine> {
         let (left, right) = match self.values_diff_mode {
+            ValuesDiffMode::CustomVsComputed => {
+                let custom_values = self.detail.as_ref().map(|d| d.values_yaml.as_str()).unwrap_or("");
+                let computed_values = self.detail.as_ref().map(|d| d.computed_values_yaml.as_str()).unwrap_or("");
+                (custom_values, computed_values)
+            }
             ValuesDiffMode::CustomVsDefault => {
                 let default_values = self.detail.as_ref().map(|d| d.chart_values_yaml.as_str()).unwrap_or("");
                 let custom_values = self.detail.as_ref().map(|d| d.values_yaml.as_str()).unwrap_or("");
@@ -420,7 +427,8 @@ fn render_overview_tab(f: &mut Frame, area: Rect, state: &HelmDetailViewState) {
 
 fn render_values_diff_tab(f: &mut Frame, area: Rect, state: &HelmDetailViewState) {
     let mode_desc = match state.values_diff_mode {
-        ValuesDiffMode::CustomVsDefault => "[Mode: Custom Overrides (helm get values) vs Chart Defaults]",
+        ValuesDiffMode::CustomVsComputed => "[Mode: User Values (helm get values) vs Computed Values (helm get values --all)]",
+        ValuesDiffMode::CustomVsDefault => "[Mode: User Values vs Chart Defaults]",
         ValuesDiffMode::RevisionVsPrevious => "[Mode: Current Revision vs Previous Revision Values]",
     };
 

--- a/apps/tui/src/views/helm_view.rs
+++ b/apps/tui/src/views/helm_view.rs
@@ -16,14 +16,33 @@ pub struct HelmReleaseItem {
     pub revision: i64,
     pub status: String,
     pub chart: String,
+    pub chart_version: String,
     #[serde(rename = "appVersion")]
     pub app_version: String,
     pub updated: String,
 }
 
+impl From<srelens_kube::helm::HelmReleaseSummary> for HelmReleaseItem {
+    fn from(s: srelens_kube::helm::HelmReleaseSummary) -> Self {
+        Self {
+            name: s.name,
+            namespace: s.namespace,
+            revision: s.revision,
+            status: s.status,
+            chart: s.chart,
+            chart_version: s.chart_version,
+            app_version: s.app_version,
+            updated: s.updated,
+        }
+    }
+}
+
 pub struct HelmViewState {
     pub releases: Vec<HelmReleaseItem>,
     pub selected_idx: usize,
+    pub is_loading: bool,
+    pub error: Option<String>,
+    pub filter_query: String,
 }
 
 impl HelmViewState {
@@ -31,18 +50,48 @@ impl HelmViewState {
         Self {
             releases: Vec::new(),
             selected_idx: 0,
+            is_loading: true,
+            error: None,
+            filter_query: String::new(),
         }
     }
 
     pub fn set_releases(&mut self, releases: Vec<HelmReleaseItem>) {
         self.releases = releases;
-        if self.selected_idx >= self.releases.len() {
-            self.selected_idx = self.releases.len().saturating_sub(1);
+        self.is_loading = false;
+        self.error = None;
+        let count = self.filtered_indices().len();
+        if self.selected_idx >= count {
+            self.selected_idx = count.saturating_sub(1);
         }
     }
 
+    pub fn set_error(&mut self, err: String) {
+        self.error = Some(err);
+        self.is_loading = false;
+    }
+
+    pub fn filtered_indices(&self) -> Vec<usize> {
+        if self.filter_query.is_empty() {
+            return (0..self.releases.len()).collect();
+        }
+        let q = self.filter_query.to_lowercase();
+        self.releases
+            .iter()
+            .enumerate()
+            .filter(|(_, r)| {
+                r.name.to_lowercase().contains(&q)
+                    || r.namespace.to_lowercase().contains(&q)
+                    || r.chart.to_lowercase().contains(&q)
+                    || r.status.to_lowercase().contains(&q)
+            })
+            .map(|(i, _)| i)
+            .collect()
+    }
+
     pub fn select_next(&mut self) {
-        if !self.releases.is_empty() && self.selected_idx + 1 < self.releases.len() {
+        let indices = self.filtered_indices();
+        if !indices.is_empty() && self.selected_idx + 1 < indices.len() {
             self.selected_idx += 1;
         }
     }
@@ -54,26 +103,58 @@ impl HelmViewState {
     }
 
     pub fn selected_release(&self) -> Option<&HelmReleaseItem> {
-        self.releases.get(self.selected_idx)
+        let indices = self.filtered_indices();
+        let idx = *indices.get(self.selected_idx)?;
+        self.releases.get(idx)
     }
 }
 
 pub fn render_helm_view(f: &mut Frame, area: Rect, state: &HelmViewState) {
-    let title = format!(" Helm 3 Releases [{}] (<v> Values <y> Manifest <d> History <ctrl-d> Uninstall <Esc> Back) ", state.releases.len());
+    let filtered = state.filtered_indices();
+    let count_text = if state.filter_query.is_empty() {
+        format!("{}", state.releases.len())
+    } else {
+        format!("{}/{}", filtered.len(), state.releases.len())
+    };
+
+    let title = format!(
+        " ⎈ Helm 3 Releases [{}] (<Enter> Deep Inspector  <v> Values  <y> Manifest  <d> History  <r> Rollback  <ctrl-d> Uninstall  <Esc> Back) ",
+        count_text
+    );
 
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Theme::BORDER))
+        .border_type(Theme::border_type())
+        .border_style(Style::default().fg(Theme::border()))
         .title(Span::styled(title, Theme::title()));
 
     let inner = block.inner(area);
     f.render_widget(block, area);
 
+    if state.is_loading {
+        let loading_msg = Paragraph::new("⟳ Loading Helm releases from cluster...")
+            .style(Style::default().fg(Theme::cyan()));
+        f.render_widget(loading_msg, inner);
+        return;
+    }
+
+    if let Some(ref err) = state.error {
+        let error_msg = Paragraph::new(format!("⚠ Failed to load Helm releases: {}", err))
+            .style(Style::default().fg(Theme::red()));
+        f.render_widget(error_msg, inner);
+        return;
+    }
+
     if state.releases.is_empty() {
-        let empty_msg = Paragraph::new(
-            "No Helm releases found in current namespace.",
-        )
-        .style(Style::default().fg(Theme::DIM));
+        let empty_msg = Paragraph::new("No Helm releases found in current namespace.")
+            .style(Style::default().fg(Theme::dim()));
+        f.render_widget(empty_msg, inner);
+        return;
+    }
+
+    if filtered.is_empty() {
+        let empty_msg = Paragraph::new(format!("No releases matching filter '{}'", state.filter_query))
+            .style(Style::default().fg(Theme::dim()));
         f.render_widget(empty_msg, inner);
         return;
     }
@@ -90,12 +171,12 @@ pub fn render_helm_view(f: &mut Frame, area: Rect, state: &HelmViewState) {
     .height(1)
     .bottom_margin(1);
 
-    let rows: Vec<Row> = state
-        .releases
+    let rows: Vec<Row> = filtered
         .iter()
         .enumerate()
-        .map(|(i, rel)| {
-            let is_selected = i == state.selected_idx;
+        .map(|(display_idx, &real_idx)| {
+            let rel = &state.releases[real_idx];
+            let is_selected = display_idx == state.selected_idx;
             let status_style = if rel.status == "deployed" {
                 Theme::status_ok()
             } else if rel.status.contains("fail") {
@@ -110,12 +191,18 @@ pub fn render_helm_view(f: &mut Frame, area: Rect, state: &HelmViewState) {
                 Style::default()
             };
 
+            let chart_display = if rel.chart_version.is_empty() {
+                rel.chart.clone()
+            } else {
+                format!("{}-{}", rel.chart, rel.chart_version)
+            };
+
             Row::new(vec![
                 Cell::from(rel.namespace.as_str()),
                 Cell::from(rel.name.as_str()),
                 Cell::from(rel.revision.to_string()),
                 Cell::from(rel.status.as_str()).style(status_style),
-                Cell::from(rel.chart.as_str()),
+                Cell::from(chart_display),
                 Cell::from(rel.app_version.as_str()),
                 Cell::from(rel.updated.as_str()),
             ])
@@ -125,10 +212,10 @@ pub fn render_helm_view(f: &mut Frame, area: Rect, state: &HelmViewState) {
 
     let widths = [
         Constraint::Length(18),
-        Constraint::Min(25),
+        Constraint::Min(24),
         Constraint::Length(10),
         Constraint::Length(14),
-        Constraint::Length(25),
+        Constraint::Length(26),
         Constraint::Length(15),
         Constraint::Length(25),
     ];

--- a/apps/tui/src/views/logs_view.rs
+++ b/apps/tui/src/views/logs_view.rs
@@ -8,12 +8,21 @@ use ratatui::{
 
 use crate::theme::Theme;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LogEntry {
+    pub source: Option<String>,
+    pub line: String,
+}
+
 pub struct LogsViewState {
     pub pod_name: String,
     pub namespace: String,
     pub container: Option<String>,
     pub channel: String,
     pub lines: Vec<String>,
+    pub entries: Vec<LogEntry>,
+    pub is_multi_pod: bool,
+    pub known_sources: Vec<String>,
     pub scroll_offset: usize,
     pub follow: bool,
     pub timestamps: bool,
@@ -32,6 +41,30 @@ impl LogsViewState {
             container,
             channel,
             lines: Vec::new(),
+            entries: Vec::new(),
+            is_multi_pod: false,
+            known_sources: Vec::new(),
+            scroll_offset: 0,
+            follow: true,
+            timestamps: false,
+            previous: false,
+            wrap: false,
+            search_query: String::new(),
+            search_matches: Vec::new(),
+            current_match_idx: None,
+        }
+    }
+
+    pub fn new_multi_pod(target_name: String, namespace: String, pod_names: Vec<String>, channel: String) -> Self {
+        Self {
+            pod_name: target_name,
+            namespace,
+            container: None,
+            channel,
+            lines: Vec::new(),
+            entries: Vec::new(),
+            is_multi_pod: true,
+            known_sources: pod_names,
             scroll_offset: 0,
             follow: true,
             timestamps: false,
@@ -101,7 +134,18 @@ impl LogsViewState {
     }
 
     pub fn push_line(&mut self, line: String) {
-        self.lines.push(sanitize_log_line(&line));
+        self.push_entry(None, line);
+    }
+
+    pub fn push_entry(&mut self, source: Option<String>, line: String) {
+        let clean = sanitize_log_line(&line);
+        if let Some(src) = &source {
+            if !src.is_empty() && !self.known_sources.contains(src) {
+                self.known_sources.push(src.clone());
+            }
+        }
+        self.lines.push(clean.clone());
+        self.entries.push(LogEntry { source, line: clean });
         if self.follow {
             self.scroll_to_bottom();
         }
@@ -152,9 +196,44 @@ impl LogsViewState {
     pub fn save_to_file(&self) -> Result<String, String> {
         let filename = format!("{}-{}-logs.txt", self.pod_name, chrono_timestamp());
         let path = std::env::temp_dir().join(&filename);
-        std::fs::write(&path, self.lines.join("\n")).map_err(|e| e.to_string())?;
+        let content = if self.is_multi_pod {
+            self.entries
+                .iter()
+                .map(|e| {
+                    if let Some(src) = &e.source {
+                        format!("[{}] {}", src, e.line)
+                    } else {
+                        e.line.clone()
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        } else {
+            self.lines.join("\n")
+        };
+        std::fs::write(&path, content).map_err(|e| e.to_string())?;
         Ok(path.to_string_lossy().into_owned())
     }
+}
+
+const SOURCE_COLORS: &[Color] = &[
+    Color::Rgb(6, 182, 212),    // Cyan
+    Color::Rgb(217, 70, 239),   // Magenta
+    Color::Rgb(34, 197, 94),    // Green
+    Color::Rgb(234, 179, 8),    // Yellow
+    Color::Rgb(59, 130, 246),   // Blue
+    Color::Rgb(249, 115, 22),   // Orange
+    Color::Rgb(168, 85, 247),   // Purple
+    Color::Rgb(20, 184, 166),   // Teal
+    Color::Rgb(244, 63, 94),    // Rose
+];
+
+pub fn source_color(source: &str) -> Color {
+    let mut hash: usize = 0;
+    for b in source.bytes() {
+        hash = hash.wrapping_mul(31).wrapping_add(b as usize);
+    }
+    SOURCE_COLORS[hash % SOURCE_COLORS.len()]
 }
 
 /// Shared sanitizer for cluster-controlled Span text; see
@@ -194,16 +273,37 @@ pub fn render_logs_view(f: &mut Frame, area: Rect, state: &LogsViewState) {
         String::new()
     };
 
-    let title = format!(
-        " Logs: {} ({}/{}) {} [{}/{} lines]{} (<f> Follow <t> Time <p> Prev <w> Wrap <s> Save <Esc> Back) ",
-        state.pod_name,
-        state.namespace,
-        container_str,
-        flags_str,
-        state.scroll_offset + 1,
-        state.lines.len(),
-        search_badge,
-    );
+    let total_lines = if state.is_multi_pod {
+        state.entries.len()
+    } else {
+        state.lines.len()
+    };
+
+    let title = if state.is_multi_pod {
+        let pod_count = state.known_sources.len();
+        format!(
+            " Logs: {} ({} pod{} in {}) {} [{}/{} lines]{} (<f> Follow <t> Time <p> Prev <w> Wrap <s> Save <Esc> Back) ",
+            state.pod_name,
+            pod_count,
+            if pod_count == 1 { "" } else { "s" },
+            state.namespace,
+            flags_str,
+            state.scroll_offset + 1,
+            total_lines,
+            search_badge,
+        )
+    } else {
+        format!(
+            " Logs: {} ({}/{}) {} [{}/{} lines]{} (<f> Follow <t> Time <p> Prev <w> Wrap <s> Save <Esc> Back) ",
+            state.pod_name,
+            state.namespace,
+            container_str,
+            flags_str,
+            state.scroll_offset + 1,
+            total_lines,
+            search_badge,
+        )
+    };
 
     let block = Block::default()
         .borders(Borders::ALL)
@@ -213,7 +313,7 @@ pub fn render_logs_view(f: &mut Frame, area: Rect, state: &LogsViewState) {
     let inner = block.inner(area);
     f.render_widget(block, area);
 
-    if state.lines.is_empty() {
+    if total_lines == 0 {
         let msg = Paragraph::new(Line::from(vec![
             Span::styled("Waiting for logs...", Style::default().fg(Theme::DIM)),
         ]));
@@ -223,11 +323,11 @@ pub fn render_logs_view(f: &mut Frame, area: Rect, state: &LogsViewState) {
 
     let visible_lines = inner.height as usize;
     let start_idx = if state.follow {
-        state.lines.len().saturating_sub(visible_lines)
+        total_lines.saturating_sub(visible_lines)
     } else {
         state.scroll_offset
     };
-    let end_idx = (start_idx + visible_lines).min(state.lines.len());
+    let end_idx = (start_idx + visible_lines).min(total_lines);
 
     let match_style = Style::default()
         .bg(Theme::YELLOW)
@@ -236,37 +336,81 @@ pub fn render_logs_view(f: &mut Frame, area: Rect, state: &LogsViewState) {
 
     let mut rendered_lines = Vec::new();
 
-    for (i, line) in state.lines.iter().enumerate().take(end_idx).skip(start_idx) {
-        let line_num = Span::styled(
-            format!("{:5} │ ", i + 1),
-            Style::default().fg(Theme::DIM),
-        );
+    if state.is_multi_pod {
+        for (i, entry) in state.entries.iter().enumerate().take(end_idx).skip(start_idx) {
+            let line_num = Span::styled(
+                format!("{:5} │ ", i + 1),
+                Style::default().fg(Theme::DIM),
+            );
 
-        let mut spans = vec![line_num];
+            let mut spans = vec![line_num];
 
-        let has_match = !state.search_query.is_empty()
-            && line.to_lowercase().contains(&state.search_query.to_lowercase());
+            if let Some(src) = &entry.source {
+                let color = source_color(src);
+                spans.push(Span::styled(
+                    format!("[{}] ", src),
+                    Style::default().fg(color).add_modifier(Modifier::BOLD),
+                ));
+            }
 
-        if has_match {
-            let highlighted = super::highlight_text_matches(line, &state.search_query, Style::default().fg(Theme::FG), match_style);
-            spans.extend(highlighted);
-        } else {
-            let lower = line.to_lowercase();
-            let log_style = if lower.contains("error") || lower.contains("fatal") || lower.contains("exception") || lower.contains("panic") {
-                Style::default().fg(Theme::RED)
-            } else if lower.contains("warn") || lower.contains("warning") {
-                Style::default().fg(Theme::YELLOW)
-            } else if lower.contains("info") {
-                Style::default().fg(Theme::FG)
-            } else if lower.contains("debug") || lower.contains("trace") {
-                Style::default().fg(Theme::DIM)
+            let line = &entry.line;
+            let has_match = !state.search_query.is_empty()
+                && line.to_lowercase().contains(&state.search_query.to_lowercase());
+
+            if has_match {
+                let highlighted = super::highlight_text_matches(line, &state.search_query, Style::default().fg(Theme::FG), match_style);
+                spans.extend(highlighted);
             } else {
-                Style::default().fg(Theme::FG)
-            };
-            spans.push(Span::styled(line.clone(), log_style));
-        }
+                let lower = line.to_lowercase();
+                let log_style = if lower.contains("error") || lower.contains("fatal") || lower.contains("exception") || lower.contains("panic") {
+                    Style::default().fg(Theme::RED)
+                } else if lower.contains("warn") || lower.contains("warning") {
+                    Style::default().fg(Theme::YELLOW)
+                } else if lower.contains("info") {
+                    Style::default().fg(Theme::FG)
+                } else if lower.contains("debug") || lower.contains("trace") {
+                    Style::default().fg(Theme::DIM)
+                } else {
+                    Style::default().fg(Theme::FG)
+                };
+                spans.push(Span::styled(line.clone(), log_style));
+            }
 
-        rendered_lines.push(Line::from(spans));
+            rendered_lines.push(Line::from(spans));
+        }
+    } else {
+        for (i, line) in state.lines.iter().enumerate().take(end_idx).skip(start_idx) {
+            let line_num = Span::styled(
+                format!("{:5} │ ", i + 1),
+                Style::default().fg(Theme::DIM),
+            );
+
+            let mut spans = vec![line_num];
+
+            let has_match = !state.search_query.is_empty()
+                && line.to_lowercase().contains(&state.search_query.to_lowercase());
+
+            if has_match {
+                let highlighted = super::highlight_text_matches(line, &state.search_query, Style::default().fg(Theme::FG), match_style);
+                spans.extend(highlighted);
+            } else {
+                let lower = line.to_lowercase();
+                let log_style = if lower.contains("error") || lower.contains("fatal") || lower.contains("exception") || lower.contains("panic") {
+                    Style::default().fg(Theme::RED)
+                } else if lower.contains("warn") || lower.contains("warning") {
+                    Style::default().fg(Theme::YELLOW)
+                } else if lower.contains("info") {
+                    Style::default().fg(Theme::FG)
+                } else if lower.contains("debug") || lower.contains("trace") {
+                    Style::default().fg(Theme::DIM)
+                } else {
+                    Style::default().fg(Theme::FG)
+                };
+                spans.push(Span::styled(line.clone(), log_style));
+            }
+
+            rendered_lines.push(Line::from(spans));
+        }
     }
 
     let mut paragraph = Paragraph::new(rendered_lines);
@@ -275,3 +419,81 @@ pub fn render_logs_view(f: &mut Frame, area: Rect, state: &LogsViewState) {
     }
     f.render_widget(paragraph, inner);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    #[test]
+    fn test_multi_pod_logs_state() {
+        let mut state = LogsViewState::new_multi_pod(
+            "frontend".to_string(),
+            "default".to_string(),
+            vec!["frontend-1".to_string(), "frontend-2".to_string()],
+            "chan-123".to_string(),
+        );
+
+        assert!(state.is_multi_pod);
+        assert_eq!(state.pod_name, "frontend");
+        assert_eq!(state.known_sources.len(), 2);
+
+        state.push_entry(Some("frontend-1".to_string()), "server started".to_string());
+        state.push_entry(Some("frontend-2".to_string()), "connected to db".to_string());
+        state.push_entry(Some("frontend-3".to_string()), "cache ready".to_string());
+
+        assert_eq!(state.entries.len(), 3);
+        assert_eq!(state.lines.len(), 3);
+        assert_eq!(state.known_sources.len(), 3);
+
+        let color1 = source_color("frontend-1");
+        let color2 = source_color("frontend-2");
+        let color1_again = source_color("frontend-1");
+        assert_eq!(color1, color1_again);
+        // Different pods likely have distinct colors
+        assert_ne!(color1, color2);
+    }
+
+    #[test]
+    fn test_multi_pod_logs_render() {
+        let mut state = LogsViewState::new_multi_pod(
+            "api-service".to_string(),
+            "prod".to_string(),
+            vec!["api-1".to_string(), "api-2".to_string()],
+            "chan-456".to_string(),
+        );
+        state.push_entry(Some("api-1".to_string()), "GET /health 200".to_string());
+        state.push_entry(Some("api-2".to_string()), "POST /login 200".to_string());
+
+        let backend = TestBackend::new(80, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                render_logs_view(f, area, &state);
+            })
+            .unwrap();
+
+        let buffer = terminal.backend().buffer();
+        let rendered: String = (0..buffer.area.height)
+            .flat_map(|y| {
+                let mut line = String::new();
+                for x in 0..buffer.area.width {
+                    line.push_str(buffer[(x, y)].symbol());
+                }
+                line.push('\n');
+                line.into_bytes()
+            })
+            .map(|b| b as char)
+            .collect();
+
+        assert!(rendered.contains("api-service"));
+        assert!(rendered.contains("2 pods in prod"));
+        assert!(rendered.contains("[api-1]"));
+        assert!(rendered.contains("[api-2]"));
+        assert!(rendered.contains("GET /health 200"));
+        assert!(rendered.contains("POST /login 200"));
+    }
+}
+

--- a/apps/tui/src/views/logs_view.rs
+++ b/apps/tui/src/views/logs_view.rs
@@ -201,7 +201,7 @@ impl LogsViewState {
                 .iter()
                 .map(|e| {
                     if let Some(src) = &e.source {
-                        format!("[{}] {}", src, e.line)
+                        format!("[{}] {}", sanitize_log_line(src), e.line)
                     } else {
                         e.line.clone()
                     }
@@ -347,8 +347,9 @@ pub fn render_logs_view(f: &mut Frame, area: Rect, state: &LogsViewState) {
 
             if let Some(src) = &entry.source {
                 let color = source_color(src);
+                let clean_src = sanitize_log_line(src);
                 spans.push(Span::styled(
-                    format!("[{}] ", src),
+                    format!("[{}] ", clean_src),
                     Style::default().fg(color).add_modifier(Modifier::BOLD),
                 ));
             }

--- a/apps/tui/src/views/metrics_panel_view.rs
+++ b/apps/tui/src/views/metrics_panel_view.rs
@@ -122,7 +122,7 @@ pub fn bucket_samples(
     if window_samples.is_empty() {
         let cpu = samples.last().map(|s| s.cpu_millicores).unwrap_or(0);
         let mem = samples.last().map(|s| s.memory_mib).unwrap_or(0);
-        return (vec![cpu], vec![mem]);
+        return (vec![cpu; width], vec![mem; width]);
     }
 
     // Each column i in 0..width represents a time slice of bucket_duration_ms
@@ -547,5 +547,38 @@ mod tests {
         let non_zeros_1h = cpu_1h.iter().filter(|&&v| v > 0).count();
         assert!(non_zeros_1h < non_zeros_10m, "1h window should compress data even more");
         assert!(non_zeros_1h <= 6);
+
+        // Samples falling completely outside the window still return width elements
+        let old_samples = vec![
+            MetricSample {
+                timestamp_epoch_ms: 1000,
+                cpu_millicores: 120,
+                memory_mib: 250,
+            },
+            MetricSample {
+                timestamp_epoch_ms: 2000,
+                cpu_millicores: 150,
+                memory_mib: 300,
+            },
+        ];
+        // Window from 2000 to 2000 with window_ms = 500 means start_time is 1500, but with window_samples empty:
+        // If we have samples, but filter yields empty (e.g. timestamps in future or filtered out)
+        // With now = 2000, start_time = 2000 (window_ms=0), window_samples includes sample at 2000.
+        // Let's test window_samples.is_empty() with a mock where filter excludes:
+        let out_of_window = vec![MetricSample {
+            timestamp_epoch_ms: 5000,
+            cpu_millicores: 120,
+            memory_mib: 250,
+        }];
+        // If now is 5000 and start_time is 4000, sample is included.
+        // To test window_samples.is_empty(), we pass samples that don't match the condition:
+        // Actually window_samples filters: s.timestamp_epoch_ms >= start_time && s.timestamp_epoch_ms <= now
+        // where now = samples.last().timestamp_epoch_ms and start_time = now - window_ms.
+        // So the last sample ALWAYS has timestamp == now >= start_time, so window_samples will ALWAYS contain at least samples.last()!
+        // The only way window_samples is empty is if now < start_time which is prevented by saturating_sub.
+        // BUT if it ever is empty, it returns vec![cpu; width] where width elements are returned:
+        let (cpu_res, mem_res) = bucket_samples(&out_of_window, 1000, 40);
+        assert_eq!(cpu_res.len(), 40);
+        assert_eq!(mem_res.len(), 40);
     }
 }

--- a/apps/tui/src/views/metrics_panel_view.rs
+++ b/apps/tui/src/views/metrics_panel_view.rs
@@ -548,23 +548,7 @@ mod tests {
         assert!(non_zeros_1h < non_zeros_10m, "1h window should compress data even more");
         assert!(non_zeros_1h <= 6);
 
-        // Samples falling completely outside the window still return width elements
-        let old_samples = vec![
-            MetricSample {
-                timestamp_epoch_ms: 1000,
-                cpu_millicores: 120,
-                memory_mib: 250,
-            },
-            MetricSample {
-                timestamp_epoch_ms: 2000,
-                cpu_millicores: 150,
-                memory_mib: 300,
-            },
-        ];
-        // Window from 2000 to 2000 with window_ms = 500 means start_time is 1500, but with window_samples empty:
-        // If we have samples, but filter yields empty (e.g. timestamps in future or filtered out)
-        // With now = 2000, start_time = 2000 (window_ms=0), window_samples includes sample at 2000.
-        // Let's test window_samples.is_empty() with a mock where filter excludes:
+        // Samples windowing test:
         let out_of_window = vec![MetricSample {
             timestamp_epoch_ms: 5000,
             cpu_millicores: 120,

--- a/apps/tui/src/views/metrics_panel_view.rs
+++ b/apps/tui/src/views/metrics_panel_view.rs
@@ -27,6 +27,15 @@ impl MetricsTimeRange {
         }
     }
 
+    pub fn half_label(&self) -> &'static str {
+        match self {
+            Self::FiveMin => "2.5m",
+            Self::TenMin => "5m",
+            Self::ThirtyMin => "15m",
+            Self::OneHour => "30m",
+        }
+    }
+
     pub fn window_ms(&self) -> u64 {
         match self {
             Self::FiveMin => 5 * 60 * 1000,
@@ -44,6 +53,15 @@ impl MetricsTimeRange {
             Self::OneHour => Self::FiveMin,
         }
     }
+
+    pub fn prev(&self) -> Self {
+        match self {
+            Self::FiveMin => Self::OneHour,
+            Self::TenMin => Self::FiveMin,
+            Self::ThirtyMin => Self::TenMin,
+            Self::OneHour => Self::ThirtyMin,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -53,6 +71,7 @@ pub struct MetricsPanelState {
     pub namespace: Option<String>,
     pub range: MetricsTimeRange,
     pub samples: Vec<MetricSample>,
+    pub range_button_rects: std::sync::Arc<std::sync::Mutex<Vec<(Rect, MetricsTimeRange)>>>,
 }
 
 impl MetricsPanelState {
@@ -63,6 +82,7 @@ impl MetricsPanelState {
             namespace,
             range: MetricsTimeRange::FiveMin,
             samples,
+            range_button_rects: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
         }
     }
 
@@ -70,9 +90,90 @@ impl MetricsPanelState {
         self.range = self.range.next();
     }
 
+    pub fn cycle_time_range_prev(&mut self) {
+        self.range = self.range.prev();
+    }
+
     pub fn update_samples(&mut self, samples: &[MetricSample]) {
         self.samples = samples.to_vec();
     }
+}
+
+/// Downsamples and scales recorded samples into `width` discrete time buckets spanning `window_ms`.
+/// Each column represents a bucket across the selected time range ending at `now`.
+pub fn bucket_samples(
+    samples: &[MetricSample],
+    window_ms: u64,
+    width: usize,
+) -> (Vec<u64>, Vec<u64>) {
+    if width == 0 || samples.is_empty() {
+        return (vec![], vec![]);
+    }
+
+    let now = samples.last().map(|s| s.timestamp_epoch_ms).unwrap_or(0);
+    let start_time = now.saturating_sub(window_ms);
+
+    // Filter samples within the window
+    let window_samples: Vec<&MetricSample> = samples
+        .iter()
+        .filter(|s| s.timestamp_epoch_ms >= start_time && s.timestamp_epoch_ms <= now)
+        .collect();
+
+    if window_samples.is_empty() {
+        let cpu = samples.last().map(|s| s.cpu_millicores).unwrap_or(0);
+        let mem = samples.last().map(|s| s.memory_mib).unwrap_or(0);
+        return (vec![cpu], vec![mem]);
+    }
+
+    // Each column i in 0..width represents a time slice of bucket_duration_ms
+    let mut buckets: Vec<(u64, u64, usize)> = vec![(0, 0, 0); width];
+
+    for s in &window_samples {
+        let offset = s.timestamp_epoch_ms.saturating_sub(start_time);
+        let col = if window_ms > 0 {
+            let c = (offset as u128 * width as u128 / window_ms as u128) as usize;
+            c.min(width.saturating_sub(1))
+        } else {
+            width.saturating_sub(1)
+        };
+        buckets[col].0 += s.cpu_millicores;
+        buckets[col].1 += s.memory_mib;
+        buckets[col].2 += 1;
+    }
+
+    // Earliest recorded sample offset determines where data starts in the window
+    let earliest_offset = window_samples.first().unwrap().timestamp_epoch_ms.saturating_sub(start_time);
+    let earliest_col = if window_ms > 0 {
+        ((earliest_offset as u128 * width as u128 / window_ms as u128) as usize).min(width.saturating_sub(1))
+    } else {
+        0
+    };
+
+    let mut cpu_data = Vec::with_capacity(width);
+    let mut mem_data = Vec::with_capacity(width);
+    let mut last_cpu = 0;
+    let mut last_mem = 0;
+
+    for (col_idx, (sum_c, sum_m, count)) in buckets.into_iter().enumerate() {
+        if col_idx < earliest_col {
+            // Before earliest sample in this window: empty timeline
+            cpu_data.push(0);
+            mem_data.push(0);
+        } else if count > 0 {
+            let avg_c = sum_c / count as u64;
+            let avg_m = sum_m / count as u64;
+            last_cpu = avg_c;
+            last_mem = avg_m;
+            cpu_data.push(avg_c);
+            mem_data.push(avg_m);
+        } else {
+            // Sample gap: carry forward last known value
+            cpu_data.push(last_cpu);
+            mem_data.push(last_mem);
+        }
+    }
+
+    (cpu_data, mem_data)
 }
 
 /// Renders the interactive Metrics Panel modal overlay with real-time Sparklines.
@@ -148,6 +249,9 @@ pub fn render_metrics_panel_modal(
         Span::styled("Time Range: ", Theme::header_label()),
     ];
 
+    let mut btn_rects = Vec::new();
+    let mut current_btn_x = body_chunks[0].x + 12;
+
     for (idx, r) in ranges.iter().enumerate() {
         let is_selected = *r == state.range;
         let style = if is_selected {
@@ -158,8 +262,25 @@ pub fn render_metrics_panel_modal(
         } else {
             Style::default().fg(Theme::DIM)
         };
-        range_spans.push(Span::styled(format!(" [{}: {}] ", idx + 1, r.label()), style));
+        let label_str = format!(" [{}: {}] ", idx + 1, r.label());
+        let btn_w = label_str.len() as u16;
+        btn_rects.push((
+            Rect {
+                x: current_btn_x,
+                y: body_chunks[0].y,
+                width: btn_w,
+                height: 1,
+            },
+            *r,
+        ));
+        current_btn_x += btn_w + 1;
+
+        range_spans.push(Span::styled(label_str, style));
         range_spans.push(Span::raw(" "));
+    }
+
+    if let Ok(mut lock) = state.range_button_rects.lock() {
+        *lock = btn_rects;
     }
 
     range_spans.push(Span::styled(
@@ -182,7 +303,7 @@ pub fn render_metrics_panel_modal(
         return;
     }
 
-    // Filter samples within window
+    // Filter samples within window for metrics stats
     let now = samples.last().map(|s| s.timestamp_epoch_ms).unwrap_or(0);
     let window_ms = state.range.window_ms();
     let window_samples: Vec<&MetricSample> = samples
@@ -196,31 +317,28 @@ pub fn render_metrics_panel_modal(
         window_samples
     };
 
-    let cpu_data: Vec<u64> = active_samples.iter().map(|s| s.cpu_millicores).collect();
-    let mem_data: Vec<u64> = active_samples.iter().map(|s| s.memory_mib).collect();
-
-    let cur_cpu = cpu_data.last().copied().unwrap_or(0);
-    let min_cpu = cpu_data.iter().copied().min().unwrap_or(0);
-    let max_cpu = cpu_data.iter().copied().max().unwrap_or(0);
-    let avg_cpu = if !cpu_data.is_empty() {
-        cpu_data.iter().sum::<u64>() / cpu_data.len() as u64
+    let cur_cpu = samples.last().map(|s| s.cpu_millicores).unwrap_or(0);
+    let min_cpu = active_samples.iter().map(|s| s.cpu_millicores).min().unwrap_or(0);
+    let max_cpu = active_samples.iter().map(|s| s.cpu_millicores).max().unwrap_or(0);
+    let avg_cpu = if !active_samples.is_empty() {
+        active_samples.iter().map(|s| s.cpu_millicores).sum::<u64>() / active_samples.len() as u64
     } else {
         0
     };
 
-    let cur_mem = mem_data.last().copied().unwrap_or(0);
-    let min_mem = mem_data.iter().copied().min().unwrap_or(0);
-    let max_mem = mem_data.iter().copied().max().unwrap_or(0);
-    let avg_mem = if !mem_data.is_empty() {
-        mem_data.iter().sum::<u64>() / mem_data.len() as u64
+    let cur_mem = samples.last().map(|s| s.memory_mib).unwrap_or(0);
+    let min_mem = active_samples.iter().map(|s| s.memory_mib).min().unwrap_or(0);
+    let max_mem = active_samples.iter().map(|s| s.memory_mib).max().unwrap_or(0);
+    let avg_mem = if !active_samples.is_empty() {
+        active_samples.iter().map(|s| s.memory_mib).sum::<u64>() / active_samples.len() as u64
     } else {
         0
     };
 
     // 1. CPU Sparkline Box
     let cpu_title = format!(
-        " CPU Usage: {}m  (min: {}m, avg: {}m, peak: {}m) ",
-        cur_cpu, min_cpu, avg_cpu, max_cpu
+        " CPU Usage: {}m  ({} min: {}m, avg: {}m, peak: {}m) ",
+        cur_cpu, state.range.label(), min_cpu, avg_cpu, max_cpu
     );
     let cpu_block = Block::default()
         .borders(Borders::ALL)
@@ -230,16 +348,37 @@ pub fn render_metrics_panel_modal(
     let cpu_inner = cpu_block.inner(body_chunks[1]);
     f.render_widget(cpu_block, body_chunks[1]);
 
+    let cpu_splits = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(4),
+            Constraint::Length(1),
+        ])
+        .split(cpu_inner);
+
+    let (cpu_data, mem_data) = bucket_samples(samples, window_ms, cpu_splits[0].width as usize);
+
     let cpu_sparkline = Sparkline::default()
         .data(&cpu_data)
         .style(Style::default().fg(Theme::CYAN))
         .max(max_cpu.max(10));
-    f.render_widget(cpu_sparkline, cpu_inner);
+    f.render_widget(cpu_sparkline, cpu_splits[0]);
+
+    let axis_width = (cpu_splits[1].width as usize).saturating_sub(12);
+    let cpu_axis = Line::from(vec![
+        Span::styled(format!(" -{}", state.range.label()), Style::default().fg(Theme::DIM)),
+        Span::styled(
+            format!("{:^width$}", format!("-{}", state.range.half_label()), width = axis_width),
+            Style::default().fg(Theme::DIM),
+        ),
+        Span::styled("now ", Style::default().fg(Theme::CYAN)),
+    ]);
+    f.render_widget(Paragraph::new(cpu_axis), cpu_splits[1]);
 
     // 2. Memory Sparkline Box
     let mem_title = format!(
-        " Memory Usage: {} MiB  (min: {} MiB, avg: {} MiB, peak: {} MiB) ",
-        cur_mem, min_mem, avg_mem, max_mem
+        " Memory Usage: {} MiB  ({} min: {} MiB, avg: {} MiB, peak: {} MiB) ",
+        cur_mem, state.range.label(), min_mem, avg_mem, max_mem
     );
     let mem_block = Block::default()
         .borders(Borders::ALL)
@@ -249,19 +388,37 @@ pub fn render_metrics_panel_modal(
     let mem_inner = mem_block.inner(body_chunks[2]);
     f.render_widget(mem_block, body_chunks[2]);
 
+    let mem_splits = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(4),
+            Constraint::Length(1),
+        ])
+        .split(mem_inner);
+
     let mem_sparkline = Sparkline::default()
         .data(&mem_data)
         .style(Style::default().fg(Color::Rgb(168, 85, 247)))
         .max(max_mem.max(10));
-    f.render_widget(mem_sparkline, mem_inner);
+    f.render_widget(mem_sparkline, mem_splits[0]);
+
+    let mem_axis = Line::from(vec![
+        Span::styled(format!(" -{}", state.range.label()), Style::default().fg(Theme::DIM)),
+        Span::styled(
+            format!("{:^width$}", format!("-{}", state.range.half_label()), width = axis_width),
+            Style::default().fg(Theme::DIM),
+        ),
+        Span::styled("now ", Style::default().fg(Color::Rgb(168, 85, 247))),
+    ]);
+    f.render_widget(Paragraph::new(mem_axis), mem_splits[1]);
 
     // 3. Footer Key Hints
     let footer_hints = Line::from(vec![
-        Span::styled("<Tab/1-4>", Theme::header_label()),
+        Span::styled("<Tab/1-4/←/→>", Theme::header_label()),
         Span::raw(" Switch Range  "),
         Span::styled("<r>", Theme::header_label()),
         Span::raw(" Refresh  "),
-        Span::styled("<Esc>", Theme::header_label()),
+        Span::styled("<Esc/q>", Theme::header_label()),
         Span::raw(" Close"),
     ]);
     f.render_widget(Paragraph::new(footer_hints).alignment(Alignment::Center), body_chunks[3]);
@@ -320,5 +477,75 @@ mod tests {
 
         panel.cycle_time_range();
         assert_eq!(panel.range, MetricsTimeRange::TenMin);
+    }
+
+    #[test]
+    fn test_render_modal_50_samples() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let mut samples = Vec::new();
+        for i in 0..50 {
+            samples.push(MetricSample {
+                timestamp_epoch_ms: 10000 + i * 4000,
+                cpu_millicores: 579,
+                memory_mib: 14787,
+            });
+        }
+        let panel = MetricsPanelState::new("Node".to_string(), "test-node".to_string(), None, samples);
+        let backend = TestBackend::new(100, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| render_metrics_panel_modal(f, f.area(), &panel)).unwrap();
+
+        let buffer = terminal.backend().buffer();
+        let content: String = (0..buffer.area.height)
+            .map(|y| {
+                let mut line = String::new();
+                for x in 0..buffer.area.width {
+                    line.push_str(buffer[(x, y)].symbol());
+                }
+                line
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(content.contains("Live Metrics Timeline"));
+        assert!(content.contains("-5m"));
+        assert!(content.contains("-2.5m"));
+        assert!(content.contains("now"));
+        assert!(content.contains("5m min: 579m"));
+    }
+
+    #[test]
+    fn test_bucket_samples_rescaling_with_range_change() {
+        let mut samples = Vec::new();
+        let base_time: u64 = 1_700_000_000_000;
+        // 50 samples spaced 4s apart = 196s duration ending at base_time + 196,000
+        for i in 0..50 {
+            samples.push(MetricSample {
+                timestamp_epoch_ms: base_time + i * 4000,
+                cpu_millicores: 500 + i * 10,
+                memory_mib: 1000 + i * 20,
+            });
+        }
+
+        // Window 5m (300,000 ms), width = 75
+        let (cpu_5m, _) = bucket_samples(&samples, 5 * 60 * 1000, 75);
+        assert_eq!(cpu_5m.len(), 75);
+        let non_zeros_5m = cpu_5m.iter().filter(|&&v| v > 0).count();
+        assert!(non_zeros_5m >= 45, "5m window should contain most samples across 75 width");
+
+        // Window 10m (600,000 ms), width = 75
+        let (cpu_10m, _) = bucket_samples(&samples, 10 * 60 * 1000, 75);
+        assert_eq!(cpu_10m.len(), 75);
+        let non_zeros_10m = cpu_10m.iter().filter(|&&v| v > 0).count();
+        assert!(non_zeros_10m < non_zeros_5m, "10m window should compress timeline compared to 5m");
+        assert!(non_zeros_10m >= 20 && non_zeros_10m <= 30);
+
+        // Window 1h (3,600,000 ms), width = 75
+        let (cpu_1h, _) = bucket_samples(&samples, 60 * 60 * 1000, 75);
+        let non_zeros_1h = cpu_1h.iter().filter(|&&v| v > 0).count();
+        assert!(non_zeros_1h < non_zeros_10m, "1h window should compress data even more");
+        assert!(non_zeros_1h <= 6);
     }
 }

--- a/apps/tui/src/views/mod.rs
+++ b/apps/tui/src/views/mod.rs
@@ -3,6 +3,7 @@ pub mod cracked_lens;
 pub mod describe_view;
 pub mod exec_view;
 pub mod helm_view;
+pub mod helm_detail_view;
 pub mod logs_view;
 pub mod metrics_panel_view;
 pub mod overview_view;
@@ -13,6 +14,9 @@ pub mod settings_view;
 pub mod toolbox_view;
 pub mod tree_view;
 pub mod node_inspector_view;
+pub mod topology_view;
+pub mod gpu_view;
+pub mod top_view;
 pub mod yaml_view;
 
 /// Strip everything from cluster-controlled text that would desynchronise
@@ -112,7 +116,8 @@ pub use assistant_view::{render_assistant_view, AssistantViewState};
 pub use cracked_lens::render_cracked_lens;
 pub use describe_view::{render_describe_view, DescribeViewState};
 pub use exec_view::ExecRunner;
-pub use helm_view::{render_helm_view, HelmViewState};
+pub use helm_view::{render_helm_view, HelmReleaseItem, HelmViewState};
+pub use helm_detail_view::{render_helm_detail_view, HelmDetailTab, HelmDetailViewState, ValuesDiffMode};
 pub use logs_view::{render_logs_view, LogsViewState};
 pub use metrics_panel_view::{render_metrics_panel_modal, MetricsPanelState, MetricsTimeRange};
 pub use overview_view::{render_overview_view, OverviewViewState};

--- a/apps/tui/src/views/node_inspector_view.rs
+++ b/apps/tui/src/views/node_inspector_view.rs
@@ -6,7 +6,7 @@ use ratatui::{
     Frame,
 };
 
-use srelens_kube::node_inspector::{NodeInspectorDetails, NodePodItem};
+pub use srelens_kube::node_inspector::{NodeInspectorDetails, NodePodItem};
 use crate::theme::Theme;
 
 #[derive(Debug, Clone)]

--- a/apps/tui/src/views/port_forward_view.rs
+++ b/apps/tui/src/views/port_forward_view.rs
@@ -66,7 +66,8 @@ pub fn render_port_forward_view(f: &mut Frame, area: Rect, state: &PortForwardVi
 
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Theme::BORDER))
+        .border_type(Theme::border_type())
+        .border_style(Style::default().fg(Theme::border()))
         .title(Span::styled(title, Theme::title()));
 
     let inner = block.inner(area);
@@ -76,7 +77,7 @@ pub fn render_port_forward_view(f: &mut Frame, area: Rect, state: &PortForwardVi
         let empty_msg = Paragraph::new(
             "No active port forwards. Select a Pod or Service and press <shift-f> to start a port forward.",
         )
-        .style(Style::default().fg(Theme::DIM));
+        .style(Style::default().fg(Theme::dim()));
         f.render_widget(empty_msg, inner);
         return;
     }

--- a/apps/tui/src/views/resource_table.rs
+++ b/apps/tui/src/views/resource_table.rs
@@ -6,7 +6,7 @@ use ratatui::{
     Frame,
 };
 use serde_json::Value;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use crate::commands::ResourceKind;
 use crate::theme::{status_style, Theme};
@@ -84,6 +84,8 @@ pub struct ResourceTableState {
     pub last_viewport_rect: std::cell::Cell<Rect>,
     pub last_start_idx: std::cell::Cell<usize>,
     pub last_area_width: std::cell::Cell<u16>,
+    /// Active port forwards: (namespace, name) -> Vec<(local_port, remote_port, forward_id)>
+    pub active_port_forwards: HashMap<(String, String), Vec<(u16, u16, String)>>,
 }
 
 impl ResourceTableState {
@@ -108,6 +110,7 @@ impl ResourceTableState {
             last_viewport_rect: std::cell::Cell::new(Rect::default()),
             last_start_idx: std::cell::Cell::new(0),
             last_area_width: std::cell::Cell::new(0),
+            active_port_forwards: HashMap::new(),
         }
     }
 
@@ -425,8 +428,8 @@ pub fn default_columns_for_kind(kind: &ResourceKind) -> Vec<ColumnDef> {
             ColumnDef { name: "AGE", key: "age", width: Constraint::Length(8) },
         ],
         ResourceKind::Nodes => vec![
-            ColumnDef { name: "NAME", key: "name", width: Constraint::Min(30) },
-            ColumnDef { name: "STATUS", key: "status", width: Constraint::Length(14) },
+            ColumnDef { name: "NAME", key: "name", width: Constraint::Length(24) },
+            ColumnDef { name: "STATUS", key: "status", width: Constraint::Length(26) },
             ColumnDef { name: "ROLES", key: "roles", width: Constraint::Length(16) },
             ColumnDef { name: "VERSION", key: "version", width: Constraint::Length(14) },
             ColumnDef { name: "CPU", key: "allocatableCpuMillicores", width: Constraint::Length(12) },
@@ -775,6 +778,53 @@ pub fn extract_field_str<'a>(val: &'a Value, key: &str) -> String {
         }
     }
 
+    // Node & workload status resolution (including cordoned/SchedulingDisabled nodes)
+    if key_lower == "status" {
+        let is_unschedulable = val
+            .get("unschedulable")
+            .and_then(|v| v.as_bool())
+            .or_else(|| val.pointer("/spec/unschedulable").and_then(|v| v.as_bool()))
+            .unwrap_or(false);
+
+        let mut status_str = if let Some(s) = val.get("status").and_then(|v| v.as_str()) {
+            s.to_string()
+        } else if let Some(phase) = val.get("phase").or_else(|| val.pointer("/status/phase")).and_then(|v| v.as_str()) {
+            phase.to_string()
+        } else if let Some(conds) = val.pointer("/status/conditions").and_then(|v| v.as_array()) {
+            if let Some(ready_cond) = conds.iter().find(|c| c.get("type").and_then(|t| t.as_str()) == Some("Ready")) {
+                if ready_cond.get("status").and_then(|s| s.as_str()) == Some("True") {
+                    "Ready".to_string()
+                } else {
+                    "NotReady".to_string()
+                }
+            } else {
+                String::new()
+            }
+        } else {
+            String::new()
+        };
+
+        if is_unschedulable {
+            if status_str.is_empty() {
+                status_str = "SchedulingDisabled".to_string();
+            } else if !status_str.contains("SchedulingDisabled") {
+                status_str = format!("{status_str},SchedulingDisabled");
+            }
+            return status_str;
+        } else if !status_str.is_empty() {
+            return status_str;
+        }
+    }
+
+    if key_lower == "unschedulable" {
+        let is_unschedulable = val
+            .get("unschedulable")
+            .and_then(|v| v.as_bool())
+            .or_else(|| val.pointer("/spec/unschedulable").and_then(|v| v.as_bool()))
+            .unwrap_or(false);
+        return if is_unschedulable { "true".to_string() } else { "false".to_string() };
+    }
+
     // 1. Direct key lookup
     if let Some(v) = val.get(key) {
         if let Some(s) = raw_value_to_string(v) {
@@ -992,14 +1042,20 @@ fn render_single_resource_table(f: &mut Frame, area: Rect, state: &ResourceTable
         format!(" [{}]", state.filtered_indices.len())
     };
 
-    let title = format!(" {}{}{}{}{} ", state.kind.display_name(), segment_badge, count_badge, triage_badge, reason_badge);
+    let pf_badge = if !state.active_port_forwards.is_empty() && (state.kind == ResourceKind::Pods || state.kind == ResourceKind::Services) {
+        format!(" [PF: {} active]", state.active_port_forwards.len())
+    } else {
+        String::new()
+    };
+
+    let title = format!(" {}{}{}{}{}{} ", state.kind.display_name(), segment_badge, count_badge, pf_badge, triage_badge, reason_badge);
 
     let border_color = if state.kind == ResourceKind::Events && state.reason_rail_focused {
-        Theme::BORDER
+        Theme::border()
     } else if state.kind == ResourceKind::Events && state.warning_triage {
         Color::Yellow
     } else {
-        Theme::BORDER
+        Theme::border()
     };
 
     let block = Block::default()
@@ -1016,8 +1072,8 @@ fn render_single_resource_table(f: &mut Frame, area: Rect, state: &ResourceTable
 
     if state.is_loading {
         let loading_msg = Paragraph::new(Line::from(vec![
-            Span::styled("⚡ Loading ", Style::default().fg(Theme::CYAN).add_modifier(Modifier::BOLD)),
-            Span::styled(format!("{} from cluster API...", state.kind.display_name()), Style::default().fg(Theme::DIM)),
+            Span::styled("⚡ Loading ", Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)),
+            Span::styled(format!("{} from cluster API...", state.kind.display_name()), Style::default().fg(Theme::dim())),
         ]));
         f.render_widget(loading_msg, inner);
         return;
@@ -1025,7 +1081,7 @@ fn render_single_resource_table(f: &mut Frame, area: Rect, state: &ResourceTable
 
     if state.filtered_indices.is_empty() {
         let empty_msg = Paragraph::new(Line::from(vec![
-            Span::styled(format!("No {} found in this scope.", state.kind.display_name()), Style::default().fg(Theme::DIM)),
+            Span::styled(format!("No {} found in this scope.", state.kind.display_name()), Style::default().fg(Theme::dim())),
         ]));
         f.render_widget(empty_msg, inner);
         return;
@@ -1068,12 +1124,44 @@ fn render_single_resource_table(f: &mut Frame, area: Rect, state: &ResourceTable
                 let cell_style = if is_status_col {
                     status_style(&text)
                 } else if is_selected {
-                    Style::default().fg(Theme::SEL_FG).add_modifier(Modifier::BOLD)
+                    Style::default().fg(Theme::sel_fg()).add_modifier(Modifier::BOLD)
                 } else {
-                    Style::default().fg(Theme::FG)
+                    Style::default().fg(Theme::fg())
                 };
 
                 let prefix = if col.key == "name" && is_marked { "✔ " } else { "" };
+                if col.key == "name" {
+                    let ns = extract_field_str(item, "namespace");
+                    let name = extract_field_str(item, "name");
+                    let active_forwards = state.active_port_forwards.get(&(ns.clone(), name.clone()))
+                        .or_else(|| state.active_port_forwards.get(&(String::new(), name.clone())));
+
+                    if let Some(forwards) = active_forwards {
+                        if !forwards.is_empty() {
+                            let pf_str = forwards
+                                .iter()
+                                .map(|(loc, rem, _)| {
+                                    if loc == rem {
+                                        format!("{}", loc)
+                                    } else {
+                                        format!("{}→{}", loc, rem)
+                                    }
+                                })
+                                .collect::<Vec<_>>()
+                                .join(",");
+
+                            let line = Line::from(vec![
+                                Span::styled(format!("{}{}", prefix, text), cell_style),
+                                Span::raw(" "),
+                                Span::styled(
+                                    format!("[PF: {}]", pf_str),
+                                    Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD),
+                                ),
+                            ]);
+                            return Cell::from(line);
+                        }
+                    }
+                }
                 Cell::from(format!("{}{}", prefix, text)).style(cell_style)
             });
 
@@ -1082,7 +1170,12 @@ fn render_single_resource_table(f: &mut Frame, area: Rect, state: &ResourceTable
             } else if is_marked {
                 Theme::marked_row()
             } else if display_idx % 2 == 0 {
-                Style::default().bg(Color::Rgb(22, 24, 30))
+                let alt_bg = if Theme::active_palette().is_light {
+                    Color::Rgb(242, 244, 248)
+                } else {
+                    Color::Rgb(22, 24, 30)
+                };
+                Style::default().bg(alt_bg)
             } else {
                 Style::default()
             };
@@ -1091,7 +1184,46 @@ fn render_single_resource_table(f: &mut Frame, area: Rect, state: &ResourceTable
         })
         .collect();
 
-    let widths: Vec<Constraint> = state.columns.iter().map(|c| c.width).collect();
+    let widths: Vec<Constraint> = if state.kind == ResourceKind::Nodes {
+        let max_name_len = state
+            .filtered_indices
+            .iter()
+            .map(|&idx| {
+                let is_marked = state.marked_indices.contains(&idx);
+                let prefix_len = if is_marked { 2 } else { 0 };
+                prefix_len + extract_field_str(&state.raw_items[idx], "name").len()
+            })
+            .max()
+            .unwrap_or(12)
+            .max("NAME".len());
+        let name_width = (max_name_len + 3) as u16;
+
+        let max_status_len = state
+            .filtered_indices
+            .iter()
+            .map(|&idx| extract_field_str(&state.raw_items[idx], "status").len())
+            .max()
+            .unwrap_or(8)
+            .max("STATUS".len());
+        let status_width = (max_status_len + 3) as u16;
+
+        state
+            .columns
+            .iter()
+            .enumerate()
+            .map(|(i, c)| {
+                if i == 0 && c.key == "name" {
+                    Constraint::Length(name_width)
+                } else if i == 1 && c.key == "status" {
+                    Constraint::Length(status_width)
+                } else {
+                    c.width
+                }
+            })
+            .collect()
+    } else {
+        state.columns.iter().map(|c| c.width).collect()
+    };
     let table = Table::new(rows, widths).header(header);
     f.render_widget(table, inner);
 }
@@ -1450,5 +1582,46 @@ mod tests {
         // Clear reason filter
         state.set_reason_filter(None, "");
         assert_eq!(state.filtered_indices.len(), 4);
+    }
+
+    #[test]
+    fn test_node_cordon_status_and_style() {
+        let normal_node = json!({
+            "name": "worker-1",
+            "status": "Ready",
+            "unschedulable": false
+        });
+        assert_eq!(extract_field_str(&normal_node, "status"), "Ready");
+        assert_eq!(extract_field_str(&normal_node, "unschedulable"), "false");
+        assert_eq!(status_style(&extract_field_str(&normal_node, "status")), Theme::status_ok());
+
+        let cordoned_node = json!({
+            "name": "worker-2",
+            "status": "Ready",
+            "unschedulable": true
+        });
+        assert_eq!(extract_field_str(&cordoned_node, "status"), "Ready,SchedulingDisabled");
+        assert_eq!(extract_field_str(&cordoned_node, "unschedulable"), "true");
+        assert_eq!(status_style(&extract_field_str(&cordoned_node, "status")), Theme::status_warn());
+
+        let notready_cordoned = json!({
+            "name": "worker-3",
+            "status": "NotReady",
+            "unschedulable": true
+        });
+        assert_eq!(extract_field_str(&notready_cordoned, "status"), "NotReady,SchedulingDisabled");
+        assert_eq!(status_style(&extract_field_str(&notready_cordoned, "status")), Theme::status_error());
+
+        // Raw k8s node json format
+        let raw_cordoned = json!({
+            "metadata": { "name": "k8s-node-1" },
+            "spec": { "unschedulable": true },
+            "status": {
+                "conditions": [
+                    { "type": "Ready", "status": "True" }
+                ]
+            }
+        });
+        assert_eq!(extract_field_str(&raw_cordoned, "status"), "Ready,SchedulingDisabled");
     }
 }

--- a/apps/tui/src/views/toolbox_view.rs
+++ b/apps/tui/src/views/toolbox_view.rs
@@ -161,3 +161,56 @@ pub fn render_toolbox_view(f: &mut Frame, area: Rect, state: &ToolboxViewState) 
     let table = Table::new(rows, widths).header(headers);
     f.render_widget(table, inner);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    #[test]
+    fn test_toolbox_view_state_and_render() {
+        let mut state = ToolboxViewState::new();
+        assert!(!state.tools.is_empty());
+
+        // Test navigation
+        state.select_next();
+        state.select_prev();
+        assert_eq!(state.selected_idx, 0);
+
+        // Test mock tools to cover all status branches
+        state.tools = vec![
+            ToolStatusItem {
+                name: "kubectl".to_string(),
+                installed: true,
+                version: Some("v1.30.0".to_string()),
+                path: Some("/usr/local/bin/kubectl".to_string()),
+                required: true,
+            },
+            ToolStatusItem {
+                name: "required-tool".to_string(),
+                installed: false,
+                version: None,
+                path: None,
+                required: true,
+            },
+            ToolStatusItem {
+                name: "optional-tool".to_string(),
+                installed: false,
+                version: None,
+                path: None,
+                required: false,
+            },
+        ];
+
+        let backend = TestBackend::new(100, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| render_toolbox_view(f, f.area(), &state)).unwrap();
+
+        // Nonexistent tool detection to test failure branches
+        let missing = detect_tool("definitely-nonexistent-bin-987", &["also-nonexistent"], false, &["--version"]);
+        assert!(!missing.installed);
+        assert!(missing.path.is_none());
+        assert!(missing.version.is_none());
+    }
+}

--- a/apps/tui/src/views/top_view.rs
+++ b/apps/tui/src/views/top_view.rs
@@ -1,0 +1,705 @@
+use std::collections::HashMap;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Cell, Clear, Row, Table};
+use ratatui::Frame;
+
+use crate::theme::Theme;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TopTab {
+    Pods,
+    Nodes,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TopSortBy {
+    Cpu,
+    Memory,
+}
+
+#[derive(Debug, Clone)]
+pub struct TopPodRow {
+    pub namespace: String,
+    pub name: String,
+    pub cpu_millicores: i64,
+    pub cpu_req_millicores: i64,
+    pub cpu_lim_millicores: i64,
+    pub mem_mib: i64,
+    pub mem_req_mib: i64,
+    pub mem_lim_mib: i64,
+}
+
+impl TopPodRow {
+    pub fn cpu_req_pct(&self) -> Option<f64> {
+        if self.cpu_req_millicores > 0 {
+            Some((self.cpu_millicores as f64 / self.cpu_req_millicores as f64) * 100.0)
+        } else {
+            None
+        }
+    }
+
+    pub fn cpu_lim_pct(&self) -> Option<f64> {
+        if self.cpu_lim_millicores > 0 {
+            Some((self.cpu_millicores as f64 / self.cpu_lim_millicores as f64) * 100.0)
+        } else {
+            None
+        }
+    }
+
+    pub fn mem_req_pct(&self) -> Option<f64> {
+        if self.mem_req_mib > 0 {
+            Some((self.mem_mib as f64 / self.mem_req_mib as f64) * 100.0)
+        } else {
+            None
+        }
+    }
+
+    pub fn mem_lim_pct(&self) -> Option<f64> {
+        if self.mem_lim_mib > 0 {
+            Some((self.mem_mib as f64 / self.mem_lim_mib as f64) * 100.0)
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TopNodeRow {
+    pub name: String,
+    pub status: String,
+    pub cpu_millicores: i64,
+    pub cpu_alloc_millicores: i64,
+    pub mem_mib: i64,
+    pub mem_alloc_mib: i64,
+}
+
+impl TopNodeRow {
+    pub fn cpu_alloc_pct(&self) -> Option<f64> {
+        if self.cpu_alloc_millicores > 0 {
+            Some((self.cpu_millicores as f64 / self.cpu_alloc_millicores as f64) * 100.0)
+        } else {
+            None
+        }
+    }
+
+    pub fn mem_alloc_pct(&self) -> Option<f64> {
+        if self.mem_alloc_mib > 0 {
+            Some((self.mem_mib as f64 / self.mem_alloc_mib as f64) * 100.0)
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TopViewState {
+    pub active_tab: TopTab,
+    pub sort_by: TopSortBy,
+    pub sort_ascending: bool,
+    pub selected_idx: usize,
+    pub scroll_offset: usize,
+    pub pods: Vec<TopPodRow>,
+    pub nodes: Vec<TopNodeRow>,
+    pub filter: String,
+    pub active_port_forwards: HashMap<(String, String), Vec<(u16, u16, String)>>,
+}
+
+impl Default for TopViewState {
+    fn default() -> Self {
+        Self::new(TopTab::Pods)
+    }
+}
+
+impl TopViewState {
+    pub fn new(tab: TopTab) -> Self {
+        Self {
+            active_tab: tab,
+            sort_by: TopSortBy::Cpu,
+            sort_ascending: false,
+            selected_idx: 0,
+            scroll_offset: 0,
+            pods: Vec::new(),
+            nodes: Vec::new(),
+            filter: String::new(),
+            active_port_forwards: HashMap::new(),
+        }
+    }
+
+    pub fn extract_pod_resources(val: &serde_json::Value) -> (i64, i64, i64, i64) {
+        let mut req_cpu = val.get("cpuReqMillicores").and_then(|v| v.as_i64()).unwrap_or(0);
+        let mut lim_cpu = val.get("cpuLimMillicores").and_then(|v| v.as_i64()).unwrap_or(0);
+        let mut req_mem = val.get("memReqMiB").and_then(|v| v.as_i64()).unwrap_or(0);
+        let mut lim_mem = val.get("memLimMiB").and_then(|v| v.as_i64()).unwrap_or(0);
+
+        if req_cpu == 0 && lim_cpu == 0 && req_mem == 0 && lim_mem == 0 {
+            if let Some(conts) = val.pointer("/spec/containers").and_then(|v| v.as_array()) {
+                for c in conts {
+                    if let Some(c_req_cpu) = c.pointer("/resources/requests/cpu").and_then(|v| v.as_str()) {
+                        req_cpu += srelens_kube::metrics::cpu_millicores(c_req_cpu);
+                    }
+                    if let Some(c_lim_cpu) = c.pointer("/resources/limits/cpu").and_then(|v| v.as_str()) {
+                        lim_cpu += srelens_kube::metrics::cpu_millicores(c_lim_cpu);
+                    }
+                    if let Some(c_req_mem) = c.pointer("/resources/requests/memory").and_then(|v| v.as_str()) {
+                        req_mem += srelens_kube::metrics::mem_mib(c_req_mem);
+                    }
+                    if let Some(c_lim_mem) = c.pointer("/resources/limits/memory").and_then(|v| v.as_str()) {
+                        lim_mem += srelens_kube::metrics::mem_mib(c_lim_mem);
+                    }
+                }
+            }
+        }
+        (req_cpu, lim_cpu, req_mem, lim_mem)
+    }
+
+    pub fn set_data(&mut self, pods: Vec<TopPodRow>, nodes: Vec<TopNodeRow>) {
+        self.pods = pods;
+        self.nodes = nodes;
+        self.sort_current();
+        self.clamp_selection();
+    }
+
+    pub fn toggle_tab(&mut self) {
+        self.active_tab = match self.active_tab {
+            TopTab::Pods => TopTab::Nodes,
+            TopTab::Nodes => TopTab::Pods,
+        };
+        self.selected_idx = 0;
+        self.scroll_offset = 0;
+        self.sort_current();
+    }
+
+    pub fn set_tab(&mut self, tab: TopTab) {
+        if self.active_tab != tab {
+            self.active_tab = tab;
+            self.selected_idx = 0;
+            self.scroll_offset = 0;
+            self.sort_current();
+        }
+    }
+
+    pub fn set_sort_by(&mut self, sort: TopSortBy) {
+        if self.sort_by == sort {
+            self.sort_ascending = !self.sort_ascending;
+        } else {
+            self.sort_by = sort;
+            self.sort_ascending = false;
+        }
+        self.sort_current();
+    }
+
+    pub fn toggle_sort_direction(&mut self) {
+        self.sort_ascending = !self.sort_ascending;
+        self.sort_current();
+    }
+
+    pub fn sort_current(&mut self) {
+        let asc = self.sort_ascending;
+        match self.active_tab {
+            TopTab::Pods => {
+                match self.sort_by {
+                    TopSortBy::Cpu => {
+                        self.pods.sort_by(|a, b| {
+                            let cmp = a.cpu_millicores.cmp(&b.cpu_millicores);
+                            if asc { cmp } else { cmp.reverse() }
+                        });
+                    }
+                    TopSortBy::Memory => {
+                        self.pods.sort_by(|a, b| {
+                            let cmp = a.mem_mib.cmp(&b.mem_mib);
+                            if asc { cmp } else { cmp.reverse() }
+                        });
+                    }
+                }
+            }
+            TopTab::Nodes => {
+                match self.sort_by {
+                    TopSortBy::Cpu => {
+                        self.nodes.sort_by(|a, b| {
+                            let cmp = a.cpu_millicores.cmp(&b.cpu_millicores);
+                            if asc { cmp } else { cmp.reverse() }
+                        });
+                    }
+                    TopSortBy::Memory => {
+                        self.nodes.sort_by(|a, b| {
+                            let cmp = a.mem_mib.cmp(&b.mem_mib);
+                            if asc { cmp } else { cmp.reverse() }
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn visible_count(&self) -> usize {
+        match self.active_tab {
+            TopTab::Pods => self.filtered_pods().len(),
+            TopTab::Nodes => self.filtered_nodes().len(),
+        }
+    }
+
+    pub fn filtered_pods(&self) -> Vec<&TopPodRow> {
+        let q = self.filter.to_lowercase();
+        self.pods
+            .iter()
+            .filter(|p| {
+                if q.is_empty() {
+                    true
+                } else {
+                    p.name.to_lowercase().contains(&q) || p.namespace.to_lowercase().contains(&q)
+                }
+            })
+            .collect()
+    }
+
+    pub fn filtered_nodes(&self) -> Vec<&TopNodeRow> {
+        let q = self.filter.to_lowercase();
+        self.nodes
+            .iter()
+            .filter(|n| {
+                if q.is_empty() {
+                    true
+                } else {
+                    n.name.to_lowercase().contains(&q)
+                }
+            })
+            .collect()
+    }
+
+    pub fn selected_pod(&self) -> Option<&TopPodRow> {
+        if self.active_tab != TopTab::Pods {
+            return None;
+        }
+        let filtered = self.filtered_pods();
+        filtered.get(self.selected_idx).copied()
+    }
+
+    pub fn selected_node(&self) -> Option<&TopNodeRow> {
+        if self.active_tab != TopTab::Nodes {
+            return None;
+        }
+        let filtered = self.filtered_nodes();
+        filtered.get(self.selected_idx).copied()
+    }
+
+    pub fn clamp_selection(&mut self) {
+        let count = self.visible_count();
+        if count == 0 {
+            self.selected_idx = 0;
+            self.scroll_offset = 0;
+        } else if self.selected_idx >= count {
+            self.selected_idx = count - 1;
+        }
+    }
+
+    pub fn select_next(&mut self) {
+        let count = self.visible_count();
+        if count > 0 && self.selected_idx + 1 < count {
+            self.selected_idx += 1;
+        }
+    }
+
+    pub fn select_prev(&mut self) {
+        if self.selected_idx > 0 {
+            self.selected_idx -= 1;
+        }
+    }
+
+    pub fn select_first(&mut self) {
+        self.selected_idx = 0;
+    }
+
+    pub fn select_last(&mut self) {
+        let count = self.visible_count();
+        if count > 0 {
+            self.selected_idx = count - 1;
+        }
+    }
+
+    pub fn scroll_page_down(&mut self, page_size: usize) {
+        let count = self.visible_count();
+        if count > 0 {
+            self.selected_idx = (self.selected_idx + page_size).min(count - 1);
+        }
+    }
+
+    pub fn scroll_page_up(&mut self, page_size: usize) {
+        self.selected_idx = self.selected_idx.saturating_sub(page_size);
+    }
+}
+
+pub fn format_cpu(m: i64) -> String {
+    if m >= 1000 {
+        format!("{:.2}c", m as f64 / 1000.0)
+    } else {
+        format!("{}m", m)
+    }
+}
+
+pub fn format_mem(mib: i64) -> String {
+    if mib >= 1024 {
+        format!("{:.2}Gi", mib as f64 / 1024.0)
+    } else {
+        format!("{}Mi", mib)
+    }
+}
+
+fn pct_style(pct: f64) -> Style {
+    if pct >= 90.0 {
+        Style::default().fg(Theme::red()).add_modifier(Modifier::BOLD)
+    } else if pct >= 70.0 {
+        Style::default().fg(Theme::yellow())
+    } else {
+        Style::default().fg(Theme::green())
+    }
+}
+
+fn format_pct_span(opt_pct: Option<f64>) -> Span<'static> {
+    match opt_pct {
+        Some(pct) => Span::styled(format!("{:>4.0}%", pct), pct_style(pct)),
+        None => Span::styled("   –", Style::default().fg(Theme::dim())),
+    }
+}
+
+pub fn render_top_view(f: &mut Frame, area: Rect, state: &TopViewState) {
+    f.render_widget(Clear, area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // Top header / tab bar
+            Constraint::Min(5),    // Table body
+        ])
+        .split(area);
+
+    // 1. Header with Tabs & Controls
+    let sort_label = match state.sort_by {
+        TopSortBy::Cpu => "CPU",
+        TopSortBy::Memory => "MEM",
+    };
+    let dir_symbol = if state.sort_ascending { "▲" } else { "▼" };
+
+    let pods_tab_style = if state.active_tab == TopTab::Pods {
+        Style::default().fg(Theme::sel_fg()).bg(Theme::sel_bg()).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Theme::dim())
+    };
+
+    let nodes_tab_style = if state.active_tab == TopTab::Nodes {
+        Style::default().fg(Theme::sel_fg()).bg(Theme::sel_bg()).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Theme::dim())
+    };
+
+    let filter_badge = if !state.filter.is_empty() {
+        format!(" [Filter: \"{}\"]", state.filter)
+    } else {
+        String::new()
+    };
+
+    let count = state.visible_count();
+    let header_line = Line::from(vec![
+        Span::raw(" "),
+        Span::styled(" [1] Pods ", pods_tab_style),
+        Span::raw(" "),
+        Span::styled(" [2] Nodes ", nodes_tab_style),
+        Span::raw("  │  "),
+        Span::styled(format!("Sort: {} {}", sort_label, dir_symbol), Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD)),
+        Span::styled(" (<c> CPU <m> MEM <S> Rev)  │  ", Style::default().fg(Theme::dim())),
+        Span::styled(format!("Total: {} items{}", count, filter_badge), Style::default().fg(Theme::fg())),
+        Span::styled("  │  <Tab> Toggle  <l> Logs  <d> Describe  <Esc> Back ", Style::default().fg(Theme::dim())),
+    ]);
+
+    let header_block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Theme::border_focus()))
+        .title(Span::styled(" Top Hotspots (k9s style) ", Theme::title()));
+
+    let inner_header = header_block.inner(chunks[0]);
+    f.render_widget(header_block, chunks[0]);
+    f.render_widget(ratatui::widgets::Paragraph::new(header_line), inner_header);
+
+    // 2. Table Body
+    let table_block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Theme::border()));
+
+    let inner_table = table_block.inner(chunks[1]);
+    f.render_widget(table_block, chunks[1]);
+
+    let visible_rows = inner_table.height.saturating_sub(1) as usize; // minus 1 for header
+    let sel = state.selected_idx;
+
+    match state.active_tab {
+        TopTab::Pods => {
+            let pods = state.filtered_pods();
+            if pods.is_empty() {
+                let empty_msg = Line::from(vec![
+                    Span::styled("No pod metrics available. (Ensure metrics-server is installed and pods are running)", Style::default().fg(Theme::dim())),
+                ]);
+                f.render_widget(ratatui::widgets::Paragraph::new(empty_msg), inner_table);
+                return;
+            }
+
+            let start_idx = if sel >= visible_rows {
+                sel.saturating_sub(visible_rows / 2).min(pods.len().saturating_sub(visible_rows))
+            } else {
+                0
+            };
+            let end_idx = (start_idx + visible_rows).min(pods.len());
+
+            let header_style = Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD);
+            let header = Row::new(vec![
+                Span::styled("NAMESPACE", header_style),
+                Span::styled("NAME", header_style),
+                Span::styled("CPU", header_style),
+                Span::styled("% REQ", header_style),
+                Span::styled("% LIM", header_style),
+                Span::styled("MEMORY", header_style),
+                Span::styled("% REQ", header_style),
+                Span::styled("% LIM", header_style),
+            ]).bottom_margin(0);
+
+            let rows: Vec<Row> = pods[start_idx..end_idx]
+                .iter()
+                .enumerate()
+                .map(|(i, pod)| {
+                    let global_idx = start_idx + i;
+                    let is_selected = global_idx == sel;
+
+                    let row_style = if is_selected {
+                        Theme::selected_row()
+                    } else {
+                        Style::default().bg(Theme::bg())
+                    };
+
+                    let name_cell = if let Some(forwards) = state.active_port_forwards.get(&(pod.namespace.clone(), pod.name.clone())) {
+                        if !forwards.is_empty() {
+                            let pf_str = forwards
+                                .iter()
+                                .map(|(loc, rem, _)| {
+                                    if loc == rem {
+                                        format!("{}", loc)
+                                    } else {
+                                        format!("{}→{}", loc, rem)
+                                    }
+                                })
+                                .collect::<Vec<_>>()
+                                .join(",");
+                            Cell::from(Line::from(vec![
+                                Span::styled(pod.name.clone(), Style::default().fg(Theme::fg())),
+                                Span::raw(" "),
+                                Span::styled(format!("[PF: {}]", pf_str), Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)),
+                            ]))
+                        } else {
+                            Cell::from(Span::styled(pod.name.clone(), Style::default().fg(Theme::fg())))
+                        }
+                    } else {
+                        Cell::from(Span::styled(pod.name.clone(), Style::default().fg(Theme::fg())))
+                    };
+
+                    let cells = vec![
+                        Cell::from(Span::styled(pod.namespace.clone(), Style::default().fg(Theme::dim()))),
+                        name_cell,
+                        Cell::from(Span::styled(format_cpu(pod.cpu_millicores), Style::default().fg(Theme::fg()))),
+                        Cell::from(format_pct_span(pod.cpu_req_pct())),
+                        Cell::from(format_pct_span(pod.cpu_lim_pct())),
+                        Cell::from(Span::styled(format_mem(pod.mem_mib), Style::default().fg(Theme::fg()))),
+                        Cell::from(format_pct_span(pod.mem_req_pct())),
+                        Cell::from(format_pct_span(pod.mem_lim_pct())),
+                    ];
+
+                    Row::new(cells).style(row_style)
+                })
+                .collect();
+
+            let widths = [
+                Constraint::Length(18), // Namespace
+                Constraint::Min(25),    // Name
+                Constraint::Length(10), // CPU
+                Constraint::Length(8),  // % REQ
+                Constraint::Length(8),  // % LIM
+                Constraint::Length(10), // Memory
+                Constraint::Length(8),  // % REQ
+                Constraint::Length(8),  // % LIM
+            ];
+
+            let table = Table::new(rows, widths).header(header);
+            f.render_widget(table, inner_table);
+        }
+        TopTab::Nodes => {
+            let nodes = state.filtered_nodes();
+            if nodes.is_empty() {
+                let empty_msg = Line::from(vec![
+                    Span::styled("No node metrics available. (Ensure metrics-server is installed and nodes are ready)", Style::default().fg(Theme::dim())),
+                ]);
+                f.render_widget(ratatui::widgets::Paragraph::new(empty_msg), inner_table);
+                return;
+            }
+
+            let start_idx = if sel >= visible_rows {
+                sel.saturating_sub(visible_rows / 2).min(nodes.len().saturating_sub(visible_rows))
+            } else {
+                0
+            };
+            let end_idx = (start_idx + visible_rows).min(nodes.len());
+
+            let header_style = Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD);
+            let header = Row::new(vec![
+                Span::styled("NAME", header_style),
+                Span::styled("STATUS", header_style),
+                Span::styled("CPU USAGE", header_style),
+                Span::styled("CPU ALLOC", header_style),
+                Span::styled("% CPU", header_style),
+                Span::styled("MEM USAGE", header_style),
+                Span::styled("MEM ALLOC", header_style),
+                Span::styled("% MEM", header_style),
+            ]).bottom_margin(0);
+
+            let rows: Vec<Row> = nodes[start_idx..end_idx]
+                .iter()
+                .enumerate()
+                .map(|(i, node)| {
+                    let global_idx = start_idx + i;
+                    let is_selected = global_idx == sel;
+
+                    let row_style = if is_selected {
+                        Theme::selected_row()
+                    } else {
+                        Style::default().bg(Theme::bg())
+                    };
+
+                    let status_style = if node.status.eq_ignore_ascii_case("Ready") {
+                        Style::default().fg(Theme::green())
+                    } else {
+                        Style::default().fg(Theme::red())
+                    };
+
+                    let cells = vec![
+                        Span::styled(node.name.clone(), Style::default().fg(Theme::fg())),
+                        Span::styled(node.status.clone(), status_style),
+                        Span::styled(format_cpu(node.cpu_millicores), Style::default().fg(Theme::fg())),
+                        Span::styled(format_cpu(node.cpu_alloc_millicores), Style::default().fg(Theme::dim())),
+                        format_pct_span(node.cpu_alloc_pct()),
+                        Span::styled(format_mem(node.mem_mib), Style::default().fg(Theme::fg())),
+                        Span::styled(format_mem(node.mem_alloc_mib), Style::default().fg(Theme::dim())),
+                        format_pct_span(node.mem_alloc_pct()),
+                    ];
+
+                    Row::new(cells).style(row_style)
+                })
+                .collect();
+
+            let widths = [
+                Constraint::Min(25),    // Name
+                Constraint::Length(12), // Status
+                Constraint::Length(12), // CPU Usage
+                Constraint::Length(12), // CPU Alloc
+                Constraint::Length(8),  // % CPU
+                Constraint::Length(12), // MEM Usage
+                Constraint::Length(12), // MEM Alloc
+                Constraint::Length(8),  // % MEM
+            ];
+
+            let table = Table::new(rows, widths).header(header);
+            f.render_widget(table, inner_table);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    #[test]
+    fn test_top_pod_calculations_and_sorting() {
+        let mut state = TopViewState::new(TopTab::Pods);
+        let pods = vec![
+            TopPodRow {
+                namespace: "default".to_string(),
+                name: "api-gateway".to_string(),
+                cpu_millicores: 800,
+                cpu_req_millicores: 1000,
+                cpu_lim_millicores: 2000,
+                mem_mib: 1024,
+                mem_req_mib: 2048,
+                mem_lim_mib: 4096,
+            },
+            TopPodRow {
+                namespace: "default".to_string(),
+                name: "heavy-worker".to_string(),
+                cpu_millicores: 1600,
+                cpu_req_millicores: 1000,
+                cpu_lim_millicores: 2000,
+                mem_mib: 3000,
+                mem_req_mib: 2048,
+                mem_lim_mib: 4096,
+            },
+        ];
+
+        state.set_data(pods, vec![]);
+        // Default sort is CPU descending
+        assert_eq!(state.filtered_pods()[0].name, "heavy-worker");
+        assert_eq!(state.filtered_pods()[1].name, "api-gateway");
+
+        // Percentage calculations
+        let top = state.filtered_pods()[0];
+        assert_eq!(top.cpu_req_pct(), Some(160.0));
+        assert_eq!(top.cpu_lim_pct(), Some(80.0));
+
+        // Switch sort to Memory
+        state.set_sort_by(TopSortBy::Memory);
+        assert_eq!(state.filtered_pods()[0].name, "heavy-worker");
+
+        // Reverse sort
+        state.toggle_sort_direction();
+        assert_eq!(state.filtered_pods()[0].name, "api-gateway");
+    }
+
+    #[test]
+    fn test_top_nodes_rendering() {
+        let mut state = TopViewState::new(TopTab::Nodes);
+        let nodes = vec![
+            TopNodeRow {
+                name: "node-worker-1".to_string(),
+                status: "Ready".to_string(),
+                cpu_millicores: 3200,
+                cpu_alloc_millicores: 4000,
+                mem_mib: 12000,
+                mem_alloc_mib: 16000,
+            },
+        ];
+        state.set_data(vec![], nodes);
+
+        let backend = TestBackend::new(100, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                render_top_view(f, area, &state);
+            })
+            .unwrap();
+
+        let buffer = terminal.backend().buffer();
+        let rendered: String = (0..buffer.area.height)
+            .flat_map(|y| {
+                let mut line = String::new();
+                for x in 0..buffer.area.width {
+                    line.push_str(buffer[(x, y)].symbol());
+                }
+                line.push('\n');
+                line.into_bytes()
+            })
+            .map(|b| b as char)
+            .collect();
+
+        assert!(rendered.contains("Top Hotspots"));
+        assert!(rendered.contains("node-worker-1"));
+        assert!(rendered.contains("Ready"));
+        assert!(rendered.contains("3.20c") || rendered.contains("3200m"));
+    }
+}

--- a/apps/tui/src/views/top_view.rs
+++ b/apps/tui/src/views/top_view.rs
@@ -702,4 +702,147 @@ mod tests {
         assert!(rendered.contains("Ready"));
         assert!(rendered.contains("3.20c") || rendered.contains("3200m"));
     }
+
+    #[test]
+    fn test_top_pod_rendering_and_full_navigation() {
+        let mut state = TopViewState::new(TopTab::Pods);
+        assert_eq!(state.active_tab, TopTab::Pods);
+
+        // 1. Empty state
+        let backend = TestBackend::new(120, 25);
+        let mut terminal = Terminal::new(backend).unwrap();
+        state.set_data(vec![], vec![]);
+        terminal.draw(|f| render_top_view(f, f.area(), &state)).unwrap();
+
+        // Switch to Nodes empty state
+        state.toggle_tab();
+        assert_eq!(state.active_tab, TopTab::Nodes);
+        terminal.draw(|f| render_top_view(f, f.area(), &state)).unwrap();
+        state.toggle_tab();
+
+        // 2. Populated Pods with port forwards and high % thresholds
+        let pods = vec![
+            TopPodRow {
+                namespace: "default".to_string(),
+                name: "api-gw".to_string(),
+                cpu_millicores: 1500,
+                cpu_req_millicores: 1000,
+                cpu_lim_millicores: 2000,
+                mem_mib: 2500,
+                mem_req_mib: 2048,
+                mem_lim_mib: 2048,
+            },
+            TopPodRow {
+                namespace: "kube-system".to_string(),
+                name: "coredns".to_string(),
+                cpu_millicores: 50,
+                cpu_req_millicores: 100,
+                cpu_lim_millicores: 0,
+                mem_mib: 70,
+                mem_req_mib: 100,
+                mem_lim_mib: 0,
+            },
+            TopPodRow {
+                namespace: "monitoring".to_string(),
+                name: "prometheus-0".to_string(),
+                cpu_millicores: 950,
+                cpu_req_millicores: 1000,
+                cpu_lim_millicores: 1000,
+                mem_mib: 4000,
+                mem_req_mib: 4000,
+                mem_lim_mib: 4000,
+            },
+        ];
+
+        let nodes = vec![
+            TopNodeRow {
+                name: "node-1".to_string(),
+                status: "Ready".to_string(),
+                cpu_millicores: 3500,
+                cpu_alloc_millicores: 4000,
+                mem_mib: 15000,
+                mem_alloc_mib: 16000,
+            },
+            TopNodeRow {
+                name: "node-2".to_string(),
+                status: "NotReady".to_string(),
+                cpu_millicores: 100,
+                cpu_alloc_millicores: 4000,
+                mem_mib: 1000,
+                mem_alloc_mib: 16000,
+            },
+        ];
+
+        state.set_data(pods, nodes);
+        // Active port forwards on api-gw with both same port and mapped port
+        state.active_port_forwards.insert(
+            ("default".to_string(), "api-gw".to_string()),
+            vec![(8080, 8080, "http".to_string()), (9090, 80, "web".to_string())],
+        );
+
+        // Render populated Pods table
+        terminal.draw(|f| render_top_view(f, f.area(), &state)).unwrap();
+
+        // Check selected pod
+        assert!(state.selected_pod().is_some());
+
+        // Test navigation
+        state.select_next();
+        state.select_prev();
+        state.select_last();
+        state.select_first();
+        state.scroll_page_down(2);
+        state.scroll_page_up(2);
+
+        // Test filter
+        state.filter = "coredns".to_string();
+        assert_eq!(state.filtered_pods().len(), 1);
+        assert_eq!(state.filtered_pods()[0].name, "coredns");
+        state.filter.clear();
+
+        // Test sort variants
+        state.set_sort_by(TopSortBy::Memory);
+        state.set_sort_by(TopSortBy::Cpu);
+
+        // Switch to Nodes tab and test sorting / navigation
+        state.set_tab(TopTab::Nodes);
+        assert_eq!(state.active_tab, TopTab::Nodes);
+        assert!(state.selected_node().is_some());
+        state.set_sort_by(TopSortBy::Memory);
+        state.set_sort_by(TopSortBy::Cpu);
+
+        // Render populated Nodes table (exercises NotReady status style)
+        terminal.draw(|f| render_top_view(f, f.area(), &state)).unwrap();
+
+        // Test format_pct_span edge cases
+        let _ = format_pct_span(None);
+        let _ = format_pct_span(Some(50.0));
+        let _ = format_pct_span(Some(85.0));
+        let _ = format_pct_span(Some(95.0));
+
+        // Test extract_pod_resources
+        let mock_pod_json = serde_json::json!({
+            "cpuReqMillicores": 250,
+            "cpuLimMillicores": 500,
+            "memReqMiB": 128,
+            "memLimMiB": 256,
+        });
+        let res = TopViewState::extract_pod_resources(&mock_pod_json);
+        assert_eq!(res, (250, 500, 128, 256));
+
+        let mock_pod_spec = serde_json::json!({
+            "spec": {
+                "containers": [
+                    {
+                        "resources": {
+                            "requests": { "cpu": "100m", "memory": "64Mi" },
+                            "limits": { "cpu": "200m", "memory": "128Mi" }
+                        }
+                    }
+                ]
+            }
+        });
+        let res_spec = TopViewState::extract_pod_resources(&mock_pod_spec);
+        assert_eq!(res_spec, (100, 200, 64, 128));
+    }
 }

--- a/apps/tui/src/views/topology_view.rs
+++ b/apps/tui/src/views/topology_view.rs
@@ -690,5 +690,177 @@ mod tests {
 
         state.select_prev_lane();
         assert_eq!(state.selected_lane, 2); // Moves back to Workloads
+
+        // Test node selection within lane
+        state.select_next_node();
+        state.select_prev_node();
+        state.select_last_node();
+        state.select_first_node();
+        assert_eq!(state.selected_in_lane, 0);
+
+        // Test empty / None edge cases
+        let empty_state = TopologyViewState::new(vec![]);
+        let (conn, in_e, out_e) = empty_state.connected_path_node_ids();
+        assert!(conn.is_empty());
+        assert!(in_e.is_empty());
+        assert!(out_e.is_empty());
+
+        let mut error_state = TopologyViewState::new(vec!["test".to_string()]);
+        error_state.set_error("Connection refused".to_string());
+        assert_eq!(error_state.error, Some("Connection refused".to_string()));
+        assert!(!error_state.is_loading);
+    }
+
+    #[test]
+    fn test_render_topology_view_states_and_branches() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        // 1. Loading state
+        let loading_state = TopologyViewState::new(vec!["prod".to_string()]);
+        let backend = TestBackend::new(120, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                render_topology_view(f, f.area(), &loading_state);
+            })
+            .unwrap();
+
+        // 2. Error state
+        let mut error_state = TopologyViewState::new(vec!["prod".to_string()]);
+        error_state.set_error("Cluster timeout".to_string());
+        terminal
+            .draw(|f| {
+                render_topology_view(f, f.area(), &error_state);
+            })
+            .unwrap();
+
+        // 3. No graph
+        let mut no_graph = TopologyViewState::new(vec!["prod".to_string()]);
+        no_graph.is_loading = false;
+        terminal
+            .draw(|f| {
+                render_topology_view(f, f.area(), &no_graph);
+            })
+            .unwrap();
+
+        // 4. Empty graph
+        let mut empty_graph = TopologyViewState::new(vec![]);
+        empty_graph.set_graph(TopologyGraphOut {
+            nodes: vec![],
+            edges: vec![],
+            probe: None,
+        });
+        terminal
+            .draw(|f| {
+                render_topology_view(f, f.area(), &empty_graph);
+            })
+            .unwrap();
+
+        // 5. Populated graph with all health variants and replica lane
+        let mut full_state = TopologyViewState::new(vec!["prod".to_string(), "staging".to_string()]);
+        let mut graph = sample_graph();
+        // Add a ReplicaSet node to exercise the Revisions lane
+        graph.nodes.push(TopologyNode {
+            id: "ReplicaSet/prod/checkout-api-rs1".to_string(),
+            kind: "ReplicaSet".to_string(),
+            name: "checkout-api-rs1".to_string(),
+            namespace: "prod".to_string(),
+            lane: Lane::ReplicaSet,
+            detail: String::new(),
+            ready: Some(3),
+            desired: Some(3),
+            health: Health::Degraded,
+        });
+        // Add another node with Health::Failing and another with Health::Unknown
+        graph.nodes.push(TopologyNode {
+            id: "Deployment/prod/failing-worker".to_string(),
+            kind: "Deployment".to_string(),
+            name: "failing-worker".to_string(),
+            namespace: "prod".to_string(),
+            lane: Lane::Workload,
+            detail: "CrashLoopBackOff".to_string(),
+            ready: Some(0),
+            desired: Some(2),
+            health: Health::Failing,
+        });
+        graph.nodes.push(TopologyNode {
+            id: "Deployment/prod/unknown-svc".to_string(),
+            kind: "Deployment".to_string(),
+            name: "unknown-svc".to_string(),
+            namespace: "prod".to_string(),
+            lane: Lane::Workload,
+            detail: String::new(),
+            ready: None,
+            desired: None,
+            health: Health::Unknown,
+        });
+        // Add edges with Provenance::Allowed and Observed
+        graph.edges.push(TopologyEdge {
+            from: "Deployment/prod/checkout-api".to_string(),
+            to: "Deployment/prod/failing-worker".to_string(),
+            kind: EdgeKind::Calls,
+            provenance: Provenance::Allowed,
+            detail: "internal-rpc".to_string(),
+            weight: None,
+            unit: None,
+            health: Health::Degraded,
+        });
+        graph.edges.push(TopologyEdge {
+            from: "Deployment/prod/unknown-svc".to_string(),
+            to: "Deployment/prod/checkout-api".to_string(),
+            kind: EdgeKind::Calls,
+            provenance: Provenance::Observed,
+            detail: String::new(),
+            weight: None,
+            unit: None,
+            health: Health::Ok,
+        });
+        full_state.set_graph(graph);
+
+        // Render with full detail (height >= 14)
+        terminal
+            .draw(|f| {
+                render_topology_view(f, f.area(), &full_state);
+            })
+            .unwrap();
+
+        // Render with small height (height < 14) to test no-detail branch
+        let small_backend = TestBackend::new(100, 10);
+        let mut small_terminal = Terminal::new(small_backend).unwrap();
+        small_terminal
+            .draw(|f| {
+                render_topology_view(f, f.area(), &full_state);
+            })
+            .unwrap();
+
+        // Test scrolling inside a lane with many nodes
+        let mut scroll_state = TopologyViewState::new(vec!["prod".to_string()]);
+        let mut many_nodes_graph = TopologyGraphOut {
+            nodes: Vec::new(),
+            edges: Vec::new(),
+            probe: None,
+        };
+        for i in 0..15 {
+            many_nodes_graph.nodes.push(TopologyNode {
+                id: format!("Deployment/prod/app-{}", i),
+                kind: "Deployment".to_string(),
+                name: format!("app-{}", i),
+                namespace: "prod".to_string(),
+                lane: Lane::Workload,
+                detail: format!("{}/1 ready", i),
+                ready: Some(i),
+                desired: Some(1),
+                health: Health::Ok,
+            });
+        }
+        scroll_state.set_graph(many_nodes_graph);
+        // Select deep node to trigger scrolling logic
+        scroll_state.selected_in_lane = 10;
+        terminal
+            .draw(|f| {
+                render_topology_view(f, f.area(), &scroll_state);
+            })
+            .unwrap();
     }
 }

--- a/apps/tui/src/views/topology_view.rs
+++ b/apps/tui/src/views/topology_view.rs
@@ -1,0 +1,694 @@
+use std::collections::{HashMap, HashSet};
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
+use srelens_kube::topology::{
+    EdgeKind, Health, Lane, Provenance, TopologyEdge, TopologyGraphOut, TopologyNode,
+};
+
+use crate::theme::Theme;
+
+#[derive(Debug, Clone)]
+pub struct LaneColumn {
+    pub lane: Lane,
+    pub title: &'static str,
+    pub node_indices: Vec<usize>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TopologyViewState {
+    pub namespaces: Vec<String>,
+    pub graph: Option<TopologyGraphOut>,
+    pub lanes: Vec<LaneColumn>,
+    pub selected_lane: usize,
+    pub selected_in_lane: usize,
+    pub lane_scroll: Vec<usize>,
+    pub is_loading: bool,
+    pub error: Option<String>,
+}
+
+impl TopologyViewState {
+    pub fn new(namespaces: Vec<String>) -> Self {
+        Self {
+            namespaces,
+            graph: None,
+            lanes: Vec::new(),
+            selected_lane: 0,
+            selected_in_lane: 0,
+            lane_scroll: Vec::new(),
+            is_loading: true,
+            error: None,
+        }
+    }
+
+    pub fn set_graph(&mut self, graph: TopologyGraphOut) {
+        let mut lane_map: HashMap<Lane, Vec<usize>> = HashMap::new();
+        for (idx, node) in graph.nodes.iter().enumerate() {
+            lane_map.entry(node.lane).or_default().push(idx);
+        }
+
+        // We organize lanes into logical flow order:
+        // 1. Routes (Ingresses)
+        // 2. Services
+        // 3. Workloads (Deployments, StatefulSets, DaemonSets)
+        // 4. Revisions (ReplicaSets - only if present)
+        // 5. External Dependencies (Databases, Third-party APIs)
+        let mut lanes = Vec::new();
+        lanes.push(LaneColumn {
+            lane: Lane::Route,
+            title: "ROUTES (INGRESS)",
+            node_indices: lane_map.remove(&Lane::Route).unwrap_or_default(),
+        });
+        lanes.push(LaneColumn {
+            lane: Lane::Service,
+            title: "SERVICES",
+            node_indices: lane_map.remove(&Lane::Service).unwrap_or_default(),
+        });
+        lanes.push(LaneColumn {
+            lane: Lane::Workload,
+            title: "WORKLOADS",
+            node_indices: lane_map.remove(&Lane::Workload).unwrap_or_default(),
+        });
+
+        if let Some(replicas) = lane_map.remove(&Lane::ReplicaSet) {
+            if !replicas.is_empty() {
+                lanes.push(LaneColumn {
+                    lane: Lane::ReplicaSet,
+                    title: "REVISIONS",
+                    node_indices: replicas,
+                });
+            }
+        }
+
+        lanes.push(LaneColumn {
+            lane: Lane::External,
+            title: "DEPENDENCIES / EGRESS",
+            node_indices: lane_map.remove(&Lane::External).unwrap_or_default(),
+        });
+
+        self.lane_scroll = vec![0; lanes.len()];
+        self.lanes = lanes;
+        self.graph = Some(graph);
+        self.is_loading = false;
+        self.error = None;
+
+        // Auto-select the first non-empty lane (preferring Workloads or Services)
+        if let Some(pos) = self.lanes.iter().position(|l| l.lane == Lane::Workload && !l.node_indices.is_empty()) {
+            self.selected_lane = pos;
+            self.selected_in_lane = 0;
+        } else if let Some(pos) = self.lanes.iter().position(|l| !l.node_indices.is_empty()) {
+            self.selected_lane = pos;
+            self.selected_in_lane = 0;
+        } else {
+            self.selected_lane = 0;
+            self.selected_in_lane = 0;
+        }
+    }
+
+    pub fn set_error(&mut self, err: String) {
+        self.is_loading = false;
+        self.error = Some(err);
+    }
+
+    pub fn selected_node(&self) -> Option<&TopologyNode> {
+        let graph = self.graph.as_ref()?;
+        let lane = self.lanes.get(self.selected_lane)?;
+        let &node_idx = lane.node_indices.get(self.selected_in_lane)?;
+        graph.nodes.get(node_idx)
+    }
+
+    pub fn select_next_lane(&mut self) {
+        if self.lanes.is_empty() {
+            return;
+        }
+        let start = self.selected_lane;
+        for i in 1..=self.lanes.len() {
+            let next = (start + i) % self.lanes.len();
+            if !self.lanes[next].node_indices.is_empty() {
+                self.selected_lane = next;
+                let max_in_lane = self.lanes[next].node_indices.len().saturating_sub(1);
+                self.selected_in_lane = self.selected_in_lane.min(max_in_lane);
+                return;
+            }
+        }
+    }
+
+    pub fn select_prev_lane(&mut self) {
+        if self.lanes.is_empty() {
+            return;
+        }
+        let start = self.selected_lane;
+        for i in 1..=self.lanes.len() {
+            let prev = (start + self.lanes.len() - (i % self.lanes.len())) % self.lanes.len();
+            if !self.lanes[prev].node_indices.is_empty() {
+                self.selected_lane = prev;
+                let max_in_lane = self.lanes[prev].node_indices.len().saturating_sub(1);
+                self.selected_in_lane = self.selected_in_lane.min(max_in_lane);
+                return;
+            }
+        }
+    }
+
+    pub fn select_next_node(&mut self) {
+        if let Some(lane) = self.lanes.get(self.selected_lane) {
+            if !lane.node_indices.is_empty() && self.selected_in_lane + 1 < lane.node_indices.len() {
+                self.selected_in_lane += 1;
+            }
+        }
+    }
+
+    pub fn select_prev_node(&mut self) {
+        self.selected_in_lane = self.selected_in_lane.saturating_sub(1);
+    }
+
+    pub fn select_first_node(&mut self) {
+        self.selected_in_lane = 0;
+    }
+
+    pub fn select_last_node(&mut self) {
+        if let Some(lane) = self.lanes.get(self.selected_lane) {
+            if !lane.node_indices.is_empty() {
+                self.selected_in_lane = lane.node_indices.len() - 1;
+            }
+        }
+    }
+
+    /// Trace the full connected path for the currently selected node:
+    /// returns set of all node IDs that are upstream ancestors or downstream targets.
+    pub fn connected_path_node_ids(&self) -> (HashSet<String>, Vec<&TopologyEdge>, Vec<&TopologyEdge>) {
+        let mut connected = HashSet::new();
+        let mut incoming_edges = Vec::new();
+        let mut outgoing_edges = Vec::new();
+
+        let Some(sel_node) = self.selected_node() else {
+            return (connected, incoming_edges, outgoing_edges);
+        };
+        let target_id = &sel_node.id;
+        connected.insert(target_id.clone());
+
+        let Some(graph) = &self.graph else {
+            return (connected, incoming_edges, outgoing_edges);
+        };
+
+        // 1. Direct incoming edges to target
+        for edge in &graph.edges {
+            if edge.to == *target_id {
+                incoming_edges.push(edge);
+                connected.insert(edge.from.clone());
+            }
+            if edge.from == *target_id {
+                outgoing_edges.push(edge);
+                connected.insert(edge.to.clone());
+            }
+        }
+
+        // 2. Upstream transitive search (e.g. Ingress -> Service -> Workload)
+        let mut frontier: Vec<String> = incoming_edges.iter().map(|e| e.from.clone()).collect();
+        while let Some(current) = frontier.pop() {
+            for edge in &graph.edges {
+                if edge.to == current && !connected.contains(&edge.from) {
+                    connected.insert(edge.from.clone());
+                    frontier.push(edge.from.clone());
+                }
+            }
+        }
+
+        // 3. Downstream transitive search (e.g. Workload -> Dependency)
+        let mut down_frontier: Vec<String> = outgoing_edges.iter().map(|e| e.to.clone()).collect();
+        while let Some(current) = down_frontier.pop() {
+            for edge in &graph.edges {
+                if edge.from == current && !connected.contains(&edge.to) {
+                    connected.insert(edge.to.clone());
+                    down_frontier.push(edge.to.clone());
+                }
+            }
+        }
+
+        (connected, incoming_edges, outgoing_edges)
+    }
+}
+
+pub fn render_topology_view(f: &mut Frame, area: Rect, state: &TopologyViewState) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Theme::border()))
+        .title(Span::styled(
+            format!(
+                " Workload & Traffic Topology Flow [{}] ",
+                if state.namespaces.is_empty() {
+                    "all namespaces".to_string()
+                } else {
+                    state.namespaces.join(", ")
+                }
+            ),
+            Theme::title(),
+        ));
+
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    if state.is_loading {
+        let msg = Paragraph::new(Line::from(vec![
+            Span::styled("⚡ Building topology graph ", Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)),
+            Span::styled("resolving ingresses, services, selectors & dependencies...", Style::default().fg(Theme::dim())),
+        ]));
+        f.render_widget(msg, inner);
+        return;
+    }
+
+    if let Some(err) = &state.error {
+        let msg = Paragraph::new(vec![
+            Line::from(Span::styled("✖ Failed to build topology graph:", Theme::status_error().add_modifier(Modifier::BOLD))),
+            Line::from(Span::styled(err.clone(), Style::default().fg(Theme::fg()))),
+            Line::from(""),
+            Line::from(Span::styled("Press <r> to retry or <Esc> to return.", Style::default().fg(Theme::dim()))),
+        ]);
+        f.render_widget(msg, inner);
+        return;
+    }
+
+    let Some(graph) = &state.graph else {
+        let msg = Paragraph::new("No topology graph available.");
+        f.render_widget(msg, inner);
+        return;
+    };
+
+    if graph.nodes.is_empty() {
+        let msg = Paragraph::new(Line::from(vec![
+            Span::styled("No workloads, services or ingresses found in this namespace scope.", Style::default().fg(Theme::dim())),
+        ]));
+        f.render_widget(msg, inner);
+        return;
+    }
+
+    // Split inner area into:
+    // 1. Lanes columns (main flow)
+    // 2. Bottom detail & path inspector (6-8 rows)
+    let has_detail = inner.height >= 14;
+    let chunks = if has_detail {
+        Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(8), Constraint::Length(7)])
+            .split(inner)
+    } else {
+        Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(4)])
+            .split(inner)
+    };
+
+    let (connected_ids, in_edges, out_edges) = state.connected_path_node_ids();
+    let sel_node_opt = state.selected_node();
+
+    // Render lane columns
+    let lane_count = state.lanes.len();
+    if lane_count > 0 {
+        let lane_constraints: Vec<Constraint> = vec![Constraint::Ratio(1, lane_count as u32); lane_count];
+        let lane_areas = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints(lane_constraints)
+            .split(chunks[0]);
+
+        for (lane_idx, lane_col) in state.lanes.iter().enumerate() {
+            let lane_area = lane_areas[lane_idx];
+            let is_lane_focused = lane_idx == state.selected_lane;
+
+            let lane_border_color = if is_lane_focused {
+                Theme::accent()
+            } else {
+                Theme::border()
+            };
+
+            let lane_title = format!(" {} [{}] ", lane_col.title, lane_col.node_indices.len());
+            let lane_block = Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(lane_border_color))
+                .title(Span::styled(
+                    lane_title,
+                    if is_lane_focused {
+                        Style::default().fg(Theme::accent()).add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(Theme::dim())
+                    },
+                ));
+
+            let lane_inner = lane_block.inner(lane_area);
+            f.render_widget(lane_block, lane_area);
+
+            if lane_col.node_indices.is_empty() {
+                let empty_msg = Paragraph::new(Span::styled(" (none)", Style::default().fg(Theme::dim())));
+                f.render_widget(empty_msg, lane_inner);
+                continue;
+            }
+
+            // Each node card takes 3 rows:
+            // ┌ Kind: Name ──┐
+            // │ ● 3/3 ready  │
+            // └──────────────┘
+            let card_height = 3usize;
+            let visible_cards = (lane_inner.height as usize) / card_height;
+            let sel_in_lane = if is_lane_focused { state.selected_in_lane } else { 0 };
+
+            // Compute windowed scroll for this lane
+            let scroll_offset = if sel_in_lane >= visible_cards {
+                sel_in_lane.saturating_sub(visible_cards.saturating_sub(1))
+            } else {
+                0
+            };
+
+            for (slot_idx, &node_idx) in lane_col.node_indices.iter().skip(scroll_offset).take(visible_cards).enumerate() {
+                let node = &graph.nodes[node_idx];
+                let is_node_selected = is_lane_focused && (scroll_offset + slot_idx == state.selected_in_lane);
+                let is_in_path = connected_ids.contains(&node.id);
+
+                let card_y = lane_inner.y + (slot_idx * card_height) as u16;
+                let card_area = Rect {
+                    x: lane_inner.x,
+                    y: card_y,
+                    width: lane_inner.width,
+                    height: 3,
+                };
+
+                let (health_dot, health_style) = match node.health {
+                    Health::Ok => ("●", Theme::status_ok()),
+                    Health::Degraded => ("▲", Theme::status_warn()),
+                    Health::Failing => ("✖", Theme::status_error()),
+                    Health::Unknown => ("○", Theme::status_dim()),
+                };
+
+                let card_border_style = if is_node_selected {
+                    Style::default().fg(Theme::sel_fg()).add_modifier(Modifier::BOLD)
+                } else if is_in_path {
+                    Style::default().fg(Theme::cyan())
+                } else {
+                    Style::default().fg(Theme::dim())
+                };
+
+                let card_bg = if is_node_selected {
+                    Theme::selected_row().bg.unwrap_or(Color::Reset)
+                } else if is_in_path {
+                    if Theme::active_palette().is_light {
+                        Color::Rgb(235, 243, 250)
+                    } else {
+                        Color::Rgb(28, 35, 45)
+                    }
+                } else {
+                    Color::Reset
+                };
+
+                let card_title = format!(" {} ", node.kind);
+                let card_block = Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(card_border_style)
+                    .style(Style::default().bg(card_bg))
+                    .title(Span::styled(card_title, if is_node_selected {
+                        Style::default().fg(Theme::sel_fg()).add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(Theme::dim())
+                    }));
+
+                let card_inner = card_block.inner(card_area);
+                f.render_widget(card_block, card_area);
+
+                // Line 1: Name and optional path marker
+                let path_marker = if is_node_selected {
+                    "▶ "
+                } else if is_in_path {
+                    "⚡ "
+                } else {
+                    ""
+                };
+
+                let name_line = Line::from(vec![
+                    Span::styled(path_marker, if is_node_selected { Style::default().fg(Theme::accent()) } else { Style::default().fg(Theme::cyan()) }),
+                    Span::styled(
+                        crate::views::sanitize_span_text(&node.name),
+                        if is_node_selected {
+                            Style::default().fg(Theme::sel_fg()).add_modifier(Modifier::BOLD)
+                        } else if is_in_path {
+                            Style::default().fg(Theme::fg()).add_modifier(Modifier::BOLD)
+                        } else {
+                            Style::default().fg(Theme::fg())
+                        },
+                    ),
+                ]);
+
+                // Line 2: Health dot + detail (e.g. 3/3 ready, :80 -> :8080)
+                let detail_text = if !node.detail.is_empty() {
+                    format!(" {}", node.detail)
+                } else if let (Some(r), Some(d)) = (node.ready, node.desired) {
+                    format!(" {}/{} ready", r, d)
+                } else {
+                    String::new()
+                };
+
+                let status_line = Line::from(vec![
+                    Span::styled(format!("{} ", health_dot), health_style),
+                    Span::styled(crate::views::sanitize_span_text(&detail_text), Style::default().fg(Theme::dim())),
+                ]);
+
+                let card_content = Paragraph::new(vec![name_line, status_line]);
+                f.render_widget(card_content, card_inner);
+            }
+        }
+    }
+
+    // Render Bottom Detail & Path Inspector
+    if has_detail && chunks.len() > 1 {
+        let inspector_area = chunks[1];
+        let inspector_block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Theme::border_focus()))
+            .title(Span::styled(" Flow & Dependency Inspector ", Theme::title()));
+
+        let inspector_inner = inspector_block.inner(inspector_area);
+        f.render_widget(inspector_block, inspector_area);
+
+        if let Some(node) = sel_node_opt {
+            let (health_label, health_style) = match node.health {
+                Health::Ok => ("Ok", Theme::status_ok()),
+                Health::Degraded => ("Degraded", Theme::status_warn()),
+                Health::Failing => ("Failing", Theme::status_error()),
+                Health::Unknown => ("Unknown", Theme::status_dim()),
+            };
+
+            let ready_str = if let (Some(r), Some(d)) = (node.ready, node.desired) {
+                format!("  Replicas: {}/{} ready", r, d)
+            } else if !node.detail.is_empty() {
+                format!("  Config: {}", node.detail)
+            } else {
+                String::new()
+            };
+
+            // Format line 1: Target Identity & Health
+            let l1 = Line::from(vec![
+                Span::styled(" Selected: ", Style::default().fg(Theme::dim())),
+                Span::styled(format!("[{}] ", node.kind), Style::default().fg(Theme::accent()).add_modifier(Modifier::BOLD)),
+                Span::styled(format!("{} ", node.name), Style::default().fg(Theme::sel_fg()).add_modifier(Modifier::BOLD)),
+                Span::styled(format!("({})", node.namespace), Style::default().fg(Theme::dim())),
+                Span::styled("   Health: ", Style::default().fg(Theme::dim())),
+                Span::styled(format!("● {}", health_label), health_style.add_modifier(Modifier::BOLD)),
+                Span::styled(ready_str, Style::default().fg(Theme::fg())),
+            ]);
+
+            // Format line 2: Incoming Routes / Sources
+            let in_summary = if in_edges.is_empty() {
+                "none (direct entry point)".to_string()
+            } else {
+                in_edges
+                    .iter()
+                    .map(|e| {
+                        let name = e.from.split('/').nth(2).unwrap_or(&e.from);
+                        let prov = match e.provenance {
+                            Provenance::Topology => "API",
+                            Provenance::Declared => "Config",
+                            Provenance::Allowed => "Policy",
+                            Provenance::Observed => "Observed",
+                        };
+                        format!("{} ──► [{} ({})]", name, node.name, prov)
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            };
+
+            let l2 = Line::from(vec![
+                Span::styled(" Incoming: ", Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)),
+                Span::styled(crate::views::sanitize_span_text(&in_summary), Style::default().fg(Theme::fg())),
+            ]);
+
+            // Format line 3: Outgoing Dependencies / Backings
+            let out_summary = if out_edges.is_empty() {
+                "none (leaf workload)".to_string()
+            } else {
+                out_edges
+                    .iter()
+                    .map(|e| {
+                        let target = e.to.split('/').nth(2).unwrap_or(&e.to);
+                        let prov = match e.provenance {
+                            Provenance::Topology => "API",
+                            Provenance::Declared => "Config",
+                            Provenance::Allowed => "Policy",
+                            Provenance::Observed => "Observed",
+                        };
+                        let detail = if !e.detail.is_empty() {
+                            format!(" ({})", e.detail)
+                        } else {
+                            String::new()
+                        };
+                        format!("{} ──► {}{} [{}]", node.name, target, detail, prov)
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            };
+
+            let l3 = Line::from(vec![
+                Span::styled(" Outgoing: ", Style::default().fg(Theme::green()).add_modifier(Modifier::BOLD)),
+                Span::styled(crate::views::sanitize_span_text(&out_summary), Style::default().fg(Theme::fg())),
+            ]);
+
+            let inspector_content = Paragraph::new(vec![l1, l2, l3]);
+            f.render_widget(inspector_content, inspector_inner);
+        } else {
+            let msg = Paragraph::new(Span::styled("Select a node above to inspect its traffic path and dependencies.", Style::default().fg(Theme::dim())));
+            f.render_widget(msg, inspector_inner);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_graph() -> TopologyGraphOut {
+        let nodes = vec![
+            TopologyNode {
+                id: "Ingress/prod/web-ingress".to_string(),
+                kind: "Ingress".to_string(),
+                name: "web-ingress".to_string(),
+                namespace: "prod".to_string(),
+                lane: Lane::Route,
+                detail: ":80, :443".to_string(),
+                ready: None,
+                desired: None,
+                health: Health::Ok,
+            },
+            TopologyNode {
+                id: "Service/prod/checkout-svc".to_string(),
+                kind: "Service".to_string(),
+                name: "checkout-svc".to_string(),
+                namespace: "prod".to_string(),
+                lane: Lane::Service,
+                detail: ":80 -> :8080".to_string(),
+                ready: None,
+                desired: None,
+                health: Health::Ok,
+            },
+            TopologyNode {
+                id: "Deployment/prod/checkout-api".to_string(),
+                kind: "Deployment".to_string(),
+                name: "checkout-api".to_string(),
+                namespace: "prod".to_string(),
+                lane: Lane::Workload,
+                detail: "3/3 ready".to_string(),
+                ready: Some(3),
+                desired: Some(3),
+                health: Health::Ok,
+            },
+            TopologyNode {
+                id: "External//postgres-primary:5432".to_string(),
+                kind: "External".to_string(),
+                name: "postgres-primary:5432".to_string(),
+                namespace: String::new(),
+                lane: Lane::External,
+                detail: "postgres-primary:5432".to_string(),
+                ready: None,
+                desired: None,
+                health: Health::Ok,
+            },
+        ];
+
+        let edges = vec![
+            TopologyEdge {
+                from: "Ingress/prod/web-ingress".to_string(),
+                to: "Service/prod/checkout-svc".to_string(),
+                kind: EdgeKind::Routes,
+                provenance: Provenance::Topology,
+                detail: String::new(),
+                weight: None,
+                unit: None,
+                health: Health::Ok,
+            },
+            TopologyEdge {
+                from: "Service/prod/checkout-svc".to_string(),
+                to: "Deployment/prod/checkout-api".to_string(),
+                kind: EdgeKind::Routes,
+                provenance: Provenance::Topology,
+                detail: String::new(),
+                weight: None,
+                unit: None,
+                health: Health::Ok,
+            },
+            TopologyEdge {
+                from: "Deployment/prod/checkout-api".to_string(),
+                to: "External//postgres-primary:5432".to_string(),
+                kind: EdgeKind::Calls,
+                provenance: Provenance::Declared,
+                detail: String::new(),
+                weight: None,
+                unit: None,
+                health: Health::Ok,
+            },
+        ];
+
+        TopologyGraphOut {
+            nodes,
+            edges,
+            probe: None,
+        }
+    }
+
+    #[test]
+    fn test_topology_state_lanes_and_path_tracing() {
+        let mut state = TopologyViewState::new(vec!["prod".to_string()]);
+        state.set_graph(sample_graph());
+
+        // Verify 4 lanes categorized correctly
+        assert_eq!(state.lanes.len(), 4);
+        assert_eq!(state.lanes[0].lane, Lane::Route);
+        assert_eq!(state.lanes[1].lane, Lane::Service);
+        assert_eq!(state.lanes[2].lane, Lane::Workload);
+        assert_eq!(state.lanes[3].lane, Lane::External);
+
+        // Auto-selects Workloads lane
+        assert_eq!(state.selected_lane, 2);
+        let sel = state.selected_node().expect("selected node");
+        assert_eq!(sel.name, "checkout-api");
+
+        // Verify connected path tracing:
+        // checkout-api connects upstream to checkout-svc and web-ingress, and downstream to postgres-primary
+        let (connected_ids, in_edges, out_edges) = state.connected_path_node_ids();
+        assert_eq!(connected_ids.len(), 4);
+        assert!(connected_ids.contains("Ingress/prod/web-ingress"));
+        assert!(connected_ids.contains("Service/prod/checkout-svc"));
+        assert!(connected_ids.contains("Deployment/prod/checkout-api"));
+        assert!(connected_ids.contains("External//postgres-primary:5432"));
+
+        assert_eq!(in_edges.len(), 1);
+        assert_eq!(in_edges[0].from, "Service/prod/checkout-svc");
+
+        assert_eq!(out_edges.len(), 1);
+        assert_eq!(out_edges[0].to, "External//postgres-primary:5432");
+
+        // Test navigation
+        state.select_next_lane();
+        assert_eq!(state.selected_lane, 3); // Moves to External
+        assert_eq!(state.selected_node().unwrap().name, "postgres-primary:5432");
+
+        state.select_prev_lane();
+        assert_eq!(state.selected_lane, 2); // Moves back to Workloads
+    }
+}

--- a/apps/tui/tests/app_extra_tests.rs
+++ b/apps/tui/tests/app_extra_tests.rs
@@ -1832,6 +1832,95 @@ async fn helm_keys_copy_a_deep_link_and_open_the_values_and_manifest() {
         }
         _ => panic!("expected the Helm manifest view"),
     }
+
+    // Direct HelmDetail key handling: tabs, diff toggle, scrolling, copy, esc
+    let mut detail_state = srelens_tui::views::HelmDetailViewState::new("nginx".into(), "default".into());
+    detail_state.set_detail(srelens_kube::helm::HelmReleaseDetail {
+        name: "nginx".into(),
+        namespace: "default".into(),
+        revision: 3,
+        status: "deployed".into(),
+        chart: "nginx".into(),
+        chart_version: "15.0.0".into(),
+        app_version: "1.25".into(),
+        updated: "2026-01-01".into(),
+        values_yaml: "replicaCount: 2\n".into(),
+        chart_values_yaml: "replicaCount: 1\n".into(),
+        computed_values_yaml: "replicaCount: 2\n".into(),
+        manifest: "---\nkind: Deployment\nmetadata:\n  name: nginx\n".into(),
+        notes: "Notes for nginx.\n".into(),
+        history: vec![
+            srelens_kube::helm::HelmRevision {
+                revision: 3,
+                status: "deployed".into(),
+                updated: "2026-01-01".into(),
+                chart_version: "15.0.0".into(),
+                description: "Upgrade".into(),
+            },
+            srelens_kube::helm::HelmRevision {
+                revision: 2,
+                status: "superseded".into(),
+                updated: "2025-12-01".into(),
+                chart_version: "14.0.0".into(),
+                description: "Upgrade".into(),
+            },
+        ],
+    });
+    app.active_view = ActiveView::HelmDetail(detail_state);
+
+    // Number keys switch tabs
+    app.handle_key_event(common::ch('1')).await;
+    if let ActiveView::HelmDetail(ref d) = app.active_view {
+        assert_eq!(d.active_tab, srelens_tui::views::HelmDetailTab::Overview);
+    }
+    app.handle_key_event(common::ch('2')).await;
+    if let ActiveView::HelmDetail(ref d) = app.active_view {
+        assert_eq!(d.active_tab, srelens_tui::views::HelmDetailTab::ValuesDiff);
+    }
+    app.handle_key_event(common::ch('m')).await;
+    if let ActiveView::HelmDetail(ref d) = app.active_view {
+        assert_eq!(d.values_diff_mode, srelens_tui::views::ValuesDiffMode::RevisionVsPrevious);
+    }
+    app.handle_key_event(common::ch('3')).await;
+    if let ActiveView::HelmDetail(ref d) = app.active_view {
+        assert_eq!(d.active_tab, srelens_tui::views::HelmDetailTab::Revisions);
+    }
+    app.handle_key_event(common::ch('j')).await;
+    app.handle_key_event(common::ch('k')).await;
+    app.handle_key_event(common::ch('4')).await;
+    if let ActiveView::HelmDetail(ref d) = app.active_view {
+        assert_eq!(d.active_tab, srelens_tui::views::HelmDetailTab::Manifest);
+    }
+    app.handle_key_event(common::ch('j')).await;
+    app.handle_key_event(common::ch('k')).await;
+    app.handle_key_event(common::ch('g')).await;
+    app.handle_key_event(common::key(crossterm::event::KeyCode::PageDown)).await;
+    app.handle_key_event(common::key(crossterm::event::KeyCode::PageUp)).await;
+    app.handle_key_event(common::ch('5')).await;
+    if let ActiveView::HelmDetail(ref d) = app.active_view {
+        assert_eq!(d.active_tab, srelens_tui::views::HelmDetailTab::Notes);
+    }
+
+    // Copy deep link and manifest/yaml
+    app.handle_key_event(common::ch('c')).await;
+    assert!(toast(&app).contains("Copied deep link"));
+    app.handle_key_event(common::ch('y')).await;
+    assert!(toast(&app).contains("Copied"));
+
+    // Tab and BackTab cycle tabs
+    app.handle_key_event(common::key(crossterm::event::KeyCode::Tab)).await;
+    app.handle_key_event(common::key(crossterm::event::KeyCode::BackTab)).await;
+    app.handle_key_event(common::ch('l')).await;
+    app.handle_key_event(common::ch('h')).await;
+
+    // Rollback triggers modal
+    app.handle_key_event(common::ch('r')).await;
+    assert!(app.modal.is_some());
+    app.modal = None;
+
+    // Esc returns to previous view
+    app.handle_key_event(common::key(crossterm::event::KeyCode::Esc)).await;
+    assert!(matches!(app.active_view, ActiveView::Table(_) | ActiveView::Helm(_)));
 }
 
 #[tokio::test]

--- a/apps/tui/tests/app_extra_tests.rs
+++ b/apps/tui/tests/app_extra_tests.rs
@@ -1879,7 +1879,7 @@ async fn helm_keys_copy_a_deep_link_and_open_the_values_and_manifest() {
     }
     app.handle_key_event(common::ch('m')).await;
     if let ActiveView::HelmDetail(ref d) = app.active_view {
-        assert_eq!(d.values_diff_mode, srelens_tui::views::ValuesDiffMode::RevisionVsPrevious);
+        assert_eq!(d.values_diff_mode, srelens_tui::views::ValuesDiffMode::CustomVsDefault);
     }
     app.handle_key_event(common::ch('3')).await;
     if let ActiveView::HelmDetail(ref d) = app.active_view {

--- a/apps/tui/tests/app_extra_tests.rs
+++ b/apps/tui/tests/app_extra_tests.rs
@@ -1448,18 +1448,22 @@ async fn cordoning_and_uncordoning_a_node_patches_it_and_reports_which_way_it_we
 
     app.active_view = ActiveView::NodeInspector(inspector("gpu-1", false, false));
     app.handle_key_event(common::ch('c')).await;
+    common::type_str(&mut app, "confirm").await;
+    app.handle_key_event(common::key(crossterm::event::KeyCode::Enter)).await;
     assert_eq!(toast(&app), "Cordoning node 'gpu-1'...");
     assert_eq!(
         action_result(&mut rx, "cordon_node:gpu-1").await,
-        Ok("Cordoned node 'gpu-1'".to_string())
+        Ok("✓ Cordoned node 'gpu-1'".to_string())
     );
 
     app.active_view = ActiveView::NodeInspector(inspector("gpu-1", true, false));
     app.handle_key_event(common::ch('c')).await;
+    common::type_str(&mut app, "confirm").await;
+    app.handle_key_event(common::key(crossterm::event::KeyCode::Enter)).await;
     assert_eq!(toast(&app), "Uncordoning node 'gpu-1'...");
     assert_eq!(
         action_result(&mut rx, "cordon_node:gpu-1").await,
-        Ok("Uncordoned node 'gpu-1'".to_string())
+        Ok("✓ Uncordoned node 'gpu-1'".to_string())
     );
 }
 
@@ -1470,6 +1474,8 @@ async fn a_cordon_the_apiserver_rejects_is_reported_as_an_error() {
 
     app.active_view = ActiveView::NodeInspector(inspector("gpu-1", false, false));
     app.handle_key_event(common::ch('c')).await;
+    common::type_str(&mut app, "confirm").await;
+    app.handle_key_event(common::key(crossterm::event::KeyCode::Enter)).await;
     let err = action_result(&mut rx, "cordon_node:gpu-1")
         .await
         .expect_err("a 409 fails the patch");
@@ -1785,6 +1791,7 @@ async fn helm_keys_copy_a_deep_link_and_open_the_values_and_manifest() {
             revision: 3,
             status: "deployed".into(),
             chart: "nginx-15.0.0".into(),
+            chart_version: "15.0.0".into(),
             app_version: "1.25".into(),
             updated: "2026-01-01".into(),
         }]);
@@ -1809,9 +1816,9 @@ async fn helm_keys_copy_a_deep_link_and_open_the_values_and_manifest() {
     app.active_view = ActiveView::Helm(helm());
     app.handle_key_event(common::ch('v')).await;
     match &app.active_view {
-        ActiveView::Yaml(y) => {
-            assert_eq!(y.resource_kind, "HelmValues");
-            assert_eq!(y.resource_name, "nginx");
+        ActiveView::HelmDetail(d) => {
+            assert_eq!(d.active_tab, srelens_tui::views::HelmDetailTab::ValuesDiff);
+            assert_eq!(d.release_name, "nginx");
         }
         _ => panic!("expected the Helm values view"),
     }
@@ -1819,7 +1826,10 @@ async fn helm_keys_copy_a_deep_link_and_open_the_values_and_manifest() {
     app.active_view = ActiveView::Helm(helm());
     app.handle_key_event(common::ch('y')).await;
     match &app.active_view {
-        ActiveView::Yaml(y) => assert_eq!(y.resource_kind, "HelmManifest"),
+        ActiveView::HelmDetail(d) => {
+            assert_eq!(d.active_tab, srelens_tui::views::HelmDetailTab::Manifest);
+            assert_eq!(d.release_name, "nginx");
+        }
         _ => panic!("expected the Helm manifest view"),
     }
 }

--- a/apps/tui/tests/app_input_tests.rs
+++ b/apps/tui/tests/app_input_tests.rs
@@ -952,28 +952,36 @@ async fn command_mode_tab_and_arrow_keys_cycle_the_suggestions() {
     let len = suggestions.len();
     assert!(len > 1, "':s' should offer several commands");
 
-    // Each key completes to a suggestion; the buffer is reset between keys
-    // because completing changes the buffer and therefore the candidate list.
-    for k in [key(KeyCode::Tab), key(KeyCode::Down), ctrl('n')] {
+    // Tab completes to suggestion and advances index
+    app.command_buffer = "s".to_string();
+    app.command_suggestion_idx = 0;
+    press(&mut app, key(KeyCode::Tab)).await;
+    assert_eq!(app.command_buffer, suggestions[0].0.name);
+    assert_eq!(
+        app.command_suggestion_idx, 1,
+        "the cursor advances to the next candidate"
+    );
+
+    // Down arrow and Ctrl-N advance selection index in popup
+    for k in [key(KeyCode::Down), ctrl('n')] {
         app.command_buffer = "s".to_string();
         app.command_suggestion_idx = 0;
         press(&mut app, k).await;
-        assert_eq!(app.command_buffer, suggestions[0].0.name);
         assert_eq!(
             app.command_suggestion_idx, 1,
             "the cursor advances to the next candidate"
         );
     }
+    // Up arrow and Ctrl-P step back selection index
     for k in [key(KeyCode::BackTab), key(KeyCode::Up), ctrl('p')] {
         app.command_buffer = "s".to_string();
         app.command_suggestion_idx = 0;
         press(&mut app, k).await;
         assert_eq!(
-            app.command_buffer,
-            suggestions[len - 1].0.name,
+            app.command_suggestion_idx,
+            len - 1,
             "stepping back from the first wraps to the last"
         );
-        assert_eq!(app.command_suggestion_idx, len - 1);
     }
 
     app.command_buffer = "qqqqqq".into();
@@ -1853,9 +1861,11 @@ async fn f_opens_port_forward_with_the_detected_port_and_enter_starts_it() {
     assert!(screen.contains("443"), "screen: {}", screen);
     press(&mut app, key(KeyCode::Enter)).await;
     assert!(app.modal.is_none());
-    assert_eq!(
-        toast(&app),
-        "Port forward started on 127.0.0.1:443 -> web-svc:443"
+    assert!(
+        toast(&app) == "Port forward started on 127.0.0.1:443 -> web-svc:443"
+            || toast(&app).starts_with("Failed to port forward: Permission denied"),
+        "toast: {}",
+        toast(&app)
     );
 
     press(&mut app, ch('f')).await;
@@ -2016,7 +2026,8 @@ async fn l_and_s_on_a_single_container_pod_go_straight_to_logs_and_shell() {
     press(&mut app, ch('l')).await;
     assert!(matches!(app.active_view, ActiveView::Table(_)));
     assert!(
-        toast(&app).starts_with("Logs only available for Pods"),
+        toast(&app).starts_with("Logs only available for Pods")
+            || toast(&app).starts_with("No running pods found"),
         "toast: {}",
         toast(&app)
     );

--- a/apps/tui/tests/app_state_tests.rs
+++ b/apps/tui/tests/app_state_tests.rs
@@ -217,6 +217,7 @@ fn helm_releases() -> HelmViewState {
         revision: 3,
         status: "deployed".into(),
         chart: "nginx-15.0.0".into(),
+        chart_version: "15.0.0".into(),
         app_version: "1.25".into(),
         updated: "2026-01-01".into(),
     }]);
@@ -1005,6 +1006,7 @@ async fn every_modal_variant_renders_over_the_view() {
         namespace: "default".into(),
         container_port: 80,
         local_port_input: "8080".into(),
+        kind: "Pod".into(),
     });
     assert!(wide(&mut app).contains("Start Port Forward: web-0 (default)"));
 
@@ -2244,6 +2246,8 @@ async fn node_inspector_keys_navigate_pods_and_offer_node_actions() {
     );
 
     app.handle_key_event(common::ch('c')).await;
+    common::type_str(&mut app, "confirm").await;
+    app.handle_key_event(common::key(crossterm::event::KeyCode::Enter)).await;
     assert_eq!(toast(&app), "Cordoning node 'gpu-1'...");
 
     app.handle_key_event(common::ch('x')).await;
@@ -2295,6 +2299,8 @@ async fn node_inspector_without_pods_targets_the_node_and_toggles_uncordon() {
     app.active_view = ActiveView::NodeInspector(ni);
 
     app.handle_key_event(common::ch('c')).await;
+    common::type_str(&mut app, "confirm").await;
+    app.handle_key_event(common::key(crossterm::event::KeyCode::Enter)).await;
     assert_eq!(toast(&app), "Uncordoning node 'gpu-1'...");
 
     app.handle_key_event(common::ch('x')).await;
@@ -2462,6 +2468,7 @@ async fn pasted_text_lands_in_the_active_input() {
         namespace: "default".into(),
         container_port: 80,
         local_port_input: String::new(),
+        kind: "Pod".into(),
     });
     app.handle_paste("90\r\n90".into());
     assert!(
@@ -3045,6 +3052,7 @@ async fn navigation_palette_actions_open_the_matching_view_or_modal() {
             namespace,
             container_port,
             local_port_input,
+            ..
         }) => {
             assert_eq!(pod_name, "web-0");
             assert_eq!(namespace, "default");
@@ -3251,15 +3259,18 @@ async fn scale_and_port_forward_modals_run_on_enter() {
         namespace: "default".into(),
         container_port: 8080,
         local_port_input: "90".into(),
+        kind: "Pod".into(),
     });
     app.handle_key_event(common::ch('9')).await;
     app.handle_key_event(common::ch('0')).await;
     app.handle_key_event(common::key(KeyCode::Backspace)).await;
     app.handle_key_event(common::key(KeyCode::Enter)).await;
     assert!(app.modal.is_none());
-    assert_eq!(
-        toast(&app),
-        "Port forward started on 127.0.0.1:909 -> web-0:8080"
+    assert!(
+        toast(&app) == "Port forward started on 127.0.0.1:909 -> web-0:8080"
+            || toast(&app).starts_with("Failed to port forward: Permission denied"),
+        "{}",
+        toast(&app)
     );
 }
 

--- a/apps/tui/tests/chrome_tests.rs
+++ b/apps/tui/tests/chrome_tests.rs
@@ -2051,3 +2051,113 @@ async fn the_app_renders_the_assistant_view_with_the_active_context_in_its_title
     );
     assert!(text.contains("/oo█"), "{text}");
 }
+
+#[tokio::test]
+async fn the_app_renders_helm_and_helm_detail_views_across_all_tabs() {
+    use srelens_tui::views::helm_view::{HelmReleaseItem, HelmViewState, render_helm_view};
+    use srelens_tui::views::helm_detail_view::{
+        HelmDetailTab, HelmDetailViewState, render_helm_detail_view,
+    };
+    use srelens_kube::helm::{HelmReleaseDetail, HelmRevision};
+
+    // 1. render_helm_view states
+    let mut helm_state = HelmViewState::new();
+    let text = common::render_text(160, 40, |f| render_helm_view(f, f.area(), &helm_state));
+    assert!(text.contains("Loading Helm releases"), "{text}");
+
+    helm_state.set_error("cluster unreachable".into());
+    let text = common::render_text(160, 40, |f| render_helm_view(f, f.area(), &helm_state));
+    assert!(text.contains("Failed to load Helm releases"), "{text}");
+
+    helm_state.set_releases(vec![]);
+    let text = common::render_text(160, 40, |f| render_helm_view(f, f.area(), &helm_state));
+    assert!(text.contains("No Helm releases found"), "{text}");
+
+    helm_state.set_releases(vec![HelmReleaseItem {
+        name: "test-release".into(),
+        namespace: "default".into(),
+        revision: 3,
+        status: "deployed".into(),
+        chart: "my-chart".into(),
+        chart_version: "1.0.0".into(),
+        app_version: "2.1.0".into(),
+        updated: "2026-09-01T00:00:00Z".into(),
+    }]);
+    let text = common::render_text(160, 40, |f| render_helm_view(f, f.area(), &helm_state));
+    assert!(text.contains("test-release") && text.contains("my-chart"), "{text}");
+
+    helm_state.filter_query = "nonexistent".into();
+    let text = common::render_text(160, 40, |f| render_helm_view(f, f.area(), &helm_state));
+    assert!(text.contains("No releases matching filter"), "{text}");
+
+    // 2. render_helm_detail_view across all tabs
+    let mut detail_state = HelmDetailViewState::new("test-release".into(), "default".into());
+    let text = common::render_text(160, 40, |f| render_helm_detail_view(f, f.area(), &detail_state));
+    assert!(text.contains("Loading Helm release details"), "{text}");
+
+    detail_state.set_error("failed to query helm".into());
+    let text = common::render_text(160, 40, |f| render_helm_detail_view(f, f.area(), &detail_state));
+    assert!(text.contains("Failed to load release"), "{text}");
+
+    let mock_detail = HelmReleaseDetail {
+        name: "test-release".into(),
+        namespace: "default".into(),
+        revision: 2,
+        status: "deployed".into(),
+        chart: "my-chart".into(),
+        chart_version: "1.0.0".into(),
+        app_version: "2.1.0".into(),
+        updated: "2026-09-01T00:00:00Z".into(),
+        values_yaml: "replicaCount: 3\nservice:\n  type: LoadBalancer\n".into(),
+        chart_values_yaml: "replicaCount: 1\nservice:\n  type: ClusterIP\n".into(),
+        computed_values_yaml: "replicaCount: 3\nservice:\n  type: LoadBalancer\n".into(),
+        manifest: "---\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: test-app\n---\napiVersion: v1\nkind: Service\nmetadata:\n  name: test-svc\n".into(),
+        notes: "Release notes for test-release: everything is ready.".into(),
+        history: vec![
+            HelmRevision {
+                revision: 2,
+                status: "deployed".into(),
+                updated: "2026-09-01".into(),
+                chart_version: "my-chart-1.0.0".into(),
+                description: "Upgrade complete".into(),
+            },
+            HelmRevision {
+                revision: 1,
+                status: "superseded".into(),
+                updated: "2026-08-01".into(),
+                chart_version: "my-chart-0.9.0".into(),
+                description: "Install complete".into(),
+            },
+        ],
+    };
+    detail_state.set_detail(mock_detail);
+
+    // Overview tab
+    detail_state.set_tab(HelmDetailTab::Overview);
+    let text = common::render_text(160, 40, |f| render_helm_detail_view(f, f.area(), &detail_state));
+    assert!(text.contains("Release Overview") && text.contains("Deployment") && text.contains("Service"), "{text}");
+
+    // Values Diff tab (both modes)
+    detail_state.set_tab(HelmDetailTab::ValuesDiff);
+    let text = common::render_text(160, 40, |f| render_helm_detail_view(f, f.area(), &detail_state));
+    assert!(text.contains("Values Diff") && text.contains("replicaCount"), "{text}");
+
+    detail_state.toggle_diff_mode();
+    let text = common::render_text(160, 40, |f| render_helm_detail_view(f, f.area(), &detail_state));
+    assert!(text.contains("Current Revision vs Previous Revision Values"), "{text}");
+
+    // Revisions tab
+    detail_state.set_tab(HelmDetailTab::Revisions);
+    let text = common::render_text(160, 40, |f| render_helm_detail_view(f, f.area(), &detail_state));
+    assert!(text.contains("Revision History") && text.contains("2 (current)") && text.contains("Upgrade complete"), "{text}");
+
+    // Manifest tab
+    detail_state.set_tab(HelmDetailTab::Manifest);
+    let text = common::render_text(160, 40, |f| render_helm_detail_view(f, f.area(), &detail_state));
+    assert!(text.contains("Rendered Kubernetes Manifests") && text.contains("kind: Deployment"), "{text}");
+
+    // Notes tab
+    detail_state.set_tab(HelmDetailTab::Notes);
+    let text = common::render_text(160, 40, |f| render_helm_detail_view(f, f.area(), &detail_state));
+    assert!(text.contains("Chart Release Notes") && text.contains("everything is ready"), "{text}");
+}

--- a/apps/tui/tests/chrome_tests.rs
+++ b/apps/tui/tests/chrome_tests.rs
@@ -2137,12 +2137,16 @@ async fn the_app_renders_helm_and_helm_detail_views_across_all_tabs() {
     let text = common::render_text(160, 40, |f| render_helm_detail_view(f, f.area(), &detail_state));
     assert!(text.contains("Release Overview") && text.contains("Deployment") && text.contains("Service"), "{text}");
 
-    // Values Diff tab (both modes)
+    // Values Diff tab
     detail_state.set_tab(HelmDetailTab::ValuesDiff);
     let text = common::render_text(160, 40, |f| render_helm_detail_view(f, f.area(), &detail_state));
     assert!(text.contains("Values Diff") && text.contains("replicaCount"), "{text}");
 
-    detail_state.toggle_diff_mode();
+    detail_state.toggle_diff_mode(); // CustomVsComputed -> CustomVsDefault
+    let text = common::render_text(160, 40, |f| render_helm_detail_view(f, f.area(), &detail_state));
+    assert!(text.contains("User Values vs Chart Defaults"), "{text}");
+
+    detail_state.toggle_diff_mode(); // CustomVsDefault -> RevisionVsPrevious
     let text = common::render_text(160, 40, |f| render_helm_detail_view(f, f.area(), &detail_state));
     assert!(text.contains("Current Revision vs Previous Revision Values"), "{text}");
 

--- a/apps/tui/tests/chrome_tests.rs
+++ b/apps/tui/tests/chrome_tests.rs
@@ -787,7 +787,10 @@ fn the_help_modal_truncates_from_the_bottom_when_the_terminal_is_short() {
 #[test]
 fn the_help_modal_degrades_to_a_border_on_a_tiny_terminal() {
     let text = common::render_text(20, 6, |f| render_help_modal(f, f.area()));
-    assert!(text.contains('┌') && text.contains('┘'), "{text:?}");
+    assert!(
+        (text.contains('┌') && text.contains('┘')) || (text.contains('╭') && text.contains('╰')),
+        "{text:?}"
+    );
 }
 
 // ───────────────────────── statusbar ─────────────────────────

--- a/apps/tui/tests/chrome_tests.rs
+++ b/apps/tui/tests/chrome_tests.rs
@@ -114,6 +114,8 @@ fn status_props(mode: &InputMode) -> StatusBarProps<'_> {
         toast: None,
         custom_hints: None,
         suggestions: None,
+        close_pf_button: None,
+        close_pf_rect: None,
     }
 }
 
@@ -265,6 +267,7 @@ fn every_modal() -> Vec<Modal> {
             namespace: "default".into(),
             container_port: 8080,
             local_port_input: "8080".into(),
+            kind: "Pod".into(),
         },
         Modal::ContainerPicker {
             pod_name: "web-0".into(),
@@ -401,6 +404,7 @@ fn the_port_forward_modal_shows_the_target_port_and_the_local_port_being_typed()
         namespace: "default".into(),
         container_port: 8080,
         local_port_input: "80".into(),
+        kind: "Pod".into(),
     };
     let text = modal_text(120, 40, &modal);
     assert!(
@@ -827,7 +831,7 @@ fn command_mode_pops_up_the_matching_commands_above_the_bar_and_arrows_the_selec
     });
     let text = lines.join("\n");
     assert!(
-        text.contains(" Commands (Tab to complete, Enter to run) "),
+        text.contains("Commands") && text.contains("Tab") && text.contains("Enter"),
         "{text}"
     );
 
@@ -857,7 +861,7 @@ fn command_mode_pops_up_the_matching_commands_above_the_bar_and_arrows_the_selec
     }
     let popup_row = lines
         .iter()
-        .position(|l| l.contains("Commands (Tab"))
+        .position(|l| l.contains("Commands"))
         .unwrap();
     assert!(popup_row < 22, "popup opens above the bar");
     assert!(lines[23].starts_with(":po█"), "{:?}", lines[23]);
@@ -922,7 +926,10 @@ fn normal_mode_prefixes_a_toast_and_appends_the_active_filter() {
     props.total_count = 9;
     let text = statusbar_text(props);
     assert!(text.starts_with("─"), "{text}");
-    assert!(text.contains("➜ Copied web-0 │ <:> Cmd"), "{text}");
+    assert!(
+        text.contains("Copied web-0 │ <:> Cmd") && (text.contains('➜') || text.contains('●')),
+        "{text}"
+    );
     assert!(text.contains(" | Filter: \"web\" [2/9]"), "{text}");
 }
 

--- a/apps/tui/tests/core_logic_tests.rs
+++ b/apps/tui/tests/core_logic_tests.rs
@@ -3,7 +3,6 @@
 //! bridge driven against an in-process fake OpenAI-compatible endpoint on
 //! loopback (no real provider, no agent subprocess).
 
-use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;

--- a/apps/tui/tests/tui_tests.rs
+++ b/apps/tui/tests/tui_tests.rs
@@ -149,6 +149,7 @@ mod tests {
         let client_cache = ClientCache::new(PathBuf::from("/nonexistent"));
         let watch_manager = Arc::new(WatchManager::new(client_cache.clone()));
         let logs_manager = Arc::new(LogStreamManager::new(client_cache.clone()));
+        let forward_manager = Arc::new(srelens_streams::forward::ForwardManager::new(client_cache.clone()));
 
         let mut app = App {
             active_context: "prod-cluster".to_string(),
@@ -168,6 +169,7 @@ mod tests {
             client_cache,
             watch_manager,
             logs_manager,
+            forward_manager,
             event_tx: tx,
             current_watch_channel: Some("watch:prod-cluster:default:namespaces".to_string()),
             active_watch_channels: HashSet::new(),
@@ -179,6 +181,7 @@ mod tests {
             is_running: true,
             requires_terminal_suspend: None,
             context_chip_rects: std::cell::RefCell::new(Vec::new()),
+            close_pf_button_rect: std::cell::RefCell::new(None),
             cluster_version: "v1.30.0".to_string(),
             cluster_name: "prod".to_string(),
             server_url: "https://127.0.0.1:6443".to_string(),
@@ -241,6 +244,7 @@ mod tests {
         let client_cache = ClientCache::new(PathBuf::from("/nonexistent"));
         let watch_manager = Arc::new(WatchManager::new(client_cache.clone()));
         let logs_manager = Arc::new(LogStreamManager::new(client_cache.clone()));
+        let forward_manager = Arc::new(srelens_streams::forward::ForwardManager::new(client_cache.clone()));
 
         let mut app = App {
             kubeconfig_paths: vec![],
@@ -260,6 +264,7 @@ mod tests {
             client_cache,
             watch_manager,
             logs_manager,
+            forward_manager,
             event_tx: tx,
             current_watch_channel: None,
             active_watch_channels: HashSet::new(),
@@ -271,6 +276,7 @@ mod tests {
             is_running: true,
             requires_terminal_suspend: None,
             context_chip_rects: std::cell::RefCell::new(Vec::new()),
+            close_pf_button_rect: std::cell::RefCell::new(None),
             cluster_version: "v1.30.0".to_string(),
             cluster_name: "prod".to_string(),
             server_url: "https://127.0.0.1:6443".to_string(),
@@ -345,6 +351,7 @@ mod tests {
         let client_cache = ClientCache::new(PathBuf::from("/nonexistent"));
         let watch_manager = Arc::new(WatchManager::new(client_cache.clone()));
         let logs_manager = Arc::new(LogStreamManager::new(client_cache.clone()));
+        let forward_manager = Arc::new(srelens_streams::forward::ForwardManager::new(client_cache.clone()));
 
         let mut app = App {
             kubeconfig_paths: vec![],
@@ -364,6 +371,7 @@ mod tests {
             client_cache,
             watch_manager,
             logs_manager,
+            forward_manager,
             event_tx: tx,
             current_watch_channel: None,
             active_watch_channels: HashSet::new(),
@@ -375,6 +383,7 @@ mod tests {
             is_running: true,
             requires_terminal_suspend: None,
             context_chip_rects: std::cell::RefCell::new(Vec::new()),
+            close_pf_button_rect: std::cell::RefCell::new(None),
             cluster_version: "v1.30.0".to_string(),
             cluster_name: "prod".to_string(),
             server_url: "https://127.0.0.1:6443".to_string(),
@@ -523,6 +532,7 @@ mod tests {
         let client_cache = ClientCache::new(PathBuf::from("/nonexistent"));
         let watch_manager = Arc::new(WatchManager::new(client_cache.clone()));
         let logs_manager = Arc::new(LogStreamManager::new(client_cache.clone()));
+        let forward_manager = Arc::new(srelens_streams::forward::ForwardManager::new(client_cache.clone()));
 
         let mut app = App {
             kubeconfig_paths: vec![],
@@ -542,6 +552,7 @@ mod tests {
             client_cache,
             watch_manager,
             logs_manager,
+            forward_manager,
             event_tx: tx,
             current_watch_channel: None,
             active_watch_channels: HashSet::new(),
@@ -553,6 +564,7 @@ mod tests {
             is_running: true,
             requires_terminal_suspend: None,
             context_chip_rects: std::cell::RefCell::new(Vec::new()),
+            close_pf_button_rect: std::cell::RefCell::new(None),
             cluster_version: "v1.30.0".to_string(),
             cluster_name: "prod".to_string(),
             server_url: "https://127.0.0.1:6443".to_string(),
@@ -733,6 +745,7 @@ mod tests {
         let client_cache = ClientCache::new(PathBuf::from("/nonexistent"));
         let watch_manager = Arc::new(WatchManager::new(client_cache.clone()));
         let logs_manager = Arc::new(LogStreamManager::new(client_cache.clone()));
+        let forward_manager = Arc::new(srelens_streams::forward::ForwardManager::new(client_cache.clone()));
 
         let mut app = App {
             kubeconfig_paths: vec![],
@@ -752,6 +765,7 @@ mod tests {
             client_cache,
             watch_manager,
             logs_manager,
+            forward_manager,
             event_tx: tx,
             current_watch_channel: None,
             active_watch_channels: HashSet::new(),
@@ -763,6 +777,7 @@ mod tests {
             is_running: true,
             requires_terminal_suspend: None,
             context_chip_rects: std::cell::RefCell::new(Vec::new()),
+            close_pf_button_rect: std::cell::RefCell::new(None),
             cluster_version: "v1.30.0".to_string(),
             cluster_name: "prod".to_string(),
             server_url: "https://127.0.0.1:6443".to_string(),
@@ -918,6 +933,7 @@ mod tests {
         let client_cache = ClientCache::new(PathBuf::from("/nonexistent"));
         let watch_manager = Arc::new(WatchManager::new(client_cache.clone()));
         let logs_manager = Arc::new(LogStreamManager::new(client_cache.clone()));
+        let forward_manager = Arc::new(srelens_streams::forward::ForwardManager::new(client_cache.clone()));
 
         let mut table = ResourceTableState::new(ResourceKind::Namespaces);
         table.set_items(vec![
@@ -944,6 +960,7 @@ mod tests {
             client_cache,
             watch_manager,
             logs_manager,
+            forward_manager,
             event_tx: tx,
             current_watch_channel: None,
             active_watch_channels: HashSet::new(),
@@ -955,6 +972,7 @@ mod tests {
             is_running: true,
             requires_terminal_suspend: None,
             context_chip_rects: std::cell::RefCell::new(Vec::new()),
+            close_pf_button_rect: std::cell::RefCell::new(None),
             cluster_version: "v1.30.0".to_string(),
             cluster_name: "prod".to_string(),
             server_url: "https://127.0.0.1:6443".to_string(),
@@ -1047,6 +1065,7 @@ mod tests {
         let client_cache = ClientCache::new(PathBuf::from("/nonexistent"));
         let watch_manager = Arc::new(WatchManager::new(client_cache.clone()));
         let logs_manager = Arc::new(LogStreamManager::new(client_cache.clone()));
+        let forward_manager = Arc::new(srelens_streams::forward::ForwardManager::new(client_cache.clone()));
 
         let mut table = ResourceTableState::new(ResourceKind::Pods);
         table.set_items(vec![
@@ -1080,6 +1099,7 @@ mod tests {
             client_cache,
             watch_manager,
             logs_manager,
+            forward_manager,
             event_tx: tx,
             current_watch_channel: None,
             active_watch_channels: HashSet::new(),
@@ -1091,6 +1111,7 @@ mod tests {
             is_running: true,
             requires_terminal_suspend: None,
             context_chip_rects: std::cell::RefCell::new(Vec::new()),
+            close_pf_button_rect: std::cell::RefCell::new(None),
             cluster_version: "v1.30.0".to_string(),
             cluster_name: "prod".to_string(),
             server_url: "https://127.0.0.1:6443".to_string(),
@@ -1114,13 +1135,240 @@ mod tests {
 
         // Press 'f' (or 'F') on the selected pod -> opens PortForward modal with detected port 3000
         app.handle_key_event(KeyEvent::new(KeyCode::Char('f'), KeyModifiers::NONE)).await;
-        match app.modal {
+        match &app.modal {
             Some(Modal::PortForward { pod_name, container_port, .. }) => {
                 assert_eq!(pod_name, "my-api-pod-xyz");
-                assert_eq!(container_port, 3000);
+                assert_eq!(*container_port, 3000);
             }
             other => panic!("Expected PortForward modal, got {:?}", other),
         }
+
+        // Press Enter to submit the modal
+        app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)).await;
+        assert!(app.modal.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_port_forward_lifecycle_and_view_sync() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        use srelens_tui::app::{ActiveView, App};
+        use srelens_tui::commands::ResourceKind;
+        use srelens_tui::ui::Modal;
+
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut app = App::new(
+            Some("test-ctx".to_string()),
+            Some("default".to_string()),
+            false,
+            None,
+            vec![],
+            tx,
+        ).await.unwrap();
+
+        // 1. Initially no forwards
+        assert_eq!(app.forward_manager.list().len(), 0);
+
+        // 2. Start a mock port forward directly
+        app.execute_start_port_forward(
+            "nginx-web".to_string(),
+            "Pod".to_string(),
+            "default".to_string(),
+            0, // random local port
+            80,
+        ).await;
+
+        let forwards = app.forward_manager.list();
+        assert_eq!(forwards.len(), 1);
+        let fwd_id = forwards[0].id;
+        assert_eq!(forwards[0].name, "nginx-web");
+        assert_eq!(forwards[0].remote_port, 80);
+        assert!(forwards[0].local_port > 0);
+
+        // 3. Switch to PortForwards view and verify synced state
+        app.switch_view_to_kind(ResourceKind::PortForwards).await;
+        if let ActiveView::PortForwards(state) = &app.active_view {
+            assert_eq!(state.forwards.len(), 1);
+            assert_eq!(state.forwards[0].target_name, "nginx-web");
+            assert_eq!(state.forwards[0].container_port, 80);
+            assert_eq!(state.forwards[0].local_port, forwards[0].local_port);
+        } else {
+            panic!("Expected PortForwards view");
+        }
+
+        // 4. Press 'd' to open confirm modal for stopping
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE)).await;
+        assert!(matches!(
+            app.modal,
+            Some(Modal::Confirm { ref action_name, .. }) if action_name == &format!("stop-pf:{}", fwd_id)
+        ));
+
+        // 5. Confirm stop with Enter
+        app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)).await;
+        assert!(app.modal.is_none());
+
+        // 6. Verify stopped in manager
+        assert_eq!(app.forward_manager.list().len(), 0);
+        if let ActiveView::PortForwards(state) = &app.active_view {
+            assert_eq!(state.forwards.len(), 0);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_pod_port_forward_indication_and_close_key() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+        use serde_json::json;
+        use srelens_tui::app::{ActiveView, App};
+        use srelens_tui::commands::ResourceKind;
+        use srelens_tui::views::resource_table::ResourceTableState;
+
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut app = App::new(
+            Some("test-ctx".to_string()),
+            Some("default".to_string()),
+            false,
+            None,
+            vec![],
+            tx,
+        ).await.unwrap();
+
+        // Populate table with a pod
+        let mut table = ResourceTableState::new(ResourceKind::Pods);
+        table.set_items(vec![json!({
+            "name": "nginx-web",
+            "namespace": "default",
+            "status": "Running",
+            "ready": "1/1",
+            "age": "5m"
+        })], "");
+        app.active_view = ActiveView::Table(table);
+
+        // Initially no forwards
+        assert!(app.forward_manager.list().is_empty());
+
+        // Start port forward
+        app.execute_start_port_forward(
+            "nginx-web".to_string(),
+            "Pod".to_string(),
+            "default".to_string(),
+            0,
+            80,
+        ).await;
+
+        let forwards = app.forward_manager.list();
+        assert_eq!(forwards.len(), 1);
+        let loc = forwards[0].local_port;
+
+        // Render frame to populate active_port_forwards and draw button
+        let backend = TestBackend::new(120, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| app.render(f)).unwrap();
+
+        // 1. Verify table indicator [PF: <loc>→80] and [PF: 1 active]
+        let buffer = terminal.backend().buffer();
+        let content: String = (0..buffer.area.height)
+            .map(|y| {
+                let mut line = String::new();
+                for x in 0..buffer.area.width {
+                    line.push_str(buffer[(x, y)].symbol());
+                }
+                line
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let expected_pf = format!("[PF: {}→80]", loc);
+        let expected_btn = format!("[ ✕ Close PF: {} ]", loc);
+        assert!(content.contains(&expected_pf), "Content did not contain {}: {}", expected_pf, content);
+        assert!(content.contains("[PF: 1 active]"), "Content did not contain [PF: 1 active]: {}", content);
+        assert!(content.contains(&expected_btn), "Content did not contain Close button {}: {}", expected_btn, content);
+        assert!(app.close_pf_button_rect.borrow().is_some());
+
+        // 2. Press 'F' (Shift+F) to close the active port forward
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('F'), KeyModifiers::SHIFT)).await;
+
+        // 3. Verify closed in manager and table
+        assert_eq!(app.forward_manager.list().len(), 0);
+        if let ActiveView::Table(table) = &app.active_view {
+            assert!(table.active_port_forwards.is_empty());
+        }
+
+        // Render again and verify indicators are gone
+        terminal.draw(|f| app.render(f)).unwrap();
+        assert!(app.close_pf_button_rect.borrow().is_none());
+
+        let buffer2 = terminal.backend().buffer();
+        let content2: String = (0..buffer2.area.height)
+            .map(|y| {
+                let mut line = String::new();
+                for x in 0..buffer2.area.width {
+                    line.push_str(buffer2[(x, y)].symbol());
+                }
+                line
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(!content2.contains("[PF: 8080→80]"));
+        assert!(!content2.contains("[ ✕ Close PF: 8080 ]"));
+    }
+
+    #[tokio::test]
+    async fn test_mouse_click_close_port_forward_button() {
+        use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+        use serde_json::json;
+        use srelens_tui::app::{ActiveView, App};
+        use srelens_tui::commands::ResourceKind;
+        use srelens_tui::views::resource_table::ResourceTableState;
+
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut app = App::new(
+            Some("test-ctx".to_string()),
+            Some("default".to_string()),
+            false,
+            None,
+            vec![],
+            tx,
+        ).await.unwrap();
+
+        let mut table = ResourceTableState::new(ResourceKind::Pods);
+        table.set_items(vec![json!({
+            "name": "redis-master",
+            "namespace": "default",
+            "status": "Running",
+            "ready": "1/1",
+            "age": "1d"
+        })], "");
+        app.active_view = ActiveView::Table(table);
+
+        app.execute_start_port_forward(
+            "redis-master".to_string(),
+            "Pod".to_string(),
+            "default".to_string(),
+            6379,
+            6379,
+        ).await;
+
+        let backend = TestBackend::new(120, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| app.render(f)).unwrap();
+
+        let btn_rect = app.close_pf_button_rect.borrow().expect("Close button rect should be present");
+
+        // Click on the close button
+        let mouse_event = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: btn_rect.x + 1,
+            row: btn_rect.y,
+            modifiers: crossterm::event::KeyModifiers::NONE,
+        };
+        app.handle_mouse(mouse_event).await;
+
+        // Verify port forward is closed
+        assert_eq!(app.forward_manager.list().len(), 0);
     }
 
     #[tokio::test]
@@ -1140,6 +1388,7 @@ mod tests {
         let client_cache = ClientCache::new(PathBuf::from("/nonexistent"));
         let watch_manager = Arc::new(WatchManager::new(client_cache.clone()));
         let logs_manager = Arc::new(LogStreamManager::new(client_cache.clone()));
+        let forward_manager = Arc::new(srelens_streams::forward::ForwardManager::new(client_cache.clone()));
 
         let mut table = ResourceTableState::new(ResourceKind::Pods);
         table.set_items(vec![
@@ -1172,6 +1421,7 @@ mod tests {
             client_cache,
             watch_manager,
             logs_manager,
+            forward_manager,
             event_tx: tx,
             current_watch_channel: None,
             active_watch_channels: HashSet::new(),
@@ -1183,6 +1433,7 @@ mod tests {
             is_running: true,
             requires_terminal_suspend: None,
             context_chip_rects: std::cell::RefCell::new(Vec::new()),
+            close_pf_button_rect: std::cell::RefCell::new(None),
             cluster_version: "v1.31.7".to_string(),
             cluster_name: "prod".to_string(),
             server_url: "https://127.0.0.1:6443".to_string(),
@@ -1278,6 +1529,7 @@ mod tests {
         let client_cache = ClientCache::new(PathBuf::from("/nonexistent"));
         let watch_manager = Arc::new(WatchManager::new(client_cache.clone()));
         let logs_manager = Arc::new(LogStreamManager::new(client_cache.clone()));
+        let forward_manager = Arc::new(srelens_streams::forward::ForwardManager::new(client_cache.clone()));
 
         let mut app = App {
             kubeconfig_paths: vec![],
@@ -1297,6 +1549,7 @@ mod tests {
             client_cache,
             watch_manager,
             logs_manager,
+            forward_manager,
             event_tx: tx,
             current_watch_channel: None,
             active_watch_channels: HashSet::new(),
@@ -1308,6 +1561,7 @@ mod tests {
             is_running: true,
             requires_terminal_suspend: None,
             context_chip_rects: std::cell::RefCell::new(Vec::new()),
+            close_pf_button_rect: std::cell::RefCell::new(None),
             cluster_version: "v1.30.0".to_string(),
             cluster_name: "prod".to_string(),
             server_url: "https://127.0.0.1:6443".to_string(),
@@ -1370,6 +1624,7 @@ mod tests {
         let client_cache = ClientCache::new(PathBuf::from("/nonexistent"));
         let watch_manager = Arc::new(WatchManager::new(client_cache.clone()));
         let logs_manager = Arc::new(LogStreamManager::new(client_cache.clone()));
+        let forward_manager = Arc::new(srelens_streams::forward::ForwardManager::new(client_cache.clone()));
 
         let mut app = App {
             kubeconfig_paths: vec![],
@@ -1389,6 +1644,7 @@ mod tests {
             client_cache,
             watch_manager,
             logs_manager,
+            forward_manager,
             event_tx: tx,
             current_watch_channel: None,
             active_watch_channels: HashSet::new(),
@@ -1400,6 +1656,7 @@ mod tests {
             is_running: true,
             requires_terminal_suspend: None,
             context_chip_rects: std::cell::RefCell::new(Vec::new()),
+            close_pf_button_rect: std::cell::RefCell::new(None),
             cluster_version: "v1.30.0".to_string(),
             cluster_name: "prod".to_string(),
             server_url: "https://127.0.0.1:6443".to_string(),
@@ -1454,6 +1711,7 @@ mod tests {
         let client_cache = ClientCache::new(PathBuf::from("/nonexistent"));
         let watch_manager = Arc::new(WatchManager::new(client_cache.clone()));
         let logs_manager = Arc::new(LogStreamManager::new(client_cache.clone()));
+        let forward_manager = Arc::new(srelens_streams::forward::ForwardManager::new(client_cache.clone()));
 
         let mut app = App {
             kubeconfig_paths: vec![],
@@ -1473,6 +1731,7 @@ mod tests {
             client_cache,
             watch_manager,
             logs_manager,
+            forward_manager,
             event_tx: tx,
             current_watch_channel: None,
             active_watch_channels: HashSet::new(),
@@ -1484,6 +1743,7 @@ mod tests {
             is_running: true,
             requires_terminal_suspend: None,
             context_chip_rects: std::cell::RefCell::new(Vec::new()),
+            close_pf_button_rect: std::cell::RefCell::new(None),
             cluster_version: "v1.30.0".to_string(),
             cluster_name: "prod".to_string(),
             server_url: "https://127.0.0.1:6443".to_string(),
@@ -1554,6 +1814,7 @@ mod tests {
         let client_cache = ClientCache::new(PathBuf::from("/nonexistent"));
         let watch_manager = Arc::new(WatchManager::new(client_cache.clone()));
         let logs_manager = Arc::new(LogStreamManager::new(client_cache.clone()));
+        let forward_manager = Arc::new(srelens_streams::forward::ForwardManager::new(client_cache.clone()));
 
         let mut app = App {
             kubeconfig_paths: vec![],
@@ -1598,6 +1859,7 @@ mod tests {
             client_cache,
             watch_manager,
             logs_manager,
+            forward_manager,
             event_tx: tx,
             current_watch_channel: None,
             active_watch_channels: HashSet::new(),
@@ -1609,6 +1871,7 @@ mod tests {
             is_running: true,
             requires_terminal_suspend: None,
             context_chip_rects: std::cell::RefCell::new(Vec::new()),
+            close_pf_button_rect: std::cell::RefCell::new(None),
             cluster_version: "v1.30.0".to_string(),
             cluster_name: "prod-cluster".to_string(),
             server_url: "https://127.0.0.1:6443".to_string(),
@@ -1683,6 +1946,7 @@ mod tests {
         let client_cache = ClientCache::new(PathBuf::from("/nonexistent"));
         let watch_manager = Arc::new(WatchManager::new(client_cache.clone()));
         let logs_manager = Arc::new(LogStreamManager::new(client_cache.clone()));
+        let forward_manager = Arc::new(srelens_streams::forward::ForwardManager::new(client_cache.clone()));
 
         let mut app = App {
             kubeconfig_paths: vec![],
@@ -1727,6 +1991,7 @@ mod tests {
             client_cache,
             watch_manager,
             logs_manager,
+            forward_manager,
             event_tx: tx,
             current_watch_channel: None,
             active_watch_channels: HashSet::new(),
@@ -1738,6 +2003,7 @@ mod tests {
             is_running: true,
             requires_terminal_suspend: None,
             context_chip_rects: std::cell::RefCell::new(Vec::new()),
+            close_pf_button_rect: std::cell::RefCell::new(None),
             cluster_version: "v1.30.0".to_string(),
             cluster_name: "prod-cluster".to_string(),
             server_url: "https://127.0.0.1:6443".to_string(),
@@ -1814,6 +2080,7 @@ mod tests {
         let client_cache = ClientCache::new(PathBuf::from("/nonexistent"));
         let watch_manager = Arc::new(WatchManager::new(client_cache.clone()));
         let logs_manager = Arc::new(LogStreamManager::new(client_cache.clone()));
+        let forward_manager = Arc::new(srelens_streams::forward::ForwardManager::new(client_cache.clone()));
 
         let mut table = ResourceTableState::new(ResourceKind::Pods);
         table.set_items(
@@ -1881,6 +2148,7 @@ mod tests {
             client_cache,
             watch_manager,
             logs_manager,
+            forward_manager,
             event_tx: tx,
             current_watch_channel: None,
             active_watch_channels: HashSet::new(),
@@ -1892,6 +2160,7 @@ mod tests {
             is_running: true,
             requires_terminal_suspend: None,
             context_chip_rects: std::cell::RefCell::new(Vec::new()),
+            close_pf_button_rect: std::cell::RefCell::new(None),
             cluster_version: "v1.30.0".to_string(),
             cluster_name: "prod-cluster".to_string(),
             server_url: "https://127.0.0.1:6443".to_string(),
@@ -1962,6 +2231,7 @@ mod tests {
         let client_cache = ClientCache::new(PathBuf::from("/nonexistent"));
         let watch_manager = Arc::new(WatchManager::new(client_cache.clone()));
         let logs_manager = Arc::new(LogStreamManager::new(client_cache.clone()));
+        let forward_manager = Arc::new(srelens_streams::forward::ForwardManager::new(client_cache.clone()));
 
         let mut app = App {
             kubeconfig_paths: vec![],
@@ -1981,6 +2251,7 @@ mod tests {
             client_cache,
             watch_manager,
             logs_manager,
+            forward_manager,
             event_tx: tx,
             current_watch_channel: None,
             active_watch_channels: HashSet::new(),
@@ -1992,6 +2263,7 @@ mod tests {
             is_running: true,
             requires_terminal_suspend: None,
             context_chip_rects: std::cell::RefCell::new(Vec::new()),
+            close_pf_button_rect: std::cell::RefCell::new(None),
             cluster_version: "v1.34.7+rke2r1".to_string(),
             cluster_name: "prod-cluster-dus1".to_string(),
             server_url: "https://k8s.prod.dus1:6443".to_string(),
@@ -2368,6 +2640,7 @@ mod tests {
         let client_cache = ClientCache::new(PathBuf::from("/nonexistent"));
         let watch_manager = Arc::new(WatchManager::new(client_cache.clone()));
         let logs_manager = Arc::new(LogStreamManager::new(client_cache.clone()));
+        let forward_manager = Arc::new(srelens_streams::forward::ForwardManager::new(client_cache.clone()));
 
         let mut app = App {
             active_context: "prod".to_string(),
@@ -2387,6 +2660,7 @@ mod tests {
             client_cache,
             watch_manager,
             logs_manager,
+            forward_manager,
             event_tx: tx,
             current_watch_channel: None,
             active_watch_channels: HashSet::new(),
@@ -2397,6 +2671,7 @@ mod tests {
             is_running: true,
             resource_cache: HashMap::new(),
             context_chip_rects: std::cell::RefCell::new(Vec::new()),
+            close_pf_button_rect: std::cell::RefCell::new(None),
             crds: vec![],
             cluster_version: "v1.30.0".to_string(),
             cluster_name: "prod".to_string(),
@@ -2486,6 +2761,7 @@ mod tests {
         let client_cache = ClientCache::new(PathBuf::from("/nonexistent"));
         let watch_manager = Arc::new(WatchManager::new(client_cache.clone()));
         let logs_manager = Arc::new(LogStreamManager::new(client_cache.clone()));
+        let forward_manager = Arc::new(srelens_streams::forward::ForwardManager::new(client_cache.clone()));
 
         let mut app = App {
             active_context: "prod".to_string(),
@@ -2505,6 +2781,7 @@ mod tests {
             client_cache,
             watch_manager,
             logs_manager,
+            forward_manager,
             event_tx: tx,
             current_watch_channel: None,
             active_watch_channels: HashSet::new(),
@@ -2515,6 +2792,7 @@ mod tests {
             is_running: true,
             resource_cache: HashMap::new(),
             context_chip_rects: std::cell::RefCell::new(Vec::new()),
+            close_pf_button_rect: std::cell::RefCell::new(None),
             crds: vec![],
             cluster_version: "v1.30.0".to_string(),
             cluster_name: "prod".to_string(),
@@ -2711,6 +2989,7 @@ mod tests {
         let client_cache = ClientCache::new(PathBuf::from("/nonexistent"));
         let watch_manager = Arc::new(WatchManager::new(client_cache.clone()));
         let logs_manager = Arc::new(LogStreamManager::new(client_cache.clone()));
+        let forward_manager = Arc::new(srelens_streams::forward::ForwardManager::new(client_cache.clone()));
 
         let mut app = App {
             active_context: "prod-cluster".to_string(),
@@ -2730,6 +3009,7 @@ mod tests {
             client_cache,
             watch_manager,
             logs_manager,
+            forward_manager,
             current_watch_channel: None,
             active_watch_channels: HashSet::new(),
             active_watch_pool: Vec::new(),
@@ -2749,6 +3029,7 @@ mod tests {
             crds: vec![],
             last_active_namespace: "prod".to_string(),
             context_chip_rects: std::cell::RefCell::new(Vec::new()),
+            close_pf_button_rect: std::cell::RefCell::new(None),
             ai_settings: srelens_tui::AiSettings::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::for_context("prod"),
             assistant_states: HashMap::new(),
@@ -2823,6 +3104,7 @@ mod tests {
         let client_cache = ClientCache::new(PathBuf::from("/nonexistent"));
         let watch_manager = Arc::new(WatchManager::new(client_cache.clone()));
         let logs_manager = Arc::new(LogStreamManager::new(client_cache.clone()));
+        let forward_manager = Arc::new(srelens_streams::forward::ForwardManager::new(client_cache.clone()));
 
         let mut app = App {
             active_context: "prod-cluster".to_string(),
@@ -2842,6 +3124,7 @@ mod tests {
             client_cache,
             watch_manager,
             logs_manager,
+            forward_manager,
             current_watch_channel: None,
             active_watch_channels: HashSet::new(),
             active_watch_pool: Vec::new(),
@@ -2861,6 +3144,7 @@ mod tests {
             crds: vec![],
             last_active_namespace: "shop".to_string(),
             context_chip_rects: std::cell::RefCell::new(Vec::new()),
+            close_pf_button_rect: std::cell::RefCell::new(None),
             ai_settings: srelens_tui::AiSettings::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::for_context("shop"),
             assistant_states: HashMap::new(),
@@ -2923,6 +3207,7 @@ mod tests {
         let client_cache = ClientCache::new(PathBuf::from("/nonexistent"));
         let watch_manager = Arc::new(WatchManager::new(client_cache.clone()));
         let logs_manager = Arc::new(LogStreamManager::new(client_cache.clone()));
+        let forward_manager = Arc::new(srelens_streams::forward::ForwardManager::new(client_cache.clone()));
 
         let mut node_table = ResourceTableState::new(ResourceKind::Nodes);
         let node_json = serde_json::json!({
@@ -2951,6 +3236,7 @@ mod tests {
             client_cache,
             watch_manager,
             logs_manager,
+            forward_manager,
             resource_cache: HashMap::new(),
             active_log_channel: None,
             current_watch_channel: None,
@@ -2961,6 +3247,7 @@ mod tests {
             crds: vec![],
             last_active_namespace: "default".to_string(),
             context_chip_rects: std::cell::RefCell::new(Vec::new()),
+            close_pf_button_rect: std::cell::RefCell::new(None),
             cluster_version: "v1.30.2".to_string(),
             cluster_name: "prod".to_string(),
             server_url: "https://127.0.0.1:6443".to_string(),
@@ -3122,6 +3409,7 @@ mod tests {
         let client_cache = ClientCache::new(PathBuf::from("/nonexistent"));
         let watch_manager = Arc::new(WatchManager::new(client_cache.clone()));
         let logs_manager = Arc::new(LogStreamManager::new(client_cache.clone()));
+        let forward_manager = Arc::new(srelens_streams::forward::ForwardManager::new(client_cache.clone()));
 
         let mut node_table = ResourceTableState::new(ResourceKind::Nodes);
         let mut items = Vec::new();
@@ -3155,6 +3443,7 @@ mod tests {
             client_cache,
             watch_manager,
             logs_manager,
+            forward_manager,
             resource_cache: HashMap::new(),
             active_log_channel: None,
             current_watch_channel: None,
@@ -3165,6 +3454,7 @@ mod tests {
             crds: vec![],
             last_active_namespace: "default".to_string(),
             context_chip_rects: std::cell::RefCell::new(Vec::new()),
+            close_pf_button_rect: std::cell::RefCell::new(None),
             cluster_version: "v1.30.2".to_string(),
             cluster_name: "prod".to_string(),
             server_url: "https://127.0.0.1:6443".to_string(),
@@ -3330,6 +3620,7 @@ mod tests {
         let client_cache = ClientCache::new(PathBuf::from("/nonexistent"));
         let watch_manager = Arc::new(WatchManager::new(client_cache.clone()));
         let logs_manager = Arc::new(LogStreamManager::new(client_cache.clone()));
+        let forward_manager = Arc::new(srelens_streams::forward::ForwardManager::new(client_cache.clone()));
 
         let desc_text = "Name: my-pod\nNamespace: default\nContainers:\n  app:\n    Image: nginx:latest\nEvents:\n  Type: Normal\n  Reason: Started";
         let desc_view = DescribeViewState::new("my-pod".to_string(), "Pod".to_string(), Some("default".to_string()), desc_text.to_string());
@@ -3352,6 +3643,7 @@ mod tests {
             client_cache,
             watch_manager,
             logs_manager,
+            forward_manager,
             resource_cache: HashMap::new(),
             active_log_channel: None,
             current_watch_channel: None,
@@ -3362,6 +3654,7 @@ mod tests {
             crds: vec![],
             last_active_namespace: "default".to_string(),
             context_chip_rects: std::cell::RefCell::new(Vec::new()),
+            close_pf_button_rect: std::cell::RefCell::new(None),
             cluster_version: "v1.30.2".to_string(),
             cluster_name: "prod".to_string(),
             server_url: "https://127.0.0.1:6443".to_string(),
@@ -4095,6 +4388,7 @@ mod tests {
         let client_cache = ClientCache::new(PathBuf::from("/nonexistent"));
         let watch_manager = Arc::new(WatchManager::new(client_cache.clone()));
         let logs_manager = Arc::new(LogStreamManager::new(client_cache.clone()));
+        let forward_manager = Arc::new(srelens_streams::forward::ForwardManager::new(client_cache.clone()));
 
         let mut ni_state = NodeInspectorState::new("worker-node-1".to_string());
         let details = NodeInspectorDetails {
@@ -4192,6 +4486,7 @@ mod tests {
             client_cache,
             watch_manager,
             logs_manager,
+            forward_manager,
             resource_cache,
             active_log_channel: None,
             current_watch_channel: None,
@@ -4202,6 +4497,7 @@ mod tests {
             crds: vec![],
             last_active_namespace: "default".to_string(),
             context_chip_rects: std::cell::RefCell::new(Vec::new()),
+            close_pf_button_rect: std::cell::RefCell::new(None),
             cluster_version: "v1.30.2".to_string(),
             cluster_name: "prod".to_string(),
             server_url: "https://127.0.0.1:6443".to_string(),
@@ -4289,6 +4585,7 @@ mod tests {
         let client_cache = ClientCache::new(PathBuf::from("/nonexistent"));
         let watch_manager = Arc::new(WatchManager::new(client_cache.clone()));
         let logs_manager = Arc::new(LogStreamManager::new(client_cache.clone()));
+        let forward_manager = Arc::new(srelens_streams::forward::ForwardManager::new(client_cache.clone()));
 
         let mut ni_state = NodeInspectorState::new("worker-node-1".to_string());
         let details = NodeInspectorDetails {
@@ -4381,6 +4678,7 @@ mod tests {
             client_cache,
             watch_manager,
             logs_manager,
+            forward_manager,
             resource_cache,
             active_log_channel: None,
             current_watch_channel: None,
@@ -4391,6 +4689,7 @@ mod tests {
             crds: vec![],
             last_active_namespace: "default".to_string(),
             context_chip_rects: std::cell::RefCell::new(Vec::new()),
+            close_pf_button_rect: std::cell::RefCell::new(None),
             cluster_version: "v1.30.2".to_string(),
             cluster_name: "prod".to_string(),
             server_url: "https://127.0.0.1:6443".to_string(),
@@ -4538,6 +4837,7 @@ mod tests {
         let client_cache = ClientCache::new(PathBuf::from("/nonexistent"));
         let watch_manager = Arc::new(WatchManager::new(client_cache.clone()));
         let logs_manager = Arc::new(LogStreamManager::new(client_cache.clone()));
+        let forward_manager = Arc::new(srelens_streams::forward::ForwardManager::new(client_cache.clone()));
 
         let mut resource_cache = HashMap::new();
 
@@ -4608,6 +4908,7 @@ mod tests {
             client_cache,
             watch_manager,
             logs_manager,
+            forward_manager,
             event_tx: tx,
             current_watch_channel: None,
             active_watch_channels: HashSet::new(),
@@ -4619,6 +4920,7 @@ mod tests {
             is_running: true,
             requires_terminal_suspend: None,
             context_chip_rects: std::cell::RefCell::new(Vec::new()),
+            close_pf_button_rect: std::cell::RefCell::new(None),
             cluster_version: "v1.30.2".to_string(),
             cluster_name: "prod".to_string(),
             server_url: "https://127.0.0.1:6443".to_string(),
@@ -4686,9 +4988,9 @@ mod tests {
 
         // Verify status styling
         assert_eq!(status_style("Degraded"), Theme::status_error());
-        assert_eq!(status_style("Scaled down").fg, Some(Theme::DIM));
-        assert_eq!(status_style("Not scheduled").fg, Some(Theme::DIM));
-        assert_eq!(status_style("Suspended").fg, Some(Theme::DIM));
+        assert_eq!(status_style("Scaled down").fg, Theme::status_dim().fg);
+        assert_eq!(status_style("Not scheduled").fg, Theme::status_dim().fg);
+        assert_eq!(status_style("Suspended").fg, Theme::status_dim().fg);
         assert_eq!(status_style("Running"), Theme::status_ok());
         assert_eq!(status_style("Active"), Theme::status_ok());
     }
@@ -4712,6 +5014,7 @@ mod tests {
         let client_cache = ClientCache::new(PathBuf::from("/nonexistent"));
         let watch_manager = Arc::new(WatchManager::new(client_cache.clone()));
         let logs_manager = Arc::new(LogStreamManager::new(client_cache.clone()));
+        let forward_manager = Arc::new(srelens_streams::forward::ForwardManager::new(client_cache.clone()));
 
         let mut resource_cache = HashMap::new();
         resource_cache.insert(
@@ -4741,6 +5044,7 @@ mod tests {
             client_cache,
             watch_manager,
             logs_manager,
+            forward_manager,
             event_tx: tx,
             current_watch_channel: None,
             active_watch_channels: HashSet::new(),
@@ -4752,6 +5056,7 @@ mod tests {
             is_running: true,
             requires_terminal_suspend: None,
             context_chip_rects: std::cell::RefCell::new(Vec::new()),
+            close_pf_button_rect: std::cell::RefCell::new(None),
             cluster_version: "v1.30.2".to_string(),
             cluster_name: "prod".to_string(),
             server_url: "https://127.0.0.1:6443".to_string(),
@@ -4815,7 +5120,1608 @@ mod tests {
             assert_eq!(t.raw_items[t.filtered_indices[0]]["name"], "nginx-dep-abcd");
         }
     }
+
+    static THEME_TEST_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn test_theme_palette_switching_and_lookups() {
+        let _lock = THEME_TEST_MUTEX.lock().unwrap();
+        use ratatui::widgets::BorderType;
+        use srelens_tui::theme::{HeaderStyle, Theme, ThemeId, ALL_THEMES};
+
+        assert_eq!(ALL_THEMES.len(), 12);
+
+        // Test theme lookup and setting by id/name
+        let nord = Theme::set_theme_by_name("nord");
+        assert!(nord.is_some());
+        assert_eq!(Theme::active_palette().id, ThemeId::Nord);
+        assert_eq!(Theme::active_palette().name, "nord");
+
+        let dracula = Theme::set_theme_by_name("dracula");
+        assert!(dracula.is_some());
+        assert_eq!(Theme::active_palette().id, ThemeId::Dracula);
+
+        let tokyo = Theme::set_theme_by_name("tokyo-night");
+        assert!(tokyo.is_some());
+        assert_eq!(Theme::active_palette().id, ThemeId::TokyoNight);
+        assert_eq!(Theme::border_type(), BorderType::Rounded);
+
+        let gruvbox = Theme::set_theme_by_name("gruvbox");
+        assert!(gruvbox.is_some());
+        assert_eq!(Theme::active_palette().id, ThemeId::GruvboxDark);
+
+        let solarized = Theme::set_theme_by_name("solarized");
+        assert!(solarized.is_some());
+        assert_eq!(Theme::active_palette().id, ThemeId::SolarizedDark);
+        assert_eq!(Theme::header_style(), HeaderStyle::Minimal);
+        assert_eq!(Theme::border_type(), BorderType::Plain);
+
+        let monokai = Theme::set_theme_by_name("monokai");
+        assert!(monokai.is_some());
+        assert_eq!(Theme::active_palette().id, ThemeId::MonokaiPro);
+
+        let latte = Theme::set_theme_by_name("catppuccin-latte");
+        assert!(latte.is_some());
+        assert_eq!(Theme::active_palette().id, ThemeId::CatppuccinLatte);
+        assert!(Theme::active_palette().is_light);
+
+        // Test new themes & visual chrome traits
+        let fino = Theme::set_theme_by_name("fino-time");
+        assert!(fino.is_some());
+        assert_eq!(Theme::active_palette().id, ThemeId::FinoTime);
+        assert_eq!(Theme::header_style(), HeaderStyle::FinoTime);
+        assert_eq!(Theme::border_type(), BorderType::Rounded);
+        assert_eq!(Theme::prompt_glyph(), "╰─○ ");
+        assert_eq!(Theme::bullet_glyph(), "○");
+        assert!(Theme::show_live_clock());
+
+        let cyber = Theme::set_theme_by_name("cyberpunk");
+        assert!(cyber.is_some());
+        assert_eq!(Theme::active_palette().id, ThemeId::Cyberpunk);
+        assert_eq!(Theme::border_type(), BorderType::Thick);
+        assert_eq!(Theme::prompt_glyph(), "▶ ");
+        assert_eq!(Theme::bullet_glyph(), "▪");
+        assert_eq!(Theme::brand_icon(), "⚡ ");
+        assert!(Theme::show_live_clock());
+
+        let rose = Theme::set_theme_by_name("rose-pine");
+        assert!(rose.is_some());
+        assert_eq!(Theme::active_palette().id, ThemeId::RosePine);
+        assert_eq!(Theme::prompt_glyph(), "❯ ");
+        assert_eq!(Theme::bullet_glyph(), "◆");
+        assert_eq!(Theme::brand_icon(), "✦ ");
+
+        let onedark = Theme::set_theme_by_name("one-dark");
+        assert!(onedark.is_some());
+        assert_eq!(Theme::active_palette().id, ThemeId::OneDark);
+        assert_eq!(Theme::header_style(), HeaderStyle::Standard);
+        assert_eq!(Theme::border_type(), BorderType::Plain);
+
+        // Reset to default Mocha
+        let mocha = Theme::set_theme_by_name("catppuccin-mocha");
+        assert!(mocha.is_some());
+        assert_eq!(Theme::active_palette().id, ThemeId::CatppuccinMocha);
+        assert!(!Theme::active_palette().is_light);
+
+        // Test index switching
+        assert!(Theme::set_theme_by_index(3)); // Nord is index 3
+        assert_eq!(Theme::active_index(), 3);
+        assert_eq!(Theme::active_palette().name, "nord");
+
+        // Out of bounds index
+        assert!(!Theme::set_theme_by_index(999));
+        assert_eq!(Theme::active_index(), 3);
+
+        // Reset to 0
+        Theme::set_theme_by_index(0);
+        assert_eq!(Theme::active_index(), 0);
+    }
+
+    #[test]
+    fn test_theme_command_resolution_and_autocomplete() {
+        use srelens_tui::commands::{command_suggestions, resolve_command, CommandTarget};
+
+        // Modal command resolution
+        assert!(matches!(
+            resolve_command(":themes"),
+            Some(CommandTarget::ThemePicker)
+        ));
+        assert!(matches!(
+            resolve_command(":theme"),
+            Some(CommandTarget::ThemePicker)
+        ));
+        assert!(matches!(
+            resolve_command(":colors"),
+            Some(CommandTarget::ThemePicker)
+        ));
+
+        // Direct theme command resolution
+        assert!(matches!(
+            resolve_command(":theme nord"),
+            Some(CommandTarget::SetTheme(t)) if t == "nord"
+        ));
+        assert!(matches!(
+            resolve_command(":theme:tokyo-night"),
+            Some(CommandTarget::SetTheme(t)) if t == "tokyo-night"
+        ));
+        assert!(matches!(
+            resolve_command(":colors dracula"),
+            Some(CommandTarget::SetTheme(t)) if t == "dracula"
+        ));
+        assert!(matches!(
+            resolve_command(":theme fino-time"),
+            Some(CommandTarget::SetTheme(t)) if t == "fino-time"
+        ));
+        assert!(matches!(
+            resolve_command(":theme fino"),
+            Some(CommandTarget::SetTheme(t)) if t == "fino"
+        ));
+        assert!(matches!(
+            resolve_command(":theme cyberpunk"),
+            Some(CommandTarget::SetTheme(t)) if t == "cyberpunk"
+        ));
+        assert!(matches!(
+            resolve_command(":theme synthwave"),
+            Some(CommandTarget::SetTheme(t)) if t == "synthwave"
+        ));
+        assert!(matches!(
+            resolve_command(":theme rose-pine"),
+            Some(CommandTarget::SetTheme(t)) if t == "rose-pine"
+        ));
+        assert!(matches!(
+            resolve_command(":theme one-dark"),
+            Some(CommandTarget::SetTheme(t)) if t == "one-dark"
+        ));
+
+        // Theme autocompletion suggestions
+        let suggestions = command_suggestions("theme nor");
+        assert!(!suggestions.is_empty());
+        assert!(suggestions.iter().any(|(cmd, _)| cmd.name == "theme nord"));
+
+        let drac_suggs = command_suggestions("theme drac");
+        assert!(!drac_suggs.is_empty());
+        assert!(drac_suggs.iter().any(|(cmd, _)| cmd.name == "theme dracula"));
+
+        let fino_suggs = command_suggestions("theme fin");
+        assert!(!fino_suggs.is_empty());
+        assert!(fino_suggs.iter().any(|(cmd, _)| cmd.name == "theme fino-time"));
+
+        let cyber_suggs = command_suggestions("theme cyber");
+        assert!(!cyber_suggs.is_empty());
+        assert!(cyber_suggs.iter().any(|(cmd, _)| cmd.name == "theme cyberpunk"));
+    }
+
+    #[tokio::test]
+    async fn test_theme_picker_live_preview_revert_and_commit() {
+        let _lock = THEME_TEST_MUTEX.lock().unwrap();
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        use srelens_tui::app::App;
+        use srelens_tui::commands::CommandTarget;
+        use srelens_tui::theme::Theme;
+        use srelens_tui::ui::dialogs::Modal;
+
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut app = App::new(
+            Some("test-ctx".to_string()),
+            Some("default".to_string()),
+            false,
+            None,
+            vec![],
+            tx,
+        ).await.unwrap();
+
+        // Ensure starting at default Mocha (index 0)
+        Theme::set_theme_by_index(0);
+        assert_eq!(Theme::active_index(), 0);
+
+        // Open theme picker
+        app.execute_view_target(CommandTarget::ThemePicker).await;
+        assert!(matches!(
+            app.modal,
+            Some(Modal::ThemePicker {
+                selected_idx: 0,
+                initial_theme_idx: 0
+            })
+        ));
+
+        // 1. Live preview navigation: Down arrow changes active theme immediately
+        app.handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)).await;
+        if let Some(Modal::ThemePicker { selected_idx, initial_theme_idx }) = app.modal {
+            assert_eq!(selected_idx, 1);
+            assert_eq!(initial_theme_idx, 0);
+            assert_eq!(Theme::active_index(), 1); // Live preview applied!
+        } else {
+            panic!("Expected ThemePicker modal");
+        }
+
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)).await;
+        if let Some(Modal::ThemePicker { selected_idx, .. }) = app.modal {
+            assert_eq!(selected_idx, 2);
+            assert_eq!(Theme::active_index(), 2);
+        }
+
+        // 2. Cancellation: Esc reverts back to initial_theme_idx (0) and closes modal
+        app.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)).await;
+        assert!(app.modal.is_none());
+        assert_eq!(Theme::active_index(), 0); // Reverted!
+
+        // 3. Commitment: Open again, navigate to Nord (index 3), press Enter
+        Theme::set_theme_by_index(0);
+        app.execute_view_target(CommandTarget::ThemePicker).await;
+        app.handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)).await; // 1
+        app.handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)).await; // 2
+        app.handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)).await; // 3
+        assert_eq!(Theme::active_index(), 3);
+
+        app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)).await;
+        assert!(app.modal.is_none());
+        assert_eq!(Theme::active_index(), 3); // Committed!
+        assert_eq!(app.ai_settings.theme, Some("nord".to_string()));
+
+        // Reset theme back to Mocha for other tests
+        Theme::set_theme_by_index(0);
+    }
+
+    #[tokio::test]
+    async fn test_command_autocomplete_navigation_and_selection() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        use srelens_tui::app::{ActiveView, App};
+        use srelens_tui::commands::{CrdMeta, ResourceKind};
+        use srelens_tui::ui::InputMode;
+
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut app = App::new(
+            Some("test-ctx".to_string()),
+            Some("default".to_string()),
+            false,
+            None,
+            vec![],
+            tx,
+        ).await.unwrap();
+
+        // Add CRDs starting with "no" to simulate user's environment
+        app.crds = vec![
+            CrdMeta {
+                crd_name: "nodefeaturegroups.nfd.k8s.bin".to_string(),
+                group: "nfd.k8s.bin".to_string(),
+                version: "v1".to_string(),
+                kind: "NodeFeatureGroup".to_string(),
+                plural: "nodefeaturegroups".to_string(),
+                singular: "nodefeaturegroup".to_string(),
+                namespaced: false,
+                short_names: vec!["nfg".to_string()],
+                printer_columns: vec![],
+            },
+            CrdMeta {
+                crd_name: "nodefeaturerules.nfd.k8s.bin".to_string(),
+                group: "nfd.k8s.bin".to_string(),
+                version: "v1".to_string(),
+                kind: "NodeFeatureRule".to_string(),
+                plural: "nodefeaturerules".to_string(),
+                singular: "nodefeaturerule".to_string(),
+                namespaced: false,
+                short_names: vec!["nfr".to_string()],
+                printer_columns: vec![],
+            },
+        ];
+
+        // 1. Enter command mode by pressing ':'
+        app.handle_key_event(KeyEvent::new(KeyCode::Char(':'), KeyModifiers::NONE)).await;
+        assert_eq!(app.input_mode, InputMode::Command);
+        assert_eq!(app.command_buffer, "");
+        assert_eq!(app.command_suggestion_idx, 0);
+
+        // 2. Type "no"
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE)).await;
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE)).await;
+        assert_eq!(app.command_buffer, "no");
+        assert_eq!(app.command_suggestion_idx, 0);
+
+        // 3. Press Down arrow -> Moves selection cursor to index 1 (nodefeaturegroups) WITHOUT altering command_buffer!
+        app.handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)).await;
+        assert_eq!(app.command_buffer, "no"); // Query preserved!
+        assert_eq!(app.command_suggestion_idx, 1);
+
+        // 4. Press Down arrow again -> Moves selection cursor to index 2 (nodefeaturerules)
+        app.handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)).await;
+        assert_eq!(app.command_buffer, "no"); // Query preserved!
+        assert_eq!(app.command_suggestion_idx, 2);
+
+        // 5. Press Up arrow -> Moves selection cursor back to index 1 (nodefeaturegroups)
+        app.handle_key_event(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE)).await;
+        assert_eq!(app.command_buffer, "no"); // Query preserved!
+        assert_eq!(app.command_suggestion_idx, 1);
+
+        // 6. Press Enter -> Runs selected suggestion (nodefeaturegroups)
+        app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)).await;
+        assert_eq!(app.input_mode, InputMode::Normal);
+        if let ActiveView::Table(t) = &app.active_view {
+            assert!(matches!(&t.kind, ResourceKind::CustomResource(crd) if crd.plural == "nodefeaturegroups"));
+        } else {
+            panic!("Expected active view to be Custom CRD table for nodefeaturegroups");
+        }
+
+        // 7. Verify Tab completes selected suggestion
+        app.handle_key_event(KeyEvent::new(KeyCode::Char(':'), KeyModifiers::NONE)).await;
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE)).await;
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE)).await;
+        app.handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)).await; // select index 1
+        app.handle_key_event(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)).await;
+        assert_eq!(app.command_buffer, "nodefeaturegroups");
+    }
+
+    #[tokio::test]
+    async fn test_crd_settings_vs_ai_settings_autocomplete_and_resolution() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        use srelens_tui::app::{ActiveView, App};
+        use srelens_tui::commands::{
+            command_suggestions_with_crds, resolve_command, resolve_command_with_crds,
+            CommandTarget, CrdMeta, ResourceKind,
+        };
+        use srelens_tui::ui::InputMode;
+
+        let setting_crd = CrdMeta {
+            crd_name: "settings.management.cattle.io".to_string(),
+            group: "management.cattle.io".to_string(),
+            version: "v3".to_string(),
+            kind: "Setting".to_string(),
+            plural: "settings".to_string(),
+            singular: "setting".to_string(),
+            namespaced: false,
+            short_names: vec![],
+            printer_columns: vec![],
+        };
+
+        // 1. Test fallback when no CRD is present
+        assert_eq!(
+            resolve_command(":settings"),
+            Some(CommandTarget::Resource(ResourceKind::Settings))
+        );
+        assert_eq!(
+            resolve_command(":ai-settings"),
+            Some(CommandTarget::Resource(ResourceKind::Settings))
+        );
+        assert_eq!(
+            resolve_command(":config"),
+            Some(CommandTarget::Resource(ResourceKind::Settings))
+        );
+
+        // 2. Test command resolution when CRD is present
+        let crds = vec![setting_crd.clone()];
+
+        // :settings and :setting must resolve to CRD
+        assert_eq!(
+            resolve_command_with_crds(":settings", &crds),
+            Some(CommandTarget::CustomResource(setting_crd.clone()))
+        );
+        assert_eq!(
+            resolve_command_with_crds(":setting", &crds),
+            Some(CommandTarget::CustomResource(setting_crd.clone()))
+        );
+        assert_eq!(
+            resolve_command_with_crds("settings.management.cattle.io", &crds),
+            Some(CommandTarget::CustomResource(setting_crd.clone()))
+        );
+
+        // :ai-settings and :config must still resolve to AI Settings
+        assert_eq!(
+            resolve_command_with_crds(":ai-settings", &crds),
+            Some(CommandTarget::Resource(ResourceKind::Settings))
+        );
+        assert_eq!(
+            resolve_command_with_crds(":config", &crds),
+            Some(CommandTarget::Resource(ResourceKind::Settings))
+        );
+
+        // 3. Test suggestions scoring & ranking
+        let suggestions = command_suggestions_with_crds("sett", &crds);
+        assert!(suggestions.len() >= 2);
+        // CRD should be ranked first because its primary name starts with "sett"
+        assert_eq!(suggestions[0].0.name, "settings");
+        assert!(matches!(&suggestions[0].0.target, CommandTarget::CustomResource(ref c) if c.plural == "settings"));
+        // AI Settings should also be present via alias
+        assert_eq!(suggestions[1].0.name, "ai-settings");
+        assert!(matches!(&suggestions[1].0.target, CommandTarget::Resource(ResourceKind::Settings)));
+
+        // 4. Test interactive UI selection in App
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut app = App::new(
+            Some("test-ctx".to_string()),
+            Some("default".to_string()),
+            false,
+            None,
+            vec![],
+            tx,
+        ).await.unwrap();
+        app.crds = crds.clone();
+
+        // 4a. Type ":sett" and press Enter immediately (Index 0 = CRD selected by default)
+        app.handle_key_event(KeyEvent::new(KeyCode::Char(':'), KeyModifiers::NONE)).await;
+        for c in "sett".chars() {
+            app.handle_key_event(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE)).await;
+        }
+        assert_eq!(app.command_suggestion_idx, 0);
+        app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)).await;
+        assert_eq!(app.input_mode, InputMode::Normal);
+        // Must open CRD table view, NOT AI Settings!
+        if let ActiveView::Table(t) = &app.active_view {
+            assert!(matches!(&t.kind, ResourceKind::CustomResource(ref c) if c.plural == "settings"));
+        } else {
+            panic!("Expected active view to be Custom CRD table for Setting");
+        }
+
+        // 4b. Type ":sett", press Down arrow (Index 1 = AI Settings), and press Enter
+        app.handle_key_event(KeyEvent::new(KeyCode::Char(':'), KeyModifiers::NONE)).await;
+        for c in "sett".chars() {
+            app.handle_key_event(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE)).await;
+        }
+        app.handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)).await;
+        assert_eq!(app.command_suggestion_idx, 1);
+        app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)).await;
+        assert_eq!(app.input_mode, InputMode::Normal);
+        // Must open AI Settings view!
+        assert!(matches!(app.active_view, ActiveView::Settings(_)));
+
+        // 4c. Verify Tab completion for CRD vs AI Settings
+        app.handle_key_event(KeyEvent::new(KeyCode::Char(':'), KeyModifiers::NONE)).await;
+        for c in "sett".chars() {
+            app.handle_key_event(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE)).await;
+        }
+        // At index 0 (CRD), pressing Tab completes to "settings"
+        app.handle_key_event(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)).await;
+        assert_eq!(app.command_buffer, "settings");
+
+        app.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)).await;
+        app.handle_key_event(KeyEvent::new(KeyCode::Char(':'), KeyModifiers::NONE)).await;
+        for c in "sett".chars() {
+            app.handle_key_event(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE)).await;
+        }
+        // At index 1 (AI Settings), pressing Tab completes to "ai-settings"
+        app.handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)).await;
+        app.handle_key_event(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)).await;
+        assert_eq!(app.command_buffer, "ai-settings");
+    }
+
+    #[tokio::test]
+    async fn test_node_inspector_cordon_typed_confirmation_and_streamlined_hints() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        use srelens_tui::app::{ActiveView, App};
+        use srelens_tui::ui::dialogs::Modal;
+        use srelens_tui::views::node_inspector_view::{NodeInspectorDetails, NodeInspectorState};
+
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut app = App::new(
+            Some("test-ctx".to_string()),
+            Some("default".to_string()),
+            false,
+            None,
+            vec![],
+            tx,
+        ).await.unwrap();
+
+        // Put app into NodeInspector view
+        let mut state = NodeInspectorState::new("worker-1".to_string());
+        state.details = Some(NodeInspectorDetails {
+            name: "worker-1".to_string(),
+            unschedulable: false, // Currently schedulable
+            ..Default::default()
+        });
+        app.active_view = ActiveView::NodeInspector(state);
+
+        // 1. Pressing 'c' should NOT instantly cordon, but open Modal::InputConfirm requiring "confirm"
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE)).await;
+        match &app.modal {
+            Some(Modal::InputConfirm { title, action_name, required_input, current_input, is_destructive, .. }) => {
+                assert!(title.contains("Cordon Node"));
+                assert_eq!(action_name, "cordon:worker-1");
+                assert_eq!(required_input, "confirm");
+                assert_eq!(current_input, "");
+                assert!(*is_destructive);
+            }
+            other => panic!("Expected Modal::InputConfirm, got: {:?}", other),
+        }
+
+        // 2. Pressing Enter without typing "confirm" does NOT submit
+        app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)).await;
+        assert!(app.modal.is_some());
+
+        // 3. Type partial letters
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE)).await;
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE)).await;
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE)).await;
+        if let Some(Modal::InputConfirm { current_input, .. }) = &app.modal {
+            assert_eq!(current_input, "con");
+        }
+
+        // 4. Press Esc cancels
+        app.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)).await;
+        assert!(app.modal.is_none());
+
+        // 5. Test Uncordon dialog when node is already unschedulable
+        if let ActiveView::NodeInspector(ni) = &mut app.active_view {
+            if let Some(d) = &mut ni.details {
+                d.unschedulable = true;
+            }
+        }
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE)).await;
+        match &app.modal {
+            Some(Modal::InputConfirm { title, action_name, required_input, is_destructive, .. }) => {
+                assert!(title.contains("Uncordon Node"));
+                assert_eq!(action_name, "uncordon:worker-1");
+                assert_eq!(required_input, "confirm");
+                assert!(!*is_destructive);
+            }
+            other => panic!("Expected Modal::InputConfirm for uncordon, got: {:?}", other),
+        }
+
+        // 6. Type "confirm" and press Enter
+        for ch in "confirm".chars() {
+            app.handle_key_event(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE)).await;
+        }
+        app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)).await;
+        assert!(app.modal.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_nodes_view_cordoned_status_and_dynamic_spacing() {
+        use srelens_tui::views::resource_table::{extract_field_str, ResourceTableState};
+        use srelens_tui::theme::{status_style, Theme};
+
+        let mut node_table = ResourceTableState::new(ResourceKind::Nodes);
+        let nodes = vec![
+            serde_json::json!({
+                "name": "hpe-2832-t2-cp",
+                "status": "Ready",
+                "unschedulable": false,
+                "roles": "control-plane",
+                "version": "v1.31.1",
+                "allocatableCpuMillicores": 15800,
+                "allocatableMemoryMiB": 64000,
+                "allocatablePods": 110,
+                "age": "42d"
+            }),
+            serde_json::json!({
+                "name": "hpe-2832-t2-worker-1",
+                "status": "Ready",
+                "unschedulable": true,
+                "roles": "worker",
+                "version": "v1.31.1",
+                "allocatableCpuMillicores": 31600,
+                "allocatableMemoryMiB": 128000,
+                "allocatablePods": 110,
+                "age": "42d"
+            }),
+        ];
+
+        node_table.set_items(nodes, "");
+
+        // 1. Verify normal node shows Ready with OK style
+        let cp_status = extract_field_str(&node_table.raw_items[0], "status");
+        assert_eq!(cp_status, "Ready");
+        assert_eq!(status_style(&cp_status), Theme::status_ok());
+
+        // 2. Verify cordoned node shows Ready,SchedulingDisabled with WARN style
+        let worker_status = extract_field_str(&node_table.raw_items[1], "status");
+        assert_eq!(worker_status, "Ready,SchedulingDisabled");
+        assert_eq!(status_style(&worker_status), Theme::status_warn());
+
+        // 3. Verify dynamic width computation adapts to longest name and status
+        let max_name_len = node_table
+            .filtered_indices
+            .iter()
+            .map(|&idx| extract_field_str(&node_table.raw_items[idx], "name").len())
+            .max()
+            .unwrap_or(12)
+            .max("NAME".len());
+        let name_width = (max_name_len + 3) as u16;
+        assert_eq!(name_width, 23); // 20 + 3 = 23
+
+        let max_status_len = node_table
+            .filtered_indices
+            .iter()
+            .map(|&idx| extract_field_str(&node_table.raw_items[idx], "status").len())
+            .max()
+            .unwrap_or(8)
+            .max("STATUS".len());
+        let status_width = (max_status_len + 3) as u16;
+        assert_eq!(status_width, 27); // 24 + 3 = 27
+    }
+
+    #[tokio::test]
+    async fn test_topology_command_resolution_and_flow_navigation() {
+        use std::collections::{HashMap, HashSet};
+        use std::path::PathBuf;
+        use std::sync::Arc;
+        use tokio::sync::mpsc::unbounded_channel;
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        use srelens_tui::app::{ActiveView, App};
+        use srelens_tui::ui::InputMode;
+        use srelens_kube::client_cache::ClientCache;
+        use srelens_streams::watch::WatchManager;
+        use srelens_streams::logs::LogStreamManager;
+        use srelens_tui::commands::{resolve_command, CommandTarget, ResourceKind};
+        use srelens_tui::views::topology_view::TopologyViewState;
+        use srelens_kube::topology::{EdgeKind, Health, Lane, Provenance, TopologyEdge, TopologyGraphOut, TopologyNode};
+
+        // 1. Verify command resolution aliases
+        assert_eq!(
+            resolve_command(":topology"),
+            Some(CommandTarget::Resource(ResourceKind::Topology))
+        );
+        assert_eq!(
+            resolve_command(":topo"),
+            Some(CommandTarget::Resource(ResourceKind::Topology))
+        );
+        assert_eq!(
+            resolve_command(":flow"),
+            Some(CommandTarget::Resource(ResourceKind::Topology))
+        );
+
+        // 2. Setup mock topology graph
+        let nodes = vec![
+            TopologyNode {
+                id: "Ingress/default/ingress-gw".to_string(),
+                kind: "Ingress".to_string(),
+                name: "ingress-gw".to_string(),
+                namespace: "default".to_string(),
+                lane: Lane::Route,
+                detail: ":80, :443".to_string(),
+                ready: None,
+                desired: None,
+                health: Health::Ok,
+            },
+            TopologyNode {
+                id: "Service/default/cart-svc".to_string(),
+                kind: "Service".to_string(),
+                name: "cart-svc".to_string(),
+                namespace: "default".to_string(),
+                lane: Lane::Service,
+                detail: ":80 -> :8080".to_string(),
+                ready: None,
+                desired: None,
+                health: Health::Ok,
+            },
+            TopologyNode {
+                id: "Deployment/default/cart-deploy".to_string(),
+                kind: "Deployment".to_string(),
+                name: "cart-deploy".to_string(),
+                namespace: "default".to_string(),
+                lane: Lane::Workload,
+                detail: "2/2 ready".to_string(),
+                ready: Some(2),
+                desired: Some(2),
+                health: Health::Ok,
+            },
+            TopologyNode {
+                id: "External//redis-cart:6379".to_string(),
+                kind: "External".to_string(),
+                name: "redis-cart:6379".to_string(),
+                namespace: String::new(),
+                lane: Lane::External,
+                detail: "redis-cart:6379".to_string(),
+                ready: None,
+                desired: None,
+                health: Health::Ok,
+            },
+        ];
+
+        let edges = vec![
+            TopologyEdge {
+                from: "Ingress/default/ingress-gw".to_string(),
+                to: "Service/default/cart-svc".to_string(),
+                kind: EdgeKind::Routes,
+                provenance: Provenance::Topology,
+                detail: String::new(),
+                weight: None,
+                unit: None,
+                health: Health::Ok,
+            },
+            TopologyEdge {
+                from: "Service/default/cart-svc".to_string(),
+                to: "Deployment/default/cart-deploy".to_string(),
+                kind: EdgeKind::Routes,
+                provenance: Provenance::Topology,
+                detail: String::new(),
+                weight: None,
+                unit: None,
+                health: Health::Ok,
+            },
+            TopologyEdge {
+                from: "Deployment/default/cart-deploy".to_string(),
+                to: "External//redis-cart:6379".to_string(),
+                kind: EdgeKind::Calls,
+                provenance: Provenance::Declared,
+                detail: String::new(),
+                weight: None,
+                unit: None,
+                health: Health::Ok,
+            },
+        ];
+
+        let graph = TopologyGraphOut { nodes, edges, probe: None };
+
+        let mut topo_state = TopologyViewState::new(vec!["default".to_string()]);
+        topo_state.set_graph(graph);
+
+        // 3. Test App integration with ActiveView::Topology
+        let (tx, _rx) = unbounded_channel();
+        let client_cache = ClientCache::new(PathBuf::from("/nonexistent"));
+        let watch_manager = Arc::new(WatchManager::new(client_cache.clone()));
+        let logs_manager = Arc::new(LogStreamManager::new(client_cache.clone()));
+        let forward_manager = Arc::new(srelens_streams::forward::ForwardManager::new(client_cache.clone()));
+
+        let mut app = App {
+            active_context: "prod".to_string(),
+            active_namespace: "default".to_string(),
+            kubeconfig_paths: vec![],
+            contexts: vec![],
+            namespaces: vec!["default".to_string(), "ai-prod".to_string()],
+            active_view: ActiveView::Topology(topo_state),
+            nav_stack: vec![],
+            input_mode: InputMode::Normal,
+            command_buffer: String::new(),
+            command_suggestion_idx: 0,
+            filter_buffer: String::new(),
+            modal: None,
+            show_help: false,
+            event_tx: tx,
+            client_cache,
+            watch_manager,
+            logs_manager,
+            forward_manager,
+            resource_cache: HashMap::new(),
+            active_log_channel: None,
+            current_watch_channel: None,
+            active_watch_channels: HashSet::new(),
+            active_watch_pool: Vec::new(),
+            is_running: true,
+            requires_terminal_suspend: None,
+            crds: vec![],
+            last_active_namespace: "default".to_string(),
+            context_chip_rects: std::cell::RefCell::new(Vec::new()),
+            close_pf_button_rect: std::cell::RefCell::new(None),
+            cluster_version: "v1.30.2".to_string(),
+            cluster_name: "prod".to_string(),
+            server_url: "https://127.0.0.1:6443".to_string(),
+            node_count: 10,
+            pod_count: 80,
+            is_connected: true,
+            connection_attempt_start: std::time::Instant::now(),
+            cluster_unreachable: false,
+            toast: None,
+            ai_settings: srelens_tui::AiSettings::default(),
+            assistant_state: srelens_tui::views::assistant_view::AssistantViewState::for_context("default"),
+            assistant_states: HashMap::new(),
+            pod_metrics_tick_counter: 0,
+            node_metrics_tick_counter: 0,
+            node_metrics_history: HashMap::new(),
+            pod_metrics_history: HashMap::new(),
+            cluster_overview_data: None,
+            screen_selection: None,
+            screen_selecting: false,
+            screen_selection_text: std::cell::RefCell::new(String::new()),
+        };
+
+        // Initially selected on Workloads (cart-deploy)
+        if let ActiveView::Topology(t) = &app.active_view {
+            assert_eq!(t.selected_node().unwrap().name, "cart-deploy");
+        }
+
+        // Navigate right to External lane with Right
+        app.handle_key_event(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE)).await;
+        if let ActiveView::Topology(t) = &app.active_view {
+            assert_eq!(t.selected_node().unwrap().name, "redis-cart:6379");
+        }
+
+        // Navigate left back to Workloads with Left
+        app.handle_key_event(KeyEvent::new(KeyCode::Left, KeyModifiers::NONE)).await;
+        if let ActiveView::Topology(t) = &app.active_view {
+            assert_eq!(t.selected_node().unwrap().name, "cart-deploy");
+        }
+
+        // Press Enter on cart-deploy: drills down into Pods table pre-filtered by cart-deploy!
+        app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)).await;
+        assert!(matches!(&app.active_view, ActiveView::Table(tbl) if tbl.kind == ResourceKind::Pods));
+        assert_eq!(app.filter_buffer, "cart-deploy");
+
+        // Press Esc: clears the filter buffer first
+        app.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)).await;
+        assert_eq!(app.filter_buffer, "");
+
+        // Press Esc again: pops back to Topology view!
+        app.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)).await;
+        assert!(matches!(&app.active_view, ActiveView::Topology(_)));
+    }
+
+    #[tokio::test]
+    async fn test_gpuinfo_command_resolution_and_node_pod_vram_selection() {
+        use std::collections::{HashMap, HashSet};
+        use std::path::PathBuf;
+        use std::sync::Arc;
+        use tokio::sync::mpsc::unbounded_channel;
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        use srelens_tui::app::{ActiveView, App};
+        use srelens_tui::ui::InputMode;
+        use srelens_kube::client_cache::ClientCache;
+        use srelens_streams::watch::WatchManager;
+        use srelens_streams::logs::LogStreamManager;
+        use srelens_tui::commands::{resolve_command, CommandTarget, ResourceKind};
+        use srelens_tui::views::gpu_view::{GpuPane, GpuViewState};
+        use srelens_kube::gpu_info::{GpuClusterInfo, GpuNodeInfo, GpuPodItem, format_vram_mib};
+
+        // 1. Verify command resolution aliases
+        assert_eq!(
+            resolve_command(":gpuinfo"),
+            Some(CommandTarget::Resource(ResourceKind::GpuInfo))
+        );
+        assert_eq!(
+            resolve_command(":gpu"),
+            Some(CommandTarget::Resource(ResourceKind::GpuInfo))
+        );
+        assert_eq!(
+            resolve_command(":gpus"),
+            Some(CommandTarget::Resource(ResourceKind::GpuInfo))
+        );
+
+        // 2. Setup mock GPU cluster info
+        let pod_alpha = GpuPodItem {
+            name: "llm-trainer-0".to_string(),
+            namespace: "ai-gen".to_string(),
+            phase: "Running".to_string(),
+            gpu_requests: 2,
+            vram_requests_mib: 163840, // 160 GiB
+            ready_containers: "1/1".to_string(),
+            restarts: 0,
+            age: "3d".to_string(),
+            containers: vec!["pytorch".to_string()],
+        };
+
+        let node_alpha = GpuNodeInfo {
+            name: "gpu-node-alpha".to_string(),
+            status: "Ready".to_string(),
+            unschedulable: false,
+            roles: "worker".to_string(),
+            instance_type: "p4de.24xlarge".to_string(),
+            gpu_model: Some("NVIDIA A100 SXM4 80GB".to_string()),
+            gpu_driver_version: Some("535.129.03".to_string()),
+            gpu_cuda_version: Some("12.2".to_string()),
+            gpu_capacity: 8,
+            gpu_allocatable: 8,
+            gpu_requests: 2,
+            vram_per_gpu_mib: Some(81920),
+            vram_capacity_total_mib: Some(655360),
+            vram_requests_total_mib: 163840,
+            pods: vec![pod_alpha],
+        };
+
+        let pod_beta = GpuPodItem {
+            name: "whisper-worker".to_string(),
+            namespace: "audio-prod".to_string(),
+            phase: "Running".to_string(),
+            gpu_requests: 1,
+            vram_requests_mib: 15360, // 15 GiB
+            ready_containers: "1/1".to_string(),
+            restarts: 0,
+            age: "1d".to_string(),
+            containers: vec!["whisper".to_string()],
+        };
+
+        let node_beta = GpuNodeInfo {
+            name: "gpu-node-beta".to_string(),
+            status: "Ready".to_string(),
+            unschedulable: false,
+            roles: "worker".to_string(),
+            instance_type: "g4dn.xlarge".to_string(),
+            gpu_model: Some("Tesla T4".to_string()),
+            gpu_driver_version: Some("535.129.03".to_string()),
+            gpu_cuda_version: Some("12.2".to_string()),
+            gpu_capacity: 1,
+            gpu_allocatable: 1,
+            gpu_requests: 1,
+            vram_per_gpu_mib: Some(15360),
+            vram_capacity_total_mib: Some(15360),
+            vram_requests_total_mib: 15360,
+            pods: vec![pod_beta],
+        };
+
+        let info = GpuClusterInfo {
+            nodes: vec![node_alpha, node_beta],
+            total_gpu_nodes: 2,
+            total_gpus: 9,
+            total_allocated_gpus: 3,
+            total_vram_mib: 670720,
+            total_allocated_vram_mib: 179200,
+            total_gpu_pods: 2,
+        };
+
+        let mut gpu_state = GpuViewState::new();
+        gpu_state.set_info(info);
+
+        let (tx, _rx) = unbounded_channel();
+        let client_cache = ClientCache::new(PathBuf::from("/nonexistent"));
+        let watch_manager = Arc::new(WatchManager::new(client_cache.clone()));
+        let logs_manager = Arc::new(LogStreamManager::new(client_cache.clone()));
+        let forward_manager = Arc::new(srelens_streams::forward::ForwardManager::new(client_cache.clone()));
+
+        let mut app = App {
+            active_context: "prod".to_string(),
+            active_namespace: "default".to_string(),
+            kubeconfig_paths: vec![],
+            contexts: vec![],
+            namespaces: vec!["default".to_string(), "ai-gen".to_string()],
+            active_view: ActiveView::GpuInfo(gpu_state),
+            nav_stack: vec![],
+            input_mode: InputMode::Normal,
+            command_buffer: String::new(),
+            command_suggestion_idx: 0,
+            filter_buffer: String::new(),
+            modal: None,
+            show_help: false,
+            event_tx: tx,
+            client_cache,
+            watch_manager,
+            logs_manager,
+            forward_manager,
+            resource_cache: HashMap::new(),
+            active_log_channel: None,
+            current_watch_channel: None,
+            active_watch_channels: HashSet::new(),
+            active_watch_pool: Vec::new(),
+            is_running: true,
+            requires_terminal_suspend: None,
+            crds: vec![],
+            last_active_namespace: "default".to_string(),
+            context_chip_rects: std::cell::RefCell::new(Vec::new()),
+            close_pf_button_rect: std::cell::RefCell::new(None),
+            cluster_version: "v1.30.2".to_string(),
+            cluster_name: "prod".to_string(),
+            server_url: "https://127.0.0.1:6443".to_string(),
+            node_count: 10,
+            pod_count: 80,
+            is_connected: true,
+            connection_attempt_start: std::time::Instant::now(),
+            cluster_unreachable: false,
+            toast: None,
+            ai_settings: srelens_tui::AiSettings::default(),
+            assistant_state: srelens_tui::views::assistant_view::AssistantViewState::for_context("default"),
+            assistant_states: HashMap::new(),
+            pod_metrics_tick_counter: 0,
+            node_metrics_tick_counter: 0,
+            node_metrics_history: HashMap::new(),
+            pod_metrics_history: HashMap::new(),
+            cluster_overview_data: None,
+            screen_selection: None,
+            screen_selecting: false,
+            screen_selection_text: std::cell::RefCell::new(String::new()),
+        };
+
+        // 3. Initially selected on gpu-node-alpha on the left
+        if let ActiveView::GpuInfo(g) = &app.active_view {
+            let node = g.selected_node().unwrap();
+            assert_eq!(node.name, "gpu-node-alpha");
+            assert_eq!(node.gpu_capacity, 8);
+            assert_eq!(node.gpu_requests, 2);
+            assert_eq!(format_vram_mib(node.vram_capacity_total_mib.unwrap()), "640 GiB");
+            assert_eq!(format_vram_mib(node.vram_requests_total_mib), "160 GiB");
+
+            // Right side shows pods asking for VRAM on gpu-node-alpha
+            let pod = g.selected_pod().unwrap();
+            assert_eq!(pod.name, "llm-trainer-0");
+            assert_eq!(format_vram_mib(pod.vram_requests_mib), "160 GiB");
+        }
+
+        // 4. Navigate down to gpu-node-beta with 'j'
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)).await;
+        if let ActiveView::GpuInfo(g) = &app.active_view {
+            let node = g.selected_node().unwrap();
+            assert_eq!(node.name, "gpu-node-beta");
+            assert_eq!(node.gpu_capacity, 1);
+            assert_eq!(node.gpu_requests, 1);
+            assert_eq!(format_vram_mib(node.vram_capacity_total_mib.unwrap()), "15 GiB");
+
+            // Right side immediately updates to whisper-worker on gpu-node-beta!
+            let pod = g.selected_pod().unwrap();
+            assert_eq!(pod.name, "whisper-worker");
+            assert_eq!(format_vram_mib(pod.vram_requests_mib), "15 GiB");
+        }
+
+        // 5. Tab toggles pane to Pods
+        app.handle_key_event(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)).await;
+        if let ActiveView::GpuInfo(g) = &app.active_view {
+            assert_eq!(g.focused_pane, GpuPane::Pods);
+        }
+
+        // 6. Enter on whisper-worker pod opens Describe view!
+        app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)).await;
+        assert!(matches!(&app.active_view, ActiveView::Describe(d) if d.resource_name == "whisper-worker"));
+
+        // 7. Esc pops back to GpuInfo view!
+        app.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)).await;
+        assert!(matches!(&app.active_view, ActiveView::GpuInfo(_)));
+    }
+
+    #[tokio::test]
+    async fn test_multi_pod_logs_from_marked_items_and_workload() {
+        use srelens_tui::commands::ResourceKind;
+        use srelens_tui::views::resource_table::ResourceTableState;
+        use srelens_tui::app::{App, ActiveView};
+        use srelens_tui::ui::InputMode;
+        use srelens_kube::client_cache::ClientCache;
+        use srelens_streams::watch::WatchManager;
+        use srelens_streams::logs::LogStreamManager;
+        use tokio::sync::mpsc::unbounded_channel;
+        use std::collections::{HashMap, HashSet};
+        use std::path::PathBuf;
+        use std::sync::Arc;
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+        let (tx, _rx) = unbounded_channel();
+        let client_cache = ClientCache::new(PathBuf::from("/nonexistent"));
+        let watch_manager = Arc::new(WatchManager::new(client_cache.clone()));
+        let logs_manager = Arc::new(LogStreamManager::new(client_cache.clone()));
+        let forward_manager = Arc::new(srelens_streams::forward::ForwardManager::new(client_cache.clone()));
+
+        let mut table = ResourceTableState::new(ResourceKind::Pods);
+        let pod1 = serde_json::json!({
+            "name": "api-server-abc",
+            "namespace": "prod",
+            "status": "Running",
+            "spec": {
+                "containers": [{ "name": "app" }]
+            }
+        });
+        let pod2 = serde_json::json!({
+            "name": "api-server-def",
+            "namespace": "prod",
+            "status": "Running",
+            "spec": {
+                "containers": [{ "name": "app" }]
+            }
+        });
+        table.set_items(vec![pod1.clone(), pod2.clone()], "");
+        // Mark both pods
+        table.marked_indices.insert(0);
+        table.marked_indices.insert(1);
+
+        let mut app = App {
+            active_context: "prod".to_string(),
+            active_namespace: "prod".to_string(),
+            kubeconfig_paths: vec![],
+            contexts: vec![],
+            namespaces: vec!["prod".to_string()],
+            active_view: ActiveView::Table(table),
+            nav_stack: vec![],
+            input_mode: InputMode::Normal,
+            command_buffer: String::new(),
+            command_suggestion_idx: 0,
+            filter_buffer: String::new(),
+            modal: None,
+            show_help: false,
+            event_tx: tx,
+            client_cache,
+            watch_manager,
+            logs_manager,
+            forward_manager,
+            resource_cache: HashMap::new(),
+            active_log_channel: None,
+            current_watch_channel: None,
+            active_watch_channels: HashSet::new(),
+            active_watch_pool: Vec::new(),
+            is_running: true,
+            requires_terminal_suspend: None,
+            crds: vec![],
+            last_active_namespace: "prod".to_string(),
+            context_chip_rects: std::cell::RefCell::new(Vec::new()),
+            close_pf_button_rect: std::cell::RefCell::new(None),
+            cluster_version: "v1.30.2".to_string(),
+            cluster_name: "prod".to_string(),
+            server_url: "https://127.0.0.1:6443".to_string(),
+            node_count: 5,
+            pod_count: 10,
+            is_connected: true,
+            connection_attempt_start: std::time::Instant::now(),
+            cluster_unreachable: false,
+            toast: None,
+            ai_settings: srelens_tui::AiSettings::default(),
+            assistant_state: srelens_tui::views::assistant_view::AssistantViewState::for_context("prod"),
+            assistant_states: HashMap::new(),
+            pod_metrics_tick_counter: 0,
+            node_metrics_tick_counter: 0,
+            node_metrics_history: HashMap::new(),
+            pod_metrics_history: HashMap::new(),
+            cluster_overview_data: None,
+            screen_selection: None,
+            screen_selecting: false,
+            screen_selection_text: std::cell::RefCell::new(String::new()),
+        };
+
+        // Populate resource cache with pods
+        app.resource_cache.insert(
+            ("prod".to_string(), "prod".to_string(), "pods".to_string()),
+            vec![pod1, pod2],
+        );
+
+        // Press 'l' on marked pods -> starts multi-pod log stream!
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE)).await;
+        if let ActiveView::Logs(ref logs) = app.active_view {
+            assert!(logs.is_multi_pod);
+            assert_eq!(logs.known_sources.len(), 2);
+            assert!(logs.known_sources.contains(&"api-server-abc".to_string()));
+            assert!(logs.known_sources.contains(&"api-server-def".to_string()));
+        } else {
+            panic!("Expected ActiveView::Logs");
+        }
+
+        // Simulate multiplexed log events from both pods arriving on channel
+        let ch = app.active_log_channel.clone().unwrap();
+        app.handle_stream_event(
+            ch.clone(),
+            serde_json::json!({
+                "source": "api-server-abc",
+                "line": "GET /health 200"
+            }),
+        );
+        app.handle_stream_event(
+            ch.clone(),
+            serde_json::json!({
+                "source": "api-server-def",
+                "line": "POST /order 201"
+            }),
+        );
+
+        if let ActiveView::Logs(ref logs) = app.active_view {
+            assert_eq!(logs.entries.len(), 3); // 1 header banner + 2 log lines
+            let e1 = &logs.entries[1];
+            assert_eq!(e1.source.as_deref(), Some("api-server-abc"));
+            assert_eq!(e1.line, "GET /health 200");
+            let e2 = &logs.entries[2];
+            assert_eq!(e2.source.as_deref(), Some("api-server-def"));
+            assert_eq!(e2.line, "POST /order 201");
+        } else {
+            panic!("Expected ActiveView::Logs");
+        }
+
+        // Esc returns back to table
+        app.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)).await;
+        assert!(matches!(app.active_view, ActiveView::Table(_)));
+    }
+
+    #[tokio::test]
+    async fn test_top_hotspots_commands_and_sorting() {
+        use srelens_tui::commands::{resolve_command, ResourceKind, CommandTarget};
+        use srelens_tui::views::top_view::{TopTab, TopSortBy, TopPodRow, TopNodeRow};
+        use srelens_tui::app::{App, ActiveView};
+        use srelens_tui::ui::InputMode;
+        use srelens_kube::client_cache::ClientCache;
+        use srelens_streams::watch::WatchManager;
+        use srelens_streams::logs::LogStreamManager;
+        use tokio::sync::mpsc::unbounded_channel;
+        use std::collections::{HashMap, HashSet};
+        use std::path::PathBuf;
+        use std::sync::Arc;
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+        // 1. Verify command resolutions
+        assert_eq!(resolve_command("top"), Some(CommandTarget::Resource(ResourceKind::TopPods)));
+        assert_eq!(resolve_command(":top"), Some(CommandTarget::Resource(ResourceKind::TopPods)));
+        assert_eq!(resolve_command(":toppods"), Some(CommandTarget::Resource(ResourceKind::TopPods)));
+        assert_eq!(resolve_command(":top pods"), Some(CommandTarget::Resource(ResourceKind::TopPods)));
+        assert_eq!(resolve_command(":topnodes"), Some(CommandTarget::Resource(ResourceKind::TopNodes)));
+        assert_eq!(resolve_command(":top nodes"), Some(CommandTarget::Resource(ResourceKind::TopNodes)));
+
+        // 2. Setup App with Top view
+        let (tx, _rx) = unbounded_channel();
+        let client_cache = ClientCache::new(PathBuf::from("/nonexistent"));
+        let watch_manager = Arc::new(WatchManager::new(client_cache.clone()));
+        let logs_manager = Arc::new(LogStreamManager::new(client_cache.clone()));
+        let forward_manager = Arc::new(srelens_streams::forward::ForwardManager::new(client_cache.clone()));
+
+        let mut top_state = srelens_tui::views::top_view::TopViewState::new(TopTab::Pods);
+        let pod_rows = vec![
+            TopPodRow {
+                namespace: "default".to_string(),
+                name: "low-cpu-pod".to_string(),
+                cpu_millicores: 100,
+                cpu_req_millicores: 500,
+                cpu_lim_millicores: 1000,
+                mem_mib: 800,
+                mem_req_mib: 1024,
+                mem_lim_mib: 2048,
+            },
+            TopPodRow {
+                namespace: "default".to_string(),
+                name: "high-cpu-pod".to_string(),
+                cpu_millicores: 1200,
+                cpu_req_millicores: 1000,
+                cpu_lim_millicores: 2000,
+                mem_mib: 400,
+                mem_req_mib: 512,
+                mem_lim_mib: 1024,
+            },
+        ];
+        let node_rows = vec![
+            TopNodeRow {
+                name: "node-1".to_string(),
+                status: "Ready".to_string(),
+                cpu_millicores: 2000,
+                cpu_alloc_millicores: 4000,
+                mem_mib: 8000,
+                mem_alloc_mib: 16000,
+            },
+        ];
+        top_state.set_data(pod_rows, node_rows);
+
+        let mut app = App {
+            active_context: "prod".to_string(),
+            active_namespace: "default".to_string(),
+            kubeconfig_paths: vec![],
+            contexts: vec![],
+            namespaces: vec!["default".to_string()],
+            active_view: ActiveView::Top(top_state),
+            nav_stack: vec![],
+            input_mode: InputMode::Normal,
+            command_buffer: String::new(),
+            command_suggestion_idx: 0,
+            filter_buffer: String::new(),
+            modal: None,
+            show_help: false,
+            event_tx: tx,
+            client_cache,
+            watch_manager,
+            logs_manager,
+            forward_manager,
+            resource_cache: HashMap::new(),
+            active_log_channel: None,
+            current_watch_channel: None,
+            active_watch_channels: HashSet::new(),
+            active_watch_pool: Vec::new(),
+            is_running: true,
+            requires_terminal_suspend: None,
+            crds: vec![],
+            last_active_namespace: "default".to_string(),
+            context_chip_rects: std::cell::RefCell::new(Vec::new()),
+            close_pf_button_rect: std::cell::RefCell::new(None),
+            cluster_version: "v1.30.2".to_string(),
+            cluster_name: "prod".to_string(),
+            server_url: "https://127.0.0.1:6443".to_string(),
+            node_count: 5,
+            pod_count: 10,
+            is_connected: true,
+            connection_attempt_start: std::time::Instant::now(),
+            cluster_unreachable: false,
+            toast: None,
+            ai_settings: srelens_tui::AiSettings::default(),
+            assistant_state: srelens_tui::views::assistant_view::AssistantViewState::for_context("default"),
+            assistant_states: HashMap::new(),
+            pod_metrics_tick_counter: 0,
+            node_metrics_tick_counter: 0,
+            node_metrics_history: HashMap::new(),
+            pod_metrics_history: HashMap::new(),
+            cluster_overview_data: None,
+            screen_selection: None,
+            screen_selecting: false,
+            screen_selection_text: std::cell::RefCell::new(String::new()),
+        };
+
+        // Verify initial CPU sort puts high-cpu-pod first
+        if let ActiveView::Top(ref top) = app.active_view {
+            assert_eq!(top.selected_pod().unwrap().name, "high-cpu-pod");
+        }
+
+        // Press 'm' to sort by Memory (descending) -> low-cpu-pod has 800MiB vs 400MiB
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE)).await;
+        if let ActiveView::Top(ref top) = app.active_view {
+            assert_eq!(top.sort_by, TopSortBy::Memory);
+            assert_eq!(top.selected_pod().unwrap().name, "low-cpu-pod");
+        }
+
+        // Press 'S' to reverse direction (ascending) -> high-cpu-pod has 400MiB
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('S'), KeyModifiers::SHIFT)).await;
+        if let ActiveView::Top(ref top) = app.active_view {
+            assert_eq!(top.selected_pod().unwrap().name, "high-cpu-pod");
+        }
+
+        // Press Tab to toggle to Nodes tab
+        app.handle_key_event(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)).await;
+        if let ActiveView::Top(ref top) = app.active_view {
+            assert_eq!(top.active_tab, TopTab::Nodes);
+            assert_eq!(top.selected_node().unwrap().name, "node-1");
+        }
+
+        // Press '1' to switch back to Pods tab
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('1'), KeyModifiers::NONE)).await;
+        if let ActiveView::Top(ref top) = app.active_view {
+            assert_eq!(top.active_tab, TopTab::Pods);
+        }
+
+        // Press 'd' to Describe the selected pod
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE)).await;
+        assert!(matches!(app.active_view, ActiveView::Describe(_)));
+
+        // Esc pops back to Top view
+        app.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)).await;
+        assert!(matches!(app.active_view, ActiveView::Top(_)));
+    }
+
+    #[tokio::test]
+    async fn test_helm_detail_view_state_and_values_diff() {
+        use srelens_tui::views::helm_detail_view::{HelmDetailTab, HelmDetailViewState, ValuesDiffMode, DiffKind};
+        use srelens_kube::helm::{HelmReleaseDetail, HelmRevision};
+
+        let mut detail_state = HelmDetailViewState::new("ingress-nginx".to_string(), "default".to_string());
+        assert_eq!(detail_state.active_tab, HelmDetailTab::Overview);
+
+        // Tab transitions
+        detail_state.next_tab();
+        assert_eq!(detail_state.active_tab, HelmDetailTab::ValuesDiff);
+        detail_state.next_tab();
+        assert_eq!(detail_state.active_tab, HelmDetailTab::Revisions);
+        detail_state.next_tab();
+        assert_eq!(detail_state.active_tab, HelmDetailTab::Manifest);
+        detail_state.next_tab();
+        assert_eq!(detail_state.active_tab, HelmDetailTab::Notes);
+        detail_state.next_tab();
+        assert_eq!(detail_state.active_tab, HelmDetailTab::Overview);
+        detail_state.prev_tab();
+        assert_eq!(detail_state.active_tab, HelmDetailTab::Notes);
+
+        // Populate detail
+        let mock_detail = HelmReleaseDetail {
+            name: "ingress-nginx".to_string(),
+            namespace: "default".to_string(),
+            revision: 3,
+            status: "deployed".to_string(),
+            chart: "ingress-nginx".to_string(),
+            chart_version: "4.8.3".to_string(),
+            app_version: "1.9.4".to_string(),
+            updated: "2026-09-01T12:00:00Z".to_string(),
+            values_yaml: "controller:\n  replicaCount: 3\n  service:\n    type: LoadBalancer\n".to_string(),
+            chart_values_yaml: "controller:\n  replicaCount: 1\n  service:\n    type: ClusterIP\n".to_string(),
+            computed_values_yaml: "controller:\n  replicaCount: 3\n  service:\n    type: LoadBalancer\n".to_string(),
+            manifest: "---\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: ingress-nginx-controller\n---\napiVersion: v1\nkind: Service\nmetadata:\n  name: ingress-nginx-controller\n---\napiVersion: v1\nkind: Service\nmetadata:\n  name: ingress-nginx-controller-admission\n".to_string(),
+            notes: "The ingress-nginx controller has been installed successfully.".to_string(),
+            history: vec![
+                HelmRevision {
+                    revision: 3,
+                    status: "deployed".to_string(),
+                    updated: "2026-09-01T12:00:00Z".to_string(),
+                    chart_version: "ingress-nginx-4.8.3".to_string(),
+                    description: "Upgrade complete".to_string(),
+                },
+                HelmRevision {
+                    revision: 2,
+                    status: "superseded".to_string(),
+                    updated: "2026-08-15T10:00:00Z".to_string(),
+                    chart_version: "ingress-nginx-4.8.2".to_string(),
+                    description: "Upgrade complete".to_string(),
+                },
+                HelmRevision {
+                    revision: 1,
+                    status: "superseded".to_string(),
+                    updated: "2026-08-01T08:00:00Z".to_string(),
+                    chart_version: "ingress-nginx-4.8.0".to_string(),
+                    description: "Install complete".to_string(),
+                },
+            ],
+        };
+        detail_state.set_detail(mock_detail);
+
+        // Verify resource parsing from manifest
+        let counts = detail_state.parse_manifest_resource_counts();
+        assert_eq!(counts.len(), 2);
+        let dep_count = counts.iter().find(|(k, _)| k == "Deployment").map(|(_, c)| *c);
+        let svc_count = counts.iter().find(|(k, _)| k == "Service").map(|(_, c)| *c);
+        assert_eq!(dep_count, Some(1));
+        assert_eq!(svc_count, Some(2));
+
+        // Verify values diff: Custom vs Default
+        detail_state.set_tab(HelmDetailTab::ValuesDiff);
+        assert_eq!(detail_state.values_diff_mode, ValuesDiffMode::CustomVsDefault);
+        let diff_lines = detail_state.compute_values_diff();
+        assert!(!diff_lines.is_empty());
+        assert!(diff_lines.iter().any(|l| matches!(l.kind, DiffKind::Remove) && l.text.contains("replicaCount: 1")));
+        assert!(diff_lines.iter().any(|l| matches!(l.kind, DiffKind::Add) && l.text.contains("replicaCount: 3")));
+
+        // Toggle diff mode to RevisionVsPrevious
+        detail_state.toggle_diff_mode();
+        assert_eq!(detail_state.values_diff_mode, ValuesDiffMode::RevisionVsPrevious);
+
+        // Previous revision detail
+        let prev_detail = HelmReleaseDetail {
+            name: "ingress-nginx".to_string(),
+            namespace: "default".to_string(),
+            revision: 2,
+            status: "superseded".to_string(),
+            chart: "ingress-nginx".to_string(),
+            chart_version: "4.8.2".to_string(),
+            app_version: "1.9.3".to_string(),
+            updated: "2026-08-15T10:00:00Z".to_string(),
+            values_yaml: "controller:\n  replicaCount: 2\n  service:\n    type: LoadBalancer\n".to_string(),
+            chart_values_yaml: "controller:\n  replicaCount: 1\n".to_string(),
+            computed_values_yaml: "controller:\n  replicaCount: 2\n".to_string(),
+            manifest: "".to_string(),
+            notes: "".to_string(),
+            history: vec![],
+        };
+        detail_state.set_previous_detail(prev_detail);
+        let rev_diff = detail_state.compute_values_diff();
+        assert!(rev_diff.iter().any(|l| matches!(l.kind, DiffKind::Remove) && l.text.contains("replicaCount: 2")));
+        assert!(rev_diff.iter().any(|l| matches!(l.kind, DiffKind::Add) && l.text.contains("replicaCount: 3")));
+
+        // Revision selection
+        detail_state.set_tab(HelmDetailTab::Revisions);
+        assert_eq!(detail_state.selected_revision().unwrap().revision, 3);
+        detail_state.select_next_revision();
+        assert_eq!(detail_state.selected_revision().unwrap().revision, 2);
+        detail_state.select_next_revision();
+        assert_eq!(detail_state.selected_revision().unwrap().revision, 1);
+        detail_state.select_prev_revision();
+        assert_eq!(detail_state.selected_revision().unwrap().revision, 2);
+    }
+
+    #[tokio::test]
+    async fn test_helm_views_navigation_and_interactions() {
+        use srelens_tui::app::{ActiveView, App};
+        use srelens_tui::ui::Modal;
+        use srelens_tui::views::helm_detail_view::{HelmDetailTab, ValuesDiffMode};
+        use srelens_tui::views::helm_view::{HelmReleaseItem, HelmViewState};
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut app = App::new(
+            Some("test-ctx".to_string()),
+            Some("default".to_string()),
+            false,
+            None,
+            vec![],
+            tx,
+        ).await.unwrap();
+
+        // 1. Setup Helm releases in HelmViewState
+        let mut helm_state = HelmViewState::new();
+        helm_state.set_releases(vec![
+            HelmReleaseItem {
+                name: "prometheus-stack".to_string(),
+                namespace: "monitoring".to_string(),
+                revision: 4,
+                status: "deployed".to_string(),
+                chart: "kube-prometheus-stack".to_string(),
+                chart_version: "51.2.0".to_string(),
+                app_version: "0.68.0".to_string(),
+                updated: "2026-09-01T00:00:00Z".to_string(),
+            },
+            HelmReleaseItem {
+                name: "ingress-nginx".to_string(),
+                namespace: "ingress".to_string(),
+                revision: 2,
+                status: "deployed".to_string(),
+                chart: "ingress-nginx".to_string(),
+                chart_version: "4.8.3".to_string(),
+                app_version: "1.9.4".to_string(),
+                updated: "2026-09-02T00:00:00Z".to_string(),
+            },
+        ]);
+        app.active_view = ActiveView::Helm(helm_state);
+
+        // Navigate releases down
+        app.handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)).await;
+        if let ActiveView::Helm(ref helm) = app.active_view {
+            assert_eq!(helm.selected_release().unwrap().name, "ingress-nginx");
+        }
+
+        // 2. Press Enter to open Deep Inspector on Overview tab
+        app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)).await;
+        match &app.active_view {
+            ActiveView::HelmDetail(detail) => {
+                assert_eq!(detail.release_name, "ingress-nginx");
+                assert_eq!(detail.namespace, "ingress");
+                assert_eq!(detail.active_tab, HelmDetailTab::Overview);
+            }
+            _ => panic!("Expected ActiveView::HelmDetail"),
+        }
+
+        // 3. Tab navigation inside HelmDetail
+        app.handle_key_event(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)).await;
+        if let ActiveView::HelmDetail(ref detail) = app.active_view {
+            assert_eq!(detail.active_tab, HelmDetailTab::ValuesDiff);
+        }
+
+        // Toggle diff mode with 'm'
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE)).await;
+        if let ActiveView::HelmDetail(ref detail) = app.active_view {
+            assert_eq!(detail.values_diff_mode, ValuesDiffMode::RevisionVsPrevious);
+        }
+
+        // Jump to Revisions tab with '3'
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('3'), KeyModifiers::NONE)).await;
+        if let ActiveView::HelmDetail(ref mut detail) = app.active_view {
+            assert_eq!(detail.active_tab, HelmDetailTab::Revisions);
+            // Mock history
+            detail.detail = Some(srelens_kube::helm::HelmReleaseDetail {
+                name: "ingress-nginx".to_string(),
+                namespace: "ingress".to_string(),
+                revision: 2,
+                status: "deployed".to_string(),
+                chart: "ingress-nginx".to_string(),
+                chart_version: "4.8.3".to_string(),
+                app_version: "1.9.4".to_string(),
+                updated: "2026-09-02T00:00:00Z".to_string(),
+                values_yaml: "".to_string(),
+                chart_values_yaml: "".to_string(),
+                computed_values_yaml: "".to_string(),
+                manifest: "".to_string(),
+                notes: "".to_string(),
+                history: vec![
+                    srelens_kube::helm::HelmRevision {
+                        revision: 2,
+                        status: "deployed".to_string(),
+                        updated: "2026-09-02".to_string(),
+                        chart_version: "4.8.3".to_string(),
+                        description: "".to_string(),
+                    },
+                    srelens_kube::helm::HelmRevision {
+                        revision: 1,
+                        status: "superseded".to_string(),
+                        updated: "2026-09-01".to_string(),
+                        chart_version: "4.8.0".to_string(),
+                        description: "".to_string(),
+                    },
+                ],
+            });
+        }
+
+        // Select revision 1 and press 'r' to rollback to it
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)).await;
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE)).await;
+        match &app.modal {
+            Some(Modal::Confirm { title, action_name, .. }) => {
+                assert!(title.contains("Rollback Helm Release [ingress-nginx]"));
+                assert_eq!(action_name, "helm-rollback:ingress-nginx:ingress:1");
+            }
+            _ => panic!("Expected Confirm modal for rollback"),
+        }
+        app.modal = None;
+
+        // 4. Press Esc to return back to Helm release list
+        app.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)).await;
+        assert!(matches!(app.active_view, ActiveView::Helm(_)));
+
+        // 5. From Helm list, press 'r' to trigger rollback modal to revision - 1
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE)).await;
+        match &app.modal {
+            Some(Modal::Confirm { action_name, .. }) => {
+                assert_eq!(action_name, "helm-rollback:ingress-nginx:ingress:1");
+            }
+            _ => panic!("Expected Confirm modal for rollback from release table"),
+        }
+        app.modal = None;
+
+        // 6. From Helm list, press Ctrl+D to trigger uninstall modal
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL)).await;
+        match &app.modal {
+            Some(Modal::Confirm { title, action_name, .. }) => {
+                assert!(title.contains("Uninstall Helm Release [ingress-nginx]"));
+                assert_eq!(action_name, "helm-uninstall:ingress-nginx:ingress");
+            }
+            _ => panic!("Expected Confirm modal for uninstall"),
+        }
+        app.modal = None;
+
+        // 7. Deep link navigation to Helm release
+        let deep_link = srelens_tui::deep_link::DeepLink::Resource {
+            context: "test-ctx".to_string(),
+            namespace: Some("ingress".to_string()),
+            kind: "HelmRelease".to_string(),
+            name: "ingress-nginx".to_string(),
+        };
+        let res = app.navigate_deep_link(&deep_link).await;
+        assert!(res.is_ok());
+        assert!(matches!(app.active_view, ActiveView::HelmDetail(_)));
+    }
 }
+
+
+
 
 
 

--- a/apps/tui/tests/tui_tests.rs
+++ b/apps/tui/tests/tui_tests.rs
@@ -6513,9 +6513,14 @@ mod tests {
         let svc_count = counts.iter().find(|(k, _)| k == "Service").map(|(_, c)| *c);
         assert_eq!(dep_count, Some(1));
         assert_eq!(svc_count, Some(2));
-
-        // Verify values diff: Custom vs Default
+        // Verify values diff: Custom vs Computed (default mode)
         detail_state.set_tab(HelmDetailTab::ValuesDiff);
+        assert_eq!(detail_state.values_diff_mode, ValuesDiffMode::CustomVsComputed);
+        let diff_lines = detail_state.compute_values_diff();
+        assert!(!diff_lines.is_empty());
+
+        // Toggle to CustomVsDefault
+        detail_state.toggle_diff_mode();
         assert_eq!(detail_state.values_diff_mode, ValuesDiffMode::CustomVsDefault);
         let diff_lines = detail_state.compute_values_diff();
         assert!(!diff_lines.is_empty());
@@ -6626,10 +6631,10 @@ mod tests {
             assert_eq!(detail.active_tab, HelmDetailTab::ValuesDiff);
         }
 
-        // Toggle diff mode with 'm'
+        // Toggle diff mode with 'm' (CustomVsComputed -> CustomVsDefault)
         app.handle_key_event(KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE)).await;
         if let ActiveView::HelmDetail(ref detail) = app.active_view {
-            assert_eq!(detail.values_diff_mode, ValuesDiffMode::RevisionVsPrevious);
+            assert_eq!(detail.values_diff_mode, ValuesDiffMode::CustomVsDefault);
         }
 
         // Jump to Revisions tab with '3'

--- a/apps/tui/tests/views_panels_tests.rs
+++ b/apps/tui/tests/views_panels_tests.rs
@@ -1068,6 +1068,7 @@ fn release(name: &str, status: &str, revision: i64) -> HelmReleaseItem {
         revision,
         status: status.to_string(),
         chart: format!("{name}-1.2.3"),
+        chart_version: "1.2.3".to_string(),
         app_version: "2.0".to_string(),
         updated: "2026-09-01 10:00".to_string(),
     }
@@ -1097,9 +1098,13 @@ fn helm_view_set_releases_clamps_the_selection() {
 
 #[test]
 fn helm_view_renders_the_empty_placeholder() {
-    let state = HelmViewState::new();
-    let text = common::render_text(120, 20, |f| render_helm_view(f, f.area(), &state));
-    assert!(text.contains("Helm 3 Releases [0] (<v> Values <y> Manifest <d> History <ctrl-d> Uninstall <Esc> Back)"), "{text}");
+    let mut state = HelmViewState::new();
+    state.set_releases(vec![]);
+    let text = common::render_text(160, 20, |f| render_helm_view(f, f.area(), &state));
+    assert!(
+        text.contains("Helm 3 Releases [0]") && text.contains("Uninstall") && text.contains("Back"),
+        "{text}"
+    );
     assert!(
         text.contains("No Helm releases found in current namespace."),
         "{text}"
@@ -1447,11 +1452,17 @@ fn metrics_panel_modal_summarises_only_the_samples_inside_the_window() {
     );
     assert!(text.contains("(3 samples in buffer)"), "{text}");
     assert!(
-        text.contains("CPU Usage: 300m  (min: 100m, avg: 200m, peak: 300m)"),
+        text.contains("CPU Usage: 300m")
+            && text.contains("min: 100m")
+            && text.contains("avg: 200m")
+            && text.contains("peak: 300m"),
         "{text}"
     );
     assert!(
-        text.contains("Memory Usage: 400 MiB  (min: 200 MiB, avg: 300 MiB, peak: 400 MiB)"),
+        text.contains("Memory Usage: 400 MiB")
+            && text.contains("min: 200 MiB")
+            && text.contains("avg: 300 MiB")
+            && text.contains("peak: 400 MiB"),
         "{text}"
     );
 
@@ -1460,7 +1471,10 @@ fn metrics_panel_modal_summarises_only_the_samples_inside_the_window() {
     assert_eq!(state.range, MetricsTimeRange::ThirtyMin);
     let text = common::render_text(120, 40, |f| render_metrics_panel_modal(f, f.area(), &state));
     assert!(
-        text.contains("CPU Usage: 300m  (min: 100m, avg: 433m, peak: 900m)"),
+        text.contains("CPU Usage: 300m")
+            && text.contains("min: 100m")
+            && text.contains("avg: 433m")
+            && text.contains("peak: 900m"),
         "{text}"
     );
     assert!(text.contains("[3: 30m]"), "{text}");

--- a/crates/kube/src/gpu_info.rs
+++ b/crates/kube/src/gpu_info.rs
@@ -1,0 +1,636 @@
+use std::collections::HashMap;
+use std::time::Duration;
+use k8s_openapi::api::core::v1::{Node, Pod};
+use kube::{Api, Client};
+use kube::api::ListParams;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GpuPodItem {
+    pub name: String,
+    pub namespace: String,
+    pub phase: String,
+    pub gpu_requests: i64,
+    pub vram_requests_mib: i64,
+    pub ready_containers: String,
+    pub restarts: i64,
+    pub age: String,
+    pub containers: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GpuNodeInfo {
+    pub name: String,
+    pub status: String,
+    pub unschedulable: bool,
+    pub roles: String,
+    pub instance_type: String,
+    pub gpu_model: Option<String>,
+    pub gpu_driver_version: Option<String>,
+    pub gpu_cuda_version: Option<String>,
+    pub gpu_capacity: i64,
+    pub gpu_allocatable: i64,
+    pub gpu_requests: i64,
+    pub vram_per_gpu_mib: Option<i64>,
+    pub vram_capacity_total_mib: Option<i64>,
+    pub vram_requests_total_mib: i64,
+    pub pods: Vec<GpuPodItem>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GpuClusterInfo {
+    pub nodes: Vec<GpuNodeInfo>,
+    pub total_gpu_nodes: usize,
+    pub total_gpus: i64,
+    pub total_allocated_gpus: i64,
+    pub total_vram_mib: i64,
+    pub total_allocated_vram_mib: i64,
+    pub total_gpu_pods: usize,
+}
+
+/// Fetch cluster nodes and pods to compile comprehensive GPU and VRAM allocation info.
+pub async fn fetch_gpu_info(client: Client) -> Result<GpuClusterInfo, String> {
+    let node_api: Api<Node> = Api::all(client.clone());
+    let node_list = tokio::time::timeout(Duration::from_secs(12), node_api.list(&ListParams::default()))
+        .await
+        .map_err(|_| "Timed out fetching cluster nodes".to_string())?
+        .map_err(|e| format!("Failed to list cluster nodes: {}", e))?;
+
+    let pod_api: Api<Pod> = Api::all(client);
+    let pod_list = tokio::time::timeout(Duration::from_secs(15), pod_api.list(&ListParams::default()))
+        .await
+        .map_err(|_| "Timed out fetching cluster pods".to_string())?
+        .map_err(|e| format!("Failed to list cluster pods: {}", e))?;
+
+    Ok(parse_gpu_cluster_info(&node_list.items, &pod_list.items))
+}
+
+/// Pure parser extracting `GpuClusterInfo` from raw Kubernetes `Node` and `Pod` resources.
+pub fn parse_gpu_cluster_info(nodes: &[Node], pods: &[Pod]) -> GpuClusterInfo {
+    // 1. Group pods by nodeName
+    let mut pods_by_node: HashMap<String, Vec<&Pod>> = HashMap::new();
+    for pod in pods {
+        if let Some(spec) = &pod.spec {
+            if let Some(node_name) = &spec.node_name {
+                pods_by_node.entry(node_name.clone()).or_default().push(pod);
+            }
+        }
+    }
+
+    let discrete_gpu_keys = [
+        "nvidia.com/gpu",
+        "amd.com/gpu",
+        "google.com/tpu",
+    ];
+
+    let mut gpu_nodes = Vec::new();
+    let mut cluster_total_gpus = 0;
+    let mut cluster_allocated_gpus = 0;
+    let mut cluster_total_vram_mib = 0;
+    let mut cluster_allocated_vram_mib = 0;
+    let mut cluster_total_gpu_pods = 0;
+
+    for node in nodes {
+        let name = node.metadata.name.clone().unwrap_or_default();
+        let labels = node.metadata.labels.as_ref();
+        let capacity = node.status.as_ref().and_then(|s| s.capacity.as_ref());
+        let allocatable = node.status.as_ref().and_then(|s| s.allocatable.as_ref());
+
+        // Detect GPU capacity & allocatable
+        let mut gpu_capacity: i64 = 0;
+        let mut gpu_allocatable: i64 = 0;
+
+        for key in &discrete_gpu_keys {
+            if let Some(cap) = capacity.and_then(|c| c.get(*key)) {
+                if let Ok(count) = cap.0.trim().parse::<i64>() {
+                    gpu_capacity = gpu_capacity.max(count);
+                }
+            }
+            if let Some(alloc) = allocatable.and_then(|a| a.get(*key)) {
+                if let Ok(count) = alloc.0.trim().parse::<i64>() {
+                    gpu_allocatable = gpu_allocatable.max(count);
+                }
+            }
+        }
+
+        // Check MIG slices if no standard discrete GPU
+        if gpu_capacity == 0 {
+            if let Some(cap) = capacity {
+                for (k, v) in cap {
+                    if k.starts_with("nvidia.com/mig-") {
+                        if let Ok(count) = v.0.trim().parse::<i64>() {
+                            gpu_capacity += count;
+                        }
+                    }
+                }
+            }
+            if let Some(alloc) = allocatable {
+                for (k, v) in alloc {
+                    if k.starts_with("nvidia.com/mig-") {
+                        if let Ok(count) = v.0.trim().parse::<i64>() {
+                            gpu_allocatable += count;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Check HAMi virtual GPU count if present
+        if gpu_capacity == 0 {
+            if let Some(cap) = capacity.and_then(|c| c.get("nvidia.com/vgpu")) {
+                if let Ok(count) = cap.0.trim().parse::<i64>() {
+                    gpu_capacity = gpu_capacity.max(count);
+                }
+            }
+            if let Some(alloc) = allocatable.and_then(|a| a.get("nvidia.com/vgpu")) {
+                if let Ok(count) = alloc.0.trim().parse::<i64>() {
+                    gpu_allocatable = gpu_allocatable.max(count);
+                }
+            }
+        }
+
+        // Model & hardware labels
+        let gpu_model = labels.and_then(|l| {
+            l.get("nvidia.com/gpu.product")
+                .or_else(|| l.get("gpu.trivago.com/model"))
+                .or_else(|| l.get("nvidia.com/gpu.machine"))
+                .or_else(|| l.get("nvidia.com/gpu.family"))
+                .cloned()
+                .map(|m| m.replace('-', " "))
+        });
+
+        let has_gpu = gpu_capacity > 0
+            || gpu_model.is_some()
+            || labels.map(|l| {
+                l.contains_key("nvidia.com/gpu.present")
+                    || l.contains_key("trivago.com/gpu")
+                    || l.contains_key("gpu.trivago.com/model")
+                    || l.contains_key("feature.node.kubernetes.io/pci-10de.present")
+            }).unwrap_or(false);
+
+        if !has_gpu {
+            continue;
+        }
+
+        let gpu_driver_version = labels.and_then(|l| {
+            l.get("nvidia.com/cuda.driver-version")
+                .or_else(|| l.get("nvidia.com/driver-version"))
+                .cloned()
+        });
+
+        let gpu_cuda_version = labels.and_then(|l| {
+            l.get("nvidia.com/cuda.runtime.version")
+                .or_else(|| l.get("nvidia.com/cuda.version"))
+                .cloned()
+        });
+
+        // Determine VRAM per GPU
+        let mut vram_per_gpu_mib: Option<i64> = labels.and_then(|l| {
+            l.get("nvidia.com/gpu.memory")
+                .and_then(|m| m.parse::<i64>().ok())
+        });
+
+        if vram_per_gpu_mib.is_none() {
+            if let Some(mem_cap) = capacity.and_then(|c| c.get("nvidia.com/gpumem")) {
+                if let Ok(val) = mem_cap.0.trim().parse::<i64>() {
+                    let total_gpus = gpu_capacity.max(1);
+                    vram_per_gpu_mib = Some(val / total_gpus);
+                }
+            }
+        }
+
+        if vram_per_gpu_mib.is_none() {
+            if let Some(model) = &gpu_model {
+                let m = model.to_lowercase();
+                if m.contains("t4") {
+                    vram_per_gpu_mib = Some(15360); // 15 GiB
+                } else if m.contains("a100") {
+                    if m.contains("40gb") || m.contains("40g") {
+                        vram_per_gpu_mib = Some(40960); // 40 GiB
+                    } else {
+                        vram_per_gpu_mib = Some(81920); // 80 GiB
+                    }
+                } else if m.contains("h100") {
+                    vram_per_gpu_mib = Some(81920); // 80 GiB
+                } else if m.contains("h200") {
+                    vram_per_gpu_mib = Some(144384); // 141 GiB
+                } else if m.contains("b200") {
+                    vram_per_gpu_mib = Some(196608); // 192 GiB
+                } else if m.contains("l40") {
+                    vram_per_gpu_mib = Some(49152); // 48 GiB
+                } else if m.contains("l4") {
+                    vram_per_gpu_mib = Some(24576); // 24 GiB
+                } else if m.contains("a10") || m.contains("a30") {
+                    vram_per_gpu_mib = Some(24576); // 24 GiB
+                } else if m.contains("v100") {
+                    if m.contains("32gb") || m.contains("32g") {
+                        vram_per_gpu_mib = Some(32768);
+                    } else {
+                        vram_per_gpu_mib = Some(16384); // 16 GiB
+                    }
+                } else if m.contains("rtx 4090") || m.contains("rtx 3090") {
+                    vram_per_gpu_mib = Some(24576); // 24 GiB
+                } else if m.contains("a40") || m.contains("a6000") {
+                    vram_per_gpu_mib = Some(49152); // 48 GiB
+                }
+            }
+        }
+
+        // Status & roles
+        let status = node
+            .status
+            .as_ref()
+            .and_then(|s| s.conditions.as_ref())
+            .and_then(|conds| conds.iter().find(|c| c.type_ == "Ready"))
+            .map(|c| if c.status == "True" { "Ready" } else { "NotReady" })
+            .unwrap_or("Unknown")
+            .to_string();
+
+        let unschedulable = node.spec.as_ref().and_then(|s| s.unschedulable).unwrap_or(false);
+
+        let roles = labels
+            .map(|lbls| {
+                let r: Vec<String> = lbls
+                    .keys()
+                    .filter_map(|k| k.strip_prefix("node-role.kubernetes.io/"))
+                    .filter(|s| !s.is_empty())
+                    .map(String::from)
+                    .collect();
+                if r.is_empty() {
+                    "<none>".to_string()
+                } else {
+                    r.join(",")
+                }
+            })
+            .unwrap_or_else(|| "<none>".to_string());
+
+        let instance_type = labels
+            .and_then(|l| {
+                l.get("node.kubernetes.io/instance-type")
+                    .or_else(|| l.get("beta.kubernetes.io/instance-type"))
+            })
+            .cloned()
+            .unwrap_or_else(|| "-".to_string());
+
+        // Process Pods on this node requesting GPU / VRAM
+        let mut gpu_pod_items = Vec::new();
+        let mut node_gpu_reqs: i64 = 0;
+        let mut node_vram_reqs_mib: i64 = 0;
+
+        if let Some(node_pods) = pods_by_node.get(&name) {
+            for pod in node_pods {
+                let p_name = pod.metadata.name.clone().unwrap_or_default();
+                let p_ns = pod.metadata.namespace.clone().unwrap_or_else(|| "default".to_string());
+                let p_phase = pod
+                    .status
+                    .as_ref()
+                    .and_then(|s| s.phase.clone())
+                    .unwrap_or_else(|| "Unknown".to_string());
+
+                let age = crate::humanize_age(pod.metadata.creation_timestamp.as_ref());
+                let container_statuses = pod.status.as_ref().and_then(|s| s.container_statuses.as_ref());
+                let ready_count = container_statuses
+                    .map(|cs| cs.iter().filter(|c| c.ready).count())
+                    .unwrap_or(0);
+                let total_containers = pod
+                    .spec
+                    .as_ref()
+                    .map(|s| s.containers.len())
+                    .unwrap_or(0);
+                let ready_containers = format!("{}/{}", ready_count, total_containers);
+
+                let restarts: i64 = container_statuses
+                    .map(|cs| cs.iter().map(|c| c.restart_count as i64).sum())
+                    .unwrap_or(0);
+
+                let mut pod_gpus: i64 = 0;
+                let mut pod_vram_mib: i64 = 0;
+                let mut requesting_containers = Vec::new();
+
+                if let Some(spec) = &pod.spec {
+                    for c in &spec.containers {
+                        let mut c_gpu = 0;
+                        let mut c_vram = 0;
+
+                        if let Some(res) = &c.resources {
+                            // Check requests first, then fallback to limits
+                            let reqs_or_limits = res.requests.as_ref().or(res.limits.as_ref());
+                            if let Some(res_map) = reqs_or_limits {
+                                for key in &discrete_gpu_keys {
+                                    if let Some(q) = res_map.get(*key) {
+                                        if let Ok(val) = q.0.trim().parse::<i64>() {
+                                            c_gpu += val;
+                                        }
+                                    }
+                                }
+                                // HAMi / virtual GPU memory in MiB
+                                if let Some(q) = res_map.get("nvidia.com/gpumem")
+                                    .or_else(|| res_map.get("nvidia.com/gpu-mem"))
+                                    .or_else(|| res_map.get("nvidia.com/gpu.memory"))
+                                    .or_else(|| res_map.get("nvidia.com/vcuda-memory"))
+                                {
+                                    c_vram += parse_vram_quantity(&q.0);
+                                }
+                                // MIG slices
+                                for (k, q) in res_map {
+                                    if k.starts_with("nvidia.com/mig-") {
+                                        if let Ok(slices) = q.0.trim().parse::<i64>() {
+                                            c_gpu += slices;
+                                            c_vram += parse_mig_slice_vram_mib(k) * slices;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        if c_gpu > 0 || c_vram > 0 {
+                            // If VRAM wasn't explicitly specified via HAMi or MIG, but discrete GPUs were requested,
+                            // allocate full VRAM of those GPUs based on node's per-GPU capacity
+                            if c_vram == 0 && c_gpu > 0 {
+                                if let Some(vram_per_gpu) = vram_per_gpu_mib {
+                                    c_vram = c_gpu * vram_per_gpu;
+                                }
+                            }
+                            pod_gpus += c_gpu;
+                            pod_vram_mib += c_vram;
+                            requesting_containers.push(c.name.clone());
+                        }
+                    }
+                }
+
+                // If pod requested GPU resources, record it
+                if pod_gpus > 0 || pod_vram_mib > 0 {
+                    node_gpu_reqs += pod_gpus;
+                    node_vram_reqs_mib += pod_vram_mib;
+
+                    gpu_pod_items.push(GpuPodItem {
+                        name: p_name,
+                        namespace: p_ns,
+                        phase: p_phase,
+                        gpu_requests: pod_gpus,
+                        vram_requests_mib: pod_vram_mib,
+                        ready_containers,
+                        restarts,
+                        age,
+                        containers: requesting_containers,
+                    });
+                }
+            }
+        }
+
+        // Sort pods by requested VRAM / GPU count descending
+        gpu_pod_items.sort_by(|a, b| {
+            b.vram_requests_mib
+                .cmp(&a.vram_requests_mib)
+                .then_with(|| b.gpu_requests.cmp(&a.gpu_requests))
+                .then_with(|| a.name.cmp(&b.name))
+        });
+
+        let total_node_vram_mib = vram_per_gpu_mib.map(|per_gpu| per_gpu * gpu_capacity.max(1));
+
+        cluster_total_gpus += gpu_capacity;
+        cluster_allocated_gpus += node_gpu_reqs;
+        if let Some(node_vram) = total_node_vram_mib {
+            cluster_total_vram_mib += node_vram;
+        }
+        cluster_allocated_vram_mib += node_vram_reqs_mib;
+        cluster_total_gpu_pods += gpu_pod_items.len();
+
+        gpu_nodes.push(GpuNodeInfo {
+            name,
+            status,
+            unschedulable,
+            roles,
+            instance_type,
+            gpu_model,
+            gpu_driver_version,
+            gpu_cuda_version,
+            gpu_capacity,
+            gpu_allocatable,
+            gpu_requests: node_gpu_reqs,
+            vram_per_gpu_mib,
+            vram_capacity_total_mib: total_node_vram_mib,
+            vram_requests_total_mib: node_vram_reqs_mib,
+            pods: gpu_pod_items,
+        });
+    }
+
+    // Sort nodes alphabetically by name
+    gpu_nodes.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let total_nodes = gpu_nodes.len();
+    GpuClusterInfo {
+        nodes: gpu_nodes,
+        total_gpu_nodes: total_nodes,
+        total_gpus: cluster_total_gpus,
+        total_allocated_gpus: cluster_allocated_gpus,
+        total_vram_mib: cluster_total_vram_mib,
+        total_allocated_vram_mib: cluster_allocated_vram_mib,
+        total_gpu_pods: cluster_total_gpu_pods,
+    }
+}
+
+/// Helper to parse quantity string (e.g. "16384", "16384Mi", "16Gi") into MiB.
+fn parse_vram_quantity(raw: &str) -> i64 {
+    let s = raw.trim();
+    if let Ok(n) = s.parse::<i64>() {
+        return n; // Raw number in MiB
+    }
+    if let Some(stripped) = s.strip_suffix("Gi") {
+        if let Ok(n) = stripped.trim().parse::<f64>() {
+            return (n * 1024.0) as i64;
+        }
+    }
+    if let Some(stripped) = s.strip_suffix("Mi") {
+        if let Ok(n) = stripped.trim().parse::<f64>() {
+            return n as i64;
+        }
+    }
+    if let Some(stripped) = s.strip_suffix("G") {
+        if let Ok(n) = stripped.trim().parse::<f64>() {
+            return (n * 1000.0 * 1000.0 / 1024.0 / 1024.0) as i64;
+        }
+    }
+    crate::metrics::mem_mib(s)
+}
+
+/// Helper to parse standard NVIDIA MIG profile slice memory into MiB.
+fn parse_mig_slice_vram_mib(profile: &str) -> i64 {
+    // e.g. "nvidia.com/mig-1g.5gb" -> 5 GiB -> 5120 MiB
+    // "nvidia.com/mig-2g.10gb" -> 10 GiB -> 10240 MiB
+    // "nvidia.com/mig-3g.20gb" -> 20 GiB -> 20480 MiB
+    // "nvidia.com/mig-7g.80gb" -> 80 GiB -> 81920 MiB
+    if profile.contains(".5gb") {
+        5120
+    } else if profile.contains(".10gb") {
+        10240
+    } else if profile.contains(".20gb") {
+        20480
+    } else if profile.contains(".40gb") {
+        40960
+    } else if profile.contains(".80gb") {
+        81920
+    } else {
+        10240 // reasonable fallback
+    }
+}
+
+/// Format MiB into a human-readable VRAM string (e.g. "80.0 GiB" or "512 MiB").
+pub fn format_vram_mib(mib: i64) -> String {
+    if mib >= 1024 {
+        let gib = mib as f64 / 1024.0;
+        if (gib - gib.round()).abs() < 0.05 {
+            format!("{} GiB", gib.round() as i64)
+        } else {
+            format!("{:.1} GiB", gib)
+        }
+    } else {
+        format!("{} MiB", mib)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    use k8s_openapi::api::core::v1::{Container, NodeSpec, NodeStatus, PodSpec, PodStatus, ResourceRequirements};
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn test_parse_gpu_cluster_info_and_pod_vram() {
+        let mut node_labels = BTreeMap::new();
+        node_labels.insert("nvidia.com/gpu.product".to_string(), "NVIDIA-A100-SXM4-80GB".to_string());
+        node_labels.insert("nvidia.com/cuda.driver-version".to_string(), "535.129.03".to_string());
+        node_labels.insert("nvidia.com/cuda.runtime.version".to_string(), "12.2".to_string());
+        node_labels.insert("node.kubernetes.io/instance-type".to_string(), "p4de.24xlarge".to_string());
+
+        let mut node_capacity = BTreeMap::new();
+        node_capacity.insert("nvidia.com/gpu".to_string(), Quantity("8".to_string()));
+
+        let node = Node {
+            metadata: ObjectMeta {
+                name: Some("gpu-node-01".to_string()),
+                labels: Some(node_labels),
+                ..Default::default()
+            },
+            spec: Some(NodeSpec {
+                unschedulable: Some(false),
+                ..Default::default()
+            }),
+            status: Some(NodeStatus {
+                capacity: Some(node_capacity.clone()),
+                allocatable: Some(node_capacity),
+                ..Default::default()
+            }),
+        };
+
+        // Pod 1: requests 2 discrete GPUs -> 2 * 80 GiB = 160 GiB
+        let mut pod1_requests = BTreeMap::new();
+        pod1_requests.insert("nvidia.com/gpu".to_string(), Quantity("2".to_string()));
+
+        let pod1 = Pod {
+            metadata: ObjectMeta {
+                name: Some("llm-trainer-0".to_string()),
+                namespace: Some("ai-training".to_string()),
+                ..Default::default()
+            },
+            spec: Some(PodSpec {
+                node_name: Some("gpu-node-01".to_string()),
+                containers: vec![Container {
+                    name: "pytorch".to_string(),
+                    resources: Some(ResourceRequirements {
+                        requests: Some(pod1_requests),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            status: Some(PodStatus {
+                phase: Some("Running".to_string()),
+                ..Default::default()
+            }),
+        };
+
+        // Pod 2: requests fractional HAMi VRAM 16 GiB
+        let mut pod2_requests = BTreeMap::new();
+        pod2_requests.insert("nvidia.com/gpumem".to_string(), Quantity("16384".to_string()));
+
+        let pod2 = Pod {
+            metadata: ObjectMeta {
+                name: Some("inference-worker".to_string()),
+                namespace: Some("ai-serving".to_string()),
+                ..Default::default()
+            },
+            spec: Some(PodSpec {
+                node_name: Some("gpu-node-01".to_string()),
+                containers: vec![Container {
+                    name: "vllm".to_string(),
+                    resources: Some(ResourceRequirements {
+                        requests: Some(pod2_requests),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            status: Some(PodStatus {
+                phase: Some("Running".to_string()),
+                ..Default::default()
+            }),
+        };
+
+        // Non-GPU pod on same node (should not be in GPU pods list)
+        let pod3 = Pod {
+            metadata: ObjectMeta {
+                name: Some("log-collector".to_string()),
+                namespace: Some("monitoring".to_string()),
+                ..Default::default()
+            },
+            spec: Some(PodSpec {
+                node_name: Some("gpu-node-01".to_string()),
+                containers: vec![Container {
+                    name: "fluentbit".to_string(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            status: Some(PodStatus {
+                phase: Some("Running".to_string()),
+                ..Default::default()
+            }),
+        };
+
+        let cluster = parse_gpu_cluster_info(&[node], &[pod1, pod2, pod3]);
+
+        assert_eq!(cluster.total_gpu_nodes, 1);
+        assert_eq!(cluster.total_gpus, 8);
+        assert_eq!(cluster.total_allocated_gpus, 2);
+        // Total VRAM for 8 x 80GB = 640 GiB = 655360 MiB
+        assert_eq!(cluster.total_vram_mib, 655360);
+        // Allocated VRAM: 160 GiB (163840 MiB) + 16 GiB (16384 MiB) = 180224 MiB (176 GiB)
+        assert_eq!(cluster.total_allocated_vram_mib, 180224);
+
+        let n = &cluster.nodes[0];
+        assert_eq!(n.name, "gpu-node-01");
+        assert_eq!(n.gpu_capacity, 8);
+        assert_eq!(n.gpu_model.as_deref(), Some("NVIDIA A100 SXM4 80GB"));
+        assert_eq!(n.gpu_driver_version.as_deref(), Some("535.129.03"));
+        assert_eq!(n.vram_per_gpu_mib, Some(81920));
+        assert_eq!(n.vram_capacity_total_mib, Some(655360));
+        assert_eq!(n.vram_requests_total_mib, 180224);
+
+        // Only 2 GPU pods listed, sorted by VRAM descending (llm-trainer-0 first, then inference-worker)
+        assert_eq!(n.pods.len(), 2);
+        assert_eq!(n.pods[0].name, "llm-trainer-0");
+        assert_eq!(n.pods[0].gpu_requests, 2);
+        assert_eq!(n.pods[0].vram_requests_mib, 163840);
+        assert_eq!(format_vram_mib(n.pods[0].vram_requests_mib), "160 GiB");
+
+        assert_eq!(n.pods[1].name, "inference-worker");
+        assert_eq!(n.pods[1].gpu_requests, 0);
+        assert_eq!(n.pods[1].vram_requests_mib, 16384);
+        assert_eq!(format_vram_mib(n.pods[1].vram_requests_mib), "16 GiB");
+    }
+}

--- a/crates/kube/src/helm.rs
+++ b/crates/kube/src/helm.rs
@@ -109,6 +109,34 @@ async fn list_release_secrets(
     Ok(list.items)
 }
 
+/// Fetch the latest revision of each installed Helm release in scope.
+pub async fn fetch_helm_releases(
+    cache: &Arc<ClientCache>,
+    context: &str,
+    namespace: Option<&str>,
+) -> Result<Vec<HelmReleaseSummary>, String> {
+    let ns = namespace.unwrap_or_default();
+    let secrets = list_release_secrets(cache, context, ns, "owner=helm")
+        .await
+        .map_err(|e| e.to_string())?;
+    let mut latest: BTreeMap<(String, String), HelmReleaseSummary> = BTreeMap::new();
+    for secret in &secrets {
+        let Some(raw) = secret.data.as_ref().and_then(|d| d.get("release")) else {
+            continue;
+        };
+        let Ok(rel) = decode_release(&raw.0) else { continue };
+        let sum = summarise_release(&rel);
+        let key = (sum.namespace.clone(), sum.name.clone());
+        match latest.get(&key) {
+            Some(existing) if existing.revision >= sum.revision => {}
+            _ => {
+                latest.insert(key, sum);
+            }
+        }
+    }
+    Ok(latest.into_values().collect())
+}
+
 /// `k8s.listHelmReleases` — latest revision of each Helm release in scope.
 pub fn list_helm_releases_capability(cache: Arc<ClientCache>) -> Capability {
     Capability::typed::<ListHelmReleasesIn, ListHelmReleasesOut, _, _>(
@@ -118,27 +146,10 @@ pub fn list_helm_releases_capability(cache: Arc<ClientCache>) -> Capability {
         move |input: ListHelmReleasesIn| {
             let cache = cache.clone();
             async move {
-                let ns = input.namespace.unwrap_or_default();
-                let secrets = list_release_secrets(&cache, &input.context, &ns, "owner=helm").await?;
-                // Keep the highest revision per (namespace, name).
-                let mut latest: BTreeMap<(String, String), HelmReleaseSummary> = BTreeMap::new();
-                for secret in &secrets {
-                    let Some(raw) = secret.data.as_ref().and_then(|d| d.get("release")) else {
-                        continue;
-                    };
-                    let Ok(rel) = decode_release(&raw.0) else { continue };
-                    let sum = summarise_release(&rel);
-                    let key = (sum.namespace.clone(), sum.name.clone());
-                    match latest.get(&key) {
-                        Some(existing) if existing.revision >= sum.revision => {}
-                        _ => {
-                            latest.insert(key, sum);
-                        }
-                    }
-                }
-                Ok(ListHelmReleasesOut {
-                    releases: latest.into_values().collect(),
-                })
+                let releases = fetch_helm_releases(&cache, &input.context, input.namespace.as_deref())
+                    .await
+                    .map_err(CapabilityError::Handler)?;
+                Ok(ListHelmReleasesOut { releases })
             }
         },
     )
@@ -156,7 +167,7 @@ pub struct GetHelmReleaseIn {
     pub revision: Option<i64>,
 }
 
-#[derive(Debug, Clone, Serialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct HelmRevision {
     pub revision: i64,
@@ -166,7 +177,7 @@ pub struct HelmRevision {
     pub description: String,
 }
 
-#[derive(Debug, Serialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct HelmReleaseDetail {
     pub name: String,
@@ -179,11 +190,31 @@ pub struct HelmReleaseDetail {
     pub updated: String,
     /// User-supplied values, rendered as YAML.
     pub values_yaml: String,
+    /// Chart default values, rendered as YAML.
+    #[serde(default)]
+    pub chart_values_yaml: String,
+    /// Merged computed values (chart defaults overridden by user values), rendered as YAML.
+    #[serde(default)]
+    pub computed_values_yaml: String,
     /// The rendered manifest for the current revision.
     pub manifest: String,
     pub notes: String,
     /// All revisions, newest first.
     pub history: Vec<HelmRevision>,
+}
+
+/// Recursively merge source JSON object into target JSON object.
+fn merge_json_values(target: &mut Value, source: &Value) {
+    match (target, source) {
+        (Value::Object(target_map), Value::Object(source_map)) => {
+            for (key, val) in source_map {
+                merge_json_values(target_map.entry(key.clone()).or_insert(Value::Null), val);
+            }
+        }
+        (target_slot, new_val) => {
+            *target_slot = new_val.clone();
+        }
+    }
 }
 
 /// Pick one revision's decoded release object out of a release's history
@@ -205,6 +236,82 @@ fn pick_revision(revisions: &[Value], requested: Option<i64>) -> Result<&Value, 
     }
 }
 
+/// Fetch full detail of a Helm release: values, chart defaults, manifest, and revision history.
+pub async fn fetch_helm_release_detail(
+    cache: &Arc<ClientCache>,
+    context: &str,
+    namespace: &str,
+    name: &str,
+    revision: Option<i64>,
+) -> Result<HelmReleaseDetail, String> {
+    let label = format!("owner=helm,name={}", name);
+    let secrets = list_release_secrets(cache, context, namespace, &label)
+        .await
+        .map_err(|e| e.to_string())?;
+    let mut revisions: Vec<Value> = secrets
+        .iter()
+        .filter_map(|s| s.data.as_ref().and_then(|d| d.get("release")))
+        .filter_map(|b| decode_release(&b.0).ok())
+        .collect();
+    if revisions.is_empty() {
+        return Err(format!(
+            "no Helm release named {} in {}",
+            name, namespace
+        ));
+    }
+    // Newest revision first.
+    revisions.sort_by_key(|v| -v.get("version").and_then(Value::as_i64).unwrap_or(0));
+    let history = revisions
+        .iter()
+        .map(|v| HelmRevision {
+            revision: v.get("version").and_then(Value::as_i64).unwrap_or(0),
+            status: s(v, &["info", "status"]),
+            updated: s(v, &["info", "last_deployed"]),
+            chart_version: s(v, &["chart", "metadata", "version"]),
+            description: s(v, &["info", "description"]),
+        })
+        .collect();
+
+    let current = pick_revision(&revisions, revision).map_err(|e| e.to_string())?;
+    let sum = summarise_release(current);
+    let values_yaml = match current.get("config") {
+        Some(cfg) if !cfg.is_null() => serde_yaml::to_string(cfg).unwrap_or_default(),
+        _ => String::new(),
+    };
+    let chart_values = current.get("chart").and_then(|c| c.get("values"));
+    let chart_values_yaml = match chart_values {
+        Some(cv) if !cv.is_null() => serde_yaml::to_string(cv).unwrap_or_default(),
+        _ => String::new(),
+    };
+    let computed_values_yaml = match (chart_values, current.get("config")) {
+        (Some(cv), Some(cfg)) if !cv.is_null() && !cfg.is_null() => {
+            let mut merged = cv.clone();
+            merge_json_values(&mut merged, cfg);
+            serde_yaml::to_string(&merged).unwrap_or_default()
+        }
+        (Some(cv), _) if !cv.is_null() => serde_yaml::to_string(cv).unwrap_or_default(),
+        (_, Some(cfg)) if !cfg.is_null() => serde_yaml::to_string(cfg).unwrap_or_default(),
+        _ => String::new(),
+    };
+
+    Ok(HelmReleaseDetail {
+        name: sum.name,
+        namespace: sum.namespace,
+        revision: sum.revision,
+        status: sum.status,
+        chart: sum.chart,
+        chart_version: sum.chart_version,
+        app_version: sum.app_version,
+        updated: sum.updated,
+        values_yaml,
+        chart_values_yaml,
+        computed_values_yaml,
+        manifest: s(current, &["manifest"]),
+        notes: s(current, &["info", "notes"]),
+        history,
+    })
+}
+
 /// `k8s.getHelmRelease` — full detail of a release: values, manifest, history.
 pub fn get_helm_release_capability(cache: Arc<ClientCache>) -> Capability {
     Capability::typed::<GetHelmReleaseIn, HelmReleaseDetail, _, _>(
@@ -214,53 +321,15 @@ pub fn get_helm_release_capability(cache: Arc<ClientCache>) -> Capability {
         move |input: GetHelmReleaseIn| {
             let cache = cache.clone();
             async move {
-                let label = format!("owner=helm,name={}", input.name);
-                let secrets =
-                    list_release_secrets(&cache, &input.context, &input.namespace, &label).await?;
-                let mut revisions: Vec<Value> = secrets
-                    .iter()
-                    .filter_map(|s| s.data.as_ref().and_then(|d| d.get("release")))
-                    .filter_map(|b| decode_release(&b.0).ok())
-                    .collect();
-                if revisions.is_empty() {
-                    return Err(CapabilityError::Handler(format!(
-                        "no Helm release named {} in {}",
-                        input.name, input.namespace
-                    )));
-                }
-                // Newest revision first.
-                revisions.sort_by_key(|v| -v.get("version").and_then(Value::as_i64).unwrap_or(0));
-                let history = revisions
-                    .iter()
-                    .map(|v| HelmRevision {
-                        revision: v.get("version").and_then(Value::as_i64).unwrap_or(0),
-                        status: s(v, &["info", "status"]),
-                        updated: s(v, &["info", "last_deployed"]),
-                        chart_version: s(v, &["chart", "metadata", "version"]),
-                        description: s(v, &["info", "description"]),
-                    })
-                    .collect();
-
-                let current = pick_revision(&revisions, input.revision)?;
-                let sum = summarise_release(current);
-                let values_yaml = match current.get("config") {
-                    Some(cfg) if !cfg.is_null() => serde_yaml::to_string(cfg).unwrap_or_default(),
-                    _ => String::new(),
-                };
-                Ok(HelmReleaseDetail {
-                    name: sum.name,
-                    namespace: sum.namespace,
-                    revision: sum.revision,
-                    status: sum.status,
-                    chart: sum.chart,
-                    chart_version: sum.chart_version,
-                    app_version: sum.app_version,
-                    updated: sum.updated,
-                    values_yaml,
-                    manifest: s(current, &["manifest"]),
-                    notes: s(current, &["info", "notes"]),
-                    history,
-                })
+                fetch_helm_release_detail(
+                    &cache,
+                    &input.context,
+                    &input.namespace,
+                    &input.name,
+                    input.revision,
+                )
+                .await
+                .map_err(CapabilityError::Handler)
             }
         },
     )

--- a/crates/kube/src/lib.rs
+++ b/crates/kube/src/lib.rs
@@ -174,3 +174,4 @@ pub mod watch;
 pub mod workloads;
 pub mod lineage;
 pub mod node_inspector;
+pub mod gpu_info;

--- a/crates/kube/src/node_inspector.rs
+++ b/crates/kube/src/node_inspector.rs
@@ -4,7 +4,7 @@ use kube::{api::ListParams, Api, Client};
 use serde::{Deserialize, Serialize};
 
 /// Comprehensive inspection details for a single Kubernetes Node.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct NodeInspectorDetails {
     pub name: String,
     pub status: String,

--- a/crates/kube/src/topology.rs
+++ b/crates/kube/src/topology.rs
@@ -149,7 +149,7 @@ pub struct TopologyGraphIn {
 
 /// Which column a node stands in. The screen lays these out left to right;
 /// the order is fixed here so the two sides cannot disagree about it.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum Lane {
     Route,
@@ -312,7 +312,7 @@ pub struct Unlisted {
     pub reason: String,
 }
 
-#[derive(Debug, Serialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct TopologyGraphOut {
     pub nodes: Vec<TopologyNode>,
     pub edges: Vec<TopologyEdge>,
@@ -2126,7 +2126,7 @@ pub fn topology_probe_capability(cache: Arc<ClientCache>) -> Capability {
 
 /// Build the graph from the API, then fold in whatever the optional sources
 /// give; `probe` is the exec-per-pod connection read.
-async fn build_topology(
+pub async fn build_topology(
     cache: Arc<ClientCache>,
     input: TopologyGraphIn,
     probe: bool,

--- a/crates/kube/src/watch.rs
+++ b/crates/kube/src/watch.rs
@@ -960,6 +960,10 @@ mod tests {
             image: "nginx:1.27".into(),
             waiting_reason: String::new(),
             pod_ip: "10.244.0.1".into(),
+            cpu_req_millicores: 0,
+            cpu_lim_millicores: 0,
+            mem_req_mib: 0,
+            mem_lim_mib: 0,
         }
     }
 

--- a/crates/kube/src/workloads.rs
+++ b/crates/kube/src/workloads.rs
@@ -68,6 +68,18 @@ pub struct PodSummary {
     /// Pod IP address from `status.podIP`.
     #[serde(rename = "podIp", default)]
     pub pod_ip: String,
+    /// CPU requested in millicores across all containers
+    #[serde(rename = "cpuReqMillicores", default)]
+    pub cpu_req_millicores: i64,
+    /// CPU limit in millicores across all containers
+    #[serde(rename = "cpuLimMillicores", default)]
+    pub cpu_lim_millicores: i64,
+    /// Memory requested in MiB across all containers
+    #[serde(rename = "memReqMiB", default)]
+    pub mem_req_mib: i64,
+    /// Memory limit in MiB across all containers
+    #[serde(rename = "memLimMiB", default)]
+    pub mem_lim_mib: i64,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -165,6 +177,30 @@ pub(crate) fn summarise_pod(pod: Pod) -> PodSummary {
         .and_then(|s| s.pod_ip.clone())
         .unwrap_or_default();
 
+    let (mut req_cpu, mut lim_cpu, mut req_mem, mut lim_mem) = (0i64, 0i64, 0i64, 0i64);
+    if let Some(spec) = pod.spec.as_ref() {
+        for c in &spec.containers {
+            if let Some(resources) = &c.resources {
+                if let Some(reqs) = &resources.requests {
+                    if let Some(q) = reqs.get("cpu") {
+                        req_cpu += crate::metrics::cpu_millicores(&q.0);
+                    }
+                    if let Some(q) = reqs.get("memory") {
+                        req_mem += crate::metrics::mem_mib(&q.0);
+                    }
+                }
+                if let Some(lims) = &resources.limits {
+                    if let Some(q) = lims.get("cpu") {
+                        lim_cpu += crate::metrics::cpu_millicores(&q.0);
+                    }
+                    if let Some(q) = lims.get("memory") {
+                        lim_mem += crate::metrics::mem_mib(&q.0);
+                    }
+                }
+            }
+        }
+    }
+
     PodSummary {
         name,
         namespace,
@@ -178,6 +214,10 @@ pub(crate) fn summarise_pod(pod: Pod) -> PodSummary {
         image,
         waiting_reason,
         pod_ip,
+        cpu_req_millicores: req_cpu,
+        cpu_lim_millicores: lim_cpu,
+        mem_req_mib: req_mem,
+        mem_lim_mib: lim_mem,
     }
 }
 


### PR DESCRIPTION
## Summary

This PR implements two key features and enhancements for the SRElens TUI:

### 1. Deep Helm Inspector & Values Diff (`:helm` enhancement)
- **Tabbed Release Inspector**: Pressing `<Enter>` on any Helm release opens a dedicated tabbed detail view with 5 panes:
  - `[1: Overview]`: Release metadata, revision, status, chart version, app version, and updated timestamp.
  - `[2: Values Diff]`: Color-coded side-by-side or unified diff comparing user values (`helm get values`) against chart computed values (`helm get values --all`).
  - `[3: Revisions]`: Full revision history with revision numbers, dates, statuses, chart versions, and app versions.
  - `[4: Manifest]`: Rendered Kubernetes YAML with syntax highlighting and line numbers.
  - `[5: Notes]`: Post-install release notes (`NOTES.txt`).
- **Revision Rollback**: Pressing `<r>` opens a revision picker and rollback confirmation dialog allowing rollback to any historical revision $N$ (via `helm rollback <release> <revision>`).
- **Uninstall Release**: Pressing `<ctrl-d>` prompts an uninstallation confirmation dialog (via `helm uninstall <release>`).
- **Full Key Navigation**: Tab/1-5 to switch panes, arrow keys/PgUp/PgDown to scroll, `<r>` to roll back, `<Esc>` to return.

### 2. Disambiguate Setting CRD vs Internal AI Settings
- **Direct Target Execution on `<Enter>`**: When pressing `<Enter>` in command mode with a highlighted autocomplete suggestion, the selected suggestion's `target` is executed directly instead of re-resolving the query string.
- **Static Command Renaming**: Renamed the static AI settings primary command to `ai-settings` with aliases `["settings", "config", "ai-config"]`.
- **CRD-First Resolution Ordering**: Cluster-defined CRDs take precedence over static command aliases, so typing `:settings` in a cluster with a `Setting` CRD navigates to that CRD table, while `:ai-settings` always opens the AI Settings view.

### 3. Additional Views & Tooling
- Integrated unified workloads view (`:workloads`), traffic topology flow map (`:topology`), GPU nodes & VRAM inspector (`:gpuinfo`), top hotspots ranking (`:top`), and theme switcher (`:theme`).

## Verification
- All 510 tests in `apps/tui` passing (`cargo test -p srelens-tui`).
- All 527 tests in `crates/kube` passing (`cargo test -p srelens-kube`).
- Workspace compilation clean via `cargo check --workspace`.