### PR TITLE
feat(packaging): brew install srelens/tap/srelens-tui

### DIFF
--- a/.github/workflows/homebrew-publish.yml
+++ b/.github/workflows/homebrew-publish.yml
@@ -63,12 +63,23 @@ jobs:
           # normal middle of setting it up, not a mistake. Cloning a repository
           # that is not there yet would fail the release for it.
           #
-          # A warning rather than silence: once the token is configured somebody
-          # is expecting a publish, so a skip should say why.
-          if ! GH_TOKEN="$TOKEN" gh api "repos/${TAP_REPO}" >/dev/null 2>&1; then
-            echo "::warning::${TAP_REPO} does not exist, or HOMEBREW_TAP_TOKEN cannot see it — skipping the Homebrew publish. See packaging/homebrew/README.md."
-            echo "publish=false" >> "$GITHUB_OUTPUT"
-            exit 0
+          # Only a VERIFIED 404 counts as "not set up yet". An expired token, a
+          # revoked grant, a rate limit or a network blip all make this command
+          # fail too, and treating those as absence would report "the tap is not
+          # ready" — a fact about the tap — on the strength of not having been
+          # able to look. The formula would then go stale behind a green run.
+          probe=$(GH_TOKEN="$TOKEN" gh api "repos/${TAP_REPO}" 2>&1) && status=0 || status=$?
+          if [ "$status" -ne 0 ]; then
+            if printf '%s' "$probe" | grep -q 'HTTP 404'; then
+              # A warning rather than silence: once the token is configured
+              # somebody is expecting a publish, so a skip should say why.
+              echo "::warning::${TAP_REPO} does not exist yet — skipping the Homebrew publish. See packaging/homebrew/README.md."
+              echo "publish=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "::error::could not check ${TAP_REPO}, so whether it is ready is unknown — not skipping on a guess. Fix the cause and re-run this workflow; it is dispatchable for any published version."
+            printf '%s\n' "$probe" >&2
+            exit 1
           fi
           echo "publish=true" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/homebrew-publish.yml
+++ b/.github/workflows/homebrew-publish.yml
@@ -44,19 +44,33 @@ jobs:
       # to. Until someone creates it and sets the token, this skips rather than
       # failing: a release should not go red because a distribution channel is
       # not set up yet. Same rule the AUR publish already follows.
-      - name: Skip when the tap token isn't configured
+      - name: Skip when the tap isn't set up
         id: gate
         shell: bash
         env:
           TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          TAP_REPO: ${{ vars.HOMEBREW_TAP_REPO || 'srelens/homebrew-tap' }}
         run: |
           if [ -z "${TOKEN:-}" ]; then
             echo "HOMEBREW_TAP_TOKEN not set — skipping the Homebrew publish."
             echo "See packaging/homebrew/README.md for what it needs."
             echo "publish=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "publish=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          # BOTH halves of the promise, not just the token. Setting up a tap is
+          # two steps by two different means — a secret here, a repository over
+          # there — so the state where one exists and the other does not is the
+          # normal middle of setting it up, not a mistake. Cloning a repository
+          # that is not there yet would fail the release for it.
+          #
+          # A warning rather than silence: once the token is configured somebody
+          # is expecting a publish, so a skip should say why.
+          if ! GH_TOKEN="$TOKEN" gh api "repos/${TAP_REPO}" >/dev/null 2>&1; then
+            echo "::warning::${TAP_REPO} does not exist, or HOMEBREW_TAP_TOKEN cannot see it — skipping the Homebrew publish. See packaging/homebrew/README.md."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "publish=true" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         if: steps.gate.outputs.publish == 'true'

--- a/.github/workflows/homebrew-publish.yml
+++ b/.github/workflows/homebrew-publish.yml
@@ -1,0 +1,148 @@
+name: Publish Homebrew
+
+# Pushes the srelens-tui formula to the tap. Called by the release workflow
+# after a stable release goes public, and runnable BY HAND for any already
+# published version.
+#
+# Split out for the same reason `aur-publish.yml` is: welded to the release
+# pipeline, a failed push could only be retried by cutting another release,
+# which is how AUR sat four versions behind before it was separated.
+#
+# A tap carries exactly ONE version of a formula — `brew install` gets whatever
+# it currently points at — so this takes a single version rather than a list.
+# There is no back-catalogue to fill in.
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version to publish, without a leading v (e.g. 1.2.3)'
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Published version to push to the tap, without a leading v. Defaults to the newest stable release.'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+# One branch in one repository, so two runs would race on `git push`.
+concurrency:
+  group: homebrew-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: publish Homebrew (srelens-tui)
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # The tap lives in its own repository, which GITHUB_TOKEN cannot write
+      # to. Until someone creates it and sets the token, this skips rather than
+      # failing: a release should not go red because a distribution channel is
+      # not set up yet. Same rule the AUR publish already follows.
+      - name: Skip when the tap token isn't configured
+        id: gate
+        shell: bash
+        env:
+          TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          if [ -z "${TOKEN:-}" ]; then
+            echo "HOMEBREW_TAP_TOKEN not set — skipping the Homebrew publish."
+            echo "See packaging/homebrew/README.md for what it needs."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        if: steps.gate.outputs.publish == 'true'
+        with:
+          node-version: 22
+
+      # A manual run may omit the version, meaning "whatever the newest stable
+      # release is". Resolved here rather than defaulted in the input, so the
+      # log records which version was chosen.
+      - name: Resolve version
+        id: resolve
+        if: steps.gate.outputs.publish == 'true'
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${INPUT_VERSION:-}"
+          if [ -z "$VERSION" ]; then
+            TAG=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq '.tag_name // empty')
+            VERSION="${TAG#srelens-v}"
+            echo "No version given — using the newest stable release: ${TAG:-<none>}"
+          fi
+          VERSION="${VERSION#v}"
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::'${VERSION}' is not a stable X.Y.Z version. A dev pre-release is not what someone typing 'brew install' is asking for."
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Publishing srelens-tui ${VERSION}"
+
+      # Rendering reads the release's own SHA256SUMS, so a release that is
+      # missing the TUI archives fails here with that said plainly, rather than
+      # producing a formula that 404s on a user's machine.
+      - name: Render the formula
+        id: render
+        if: steps.gate.outputs.publish == 'true'
+        shell: bash
+        env:
+          VERSION: ${{ steps.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p _tap/Formula
+          node packaging/homebrew/render.mjs "$VERSION" --out _tap/Formula/srelens-tui.rb
+          echo "--- rendered formula ---"
+          cat _tap/Formula/srelens-tui.rb
+
+      - name: Push to the tap
+        if: steps.gate.outputs.publish == 'true'
+        shell: bash
+        env:
+          VERSION: ${{ steps.resolve.outputs.version }}
+          TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          TAP_REPO: ${{ vars.HOMEBREW_TAP_REPO || 'srelens/homebrew-tap' }}
+        run: |
+          set -euo pipefail
+          # The token is written to a credential file rather than into the
+          # remote URL: a URL with a secret in it ends up in `git remote -v`,
+          # in error messages, and in the run log the first time a command
+          # fails.
+          CREDENTIALS=/tmp/homebrew-tap-credentials
+          install -m 600 /dev/null "$CREDENTIALS"
+          printf 'https://x-access-token:%s@github.com\n' "$TOKEN" > "$CREDENTIALS"
+          git config --global credential.helper "store --file=$CREDENTIALS"
+          git config --global user.name "srelens release"
+          git config --global user.email "noreply@github.com"
+
+          git clone --depth 1 "https://github.com/${TAP_REPO}.git" tap
+          mkdir -p tap/Formula
+          cp _tap/Formula/srelens-tui.rb tap/Formula/srelens-tui.rb
+          cd tap
+
+          # Nothing to do is a success, not a failure: re-running the publish
+          # for a version already on the tap should be a no-op rather than an
+          # empty commit or a red run.
+          if git diff --quiet -- Formula/srelens-tui.rb; then
+            echo "The tap already carries srelens-tui ${VERSION} — nothing to push."
+            exit 0
+          fi
+
+          git add Formula/srelens-tui.rb
+          git commit -m "srelens-tui ${VERSION}"
+          git push
+          echo "Pushed srelens-tui ${VERSION} to ${TAP_REPO}."
+
+      - name: Clean up credentials
+        if: always()
+        run: rm -f /tmp/homebrew-tap-credentials

--- a/.github/workflows/homebrew-publish.yml
+++ b/.github/workflows/homebrew-publish.yml
@@ -130,15 +130,23 @@ jobs:
           cp _tap/Formula/srelens-tui.rb tap/Formula/srelens-tui.rb
           cd tap
 
+          # Staged BEFORE the comparison, and compared against the index.
+          # `git diff` only looks at tracked files, so on the very first publish
+          # — when the tap has no Formula/srelens-tui.rb yet — the freshly
+          # copied file is untracked, the diff is empty, and this would report
+          # "already carries" and exit without publishing anything. That is the
+          # one run where being wrong matters most: the install command has just
+          # been advertised and nothing is behind it.
+          git add Formula/srelens-tui.rb
+
           # Nothing to do is a success, not a failure: re-running the publish
           # for a version already on the tap should be a no-op rather than an
           # empty commit or a red run.
-          if git diff --quiet -- Formula/srelens-tui.rb; then
+          if git diff --cached --quiet; then
             echo "The tap already carries srelens-tui ${VERSION} — nothing to push."
             exit 0
           fi
 
-          git add Formula/srelens-tui.rb
           git commit -m "srelens-tui ${VERSION}"
           git push
           echo "Pushed srelens-tui ${VERSION} to ${TAP_REPO}."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1275,6 +1275,23 @@ jobs:
   # BY HAND for an already-released version. Welded to this pipeline, a failed
   # AUR push could only be retried by cutting another release — which is how AUR
   # sat at 0.2.0 while four stable releases came and went.
+  # Homebrew formula for the TUI (#451). Stable only, for the same reason AUR
+  # is: a tap carries one version per formula, and a dev pre-release version
+  # is not what someone typing `brew install` is asking for.
+  #
+  # Needs tui-publish as well as publish-release — the formula is rendered
+  # from the release's own SHA256SUMS, so it cannot be built before the
+  # archives are attached.
+  homebrew:
+    needs: [version, tui-publish, publish-release]
+    if: ${{ github.ref_name == 'main' && needs.publish-release.result == 'success' && needs.version.outputs.release == 'true' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/homebrew-publish.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+    secrets: inherit
+
   aur:
     # Also needs publish-release: updpkgsums fetches the release assets over
     # plain HTTPS, which only works once the release is out of draft.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Download the latest release for your platform from
 | macOS | `.dmg` for Apple Silicon and Intel | Developer ID signed and notarized |
 | Linux | `.AppImage`, `.deb`, `.rpm` | AppImage supports the in-app updater |
 | Windows | `.exe`, `.msi` | Windows may show a SmartScreen prompt while code signing remains on the roadmap |
-| Terminal UI | `srelens-tui-<version>-<target>.tar.gz` / `.zip` | A single binary for Linux (glibc and static musl), macOS and Windows, on x86-64 and arm64; macOS builds on a stable release are signed and notarized |
+| Terminal UI | `brew install srelens/tap/srelens-tui`, or `srelens-tui-<version>-<target>.tar.gz` / `.zip` | A single binary for Linux (glibc and static musl), macOS and Windows, on x86-64 and arm64; macOS builds on a stable release are signed and notarized |
 
 See the [installation guide](docs/INSTALL.md) for platform-specific installation,
 first-launch, updating, verification, and uninstall instructions.

--- a/apps/tui/src/self_update.rs
+++ b/apps/tui/src/self_update.rs
@@ -607,6 +607,29 @@ pub fn plan(
     })))
 }
 
+/// Who owns the binary at `path`, decided AFTER following links, and the
+/// resolved path it was decided from.
+///
+/// The resolution is the whole point. Homebrew installs into
+/// `<prefix>/Cellar/<formula>/<version>/bin` and links that into
+/// `<prefix>/bin`, so the path someone invokes is a symlink — and on Intel
+/// macOS that prefix is `/usr/local`, which is also where the install guide
+/// tells people to put a copy by hand. Matching on the path as given would
+/// either miss every brew install there or refuse every manual one; the two
+/// are indistinguishable until the link is followed.
+///
+/// The resolved path comes back so this is testable without a real
+/// `/opt/homebrew` to point at: a test can assert the link was followed
+/// even where it cannot arrange for the result to match a package root.
+pub fn resolve_owner(path: &Path) -> (PathBuf, Option<&'static str>) {
+    // A path that cannot be resolved — it does not exist yet, a permission
+    // stops the walk — is used as given rather than treated as an error.
+    // Failing to look is not evidence of ownership either way.
+    let resolved = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let manager = package_manager_for(&resolved);
+    (resolved, manager)
+}
+
 /// Download, verify, and install the binary a [`Plan`] names.
 ///
 /// Verification happens before anything is written, so a mismatched download
@@ -615,14 +638,8 @@ pub fn apply(
     plan: &Plan,
     fetch: &impl Fn(&str) -> Result<Vec<u8>, UpdateError>,
 ) -> Result<(), UpdateError> {
-    // Resolved before the check, because a package manager's binary is
-    // usually reached through a link: Homebrew installs into
-    // `<prefix>/Cellar/<formula>/<version>/bin` and links that into
-    // `<prefix>/bin`. Testing the invoked path would see `/usr/local/bin`,
-    // which is also where the install guide tells people to put a copy by
-    // hand — so the two are only distinguishable after following the link.
-    let real = std::fs::canonicalize(&plan.target).unwrap_or_else(|_| plan.target.clone());
-    if let Some(manager) = package_manager_for(&real) {
+    let (real, owner) = resolve_owner(&plan.target);
+    if let Some(manager) = owner {
         return Err(UpdateError::PackageManaged {
             manager,
             path: real,
@@ -1073,6 +1090,45 @@ mod tests {
         );
 
         set(0o755);
+    }
+
+    /// Ownership is decided after following links, not before.
+    ///
+    /// Asserting on literal Cellar paths does not test this: those match
+    /// with or without the resolution. Building brew's actual shape — a
+    /// `bin/` link into a `Cellar/` tree — and checking WHICH path the
+    /// decision was made from is what fails if the resolution is dropped.
+    #[cfg(unix)]
+    #[test]
+    fn ownership_is_decided_after_following_the_link() {
+        use super::resolve_owner;
+
+        let _guard = file_test_lock();
+        let dir = tempfile::tempdir().expect("temp dir");
+        let cellar = dir.path().join("Cellar/srelens-tui/1.2.3/bin");
+        std::fs::create_dir_all(&cellar).expect("cellar");
+        let installed = cellar.join("srelens-tui");
+        std::fs::write(&installed, b"the real binary").expect("write");
+
+        let bin = dir.path().join("bin");
+        std::fs::create_dir_all(&bin).expect("bin");
+        let linked = bin.join("srelens-tui");
+        std::os::unix::fs::symlink(&installed, &linked).expect("symlink");
+
+        let (resolved, _) = resolve_owner(&linked);
+        assert_eq!(
+            resolved,
+            std::fs::canonicalize(&installed).expect("canonicalize"),
+            "the decision must be made from the link's target"
+        );
+        assert_ne!(resolved, linked, "not from the link itself");
+
+        // A path that does not resolve is used as given rather than
+        // becoming an error.
+        let missing = dir.path().join("not-here");
+        let (resolved, owner) = resolve_owner(&missing);
+        assert_eq!(resolved, missing);
+        assert_eq!(owner, None);
     }
 
     /// Two calls never collide, which is what lets the name be unpredictable

--- a/apps/tui/src/self_update.rs
+++ b/apps/tui/src/self_update.rs
@@ -1153,6 +1153,28 @@ mod tests {
         set(0o755);
     }
 
+    /// Ownership carried by the LINK'S OWN location survives.
+    ///
+    /// A distribution may install `/usr/bin/x` pointing into `/usr/lib/…`,
+    /// where following the link first throws away the `/usr/bin/` that said
+    /// who owns it — the opposite of the Homebrew case, where ownership lives
+    /// in the target. That is why both are checked.
+    ///
+    /// NOT gated to Unix: it is string matching over a literal path and needs
+    /// no filesystem. The first version of this lived inside the Unix-only
+    /// test below, so it never compiled on the machine it was written on and
+    /// broke CI on the one platform that runs it.
+    #[test]
+    fn ownership_from_the_links_own_location_survives() {
+        use super::resolve_owner;
+        use std::path::Path;
+
+        let packaged = Path::new("/usr/bin/srelens-tui");
+        let (from, owner) = resolve_owner(packaged);
+        assert_eq!(owner, Some("your distribution's package manager"));
+        assert_eq!(from, packaged, "the deciding path is the one that matched");
+    }
+
     /// Ownership is decided after following links, not before.
     ///
     /// Asserting on literal Cellar paths does not test this: those match
@@ -1183,22 +1205,6 @@ mod tests {
             "the decision must be made from the link's target"
         );
         assert_ne!(resolved, linked, "not from the link itself");
-
-        // The link's OWN location decides when it is the one that carries
-        // ownership: a distribution may install `/usr/bin/x` pointing into
-        // `/usr/lib/...`, where following the link would throw away the
-        // `/usr/bin/` that said who owns it.
-        let packaged = Path::new("/usr/bin/srelens-tui");
-        let (from, owner) = resolve_owner(packaged);
-        assert_eq!(
-            owner,
-            Some("your distribution's package manager"),
-            "ownership carried by the link's location must survive"
-        );
-        assert_eq!(
-            from, packaged,
-            "and the deciding path is the one that matched"
-        );
 
         // A path that does not resolve is used as given rather than
         // becoming an error.

--- a/apps/tui/src/self_update.rs
+++ b/apps/tui/src/self_update.rs
@@ -615,10 +615,17 @@ pub fn apply(
     plan: &Plan,
     fetch: &impl Fn(&str) -> Result<Vec<u8>, UpdateError>,
 ) -> Result<(), UpdateError> {
-    if let Some(manager) = package_manager_for(&plan.target) {
+    // Resolved before the check, because a package manager's binary is
+    // usually reached through a link: Homebrew installs into
+    // `<prefix>/Cellar/<formula>/<version>/bin` and links that into
+    // `<prefix>/bin`. Testing the invoked path would see `/usr/local/bin`,
+    // which is also where the install guide tells people to put a copy by
+    // hand — so the two are only distinguishable after following the link.
+    let real = std::fs::canonicalize(&plan.target).unwrap_or_else(|_| plan.target.clone());
+    if let Some(manager) = package_manager_for(&real) {
         return Err(UpdateError::PackageManaged {
             manager,
-            path: plan.target.clone(),
+            path: real,
         });
     }
     let dir = plan.target.parent().unwrap_or_else(|| Path::new("."));

--- a/apps/tui/src/self_update.rs
+++ b/apps/tui/src/self_update.rs
@@ -622,6 +622,22 @@ pub fn plan(
 /// `/opt/homebrew` to point at: a test can assert the link was followed
 /// even where it cannot arrange for the result to match a package root.
 pub fn resolve_owner(path: &Path) -> (PathBuf, Option<&'static str>) {
+    // The LINK'S OWN LOCATION is checked first, because it can carry ownership
+    // that its target does not. A distribution package may install
+    // `/usr/bin/srelens-tui` pointing into `/usr/lib/srelens/`, and following
+    // the link throws away the `/usr/bin/` that said who owns it — leaving the
+    // updater to report a permissions problem, or to overwrite a packaged
+    // symlink when re-run with enough privilege.
+    if let Some(manager) = package_manager_for(path) {
+        return (path.to_path_buf(), Some(manager));
+    }
+
+    // Then the target, which is where Homebrew's ownership lives: it links
+    // `<prefix>/bin/x` to `<prefix>/Cellar/x/<version>/bin/x`, and on Intel
+    // macOS that prefix is `/usr/local` — the same place the install guide
+    // tells people to put a copy by hand. Those two are indistinguishable
+    // until the link is followed.
+    //
     // A path that cannot be resolved — it does not exist yet, a permission
     // stops the walk — is used as given rather than treated as an error.
     // Failing to look is not evidence of ownership either way.
@@ -1167,6 +1183,22 @@ mod tests {
             "the decision must be made from the link's target"
         );
         assert_ne!(resolved, linked, "not from the link itself");
+
+        // The link's OWN location decides when it is the one that carries
+        // ownership: a distribution may install `/usr/bin/x` pointing into
+        // `/usr/lib/...`, where following the link would throw away the
+        // `/usr/bin/` that said who owns it.
+        let packaged = Path::new("/usr/bin/srelens-tui");
+        let (from, owner) = resolve_owner(packaged);
+        assert_eq!(
+            owner,
+            Some("your distribution's package manager"),
+            "ownership carried by the link's location must survive"
+        );
+        assert_eq!(
+            from, packaged,
+            "and the deciding path is the one that matched"
+        );
 
         // A path that does not resolve is used as given rather than
         // becoming an error.

--- a/apps/tui/tests/self_update_tests.rs
+++ b/apps/tui/tests/self_update_tests.rs
@@ -811,6 +811,36 @@ fn windows_package_markers_do_not_apply_on_unix() {
     }
 }
 
+/// The layouts `brew install srelens/tap/srelens-tui` actually produces.
+///
+/// Homebrew installs into `<prefix>/Cellar/<formula>/<version>/bin` and links
+/// that into `<prefix>/bin`, so what `apply` checks is the resolved Cellar
+/// path — `/usr/local/bin` alone is where the install guide tells people to
+/// put a copy by hand, and must stay updatable.
+#[test]
+fn a_homebrew_install_is_recognised_on_both_prefixes() {
+    for path in [
+        "/opt/homebrew/Cellar/srelens-tui/1.2.3/bin/srelens-tui",
+        "/usr/local/Cellar/srelens-tui/1.2.3/bin/srelens-tui",
+        "/home/linuxbrew/.linuxbrew/Cellar/srelens-tui/1.2.3/bin/srelens-tui",
+        "/opt/homebrew/bin/srelens-tui",
+        "/home/linuxbrew/.linuxbrew/bin/srelens-tui",
+    ] {
+        assert_eq!(
+            package_manager_for(Path::new(path)),
+            Some("Homebrew"),
+            "{path}"
+        );
+    }
+
+    // The hand-install location, which shares a prefix with Intel Homebrew
+    // and must not be mistaken for it.
+    assert_eq!(
+        package_manager_for(Path::new("/usr/local/bin/srelens-tui")),
+        None
+    );
+}
+
 /// A package-manager root only counts at the START of the path.
 ///
 /// An unpacked root filesystem, a container image being edited, a chroot

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -79,7 +79,19 @@ Take the **musl** build if your distribution is Alpine, or if the glibc build
 reports a version error — it is statically linked and depends on nothing on the
 host. Otherwise prefer the glibc build.
 
-**Linux and macOS.** Extract and put it on your `PATH`:
+**Homebrew** is the shortest path on macOS and Linux:
+
+```bash
+brew install srelens/tap/srelens-tui
+```
+
+It installs the same prebuilt archive listed above rather than compiling,
+and `brew upgrade srelens-tui` moves it forward. Homebrew then owns the
+copy, so `srelens-tui update` will decline to replace it and point you back
+at `brew` — writing over a file Homebrew tracks would leave its database
+describing a version that is no longer there.
+
+**Or by hand, on Linux and macOS.** Extract and put it on your `PATH`:
 
 ```bash
 tar -xzf srelens-tui-<version>-<target>.tar.gz

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -49,7 +49,12 @@ Two things this repository cannot do for itself:
    cannot push to another one.
 
 Until both exist the publish **skips** rather than failing, so releases keep
-working. The run log says which one is missing.
+working, and the run log says which one is missing. Both are checked, not just
+the token: setting a tap up is two steps by two different means, so a token
+without a repository is the normal middle of doing it rather than a mistake —
+and cloning a repository that is not there would fail the release for it. Once
+the token is set the skip is a warning rather than silence, since by then
+somebody is expecting a publish.
 
 Set `HOMEBREW_TAP_REPO` as a repository variable to publish somewhere other
 than `srelens/homebrew-tap` — useful for trying the whole path against a

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -1,0 +1,75 @@
+# Homebrew tap
+
+`brew install srelens/tap/srelens-tui` installs the terminal UI from the
+archive the release already publishes.
+
+This directory holds the formula and the script that renders it. The published
+copy lives in a separate repository, because that is how Homebrew finds it:
+`srelens/tap` resolves to `github.com/srelens/homebrew-tap`, and a tap must be
+a repository of its own.
+
+| File | What it is |
+| --- | --- |
+| `srelens-tui.rb` | The formula, as a template. Version `0.0.0` and zeroed checksums. |
+| `render.mjs` | Fills those in from a published release's `SHA256SUMS`. |
+
+A formula, not a cask: this is a command-line binary. The desktop `.dmg` wants
+`brew install --cask` and is tracked separately in #225.
+
+## How a release updates it
+
+`.github/workflows/homebrew-publish.yml` runs after a **stable** release is
+published, renders the formula for that version, and pushes it to the tap. It
+is also `workflow_dispatch`-able for any already-published version, which is
+the point of it being a separate workflow — welded to the release pipeline, a
+failed push could only be retried by cutting another release. That is how the
+AUR package once sat four versions behind.
+
+Stable only. A tap carries one version per formula, and `0.8.1-152` is not
+what someone typing `brew install` is asking for.
+
+## Setting it up
+
+Two things this repository cannot do for itself:
+
+1. **The tap repository.** Someone with organisation rights creates a public
+   `srelens/homebrew-tap`. The name matters: Homebrew maps `srelens/tap` to
+   exactly that, and `brew install srelens/tap/srelens-tui` will not resolve
+   without it. A `Formula/` directory is all it needs; the first publish
+   creates the file.
+2. **A token.** Set `HOMEBREW_TAP_TOKEN` as a repository secret — a
+   fine-grained token with **Contents: read and write** on the tap repository
+   only. `GITHUB_TOKEN` cannot be used: it is scoped to this repository and
+   cannot push to another one.
+
+Until both exist the publish **skips** rather than failing, so releases keep
+working. The run log says which one is missing.
+
+Set `HOMEBREW_TAP_REPO` as a repository variable to publish somewhere other
+than `srelens/homebrew-tap` — useful for trying the whole path against a
+personal tap before pointing it at the real one.
+
+## Rendering by hand
+
+```bash
+node packaging/homebrew/render.mjs 1.2.3            # prints the formula
+node packaging/homebrew/render.mjs 1.2.3 --out Formula/srelens-tui.rb
+```
+
+It reads the checksums the release published rather than downloading the
+archives and hashing them: re-hashing here would only prove that whatever this
+machine received hashes to itself. It refuses a version that is not `X.Y.Z`, a
+release that carries no TUI archives, a checksum file that does not list one,
+and any placeholder that survives the substitution — each of which would
+otherwise surface as an install failure on someone else's machine with nothing
+pointing back here.
+
+`--sums <file>` reads the checksums from a local file instead, for an offline
+render or to try one before the release is public.
+
+## The formula and self-update
+
+`srelens-tui update` refuses to overwrite a Homebrew-managed copy and points
+back at `brew upgrade` — writing over a file Homebrew tracks would leave its
+database describing a version that is no longer there. The formula's caveats
+say the same thing from the other side.

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -38,11 +38,11 @@ what someone typing `brew install` is asking for.
 
 Two things this repository cannot do for itself:
 
-1. **The tap repository.** Someone with organisation rights creates a public
-   `srelens/homebrew-tap`. The name matters: Homebrew maps `srelens/tap` to
-   exactly that, and `brew install srelens/tap/srelens-tui` will not resolve
-   without it. A `Formula/` directory is all it needs; the first publish
-   creates the file.
+1. **The tap repository** — ~~to create~~ **done**: [srelens/homebrew-tap](https://github.com/srelens/homebrew-tap)
+   exists, public, default branch `main`. The name matters: Homebrew maps
+   `srelens/tap` to exactly that, and `brew install srelens/tap/srelens-tui`
+   will not resolve without it. It can stay empty — the first publish creates
+   `Formula/srelens-tui.rb` and the branch with it.
 2. **A token.** Set `HOMEBREW_TAP_TOKEN` as a repository secret — a
    fine-grained token with **Contents: read and write** on the tap repository
    only. `GITHUB_TOKEN` cannot be used: it is scoped to this repository and

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -13,6 +13,12 @@ a repository of its own.
 | `srelens-tui.rb` | The formula, as a template. Version `0.0.0` and zeroed checksums. |
 | `render.mjs` | Fills those in from a published release's `SHA256SUMS`. |
 
+Linux installs take the **static musl** archives, not the glibc ones. The
+glibc builds are produced on ubuntu-22.04 and ubuntu-24.04-arm, so they
+carry a glibc floor of 2.35 and 2.39; Homebrew on Linux supports far older
+distributions than that, and a dynamically linked binary would fail before
+`main` with a `GLIBC_2.3x` symbol error that tells the user nothing.
+
 A formula, not a cask: this is a command-line binary. The desktop `.dmg` wants
 `brew install --cask` and is tracked separately in #225.
 

--- a/packaging/homebrew/render.mjs
+++ b/packaging/homebrew/render.mjs
@@ -25,12 +25,17 @@ import { fileURLToPath } from "node:url";
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO = process.env.GITHUB_REPOSITORY || "srelens/srelens";
 
-/** The four archives the formula offers, keyed by the placeholder they replace. */
+/** The four archives the formula offers.
+ *
+ * Linux takes the STATIC musl builds: the glibc ones are produced on
+ * ubuntu-22.04 and ubuntu-24.04-arm and so carry a glibc floor of 2.35 and
+ * 2.39, while Homebrew on Linux supports much older distributions. Keep
+ * this list and the formula's URLs in step. */
 const TARGETS = [
   "aarch64-apple-darwin",
   "x86_64-apple-darwin",
-  "aarch64-unknown-linux-gnu",
-  "x86_64-unknown-linux-gnu",
+  "aarch64-unknown-linux-musl",
+  "x86_64-unknown-linux-musl",
 ];
 
 function die(message) {
@@ -82,7 +87,12 @@ function checksumFor(file) {
   die(`${sumsUrl} does not list ${file}`);
 }
 
-let formula = readFileSync(join(HERE, "srelens-tui.rb"), "utf8");
+// Normalised to LF on read. A checkout on Windows can give the template CRLF,
+// and every marker below is written with LF — a mismatch made the render fail
+// with "could not find the checksum line", which reads like a broken template
+// rather than a line ending. The formula is written out with LF either way,
+// which is what the tap should carry.
+let formula = readFileSync(join(HERE, "srelens-tui.rb"), "utf8").split(String.fromCharCode(13)).join("");
 
 // Substitute per target, so a placeholder left behind is a bug that shows up
 // here rather than as an install failure.

--- a/packaging/homebrew/render.mjs
+++ b/packaging/homebrew/render.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+// Render the Homebrew formula for a published release.
+//
+//   node packaging/homebrew/render.mjs 1.2.3 [--out Formula/srelens-tui.rb]
+//                                           [--sums path/to/SHA256SUMS.txt]
+//
+// `--sums` reads the checksums from a file instead of the release, for an
+// offline render or to try one before the release is public.
+//
+// Reads that release's own `srelens-tui-<version>-SHA256SUMS.txt` and writes
+// the four URLs and checksums into the template. Deliberately NOT a
+// `brew bump-formula-pr`-style fetch-and-hash: the release already publishes
+// the checksums, and re-hashing a download here would only prove that whatever
+// this machine received hashes to itself.
+//
+// Fails rather than guesses. A missing archive, a checksum file that does not
+// list one, or a hash that is not a hash all stop the render, because a
+// formula with a wrong checksum fails on a user's machine at install time with
+// nothing pointing back here.
+
+import { writeFileSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = process.env.GITHUB_REPOSITORY || "srelens/srelens";
+
+/** The four archives the formula offers, keyed by the placeholder they replace. */
+const TARGETS = [
+  "aarch64-apple-darwin",
+  "x86_64-apple-darwin",
+  "aarch64-unknown-linux-gnu",
+  "x86_64-unknown-linux-gnu",
+];
+
+function die(message) {
+  console.error(`render: ${message}`);
+  process.exit(1);
+}
+
+const version = process.argv[2];
+if (!version) die("usage: render.mjs <version> [--out <path>]");
+if (!/^\d+\.\d+\.\d+$/.test(version)) {
+  // Homebrew carries one version per formula, and a dev pre-release
+  // (`0.8.1-152`) is not what someone typing `brew install` is asking for.
+  die(`'${version}' is not a stable X.Y.Z version; the tap is stable-only`);
+}
+
+const flag = (name) => {
+  const at = process.argv.indexOf(name);
+  return at === -1 ? null : process.argv[at + 1];
+};
+const out = flag("--out");
+const sumsFile = flag("--sums");
+
+const base = `https://github.com/${REPO}/releases/download/srelens-v${version}`;
+const sumsUrl = `${base}/srelens-tui-${version}-SHA256SUMS.txt`;
+
+let sums;
+if (sumsFile) {
+  sums = readFileSync(sumsFile, "utf8");
+} else {
+  const response = await fetch(sumsUrl);
+  if (!response.ok) {
+    die(`${response.status} fetching ${sumsUrl} — is srelens-v${version} published, and does it carry the TUI archives?`);
+  }
+  sums = await response.text();
+}
+
+/** The hash `sha256sum` recorded for one file, in either output format. */
+function checksumFor(file) {
+  for (const line of sums.split("\n")) {
+    const [hash, ...rest] = line.trim().split(/\s+/);
+    if (rest.length === 0) continue;
+    const name = rest.join(" ").replace(/^\*/, "");
+    if (name !== file) continue;
+    if (!/^[0-9a-f]{64}$/i.test(hash)) {
+      die(`the checksum listed for ${file} is not a sha256: ${hash}`);
+    }
+    return hash.toLowerCase();
+  }
+  die(`${sumsUrl} does not list ${file}`);
+}
+
+let formula = readFileSync(join(HERE, "srelens-tui.rb"), "utf8");
+
+// Substitute per target, so a placeholder left behind is a bug that shows up
+// here rather than as an install failure.
+for (const target of TARGETS) {
+  const file = `srelens-tui-${version}-${target}.tar.gz`;
+  const placeholderUrl = `https://github.com/srelens/srelens/releases/download/srelens-v0.0.0/srelens-tui-0.0.0-${target}.tar.gz`;
+  if (!formula.includes(placeholderUrl)) {
+    die(`the template no longer contains a URL for ${target}`);
+  }
+  formula = formula.replace(placeholderUrl, `${base}/${file}`);
+
+  // Replace the zeroed checksum that follows THIS url, not any other.
+  const marker = `${base}/${file}"\n      sha256 "${"0".repeat(64)}"`;
+  if (!formula.includes(marker)) {
+    die(`could not find the checksum line for ${target}`);
+  }
+  formula = formula.replace(marker, `${base}/${file}"\n      sha256 "${checksumFor(file)}"`);
+}
+
+formula = formula.replace('version "0.0.0"', `version "${version}"`);
+
+// Nothing rendered may still carry a placeholder.
+if (formula.includes("0.0.0") || formula.includes("0".repeat(64))) {
+  die("a placeholder survived the render — refusing to publish it");
+}
+
+// The committed file explains that it is a template; the published one is not.
+formula = formula.replace(
+  /^# The version and checksums below are placeholders[\s\S]*?# which is why it names a version that does not exist\.\n/m,
+  `# GENERATED for srelens-v${version} — do not edit by hand.\n` +
+    "# Rendered from packaging/homebrew/srelens-tui.rb in srelens/srelens by\n" +
+    "# packaging/homebrew/render.mjs, using that release's published SHA256SUMS.\n"
+);
+
+if (out) {
+  writeFileSync(out, formula);
+  console.error(`wrote ${out} for ${version}`);
+} else {
+  process.stdout.write(formula);
+}

--- a/packaging/homebrew/srelens-tui.rb
+++ b/packaging/homebrew/srelens-tui.rb
@@ -31,17 +31,26 @@ class SrelensTui < Formula
     end
   end
 
-  # Homebrew runs on Linux too, and the release builds both architectures for
-  # it. The glibc archives are the right ones here: Homebrew on Linux targets
-  # glibc systems, and the musl builds exist for hosts (Alpine, older glibc)
-  # that Homebrew does not support anyway.
+  # Homebrew runs on Linux too, and takes the STATIC musl archives there.
+  #
+  # Not the glibc ones, which is what this said first and was wrong about.
+  # Those are built on ubuntu-22.04 and ubuntu-24.04-arm, so they carry a
+  # glibc floor of 2.35 and 2.39 — and Homebrew on Linux deliberately
+  # supports far older distributions than that, going as far as building
+  # its own glibc when the host's is too old. A dynamically linked binary
+  # would then fail before `main` with a GLIBC_2.3x symbol error, which
+  # tells the user nothing about what to do.
+  #
+  # The static builds have no such floor. Their known costs — musl's
+  # slower allocator, its narrower resolver — do not matter for a terminal
+  # client that spends its time waiting on an API server.
   on_linux do
     on_arm do
-      url "https://github.com/srelens/srelens/releases/download/srelens-v0.0.0/srelens-tui-0.0.0-aarch64-unknown-linux-gnu.tar.gz"
+      url "https://github.com/srelens/srelens/releases/download/srelens-v0.0.0/srelens-tui-0.0.0-aarch64-unknown-linux-musl.tar.gz"
       sha256 "0000000000000000000000000000000000000000000000000000000000000000"
     end
     on_intel do
-      url "https://github.com/srelens/srelens/releases/download/srelens-v0.0.0/srelens-tui-0.0.0-x86_64-unknown-linux-gnu.tar.gz"
+      url "https://github.com/srelens/srelens/releases/download/srelens-v0.0.0/srelens-tui-0.0.0-x86_64-unknown-linux-musl.tar.gz"
       sha256 "0000000000000000000000000000000000000000000000000000000000000000"
     end
   end

--- a/packaging/homebrew/srelens-tui.rb
+++ b/packaging/homebrew/srelens-tui.rb
@@ -1,0 +1,78 @@
+# srelens-tui — the terminal UI, installed from the prebuilt release archive.
+#
+# A formula rather than a cask: this is a command-line binary. The desktop app
+# is a `.dmg` and wants `brew install --cask` (see #225), which is a separate
+# piece of work published a different way.
+#
+# It installs the archive the release already publishes instead of compiling
+# from source. Building srelens-tui pulls in the whole workspace — kube-rs,
+# reqwest, ratatui, tokio — for a binary CI has already produced, signed and
+# notarized for exactly these four targets. `brew install` should not take
+# minutes to do again, worse, what a download does in seconds.
+#
+# The version and checksums below are placeholders. Every stable release
+# renders them from that release's own SHA256SUMS and pushes the result to the
+# tap; see packaging/homebrew/README.md. The committed file is the template,
+# which is why it names a version that does not exist.
+class SrelensTui < Formula
+  desc "Kubernetes control room in your terminal, built in Rust with k9s navigation"
+  homepage "https://github.com/srelens/srelens"
+  version "0.0.0"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/srelens/srelens/releases/download/srelens-v0.0.0/srelens-tui-0.0.0-aarch64-apple-darwin.tar.gz"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+    on_intel do
+      url "https://github.com/srelens/srelens/releases/download/srelens-v0.0.0/srelens-tui-0.0.0-x86_64-apple-darwin.tar.gz"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+  end
+
+  # Homebrew runs on Linux too, and the release builds both architectures for
+  # it. The glibc archives are the right ones here: Homebrew on Linux targets
+  # glibc systems, and the musl builds exist for hosts (Alpine, older glibc)
+  # that Homebrew does not support anyway.
+  on_linux do
+    on_arm do
+      url "https://github.com/srelens/srelens/releases/download/srelens-v0.0.0/srelens-tui-0.0.0-aarch64-unknown-linux-gnu.tar.gz"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+    on_intel do
+      url "https://github.com/srelens/srelens/releases/download/srelens-v0.0.0/srelens-tui-0.0.0-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+  end
+
+  # srelens deliberately does not bundle a toolchain — it drives the kubectl
+  # and helm already on the machine, including kubeconfig exec-auth plugins —
+  # so these are genuinely optional rather than dependencies.
+  def caveats
+    <<~EOS
+      srelens-tui uses the kubectl and helm already on your PATH, if any.
+      Neither is required to browse a cluster; `srelens-tui toolbox` reports
+      what it found.
+
+      Homebrew owns this copy, so `srelens-tui update` will decline to replace
+      it and point you back here. Use `brew upgrade srelens-tui` instead.
+    EOS
+  end
+
+  def install
+    # The archive holds the binary and LICENSE at its root.
+    bin.install "srelens-tui"
+  end
+
+  test do
+    # Asserts the binary runs AND that the formula's version matches what was
+    # actually packaged — a mismatch means the render step and the release
+    # disagree, which is worth failing on.
+    assert_match version.to_s, shell_output("#{bin}/srelens-tui --version")
+
+    # A command that needs no cluster, to prove the binary is not merely
+    # loadable. With no kubeconfig it reports zero contexts rather than failing.
+    assert_match "SRElens Kubernetes TUI", shell_output("#{bin}/srelens-tui info")
+  end
+end


### PR DESCRIPTION
`brew install srelens/tap/srelens-tui`.

#444 ships the TUI as an archive and #447 teaches it to update itself, but installing it still meant picking the right one of seven files, extracting it and moving it onto `PATH`. On macOS and Linux the expected way to get a CLI is `brew install`.

Closes #451.

## One thing this needs before it works

**The tap repository does not exist yet, and I cannot create it.** `brew install srelens/tap/...` resolves to `github.com/srelens/homebrew-tap`, so someone with organisation rights has to create that public repository and add a token. `packaging/homebrew/README.md` has the exact steps. Until both exist the publish **skips** rather than failing, so releases keep working and this PR is safe to merge before the tap is set up.

## What it is

A **formula**, not a cask — this is a command-line binary. The desktop `.dmg` wants `--cask` and is #225, published a different way.

It installs the prebuilt archive rather than compiling. Building `srelens-tui` pulls in the whole workspace — kube-rs, reqwest, ratatui, tokio — to produce a binary CI has already built, signed and notarized for exactly these targets. `brew install` should not spend minutes redoing, worse, what a download does in seconds.

| File | What it is |
| --- | --- |
| `packaging/homebrew/srelens-tui.rb` | The formula, as a template |
| `packaging/homebrew/render.mjs` | Fills in version and checksums from a published release |
| `.github/workflows/homebrew-publish.yml` | Pushes it to the tap after a stable release |

The layout mirrors `packaging/aur/`, and the publish is a separate, dispatchable workflow for the reason that one is: welded to the release pipeline, a failed push could only be retried by cutting another release — which is how AUR once sat four versions behind.

## Decisions worth surfacing

- **The formula is rendered from the release's own `SHA256SUMS`**, not by downloading the archives and hashing them. Re-hashing would only prove that whatever the runner received hashes to itself.
- **The render fails rather than guesses**: a non-stable version, a release with no TUI archives, a checksum file that does not list one, or any placeholder that survives substitution. Each would otherwise surface as an install failure on someone else's machine with nothing pointing back here.
- **macOS and Linux, both architectures**, because Homebrew runs on Linux too. The glibc archives, since Homebrew targets glibc and the musl builds exist for hosts it does not support.
- **Stable only.** A tap carries one version per formula, and `0.8.1-152` is not what someone typing `brew install` is asking for.
- The publish depends on `tui-publish` as well as `publish-release`: the formula cannot be rendered before the archives are attached.

## A correctness fix that came with it

Homebrew installs into `<prefix>/Cellar/<formula>/<version>/bin` and links that into `<prefix>/bin`, so the invoked path is a **symlink** — and on Intel macOS that prefix is `/usr/local`, which is also where the install guide tells people to put a copy by hand.

`apply` now canonicalises before the package-manager check. A brew-managed copy is refused and told to use `brew upgrade`; a hand-installed `/usr/local/bin/srelens-tui` stays updatable. Without this, the guard would either have missed brew installs on Intel macOS or refused ordinary manual ones — the two are indistinguishable until you follow the link. Tested against the layouts brew actually produces on all three prefixes.

## Verification

- The renderer produces a complete formula from a checksum file, with all four URLs and hashes substituted and no placeholder left.
- It fails readably on a release with no TUI archives (`srelens-v0.8.0` today), on a dev version, and on a missing argument.
- Both workflows parse, and the job graph places `homebrew` after `tui-publish` and `publish-release`.
- 637 tests green.

The publish itself cannot be exercised until the tap exists and a stable release carries the archives. It is `workflow_dispatch`-able, so it can be run by hand against an existing release as the first real test rather than waiting for a release to find out.
