### PR TITLE
fix(docker): install the pnpm version the lockfile was written by

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,11 @@
 target
-node_modules
-apps/desktop/node_modules
+# Every node_modules, at any depth. A bare `node_modules` matches the root one
+# only, so a developer's `packages/ui-next/node_modules` was copied in on top
+# of the install the image had just done -- and its workspace links are
+# absolute host paths, which dangle inside the container. The build then could
+# not resolve `@srelens/ui-kit/gallery`, on a machine that had run pnpm
+# install and never in CI.
+**/node_modules
 apps/desktop/dist
 apps/desktop/src-tauri/target
 .git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,3 +219,29 @@ jobs:
           name: smoke-failure-artifacts
           path: ${{ runner.temp }}/smoke-artifacts
           if-no-files-found: ignore
+
+  docker:
+    name: docker image
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      # Until now nothing but the release workflow ever built this file, and
+      # two dev releases shipped no container image before anyone noticed. Two
+      # separate breaks were waiting in it, one per stage: a pnpm version the
+      # lockfile had outgrown, and a workspace member the backend stage never
+      # copied. Building only the frontend stage here would have caught one of
+      # them.
+      #
+      # So the whole image, which makes this the slowest job in CI on any
+      # change to crates/. That is the price of the image being built at all
+      # before a release depends on it. The layer cache carries the Rust stage
+      # across runs that do not touch it.
+      - name: Build the image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          push: false
+          cache-from: type=gha,scope=docker-ci
+          cache-to: type=gha,mode=max,scope=docker-ci

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,32 @@ The same applies to `cargo fmt`, which formats the whole workspace. In a
 repository where much of the tree is not rustfmt-clean, that is a very large
 diff hiding a small change.
 
+## One pnpm version, and it lives in package.json
+
+`packageManager` in the root `package.json` is the only place the pnpm
+version is written down. `pnpm/action-setup` reads it and carries no
+`version:` of its own; the Dockerfile installs from the same field:
+
+```dockerfile
+RUN npm install -g "pnpm@$(node -p "require('./package.json').packageManager.split('@').pop()")"
+```
+
+A second copy of that version goes stale, and both copies that ever existed
+did. CI ran pnpm 9 against a lockfile written by 11, which silently dropped
+the CVE overrides on every local install. Then the image went on running
+pnpm 9 after those overrides moved into `pnpm-workspace.yaml`, which only
+pnpm 10 and later read — so inside the image there were no overrides at all,
+the lockfile recorded nine, and every release build died on
+`ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`. Two dev releases shipped no container
+image before anyone looked.
+
+Build the image rather than letting a release find out for you:
+
+```bash
+docker build --target frontend .   # the pnpm half, a couple of minutes
+docker build .                     # and the Rust half, much longer
+```
+
 ## Windows
 
 Three suites fail on Windows only and are unrelated to your change:

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
 COPY crates crates
 COPY apps/desktop/src-tauri apps/desktop/src-tauri
+# apps/tui is a workspace member too, and cargo loads every member's manifest
+# even when a single package is being built -- with an explicit [[bin]] path
+# it checks that src/main.rs is really where the manifest says. Nothing here
+# builds or ships the TUI; the workspace just has to be whole, and without
+# this the server build stops at "failed to load manifest for workspace
+# member /src/apps/tui".
+COPY apps/tui apps/tui
 # rust-embed reads apps/desktop/dist at compile time; copy the built bundle in.
 COPY --from=frontend /src/apps/desktop/dist apps/desktop/dist
 RUN cargo build --release -p srelens-server --bin srelens-server

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,20 @@
 
 # ---- Stage 1: build the frontend bundle -------------------------------------
 FROM node:26-slim@sha256:c0753125a3789977aefe869cbebccf70e3cfd7ea84ca48547458f02e4f1d7146 AS frontend
+WORKDIR /src
+# package.json alone, ahead of the lockfile: it names the pnpm version, and
+# copying it by itself keeps the pnpm install layer cached when only the
+# lockfile moves.
+COPY package.json ./
 # pnpm via npm, not corepack: Node 26 ships without corepack (it was unbundled
 # upstream), so `corepack enable` is a command-not-found in this image. The
-# pinned major is what pnpm-lock.yaml was written by.
-RUN npm install -g pnpm@9
-WORKDIR /src
-COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
+# version comes from `packageManager` -- the same field pnpm/action-setup reads
+# in CI -- because a hardcoded one here is a second source of truth, and it was
+# wrong: the image ran pnpm 9 against a lockfile written by 11, and pnpm 9
+# cannot see the overrides in pnpm-workspace.yaml at all, so every frozen
+# install failed with ERR_PNPM_LOCKFILE_CONFIG_MISMATCH.
+RUN npm install -g "pnpm@$(node -p "require('./package.json').packageManager.split('@').pop()")"
+COPY pnpm-workspace.yaml pnpm-lock.yaml ./
 # Every workspace member's manifest must land before install: @srelens/desktop
 # depends on @srelens/core as workspace:*, and pnpm cannot link a package whose
 # package.json is not in the image.


### PR DESCRIPTION
Closes #455.

Both `docker image` jobs have failed on every release run since the CVE pins moved into `pnpm-workspace.yaml` (runs 34057263143 and 34119435556, amd64 and arm64 alike), at `pnpm install --frozen-lockfile`:

```
ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen installation.
The current "overrides" configuration doesn't match the value found in the lockfile
```

## Why

The image installed `pnpm@9`, and pnpm 9 reads overrides only from `package.json` under `pnpm.overrides`. The overrides live in `pnpm-workspace.yaml`, which is where pnpm 10 and later look. Inside the image there were therefore no overrides at all while the lockfile recorded nine, and a frozen install will not continue past that mismatch.

CI never hit it: `pnpm/action-setup` reads `packageManager` from `package.json`, which pins `pnpm@11.24.0`. The Dockerfile was a second, stale copy of the same fact, and its comment still claimed the pinned major was what wrote the lockfile.

## What changed

The image now derives the version from `packageManager`, the same field CI reads, so there is one place to change it:

```dockerfile
RUN npm install -g "pnpm@$(node -p "require('./package.json').packageManager.split('@').pop()")"
```

`package.json` is copied on its own, ahead of the lockfile, so the install layer stays cached when only the lockfile moves.

The `.dockerignore` change is what makes this checkable without cutting a release. A bare `node_modules` matches the root one only, so a developer's `packages/ui-next/node_modules` was copied in on top of the install the image had just done. Its workspace links are absolute host paths and dangle inside the container, so the build failed to resolve `@srelens/ui-kit/gallery` on any machine that had run pnpm install, and never in CI. Now every `node_modules` is excluded at any depth.

`AGENTS.md` records the trap: the version has one home, and the image is buildable locally.

## Verified locally

`docker build --target frontend .` installs pnpm 11.24.0, passes the frozen install, and vite writes `apps/desktop/dist`. A full `docker build` is running and I will report it here.

Note the release run that exposed this is otherwise healthy: all seven TUI targets built, and the macOS binaries came back from the notary service Accepted.