### PR TITLE
fix(packaging): judge the fallback's ancestors before creating it; runnable README line

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Download the latest release for your platform from
 | macOS | `.dmg` for Apple Silicon and Intel | Developer ID signed and notarized |
 | Linux | `.AppImage`, `.deb`, `.rpm` | AppImage supports the in-app updater |
 | Windows | `.exe`, `.msi` | Windows may show a SmartScreen prompt while code signing remains on the roadmap |
-| Terminal UI | Linux: `( f="$(mktemp)" && trap 'rm -f "$f"' EXIT && curl -fsSL <install.sh> -o "$f" && sh "$f" )`; macOS: `brew install srelens/tap/srelens-tui`; or `srelens-tui-<version>-<target>.tar.gz` / `.zip` | A single binary for Linux (glibc and static musl), macOS and Windows, on x86-64 and arm64; macOS builds on a stable release are signed and notarized |
+| Terminal UI | Linux: `( f="$(mktemp)" && trap 'rm -f "$f"' EXIT && curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/install.sh -o "$f" && sh "$f" )`; macOS: `brew install srelens/tap/srelens-tui`; or `srelens-tui-<version>-<target>.tar.gz` / `.zip` | A single binary for Linux (glibc and static musl), macOS and Windows, on x86-64 and arm64; macOS builds on a stable release are signed and notarized |
 
 See the [installation guide](docs/INSTALL.md) for platform-specific installation,
 first-launch, updating, verification, and uninstall instructions.

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -426,7 +426,23 @@ verify_checksum() {
 # repointed the moment after it is approved, and the install lands wherever
 # it now says. Everything downstream uses what this sets.
 prepare_install_dir() {
-    dir="$1"
+    want="$1"
+    # What already EXISTS of the path is judged before anything is added to
+    # it. `mkdir -p` first and the walk afterwards meant a refused fallback
+    # still left its mark: `sudo` carrying a non-root HOME into a run whose
+    # /usr/local/bin had been rejected would create root-owned .local/bin
+    # directories under that home and only then refuse the foreign-owned
+    # ancestor -- a persistent change from an install that reports having
+    # installed nothing. So: the nearest existing ancestor and everything
+    # above it first; the caller walks the full path, new components
+    # included, once it exists. assert_safe_dir reuses `dir`, hence `want`.
+    existing="$want"
+    while [ ! -d "$existing" ] && [ "$existing" != "/" ]; do
+        existing="${existing%/*}"
+        [ -n "$existing" ] || existing="/"
+    done
+    assert_safe_dir "$existing"
+    dir="$want"
     mkdir -p "$dir" 2>/dev/null ||
         die "cannot create $dir"
     [ -w "$dir" ] ||

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -436,10 +436,25 @@ prepare_install_dir() {
     # installed nothing. So: the nearest existing ancestor and everything
     # above it first; the caller walks the full path, new components
     # included, once it exists. assert_safe_dir reuses `dir`, hence `want`.
+    #
+    # Absolute, or nothing. The fallback is built from HOME, which the
+    # caller sets, and a relative HOME would make this a walk of names
+    # relative to wherever the script happens to be run from -- and a walk
+    # with nowhere to stop: `${x%/*}` of a name with no slash in it is the
+    # name itself.
+    case "$want" in
+        /*) ;;
+        *) die "$want is not an absolute path (HOME=${HOME:-unset}), so there is nowhere definite to install to. Set HOME to an absolute directory and run this again." ;;
+    esac
     existing="$want"
     while [ ! -d "$existing" ] && [ "$existing" != "/" ]; do
-        existing="${existing%/*}"
-        [ -n "$existing" ] || existing="/"
+        parent="${existing%/*}"
+        [ -n "$parent" ] || parent="/"
+        # Belt to the case above's braces: a step that removes nothing
+        # would loop forever, so it stops the install instead.
+        [ "$parent" != "$existing" ] ||
+            die "cannot find an existing ancestor of $want"
+        existing="$parent"
     done
     assert_safe_dir "$existing"
     dir="$want"

--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -456,7 +456,12 @@ prepare_install_dir() {
             die "cannot find an existing ancestor of $want"
         existing="$parent"
     done
-    assert_safe_dir "$existing"
+    # As a PARENT, which is what it is: the destination will be created
+    # beneath it. Judged by the destination's stricter rule, a sticky /tmp
+    # under a HOME that does not exist yet would be refused -- the very
+    # thing the sticky exemption exists to allow. The destination itself
+    # gets its own rule from the caller's walk once it exists.
+    assert_safe_dir "$existing" parent
     dir="$want"
     mkdir -p "$dir" 2>/dev/null ||
         die "cannot create $dir"
@@ -485,8 +490,13 @@ prepare_install_dir() {
 #     cannot be established from a shell -- see the note at that check.
 #
 # The same rule srelens-tui's own `update` applies to the binary it replaces.
+#
+# The last component is the destination unless the caller says `parent`:
+# prepare_install_dir walks the nearest EXISTING ancestor before creating
+# anything beneath it, and that ancestor is a parent, sticky /tmp included.
 assert_safe_dir() {
     dir="$1"
+    last_role="${2:-destination}"
 
     # Resolve first. `ls -ld` on a symlink describes the LINK -- mode
     # `lrwxrwxrwx`, owned by whoever made it -- which says nothing about where
@@ -509,9 +519,10 @@ assert_safe_dir() {
         esac
         prefix="$prefix/$name"
         # The last component is where the binary lands, and it is held to a
-        # stricter rule than the ones above it.
+        # stricter rule than the ones above it -- unless the caller said it
+        # is a parent too.
         if [ -z "$rest" ]; then
-            assert_component "$prefix" destination
+            assert_component "$prefix" "$last_role"
         else
             assert_component "$prefix" parent
         fi

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -557,6 +557,23 @@ if [ "$made_user" = "tester" ]; then
         else
             ok "nothing was installed under the replaceable ancestor"
         fi
+        # And when the fallback directory does not exist yet, under an
+        # ancestor that is writable but somebody else's: the refusal has to
+        # come BEFORE `mkdir -p`, or the install leaves a fresh .local/bin
+        # behind while reporting that it refused the destination.
+        home="$work/homes/foreign-parent-fresh"
+        rm -rf "$home"
+        mkdir -p "$home/.local"
+        chown tester "$home" 2>/dev/null || true
+        chown "$other_user" "$home/.local" 2>/dev/null || true
+        chmod 0777 "$home/.local"
+        out="$(install_into "$home")" && rc=0 || rc=$?
+        check "a fallback under a foreign ancestor is refused before it is created" "safely" "$out" "$rc" 1
+        if [ -e "$home/.local/bin" ]; then
+            no "the refused fallback directory was created anyway"
+        else
+            ok "and no directory was created under the foreign ancestor"
+        fi
     else
         echo "  skip  no second account: cannot test foreign ownership"
     fi

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -530,6 +530,13 @@ if [ "$made_user" = "tester" ]; then
     new_home "$home"
     out="$(install_into "$home")" && rc=0 || rc=$?
     check "a sticky world-writable ANCESTOR is still fine" "Installed:" "$out" "$rc" 0
+    # Including when the home under it does not exist yet, so the sticky
+    # directory is the nearest EXISTING component of the fallback: it is
+    # judged as the parent it is, not by the destination's stricter rule.
+    home="$sticky_parent/new-home"
+    rm -rf "$home"
+    out="$(install_into "$home")" && rc=0 || rc=$?
+    check "a fallback created beneath a sticky ancestor is still fine" "Installed: $home/.local/bin/srelens-tui" "$out" "$rc" 0
 
     # A directory belonging to somebody else: they can arrange the swap at
     # leisure and get a file written by the installing account out of it.

--- a/packaging/install/test.sh
+++ b/packaging/install/test.sh
@@ -475,6 +475,20 @@ if [ "$made_user" = "tester" ]; then
     out="$(install_into "$home")" && rc=0 || rc=$?
     check "an ordinary home installs" "Installed: $home/.local/bin/srelens-tui" "$out" "$rc" 0
 
+    # A relative HOME makes a relative fallback, and the walk up to its
+    # nearest existing ancestor has nowhere to stop: `${x%/*}` of a name
+    # with no slash is the name itself. Refused before the walk. Under
+    # `timeout` where there is one, so a regression fails rather than hangs.
+    hold=""
+    command -v timeout >/dev/null 2>&1 && hold="timeout 60"
+    out="$(su tester -c "cd '$work' && HOME=relative-home $hold sh '$script' --version '$version'" 2>&1)" && rc=0 || rc=$?
+    check "a relative HOME is refused rather than walked forever" "is not an absolute path" "$out" "$rc" 1
+    if [ -e "$work/relative-home" ]; then
+        no "the relative fallback was created"
+    else
+        ok "and nothing was created under the working directory"
+    fi
+
     # An unpredictable staging name does not survive a directory other users
     # can unlink from: they can take the staged file away and leave a symlink,
     # or replace the finished binary before it is run. Only the directory's


### PR DESCRIPTION
Closes #472. Two Codex findings posted on #461 eight seconds before it merged, so they landed in dev unfixed.

**README (P1).** The Linux install line had `curl -fsSL <install.sh> -o "$f"`. In a POSIX shell `<install.sh>` is a redirection, so a paste failed with `cannot open install.sh` before curl ran. It now carries the full raw.githubusercontent.com URL that `docs/INSTALL.md` already uses.

**Fallback directory (P2).** `prepare_install_dir` ran `mkdir -p` first and `main` walked the path with `assert_safe_dir` afterwards. When `/usr/local/bin` was rejected and `HOME` had a writable but foreign ancestor — `sudo` carrying a non-root `HOME` — the install created root-owned `.local/bin` under that home and *then* refused the ancestor, leaving a persistent change from a run that reports having installed nothing. The nearest existing ancestor and everything above it are now walked before anything is created; the caller's walk of the full path afterwards covers the new components.

**Test.** A home whose `.local` belongs to another account and is world-writable, with no `bin/` under it yet: the install is refused and no directory is left behind.

Verified: shellcheck clean; the full suite as root on Debian bookworm and Alpine 3.20 (BusyBox).
