### PR TITLE
chore(github): add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,80 @@
+name: Bug report
+description: Report a reproducible problem in srelens.
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Search existing issues before filing a new report.
+        For vulnerabilities, follow the [security policy](https://github.com/srelens/srelens/security/policy) instead of opening a public issue.
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: What happened?
+      description: Describe the problem and its impact. Include the exact error message if there is one.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: What did you expect?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Include the smallest sequence that reproduces the problem, or explain when it occurs if it is intermittent.
+      placeholder: |
+        1. Open ...
+        2. Select ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: srelens version
+      description: Include the release version and stable/dev channel, or the commit if built from source.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Where does it happen?
+      multiple: true
+      options:
+        - Desktop — new UI
+        - Desktop — classic UI
+        - Web
+        - TUI
+        - MCP
+        - Build or installation
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: OS version, CPU architecture and install method. For web mode, include the browser and version.
+      placeholder: macOS on Apple Silicon, DMG install
+    validations:
+      required: true
+
+  - type: textarea
+    id: cluster-context
+    attributes:
+      label: Cluster context
+      description: If relevant, include the Kubernetes version, distribution and affected resource kinds. Do not include kubeconfig credentials or Secret values.
+
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Logs, screenshots or recordings
+      description: Attach anything that helps reproduce the problem. Remove tokens, credentials and other sensitive values first.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/srelens/srelens/security/policy
+    about: Follow the security policy to report vulnerabilities privately.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,49 @@
+name: Feature request
+description: Suggest a feature or improvement for srelens.
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: Search existing issues first; add context to an existing request when it describes the same need.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: Describe the workflow, who needs it, and what is difficult today.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: Describe what you would like srelens to do and give an example of how you would use it.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Relevant surfaces
+      multiple: true
+      options:
+        - Desktop — new UI
+        - Desktop — classic UI
+        - Web
+        - TUI
+        - MCP
+        - Build or installation
+        - Documentation
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives and workarounds
+      description: What have you tried, and what is still missing?
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add related issues, examples, sketches or screenshots that clarify the request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+<!--
+Target dev. Read CONTRIBUTING.md and docs/DEVELOPMENT.md before submitting.
+Keep the PR focused. Remove optional sections that do not apply.
+-->
+
+## What changed and why
+
+<!-- Describe the problem and resulting behavior. Include a before/after example where useful. -->
+
+## Related issues
+
+<!-- Use "Closes #123" only when this PR fully resolves the issue. -->
+
+## Validation
+
+<!--
+List the commands you ran and their results; explain any checks you could not run.
+For code changes, describe the failing test that motivated the fix and the passing result.
+Frontend: pnpm typecheck, pnpm build, pnpm test (the root coverage gate).
+Rust: cargo test --workspace, or explain which workspace feature combination you tested.
+Do not lower coverage floors. Documentation-only changes can describe their validation here.
+-->
+
+## UI evidence (if applicable)
+
+<!-- Add screenshots or a short recording and describe the screen interactions you verified. Tests alone are not enough for UI changes. -->
+
+## Compatibility and rollout (if applicable)
+
+<!--
+Describe behavior changes, migration steps or material risks for desktop, web, TUI and MCP.
+For capability changes, confirm registration, consent annotations, caller JSON field names,
+catalog/e2e coverage and web-mode handling as described in docs/DEVELOPMENT.md.
+-->


### PR DESCRIPTION
Adds default GitHub templates so contributors provide the context needed to reproduce bugs, assess feature requests and review changes.

- Bug reports ask for observed/expected behavior, reproduction steps, release/channel, affected surface, environment and optional diagnostics.
- Feature requests capture the problem, proposed behavior, affected surfaces and alternatives.
- The issue chooser links to the existing private security-reporting policy and keeps blank issues available.
- The PR template points contributors to `dev` and prompts for behavior changes, related issues, validation, UI evidence and compatibility, matching CONTRIBUTING.md and docs/DEVELOPMENT.md.

Validation: parsed the issue forms as YAML and checked metadata, field types, unique IDs, dropdown options, required fields and existing repository labels. Checked the chooser configuration, PR template guidance and `git diff --check`. These are template-only changes; no application code changed.
