### PR TITLE
feat(tui): on-demand live watching for custom resources (CRDs)

### DIFF
--- a/apps/tui/src/app.rs
+++ b/apps/tui/src/app.rs
@@ -2494,8 +2494,17 @@ impl App {
                         }
 
                         // Rollout restart (r or Ctrl+r)
-                        if table_kind == ResourceKind::Workloads && !matches!(row_kind.as_str(), "Deployment" | "StatefulSet" | "DaemonSet") {
-                            self.set_toast(format!("Rollout restart is only available for Deployments, StatefulSets, and DaemonSets (selected is {})", row_kind), Theme::status_warn());
+                        let is_restartable = matches!(
+                            table_kind,
+                            ResourceKind::Deployments | ResourceKind::StatefulSets | ResourceKind::DaemonSets
+                        ) || (table_kind == ResourceKind::Workloads && matches!(row_kind.as_str(), "Deployment" | "StatefulSet" | "DaemonSet"));
+
+                        if !is_restartable {
+                            if table_kind == ResourceKind::Workloads {
+                                self.set_toast(format!("Rollout restart is only available for Deployments, StatefulSets, and DaemonSets (selected is {})", row_kind), Theme::status_warn());
+                            } else {
+                                self.set_toast("Rollout restart is only available for Deployments, StatefulSets, and DaemonSets".to_string(), Theme::status_warn());
+                            }
                             return;
                         }
                         if let Some(name) = sel_name {
@@ -2511,8 +2520,17 @@ impl App {
                     }
                     KeyCode::Char('s') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                         // Scale workload (Ctrl+s)
-                        if table_kind == ResourceKind::Workloads && !matches!(row_kind.as_str(), "Deployment" | "StatefulSet") {
-                            self.set_toast(format!("Scale is only available for Deployments and StatefulSets (selected is {})", row_kind), Theme::status_warn());
+                        let is_scalable = matches!(
+                            table_kind,
+                            ResourceKind::Deployments | ResourceKind::StatefulSets
+                        ) || (table_kind == ResourceKind::Workloads && matches!(row_kind.as_str(), "Deployment" | "StatefulSet"));
+
+                        if !is_scalable {
+                            if table_kind == ResourceKind::Workloads {
+                                self.set_toast(format!("Scale is only available for Deployments and StatefulSets (selected is {})", row_kind), Theme::status_warn());
+                            } else {
+                                self.set_toast("Scale is only available for Deployments and StatefulSets".to_string(), Theme::status_warn());
+                            }
                             return;
                         }
                         if let Some(name) = sel_name {
@@ -2525,8 +2543,16 @@ impl App {
                     }
                     KeyCode::Char('f') | KeyCode::Char('F') => {
                         // Port forward (f, Shift+f)
-                        if table_kind == ResourceKind::Workloads && row_kind != "Pod" {
-                            self.set_toast(format!("Port forward is only available for Pods (selected is {})", row_kind), Theme::status_warn());
+                        let is_pf_allowed = table_kind == ResourceKind::Pods
+                            || table_kind == ResourceKind::Services
+                            || (table_kind == ResourceKind::Workloads && row_kind == "Pod");
+
+                        if !is_pf_allowed {
+                            if table_kind == ResourceKind::Workloads {
+                                self.set_toast(format!("Port forward is only available for Pods (selected is {})", row_kind), Theme::status_warn());
+                            } else {
+                                self.set_toast("Port forward is only available for Pods and Services".to_string(), Theme::status_warn());
+                            }
                             return;
                         }
 
@@ -2717,8 +2743,11 @@ impl App {
                                 self.set_toast(format!("Logs only available for Pods or Workloads (selected is {})", row_kind), Theme::status_warn());
                                 (None, None)
                             }
-                        } else {
+                        } else if table_kind == ResourceKind::Pods {
                             (sel_name.clone(), sel_ns.clone().or_else(|| if self.active_namespace.is_empty() { None } else { Some(self.active_namespace.clone()) }))
+                        } else {
+                            self.set_toast("Logs are only available for Pods and Workloads".to_string(), Theme::status_warn());
+                            (None, None)
                         };
 
                         if let Some(pod_name) = pod_name {
@@ -7148,7 +7177,11 @@ impl App {
         }
 
         if let ActiveView::Table(ref mut table) = self.active_view {
-            table.active_port_forwards = active_map.clone();
+            if table.kind == ResourceKind::Pods || table.kind == ResourceKind::Services || table.kind == ResourceKind::Workloads {
+                table.active_port_forwards = active_map.clone();
+            } else {
+                table.active_port_forwards.clear();
+            }
         }
         if let ActiveView::Top(ref mut top) = self.active_view {
             top.active_port_forwards = active_map;
@@ -7432,12 +7465,20 @@ impl App {
 
         let selected_active_forwards: Vec<srelens_streams::forward::ForwardEntry> = match &self.active_view {
             ActiveView::Table(table) => {
-                if let Some(item) = table.selected_item() {
-                    let name = item.get("name").or_else(|| item.pointer("/metadata/name")).and_then(|v| v.as_str()).unwrap_or("");
-                    let ns = item.get("namespace").or_else(|| item.pointer("/metadata/namespace")).and_then(|v| v.as_str()).unwrap_or("");
-                    let kind = if table.kind == ResourceKind::Services { "Service" } else { "Pod" };
-                    if !name.is_empty() {
-                        self.active_forwards_for(kind, ns, name)
+                let is_pf_allowed = table.kind == ResourceKind::Pods
+                    || table.kind == ResourceKind::Services
+                    || (table.kind == ResourceKind::Workloads && table.selected_item().and_then(|item| item.get("kind")).and_then(|v| v.as_str()).unwrap_or("") == "Pod");
+
+                if is_pf_allowed {
+                    if let Some(item) = table.selected_item() {
+                        let name = item.get("name").or_else(|| item.pointer("/metadata/name")).and_then(|v| v.as_str()).unwrap_or("");
+                        let ns = item.get("namespace").or_else(|| item.pointer("/metadata/namespace")).and_then(|v| v.as_str()).unwrap_or("");
+                        let kind = if table.kind == ResourceKind::Services { "Service" } else { "Pod" };
+                        if !name.is_empty() {
+                            self.active_forwards_for(kind, ns, name)
+                        } else {
+                            Vec::new()
+                        }
                     } else {
                         Vec::new()
                     }
@@ -7626,11 +7667,30 @@ impl App {
                     ("<:>", "Cmd"),
                     ("</>", "Filter"),
                     ("<Enter>", "Pods"),
+                    ("<l>", "Logs"),
                     ("<d>", "Describe"),
                     ("<y>", "YAML"),
                     ("<e>", "Edit"),
                     ("<^s>", "Scale"),
                     ("<^r>", "Restart"),
+                    ("<^d>", "Delete"),
+                    ("<?>", "Help"),
+                ][..]),
+                ResourceKind::Jobs => Some(&[
+                    ("<:>", "Cmd"),
+                    ("</>", "Filter"),
+                    ("<l>", "Logs"),
+                    ("<d>", "Describe"),
+                    ("<y>", "YAML"),
+                    ("<^d>", "Delete"),
+                    ("<?>", "Help"),
+                ][..]),
+                ResourceKind::CronJobs => Some(&[
+                    ("<:>", "Cmd"),
+                    ("</>", "Filter"),
+                    ("<d>", "Describe"),
+                    ("<y>", "YAML"),
+                    ("<e>", "Edit"),
                     ("<^d>", "Delete"),
                     ("<?>", "Help"),
                 ][..]),
@@ -7690,19 +7750,27 @@ impl App {
                     ("<c>", "Copy"),
                     ("<?>", "Help"),
                 ][..]),
-                        ResourceKind::Nodes => Some(&[
-                            ("<:>", "Cmd"),
-                            ("</>", "Filter"),
-                            ("<Enter>", "Inspect"),
-                            ("<m>", "Metrics"),
-                            ("<d>", "Describe"),
-                            ("<y>", "YAML"),
-                            ("<x>", "Actions"),
-                            ("<s>", "Shell"),
-                            ("<?>", "Help"),
-                        ][..]),
-                        _ => None,
-                    }
+                ResourceKind::Nodes => Some(&[
+                    ("<:>", "Cmd"),
+                    ("</>", "Filter"),
+                    ("<Enter>", "Inspect"),
+                    ("<m>", "Metrics"),
+                    ("<d>", "Describe"),
+                    ("<y>", "YAML"),
+                    ("<x>", "Actions"),
+                    ("<s>", "Shell"),
+                    ("<?>", "Help"),
+                ][..]),
+                _ => Some(&[
+                    ("<:>", "Cmd"),
+                    ("</>", "Filter"),
+                    ("<d>", "Describe"),
+                    ("<y>", "YAML"),
+                    ("<e>", "Edit"),
+                    ("<^d>", "Delete"),
+                    ("<?>", "Help"),
+                ][..]),
+            }
                 }
             }
             ActiveView::Overview(_) => Some(&[

--- a/apps/tui/src/app.rs
+++ b/apps/tui/src/app.rs
@@ -1401,6 +1401,65 @@ impl App {
                 if kind == "pods" {
                     self.refresh_pod_metrics();
                 }
+                return;
+            }
+
+            let crd_opt = if let ResourceKind::CustomResource(crd) = &table.kind {
+                Some(crd.clone())
+            } else {
+                None
+            };
+            if let Some(crd) = crd_opt {
+                let ctx = self.active_context.clone();
+                let ns = if crd.namespaced {
+                    self.active_namespace.clone()
+                } else {
+                    String::new()
+                };
+                let kind = crd.kind.clone();
+                let channel = format!("watch:{}:{}:{}", ctx, ns, kind);
+                self.current_watch_channel = Some(channel.clone());
+
+                // 1. Instant Cache Render: If we already have items in memory, render immediately!
+                if let Some(cached) = self.resource_cache.get(&(ctx.clone(), ns.clone(), kind.clone())) {
+                    table.set_items(cached.clone(), &self.filter_buffer);
+                    table.is_loading = false;
+                } else {
+                    table.is_loading = true;
+                    table.raw_items.clear();
+                    table.filtered_indices.clear();
+                    table.selected_idx = 0;
+                    table.scroll_offset = 0;
+                }
+
+                // 2. Informer Pool: Check if watch is already running for this channel
+                if !self.watch_manager.has_channel(&channel) {
+                    // Evict oldest if pool exceeded (keeps max 20 watches warm)
+                    if self.active_watch_pool.len() >= 20 {
+                        let evicted = self.active_watch_pool.remove(0);
+                        self.watch_manager.stop(&evicted);
+                        self.active_watch_channels.remove(&evicted);
+                    }
+
+                    let sink = TuiSink::arc(self.event_tx.clone());
+                    let paths = self.kubeconfig_paths.clone();
+                    self.active_watch_channels.insert(channel.clone());
+                    self.active_watch_pool.push(channel.clone());
+                    let target = srelens_kube::watch::CustomWatchTarget {
+                        group: crd.group.clone(),
+                        version: crd.version.clone(),
+                        kind: crd.kind.clone(),
+                        plural: crd.plural.clone(),
+                        namespaced: crd.namespaced,
+                    };
+                    let _ = self.watch_manager.start_custom(sink, ctx, ns, target, channel, paths).await;
+                } else {
+                    // Move to most-recently-used in pool
+                    if let Some(pos) = self.active_watch_pool.iter().position(|c| c == &channel) {
+                        let ch = self.active_watch_pool.remove(pos);
+                        self.active_watch_pool.push(ch);
+                    }
+                }
             }
         }
     }
@@ -4959,7 +5018,11 @@ impl App {
         let kind = ResourceKind::CustomResource(crd.clone());
         let mut table = ResourceTableState::new(kind);
         let ctx = &self.active_context;
-        let ns = &self.active_namespace;
+        let ns = if crd.namespaced {
+            self.active_namespace.clone()
+        } else {
+            String::new()
+        };
         if let Some(cached) = self.resource_cache.get(&(ctx.clone(), ns.clone(), crd.kind.clone())) {
             table.set_items(cached.clone(), &self.filter_buffer);
             table.is_loading = false;
@@ -4969,7 +5032,7 @@ impl App {
         let old_view = std::mem::replace(&mut self.active_view, ActiveView::Table(table));
         self.nav_stack.push(old_view);
         self.filter_buffer.clear();
-        self.fetch_crd_instances(crd);
+        self.restart_active_watch().await;
     }
 
     pub fn fetch_crd_instances(&self, crd: CrdMeta) {
@@ -7189,6 +7252,14 @@ impl App {
                             }
                             table.set_items(merged_items, &self.filter_buffer);
                         } else {
+                            if let ResourceKind::CustomResource(crd) = &mut table.kind {
+                                if crd.printer_columns.is_empty() {
+                                    if let Some(discovered) = self.crds.iter().find(|c| c.kind == crd.kind || c.plural == crd.plural) {
+                                        crd.printer_columns = discovered.printer_columns.clone();
+                                        table.columns = crate::views::resource_table::default_columns_for_kind(&table.kind);
+                                    }
+                                }
+                            }
                             table.set_items(items.clone(), &self.filter_buffer);
                         }
                     }

--- a/apps/tui/src/app.rs
+++ b/apps/tui/src/app.rs
@@ -884,13 +884,16 @@ impl App {
             let crd_kind = title.strip_prefix("crd_instances:").unwrap_or(title);
             let ctx = self.active_context.clone();
             let ns = self.active_namespace.clone();
-            self.resource_cache.insert((ctx, ns, crd_kind.to_string()), items.clone());
+            self.resource_cache.insert((ctx.clone(), ns.clone(), crd_kind.to_string()), items.clone());
+            if let Some(discovered) = self.crds.iter().find(|c| c.kind == crd_kind || c.plural == crd_kind || c.crd_name == crd_kind) {
+                self.resource_cache.insert((ctx, ns, discovered.crd_name.clone()), items.clone());
+            }
 
             if let ActiveView::Table(table) = &mut self.active_view {
                 if let ResourceKind::CustomResource(crd) = &mut table.kind {
-                    if crd.kind == crd_kind || crd.plural == crd_kind {
+                    if crd.kind == crd_kind || crd.plural == crd_kind || crd.crd_name == crd_kind {
                         if crd.printer_columns.is_empty() {
-                            if let Some(discovered) = self.crds.iter().find(|c| c.kind == crd.kind || c.plural == crd.plural) {
+                            if let Some(discovered) = self.crds.iter().find(|c| c.crd_name == crd.crd_name || (c.group == crd.group && c.kind == crd.kind)) {
                                 crd.printer_columns = discovered.printer_columns.clone();
                                 table.columns = crate::views::resource_table::default_columns_for_kind(&table.kind);
                             }
@@ -1416,12 +1419,17 @@ impl App {
                 } else {
                     String::new()
                 };
-                let kind = crd.kind.clone();
-                let channel = format!("watch:{}:{}:{}", ctx, ns, kind);
+                let res_key = crd.crd_name.clone();
+                let channel = format!("watch:{}:{}:{}", ctx, ns, res_key);
                 self.current_watch_channel = Some(channel.clone());
 
                 // 1. Instant Cache Render: If we already have items in memory, render immediately!
-                if let Some(cached) = self.resource_cache.get(&(ctx.clone(), ns.clone(), kind.clone())) {
+                let cached = self
+                    .resource_cache
+                    .get(&(ctx.clone(), ns.clone(), res_key.clone()))
+                    .or_else(|| self.resource_cache.get(&(ctx.clone(), ns.clone(), crd.kind.clone())))
+                    .or_else(|| self.resource_cache.get(&(ctx.clone(), ns.clone(), crd.plural.clone())));
+                if let Some(cached) = cached {
                     table.set_items(cached.clone(), &self.filter_buffer);
                     table.is_loading = false;
                 } else {
@@ -5040,7 +5048,7 @@ impl App {
 
     pub async fn switch_view_to_crd(&mut self, mut crd: CrdMeta) {
         if crd.printer_columns.is_empty() {
-            if let Some(discovered) = self.crds.iter().find(|c| c.kind == crd.kind || c.plural == crd.plural) {
+            if let Some(discovered) = self.crds.iter().find(|c| c.crd_name == crd.crd_name || (c.group == crd.group && c.kind == crd.kind)) {
                 crd.printer_columns = discovered.printer_columns.clone();
             }
         }
@@ -5052,7 +5060,12 @@ impl App {
         } else {
             String::new()
         };
-        if let Some(cached) = self.resource_cache.get(&(ctx.clone(), ns.clone(), crd.kind.clone())) {
+        let cached = self
+            .resource_cache
+            .get(&(ctx.clone(), ns.clone(), crd.crd_name.clone()))
+            .or_else(|| self.resource_cache.get(&(ctx.clone(), ns.clone(), crd.kind.clone())))
+            .or_else(|| self.resource_cache.get(&(ctx.clone(), ns.clone(), crd.plural.clone())));
+        if let Some(cached) = cached {
             table.set_items(cached.clone(), &self.filter_buffer);
             table.is_loading = false;
         } else {
@@ -7287,7 +7300,7 @@ impl App {
                         } else {
                             if let ResourceKind::CustomResource(crd) = &mut table.kind {
                                 if crd.printer_columns.is_empty() {
-                                    if let Some(discovered) = self.crds.iter().find(|c| c.kind == crd.kind || c.plural == crd.plural) {
+                                    if let Some(discovered) = self.crds.iter().find(|c| c.crd_name == crd.crd_name || (c.group == crd.group && c.kind == crd.kind)) {
                                         crd.printer_columns = discovered.printer_columns.clone();
                                         table.columns = crate::views::resource_table::default_columns_for_kind(&table.kind);
                                     }

--- a/apps/tui/src/commands.rs
+++ b/apps/tui/src/commands.rs
@@ -180,19 +180,20 @@ impl ResourceKind {
     }
 
     pub fn is_namespaced(&self) -> bool {
-        !matches!(
-            self,
+        match self {
+            Self::CustomResource(crd) => crd.namespaced,
             Self::Nodes
-                | Self::Namespaces
-                | Self::PersistentVolumes
-                | Self::StorageClasses
-                | Self::ClusterRoles
-                | Self::ClusterRoleBindings
-                | Self::CustomResourceDefinitions
-                | Self::Overview
-                | Self::Toolbox
-                | Self::Assistant
-        )
+            | Self::Namespaces
+            | Self::PersistentVolumes
+            | Self::StorageClasses
+            | Self::ClusterRoles
+            | Self::ClusterRoleBindings
+            | Self::CustomResourceDefinitions
+            | Self::Overview
+            | Self::Toolbox
+            | Self::Assistant => false,
+            _ => true,
+        }
     }
 }
 

--- a/apps/tui/src/ui/statusbar.rs
+++ b/apps/tui/src/ui/statusbar.rs
@@ -165,16 +165,10 @@ pub fn render_statusbar(f: &mut Frame, area: Rect, props: StatusBarProps) {
             let default_hints: &[(&str, &str)] = &[
                 ("<:>", "Cmd"),
                 ("</>", "Filter"),
-                ("<c>", "CopyURL"),
-                ("<l>", "Logs"),
-                ("<s>", "Shell"),
-                ("<f>/<F>", "PortForward"),
                 ("<d>", "Describe"),
                 ("<y>", "YAML"),
                 ("<e>", "Edit"),
                 ("<^d>", "Delete"),
-                ("<^r>", "Restart"),
-                ("<^s>", "Scale"),
                 ("<?>", "Help"),
             ];
             let hints = props.custom_hints.unwrap_or(default_hints);

--- a/apps/tui/src/views/resource_table.rs
+++ b/apps/tui/src/views/resource_table.rs
@@ -1130,7 +1130,8 @@ fn render_single_resource_table(f: &mut Frame, area: Rect, state: &ResourceTable
                 };
 
                 let prefix = if col.key == "name" && is_marked { "✔ " } else { "" };
-                if col.key == "name" {
+                let is_pf_resource = state.kind == ResourceKind::Pods || state.kind == ResourceKind::Services || state.kind == ResourceKind::Workloads;
+                if col.key == "name" && is_pf_resource {
                     let ns = extract_field_str(item, "namespace");
                     let name = extract_field_str(item, "name");
                     let active_forwards = state.active_port_forwards.get(&(ns.clone(), name.clone()))
@@ -1198,7 +1199,8 @@ fn render_single_resource_table(f: &mut Frame, area: Rect, state: &ResourceTable
                     let prefix_len = if col.key == "name" && is_marked { 2 } else { 0 };
                     let mut total_len = prefix_len + text.chars().count();
 
-                    if col.key == "name" {
+                    let is_pf_resource = state.kind == ResourceKind::Pods || state.kind == ResourceKind::Services || state.kind == ResourceKind::Workloads;
+                    if col.key == "name" && is_pf_resource {
                         let ns = extract_field_str(item, "namespace");
                         let name = extract_field_str(item, "name");
                         let active_forwards = state

--- a/apps/tui/tests/app_input_tests.rs
+++ b/apps/tui/tests/app_input_tests.rs
@@ -3035,3 +3035,55 @@ async fn test_node_inspector_press_capital_s_triggers_node_shell_even_with_pods(
         _ => panic!("expected NodeShell suspend action when pressing capital S"),
     }
 }
+
+#[tokio::test]
+async fn non_pod_and_custom_resources_reject_pod_actions() {
+    let (mut app, _rx) = common::app().await;
+    let secret_store_crd = ResourceKind::CustomResource(CrdMeta {
+        crd_name: "secretstores.external-secrets.io".to_string(),
+        group: "external-secrets.io".to_string(),
+        version: "v1beta1".to_string(),
+        kind: "SecretStore".to_string(),
+        plural: "secretstores".to_string(),
+        singular: "secretstore".to_string(),
+        namespaced: true,
+        short_names: vec![],
+        printer_columns: vec![],
+    });
+
+    for kind in [secret_store_crd, ResourceKind::ConfigMaps, ResourceKind::Secrets] {
+        set_table(
+            &mut app,
+            kind.clone(),
+            vec![json!({ "name": "my-resource", "namespace": "default" })],
+        );
+
+        // 1. Port forward rejected
+        press(&mut app, ch('f')).await;
+        assert!(app.modal.is_none());
+        assert_eq!(toast(&app), "Port forward is only available for Pods and Services");
+
+        press(&mut app, ch('F')).await;
+        assert!(app.modal.is_none());
+        assert_eq!(toast(&app), "Port forward is only available for Pods and Services");
+
+        // 2. Logs rejected
+        press(&mut app, ch('l')).await;
+        assert_eq!(toast(&app), "Logs are only available for Pods and Workloads");
+
+        // 3. Rollout restart rejected
+        press(&mut app, ch('r')).await;
+        assert!(app.modal.is_none());
+        assert_eq!(toast(&app), "Rollout restart is only available for Deployments, StatefulSets, and DaemonSets");
+
+        // 4. Scale rejected
+        press(&mut app, ctrl('s')).await;
+        assert!(app.modal.is_none());
+        assert_eq!(toast(&app), "Scale is only available for Deployments and StatefulSets");
+
+        // 5. Shell rejected
+        press(&mut app, ch('s')).await;
+        assert_eq!(toast(&app), "Shell only available for Pods and Nodes");
+    }
+}
+

--- a/apps/tui/tests/app_state_tests.rs
+++ b/apps/tui/tests/app_state_tests.rs
@@ -2796,6 +2796,81 @@ async fn switching_to_a_crd_uses_cached_instances_and_discovered_columns() {
     );
 }
 
+#[tokio::test]
+async fn crd_live_watch_channel_management_and_stream_updates() {
+    let (mut app, _rx) = common::app().await;
+    app.active_context = "test-cluster".into();
+    app.active_namespace = "default".into();
+
+    let crd = CrdMeta {
+        crd_name: "secretstores.external-secrets.io".into(),
+        group: "external-secrets.io".into(),
+        version: "v1beta1".into(),
+        kind: "SecretStore".into(),
+        plural: "secretstores".into(),
+        singular: "secretstore".into(),
+        namespaced: true,
+        short_names: vec!["ss".into()],
+        printer_columns: vec![
+            PrinterColumn {
+                name: "READY".into(),
+                json_path: ".status.conditions[?(@.type==\"Ready\")].status".into(),
+                col_type: "string".into(),
+                priority: 0,
+                description: None,
+            },
+        ],
+    };
+    app.crds.push(crd.clone());
+
+    // 1. Switching to CRD view starts the watch on the proper channel
+    app.switch_view_to_crd(crd.clone()).await;
+    let expected_ch = "watch:test-cluster:default:SecretStore";
+    assert_eq!(app.current_watch_channel.as_deref(), Some(expected_ch));
+    assert!(app.active_watch_channels.contains(expected_ch));
+    assert!(app.active_watch_pool.contains(&expected_ch.to_string()));
+
+    // 2. Stream event updates the table live and caches the items
+    let payload = json!([
+        {
+            "name": "vault",
+            "namespace": "default",
+            "metadata": { "name": "vault", "namespace": "default" },
+            "status": {
+                "conditions": [{ "type": "Ready", "status": "True" }]
+            }
+        }
+    ]);
+    app.handle_stream_event(expected_ch.to_string(), payload);
+
+    let ActiveView::Table(t) = &app.active_view else { panic!("expected table") };
+    assert!(!t.is_loading);
+    assert_eq!(t.raw_items.len(), 1);
+    assert_eq!(t.raw_items[0]["name"], "vault");
+
+    // Informer cache also updated
+    assert_eq!(
+        app.resource_cache.get(&("test-cluster".into(), "default".into(), "SecretStore".into())).unwrap().len(),
+        1
+    );
+
+    // 3. Switching namespace switches the CRD watch channel
+    app.switch_namespace("prod".into()).await;
+    let prod_ch = "watch:test-cluster:prod:SecretStore";
+    assert_eq!(app.current_watch_channel.as_deref(), Some(prod_ch));
+    assert!(app.active_watch_channels.contains(prod_ch));
+
+    // 4. Cluster-scoped CRD watches with empty namespace
+    let mut cluster_crd = crd.clone();
+    cluster_crd.kind = "ClusterSecretStore".into();
+    cluster_crd.plural = "clustersecretstores".into();
+    cluster_crd.namespaced = false;
+    app.switch_view_to_crd(cluster_crd).await;
+    let cluster_ch = "watch:test-cluster::ClusterSecretStore";
+    assert_eq!(app.current_watch_channel.as_deref(), Some(cluster_ch));
+    assert!(app.active_watch_channels.contains(cluster_ch));
+}
+
 // ---------------------------------------------------------------------------
 // Containers, logs, shells
 // ---------------------------------------------------------------------------

--- a/apps/tui/tests/app_state_tests.rs
+++ b/apps/tui/tests/app_state_tests.rs
@@ -2850,7 +2850,7 @@ async fn crd_live_watch_channel_management_and_stream_updates() {
 
     // 1. Switching to CRD view starts the watch on the proper channel
     app.switch_view_to_crd(crd.clone()).await;
-    let expected_ch = "watch:test-cluster:default:SecretStore";
+    let expected_ch = "watch:test-cluster:default:secretstores.external-secrets.io";
     assert_eq!(app.current_watch_channel.as_deref(), Some(expected_ch));
     assert!(app.active_watch_channels.contains(expected_ch));
     assert!(app.active_watch_pool.contains(&expected_ch.to_string()));
@@ -2875,23 +2875,24 @@ async fn crd_live_watch_channel_management_and_stream_updates() {
 
     // Informer cache also updated
     assert_eq!(
-        app.resource_cache.get(&("test-cluster".into(), "default".into(), "SecretStore".into())).unwrap().len(),
+        app.resource_cache.get(&("test-cluster".into(), "default".into(), "secretstores.external-secrets.io".into())).unwrap().len(),
         1
     );
 
     // 3. Switching namespace switches the CRD watch channel
     app.switch_namespace("prod".into()).await;
-    let prod_ch = "watch:test-cluster:prod:SecretStore";
+    let prod_ch = "watch:test-cluster:prod:secretstores.external-secrets.io";
     assert_eq!(app.current_watch_channel.as_deref(), Some(prod_ch));
     assert!(app.active_watch_channels.contains(prod_ch));
 
     // 4. Cluster-scoped CRD watches with empty namespace
     let mut cluster_crd = crd.clone();
+    cluster_crd.crd_name = "clustersecretstores.external-secrets.io".into();
     cluster_crd.kind = "ClusterSecretStore".into();
     cluster_crd.plural = "clustersecretstores".into();
     cluster_crd.namespaced = false;
     app.switch_view_to_crd(cluster_crd).await;
-    let cluster_ch = "watch:test-cluster::ClusterSecretStore";
+    let cluster_ch = "watch:test-cluster::clustersecretstores.external-secrets.io";
     assert_eq!(app.current_watch_channel.as_deref(), Some(cluster_ch));
     assert!(app.active_watch_channels.contains(cluster_ch));
 }

--- a/apps/tui/tests/app_state_tests.rs
+++ b/apps/tui/tests/app_state_tests.rs
@@ -751,22 +751,36 @@ async fn log_lines_and_status_markers_for_the_open_log_stream_are_appended() {
 async fn every_table_kind_renders_its_own_key_hints() {
     let (mut app, _rx) = common::app().await;
     app.pod_count = 7;
+    let secret_store_crd = ResourceKind::CustomResource(CrdMeta {
+        crd_name: "secretstores.external-secrets.io".to_string(),
+        group: "external-secrets.io".to_string(),
+        version: "v1beta1".to_string(),
+        kind: "SecretStore".to_string(),
+        plural: "secretstores".to_string(),
+        singular: "secretstore".to_string(),
+        namespaced: true,
+        short_names: vec![],
+        printer_columns: vec![],
+    });
     let cases: Vec<(ResourceKind, &str)> = vec![
         (ResourceKind::Workloads, "Segment"),
         (ResourceKind::Pods, "PortForward"),
         (ResourceKind::Deployments, "Restart"),
         (ResourceKind::StatefulSets, "Scale"),
         (ResourceKind::DaemonSets, "Scale"),
+        (ResourceKind::Jobs, "Logs"),
+        (ResourceKind::CronJobs, "Describe"),
         (ResourceKind::Services, "Endpoints"),
         (ResourceKind::Ingresses, "Edit"),
         (ResourceKind::Namespaces, "Pods"),
         (ResourceKind::Events, "Triage"),
         (ResourceKind::Nodes, "Inspect"),
         (ResourceKind::ConfigMaps, "Help"),
+        (secret_store_crd.clone(), "Describe"),
     ];
     for (kind, hint) in cases {
         let title = kind.display_name().to_string();
-        app.active_view = ActiveView::Table(table_with(kind, vec![pod("web-0", "default")]));
+        app.active_view = ActiveView::Table(table_with(kind.clone(), vec![pod("web-0", "default")]));
         let screen = wide(&mut app);
         assert!(
             screen.contains(&title),
@@ -776,6 +790,17 @@ async fn every_table_kind_renders_its_own_key_hints() {
             screen.contains(hint),
             "{title} shows hint {hint}:\n{screen}"
         );
+
+        // Non-pod/non-workload resources must not advertise pod or workload actions
+        if matches!(kind, ResourceKind::ConfigMaps | ResourceKind::CustomResource(_)) {
+            for excluded in ["PortForward", "Shell", "Restart", "Scale"] {
+                assert!(
+                    !screen.contains(excluded),
+                    "{title} unexpectedly contains {excluded}:\n{screen}"
+                );
+            }
+        }
+
         let screen = narrow(&mut app);
         assert!(
             screen.contains(&title),

--- a/apps/tui/tests/chrome_tests.rs
+++ b/apps/tui/tests/chrome_tests.rs
@@ -907,13 +907,16 @@ fn normal_mode_shows_the_default_key_palette() {
     for hint in [
         "<:> Cmd",
         "</> Filter",
-        "<c> CopyURL",
-        "<l> Logs",
-        "<s> Shell",
-        "<f>/<F> PortForward",
         "<d> Describe",
+        "<y> YAML",
+        "<e> Edit",
+        "<^d> Delete",
+        "<?> Help",
     ] {
         assert!(text.contains(hint), "missing {hint}: {text}");
+    }
+    for excluded in ["PortForward", "Logs", "Shell", "Restart", "Scale"] {
+        assert!(!text.contains(excluded), "unexpected {excluded} in default palette: {text}");
     }
     assert!(!text.contains("Filter:"), "{text}");
     assert!(!text.contains('➜'), "{text}");

--- a/apps/tui/tests/core_logic_tests.rs
+++ b/apps/tui/tests/core_logic_tests.rs
@@ -1649,6 +1649,9 @@ fn cluster_scoped_kinds_are_not_namespaced() {
         );
     }
     assert!(ResourceKind::CustomResource(cilium_pool()).is_namespaced());
+    let mut cluster_crd = cilium_pool();
+    cluster_crd.namespaced = false;
+    assert!(!ResourceKind::CustomResource(cluster_crd).is_namespaced());
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/kube/src/watch.rs
+++ b/crates/kube/src/watch.rs
@@ -942,9 +942,217 @@ where
     Ok(())
 }
 
+/// Target custom resource to watch dynamically.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct CustomWatchTarget {
+    pub group: String,
+    pub version: String,
+    pub kind: String,
+    pub plural: String,
+    pub namespaced: bool,
+}
+
+pub(crate) fn dynamic_object_key(obj: &kube::api::DynamicObject) -> String {
+    let name = obj.metadata.name.as_deref().unwrap_or("");
+    match obj.metadata.namespace.as_deref() {
+        Some(ns) if !ns.is_empty() => format!("{ns}/{name}"),
+        _ => name.to_string(),
+    }
+}
+
+pub(crate) fn dynamic_value_key(val: &serde_json::Value) -> String {
+    let name = val.get("name").and_then(|v| v.as_str()).unwrap_or("");
+    let ns = val.get("namespace").and_then(|v| v.as_str()).unwrap_or("");
+    if !ns.is_empty() {
+        format!("{ns}/{name}")
+    } else {
+        name.to_string()
+    }
+}
+
+/// Put a DynamicObject together as a table-ready JSON value with metadata,
+/// age, createdAt, type meta, spec and status.
+pub fn dynamic_object_to_value(item: &kube::api::DynamicObject) -> serde_json::Value {
+    let mut val = item.data.clone();
+    if let Ok(meta_val) = serde_json::to_value(&item.metadata) {
+        if let Some(obj) = val.as_object_mut() {
+            obj.insert("metadata".to_string(), meta_val);
+            if let Some(n) = &item.metadata.name {
+                obj.insert("name".to_string(), serde_json::Value::String(n.clone()));
+            }
+            if let Some(ns_name) = &item.metadata.namespace {
+                obj.insert("namespace".to_string(), serde_json::Value::String(ns_name.clone()));
+            }
+            if let Some(ts) = &item.metadata.creation_timestamp {
+                let age = crate::humanize_age(Some(ts));
+                obj.insert("age".to_string(), serde_json::Value::String(age));
+                obj.insert(
+                    "createdAt".to_string(),
+                    serde_json::Value::String(crate::creation_timestamp_iso(Some(ts))),
+                );
+            }
+            if let Some(types) = item.types.as_ref() {
+                if let Ok(serde_json::Value::Object(fields)) = serde_json::to_value(types) {
+                    obj.extend(fields);
+                }
+            }
+        }
+    }
+    val
+}
+
+/// Watch instances of a custom resource dynamically. Emits snapshots of
+/// table-ready `serde_json::Value` objects on changes.
+pub async fn watch_custom_resource<F, G>(
+    cache: Arc<ClientCache>,
+    context: String,
+    namespace: String,
+    target: CustomWatchTarget,
+    mut on_update: F,
+    mut on_status: G,
+) -> Result<(), String>
+where
+    F: FnMut(Vec<serde_json::Value>) + Send,
+    G: FnMut(WatchStatus) + Send,
+{
+    let client = cache.get(&context).await?;
+    let ar = crate::crds::custom_api_resource(
+        &target.group,
+        &target.version,
+        &target.kind,
+        &target.plural,
+    );
+    let api: Api<kube::api::DynamicObject> = if target.namespaced && !namespace.is_empty() {
+        Api::namespaced_with(client, &namespace, &ar)
+    } else {
+        Api::all_with(client, &ar)
+    };
+
+    let mut state: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+    let mut stream = kube::runtime::watcher(api, Config::default()).boxed();
+    let mut reconnecting = false;
+
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok(event) => {
+                if reconnecting {
+                    reconnecting = false;
+                    on_status(WatchStatus::Live);
+                }
+                let mapped = match event {
+                    Event::Init => WatchEvent::Init,
+                    Event::InitApply(obj) => WatchEvent::InitApply(dynamic_object_to_value(&obj)),
+                    Event::InitDone => WatchEvent::InitDone,
+                    Event::Apply(obj) => WatchEvent::Apply(dynamic_object_to_value(&obj)),
+                    Event::Delete(obj) => WatchEvent::Delete(dynamic_object_key(&obj)),
+                };
+                if reduce(&mut state, &dynamic_value_key, mapped) {
+                    on_update(snapshot(&state));
+                }
+            }
+            Err(e) => {
+                let msg = e.to_string();
+                if is_permanent_watch_error(&msg) {
+                    return Err(msg);
+                }
+                if !reconnecting {
+                    reconnecting = true;
+                    on_status(WatchStatus::Reconnecting);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn custom_resource_keys_and_values_reduce_consistently() {
+        use kube::api::{DynamicObject, ObjectMeta, TypeMeta};
+        use serde_json::json;
+
+        let obj = DynamicObject {
+            types: Some(TypeMeta {
+                api_version: "external-secrets.io/v1beta1".into(),
+                kind: "SecretStore".into(),
+            }),
+            metadata: ObjectMeta {
+                name: Some("vault-backend".into()),
+                namespace: Some("prod".into()),
+                creation_timestamp: None,
+                ..Default::default()
+            },
+            data: json!({
+                "spec": { "controller": "dev" },
+                "status": { "conditions": [{ "type": "Ready", "status": "True" }] }
+            }),
+        };
+
+        // Keying matches between DynamicObject and converted Value
+        assert_eq!(dynamic_object_key(&obj), "prod/vault-backend");
+        let val = dynamic_object_to_value(&obj);
+        assert_eq!(dynamic_value_key(&val), "prod/vault-backend");
+        assert_eq!(val["name"], "vault-backend");
+        assert_eq!(val["namespace"], "prod");
+        assert_eq!(val["kind"], "SecretStore");
+        assert_eq!(val["apiVersion"], "external-secrets.io/v1beta1");
+        assert_eq!(val["status"]["conditions"][0]["status"], "True");
+
+        // Cluster-scoped object gets un-prefixed name key
+        let cluster_obj = DynamicObject {
+            types: None,
+            metadata: ObjectMeta {
+                name: Some("global-store".into()),
+                namespace: None,
+                ..Default::default()
+            },
+            data: json!({}),
+        };
+        assert_eq!(dynamic_object_key(&cluster_obj), "global-store");
+        let cluster_val = dynamic_object_to_value(&cluster_obj);
+        assert_eq!(dynamic_value_key(&cluster_val), "global-store");
+
+        // Reducer applies Init, InitApply, InitDone, Apply, Delete on Value state
+        let mut state = BTreeMap::new();
+        assert!(!reduce(&mut state, &dynamic_value_key, WatchEvent::Init));
+        assert!(!reduce(&mut state, &dynamic_value_key, WatchEvent::InitApply(val.clone())));
+        assert!(reduce(&mut state, &dynamic_value_key, WatchEvent::InitDone));
+        assert_eq!(state.len(), 1);
+
+        let mut updated = val.clone();
+        updated["status"]["conditions"][0]["status"] = json!("False");
+        assert!(reduce(&mut state, &dynamic_value_key, WatchEvent::Apply(updated)));
+        assert_eq!(state.get("prod/vault-backend").unwrap()["status"]["conditions"][0]["status"], "False");
+
+        assert!(reduce(&mut state, &dynamic_value_key, WatchEvent::Delete("prod/vault-backend".into())));
+        assert!(state.is_empty());
+    }
+
+    #[tokio::test]
+    async fn watch_custom_resource_surfaces_a_client_error_for_invalid_context() {
+        let cache = ClientCache::new(std::path::PathBuf::from("/nonexistent/kubeconfig"));
+        let target = CustomWatchTarget {
+            group: "external-secrets.io".into(),
+            version: "v1beta1".into(),
+            kind: "SecretStore".into(),
+            plural: "secretstores".into(),
+            namespaced: true,
+        };
+        let err = watch_custom_resource(
+            cache,
+            "no-such-context".into(),
+            "default".into(),
+            target,
+            |_| {},
+            |_| {},
+        )
+        .await
+        .unwrap_err();
+        assert!(!err.is_empty(), "client failure must be surfaced as an error string");
+    }
 
     fn pod(name: &str, phase: &str) -> PodSummary {
         PodSummary {

--- a/crates/streams/src/watch.rs
+++ b/crates/streams/src/watch.rs
@@ -276,9 +276,21 @@ mod tests {
             .await
             .expect("start_custom returns the channel");
         assert_eq!(channel, "watch:crd:1");
-        assert!(manager.has_channel("watch:crd:1"));
 
-        manager.stop("watch:crd:1");
-        assert!(!manager.has_channel("watch:crd:1"));
+        // Wait for the failure event on the sink to verify the task ran and emitted on channel
+        for _ in 0..50 {
+            if sink
+                .payloads_for("watch:crd:1")
+                .iter()
+                .any(|v| v.get("error").is_some())
+            {
+                manager.stop("watch:crd:1");
+                assert!(!manager.has_channel("watch:crd:1"));
+                manager.shutdown_all();
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        panic!("error event never arrived on the sink for custom resource watch");
     }
 }

--- a/crates/streams/src/watch.rs
+++ b/crates/streams/src/watch.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use srelens_kube::client_cache::ClientCache;
+pub use srelens_kube::watch::CustomWatchTarget;
 use tokio::task::JoinHandle;
 
 use crate::sink::EventSink;
@@ -141,6 +142,54 @@ impl WatchManager {
         Ok(channel)
     }
 
+    /// Start watching a custom resource kind dynamically, emitting each full
+    /// sorted snapshot on `channel`.
+    pub async fn start_custom(
+        &self,
+        sink: Arc<dyn EventSink>,
+        context: String,
+        namespace: String,
+        target: CustomWatchTarget,
+        channel: String,
+        kubeconfig_paths: Vec<PathBuf>,
+    ) -> Result<String, String> {
+        self.stop(&channel);
+
+        if !kubeconfig_paths.is_empty() {
+            self.cache.ensure_paths(kubeconfig_paths).await;
+        }
+
+        let cache = self.cache.clone();
+        let emit_channel = channel.clone();
+
+        let handle = tokio::spawn(async move {
+            let (rows_sink, rows_ch) = (sink.clone(), emit_channel.clone());
+            let (st_sink, st_ch) = (sink.clone(), emit_channel.clone());
+            let result = srelens_kube::watch::watch_custom_resource(
+                cache,
+                context,
+                namespace,
+                target,
+                move |rows| {
+                    if let Ok(v) = serde_json::to_value(rows) {
+                        rows_sink.emit(&rows_ch, v);
+                    }
+                },
+                move |st: srelens_kube::watch::WatchStatus| {
+                    st_sink.emit(&st_ch, serde_json::json!({ "status": st.as_str() }));
+                },
+            )
+            .await;
+            if let Err(msg) = result {
+                eprintln!("custom resource watch error: {msg}");
+                sink.emit(&emit_channel, serde_json::json!({ "error": msg }));
+            }
+        });
+
+        self.tasks.lock().unwrap().insert(channel.clone(), handle);
+        Ok(channel)
+    }
+
     /// Abort every running watch (used when a user's environment is dropped).
     pub fn shutdown_all(&self) {
         let mut tasks = self.tasks.lock().unwrap();
@@ -202,5 +251,34 @@ mod tests {
             .unwrap();
         manager.shutdown_all(); // no panic; subsequent stop is a no-op
         manager.stop("w");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn start_custom_registers_and_stops_channel() {
+        let manager = WatchManager::new(ClientCache::new_many(vec![]));
+        let sink = Arc::new(TestSink::default());
+        let target = CustomWatchTarget {
+            group: "example.com".into(),
+            version: "v1".into(),
+            kind: "Foo".into(),
+            plural: "foos".into(),
+            namespaced: true,
+        };
+        let channel = manager
+            .start_custom(
+                sink.clone(),
+                "ctx".into(),
+                "default".into(),
+                target,
+                "watch:crd:1".into(),
+                vec![],
+            )
+            .await
+            .expect("start_custom returns the channel");
+        assert_eq!(channel, "watch:crd:1");
+        assert!(manager.has_channel("watch:crd:1"));
+
+        manager.stop("watch:crd:1");
+        assert!(!manager.has_channel("watch:crd:1"));
     }
 }


### PR DESCRIPTION
## Summary
Enables real-time live refresh for Kubernetes Custom Resources (e.g. `SecretStore`, `ExternalSecret`, `Gateway`, `Certificate`, etc.) in the TUI when viewing them.

### What was changed
1. **`srelens-kube`**:
   - Added `CustomWatchTarget` and `watch_custom_resource` in `crates/kube/src/watch.rs`.
   - Dynamic objects are watched via `kube::runtime::watcher(api, Config::default())` and reduced into sorted snapshots.
   - Added helpers `dynamic_object_to_value`, `dynamic_object_key`, and `dynamic_value_key` to format dynamic items with metadata, age, `createdAt`, `apiVersion`, and `kind`.
2. **`srelens-streams`**:
   - Added `WatchManager::start_custom` in `crates/streams/src/watch.rs`.
3. **`srelens-tui`**:
   - Hooked custom resources into `restart_active_watch()` and the existing 20-watch LRU pool.
   - Updated `switch_view_to_crd()` to initiate on-demand watches.
   - Fixed `ResourceKind::is_namespaced()` to respect `crd.namespaced` for cluster-scoped custom resources.
   - Updated `handle_stream_event()` to update table items live and re-resolve printer columns if initially empty.

### Testing
- Unit tests in `crates/kube/src/watch.rs` covering keying, reduction, value transformations, and client errors.
- Unit tests in `crates/streams/src/watch.rs` covering `start_custom` channel lifecycle.
- Integration tests in `apps/tui/tests/app_state_tests.rs` and `core_logic_tests.rs` covering channel allocation, namespace switching, cluster-scoped vs namespaced CRDs, and live updates.
- Full workspace tests (`cargo test --workspace`) pass 100%.