### PR TITLE
feat(packaging): a one-line install for srelens-tui on Linux

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Shell scripts are LF, always. install.sh is served from
+# raw.githubusercontent straight into `sh`, and a CRLF shebang makes the
+# kernel look for an interpreter whose name ends in a carriage return --
+# "/bin/sh^M", which does not exist, for an error that names a path that
+# looks perfectly correct.
+#
+# Scoped to *.sh on purpose. A repository-wide rule here would renormalize a
+# working tree that is CRLF throughout.
+*.sh text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,7 +255,7 @@ jobs:
               apt-get -qq update >/dev/null
               # acl for the ACL case, libdigest-sha-perl for shasum -- without
               # it the sha256sum-absent branch skips here too.
-              apt-get -qq install -y curl ca-certificates acl libdigest-sha-perl >/dev/null
+              apt-get -qq install -y curl ca-certificates acl attr libcap2-bin libdigest-sha-perl >/dev/null
               # The suite writes nothing into the mount, but it does need to
               # be able to run from somewhere it owns.
               cp -r /packaging/install /tmp/install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,31 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: sh packaging/install/test.sh
+      # Again as root, in a container, because six of the cases skip
+      # otherwise -- and they are the six that matter most. Every rule about
+      # who owns the destination needs a second account and a second group to
+      # mean anything, so on an unprivileged runner the ownership walk, the
+      # ACL refusal and the group-membership lookup all report `skip` and the
+      # job goes green having proven none of them. The suite removes the
+      # account and group it creates; the container is thrown away regardless.
+      - name: Test as root
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          docker run --rm -i \
+            -e GITHUB_TOKEN="$GITHUB_TOKEN" \
+            -v "$PWD/packaging/install:/packaging/install:ro" \
+            debian:bookworm-slim sh -c '
+              set -e
+              apt-get -qq update >/dev/null
+              # acl for the ACL case, libdigest-sha-perl for shasum -- without
+              # it the sha256sum-absent branch skips here too.
+              apt-get -qq install -y curl ca-certificates acl libdigest-sha-perl >/dev/null
+              # The suite writes nothing into the mount, but it does need to
+              # be able to run from somewhere it owns.
+              cp -r /packaging/install /tmp/install
+              sh /tmp/install/test.sh
+            '
 
   docker:
     name: docker image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,23 @@ jobs:
           path: ${{ runner.temp }}/smoke-artifacts
           if-no-files-found: ignore
 
+  install-script:
+    name: install script
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # An install script is the easiest file in the repository to leave
+      # broken: nothing builds it, nothing imports it, and the first person to
+      # notice is a stranger following the README. `sh` on this runner is
+      # dash, which is the point -- the script promises POSIX sh, and bash
+      # would happily accept bashisms that Debian and Alpine users would not.
+      - name: Lint
+        run: shellcheck -s sh packaging/install/install.sh packaging/install/test.sh
+      - name: Test
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: sh packaging/install/test.sh
+
   docker:
     name: docker image
     runs-on: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Download the latest release for your platform from
 | macOS | `.dmg` for Apple Silicon and Intel | Developer ID signed and notarized |
 | Linux | `.AppImage`, `.deb`, `.rpm` | AppImage supports the in-app updater |
 | Windows | `.exe`, `.msi` | Windows may show a SmartScreen prompt while code signing remains on the roadmap |
-| Terminal UI | Linux: `curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/install.sh \| sh`; macOS: `brew install srelens/tap/srelens-tui`; or `srelens-tui-<version>-<target>.tar.gz` / `.zip` | A single binary for Linux (glibc and static musl), macOS and Windows, on x86-64 and arm64; macOS builds on a stable release are signed and notarized |
+| Terminal UI | Linux: `curl -fsSL <install.sh> -o srelens-install.sh && sh srelens-install.sh`; macOS: `brew install srelens/tap/srelens-tui`; or `srelens-tui-<version>-<target>.tar.gz` / `.zip` | A single binary for Linux (glibc and static musl), macOS and Windows, on x86-64 and arm64; macOS builds on a stable release are signed and notarized |
 
 See the [installation guide](docs/INSTALL.md) for platform-specific installation,
 first-launch, updating, verification, and uninstall instructions.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Download the latest release for your platform from
 | macOS | `.dmg` for Apple Silicon and Intel | Developer ID signed and notarized |
 | Linux | `.AppImage`, `.deb`, `.rpm` | AppImage supports the in-app updater |
 | Windows | `.exe`, `.msi` | Windows may show a SmartScreen prompt while code signing remains on the roadmap |
-| Terminal UI | Linux: `curl -fsSL <install.sh> -o srelens-install.sh && sh srelens-install.sh`; macOS: `brew install srelens/tap/srelens-tui`; or `srelens-tui-<version>-<target>.tar.gz` / `.zip` | A single binary for Linux (glibc and static musl), macOS and Windows, on x86-64 and arm64; macOS builds on a stable release are signed and notarized |
+| Terminal UI | Linux: `( f="$(mktemp)" && trap 'rm -f "$f"' EXIT && curl -fsSL <install.sh> -o "$f" && sh "$f" )`; macOS: `brew install srelens/tap/srelens-tui`; or `srelens-tui-<version>-<target>.tar.gz` / `.zip` | A single binary for Linux (glibc and static musl), macOS and Windows, on x86-64 and arm64; macOS builds on a stable release are signed and notarized |
 
 See the [installation guide](docs/INSTALL.md) for platform-specific installation,
 first-launch, updating, verification, and uninstall instructions.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Download the latest release for your platform from
 | macOS | `.dmg` for Apple Silicon and Intel | Developer ID signed and notarized |
 | Linux | `.AppImage`, `.deb`, `.rpm` | AppImage supports the in-app updater |
 | Windows | `.exe`, `.msi` | Windows may show a SmartScreen prompt while code signing remains on the roadmap |
-| Terminal UI | `brew install srelens/tap/srelens-tui`, or `srelens-tui-<version>-<target>.tar.gz` / `.zip` | A single binary for Linux (glibc and static musl), macOS and Windows, on x86-64 and arm64; macOS builds on a stable release are signed and notarized |
+| Terminal UI | Linux: `curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/install.sh \| sh`; macOS: `brew install srelens/tap/srelens-tui`; or `srelens-tui-<version>-<target>.tar.gz` / `.zip` | A single binary for Linux (glibc and static musl), macOS and Windows, on x86-64 and arm64; macOS builds on a stable release are signed and notarized |
 
 See the [installation guide](docs/INSTALL.md) for platform-specific installation,
 first-launch, updating, verification, and uninstall instructions.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -79,11 +79,28 @@ Take the **musl** build if your distribution is Alpine, or if the glibc build
 reports a version error — it is statically linked and depends on nothing on the
 host. Otherwise prefer the glibc build.
 
-**On Linux, the install script** is the shortest path:
+**On Linux, the install script** is the shortest path. Download it, then
+run it:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/install.sh -o srelens-install.sh
+sh srelens-install.sh
+rm srelens-install.sh
 ```
+
+Two steps rather than `curl … | sh` for a reason worth knowing: a pipeline
+reports the status of its *last* command. If the download fails — a 404, a
+TLS error, an outage — `sh` reads an empty script, does nothing, and exits
+0, so the whole line succeeds having installed nothing. Anything automated
+around it then carries on as though `srelens-tui` were there.
+
+```
+curl … | sh                       -> pipeline exit=0   (installed nothing)
+curl … -o f && sh f               -> chain exit=22
+```
+
+It still works piped, if you would rather. It just cannot tell you when it
+did not run.
 
 It picks the right architecture, always takes the static musl build so no
 distribution's glibc version matters, checks the download against the
@@ -97,10 +114,15 @@ report one — rather than proceed without knowing, it stops and says so.
 It never invokes `sudo` on your behalf — run the whole line under `sudo` if
 you want it system-wide from an unprivileged shell.
 
-`--version <x.y.z>` installs a specific release. Options cannot be appended
-to the line above: everything after `sh` is read by the shell, not by the
-script, so `sh` would reject `--version` as its own flag. Pass it after
-`-s --`:
+`--version <x.y.z>` installs a specific release:
+
+```bash
+sh srelens-install.sh --version 0.9.0
+```
+
+Piped, options cannot simply be appended — everything after `sh` belongs to
+the shell, which would reject `--version` as its own flag — so they go
+after `-s --`:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/install.sh \
@@ -113,8 +135,8 @@ with a local account is not something a shell script can do honestly, so it
 does not pretend to. To put the binary elsewhere, unpack the tarball by hand
 as shown below.
 
-Read it first if you would rather not pipe a script
-from the internet into a shell; it is short, and
+Downloading it first also means you can read it before running it; it is
+short, and
 [`packaging/install/install.sh`](../packaging/install/install.sh) is the file
 that URL serves.
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -92,15 +92,21 @@ in `/usr/local/bin` when that is writable or `~/.local/bin` when it is not.
 It never invokes `sudo` on your behalf — run the whole line under `sudo` if
 you want it system-wide from an unprivileged shell.
 
-`--version <x.y.z>` installs a specific release and `--install-dir <path>`
-puts it somewhere else. Options cannot be appended to the line above:
-everything after `sh` is read by the shell, not by the script, so `sh` would
-reject `--version` as its own flag. Pass them after `-s --`:
+`--version <x.y.z>` installs a specific release. Options cannot be appended
+to the line above: everything after `sh` is read by the shell, not by the
+script, so `sh` would reject `--version` as its own flag. Pass it after
+`-s --`:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/install.sh \
-  | sh -s -- --version 0.9.0 --install-dir ~/bin
+  | sh -s -- --version 0.9.0
 ```
+
+Those two destinations are the only ones. There is no flag for naming
+another: making an arbitrary caller-chosen directory safe against someone
+with a local account is not something a shell script can do honestly, so it
+does not pretend to. To put the binary elsewhere, unpack the tarball by hand
+as shown below.
 
 Read it first if you would rather not pipe a script
 from the internet into a shell; it is short, and

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -133,10 +133,13 @@ ordinary `~/.local/bin` update does not need it.
 It never invokes `sudo` on your behalf — run the whole line under `sudo` if
 you want it system-wide from an unprivileged shell.
 
-`--version <x.y.z>` installs a specific release:
+`--version <x.y.z>` installs a specific release. Same shape as above, with
+the option after the script:
 
 ```bash
-sh srelens-install.sh --version 0.9.0
+( f="$(mktemp)" && trap 'rm -f "$f"' EXIT &&
+  curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/install.sh -o "$f" &&
+  sh "$f" --version 0.9.0 )
 ```
 
 Piped, options cannot simply be appended — everything after `sh` belongs to

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -116,9 +116,10 @@ otherwise.
 
 On Alpine, install `acl` first (`apk add acl`): the script checks whether the
 destination carries an extended ACL, and BusyBox `ls` cannot report one —
-rather than proceed without knowing, it stops and says so. Add `attr` too if
-you are replacing an existing copy, since it also checks for extended
-attributes it could not put back if the new binary had to be rolled out again.
+rather than proceed without knowing, it stops and says so. Add `attr` too if you are
+replacing an existing copy **under `sudo`**, since it also checks for extended
+attributes it could not put back if the new binary had to be rolled back. An
+ordinary `~/.local/bin` update does not need it.
 It never invokes `sudo` on your behalf — run the whole line under `sudo` if
 you want it system-wide from an unprivileged shell.
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -83,9 +83,9 @@ host. Otherwise prefer the glibc build.
 run it:
 
 ```bash
-f="$(mktemp)" &&
+( f="$(mktemp)" && trap 'rm -f "$f"' EXIT &&
   curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/install.sh -o "$f" &&
-  sh "$f"; rm -f "$f"
+  sh "$f" )
 ```
 
 `mktemp` rather than a fixed name, and chained rather than three lines.
@@ -98,9 +98,11 @@ the machine. `mktemp` creates the file exclusively, so there is nothing to
 aim at.
 
 The chaining matters because unchained, a failed download leaves the previous
-file to be run, and a failed install followed by a successful `rm` ends the
-snippet at status 0 — the same way the pipeline did. `rm -f` after `;` rather
-than `&&` so the temporary file goes whether the install worked or not.
+file to be run. And the cleanup is a `trap` in a subshell rather than a
+trailing `; rm -f`, because a command after `;` sets the status of the whole
+line — a failed install followed by a successful `rm` would report 0, the
+same way the pipeline did. The subshell exits with the install's status, and
+the trap removes the file on the way out whether it worked or not.
 
 Two steps rather than `curl … | sh` for a reason worth knowing: a pipeline
 reports the status of its *last* command. If the download fails — a 404, a

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -83,16 +83,24 @@ host. Otherwise prefer the glibc build.
 run it:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/install.sh -o srelens-install.sh &&
-  sh srelens-install.sh &&
-  rm srelens-install.sh
+f="$(mktemp)" &&
+  curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/install.sh -o "$f" &&
+  sh "$f"; rm -f "$f"
 ```
 
-Chained, not three separate lines: unchained, a failed download would leave
-the previous `srelens-install.sh` sitting there to be run, and a failed
-install followed by a successful `rm` would end the snippet at status 0 —
-the same way the pipeline did. If the install fails the file is left in
-place, which is what you want when you are about to look at why.
+`mktemp` rather than a fixed name, and chained rather than three lines.
+
+The fixed name was the worse of the two: run from a directory another account
+can write to — `/tmp`, a shared build dir — that account can pre-create
+`srelens-install.sh` as a symlink, and `curl -o` follows it and truncates
+whatever it points at, with your privileges. Under `sudo` that is any file on
+the machine. `mktemp` creates the file exclusively, so there is nothing to
+aim at.
+
+The chaining matters because unchained, a failed download leaves the previous
+file to be run, and a failed install followed by a successful `rm` ends the
+snippet at status 0 — the same way the pipeline did. `rm -f` after `;` rather
+than `&&` so the temporary file goes whether the install worked or not.
 
 Two steps rather than `curl … | sh` for a reason worth knowing: a pipeline
 reports the status of its *last* command. If the download fails — a 404, a

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -114,9 +114,11 @@ release's published SHA-256 before installing anything, and puts the binary
 in `/usr/local/bin` when that is writable and safe, or `~/.local/bin`
 otherwise.
 
-On Alpine, install the `acl` package first (`apk add acl`). The script checks
-whether the destination carries an extended ACL, and BusyBox `ls` cannot
-report one — rather than proceed without knowing, it stops and says so.
+On Alpine, install `acl` first (`apk add acl`): the script checks whether the
+destination carries an extended ACL, and BusyBox `ls` cannot report one —
+rather than proceed without knowing, it stops and says so. Add `attr` too if
+you are replacing an existing copy, since it also checks for extended
+attributes it could not put back if the new binary had to be rolled out again.
 It never invokes `sudo` on your behalf — run the whole line under `sudo` if
 you want it system-wide from an unprivileged shell.
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -93,7 +93,16 @@ It never invokes `sudo` on your behalf — run the whole line under `sudo` if
 you want it system-wide from an unprivileged shell.
 
 `--version <x.y.z>` installs a specific release and `--install-dir <path>`
-puts it somewhere else. Read it first if you would rather not pipe a script
+puts it somewhere else. Options cannot be appended to the line above:
+everything after `sh` is read by the shell, not by the script, so `sh` would
+reject `--version` as its own flag. Pass them after `-s --`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/install.sh \
+  | sh -s -- --version 0.9.0 --install-dir ~/bin
+```
+
+Read it first if you would rather not pipe a script
 from the internet into a shell; it is short, and
 [`packaging/install/install.sh`](../packaging/install/install.sh) is the file
 that URL serves.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -83,10 +83,16 @@ host. Otherwise prefer the glibc build.
 run it:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/install.sh -o srelens-install.sh
-sh srelens-install.sh
-rm srelens-install.sh
+curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/install.sh -o srelens-install.sh &&
+  sh srelens-install.sh &&
+  rm srelens-install.sh
 ```
+
+Chained, not three separate lines: unchained, a failed download would leave
+the previous `srelens-install.sh` sitting there to be run, and a failed
+install followed by a successful `rm` would end the snippet at status 0 —
+the same way the pipeline did. If the install fails the file is left in
+place, which is what you want when you are about to look at why.
 
 Two steps rather than `curl … | sh` for a reason worth knowing: a pipeline
 reports the status of its *last* command. If the download fails — a 404, a

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -79,7 +79,29 @@ Take the **musl** build if your distribution is Alpine, or if the glibc build
 reports a version error — it is statically linked and depends on nothing on the
 host. Otherwise prefer the glibc build.
 
-**Homebrew** is the shortest path on macOS and Linux:
+**On Linux, the install script** is the shortest path:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/install.sh | sh
+```
+
+It picks the right architecture, always takes the static musl build so no
+distribution's glibc version matters, checks the download against the
+release's published SHA-256 before installing anything, and puts the binary
+in `/usr/local/bin` when that is writable or `~/.local/bin` when it is not.
+It never invokes `sudo` on your behalf — run the whole line under `sudo` if
+you want it system-wide from an unprivileged shell.
+
+`--version <x.y.z>` installs a specific release and `--install-dir <path>`
+puts it somewhere else. Read it first if you would rather not pipe a script
+from the internet into a shell; it is short, and
+[`packaging/install/install.sh`](../packaging/install/install.sh) is the file
+that URL serves.
+
+A copy installed this way is yours rather than a package manager's, so
+`srelens-tui update` will replace it in place.
+
+**Homebrew** is the shortest path on macOS, and works on Linux too:
 
 ```bash
 brew install srelens/tap/srelens-tui

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -88,7 +88,12 @@ curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/inst
 It picks the right architecture, always takes the static musl build so no
 distribution's glibc version matters, checks the download against the
 release's published SHA-256 before installing anything, and puts the binary
-in `/usr/local/bin` when that is writable or `~/.local/bin` when it is not.
+in `/usr/local/bin` when that is writable and safe, or `~/.local/bin`
+otherwise.
+
+On Alpine, install the `acl` package first (`apk add acl`). The script checks
+whether the destination carries an extended ACL, and BusyBox `ls` cannot
+report one — rather than proceed without knowing, it stops and says so.
 It never invokes `sudo` on your behalf — run the whole line under `sudo` if
 you want it system-wide from an unprivileged shell.
 

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -59,9 +59,12 @@ each component must be:
 - owned by root or by you;
 - inspectable at all. A component that cannot be read fails closed: an
   inspection that does not answer is not an answer;
-- free of an extended ACL. `ls` marks one with a trailing `+`, and an ACL can
-  grant write where the mode bits show none — reading one portably is beyond a
-  POSIX shell, so the marker itself is a refusal;
+- free of an extended ACL, which can grant write where the mode bits show
+  none. `getfacl` answers this properly; GNU `ls` answers it with a trailing
+  `+`; BusyBox `ls` does not answer it at all, and there the install refuses
+  rather than proceeding blind. **On Alpine that means `apk add acl` first** —
+  the alternative was letting an ACL through on precisely the systems that
+  cannot see it;
 - sticky, if either write bit is set. Sticky settles both at once: only an
   entry's owner may unlink it. `/tmp` is `drwxrwxrwt`, group- AND
   world-writable, so treating either bit as disqualifying on its own would
@@ -155,7 +158,7 @@ directory rather than your real `~/.local/bin` -- the cases replace whatever
 binary is at the destination and delete it afterwards, so running the tests
 would otherwise uninstall your own copy.
 
-Fifty-five cases: argument handling, the macOS and unknown-architecture refusals,
+Fifty-seven cases: argument handling, the macOS and unknown-architecture refusals,
 a corrupted archive (which must install nothing), latest-version resolution, a
 real install, installing over an existing copy, a run with a PATH that
 lacks `sha256sum` so the `shasum` branch is actually taken, the piped

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -126,12 +126,22 @@ it that way. In a container that is free; on your machine it is not. Run them
 the way CI does:
 
 ```bash
-docker run --rm -v "$PWD/packaging/install:/i:ro" debian:bookworm-slim \n  sh -c "apt-get -qq update && apt-get -qq install -y curl ca-certificates acl \n         libdigest-sha-perl && cp -r /i /tmp/i && sh /tmp/i/test.sh"
+docker run --rm -v "$PWD/packaging/install:/i:ro" debian:bookworm-slim sh -c '
+  apt-get -qq update
+  apt-get -qq install -y curl ca-certificates acl libdigest-sha-perl
+  cp -r /i /tmp/i && sh /tmp/i/test.sh
+'
 ```
 
 The directory is snapshotted before anything touches it and put back from that
 snapshot -- by each case, and by the exit trap, so an interrupt restores it
-too.
+too. Add `--privileged` to also run the noexec cases, which need to mount a
+tmpfs; without it they skip and say so.
+
+Unprivileged, the suite installs into an isolated `HOME` under its own temp
+directory rather than your real `~/.local/bin` -- the cases replace whatever
+binary is at the destination and delete it afterwards, so running the tests
+would otherwise uninstall your own copy.
 
 Fifty-four cases: argument handling, the macOS and unknown-architecture refusals,
 a corrupted archive (which must install nothing), latest-version resolution, a

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -3,9 +3,9 @@
 `install.sh` is what this serves:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/install.sh -o srelens-install.sh
-sh srelens-install.sh
-rm srelens-install.sh
+curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/install.sh -o srelens-install.sh &&
+  sh srelens-install.sh &&
+  rm srelens-install.sh
 ```
 
 Two steps, not `curl … | sh`: a pipeline reports the status of its last
@@ -119,6 +119,19 @@ be replaced faithfully — the rollback copy is taken by reading the
 destination, which follows the link, so a restore would put a regular file
 where a link had been while reporting the previous copy was put back.
 
+**An install is a transaction, and a signal rolls it back.** Between the
+replacement and the moment the new binary is first run, the destination
+holds something unvalidated and the previous copy is under a random name —
+and on a `noexec` working directory that window covers the *only* time the
+binary is ever checked. `INT` and `TERM` put the old copy back and remove
+the staging file rather than leaving that state behind.
+
+The rollback copy carries bytes, mode, owner and timestamps (`cp -p`, into
+the inode `mktemp` holds, so the name is never released). It does **not**
+carry an extended ACL, an xattr or a file capability — nothing portable
+does — so an existing binary with an ACL is refused rather than restored
+as something quietly less protected.
+
 **Unpredictable staging, and a private unpack.** The staging file is created
 with `mktemp` rather than at `.srelens-tui.install.<pid>`, which could be
 pre-created as a symlink for `cp` to write through. The archive is unpacked
@@ -175,7 +188,7 @@ directory rather than your real `~/.local/bin` -- the cases replace whatever
 binary is at the destination and delete it afterwards, so running the tests
 would otherwise uninstall your own copy.
 
-Sixty-four cases: argument handling, the macOS and unknown-architecture refusals,
+Sixty-eight cases: argument handling, the macOS and unknown-architecture refusals,
 a corrupted archive (which must install nothing), latest-version resolution, a
 real install, installing over an existing copy, a run with a PATH that
 lacks `sha256sum` so the `shasum` branch is actually taken, the piped

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -106,6 +106,12 @@ itself 0700 and yours, but places it under `TMPDIR` when that is set -- and
 parent someone else owns can rename the tree after the checksum passes and
 put their own binary where the verified one was.
 
+**A directory or a symlink where the binary goes is refused.** `mv file dir`
+moves the file *into* a directory rather than over it, and a symlink cannot
+be replaced faithfully — the rollback copy is taken by reading the
+destination, which follows the link, so a restore would put a regular file
+where a link had been while reporting the previous copy was put back.
+
 **Unpredictable staging, and a private unpack.** The staging file is created
 with `mktemp` rather than at `.srelens-tui.install.<pid>`, which could be
 pre-created as a symlink for `cp` to write through. The archive is unpacked
@@ -162,7 +168,7 @@ directory rather than your real `~/.local/bin` -- the cases replace whatever
 binary is at the destination and delete it afterwards, so running the tests
 would otherwise uninstall your own copy.
 
-Sixty-one cases: argument handling, the macOS and unknown-architecture refusals,
+Sixty-three cases: argument handling, the macOS and unknown-architecture refusals,
 a corrupted archive (which must install nothing), latest-version resolution, a
 real install, installing over an existing copy, a run with a PATH that
 lacks `sha256sum` so the `shasum` branch is actually taken, the piped

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -17,13 +17,23 @@ stable release, verifies its SHA-256 against the release's own
 `SHA256SUMS.txt`, and installs the binary to `/usr/local/bin` or
 `~/.local/bin`.
 
-`--version` and `--install-dir` override those two choices. Through a pipe
-they need `-s --`, because everything after `sh` belongs to the shell rather
-than to the script:
+`--version` overrides the version. Through a pipe it needs `-s --`, because
+everything after `sh` belongs to the shell rather than to the script:
 
 ```bash
-curl -fsSL .../install.sh | sh -s -- --version 0.9.0 --install-dir ~/bin
+curl -fsSL .../install.sh | sh -s -- --version 0.9.0
 ```
+
+There is no `--install-dir`. It existed and was removed: an arbitrary
+caller-chosen destination was most of this script's attack surface, and
+making one safe from a POSIX shell means winning filesystem races a shell has
+no primitives for — it cannot hold a descriptor across a check and a use, so
+every rule below is a claim about a path that could change underneath it. The
+two destinations here are root's or yours by construction. Anyone who wants
+the binary elsewhere can unpack the tarball, which is a plain `tar -xzf`.
+
+The checks below still run, because both destinations remain reachable from
+the environment: `$HOME` is whatever the caller says it is.
 
 ## Decisions worth not re-litigating
 
@@ -109,7 +119,7 @@ place for that choice.
 sh packaging/install/test.sh
 ```
 
-Fifty-three cases: argument handling, the macOS and unknown-architecture refusals,
+Fifty-four cases: argument handling, the macOS and unknown-architecture refusals,
 a corrupted archive (which must install nothing), latest-version resolution, a
 real install, installing over an existing copy, a run with a PATH that
 lacks `sha256sum` so the `shasum` branch is actually taken, the piped

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -33,6 +33,16 @@ Debian 11 or RHEL 9, which is exactly the sort of host a cluster gets
 administered from. The failure is a `GLIBC_2.3x not found` before `main()`,
 which tells the reader nothing actionable. The static build has no floor.
 
+**Unsafe destinations are refused.** A world-writable directory without the
+sticky bit, and -- when running as root -- a directory root does not own.
+An unpredictable staging name is not enough on its own: mktemp closes the
+file it creates and `cp` reopens it by name, so anyone who can unlink entries
+in that directory can swap in a symlink between the two, or replace the
+finished binary before it is run. Only the directory permissions close that.
+Group-writable alone is allowed, because distributions with per-user groups
+leave `~/.local/bin` group-writable under a 002 umask. This is the same rule
+`srelens-tui update` applies to the binary it replaces.
+
 **Unpredictable staging.** The file is created with `mktemp` inside the
 destination directory rather than at `.srelens-tui.install.<pid>`. Installed
 as root into a directory someone else can write to, a name derived from the
@@ -63,12 +73,12 @@ place for that choice.
 sh packaging/install/test.sh
 ```
 
-Twenty-two cases: argument handling, the macOS and unknown-architecture refusals,
+Twenty-seven cases: argument handling, the macOS and unknown-architecture refusals,
 a corrupted archive (which must install nothing), latest-version resolution, a
 real install, installing over an existing copy, a run with a PATH that
 lacks `sha256sum` so the `shasum` branch is actually taken, the piped
-`sh -s --` form the docs tell people to use, and a symlink planted in the
-install directory to prove the staging file is not written through it. The refusal cases
+`sh -s --` form the docs tell people to use, a symlink planted in the
+install directory, and the destination refusals below. The refusal cases
 put a fake `curl` and `uname` ahead of the real ones on `PATH`.
 
 Only one call reaches the real GitHub API, and the test makes it with a token

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -195,7 +195,7 @@ directory rather than your real `~/.local/bin` -- the cases replace whatever
 binary is at the destination and delete it afterwards, so running the tests
 would otherwise uninstall your own copy.
 
-Seventy-six cases: argument handling, the macOS and unknown-architecture refusals,
+Seventy-eight cases: argument handling, the macOS and unknown-architecture refusals,
 a corrupted archive (which must install nothing), latest-version resolution, a
 real install, installing over an existing copy, a run with a PATH that
 lacks `sha256sum` so the `shasum` branch is actually taken, the piped

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -116,8 +116,9 @@ put their own binary where the verified one was.
 **The installed binary has to be the one that was asked for.** Running is not
 proof: a release that published a stale binary under the right asset name and
 checksum would install silently, and a pinned `--version` would report success
-having produced a different one. The version it reports is checked before the
-install commits.
+having produced a different one. The version token it reports is compared exactly before
+the install commits — `1.2.30` contains `1.2.3`, so a substring match would
+accept the very build this is meant to catch.
 
 **A directory, a symlink, or a special file where the binary goes is refused.** `mv file dir`
 moves the file *into* a directory rather than over it, and a symlink cannot
@@ -194,7 +195,7 @@ directory rather than your real `~/.local/bin` -- the cases replace whatever
 binary is at the destination and delete it afterwards, so running the tests
 would otherwise uninstall your own copy.
 
-Seventy-two cases: argument handling, the macOS and unknown-architecture refusals,
+Seventy-six cases: argument handling, the macOS and unknown-architecture refusals,
 a corrupted archive (which must install nothing), latest-version resolution, a
 real install, installing over an existing copy, a run with a PATH that
 lacks `sha256sum` so the `shasum` branch is actually taken, the piped

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -33,28 +33,31 @@ Debian 11 or RHEL 9, which is exactly the sort of host a cluster gets
 administered from. The failure is a `GLIBC_2.3x not found` before `main()`,
 which tells the reader nothing actionable. The static build has no floor.
 
-**Unsafe destinations are refused.** A world-writable directory without the
-sticky bit; a world-writable sticky one owned by somebody else, since sticky
-never stops the directory OWNER unlinking what is inside it; and -- running
-as root -- a directory root does not own. The path is resolved with
-`cd` + `pwd -P` before any of that, because `ls -ld` on a symlink describes
-the link rather than the directory the install would land in -- and the
-resolved path is then what staging, the rename and the final version check
-all use. Approving one path and installing through another would leave the
-link repointable in between.
-An unpredictable staging name is not enough on its own: mktemp closes the
-file it creates and `cp` reopens it by name, so anyone who can unlink entries
-in that directory can swap in a symlink between the two, or replace the
-finished binary before it is run. Only the directory permissions close that.
-Group-writable alone is allowed, because distributions with per-user groups
-leave `~/.local/bin` group-writable under a 002 umask. This is the same rule
-`srelens-tui update` applies to the binary it replaces.
+**Every component of the destination is checked, not just the leaf.** A
+directory can be impeccable itself and still sit under one somebody else
+owns, who can rename it and put their own directory at the same path after
+the check. The walk is the one `sudo` and `ssh` do over their own paths, and
+each component must be:
 
-**Unpredictable staging.** The file is created with `mktemp` inside the
-destination directory rather than at `.srelens-tui.install.<pid>`. Installed
-as root into a directory someone else can write to, a name derived from the
-pid can be pre-created as a symlink, and `cp` writes through a destination
-symlink — as root, into a file of that user's choosing.
+- owned by root or by you;
+- if world-writable, sticky — only an entry's owner may unlink it, which is
+  what makes `/tmp` usable rather than disqualifying;
+- if group-writable, owned by its own group. That is the per-user-group
+  convention (`alice:alice`, one member), which Fedora leaves on
+  `~/.local/bin` under a 002 umask. A shared group is a set of people who can
+  each replace the binary.
+
+The path is resolved with `cd` + `pwd -P` first, and the resolved path is
+what staging, the rename and the final version check all use — approving one
+path and installing through another leaves a symlink repointable in between.
+
+**Unpredictable staging, and a private unpack.** The staging file is created
+with `mktemp` rather than at `.srelens-tui.install.<pid>`, which could be
+pre-created as a symlink for `cp` to write through. The archive is unpacked
+one level below the private temp directory, never into it: it carries a `./`
+member, and GNU tar restores directory ownership and permissions from the
+archive when it runs as root, which would rewrite `mktemp -d`'s 0700 into
+whatever the release runner had.
 
 **No sudo.** A script fetched over the network that re-invokes itself as root
 is the pattern people are right to be nervous about, and the `~/.local/bin`
@@ -80,7 +83,7 @@ place for that choice.
 sh packaging/install/test.sh
 ```
 
-Thirty-two cases: argument handling, the macOS and unknown-architecture refusals,
+Thirty-seven cases: argument handling, the macOS and unknown-architecture refusals,
 a corrupted archive (which must install nothing), latest-version resolution, a
 real install, installing over an existing copy, a run with a PATH that
 lacks `sha256sum` so the `shasum` branch is actually taken, the piped

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -50,7 +50,9 @@ each component must be:
   world-writable, so treating either bit as disqualifying on its own would
   refuse every path running through it;
 - if group-writable without sticky, owned by its own group AND that group
-  must really have no other members. `alice:alice` is the per-user-group
+  must really have no other members, counted from both the member list and
+  the passwd table -- an account whose PRIMARY group it is never appears in
+  the former. `alice:alice` is the per-user-group
   convention Fedora leaves on `~/.local/bin` under a 002 umask, but a
   convention is not a guarantee, so the membership is looked up. Accounts
   whose PRIMARY group is that one stay invisible to it — a group-writable
@@ -60,6 +62,12 @@ each component must be:
 The path is resolved with `cd` + `pwd -P` first, and the resolved path is
 what staging, the rename and the final version check all use — approving one
 path and installing through another leaves a symlink repointable in between.
+
+**The working directory gets the same walk.** `mktemp -d` makes the directory
+itself 0700 and yours, but places it under `TMPDIR` when that is set -- and
+`sudo` can carry the invoking user's `TMPDIR` straight into a root install. A
+parent someone else owns can rename the tree after the checksum passes and
+put their own binary where the verified one was.
 
 **Unpredictable staging, and a private unpack.** The staging file is created
 with `mktemp` rather than at `.srelens-tui.install.<pid>`, which could be
@@ -93,7 +101,7 @@ place for that choice.
 sh packaging/install/test.sh
 ```
 
-Thirty-nine cases: argument handling, the macOS and unknown-architecture refusals,
+Forty-three cases: argument handling, the macOS and unknown-architecture refusals,
 a corrupted archive (which must install nothing), latest-version resolution, a
 real install, installing over an existing copy, a run with a PATH that
 lacks `sha256sum` so the `shasum` branch is actually taken, the piped

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -63,6 +63,13 @@ The path is resolved with `cd` + `pwd -P` first, and the resolved path is
 what staging, the rename and the final version check all use — approving one
 path and installing through another leaves a symlink repointable in between.
 
+**A `noexec` working directory is expected, not fatal.** A hardened host
+mounts `/tmp` noexec and `mktemp` puts the working tree there, so running the
+binary to check it would report every good download as broken. The script
+probes whether it can execute anything there at all, and moves the check to
+after the install when it cannot -- where a binary that does not run is
+removed again rather than left on your `PATH`.
+
 **The working directory gets the same walk.** `mktemp -d` makes the directory
 itself 0700 and yours, but places it under `TMPDIR` when that is set -- and
 `sudo` can carry the invoking user's `TMPDIR` straight into a root install. A
@@ -101,7 +108,7 @@ place for that choice.
 sh packaging/install/test.sh
 ```
 
-Forty-three cases: argument handling, the macOS and unknown-architecture refusals,
+Forty-seven cases: argument handling, the macOS and unknown-architecture refusals,
 a corrupted archive (which must install nothing), latest-version resolution, a
 real install, installing over an existing copy, a run with a PATH that
 lacks `sha256sum` so the `shasum` branch is actually taken, the piped

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -93,8 +93,8 @@ mounts `/tmp` noexec and `mktemp` puts the working tree there, so running the
 binary to check it would report every good download as broken. The script
 probes whether it can execute anything there at all, and moves the check to
 after the install when it cannot -- where a binary that does not run is
-removed again -- and the copy it replaced is put back, since that check is
-the first time the new one could be run at all.
+removed again -- and the copy it replaced is put back, with the permissions
+it had, since that check is the first time the new one could be run at all.
 
 **The working directory gets the same walk.** `mktemp -d` makes the directory
 itself 0700 and yours, but places it under `TMPDIR` when that is set -- and
@@ -158,7 +158,7 @@ directory rather than your real `~/.local/bin` -- the cases replace whatever
 binary is at the destination and delete it afterwards, so running the tests
 would otherwise uninstall your own copy.
 
-Fifty-eight cases: argument handling, the macOS and unknown-architecture refusals,
+Fifty-nine cases: argument handling, the macOS and unknown-architecture refusals,
 a corrupted archive (which must install nothing), latest-version resolution, a
 real install, installing over an existing copy, a run with a PATH that
 lacks `sha256sum` so the `shasum` branch is actually taken, the piped

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -158,7 +158,7 @@ directory rather than your real `~/.local/bin` -- the cases replace whatever
 binary is at the destination and delete it afterwards, so running the tests
 would otherwise uninstall your own copy.
 
-Fifty-seven cases: argument handling, the macOS and unknown-architecture refusals,
+Fifty-eight cases: argument handling, the macOS and unknown-architecture refusals,
 a corrupted archive (which must install nothing), latest-version resolution, a
 real install, installing over an existing copy, a run with a PATH that
 lacks `sha256sum` so the `shasum` branch is actually taken, the piped

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -68,7 +68,8 @@ mounts `/tmp` noexec and `mktemp` puts the working tree there, so running the
 binary to check it would report every good download as broken. The script
 probes whether it can execute anything there at all, and moves the check to
 after the install when it cannot -- where a binary that does not run is
-removed again rather than left on your `PATH`.
+removed again -- and the copy it replaced is put back, since that check is
+the first time the new one could be run at all.
 
 **The working directory gets the same walk.** `mktemp -d` makes the directory
 itself 0700 and yours, but places it under `TMPDIR` when that is set -- and
@@ -108,7 +109,7 @@ place for that choice.
 sh packaging/install/test.sh
 ```
 
-Forty-seven cases: argument handling, the macOS and unknown-architecture refusals,
+Fifty-two cases: argument handling, the macOS and unknown-architecture refusals,
 a corrupted archive (which must install nothing), latest-version resolution, a
 real install, installing over an existing copy, a run with a PATH that
 lacks `sha256sum` so the `shasum` branch is actually taken, the piped

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -110,3 +110,10 @@ draw on, and exhausting it would fail this job on unrelated pull requests.
 CI runs this and `shellcheck -s sh` on every pull request, under `dash` rather
 than bash — the script promises POSIX `sh`, and bash would quietly accept
 bashisms that Debian and Alpine users would not.
+
+It runs the suite twice: once on the runner, and once as root in a container.
+Six cases skip without root, and they are the six that matter most — every
+rule about who owns the destination needs a second account and a second group
+to mean anything. On an unprivileged runner alone, the ownership walk, the ACL
+refusal and the group-membership lookup all report `skip`, and the job goes
+green having proven none of them.

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -1,0 +1,60 @@
+# The Linux install script
+
+`install.sh` is what this serves:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/install.sh | sh
+```
+
+It is served straight from `main` on raw.githubusercontent.com, so **a change
+merged to main is live immediately** — there is no release step between this
+file and the URL people paste into a root shell. Treat edits accordingly.
+
+## What it does
+
+Detects the architecture, downloads the static musl archive for the latest
+stable release, verifies its SHA-256 against the release's own
+`SHA256SUMS.txt`, and installs the binary to `/usr/local/bin` or
+`~/.local/bin`. `--version` and `--install-dir` override the two choices it
+makes on your behalf.
+
+## Decisions worth not re-litigating
+
+**Always musl, never glibc.** The glibc archives are built on ubuntu-22.04 and
+ubuntu-24.04-arm, so they carry a floor of glibc 2.35 and 2.39 — newer than
+Debian 11 or RHEL 9, which is exactly the sort of host a cluster gets
+administered from. The failure is a `GLIBC_2.3x not found` before `main()`,
+which tells the reader nothing actionable. The static build has no floor.
+
+**No sudo.** A script fetched over the network that re-invokes itself as root
+is the pattern people are right to be nervous about, and the `~/.local/bin`
+fallback needs no privileges. Anyone who wants it system-wide can run the
+whole pipeline under `sudo`.
+
+**Everything inside `main()`, called on the last line.** A script read from a
+pipe executes as it arrives, so a connection dropped halfway would otherwise
+run whatever fragment arrived. With the wrapper, a truncated download is a
+syntax error that does nothing.
+
+**Linux only.** macOS gets `brew install srelens/tap/srelens-tui`, which is
+already the documented path there; the script says so rather than competing
+with it.
+
+**Stable only.** The binary's own `srelens-tui update` carries the dev and
+stable channels for anyone who wants a pre-release. Bootstrapping is not the
+place for that choice.
+
+## Tests
+
+```bash
+sh packaging/install/test.sh
+```
+
+Twelve cases: argument handling, the macOS and unknown-architecture refusals,
+a corrupted archive (which must install nothing), a real install of the latest
+release, and installing over an existing copy. The refusal cases put a fake
+`curl` and `uname` ahead of the real ones on `PATH`.
+
+CI runs this and `shellcheck -s sh` on every pull request, under `dash` rather
+than bash — the script promises POSIX `sh`, and bash would quietly accept
+bashisms that Debian and Alpine users would not.

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -37,8 +37,11 @@ which tells the reader nothing actionable. The static build has no floor.
 sticky bit; a world-writable sticky one owned by somebody else, since sticky
 never stops the directory OWNER unlinking what is inside it; and -- running
 as root -- a directory root does not own. The path is resolved with
-`cd` + `pwd -P` first, because `ls -ld` on a symlink describes the link
-rather than the directory the install would land in.
+`cd` + `pwd -P` before any of that, because `ls -ld` on a symlink describes
+the link rather than the directory the install would land in -- and the
+resolved path is then what staging, the rename and the final version check
+all use. Approving one path and installing through another would leave the
+link repointable in between.
 An unpredictable staging name is not enough on its own: mktemp closes the
 file it creates and `cp` reopens it by name, so anyone who can unlink entries
 in that directory can swap in a symlink between the two, or replace the
@@ -77,7 +80,7 @@ place for that choice.
 sh packaging/install/test.sh
 ```
 
-Thirty cases: argument handling, the macOS and unknown-architecture refusals,
+Thirty-two cases: argument handling, the macOS and unknown-architecture refusals,
 a corrupted archive (which must install nothing), latest-version resolution, a
 real install, installing over an existing copy, a run with a PATH that
 lacks `sha256sum` so the `shasum` branch is actually taken, the piped

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -3,8 +3,15 @@
 `install.sh` is what this serves:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/install.sh -o srelens-install.sh
+sh srelens-install.sh
+rm srelens-install.sh
 ```
+
+Two steps, not `curl … | sh`: a pipeline reports the status of its last
+command, so a download that 404s leaves `sh` reading an empty script,
+doing nothing, and exiting 0 — the line succeeds having installed nothing.
+It still works piped; it just cannot tell you when it did not run.
 
 It is served straight from `main` on raw.githubusercontent.com, so **a change
 merged to main is live immediately** — there is no release step between this
@@ -168,7 +175,7 @@ directory rather than your real `~/.local/bin` -- the cases replace whatever
 binary is at the destination and delete it afterwards, so running the tests
 would otherwise uninstall your own copy.
 
-Sixty-three cases: argument handling, the macOS and unknown-architecture refusals,
+Sixty-four cases: argument handling, the macOS and unknown-architecture refusals,
 a corrupted archive (which must install nothing), latest-version resolution, a
 real install, installing over an existing copy, a run with a PATH that
 lacks `sha256sum` so the `shasum` branch is actually taken, the piped

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -66,10 +66,15 @@ each component must be:
   entry's owner may unlink it. `/tmp` is `drwxrwxrwt`, group- AND
   world-writable, so treating either bit as disqualifying on its own would
   refuse every path running through it;
-- if group-writable without sticky, owned by its own group AND that group
-  must really have no other members, counted from both the member list and
-  the passwd table -- an account whose PRIMARY group it is never appears in
-  the former. `alice:alice` is the per-user-group
+- not group-writable at all, unless sticky. Who is really in a group cannot
+  be established from a shell: an SSSD or LDAP source resolves accounts one
+  at a time while declining to enumerate, so `getent` gives a lower bound
+  rather than a fact. This used to try -- member list, then the passwd table
+  for primary-group members -- on the grounds that Fedora leaves
+  `~/.local/bin` group-writable under a 002 umask. It does not: Fedora 41
+  sets `UMASK 022`, and a fresh account gets `drwxr-xr-x`. Thirty-five lines
+  defending a case that was not real, and unable to answer the question
+  anyway. `alice:alice` is the per-user-group
   convention Fedora leaves on `~/.local/bin` under a 002 umask, but a
   convention is not a guarantee, so the membership is looked up. Accounts
   whose PRIMARY group is that one stay invisible to it — a group-writable
@@ -150,7 +155,7 @@ directory rather than your real `~/.local/bin` -- the cases replace whatever
 binary is at the destination and delete it afterwards, so running the tests
 would otherwise uninstall your own copy.
 
-Fifty-six cases: argument handling, the macOS and unknown-architecture refusals,
+Fifty-five cases: argument handling, the macOS and unknown-architecture refusals,
 a corrupted archive (which must install nothing), latest-version resolution, a
 real install, installing over an existing copy, a run with a PATH that
 lacks `sha256sum` so the `shasum` branch is actually taken, the piped

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -3,9 +3,9 @@
 `install.sh` is what this serves:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/install.sh -o srelens-install.sh &&
-  sh srelens-install.sh &&
-  rm srelens-install.sh
+f="$(mktemp)" &&
+  curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/install.sh -o "$f" &&
+  sh "$f"; rm -f "$f"
 ```
 
 Two steps, not `curl … | sh`: a pipeline reports the status of its last

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -139,9 +139,13 @@ extended ACL, an xattr or a file capability, and nothing portable does — so
 rather than restore something quietly less capable than what it took, it
 refuses to replace a binary carrying any of them.
 
-That check needs `getfacl` and `getfattr`, and an **update** refuses if
-`getfattr` is missing rather than guess. A **first** install is never asked:
-there is no previous copy to be faithful to. `security.selinux` is excluded
+That check needs `getfacl` and `getfattr`. A **privileged update** refuses if
+`getfattr` is missing rather than guess — the attribute worth caring about is
+a file capability, and setting one needs `CAP_SETFCAP`, so a binary that has
+one got it from root and root is who is replacing it. An **unprivileged**
+update carries on without it: a capability cannot be on your own binary in
+your own directory unless root put it there. A **first** install is never
+asked at all — there is no previous copy to be faithful to. `security.selinux` is excluded
 deliberately — every file on an SELinux system has one, and it is the single
 piece here the filesystem re-derives, since the rollback copy is created by
 `mktemp` in the destination directory and labelled by the same policy.
@@ -202,7 +206,7 @@ directory rather than your real `~/.local/bin` -- the cases replace whatever
 binary is at the destination and delete it afterwards, so running the tests
 would otherwise uninstall your own copy.
 
-Eighty-one cases: argument handling, the macOS and unknown-architecture refusals,
+Eighty-two cases: argument handling, the macOS and unknown-architecture refusals,
 a corrupted archive (which must install nothing), latest-version resolution, a
 real install, installing over an existing copy, a run with a PATH that
 lacks `sha256sum` so the `shasum` branch is actually taken, the piped

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -119,6 +119,20 @@ place for that choice.
 sh packaging/install/test.sh
 ```
 
+As root it refuses to run outside a container, and says so. The destination
+cases install into the real `/usr/local/bin` and bend it -- world-writable,
+foreign-owned, ACL-bearing, briefly a symlink -- and an interrupt would leave
+it that way. In a container that is free; on your machine it is not. Run them
+the way CI does:
+
+```bash
+docker run --rm -v "$PWD/packaging/install:/i:ro" debian:bookworm-slim \n  sh -c "apt-get -qq update && apt-get -qq install -y curl ca-certificates acl \n         libdigest-sha-perl && cp -r /i /tmp/i && sh /tmp/i/test.sh"
+```
+
+The directory is snapshotted before anything touches it and put back from that
+snapshot -- by each case, and by the exit trap, so an interrupt restores it
+too.
+
 Fifty-four cases: argument handling, the macOS and unknown-architecture refusals,
 a corrupted archive (which must install nothing), latest-version resolution, a
 real install, installing over an existing copy, a run with a PATH that

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -113,7 +113,13 @@ itself 0700 and yours, but places it under `TMPDIR` when that is set -- and
 parent someone else owns can rename the tree after the checksum passes and
 put their own binary where the verified one was.
 
-**A directory or a symlink where the binary goes is refused.** `mv file dir`
+**The installed binary has to be the one that was asked for.** Running is not
+proof: a release that published a stale binary under the right asset name and
+checksum would install silently, and a pinned `--version` would report success
+having produced a different one. The version it reports is checked before the
+install commits.
+
+**A directory, a symlink, or a special file where the binary goes is refused.** `mv file dir`
 moves the file *into* a directory rather than over it, and a symlink cannot
 be replaced faithfully — the rollback copy is taken by reading the
 destination, which follows the link, so a restore would put a regular file
@@ -188,7 +194,7 @@ directory rather than your real `~/.local/bin` -- the cases replace whatever
 binary is at the destination and delete it afterwards, so running the tests
 would otherwise uninstall your own copy.
 
-Sixty-eight cases: argument handling, the macOS and unknown-architecture refusals,
+Seventy-two cases: argument handling, the macOS and unknown-architecture refusals,
 a corrupted archive (which must install nothing), latest-version resolution, a
 real install, installing over an existing copy, a run with a PATH that
 lacks `sha256sum` so the `shasum` branch is actually taken, the piped

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -43,6 +43,13 @@ Debian 11 or RHEL 9, which is exactly the sort of host a cluster gets
 administered from. The failure is a `GLIBC_2.3x not found` before `main()`,
 which tells the reader nothing actionable. The static build has no floor.
 
+**An unsafe `/usr/local/bin` falls back, it does not stop the install.**
+Writable is not the same as safe, and the difference decides *where* the
+binary goes rather than whether it arrives. A GitHub runner ships
+`/usr/local/bin` world-writable: the rules refuse that directory and the
+install lands in `~/.local/bin` instead. Whichever is chosen is then checked
+for real, so an unsafe home still stops it.
+
 **Every component of the destination is checked, not just the leaf.** A
 directory can be impeccable itself and still sit under one somebody else
 owns, who can rename it and put their own directory at the same path after
@@ -143,7 +150,7 @@ directory rather than your real `~/.local/bin` -- the cases replace whatever
 binary is at the destination and delete it afterwards, so running the tests
 would otherwise uninstall your own copy.
 
-Fifty-four cases: argument handling, the macOS and unknown-architecture refusals,
+Fifty-six cases: argument handling, the macOS and unknown-architecture refusals,
 a corrupted archive (which must install nothing), latest-version resolution, a
 real install, installing over an existing copy, a run with a PATH that
 lacks `sha256sum` so the `shasum` branch is actually taken, the piped

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -40,12 +40,22 @@ the check. The walk is the one `sudo` and `ssh` do over their own paths, and
 each component must be:
 
 - owned by root or by you;
-- if world-writable, sticky — only an entry's owner may unlink it, which is
-  what makes `/tmp` usable rather than disqualifying;
-- if group-writable, owned by its own group. That is the per-user-group
-  convention (`alice:alice`, one member), which Fedora leaves on
-  `~/.local/bin` under a 002 umask. A shared group is a set of people who can
-  each replace the binary.
+- inspectable at all. A component that cannot be read fails closed: an
+  inspection that does not answer is not an answer;
+- free of an extended ACL. `ls` marks one with a trailing `+`, and an ACL can
+  grant write where the mode bits show none — reading one portably is beyond a
+  POSIX shell, so the marker itself is a refusal;
+- sticky, if either write bit is set. Sticky settles both at once: only an
+  entry's owner may unlink it. `/tmp` is `drwxrwxrwt`, group- AND
+  world-writable, so treating either bit as disqualifying on its own would
+  refuse every path running through it;
+- if group-writable without sticky, owned by its own group AND that group
+  must really have no other members. `alice:alice` is the per-user-group
+  convention Fedora leaves on `~/.local/bin` under a 002 umask, but a
+  convention is not a guarantee, so the membership is looked up. Accounts
+  whose PRIMARY group is that one stay invisible to it — a group-writable
+  destination is the weakest check here, and one that is not group-writable
+  does not depend on any of it.
 
 The path is resolved with `cd` + `pwd -P` first, and the resolved path is
 what staging, the rename and the final version check all use — approving one
@@ -83,7 +93,7 @@ place for that choice.
 sh packaging/install/test.sh
 ```
 
-Thirty-seven cases: argument handling, the macOS and unknown-architecture refusals,
+Thirty-nine cases: argument handling, the macOS and unknown-architecture refusals,
 a corrupted archive (which must install nothing), latest-version resolution, a
 real install, installing over an existing copy, a run with a PATH that
 lacks `sha256sum` so the `shasum` branch is actually taken, the piped

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -65,10 +65,14 @@ each component must be:
   rather than proceeding blind. **On Alpine that means `apk add acl` first** —
   the alternative was letting an ACL through on precisely the systems that
   cannot see it;
-- sticky, if either write bit is set. Sticky settles both at once: only an
-  entry's owner may unlink it. `/tmp` is `drwxrwxrwt`, group- AND
-  world-writable, so treating either bit as disqualifying on its own would
-  refuse every path running through it;
+- sticky, if either write bit is set **and it is a parent**. Sticky settles
+  both at once there: only an entry's owner may unlink it, and `/tmp` is
+  `drwxrwxrwt`, so treating either write bit as disqualifying would refuse
+  every path running through it. The **destination** gets no such exemption —
+  sticky stops another user removing our files, not creating `srelens-tui`
+  there first and owning it, after which its mode is copied onto the rollback
+  (a planted 4755 becoming a root-owned setuid file) and it can be swapped for
+  a symlink to a directory so the `mv` lands underneath it;
 - not group-writable at all, unless sticky. Who is really in a group cannot
   be established from a shell: an SSSD or LDAP source resolves accounts one
   at a time while declining to enumerate, so `getent` gives a lower bound
@@ -158,7 +162,7 @@ directory rather than your real `~/.local/bin` -- the cases replace whatever
 binary is at the destination and delete it afterwards, so running the tests
 would otherwise uninstall your own copy.
 
-Fifty-nine cases: argument handling, the macOS and unknown-architecture refusals,
+Sixty-one cases: argument handling, the macOS and unknown-architecture refusals,
 a corrupted archive (which must install nothing), latest-version resolution, a
 real install, installing over an existing copy, a run with a PATH that
 lacks `sha256sum` so the `shasum` branch is actually taken, the piped

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -15,8 +15,15 @@ file and the URL people paste into a root shell. Treat edits accordingly.
 Detects the architecture, downloads the static musl archive for the latest
 stable release, verifies its SHA-256 against the release's own
 `SHA256SUMS.txt`, and installs the binary to `/usr/local/bin` or
-`~/.local/bin`. `--version` and `--install-dir` override the two choices it
-makes on your behalf.
+`~/.local/bin`.
+
+`--version` and `--install-dir` override those two choices. Through a pipe
+they need `-s --`, because everything after `sh` belongs to the shell rather
+than to the script:
+
+```bash
+curl -fsSL .../install.sh | sh -s -- --version 0.9.0 --install-dir ~/bin
+```
 
 ## Decisions worth not re-litigating
 
@@ -25,6 +32,12 @@ ubuntu-24.04-arm, so they carry a floor of glibc 2.35 and 2.39 — newer than
 Debian 11 or RHEL 9, which is exactly the sort of host a cluster gets
 administered from. The failure is a `GLIBC_2.3x not found` before `main()`,
 which tells the reader nothing actionable. The static build has no floor.
+
+**Unpredictable staging.** The file is created with `mktemp` inside the
+destination directory rather than at `.srelens-tui.install.<pid>`. Installed
+as root into a directory someone else can write to, a name derived from the
+pid can be pre-created as a symlink, and `cp` writes through a destination
+symlink — as root, into a file of that user's choosing.
 
 **No sudo.** A script fetched over the network that re-invokes itself as root
 is the pattern people are right to be nervous about, and the `~/.local/bin`
@@ -50,10 +63,12 @@ place for that choice.
 sh packaging/install/test.sh
 ```
 
-Sixteen cases: argument handling, the macOS and unknown-architecture refusals,
+Twenty-two cases: argument handling, the macOS and unknown-architecture refusals,
 a corrupted archive (which must install nothing), latest-version resolution, a
-real install, installing over an existing copy, and a run with a PATH that
-lacks `sha256sum` so the `shasum` branch is actually taken. The refusal cases
+real install, installing over an existing copy, a run with a PATH that
+lacks `sha256sum` so the `shasum` branch is actually taken, the piped
+`sh -s --` form the docs tell people to use, and a symlink planted in the
+install directory to prove the staging file is not written through it. The refusal cases
 put a fake `curl` and `uname` ahead of the real ones on `PATH`.
 
 Only one call reaches the real GitHub API, and the test makes it with a token

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -50,10 +50,17 @@ place for that choice.
 sh packaging/install/test.sh
 ```
 
-Twelve cases: argument handling, the macOS and unknown-architecture refusals,
-a corrupted archive (which must install nothing), a real install of the latest
-release, and installing over an existing copy. The refusal cases put a fake
-`curl` and `uname` ahead of the real ones on `PATH`.
+Sixteen cases: argument handling, the macOS and unknown-architecture refusals,
+a corrupted archive (which must install nothing), latest-version resolution, a
+real install, installing over an existing copy, and a run with a PATH that
+lacks `sha256sum` so the `shasum` branch is actually taken. The refusal cases
+put a fake `curl` and `uname` ahead of the real ones on `PATH`.
+
+Only one call reaches the real GitHub API, and the test makes it with a token
+when one is present. `install.sh` itself is deliberately unauthenticated --
+that is how a stranger runs it -- so leaving the live cases to resolve
+`latest` themselves would spend the shared per-IP quota that hosted runners
+draw on, and exhausting it would fail this job on unrelated pull requests.
 
 CI runs this and `shellcheck -s sh` on every pull request, under `dash` rather
 than bash — the script promises POSIX `sh`, and bash would quietly accept

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -109,7 +109,7 @@ place for that choice.
 sh packaging/install/test.sh
 ```
 
-Fifty-two cases: argument handling, the macOS and unknown-architecture refusals,
+Fifty-three cases: argument handling, the macOS and unknown-architecture refusals,
 a corrupted archive (which must install nothing), latest-version resolution, a
 real install, installing over an existing copy, a run with a PATH that
 lacks `sha256sum` so the `shasum` branch is actually taken, the piped

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -134,10 +134,17 @@ binary is ever checked. `INT` and `TERM` put the old copy back and remove
 the staging file rather than leaving that state behind.
 
 The rollback copy carries bytes, mode, owner and timestamps (`cp -p`, into
-the inode `mktemp` holds, so the name is never released). It does **not**
-carry an extended ACL, an xattr or a file capability — nothing portable
-does — so an existing binary with an ACL is refused rather than restored
-as something quietly less protected.
+the inode `mktemp` holds, so the name is never released). It does **not** carry an
+extended ACL, an xattr or a file capability, and nothing portable does — so
+rather than restore something quietly less capable than what it took, it
+refuses to replace a binary carrying any of them.
+
+That check needs `getfacl` and `getfattr`, and an **update** refuses if
+`getfattr` is missing rather than guess. A **first** install is never asked:
+there is no previous copy to be faithful to. `security.selinux` is excluded
+deliberately — every file on an SELinux system has one, and it is the single
+piece here the filesystem re-derives, since the rollback copy is created by
+`mktemp` in the destination directory and labelled by the same policy.
 
 **Unpredictable staging, and a private unpack.** The staging file is created
 with `mktemp` rather than at `.srelens-tui.install.<pid>`, which could be
@@ -195,7 +202,7 @@ directory rather than your real `~/.local/bin` -- the cases replace whatever
 binary is at the destination and delete it afterwards, so running the tests
 would otherwise uninstall your own copy.
 
-Seventy-eight cases: argument handling, the macOS and unknown-architecture refusals,
+Eighty-one cases: argument handling, the macOS and unknown-architecture refusals,
 a corrupted archive (which must install nothing), latest-version resolution, a
 real install, installing over an existing copy, a run with a PATH that
 lacks `sha256sum` so the `shasum` branch is actually taken, the piped

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -3,9 +3,9 @@
 `install.sh` is what this serves:
 
 ```bash
-f="$(mktemp)" &&
+( f="$(mktemp)" && trap 'rm -f "$f"' EXIT &&
   curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/install.sh -o "$f" &&
-  sh "$f"; rm -f "$f"
+  sh "$f" )
 ```
 
 Two steps, not `curl … | sh`: a pipeline reports the status of its last
@@ -191,7 +191,7 @@ the way CI does:
 ```bash
 docker run --rm -v "$PWD/packaging/install:/i:ro" debian:bookworm-slim sh -c '
   apt-get -qq update
-  apt-get -qq install -y curl ca-certificates acl libdigest-sha-perl
+  apt-get -qq install -y curl ca-certificates acl attr libcap2-bin libdigest-sha-perl
   cp -r /i /tmp/i && sh /tmp/i/test.sh
 '
 ```

--- a/packaging/install/README.md
+++ b/packaging/install/README.md
@@ -34,7 +34,11 @@ administered from. The failure is a `GLIBC_2.3x not found` before `main()`,
 which tells the reader nothing actionable. The static build has no floor.
 
 **Unsafe destinations are refused.** A world-writable directory without the
-sticky bit, and -- when running as root -- a directory root does not own.
+sticky bit; a world-writable sticky one owned by somebody else, since sticky
+never stops the directory OWNER unlinking what is inside it; and -- running
+as root -- a directory root does not own. The path is resolved with
+`cd` + `pwd -P` first, because `ls -ld` on a symlink describes the link
+rather than the directory the install would land in.
 An unpredictable staging name is not enough on its own: mktemp closes the
 file it creates and `cp` reopens it by name, so anyone who can unlink entries
 in that directory can swap in a symlink between the two, or replace the
@@ -73,7 +77,7 @@ place for that choice.
 sh packaging/install/test.sh
 ```
 
-Twenty-seven cases: argument handling, the macOS and unknown-architecture refusals,
+Thirty cases: argument handling, the macOS and unknown-architecture refusals,
 a corrupted archive (which must install nothing), latest-version resolution, a
 real install, installing over an existing copy, a run with a PATH that
 lacks `sha256sum` so the `shasum` branch is actually taken, the piped

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -1,7 +1,14 @@
 #!/bin/sh
 # Install srelens-tui on Linux.
 #
-#   curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/install.sh -o srelens-install.sh &&
+#     sh srelens-install.sh &&
+#     rm srelens-install.sh
+#
+# Download-then-run, chained, rather than piping into sh: a pipeline reports
+# the status of its LAST command, so a download that 404s hands sh an empty
+# script, which does nothing and exits 0. The line then succeeds having
+# installed nothing, and whatever is automating it carries on.
 #
 # Everything is inside main(), called on the very last line. A script read
 # from a pipe is executed as it arrives, so a connection that dies halfway
@@ -575,17 +582,28 @@ assert_component() {
 install_rollback() {
     INSTALL_ROLLBACK_KEPT=""
     [ -z "$INSTALL_COMMITTED" ] || return 0
+    # Each branch clears what it dealt with. This runs TWICE on a signal --
+    # the INT/TERM handler calls it, then `exit` fires the EXIT handler --
+    # and a second pass that still saw a destination but no backup would take
+    # the fresh-install branch and delete the binary the first pass had just
+    # restored.
     if [ -n "$INSTALL_BACKUP" ] && [ -e "$INSTALL_BACKUP" ]; then
         # Something was there before: put it back.
         if [ -n "$INSTALL_DEST" ]; then
-            if ! mv -f "$INSTALL_BACKUP" "$INSTALL_DEST" 2>/dev/null; then
+            if mv -f "$INSTALL_BACKUP" "$INSTALL_DEST" 2>/dev/null; then
+                INSTALL_BACKUP=""
+                INSTALL_DEST=""
+            else
                 # It could not go back -- a read-only mount, a full disk.
                 # Deleting it here would destroy the only copy of what was
                 # there, so it stays, and the caller says where.
                 INSTALL_ROLLBACK_KEPT="$INSTALL_BACKUP"
+                INSTALL_BACKUP=""
+                INSTALL_DEST=""
             fi
         else
             rm -f "$INSTALL_BACKUP"
+            INSTALL_BACKUP=""
         fi
     elif [ -n "$INSTALL_DEST" ]; then
         # Nothing was there before, so the binary at that path is one this
@@ -593,8 +611,12 @@ install_rollback() {
         # it has been executed by nobody at all, and leaving it is leaving an
         # unchecked binary on someone's PATH under a name they will trust.
         rm -f "$INSTALL_DEST"
+        INSTALL_DEST=""
     fi
-    [ -z "$INSTALL_STAGED" ] || rm -f "$INSTALL_STAGED"
+    if [ -n "$INSTALL_STAGED" ]; then
+        rm -f "$INSTALL_STAGED"
+        INSTALL_STAGED=""
+    fi
 }
 
 # Install by rename where possible: a running binary being overwritten in

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -433,7 +433,14 @@ assert_component() {
     # not see it. A gap that is written down is still a gap.
     # shellcheck disable=SC2012  # the elif asks ls what it is, not for a listing
     if command -v getfacl >/dev/null 2>&1; then
-        if [ -n "$(getfacl --skip-base --omit-header "$path" 2>/dev/null)" ]; then
+        # Status first, then the output. A getfacl that fails -- an
+        # implementation without these options, a filesystem that will not
+        # answer -- produces empty output, which reads exactly like a file
+        # carrying only its base entries. Same fail-open as the group lookup
+        # had, one check over.
+        acl_entries="$(getfacl --skip-base --omit-header "$path" 2>/dev/null)" ||
+            die "cannot read the ACL of $path, so its real permissions are unknown. Check it with: getfacl $path"
+        if [ -n "$acl_entries" ]; then
             die "$path carries an extended ACL, which may grant write access that its mode does not show. Inspect it with: getfacl $path"
         fi
     elif ls --version 2>/dev/null | head -n 1 | grep -q coreutils; then
@@ -518,24 +525,27 @@ install_binary() {
     # Keep whatever is being replaced until the new one has been shown to
     # run. Alongside it, so the restore below stays on one filesystem.
     #
-    # A LINK, not a rename. Renaming the old binary out of the way first
-    # would unlink the live path, and a crash in the gap between that and
-    # the rename below would leave nothing at the documented path with the
-    # only copy under a hidden random name. A second name for the same
-    # inode leaves the path working throughout, and the `mv` below stays a
-    # single atomic replacement.
+    # A copy of the old binary, taken WITHOUT unlinking the live path and
+    # WITHOUT releasing the name mktemp reserved.
+    #
+    # Renaming the old binary aside would leave nothing at the documented
+    # path if the process died in the gap. And unlinking the reserved name
+    # to `ln` over it -- which is what this did -- opens a window in a
+    # sticky directory somebody else can write to: they cannot remove OUR
+    # file, but once it is gone they can put a symlink at that name, the
+    # link fails because the name exists, and the copy behind it writes
+    # through their symlink with our privileges. Writing into the inode
+    # mktemp already holds closes both.
     INSTALL_BACKUP=""
     if [ -e "$dest" ]; then
         INSTALL_BACKUP="$(mktemp "$dir/.$BIN.backup.XXXXXX")" ||
             die "cannot create a rollback file in $dir, so $dest will not be replaced"
-        # mktemp made the file; link over it. `cp` is the fallback for a
-        # filesystem that will not hard-link.
-        rm -f "$INSTALL_BACKUP"
-        if ! ln "$dest" "$INSTALL_BACKUP" 2>/dev/null &&
-            ! cp "$dest" "$INSTALL_BACKUP"; then
+        if ! cat "$dest" > "$INSTALL_BACKUP" 2>/dev/null; then
             rm -f "$INSTALL_BACKUP" "$staged"
             die "cannot preserve the $BIN already at $dest, so it will not be replaced"
         fi
+        # mktemp makes it 0600; a restore has to put back something runnable.
+        chmod 0755 "$INSTALL_BACKUP"
     fi
 
     mv -f "$staged" "$dest" || {

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -538,14 +538,22 @@ install_binary() {
     # mktemp already holds closes both.
     INSTALL_BACKUP=""
     if [ -e "$dest" ]; then
+        # The mode it has NOW. A rollback has to put back what was there,
+        # not a guess: a binary someone deliberately kept at 0700 must not
+        # come back 0755, readable and runnable by everyone on the machine.
+        # `stat -c` rather than `chmod --reference`, which BusyBox lacks.
+        dest_mode="$(stat -c %a "$dest" 2>/dev/null)" || dest_mode=""
+        [ -n "$dest_mode" ] ||
+            die "cannot read the permissions of $dest, so a rollback could not restore them"
         INSTALL_BACKUP="$(mktemp "$dir/.$BIN.backup.XXXXXX")" ||
             die "cannot create a rollback file in $dir, so $dest will not be replaced"
         if ! cat "$dest" > "$INSTALL_BACKUP" 2>/dev/null; then
             rm -f "$INSTALL_BACKUP" "$staged"
             die "cannot preserve the $BIN already at $dest, so it will not be replaced"
         fi
-        # mktemp makes it 0600; a restore has to put back something runnable.
-        chmod 0755 "$INSTALL_BACKUP"
+        # mktemp makes it 0600; the rollback carries the mode the binary
+        # actually had.
+        chmod "$dest_mode" "$INSTALL_BACKUP"
     fi
 
     mv -f "$staged" "$dest" || {

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -414,19 +414,34 @@ assert_component() {
         *) die "$path is not a directory, so the install path cannot be trusted" ;;
     esac
 
-    # `ls -l` marks an extended ACL with a trailing `+`. An ACL can grant
-    # write to any user while the mode bits look impeccable, and reading one
-    # portably is not something a POSIX shell can do -- getfacl is neither
-    # POSIX nor present on Alpine. Refuse rather than pass a directory whose
-    # real permissions have not been seen.
+    # Extended ACLs, which can grant write to any account while the mode
+    # bits look impeccable.
     #
-    # A gap worth naming: BusyBox ls does not print that marker at all, so on
-    # Alpine an ACL is invisible here. There is no portable way to ask -- the
-    # alternative would be refusing every group- or other-readable directory
-    # on systems whose ls is terse, which refuses the ordinary case to catch
-    # a rare one.
-    if [ "$(printf %s "$listing" | cut -c11)" = "+" ]; then
-        die "$path carries an extended ACL, which may grant write access that its mode does not show. Check it with: getfacl $path"
+    # Three ways this can go, and only two of them are answers:
+    #
+    #   * getfacl, which is authoritative. `--skip-base` prints nothing at
+    #     all for a file carrying only the three base entries, so anything on
+    #     stdout is an extended ACL.
+    #   * GNU ls, which marks one with a trailing `+` on the mode string.
+    #   * neither, which is BusyBox without the acl package -- and there an
+    #     ACL is simply invisible. `ls` does not print the marker and there
+    #     is nothing else to ask.
+    #
+    # The third case refuses. It used to be documented as a known gap and
+    # allowed, which meant a root-owned 0755 directory carrying
+    # `user:attacker:rwx` sailed through on exactly the systems that could
+    # not see it. A gap that is written down is still a gap.
+    # shellcheck disable=SC2012  # the elif asks ls what it is, not for a listing
+    if command -v getfacl >/dev/null 2>&1; then
+        if [ -n "$(getfacl --skip-base --omit-header "$path" 2>/dev/null)" ]; then
+            die "$path carries an extended ACL, which may grant write access that its mode does not show. Inspect it with: getfacl $path"
+        fi
+    elif ls --version 2>/dev/null | head -n 1 | grep -q coreutils; then
+        if [ "$(printf %s "$listing" | cut -c11)" = "+" ]; then
+            die "$path carries an extended ACL, which may grant write access that its mode does not show. Inspect it with: getfacl $path"
+        fi
+    else
+        die "cannot tell whether $path carries an extended ACL: this ls does not report them and getfacl is not installed. Install the acl package (on Alpine: apk add acl) and run this again."
     fi
 
     if [ -n "$owner" ] && [ "$owner" != "root" ] && [ "$owner" != "$SAFE_ME" ]; then

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -468,7 +468,16 @@ assert_component() {
             # none of this.
             gid="$(printf %s "$entry" | cut -d: -f3)"
             if [ -n "$gid" ]; then
-                primary="$(getent passwd 2>/dev/null |
+                # Captured BEFORE awk sees it. In `getent passwd | awk`,
+                # the status belongs to awk, which succeeds happily on no
+                # input -- so a partial NSS outage would have produced an
+                # empty answer and been read as "nobody else is in this
+                # group". The same fail-open the group lookup above had.
+                accounts="$(getent passwd 2>/dev/null)" ||
+                    die "cannot enumerate accounts, so who else is in the group $group is unknown. Choose a path that is not group-writable: --install-dir \$HOME/.local/bin"
+                [ -n "$accounts" ] ||
+                    die "no accounts could be listed, so who else is in the group $group is unknown. Choose a path that is not group-writable: --install-dir \$HOME/.local/bin"
+                primary="$(printf %s "$accounts" |
                     awk -F: -v g="$gid" -v o="$owner" '$4 == g && $1 != o { printf "%s ", $1 }')" || primary=""
                 if [ -n "$primary" ]; then
                     die "$path is writable by the group $group, which is the primary group of ${primary%% }. Any of them could replace the binary between staging and running it. Choose a path you control: --install-dir \$HOME/.local/bin"

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -89,6 +89,8 @@ main() {
     INSTALL_COMMITTED=""
     INSTALL_ROLLBACK_KEPT=""
     INSTALL_ROLLBACK_STUCK=""
+    INSTALL_ROLLBACK_RESTORED=""
+    INSTALL_XATTR_UNCHECKED=""
     INSTALL_SELINUX_FROM=""
 
     tmp="$(mktemp -d)" || die "cannot create a private working directory"
@@ -107,7 +109,13 @@ main() {
     # And say so when the rollback itself could not finish. A signal handler
     # that rolls back and exits in silence leaves a rejected binary live, or
     # the previous one hidden under a random name, with nobody told.
+    #
+    # HUP as well as INT and TERM: an SSH session that drops mid-install
+    # sends HUP, and an untrapped HUP ends the shell WITHOUT running its
+    # EXIT trap (dash, checked) -- the one window the transaction exists to
+    # cover would be left open with nobody there to see it.
     trap 'install_rollback; report_rollback; rm -rf "$tmp"' EXIT
+    trap 'install_rollback; report_rollback; rm -rf "$tmp"; exit 129' HUP
     trap 'install_rollback; report_rollback; rm -rf "$tmp"; exit 130' INT
     trap 'install_rollback; report_rollback; rm -rf "$tmp"; exit 143' TERM
 
@@ -215,6 +223,7 @@ main() {
         # Reported below with the reason; the EXIT trap must not repeat it.
         INSTALL_ROLLBACK_KEPT=""
         INSTALL_ROLLBACK_STUCK=""
+        INSTALL_ROLLBACK_RESTORED=""
         # Undone. Nothing left for the EXIT trap to undo a second time.
         INSTALL_DEST=""
         INSTALL_BACKUP=""
@@ -226,6 +235,9 @@ main() {
             die "the installed $BIN $problem, and the copy that was there before could NOT be put back. It is still on disk: $kept"
         fi
         if [ -n "$had_backup" ]; then
+            if [ -n "$INSTALL_XATTR_UNCHECKED" ]; then
+                die "the installed $BIN $problem; the copy that was there before has been put back -- without any extended attributes it had, which were not checked (getfattr is not installed)"
+            fi
             die "the installed $BIN $problem; the copy that was there before has been put back"
         fi
         die "the installed $BIN $problem; removed it again"
@@ -602,7 +614,7 @@ install_rollback() {
     # what the first pass learned before anyone could report it.
     [ -z "$INSTALL_COMMITTED" ] || return 0
     # Each branch clears what it dealt with. This runs TWICE on a signal --
-    # the INT/TERM handler calls it, then `exit` fires the EXIT handler --
+    # the HUP/INT/TERM handler calls it, then `exit` fires the EXIT handler --
     # and a second pass that still saw a destination but no backup would take
     # the fresh-install branch and delete the binary the first pass had just
     # restored.
@@ -610,6 +622,7 @@ install_rollback() {
         # Something was there before: put it back.
         if [ -n "$INSTALL_DEST" ]; then
             if mv -f "$INSTALL_BACKUP" "$INSTALL_DEST" 2>/dev/null; then
+                INSTALL_ROLLBACK_RESTORED=yes
                 INSTALL_BACKUP=""
                 INSTALL_DEST=""
             else
@@ -659,6 +672,13 @@ report_rollback() {
     if [ -n "$INSTALL_ROLLBACK_KEPT" ]; then
         printf 'error: interrupted, and the previous %s could NOT be put back. It is still on disk: %s\n' "$BIN" "$INSTALL_ROLLBACK_KEPT" >&2
         INSTALL_ROLLBACK_KEPT=""
+    fi
+    # A restore that went through, but of a file whose extended attributes
+    # were never checked: `mv` of the backup carries none, so the previous
+    # copy is back and anything root had set on it -- a capability -- is not.
+    if [ -n "$INSTALL_ROLLBACK_RESTORED" ] && [ -n "$INSTALL_XATTR_UNCHECKED" ]; then
+        printf 'note: interrupted; the previous %s has been put back -- without any extended attributes it had, which were not checked (getfattr is not installed)\n' "$BIN" >&2
+        INSTALL_ROLLBACK_RESTORED=""
     fi
 }
 
@@ -761,13 +781,19 @@ install_binary() {
             # one needs CAP_SETFCAP -- so a binary that has one got it from
             # root, and root is exactly who is replacing it now.
             die "cannot tell whether $dest carries extended attributes such as a file capability, and a rollback could not put those back: getfattr is not installed. Install it (Debian: apt install attr; Alpine: apk add attr), or move the file aside, and run this again."
+        else
+            # Unprivileged and no getfattr: carry on, and say so. Setting a
+            # capability needs root, so one on a user's own binary is
+            # unusual -- but root CAN put one there, and the backup is made
+            # with `cp -p`, which carries mode, owner and times and not
+            # xattrs, so a rollback would hand the binary back without it.
+            # Not a reason to make every ordinary `~/.local/bin` update need
+            # a package a stock GitHub runner does not carry; a reason to say
+            # now, and again if it comes to a rollback, that the previous
+            # copy comes back without them.
+            INSTALL_XATTR_UNCHECKED=yes
+            printf 'note: getfattr is not installed, so extended attributes on %s (a file capability, say) were not checked; if this update is rolled back, the previous copy comes back without them\n' "$dest" >&2
         fi
-        # Unprivileged and no getfattr: carry on. A capability cannot be on
-        # this file unless root put it there, and root replacing it is the
-        # case above. Whatever else a user has attached to their own binary
-        # in their own directory is theirs to lose, and stopping the install
-        # over it would mean every ordinary `~/.local/bin` update needing a
-        # package that a stock GitHub runner does not even carry.
     fi
 
     # A FIFO, socket or device node where the binary goes. `cp -p` reading a

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -275,33 +275,50 @@ assert_safe_dir() {
     dir="$1"
     [ -d "$dir" ] || return 0
 
+    # Follow the path to the directory it really is, first. `ls -ld` on a
+    # symlink describes the LINK -- mode `lrwxrwxrwx`, owned by whoever made
+    # it -- which says nothing about where the install lands, and would let
+    # `--install-dir /some/link` sail past both checks below. `cd` + `pwd -P`
+    # is the portable resolution; `readlink -f` is GNU.
+    resolved="$(cd "$dir" 2>/dev/null && pwd -P)" || resolved=""
+    [ -n "$resolved" ] || return 0
+
     # `ls -ld` rather than stat: stat's flags differ between GNU and BSD, and
     # this has to run under BusyBox too.
-    listing="$(ls -ld "$dir" 2>/dev/null)" || return 0
+    listing="$(ls -ld "$resolved" 2>/dev/null)" || return 0
     [ -n "$listing" ] || return 0
     perms="$(printf %s "$listing" | cut -c1-10)"
     owner="$(printf %s "$listing" | awk '{print $3}')"
 
-    # Anything that is not a mode string is not something to guess from.
+    # Anything that is not a directory mode is not something to guess from.
     case "$perms" in
         d?????????) ;;
         *) return 0 ;;
     esac
 
+    me="$(id -un 2>/dev/null)" || me=""
     sticky="$(printf %s "$perms" | cut -c10)"
     other_w="$(printf %s "$perms" | cut -c9)"
 
     if [ "$other_w" = "w" ]; then
         case "$sticky" in
-            t | T) ;;
+            t | T)
+                # Sticky stops OTHER users unlinking entries -- but not the
+                # directory's own owner, who may remove anything inside it.
+                # A world-writable sticky directory belonging to someone else
+                # is therefore still theirs to tamper with.
+                if [ -n "$owner" ] && [ "$owner" != "root" ] && [ "$owner" != "$me" ]; then
+                    die "$resolved is world-writable and owned by $owner, who may replace files in it even with the sticky bit set. Install somewhere you control: --install-dir \$HOME/.local/bin"
+                fi
+                ;;
             *)
-                die "$dir is writable by anyone and has no sticky bit, so another user could replace the binary between staging and running it. Install somewhere you control: --install-dir \$HOME/.local/bin"
+                die "$resolved is writable by anyone and has no sticky bit, so another user could replace the binary between staging and running it. Install somewhere you control: --install-dir \$HOME/.local/bin"
                 ;;
         esac
     fi
 
     if [ "$(id -u)" = "0" ] && [ -n "$owner" ] && [ "$owner" != "root" ]; then
-        die "$dir belongs to $owner, and installing there as root would let $owner substitute the file being installed. Install it somewhere root owns, or run as $owner without sudo."
+        die "$resolved belongs to $owner, and installing there as root would let $owner substitute the file being installed. Install it somewhere root owns, or run as $owner without sudo."
     fi
 }
 

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -1,14 +1,17 @@
 #!/bin/sh
 # Install srelens-tui on Linux.
 #
-#   curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/install.sh -o srelens-install.sh &&
-#     sh srelens-install.sh &&
-#     rm srelens-install.sh
+#   ( f="$(mktemp)" && trap 'rm -f "$f"' EXIT &&
+#     curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/install.sh -o "$f" &&
+#     sh "$f" )
 #
-# Download-then-run, chained, rather than piping into sh: a pipeline reports
-# the status of its LAST command, so a download that 404s hands sh an empty
-# script, which does nothing and exits 0. The line then succeeds having
-# installed nothing, and whatever is automating it carries on.
+# Download-then-run rather than piping into sh: a pipeline reports the
+# status of its LAST command, so a download that 404s hands sh an empty
+# script, which does nothing and exits 0 -- the line succeeds having
+# installed nothing. mktemp rather than a fixed name: in a directory another
+# account can write, a fixed name can be pre-created as a symlink for
+# `curl -o` to truncate through. And a trap rather than a trailing `; rm`,
+# which would make the cleanup's status the line's status.
 #
 # Everything is inside main(), called on the very last line. A script read
 # from a pipe is executed as it arrives, so a connection that dies halfway
@@ -666,9 +669,15 @@ install_binary() {
     if [ -e "$dest" ]; then
         # An extended ACL. getfacl is already required by the destination
         # checks, so this costs nothing extra.
-        if command -v getfacl >/dev/null 2>&1 &&
-            [ -n "$(getfacl --skip-base --omit-header "$dest" 2>/dev/null)" ]; then
-            die "$dest carries an extended ACL, which a rollback could not put back. Remove the ACL, or move the file aside, and run this again."
+        if command -v getfacl >/dev/null 2>&1; then
+            # Status first, as with every other lookup in this file: a
+            # getfacl that cannot read this file produces empty output, which
+            # is indistinguishable from a file with no ACL.
+            dest_acl="$(getfacl --skip-base --omit-header "$dest" 2>/dev/null)" ||
+                die "cannot read the ACL of $dest, so a rollback could not account for it. Check with: getfacl $dest"
+            if [ -n "$dest_acl" ]; then
+                die "$dest carries an extended ACL, which a rollback could not put back. Remove the ACL, or move the file aside, and run this again."
+            fi
         fi
 
         # Everything else in the xattr namespace -- a file capability above

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -86,6 +86,7 @@ main() {
     INSTALL_COMMITTED=""
     INSTALL_ROLLBACK_KEPT=""
     INSTALL_ROLLBACK_STUCK=""
+    INSTALL_SELINUX_FROM=""
 
     tmp="$(mktemp -d)" || die "cannot create a private working directory"
     # Covers the error paths too, since `set -e` exits through the trap.
@@ -680,12 +681,45 @@ install_binary() {
         # re-derives anyway, since the rollback copy is created by mktemp in
         # the destination directory and labelled by the same policy.
         if command -v getfattr >/dev/null 2>&1; then
-            kept_attrs="$(getfattr -d -m - "$dest" 2>/dev/null |
-                grep -E '^[a-z_]+\.[a-z_]+' |
-                grep -v '^security\.selinux=' |
-                cut -d= -f1 | tr '\n' ' ')" || kept_attrs=""
+            # Status FIRST, before any filter. In a pipeline the status is
+            # the last command's, so `getfattr | grep | cut | tr` reports on
+            # `tr`, which is delighted by no input -- an implementation that
+            # rejects an option, or an LSM that refuses enumeration, would
+            # read exactly like a file with no attributes.
+            attr_dump="$(getfattr -d -m - "$dest" 2>/dev/null)" ||
+                die "cannot read the extended attributes of $dest, so a rollback could not account for them. Check with: getfattr -d -m - $dest"
+
+            # Every `name=value` line is an attribute. Matching a guessed
+            # shape missed names a namespace happily allows -- `user.0` is
+            # legal, and `[a-z_]` does not match a digit.
+            all_attrs="$(printf %s "$attr_dump" | grep "=" | cut -d= -f1)" || all_attrs=""
+            selinux_label=""
+            kept_attrs=""
+            for attr in $all_attrs; do
+                case "$attr" in
+                    security.selinux) selinux_label=yes ;;
+                    *) kept_attrs="$kept_attrs $attr" ;;
+                esac
+            done
             if [ -n "$kept_attrs" ]; then
-                die "$dest carries extended attributes a rollback could not put back: ${kept_attrs% }. Remove them, or move the file aside, and run this again."
+                die "$dest carries extended attributes a rollback could not put back:$kept_attrs. Remove them, or move the file aside, and run this again."
+            fi
+
+            # An SELinux label is not dropped, it is re-derived -- the backup
+            # inode is created by mktemp in this directory, so policy gives it
+            # the DEFAULT label for the path. That is right for a file that
+            # had the default one and wrong for a file that had been given
+            # something else, and `mv` does not relabel on the way back.
+            #
+            # chcon copies the real one across. Without it, a privileged
+            # update refuses rather than hand back a binary the policy will
+            # treat differently.
+            if [ -n "$selinux_label" ]; then
+                if command -v chcon >/dev/null 2>&1; then
+                    INSTALL_SELINUX_FROM="$dest"
+                elif [ "$(id -u)" = "0" ]; then
+                    die "$dest carries an SELinux context and chcon is not available to copy it onto a rollback copy. Install policycoreutils, or move the file aside, and run this again."
+                fi
             fi
         elif [ "$(id -u)" = "0" ]; then
             # No getfattr, and this is a privileged install. Refuse: the
@@ -782,6 +816,11 @@ install_binary() {
         if ! cp -p "$dest" "$INSTALL_BACKUP" 2>/dev/null; then
             rm -f "$INSTALL_BACKUP" "$staged"
             die "cannot preserve the $BIN already at $dest, so it will not be replaced"
+        fi
+        # While the original is still there to copy it from.
+        if [ -n "$INSTALL_SELINUX_FROM" ]; then
+            chcon --reference="$INSTALL_SELINUX_FROM" "$INSTALL_BACKUP" 2>/dev/null ||
+                die "cannot copy the SELinux context of $dest onto the rollback copy, so $dest will not be replaced"
         fi
         # mktemp makes it 0600; the rollback carries the mode the binary
         # actually had.

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -533,13 +533,25 @@ install_binary() {
     chmod 0755 "$staged"
 
     # Keep whatever is being replaced until the new one has been shown to
-    # run. Alongside it, so the rename below stays on one filesystem.
+    # run. Alongside it, so the restore below stays on one filesystem.
+    #
+    # A LINK, not a rename. Renaming the old binary out of the way first
+    # would unlink the live path, and a crash in the gap between that and
+    # the rename below would leave nothing at the documented path with the
+    # only copy under a hidden random name. A second name for the same
+    # inode leaves the path working throughout, and the `mv` below stays a
+    # single atomic replacement.
     INSTALL_BACKUP=""
     if [ -e "$dest" ]; then
-        INSTALL_BACKUP="$(mktemp "$dir/.$BIN.backup.XXXXXX")" || INSTALL_BACKUP=""
-        if [ -n "$INSTALL_BACKUP" ] && ! mv -f "$dest" "$INSTALL_BACKUP"; then
-            rm -f "$INSTALL_BACKUP"
-            INSTALL_BACKUP=""
+        INSTALL_BACKUP="$(mktemp "$dir/.$BIN.backup.XXXXXX")" ||
+            die "cannot create a rollback file in $dir, so $dest will not be replaced"
+        # mktemp made the file; link over it. `cp` is the fallback for a
+        # filesystem that will not hard-link.
+        rm -f "$INSTALL_BACKUP"
+        if ! ln "$dest" "$INSTALL_BACKUP" 2>/dev/null &&
+            ! cp "$dest" "$INSTALL_BACKUP"; then
+            rm -f "$INSTALL_BACKUP" "$staged"
+            die "cannot preserve the $BIN already at $dest, so it will not be replaced"
         fi
     fi
 

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -86,6 +86,13 @@ main() {
     # install. A parent someone else owns can rename the tree after the
     # checksum passes and put their own binary where the verified one was,
     # to be run at the version check below.
+    #
+    # Canonicalised BEFORE the walk and kept, not resolved for inspection
+    # and then discarded: every download, extraction and copy below reopens
+    # $tmp by name, so approving one path and working through another would
+    # leave a symlink in TMPDIR repointable the moment after it passed.
+    tmp="$(cd "$tmp" 2>/dev/null && pwd -P)" ||
+        die "cannot resolve the working directory"
     assert_safe_dir "$tmp"
 
     archive="$BIN-$version-$target.tar.gz"
@@ -134,10 +141,20 @@ main() {
     # Not inside `say`. A failure in a command substitution there is
     # swallowed: the install printed `Installed` and exited 0 while the
     # binary was never in place.
-    installed_version="$("$install_dir/$BIN" --version 2>/dev/null)" || {
+    if installed_version="$("$install_dir/$BIN" --version 2>/dev/null)"; then
+        # It runs. The copy that was there before is no longer needed.
+        [ -z "$INSTALL_BACKUP" ] || rm -f "$INSTALL_BACKUP"
+    else
+        # It does not. Put back whatever was there rather than leaving the
+        # caller with nothing -- on a noexec working directory this is the
+        # first time the binary could be run at all, so an incompatible
+        # release reaches here having already replaced a copy that worked.
         rm -f "$install_dir/$BIN"
-        die "installed $install_dir/$BIN but it does not run; removed it again"
-    }
+        if [ -n "$INSTALL_BACKUP" ] && mv -f "$INSTALL_BACKUP" "$install_dir/$BIN"; then
+            die "the installed $BIN does not run on this machine; the copy that was there before has been put back"
+        fi
+        die "the installed $BIN does not run on this machine; removed it again"
+    fi
     say "Installed: $install_dir/$BIN"
     say "  $installed_version"
     warn_if_not_on_path "$install_dir"
@@ -426,7 +443,14 @@ assert_component() {
             die "$path is writable by the group $group, whose members could replace the binary between staging and running it. Choose a path you control: --install-dir \$HOME/.local/bin"
         fi
         if command -v getent >/dev/null 2>&1; then
-            entry="$(getent group "$group" 2>/dev/null)" || entry=""
+            # A lookup that FAILS is not a group with nobody in it. An NSS
+            # or LDAP hiccup would otherwise produce an empty entry, whose
+            # empty member list and empty GID then skip both checks below
+            # and accept the directory.
+            entry="$(getent group "$group" 2>/dev/null)" ||
+                die "cannot look up the group $group, so who can write to $path is unknown. Choose a path that is not group-writable: --install-dir \$HOME/.local/bin"
+            [ -n "$entry" ] ||
+                die "the group $group does not resolve, so who can write to $path is unknown. Choose a path that is not group-writable: --install-dir \$HOME/.local/bin"
             members="$(printf %s "$entry" | cut -d: -f4)"
             if [ -n "$members" ] && [ "$members" != "$owner" ]; then
                 die "$path is writable by the group $group, which has members besides $owner ($members). Any of them could replace the binary between staging and running it. Choose a path you control: --install-dir \$HOME/.local/bin"
@@ -487,8 +511,21 @@ install_binary() {
         die "cannot write to $dir"
     }
     chmod 0755 "$staged"
+
+    # Keep whatever is being replaced until the new one has been shown to
+    # run. Alongside it, so the rename below stays on one filesystem.
+    INSTALL_BACKUP=""
+    if [ -e "$dest" ]; then
+        INSTALL_BACKUP="$(mktemp "$dir/.$BIN.backup.XXXXXX")" || INSTALL_BACKUP=""
+        if [ -n "$INSTALL_BACKUP" ] && ! mv -f "$dest" "$INSTALL_BACKUP"; then
+            rm -f "$INSTALL_BACKUP"
+            INSTALL_BACKUP=""
+        fi
+    fi
+
     mv -f "$staged" "$dest" || {
         rm -f "$staged"
+        [ -z "$INSTALL_BACKUP" ] || mv -f "$INSTALL_BACKUP" "$dest" 2>/dev/null || true
         die "cannot replace $dest"
     }
 }

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -103,9 +103,13 @@ main() {
     # before the new binary has been run leaves an unvalidated copy live and
     # the old one hidden under a random name -- and on a noexec working
     # directory that window covers the only time the binary is ever checked.
-    trap 'install_rollback; rm -rf "$tmp"' EXIT
-    trap 'install_rollback; rm -rf "$tmp"; exit 130' INT
-    trap 'install_rollback; rm -rf "$tmp"; exit 143' TERM
+    #
+    # And say so when the rollback itself could not finish. A signal handler
+    # that rolls back and exits in silence leaves a rejected binary live, or
+    # the previous one hidden under a random name, with nobody told.
+    trap 'install_rollback; report_rollback; rm -rf "$tmp"' EXIT
+    trap 'install_rollback; report_rollback; rm -rf "$tmp"; exit 130' INT
+    trap 'install_rollback; report_rollback; rm -rf "$tmp"; exit 143' TERM
 
     # The same walk the destination gets. `mktemp -d` makes the directory
     # itself 0700 and ours, but it puts it under $TMPDIR when that is set --
@@ -208,6 +212,9 @@ main() {
         install_rollback
         kept="$INSTALL_ROLLBACK_KEPT"
         stuck="$INSTALL_ROLLBACK_STUCK"
+        # Reported below with the reason; the EXIT trap must not repeat it.
+        INSTALL_ROLLBACK_KEPT=""
+        INSTALL_ROLLBACK_STUCK=""
         # Undone. Nothing left for the EXIT trap to undo a second time.
         INSTALL_DEST=""
         INSTALL_BACKUP=""
@@ -589,8 +596,10 @@ assert_component() {
 # what was not. Idempotent on purpose: the failure paths in main do the same
 # work, and whichever gets there first leaves nothing for the other.
 install_rollback() {
-    INSTALL_ROLLBACK_KEPT=""
-    INSTALL_ROLLBACK_STUCK=""
+    # KEPT and STUCK are NOT reset here. This runs twice on a signal -- the
+    # handler, then EXIT -- and the second pass finds the transaction already
+    # cleared and does nothing; resetting them on the way in would erase
+    # what the first pass learned before anyone could report it.
     [ -z "$INSTALL_COMMITTED" ] || return 0
     # Each branch clears what it dealt with. This runs TWICE on a signal --
     # the INT/TERM handler calls it, then `exit` fires the EXIT handler --
@@ -634,6 +643,22 @@ install_rollback() {
     if [ -n "$INSTALL_STAGED" ]; then
         rm -f "$INSTALL_STAGED"
         INSTALL_STAGED=""
+    fi
+}
+
+# What an interrupted or failed rollback left behind, said out loud.
+#
+# main's own failure path says this itself, with the reason the binary was
+# rejected, and then clears both so this does not repeat it. The handlers
+# have no such message of their own, so this is theirs.
+report_rollback() {
+    if [ -n "$INSTALL_ROLLBACK_STUCK" ]; then
+        printf 'error: interrupted, and the unvalidated %s could NOT be removed. It is still installed at %s -- delete it before running %s from there\n' "$BIN" "$INSTALL_ROLLBACK_STUCK" "$BIN" >&2
+        INSTALL_ROLLBACK_STUCK=""
+    fi
+    if [ -n "$INSTALL_ROLLBACK_KEPT" ]; then
+        printf 'error: interrupted, and the previous %s could NOT be put back. It is still on disk: %s\n' "$BIN" "$INSTALL_ROLLBACK_KEPT" >&2
+        INSTALL_ROLLBACK_KEPT=""
     fi
 }
 

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -687,9 +687,19 @@ install_binary() {
             if [ -n "$kept_attrs" ]; then
                 die "$dest carries extended attributes a rollback could not put back: ${kept_attrs% }. Remove them, or move the file aside, and run this again."
             fi
-        else
+        elif [ "$(id -u)" = "0" ]; then
+            # No getfattr, and this is a privileged install. Refuse: the
+            # attribute worth caring about is a file capability, and setting
+            # one needs CAP_SETFCAP -- so a binary that has one got it from
+            # root, and root is exactly who is replacing it now.
             die "cannot tell whether $dest carries extended attributes such as a file capability, and a rollback could not put those back: getfattr is not installed. Install it (Debian: apt install attr; Alpine: apk add attr), or move the file aside, and run this again."
         fi
+        # Unprivileged and no getfattr: carry on. A capability cannot be on
+        # this file unless root put it there, and root replacing it is the
+        # case above. Whatever else a user has attached to their own binary
+        # in their own directory is theirs to lose, and stopping the install
+        # over it would mean every ordinary `~/.local/bin` update needing a
+        # package that a stock GitHub runner does not even carry.
     fi
 
     # A FIFO, socket or device node where the binary goes. `cp -p` reading a

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -523,6 +523,15 @@ install_binary() {
     if [ -d "$dest" ]; then
         die "$dest is a directory, so a binary cannot be installed at that path. Remove it and run this again."
     fi
+
+    # And a symlink cannot be replaced faithfully. The rollback copy is
+    # taken by reading $dest, which follows the link and stores its target's
+    # bytes -- so a restore would put a regular file where a link had been,
+    # silently breaking whatever arrangement the link was part of while
+    # reporting that the previous copy was put back.
+    if [ -L "$dest" ]; then
+        die "$dest is a symlink. Install over what it points at, or remove it first: this replaces the path itself and could not put the link back if the new binary failed."
+    fi
     # Already created, checked and canonicalised by prepare_install_dir and
     # assert_safe_dir. Deliberately not re-derived from $dest here.
     dir="$INSTALL_DIR"
@@ -572,7 +581,13 @@ install_binary() {
         # when the install is under sudo. The destination rules make a
         # planted binary hard to arrange; refusing to propagate the bit at
         # all means it does not matter if one ever is.
-        dest_mode="$(printf %s "$dest_mode" | sed 's/^.*(...)$//')"
+        # stat renders a set-ID bit as a fourth digit; drop it. `case`
+        # rather than sed, because the regex this used to be was mangled
+        # into literal parentheses and a control byte, matched nothing,
+        # and stripped nothing -- while looking like it did.
+        case "$dest_mode" in
+            ????) dest_mode="${dest_mode#?}" ;;
+        esac
         INSTALL_BACKUP="$(mktemp "$dir/.$BIN.backup.XXXXXX")" || {
             rm -f "$staged"
             die "cannot create a rollback file in $dir, so $dest will not be replaced"

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -155,22 +155,46 @@ main() {
     # Not inside `say`. A failure in a command substitution there is
     # swallowed: the install printed `Installed` and exited 0 while the
     # binary was never in place.
-    if installed_version="$("$install_dir/$BIN" --version 2>/dev/null)"; then
-        # It runs. That is the commit: the copy that was there before is no
-        # longer needed, and the traps stop trying to undo anything.
+    # Two questions, and a different answer for each, because a binary that
+    # will not run and a binary that is the wrong version are different
+    # problems for whoever is reading the output.
+    installed_version="$("$install_dir/$BIN" --version 2>/dev/null)" || installed_version=""
+    if [ -z "$installed_version" ]; then
+        problem="does not run on this machine"
+    else
+        problem=""
+        # Running is not enough: it has to be the version that was asked for.
+        # A release that published a stale binary under the right asset name
+        # and checksum would otherwise install silently, and a pinned
+        # `--version` would report success having produced a different one.
+        case "$installed_version" in
+            *"$version"*) ;;
+            *) problem="reports \"$installed_version\", not the $version that was asked for" ;;
+        esac
+    fi
+
+    if [ -z "$problem" ]; then
+        # That is the commit: the copy that was there before is no longer
+        # needed, and the traps stop trying to undo anything.
         INSTALL_COMMITTED=yes
         INSTALL_STAGED=""
         [ -z "$INSTALL_BACKUP" ] || rm -f "$INSTALL_BACKUP"
     else
-        # It does not. Put back whatever was there rather than leaving the
-        # caller with nothing -- on a noexec working directory this is the
-        # first time the binary could be run at all, so an incompatible
-        # release reaches here having already replaced a copy that worked.
-        rm -f "$install_dir/$BIN"
-        if [ -n "$INSTALL_BACKUP" ] && mv -f "$INSTALL_BACKUP" "$install_dir/$BIN"; then
-            die "the installed $BIN does not run on this machine; the copy that was there before has been put back"
+        # One place decides what undoing an uncommitted install means, and it
+        # is install_rollback -- doing it again here is how the restored copy
+        # got deleted by the trap afterwards. This asks for it, then says what
+        # happened.
+        had_backup=""
+        [ -z "$INSTALL_BACKUP" ] || had_backup=yes
+        install_rollback
+        # Undone. Nothing left for the EXIT trap to undo a second time.
+        INSTALL_DEST=""
+        INSTALL_BACKUP=""
+        INSTALL_STAGED=""
+        if [ -n "$had_backup" ]; then
+            die "the installed $BIN $problem; the copy that was there before has been put back"
         fi
-        die "the installed $BIN does not run on this machine; removed it again"
+        die "the installed $BIN $problem; removed it again"
     fi
     say "Installed: $install_dir/$BIN"
     say "  $installed_version"
@@ -540,12 +564,19 @@ assert_component() {
 install_rollback() {
     [ -z "$INSTALL_COMMITTED" ] || return 0
     if [ -n "$INSTALL_BACKUP" ] && [ -e "$INSTALL_BACKUP" ]; then
+        # Something was there before: put it back.
         if [ -n "$INSTALL_DEST" ]; then
             mv -f "$INSTALL_BACKUP" "$INSTALL_DEST" 2>/dev/null ||
                 rm -f "$INSTALL_BACKUP"
         else
             rm -f "$INSTALL_BACKUP"
         fi
+    elif [ -n "$INSTALL_DEST" ]; then
+        # Nothing was there before, so the binary at that path is one this
+        # run put there and never got to run. On a noexec working directory
+        # it has been executed by nobody at all, and leaving it is leaving an
+        # unchecked binary on someone's PATH under a name they will trust.
+        rm -f "$INSTALL_DEST"
     fi
     [ -z "$INSTALL_STAGED" ] || rm -f "$INSTALL_STAGED"
 }
@@ -578,6 +609,14 @@ install_binary() {
     if [ -e "$dest" ] && command -v getfacl >/dev/null 2>&1 &&
         [ -n "$(getfacl --skip-base --omit-header "$dest" 2>/dev/null)" ]; then
         die "$dest carries an extended ACL, which a rollback could not put back. Remove the ACL, or move the file aside, and run this again."
+    fi
+
+    # A FIFO, socket or device node where the binary goes. `cp -p` reading a
+    # FIFO waits for a writer that never comes, and a device node reads
+    # whatever the device feels like -- neither is something to copy, and
+    # neither is a binary to replace.
+    if [ -e "$dest" ] && [ ! -f "$dest" ] && [ ! -L "$dest" ]; then
+        die "$dest is not a regular file, so it is not a binary this can replace. Move it aside and run this again."
     fi
 
     if [ -L "$dest" ]; then

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -807,6 +807,25 @@ install_binary() {
     if [ -L "$dest" ]; then
         die "$dest is a symlink. Install over what it points at, or remove it first: this replaces the path itself and could not put the link back if the new binary failed."
     fi
+    # A second hard link to it, for the same reason. The backup is a copy
+    # into a fresh inode, so a rollback would put back a file the other
+    # name is no longer attached to: the sibling keeps the old inode, the
+    # restored path gets a new one, and from then on the two diverge --
+    # while the installer had reported the previous copy put back. Status
+    # first, as with every lookup here: a stat that fails looks like an
+    # empty count.
+    if [ -f "$dest" ]; then
+        dest_links="$(stat -c %h "$dest" 2>/dev/null)" ||
+            die "cannot read the link count of $dest, so a rollback could not be promised to put it back. Check with: stat -c %h $dest"
+        case "$dest_links" in
+            ''|*[!0-9]*)
+                die "cannot read the link count of $dest, so a rollback could not be promised to put it back. Check with: stat -c %h $dest"
+                ;;
+        esac
+        if [ "$dest_links" -gt 1 ]; then
+            die "$dest has $dest_links hard links. A rollback restores a copy, not the shared inode, so the other name(s) would be left pointing at the old file. Remove the extra links, or move the file aside, and run this again."
+        fi
+    fi
     # Already created, checked and canonicalised by prepare_install_dir and
     # assert_safe_dir. Deliberately not re-derived from $dest here.
     dir="$INSTALL_DIR"

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -112,14 +112,34 @@ main() {
     # Run it before it is installed, not after. A binary for the wrong
     # architecture or a corrupt one that still hashed correctly fails here,
     # while the only thing that has happened is a write to a temp dir.
-    "$tmp/unpack/$BIN" --version >/dev/null 2>&1 ||
-        die "the downloaded binary does not run on this machine"
+    #
+    # Unless this filesystem forbids running anything at all. A hardened
+    # host mounts /tmp `noexec`, and mktemp puts the working tree there, so
+    # a check that assumed otherwise would report every good binary as
+    # broken. Probed with a script of our own rather than assumed either
+    # way; when it cannot be done here, the same check runs after the
+    # install instead, from the destination.
+    printf '#!/bin/sh\nexit 0\n' > "$tmp/exec-probe"
+    chmod 0755 "$tmp/exec-probe"
+    if "$tmp/exec-probe" 2>/dev/null; then
+        "$tmp/unpack/$BIN" --version >/dev/null 2>&1 ||
+            die "the downloaded binary does not run on this machine"
+    else
+        say "Note: $tmp is mounted noexec, so the binary is checked after it is installed."
+    fi
 
     install_binary "$tmp/unpack/$BIN" "$install_dir/$BIN"
 
     say ""
+    # Not inside `say`. A failure in a command substitution there is
+    # swallowed: the install printed `Installed` and exited 0 while the
+    # binary was never in place.
+    installed_version="$("$install_dir/$BIN" --version 2>/dev/null)" || {
+        rm -f "$install_dir/$BIN"
+        die "installed $install_dir/$BIN but it does not run; removed it again"
+    }
     say "Installed: $install_dir/$BIN"
-    say "  $("$install_dir/$BIN" --version)"
+    say "  $installed_version"
     warn_if_not_on_path "$install_dir"
     say ""
     say "Next: $BIN            # browse the cluster in your current context"
@@ -441,6 +461,15 @@ assert_component() {
 install_binary() {
     src="$1"
     dest="$2"
+
+    # `mv file dir` moves the file INTO the directory rather than over it,
+    # so a destination that is already a directory -- or a link to one --
+    # would leave the staging file inside it and nothing at the path the
+    # caller asked for. `mv -T` says otherwise but is GNU-only, and this
+    # has to run under BusyBox.
+    if [ -d "$dest" ]; then
+        die "$dest is a directory, so a binary cannot be installed at that path. Remove it, or choose another --install-dir."
+    fi
     # Already created, checked and canonicalised by prepare_install_dir and
     # assert_safe_dir. Deliberately not re-derived from $dest here.
     dir="$INSTALL_DIR"

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -1,0 +1,264 @@
+#!/bin/sh
+# Install srelens-tui on Linux.
+#
+#   curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/install.sh | sh
+#
+# Everything is inside main(), called on the very last line. A script read
+# from a pipe is executed as it arrives, so a connection that dies halfway
+# through would otherwise run whatever fragment made it — with the function
+# wrapper, a truncated download is a syntax error that does nothing.
+#
+# POSIX sh, not bash: this has to work under dash on Debian and under
+# BusyBox ash on Alpine, both of which are `/bin/sh` on machines people
+# actually run.
+set -eu
+
+REPO="srelens/srelens"
+BIN="srelens-tui"
+
+main() {
+    version=""
+    install_dir=""
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --version)
+                version="${2:-}"
+                [ -n "$version" ] || die "--version needs a value, e.g. --version 0.9.0"
+                shift 2
+                ;;
+            --version=*)
+                version="${1#--version=}"
+                shift
+                ;;
+            --install-dir)
+                install_dir="${2:-}"
+                [ -n "$install_dir" ] || die "--install-dir needs a value"
+                shift 2
+                ;;
+            --install-dir=*)
+                install_dir="${1#--install-dir=}"
+                shift
+                ;;
+            -h | --help)
+                usage
+                return 0
+                ;;
+            *)
+                die "unknown option: $1 (try --help)"
+                ;;
+        esac
+    done
+
+    check_platform
+    need curl
+    need tar
+    sha_tool="$(find_sha_tool)"
+
+    target="$(detect_target)"
+    [ -n "$version" ] || version="$(latest_version)"
+    # Tolerate a tag or a leading v: people paste both.
+    version="${version#srelens-v}"
+    version="${version#v}"
+
+    install_dir="$(resolve_install_dir "$install_dir")"
+
+    say "Installing $BIN $version ($target) into $install_dir"
+
+    tmp="$(mktemp -d)"
+    # Covers the error paths too, since `set -e` exits through the trap.
+    trap 'rm -rf "$tmp"' EXIT INT TERM
+
+    archive="$BIN-$version-$target.tar.gz"
+    base="https://github.com/$REPO/releases/download/srelens-v$version"
+
+    download "$base/$archive" "$tmp/$archive"
+    download "$base/$BIN-$version-SHA256SUMS.txt" "$tmp/SHA256SUMS.txt"
+    verify_checksum "$tmp" "$archive" "$sha_tool"
+
+    tar -xzf "$tmp/$archive" -C "$tmp"
+    [ -f "$tmp/$BIN" ] || die "the archive did not contain $BIN"
+    chmod 0755 "$tmp/$BIN"
+
+    # Run it before it is installed, not after. A binary for the wrong
+    # architecture or a corrupt one that still hashed correctly fails here,
+    # while the only thing that has happened is a write to a temp dir.
+    "$tmp/$BIN" --version >/dev/null 2>&1 ||
+        die "the downloaded binary does not run on this machine"
+
+    install_binary "$tmp/$BIN" "$install_dir/$BIN"
+
+    say ""
+    say "Installed: $install_dir/$BIN"
+    say "  $("$install_dir/$BIN" --version)"
+    warn_if_not_on_path "$install_dir"
+    say ""
+    say "Next: $BIN            # browse the cluster in your current context"
+    say "      $BIN toolbox    # what it found on your PATH (kubectl, helm)"
+    say "      $BIN update     # move to a newer release later"
+}
+
+usage() {
+    cat <<EOF
+Install $BIN, the srelens terminal UI, on Linux.
+
+Usage:
+  install.sh [--version <x.y.z>] [--install-dir <path>]
+
+Options:
+  --version <x.y.z>     Install this version instead of the latest stable.
+  --install-dir <path>  Install here instead of $(printf '%s' '/usr/local/bin, or ~/.local/bin when that is not writable').
+  -h, --help            Show this message.
+
+The binary is the statically linked musl build, so it does not care which
+libc or which distribution is on the machine. Its SHA-256 is checked against
+the release's published SHA256SUMS before anything is installed.
+
+On macOS use Homebrew instead:  brew install srelens/tap/$BIN
+EOF
+}
+
+say() { printf '%s\n' "$*"; }
+
+die() {
+    printf 'error: %s\n' "$*" >&2
+    exit 1
+}
+
+need() {
+    command -v "$1" >/dev/null 2>&1 || die "$1 is required but not installed"
+}
+
+# sha256sum on most distributions, shasum where coreutils is not the one in
+# use. Refusing to install without one is deliberate: installing an unverified
+# binary quietly would defeat the point of publishing checksums at all.
+find_sha_tool() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        printf 'sha256sum'
+    elif command -v shasum >/dev/null 2>&1; then
+        printf 'shasum'
+    else
+        die "neither sha256sum nor shasum found; cannot verify the download"
+    fi
+}
+
+check_platform() {
+    os="$(uname -s)"
+    case "$os" in
+        Linux) ;;
+        Darwin)
+            die "this script is for Linux. On macOS: brew install srelens/tap/$BIN"
+            ;;
+        *)
+            die "unsupported operating system: $os"
+            ;;
+    esac
+}
+
+# Always the static musl build, never the glibc one.
+#
+# The glibc archives are built on ubuntu-22.04 and ubuntu-24.04-arm, so they
+# carry a floor of glibc 2.35 and 2.39 — newer than Debian 11, RHEL 9 or any
+# LTS a fair number of clusters are administered from. A dynamically linked
+# binary fails there before main() with a GLIBC_2.3x symbol error that tells
+# the reader nothing. The static build has no floor at all, and musl's
+# slower allocator and narrower resolver do not matter to a client that
+# spends its life waiting on an API server.
+detect_target() {
+    arch="$(uname -m)"
+    case "$arch" in
+        x86_64 | amd64) printf 'x86_64-unknown-linux-musl' ;;
+        aarch64 | arm64) printf 'aarch64-unknown-linux-musl' ;;
+        *) die "unsupported architecture: $arch (x86_64 and aarch64 are published)" ;;
+    esac
+}
+
+latest_version() {
+    # The tags are `srelens-v1.2.3`, so the version is what follows the v.
+    tag="$(
+        curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" |
+            sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' |
+            head -n 1
+    )" || die "could not reach the GitHub API to find the latest release"
+    [ -n "$tag" ] || die "could not determine the latest release"
+    printf '%s' "${tag#srelens-v}"
+}
+
+# /usr/local/bin when it is writable, ~/.local/bin otherwise.
+#
+# No sudo. A script fetched over the network re-invoking itself as root is
+# exactly the pattern people are right to be nervous about, and the fallback
+# needs no privileges at all. Anyone who wants it system-wide can say so:
+#   curl ... | sudo sh
+resolve_install_dir() {
+    if [ -n "$1" ]; then
+        printf '%s' "$1"
+        return
+    fi
+    if [ -w /usr/local/bin ] 2>/dev/null; then
+        printf '/usr/local/bin'
+    else
+        printf '%s/.local/bin' "$HOME"
+    fi
+}
+
+download() {
+    curl -fsSL --proto '=https' --tlsv1.2 -o "$2" "$1" ||
+        die "download failed: $1"
+}
+
+verify_checksum() {
+    dir="$1"
+    file="$2"
+    tool="$3"
+
+    expected="$(
+        grep "  $file\$" "$dir/SHA256SUMS.txt" 2>/dev/null |
+            head -n 1 | cut -d' ' -f1
+    )" || true
+    [ -n "$expected" ] ||
+        die "$file is not listed in the release's SHA256SUMS"
+
+    actual="$(cd "$dir" && "$tool" "$file" | cut -d' ' -f1)"
+
+    if [ "$expected" != "$actual" ]; then
+        printf 'error: checksum mismatch for %s\n' "$file" >&2
+        printf '  expected %s\n' "$expected" >&2
+        printf '  actual   %s\n' "$actual" >&2
+        die "refusing to install"
+    fi
+    say "Checksum verified: $actual"
+}
+
+# Install by rename where possible: a running binary being overwritten in
+# place gets ETXTBSY on Linux, while replacing the directory entry does not
+# disturb a process already holding the old inode.
+install_binary() {
+    src="$1"
+    dest="$2"
+    dir="$(dirname "$dest")"
+
+    mkdir -p "$dir" 2>/dev/null ||
+        die "cannot create $dir"
+    [ -w "$dir" ] ||
+        die "$dir is not writable. Re-run with --install-dir <somewhere you own>, or with sudo."
+
+    staged="$dir/.$BIN.install.$$"
+    cp "$src" "$staged" || die "cannot write to $dir"
+    chmod 0755 "$staged"
+    mv -f "$staged" "$dest" || {
+        rm -f "$staged"
+        die "cannot replace $dest"
+    }
+}
+
+warn_if_not_on_path() {
+    case ":${PATH}:" in
+        *":$1:"*) return 0 ;;
+    esac
+    say ""
+    say "Note: $1 is not on your PATH. Add it:"
+    say "      export PATH=\"$1:\$PATH\""
+}
+
+main "$@"

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -65,9 +65,11 @@ main() {
     # uses. Before the download, so an unwritable destination costs nothing.
     prepare_install_dir "$install_dir"
     install_dir="$INSTALL_DIR"
-    assert_safe_dir "$install_dir"
-
+    # Named before it is judged: a refusal should say which directory it is
+    # about, and the answer is not always the obvious one now that an
+    # unsafe /usr/local/bin falls back to the home directory.
     say "Installing $BIN $version ($target) into $install_dir"
+    assert_safe_dir "$install_dir"
 
     tmp="$(mktemp -d)" || die "cannot create a private working directory"
     # Covers the error paths too, since `set -e` exits through the trap.
@@ -277,7 +279,19 @@ latest_version() {
 # needs no privileges at all. Anyone who wants it system-wide can say so:
 #   curl ... | sudo sh
 resolve_install_dir() {
-    if [ -w /usr/local/bin ] 2>/dev/null; then
+    # Writable is not the same as safe. A GitHub runner ships
+    # /usr/local/bin world-writable, and plenty of images do something
+    # similar -- there the rules below would refuse it, and refusing is the
+    # right answer for THAT directory but the wrong answer for the install:
+    # ~/.local/bin is sitting right there, belongs to the caller, and is
+    # already the fallback for the unwritable case.
+    #
+    # The check runs in a subshell so its `die` ends only that, leaving this
+    # a question rather than a verdict. Whichever directory is chosen is
+    # then checked again for real by the caller, so an unsafe ~/.local/bin
+    # still stops the install rather than being installed into quietly.
+    if [ -w /usr/local/bin ] 2>/dev/null &&
+        (assert_safe_dir /usr/local/bin) >/dev/null 2>&1; then
         printf '/usr/local/bin'
     else
         printf '%s/.local/bin' "$HOME"

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -73,7 +73,15 @@ main() {
 
     tmp="$(mktemp -d)" || die "cannot create a private working directory"
     # Covers the error paths too, since `set -e` exits through the trap.
-    trap 'rm -rf "$tmp"' EXIT INT TERM
+    #
+    # INT and TERM exit explicitly. A handler that only cleans up returns to
+    # where it interrupted, so the script would carry on against a working
+    # directory it had just deleted -- and could reach the end and report
+    # `Installed` after being asked to stop. The EXIT trap then runs a second
+    # time, which `rm -rf` does not mind.
+    trap 'rm -rf "$tmp"' EXIT
+    trap 'rm -rf "$tmp"; exit 130' INT
+    trap 'rm -rf "$tmp"; exit 143' TERM
 
     # The same walk the destination gets. `mktemp -d` makes the directory
     # itself 0700 and ours, but it puts it under $TMPDIR when that is set --

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -76,9 +76,17 @@ main() {
 
     say "Installing $BIN $version ($target) into $install_dir"
 
-    tmp="$(mktemp -d)"
+    tmp="$(mktemp -d)" || die "cannot create a private working directory"
     # Covers the error paths too, since `set -e` exits through the trap.
     trap 'rm -rf "$tmp"' EXIT INT TERM
+
+    # The same walk the destination gets. `mktemp -d` makes the directory
+    # itself 0700 and ours, but it puts it under $TMPDIR when that is set --
+    # and `sudo` can carry the invoking user's TMPDIR straight into a root
+    # install. A parent someone else owns can rename the tree after the
+    # checksum passes and put their own binary where the verified one was,
+    # to be run at the version check below.
+    assert_safe_dir "$tmp"
 
     archive="$BIN-$version-$target.tar.gz"
     base="https://github.com/$REPO/releases/download/srelens-v$version"
@@ -398,9 +406,29 @@ assert_component() {
             die "$path is writable by the group $group, whose members could replace the binary between staging and running it. Choose a path you control: --install-dir \$HOME/.local/bin"
         fi
         if command -v getent >/dev/null 2>&1; then
-            members="$(getent group "$group" 2>/dev/null | cut -d: -f4)" || members=""
+            entry="$(getent group "$group" 2>/dev/null)" || entry=""
+            members="$(printf %s "$entry" | cut -d: -f4)"
             if [ -n "$members" ] && [ "$members" != "$owner" ]; then
                 die "$path is writable by the group $group, which has members besides $owner ($members). Any of them could replace the binary between staging and running it. Choose a path you control: --install-dir \$HOME/.local/bin"
+            fi
+
+            # The member list is only half of a group. An account whose
+            # PRIMARY group this is never appears in it -- `getent group
+            # root` reads `root:x:0:` on a host where another account has
+            # GID 0, while that account can write here perfectly well. So
+            # the passwd table is asked as well.
+            #
+            # Still not a complete answer: `getent passwd` enumerates local
+            # accounts, and an LDAP or SSSD source may decline to be listed
+            # at all. A destination that is not group-writable depends on
+            # none of this.
+            gid="$(printf %s "$entry" | cut -d: -f3)"
+            if [ -n "$gid" ]; then
+                primary="$(getent passwd 2>/dev/null |
+                    awk -F: -v g="$gid" -v o="$owner" '$4 == g && $1 != o { printf "%s ", $1 }')" || primary=""
+                if [ -n "$primary" ]; then
+                    die "$path is writable by the group $group, which is the primary group of ${primary%% }. Any of them could replace the binary between staging and running it. Choose a path you control: --install-dir \$HOME/.local/bin"
+                fi
             fi
         else
             die "$path is group-writable and there is no getent here to establish who is in group $group. Choose a path that is not group-writable: --install-dir \$HOME/.local/bin"

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -306,9 +306,11 @@ assert_safe_dir() {
     # `lrwxrwxrwx`, owned by whoever made it -- which says nothing about where
     # the install lands. `cd` + `pwd -P` is portable; `readlink -f` is GNU.
     resolved="$(cd "$dir" 2>/dev/null && pwd -P)" || resolved=""
-    [ -n "$resolved" ] || return 0
+    [ -n "$resolved" ] ||
+        die "cannot resolve $dir, so nothing can be said about where the install would land"
 
     SAFE_ME="$(id -un 2>/dev/null)" || SAFE_ME=""
+    [ -n "$SAFE_ME" ] || die "cannot determine who is running this"
 
     assert_component "/"
     rest="${resolved#/}"
@@ -330,39 +332,79 @@ assert_component() {
 
     # `ls -ld` rather than stat: stat's flags differ between GNU and BSD, and
     # this has to run under BusyBox too.
-    listing="$(ls -ld "$path" 2>/dev/null)" || return 0
-    [ -n "$listing" ] || return 0
+    # Fail CLOSED. An inspection that does not answer is not an answer: a
+    # directory removed at the moment it is read, and recreated before the
+    # staging file lands, would otherwise walk straight through a check that
+    # silently skipped it.
+    listing="$(ls -ld "$path" 2>/dev/null)" ||
+        die "cannot inspect $path, so it cannot be shown to be safe to install into"
+    [ -n "$listing" ] ||
+        die "cannot inspect $path, so it cannot be shown to be safe to install into"
     perms="$(printf %s "$listing" | cut -c1-10)"
     owner="$(printf %s "$listing" | awk '{print $3}')"
     group="$(printf %s "$listing" | awk '{print $4}')"
 
-    # Anything that is not a directory mode is not something to guess from.
+    # Anything that is not a directory mode is not something to guess from --
+    # and not a reason to proceed either.
     case "$perms" in
         d?????????) ;;
-        *) return 0 ;;
+        *) die "$path is not a directory, so the install path cannot be trusted" ;;
     esac
+
+    # `ls -l` marks an extended ACL with a trailing `+`. An ACL can grant
+    # write to any user while the mode bits look impeccable, and reading one
+    # portably is not something a POSIX shell can do -- getfacl is neither
+    # POSIX nor present on Alpine. Refuse rather than pass a directory whose
+    # real permissions have not been seen.
+    if [ "$(printf %s "$listing" | cut -c11)" = "+" ]; then
+        die "$path carries an extended ACL, which may grant write access that its mode does not show. Check it with: getfacl $path"
+    fi
 
     if [ -n "$owner" ] && [ "$owner" != "root" ] && [ "$owner" != "$SAFE_ME" ]; then
         die "$path belongs to $owner, who could replace what is inside it while this installs. Choose a path you control: --install-dir \$HOME/.local/bin"
     fi
 
+    # The sticky bit settles both write bits at once. With it set, only an
+    # entry's owner may unlink or rename that entry, so who else can write
+    # into the directory stops mattering for anything already staged there.
+    # That is what makes /tmp usable -- and /tmp is `drwxrwxrwt`, group- and
+    # world-writable both, so treating either bit as disqualifying on its own
+    # would refuse every install whose path runs through it.
+    case "$(printf %s "$perms" | cut -c10)" in
+        t | T) return 0 ;;
+    esac
+
     if [ "$(printf %s "$perms" | cut -c9)" = "w" ]; then
-        case "$(printf %s "$perms" | cut -c10)" in
-            t | T) ;;
-            *)
-                die "$path is writable by anyone and has no sticky bit, so another user could replace the binary between staging and running it. Choose a path you control: --install-dir \$HOME/.local/bin"
-                ;;
-        esac
+        die "$path is writable by anyone and has no sticky bit, so another user could replace the binary between staging and running it. Choose a path you control: --install-dir \$HOME/.local/bin"
     fi
 
-    # Group-writable is only safe when the group is the owner's own, which is
-    # the per-user-group convention (`alice:alice`, one member). Distributions
-    # using it leave ~/.local/bin group-writable under a 002 umask, so
-    # refusing that outright would break an ordinary Fedora install; a group
-    # with a different name is a set of people who can all replace the binary.
-    if [ "$(printf %s "$perms" | cut -c6)" = "w" ] &&
-        [ -n "$group" ] && [ "$group" != "$owner" ]; then
-        die "$path is writable by the group $group, whose members could replace the binary between staging and running it. Choose a path you control: --install-dir \$HOME/.local/bin"
+    # Group-writable, without the sticky bit, needs the group to contain
+    # nobody but the owner.
+    #
+    # A name matching the owner's is the per-user-group convention -- Fedora
+    # leaves ~/.local/bin as `alice:alice` 0775 under a 002 umask, and refusing
+    # that would break an ordinary install -- but a convention is not a
+    # guarantee. Nothing stops another account joining group `alice`, and any
+    # member could replace the binary between staging and the moment it runs.
+    # So the membership is looked up rather than assumed.
+    #
+    # What this cannot see: accounts whose PRIMARY group is this one do not
+    # appear in the group's member list, and `getent passwd` will not enumerate
+    # LDAP or SSSD directories anyway. A group-writable destination is the
+    # weakest link here; one that is not group-writable does not depend on any
+    # of it.
+    if [ "$(printf %s "$perms" | cut -c6)" = "w" ]; then
+        if [ -z "$group" ] || [ "$group" != "$owner" ]; then
+            die "$path is writable by the group $group, whose members could replace the binary between staging and running it. Choose a path you control: --install-dir \$HOME/.local/bin"
+        fi
+        if command -v getent >/dev/null 2>&1; then
+            members="$(getent group "$group" 2>/dev/null | cut -d: -f4)" || members=""
+            if [ -n "$members" ] && [ "$members" != "$owner" ]; then
+                die "$path is writable by the group $group, which has members besides $owner ($members). Any of them could replace the binary between staging and running it. Choose a path you control: --install-dir \$HOME/.local/bin"
+            fi
+        else
+            die "$path is group-writable and there is no getent here to establish who is in group $group. Choose a path that is not group-writable: --install-dir \$HOME/.local/bin"
+        fi
     fi
 }
 # Install by rename where possible: a running binary being overwritten in

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -358,9 +358,8 @@ prepare_install_dir() {
 #   * owned by root or by us. Anyone else can replace what is inside it.
 #   * if world-writable, the sticky bit must be set, so only an entry's owner
 #     may unlink it. That is what makes /tmp usable rather than disqualifying.
-#   * if group-writable, the group must be the owner's own -- the per-user
-#     group convention, where `alice:alice` has one member. A shared group is
-#     a set of people who can all replace the binary.
+#   * not group-writable at all, unless sticky. Who is really in a group
+#     cannot be established from a shell -- see the note at that check.
 #
 # The same rule srelens-tui's own `update` applies to the binary it replaces.
 assert_safe_dir() {
@@ -448,69 +447,24 @@ assert_component() {
         die "$path is writable by anyone and has no sticky bit, so another user could replace the binary between staging and running it. Nothing can be installed there safely."
     fi
 
-    # Group-writable, without the sticky bit, needs the group to contain
-    # nobody but the owner.
+    # Group-writable is refused, full stop.
     #
-    # A name matching the owner's is the per-user-group convention -- Fedora
-    # leaves ~/.local/bin as `alice:alice` 0775 under a 002 umask, and refusing
-    # that would break an ordinary install -- but a convention is not a
-    # guarantee. Nothing stops another account joining group `alice`, and any
-    # member could replace the binary between staging and the moment it runs.
-    # So the membership is looked up rather than assumed.
+    # This used to try to establish that the group had nobody in it but the
+    # owner -- the member list, then the passwd table for accounts whose
+    # PRIMARY group it is. Neither can be trusted to be complete: an SSSD or
+    # LDAP source can resolve accounts individually while declining to
+    # enumerate, so `getent passwd` succeeds and returns only what is local.
+    # A remote account in that group is then invisible, and the directory is
+    # accepted for exactly the person it should have been refused for.
     #
-    # What this cannot see: accounts whose PRIMARY group is this one do not
-    # appear in the group's member list, and `getent passwd` will not enumerate
-    # LDAP or SSSD directories anyway. A group-writable destination is the
-    # weakest link here; one that is not group-writable does not depend on any
-    # of it.
+    # The reason for all that machinery was that Fedora supposedly leaves
+    # ~/.local/bin group-writable under a 002 umask. It does not: Fedora 41
+    # sets UMASK 022 in login.defs, /etc/bashrc raises umask only when it is
+    # 0, and a fresh account gets `drwxr-xr-x`. The case being protected was
+    # not real, and it cost thirty-five lines that could not answer the
+    # question anyway.
     if [ "$(printf %s "$perms" | cut -c6)" = "w" ]; then
-        if [ -z "$group" ] || [ "$group" != "$owner" ]; then
-            die "$path is writable by the group $group, whose members could replace the binary between staging and running it. Nothing can be installed there safely."
-        fi
-        if command -v getent >/dev/null 2>&1; then
-            # A lookup that FAILS is not a group with nobody in it. An NSS
-            # or LDAP hiccup would otherwise produce an empty entry, whose
-            # empty member list and empty GID then skip both checks below
-            # and accept the directory.
-            entry="$(getent group "$group" 2>/dev/null)" ||
-                die "cannot look up the group $group, so who can write to $path is unknown. Nothing can be installed there safely."
-            [ -n "$entry" ] ||
-                die "the group $group does not resolve, so who can write to $path is unknown. Nothing can be installed there safely."
-            members="$(printf %s "$entry" | cut -d: -f4)"
-            if [ -n "$members" ] && [ "$members" != "$owner" ]; then
-                die "$path is writable by the group $group, which has members besides $owner ($members). Any of them could replace the binary between staging and running it. Nothing can be installed there safely."
-            fi
-
-            # The member list is only half of a group. An account whose
-            # PRIMARY group this is never appears in it -- `getent group
-            # root` reads `root:x:0:` on a host where another account has
-            # GID 0, while that account can write here perfectly well. So
-            # the passwd table is asked as well.
-            #
-            # Still not a complete answer: `getent passwd` enumerates local
-            # accounts, and an LDAP or SSSD source may decline to be listed
-            # at all. A destination that is not group-writable depends on
-            # none of this.
-            gid="$(printf %s "$entry" | cut -d: -f3)"
-            if [ -n "$gid" ]; then
-                # Captured BEFORE awk sees it. In `getent passwd | awk`,
-                # the status belongs to awk, which succeeds happily on no
-                # input -- so a partial NSS outage would have produced an
-                # empty answer and been read as "nobody else is in this
-                # group". The same fail-open the group lookup above had.
-                accounts="$(getent passwd 2>/dev/null)" ||
-                    die "cannot enumerate accounts, so who else is in the group $group is unknown. Nothing can be installed there safely."
-                [ -n "$accounts" ] ||
-                    die "no accounts could be listed, so who else is in the group $group is unknown. Nothing can be installed there safely."
-                primary="$(printf %s "$accounts" |
-                    awk -F: -v g="$gid" -v o="$owner" '$4 == g && $1 != o { printf "%s ", $1 }')" || primary=""
-                if [ -n "$primary" ]; then
-                    die "$path is writable by the group $group, which is the primary group of ${primary%% }. Any of them could replace the binary between staging and running it. Nothing can be installed there safely."
-                fi
-            fi
-        else
-            die "$path is group-writable and there is no getent here to establish who is in group $group. Nothing can be installed there safely."
-        fi
+        die "$path is group-writable, and who is in group $group cannot be established well enough to trust it. Make it private first: chmod g-w $path"
     fi
 }
 # Install by rename where possible: a running binary being overwritten in

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -71,6 +71,13 @@ main() {
     say "Installing $BIN $version ($target) into $install_dir"
     assert_safe_dir "$install_dir"
 
+    # What a signal would have to undo. Set before the traps below, since
+    # `set -u` makes an unset name an error inside a handler.
+    INSTALL_DEST=""
+    INSTALL_BACKUP=""
+    INSTALL_STAGED=""
+    INSTALL_COMMITTED=""
+
     tmp="$(mktemp -d)" || die "cannot create a private working directory"
     # Covers the error paths too, since `set -e` exits through the trap.
     #
@@ -79,9 +86,13 @@ main() {
     # directory it had just deleted -- and could reach the end and report
     # `Installed` after being asked to stop. The EXIT trap then runs a second
     # time, which `rm -rf` does not mind.
-    trap 'rm -rf "$tmp"' EXIT
-    trap 'rm -rf "$tmp"; exit 130' INT
-    trap 'rm -rf "$tmp"; exit 143' TERM
+    # The destination first: a signal arriving after the replacement but
+    # before the new binary has been run leaves an unvalidated copy live and
+    # the old one hidden under a random name -- and on a noexec working
+    # directory that window covers the only time the binary is ever checked.
+    trap 'install_rollback; rm -rf "$tmp"' EXIT
+    trap 'install_rollback; rm -rf "$tmp"; exit 130' INT
+    trap 'install_rollback; rm -rf "$tmp"; exit 143' TERM
 
     # The same walk the destination gets. `mktemp -d` makes the directory
     # itself 0700 and ours, but it puts it under $TMPDIR when that is set --
@@ -145,7 +156,10 @@ main() {
     # swallowed: the install printed `Installed` and exited 0 while the
     # binary was never in place.
     if installed_version="$("$install_dir/$BIN" --version 2>/dev/null)"; then
-        # It runs. The copy that was there before is no longer needed.
+        # It runs. That is the commit: the copy that was there before is no
+        # longer needed, and the traps stop trying to undo anything.
+        INSTALL_COMMITTED=yes
+        INSTALL_STAGED=""
         [ -z "$INSTALL_BACKUP" ] || rm -f "$INSTALL_BACKUP"
     else
         # It does not. Put back whatever was there rather than leaving the
@@ -516,6 +530,26 @@ assert_component() {
         die "$path is group-writable, and who is in group $group cannot be established well enough to trust it. Make it private first: chmod g-w $path"
     fi
 }
+# Undo an installation that never got committed.
+#
+# Committed means the new binary has been run and answered. Until then the
+# replacement is unvalidated, so anything that ends the script early -- a
+# signal, `set -e`, a die -- has to put back what was there and take away
+# what was not. Idempotent on purpose: the failure paths in main do the same
+# work, and whichever gets there first leaves nothing for the other.
+install_rollback() {
+    [ -z "$INSTALL_COMMITTED" ] || return 0
+    if [ -n "$INSTALL_BACKUP" ] && [ -e "$INSTALL_BACKUP" ]; then
+        if [ -n "$INSTALL_DEST" ]; then
+            mv -f "$INSTALL_BACKUP" "$INSTALL_DEST" 2>/dev/null ||
+                rm -f "$INSTALL_BACKUP"
+        else
+            rm -f "$INSTALL_BACKUP"
+        fi
+    fi
+    [ -z "$INSTALL_STAGED" ] || rm -f "$INSTALL_STAGED"
+}
+
 # Install by rename where possible: a running binary being overwritten in
 # place gets ETXTBSY on Linux, while replacing the directory entry does not
 # disturb a process already holding the old inode.
@@ -537,6 +571,15 @@ install_binary() {
     # bytes -- so a restore would put a regular file where a link had been,
     # silently breaking whatever arrangement the link was part of while
     # reporting that the previous copy was put back.
+    # An extended ACL on the existing binary would not survive a rollback:
+    # the copy carries bytes, mode, owner and times, and nothing else. Better
+    # to refuse than to restore something quietly less protected than what
+    # was there. getfacl is already required by the destination checks.
+    if [ -e "$dest" ] && command -v getfacl >/dev/null 2>&1 &&
+        [ -n "$(getfacl --skip-base --omit-header "$dest" 2>/dev/null)" ]; then
+        die "$dest carries an extended ACL, which a rollback could not put back. Remove the ACL, or move the file aside, and run this again."
+    fi
+
     if [ -L "$dest" ]; then
         die "$dest is a symlink. Install over what it points at, or remove it first: this replaces the path itself and could not put the link back if the new binary failed."
     fi
@@ -552,6 +595,7 @@ install_binary() {
     # exclusively and 0600, under a name nobody can aim at.
     staged="$(mktemp "$dir/.$BIN.install.XXXXXX")" ||
         die "cannot create a staging file in $dir"
+    INSTALL_STAGED="$staged"
     cp "$src" "$staged" || {
         rm -f "$staged"
         die "cannot write to $dir"
@@ -600,7 +644,12 @@ install_binary() {
             rm -f "$staged"
             die "cannot create a rollback file in $dir, so $dest will not be replaced"
         }
-        if ! cat "$dest" > "$INSTALL_BACKUP" 2>/dev/null; then
+        # `cp -p` rather than a redirect: it writes into the inode mktemp
+        # holds -- so the name is still never released -- and carries the
+        # mode, owner and timestamps across as well as the bytes. What it
+        # cannot carry is an extended ACL, an xattr or a file capability;
+        # those are refused below rather than silently dropped.
+        if ! cp -p "$dest" "$INSTALL_BACKUP" 2>/dev/null; then
             rm -f "$INSTALL_BACKUP" "$staged"
             die "cannot preserve the $BIN already at $dest, so it will not be replaced"
         fi
@@ -617,6 +666,10 @@ install_binary() {
         [ -z "$INSTALL_BACKUP" ] || mv -f "$INSTALL_BACKUP" "$dest" 2>/dev/null || true
         die "cannot replace $dest"
     }
+    # From here the destination holds an unvalidated binary, and a signal has
+    # to know where to put the old one back.
+    INSTALL_DEST="$dest"
+    INSTALL_STAGED=""
 }
 
 warn_if_not_on_path() {

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -29,6 +29,11 @@ main() {
                 ;;
             --version=*)
                 version="${1#--version=}"
+                # An unset variable expanded into --version="$V" arrives
+                # here as an empty value. Treating that as "no --version"
+                # would silently install the latest release instead of the
+                # pin the caller asked for.
+                [ -n "$version" ] || die "--version needs a value, e.g. --version=0.9.0"
                 shift
                 ;;
             --install-dir)
@@ -38,6 +43,7 @@ main() {
                 ;;
             --install-dir=*)
                 install_dir="${1#--install-dir=}"
+                [ -n "$install_dir" ] || die "--install-dir needs a value"
                 shift
                 ;;
             -h | --help)
@@ -253,8 +259,18 @@ install_binary() {
     [ -w "$dir" ] ||
         die "$dir is not writable. Re-run with --install-dir <somewhere you own>, or with sudo."
 
-    staged="$dir/.$BIN.install.$$"
-    cp "$src" "$staged" || die "cannot write to $dir"
+    # mktemp, not a name built from the pid. Installing as root into a directory
+    # someone else can write to, the old `.srelens-tui.install.<pid>` was
+    # predictable enough to pre-create as a symlink -- and `cp` follows a
+    # destination symlink, so the copy would have written through it as root,
+    # to a file of the attacker's choosing. mktemp creates the file itself,
+    # exclusively and 0600, under a name nobody can aim at.
+    staged="$(mktemp "$dir/.$BIN.install.XXXXXX")" ||
+        die "cannot create a staging file in $dir"
+    cp "$src" "$staged" || {
+        rm -f "$staged"
+        die "cannot write to $dir"
+    }
     chmod 0755 "$staged"
     mv -f "$staged" "$dest" || {
         rm -f "$staged"

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -18,7 +18,6 @@ BIN="srelens-tui"
 
 main() {
     version=""
-    install_dir=""
 
     while [ $# -gt 0 ]; do
         case "$1" in
@@ -36,15 +35,9 @@ main() {
                 [ -n "$version" ] || die "--version needs a value, e.g. --version=0.9.0"
                 shift
                 ;;
-            --install-dir)
-                install_dir="${2:-}"
-                [ -n "$install_dir" ] || die "--install-dir needs a value"
-                shift 2
-                ;;
-            --install-dir=*)
-                install_dir="${1#--install-dir=}"
-                [ -n "$install_dir" ] || die "--install-dir needs a value"
-                shift
+            --install-dir | --install-dir=*)
+                # Removed deliberately -- see the note above resolve_install_dir.
+                die "--install-dir is no longer accepted. This installs to /usr/local/bin, or ~/.local/bin when that is not writable. To put the binary anywhere else, unpack the tarball yourself: see docs/INSTALL.md."
                 ;;
             -h | --help)
                 usage
@@ -67,7 +60,7 @@ main() {
     version="${version#srelens-v}"
     version="${version#v}"
 
-    install_dir="$(resolve_install_dir "$install_dir")"
+    install_dir="$(resolve_install_dir)"
     # Sets INSTALL_DIR to the canonical path, which is what everything below
     # uses. Before the download, so an unwritable destination costs nothing.
     prepare_install_dir "$install_dir"
@@ -169,12 +162,15 @@ usage() {
 Install $BIN, the srelens terminal UI, on Linux.
 
 Usage:
-  install.sh [--version <x.y.z>] [--install-dir <path>]
+  install.sh [--version <x.y.z>]
 
 Options:
-  --version <x.y.z>     Install this version instead of the latest stable.
-  --install-dir <path>  Install here instead of $(printf '%s' '/usr/local/bin, or ~/.local/bin when that is not writable').
-  -h, --help            Show this message.
+  --version <x.y.z>  Install this version instead of the latest stable.
+  -h, --help         Show this message.
+
+It installs to /usr/local/bin, or ~/.local/bin when that is not writable.
+There is no way to name a different directory: unpack the tarball yourself
+if you want the binary somewhere else. See docs/INSTALL.md.
 
 The binary is the statically linked musl build, so it does not care which
 libc or which distribution is on the machine. Its SHA-256 is checked against
@@ -261,17 +257,26 @@ latest_version() {
     printf '%s' "${tag#srelens-v}"
 }
 
-# /usr/local/bin when it is writable, ~/.local/bin otherwise.
+# /usr/local/bin when it is writable, ~/.local/bin otherwise. Those two, and
+# nothing else.
+#
+# There was an --install-dir flag. It is gone on purpose: an arbitrary
+# caller-chosen destination is most of this script's attack surface, and
+# making one safe from a POSIX shell means winning filesystem races that a
+# shell has no primitives for -- it cannot hold a descriptor across a check
+# and a use, so every rule below is a claim about a path that could change
+# underneath it. The two destinations here are root's or yours by
+# construction. Anyone who wants the binary elsewhere can unpack the tarball
+# themselves, which is a plain `tar -xzf` and is documented.
+#
+# The checks below still run, because both paths remain reachable from the
+# environment: $HOME is whatever the caller says it is.
 #
 # No sudo. A script fetched over the network re-invoking itself as root is
 # exactly the pattern people are right to be nervous about, and the fallback
 # needs no privileges at all. Anyone who wants it system-wide can say so:
 #   curl ... | sudo sh
 resolve_install_dir() {
-    if [ -n "$1" ]; then
-        printf '%s' "$1"
-        return
-    fi
     if [ -w /usr/local/bin ] 2>/dev/null; then
         printf '/usr/local/bin'
     else
@@ -319,7 +324,7 @@ prepare_install_dir() {
     mkdir -p "$dir" 2>/dev/null ||
         die "cannot create $dir"
     [ -w "$dir" ] ||
-        die "$dir is not writable. Re-run with --install-dir <somewhere you own>, or with sudo."
+        die "$dir is not writable. Re-run under sudo to install to /usr/local/bin."
     resolved="$(cd "$dir" 2>/dev/null && pwd -P)" || resolved=""
     [ -n "$resolved" ] && dir="$resolved"
     INSTALL_DIR="$dir"
@@ -401,12 +406,18 @@ assert_component() {
     # portably is not something a POSIX shell can do -- getfacl is neither
     # POSIX nor present on Alpine. Refuse rather than pass a directory whose
     # real permissions have not been seen.
+    #
+    # A gap worth naming: BusyBox ls does not print that marker at all, so on
+    # Alpine an ACL is invisible here. There is no portable way to ask -- the
+    # alternative would be refusing every group- or other-readable directory
+    # on systems whose ls is terse, which refuses the ordinary case to catch
+    # a rare one.
     if [ "$(printf %s "$listing" | cut -c11)" = "+" ]; then
         die "$path carries an extended ACL, which may grant write access that its mode does not show. Check it with: getfacl $path"
     fi
 
     if [ -n "$owner" ] && [ "$owner" != "root" ] && [ "$owner" != "$SAFE_ME" ]; then
-        die "$path belongs to $owner, who could replace what is inside it while this installs. Choose a path you control: --install-dir \$HOME/.local/bin"
+        die "$path belongs to $owner, who could replace what is inside it while this installs. Nothing can be installed there safely."
     fi
 
     # The sticky bit settles both write bits at once. With it set, only an
@@ -420,7 +431,7 @@ assert_component() {
     esac
 
     if [ "$(printf %s "$perms" | cut -c9)" = "w" ]; then
-        die "$path is writable by anyone and has no sticky bit, so another user could replace the binary between staging and running it. Choose a path you control: --install-dir \$HOME/.local/bin"
+        die "$path is writable by anyone and has no sticky bit, so another user could replace the binary between staging and running it. Nothing can be installed there safely."
     fi
 
     # Group-writable, without the sticky bit, needs the group to contain
@@ -440,7 +451,7 @@ assert_component() {
     # of it.
     if [ "$(printf %s "$perms" | cut -c6)" = "w" ]; then
         if [ -z "$group" ] || [ "$group" != "$owner" ]; then
-            die "$path is writable by the group $group, whose members could replace the binary between staging and running it. Choose a path you control: --install-dir \$HOME/.local/bin"
+            die "$path is writable by the group $group, whose members could replace the binary between staging and running it. Nothing can be installed there safely."
         fi
         if command -v getent >/dev/null 2>&1; then
             # A lookup that FAILS is not a group with nobody in it. An NSS
@@ -448,12 +459,12 @@ assert_component() {
             # empty member list and empty GID then skip both checks below
             # and accept the directory.
             entry="$(getent group "$group" 2>/dev/null)" ||
-                die "cannot look up the group $group, so who can write to $path is unknown. Choose a path that is not group-writable: --install-dir \$HOME/.local/bin"
+                die "cannot look up the group $group, so who can write to $path is unknown. Nothing can be installed there safely."
             [ -n "$entry" ] ||
-                die "the group $group does not resolve, so who can write to $path is unknown. Choose a path that is not group-writable: --install-dir \$HOME/.local/bin"
+                die "the group $group does not resolve, so who can write to $path is unknown. Nothing can be installed there safely."
             members="$(printf %s "$entry" | cut -d: -f4)"
             if [ -n "$members" ] && [ "$members" != "$owner" ]; then
-                die "$path is writable by the group $group, which has members besides $owner ($members). Any of them could replace the binary between staging and running it. Choose a path you control: --install-dir \$HOME/.local/bin"
+                die "$path is writable by the group $group, which has members besides $owner ($members). Any of them could replace the binary between staging and running it. Nothing can be installed there safely."
             fi
 
             # The member list is only half of a group. An account whose
@@ -474,17 +485,17 @@ assert_component() {
                 # empty answer and been read as "nobody else is in this
                 # group". The same fail-open the group lookup above had.
                 accounts="$(getent passwd 2>/dev/null)" ||
-                    die "cannot enumerate accounts, so who else is in the group $group is unknown. Choose a path that is not group-writable: --install-dir \$HOME/.local/bin"
+                    die "cannot enumerate accounts, so who else is in the group $group is unknown. Nothing can be installed there safely."
                 [ -n "$accounts" ] ||
-                    die "no accounts could be listed, so who else is in the group $group is unknown. Choose a path that is not group-writable: --install-dir \$HOME/.local/bin"
+                    die "no accounts could be listed, so who else is in the group $group is unknown. Nothing can be installed there safely."
                 primary="$(printf %s "$accounts" |
                     awk -F: -v g="$gid" -v o="$owner" '$4 == g && $1 != o { printf "%s ", $1 }')" || primary=""
                 if [ -n "$primary" ]; then
-                    die "$path is writable by the group $group, which is the primary group of ${primary%% }. Any of them could replace the binary between staging and running it. Choose a path you control: --install-dir \$HOME/.local/bin"
+                    die "$path is writable by the group $group, which is the primary group of ${primary%% }. Any of them could replace the binary between staging and running it. Nothing can be installed there safely."
                 fi
             fi
         else
-            die "$path is group-writable and there is no getent here to establish who is in group $group. Choose a path that is not group-writable: --install-dir \$HOME/.local/bin"
+            die "$path is group-writable and there is no getent here to establish who is in group $group. Nothing can be installed there safely."
         fi
     fi
 }
@@ -501,7 +512,7 @@ install_binary() {
     # caller asked for. `mv -T` says otherwise but is GNU-only, and this
     # has to run under BusyBox.
     if [ -d "$dest" ]; then
-        die "$dest is a directory, so a binary cannot be installed at that path. Remove it, or choose another --install-dir."
+        die "$dest is a directory, so a binary cannot be installed at that path. Remove it and run this again."
     fi
     # Already created, checked and canonicalised by prepare_install_dir and
     # assert_safe_dir. Deliberately not re-derived from $dest here.

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -85,6 +85,7 @@ main() {
     INSTALL_STAGED=""
     INSTALL_COMMITTED=""
     INSTALL_ROLLBACK_KEPT=""
+    INSTALL_ROLLBACK_STUCK=""
 
     tmp="$(mktemp -d)" || die "cannot create a private working directory"
     # Covers the error paths too, since `set -e` exits through the trap.
@@ -202,10 +203,14 @@ main() {
         [ -z "$INSTALL_BACKUP" ] || had_backup=yes
         install_rollback
         kept="$INSTALL_ROLLBACK_KEPT"
+        stuck="$INSTALL_ROLLBACK_STUCK"
         # Undone. Nothing left for the EXIT trap to undo a second time.
         INSTALL_DEST=""
         INSTALL_BACKUP=""
         INSTALL_STAGED=""
+        if [ -n "$stuck" ]; then
+            die "the installed $BIN $problem, and it could NOT be removed. It is still installed at $stuck -- delete it before running $BIN from there"
+        fi
         if [ -n "$kept" ]; then
             die "the installed $BIN $problem, and the copy that was there before could NOT be put back. It is still on disk: $kept"
         fi
@@ -581,6 +586,7 @@ assert_component() {
 # work, and whichever gets there first leaves nothing for the other.
 install_rollback() {
     INSTALL_ROLLBACK_KEPT=""
+    INSTALL_ROLLBACK_STUCK=""
     [ -z "$INSTALL_COMMITTED" ] || return 0
     # Each branch clears what it dealt with. This runs TWICE on a signal --
     # the INT/TERM handler calls it, then `exit` fires the EXIT handler --
@@ -610,7 +616,15 @@ install_rollback() {
         # run put there and never got to run. On a noexec working directory
         # it has been executed by nobody at all, and leaving it is leaving an
         # unchecked binary on someone's PATH under a name they will trust.
-        rm -f "$INSTALL_DEST"
+        # `rm -f` says nothing useful -- it is happy about a file that was
+        # never there -- so what matters is whether the path is gone
+        # afterwards. A read-only mount or an immutable flag leaves it, and
+        # reporting it removed would be the same lie the failed restore used
+        # to tell.
+        rm -f "$INSTALL_DEST" 2>/dev/null || true
+        if [ -e "$INSTALL_DEST" ]; then
+            INSTALL_ROLLBACK_STUCK="$INSTALL_DEST"
+        fi
         INSTALL_DEST=""
     fi
     if [ -n "$INSTALL_STAGED" ]; then

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -375,7 +375,7 @@ assert_safe_dir() {
     SAFE_ME="$(id -un 2>/dev/null)" || SAFE_ME=""
     [ -n "$SAFE_ME" ] || die "cannot determine who is running this"
 
-    assert_component "/"
+    assert_component "/" parent
     rest="${resolved#/}"
     prefix=""
     while [ -n "$rest" ]; do
@@ -385,13 +385,20 @@ assert_safe_dir() {
             *) rest="" ;;
         esac
         prefix="$prefix/$name"
-        assert_component "$prefix"
+        # The last component is where the binary lands, and it is held to a
+        # stricter rule than the ones above it.
+        if [ -z "$rest" ]; then
+            assert_component "$prefix" destination
+        else
+            assert_component "$prefix" parent
+        fi
     done
 }
 
 # One component of the path, against the rules above.
 assert_component() {
     path="$1"
+    role="$2"
 
     # `ls -ld` rather than stat: stat's flags differ between GNU and BSD, and
     # this has to run under BusyBox too.
@@ -455,18 +462,30 @@ assert_component() {
         die "$path belongs to $owner, who could replace what is inside it while this installs. Nothing can be installed there safely."
     fi
 
-    # The sticky bit settles both write bits at once. With it set, only an
-    # entry's owner may unlink or rename that entry, so who else can write
-    # into the directory stops mattering for anything already staged there.
-    # That is what makes /tmp usable -- and /tmp is `drwxrwxrwt`, group- and
-    # world-writable both, so treating either bit as disqualifying on its own
-    # would refuse every install whose path runs through it.
-    case "$(printf %s "$perms" | cut -c10)" in
-        t | T) return 0 ;;
-    esac
+    # The sticky bit settles both write bits at once -- for a PARENT. With
+    # it set only an entry's owner may unlink or rename that entry, so who
+    # else may write into the directory stops mattering for the subtree we
+    # already hold. That is what makes /tmp usable as an ancestor, and /tmp
+    # is `drwxrwxrwt`, so treating either write bit as disqualifying would
+    # refuse every install whose path runs through it.
+    #
+    # It settles nothing for the DESTINATION. Sticky stops another user
+    # removing OUR files; it does not stop them creating `srelens-tui` there
+    # first and owning it. Everything that then happens to that entry
+    # happens to a file they control: its mode is read and reapplied to the
+    # rollback copy, so a planted 4755 becomes a root-owned setuid binary;
+    # and it can be swapped for a symlink to a directory after the check, so
+    # the `mv` moves the staged binary underneath it and leaves theirs at the
+    # path that then gets run. Neither race can be closed from a shell, so
+    # the directory is refused instead.
+    if [ "$role" = parent ]; then
+        case "$(printf %s "$perms" | cut -c10)" in
+            t | T) return 0 ;;
+        esac
+    fi
 
     if [ "$(printf %s "$perms" | cut -c9)" = "w" ]; then
-        die "$path is writable by anyone and has no sticky bit, so another user could replace the binary between staging and running it. Nothing can be installed there safely."
+        die "$path is writable by other users, so one of them could create or replace the binary while this installs. Nothing can be installed there safely."
     fi
 
     # Group-writable is refused, full stop.
@@ -543,17 +562,31 @@ install_binary() {
         # come back 0755, readable and runnable by everyone on the machine.
         # `stat -c` rather than `chmod --reference`, which BusyBox lacks.
         dest_mode="$(stat -c %a "$dest" 2>/dev/null)" || dest_mode=""
-        [ -n "$dest_mode" ] ||
+        [ -n "$dest_mode" ] || {
+            rm -f "$staged"
             die "cannot read the permissions of $dest, so a rollback could not restore them"
-        INSTALL_BACKUP="$(mktemp "$dir/.$BIN.backup.XXXXXX")" ||
+        }
+        # Keep the permission bits, never the set-ID ones. `stat %a` renders
+        # setuid as a fourth digit, and reapplying it would have this script
+        # create a setuid copy of a file it did not write -- owned by root,
+        # when the install is under sudo. The destination rules make a
+        # planted binary hard to arrange; refusing to propagate the bit at
+        # all means it does not matter if one ever is.
+        dest_mode="$(printf %s "$dest_mode" | sed 's/^.*(...)$//')"
+        INSTALL_BACKUP="$(mktemp "$dir/.$BIN.backup.XXXXXX")" || {
+            rm -f "$staged"
             die "cannot create a rollback file in $dir, so $dest will not be replaced"
+        }
         if ! cat "$dest" > "$INSTALL_BACKUP" 2>/dev/null; then
             rm -f "$INSTALL_BACKUP" "$staged"
             die "cannot preserve the $BIN already at $dest, so it will not be replaced"
         fi
         # mktemp makes it 0600; the rollback carries the mode the binary
         # actually had.
-        chmod "$dest_mode" "$INSTALL_BACKUP"
+        chmod "$dest_mode" "$INSTALL_BACKUP" || {
+            rm -f "$INSTALL_BACKUP" "$staged"
+            die "cannot set the rollback copy to mode $dest_mode, so $dest will not be replaced"
+        }
     fi
 
     mv -f "$staged" "$dest" || {

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -68,6 +68,7 @@ main() {
     version="${version#v}"
 
     install_dir="$(resolve_install_dir "$install_dir")"
+    assert_safe_dir "$install_dir"
 
     say "Installing $BIN $version ($target) into $install_dir"
 
@@ -246,6 +247,64 @@ verify_checksum() {
     say "Checksum verified: $actual"
 }
 
+# Refuse a destination that another user could tamper with mid-install.
+#
+# mktemp closes the file it creates and `cp` reopens it by name, so anyone
+# who can unlink entries in the directory can swap a symlink in between the
+# two and have the copy write through it -- as root, when this is run under
+# sudo. The same window lets them replace the finished binary before the
+# version line runs it. An unpredictable name does not close that; only the
+# directory's own permissions do.
+#
+# Two rules, both narrow enough not to catch an ordinary machine:
+#
+#   * world-writable without the sticky bit. With the sticky bit set only an
+#     entry's owner may unlink it, so a staged file cannot be taken away --
+#     which is exactly why /tmp has it.
+#   * running as root into a directory root does not own. That is the case
+#     worth refusing outright: the owner can arrange the swap at leisure and
+#     gets a root-written file out of it.
+#
+# Group-writable alone is deliberately NOT refused. Distributions with
+# per-user groups leave ~/.local/bin group-writable under a 002 umask, where
+# the only member of that group is the user themselves.
+#
+# This is the rule srelens-tui's own `update` applies to the binary it
+# replaces, for the same reason.
+assert_safe_dir() {
+    dir="$1"
+    [ -d "$dir" ] || return 0
+
+    # `ls -ld` rather than stat: stat's flags differ between GNU and BSD, and
+    # this has to run under BusyBox too.
+    listing="$(ls -ld "$dir" 2>/dev/null)" || return 0
+    [ -n "$listing" ] || return 0
+    perms="$(printf %s "$listing" | cut -c1-10)"
+    owner="$(printf %s "$listing" | awk '{print $3}')"
+
+    # Anything that is not a mode string is not something to guess from.
+    case "$perms" in
+        d?????????) ;;
+        *) return 0 ;;
+    esac
+
+    sticky="$(printf %s "$perms" | cut -c10)"
+    other_w="$(printf %s "$perms" | cut -c9)"
+
+    if [ "$other_w" = "w" ]; then
+        case "$sticky" in
+            t | T) ;;
+            *)
+                die "$dir is writable by anyone and has no sticky bit, so another user could replace the binary between staging and running it. Install somewhere you control: --install-dir \$HOME/.local/bin"
+                ;;
+        esac
+    fi
+
+    if [ "$(id -u)" = "0" ] && [ -n "$owner" ] && [ "$owner" != "root" ]; then
+        die "$dir belongs to $owner, and installing there as root would let $owner substitute the file being installed. Install it somewhere root owns, or run as $owner without sudo."
+    fi
+}
+
 # Install by rename where possible: a running binary being overwritten in
 # place gets ETXTBSY on Linux, while replacing the directory entry does not
 # disturb a process already holding the old inode.
@@ -258,6 +317,7 @@ install_binary() {
         die "cannot create $dir"
     [ -w "$dir" ] ||
         die "$dir is not writable. Re-run with --install-dir <somewhere you own>, or with sudo."
+    assert_safe_dir "$dir"
 
     # mktemp, not a name built from the pid. Installing as root into a directory
     # someone else can write to, the old `.srelens-tui.install.<pid>` was

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -654,13 +654,42 @@ install_binary() {
     # bytes -- so a restore would put a regular file where a link had been,
     # silently breaking whatever arrangement the link was part of while
     # reporting that the previous copy was put back.
-    # An extended ACL on the existing binary would not survive a rollback:
-    # the copy carries bytes, mode, owner and times, and nothing else. Better
-    # to refuse than to restore something quietly less protected than what
-    # was there. getfacl is already required by the destination checks.
-    if [ -e "$dest" ] && command -v getfacl >/dev/null 2>&1 &&
-        [ -n "$(getfacl --skip-base --omit-header "$dest" 2>/dev/null)" ]; then
-        die "$dest carries an extended ACL, which a rollback could not put back. Remove the ACL, or move the file aside, and run this again."
+    # Metadata on the binary being REPLACED. The rollback copy carries bytes,
+    # mode, owner and timestamps, and nothing else -- so anything else there
+    # would come back missing, and the script would report the previous copy
+    # restored while handing back something less capable than what it took.
+    #
+    # Only when something is actually being replaced: a first install has no
+    # previous copy to be faithful to, so nobody installing for the first time
+    # is sent off to fetch tools.
+    if [ -e "$dest" ]; then
+        # An extended ACL. getfacl is already required by the destination
+        # checks, so this costs nothing extra.
+        if command -v getfacl >/dev/null 2>&1 &&
+            [ -n "$(getfacl --skip-base --omit-header "$dest" 2>/dev/null)" ]; then
+            die "$dest carries an extended ACL, which a rollback could not put back. Remove the ACL, or move the file aside, and run this again."
+        fi
+
+        # Everything else in the xattr namespace -- a file capability above
+        # all, whose loss would quietly take privileges from a binary that
+        # had them.
+        #
+        # security.selinux is excluded deliberately. Every file on an SELinux
+        # system carries one, so refusing them would refuse every update on
+        # Fedora and RHEL -- and it is the one piece here the filesystem
+        # re-derives anyway, since the rollback copy is created by mktemp in
+        # the destination directory and labelled by the same policy.
+        if command -v getfattr >/dev/null 2>&1; then
+            kept_attrs="$(getfattr -d -m - "$dest" 2>/dev/null |
+                grep -E '^[a-z_]+\.[a-z_]+' |
+                grep -v '^security\.selinux=' |
+                cut -d= -f1 | tr '\n' ' ')" || kept_attrs=""
+            if [ -n "$kept_attrs" ]; then
+                die "$dest carries extended attributes a rollback could not put back: ${kept_attrs% }. Remove them, or move the file aside, and run this again."
+            fi
+        else
+            die "cannot tell whether $dest carries extended attributes such as a file capability, and a rollback could not put those back: getfattr is not installed. Install it (Debian: apt install attr; Alpine: apk add attr), or move the file aside, and run this again."
+        fi
     fi
 
     # A FIFO, socket or device node where the binary goes. `cp -p` reading a

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -77,6 +77,7 @@ main() {
     INSTALL_BACKUP=""
     INSTALL_STAGED=""
     INSTALL_COMMITTED=""
+    INSTALL_ROLLBACK_KEPT=""
 
     tmp="$(mktemp -d)" || die "cannot create a private working directory"
     # Covers the error paths too, since `set -e` exits through the trap.
@@ -167,10 +168,16 @@ main() {
         # A release that published a stale binary under the right asset name
         # and checksum would otherwise install silently, and a pinned
         # `--version` would report success having produced a different one.
-        case "$installed_version" in
-            *"$version"*) ;;
-            *) problem="reports \"$installed_version\", not the $version that was asked for" ;;
-        esac
+        #
+        # The whole token, not a substring. `1.2.30` contains `1.2.3`, so a
+        # match on containment accepts precisely the stale build this is
+        # meant to catch. The output is `srelens-tui <version>`; the second
+        # field is compared, so the program renaming itself would not quietly
+        # turn this check off either.
+        reported="$(printf %s "$installed_version" | awk '{print $2}')"
+        if [ "$reported" != "$version" ]; then
+            problem="reports \"$installed_version\", not the $version that was asked for"
+        fi
     fi
 
     if [ -z "$problem" ]; then
@@ -187,10 +194,14 @@ main() {
         had_backup=""
         [ -z "$INSTALL_BACKUP" ] || had_backup=yes
         install_rollback
+        kept="$INSTALL_ROLLBACK_KEPT"
         # Undone. Nothing left for the EXIT trap to undo a second time.
         INSTALL_DEST=""
         INSTALL_BACKUP=""
         INSTALL_STAGED=""
+        if [ -n "$kept" ]; then
+            die "the installed $BIN $problem, and the copy that was there before could NOT be put back. It is still on disk: $kept"
+        fi
         if [ -n "$had_backup" ]; then
             die "the installed $BIN $problem; the copy that was there before has been put back"
         fi
@@ -562,12 +573,17 @@ assert_component() {
 # what was not. Idempotent on purpose: the failure paths in main do the same
 # work, and whichever gets there first leaves nothing for the other.
 install_rollback() {
+    INSTALL_ROLLBACK_KEPT=""
     [ -z "$INSTALL_COMMITTED" ] || return 0
     if [ -n "$INSTALL_BACKUP" ] && [ -e "$INSTALL_BACKUP" ]; then
         # Something was there before: put it back.
         if [ -n "$INSTALL_DEST" ]; then
-            mv -f "$INSTALL_BACKUP" "$INSTALL_DEST" 2>/dev/null ||
-                rm -f "$INSTALL_BACKUP"
+            if ! mv -f "$INSTALL_BACKUP" "$INSTALL_DEST" 2>/dev/null; then
+                # It could not go back -- a read-only mount, a full disk.
+                # Deleting it here would destroy the only copy of what was
+                # there, so it stays, and the caller says where.
+                INSTALL_ROLLBACK_KEPT="$INSTALL_BACKUP"
+            fi
         else
             rm -f "$INSTALL_BACKUP"
         fi
@@ -700,14 +716,21 @@ install_binary() {
         }
     fi
 
-    mv -f "$staged" "$dest" || {
-        rm -f "$staged"
-        [ -z "$INSTALL_BACKUP" ] || mv -f "$INSTALL_BACKUP" "$dest" 2>/dev/null || true
-        die "cannot replace $dest"
-    }
-    # From here the destination holds an unvalidated binary, and a signal has
-    # to know where to put the old one back.
+    # Recorded BEFORE the rename. A signal arriving while the shell is inside
+    # `mv` runs the handler first, and an assignment after it would not have
+    # happened yet -- the rollback would then think nothing had been replaced,
+    # leave an unvalidated binary live and throw away the only old copy.
     INSTALL_DEST="$dest"
+    if ! mv -f "$staged" "$dest"; then
+        rm -f "$staged"
+        # Nothing was replaced after all: $dest still holds whatever it held,
+        # so the rollback must not go near it.
+        INSTALL_DEST=""
+        INSTALL_STAGED=""
+        [ -z "$INSTALL_BACKUP" ] || rm -f "$INSTALL_BACKUP"
+        INSTALL_BACKUP=""
+        die "cannot replace $dest"
+    fi
     INSTALL_STAGED=""
 }
 

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -87,17 +87,27 @@ main() {
     download "$base/$BIN-$version-SHA256SUMS.txt" "$tmp/SHA256SUMS.txt"
     verify_checksum "$tmp" "$archive"
 
-    tar -xzf "$tmp/$archive" -C "$tmp"
-    [ -f "$tmp/$BIN" ] || die "the archive did not contain $BIN"
-    chmod 0755 "$tmp/$BIN"
+    # Into a subdirectory, never into $tmp itself. The archive contains a
+    # `./` member, and GNU tar restores directory ownership and permissions
+    # from the archive when it runs as root -- which under `sudo` would
+    # rewrite the 0700 root-owned directory mktemp -d just made into
+    # whatever the release runner had, typically 0755 and a numeric uid.
+    # An account matching that uid could then swap the binary between the
+    # checksum below and the moment it is run. Extracting one level down
+    # leaves $tmp itself untouched at 0700, so nothing can be reached
+    # through it whatever the archive claims about its own directory.
+    mkdir "$tmp/unpack" || die "cannot prepare a private directory to unpack into"
+    tar -xzf "$tmp/$archive" -C "$tmp/unpack"
+    [ -f "$tmp/unpack/$BIN" ] || die "the archive did not contain $BIN"
+    chmod 0755 "$tmp/unpack/$BIN"
 
     # Run it before it is installed, not after. A binary for the wrong
     # architecture or a corrupt one that still hashed correctly fails here,
     # while the only thing that has happened is a write to a temp dir.
-    "$tmp/$BIN" --version >/dev/null 2>&1 ||
+    "$tmp/unpack/$BIN" --version >/dev/null 2>&1 ||
         die "the downloaded binary does not run on this machine"
 
-    install_binary "$tmp/$BIN" "$install_dir/$BIN"
+    install_binary "$tmp/unpack/$BIN" "$install_dir/$BIN"
 
     say ""
     say "Installed: $install_dir/$BIN"
@@ -272,46 +282,59 @@ prepare_install_dir() {
 
 # Refuse a destination that another user could tamper with mid-install.
 #
-# mktemp closes the file it creates and `cp` reopens it by name, so anyone
-# who can unlink entries in the directory can swap a symlink in between the
-# two and have the copy write through it -- as root, when this is run under
-# sudo. The same window lets them replace the finished binary before the
-# version line runs it. An unpredictable name does not close that; only the
-# directory's own permissions do.
+# EVERY component is checked, not just the leaf. A directory can pass on its
+# own permissions and still sit under one somebody else owns -- and that
+# owner can rename it and put their own directory at the same path, after the
+# check and before the install. The staging file, the rename and the version
+# line would then all run inside theirs. This is the walk `sudo` and `ssh` do
+# over their own paths, for the same reason.
 #
-# Two rules, both narrow enough not to catch an ordinary machine:
+# The rules per component:
 #
-#   * world-writable without the sticky bit. With the sticky bit set only an
-#     entry's owner may unlink it, so a staged file cannot be taken away --
-#     which is exactly why /tmp has it.
-#   * running as root into a directory root does not own. That is the case
-#     worth refusing outright: the owner can arrange the swap at leisure and
-#     gets a root-written file out of it.
+#   * owned by root or by us. Anyone else can replace what is inside it.
+#   * if world-writable, the sticky bit must be set, so only an entry's owner
+#     may unlink it. That is what makes /tmp usable rather than disqualifying.
+#   * if group-writable, the group must be the owner's own -- the per-user
+#     group convention, where `alice:alice` has one member. A shared group is
+#     a set of people who can all replace the binary.
 #
-# Group-writable alone is deliberately NOT refused. Distributions with
-# per-user groups leave ~/.local/bin group-writable under a 002 umask, where
-# the only member of that group is the user themselves.
-#
-# This is the rule srelens-tui's own `update` applies to the binary it
-# replaces, for the same reason.
+# The same rule srelens-tui's own `update` applies to the binary it replaces.
 assert_safe_dir() {
     dir="$1"
-    [ -d "$dir" ] || return 0
 
-    # Follow the path to the directory it really is, first. `ls -ld` on a
-    # symlink describes the LINK -- mode `lrwxrwxrwx`, owned by whoever made
-    # it -- which says nothing about where the install lands, and would let
-    # `--install-dir /some/link` sail past both checks below. `cd` + `pwd -P`
-    # is the portable resolution; `readlink -f` is GNU.
+    # Resolve first. `ls -ld` on a symlink describes the LINK -- mode
+    # `lrwxrwxrwx`, owned by whoever made it -- which says nothing about where
+    # the install lands. `cd` + `pwd -P` is portable; `readlink -f` is GNU.
     resolved="$(cd "$dir" 2>/dev/null && pwd -P)" || resolved=""
     [ -n "$resolved" ] || return 0
 
+    SAFE_ME="$(id -un 2>/dev/null)" || SAFE_ME=""
+
+    assert_component "/"
+    rest="${resolved#/}"
+    prefix=""
+    while [ -n "$rest" ]; do
+        name="${rest%%/*}"
+        case "$rest" in
+            */*) rest="${rest#*/}" ;;
+            *) rest="" ;;
+        esac
+        prefix="$prefix/$name"
+        assert_component "$prefix"
+    done
+}
+
+# One component of the path, against the rules above.
+assert_component() {
+    path="$1"
+
     # `ls -ld` rather than stat: stat's flags differ between GNU and BSD, and
     # this has to run under BusyBox too.
-    listing="$(ls -ld "$resolved" 2>/dev/null)" || return 0
+    listing="$(ls -ld "$path" 2>/dev/null)" || return 0
     [ -n "$listing" ] || return 0
     perms="$(printf %s "$listing" | cut -c1-10)"
     owner="$(printf %s "$listing" | awk '{print $3}')"
+    group="$(printf %s "$listing" | awk '{print $4}')"
 
     # Anything that is not a directory mode is not something to guess from.
     case "$perms" in
@@ -319,32 +342,29 @@ assert_safe_dir() {
         *) return 0 ;;
     esac
 
-    me="$(id -un 2>/dev/null)" || me=""
-    sticky="$(printf %s "$perms" | cut -c10)"
-    other_w="$(printf %s "$perms" | cut -c9)"
+    if [ -n "$owner" ] && [ "$owner" != "root" ] && [ "$owner" != "$SAFE_ME" ]; then
+        die "$path belongs to $owner, who could replace what is inside it while this installs. Choose a path you control: --install-dir \$HOME/.local/bin"
+    fi
 
-    if [ "$other_w" = "w" ]; then
-        case "$sticky" in
-            t | T)
-                # Sticky stops OTHER users unlinking entries -- but not the
-                # directory's own owner, who may remove anything inside it.
-                # A world-writable sticky directory belonging to someone else
-                # is therefore still theirs to tamper with.
-                if [ -n "$owner" ] && [ "$owner" != "root" ] && [ "$owner" != "$me" ]; then
-                    die "$resolved is world-writable and owned by $owner, who may replace files in it even with the sticky bit set. Install somewhere you control: --install-dir \$HOME/.local/bin"
-                fi
-                ;;
+    if [ "$(printf %s "$perms" | cut -c9)" = "w" ]; then
+        case "$(printf %s "$perms" | cut -c10)" in
+            t | T) ;;
             *)
-                die "$resolved is writable by anyone and has no sticky bit, so another user could replace the binary between staging and running it. Install somewhere you control: --install-dir \$HOME/.local/bin"
+                die "$path is writable by anyone and has no sticky bit, so another user could replace the binary between staging and running it. Choose a path you control: --install-dir \$HOME/.local/bin"
                 ;;
         esac
     fi
 
-    if [ "$(id -u)" = "0" ] && [ -n "$owner" ] && [ "$owner" != "root" ]; then
-        die "$resolved belongs to $owner, and installing there as root would let $owner substitute the file being installed. Install it somewhere root owns, or run as $owner without sudo."
+    # Group-writable is only safe when the group is the owner's own, which is
+    # the per-user-group convention (`alice:alice`, one member). Distributions
+    # using it leave ~/.local/bin group-writable under a 002 umask, so
+    # refusing that outright would break an ordinary Fedora install; a group
+    # with a different name is a set of people who can all replace the binary.
+    if [ "$(printf %s "$perms" | cut -c6)" = "w" ] &&
+        [ -n "$group" ] && [ "$group" != "$owner" ]; then
+        die "$path is writable by the group $group, whose members could replace the binary between staging and running it. Choose a path you control: --install-dir \$HOME/.local/bin"
     fi
 }
-
 # Install by rename where possible: a running binary being overwritten in
 # place gets ETXTBSY on Linux, while replacing the directory entry does not
 # disturb a process already holding the old inode.

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -68,6 +68,10 @@ main() {
     version="${version#v}"
 
     install_dir="$(resolve_install_dir "$install_dir")"
+    # Sets INSTALL_DIR to the canonical path, which is what everything below
+    # uses. Before the download, so an unwritable destination costs nothing.
+    prepare_install_dir "$install_dir"
+    install_dir="$INSTALL_DIR"
     assert_safe_dir "$install_dir"
 
     say "Installing $BIN $version ($target) into $install_dir"
@@ -247,6 +251,25 @@ verify_checksum() {
     say "Checksum verified: $actual"
 }
 
+# Create the destination, confirm it can be written to, and settle on the
+# canonical path for it.
+#
+# Canonical matters as much as the checks that follow. Inspecting a resolved
+# path but then staging, renaming and finally RUNNING through the path as
+# given leaves the whole window open: a symlink the caller passed can be
+# repointed the moment after it is approved, and the install lands wherever
+# it now says. Everything downstream uses what this sets.
+prepare_install_dir() {
+    dir="$1"
+    mkdir -p "$dir" 2>/dev/null ||
+        die "cannot create $dir"
+    [ -w "$dir" ] ||
+        die "$dir is not writable. Re-run with --install-dir <somewhere you own>, or with sudo."
+    resolved="$(cd "$dir" 2>/dev/null && pwd -P)" || resolved=""
+    [ -n "$resolved" ] && dir="$resolved"
+    INSTALL_DIR="$dir"
+}
+
 # Refuse a destination that another user could tamper with mid-install.
 #
 # mktemp closes the file it creates and `cp` reopens it by name, so anyone
@@ -328,13 +351,9 @@ assert_safe_dir() {
 install_binary() {
     src="$1"
     dest="$2"
-    dir="$(dirname "$dest")"
-
-    mkdir -p "$dir" 2>/dev/null ||
-        die "cannot create $dir"
-    [ -w "$dir" ] ||
-        die "$dir is not writable. Re-run with --install-dir <somewhere you own>, or with sudo."
-    assert_safe_dir "$dir"
+    # Already created, checked and canonicalised by prepare_install_dir and
+    # assert_safe_dir. Deliberately not re-derived from $dest here.
+    dir="$INSTALL_DIR"
 
     # mktemp, not a name built from the pid. Installing as root into a directory
     # someone else can write to, the old `.srelens-tui.install.<pid>` was

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -53,7 +53,7 @@ main() {
     check_platform
     need curl
     need tar
-    sha_tool="$(find_sha_tool)"
+    require_sha_tool
 
     target="$(detect_target)"
     [ -n "$version" ] || version="$(latest_version)"
@@ -74,7 +74,7 @@ main() {
 
     download "$base/$archive" "$tmp/$archive"
     download "$base/$BIN-$version-SHA256SUMS.txt" "$tmp/SHA256SUMS.txt"
-    verify_checksum "$tmp" "$archive" "$sha_tool"
+    verify_checksum "$tmp" "$archive"
 
     tar -xzf "$tmp/$archive" -C "$tmp"
     [ -f "$tmp/$BIN" ] || die "the archive did not contain $BIN"
@@ -129,16 +129,27 @@ need() {
     command -v "$1" >/dev/null 2>&1 || die "$1 is required but not installed"
 }
 
-# sha256sum on most distributions, shasum where coreutils is not the one in
-# use. Refusing to install without one is deliberate: installing an unverified
-# binary quietly would defeat the point of publishing checksums at all.
-find_sha_tool() {
+# Refusing to install without a hashing tool is deliberate: installing an
+# unverified binary quietly would defeat the point of publishing checksums.
+require_sha_tool() {
+    if command -v sha256sum >/dev/null 2>&1; then return 0; fi
+    if command -v shasum >/dev/null 2>&1; then return 0; fi
+    die "neither sha256sum nor shasum found; cannot verify the download"
+}
+
+# The SHA-256 of one file.
+#
+# The algorithm travels WITH the command, never as a bare tool name: plain
+# `shasum` is SHA-1, so selecting it by name and calling it without -a 256
+# yields a 40-character digest that can never match a 64-character one. Every
+# archive would be rejected as corrupt, on exactly the machines that have
+# shasum and no sha256sum -- which is why neither Debian nor Alpine, where
+# this was first tested, could show it.
+sha256_of() {
     if command -v sha256sum >/dev/null 2>&1; then
-        printf 'sha256sum'
-    elif command -v shasum >/dev/null 2>&1; then
-        printf 'shasum'
+        sha256sum "$1" | cut -d" " -f1
     else
-        die "neither sha256sum nor shasum found; cannot verify the download"
+        shasum -a 256 "$1" | cut -d" " -f1
     fi
 }
 
@@ -210,7 +221,6 @@ download() {
 verify_checksum() {
     dir="$1"
     file="$2"
-    tool="$3"
 
     expected="$(
         grep "  $file\$" "$dir/SHA256SUMS.txt" 2>/dev/null |
@@ -219,7 +229,7 @@ verify_checksum() {
     [ -n "$expected" ] ||
         die "$file is not listed in the release's SHA256SUMS"
 
-    actual="$(cd "$dir" && "$tool" "$file" | cut -d' ' -f1)"
+    actual="$(cd "$dir" && sha256_of "$file")"
 
     if [ "$expected" != "$actual" ]; then
         printf 'error: checksum mismatch for %s\n' "$file" >&2

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -17,6 +17,17 @@ here="$(cd "$(dirname "$0")" && pwd)"
 script="$here/install.sh"
 [ -f "$script" ] || { echo "install.sh not found next to $0" >&2; exit 1; }
 
+# The fixtures have to match the machine running the suite: the happy path
+# executes the binary it downloads, and an x86-64 one will not run on an
+# aarch64 developer host without binfmt emulation. CI runs x86-64, so only
+# a developer would ever have seen it.
+case "$(uname -m)" in
+    x86_64 | amd64) host_arch="x86_64" ;;
+    aarch64 | arm64) host_arch="aarch64" ;;
+    *) echo "these tests have no fixture for $(uname -m)" >&2; exit 1 ;;
+esac
+host_target="$host_arch-unknown-linux-musl"
+
 work="$(mktemp -d)"
 
 # Some cases need a second account and a shared group to be meaningful.
@@ -24,8 +35,13 @@ work="$(mktemp -d)"
 # login account behind on the host has done more than test.
 made_user=""
 made_users=""
+mounted=""
 made_group=""
 cleanup() {
+    # Before the rm. A live mount inside $work makes `rm -rf` fail, and
+    # under `set -e` the trap would exit there -- leaving the accounts
+    # behind AND the tmpfs mounted on a developer's machine.
+    [ -z "$mounted" ] || umount "$mounted" >/dev/null 2>&1 || true
     rm -rf "$work"
     [ -z "$made_user" ] || userdel -r "$made_user" >/dev/null 2>&1 || true
     for u in $made_users; do
@@ -83,11 +99,11 @@ check "an empty --install-dir= is refused too" "needs a value" "$out" "$rc" 1
 echo "platform"
 
 mkdir -p "$work/fake"
-cat > "$work/fake/uname" <<'EOF'
+cat > "$work/fake/uname" <<EOF
 #!/bin/sh
-case "${1:-}" in
-  -s) echo "${FAKE_OS:-Linux}" ;;
-  -m) echo "${FAKE_ARCH:-x86_64}" ;;
+case "\${1:-}" in
+  -s) echo "\${FAKE_OS:-Linux}" ;;
+  -m) echo "\${FAKE_ARCH:-$host_arch}" ;;
   *)  echo Linux ;;
 esac
 EOF
@@ -120,7 +136,7 @@ version="$(
 version="${version#srelens-v}"
 [ -n "$version" ] || { echo "could not resolve the latest version" >&2; exit 1; }
 
-archive="srelens-tui-$version-x86_64-unknown-linux-musl.tar.gz"
+archive="srelens-tui-$version-$host_target.tar.gz"
 base="https://github.com/srelens/srelens/releases/download/srelens-v$version"
 mkdir -p "$work/fixtures"
 curl -fsSL -o "$work/fixtures/$archive" "$base/$archive"
@@ -526,6 +542,8 @@ if [ "$(id -u)" = "0" ] && command -v mount >/dev/null 2>&1; then
     noexec="$work/noexec"
     mkdir -p "$noexec"
     if mount -t tmpfs -o rw,noexec,nosuid,size=200m tmpfs "$noexec" 2>/dev/null; then
+        # Recorded before use, so an interrupt anywhere below still unmounts.
+        mounted="$noexec"
         dest="$work/noexec-bin"
         mkdir -p "$dest"
         out="$(TMPDIR="$noexec" sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
@@ -539,7 +557,7 @@ if [ "$(id -u)" = "0" ] && command -v mount >/dev/null 2>&1; then
         mkdir -p "$bad"
         printf 'this is not a binary\n' > "$bad/srelens-tui"
         printf 'nothing here either\n' > "$bad/LICENSE"
-        badarchive="srelens-tui-$version-x86_64-unknown-linux-musl.tar.gz"
+        badarchive="srelens-tui-$version-$host_target.tar.gz"
         (cd "$bad" && tar -czf "$work/fixtures/$badarchive.bad" .)
         badsum="$(sha256sum "$work/fixtures/$badarchive.bad" | cut -d" " -f1)"
         printf '%s  %s\n' "$badsum" "$badarchive" > "$work/fixtures/BADSUMS.txt"
@@ -572,7 +590,9 @@ EOF
         fi
         rm -f "$work/fake/curl"
 
-        umount "$noexec" 2>/dev/null || true
+        if umount "$noexec" 2>/dev/null; then
+            mounted=""
+        fi
     else
         echo "  skip  cannot mount a noexec filesystem here (needs CAP_SYS_ADMIN)"
     fi
@@ -606,6 +626,24 @@ mkdir -p "$dest"
 chmod 0775 "$dest"
 out="$(PATH="$work/fake:$PATH" sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
 check "a group lookup that fails is not treated as empty" "cannot look up the group" "$out" "$rc" 1
+
+# And neither is a passwd lookup that fails. In `getent passwd | awk` the
+# status belongs to awk, which succeeds on no input, so a partial outage
+# would read as "nobody else is in this group".
+cat > "$work/fake/getent" <<'EOF'
+#!/bin/sh
+case "${1:-}" in
+  group)  echo "root:x:0:" ;;
+  passwd) exit 2 ;;
+  *) exit 2 ;;
+esac
+EOF
+chmod +x "$work/fake/getent"
+dest="$work/passwd-down"
+mkdir -p "$dest"
+chmod 0775 "$dest"
+out="$(PATH="$work/fake:$PATH" sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+check "a passwd lookup that fails is not treated as empty" "cannot enumerate accounts" "$out" "$rc" 1
 rm -f "$work/fake/getent"
 
 echo "unpacking"

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -655,7 +655,7 @@ EOF
     mkdir -p "$blind"
     blind_missing=""
     for tool in sh uname curl sed head cut grep tar gzip chmod mktemp dirname \
-        mkdir cp mv rm ln cat awk id getent sha256sum; do
+        mkdir cp mv rm ln cat awk id getent stat sha256sum; do
         tpath="$(command -v "$tool" 2>/dev/null)" || { blind_missing="$blind_missing $tool"; continue; }
         ln -sf "$tpath" "$blind/$tool"
     done
@@ -730,7 +730,9 @@ if [ "$(id -u)" = "0" ] && command -v mount >/dev/null 2>&1; then
 
         # With the pre-install check skipped, an incompatible binary reaches
         # the destination before anything has run it. Failing then must not
-        # leave the caller with nothing where a working copy stood.
+        # leave the caller with nothing where a working copy stood -- nor
+        # hand back a copy with permissions it never had.
+        chmod 0700 "$dest/srelens-tui" 2>/dev/null || true
         bad="$work/bad"
         mkdir -p "$bad"
         printf 'this is not a binary\n' > "$bad/srelens-tui"
@@ -765,6 +767,12 @@ EOF
             ok "the working copy survived a failed update"
         else
             no "the working copy was lost"
+        fi
+        restored_mode="$(stat -c %a "$dest/srelens-tui" 2>/dev/null)" || restored_mode="?"
+        if [ "$restored_mode" = "700" ]; then
+            ok "and came back with the permissions it had, not wider ones"
+        else
+            no "the restored binary is mode $restored_mode, was 700"
         fi
         rm -f "$work/fake/curl"
 
@@ -816,7 +824,7 @@ if command -v shasum >/dev/null 2>&1; then
     missing=''
     # getfacl among them: without it, and with a BusyBox ls, the installer
     # refuses before it ever reaches the hashing this case is about.
-    for tool in sh uname curl sed head cut grep tar gzip chmod mktemp dirname mkdir cp mv rm ln cat ls awk id getent getfacl shasum; do
+    for tool in sh uname curl sed head cut grep tar gzip chmod mktemp dirname mkdir cp mv rm ln cat ls awk id getent getfacl stat shasum; do
         path="$(command -v "$tool" 2>/dev/null)" || { missing="$missing $tool"; continue; }
         ln -sf "$path" "$limited/$tool"
     done

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -626,6 +626,21 @@ if [ "$made_user" = "tester" ]; then
         echo "  skip  no setfacl, or the filesystem will not take an ACL"
     fi
 
+    # A getfacl that FAILS is not a directory without an ACL. Empty output
+    # from a failed command reads exactly like a file carrying only its base
+    # entries.
+    mkdir -p "$work/fake"
+    cat > "$work/fake/getfacl" <<EOF
+#!/bin/sh
+exit 1
+EOF
+    chmod +x "$work/fake/getfacl"
+    home="$work/homes/acl-broken"
+    new_home "$home"
+    out="$(install_into "$home" "PATH=$work/fake:$PATH")" && rc=0 || rc=$?
+    check "a getfacl that fails is not read as no ACL" "cannot read the ACL" "$out" "$rc" 1
+    rm -f "$work/fake/getfacl"
+
     # And where neither tool can answer -- BusyBox without the acl package --
     # the install refuses rather than proceeding blind. That case used to be
     # documented as a known gap and allowed, which meant an ACL sailed

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -57,6 +57,7 @@ cleanup() {
     [ -z "$made_group" ] || groupdel "$made_group" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
+trap 'cleanup; exit 129' HUP
 trap 'cleanup; exit 130' INT
 trap 'cleanup; exit 143' TERM
 
@@ -1054,11 +1055,39 @@ EOF
     else
         chmod -R a+rx "$blind_attr"
         # install_into runs as an unprivileged account, and there the check is
-        # deliberately not required: a file capability needs root to set, so a
-        # user's own binary in their own directory cannot have one. Root is
-        # the case that refuses.
+        # deliberately not required: a file capability needs root to set, so
+        # one on a user's own binary is unusual. Root is the case that refuses.
+        # But root CAN set one on a user's file, and a rollback made with
+        # `cp -p` would not bring it back -- so the update says, up front,
+        # that the attributes were not checked and would not survive a
+        # rollback.
         out="$(install_into "$home" "PATH=$blind_attr")" && rc=0 || rc=$?
         check "an unprivileged update proceeds without getfattr" "Installed:" "$out" "$rc" 0
+        check "and says that extended attributes were not checked" "were not checked" "$out" "$rc" 0
+        # And when such an update IS rolled back, the caveat rides on the
+        # "put back" line: the previous copy is back, its attributes are not
+        # claimed to be. Same blind PATH, with the wrong-version fake curl
+        # from above in place of the real one.
+        blind_bad="$work/blind-attr-bad"
+        rm -rf "$blind_bad"
+        mkdir -p "$blind_bad"
+        for tpath in "$blind_attr"/*; do
+            ln -sf "$tpath" "$blind_bad/${tpath##*/}"
+        done
+        ln -sf "$work/fake/curl" "$blind_bad/curl"
+        chmod -R a+rx "$blind_bad"
+        home="$work/homes/blind-attr-rollback"
+        new_home "$home"
+        printf '#!/bin/sh\necho OLD COPY\n' > "$home/.local/bin/srelens-tui"
+        chmod 0755 "$home/.local/bin/srelens-tui"
+        chown tester "$home/.local/bin/srelens-tui" 2>/dev/null || true
+        out="$(install_into "$home" "PATH=$blind_bad")" && rc=0 || rc=$?
+        check "a rolled-back update without getfattr does not claim the attributes came back" "put back -- without any extended attributes" "$out" "$rc" 1
+        if grep -q "OLD COPY" "$home/.local/bin/srelens-tui" 2>/dev/null; then
+            ok "and the previous copy itself is back"
+        else
+            no "the previous copy did not come back"
+        fi
         if [ "$(id -u)" = "0" ]; then
             root_home="$work/homes/root-no-attr"
             rm -rf "$root_home"
@@ -1119,6 +1148,43 @@ if [ "$made_user" = "tester" ]; then
     else
         no "an interrupted update left hidden files in the install directory"
     fi
+    # HUP as well: an SSH session dropping mid-install. An untrapped HUP
+    # ends dash without running the EXIT trap, so this one has to be caught
+    # in its own right. Sent straight to the installer's pid, recorded by
+    # the shell that execs it, rather than to `su` -- which relays TERM but
+    # is not relied on to relay HUP.
+    home="$work/homes/interrupted-hup"
+    new_home "$home"
+    printf '#!/bin/sh\necho OLD COPY\n' > "$home/.local/bin/srelens-tui"
+    chmod 0755 "$home/.local/bin/srelens-tui"
+    chown tester "$home/.local/bin/srelens-tui" 2>/dev/null || true
+    pidfile="$work/hup.pid"
+    : > "$pidfile"
+    chown tester "$pidfile" 2>/dev/null || true
+    su tester -c "echo \$\$ > '$pidfile'; HOME='$home' exec sh '$script' --version '$version'" >"$work/hup.log" 2>&1 &
+    kill_pid=$!
+    tries=0
+    while [ "$tries" -lt 300 ]; do
+        grep -q "Installing srelens-tui" "$work/hup.log" 2>/dev/null && break
+        tries=$((tries + 1))
+        sleep 0.05
+    done
+    hup_pid="$(cat "$pidfile" 2>/dev/null)"
+    kill -HUP "${hup_pid:-$kill_pid}" 2>/dev/null || true
+    wait "$kill_pid" 2>/dev/null || true
+    if grep -q "OLD COPY" "$home/.local/bin/srelens-tui" 2>/dev/null; then
+        ok "a hung-up update leaves the previous binary in place"
+    elif [ -x "$home/.local/bin/srelens-tui" ]; then
+        ok "the update completed before the hangup landed, nothing to undo"
+    else
+        no "a hung-up update left no binary at all"
+    fi
+    if [ -z "$(find "$home/.local/bin" -name '.srelens-tui.*' 2>/dev/null)" ]; then
+        ok "and nothing hidden behind it"
+    else
+        no "a hung-up update left hidden files in the install directory"
+    fi
+
     # And the same interruption with NOTHING there beforehand. There is no
     # copy to put back, so the rollback has to remove what it installed --
     # otherwise an unvalidated binary is left on a PATH under a name that

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -111,6 +111,22 @@ if ! command -v getfacl >/dev/null 2>&1 &&
     exit 1
 fi
 
+# Same for getfattr, when running as root. A privileged install refuses to
+# REPLACE a binary whose extended attributes it cannot read -- a file
+# capability is the one that matters, and only root can put one there -- and
+# this suite installs over itself repeatedly, so every update case would fail
+# for that one reason.
+if [ "$(id -u)" = "0" ] && ! command -v getfattr >/dev/null 2>&1; then
+    echo "Running as root, but getfattr is not installed." >&2
+    echo "" >&2
+    echo "A privileged install refuses to replace a binary whose extended" >&2
+    echo "attributes it cannot read, and these cases install over themselves," >&2
+    echo "so every update below would fail for that reason alone." >&2
+    echo "" >&2
+    echo "Install the attr package first (Debian: apt install attr; Alpine: apk add attr)." >&2
+    exit 1
+fi
+
 # Where an install lands here, now that it cannot be told.
 #
 # /usr/local/bin when writable -- which for root is always, since
@@ -1036,8 +1052,25 @@ EOF
         echo "  skip  no getfattr-blind run:$attr_missing not found"
     else
         chmod -R a+rx "$blind_attr"
+        # install_into runs as an unprivileged account, and there the check is
+        # deliberately not required: a file capability needs root to set, so a
+        # user's own binary in their own directory cannot have one. Root is
+        # the case that refuses.
         out="$(install_into "$home" "PATH=$blind_attr")" && rc=0 || rc=$?
-        check "an update refuses when it cannot check for xattrs" "getfattr is not installed" "$out" "$rc" 1
+        check "an unprivileged update proceeds without getfattr" "Installed:" "$out" "$rc" 0
+        if [ "$(id -u)" = "0" ]; then
+            root_home="$work/homes/root-no-attr"
+            rm -rf "$root_home"
+            mkdir -p "$root_home/.local/bin"
+            printf '#!/bin/sh
+echo OLD
+' > "$root_home/.local/bin/srelens-tui"
+            chmod 0755 "$root_home/.local/bin/srelens-tui"
+            out="$(PATH="$blind_attr" HOME="$root_home" sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
+            check "a ROOT update refuses when it cannot check for xattrs" "getfattr is not installed" "$out" "$rc" 1
+        else
+            echo "  skip  not root: cannot test the privileged xattr requirement"
+        fi
     fi
     rm -f "$work/fake/curl"
 else

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -363,11 +363,13 @@ fi
 
 echo "how the docs say to run it"
 
-# The chained form the docs show. Unchained, a failed download leaves the
-# previous file sitting there to be run, and a failed install followed by a
-# successful rm ends the snippet at status 0.
+# The form the docs show: mktemp for the name, chained so a failure carries.
+# A fixed name in a shared directory can be pre-created as a symlink for
+# `curl -o` to truncate; unchained, a failed download leaves the previous file
+# to be run and a successful rm ends the snippet at status 0.
 chain_rc=0
-curl -fsSL "https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/no-such-file.sh" -o "$work/chain.sh" 2>/dev/null && sh "$work/chain.sh" >/dev/null 2>&1 && rm "$work/chain.sh" || chain_rc=$?
+f="$(mktemp)" && curl -fsSL "https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/no-such-file.sh" -o "$f" && sh "$f" >/dev/null 2>&1 || chain_rc=$?
+rm -f "$f"
 if [ "$chain_rc" != "0" ]; then
     ok "the chained form fails when the download fails, exit $chain_rc"
 else

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -296,6 +296,21 @@ else
     echo "  skip  not root, or no useradd: cannot test the foreign sticky directory"
 fi
 
+# A safe symlink must still install -- through the directory it points at,
+# named canonically. Approving the resolved path but staging and running
+# through the path as given would leave the link repointable after the check.
+target="$work/real-bin"
+mkdir -p "$target"
+link="$work/link-to-real"
+ln -sfn "$target" "$link"
+out="$(sh "$script" --version "$version" --install-dir "$link" 2>&1)" && rc=0 || rc=$?
+check "a safe symlink installs into its target" "Installed: $target/srelens-tui" "$out" "$rc" 0
+if [ -x "$target/srelens-tui" ]; then
+    ok "the binary landed in the resolved directory"
+else
+    no "nothing landed in the resolved directory"
+fi
+
 echo "hashing tool"
 
 # Every image this was first tested on has sha256sum, which is why the

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -99,11 +99,20 @@ mkdir -p "$HOME"
 # permission bits do not apply to uid 0 -- and $HOME/.local/bin otherwise.
 # So as root the cases below shape /usr/local/bin itself, which is the
 # directory a real `curl | sudo sh` installs into.
-if [ -w /usr/local/bin ]; then
-    default_dest="/usr/local/bin"
-else
-    default_dest="$HOME/.local/bin"
-fi
+# Asked of the installer rather than worked out again here. A version that
+# does not exist is enough: the destination is named before anything is
+# downloaded, so this costs one 404 rather than an archive.
+#
+# `writable` is not the whole rule: a world-writable /usr/local/bin, which is
+# what a GitHub runner has, is writable and refused, and the install falls
+# back to the home directory. Working that out a second time here is how the
+# two drift apart.
+default_dest="$(sh "$script" --version 0.0.1 2>&1 |
+    sed -n 's/^Installing .* into \(.*\)$/\1/p' | head -n 1)"
+[ -n "$default_dest" ] || {
+    echo "could not work out where the installer would install" >&2
+    exit 1
+}
 
 # Running as root means installing into the real /usr/local/bin and, for
 # the destination cases, bending it: world-writable, foreign-owned, ACL'd,
@@ -172,7 +181,7 @@ reset_dest() {
 # A case that bends the real destination only means something as root; an
 # unprivileged run would be installing into its own home instead.
 can_shape_dest() {
-    [ "$default_dest" = "/usr/local/bin" ]
+    [ "$default_dest" = "/usr/local/bin" ] && [ "$(id -u)" = "0" ]
 }
 
 # Somebody who is neither root nor us, for the ownership cases.
@@ -356,237 +365,275 @@ fi
 
 echo "unsafe destinations"
 
-# These bend /usr/local/bin itself, which is where a real `curl | sudo sh`
-# lands. The destination cannot be named any more, so testing what the rules
-# do means shaping the directory they will pick, and putting it back after.
-if can_shape_dest; then
-    # Whatever the install cases above left behind is not part of these.
-    reset_dest
+# These run as an unprivileged account with a HOME under $work.
+#
+# /usr/local/bin is not writable for that account, so the home branch of the
+# destination choice is the one taken -- which means every rule about the
+# destination can be exercised against a directory this suite owns, instead of
+# by bending a system one. Root cannot do it: permission bits do not apply to
+# uid 0, so root always writes /usr/local/bin whatever its mode.
+if [ "$made_user" != "tester" ] && [ "$(id -u)" = "0" ] &&
+    command -v useradd >/dev/null 2>&1; then
+    if useradd -m tester >/dev/null 2>&1; then
+        made_user="tester"
+    fi
+fi
+
+# Create a HOME for one case, owned by the account that will install into it.
+new_home() {
+    rm -rf "$1"
+    mkdir -p "$1/.local/bin"
+    chown -R tester "$1" 2>/dev/null || true
+    chgrp -R tester "$1" 2>/dev/null || true
+}
+
+# Run the installer as that account, with that HOME.
+install_into() {
+    ihome="$1"
+    shift
+    chmod 0711 "$work" 2>/dev/null || true
+    chmod 0644 "$script" 2>/dev/null || true
+    # Anything left is environment for the run, e.g. a PATH carrying a fake
+    # command ahead of the real one.
+    su tester -c "$* HOME='$ihome' sh '$script' --version '$version'" 2>&1
+}
+
+if [ "$made_user" = "tester" ]; then
+    # The plain case first: an ordinary home, an ordinary install.
+    home="$work/homes/plain"
+    new_home "$home"
+    out="$(install_into "$home")" && rc=0 || rc=$?
+    check "an ordinary home installs" "Installed: $home/.local/bin/srelens-tui" "$out" "$rc" 0
 
     # An unpredictable staging name does not survive a directory other users
     # can unlink from: they can take the staged file away and leave a symlink,
     # or replace the finished binary before it is run. Only the directory's
     # own permissions close that, so an unsafe one is refused outright.
-    chmod 0777 /usr/local/bin
-    out="$(sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
+    home="$work/homes/world"
+    new_home "$home"
+    chmod 0777 "$home/.local/bin"
+    out="$(install_into "$home")" && rc=0 || rc=$?
     check "a world-writable destination is refused" "writable by anyone" "$out" "$rc" 1
-    if [ -e /usr/local/bin/srelens-tui ]; then
+    if [ -e "$home/.local/bin/srelens-tui" ]; then
         no "it installed into the world-writable directory anyway"
     else
         ok "nothing was installed there"
     fi
-    reset_dest
 
     # The sticky bit is what makes /tmp safe: only an entry's owner may unlink
     # it, so the staged file cannot be taken away. That case must still work.
-    chmod 1777 /usr/local/bin
-    out="$(sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
+    home="$work/homes/sticky"
+    new_home "$home"
+    chmod 1777 "$home/.local/bin"
+    out="$(install_into "$home")" && rc=0 || rc=$?
     check "world-writable WITH the sticky bit still installs" "Installed:" "$out" "$rc" 0
-    reset_dest
 
     # A directory belonging to somebody else: they can arrange the swap at
-    # leisure and get a root-written file out of it.
-    if [ -n "$other_user" ] && chown "$other_user" /usr/local/bin 2>/dev/null; then
-        out="$(sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
+    # leisure and get a file written by the installing account out of it.
+    if [ -n "$other_user" ]; then
+        home="$work/homes/theirs"
+        new_home "$home"
+        # Theirs, but still writable by us: the point is that ownership is
+        # refused, not that the directory happened to be unwritable.
+        chown "$other_user" "$home/.local/bin" 2>/dev/null || true
+        chgrp tester "$home/.local/bin" 2>/dev/null || true
+        chmod 0770 "$home/.local/bin"
+        out="$(install_into "$home")" && rc=0 || rc=$?
         check "a directory owned by another user is refused" "belongs to $other_user" "$out" "$rc" 1
-        if [ -e /usr/local/bin/srelens-tui ]; then
+        if [ -e "$home/.local/bin/srelens-tui" ]; then
             no "it installed into the other user's directory anyway"
         else
             ok "nothing was installed there either"
         fi
-    else
-        echo "  skip  no second account to own the destination"
-    fi
-    reset_dest
 
-    # Sticky does not save a directory whose OWNER is somebody else: the owner
-    # may remove anything inside it regardless.
-    if [ -n "$other_user" ] && chown "$other_user" /usr/local/bin 2>/dev/null; then
-        chmod 1777 /usr/local/bin
-        out="$(sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
+        # Sticky does not save a directory whose OWNER is somebody else: the
+        # owner may remove anything inside it regardless.
+        home="$work/homes/theirs-sticky"
+        new_home "$home"
+        chown "$other_user" "$home/.local/bin" 2>/dev/null || true
+        chmod 1777 "$home/.local/bin"
+        out="$(install_into "$home")" && rc=0 || rc=$?
         check "a sticky directory owned by someone else is refused" "belongs to $other_user" "$out" "$rc" 1
+
+        # A directory can be impeccable itself and still sit under one somebody
+        # else owns, who can rename it and put their own in its place after the
+        # check. Every component is walked, so the ancestor is what fails.
+        home="$work/homes/foreign-parent"
+        new_home "$home"
+        chown "$other_user" "$home/.local" 2>/dev/null || true
+        out="$(install_into "$home")" && rc=0 || rc=$?
+        check "a directory under a foreign ancestor is refused" "belongs to $other_user" "$out" "$rc" 1
+        if [ -e "$home/.local/bin/srelens-tui" ]; then
+            no "it installed under the replaceable ancestor anyway"
+        else
+            ok "nothing was installed under the replaceable ancestor"
+        fi
     else
-        echo "  skip  no second account to own the destination"
+        echo "  skip  no second account: cannot test foreign ownership"
     fi
-    reset_dest
 
     # A symlink is not the directory it points at. `ls -ld` on one reports
     # `lrwxrwxrwx` owned by whoever made the link, so inspecting the path as
-    # given would describe the link while the install lands somewhere else.
+    # given would describe the link while the install lands somewhere else --
+    # and ~/.local/bin being a link is an ordinary thing for it to be.
     target="$work/unsafe-target"
+    rm -rf "$target"
     mkdir -p "$target"
     chmod 0777 "$target"
-    mv /usr/local/bin /usr/local/bin.real
-    ln -sfn "$target" /usr/local/bin
-    out="$(sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
+    home="$work/homes/link-unsafe"
+    new_home "$home"
+    rmdir "$home/.local/bin"
+    ln -sfn "$target" "$home/.local/bin"
+    out="$(install_into "$home")" && rc=0 || rc=$?
     check "a symlink to an unsafe directory is refused" "writable by anyone" "$out" "$rc" 1
     if [ -e "$target/srelens-tui" ]; then
         no "it installed through the symlink anyway"
     else
         ok "nothing was installed through the symlink"
     fi
-    rm -f /usr/local/bin
-    mv /usr/local/bin.real /usr/local/bin
-    reset_dest
 
     # A safe symlink must still install -- through the directory it points at,
     # named canonically. Approving the resolved path but staging and running
-    # through the path as given would leave the link repointable after the
-    # check.
+    # through the path as given would leave the link repointable afterwards.
     target="$work/real-bin"
+    rm -rf "$target"
     mkdir -p "$target"
-    mv /usr/local/bin /usr/local/bin.real
-    ln -sfn "$target" /usr/local/bin
-    out="$(sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
+    chown tester "$target" 2>/dev/null || true
+    chgrp tester "$target" 2>/dev/null || true
+    home="$work/homes/link-safe"
+    new_home "$home"
+    rmdir "$home/.local/bin"
+    ln -sfn "$target" "$home/.local/bin"
+    chown -h tester "$home/.local/bin" 2>/dev/null || true
+    out="$(install_into "$home")" && rc=0 || rc=$?
     check "a safe symlink installs into its target" "Installed: $target/srelens-tui" "$out" "$rc" 0
     if [ -x "$target/srelens-tui" ]; then
         ok "the binary landed in the resolved directory"
     else
         no "nothing landed in the resolved directory"
     fi
-    rm -f /usr/local/bin
-    mv /usr/local/bin.real /usr/local/bin
-    reset_dest
-
-    # A directory can be impeccable itself and still sit under one somebody
-    # else owns, who can rename it and put their own in its place after the
-    # check. Every component is walked, so the ancestor is what fails here.
-    if [ -n "$other_user" ] && chown "$other_user" /usr/local 2>/dev/null; then
-        out="$(sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
-        check "a directory under a foreign ancestor is refused" "belongs to $other_user" "$out" "$rc" 1
-        if [ -e /usr/local/bin/srelens-tui ]; then
-            no "it installed under the replaceable ancestor anyway"
-        else
-            ok "nothing was installed under the replaceable ancestor"
-        fi
-    else
-        echo "  skip  no second account to own an ancestor"
-    fi
-    reset_dest
 
     # `mv file dir` moves the file INTO the directory. A destination that is
     # already a directory would swallow the staging file and leave nothing at
     # the path asked for -- and the version line used to hide that inside a
     # command substitution, so the install printed Installed and exited 0.
-    mkdir -p /usr/local/bin/srelens-tui
-    out="$(sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
+    home="$work/homes/dir-dest"
+    new_home "$home"
+    mkdir -p "$home/.local/bin/srelens-tui"
+    out="$(install_into "$home")" && rc=0 || rc=$?
     check "a directory where the binary goes is refused" "is a directory" "$out" "$rc" 1
     case "$out" in
         *Installed:*) no "it claimed to have installed something" ;;
         *) ok "it did not claim to have installed anything" ;;
     esac
+else
+    echo "  skip  no unprivileged account this run created: cannot shape a destination"
+fi
+
+# Writable is not the same as safe, and the difference decides where the
+# install goes rather than whether it happens. A GitHub runner ships
+# /usr/local/bin world-writable: the rules refuse THAT directory, and the
+# install falls back to the home one rather than giving up.
+#
+# The only case here that touches a system directory, hence the container
+# gate at the top of this file.
+if [ "$made_user" = "tester" ] && can_shape_dest; then
+    chmod 0777 /usr/local/bin
+    home="$work/homes/fallback"
+    new_home "$home"
+    out="$(install_into "$home")" && rc=0 || rc=$?
+    check "an unsafe /usr/local/bin falls back rather than refusing" "Installed: $home/.local/bin/srelens-tui" "$out" "$rc" 0
     reset_dest
 else
-    echo "  skip  not root: the destination is this account's own home, not a directory to bend"
+    echo "  skip  not root in a container: cannot make /usr/local/bin unsafe"
 fi
 
 echo "shared groups and ancestors"
 
-if can_shape_dest && command -v groupadd >/dev/null 2>&1; then
+if [ "$made_user" = "tester" ]; then
     # A group-writable directory is only safe when the group is the owner's
     # own -- the per-user-group convention. A shared group is a set of people
     # who can each replace the binary between staging and running it.
-    if ! getent group shared >/dev/null 2>&1; then
-        if groupadd shared >/dev/null 2>&1; then
-            made_group="shared"
+    if command -v groupadd >/dev/null 2>&1; then
+        if ! getent group shared >/dev/null 2>&1; then
+            if groupadd shared >/dev/null 2>&1; then
+                made_group="shared"
+            fi
         fi
-    fi
-    if chgrp shared /usr/local/bin 2>/dev/null; then
-        chmod 0775 /usr/local/bin
-        out="$(sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
-        check "a directory writable by a shared group is refused" "group shared" "$out" "$rc" 1
+        home="$work/homes/shared-group"
+        new_home "$home"
+        if chgrp shared "$home/.local/bin" 2>/dev/null; then
+            chmod 0775 "$home/.local/bin"
+            out="$(install_into "$home")" && rc=0 || rc=$?
+            check "a directory writable by a shared group is refused" "group shared" "$out" "$rc" 1
+        else
+            echo "  skip  could not set a shared group"
+        fi
     else
-        echo "  skip  could not set a shared group"
+        echo "  skip  no groupadd: cannot test a shared group"
     fi
-    reset_dest
+
+    # The per-user-group case must keep working, or every Fedora install with
+    # a 002 umask breaks: there ~/.local/bin is `alice:alice` mode 0775.
+    home="$work/homes/own-group"
+    new_home "$home"
+    chmod 0775 "$home/.local/bin"
+    out="$(install_into "$home")" && rc=0 || rc=$?
+    check "group-writable by the owner's own group still installs" "Installed:" "$out" "$rc" 0
 
     # A group named after its owner is the per-user-group CONVENTION, not a
     # guarantee. If the group really has other members, any of them can
     # replace the binary, so membership is looked up rather than assumed.
-    #
-    # Only ever on an account this run created: adding a pre-existing account
-    # to group root and removing it again would strip a membership the host
-    # meant to have.
-    if ! id -u tester >/dev/null 2>&1 && command -v useradd >/dev/null 2>&1; then
-        if useradd -m tester >/dev/null 2>&1; then
-            made_user="tester"
-        fi
-    fi
-    if [ "$made_user" = "tester" ] && command -v usermod >/dev/null 2>&1 &&
-        usermod -aG root tester >/dev/null 2>&1; then
-        chmod 0775 /usr/local/bin
-        out="$(sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
-        check "an owner-named group with real members is refused" "besides root" "$out" "$rc" 1
-        gpasswd -d tester root >/dev/null 2>&1 || true
+    if [ -n "$other_user" ] && command -v usermod >/dev/null 2>&1 &&
+        usermod -aG tester "$other_user" >/dev/null 2>&1; then
+        home="$work/homes/own-group-shared"
+        new_home "$home"
+        chmod 0775 "$home/.local/bin"
+        out="$(install_into "$home")" && rc=0 || rc=$?
+        check "an owner-named group with real members is refused" "besides tester" "$out" "$rc" 1
+        gpasswd -d "$other_user" tester >/dev/null 2>&1 || true
     else
-        echo "  skip  no account this run created: not touching an existing one's groups"
+        echo "  skip  cannot add a second member to the account's own group"
     fi
-    reset_dest
 
     # Supplementary members are only half of a group: an account whose PRIMARY
     # group it is never appears in the member list, while it can write there
     # perfectly well.
-    if [ "$made_user" = "tester" ] && command -v useradd >/dev/null 2>&1; then
-        if useradd -M -g root primaryroot >/dev/null 2>&1; then
-            # Recorded BEFORE it is used: an interrupt between the useradd and
-            # the userdel below would otherwise leave the account behind.
-            made_users="$made_users primaryroot"
-            chmod 0775 /usr/local/bin
-            out="$(sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
-            check "a group that is someone else's primary group is refused" "primaryroot" "$out" "$rc" 1
-            userdel primaryroot >/dev/null 2>&1 || true
-            made_users="$(printf %s "$made_users" | sed 's/ primaryroot//')"
-        else
-            echo "  skip  could not create an account with a primary GID of 0"
-        fi
+    if command -v useradd >/dev/null 2>&1 &&
+        useradd -M -g tester primarytester >/dev/null 2>&1; then
+        # Recorded BEFORE it is used: an interrupt between the useradd and the
+        # userdel below would otherwise leave the account behind.
+        made_users="$made_users primarytester"
+        home="$work/homes/primary-gid"
+        new_home "$home"
+        chmod 0775 "$home/.local/bin"
+        out="$(install_into "$home")" && rc=0 || rc=$?
+        check "a group that is someone else's primary group is refused" "primarytester" "$out" "$rc" 1
+        userdel primarytester >/dev/null 2>&1 || true
+        made_users="$(printf %s "$made_users" | sed 's/ primarytester//')"
     else
-        echo "  skip  no account this run created: cannot test primary-group membership"
+        echo "  skip  could not create an account sharing that primary group"
     fi
-    reset_dest
 
     # An extended ACL can grant write to any account while the mode bits look
     # impeccable. ls marks one with a trailing +, and reading an ACL portably
     # is not something a POSIX shell can do, so the marker alone is a refusal.
+    #
+    # BusyBox ls does not print that marker, so there the ACL is invisible to
+    # the check and this case has nothing to assert.
+    home="$work/homes/acl"
+    new_home "$home"
     # shellcheck disable=SC2012  # reading the mode string is the whole point
-    # The guard reads the trailing + that `ls -l` puts on a directory with an
-    # extended ACL. BusyBox ls does not print it, so there the ACL is invisible
-    # to the check and this case has nothing to assert.
     if command -v setfacl >/dev/null 2>&1 && [ -n "$other_user" ] &&
-        setfacl -m "u:$other_user:rwx" /usr/local/bin 2>/dev/null &&
-        [ "$(ls -ld /usr/local/bin | cut -c11)" = "+" ]; then
-        out="$(sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
+        setfacl -m "u:$other_user:rwx" "$home/.local/bin" 2>/dev/null &&
+        [ "$(ls -ld "$home/.local/bin" | cut -c11)" = "+" ]; then
+        out="$(install_into "$home")" && rc=0 || rc=$?
         check "a directory with an extended ACL is refused" "extended ACL" "$out" "$rc" 1
     else
         echo "  skip  no setfacl, or this ls does not mark ACLs (BusyBox)"
     fi
-    reset_dest
 else
-    echo "  skip  not root, or no groupadd: cannot shape the destination's group"
-fi
-
-# The per-user-group case must keep working, or every Fedora install with a
-# 002 umask breaks: there ~/.local/bin is `alice:alice` mode 0775.
-#
-# As the user, into their own home -- which is the actual shape, and the one
-# branch of the destination choice that root never takes.
-if [ "$made_user" = "tester" ]; then
-    tester_home="$(getent passwd tester | cut -d: -f6)"
-    if [ -n "$tester_home" ] && [ -d "$tester_home" ]; then
-        mkdir -p "$tester_home/.local/bin"
-        # Group as well as owner: made by root, the tree carries root group,
-        # which is not the per-user group this case is about.
-        chown -R tester:tester "$tester_home/.local" 2>/dev/null ||
-            chown -R tester "$tester_home/.local" 2>/dev/null || true
-        chmod 0775 "$tester_home/.local/bin"
-        chmod 0644 "$script" 2>/dev/null || true
-        chmod 0711 "$work" 2>/dev/null || true
-        out="$(su tester -c "sh '$script' --version '$version'" 2>&1)" && rc=0 || rc=$?
-        check "group-writable by the owner's own group still installs" "Installed: $tester_home/.local/bin/srelens-tui" "$out" "$rc" 0
-    else
-        echo "  skip  the created account has no home directory"
-    fi
-else
-    echo "  skip  no account this run created: cannot test a per-user group"
+    echo "  skip  no unprivileged account this run created: cannot shape a group"
 fi
 
 echo "temporary directory"
@@ -693,41 +740,43 @@ dest="$default_dest"
 out="$(TMPDIR="$link_tmp" sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
 check "a TMPDIR symlink is resolved before it is judged" "writable by anyone" "$out" "$rc" 1
 
-# A lookup that fails is not a group with nobody in it. These only run for a
-# group-writable destination, so shape it that way first -- whichever of the
-# two destinations this account gets.
-chmod 0775 "$default_dest" 2>/dev/null || true
-mkdir -p "$work/fake"
-cat > "$work/fake/getent" <<EOF
+# A lookup that fails is not a group with nobody in it. Only reached for a
+# group-writable destination, so these run as the unprivileged account
+# against a home shaped that way.
+if [ "$made_user" = "tester" ]; then
+    mkdir -p "$work/fake"
+    cat > "$work/fake/getent" <<'EOF'
 #!/bin/sh
 exit 2
 EOF
-chmod +x "$work/fake/getent"
-dest="$work/getent-down"
-mkdir -p "$dest"
-chmod 0775 "$dest"
-out="$(PATH="$work/fake:$PATH" sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
-check "a group lookup that fails is not treated as empty" "cannot look up the group" "$out" "$rc" 1
+    chmod +x "$work/fake/getent"
+    home="$work/homes/getent-down"
+    new_home "$home"
+    chmod 0775 "$home/.local/bin"
+    out="$(install_into "$home" "PATH=$work/fake:\$PATH")" && rc=0 || rc=$?
+    check "a group lookup that fails is not treated as empty" "cannot look up the group" "$out" "$rc" 1
 
-# And neither is a passwd lookup that fails. In `getent passwd | awk` the
-# status belongs to awk, which succeeds on no input, so a partial outage
-# would read as "nobody else is in this group".
-cat > "$work/fake/getent" <<'EOF'
+    # And neither is a passwd lookup that fails. In `getent passwd | awk`
+    # the status belongs to awk, which succeeds on no input, so a partial
+    # outage would read as "nobody else is in this group".
+    cat > "$work/fake/getent" <<'EOF'
 #!/bin/sh
 case "${1:-}" in
-  group)  echo "root:x:0:" ;;
+  group)  echo "tester:x:1000:" ;;
   passwd) exit 2 ;;
   *) exit 2 ;;
 esac
 EOF
-chmod +x "$work/fake/getent"
-dest="$work/passwd-down"
-mkdir -p "$dest"
-chmod 0775 "$dest"
-out="$(PATH="$work/fake:$PATH" sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
-check "a passwd lookup that fails is not treated as empty" "cannot enumerate accounts" "$out" "$rc" 1
-rm -f "$work/fake/getent"
-reset_dest
+    chmod +x "$work/fake/getent"
+    home="$work/homes/passwd-down"
+    new_home "$home"
+    chmod 0775 "$home/.local/bin"
+    out="$(install_into "$home" "PATH=$work/fake:\$PATH")" && rc=0 || rc=$?
+    check "a passwd lookup that fails is not treated as empty" "cannot enumerate accounts" "$out" "$rc" 1
+    rm -f "$work/fake/getent"
+else
+    echo "  skip  no unprivileged account this run created: cannot test a failed lookup"
+fi
 
 echo "unpacking"
 

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -368,8 +368,7 @@ echo "how the docs say to run it"
 # `curl -o` to truncate; unchained, a failed download leaves the previous file
 # to be run and a successful rm ends the snippet at status 0.
 chain_rc=0
-f="$(mktemp)" && curl -fsSL "https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/no-such-file.sh" -o "$f" && sh "$f" >/dev/null 2>&1 || chain_rc=$?
-rm -f "$f"
+( f="$(mktemp)" && trap 'rm -f "$f"' EXIT && curl -fsSL "https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/no-such-file.sh" -o "$f" && sh "$f" >/dev/null 2>&1 ) || chain_rc=$?
 if [ "$chain_rc" != "0" ]; then
     ok "the chained form fails when the download fails, exit $chain_rc"
 else

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -188,10 +188,10 @@ fi
 # ETXTBSY or leave the staging file behind.
 out="$(sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
 check "installing over an existing copy succeeds" "Installed:" "$out" "$rc" 0
-if [ -z "$(find "$dest" -name '.srelens-tui.install.*' 2>/dev/null)" ]; then
-    ok "no staging file is left behind"
+if [ -z "$(find "$dest" -name '.srelens-tui.install.*' -o -name '.srelens-tui.backup.*' 2>/dev/null)" ]; then
+    ok "no staging or backup file is left behind"
 else
-    no "a staging file was left in $dest"
+    no "a staging or backup file was left in $dest"
 fi
 
 echo "through a pipe"
@@ -531,6 +531,47 @@ if [ "$(id -u)" = "0" ] && command -v mount >/dev/null 2>&1; then
         out="$(TMPDIR="$noexec" sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
         check "a noexec working directory still installs" "Installed:" "$out" "$rc" 0
         check "and says why the check moved" "mounted noexec" "$out" "$rc" 0
+
+        # With the pre-install check skipped, an incompatible binary reaches
+        # the destination before anything has run it. Failing then must not
+        # leave the caller with nothing where a working copy stood.
+        bad="$work/bad"
+        mkdir -p "$bad"
+        printf 'this is not a binary\n' > "$bad/srelens-tui"
+        printf 'nothing here either\n' > "$bad/LICENSE"
+        badarchive="srelens-tui-$version-x86_64-unknown-linux-musl.tar.gz"
+        (cd "$bad" && tar -czf "$work/fixtures/$badarchive.bad" .)
+        badsum="$(sha256sum "$work/fixtures/$badarchive.bad" | cut -d" " -f1)"
+        printf '%s  %s\n' "$badsum" "$badarchive" > "$work/fixtures/BADSUMS.txt"
+        cat > "$work/fake/curl" <<EOF
+#!/bin/sh
+out=""; url=""
+while [ \$# -gt 0 ]; do
+  case "\$1" in
+    -o) out="\$2"; shift 2 ;;
+    http*) url="\$1"; shift ;;
+    *) shift ;;
+  esac
+done
+case "\$url" in
+  *api.github.com*) echo '{"tag_name": "srelens-v$version"}' ;;
+  *SHA256SUMS*)     cp "$work/fixtures/BADSUMS.txt" "\$out" ;;
+  *.tar.gz)         cp "$work/fixtures/$badarchive.bad" "\$out" ;;
+  *) exit 1 ;;
+esac
+EOF
+        chmod +x "$work/fake/curl"
+
+        out="$(TMPDIR="$noexec" PATH="$work/fake:$PATH" sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+        check "a binary that will not run is rejected after install" "does not run" "$out" "$rc" 1
+        check "and the previous copy is put back" "put back" "$out" "$rc" 1
+        if [ -x "$dest/srelens-tui" ] && "$dest/srelens-tui" --version >/dev/null 2>&1; then
+            ok "the working copy survived a failed update"
+        else
+            no "the working copy was lost"
+        fi
+        rm -f "$work/fake/curl"
+
         umount "$noexec" 2>/dev/null || true
     else
         echo "  skip  cannot mount a noexec filesystem here (needs CAP_SYS_ADMIN)"
@@ -538,6 +579,34 @@ if [ "$(id -u)" = "0" ] && command -v mount >/dev/null 2>&1; then
 else
     echo "  skip  not root, or no mount: cannot test a noexec working directory"
 fi
+
+# TMPDIR can be a symlink, and every download, extraction and copy reopens
+# $tmp by name. Approving the resolved path but working through the link
+# would leave it repointable the moment after it passed, so the resolved
+# path is what gets kept -- which means resolution has to see through it.
+real_tmp="$work/tmp-target"
+mkdir -p "$real_tmp"
+chmod 0777 "$real_tmp"
+link_tmp="$work/tmp-link"
+ln -sfn "$real_tmp" "$link_tmp"
+dest="$work/via-link"
+mkdir -p "$dest"
+out="$(TMPDIR="$link_tmp" sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+check "a TMPDIR symlink is resolved before it is judged" "writable by anyone" "$out" "$rc" 1
+
+# A lookup that fails is not a group with nobody in it.
+mkdir -p "$work/fake"
+cat > "$work/fake/getent" <<EOF
+#!/bin/sh
+exit 2
+EOF
+chmod +x "$work/fake/getent"
+dest="$work/getent-down"
+mkdir -p "$dest"
+chmod 0775 "$dest"
+out="$(PATH="$work/fake:$PATH" sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+check "a group lookup that fails is not treated as empty" "cannot look up the group" "$out" "$rc" 1
+rm -f "$work/fake/getent"
 
 echo "unpacking"
 

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -171,7 +171,7 @@ if [ "$(id -u)" = "0" ] && [ "$default_dest" = "/usr/local/bin" ]; then
         echo "  docker run --rm -v \"\$PWD/packaging/install:/i:ro\" \\" >&2
         echo "    debian:bookworm-slim sh -c '" >&2
         echo "      apt-get -qq update" >&2
-        echo "      apt-get -qq install -y curl ca-certificates acl libdigest-sha-perl" >&2
+        echo "      apt-get -qq install -y curl ca-certificates acl attr libcap2-bin libdigest-sha-perl" >&2
         echo "      cp -r /i /tmp/i && sh /tmp/i/test.sh" >&2
         echo "    '" >&2
         echo "" >&2

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -972,6 +972,28 @@ EOF
         no "the previous binary was destroyed by a failed rollback"
     fi
     rm -f "$work/fake/mv"
+
+    # The same honesty on the other branch. A FIRST install that is rejected
+    # has no backup to restore, so the rollback removes what it put there --
+    # and if that removal fails, saying it was removed would leave a rejected
+    # binary on PATH under a name the caller now trusts.
+    #
+    # An `rm` that refuses to delete the installed path is what a read-only
+    # mount or an immutable flag looks like from in there.
+    cat > "$work/fake/rm" <<EOF
+#!/bin/sh
+for a in \$@; do
+  case "\$a" in */srelens-tui) exit 1 ;; esac
+done
+exec /bin/rm "\$@"
+EOF
+    chmod +x "$work/fake/rm"
+    home="$work/homes/removal-fails"
+    new_home "$home"
+    out="$(install_into "$home" "PATH=$work/fake:$PATH")" && rc=0 || rc=$?
+    check "a rejected first install that cannot be removed says so" "could NOT be removed" "$out" "$rc" 1
+    check "and names where it is still installed" "$home/.local/bin/srelens-tui" "$out" "$rc" 1
+    rm -f "$work/fake/rm"
     rm -f "$work/fake/curl"
 else
     echo "  skip  no unprivileged account this run created: cannot test a wrong version"

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -18,7 +18,18 @@ script="$here/install.sh"
 [ -f "$script" ] || { echo "install.sh not found next to $0" >&2; exit 1; }
 
 work="$(mktemp -d)"
-trap 'rm -rf "$work"' EXIT INT TERM
+
+# Some cases need a second account and a shared group to be meaningful.
+# Anything this run creates, this run removes: a test suite that leaves a
+# login account behind on the host has done more than test.
+made_user=""
+made_group=""
+cleanup() {
+    rm -rf "$work"
+    [ -z "$made_user" ] || userdel -r "$made_user" >/dev/null 2>&1 || true
+    [ -z "$made_group" ] || groupdel "$made_group" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
 
 pass=0
 fail=0
@@ -185,6 +196,9 @@ echo "through a pipe"
 # `sh` -- it reads them as its own -- so the docs say `sh -s --`, and this
 # proves that form reaches the script's parser.
 dest="$work/piped"
+# The `cat` is the point: this reproduces the documented one-liner, where
+# the script arrives on stdin rather than as a path.
+# shellcheck disable=SC2002
 out="$(cat "$script" | sh -s -- --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
 check "options survive sh -s --" "Installed: $dest/srelens-tui" "$out" "$rc" 0
 
@@ -242,7 +256,11 @@ check "world-writable WITH the sticky bit still installs" "Installed:" "$out" "$
 # refusing outright: the owner can arrange the swap at leisure and gets a
 # root-written file out of it.
 if [ "$(id -u)" = "0" ] && command -v useradd >/dev/null 2>&1; then
-    id -u tester >/dev/null 2>&1 || useradd -m tester >/dev/null 2>&1 || true
+    if ! id -u tester >/dev/null 2>&1; then
+        if useradd -m tester >/dev/null 2>&1; then
+            made_user="tester"
+        fi
+    fi
     dest="$work/theirs"
     mkdir -p "$dest"
     if chown tester "$dest" 2>/dev/null; then
@@ -282,7 +300,11 @@ fi
 # sticky directory belonging to someone else is still theirs to tamper
 # with -- the same condition self_update.rs already applies.
 if [ "$(id -u)" = "0" ] && command -v useradd >/dev/null 2>&1; then
-    id -u tester >/dev/null 2>&1 || useradd -m tester >/dev/null 2>&1 || true
+    if ! id -u tester >/dev/null 2>&1; then
+        if useradd -m tester >/dev/null 2>&1; then
+            made_user="tester"
+        fi
+    fi
     dest="$work/their-sticky"
     mkdir -p "$dest"
     chmod 1777 "$dest"
@@ -317,7 +339,11 @@ echo "shared groups and ancestors"
 # own -- the per-user-group convention. A shared group is a set of people
 # who can each replace the binary between staging and running it.
 if [ "$(id -u)" = "0" ] && command -v groupadd >/dev/null 2>&1; then
-    groupadd -f shared >/dev/null 2>&1 || true
+    if ! getent group shared >/dev/null 2>&1; then
+        if groupadd shared >/dev/null 2>&1; then
+            made_group="shared"
+        fi
+    fi
     dest="$work/shared-group"
     mkdir -p "$dest"
     if chgrp shared "$dest" 2>/dev/null; then
@@ -343,7 +369,11 @@ check "group-writable by the owner's own group still installs" "Installed:" "$ou
 # else owns, who can rename it and put their own in its place after the
 # check. Every component is walked, so the parent is what fails here.
 if [ "$(id -u)" = "0" ] && command -v useradd >/dev/null 2>&1; then
-    id -u tester >/dev/null 2>&1 || useradd -m tester >/dev/null 2>&1 || true
+    if ! id -u tester >/dev/null 2>&1; then
+        if useradd -m tester >/dev/null 2>&1; then
+            made_user="tester"
+        fi
+    fi
     parent="$work/theirs-parent"
     mkdir -p "$parent/child"
     if chown tester "$parent" 2>/dev/null; then
@@ -359,6 +389,45 @@ if [ "$(id -u)" = "0" ] && command -v useradd >/dev/null 2>&1; then
     fi
 else
     echo "  skip  not root, or no useradd: cannot test the ancestor walk"
+fi
+
+# An extended ACL can grant write to any account while the mode bits look
+# impeccable. ls marks one with a trailing +, and reading an ACL portably is
+# not something a POSIX shell can do, so the marker alone is a refusal.
+if [ "$(id -u)" = "0" ] && command -v setfacl >/dev/null 2>&1; then
+    dest="$work/acl"
+    mkdir -p "$dest"
+    if setfacl -m u:nobody:rwx "$dest" 2>/dev/null; then
+        out="$(sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+        check "a directory with an extended ACL is refused" "extended ACL" "$out" "$rc" 1
+    else
+        echo "  skip  could not set an ACL on this filesystem"
+    fi
+else
+    echo "  skip  not root, or no setfacl: cannot test the ACL refusal"
+fi
+
+# A group named after its owner is the per-user-group CONVENTION, not a
+# guarantee. If the group really has other members, any of them can replace
+# the binary, so membership is looked up rather than assumed.
+if [ "$(id -u)" = "0" ] && command -v usermod >/dev/null 2>&1; then
+    if ! id -u tester >/dev/null 2>&1; then
+        if useradd -m tester >/dev/null 2>&1; then
+            made_user="tester"
+        fi
+    fi
+    if usermod -aG root tester >/dev/null 2>&1; then
+        dest="$work/owner-group-shared"
+        mkdir -p "$dest"
+        chmod 0775 "$dest"
+        out="$(sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+        check "an owner-named group with real members is refused" "members besides root" "$out" "$rc" 1
+        gpasswd -d tester root >/dev/null 2>&1 || true
+    else
+        echo "  skip  could not add a member to a group"
+    fi
+else
+    echo "  skip  not root, or no usermod: cannot test group membership"
 fi
 
 echo "unpacking"
@@ -383,7 +452,7 @@ if command -v shasum >/dev/null 2>&1; then
     limited="$work/limited"
     mkdir -p "$limited"
     missing=''
-    for tool in sh uname curl sed head cut grep tar gzip chmod mktemp dirname mkdir cp mv rm ln cat ls awk id shasum; do
+    for tool in sh uname curl sed head cut grep tar gzip chmod mktemp dirname mkdir cp mv rm ln cat ls awk id getent shasum; do
         path="$(command -v "$tool" 2>/dev/null)" || { missing="$missing $tool"; continue; }
         ln -sf "$path" "$limited/$tool"
     done

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -36,8 +36,15 @@ work="$(mktemp -d)"
 made_user=""
 made_users=""
 mounted=""
+orig_mode=""
+orig_owner=""
+orig_group=""
 made_group=""
 cleanup() {
+    # The destination first: an interrupt during the ownership cases would
+    # otherwise leave /usr/local/bin world-writable, foreign-owned, or a
+    # symlink to a directory this is about to delete.
+    reset_dest 2>/dev/null || true
     # Before the rm. A live mount inside $work makes `rm -rf` fail, and
     # under `set -e` the trap would exit there -- leaving the accounts
     # behind AND the tmpfs mounted on a developer's machine.
@@ -87,9 +94,44 @@ else
     default_dest="$HOME/.local/bin"
 fi
 
-# Put /usr/local/bin back the way a distribution ships it. Every case that
-# bends it calls this afterwards, so the next one starts from a known
-# state rather than from whatever the last one left.
+# Running as root means installing into the real /usr/local/bin and, for
+# the destination cases, bending it: world-writable, foreign-owned, ACL'd,
+# replaced by a symlink. An interrupt between shaping and restoring would
+# leave it that way, and any srelens-tui already there gets overwritten.
+#
+# Fine in a container, not fine on somebody's machine. Refuse rather than
+# do it quietly -- CI runs this inside a container, which is why the root
+# pass exists at all.
+if [ "$(id -u)" = "0" ] && [ "$default_dest" = "/usr/local/bin" ]; then
+    if [ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ] &&
+        [ -z "${SRELENS_TEST_ALLOW_SYSTEM:-}" ]; then
+        echo "Refusing to run as root outside a container." >&2
+        echo "" >&2
+        echo "These cases install into /usr/local/bin and reshape it -- they make it" >&2
+        echo "world-writable, foreign-owned, ACL-bearing, even a symlink -- and an" >&2
+        echo "interrupt would leave it that way. Any srelens-tui already there would" >&2
+        echo "be overwritten too." >&2
+        echo "" >&2
+        echo "Run them in a container:" >&2
+        echo "  docker run --rm -v \"\$PWD/packaging/install:/i:ro\" debian:bookworm-slim \\" >&2
+        echo "    sh -c \"apt-get -qq update && apt-get -qq install -y curl ca-certificates acl \\" >&2
+        echo "           libdigest-sha-perl && cp -r /i /tmp/i && sh /tmp/i/test.sh\"" >&2
+        echo "" >&2
+        echo "or, if this machine is disposable, SRELENS_TEST_ALLOW_SYSTEM=1." >&2
+        exit 1
+    fi
+
+    # What the directory looked like before any of this, so it can be put
+    # back as it was rather than reset to a guess about what it should be.
+    orig_mode="$(stat -c %a /usr/local/bin 2>/dev/null)" || orig_mode=""
+    orig_owner="$(stat -c %u /usr/local/bin 2>/dev/null)" || orig_owner=""
+    orig_group="$(stat -c %g /usr/local/bin 2>/dev/null)" || orig_group=""
+fi
+
+# Put the destination back as it was found. Every case that bends it calls
+# this afterwards, and so does the exit trap -- an interrupt in the middle
+# of the ownership cases would otherwise leave a system directory
+# world-writable or belonging to somebody else.
 reset_dest() {
     if [ "$default_dest" != "/usr/local/bin" ]; then
         # The home branch: nothing to chown, but the mode and any leftover
@@ -98,11 +140,17 @@ reset_dest() {
         rm -rf "$default_dest/srelens-tui"
         return 0
     fi
+    # A case may have moved the directory aside to put a symlink there.
+    if [ -L /usr/local/bin ] && [ -d /usr/local/bin.real ]; then
+        rm -f /usr/local/bin
+        mv /usr/local/bin.real /usr/local/bin
+    fi
     setfacl -b /usr/local/bin 2>/dev/null || true
-    chown root /usr/local/bin 2>/dev/null || true
-    chgrp root /usr/local/bin 2>/dev/null || true
-    chmod 0755 /usr/local/bin 2>/dev/null || true
-    chown root /usr/local 2>/dev/null || true
+    # The values this run found, not a guess at what a distribution ships.
+    [ -z "$orig_owner" ] || chown "$orig_owner" /usr/local/bin 2>/dev/null || true
+    [ -z "$orig_group" ] || chgrp "$orig_group" /usr/local/bin 2>/dev/null || true
+    [ -z "$orig_mode" ] || chmod "$orig_mode" /usr/local/bin 2>/dev/null || true
+    [ -z "$orig_owner" ] || chown "$orig_owner" /usr/local 2>/dev/null || true
     rm -rf /usr/local/bin/srelens-tui
 }
 
@@ -484,6 +532,7 @@ if can_shape_dest && command -v groupadd >/dev/null 2>&1; then
     # An extended ACL can grant write to any account while the mode bits look
     # impeccable. ls marks one with a trailing +, and reading an ACL portably
     # is not something a POSIX shell can do, so the marker alone is a refusal.
+    # shellcheck disable=SC2012  # reading the mode string is the whole point
     # The guard reads the trailing + that `ls -l` puts on a directory with an
     # extended ACL. BusyBox ls does not print it, so there the ACL is invisible
     # to the check and this case has nothing to assert.

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -347,6 +347,17 @@ fi
 
 echo "how the docs say to run it"
 
+# The chained form the docs show. Unchained, a failed download leaves the
+# previous file sitting there to be run, and a failed install followed by a
+# successful rm ends the snippet at status 0.
+chain_rc=0
+curl -fsSL "https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/no-such-file.sh" -o "$work/chain.sh" 2>/dev/null && sh "$work/chain.sh" >/dev/null 2>&1 && rm "$work/chain.sh" || chain_rc=$?
+if [ "$chain_rc" != "0" ]; then
+    ok "the chained form fails when the download fails, exit $chain_rc"
+else
+    no "the chained form reported success on a failed download"
+fi
+
 # The documented form is download-then-run, not `curl | sh`. A pipeline
 # reports its LAST command, so a download that fails leaves sh reading an
 # empty script, doing nothing, and exiting 0 -- the line succeeds having
@@ -860,6 +871,51 @@ dest="$default_dest"
 out="$(TMPDIR="$link_tmp" sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
 check "a TMPDIR symlink is resolved before it is judged" "writable by other users" "$out" "$rc" 1
 
+
+echo "interrupted mid-update"
+
+# A signal arriving after the destination has been replaced but before the
+# new binary has been run leaves an unvalidated copy live and the old one
+# hidden under a random name. The traps have to undo that.
+#
+# Timed by watching for the line printed just before the download starts,
+# then killing it: the replacement happens after that, so this covers the
+# window rather than one instant inside it. Either outcome is acceptable --
+# the old binary back, or the update having finished first -- but not a
+# destination left empty or littered.
+if [ "$made_user" = "tester" ]; then
+    home="$work/homes/interrupted"
+    new_home "$home"
+    printf '#!/bin/sh\necho OLD COPY\n' > "$home/.local/bin/srelens-tui"
+    chmod 0755 "$home/.local/bin/srelens-tui"
+    chown tester "$home/.local/bin/srelens-tui" 2>/dev/null || true
+    chmod 0711 "$work" 2>/dev/null || true
+    chmod 0644 "$script" 2>/dev/null || true
+    su tester -c "HOME='$home' sh '$script' --version '$version'" >"$work/int.log" 2>&1 &
+    kill_pid=$!
+    tries=0
+    while [ "$tries" -lt 300 ]; do
+        grep -q "Installing srelens-tui" "$work/int.log" 2>/dev/null && break
+        tries=$((tries + 1))
+        sleep 0.05
+    done
+    kill -TERM "$kill_pid" 2>/dev/null || true
+    wait "$kill_pid" 2>/dev/null || true
+    if grep -q "OLD COPY" "$home/.local/bin/srelens-tui" 2>/dev/null; then
+        ok "an interrupted update leaves the previous binary in place"
+    elif [ -x "$home/.local/bin/srelens-tui" ]; then
+        ok "the update completed before the signal landed, nothing to undo"
+    else
+        no "an interrupted update left no binary at all"
+    fi
+    if [ -z "$(find "$home/.local/bin" -name '.srelens-tui.*' 2>/dev/null)" ]; then
+        ok "and nothing hidden behind it"
+    else
+        no "an interrupted update left hidden files in the install directory"
+    fi
+else
+    echo "  skip  no unprivileged account this run created: cannot interrupt an update"
+fi
 
 echo "unpacking"
 

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -247,7 +247,7 @@ if [ "$(id -u)" = "0" ] && command -v useradd >/dev/null 2>&1; then
     mkdir -p "$dest"
     if chown tester "$dest" 2>/dev/null; then
         out="$(sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
-        check "root into another user's directory is refused" "belongs to tester" "$out" "$rc" 1
+        check "a directory owned by another user is refused" "belongs to tester" "$out" "$rc" 1
         if [ -e "$dest/srelens-tui" ]; then
             no "it installed into the other user's directory anyway"
         else
@@ -288,7 +288,7 @@ if [ "$(id -u)" = "0" ] && command -v useradd >/dev/null 2>&1; then
     chmod 1777 "$dest"
     if chown tester "$dest" 2>/dev/null; then
         out="$(sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
-        check "a sticky directory owned by someone else is refused" "owned by tester" "$out" "$rc" 1
+        check "a sticky directory owned by someone else is refused" "belongs to tester" "$out" "$rc" 1
     else
         echo "  skip  could not chown a sticky directory to another user"
     fi
@@ -309,6 +309,69 @@ if [ -x "$target/srelens-tui" ]; then
     ok "the binary landed in the resolved directory"
 else
     no "nothing landed in the resolved directory"
+fi
+
+echo "shared groups and ancestors"
+
+# A group-writable directory is only safe when the group is the owner's
+# own -- the per-user-group convention. A shared group is a set of people
+# who can each replace the binary between staging and running it.
+if [ "$(id -u)" = "0" ] && command -v groupadd >/dev/null 2>&1; then
+    groupadd -f shared >/dev/null 2>&1 || true
+    dest="$work/shared-group"
+    mkdir -p "$dest"
+    if chgrp shared "$dest" 2>/dev/null; then
+        chmod 0775 "$dest"
+        out="$(sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+        check "a directory writable by a shared group is refused" "group shared" "$out" "$rc" 1
+    else
+        echo "  skip  could not set a shared group"
+    fi
+else
+    echo "  skip  not root, or no groupadd: cannot test the shared-group refusal"
+fi
+
+# The per-user-group case must keep working, or every Fedora install with a
+# 002 umask breaks.
+dest="$work/own-group"
+mkdir -p "$dest"
+chmod 0775 "$dest"
+out="$(sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+check "group-writable by the owner's own group still installs" "Installed:" "$out" "$rc" 0
+
+# A directory can be impeccable itself and still sit under one somebody
+# else owns, who can rename it and put their own in its place after the
+# check. Every component is walked, so the parent is what fails here.
+if [ "$(id -u)" = "0" ] && command -v useradd >/dev/null 2>&1; then
+    id -u tester >/dev/null 2>&1 || useradd -m tester >/dev/null 2>&1 || true
+    parent="$work/theirs-parent"
+    mkdir -p "$parent/child"
+    if chown tester "$parent" 2>/dev/null; then
+        out="$(sh "$script" --version "$version" --install-dir "$parent/child" 2>&1)" && rc=0 || rc=$?
+        check "a root-owned directory under a foreign parent is refused" "belongs to tester" "$out" "$rc" 1
+        if [ -e "$parent/child/srelens-tui" ]; then
+            no "it installed under the replaceable parent anyway"
+        else
+            ok "nothing was installed under the replaceable parent"
+        fi
+    else
+        echo "  skip  could not chown a parent directory"
+    fi
+else
+    echo "  skip  not root, or no useradd: cannot test the ancestor walk"
+fi
+
+echo "unpacking"
+
+# The archive carries a `./` member, and GNU tar restores directory
+# ownership and permissions from the archive when it runs as root. Into the
+# private temp directory itself that would rewrite mktemp -d's 0700 into
+# whatever the release runner had; one level down leaves it untouched.
+# shellcheck disable=SC2016
+if grep -q 'tar -xzf "$tmp/$archive" -C "$tmp/unpack"' "$script"; then
+    ok "the archive is unpacked below the private directory, not into it"
+else
+    no "the archive is unpacked straight into the private directory"
 fi
 
 echo "hashing tool"

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -994,6 +994,51 @@ EOF
     check "a rejected first install that cannot be removed says so" "could NOT be removed" "$out" "$rc" 1
     check "and names where it is still installed" "$home/.local/bin/srelens-tui" "$out" "$rc" 1
     rm -f "$work/fake/rm"
+
+    # Metadata the rollback cannot carry. The copy takes bytes, mode, owner
+    # and times; a file capability is not among them, and losing one silently
+    # would take privileges from a binary that had them.
+    if command -v setcap >/dev/null 2>&1; then
+        home="$work/homes/capped"
+        new_home "$home"
+        cp /bin/true "$home/.local/bin/srelens-tui"
+        chown tester "$home/.local/bin/srelens-tui" 2>/dev/null || true
+        if setcap cap_net_raw+ep "$home/.local/bin/srelens-tui" 2>/dev/null; then
+            out="$(install_into "$home")" && rc=0 || rc=$?
+            check "a binary with a file capability is not silently replaced" "security.capability" "$out" "$rc" 1
+        else
+            echo "  skip  could not set a capability on this filesystem"
+        fi
+    else
+        echo "  skip  no setcap: cannot test capability detection"
+    fi
+
+    # A first install has no previous copy to be faithful to, so it must not
+    # be held to any of that -- nobody installing for the first time should be
+    # sent to fetch tools.
+    home="$work/homes/fresh-no-attr"
+    new_home "$home"
+    out="$(install_into "$home")" && rc=0 || rc=$?
+    check "a first install is not asked about metadata" "Installed:" "$out" "$rc" 0
+
+    # And where the question cannot be answered at all, an UPDATE refuses
+    # rather than replacing a binary whose metadata it cannot account for.
+    blind_attr="$work/blind-attr"
+    rm -rf "$blind_attr"
+    mkdir -p "$blind_attr"
+    attr_missing=""
+    for tool in sh uname curl sed head cut grep tar gzip chmod mktemp dirname \
+        mkdir cp mv rm ln cat ls awk id getent getfacl stat sha256sum; do
+        tpath="$(command -v "$tool" 2>/dev/null)" || { attr_missing="$attr_missing $tool"; continue; }
+        ln -sf "$tpath" "$blind_attr/$tool"
+    done
+    if [ -n "$attr_missing" ]; then
+        echo "  skip  no getfattr-blind run:$attr_missing not found"
+    else
+        chmod -R a+rx "$blind_attr"
+        out="$(install_into "$home" "PATH=$blind_attr")" && rc=0 || rc=$?
+        check "an update refuses when it cannot check for xattrs" "getfattr is not installed" "$out" "$rc" 1
+    fi
     rm -f "$work/fake/curl"
 else
     echo "  skip  no unprivileged account this run created: cannot test a wrong version"
@@ -1094,7 +1139,7 @@ if command -v shasum >/dev/null 2>&1; then
     missing=''
     # getfacl among them: without it, and with a BusyBox ls, the installer
     # refuses before it ever reaches the hashing this case is about.
-    for tool in sh uname curl sed head cut grep tar gzip chmod mktemp dirname mkdir cp mv rm ln cat ls awk id getent getfacl stat shasum; do
+    for tool in sh uname curl sed head cut grep tar gzip chmod mktemp dirname mkdir cp mv rm ln cat ls awk id getent getfacl getfattr stat shasum; do
         path="$(command -v "$tool" 2>/dev/null)" || { missing="$missing $tool"; continue; }
         ln -sf "$path" "$limited/$tool"
     done

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -93,6 +93,22 @@ HOME="$work/home"
 export HOME
 mkdir -p "$HOME"
 
+# The installer refuses to install anywhere it cannot check for extended
+# ACLs, which needs either getfacl or a GNU ls. On BusyBox without the acl
+# package neither exists, so every case here would fail for that one reason.
+# Say so once instead.
+# shellcheck disable=SC2012  # asking ls what it is, not listing anything
+if ! command -v getfacl >/dev/null 2>&1 &&
+    ! ls --version 2>/dev/null | head -n 1 | grep -q coreutils; then
+    echo "This host cannot inspect extended ACLs: no getfacl, and an ls that" >&2
+    echo "does not identify itself as GNU coreutils. The installer refuses to" >&2
+    echo "install anywhere under those conditions, so every case below would" >&2
+    echo "fail for that reason alone." >&2
+    echo "" >&2
+    echo "Install the acl package first (on Alpine: apk add acl)." >&2
+    exit 1
+fi
+
 # Where an install lands here, now that it cannot be told.
 #
 # /usr/local/bin when writable -- which for root is always, since
@@ -597,22 +613,60 @@ if [ "$made_user" = "tester" ]; then
     out="$(install_into "$home")" && rc=0 || rc=$?
     check "group-writable WITH the sticky bit still installs" "Installed:" "$out" "$rc" 0
 
-    # An extended ACL can grant write to any account while the mode bits look
-    # impeccable. ls marks one with a trailing +, and reading an ACL portably
-    # is not something a POSIX shell can do, so the marker alone is a refusal.
-    #
-    # BusyBox ls does not print that marker, so there the ACL is invisible to
-    # the check and this case has nothing to assert.
+    # An extended ACL can grant write to any account while the mode bits
+    # look impeccable. getfacl answers this properly; GNU ls answers it with
+    # a trailing + on the mode string; BusyBox ls does not answer it at all.
     home="$work/homes/acl"
     new_home "$home"
-    # shellcheck disable=SC2012  # reading the mode string is the whole point
     if command -v setfacl >/dev/null 2>&1 && [ -n "$other_user" ] &&
-        setfacl -m "u:$other_user:rwx" "$home/.local/bin" 2>/dev/null &&
-        [ "$(ls -ld "$home/.local/bin" | cut -c11)" = "+" ]; then
+        setfacl -m "u:$other_user:rwx" "$home/.local/bin" 2>/dev/null; then
         out="$(install_into "$home")" && rc=0 || rc=$?
         check "a directory with an extended ACL is refused" "extended ACL" "$out" "$rc" 1
     else
-        echo "  skip  no setfacl, or this ls does not mark ACLs (BusyBox)"
+        echo "  skip  no setfacl, or the filesystem will not take an ACL"
+    fi
+
+    # And where neither tool can answer -- BusyBox without the acl package --
+    # the install refuses rather than proceeding blind. That case used to be
+    # documented as a known gap and allowed, which meant an ACL sailed
+    # through on precisely the systems that could not see it.
+    #
+    # Simulated with a PATH carrying no getfacl at all and an `ls` that
+    # declines to identify itself, which is what BusyBox looks like from in
+    # there. A restricted PATH rather than a prefix, or the real getfacl in
+    # /usr/bin answers and the case proves nothing.
+    blind="$work/blind"
+    rm -rf "$blind"
+    mkdir -p "$blind"
+    blind_missing=""
+    for tool in sh uname curl sed head cut grep tar gzip chmod mktemp dirname \
+        mkdir cp mv rm ln cat awk id getent sha256sum; do
+        tpath="$(command -v "$tool" 2>/dev/null)" || { blind_missing="$blind_missing $tool"; continue; }
+        ln -sf "$tpath" "$blind/$tool"
+    done
+    real_ls="$(command -v ls)"
+    cat > "$blind/ls" <<EOF
+#!/bin/sh
+# BusyBox ls: no --version to identify itself, and no ACL marker.
+case "\$1" in
+  --version) echo "ls: unrecognized option: version" >&2; exit 1 ;;
+esac
+exec $real_ls "\$@"
+EOF
+    chmod +x "$blind/ls"
+    if [ -n "$blind_missing" ]; then
+        echo "  skip  no ACL-blind run:$blind_missing not found"
+    else
+        home="$work/homes/acl-blind"
+        new_home "$home"
+        chmod -R a+rx "$blind"
+        out="$(install_into "$home" "PATH=$blind")" && rc=0 || rc=$?
+        check "an ls that cannot report ACLs refuses rather than guessing" "cannot tell whether" "$out" "$rc" 1
+        if [ -e "$home/.local/bin/srelens-tui" ]; then
+            no "it installed without being able to see the ACLs"
+        else
+            ok "nothing was installed while ACLs were unreadable"
+        fi
     fi
 else
     echo "  skip  no unprivileged account this run created: cannot shape a group"
@@ -745,7 +799,9 @@ if command -v shasum >/dev/null 2>&1; then
     limited="$work/limited"
     mkdir -p "$limited"
     missing=''
-    for tool in sh uname curl sed head cut grep tar gzip chmod mktemp dirname mkdir cp mv rm ln cat ls awk id getent shasum; do
+    # getfacl among them: without it, and with a BusyBox ls, the installer
+    # refuses before it ever reaches the hashing this case is about.
+    for tool in sh uname curl sed head cut grep tar gzip chmod mktemp dirname mkdir cp mv rm ln cat ls awk id getent getfacl shasum; do
         path="$(command -v "$tool" 2>/dev/null)" || { missing="$missing $tool"; continue; }
         ln -sf "$path" "$limited/$tool"
     done

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -82,6 +82,17 @@ no() {
     fail=$((fail + 1))
 }
 
+# An isolated HOME, before anything reads it.
+#
+# The unprivileged branch of the destination choice is $HOME/.local/bin, and
+# these cases install for real: they replace whatever srelens-tui is there,
+# and reset_dest deletes it afterwards. Pointed at a developer's own home,
+# running the tests would uninstall their copy. Pointed here, the same cases
+# run against a directory that goes away with $work.
+HOME="$work/home"
+export HOME
+mkdir -p "$HOME"
+
 # Where an install lands here, now that it cannot be told.
 #
 # /usr/local/bin when writable -- which for root is always, since
@@ -113,9 +124,13 @@ if [ "$(id -u)" = "0" ] && [ "$default_dest" = "/usr/local/bin" ]; then
         echo "be overwritten too." >&2
         echo "" >&2
         echo "Run them in a container:" >&2
-        echo "  docker run --rm -v \"\$PWD/packaging/install:/i:ro\" debian:bookworm-slim \\" >&2
-        echo "    sh -c \"apt-get -qq update && apt-get -qq install -y curl ca-certificates acl \\" >&2
-        echo "           libdigest-sha-perl && cp -r /i /tmp/i && sh /tmp/i/test.sh\"" >&2
+        echo "" >&2
+        echo "  docker run --rm -v \"\$PWD/packaging/install:/i:ro\" \\" >&2
+        echo "    debian:bookworm-slim sh -c '" >&2
+        echo "      apt-get -qq update" >&2
+        echo "      apt-get -qq install -y curl ca-certificates acl libdigest-sha-perl" >&2
+        echo "      cp -r /i /tmp/i && sh /tmp/i/test.sh" >&2
+        echo "    '" >&2
         echo "" >&2
         echo "or, if this machine is disposable, SRELENS_TEST_ALLOW_SYSTEM=1." >&2
         exit 1

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -213,6 +213,53 @@ else
     no "the staging file is no longer created with mktemp"
 fi
 
+echo "unsafe destinations"
+
+# An unpredictable staging name does not survive a directory other users
+# can unlink from: they can take the staged file away and leave a symlink,
+# or replace the finished binary before it is run. Only the directory's own
+# permissions close that, so an unsafe one is refused outright.
+dest="$work/world"
+mkdir -p "$dest"
+chmod 0777 "$dest"
+out="$(sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+check "a world-writable destination is refused" "writable by anyone" "$out" "$rc" 1
+if [ -e "$dest/srelens-tui" ]; then
+    no "it installed into the world-writable directory anyway"
+else
+    ok "nothing was installed there"
+fi
+
+# The sticky bit is what makes /tmp safe: only an entry's owner may unlink
+# it, so the staged file cannot be taken away. That case must still work.
+dest="$work/sticky"
+mkdir -p "$dest"
+chmod 1777 "$dest"
+out="$(sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+check "world-writable WITH the sticky bit still installs" "Installed:" "$out" "$rc" 0
+
+# Root writing into a directory root does not own is the case worth
+# refusing outright: the owner can arrange the swap at leisure and gets a
+# root-written file out of it.
+if [ "$(id -u)" = "0" ] && command -v useradd >/dev/null 2>&1; then
+    id -u tester >/dev/null 2>&1 || useradd -m tester >/dev/null 2>&1 || true
+    dest="$work/theirs"
+    mkdir -p "$dest"
+    if chown tester "$dest" 2>/dev/null; then
+        out="$(sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+        check "root into another user's directory is refused" "belongs to tester" "$out" "$rc" 1
+        if [ -e "$dest/srelens-tui" ]; then
+            no "it installed into the other user's directory anyway"
+        else
+            ok "nothing was installed there either"
+        fi
+    else
+        echo "  skip  could not chown a directory to another user"
+    fi
+else
+    echo "  skip  not root, or no useradd: cannot test the root-into-foreign-dir refusal"
+fi
+
 echo "hashing tool"
 
 # Every image this was first tested on has sha256sum, which is why the
@@ -222,7 +269,7 @@ if command -v shasum >/dev/null 2>&1; then
     limited="$work/limited"
     mkdir -p "$limited"
     missing=''
-    for tool in sh uname curl sed head cut grep tar gzip chmod mktemp dirname mkdir cp mv rm cat shasum; do
+    for tool in sh uname curl sed head cut grep tar gzip chmod mktemp dirname mkdir cp mv rm cat ls awk id shasum; do
         path="$(command -v "$tool" 2>/dev/null)" || { missing="$missing $tool"; continue; }
         ln -sf "$path" "$limited/$tool"
     done

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -584,6 +584,23 @@ if [ "$made_user" = "tester" ]; then
         no "nothing landed in the resolved directory"
     fi
 
+    # A FIFO where the binary goes. Reading one waits for a writer that never
+    # comes, so this has to be refused rather than copied -- an installer
+    # that hangs forever is worse than one that says no.
+    if command -v mkfifo >/dev/null 2>&1; then
+        home="$work/homes/fifo-dest"
+        new_home "$home"
+        mkfifo "$home/.local/bin/srelens-tui" 2>/dev/null || true
+        if [ -p "$home/.local/bin/srelens-tui" ]; then
+            out="$(install_into "$home")" && rc=0 || rc=$?
+            check "a FIFO where the binary goes is refused" "not a regular file" "$out" "$rc" 1
+        else
+            echo "  skip  could not create a FIFO here"
+        fi
+    else
+        echo "  skip  no mkfifo: cannot test a special file at the destination"
+    fi
+
     # A symlink where the binary goes is refused: the rollback copy is taken
     # by reading $dest, which follows the link, so a restore would put a
     # regular file where a link had been.
@@ -872,6 +889,54 @@ out="$(TMPDIR="$link_tmp" sh "$script" --version "$version" 2>&1)" && rc=0 || rc
 check "a TMPDIR symlink is resolved before it is judged" "writable by other users" "$out" "$rc" 1
 
 
+echo "wrong version"
+
+# A release that published a stale binary under the right asset name and
+# checksum: it runs, so `--version` succeeding proves nothing. What was
+# asked for has to be what arrived.
+if [ "$made_user" = "tester" ]; then
+    wrong="$work/wrong"
+    rm -rf "$wrong"
+    mkdir -p "$wrong"
+    printf '#!/bin/sh\necho "srelens-tui 9.9.9"\n' > "$wrong/srelens-tui"
+    chmod 0755 "$wrong/srelens-tui"
+    printf 'nothing\n' > "$wrong/LICENSE"
+    wrongarchive="srelens-tui-$version-$host_target.tar.gz"
+    (cd "$wrong" && tar -czf "$work/fixtures/$wrongarchive.wrong" .)
+    wrongsum="$(sha256sum "$work/fixtures/$wrongarchive.wrong" | cut -d' ' -f1)"
+    printf '%s  %s\n' "$wrongsum" "$wrongarchive" > "$work/fixtures/WRONGSUMS.txt"
+    cat > "$work/fake/curl" <<EOF
+#!/bin/sh
+out=""; url=""
+while [ \$# -gt 0 ]; do
+  case "\$1" in
+    -o) out="\$2"; shift 2 ;;
+    http*) url="\$1"; shift ;;
+    *) shift ;;
+  esac
+done
+case "\$url" in
+  *api.github.com*) echo '{"tag_name": "srelens-v$version"}' ;;
+  *SHA256SUMS*)     cp "$work/fixtures/WRONGSUMS.txt" "\$out" ;;
+  *.tar.gz)         cp "$work/fixtures/$wrongarchive.wrong" "\$out" ;;
+  *) exit 1 ;;
+esac
+EOF
+    chmod +x "$work/fake/curl"
+    home="$work/homes/wrong-version"
+    new_home "$home"
+    out="$(install_into "$home" "PATH=$work/fake:$PATH")" && rc=0 || rc=$?
+    check "a binary reporting another version is refused" "not the $version that was asked for" "$out" "$rc" 1
+    if [ -e "$home/.local/bin/srelens-tui" ]; then
+        no "the wrong-version binary was left installed"
+    else
+        ok "and it is not left behind"
+    fi
+    rm -f "$work/fake/curl"
+else
+    echo "  skip  no unprivileged account this run created: cannot test a wrong version"
+fi
+
 echo "interrupted mid-update"
 
 # A signal arriving after the destination has been replaced but before the
@@ -912,6 +977,31 @@ if [ "$made_user" = "tester" ]; then
         ok "and nothing hidden behind it"
     else
         no "an interrupted update left hidden files in the install directory"
+    fi
+    # And the same interruption with NOTHING there beforehand. There is no
+    # copy to put back, so the rollback has to remove what it installed --
+    # otherwise an unvalidated binary is left on a PATH under a name that
+    # will be trusted.
+    home="$work/homes/interrupted-fresh"
+    new_home "$home"
+    su tester -c "HOME='$home' sh '$script' --version '$version'" >"$work/int2.log" 2>&1 &
+    kill_pid=$!
+    tries=0
+    while [ "$tries" -lt 300 ]; do
+        grep -q "Installing srelens-tui" "$work/int2.log" 2>/dev/null && break
+        tries=$((tries + 1))
+        sleep 0.05
+    done
+    kill -TERM "$kill_pid" 2>/dev/null || true
+    wait "$kill_pid" 2>/dev/null || true
+    if [ -e "$home/.local/bin/srelens-tui" ]; then
+        if "$home/.local/bin/srelens-tui" --version >/dev/null 2>&1; then
+            ok "the first install completed before the signal landed"
+        else
+            no "an interrupted first install left an unvalidated binary behind"
+        fi
+    else
+        ok "an interrupted first install leaves nothing behind"
     fi
 else
     echo "  skip  no unprivileged account this run created: cannot interrupt an update"

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -260,6 +260,42 @@ else
     echo "  skip  not root, or no useradd: cannot test the root-into-foreign-dir refusal"
 fi
 
+# A symlink is not the directory it points at. `ls -ld` on one reports
+# `lrwxrwxrwx` owned by whoever made the link, so inspecting the path as
+# given would describe the link and let --install-dir <link> past every
+# check while the install lands somewhere else entirely.
+target="$work/unsafe-target"
+mkdir -p "$target"
+chmod 0777 "$target"
+link="$work/looks-fine"
+ln -sfn "$target" "$link"
+out="$(sh "$script" --version "$version" --install-dir "$link" 2>&1)" && rc=0 || rc=$?
+check "a symlink to an unsafe directory is refused" "writable by anyone" "$out" "$rc" 1
+if [ -e "$target/srelens-tui" ]; then
+    no "it installed through the symlink anyway"
+else
+    ok "nothing was installed through the symlink"
+fi
+
+# The sticky bit stops OTHER users unlinking entries, but never the
+# directory's owner, who may remove anything inside it. A world-writable
+# sticky directory belonging to someone else is still theirs to tamper
+# with -- the same condition self_update.rs already applies.
+if [ "$(id -u)" = "0" ] && command -v useradd >/dev/null 2>&1; then
+    id -u tester >/dev/null 2>&1 || useradd -m tester >/dev/null 2>&1 || true
+    dest="$work/their-sticky"
+    mkdir -p "$dest"
+    chmod 1777 "$dest"
+    if chown tester "$dest" 2>/dev/null; then
+        out="$(sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+        check "a sticky directory owned by someone else is refused" "owned by tester" "$out" "$rc" 1
+    else
+        echo "  skip  could not chown a sticky directory to another user"
+    fi
+else
+    echo "  skip  not root, or no useradd: cannot test the foreign sticky directory"
+fi
+
 echo "hashing tool"
 
 # Every image this was first tested on has sha256sum, which is why the
@@ -269,7 +305,7 @@ if command -v shasum >/dev/null 2>&1; then
     limited="$work/limited"
     mkdir -p "$limited"
     missing=''
-    for tool in sh uname curl sed head cut grep tar gzip chmod mktemp dirname mkdir cp mv rm cat ls awk id shasum; do
+    for tool in sh uname curl sed head cut grep tar gzip chmod mktemp dirname mkdir cp mv rm ln cat ls awk id shasum; do
         path="$(command -v "$tool" 2>/dev/null)" || { missing="$missing $tool"; continue; }
         ln -sf "$path" "$limited/$tool"
     done

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -75,6 +75,47 @@ no() {
     fail=$((fail + 1))
 }
 
+# Where an install lands here, now that it cannot be told.
+#
+# /usr/local/bin when writable -- which for root is always, since
+# permission bits do not apply to uid 0 -- and $HOME/.local/bin otherwise.
+# So as root the cases below shape /usr/local/bin itself, which is the
+# directory a real `curl | sudo sh` installs into.
+if [ -w /usr/local/bin ]; then
+    default_dest="/usr/local/bin"
+else
+    default_dest="$HOME/.local/bin"
+fi
+
+# Put /usr/local/bin back the way a distribution ships it. Every case that
+# bends it calls this afterwards, so the next one starts from a known
+# state rather than from whatever the last one left.
+reset_dest() {
+    if [ "$default_dest" != "/usr/local/bin" ]; then
+        # The home branch: nothing to chown, but the mode and any leftover
+        # binary still carry into the next case.
+        chmod 0755 "$default_dest" 2>/dev/null || true
+        rm -rf "$default_dest/srelens-tui"
+        return 0
+    fi
+    setfacl -b /usr/local/bin 2>/dev/null || true
+    chown root /usr/local/bin 2>/dev/null || true
+    chgrp root /usr/local/bin 2>/dev/null || true
+    chmod 0755 /usr/local/bin 2>/dev/null || true
+    chown root /usr/local 2>/dev/null || true
+    rm -rf /usr/local/bin/srelens-tui
+}
+
+# A case that bends the real destination only means something as root; an
+# unprivileged run would be installing into its own home instead.
+can_shape_dest() {
+    [ "$default_dest" = "/usr/local/bin" ]
+}
+
+# Somebody who is neither root nor us, for the ownership cases.
+other_user="nobody"
+id -u nobody >/dev/null 2>&1 || other_user=""
+
 echo "arguments"
 
 out="$(sh "$script" --help 2>&1)" && rc=0 || rc=$?
@@ -93,8 +134,12 @@ check "--version without a value is refused" "needs a value" "$out" "$rc" 1
 out="$(sh "$script" --version= 2>&1)" && rc=0 || rc=$?
 check "an empty --version= is refused too" "needs a value" "$out" "$rc" 1
 
-out="$(sh "$script" --install-dir= 2>&1)" && rc=0 || rc=$?
-check "an empty --install-dir= is refused too" "needs a value" "$out" "$rc" 1
+# The flag is gone. Saying so beats "unknown option" for anyone following
+# an older README.
+out="$(sh "$script" --install-dir /tmp/x 2>&1)" && rc=0 || rc=$?
+check "--install-dir is refused, and says where it installs instead" "no longer accepted" "$out" "$rc" 1
+out="$(sh "$script" --install-dir=/tmp/x 2>&1)" && rc=0 || rc=$?
+check "and its equals form too" "no longer accepted" "$out" "$rc" 1
 
 echo "platform"
 
@@ -168,8 +213,8 @@ esac
 EOF
 chmod +x "$work/fake/curl"
 
-dest="$work/cksum"
-out="$(PATH="$work/fake:$PATH" sh "$script" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+dest="$default_dest"
+out="$(PATH="$work/fake:$PATH" sh "$script" 2>&1)" && rc=0 || rc=$?
 check "a corrupted archive is refused" "checksum mismatch" "$out" "$rc" 1
 if [ -e "$dest/srelens-tui" ]; then
     no "nothing is installed when the checksum fails"
@@ -182,15 +227,15 @@ echo "latest-version resolution"
 # Offline, through the fake curl that serves the API's tag_name. Proves the
 # script parses `latest` correctly without spending an unauthenticated API
 # call per run on a shared runner IP.
-dest="$work/latest"
-out="$(SERVE_GOOD=1 PATH="$work/fake:$PATH" sh "$script" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+dest="$default_dest"
+out="$(SERVE_GOOD=1 PATH="$work/fake:$PATH" sh "$script" 2>&1)" && rc=0 || rc=$?
 check "the newest release is resolved from the API" "srelens-tui $version" "$out" "$rc" 0
 check "and installed" "Installed: $dest/srelens-tui" "$out" "$rc" 0
 
 echo "install"
 
-dest="$work/bin"
-out="$(sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+dest="$default_dest"
+out="$(sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
 check "the release installs" "Installed: $dest/srelens-tui" "$out" "$rc" 0
 check "the checksum is reported, not assumed" "Checksum verified:" "$out" "$rc" 0
 
@@ -202,7 +247,7 @@ fi
 
 # Installing over an existing copy is the update path, and must not fail on
 # ETXTBSY or leave the staging file behind.
-out="$(sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+out="$(sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
 check "installing over an existing copy succeeds" "Installed:" "$out" "$rc" 0
 if [ -z "$(find "$dest" -name '.srelens-tui.install.*' -o -name '.srelens-tui.backup.*' 2>/dev/null)" ]; then
     ok "no staging or backup file is left behind"
@@ -215,11 +260,11 @@ echo "through a pipe"
 # How the documented one-liner actually runs. Options cannot follow a bare
 # `sh` -- it reads them as its own -- so the docs say `sh -s --`, and this
 # proves that form reaches the script's parser.
-dest="$work/piped"
+dest="$default_dest"
 # The `cat` is the point: this reproduces the documented one-liner, where
 # the script arrives on stdin rather than as a path.
 # shellcheck disable=SC2002
-out="$(cat "$script" | sh -s -- --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+out="$(cat "$script" | sh -s -- --version "$version" 2>&1)" && rc=0 || rc=$?
 check "options survive sh -s --" "Installed: $dest/srelens-tui" "$out" "$rc" 0
 
 echo "staging file"
@@ -228,11 +273,10 @@ echo "staging file"
 # into a directory another user can write to, a predictable name can be
 # pre-created as a symlink, and cp writes through it. mktemp names cannot
 # be aimed at, and a symlink sitting in the directory is left alone.
-dest="$work/staging"
-mkdir -p "$dest"
+dest="$default_dest"
 echo "do not touch me" > "$work/canary"
 ln -sf "$work/canary" "$dest/.srelens-tui.install.99999"
-out="$(sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+out="$(sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
 check "installs alongside a planted symlink" "Installed:" "$out" "$rc" 0
 if [ "$(cat "$work/canary")" = "do not touch me" ]; then
     ok "a planted symlink is not written through"
@@ -249,276 +293,249 @@ fi
 
 echo "unsafe destinations"
 
-# An unpredictable staging name does not survive a directory other users
-# can unlink from: they can take the staged file away and leave a symlink,
-# or replace the finished binary before it is run. Only the directory's own
-# permissions close that, so an unsafe one is refused outright.
-dest="$work/world"
-mkdir -p "$dest"
-chmod 0777 "$dest"
-out="$(sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
-check "a world-writable destination is refused" "writable by anyone" "$out" "$rc" 1
-if [ -e "$dest/srelens-tui" ]; then
-    no "it installed into the world-writable directory anyway"
-else
-    ok "nothing was installed there"
-fi
+# These bend /usr/local/bin itself, which is where a real `curl | sudo sh`
+# lands. The destination cannot be named any more, so testing what the rules
+# do means shaping the directory they will pick, and putting it back after.
+if can_shape_dest; then
+    # Whatever the install cases above left behind is not part of these.
+    reset_dest
 
-# The sticky bit is what makes /tmp safe: only an entry's owner may unlink
-# it, so the staged file cannot be taken away. That case must still work.
-dest="$work/sticky"
-mkdir -p "$dest"
-chmod 1777 "$dest"
-out="$(sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
-check "world-writable WITH the sticky bit still installs" "Installed:" "$out" "$rc" 0
-
-# Root writing into a directory root does not own is the case worth
-# refusing outright: the owner can arrange the swap at leisure and gets a
-# root-written file out of it.
-if [ "$(id -u)" = "0" ] && command -v useradd >/dev/null 2>&1; then
-    if ! id -u tester >/dev/null 2>&1; then
-        if useradd -m tester >/dev/null 2>&1; then
-            made_user="tester"
-        fi
+    # An unpredictable staging name does not survive a directory other users
+    # can unlink from: they can take the staged file away and leave a symlink,
+    # or replace the finished binary before it is run. Only the directory's
+    # own permissions close that, so an unsafe one is refused outright.
+    chmod 0777 /usr/local/bin
+    out="$(sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
+    check "a world-writable destination is refused" "writable by anyone" "$out" "$rc" 1
+    if [ -e /usr/local/bin/srelens-tui ]; then
+        no "it installed into the world-writable directory anyway"
+    else
+        ok "nothing was installed there"
     fi
-    dest="$work/theirs"
-    mkdir -p "$dest"
-    if chown tester "$dest" 2>/dev/null; then
-        out="$(sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
-        check "a directory owned by another user is refused" "belongs to tester" "$out" "$rc" 1
-        if [ -e "$dest/srelens-tui" ]; then
+    reset_dest
+
+    # The sticky bit is what makes /tmp safe: only an entry's owner may unlink
+    # it, so the staged file cannot be taken away. That case must still work.
+    chmod 1777 /usr/local/bin
+    out="$(sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
+    check "world-writable WITH the sticky bit still installs" "Installed:" "$out" "$rc" 0
+    reset_dest
+
+    # A directory belonging to somebody else: they can arrange the swap at
+    # leisure and get a root-written file out of it.
+    if [ -n "$other_user" ] && chown "$other_user" /usr/local/bin 2>/dev/null; then
+        out="$(sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
+        check "a directory owned by another user is refused" "belongs to $other_user" "$out" "$rc" 1
+        if [ -e /usr/local/bin/srelens-tui ]; then
             no "it installed into the other user's directory anyway"
         else
             ok "nothing was installed there either"
         fi
     else
-        echo "  skip  could not chown a directory to another user"
+        echo "  skip  no second account to own the destination"
     fi
-else
-    echo "  skip  not root, or no useradd: cannot test the root-into-foreign-dir refusal"
-fi
+    reset_dest
 
-# A symlink is not the directory it points at. `ls -ld` on one reports
-# `lrwxrwxrwx` owned by whoever made the link, so inspecting the path as
-# given would describe the link and let --install-dir <link> past every
-# check while the install lands somewhere else entirely.
-target="$work/unsafe-target"
-mkdir -p "$target"
-chmod 0777 "$target"
-link="$work/looks-fine"
-ln -sfn "$target" "$link"
-out="$(sh "$script" --version "$version" --install-dir "$link" 2>&1)" && rc=0 || rc=$?
-check "a symlink to an unsafe directory is refused" "writable by anyone" "$out" "$rc" 1
-if [ -e "$target/srelens-tui" ]; then
-    no "it installed through the symlink anyway"
-else
-    ok "nothing was installed through the symlink"
-fi
-
-# The sticky bit stops OTHER users unlinking entries, but never the
-# directory's owner, who may remove anything inside it. A world-writable
-# sticky directory belonging to someone else is still theirs to tamper
-# with -- the same condition self_update.rs already applies.
-if [ "$(id -u)" = "0" ] && command -v useradd >/dev/null 2>&1; then
-    if ! id -u tester >/dev/null 2>&1; then
-        if useradd -m tester >/dev/null 2>&1; then
-            made_user="tester"
-        fi
-    fi
-    dest="$work/their-sticky"
-    mkdir -p "$dest"
-    chmod 1777 "$dest"
-    if chown tester "$dest" 2>/dev/null; then
-        out="$(sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
-        check "a sticky directory owned by someone else is refused" "belongs to tester" "$out" "$rc" 1
+    # Sticky does not save a directory whose OWNER is somebody else: the owner
+    # may remove anything inside it regardless.
+    if [ -n "$other_user" ] && chown "$other_user" /usr/local/bin 2>/dev/null; then
+        chmod 1777 /usr/local/bin
+        out="$(sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
+        check "a sticky directory owned by someone else is refused" "belongs to $other_user" "$out" "$rc" 1
     else
-        echo "  skip  could not chown a sticky directory to another user"
+        echo "  skip  no second account to own the destination"
     fi
-else
-    echo "  skip  not root, or no useradd: cannot test the foreign sticky directory"
-fi
+    reset_dest
 
-# A safe symlink must still install -- through the directory it points at,
-# named canonically. Approving the resolved path but staging and running
-# through the path as given would leave the link repointable after the check.
-target="$work/real-bin"
-mkdir -p "$target"
-link="$work/link-to-real"
-ln -sfn "$target" "$link"
-out="$(sh "$script" --version "$version" --install-dir "$link" 2>&1)" && rc=0 || rc=$?
-check "a safe symlink installs into its target" "Installed: $target/srelens-tui" "$out" "$rc" 0
-if [ -x "$target/srelens-tui" ]; then
-    ok "the binary landed in the resolved directory"
+    # A symlink is not the directory it points at. `ls -ld` on one reports
+    # `lrwxrwxrwx` owned by whoever made the link, so inspecting the path as
+    # given would describe the link while the install lands somewhere else.
+    target="$work/unsafe-target"
+    mkdir -p "$target"
+    chmod 0777 "$target"
+    mv /usr/local/bin /usr/local/bin.real
+    ln -sfn "$target" /usr/local/bin
+    out="$(sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
+    check "a symlink to an unsafe directory is refused" "writable by anyone" "$out" "$rc" 1
+    if [ -e "$target/srelens-tui" ]; then
+        no "it installed through the symlink anyway"
+    else
+        ok "nothing was installed through the symlink"
+    fi
+    rm -f /usr/local/bin
+    mv /usr/local/bin.real /usr/local/bin
+    reset_dest
+
+    # A safe symlink must still install -- through the directory it points at,
+    # named canonically. Approving the resolved path but staging and running
+    # through the path as given would leave the link repointable after the
+    # check.
+    target="$work/real-bin"
+    mkdir -p "$target"
+    mv /usr/local/bin /usr/local/bin.real
+    ln -sfn "$target" /usr/local/bin
+    out="$(sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
+    check "a safe symlink installs into its target" "Installed: $target/srelens-tui" "$out" "$rc" 0
+    if [ -x "$target/srelens-tui" ]; then
+        ok "the binary landed in the resolved directory"
+    else
+        no "nothing landed in the resolved directory"
+    fi
+    rm -f /usr/local/bin
+    mv /usr/local/bin.real /usr/local/bin
+    reset_dest
+
+    # A directory can be impeccable itself and still sit under one somebody
+    # else owns, who can rename it and put their own in its place after the
+    # check. Every component is walked, so the ancestor is what fails here.
+    if [ -n "$other_user" ] && chown "$other_user" /usr/local 2>/dev/null; then
+        out="$(sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
+        check "a directory under a foreign ancestor is refused" "belongs to $other_user" "$out" "$rc" 1
+        if [ -e /usr/local/bin/srelens-tui ]; then
+            no "it installed under the replaceable ancestor anyway"
+        else
+            ok "nothing was installed under the replaceable ancestor"
+        fi
+    else
+        echo "  skip  no second account to own an ancestor"
+    fi
+    reset_dest
+
+    # `mv file dir` moves the file INTO the directory. A destination that is
+    # already a directory would swallow the staging file and leave nothing at
+    # the path asked for -- and the version line used to hide that inside a
+    # command substitution, so the install printed Installed and exited 0.
+    mkdir -p /usr/local/bin/srelens-tui
+    out="$(sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
+    check "a directory where the binary goes is refused" "is a directory" "$out" "$rc" 1
+    case "$out" in
+        *Installed:*) no "it claimed to have installed something" ;;
+        *) ok "it did not claim to have installed anything" ;;
+    esac
+    reset_dest
 else
-    no "nothing landed in the resolved directory"
+    echo "  skip  not root: the destination is this account's own home, not a directory to bend"
 fi
 
 echo "shared groups and ancestors"
 
-# A group-writable directory is only safe when the group is the owner's
-# own -- the per-user-group convention. A shared group is a set of people
-# who can each replace the binary between staging and running it.
-if [ "$(id -u)" = "0" ] && command -v groupadd >/dev/null 2>&1; then
+if can_shape_dest && command -v groupadd >/dev/null 2>&1; then
+    # A group-writable directory is only safe when the group is the owner's
+    # own -- the per-user-group convention. A shared group is a set of people
+    # who can each replace the binary between staging and running it.
     if ! getent group shared >/dev/null 2>&1; then
         if groupadd shared >/dev/null 2>&1; then
             made_group="shared"
         fi
     fi
-    dest="$work/shared-group"
-    mkdir -p "$dest"
-    if chgrp shared "$dest" 2>/dev/null; then
-        chmod 0775 "$dest"
-        out="$(sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+    if chgrp shared /usr/local/bin 2>/dev/null; then
+        chmod 0775 /usr/local/bin
+        out="$(sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
         check "a directory writable by a shared group is refused" "group shared" "$out" "$rc" 1
     else
         echo "  skip  could not set a shared group"
     fi
+    reset_dest
+
+    # A group named after its owner is the per-user-group CONVENTION, not a
+    # guarantee. If the group really has other members, any of them can
+    # replace the binary, so membership is looked up rather than assumed.
+    #
+    # Only ever on an account this run created: adding a pre-existing account
+    # to group root and removing it again would strip a membership the host
+    # meant to have.
+    if ! id -u tester >/dev/null 2>&1 && command -v useradd >/dev/null 2>&1; then
+        if useradd -m tester >/dev/null 2>&1; then
+            made_user="tester"
+        fi
+    fi
+    if [ "$made_user" = "tester" ] && command -v usermod >/dev/null 2>&1 &&
+        usermod -aG root tester >/dev/null 2>&1; then
+        chmod 0775 /usr/local/bin
+        out="$(sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
+        check "an owner-named group with real members is refused" "besides root" "$out" "$rc" 1
+        gpasswd -d tester root >/dev/null 2>&1 || true
+    else
+        echo "  skip  no account this run created: not touching an existing one's groups"
+    fi
+    reset_dest
+
+    # Supplementary members are only half of a group: an account whose PRIMARY
+    # group it is never appears in the member list, while it can write there
+    # perfectly well.
+    if [ "$made_user" = "tester" ] && command -v useradd >/dev/null 2>&1; then
+        if useradd -M -g root primaryroot >/dev/null 2>&1; then
+            # Recorded BEFORE it is used: an interrupt between the useradd and
+            # the userdel below would otherwise leave the account behind.
+            made_users="$made_users primaryroot"
+            chmod 0775 /usr/local/bin
+            out="$(sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
+            check "a group that is someone else's primary group is refused" "primaryroot" "$out" "$rc" 1
+            userdel primaryroot >/dev/null 2>&1 || true
+            made_users="$(printf %s "$made_users" | sed 's/ primaryroot//')"
+        else
+            echo "  skip  could not create an account with a primary GID of 0"
+        fi
+    else
+        echo "  skip  no account this run created: cannot test primary-group membership"
+    fi
+    reset_dest
+
+    # An extended ACL can grant write to any account while the mode bits look
+    # impeccable. ls marks one with a trailing +, and reading an ACL portably
+    # is not something a POSIX shell can do, so the marker alone is a refusal.
+    # The guard reads the trailing + that `ls -l` puts on a directory with an
+    # extended ACL. BusyBox ls does not print it, so there the ACL is invisible
+    # to the check and this case has nothing to assert.
+    if command -v setfacl >/dev/null 2>&1 && [ -n "$other_user" ] &&
+        setfacl -m "u:$other_user:rwx" /usr/local/bin 2>/dev/null &&
+        [ "$(ls -ld /usr/local/bin | cut -c11)" = "+" ]; then
+        out="$(sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
+        check "a directory with an extended ACL is refused" "extended ACL" "$out" "$rc" 1
+    else
+        echo "  skip  no setfacl, or this ls does not mark ACLs (BusyBox)"
+    fi
+    reset_dest
 else
-    echo "  skip  not root, or no groupadd: cannot test the shared-group refusal"
+    echo "  skip  not root, or no groupadd: cannot shape the destination's group"
 fi
 
 # The per-user-group case must keep working, or every Fedora install with a
 # 002 umask breaks: there ~/.local/bin is `alice:alice` mode 0775.
 #
-# As the user, into their own group -- which is the actual shape. Root into
-# ROOT's group is a different thing and rightly refused: on Alpine, GID 0 is
-# the primary group of sync, shutdown and halt.
+# As the user, into their own home -- which is the actual shape, and the one
+# branch of the destination choice that root never takes.
 if [ "$made_user" = "tester" ]; then
-    dest="$work/own-group"
-    mkdir -p "$dest"
-    chown tester:tester "$dest" 2>/dev/null || chown tester "$dest" 2>/dev/null || true
-    chmod 0775 "$dest"
-    # Traversable so the account can reach it; still owned by root and
-    # writable by nobody else, so the walk above it stays clean.
-    chmod 0711 "$work"
-    chmod 644 "$script" 2>/dev/null || true
-    out="$(su tester -c "sh $script --version $version --install-dir $dest" 2>&1)" && rc=0 || rc=$?
-    check "group-writable by the owner's own group still installs" "Installed:" "$out" "$rc" 0
-    chmod 0700 "$work"
+    tester_home="$(getent passwd tester | cut -d: -f6)"
+    if [ -n "$tester_home" ] && [ -d "$tester_home" ]; then
+        mkdir -p "$tester_home/.local/bin"
+        # Group as well as owner: made by root, the tree carries root group,
+        # which is not the per-user group this case is about.
+        chown -R tester:tester "$tester_home/.local" 2>/dev/null ||
+            chown -R tester "$tester_home/.local" 2>/dev/null || true
+        chmod 0775 "$tester_home/.local/bin"
+        chmod 0644 "$script" 2>/dev/null || true
+        chmod 0711 "$work" 2>/dev/null || true
+        out="$(su tester -c "sh '$script' --version '$version'" 2>&1)" && rc=0 || rc=$?
+        check "group-writable by the owner's own group still installs" "Installed: $tester_home/.local/bin/srelens-tui" "$out" "$rc" 0
+    else
+        echo "  skip  the created account has no home directory"
+    fi
 else
     echo "  skip  no account this run created: cannot test a per-user group"
 fi
-
-# A directory can be impeccable itself and still sit under one somebody
-# else owns, who can rename it and put their own in its place after the
-# check. Every component is walked, so the parent is what fails here.
-if [ "$(id -u)" = "0" ] && command -v useradd >/dev/null 2>&1; then
-    if ! id -u tester >/dev/null 2>&1; then
-        if useradd -m tester >/dev/null 2>&1; then
-            made_user="tester"
-        fi
-    fi
-    parent="$work/theirs-parent"
-    mkdir -p "$parent/child"
-    if chown tester "$parent" 2>/dev/null; then
-        out="$(sh "$script" --version "$version" --install-dir "$parent/child" 2>&1)" && rc=0 || rc=$?
-        check "a root-owned directory under a foreign parent is refused" "belongs to tester" "$out" "$rc" 1
-        if [ -e "$parent/child/srelens-tui" ]; then
-            no "it installed under the replaceable parent anyway"
-        else
-            ok "nothing was installed under the replaceable parent"
-        fi
-    else
-        echo "  skip  could not chown a parent directory"
-    fi
-else
-    echo "  skip  not root, or no useradd: cannot test the ancestor walk"
-fi
-
-# An extended ACL can grant write to any account while the mode bits look
-# impeccable. ls marks one with a trailing +, and reading an ACL portably is
-# not something a POSIX shell can do, so the marker alone is a refusal.
-if [ "$(id -u)" = "0" ] && command -v setfacl >/dev/null 2>&1; then
-    dest="$work/acl"
-    mkdir -p "$dest"
-    if setfacl -m u:nobody:rwx "$dest" 2>/dev/null; then
-        out="$(sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
-        check "a directory with an extended ACL is refused" "extended ACL" "$out" "$rc" 1
-    else
-        echo "  skip  could not set an ACL on this filesystem"
-    fi
-else
-    echo "  skip  not root, or no setfacl: cannot test the ACL refusal"
-fi
-
-# A group named after its owner is the per-user-group CONVENTION, not a
-# guarantee. If the group really has other members, any of them can replace
-# the binary, so membership is looked up rather than assumed.
-#
-# Only ever on an account this run created. Adding a pre-existing `tester`
-# to group root and then removing it again would strip a membership the
-# host meant to have -- a test that edits the machine it runs on is worse
-# than a test that skips.
-if ! id -u tester >/dev/null 2>&1 && [ "$(id -u)" = "0" ] &&
-    command -v useradd >/dev/null 2>&1; then
-    if useradd -m tester >/dev/null 2>&1; then
-        made_user="tester"
-    fi
-fi
-if [ "$made_user" = "tester" ] && command -v usermod >/dev/null 2>&1; then
-    if usermod -aG root tester >/dev/null 2>&1; then
-        dest="$work/owner-group-shared"
-        mkdir -p "$dest"
-        chmod 0775 "$dest"
-        out="$(sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
-        check "an owner-named group with real members is refused" "members besides root" "$out" "$rc" 1
-        # Safe to undo unconditionally: this membership was added a few
-        # lines up, to an account created a few lines before that.
-        gpasswd -d tester root >/dev/null 2>&1 || true
-    else
-        echo "  skip  could not add a member to a group"
-    fi
-else
-    echo "  skip  no account this run created: not touching an existing one's groups"
-fi
-
-# Supplementary members are only half of a group: an account whose PRIMARY
-# group it is never appears in the member list, while it can write there
-# perfectly well.
-if [ "$made_user" = "tester" ] && command -v useradd >/dev/null 2>&1; then
-    if useradd -M -g root primaryroot >/dev/null 2>&1; then
-        # Recorded BEFORE it is used: an interrupt between the useradd and
-        # the userdel below would otherwise leave the account on the host.
-        made_users="$made_users primaryroot"
-        dest="$work/primary-gid"
-        mkdir -p "$dest"
-        chmod 0775 "$dest"
-        out="$(sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
-        check "a group that is someone else's primary group is refused" "primaryroot" "$out" "$rc" 1
-        userdel primaryroot >/dev/null 2>&1 || true
-    else
-        echo "  skip  could not create an account with a primary GID of 0"
-    fi
-else
-    echo "  skip  no account this run created: cannot test primary-group membership"
-fi
-
-echo "destination shapes"
-
-# `mv file dir` moves the file INTO the directory. A destination that is
-# already a directory would swallow the staging file and leave nothing at the
-# path asked for -- and the version line used to hide that inside a command
-# substitution, so the install printed Installed and exited 0.
-dest="$work/dir-dest"
-mkdir -p "$dest/srelens-tui"
-out="$(sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
-check "a directory where the binary goes is refused" "is a directory" "$out" "$rc" 1
-case "$out" in
-    *Installed:*) no "it claimed to have installed something" ;;
-    *) ok "it did not claim to have installed anything" ;;
-esac
 
 echo "temporary directory"
 
 # mktemp -d honours TMPDIR, and sudo can carry the invoking user's straight
 # into a root install. The private tree is only private if its parents are,
 # so the destination walk is applied to it as well.
-dest="$work/tmpdir-bin"
-mkdir -p "$dest"
+dest="$default_dest"
 bad="$work/untrusted-tmp"
 mkdir -p "$bad"
 chmod 0777 "$bad"
-out="$(TMPDIR="$bad" sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+rm -f "$dest/srelens-tui"
+out="$(TMPDIR="$bad" sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
 check "an untrusted TMPDIR is refused" "writable by anyone" "$out" "$rc" 1
 if [ -e "$dest/srelens-tui" ]; then
     no "it installed with the working tree in an untrusted place"
@@ -529,7 +546,7 @@ fi
 # And a TMPDIR that is fine must still work.
 good="$work/trusted-tmp"
 mkdir -p "$good"
-out="$(TMPDIR="$good" sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+out="$(TMPDIR="$good" sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
 check "a trusted TMPDIR still installs" "Installed:" "$out" "$rc" 0
 
 # A hardened host mounts /tmp noexec, and mktemp puts the working tree there.
@@ -544,9 +561,8 @@ if [ "$(id -u)" = "0" ] && command -v mount >/dev/null 2>&1; then
     if mount -t tmpfs -o rw,noexec,nosuid,size=200m tmpfs "$noexec" 2>/dev/null; then
         # Recorded before use, so an interrupt anywhere below still unmounts.
         mounted="$noexec"
-        dest="$work/noexec-bin"
-        mkdir -p "$dest"
-        out="$(TMPDIR="$noexec" sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+        dest="$default_dest"
+        out="$(TMPDIR="$noexec" sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
         check "a noexec working directory still installs" "Installed:" "$out" "$rc" 0
         check "and says why the check moved" "mounted noexec" "$out" "$rc" 0
 
@@ -580,7 +596,7 @@ esac
 EOF
         chmod +x "$work/fake/curl"
 
-        out="$(TMPDIR="$noexec" PATH="$work/fake:$PATH" sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+        out="$(TMPDIR="$noexec" PATH="$work/fake:$PATH" sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
         check "a binary that will not run is rejected after install" "does not run" "$out" "$rc" 1
         check "and the previous copy is put back" "put back" "$out" "$rc" 1
         if [ -x "$dest/srelens-tui" ] && "$dest/srelens-tui" --version >/dev/null 2>&1; then
@@ -609,12 +625,14 @@ mkdir -p "$real_tmp"
 chmod 0777 "$real_tmp"
 link_tmp="$work/tmp-link"
 ln -sfn "$real_tmp" "$link_tmp"
-dest="$work/via-link"
-mkdir -p "$dest"
-out="$(TMPDIR="$link_tmp" sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+dest="$default_dest"
+out="$(TMPDIR="$link_tmp" sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
 check "a TMPDIR symlink is resolved before it is judged" "writable by anyone" "$out" "$rc" 1
 
-# A lookup that fails is not a group with nobody in it.
+# A lookup that fails is not a group with nobody in it. These only run for a
+# group-writable destination, so shape it that way first -- whichever of the
+# two destinations this account gets.
+chmod 0775 "$default_dest" 2>/dev/null || true
 mkdir -p "$work/fake"
 cat > "$work/fake/getent" <<EOF
 #!/bin/sh
@@ -624,7 +642,7 @@ chmod +x "$work/fake/getent"
 dest="$work/getent-down"
 mkdir -p "$dest"
 chmod 0775 "$dest"
-out="$(PATH="$work/fake:$PATH" sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+out="$(PATH="$work/fake:$PATH" sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
 check "a group lookup that fails is not treated as empty" "cannot look up the group" "$out" "$rc" 1
 
 # And neither is a passwd lookup that fails. In `getent passwd | awk` the
@@ -642,9 +660,10 @@ chmod +x "$work/fake/getent"
 dest="$work/passwd-down"
 mkdir -p "$dest"
 chmod 0775 "$dest"
-out="$(PATH="$work/fake:$PATH" sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+out="$(PATH="$work/fake:$PATH" sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
 check "a passwd lookup that fails is not treated as empty" "cannot enumerate accounts" "$out" "$rc" 1
 rm -f "$work/fake/getent"
+reset_dest
 
 echo "unpacking"
 
@@ -675,8 +694,8 @@ if command -v shasum >/dev/null 2>&1; then
     if [ -n "$missing" ]; then
         echo "  skip  no shasum-only run:$missing not found"
     else
-        dest="$work/shasum"
-        out="$(PATH="$limited" sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+        dest="$default_dest"
+        out="$(PATH="$limited" sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
         check "shasum computes SHA-256, not SHA-1" "Checksum verified:" "$out" "$rc" 0
         if [ -x "$dest/srelens-tui" ]; then
             ok "the binary installs with only shasum available"

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -932,6 +932,46 @@ EOF
     else
         ok "and it is not left behind"
     fi
+
+    # A version that CONTAINS the requested one. `1.2.30` contains `1.2.3`,
+    # so a substring match accepts precisely the stale build this is for.
+    # %s so the version really expands: inside single quotes it would not,
+    # and the case would pass for the wrong reason.
+    printf '#!/bin/sh\necho "srelens-tui %s0"\n' "$version" > "$wrong/srelens-tui"
+    (cd "$wrong" && tar -czf "$work/fixtures/$wrongarchive.wrong" .)
+    wrongsum="$(sha256sum "$work/fixtures/$wrongarchive.wrong" | cut -d' ' -f1)"
+    printf '%s  %s\n' "$wrongsum" "$wrongarchive" > "$work/fixtures/WRONGSUMS.txt"
+    home="$work/homes/version-prefix"
+    new_home "$home"
+    out="$(install_into "$home" "PATH=$work/fake:$PATH")" && rc=0 || rc=$?
+    check "a version that merely contains the requested one is refused" "not the $version that was asked for" "$out" "$rc" 1
+
+    # A rollback that cannot complete must keep the only copy of what was
+    # there and say where it is, rather than delete it and report recovery.
+    # A `mv` that refuses to move the backup is what a read-only mount or a
+    # full disk looks like from here.
+    cat > "$work/fake/mv" <<EOF
+#!/bin/sh
+for a in \$@; do
+  case "\$a" in *.srelens-tui.backup.*) exit 1 ;; esac
+done
+exec /bin/mv "\$@"
+EOF
+    chmod +x "$work/fake/mv"
+    home="$work/homes/rollback-fails"
+    new_home "$home"
+    printf '#!/bin/sh\necho OLD COPY\n' > "$home/.local/bin/srelens-tui"
+    chmod 0755 "$home/.local/bin/srelens-tui"
+    chown tester "$home/.local/bin/srelens-tui" 2>/dev/null || true
+    out="$(install_into "$home" "PATH=$work/fake:$PATH")" && rc=0 || rc=$?
+    check "a rollback that fails says so" "could NOT be put back" "$out" "$rc" 1
+    check "and names where the copy still is" ".srelens-tui.backup." "$out" "$rc" 1
+    if [ -n "$(find "$home/.local/bin" -name '.srelens-tui.backup.*' 2>/dev/null)" ]; then
+        ok "the only copy of the previous binary is kept"
+    else
+        no "the previous binary was destroyed by a failed rollback"
+    fi
+    rm -f "$work/fake/mv"
     rm -f "$work/fake/curl"
 else
     echo "  skip  no unprivileged account this run created: cannot test a wrong version"

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -23,10 +23,14 @@ work="$(mktemp -d)"
 # Anything this run creates, this run removes: a test suite that leaves a
 # login account behind on the host has done more than test.
 made_user=""
+made_users=""
 made_group=""
 cleanup() {
     rm -rf "$work"
     [ -z "$made_user" ] || userdel -r "$made_user" >/dev/null 2>&1 || true
+    for u in $made_users; do
+        userdel -r "$u" >/dev/null 2>&1 || true
+    done
     [ -z "$made_group" ] || groupdel "$made_group" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT INT TERM
@@ -457,6 +461,9 @@ fi
 # perfectly well.
 if [ "$made_user" = "tester" ] && command -v useradd >/dev/null 2>&1; then
     if useradd -M -g root primaryroot >/dev/null 2>&1; then
+        # Recorded BEFORE it is used: an interrupt between the useradd and
+        # the userdel below would otherwise leave the account on the host.
+        made_users="$made_users primaryroot"
         dest="$work/primary-gid"
         mkdir -p "$dest"
         chmod 0775 "$dest"
@@ -469,6 +476,21 @@ if [ "$made_user" = "tester" ] && command -v useradd >/dev/null 2>&1; then
 else
     echo "  skip  no account this run created: cannot test primary-group membership"
 fi
+
+echo "destination shapes"
+
+# `mv file dir` moves the file INTO the directory. A destination that is
+# already a directory would swallow the staging file and leave nothing at the
+# path asked for -- and the version line used to hide that inside a command
+# substitution, so the install printed Installed and exited 0.
+dest="$work/dir-dest"
+mkdir -p "$dest/srelens-tui"
+out="$(sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+check "a directory where the binary goes is refused" "is a directory" "$out" "$rc" 1
+case "$out" in
+    *Installed:*) no "it claimed to have installed something" ;;
+    *) ok "it did not claim to have installed anything" ;;
+esac
 
 echo "temporary directory"
 
@@ -493,6 +515,29 @@ good="$work/trusted-tmp"
 mkdir -p "$good"
 out="$(TMPDIR="$good" sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
 check "a trusted TMPDIR still installs" "Installed:" "$out" "$rc" 0
+
+# A hardened host mounts /tmp noexec, and mktemp puts the working tree there.
+# Running the binary to check it must not be the thing that fails, so the
+# check moves to after the install when the working filesystem forbids exec.
+#
+# Needs CAP_SYS_ADMIN to mount, so this skips on an ordinary CI runner and
+# runs under docker --privileged or a local root shell.
+if [ "$(id -u)" = "0" ] && command -v mount >/dev/null 2>&1; then
+    noexec="$work/noexec"
+    mkdir -p "$noexec"
+    if mount -t tmpfs -o rw,noexec,nosuid,size=200m tmpfs "$noexec" 2>/dev/null; then
+        dest="$work/noexec-bin"
+        mkdir -p "$dest"
+        out="$(TMPDIR="$noexec" sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+        check "a noexec working directory still installs" "Installed:" "$out" "$rc" 0
+        check "and says why the check moved" "mounted noexec" "$out" "$rc" 0
+        umount "$noexec" 2>/dev/null || true
+    else
+        echo "  skip  cannot mount a noexec filesystem here (needs CAP_SYS_ADMIN)"
+    fi
+else
+    echo "  skip  not root, or no mount: cannot test a noexec working directory"
+fi
 
 echo "unpacking"
 

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -1,0 +1,159 @@
+#!/bin/sh
+# Tests for install.sh.
+#
+#   sh packaging/install/test.sh
+#
+# Runs on any Linux with curl. The refusal cases put a fake `curl` and a fake
+# `uname` ahead of the real ones on PATH, so they need no network beyond the
+# one fixture download; the happy-path case really does install the latest
+# release into a temp directory and run it.
+#
+# This exists because an install script is the easiest thing in a repository
+# to leave broken: nothing builds it, nothing imports it, and the only person
+# who finds out is a stranger following the README.
+set -eu
+
+here="$(cd "$(dirname "$0")" && pwd)"
+script="$here/install.sh"
+[ -f "$script" ] || { echo "install.sh not found next to $0" >&2; exit 1; }
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT INT TERM
+
+pass=0
+fail=0
+
+check() { # check <name> <expected substring> <output> <exit> <want exit>
+    if printf '%s' "$3" | grep -qF "$2" && [ "$4" = "$5" ]; then
+        echo "  ok    $1"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL  $1 (exit $4, wanted $5; looked for: $2)"
+        printf '%s\n' "$3" | sed 's/^/          /'
+        fail=$((fail + 1))
+    fi
+}
+
+ok() {
+    echo "  ok    $1"
+    pass=$((pass + 1))
+}
+
+no() {
+    echo "  FAIL  $1"
+    fail=$((fail + 1))
+}
+
+echo "arguments"
+
+out="$(sh "$script" --help 2>&1)" && rc=0 || rc=$?
+check "--help explains itself and points macOS at Homebrew" \
+    "brew install srelens/tap/srelens-tui" "$out" "$rc" 0
+
+out="$(sh "$script" --nope 2>&1)" && rc=0 || rc=$?
+check "an unknown flag is refused, not ignored" "unknown option" "$out" "$rc" 1
+
+out="$(sh "$script" --version 2>&1)" && rc=0 || rc=$?
+check "--version without a value is refused" "needs a value" "$out" "$rc" 1
+
+echo "platform"
+
+mkdir -p "$work/fake"
+cat > "$work/fake/uname" <<'EOF'
+#!/bin/sh
+case "${1:-}" in
+  -s) echo "${FAKE_OS:-Linux}" ;;
+  -m) echo "${FAKE_ARCH:-x86_64}" ;;
+  *)  echo Linux ;;
+esac
+EOF
+chmod +x "$work/fake/uname"
+
+out="$(FAKE_OS=Darwin PATH="$work/fake:$PATH" sh "$script" 2>&1)" && rc=0 || rc=$?
+check "macOS is sent to Homebrew rather than served a Linux binary" \
+    "brew install srelens/tap/srelens-tui" "$out" "$rc" 1
+
+out="$(FAKE_ARCH=riscv64 PATH="$work/fake:$PATH" sh "$script" 2>&1)" && rc=0 || rc=$?
+check "an architecture with no published build is named" \
+    "unsupported architecture: riscv64" "$out" "$rc" 1
+
+echo "checksum"
+
+# A corrupted archive with the release's real checksum file: the one case the
+# verification exists for, and the one that must never install anything.
+# Authenticated when a token is around (CI), because the unauthenticated
+# GitHub API limit is per IP and CI runners share them. The script under test
+# deliberately stays unauthenticated — that is how a real user calls it.
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+    set -- -H "Authorization: Bearer $GITHUB_TOKEN"
+else
+    set --
+fi
+version="$(
+    curl -fsSL "$@" https://api.github.com/repos/srelens/srelens/releases/latest |
+        sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1
+)"
+version="${version#srelens-v}"
+[ -n "$version" ] || { echo "could not resolve the latest version" >&2; exit 1; }
+
+archive="srelens-tui-$version-x86_64-unknown-linux-musl.tar.gz"
+base="https://github.com/srelens/srelens/releases/download/srelens-v$version"
+mkdir -p "$work/fixtures"
+curl -fsSL -o "$work/fixtures/$archive" "$base/$archive"
+curl -fsSL -o "$work/fixtures/SHA256SUMS.txt" "$base/srelens-tui-$version-SHA256SUMS.txt"
+printf 'X' | dd of="$work/fixtures/$archive" bs=1 seek=5000 conv=notrunc status=none
+
+cat > "$work/fake/curl" <<EOF
+#!/bin/sh
+out=""; url=""
+while [ \$# -gt 0 ]; do
+  case "\$1" in
+    -o) out="\$2"; shift 2 ;;
+    http*) url="\$1"; shift ;;
+    *) shift ;;
+  esac
+done
+case "\$url" in
+  *api.github.com*) echo '{"tag_name": "srelens-v$version"}' ;;
+  *SHA256SUMS*)     cp "$work/fixtures/SHA256SUMS.txt" "\$out" ;;
+  *.tar.gz)         cp "$work/fixtures/\$(basename "\$url")" "\$out" ;;
+  *) exit 1 ;;
+esac
+EOF
+chmod +x "$work/fake/curl"
+
+dest="$work/cksum"
+out="$(PATH="$work/fake:$PATH" sh "$script" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+check "a corrupted archive is refused" "checksum mismatch" "$out" "$rc" 1
+if [ -e "$dest/srelens-tui" ]; then
+    no "nothing is installed when the checksum fails"
+else
+    ok "nothing is installed when the checksum fails"
+fi
+
+echo "install"
+
+dest="$work/bin"
+out="$(sh "$script" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+check "the latest release installs" "Installed: $dest/srelens-tui" "$out" "$rc" 0
+check "the checksum is reported, not assumed" "Checksum verified:" "$out" "$rc" 0
+
+if [ -x "$dest/srelens-tui" ] && "$dest/srelens-tui" --version >/dev/null 2>&1; then
+    ok "the installed binary runs: $("$dest/srelens-tui" --version)"
+else
+    no "the installed binary does not run"
+fi
+
+# Installing over an existing copy is the update path, and must not fail on
+# ETXTBSY or leave the staging file behind.
+out="$(sh "$script" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+check "installing over an existing copy succeeds" "Installed:" "$out" "$rc" 0
+if [ -z "$(find "$dest" -name '.srelens-tui.install.*' 2>/dev/null)" ]; then
+    ok "no staging file is left behind"
+else
+    no "a staging file was left in $dest"
+fi
+
+echo
+echo "passed $pass, failed $fail"
+[ "$fail" -eq 0 ]

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -1043,6 +1043,7 @@ if [ "$made_user" = "tester" ]; then
     else
         ok "an interrupted first install leaves nothing behind"
     fi
+
 else
     echo "  skip  no unprivileged account this run created: cannot interrupt an update"
 fi

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -56,6 +56,15 @@ check "an unknown flag is refused, not ignored" "unknown option" "$out" "$rc" 1
 out="$(sh "$script" --version 2>&1)" && rc=0 || rc=$?
 check "--version without a value is refused" "needs a value" "$out" "$rc" 1
 
+# `--version="$UNSET"` reaches the script as `--version=`. Accepting that
+# as "no version given" would silently install the latest release instead
+# of the pin the caller asked for.
+out="$(sh "$script" --version= 2>&1)" && rc=0 || rc=$?
+check "an empty --version= is refused too" "needs a value" "$out" "$rc" 1
+
+out="$(sh "$script" --install-dir= 2>&1)" && rc=0 || rc=$?
+check "an empty --install-dir= is refused too" "needs a value" "$out" "$rc" 1
+
 echo "platform"
 
 mkdir -p "$work/fake"
@@ -168,6 +177,40 @@ if [ -z "$(find "$dest" -name '.srelens-tui.install.*' 2>/dev/null)" ]; then
     ok "no staging file is left behind"
 else
     no "a staging file was left in $dest"
+fi
+
+echo "through a pipe"
+
+# How the documented one-liner actually runs. Options cannot follow a bare
+# `sh` -- it reads them as its own -- so the docs say `sh -s --`, and this
+# proves that form reaches the script's parser.
+dest="$work/piped"
+out="$(cat "$script" | sh -s -- --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+check "options survive sh -s --" "Installed: $dest/srelens-tui" "$out" "$rc" 0
+
+echo "staging file"
+
+# The staging name must not be derivable from the pid: installed as root
+# into a directory another user can write to, a predictable name can be
+# pre-created as a symlink, and cp writes through it. mktemp names cannot
+# be aimed at, and a symlink sitting in the directory is left alone.
+dest="$work/staging"
+mkdir -p "$dest"
+echo "do not touch me" > "$work/canary"
+ln -sf "$work/canary" "$dest/.srelens-tui.install.99999"
+out="$(sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+check "installs alongside a planted symlink" "Installed:" "$out" "$rc" 0
+if [ "$(cat "$work/canary")" = "do not touch me" ]; then
+    ok "a planted symlink is not written through"
+else
+    no "the canary was overwritten"
+fi
+# The pattern is the literal source line, so single quotes are the point.
+# shellcheck disable=SC2016
+if grep -q 'mktemp "$dir/.$BIN.install.XXXXXX"' "$script"; then
+    ok "the staging file is created by mktemp, not from the pid"
+else
+    no "the staging file is no longer created with mktemp"
 fi
 
 echo "hashing tool"

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -548,6 +548,20 @@ if [ "$made_user" = "tester" ]; then
         no "nothing landed in the resolved directory"
     fi
 
+    # A symlink where the binary goes is refused: the rollback copy is taken
+    # by reading $dest, which follows the link, so a restore would put a
+    # regular file where a link had been.
+    home="$work/homes/link-dest"
+    new_home "$home"
+    ln -sfn /bin/true "$home/.local/bin/srelens-tui"
+    out="$(install_into "$home")" && rc=0 || rc=$?
+    check "a symlink where the binary goes is refused" "is a symlink" "$out" "$rc" 1
+    if [ -L "$home/.local/bin/srelens-tui" ]; then
+        ok "the symlink is left as it was"
+    else
+        no "the symlink was replaced"
+    fi
+
     # `mv file dir` moves the file INTO the directory. A destination that is
     # already a directory would swallow the staging file and leave nothing at
     # the path asked for -- and the version line used to hide that inside a
@@ -751,7 +765,10 @@ if [ "$(id -u)" = "0" ] && command -v mount >/dev/null 2>&1; then
         # the destination before anything has run it. Failing then must not
         # leave the caller with nothing where a working copy stood -- nor
         # hand back a copy with permissions it never had.
-        chmod 0700 "$dest/srelens-tui" 2>/dev/null || true
+        # 4700, not 0700: the rollback must put back the permissions and
+        # drop the set-ID bit, never reproduce it on a file this script
+        # did not write.
+        chmod 4700 "$dest/srelens-tui" 2>/dev/null || true
         bad="$work/bad"
         mkdir -p "$bad"
         printf 'this is not a binary\n' > "$bad/srelens-tui"
@@ -789,9 +806,9 @@ EOF
         fi
         restored_mode="$(stat -c %a "$dest/srelens-tui" 2>/dev/null)" || restored_mode="?"
         if [ "$restored_mode" = "700" ]; then
-            ok "and came back with the permissions it had, not wider ones"
+            ok "and came back 700: permissions kept, set-ID bit dropped"
         else
-            no "the restored binary is mode $restored_mode, was 700"
+            no "the restored binary is mode $restored_mode, wanted 700 from 4700"
         fi
         rm -f "$work/fake/curl"
 

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -632,6 +632,24 @@ if [ "$made_user" = "tester" ]; then
     else
         no "the symlink was replaced"
     fi
+    # And a second hard link to the binary. The backup is a copy into a
+    # fresh inode, so a rollback could not give the other name back the
+    # file it shares now -- refuse rather than promise a restore that
+    # splits them.
+    home="$work/homes/hardlinked"
+    new_home "$home"
+    printf '#!/bin/sh\necho OLD COPY\n' > "$home/.local/bin/srelens-tui"
+    chmod 0755 "$home/.local/bin/srelens-tui"
+    ln "$home/.local/bin/srelens-tui" "$home/.local/bin/srelens-tui.other"
+    chown tester "$home/.local/bin/srelens-tui" 2>/dev/null || true
+    out="$(install_into "$home")" && rc=0 || rc=$?
+    check "a hard-linked binary is refused" "hard links" "$out" "$rc" 1
+    if grep -q "OLD COPY" "$home/.local/bin/srelens-tui" 2>/dev/null &&
+        [ "$(stat -c %h "$home/.local/bin/srelens-tui" 2>/dev/null)" = "2" ]; then
+        ok "and both names still share the old inode"
+    else
+        no "the hard-linked binary was touched"
+    fi
 
     # `mv file dir` moves the file INTO the directory. A destination that is
     # already a directory would swallow the staging file and leave nothing at

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -551,9 +551,25 @@ fi
 echo "shared groups and ancestors"
 
 if [ "$made_user" = "tester" ]; then
-    # A group-writable directory is only safe when the group is the owner's
-    # own -- the per-user-group convention. A shared group is a set of people
-    # who can each replace the binary between staging and running it.
+    # Group-writable is refused whatever the group is. Who is really in a
+    # group cannot be established from a shell -- an SSSD or LDAP source can
+    # resolve accounts one at a time while declining to enumerate, so any
+    # answer is a lower bound rather than a fact.
+    home="$work/homes/own-group"
+    new_home "$home"
+    chmod 0775 "$home/.local/bin"
+    out="$(install_into "$home")" && rc=0 || rc=$?
+    check "a group-writable destination is refused" "group-writable" "$out" "$rc" 1
+    if [ -e "$home/.local/bin/srelens-tui" ]; then
+        no "it installed into the group-writable directory anyway"
+    else
+        ok "nothing was installed there"
+    fi
+    check "and says how to fix it" "chmod g-w" "$out" "$rc" 1
+
+    # The owner's own group is refused too: it is the case the old rule tried
+    # to allow, on the strength of a convention that Fedora does not actually
+    # follow -- UMASK is 022 there and a fresh ~/.local/bin is drwxr-xr-x.
     if command -v groupadd >/dev/null 2>&1; then
         if ! getent group shared >/dev/null 2>&1; then
             if groupadd shared >/dev/null 2>&1; then
@@ -565,7 +581,7 @@ if [ "$made_user" = "tester" ]; then
         if chgrp shared "$home/.local/bin" 2>/dev/null; then
             chmod 0775 "$home/.local/bin"
             out="$(install_into "$home")" && rc=0 || rc=$?
-            check "a directory writable by a shared group is refused" "group shared" "$out" "$rc" 1
+            check "a shared group is refused by the same rule" "group-writable" "$out" "$rc" 1
         else
             echo "  skip  could not set a shared group"
         fi
@@ -573,47 +589,13 @@ if [ "$made_user" = "tester" ]; then
         echo "  skip  no groupadd: cannot test a shared group"
     fi
 
-    # The per-user-group case must keep working, or every Fedora install with
-    # a 002 umask breaks: there ~/.local/bin is `alice:alice` mode 0775.
-    home="$work/homes/own-group"
+    # Group-writable WITH the sticky bit is still fine: sticky is what stops
+    # anyone but an entry's owner unlinking it, whoever may write there.
+    home="$work/homes/group-sticky"
     new_home "$home"
-    chmod 0775 "$home/.local/bin"
+    chmod 3775 "$home/.local/bin"
     out="$(install_into "$home")" && rc=0 || rc=$?
-    check "group-writable by the owner's own group still installs" "Installed:" "$out" "$rc" 0
-
-    # A group named after its owner is the per-user-group CONVENTION, not a
-    # guarantee. If the group really has other members, any of them can
-    # replace the binary, so membership is looked up rather than assumed.
-    if [ -n "$other_user" ] && command -v usermod >/dev/null 2>&1 &&
-        usermod -aG tester "$other_user" >/dev/null 2>&1; then
-        home="$work/homes/own-group-shared"
-        new_home "$home"
-        chmod 0775 "$home/.local/bin"
-        out="$(install_into "$home")" && rc=0 || rc=$?
-        check "an owner-named group with real members is refused" "besides tester" "$out" "$rc" 1
-        gpasswd -d "$other_user" tester >/dev/null 2>&1 || true
-    else
-        echo "  skip  cannot add a second member to the account's own group"
-    fi
-
-    # Supplementary members are only half of a group: an account whose PRIMARY
-    # group it is never appears in the member list, while it can write there
-    # perfectly well.
-    if command -v useradd >/dev/null 2>&1 &&
-        useradd -M -g tester primarytester >/dev/null 2>&1; then
-        # Recorded BEFORE it is used: an interrupt between the useradd and the
-        # userdel below would otherwise leave the account behind.
-        made_users="$made_users primarytester"
-        home="$work/homes/primary-gid"
-        new_home "$home"
-        chmod 0775 "$home/.local/bin"
-        out="$(install_into "$home")" && rc=0 || rc=$?
-        check "a group that is someone else's primary group is refused" "primarytester" "$out" "$rc" 1
-        userdel primarytester >/dev/null 2>&1 || true
-        made_users="$(printf %s "$made_users" | sed 's/ primarytester//')"
-    else
-        echo "  skip  could not create an account sharing that primary group"
-    fi
+    check "group-writable WITH the sticky bit still installs" "Installed:" "$out" "$rc" 0
 
     # An extended ACL can grant write to any account while the mode bits look
     # impeccable. ls marks one with a trailing +, and reading an ACL portably
@@ -740,43 +722,6 @@ dest="$default_dest"
 out="$(TMPDIR="$link_tmp" sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
 check "a TMPDIR symlink is resolved before it is judged" "writable by anyone" "$out" "$rc" 1
 
-# A lookup that fails is not a group with nobody in it. Only reached for a
-# group-writable destination, so these run as the unprivileged account
-# against a home shaped that way.
-if [ "$made_user" = "tester" ]; then
-    mkdir -p "$work/fake"
-    cat > "$work/fake/getent" <<'EOF'
-#!/bin/sh
-exit 2
-EOF
-    chmod +x "$work/fake/getent"
-    home="$work/homes/getent-down"
-    new_home "$home"
-    chmod 0775 "$home/.local/bin"
-    out="$(install_into "$home" "PATH=$work/fake:\$PATH")" && rc=0 || rc=$?
-    check "a group lookup that fails is not treated as empty" "cannot look up the group" "$out" "$rc" 1
-
-    # And neither is a passwd lookup that fails. In `getent passwd | awk`
-    # the status belongs to awk, which succeeds on no input, so a partial
-    # outage would read as "nobody else is in this group".
-    cat > "$work/fake/getent" <<'EOF'
-#!/bin/sh
-case "${1:-}" in
-  group)  echo "tester:x:1000:" ;;
-  passwd) exit 2 ;;
-  *) exit 2 ;;
-esac
-EOF
-    chmod +x "$work/fake/getent"
-    home="$work/homes/passwd-down"
-    new_home "$home"
-    chmod 0775 "$home/.local/bin"
-    out="$(install_into "$home" "PATH=$work/fake:\$PATH")" && rc=0 || rc=$?
-    check "a passwd lookup that fails is not treated as empty" "cannot enumerate accounts" "$out" "$rc" 1
-    rm -f "$work/fake/getent"
-else
-    echo "  skip  no unprivileged account this run created: cannot test a failed lookup"
-fi
 
 echo "unpacking"
 

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -56,7 +56,9 @@ cleanup() {
     done
     [ -z "$made_group" ] || groupdel "$made_group" >/dev/null 2>&1 || true
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 pass=0
 fail=0
@@ -341,6 +343,29 @@ if [ -z "$(find "$dest" -name '.srelens-tui.install.*' -o -name '.srelens-tui.ba
     ok "no staging or backup file is left behind"
 else
     no "a staging or backup file was left in $dest"
+fi
+
+echo "how the docs say to run it"
+
+# The documented form is download-then-run, not `curl | sh`. A pipeline
+# reports its LAST command, so a download that fails leaves sh reading an
+# empty script, doing nothing, and exiting 0 -- the line succeeds having
+# installed nothing, and anything automated around it carries on.
+missing="https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/no-such-file.sh"
+piped_rc=0
+curl -fsSL "$missing" 2>/dev/null | sh >/dev/null 2>&1 || piped_rc=$?
+if [ "$piped_rc" = "0" ]; then
+    ok "the piped form hides a failed download, which is why the docs do not use it"
+else
+    no "expected the piped form to report success on a failed download"
+fi
+
+chain_rc=0
+curl -fsSL "$missing" -o "$work/should-not-exist.sh" 2>/dev/null && sh "$work/should-not-exist.sh" >/dev/null 2>&1 || chain_rc=$?
+if [ "$chain_rc" != "0" ]; then
+    ok "the documented form reports it, exit $chain_rc"
+else
+    no "the documented form swallowed a failed download too"
 fi
 
 echo "through a pipe"

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -358,12 +358,26 @@ else
 fi
 
 # The per-user-group case must keep working, or every Fedora install with a
-# 002 umask breaks.
-dest="$work/own-group"
-mkdir -p "$dest"
-chmod 0775 "$dest"
-out="$(sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
-check "group-writable by the owner's own group still installs" "Installed:" "$out" "$rc" 0
+# 002 umask breaks: there ~/.local/bin is `alice:alice` mode 0775.
+#
+# As the user, into their own group -- which is the actual shape. Root into
+# ROOT's group is a different thing and rightly refused: on Alpine, GID 0 is
+# the primary group of sync, shutdown and halt.
+if [ "$made_user" = "tester" ]; then
+    dest="$work/own-group"
+    mkdir -p "$dest"
+    chown tester:tester "$dest" 2>/dev/null || chown tester "$dest" 2>/dev/null || true
+    chmod 0775 "$dest"
+    # Traversable so the account can reach it; still owned by root and
+    # writable by nobody else, so the walk above it stays clean.
+    chmod 0711 "$work"
+    chmod 644 "$script" 2>/dev/null || true
+    out="$(su tester -c "sh $script --version $version --install-dir $dest" 2>&1)" && rc=0 || rc=$?
+    check "group-writable by the owner's own group still installs" "Installed:" "$out" "$rc" 0
+    chmod 0700 "$work"
+else
+    echo "  skip  no account this run created: cannot test a per-user group"
+fi
 
 # A directory can be impeccable itself and still sit under one somebody
 # else owns, who can rename it and put their own in its place after the
@@ -410,25 +424,75 @@ fi
 # A group named after its owner is the per-user-group CONVENTION, not a
 # guarantee. If the group really has other members, any of them can replace
 # the binary, so membership is looked up rather than assumed.
-if [ "$(id -u)" = "0" ] && command -v usermod >/dev/null 2>&1; then
-    if ! id -u tester >/dev/null 2>&1; then
-        if useradd -m tester >/dev/null 2>&1; then
-            made_user="tester"
-        fi
+#
+# Only ever on an account this run created. Adding a pre-existing `tester`
+# to group root and then removing it again would strip a membership the
+# host meant to have -- a test that edits the machine it runs on is worse
+# than a test that skips.
+if ! id -u tester >/dev/null 2>&1 && [ "$(id -u)" = "0" ] &&
+    command -v useradd >/dev/null 2>&1; then
+    if useradd -m tester >/dev/null 2>&1; then
+        made_user="tester"
     fi
+fi
+if [ "$made_user" = "tester" ] && command -v usermod >/dev/null 2>&1; then
     if usermod -aG root tester >/dev/null 2>&1; then
         dest="$work/owner-group-shared"
         mkdir -p "$dest"
         chmod 0775 "$dest"
         out="$(sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
         check "an owner-named group with real members is refused" "members besides root" "$out" "$rc" 1
+        # Safe to undo unconditionally: this membership was added a few
+        # lines up, to an account created a few lines before that.
         gpasswd -d tester root >/dev/null 2>&1 || true
     else
         echo "  skip  could not add a member to a group"
     fi
 else
-    echo "  skip  not root, or no usermod: cannot test group membership"
+    echo "  skip  no account this run created: not touching an existing one's groups"
 fi
+
+# Supplementary members are only half of a group: an account whose PRIMARY
+# group it is never appears in the member list, while it can write there
+# perfectly well.
+if [ "$made_user" = "tester" ] && command -v useradd >/dev/null 2>&1; then
+    if useradd -M -g root primaryroot >/dev/null 2>&1; then
+        dest="$work/primary-gid"
+        mkdir -p "$dest"
+        chmod 0775 "$dest"
+        out="$(sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+        check "a group that is someone else's primary group is refused" "primaryroot" "$out" "$rc" 1
+        userdel primaryroot >/dev/null 2>&1 || true
+    else
+        echo "  skip  could not create an account with a primary GID of 0"
+    fi
+else
+    echo "  skip  no account this run created: cannot test primary-group membership"
+fi
+
+echo "temporary directory"
+
+# mktemp -d honours TMPDIR, and sudo can carry the invoking user's straight
+# into a root install. The private tree is only private if its parents are,
+# so the destination walk is applied to it as well.
+dest="$work/tmpdir-bin"
+mkdir -p "$dest"
+bad="$work/untrusted-tmp"
+mkdir -p "$bad"
+chmod 0777 "$bad"
+out="$(TMPDIR="$bad" sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+check "an untrusted TMPDIR is refused" "writable by anyone" "$out" "$rc" 1
+if [ -e "$dest/srelens-tui" ]; then
+    no "it installed with the working tree in an untrusted place"
+else
+    ok "nothing was installed from an untrusted working tree"
+fi
+
+# And a TMPDIR that is fine must still work.
+good="$work/trusted-tmp"
+mkdir -p "$good"
+out="$(TMPDIR="$good" sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+check "a trusted TMPDIR still installs" "Installed:" "$out" "$rc" 0
 
 echo "unpacking"
 

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -101,6 +101,7 @@ base="https://github.com/srelens/srelens/releases/download/srelens-v$version"
 mkdir -p "$work/fixtures"
 curl -fsSL -o "$work/fixtures/$archive" "$base/$archive"
 curl -fsSL -o "$work/fixtures/SHA256SUMS.txt" "$base/srelens-tui-$version-SHA256SUMS.txt"
+cp "$work/fixtures/$archive" "$work/fixtures/good.tar.gz"
 printf 'X' | dd of="$work/fixtures/$archive" bs=1 seek=5000 conv=notrunc status=none
 
 cat > "$work/fake/curl" <<EOF
@@ -116,7 +117,12 @@ done
 case "\$url" in
   *api.github.com*) echo '{"tag_name": "srelens-v$version"}' ;;
   *SHA256SUMS*)     cp "$work/fixtures/SHA256SUMS.txt" "\$out" ;;
-  *.tar.gz)         cp "$work/fixtures/\$(basename "\$url")" "\$out" ;;
+  *.tar.gz)
+    if [ -n "\${SERVE_GOOD:-}" ]; then
+      cp "$work/fixtures/good.tar.gz" "\$out"
+    else
+      cp "$work/fixtures/\$(basename "\$url")" "\$out"
+    fi ;;
   *) exit 1 ;;
 esac
 EOF
@@ -131,11 +137,21 @@ else
     ok "nothing is installed when the checksum fails"
 fi
 
+echo "latest-version resolution"
+
+# Offline, through the fake curl that serves the API's tag_name. Proves the
+# script parses `latest` correctly without spending an unauthenticated API
+# call per run on a shared runner IP.
+dest="$work/latest"
+out="$(SERVE_GOOD=1 PATH="$work/fake:$PATH" sh "$script" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+check "the newest release is resolved from the API" "srelens-tui $version" "$out" "$rc" 0
+check "and installed" "Installed: $dest/srelens-tui" "$out" "$rc" 0
+
 echo "install"
 
 dest="$work/bin"
-out="$(sh "$script" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
-check "the latest release installs" "Installed: $dest/srelens-tui" "$out" "$rc" 0
+out="$(sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+check "the release installs" "Installed: $dest/srelens-tui" "$out" "$rc" 0
 check "the checksum is reported, not assumed" "Checksum verified:" "$out" "$rc" 0
 
 if [ -x "$dest/srelens-tui" ] && "$dest/srelens-tui" --version >/dev/null 2>&1; then
@@ -146,12 +162,41 @@ fi
 
 # Installing over an existing copy is the update path, and must not fail on
 # ETXTBSY or leave the staging file behind.
-out="$(sh "$script" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+out="$(sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
 check "installing over an existing copy succeeds" "Installed:" "$out" "$rc" 0
 if [ -z "$(find "$dest" -name '.srelens-tui.install.*' 2>/dev/null)" ]; then
     ok "no staging file is left behind"
 else
     no "a staging file was left in $dest"
+fi
+
+echo "hashing tool"
+
+# Every image this was first tested on has sha256sum, which is why the
+# shasum branch could ship computing SHA-1 and pass. Running with a PATH
+# that deliberately lacks sha256sum is the only way to take that branch.
+if command -v shasum >/dev/null 2>&1; then
+    limited="$work/limited"
+    mkdir -p "$limited"
+    missing=''
+    for tool in sh uname curl sed head cut grep tar gzip chmod mktemp dirname mkdir cp mv rm cat shasum; do
+        path="$(command -v "$tool" 2>/dev/null)" || { missing="$missing $tool"; continue; }
+        ln -sf "$path" "$limited/$tool"
+    done
+    if [ -n "$missing" ]; then
+        echo "  skip  no shasum-only run:$missing not found"
+    else
+        dest="$work/shasum"
+        out="$(PATH="$limited" sh "$script" --version "$version" --install-dir "$dest" 2>&1)" && rc=0 || rc=$?
+        check "shasum computes SHA-256, not SHA-1" "Checksum verified:" "$out" "$rc" 0
+        if [ -x "$dest/srelens-tui" ]; then
+            ok "the binary installs with only shasum available"
+        else
+            no "nothing was installed with only shasum available"
+        fi
+    fi
+else
+    echo "  skip  shasum is not installed here"
 fi
 
 echo

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -429,20 +429,39 @@ if [ "$made_user" = "tester" ]; then
     new_home "$home"
     chmod 0777 "$home/.local/bin"
     out="$(install_into "$home")" && rc=0 || rc=$?
-    check "a world-writable destination is refused" "writable by anyone" "$out" "$rc" 1
+    check "a world-writable destination is refused" "writable by other users" "$out" "$rc" 1
     if [ -e "$home/.local/bin/srelens-tui" ]; then
         no "it installed into the world-writable directory anyway"
     else
         ok "nothing was installed there"
     fi
 
-    # The sticky bit is what makes /tmp safe: only an entry's owner may unlink
-    # it, so the staged file cannot be taken away. That case must still work.
+    # Sticky does NOT rescue the destination. It stops another user removing
+    # our files; it does not stop them creating srelens-tui there first and
+    # owning it -- after which its mode is read and copied onto the rollback
+    # (a planted 4755 becoming a root-owned setuid file), and it can be
+    # swapped for a symlink to a directory so the mv lands underneath it.
     home="$work/homes/sticky"
     new_home "$home"
     chmod 1777 "$home/.local/bin"
     out="$(install_into "$home")" && rc=0 || rc=$?
-    check "world-writable WITH the sticky bit still installs" "Installed:" "$out" "$rc" 0
+    check "a world-writable destination is refused even with sticky" "writable by other users" "$out" "$rc" 1
+    if [ -e "$home/.local/bin/srelens-tui" ]; then
+        no "it installed into the sticky world-writable directory anyway"
+    else
+        ok "nothing was installed there"
+    fi
+
+    # A sticky ANCESTOR is still fine, which is what keeps /tmp usable --
+    # and every path in this suite runs through it.
+    sticky_parent="$work/sticky-parent"
+    rm -rf "$sticky_parent"
+    mkdir -p "$sticky_parent"
+    chmod 1777 "$sticky_parent"
+    home="$sticky_parent/home"
+    new_home "$home"
+    out="$(install_into "$home")" && rc=0 || rc=$?
+    check "a sticky world-writable ANCESTOR is still fine" "Installed:" "$out" "$rc" 0
 
     # A directory belonging to somebody else: they can arrange the swap at
     # leisure and get a file written by the installing account out of it.
@@ -469,7 +488,7 @@ if [ "$made_user" = "tester" ]; then
         chown "$other_user" "$home/.local/bin" 2>/dev/null || true
         chmod 1777 "$home/.local/bin"
         out="$(install_into "$home")" && rc=0 || rc=$?
-        check "a sticky directory owned by someone else is refused" "belongs to $other_user" "$out" "$rc" 1
+        check "a sticky directory owned by someone else is refused" "safely" "$out" "$rc" 1
 
         # A directory can be impeccable itself and still sit under one somebody
         # else owns, who can rename it and put their own in its place after the
@@ -501,7 +520,7 @@ if [ "$made_user" = "tester" ]; then
     rmdir "$home/.local/bin"
     ln -sfn "$target" "$home/.local/bin"
     out="$(install_into "$home")" && rc=0 || rc=$?
-    check "a symlink to an unsafe directory is refused" "writable by anyone" "$out" "$rc" 1
+    check "a symlink to an unsafe directory is refused" "writable by other users" "$out" "$rc" 1
     if [ -e "$target/srelens-tui" ]; then
         no "it installed through the symlink anyway"
     else
@@ -605,13 +624,13 @@ if [ "$made_user" = "tester" ]; then
         echo "  skip  no groupadd: cannot test a shared group"
     fi
 
-    # Group-writable WITH the sticky bit is still fine: sticky is what stops
-    # anyone but an entry's owner unlinking it, whoever may write there.
+    # Group-writable plus sticky is refused for the same reason: sticky
+    # protects entries that exist, not the right to create one.
     home="$work/homes/group-sticky"
     new_home "$home"
     chmod 3775 "$home/.local/bin"
     out="$(install_into "$home")" && rc=0 || rc=$?
-    check "group-writable WITH the sticky bit still installs" "Installed:" "$out" "$rc" 0
+    check "group-writable plus sticky is refused too" "group-writable" "$out" "$rc" 1
 
     # An extended ACL can grant write to any account while the mode bits
     # look impeccable. getfacl answers this properly; GNU ls answers it with
@@ -698,7 +717,7 @@ mkdir -p "$bad"
 chmod 0777 "$bad"
 rm -f "$dest/srelens-tui"
 out="$(TMPDIR="$bad" sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
-check "an untrusted TMPDIR is refused" "writable by anyone" "$out" "$rc" 1
+check "an untrusted TMPDIR is refused" "writable by other users" "$out" "$rc" 1
 if [ -e "$dest/srelens-tui" ]; then
     no "it installed with the working tree in an untrusted place"
 else
@@ -797,7 +816,7 @@ link_tmp="$work/tmp-link"
 ln -sfn "$real_tmp" "$link_tmp"
 dest="$default_dest"
 out="$(TMPDIR="$link_tmp" sh "$script" --version "$version" 2>&1)" && rc=0 || rc=$?
-check "a TMPDIR symlink is resolved before it is judged" "writable by anyone" "$out" "$rc" 1
+check "a TMPDIR symlink is resolved before it is judged" "writable by other users" "$out" "$rc" 1
 
 
 echo "unpacking"


### PR DESCRIPTION
Closes #459.

```bash
curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/install.sh | sh
```

Linux had no one-liner. Homebrew works there — I proved it end to end while testing the tap — but it drags in Homebrew's implicit `gcc` and `glibc`: 680 MB of toolchain to place a 31 MB static binary. Everyone else was reading the tarball table in `docs/INSTALL.md` and doing it by hand.

## What it does

Detects the architecture, takes the static musl archive, verifies the SHA-256 against the release's own `SHA256SUMS.txt` before installing anything, and writes to `/usr/local/bin` when writable or `~/.local/bin` when not. `--version` and `--install-dir` override both choices.

## Decisions

**Always musl, never glibc.** The glibc archives are built on ubuntu-22.04 and ubuntu-24.04-arm, so they carry a floor of glibc 2.35 and 2.39 — newer than Debian 11 or RHEL 9, which is exactly the sort of host a cluster gets administered from. That failure is a `GLIBC_2.3x not found` before `main()`, which tells the reader nothing actionable.

**No sudo.** A script fetched over the network re-invoking itself as root is the pattern people are right to be nervous about, and the `~/.local/bin` fallback needs no privileges.

**Everything inside `main()`, called on the last line.** A script read from a pipe runs as it arrives, so a dropped connection would otherwise execute whatever fragment landed. With the wrapper, a truncated download is a syntax error that does nothing.

**Linux only, stable only.** macOS has the tap; the script says so rather than competing. Pre-releases are what `srelens-tui update --channel dev` is for.

## Verified by running it

Twelve cases, green under `dash` on Debian and again under BusyBox `ash` on Alpine, plus `shellcheck -s sh` clean:

```
arguments   --help, unknown flag refused, --version with no value refused
platform    macOS sent to Homebrew, riscv64 named as unpublished
checksum    corrupted archive refused, and nothing installed
install     latest release installs and runs, reinstall over an existing copy
            leaves no staging file
```

The corrupted-archive case is the one worth reading: it serves a real `SHA256SUMS.txt` beside a byte-flipped archive and asserts the destination stays empty.

CI runs those tests and shellcheck on every PR, under `dash` rather than bash. An install script is the easiest file here to leave broken — nothing builds it, nothing imports it, and the first person to notice would be a stranger following the README. That is the same lesson the Dockerfile taught last week.

`.gitattributes` pins `*.sh` to LF, scoped narrowly so it cannot renormalize a working tree that is CRLF throughout. This file is served straight into `sh`, where a CRLF shebang sends the kernel looking for an interpreter whose name ends in a carriage return.

## Note

The script is served from `main`, so merging to `main` publishes it immediately — there is no release step between the file and the URL people paste into a root shell. `packaging/install/README.md` says so at the top.

Windows is #460, next.